### PR TITLE
Plugins Autoconfig: Update notice text for users with already-registered plugins

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -271,7 +271,14 @@ const PlansSetup = React.createClass( {
 			return this.renderStatusError( plugin );
 		}
 
-		const { translate } = this.props;
+		if ( 'done' === plugin.status ) {
+			return (
+				<div className="plugin-item__finished">
+					{ this.getStatusText( plugin ) }
+				</div>
+			);
+		}
+
 		const statusProps = {
 			isCompact: true,
 			status: 'is-info',
@@ -279,22 +286,22 @@ const PlansSetup = React.createClass( {
 			icon: 'plugins',
 		};
 
+		return <Notice { ...statusProps } text={ this.getStatusText( plugin ) } />;
+	},
+
+	getStatusText( plugin ) {
+		const { translate } = this.props;
 		switch ( plugin.status ) {
 			case 'done':
-				// Done doesn't use a notice
-				return (
-					<div className="plugin-item__finished">
-						{ translate( 'Successfully installed & configured.' ) }
-					</div>
-				);
+				return translate( 'Successfully installed & configured.' );
 			case 'activate':
 			case 'configure':
-				return <Notice { ...statusProps } text={ translate( 'Almost done' ) } />;
+				return translate( 'Almost done' );
 			case 'install':
-				return <Notice { ...statusProps } text={ translate( 'Working…' ) } />;
+				return translate( 'Working…' );
 			case 'wait':
 			default:
-				return <Notice { ...statusProps } text={ translate( 'Waiting to install' ) } />;
+				return translate( 'Waiting to install' );
 		}
 	},
 

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -351,8 +351,9 @@ const PlansSetup = React.createClass( {
 					) } />
 				);
 			default:
+				const errorMessage = get( plugin, 'error.message', '' ).replace( /<.[^<>]*?>/g, '' );
 				return (
-					<Notice { ...statusProps } text={ plugin.error.message || translate( 'An error occured.' ) } />
+					<Notice { ...statusProps } text={ errorMessage || translate( 'An error occured.' ) } />
 				);
 		}
 	},


### PR DESCRIPTION
This PR continues discussion from #9703. I've merged the code to handle duplicate plugin registration, this PR is to discuss what the copy and action should be.

I've also take this opportunity to take @gwwar's advice and refactor `renderStatus` into `renderStatus` and `renderStatusError`, so the logic should be easier to follow.

To test (same as previous PR)

- Set up Akismet under one wp.com account
- Connect Jetpack on that site to a different wp.com account, and buy a plan
- Go through the autoconfig flow (should be prompted after buying plan, or you can go directly to /plugins/setup/$site)
- The plugins will run through installing, and once everything's finished, you should see a blue notice under Akismet, saying "This plugin is already registered with another plan.", with an action to "Manage Plans" linking to `/me/purchases`

![screen shot 2016-12-08 at 10 33 14 am](https://cloud.githubusercontent.com/assets/541093/21018253/37fc747c-bd3a-11e6-87c4-ccc335b59314.png)

(I've marked this in progress as I've noticed an error with the plugin notices, but I want to keep the convo going on what this copy should be.)

cc @johnHackworth @rickybanister @beaulebens @richardmuscat @annezazuu 