### PR TITLE
state/themes/selectors: Add getThemeForumUrl() selector

### DIFF
--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -407,6 +407,21 @@ export function getThemeSignupUrl( state, theme ) {
 }
 
 /**
+ * Returns the URL for a premium theme's dedicated forum, or for the general themes
+ * forum for a free theme.
+ *
+ * @param  {Object}  state   Global state tree
+ * @param  {String}  themeId Theme ID
+ * @return {?String}         Theme forum URL
+ */
+export function getThemeForumUrl( state, themeId ) {
+	if ( isThemePremium( state, themeId ) ) {
+		return '//premium-themes.forums.wordpress.com/forum/' + themeId;
+	}
+	return '//en.forums.wordpress.com/forum/themes';
+}
+
+/**
  * Returns the currently active theme on a given site.
  *
  * This selector previously worked using data from sites subtree.

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -26,6 +26,7 @@ import {
 	getThemePurchaseUrl,
 	getThemeCustomizeUrl,
 	getThemeSignupUrl,
+	getThemeForumUrl,
 	getActiveTheme,
 	isRequestingActiveTheme,
 	isThemeActive,
@@ -1034,6 +1035,42 @@ describe( 'themes selectors', () => {
 			} );
 
 			expect( signupUrl ).to.equal( '/start/with-theme?ref=calypshowcase&theme=mood&premium=true' );
+		} );
+	} );
+
+	describe( '#getThemeForumUrl', () => {
+		it( 'given a free theme, should return the general themes forum URL', () => {
+			const forumUrl = getThemeForumUrl(
+				{
+					themes: {
+						queries: {
+							wpcom: new ThemeQueryManager( {
+								items: { twentysixteen }
+							} )
+						}
+					}
+				},
+				'twentysixteen'
+			);
+
+			expect( forumUrl ).to.equal( '//en.forums.wordpress.com/forum/themes' );
+		} );
+
+		it( 'given a premium theme, should return the specific theme forum URL', () => {
+			const forumUrl = getThemeForumUrl(
+				{
+					themes: {
+						queries: {
+							wpcom: new ThemeQueryManager( {
+								items: { mood }
+							} )
+						}
+					}
+				},
+				'mood'
+			);
+
+			expect( forumUrl ).to.equal( '//premium-themes.forums.wordpress.com/forum/mood' );
 		} );
 	} );
 


### PR DESCRIPTION
Will replace the old `getForumUrl()` helper. Not yet wired, so only covered by unit tests. Will be wired by #8785.