### PR TITLE
JPC: Added monthly plans to the vaultpress landing page conditionals

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -233,21 +233,21 @@ const JetpackConnectMain = React.createClass( {
 	getTexts() {
 		const { type, selectedPlan } = this.props;
 
-		if ( type === 'pro' || selectedPlan === 'jetpack_business' ) {
+		if ( type === 'pro' || selectedPlan === 'jetpack_business' || selectedPlan === 'jetpack_business_monthly' ) {
 			return {
 				headerTitle: this.translate( 'Get Jetpack Professional' ),
 				headerSubtitle: this.translate( 'To start securing and backing up your site, first install Jetpack, ' +
 					'then purchase and activate your plan.' ),
 			};
 		}
-		if ( type === 'premium' || selectedPlan === 'jetpack_premium' ) {
+		if ( type === 'premium' || selectedPlan === 'jetpack_premium' || selectedPlan === 'jetpack_premium_monthly' ) {
 			return {
 				headerTitle: this.translate( 'Get Jetpack Premium' ),
 				headerSubtitle: this.translate( 'To start securing and backing up your site, first install Jetpack, ' +
 					'then purchase and activate your plan.' ),
 			};
 		}
-		if ( type === 'personal' || selectedPlan === 'jetpack_personal' ) {
+		if ( type === 'personal' || selectedPlan === 'jetpack_personal' || selectedPlan === 'jetpack_personal_monthly' ) {
 			return {
 				headerTitle: this.translate( 'Get Jetpack Personal' ),
 				headerSubtitle: this.translate( 'To start securing and backing up your site, first install Jetpack, ' +


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/9826 

This adds the jetpack monthly plans to the new set of rules for vaultpress & akismet plans flow.

How to test
========
1. Go to http://calypso.localhost:3000/jetpack/connect/vaultpress and select a monthly plan
2. The header should be "Get Jetpack [plan name]" and the subheader "To start securing and backing up your site, first install Jetpack, then purchase and activate your plan.", instead of the regular "Connect a self-hosted WordPress / We'll be installing the Jetpack plugin so WordPress.com can connect to your self-hosted WordPress site."

ping @richardmuscat @roccotripaldi @oskosk 