### PR TITLE
GuidedTours: rename selectors and add dependency comments

### DIFF
--- a/client/layout/guided-tours/main-tour.js
+++ b/client/layout/guided-tours/main-tour.js
@@ -1,7 +1,13 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
 import { translate } from 'i18n-calypso';
 import { overEvery as and } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
 import {
 	makeTour,
 	Tour,

--- a/client/layout/guided-tours/main-tour.js
+++ b/client/layout/guided-tours/main-tour.js
@@ -21,10 +21,10 @@ import {
 import {
 	isNewUser,
 	isEnabled,
-	selectedSiteIsPreviewable,
-	selectedSiteIsCustomizable,
-	previewIsNotShowing,
-	previewIsShowing,
+	isSelectedSitePreviewable,
+	isSelectedSiteCustomizable,
+	isPreviewNotShowing,
+	isPreviewShowing,
 } from 'state/ui/guided-tours/contexts';
 import { getScrollableSidebar } from 'layout/guided-tours/positioning';
 import scrollTo from 'lib/scroll-to';
@@ -89,7 +89,7 @@ export const MainTour = makeTour(
 			target="site-card-preview"
 			arrow="top-left"
 			placement="below"
-			when={ selectedSiteIsPreviewable }
+			when={ isSelectedSitePreviewable }
 			scrollContainer=".sidebar__region"
 		>
 			<p>
@@ -114,7 +114,7 @@ export const MainTour = makeTour(
 
 		<Step name="in-preview"
 			placement="center"
-			when={ selectedSiteIsPreviewable }
+			when={ isSelectedSitePreviewable }
 		>
 			<p>
 				{
@@ -128,7 +128,7 @@ export const MainTour = makeTour(
 			<ButtonRow>
 				<Next step="close-preview" />
 				<Quit />
-				<Continue hidden step="close-preview" when={ previewIsNotShowing } />
+				<Continue hidden step="close-preview" when={ isPreviewNotShowing } />
 			</ButtonRow>
 		</Step>
 
@@ -136,19 +136,19 @@ export const MainTour = makeTour(
 			target="web-preview__close"
 			arrow="left-top"
 			placement="beside"
-			when={ and( selectedSiteIsPreviewable, previewIsShowing ) }
+			when={ and( isSelectedSitePreviewable, isPreviewShowing ) }
 		>
 			<p>
 				{ translate( 'Take a look at your site — and then close the site preview. You can come back here anytime.' ) }
 			</p>
-			<Continue icon="cross-small" step="themes" target="web-preview__close" when={ previewIsNotShowing } />
+			<Continue icon="cross-small" step="themes" target="web-preview__close" when={ isPreviewNotShowing } />
 		</Step>
 
 		<Step name="themes"
 			target="themes"
 			arrow="top-left"
 			placement="below"
-			when={ selectedSiteIsCustomizable }
+			when={ isSelectedSiteCustomizable }
 			scrollContainer=".sidebar__region"
 			shouldScrollTo
 		>

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import config from 'config';
 import { getSectionName, isPreviewShowing, getSelectedSite } from 'state/ui/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import config from 'config';
-import { getSectionName, isPreviewShowing, getSelectedSite } from 'state/ui/selectors';
+import { getSectionName, isPreviewShowing as isPreviewShowingSelector, getSelectedSite } from 'state/ui/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { abtest } from 'lib/abtest';
 
@@ -12,11 +12,11 @@ export const inSection = sectionName => state =>
 export const isEnabled = feature => () =>
 	config.isEnabled( feature );
 
-export const previewIsNotShowing = state =>
-	! isPreviewShowing( state );
+export const isPreviewNotShowing = state =>
+	! isPreviewShowingSelector( state );
 
-export const previewIsShowing = state =>
-	isPreviewShowing( state );
+export const isPreviewShowing = state =>
+	isPreviewShowingSelector( state );
 
 const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
 export const isNewUser = state => {
@@ -29,10 +29,10 @@ export const isNewUser = state => {
 	return ( Date.now() - creation ) <= WEEK_IN_MILLISECONDS;
 };
 
-export const selectedSiteIsPreviewable = state =>
+export const isSelectedSitePreviewable = state =>
 	getSelectedSite( state ) && getSelectedSite( state ).is_previewable;
 
-export const selectedSiteIsCustomizable = state =>
+export const isSelectedSiteCustomizable = state =>
 	getSelectedSite( state ) && getSelectedSite( state ).is_customizable;
 
 export const isAbTestInVariant = ( testName, variant ) => () =>


### PR DESCRIPTION
This PR renames a few selectors from Guided Tours to make their type a bit more obvious. It also adds a few missing dependency comments. 

To test:
- test that the main tour at http://calypso.localhost:3000/?tour=main still works