### PR TITLE
Themes: Move ThemesSearchCard around (part 2)

### DIFF
--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
+import pickBy from 'lodash/pickBy';
 
 /**
  * Internal dependencies
@@ -9,17 +10,57 @@ import React from 'react';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThemesSiteSelectorModal from './themes-site-selector-modal';
 import { connectOptions } from './theme-options';
+import { addTracking } from './helpers';
 import ThemeShowcase from './theme-showcase';
+import ThemesSelection from './themes-selection';
 
-const MultiSiteThemeShowcase = connectOptions(
-	( props ) => (
-		<ThemesSiteSelectorModal { ...props } sourcePath="/design">
-			<ThemeShowcase source="showcase">
-				<SidebarNavigation />
-			</ThemeShowcase>
-		</ThemesSiteSelectorModal>
-	)
-);
+const MultiSiteThemeShowcase = connectOptions( React.createClass( {
+	propTypes: {
+		getScreenshotOption: PropTypes.func,
+	},
+
+	render() {
+		const { getScreenshotOption, search, options } = this.props;
+
+		return (
+			<ThemesSiteSelectorModal { ...this.props } sourcePath="/design">
+				<ThemeShowcase source="showcase">
+					<SidebarNavigation />
+				</ThemeShowcase>
+				<ThemesSelection
+					siteId={ this.props.siteId }
+					selectedSite={ this.props.selectedSite }
+					getScreenshotUrl={ function( theme ) {
+						if ( ! getScreenshotOption( theme ).getUrl ) {
+							return null;
+						}
+						return getScreenshotOption( theme ).getUrl( theme );
+					} }
+					onScreenshotClick={ function( theme ) {
+						if ( ! getScreenshotOption( theme ).action ) {
+							return;
+						}
+						getScreenshotOption( theme ).action( theme );
+					} }
+					getActionLabel={ function( theme ) {
+						return getScreenshotOption( theme ).label;
+					} }
+					getOptions={ function( theme ) {
+						return pickBy(
+							addTracking( options ),
+							option => ! ( option.hideForTheme && option.hideForTheme( theme ) )
+						); } }
+					trackScrollPage={ this.props.trackScrollPage }
+					search={ search }
+					tier={ this.props.tier }
+					filter={ this.props.filter }
+					vertical={ this.props.vertical }
+					queryParams={ this.props.queryParams }
+					themesList={ this.props.themesList } />
+			</ThemesSiteSelectorModal>
+		);
+	}
+} ) );
 
 export default ( props ) => (
 	<MultiSiteThemeShowcase { ...props }

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
- import React, { PropTypes } from 'react';
- import pickBy from 'lodash/pickBy';
+import React, { PropTypes } from 'react';
+import pickBy from 'lodash/pickBy';
 
 /**
  * Internal dependencies

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
+ import React, { PropTypes } from 'react';
+ import pickBy from 'lodash/pickBy';
 
 /**
  * Internal dependencies
@@ -14,13 +15,19 @@ import JetpackReferrerMessage from './jetpack-referrer-message';
 import JetpackUpgradeMessage from './jetpack-upgrade-message';
 import JetpackManageDisabledMessage from './jetpack-manage-disabled-message';
 import { connectOptions } from './theme-options';
+import { addTracking } from './helpers';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
+import ThemesSelection from './themes-selection';
 
-export default connectOptions(
-	( props ) => {
-		const { site, siteId, analyticsPath, analyticsPageTitle } = props;
+const SingleSiteThemeShowcaseJetpack = React.createClass( {
+	propTypes: {
+		getScreenshotOption: PropTypes.func,
+	},
+
+	render() {
+		const { site, siteId, getScreenshotOption, search, options, analyticsPath, analyticsPageTitle } = this.props;
 		const jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' );
 
 		if ( ! jetpackEnabled ) {
@@ -45,15 +52,49 @@ export default connectOptions(
 		}
 
 		return (
-			<ThemeShowcase { ...props } siteId={ siteId }>
-				{ siteId && <QuerySitePlans siteId={ siteId } /> }
-				{ siteId && <QuerySitePurchases siteId={ siteId } /> }
-				<SidebarNavigation />
-				<ThanksModal
-					site={ site }
-					source={ 'list' } />
-				<CurrentTheme siteId={ siteId } />
-			</ThemeShowcase>
+			<div>
+				<ThemeShowcase { ...this.props } siteId={ siteId }>
+					{ siteId && <QuerySitePlans siteId={ siteId } /> }
+					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
+					<SidebarNavigation />
+					<ThanksModal
+						site={ site }
+						source={ 'list' } />
+					<CurrentTheme siteId={ siteId } />
+				</ThemeShowcase>
+				<ThemesSelection
+					siteId={ this.props.siteId }
+					selectedSite={ this.props.selectedSite }
+					getScreenshotUrl={ function( theme ) {
+						if ( ! getScreenshotOption( theme ).getUrl ) {
+							return null;
+						}
+						return getScreenshotOption( theme ).getUrl( theme );
+					} }
+					onScreenshotClick={ function( theme ) {
+						if ( ! getScreenshotOption( theme ).action ) {
+							return;
+						}
+						getScreenshotOption( theme ).action( theme );
+					} }
+					getActionLabel={ function( theme ) {
+						return getScreenshotOption( theme ).label;
+					} }
+					getOptions={ function( theme ) {
+						return pickBy(
+							addTracking( options ),
+							option => ! ( option.hideForTheme && option.hideForTheme( theme ) )
+						); } }
+					trackScrollPage={ this.props.trackScrollPage }
+					search={ search }
+					tier={ this.props.tier }
+					filter={ this.props.filter }
+					vertical={ this.props.vertical }
+					queryParams={ this.props.queryParams }
+					themesList={ this.props.themesList } />
+			</div>
 		);
 	}
-);
+} );
+
+export default connectOptions( SingleSiteThemeShowcaseJetpack );

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
+import pickBy from 'lodash/pickBy';
 
 /**
  * Internal dependencies
@@ -10,32 +11,72 @@ import CurrentTheme from 'my-sites/themes/current-theme';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 import { connectOptions } from './theme-options';
+import { addTracking } from './helpers';
 import { FEATURE_ADVANCED_DESIGN } from 'lib/plans/constants';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
+import ThemesSelection from './themes-selection';
 
-export default connectOptions(
-	( props ) => {
-		const { site, siteId, translate } = props;
+const SingleSiteThemeShowcaseWpcom = React.createClass( {
+	propTypes: {
+		getScreenshotOption: PropTypes.func,
+	},
+
+	render() {
+		const { site, siteId, getScreenshotOption, search, options, translate } = this.props;
 
 		return (
-			<ThemeShowcase { ...props } siteId={ siteId }>
-				{ siteId && <QuerySitePlans siteId={ siteId } /> }
-				{ siteId && <QuerySitePurchases siteId={ siteId } /> }
-				<SidebarNavigation />
-				<ThanksModal
-					site={ site }
-					source={ 'list' } />
-				<CurrentTheme siteId={ siteId } />
-				<UpgradeNudge
-					title={ translate( 'Get Custom Design with Premium' ) }
-					message={ translate( 'Customize your theme using premium fonts, color palettes, and the CSS editor.' ) }
-					feature={ FEATURE_ADVANCED_DESIGN }
-					event="themes_custom_design"
-					/>
-			</ThemeShowcase>
+			<div>
+				<ThemeShowcase { ...this.props } siteId={ siteId }>
+					{ siteId && <QuerySitePlans siteId={ siteId } /> }
+					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
+					<SidebarNavigation />
+					<ThanksModal
+						site={ site }
+						source={ 'list' } />
+					<CurrentTheme siteId={ siteId } />
+					<UpgradeNudge
+						title={ translate( 'Get Custom Design with Premium' ) }
+						message={ translate( 'Customize your theme using premium fonts, color palettes, and the CSS editor.' ) }
+						feature={ FEATURE_ADVANCED_DESIGN }
+						event="themes_custom_design"
+						/>
+				</ThemeShowcase>
+				<ThemesSelection
+					siteId={ this.props.siteId }
+					selectedSite={ this.props.selectedSite }
+					getScreenshotUrl={ function( theme ) {
+						if ( ! getScreenshotOption( theme ).getUrl ) {
+							return null;
+						}
+						return getScreenshotOption( theme ).getUrl( theme );
+					} }
+					onScreenshotClick={ function( theme ) {
+						if ( ! getScreenshotOption( theme ).action ) {
+							return;
+						}
+						getScreenshotOption( theme ).action( theme );
+					} }
+					getActionLabel={ function( theme ) {
+						return getScreenshotOption( theme ).label;
+					} }
+					getOptions={ function( theme ) {
+						return pickBy(
+							addTracking( options ),
+							option => ! ( option.hideForTheme && option.hideForTheme( theme ) )
+						); } }
+					trackScrollPage={ this.props.trackScrollPage }
+					search={ search }
+					tier={ this.props.tier }
+					filter={ this.props.filter }
+					vertical={ this.props.vertical }
+					queryParams={ this.props.queryParams }
+					themesList={ this.props.themesList } />
+			</div>
 		);
 	}
- );
+} );
+
+export default connectOptions( SingleSiteThemeShowcaseWpcom );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -5,17 +5,15 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
-import pickBy from 'lodash/pickBy';
 
 /**
  * Internal dependencies
  */
 import Main from 'components/main';
 import ThemePreview from './theme-preview';
-import ThemesSelection from './themes-selection';
 import StickyPanel from 'components/sticky-panel';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { addTracking, trackClick } from './helpers';
+import { trackClick } from './helpers';
 import DocumentHead from 'components/data/document-head';
 import { getFilter, getSortedFilterTerms, stripFilters } from './theme-filters.js';
 import buildUrl from 'lib/mixins/url-search/build-url';
@@ -60,7 +58,6 @@ const ThemeShowcase = React.createClass( {
 		options: PropTypes.objectOf( optionShape ),
 		defaultOption: optionShape,
 		secondaryOption: optionShape,
-		getScreenshotOption: PropTypes.func,
 		siteSlug: PropTypes.string,
 	},
 
@@ -147,7 +144,7 @@ const ThemeShowcase = React.createClass( {
 	},
 
 	render() {
-		const { site, options, getScreenshotOption, secondaryOption, tier, search } = this.props;
+		const { site, options, secondaryOption, tier, search } = this.props;
 		const primaryOption = this.getPrimaryOption();
 
 		// If a preview action is passed, use that. Otherwise, use our own.
@@ -187,36 +184,6 @@ const ThemeShowcase = React.createClass( {
 						tier={ tier }
 						select={ this.onTierSelect } />
 				</StickyPanel>
-				<ThemesSelection
-					siteId={ this.props.siteId }
-					selectedSite={ this.props.selectedSite }
-					getScreenshotUrl={ function( theme ) {
-						if ( ! getScreenshotOption( theme ).getUrl ) {
-							return null;
-						}
-						return getScreenshotOption( theme ).getUrl( theme );
-					} }
-					onScreenshotClick={ function( theme ) {
-						if ( ! getScreenshotOption( theme ).action ) {
-							return;
-						}
-						getScreenshotOption( theme ).action( theme );
-					} }
-					getActionLabel={ function( theme ) {
-						return getScreenshotOption( theme ).label;
-					} }
-					getOptions={ function( theme ) {
-						return pickBy(
-							addTracking( options ),
-							option => ! ( option.hideForTheme && option.hideForTheme( theme ) )
-						); } }
-					trackScrollPage={ this.props.trackScrollPage }
-					search={ search }
-					tier={ this.props.tier }
-					filter={ this.props.filter }
-					vertical={ this.props.vertical }
-					queryParams={ this.props.queryParams }
-					themesList={ this.props.themesList } />
 			</Main>
 		);
 	}

--- a/client/my-sites/themes/themes-site-selector-modal.jsx
+++ b/client/my-sites/themes/themes-site-selector-modal.jsx
@@ -23,7 +23,7 @@ const OPTION_SHAPE = PropTypes.shape( {
 
 const ThemesSiteSelectorModal = React.createClass( {
 	propTypes: {
-		children: PropTypes.element,
+		children: PropTypes.arrayOf( PropTypes.element ),
 		options: PropTypes.objectOf( OPTION_SHAPE ),
 		defaultOption: OPTION_SHAPE,
 		secondaryOption: OPTION_SHAPE,


### PR DESCRIPTION
_PR for #9671 (part 2/2, after #9698):_
Moving `ThemesSelection` up at { `single-site-wpcom`, `single-site-jetpack` } level, to allow a more flexible architecture and having search trigger multiple data containers.

This does NOT move { `multi-site`, `logged-out` } due to some intricacies on multi-site. See #9823 experimental branch for that.

No UI change. 
Pure refactoring.


### Testing

* Please don't test yet — it's broken, it's in progress.
* HERE BE DRAGONS 🐉 