### PR TITLE
Taxonomies: Unvalidate the term form when no parent selected and Top level unchecked

### DIFF
--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -32,7 +32,7 @@ class TermFormDialog extends Component {
 		selectedParent: [],
 		isTopLevel: true,
 		isValid: false,
-		error: null,
+		errors: {},
 		saving: false
 	};
 
@@ -171,14 +171,13 @@ class TermFormDialog extends Component {
 	}
 
 	isValid() {
-		let error;
-
+		const errors = {};
 		const values = this.getFormValues();
 
+		// Validating the name
 		if ( ! values.name.length ) {
-			error = true;
+			errors.name = this.props.translate( 'Name required', { textOnly: true } );
 		}
-
 		const lowerCasedTermName = values.name.toLowerCase();
 		const matchingTerm = find( this.props.terms, ( term ) => {
 			return (
@@ -186,22 +185,28 @@ class TermFormDialog extends Component {
 				( ! this.props.term || term.ID !== this.props.term.ID )
 			);
 		} );
-
 		if ( matchingTerm ) {
-			error = this.props.translate( 'Name already exists', {
+			errors.name = this.props.translate( 'Name already exists', {
 				context: 'Terms: Add term error message - duplicate term name exists',
 				textOnly: true
 			} );
 		}
 
-		if ( error !== this.state.error ) {
-			this.setState( {
-				error: error,
-				isValid: ! error
+		// Validating the parent
+		if ( this.props.isHierarchical && ! this.state.isTopLevel && ! values.parent ) {
+			errors.parent = this.props.translate( 'Parent item required when "Top level" is unchecked', {
+				context: 'Terms: Add term error message',
+				textOnly: true
 			} );
 		}
 
-		return ! error;
+		const isValid = ! Object.keys( errors ).length;
+		this.setState( {
+			errors,
+			isValid
+		} );
+
+		return isValid;
 	}
 
 	renderParentSelector() {
@@ -212,6 +217,7 @@ class TermFormDialog extends Component {
 			query.search = searchTerm;
 		}
 		const hideTermAndChildren = get( this.props.term, 'ID' );
+		const isError = !! this.state.errors.parent;
 
 		// if there is only one term for the site, and we are editing that term
 		// do not show the parent selector
@@ -231,12 +237,14 @@ class TermFormDialog extends Component {
 				<TermTreeSelectorTerms
 					siteId={ siteId }
 					taxonomy={ taxonomy }
+					isError={ isError }
 					onSearch={ this.onSearch }
 					onChange={ this.onParentChange }
 					query={ query }
 					selected={ selectedParent }
 					hideTermAndChildren={ hideTermAndChildren }
 				/>
+				{ isError && <FormInputValidation isError text={ this.state.errors.parent } /> }
 			</FormFieldset>
 		);
 	}
@@ -257,7 +265,7 @@ class TermFormDialog extends Component {
 			onClick: this.saveTerm
 		} ];
 
-		const isError = this.state.error && !! this.state.error.length;
+		const isError = !! this.state.errors.name;
 
 		return (
 			<Dialog
@@ -277,7 +285,7 @@ class TermFormDialog extends Component {
 						value={ name }
 						onChange={ this.onNameChange }
 					/>
-					{ isError && <FormInputValidation isError text={ this.state.error } /> }
+					{ isError && <FormInputValidation isError text={ this.state.errors.name } /> }
 				</FormFieldset>
 				{ showDescriptionInput && <FormFieldset>
 						<FormLegend>

--- a/client/blocks/term-tree-selector/style.scss
+++ b/client/blocks/term-tree-selector/style.scss
@@ -9,6 +9,10 @@
 		background-color: transparent;
 		border: none;
 	}
+
+	&.is-error {
+		border-color: $alert-red;
+	}
 }
 
 .term-tree-selector__search {

--- a/client/blocks/term-tree-selector/terms.jsx
+++ b/client/blocks/term-tree-selector/terms.jsx
@@ -55,7 +55,8 @@ const TermTreeSelectorList = React.createClass( {
 		defaultTermId: PropTypes.number,
 		lastPage: PropTypes.number,
 		onSearch: PropTypes.func,
-		onChange: PropTypes.func
+		onChange: PropTypes.func,
+		isError: PropTypes.bool
 	},
 
 	getInitialState() {
@@ -394,10 +395,11 @@ const TermTreeSelectorList = React.createClass( {
 		const searchLength = this.state.searchTerm.length;
 		const showSearch = ( searchLength > 0 || ! isCompact ) &&
 			( this.props.terms || ( ! this.props.terms && searchLength > 0 ) );
-		const { className, loading, siteId, taxonomy, query } = this.props;
+		const { className, isError, loading, siteId, taxonomy, query } = this.props;
 		const classes = classNames( 'term-tree-selector', className, {
 			'is-loading': loading,
-			'is-compact': isCompact
+			'is-compact': isCompact,
+			'is-error': isError
 		} );
 
 		return (


### PR DESCRIPTION
This PR seeks to enhance the errors management in TermFormDialog Component.

 - We now show "Name required" if we leave the term name empty
 - We also invalidate the form and show a message if "Top level" is unchecked but no parent term is selected.

<img width="547" alt="screen shot 2016-12-15 at 10 58 51" src="https://cloud.githubusercontent.com/assets/272444/21219536/7e514418-c2b5-11e6-9b21-4ef556bff5b0.png">

**Testing instructions**

 - Edit a top level category from `/settings/taxonomies/category/$site`
 - Uncheck "Top Level"
 - You should see a validation error
 - Select a parent category
 - The validation error should disappear