### PR TITLE
Theme Sheet: Use isPurchased instead of theme.price check

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -34,9 +34,10 @@ import ThanksModal from 'my-sites/themes/thanks-modal';
 import QueryActiveTheme from 'components/data/query-active-theme';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QueryUserPurchases from 'components/data/query-user-purchases';
+import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemesSiteSelectorModal from 'my-sites/themes/themes-site-selector-modal';
 import { connectOptions } from 'my-sites/themes/theme-options';
-import { isThemeActive, getThemeRequestErrors } from 'state/themes/selectors';
+import { isThemeActive, isThemePurchased, getThemeRequestErrors } from 'state/themes/selectors';
 import { getBackPath } from 'state/themes/themes-ui/selectors';
 import EmptyContentComponent from 'components/empty-content';
 import ThemePreview from 'my-sites/themes/theme-preview';
@@ -45,6 +46,8 @@ import DocumentHead from 'components/data/document-head';
 import { decodeEntities } from 'lib/formatting';
 import { getTheme } from 'state/themes/selectors';
 import { isValidTerm } from 'my-sites/themes/theme-filters';
+import { hasFeature } from 'state/sites/plans/selectors';
+import { FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
 
 const ThemeSheet = React.createClass( {
 	displayName: 'ThemeSheet',
@@ -65,6 +68,7 @@ const ThemeSheet = React.createClass( {
 		// Connected props
 		isLoggedIn: React.PropTypes.bool,
 		isActive: React.PropTypes.bool,
+		isPurchased: React.PropTypes.bool,
 		selectedSite: React.PropTypes.object,
 		siteSlug: React.PropTypes.string,
 		backPath: React.PropTypes.string,
@@ -321,9 +325,9 @@ const ThemeSheet = React.createClass( {
 	},
 
 	getDefaultOptionLabel() {
-		const { defaultOption, isActive, isLoggedIn, price } = this.props;
+		const { defaultOption, isActive, isLoggedIn, isPurchased } = this.props;
 		if ( isLoggedIn && ! isActive ) {
-			if ( price ) { // purchase
+			if ( isPremium( this.props ) && ! isPurchased ) { // purchase
 				return i18n.translate( 'Pick this design' );
 			} // else: activate
 			return i18n.translate( 'Activate this design' );
@@ -375,7 +379,7 @@ const ThemeSheet = React.createClass( {
 
 	renderPrice() {
 		let price = this.props.price;
-		if ( ! this.isLoaded() || this.props.isActive ) {
+		if ( ! this.isLoaded() || this.props.isActive || this.props.isPurchased ) {
 			price = '';
 		} else if ( ! isPremium( this.props ) ) {
 			price = i18n.translate( 'Free' );
@@ -432,6 +436,7 @@ const ThemeSheet = React.createClass( {
 			<Main className="theme__sheet">
 				<QueryTheme themeId={ this.props.id } siteId={ siteIdOrWpcom } />
 				{ currentUserId && <QueryUserPurchases userId={ currentUserId } /> }
+				{ siteID && <QuerySitePurchases siteId={ siteID } /> }
 				{ siteID && <QuerySitePlans siteId={ siteID } /> }
 				<DocumentHead
 					title={ title }
@@ -489,7 +494,7 @@ const ConnectedThemeSheet = connectOptions(
 );
 
 const ThemeSheetWithOptions = ( props ) => {
-	const { selectedSite: site, isActive, price, isLoggedIn } = props;
+	const { selectedSite: site, isActive, isLoggedIn, isPurchased } = props;
 	const siteId = site ? site.ID : null;
 
 	let defaultOption;
@@ -498,7 +503,7 @@ const ThemeSheetWithOptions = ( props ) => {
 		defaultOption = 'signup';
 	} else if ( isActive ) {
 		defaultOption = 'customize';
-	} else if ( price ) {
+	} else if ( isPremium( props ) && ! isPurchased ) {
 		defaultOption = 'purchase';
 	} else {
 		defaultOption = 'activate';
@@ -583,7 +588,11 @@ export default connect(
 			currentUserId,
 			isCurrentUserPaid,
 			isLoggedIn: !! currentUserId,
-			isActive: selectedSite && isThemeActive( state, id, selectedSite.ID )
+			isActive: selectedSite && isThemeActive( state, id, selectedSite.ID ),
+			isPurchased: selectedSite && (
+				isThemePurchased( state, id, selectedSite.ID ) ||
+				hasFeature( state, selectedSite.ID, FEATURE_UNLIMITED_PREMIUM_THEMES )
+			),
 		};
 	}
 )( ThemeSheetWithOptions );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -526,7 +526,7 @@ const ThemeSheetWithOptions = ( props ) => {
 	);
 };
 
-const getThemeDerailsFromTheme = ( theme ) => {
+const getThemeDetailsFromTheme = ( theme ) => {
 	return {
 		name: theme.name,
 		author: theme.author,
@@ -576,7 +576,7 @@ export default connect(
 		const isCurrentUserPaid = isUserPaid( state, currentUserId );
 		const theme = getTheme( state, siteIdOrWpcom, id );
 		const error = theme ? false : getThemeRequestErrors( state, id, siteIdOrWpcom );
-		const themeDetails = theme ? getThemeDerailsFromTheme( theme ) : {};
+		const themeDetails = theme ? getThemeDetailsFromTheme( theme ) : {};
 		return {
 			...themeDetails,
 			id,

--- a/client/my-sites/theme/test/main.jsx
+++ b/client/my-sites/theme/test/main.jsx
@@ -28,6 +28,7 @@ describe( 'main', function() {
 			mockery.registerMock( 'my-sites/themes/thanks-modal', EmptyComponent );
 			mockery.registerMock( 'my-sites/themes/themes-site-selector-modal', EmptyComponent );
 			mockery.registerMock( 'components/data/query-user-purchases', EmptyComponent );
+			mockery.registerMock( 'components/data/query-site-purchases', EmptyComponent );
 			mockery.registerMock( 'lib/analytics', {} );
 			mockery.registerMock( 'my-sites/themes/helpers', {
 				isPremium: noop,


### PR DESCRIPTION
I've missed this occurrence where we were relying on the `theme.price` attribute (which with the old Redux arch would be `undefined` if a user had already purchased the theme, or if the site had a business upgrade that included unlimited premium themes). The fix is to use the new `isThemePurchased` and `hasFeature( ..., FEATURE_UNLIMITED_PREMIUM_THEMES )` selectors.

To test:
* Try theme sheet in single and multi-site modes:
  * Verify that on a site with a business plan, the primary CTA activates the selected theme. Furthermore, no price should be displayed on the CTA button.
  * Same on a site without a business plan
     * with a purchased premium theme.
     * with a free theme.
 * On a site with no business plan, the primary CTA should purchase the chosen theme. The price should be displayed on the CTA button.

Fixes #9844