### PR TITLE
Media: Implement MediaQueryManager

### DIFF
--- a/client/lib/query-manager/key.js
+++ b/client/lib/query-manager/key.js
@@ -1,9 +1,7 @@
 /**
  * External dependencies
  */
-import sortBy from 'lodash/sortBy';
-import toPairs from 'lodash/toPairs';
-import fromPairs from 'lodash/fromPairs';
+import { sortBy, toPairs, fromPairs, omitBy } from 'lodash';
 
 /**
  * QueryKey manages the serialization and deserialization of a query key for
@@ -11,13 +9,65 @@ import fromPairs from 'lodash/fromPairs';
  */
 export default class QueryKey {
 	/**
+	 * If defined in extending class, will omit all parameters where values
+	 * match that of the default query
+	 *
+	 * @type {?Object}
+	 */
+	static DEFAULT_QUERY = null;
+
+	/**
+	 * If defined in extending class as true, will omit all null values from
+	 * stringified or parsed query objects
+	 *
+	 * @type {Boolean}
+	 */
+	static OMIT_NULL_VALUES = false;
+
+	/**
+	 * Given a query object, determines which values of query are included in
+	 * stringification or parsed return value. The base class will omit only
+	 * undefined values, but can be extended to omit null values or values
+	 * matching those in a default query.
+	 *
+	 * @param  {Object} query Query object
+	 * @return {Object}       Pruned query object
+	 */
+	static omit( query ) {
+		const { OMIT_NULL_VALUES, DEFAULT_QUERY } = this;
+		if ( ! OMIT_NULL_VALUES && ! DEFAULT_QUERY ) {
+			return query;
+		}
+
+		return omitBy( query, ( value, key ) => {
+			if ( OMIT_NULL_VALUES && null === value ) {
+				return true;
+			}
+
+			if ( DEFAULT_QUERY && DEFAULT_QUERY[ key ] === value ) {
+				return true;
+			}
+
+			return false;
+		} );
+	}
+
+	/**
 	 * Returns a serialized query, given a query object
 	 *
 	 * @param  {Object} query Query object
 	 * @return {String}       Serialized query
 	 */
 	static stringify( query ) {
-		return JSON.stringify( sortBy( toPairs( query ), ( pair ) => pair[ 0 ] ) );
+		const prunedQuery = this.omit( query );
+
+		// A stable query is one which produces the same result regardless of
+		// key ordering in the original object, to ensure that:
+		//
+		// QueryKey.stringify( { a: 1, b: 2 } ) === QueryKey.stringify( { b: 2, a: 1 } )
+		const stableQuery = sortBy( toPairs( prunedQuery ), ( pair ) => pair[ 0 ] );
+
+		return JSON.stringify( stableQuery );
 	}
 
 	/**
@@ -27,6 +77,6 @@ export default class QueryKey {
 	 * @return {Object}     Query object
 	 */
 	static parse( key ) {
-		return fromPairs( JSON.parse( key ) );
+		return this.omit( fromPairs( JSON.parse( key ) ) );
 	}
 }

--- a/client/lib/query-manager/media/constants.js
+++ b/client/lib/query-manager/media/constants.js
@@ -1,0 +1,12 @@
+export const DEFAULT_MEDIA_QUERY = {
+	context: 'display',
+	http_envelope: false,
+	pretty: false,
+	number: 20,
+	offset: 0,
+	page: 1,
+	order: 'DESC',
+	order_by: 'date',
+	mime_type: '',
+	search: ''
+};

--- a/client/lib/query-manager/media/index.js
+++ b/client/lib/query-manager/media/index.js
@@ -1,0 +1,115 @@
+/**
+ * External dependencies
+ */
+import moment from 'moment';
+import { every, includes } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import PaginatedQueryManager from '../paginated';
+import MediaQueryKey from './key';
+import { DEFAULT_MEDIA_QUERY } from './constants';
+
+/**
+ * MediaQueryManager manages media which can be queried and change over time
+ */
+export default class MediaQueryManager extends PaginatedQueryManager {
+	/**
+	 * Returns true if the media item matches the given query, or false
+	 * otherwise.
+	 *
+	 * @param  {Object}  query Query object
+	 * @param  {Object}  media Item to consider
+	 * @return {Boolean}       Whether media item matches query
+	 */
+	matches( query, media ) {
+		return every( { ...DEFAULT_MEDIA_QUERY, ...query }, ( value, key ) => {
+			switch ( key ) {
+				case 'search':
+					if ( ! value ) {
+						return true;
+					}
+
+					return media.title && includes( media.title.toLowerCase(), value.toLowerCase() );
+
+				case 'mime_type':
+					if ( ! value ) {
+						return true;
+					}
+
+					// See: https://developer.wordpress.org/reference/functions/wp_post_mime_type_where/
+					return new RegExp( `^${
+						value
+							// Replace wildcard-only, wildcard group, and empty
+							// group with wildcard pattern matching
+							.replace( /(^%|(\/)%?)$/, '$2.+' )
+							// Split subgroup and group to filter
+							.split( '/' )
+							// Remove invalid characters
+							.map( ( group ) => group.replace( /[^-*.+a-zA-Z0-9]/g, '' ) )
+							// If no group, append wildcard match
+							.concat( '.+' )
+							// Take only subgroup and group
+							.slice( 0, 2 )
+							// Finally, merge back into string
+							.join( '/' )
+					}$` ).test( media.mime_type );
+
+				case 'post_ID':
+					// Note that documentation specifies that query value of 0
+					// will match only media not attached to posts, but since
+					// those media items assign post_ID of 0, we can still
+					// match by equality
+					return value === media.post_ID;
+
+				case 'after':
+				case 'before':
+					const queryDate = moment( value, moment.ISO_8601 );
+					const comparison = /after$/.test( key ) ? 'isAfter' : 'isBefore';
+					return queryDate.isValid() && moment( media.date )[ comparison ]( queryDate );
+			}
+
+			return true;
+		} );
+	}
+
+	/**
+	 * A sort comparison function that defines the sort order of media items
+	 * under consideration of the specified query.
+	 *
+	 * @param  {Object} query  Query object
+	 * @param  {Object} mediaA First media item
+	 * @param  {Object} mediaB Second media item
+	 * @return {Number}        0 if equal, less than 0 if mediaA is first,
+	 *                         greater than 0 if mediaB is first.
+	 */
+	sort( query, mediaA, mediaB ) {
+		let order;
+
+		switch ( query.order_by ) {
+			case 'ID':
+				order = mediaA.ID - mediaB.ID;
+				break;
+
+			case 'title':
+				order = mediaA.title.localeCompare( mediaB.title );
+				break;
+
+			case 'date':
+			default:
+				order = moment( mediaA.date ).diff( mediaB.date );
+		}
+
+		// Default to descending order, opposite sign of ordered result
+		if ( ! query.order || /^desc$/i.test( query.order ) ) {
+			order *= -1;
+		}
+
+		return order || 0;
+	}
+}
+
+MediaQueryManager.QueryKey = MediaQueryKey;
+
+MediaQueryManager.DEFAULT_QUERY = DEFAULT_MEDIA_QUERY;

--- a/client/lib/query-manager/media/key.js
+++ b/client/lib/query-manager/media/key.js
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_MEDIA_QUERY } from './constants';
+
+/**
+ * MediaQueryKey manages the serialization and deserialization of a query key
+ * for use in tracking query results in an instance of MediaQueryManager
+ */
+export default class MediaQueryKey {
+	/**
+	 * Default query used in determining values to be omitted from stringified
+	 * or parsed query objects
+	 *
+	 * @type {?Object}
+	 */
+	static DEFAULT_QUERY = DEFAULT_MEDIA_QUERY;
+
+	/**
+	 * Controls omission to remove all null values from stringified or parsed
+	 * query objects
+	 *
+	 * @type {Boolean}
+	 */
+	static OMIT_NULL_VALUES = true;
+}

--- a/client/lib/query-manager/media/test/index.js
+++ b/client/lib/query-manager/media/test/index.js
@@ -1,0 +1,339 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import MediaQueryManager from '../';
+
+/**
+ * Constants
+ */
+const DEFAULT_MEDIA = {
+	ID: 42,
+	URL: 'https://example.files.wordpress.com/2014/06/flower.gif',
+	guid: 'http://example.files.wordpress.com/2014/06/flower.gif',
+	date: '2014-06-12T22:12:30+00:00',
+	post_ID: 41,
+	author_ID: 73705554,
+	file: 'flower.gif',
+	mime_type: 'image/gif',
+	extension: 'gif',
+	title: 'flower',
+	caption: '',
+	description: '',
+	alt: '',
+	icon: 'https://s1.wp.com/wp-includes/images/media/default.png',
+	thumbnails: {},
+	height: 405,
+	width: 600,
+	exif: {}
+};
+
+describe( 'MediaQueryManager', () => {
+	let manager;
+	beforeEach( () => {
+		manager = new MediaQueryManager();
+	} );
+
+	describe( '#matches()', () => {
+		context( 'query.search', () => {
+			it( 'should return false for a non-matching search', () => {
+				const isMatch = manager.matches( {
+					search: 'Cars'
+				}, DEFAULT_MEDIA );
+
+				expect( isMatch ).to.be.false;
+			} );
+
+			it( 'should return true for an empty search', () => {
+				const isMatch = manager.matches( {
+					search: ''
+				}, DEFAULT_MEDIA );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should return true for a matching title search', () => {
+				const isMatch = manager.matches( {
+					search: 'lower'
+				}, DEFAULT_MEDIA );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should search case-insensitive', () => {
+				const isMatch = manager.matches( {
+					search: 'fLoWeR'
+				}, DEFAULT_MEDIA );
+
+				expect( isMatch ).to.be.true;
+			} );
+		} );
+
+		context( 'query.mime_type', () => {
+			it( 'should return true for an empty mime type', () => {
+				const isMatch = manager.matches( {
+					mime_type: ''
+				}, DEFAULT_MEDIA );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should return true an exact match', () => {
+				const isMatch = manager.matches( {
+					mime_type: 'image/gif'
+				}, DEFAULT_MEDIA );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should return true for mime subgroup exact match', () => {
+				const isMatch = manager.matches( {
+					mime_type: 'image'
+				}, DEFAULT_MEDIA );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should return true for mime subgroup exact match with trailing slash', () => {
+				const isMatch = manager.matches( {
+					mime_type: 'image/'
+				}, DEFAULT_MEDIA );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should return false for mime subgroup partial match', () => {
+				const isMatch = manager.matches( {
+					mime_type: 'imag'
+				}, DEFAULT_MEDIA );
+
+				expect( isMatch ).to.be.false;
+			} );
+
+			it( 'should return false for mime group partial match', () => {
+				const isMatch = manager.matches( {
+					mime_type: 'image/gi'
+				}, DEFAULT_MEDIA );
+
+				expect( isMatch ).to.be.false;
+			} );
+
+			it( 'should return true for wildcard match', () => {
+				const isMatch = manager.matches( {
+					mime_type: '%'
+				}, DEFAULT_MEDIA );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should return false for mime subgroup wildcard match', () => {
+				const isMatch = manager.matches( {
+					mime_type: '%/gif'
+				}, DEFAULT_MEDIA );
+
+				expect( isMatch ).to.be.false;
+			} );
+
+			it( 'should return true for mime group wildcard match', () => {
+				const isMatch = manager.matches( {
+					mime_type: 'image/%'
+				}, DEFAULT_MEDIA );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should return false for mime subgroup partial wildcard match', () => {
+				const isMatch = manager.matches( {
+					mime_type: 'ima%/%'
+				}, DEFAULT_MEDIA );
+
+				expect( isMatch ).to.be.false;
+			} );
+
+			it( 'should return false for mime group partial wildcard match', () => {
+				const isMatch = manager.matches( {
+					mime_type: 'image/gi%'
+				}, DEFAULT_MEDIA );
+
+				expect( isMatch ).to.be.false;
+			} );
+		} );
+
+		context( 'query.post_ID', () => {
+			it( 'should return false if post ID does not match', () => {
+				const isMatch = manager.matches( {
+					post_ID: 0
+				}, DEFAULT_MEDIA );
+
+				expect( isMatch ).to.be.false;
+			} );
+
+			it( 'should return true if post ID matches', () => {
+				const isMatch = manager.matches( {
+					post_ID: 41
+				}, DEFAULT_MEDIA );
+
+				expect( isMatch ).to.be.true;
+			} );
+		} );
+
+		context( 'query.before', () => {
+			it( 'should return false if query is not ISO 8601', () => {
+				const isMatch = manager.matches( {
+					before: '2018'
+				}, DEFAULT_MEDIA );
+
+				expect( isMatch ).to.be.false;
+			} );
+
+			it( 'should return false if media is not before date', () => {
+				const isMatch = manager.matches( {
+					before: '2010-04-25T15:47:33-04:00'
+				}, DEFAULT_MEDIA );
+
+				expect( isMatch ).to.be.false;
+			} );
+
+			it( 'should return true if media is before date', () => {
+				const isMatch = manager.matches( {
+					before: '2018-04-25T15:47:33-04:00'
+				}, DEFAULT_MEDIA );
+
+				expect( isMatch ).to.be.true;
+			} );
+		} );
+
+		context( 'query.after', () => {
+			it( 'should return false if query is not ISO 8601', () => {
+				const isMatch = manager.matches( {
+					after: '2010'
+				}, DEFAULT_MEDIA );
+
+				expect( isMatch ).to.be.false;
+			} );
+
+			it( 'should return false if media is not after date', () => {
+				const isMatch = manager.matches( {
+					after: '2018-04-25T15:47:33-04:00'
+				}, DEFAULT_MEDIA );
+
+				expect( isMatch ).to.be.false;
+			} );
+
+			it( 'should return true if media is after date', () => {
+				const isMatch = manager.matches( {
+					after: '2010-04-25T15:47:33-04:00'
+				}, DEFAULT_MEDIA );
+
+				expect( isMatch ).to.be.true;
+			} );
+		} );
+	} );
+
+	describe( '#sort()', () => {
+		context( 'query.order', () => {
+			it( 'should sort descending by default', () => {
+				const sorted = [
+					{ ID: 200 },
+					{ ID: 400 }
+				].sort( manager.sort.bind( manager, {
+					order_by: 'ID'
+				} ) );
+
+				expect( sorted ).to.eql( [
+					{ ID: 400 },
+					{ ID: 200 }
+				] );
+			} );
+
+			it( 'should reverse order when specified as ascending', () => {
+				const sorted = [
+					{ ID: 400 },
+					{ ID: 200 }
+				].sort( manager.sort.bind( manager, {
+					order_by: 'ID',
+					order: 'ASC'
+				} ) );
+
+				expect( sorted ).to.eql( [
+					{ ID: 200 },
+					{ ID: 400 }
+				] );
+			} );
+		} );
+
+		context( 'query.order_by', () => {
+			context( 'date', () => {
+				const olderMedia = {
+					...DEFAULT_MEDIA,
+					date: '2016-04-25T11:40:52-04:00'
+				};
+
+				const newerMedia = {
+					...DEFAULT_MEDIA,
+					ID: 152,
+					date: '2016-04-25T15:47:33-04:00'
+				};
+
+				it( 'should order by date', () => {
+					const sorted = [
+						olderMedia,
+						newerMedia
+					].sort( manager.sort.bind( manager, {} ) );
+
+					expect( sorted ).to.eql( [
+						newerMedia,
+						olderMedia
+					] );
+				} );
+			} );
+
+			context( 'title', () => {
+				const abMedia = {
+					...DEFAULT_MEDIA,
+					title: 'AB'
+				};
+
+				const aaMedia = {
+					...DEFAULT_MEDIA,
+					ID: 152,
+					title: 'Aa'
+				};
+
+				it( 'should sort by title', () => {
+					const sorted = [
+						aaMedia,
+						abMedia
+					].sort( manager.sort.bind( manager, {
+						order_by: 'title'
+					} ) );
+
+					expect( sorted ).to.eql( [
+						abMedia,
+						aaMedia
+					] );
+				} );
+			} );
+
+			context( 'ID', () => {
+				it( 'should sort by ID', () => {
+					const sorted = [
+						{ ID: 200 },
+						{ ID: 400 }
+					].sort( manager.sort.bind( manager, {
+						order_by: 'ID'
+					} ) );
+
+					expect( sorted ).to.eql( [
+						{ ID: 400 },
+						{ ID: 200 }
+					] );
+				} );
+			} );
+		} );
+	} );
+} );

--- a/client/lib/query-manager/test/key.js
+++ b/client/lib/query-manager/test/key.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import deepFreeze from 'deep-freeze';
 import { expect } from 'chai';
 
 /**
@@ -9,11 +10,51 @@ import { expect } from 'chai';
 import QueryKey from '../key';
 
 describe( 'QueryKey', () => {
+	describe( '.omit()', () => {
+		it( 'should return same query if omission behavior not defined', () => {
+			const original = deepFreeze( { ok: true } );
+			const pruned = QueryKey.omit( original );
+
+			expect( pruned ).to.equal( original );
+		} );
+
+		it( 'should omit values matching default query of extending class', () => {
+			class QueryKeyWithDefaults extends QueryKey {
+				static DEFAULT_QUERY = { ok: true };
+			}
+
+			const pruned = QueryKeyWithDefaults.omit( { ok: true, foo: null } );
+
+			expect( pruned ).to.eql( { foo: null } );
+		} );
+
+		it( 'should omit null values if configured by extending class', () => {
+			class QueryKeyWithNullOmission extends QueryKey {
+				static OMIT_NULL_VALUES = true;
+			}
+
+			const pruned = QueryKeyWithNullOmission.omit( { ok: true, foo: null } );
+
+			expect( pruned ).to.eql( { ok: true } );
+		} );
+	} );
+
 	describe( '.stringify()', () => {
 		it( 'should return a JSON string of the object', () => {
 			const key = QueryKey.stringify( { ok: true } );
 
 			expect( key ).to.equal( '[["ok",true]]' );
+		} );
+
+		it( 'should prune by omission behavior', () => {
+			class QueryKeyWithOmission extends QueryKey {
+				static DEFAULT_QUERY = { ok: true };
+				static OMIT_NULL_VALUES = true;
+			}
+
+			const key = QueryKeyWithOmission.stringify( { ok: true, foo: null } );
+
+			expect( key ).to.equal( '[]' );
 		} );
 
 		it( 'should return the same string for two objects with different property creation order', () => {
@@ -29,6 +70,17 @@ describe( 'QueryKey', () => {
 			const query = QueryKey.parse( '[["ok",true]]' );
 
 			expect( query ).to.eql( { ok: true } );
+		} );
+
+		it( 'should prune by omission behavior', () => {
+			class QueryKeyWithOmission extends QueryKey {
+				static DEFAULT_QUERY = { ok: true };
+				static OMIT_NULL_VALUES = true;
+			}
+
+			const query = QueryKeyWithOmission.parse( '[["ok",true],["foo",null]]' );
+
+			expect( query ).to.eql( {} );
 		} );
 	} );
 } );


### PR DESCRIPTION
This pull request seeks to implement a `MediaQueryManager` class, with plans for eventual use in the Reduxification of the media store.

For more information about Query Manager, see:

- [Query Manager documentation](https://github.com/Automattic/wp-calypso/tree/master/client/lib/query-manager)
- #5135
- [`state.posts.queries` reducer implementation](https://github.com/Automattic/wp-calypso/blob/33f00235dc81c8a915cb6e8d5d742c09c544109c/client/state/posts/reducer.js#L132-L230)

__Implementation notes:__

A common pattern in query managers is omitting keys in stringifying / parsing that match values in a default query, or null values. Since `MediaQueryManager` follows this same pattern, I decided to move this logic as an option to the base `QueryKey` class (see 6e8c1f1).

__Testing instructions:__

This pull request does not include any functional changes to the application, though you may wish to verify that the revisions to `QueryKey` do not result in regressions (notably, you can try trashing a post from the [custom post types list screen](http://calypso.localhost:3000/types/post)).

Instead, simply verify that tests pass:

```
npm run test-client client/lib/query-manager
```

cc @ockham @tyxla 