### PR TITLE
Components: Upgrade react-virtualized to 8.x

### DIFF
--- a/client/blocks/taxonomy-manager/list.jsx
+++ b/client/blocks/taxonomy-manager/list.jsx
@@ -126,14 +126,19 @@ export class TaxonomyManagerList extends Component {
 		);
 	}
 
-	renderRow = ( { index } ) => {
+	renderRow = ( { key, style, index } ) => {
 		const item = this.getItem( index );
 		if ( item ) {
-			return this.renderItem( item );
+			const renderedItem = this.renderItem( item );
+			if ( renderedItem ) {
+				return React.cloneElement( renderedItem, { key, style } );
+			}
+
+			return;
 		}
 
 		return (
-			<CompactCard className="taxonomy-manager__list-item is-placeholder">
+			<CompactCard key={ key } style={ style } className="taxonomy-manager__list-item is-placeholder">
 				<span className="taxonomy-manager__label">
 					{ this.props.translate( 'Loading…' ) }
 				</span>

--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -36,12 +36,17 @@
 
 .taxonomy-manager__list-item-card {
 	cursor: pointer;
+
+	.taxonomy-manager__list-item:last-child &.card.is-compact {
+		margin-bottom: 0;
+	}
 }
 
 .taxonomy-manager__action-wrapper {
 	cursor: pointer;
-	font-size: 24px;
-	padding: 10px 28px;
+	font-size: 0;
+	line-height: 1;
+	padding: 15px 28px;
 	position: absolute;
 		right: 0;
 		top: 0;

--- a/client/blocks/term-tree-selector/style.scss
+++ b/client/blocks/term-tree-selector/style.scss
@@ -52,6 +52,7 @@ input[type=checkbox].term-tree-selector__input {
 }
 
 .term-tree-selector__list-item {
+	box-sizing: border-box;
 	position: relative;
 	padding: 2px 8px;
 	font-size: 13px;

--- a/client/blocks/term-tree-selector/terms.jsx
+++ b/client/blocks/term-tree-selector/terms.jsx
@@ -5,7 +5,7 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import VirtualScroll from 'react-virtualized/VirtualScroll';
+import List from 'react-virtualized/List';
 import {
 	debounce,
 	difference,
@@ -110,7 +110,7 @@ const TermTreeSelectorList = React.createClass( {
 		);
 
 		if ( forceUpdate ) {
-			this.virtualScroll.forceUpdate();
+			this.virtualScroll.forceUpdateGrid();
 		}
 
 		if ( this.props.terms !== prevProps.terms ) {
@@ -124,7 +124,6 @@ const TermTreeSelectorList = React.createClass( {
 		}
 
 		this.virtualScroll.recomputeRowHeights();
-		this.virtualScroll.forceUpdate();
 
 		// Compact mode passes the height of the scrollable region as a derived
 		// number, and will not be updated unless our component re-renders
@@ -367,14 +366,19 @@ const TermTreeSelectorList = React.createClass( {
 		}
 	},
 
-	renderRow( { index } ) {
+	renderRow( { key, style, index } ) {
 		const item = this.getItem( index );
 		if ( item ) {
-			return this.renderItem( item );
+			const renderedItem = this.renderItem( item );
+			if ( renderedItem ) {
+				return React.cloneElement( renderedItem, { key, style } );
+			}
+
+			return;
 		}
 
 		return (
-			<div key="placeholder" className="term-tree-selector__list-item is-placeholder">
+			<div key={ key } style={ style } className="term-tree-selector__list-item is-placeholder">
 				<label>
 					<input
 						type={ this.props.multiple ? 'checkbox' : 'radio' }
@@ -414,7 +418,7 @@ const TermTreeSelectorList = React.createClass( {
 						searchTerm={ this.state.searchTerm }
 						onSearch={ this.onSearch } />
 				) }
-				<VirtualScroll
+				<List
 					ref={ this.setVirtualScrollRef }
 					width={ this.getResultsWidth() }
 					height={ isCompact ? this.getCompactContainerHeight() : 300 }

--- a/client/components/virtual-list/index.jsx
+++ b/client/components/virtual-list/index.jsx
@@ -4,7 +4,7 @@
 import React, { PropTypes, Component } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import VirtualScroll from 'react-virtualized/VirtualScroll';
+import List from 'react-virtualized/List';
 import AutoSizer from 'react-virtualized/AutoSizer';
 import {
 	debounce,
@@ -55,7 +55,7 @@ export class VirtualList extends Component {
 		);
 
 		if ( forceUpdate ) {
-			this.virtualScroll.forceUpdate();
+			this.virtualScroll.forceUpdateGrid();
 		}
 
 		if ( this.props.items !== prevProps.items ) {
@@ -69,7 +69,6 @@ export class VirtualList extends Component {
 		}
 
 		this.virtualScroll.recomputeRowHeights();
-		this.virtualScroll.forceUpdate();
 	}
 
 	getPageForIndex( index ) {
@@ -150,13 +149,13 @@ export class VirtualList extends Component {
 		}
 	};
 
-	renderRow = props => {
+	renderRow = ( { key, style, ...props } ) => {
 		const element = this.props.renderRow( props );
 		if ( ! element ) {
 			return element;
 		}
 		const setRowRef = ( ...args ) => this.setRowRef( props.index, ...args );
-		return React.cloneElement( element, { ref: setRowRef } );
+		return React.cloneElement( element, { ref: setRowRef, key, style } );
 	};
 
 	render() {
@@ -170,7 +169,7 @@ export class VirtualList extends Component {
 			<AutoSizer disableHeight>
 				{ ( { width } ) => (
 					<div className={ classes }>
-						<VirtualScroll
+						<List
 							ref={ this.setVirtualScrollRef }
 							onRowsRendered={ this.setRequestedPages }
 							rowCount={ rowCount }

--- a/client/my-sites/post-selector/selector.jsx
+++ b/client/my-sites/post-selector/selector.jsx
@@ -5,7 +5,7 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import getScrollbarSize from 'dom-helpers/util/scrollbarSize';
-import VirtualScroll from 'react-virtualized/VirtualScroll';
+import List from 'react-virtualized/List';
 import AutoSizer from 'react-virtualized/AutoSizer';
 import {
 	debounce,
@@ -115,7 +115,7 @@ const PostSelectorPosts = React.createClass( {
 		);
 
 		if ( forceUpdate ) {
-			this.virtualScroll.forceUpdate();
+			this.virtualScroll.forceUpdateGrid();
 		}
 
 		if ( this.props.posts !== prevProps.posts ) {
@@ -363,18 +363,24 @@ const PostSelectorPosts = React.createClass( {
 		);
 	},
 
-	renderRow( { index } ) {
+	renderRow( { key, style, index } ) {
 		const item = this.getItem( index );
 		if ( item ) {
-			return this.renderItem( item );
+			const renderedItem = this.renderItem( item );
+			if ( renderedItem ) {
+				return React.cloneElement( renderedItem, { key, style } );
+			}
+
+			return;
 		}
 
 		return (
-			<div key="placeholder" className="post-selector__list-item is-placeholder">
+			<div key={ key } style={ style } className="post-selector__list-item is-placeholder">
 				<label>
 					<input
 						type={ this.props.multiple ? 'checkbox' : 'radio' }
 						disabled
+						checked={ false }
 						className="post-selector__input" />
 					<span className="post-selector__label">
 						{ this.translate( 'Loading…' ) }
@@ -416,7 +422,7 @@ const PostSelectorPosts = React.createClass( {
 						key={ JSON.stringify( query ) }
 						disableHeight={ isCompact }>
 						{ ( { height, width } ) => (
-							<VirtualScroll
+							<List
 								ref={ this.setVirtualScrollRef }
 								width={ width }
 								height={ isCompact ? this.getCompactContainerHeight() : height }

--- a/client/my-sites/post-selector/style.scss
+++ b/client/my-sites/post-selector/style.scss
@@ -64,6 +64,7 @@ input[type=checkbox].post-selector__input {
 }
 
 .post-selector__list-item {
+	box-sizing: border-box;
 	position: relative;
 	padding: 2px 8px;
 	font-size: 13px;

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -11,7 +11,7 @@ import range from 'lodash/range';
 import size from 'lodash/size';
 import AutoSizer from 'react-virtualized/AutoSizer';
 import WindowScroller from 'react-virtualized/WindowScroller';
-import VirtualScroll from 'react-virtualized/VirtualScroll';
+import List from 'react-virtualized/List';
 
 /**
  * Internal dependencies
@@ -112,9 +112,14 @@ class PostTypeList extends Component {
 		return <PostItem key="placeholder" />;
 	}
 
-	renderPostRow( { index } ) {
+	renderPostRow( { key, style, index } ) {
 		const { global_ID: globalId } = this.props.posts[ index ];
-		return <PostItem key={ globalId } globalId={ globalId } />;
+
+		return (
+			<div key={ key } style={ style } className="post-type-list__item">
+				<PostItem globalId={ globalId } />
+			</div>
+		);
 	}
 
 	render() {
@@ -142,7 +147,7 @@ class PostTypeList extends Component {
 						{ ( { height, scrollTop } ) => (
 							<AutoSizer disableHeight>
 								{ ( { width } ) => (
-									<VirtualScroll
+									<List
 										autoHeight
 										scrollTop={ scrollTop }
 										height={ height }

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -29,3 +29,7 @@
 	max-height: 100%;
 	max-width: none;
 }
+
+.post-type-list__item:last-child .card.is-compact.post-item {
+	margin-bottom: 0;
+}

--- a/client/post-editor/editor-categories-tags/test/accordion.jsx
+++ b/client/post-editor/editor-categories-tags/test/accordion.jsx
@@ -21,12 +21,12 @@ describe( 'EditorCategoriesTagsAccordion', function() {
 	before( () => {
 		mockery.registerMock( 'post-editor/editor-term-selector', EmptyComponent );
 		mockery.registerMock( 'components/info-popover', EmptyComponent );
-		mockery.registerMock( 'react-virtualized/VirtualScroll', EmptyComponent );
+		mockery.registerMock( 'react-virtualized/List', EmptyComponent );
 
 		mount = require( 'enzyme' ).mount;
 		i18n = require( 'i18n-calypso' );
 
-		// require needs to be here in order for mocking of VirtualScroll to work
+		// require needs to be here in order for mocking of List to work
 		EditorCategoriesTagsAccordion = require ( 'post-editor/editor-categories-tags/accordion' ).EditorCategoriesTagsAccordion;
 	} );
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -531,7 +531,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000588"
+      "version": "1.0.30000590"
     },
     "caseless": {
       "version": "0.11.0"
@@ -2838,9 +2838,6 @@
     "percentage-regex": {
       "version": "3.0.0"
     },
-    "performance-now": {
-      "version": "0.2.0"
-    },
     "phone": {
       "version": "1.0.8",
       "from": "git+https://github.com/Automattic/node-phone.git#6be6549b03137f2cca01e202250bf2590750119e",
@@ -2998,9 +2995,6 @@
     "querystring-es3": {
       "version": "0.2.1"
     },
-    "raf": {
-      "version": "3.3.0"
-    },
     "randomatic": {
       "version": "1.1.6"
     },
@@ -3093,7 +3087,7 @@
       }
     },
     "react-virtualized": {
-      "version": "7.9.1",
+      "version": "8.5.3",
       "dependencies": {
         "classnames": {
           "version": "2.2.5"

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "react-pure-render": "1.0.2",
     "react-redux": "4.4.5",
     "react-tap-event-plugin": "2.0.1",
-    "react-virtualized": "7.9.1",
+    "react-virtualized": "8.5.3",
     "redux": "3.0.4",
     "redux-thunk": "1.0.0",
     "rtlcss": "2.0.5",


### PR DESCRIPTION
**WIP**: Still some issues with styling of lists causing overflow on taxonomy manager, cc @youknowriad @timmyc 

This pull request seeks to upgrade our `react-virtualized` dependency from 7.9.1 to 8.5.3. The 8.x release introduced a few breaking changes, particularly related to naming of components and props, but more importantly with removal of a layer of components in `react-virtualized`, placing the burden of keys and styles on the implementing component. See version 8 upgrade guide for more information:

https://github.com/bvaughn/react-virtualized/blob/master/docs/upgrades/Version8.md

__Testing Instructions:__

Verify that there are no regressions in usage of `<ReactVirtualized>`, particularly in:

- [Editor](http://calypso.localhost:3000/post) "Link to existing content" post selector
- [Editor](http://calypso.localhost:3000/post) "Page parent" post selector
- [Editor](http://calypso.localhost:3000/post) "Category" term selector
- [Settings > Writing](http://calypso.localhost:3000/settings/writing) taxonomy manager listing
- [Custom post type list screen](http://calypso.localhost:3000/types/post)