### PR TITLE
Theme Sheet: Use information from WordPress.org for themes on Jetpack sites

### DIFF
--- a/client/components/data/query-active-theme/index.jsx
+++ b/client/components/data/query-active-theme/index.jsx
@@ -12,10 +12,7 @@ import { isRequestingActiveTheme } from 'state/themes/selectors';
 
 class QueryActiveTheme extends Component {
 	static propTypes = {
-		siteId: PropTypes.oneOfType( [
-			PropTypes.number,
-			PropTypes.oneOf( [ 'wpcom' ] )
-		] ).isRequired,
+		siteId: PropTypes.number.isRequired,
 		// Connected props
 		isRequesting: PropTypes.bool.isRequired,
 		requestActiveTheme: PropTypes.func.isRequired,

--- a/client/components/data/query-theme/index.jsx
+++ b/client/components/data/query-theme/index.jsx
@@ -14,7 +14,7 @@ class QueryTheme extends Component {
 	static propTypes = {
 		siteId: PropTypes.oneOfType( [
 			PropTypes.number,
-			PropTypes.oneOf( [ 'wpcom' ] )
+			PropTypes.oneOf( [ 'wpcom', 'wporg' ] )
 		] ).isRequired,
 		themeId: PropTypes.string.isRequired,
 		// Connected props

--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -95,5 +95,39 @@ module.exports = {
 			.end( function( err, data ) {
 				callback( err, data.body );
 			} );
-	}
+	},
+	/**
+	 * Get information about a given theme from the WordPress.org API.
+	 * If provided with a callback, will call that on succes with an object with theme details.
+	 * Otherwise, will return a promise.
+	 *
+	 * @param {string}     themeId  The theme identifier.
+	 * @param {function}   callback Callback that gets executed after the XHR returns the results.
+	 * @returns {?Promise} Promise  that is returned if no callback parameter is passed
+	 */
+	fetchThemeInformation: function( themeId, callback ) {
+		const url = 'https://api.wordpress.org/themes/info/1.1/';
+		const query = { action: 'theme_information', 'request[slug]': themeId };
+		// if callback is provided, behave traditionally
+		if ( 'function' === typeof callback ) {
+			return superagent
+				.get( url )
+				.set( 'Accept', 'application/json' )
+				.query( query )
+				.end( ( err, { body } ) => {
+					callback( err, body );
+				} );
+		}
+
+		// otherwise, return a Promise
+		return new Promise( ( resolve, reject ) => {
+			return superagent
+				.get( url )
+				.set( 'Accept', 'application/json' )
+				.query( query )
+				.end( ( err, { body } ) => {
+					err ? reject( err ) : resolve( body );
+				} );
+		} );
+	},
 };

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -28,7 +28,6 @@ import { getSelectedSite } from 'state/ui/selectors';
 import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { isUserPaid } from 'state/purchases/selectors';
-import { getForumUrl } from 'my-sites/themes/helpers';
 import { isPremiumTheme as isPremium } from 'state/themes/utils';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 import QueryActiveTheme from 'components/data/query-active-theme';
@@ -37,7 +36,7 @@ import QueryUserPurchases from 'components/data/query-user-purchases';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemesSiteSelectorModal from 'my-sites/themes/themes-site-selector-modal';
 import { connectOptions } from 'my-sites/themes/theme-options';
-import { isThemeActive, isThemePurchased, getThemeRequestErrors } from 'state/themes/selectors';
+import { isThemeActive, isThemePurchased, getThemeRequestErrors, getThemeForumUrl } from 'state/themes/selectors';
 import { getBackPath } from 'state/themes/themes-ui/selectors';
 import EmptyContentComponent from 'components/empty-content';
 import ThemePreview from 'my-sites/themes/theme-preview';
@@ -278,7 +277,7 @@ const ThemeSheet = React.createClass( {
 					{ i18n.translate( 'Have a question about this theme?' ) }
 					<small>{ description }</small>
 				</div>
-				<Button primary={ isPrimary } href={ getForumUrl( this.props ) }>Visit forum</Button>
+				<Button primary={ isPrimary } href={ this.props.forumUrl }>Visit forum</Button>
 			</Card>
 		);
 	},
@@ -601,6 +600,7 @@ export default connect(
 				isThemePurchased( state, id, selectedSite.ID ) ||
 				hasFeature( state, selectedSite.ID, FEATURE_UNLIMITED_PREMIUM_THEMES )
 			),
+			forumUrl: getThemeForumUrl( state, id )
 		};
 	}
 )( ThemeSheetWithOptions );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -319,13 +319,16 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderFeaturesCard() {
-		const { siteSlug, taxonomies } = this.props;
+		const { isJetpack, siteSlug, taxonomies } = this.props;
 		const themeFeatures = taxonomies && taxonomies.theme_feature instanceof Array
 		? taxonomies.theme_feature.map( function( item ) {
 			const term = isValidTerm( item.slug ) ? item.slug : `feature:${ item.slug }`;
 			return (
 				<li key={ 'theme-features-item-' + item.slug }>
-					<a href={ `/design/filter/${ term }/${ siteSlug || '' }` }>{ item.name }</a>
+					{ isJetpack
+						? <a>{ item.name }</a>
+						: <a href={ `/design/filter/${ term }/${ siteSlug || '' }` }>{ item.name }</a>
+					}
 				</li>
 			);
 		} ) : [];

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -266,6 +266,10 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderThemeForumCard( isPrimary = false ) {
+		if ( ! this.props.forumUrl ) {
+			return null;
+		}
+
 		const description = isPremium( this.props )
 			? i18n.translate( 'Get in touch with the theme author' )
 			: i18n.translate( 'Get help from volunteers and staff' );
@@ -606,7 +610,7 @@ export default connect(
 				isThemePurchased( state, id, selectedSite.ID ) ||
 				hasFeature( state, selectedSite.ID, FEATURE_UNLIMITED_PREMIUM_THEMES )
 			),
-			forumUrl: getThemeForumUrl( state, id )
+			forumUrl: selectedSite && getThemeForumUrl( state, id, selectedSite.ID )
 		};
 	}
 )( ThemeSheetWithOptions );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -237,7 +237,7 @@ const ThemeSheet = React.createClass( {
 				</Card>
 				{ this.renderFeaturesCard() }
 				{ this.renderDownload() }
-				{ this.renderRelatedThemes() }
+				{ ! this.props.isJetpack && this.renderRelatedThemes() }
 			</div>
 		);
 	},

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -339,7 +339,13 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderDownload() {
-		if ( isPremium( this.props ) ) {
+		// Don't render download button:
+		// * If it's a premium theme
+		// * If it's on a Jetpack site, and the theme object doesn't have a 'download' attr
+		//   Note that not having a 'download' attr would be permissible for a theme on WPCOM
+		//   since we don't provide any for some themes found on WordPress.org (notably the 'Twenties').
+		//   The <ThemeDownloadCard /> component can handle that case.
+		if ( isPremium( this.props ) || ( this.props.isJetpack && ! this.props.download ) ) {
 			return null;
 		}
 		return <ThemeDownloadCard theme={ this.props.id } href={ this.props.download } />;

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -156,6 +156,17 @@ const ThemeSheet = React.createClass( {
 		return null;
 	},
 
+	renderPreviewButton() {
+		return (
+			<a className="theme__sheet-preview-link" onClick={ this.togglePreview } data-tip-target="theme-sheet-preview">
+				<Gridicon icon="themes" size={ 18 } />
+				<span className="theme__sheet-preview-link-text">
+					{ i18n.translate( 'Open Live Demo', { context: 'Individual theme live preview button' } ) }
+				</span>
+			</a>
+		);
+	},
+
 	renderScreenshot() {
 		let screenshot;
 		if ( this.props.isJetpack ) {
@@ -166,12 +177,7 @@ const ThemeSheet = React.createClass( {
 		const img = screenshot && <img className="theme__sheet-img" src={ screenshot + '?=w680' } />;
 		return (
 			<div className="theme__sheet-screenshot">
-				<a className="theme__sheet-preview-link" onClick={ this.togglePreview } data-tip-target="theme-sheet-preview">
-					<Gridicon icon="themes" size={ 18 } />
-					<span className="theme__sheet-preview-link-text">
-						{ i18n.translate( 'Open Live Demo', { context: 'Individual theme live preview button' } ) }
-					</span>
-				</a>
+				{ this.props.demo_uri && this.renderPreviewButton() }
 				{ img }
 			</div>
 		);

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -426,7 +426,7 @@ const ThemeSheet = React.createClass( {
 		const analyticsPath = `/theme/:slug${ section ? '/' + section : '' }${ siteID ? '/:site_id' : '' }`;
 		const analyticsPageTitle = `Themes > Details Sheet${ section ? ' > ' + titlecase( section ) : '' }${ siteID ? ' > Site' : '' }`;
 
-		const { name: themeName, description, currentUserId, siteIdOrWpcom } = this.props;
+		const { name: themeName, description, currentUserId, isJetpack, siteIdOrWpcom } = this.props;
 		const title = themeName && i18n.translate( '%(themeName)s Theme', {
 			args: { themeName }
 		} );
@@ -451,6 +451,7 @@ const ThemeSheet = React.createClass( {
 		return (
 			<Main className="theme__sheet">
 				<QueryTheme themeId={ this.props.id } siteId={ siteIdOrWpcom } />
+				{ isJetpack && <QueryTheme themeId={ this.props.id } siteId="wporg" /> }
 				{ currentUserId && <QueryUserPurchases userId={ currentUserId } /> }
 				{ siteID && <QuerySitePurchases siteId={ siteID } /> }
 				{ siteID && <QuerySitePlans siteId={ siteID } /> }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -577,6 +577,7 @@ export default connect(
 		const isCurrentUserPaid = isUserPaid( state, currentUserId );
 		const theme = getTheme( state, siteIdOrWpcom, id );
 		const error = theme ? false : getThemeRequestErrors( state, id, siteIdOrWpcom );
+
 		return {
 			...theme,
 			id,

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import i18n from 'i18n-calypso';
 import titlecase from 'to-title-case';
+import { isArray } from 'lodash';
 
 /**
  * Internal dependencies
@@ -320,8 +321,11 @@ const ThemeSheet = React.createClass( {
 
 	renderFeaturesCard() {
 		const { isJetpack, siteSlug, taxonomies } = this.props;
-		const themeFeatures = taxonomies && taxonomies.theme_feature instanceof Array
-		? taxonomies.theme_feature.map( function( item ) {
+		if ( ! taxonomies || ! isArray( taxonomies.theme_feature ) ) {
+			return null;
+		}
+
+		const themeFeatures = taxonomies.theme_feature.map( function( item ) {
 			const term = isValidTerm( item.slug ) ? item.slug : `feature:${ item.slug }`;
 			return (
 				<li key={ 'theme-features-item-' + item.slug }>
@@ -331,7 +335,7 @@ const ThemeSheet = React.createClass( {
 					}
 				</li>
 			);
-		} ) : [];
+		} );
 
 		return (
 			<div>

--- a/client/my-sites/theme/test/main.jsx
+++ b/client/my-sites/theme/test/main.jsx
@@ -32,7 +32,6 @@ describe( 'main', function() {
 			mockery.registerMock( 'lib/analytics', {} );
 			mockery.registerMock( 'my-sites/themes/helpers', {
 				isPremium: noop,
-				getForumUrl: noop,
 				getDetailsUrl: noop,
 			} );
 			mockery.registerSubstitute( 'matches-selector', 'component-matches-selector' );

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -14,7 +14,7 @@ import mapValues from 'lodash/mapValues';
  */
 import config from 'config';
 import { sectionify } from 'lib/route/path';
-import { oldShowcaseUrl, isPremiumTheme as isPremium } from 'state/themes/utils';
+import { oldShowcaseUrl } from 'state/themes/utils';
 
 export function getPreviewUrl( theme ) {
 	return `${ theme.demo_uri }?demo=true&iframe=true&theme_preview=true`;
@@ -62,10 +62,6 @@ export function getSupportUrl( theme, site ) {
 
 	const sitePart = site ? `${ site.slug }/` : '';
 	return `${ oldShowcaseUrl }${ sitePart }${ theme.id }/support`;
-}
-
-export function getForumUrl( theme ) {
-	return isPremium( theme ) ? '//premium-themes.forums.wordpress.com/forum/' + theme.id : '//en.forums.wordpress.com/forum/themes';
 }
 
 export function getHelpUrl( theme, site ) {

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -16,11 +16,7 @@ import config from 'config';
 import { sectionify } from 'lib/route/path';
 import { oldShowcaseUrl, isPremiumTheme as isPremium } from 'state/themes/utils';
 
-export function getPreviewUrl( theme, site ) {
-	if ( site && site.jetpack ) {
-		return site.options.admin_url + 'customize.php?theme=' + theme.id + '&return=' + encodeURIComponent( window.location );
-	}
-
+export function getPreviewUrl( theme ) {
 	return `${ theme.demo_uri }?demo=true&iframe=true&theme_preview=true`;
 }
 

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -11,13 +11,14 @@ import { translate } from 'i18n-calypso';
  */
 import Dialog from 'components/dialog';
 import PulsingDot from 'components/pulsing-dot';
-import { getForumUrl, trackClick } from './helpers';
+import { trackClick } from './helpers';
 import { isJetpackSite } from 'state/sites/selectors';
 import {
 	getActiveTheme,
 	getTheme,
 	getThemeDetailsUrl,
 	getThemeCustomizeUrl,
+	getThemeForumUrl,
 	isActivatingTheme,
 	hasActivatedTheme
 } from 'state/themes/selectors';
@@ -82,7 +83,7 @@ const ThanksModal = React.createClass( {
 			<li>
 				{ translate( 'Have questions? Stop by our {{a}}support forums.{{/a}}', {
 					components: {
-						a: <a href={ getForumUrl( this.props.currentTheme ) }
+						a: <a href={ this.props.forumUrl }
 							onClick={ this.onLinkClick( 'support' ) } />
 					}
 				} ) }
@@ -209,6 +210,7 @@ export default connect(
 			currentTheme,
 			detailsUrl: site && getThemeDetailsUrl( state, currentTheme, site.ID ),
 			customizeUrl: site && getThemeCustomizeUrl( state, currentTheme, site.ID ),
+			forumUrl: getThemeForumUrl( state, currentThemeId ),
 			isActivating: !! ( site && isActivatingTheme( state, site.ID ) ),
 			hasActivated: !! ( site && hasActivatedTheme( state, site.ID ) )
 		};

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -8,6 +8,7 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import wpcom from 'lib/wp';
+import wporg from 'lib/wporg';
 import {
 	// Old action names
 	THEME_BACK_PATH_SET,
@@ -256,6 +257,24 @@ export function requestTheme( themeId, siteId ) {
 			siteId,
 			themeId
 		} );
+
+		if ( siteId === 'wporg' ) {
+			return wporg.fetchThemeInformation( themeId ).then( ( theme ) => {
+				dispatch( receiveTheme( theme, siteId ) );
+				dispatch( {
+					type: THEME_REQUEST_SUCCESS,
+					siteId,
+					themeId
+				} );
+			} ).catch( ( error ) => {
+				dispatch( {
+					type: THEME_REQUEST_FAILURE,
+					siteId,
+					themeId,
+					error
+				} );
+			} );
+		}
 
 		if ( siteId === 'wpcom' ) {
 			return wpcom.undocumented().themeDetails( themeId ).then( ( theme ) => {

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -44,7 +44,12 @@ import {
 import { isJetpackSite } from 'state/sites/selectors';
 import { getActiveTheme } from './selectors';
 import { getQueryParams } from './themes-list/selectors';
-import { getThemeIdFromStylesheet, filterThemesForJetpack, normalizeWpcomTheme } from './utils';
+import {
+	getThemeIdFromStylesheet,
+	filterThemesForJetpack,
+	normalizeWpcomTheme,
+	normalizeWporgTheme
+} from './utils';
 
 const debug = debugFactory( 'calypso:themes:actions' ); //eslint-disable-line no-unused-vars
 
@@ -260,7 +265,7 @@ export function requestTheme( themeId, siteId ) {
 
 		if ( siteId === 'wporg' ) {
 			return wporg.fetchThemeInformation( themeId ).then( ( theme ) => {
-				dispatch( receiveTheme( theme, siteId ) );
+				dispatch( receiveTheme( normalizeWporgTheme( theme ), siteId ) );
 				dispatch( {
 					type: THEME_REQUEST_SUCCESS,
 					siteId,

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -265,6 +265,11 @@ export function requestTheme( themeId, siteId ) {
 
 		if ( siteId === 'wporg' ) {
 			return wporg.fetchThemeInformation( themeId ).then( ( theme ) => {
+				// Apparently, the WP.org REST API endpoint doesn't 404 but instead returns false
+				// if a theme can't be found.
+				if ( ! theme ) {
+					throw ( 'Theme not found' ); // Will be caught by .catch() below
+				}
 				dispatch( receiveTheme( normalizeWporgTheme( theme ), siteId ) );
 				dispatch( {
 					type: THEME_REQUEST_SUCCESS,

--- a/client/state/themes/schema.js
+++ b/client/state/themes/schema.js
@@ -80,7 +80,7 @@ export const queriesSchema = {
 export const activeThemesSchema = {
 	type: 'object',
 	patternProperties: {
-		'^(wpcom|\\d+)$': {
+		'^\\d+$': {
 			description: 'Theme ID',
 			type: 'string'
 		}

--- a/client/state/themes/schema.js
+++ b/client/state/themes/schema.js
@@ -28,7 +28,7 @@ export const queriesSchema = {
 	type: 'object',
 	patternProperties: {
 		// Site ID
-		'^(wpcom|\\d+)$': {
+		'^(wpcom|wporg|\\d+)$': {
 			type: 'object',
 			properties: {
 				data: {

--- a/client/state/themes/schema.js
+++ b/client/state/themes/schema.js
@@ -18,8 +18,6 @@ const themeSchema = {
 		'name',
 		'author',
 		'screenshot',
-		'stylesheet',
-		'demo_uri',
 		'author_uri'
 	]
 };

--- a/client/state/themes/schema.js
+++ b/client/state/themes/schema.js
@@ -17,8 +17,7 @@ const themeSchema = {
 		'id',
 		'name',
 		'author',
-		'screenshot',
-		'author_uri'
+		'screenshot'
 	]
 };
 

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -447,9 +447,17 @@ export function getThemeSignupUrl( state, theme ) {
  *
  * @param  {Object}  state   Global state tree
  * @param  {String}  themeId Theme ID
+ * @param  {String}  siteId  Site ID
  * @return {?String}         Theme forum URL
  */
-export function getThemeForumUrl( state, themeId ) {
+export function getThemeForumUrl( state, themeId, siteId ) {
+	if ( isJetpackSite( state, siteId ) ) {
+		if ( isWporgTheme( state, themeId ) ) {
+			return '//wordpress.org/support/theme/' + themeId;
+		}
+		return null;
+	}
+
 	if ( isThemePremium( state, themeId ) ) {
 		return '//premium-themes.forums.wordpress.com/forum/' + themeId;
 	}

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -72,7 +72,7 @@ export const getTheme = createSelector(
 		}
 		return {
 			...theme,
-			...pick( wporgTheme, [ 'demo_uri', 'download' ] )
+			...pick( wporgTheme, [ 'demo_uri', 'download', 'taxonomies' ] )
 		};
 	},
 	( state ) => state.themes.queries

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { includes, isEqual, omit, some, get } from 'lodash';
+import { includes, isEqual, omit, some, get, pick } from 'lodash';
 import createSelector from 'lib/create-selector';
 
 /**
@@ -60,7 +60,20 @@ export const getTheme = createSelector(
 			return null;
 		}
 
-		return manager.getItem( themeId );
+		const theme = manager.getItem( themeId );
+		if ( siteId === 'wpcom' || siteId === 'wporg' ) {
+			return theme;
+		}
+		// We're dealing with a Jetpack site. If we have theme info obtained from the
+		// WordPress.org API, merge it.
+		const wporgTheme = getTheme( state, 'wporg', themeId );
+		if ( ! wporgTheme ) {
+			return theme;
+		}
+		return {
+			...theme,
+			...pick( wporgTheme, [ 'demo_uri' ] )
+		};
 	},
 	( state ) => state.themes.queries
 );

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -72,7 +72,7 @@ export const getTheme = createSelector(
 		}
 		return {
 			...theme,
-			...pick( wporgTheme, [ 'demo_uri' ] )
+			...pick( wporgTheme, [ 'demo_uri', 'download' ] )
 		};
 	},
 	( state ) => state.themes.queries

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -292,6 +292,17 @@ export function isRequestingActiveTheme( state, siteId ) {
 }
 
 /**
+ * Whether a theme is present in the WordPress.org Theme Directory
+ *
+ * @param  {Object}  state   Global state tree
+ * @param  {Number}  themeId Theme ID
+ * @return {Boolean}         Whether theme is in WP.org theme directory
+ */
+export function isWporgTheme( state, themeId ) {
+	return !! getTheme( state, 'wporg', themeId );
+}
+
+/**
  * Returns the URL for a given theme's details sheet.
  *
  * @param  {Object}  state  Global state tree

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -229,19 +229,19 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestTheme()', () => {
-		useNock( ( nock ) => {
-			nock( 'https://public-api.wordpress.com:443' )
-				.persist()
-				.get( '/rest/v1.2/themes/twentysixteen' )
-				.reply( 200, { id: 'twentysixteen', name: 'Twenty Sixteen' } )
-				.get( '/rest/v1.2/themes/twentyumpteen' )
-				.reply( 404, {
-					error: 'unknown_theme',
-					message: 'Unknown theme'
-				} );
-		} );
-
 		context( 'with a wpcom site', () => {
+			useNock( ( nock ) => {
+				nock( 'https://public-api.wordpress.com:443' )
+					.persist()
+					.get( '/rest/v1.2/themes/twentysixteen' )
+					.reply( 200, { id: 'twentysixteen', name: 'Twenty Sixteen' } )
+					.get( '/rest/v1.2/themes/twentyumpteen' )
+					.reply( 404, {
+						error: 'unknown_theme',
+						message: 'Unknown theme'
+					} );
+			} );
+
 			it( 'should dispatch request action when thunk triggered', () => {
 				requestTheme( 'twentysixteen', 'wpcom' )( spy );
 
@@ -285,9 +285,63 @@ describe( 'actions', () => {
 				} );
 			} );
 		} );
+
 		context( 'with a Jetpack site', () => {
-			// TODO!
-			// But do we have a theme details endpoint on Jetpack sites at all?
+			// see lib/wpcom-undocumented/lib/undocumented#jetpackThemeDetails
+			useNock( ( nock ) => {
+				nock( 'https://public-api.wordpress.com:443' )
+					.persist()
+					.post( '/rest/v1.1/sites/77203074/themes', { themes: 'twentyfifteen' } )
+					.reply( 200, { themes: [ { id: 'twentyfifteen', name: 'Twenty Fifteen' } ] } )
+					.post( '/rest/v1.1/sites/77203074/themes', { themes: 'twentyumpteen' } )
+					.reply( 404, {
+						error: 'unknown_theme',
+						message: 'Unknown theme'
+					} );
+			} );
+
+			it( 'should dispatch request action when thunk triggered', () => {
+				requestTheme( 'twentyfifteen', 77203074 )( spy );
+
+				expect( spy ).to.have.been.calledWith( {
+					type: THEME_REQUEST,
+					siteId: 77203074,
+					themeId: 'twentyfifteen'
+				} );
+			} );
+
+			it( 'should dispatch themes receive action when request completes', () => {
+				return requestTheme( 'twentyfifteen', 77203074 )( spy ).then( () => {
+					expect( spy ).to.have.been.calledWith( {
+						type: THEMES_RECEIVE,
+						themes: [
+							sinon.match( { id: 'twentyfifteen', name: 'Twenty Fifteen' } )
+						],
+						siteId: 77203074
+					} );
+				} );
+			} );
+
+			it( 'should dispatch themes request success action when request completes', () => {
+				return requestTheme( 'twentyfifteen', 77203074 )( spy ).then( () => {
+					expect( spy ).to.have.been.calledWith( {
+						type: THEME_REQUEST_SUCCESS,
+						siteId: 77203074,
+						themeId: 'twentyfifteen'
+					} );
+				} );
+			} );
+
+			it( 'should dispatch fail action when request fails', () => {
+				return requestTheme( 'twentyumpteen', 77203074 )( spy ).then( () => {
+					expect( spy ).to.have.been.calledWith( {
+						type: THEME_REQUEST_FAILURE,
+						siteId: 77203074,
+						themeId: 'twentyumpteen',
+						error: sinon.match( { message: 'Unknown theme' } )
+					} );
+				} );
+			} );
 		} );
 	} );
 

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -233,7 +233,7 @@ describe( 'actions', () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.2/themes/twentysixteen' )
-				.reply( 200, { id: 'twentysixteen', title: 'Twenty Sixteen' } )
+				.reply( 200, { id: 'twentysixteen', name: 'Twenty Sixteen' } )
 				.get( '/rest/v1.2/themes/twentyumpteen' )
 				.reply( 404, {
 					error: 'unknown_theme',
@@ -257,7 +257,7 @@ describe( 'actions', () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: THEMES_RECEIVE,
 						themes: [
-							sinon.match( { id: 'twentysixteen', title: 'Twenty Sixteen' } )
+							sinon.match( { id: 'twentysixteen', name: 'Twenty Sixteen' } )
 						],
 						siteId: 'wpcom'
 					} );

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -348,13 +348,13 @@ describe( 'actions', () => {
 			useNock( ( nock ) => {
 				nock( 'https://api.wordpress.org' )
 					.persist()
+					.defaultReplyHeaders( {
+						'Content-Type': 'application/json'
+					} )
 					.get( '/themes/info/1.1/?action=theme_information&request%5Bslug%5D=twentyseventeen' )
 					.reply( 200, { slug: 'twentyseventeen', name: 'Twenty Seventeen' } )
 					.get( '/themes/info/1.1/?action=theme_information&request%5Bslug%5D=twentyumpteen' )
-					.reply( 404, {
-						error: 'not_found',
-						message: 'Not found'
-					} );
+					.reply( 200, false );
 			} );
 
 			it( 'should dispatch request action when thunk triggered', () => {
@@ -395,7 +395,7 @@ describe( 'actions', () => {
 						type: THEME_REQUEST_FAILURE,
 						siteId: 'wporg',
 						themeId: 'twentyumpteen',
-						error: sinon.match( { message: 'Not Found' } )
+						error: sinon.match( 'not found' )
 					} );
 				} );
 			} );

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -1160,38 +1160,120 @@ describe( 'themes selectors', () => {
 	} );
 
 	describe( '#getThemeForumUrl', () => {
-		it( 'given a free theme, should return the general themes forum URL', () => {
-			const forumUrl = getThemeForumUrl(
-				{
-					themes: {
-						queries: {
-							wpcom: new ThemeQueryManager( {
-								items: { twentysixteen }
-							} )
+		context( 'on a WP.com site', () => {
+			it( 'given a free theme, should return the general themes forum URL', () => {
+				const forumUrl = getThemeForumUrl(
+					{
+						sites: {
+							items: {}
+						},
+						themes: {
+							queries: {
+								wpcom: new ThemeQueryManager( {
+									items: { twentysixteen }
+								} )
+							}
 						}
-					}
-				},
-				'twentysixteen'
-			);
+					},
+					'twentysixteen'
+				);
 
-			expect( forumUrl ).to.equal( '//en.forums.wordpress.com/forum/themes' );
+				expect( forumUrl ).to.equal( '//en.forums.wordpress.com/forum/themes' );
+			} );
+
+			it( 'given a premium theme, should return the specific theme forum URL', () => {
+				const forumUrl = getThemeForumUrl(
+					{
+						sites: {
+							items: {}
+						},
+						themes: {
+							queries: {
+								wpcom: new ThemeQueryManager( {
+									items: { mood }
+								} )
+							}
+						}
+					},
+					'mood'
+				);
+
+				expect( forumUrl ).to.equal( '//premium-themes.forums.wordpress.com/forum/mood' );
+			} );
 		} );
 
-		it( 'given a premium theme, should return the specific theme forum URL', () => {
-			const forumUrl = getThemeForumUrl(
-				{
-					themes: {
-						queries: {
-							wpcom: new ThemeQueryManager( {
-								items: { mood }
-							} )
+		context( 'on a Jetpack site', () => {
+			it( 'given a theme that\'s not found on WP.org, should return null', () => {
+				const forumUrl = getThemeForumUrl(
+					{
+						sites: {
+							items: {
+								77203074: {
+									ID: 77203074,
+									URL: 'https://example.net',
+									jetpack: true
+								}
+							}
+						},
+						themes: {
+							queries: {
+								wpcom: new ThemeQueryManager( {
+									items: { twentysixteen }
+								} )
+							}
+						}
+					},
+					'twentysixteen',
+					77203074
+				);
+
+				expect( forumUrl ).to.be.null;
+			} );
+
+			it( 'given a theme that\'s found on WP.org, should return the correspoding WP.org theme forum URL', () => {
+				const jetpackTheme = {
+					id: 'twentyseventeen',
+					name: 'Twenty Seventeen',
+					author: 'the WordPress team',
+				};
+				const wporgTheme = {
+					demo_uri: 'https://wp-themes.com/twentyseventeen',
+					download: 'http://downloads.wordpress.org/theme/twentyseventeen.1.1.zip',
+					taxonomies: {
+						theme_feature: {
+							'custom-header': 'Custom Header'
 						}
 					}
-				},
-				'mood'
-			);
+				};
 
-			expect( forumUrl ).to.equal( '//premium-themes.forums.wordpress.com/forum/mood' );
+				const forumUrl = getThemeForumUrl(
+					{
+						sites: {
+							items: {
+								77203074: {
+									ID: 77203074,
+									URL: 'https://example.net',
+									jetpack: true
+								}
+							}
+						},
+						themes: {
+							queries: {
+								77203074: new ThemeQueryManager( {
+									items: { twentyseventeen: jetpackTheme }
+								} ),
+								wporg: new ThemeQueryManager( {
+									items: { twentyseventeen: wporgTheme }
+								} )
+							}
+						}
+					},
+					'twentyseventeen',
+					77203074
+				);
+
+				expect( forumUrl ).to.equal( '//wordpress.org/support/theme/twentyseventeen' );
+			} );
 		} );
 	} );
 

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -130,6 +130,62 @@ describe( 'themes selectors', () => {
 
 			expect( theme ).to.equal( twentysixteen );
 		} );
+
+		context( 'on a Jetpack site', () => {
+			it( 'with a theme not found on WP.org, should return the theme object', () => {
+				const jetpackTheme = {
+					id: 'twentyseventeen',
+					name: 'Twenty Seventeen',
+					author: 'the WordPress team',
+				};
+
+				const theme = getTheme( {
+					themes: {
+						queries: {
+							2916284: new ThemeQueryManager( {
+								items: { twentyseventeen: jetpackTheme }
+							} )
+						}
+					}
+				}, 2916284, 'twentyseventeen' );
+
+				expect( theme ).to.deep.equal( jetpackTheme );
+			} );
+
+			it( 'with a theme found on WP.org, should return an object with some attrs merged from WP.org', () => {
+				const jetpackTheme = {
+					id: 'twentyseventeen',
+					name: 'Twenty Seventeen',
+					author: 'the WordPress team',
+				};
+				const wporgTheme = {
+					demo_uri: 'https://wp-themes.com/twentyseventeen',
+					download: 'http://downloads.wordpress.org/theme/twentyseventeen.1.1.zip',
+					taxonomies: {
+						theme_feature: {
+							'custom-header': 'Custom Header'
+						}
+					}
+				};
+				const theme = getTheme( {
+					themes: {
+						queries: {
+							2916284: new ThemeQueryManager( {
+								items: { twentyseventeen: jetpackTheme }
+							} ),
+							wporg: new ThemeQueryManager( {
+								items: { twentyseventeen: wporgTheme }
+							} ),
+						}
+					}
+				}, 2916284, 'twentyseventeen' );
+
+				expect( theme ).to.deep.equal( {
+					...jetpackTheme,
+					...wporgTheme
+				} );
+			} );
+		} );
 	} );
 
 	describe( '#getThemesRequestError()', () => {

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -29,6 +29,7 @@ import {
 	getThemeForumUrl,
 	getActiveTheme,
 	isRequestingActiveTheme,
+	isWporgTheme,
 	isThemeActive,
 	isActivatingTheme,
 	hasActivatedTheme,
@@ -1372,6 +1373,45 @@ describe( 'themes selectors', () => {
 		);
 
 			expect( isRequesting ).to.be.true;
+		} );
+	} );
+
+	describe( '#isWporgTheme()', () => {
+		it( 'should return false if theme is not found on WP.org', () => {
+			const isWporg = isWporgTheme( {
+				themes: {
+					queries: {
+					}
+				}
+			}, 'twentyseventeen' );
+
+			expect( isWporg ).to.be.false;
+		} );
+
+		it( 'should return true if theme is found on WP.org', () => {
+			const wporgTheme = {
+				id: 'twentyseventeen',
+				name: 'Twenty Seventeen',
+				author: 'wordpressdotorg',
+				demo_uri: 'https://wp-themes.com/twentyseventeen',
+				download: 'http://downloads.wordpress.org/theme/twentyseventeen.1.1.zip',
+				taxonomies: {
+					theme_feature: {
+						'custom-header': 'Custom Header'
+					}
+				}
+			};
+			const isWporg = isWporgTheme( {
+				themes: {
+					queries: {
+						wporg: new ThemeQueryManager( {
+							items: { twentyseventeen: wporgTheme }
+						} ),
+					}
+				}
+			}, 'twentyseventeen' );
+
+			expect( isWporg ).to.be.true;
 		} );
 	} );
 

--- a/client/state/themes/test/utils.js
+++ b/client/state/themes/test/utils.js
@@ -8,6 +8,7 @@ import { expect } from 'chai';
  */
 import {
 	normalizeWpcomTheme,
+	normalizeWporgTheme,
 	getThemeIdFromStylesheet,
 	getNormalizedThemesQuery,
 	getSerializedThemesQuery,
@@ -47,6 +48,31 @@ describe( 'utils', () => {
 				stylesheet: 'premium/mood',
 				demo_uri: 'https://mooddemo.wordpress.com/',
 				author_uri: 'https://wordpress.com/themes/'
+			} );
+		} );
+	} );
+
+	describe( '#normalizeWporgTheme()', () => {
+		it( 'should return an empty object when given no argument', () => {
+			const normalizedTheme = normalizeWporgTheme();
+			expect( normalizedTheme ).to.deep.equal( {} );
+		} );
+		it( 'should rename some keys', () => {
+			const normalizedTheme = normalizeWporgTheme( {
+				slug: 'twentyfifteen',
+				name: 'Twenty Fifteen',
+				author: 'wordpressdotorg',
+				screenshot_url: '//ts.w.org/wp-content/themes/twentyfifteen/screenshot.png?ver=1.7',
+				preview_url: 'https://wp-themes.com/twentyfifteen',
+				download_link: 'http://downloads.wordpress.org/theme/twentyfifteen.1.7.zip'
+			} );
+			expect( normalizedTheme ).to.deep.equal( {
+				id: 'twentyfifteen',
+				name: 'Twenty Fifteen',
+				author: 'wordpressdotorg',
+				screenshot: '//ts.w.org/wp-content/themes/twentyfifteen/screenshot.png?ver=1.7',
+				demo_uri: 'https://wp-themes.com/twentyfifteen',
+				download: 'http://downloads.wordpress.org/theme/twentyfifteen.1.7.zip'
 			} );
 		} );
 	} );

--- a/client/state/themes/test/utils.js
+++ b/client/state/themes/test/utils.js
@@ -64,7 +64,11 @@ describe( 'utils', () => {
 				author: 'wordpressdotorg',
 				screenshot_url: '//ts.w.org/wp-content/themes/twentyfifteen/screenshot.png?ver=1.7',
 				preview_url: 'https://wp-themes.com/twentyfifteen',
-				download_link: 'http://downloads.wordpress.org/theme/twentyfifteen.1.7.zip'
+				download_link: 'http://downloads.wordpress.org/theme/twentyfifteen.1.7.zip',
+				tags: {
+					'custom-header': 'Custom Header',
+					'two-columns': 'Two Columns'
+				}
 			} );
 			expect( normalizedTheme ).to.deep.equal( {
 				id: 'twentyfifteen',
@@ -72,7 +76,13 @@ describe( 'utils', () => {
 				author: 'wordpressdotorg',
 				screenshot: '//ts.w.org/wp-content/themes/twentyfifteen/screenshot.png?ver=1.7',
 				demo_uri: 'https://wp-themes.com/twentyfifteen',
-				download: 'http://downloads.wordpress.org/theme/twentyfifteen.1.7.zip'
+				download: 'http://downloads.wordpress.org/theme/twentyfifteen.1.7.zip',
+				taxonomies: {
+					theme_feature: [
+						{ slug: 'custom-header', name: 'Custom Header' },
+						{ slug: 'two-columns', name: 'Two Columns' }
+					]
+				}
 			} );
 		} );
 	} );

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import startsWith from 'lodash/startsWith';
-import { filter, get, mapKeys, omit, omitBy, split } from 'lodash';
+import { filter, get, map, mapKeys, omit, omitBy, split } from 'lodash';
 
 /**
  * Internal dependencies
@@ -37,6 +37,36 @@ export function normalizeWpcomTheme( theme ) {
 	return mapKeys( theme, ( value, key ) => (
 		get( attributesMap, key, key )
 	) );
+}
+
+/**
+ * Normalizes a theme obtained from the WordPress.org REST API
+ *
+ * @param  {Object} theme  Themes object
+ * @return {Object}        Normalized theme object
+ */
+export function normalizeWporgTheme( theme ) {
+	const attributesMap = {
+		slug: 'id',
+		preview_url: 'demo_uri',
+		screenshot_url: 'screenshot',
+		download_link: 'download'
+	};
+
+	const normalizedTheme = mapKeys( theme, ( value, key ) => (
+		get( attributesMap, key, key )
+	) );
+
+	if ( ! normalizedTheme.tags ) {
+		return normalizedTheme;
+	}
+
+	return {
+		...omit( normalizedTheme, 'tags' ),
+		taxonomies: { theme_feature: map( normalizedTheme.tags,
+			( name, slug ) => ( { name, slug } )
+		) }
+	};
 }
 
 /**


### PR DESCRIPTION
Allows us to find out if a theme on a Jetpack site is present on WP.org and act accordingly.

Implements https://github.com/Automattic/wp-calypso/pull/9869#issuecomment-265479960:

1. Show the tags in the features, but unlinked? ✅ 
2. Remove download as it would imply "download from Jetpack site" and doesn't seem entirely accurate to me. _-- I've kept it for now since I thought it might still be useful -- my counter-example being a Jetpress site that was recently transferred and is using a WPCOM theme the user _might_ also want to use elsewhere. Oh well, a bit contrived, I guess_ 😄 
3. You might also like: could [s]tay, but let's get without it for now. ✅ 
4. Support...
   * If it's a theme on .org, link to the theme's specific support forum (example: https://wordpress.org/support/theme/twentysixteen )
   * if it's not a theme on .org (i.e. custom, premium, etc.), hide the Support link

(Question about item 4. -- I'm not sure I've implemented it correctly, I'm currently _not_ removing the entire 'Support' tab but only the link to the theme forum. I wasn't sure I understood the idea correctly, and I thought the other two links might still make some sense even on a JP site. _Clarification needed_ 😄)

To do all that, this PR:
* Adds a `fetchThemeInformation` method to `lib/wporg`
* Changes `requestTheme` to hit that endpoint if `siteId === 'wporg'`, thus putting themes fetched from there in a new `wporg` subtree
* Adds a normalization util to account for different attribute names in objects obtained from the WP.org API
* Changes the `getTheme` selector so that if a theme on a JP site is requested, supplementary data (upon availability) such as demo URI, download URI, or `taxonomies` is merged into the returned object.
* Adds an `isWporgTheme( state, themeId )` aliasing `!! getTheme( state, 'wpcom', themeId )`
* Modifies the theme sheet to conditionally hide some UI elements (such as the 'Open Live Demo' link) if some given theme attributes aren't available (for cases where no data from WP.org was available).

To test:
* Try the theme sheet on a Jetpack site, ideally for a theme that's not on WPCOM. Try two different themes, one that _is_  on WP.org, and one that isn't.
* WP.org theme: Check that the following UI elements are present and work properly:
  * 'Open Live Demo' link
  * 'Download' button
  * Theme Features (but they don't link anywhere!)
  * Related theme suggestions are _not_ there
  * 'Visit forum' link in the 'Support' tab should point to theme-specific forum on WP.org
* non-WP.org theme: None of the above UI elements should be present
* Also check that wpcom theme sheets still work as before.

(For reference, here's an example response containing all the fields we can get from WP.org: https://api.wordpress.org/themes/info/1.1/?action=theme_information&request%5Bslug%5D=twentyfourteen)