### PR TITLE
Editor: Display post locked dialog when other user is editing

### DIFF
--- a/client/post-editor/editor-post-lock-dialog/index.jsx
+++ b/client/post-editor/editor-post-lock-dialog/index.jsx
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import page from 'page';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+import { takeOverPostLock } from 'state/posts/actions';
+import { getSelectedSiteId, getPostsPath } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { isPostEditLocked, getEditedPostValue } from 'state/posts/selectors';
+
+class EditorPostLockDialog extends Component {
+	static propTypes = {
+		translate: PropTypes.func,
+		isLocked: PropTypes.bool,
+		postsPath: PropTypes.string,
+		onTakeOver: PropTypes.func
+	};
+
+	static defaultProps = {
+		translate: () => {},
+		onTakeOver: () => {}
+	};
+
+	returnToPosts = () => {
+		page( this.props.postsPath );
+	};
+
+	takeOver = () => {
+		const { siteId, postId, onTakeOver } = this.props;
+		onTakeOver( siteId, postId );
+	};
+
+	render() {
+		const { isLocked, translate } = this.props;
+		if ( ! isLocked ) {
+			return null;
+		}
+
+		return (
+			<Dialog
+				buttons={ [
+					{
+						action: 'cancel',
+						label: translate( 'Back to Blog Posts' ),
+						onClick: this.returnToPosts
+					},
+					{
+						action: 'confirm',
+						label: translate( 'Take Over', { context: 'verb' } ),
+						onClick: this.takeOver
+					}
+				] }
+				onClose={ this.returnToPosts }
+				isVisible>
+				Post Being Edited
+			</Dialog>
+		);
+	}
+}
+
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const postId = getEditorPostId( state );
+		const postType = getEditedPostValue( state, siteId, postId, 'type' );
+		const isLocked = isPostEditLocked( state, siteId, postId );
+		const postsPath = getPostsPath( state, siteId, postType );
+
+		return { isLocked, postsPath };
+	},
+	{ onTakeOver: takeOverPostLock }
+)( localize( EditorPostLockDialog ) );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -49,6 +49,7 @@ import EditorDocumentHead from 'post-editor/editor-document-head';
 import EditorPostTypeUnsupported from 'post-editor/editor-post-type-unsupported';
 import EditorForbidden from 'post-editor/editor-forbidden';
 import EditorNotice from 'post-editor/editor-notice';
+import EditorPostLockDialog from 'post-editor/editor-post-lock-dialog';
 import { savePreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
 import QueryPreferences from 'components/data/query-preferences';
@@ -196,6 +197,7 @@ export const PostEditor = React.createClass( {
 				<EditorDocumentHead />
 				<EditorPostTypeUnsupported />
 				<EditorForbidden />
+				<EditorPostLockDialog />
 				<div className="post-editor__inner">
 					<div className="post-editor__content">
 						<EditorMobileNavigation site={ site } onClose={ this.onClose } />

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -463,3 +463,17 @@ export function getPostMetadata( state, siteId, postId, key ) {
 
 	return get( find( post.metadata, { key } ), 'value', null );
 }
+
+export function isPostEditLocked( state, siteId, postId ) {
+	const lock = getPostMetadata( state, siteId, postId, '_edit_lock' );
+	if ( ! lock ) {
+		return false;
+	}
+
+	const [ timestamp, userId ] = lock.split( ':' );
+	if ( timestamp < ( Date.now() / 1000 ) - 150 ) {
+		return false;
+	}
+
+	return getCurrentUserId( state ) !== userId;
+}

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -19,6 +19,7 @@ import {
 } from './utils';
 import { DEFAULT_POST_QUERY, DEFAULT_NEW_POST_VALUES } from './constants';
 import addQueryArgs from 'lib/route/add-query-args';
+import { getCurrentUserId } from 'state/current-user/selectors';
 
 /**
  * Returns a post object by its global ID.
@@ -452,4 +453,13 @@ export function getSitePostsByTerm( state, siteId, taxonomy, termId ) {
 		return post.terms && post.terms[ taxonomy ] &&
 			find( post.terms[ taxonomy ], postTerm => postTerm.ID === termId );
 	} );
+}
+
+export function getPostMetadata( state, siteId, postId, key ) {
+	const post = getSitePost( state, siteId, postId );
+	if ( ! post || ! post.metadata ) {
+		return null;
+	}
+
+	return get( find( post.metadata, { key } ), 'value', null );
 }

--- a/client/state/ui/selectors.js
+++ b/client/state/ui/selectors.js
@@ -6,7 +6,7 @@ import { includes, get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getSite, getSiteSlug } from 'state/sites/selectors';
+import { getSite, getSiteSlug, isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
 
 /**
  * Returns the site object for the currently selected site.
@@ -138,4 +138,24 @@ export function hasSidebar( state ) {
 		return false;
 	}
 	return get( getSection( state ), 'secondary', true );
+}
+
+export function getPostsPath( state, siteId, postType = 'post' ) {
+	let path;
+	switch ( postType ) {
+		case 'post': path = '/posts'; break;
+		case 'page': path = '/pages'; break;
+		default: path = `/types/${ postType }`;
+	}
+
+	if ( 'post' === postType && ! isJetpackSite( state, siteId ) && ! isSingleUserSite( state, siteId ) ) {
+		path += '/my';
+	}
+
+	const siteSlug = getSiteSlug( state, siteId );
+	if ( siteSlug ) {
+		path += '/' + siteSlug;
+	}
+
+	return path;
 }


### PR DESCRIPTION
Closes #1613

__Very WIP:__ The dialog is currently shown, but design, behaviors to assign the meta and take over a post, plus clean-up and tests, are yet to be completed.

This pull request seeks to display a dialog when attempting to edit a post which is being edited by another user. They are prompted to choose between returning to the all posts screen or take over editing controls of the post.

![WIP](https://cloud.githubusercontent.com/assets/1779930/21052118/54ec767e-bdf1-11e6-8936-2b180870eea7.png)

_[Reference Design](https://cloud.githubusercontent.com/assets/4389/12146259/a06112fc-b48a-11e5-98cc-073896e8fdea.png)_

__Technical Questions:__

I've not yet settled on a technical implementation for "taking over" a post. In Core, this is achieved through the [Heartbeat API](https://wptavern.com/how-to-take-control-of-the-wordpress-heartbeat-api), refreshing the post lock and verifying that another user has not taken over in the process of doing so. Because we have no such heartbeat API in Calypso, we must consider an alternative. The two obvious options to me are (a) polling and (b) websockets, which the latter being preferable though more complex.

__Testing instructions:__

_TBD_
