### PR TITLE
Fix incorrect binding on the chatStarted method.

### DIFF
--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -67,7 +67,7 @@ const RemovePurchase = React.createClass( {
 		olarkEvents.off( 'api.chat.onBeginConversation', this.chatStarted );
 	},
 
-	chatStarted: () => {
+	chatStarted() {
 		this.recordChatEvent( 'calypso_precancellation_chat_begin' );
 		olarkApi( 'api.chat.sendNotificationToOperator', {
 			body: 'Context: Precancellation'


### PR DESCRIPTION
This pull request fixes the binding on the `chatStarted` function so that `this` refers to the react component instead of the global `window` object.

The main symptom of this bug was that the `calypso_precancellation_chat_begin` tracks ping was not being recorded.

This was reported verbally to me by @jeremeylduvall in slack

#### How to test

1. Navigate to http://calypso.localhost:3000/me/purchases/
2. Select a product to cancel
3. Click the "Remove WordPress.com Business" (or whatever the product is)
4. If operators are available you should see the chat with us link
5. Click the chat with us link
6. Enter some text in the chatbox and send it.
7. The action of starting the chat here should have pinged tracks with `calypso_precancellation_chat_begin`