### PR TITLE
TermFormDialog: do not render parent selector when only one term exists

### DIFF
--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -206,13 +206,19 @@ class TermFormDialog extends Component {
 	}
 
 	renderParentSelector() {
-		const { labels, siteId, taxonomy, translate } = this.props;
+		const { labels, siteId, taxonomy, translate, terms } = this.props;
 		const { searchTerm, selectedParent } = this.state;
 		const query = {};
 		if ( searchTerm && searchTerm.length ) {
 			query.search = searchTerm;
 		}
 		const hideTermAndChildren = get( this.props.term, 'ID' );
+
+		// if there is only one term for the site, and we are editing that term
+		// do not show the parent selector
+		if ( hideTermAndChildren && terms && terms.length === 1 ) {
+			return null;
+		}
 
 		return (
 			<FormFieldset>


### PR DESCRIPTION
Originally reported in pbg9X-bkY-p2 - things look a bit strange when editing the lone category on a site.

__Before__
<img width="570" alt="manage_categories_ _timmy_s_photo_blog_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/21069824/8a558be8-be32-11e6-8650-062e16fd628b.png">

__After__
<img width="571" alt="manage_categories_ _timmy_s_photo_blog_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/21069831/9e603804-be32-11e6-906f-cf58ed611621.png">

__To Test__
- Open the Settings > Writing page for a site with only one category
- Select categories, then edit the lone category
- Validate the parent selector portion of the form is not shown
- Click Add Category
- Verify the parent selector is shown
