### PR TITLE
Increase A/B test ratio for pre-sales chat

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -94,8 +94,8 @@ module.exports = {
 	presaleChatButton: {
 		datestamp: '20161129',
 		variations: {
-			showChatButton: 20,
-			original: 80
+			showChatButton: 50,
+			original: 50
 		},
 		defaultVariation: 'original',
 		allowAnyLocale: true,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -99,6 +99,7 @@ module.exports = {
 		},
 		defaultVariation: 'original',
 		allowAnyLocale: true,
+		allowExistingUsers: true,
 	},
 
 	noSurveyStep: {


### PR DESCRIPTION
Last week we shipped an option to let users chat with us during the checkout process. To be safe just in case it would impact revenue, we turned it on at only 20%. This PR increases that percentage to 50% so that we can show the chat variant to more people. We'll test this for a day or two and then turn it on probably all the way.

**How to test**
1. Navigate to http://calypso.localhost:3000/plans
2. From the browser console enter: localStorage.setItem( 'ABTests', '{"presaleChatButton_20161129":"showChatButton"}' ). This will allow us to bypass the abtest
3. Select the Business plan.
4. Notice on the checkout screen you will see a new button on the bottom right labeled "Need help? Chat with us"
5. Click the chat with us button.
6. Within tracks notice that a ping has been made for calypso_chat_button_click
7. Start a chat.
8. Within olark notice that the user is tagged with "Context: presale"
9. Check tracks and notice that another ping has made for calypso_chat_button_chat_begin

We should also test that the chat link doesn't appear for other upgrades (e.g. Personal or Premium).

**What to expect**
Here's what the chat prompt looks like:

![screen shot 2016-11-29 at 6 13 55 pm](https://cloud.githubusercontent.com/assets/1854440/20733770/40313d18-b663-11e6-8d12-f8a5fd89750f.png)

Cc @omarjackman 

