### PR TITLE
FollowersCount: add new block

### DIFF
--- a/client/blocks/followers-count/README.md
+++ b/client/blocks/followers-count/README.md
@@ -1,0 +1,15 @@
+# Followers Count
+
+`FollowersCount` displays a button with the `subscriber_count` of the currently selected `site`, linked to the new-ish `people/followers` page.
+
+## Example
+
+```js
+import FollowersCount from 'blocks/followers-count';
+
+render() {
+	return (
+		<FollowersCount />
+	);
+}
+```

--- a/client/blocks/followers-count/index.jsx
+++ b/client/blocks/followers-count/index.jsx
@@ -4,6 +4,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,16 +15,16 @@ import { getSelectedSite } from 'state/ui/selectors';
 
 class FollowersCount extends Component {
 	render() {
-		const { site, translate } = this.props;
+		const { slug, followers, translate } = this.props;
 
-		if ( ! site || ! site.subscribers_count ) {
+		if ( ! followers ) {
 			return null;
 		}
 
 		return (
 			<div className="followers-count">
-				<Button borderless href={ '/people/followers/' + site.slug }>
-					{ translate( 'Followers' ) } <Count count={ site.subscribers_count } />
+				<Button borderless href={ '/people/followers/' + slug }>
+					{ translate( 'Followers' ) } <Count count={ followers } />
 				</Button>
 			</div>
 		);
@@ -34,6 +35,7 @@ export default connect( ( state ) => {
 	const site = getSelectedSite( state );
 
 	return {
-		site
+		slug: get( site, 'slug' ),
+		followers: get( site, 'subscribers_count' ),
 	};
 } )( localize( FollowersCount ) );

--- a/client/blocks/followers-count/index.jsx
+++ b/client/blocks/followers-count/index.jsx
@@ -1,0 +1,39 @@
+/**
+ * External Dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Count from 'components/count';
+import { getSelectedSite } from 'state/ui/selectors';
+
+class FollowersCount extends Component {
+	render() {
+		const { site, translate } = this.props;
+
+		if ( ! site || ! site.subscribers_count ) {
+			return null;
+		}
+
+		return (
+			<div className="followers-count">
+				<Button borderless href={ '/people/followers/' + site.slug }>
+					{ translate( 'Followers' ) } <Count count={ site.subscribers_count } />
+				</Button>
+			</div>
+		);
+	}
+}
+
+export default connect( ( state ) => {
+	const site = getSelectedSite( state );
+
+	return {
+		site
+	};
+} )( localize( FollowersCount ) );

--- a/client/my-sites/stats/stats-navigation/index.jsx
+++ b/client/my-sites/stats/stats-navigation/index.jsx
@@ -11,6 +11,7 @@ import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 import siteStatsStickyTabActions from 'lib/site-stats-sticky-tab/actions';
+import FollowersCount from 'blocks/followers-count';
 
 class StatsNavigation extends Component {
 	static propTypes = {
@@ -42,6 +43,7 @@ class StatsNavigation extends Component {
 			year: translate( 'Years' )
 		};
 
+
 		return (
 			<SectionNav selectedText={ sectionTitles[ section ] }>
 				<NavTabs label={ translate( 'Stats' ) }>
@@ -61,6 +63,7 @@ class StatsNavigation extends Component {
 						{ sectionTitles.year }
 					</NavItem>
 				</NavTabs>
+				<FollowersCount />
 			</SectionNav>
 		);
 	}

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -18,6 +18,14 @@
 	margin-left: 4px;
 }
 
+.is-section-stats .followers-count .button {
+	margin-right: 16px;
+
+	@include breakpoint( "<480px" ) {
+		display: none;
+	}
+}
+
 // Welcome Stats message
 // -- extends .welcome-message /assets/stylesheets/shared/welcome.scss
 


### PR DESCRIPTION
This brings a follower count conveniently to the top of the stats page. As stats is essentially the landing page, this gives a quick hit and more prominence to a number which hopefully always goes up.

![image](https://cloud.githubusercontent.com/assets/48685/20847922/0afdc250-b89e-11e6-8d94-8df9563f50d5.png)

So purdy.