### PR TITLE
Site Settings: Use separate cards for settings within the Writing tab

### DIFF
--- a/client/my-sites/site-settings/custom-post-types-fieldset/index.jsx
+++ b/client/my-sites/site-settings/custom-post-types-fieldset/index.jsx
@@ -14,7 +14,6 @@ import { getSiteSlug, isJetpackMinimumVersion } from 'state/sites/selectors';
 import { addSiteFragment } from 'lib/route';
 import QueryPostTypes from 'components/data/query-post-types';
 import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
 import FormToggle from 'components/forms/form-toggle';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import SectionHeader from 'components/section-header';
@@ -110,7 +109,6 @@ class CustomPostTypesFieldset extends Component {
 				{ siteId && (
 					<QueryPostTypes siteId={ siteId } />
 				) }
-				<FormLabel>{ translate( 'Custom Content Types' ) }</FormLabel>
 				<p>
 					{ translate( 'Display different types of content on your site with {{link}}custom content types{{/link}}.', {
 						components: {

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -223,7 +223,7 @@ const SiteSettingsFormWriting = React.createClass( {
 				) }
 
 				{ config.isEnabled( 'press-this' ) && (
-					<div>
+					<div className="press-this">
 						{
 							this.renderSectionHeader( this.translate( 'Press This', {
 								context: 'name of browser bookmarklet tool'
@@ -231,7 +231,7 @@ const SiteSettingsFormWriting = React.createClass( {
 						}
 						<Card className="site-settings">
 							<FormFieldset>
-								<div className="press-this">
+								<div>
 									<p>{ this.translate( 'Press This is a bookmarklet: a little app that runs in your browser and lets you grab bits of the web.' ) }</p>
 									<p>{ this.translate( 'Use Press This to clip text, images and videos from any web page. Then edit and add more straight from Press This before you save or publish it in a post on your site.' ) }</p>
 									<p>{ this.translate( 'Drag-and-drop the following link to your bookmarks bar or right click it and add it to your favorites for a posting shortcut.' ) }</p>

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -118,6 +118,22 @@ const SiteSettingsFormWriting = React.createClass( {
 		}
 	},
 
+	renderSectionHeader( title, showButton = true ) {
+		return (
+			<SectionHeader label={ title }>
+				{ showButton &&
+					<Button
+						compact
+						primary
+						onClick={ this.submitFormAndActivateCustomContentModule }
+						disabled={ this.state.fetchingSettings || this.state.submittingForm }>
+						{ this.state.submittingForm ? this.translate( 'Saving…' ) : this.translate( 'Save Settings' ) }
+					</Button>
+				}
+			</SectionHeader>
+		);
+	},
+
 	render: function() {
 		const markdownSupported = this.state.markdown_supported;
 		return (
@@ -129,15 +145,8 @@ const SiteSettingsFormWriting = React.createClass( {
 						<TaxonomyCard taxonomy="post_tag" postType="post" />
 					</div>
 				}
-				<SectionHeader label={ this.translate( 'Writing Settings' ) }>
-					<Button
-						compact
-						primary
-						onClick={ this.submitFormAndActivateCustomContentModule }
-						disabled={ this.state.fetchingSettings || this.state.submittingForm }>
-						{ this.state.submittingForm ? this.translate( 'Saving…' ) : this.translate( 'Save Settings' ) }
-					</Button>
-				</SectionHeader>
+
+				{ this.renderSectionHeader( this.translate( 'Composing' ) ) }
 				<Card className="site-settings">
 					<FormFieldset>
 						<QueryTerms siteId={ this.props.siteId } taxonomy="category" />
@@ -150,7 +159,7 @@ const SiteSettingsFormWriting = React.createClass( {
 							valueLink={ this.linkState( 'default_category' ) }
 							disabled={ this.props.isRequestingCategories }
 							onClick={ this.recordEvent.bind( this, 'Selected Default Post Category' ) }>
-							{ map(this.props.categories, category => {
+							{ map( this.props.categories, category => {
 								return <option value={ category.ID } key={ 'post-category-' + category.ID }>{ category.name }</option>;
 							} ) }
 						</FormSelect>
@@ -176,14 +185,6 @@ const SiteSettingsFormWriting = React.createClass( {
 						</FormSelect>
 					</FormFieldset>
 
-					{ config.isEnabled( 'manage/custom-post-types' ) && this.props.jetpackVersionSupportsCustomTypes && (
-						<CustomPostTypeFieldset
-							requestingSettings={ this.state.fetchingSettings }
-							value={ pick( this.state, 'jetpack_testimonial', 'jetpack_portfolio' ) }
-							onChange={ this.setCustomPostTypeSetting }
-							recordEvent={ this.recordEvent }
-							className="site-settings__custom-post-type-fieldset has-divider is-top-only" />
-					) }
 					{ markdownSupported &&
 						<FormFieldset className="has-divider is-top-only">
 							<FormLabel>
@@ -195,35 +196,59 @@ const SiteSettingsFormWriting = React.createClass( {
 									checkedLink={ this.linkState( 'wpcom_publish_posts_with_markdown' ) }
 									disabled={ this.state.fetchingSettings }
 									onClick={ this.recordEvent.bind( this, 'Clicked Markdown for Posts Checkbox' ) } />
-								<span>{ this.translate( 'Use markdown for posts and pages. {{a}}Learn more about markdown{{/a}}.', {
+								<span>{
+									this.translate( 'Use markdown for posts and pages. {{a}}Learn more about markdown{{/a}}.', {
 										components: {
 											a: <a href="http://en.support.wordpress.com/markdown-quick-reference/" target="_blank" rel="noopener noreferrer" />
 										}
-									} ) }</span>
+									} )
+								}</span>
 							</FormLabel>
 						</FormFieldset>
 					}
-
-					{ config.isEnabled( 'press-this' ) &&
-						<FormFieldset className="has-divider is-top-only">
-							<div className="press-this">
-								<FormLabel>{ this.translate( 'Press This', { context: 'name of browser bookmarklet tool' } ) }</FormLabel>
-								<p>{ this.translate( 'Press This is a bookmarklet: a little app that runs in your browser and lets you grab bits of the web.' ) }</p>
-								<p>{ this.translate( 'Use Press This to clip text, images and videos from any web page. Then edit and add more straight from Press This before you save or publish it in a post on your site.' ) }</p>
-								<p>{ this.translate( 'Drag-and-drop the following link to your bookmarks bar or right click it and add it to your favorites for a posting shortcut.' ) }</p>
-								<p className="pressthis">
-									<PressThisLink
-										site={ this.props.site }
-										onClick={ this.recordEvent.bind( this, 'Clicked Press This Button' ) }
-										onDragStart={ this.recordEvent.bind( this, 'Dragged Press This Button' ) }>
-										<span className="noticon noticon-pinned"></span>
-										<span>{ this.translate( 'Press This', { context: 'name of browser bookmarklet tool' } ) }</span>
-									</PressThisLink>
-								</p>
-							</div>
-						</FormFieldset>
-					}
 				</Card>
+
+				{ config.isEnabled( 'manage/custom-post-types' ) && this.props.jetpackVersionSupportsCustomTypes && (
+					<div>
+						{ this.renderSectionHeader( this.translate( 'Custom Content Types' ) ) }
+						<Card className="site-settings">
+							<CustomPostTypeFieldset
+								requestingSettings={ this.state.fetchingSettings }
+								value={ pick( this.state, 'jetpack_testimonial', 'jetpack_portfolio' ) }
+								onChange={ this.setCustomPostTypeSetting }
+								recordEvent={ this.recordEvent }
+								className="site-settings__custom-post-type-fieldset" />
+						</Card>
+					</div>
+				) }
+
+				{ config.isEnabled( 'press-this' ) && (
+					<div>
+						{
+							this.renderSectionHeader( this.translate( 'Press This', {
+								context: 'name of browser bookmarklet tool'
+							} ), false )
+						}
+						<Card className="site-settings">
+							<FormFieldset>
+								<div className="press-this">
+									<p>{ this.translate( 'Press This is a bookmarklet: a little app that runs in your browser and lets you grab bits of the web.' ) }</p>
+									<p>{ this.translate( 'Use Press This to clip text, images and videos from any web page. Then edit and add more straight from Press This before you save or publish it in a post on your site.' ) }</p>
+									<p>{ this.translate( 'Drag-and-drop the following link to your bookmarks bar or right click it and add it to your favorites for a posting shortcut.' ) }</p>
+									<p className="pressthis">
+										<PressThisLink
+											site={ this.props.site }
+											onClick={ this.recordEvent.bind( this, 'Clicked Press This Button' ) }
+											onDragStart={ this.recordEvent.bind( this, 'Dragged Press This Button' ) }>
+											<span className="noticon noticon-pinned"></span>
+											<span>{ this.translate( 'Press This', { context: 'name of browser bookmarklet tool' } ) }</span>
+										</PressThisLink>
+									</p>
+								</div>
+							</FormFieldset>
+						</Card>
+					</div>
+				) }
 			</form>
 		);
 	}


### PR DESCRIPTION
This PR is part of #9171. It separates the settings in the Writing tab of Site Settings into separate cards, laying the groundwork for adding new cards for Jetpack settings. This approach is following the latest mockups that we have for Jetpack Settings in Calypso in p6TEKc-HQ-p2 and does no significant modifications; it only separates the settings in different cards, so we can easily start integrating new cards and changes to the existing ones.

#### Before
![](https://cldup.com/bSWK9T9eXw.png)

#### After
![](https://cldup.com/GfRPM4RcFy.png)

/cc 
@oskosk, @johnHackworth, @roccotripaldi for code review.
@MichaelArestad, @rickybanister for design review.