### PR TITLE
Themes: Upload page tweaks

### DIFF
--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import page from 'page';
 import React from 'react';
 import { connect } from 'react-redux';
 import { includes, find } from 'lodash';
@@ -129,6 +128,10 @@ class Upload extends React.Component {
 		this.props.uploadTheme( this.props.siteId, file );
 	}
 
+	onBackClick = () => {
+		window.history.back();
+	};
+
 	renderDropZone() {
 		const { translate } = this.props;
 		const uploadPromptText = translate(
@@ -232,7 +235,7 @@ class Upload extends React.Component {
 				<ThanksModal
 					site={ selectedSite }
 					source="upload" />
-				<HeaderCake onClick={ page.back }>{ translate( 'Upload theme' ) }</HeaderCake>
+				<HeaderCake onClick={ this.onBackClick }>{ translate( 'Upload theme' ) }</HeaderCake>
 				<Card>
 					{ ! inProgress && ! complete && this.renderDropZone() }
 					{ inProgress && this.renderProgressBar() }

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -80,12 +80,15 @@ class Upload extends React.Component {
 
 	successMessage() {
 		const { translate, uploadedTheme, themeId } = this.props;
-		notices.success( translate( 'Successfully uploaded theme %(name)s', {
-			args: {
-				// using themeId lets us show a message before theme data arrives
-				name: uploadedTheme ? uploadedTheme.name : themeId
-			}
-		} ) );
+		notices.success(
+			translate( 'Successfully uploaded theme %(name)s', {
+				args: {
+					// using themeId lets us show a message before theme data arrives
+					name: uploadedTheme ? uploadedTheme.name : themeId
+				}
+			} ),
+			{ duration: 5000 }
+		);
 	}
 
 	failureMessage() {

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -58,8 +58,7 @@ class Upload extends React.Component {
 		installing: React.PropTypes.bool,
 	};
 
-	constructor( props ) {
-		super( props );
+	componentDidMount() {
 		const { siteId, inProgress } = this.props;
 		! inProgress && this.props.clearThemeUpload( siteId );
 	}


### PR DESCRIPTION
**1) Fix react warnings on mount**

<img width="1279" alt="screen shot 2016-12-14 at 12 39 53" src="https://cloud.githubusercontent.com/assets/7767559/21182413/e41ee504-c1fa-11e6-8e02-68cb32a1660b.png">

Test: 
* Go to http://calypso.localhost:3000/design/{site}
* Click 'upload theme' button
* should not see the specific warning above in the console

**2) Fix back button**
Test:
* as above
* back button should always work

**3) Automatically close notices**
Test:
* as above
* upload a theme (must be a jetpack site)
* Success/error notice should disappear after 5 seconds


