### PR TITLE
Scroll to top of recs after search has been removed

### DIFF
--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -175,10 +175,15 @@ const SearchStream = React.createClass( {
 	},
 
 	updateQuery( newValue ) {
+		this.scrollToTop();
 		const trimmedValue = trim( newValue ).substring( 0, 1024 );
 		if ( trimmedValue === '' || trimmedValue.length > 1 && trimmedValue !== this.props.query ) {
 			this.props.onQueryChange( newValue );
 		}
+	},
+
+	scrollToTop() {
+		window.scrollTo( 0, 0 );
 	},
 
 	cardFactory() {
@@ -229,6 +234,7 @@ const SearchStream = React.createClass( {
 						<SearchInput
 							initialValue={ this.props.query }
 							onSearch={ this.updateQuery }
+							onSearchClose={ this.scrollToTop }
 							autoFocus={ ! this.props.query }
 							delaySearch={ true }
 							delayTimeout={ 500 }


### PR DESCRIPTION
This PR aims to make it so that when the search query is removed and the recs are shown on the Reader Search page, the window is scrolled to the top.

This fixes an issue outlined here #9731
