### PR TITLE
Add a chat bubble next to the presales chat button

### DIFF
--- a/client/components/olark-chat-button/index.jsx
+++ b/client/components/olark-chat-button/index.jsx
@@ -49,7 +49,7 @@ class OlarkChatButton extends Component {
 	}
 
 	render() {
-		const { className, isAvailable, title, borderless } = this.props;
+		const { className, isAvailable, children, borderless } = this.props;
 		const classes = classnames( className, 'olark-chat-button', 'button', {
 			'is-borderless': !! borderless
 		} );
@@ -60,7 +60,7 @@ class OlarkChatButton extends Component {
 
 		return (
 			<button className={ classes } onClick={ this.openChat }>
-				{ title }
+				{ children }
 			</button>
 		);
 	}

--- a/client/my-sites/upgrades/checkout/payment-chat-button.jsx
+++ b/client/my-sites/upgrades/checkout/payment-chat-button.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import OlarkChatButton from 'components/olark-chat-button';
+import Gridicon from 'components/gridicon';
 
 export default localize( ( { cart, translate, paymentType, transactionStep } ) => {
 	const { products } = cart;
@@ -23,7 +24,9 @@ export default localize( ( { cart, translate, paymentType, transactionStep } ) =
 				payment_type: paymentType,
 				transaction_step: transactionStep,
 				product_slug: productSlug,
-			} }
-			title={ translate( 'Need help? Chat with us' ) } />
+			} }>
+				<Gridicon icon="chat" className="checkout__payment-chat-button-icon" />
+				{ translate( 'Need help? Chat with us' ) }
+		</OlarkChatButton>
 	);
 } );

--- a/client/my-sites/upgrades/checkout/style.scss
+++ b/client/my-sites/upgrades/checkout/style.scss
@@ -825,9 +825,15 @@
 	}
 }
 
+.checkout__payment-chat-button-icon {
+	color: $blue-wordpress;
+	margin-right: 5px;
+}
+
 .checkout__payment-chat-button {
 	@include breakpoint( "<660px" ) {
 		width: 100%;
+		text-align: center;
 	}
 
 	@include breakpoint( ">960px" ) {


### PR DESCRIPTION
This pull request adds a chat bubble next to the "chat with us" button on the upgrades checkout screen. 

As suggested in https://github.com/Automattic/wp-calypso/pull/9709#issuecomment-263828008

### How to test
1. Navigate to http://calypso.localhost:3000/plans
2. From the browser console enter: `localStorage.setItem( 'ABTests', '{"presaleChatButton_20161129":"showChatButton"}' )`. This will allow us to bypass the abtest
3. Select the "Business" plan
4. Notice the "Need help? Chat with us" button now has a chat bubble next to it.

### What to expect
![screen shot 2016-12-02 at 1 37 57 pm](https://cloud.githubusercontent.com/assets/1854440/20845782/a4aff1c0-b894-11e6-9bbe-43b2ffbda211.png)
![screen shot 2016-12-02 at 1 38 16 pm](https://cloud.githubusercontent.com/assets/1854440/20845785/a725a652-b894-11e6-87ae-11f2887a872b.png)

