### PR TITLE
Site Picker: Make paths translatable

### DIFF
--- a/client/my-sites/sites/sites.jsx
+++ b/client/my-sites/sites/sites.jsx
@@ -64,7 +64,14 @@ export const Sites = React.createClass( {
 			return this.props.getSiteSelectionHeaderText();
 		}
 
-		const path = this.props.path.split( '?' )[ 0 ].replace( /\//g, ' ' );
+		let path = this.props.path.split( '?' )[ 0 ].replace( /\//g, ' ' );
+
+		switch ( path.toLowerCase().trim() ) {
+			case 'insights':
+			case 'stats insights':
+				path = this.translate( 'Insights' );
+				break;
+		}
 
 		return this.translate( 'Please select a site to open {{strong}}%(path)s{{/strong}}', {
 			args: {

--- a/client/my-sites/sites/sites.jsx
+++ b/client/my-sites/sites/sites.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import page from 'page';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -64,22 +65,33 @@ export const Sites = React.createClass( {
 			return this.props.getSiteSelectionHeaderText();
 		}
 
-		let path = this.props.path.split( '?' )[ 0 ].replace( /\//g, ' ' );
+		let path = this.props.path.split( '?' )[ 0 ].split( '/' )[ 1 ].toLowerCase();
 
-		switch ( path.toLowerCase().trim() ) {
-			case 'insights':
-			case 'stats insights':
-				path = this.translate( 'Insights' );
-				break;
-			case 'domains':
-				path = this.translate( 'Domains' );
+		switch ( path ) {
+			case 'stats':
+				path = i18n.translate( 'Insights' );
 				break;
 			case 'plans':
-				path = this.translate( 'Plans' );
+				path = i18n.translate( 'Plans' );
+				break;
+			case 'media':
+				path = i18n.translate( 'Media' );
+				break;
+			case 'sharing':
+				path = i18n.translate( 'Sharing' );
+				break;
+			case 'people':
+				path = i18n.translate( 'People' );
+				break;
+			case 'domains':
+				path = i18n.translate( 'Domains' );
+				break;
+			case 'settings':
+				path = i18n.translate( 'Settings' );
 				break;
 		}
 
-		return this.translate( 'Please select a site to open {{strong}}%(path)s{{/strong}}', {
+		return i18n.translate( 'Please select a site to open {{strong}}%(path)s{{/strong}}', {
 			args: {
 				path: path
 			},

--- a/client/my-sites/sites/sites.jsx
+++ b/client/my-sites/sites/sites.jsx
@@ -65,7 +65,10 @@ export const Sites = React.createClass( {
 			return this.props.getSiteSelectionHeaderText();
 		}
 
-		let path = this.props.path.split( '?' )[ 0 ].split( '/' )[ 1 ].toLowerCase();
+		let path = this.props.path.split( '?' )[ 0 ].split( '/' )[ 1 ];
+		if ( typeof path !== 'undefined' ) {
+			path = path.toLowerCase();
+		}
 
 		switch ( path ) {
 			case 'stats':

--- a/client/my-sites/sites/sites.jsx
+++ b/client/my-sites/sites/sites.jsx
@@ -71,6 +71,12 @@ export const Sites = React.createClass( {
 			case 'stats insights':
 				path = this.translate( 'Insights' );
 				break;
+			case 'domains':
+				path = this.translate( 'Domains' );
+				break;
+			case 'plans':
+				path = this.translate( 'Plans' );
+				break;
 		}
 
 		return this.translate( 'Please select a site to open {{strong}}%(path)s{{/strong}}', {


### PR DESCRIPTION
Addresses #10072. Because the path title simply comes from the URL, we need to take a whitelist approach. If you know more paths that could use this treatment, feel free to list them here, and I'll add them.

Edit (2017-05-08, @yoavf):
**Testing:**
- Set your UI language to Fr
- Visit the following paths, and make sure the location is translated.
  - /stats/insights
  - /plans
  - /domains
  - /media
  - /sharing
  - /people/team
  - /settings
  - /settings/import

Example: for /people/team you should see
![screen shot 2017-05-08 at 10 30 55](https://cloud.githubusercontent.com/assets/844866/25794425/7fbc894e-33d9-11e7-8c7d-7a94709dd41a.png)
instead of
![screen shot 2017-05-08 at 10 30 36](https://cloud.githubusercontent.com/assets/844866/25794431/892861a6-33d9-11e7-9b64-d76b209b6b96.png)

