### PR TITLE
Editor: minor trash pickup to make autoSave dialog logic more legible

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -3,10 +3,8 @@
  */
 const ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:post-editor' ),
-	page = require( 'page' ),
-	debounce = require( 'lodash/debounce' ),
-	throttle = require( 'lodash/throttle' );
+	page = require( 'page' );
+import { debounce, throttle, get } from 'lodash';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
@@ -133,7 +131,6 @@ export const PostEditor = React.createClass( {
 	},
 
 	componentDidMount: function() {
-		debug( 'PostEditor react component mounted.' );
 		// if content is passed in, e.g., through url param
 		if ( this.state.post && this.state.post.content ) {
 			this.refs.editor.setEditorContent( this.state.post.content, { initial: true } );
@@ -188,7 +185,7 @@ export const PostEditor = React.createClass( {
 		if ( this.state.post ) {
 			isPage = utils.isPage( this.state.post );
 			isTrashed = this.state.post.status === 'trash';
-			hasAutosave = ( this.state.post.meta && this.state.post.meta.data && this.state.post.meta.data.autosave );
+			hasAutosave = get( this.state.post.meta, [ 'data', 'autosave' ] );
 		}
 		return (
 			<div className="post-editor">
@@ -414,7 +411,6 @@ export const PostEditor = React.createClass( {
 	},
 
 	onEditorContentChange: function() {
-		debug( 'editor content changed' );
 		this.debouncedSaveRawContent();
 		this.debouncedAutosave();
 	},


### PR DESCRIPTION
While investigating #9833 - the code trail led me to `post-editor.jsx`.  Much `TODO` in this file, but the particular area I was looking at had a long `if` statement that was begging to be simplified with a `get` - so in an effort to pickup trash daily, here is a very small PR.

__Changes Made__
Updated the conditional logic that determines if `autosave` data exists to use `lodash#get()`.  And for good measure removed old `debug` statements.

__To Test__
Ideally - get a published post to have some autosave data.  To do so, open a published post in the editor, make some changes and wait for the autosave to kick in.
- Open the post with autosave data in the editor, confirm the autosave restore dialog is still shown
- Open a new draft in the editor, ensure no dialog is shown
