### PR TITLE
Taxonomies: Disable text area resizing of textarea

### DIFF
--- a/client/blocks/term-form-dialog/style.scss
+++ b/client/blocks/term-form-dialog/style.scss
@@ -20,3 +20,7 @@
 		min-width: none;
 	}
 }
+
+.term-form-dialog textarea {
+	resize: vertical;
+}


### PR DESCRIPTION
I disable textarea horizontal resizing in this PR

Closes #9963

**Testing instructions**

 * Go to the taxonomy manager : `/settings/taxonomies/category/$site`
 * Click "Add category" 
 * Expand the description's Textarea
 * You should not be able to expand it horizontally 