### PR TITLE
Me: remove the `get` method to load user flags from `/me` endpoint

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -36,7 +36,6 @@ var config = require( 'config' ),
 	user = require( 'lib/user' )(),
 	receiveUser = require( 'state/users/actions' ).receiveUser,
 	setCurrentUserId = require( 'state/current-user/actions' ).setCurrentUserId,
-	setCurrentUserFlags = require( 'state/current-user/actions' ).setCurrentUserFlags,
 	sites = require( 'lib/sites-list' )(),
 	superProps = require( 'lib/analytics/super-props' ),
 	translatorJumpstart = require( 'lib/translator-jumpstart' ),
@@ -196,7 +195,6 @@ function reduxStoreReady( reduxStore ) {
 		// Set current user in Redux store
 		reduxStore.dispatch( receiveUser( user.get() ) );
 		reduxStore.dispatch( setCurrentUserId( user.get().ID ) );
-		reduxStore.dispatch( setCurrentUserFlags( user.get().meta.data.flags.active_flags ) );
 
 		if ( config.isEnabled( 'push-notifications' ) ) {
 			// If the browser is capable, registers a service worker & exposes the API


### PR DESCRIPTION
From what I can tell, we don't user user meta "flags" any longer after #9764 lands — they are a legacy set of user metadata that were used during the Newdash (aka Atlas) transition to Calypso several years ago.

Can we remove it now? They are loaded for `user` object data and not useful or used any more.

Note, there is a related REST API endpoint — see https://developer.wordpress.com/docs/api/1.1/get/me/ at a URL like `https://public-api.wordpress.com/rest/v1/me/flags`, which we could consider deprecating on the API side as well at the same time.

Anyone know of other uses for this data?