### PR TITLE
Reader: reduce excerpt lines from 3 to 2 in post card

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -400,6 +400,13 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	}
 }
 
+// 3 line excerpt for thumbnail cards
+.reader-post-card.card.has-thumbnail:not(.is-gallery) {
+	.reader-post-card__excerpt {
+		max-height: 15px * 1.6 * 3;
+	}
+}
+
 // Action buttons in post card
 .reader-post-card.card .reader-post-actions__item {
 	font-size: 14px;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -370,11 +370,17 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	position: relative;
 }
 
-// If we're not showing the entire excerpt, clamp to 2 lines
+// If we're not showing the entire excerpt, clamp lines
 .reader-post-card.card:not(.is-showing-entire-excerpt) {
 	.reader-post-card__excerpt {
 		overflow: hidden;
-		max-height: 15px * 1.6 * 2;
+		max-height: 15px * 1.6 * 3;
+
+
+		// Clamp to 2 lines on wider viewports
+		@include breakpoint( ">960px" ) {
+			max-height: 15px * 1.6 * 2;
+		}
 
 		&::before {
 			@include long-content-fade( $size: 15px * 1.6 * 5 );

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -370,11 +370,11 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	position: relative;
 }
 
-// If we're not showing the entire excerpt, clamp to 3 lines
+// If we're not showing the entire excerpt, clamp to 2 lines
 .reader-post-card.card:not(.is-showing-entire-excerpt) {
 	.reader-post-card__excerpt {
 		overflow: hidden;
-		max-height: 15px * 1.6 * 3;
+		max-height: 15px * 1.6 * 2;
 
 		&::before {
 			@include long-content-fade( $size: 15px * 1.6 * 5 );


### PR DESCRIPTION
We currently show 3 lines of an excerpt in post cards. This PR tries reducing it to two for text and gallery cards only. Fixes #9556.

Thumbnail (still 3 lines):
<img width="879" alt="screen shot 2016-12-08 at 13 56 19" src="https://cloud.githubusercontent.com/assets/17325/20993294/2b6bbd4e-bd4e-11e6-8472-b22c4f0d5b67.png">

Text only (now 2 lines):
<img width="860" alt="screen shot 2016-12-08 at 13 56 26" src="https://cloud.githubusercontent.com/assets/17325/20993293/2b69e6a4-bd4e-11e6-88e3-9d4450db2510.png">

Gallery (now 2 lines):
<img width="877" alt="screen shot 2016-12-08 at 13 56 34" src="https://cloud.githubusercontent.com/assets/17325/20993292/2b69d920-bd4e-11e6-87ef-46414502e20d.png">

