### PR TITLE
Checkout: Thank you: Show a different page for domain mappings

### DIFF
--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -1,10 +1,7 @@
 /**
  * External dependencies
  */
-var assign = require( 'lodash/assign' ),
-	difference = require( 'lodash/difference' ),
-	isEmpty = require( 'lodash/isEmpty' ),
-	pick = require( 'lodash/pick' );
+import { assign, difference, get, isEmpty, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -218,10 +215,7 @@ function isDomainMapping( product ) {
 }
 
 function isDomainMappingNotMappedToWordPressDotCom( product ) {
-	product = formatProduct( product );
-	assertValidProduct( product );
-
-	return product.product_slug === 'domain_map' && product.mappedDomainHasWpcomNameServers;
+	return isDomainMapping( product ) && ! get( product, 'mappedDomainHasWpcomNameServers', false );
 }
 
 function isSiteRedirect( product ) {

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -217,6 +217,13 @@ function isDomainMapping( product ) {
 	return product.product_slug === 'domain_map';
 }
 
+function isDomainMappingNotMappedToWordPressDotCom( product ) {
+	product = formatProduct( product );
+	assertValidProduct( product );
+
+	return product.product_slug === 'domain_map' && product.mappedDomainHasWpcomNameServers;
+}
+
 function isSiteRedirect( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
@@ -349,6 +356,7 @@ module.exports = {
 	isCustomDesign,
 	isDependentProduct,
 	isDomainMapping,
+	isDomainMappingNotMappedToWordPressDotCom,
 	isDomainProduct,
 	isDomainRedemption,
 	isDomainRegistration,

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -31,6 +31,7 @@ import PlanThankYouCard from 'blocks/plan-thank-you-card';
 import {
 	isChargeback,
 	isDomainMapping,
+	isDomainMappingNotMappedToWordPressDotCom,
 	isDomainProduct,
 	isDomainRedemption,
 	isDomainRegistration,
@@ -248,7 +249,7 @@ const CheckoutThankYou = React.createClass( {
 				return [ DomainRegistrationDetails, ...findPurchaseAndDomain( purchases, isDomainRegistration ) ];
 			} else if ( purchases.some( isGoogleApps ) ) {
 				return [ GoogleAppsDetails, ...findPurchaseAndDomain( purchases, isGoogleApps ) ];
-			} else if ( purchases.some( isDomainMapping ) ) {
+			} else if ( purchases.some( isDomainMappingNotMappedToWordPressDotCom ) ) {
 				return [ DomainMappingDetails, ...findPurchaseAndDomain( purchases, isDomainMapping ) ];
 			} else if ( purchases.some( isSiteRedirect ) ) {
 				return [ SiteRedirectDetails, ...findPurchaseAndDomain( purchases, isSiteRedirect ) ];

--- a/client/state/receipts/assembler.js
+++ b/client/state/receipts/assembler.js
@@ -5,6 +5,7 @@ export function createReceiptObject( data ) {
 			return {
 				freeTrial: purchase.free_trial,
 				isDomainRegistration: Boolean( purchase.is_domain_registration ),
+				mappedDomainHasWpcomNameServers: Boolean( purchase.mapped_domain_has_wpcom_name_servers ),
 				meta: purchase.meta,
 				productId: purchase.product_id,
 				productSlug: purchase.product_slug,


### PR DESCRIPTION
This pull request fixes #9818 by showing a generic success page for a domain mappings that are already mapped to a WordPress.com site:

<img width="770" alt="screen shot 2016-12-09 at 21 28 45" src="https://cloud.githubusercontent.com/assets/275961/21065106/7e4a0c60-be56-11e6-8fe5-c345b7d3df88.png">
  
#### Testing instructions
  
1. Run `git checkout **`** and start your server
1. Apply this patch: D3643-code
2. Purchase a domain mapping for a domain which has name servers pointing to ns1.wordpress.com
3. Check that you see the success page as above
2. Purchase a domain mapping for a domain which DOES NOT HAVE name servers pointing to ns1.wordpress.com
3. Check that you see the regular domain mapping success page (see #9818)  
  
#### Reviews
  
- [ ] Code
- [ ] Product
   
@Automattic/sdev-feed
