### PR TITLE
Theme Sheet: Fix for Jetpack sites

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -153,11 +153,17 @@ const ThemeSheet = React.createClass( {
 		if ( this.isLoaded() ) {
 			return this.props.screenshots[ 0 ];
 		}
-		return '';
+		return null;
 	},
 
 	renderScreenshot() {
-		const img = <img className="theme__sheet-img" src={ this.getFullLengthScreenshot() + '?=w680' } />;
+		let screenshot;
+		if ( this.props.isJetpack ) {
+			screenshot = this.props.screenshot;
+		} else {
+			screenshot = this.getFullLengthScreenshot();
+		}
+		const img = screenshot && <img className="theme__sheet-img" src={ screenshot + '?=w680' } />;
 		return (
 			<div className="theme__sheet-screenshot">
 				<a className="theme__sheet-preview-link" onClick={ this.togglePreview } data-tip-target="theme-sheet-preview">
@@ -166,7 +172,7 @@ const ThemeSheet = React.createClass( {
 						{ i18n.translate( 'Open Live Demo', { context: 'Individual theme live preview button' } ) }
 					</span>
 				</a>
-				{ this.getFullLengthScreenshot() && img }
+				{ img }
 			</div>
 		);
 	},
@@ -208,11 +214,21 @@ const ThemeSheet = React.createClass( {
 		}[ section ];
 	},
 
+	renderDescription() {
+		if ( this.props.descriptionLong ) {
+			return (
+				<div dangerouslySetInnerHTML={ { __html: this.props.descriptionLong } } />
+			);
+		}
+		// description doesn't contain any formatting, so we don't need to dangerouslySetInnerHTML
+		return <div>{ this.props.description }</div>;
+	},
+
 	renderOverviewTab() {
 		return (
 			<div>
 				<Card className="theme__sheet-content">
-					<div dangerouslySetInnerHTML={ { __html: this.props.descriptionLong } } />
+					{ this.renderDescription() }
 				</Card>
 				{ this.renderFeaturesCard() }
 				{ this.renderDownload() }
@@ -553,7 +569,8 @@ export default connect(
 	( state, { id } ) => {
 		const selectedSite = getSelectedSite( state );
 		const siteSlug = selectedSite ? getSiteSlug( state, selectedSite.ID ) : '';
-		const siteIdOrWpcom = ( selectedSite && isJetpackSite( state, selectedSite.ID ) ) ? selectedSite.ID : 'wpcom';
+		const isJetpack = selectedSite && isJetpackSite( state, selectedSite.ID );
+		const siteIdOrWpcom = isJetpack ? selectedSite.ID : 'wpcom';
 		const backPath = getBackPath( state );
 		const currentUserId = getCurrentUserId( state );
 		const isCurrentUserPaid = isUserPaid( state, currentUserId );
@@ -565,6 +582,7 @@ export default connect(
 			error,
 			selectedSite,
 			siteSlug,
+			isJetpack,
 			siteIdOrWpcom,
 			backPath,
 			currentUserId,

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -741,6 +741,23 @@ export function hasJetpackSiteJetpackThemes( state, siteId ) {
 }
 
 /**
+ * Determines if the Jetpack plugin of a Jetpack Site has extend themes management features.
+ * Returns null if the site is not known or is not a Jetpack site.
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} siteId Site ID
+ * @return {?Boolean} true if the site has Jetpack extended themes management features
+ */
+export function hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ) {
+	if ( ! isJetpackSite( state, siteId ) ) {
+		return null;
+	}
+
+	const siteJetpackVersion = getSiteOption( state, siteId, 'jetpack_version' );
+	return versionCompare( siteJetpackVersion, '4.4.2' ) >= 0;
+}
+
+/**
  * Determines if a site is the main site in a Network
  * True if it is either in a non multi-site configuration
  * or if its url matches the `main_network_site` url option.

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -37,6 +37,7 @@ import {
 	canJetpackSiteAutoUpdateFiles,
 	hasJetpackSiteJetpackMenus,
 	hasJetpackSiteJetpackThemes,
+	hasJetpackSiteJetpackThemesExtendedFeatures,
 	isJetpackSiteSecondaryNetworkSite,
 	verifyJetpackModulesActive,
 	getJetpackSiteRemoteManagementURL,
@@ -1672,6 +1673,52 @@ describe( 'selectors', () => {
 
 			const hasThemes = hasJetpackSiteJetpackThemes( state, siteId );
 			expect( hasThemes ).to.equal( true );
+		} );
+	} );
+
+	describe( '#hasJetpackSiteJetpackThemesExtendedFeatures()', () => {
+		it( 'it should return `null` if the given site is not a Jetpack site', () => {
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me'
+				}
+			} );
+
+			const hasThemesExtendedFeatures = hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId );
+			expect( hasThemesExtendedFeatures ).to.be.null;
+		} );
+
+		it( 'it should return `false` if jetpack version is smaller than 4.4.2', () => {
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					jetpack: true,
+					options: {
+						jetpack_version: '4.4.1'
+					}
+				}
+			} );
+
+			const hasThemesExtendedFeatures = hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId );
+			expect( hasThemesExtendedFeatures ).to.be.false;
+		} );
+
+		it( 'it should return `true` if jetpack version is greater or equal to 4.4.2', () => {
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					jetpack: true,
+					options: {
+						jetpack_version: '4.4.2'
+					}
+				}
+			} );
+
+			const hasThemesExtendedFeatures = hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId );
+			expect( hasThemesExtendedFeatures ).to.be.true;
 		} );
 	} );
 

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -292,7 +292,11 @@ export function getThemeDetailsUrl( state, theme, siteId ) {
 	}
 
 	if ( isJetpackSite( state, siteId ) &&
-		! ( canJetpackSiteManage( state, siteId ) && hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ) ) ) {
+		! (
+			config.isEnabled( 'manage/themes/details/jetpack' ) &&
+			canJetpackSiteManage( state, siteId ) &&
+			hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId )
+		) ) {
 		return getSiteOption( state, siteId, 'admin_url' ) + 'themes.php?theme=' + theme.id;
 	}
 

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -8,7 +8,13 @@ import createSelector from 'lib/create-selector';
  * Internal dependencies
  */
 import config from 'config';
-import { getSiteSlug, getSiteOption, isJetpackSite } from 'state/sites/selectors';
+import {
+	getSiteSlug,
+	getSiteOption,
+	isJetpackSite,
+	canJetpackSiteManage,
+	hasJetpackSiteJetpackThemesExtendedFeatures
+} from 'state/sites/selectors';
 import { getSitePurchases } from 'state/purchases/selectors';
 import { isPremiumTheme, oldShowcaseUrl } from './utils';
 import {
@@ -285,7 +291,8 @@ export function getThemeDetailsUrl( state, theme, siteId ) {
 		return null;
 	}
 
-	if ( isJetpackSite( state, siteId ) ) {
+	if ( isJetpackSite( state, siteId ) &&
+		! ( canJetpackSiteManage( state, siteId ) && hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ) ) ) {
 		return getSiteOption( state, siteId, 'admin_url' ) + 'themes.php?theme=' + theme.id;
 	}
 

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -664,7 +664,7 @@ describe( 'themes selectors', () => {
 	} );
 
 	describe( '#getThemeDetailsUrl', () => {
-		it( 'given a theme and no site ID, should return the details URL', () => {
+		it( 'given a theme and no site ID, should return the Calypso theme sheet URL', () => {
 			const detailsUrl = getThemeDetailsUrl(
 				{
 					sites: {
@@ -684,7 +684,7 @@ describe( 'themes selectors', () => {
 			expect( detailsUrl ).to.equal( '/theme/twentysixteen' );
 		} );
 
-		it( 'given a theme and wpcom site ID, should return the details URL', () => {
+		it( 'given a theme and wpcom site ID, should return the Calypso theme sheet URL', () => {
 			const detailsUrl = getThemeDetailsUrl(
 				{
 					sites: {
@@ -705,29 +705,93 @@ describe( 'themes selectors', () => {
 			expect( detailsUrl ).to.equal( '/theme/twentysixteen/example.wordpress.com' );
 		} );
 
-		it( 'given a theme and Jetpack site ID, should return the details URL', () => {
-			const detailsUrl = getThemeDetailsUrl(
-				{
-					sites: {
-						items: {
-							77203074: {
-								ID: 77203074,
-								URL: 'https://example.net',
-								jetpack: true,
-								options: {
-									admin_url: 'https://example.net/wp-admin/'
+		context( 'given a theme and a Jetpack site ID', () => {
+			context( 'with JP version < 4.4.2', () => {
+				it( 'should return the site\'s wp-admin theme details URL', () => {
+					const detailsUrl = getThemeDetailsUrl(
+						{
+							sites: {
+								items: {
+									77203074: {
+										ID: 77203074,
+										URL: 'https://example.net',
+										jetpack: true,
+										options: {
+											admin_url: 'https://example.net/wp-admin/',
+											jetpack_version: '4.4.1'
+										}
+									}
 								}
 							}
-						}
-					}
-				},
-				{
-					id: 'twentysixteen',
-					stylesheet: 'pub/twentysixteen'
-				},
-				77203074
-			);
-			expect( detailsUrl ).to.equal( 'https://example.net/wp-admin/themes.php?theme=twentysixteen' );
+						},
+						{
+							id: 'twentysixteen',
+							stylesheet: 'pub/twentysixteen'
+						},
+						77203074
+					);
+					expect( detailsUrl ).to.equal( 'https://example.net/wp-admin/themes.php?theme=twentysixteen' );
+				} );
+			} );
+
+			context( 'with JP version >= 4.4.2', () => {
+				context( 'with Jetpack Manage turned off', () => {
+					it( 'should return the site\'s wp-admin theme details URL', () => {
+						const detailsUrl = getThemeDetailsUrl(
+							{
+								sites: {
+									items: {
+										77203074: {
+											ID: 77203074,
+											URL: 'https://example.net',
+											jetpack: true,
+											options: {
+												admin_url: 'https://example.net/wp-admin/',
+												jetpack_version: '4.4.2',
+												active_modules: []
+											}
+										}
+									}
+								}
+							},
+							{
+								id: 'twentysixteen',
+								stylesheet: 'pub/twentysixteen'
+							},
+							77203074
+						);
+						expect( detailsUrl ).to.equal( 'https://example.net/wp-admin/themes.php?theme=twentysixteen' );
+					} );
+				} );
+
+				context( 'with Jetpack Manage not explicitly turned off', () => {
+					it( 'should return the Calypso theme sheet URL', () => {
+						const detailsUrl = getThemeDetailsUrl(
+							{
+								sites: {
+									items: {
+										77203074: {
+											ID: 77203074,
+											URL: 'https://example.net',
+											jetpack: true,
+											options: {
+												admin_url: 'https://example.net/wp-admin/',
+												jetpack_version: '4.4.2'
+											}
+										}
+									}
+								}
+							},
+							{
+								id: 'twentysixteen',
+								stylesheet: 'pub/twentysixteen'
+							},
+							77203074
+						);
+						expect( detailsUrl ).to.equal( '/theme/twentysixteen/example.net' );
+					} );
+				} );
+			} );
 		} );
 	} );
 

--- a/config/development.json
+++ b/config/development.json
@@ -101,6 +101,7 @@
 		"manage/themes-jetpack": true,
 		"manage/themes-ssr": true,
 		"manage/themes/details": true,
+		"manage/themes/details/jetpack": true,
 		"manage/themes/logged-out": true,
 		"manage/themes/magic-search": true,
 		"manage/themes/upload": true,

--- a/config/test.json
+++ b/config/test.json
@@ -74,6 +74,7 @@
 		"manage/themes": true,
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
+		"manage/themes/details/jetpack": true,
 		"manage/themes/logged-out": true,
 		"me/account": true,
 		"me/find-friends": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -80,6 +80,7 @@
 		"manage/themes": true,
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
+		"manage/themes/details/jetpack": true,
 		"manage/themes/logged-out": true,
 		"manage/themes/magic-search": true,
 		"manage/themes/upload": true,


### PR DESCRIPTION
Fix the theme sheet so it's able to display information about a given theme on a Jetpack site.

* Introduce a `hasJetpackSiteJetpackThemesExtendedFeatures` selector (checking that JP >= 4.4.2) that we might also want to reuse for theme upload /cc @seear 
* Modify `getThemeDetailsUrl` to point to the Calypso theme details sheet even for Jetpack sites (under some conditions, including `hasJetpackSiteJetpackThemesExtendedFeatures`, and a feature flag).

Visual _before_ state (skeleton keeps on pulsating forever):

![image](https://cloud.githubusercontent.com/assets/96308/20985913/bd9f4eac-bcc6-11e6-8c66-182f1273e37b.png)

Visual _after_ state:

![screen shot 2016-12-07 at 15 11 55](https://cloud.githubusercontent.com/assets/4389/20973162/8b07eec2-bc8f-11e6-873e-1ce8dabda90f.png)

To test:
* In the showcase, in Single Jetpack Site mode, check the 'Info' link in the ellipsis menu. If your JP < 4.4.2, it should point to the JP site's wp-admin. If it's >= 4.4.2, it should point to the theme sheet.
* Check the theme sheet
* Check that it still works as before for non-Jetpack sites.