### PR TITLE
People: Blocks: Fix broken delete user UI by passing ignoreContext

### DIFF
--- a/client/blocks/author-selector/index.jsx
+++ b/client/blocks/author-selector/index.jsx
@@ -4,7 +4,7 @@
 import ReactDom from 'react-dom';
 import React from 'react';
 import debugModule from 'debug';
-import trim from 'lodash/trim';
+import { trim, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -40,6 +40,12 @@ const SwitcherShell = React.createClass( {
 	getInitialState: function() {
 		return {
 			showAuthorMenu: false
+		};
+	},
+
+	getDefaultProps() {
+		return {
+			ignoreContext: noop
 		};
 	},
 
@@ -89,7 +95,8 @@ const SwitcherShell = React.createClass( {
 					position={ this.props.popoverPosition }
 					context={ this.refs && this.refs.authorSelectorChevron }
 					onKeyDown={ this._onKeyDown }
-					className="author-selector__popover popover">
+					className="author-selector__popover popover"
+					ignoreContext={ this.props.ignoreContext } >
 					{ ( this.props.fetchOptions.search || users.length > 10 ) &&
 						<Search
 							onSearch={ this._onSearch }

--- a/client/blocks/author-selector/index.jsx
+++ b/client/blocks/author-selector/index.jsx
@@ -1,30 +1,31 @@
 /**
  * External dependencies
  */
-var ReactDom = require( 'react-dom' ),
-	React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:author-selector' ),
-	trim = require( 'lodash/trim' );
+import ReactDom from 'react-dom';
+import React from 'react';
+import debugModule from 'debug';
+import trim from 'lodash/trim';
 
 /**
  * Internal dependencies
  */
-var Popover = require( 'components/popover' ),
-	PopoverMenuItem = require( 'components/popover/menu-item' ),
-	SiteUsersFetcher = require( 'components/site-users-fetcher' ),
-	UserItem = require( 'components/user' ),
-	Gridicon = require( 'components/gridicon' ),
-	InfiniteList = require( 'components/infinite-list' ),
-	UsersActions = require( 'lib/users/actions' ),
-	Search = require( 'components/search' ),
-	hasTouch = require( 'lib/touch-detect' ).hasTouch;
+import Popover from 'components/popover';
+import PopoverMenuItem from 'components/popover/menu-item';
+import SiteUsersFetcher from 'components/site-users-fetcher';
+import UserItem from 'components/user';
+import Gridicon from 'components/gridicon';
+import InfiniteList from 'components/infinite-list';
+import UsersActions from 'lib/users/actions';
+import Search from 'components/search';
+import { hasTouch } from 'lib/touch-detect';
 
 /**
  * Module variables
  */
-var instance = 0, SwitcherShell;
+const debug = debugModule( 'calypso:author-selector' );
+let instance = 0;
 
-SwitcherShell = React.createClass( {
+const SwitcherShell = React.createClass( {
 	displayName: 'AuthorSwitcherShell',
 	propTypes: {
 		users: React.PropTypes.array,
@@ -64,8 +65,8 @@ SwitcherShell = React.createClass( {
 	},
 
 	render: function() {
-		var users = this.props.users,
-			infiniteListKey = this.props.fetchNameSpace + this.instance;
+		const { users, fetchNameSpace } = this.props;
+		const infiniteListKey = fetchNameSpace + this.instance;
 
 		if ( ! this._userCanSelectAuthor() ) {
 			return <span>{ this.props.children }</span>;
@@ -89,30 +90,32 @@ SwitcherShell = React.createClass( {
 					context={ this.refs && this.refs.authorSelectorChevron }
 					onKeyDown={ this._onKeyDown }
 					className="author-selector__popover popover">
-					{ this.props.fetchOptions.search || users.length > 10 ?
+					{ ( this.props.fetchOptions.search || users.length > 10 ) &&
 						<Search
 							onSearch={ this._onSearch }
 							placeholder={ this.translate( 'Find Author…', { context: 'search label' } ) }
 							delaySearch={ true }
 							ref="authorSelectorSearch"
-						/> :
-					null }
-					{ this.props.fetchInitialized && ! users.length && this.props.fetchOptions.search && ! this.props.fetchingUsers ?
-						this._noUsersFound() :
-						<InfiniteList
-							items={ users }
-							key={ infiniteListKey }
-							className="author-selector__infinite-list"
-							ref={ this._setListContext }
-							context={ this.state.listContext }
-							fetchingNextPage={ this.props.fetchingUsers }
-							guessedItemHeight={ 42 }
-							lastPage={ this._isLastPage() }
-							fetchNextPage={ this._fetchNextPage }
-							getItemRef={ this._getAuthorItemGUID }
-							renderLoadingPlaceholders={ this._renderLoadingAuthors }
-							renderItem={ this._renderAuthor }>
-						</InfiniteList>
+						/>
+					}
+					{ this.props.fetchInitialized && ! users.length && this.props.fetchOptions.search && ! this.props.fetchingUsers
+						? this._noUsersFound()
+						: (
+							<InfiniteList
+								items={ users }
+								key={ infiniteListKey }
+								className="author-selector__infinite-list"
+								ref={ this._setListContext }
+								context={ this.state.listContext }
+								fetchingNextPage={ this.props.fetchingUsers }
+								guessedItemHeight={ 42 }
+								lastPage={ this._isLastPage() }
+								fetchNextPage={ this._fetchNextPage }
+								getItemRef={ this._getAuthorItemGUID }
+								renderLoadingPlaceholders={ this._renderLoadingAuthors }
+								renderItem={ this._renderAuthor }>
+							</InfiniteList>
+						)
 					}
 				</Popover>
 			</span>
@@ -120,7 +123,7 @@ SwitcherShell = React.createClass( {
 	},
 
 	_isLastPage: function() {
-		var usersLength = this.props.users.length;
+		let usersLength = this.props.users.length;
 		if ( this.props.exclude ) {
 			usersLength += this.props.excludedUsers.length;
 		}
@@ -135,7 +138,7 @@ SwitcherShell = React.createClass( {
 	},
 
 	_userCanSelectAuthor: function() {
-		var users = this.props.users;
+		const { users } = this.props;
 
 		if ( this.props.fetchOptions.search ) {
 			return true;
@@ -156,7 +159,7 @@ SwitcherShell = React.createClass( {
 	},
 
 	_onClose: function( event ) {
-		var toggleElement = ReactDom.findDOMNode( this.refs[ 'author-selector-toggle' ] );
+		const toggleElement = ReactDom.findDOMNode( this.refs[ 'author-selector-toggle' ] );
 
 		if ( event && toggleElement.contains( event.target ) ) {
 			// let _toggleShowAuthor() handle this case
@@ -169,7 +172,7 @@ SwitcherShell = React.createClass( {
 	},
 
 	_renderAuthor: function( author ) {
-		var authorGUID = this._getAuthorItemGUID( author );
+		const authorGUID = this._getAuthorItemGUID( author );
 		return (
 			<PopoverMenuItem
 				className="author-selector__menu-item"
@@ -177,7 +180,7 @@ SwitcherShell = React.createClass( {
 				focusOnHover={ false }
 				key={ authorGUID }
 				tabIndex="-1">
-				<UserItem user={ author }/>
+				<UserItem user={ author } />
 			</PopoverMenuItem>
 		);
 	},
@@ -202,7 +205,7 @@ SwitcherShell = React.createClass( {
 	},
 
 	_fetchNextPage: function() {
-		var fetchOptions = Object.assign( {}, this.props.fetchOptions, { offset: this.props.users.length } );
+		const fetchOptions = Object.assign( {}, this.props.fetchOptions, { offset: this.props.users.length } );
 		debug( 'fetching next batch of authors' );
 		UsersActions.fetchUsers( fetchOptions );
 	},
@@ -254,12 +257,10 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		var searchString = this.state.search || '',
-			fetchOptions;
-
+		let searchString = this.state.search || '';
 		searchString = trim( searchString );
 
-		fetchOptions = {
+		const fetchOptions = {
 			siteId: this.props.siteId,
 			order: 'ASC',
 			order_by: 'display_name',

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -21,8 +21,9 @@ const Card = require( 'components/card' ),
 	accept = require( 'lib/accept' ),
 	analytics = require( 'lib/analytics' );
 import Gravatar from 'components/gravatar';
+import { localize } from 'i18n-calypso';
 
-module.exports = React.createClass( {
+const DeleteUser = React.createClass( {
 	displayName: 'DeleteUser',
 
 	mixins: [ PureRenderMixin ],
@@ -44,11 +45,12 @@ module.exports = React.createClass( {
 	},
 
 	getRemoveText: function() {
+		const { translate } = this.props;
 		if ( ! this.props.user || ! this.props.user.name ) {
-			return this.translate( 'Remove User' );
+			return translate( 'Remove User' );
 		}
 
-		return this.translate( 'Remove %(username)s', {
+		return translate( 'Remove %(username)s', {
 			args: {
 				username: this.props.user.name,
 			}
@@ -56,11 +58,12 @@ module.exports = React.createClass( {
 	},
 
 	getDeleteText: function() {
+		const { translate } = this.props;
 		if ( ! this.props.user || ! this.props.user.name ) {
-			return this.translate( 'Delete User' );
+			return translate( 'Delete User' );
 		}
 
-		return this.translate( 'Delete %(username)s', {
+		return translate( 'Delete %(username)s', {
 			args: {
 				username: this.props.user.name,
 			}
@@ -68,7 +71,7 @@ module.exports = React.createClass( {
 	},
 
 	handleRadioChange: function( event ) {
-		let name = event.currentTarget.name,
+		const name = event.currentTarget.name,
 			value = event.currentTarget.value,
 			updateObj = {};
 
@@ -85,27 +88,28 @@ module.exports = React.createClass( {
 	},
 
 	removeUser: function() {
+		const { translate } = this.props;
 		accept( (
 			<div>
 				<p>
 				{
-					this.props.user && this.props.user.name ?
-					this.translate(
+					this.props.user && this.props.user.name
+					? translate(
 						'If you remove %(username)s, that user will no longer be able to access this site, ' +
 						'but any content that was created by %(username)s will remain on the site.', {
 							args: {
 								username: this.props.user.name
 							}
 						}
-					) :
-					this.translate(
+					)
+					: translate(
 						'If you remove this user, he or she will no longer be able to access this site, ' +
 						'but any content that was created by this user will remain on the site.'
 					)
 				}
 				</p>
 				<p>
-					{ this.translate( 'Would you still like to remove this user?' ) }
+					{ translate( 'Would you still like to remove this user?' ) }
 				</p>
 			</div>
 			),
@@ -117,7 +121,7 @@ module.exports = React.createClass( {
 					analytics.ga.recordEvent( 'People', 'Clicked Cancel Remove User on Edit User Network Site' );
 				}
 			},
-			this.translate( 'Remove' )
+			translate( 'Remove' )
 		);
 		analytics.ga.recordEvent( 'People', 'Clicked Remove User on Edit User Network Site' );
 	},
@@ -138,16 +142,18 @@ module.exports = React.createClass( {
 	},
 
 	getAuthorSelectPlaceholder: function() {
+		const { translate } = this.props;
 		return (
 			<span className="delete-user__select-placeholder">
-				{ this.translate( 'select a user' ) }
+				{ translate( 'select a user' ) }
 			</span>
 		);
 	},
 
 	getTranslatedAssignLabel: function() {
 		const ignoreContext = this.refs ? this.refs.reassignLabel : undefined;
-		return this.translate( 'Attribute all content to {{AuthorSelector/}}', {
+		const { translate } = this.props;
+		return translate( 'Attribute all content to {{AuthorSelector/}}', {
 			components: {
 				AuthorSelector: (
 					<AuthorSelector
@@ -159,14 +165,16 @@ module.exports = React.createClass( {
 						popoverPosition="top left"
 					>
 						{
-							this.state.reassignUser ?
-							<span>
-								<Gravatar size={ 26 } user={ this.state.reassignUser } />
-								<span className="delete-user__reassign-user-name">
-									{ this.state.reassignUser.name }
+							this.state.reassignUser
+							? (
+								<span>
+									<Gravatar size={ 26 } user={ this.state.reassignUser } />
+									<span className="delete-user__reassign-user-name">
+										{ this.state.reassignUser.name }
+									</span>
 								</span>
-							</span> :
-							this.getAuthorSelectPlaceholder()
+							)
+							: this.getAuthorSelectPlaceholder()
 						}
 					</AuthorSelector>
 				)
@@ -183,8 +191,9 @@ module.exports = React.createClass( {
 	},
 
 	renderSingleSite: function() {
+		const { translate } = this.props;
 		return (
-			<Card className="delete-user">
+			<Card className="delete-user__single-site">
 				<form onSubmit={ this.deleteUser }>
 					<FormSectionHeading>
 						{ this.getDeleteText() }
@@ -192,16 +201,16 @@ module.exports = React.createClass( {
 
 					<p className="delete-user__explanation">
 						{
-							this.props.user.name ?
-							this.translate(
+							this.props.user.name
+							? translate(
 								'You have the option of reassigning all content created by ' +
 								'%(username)s, or deleting the content entirely.', {
 									args: {
 										username: this.props.user.name,
 									}
 								}
-							) :
-							this.translate(
+							)
+							: translate(
 								'You have the option of reassigning all content created by ' +
 								'this user, or deleting the content entirely.'
 							)
@@ -232,15 +241,15 @@ module.exports = React.createClass( {
 
 							<span>
 								{
-									this.props.user.name ?
-									this.translate(
+									this.props.user.name
+									? translate(
 										'Delete all content created by %(username)s', {
 											args: {
 												username: this.props.user.name ? this.props.user.name : '',
 											}
 										}
-									) :
-									this.translate(
+									)
+									: translate(
 										'Delete all content created by this user'
 									)
 								}
@@ -250,7 +259,7 @@ module.exports = React.createClass( {
 
 					<FormButtonsBar>
 						<FormButton disabled={ this.isDeleteButtonDisabled() } >
-							{ this.translate( 'Delete user', { context: 'Button label' } ) }
+							{ translate( 'Delete user', { context: 'Button label' } ) }
 						</FormButton>
 					</FormButtonsBar>
 				</form>
@@ -260,8 +269,10 @@ module.exports = React.createClass( {
 
 	renderMultisite: function() {
 		return (
-			<CompactCard className="delete-user" >
-				<a className="edit-team-member-form__remove-user" onClick={ this.removeUser }>
+			<CompactCard className="delete-user__multisite" >
+				<a
+					className="delete-user__remove-user"
+					onClick={ this.removeUser }>
 					<Gridicon icon="trash" />
 					{ this.getRemoveText() }
 				</a>
@@ -281,3 +292,5 @@ module.exports = React.createClass( {
 		return this.props.isMultisite ? this.renderMultisite() : this.renderSingleSite();
 	}
 } );
+
+export default localize( DeleteUser );

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-const React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' );
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -146,6 +146,7 @@ module.exports = React.createClass( {
 	},
 
 	getTranslatedAssignLabel: function() {
+		const ignoreContext = this.refs ? this.refs.reassignLabel : undefined;
 		return this.translate( 'Attribute all content to {{AuthorSelector/}}', {
 			components: {
 				AuthorSelector: (
@@ -154,6 +155,8 @@ module.exports = React.createClass( {
 						siteId={ this.props.siteId }
 						onSelect={ this.onSelectAuthor }
 						exclude={ [ this.props.user.ID ] }
+						ignoreContext={ ignoreContext }
+						popoverPosition="top left"
 					>
 						{
 							this.state.reassignUser ?
@@ -206,7 +209,7 @@ module.exports = React.createClass( {
 					</p>
 
 					<FormFieldset>
-						<FormLabel>
+						<FormLabel ref="reassignLabel">
 							<FormRadio
 								name="radioOption"
 								onChange={ this.handleRadioChange }

--- a/client/my-sites/people/delete-user/style.scss
+++ b/client/my-sites/people/delete-user/style.scss
@@ -6,7 +6,7 @@
 	color: $gray;
 }
 
-.delete-user .author-selector__author-toggle .gravatar {
+.delete-user__single-site .author-selector__author-toggle .gravatar {
 	margin-left: 6px;
 	vertical-align: middle;
 }
@@ -15,7 +15,11 @@
 	margin: 0 3px 0 8px
 }
 
-.edit-team-member-form__remove-user .gridicon {
+.delete-user__remove-user .gridicon {
 	margin: -2px 4px 0 0;
 	vertical-align: middle;
+}
+
+.delete-user__remove-user {
+	cursor: pointer;
 }

--- a/client/my-sites/people/edit-team-member-form/style.scss
+++ b/client/my-sites/people/edit-team-member-form/style.scss
@@ -9,7 +9,3 @@
 		margin-bottom: 0;
 	}
 }
-
-.edit-team-member-form__remove-user {
-	cursor: pointer;
-}


### PR DESCRIPTION
Props @timmyc for his help debugging and pointing me towards `ignoreContext`.

This PR fixes an issue where the delete user UI was unusable for single site Jetpack installations. After some debugging with @timmyc, we believe that what was happening is:

- Clicking the AuthorSelector component briefly displayed the component
- Since that component is within the label, we focused on the radio which is outside the context for the `AuthorSelector`
- Which closed the `AuthorSelector`

The fix was fairly simple, just pass `ignoreContext` which would ignore clicks within the label. But, I went ahead and addressed many ESLint issues as well.

To test:

- Go to `/people/team/$site` where `$site` is a single site Jetpack installation
- Click on a user that is not yourself
- Click "select a user" within "Attribute all content to select a user"
- Ensure the AuthorSelector shows
