### PR TITLE
Framework: bump localforage to 1.4.3

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -29,7 +29,7 @@
       "version": "0.8.2"
     },
     "ajv": {
-      "version": "4.9.2",
+      "version": "4.10.0",
       "dev": true
     },
     "ajv-keywords": {
@@ -389,6 +389,9 @@
     "balanced-match": {
       "version": "0.4.2"
     },
+    "base62": {
+      "version": "0.1.1"
+    },
     "Base64": {
       "version": "0.2.1"
     },
@@ -531,7 +534,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000595"
+      "version": "1.0.30000597"
     },
     "caseless": {
       "version": "0.11.0"
@@ -598,7 +601,7 @@
       "version": "1.1.1"
     },
     "clean-css": {
-      "version": "3.4.21",
+      "version": "3.4.22",
       "dependencies": {
         "commander": {
           "version": "2.8.1"
@@ -926,7 +929,7 @@
       "version": "1.0.0"
     },
     "delegate": {
-      "version": "3.1.0"
+      "version": "3.1.1"
     },
     "delegates": {
       "version": "1.0.0"
@@ -1146,6 +1149,14 @@
       "version": "1.1.1",
       "dev": true
     },
+    "es3ify": {
+      "version": "0.1.4",
+      "dependencies": {
+        "esprima-fb": {
+          "version": "3001.1.0-dev-harmony-fb"
+        }
+      }
+    },
     "es5-ext": {
       "version": "0.10.12"
     },
@@ -1316,6 +1327,9 @@
       "version": "3.0.2",
       "dev": true
     },
+    "esmangle-evaluator": {
+      "version": "1.0.1"
+    },
     "espree": {
       "version": "3.3.2",
       "dev": true,
@@ -1424,6 +1438,14 @@
     },
     "extsprintf": {
       "version": "1.0.2"
+    },
+    "falafel": {
+      "version": "1.2.0",
+      "dependencies": {
+        "acorn": {
+          "version": "1.2.2"
+        }
+      }
     },
     "fast-future": {
       "version": "1.0.1"
@@ -1534,8 +1556,7 @@
       "version": "0.1.4"
     },
     "foreach": {
-      "version": "2.0.5",
-      "dev": true
+      "version": "2.0.5"
     },
     "foreachasync": {
       "version": "3.0.0"
@@ -1667,7 +1688,7 @@
       }
     },
     "good-listener": {
-      "version": "1.2.0"
+      "version": "1.2.1"
     },
     "got": {
       "version": "3.3.1",
@@ -1838,6 +1859,9 @@
     "imagesloaded": {
       "version": "4.1.1"
     },
+    "immediate": {
+      "version": "3.0.6"
+    },
     "immutable": {
       "version": "3.7.6"
     },
@@ -1872,6 +1896,9 @@
     },
     "ini": {
       "version": "1.3.4"
+    },
+    "inline-process-browser": {
+      "version": "1.0.0"
     },
     "inquirer": {
       "version": "0.12.0",
@@ -2213,6 +2240,17 @@
     "jstimezonedetect": {
       "version": "1.0.5"
     },
+    "jstransform": {
+      "version": "3.0.0",
+      "dependencies": {
+        "esprima-fb": {
+          "version": "3001.1.0-dev-harmony-fb"
+        },
+        "source-map": {
+          "version": "0.1.31"
+        }
+      }
+    },
     "jstransformer": {
       "version": "0.0.3"
     },
@@ -2276,6 +2314,9 @@
       "version": "0.3.0",
       "dev": true
     },
+    "lie": {
+      "version": "3.0.2"
+    },
     "load-json-file": {
       "version": "1.1.0"
     },
@@ -2288,15 +2329,7 @@
       }
     },
     "localforage": {
-      "version": "1.4.0",
-      "dependencies": {
-        "asap": {
-          "version": "1.0.0"
-        },
-        "promise": {
-          "version": "5.0.0"
-        }
-      }
+      "version": "1.4.3"
     },
     "lodash": {
       "version": "4.15.0"
@@ -2696,8 +2729,7 @@
       "dev": true
     },
     "object-keys": {
-      "version": "1.0.11",
-      "dev": true
+      "version": "1.0.11"
     },
     "object.assign": {
       "version": "4.0.4",
@@ -2753,7 +2785,7 @@
       "version": "1.0.2"
     },
     "osenv": {
-      "version": "0.1.3"
+      "version": "0.1.4"
     },
     "outlayer": {
       "version": "2.1.0"
@@ -3729,7 +3761,7 @@
       "version": "1.1.2"
     },
     "symbol-tree": {
-      "version": "3.1.4",
+      "version": "3.2.0",
       "dev": true
     },
     "sync-exec": {
@@ -3936,6 +3968,23 @@
       "version": "1.0.0",
       "dev": true
     },
+    "unreachable-branch-transform": {
+      "version": "0.3.0",
+      "dependencies": {
+        "ast-types": {
+          "version": "0.8.15"
+        },
+        "esprima-fb": {
+          "version": "15001.1001.0-dev-harmony-fb"
+        },
+        "recast": {
+          "version": "0.10.43"
+        },
+        "source-map": {
+          "version": "0.5.6"
+        }
+      }
+    },
     "unzip-response": {
       "version": "1.0.2"
     },
@@ -4047,12 +4096,12 @@
           "version": "1.3.3",
           "dev": true
         },
-        "after": {
-          "version": "0.8.1",
-          "dev": true
-        },
         "base64-arraybuffer": {
           "version": "0.1.5",
+          "dev": true
+        },
+        "base64id": {
+          "version": "1.0.0",
           "dev": true
         },
         "commander": {
@@ -4072,11 +4121,11 @@
           "dev": true
         },
         "engine.io": {
-          "version": "1.8.1",
+          "version": "1.8.2",
           "dev": true
         },
         "engine.io-client": {
-          "version": "1.8.1",
+          "version": "1.8.2",
           "dev": true,
           "dependencies": {
             "component-emitter": {
@@ -4086,14 +4135,8 @@
           }
         },
         "engine.io-parser": {
-          "version": "1.3.1",
-          "dev": true,
-          "dependencies": {
-            "has-binary": {
-              "version": "0.1.6",
-              "dev": true
-            }
-          }
+          "version": "1.3.2",
+          "dev": true
         },
         "filesize": {
           "version": "3.3.0",
@@ -4120,7 +4163,7 @@
           "dev": true
         },
         "socket.io": {
-          "version": "1.7.1",
+          "version": "1.7.2",
           "dev": true
         },
         "socket.io-adapter": {
@@ -4128,7 +4171,7 @@
           "dev": true
         },
         "socket.io-client": {
-          "version": "1.7.1",
+          "version": "1.7.2",
           "dev": true,
           "dependencies": {
             "component-emitter": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "json-loader": "0.5.4",
     "key-mirror": "1.0.1",
     "keymaster": "1.6.2",
-    "localforage": "1.4.0",
+    "localforage": "1.4.3",
     "lodash": "4.15.0",
     "lunr": "0.5.7",
     "marked": "0.3.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,6 +38,9 @@ const webpackConfig = {
 		devtoolModuleFilenameTemplate: 'app:///[resource-path]'
 	},
 	module: {
+		// avoids this warning:
+		// https://github.com/localForage/localForage/issues/577
+		noParse: /[\/\\]node_modules[\/\\]localforage[\/\\]dist[\/\\]localforage\.js$/,
 		loaders: [
 			{
 				test: /sections.js$/,


### PR DESCRIPTION
Part of #8376

Warnings were added in node [6.6.0](https://nodejs.org/en/blog/release/v6.6.0/) for unhandled promise rejections which were cluttering our test suites with messages like:
```
(node:3495) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): Error: Driver not found.
(node:3495) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 5): Error: No available storage method found.
(node:3495) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 7): Error: Driver not found.
(node:3495) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 10): Error: No available storage method found.
```

Updating to localforage latest appears to fix the unhandled promise rejections coming from the library. We should track down the rest in our code in future PRs.

### Test Instructions
- `make distclean`
- `make run`
- No functional changes
- Set debug to `localstorage.debug='calypso:state'`
- Try to clear IndexedDB, refresh page, check if things are being persisted
- Run tests `make test`, see that fewer warnings are thrown. For example the following has a warning in master but not in this branch:
```
npm run test-client client/lib/menu-data/test/menu-data.js
```


