### PR TITLE
Ads for Jetpack: Change WordAds for Jetpack title from "AdControl" to just "Ads."

### DIFF
--- a/client/my-sites/ads/controller.js
+++ b/client/my-sites/ads/controller.js
@@ -27,7 +27,7 @@ function _recordPageView( context, analyticsPageTitle ) {
 }
 
 function _getLayoutTitle( context ) {
-	var title = sites.getSelectedSite().jetpack ? 'AdControl' : 'WordAds';
+	var title = sites.getSelectedSite().jetpack ? 'Ads' : 'WordAds';
 	switch ( context.params.section ) {
 		case 'earnings':
 			return i18n.translate( '%(wordads)s Earnings', { args: { wordads: title } } );

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -164,7 +164,7 @@ export class MySitesSidebar extends Component {
 		return (
 			canManageAds &&
 			<SidebarItem
-				label={ site.jetpack ? 'AdControl' : 'WordAds' }
+				label={ site.jetpack ? 'Ads' : 'WordAds' }
 				className={ this.itemLinkClass( '/ads', 'rads' ) }
 				link={ adsLink }
 				onNavigate={ this.onNavigate }


### PR DESCRIPTION
It was decided by @samhotchkiss et al to change the nomenclature of WordAds in Jetpack/AdControl to just "Ads."

**Updated**
<img width="736" alt="screen shot 2016-12-07 at 11 57 53 am" src="https://cloud.githubusercontent.com/assets/273708/20984466/3a40ad4a-bc75-11e6-985f-706ff326a7e1.png">

**Previously**
<img width="721" alt="screen shot 2016-12-07 at 11 59 06 am" src="https://cloud.githubusercontent.com/assets/273708/20984471/40e8f1fc-bc75-11e6-9ffc-4ed0f1e947c4.png">

To test:
1. Browse in `My Sites` to Jetpack site approved for WordAds (e.g. https://wordpress.com/ads/settings/www.fivebladesbrewing.com)
2. Copy should read `Ads` in sidebar and `Ads Earnings|Settings` in title.