### PR TITLE
Security: Move analytics logic to use recordGoogleEvent.

### DIFF
--- a/client/me/security-2fa-disable/index.jsx
+++ b/client/me/security-2fa-disable/index.jsx
@@ -12,7 +12,7 @@ import FormButton from 'components/forms/form-button';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import Security2faStatus from 'me/security-2fa-status';
 import Security2faCodePrompt from 'me/security-2fa-code-prompt';
-import analytics from 'lib/analytics';
+import { recordGoogleEvent } from 'state/analytics/actions';
 import { successNotice } from 'state/notices/actions';
 
 class Security2faDisable extends Component {
@@ -20,6 +20,8 @@ class Security2faDisable extends Component {
 		onFinished: PropTypes.func.isRequired,
 		userSettings: PropTypes.object.isRequired,
 		translate: PropTypes.func,
+		recordGoogleEvent: PropTypes.func,
+		successNotice: PropTypes.func,
 	}
 
 	constructor() {
@@ -30,7 +32,7 @@ class Security2faDisable extends Component {
 	}
 
 	onRevealCodePrompt = () => {
-		analytics.ga.recordEvent( 'Me', 'Clicked On Disable Two-Step Authentication Button' );
+		this.props.recordGoogleEvent( 'Me', 'Clicked On Disable Two-Step Authentication Button' );
 		this.setState( { showingCodePrompt: true } );
 	}
 
@@ -159,7 +161,10 @@ class Security2faDisable extends Component {
 
 export default connect(
 	null,
-	{ successNotice },
+	{
+		successNotice,
+		recordGoogleEvent
+	},
 	null,
 	{ pure: false }
 )( localize( Security2faDisable ) );


### PR DESCRIPTION
This is a quick follow-up to a trash-day PR #9401.  Here, per @obenland 's suggest, I am simply using the `recordGoogleEvent` redux action instead of using the analytics library directly.

__To Test__
- Open up the [Security Settings Page](http://calypso.localhost:3000/me/security) for an account that has 2FA enabled
- Set your `localStorage` debug to `calypso:analytics`
- Click on the "Disable Two Step Authentication" button inside the 2fa tab
- Note the analytics event "Action: Clicked On Disable Two-Step Authentication Button" is shown in your browser's console