### PR TITLE
Add SERVER_DESERIALIZE to themes/queries reducer.

### DIFF
--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -27,7 +27,8 @@ import {
 	ACTIVE_THEME_REQUEST_SUCCESS,
 	ACTIVE_THEME_REQUEST_FAILURE,
 	SERIALIZE,
-	DESERIALIZE
+	DESERIALIZE,
+	SERVER_DESERIALIZE
 } from 'state/action-types';
 import {
 	getSerializedThemesQuery,
@@ -220,6 +221,15 @@ export const queries = ( () => {
 			[ siteId ]: nextManager
 		};
 	}
+	const deserialize = ( state ) => {
+		if ( ! isValidStateWithSchema( state, queriesSchema ) ) {
+			return {};
+		}
+
+		return mapValues( state, ( { data, options } ) => {
+			return new ThemeQueryManager( data, options );
+		} );
+	};
 	return createReducer( {}, {
 		[ THEMES_REQUEST_SUCCESS ]: ( state, { siteId, query, themes, found } ) => {
 			return applyToManager( state, siteId, 'receive', true, themes, { query, found } );
@@ -230,15 +240,8 @@ export const queries = ( () => {
 		[ SERIALIZE ]: ( state ) => {
 			return mapValues( state, ( { data, options } ) => ( { data, options } ) );
 		},
-		[ DESERIALIZE ]: ( state ) => {
-			if ( ! isValidStateWithSchema( state, queriesSchema ) ) {
-				return {};
-			}
-
-			return mapValues( state, ( { data, options } ) => {
-				return new ThemeQueryManager( data, options );
-			} );
-		}
+		[ DESERIALIZE ]: deserialize,
+		[ SERVER_DESERIALIZE ]: deserialize,
 	} );
 } )();
 


### PR DESCRIPTION
## Info
`queries` reducer from themes worked incorrectly when it was inflated from state provided by server.
This was happening because `queries` operates on `QueryManager` instances and not state raw data. The "raw" data was `queries` state serialized on server and send as a part of SSR and feed back to `queries` on client. To work it requires deserialization process that will transform raw data into `QueryManager` form. For SSRed state this process is don by defining `SERVER_DESERIALIZE` action handler in `queries` reducer that handles deserialization. For `queries` normal and server deserialization is exactly the same.