### PR TITLE
Add the chat with us button to the paypal checkout screen

### DIFF
--- a/client/my-sites/upgrades/checkout/payment-chat-button.jsx
+++ b/client/my-sites/upgrades/checkout/payment-chat-button.jsx
@@ -22,7 +22,7 @@ export default localize( ( { cart, translate, paymentType, transactionStep } ) =
 			chatContext="presale"
 			tracksData={ {
 				payment_type: paymentType,
-				transaction_step: transactionStep.name,
+				transaction_step: transactionStep && transactionStep.name,
 				product_slug: productSlug,
 			} }>
 				<Gridicon icon="chat" className="checkout__payment-chat-button-icon" />


### PR DESCRIPTION
This pull request adds a "Chat with us" button to the paypal variation of the checkout screen so that we can offer users the chance to chat with a Happiness Engineer before making their purchase.

### How to test
1. Navigate to http://calypso.localhost:3000/plans
2. From the browser console enter: `localStorage.setItem( 'ABTests', '{"presaleChatButton_20161129":"showChatButton"}' )`. This will allow us to bypass the abtest
3. Select the business plan
4. Click "or use PayPal"
5. Notice on the checkout screen you will see a new button on the bottom right labeled "Need help? Chat with us"
6. Click the chat with us button.
7. Within tracks notice that a ping has been made for `calypso_chat_button_click`
8. Start a chat.
9. Within olark notice that the user is tagged with "Context: presale"
10. Check tracks and notice that another ping has made for `calypso_chat_button_chat_begin`


### What to expect
![screen shot 2016-12-05 at 10 42 57 am](https://cloud.githubusercontent.com/assets/1854440/20891183/ae002d2c-bad7-11e6-9e43-8f6ea332add7.png)
![screen shot 2016-12-05 at 10 42 41 am](https://cloud.githubusercontent.com/assets/1854440/20891187/b0cf17b6-bad7-11e6-9f5b-cd2fa9b77172.png)