### PR TITLE
Taxonomy Manger: Enable on Stage.

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -60,6 +60,7 @@
 		"manage/security": true,
 		"manage/sharing": true,
 		"manage/site-settings/analytics": true,
+		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,
 		"manage/seo": true,
 		"manage/stats": true,


### PR DESCRIPTION
To ease testing of the new Taxonomy Manager, this branch is just enabling it on Staging.

Details see: pbg9X-bkY-p2