### PR TITLE
Reader: Fix in-stream recs z-index

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -49,6 +49,7 @@ $z-layers: (
 		'.reader-list-gap__button': 1,
 		'.reader-feed-header': 0,
 		'.reader-feed-header__back-and-follow': 0,
+		'.reader-related-card-v2.card': 0,
 		'.post-trends__title': 1,
 		'.plugin-item__label': 1,
 		'.wp-editor-tools': 1,
@@ -204,6 +205,12 @@ $z-layers: (
 	'.reader-feed-header__back-and-follow': (
 		'.card.header-cake': 1,
 		'.reader-feed-header__follow': 1
+	),
+	'.reader-related-card-v2.card': (
+		'.reader-related-card-v2__meta': 1
+	),
+	'.reader-related-card-v2__meta': (
+		'.follow-button': 1
 	),
 
 	// The following may be inserted into different areas.

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -136,11 +136,12 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 }
 
 .reader-related-card-v2.card {
+	z-index: z-index( 'root', '.reader-related-card-v2.card' );
 
 	.reader-related-card-v2__meta {
 		display: flex;
 		margin-bottom: 13px;
-		z-index: 1;
+		z-index: z-index( '.reader-related-card-v2.card', '.reader-related-card-v2__meta' );
 	}
 
 	.reader-related-card-v2__post {
@@ -380,7 +381,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	margin-bottom: 12px;
 	margin-top: -4px;
 	padding: 0;
-	z-index: 1;
+	z-index: z-index( '.reader-related-card-v2__meta', '.follow-button' );
 
 	.gridicon__follow {
 		fill: $blue-medium;


### PR DESCRIPTION
**Before:**
![screenshot 2016-12-14 10 06 39](https://cloud.githubusercontent.com/assets/4924246/21196216/b5775402-c1eb-11e6-92f2-1e1f7d4e8bb2.png)

**After:**
![screenshot 2016-12-14 10 50 27](https://cloud.githubusercontent.com/assets/4924246/21196222/ba2a95e0-c1eb-11e6-99ba-65f75a11ced7.png)

I believe this happened after fixing: https://github.com/Automattic/wp-calypso/pull/9396
