### PR TITLE
DevDocs: Generate an index of proptypes for client consumption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ env-config.sh
 /public/images/flags/*.png
 /server/devdocs/search-index.js
 /server/devdocs/components-usage-stats.json
+/server/devdocs/proptypes-index.json
 /server/bundler/assets-*.json
 
 *.rdb

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ AUTOPREFIXER ?= $(NODE_BIN)/postcss -r --use autoprefixer --autoprefixer.browser
 RECORD_ENV ?= $(BIN)/record-env
 ALL_DEVDOCS_JS ?= server/devdocs/bin/generate-devdocs-index
 COMPONENTS_USAGE_STATS_JS ?= server/devdocs/bin/generate-components-usage-stats.js
+COMPONENTS_PROPTYPES_JS ?= server/devdocs/bin/generate-proptypes-index.js
 
 # files used as prereqs
 SASS_FILES := $(shell \
@@ -58,6 +59,9 @@ COMPONENTS_USAGE_STATS_FILES = $(shell \
 		-not \( -path '*/docs-example/*' -prune \) \
 		-type f \
 		\( -name '*.js' -or -name '*.jsx' \) \
+)
+COMPONENTS_PROPTYPE_FILES = $(shell \
+	find client -name 'index.jsx' -or -name 'example.jsx' \
 )
 CLIENT_CONFIG_FILE := client/config/index.js
 
@@ -149,6 +153,9 @@ server/devdocs/search-index.js: $(MD_FILES) $(ALL_DEVDOCS_JS)
 server/devdocs/components-usage-stats.json: $(COMPONENTS_USAGE_STATS_FILES) $(COMPONENTS_USAGE_STATS_JS)
 	@$(COMPONENTS_USAGE_STATS_JS) $(COMPONENTS_USAGE_STATS_FILES)
 
+server/devdocs/proptypes-index.json: $(COMPONENTS_PROPTYPE_FILES) $(COMPONENTS_PROPTYPES_JS)
+	@$(COMPONENTS_PROPTYPES_JS) $(COMPONENTS_PROPTYPE_FILES)
+
 build-dll: node_modules
 	@mkdir -p build
 	@CALYPSO_ENV=$(CALYPSO_ENV) $(NODE_BIN)/webpack --display-error-details --config webpack-dll.config.js
@@ -161,9 +168,9 @@ build: install build-$(CALYPSO_ENV)
 
 build-css: public/style.css public/style-rtl.css public/style-debug.css public/editor.css
 
-build-development: server/devdocs/components-usage-stats.json build-server build-dll $(CLIENT_CONFIG_FILE) server/devdocs/search-index.js build-css
+build-development: server/devdocs/proptypes-index.json server/devdocs/components-usage-stats.json build-server build-dll $(CLIENT_CONFIG_FILE) server/devdocs/search-index.js build-css
 
-build-wpcalypso: server/devdocs/components-usage-stats.json build-server build-dll $(CLIENT_CONFIG_FILE) server/devdocs/search-index.js build-css
+build-wpcalypso: server/devdocs/proptypes-index.json server/devdocs/components-usage-stats.json build-server build-dll $(CLIENT_CONFIG_FILE) server/devdocs/search-index.js build-css
 	@$(BUNDLER)
 
 build-horizon build-stage build-production: build-server build-dll $(CLIENT_CONFIG_FILE) build-css
@@ -175,7 +182,7 @@ build-desktop build-desktop-mac-app-store: build-server $(CLIENT_CONFIG_FILE) bu
 # the `clean` rule deletes all the files created from `make build`, but not
 # those created by `make install`
 clean:
-	@rm -rf public/style*.css public/style-debug.css.map public/*.js $(CLIENT_CONFIG_FILE) server/devdocs/search-index.js server/devdocs/components-usage-stats.json public/editor.css build/* server/bundler/*.json .babel-cache
+	@rm -rf public/style*.css public/style-debug.css.map public/*.js $(CLIENT_CONFIG_FILE) server/devdocs/search-index.js server/devdocs/proptypes-index.json server/devdocs/components-usage-stats.json public/editor.css build/* server/bundler/*.json .babel-cache
 
 # the `distclean` rule deletes all the files created from `make install`
 distclean: clean

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,11 @@ COMPONENTS_USAGE_STATS_FILES = $(shell \
 		\( -name '*.js' -or -name '*.jsx' \) \
 )
 COMPONENTS_PROPTYPE_FILES = $(shell \
-	find client -name 'index.jsx' -or -name 'example.jsx' \
+	find client \
+		-name 'index.jsx' \
+		-or -name 'index.js' \
+		-or -name 'example.jsx' \
+		-and -not -path '*/test/*' \
 )
 CLIENT_CONFIG_FILE := client/config/index.js
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3093,6 +3093,20 @@
     "react-day-picker": {
       "version": "2.4.1"
     },
+    "react-docgen": {
+      "version": "2.13.0",
+      "dependencies": {
+        "async": {
+          "version": "1.5.2"
+        },
+        "babylon": {
+          "version": "5.8.38"
+        },
+        "commander": {
+          "version": "2.9.0"
+        }
+      }
+    },
     "react-dom": {
       "version": "15.4.0"
     },

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "react-addons-update": "15.4.0",
     "react-click-outside": "2.1.0",
     "react-day-picker": "2.4.1",
-    "react-docgen": "2.12.1",
+    "react-docgen": "2.13.0",
     "react-dom": "15.4.0",
     "react-masonry-component": "4.2.2",
     "react-pure-render": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "react-addons-update": "15.4.0",
     "react-click-outside": "2.1.0",
     "react-day-picker": "2.4.1",
+    "react-docgen": "2.12.1",
     "react-dom": "15.4.0",
     "react-masonry-component": "4.2.2",
     "react-pure-render": "1.0.2",

--- a/server/devdocs/bin/generate-proptypes-index.js
+++ b/server/devdocs/bin/generate-proptypes-index.js
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+/**
+ * This file generates an index of proptypes by component displayname, slug and folder name
+ */
+
+const fs = require( 'fs' ),
+	path = require( 'path' ),
+	async = require( 'async' ),
+	reactDocgen = require( 'react-docgen' ),
+	root = path.dirname( path.join( __dirname, '..', '..' ) );
+
+/**
+ * Converts a camel cased string into a slug
+ * @param {String} name The camel cased string to slugify
+ * @return {String}
+ */
+const camelCaseToSlug = ( name ) => {
+	if ( ! name ) {
+		return name;
+	}
+
+	return name
+		.replace( /\.?([A-Z])/g, ( x, y ) => '-' + y.toLowerCase() )
+		.replace( /^-/, '' );
+};
+
+/**
+ * Async.Map over items, in a Promise fashion
+ * @param {Array} items The items to iterate over
+ * @param {func} func The function to call
+ * @return {Promise} A promise that they will be iterated over
+ */
+const map = ( items, func ) => {
+	return new Promise( ( resolve, reject ) => {
+		async.map( items, func, ( error, results ) => {
+			if ( error ) {
+				reject( error );
+			} else {
+				resolve( results );
+			}
+		} );
+	} );
+};
+
+/**
+ * Wraps fs.readFile in a Promise
+ * @param {string} filePath The path to of the file to read
+ * @return {Promise} The promise that the file will be read
+ */
+const readFile = ( filePath ) => {
+	return new Promise( ( resolve, reject ) => {
+		fs.readFile( filePath, { encoding: 'utf8' }, ( error, data ) => {
+			if ( error ) {
+				reject( error );
+			} else {
+				resolve( data );
+			}
+		} );
+	} );
+};
+
+/**
+ * Calculates a filepath's include path and begins reading the file for parsing
+ * Calls back with null, if an error occurs or an object if it succeeds
+ * @param {string} filePath The path to read
+ * @param {func} cb The callback for when the function has completed
+ */
+const processFile = ( filePath, cb ) => {
+	const filename = path.basename( filePath );
+	const includePath = new RegExp(`^client\/(.*?)\/${ filename }$`);
+	try {
+		const usePath = path.isAbsolute( filePath ) ? filePath : path.join( process.cwd(), filePath );
+		const document = readFile( usePath );
+		cb( null, {
+			document,
+			includePath: includePath.exec( filePath )[1]
+		} );
+		return;
+	} catch ( error ) {
+		console.log(`Skipping ${ filePath } due to fs error: ${ error }`);
+	}
+	cb( null, null );
+};
+
+/**
+ * Given a processed file object, parses the file for proptypes and calls the callback
+ * Calls back with null on any error, or a parsed object if it succeeds
+ * @param {Object} docObj The processed document object
+ * @param {func} cb The callback when it has completed
+ */
+const processDocumentPromise = ( docObj, cb ) => {
+	docObj.document.then( ( document ) => {
+		const parsed = reactDocgen.parse( document );
+		parsed.includePath = docObj.includePath;
+		cb(null, parsed)
+	} ).catch( ( error ) => {
+		// skipping, probably because the file couldn't be parsed for many reasons (there are lots of them!)
+		cb(null, null);
+	} );
+};
+
+/**
+ * Causes a side effect in `index`. Unconditionally appends `currentIndex` to `index[ name ]`, even if
+ * `index[ name ]` is undefined
+ * @param {string} name The index of `index`
+ * @param {Number} currentIndex The current index to append to `index`
+ * @param {Array} index The array to apply side effects to
+ */
+const applyIndex = ( name, currentIndex, index ) => {
+	index[ name ] = [ currentIndex ].concat( index[ name ] || [] );
+};
+
+/**
+ * Sort an object keys alphabetically
+ * @param {Object} obj The object whose keys are to be sorted
+ * @return {Object} The sorted object
+ */
+const sortObjectByPropertyName = (obj) => {
+	return Object.keys( obj )
+		.sort()
+		.reduce( ( accumulator, current ) => {
+			accumulator[ current ] = obj[ current ];
+			return accumulator;
+		}, {});
+};
+
+/**
+ * Creates an index of the files
+ * @param {Array} parsed
+ * @return {{data: Array, index: {displayName: {}, slug: {}, includePath: {}}}}
+ */
+const createIndex = ( parsed ) => {
+	const final = {
+		data: [],
+		index: {
+			displayName: {},
+			includePath: {},
+			slug: {}
+		}
+	};
+
+	let currentIndex = 0;
+	parsed.forEach( ( component ) => {
+		if ( ! component ) {
+			return;
+		}
+
+		const displayName = component.displayName;
+		const slug = camelCaseToSlug( displayName );
+		const includePath = component.includePath;
+
+		if ( displayName === undefined || displayName === '' ) {
+			return;
+		}
+
+		final.data[ currentIndex ] = component;
+		applyIndex( displayName, currentIndex, final.index.displayName );
+		applyIndex( slug, currentIndex, final.index.slug );
+		applyIndex( includePath, currentIndex, final.index.includePath );
+
+		currentIndex++;
+	} );
+
+	// for human readability, not strictly necessary
+	final.index.displayName = sortObjectByPropertyName( final.index.displayName );
+	final.index.includePath = sortObjectByPropertyName( final.index.includePath );
+	final.index.slug = sortObjectByPropertyName( final.index.slug );
+
+	return final;
+};
+
+/**
+ * Write the file
+ * @param {Object} contents The contents of the file
+ */
+const writeFile = ( contents ) => {
+	fs.writeFileSync( path.join( root, 'server/devdocs/proptypes-index.json' ), JSON.stringify( contents ) );
+};
+
+const main = (() => {
+	const fileList = process
+		.argv
+		.splice( 2, process.argv.length )
+		.map( ( fileWithPath ) => {
+			return fileWithPath.replace( /^\.\//, '' );
+		} );
+
+	if ( fileList.length === 0 ) {
+		process.stderr.write( 'You must pass a list of files to process' );
+		process.exit( 1 );
+	}
+
+	map( fileList, processFile )
+		.then( ( documents ) => map( documents, processDocumentPromise ) )
+		.then( ( parsed ) => createIndex( parsed ) )
+		.then( writeFile );
+} )();

--- a/server/devdocs/bin/generate-proptypes-index.js
+++ b/server/devdocs/bin/generate-proptypes-index.js
@@ -8,7 +8,8 @@ const fs = require( 'fs' ),
 	path = require( 'path' ),
 	async = require( 'async' ),
 	reactDocgen = require( 'react-docgen' ),
-	root = path.dirname( path.join( __dirname, '..', '..' ) );
+	root = path.dirname( path.join( __dirname, '..', '..' ) ),
+	pathSwap = new RegExp(path.sep, 'g');
 
 /**
  * Converts a camel cased string into a slug
@@ -41,13 +42,15 @@ const readFile = ( filePath ) => {
  */
 const processFile = ( filePath ) => {
 	const filename = path.basename( filePath );
-	const includePath = new RegExp(`^client\/(.*?)\/${ filename }$`);
+	const includePathRegEx = new RegExp(`^client${ path.sep }(.*?)${ path.sep }${ filename }$`);
+	const includePathSuffix = ( filename === 'index.jsx' ? '' : path.sep + path.basename( filename, '.jsx' ) );
+	const includePath = ( includePathRegEx.exec( filePath )[1] + includePathSuffix ).replace( pathSwap, '/' ) ;
 	try {
 		const usePath = path.isAbsolute( filePath ) ? filePath : path.join( process.cwd(), filePath );
 		const document = readFile( usePath );
 		return {
 			document,
-			includePath: includePath.exec( filePath )[1]
+			includePath
 		};
 	} catch ( error ) {
 		console.log(`Skipping ${ filePath } due to fs error: ${ error }`);

--- a/server/devdocs/bin/generate-proptypes-index.js
+++ b/server/devdocs/bin/generate-proptypes-index.js
@@ -4,12 +4,16 @@
  * This file generates an index of proptypes by component displayname, slug and folder name
  */
 
-const fs = require( 'fs' ),
-	path = require( 'path' ),
-	async = require( 'async' ),
-	reactDocgen = require( 'react-docgen' ),
-	root = path.dirname( path.join( __dirname, '..', '..' ) ),
-	pathSwap = new RegExp(path.sep, 'g');
+/**
+ * External Dependencies
+ */
+
+const fs = require( 'fs' );
+const path = require( 'path' );
+const reactDocgen = require( 'react-docgen' );
+
+const root = path.dirname( path.join( __dirname, '..', '..' ) );
+const pathSwap = new RegExp(path.sep, 'g');
 
 /**
  * Converts a camel cased string into a slug


### PR DESCRIPTION
One of the first steps in rendering the propTypes in the client is getting them to the client. This creates a new artifact during a build (194k -- 24k gzip'd) that parses **all** the `index.jsx` and `example.jsx` files. The reasoning behind this is two fold:

1. We don't really know at build time which components are in the devdocs. While we could discover them, it would add complexity.
2. We also want the `example.jsx` files for now and they will be removed in a future iteration. This is so that a user of this file can know what props are exposed through the example wrapper component, if any.

I believe this PR opens the door to some really awesome things. Such as:

1. Searching for a component by includePath
2. Adding a props reference to readme's as part of the build
3. Adding a props reference in devdocs

## The generated file

An array of parsed objects, which looks something like this for a small component:

``` json
{
	"description": "",
	"displayName": "BulkSelect",
	"methods": [
	  {
		"name": "getStateIcon",
		"docblock": null,
		"modifiers": [],
		"params": [],
		"returns": null
	  },
	  {
		"name": "hasAllElementsSelected",
		"docblock": null,
		"modifiers": [],
		"params": [],
		"returns": null
	  },
	  {
		"name": "hasSomeElementsSelected",
		"docblock": null,
		"modifiers": [],
		"params": [],
		"returns": null
	  },
	  {
		"name": "handleToggleAll",
		"docblock": null,
		"modifiers": [],
		"params": [],
		"returns": null
	  }
	],
	"props": {
	  "totalElements": {
		"type": {
		  "name": "number"
		},
		"required": true,
		"description": ""
	  },
	  "selectedElements": {
		"type": {
		  "name": "number"
		},
		"required": true,
		"description": ""
	  },
	  "onToggle": {
		"type": {
		  "name": "func"
		},
		"required": true,
		"description": ""
	  }
	},
	"includePath": "components/bulk-select",
	"slug": "bulk-select"
  },
```