### PR TITLE
Reader Refresh: Update get-video-id to the latest version

### DIFF
--- a/client/lib/post-normalizer/rule-content-detect-media.js
+++ b/client/lib/post-normalizer/rule-content-detect-media.js
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import { map, compact, includes, some, filter } from 'lodash';
-import getVideoId from 'get-video-id';
+import getEmbedMetadata from 'get-video-id';
 
 /**
  * Internal Dependencies
@@ -66,7 +66,8 @@ const detectImage = ( image ) => {
  * @returns {string} html src for an iframe that autoplays if from a source we understand.  else null;
  */
 const getAutoplayIframe = ( iframe ) => {
-	if ( iframe.src.indexOf( 'youtube' ) > 0 ) {
+	const metadata = getEmbedMetadata( iframe.src );
+	if ( metadata && metadata.service === 'youtube' ) {
 		const autoplayIframe = iframe.cloneNode();
 		if ( autoplayIframe.src.indexOf( '?' ) === -1 ) {
 			autoplayIframe.src += '?autoplay=1';
@@ -83,11 +84,15 @@ const getAutoplayIframe = ( iframe ) => {
  * @returns {string} thumbnailUrl - the url for a thumbnail of the video, null if we cannot determine it
  */
 const getThumbnailUrl = ( iframe ) => {
-	if ( iframe.src.indexOf( 'youtube' ) > 0 ) {
-		const videoId = getVideoId( iframe.src );
-
-		return videoId ? `https://img.youtube.com/vi/${ videoId }/mqdefault.jpg` : null;
+	const metadata = getEmbedMetadata( iframe.src );
+	if ( ! metadata ) {
+		return null;
 	}
+
+	if ( metadata.service === 'youtube' ) {
+		return `https://img.youtube.com/vi/${ metadata.id }/mqdefault.jpg`;
+	}
+
 	return null;
 };
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -150,7 +150,7 @@
       "version": "1.5.0"
     },
     "babel-code-frame": {
-      "version": "6.16.0",
+      "version": "6.20.0",
       "dependencies": {
         "chalk": {
           "version": "1.1.3"
@@ -173,7 +173,7 @@
       "dev": true
     },
     "babel-generator": {
-      "version": "6.19.0",
+      "version": "6.20.0",
       "dependencies": {
         "source-map": {
           "version": "0.5.6"
@@ -211,7 +211,7 @@
       "version": "6.18.0"
     },
     "babel-helper-remap-async-to-generator": {
-      "version": "6.18.0"
+      "version": "6.20.3"
     },
     "babel-helper-replace-supers": {
       "version": "6.18.0"
@@ -256,7 +256,7 @@
       "version": "6.13.0"
     },
     "babel-plugin-syntax-trailing-function-commas": {
-      "version": "6.13.0"
+      "version": "6.20.0"
     },
     "babel-plugin-transform-async-generator-functions": {
       "version": "6.17.0"
@@ -274,7 +274,7 @@
       "version": "6.8.0"
     },
     "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.18.0"
+      "version": "6.20.0"
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.18.0"
@@ -331,7 +331,7 @@
       "version": "6.8.0"
     },
     "babel-plugin-transform-object-rest-spread": {
-      "version": "6.19.0"
+      "version": "6.20.2"
     },
     "babel-plugin-transform-react-display-name": {
       "version": "6.8.0"
@@ -340,7 +340,7 @@
       "version": "6.8.0"
     },
     "babel-plugin-transform-regenerator": {
-      "version": "6.16.1"
+      "version": "6.20.0"
     },
     "babel-plugin-transform-runtime": {
       "version": "6.9.0"
@@ -369,16 +369,16 @@
       }
     },
     "babel-runtime": {
-      "version": "6.18.0"
+      "version": "6.20.0"
     },
     "babel-template": {
       "version": "6.16.0"
     },
     "babel-traverse": {
-      "version": "6.19.0"
+      "version": "6.20.0"
     },
     "babel-types": {
-      "version": "6.19.0"
+      "version": "6.20.0"
     },
     "babylon": {
       "version": "6.14.1"
@@ -531,7 +531,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000592"
+      "version": "1.0.30000595"
     },
     "caseless": {
       "version": "0.11.0"
@@ -1600,7 +1600,7 @@
       "version": "4.0.1"
     },
     "get-video-id": {
-      "version": "1.1.0"
+      "version": "2.0.0"
     },
     "getpass": {
       "version": "0.1.6",
@@ -2227,7 +2227,7 @@
       "version": "1.6.2"
     },
     "kind-of": {
-      "version": "3.0.4"
+      "version": "3.1.0"
     },
     "klaw": {
       "version": "1.3.1"
@@ -3171,7 +3171,10 @@
       "version": "1.3.2"
     },
     "regenerator-runtime": {
-      "version": "0.9.6"
+      "version": "0.10.1"
+    },
+    "regenerator-transform": {
+      "version": "0.9.8"
     },
     "regex-cache": {
       "version": "0.4.3"
@@ -4029,7 +4032,7 @@
       }
     },
     "webpack-core": {
-      "version": "0.6.8",
+      "version": "0.6.9",
       "dependencies": {
         "source-map": {
           "version": "0.4.4"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "filesize": "3.2.1",
     "flag-icon-css": "2.3.0",
     "flux": "2.1.1",
-    "get-video-id": "1.1.0",
+    "get-video-id": "2.0.0",
     "hard-source-webpack-plugin": "0.0.42",
     "he": "0.5.0",
     "html-loader": "0.4.0",


### PR DESCRIPTION
- update get-video-id to the latest version
- updated shrinkwrap

This is a precursor to being able to support more video source (see https://github.com/Automattic/wp-calypso/issues/9611).  The latest version of `get-video-id` returns both the id *and* the service as opposed to just the id. This means we don't need to duplicate the logic (it had bugs) of figuring out which service within wp-calypso.

To test:
- load wpcalypso and scroll through any stream that may have videos.  Ensure that it still behaves as expected