### PR TITLE
Reader Refresh: Fix double-back button for site-stream

### DIFF
--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -165,7 +165,7 @@ class SiteStream extends React.Component {
 				showPostHeader={ false }
 				showSiteNameOnCards={ false }>
 				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: title } ) } />
-				{ this.props.showBack && <HeaderBack /> }
+				{ ! config.isEnabled( 'reader/refresh/stream' ) && this.props.showBack && <HeaderBack /> }
 				<FeedHeader site={ site } feed={ this.state.feed } showBack={ this.props.showBack } />
 				{ featuredContent }
 			</Stream>


### PR DESCRIPTION
This is a fix for an [issue](https://github.com/Automattic/wp-calypso/issues/9949) where the back button will appear twice on `site-stream` sometimes.
The issue was introduced in [1a5f99136cb89](https://github.com/Automattic/wp-calypso/commit/1a5f99136cb89febfb2b20df211a9343edcb03ab).

Before: https://cldup.com/R1UN9VSo0m.png
After: single back button.