### PR TITLE
Checkout: remove thank-you page email nudge test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -71,14 +71,6 @@ module.exports = {
 		defaultVariation: 'excludeDotBlogSubdomain',
 		allowAnyLocale: true,
 	},
-	paidNuxThankYouPage: {
-		datestamp: '20161114',
-		variations: {
-			original: 50,
-			emailNudgeOnTop: 50,
-		},
-		defaultVariation: 'original',
-	},
 	siteTitleStep: {
 		datestamp: '20160928',
 		variations: {

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -54,7 +54,6 @@ import { getFeatureByKey, shouldFetchSitePlans } from 'lib/plans';
 import SiteRedirectDetails from './site-redirect-details';
 import Notice from 'components/notice';
 import upgradesPaths from 'my-sites/upgrades/paths';
-import { abtest } from 'lib/abtest';
 
 function getPurchases( props ) {
 	return props.receipt.data.purchases;
@@ -116,13 +115,11 @@ const CheckoutThankYou = React.createClass( {
 			return null;
 		}
 
-		const emailNudgeOnTop = abtest( 'paidNuxThankYouPage' ) === 'emailNudgeOnTop';
-
 		return (
 			<Notice
 				className="checkout-thank-you__verification-notice"
 				showDismiss={ false }
-				status={ emailNudgeOnTop ? 'is-warning' : '' }
+				status="is-warning"
 				>
 				{ this.translate( 'We’ve sent a message to {{strong}}%(email)s{{/strong}}. ' +
 					'Please check your email to confirm your address.', {
@@ -188,7 +185,6 @@ const CheckoutThankYou = React.createClass( {
 
 		const userCreatedMoment = moment( this.props.userDate );
 		const isNewUser = userCreatedMoment.isAfter( moment().subtract( 2, 'hours' ) );
-		const emailNudgeOnTop = abtest( 'paidNuxThankYouPage' ) === 'emailNudgeOnTop';
 
 		// this placeholder is using just wp logo here because two possible states do not share a common layout
 		if ( ! purchases && ! this.isGenericReceipt() ) {
@@ -204,9 +200,8 @@ const CheckoutThankYou = React.createClass( {
 		if ( isNewUser && wasOnlyDotcomPlanPurchased ) {
 			return (
 				<Main className="checkout-thank-you">
-					{ emailNudgeOnTop ? this.renderConfirmationNotice() : null }
+					{ this.renderConfirmationNotice() }
 					<PlanThankYouCard siteId={ this.props.selectedSite.ID } />
-					{ ! emailNudgeOnTop ? this.renderConfirmationNotice() : null }
 				</Main>
 			);
 		}


### PR DESCRIPTION
Test variant performed better than the previous default (email nudge below thank-you card; gray notice). Removing the test and making the tested variant the new default.

To test:

- sandbox the store
- go through signup and buy a plan in the process
- on the thank-you page after checkout, make sure it's the green one with the yellow email nudge on top (screenshot below)

<img width="1087" alt="screen shot 2016-12-05 at 10 21 53 am" src="https://cloud.githubusercontent.com/assets/23619/20879549/ad5b85d6-bad4-11e6-84ff-1b303b80368d.png">
