### PR TITLE
Pages: Don't show "Set as Homepage" outside of a single site context

### DIFF
--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -25,6 +25,7 @@ var updatePostStatus = require( 'lib/mixins/update-post-status' ),
 	config = require( 'config' );
 
 import MenuSeparator from 'components/popover/menu-separator';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { hasStaticFrontPage } from 'state/sites/selectors';
 import {
 	isFrontPage,
@@ -113,6 +114,10 @@ const Page = React.createClass( {
 	},
 
 	getSetAsHomepageItem: function() {
+		if ( ! this.props.selectedSiteId ) {
+			return null;
+		}
+
 		const isPublished = this.props.page.status === 'publish';
 
 		if ( ! isPublished || this.props.isFrontPage ||
@@ -414,6 +419,7 @@ const Page = React.createClass( {
 export default connect(
 	( state, props ) => {
 		return {
+			selectedSiteId: getSelectedSiteId( state ),
 			hasStaticFrontPage: hasStaticFrontPage( state, props.page.site_ID ),
 			isFrontPage: isFrontPage( state, props.page.site_ID, props.page.ID ),
 			isPostsPage: isPostsPage( state, props.page.site_ID, props.page.ID ),


### PR DESCRIPTION
If no site is selected, simply don't render the menu item

## To test:

### Reproduce existing behavior
* Go to `/pages` on master
* Click on the ellipsis for a page
* See the "Set as Homepage" menu item

### Verify the fix
* Switch to this branch
* Go to `/pages`
* Click on the ellipsis for a page
* Verify you do not see the "Set as Homepage" menu item
* Sanity check all other menu items & their behavior
* Select a test site
* Ensure the "Set as Hompage" menu item is present & functional as before
* Sanity check all other menu items & their behavior

Fixes #9548