### PR TITLE
Themes: Add QueryTheme component to upload page

### DIFF
--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -29,7 +29,7 @@ const ThanksModal = React.createClass( {
 
 	propTypes: {
 		// Where is the modal being used?
-		source: React.PropTypes.oneOf( [ 'details', 'list' ] ).isRequired,
+		source: React.PropTypes.oneOf( [ 'details', 'list', 'upload' ] ).isRequired,
 		// Connected props
 		isActivating: React.PropTypes.bool.isRequired,
 		hasActivated: React.PropTypes.bool.isRequired,

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -83,6 +83,7 @@ class Upload extends React.Component {
 		const { translate, uploadedTheme, themeId } = this.props;
 		notices.success( translate( 'Successfully uploaded theme %(name)s', {
 			args: {
+				// using themeId lets us show a message before theme data arrives
 				name: uploadedTheme ? uploadedTheme.name : themeId
 			}
 		} ) );

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -18,7 +18,8 @@ import DropZone from 'components/drop-zone';
 import ProgressBar from 'components/progress-bar';
 import Button from 'components/button';
 import ThanksModal from 'my-sites/themes/thanks-modal';
-// Necessary for ThanksModal (QueryTheme not needed, since we've stored upload details)
+import QueryTheme from 'components/data/query-theme';
+// Necessary for ThanksModal
 import QueryActiveTheme from 'components/data/query-active-theme';
 import { localize } from 'i18n-calypso';
 import notices from 'notices';
@@ -79,10 +80,10 @@ class Upload extends React.Component {
 	}
 
 	successMessage() {
-		const { translate, uploadedTheme } = this.props;
+		const { translate, uploadedTheme, themeId } = this.props;
 		notices.success( translate( 'Successfully uploaded theme %(name)s', {
 			args: {
-				name: uploadedTheme.name
+				name: uploadedTheme ? uploadedTheme.name : themeId
 			}
 		} ) );
 	}
@@ -210,10 +211,21 @@ class Upload extends React.Component {
 	}
 
 	render() {
-		const { translate, inProgress, complete, failed, siteId, selectedSite } = this.props;
+		const {
+			translate,
+			inProgress,
+			complete,
+			failed,
+			siteId,
+			selectedSite,
+			themeId,
+			uploadedTheme,
+		} = this.props;
+
 		return (
 			<Main>
 				<QueryActiveTheme siteId={ siteId } />
+				{ themeId && <QueryTheme siteId={ siteId } themeId={ themeId } /> }
 				<ThanksModal
 					site={ selectedSite }
 					source="upload" />
@@ -221,7 +233,7 @@ class Upload extends React.Component {
 				<Card>
 					{ ! inProgress && ! complete && this.renderDropZone() }
 					{ inProgress && this.renderProgressBar() }
-					{ complete && ! failed && this.renderTheme() }
+					{ complete && ! failed && uploadedTheme && this.renderTheme() }
 				</Card>
 			</Main>
 		);
@@ -250,6 +262,7 @@ export default connect(
 			inProgress: isUploadInProgress( state, siteId ),
 			complete: isUploadComplete( state, siteId ),
 			failed: hasUploadFailed( state, siteId ),
+			themeId,
 			uploadedTheme: getTheme( state, siteId, themeId ),
 			error: getUploadError( state, siteId ),
 			progressTotal: getUploadProgressTotal( state, siteId ),


### PR DESCRIPTION
Necessary for automated transfers because theme details are not passed back by the transfer endpoint as they are with the upload endpoint.

We can add placeholders whilst the theme details load in a separate PR.

**To Test**
Automated transfers from this page are not yet supported, but we can simulate the scenario where we don't have full theme details until complete transfer by testing a theme upload on a Jetpack site with [this line](https://github.com/Automattic/wp-calypso/blob/34ea9257713618f1ac2473a8ca92587496eb574a/client/state/themes/actions.js#L514) commented out:
```
//dispatch( receiveTheme( theme, siteId ) );
```

* Needs a .org site with Jetpack > 4.4
* Go to http://calypso.localhost:3000/design/upload/{jetpack site}
* Select or drag a theme zip to upload

Expected:
Theme should upload to jetpack site and show theme details


