### PR TITLE
Reader: Fix busted empty state recs in Search

### DIFF
--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -93,7 +93,8 @@ export function RelatedPostCard( { post, site, siteId, onPostClick = noop, onSit
 	const featuredImage = post.canonical_image;
 	const postLink = getPostUrl( post );
 	const classes = classnames( 'reader-related-card-v2', {
-		'has-thumbnail': !! featuredImage
+		'has-thumbnail': !! featuredImage,
+		'has-excerpt': post.excerpt.length > 1
 	} );
 	const postClickTracker = partial( onPostClick, post );
 	const siteClickTracker = partial( onSiteClick, post );

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -204,6 +204,13 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 			font-size: 14px;
 		}
 	}
+
+	&.has-excerpt {
+
+		.reader-related-card-v2__title {
+			margin-bottom: 10px;
+		}
+	}
 }
 
 .reader-related-card-v2__blocks {
@@ -338,6 +345,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 .reader-related-card-v2__byline-author {
 	margin-top: -5px;
+	word-break: break-word;
 }
 
 .reader-related-card-v2__byline-site {
@@ -393,10 +401,6 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 			color: $alert-green;
 		}
 	}
-
-	@media ( max-width: 535px ) {
-		margin-right: 10px;
-	}
 }
 
 .reader-related-card-v2__featured-image {
@@ -427,7 +431,6 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	font-size: 16px;
 	font-weight: 700;
 	line-height: 1.4;
-	margin-bottom: 10px;
 }
 
 .reader-related-card-v2__excerpt {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -12,7 +12,6 @@
 	}
 }
 
-
 .search-stream .search {
 	margin: 0;
 }
@@ -35,6 +34,11 @@
 	width: 830px;
 }
 
+// Custom breakpoints needed to match Related Posts
+$reader-related-card-v2-breakpoint-medium: "( min-width: 661px ) and ( max-width: 730px )";
+$reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
+
+// Recommendations in Search
 .is-reader-page .search-stream .reader__content {
 	padding-top: 100px;
 }
@@ -44,31 +48,62 @@
  }
 
  .is-reader-page .search-stream .reader__content {
-	 display: flex;
-	 flex-wrap: wrap;
- }
-
- .search-stream  .reader-related-card-v2__title {
-	 padding-top: 15px;
+	display: flex;
+	flex-flow: wrap;
  }
 
  .is-reader-page .search-stream__blank-suggestions {
 	 margin-bottom: -15px;
  }
 
-.is-reader-page .search-stream__recommendation-list-item:nth-child(odd) {
-	margin-right: 0px;
- }
-
  .is-reader-page .search-stream__recommendation-list-item {
-	 flex-basis: 30%;
-	 flex-grow: 0.5;
-	 margin-right: 45px;
-	 display: flex;
-	 list-style-type: none;
-	 border-top: 1px solid lighten( $gray, 20% );
-	 padding-top: 14px;
-	 padding-bottom: 12px;
+	box-sizing: border-box;
+	border-bottom: 1px solid lighten( $gray, 20% );
+	display: flex;
+	flex-basis: calc( 50% - 15px );
+	margin: 0 15px 0 0;
+	padding: 20px 0;
+
+	&:nth-child( 2n+0 ) {
+		flex-basis: calc( 50% - 15px );
+		margin: 0 0 0 15px;
+	}
+
+	 .has-thumbnail {
+
+		.reader-related-card-v2__post {
+			max-height: 220px;
+
+			@media #{$reader-related-card-v2-breakpoint-small} {
+				max-height: 170px;
+			}
+
+			@media #{$reader-related-card-v2-breakpoint-medium} {
+				max-height: 170px;
+			}
+		}
+	}
+
+	.reader-related-card-v2__site-info {
+
+		@media #{$reader-related-card-v2-breakpoint-small} {
+			margin-top: 35px;
+		}
+
+		@media #{$reader-related-card-v2-breakpoint-medium} {
+			margin-top: 35px;
+		}
+	}
+
+	@media #{$reader-related-card-v2-breakpoint-medium} {
+		flex-basis: 100%;
+		margin-right: 0;
+	}
+
+	@media #{$reader-related-card-v2-breakpoint-small} {
+		flex-basis: 100%;
+		margin-right: 0;
+	}
  }
 
 .search-stream__input-card.card {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -44,11 +44,6 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	flex-flow: wrap;
 	margin-top: 80px;
 
-	@media #{$reader-related-card-v2-breakpoint-medium} {
-		flex-flow: initial;
-		flex-direction: column;
-	}
-
 	@include breakpoint( ">660px" ) {
 		margin-top: 130px;
 	}
@@ -111,11 +106,11 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 			max-height: 220px;
 
 			@media #{$reader-related-card-v2-breakpoint-small} {
-				max-height: 170px;
+				max-height: 160px;
 			}
 
 			@media #{$reader-related-card-v2-breakpoint-medium} {
-				max-height: 170px;
+				max-height: 160px;
 			}
 		}
 

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -118,6 +118,17 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 				max-height: 170px;
 			}
 		}
+
+		.reader-related-card-v2__site-info {
+
+			@media #{$reader-related-card-v2-breakpoint-small} {
+				margin-top: 45px;
+			}
+
+			@media #{$reader-related-card-v2-breakpoint-medium} {
+				margin-top: 45px;
+			}
+		}
 	}
 
 	.reader-related-card-v2__featured-image {
@@ -129,17 +140,6 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 		@media #{$reader-related-card-v2-breakpoint-small} {
 			margin: 0 15px 0 0;
-		}
-	}
-
-	.reader-related-card-v2__site-info {
-
-		@media #{$reader-related-card-v2-breakpoint-small} {
-			margin-top: 45px;
-		}
-
-		@media #{$reader-related-card-v2-breakpoint-medium} {
-			margin-top: 45px;
 		}
 	}
 

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -40,16 +40,22 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 // Recommendations in Search
 .is-reader-page .search-stream .reader__content {
-	padding-top: 100px;
+	display: flex;
+	flex-flow: wrap;
+	margin-top: 80px;
+
+	@media #{$reader-related-card-v2-breakpoint-medium} {
+		flex-flow: initial;
+		flex-direction: column;
+	}
+
+	@include breakpoint( ">660px" ) {
+		margin-top: 130px;
+	}
 }
 
 .is-reader-page .search-stream__input-card.card {
 	box-shadow: 0 0 0 2px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
- }
-
- .is-reader-page .search-stream .reader__content {
-	display: flex;
-	flex-flow: wrap;
  }
 
  .is-reader-page .search-stream__blank-suggestions {
@@ -61,12 +67,42 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	border-bottom: 1px solid lighten( $gray, 20% );
 	display: flex;
 	flex-basis: calc( 50% - 15px );
-	margin: 0 15px 0 0;
+	margin: 0 0 0 15px;
 	padding: 20px 0;
+
+	@media #{$reader-related-card-v2-breakpoint-medium} {
+		flex-basis: 100%;
+		margin: 0;
+	}
+
+	@include breakpoint( "<660px" ) {
+		flex-basis: calc( 50% - 30px );
+		margin: 0 15px 0;
+	}
+
+	@media #{$reader-related-card-v2-breakpoint-small}  {
+		flex-basis: 100%;
+		margin: 0 15px 0;
+	}
 
 	&:nth-child( 2n+0 ) {
 		flex-basis: calc( 50% - 15px );
-		margin: 0 0 0 15px;
+		margin: 0 15px 0 0;
+
+		@media #{$reader-related-card-v2-breakpoint-medium} {
+			flex-basis: 100%;
+			margin: 0;
+		}
+
+		@include breakpoint( "<660px" ) {
+			flex-basis: calc( 50% - 30px );
+			margin: 0 15px 0;
+		}
+
+		@media #{$reader-related-card-v2-breakpoint-small} {
+			flex-basis: 100%;
+			margin: 0 15px 0;
+		}
 	}
 
 	 .has-thumbnail {
@@ -84,25 +120,34 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		}
 	}
 
+	.reader-related-card-v2__featured-image {
+		margin: 0 0 19px;
+
+		@media #{$reader-related-card-v2-breakpoint-medium} {
+			margin: 0 15px 0 0;
+		}
+
+		@media #{$reader-related-card-v2-breakpoint-small} {
+			margin: 0 15px 0 0;
+		}
+	}
+
 	.reader-related-card-v2__site-info {
 
 		@media #{$reader-related-card-v2-breakpoint-small} {
-			margin-top: 35px;
+			margin-top: 45px;
 		}
 
 		@media #{$reader-related-card-v2-breakpoint-medium} {
-			margin-top: 35px;
+			margin-top: 45px;
 		}
 	}
 
-	@media #{$reader-related-card-v2-breakpoint-medium} {
-		flex-basis: 100%;
-		margin-right: 0;
-	}
+	.reader-related-card-v2__meta .follow-button {
 
-	@media #{$reader-related-card-v2-breakpoint-small} {
-		flex-basis: 100%;
-		margin-right: 0;
+		@include breakpoint( "<480px" ) {
+			margin-right: 0;
+		}
 	}
  }
 


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/9730

**Before:**
![screenshot 2016-12-06 15 56 45](https://cloud.githubusercontent.com/assets/4924246/20949154/c72b4cdc-bbcc-11e6-8628-86695ca578ff.png)

**After:**
![screenshot 2016-12-06 15 57 58](https://cloud.githubusercontent.com/assets/4924246/20949162/d2ed20a4-bbcc-11e6-8d66-69f7c25dda13.png)

Dropped down to a single column for really narrow widths as mentioned in: https://github.com/Automattic/wp-calypso/issues/9730#issuecomment-263989324

There's going to be some spacing issues similar to https://github.com/Automattic/wp-calypso/issues/9739, but I'll fix those separately. This PR is solely for fixing some overlapping/misalignment due to breakpoints.