### PR TITLE
Jetpack Connect: Retry Auth

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -246,8 +246,9 @@ const LoggedInForm = React.createClass( {
 			this.activateManageAndRedirect();
 		}
 		if ( authorizeError && this.props.authAttempts < MAX_AUTH_ATTEMPTS && ! this.retryingAuth ) {
+			const attempts = this.props.authAttempts || 0;
 			this.retryingAuth = true;
-			this.props.retryAuth( queryObject.site, this.props.authAttempts + 1 );
+			this.props.retryAuth( queryObject.site, attempts + 1 );
 		}
 	},
 
@@ -369,12 +370,20 @@ const LoggedInForm = React.createClass( {
 	},
 
 	renderNotices() {
-		const { authorizeError, queryObject } = this.props.jetpackConnectAuthorize;
+		const { authorizeError, queryObject, isAuthorizing, authorizeSuccess } = this.props.jetpackConnectAuthorize;
 		if ( queryObject.already_authorized && ! this.props.isAlreadyOnSitesList ) {
 			return <JetpackConnectNotices noticeType="alreadyConnectedByOtherUser" />;
 		}
 
-		if ( this.retryingAuth || ! authorizeError || this.props.authAttempts < MAX_AUTH_ATTEMPTS ) {
+		if ( this.retryingAuth ) {
+			return <JetpackConnectNotices noticeType="retryingAuth" />;
+		}
+
+		if ( this.props.authAttempts < MAX_AUTH_ATTEMPTS && this.props.authAttempts > 0 && ! isAuthorizing && ! authorizeSuccess ) {
+			return <JetpackConnectNotices noticeType="retryAuth" />;
+		}
+
+		if ( ! authorizeError ) {
 			return null;
 		}
 

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -82,6 +82,18 @@ export default React.createClass( {
 			noticeValues.icon = 'status';
 			return noticeValues;
 		}
+		if ( this.props.noticeType === 'retryingAuth' ) {
+			noticeValues.text = this.translate( 'Error authorizing. Page is refreshing for an other attempt.' );
+			noticeValues.status = 'is-warning';
+			noticeValues.icon = 'notice';
+			return noticeValues;
+		}
+		if ( this.props.noticeType === 'retryAuth' ) {
+			noticeValues.text = this.translate( 'In some cases, authorization can take a few attempts. Please try again.' );
+			noticeValues.status = 'is-warning';
+			noticeValues.icon = 'notice';
+			return noticeValues;
+		}
 		if ( this.props.noticeType === 'secretExpired' ) {
 			noticeValues.text = this.translate( 'Oops, that took a while. You\'ll have to try again.' );
 			noticeValues.status = 'is-error';

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -207,6 +207,7 @@ export default {
 	},
 	retryAuth( url, attemptNumber ) {
 		return ( dispatch ) => {
+			debug( 'retrying auth', url, attemptNumber );
 			dispatch( {
 				type: JETPACK_CONNECT_RETRY_AUTH,
 				attemptNumber: attemptNumber,


### PR DESCRIPTION
This PR will show better error messaging when we encounter errors during Jetpack's connection process.

Currently, when we encounter an error, we simply re-load the page, and show no indication that folks should try again. This is causing confusion, as folks believe that there is something broken on our end.

Here's what the error messages look like: 
https://cloudup.com/cYcNxrLkLjl

To test for yourself:
- run this branch locally at calypso.localhost:3000
- sandbox wordpress' API and force it return errors during connection process
- attempt to connect an unconnected jetpack site by going to calypso.localhost:3000/jetpack/connect
- ensure you see error messages
