### PR TITLE
GuidedTours: make the design showcase tour work with both magic and non-magic search

### DIFF
--- a/client/layout/guided-tours/design-showcase-welcome-tour.js
+++ b/client/layout/guided-tours/design-showcase-welcome-tour.js
@@ -57,7 +57,7 @@ export const DesignShowcaseWelcomeTour = makeTour(
 		</Step>
 
 		<Step name="search"
-			target=".themes-magic-search-card .search__icon-navigation"
+			target=".themes-magic-search-card .search__icon-navigation, .themes__search-card .search__icon-navigation"
 			arrow="top-left"
 			placement="below"
 			next="theme-options"


### PR DESCRIPTION
The design showcase welcome tour (cf. #9602) previously used the `themes-magic-search-card` class to select the search field. However, this is only available if the `manage/themes/magic-search` feature is enabled, which it is not in production. 

This PR provides an alternative selector for the search field, the `themes__search-card` class, to make the tour work regardless of whether the magic search feature is active or not. 

To test:

- go to http://calypso.localhost:3000/design/SITE_URL?tour=designShowcaseWelcome and make sure the design showcase tour works
- in `development.json` change the `manage/themes/magic-search` feature flag to false and restart Calypso
- go to http://calypso.localhost:3000/design/SITE_URL?tour=designShowcaseWelcome and make sure the design showcase tour works
