### PR TITLE
Fix crashing devdocs/blocks page for lack of post excerpt in reader-related-card-v2

### DIFF
--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -94,7 +94,7 @@ export function RelatedPostCard( { post, site, siteId, onPostClick = noop, onSit
 	const postLink = getPostUrl( post );
 	const classes = classnames( 'reader-related-card-v2', {
 		'has-thumbnail': !! featuredImage,
-		'has-excerpt': post.excerpt.length > 1
+		'has-excerpt': post.excerpt && post.excerpt.length > 1
 	} );
 	const postClickTracker = partial( onPostClick, post );
 	const siteClickTracker = partial( onSiteClick, post );


### PR DESCRIPTION
The change added [here](https://github.com/Automattic/wp-calypso/pull/9837/files#diff-e6b36abe5c53b8f8009a62958e11c066R97) crashes if there's no post excerpt, specifically on the DevDocs/blocks page.

@jancavan can you take a look and make sure this is the appropriate fix?