### PR TITLE
Reader: Add border to images in More blocks

### DIFF
--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -400,6 +400,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 }
 
 .reader-related-card-v2__featured-image {
+	border: 1px solid lighten( $gray, 20% );
 	display: block;
 	height: 80px;
 
@@ -460,6 +461,10 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		&::after {
 			content: none;
 		}
+	}
+
+	.reader-related-card-v2__featured-image {
+		border: 0;
 	}
 
 	.reader-related-card-v2__site-info {


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/9491

**Before:**
![screenshot 2016-12-01 16 10 59](https://cloud.githubusercontent.com/assets/4924246/20818209/1814b830-b7e1-11e6-9b37-f580b5048fc8.png)

![screenshot 2016-12-01 16 09 57](https://cloud.githubusercontent.com/assets/4924246/20818213/1c45084c-b7e1-11e6-9862-571fe7b870f8.png)

**After:**
![screenshot 2016-12-01 16 10 38](https://cloud.githubusercontent.com/assets/4924246/20818216/2335bd22-b7e1-11e6-9fe2-4040aaa0c488.png)

![screenshot 2016-12-01 16 10 03](https://cloud.githubusercontent.com/assets/4924246/20818220/27a1608c-b7e1-11e6-9e5f-dcdfff2d5a4d.png)
