### PR TITLE
Reader: turn off Elasticsearch-powered tag stream on development and wpcalypso

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -133,7 +133,7 @@
 		"reader/refresh/stream": true,
 		"reader/search": true,
 		"reader/start": true,
-		"reader/tags-with-elasticsearch": true,
+		"reader/tags-with-elasticsearch": false,
 		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -105,7 +105,7 @@
 		"reader/related-posts": true,
 		"reader/search": true,
 		"reader/start": true,
-		"reader/tags-with-elasticsearch": true,
+		"reader/tags-with-elasticsearch": false,
 		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,


### PR DESCRIPTION
Turn off Elasticsearch-powered tag stream on development and wpcalypso so we're using v1.2 API endpoints across the board.

cc @blowery 