### PR TITLE
JPC: Add vaultpress landing

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -434,7 +434,7 @@ class PlanFeatures extends Component {
 	}
 
 	renderBottomButtons() {
-		const { canPurchase, planProperties, isInSignup, site } = this.props;
+		const { canPurchase, planProperties, isInSignup, isLandingPage, site } = this.props;
 
 		return map( planProperties, ( properties ) => {
 			const {
@@ -462,6 +462,7 @@ class PlanFeatures extends Component {
 						freePlan={ isFreePlan( planName ) }
 						isPlaceholder={ isPlaceholder }
 						isInSignup={ isInSignup }
+						isLandingPage={ isLandingPage }
 						manageHref={ `/plans/my-plan/${ site.slug }` }
 					/>
 				</td>

--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -61,7 +61,7 @@ const jetpackConnectFirstStep = ( context, type ) => {
 	);
 };
 
-const getPlansLandingPage = ( context, hideFreePlan, path ) => {
+const getPlansLandingPage = ( context, hideFreePlan, path, landingType ) => {
 	const PlansLanding = require( './plans-landing' ),
 		analyticsPageTitle = 'Plans',
 		basePath = route.sectionify( context.path ),
@@ -80,6 +80,7 @@ const getPlansLandingPage = ( context, hideFreePlan, path ) => {
 			destinationType={ context.params.destinationType }
 			intervalType={ context.params.intervalType }
 			isLanding={ true }
+			landingType={ landingType }
 			basePlansPath={ path }
 			hideFreePlan={ hideFreePlan } />,
 		document.getElementById( 'primary' ),
@@ -219,15 +220,15 @@ export default {
 	},
 
 	vaultpressLanding( context ) {
-		getPlansLandingPage( context, true, '/jetpack/connect/vaultpress' );
+		getPlansLandingPage( context, true, '/jetpack/connect/vaultpress', 'vaultpress' );
 	},
 
 	akismetLanding( context ) {
-		getPlansLandingPage( context, true, '/jetpack/connect/akismet' );
+		getPlansLandingPage( context, true, '/jetpack/connect/akismet', 'akismet' );
 	},
 
 	plansLanding( context ) {
-		getPlansLandingPage( context, false, '/jetpack/connect/store' );
+		getPlansLandingPage( context, false, '/jetpack/connect/store', 'jetpack' );
 	},
 
 	plansSelection( context ) {

--- a/client/signup/jetpack-connect/plans-grid.jsx
+++ b/client/signup/jetpack-connect/plans-grid.jsx
@@ -22,6 +22,11 @@ export default React.createClass( {
 		if ( this.props.isLanding ) {
 			headerText = this.translate( 'Pick a plan that\'s right for you.' );
 			subheaderText = '';
+
+			if ( this.props.landingType === 'vaultpress' ) {
+				headerText = this.translate( 'Select your VaultPress plan.' );
+				subheaderText = this.translate( 'VaultPress backup and security plans are now cheaper as part of Jetpack.' );
+			}
 		}
 		return (
 			<StepHeader


### PR DESCRIPTION
This PR changes the texts that we show in wordpress.com/jetpack/connect/vaultpress to make them vaultpress-related. Not a lot of changes, it only makes the landing page aware of its vaultpressness.

![image](https://cloud.githubusercontent.com/assets/1554855/20886547/dab65fe8-baf6-11e6-88a5-be58e5206cac.png)

to test:

1. go to http://calypso.localhost:3000/jetpack/connect/vaultpress and make sure the text you see are vaultpress-related and the bottom row of buttons reads "select" instead of "upgrade"

ping @richardmuscat @oskosk @tyxla 