### PR TITLE
Update/remove sitelist usage from checkout

### DIFF
--- a/client/lib/checkout/index.js
+++ b/client/lib/checkout/index.js
@@ -8,7 +8,7 @@ export function getExitCheckoutUrl( cart, siteSlug ) {
 	let url = '/plans/';
 
 	if ( cartItems.hasRenewalItem( cart ) ) {
-		let renewalItem = cartItems.getRenewalItems( cart )[ 0 ];
+		const renewalItem = cartItems.getRenewalItems( cart )[ 0 ];
 
 		return managePurchase( renewalItem.extra.purchaseDomain, renewalItem.extra.purchaseId );
 	}
@@ -23,5 +23,5 @@ export function getExitCheckoutUrl( cart, siteSlug ) {
 		url = '/design/';
 	}
 
-	return url + siteSlug;
+	return siteSlug ? url + siteSlug : url;
 }

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -196,7 +196,7 @@ module.exports = {
 						product={ product }
 						productsList={ productsList }
 						selectedFeature={ selectedFeature }
-						sites={ sites } />
+					/>
 				</CheckoutData>
 			),
 			document.getElementById( 'primary' ),


### PR DESCRIPTION
#### note:
Reapplying changes made in #9429. #9429 was reverted after some build issues with another PR that was landed shortly before (see [this comment](https://github.com/Automattic/wp-calypso/pull/9429#issuecomment-264275996) for more detail).

## Aims
As part of #8726, this PR removes reference to 'lib/sites-list' from the upgrades/checkout component.

## Test Plan

- Navigate to [plans](http://calypso.localhost:3000/plans) and select a site.
- Choose an upgrade... this should take you to the checkout page.
- Check that this page has not changed functionally.
    - it should be visually identical before & after this patch

cc: @gwwar 