### PR TITLE
Fix for IE11 Photo Cards & In-Stream Recs

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -598,3 +598,8 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 .is-section-devdocs .reader-post-card__featured-image {
 	bottom: 16px;
 }
+
+// IE11 fix for photo cards
+.is-reader-page .reader-post-card.is-photos .reader-post-card__post-details {
+	flex: none;
+}

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -515,3 +515,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	margin-top: 20px;
 	padding-top: 20px;
 }
+// IE11 fix for in-stream recs
+.is-reader-page .reader-stream__recommended-posts-list-item .reader-related-card-v2 {
+	flex: none;
+}


### PR DESCRIPTION
attempt at fixing: https://github.com/Automattic/wp-calypso/issues/9917

solution: remove flex at the deepest possible element where it has no effect on layout