### PR TITLE
Add InfoLink component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -97,6 +97,7 @@
 @import 'components/happiness-support/style';
 @import 'components/header-cake/style';
 @import 'components/infinite-list/style';
+@import 'components/info-link/style';
 @import 'components/info-popover/style';
 @import 'components/input-chrono/style';
 @import 'components/logged-out-form/style';

--- a/client/components/info-link/README.md
+++ b/client/components/info-link/README.md
@@ -1,0 +1,25 @@
+InfoLink
+===========
+
+`InfoLink` shows an `InfoPopover` with an `ExternalLink` inside.
+
+Useful for linking to external help pages from site settings.
+
+`children` will be rendered as children of `ExternalLink`
+
+
+### `InfoLink` Properties
+
+All props passed to `InfoLink`, except `href` will be passed to `InfoPopover` as props.
+
+#### `href`
+
+The `href` lets you specify the URL the content will be linking to.
+
+### Basic `InfoLink` Usage
+
+```jsx
+<InfoLink href={ 'https://jetpack.com/support/photon/' }>
+	Learn more about Photon
+</InfoLink>
+```

--- a/client/components/info-link/docs/example.jsx
+++ b/client/components/info-link/docs/example.jsx
@@ -1,0 +1,28 @@
+/**
+* External dependencies
+*/
+import React, { Component } from 'react';
+
+/**
+* Internal dependencies
+*/
+import InfoLink from 'components/info-link';
+import ExternalLink from 'components/external-link';
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+
+class InfoLinkExample extends Component {
+	static displayName = 'InfoLink';
+
+	render() {
+		return (
+			<SectionHeader label={ 'Speed up your images and photon with Photon' }>
+				<InfoLink href={ 'https://jetpack.com/support/photon/' }>
+					Learn more about Photon
+				</InfoLink>
+			</SectionHeader>
+		);
+	}
+}
+
+export default InfoLinkExample;

--- a/client/components/info-link/index.jsx
+++ b/client/components/info-link/index.jsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { omit } from 'lodash';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import InfoPopover from 'components/info-popover';
+import ExternalLink from 'components/external-link';
+
+const InfoLink = ( props ) => {
+	const otherProps = omit( props, [ 'children', 'href', 'className' ] );
+	return (
+		<InfoPopover className={ classNames( 'info-link', props.className ) } { ...otherProps }>
+				<ExternalLink icon={ true } href={ props.href } >
+					{ props.children }
+				</ExternalLink>
+		</InfoPopover>
+	);
+};
+
+InfoLink.propTypes = {
+	href: PropTypes.string.isRequired
+};
+
+export default InfoLink;

--- a/client/components/info-link/style.scss
+++ b/client/components/info-link/style.scss
@@ -1,0 +1,3 @@
+.info-link a {
+	text-decoration: none;
+}

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -54,6 +54,7 @@ import Ribbon from 'components/ribbon/docs/example';
 import Timezone from 'components/timezone/docs/example';
 import ClipboardButtons from 'components/forms/clipboard-button/docs/example';
 import ClipboardButtonInput from 'components/clipboard-button-input/docs/example';
+import InfoLink from 'components/info-link/docs/example';
 import InfoPopover from 'components/info-popover/docs/example';
 import Tooltip from 'components/tooltip/docs/example';
 import FoldableCard from 'components/foldable-card/docs/example';
@@ -139,6 +140,7 @@ let DesignAssets = React.createClass( {
 					<Gridicons />
 					<Headers />
 					<ImagePreloader />
+					<InfoLink />
 					<InfoPopover />
 					<Tooltip />
 					<InputChrono />


### PR DESCRIPTION
Part of #9171 and #9802

#### Changes proposed in this Pull Request:

Adds an `<InfoLink` component that shows an `info-link` icon and accepts an `href` prop with an URL to link to.

##### Testing instructions

1. Visit https://calypso.live/devdocs/design?branch=add/info-link-component
2. Search for `InfoLink`. 
3. Click the link and expect to be shown a link to the Jetpack Photon feature page.

![image](https://cloud.githubusercontent.com/assets/746152/21182713/40d48f00-c1e3-11e6-946b-1f2a80223780.png)


#### Why

The site settings cards corresponding to module activation need to include a link to the matching Jetpack feature description page (in the jetpack.com site) for reference. 

[As recommended by MichaelArestad](https://github.com/Automattic/wp-calypso/pull/9802#discussion_r91405194), this PR introduces the new component for simplifying styling.


