### PR TITLE
Themes: Change component order inside `ThemeShowcase`

### DIFF
--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -13,11 +13,12 @@ import ThemeShowcase from './theme-showcase';
 
 const MultiSiteThemeShowcase = connectOptions(
 	( props ) => (
-		<ThemesSiteSelectorModal { ...props } sourcePath="/design">
-			<ThemeShowcase source="showcase">
-				<SidebarNavigation />
-			</ThemeShowcase>
-		</ThemesSiteSelectorModal>
+		<div>
+			<SidebarNavigation />
+			<ThemesSiteSelectorModal { ...props } sourcePath="/design">
+				<ThemeShowcase source="showcase" />
+			</ThemesSiteSelectorModal>
+		</div>
 	)
 );
 

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -45,15 +45,17 @@ export default connectOptions(
 		}
 
 		return (
-			<ThemeShowcase { ...props } siteId={ siteId }>
-				{ siteId && <QuerySitePlans siteId={ siteId } /> }
-				{ siteId && <QuerySitePurchases siteId={ siteId } /> }
-				<SidebarNavigation />
-				<ThanksModal
-					site={ site }
-					source={ 'list' } />
+			<div>
 				<CurrentTheme siteId={ siteId } />
-			</ThemeShowcase>
+				<ThemeShowcase { ...props } siteId={ siteId }>
+					{ siteId && <QuerySitePlans siteId={ siteId } /> }
+					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
+					<SidebarNavigation />
+					<ThanksModal
+						site={ site }
+						source={ 'list' } />
+				</ThemeShowcase>
+			</div>
 		);
 	}
 );

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -46,11 +46,11 @@ export default connectOptions(
 
 		return (
 			<div>
+				<SidebarNavigation />
 				<CurrentTheme siteId={ siteId } />
 				<ThemeShowcase { ...props } siteId={ siteId }>
 					{ siteId && <QuerySitePlans siteId={ siteId } /> }
 					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
-					<SidebarNavigation />
 					<ThanksModal
 						site={ site }
 						source={ 'list' } />

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -21,13 +21,7 @@ export default connectOptions(
 		const { site, siteId, translate } = props;
 
 		return (
-			<ThemeShowcase { ...props } siteId={ siteId }>
-				{ siteId && <QuerySitePlans siteId={ siteId } /> }
-				{ siteId && <QuerySitePurchases siteId={ siteId } /> }
-				<SidebarNavigation />
-				<ThanksModal
-					site={ site }
-					source={ 'list' } />
+			<div>
 				<CurrentTheme siteId={ siteId } />
 				<UpgradeNudge
 					title={ translate( 'Get Custom Design with Premium' ) }
@@ -35,7 +29,15 @@ export default connectOptions(
 					feature={ FEATURE_ADVANCED_DESIGN }
 					event="themes_custom_design"
 					/>
-			</ThemeShowcase>
+				<ThemeShowcase { ...props } siteId={ siteId }>
+					{ siteId && <QuerySitePlans siteId={ siteId } /> }
+					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
+					<SidebarNavigation />
+					<ThanksModal
+						site={ site }
+						source={ 'list' } />
+				</ThemeShowcase>
+			</div>
 		);
 	}
  );

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -22,6 +22,7 @@ export default connectOptions(
 
 		return (
 			<div>
+				<SidebarNavigation />
 				<CurrentTheme siteId={ siteId } />
 				<UpgradeNudge
 					title={ translate( 'Get Custom Design with Premium' ) }
@@ -32,7 +33,6 @@ export default connectOptions(
 				<ThemeShowcase { ...props } siteId={ siteId }>
 					{ siteId && <QuerySitePlans siteId={ siteId } /> }
 					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
-					<SidebarNavigation />
 					<ThanksModal
 						site={ site }
 						source={ 'list' } />

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -166,7 +166,6 @@ const ThemeShowcase = React.createClass( {
 			<Main className="themes">
 				<DocumentHead title={ themesMeta[ tier ].title } meta={ metas } />
 				<PageViewTracker path={ this.props.analyticsPath } title={ this.props.analyticsPageTitle } />
-				{ this.props.children }
 				{ this.state.showPreview &&
 					<ThemePreview showPreview={ this.state.showPreview }
 						theme={ this.state.previewingTheme }
@@ -215,6 +214,7 @@ const ThemeShowcase = React.createClass( {
 					tier={ this.props.tier }
 					filter={ this.props.filter }
 					vertical={ this.props.vertical } />
+					{ this.props.children }
 			</Main>
 		);
 	}

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -214,9 +214,7 @@ const ThemeShowcase = React.createClass( {
 					search={ search }
 					tier={ this.props.tier }
 					filter={ this.props.filter }
-					vertical={ this.props.vertical }
-					queryParams={ this.props.queryParams }
-					themesList={ this.props.themesList } />
+					vertical={ this.props.vertical } />
 			</Main>
 		);
 	}


### PR DESCRIPTION
WIP, based on #9980. Will allow us to insert a second `ThemesSelection` that will end up in the right place. Not perfectly pretty, but it will do for now.

`<div>`s to the rescue!

To test:
* Check all showcase modes (logged-out, multi-site, single-site-wpcom, single-site-jetpack) and verify that all components are in their right places. Pay special attention to:
 * the current theme bar
 * the `<UpgradeNudge>`
 * the mobile-only `<SidebarNavigation>`
 * the Thanks Modal