### PR TITLE
Themes: Remove getThemes() selector

### DIFF
--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -27,27 +27,6 @@ import {
 import { DEFAULT_THEME_QUERY } from './constants';
 
 /**
- * Returns an array of theme objects by site ID.
- *
- * @param  {Object} state  Global state tree
- * @param  {Number} siteId Site ID
- * @return {Array}         Site themes
- */
-export const getThemes = createSelector(
-	( state, siteId ) => {
-		const manager = state.themes.queries[ siteId ];
-		if ( ! manager ) {
-			return [];
-		}
-
-		// FIXME: The themes endpoint weirdly sometimes returns duplicates (spread
-		// over different pages) which we need to remove manually here for now.
-		return uniq( manager.getItems() );
-	},
-	( state ) => state.themes.queries
-);
-
-/**
  * Returns a theme object by site ID, theme ID pair.
  *
  * @param  {Object}  state   Global state tree

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -2,13 +2,11 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { values } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import {
-	getThemes,
 	getTheme,
 	getThemeRequestErrors,
 	isRequestingTheme,
@@ -71,40 +69,10 @@ const mood = {
 
 describe( 'themes selectors', () => {
 	beforeEach( () => {
-		getThemes.memoizedSelector.cache.clear();
 		getTheme.memoizedSelector.cache.clear();
 		getThemesForQuery.memoizedSelector.cache.clear();
 		getThemesForQueryIgnoringPage.memoizedSelector.cache.clear();
 		isRequestingThemesForQueryIgnoringPage.memoizedSelector.cache.clear();
-	} );
-
-	describe( '#getThemes()', () => {
-		it( 'should return an array of theme objects for the site', () => {
-			const themeObjects = {
-				wpcom: {
-					mood
-				},
-				77203074: {
-					twentyfifteen,
-					twentysixteen
-				}
-			};
-			const state = {
-				themes: {
-					queries: {
-						wpcom: new ThemeQueryManager( {
-							items: themeObjects.wpcom
-						} ),
-						77203074: new ThemeQueryManager( {
-							items: themeObjects[ 77203074 ]
-						} )
-					},
-
-				}
-			};
-
-			expect( getThemes( state, 77203074 ) ).to.have.members( values( themeObjects[ 77203074 ] ) );
-		} );
 	} );
 
 	describe( '#getTheme()', () => {


### PR DESCRIPTION
This is a selector that would return all themes on a given site regardless. It isn't of any practical value really:
In a themes list UI setting, we'll always want the results to be queryable, so getThemesForQuery() should be used instead.