### PR TITLE
Desktop: Enable Personal Plan feature flag.

### DIFF
--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -57,6 +57,7 @@
 		"oauth": true,
 		"olark": false,
 		"persist-redux": true,
+		"plans/personal-plan": true,
 		"post-editor/author-selector": true,
 		"press-this": false,
 		"reader": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -65,6 +65,7 @@
 		"oauth": true,
 		"olark": true,
 		"persist-redux": true,
+		"plans/personal-plan": true,
 		"post-editor/author-selector": true,
 		"press-this": false,
 		"preview-layout": true,


### PR DESCRIPTION
Enables the Personal Plan feature flag on the desktop environment.

Fixes https://github.com/Automattic/wp-desktop/issues/247.

cc: @roundhill @sendhil 