### PR TITLE
Makes Email navigation and empty state clearer

### DIFF
--- a/client/my-sites/upgrades/domain-management/email/index.jsx
+++ b/client/my-sites/upgrades/domain-management/email/index.jsx
@@ -110,11 +110,11 @@ const Email = React.createClass( {
 			};
 		} else {
 			emptyContentProps = {
-				title: this.translate( "You don't have any domains yet." ),
+				title: this.translate( "Enable powerful email features." ),
 				line: this.translate(
-					'Add a domain to your site to make it easier ' +
-					'to remember and easier to share, and get access to email ' +
-					'forwarding, G Suite, and other email services.'
+					'To set up email forwarding, G Suite, and other email ' +
+					'services for your site, upgrade your site’s web address ' +
+					'to a professional custom domain.'
 				)
 			};
 		}

--- a/client/my-sites/upgrades/navigation.jsx
+++ b/client/my-sites/upgrades/navigation.jsx
@@ -79,7 +79,7 @@ const PlansNavigation = React.createClass( {
 					{ ! isJetpack && userCanManageOptions &&
 						<NavItem path={ `/domains/manage/email/${ site.slug }` } key="googleApps"
 							selected={ path === '/domains/manage/email' }>
-							{ this.translate( 'G Suite' ) }
+							{ this.translate( 'Email' ) }
 						</NavItem>
 					}
 				</NavTabs>


### PR DESCRIPTION
resolves https://github.com/Automattic/wp-calypso/issues/9595

To test: 
- calypso.live/?branch=update/g-suite-in-plans-empty-state
- navigate to `Plans`
- make sure label in sub-nav says "email"
- click "email" and make sure that empty state instructions are helpful and work as expected

Before:
![](https://cloudup.com/cu7gkxpx6Yl+)

After:
![](https://cloudup.com/ckhKZxZOT58+)