### PR TITLE
Reader: Fix cards and in-stream recs cropped in IE 11

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -123,6 +123,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			}
 
 			.reader-post-card__post-details {
+				flex: 0 auto;
 				margin-top: -10px;
 			}
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -123,7 +123,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			}
 
 			.reader-post-card__post-details {
-				flex: 0 auto;
+				flex: 0 auto; // IE11 Photo card actions hidden
 				margin-top: -10px;
 			}
 
@@ -166,13 +166,16 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		}
 
 		.reader-post-card__post-details {
+			flex: 1;
 
 			@media #{$reader-post-card-breakpoint-medium} {
+				flex: 0 auto;
 				margin-top: 7px;
 				width: 100%;
 			}
 
 			@media #{$reader-post-card-breakpoint-small} {
+				flex: 0 auto;
 				margin-top: 7px;
 				width: 100%;
 			}
@@ -317,7 +320,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	margin-top: 14px;
 
 	.reader-post-card__post-details {
-		flex: 1;
+		flex: 0 auto;
 	}
 
 	@media #{$reader-post-card-breakpoint-large} {

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -116,7 +116,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 .reader-related-card-v2.card.is-compact {
 	box-shadow: none;
-	flex: 1;
+	flex: 1 1 auto;
 	padding: 0;
 
 	@include breakpoint( "<480px" ) {

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -116,7 +116,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 .reader-related-card-v2.card.is-compact {
 	box-shadow: none;
-	flex: 1 1 auto;
+	flex: 1;
 	padding: 0;
 
 	@include breakpoint( "<480px" ) {

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -128,6 +128,11 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		display: flex;
 		flex-direction: column;
 	}
+
+	@media #{$reader-related-card-v2-breakpoint-small} {
+		display: flex;
+		flex-direction: column;
+	}
 }
 
 .reader-related-card-v2.card {

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -510,13 +510,6 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 				top: -10px;
 			}
 		}
-
-		&.has-thumbnail {
-
-			.gridicon {
-
-			}
-		}
 	}
 
 	.card.reader-related-card-v2 {

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -451,7 +451,8 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 }
 
 .reader-stream__recommended-posts-list-item {
-	flex: 1;
+	display: flex;
+	flex: 1 1 auto;
 	flex-direction: column;
 	list-style-type: none;
 	position: relative;

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -451,55 +451,70 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 }
 
 .reader-stream__recommended-posts-list-item {
-	display: flex;
-	flex: 1;
-	flex-direction: column;
 	list-style-type: none;
+	position: relative;
+	width: 50%;
 	position: relative;
 		top: -40px;
 
 	@media #{$reader-related-card-v2-breakpoint-medium} {
 		flex-direction: row;
 		top: 0;
+		width: 100%;
 	}
 
 	@media #{$reader-related-card-v2-breakpoint-small} {
 		flex-direction: row;
 		top: 0;
+		width: 100%;
 	}
 
 	.reader-stream__recommended-post-dismiss {
-		display: flex;
-		justify-content: flex-end;
+		height: 30px;
 
-		@media #{$reader-related-card-v2-breakpoint-medium} {
-			flex-grow: 1;
-			align-self: baseline;
-			justify-content: flex-start;
+		.button {
+			float: right;
+
+			@media #{$reader-related-card-v2-breakpoint-medium} {
+				float: none;
+			}
+
+			@media #{$reader-related-card-v2-breakpoint-small} {
+				float: none;
+			}
 		}
 
-		@include breakpoint( "<660px" ) {
-			justify-content: flex-end;
+		@media #{$reader-related-card-v2-breakpoint-medium} {
+			float: left;
+			position: relative;
+			width: 20px;
 		}
 
 		@media #{$reader-related-card-v2-breakpoint-small} {
-			flex-grow: 1;
-			align-self: baseline;
-			justify-content: flex-start;
+			float: left;
+			position: relative;
+			width: 20px;
 		}
 
 		.gridicon {
 			fill: lighten( $gray, 10% );
 			width: 14px;
 			height: 14px;
-			top: 0;
+			top: -3px;
 
 			@media #{$reader-related-card-v2-breakpoint-medium} {
-				top: 4px;
+				top: -10px;
 			}
 
 			@media #{$reader-related-card-v2-breakpoint-small} {
-				top: 4px;
+				top: -10px;
+			}
+		}
+
+		&.has-thumbnail {
+
+			.gridicon {
+
 			}
 		}
 	}
@@ -509,11 +524,57 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		padding-top: 10px;
 
 		@media #{$reader-related-card-v2-breakpoint-medium} {
-			flex-grow: 40;
+			padding-top: 0;
 		}
 
 		@media #{$reader-related-card-v2-breakpoint-small} {
-			flex-grow: 40;
+			padding-top: 0;
+		}
+
+		&.has-thumbnail {
+
+			.reader-related-card-v2__meta {
+				margin-bottom: 15px;
+
+				@media #{$reader-related-card-v2-breakpoint-medium} {
+					margin-top: -2px;
+				}
+
+				@media #{$reader-related-card-v2-breakpoint-small} {
+					margin-top: -2px;
+				}
+			}
+
+			.reader-related-card-v2__meta .follow-button {
+				margin-top: -7px;
+			}
+
+			.reader-related-card-v2__meta .gravatar {
+				margin: 3px 8px 0 0;
+			}
+
+			.reader-related-card-v2__site-info {
+
+				@media #{$reader-related-card-v2-breakpoint-small} {
+					margin-top: 50px;
+				}
+
+				@media #{$reader-related-card-v2-breakpoint-medium} {
+					margin-top: 50px;
+				}
+			}
+
+			.reader-related-card-v2__post {
+				max-height: 200px;
+
+				@media #{$reader-related-card-v2-breakpoint-small} {
+					max-height: 150px;
+				}
+
+				@media #{$reader-related-card-v2-breakpoint-medium} {
+					max-height: 150px;
+				}
+			}
 		}
 	}
 
@@ -566,44 +627,6 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 		.reader-related-card-v2__excerpt {
 			-webkit-line-clamp: initial;
-		}
-	}
-
-	.has-thumbnail {
-
-		.reader-related-card-v2__meta {
-			margin-bottom: 15px;
-		}
-
-		.reader-related-card-v2__meta .follow-button {
-			margin-top: -7px;
-		}
-
-		.reader-related-card-v2__meta .gravatar {
-			margin: 3px 8px 0 0;
-		}
-
-		.reader-related-card-v2__site-info {
-
-			@media #{$reader-related-card-v2-breakpoint-small} {
-				margin-top: 50px;
-			}
-
-			@media #{$reader-related-card-v2-breakpoint-medium} {
-				margin-top: 50px;
-			}
-		}
-
-		.reader-related-card-v2__post {
-			max-height: 200px;
-
-			@media #{$reader-related-card-v2-breakpoint-small} {
-				max-height: 150px;
-			}
-
-			@media #{$reader-related-card-v2-breakpoint-medium} {
-				max-height: 150px;
-			}
 		}
 	}
 

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -452,7 +452,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 .reader-stream__recommended-posts-list-item {
 	display: flex;
-	flex: 1 1 auto;
+	flex: 1 1 0%;
 	flex-direction: column;
 	list-style-type: none;
 	position: relative;

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -451,7 +451,6 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 }
 
 .reader-stream__recommended-posts-list-item {
-	display: flex;
 	flex: 1;
 	flex-direction: column;
 	list-style-type: none;

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -452,7 +452,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 .reader-stream__recommended-posts-list-item {
 	display: flex;
-	flex: 1 1 0%;
+	flex: 1;
 	flex-direction: column;
 	list-style-type: none;
 	position: relative;

--- a/client/reader/stream/recommended-posts.jsx
+++ b/client/reader/stream/recommended-posts.jsx
@@ -89,12 +89,13 @@ export class RecommendedPosts extends React.PureComponent {
 							( post, index ) => {
 								const uiIndex = this.props.index + index;
 								return ( <li className="reader-stream__recommended-posts-list-item" key={ post.global_ID }>
-									<Button borderless
+									<div className="reader-stream__recommended-post-dismiss">
+										<Button borderless
 										title={ this.props.translate( 'Dismiss this recommendation' ) }
-										className="reader-stream__recommended-post-dismiss"
 										onClick={ partial( dismissRecommendation, uiIndex, this.props.storeId, post ) }>
 										<Gridicon icon="cross" size={ 14 } />
-									</Button>
+										</Button>
+									</div>
 									<RelatedPostCard
 										post={ post }
 										onPostClick={ partial( handlePostClick, uiIndex ) }


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/9917

**Photo card before:**
![screenshot 2016-12-12 12 30 23](https://cloud.githubusercontent.com/assets/4924246/21118430/b89ebc08-c072-11e6-9a94-1c5f5ebb7596.png)

**Photo card after:**
![screenshot 2016-12-12 12 30 07](https://cloud.githubusercontent.com/assets/4924246/21118433/bf3f9aa0-c072-11e6-993f-3a939ff2af7c.png)

**In-stream recs before:**
![screenshot 2016-12-12 13 50 23](https://cloud.githubusercontent.com/assets/4924246/21118442/c6d86116-c072-11e6-9c65-d6e8a32291a7.png)

**In-stream recs after:**
![screenshot 2016-12-12 13 50 44](https://cloud.githubusercontent.com/assets/4924246/21118447/cb043cce-c072-11e6-8edc-cde94dc513c0.png)
