### PR TITLE
Reader: Fix how we flag if we were last loaded by popstate.

### DIFF
--- a/client/lib/detect-history-navigation/index.js
+++ b/client/lib/detect-history-navigation/index.js
@@ -1,14 +1,10 @@
-var _loadedViaHistory = false;
+let _loadedViaHistory = false;
 
 module.exports = {
 	start: function() {
-		window.addEventListener( 'popstate', function() {
-			_loadedViaHistory = true;
-		} );
-		setTimeout( function() {
-			window.addEventListener( 'popstate', function() {
-				_loadedViaHistory = false;
-			} );
+		// add a popstate listener that sets the flag
+		window.addEventListener( 'popstate', function( event ) {
+			_loadedViaHistory = !! event.state;
 		} );
 	},
 	loadedViaHistory: function() {


### PR DESCRIPTION
Fixes scroll restoration on firefox post v43.

To test, open a stream in the reader, scroll down, open a post, then hit back. You should end up in the origin stream, at the place you left off.

Try from the following stream / search / discover. Also try going from a stream to full post to another stream to full post and then back your way out.