### PR TITLE
Reader Refresh: show follow button in tag streams

### DIFF
--- a/client/reader/stream/refresh-post.jsx
+++ b/client/reader/stream/refresh-post.jsx
@@ -53,7 +53,7 @@ class ReaderPostCardAdapter extends React.Component {
 				onClick={ this.onClick }
 				onCommentClick={ this.onCommentClick }
 				isSelected={ this.props.isSelected }
-				showPrimaryFollowButton={ this.props.showPrimaryFollowButton }
+				showPrimaryFollowButton={ this.props.showPrimaryFollowButtonOnCards }
 				showEntireExcerpt={ isDiscoverPost }
 				useBetterExcerpt={ ! isDiscoverPost }
 				showSiteName={ this.props.showSiteName }>

--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -47,7 +47,8 @@ export default {
 					mcKey
 				),
 				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
-				showBack: !! context.lastRoute
+				showBack: !! context.lastRoute,
+				showPrimaryFollowButtonOnCards: true
 			} ),
 			document.getElementById( 'primary' ),
 			context.store

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -94,7 +94,7 @@ const TagStream = React.createClass( {
 		const title = decodeURIComponent( this.state.title );
 
 		return (
-			<Stream { ...this.props } listName={ this.state.title } emptyContent={ emptyContent } showFollowInHeader={ true } >
+			<Stream { ...this.props } listName={ this.state.title } emptyContent={ emptyContent } showFollowInHeader={ true }>
 				<DocumentHead title={ this.translate( '%s ‹ Reader', { args: title } ) } />
 				{ this.props.showBack && <HeaderBack /> }
 				{ config.isEnabled( 'reader/refresh/stream' )


### PR DESCRIPTION
Fixes #9763.

A regression caused follow buttons to disappear from cards in tag streams. This PR fixes that:

<img width="866" alt="screen shot 2016-12-02 at 14 38 42" src="https://cloud.githubusercontent.com/assets/17325/20820029/0d6336a2-b89d-11e6-8b21-f5a6676ca807.png">

### To test

Visit a tag stream and ensure it has follow buttons, e.g. http://calypso.localhost:3000/tag/banana.