### PR TITLE
Reader: Expand rules for when a sitename matches an author name

### DIFF
--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -2,6 +2,9 @@
  * External dependencies
  */
 import React from 'react';
+import { numberFormat, localize } from 'i18n-calypso';
+import { has } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -10,11 +13,8 @@ import ReaderAvatar from 'blocks/reader-avatar';
 import ReaderAuthorLink from 'blocks/reader-author-link';
 import ReaderSiteStreamLink from 'blocks/reader-site-stream-link';
 import ReaderFollowButton from 'reader/follow-button';
-import { localize } from 'i18n-calypso';
-import classnames from 'classnames';
 import { getStreamUrl } from 'reader/route';
-import { numberFormat } from 'i18n-calypso';
-import { has } from 'lodash';
+import { areEqualIgnoringWhitespaceAndCase } from 'lib/string';
 
 const AuthorCompactProfile = React.createClass( {
 	propTypes: {
@@ -38,7 +38,7 @@ const AuthorCompactProfile = React.createClass( {
 		}
 
 		const hasAuthorName = has( author, 'name' );
-		const hasMatchingAuthorAndSiteNames = hasAuthorName && siteName.toLowerCase() === author.name.toLowerCase();
+		const hasMatchingAuthorAndSiteNames = hasAuthorName && areEqualIgnoringWhitespaceAndCase( siteName, author.name );
 		const classes = classnames( 'author-compact-profile', {
 			'has-author-link': ! hasMatchingAuthorAndSiteNames,
 			'has-author-icon': siteIcon || feedIcon || ( author && author.has_avatar )

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -20,6 +20,7 @@ import {
 import ReaderSiteStreamLink from 'blocks/reader-site-stream-link';
 import { getStreamUrl } from 'reader/route';
 import ReaderAuthorLink from 'blocks/reader-author-link';
+import { areEqualIgnoringWhitespaceAndCase } from 'lib/string';
 
 class PostByline extends React.Component {
 
@@ -55,7 +56,7 @@ class PostByline extends React.Component {
 		const primaryTag = post && post.primary_tag;
 		const siteName = siteNameFromSiteAndPost( site, post );
 		const hasAuthorName = has( post, 'author.name' );
-		const hasMatchingAuthorAndSiteNames = hasAuthorName && siteName.toLowerCase() === post.author.name.toLowerCase();
+		const hasMatchingAuthorAndSiteNames = hasAuthorName && areEqualIgnoringWhitespaceAndCase( siteName, post.author.name );
 		const shouldDisplayAuthor = ! isDiscoverPost && hasAuthorName && ( ! hasMatchingAuthorAndSiteNames || ! showSiteName );
 		const streamUrl = getStreamUrl( feedId, siteId );
 		const siteIcon = get( site, 'icon.img' );

--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -17,6 +17,7 @@ import Card from 'components/card/compact';
 import Gravatar from 'components/gravatar';
 import FollowButton from 'reader/follow-button';
 import { getPostUrl, getStreamUrl } from 'reader/route';
+import { areEqualIgnoringWhitespaceAndCase } from 'lib/string';
 
 function FeaturedImage( { image, href } ) {
 	return (
@@ -31,7 +32,7 @@ function FeaturedImage( { image, href } ) {
 function AuthorAndSiteFollow( { post, site, onSiteClick } ) {
 	const siteUrl = getStreamUrl( post.feed_ID, post.site_ID );
 	const siteName = ( site && site.title ) || post.site_name;
-	const authorAndSiteAreDifferent = siteName.toLowerCase() !== post.author.name.toLowerCase();
+	const authorAndSiteAreDifferent = ! areEqualIgnoringWhitespaceAndCase( siteName, post.author.name );
 
 	return (
 		<div className="reader-related-card-v2__meta">
@@ -39,14 +40,14 @@ function AuthorAndSiteFollow( { post, site, onSiteClick } ) {
 				<Gravatar user={ post.author } />
 			</a>
 			<div className="reader-related-card-v2__byline">
+				{ authorAndSiteAreDifferent &&
 				<span className="reader-related-card-v2__byline-author">
 					<a href={ siteUrl } onClick={ onSiteClick } className="reader-related-card-v2__link">{ post.author.name }</a>
 				</span>
-				{ authorAndSiteAreDifferent &&
+				}
 				<span className="reader-related-card-v2__byline-site">
 					<a href={ siteUrl } onClick={ onSiteClick } className="reader-related-card-v2__link">{ siteName }</a>
 				</span>
-				}
 			</div>
 			<FollowButton siteUrl={ post.site_URL } />
 		</div>

--- a/client/lib/string/index.js
+++ b/client/lib/string/index.js
@@ -1,0 +1,23 @@
+/**
+ * External Dependencies
+ */
+
+/**
+ * Internal Dependencies
+ */
+
+/**
+ * Are two strings equal, when ignoring whitespace and case?
+ *
+ * @export
+ * @param {string} a the first string
+ * @param {string} b the second string
+ * @returns
+ */
+export function areEqualIgnoringWhitespaceAndCase( a, b ) {
+	a = a.replace( /[\s'."]/g, '' );
+	b = b.replace( /[\s'."]/g, '' );
+	return a.toLowerCase() === b.toLowerCase();
+}
+
+

--- a/client/lib/string/index.js
+++ b/client/lib/string/index.js
@@ -15,8 +15,8 @@
  * @returns
  */
 export function areEqualIgnoringWhitespaceAndCase( a, b ) {
-	a = a.replace( /[\s'."]/g, '' );
-	b = b.replace( /[\s'."]/g, '' );
+	a = a.replace( /[\s'.\-_"]/g, '' );
+	b = b.replace( /[\s'.\-_"]/g, '' );
 	return a.toLowerCase() === b.toLowerCase();
 }
 

--- a/client/lib/string/test/index.js
+++ b/client/lib/string/test/index.js
@@ -1,0 +1,28 @@
+/**
+ * External Dependencies
+*/
+import { assert } from 'chai';
+
+/**
+ * Internal Dependencies
+ */
+import { areEqualIgnoringWhitespaceAndCase } from '../';
+
+describe( 'lib/string/areEqualIgnoringWhitespaceAndCase', () => {
+	it( 'should match', () => {
+		const pairs = [
+			// actual, expected
+			[ '', '' ],
+			[ 'hi there', 'Hi There' ],
+			[ 'hithere', 'Hi There' ],
+			[ 'hi-there', 'Hi There.' ],
+			[ 'hi_there', 'Hi THERE' ]
+		];
+		pairs.forEach( ( pair ) => {
+			assert.isTrue(
+				areEqualIgnoringWhitespaceAndCase( pair[ 0 ], pair[ 1 ] ),
+				`'${ pair[ 0 ] }' v '${ pair[ 1 ] }'`
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
It uses to be an caseless match, but that didn't catch a wide variety of common patterns. This removes whitespace
and punctuation from the site name and author name before attempting a match.

Fixes #9376