### PR TITLE
Taxonomies: Reset the dialog state onOpen instead of onClose

### DIFF
--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -65,7 +65,6 @@ class TermFormDialog extends Component {
 		if ( this.state.saving ) {
 			return;
 		}
-		this.setState( this.constructor.initialState );
 		this.props.onClose();
 	};
 
@@ -147,7 +146,7 @@ class TermFormDialog extends Component {
 	componentWillReceiveProps( newProps ) {
 		if (
 			this.props.term !== newProps.term ||
-			this.props.showDialog !== newProps.showDialog
+			this.props.showDialog !== newProps.showDialog && newProps.showDialog
 		) {
 			this.init( newProps );
 		}


### PR DESCRIPTION
To avoid state changes while the closing animation has not finished, I moved the reset state logic to the moment we open the dialog.

closes #9966

**Testing instructions**

 * Try creating a new category. You should not see the form values changing while closing the dialog
 * Same for editing a category.
 * Make sure the form shows the right field values while switching between categories