### PR TITLE
WordAds: Fix non-admins from seeing WordAds link

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -31,6 +31,7 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getThemeCustomizeUrl as getCustomizeUrl } from 'state/themes/selectors';
 import { setNextLayoutFocus, setLayoutFocus } from 'state/ui/layout-focus/actions';
+import { userCan } from 'lib/site/utils';
 
 /**
  * Module variables
@@ -155,14 +156,12 @@ export class MySitesSidebar extends Component {
 	}
 
 	ads() {
-		var site = this.getSelectedSite(),
-			adsLink = '/ads/earnings' + this.siteSuffix();
-
-		if ( ! site || ! site.options.wordads ) {
-			return null;
-		}
+		const site = this.getSelectedSite();
+		const adsLink = '/ads/earnings' + this.siteSuffix();
+		const canManageAds = site && site.options.wordads && userCan( 'manage_options', site );
 
 		return (
+			canManageAds &&
 			<SidebarItem
 				label={ site.jetpack ? 'AdControl' : 'WordAds' }
 				className={ this.itemLinkClass( '/ads', 'rads' ) }


### PR DESCRIPTION
@benchilcote reports that non-admins are able to see the WordAds sidebar link in Calypso, though they are unable to access the page (as intended). This fix changes the sidebar to additionally prevent users that shouldn't see the link (e.g. non-admins) from seeing the link.

## Testing instructions
1. Create a new premium site (or go to existing premium site) and activate WordAds.
2. Create new user w/ < admin access (e.g. editor).
3. SU or login as non-admin user.
4. WordAds link should not appear in sidebar (but should for admin).

**Non-admin**
<img width="1184" alt="screen shot 2016-12-02 at 12 03 11 pm" src="https://cloud.githubusercontent.com/assets/273708/20848568/7bdb918a-b887-11e6-91f3-f6faea1551ba.png">

**Admin**
<img width="1184" alt="screen shot 2016-12-02 at 12 04 59 pm" src="https://cloud.githubusercontent.com/assets/273708/20848593/94a959d6-b887-11e6-988a-8a8b994a81b3.png">
