### PR TITLE
Redux: Create two new util helpers for creating reducers

### DIFF
--- a/client/state/README.md
+++ b/client/state/README.md
@@ -42,3 +42,64 @@ function extended() {
 dispatch( extended() );
 // Dispatches two actions `{ type: 'example', extended: true }`
 ```
+
+### keyedReducer( keyName, reducer )
+
+Sometimes we have a collection of properties that represent some object or data item and our reducers contain a collection of those items.
+For example, we may have a list of widgets for a site, but our reducer keeps a collection of those sites.
+
+It's fairly common to see reducers built like this:
+
+```js
+const widgetCount = ( state = {}, action ) => {
+	if ( ADD_WIDGET === action.type ) {
+		return {
+			...state,
+			[ action.siteId ]: state[ action.siteId ] + 1,
+		}
+	}
+
+	return state;
+}
+```
+
+Notice that the reducer _wants_ to operate on a simple integer, but because it has to store a collection of these things, identified by which `siteId` it belongs to, we have a complicated initial state and confusing syntax on the return value.
+
+What if we could write them like this instead…
+
+```js
+const widgetCount = ( state = 0, action ) => {
+	if ( ADD_WIDGET === action.type ) {
+		return state + 1;
+	}
+
+	return state;
+}
+```
+
+…and somehow it would know to assign this to the proper site?
+
+This utility helper provides the glue for us to allow this style of reducer composition. It creates a reducer for a collection of items which are identified by some key. In our case, we can create it with the `siteId` of the action as the key.
+
+```js
+export default keyedReducer( 'siteId', widgetCount );
+```
+
+This will automatically search for a `siteId` property in the action and dispatch the update to the appropriate item in the collection.
+Unlike building a reducer without this helper, the updates will only apply to the item in the collection with the given key.
+
+By using this helper we can keep our reducers small and easy to reason about.
+They automatically benefit from the way `combineReducers` will immutably update the state, wherein if no changes actually occur then no updates will follow.
+We are left with simple update expressions that are decoupled from the rest of the items in the collection.
+We are provided the opportunity to make straightforward tests without complicated mocks.
+
+### withSchemaValidation( schema, reducer )
+
+When Calypso boots up it loads the last-known state out of persistent storage in the browser.
+If that state was saved from an old version of the reducer code it could be incompatible with the new state model.
+Thankfully we are given the ability to validate the schema and conditionally load the persisted state only if it's valid.
+This can be done by passing a schema into a call to `createReducer()`, but sometimes `createReducer()` provides more abstraction than is necessary.
+
+This helper produces a new reducer given an original reducer and schema.
+The new reducer will automatically validate the persisted state when Calypso loads and reinitialize if it isn't valid.
+It is in most regards a lightweight version of `createReducer()`.

--- a/client/state/README.md
+++ b/client/state/README.md
@@ -93,6 +93,36 @@ They automatically benefit from the way `combineReducers` will immutably update 
 We are left with simple update expressions that are decoupled from the rest of the items in the collection.
 We are provided the opportunity to make straightforward tests without complicated mocks.
 
+#### Example
+
+```js
+const age = ( state = 0, action ) =>
+    GROW === action.type
+        ? state + 1
+        : state
+
+const title = ( state = 'grunt', action ) =>
+    PROMOTION === action.type
+        ? action.title
+        : state
+
+const userReducer = combineReducers( {
+    age,
+    title,
+} )
+
+export default keyedReducer( 'username', userReducer )
+
+dispatch( { type: GROW, username: 'hunter02' } )
+
+state.users === {
+    hunter02: {
+        age: 1,
+        title: 'grunt',
+    }
+}
+```
+
 ### withSchemaValidation( schema, reducer )
 
 When Calypso boots up it loads the last-known state out of persistent storage in the browser.

--- a/client/state/README.md
+++ b/client/state/README.md
@@ -133,3 +133,20 @@ This can be done by passing a schema into a call to `createReducer()`, but somet
 This helper produces a new reducer given an original reducer and schema.
 The new reducer will automatically validate the persisted state when Calypso loads and reinitialize if it isn't valid.
 It is in most regards a lightweight version of `createReducer()`.
+
+#### Example
+
+```js
+const ageReducer = ( state = 0, action ) =>
+	GROW === action.type
+		? state + 1
+		: state
+
+const schema = { type: 'number', minimum: 0 }
+
+export const age = withSchemaValidation( schema, age )
+
+ageReducer( -5, { type: DESERIALIZE } ) === -5
+age( -5, { type: DESERIALIZE } ) === 0
+age( 23, { type: DESERIALIZE } ) === 23
+```

--- a/client/state/README.md
+++ b/client/state/README.md
@@ -144,7 +144,7 @@ const ageReducer = ( state = 0, action ) =>
 
 const schema = { type: 'number', minimum: 0 }
 
-export const age = withSchemaValidation( schema, age )
+export const age = withSchemaValidation( schema, ageReducer )
 
 ageReducer( -5, { type: DESERIALIZE } ) === -5
 age( -5, { type: DESERIALIZE } ) === 0

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -281,6 +281,11 @@ describe( 'utils', () => {
 			const keyed = keyedReducer( 'name', age );
 			expect( keyed( prevState, { type: 'STAY', name: 'Bonobo' } ) ).to.equal( prevState );
 		} );
+
+		it( 'should not initialize a state if no changes and not keyed (simple state)', () => {
+			const keyed = keyedReducer( 'name', age );
+			expect( keyed( prevState, { type: 'STAY', name: 'Calypso' } ) ).to.equal( prevState );
+		} );
 	} );
 
 	describe( '#withSchemaValidation', () => {

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -253,9 +253,9 @@ describe( 'utils', () => {
 				? state + 1
 				: state;
 
-		const prevState = {
+		const prevState = deepFreeze( {
 			Bonobo: 13,
-		};
+		} );
 
 		it( 'should create keyed state given simple reducers', () => {
 			const keyed = keyedReducer( 'name', age );
@@ -275,6 +275,19 @@ describe( 'utils', () => {
 		it( 'should skip if no key is provided in the action', () => {
 			const keyed = keyedReducer( 'name', age );
 			expect( keyed( prevState, { type: 'GROW' } ) ).to.equal( prevState );
+		} );
+
+		it( 'should handle falsey keys', () => {
+			const keyed = keyedReducer( 'name', age );
+			expect( keyed( { [ 0 ]: 10 }, grow( 0 ) ) ).to.eql( { '0': 11 } );
+		} );
+
+		it( 'should handle coerced-to-string keys', () => {
+			const keyed = keyedReducer( 'name', age );
+			expect( keyed( { '10': 10 }, grow( '10' ) ) ).to.eql( { '10': 11 } );
+			expect( keyed( { [ 10 ]: 10 }, grow( '10' ) ) ).to.eql( { '10': 11 } );
+			expect( keyed( { [ 10 ]: 10 }, grow( 10 ) ) ).to.eql( { '10': 11 } );
+			expect( keyed( { '10': 10 }, grow( 10 ) ) ).to.eql( { '10': 11 } );
 		} );
 
 		it( 'should return without changes if no actual changes occur', () => {

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -257,6 +257,31 @@ describe( 'utils', () => {
 			Bonobo: 13,
 		} );
 
+		it( 'should only accept string-type key names', () => {
+			expect( () => keyedReducer( null, age ) ).to.throw( TypeError );
+			expect( () => keyedReducer( undefined, age ) ).to.throw( TypeError );
+			expect( () => keyedReducer( [], age ) ).to.throw( TypeError );
+			expect( () => keyedReducer( {}, age ) ).to.throw( TypeError );
+			expect( () => keyedReducer( true, age ) ).to.throw( TypeError );
+			expect( () => keyedReducer( 10, age ) ).to.throw( TypeError );
+			expect( () => keyedReducer( 15.4, age ) ).to.throw( TypeError );
+			expect( () => keyedReducer( '', age ) ).to.throw( TypeError );
+			expect( () => keyedReducer( 'key', age ) ).to.not.throw( TypeError );
+		} );
+
+		it( 'should only accept a function as the reducer argument', () => {
+			expect( () => keyedReducer( 'key', null ) ).to.throw( TypeError );
+			expect( () => keyedReducer( 'key', undefined ) ).to.throw( TypeError );
+			expect( () => keyedReducer( 'key', [] ) ).to.throw( TypeError );
+			expect( () => keyedReducer( 'key', {} ) ).to.throw( TypeError );
+			expect( () => keyedReducer( 'key', true ) ).to.throw( TypeError );
+			expect( () => keyedReducer( 'key', 10 ) ).to.throw( TypeError );
+			expect( () => keyedReducer( 'key', 15.4 ) ).to.throw( TypeError );
+			expect( () => keyedReducer( 'key', '' ) ).to.throw( TypeError );
+			expect( () => keyedReducer( 'key' ) ).to.throw( TypeError );
+			expect( () => keyedReducer( 'key', () => {} ).to.not.throw( TypeError ) );
+		} );
+
 		it( 'should create keyed state given simple reducers', () => {
 			const keyed = keyedReducer( 'name', age );
 			expect( keyed( undefined, grow( 'Calypso' ) ) ).to.eql( {

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -23,6 +23,84 @@ export function isValidStateWithSchema( state, schema ) {
 }
 
 /**
+ * Creates a super-reducer as a map of reducers over keyed objects
+ *
+ * Use this when wanting to write reducers that operate
+ * on a single object as if it lived in isolation when
+ * really it lives in a map of similar objects referenced
+ * by some predesignated key or id. This could be used
+ * for example when reducing properties on a site object
+ * wherein we have many sites keyed by site id.
+ *
+ * Note! This will only apply the supplied reducer to
+ * the item referenced by the supplied key in the action.
+ *
+ * If no key exists whose name matches the given keyName
+ * then this super-reducer will abort and return the
+ * previous state.
+ *
+ * If some action should apply to every single item
+ * in the map of keyed objects, this utility cannot be
+ * used as it will only reduce the referenced item.
+ *
+ * @example
+ * const age = ( state = 0, action ) =>
+ *     GROW === action.type
+ *         ? state + 1
+ *         : state
+ *
+ * const title = ( state = 'grunt', action ) =>
+ *     PROMOTION === action.type
+ *         ? action.title
+ *         : state
+ *
+ * const userReducer = combineReducers( {
+ *     age,
+ *     title,
+ * } )
+ *
+ * export default keyedReducer( 'username', userReducer )
+ *
+ * dispatch( { type: GROW, username: 'hunter02' } )
+ *
+ * state.users === {
+ *     hunter02: {
+ *         age: 1,
+ *         title: 'grunt',
+ *     }
+ * }
+ *
+ * @param {string} keyName name of key in action referencing item in state map
+ * @param {function} reducer applied to referenced item in state map
+ * @return {function} super-reducer applying reducer over map of keyed items
+ */
+export const keyedReducer = ( keyName, reducer ) => ( state = {}, action ) => {
+	// the action must refer to some item in the map
+	const itemKey = action[ keyName ];
+
+	// if no reference exists abort
+	// and return unchanged state
+	if ( ! itemKey ) {
+		return state;
+	}
+
+	// pass the old sub-state from that item into the reducer
+	const oldState = state[ itemKey ];
+	const newState = reducer( oldState, action );
+
+	// and do nothing if the new sub-state matches the old sub-state
+	if ( newState === oldState ) {
+		return state;
+	}
+
+	// otherwise immutably update the super-state
+	return {
+		...state,
+		[ itemKey ]: newState,
+	};
+};
+
+/**
  * Given an action object or thunk, returns an updated object or thunk which
  * will include additional data in the action (as provided) when dispatched.
  *
@@ -116,3 +194,45 @@ export function createReducer( initialState = null, customHandlers = {}, schema 
 		return state;
 	};
 }
+
+/**
+ * Creates schema-validating reducer
+ *
+ * Use this to wrap simple reducers with a schema-based
+ * validation check when loading the initial state from
+ * persistent storage.
+ *
+ * When this wraps a reducer with a known JSON schema,
+ * it will intercept the DESERIALIZE action (on app boot)
+ * and check if the persisted state is still valid state.
+ * If so it will return the persisted state, otherwise
+ * it will return the initial state computed from
+ * passing the null action.
+ *
+ * @example
+ * const ageReducer = ( state = 0, action ) =>
+ *     GROW === action.type
+ *         ? state + 1
+ *         : state
+ *
+ * const schema = { type: 'number', minimum: 0 }
+ *
+ * export const age = withSchemaValidation( schema, age )
+ *
+ * // ageReducer( -5, { type: DESERIALIZE } ) === -5
+ * // age( -5, { type: DESERIALIZE } ) === 0
+ * // age( 23, { type: DESERIALIZE } ) === 23
+ *
+ * @param {object} schema JSON-schema description of state
+ * @param {function} reducer normal reducer from ( state, action ) to new state
+ * @returns {function} wrapped reducer handling validation on DESERIALIZE
+ */
+export const withSchemaValidation = ( schema, reducer ) => ( state, action ) => {
+	if ( DESERIALIZE === action.type ) {
+		return state && isValidStateWithSchema( state, schema )
+			? state
+			: reducer( undefined, { type: '@@dummy/INIT' } );
+	}
+
+	return reducer( state, action );
+};

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -92,7 +92,7 @@ export const keyedReducer = ( keyName, reducer ) => {
 
 	return ( state = {}, action ) => {
 		// don't allow coercion of key name: null => 0
-		if ( ! action.hasOwnProperty( keyName )  ) {
+		if ( ! action.hasOwnProperty( keyName ) ) {
 			return state;
 		}
 

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -78,12 +78,21 @@ export const keyedReducer = ( keyName, reducer ) => {
 	const initialState = reducer( undefined, { type: '@@calypso/INIT' } );
 
 	return ( state = {}, action ) => {
+		// some keys are invalid
+		if (
+			null === keyName ||
+			undefined === keyName ||
+			! action.hasOwnProperty( keyName ) // don't allow coercion of key name: null => 0
+		) {
+			return state;
+		}
+
 		// the action must refer to some item in the map
 		const itemKey = action[ keyName ];
 
-		// if no reference exists abort
-		// and return unchanged state
-		if ( ! itemKey ) {
+		// if the action doesn't contain a valid reference
+		// then return without any updates
+		if ( null === itemKey || undefined === itemKey ) {
 			return state;
 		}
 

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -219,9 +219,9 @@ export function createReducer( initialState = null, customHandlers = {}, schema 
  *
  * export const age = withSchemaValidation( schema, age )
  *
- * // ageReducer( -5, { type: DESERIALIZE } ) === -5
- * // age( -5, { type: DESERIALIZE } ) === 0
- * // age( 23, { type: DESERIALIZE } ) === 23
+ * ageReducer( -5, { type: DESERIALIZE } ) === -5
+ * age( -5, { type: DESERIALIZE } ) === 0
+ * age( 23, { type: DESERIALIZE } ) === 23
  *
  * @param {object} schema JSON-schema description of state
  * @param {function} reducer normal reducer from ( state, action ) to new state

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -85,18 +85,18 @@ export const keyedReducer = ( keyName, reducer ) => ( state = {}, action ) => {
 	}
 
 	// pass the old sub-state from that item into the reducer
-	const oldState = state[ itemKey ];
-	const newState = reducer( oldState, action );
+	const oldItemState = state[ itemKey ];
+	const newItemState = reducer( oldItemState, action );
 
 	// and do nothing if the new sub-state matches the old sub-state
-	if ( newState === oldState ) {
+	if ( newItemState === oldItemState ) {
 		return state;
 	}
 
 	// otherwise immutably update the super-state
 	return {
 		...state,
-		[ itemKey ]: newState,
+		[ itemKey ]: newItemState,
 	};
 };
 
@@ -231,7 +231,7 @@ export const withSchemaValidation = ( schema, reducer ) => ( state, action ) => 
 	if ( DESERIALIZE === action.type ) {
 		return state && isValidStateWithSchema( state, schema )
 			? state
-			: reducer( undefined, { type: '@@dummy/INIT' } );
+			: reducer( undefined, { type: '@@calypso/INIT' } );
 	}
 
 	return reducer( state, action );

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -75,15 +75,24 @@ export function isValidStateWithSchema( state, schema ) {
  * @return {function} super-reducer applying reducer over map of keyed items
  */
 export const keyedReducer = ( keyName, reducer ) => {
+	// some keys are invalid
+	if ( 'string' !== typeof keyName ) {
+		throw new TypeError( `Key name passed into ``keyedReducer`` must be a string but I detected a ${ typeof keyName }` );
+	}
+
+	if ( ! keyName.length ) {
+		throw new TypeError( 'Key name passed into `keyedReducer` must have a non-zero length but I detected an empty string' );
+	}
+
+	if ( 'function' !== typeof reducer ) {
+		throw new TypeError( `Reducer passed into ``keyedReducer`` must be a function but I detected a ${ typeof reducer }` );
+	}
+
 	const initialState = reducer( undefined, { type: '@@calypso/INIT' } );
 
 	return ( state = {}, action ) => {
-		// some keys are invalid
-		if (
-			null === keyName ||
-			undefined === keyName ||
-			! action.hasOwnProperty( keyName ) // don't allow coercion of key name: null => 0
-		) {
+		// don't allow coercion of key name: null => 0
+		if ( ! action.hasOwnProperty( keyName )  ) {
 			return state;
 		}
 


### PR DESCRIPTION
Creates two new helpers to be used in #9914 for managing state and
creating reducers that are idiomatic to Redux.

 - `keyedReducer()` for managing collections of keyed items
 - `withValidation()` for wrapping reducers in state validation

There are no functional or visual changes introduced in this PR. It merely adds new functionality to be used by later PRs.

**Tests to come next**