### PR TITLE
Reader: display tag header image for emoji tags

### DIFF
--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -54,7 +54,7 @@ class TagStreamHeader extends React.Component {
 	}
 
 	render() {
-		const { tag, isPlaceholder, showFollow, following, onFollowToggle, translate, hasBackButton } = this.props;
+		const { title, isPlaceholder, showFollow, following, onFollowToggle, translate, hasBackButton, imageSearchString } = this.props;
 		const classes = classnames( {
 			'tag-stream__header': true,
 			'is-placeholder': isPlaceholder,
@@ -79,7 +79,7 @@ class TagStreamHeader extends React.Component {
 
 		return (
 			<div className={ classes }>
-				<QueryReaderTagImages tag={ tag } />
+				<QueryReaderTagImages tag={ imageSearchString } />
 				{ showFollow &&
 					<div className="tag-stream__header-follow">
 						<FollowButton
@@ -93,7 +93,7 @@ class TagStreamHeader extends React.Component {
 
 				<div className="tag-stream__header-image" style={ imageStyle }>
 					<h1 className="tag-stream__header-image-title">
-						<Gridicon icon="tag" size={ 24 } />{ tag }
+						<Gridicon icon="tag" size={ 24 } />{ title }
 					</h1>
 					{ tagImage &&
 						<div className="tag-stream__header-image-byline">
@@ -114,7 +114,7 @@ class TagStreamHeader extends React.Component {
 export default connect(
 	( state, ownProps ) => {
 		return {
-			tagImages: getTagImages( state, ownProps.tag )
+			tagImages: getTagImages( state, ownProps.imageSearchString )
 		};
 	}
 )( localize( TagStreamHeader ) );

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import React from 'react';
-import { has, trim } from 'lodash';
+import { has } from 'lodash';
 import twemoji from 'twemoji';
 import emojiText from 'emoji-text';
 
@@ -99,9 +99,9 @@ const TagStream = React.createClass( {
 
 		// If the tag contains emoji, convert to text equivalent
 		if ( twemoji.test( title ) ) {
-			imageSearchString = trim( emojiText.convert( title, {
-				delimiter: ' '
-			} ) );
+			imageSearchString = emojiText.convert( title, {
+				delimiter: ''
+			} );
 		}
 
 		return (

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -2,7 +2,9 @@
  * External Dependencies
  */
 import React from 'react';
-import { has } from 'lodash';
+import { has, trim } from 'lodash';
+import twemoji from 'twemoji';
+import emojiText from 'emoji-text';
 
 /**
  * Internal Dependencies
@@ -93,6 +95,15 @@ const TagStream = React.createClass( {
 		const emptyContent = ( <EmptyContent tag={ this.props.tag } /> );
 		const title = decodeURIComponent( this.state.title );
 
+		let imageSearchString = this.props.tag;
+
+		// If the tag contains emoji, convert to text equivalent
+		if ( twemoji.test( title ) ) {
+			imageSearchString = trim( emojiText.convert( title, {
+				delimiter: ' '
+			} ) );
+		}
+
 		return (
 			<Stream { ...this.props } listName={ this.state.title } emptyContent={ emptyContent } showFollowInHeader={ true }>
 				<DocumentHead title={ this.translate( '%s ‹ Reader', { args: title } ) } />
@@ -100,6 +111,8 @@ const TagStream = React.createClass( {
 				{ config.isEnabled( 'reader/refresh/stream' )
 					? <TagStreamHeader
 						tag={ this.props.tag }
+						title={ title }
+						imageSearchString={ imageSearchString }
 						showFollow={ this.state.canFollow }
 						following={ this.state.subscribed }
 						onFollowToggle={ this.toggleFollowing }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -29,11 +29,11 @@
       "version": "0.8.2"
     },
     "ajv": {
-      "version": "4.9.0",
+      "version": "4.9.2",
       "dev": true
     },
     "ajv-keywords": {
-      "version": "1.1.1",
+      "version": "1.2.0",
       "dev": true
     },
     "align-text": {
@@ -419,7 +419,7 @@
       "version": "3.1.3"
     },
     "binary-extensions": {
-      "version": "1.7.0"
+      "version": "1.8.0"
     },
     "bindings": {
       "version": "1.2.1"
@@ -531,7 +531,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000588"
+      "version": "1.0.30000592"
     },
     "caseless": {
       "version": "0.11.0"
@@ -1050,6 +1050,9 @@
     },
     "emitter-component": {
       "version": "1.0.0"
+    },
+    "emoji-text": {
+      "version": "0.2.6"
     },
     "emojis-list": {
       "version": "2.1.0"
@@ -1799,7 +1802,7 @@
       }
     },
     "http-proxy": {
-      "version": "1.15.2",
+      "version": "1.16.2",
       "dev": true
     },
     "http-signature": {
@@ -2704,7 +2707,7 @@
       "version": "2.0.1"
     },
     "object.values": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dev": true
     },
     "on-finished": {
@@ -3446,7 +3449,7 @@
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.1"
+      "version": "3.0.2"
     },
     "simple-get": {
       "version": "1.4.3"
@@ -3522,7 +3525,7 @@
       "dev": true
     },
     "source-list-map": {
-      "version": "0.1.6"
+      "version": "0.1.7"
     },
     "source-map": {
       "version": "0.1.39"
@@ -4174,6 +4177,9 @@
           "version": "0.5.6"
         }
       }
+    },
+    "wemoji": {
+      "version": "0.1.9"
     },
     "whatwg-fetch": {
       "version": "2.0.1"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "dom-scroll-into-view": "1.0.1",
     "draft-js": "0.8.1",
     "email-validator": "1.0.1",
+    "emoji-text": "0.2.6",
     "escape-regexp": "0.0.1",
     "escape-string-regexp": "1.0.3",
     "events": "1.0.2",


### PR DESCRIPTION
We don't currently display a background image in a tag header for emoji tags, for example:

<img width="865" alt="screen shot 2016-12-07 at 13 10 03" src="https://cloud.githubusercontent.com/assets/17325/20949500/84e28720-bc7e-11e6-8f89-fee79a803682.png">

This PR is a proof-of-concept that converts emoji tag titles into an image search string, resulting in some pretty cool headers:

<img width="892" alt="screen shot 2016-12-07 at 13 03 48" src="https://cloud.githubusercontent.com/assets/17325/20949467/52f4296c-bc7e-11e6-9b3b-a2efd11c1e02.png">

We may later choose to do this emoji -> text lookup in the API endpoint instead.

Fixes #9746.