### PR TITLE
Enable presales chat on all of the calypso environments

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -82,6 +82,7 @@
 		"upgrades/in-app-purchase": false,
 		"upgrades/paypal": false,
 		"upgrades/premium-themes": true,
+		"upgrades/presale-chat": true,
 		"upgrades/removal-survey": true
 	},
 	"rtl": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -101,7 +101,8 @@
 		"upgrades/paypal": true,
 		"upgrades/premium-themes": true,
 		"upgrades/removal-survey": true,
-		"upgrades/precancellation-chat": true
+		"upgrades/precancellation-chat": true,
+		"upgrades/presale-chat": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"wpcom_signup_id": "39911",

--- a/config/production.json
+++ b/config/production.json
@@ -101,7 +101,8 @@
 		"upgrades/paypal": true,
 		"upgrades/premium-themes": true,
 		"upgrades/removal-survey": true,
-		"upgrades/precancellation-chat": true
+		"upgrades/precancellation-chat": true,
+		"upgrades/presale-chat": true
 	},
 	"rtl": false,
 	"jetpack_min_version": "3.3",

--- a/config/stage.json
+++ b/config/stage.json
@@ -107,7 +107,8 @@
 		"upgrades/paypal": true,
 		"upgrades/premium-themes": true,
 		"upgrades/removal-survey": true,
-		"upgrades/precancellation-chat": true
+		"upgrades/precancellation-chat": true,
+		"upgrades/presale-chat": true
 	},
 	"siftscience_key": "e00e878351",
 	"wpcom_signup_id": "39911",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -123,7 +123,8 @@
 		"upgrades/paypal": true,
 		"upgrades/premium-themes": true,
 		"upgrades/removal-survey": true,
-		"upgrades/precancellation-chat": true
+		"upgrades/precancellation-chat": true,
+		"upgrades/presale-chat": true
 	},
 	"siftscience_key": "e00e878351",
 	"wpcom_signup_id": "39911",


### PR DESCRIPTION
This pull request enables pre sales chat on all environments with the exception of desktop.

Original work was done in #9709