### PR TITLE
GuidedTours: add easy default message and icon to `Continue`

### DIFF
--- a/client/layout/guided-tours/config-elements.js
+++ b/client/layout/guided-tours/config-elements.js
@@ -21,6 +21,7 @@ import debugFactory from 'debug';
 import Card from 'components/card';
 import Button from 'components/button';
 import ExternalLink from 'components/external-link';
+import Gridicon from 'components/gridicon';
 import pathToSection from 'lib/path-to-section';
 import { ROUTE_SET } from 'state/action-types';
 import { tourBranching } from './config-parsing';
@@ -408,6 +409,14 @@ export class Continue extends Component {
 		}
 	}
 
+	defaultMessage() {
+		return this.props.icon
+			? translate( 'Click the {{icon/}} to continue.', {
+				components: { icon: <Gridicon icon={ this.props.icon } size={ 24 } /> }
+			} )
+			: translate( 'Click to continue.' );
+	}
+
 	render() {
 		if ( this.props.hidden ) {
 			return null;
@@ -415,7 +424,7 @@ export class Continue extends Component {
 
 		return (
 			<p className="guided-tours__actionstep-instructions">
-				<em>{ this.props.children || translate( 'Click to continue.' ) }</em>
+				<em>{ this.props.children || this.defaultMessage() }</em>
 			</p>
 		);
 	}

--- a/client/layout/guided-tours/main-tour.js
+++ b/client/layout/guided-tours/main-tour.js
@@ -62,7 +62,7 @@ export const MainTour = makeTour(
 						} )
 				}
 			</p>
-			<Continue icon="my-sites" target="my-sites" step="sidebar" click />
+			<Continue click icon="my-sites" step="sidebar" target="my-sites" />
 		</Step>
 
 		<Step name="sidebar"
@@ -95,7 +95,7 @@ export const MainTour = makeTour(
 					} )
 				}
 			</p>
-			<Continue step="in-preview" target="site-card-preview" click>
+			<Continue click step="in-preview" target="site-card-preview">
 				{
 					translate( "Click {{strong}}your site's name{{/strong}} to continue.", {
 						components: {
@@ -122,7 +122,7 @@ export const MainTour = makeTour(
 			<ButtonRow>
 				<Next step="close-preview" />
 				<Quit />
-				<Continue step="close-preview" when={ previewIsNotShowing } hidden />
+				<Continue hidden step="close-preview" when={ previewIsNotShowing } />
 			</ButtonRow>
 		</Step>
 
@@ -135,7 +135,7 @@ export const MainTour = makeTour(
 			<p>
 				{ translate( 'Take a look at your site — and then close the site preview. You can come back here anytime.' ) }
 			</p>
-			<Continue step="themes" icon="cross-small" target="web-preview__close" when={ previewIsNotShowing } />
+			<Continue icon="cross-small" step="themes" target="web-preview__close" when={ previewIsNotShowing } />
 		</Step>
 
 		<Step name="themes"

--- a/client/layout/guided-tours/main-tour.js
+++ b/client/layout/guided-tours/main-tour.js
@@ -21,7 +21,6 @@ import {
 	previewIsShowing,
 } from 'state/ui/guided-tours/contexts';
 import { getScrollableSidebar } from 'layout/guided-tours/positioning';
-import Gridicon from 'components/gridicon';
 import scrollTo from 'lib/scroll-to';
 
 const scrollSidebarToTop = () =>
@@ -63,15 +62,7 @@ export const MainTour = makeTour(
 						} )
 				}
 			</p>
-			<Continue icon="my-sites" target="my-sites" step="sidebar" click>
-				{
-					translate( 'Click the {{GridIcon/}} to continue.', {
-						components: {
-							GridIcon: <Gridicon icon="my-sites" size={ 24 } />,
-						}
-					} )
-				}
-			</Continue>
+			<Continue icon="my-sites" target="my-sites" step="sidebar" click />
 		</Step>
 
 		<Step name="sidebar"
@@ -144,15 +135,7 @@ export const MainTour = makeTour(
 			<p>
 				{ translate( 'Take a look at your site — and then close the site preview. You can come back here anytime.' ) }
 			</p>
-			<Continue step="themes" target="web-preview__close" when={ previewIsNotShowing }>
-				{
-					translate( 'Click the {{GridIcon/}} to continue.', {
-						components: {
-							GridIcon: <Gridicon icon="cross-small" size={ 24 } />,
-						}
-					} )
-				}
-			</Continue>
+			<Continue step="themes" icon="cross-small" target="web-preview__close" when={ previewIsNotShowing } />
 		</Step>
 
 		<Step name="themes"


### PR DESCRIPTION
If using `Continue` with an icon and the default message ("click the <icon> to continue"), it was previously more burdensome than necessary to properly include the icon using translate's `components` property. This PR makes this default behavior a bit easier by moving most of that logic into the `Continue` element. The tour author only needs to supply the icon name now. 

Props to @mcsf. 

To test:

- go to http://calypso.localhost:3000/?tour=main
- make sure the icons still display properly in the `my-sites` and `close-preview` steps. 
