### PR TITLE
Plugins: Refactor PluginSite as stateless functional component

### DIFF
--- a/client/my-sites/plugins/plugin-site/README.md
+++ b/client/my-sites/plugins/plugin-site/README.md
@@ -6,9 +6,9 @@ This component is used to represent the state of a single instance of a plugin i
 #### How to use:
 
 ```js
-var PluginSite = require( 'my-sites/plugins/plugin-site/plugin-site' );
+import PluginSite from 'my-sites/plugins/plugin-site/plugin-site';
 
-render: function() {
+render() {
     return <PluginSite
             site={ site }
             secondarySites={ this.getSecondaryPluginSites( site ) }

--- a/client/my-sites/plugins/plugin-site/plugin-site.jsx
+++ b/client/my-sites/plugins/plugin-site/plugin-site.jsx
@@ -1,27 +1,24 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var PluginSiteJetpack = require( 'my-sites/plugins/plugin-site-jetpack' ),
-	PluginSiteNetwork = require( 'my-sites/plugins/plugin-site-network' );
+import PluginSiteJetpack from 'my-sites/plugins/plugin-site-jetpack';
+import PluginSiteNetwork from 'my-sites/plugins/plugin-site-network';
 
-module.exports = React.createClass( {
-
-	displayName: 'PluginSite',
-
-	render: function() {
-		if ( ! this.props.site ) {
-			return null;
-		}
-
-		if ( this.props.site.jetpack && this.props.secondarySites && this.props.secondarySites.length ) {
-			return <PluginSiteNetwork { ...this.props } />;
-		}
-
-		return <PluginSiteJetpack { ...this.props } />;
+const PluginSite = ( props ) => {
+	if ( ! props.site ) {
+		return null;
 	}
-} );
+
+	if ( props.site.jetpack && props.secondarySites && props.secondarySites.length ) {
+		return <PluginSiteNetwork { ...props } />;
+	}
+
+	return <PluginSiteJetpack { ...props } />;
+};
+
+export default PluginSite;


### PR DESCRIPTION
This PR refactors the `PluginSite` factory component into a stateless functional component. It also modernizes the example in the component README.

To test:

* Checkout this branch
* Verify there are no regressions with the component: `/plugins/hello-dolly`

/cc @enejb @johnHackworth @lezama