### PR TITLE
CircleCI config: add copy of master strings to msgcat cmd

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,8 +5,17 @@ test:
   pre:
     - NODE_ENV=test make client/config/index.js:
         parallel: true
-    - case $CIRCLE_NODE_INDEX in 0) NODE_ENV=test make build-server ;; esac:
-        parallel: true
+    - ? |
+          # make the build-server and i18n string data in parallel
+          if [[ "$CIRCLE_NODE_INDEX" == 0 ]]; then NODE_ENV=test make build-server; fi
+          if ( [[ "$CIRCLE_NODE_INDEX" == 1 ]] || [[ "$CIRCLE_NODE_TOTAL" == 1 ]] ) && [[ "$CIRCLE_BRANCH" == "master" ]]; then
+            make translate
+          elif [[ "$CIRCLE_NODE_INDEX" == 1 ]] || [[ "$CIRCLE_NODE_TOTAL" == 1 ]]; then
+            git clone https://github.com/Automattic/gp-localci-client.git
+            bash gp-localci-client/generate-new-strings-pot.sh $CIRCLE_BRANCH $CIRCLE_SHA1 $CIRCLE_ARTIFACTS/translate
+            rm -rf gp-localci-client
+          fi
+      : parallel: true
   override:
     - bin/run-lint :
         parallel: true
@@ -23,18 +32,6 @@ test:
         parallel: true
   post:
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/ && find . -type f -regex  "./test-results.*\.xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;:
-        parallel: true
-    - ? |
-          if [[ $CIRCLE_NODE_INDEX == 0 ]]; then
-            make translate;
-            mkdir -p $CIRCLE_ARTIFACTS/translate;
-            cp calypso-strings.pot $CIRCLE_ARTIFACTS/translate/calypso-strings.pot;
-            if [[ $CIRCLE_BRANCH != "master" ]]; then
-              node bin/get-circle-string-artifact-url | xargs curl > $CIRCLE_ARTIFACTS/translate/calypso-strings-master.pot;
-              msgcat -u $CIRCLE_ARTIFACTS/translate/calypso-strings.pot $CIRCLE_ARTIFACTS/translate/calypso-strings-master.pot > $CIRCLE_ARTIFACTS/translate/localci-new-strings.pot;
-            fi;
-          fi;
-      :
         parallel: true
 notify:
   webhooks:


### PR DESCRIPTION
1. We concat master, branch, and copy of master to eliminate dropped strings. We only want the *new* strings coming in the branch pot and this workaround gives us exactly that. Props @akirk.
2. We move this to run in parallel with the build-server execution so we don’t delay overall build time at all. Props @debhal.
3. We switch to git checkout of master (instead of curling the last master pot) so we don’t get any new strings slipped into master since the branch occurred.

See: https://github.com/Automattic/gp-localci