### PR TITLE
Guided Tours: Add isAbTestInVariant selector

### DIFF
--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -1,6 +1,7 @@
 import config from 'config';
 import { getSectionName, isPreviewShowing, getSelectedSite } from 'state/ui/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
+import { abtest } from 'lib/abtest';
 
 export const inSection = sectionName => state =>
 	getSectionName( state ) === sectionName;
@@ -30,3 +31,6 @@ export const selectedSiteIsPreviewable = state =>
 
 export const selectedSiteIsCustomizable = state =>
 	getSelectedSite( state ) && getSelectedSite( state ).is_customizable;
+
+export const isAbTestInVariant = ( testName, variant ) => () =>
+	abtest( testName ) === variant;


### PR DESCRIPTION
This code was extracted from #8627, so we can implement it in other tours before we manage to review and merge a whole Site Title tour. 

I'm not sure how to test this without a tour. Maybe the Main tour can be used for this. `<Tour name="main" version="20160601" path="/" when={ isAbTestInVariant( 'someTest', 'someVariant' ) } >`. You should see that someTest was assigned a variant in a/b test menu (you should pick some that wasn't assigned before)

cc @mcsf @lsinger 