### PR TITLE
Reader Refresh: Vimeo support

### DIFF
--- a/client/blocks/reader-post-card/featured-video.jsx
+++ b/client/blocks/reader-post-card/featured-video.jsx
@@ -93,7 +93,8 @@ class FeaturedVideo extends React.Component {
 	}
 }
 
-export default connect(
-	( state, ownProps ) => ( {
-		thumbnailUrl: getThumbnailForIframe( state, ownProps.videoEmbed.src ),
-	} ) )( localize( FeaturedVideo ) );
+const mapStateToProps = ( state, ownProps ) => ( {
+	thumbnailUrl: getThumbnailForIframe( state, ownProps.videoEmbed.src ),
+} );
+
+export default connect( mapStateToProps )( localize( FeaturedVideo ) );

--- a/client/blocks/reader-post-card/featured-video.jsx
+++ b/client/blocks/reader-post-card/featured-video.jsx
@@ -2,15 +2,17 @@
  * External Dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import { throttle, constant } from 'lodash';
 import ReactDom from 'react-dom';
 import { localize } from 'i18n-calypso';
-
 /**
  * Internal Dependencies
  */
 import EmbedHelper from 'reader/embed-helper';
 import FeaturedImage from './featured-image';
+import { getThumbnailForIframe } from 'state/reader/thumbnails/selectors';
+import QueryReaderThumbnail from 'components/data/query-reader-thumbnails';
 
 class FeaturedVideo extends React.Component {
 
@@ -73,18 +75,25 @@ class FeaturedVideo extends React.Component {
 						src="/calypso/images/reader/play-icon.png"
 						title={ translate( 'Play Video' ) }
 					/>
+				<QueryReaderThumbnail embedUrl={ this.props.videoEmbed.src } />
 				</FeaturedImage>
 			);
 		}
 
 		/* eslint-disable react/no-danger */
 		return (
-			<div ref={ this.setVideoEmbedRef } className="reader-post-card__video"
-				dangerouslySetInnerHTML={ { __html: thumbnailUrl ? autoplayIframe : iframe } }
-			/>
+			<div>
+				<QueryReaderThumbnail embedUrl={ this.props.videoEmbed.src } />
+				<div ref={ this.setVideoEmbedRef } className="reader-post-card__video"
+					dangerouslySetInnerHTML={ { __html: thumbnailUrl ? autoplayIframe : iframe } }
+				/>
+			</div>
 		);
 		/* eslint-enable-line react/no-danger */
 	}
 }
 
-export default localize( FeaturedVideo );
+export default connect(
+	( state, ownProps ) => ( {
+		thumbnailUrl: getThumbnailForIframe( state, ownProps.videoEmbed.src ),
+	} ) )( localize( FeaturedVideo ) );

--- a/client/blocks/reader-post-card/featured-video.jsx
+++ b/client/blocks/reader-post-card/featured-video.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import { throttle, constant } from 'lodash';
 import ReactDom from 'react-dom';
 import { localize } from 'i18n-calypso';
+
 /**
  * Internal Dependencies
  */

--- a/client/blocks/reader-post-card/featured-video.jsx
+++ b/client/blocks/reader-post-card/featured-video.jsx
@@ -84,9 +84,14 @@ class FeaturedVideo extends React.Component {
 		return (
 			<div>
 				<QueryReaderThumbnail embedUrl={ this.props.videoEmbed.src } />
-				<div ref={ this.setVideoEmbedRef } className="reader-post-card__video"
-					dangerouslySetInnerHTML={ { __html: thumbnailUrl ? autoplayIframe : iframe } }
-				/>
+
+				// if we couldn't retrieve a thumbnail that usually means there was an issue
+				// with the video and we shouldn't display it
+				{ this.props.thumbnailUrl &&
+					<div ref={ this.setVideoEmbedRef } className="reader-post-card__video"
+						dangerouslySetInnerHTML={ { __html: thumbnailUrl ? autoplayIframe : iframe } }
+					/>
+				}
 			</div>
 		);
 		/* eslint-enable-line react/no-danger */

--- a/client/blocks/reader-post-card/featured-video.jsx
+++ b/client/blocks/reader-post-card/featured-video.jsx
@@ -76,19 +76,19 @@ class FeaturedVideo extends React.Component {
 						src="/calypso/images/reader/play-icon.png"
 						title={ translate( 'Play Video' ) }
 					/>
-				<QueryReaderThumbnail embedUrl={ this.props.videoEmbed.src } />
 				</FeaturedImage>
 			);
 		}
+
+		// if we can't retrieve a thumbnail that means there was an issue
+		// with the embed and we shouldn't display it
+		const showEmbed = !! this.props.thumbnailUrl;
 
 		/* eslint-disable react/no-danger */
 		return (
 			<div>
 				<QueryReaderThumbnail embedUrl={ this.props.videoEmbed.src } />
-
-				// if we couldn't retrieve a thumbnail that usually means there was an issue
-				// with the video and we shouldn't display it
-				{ this.props.thumbnailUrl &&
+				{ showEmbed &&
 					<div ref={ this.setVideoEmbedRef } className="reader-post-card__video"
 						dangerouslySetInnerHTML={ { __html: thumbnailUrl ? autoplayIframe : iframe } }
 					/>

--- a/client/components/data/query-reader-thumbnails/README.md
+++ b/client/components/data/query-reader-thumbnails/README.md
@@ -1,0 +1,28 @@
+Query Reader Thumbnails
+========================
+
+`<QueryReaderThumbnails />` is a React component used in managing network requests for Reader thumbnail urls.
+
+## Usage
+
+Render the component. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+
+// TODO iframe --> embed
+```jsx
+import React from 'react';
+import QueryReaderThumbnails from 'components/data/query-reader-thumbnail';
+import getThumbnailForIframe;
+
+function MyFeaturedAsset( { embedUrl, thumbnailUrl } ) {
+	return (
+		<div>
+			<QueryReaderThumbnails embedUrl={ embedUrl } } />
+			<image src={ thumbnailUrl } />
+		</div>
+	);
+}
+
+connect( ( state, ownProps) => ( {
+	thumbnailUrl: getThumbnailForIframe( state, ownProps.embedUrl ),
+	} ) )( MyFeaturedAsset );
+```

--- a/client/components/data/query-reader-thumbnails/README.md
+++ b/client/components/data/query-reader-thumbnails/README.md
@@ -7,7 +7,6 @@ Query Reader Thumbnails
 
 Render the component. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
-// TODO iframe --> embed
 ```jsx
 import React from 'react';
 import QueryReaderThumbnails from 'components/data/query-reader-thumbnail';

--- a/client/components/data/query-reader-thumbnails/index.jsx
+++ b/client/components/data/query-reader-thumbnails/index.jsx
@@ -13,10 +13,20 @@ import { requestThumbnail } from 'state/reader/thumbnails/actions';
 
 class QueryReaderThumbnails extends Component {
 	componentWillMount() {
-		if ( ! this.props.shouldRequestThumbnail || ! this.props.embedUrl ) {
+		this.request( this.props );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.embedUrl !== this.props.embedUrl ) {
+			this.request( nextProps );
+		}
+	}
+
+	request( props ) {
+		if ( ! props.shouldRequestThumbnail || ! props.embedUrl ) {
 			return;
 		}
-		this.props.requestThumbnail( this.props.embedUrl );
+		props.requestThumbnail( props.embedUrl );
 	}
 
 	render() {

--- a/client/components/data/query-reader-thumbnails/index.jsx
+++ b/client/components/data/query-reader-thumbnails/index.jsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import { getThumbnailForIframe } from 'state/reader/thumbnails/selectors';
+import { requestThumbnail } from 'state/reader/thumbnails/actions';
+
+class QueryReaderThumbnails extends Component {
+	componentWillMount() {
+		if ( ! this.props.shouldRequestThumbnail || ! this.props.embedUrl ) {
+			return;
+		}
+		this.props.requestThumbnail( this.props.embedUrl );
+	}
+
+	render() {
+		return null;
+	}
+}
+
+QueryReaderThumbnails.propTypes = {
+	shouldRequestThumbnail: PropTypes.bool,
+	requestThumbnail: PropTypes.func
+};
+
+export default connect(
+	( state, ownProps ) => {
+		return {
+			shouldRequestThumbnail: ! getThumbnailForIframe( state, ownProps.embedUrl )
+		};
+	},
+	( dispatch ) => {
+		return bindActionCreators( {
+			requestThumbnail
+		}, dispatch );
+	}
+)( QueryReaderThumbnails );

--- a/client/components/data/query-reader-thumbnails/index.jsx
+++ b/client/components/data/query-reader-thumbnails/index.jsx
@@ -29,15 +29,15 @@ QueryReaderThumbnails.propTypes = {
 	requestThumbnail: PropTypes.func
 };
 
+const mapStateToProps = ( state, ownProps ) => ( {
+	shouldRequestThumbnail: ! getThumbnailForIframe( state, ownProps.embedUrl ),
+} );
+
+const mapDispatchToProps = ( dispatch ) => (
+	bindActionCreators( { requestThumbnail }, dispatch )
+);
+
 export default connect(
-	( state, ownProps ) => {
-		return {
-			shouldRequestThumbnail: ! getThumbnailForIframe( state, ownProps.embedUrl )
-		};
-	},
-	( dispatch ) => {
-		return bindActionCreators( {
-			requestThumbnail
-		}, dispatch );
-	}
+	mapStateToProps,
+	mapDispatchToProps,
 )( QueryReaderThumbnails );

--- a/client/lib/post-normalizer/rule-content-detect-media.js
+++ b/client/lib/post-normalizer/rule-content-detect-media.js
@@ -109,12 +109,9 @@ const detectEmbed = ( iframe ) => {
 	const height = Number( iframe.height );
 	const aspectRatio = width / height;
 
-	const embedUrl = iframe.getAttribute( 'data-wpcom-embed-url' );
-
 	return {
 		type: getEmbedType( iframe ),
 		src: iframe.src,
-		embedUrl,
 		iframe: iframe.outerHTML,
 		aspectRatio: aspectRatio,
 		width: width,

--- a/client/lib/post-normalizer/rule-content-detect-media.js
+++ b/client/lib/post-normalizer/rule-content-detect-media.js
@@ -67,7 +67,7 @@ const detectImage = ( image ) => {
  */
 const getAutoplayIframe = ( iframe ) => {
 	const metadata = getEmbedMetadata( iframe.src );
-	if ( metadata && metadata.service === 'youtube' ) {
+	if ( metadata && ( metadata.service === 'youtube' || metadata.service === 'vimeo' ) ) {
 		const autoplayIframe = iframe.cloneNode();
 		if ( autoplayIframe.src.indexOf( '?' ) === -1 ) {
 			autoplayIframe.src += '?autoplay=1';
@@ -76,23 +76,6 @@ const getAutoplayIframe = ( iframe ) => {
 		}
 		return autoplayIframe.outerHTML;
 	}
-	return null;
-};
-
-/** For an iframe we know how to process, return the url of a thumbnail
- * @param {Node} iframe - the DOM node for the iframe
- * @returns {string} thumbnailUrl - the url for a thumbnail of the video, null if we cannot determine it
- */
-const getThumbnailUrl = ( iframe ) => {
-	const metadata = getEmbedMetadata( iframe.src );
-	if ( ! metadata ) {
-		return null;
-	}
-
-	if ( metadata.service === 'youtube' ) {
-		return `https://img.youtube.com/vi/${ metadata.id }/mqdefault.jpg`;
-	}
-
 	return null;
 };
 
@@ -138,7 +121,6 @@ const detectEmbed = ( iframe ) => {
 		height: height,
 		mediaType: 'video',
 		autoplayIframe: getAutoplayIframe( iframe ),
-		thumbnailUrl: getThumbnailUrl( iframe ),
 	};
 };
 

--- a/client/lib/post-normalizer/rule-pick-canonical-media.js
+++ b/client/lib/post-normalizer/rule-pick-canonical-media.js
@@ -30,8 +30,8 @@ function isCandidateForFeature( media ) {
 	if ( media.mediaType === 'image' ) {
 		return isImageLargeEnoughForFeature( media );
 	} else if ( media.mediaType === 'video' ) {
-		// we need to have a thumbnail and know how to autoplay it
-		return media.thumbnailUrl && media.autoplayIframe;
+		// we need to know how to autoplay it which probably means we know how to get a thumbnail
+		return media.autoplayIframe;
 	}
 
 	return false;

--- a/client/state/reader/reducer.js
+++ b/client/state/reader/reducer.js
@@ -14,6 +14,7 @@ import start from './start/reducer';
 import posts from './posts/reducer';
 import relatedPosts from './related-posts/reducer';
 import tags from './tags/reducer';
+import thumbnails from './thumbnails/reducer';
 
 export default combineReducers( {
 	feeds,
@@ -23,5 +24,6 @@ export default combineReducers( {
 	start,
 	posts,
 	relatedPosts,
-	tags
+	tags,
+	thumbnails,
 } );


### PR DESCRIPTION
The final piece of the puzzle for implementing https://github.com/Automattic/wp-calypso/issues/9611 (Vimeo support for the WP Reader Video Embeds)

~It is functional in this branch but still needs some work and cleaning~

TODO:
- [x] land #10001
- [x] clean
- [x] test
- [x] handle crappy responses from apis ( 403s, unexpected values, etc) - @bluefuton 