### PR TITLE
Jetpack Settings: Add Theme Enhancements card under Writing Settings for Jetpack sites

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -321,6 +321,7 @@
 @import 'my-sites/site-settings/press-this/style';
 @import 'my-sites/site-settings/site-icon-setting/style';
 @import 'my-sites/site-settings/taxonomies/style';
+@import 'my-sites/site-settings/theme-enhancements/style';
 @import 'my-sites/importer/style';
 @import 'blocks/site/style';
 @import 'my-sites/sites/style';

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -20,7 +20,12 @@ import Card from 'components/card';
 import Button from 'components/button';
 import QueryTaxonomies from 'components/data/query-taxonomies';
 import TaxonomyCard from './taxonomies/taxonomy-card';
-import { isJetpackModuleActive, isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
+import {
+	isJetpackModuleActive,
+	isJetpackMinimumVersion,
+	isJetpackSite,
+	siteSupportsJetpackSettingsUI
+} from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestPostTypes } from 'state/post-types/actions';
 import CustomPostTypeFieldset from './custom-post-types-fieldset';
@@ -192,7 +197,7 @@ class SiteSettingsFormWriting extends Component {
 				) }
 
 				{
-					this.props.isJetpackSite && (
+					this.props.isJetpackSite && this.props.jetpackSettingsUISupported && (
 						<ThemeEnhancements
 							submittingForm={ this.state.submittingForm }
 							onSubmitForm={ this.handleSubmitForm }
@@ -223,6 +228,7 @@ const connectComponent = connect(
 		return {
 			jetpackCustomTypesModuleActive: false !== isJetpackModuleActive( state, siteId, 'custom-content-types' ),
 			jetpackVersionSupportsCustomTypes: false !== isJetpackMinimumVersion( state, siteId, '4.2.0' ),
+			jetpackSettingsUISupported: siteSupportsJetpackSettingsUI( state, siteId ),
 			isJetpackSite: isJetpackSite( state, siteId ),
 			siteId
 		};

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -30,6 +30,8 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestPostTypes } from 'state/post-types/actions';
 import CustomPostTypeFieldset from './custom-post-types-fieldset';
 import ThemeEnhancements from './theme-enhancements';
+import QueryJetpackModules from 'components/data/query-jetpack-modules';
+import QueryJetpackSettings from 'components/data/query-jetpack-settings';
 
 class SiteSettingsFormWriting extends Component {
 
@@ -101,6 +103,7 @@ class SiteSettingsFormWriting extends Component {
 			fields,
 			handleToggle,
 			isRequestingSettings,
+			isSavingSettings,
 			jetpackVersionSupportsCustomTypes,
 			onChangeField,
 			markChanged,
@@ -198,11 +201,17 @@ class SiteSettingsFormWriting extends Component {
 
 				{
 					this.props.isJetpackSite && this.props.jetpackSettingsUISupported && (
-						<ThemeEnhancements
-							submittingForm={ this.state.submittingForm }
-							onSubmitForm={ this.handleSubmitForm }
-							fetchingSettings={ this.state.fetchingSettings }
-							/>
+						<div>
+							<QueryJetpackSettings siteId={ this.props.siteId } />
+							<QueryJetpackModules siteId={ this.props.siteId } />
+							<ThemeEnhancements
+								onSubmitForm={ this.submitFormAndActivateCustomContentModule }
+								handleToggle={ handleToggle }
+								isSavingSettings={ isSavingSettings }
+								isRequestingSettings={ isRequestingSettings }
+								fields={ fields }
+								/>
+						</div>
 					)
 				}
 
@@ -243,7 +252,12 @@ const getFormSettings = partialRight( pick, [
 	'wpcom_publish_posts_with_markdown',
 	'markdown_supported',
 	'jetpack_testimonial',
-	'jetpack_portfolio'
+	'jetpack_portfolio',
+	'infinite_scroll',
+	'infinite_scroll_google_analytics',
+	'wp_mobile_excerpt',
+	'wp_mobile_featured_images',
+	'wp_mobile_app_promos'
 ] );
 
 export default flowRight(

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -31,7 +31,6 @@ import { requestPostTypes } from 'state/post-types/actions';
 import CustomPostTypeFieldset from './custom-post-types-fieldset';
 import ThemeEnhancements from './theme-enhancements';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
-import QueryJetpackSettings from 'components/data/query-jetpack-settings';
 
 class SiteSettingsFormWriting extends Component {
 
@@ -202,8 +201,8 @@ class SiteSettingsFormWriting extends Component {
 				{
 					this.props.isJetpackSite && this.props.jetpackSettingsUISupported && (
 						<div>
-							<QueryJetpackSettings siteId={ this.props.siteId } />
 							<QueryJetpackModules siteId={ this.props.siteId } />
+
 							<ThemeEnhancements
 								onSubmitForm={ this.submitFormAndActivateCustomContentModule }
 								handleToggle={ handleToggle }

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -24,7 +24,7 @@ import {
 	isJetpackModuleActive,
 	isJetpackMinimumVersion,
 	isJetpackSite,
-	siteSupportsJetpackSettingsUI
+	siteSupportsJetpackSettingsUi
 } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestPostTypes } from 'state/post-types/actions';
@@ -236,7 +236,7 @@ const connectComponent = connect(
 		return {
 			jetpackCustomTypesModuleActive: false !== isJetpackModuleActive( state, siteId, 'custom-content-types' ),
 			jetpackVersionSupportsCustomTypes: false !== isJetpackMinimumVersion( state, siteId, '4.2.0' ),
-			jetpackSettingsUISupported: siteSupportsJetpackSettingsUI( state, siteId ),
+			jetpackSettingsUISupported: siteSupportsJetpackSettingsUi( state, siteId ),
 			isJetpackSite: isJetpackSite( state, siteId ),
 			siteId
 		};

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -195,7 +195,7 @@ class SiteSettingsFormWriting extends Component {
 					this.props.isJetpackSite && (
 						<ThemeEnhancements
 							submittingForm={ this.state.submittingForm }
-							onSubmitForm={ this.submitFormAndActivateCustomContentModule }
+							onSubmitForm={ this.handleSubmitForm }
 							fetchingSettings={ this.state.fetchingSettings }
 							/>
 					)

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -20,10 +20,11 @@ import Card from 'components/card';
 import Button from 'components/button';
 import QueryTaxonomies from 'components/data/query-taxonomies';
 import TaxonomyCard from './taxonomies/taxonomy-card';
-import { isJetpackModuleActive, isJetpackMinimumVersion } from 'state/sites/selectors';
+import { isJetpackModuleActive, isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestPostTypes } from 'state/post-types/actions';
 import CustomPostTypeFieldset from './custom-post-types-fieldset';
+import ThemeEnhancements from './theme-enhancements';
 
 class SiteSettingsFormWriting extends Component {
 
@@ -190,6 +191,16 @@ class SiteSettingsFormWriting extends Component {
 					</div>
 				) }
 
+				{
+					this.props.isJetpackSite && (
+						<ThemeEnhancements
+							submittingForm={ this.state.submittingForm }
+							onSubmitForm={ this.submitFormAndActivateCustomContentModule }
+							fetchingSettings={ this.state.fetchingSettings }
+							/>
+					)
+				}
+
 				{ config.isEnabled( 'press-this' ) && (
 					<div>
 						{
@@ -212,6 +223,7 @@ const connectComponent = connect(
 		return {
 			jetpackCustomTypesModuleActive: false !== isJetpackModuleActive( state, siteId, 'custom-content-types' ),
 			jetpackVersionSupportsCustomTypes: false !== isJetpackMinimumVersion( state, siteId, '4.2.0' ),
+			isJetpackSite: isJetpackSite( state, siteId ),
 			siteId
 		};
 	},

--- a/client/my-sites/site-settings/jetpack-module-toggle/index.jsx
+++ b/client/my-sites/site-settings/jetpack-module-toggle/index.jsx
@@ -63,7 +63,7 @@ class JetpackModuleToggle extends Component {
 					toggling={ this.props.toggling }
 					onChange={ this.handleChange }
 					disabled={ this.props.disabled || this.props.toggleDisabled } >
-					<span>{ this.props.label }</span>
+					<span className="site-settings__toggle-label">{ this.props.label }</span>
 					{
 						this.props.description && (
 							<FormSettingExplanation isIndented>

--- a/client/my-sites/site-settings/jetpack-module-toggle/style.scss
+++ b/client/my-sites/site-settings/jetpack-module-toggle/style.scss
@@ -5,3 +5,8 @@
 .jetpack-module-toggle p.form-setting-explanation.is-indented {
 	margin-left: 32px;
 }
+
+.jetpack-module-toggle .site-settings__toggle-label {
+	flex: 0 1 100%;
+	margin-left: 12px;
+}

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -13,10 +13,9 @@ import { protectForm } from 'lib/protect-form';
 import SectionHeader from 'components/section-header';
 import Card from 'components/card';
 import Button from 'components/button';
-import FormLabel from 'components/forms/form-label';
-import FormCheckbox from 'components/forms/form-checkbox';
 import JetpackModuleToggle from '../jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
+import FormToggle from 'components/forms/form-toggle';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import QueryJetpackSettings from 'components/data/query-jetpack-settings';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -36,7 +35,6 @@ class ThemeEnhancements extends Component {
 
 		this.state = {};
 
-		this.onCheckboxChange = this.onCheckboxChange.bind( this );
 		this.onSubmitForm = this.onSubmitForm.bind( this );
 	}
 
@@ -58,13 +56,22 @@ class ThemeEnhancements extends Component {
 		return fieldValue;
 	}
 
-	onCheckboxChange( event ) {
-		const currentTargetName = event.currentTarget.name,
-			currentTargetChecked = !! event.currentTarget.checked;
+	isFieldTruthy( fieldName ) {
+		switch ( fieldName ) {
+			case 'wp_mobile_excerpt':
+			case 'wp_mobile_featured_images':
+				return this.state[ fieldName ] === 'enabled';
+		}
 
-		this.setState( {
-			[ currentTargetName ]: this.sanitizeFieldValue( currentTargetName, currentTargetChecked )
-		} );
+		return !! this.state[ fieldName ];
+	}
+
+	handleToggle( name ) {
+		return () => {
+			this.setState( {
+				[ name ]: this.sanitizeFieldValue( name, ! this.isFieldTruthy( name ) )
+			} );
+		};
 	}
 
 	onSubmitForm( event ) {
@@ -121,27 +128,29 @@ class ThemeEnhancements extends Component {
 						{
 							infiniteScrollModuleActive && (
 								<div className="theme-enhancements__module-settings is-indented">
-									<FormLabel>
-										<FormCheckbox
-											onChange={ this.onCheckboxChange }
-											disabled={ isFormPending }
-											checked={ !! this.state.infinite_scroll }
-											name="infinite_scroll" />
-										<span>{ translate( 'Scroll infinitely (Shows 7 posts on each load)' ) }</span>
-									</FormLabel>
+									<FormToggle
+										className="theme-enhancements__module-settings-toggle is-compact"
+										checked={ this.isFieldTruthy( 'infinite_scroll' ) }
+										disabled={ isFormPending }
+										onChange={ this.handleToggle( 'infinite_scroll' ) }>
+										<span>
+											{ translate(
+												'Scroll infinitely (Shows 7 posts on each load)'
+											) }
+										</span>
+									</FormToggle>
 
-									<FormLabel>
-										<FormCheckbox
-											onChange={ this.onCheckboxChange }
-											disabled={ isFormPending }
-											checked={ !! this.state.infinite_scroll_google_analytics }
-											name="infinite_scroll_google_analytics" />
+									<FormToggle
+										className="theme-enhancements__module-settings-toggle is-compact"
+										checked={ this.isFieldTruthy( 'infinite_scroll_google_analytics' ) }
+										disabled={ isFormPending }
+										onChange={ this.handleToggle( 'infinite_scroll_google_analytics' ) }>
 										<span>
 											{ translate(
 												'Track each infinite Scroll post load as a page view in Google Analytics'
 											) }
 										</span>
-									</FormLabel>
+									</FormToggle>
 								</div>
 							)
 						}
@@ -165,36 +174,41 @@ class ThemeEnhancements extends Component {
 						{
 							minilevenModuleActive && (
 								<div className="theme-enhancements__module-settings is-indented">
-									<FormLabel>
-										<FormCheckbox
-											onChange={ this.onCheckboxChange }
-											disabled={ isFormPending }
-											checked={ this.state.wp_mobile_excerpt === 'enabled' }
-											name="wp_mobile_excerpt" />
-										<span>{ translate( 'Use excerpts instead of full posts on front page and archive pages' ) }</span>
-									</FormLabel>
+									<FormToggle
+										className="theme-enhancements__module-settings-toggle is-compact"
+										checked={ this.isFieldTruthy( 'wp_mobile_excerpt' ) }
+										disabled={ isFormPending }
+										onChange={ this.handleToggle( 'wp_mobile_excerpt' ) }>
+										<span>
+											{ translate(
+												'Use excerpts instead of full posts on front page and archive pages'
+											) }
+										</span>
+									</FormToggle>
 
-									<FormLabel>
-										<FormCheckbox
-											onChange={ this.onCheckboxChange }
-											disabled={ isFormPending }
-											checked={ this.state.wp_mobile_featured_images === 'enabled' }
-											name="wp_mobile_featured_images" />
-										<span>{ translate( 'Hide all featured images' ) }</span>
-									</FormLabel>
+									<FormToggle
+										className="theme-enhancements__module-settings-toggle is-compact"
+										checked={ this.isFieldTruthy( 'wp_mobile_featured_images' ) }
+										disabled={ isFormPending }
+										onChange={ this.handleToggle( 'wp_mobile_featured_images' ) }>
+										<span>
+											{ translate(
+												'Hide all featured images'
+											) }
+										</span>
+									</FormToggle>
 
-									<FormLabel>
-										<FormCheckbox
-											onChange={ this.onCheckboxChange }
-											disabled={ isFormPending }
-											checked={ !! this.state.wp_mobile_app_promos }
-											name="wp_mobile_app_promos" />
+									<FormToggle
+										className="theme-enhancements__module-settings-toggle is-compact"
+										checked={ this.isFieldTruthy( 'wp_mobile_app_promos' ) }
+										disabled={ isFormPending }
+										onChange={ this.handleToggle( 'wp_mobile_app_promos' ) }>
 										<span>
 											{ translate(
 												'Show an ad for the WordPress mobile apps in the footer of the mobile theme'
 											) }
 										</span>
-									</FormLabel>
+									</FormToggle>
 								</div>
 							)
 						}

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -21,7 +21,11 @@ import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import QueryJetpackSettings from 'components/data/query-jetpack-settings';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isModuleActive, isFetchingModules } from 'state/jetpack-settings/modules/selectors';
-import { getJetpackSettings, isRequestingJetpackSettings } from 'state/jetpack-settings/settings/selectors';
+import {
+	getJetpackSettings,
+	isRequestingJetpackSettings,
+	isUpdatingJetpackSettings
+} from 'state/jetpack-settings/settings/selectors';
 import { updateSettings } from 'state/jetpack-settings/settings/actions';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
@@ -76,12 +80,13 @@ class ThemeEnhancements extends Component {
 			fetchingSettings,
 			fetchingModuleData,
 			submittingForm,
+			updatingSettings,
 			selectedSiteId,
 			infiniteScrollModuleActive,
 			minilevenModuleActive,
 			translate
 		} = this.props;
-		const isFormPending = fetchingSettings || fetchingModuleData || submittingForm;
+		const isFormPending = fetchingSettings || fetchingModuleData || submittingForm || updatingSettings;
 
 		return (
 			<div>
@@ -228,7 +233,8 @@ export default connect(
 			infiniteScrollModuleActive: !! isModuleActive( state, selectedSiteId, 'infinite-scroll' ),
 			minilevenModuleActive: !! isModuleActive( state, selectedSiteId, 'minileven' ),
 			moduleSettings,
-			fetchingModuleData: !! ( fetchingModules || fetchingSettings )
+			fetchingModuleData: !! ( fetchingModules || fetchingSettings ),
+			updatingSettings: isUpdatingJetpackSettings( state, selectedSiteId ),
 		};
 	},
 	{

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -33,6 +33,7 @@ class ThemeEnhancements extends Component {
 			infinite_scroll_google_analytics: 0,
 			wp_mobile_excerpt: 'disabled',
 			wp_mobile_featured_images: 'disabled',
+			wp_mobile_app_promos: 0
 		};
 
 		this.onCheckboxChange = this.onCheckboxChange.bind( this );
@@ -67,7 +68,7 @@ class ThemeEnhancements extends Component {
 				fields = [ 'infinite_scroll', 'infinite_scroll_google_analytics' ];
 				break;
 			case 'minileven':
-				fields = [ 'wp_mobile_excerpt', 'wp_mobile_featured_images' ];
+				fields = [ 'wp_mobile_excerpt', 'wp_mobile_featured_images', 'wp_mobile_app_promos' ];
 				break;
 		}
 
@@ -176,6 +177,14 @@ class ThemeEnhancements extends Component {
 											disabled={ submittingForm }
 											name="wp_mobile_featured_images" />
 										<span>{ translate( 'Hide all featured images' ) }</span>
+									</FormLabel>
+
+									<FormLabel>
+										<FormCheckbox
+											onChange={ this.onCheckboxChange }
+											disabled={ submittingForm }
+											name="wp_mobile_app_promos" />
+										<span>{ translate( 'Show an ad for the WordPress mobile apps in the footer of the mobile theme' ) }</span>
 									</FormLabel>
 								</div>
 							)

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { pick } from 'lodash';
+import { pick, isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,8 +18,10 @@ import FormCheckbox from 'components/forms/form-checkbox';
 import JetpackModuleToggle from '../jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
+import QueryJetpackModuleSettings from 'components/data/query-jetpack-module-settings';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isModuleActive } from 'state/jetpack-settings/modules/selectors';
+import { getCurrentModuleSettings } from 'state/jetpack-settings/module-settings/selectors';
 import { updateModuleSettings } from 'state/jetpack-settings/module-settings/actions';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
@@ -29,15 +31,26 @@ class ThemeEnhancements extends Component {
 		super( props );
 
 		this.state = {
-			infinite_scroll: 1,
-			infinite_scroll_google_analytics: 0,
+			infinite_scroll: true,
+			infinite_scroll_google_analytics: false,
 			wp_mobile_excerpt: 'disabled',
 			wp_mobile_featured_images: 'disabled',
-			wp_mobile_app_promos: 0
+			wp_mobile_app_promos: false
 		};
 
 		this.onCheckboxChange = this.onCheckboxChange.bind( this );
 		this.onSubmitForm = this.onSubmitForm.bind( this );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		const newState = {
+			...nextProps.infiniteScrollModuleSettings,
+			...nextProps.minilevenModuleSettings
+		};
+
+		if ( ! isEqual( newState, this.state ) ) {
+			this.setState( newState );
+		}
 	}
 
 	sanitizeFieldValue( fieldName, fieldValue ) {
@@ -97,6 +110,9 @@ class ThemeEnhancements extends Component {
 		return (
 			<div>
 				<QueryJetpackModules siteId={ selectedSiteId } />
+				<QueryJetpackModuleSettings siteId={ selectedSiteId } moduleSlug={ 'infinite-scroll' } />
+				<QueryJetpackModuleSettings siteId={ selectedSiteId } moduleSlug={ 'minileven' } />
+
 				<SectionHeader label={ translate( 'Theme Enhancements' ) }>
 					<Button
 						compact
@@ -129,6 +145,7 @@ class ThemeEnhancements extends Component {
 										<FormCheckbox
 											onChange={ this.onCheckboxChange }
 											disabled={ submittingForm }
+											checked={ !! this.state.infinite_scroll }
 											name="infinite_scroll" />
 										<span>{ translate( 'Scroll infinitely (Shows 7 posts on each load)' ) }</span>
 									</FormLabel>
@@ -137,6 +154,7 @@ class ThemeEnhancements extends Component {
 										<FormCheckbox
 											onChange={ this.onCheckboxChange }
 											disabled={ submittingForm }
+											checked={ !! this.state.infinite_scroll_google_analytics }
 											name="infinite_scroll_google_analytics" />
 										<span>
 											{ translate(
@@ -171,6 +189,7 @@ class ThemeEnhancements extends Component {
 										<FormCheckbox
 											onChange={ this.onCheckboxChange }
 											disabled={ submittingForm }
+											checked={ this.state.wp_mobile_excerpt === 'enabled' }
 											name="wp_mobile_excerpt" />
 										<span>{ translate( 'Use excerpts instead of full posts on front page and archive pages' ) }</span>
 									</FormLabel>
@@ -179,6 +198,7 @@ class ThemeEnhancements extends Component {
 										<FormCheckbox
 											onChange={ this.onCheckboxChange }
 											disabled={ submittingForm }
+											checked={ this.state.wp_mobile_featured_images === 'enabled' }
 											name="wp_mobile_featured_images" />
 										<span>{ translate( 'Hide all featured images' ) }</span>
 									</FormLabel>
@@ -187,6 +207,7 @@ class ThemeEnhancements extends Component {
 										<FormCheckbox
 											onChange={ this.onCheckboxChange }
 											disabled={ submittingForm }
+											checked={ !! this.state.wp_mobile_app_promos }
 											name="wp_mobile_app_promos" />
 										<span>
 											{ translate(
@@ -222,6 +243,8 @@ export default connect(
 			selectedSiteId,
 			infiniteScrollModuleActive: !! isModuleActive( state, selectedSiteId, 'infinite-scroll' ),
 			minilevenModuleActive: !! isModuleActive( state, selectedSiteId, 'minileven' ),
+			infiniteScrollModuleSettings: getCurrentModuleSettings( state, selectedSiteId, 'infinite-scroll' ),
+			minilevenModuleSettings: getCurrentModuleSettings( state, selectedSiteId, 'minileven' ),
 		};
 	},
 	{

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -1,13 +1,15 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { pick } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import { protectForm } from 'lib/protect-form';
 import SectionHeader from 'components/section-header';
 import Card from 'components/card';
 import Button from 'components/button';
@@ -18,113 +20,172 @@ import FormFieldset from 'components/forms/form-fieldset';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isModuleActive } from 'state/jetpack-settings/modules/selectors';
+import { updateModuleSettings } from 'state/jetpack-settings/module-settings/actions';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
 
-const ThemeEnhancements = ( {
-	onSubmitForm,
-	fetchingSettings,
-	submittingForm,
-	selectedSiteId,
-	infiniteScrollModuleActive,
-	minilevenModuleActive,
-	translate
-} ) => {
-	return (
-		<div>
-			<QueryJetpackModules siteId={ selectedSiteId } />
-			<SectionHeader label={ translate( 'Theme Enhancements' ) }>
-				<Button
-					compact
-					primary
-					onClick={ onSubmitForm }
-					disabled={ fetchingSettings || submittingForm }>
-					{ submittingForm ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
-				</Button>
-			</SectionHeader>
-			<Card className="theme-enhancements__card site-settings">
-				<FormFieldset>
-					<div className="theme-enhancements__info-link-container">
-						<InfoPopover position={ 'left' }>
-							<ExternalLink icon={ true } href={ 'https://jetpack.com/support/infinite-scroll' } target="_blank">
-								{ translate( 'Learn more about Infinite Scroll' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
+class ThemeEnhancements extends Component {
+	constructor( props ) {
+		super( props );
 
-					<JetpackModuleToggle
-						siteId={ selectedSiteId }
-						moduleSlug="infinite-scroll"
-						label={ translate( 'Add support for infinite scroll to your theme.' ) }
-						/>
+		this.state = {
+			infinite_scroll: 1,
+			infinite_scroll_google_analytics: 0,
+			wp_mobile_excerpt: 'disabled',
+			wp_mobile_featured_images: 'disabled',
+		};
 
-					{
-						infiniteScrollModuleActive && (
-							<div className="theme-enhancements__module-settings is-indented">
-								<FormLabel>
-									<FormCheckbox
-										disabled={ submittingForm }
-										name="infinite_scroll" />
-									<span>{ translate( 'Scroll infinitely (Shows 7 posts on each load)' ) }</span>
-								</FormLabel>
+		this.onCheckboxChange = this.onCheckboxChange.bind( this );
+		this.onSubmitForm = this.onSubmitForm.bind( this );
+	}
 
-								<FormLabel>
-									<FormCheckbox
-										disabled={ submittingForm }
-										name="infinite_scroll_google_analytics" />
-									<span>{ translate( 'Track each infinite Scroll post load as a page view in Google Analytics' ) }</span>
-								</FormLabel>
-							</div>
-						)
-					}
-				</FormFieldset>
+	sanitizeFieldValue( fieldName, fieldValue ) {
+		switch ( fieldName ) {
+			case 'wp_mobile_excerpt':
+			case 'wp_mobile_featured_images':
+				return fieldValue ? 'enabled' : 'disabled';
+		}
 
-				<FormFieldset>
-					<div className="theme-enhancements__info-link-container">
-						<InfoPopover position={ 'left' }>
-							<ExternalLink icon={ true } href={ 'https://jetpack.com/support/infinite-scroll' } target="_blank">
-								{ translate( 'Learn more about Infinite Scroll' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
+		return fieldValue;
+	}
 
-					<JetpackModuleToggle
-						siteId={ selectedSiteId }
-						moduleSlug="minileven"
-						label={ translate( 'Optimize your site with a phone-friendly theme.' ) }
-						/>
+	onCheckboxChange( event ) {
+		const currentTargetName = event.currentTarget.name,
+			currentTargetChecked = !! event.currentTarget.checked;
 
-					{
-						minilevenModuleActive && (
-							<div className="theme-enhancements__module-settings is-indented">
-								<FormLabel>
-									<FormCheckbox
-										disabled={ submittingForm }
-										name="wp_mobile_excerpt" />
-									<span>{ translate( 'Use excerpts instead of full posts on front page and archive pages' ) }</span>
-								</FormLabel>
+		this.setState( {
+			[ currentTargetName ]: this.sanitizeFieldValue( currentTargetName, currentTargetChecked )
+		} );
+	}
 
-								<FormLabel>
-									<FormCheckbox
-										disabled={ submittingForm }
-										name="wp_mobile_featured_images" />
-									<span>{ translate( 'Hide all featured images' ) }</span>
-								</FormLabel>
+	updateSettingsForModule( module ) {
+		const { selectedSiteId } = this.props;
+		let fields = [];
 
-								<FormLabel>
-									<FormCheckbox
-										disabled={ submittingForm }
-										name="wp_mobile_app_promos" />
-									<span>{ translate( 'Show an ad for the WordPress mobile apps in the footer' ) }</span>
-								</FormLabel>
-							</div>
-						)
-					}
-				</FormFieldset>
-			</Card>
-		</div>
-	);
-};
+		switch ( module ) {
+			case 'infinite-scroll':
+				fields = [ 'infinite_scroll', 'infinite_scroll_google_analytics' ];
+				break;
+			case 'minileven':
+				fields = [ 'wp_mobile_excerpt', 'wp_mobile_featured_images' ];
+				break;
+		}
+
+		if ( ! fields.length ) {
+			return;
+		}
+
+		return this.props.updateModuleSettings( selectedSiteId, module, pick( this.state, fields ) );
+	}
+
+	onSubmitForm() {
+		// TODO: real handling of the form
+		this.updateSettingsForModule( 'infinite-scroll' );
+		this.updateSettingsForModule( 'minileven' );
+	}
+
+	render() {
+		const {
+			fetchingSettings,
+			submittingForm,
+			selectedSiteId,
+			infiniteScrollModuleActive,
+			minilevenModuleActive,
+			translate
+		} = this.props;
+		return (
+			<div>
+				<QueryJetpackModules siteId={ selectedSiteId } />
+				<SectionHeader label={ translate( 'Theme Enhancements' ) }>
+					<Button
+						compact
+						primary
+						onClick={ this.onSubmitForm }
+						disabled={ fetchingSettings || submittingForm }>
+						{ submittingForm ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
+					</Button>
+				</SectionHeader>
+				<Card className="theme-enhancements__card site-settings">
+					<FormFieldset>
+						<div className="theme-enhancements__info-link-container">
+							<InfoPopover position={ 'left' }>
+								<ExternalLink icon={ true } href={ 'https://jetpack.com/support/infinite-scroll' } target="_blank">
+									{ translate( 'Learn more about Infinite Scroll' ) }
+								</ExternalLink>
+							</InfoPopover>
+						</div>
+
+						<JetpackModuleToggle
+							siteId={ selectedSiteId }
+							moduleSlug="infinite-scroll"
+							label={ translate( 'Add support for infinite scroll to your theme.' ) }
+							/>
+
+						{
+							infiniteScrollModuleActive && (
+								<div className="theme-enhancements__module-settings is-indented">
+									<FormLabel>
+										<FormCheckbox
+											onChange={ this.onCheckboxChange }
+											disabled={ submittingForm }
+											name="infinite_scroll" />
+										<span>{ translate( 'Scroll infinitely (Shows 7 posts on each load)' ) }</span>
+									</FormLabel>
+
+									<FormLabel>
+										<FormCheckbox
+											onChange={ this.onCheckboxChange }
+											disabled={ submittingForm }
+											name="infinite_scroll_google_analytics" />
+										<span>{ translate( 'Track each infinite Scroll post load as a page view in Google Analytics' ) }</span>
+									</FormLabel>
+								</div>
+							)
+						}
+					</FormFieldset>
+
+					<FormFieldset>
+						<div className="theme-enhancements__info-link-container">
+							<InfoPopover position={ 'left' }>
+								<ExternalLink icon={ true } href={ 'https://jetpack.com/support/infinite-scroll' } target="_blank">
+									{ translate( 'Learn more about Infinite Scroll' ) }
+								</ExternalLink>
+							</InfoPopover>
+						</div>
+
+						<JetpackModuleToggle
+							siteId={ selectedSiteId }
+							moduleSlug="minileven"
+							label={ translate( 'Optimize your site with a phone-friendly theme.' ) }
+							/>
+
+						{
+							minilevenModuleActive && (
+								<div className="theme-enhancements__module-settings is-indented">
+									<FormLabel>
+										<FormCheckbox
+											onChange={ this.onCheckboxChange }
+											disabled={ submittingForm }
+											name="wp_mobile_excerpt" />
+										<span>{ translate( 'Use excerpts instead of full posts on front page and archive pages' ) }</span>
+									</FormLabel>
+
+									<FormLabel>
+										<FormCheckbox
+											onChange={ this.onCheckboxChange }
+											disabled={ submittingForm }
+											name="wp_mobile_featured_images" />
+										<span>{ translate( 'Hide all featured images' ) }</span>
+									</FormLabel>
+								</div>
+							)
+						}
+					</FormFieldset>
+				</Card>
+			</div>
+		);
+	}
+}
 
 ThemeEnhancements.defaultProps = {
 	submittingForm: false,
@@ -145,5 +206,8 @@ export default connect(
 			infiniteScrollModuleActive: !! isModuleActive( state, selectedSiteId, 'infinite-scroll' ),
 			minilevenModuleActive: !! isModuleActive( state, selectedSiteId, 'minileven' ),
 		};
+	},
+	{
+		updateModuleSettings
 	}
-)( localize( ThemeEnhancements ) );
+)( protectForm( localize( ThemeEnhancements ) ) );

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -116,6 +116,7 @@ class ThemeEnhancements extends Component {
 			minilevenModuleActive,
 			translate
 		} = this.props;
+		const formPending = this.isFormPending();
 
 		return (
 			<div>
@@ -127,7 +128,7 @@ class ThemeEnhancements extends Component {
 						compact
 						primary
 						onClick={ this.onSubmitForm }
-						disabled={ this.isFormPending() }
+						disabled={ formPending }
 					>
 						{ submittingForm || updatingSettings
 							? translate( 'Saving…' )
@@ -149,6 +150,7 @@ class ThemeEnhancements extends Component {
 							siteId={ selectedSiteId }
 							moduleSlug="infinite-scroll"
 							label={ translate( 'Add support for infinite scroll to your theme.' ) }
+							disabled={ formPending }
 							/>
 
 						{
@@ -182,6 +184,7 @@ class ThemeEnhancements extends Component {
 							siteId={ selectedSiteId }
 							moduleSlug="minileven"
 							label={ translate( 'Optimize your site with a phone-friendly theme.' ) }
+							disabled={ formPending }
 							/>
 
 						{

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { pick, map } from 'lodash';
+import { map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,7 +22,7 @@ import QueryJetpackModuleSettings from 'components/data/query-jetpack-module-set
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isModuleActive, isFetchingModules } from 'state/jetpack-settings/modules/selectors';
 import { getCurrentModuleSettings, isRequestingModuleSettings } from 'state/jetpack-settings/module-settings/selectors';
-import { updateModuleSettings } from 'state/jetpack-settings/module-settings/actions';
+import { updateSettings } from 'state/jetpack-settings/settings/actions';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
 
@@ -68,31 +68,10 @@ class ThemeEnhancements extends Component {
 		} );
 	}
 
-	updateSettingsForModule( module ) {
-		const { selectedSiteId } = this.props;
-		let fields = [];
-
-		switch ( module ) {
-			case 'infinite-scroll':
-				fields = [ 'infinite_scroll', 'infinite_scroll_google_analytics' ];
-				break;
-			case 'minileven':
-				fields = [ 'wp_mobile_excerpt', 'wp_mobile_featured_images', 'wp_mobile_app_promos' ];
-				break;
-		}
-
-		if ( ! fields.length ) {
-			return;
-		}
-
-		return this.props.updateModuleSettings( selectedSiteId, module, pick( this.state, fields ) );
-	}
-
 	onSubmitForm( event ) {
-		const { onSubmitForm } = this.props;
+		const { onSubmitForm, selectedSiteId } = this.props;
 
-		this.updateSettingsForModule( 'infinite-scroll' );
-		this.updateSettingsForModule( 'minileven' );
+		this.props.updateSettings( selectedSiteId, this.state );
 
 		onSubmitForm( event );
 	}
@@ -254,6 +233,6 @@ export default connect(
 		};
 	},
 	{
-		updateModuleSettings
+		updateSettings
 	}
 )( protectForm( localize( ThemeEnhancements ) ) );

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -1,0 +1,149 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import SectionHeader from 'components/section-header';
+import Card from 'components/card';
+import Button from 'components/button';
+import FormLabel from 'components/forms/form-label';
+import FormCheckbox from 'components/forms/form-checkbox';
+import JetpackModuleToggle from '../jetpack-module-toggle';
+import FormFieldset from 'components/forms/form-fieldset';
+import QueryJetpackModules from 'components/data/query-jetpack-modules';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isModuleActive } from 'state/jetpack-settings/modules/selectors';
+import InfoPopover from 'components/info-popover';
+import ExternalLink from 'components/external-link';
+
+const ThemeEnhancements = ( {
+	onSubmitForm,
+	fetchingSettings,
+	submittingForm,
+	selectedSiteId,
+	infiniteScrollModuleActive,
+	minilevenModuleActive,
+	translate
+} ) => {
+	return (
+		<div>
+			<QueryJetpackModules siteId={ selectedSiteId } />
+			<SectionHeader label={ translate( 'Theme Enhancements' ) }>
+				<Button
+					compact
+					primary
+					onClick={ onSubmitForm }
+					disabled={ fetchingSettings || submittingForm }>
+					{ submittingForm ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
+				</Button>
+			</SectionHeader>
+			<Card className="theme-enhancements__card site-settings">
+				<FormFieldset>
+					<div className="theme-enhancements__info-link-container">
+						<InfoPopover position={ 'left' }>
+							<ExternalLink icon={ true } href={ 'https://jetpack.com/support/infinite-scroll' } target="_blank">
+								{ translate( 'Learn more about Infinite Scroll' ) }
+							</ExternalLink>
+						</InfoPopover>
+					</div>
+
+					<JetpackModuleToggle
+						siteId={ selectedSiteId }
+						moduleSlug="infinite-scroll"
+						label={ translate( 'Add support for infinite scroll to your theme.' ) }
+						/>
+
+					{
+						infiniteScrollModuleActive && (
+							<div className="theme-enhancements__module-settings is-indented">
+								<FormLabel>
+									<FormCheckbox
+										disabled={ submittingForm }
+										name="infinite_scroll" />
+									<span>{ translate( 'Scroll infinitely (Shows 7 posts on each load)' ) }</span>
+								</FormLabel>
+
+								<FormLabel>
+									<FormCheckbox
+										disabled={ submittingForm }
+										name="infinite_scroll_google_analytics" />
+									<span>{ translate( 'Track each infinite Scroll post load as a page view in Google Analytics' ) }</span>
+								</FormLabel>
+							</div>
+						)
+					}
+				</FormFieldset>
+
+				<FormFieldset>
+					<div className="theme-enhancements__info-link-container">
+						<InfoPopover position={ 'left' }>
+							<ExternalLink icon={ true } href={ 'https://jetpack.com/support/infinite-scroll' } target="_blank">
+								{ translate( 'Learn more about Infinite Scroll' ) }
+							</ExternalLink>
+						</InfoPopover>
+					</div>
+
+					<JetpackModuleToggle
+						siteId={ selectedSiteId }
+						moduleSlug="minileven"
+						label={ translate( 'Optimize your site with a phone-friendly theme.' ) }
+						/>
+
+					{
+						minilevenModuleActive && (
+							<div className="theme-enhancements__module-settings is-indented">
+								<FormLabel>
+									<FormCheckbox
+										disabled={ submittingForm }
+										name="wp_mobile_excerpt" />
+									<span>{ translate( 'Use excerpts instead of full posts on front page and archive pages' ) }</span>
+								</FormLabel>
+
+								<FormLabel>
+									<FormCheckbox
+										disabled={ submittingForm }
+										name="wp_mobile_featured_images" />
+									<span>{ translate( 'Hide all featured images' ) }</span>
+								</FormLabel>
+
+								<FormLabel>
+									<FormCheckbox
+										disabled={ submittingForm }
+										name="wp_mobile_app_promos" />
+									<span>{ translate( 'Show an ad for the WordPress mobile apps in the footer' ) }</span>
+								</FormLabel>
+							</div>
+						)
+					}
+				</FormFieldset>
+			</Card>
+		</div>
+	);
+};
+
+ThemeEnhancements.defaultProps = {
+	submittingForm: false,
+};
+
+ThemeEnhancements.propTypes = {
+	onSubmitForm: PropTypes.func.isRequired,
+	fetchingSettings: PropTypes.bool.isRequired,
+	submittingForm: PropTypes.bool,
+};
+
+export default connect(
+	( state ) => {
+		const selectedSiteId = getSelectedSiteId( state );
+
+		return {
+			selectedSiteId,
+			infiniteScrollModuleActive: !! isModuleActive( state, selectedSiteId, 'infinite-scroll' ),
+			minilevenModuleActive: !! isModuleActive( state, selectedSiteId, 'minileven' ),
+		};
+	}
+)( localize( ThemeEnhancements ) );

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -82,10 +82,33 @@ class ThemeEnhancements extends Component {
 		onSubmitForm( event );
 	}
 
-	render() {
+	isFormPending() {
 		const {
 			fetchingSettings,
 			fetchingModuleData,
+			submittingForm,
+			updatingSettings
+		} = this.props;
+
+		return fetchingSettings || fetchingModuleData || submittingForm || updatingSettings;
+	}
+
+	renderToggle( name, label ) {
+		return (
+			<FormToggle
+				className="theme-enhancements__module-settings-toggle is-compact"
+				checked={ this.isFieldTruthy( name ) }
+				disabled={ this.isFormPending() }
+				onChange={ this.handleToggle( name ) }>
+				<span>
+					{ label }
+				</span>
+			</FormToggle>
+		);
+	}
+
+	render() {
+		const {
 			submittingForm,
 			updatingSettings,
 			selectedSiteId,
@@ -93,7 +116,6 @@ class ThemeEnhancements extends Component {
 			minilevenModuleActive,
 			translate
 		} = this.props;
-		const isFormPending = fetchingSettings || fetchingModuleData || submittingForm || updatingSettings;
 
 		return (
 			<div>
@@ -105,8 +127,12 @@ class ThemeEnhancements extends Component {
 						compact
 						primary
 						onClick={ this.onSubmitForm }
-						disabled={ isFormPending }>
-						{ submittingForm ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
+						disabled={ this.isFormPending() }
+					>
+						{ submittingForm || updatingSettings
+							? translate( 'Saving…' )
+							: translate( 'Save Settings' )
+						}
 					</Button>
 				</SectionHeader>
 				<Card className="theme-enhancements__card site-settings">
@@ -128,29 +154,16 @@ class ThemeEnhancements extends Component {
 						{
 							infiniteScrollModuleActive && (
 								<div className="theme-enhancements__module-settings is-indented">
-									<FormToggle
-										className="theme-enhancements__module-settings-toggle is-compact"
-										checked={ this.isFieldTruthy( 'infinite_scroll' ) }
-										disabled={ isFormPending }
-										onChange={ this.handleToggle( 'infinite_scroll' ) }>
-										<span>
-											{ translate(
-												'Scroll infinitely (Shows 7 posts on each load)'
-											) }
-										</span>
-									</FormToggle>
-
-									<FormToggle
-										className="theme-enhancements__module-settings-toggle is-compact"
-										checked={ this.isFieldTruthy( 'infinite_scroll_google_analytics' ) }
-										disabled={ isFormPending }
-										onChange={ this.handleToggle( 'infinite_scroll_google_analytics' ) }>
-										<span>
-											{ translate(
-												'Track each infinite Scroll post load as a page view in Google Analytics'
-											) }
-										</span>
-									</FormToggle>
+									{
+										this.renderToggle( 'infinite_scroll', translate(
+											'Scroll infinitely (Shows 7 posts on each load)'
+										) )
+									}
+									{
+										this.renderToggle( 'infinite_scroll_google_analytics', translate(
+											'Track each infinite Scroll post load as a page view in Google Analytics'
+										) )
+									}
 								</div>
 							)
 						}
@@ -174,41 +187,21 @@ class ThemeEnhancements extends Component {
 						{
 							minilevenModuleActive && (
 								<div className="theme-enhancements__module-settings is-indented">
-									<FormToggle
-										className="theme-enhancements__module-settings-toggle is-compact"
-										checked={ this.isFieldTruthy( 'wp_mobile_excerpt' ) }
-										disabled={ isFormPending }
-										onChange={ this.handleToggle( 'wp_mobile_excerpt' ) }>
-										<span>
-											{ translate(
-												'Use excerpts instead of full posts on front page and archive pages'
-											) }
-										</span>
-									</FormToggle>
-
-									<FormToggle
-										className="theme-enhancements__module-settings-toggle is-compact"
-										checked={ this.isFieldTruthy( 'wp_mobile_featured_images' ) }
-										disabled={ isFormPending }
-										onChange={ this.handleToggle( 'wp_mobile_featured_images' ) }>
-										<span>
-											{ translate(
-												'Hide all featured images'
-											) }
-										</span>
-									</FormToggle>
-
-									<FormToggle
-										className="theme-enhancements__module-settings-toggle is-compact"
-										checked={ this.isFieldTruthy( 'wp_mobile_app_promos' ) }
-										disabled={ isFormPending }
-										onChange={ this.handleToggle( 'wp_mobile_app_promos' ) }>
-										<span>
-											{ translate(
-												'Show an ad for the WordPress mobile apps in the footer of the mobile theme'
-											) }
-										</span>
-									</FormToggle>
+									{
+										this.renderToggle( 'wp_mobile_excerpt', translate(
+											'Use excerpts instead of full posts on front page and archive pages'
+										) )
+									}
+									{
+										this.renderToggle( 'wp_mobile_featured_images', translate(
+											'Hide all featured images'
+										) )
+									}
+									{
+										this.renderToggle( 'wp_mobile_app_promos', translate(
+											'Show an ad for the WordPress mobile apps in the footer of the mobile theme'
+										) )
+									}
 								</div>
 							)
 						}

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { map } from 'lodash';
+import { pick, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,10 +18,10 @@ import FormCheckbox from 'components/forms/form-checkbox';
 import JetpackModuleToggle from '../jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
-import QueryJetpackModuleSettings from 'components/data/query-jetpack-module-settings';
+import QueryJetpackSettings from 'components/data/query-jetpack-settings';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isModuleActive, isFetchingModules } from 'state/jetpack-settings/modules/selectors';
-import { getCurrentModuleSettings, isRequestingModuleSettings } from 'state/jetpack-settings/module-settings/selectors';
+import { getJetpackSettings, isRequestingJetpackSettings } from 'state/jetpack-settings/settings/selectors';
 import { updateSettings } from 'state/jetpack-settings/settings/actions';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
@@ -37,12 +37,7 @@ class ThemeEnhancements extends Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		const moduleSettings = {
-			...nextProps.infiniteScrollModuleSettings,
-			...nextProps.minilevenModuleSettings
-		};
-
-		map( moduleSettings, ( settingValue, settingName ) => {
+		map( nextProps.moduleSettings, ( settingValue, settingName ) => {
 			if ( ! this.state.hasOwnProperty( settingName ) ) {
 				this.setState( { [ settingName ]: settingValue } );
 			}
@@ -91,8 +86,7 @@ class ThemeEnhancements extends Component {
 		return (
 			<div>
 				<QueryJetpackModules siteId={ selectedSiteId } />
-				<QueryJetpackModuleSettings siteId={ selectedSiteId } moduleSlug={ 'infinite-scroll' } />
-				<QueryJetpackModuleSettings siteId={ selectedSiteId } moduleSlug={ 'minileven' } />
+				<QueryJetpackSettings siteId={ selectedSiteId } />
 
 				<SectionHeader label={ translate( 'Theme Enhancements' ) }>
 					<Button
@@ -220,16 +214,21 @@ export default connect(
 	( state ) => {
 		const selectedSiteId = getSelectedSiteId( state );
 		const fetchingModules = isFetchingModules( state, selectedSiteId );
-		const fetchingInfiniteScrollModuleSettings = isRequestingModuleSettings( state, selectedSiteId, 'infinite-scroll' );
-		const fetchingMinilevenModuleSettings = isRequestingModuleSettings( state, selectedSiteId, 'minileven' );
+		const fetchingSettings = isRequestingJetpackSettings( state, selectedSiteId );
+		const moduleSettings = pick( getJetpackSettings( state, selectedSiteId ), [
+			'infinite_scroll',
+			'infinite_scroll_google_analytics',
+			'wp_mobile_excerpt',
+			'wp_mobile_featured_images',
+			'wp_mobile_app_promos'
+		] );
 
 		return {
 			selectedSiteId,
 			infiniteScrollModuleActive: !! isModuleActive( state, selectedSiteId, 'infinite-scroll' ),
 			minilevenModuleActive: !! isModuleActive( state, selectedSiteId, 'minileven' ),
-			infiniteScrollModuleSettings: getCurrentModuleSettings( state, selectedSiteId, 'infinite-scroll' ),
-			minilevenModuleSettings: getCurrentModuleSettings( state, selectedSiteId, 'minileven' ),
-			fetchingModuleData: !! ( fetchingModules || fetchingInfiniteScrollModuleSettings || fetchingMinilevenModuleSettings )
+			moduleSettings,
+			fetchingModuleData: !! ( fetchingModules || fetchingSettings )
 		};
 	},
 	{

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -138,7 +138,11 @@ class ThemeEnhancements extends Component {
 											onChange={ this.onCheckboxChange }
 											disabled={ submittingForm }
 											name="infinite_scroll_google_analytics" />
-										<span>{ translate( 'Track each infinite Scroll post load as a page view in Google Analytics' ) }</span>
+										<span>
+											{ translate(
+												'Track each infinite Scroll post load as a page view in Google Analytics'
+											) }
+										</span>
 									</FormLabel>
 								</div>
 							)
@@ -148,8 +152,8 @@ class ThemeEnhancements extends Component {
 					<FormFieldset>
 						<div className="theme-enhancements__info-link-container">
 							<InfoPopover position={ 'left' }>
-								<ExternalLink icon={ true } href={ 'https://jetpack.com/support/infinite-scroll' } target="_blank">
-									{ translate( 'Learn more about Infinite Scroll' ) }
+								<ExternalLink icon={ true } href={ 'https://jetpack.com/support/mobile-theme' } target="_blank">
+									{ translate( 'Learn more about Mobile Theme' ) }
 								</ExternalLink>
 							</InfoPopover>
 						</div>
@@ -184,7 +188,11 @@ class ThemeEnhancements extends Component {
 											onChange={ this.onCheckboxChange }
 											disabled={ submittingForm }
 											name="wp_mobile_app_promos" />
-										<span>{ translate( 'Show an ad for the WordPress mobile apps in the footer of the mobile theme' ) }</span>
+										<span>
+											{ translate(
+												'Show an ad for the WordPress mobile apps in the footer of the mobile theme'
+											) }
+										</span>
 									</FormLabel>
 								</div>
 							)

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -111,108 +111,139 @@ class ThemeEnhancements extends Component {
 		);
 	}
 
-	render() {
+	renderHeader() {
 		const {
 			submittingForm,
 			updatingSettings,
+			translate
+		} = this.props;
+		const formPending = this.isFormPending();
+
+		return (
+			<SectionHeader label={ translate( 'Theme Enhancements' ) }>
+				<Button
+					compact
+					primary
+					onClick={ this.onSubmitForm }
+					disabled={ formPending }
+				>
+					{ submittingForm || updatingSettings
+						? translate( 'Saving…' )
+						: translate( 'Save Settings' )
+					}
+				</Button>
+			</SectionHeader>
+		);
+	}
+
+	renderInfiniteScrollSettings() {
+		const {
 			selectedSiteId,
 			infiniteScrollModuleActive,
+			translate
+		} = this.props;
+		const formPending = this.isFormPending();
+
+		return (
+			<FormFieldset>
+				<div className="theme-enhancements__info-link-container">
+					<InfoPopover position={ 'left' }>
+						<ExternalLink icon={ true } href={ 'https://jetpack.com/support/infinite-scroll' } target="_blank">
+							{ translate( 'Learn more about Infinite Scroll' ) }
+						</ExternalLink>
+					</InfoPopover>
+				</div>
+
+				<JetpackModuleToggle
+					siteId={ selectedSiteId }
+					moduleSlug="infinite-scroll"
+					label={ translate( 'Add support for infinite scroll to your theme.' ) }
+					disabled={ formPending }
+					/>
+
+				{
+					infiniteScrollModuleActive && (
+						<div className="theme-enhancements__module-settings is-indented">
+							{
+								this.renderToggle( 'infinite_scroll', translate(
+									'Scroll infinitely (Shows 7 posts on each load)'
+								) )
+							}
+							{
+								this.renderToggle( 'infinite_scroll_google_analytics', translate(
+									'Track each infinite Scroll post load as a page view in Google Analytics'
+								) )
+							}
+						</div>
+					)
+				}
+			</FormFieldset>
+		);
+	}
+
+	renderMinilevenSettings() {
+		const {
+			selectedSiteId,
 			minilevenModuleActive,
 			translate
 		} = this.props;
 		const formPending = this.isFormPending();
 
 		return (
+			<FormFieldset>
+				<div className="theme-enhancements__info-link-container">
+					<InfoPopover position={ 'left' }>
+						<ExternalLink icon={ true } href={ 'https://jetpack.com/support/mobile-theme' } target="_blank">
+							{ translate( 'Learn more about the Mobile Theme' ) }
+						</ExternalLink>
+					</InfoPopover>
+				</div>
+
+				<JetpackModuleToggle
+					siteId={ selectedSiteId }
+					moduleSlug="minileven"
+					label={ translate( 'Optimize your site with a phone-friendly theme.' ) }
+					disabled={ formPending }
+					/>
+
+				{
+					minilevenModuleActive && (
+						<div className="theme-enhancements__module-settings is-indented">
+							{
+								this.renderToggle( 'wp_mobile_excerpt', translate(
+									'Use excerpts instead of full posts on front page and archive pages'
+								) )
+							}
+							{
+								this.renderToggle( 'wp_mobile_featured_images', translate(
+									'Hide all featured images'
+								) )
+							}
+							{
+								this.renderToggle( 'wp_mobile_app_promos', translate(
+									'Show an ad for the WordPress mobile apps in the footer of the mobile theme'
+								) )
+							}
+						</div>
+					)
+				}
+			</FormFieldset>
+		);
+	}
+
+	render() {
+		const { selectedSiteId } = this.props;
+
+		return (
 			<div>
 				<QueryJetpackModules siteId={ selectedSiteId } />
 				<QueryJetpackSettings siteId={ selectedSiteId } />
 
-				<SectionHeader label={ translate( 'Theme Enhancements' ) }>
-					<Button
-						compact
-						primary
-						onClick={ this.onSubmitForm }
-						disabled={ formPending }
-					>
-						{ submittingForm || updatingSettings
-							? translate( 'Saving…' )
-							: translate( 'Save Settings' )
-						}
-					</Button>
-				</SectionHeader>
+				{ this.renderHeader() }
+
 				<Card className="theme-enhancements__card site-settings">
-					<FormFieldset>
-						<div className="theme-enhancements__info-link-container">
-							<InfoPopover position={ 'left' }>
-								<ExternalLink icon={ true } href={ 'https://jetpack.com/support/infinite-scroll' } target="_blank">
-									{ translate( 'Learn more about Infinite Scroll' ) }
-								</ExternalLink>
-							</InfoPopover>
-						</div>
-
-						<JetpackModuleToggle
-							siteId={ selectedSiteId }
-							moduleSlug="infinite-scroll"
-							label={ translate( 'Add support for infinite scroll to your theme.' ) }
-							disabled={ formPending }
-							/>
-
-						{
-							infiniteScrollModuleActive && (
-								<div className="theme-enhancements__module-settings is-indented">
-									{
-										this.renderToggle( 'infinite_scroll', translate(
-											'Scroll infinitely (Shows 7 posts on each load)'
-										) )
-									}
-									{
-										this.renderToggle( 'infinite_scroll_google_analytics', translate(
-											'Track each infinite Scroll post load as a page view in Google Analytics'
-										) )
-									}
-								</div>
-							)
-						}
-					</FormFieldset>
-
-					<FormFieldset>
-						<div className="theme-enhancements__info-link-container">
-							<InfoPopover position={ 'left' }>
-								<ExternalLink icon={ true } href={ 'https://jetpack.com/support/mobile-theme' } target="_blank">
-									{ translate( 'Learn more about the Mobile Theme' ) }
-								</ExternalLink>
-							</InfoPopover>
-						</div>
-
-						<JetpackModuleToggle
-							siteId={ selectedSiteId }
-							moduleSlug="minileven"
-							label={ translate( 'Optimize your site with a phone-friendly theme.' ) }
-							disabled={ formPending }
-							/>
-
-						{
-							minilevenModuleActive && (
-								<div className="theme-enhancements__module-settings is-indented">
-									{
-										this.renderToggle( 'wp_mobile_excerpt', translate(
-											'Use excerpts instead of full posts on front page and archive pages'
-										) )
-									}
-									{
-										this.renderToggle( 'wp_mobile_featured_images', translate(
-											'Hide all featured images'
-										) )
-									}
-									{
-										this.renderToggle( 'wp_mobile_app_promos', translate(
-											'Show an ad for the WordPress mobile apps in the footer of the mobile theme'
-										) )
-									}
-								</div>
-							)
-						}
-					</FormFieldset>
+					{ this.renderInfiniteScrollSettings() }
+					{ this.renderMinilevenSettings() }
 				</Card>
 			</div>
 		);

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -71,15 +71,19 @@ class ThemeEnhancements extends Component {
 			this.setState( {
 				[ name ]: this.sanitizeFieldValue( name, ! this.isFieldTruthy( name ) )
 			} );
+			this.props.markChanged();
 		};
 	}
 
 	onSubmitForm( event ) {
 		const { onSubmitForm, selectedSiteId } = this.props;
 
-		this.props.updateSettings( selectedSiteId, this.state );
-
-		onSubmitForm( event );
+		Promise.all( [
+			this.props.updateSettings( selectedSiteId, this.state ),
+			onSubmitForm( event )
+		] ).then( () => {
+			this.props.markSaved();
+		} );
 	}
 
 	isFormPending() {

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -19,13 +19,13 @@ import FormToggle from 'components/forms/form-toggle';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import QueryJetpackSettings from 'components/data/query-jetpack-settings';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isModuleActive, isFetchingModules } from 'state/jetpack-settings/modules/selectors';
+import { isModuleActive, isFetchingModules } from 'state/jetpack/modules/selectors';
 import {
 	getJetpackSettings,
 	isRequestingJetpackSettings,
 	isUpdatingJetpackSettings
-} from 'state/jetpack-settings/settings/selectors';
-import { updateSettings } from 'state/jetpack-settings/settings/actions';
+} from 'state/jetpack/settings/selectors';
+import { updateSettings } from 'state/jetpack/settings/actions';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
 

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -148,7 +148,7 @@ class ThemeEnhancements extends Component {
 			<FormFieldset>
 				<div className="theme-enhancements__info-link-container">
 					<InfoPopover position={ 'left' }>
-						<ExternalLink icon={ true } href={ 'https://jetpack.com/support/infinite-scroll' } target="_blank">
+						<ExternalLink href={ 'https://jetpack.com/support/infinite-scroll' } target="_blank">
 							{ translate( 'Learn more about Infinite Scroll' ) }
 						</ExternalLink>
 					</InfoPopover>
@@ -193,8 +193,8 @@ class ThemeEnhancements extends Component {
 			<FormFieldset>
 				<div className="theme-enhancements__info-link-container">
 					<InfoPopover position={ 'left' }>
-						<ExternalLink icon={ true } href={ 'https://jetpack.com/support/mobile-theme' } target="_blank">
-							{ translate( 'Learn more about the Mobile Theme' ) }
+						<ExternalLink href={ 'https://jetpack.com/support/mobile-theme' } target="_blank">
+							{ translate( 'Learn more about Mobile Theme' ) }
 						</ExternalLink>
 					</InfoPopover>
 				</div>

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -202,7 +202,7 @@ class ThemeEnhancements extends Component {
 				<JetpackModuleToggle
 					siteId={ selectedSiteId }
 					moduleSlug="minileven"
-					label={ translate( 'Optimize your site with a phone-friendly theme.' ) }
+					label={ translate( 'Optimize your site with a mobile-friendly theme for tablets and phones.' ) }
 					disabled={ formPending }
 					/>
 
@@ -211,7 +211,7 @@ class ThemeEnhancements extends Component {
 						<div className="theme-enhancements__module-settings is-indented">
 							{
 								this.renderToggle( 'wp_mobile_excerpt', translate(
-									'Use excerpts instead of full posts on front page and archive pages'
+									'Show excerpts on front page and on archive pages instead of full posts'
 								) )
 							}
 							{

--- a/client/my-sites/site-settings/theme-enhancements/style.scss
+++ b/client/my-sites/site-settings/theme-enhancements/style.scss
@@ -1,0 +1,7 @@
+.theme-enhancements__module-settings.is-indented {
+	margin: 16px 32px;
+}
+
+.theme-enhancements__info-link-container {
+	float: right;
+}

--- a/client/my-sites/site-settings/theme-enhancements/style.scss
+++ b/client/my-sites/site-settings/theme-enhancements/style.scss
@@ -1,5 +1,9 @@
 .theme-enhancements__module-settings.is-indented {
 	margin: 16px 32px;
+
+	.form-toggle__switch {
+		margin-right: 8px;
+	}
 }
 
 .theme-enhancements__info-link-container {

--- a/client/my-sites/site-settings/theme-enhancements/style.scss
+++ b/client/my-sites/site-settings/theme-enhancements/style.scss
@@ -1,9 +1,5 @@
 .theme-enhancements__module-settings.is-indented {
 	margin: 16px 32px;
-
-	.form-toggle__switch {
-		margin-right: 8px;
-	}
 }
 
 .theme-enhancements__info-link-container {


### PR DESCRIPTION
### Introduction

This PR is part of #9171. It introduces a Theme Enhancements card under Writing Settings. This card will be used to manage the settings of the Infinite Scroll and Mobile Theme Jetpack modules.

### Preview

#### Both modules activated, some settings are disabled
![](https://cldup.com/xCIIPi8iRc.png)

#### Initial loading
![](https://cldup.com/knDrQ3NSGK.png)

#### Loading while saving
![](https://cldup.com/vS2p_mDNWX.png)

#### Disabled modules (settings are hidden)
![](https://cldup.com/lBqsNkjADP.png)

### Testing

* Checkout this branch.
* Select one of your Jetpack sites with Jetpack 4.5 or newer.
* Go to `/settings/writing/$site`, where `$site` is the slug of your Jetpack site.
* Verify the Theme Enhancements card is displayed properly.
* Play with the main toggles that enable the modules, and verify they save correctly in your Jetpack site (note that notices are implemented separately in #10583).
* Verify that the settings of a module are displayed only when the module is active.
* Play around with the settings of each module and click "Save Settings". Verify they save properly in your Jetpack site.
* Verify the links of the info popovers are working as expected and lead to the right place.
* Test with a Jetpack site that has Jetpack 4.4.2 or older, and verify the card is not shown.
* Test with a WordPress.com site and verify that the card is not shown.