### PR TITLE
Reader: fix post card header for IE Edge

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -411,7 +411,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 // 3 line excerpt for thumbnail cards
-.reader-post-card.card.has-thumbnail:not(.is-gallery):not(.is-showing-entire-excerpt) {
+.reader-post-card.card.has-thumbnail:not(.is-gallery) {
 
 	.reader-post-card__excerpt {
 		max-height: 15px * 1.6 * 3;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -253,10 +253,10 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 .reader-post-card__timestamp {
 	display: inline-table;
-	margin-right: 10px;
 }
 
 .reader-post-card__tag {
+	margin-left: 10px;
 	overflow: hidden;
 	position: relative;
 	height: 20px;
@@ -411,7 +411,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 // 3 line excerpt for thumbnail cards
-.reader-post-card.card.has-thumbnail:not(.is-gallery) {
+.reader-post-card.card.has-thumbnail:not(.is-gallery):not(.is-showing-entire-excerpt) {
 
 	.reader-post-card__excerpt {
 		max-height: 15px * 1.6 * 3;


### PR DESCRIPTION
IE Edge was wrapping the timestamp in the card header, as reported in #9904:

<img width="389" alt="screen shot 2016-12-14 at 16 55 39" src="https://cloud.githubusercontent.com/assets/17325/21169110/2c415c0e-c21e-11e6-8d40-35f1beed7b45.png">


This PR addresses the wrapping:

<img width="858" alt="screen shot 2016-12-14 at 16 51 42" src="https://cloud.githubusercontent.com/assets/17325/21169119/4827f022-c21e-11e6-9ba3-c1734c62c36e.png">

Fixes #9904.