### PR TITLE
Themes: Normalize in actions instead of Theme Sheet

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -526,23 +526,6 @@ const ThemeSheetWithOptions = ( props ) => {
 	);
 };
 
-const getThemeDetailsFromTheme = ( theme ) => {
-	return {
-		name: theme.name,
-		author: theme.author,
-		price: theme.price,
-		screenshot: theme.screenshot,
-		screenshots: theme.screenshots,
-		description: theme.description,
-		descriptionLong: theme.description_long,
-		supportDocumentation: theme.support_documentation || undefined,
-		download: theme.download_uri || undefined,
-		taxonomies: theme.taxonomies,
-		stylesheet: theme.stylesheet,
-		demo_uri: theme.demo_uri,
-	};
-};
-
 export default connect(
 	/*
 	 * A number of the props that this mapStateToProps function computes are used
@@ -576,9 +559,8 @@ export default connect(
 		const isCurrentUserPaid = isUserPaid( state, currentUserId );
 		const theme = getTheme( state, siteIdOrWpcom, id );
 		const error = theme ? false : getThemeRequestErrors( state, id, siteIdOrWpcom );
-		const themeDetails = theme ? getThemeDetailsFromTheme( theme ) : {};
 		return {
-			...themeDetails,
+			...theme,
 			id,
 			error,
 			selectedSite,

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -273,8 +273,8 @@ export function requestTheme( themeId, siteId ) {
 
 		// See comment next to lib/wpcom-undocumented/lib/undocumented#jetpackThemeDetails() why we can't
 		// the regular themeDetails() method for Jetpack sites yet.
-		return wpcom.undocumented().jetpackThemeDetails( themeId, siteId ).then( ( theme ) => {
-			dispatch( receiveThemes( theme.themes, siteId ) );
+		return wpcom.undocumented().jetpackThemeDetails( themeId, siteId ).then( ( { themes } ) => {
+			dispatch( receiveThemes( themes, siteId ) );
 			dispatch( {
 				type: THEME_REQUEST_SUCCESS,
 				siteId,

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -208,6 +208,8 @@ export function requestThemes( siteId, query = {} ) {
 
 			let filteredThemes = themes;
 			if ( siteId !== 'wpcom' ) {
+				// A Jetpack site's themes endpoint ignores the query, returning an unfiltered list of all installed themes instead,
+				// So we have to filter on the client side instead.
 				filteredThemes = filterThemesForJetpack( themes, query );
 			}
 

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { conforms, omit, property } from 'lodash';
+import { conforms, map, omit, property } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -43,7 +43,7 @@ import {
 import { isJetpackSite } from 'state/sites/selectors';
 import { getActiveTheme } from './selectors';
 import { getQueryParams } from './themes-list/selectors';
-import { getThemeIdFromStylesheet, filterThemesForJetpack } from './utils';
+import { getThemeIdFromStylesheet, filterThemesForJetpack, normalizeWpcomTheme } from './utils';
 
 const debug = debugFactory( 'calypso:themes:actions' ); //eslint-disable-line no-unused-vars
 
@@ -203,7 +203,9 @@ export function requestThemes( siteId, query = {} ) {
 			query
 		} );
 
-		return wpcom.undocumented().themes( siteIdToQuery, queryWithApiVersion ).then( ( { found, themes } ) => {
+		return wpcom.undocumented().themes( siteIdToQuery, queryWithApiVersion ).then( ( { found, themes: rawThemes } ) => {
+			const themes = map( rawThemes, normalizeWpcomTheme );
+
 			dispatch( receiveThemes( themes, siteId ) );
 
 			let filteredThemes = themes;
@@ -257,7 +259,7 @@ export function requestTheme( themeId, siteId ) {
 
 		if ( siteId === 'wpcom' ) {
 			return wpcom.undocumented().themeDetails( themeId ).then( ( theme ) => {
-				dispatch( receiveTheme( theme, siteId ) );
+				dispatch( receiveTheme( normalizeWpcomTheme( theme ), siteId ) );
 				dispatch( {
 					type: THEME_REQUEST_SUCCESS,
 					siteId,
@@ -276,7 +278,7 @@ export function requestTheme( themeId, siteId ) {
 		// See comment next to lib/wpcom-undocumented/lib/undocumented#jetpackThemeDetails() why we can't
 		// the regular themeDetails() method for Jetpack sites yet.
 		return wpcom.undocumented().jetpackThemeDetails( themeId, siteId ).then( ( { themes } ) => {
-			dispatch( receiveThemes( themes, siteId ) );
+			dispatch( receiveThemes( map( themes, normalizeWpcomTheme ), siteId ) );
 			dispatch( {
 				type: THEME_REQUEST_SUCCESS,
 				siteId,

--- a/client/state/themes/test/utils.js
+++ b/client/state/themes/test/utils.js
@@ -7,6 +7,7 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
+	normalizeWpcomTheme,
 	getThemeIdFromStylesheet,
 	getNormalizedThemesQuery,
 	getSerializedThemesQuery,
@@ -15,6 +16,41 @@ import {
 } from '../utils';
 
 describe( 'utils', () => {
+	describe( '#normalizeWpcomTheme()', () => {
+		it( 'should return an empty object when given no argument', () => {
+			const normalizedTheme = normalizeWpcomTheme();
+			expect( normalizedTheme ).to.deep.equal( {} );
+		} );
+		it( 'should rename some keys', () => {
+			const normalizedTheme = normalizeWpcomTheme( {
+				id: 'mood',
+				name: 'Mood',
+				author: 'Automattic',
+				description: 'Mood is a business theme with positive vibe...',
+				description_long: '<p>Say hello to <em>Mood</em>, a business theme with a positive vibe...',
+				support_documentation: '<h2>Getting started</h2>↵<p>When you first activate <em>Mood</em>,...',
+				screenshot: 'mood.jpg',
+				price: '$20',
+				stylesheet: 'premium/mood',
+				demo_uri: 'https://mooddemo.wordpress.com/',
+				author_uri: 'https://wordpress.com/themes/'
+			} );
+			expect( normalizedTheme ).to.deep.equal( {
+				id: 'mood',
+				name: 'Mood',
+				author: 'Automattic',
+				description: 'Mood is a business theme with positive vibe...',
+				descriptionLong: '<p>Say hello to <em>Mood</em>, a business theme with a positive vibe...',
+				supportDocumentation: '<h2>Getting started</h2>↵<p>When you first activate <em>Mood</em>,...',
+				screenshot: 'mood.jpg',
+				price: '$20',
+				stylesheet: 'premium/mood',
+				demo_uri: 'https://mooddemo.wordpress.com/',
+				author_uri: 'https://wordpress.com/themes/'
+			} );
+		} );
+	} );
+
 	describe( '#getThemeIdFromStylesheet()', () => {
 		it( 'should return undefined when given no argument', () => {
 			const themeId = getThemeIdFromStylesheet();

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import startsWith from 'lodash/startsWith';
-import { filter, omit, omitBy, split } from 'lodash';
+import { filter, get, mapKeys, omit, omitBy, split } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,6 +20,24 @@ export const oldShowcaseUrl = '//wordpress.com/themes/';
 /**
  * Utility
  */
+
+ /**
+  * Normalizes a theme obtained from the WordPress.com REST API
+  *
+  * @param  {Object} theme  Themes object
+  * @return {Object}        Normalized theme object
+  */
+export function normalizeWpcomTheme( theme ) {
+	const attributesMap = {
+		description_long: 'descriptionLong',
+		support_documentation: 'supportDocumentation',
+		download_uri: 'download'
+	};
+
+	return mapKeys( theme, ( value, key ) => (
+		get( attributesMap, key, key )
+	) );
+}
 
 /**
  * Given a theme stylesheet string (like 'pub/twentysixteen'), returns the corresponding theme ID ('twentysixteen').


### PR DESCRIPTION
No visual changes. To test -- verify that the theme showcase still works. Pay attention to the presence e.g. of a long description in the theme sheet.