### PR TITLE
Components: Use resizeImageUrl utility for site icon resizing

### DIFF
--- a/client/components/site-icon/index.jsx
+++ b/client/components/site-icon/index.jsx
@@ -3,13 +3,15 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import url from 'url';
+import { includes } from 'lodash';
+import { parse as parseUrl } from 'url';
 import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import { getSite } from 'state/sites/selectors';
+import resizeImageUrl from 'lib/resize-image-url';
 import Gridicon from 'components/gridicon';
 
 const SiteIcon = React.createClass( {
@@ -29,27 +31,20 @@ const SiteIcon = React.createClass( {
 		size: React.PropTypes.number
 	},
 
-	imgSizeParam( host ) {
-		return host && host.indexOf( 'gravatar.com' ) === -1 ? 'w' : 's';
-	},
+	getIconSrcUrl( imageUrl ) {
+		const { host } = parseUrl( imageUrl, true, true );
+		const sizeParam = includes( host, 'gravatar.com' ) ? 's' : 'w';
 
-	getIconSrcURL( imgURL ) {
-		var parsed = url.parse( imgURL, true, true ),
-			sizeParam = this.imgSizeParam( parsed.host );
-
-		parsed.query[sizeParam] = this.props.imgSize;
-
-		// Use query param to set retina size: we use the same
-		// size everyhere, even if the intended display size is
-		// a bit smaller, to keep just one cached image per site.
-		return url.format( parsed );
+		return resizeImageUrl( imageUrl, {
+			[ sizeParam ]: this.props.imgSize
+		} );
 	},
 
 	render() {
 		var iconSrc, iconClasses, style;
 
 		// Set the site icon path if it's available
-		iconSrc = ( this.props.site && this.props.site.icon ) ? this.getIconSrcURL( this.props.site.icon.img ) : null;
+		iconSrc = ( this.props.site && this.props.site.icon ) ? this.getIconSrcUrl( this.props.site.icon.img ) : null;
 
 		iconClasses = classNames( {
 			'site-icon': true,

--- a/client/lib/resize-image-url/README.md
+++ b/client/lib/resize-image-url/README.md
@@ -1,12 +1,18 @@
 # Resize Image URL
 
-A simple utility to modify the sizing params on a "safe" URL (something that has been passed through `safe-image-url`)
-without changing the path or host.
+A simple utility to modify the sizing params on a URL without changing the path
+or host.
 
-## Example
+## Usage
+
+Pass a URL and object of resizing parameters to the function. The return value
+reflects the resized image URL. The function supports WordPress.com, Photon,
+and Gravatar image URLs.
+
 ```js
-var image = safeImageUrl( post.featured_image),
-  imageThumb = resizeImageUrl( safeImageUrl, { resize: '40,40' } );
+resizeImageUrl( 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?w=1000', { resize: '500,500' } );
+// https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?resize=500%2C500
 ```
 
-It takes the standard set of Photon parameters and removes any sizing params already present.
+Reference the [Photon API documentation](https://developer.wordpress.com/docs/photon/api/)
+for supported parameters to be passed.

--- a/client/lib/resize-image-url/test/index.js
+++ b/client/lib/resize-image-url/test/index.js
@@ -1,29 +1,92 @@
-// External Dependencies
-var assert = require( 'chai' ).assert;
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
 
-var resizeImageUrl = require( '..' ),
-	safeImageUrl = 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?w=1000&h=1000';
+describe( 'resizeImageUrl()', () => {
+	const imageUrl = 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?w=1000&h=1000&resize=foo&fit=meh';
 
-// helper functions
-describe( 'index', function() {
-	it( 'should strip the w and h query params', function() {
-		var resizedImageUrl = resizeImageUrl( safeImageUrl );
-		assert.equal( resizedImageUrl, 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg' );
+	let resizeImageUrl;
+	before( () => {
+		resizeImageUrl = require( '..' );
 	} );
 
-	it( 'should delete the resize & fit query params', function() {
-		var resizedImageUrl = resizeImageUrl( safeImageUrl + '&resize=foo&fit=meh' );
-		assert.equal( resizedImageUrl, 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg' );
+	it( 'should strip original query params', () => {
+		const resizedUrl = resizeImageUrl( imageUrl );
+		expect( resizedUrl ).to.equal( 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg' );
 	} );
 
-	it( 'should append optional resize arguments', function() {
-		var resizedImageUrl = resizeImageUrl( safeImageUrl, { resize: '40,40' } );
-		assert.equal( resizedImageUrl, 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?resize=40%2C40' );
+	it( 'should not attempt to resize non-HTTP protocols', () => {
+		const blobImageUrl = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+		const resizedUrl = resizeImageUrl( blobImageUrl, { resize: '40,40' } );
+		expect( resizedUrl ).to.equal( blobImageUrl );
 	} );
 
-	it( 'should not attempt to resize non-HTTP protocols', function() {
-		var imageUrl = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-		var resizedImageUrl = resizeImageUrl( imageUrl, { resize: '40,40' } );
-		assert.equal( resizedImageUrl, imageUrl );
+	it( 'should allow arguments to be specified as strings', () => {
+		const resizedUrl = resizeImageUrl( imageUrl, { w: '40' } );
+		expect( resizedUrl ).to.equal( 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?w=40' );
+	} );
+
+	it( 'should preserve unrelated query arguments', () => {
+		const gravatarUrl = 'https://gravatar.com/avatar/00000000000000000000000000000000?d=https%3A%2F%2Fexample.com%2Favatar.jpg';
+		const resizedUrl = resizeImageUrl( gravatarUrl, { s: '40' } );
+		const expectedUrl = 'https://gravatar.com/avatar/00000000000000000000000000000000?d=https%3A%2F%2Fexample.com%2Favatar.jpg&s=40';
+		expect( resizedUrl ).to.equal( expectedUrl );
+	} );
+
+	context( 'standard pixel density', () => {
+		it( 'should append resize argument', () => {
+			const resizedUrl = resizeImageUrl( imageUrl, { resize: '40,40' } );
+			expect( resizedUrl ).to.equal( 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?resize=40%2C40' );
+		} );
+
+		it( 'should append fit argument', () => {
+			const resizedUrl = resizeImageUrl( imageUrl, { fit: '40,40' } );
+			expect( resizedUrl ).to.equal( 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?fit=40%2C40' );
+		} );
+
+		it( 'should append w argument', () => {
+			const resizedUrl = resizeImageUrl( imageUrl, { w: 40 } );
+			expect( resizedUrl ).to.equal( 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?w=40' );
+		} );
+
+		it( 'should append s argument', () => {
+			const resizedUrl = resizeImageUrl( imageUrl, { s: 200 } );
+			expect( resizedUrl ).to.equal( 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?s=200' );
+		} );
+	} );
+
+	context( 'high pixel density', () => {
+		before( () => {
+			global.window = { devicePixelRatio: 2 };
+			delete require.cache[ require.resolve( '..' ) ];
+			resizeImageUrl = require( '..' );
+		} );
+
+		after( () => {
+			delete global.window;
+			delete require.cache[ require.resolve( '..' ) ];
+			resizeImageUrl = require( '..' );
+		} );
+
+		it( 'should append resize argument', () => {
+			const resizedUrl = resizeImageUrl( imageUrl, { resize: '40,40' } );
+			expect( resizedUrl ).to.equal( 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?resize=80%2C80' );
+		} );
+
+		it( 'should append fit argument', () => {
+			const resizedUrl = resizeImageUrl( imageUrl, { fit: '40,40' } );
+			expect( resizedUrl ).to.equal( 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?fit=80%2C80' );
+		} );
+
+		it( 'should append w argument', () => {
+			const resizedUrl = resizeImageUrl( imageUrl, { w: 40 } );
+			expect( resizedUrl ).to.equal( 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?w=80' );
+		} );
+
+		it( 'should append s argument', () => {
+			const resizedUrl = resizeImageUrl( imageUrl, { s: 200 } );
+			expect( resizedUrl ).to.equal( 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?s=400' );
+		} );
 	} );
 } );


### PR DESCRIPTION
Related: #9776

This pull request seeks to resolve an issue observed in #9776 where the `<SiteIcon />` component attempts to apply resizing parameters to a local file URL, resulting in it now being shown. The changes here update the `<SiteIcon />` component to instead use the common `resizeImageUrl` utility function. In doing so, the utility needed to be updated to support the Gravatar `s` query parameter. In addition to avoiding resizing of invalid URLs, using the utility also allows a 2x multiplier to be applied for site icons on high pixel-density ("retina") displays.

__Implementation notes:__

In the course of implementing this, `resizeImageUrl` was significantly refactored, including improved comments, documentation, tests, and consolidated logic for applying the image size multiplier to sizing parameters.

__Testing instructions:__

Observe that there are no regressions in [`resizeImageUrl` usage](https://github.com/Automattic/wp-calypso/search?utf8=%E2%9C%93&q=resizeimageurl), particularly related to the `<SiteIcon />` component. Confirm that your sites list continues to display the correct site icons, in high pixel-density sizing if applicable.

1. Navigate to My Sites.
2. Note that current site in sidebar has correct image (test against both Jetpack and WordPress.com sites)