### PR TITLE
Revert "Framework: Upgrade to react-redux v5"

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -90,8 +90,11 @@ const ThemeSheet = React.createClass( {
 	},
 
 	getDefaultProps() {
+		// The defaultOption default prop is surprisingly important, see the long
+		// comment near the connect() function at the bottom of this file.
 		return {
-			section: ''
+			section: '',
+			defaultOption: {}
 		};
 	},
 
@@ -575,6 +578,29 @@ const ThemeSheetWithOptions = ( props ) => {
 };
 
 export default connect(
+	/*
+	 * A number of the props that this mapStateToProps function computes are used
+	 * by ThemeSheetWithOptions to compute defaultOption. After a state change
+	 * triggered by an async action, connect()ed child components are, quite
+	 * counter-intuitively, updated before their connect()ed parents (this is
+	 * https://github.com/reactjs/redux/issues/1415), and might be fixed by
+	 * react-redux 5.0.
+	 * For this reason, after e.g. activating a theme in single-site mode,
+	 * first the ThemeSheetWithOptions component's (child) connectOptions component
+	 * will update in response to the currently displayed theme being activated.
+	 * Doing so, it will filter and remove the activate option (adding customize
+	 * instead). However, since the parent connect()ed-ThemeSheetWithOptions will
+	 * only react to the state change afterwards, there is a brief moment when
+	 * connectOptions still receives "activate" as its defaultOption prop, when
+	 * activate is no longer part of its filtered options set, hence passing on
+	 * undefined as the defaultOption object prop for its child. For the theme
+	 * sheet, which eventually gets that defaultOption object prop, this means
+	 * we must be careful to not accidentally access any attribute of that
+	 * defaultOption prop. Otherwise, there will be an error that will prevent the
+	 * state update from finishing properly, hence not updating defaultOption at all.
+	 * The solution to this incredibly intricate issue is simple: Give ThemeSheet
+	 * a valid defaultProp for defaultOption.
+	 */
 	( state, { id } ) => {
 		const selectedSite = getSelectedSite( state );
 		const siteSlug = selectedSite ? getSiteSlug( state, selectedSite.ID ) : '';

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2255,7 +2255,7 @@
       "version": "0.0.3"
     },
     "jsx-ast-utils": {
-      "version": "1.3.5",
+      "version": "1.3.4",
       "dev": true
     },
     "key-mirror": {
@@ -2337,9 +2337,6 @@
     "lodash-deep": {
       "version": "1.5.3",
       "dev": true
-    },
-    "lodash-es": {
-      "version": "4.17.2"
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -3115,7 +3112,7 @@
       "version": "1.0.2"
     },
     "react-redux": {
-      "version": "5.0.1"
+      "version": "4.4.5"
     },
     "react-tap-event-plugin": {
       "version": "2.0.1"
@@ -3281,7 +3278,7 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.2.0"
+      "version": "1.1.7"
     },
     "resolve-from": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "react-dom": "15.4.0",
     "react-masonry-component": "4.2.2",
     "react-pure-render": "1.0.2",
-    "react-redux": "5.0.1",
+    "react-redux": "4.4.5",
     "react-tap-event-plugin": "2.0.1",
     "react-virtualized": "7.9.1",
     "redux": "3.0.4",


### PR DESCRIPTION
Reverts Automattic/wp-calypso#9707

because of (possibly related) errors in production

> Uncaught (in promise) TypeError: ReactDefaultInjection.inject is not a function