### PR TITLE
Guided Tours: Cleanup selectors, add jsdocs

### DIFF
--- a/client/layout/guided-tours/tours/main-tour.js
+++ b/client/layout/guided-tours/tours/main-tour.js
@@ -3,7 +3,10 @@
  */
 import React from 'react';
 import { translate } from 'i18n-calypso';
-import { overEvery as and } from 'lodash';
+import {
+	negate as not,
+	overEvery as and,
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,9 +26,8 @@ import {
 	isEnabled,
 	isSelectedSitePreviewable,
 	isSelectedSiteCustomizable,
-	isPreviewNotShowing,
-	isPreviewShowing,
 } from 'state/ui/guided-tours/contexts';
+import { isPreviewShowing } from 'state/ui/selectors';
 import { getScrollableSidebar } from 'layout/guided-tours/positioning';
 import scrollTo from 'lib/scroll-to';
 
@@ -128,7 +130,7 @@ export const MainTour = makeTour(
 			<ButtonRow>
 				<Next step="close-preview" />
 				<Quit />
-				<Continue hidden step="close-preview" when={ isPreviewNotShowing } />
+				<Continue hidden step="close-preview" when={ not( isPreviewShowing ) } />
 			</ButtonRow>
 		</Step>
 
@@ -141,7 +143,7 @@ export const MainTour = makeTour(
 			<p>
 				{ translate( 'Take a look at your site — and then close the site preview. You can come back here anytime.' ) }
 			</p>
-			<Continue icon="cross-small" step="themes" target="web-preview__close" when={ isPreviewNotShowing } />
+			<Continue icon="cross-small" step="themes" target="web-preview__close" when={ not( isPreviewShowing ) } />
 		</Step>
 
 		<Step name="themes"

--- a/client/layout/guided-tours/tours/theme-sheet-welcome-tour.js
+++ b/client/layout/guided-tours/tours/theme-sheet-welcome-tour.js
@@ -21,8 +21,8 @@ import {
 	isAbTestInVariant,
 	isEnabled,
 	isNewUser,
-	isPreviewShowing,
 } from 'state/ui/guided-tours/contexts';
+import { isPreviewShowing } from 'state/ui/selectors';
 import { isDesktop } from 'lib/viewport';
 
 export const ThemeSheetWelcomeTour = makeTour(

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -1004,7 +1004,7 @@ export function getCustomizerUrl( state, siteId ) {
 	}, adminUrl );
 }
 
-/*
+/**
  * Returns true if the site has unchanged site title
  *
  * @param {Object} state Global state tree

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -7,41 +7,71 @@ import {
 	getSectionName,
 	getSelectedSite,
 	getSelectedSiteId,
-	isPreviewShowing as isPreviewShowingSelector,
 } from 'state/ui/selectors';
 import { getLastAction } from 'state/ui/action-log/selectors';
 import { getCurrentUser, canCurrentUser } from 'state/current-user/selectors';
 import { hasDefaultSiteTitle } from 'state/sites/selectors';
 
+const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
+
+/*
+ * Returns selector that tests if user is in given section
+ *
+ * @param {String} sectionName Name of section
+ * @return {Function} Selector function
+ */
 export const inSection = sectionName => state =>
 	getSectionName( state ) === sectionName;
 
+/*
+ * Returns selector that tests if feature is enabled in config
+ *
+ * @param {String} feature Name of feature
+ * @return {Function} Selector function
+ */
 export const isEnabled = feature => () =>
 	config.isEnabled( feature );
 
-export const isPreviewNotShowing = state =>
-	! isPreviewShowingSelector( state );
-
-export const isPreviewShowing = state =>
-	isPreviewShowingSelector( state );
-
+/*
+ * Returns milliseconds since user registration
+ *
+ * @param {Object} state Global state tree
+ * @return {Number|Boolean} Milliseconds since registration, false if cannot be determined
+ */
 const timeSinceUserRegistration = state => {
 	const user = getCurrentUser( state );
 	const registrationDate = user && Date.parse( user.date );
 	return registrationDate ? ( Date.now() - registrationDate ) : false;
 };
 
-const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
+/*
+ * Returns true if user is considered "new" (less than week since registration)
+ *
+ * @param {Object} state Global state tree
+ * @return {Boolean} True if user is new, false otherwise
+ */
 export const isNewUser = state => {
 	const userAge = timeSinceUserRegistration( state );
 	return userAge !== false ? userAge <= WEEK_IN_MILLISECONDS : false;
 };
 
+/*
+ * Returns selector that tests if user is older than given time since registration
+ *
+ * @param {Number} age Number of milliseconds
+ * @return {Function} Selector function
+ */
 export const isUserOlderThan = age => state => {
 	const userAge = timeSinceUserRegistration( state );
 	return userAge !== false ? userAge >= age : false;
 };
 
+/*
+ * Returns selector that tests if user has registered before given date
+ *
+ * @param {Date} date Date of registration
+ * @return {Function} Selector function
+ */
 export const hasUserRegisteredBefore = date => state => {
 	const compareDate = date && Date.parse( date );
 	const user = getCurrentUser( state );
@@ -49,23 +79,60 @@ export const hasUserRegisteredBefore = date => state => {
 	return ( registrationDate < compareDate );
 };
 
+/*
+ * Returns selector that tests whether user interacted with given component
+ *
+ * @param {String} componentName Name of component to test
+ * @return {Function} Selector function
+ */
 export const hasUserInteractedWithComponent = componentName => state =>
 	getLastAction( state ).component === componentName;
 
+/*
+ * Returns true if selected site can be previewed
+ *
+ * @param {Object} state Global state tree
+ * @return {Boolean} True if selected site can be previewed, false otherwise.
+ */
 export const isSelectedSitePreviewable = state =>
 	getSelectedSite( state ) && getSelectedSite( state ).is_previewable;
 
+/*
+ * Returns true if current user can run customizer for selected site
+ *
+ * @param {Object} state Global state tree
+ * @return {Boolean} True if user can run customizer, false otherwise.
+ */
 export const isSelectedSiteCustomizable = state =>
 	getSelectedSite( state ) && getSelectedSite( state ).is_customizable;
 
+/*
+ * Returns true if a/b test is in given variant
+ *
+ * @param {String} testName Name of A/B test
+ * @param {String} variant Variant identifier
+ * @return {Boolean} True if test is in given variant
+ */
 export const isAbTestInVariant = ( testName, variant ) => () =>
 	abtest( testName ) === variant;
 
+/*
+ * Returns true if the selected site has unchanged site title
+ *
+ * @param {Object} state Global state tree
+ * @return {Boolean} True if site title is default, false otherwise.
+ */
 export const hasSelectedSiteDefaultSiteTitle = state => {
 	const siteId = getSelectedSiteId( state );
 	return siteId ? hasDefaultSiteTitle( state, siteId ) : false;
 };
 
+/*
+ * Returns true if current user can edit settings of selected site
+ *
+ * @param {Object} state Global state tree
+ * @return {Boolean} True if user can edit settings, false otherwise.
+ */
 export const canUserEditSettingsOfSelectedSite = state => {
 	const siteId = getSelectedSiteId( state );
 	return siteId ? canCurrentUser( state, siteId, 'manage_options' ) : false;

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -14,7 +14,7 @@ import { hasDefaultSiteTitle } from 'state/sites/selectors';
 
 const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
 
-/*
+/**
  * Returns a selector that tests if the current user is in a given section
  *
  * @param {String} sectionName Name of section
@@ -23,7 +23,7 @@ const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
 export const inSection = sectionName => state =>
 	getSectionName( state ) === sectionName;
 
-/*
+/**
  * Returns a selector that tests if a feature is enabled in config
  *
  * @param {String} feature Name of feature
@@ -32,7 +32,7 @@ export const inSection = sectionName => state =>
 export const isEnabled = feature => () =>
 	config.isEnabled( feature );
 
-/*
+/**
  * Returns milliseconds since registration date of the current user
  *
  * @param {Object} state Global state tree
@@ -44,7 +44,7 @@ const timeSinceUserRegistration = state => {
 	return registrationDate ? ( Date.now() - registrationDate ) : false;
 };
 
-/*
+/**
  * Returns true if the user is considered "new" (less than a week since registration)
  *
  * @param {Object} state Global state tree
@@ -55,7 +55,7 @@ export const isNewUser = state => {
 	return userAge !== false ? userAge <= WEEK_IN_MILLISECONDS : false;
 };
 
-/*
+/**
  * Returns a selector that tests if the user is older than a given time
  *
  * @param {Number} age Number of milliseconds
@@ -66,7 +66,7 @@ export const isUserOlderThan = age => state => {
 	return userAge !== false ? userAge >= age : false;
 };
 
-/*
+/**
  * Returns a selector that tests if the user has registered before given date
  *
  * @param {Date} date Date of registration
@@ -79,8 +79,10 @@ export const hasUserRegisteredBefore = date => state => {
 	return ( registrationDate < compareDate );
 };
 
-/*
- * Returns a selector that tests whether the user has interacted with a given component
+/**
+ * Returns a selector that tests whether the user has interacted with a given component.
+ *
+ * @see client/components/track-interactions
  *
  * @param {String} componentName Name of component to test
  * @return {Function} Selector function
@@ -88,7 +90,7 @@ export const hasUserRegisteredBefore = date => state => {
 export const hasUserInteractedWithComponent = componentName => state =>
 	getLastAction( state ).component === componentName;
 
-/*
+/**
  * Returns true if the selected site can be previewed
  *
  * @param {Object} state Global state tree
@@ -97,7 +99,7 @@ export const hasUserInteractedWithComponent = componentName => state =>
 export const isSelectedSitePreviewable = state =>
 	getSelectedSite( state ) && getSelectedSite( state ).is_previewable;
 
-/*
+/**
  * Returns true if the current user can run customizer for the selected site
  *
  * @param {Object} state Global state tree
@@ -106,8 +108,10 @@ export const isSelectedSitePreviewable = state =>
 export const isSelectedSiteCustomizable = state =>
 	getSelectedSite( state ) && getSelectedSite( state ).is_customizable;
 
-/*
- * Returns a selector that tests whether an a/b test is in a given variant
+/**
+ * Returns a selector that tests whether an A/B test is in a given variant.
+ *
+ * @see client/lib/abtest
  *
  * @param {String} testName Name of A/B test
  * @param {String} variant Variant identifier
@@ -116,7 +120,7 @@ export const isSelectedSiteCustomizable = state =>
 export const isAbTestInVariant = ( testName, variant ) => () =>
 	abtest( testName ) === variant;
 
-/*
+/**
  * Returns true if the selected site has an unchanged site title
  *
  * @param {Object} state Global state tree
@@ -127,8 +131,9 @@ export const hasSelectedSiteDefaultSiteTitle = state => {
 	return siteId ? hasDefaultSiteTitle( state, siteId ) : false;
 };
 
-/*
- * Returns true if the current user can edit settings of the selected site
+/**
+ * Returns true if the current user can edit settings of the selected site.
+ * Used in the siteTitle tour.
  *
  * @param {Object} state Global state tree
  * @return {Boolean} True if user can edit settings, false otherwise.

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -15,7 +15,7 @@ import { hasDefaultSiteTitle } from 'state/sites/selectors';
 const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
 
 /*
- * Returns selector that tests if user is in given section
+ * Returns a selector that tests if the current user is in a given section
  *
  * @param {String} sectionName Name of section
  * @return {Function} Selector function
@@ -24,7 +24,7 @@ export const inSection = sectionName => state =>
 	getSectionName( state ) === sectionName;
 
 /*
- * Returns selector that tests if feature is enabled in config
+ * Returns a selector that tests if a feature is enabled in config
  *
  * @param {String} feature Name of feature
  * @return {Function} Selector function
@@ -33,7 +33,7 @@ export const isEnabled = feature => () =>
 	config.isEnabled( feature );
 
 /*
- * Returns milliseconds since user registration
+ * Returns milliseconds since registration date of the current user
  *
  * @param {Object} state Global state tree
  * @return {Number|Boolean} Milliseconds since registration, false if cannot be determined
@@ -45,7 +45,7 @@ const timeSinceUserRegistration = state => {
 };
 
 /*
- * Returns true if user is considered "new" (less than week since registration)
+ * Returns true if the user is considered "new" (less than a week since registration)
  *
  * @param {Object} state Global state tree
  * @return {Boolean} True if user is new, false otherwise
@@ -56,7 +56,7 @@ export const isNewUser = state => {
 };
 
 /*
- * Returns selector that tests if user is older than given time since registration
+ * Returns a selector that tests if the user is older than a given time
  *
  * @param {Number} age Number of milliseconds
  * @return {Function} Selector function
@@ -67,7 +67,7 @@ export const isUserOlderThan = age => state => {
 };
 
 /*
- * Returns selector that tests if user has registered before given date
+ * Returns a selector that tests if the user has registered before given date
  *
  * @param {Date} date Date of registration
  * @return {Function} Selector function
@@ -80,7 +80,7 @@ export const hasUserRegisteredBefore = date => state => {
 };
 
 /*
- * Returns selector that tests whether user interacted with given component
+ * Returns a selector that tests whether the user has interacted with a given component
  *
  * @param {String} componentName Name of component to test
  * @return {Function} Selector function
@@ -89,7 +89,7 @@ export const hasUserInteractedWithComponent = componentName => state =>
 	getLastAction( state ).component === componentName;
 
 /*
- * Returns true if selected site can be previewed
+ * Returns true if the selected site can be previewed
  *
  * @param {Object} state Global state tree
  * @return {Boolean} True if selected site can be previewed, false otherwise.
@@ -98,7 +98,7 @@ export const isSelectedSitePreviewable = state =>
 	getSelectedSite( state ) && getSelectedSite( state ).is_previewable;
 
 /*
- * Returns true if current user can run customizer for selected site
+ * Returns true if the current user can run customizer for the selected site
  *
  * @param {Object} state Global state tree
  * @return {Boolean} True if user can run customizer, false otherwise.
@@ -107,17 +107,17 @@ export const isSelectedSiteCustomizable = state =>
 	getSelectedSite( state ) && getSelectedSite( state ).is_customizable;
 
 /*
- * Returns true if a/b test is in given variant
+ * Returns a selector that tests whether an a/b test is in a given variant
  *
  * @param {String} testName Name of A/B test
  * @param {String} variant Variant identifier
- * @return {Boolean} True if test is in given variant
+ * @return {Function} Selector function
  */
 export const isAbTestInVariant = ( testName, variant ) => () =>
 	abtest( testName ) === variant;
 
 /*
- * Returns true if the selected site has unchanged site title
+ * Returns true if the selected site has an unchanged site title
  *
  * @param {Object} state Global state tree
  * @return {Boolean} True if site title is default, false otherwise.
@@ -128,7 +128,7 @@ export const hasSelectedSiteDefaultSiteTitle = state => {
 };
 
 /*
- * Returns true if current user can edit settings of selected site
+ * Returns true if the current user can edit settings of the selected site
  *
  * @param {Object} state Global state tree
  * @return {Boolean} True if user can edit settings, false otherwise.


### PR DESCRIPTION
- added docs for GT context selectors
- removed `isPreviewShowing` from our context selectors, as they were just reexported selectors from other places, without a single change. I think it better communicates that you can use any selector from our codebase and there is generally no need to create special ones unless you have a specific use case
- removed `isPreviewNotShowing` in favor of using `_.negate( isPreviewShowing )` - it opened up a precedent to manually create a negated selector for every single boolean one

To test:
- well, mainly explore if my jsdocs make sense. I don't have much experience with them
- secondly, make sure calypso compiles & our tours can still run