### PR TITLE
Reader: don't line clamp full length excerpts (used on Discover)

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -411,7 +411,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 // 3 line excerpt for thumbnail cards
-.reader-post-card.card.has-thumbnail:not(.is-gallery) {
+.reader-post-card.card.has-thumbnail:not(.is-gallery):not(.is-showing-entire-excerpt) {
 
 	.reader-post-card__excerpt {
 		max-height: 15px * 1.6 * 3;


### PR DESCRIPTION
This PR fixes a regression whereby full length excerpts (as used on Discover) were being clamped to 3 lines with no fade:

<img width="877" alt="screen shot 2016-12-14 at 17 01 36" src="https://cloud.githubusercontent.com/assets/17325/21169197/0e4974ec-c21f-11e6-98bb-ede558b36e7b.png">

After:

<img width="882" alt="screen shot 2016-12-14 at 17 02 00" src="https://cloud.githubusercontent.com/assets/17325/21169200/1441d65a-c21f-11e6-8c74-665a64d901b3.png">

### To test 

Head to http://calypso.localhost:3000/discover and make sure no excerpts are cropped after 3 lines.