### PR TITLE
Jetpack Settings: Use the Jetpack site REST API for module deactivation

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -175,7 +175,7 @@ Undocumented.prototype.jetpackModuleDeactivate = function( siteId, moduleSlug, f
 	//@TODO: implement and test this endpoint, it's currently not working
 	return this.wpcom.req.post(
 		{ path: '/jetpack-blogs/' + siteId + '/rest-api/' },
-		{ path: '/module/' + moduleSlug + '/active/', body: JSON.stringify( { active: false } ) },
+		{ path: '/jetpack/v4/module/' + moduleSlug + '/active/', body: JSON.stringify( { active: false } ) },
 		fn
 	);
 };

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -163,6 +163,24 @@ Undocumented.prototype.jetpackModulesDeactivate = function( siteId, moduleSlug, 
 };
 
 /*
+ * Deactivate a Jetpack module with slug moduleSlug for a site with id siteid.
+ * Similar to jetpackModulesDeactivate(), but uses the REST API of the Jetpack site.
+ *
+ * @param {int} [siteId]
+ * @param {string} [moduleSlug]
+ * @param {Function} fn
+ * @api public
+ */
+Undocumented.prototype.jetpackModuleDeactivate = function( siteId, moduleSlug, fn ) {
+	//@TODO: implement and test this endpoint, it's currently not working
+	return this.wpcom.req.post(
+		{ path: '/jetpack-blogs/' + siteId + '/rest-api/' },
+		{ path: '/module/' + moduleSlug + '/active/', body: JSON.stringify( { active: false } ) },
+		fn
+	);
+};
+
+/*
  * Retrieve the settings of a Jetpack module with moduleSlug on the site with id siteId
  *
  * @param {int} [siteId]

--- a/client/state/jetpack-settings/modules/actions.js
+++ b/client/state/jetpack-settings/modules/actions.js
@@ -54,7 +54,7 @@ export const deactivateModule = ( siteId, moduleSlug ) => {
 			moduleSlug
 		} );
 
-		return wp.undocumented().jetpackModulesDeactivate( siteId, moduleSlug )
+		return wp.undocumented().jetpackModuleDeactivate( siteId, moduleSlug )
 			.then( () => {
 				dispatch( {
 					type: JETPACK_MODULE_DEACTIVATE_SUCCESS,

--- a/client/state/jetpack-settings/modules/test/actions.js
+++ b/client/state/jetpack-settings/modules/test/actions.js
@@ -122,8 +122,16 @@ describe( 'actions', () => {
 		describe( '#success', () => {
 			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
-				.post( '/rest/v1.1/sites/123456/jetpack/modules/module-b' )
-				.reply( 200, MODULE_DATA_FIXTURE[ 'module-b' ] );
+					.post( '/rest/v1.1/jetpack-blogs/123456/rest-api/', {
+						path: '/module/module-b/active/',
+						body: JSON.stringify( { active: false } )
+					} )
+					.reply( 200, {
+						data: {
+							code: 'success',
+							message: 'The requested Jetpack module was deactivated.'
+						}
+					} );
 			} );
 
 			it( 'should dispatch JETPACK_MODULE_DEACTIVATE_SUCCESS when API deactivates a module', () => {
@@ -141,11 +149,14 @@ describe( 'actions', () => {
 		describe( '#failure', () => {
 			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
-				.post( '/rest/v1.1/sites/123456/jetpack/modules/module-b' )
-				.reply( 400, {
-					error: 'deactivation_error',
-					message: 'The Jetpack Module is already deactivated.'
-				} );
+					.post( '/rest/v1.1/jetpack-blogs/123456/rest-api/', {
+						path: '/module/module-b/active/',
+						body: JSON.stringify( { active: false } )
+					} )
+					.reply( 400, {
+						error: 'deactivation_error',
+						message: 'The Jetpack Module is already deactivated.'
+					} );
 			} );
 
 			it( 'should dispatch JETPACK_MODULE_DEACTIVATE_FAILURE when deactivating a module fails', () => {

--- a/client/state/jetpack-settings/modules/test/actions.js
+++ b/client/state/jetpack-settings/modules/test/actions.js
@@ -123,7 +123,7 @@ describe( 'actions', () => {
 			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.post( '/rest/v1.1/jetpack-blogs/123456/rest-api/', {
-						path: '/module/module-b/active/',
+						path: '/jetpack/v4/module/module-b/active/',
 						body: JSON.stringify( { active: false } )
 					} )
 					.reply( 200, {
@@ -150,7 +150,7 @@ describe( 'actions', () => {
 			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.post( '/rest/v1.1/jetpack-blogs/123456/rest-api/', {
-						path: '/module/module-b/active/',
+						path: '/jetpack/v4/module/module-b/active/',
 						body: JSON.stringify( { active: false } )
 					} )
 					.reply( 400, {

--- a/client/state/jetpack-settings/modules/test/actions.js
+++ b/client/state/jetpack-settings/modules/test/actions.js
@@ -13,7 +13,6 @@ import {
 	deactivateModule,
 	fetchModuleList
 } from '../actions';
-import { moduleData as MODULE_DATA_FIXTURE } from './fixture';
 import {
 	JETPACK_MODULE_ACTIVATE,
 	JETPACK_MODULE_ACTIVATE_SUCCESS,


### PR DESCRIPTION
This PR updates the `deactivateJetpackModule()` action to use the REST API of the Jetpack site instead of the XML-RPC one. Tests are also updated accordingly. This PR is part of the Jetpack Module Settings group effort (#9171).

### New WP.COM API methods

For interacting with the .com API it introduces a new method that is not yet implemented on the API side:

* `jetpackModuleDeactivate()`

In order to fully test the method you can:

* Apply D3588-code on your .com sandbox
* Apply Automattic/jetpack#5418 on your Jetpack site (this PR is needed to allow remote requests to the Jetpack REST API).
* Connect your Jetpack site to your .com sandbox and verify they talk to each other.

### To test

* Get this branch going locally
* Verify all module actions tests pass:

```
npm run test-client client/state/jetpack-settings/modules/test/actions.js
```
