### PR TITLE
Reader: Limit to 4 lines, in-stream and More on WP recs

### DIFF
--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -282,24 +282,24 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 			.reader-related-card-v2__site-info {
 
-				@media #{$reader-related-card-v2-breakpoint-small} {
+				@media #{$reader-related-card-v2-breakpoint-medium} {
 					margin-top: 50px;
 				}
 
-				@media #{$reader-related-card-v2-breakpoint-medium} {
+				@media #{$reader-related-card-v2-breakpoint-small} {
 					margin-top: 50px;
 				}
 			}
 
 			.reader-related-card-v2__post {
-				max-height: 220px;
-
-				@media #{$reader-related-card-v2-breakpoint-small} {
-					max-height: 170px;
-				}
+				max-height: 205px;
 
 				@media #{$reader-related-card-v2-breakpoint-medium} {
-					max-height: 170px;
+					max-height: 150px;
+				}
+
+				@media #{$reader-related-card-v2-breakpoint-small} {
+					max-height: 150px;
 				}
 			}
 		}

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -100,17 +100,33 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		}
 	}
 
+	.reader-related-card-v2__post {
+		max-height: 205px;
+
+		@media #{$reader-related-card-v2-breakpoint-small} {
+			max-height: 100px;
+		}
+
+		@media #{$reader-related-card-v2-breakpoint-medium} {
+			max-height: 100px;
+		}
+
+		.reader-related-card-v2__excerpt {
+			-webkit-line-clamp: initial;
+		}
+	}
+
 	 .has-thumbnail {
 
 		.reader-related-card-v2__post {
-			max-height: 220px;
+			max-height: 199px;
 
 			@media #{$reader-related-card-v2-breakpoint-small} {
-				max-height: 160px;
+				max-height: 145px;
 			}
 
 			@media #{$reader-related-card-v2-breakpoint-medium} {
-				max-height: 160px;
+				max-height: 145px;
 			}
 		}
 

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -119,7 +119,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	 .has-thumbnail {
 
 		.reader-related-card-v2__post {
-			max-height: 199px;
+			max-height: 200px;
 
 			@media #{$reader-related-card-v2-breakpoint-small} {
 				max-height: 145px;

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -556,16 +556,16 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	.reader-related-card-v2__post {
 		max-height: 205px;
 
-		@include breakpoint( "<960px" ) {
-			max-height: 249px;
-		}
-
 		@media #{$reader-related-card-v2-breakpoint-medium} {
-			max-height: 165px;
+			max-height: 100px;
 		}
 
 		@media #{$reader-related-card-v2-breakpoint-small} {
-			max-height: 142px;
+			max-height: 100px;
+		}
+
+		.reader-related-card-v2__excerpt {
+			-webkit-line-clamp: initial;
 		}
 	}
 
@@ -595,14 +595,18 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		}
 
 		.reader-related-card-v2__post {
-			max-height: 220px;
+			max-height: 200px;
 
 			@media #{$reader-related-card-v2-breakpoint-small} {
-				max-height: 170px;
+				max-height: 150px;
 			}
 
 			@media #{$reader-related-card-v2-breakpoint-medium} {
-				max-height: 170px;
+				max-height: 150px;
+			}
+
+			.reader-related-card-v2__excerpt {
+				-webkit-line-clamp: 3;
 			}
 		}
 	}

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -604,10 +604,6 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 			@media #{$reader-related-card-v2-breakpoint-medium} {
 				max-height: 150px;
 			}
-
-			.reader-related-card-v2__excerpt {
-				-webkit-line-clamp: 3;
-			}
 		}
 	}
 


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/9777

**In-stream recs:**

![screenshot 2016-12-09 18 54 17](https://cloud.githubusercontent.com/assets/4924246/21070822/083ccda4-be43-11e6-9406-244bb86c2411.png)

![screenshot 2016-12-09 18 54 54](https://cloud.githubusercontent.com/assets/4924246/21070823/09fe5db0-be43-11e6-80af-7c471bf9a3d5.png)

If paired with a rec without a thumbnail:

![screenshot 2016-12-09 18 52 04](https://cloud.githubusercontent.com/assets/4924246/21070825/1728f0a4-be43-11e6-9f3a-b4f83f49523f.png)

![screenshot 2016-12-09 18 52 16](https://cloud.githubusercontent.com/assets/4924246/21070826/18e74292-be43-11e6-82e3-df14931e1c1b.png)

**Full-post More on WP:**

![screenshot 2016-12-09 18 57 23](https://cloud.githubusercontent.com/assets/4924246/21070828/29d329ae-be43-11e6-84c5-f2bdcee1bbd3.png)

![screenshot 2016-12-09 18 58 59](https://cloud.githubusercontent.com/assets/4924246/21070829/2cb7422c-be43-11e6-9db4-a52eb09f76f1.png)
