### PR TITLE
Plugins: ES6ify PluginIcon and turn it into a stateless functional component

### DIFF
--- a/client/my-sites/plugins/plugin-icon/README.md
+++ b/client/my-sites/plugins/plugin-icon/README.md
@@ -6,9 +6,9 @@ This component is used to display the icon for a plugin. It takes a plugin image
 #### How to use:
 
 ```js
-var PluginIcon = require( 'my-sites/plugins/plugin-icon/plugin-icon' );
+import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
 
-render: function() {
+render() {
     return (
         <div className="your-stuff">
               <PluginIcon image={ plugin.icon } />
@@ -19,4 +19,6 @@ render: function() {
 
 #### Props
 
-* `image`: an image source.
+* `image` (`string`) - an image source.
+* `isPlaceholder` (`bool`) - `true` to display as a placeholder.
+* `className` (`string`) - A string that adds additional class names to this component.

--- a/client/my-sites/plugins/plugin-icon/plugin-icon.jsx
+++ b/client/my-sites/plugins/plugin-icon/plugin-icon.jsx
@@ -1,34 +1,30 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import Gridicon from 'components/gridicon';
-import PureRenderMixin from 'react-pure-render/mixin';
 
-export default React.createClass( {
+const PluginIcon = ( { className, image, isPlaceholder } ) => {
+	const classes = classNames( {
+		'plugin-icon': true,
+		'is-placeholder': isPlaceholder,
+		'is-fallback': ! image,
+	}, className );
 
-	displayName: 'PluginIcon',
+	return (
+		<div className={ classes } >
+			{ isPlaceholder || ! image
+				? <Gridicon icon="plugins" />
+				: <img className="plugin-icon__img" src={ image } />
+			}
+		</div>
+	);
+};
 
-	propTypes: {
-		image: React.PropTypes.string,
-		isPlaceholder: React.PropTypes.bool
-	},
+PluginIcon.propTypes = {
+	image: PropTypes.string,
+	isPlaceholder: PropTypes.bool
+};
 
-	mixins: [ PureRenderMixin ],
-
-	render() {
-		const className = classNames( {
-				'plugin-icon': true,
-				'is-placeholder': this.props.isPlaceholder,
-				'is-fallback': ! this.props.image
-			} ),
-		avatar = ( this.props.isPlaceholder || ! this.props.image ) ? <Gridicon icon="plugins" /> : <img className="plugin-icon__img" src={ this.props.image } />;
-
-		return (
-			<div className={ classNames( this.props.className, className ) } >
-				{ avatar }
-			</div>
-		);
-	}
-} );
+export default PluginIcon;


### PR DESCRIPTION
This PR ES6ifies the `PluginIcon` component, and turns it into a stateless functional component. Also, it suggests some improvements and expands to the component README.

To test:

* Checkout this branch
* Open various pages where plugin icons are used, and verify there are no regressions:
  * /plugins/browse
  * /plugins/browse/new/
  * /plugins/$plugin
  * /plugins/$plugin/$site

/cc @enejb @johnHackworth @lezama 