### PR TITLE
State: Improve and fix actions and their tests for google apps users

### DIFF
--- a/client/state/google-apps-users/actions.js
+++ b/client/state/google-apps-users/actions.js
@@ -54,10 +54,10 @@ export function fetchBySiteId( siteId ) {
 				items: data.accounts
 			} );
 		}, ( error ) => {
-			return {
+			dispatch( {
 				type: GOOGLE_APPS_USERS_FETCH_FAILED,
 				error
-			}
+			} );
 		} );
 	};
 }

--- a/client/state/google-apps-users/test/actions.js
+++ b/client/state/google-apps-users/test/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import sinon from 'sinon';
+import sinon, { match } from 'sinon';
 import { expect } from 'chai';
 
 /**
@@ -81,9 +81,13 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch fail when the request fails', () => {
-			fetchByDomain( '' )( spy ).then( () => {
+			fetchByDomain( noUpgradeDomain )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
-					type: GOOGLE_APPS_USERS_FETCH_FAILED
+					type: GOOGLE_APPS_USERS_FETCH_FAILED,
+					error: match( {
+						statusCode: 400,
+						error: 'upgrade_required',
+					} )
 				} );
 			} );
 		} );
@@ -137,9 +141,13 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch fail when the request fails', () => {
-			fetchBySiteId( '' )( spy ).then( () => {
+			fetchBySiteId( noUpgradeSiteId )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
-					type: GOOGLE_APPS_USERS_FETCH_FAILED
+					type: GOOGLE_APPS_USERS_FETCH_FAILED,
+					error: match( {
+						statusCode: 400,
+						error: 'upgrade_required',
+					} )
 				} );
 			} );
 		} );

--- a/client/state/google-apps-users/test/actions.js
+++ b/client/state/google-apps-users/test/actions.js
@@ -54,12 +54,12 @@ describe( 'actions', () => {
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
-				.get( `/rest/v1.1/domains/${noUpgradeDomain}/google-apps` )
+				.get( `/rest/v1.1/domains/${ noUpgradeDomain }/google-apps` )
 				.reply( 400, {
 					error: 'upgrade_required'
 				} )
-				.get( `/rest/v1.1/domains/${upgradedDomain}/google-apps` )
-				.reply( 200, upgradeResponse )
+				.get( `/rest/v1.1/domains/${ upgradedDomain }/google-apps` )
+				.reply( 200, upgradeResponse );
 		} );
 
 		it( 'should dispatch fetch action with domain data for a domain', () => {
@@ -89,13 +89,58 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( '#fetchBySite', () => {
-		it( 'should dispatch fetch action with site id for site', () => {
-			fetchBySiteId( 123 )( spy );
+	describe( '#fetchBySiteId', () => {
+		const noUpgradeSiteId = 12345678,
+			upgradedSiteId = 87654321,
+			upgradeResponse = {
+				accounts: [
+					{
+						domain: 'yesupgrade.com',
+						email: 'test@yesupgrade.com',
+						firstname: 'Test',
+						fullname: 'Test User',
+						lastname: 'Test',
+						mailbox: 'test',
+						site_id: 12345678,
+						suspended: false
+					}
+				]
+			};
+
+		useNock( ( nock ) => {
+			nock( 'https://public-api.wordpress.com:443' )
+				.persist()
+				.get( `/rest/v1.1/sites/${ noUpgradeSiteId }/google-apps` )
+				.reply( 400, {
+					error: 'upgrade_required'
+				} )
+				.get( `/rest/v1.1/sites/${ upgradedSiteId }/google-apps` )
+				.reply( 200, upgradeResponse );
+		} );
+
+		it( 'should dispatch fetch action with site data for a site', () => {
+			fetchBySiteId( noUpgradeSiteId )( spy );
 
 			expect( spy ).to.have.been.calledWith( {
 				type: GOOGLE_APPS_USERS_FETCH,
-				siteId: 123
+				siteId: noUpgradeSiteId
+			} );
+		} );
+
+		it( 'should dispatch complete when request completes', () => {
+			fetchBySiteId( upgradedSiteId )( spy ).then( () => {
+				expect( spy ).to.have.been.calledWith( {
+					type: GOOGLE_APPS_USERS_FETCH_COMPLETED,
+					items: upgradeResponse.accounts
+				} );
+			} );
+		} );
+
+		it( 'should dispatch fail when the request fails', () => {
+			fetchBySiteId( '' )( spy ).then( () => {
+				expect( spy ).to.have.been.calledWith( {
+					type: GOOGLE_APPS_USERS_FETCH_FAILED
+				} );
 			} );
 		} );
 	} );


### PR DESCRIPTION
This PR does some improvements and fixes to `google-apps-users`:

* Dispatch the failure action in `fetchBySiteId` instead of returning it.
* Add more tests for testing all dispatched action types in `fetchBySiteId`.
* Fix the failure tests by specifying proper arguments when calling the action thunks.

To test:

* Checkout this branch
* Verify all tests are passing by calling this in your terminal:
`npm run test-client client/state/google-apps-users/test/actions.js`

/cc @umurkontaci 