### PR TITLE
Reinforce use of siteId in sites-dropdown+ancestors components

### DIFF
--- a/client/components/site-selector-modal/index.jsx
+++ b/client/components/site-selector-modal/index.jsx
@@ -98,7 +98,7 @@ class SiteSelectorModal extends Component {
 				</div>
 				<SitesDropdown
 					onSiteSelect={ this.setSite }
-					selected={ this.state.site.slug }
+					selectedSiteId={ this.state.site.ID }
 					filter={ this.props.filter } />
 			</Dialog>
 		);

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
+import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 import noop from 'lodash/noop';
 
@@ -17,60 +16,60 @@ import Gridicon from 'components/gridicon';
 
 const sites = sitesList();
 
-export default React.createClass( {
+export default class SitesDropdown extends PureComponent {
 
-	displayName: 'SitesDropdown',
-
-	mixins: [ PureRenderMixin ],
-
-	propTypes: {
-		selected: React.PropTypes.oneOfType( [
-			React.PropTypes.number,
-			React.PropTypes.string
-		] ),
+	static propTypes = {
+		selectedSiteId: React.PropTypes.number,
 		showAllSites: React.PropTypes.bool,
 		onClose: React.PropTypes.func,
 		onSiteSelect: React.PropTypes.func,
 		filter: React.PropTypes.func,
 		isPlaceholder: React.PropTypes.bool
-	},
+	}
 
-	getDefaultProps() {
-		return {
-			showAllSites: false,
-			onClose: noop,
-			onSiteSelect: noop,
-			isPlaceholder: false
-		};
-	},
+	static defaultProps = {
+		showAllSites: false,
+		onClose: noop,
+		onSiteSelect: noop,
+		isPlaceholder: false
+	}
 
-	getInitialState() {
-		const primary = sites.getPrimary();
-		return {
-			selected: this.props.selected || primary && primary.slug
+	constructor( props ) {
+		super( props );
+
+		this.selectSite = this.selectSite.bind( this );
+		this.toggleOpen = this.toggleOpen.bind( this );
+		this.onClose = this.onClose.bind( this );
+
+		const selectedSite = props.selectedSiteId
+			? sites.getSite( props.selectedSiteId )
+			: sites.getPrimary();
+
+		this.state = {
+			selectedSiteSlug: selectedSite && selectedSite.slug
 		};
-	},
+	}
 
 	getSelectedSite() {
-		return sites.getSite( this.state.selected );
-	},
+		return sites.getSite( this.state.selectedSiteSlug );
+	}
 
 	selectSite( siteSlug ) {
 		this.props.onSiteSelect( siteSlug );
 		this.setState( {
-			selected: siteSlug,
+			selectedSiteSlug: siteSlug,
 			open: false
 		} );
-	},
+	}
 
 	toggleOpen() {
 		this.setState( { open: ! this.state.open } );
-	},
+	}
 
 	onClose( e ) {
 		this.setState( { open: false } );
 		this.props.onClose && this.props.onClose( e );
-	},
+	}
 
 	render() {
 		return (
@@ -92,7 +91,7 @@ export default React.createClass( {
 							autoFocus={ true }
 							onClose={ this.onClose }
 							onSiteSelect={ this.selectSite }
-							selected={ this.state.selected }
+							selected={ this.state.selectedSiteSlug }
 							hideSelected={ true }
 							filter={ this.props.filter }
 						/>
@@ -101,4 +100,4 @@ export default React.createClass( {
 			</div>
 		);
 	}
-} );
+}

--- a/client/components/sites-dropdown/test/index.js
+++ b/client/components/sites-dropdown/test/index.js
@@ -1,0 +1,127 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import noop from 'lodash/noop';
+
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+import useMockery from 'test/helpers/use-mockery';
+import useFilesystemMocks from 'test/helpers/use-filesystem-mocks';
+
+describe( 'index', function() {
+	useFakeDom();
+
+	useFilesystemMocks( __dirname );
+
+	useMockery( mockery => {
+		mockery.registerSubstitute( 'matches-selector', 'component-matches-selector' );
+	} );
+
+	let SitesDropdown;
+
+	before( function() {
+		SitesDropdown = require( '../index.jsx' );
+	} );
+
+	describe( 'component rendering', function() {
+		it( 'should render a dropdown component initially closed', function() {
+			const sitesDropdown = shallow( <SitesDropdown /> );
+			expect( sitesDropdown.hasClass( 'sites-dropdown' ) ).to.be.true;
+			expect( sitesDropdown.hasClass( 'is-open' ) ).to.be.false;
+		} );
+
+		it( 'should toggle the dropdown, when it is clicked', function() {
+			const toggleOpenSpy = sinon.spy( SitesDropdown.prototype, 'toggleOpen' );
+			const sitesDropdown = shallow( <SitesDropdown /> );
+
+			sitesDropdown.find( '.sites-dropdown__selected' ).simulate( 'click' );
+
+			sinon.assert.calledOnce( toggleOpenSpy );
+			expect( sitesDropdown.hasClass( 'is-open' ) ).to.be.true;
+
+			toggleOpenSpy.restore();
+		} );
+	} );
+
+	describe( 'component state', function() {
+		it( "should initially consider as selected the user's primary site, when is not specified something different", function() {
+			const sitesDropdown = shallow( <SitesDropdown /> );
+			expect( sitesDropdown.instance().state.selectedSiteSlug ).to.be.equal( 'primary.wordpress.com' );
+		} );
+
+		it( 'should initially consider as selected the site whose id is passed as `selectedSiteId` prop', function() {
+			const sitesDropdown = shallow( <SitesDropdown selectedSiteId={ 42 } /> );
+			expect( sitesDropdown.instance().state.selectedSiteSlug ).to.be.equal( 'foo.wordpress.com' );
+		} );
+	} );
+
+	describe( 'selectSite', function() {
+		it( 'should update the `selectedSiteSlug`, and `open` state properties', function() {
+			const setStateSpy = sinon.spy();
+			const siteSelectedSpy = sinon.spy();
+			const fakeContext = {
+				setState: setStateSpy,
+				props: {
+					onSiteSelect: siteSelectedSpy
+				}
+			};
+
+			SitesDropdown.prototype.selectSite.call( fakeContext, 'foobar' );
+
+			sinon.assert.calledOnce( siteSelectedSpy );
+			sinon.assert.calledWith( siteSelectedSpy, 'foobar' );
+
+			sinon.assert.calledOnce( setStateSpy );
+			sinon.assert.calledWith( setStateSpy, { open: false, selectedSiteSlug: 'foobar' } );
+		} );
+	} );
+
+	describe( 'onClose', function() {
+		it( 'should set `open` state property to false', function() {
+			const setStateSpy = sinon.spy();
+			const fakeContext = {
+				setState: setStateSpy,
+				props: {
+					onClose: noop
+				}
+			};
+
+			SitesDropdown.prototype.onClose.call( fakeContext );
+
+			sinon.assert.calledOnce( setStateSpy );
+			sinon.assert.calledWith( setStateSpy, { open: false } );
+		} );
+
+		it( 'should run the component `onClose` hook, when it is provided', function() {
+			const onCloseSpy = sinon.spy();
+			const fakeContext = {
+				setState: noop,
+				props: {
+					onClose: onCloseSpy
+				}
+			};
+
+			SitesDropdown.prototype.onClose.call( fakeContext );
+			sinon.assert.calledOnce( onCloseSpy );
+		} );
+	} );
+
+	describe( 'getSelectedSite', function() {
+		it( 'should return a site on the basis of the component `selectedSiteSlug` state property', function() {
+			const fakeState = {
+				selectedSiteSlug: 'foo.wordpress.com'
+			};
+			const selectedSite = SitesDropdown.prototype.getSelectedSite.call( { state: fakeState } );
+			expect( selectedSite ).to.be.eql( {
+				ID: 42,
+				slug: 'foo.wordpress.com'
+			} );
+		} );
+	} );
+} );

--- a/client/components/sites-dropdown/test/lib/sites-list/index.js
+++ b/client/components/sites-dropdown/test/lib/sites-list/index.js
@@ -1,0 +1,39 @@
+
+const sites = {
+	1: {
+		ID: 1,
+		slug: 'primary.wordpress.com'
+	},
+	42: {
+		ID: 42,
+		slug: 'foo.wordpress.com'
+	}
+};
+
+class SiteList {
+	getPrimary() {
+		return sites[ '1' ];
+	}
+
+	getSite( siteId ) {
+		if ( sites[ siteId ] ) {
+			return sites[ siteId ];
+		}
+
+		for ( const k in sites ) {
+			if ( sites.hasOwnProperty( k ) ) {
+				if ( sites[ k ].slug === siteId ) {
+					return sites[ k ];
+				}
+			}
+		}
+
+		return null;
+	}
+}
+
+const siteList = new SiteList;
+
+export default function factory() {
+	return siteList;
+}

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -379,13 +379,13 @@ const Account = React.createClass( {
 			);
 		}
 
-		let primarySiteId = this.props.userSettings.getSetting( 'primary_site_ID' );
+		const primarySiteId = this.props.userSettings.getSetting( 'primary_site_ID' );
 
 		return (
 			<SitesDropdown
 				key={ primarySiteId }
 				isPlaceholder={ ! primarySiteId }
-				selected={ this.props.userSettings.getSetting( 'primary_site_ID' ) }
+				selectedSiteId={ primarySiteId }
 				onSiteSelect={ this.onSiteSelect }
 			/>
 		);

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -23,7 +23,7 @@ import FormButton from 'components/forms/form-button';
 import SitesDropdown from 'components/sites-dropdown';
 import siteList from 'lib/sites-list';
 import HelpContactClosureNotice from '../help-contact-closure-notice';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
  * Module variables
@@ -77,7 +77,7 @@ export const HelpContactForm = React.createClass( {
 			howYouFeel: 'unspecified',
 			message: '',
 			subject: '',
-			siteSlug: this.getSiteSlug()
+			siteSlug: this.getSiteId()
 		};
 	},
 
@@ -93,21 +93,22 @@ export const HelpContactForm = React.createClass( {
 		this.props.valueLink.requestChange( this.state );
 	},
 
-	getSiteSlug() {
-		if ( this.props.selectedSiteSlug ) {
-			return this.props.selectedSiteSlug;
+	getSiteId() {
+		if ( this.props.selectedSiteId ) {
+			return this.props.selectedSiteId;
 		}
 
 		const primarySite = sites.getPrimary();
 		if ( primarySite ) {
-			return primarySite.slug;
+			return primarySite.ID;
 		}
 
 		return null;
 	},
 
 	setSite( siteSlug ) {
-		this.setState( { siteSlug } );
+		const site = sites.getSite( siteSlug );
+		this.setState( { siteId: site.ID } );
 	},
 
 	trackClickStats( selectionName, selectedOption ) {
@@ -242,7 +243,7 @@ export const HelpContactForm = React.createClass( {
 					<div className="help-contact-form__site-selection">
 						<FormLabel>{ translate( 'Which site do you need help with?' ) }</FormLabel>
 						<SitesDropdown
-							selected={ this.state.siteSlug }
+							selectedSiteId={ this.state.siteId }
 							onSiteSelect={ this.setSite } />
 					</div>
 				) }
@@ -268,8 +269,10 @@ export const HelpContactForm = React.createClass( {
 	}
 } );
 
-export default connect( ( state ) => {
+const mapStateToProps = ( state ) => {
 	return {
-		selectedSiteSlug: getSelectedSiteSlug( state )
+		selectedSiteId: getSelectedSiteId( state )
 	};
-} )( localize( HelpContactForm ) );
+};
+
+export default connect( mapStateToProps )( localize( HelpContactForm ) );


### PR DESCRIPTION
As discussed with @gwwar in #9624 ,
I am opening this pull request in which we reinforce the use of the `siteId` as unique way to identify a site into the `sites-dropdown` component, and its ancestors.

Since it's not clear, if this is something we want really to merge, at the moment I just focused on the main implementation, avoiding other janitorial fixes on the files in the changeset.

If we decide to merge this PR, I will happy to add also some tests on the `sites-dropdown` component.

Ask to share their opinion on this also to @mtias @ockham @aduth @ebinnion .