### PR TITLE
Add themeRequestError reducer and getThemeRequestError selector and tests.

### DIFF
--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import { mapValues } from 'lodash';
+import { mapValues, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -170,14 +170,17 @@ export function themeRequests( state = {}, action ) {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const themeRequestsError = createReducer( {}, {
+export const themeRequestErrors = createReducer( {}, {
 	[ THEME_REQUEST_FAILURE ]: ( state, { siteId, themeId, error } ) => ( {
 		...state,
-		[ siteId ]: Object.assign( {}, state[ siteId ], { [ themeId ]: { error } } )
+		[ siteId ]: {
+			...state[ siteId ],
+			[ themeId ]: error
+		}
 	} ),
 	[ THEME_REQUEST_SUCCESS ]: ( state, { siteId, themeId } ) => ( {
 		...state,
-		[ siteId ]: Object.assign( {}, state[ siteId ], { [ themeId ]: null } )
+		[ siteId ]: omit( state[ siteId ], themeId ),
 	} )
 } );
 
@@ -287,7 +290,7 @@ export default combineReducers( {
 	// queryRequests,
 	// lastQuery
 	themeRequests,
-	// themeRequestsError
+	// themeRequestErrors
 	activeThemes,
 	activeThemeRequests,
 	activationRequests,

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -162,6 +162,26 @@ export function themeRequests( state = {}, action ) {
 }
 
 /**
+ * Returns the updated site theme requests error state after an action has been
+ * dispatched. The state reflects a mapping of site ID, theme ID pairing to a
+ * object describing request error. If there is no error null is storred.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export const themeRequestsError = createReducer( {}, {
+	[ THEME_REQUEST_FAILURE ]: ( state, { siteId, themeId, error } ) => ( {
+		...state,
+		[ siteId ]: Object.assign( {}, state[ siteId ], { [ themeId ]: { error } } )
+	} ),
+	[ THEME_REQUEST_SUCCESS ]: ( state, { siteId, themeId } ) => ( {
+		...state,
+		[ siteId ]: Object.assign( {}, state[ siteId ], { [ themeId ]: null } )
+	} )
+} );
+
+/**
  * Returns the updated theme query requesting state after an action has been
  * dispatched. The state reflects a mapping of serialized query to whether a
  * network request is in-progress for that query.
@@ -267,6 +287,7 @@ export default combineReducers( {
 	// queryRequests,
 	// lastQuery
 	themeRequests,
+	// themeRequestsError
 	activeThemes,
 	activeThemeRequests,
 	activationRequests,

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -67,12 +67,8 @@ export const getTheme = createSelector(
  * @param  {Number}  siteId  Site ID
  * @return {Object}          error object if present or null otherwise
  */
-export function getThemeRequestsError( state, themeId, siteId ) {
-	const themes = get( state.themes.themeRequestsError, siteId, null );
-	if ( ! themes ) {
-		return null;
-	}
-	return get( themes, themeId, null );
+export function getThemeRequestErrors( state, themeId, siteId ) {
+	return get( state.themes.themeRequestErrors, [ siteId, themeId ], null );
 }
 
 /**

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -60,6 +60,22 @@ export const getTheme = createSelector(
 );
 
 /**
+ * Returns theme request error object
+ *
+ * @param  {Object}  state   Global state tree
+ * @param  {String}  themeId Theme ID
+ * @param  {Number}  siteId  Site ID
+ * @return {Object}          error object if present or null otherwise
+ */
+export function getThemeRequestsError( state, themeId, siteId ) {
+	const themes = get( state.themes.themeRequestsError, siteId, null );
+	if ( ! themes ) {
+		return null;
+	}
+	return get( themes, themeId, null );
+}
+
+/**
  * Returns an array of normalized themes for the themes query, or null if no
  * themes have been received.
  *

--- a/client/state/themes/test/reducer.js
+++ b/client/state/themes/test/reducer.js
@@ -30,7 +30,7 @@ import reducer, {
 	queries,
 	lastQuery,
 	themeRequests,
-	themeRequestsError,
+	themeRequestErrors,
 	activeThemes,
 	activationRequests,
 	activeThemeRequests,
@@ -465,29 +465,27 @@ describe( 'reducer', () => {
 		} );
 	} );
 
-	describe( '#themeRequestsError()', () => {
+	describe( '#themeRequestErrors()', () => {
 		it( 'should default to an empty object', () => {
-			const state = themeRequestsError( undefined, {} );
+			const state = themeRequestErrors( undefined, {} );
 
 			expect( state ).to.deep.equal( {} );
 		} );
 
-		it( 'should map site ID, theme ID to null value if request was successful', () => {
-			const state = themeRequestsError( deepFreeze( {} ), {
+		it( 'should create empyt mapping on success if previous state was empty', () => {
+			const state = themeRequestErrors( deepFreeze( {} ), {
 				type: THEME_REQUEST_SUCCESS,
 				siteId: 2916284,
-				themeId: 841
+				themeId: 'twentysixteen'
 			} );
 
 			expect( state ).to.deep.equal( {
-				2916284: {
-					841: null
-				}
+				2916284: {}
 			} );
 		} );
 
-		it( 'should map site ID, theme ID to error object if request finishes with failure', () => {
-			const state = themeRequestsError( deepFreeze( {} ), {
+		it( 'should map site ID, theme ID to error if request finishes with failure', () => {
+			const state = themeRequestErrors( deepFreeze( {} ), {
 				type: THEME_REQUEST_FAILURE,
 				siteId: 2916284,
 				themeId: 'vivaro',
@@ -496,15 +494,13 @@ describe( 'reducer', () => {
 
 			expect( state ).to.deep.equal( {
 				2916284: {
-					vivaro: {
-						error: 'Request error'
-					}
+					vivaro: 'Request error'
 				}
 			} );
 		} );
 
-		it( 'should switch from error to null after successful request after a failure', () => {
-			const state = themeRequestsError( deepFreeze( {
+		it( 'should switch from error to no mapping after successful request after a failure', () => {
+			const state = themeRequestErrors( deepFreeze( {
 				2916284: {
 					pinboard: {
 						error: 'Request Error'
@@ -517,37 +513,32 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.deep.equal( {
-				2916284: {
-					pinboard: null
-				}
+				2916284: {}
 			} );
 		} );
 
 		it( 'should accumulate mappings', () => {
-			const state = themeRequestsError( deepFreeze( {
+			const state = themeRequestErrors( deepFreeze( {
 				2916284: {
-					twentysixteennnnn: {
-						error: 'No such theme!'
-					}
+					twentysixteennnnn: 'No such theme!'
 				}
 			} ), {
-				type: THEME_REQUEST_SUCCESS,
+				type: THEME_REQUEST_FAILURE,
 				siteId: 2916284,
-				themeId: 'twentysixteen'
+				themeId: 'twentysixteen',
+				error: 'System error'
 			} );
 
 			expect( state ).to.deep.equal( {
 				2916284: {
-					twentysixteen: null,
-					twentysixteennnnn: {
-						error: 'No such theme!'
-					}
+					twentysixteennnnn: 'No such theme!',
+					twentysixteen: 'System error'
 				}
 			} );
 		} );
 
 		it( 'never persists state', () => {
-			const state = themeRequestsError( deepFreeze( {
+			const state = themeRequestErrors( deepFreeze( {
 				2916284: {
 					twentysixteen: null
 				}
@@ -559,7 +550,7 @@ describe( 'reducer', () => {
 		} );
 
 		it( 'never loads persisted state', () => {
-			const state = themeRequestsError( deepFreeze( {
+			const state = themeRequestErrors( deepFreeze( {
 				2916284: {
 					twentysixteen: null
 				}

--- a/client/state/themes/test/reducer.js
+++ b/client/state/themes/test/reducer.js
@@ -30,6 +30,7 @@ import reducer, {
 	queries,
 	lastQuery,
 	themeRequests,
+	themeRequestsError,
 	activeThemes,
 	activationRequests,
 	activeThemeRequests,
@@ -455,6 +456,112 @@ describe( 'reducer', () => {
 			const state = themeRequests( deepFreeze( {
 				2916284: {
 					841: true
+				}
+			} ), {
+				type: DESERIALIZE
+			} );
+
+			expect( state ).to.deep.equal( {} );
+		} );
+	} );
+
+	describe( '#themeRequestsError()', () => {
+		it( 'should default to an empty object', () => {
+			const state = themeRequestsError( undefined, {} );
+
+			expect( state ).to.deep.equal( {} );
+		} );
+
+		it( 'should map site ID, theme ID to null value if request was successful', () => {
+			const state = themeRequestsError( deepFreeze( {} ), {
+				type: THEME_REQUEST_SUCCESS,
+				siteId: 2916284,
+				themeId: 841
+			} );
+
+			expect( state ).to.deep.equal( {
+				2916284: {
+					841: null
+				}
+			} );
+		} );
+
+		it( 'should map site ID, theme ID to error object if request finishes with failure', () => {
+			const state = themeRequestsError( deepFreeze( {} ), {
+				type: THEME_REQUEST_FAILURE,
+				siteId: 2916284,
+				themeId: 'vivaro',
+				error: 'Request error'
+			} );
+
+			expect( state ).to.deep.equal( {
+				2916284: {
+					vivaro: {
+						error: 'Request error'
+					}
+				}
+			} );
+		} );
+
+		it( 'should switch from error to null after successful request after a failure', () => {
+			const state = themeRequestsError( deepFreeze( {
+				2916284: {
+					pinboard: {
+						error: 'Request Error'
+					}
+				}
+			} ), {
+				type: THEME_REQUEST_SUCCESS,
+				siteId: 2916284,
+				themeId: 'pinboard'
+			} );
+
+			expect( state ).to.deep.equal( {
+				2916284: {
+					pinboard: null
+				}
+			} );
+		} );
+
+		it( 'should accumulate mappings', () => {
+			const state = themeRequestsError( deepFreeze( {
+				2916284: {
+					twentysixteennnnn: {
+						error: 'No such theme!'
+					}
+				}
+			} ), {
+				type: THEME_REQUEST_SUCCESS,
+				siteId: 2916284,
+				themeId: 'twentysixteen'
+			} );
+
+			expect( state ).to.deep.equal( {
+				2916284: {
+					twentysixteen: null,
+					twentysixteennnnn: {
+						error: 'No such theme!'
+					}
+				}
+			} );
+		} );
+
+		it( 'never persists state', () => {
+			const state = themeRequestsError( deepFreeze( {
+				2916284: {
+					twentysixteen: null
+				}
+			} ), {
+				type: SERIALIZE
+			} );
+
+			expect( state ).to.deep.equal( {} );
+		} );
+
+		it( 'never loads persisted state', () => {
+			const state = themeRequestsError( deepFreeze( {
+				2916284: {
+					twentysixteen: null
 				}
 			} ), {
 				type: DESERIALIZE

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -10,7 +10,7 @@ import { values } from 'lodash';
 import {
 	getThemes,
 	getTheme,
-	getThemeRequestsError,
+	getThemeRequestErrors,
 	isRequestingTheme,
 	getThemesForQuery,
 	getLastThemeQuery,
@@ -133,9 +133,9 @@ describe( 'themes selectors', () => {
 
 	describe( '#getThemesRequestError()', () => {
 		it( 'should return null if thre is not request error storred for that theme on site', () => {
-			const error = getThemeRequestsError( {
+			const error = getThemeRequestErrors( {
 				themes: {
-					themeRequestsError: {}
+					themeRequestErrors: {}
 				}
 			}, 'twentysixteen', 413 );
 
@@ -143,21 +143,17 @@ describe( 'themes selectors', () => {
 		} );
 
 		it( 'should return the error object for the site ID, theme ID pair', () => {
-			const error = getThemeRequestsError( {
+			const error = getThemeRequestErrors( {
 				themes: {
-					themeRequestsError: {
+					themeRequestErrors: {
 						2916284: {
-							twentysixteen: {
-								error: 'Request error'
-							}
+							twentysixteen: 'Request error'
 						}
 					}
 				}
 			}, 'twentysixteen', 2916284, );
 
-			expect( error ).to.deep.equal( {
-				error: 'Request error'
-			} );
+			expect( error ).to.equal( 'Request error' );
 		} );
 	} );
 

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -10,6 +10,7 @@ import { values } from 'lodash';
 import {
 	getThemes,
 	getTheme,
+	getThemeRequestsError,
 	isRequestingTheme,
 	getThemesForQuery,
 	getLastThemeQuery,
@@ -127,6 +128,36 @@ describe( 'themes selectors', () => {
 			}, 2916284, 'twentysixteen' );
 
 			expect( theme ).to.equal( twentysixteen );
+		} );
+	} );
+
+	describe( '#getThemesRequestError()', () => {
+		it( 'should return null if thre is not request error storred for that theme on site', () => {
+			const error = getThemeRequestsError( {
+				themes: {
+					themeRequestsError: {}
+				}
+			}, 'twentysixteen', 413 );
+
+			expect( error ).to.be.null;
+		} );
+
+		it( 'should return the error object for the site ID, theme ID pair', () => {
+			const error = getThemeRequestsError( {
+				themes: {
+					themeRequestsError: {
+						2916284: {
+							twentysixteen: {
+								error: 'Request error'
+							}
+						}
+					}
+				}
+			}, 'twentysixteen', 2916284, );
+
+			expect( error ).to.deep.equal( {
+				error: 'Request error'
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
## Info
The new themes Redux sub-tree requires error handling. This PR adds reducer and selector that that respond to theme request action success or error. 

## Testing
Not connected yet. Will be integrated in #9750,
