### PR TITLE
Taxonomy Manager: fix sprintf error on Term add

### DIFF
--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -83,7 +83,7 @@ class TaxonomyManagerListItem extends Component {
 	tooltipText = () => {
 		const { term, translate } = this.props;
 		const name = this.getName();
-		const postCount = term.post_count;
+		const postCount = get( term, 'post_count', 0 );
 		return translate(
 			'%(postCount)d \'%(name)s\' post',
 			'%(postCount)d \'%(name)s\' posts',


### PR DESCRIPTION
Fixes #9944 - When adding a new term via the Taxonomy Manager, a sprintf error is shown in the console, this branch has a simple fix using `get` to ensure `term.post_count` is numeric.

#### To Test
1. Open up the category manager via Site Settings > Writing
2. Add a new category, give it a parent
3. Save
4. Validate no sprintf error is shown in the console.