### PR TITLE
Guided Tours: Allow tours to specify multiple paths

### DIFF
--- a/client/layout/guided-tours/config-elements.js
+++ b/client/layout/guided-tours/config-elements.js
@@ -57,7 +57,10 @@ export class Tour extends Component {
 	static propTypes = {
 		name: PropTypes.string.isRequired,
 		version: PropTypes.string,
-		path: PropTypes.string,
+		path: PropTypes.oneOfType( [
+			PropTypes.string,
+			PropTypes.arrayOf( PropTypes.string )
+		] ),
 		when: PropTypes.func,
 	};
 

--- a/client/state/ui/guided-tours/selectors/index.js
+++ b/client/state/ui/guided-tours/selectors/index.js
@@ -6,6 +6,7 @@ import {
 	difference,
 	find,
 	findLast,
+	flatMap,
 	get,
 	includes,
 	map,
@@ -38,11 +39,15 @@ const BLACKLISTED_SECTIONS = [
 const getToursHistory = state => getPreference( state, 'guided-tours-history' );
 const debug = debugFactory( 'calypso:guided-tours' );
 
-const relevantFeatures = map( GuidedToursConfig.meta, ( tourMeta, key ) => ( {
-	tour: key,
-	path: tourMeta.path,
-	when: tourMeta.when,
-} ) );
+const mappable = x => ! Array.isArray( x ) ? [ x ] : x;
+
+const relevantFeatures = flatMap( GuidedToursConfig.meta, ( tourMeta, key ) => (
+	mappable( tourMeta.path ).map( path => ( {
+		tour: key,
+		when: tourMeta.when,
+		path,
+	} ) )
+) );
 
 /*
  * Returns a collection of tour names. These tours are selected if the user has

--- a/client/state/ui/guided-tours/test/fixtures/config.js
+++ b/client/state/ui/guided-tours/test/fixtures/config.js
@@ -37,7 +37,7 @@ export const StatsTour = makeTour(
 );
 
 export const TestTour = makeTour(
-	<Tour name="test" version="test" path="/test" when={ () => true } />
+	<Tour name="test" version="test" path={ [ '/test', '/foo' ] } when={ () => true } />
 );
 
 export default combineTours( {


### PR DESCRIPTION
cc @Copons 

Another way to tackle it is allowing paths to be regular expressions.