### PR TITLE
Plugins: Enable plugin browsing on wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -15,6 +15,7 @@
 	"features": {
 		"accept-invite": true,
 		"ad-tracking": false,
+		"automated-transfer": true,
 		"apple-pay": true,
 		"catch-js-errors": true,
 		"code-splitting": true,


### PR DESCRIPTION
Enables plugin browsing on wpcalypso for WordPress.com sites.