### PR TITLE
Components: Try to find SiteIcon site object in Redux state

### DIFF
--- a/client/components/site-icon/index.jsx
+++ b/client/components/site-icon/index.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import { includes } from 'lodash';
 import { parse as parseUrl } from 'url';
 import classNames from 'classnames';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -70,6 +71,6 @@ const SiteIcon = React.createClass( {
 	}
 } );
 
-export default connect( ( state, { siteId } ) => (
-	siteId ? { site: getSite( state, siteId ) } : {}
-) )( SiteIcon );
+export default connect( ( state, { site, siteId } ) => ( {
+	site: getSite( state, get( site, 'ID', siteId ) ) || site
+} ) )( SiteIcon );


### PR DESCRIPTION
This pull request seeks to enhance the feature-flagged site icon flow by showing the updated site icon in all `<SiteIcon />` components. It does so by updating the `<SiteIcon />` component to try to find the site object in Redux state, regardless of whether a `siteId` or `site` object is passed to the component. Assuming that site icons are only updated for sites known in Redux state (i.e. selected site), this should correctly use the Redux state object for the updated site, falling back to the `lib/sites-list` object in all other cases (e.g. `<SiteSelector />` sites not known to Redux).

__Testing instructions:__

Verify that there are no regressions in display of site icons, particularly in the `<SiteSelector />` component (New Post / Switch Sites).

Next, test to ensure that changing the site icon from the settings screen updates the site icon immediately in the sidebar `<Site />` component (where `<SiteIcon />` is rendered), and in `<SiteSelector />` usage thereafter.

__Caveats:__

- The image will not show until after upload and an error may be logged from an invalid URL due to an issue slated to be resolved by #9850
- With these changes, sites in Redux state will no longer reflect polling updates to the site because we have not yet implemented polling for Redux state. In other words, if the site icon is updated in another tab, it will not be reflected in Calypso until a full refresh. Currently the site icon could be updated by the polling result.