### PR TITLE
Add delete theme on Jetpack function in undocumented.

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1621,7 +1621,7 @@ Undocumented.prototype.installThemeOnJetpack = function( siteId, themeId, fn ) {
 /**
  * Delete a theme from Jetpack site.
  *
- * @param {String}    siteId   The site ID
+ * @param {Number}    siteId   The site ID
  * @param {String}    themeId  The theme ID
  * @param {Function}  fn       The callback function
  * @returns {Promise} promise

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1618,6 +1618,23 @@ Undocumented.prototype.installThemeOnJetpack = function( siteId, themeId, fn ) {
 	}, fn );
 };
 
+/**
+ * Delete a theme from Jetpack site.
+ *
+ * @param {String}    siteId   The site ID
+ * @param {String}    themeId  The theme ID
+ * @param {Function}  fn       The callback function
+ * @returns {Promise} promise
+ */
+Undocumented.prototype.deleteThemeFromJetpack = function( siteId, themeId, fn ) {
+	const path = `/sites/${ siteId }/themes/${ themeId }/delete`;
+	debug( path );
+
+	return this.wpcom.req.post( {
+		path,
+	}, fn );
+};
+
 Undocumented.prototype.activeTheme = function( siteId, fn ) {
 	debug( '/sites/:site_id/themes/mine' );
 	return this.wpcom.req.get( { path: '/sites/' + siteId + '/themes/mine' }, fn );


### PR DESCRIPTION
### Info
This function allows calling delete endpoint to delete theme from site with Jetpack

This is needed for theme delete action that will be created in different PR.

### Testing
Not connected.