### PR TITLE
Reader: in full post content, apply bottom margin to div

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -32,7 +32,11 @@
 		margin: 0 0 8px;
 	}
 
-	p {
+	h5 {
+		font-weight: 700;
+	}
+
+	p, div {
 		margin: 0 0 24px;
 
 		&:last-child {


### PR DESCRIPTION
In full post content, we currently apply a 24px bottom margin to paragraphs.

This PR applies the same bottom margin to `<div>`s too. 

Fixes #9667.

### To test

- Ensure the text on this post has adequate space between headers and body text: http://calypso.localhost:3000/read/feeds/20830339/posts/1239277534

- Ensure spacing is consistent on this test post (top half uses `div`, bottom half uses `p`):
http://calypso.localhost:3000/read/feeds/40474143/posts/1252479833

- Open a variety of full posts and make sure that the new margin doesn't causes any wonkiness.
