### PR TITLE
Reader Refresh: Set line-clamp with pixels instead of -webkit-line-clamp

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -34,6 +34,18 @@
 	width: 830px;
 }
 
+/* clamp to 3 lines for search-rec excerpts except for those without images */
+ .is-reader-page .search-stream .reader-related-card-v2__excerpt.post-excerpt {
+	max-height: 15px * 1.6 * 3;
+}
+
+/* for recs without images give them some more height so more text shows */
+.is-reader-page .search-stream .reader-related-card-v2:not(has-thumbnail)
+		.reader-related-card-v2__excerpt.post-excerpt {
+
+	height: 130px; // the height of 3 lines of excerpt + the missing image
+}
+
 // Custom breakpoints needed to match Related Posts
 $reader-related-card-v2-breakpoint-medium: "( min-width: 661px ) and ( max-width: 730px )";
 $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -34,7 +34,7 @@
 	width: 830px;
 }
 
-/* clamp to 3 lines for search-rec excerpts except for those without images */
+/* clamp to 3 lines for search-rec excerpts */
  .is-reader-page .search-stream .reader-related-card-v2__excerpt.post-excerpt {
 	max-height: 15px * 1.6 * 3;
 }

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -39,13 +39,6 @@
 	max-height: 15px * 1.6 * 3;
 }
 
-/* for recs without images give them some more height so more text shows */
-.is-reader-page .search-stream .reader-related-card-v2:not(has-thumbnail)
-		.reader-related-card-v2__excerpt.post-excerpt {
-
-	height: 130px; // the height of 3 lines of excerpt + the missing image
-}
-
 // Custom breakpoints needed to match Related Posts
 $reader-related-card-v2-breakpoint-medium: "( min-width: 661px ) and ( max-width: 730px )";
 $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";


### PR DESCRIPTION
Firefox + IE don't understand -webkit-line-clamp so this PR aims to solve a bug where Search recs overflow far too far.

Before in FF:
![FF broken](https://cldup.com/neLU5llkxo.png)

After in FF:
![FF fixed](https://cldup.com/D3z49s1GGO.png)

Solves the reason we care about: #9672