### PR TITLE
Reader Refresh: disambiguate rec clicks for recording tracks

### DIFF
--- a/client/reader/recommendations/for-you/index.jsx
+++ b/client/reader/recommendations/for-you/index.jsx
@@ -101,7 +101,8 @@ const RecommendedForYou = React.createClass( {
 		recordAction( 'click_site_on_recommended_for_you' );
 		recordGaEvent( 'Clicked Site on Recommended For You' );
 		recordTrack( 'calypso_reader_recommended_site_clicked', {
-			clicked_url: clickedUrl
+			clicked_url: clickedUrl,
+			recommendation_source: 'recommendations-page',
 		} );
 	},
 

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -19,7 +19,7 @@ import HeaderBack from 'reader/header-back';
 import SearchInput from 'components/search';
 import SiteStore from 'lib/reader-site-store';
 import FeedStore from 'lib/feed-store';
-import { recordTrackForPost } from 'reader/stats';
+import { recordTrackForPost, recordAction } from 'reader/stats';
 import i18nUtils from 'lib/i18n-utils';
 import { suggestions } from './suggestions';
 import SearchCard from 'blocks/reader-search-card';
@@ -31,13 +31,28 @@ import config from 'config';
 const isRefreshedStream = config.isEnabled( 'reader/refresh/stream' );
 
 function RecommendedPosts( { post, site } ) {
+	function handlePostClick() {
+		recordTrackForPost( 'calypso_reader_recommended_post_clicked', post, {
+			recommendation_source: 'empty-search',
+		} );
+		recordAction( 'search_page_rec_post_click' );
+	}
+
+	function handleSiteClick() {
+		recordTrackForPost( 'calypso_reader_recommended_site_clicked', post, {
+			recommendation_source: 'empty-search',
+		} );
+		recordAction( 'search_page_rec_site_click' );
+	}
+
 	if ( ! site ) {
 		site = { title: post.site_name, };
 	}
 
 	return (
 		<div className="search-stream__recommendation-list-item" key={ post.global_ID }>
-			<RelatedPostCard post={ post } site={ site } />
+			<RelatedPostCard post={ post } site={ site }
+				onSiteClick={ handleSiteClick } onPostClick={ handlePostClick } />
 		</div>
 	);
 }

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -116,6 +116,7 @@ tracksRailcarEventWhitelist
 	.add( 'calypso_reader_searchcard_clicked' )
 	.add( 'calypso_reader_author_link_clicked' )
 	.add( 'calypso_reader_permalink_click' )
+	.add( 'calypso_reader_recommended_post_clicked' )
 ;
 
 export function recordTracksRailcar( action, eventName, railcar ) {

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -117,6 +117,7 @@ tracksRailcarEventWhitelist
 	.add( 'calypso_reader_author_link_clicked' )
 	.add( 'calypso_reader_permalink_click' )
 	.add( 'calypso_reader_recommended_post_clicked' )
+	.add( 'calypso_reader_recommended_site_clicked' )
 ;
 
 export function recordTracksRailcar( action, eventName, railcar ) {

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -1,9 +1,13 @@
-import assign from 'lodash/assign';
+/**
+ * External Dependencies
+ */
+import { assign, partial } from 'lodash';
 import debugFactory from 'debug';
-import partial from 'lodash/partial';
 
+/**
+ * Internal Dependencies
+ */
 import { mc, ga, tracks } from 'lib/analytics';
-
 import SubscriptionStore from 'lib/reader-feed-subscriptions';
 
 const debug = debugFactory( 'calypso:reader:stats' );
@@ -23,7 +27,7 @@ export function recordPermalinkClick( where, post ) {
 		reader_actions: 'visited_post_permalink',
 		reader_permalink_source: where
 	} );
-	recordGaEvent( 'Clicked Post Permalink', where )
+	recordGaEvent( 'Clicked Post Permalink', where );
 	const trackEvent = 'calypso_reader_permalink_click';
 	const args = {
 		source: where

--- a/client/reader/stream/recommended-posts.jsx
+++ b/client/reader/stream/recommended-posts.jsx
@@ -26,12 +26,16 @@ export class RecommendedPosts extends React.PureComponent {
 	}
 
 	handlePostClick = ( post ) => {
-		stats.recordTrackForPost( 'calypso_reader_in_stream_rec_post_clicked', post );
+		stats.recordTrackForPost( 'calypso_reader_recommended_post_clicked', post, {
+			recommendation_source: 'in-stream',
+		} );
 		stats.recordAction( 'in_stream_rec_post_click' );
 	}
 
 	handleSiteClick = ( post ) => {
-		stats.recordTrackForPost( 'calypso_reader_in_stream_rec_site_clicked', post );
+		stats.recordTrackForPost( 'calypso_reader_recommended_site_clicked', post, {
+			recommendation_source: 'in-stream',
+		} );
 		stats.recordAction( 'in_stream_rec_site_click' );
 	}
 


### PR DESCRIPTION
Add extra props to recommendation_clicked tracks event #9762

#### To test:
- [x] ensure that the events **calypso_reader_recommended_site_clicked** is activated from both search page and in-stream recs
- [x] ensure that the events **calypso_reader_recommended_post_clicked** is activated from both search page and in-stream recs are clicked
