### PR TITLE
Reader: add referral post to full post view

### DIFF
--- a/client/blocks/reader-full-post/README.md
+++ b/client/blocks/reader-full-post/README.md
@@ -11,7 +11,6 @@ The "new" reader full post component
 - `onPostNotFound` : A Post not found handler function
 
 *optional*
-- `context`: The `page` controller context
 - `referral`: An object containing a `blogId` and `postId`
 
 ### Referral

--- a/client/blocks/reader-full-post/README.md
+++ b/client/blocks/reader-full-post/README.md
@@ -16,4 +16,4 @@ The "new" reader full post component
 
 ### Referral
 
-The referral object can be used to link the full post view to it's source card in a reader stream. The current usage is to link discover pick cards to the full post view.
+The referral object can be used to link the full post view to its source card in a reader stream. The current usage is to link discover pick cards to the full post view.

--- a/client/blocks/reader-full-post/README.md
+++ b/client/blocks/reader-full-post/README.md
@@ -1,3 +1,19 @@
 # Reader Full Post
 
 The "new" reader full post component
+
+## Props
+
+*required*
+- `blogId`: The blog id for the post
+- `postId`: The post id
+- `onClose`: An onClose event handler function
+- `onPostNotFound` : A Post not found handler function
+
+*optional*
+- `context`: The `page` controller context
+- `referral`: An object containing a `blogId` and `postId`
+
+### Referral
+
+The referral object can be used to link the full post view to it's source card in a reader stream. The current usage is to link discover pick cards to the full post view.

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -14,8 +14,10 @@ import { recordPermalinkClick } from 'reader/stats';
 import PostTime from 'reader/post-time';
 import ReaderFullPostHeaderTags from './header-tags';
 import Gridicon from 'components/gridicon';
+import { isDiscoverPost } from 'reader/discover/helper';
 
-const ReaderFullPostHeader = ( { post } ) => {
+const ReaderFullPostHeader = ( { post, referralPost } ) => {
+
 	const handlePermalinkClick = ( { } ) => {
 		recordPermalinkClick( 'full_post_title', post );
 	};
@@ -29,13 +31,15 @@ const ReaderFullPostHeader = ( { post } ) => {
 		classes[ 'is-missing-title' ] = true;
 	}
 
+	const externalHref = isDiscoverPost( referralPost ) ? referralPost.URL : post.URL;
+
 	/* eslint-disable react/jsx-no-target-blank */
 	return (
 		<div className={ classNames( classes ) }>
 			{ post.title
 				? <AutoDirection>
 					<h1 className="reader-full-post__header-title" onClick={ handlePermalinkClick }>
-						<ExternalLink className="reader-full-post__header-title-link" href={ post.URL } target="_blank" icon={ false }>
+						<ExternalLink className="reader-full-post__header-title-link" href={ externalHref } target="_blank" icon={ false }>
 							{ post.title }
 						</ExternalLink>
 					</h1>
@@ -46,7 +50,7 @@ const ReaderFullPostHeader = ( { post } ) => {
 					? <span className="reader-full-post__header-date">
 						<a className="reader-full-post__header-date-link"
 							onClick={ recordDateClick }
-							href={ post.URL }
+							href={ externalHref }
 							target="_blank"
 							rel="noopener noreferrer">
 							<PostTime date={ post.date } />
@@ -65,7 +69,8 @@ const ReaderFullPostHeader = ( { post } ) => {
 };
 
 ReaderFullPostHeader.propTypes = {
-	post: React.PropTypes.object.isRequired
+	post: React.PropTypes.object.isRequired,
+	referralPost: React.PropTypes.object
 };
 
 export default ReaderFullPostHeader;

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -17,7 +17,6 @@ import Gridicon from 'components/gridicon';
 import { isDiscoverPost } from 'reader/discover/helper';
 
 const ReaderFullPostHeader = ( { post, referralPost } ) => {
-
 	const handlePermalinkClick = ( { } ) => {
 		recordPermalinkClick( 'full_post_title', post );
 	};

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -425,7 +425,6 @@ export default class FullPostFluxContainer extends React.Component {
 		postId: React.PropTypes.string.isRequired,
 		onClose: React.PropTypes.func.isRequired,
 		onPostNotFound: React.PropTypes.func.isRequired,
-		context: React.PropTypes.object,
 		referral: React.PropTypes.object
 	}
 

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -425,7 +425,7 @@ export default class FullPostFluxContainer extends React.Component {
 
 		let referralPost;
 		if ( props.referral ) {
-			referralPost = PostStore.get( props.referral )
+			referralPost = PostStore.get( props.referral );
 			if ( ! referralPost ) {
 				fetchPost( props.referral );
 			}

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -48,7 +48,6 @@ import LikeStore from 'lib/like-store/like-store';
 import FeaturedImage from 'blocks/reader-full-post/featured-image';
 import { getFeed } from 'state/reader/feeds/selectors';
 import { getSite } from 'state/reader/sites/selectors';
-import { getPostBySiteAndId } from 'state/reader/posts/selectors';
 import QueryReaderSite from 'components/data/query-reader-site';
 import QueryReaderFeed from 'components/data/query-reader-feed';
 import ExternalLink from 'components/external-link';
@@ -398,9 +397,6 @@ const ConnectedFullPostView = connect(
 			props.feed = getFeed( state, feedId );
 		}
 
-		if ( ownProps.referral ) {
-			props.referralPost = getPostBySiteAndId( state, ownProps.referral.blogId, ownProps.referral.postId );
-		}
 		return props;
 	},
 	{ setSection }

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -389,7 +389,7 @@ const ConnectedFullPostView = connect(
 			is_external: isExternal
 		} = ownProps.post;
 
-		const props = { };
+		const props = {};
 
 		if ( ! isExternal && siteId ) {
 			props.site = getSite( state, siteId );

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -263,6 +263,8 @@ export class FullPostView extends React.Component {
 			classes[ 'feed-' + post.feed_ID ] = true;
 		}
 
+		const externalHref = isDiscoverPost( referralPost ) ? referralPost.URL : post.URL;
+
 		/*eslint-disable react/no-danger */
 		/*eslint-disable react/jsx-no-target-blank */
 		return (
@@ -275,7 +277,7 @@ export class FullPostView extends React.Component {
 				{ post && ! post.is_external && post.site_ID && <QueryReaderSite siteId={ +post.site_ID } /> }
 				<ReaderFullPostBack onBackClick={ this.handleBack } />
 				<div className="reader-full-post__visit-site-container">
-					<ExternalLink icon={ true } href={ post.URL } onClick={ this.handleVisitSiteClick } target="_blank">
+					<ExternalLink icon={ true } href={ externalHref } onClick={ this.handleVisitSiteClick } target="_blank">
 						<span className="reader-full-post__visit-site-label">{ translate( 'Visit Site' ) }</span>
 					</ExternalLink>
 				</div>

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -71,10 +71,10 @@ export class FullPostView extends React.Component {
 		this.hasScrolledToCommentAnchor = false;
 	}
 
-	static PropTypes = {
+	static propTypes = {
 		post: React.PropTypes.object.isRequired,
 		onClose: React.PropTypes.func.isRequired,
-		referralPost: React.PropTypes.object
+		referralPost: React.PropTypes.object,
 	}
 
 	componentDidMount() {

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -388,7 +388,9 @@ const ConnectedFullPostView = connect(
 			is_external: isExternal
 		} = ownProps.post;
 
-		const props = {};
+		const props = {
+			referral: ownProps.referral
+		};
 
 		if ( ! isExternal && siteId ) {
 			props.site = getSite( state, siteId );
@@ -425,7 +427,8 @@ export default class FullPostFluxContainer extends React.Component {
 		}
 
 		return {
-			post
+			post,
+			referral: props.referral
 		};
 	}
 
@@ -449,7 +452,8 @@ export default class FullPostFluxContainer extends React.Component {
 		return this.state.post
 			? <ConnectedFullPostView
 					onClose={ this.props.onClose }
-					post={ this.state.post } />
+					post={ this.state.post }
+					referral={ this.props.referral } />
 			: null;
 	}
 }

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -71,6 +71,12 @@ export class FullPostView extends React.Component {
 		this.hasScrolledToCommentAnchor = false;
 	}
 
+	static PropTypes = {
+		post: React.PropTypes.object.isRequired,
+		onClose: React.PropTypes.func.isRequired,
+		referralPost: React.PropTypes.object
+	}
+
 	componentDidMount() {
 		KeyboardShortcuts.on( 'close-full-post', this.handleBack );
 		KeyboardShortcuts.on( 'like-selection', this.handleLike );
@@ -412,6 +418,15 @@ export default class FullPostFluxContainer extends React.Component {
 		super( props );
 		this.state = this.getStateFromStores( props );
 		this.smartSetState = smartSetState;
+	}
+
+	static propTypes = {
+		blogId: React.PropTypes.string.isRequired,
+		postId: React.PropTypes.string.isRequired,
+		onClose: React.PropTypes.func.isRequired,
+		onPostNotFound: React.PropTypes.func.isRequired,
+		context: React.PropTypes.object,
+		referral: React.PropTypes.object
 	}
 
 	getStateFromStores( props = this.props ) {

--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -43,13 +43,13 @@ export function getSiteUrl( post ) {
 }
 
 export function hasSource( post ) {
-	return this.isDiscoverPost( post ) && ! this.isDiscoverSitePick( post );
+	return isDiscoverPost( post ) && ! isDiscoverSitePick( post );
 }
 
 export function getSourceData( post ) {
 	const sourceData = get( post, 'discover_metadata.featured_post_wpcom_data' );
 
-	if ( sourceData && ! this.isDiscoverSitePick( post ) ) {
+	if ( sourceData && ! isDiscoverSitePick( post ) ) {
 		return {
 			blogId: get( sourceData, 'blog_id' ),
 			postId: get( sourceData, 'post_id' )

--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -18,6 +18,8 @@ function hasDiscoverSlug( post, searchSlug ) {
 	return !! ( metaData && find( metaData, { slug: searchSlug } ) );
 }
 
+export const discoverBlogId = config( 'discover_blog_id' );
+
 export function isDiscoverEnabled() {
 	return userUtils.getLocaleSlug() === 'en';
 }

--- a/client/reader/full-post/controller.js
+++ b/client/reader/full-post/controller.js
@@ -39,6 +39,10 @@ export function blogPost( context ) {
 		basePath = '/read/blogs/:blog_id/posts/:post_id',
 		fullPageTitle = analyticsPageTitle + ' > Blog Post > ' + blogId + ' > ' + postId;
 
+	let referral;
+	if ( context.query.ref_blog && context.query.ref_post ) {
+		referral = { blogId: context.query.ref_blog, postId: context.query.ref_post };
+	}
 	trackPageLoad( basePath, fullPageTitle, 'full_post' );
 
 	ReactDom.render(
@@ -47,6 +51,7 @@ export function blogPost( context ) {
 				blogId: blogId,
 				postId: postId,
 				context: context,
+				referral: referral,
 				onClose: function() {
 					page.back( context.lastRoute || '/' );
 				},

--- a/client/reader/full-post/controller.js
+++ b/client/reader/full-post/controller.js
@@ -50,7 +50,6 @@ export function blogPost( context ) {
 			React.createElement( ReaderFullPost, {
 				blogId: blogId,
 				postId: postId,
-				context: context,
 				referral: referral,
 				onClose: function() {
 					page.back( context.lastRoute || '/' );

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -444,17 +444,18 @@ export default class ReaderStream extends React.Component {
 		}
 	}
 
-	showFullPost( post, options ) {
-		options = options || {};
-		let hashtag = '';
-		if ( options.comments ) {
-			hashtag += '#comments';
+	showFullPost( post, options = {} ) {
+		const hashtag = options.comments ? '#comments' : '';
+		let query = '';
+		if ( post.referral ) {
+			const { blogId, postId } = post.referral;
+			query = '?ref_blog=' + blogId + '&ref_post=' + postId;
 		}
 		const method = options && options.replaceHistory ? 'replace' : 'show';
 		if ( post.feed_ID && post.feed_item_ID ) {
-			page[ method ]( '/read/feeds/' + post.feed_ID + '/posts/' + post.feed_item_ID + hashtag );
+			page[ method ]( '/read/feeds/' + post.feed_ID + '/posts/' + post.feed_item_ID + hashtag + query );
 		} else {
-			page[ method ]( '/read/blogs/' + post.site_ID + '/posts/' + post.ID + hashtag );
+			page[ method ]( '/read/blogs/' + post.site_ID + '/posts/' + post.ID + hashtag + query );
 		}
 	}
 

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -449,13 +449,13 @@ export default class ReaderStream extends React.Component {
 		let query = '';
 		if ( post.referral ) {
 			const { blogId, postId } = post.referral;
-			query = '?ref_blog=' + blogId + '&ref_post=' + postId;
+			query = `?ref_blog=${ blogId }&ref_post=${ postId }`;
 		}
 		const method = options && options.replaceHistory ? 'replace' : 'show';
 		if ( post.feed_ID && post.feed_item_ID ) {
-			page[ method ]( '/read/feeds/' + post.feed_ID + '/posts/' + post.feed_item_ID + hashtag + query );
+			page[ method ]( `/read/feeds/${ post.feed_ID }/posts/${ post.feed_item_ID }${ hashtag }${ query }` );
 		} else {
-			page[ method ]( '/read/blogs/' + post.site_ID + '/posts/' + post.ID + hashtag + query );
+			page[ method ]( `/read/blogs/${ post.site_ID }/posts/${ post.ID }${ hashtag }${ query }` );
 		}
 	}
 

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -195,11 +195,13 @@ const Post = React.createClass( {
 		let postToOpen = this.props.post;
 		// For Discover posts (but not site picks), open the original post in full post view
 		if ( this.state.originalPost ) {
-			postToOpen = this.state.originalPost;
+			postToOpen = { ...this.state.originalPost };
 
 			if ( postToOpen ) {
-				postToOpen.referral = { blogId: DiscoverHelper.discoverBlogId, postId: this.props.ID }
-
+				postToOpen.referral = {
+					blogId: DiscoverHelper.discoverBlogId,
+					postId: this.props.ID
+				};
 			}
 		}
 

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -199,6 +199,7 @@ const Post = React.createClass( {
 
 			if ( postToOpen ) {
 				postToOpen.referral = { blogId: DiscoverHelper.discoverBlogId, postId: this.props.ID }
+
 			}
 		}
 

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -196,6 +196,10 @@ const Post = React.createClass( {
 		// For Discover posts (but not site picks), open the original post in full post view
 		if ( this.state.originalPost ) {
 			postToOpen = this.state.originalPost;
+
+			if ( postToOpen ) {
+				postToOpen.referral = { blogId: DiscoverHelper.discoverBlogId, postId: this.props.ID }
+			}
 		}
 
 		this.props.handleClick( postToOpen, options );

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -195,14 +195,13 @@ const Post = React.createClass( {
 		let postToOpen = this.props.post;
 		// For Discover posts (but not site picks), open the original post in full post view
 		if ( this.state.originalPost ) {
-			postToOpen = { ...this.state.originalPost };
-
-			if ( postToOpen ) {
-				postToOpen.referral = {
+			postToOpen = {
+				...this.state.originalPost,
+				referral: {
 					blogId: DiscoverHelper.discoverBlogId,
 					postId: this.props.ID
-				};
-			}
+				}
+			};
 		}
 
 		this.props.handleClick( postToOpen, options );

--- a/client/reader/stream/refresh-post.jsx
+++ b/client/reader/stream/refresh-post.jsx
@@ -103,7 +103,7 @@ export default class ReaderPostCardAdapterFluxContainer extends React.Component 
 				postId: post.discover_metadata.featured_post_wpcom_data.post_id
 			} );
 			if ( originalPost ) {
-				originalPost.referral = { blogId: DiscoverHelper.discoverBlogId, postId: post.ID }
+				originalPost.referral = { blogId: DiscoverHelper.discoverBlogId, postId: post.ID };
 			}
 		}
 

--- a/client/reader/stream/refresh-post.jsx
+++ b/client/reader/stream/refresh-post.jsx
@@ -102,6 +102,9 @@ export default class ReaderPostCardAdapterFluxContainer extends React.Component 
 				blogId: post.discover_metadata.featured_post_wpcom_data.blog_id,
 				postId: post.discover_metadata.featured_post_wpcom_data.post_id
 			} );
+			if ( originalPost ) {
+				originalPost.referral = { blogId: DiscoverHelper.discoverBlogId, postId: post.ID }
+			}
 		}
 
 		return {

--- a/client/reader/stream/refresh-post.jsx
+++ b/client/reader/stream/refresh-post.jsx
@@ -26,7 +26,14 @@ import {
 class ReaderPostCardAdapter extends React.Component {
 
 	onClick = ( postToOpen ) => {
-		this.props.handleClick && this.props.handleClick( postToOpen );
+		const propagatePost = { ...postToOpen };
+		if ( isDiscoverPost( this.props.post ) && ! isDiscoverSitePick( this.props.post ) ) {
+			propagatePost.referral = {
+				blogId: discoverBlogId,
+				postId: this.props.post.ID
+			};
+		}
+		this.props.handleClick && this.props.handleClick( propagatePost );
 	}
 
 	onCommentClick = () => {

--- a/client/reader/stream/refresh-post.jsx
+++ b/client/reader/stream/refresh-post.jsx
@@ -27,7 +27,7 @@ class ReaderPostCardAdapter extends React.Component {
 
 	onClick = ( postToOpen ) => {
 		let referredPost;
-		if ( isDiscoverPost( this.props.post ) && ! isDiscoverSitePick( this.props.post ) ) {
+		if ( this.props.originalPost && isDiscoverPost( this.props.post ) && ! isDiscoverSitePick( this.props.post ) ) {
 			referredPost = { ...postToOpen,
 				referral: {
 					blogId: discoverBlogId,

--- a/client/reader/stream/refresh-post.jsx
+++ b/client/reader/stream/refresh-post.jsx
@@ -26,14 +26,16 @@ import {
 class ReaderPostCardAdapter extends React.Component {
 
 	onClick = ( postToOpen ) => {
-		const propagatePost = { ...postToOpen };
+		let propagatePost;
 		if ( isDiscoverPost( this.props.post ) && ! isDiscoverSitePick( this.props.post ) ) {
-			propagatePost.referral = {
-				blogId: discoverBlogId,
-				postId: this.props.post.ID
+			propagatePost = { ...postToOpen,
+				referral: {
+					blogId: discoverBlogId,
+					postId: this.props.post.ID
+				}
 			};
 		}
-		this.props.handleClick && this.props.handleClick( propagatePost );
+		this.props.handleClick && this.props.handleClick( propagatePost || postToOpen );
 	}
 
 	onCommentClick = () => {

--- a/client/reader/stream/refresh-post.jsx
+++ b/client/reader/stream/refresh-post.jsx
@@ -26,16 +26,16 @@ import {
 class ReaderPostCardAdapter extends React.Component {
 
 	onClick = ( postToOpen ) => {
-		let propagatePost;
+		let referredPost;
 		if ( isDiscoverPost( this.props.post ) && ! isDiscoverSitePick( this.props.post ) ) {
-			propagatePost = { ...postToOpen,
+			referredPost = { ...postToOpen,
 				referral: {
 					blogId: discoverBlogId,
 					postId: this.props.post.ID
 				}
 			};
 		}
-		this.props.handleClick && this.props.handleClick( propagatePost || postToOpen );
+		this.props.handleClick && this.props.handleClick( referredPost || postToOpen );
 	}
 
 	onCommentClick = () => {


### PR DESCRIPTION
This adds the ability to load a referral from the reader stream to a full post view. It uses query parameters set in the full post url to load the referred post. This way the referred URL can be shared without losing the referral.

This PR also includes the implementation to swap out the source post links with their associated discover.wordpress.com link. 

Fixes #9803 

**Test**

**From discover stream**
1. Click on a discover pick, quote or image from the [discover stream](https://calypso.live/discover?branch=fix/reader-full-post-referral).
2. The full post view title and date should have a discover.wordpress.com link

**Direct link**
1. Visit a [referred post](https://calypso.live/read/blogs/24404096/posts/1201?branch=fix/reader-full-post-referral&ref_blog=53424024&ref_post=20008)
2. Hovering over the title or post at should show the [discover.wordpress.com](https://discover.wordpress.com/2016/11/30/calgarys-deane-house/) link

_note_: Clicking the title or post will redirect to [the post](https://toddkorol.wordpress.com/2016/11/28/calgarys-deane-house/) on the source blog

**Without referral**
1. Visit [the post](https://calypso.live/read/blogs/24404096/posts/1201?branch=fix/reader-full-post-referral) without the referral parameters.
2. Hovering over the title or post date should show the source [post url](https://toddkorol.wordpress.com/2016/11/28/calgarys-deane-house/)


