### PR TITLE
Theme Showcase: Remove a number of obsolete props

### DIFF
--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -12,7 +12,7 @@ import Main from 'components/main';
 import SingleSiteThemeShowcaseWpcom from './single-site-wpcom';
 import SingleSiteThemeShowcaseJetpack from './single-site-jetpack';
 import sitesFactory from 'lib/sites-list';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { isThemeActive } from 'state/themes/selectors';
 import { canCurrentUser } from 'state/current-user/selectors';
@@ -80,12 +80,11 @@ const SingleSiteThemeShowcaseWithOptions = ( props ) => {
 
 export default connect(
 	( state ) => {
-		const selectedSite = getSelectedSite( state );
+		const selectedSiteId = getSelectedSiteId( state );
 		return {
-			selectedSite,
-			isJetpack: selectedSite && isJetpackSite( state, selectedSite.ID ),
-			isCustomizable: selectedSite && canCurrentUser( state, selectedSite.ID, 'edit_theme_options' ),
-			getScreenshotOption: ( theme ) => ( selectedSite && isThemeActive( state, theme.id, selectedSite.ID ) ) ? 'customize' : 'info'
+			isJetpack: isJetpackSite( state, selectedSiteId ),
+			isCustomizable: canCurrentUser( state, selectedSiteId, 'edit_theme_options' ),
+			getScreenshotOption: ( theme ) => isThemeActive( state, theme.id, selectedSiteId ) ? 'customize' : 'info'
 		};
 	}
 )( localize( SingleSiteThemeShowcaseWithOptions ) );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -69,7 +69,6 @@ const ThemeShowcase = React.createClass( {
 
 	getDefaultProps() {
 		return {
-			selectedSite: false,
 			tier: '',
 			search: '',
 			showUploadButton: false
@@ -221,7 +220,6 @@ const ThemeShowcase = React.createClass( {
 				}
 				<ThemesSelection query={ query }
 					siteId={ this.props.siteId }
-					selectedSite={ this.props.selectedSite }
 					getScreenshotUrl={ function( theme ) {
 						if ( ! getScreenshotOption( theme ).getUrl ) {
 							return null;
@@ -243,10 +241,6 @@ const ThemeShowcase = React.createClass( {
 							option => ! ( option.hideForTheme && option.hideForTheme( theme ) )
 						); } }
 					trackScrollPage={ this.props.trackScrollPage }
-					search={ search }
-					tier={ this.props.tier }
-					filter={ this.props.filter }
-					vertical={ this.props.vertical }
 					incrementPage={ this.incrementPage }
 					resetPage={ this.resetPage } />
 					{ this.props.children }

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -26,15 +26,10 @@ import { PAGINATION_QUERY_KEYS } from 'lib/query-manager/paginated/constants';
 
 const ThemesSelection = React.createClass( {
 	propTypes: {
-		selectedSite: PropTypes.oneOfType( [
-			PropTypes.object,
-			PropTypes.bool
-		] ).isRequired,
+		query: PropTypes.object.isRequired,
 		siteId: PropTypes.number,
-		search: PropTypes.string,
 		onScreenshotClick: PropTypes.func,
 		getOptions: PropTypes.func,
-		query: PropTypes.object.isRequired,
 		getActionLabel: PropTypes.func,
 		incrementPage: PropTypes.func,
 		resetPage: PropTypes.func,
@@ -48,10 +43,6 @@ const ThemesSelection = React.createClass( {
 		isLastPage: PropTypes.bool,
 		isThemeActive: PropTypes.func,
 		isThemePurchased: PropTypes.func,
-	},
-
-	getDefaultProps() {
-		return { search: '' };
 	},
 
 	componentWillReceiveProps( nextProps ) {


### PR DESCRIPTION
A couple of now-obsolete props that I failed to remove in #8785.

To test -- make sure that the showcase still runs. Clicking around/searching in single-site mode should reveal this quickly.