### PR TITLE
Discover Reader: add logic around card formats in discover stream

### DIFF
--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, get } from 'lodash';
+import { find, get, map, filter, last } from 'lodash';
 import url from 'url';
 import config from 'config';
 import Debug from 'debug';
@@ -84,4 +84,13 @@ export function getSourceFollowUrl( post ) {
 	}
 
 	return followUrl || '';
+}
+
+export function getDiscoverPickFormat( post ) {
+	const postFormats = get( post, 'discover_metadata.discover_fp_post_formats' );
+	const discoverFormat = filter( map( postFormats, ( format ) => {
+		// format pattern determined by discover.wordpress.com
+		return last( format.slug.match( /(\w+)-pick/ ) );
+	} ) );
+	return discoverFormat[ 0 ];
 }

--- a/client/reader/discover/test/helper.js
+++ b/client/reader/discover/test/helper.js
@@ -149,4 +149,16 @@ describe( 'helper', () => {
 			assert.isUndefined( followUrl );
 		} );
 	}	);
+
+	describe( 'getDiscoverPickFormat', () => {
+		it( 'returns the pick format if the post is a discover pick', () => {
+			const format = helper.getDiscoverPickFormat( discoverPost );
+			assert.equal( 'standard', format );
+		} );
+
+		it( 'returns undefined if the format can not be deterimined', () => {
+			const format = helper.getDiscoverPickFormat( fixtures.nonDiscoverPost );
+			assert.isUndefined( format );
+		} );
+	}	);
 } );


### PR DESCRIPTION
This is part of the extended discover tab project.

There are four discover card formats: standard, quote, image, and site.

This PR will introduce the ability to swap out the standard stream card with forthcoming discover quote, image, and site cards 