### PR TITLE
Editor: refactor RestorePostDialog

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -312,7 +312,6 @@ export const PostEditor = React.createClass( {
 				</div>
 				{ isTrashed
 					? <RestorePostDialog
-						post={ this.state.post }
 						onClose={ this.onClose }
 						onRestore={ this.onSaveTrashed }
 					/>
@@ -331,7 +330,6 @@ export const PostEditor = React.createClass( {
 				: null }
 				{ hasAutosave && this.state.showAutosaveDialog
 					? <RestorePostDialog
-						post={ this.state.post }
 						onRestore={ this.restoreAutosave }
 						onClose={ this.closeAutosaveDialog }
 						isAutosave={ true }

--- a/client/post-editor/restore-post-dialog.jsx
+++ b/client/post-editor/restore-post-dialog.jsx
@@ -1,84 +1,89 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import noop from 'lodash/noop';
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { noop, get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Dialog from 'components/dialog';
 import FormButton from 'components/forms/form-button';
-import utils from 'lib/posts/utils';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditedPostValue } from 'state/posts/selectors';
 
-export default React.createClass( {
+class EditorRestorePostDialog extends Component {
+	static propTypes = {
+		translate: PropTypes.func,
+		onClose: PropTypes.func,
+		onRestore: PropTypes.func,
+		isAutosave: PropTypes.bool,
+		postType: PropTypes.string,
+		userCanDeletePost: PropTypes.bool,
+	}
 
-	displayName: 'EditorRestorePostDialog',
+	static defaultProps = {
+		onClose: noop,
+		onRestore: noop,
+		isAutosave: false,
+	}
 
-	getDefaultProps() {
-		return {
-			onClose: noop,
-			onRestore: noop,
-			isAutosave: false
-		};
-	},
-
-	propTypes: {
-		post: React.PropTypes.object.isRequired,
-		onClose: React.PropTypes.func,
-		onRestore: React.PropTypes.func,
-		isAutosave: React.PropTypes.bool
-	},
-
-	restorePost() {
-		if ( this.props.isAutosave ) {
-			this.props.onRestore();
-		} else if ( utils.userCan( 'delete_post', this.props.post ) ) {
-			this.props.onRestore( 'draft' );
+	restorePost = () => {
+		const { isAutosave, userCanDeletePost, onRestore } = this.props;
+		if ( isAutosave ) {
+			onRestore();
+		} else if ( userCanDeletePost ) {
+			onRestore( 'draft' );
 		}
-	},
+	}
 
-	getDialogButtons() {
+	getDialogButtons = () => {
+		const { translate, onClose } = this.props;
 		return [
 			<FormButton
 				key="restore"
 				isPrimary={ true }
 				onClick={ this.restorePost }>
-					{ this.translate( 'Restore' ) }
+					{ translate( 'Restore' ) }
 			</FormButton>,
 			<FormButton
 				key="back"
 				isPrimary={ false }
-				onClick={ this.props.onClose }>
-					{ this.translate( "Don't restore" ) }
+				onClick={ onClose }>
+					{ translate( 'Don\'t restore' ) }
 			</FormButton>
 		];
-	},
+	}
 
-	getStrings() {
-		if ( this.props.isAutosave ) {
-			if ( utils.isPage( this.props.post ) ) {
+	getStrings = () => {
+		const { isAutosave, postType, translate } = this.props;
+		const isPage = postType === 'page';
+		if ( isAutosave ) {
+			if ( isPage ) {
 				return {
-					dialogTitle: this.translate( 'Saved Draft' ),
-					dialogContent: this.translate( 'A more recent revision of this page exists. Restore?' ),
+					dialogTitle: translate( 'Saved Draft' ),
+					dialogContent: translate( 'A more recent revision of this page exists. Restore?' ),
 				};
 			}
 			return {
-				dialogTitle: this.translate( 'Saved Draft' ),
-				dialogContent: this.translate( 'A more recent revision of this post exists. Restore?' ),
+				dialogTitle: translate( 'Saved Draft' ),
+				dialogContent: translate( 'A more recent revision of this post exists. Restore?' ),
 			};
 		}
-		if ( utils.isPage( this.props.post ) ) {
+		if ( isPage ) {
 			return {
-				dialogTitle: this.translate( 'Deleted Page' ),
-				dialogContent: this.translate( 'This page has been sent to the trash. Restore it to continue writing.' ),
+				dialogTitle: translate( 'Deleted Page' ),
+				dialogContent: translate( 'This page has been sent to the trash. Restore it to continue writing.' ),
 			};
 		}
 		return {
-			dialogTitle: this.translate( 'Deleted Post' ),
-			dialogContent: this.translate( 'This post has been sent to the trash. Restore it to continue writing.' ),
+			dialogTitle: translate( 'Deleted Post' ),
+			dialogContent: translate( 'This post has been sent to the trash. Restore it to continue writing.' ),
 		};
-	},
+	}
 
 	render() {
 		const strings = this.getStrings();
@@ -92,4 +97,17 @@ export default React.createClass( {
 			</Dialog>
 		);
 	}
-} );
+}
+
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const postId = getEditorPostId( state );
+		const capabilities = getEditedPostValue( state, siteId, postId, 'capabilities' );
+
+		return {
+			postType: getEditedPostValue( state, siteId, postId, 'type' ),
+			userCanDeletePost: get( capabilities, 'delete_post' ),
+		};
+	}
+)( localize( EditorRestorePostDialog ) );

--- a/client/post-editor/restore-post-dialog.jsx
+++ b/client/post-editor/restore-post-dialog.jsx
@@ -40,24 +40,6 @@ class EditorRestorePostDialog extends Component {
 		}
 	}
 
-	getDialogButtons = () => {
-		const { translate, onClose } = this.props;
-		return [
-			<FormButton
-				key="restore"
-				isPrimary={ true }
-				onClick={ this.restorePost }>
-					{ translate( 'Restore' ) }
-			</FormButton>,
-			<FormButton
-				key="back"
-				isPrimary={ false }
-				onClick={ onClose }>
-					{ translate( 'Don\'t restore' ) }
-			</FormButton>
-		];
-	}
-
 	getStrings = () => {
 		const { isAutosave, postType, translate } = this.props;
 		const isPage = postType === 'page';
@@ -86,11 +68,28 @@ class EditorRestorePostDialog extends Component {
 	}
 
 	render() {
+		const { onClose, translate } = this.props;
 		const strings = this.getStrings();
+
+		const dialogButtons = [
+			<FormButton
+				key="restore"
+				isPrimary={ true }
+				onClick={ this.restorePost }>
+					{ translate( 'Restore' ) }
+			</FormButton>,
+			<FormButton
+				key="back"
+				isPrimary={ false }
+				onClick={ onClose }>
+					{ translate( 'Don\'t restore' ) }
+			</FormButton>
+		];
+
 		return (
 			<Dialog
 				isVisible={ true }
-				buttons={ this.getDialogButtons() }
+				buttons={ dialogButtons }
 			>
 				<h1>{ strings.dialogTitle }</h1>
 				<p>{ strings.dialogContent }</p>


### PR DESCRIPTION
Not satisfied with the minor cleanup performed in #9886 - I decided to dig a bit deeper and update the `EditorRestorePostDialog` component as well.  This branch moves the component up to standards of extending `Component` and utilizing the `localize` HoC, along with grabbing the needed data directly from the state tree.

__To Test__
In order to test all aspects of the `EditorRestorePostDialog` you will need to have a test post that is trashed, and one that has some autosave data attached to it.  For info on how to setup a post with autosave data, see notes in #9886.

- For the trashed post, open up the editor using the trashed post's ID `http://calypso.localhost:3000/post/${YOURSITE}.wordpress.com/${ID}`
- confirm that the restore post dialog is shown, click "Don't Restore" and verify you are redirected back to the post listing
- Open the same URL again, but this time click "Restore", verify the editor is opened, and the post is set back to draft status
- For the autosave post, open it up in the editor
- Verify the "Saved Draft" dialog is shown, click "Don't Restore", verify nothing has changed in the content area of the editor
- Reload the autosave post, this time select "Restore" when prompted, and verify autosave changes are applied
