### PR TITLE
Components: fix Banner's CTA text misalignment

### DIFF
--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -189,7 +189,7 @@
 
 	@include breakpoint( ">480px" ) {
 		margin: 0 -6px 0 8px;
-		text-align: right;
+		text-align: center;
 		width: auto;
 
 		.is-dismissible & {
@@ -198,6 +198,7 @@
 
 		.banner__prices {
 			justify-content: flex-end;
+			text-align: right;
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/9945

| Before | After |
| --- | --- |
| ![2dfdf102-be12-11e6-8474-1e3d7b75d30c](https://cloud.githubusercontent.com/assets/2070010/21060866/97f88b92-be41-11e6-8462-14e8325701cb.png) | ![screen shot 2016-12-09 at 18 58 18](https://cloud.githubusercontent.com/assets/2070010/21060865/97da92ae-be41-11e6-9e53-fc533215c9da.png) |