### PR TITLE
Reader: Update dismissible buttons in in-stream recs

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -372,6 +372,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 // If we're not showing the entire excerpt, clamp lines
 .reader-post-card.card:not(.is-showing-entire-excerpt) {
+
 	.reader-post-card__excerpt {
 		overflow: hidden;
 		max-height: 15px * 1.6 * 3;
@@ -408,8 +409,10 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 // 3 line excerpt for thumbnail cards
 .reader-post-card.card.has-thumbnail:not(.is-gallery) {
+
 	.reader-post-card__excerpt {
 		max-height: 15px * 1.6 * 3;
+		overflow: hidden;
 	}
 }
 

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -431,19 +431,22 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 .reader-stream__recommended-posts-list {
 	display: flex;
 	flex-direction: row;
-	margin: 0;
+	margin: 0 0 -30px;
 	padding: 0;
 
 	@media #{$reader-related-card-v2-breakpoint-medium} {
 		flex-direction: column;
+		margin: 0 0 -10px;
 	}
 
 	@include breakpoint( "<660px" ) {
 		flex-direction: row;
+		margin: 0 0 -30px;
 	}
 
 	@media #{$reader-related-card-v2-breakpoint-small} {
 		flex-direction: column;
+		margin: 0 0 -10px;
 	}
 }
 
@@ -453,26 +456,36 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	flex-direction: column;
 	list-style-type: none;
 	position: relative;
+		top: -40px;
 
 	@media #{$reader-related-card-v2-breakpoint-medium} {
 		flex-direction: row;
+		top: 0;
 	}
 
 	@media #{$reader-related-card-v2-breakpoint-small} {
 		flex-direction: row;
+		top: 0;
 	}
 
 	.reader-stream__recommended-post-dismiss {
 		display: flex;
 		justify-content: flex-end;
-		border: 1px solid red;
 
 		@media #{$reader-related-card-v2-breakpoint-medium} {
+			flex-grow: 1;
 			align-self: baseline;
+			justify-content: flex-start;
+		}
+
+		@include breakpoint( "<660px" ) {
+			justify-content: flex-end;
 		}
 
 		@media #{$reader-related-card-v2-breakpoint-small} {
+			flex-grow: 1;
 			align-self: baseline;
+			justify-content: flex-start;
 		}
 
 		.gridicon {
@@ -484,8 +497,16 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	}
 
 	.card.reader-related-card-v2 {
-		border: 1px solid green;
 		margin: 0;
+		padding-top: 10px;
+
+		@media #{$reader-related-card-v2-breakpoint-medium} {
+			flex-grow: 40;
+		}
+
+		@media #{$reader-related-card-v2-breakpoint-small} {
+			flex-grow: 40;
+		}
 	}
 
 	&:first-child {

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -448,18 +448,32 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 }
 
 .reader-stream__recommended-posts-list-item {
-	flex-basis: 0;
-	flex-grow: 1;
+	display: flex;
+	flex: 1;
+	flex-direction: column;
 	list-style-type: none;
-	margin-top: -3px;
 	position: relative;
 
+	@media #{$reader-related-card-v2-breakpoint-medium} {
+		flex-direction: row;
+	}
+
+	@media #{$reader-related-card-v2-breakpoint-small} {
+		flex-direction: row;
+	}
+
 	.reader-stream__recommended-post-dismiss {
-		position: absolute;
-			top: -40px;
-			right: 0;
-		padding-left: 24px;
-		padding-bottom: 0;
+		display: flex;
+		justify-content: flex-end;
+		border: 1px solid red;
+
+		@media #{$reader-related-card-v2-breakpoint-medium} {
+			align-self: baseline;
+		}
+
+		@media #{$reader-related-card-v2-breakpoint-small} {
+			align-self: baseline;
+		}
 
 		.gridicon {
 			fill: lighten( $gray, 10% );
@@ -467,6 +481,11 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 			height: 14px;
 			top: 0;
 		}
+	}
+
+	.card.reader-related-card-v2 {
+		border: 1px solid green;
+		margin: 0;
 	}
 
 	&:first-child {

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -493,6 +493,14 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 			width: 14px;
 			height: 14px;
 			top: 0;
+
+			@media #{$reader-related-card-v2-breakpoint-medium} {
+				top: 4px;
+			}
+
+			@media #{$reader-related-card-v2-breakpoint-small} {
+				top: 4px;
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR updates the dismiss buttons in in-stream recs to match the mockups:

**Wide viewports:**
![screenshot 2016-12-08 16 21 02](https://cloud.githubusercontent.com/assets/4924246/21033018/6c067038-bd62-11e6-8b63-80388cbf4146.png)

**Narrow viewports:**
![screenshot 2016-12-08 16 20 49](https://cloud.githubusercontent.com/assets/4924246/21033019/6f5d0c74-bd62-11e6-8202-bca9a091a614.png)

Related: https://github.com/Automattic/wp-calypso/pull/9876