### PR TITLE
CircleCI config: tweak msgcat output filename

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,7 @@ test:
             cp calypso-strings.pot $CIRCLE_ARTIFACTS/translate/calypso-strings.pot;
             if [[ $CIRCLE_BRANCH != "master" ]]; then
               node bin/get-circle-string-artifact-url | xargs curl > $CIRCLE_ARTIFACTS/translate/calypso-strings-master.pot;
-              msgcat -u $CIRCLE_ARTIFACTS/translate/calypso-strings.pot $CIRCLE_ARTIFACTS/translate/calypso-strings-master.pot > $CIRCLE_ARTIFACTS/translate/new-calypso-strings.pot;
+              msgcat -u $CIRCLE_ARTIFACTS/translate/calypso-strings.pot $CIRCLE_ARTIFACTS/translate/calypso-strings-master.pot > $CIRCLE_ARTIFACTS/translate/localci-new-strings.pot;
             fi;
           fi;
       :


### PR DESCRIPTION
We need the msgcat output to be something localci-centric because we want to use LocalCI with other projects. We can just GET localci-new-strings.pot everywhere after this change.

See: https://github.com/Automattic/gp-localci