### PR TITLE
Signup: add Tracks event for Signup step submission

### DIFF
--- a/client/lib/signup/actions.js
+++ b/client/lib/signup/actions.js
@@ -27,7 +27,7 @@ const SignupActions = {
 	},
 
 	submitSignupStep( step, errors, providedDependencies ) {
-		analytics.tracks.recordEvent( 'calypso_signup_actions_submit_step', { step: step.stepName } );
+		analytics.tracks.recordEvent( 'calypso_signup_actions_submit_step', { step: step.stepName, ...providedDependencies } );
 
 		Dispatcher.handleViewAction( {
 			type: 'SUBMIT_SIGNUP_STEP',

--- a/client/lib/signup/actions.js
+++ b/client/lib/signup/actions.js
@@ -26,7 +26,7 @@ const SignupActions = {
 	},
 
 	submitSignupStep( step, errors, providedDependencies ) {
-		analytics.tracks.recordEvent( 'calypso_signup_actions_submit_step', { step: step.stepName, ...providedDependencies } );
+		analytics.tracks.recordEvent( 'calypso_signup_actions_submit_step', { ...providedDependencies, step: step.stepName } );
 
 		Dispatcher.handleViewAction( {
 			type: 'SUBMIT_SIGNUP_STEP',

--- a/client/lib/signup/actions.js
+++ b/client/lib/signup/actions.js
@@ -15,7 +15,6 @@ const SignupActions = {
 	},
 
 	saveSignupStep( step ) {
-
 		// there are some conditions in which a step could be saved/processed in the same event loop
 		// so we should defer the action
 		defer( () => {
@@ -38,7 +37,6 @@ const SignupActions = {
 	},
 
 	processSignupStep( step, errors, providedDependencies ) {
-
 		// deferred because a step can be processed as soon as it is submitted
 		defer( () => {
 			Dispatcher.handleViewAction( {

--- a/client/lib/signup/actions.js
+++ b/client/lib/signup/actions.js
@@ -27,6 +27,7 @@ const SignupActions = {
 	},
 
 	submitSignupStep( step, errors, providedDependencies ) {
+		analytics.tracks.recordEvent( 'calypso_signup_actions_submit_step', { step: step.stepName } );
 
 		Dispatcher.handleViewAction( {
 			type: 'SUBMIT_SIGNUP_STEP',


### PR DESCRIPTION
### To Test:
1. Visit Signup (`/start/`)
2. Console log the analytics library (`localStorage.setItem('debug', 'calypso:analytics');`
3. Verify that the `calypso_signup_actions_submit_step` event is fired when each step is submitted.