### PR TITLE
Data Layer: Use null-prototype object for performance

### DIFF
--- a/client/state/data-layer/utils.js
+++ b/client/state/data-layer/utils.js
@@ -25,5 +25,5 @@ const concatHandlers = ( left, right ) =>
 
 export const mergeHandlers = ( ...handlers ) =>
 	handlers.length > 1
-		? mergeWith( {}, ...handlers, concatHandlers )
+		? mergeWith( Object.create( null ), ...handlers, concatHandlers )
 		: handlers[ 0 ];


### PR DESCRIPTION
After some discussion this was seen as a way to improve performance by
speeding up property lookup and to improve safety by removing the
ability to catch on action with types like `value` or `toString`