### PR TITLE
Jetpack Settings: Use the Jetpack site REST API for module activation

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -132,6 +132,24 @@ Undocumented.prototype.jetpackModulesActivate = function( siteId, moduleSlug, fn
 };
 
 /*
+ * Activate a Jetpack module with slug moduleSlug for a site with id siteid.
+ * Similar to jetpackModulesActivate(), but uses the REST API of the Jetpack site.
+ *
+ * @param {int} [siteId]
+ * @param {string} [moduleSlug]
+ * @param {Function} fn
+ * @api public
+ */
+Undocumented.prototype.jetpackModuleActivate = function( siteId, moduleSlug, fn ) {
+	//@TODO: implement and test this endpoint, it's currently not working
+	return this.wpcom.req.post(
+		{ path: '/jetpack-blogs/' + siteId + '/rest-api/' },
+		{ path: '/module/' + moduleSlug + '/active/', body: JSON.stringify( { active: true } ) },
+		fn
+	);
+};
+
+/*
  * Deactivate the Jetpack module with moduleSlug on the site with id siteId
  *
  * @param {int} [siteId]

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -144,7 +144,7 @@ Undocumented.prototype.jetpackModuleActivate = function( siteId, moduleSlug, fn 
 	//@TODO: implement and test this endpoint, it's currently not working
 	return this.wpcom.req.post(
 		{ path: '/jetpack-blogs/' + siteId + '/rest-api/' },
-		{ path: '/module/' + moduleSlug + '/active/', body: JSON.stringify( { active: true } ) },
+		{ path: '/jetpack/v4/module/' + moduleSlug + '/active/', body: JSON.stringify( { active: true } ) },
 		fn
 	);
 };

--- a/client/state/jetpack-settings/modules/actions.js
+++ b/client/state/jetpack-settings/modules/actions.js
@@ -28,7 +28,7 @@ export const activateModule = ( siteId, moduleSlug ) => {
 			moduleSlug
 		} );
 
-		return wp.undocumented().jetpackModulesActivate( siteId, moduleSlug )
+		return wp.undocumented().jetpackModuleActivate( siteId, moduleSlug )
 			.then( () => {
 				dispatch( {
 					type: JETPACK_MODULE_ACTIVATE_SUCCESS,

--- a/client/state/jetpack-settings/modules/test/actions.js
+++ b/client/state/jetpack-settings/modules/test/actions.js
@@ -55,8 +55,16 @@ describe( 'actions', () => {
 		describe( '#success', () => {
 			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
-				.post( '/rest/v1.1/sites/123456/jetpack/modules/module-a' )
-				.reply( 200, MODULE_DATA_FIXTURE[ 'module-a' ] );
+					.post( '/rest/v1.1/jetpack-blogs/123456/rest-api/', {
+						path: '/module/module-a/active/',
+						body: JSON.stringify( { active: true } )
+					} )
+					.reply( 200, {
+						data: {
+							code: 'success',
+							message: 'The requested Jetpack module was activated.'
+						}
+					} );
 			} );
 
 			it( 'should dispatch JETPACK_MODULE_ACTIVATE_SUCCESS when API activates a module', () => {
@@ -74,11 +82,14 @@ describe( 'actions', () => {
 		describe( '#failure', () => {
 			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
-				.post( '/rest/v1.1/sites/123456/jetpack/modules/module-a' )
-				.reply( 400, {
-					error: 'activation_error',
-					message: 'The Jetpack Module is already activated.'
-				} );
+					.post( '/rest/v1.1/jetpack-blogs/123456/rest-api/', {
+						path: '/module/module-a/active/',
+						body: JSON.stringify( { active: true } )
+					} )
+					.reply( 400, {
+						error: 'activation_error',
+						message: 'The Jetpack Module is already activated.'
+					} );
 			} );
 
 			it( 'should dispatch JETPACK_MODULE_ACTIVATE_FAILURE when activating a module fails', () => {

--- a/client/state/jetpack-settings/modules/test/actions.js
+++ b/client/state/jetpack-settings/modules/test/actions.js
@@ -56,7 +56,7 @@ describe( 'actions', () => {
 			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.post( '/rest/v1.1/jetpack-blogs/123456/rest-api/', {
-						path: '/module/module-a/active/',
+						path: '/jetpack/v4/module/module-a/active/',
 						body: JSON.stringify( { active: true } )
 					} )
 					.reply( 200, {
@@ -83,7 +83,7 @@ describe( 'actions', () => {
 			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.post( '/rest/v1.1/jetpack-blogs/123456/rest-api/', {
-						path: '/module/module-a/active/',
+						path: '/jetpack/v4/module/module-a/active/',
 						body: JSON.stringify( { active: true } )
 					} )
 					.reply( 400, {


### PR DESCRIPTION
This PR updates the `activateJetpackModule()` action to use the REST API of the Jetpack site instead of the XML-RPC one. Tests are also updated accordingly. This PR is part of the Jetpack Module Settings group effort (#9171).

### New WP.COM API methods

For interacting with the .com API it introduces a new method that is not yet implemented on the API side:

* `jetpackModuleActivate()`

In order to fully test the method you can:

* Apply D3588-code on your .com sandbox
* Apply Automattic/jetpack#5418 on your Jetpack site (this PR is needed to allow remote requests to the Jetpack REST API).
* Connect your Jetpack site to your .com sandbox and verify they talk to each other.

### To test

* Get this branch going locally
* Verify all module actions tests pass:

```
npm run test-client client/state/jetpack-settings/modules/test/actions.js
```
