### PR TITLE
Themes: Add second ThemesSelection to Single Jetpack Site mode

### DIFF
--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { pickBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,10 +18,20 @@ import { connectOptions } from './theme-options';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
+import ThemesSelection from './themes-selection';
+import { addTracking } from './helpers';
 
 export default connectOptions(
 	( props ) => {
-		const { site, siteId, analyticsPath, analyticsPageTitle } = props;
+		const {
+			analyticsPath,
+			analyticsPageTitle,
+			getScreenshotOption,
+			options,
+			search,
+			site,
+			siteId
+		} = props;
 		const jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' );
 
 		if ( ! jetpackEnabled ) {
@@ -54,8 +65,34 @@ export default connectOptions(
 					<ThanksModal
 						site={ site }
 						source={ 'list' } />
+					<ThemesSelection
+						selectedSite={ false }
+						getScreenshotUrl={ function( theme ) {
+							if ( ! getScreenshotOption( theme ).getUrl ) {
+								return null;
+							}
+							return getScreenshotOption( theme ).getUrl( theme );
+						} }
+						onScreenshotClick={ function( theme ) {
+							if ( ! getScreenshotOption( theme ).action ) {
+								return;
+							}
+							getScreenshotOption( theme ).action( theme );
+						} }
+						getActionLabel={ function( theme ) {
+							return getScreenshotOption( theme ).label;
+						} }
+						getOptions={ function( theme ) {
+							return pickBy(
+								addTracking( options ),
+								option => ! ( option.hideForTheme && option.hideForTheme( theme ) )
+							); } }
+						trackScrollPage={ props.trackScrollPage }
+						search={ search }
+						tier={ props.tier }
+						filter={ props.filter }
+						vertical={ props.vertical } />
 				</ThemeShowcase>
-			</div>
-		);
+			</div>		);
 	}
 );

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -65,7 +65,7 @@ export default connectOptions(
 					<ThanksModal
 						site={ site }
 						source={ 'list' } />
-					<ThemesSelection
+					<ThemesSelection query={ /* TBD */ }
 						selectedSite={ false }
 						getScreenshotUrl={ function( theme ) {
 							if ( ! getScreenshotOption( theme ).getUrl ) {
@@ -87,11 +87,7 @@ export default connectOptions(
 								addTracking( options ),
 								option => ! ( option.hideForTheme && option.hideForTheme( theme ) )
 							); } }
-						trackScrollPage={ props.trackScrollPage }
-						search={ search }
-						tier={ props.tier }
-						filter={ props.filter }
-						vertical={ props.vertical } />
+						trackScrollPage={ props.trackScrollPage } />
 				</ThemeShowcase>
 			</div>
 		);

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -93,6 +93,7 @@ export default connectOptions(
 						filter={ props.filter }
 						vertical={ props.vertical } />
 				</ThemeShowcase>
-			</div>		);
+			</div>
+		);
 	}
 );

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -19,7 +19,9 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
 import ThemesSelection from './themes-selection';
+import ThemeUploadCard from './themes-upload-card';
 import { addTracking } from './helpers';
+import { translate } from 'i18n-calypso';
 
 export default connectOptions(
 	( props ) => {
@@ -67,6 +69,11 @@ export default connectOptions(
 					<ThanksModal
 						site={ site }
 						source={ 'list' } />
+					{ config.isEnabled( 'manage/themes/upload' ) &&
+						<ThemeUploadCard
+							label={ translate( 'WordPress.com themes' ) }
+						/>
+					}
 					<ThemesSelection
 						search={ search }
 						tier={ tier }

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -30,7 +30,9 @@ export default connectOptions(
 			options,
 			search,
 			site,
-			siteId
+			siteId,
+			tier,
+			vertical
 		} = props;
 		const jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' );
 
@@ -65,7 +67,11 @@ export default connectOptions(
 					<ThanksModal
 						site={ site }
 						source={ 'list' } />
-					<ThemesSelection query={ /* TBD */ }
+					<ThemesSelection
+						search={ search }
+						tier={ tier }
+						vertical={ vertical }
+						siteId = { siteId }
 						selectedSite={ false }
 						getScreenshotUrl={ function( theme ) {
 							if ( ! getScreenshotOption( theme ).getUrl ) {
@@ -87,7 +93,8 @@ export default connectOptions(
 								addTracking( options ),
 								option => ! ( option.hideForTheme && option.hideForTheme( theme ) )
 							); } }
-						trackScrollPage={ props.trackScrollPage } />
+						trackScrollPage={ props.trackScrollPage }
+					/>
 				</ThemeShowcase>
 			</div>
 		);

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -104,8 +104,8 @@ export default connectOptions(
 							/>
 						</div>
 					}
-						</ThemeShowcase>
-						</div>
-						);
-					}
-					);
+				</ThemeShowcase>
+			</div>
+		);
+	}
+);

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -70,40 +70,42 @@ export default connectOptions(
 						site={ site }
 						source={ 'list' } />
 					{ config.isEnabled( 'manage/themes/upload' ) &&
-						<ThemeUploadCard
-							label={ translate( 'WordPress.com themes' ) }
-						/>
+						<div>
+							<ThemeUploadCard
+								label={ translate( 'WordPress.com themes' ) }
+							/>
+							<ThemesSelection
+								search={ search }
+								tier={ tier }
+								vertical={ vertical }
+								siteId = { false }
+								selectedSite={ false }
+								getScreenshotUrl={ function( theme ) {
+									if ( ! getScreenshotOption( theme ).getUrl ) {
+										return null;
+									}
+									return getScreenshotOption( theme ).getUrl( theme );
+								} }
+								onScreenshotClick={ function( theme ) {
+									if ( ! getScreenshotOption( theme ).action ) {
+										return;
+									}
+									getScreenshotOption( theme ).action( theme );
+								} }
+								getActionLabel={ function( theme ) {
+									return getScreenshotOption( theme ).label;
+								} }
+								getOptions={ function( theme ) {
+									return pickBy(
+										addTracking( options ),
+										option => ! ( option.hideForTheme && option.hideForTheme( theme ) )
+									); } }
+								trackScrollPage={ props.trackScrollPage }
+							/>
+						</div>
 					}
-					<ThemesSelection
-						search={ search }
-						tier={ tier }
-						vertical={ vertical }
-						siteId = { false }
-						selectedSite={ false }
-						getScreenshotUrl={ function( theme ) {
-							if ( ! getScreenshotOption( theme ).getUrl ) {
-								return null;
-							}
-							return getScreenshotOption( theme ).getUrl( theme );
-						} }
-						onScreenshotClick={ function( theme ) {
-							if ( ! getScreenshotOption( theme ).action ) {
-								return;
-							}
-							getScreenshotOption( theme ).action( theme );
-						} }
-						getActionLabel={ function( theme ) {
-							return getScreenshotOption( theme ).label;
-						} }
-						getOptions={ function( theme ) {
-							return pickBy(
-								addTracking( options ),
-								option => ! ( option.hideForTheme && option.hideForTheme( theme ) )
-							); } }
-						trackScrollPage={ props.trackScrollPage }
-					/>
-				</ThemeShowcase>
-			</div>
-		);
-	}
-);
+						</ThemeShowcase>
+						</div>
+						);
+					}
+					);

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -78,7 +78,7 @@ export default connectOptions(
 						search={ search }
 						tier={ tier }
 						vertical={ vertical }
-						siteId = { siteId }
+						siteId = { false }
 						selectedSite={ false }
 						getScreenshotUrl={ function( theme ) {
 							if ( ! getScreenshotOption( theme ).getUrl ) {

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -34,6 +34,7 @@ export default connectOptions(
 			site,
 			siteId,
 			tier,
+			filter,
 			vertical
 		} = props;
 		const jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' );
@@ -77,6 +78,7 @@ export default connectOptions(
 							<ThemesSelection
 								search={ search }
 								tier={ tier }
+								filter={ filter }
 								vertical={ vertical }
 								siteId = { false }
 								selectedSite={ false }

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -80,8 +80,7 @@ export default connectOptions(
 								tier={ tier }
 								filter={ filter }
 								vertical={ vertical }
-								siteId = { false }
-								selectedSite={ false }
+								siteId = { null }
 								getScreenshotUrl={ function( theme ) {
 									if ( ! getScreenshotOption( theme ).getUrl ) {
 										return null;

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -151,7 +151,7 @@ const ThemeShowcase = React.createClass( {
 	},
 
 	render() {
-		const { site, options, getScreenshotOption, secondaryOption, search } = this.props;
+		const { site, options, getScreenshotOption, secondaryOption, search, filter } = this.props;
 		const tier = config.isEnabled( 'upgrades/premium-themes' ) ? this.props.tier : 'free';
 		const primaryOption = this.getPrimaryOption();
 
@@ -200,6 +200,7 @@ const ThemeShowcase = React.createClass( {
 				<ThemesSelection
 					search={ search }
 					tier={ this.props.tier }
+					filter={ filter }
 					vertical={ this.props.vertical }
 					siteId={ this.props.siteId }
 					getScreenshotUrl={ function( theme ) {

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -5,7 +5,7 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
-import { compact, pickBy } from 'lodash';
+import { pickBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -150,19 +150,6 @@ const ThemeShowcase = React.createClass( {
 		return primaryOption;
 	},
 
-	addVerticalToFilters() {
-		const { vertical, filter } = this.props;
-		return compact( [ filter, vertical ] ).join( ',' );
-	},
-
-	incrementPage() {
-		this.setState( { page: this.state.page + 1 } );
-	},
-
-	resetPage() {
-		this.setState( { page: 1 } );
-	},
-
 	render() {
 		const { site, options, getScreenshotOption, secondaryOption, search } = this.props;
 		const tier = config.isEnabled( 'upgrades/premium-themes' ) ? this.props.tier : 'free';
@@ -178,14 +165,6 @@ const ThemeShowcase = React.createClass( {
 			{ property: 'og:url', content: themesMeta[ tier ].canonicalUrl },
 			{ property: 'og:type', content: 'website' }
 		];
-
-		const query = {
-			search,
-			tier,
-			filter: this.addVerticalToFilters(),
-			page: this.state.page,
-			number: 20
-		};
 
 		// FIXME: Logged-in title should only be 'Themes'
 		return (
@@ -218,7 +197,10 @@ const ThemeShowcase = React.createClass( {
 						label={ this.props.uploadLabel }
 					/>
 				}
-				<ThemesSelection query={ query }
+				<ThemesSelection
+					search={ search }
+					tier={ this.props.tier }
+					vertical={ this.props.vertical }
 					siteId={ this.props.siteId }
 					getScreenshotUrl={ function( theme ) {
 						if ( ! getScreenshotOption( theme ).getUrl ) {
@@ -241,9 +223,8 @@ const ThemeShowcase = React.createClass( {
 							option => ! ( option.hideForTheme && option.hideForTheme( theme ) )
 						); } }
 					trackScrollPage={ this.props.trackScrollPage }
-					incrementPage={ this.incrementPage }
-					resetPage={ this.resetPage } />
-					{ this.props.children }
+				/>
+				{ this.props.children }
 			</Main>
 		);
 	}

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -155,14 +155,11 @@ const ConnectedThemesSelection = connect(
 	}
 )( ThemesSelection );
 
-class ThemesSelectonWithPage extends React.Component {
+class ThemesSelectionWithPage extends React.Component {
 
-	constructor() {
-		super();
-		this.state = {
-			page: 1,
-		};
-	}
+	state = {
+		page: 1,
+	};
 
 	incrementPage = () => {
 		this.setState( { page: this.state.page + 1 } );
@@ -184,4 +181,4 @@ class ThemesSelectonWithPage extends React.Component {
 
 }
 
-export default ThemesSelectonWithPage;
+export default ThemesSelectionWithPage;

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -28,10 +28,7 @@ import { PAGINATION_QUERY_KEYS } from 'lib/query-manager/paginated/constants';
 const ThemesSelection = React.createClass( {
 	propTypes: {
 		query: PropTypes.object.isRequired,
-		siteId: PropTypes.oneOfType( [
-			PropTypes.number,
-			PropTypes.oneOf( [ false ] )
-		] ),
+		siteId: PropTypes.number,
 		onScreenshotClick: PropTypes.func,
 		getOptions: PropTypes.func,
 		getActionLabel: PropTypes.func,

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -155,8 +155,12 @@ const ConnectedThemesSelection = connect(
 	}
 )( ThemesSelection );
 
+/**
+ * Provide page state management needed for `ThemesSelection`. We cannot store the
+ * current state inside `ThemesSelection` since it is also needed in its `connect`
+ * call for selectors that require the entire query object, including the page.
+ */
 class ThemesSelectionWithPage extends React.Component {
-
 	state = {
 		page: 1,
 	};
@@ -178,7 +182,6 @@ class ThemesSelectionWithPage extends React.Component {
 			/>
 		);
 	}
-
 }
 
 export default ThemesSelectionWithPage;

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -28,7 +28,10 @@ import { PAGINATION_QUERY_KEYS } from 'lib/query-manager/paginated/constants';
 const ThemesSelection = React.createClass( {
 	propTypes: {
 		query: PropTypes.object.isRequired,
-		siteId: PropTypes.number,
+		siteId: PropTypes.oneOfType( [
+			PropTypes.number,
+			PropTypes.oneOf( [ false ] )
+		] ),
 		onScreenshotClick: PropTypes.func,
 		getOptions: PropTypes.func,
 		getActionLabel: PropTypes.func,

--- a/client/my-sites/themes/themes-upload-card/index.jsx
+++ b/client/my-sites/themes/themes-upload-card/index.jsx
@@ -16,7 +16,7 @@ class ThemeUploadCard extends React.Component {
 
 	static propTypes = {
 		label: PropTypes.string,
-		href: PropTypes.string.isRequired,
+		href: PropTypes.string,
 		count: PropTypes.number,
 	};
 
@@ -35,13 +35,15 @@ class ThemeUploadCard extends React.Component {
 					label={ this.props.label }
 					count={ this.props.count }
 				>
-					<Button compact icon
-						onClick={ this.trackClick }
-						href={ this.props.href }
-					>
-						<Gridicon icon="cloud-upload" />
-						{ translate( 'Upload Theme' ) }
-					</Button>
+					{ this.props.href &&
+						<Button compact icon
+							onClick={ this.trackClick }
+							href={ this.props.href }
+						>
+							<Gridicon icon="cloud-upload" />
+							{ translate( 'Upload Theme' ) }
+						</Button>
+					}
 				</SectionHeader>
 			</div>
 		);


### PR DESCRIPTION
Behind a feature flag.

To test -- Check that the Theme Showcase still works as before, and that Single Jetpack Site mode now has the full list of WP.com themes at the bottom. Verify that searching and filtering works for both lists (keep in mind that Jetpack themes can only be filtered for `feature`s, tho).

For some more context, see https://github.com/Automattic/wp-calypso/issues/9671#issuecomment-266444977