### PR TITLE
Reader: Treat elements with caption class in figures as captions

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -160,7 +160,8 @@
 	}
 
 	.wp-caption-text,
-	figure figcaption {
+	figure figcaption,
+	figure .caption {
 		padding: 12px;
 		margin: 0;
 		font-size: 13px;


### PR DESCRIPTION
Treat elements with a  class inside a  as captions. Fixes feeds like Ars Technica.