### PR TITLE
Guided Tours: create a scaffold for documentation

### DIFF
--- a/client/layout/guided-tours/README.md
+++ b/client/layout/guided-tours/README.md
@@ -1,6 +1,30 @@
-Guided Tours
-============
+# Guided Tours
 
 Step-by-step tour framework for WordPress.com.
 
-Under heavy development.
+_(Documentation in progress)_
+
+## What is Guided Tours? 
+
+_(TODO: add a high-level overview: what is the problem we're solving and why?)_
+
+## Getting Started: Building a Simple Tour
+
+_(TODO: add a simple tour and instructions on how to build it)_
+
+## API Overview
+
+_(TODO: document all the elements in `config-elements.js`)_
+
+## List of Tours
+
+_(TODO: add tour descriptions)_
+
+- [Main Tour](tours/main-tour.js)
+- [Site Title Tour](tours/site-title-tour.js)
+- [Theme Sheet Welcome Tour](tours/theme-sheet-welcome-tour.js)
+- [Design Showcase Welcome Tour](tours/design-showcase-welcome-tour.js)
+
+## Further Reading
+
+- [In-depth architecture overview](docs/ARCHITECTURE.md)


### PR DESCRIPTION
This PR creates some scaffolding for the Guided Tours documentation so we can work independently of #9898. 

To test:
- documentation changes only — see whether they make sense. 