### PR TITLE
Jetpack: fix inverted isPluginActive parameters

### DIFF
--- a/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
@@ -44,7 +44,7 @@ const searchPlugins = search => overSome(
 	( { description } ) => includes( description.toLocaleLowerCase(), search.toLocaleLowerCase() )
 );
 
-const isPluginActive = ( plugin, hasBusiness, hasPremium ) => some( [
+const isPluginActive = ( plugin, hasPremium, hasBusiness ) => some( [
 	'standard' === plugin.plan,
 	'premium' === plugin.plan && hasPremium,
 	'business' === plugin.plan && hasBusiness,


### PR DESCRIPTION
Fixes a bug where *business* features appear active whereas *premium* ones don't on Premium sites.