### PR TITLE
Support: Remove abtest control from presales chat button

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -109,17 +109,6 @@ module.exports = {
 		allowExistingUsers: true
 	},
 
-	presaleChatButton: {
-		datestamp: '20161129',
-		variations: {
-			showChatButton: 80,
-			original: 20
-		},
-		defaultVariation: 'original',
-		allowAnyLocale: true,
-		allowExistingUsers: true,
-	},
-
 	noSurveyStep: {
 		datestamp: '20161202',
 		variations: {

--- a/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
@@ -14,7 +14,6 @@ var PayButton = require( './pay-button' ),
 	analytics = require( 'lib/analytics' ),
 	cartValues = require( 'lib/cart-values' );
 
-import { abtest } from 'lib/abtest';
 import CartCoupon from 'my-sites/upgrades/cart/cart-coupon';
 import PaymentChatButton from './payment-chat-button';
 import config from 'config';
@@ -40,8 +39,7 @@ var CreditCardPaymentBox = React.createClass( {
 		const hasBusinessPlanInCart = some( cart.products, { product_slug: PLAN_BUSINESS } );
 		const showPaymentChatButton =
 			config.isEnabled( 'upgrades/presale-chat' ) &&
-			hasBusinessPlanInCart &&
-			abtest( 'presaleChatButton' ) === 'showChatButton';
+			hasBusinessPlanInCart;
 
 		const paypalButtonClasses = classnames( 'credit-card-payment-box__switch-link', {
 			'credit-card-payment-box__switch-link-left': showPaymentChatButton

--- a/client/my-sites/upgrades/checkout/credits-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/credits-payment-box.jsx
@@ -10,7 +10,6 @@ var PayButton = require( './pay-button' ),
 	PaymentBox = require( './payment-box' ),
 	TermsOfService = require( './terms-of-service' );
 
-import { abtest } from 'lib/abtest';
 import CartCoupon from 'my-sites/upgrades/cart/cart-coupon';
 import PaymentChatButton from './payment-chat-button';
 import config from 'config';
@@ -23,8 +22,7 @@ var CreditsPaymentBox = React.createClass( {
 		const hasBusinessPlanInCart = some( cart.products, { product_slug: PLAN_BUSINESS } );
 		const showPaymentChatButton =
 			config.isEnabled( 'upgrades/presale-chat' ) &&
-			hasBusinessPlanInCart &&
-			abtest( 'presaleChatButton' ) === 'showChatButton';
+			hasBusinessPlanInCart;
 
 		return (
 			<form onSubmit={ this.props.onSubmit }>

--- a/client/my-sites/upgrades/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/paypal-payment-box.jsx
@@ -23,7 +23,6 @@ import CartCoupon from 'my-sites/upgrades/cart/cart-coupon';
 import PaymentChatButton from './payment-chat-button';
 import config from 'config';
 import { PLAN_BUSINESS } from 'lib/plans/constants';
-import { abtest } from 'lib/abtest';
 
 module.exports = React.createClass( {
 	displayName: 'PaypalPaymentBox',
@@ -133,8 +132,7 @@ module.exports = React.createClass( {
 		const hasBusinessPlanInCart = some( this.props.cart.products, { product_slug: PLAN_BUSINESS } );
 		const showPaymentChatButton =
 			config.isEnabled( 'upgrades/presale-chat' ) &&
-			hasBusinessPlanInCart &&
-			abtest( 'presaleChatButton' ) === 'showChatButton';
+			hasBusinessPlanInCart;
 		const creditCardButtonClasses = classnames( 'credit-card-payment-box__switch-link', {
 			'credit-card-payment-box__switch-link-left': showPaymentChatButton
 		} );


### PR DESCRIPTION
We're finished ab testing this so lets always show the presales chat button at checkout for business plan purchases

### How to test
#### Credit card payment
1. Make sure your test account doesn't have any credits
2. Navigate to http://calypso.localhost:3000/plans
3. Select the "Business" plan
4. Notice the "Need help? Chat with us" button is displayed.
5. Click it and start a chat to make sure that it still works

#### PayPal payment
1. Make sure your test account doesn't have any credits
2. Navigate to http://calypso.localhost:3000/plans
3. Select the "Business" plan
4. Click the "or use Paypal" link/button
5. Notice the "Need help? Chat with us" button is displayed.
6. Click it and start a chat to make sure that it still works

#### Pay using credits
1. Add at least 300 credits to your test account
2. Navigate to http://calypso.localhost:3000/plans
3. Select the "Business" plan
4. Notice the "Need help? Chat with us" button is displayed.
5. Click it and start a chat to make sure that it still works


### What to expect
![screen shot 2016-12-02 at 1 37 57 pm](https://cloud.githubusercontent.com/assets/1854440/20845782/a4aff1c0-b894-11e6-9bbe-43b2ffbda211.png)
![screen shot 2016-12-05 at 10 42 57 am](https://cloud.githubusercontent.com/assets/1854440/21190055/95cce7a4-c1ee-11e6-83a7-9b42cc52d4e0.png)
![screen shot 2016-12-14 at 11 17 31 am](https://cloud.githubusercontent.com/assets/1854440/21190168/f7d4e9c4-c1ee-11e6-8897-9e4be6000d3d.png)


