### PR TITLE
Discover: use source site in byline where available

### DIFF
--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -29,7 +29,6 @@ class PostByline extends React.Component {
 		site: React.PropTypes.object,
 		feed: React.PropTypes.object,
 		showSiteName: React.PropTypes.bool,
-		originalPost: React.PropTypes.object,
 	}
 
 	static defaultProps = {

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -28,12 +28,11 @@ class PostByline extends React.Component {
 		post: React.PropTypes.object.isRequired,
 		site: React.PropTypes.object,
 		feed: React.PropTypes.object,
-		isDiscoverPost: React.PropTypes.bool,
-		showSiteName: React.PropTypes.bool
+		showSiteName: React.PropTypes.bool,
+		originalPost: React.PropTypes.object,
 	}
 
 	static defaultProps = {
-		isDiscoverPost: false,
 		showSiteName: true
 	}
 
@@ -49,15 +48,20 @@ class PostByline extends React.Component {
 		recordPermalinkClick( 'timestamp_card', this.props.post );
 	}
 
+	getPostAuthor = () => {
+		return get( this.props, 'post.author' );
+	}
+
 	render() {
-		const { post, site, feed, isDiscoverPost, showSiteName } = this.props;
+		const { post, site, feed, showSiteName } = this.props;
 		const feedId = get( post, 'feed_ID' );
 		const siteId = get( site, 'ID' );
 		const primaryTag = post && post.primary_tag;
 		const siteName = siteNameFromSiteAndPost( site, post );
-		const hasAuthorName = has( post, 'author.name' );
+		const postAuthor = this.getPostAuthor();
+		const hasAuthorName = has( postAuthor, 'name' );
 		const hasMatchingAuthorAndSiteNames = hasAuthorName && areEqualIgnoringWhitespaceAndCase( siteName, post.author.name );
-		const shouldDisplayAuthor = ! isDiscoverPost && hasAuthorName && ( ! hasMatchingAuthorAndSiteNames || ! showSiteName );
+		const shouldDisplayAuthor = hasAuthorName && ( ! hasMatchingAuthorAndSiteNames || ! showSiteName );
 		const streamUrl = getStreamUrl( feedId, siteId );
 		const siteIcon = get( site, 'icon.img' );
 		const feedIcon = get( feed, 'image' );
@@ -76,10 +80,10 @@ class PostByline extends React.Component {
 						{ shouldDisplayAuthor &&
 						<ReaderAuthorLink
 							className="reader-post-card__link"
-							author={ post.author }
+							author={ postAuthor }
 							siteUrl={ streamUrl }
 							post={ post }>
-							{ post.author.name }
+							{ postAuthor.name }
 						</ReaderAuthorLink>
 						}
 						{ shouldDisplayAuthor && showSiteName && ', ' }

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -70,12 +70,16 @@ class PostByline extends React.Component {
 		return get( this.props.feed, 'image' );
 	}
 
+	getSiteName = () => {
+		return siteNameFromSiteAndPost( this.props.site, this.props.post );
+	}
+
 	render() {
 		const { post, site, showSiteName } = this.props;
 		const feedId = get( post, 'feed_ID' );
 		const siteId = get( site, 'ID' );
 		const primaryTag = post && post.primary_tag;
-		const siteName = siteNameFromSiteAndPost( site, post );
+		const siteName = this.getSiteName();
 		const postAuthor = this.getPostAuthor();
 		const hasAuthorName = has( postAuthor, 'name' );
 		const hasMatchingAuthorAndSiteNames = hasAuthorName && areEqualIgnoringWhitespaceAndCase( siteName, post.author.name );
@@ -110,6 +114,7 @@ class PostByline extends React.Component {
 							className="reader-post-card__site reader-post-card__link"
 							feedId={ feedId }
 							siteId={ siteId }
+							siteUrl={ streamUrl }
 							post={ post }>
 							{ siteName }
 						</ReaderSiteStreamLink> }

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -56,8 +56,22 @@ class PostByline extends React.Component {
 		return get( this.props, 'post.URL' );
 	}
 
+	getStreamUrl = () => {
+		const feedId = get( this.props.post, 'feed_ID' );
+		const siteId = get( this.props.site, 'ID' );
+		return getStreamUrl( feedId, siteId );
+	}
+
+	getSiteIcon = () => {
+		return get( this.props.site, 'icon.img' );
+	}
+
+	getFeedIcon = () => {
+		return get( this.props.feed, 'image' );
+	}
+
 	render() {
-		const { post, site, feed, showSiteName } = this.props;
+		const { post, site, showSiteName } = this.props;
 		const feedId = get( post, 'feed_ID' );
 		const siteId = get( site, 'ID' );
 		const primaryTag = post && post.primary_tag;
@@ -66,9 +80,9 @@ class PostByline extends React.Component {
 		const hasAuthorName = has( postAuthor, 'name' );
 		const hasMatchingAuthorAndSiteNames = hasAuthorName && areEqualIgnoringWhitespaceAndCase( siteName, post.author.name );
 		const shouldDisplayAuthor = hasAuthorName && ( ! hasMatchingAuthorAndSiteNames || ! showSiteName );
-		const streamUrl = getStreamUrl( feedId, siteId );
-		const siteIcon = get( site, 'icon.img' );
-		const feedIcon = get( feed, 'image' );
+		const streamUrl = this.getStreamUrl();
+		const siteIcon = this.getSiteIcon();
+		const feedIcon = this.getFeedIcon();
 		const postTimeLinkUrl = this.getPostTimeLinkUrl();
 
 		/* eslint-disable wpcalypso/jsx-gridicon-size */
@@ -77,7 +91,7 @@ class PostByline extends React.Component {
 				<ReaderAvatar
 					siteIcon={ siteIcon }
 					feedIcon={ feedIcon }
-					author={ post.author }
+					author={ postAuthor }
 					preferGravatar={ true }
 					siteUrl={ streamUrl } />
 				<div className="reader-post-card__byline-details">

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -52,6 +52,10 @@ class PostByline extends React.Component {
 		return get( this.props, 'post.author' );
 	}
 
+	getPostTimeLinkUrl = () => {
+		return get( this.props, 'post.URL' );
+	}
+
 	render() {
 		const { post, site, feed, showSiteName } = this.props;
 		const feedId = get( post, 'feed_ID' );
@@ -65,6 +69,7 @@ class PostByline extends React.Component {
 		const streamUrl = getStreamUrl( feedId, siteId );
 		const siteIcon = get( site, 'icon.img' );
 		const feedIcon = get( feed, 'image' );
+		const postTimeLinkUrl = this.getPostTimeLinkUrl();
 
 		/* eslint-disable wpcalypso/jsx-gridicon-size */
 		return (
@@ -100,7 +105,7 @@ class PostByline extends React.Component {
 							<span className="reader-post-card__timestamp">
 								<a className="reader-post-card__timestamp-link"
 									onClick={ this.recordDateClick }
-									href={ post.URL }
+									href={ postTimeLinkUrl }
 									target="_blank"
 									rel="noopener noreferrer">
 									<PostTime date={ post.date } />

--- a/client/blocks/reader-post-card/discover-byline.jsx
+++ b/client/blocks/reader-post-card/discover-byline.jsx
@@ -1,0 +1,31 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal Dependencies
+ */
+import PostByline from './byline';
+
+class DiscoverPostByline extends PostByline {
+
+	static propTypes = {
+		post: React.PropTypes.object.isRequired,
+		site: React.PropTypes.object,
+		feed: React.PropTypes.object,
+		isDiscoverPost: React.PropTypes.bool,
+		showSiteName: React.PropTypes.bool,
+		originalPost: React.PropTypes.object,
+	}
+
+	constructor( props ) {
+		super( props );
+	}
+
+	getPostAuthor = () => {
+		return { name: 'Banana' };
+	}
+}
+
+export default DiscoverPostByline;

--- a/client/blocks/reader-post-card/discover-byline.jsx
+++ b/client/blocks/reader-post-card/discover-byline.jsx
@@ -2,11 +2,13 @@
  * External Dependencies
  */
 import React from 'react';
+import { get } from 'lodash';
 
 /**
  * Internal Dependencies
  */
 import PostByline from './byline';
+//import * as DiscoverHelper from 'reader/discover/helper';
 
 class DiscoverPostByline extends PostByline {
 
@@ -19,12 +21,16 @@ class DiscoverPostByline extends PostByline {
 		originalPost: React.PropTypes.object,
 	}
 
-	constructor( props ) {
-		super( props );
-	}
-
 	getPostAuthor = () => {
 		return { name: 'Banana' };
+	}
+
+	getPostTimeLinkUrl = () => {
+		if ( this.props.originalPost ) {
+			return get( this.props.originalPost, 'URL' );
+		}
+
+		return get( this.props.post, 'discover_metadata.permalink' );
 	}
 }
 

--- a/client/blocks/reader-post-card/discover-byline.jsx
+++ b/client/blocks/reader-post-card/discover-byline.jsx
@@ -40,8 +40,8 @@ class DiscoverPostByline extends PostByline {
 	}
 
 	getSiteIcon = () => {
-		return null;
-		//return get( this.props.post, 'discover_metadata.attribution.avatar_url' );
+		//return null;
+		return get( this.props.post, 'discover_metadata.attribution.avatar_url' );
 	}
 
 	getFeedIcon = () => {

--- a/client/blocks/reader-post-card/discover-byline.jsx
+++ b/client/blocks/reader-post-card/discover-byline.jsx
@@ -39,14 +39,17 @@ class DiscoverPostByline extends PostByline {
 		return getStreamUrl( null, blogId );
 	}
 
-	// @todo
 	getSiteIcon = () => {
+		return null;
+		//return get( this.props.post, 'discover_metadata.attribution.avatar_url' );
+	}
+
+	getFeedIcon = () => {
 		return null;
 	}
 
-	// @todo
-	getFeedIcon = () => {
-		return null;
+	getSiteName = () => {
+		return get( this.props.post, 'discover_metadata.attribution.blog_name' );
 	}
 }
 

--- a/client/blocks/reader-post-card/discover-byline.jsx
+++ b/client/blocks/reader-post-card/discover-byline.jsx
@@ -8,7 +8,7 @@ import { get } from 'lodash';
  * Internal Dependencies
  */
 import PostByline from './byline';
-//import * as DiscoverHelper from 'reader/discover/helper';
+import { getStreamUrl } from 'reader/route';
 
 class DiscoverPostByline extends PostByline {
 
@@ -22,7 +22,8 @@ class DiscoverPostByline extends PostByline {
 	}
 
 	getPostAuthor = () => {
-		return { name: 'Banana' };
+		// Will be null for site picks
+		return get( this.props.originalPost, 'author' );
 	}
 
 	getPostTimeLinkUrl = () => {
@@ -31,6 +32,21 @@ class DiscoverPostByline extends PostByline {
 		}
 
 		return get( this.props.post, 'discover_metadata.permalink' );
+	}
+
+	getStreamUrl = () => {
+		const blogId = get( this.props.post, 'discover_metadata.featured_post_wpcom_data.blog_id' );
+		return getStreamUrl( null, blogId );
+	}
+
+	// @todo
+	getSiteIcon = () => {
+		return null;
+	}
+
+	// @todo
+	getFeedIcon = () => {
+		return null;
 	}
 }
 

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -124,6 +124,7 @@ export default class RefreshPostCard extends React.Component {
 			separator: /,? +/
 		} );
 		const isDiscoverPost = DiscoverHelper.isDiscoverPost( post );
+		const isDiscoverPick = DiscoverHelper.isDiscoverPick( post );
 
 		if ( ! title && isPhotoOnly ) {
 			title = '\xa0'; // force to non-breaking space if empty so that the title h1 doesn't collapse and complicate things
@@ -149,8 +150,8 @@ export default class RefreshPostCard extends React.Component {
 
 		return (
 			<Card className={ classes } onClick={ this.handleCardClick }>
-				{ isDiscoverPost
-					? <DiscoverPostByline post={ post } site={ site } feed={ feed } showSiteName={ showSiteName } />
+				{ isDiscoverPick
+					? <DiscoverPostByline post={ post } site={ site } feed={ feed } originalPost={ originalPost } />
 					: <PostByline post={ post } site={ site } feed={ feed } showSiteName={ showSiteName } />
 				}
 				{ showPrimaryFollowButton && followUrl && <FollowButton siteUrl={ followUrl } /> }

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -148,7 +148,7 @@ export default class RefreshPostCard extends React.Component {
 
 		return (
 			<Card className={ classes } onClick={ this.handleCardClick }>
-				<PostByline post={ post } site={ site } feed={ feed } showSiteName={ showSiteName } />
+				<PostByline post={ originalPost ? originalPost : post } site={ site } feed={ feed } showSiteName={ showSiteName } />
 				{ showPrimaryFollowButton && followUrl && <FollowButton siteUrl={ followUrl } /> }
 				<div className="reader-post-card__post">
 					{ ! isGallery && featuredAsset }

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -16,6 +16,7 @@ import DisplayTypes from 'state/reader/posts/display-types';
 import ReaderPostActions from 'blocks/reader-post-actions';
 import * as stats from 'reader/stats';
 import PostByline from './byline';
+import DiscoverPostByline from './discover-byline';
 import FeaturedVideo from './featured-video';
 import FeaturedImage from './featured-image';
 import FollowButton from 'reader/follow-button';
@@ -148,7 +149,10 @@ export default class RefreshPostCard extends React.Component {
 
 		return (
 			<Card className={ classes } onClick={ this.handleCardClick }>
-				<PostByline post={ originalPost ? originalPost : post } site={ site } feed={ feed } showSiteName={ showSiteName } />
+				{ isDiscoverPost
+					? <DiscoverPostByline post={ post } site={ site } feed={ feed } showSiteName={ showSiteName } />
+					: <PostByline post={ post } site={ site } feed={ feed } showSiteName={ showSiteName } />
+				}
 				{ showPrimaryFollowButton && followUrl && <FollowButton siteUrl={ followUrl } /> }
 				<div className="reader-post-card__post">
 					{ ! isGallery && featuredAsset }

--- a/client/blocks/reader-site-stream-link/index.jsx
+++ b/client/blocks/reader-site-stream-link/index.jsx
@@ -14,6 +14,7 @@ const ReaderSiteStreamLink = React.createClass( {
 	propTypes: {
 		feedId: React.PropTypes.number,
 		siteId: React.PropTypes.number,
+		siteUrl: React.PropTypes.string,
 		post: React.PropTypes.object // for stats only
 	},
 
@@ -26,8 +27,13 @@ const ReaderSiteStreamLink = React.createClass( {
 	},
 
 	render() {
-		const link = getStreamUrl( this.props.feedId, this.props.siteId );
-		const omitProps = [ 'feedId', 'siteId', 'post' ];
+		let link = this.props.siteUrl;
+
+		if ( ! link ) {
+			link = getStreamUrl( this.props.feedId, this.props.siteId );
+		}
+
+		const omitProps = [ 'feedId', 'siteId', 'post', 'siteUrl' ];
 
 		return (
 			<a { ...omit( this.props, omitProps ) } href={ link } onClick={ this.recordClick }>{ this.props.children }</a>

--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -26,6 +26,10 @@ export function isDiscoverPost( post ) {
 	return !! ( get( post, 'discover_metadata' ) || get( post, 'site_ID' ) === config( 'discover_blog_id' ) );
 }
 
+export function isDiscoverPick( post ) {
+	return hasDiscoverSlug( post, 'pick' );
+}
+
 export function isDiscoverSitePick( post ) {
 	return hasDiscoverSlug( post, 'site-pick' );
 }
@@ -36,7 +40,7 @@ export function isInternalDiscoverPost( post ) {
 
 export function getSiteUrl( post ) {
 	const blogId = get( post, 'discover_metadata.featured_post_wpcom_data.blog_id' );
-	// If we have a blog ID, we want to send them to the site detail page
+	// If we have a blog ID, we want to send them to the site stream page
 	return blogId ? readerRouteGetSiteUrl( blogId ) : get( post, 'discover_metadata.permalink' );
 }
 


### PR DESCRIPTION
Part of #9096. Fixes https://github.com/Automattic/wp-calypso/issues/10060.

> For card header, show the original poster info, not Discover poster. Use date stamp of discover post date, so they appear in order, and link date to the original external URL as usual. Include main tag (links to tag page as usual).

- [x] Show original author for picks with an original post available
- [x] Show original site name
- [x] Use Discover post date stamp
- [x] Link date stamp to original post external URL
- [ ] Get feed/site image for site picks and those without an image. (We have `avatar_url` in the Discover metadata.)
- [ ] Where should we link the site name for site picks? (we often don't have a blog ID from the API)