### PR TITLE
Taxonomy Manager: do not show delete option on default category.

### DIFF
--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -151,9 +151,11 @@ class TaxonomyManagerListItem extends Component {
 						<Gridicon icon="pencil" size={ 18 } />
 						{ translate( 'Edit' ) }
 					</PopoverMenuItem>
-					<PopoverMenuItem onClick={ this.deleteItem } icon="trash">
-						{ translate( 'Delete' ) }
-					</PopoverMenuItem>
+					{ ( ! canSetAsDefault || ! isDefault ) &&
+						<PopoverMenuItem onClick={ this.deleteItem } icon="trash">
+							{ translate( 'Delete' ) }
+						</PopoverMenuItem>
+					}
 					<PopoverMenuItem href={ this.getTaxonomyLink() } icon="external">
 						{ translate( 'View Posts' ) }
 					</PopoverMenuItem>


### PR DESCRIPTION
Fixes #9941.  When managing categories in `wp-admin` the option to delete a category ( via bulk edit or individual ) is not shown for the current Default Category.  This branch brings the same behavior to the Taxonomy Manager in calypso.

__To Test__
- Open the [Writing Settings Page](http://calypso.localhost:3000/settings/writing)
- Select Categories
- Expand the action menu on the default category, note the Delete option is not shown
- Verify the delete option shows for all other terms

<img width="737" alt="manage_categories_ _bendoutdoors_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/21066421/46bc8638-be1a-11e6-8d9f-48f25274c65a.png">
