### PR TITLE
GuidedTours: add a selector to determine whether user registered before a date

### DIFF
--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -42,6 +42,13 @@ export const isUserOlderThan = age => state => {
 	return userAge !== false ? userAge >= age : false;
 };
 
+export const hasUserRegisteredBefore = date => state => {
+	const compareDate = date && Date.parse( date );
+	const user = getCurrentUser( state );
+	const registrationDate = user && Date.parse( user.date );
+	return ( registrationDate < compareDate );
+};
+
 export const hasUserInteractedWithComponent = componentName => state =>
 	getLastAction( state ).component === componentName;
 

--- a/client/state/ui/guided-tours/test/contexts.js
+++ b/client/state/ui/guided-tours/test/contexts.js
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import useMockery from 'test/helpers/use-mockery';
+import useFakeDom from 'test/helpers/use-fake-dom';
+
+describe( 'selectors', () => {
+	let hasUserRegisteredBefore;
+
+	useFakeDom();
+
+	useMockery( mockery => {
+		mockery.registerSubstitute(
+				'layout/guided-tours/config',
+				'state/ui/guided-tours/test/fixtures/config' );
+
+		const contexts = require( '../contexts' );
+		hasUserRegisteredBefore = contexts.hasUserRegisteredBefore;
+	} );
+
+	describe( '#hasUserRegisteredBefore', () => {
+		const cutoff = new Date( '2015-10-18T17:14:52+00:00' );
+
+		const oldUser = {
+			currentUser: {
+				id: 73705554
+			},
+			users: {
+				items: {
+					73705554: { ID: 73705554, login: 'testonesite2016', date: '2014-10-18T17:14:52+00:00' }
+				}
+			},
+		};
+
+		const newUser = {
+			currentUser: {
+				id: 73705554
+			},
+			users: {
+				items: {
+					73705554: { ID: 73705554, login: 'testonesite2016', date: '2016-10-18T17:14:52+00:00' }
+				}
+			},
+		};
+
+		it( 'should return true for users registered before the cut-off date', () => {
+			expect( hasUserRegisteredBefore( cutoff )( oldUser ) ).to.be.true;
+		} );
+
+		it( 'should return false for users registered after the cut-off date', () => {
+			expect( hasUserRegisteredBefore( cutoff )( newUser ) ).to.be.false;
+		} );
+	} );
+} );


### PR DESCRIPTION
This will be useful for tours that want to announce new or changed features, such as the one in #9699. 

To test:
- make sure the test passes (`npm run test-client client/state/ui/guided-tours/test/contexts.js`) and makes sense