### PR TITLE
Reader: display emoji and international characters correctly in tag stream header

### DIFF
--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -24,8 +24,8 @@ const TAG_HEADER_HEIGHT = 140;
 class TagStreamHeader extends React.Component {
 
 	static propTypes = {
-		isPlaceholder: React.PropTypes.bool,
 		tag: React.PropTypes.string,
+		title: React.PropTypes.string,
 		showFollow: React.PropTypes.bool,
 		following: React.PropTypes.bool,
 		onFollowToggle: React.PropTypes.func,
@@ -54,10 +54,9 @@ class TagStreamHeader extends React.Component {
 	}
 
 	render() {
-		const { tag, isPlaceholder, showFollow, following, onFollowToggle, translate, hasBackButton } = this.props;
+		const { tag, title, showFollow, following, onFollowToggle, translate, hasBackButton } = this.props;
 		const classes = classnames( {
 			'tag-stream__header': true,
-			'is-placeholder': isPlaceholder,
 			'has-back-button': hasBackButton
 		} );
 		const imageStyle = {};
@@ -71,10 +70,12 @@ class TagStreamHeader extends React.Component {
 			imageStyle.backgroundImage = 'url(' + safeCssUrl + ')';
 
 			photoByWrapper = ( <span className="tag-stream__header-image-byline-label" /> );
-			authorLink = <a href={ `/read/blogs/${ tagImage.blog_id }/posts/${ tagImage.post_id }` }
-												className="tag-stream__header-image-byline-link" rel="author">
-											{ decodeEntities( tagImage.author ) }
-										</a>;
+			const authorHref = `/read/blogs/${ tagImage.blog_id }/posts/${ tagImage.post_id }`;
+			authorLink = (
+				<a href={ authorHref } className="tag-stream__header-image-byline-link" rel="author">
+					{ decodeEntities( tagImage.author ) }
+				</a>
+			);
 		}
 
 		return (
@@ -93,7 +94,7 @@ class TagStreamHeader extends React.Component {
 
 				<div className="tag-stream__header-image" style={ imageStyle }>
 					<h1 className="tag-stream__header-image-title">
-						<Gridicon icon="tag" size={ 24 } />{ tag }
+						<Gridicon icon="tag" size={ 24 } />{ title }
 					</h1>
 					{ tagImage &&
 						<div className="tag-stream__header-image-byline">

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -100,6 +100,7 @@ const TagStream = React.createClass( {
 				{ config.isEnabled( 'reader/refresh/stream' )
 					? <TagStreamHeader
 						tag={ this.props.tag }
+						title={ title }
 						showFollow={ this.state.canFollow }
 						following={ this.state.subscribed }
 						onFollowToggle={ this.toggleFollowing }


### PR DESCRIPTION
Fixes #9746.

Try  ❤️ https://calypso.localhost:3000/tag/%E2%9D%A4%EF%B8%8F
and 未分類 http://calypso.localhost:3000/tag/%E6%9C%AA%E5%88%86%E9%A1%9E

Before:

<img width="902" alt="screen shot 2016-12-07 at 11 37 35" src="https://cloud.githubusercontent.com/assets/17325/20946963/cd1bb62c-bc71-11e6-8e1a-c74ebb8e95ff.png">

After:

<img width="885" alt="screen shot 2016-12-07 at 11 38 00" src="https://cloud.githubusercontent.com/assets/17325/20946968/d391bf7e-bc71-11e6-8847-3bd64274f5e6.png">
