### PR TITLE
Reader: Switch gizmodo's feed id

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -329,7 +329,7 @@
 }
 
 // gizmodo fixes
-.reader-full-post.feed-19797 {
+.reader-full-post.feed-10080096 {
 	.align--bleed {
 		display: none;
 	}


### PR DESCRIPTION
Gizmodo's feed ID changed, so we have to track it.