### PR TITLE
Taxonomies: Update the default category's site settings value if we rename this category

### DIFF
--- a/client/state/terms/actions.js
+++ b/client/state/terms/actions.js
@@ -88,7 +88,11 @@ export function updateTerm( siteId, taxonomy, termId, termSlug, term ) {
 
 				// Update the default category if needed
 				const siteSettings = getSiteSettings( state, siteId );
-				if ( taxonomy === 'category' && get( siteSettings, [ 'default_category' ] ) === termId && updatedTerm.ID !== termId ) {
+				if (
+					taxonomy === 'category' &&
+					get( siteSettings, [ 'default_category' ] ) === termId &&
+					updatedTerm.ID !== termId
+				) {
 					dispatch( updateSiteSettings( siteId, { default_category: updatedTerm.ID } ) );
 				}
 

--- a/client/state/terms/actions.js
+++ b/client/state/terms/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, uniqueId } from 'lodash';
+import { filter, get, uniqueId } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,7 +15,9 @@ import {
 	TERMS_REQUEST_FAILURE
 } from 'state/action-types';
 import { editPost } from 'state/posts/actions';
+import { updateSiteSettings } from 'state/site-settings/actions';
 import { getSitePostsByTerm } from 'state/posts/selectors';
+import { getSiteSettings } from 'state/site-settings/selectors';
 import { getTerm, getTerms } from './selectors';
 
 /**
@@ -83,6 +85,12 @@ export function updateTerm( siteId, taxonomy, termId, termSlug, term ) {
 						}
 					} ) );
 				} );
+
+				// Update the default category if needed
+				const siteSettings = getSiteSettings( state, siteId );
+				if ( taxonomy === 'category' && get( siteSettings, [ 'default_category' ] ) === termId && updatedTerm.ID !== termId ) {
+					dispatch( updateSiteSettings( siteId, { default_category: updatedTerm.ID } ) );
+				}
 
 				return updatedTerm;
 			}


### PR DESCRIPTION
Nothing too fancy :) I just trigger a site settings update if the id of the default category changes while updating it.

closes #9967

**Testing instructions**

 * Rename the default category from the taxonomy manager
 * Submit the form
 * The "default" label should be visible in the category row after renaming the category