### PR TITLE
Reader: Removes content in tables from the better excerpt

### DIFF
--- a/client/lib/post-normalizer/rule-create-better-excerpt-refresh.js
+++ b/client/lib/post-normalizer/rule-create-better-excerpt-refresh.js
@@ -22,7 +22,7 @@ export function formatExcerpt( content ) {
 
 	// Ditch any photo captions with the wp-caption-text class, styles, scripts
 	forEach(
-		dom.querySelectorAll( '.wp-caption-text, style, script, blockquote[class^="instagram-"], figure' ),
+		dom.querySelectorAll( '.wp-caption-text, style, script, blockquote[class^="instagram-"], figure, table' ),
 		removeElement
 	);
 

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -959,5 +959,9 @@ describe( 'index', function() {
 		it( 'trims whitespace from the excerpt', function( done ) {
 			assertExcerptBecomes( '<p> </p><p>one</p><p>two</p><p>three</p><p>four</p><p> </p>', 'one two three four', done );
 		} );
+
+		it( 'removes tables from the content', function( done ) {
+			assertExcerptBecomes( '<p>test</p><table><tr><td>in a table</td></tr></table><p>more</p>', 'test more', done );
+		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #9768 

`npm run test-client` should pass. 

