### PR TITLE
Themes: Filter Jetpack Results for Search String

### DIFF
--- a/client/lib/query-manager/theme/index.js
+++ b/client/lib/query-manager/theme/index.js
@@ -1,74 +1,16 @@
 /**
- * External dependencies
- */
-import { every, some, includes } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import PaginatedQueryManager from '../paginated';
 import ThemeQueryKey from './key';
-import { isPremium } from './util';
+import { matchThemeByQuery } from './util';
 import { DEFAULT_THEME_QUERY } from './constants';
-
-const SEARCH_TAXONOMIES = [ 'subject', 'feature', 'color', 'style', 'column', 'layout' ];
 
 /**
  * ThemeQueryManager manages themes which can be queried
  */
 export default class ThemeQueryManager extends PaginatedQueryManager {
-	/**
-	 * Returns true if the theme matches the given query, or false otherwise.
-	 *
-	 * @param  {Object}  query Query object
-	 * @param  {Object}  theme Item to consider
-	 * @return {Boolean}       Whether theme matches query
-	 */
-
-	matches( query, theme ) {
-		const queryWithDefaults = { ...DEFAULT_THEME_QUERY, ...query };
-		return every( queryWithDefaults, ( value, key ) => {
-			switch ( key ) {
-				case 'search':
-					if ( ! value ) {
-						return true;
-					}
-
-					const search = value.toLowerCase();
-
-					const foundInTaxonomies = some( SEARCH_TAXONOMIES, ( taxonomy ) => (
-						theme.taxonomies && some( theme.taxonomies[ 'theme_' + taxonomy ], ( { name } ) => (
-							includes( name.toLowerCase(), search )
-						) )
-					) );
-
-					return foundInTaxonomies || (
-						( theme.name && includes( theme.name.toLowerCase(), search ) ) ||
-						( theme.author && includes( theme.author.toLowerCase(), search ) ) ||
-						( theme.descriptionLong && includes( theme.descriptionLong.toLowerCase(), search ) )
-					);
-
-				case 'filters':
-					// TODO: Change filters object shape to be more like post's terms, i.e.
-					// { color: 'blue,red', feature: 'post-slider' }
-					const filters = value.split( ',' );
-					return every( filters, ( filter ) => (
-						some( theme.taxonomies, ( terms ) => (
-							some( terms, { slug: filter } )
-						) )
-					) );
-
-				case 'tier':
-					if ( ! value ) {
-						return true;
-					}
-					const queryingForPremium = value === 'premium';
-					return queryingForPremium === isPremium( theme );
-			}
-
-			return true;
-		} );
-	}
+	matches = matchThemeByQuery;
 }
 
 ThemeQueryManager.QueryKey = ThemeQueryKey;

--- a/client/lib/query-manager/theme/index.js
+++ b/client/lib/query-manager/theme/index.js
@@ -3,14 +3,14 @@
  */
 import PaginatedQueryManager from '../paginated';
 import ThemeQueryKey from './key';
-import { matchThemeByQuery } from './util';
+import { isThemeMatchingQuery } from './util';
 import { DEFAULT_THEME_QUERY } from './constants';
 
 /**
  * ThemeQueryManager manages themes which can be queried
  */
 export default class ThemeQueryManager extends PaginatedQueryManager {
-	matches = matchThemeByQuery;
+	matches = isThemeMatchingQuery;
 }
 
 ThemeQueryManager.QueryKey = ThemeQueryKey;

--- a/client/lib/query-manager/theme/util.js
+++ b/client/lib/query-manager/theme/util.js
@@ -1,8 +1,14 @@
 /**
  * External dependencies
  */
-import { get, startsWith } from 'lodash';
+import { get, startsWith, every, some, includes } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_THEME_QUERY } from './constants';
+
+const SEARCH_TAXONOMIES = [ 'subject', 'feature', 'color', 'style', 'column', 'layout' ];
 /**
  * Whether a given theme object is premium.
  *
@@ -12,4 +18,57 @@ import { get, startsWith } from 'lodash';
 export function isPremium( theme ) {
 	const themeStylesheet = get( theme, 'stylesheet', false );
 	return themeStylesheet && startsWith( themeStylesheet, 'premium/' );
+}
+
+/**
+ * Returns true if the theme matches the given query, or false otherwise.
+ *
+ * @param  {Object}  query Query object
+ * @param  {Object}  theme Item to consider
+ * @return {Boolean}       Whether theme matches query
+ */
+
+export function matchThemeByQuery( query, theme ) {
+	const queryWithDefaults = { ...DEFAULT_THEME_QUERY, ...query };
+	return every( queryWithDefaults, ( value, key ) => {
+		switch ( key ) {
+			case 'search':
+				if ( ! value ) {
+					return true;
+				}
+
+				const search = value.toLowerCase();
+
+				const foundInTaxonomies = some( SEARCH_TAXONOMIES, ( taxonomy ) => (
+					theme.taxonomies && some( theme.taxonomies[ 'theme_' + taxonomy ], ( { name } ) => (
+						includes( name.toLowerCase(), search )
+					) )
+				) );
+
+				return foundInTaxonomies || (
+					( theme.name && includes( theme.name.toLowerCase(), search ) ) ||
+					( theme.author && includes( theme.author.toLowerCase(), search ) ) ||
+					( theme.descriptionLong && includes( theme.descriptionLong.toLowerCase(), search ) )
+				);
+
+			case 'filters':
+				// TODO: Change filters object shape to be more like post's terms, i.e.
+				// { color: 'blue,red', feature: 'post-slider' }
+				const filters = value.split( ',' );
+				return every( filters, ( filter ) => (
+					some( theme.taxonomies, ( terms ) => (
+						some( terms, { slug: filter } )
+					) )
+				) );
+
+			case 'tier':
+				if ( ! value ) {
+					return true;
+				}
+				const queryingForPremium = value === 'premium';
+				return queryingForPremium === isPremium( theme );
+		}
+
+		return true;
+	} );
 }

--- a/client/lib/query-manager/theme/util.js
+++ b/client/lib/query-manager/theme/util.js
@@ -27,7 +27,6 @@ export function isPremium( theme ) {
  * @param  {Object}  theme Item to consider
  * @return {Boolean}       Whether theme matches query
  */
-
 export function isThemeMatchingQuery( query, theme ) {
 	const queryWithDefaults = { ...DEFAULT_THEME_QUERY, ...query };
 	return every( queryWithDefaults, ( value, key ) => {

--- a/client/lib/query-manager/theme/util.js
+++ b/client/lib/query-manager/theme/util.js
@@ -28,7 +28,7 @@ export function isPremium( theme ) {
  * @return {Boolean}       Whether theme matches query
  */
 
-export function matchThemeByQuery( query, theme ) {
+export function isThemeMatchingQuery( query, theme ) {
 	const queryWithDefaults = { ...DEFAULT_THEME_QUERY, ...query };
 	return every( queryWithDefaults, ( value, key ) => {
 		switch ( key ) {

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -44,7 +44,7 @@ import { isJetpackSite } from 'state/sites/selectors';
 import { getActiveTheme } from './selectors';
 import { getQueryParams } from './themes-list/selectors';
 import { getThemeIdFromStylesheet } from './utils';
-import { matchThemeByQuery } from 'lib/query-manager/theme/util';
+import { isThemeMatchingQuery } from 'lib/query-manager/theme/util';
 
 const debug = debugFactory( 'calypso:themes:actions' ); //eslint-disable-line no-unused-vars
 
@@ -205,14 +205,14 @@ export function requestThemes( siteId, query = {} ) {
 		} );
 
 		function filterThemesForJetpack( themes, query ) {
-			return filter( themes, theme => matchThemeByQuery( theme, query ) );
+			return filter( themes, theme => isThemeMatchingQuery( theme, query ) );
 		}
 
 		return wpcom.undocumented().themes( siteIdToQuery, queryWithApiVersion ).then( ( { found, themes } ) => {
 			dispatch( receiveThemes( themes, siteId ) );
 
 			let filteredThemes = themes;
-			if ( siteIdToQuery ) {
+			if ( siteId !== 'wpcom' ) {
 				filteredThemes = filterThemesForJetpack( themes, query );
 			}
 

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { conforms, filter, omit, property } from 'lodash';
+import { conforms, omit, property } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -43,8 +43,7 @@ import {
 import { isJetpackSite } from 'state/sites/selectors';
 import { getActiveTheme } from './selectors';
 import { getQueryParams } from './themes-list/selectors';
-import { getThemeIdFromStylesheet } from './utils';
-import { isThemeMatchingQuery } from 'lib/query-manager/theme/util';
+import { getThemeIdFromStylesheet, filterThemesForJetpack } from './utils';
 
 const debug = debugFactory( 'calypso:themes:actions' ); //eslint-disable-line no-unused-vars
 
@@ -203,10 +202,6 @@ export function requestThemes( siteId, query = {} ) {
 			siteId,
 			query
 		} );
-
-		function filterThemesForJetpack( themes, query ) {
-			return filter( themes, theme => isThemeMatchingQuery( theme, query ) );
-		}
 
 		return wpcom.undocumented().themes( siteIdToQuery, queryWithApiVersion ).then( ( { found, themes } ) => {
 			dispatch( receiveThemes( themes, siteId ) );

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -187,7 +187,7 @@ export function receiveThemes( themes, siteId ) {
  * @return {Function}             Action thunk
  */
 export function requestThemes( siteId, query = {} ) {
-	return ( dispatch, getState ) => {
+	return ( dispatch ) => {
 		let siteIdToQuery, queryWithApiVersion;
 
 		if ( siteId === 'wpcom' ) {
@@ -197,8 +197,6 @@ export function requestThemes( siteId, query = {} ) {
 			siteIdToQuery = siteId;
 			queryWithApiVersion = { ...query, apiVersion: '1' };
 		}
-
-		const isJetpack = isJetpackSite( getState(), siteId );
 
 		dispatch( {
 			type: THEMES_REQUEST,
@@ -214,7 +212,7 @@ export function requestThemes( siteId, query = {} ) {
 			dispatch( receiveThemes( themes, siteId ) );
 
 			let filteredThemes = themes;
-			if ( isJetpack ) {
+			if ( siteIdToQuery ) {
 				filteredThemes = filterThemesForJetpack( themes, query );
 			}
 

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -2,11 +2,12 @@
  * External dependencies
  */
 import startsWith from 'lodash/startsWith';
-import { omit, omitBy, split } from 'lodash';
+import { filter, omit, omitBy, split } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import { isThemeMatchingQuery } from 'lib/query-manager/theme/util';
 import { DEFAULT_THEME_QUERY } from './constants';
 
 /**
@@ -109,4 +110,16 @@ export function isPremiumTheme( theme ) {
 	// contains the correct price even if the user has already purchased that
 	// theme, or if they have an upgrade that includes all premium themes).
 	return !! ( theme.cost && theme.cost.number );
+}
+
+/**
+ * Returns a filtered themes array. Filtering is done based particular themes
+ * matching provided query
+ *
+ * @param  {Array}  themes Array of themes objects
+ * @param  {Object} query  Themes query
+ * @return {String}        Serialized themes query
+ */
+export function filterThemesForJetpack( themes, query ) {
+	return filter( themes, theme => isThemeMatchingQuery( theme, query ) );
 }

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -113,12 +113,12 @@ export function isPremiumTheme( theme ) {
 }
 
 /**
- * Returns a filtered themes array. Filtering is done based particular themes
+ * Returns a filtered themes array. Filtering is done based on particular themes
  * matching provided query
  *
  * @param  {Array}  themes Array of themes objects
  * @param  {Object} query  Themes query
- * @return {String}        Serialized themes query
+ * @return {Array}         Filtered themes
  */
 export function filterThemesForJetpack( themes, query ) {
 	return filter( themes, theme => isThemeMatchingQuery( theme, query ) );


### PR DESCRIPTION
### Intro
From #9673:

> For the new Themes Redux architecture, we still need to filter results from Jetpack sites. This is necessary because the /sites/<jetpacksite/themes endpoint that our requestThemes actions (and thus, our <QueryThemes /> component) uses returns unfiltered results (i.e. ignores the query object) -- in contrast to the WPCOM specific one.

### Testing
Define testing!
1.  Make sure that `ThemeQueryManager` still works

### TODO 

- [ ] check regression, especially `ThemeQueryManager`
- [ ] add jetpress specific tests for filtering
- [ ] verify that filtering works
Why not create test first? Because this bases on already created `match` function so basically code is written.

### Reference
This PR fixes #9673