### PR TITLE
Extensions: use "env_id" instead of "env".

### DIFF
--- a/client/extensions/hello-dolly/package.json
+++ b/client/extensions/hello-dolly/package.json
@@ -3,7 +3,7 @@
 	"author": "Automattic",
 	"description": "Hello, Dolly!",
 	"version": "0.0.1",
-	"env": [ "development", "wpcalypso" ],
+	"env_id": [ "development", "wpcalypso" ],
 	"section": {
 		"name": "hello-dolly",
 		"paths": [ "/hello-dolly" ],

--- a/client/sections.js
+++ b/client/sections.js
@@ -14,7 +14,7 @@ const extensions = require( 'extensions' );
 const extensionSections = extensions.map( extension => {
 	try {
 		const pkg = JSON.parse( fs.readFileSync( path.join( __dirname, 'extensions', extension, 'package.json' ) ) );
-		return pkg.env.indexOf( config( 'env' ) ) > -1
+		return pkg.env_id.indexOf( config( 'env_id' ) ) > -1
 			? pkg.section
 			: null;
 	} catch ( e ) {


### PR DESCRIPTION
`wpcalypso` has an env of `production` and an `env_id` of `wpcalypso`.