### PR TITLE
Reader: Turn off card follow buttons for Discover

### DIFF
--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -20,7 +20,7 @@ import * as stats from 'reader/stats';
 import { localize } from 'i18n-calypso';
 import ExternalLink from 'components/external-link';
 
-const ReaderPostActions = ( { translate, post, site, onCommentClick, showEdit, showVisit, showMenu, iconSize, className } ) => {
+const ReaderPostActions = ( { translate, post, site, onCommentClick, showEdit, showVisit, showMenu, showMenuFollow, iconSize, className } ) => {
 	const onEditClick = () => {
 		stats.recordAction( 'edit_post' );
 		stats.recordGaEvent( 'Clicked Edit Post', 'full_post' );
@@ -83,7 +83,7 @@ const ReaderPostActions = ( { translate, post, site, onCommentClick, showEdit, s
 			}
 			{ showMenu &&
 				<li className="reader-post-actions__item">
-					<ReaderPostOptionsMenu className="ignore-click" post={ post } />
+					<ReaderPostOptionsMenu className="ignore-click" showFollow={ showMenuFollow } post={ post } />
 				</li>
 			}
 		</ul>
@@ -97,14 +97,16 @@ ReaderPostActions.propTypes = {
 	onCommentClick: React.PropTypes.func,
 	showEdit: React.PropTypes.bool,
 	iconSize: React.PropTypes.number,
-	showMenu: React.PropTypes.bool
+	showMenu: React.PropTypes.bool,
+	showMenuFollow: React.PropTypes.bool
 };
 
 ReaderPostActions.defaultProps = {
 	showEdit: true,
 	showVisit: false,
 	showMenu: false,
-	iconSize: 24
+	iconSize: 24,
+	showMenuFollow: true
 };
 
 export default localize( ReaderPostActions );

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -20,7 +20,20 @@ import * as stats from 'reader/stats';
 import { localize } from 'i18n-calypso';
 import ExternalLink from 'components/external-link';
 
-const ReaderPostActions = ( { translate, post, site, onCommentClick, showEdit, showVisit, showMenu, showMenuFollow, iconSize, className } ) => {
+const ReaderPostActions = ( props ) => {
+	const {
+		translate,
+		post,
+		site,
+		onCommentClick,
+		showEdit,
+		showVisit,
+		showMenu,
+		showMenuFollow,
+		iconSize,
+		className
+	} = props;
+
 	const onEditClick = () => {
 		stats.recordAction( 'edit_post' );
 		stats.recordGaEvent( 'Clicked Edit Post', 'full_post' );

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -122,6 +122,7 @@ export default class RefreshPostCard extends React.Component {
 			length: 140,
 			separator: /,? +/
 		} );
+		const isDiscoverPost = DiscoverHelper.isDiscoverPost( post );
 
 		if ( ! title && isPhotoOnly ) {
 			title = '\xa0'; // force to non-breaking space if empty so that the title h1 doesn't collapse and complicate things
@@ -129,7 +130,7 @@ export default class RefreshPostCard extends React.Component {
 
 		let followUrl;
 		if ( showPrimaryFollowButton ) {
-			if ( DiscoverHelper.isDiscoverPost( post ) ) {
+			if ( isDiscoverPost ) {
 				followUrl = DiscoverHelper.getSourceFollowUrl( post );
 			} else {
 				followUrl = feed ? feed.feed_URL : post.site_URL;
@@ -165,6 +166,7 @@ export default class RefreshPostCard extends React.Component {
 								post={ originalPost ? originalPost : post }
 								showVisit={ true }
 								showMenu={ true }
+								showMenuFollow={ ! isDiscoverPost }
 								onCommentClick={ onCommentClick }
 								showEdit={ false }
 								className="ignore-click"

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -29,13 +29,15 @@ const ReaderPostOptionsMenu = React.createClass( {
 	propTypes: {
 		post: React.PropTypes.object.isRequired,
 		feed: React.PropTypes.object,
-		onBlock: React.PropTypes.func
+		onBlock: React.PropTypes.func,
+		showFollow: React.PropTypes.bool
 	},
 
 	getDefaultProps() {
 		return {
 			onBlock: noop,
-			position: 'top left'
+			position: 'top left',
+			showFollow: true
 		};
 	},
 
@@ -142,7 +144,7 @@ const ReaderPostOptionsMenu = React.createClass( {
 				<EllipsisMenu
 					className="reader-post-options-menu__ellipsis-menu"
 					onToggle={ this.onMenuToggle }>
-					<FollowButton tagName={ PopoverMenuItem } siteUrl={ followUrl } />
+					{ this.props.showFollow && <FollowButton tagName={ PopoverMenuItem } siteUrl={ followUrl } /> }
 
 					{ isEditPossible ? <PopoverMenuItem onClick={ this.editPost } icon="pencil">
 						{ this.translate( 'Edit Post' ) }

--- a/client/reader/discover/controller.js
+++ b/client/reader/discover/controller.js
@@ -44,7 +44,7 @@ export default {
 				),
 				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
 				suppressSiteNameLink: true,
-				showPrimaryFollowButtonOnCards: true,
+				showPrimaryFollowButtonOnCards: false,
 				showBack: false,
 				className: 'is-discover-stream is-site-stream',
 			} ),


### PR DESCRIPTION
As part of the Reader Refresh, we plan to switch the byline for Discover picks to reflect the original author and site, not the Discover author (see https://github.com/Automattic/wp-calypso/issues/9096). 

As we haven't completed that yet, we've decided to turn off the follow button on cards for launch. The follow button follows the source site, which we thought may be confusing when the byline still has the Discover author's details in it.

It is still possible to follow the source site from the full post view.

### To test

Head to http://calypso.localhost:3000/discover and ensure that the cards do not have a primary follow button. Also ensure that it's not shown in the post options menu.

<img width="874" alt="screen shot 2016-12-14 at 17 59 23" src="https://cloud.githubusercontent.com/assets/17325/21170109/14e7ddae-c227-11e6-85a6-8ea4865564ec.png">
