### PR TITLE
Remove `providedDependencies` from `calypso_signup_actions_submit_step` event

### DIFF
--- a/client/lib/signup/actions.js
+++ b/client/lib/signup/actions.js
@@ -26,7 +26,7 @@ const SignupActions = {
 	},
 
 	submitSignupStep( step, errors, providedDependencies ) {
-		analytics.tracks.recordEvent( 'calypso_signup_actions_submit_step', { ...providedDependencies, step: step.stepName } );
+		analytics.tracks.recordEvent( 'calypso_signup_actions_submit_step', { step: step.stepName } );
 
 		Dispatcher.handleViewAction( {
 			type: 'SUBMIT_SIGNUP_STEP',


### PR DESCRIPTION
Passing `providedDependencies` to Tracks without formatting the prop names to remove dashes and camelcase is causing events to be rejected. The information isn't required, so we're just removing it.