### PR TITLE
Framework: Explicitly add lru-cache

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2255,7 +2255,7 @@
       "version": "0.0.3"
     },
     "jsx-ast-utils": {
-      "version": "1.3.4",
+      "version": "1.3.5",
       "dev": true
     },
     "key-mirror": {
@@ -3278,7 +3278,7 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.1.7"
+      "version": "1.2.0"
     },
     "resolve-from": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "keymaster": "1.6.2",
     "localforage": "1.4.3",
     "lodash": "4.15.0",
+    "lru-cache": "4.0.1",
     "lunr": "0.5.7",
     "marked": "0.3.5",
     "moment": "2.10.6",


### PR DESCRIPTION
And update shrinkwrap

Production was failing, saying that cache.get was not a function.
I noticed that we don't explicitly depend on lru-cache, so this adds that dependency.

Unclear how this worked in the past...