### PR TITLE
CircleCI config: add LocalCI support

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -24,4 +24,18 @@ test:
   post:
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/ && find . -type f -regex  "./test-results.*\.xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;:
         parallel: true
-    - if [[ $CIRCLE_BRANCH == "master" ]]; then make translate; mkdir $CIRCLE_ARTIFACTS/translate; cp calypso-strings.pot $CIRCLE_ARTIFACTS/translate/calypso-strings.pot; fi;
+    - ? |
+          if [[ $CIRCLE_NODE_INDEX == 0 ]]; then
+            make translate;
+            mkdir -p $CIRCLE_ARTIFACTS/translate;
+            cp calypso-strings.pot $CIRCLE_ARTIFACTS/translate/calypso-strings.pot;
+            if [[ $CIRCLE_BRANCH != "master" ]]; then
+              node bin/get-circle-string-artifact-url | xargs curl > $CIRCLE_ARTIFACTS/translate/calypso-strings-master.pot;
+              msgcat -u $CIRCLE_ARTIFACTS/translate/calypso-strings.pot $CIRCLE_ARTIFACTS/translate/calypso-strings-master.pot > $CIRCLE_ARTIFACTS/translate/new-calypso-strings.pot;
+            fi;
+          fi;
+      :
+        parallel: true
+notify:
+  webhooks:
+    - url: https://translate.wordpress.com/api/localci/-relay-new-strings-to-gh


### PR DESCRIPTION
LocalCI is a localization continuous integration package that coordinates reporting between a CI system (Circle in our case) and Github. This PR adds pot diffing (using gettext CLI tools) to generate the data necessary to feed into LocalCI and a webhook to trigger the integration.

See: https://github.com/Automattic/gp-localci