### PR TITLE
Build: Fix how we generate the style hash on platforms that use md5sum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,8 @@ CLIENT_STYLE_FILES = $(shell \
 		-type f \
 		-name 'style.scss' \
 )
-CLIENT_STYLE_FILES_HASH = $(shell echo $(CLIENT_STYLE_FILES) | $(HASH)).hash
+# the cut here limits the filename to the hash. md5sum emits the hash and some spaces followed by a dash
+CLIENT_STYLE_FILES_HASH = $(shell echo $(CLIENT_STYLE_FILES) | $(HASH) | cut -b 1-32).hash
 
 # variables
 NODE_ENV ?= development


### PR DESCRIPTION
It emits the hash followed by some spaces, followed by a -. This breaks the later touch statement.
Instead, cut the output down to the first 32 bytes, which is just the hash.

To test, spin up a docker build with `docker build .` As long as the build succeeds, we're happy.

You can get the Mac native Docker here: https://docs.docker.com/docker-for-mac/