### PR TITLE
Post Types: Try using WP REST API for post types

### DIFF
--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -186,6 +186,15 @@ UndocumentedSite.prototype.postCounts = function( options, callback ) {
 	return this.wpcom.req.get( '/sites/' + this._id + '/post-counts/' + type, query, callback );
 };
 
+UndocumentedSite.prototype.postTypes = function( options ) {
+	const query = Object.assign( {
+		apiNamespace: 'wp/v2',
+		context: 'edit'
+	}, options );
+
+	return this.wpcom.req.get( `/sites/${ this._id }/types`, query );
+};
+
 /**
  * Returns media storage limits and space used for a given site. If site has
  * unlimited storage or is a jetpack site, values returned will be -1.

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -55,12 +55,11 @@ const PublishMenu = React.createClass( {
 
 		const items = [
 			{
-				name: 'post',
+				slug: 'post',
 				label: this.translate( 'Blog Posts' ),
 				className: 'posts',
 				capability: 'edit_posts',
 				config: 'manage/posts',
-				queryable: true,
 				link: '/posts' + this.getMyParameter(),
 				paths: [ '/posts', '/posts/my' ],
 				buttonLink: site ? '/post/' + site.slug : '/post',
@@ -68,11 +67,10 @@ const PublishMenu = React.createClass( {
 				showOnAllMySites: true,
 			},
 			{
-				name: 'page',
+				slug: 'page',
 				label: this.translate( 'Pages' ),
 				className: 'pages',
 				capability: 'edit_pages',
-				queryable: true,
 				config: 'manage/pages',
 				link: '/pages',
 				buttonLink: site ? '/page/' + site.slug : '/page',
@@ -83,11 +81,10 @@ const PublishMenu = React.createClass( {
 
 		if ( config.isEnabled( 'manage/media' ) ) {
 			items.push( {
-				name: 'media',
+				slug: 'media',
 				label: this.translate( 'Media' ),
 				className: 'media-section',
 				capability: 'upload_files',
-				queryable: true,
 				config: 'manage/media',
 				link: '/media',
 				wpAdminLink: 'upload.php',
@@ -112,7 +109,7 @@ const PublishMenu = React.createClass( {
 		}
 
 		// Hide the sidebar link for media
-		if ( 'attachment' === menuItem.name ) {
+		if ( 'attachment' === menuItem.slug ) {
 			return null;
 		}
 
@@ -124,21 +121,21 @@ const PublishMenu = React.createClass( {
 		}
 
 		let link;
-		if ( ( ! isEnabled || ! menuItem.queryable ) && site.options ) {
+		if ( ( ! isEnabled ) && site.options ) {
 			link = this.props.site.options.admin_url + menuItem.wpAdminLink;
 		} else {
 			link = menuItem.link + this.props.siteSuffix;
 		}
 
 		let preload;
-		if ( includes( [ 'post', 'page' ], menuItem.name ) ) {
+		if ( includes( [ 'post', 'page' ], menuItem.slug ) ) {
 			preload = 'posts-pages';
 		} else {
 			preload = 'posts-custom';
 		}
 
 		let icon;
-		switch ( menuItem.name ) {
+		switch ( menuItem.slug ) {
 			case 'post': icon = 'posts'; break;
 			case 'page': icon = 'pages'; break;
 			case 'jetpack-portfolio': icon = 'folder'; break;
@@ -153,11 +150,11 @@ const PublishMenu = React.createClass( {
 
 		return (
 			<SidebarItem
-				key={ menuItem.name }
+				key={ menuItem.slug }
 				label={ menuItem.label }
 				className={ className }
 				link={ link }
-				onNavigate={ this.onNavigate.bind( this, menuItem.name ) }
+				onNavigate={ this.onNavigate.bind( this, menuItem.slug ) }
 				icon={ icon }
 				preloadSectionName={ preload }
 			>
@@ -172,16 +169,16 @@ const PublishMenu = React.createClass( {
 		const customPostTypes = omit( this.props.postTypes, [ 'post', 'page' ] );
 		return map( customPostTypes, ( postType, postTypeSlug ) => {
 			let buttonLink;
-			if ( config.isEnabled( 'manage/custom-post-types' ) && postType.api_queryable ) {
+			if ( config.isEnabled( 'manage/custom-post-types' ) ) {
 				buttonLink = this.props.postTypeLinks[ postTypeSlug ];
 			}
 
 			return {
-				name: postType.name,
+				name: postType.label,
+				slug: postType.slug,
 				label: decodeEntities( get( postType.labels, 'menu_name', postType.label ) ),
-				className: postType.name,
+				className: postType.slug,
 				config: 'manage/custom-post-types',
-				queryable: postType.api_queryable,
 
 				//If the API endpoint doesn't send the .capabilities property (e.g. because the site's Jetpack
 				//version isn't up-to-date), silently assume we don't have the capability to edit this CPT.
@@ -189,8 +186,8 @@ const PublishMenu = React.createClass( {
 
 				// Required to build the menu item class name. Must be discernible from other
 				// items' paths in the same section for item highlighting to work properly.
-				link: '/types/' + postType.name,
-				wpAdminLink: 'edit.php?post_type=' + postType.name,
+				link: '/types/' + postType.slug,
+				wpAdminLink: 'edit.php?post_type=' + postType.slug,
 				showOnAllMySites: false,
 				buttonLink
 			};
@@ -220,8 +217,8 @@ export default connect( ( state ) => {
 
 	return {
 		postTypes,
-		postTypeLinks: mapValues( postTypes, ( postType, postTypeSlug ) => {
-			return getEditorPath( state, siteId, null, postTypeSlug );
+		postTypeLinks: mapValues( postTypes, ( { slug } ) => {
+			return getEditorPath( state, siteId, null, slug );
 		} )
 	};
 }, null, null, { pure: false } )( PublishMenu );

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -108,8 +108,8 @@ const PublishMenu = React.createClass( {
 			return null;
 		}
 
-		// Hide the sidebar link for media
-		if ( 'attachment' === menuItem.slug ) {
+		// Skip media and feedback post types
+		if ( includes( [ 'attachment', 'feedback' ], menuItem.slug ) ) {
 			return null;
 		}
 

--- a/client/state/post-types/actions.js
+++ b/client/state/post-types/actions.js
@@ -39,8 +39,7 @@ export function requestPostTypes( siteId ) {
 			siteId
 		} );
 
-		return wpcom.undocumented().site( siteId ).postTypes()
-		.then( ( data ) => {
+		return wpcom.undocumented().site( siteId ).postTypes().then( ( data ) => {
 			dispatch( receivePostTypes( siteId, data ) );
 			dispatch( {
 				type: POST_TYPES_REQUEST_SUCCESS,

--- a/client/state/post-types/actions.js
+++ b/client/state/post-types/actions.js
@@ -39,8 +39,9 @@ export function requestPostTypes( siteId ) {
 			siteId
 		} );
 
-		return wpcom.withLocale().site( siteId ).postTypesList().then( ( { post_types: types } ) => {
-			dispatch( receivePostTypes( siteId, types ) );
+		return wpcom.undocumented().site( siteId ).postTypes()
+		.then( ( data ) => {
+			dispatch( receivePostTypes( siteId, data ) );
 			dispatch( {
 				type: POST_TYPES_REQUEST_SUCCESS,
 				siteId

--- a/client/state/post-types/reducer.js
+++ b/client/state/post-types/reducer.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import keyBy from 'lodash/keyBy';
 
 /**
  * Internal dependencies
@@ -57,7 +56,7 @@ export function items( state = {}, action ) {
 	switch ( action.type ) {
 		case POST_TYPES_RECEIVE:
 			return Object.assign( {}, state, {
-				[ action.siteId ]: keyBy( action.types, 'name' )
+				[ action.siteId ]: action.types
 			} );
 
 		case DESERIALIZE:

--- a/client/state/post-types/schema.js
+++ b/client/state/post-types/schema.js
@@ -9,12 +9,10 @@ export const items = {
 				required: [ 'name' ],
 				properties: {
 					name: { type: 'string' },
-					label: { type: 'string' },
+					slug: { type: 'string' },
 					labels: { type: 'object' },
 					description: { type: 'string' },
-					map_meta_cap: { type: 'boolean' },
 					capabilities: { type: 'object' },
-					api_queryable: { type: 'boolean' },
 					hierarchical: { type: 'boolean' },
 					supports: { type: 'object' }
 				}

--- a/client/state/post-types/schema.js
+++ b/client/state/post-types/schema.js
@@ -6,9 +6,8 @@ export const items = {
 			type: 'object',
 			additionalProperties: {
 				type: 'object',
-				required: [ 'name' ],
+				required: [ 'slug' ],
 				properties: {
-					name: { type: 'string' },
 					slug: { type: 'string' },
 					labels: { type: 'object' },
 					description: { type: 'string' },

--- a/client/state/post-types/test/actions.js
+++ b/client/state/post-types/test/actions.js
@@ -28,14 +28,16 @@ describe( 'actions', () => {
 
 	describe( '#receivePostTypes()', () => {
 		it( 'should return an action object', () => {
-			const action = receivePostTypes( 2916284, [
-				{ name: 'post', label: 'Posts' }
-			] );
+			const action = receivePostTypes( 2916284, {
+				post: { slug: 'post', label: 'Posts' }
+			} );
 
 			expect( action ).to.eql( {
 				type: POST_TYPES_RECEIVE,
 				siteId: 2916284,
-				types: [ { name: 'post', label: 'Posts' } ]
+				types: {
+					post: { slug: 'post', label: 'Posts' }
+				}
 			} );
 		} );
 	} );
@@ -44,15 +46,12 @@ describe( 'actions', () => {
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
-				.get( '/rest/v1.1/sites/2916284/post-types' )
+				.get( '/wp/v2/sites/2916284/types?context=edit' )
 				.reply( 200, {
-					found: 2,
-					post_types: [
-						{ name: 'post', label: 'Posts' },
-						{ name: 'page', label: 'Pages' }
-					]
+					post: { slug: 'post', label: 'Posts' },
+					page: { slug: 'page', label: 'Pages' }
 				} )
-				.get( '/rest/v1.1/sites/77203074/post-types' )
+				.get( '/wp/v2/sites/77203074/types?context=edit' )
 				.reply( 403, {
 					error: 'authorization_required',
 					message: 'User cannot access this private blog.'
@@ -70,10 +69,10 @@ describe( 'actions', () => {
 
 		it( 'should dispatch receive action when request completes', () => {
 			return requestPostTypes( 2916284 )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( receivePostTypes( 2916284, [
-					{ name: 'post', label: 'Posts' },
-					{ name: 'page', label: 'Pages' }
-				] ) );
+				expect( spy ).to.have.been.calledWith( receivePostTypes( 2916284, {
+					post: { slug: 'post', label: 'Posts' },
+					page: { slug: 'page', label: 'Pages' }
+				} ) );
 			} );
 		} );
 

--- a/client/state/post-types/test/reducer.js
+++ b/client/state/post-types/test/reducer.js
@@ -121,16 +121,16 @@ describe( 'reducer', () => {
 			const state = items( null, {
 				type: POST_TYPES_RECEIVE,
 				siteId: 2916284,
-				types: [
-					{ name: 'post', label: 'Posts' },
-					{ name: 'page', label: 'Pages' }
-				]
+				types: {
+					post: { slug: 'post', label: 'Posts' },
+					page: { slug: 'page', label: 'Pages' }
+				}
 			} );
 
 			expect( state ).to.eql( {
 				2916284: {
-					post: { name: 'post', label: 'Posts' },
-					page: { name: 'page', label: 'Pages' }
+					post: { slug: 'post', label: 'Posts' },
+					page: { slug: 'page', label: 'Pages' }
 				}
 			} );
 		} );
@@ -138,24 +138,24 @@ describe( 'reducer', () => {
 		it( 'should accumulate sites', () => {
 			const state = items( deepFreeze( {
 				2916284: {
-					post: { name: 'post', label: 'Posts' },
-					page: { name: 'page', label: 'Pages' }
+					post: { slug: 'post', label: 'Posts' },
+					page: { slug: 'page', label: 'Pages' }
 				}
 			} ), {
 				type: POST_TYPES_RECEIVE,
 				siteId: 77203074,
-				types: [
-					{ name: 'post', label: 'Posts' }
-				]
+				types: {
+					post: { slug: 'post', label: 'Posts' }
+				}
 			} );
 
 			expect( state ).to.eql( {
 				2916284: {
-					post: { name: 'post', label: 'Posts' },
-					page: { name: 'page', label: 'Pages' }
+					post: { slug: 'post', label: 'Posts' },
+					page: { slug: 'page', label: 'Pages' }
 				},
 				77203074: {
-					post: { name: 'post', label: 'Posts' }
+					post: { slug: 'post', label: 'Posts' }
 				}
 			} );
 		} );
@@ -163,20 +163,20 @@ describe( 'reducer', () => {
 		it( 'should override previous post types of same site ID', () => {
 			const state = items( deepFreeze( {
 				2916284: {
-					post: { name: 'post', label: 'Posts' },
-					page: { name: 'page', label: 'Pages' }
+					post: { slug: 'post', label: 'Posts' },
+					page: { slug: 'page', label: 'Pages' }
 				}
 			} ), {
 				type: POST_TYPES_RECEIVE,
 				siteId: 2916284,
-				types: [
-					{ name: 'post', label: 'Posts' }
-				]
+				types: {
+					post: { slug: 'post', label: 'Posts' }
+				}
 			} );
 
 			expect( state ).to.eql( {
 				2916284: {
-					post: { name: 'post', label: 'Posts' }
+					post: { slug: 'post', label: 'Posts' }
 				}
 			} );
 		} );
@@ -184,13 +184,13 @@ describe( 'reducer', () => {
 		it( 'should persist state', () => {
 			const state = items( deepFreeze( {
 				2916284: {
-					post: { name: 'post', label: 'Posts' }
+					post: { slug: 'post', label: 'Posts' }
 				}
 			} ), { type: SERIALIZE } );
 
 			expect( state ).to.eql( {
 				2916284: {
-					post: { name: 'post', label: 'Posts' }
+					post: { slug: 'post', label: 'Posts' }
 				}
 			} );
 		} );
@@ -198,20 +198,20 @@ describe( 'reducer', () => {
 		it( 'should load valid persisted state', () => {
 			const state = items( deepFreeze( {
 				2916284: {
-					post: { name: 'post', label: 'Posts' }
+					post: { slug: 'post', label: 'Posts' }
 				}
 			} ), { type: DESERIALIZE } );
 
 			expect( state ).to.eql( {
 				2916284: {
-					post: { name: 'post', label: 'Posts' }
+					post: { slug: 'post', label: 'Posts' }
 				}
 			} );
 		} );
 
 		it( 'should not load invalid persisted state', () => {
 			const state = items( deepFreeze( {
-				post: { name: 'post', label: 'Posts' }
+				post: { slug: 'post', label: 'Posts' }
 			} ), { type: DESERIALIZE } );
 
 			expect( state ).to.eql( {} );

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -87,8 +87,8 @@ describe( 'initial-state', () => {
 						postTypes: {
 							items: {
 								2916284: {
-									post: { name: 'post', label: 'Posts' },
-									page: { name: 'page', label: 'Pages' }
+									post: { slug: 'post', label: 'Posts' },
+									page: { slug: 'page', label: 'Pages' }
 								}
 							}
 						},
@@ -139,8 +139,8 @@ describe( 'initial-state', () => {
 						postTypes: {
 							items: {
 								2916284: {
-									post: { name: 'post', label: 'Posts' },
-									page: { name: 'page', label: 'Pages' }
+									post: { slug: 'post', label: 'Posts' },
+									page: { slug: 'page', label: 'Pages' }
 								}
 							}
 						},
@@ -150,7 +150,7 @@ describe( 'initial-state', () => {
 						postTypes: {
 							items: {
 								77203074: {
-									post: { name: 'post', label: 'Posts' }
+									post: { slug: 'post', label: 'Posts' }
 								}
 							}
 						}
@@ -196,7 +196,7 @@ describe( 'initial-state', () => {
 					postTypes: {
 						items: {
 							77203074: {
-								post: { name: 'post', label: 'Posts' }
+								post: { slug: 'post', label: 'Posts' }
 							}
 						}
 					}
@@ -213,8 +213,8 @@ describe( 'initial-state', () => {
 								postTypes: {
 									items: {
 										2916284: {
-											post: { name: 'post', label: 'Posts' },
-											page: { name: 'page', label: 'Pages' }
+											post: { slug: 'post', label: 'Posts' },
+											page: { slug: 'page', label: 'Pages' }
 										}
 									}
 								},
@@ -254,8 +254,8 @@ describe( 'initial-state', () => {
 						postTypes: {
 							items: {
 								2916284: {
-									post: { name: 'post', label: 'Posts' },
-									page: { name: 'page', label: 'Pages' }
+									post: { slug: 'post', label: 'Posts' },
+									page: { slug: 'page', label: 'Pages' }
 								}
 							}
 						},


### PR DESCRIPTION
During a recent team hangout, we talked about revisiting the notion of using a core WP REST API endpoint in Calypso.  In my recent testing of the new v2 API, post types seemed like a good target now that post type data is reliably synced via Jetpack to the shadow site.  As such, this _try_ branch implements a new undocumented method on `wpcom.site()` that calls out to the `/types` endpoint in the WP REST API.

I took a look at all files that are using `QueryPostTypes` and updated them for the minor changes in the post type object that is returned by the WP REST API.  The big difference in the response objects is the old `name` field maps to a `slug` field in the core endpoint response object.  The other big difference is the WPCOM v1.1 endpoint returns a `supports` object that is used in a few places in Calypso.  The core v2 endpoint does not return this, so I have added support, errr, for the `supports` object in D3545-code.

__To Test__
- Sandbox the API
- Apply D3545-code to your sandbox
- Then test out all the parts of the code that utilize `QueryPostTypes`.  This includes the publish menu in the sidebar, editing all post types ( new and editing existing posts ), the Site Settings > Writing page, and the post listing screens for custom post types

__Known Issues__
Right now the v2 API is returning the "Feedback" post type, so I will likely need to do another wpcom patch to flag that as `false` on `show_in_rest`.  There is a bit of a change from the current state schema for post types - not sure if that is a big concern or not.

/cc @aduth 