### PR TITLE
Reader: Add Tag icon to Tag header

### DIFF
--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -15,6 +15,7 @@ import { getFirstImageForTag } from 'state/reader/tags/images/selectors';
 import resizeImageUrl from 'lib/resize-image-url';
 import cssSafeUrl from 'lib/css-safe-url';
 import { decodeEntities } from 'lib/formatting';
+import Gridicon from 'components/gridicon';
 
 const TAG_HEADER_WIDTH = 830;
 
@@ -46,7 +47,9 @@ const TagStreamHeader = ( { tag, tagImage, isPlaceholder, showFollow, following,
 			}
 
 			<div className="tag-stream__header-image" style={ imageStyle }>
-				<h1 className="tag-stream__header-image-title">{ tag }</h1>
+				<h1 className="tag-stream__header-image-title">
+					<Gridicon icon="tag" size={ 24 } />{ tag }
+				</h1>
 				{ tagImage &&
 					<div className="tag-stream__header-image-byline">
 						<span className="tag-stream__header-image-byline-label">{ translate( 'Photo by' ) }</span> <a href={ tagImage.blog_url } className="tag-stream__header-image-byline-link" rel="author external">{ decodeEntities( tagImage.author ) }</a>, <a href={ tagImage.blog_url } className="tag-stream__header-image-byline-link" rel="external">{ decodeEntities( tagImage.blog_title ) }</a>

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -67,7 +67,7 @@
 	fill: $white;
 	position: relative;
 		right: 6px;
-		top: 2px;
+		top: 3px;
 	z-index: 2;
 }
 

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -85,9 +85,9 @@
 	color: $white;
 	font-size: 12px;
 	font-weight: 500;
+	padding-top: 24px;
 	text-align: right;
 	text-shadow: 0 1px rgba(0, 0, 0, .3);
-	transform: translateY( 150% );
 	z-index: 2;
 	-webkit-font-smoothing: antialiased;
 }

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -63,6 +63,14 @@
 	}
 }
 
+.tag-stream__header-image .gridicon.gridicons-tag {
+	fill: $white;
+	position: relative;
+		right: 6px;
+		top: 2px;
+	z-index: 2;
+}
+
 .tag-stream__header-image-title {
 	color: $white;
 	font-size: 28px;


### PR DESCRIPTION
To make it feel less weird now that tags are all lowercase and to make it more obvious that it's a tag stream.

**Before:**
![screenshot 2016-12-01 14 54 04](https://cloud.githubusercontent.com/assets/4924246/20816342/a805a7de-b7d6-11e6-9205-35250629479a.png)

**After:**
![screenshot 2016-12-01 14 54 09](https://cloud.githubusercontent.com/assets/4924246/20816346/ab526634-b7d6-11e6-9ae0-4135099fb8fe.png)
