### PR TITLE
Support: Fix tracks data so that it no longer goes into the rejects table

### DIFF
--- a/client/components/olark-chat-button/index.jsx
+++ b/client/components/olark-chat-button/index.jsx
@@ -43,7 +43,7 @@ class OlarkChatButton extends Component {
 	recordChatEvent( eventAction ) {
 		const { chatContext, tracksData } = this.props;
 		analytics.tracks.recordEvent( eventAction, {
-			...{ tracksData },
+			...tracksData,
 			chat_context: chatContext,
 		} );
 	}

--- a/client/my-sites/upgrades/checkout/payment-chat-button.jsx
+++ b/client/my-sites/upgrades/checkout/payment-chat-button.jsx
@@ -22,7 +22,7 @@ export default localize( ( { cart, translate, paymentType, transactionStep } ) =
 			chatContext="presale"
 			tracksData={ {
 				payment_type: paymentType,
-				transaction_step: transactionStep,
+				transaction_step: transactionStep.name,
 				product_slug: productSlug,
 			} }>
 				<Gridicon icon="chat" className="checkout__payment-chat-button-icon" />


### PR DESCRIPTION
This pull request fixes a typo that was causing tracks data for the olark chat button to land in the rejects table