### PR TITLE
Signup: Add an AB test for Survey step, take 2

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -118,4 +118,14 @@ module.exports = {
 		defaultVariation: 'original',
 		allowAnyLocale: true,
 	},
+
+	noSurveyStep: {
+		datestamp: '20161202',
+		variations: {
+			showSurveyStep: 50,
+			hideSurveyStep: 50,
+		},
+		defaultVariation: 'showSurveyStep',
+		allowAnyLocale: true,
+	}
 };

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -267,6 +267,11 @@ const Flows = {
 	getFlow( flowName, currentStepName = '' ) {
 		let flow = Flows.getFlows()[ flowName ];
 
+		// if the flow couldn't be found, return early
+		if ( ! flow ) {
+			return flow;
+		}
+
 		if ( user.get() ) {
 			flow = removeUserStepFromFlow( flow );
 		}
@@ -307,6 +312,15 @@ const Flows = {
 			return;
 		}
 
+		/**
+		 * This is called on Signup start (page initialization),
+		 * before the steps are rendered. Used if there is a need
+		 * to filter the first step in the flow.
+		 */
+		if ( '' === stepName ) {
+			abtest( 'noSurveyStep' );
+		}
+
 		if ( 'main' === flowName ) {
 			if ( 'survey' === stepName ) {
 				abtest( 'siteTitleStep' );
@@ -332,6 +346,11 @@ const Flows = {
 			if ( getABTestVariation( 'siteTitleStep' ) === 'showSiteTitleStep' ) {
 				return Flows.insertStepIntoFlow( 'site-title', flow, 'survey' );
 			}
+		}
+
+		// no matter the flow
+		if ( getABTestVariation( 'noSurveyStep' ) === 'hideSurveyStep' ) {
+			return Flows.removeStepFromFlow( 'survey', flow );
 		}
 
 		return flow;
@@ -368,6 +387,15 @@ const Flows = {
 		}
 
 		return flow;
+	},
+
+	removeStepFromFlow( stepName, flow ) {
+		return {
+			...flow,
+			steps: flow.steps.filter( ( step ) => {
+				return step !== stepName;
+			} )
+		};
 	}
 };
 

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -15,7 +15,7 @@ module.exports = {
 		props: {
 			surveySiteType: ( current && current.toString().match( /\/start\/(blog|delta-blog)/ ) ) ? 'blog' : 'site'
 		},
-		providesDependencies: [ 'surveySiteType', 'surveyQuestion' ]
+		//providesDependencies: [ 'surveySiteType', 'surveyQuestion' ]
 	},
 
 	themes: {
@@ -67,7 +67,7 @@ module.exports = {
 		stepName: 'domains',
 		apiRequestFunction: stepActions.createSiteWithCart,
 		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
-		dependencies: [ 'theme', 'surveyQuestion' ],
+		dependencies: [ 'theme' ],
 		delayApiRequestUntilComplete: true
 	},
 

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -15,7 +15,7 @@ module.exports = {
 		props: {
 			surveySiteType: ( current && current.toString().match( /\/start\/(blog|delta-blog)/ ) ) ? 'blog' : 'site'
 		},
-		//providesDependencies: [ 'surveySiteType', 'surveyQuestion' ]
+		providesDependencies: [ 'surveySiteType', 'surveyQuestion' ]
 	},
 
 	themes: {

--- a/client/signup/test/flows.js
+++ b/client/signup/test/flows.js
@@ -54,13 +54,17 @@ describe( 'Signup Flows Configuration', () => {
 
 		const ABTestMock = {
 			abtest: noop,
-			getABTestVariation: noop,
+			getABTestVariation: () => {
+				return null;
+			},
 		};
 
 		const getABTestVariationSpy = sinon.stub( ABTestMock, 'getABTestVariation' );
 
 		getABTestVariationSpy.onCall( 0 ).returns( 'notSiteTitle' );
-		getABTestVariationSpy.onCall( 1 ).returns( 'showSiteTitleStep' );
+		getABTestVariationSpy.onCall( 1 ).returns( 'notSiteTitle' );
+		getABTestVariationSpy.onCall( 2 ).returns( 'showSiteTitleStep' );
+		getABTestVariationSpy.onCall( 3 ).returns( 'showSiteTitleStep' );
 
 		useMockery( ( mockery ) => {
 			mockery.registerMock( 'lib/abtest', ABTestMock );
@@ -72,17 +76,20 @@ describe( 'Signup Flows Configuration', () => {
 			sinon.stub( flows, 'insertStepIntoFlow', ( stepName, flow ) => {
 				return flow;
 			} );
+			sinon.stub( flows, 'removeStepFromFlow', ( stepName, flow ) => {
+				return flow;
+			} );
 		} );
 
 		it( 'should return flow unmodified if not in main flow', () => {
 			assert.equal( flows.getABTestFilteredFlow( 'test', 'testflow' ), 'testflow' );
-			assert.equal( getABTestVariationSpy.callCount, 0 );
 			assert.equal( flows.insertStepIntoFlow.callCount, 0 );
+			assert.equal( flows.removeStepFromFlow.callCount, 0 );
 		} );
 
 		it( 'should check AB variation in main flow', () => {
 			assert.equal( flows.getABTestFilteredFlow( 'main', 'testflow' ), 'testflow' );
-			assert.equal( getABTestVariationSpy.callCount, 1 );
+			assert.equal( getABTestVariationSpy.callCount, 3 );
 			assert.equal( flows.insertStepIntoFlow.callCount, 0 );
 		} );
 
@@ -93,7 +100,7 @@ describe( 'Signup Flows Configuration', () => {
 			};
 
 			assert.equal( flows.getABTestFilteredFlow( 'main', myFlow ), myFlow );
-			assert.equal( getABTestVariationSpy.callCount, 2 );
+			assert.equal( getABTestVariationSpy.callCount, 4 );
 			assert.equal( flows.insertStepIntoFlow.callCount, 1 );
 		} );
 	} );

--- a/client/state/signup/steps/survey/selectors.js
+++ b/client/state/signup/steps/survey/selectors.js
@@ -12,5 +12,5 @@ export function getSurveyOtherText( state ) {
 }
 
 export function getSurveySiteType( state ) {
-	return get( state, 'signup.steps.survey.siteType', '' );
+	return get( state, 'signup.steps.survey.siteType', 'site' );
 }

--- a/client/state/signup/steps/survey/test/selectors.js
+++ b/client/state/signup/steps/survey/test/selectors.js
@@ -12,7 +12,7 @@ describe( 'selectors', () => {
 	it( 'should return empty string as a default state', () => {
 		expect( getSurveyVertical( { signup: undefined } ) ).to.be.eql( '' );
 		expect( getSurveyOtherText( { signup: undefined } ) ).to.be.eql( '' );
-		expect( getSurveySiteType( { signup: undefined } ) ).to.be.eql( '' );
+		expect( getSurveySiteType( { signup: undefined } ) ).to.be.eql( 'site' );
 	} );
 
 	it( 'should return chosen vertical from the state', () => {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#9794 (revert of revert)

--- Original description ---

This PR adds an AB test to help test the Survey step performance.

To test:

1. Checkout branch or use Calypso.live link
2. Start signup at /start
3. Verify if the Survey step doesn't or shows up, based on the AB test variation
4. Finish Signup
5. Verify Signup is successful
6. Make sure there are no errors in the console

cc @michaeldcain @coreh @meremagee