### PR TITLE
Account Recovery: Add the forgot your username screen

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -8,6 +8,7 @@
 
 @import 'layout/style';
 
+@import 'account-recovery/forgot-username/forgot-username-form/style';
 @import 'account-recovery/lost-password/lost-password-form/style';
 @import 'account-recovery/style';
 @import 'auth/style';

--- a/client/account-recovery/controller.js
+++ b/client/account-recovery/controller.js
@@ -8,10 +8,16 @@ import page from 'page';
  * Internal dependencies
  */
 import LostPasswordPage from 'account-recovery/lost-password';
+import ForgotUsernamePage from 'account-recovery/forgot-username';
 import { getCurrentUser } from 'state/current-user/selectors';
 
 export function lostPassword( context, next ) {
 	context.primary = <LostPasswordPage basePath={ context.path } />;
+	next();
+}
+
+export function forgotUsername( context, next ) {
+	context.primary = <ForgotUsernamePage basePath={ context.path } />;
 	next();
 }
 

--- a/client/account-recovery/forgot-username/forgot-username-form/index.jsx
+++ b/client/account-recovery/forgot-username/forgot-username-form/index.jsx
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import { identity } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Button from 'components/button';
+import FormLabel from 'components/forms/form-label';
+import FormInput from 'components/forms/form-text-input';
+
+export class ForgotUsernameFormComponent extends Component {
+	constructor( ...args ) {
+		super( ...args );
+
+		this.state = {
+			isSubmitting: false,
+			firstName: '',
+			lastName: '',
+			siteUrl: '',
+		};
+	}
+
+	submitForm = () => {
+		this.setState( { isSubmitting: true } );
+
+		//TODO: dispatch an event with firstName, etc and wait to here back
+	};
+
+	firstNameUpdated = event => this.setState( { firstName: event.target.value } );
+	lastNameUpdated = event => this.setState( { lastName: event.target.value } );
+	siteUrlUpdated = event => this.setState( { siteUrl: event.target.value } );
+
+	render() {
+		const { translate } = this.props;
+		const { isSubmitting, firstName, lastName, siteUrl } = this.state;
+		const isPrimaryButtonEnabled = firstName && lastName && siteUrl && ! isSubmitting;
+
+		return (
+			<div>
+				<h2 className="forgot-username-form__title">
+					{ translate( 'Forgot your username?' ) }
+				</h2>
+				<p>{ translate( 'Enter your information to find your username' ) }</p>
+				<Card>
+					<FormLabel>
+						{ translate( 'First Name' ) }
+						<FormInput
+							className="forgot-username-form__first-name-input"
+							onChange={ this.firstNameUpdated }
+							value={ firstName }
+							disabled={ isSubmitting } />
+					</FormLabel>
+					<FormLabel>
+						{ translate( 'Last Name' ) }
+						<FormInput
+							className="forgot-username-form__last-name-input"
+							onChange={ this.lastNameUpdated }
+							value={ lastName }
+							disabled={ isSubmitting } />
+					</FormLabel>
+					<FormLabel>
+						{ translate( "Your site's URL" ) }
+						<FormInput
+							className="forgot-username-form__site-url-input"
+							onChange={ this.siteUrlUpdated }
+							value={ siteUrl }
+							disabled={ isSubmitting } />
+					</FormLabel>
+					<Button
+						className="forgot-username-form__submit-button"
+						onClick={ this.submitForm }
+						disabled={ ! isPrimaryButtonEnabled }
+						primary>
+						{ translate( 'Continue' ) }
+					</Button>
+				</Card>
+			</div>
+		);
+	}
+}
+
+ForgotUsernameFormComponent.defaultProps = {
+	translate: identity,
+};
+
+export default localize( ForgotUsernameFormComponent );

--- a/client/account-recovery/forgot-username/forgot-username-form/style.scss
+++ b/client/account-recovery/forgot-username/forgot-username-form/style.scss
@@ -1,0 +1,17 @@
+.forgot-username-form__title {
+	font-size: 20px;
+	font-weight: 600;
+}
+
+//Use a more specific selector here so we don't have to use !important to overide any css
+.forgot-username-form__first-name-input.form-text-input,
+.forgot-username-form__last-name-input.form-text-input,
+.forgot-username-form__site-url-input.form-text-input {
+	margin-top: 4px;
+	margin-bottom: 8px;
+}
+
+.forgot-username-form__submit-button.button {
+	margin-top: 16px;
+	width: 100%;
+}

--- a/client/account-recovery/forgot-username/forgot-username-form/test/index.jsx
+++ b/client/account-recovery/forgot-username/forgot-username-form/test/index.jsx
@@ -1,0 +1,139 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow, mount } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+import { ForgotUsernameFormComponent } from '..';
+
+describe( 'ForgotUsername', () => {
+	const inputSelectors = [
+		'.forgot-username-form__first-name-input',
+		'.forgot-username-form__last-name-input',
+		'.forgot-username-form__site-url-input',
+	];
+
+	it( 'should render as expected', () => {
+		const wrapper = shallow( <ForgotUsernameFormComponent /> );
+
+		expect( wrapper ).to.have.state( 'isSubmitting' ).to.be.false;
+
+		// Expect the fields to be enabled
+		inputSelectors.forEach( selector => {
+			expect( wrapper.find( selector ).prop( 'disabled' ) ).to.not.be.ok;
+		} );
+
+		expect( wrapper.find( '.forgot-username-form__submit-button' ).prop( 'disabled' ) ).to.be.ok;
+	} );
+
+	context( 'fields', () => {
+		useFakeDom();
+
+		it( 'should be disabled while submitting', function() {
+			const wrapper = mount( <ForgotUsernameFormComponent className="test__test" /> );
+
+			// Initialize all inputs with some dummy text
+			inputSelectors.forEach( selector => {
+				wrapper.find( selector ).node.value = 'dummy text';
+				wrapper.find( selector ).simulate( 'change' );
+			} );
+
+			wrapper.find( '.forgot-username-form__submit-button' ).simulate( 'click' );
+
+			expect( wrapper ).to.have.state( 'isSubmitting' ).to.be.true;
+
+			// Expect the fields to be disabled
+			inputSelectors.forEach( selector => {
+				expect( wrapper.find( selector ).prop( 'disabled' ) ).to.be.ok;
+			} );
+		} );
+	} );
+
+	context( 'submit button', () => {
+		useFakeDom();
+
+		it( 'should be disabled if first name field is blank', function() {
+			const wrapper = mount( <ForgotUsernameFormComponent className="test__test" /> );
+
+			// Initialize all inputs with some dummy text
+			inputSelectors.forEach( selector => {
+				wrapper.find( selector ).node.value = 'dummy text';
+				wrapper.find( selector ).simulate( 'change' );
+			} );
+
+			// Change the field to be empty
+			wrapper.find( '.forgot-username-form__first-name-input' ).node.value = '';
+			wrapper.find( '.forgot-username-form__first-name-input' ).simulate( 'change' );
+
+			// Expect the button to be disabled
+			expect( wrapper.find( '.forgot-username-form__submit-button' ).prop( 'disabled' ) ).to.be.ok;
+		} );
+
+		it( 'should be disabled if last name field is blank', function() {
+			const wrapper = mount( <ForgotUsernameFormComponent className="test__test" /> );
+
+			// Initialize all inputs with some dummy text
+			inputSelectors.forEach( selector => {
+				wrapper.find( selector ).node.value = 'dummy text';
+				wrapper.find( selector ).simulate( 'change' );
+			} );
+
+			// Change the field to be empty
+			wrapper.find( '.forgot-username-form__last-name-input' ).node.value = '';
+			wrapper.find( '.forgot-username-form__last-name-input' ).simulate( 'change' );
+
+			// Expect the button to be disabled
+			expect( wrapper.find( '.forgot-username-form__submit-button' ).prop( 'disabled' ) ).to.be.ok;
+		} );
+
+		it( 'should be disabled if site url field is blank', function() {
+			const wrapper = mount( <ForgotUsernameFormComponent className="test__test" /> );
+
+			// Initialize all inputs with some dummy text
+			inputSelectors.forEach( selector => {
+				wrapper.find( selector ).node.value = 'dummy text';
+				wrapper.find( selector ).simulate( 'change' );
+			} );
+
+			// Change the field to be empty
+			wrapper.find( '.forgot-username-form__site-url-input' ).node.value = '';
+			wrapper.find( '.forgot-username-form__site-url-input' ).simulate( 'change' );
+
+			// Expect the button to be disabled
+			expect( wrapper.find( '.forgot-username-form__submit-button' ).prop( 'disabled' ) ).to.be.ok;
+		} );
+
+		it( 'should be enabled when all fields are filled in', function() {
+			const wrapper = mount( <ForgotUsernameFormComponent className="test__test" /> );
+
+			// Initialize all inputs with some dummy text
+			inputSelectors.forEach( selector => {
+				wrapper.find( selector ).node.value = 'dummy text';
+				wrapper.find( selector ).simulate( 'change' );
+			} );
+
+			// Expect the button to be enabled
+			expect( wrapper.find( '.forgot-username-form__submit-button' ).prop( 'disabled' ) ).to.not.be.ok;
+		} );
+
+		it( 'should be disabled when clicked', function() {
+			const wrapper = mount( <ForgotUsernameFormComponent className="test__test" /> );
+
+			// Initialize all inputs with some dummy text
+			inputSelectors.forEach( selector => {
+				wrapper.find( selector ).node.value = 'dummy text';
+				wrapper.find( selector ).simulate( 'change' );
+			} );
+
+			wrapper.find( '.forgot-username-form__submit-button' ).simulate( 'click' );
+
+			expect( wrapper ).to.have.state( 'isSubmitting' ).to.be.true;
+			expect( wrapper.find( '.forgot-username-form__submit-button' ).prop( 'disabled' ) ).to.be.ok;
+		} );
+	} );
+} );

--- a/client/account-recovery/forgot-username/index.jsx
+++ b/client/account-recovery/forgot-username/index.jsx
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import Main from 'components/main';
+import DocumentHead from 'components/data/document-head';
+import ForgotUsernameForm from './forgot-username-form';
+
+export default localize( ( { className, translate, basePath } ) => (
+	<Main className={ classnames( 'forgot-username', className ) }>
+		<PageViewTracker path={ basePath } title="Account Recovery > Forgot Username" />
+		<DocumentHead title={ translate( 'Forgot Username ‹ Account Recovery' ) } />
+		<ForgotUsernameForm />
+	</Main>
+) );

--- a/client/account-recovery/index.js
+++ b/client/account-recovery/index.js
@@ -1,9 +1,14 @@
 /**
  * Internal dependencies
  */
-import { lostPassword, redirectLoggedIn } from './controller';
+import {
+	lostPassword,
+	forgotUsername,
+	redirectLoggedIn
+} from './controller';
 
 export default function( router ) {
 	// Main route for account recovery is the lost password page
 	router( '/account-recovery', redirectLoggedIn, lostPassword );
+	router( '/account-recovery/forgot-username', redirectLoggedIn, forgotUsername );
 }

--- a/client/account-recovery/lost-password/lost-password-form/index.jsx
+++ b/client/account-recovery/lost-password/lost-password-form/index.jsx
@@ -88,7 +88,7 @@ export class LostPasswordFormComponent extends Component {
 							value={ userLogin }
 							disabled={ isSubmitting } />
 					</FormLabel>
-					<a href="/account-recovery/username" className="lost-password-form__forgot-username-link">
+					<a href="/account-recovery/forgot-username" className="lost-password-form__forgot-username-link">
 						{ translate( 'Forgot your username?' ) }
 					</a>
 					<Button

--- a/client/account-recovery/style.scss
+++ b/client/account-recovery/style.scss
@@ -1,4 +1,9 @@
 .is-section-account-recovery .main {
+	padding: 21px 10px;
 	max-width: 480px;
 	font-size: 13px;
+
+	@include breakpoint( ">660px" ) {
+		padding: 0px 10px;
+	}
 }


### PR DESCRIPTION
# Account Recovery: add a forgot your username page

This pull request adds the forgot username screen to the account recovery flow. This page doesn't actually do anything since a redux state tree hasn't been implemented yet to support any actions.

### How to test
#### Functionality
1. Navigate to http://calypso.localhost:3000/account-recovery/forgot-username
2. Enter a first name, last name and site url
3. Click "Continue"
4. Notice that the form is disabled
#### Responsiveness
1. Navigate to http://calypso.localhost:3000/account-recovery/forgot-username
2. Resize browser so that its small
3. Notice that the form is responsive
#### automated tests

Run `npm run test-client client/account-recovery/forgot-username`
### What to expect

![screen shot 2016-12-07 at 12 27 24 pm](https://cloud.githubusercontent.com/assets/1854440/20978885/9abe0bec-bc78-11e6-9ef0-2e166e2915ac.png)
![screen shot 2016-12-07 at 12 27 38 pm](https://cloud.githubusercontent.com/assets/1854440/20978894/9e717c74-bc78-11e6-93b6-d6955368a6b5.png)
![screen shot 2016-12-07 at 12 24 04 pm](https://cloud.githubusercontent.com/assets/1854440/20978902/a5dcd90e-bc78-11e6-8b34-3a5e865c6ce2.png)
