### PR TITLE
Reader Refresh: Randomize seed for recs on each page load

### DIFF
--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -202,7 +202,7 @@ function getStoreForRecommendedPosts( storeId ) {
 				break;
 			case 'custom_recs_posts_with_images':
 				query.algorithm = 'read:recommendations:posts/es/7';
-				query.seed = random( 0 , 10000 );
+				query.seed = random( 0, 10000 );
 				break;
 			default:
 				query.algorithm = 'read:recommendations:posts/es/1';

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -202,6 +202,22 @@ function getStoreForRecommendedPosts( storeId ) {
 				break;
 			case 'custom_recs_posts_with_images':
 				query.algorithm = 'read:recommendations:posts/es/7';
+
+				/* Seed FAQ:
+				 * Q: What does it do?
+				 * A: It throws a little randomness into the elasticsearch recommendations query so that
+				 * users don't see the same thing every time they reload the page:
+				 * https://www.elastic.co/guide/en/elasticsearch/guide/current/random-scoring.html
+				 *
+				 * Q: How did we pick this range?
+				 * A: The range here is fairly...random.  Its big enough that the same user
+				 * probably won't get it too frequently and small enough that we aren't going
+				 * cause overflows anywhere.
+				 *
+				 * Q: How often do we change the seed?
+				 * A: We change the seed each time the store is generated. Practically speaking
+				 * that means each time the page is refreshed
+				 */
 				query.seed = random( 0, 10000 );
 				break;
 			default:

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -205,18 +205,17 @@ function getStoreForRecommendedPosts( storeId ) {
 
 				/* Seed FAQ:
 				 * Q: What does it do?
-				 * A: It throws a little randomness into the elasticsearch recommendations query so that
-				 * users don't see the same thing every time they reload the page:
+				 * A: It throws a little randomness into the Elasticsearch query so that users
+				 * don't see the same recommendations every time:
 				 * https://www.elastic.co/guide/en/elasticsearch/guide/current/random-scoring.html
 				 *
 				 * Q: How did we pick this range?
-				 * A: The range here is fairly...random.  Its big enough that the same user
-				 * probably won't get it too frequently and small enough that we aren't going
-				 * cause overflows anywhere.
+				 * A: It's big enough that the same user probably won't get repeats too frequently
+				 * and small enough that we aren't going cause overflows anywhere.
 				 *
 				 * Q: How often do we change the seed?
 				 * A: We change the seed each time the store is generated. Practically speaking
-				 * that means each time the page is refreshed
+				 * that means each time the page is refreshed.
 				 */
 				query.seed = random( 0, 10000 );
 				break;

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { forEach, startsWith } from 'lodash';
+import { forEach, startsWith, random } from 'lodash';
 
 /**
  * Internal dependencies
@@ -202,6 +202,7 @@ function getStoreForRecommendedPosts( storeId ) {
 				break;
 			case 'custom_recs_posts_with_images':
 				query.algorithm = 'read:recommendations:posts/es/7';
+				query.seed = random( 0 , 10000 );
 				break;
 			default:
 				query.algorithm = 'read:recommendations:posts/es/1';

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -153,7 +153,8 @@ module.exports = {
 
 		let recommendationsStore = null;
 		if ( config.isEnabled( 'reader/refresh/stream' ) ) {
-			recommendationsStore = feedStreamFactory( 'recommendations_posts' );
+			// custom_recs_posts_with_images instead of recommendations_posts because we only want those with images for now
+			recommendationsStore = feedStreamFactory( 'custom_recs_posts_with_images' );
 			recommendationsStore.perPage = 4;
 		}
 


### PR DESCRIPTION
It would be frustrating if you got the same set of recs very consistently.
This PR aims to add a seed to the recs api call so that there are more recs in the mix.

See #9779 

Question for reviewers: 
how sticky do you think the seed should be? onRefresh? per day? etc.

I chose onRefresh because it is the easiest to implement

To test:
1. check your search page & look at the recs
1. refresh 
1. look at the recs again
1. do a double take
1. now do the same for in-stream recs