### PR TITLE
Account Recovery: Add reset password page

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -10,6 +10,7 @@
 
 @import 'account-recovery/forgot-username/forgot-username-form/style';
 @import 'account-recovery/lost-password/lost-password-form/style';
+@import 'account-recovery/reset-password/reset-password-form/style';
 @import 'account-recovery/style';
 @import 'auth/style';
 @import 'blocks/app-promo/style';

--- a/client/account-recovery/controller.js
+++ b/client/account-recovery/controller.js
@@ -9,6 +9,7 @@ import page from 'page';
  */
 import LostPasswordPage from 'account-recovery/lost-password';
 import ForgotUsernamePage from 'account-recovery/forgot-username';
+import ResetPasswordPage from 'account-recovery/reset-password';
 import { getCurrentUser } from 'state/current-user/selectors';
 
 export function lostPassword( context, next ) {
@@ -28,6 +29,14 @@ export function redirectLoggedIn( context, next ) {
 		page.redirect( '/' );
 		return;
 	}
+
+	next();
+}
+
+export function resetPassword( context, next ) {
+	context.primary = <ResetPasswordPage basePath={ context.path } />;
+
+	//TODO: Redirect to LostPasswordPage if we don't have the correct state
 
 	next();
 }

--- a/client/account-recovery/index.js
+++ b/client/account-recovery/index.js
@@ -4,6 +4,7 @@
 import {
 	lostPassword,
 	forgotUsername,
+	resetPassword,
 	redirectLoggedIn
 } from './controller';
 
@@ -11,4 +12,5 @@ export default function( router ) {
 	// Main route for account recovery is the lost password page
 	router( '/account-recovery', redirectLoggedIn, lostPassword );
 	router( '/account-recovery/forgot-username', redirectLoggedIn, forgotUsername );
+	router( '/account-recovery/reset-password', redirectLoggedIn, resetPassword );
 }

--- a/client/account-recovery/reset-password/index.jsx
+++ b/client/account-recovery/reset-password/index.jsx
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import Main from 'components/main';
+import DocumentHead from 'components/data/document-head';
+import ResetPasswordForm from './reset-password-form';
+
+export default localize( ( { className, translate, basePath } ) => (
+	<Main className={ classnames( 'reset-password', className ) }>
+		<PageViewTracker path={ basePath } title="Account Recovery > Reset Password" />
+		<DocumentHead title={ translate( 'Reset Password ‹ Account Recovery' ) } />
+		<ResetPasswordForm />
+	</Main>
+) );

--- a/client/account-recovery/reset-password/reset-password-form/index.jsx
+++ b/client/account-recovery/reset-password/reset-password-form/index.jsx
@@ -1,0 +1,117 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import { identity } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Button from 'components/button';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLegend from 'components/forms/form-legend';
+import FormLabel from 'components/forms/form-label';
+import FormRadio from 'components/forms/form-radio';
+
+export class ResetPasswordFormComponent extends Component {
+	static defaultProps = {
+		translate: identity,
+	};
+
+	static propTypes = {
+		translate: PropTypes.func.isRequired,
+	};
+
+	state = {
+		isSubmitting: false,
+		selectedResetOption: null,
+	};
+
+	submitForm = () => {
+		this.setState( { isSubmitting: true } );
+	};
+
+	onResetOptionChanged = ( event ) => {
+		this.setState( { selectedResetOption: event.currentTarget.value } );
+	};
+
+	render() {
+		const { translate } = this.props;
+		const { isSubmitting, selectedResetOption } = this.state;
+		const isPrimaryButtonEnabled = selectedResetOption && ! isSubmitting;
+
+		return (
+			<div className="reset-password-form">
+				<h2 className="reset-password-form__title">
+					{ translate( 'Reset your password' ) }
+				</h2>
+				<p>
+					{ translate(
+						'To reset your password and recover access to your account, ' +
+						'select one of these options and follow the instructions.'
+					) }
+				</p>
+				<Card>
+					<FormFieldset className="reset-password-form__field-set">
+						<FormLegend className="reset-password-form__legend">
+							{ translate( 'How would you like to reset your password?' ) }
+						</FormLegend>
+						<FormLabel>
+							<FormRadio
+								className="reset-password-form__primary-email-option"
+								value="primaryEmail"
+								checked={ 'primaryEmail' === selectedResetOption }
+								disabled={ isSubmitting }
+								onChange={ this.onResetOptionChanged } />
+							<span>
+								{ translate(
+									'Email a reset link to {{strong}}your main email address{{/strong}}',
+									{ components: { strong: <strong /> } }
+								) }
+							</span>
+						</FormLabel>
+						<FormLabel>
+							<FormRadio
+								className="reset-password-form__secondary-email-option"
+								value="secondaryEmail"
+								checked={ 'secondaryEmail' === selectedResetOption }
+								disabled={ isSubmitting }
+								onChange={ this.onResetOptionChanged } />
+							<span>
+								{ translate(
+									'Email a reset link to {{strong}}your recovery email address{{/strong}}',
+									{ components: { strong: <strong /> } }
+								) }
+							</span>
+						</FormLabel>
+						<FormLabel>
+							<FormRadio
+								className="reset-password-form__sms-option"
+								value="sms"
+								checked={ 'sms' === selectedResetOption }
+								disabled={ isSubmitting }
+								onChange={ this.onResetOptionChanged } />
+							<span>
+								{ translate(
+									'Send a reset code to {{strong}}your phone{{/strong}}',
+									{ components: { strong: <strong /> } }
+								) }
+							</span>
+						</FormLabel>
+					</FormFieldset>
+					<Button
+						className="reset-password-form__submit-button"
+						onClick={ this.submitForm }
+						disabled={ ! isPrimaryButtonEnabled }
+						primary>
+						{ translate( 'Continue' ) }
+					</Button>
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default localize( ResetPasswordFormComponent );

--- a/client/account-recovery/reset-password/reset-password-form/style.scss
+++ b/client/account-recovery/reset-password/reset-password-form/style.scss
@@ -1,0 +1,17 @@
+.reset-password-form__title {
+	font-size: 20px;
+	font-weight: 600;
+}
+
+.reset-password-form__submit-button.button {
+	margin-top: 16px;
+	width: 100%;
+}
+
+.reset-password-form__legend {
+	padding-bottom: 5px;
+}
+
+.reset-password-form .reset-password-form__field-set {
+	margin-bottom: 0px;
+}

--- a/client/account-recovery/reset-password/reset-password-form/test/index.jsx
+++ b/client/account-recovery/reset-password/reset-password-form/test/index.jsx
@@ -1,0 +1,95 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow, mount } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+import { ResetPasswordFormComponent } from '..';
+
+describe( 'ResetPasswordForm', () => {
+	const inputSelectors = [
+		'.reset-password-form__primary-email-option',
+		'.reset-password-form__secondary-email-option',
+		'.reset-password-form__sms-option',
+	];
+
+	it( 'should render as expected', () => {
+		const wrapper = shallow(
+			<ResetPasswordFormComponent
+				primaryEmail="test@gmail.com"
+				secondaryEmail="test@yahoo.com"
+				phoneNumber="+15555555555" />
+		);
+
+		expect( wrapper ).to.have.state( 'isSubmitting' ).to.be.false;
+
+		// Expect the radio buttons to be enabled
+		inputSelectors.forEach( selector => {
+			expect( wrapper.find( selector ).prop( 'disabled' ) ).to.not.be.ok;
+		} );
+
+		expect( wrapper.find( '.reset-password-form__submit-button' ).prop( 'disabled' ) ).to.be.ok;
+	} );
+
+	context( 'fields', () => {
+		useFakeDom();
+
+		it( 'should be disabled while submitting', function() {
+			const wrapper = mount(
+				<ResetPasswordFormComponent
+					primaryEmail="test@gmail.com"
+					secondaryEmail="test@yahoo.com"
+					phoneNumber="+15555555555" />
+			);
+			wrapper.find( '.reset-password-form__primary-email-option' ).simulate( 'change' );
+
+			// Expect the button to be enabled
+			expect( wrapper.find( '.reset-password-form__submit-button' ).prop( 'disabled' ) ).to.not.be.ok;
+
+			wrapper.find( '.reset-password-form__submit-button' ).simulate( 'click' );
+
+			expect( wrapper ).to.have.state( 'isSubmitting' ).to.be.true;
+
+			// Expect the fields to be disabled
+			inputSelectors.forEach( selector => {
+				expect( wrapper.find( selector ).prop( 'disabled' ) ).to.be.ok;
+			} );
+		} );
+	} );
+
+	context( 'submit button', () => {
+		useFakeDom();
+
+		it( 'should be disabled if no reset option is selected', function() {
+			const wrapper = mount(
+				<ResetPasswordFormComponent
+					primaryEmail="test@gmail.com"
+					secondaryEmail="test@yahoo.com"
+					phoneNumber="+15555555555" />
+			);
+
+			// Expect the button to be disabled
+			expect( wrapper.find( '.reset-password-form__submit-button' ).prop( 'disabled' ) ).to.be.ok;
+		} );
+
+		it( 'should be disabled when clicked', function() {
+			const wrapper = mount(
+				<ResetPasswordFormComponent
+					primaryEmail="test@gmail.com"
+					secondaryEmail="test@yahoo.com"
+					phoneNumber="+15555555555" />
+			);
+
+			wrapper.find( '.reset-password-form__primary-email-option' ).simulate( 'click' );
+			wrapper.find( '.reset-password-form__submit-button' ).simulate( 'click' );
+
+			expect( wrapper ).to.have.state( 'isSubmitting' ).to.be.true;
+			expect( wrapper.find( '.reset-password-form__submit-button' ).prop( 'disabled' ) ).to.be.ok;
+		} );
+	} );
+} );


### PR DESCRIPTION
# Account Recovery: add a reset password page

This pull request adds the reset password screen to the account recovery flow. This page doesn't actually do anything since the redux state tree hasn't been connected yet.

### How to test
#### Functionality
1. Navigate to http://calypso.localhost:3000/account-recovery/reset-password
2. Select an option
3. Click "Continue"
4. Notice that the form is disabled

#### automated tests

Run `npm run test-client client/account-recovery/select-password`
### What to expect
![screen shot 2016-12-14 at 2 15 38 pm](https://cloud.githubusercontent.com/assets/1854440/21197029/f0db2a34-c207-11e6-8efe-5e060eacdb57.png)
![screen shot 2016-12-13 at 3 22 02 pm](https://cloud.githubusercontent.com/assets/1854440/21157814/d5622f88-c148-11e6-8415-5b1a75ea4eaf.png)

