### PR TITLE
Automated Transfer: Add redux actions for site eligibility

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1,4 +1,3 @@
-
 /**
  * External dependencies.
  */

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1,3 +1,4 @@
+
 /**
  * External dependencies.
  */
@@ -2153,6 +2154,20 @@ Undocumented.prototype.transferStatus = function( siteId, transferId ) {
 	return this.wpcom.req.get( {
 		path: `/sites/${ siteId }/automated-transfers/status/${ transferId }`
 	} );
+};
+
+/**
+ * Call endpoint that determines whether a site is eligible
+ * for automated transfer.
+ *
+ * @param {int} siteId -- the ID of the site
+ *
+ * @returns {Promise} promise for handling result
+ */
+Undocumented.prototype.transferEligibility = function( siteId ) {
+	const path = `/sites/${ siteId }/automated-transfers/eligibility`;
+	debug( path );
+	return this.wpcom.req.get( { path } );
 };
 
 /**


### PR DESCRIPTION
Add the endpoint call and actions necessary for determining a site's eligibility for automated transfer. See eligibility endpoint updates in D3644-code.

Also necessary before we can show site eligibility:
* reducers
* selectors
* query component
