### PR TITLE
Jetpack Settings: Use the Jetpack site REST API for retrieving module data

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -106,6 +106,19 @@ Undocumented.prototype.jetpackModules = function( siteId, fn ) {
 };
 
 /*
+ * Retrieve Jetpack modules data for a site with id siteid.
+ * Similar to jetpackModules(), but uses the REST API of the Jetpack site.
+ *
+ * @param {int}      [siteId]
+ * @param {Function} fn
+ * @api public
+ */
+Undocumented.prototype.getJetpackModules = function( siteId, fn ) {
+	//@TODO: implement and test this endpoint, it's currently not working
+	return this.wpcom.req.get( { path: '/jetpack-blogs/' + siteId + '/rest-api/' }, { path: '/module/all/' }, fn );
+};
+
+/*
  * Activate the Jetpack module with moduleSlug on the site with id siteId
  *
  * @param {int} [siteId]

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -115,7 +115,7 @@ Undocumented.prototype.jetpackModules = function( siteId, fn ) {
  */
 Undocumented.prototype.getJetpackModules = function( siteId, fn ) {
 	//@TODO: implement and test this endpoint, it's currently not working
-	return this.wpcom.req.get( { path: '/jetpack-blogs/' + siteId + '/rest-api/' }, { path: '/module/all/' }, fn );
+	return this.wpcom.req.get( { path: '/jetpack-blogs/' + siteId + '/rest-api/' }, { path: '/jetpack/v4/module/all/' }, fn );
 };
 
 /*

--- a/client/state/jetpack-settings/modules/actions.js
+++ b/client/state/jetpack-settings/modules/actions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { omit, map } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import {
@@ -92,7 +97,15 @@ export const fetchModuleList = ( siteId ) => {
 
 		return wp.undocumented().getJetpackModules( siteId )
 			.then( ( { data } ) => {
-				dispatch( receiveJetpackModules( siteId, data ) );
+				const modules = map(
+					data,
+					( module ) => ( {
+						active: module.activated,
+						...omit( module, 'activated' )
+					} )
+				);
+
+				dispatch( receiveJetpackModules( siteId, modules ) );
 				dispatch( {
 					type: JETPACK_MODULES_REQUEST_SUCCESS,
 					siteId

--- a/client/state/jetpack-settings/modules/actions.js
+++ b/client/state/jetpack-settings/modules/actions.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { keyBy } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import {
@@ -95,10 +90,9 @@ export const fetchModuleList = ( siteId ) => {
 			siteId
 		} );
 
-		return wp.undocumented().jetpackModules( siteId )
-			.then( ( data ) => {
-				const modules = keyBy( data.modules, 'id' );
-				dispatch( receiveJetpackModules( siteId, modules ) );
+		return wp.undocumented().getJetpackModules( siteId )
+			.then( ( { data } ) => {
+				dispatch( receiveJetpackModules( siteId, data ) );
 				dispatch( {
 					type: JETPACK_MODULES_REQUEST_SUCCESS,
 					siteId

--- a/client/state/jetpack-settings/modules/selectors.js
+++ b/client/state/jetpack-settings/modules/selectors.js
@@ -13,7 +13,7 @@ import { get } from 'lodash';
  * @return {?Boolean}            Whether the module is active
  */
 export function isModuleActive( state, siteId, moduleSlug ) {
-	return get( state.jetpackSettings.jetpackModules.items, [ siteId, moduleSlug, 'active' ], null );
+	return get( state.jetpackSettings.jetpackModules.items, [ siteId, moduleSlug, 'activated' ], null );
 }
 
 /**

--- a/client/state/jetpack-settings/modules/selectors.js
+++ b/client/state/jetpack-settings/modules/selectors.js
@@ -13,7 +13,7 @@ import { get } from 'lodash';
  * @return {?Boolean}            Whether the module is active
  */
 export function isModuleActive( state, siteId, moduleSlug ) {
-	return get( state.jetpackSettings.jetpackModules.items, [ siteId, moduleSlug, 'activated' ], null );
+	return get( state.jetpackSettings.jetpackModules.items, [ siteId, moduleSlug, 'active' ], null );
 }
 
 /**

--- a/client/state/jetpack-settings/modules/test/actions.js
+++ b/client/state/jetpack-settings/modules/test/actions.js
@@ -3,6 +3,7 @@
  */
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { omit, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -179,7 +180,13 @@ describe( 'actions', () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: JETPACK_MODULES_RECEIVE,
 						siteId,
-						modules: API_MODULE_LIST_RESPONSE_FIXTURE.data
+						modules: map(
+							API_MODULE_LIST_RESPONSE_FIXTURE.data,
+							( module ) => ( {
+								active: module.activated,
+								...omit( module, 'activated' )
+							} )
+						)
 					} );
 				} );
 			} );

--- a/client/state/jetpack-settings/modules/test/actions.js
+++ b/client/state/jetpack-settings/modules/test/actions.js
@@ -160,7 +160,7 @@ describe( 'actions', () => {
 					.persist()
 					.get( '/rest/v1.1/jetpack-blogs/123456/rest-api/' )
 					.query( {
-						path: '/module/all/'
+						path: '/jetpack/v4/module/all/'
 					} )
 					.reply( 200, API_MODULE_LIST_RESPONSE_FIXTURE );
 			} );
@@ -208,7 +208,7 @@ describe( 'actions', () => {
 					.persist()
 					.get( '/rest/v1.1/jetpack-blogs/123456/rest-api/' )
 					.query( {
-						path: '/module/all/'
+						path: '/jetpack/v4/module/all/'
 					} )
 					.reply( 400, {
 						message: 'Invalid request.'

--- a/client/state/jetpack-settings/modules/test/fixture.js
+++ b/client/state/jetpack-settings/modules/test/fixture.js
@@ -2,11 +2,11 @@ export const modules = {
 	123456: {
 		'module-a': {
 			module: 'module-a',
-			active: false
+			activated: false
 		},
 		'module-b': {
 			module: 'module-b',
-			active: true,
+			activated: true,
 			options: {
 				c: {
 					currentValue: 2
@@ -31,27 +31,27 @@ export const requests = {
 };
 
 export const api_module_list_response = {
-	modules: [
-		{
-			id: 'module-a',
-			active: false
+	data: {
+		'module-a': {
+			module: 'module-a',
+			activated: false
 		},
-		{
-			id: 'module-b',
-			active: true,
+		'module-b': {
+			module: 'module-b',
+			activated: true,
 			options: {
 				c: {
 					currentValue: 2
 				}
 			}
 		}
-	]
+	}
 };
 
 export const moduleData = {
 	'module-a': {
-		id: 'module-a',
-		active: false,
+		module: 'module-a',
+		activated: false,
 		name: 'Module A',
 		description: 'Just another awesome module',
 		sort: 1,
@@ -61,8 +61,8 @@ export const moduleData = {
 		module_tags: [ 'Test tag' ]
 	},
 	'module-b': {
-		id: 'module-b',
-		active: true,
+		module: 'module-b',
+		activated: true,
 		name: 'Module A',
 		description: 'Just another awesome module',
 		sort: 1,

--- a/client/state/jetpack-settings/modules/test/fixture.js
+++ b/client/state/jetpack-settings/modules/test/fixture.js
@@ -2,11 +2,11 @@ export const modules = {
 	123456: {
 		'module-a': {
 			module: 'module-a',
-			activated: false
+			active: false
 		},
 		'module-b': {
 			module: 'module-b',
-			activated: true,
+			active: true,
 			options: {
 				c: {
 					currentValue: 2
@@ -51,7 +51,7 @@ export const api_module_list_response = {
 export const moduleData = {
 	'module-a': {
 		module: 'module-a',
-		activated: false,
+		active: false,
 		name: 'Module A',
 		description: 'Just another awesome module',
 		sort: 1,
@@ -62,7 +62,7 @@ export const moduleData = {
 	},
 	'module-b': {
 		module: 'module-b',
-		activated: true,
+		active: true,
 		name: 'Module A',
 		description: 'Just another awesome module',
 		sort: 1,


### PR DESCRIPTION
This PR updates the `fetchModuleList()` action to use the REST API of the Jetpack site instead of the XML-RPC one. Tests are also updated accordingly, and a minor change to selectors was necessary. This PR is part of the Jetpack Module Settings group effort (#9171).

### New WP.COM API methods

For interacting with the .com API it introduces a new method that is not yet implemented on the API side:

* `getJetpackModules()`

In order to fully test the method you can:

* Apply D3588-code on your .com sandbox
* Apply Automattic/jetpack#5418 on your Jetpack site (this PR is needed to allow remote requests to the Jetpack REST API).
* Connect your Jetpack site to your .com sandbox and verify they talk to each other.

### To test

* Get this branch going locally
* Verify all modules tests pass:

```
npm run test-client client/state/jetpack-settings/modules/
```
