### PR TITLE
Reader Refresh: show follow button for Discover cards

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -146,7 +146,7 @@ export default class RefreshPostCard extends React.Component {
 
 		return (
 			<Card className={ classes } onClick={ this.handleCardClick }>
-				<PostByline post={ originalPost ? originalPost : post } site={ site } feed={ feed } showSiteName={ showSiteName } />
+				<PostByline post={ post } site={ site } feed={ feed } showSiteName={ showSiteName } />
 				{ showPrimaryFollowButton && followUrl && <FollowButton siteUrl={ followUrl } /> }
 				<div className="reader-post-card__post">
 					{ ! isGallery && featuredAsset }

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -21,6 +21,7 @@ import FollowButton from 'reader/follow-button';
 import PostGallery from './gallery';
 import DailyPostButton from 'blocks/daily-post-button';
 import { isDailyPostChallengeOrPrompt } from 'blocks/daily-post-button/helper';
+import * as DiscoverHelper from 'reader/discover/helper';
 
 export default class RefreshPostCard extends React.Component {
 	static propTypes = {
@@ -127,7 +128,11 @@ export default class RefreshPostCard extends React.Component {
 
 		let followUrl;
 		if ( showPrimaryFollowButton ) {
-			followUrl = feed ? feed.feed_URL : post.site_URL;
+			if ( DiscoverHelper.isDiscoverPost( post ) ) {
+				followUrl = DiscoverHelper.getSourceFollowUrl( post );
+			} else {
+				followUrl = feed ? feed.feed_URL : post.site_URL;
+			}
 		}
 
 		let featuredAsset;
@@ -141,8 +146,8 @@ export default class RefreshPostCard extends React.Component {
 
 		return (
 			<Card className={ classes } onClick={ this.handleCardClick }>
-				<PostByline post={ post } site={ site } feed={ feed } showSiteName={ showSiteName } />
-				{ showPrimaryFollowButton && <FollowButton siteUrl={ followUrl } /> }
+				<PostByline post={ originalPost ? originalPost : post } site={ site } feed={ feed } showSiteName={ showSiteName } />
+				{ showPrimaryFollowButton && followUrl && <FollowButton siteUrl={ followUrl } /> }
 				<div className="reader-post-card__post">
 					{ ! isGallery && featuredAsset }
 					{ isGallery && <PostGallery post={ post } /> }

--- a/client/lib/reader-feed-subscriptions/actions.js
+++ b/client/lib/reader-feed-subscriptions/actions.js
@@ -14,7 +14,7 @@ var Dispatcher = require( 'dispatcher' ),
 	FeedStoreActionTypes = require( 'lib/feed-store/constants' ).action;
 
 var FeedSubscriptionActions = {
-	follow: function( url, fetchMeta ) {
+	follow: function( url, fetchMeta = true ) {
 		var meta;
 
 		if ( ! url ) {

--- a/client/reader/discover/controller.js
+++ b/client/reader/discover/controller.js
@@ -44,7 +44,7 @@ export default {
 				),
 				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
 				suppressSiteNameLink: true,
-				showPrimaryFollowButtonOnCards: false,
+				showPrimaryFollowButtonOnCards: true,
 				showBack: false,
 				className: 'is-discover-stream is-site-stream',
 			} ),

--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -77,5 +77,11 @@ export function getSourceFollowUrl( post ) {
 	if ( isInternalDiscoverPost( post ) ) {
 		followUrl = get( post, 'discover_metadata.attribution.blog_url' );
 	}
+
+	// If it's a site pick, try the permalink
+	if ( ! followUrl && isDiscoverSitePick( post ) ) {
+		followUrl = get( post, 'discover_metadata.permalink' );
+	}
+
 	return followUrl || '';
 }


### PR DESCRIPTION
Part of #9096.

This PR displays the follow button for all Discover cards. The follow button should follow the source site.

For posts that aren't picks (editorial-style pieces), we're not displaying a follow button.