### PR TITLE
Reader Refresh: fixing the width of search box

### DIFF
--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -206,6 +206,33 @@ const SearchStream = React.createClass( {
 		return SearchCardAdapter( isRecommendations );
 	},
 
+	handleStreamMounted( c ) {
+		this.streamRef = c;
+		if ( this.searchBoxRef && this.streamRef ) {
+			this.searchBoxRef.width = this.streamRef.width;
+		}
+	},
+
+	handleSearchBoxMounted( c ) {
+		this.searchBoxRef = c;
+		if ( this.searchBoxRef && this.streamRef ) {
+			this.searchBoxRef.width = this.streamRef.width;
+		}
+	},
+
+	componentDidMount() {
+		this.resizeListener = window.addEventListener( 'resize', () => {
+			if ( this.searchBoxRef && this.streamRef ) {
+				const width = this.streamRef.getClientRects()[ 0 ].width;
+				this.searchBoxRef.style.width = `${ width }px`;
+			}
+		} );
+	},
+
+	componentWillUnmount() {
+		window.removeEventListener( 'resize', this.resizeListener );
+	},
+
 	placeholderFactory( { key, ...rest } ) {
 		if ( isRefreshedStream && ! this.props.query ) {
 			return (
@@ -244,7 +271,8 @@ const SearchStream = React.createClass( {
 				className="search-stream" >
 				{ this.props.showBack && <HeaderBack /> }
 				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: this.state.title || this.props.translate( 'Search' ) } ) } />
-				<div className="search-stream__fixed-area">
+				<div ref={ this.handleStreamMounted } />
+				<div className="search-stream__fixed-area" ref={ this.handleSearchBoxMounted }>
 					<CompactCard className="search-stream__input-card">
 						<SearchInput
 							initialValue={ this.props.query }

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -208,25 +208,22 @@ const SearchStream = React.createClass( {
 
 	handleStreamMounted( c ) {
 		this.streamRef = c;
-		if ( this.searchBoxRef && this.streamRef ) {
-			this.searchBoxRef.width = this.streamRef.width;
-		}
 	},
 
 	handleSearchBoxMounted( c ) {
 		this.searchBoxRef = c;
+	},
+
+	resizeSearchBox() {
 		if ( this.searchBoxRef && this.streamRef ) {
-			this.searchBoxRef.width = this.streamRef.width;
+			const width = this.streamRef.getClientRects()[ 0 ].width;
+			this.searchBoxRef.style.width = `${ width }px`;
 		}
 	},
 
 	componentDidMount() {
-		this.resizeListener = window.addEventListener( 'resize', () => {
-			if ( this.searchBoxRef && this.streamRef ) {
-				const width = this.streamRef.getClientRects()[ 0 ].width;
-				this.searchBoxRef.style.width = `${ width }px`;
-			}
-		} );
+		this.resizeListener = window.addEventListener( 'resize', this.resizeSearchBox );
+		this.resizeSearchBox();
 	},
 
 	componentWillUnmount() {

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import ReactDom from 'react-dom';
-import { initial, flatMap, trim, sampleSize } from 'lodash';
+import { initial, flatMap, trim, sampleSize, debounce } from 'lodash';
 import closest from 'component-closest';
 import { localize } from 'i18n-calypso';
 
@@ -206,23 +206,25 @@ const SearchStream = React.createClass( {
 		return SearchCardAdapter( isRecommendations );
 	},
 
-	handleStreamMounted( c ) {
-		this.streamRef = c;
+	handleStreamMounted( ref ) {
+		this.streamRef = ref;
 	},
 
-	handleSearchBoxMounted( c ) {
-		this.searchBoxRef = c;
+	handleSearchBoxMounted( ref ) {
+		this.searchBoxRef = ref;
 	},
 
 	resizeSearchBox() {
 		if ( this.searchBoxRef && this.streamRef ) {
 			const width = this.streamRef.getClientRects()[ 0 ].width;
-			this.searchBoxRef.style.width = `${ width }px`;
+			if ( width > 0 ) {
+				this.searchBoxRef.style.width = `${ width }px`;
+			}
 		}
 	},
 
 	componentDidMount() {
-		this.resizeListener = window.addEventListener( 'resize', this.resizeSearchBox );
+		this.resizeListener = window.addEventListener( 'resize', debounce( this.resizeSearchBox, 50 ) );
 		this.resizeSearchBox();
 	},
 

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -31,7 +31,6 @@
 	top: 0px;
 	padding-top: 75px;
 	z-index: 20;
-	width: 830px;
 }
 
 // Custom breakpoints needed to match Related Posts


### PR DESCRIPTION
This is an attempt at fixing the fixed search bar width.  Its relatively tricky because `position: fixed` elements are hard to size and require escaping the React paradigm (AFAICT).

See https://github.com/Automattic/wp-calypso/issues/9861
~~I'll wait for 9861 to land before continuing to work on this because I think it may affect the solution~~ landed.

If anyone can think of a better solution I'm all ears! I hate this one