### PR TITLE
Themes: Fix Jetpack filtering with new Redux Arch

### DIFF
--- a/client/state/themes/test/utils.js
+++ b/client/state/themes/test/utils.js
@@ -8,6 +8,7 @@ import { expect } from 'chai';
  */
 import {
 	isPremium,
+	normalizeJetpackTheme,
 	normalizeWpcomTheme,
 	normalizeWporgTheme,
 	getThemeIdFromStylesheet,
@@ -46,6 +47,39 @@ describe( 'utils', () => {
 				stylesheet: 'premium/mood'
 			} );
 			expect( premium ).to.be.true;
+		} );
+	} );
+
+	describe( '#normalizeJetpackTheme()', () => {
+		it( 'should return an empty object when given no argument', () => {
+			const normalizedTheme = normalizeJetpackTheme();
+			expect( normalizedTheme ).to.deep.equal( {} );
+		} );
+		it( 'should rename some keys', () => {
+			const normalizedTheme = normalizeJetpackTheme( {
+				id: 'twentyfifteen',
+				name: 'Twenty Fifteen',
+				author: 'the WordPress team',
+				screenshot: 'twentyfifteen.png',
+				download: 'http://downloads.wordpress.org/theme/twentyfifteen.1.7.zip',
+				tags: [
+					'custom-header',
+					'two-columns'
+				]
+			} );
+			expect( normalizedTheme ).to.deep.equal( {
+				id: 'twentyfifteen',
+				name: 'Twenty Fifteen',
+				author: 'the WordPress team',
+				screenshot: 'twentyfifteen.png',
+				download: 'http://downloads.wordpress.org/theme/twentyfifteen.1.7.zip',
+				taxonomies: {
+					theme_feature: [
+						{ slug: 'custom-header' },
+						{ slug: 'two-columns' }
+					]
+				}
+			} );
 		} );
 	} );
 

--- a/client/state/themes/test/utils.js
+++ b/client/state/themes/test/utils.js
@@ -360,10 +360,10 @@ describe( 'utils', () => {
 			} );
 		} );
 
-		context( 'query.filters', () => {
+		context( 'query.filter', () => {
 			it( 'should return false if theme does not include filter', () => {
 				const isMatch = isThemeMatchingQuery( {
-					filters: 'nosuchfilter'
+					filter: 'nosuchfilter'
 				}, DEFAULT_THEME );
 
 				expect( isMatch ).to.be.false;
@@ -371,7 +371,7 @@ describe( 'utils', () => {
 
 			it( 'should return false on a partial match', () => {
 				const isMatch = isThemeMatchingQuery( {
-					filters: 'ourna'
+					filter: 'ourna'
 				}, DEFAULT_THEME );
 
 				expect( isMatch ).to.be.false;
@@ -379,7 +379,7 @@ describe( 'utils', () => {
 
 			it( 'should return true if theme includes filter', () => {
 				const isMatch = isThemeMatchingQuery( {
-					filters: 'infinite-scroll'
+					filter: 'infinite-scroll'
 				}, DEFAULT_THEME );
 
 				expect( isMatch ).to.be.true;
@@ -388,14 +388,14 @@ describe( 'utils', () => {
 			context( 'with multiple filters from a single taxonomy', () => {
 				it( 'should return false if theme doesn\'t match all filters', () => {
 					const isMatch = isThemeMatchingQuery( {
-						filters: 'infinite-scroll,business'
+						filter: 'infinite-scroll,business'
 					}, DEFAULT_THEME );
 
 					expect( isMatch ).to.be.false;
 				} );
 				it( 'should return true if theme matches all filters', () => {
 					const isMatch = isThemeMatchingQuery( {
-						filters: 'infinite-scroll,custom-header'
+						filter: 'infinite-scroll,custom-header'
 					}, DEFAULT_THEME );
 
 					expect( isMatch ).to.be.true;
@@ -405,14 +405,14 @@ describe( 'utils', () => {
 			context( 'with multiple filters from different taxonomies', () => {
 				it( 'should return false if theme doesn\'t match all filters', () => {
 					const isMatch = isThemeMatchingQuery( {
-						filters: 'infinite-scroll,green'
+						filter: 'infinite-scroll,green'
 					}, DEFAULT_THEME );
 
 					expect( isMatch ).to.be.false;
 				} );
 				it( 'should return true if theme matches all filters', () => {
 					const isMatch = isThemeMatchingQuery( {
-						filters: 'infinite-scroll,black'
+						filter: 'infinite-scroll,black'
 					}, DEFAULT_THEME );
 
 					expect( isMatch ).to.be.true;

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -247,7 +247,11 @@ export function isThemeMatchingQuery( query, theme ) {
 					( theme.descriptionLong && includes( theme.descriptionLong.toLowerCase(), search ) )
 				);
 
-			case 'filters':
+			case 'filter':
+				if ( ! value ) {
+					return true;
+				}
+
 				// TODO: Change filters object shape to be more like post's terms, i.e.
 				// { color: 'blue,red', feature: 'post-slider' }
 				const filters = value.split( ',' );

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -49,7 +49,7 @@ export function isPremium( theme ) {
 /**
  * Normalizes a theme obtained via the WordPress.com REST API from a Jetpack site
  *
- * @param  {Object} theme  Themes object
+ * @param  {Object} theme  Theme object
  * @return {Object}        Normalized theme object
  */
 export function normalizeJetpackTheme( theme = {} ) {
@@ -69,7 +69,7 @@ export function normalizeJetpackTheme( theme = {} ) {
  /**
   * Normalizes a theme obtained from the WordPress.com REST API
   *
-  * @param  {Object} theme  Themes object
+  * @param  {Object} theme  Theme object
   * @return {Object}        Normalized theme object
   */
 export function normalizeWpcomTheme( theme ) {
@@ -87,7 +87,7 @@ export function normalizeWpcomTheme( theme ) {
 /**
  * Normalizes a theme obtained from the WordPress.org REST API
  *
- * @param  {Object} theme  Themes object
+ * @param  {Object} theme  Theme object
  * @return {Object}        Normalized theme object
  */
 export function normalizeWporgTheme( theme ) {
@@ -209,7 +209,7 @@ export function isPremiumTheme( theme ) {
  * Returns a filtered themes array. Filtering is done based on particular themes
  * matching provided query
  *
- * @param  {Array}  themes Array of themes objects
+ * @param  {Array}  themes Array of theme objects
  * @param  {Object} query  Themes query
  * @return {Array}         Filtered themes
  */

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -46,6 +46,26 @@ export function isPremium( theme ) {
 	return themeStylesheet && startsWith( themeStylesheet, 'premium/' );
 }
 
+/**
+ * Normalizes a theme obtained via the WordPress.com REST API from a Jetpack site
+ *
+ * @param  {Object} theme  Themes object
+ * @return {Object}        Normalized theme object
+ */
+export function normalizeJetpackTheme( theme = {} ) {
+	if ( ! theme.tags ) {
+		return theme;
+	}
+
+	return {
+		...omit( theme, 'tags' ),
+		taxonomies: {
+			// Map slugs only since JP sites give us no names
+			theme_feature: map( theme.tags, slug => ( { slug } ) )
+		}
+	};
+}
+
  /**
   * Normalizes a theme obtained from the WordPress.com REST API
   *

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -194,7 +194,7 @@ export function isPremiumTheme( theme ) {
  * @return {Array}         Filtered themes
  */
 export function filterThemesForJetpack( themes, query ) {
-	return filter( themes, theme => isThemeMatchingQuery( theme, query ) );
+	return filter( themes, theme => isThemeMatchingQuery( query, theme ) );
 }
 
 /**


### PR DESCRIPTION
Another breakout PR from #8785 to keep that smaller. Fixes a number of glitches that broke Jetpack rendering. I'm not including the fix to `state/themes/actions` yet that actually applies `normalizeJetpackTheme` as that would've meant too much rebasing work.

* Fix arg order for `isThemeMatchingQuery` in `filterThemesForJetpack`
* Add a `normalizeJetpackTheme` util
* Have `filterThemesForJetpack` use `query.filter` instead of `query.filters` (which doesn't exist) 

Means that this code isn't wired yet, so the showcase should work as before.