### PR TITLE
Jetpack Settings: Add Media Settings card under Writing Settings for sites with Jetpack >= 4.5

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -322,6 +322,7 @@
 @import 'my-sites/site-settings/delete-site-warning-dialog/style';
 @import 'my-sites/site-settings/jetpack-module-toggle/style';
 @import 'my-sites/site-settings/jetpack-sync-panel/style';
+@import 'my-sites/site-settings/media-settings/style';
 @import 'my-sites/site-settings/press-this/style';
 @import 'my-sites/site-settings/publishing-tools/style';
 @import 'my-sites/site-settings/site-icon-setting/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -320,7 +320,6 @@
 @import 'my-sites/site-settings/delete-site/style';
 @import 'my-sites/site-settings/delete-site-options/style';
 @import 'my-sites/site-settings/delete-site-warning-dialog/style';
-@import 'my-sites/site-settings/jetpack-module-toggle/style';
 @import 'my-sites/site-settings/jetpack-sync-panel/style';
 @import 'my-sites/site-settings/media-settings/style';
 @import 'my-sites/site-settings/press-this/style';

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -20,6 +20,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestPostTypes } from 'state/post-types/actions';
 import Composing from './composing';
 import CustomContentTypes from './custom-content-types';
+import MediaSettings from './media-settings';
 import ThemeEnhancements from './theme-enhancements';
 import PublishingTools from './publishing-tools';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
@@ -79,7 +80,22 @@ class SiteSettingsFormWriting extends Component {
 					isRequestingSettings={ isRequestingSettings }
 					fields={ fields }
 				/>
-
+				{
+					this.props.isJetpackSite && this.props.jetpackSettingsUISupported && (
+						<div>
+							{
+								this.renderSectionHeader( translate( 'Media' ) )
+							}
+							<MediaSettings
+								siteId={ this.props.siteId }
+								handleToggle={ handleToggle }
+								onChangeField={ onChangeField }
+								isSavingSettings={ isSavingSettings }
+								isRequestingSettings={ isRequestingSettings }
+								fields={ fields } />
+						</div>
+					)
+				}
 				{
 					this.props.isJetpackSite && this.props.jetpackSettingsUISupported && (
 						<div>
@@ -174,6 +190,8 @@ const getFormSettings = partialRight( pick, [
 	'Phrases to Avoid',
 	'Redundant Expression',
 	'ignored_phrases',
+	'carousel_display_exif',
+	'carousel_background_color'
 ] );
 
 export default flowRight(

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -190,8 +190,10 @@ const getFormSettings = partialRight( pick, [
 	'Phrases to Avoid',
 	'Redundant Expression',
 	'ignored_phrases',
-	'carousel_display_exif',
-	'carousel_background_color'
+	'photon',
+	'carousel',
+	'carousel_background_color',
+	'carousel_display_exif'
 ] );
 
 export default flowRight(

--- a/client/my-sites/site-settings/jetpack-module-toggle/index.jsx
+++ b/client/my-sites/site-settings/jetpack-module-toggle/index.jsx
@@ -67,7 +67,7 @@ class JetpackModuleToggle extends Component {
 					{ this.props.label }
 					{
 						this.props.description && (
-							<FormSettingExplanation isIndented>
+							<FormSettingExplanation>
 								{ this.props.description }
 							</FormSettingExplanation>
 						)

--- a/client/my-sites/site-settings/jetpack-module-toggle/style.scss
+++ b/client/my-sites/site-settings/jetpack-module-toggle/style.scss
@@ -1,3 +1,3 @@
-.jetpack-module-toggle p.form-setting-explanation.is-indented {
-	margin-left: 36px;
+.jetpack-module-toggle .form-toggle__label .form-toggle__label-content {
+	margin-left: 8px;
 }

--- a/client/my-sites/site-settings/jetpack-module-toggle/style.scss
+++ b/client/my-sites/site-settings/jetpack-module-toggle/style.scss
@@ -1,3 +1,0 @@
-.jetpack-module-toggle .form-toggle__label .form-toggle__label-content {
-	margin-left: 8px;
-}

--- a/client/my-sites/site-settings/media-settings/index.jsx
+++ b/client/my-sites/site-settings/media-settings/index.jsx
@@ -1,0 +1,117 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import JetpackModuleToggle from '../jetpack-module-toggle';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormSelect from 'components/forms/form-select';
+import FormLabel from 'components/forms/form-label';
+import FormToggle from 'components/forms/form-toggle';
+import InfoPopover from 'components/info-popover';
+import ExternalLink from 'components/external-link';
+import { isJetpackModuleActive } from 'state/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { updateSettings } from 'state/jetpack/settings/actions';
+
+const MediaSettings = ( {
+	fields,
+	handleToggle,
+	onChangeField,
+	isRequestingSettings,
+	isSavingSettings,
+	siteId,
+	carouselActive,
+	translate
+} ) => {
+	const labelClassName = isSavingSettings || ! carouselActive ? 'is-disabled' : null;
+
+	return (
+		<Card className="media-settings site-settings">
+			<FormFieldset>
+				<div className="media-settings__info-link-container">
+					<InfoPopover position={ 'left' }>
+						<ExternalLink target="_blank" icon={ true } href={ 'https://jetpack.com/support/photon' } >
+							{ translate( 'Learn more about Photon' ) }
+						</ExternalLink>
+					</InfoPopover>
+				</div>
+				<JetpackModuleToggle
+					siteId={ siteId }
+					moduleSlug="photon"
+					label={ translate( 'Speed up your images and photos with Photon.' ) }
+					description="Enabling Photon is required to use Tiled Galleries."
+					disabled={ isRequestingSettings || isSavingSettings }
+					/>
+			</FormFieldset>
+			<FormFieldset className="media-settings__formfieldset has-divider is-top-only">
+				<div className="media-settings__info-link-container">
+					<InfoPopover position={ 'left' }>
+						<ExternalLink target="_blank" icon={ true } href={ 'https://jetpack.com/support/carousel' } >
+							{ translate( 'Learn more about Carousel' ) }
+						</ExternalLink>
+					</InfoPopover>
+				</div>
+				<JetpackModuleToggle
+					siteId={ siteId }
+					moduleSlug="carousel"
+					label={ translate( 'Transform standard image galleries into full-screen slideshows.' ) }
+					disabled={ isRequestingSettings || isSavingSettings }
+					/>
+				<div className="media-settings__module-settings is-indented">
+					<FormToggle
+						className="media-settings__carousel-module-settings-toggle is-compact"
+						checked={ fields.carousel_display_exif || false }
+						disabled={ isRequestingSettings || isSavingSettings || ! carouselActive }
+						onChange={ handleToggle( 'carousel_display_exif' ) } >
+						{ translate( 'Show photo metadata in carousel, when available.' ) }
+					</FormToggle>
+					<FormLabel className={ labelClassName } htmlFor="carousel_background_color">
+						{ translate( 'Background color' ) }
+					</FormLabel>
+					<FormSelect
+						name="carousel_background_color"
+						id="carousel_background_color"
+						value={ fields.carousel_background_color || '' }
+						onChange={ onChangeField( 'carousel_background_color' ) }
+						disabled={ isRequestingSettings || isSavingSettings || ! carouselActive } >
+						<option value="black" key="carousel_background_color_black">
+							{ translate( 'Black' ) }
+						</option>
+						<option value="white" key="carousel_background_color_white">
+							{ translate( 'White' ) }
+						</option>
+					</FormSelect>
+				</div>
+			</FormFieldset>
+		</Card>
+	);
+};
+
+MediaSettings.propTypes = {
+	carouselActive: PropTypes.bool.isRequired,
+	isSavingSettings: PropTypes.bool,
+	isRequestingSettings: PropTypes.bool,
+	siteId: PropTypes.number.isRequired,
+	handleToggle: PropTypes.func.isRequired,
+	onChangeField: PropTypes.func.isRequired,
+	fields: PropTypes.object
+};
+
+export default connect(
+	( state ) => {
+		const selectedSiteId = getSelectedSiteId( state );
+		return {
+			carouselActive: !! isJetpackModuleActive( state, selectedSiteId, 'carousel' )
+		};
+	},
+	{
+		updateSettings
+	}
+)( localize( MediaSettings ) );

--- a/client/my-sites/site-settings/media-settings/index.jsx
+++ b/client/my-sites/site-settings/media-settings/index.jsx
@@ -33,7 +33,7 @@ const MediaSettings = ( {
 	const labelClassName = isSavingSettings || ! carouselActive ? 'is-disabled' : null;
 
 	return (
-		<Card className="media-settings site-settings">
+		<Card className="media-settings site-settings site-settings__module-settings">
 			<FormFieldset>
 				<div className="media-settings__info-link-container">
 					<InfoPopover position={ 'left' }>
@@ -64,7 +64,7 @@ const MediaSettings = ( {
 					label={ translate( 'Transform standard image galleries into full-screen slideshows.' ) }
 					disabled={ isRequestingSettings || isSavingSettings }
 					/>
-				<div className="media-settings__module-settings is-indented">
+				<div className="media-settings__module-settings site-settings__child-settings">
 					<FormToggle
 						className="media-settings__carousel-module-settings-toggle is-compact"
 						checked={ fields.carousel_display_exif || false }

--- a/client/my-sites/site-settings/media-settings/style.scss
+++ b/client/my-sites/site-settings/media-settings/style.scss
@@ -1,0 +1,14 @@
+.media-settings__module-settings.is-indented {
+	margin-left: 32px;
+	margin-top: 16px;
+
+	.form-label {
+		&.is-disabled {
+			opacity: 0.3;
+		}
+	}
+}
+
+.media-settings__info-link-container {
+	float: right;
+}

--- a/client/my-sites/site-settings/media-settings/style.scss
+++ b/client/my-sites/site-settings/media-settings/style.scss
@@ -1,14 +1,3 @@
-.media-settings__module-settings.is-indented {
-	margin-left: 32px;
-	margin-top: 16px;
-
-	.form-label {
-		&.is-disabled {
-			opacity: 0.3;
-		}
-	}
-}
-
 .media-settings__info-link-container {
 	float: right;
 }

--- a/client/state/jetpack/settings/test/utils.js
+++ b/client/state/jetpack/settings/test/utils.js
@@ -165,6 +165,9 @@ describe( 'utils', () => {
 				comments: true,
 				highlander_comment_form_prompt: 'Leave a Reply',
 				jetpack_comment_form_color_scheme: 'light',
+				carousel: true,
+				carousel_background_color: 'black',
+				carousel_display_exif: true
 			};
 
 			expect( filterSettingsByActiveModules( settings ) ).to.eql( {
@@ -198,6 +201,8 @@ describe( 'utils', () => {
 				jetpack_portfolio: false,
 				highlander_comment_form_prompt: 'Leave a Reply',
 				jetpack_comment_form_color_scheme: 'light',
+				carousel_background_color: 'black',
+				carousel_display_exif: true
 			} );
 		} );
 
@@ -241,6 +246,9 @@ describe( 'utils', () => {
 				comments: false,
 				highlander_comment_form_prompt: 'Leave a Reply',
 				jetpack_comment_form_color_scheme: 'light',
+				carousel: false,
+				carousel_background_color: 'black',
+				carousel_display_exif: true
 			};
 
 			expect( filterSettingsByActiveModules( settings ) ).to.eql( {
@@ -280,6 +288,8 @@ describe( 'utils', () => {
 				jetpack_portfolio: false,
 				highlander_comment_form_prompt: 'Leave a Reply',
 				jetpack_comment_form_color_scheme: 'light',
+				carousel_background_color: 'black',
+				carousel_display_exif: true
 			};
 
 			expect( filterSettingsByActiveModules( settings ) ).to.eql( {

--- a/client/state/jetpack/settings/utils.js
+++ b/client/state/jetpack/settings/utils.js
@@ -98,7 +98,11 @@ export const filterSettingsByActiveModules = ( settings ) => {
 		],
 		comments: [
 			'highlander_comment_form_prompt',
-			'jetpack_comment_form_color_scheme',
+			'jetpack_comment_form_color_scheme'
+		],
+		carousel: [
+			'carousel_background_color',
+			'carousel_display_exif'
 		]
 	};
 	let filteredSettings = { ...settings };


### PR DESCRIPTION
Part of #9171

#### Changes proposed in this Pull Request:

* Introduces `my-sites/site-settings/media-settings` shown for Jetpack sites
* Introduces `my-sites/site-settings/jetpack-module-toggle`. 
* Adds the MediaSettings Card to the **Writing** Site Settings tab

#### Screenshot of the card introduced by this PR

![image](https://cloud.githubusercontent.com/assets/746152/23363931/c97e3224-fcdb-11e6-9951-15c2512c7421.png)


#### Mockup screenshot for this card

![image](https://cloud.githubusercontent.com/assets/746152/20897631/e1b22100-bb01-11e6-8b9b-4eec82be5779.png)




#### Testing instructions

1. Go to the Site Settings page for a Jetpack site
2. Get to the *Writing* tab. Scroll to the bottom until you see the **Media** card.
3. Alter any of the toggles in the Media Card. Checkboxes, selects have no effect yet.
4. Confirm that the matching module for each toggle was activated/deactivated properly in the Jetpack site by getting to the site's Jetpack Settings Admin Page.