### PR TITLE
Plugins: add automated transfer progress bar style

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -281,6 +281,7 @@
 @import 'my-sites/plugins/jetpack-plugins-setup/style';
 @import 'my-sites/plugins/plugin-action/style';
 @import 'my-sites/plugins/plugin-activate-toggle/style';
+@import 'my-sites/plugins/plugin-automated-transfer/style';
 @import 'my-sites/plugins/plugin-icon/style';
 @import 'my-sites/plugins/plugin-information/style';
 @import 'my-sites/plugins/plugin-item/style';


### PR DESCRIPTION
Add the missing style after this revert: https://github.com/Automattic/wp-calypso/commit/333edb53d812c3f424590ada1a98717c35a277e1