### PR TITLE
Editor: decode slug for display in the editor.

### DIFF
--- a/client/post-editor/editor-slug/index.jsx
+++ b/client/post-editor/editor-slug/index.jsx
@@ -122,7 +122,7 @@ class PostEditorSlug extends Component {
 					<TrackInputChanges onNewValue={ this.recordChangeStats }>
 						<FormTextInput
 							ref="slugField"
-							value={ slug }
+							value={ decodeURI( slug ) }
 							onChange={ this.onSlugChange }
 							onKeyDown={ this.onSlugKeyDown }
 							onBlur={ this.onBlur }

--- a/client/post-editor/editor-slug/index.jsx
+++ b/client/post-editor/editor-slug/index.jsx
@@ -122,7 +122,7 @@ class PostEditorSlug extends Component {
 					<TrackInputChanges onNewValue={ this.recordChangeStats }>
 						<FormTextInput
 							ref="slugField"
-							value={ decodeURI( slug ) }
+							value={ slug }
 							onChange={ this.onSlugChange }
 							onKeyDown={ this.onSlugKeyDown }
 							onBlur={ this.onBlur }

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -401,7 +401,7 @@ export function getEditedPostSlug( state, siteId, postId ) {
 
 	// when post is published, return the slug
 	if ( isPostPublished( state, siteId, postId ) ) {
-		return postSlug;
+		return decodeURI( postSlug );
 	}
 
 	// only return suggested_slug if slug has not been edited

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -1546,6 +1546,30 @@ describe( 'selectors', () => {
 			expect( slug ).to.eql( 'chewbacca' );
 		} );
 
+		it( 'should return decoded non-latin post.slug if post is published', () => {
+			const slug = getEditedPostSlug( {
+				posts: {
+					queries: {
+						2916284: new PostQueryManager( {
+							items: {
+								841: {
+									ID: 841,
+									site_ID: 2916284,
+									global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+									status: 'publish',
+									slug: '%D7%96%D7%94%D7%95%20%D7%A2%D7%99%D7%9F%20%D7%94%D7%A0%D7%9E%D7%A8'
+								}
+							}
+						} )
+					},
+					edits: {
+					}
+				}
+			}, 2916284, 841 );
+
+			expect( slug ).to.eql( 'זהו עין הנמר' );
+		} );
+
 		it( 'should return edited slug if post is not published', () => {
 			const slug = getEditedPostSlug( {
 				posts: {


### PR DESCRIPTION
This fixes #3465 - The API returns slugs in a url encoded format, which is handy, but when non-latin characters are used in the slug, the encoded representation is subsequently shown in the editor.

__To Test__
- Create a new post in the editor, from the original issue, you can use `זהו עין הנמר` as a title to trigger the bug
- Publish the post
- Expand the sidebar or the link icon next to the title and verify the slug shown is not url encoded