### PR TITLE
Reader: fix end of stream icon for white background

### DIFF
--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -386,3 +386,17 @@
 .following-edit .foldable-card.is-expanded .gridicon {
 	transform: rotate( 0deg );
 }
+
+/* = Infinite scroll end (shown at end of streams)
+ --------------------------------------------------------------- */
+
+.is-reader-page .infinite-scroll-end {
+	&:before {
+		border-bottom: none;
+	}
+
+  	&:after {
+    	background-color: inherit;
+    	margin-top: 20px;
+	}
+}

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -372,7 +372,7 @@
 		.foldable-card__content {
 			padding: 0;
 		}
- 	}
+	}
 
 	.foldable-card__expand .gridicon {
 		transform: rotate( -90deg );
@@ -395,8 +395,8 @@
 		border-bottom: none;
 	}
 
-  	&:after {
-    	background-color: inherit;
-    	margin-top: 20px;
+	&:after {
+		background-color: inherit;
+		margin-top: 20px;
 	}
 }


### PR DESCRIPTION
Fixes #9909.

Before:

<img width="873" alt="screen shot 2016-12-09 at 12 58 17" src="https://cloud.githubusercontent.com/assets/17325/21032574/35664762-be0f-11e6-9346-10c92a46d82e.png">

After:

<img width="877" alt="screen shot 2016-12-09 at 12 57 52" src="https://cloud.githubusercontent.com/assets/17325/21032579/3902d2d2-be0f-11e6-83ce-ab5fe7eeeca7.png">

### To test 

Visit a stream with a limited number of posts (e.g. http://calypso.localhost:3000/read/feeds/40474143) and scroll to the end.