### PR TITLE
Reader Refresh: No longer reload tag page if already on the right one

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -103,10 +103,13 @@ export const ReaderSidebar = React.createClass( {
 	},
 
 	highlightNewTag( tag ) {
-		defer( function() {
-			page( '/tag/' + tag.slug );
-			window.scrollTo( 0, 0 );
-		} );
+		const tagUrl = `/tag/${ tag.slug }`;
+		if ( tagUrl !== page.current ) {
+			defer( function() {
+				page( tagUrl );
+				window.scrollTo( 0, 0 );
+			} );
+		}
 	},
 
 	openExpandableMenuForCurrentTagOrList() {


### PR DESCRIPTION
Really nice description of what this fixes: #9727 

There were two options for fixing this:
  1. don't redirect to the when adding new tags to the tagstore.  The desire to redirect should be explicit not implicit
  2. before redirecting check to see if it is the same url and then ignore if so

Initially I believed that 1. would be cleaner (and ideally it would be).   Currently though the sidebar also expects a redirect on tagFollow without explicitly making any other calls.  Didn't want to drop down a rabbit hole and I figured the best time to clean would be when reduxifying!

because of the above thinking: I went with option 2

To test:
 - [x] add tags from sidebar - expect to redirect to tag page
 - [x] add tags from a tag page - expect to stay put
 - [x] add tags from other places? ( is this possible ). ❓ 
 - [x] test out pre-refresh.