### PR TITLE
Reader: fix Discover follow count + follow button alignment in IE11

### DIFF
--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -75,6 +75,7 @@
 
 		.reader-feed-header__follow {
 			display: flex;
+			flex: 1 0 auto;
 			flex-direction: row;
 			justify-content: flex-end;
 			z-index: z-index( '.reader-feed-header__back-and-follow', '.reader-feed-header__follow' );


### PR DESCRIPTION
Before: 

<img width="699" alt="screen shot 2016-12-14 at 14 35 31" src="https://cloud.githubusercontent.com/assets/17325/21166479/b95739ec-c20a-11e6-9962-bdaa7f50c3fe.png">

After:

<img width="728" alt="screen shot 2016-12-14 at 14 34 53" src="https://cloud.githubusercontent.com/assets/17325/21166482/bedd07ca-c20a-11e6-824a-0bfb278fb599.png">

### To test

Head to http://calypso.localhost:3000/discover in IE11.