### PR TITLE
TokenField: Fix errored tooltip status

### DIFF
--- a/client/components/tooltip/index.jsx
+++ b/client/components/tooltip/index.jsx
@@ -42,6 +42,7 @@ class Tooltip extends Component {
 		const classes = classnames(
 			'popover',
 			'tooltip',
+			`is-${ this.props.status }`,
 			`is-${ this.props.position }`,
 			this.props.className
 		);


### PR DESCRIPTION
Fixes an issue where the errored tooltip status was not being styled appropriated for tokens in the TokenField component. The errored tooltips when inviting a non-existent user should be red, but were blue before this PR.

It looks like this was introduced in d3bd203562068990fe5d3a2c7b8a36fa4ea2c3a5. I previously tried to fix as part of #9891, but that was reverted.

### After Screenshot

<img width="579" alt="screen shot 2016-12-12 at 9 55 59 am" src="https://cloud.githubusercontent.com/assets/1126811/21105859/63d85eb6-c051-11e6-8783-fe114a36663f.png">

### To test

- Go to `/people/new/$site` where `$site` is a WP.com site and invite a non-existent user, something like `nonexistent` or `0`.
- Note that a red tooltip should pop up