### PR TITLE
Reader: drop top margin to zero below <660px width

### DIFF
--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -4,9 +4,9 @@
 
 .is-reader-page .reader__content,
 .is-reader-page .reader-start {
-	margin-top: 10px;
+	margin-top: 0;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( ">660px" ) {
 		margin-top: 30px;
 	}
 }


### PR DESCRIPTION
Fixes #10027.

@fraying noticed that we have too much margin at the top of the stream in some browsers:

<img width="499" alt="screen shot 2016-12-14 at 17 36 37" src="https://cloud.githubusercontent.com/assets/17325/21169754/f8a0ae8a-c223-11e6-9259-322970c3f873.png">

After:

<img width="506" alt="screen shot 2016-12-14 at 17 37 00" src="https://cloud.githubusercontent.com/assets/17325/21169756/fc40f054-c223-11e6-8407-83f902fbd68d.png">