### PR TITLE
Reader Refresh: Fix for IE11 cropping gallery cards

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -218,6 +218,13 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	width: 100%;
 }
 
+/* Fix for IE11 unable to handle nested flexbox min-height.
+ * See issue: https://github.com/Automattic/wp-calypso/issues/9412 
+ */
+.is-reader-page .reader-post-card__gallery .reader-post-card__post-details {
+	flex: inherit;
+}
+
 .reader-post-card__byline-author-site {
 	overflow: hidden;
 	position: relative;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -219,9 +219,9 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 /* Fix for IE11 unable to handle nested flexbox min-height.
- * See issue: https://github.com/Automattic/wp-calypso/issues/9412 
+ * See issue: https://github.com/Automattic/wp-calypso/issues/9412
  */
-.is-reader-page .reader-post-card__gallery .reader-post-card__post-details {
+.is-reader-page .reader-post-card__post .reader-post-card__post-details {
 	flex: inherit;
 }
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -221,7 +221,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 /* Fix for IE11 unable to handle nested flexbox min-height.
  * See issue: https://github.com/Automattic/wp-calypso/issues/9412
  */
-.is-reader-page .reader-post-card__post .reader-post-card__post-details {
+.is-reader-page .reader-post-card.is-gallery .reader-post-card__post-details {
 	flex: inherit;
 }
 


### PR DESCRIPTION
Attempt to fix the gallery crop issue in IE11 as described in #9412.
