### PR TITLE
Reader Full Post: show a friendly message for 403 or 404 errors

### DIFF
--- a/client/blocks/reader-full-post/back.jsx
+++ b/client/blocks/reader-full-post/back.jsx
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
+
+const ReaderFullPostBack = ( { onBackClick, translate } ) => {
+	return (
+		<div className="reader-full-post__back-container">
+			<Button className="reader-full-post__back" borderless compact onClick={ onBackClick }>
+				<Gridicon icon="arrow-left" />
+				<span className="reader-full-post__back-label">{ translate( 'Back' ) }</span>
+			</Button>
+		</div>
+	);
+};
+
+ReaderFullPostBack.propTypes = {
+	onBackClick: React.PropTypes.func.isRequired
+};
+
+export default localize( ReaderFullPostBack );

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -53,6 +53,7 @@ import QueryReaderSite from 'components/data/query-reader-site';
 import QueryReaderFeed from 'components/data/query-reader-feed';
 import ExternalLink from 'components/external-link';
 import DocumentHead from 'components/data/document-head';
+import ReaderFullPostUnavailable from './unavailable';
 
 export class FullPostView extends React.Component {
 	constructor( props ) {
@@ -211,6 +212,10 @@ export class FullPostView extends React.Component {
 	}
 
 	parseEmoji() {
+		if ( ! this.refs.article ) {
+			return;
+		}
+
 		twemoji.parse( this.refs.article, {
 			base: config( 'twemoji_cdn_url' )
 		} );
@@ -234,6 +239,11 @@ export class FullPostView extends React.Component {
 
 	render() {
 		const { post, site, feed } = this.props;
+
+		if ( post._state === 'error' ) {
+			return <ReaderFullPostUnavailable post={ post } />;
+		}
+
 		const siteName = siteNameFromSiteAndPost( site, post );
 		const classes = { 'reader-full-post': true };
 		const showRelatedPosts = ! post.is_external && post.site_ID;

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -14,8 +14,6 @@ import { get } from 'lodash';
  * Internal Dependencies
  */
 import ReaderMain from 'components/reader-main';
-import Button from 'components/button';
-import Gridicon from 'components/gridicon';
 import EmbedContainer from 'components/embed-container';
 import PostExcerpt from 'components/post-excerpt';
 import { setSection } from 'state/ui/actions';
@@ -54,6 +52,7 @@ import QueryReaderFeed from 'components/data/query-reader-feed';
 import ExternalLink from 'components/external-link';
 import DocumentHead from 'components/data/document-head';
 import ReaderFullPostUnavailable from './unavailable';
+import ReaderFullPostBack from './back';
 
 export class FullPostView extends React.Component {
 	constructor( props ) {
@@ -241,7 +240,7 @@ export class FullPostView extends React.Component {
 		const { post, site, feed } = this.props;
 
 		if ( post._state === 'error' ) {
-			return <ReaderFullPostUnavailable post={ post } />;
+			return <ReaderFullPostUnavailable post={ post } onBackClick={ this.handleBack } />;
 		}
 
 		const siteName = siteNameFromSiteAndPost( site, post );
@@ -273,12 +272,7 @@ export class FullPostView extends React.Component {
 				}
 				{ post && post.feed_ID && <QueryReaderFeed feedId={ +post.feed_ID } /> }
 				{ post && ! post.is_external && post.site_ID && <QueryReaderSite siteId={ +post.site_ID } /> }
-				<div className="reader-full-post__back-container">
-					<Button className="reader-full-post__back" borderless compact onClick={ this.handleBack }>
-						<Gridicon icon="arrow-left" />
-						<span className="reader-full-post__back-label">{ translate( 'Back' ) }</span>
-					</Button>
-				</div>
+				<ReaderFullPostBack onBackClick={ this.handleBack } />
 				<div className="reader-full-post__visit-site-container">
 					<ExternalLink icon={ true } href={ post.URL } onClick={ this.handleVisitSiteClick } target="_blank">
 						<span className="reader-full-post__visit-site-label">{ translate( 'Visit Site' ) }</span>

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -528,3 +528,7 @@
 .reader-full-post .embed-vimeo {
 	margin-bottom: 0;
 }
+
+.reader-full-post__unavailable-message {
+	margin-top: 1em;
+}

--- a/client/blocks/reader-full-post/unavailable.jsx
+++ b/client/blocks/reader-full-post/unavailable.jsx
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import config from 'config';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import ReaderMain from 'components/reader-main';
+import DocumentHead from 'components/data/document-head';
+
+const ReaderFullPostUnavailable = ( { post, translate } ) => {
+	return (
+		<ReaderMain className="reader-full-post reader-full-post__unavailable">
+			<DocumentHead title={ translate( 'Post unavailable' ) } />
+				<div className="reader-full-post__content">
+					<div className="reader-full-post__story">
+						<h1 className="reader-full-post__header-title">{ translate( 'Post unavailable' ) }</h1>
+						<p className="reader-full-post__unavailable-message">
+							{ translate( 'Sorry, we can\'t display that post right now.' ) }
+						</p>
+						{ config.isEnabled( 'reader/full-errors' ) ? <pre>{ JSON.stringify( post, null, '  ' ) }</pre> : null }
+					</div>
+				</div>
+		</ReaderMain>
+	);
+};
+
+ReaderFullPostUnavailable.propTypes = {
+	post: React.PropTypes.object.isRequired
+};
+
+export default localize( ReaderFullPostUnavailable );

--- a/client/blocks/reader-full-post/unavailable.jsx
+++ b/client/blocks/reader-full-post/unavailable.jsx
@@ -4,16 +4,19 @@
 import React from 'react';
 import config from 'config';
 import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import ReaderMain from 'components/reader-main';
 import DocumentHead from 'components/data/document-head';
+import ReaderFullPostBack from './back';
 
-const ReaderFullPostUnavailable = ( { post, translate } ) => {
+const ReaderFullPostUnavailable = ( { post, onBackClick, translate } ) => {
 	return (
 		<ReaderMain className="reader-full-post reader-full-post__unavailable">
+			<ReaderFullPostBack onBackClick={ onBackClick } />
 			<DocumentHead title={ translate( 'Post unavailable' ) } />
 				<div className="reader-full-post__content">
 					<div className="reader-full-post__story">
@@ -29,7 +32,12 @@ const ReaderFullPostUnavailable = ( { post, translate } ) => {
 };
 
 ReaderFullPostUnavailable.propTypes = {
-	post: React.PropTypes.object.isRequired
+	post: React.PropTypes.object.isRequired,
+	onBackClick: React.PropTypes.func.isRequired
+};
+
+ReaderFullPostUnavailable.defaultProps = {
+	onBackClick: noop
 };
 
 export default localize( ReaderFullPostUnavailable );

--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -83,7 +83,7 @@ FeedPostStore.dispatchToken = Dispatcher.register( function( payload ) {
 		case FeedPostActionType.RECEIVE_FEED_POST:
 			if ( action.error ) {
 				const error = {
-					statusCode: action.error.statusCode,
+					status_code: action.error.statusCode ? action.error.statusCode : -1,
 					errorCode: '-',
 					message: action.error.toString()
 				};
@@ -210,7 +210,7 @@ function receivePost( feedId, postId, post ) {
 		return;
 	}
 
-	if ( post.errors || post.statusCode === 404 ) {
+	if ( post.errors || post.status_code === 404 ) {
 		receiveError( feedId, postId, post );
 	} else {
 		normalizePost( feedId, postId, post );
@@ -222,7 +222,7 @@ function receiveBlogPost( blogId, postId, post ) {
 		return;
 	}
 
-	if ( post.errors || post.statusCode === 404 ) {
+	if ( post.errors || post.status_code === 404 ) {
 		post.site_ID = blogId;
 		post.ID = postId;
 		post.is_external = false;
@@ -234,8 +234,8 @@ function receiveBlogPost( blogId, postId, post ) {
 
 function receiveError( feedId, postId, error ) {
 	let statusCode, errorCode, message;
-	if ( error.statusCode ) {
-		statusCode = error.statusCode;
+	if ( error.status_code ) {
+		statusCode = error.status_code;
 
 		if ( error.errors ) {
 			errorCode = error.errors.error;

--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -83,7 +83,7 @@ FeedPostStore.dispatchToken = Dispatcher.register( function( payload ) {
 		case FeedPostActionType.RECEIVE_FEED_POST:
 			if ( action.error ) {
 				const error = {
-					status_code: -1,
+					statusCode: action.error.statusCode,
 					errorCode: '-',
 					message: action.error.toString()
 				};
@@ -210,7 +210,7 @@ function receivePost( feedId, postId, post ) {
 		return;
 	}
 
-	if ( post.errors || post.status_code === 404 ) {
+	if ( post.errors || post.statusCode === 404 ) {
 		receiveError( feedId, postId, post );
 	} else {
 		normalizePost( feedId, postId, post );
@@ -222,7 +222,7 @@ function receiveBlogPost( blogId, postId, post ) {
 		return;
 	}
 
-	if ( post.errors || post.status_code === 404 ) {
+	if ( post.errors || post.statusCode === 404 ) {
 		post.site_ID = blogId;
 		post.ID = postId;
 		post.is_external = false;
@@ -234,8 +234,8 @@ function receiveBlogPost( blogId, postId, post ) {
 
 function receiveError( feedId, postId, error ) {
 	let statusCode, errorCode, message;
-	if ( error.status_code ) {
-		statusCode = error.status_code;
+	if ( error.statusCode ) {
+		statusCode = error.statusCode;
 
 		if ( error.errors ) {
 			errorCode = error.errors.error;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/8989.

This PR adds a helpful message when a full post is missing or unavailable. It also outputs the error if in a development environment:

<img width="1270" alt="screen shot 2016-12-05 at 17 04 07" src="https://cloud.githubusercontent.com/assets/17325/20873509/e3a3d426-bb0c-11e6-9831-7b08ab612cf6.png">

I've used one general message ("Post unavailable") to address all errors for the moment.

### To test 

Try visiting a post that doesn't exist, and ensure you see the 'Post unavailable' page.

Try visiting a post that you don't have permission to view (e.g. a private P2 with an unprivileged account), and ensure you see the 'Post unavailable' page.

Make sure the Back button works, both on a regular full post and on the 'Post unavailable' page.