### PR TITLE
Themes: Handle theme transfer actions in upload reducers

### DIFF
--- a/client/state/themes/upload-theme/reducer.js
+++ b/client/state/themes/upload-theme/reducer.js
@@ -14,6 +14,12 @@ import {
 	THEME_UPLOAD_FAILURE,
 	THEME_UPLOAD_CLEAR,
 	THEME_UPLOAD_PROGRESS,
+	THEME_TRANSFER_INITIATE_FAILURE,
+	THEME_TRANSFER_INITIATE_PROGRESS,
+	THEME_TRANSFER_INITIATE_REQUEST,
+	THEME_TRANSFER_INITIATE_SUCCESS,
+	THEME_TRANSFER_STATUS_FAILURE,
+	THEME_TRANSFER_STATUS_RECEIVE,
 } from 'state/action-types';
 
 export const uploadedThemeId = createReducer( {}, {
@@ -21,8 +27,13 @@ export const uploadedThemeId = createReducer( {}, {
 		...state,
 		[ siteId ]: themeId,
 	} ),
+	[ THEME_TRANSFER_STATUS_RECEIVE ]: ( state, { siteId, themeId } ) => ( {
+		...state,
+		[ siteId ]: themeId,
+	} ),
 	[ THEME_UPLOAD_CLEAR ]: ( state, { siteId } ) => ( omit( state, siteId ) ),
 	[ THEME_UPLOAD_START ]: ( state, { siteId } ) => ( omit( state, siteId ) ),
+	[ THEME_TRANSFER_INITIATE_REQUEST ]: ( state, { siteId } ) => ( omit( state, siteId ) ),
 } );
 
 export const uploadError = createReducer( {}, {
@@ -30,8 +41,17 @@ export const uploadError = createReducer( {}, {
 		...state,
 		[ siteId ]: error,
 	} ),
+	[ THEME_TRANSFER_STATUS_FAILURE ]: ( state, { siteId, error } ) => ( {
+		...state,
+		[ siteId ]: error,
+	} ),
+	[ THEME_TRANSFER_INITIATE_FAILURE ]: ( state, { siteId, error } ) => ( {
+		...state,
+		[ siteId ]: error,
+	} ),
 	[ THEME_UPLOAD_CLEAR ]: ( state, { siteId } ) => ( omit( state, siteId ) ),
 	[ THEME_UPLOAD_START ]: ( state, { siteId } ) => ( omit( state, siteId ) ),
+	[ THEME_TRANSFER_INITIATE_REQUEST ]: ( state, { siteId } ) => ( omit( state, siteId ) ),
 } );
 
 export const progressLoaded = createReducer( {}, {
@@ -39,8 +59,13 @@ export const progressLoaded = createReducer( {}, {
 		...state,
 		[ siteId ]: loaded,
 	} ),
+	[ THEME_TRANSFER_INITIATE_PROGRESS ]: ( state, { siteId, loaded } ) => ( {
+		...state,
+		[ siteId ]: loaded,
+	} ),
 	[ THEME_UPLOAD_CLEAR ]: ( state, { siteId } ) => ( omit( state, siteId ) ),
 	[ THEME_UPLOAD_START ]: ( state, { siteId } ) => ( omit( state, siteId ) ),
+	[ THEME_TRANSFER_INITIATE_REQUEST ]: ( state, { siteId } ) => ( omit( state, siteId ) ),
 } );
 
 export const progressTotal = createReducer( {}, {
@@ -48,12 +73,21 @@ export const progressTotal = createReducer( {}, {
 		...state,
 		[ siteId ]: total,
 	} ),
+	[ THEME_TRANSFER_INITIATE_PROGRESS ]: ( state, { siteId, total } ) => ( {
+		...state,
+		[ siteId ]: total,
+	} ),
 	[ THEME_UPLOAD_CLEAR ]: ( state, { siteId } ) => ( omit( state, siteId ) ),
 	[ THEME_UPLOAD_START ]: ( state, { siteId } ) => ( omit( state, siteId ) ),
+	[ THEME_TRANSFER_INITIATE_REQUEST ]: ( state, { siteId } ) => ( omit( state, siteId ) ),
 } );
 
 export const inProgress = createReducer( {}, {
 	[ THEME_UPLOAD_START ]: ( state, { siteId } ) => ( {
+		...state,
+		[ siteId ]: true,
+	} ),
+	[ THEME_TRANSFER_INITIATE_REQUEST ]: ( state, { siteId } ) => ( {
 		...state,
 		[ siteId ]: true,
 	} ),
@@ -66,6 +100,14 @@ export const inProgress = createReducer( {}, {
 		[ siteId ]: false,
 	} ),
 	[ THEME_UPLOAD_FAILURE ]: ( state, { siteId } ) => ( {
+		...state,
+		[ siteId ]: false,
+	} ),
+	[ THEME_TRANSFER_INITIATE_SUCCESS ]: ( state, { siteId } ) => ( {
+		...state,
+		[ siteId ]: false,
+	} ),
+	[ THEME_TRANSFER_INITIATE_FAILURE ]: ( state, { siteId } ) => ( {
 		...state,
 		[ siteId ]: false,
 	} ),

--- a/client/state/themes/upload-theme/reducer.js
+++ b/client/state/themes/upload-theme/reducer.js
@@ -17,7 +17,6 @@ import {
 	THEME_TRANSFER_INITIATE_FAILURE,
 	THEME_TRANSFER_INITIATE_PROGRESS,
 	THEME_TRANSFER_INITIATE_REQUEST,
-	THEME_TRANSFER_INITIATE_SUCCESS,
 	THEME_TRANSFER_STATUS_FAILURE,
 	THEME_TRANSFER_STATUS_RECEIVE,
 } from 'state/action-types';
@@ -103,11 +102,15 @@ export const inProgress = createReducer( {}, {
 		...state,
 		[ siteId ]: false,
 	} ),
-	[ THEME_TRANSFER_INITIATE_SUCCESS ]: ( state, { siteId } ) => ( {
+	[ THEME_TRANSFER_STATUS_RECEIVE ]: ( state, { siteId, status } ) => ( {
+		...state,
+		[ siteId ]: ! status === 'complete',
+	} ),
+	[ THEME_TRANSFER_INITIATE_FAILURE ]: ( state, { siteId } ) => ( {
 		...state,
 		[ siteId ]: false,
 	} ),
-	[ THEME_TRANSFER_INITIATE_FAILURE ]: ( state, { siteId } ) => ( {
+	[ THEME_TRANSFER_STATUS_FAILURE ]: ( state, { siteId } ) => ( {
 		...state,
 		[ siteId ]: false,
 	} ),

--- a/client/state/themes/upload-theme/test/reducer.js
+++ b/client/state/themes/upload-theme/test/reducer.js
@@ -12,6 +12,11 @@ import {
 	THEME_UPLOAD_FAILURE,
 	THEME_UPLOAD_CLEAR,
 	THEME_UPLOAD_PROGRESS,
+	THEME_TRANSFER_STATUS_RECEIVE,
+	THEME_TRANSFER_INITIATE_FAILURE,
+	THEME_TRANSFER_STATUS_FAILURE,
+	THEME_TRANSFER_INITIATE_PROGRESS,
+	THEME_TRANSFER_INITIATE_REQUEST,
 } from 'state/action-types';
 import {
 	uploadedThemeId,
@@ -21,7 +26,7 @@ import {
 	inProgress,
 } from '../reducer';
 
-const themeId ='twentysixteen';
+const themeId = 'twentysixteen';
 
 const error = {
 	type: 'error',
@@ -63,6 +68,18 @@ describe( 'uploadedThemeId', () => {
 		} );
 		expect( state[ siteId ] ).to.be.undefined;
 	} );
+
+	it( 'should contain theme id after successful transfer with theme', () => {
+		const state = uploadedThemeId( {}, {
+			type: THEME_TRANSFER_STATUS_RECEIVE,
+			siteId,
+			transferId: 89,
+			status: 'complete',
+			message: 'transfer complete',
+			themeId,
+		} );
+		expect( state[ siteId ] ).to.deep.equal( themeId );
+	} );
 } );
 
 describe( 'uploadError', () => {
@@ -98,6 +115,25 @@ describe( 'uploadError', () => {
 		} );
 		expect( state[ siteId ] ).to.be.undefined;
 	} );
+
+	it( 'should contain error after failed transfer request', () => {
+		const state = uploadError( {}, {
+			type: THEME_TRANSFER_INITIATE_FAILURE,
+			siteId,
+			error,
+		} );
+		expect( state[ siteId ] ).to.deep.equal( error );
+	} );
+
+	it( 'should contain error after failed transfer status request', () => {
+		const state = uploadError( {}, {
+			type: THEME_TRANSFER_STATUS_FAILURE,
+			siteId,
+			transferId: 98,
+			error,
+		} );
+		expect( state[ siteId ] ).to.deep.equal( error );
+	} );
 } );
 
 describe( 'progressLoaded', () => {
@@ -125,6 +161,16 @@ describe( 'progressLoaded', () => {
 		} );
 		expect( state[ siteId ] ).to.be.undefined;
 	} );
+
+	it( 'should contain loaded amount after transfer progress action', () => {
+		const state = progressLoaded( {}, {
+			type: THEME_TRANSFER_INITIATE_PROGRESS,
+			siteId,
+			total: 100,
+			loaded: 50,
+		} );
+		expect( state[ siteId ] ).to.equal( 50 );
+	} );
 } );
 
 describe( 'progressTotal', () => {
@@ -151,6 +197,16 @@ describe( 'progressTotal', () => {
 			siteId,
 		} );
 		expect( state[ siteId ] ).to.be.undefined;
+	} );
+
+	it( 'should contain total amount after transfer progress action', () => {
+		const state = progressTotal( {}, {
+			type: THEME_TRANSFER_INITIATE_PROGRESS,
+			siteId,
+			total: 100,
+			loaded: 50,
+		} );
+		expect( state[ siteId ] ).to.equal( 100 );
 	} );
 } );
 
@@ -190,6 +246,33 @@ describe( 'inProgress', () => {
 		const state = inProgress( {}, {
 			type: THEME_UPLOAD_CLEAR,
 			siteId,
+		} );
+		expect( state[ siteId ] ).to.not.be.true;
+	} );
+
+	it( 'should be true on transfer initiate', () => {
+		const state = inProgress( {}, {
+			type: THEME_TRANSFER_INITIATE_REQUEST,
+			siteId,
+		} );
+		expect( state[ siteId ] ).to.be.true;
+	} );
+
+	it( 'should not be true on transfer status complete', () => {
+		const state = inProgress( {}, {
+			type: THEME_TRANSFER_STATUS_RECEIVE,
+			siteId,
+			themeId,
+			status: 'complete'
+		} );
+		expect( state[ siteId ] ).to.not.be.true;
+	} );
+
+	it( 'should not be true on transfer status failure', () => {
+		const state = inProgress( {}, {
+			type: THEME_TRANSFER_STATUS_FAILURE,
+			siteId,
+			error,
 		} );
 		expect( state[ siteId ] ).to.not.be.true;
 	} );


### PR DESCRIPTION
No visual differences.

Integrate the upload page added in #9632 with site transfers initiated by a theme upload.

This PR takes the approach of integrating transfers with regular jetpack theme uploads at the reducer level. This means that the UI can continue to use all the same selectors.

I propose we take this approach now for the sake of getting transfers working quickly, then later on we can introduce dedicated reducers and selectors for the transfer actions, with a higher level of selectors that will combine uploads and transfers.

**To Test**
Unit tests run automatically by CircleCI

**Todo**
- [x] rebase once #9849 lands
- [x] add new reducer unit tests

