### PR TITLE
Personal Plan: enable storage upgrade.

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -118,7 +118,7 @@ export const PLANS_LIST = {
 			FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
 			FEATURE_FREE_THEMES,
 			FEATURE_BASIC_DESIGN,
-			isEnabled( 'plans/6gb-personal-plan' ) ? FEATURE_6GB_STORAGE : FEATURE_3GB_STORAGE,
+			FEATURE_6GB_STORAGE,
 			FEATURE_NO_ADS
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )

--- a/config/development.json
+++ b/config/development.json
@@ -123,7 +123,6 @@
 		"perfmon": false,
 		"persist-redux": true,
 		"plans/personal-plan": true,
-		"plans/6gb-personal-plan": true,
 		"post-editor-github-link": false,
 		"post-editor/image-editor": true,
 		"post-editor/insert-menu": true,


### PR DESCRIPTION
Enables the new Personal Plan storage copy on all environments by removing the development only feature flag.

[ to be merged after backend changes are deployed ]