### PR TITLE
Plugins: AT progress bar state improvements

### DIFF
--- a/client/my-sites/plugins/plugin-automated-transfer/index.jsx
+++ b/client/my-sites/plugins/plugin-automated-transfer/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { includes, omit } from 'lodash';
+import { includes } from 'lodash';
 import wrapWithClickOutside from 'react-click-outside';
 
 /**
@@ -12,15 +12,19 @@ import wrapWithClickOutside from 'react-click-outside';
  */
 import { transferStates } from 'state/automated-transfer/constants';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getAutomatedTransferStatus } from 'state/automated-transfer/selectors';
+import {
+	getAutomatedTransferStatus,
+	isAutomatedTransferTransferring,
+} from 'state/automated-transfer/selectors';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 
 class PluginAutomatedTransfer extends Component {
 
 	static propTypes = {
+		isTransferring: PropTypes.bool,
 		plugin: PropTypes.object,
-		status: PropTypes.string,
+		transferState: PropTypes.string,
 		translate: PropTypes.func,
 	}
 
@@ -35,20 +39,20 @@ class PluginAutomatedTransfer extends Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		if ( this.props.status !== nextProps.status ) {
+		if ( this.props.transferState !== nextProps.transferState ) {
 			this.setState( { clickOutside: false } );
 		}
 	}
 
 	getNoticeText = ( pluginName = '' ) => {
-		const { status, translate } = this.props;
+		const { transferState, translate } = this.props;
 		const { START, SETUP, LEAVING, CONFLICTS, COMPLETE } = transferStates;
 
 		if ( this.state.clickOutside ) {
 			return translate( "Don't leave quite yet! Just a bit longer." );
 		}
 
-		switch ( status ) {
+		switch ( transferState ) {
 			case START: return translate( 'Installing %(plugin)s…', { args: { plugin: pluginName } } );
 			case SETUP : return translate( 'Now configuring your site. This may take a few minutes.' );
 			case LEAVING: return translate( "Don't leave quite yet! Just a bit longer." );
@@ -57,24 +61,24 @@ class PluginAutomatedTransfer extends Component {
 		}
 	}
 
-	getStatus = status => {
+	getStatus = transferState => {
 		const { CONFLICTS, COMPLETE } = transferStates;
 		if ( this.state.clickOutside ) {
 			return 'is-info';
 		}
-		switch ( status ) {
+		switch ( transferState ) {
 			case CONFLICTS: return 'is-error';
 			case COMPLETE: return 'is-success';
 			default: return 'is-info';
 		}
 	}
 
-	getIcon = status => {
+	getIcon = transferState => {
 		const { CONFLICTS, COMPLETE } = transferStates;
 		if ( this.state.clickOutside ) {
 			return 'sync';
 		}
-		switch ( status ) {
+		switch ( transferState ) {
 			case CONFLICTS: return 'notice';
 			case COMPLETE: return 'checkmark';
 			default: return 'sync';
@@ -82,9 +86,9 @@ class PluginAutomatedTransfer extends Component {
 	}
 
 	handleClickOutside( event ) {
-		const { status } = this.props;
+		const { transferState } = this.props;
 		const { CONFLICTS, COMPLETE } = transferStates;
-		if ( status && CONFLICTS !== status && COMPLETE !== status ) {
+		if ( transferState && ! includes( [ CONFLICTS, COMPLETE ], transferState ) ) {
 			event.preventDefault();
 			event.stopImmediatePropagation();
 			this.setState( { clickOutside: true } );
@@ -92,22 +96,22 @@ class PluginAutomatedTransfer extends Component {
 	}
 
 	render() {
-		const { plugin, status, translate } = this.props;
-		const { CONFLICTS } = transferStates;
+		const { isTransferring, plugin, transferState, translate } = this.props;
+		const { COMPLETE, CONFLICTS } = transferStates;
 
-		if ( ! status || ! includes( omit( transferStates, 'INQUIRING' ), status ) ) {
+		if ( ! isTransferring && ! includes( [ COMPLETE, CONFLICTS ], transferState ) ) {
 			return null;
 		}
 
 		return (
 			<Notice
-				icon={ this.getIcon( status ) }
+				icon={ this.getIcon( transferState ) }
 				className="plugin-automated-transfer"
 				showDismiss={ false }
-				status={ this.getStatus( status ) }
+				status={ this.getStatus( transferState ) }
 				text={ this.getNoticeText( plugin.name ) }
 			>
-				{ CONFLICTS === status &&
+				{ CONFLICTS === transferState &&
 					<NoticeAction href="#">
 						{ translate( 'View Conflicts', {
 							comment: 'Conflicts arose during an Automated Transfer started by a plugin install.',
@@ -122,8 +126,12 @@ class PluginAutomatedTransfer extends Component {
 
 const mapStateToProps = state => {
 	const site = getSelectedSiteId( state );
-	const status = getAutomatedTransferStatus( state, site );
-	return { status };
+	const transferState = getAutomatedTransferStatus( state, site );
+	const isTransferring = isAutomatedTransferTransferring( state, site );
+	return {
+		isTransferring,
+		transferState,
+	};
 };
 
 export default connect( mapStateToProps )( localize( wrapWithClickOutside( PluginAutomatedTransfer ) ) );

--- a/client/my-sites/plugins/plugin-automated-transfer/index.jsx
+++ b/client/my-sites/plugins/plugin-automated-transfer/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
+import { includes, omit } from 'lodash';
 import wrapWithClickOutside from 'react-click-outside';
 
 /**
@@ -95,7 +95,7 @@ class PluginAutomatedTransfer extends Component {
 		const { plugin, status, translate } = this.props;
 		const { CONFLICTS } = transferStates;
 
-		if ( ! status || ! includes( transferStates, status ) ) {
+		if ( ! status || ! includes( omit( transferStates, 'INQUIRING' ), status ) ) {
 			return null;
 		}
 

--- a/client/my-sites/plugins/plugin-automated-transfer/index.jsx
+++ b/client/my-sites/plugins/plugin-automated-transfer/index.jsx
@@ -53,11 +53,9 @@ class PluginAutomatedTransfer extends Component {
 		if ( COMPLETE === transferState ) {
 			this.setState( { transferComplete: true } );
 		}
-
 		if ( this.props.transferState !== transferState ) {
 			this.setState( { clickOutside: false } );
 		}
-
 		if (
 			this.state.shouldDisplay &&
 			! isTransferring &&
@@ -78,7 +76,6 @@ class PluginAutomatedTransfer extends Component {
 		if ( transferComplete ) {
 			return translate( 'Successfully installed %(plugin)s!', { args: { plugin: pluginName } } );
 		}
-
 		switch ( transferState ) {
 			case START: return translate( 'Installing %(plugin)s…', { args: { plugin: pluginName } } );
 			case SETUP : return translate( 'Now configuring your site. This may take a few minutes.' );
@@ -96,11 +93,10 @@ class PluginAutomatedTransfer extends Component {
 		if ( transferComplete ) {
 			return 'is-success';
 		}
-
-		switch ( transferState ) {
-			case CONFLICTS: return 'is-error';
-			default: return 'is-info';
+		if ( CONFLICTS === transferState ) {
+			return 'is-error';
 		}
+		return 'is-info';
 	}
 
 	getIcon = transferState => {
@@ -113,16 +109,14 @@ class PluginAutomatedTransfer extends Component {
 		if ( transferComplete ) {
 			return 'checkmark';
 		}
-
-		switch ( transferState ) {
-			case CONFLICTS: return 'notice';
-			default: return 'sync';
+		if ( CONFLICTS === transferState ) {
+			return 'notice';
 		}
+		return 'sync';
 	}
 
 	handleClickOutside( event ) {
-		const { isTransferring } = this.props;
-		if ( isTransferring ) {
+		if ( this.props.isTransferring ) {
 			event.preventDefault();
 			event.stopImmediatePropagation();
 			this.setState( { clickOutside: true } );

--- a/client/my-sites/plugins/plugin-automated-transfer/index.jsx
+++ b/client/my-sites/plugins/plugin-automated-transfer/index.jsx
@@ -35,15 +35,18 @@ class PluginAutomatedTransfer extends Component {
 
 	state = {
 		clickOutside: false,
-		shouldDisplay: true,
+		shouldDisplay: false,
 		transferComplete: false,
 	};
 
 	componentWillMount() {
-		const { COMPLETE } = transferStates;
+		const { COMPLETE, CONFLICTS } = transferStates;
 		const { isTransferring, transferState } = this.props;
-		if ( ! isTransferring || ! transferState || COMPLETE === transferState ) {
-			this.setState( { shouldDisplay: false } );
+
+		if ( COMPLETE === transferState ) {
+			this.setState( { transferComplete: true } );
+		} else if ( isTransferring || CONFLICTS === transferState ) {
+			this.setState( { shouldDisplay: true } );
 		}
 	}
 
@@ -54,17 +57,17 @@ class PluginAutomatedTransfer extends Component {
 
 		if ( COMPLETE === nextProps.transferState ) {
 			newState.transferComplete = true;
-		} else if ( transferComplete ) {
-			newState.shouldDisplay = true;
-		} else {
+			if ( ! transferComplete ) {
+				newState.shouldDisplay = true;
+			}
+		} else if ( ! transferComplete ) {
 			if ( this.props.transferState !== nextProps.transferState ) {
 				newState.clickOutside = false;
 			}
-
-			if ( ! nextProps.isTransferring && CONFLICTS !== nextProps.transferState ) {
-				newState.shouldDisplay = false;
-			} else {
+			if ( nextProps.isTransferring || CONFLICTS === nextProps.transferState ) {
 				newState.shouldDisplay = true;
+			} else {
+				newState.shouldDisplay = false;
 			}
 		}
 

--- a/client/my-sites/plugins/plugin-automated-transfer/index.jsx
+++ b/client/my-sites/plugins/plugin-automated-transfer/index.jsx
@@ -65,11 +65,7 @@ class PluginAutomatedTransfer extends Component {
 				newState.shouldDisplay = true;
 			}
 		} else if ( ! transferComplete ) {
-			if ( nextProps.isTransferring || CONFLICTS === nextProps.transferState ) {
-				newState.shouldDisplay = true;
-			} else {
-				newState.shouldDisplay = false;
-			}
+			newState.shouldDisplay = nextProps.isTransferring || CONFLICTS === nextProps.transferState;
 		}
 
 		this.setState( newState );

--- a/client/my-sites/plugins/plugin-automated-transfer/index.jsx
+++ b/client/my-sites/plugins/plugin-automated-transfer/index.jsx
@@ -55,15 +55,16 @@ class PluginAutomatedTransfer extends Component {
 		const { transferComplete } = this.state;
 		const newState = {};
 
+		if ( this.props.transferState !== nextProps.transferState ) {
+			newState.clickOutside = false;
+		}
+
 		if ( COMPLETE === nextProps.transferState ) {
 			newState.transferComplete = true;
 			if ( ! transferComplete ) {
 				newState.shouldDisplay = true;
 			}
 		} else if ( ! transferComplete ) {
-			if ( this.props.transferState !== nextProps.transferState ) {
-				newState.clickOutside = false;
-			}
 			if ( nextProps.isTransferring || CONFLICTS === nextProps.transferState ) {
 				newState.shouldDisplay = true;
 			} else {

--- a/client/state/automated-transfer/constants.js
+++ b/client/state/automated-transfer/constants.js
@@ -2,7 +2,6 @@ export const transferStates = {
 	INQUIRING: 'inquiring',
 	START: 'start',
 	SETUP: 'setup',
-	LEAVING: 'leaving',
 	CONFLICTS: 'conflicts',
 	COMPLETE: 'complete',
 };

--- a/client/state/automated-transfer/schema.js
+++ b/client/state/automated-transfer/schema.js
@@ -1,7 +1,10 @@
+/**
+ * Internal dependencies
+ */
 import { eligibility } from './eligibility/schema';
 
 export const status = {
-	type: 'string',
+	type: [ 'string', 'null' ],
 };
 
 export const automatedTransferSite = {

--- a/client/state/automated-transfer/selectors.js
+++ b/client/state/automated-transfer/selectors.js
@@ -4,7 +4,13 @@
 import {
 	flowRight as compose,
 	get,
+	includes,
 } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { transferStates } from 'state/automated-transfer/constants';
 
 export const getAutomatedTransfer = ( state, siteId ) =>
 	get( state, [ 'automatedTransfer', siteId ], {} );
@@ -67,4 +73,16 @@ export const getEligibilityStatus = state => !! get( state, 'lastUpdated', 0 ) &
 export const isEligibleForAutomatedTransfer = compose(
 	getEligibilityStatus,
 	getEligibility
+);
+
+/**
+ * Checks if the site is currently transferring
+ *
+ * @param {Object} state global app state
+ * @param {number} siteId requested site for tranfer info
+ * @returns {bool} transferring check
+ */
+export const isAutomatedTransferTransferring = ( state, siteId ) => includes(
+	[ transferStates.START, transferStates.SETUP ],
+	getAutomatedTransferStatus( state, siteId )
 );

--- a/client/state/automated-transfer/selectors.js
+++ b/client/state/automated-transfer/selectors.js
@@ -76,13 +76,24 @@ export const isEligibleForAutomatedTransfer = compose(
 );
 
 /**
+ * Helper to get transferring state from local transfer status
+ *
+ * @param {string|null} status automated transfer status
+ * @returns {bool} transferring check
+ */
+const getIsTransferring = status => includes(
+	[ transferStates.START, transferStates.SETUP ],
+	status,
+);
+
+/**
  * Checks if the site is currently transferring
  *
  * @param {Object} state global app state
  * @param {number} siteId requested site for tranfer info
  * @returns {bool} transferring check
  */
-export const isAutomatedTransferTransferring = ( state, siteId ) => includes(
-	[ transferStates.START, transferStates.SETUP ],
-	getAutomatedTransferStatus( state, siteId )
+export const isAutomatedTransferTransferring = compose(
+	getIsTransferring,
+	getAutomatedTransferStatus,
 );


### PR DESCRIPTION
The AT eligibilty check should be near-instant, so there's no need to show a message to the user explaining what's going on.
Once the check is completed, the progress bar will show up accordingly to the results.