### PR TITLE
TaxonomyManager: Hide View Posts link for jetpack sites.

### DIFF
--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -18,7 +18,7 @@ import Count from 'components/count';
 import Dialog from 'components/dialog';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSettings } from 'state/site-settings/selectors';
-import { getSite } from 'state/sites/selectors';
+import { getSite, isJetpackSite } from 'state/sites/selectors';
 import { deleteTerm } from 'state/terms/actions';
 import { saveSiteSettings } from 'state/site-settings/actions';
 import { decodeEntities } from 'lib/formatting';
@@ -36,6 +36,7 @@ class TaxonomyManagerListItem extends Component {
 		translate: PropTypes.func,
 		siteUrl: PropTypes.string,
 		slug: PropTypes.string,
+		isJetpack: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -111,7 +112,7 @@ class TaxonomyManagerListItem extends Component {
 	};
 
 	render() {
-		const { canSetAsDefault, isDefault, onClick, term, translate } = this.props;
+		const { canSetAsDefault, isDefault, onClick, term, translate, isJetpack } = this.props;
 		const className = classNames( 'taxonomy-manager__item', {
 			'is-default': isDefault
 		} );
@@ -156,9 +157,11 @@ class TaxonomyManagerListItem extends Component {
 							{ translate( 'Delete' ) }
 						</PopoverMenuItem>
 					}
-					<PopoverMenuItem href={ this.getTaxonomyLink() } icon="external">
-						{ translate( 'View Posts' ) }
-					</PopoverMenuItem>
+					{ ! isJetpack &&
+						<PopoverMenuItem href={ this.getTaxonomyLink() } icon="external">
+							{ translate( 'View Posts' ) }
+						</PopoverMenuItem>
+					}
 					{ canSetAsDefault && ! isDefault && <PopoverMenuSeparator /> }
 					{ canSetAsDefault && ! isDefault &&
 						<PopoverMenuItem onClick={ this.setAsDefault } icon="checkmark-circle">
@@ -187,6 +190,7 @@ export default connect(
 		const siteUrl = get( getSite( state, siteId ), 'URL' );
 
 		return {
+			isJetpack: isJetpackSite( state, siteId ),
 			isDefault,
 			canSetAsDefault,
 			siteId,


### PR DESCRIPTION
For #9927 - The "View Posts" link for a term in the Taxonomy Manager assumes the taxonomy slug ( i.e. `category` ) can be used to display a post listing by term on the website.  In Jetpack/.org sites though, a site can customize a `category_base` and `tag_base`.  

Currently, we are not returning the `category_base` or `tag_base` from the site endpoints so we unfortunately do not have a way to properly link to these Jetpack sites that have customized these "term base" options.

I _believe_ this might be the reason why the "Tags & Categories" module on the Stats Insights page is hidden on Jetpack sites too.

Instead of letting this issue hold up the release of the Taxonomy Manager, I'm opting to hide this "View Posts" link on Jetpack sites within Calypso until we have access to the appropriate site options and can correctly render these links.

__To Test__
- Open either categories or tags from the Site Settings > Writing page for a WPCOM site
- Click the ellipsis menu for a term, verify the View Posts link is still shown
- Do the same on a Jetpack site, but verify the View Posts link is not shown