### PR TITLE
Signup: Update the dotblog subdomain AB test to reflect Survey step AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -63,7 +63,7 @@ module.exports = {
 		allowExistingUsers: false,
 	},
 	domainDotBlogSubdomain: {
-		datestamp: '20161125',
+		datestamp: '20161208',
 		variations: {
 			excludeDotBlogSubdomain: 50,
 			includeDotBlogSubdomain: 50,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -20,8 +20,9 @@ var StepWrapper = require( 'signup/step-wrapper' ),
 	{ DOMAINS_WITH_PLANS_ONLY } = require( 'state/current-user/constants' ),
 	{ getSurveyVertical } = require( 'state/signup/steps/survey/selectors.js' ),
 	analyticsMixin = require( 'lib/mixins/analytics' ),
-	signupUtils = require( 'signup/utils' ),
-	abtest = require( 'lib/abtest' ).abtest;
+	signupUtils = require( 'signup/utils' );
+
+import { abtest, getABTestVariation } from 'lib/abtest';
 
 import Notice from 'components/notice';
 
@@ -152,6 +153,12 @@ const DomainsStep = React.createClass( {
 	domainForm: function() {
 		const initialState = this.props.step ? this.props.step.domainForm : this.state.domainForm;
 
+		const includeDotBlogSubdomain = ( this.props.flowName === 'subdomain' ) ||
+			(
+				getABTestVariation( 'noSurveyStep' ) === 'showSurveyStep' &&
+				abtest( 'domainDotBlogSubdomain' ) === 'includeDotBlogSubdomain'
+			);
+
 		return (
 			<RegisterDomainStep
 				path={ this.props.path }
@@ -166,8 +173,7 @@ const DomainsStep = React.createClass( {
 				analyticsSection="signup"
 				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 				includeWordPressDotCom
-				includeDotBlogSubdomain={ ( this.props.flowName === 'subdomain' ) ||
-					( abtest( 'domainDotBlogSubdomain' ) === 'includeDotBlogSubdomain' ) }
+				includeDotBlogSubdomain={ includeDotBlogSubdomain }
 				isSignupStep
 				showExampleSuggestions
 				surveyVertical={ this.props.surveyVertical }


### PR DESCRIPTION
With the merge of the Survey step AB test, the data from the dotblog subdomain AB test may be skewed, because the users can get into the test without choosing a vertical in the survey step. This would result no dotblog suggestions shown to the user.

This PR fixes that and will only get the users into the test if they saw the Survey step.

To test:

1. Checkout branch or use Calypso.live link
2. Start signup
3. Enable the Survey step via the AB test.
4. Verify the domains step shows dotblog suggestions
5. Disable Survey step via the AB test.
6. Verify that domains step doesn't show dotblog suggestions.
7. Verify there aren't any console errors. 

cc @michaeldcain @meremagee 