### PR TITLE
Framework: Fix the tooltip popover z-index so it doesn't appear over notifications pane

### DIFF
--- a/client/components/tooltip/style.scss
+++ b/client/components/tooltip/style.scss
@@ -1,4 +1,6 @@
 .tooltip.popover {
+  	z-index: 100;
+
 	.popover__arrow {
 		border-width: 6px;
 	}


### PR DESCRIPTION
This is an attempt to fix #3440 

It appears the z-index of the notifications pane is 180, and the z-index of the tooltip is 1000 meaning that the tooltip displays above the notifications pane.

This simply adds an explicit z-index to the tooltip popover as `100`

**Before**

![before](https://cloud.githubusercontent.com/assets/128826/20994221/dac9e612-bd3a-11e6-810a-c4698d148a8d.gif)

**After**

![after](https://cloud.githubusercontent.com/assets/128826/20994225/e16aa5a6-bd3a-11e6-8b8c-fb9ff8234ead.gif)

**Testing Instructions**

1. On adding people enter an invalid email at mobile screen size and open notifications - does the tooltip display over the notifications
2. Test other tooltips to make sure they still appear (I have already tested taxonomy tooltips ok)
