### PR TITLE
Framework: Upgrade to react-redux v5, take two

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -90,11 +90,8 @@ const ThemeSheet = React.createClass( {
 	},
 
 	getDefaultProps() {
-		// The defaultOption default prop is surprisingly important, see the long
-		// comment near the connect() function at the bottom of this file.
 		return {
-			section: '',
-			defaultOption: {}
+			section: ''
 		};
 	},
 
@@ -578,29 +575,6 @@ const ThemeSheetWithOptions = ( props ) => {
 };
 
 export default connect(
-	/*
-	 * A number of the props that this mapStateToProps function computes are used
-	 * by ThemeSheetWithOptions to compute defaultOption. After a state change
-	 * triggered by an async action, connect()ed child components are, quite
-	 * counter-intuitively, updated before their connect()ed parents (this is
-	 * https://github.com/reactjs/redux/issues/1415), and might be fixed by
-	 * react-redux 5.0.
-	 * For this reason, after e.g. activating a theme in single-site mode,
-	 * first the ThemeSheetWithOptions component's (child) connectOptions component
-	 * will update in response to the currently displayed theme being activated.
-	 * Doing so, it will filter and remove the activate option (adding customize
-	 * instead). However, since the parent connect()ed-ThemeSheetWithOptions will
-	 * only react to the state change afterwards, there is a brief moment when
-	 * connectOptions still receives "activate" as its defaultOption prop, when
-	 * activate is no longer part of its filtered options set, hence passing on
-	 * undefined as the defaultOption object prop for its child. For the theme
-	 * sheet, which eventually gets that defaultOption object prop, this means
-	 * we must be careful to not accidentally access any attribute of that
-	 * defaultOption prop. Otherwise, there will be an error that will prevent the
-	 * state update from finishing properly, hence not updating defaultOption at all.
-	 * The solution to this incredibly intricate issue is simple: Give ThemeSheet
-	 * a valid defaultProp for defaultOption.
-	 */
 	( state, { id } ) => {
 		const selectedSite = getSelectedSite( state );
 		const siteSlug = selectedSite ? getSiteSlug( state, selectedSite.ID ) : '';

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -29,11 +29,11 @@
       "version": "0.8.2"
     },
     "ajv": {
-      "version": "4.10.0",
+      "version": "4.10.3",
       "dev": true
     },
     "ajv-keywords": {
-      "version": "1.2.0",
+      "version": "1.5.0",
       "dev": true
     },
     "align-text": {
@@ -57,6 +57,9 @@
     },
     "anymatch": {
       "version": "1.3.0"
+    },
+    "aproba": {
+      "version": "1.0.4"
     },
     "are-we-there-yet": {
       "version": "1.1.2"
@@ -529,7 +532,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000602"
+      "version": "1.0.30000604"
     },
     "caseless": {
       "version": "0.11.0"
@@ -569,7 +572,7 @@
       "version": "2.2.0"
     },
     "charenc": {
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dev": true
     },
     "cheerio": {
@@ -731,6 +734,9 @@
     "console-browserify": {
       "version": "1.1.0"
     },
+    "console-control-strings": {
+      "version": "1.1.0"
+    },
     "constant-case": {
       "version": "1.1.2"
     },
@@ -805,7 +811,7 @@
       "version": "2.2.5"
     },
     "crypt": {
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dev": true
     },
     "cryptiles": {
@@ -1335,7 +1341,7 @@
       }
     },
     "esprima": {
-      "version": "3.1.2"
+      "version": "3.1.3"
     },
     "esrecurse": {
       "version": "4.1.0",
@@ -1448,7 +1454,7 @@
       "version": "1.0.2"
     },
     "fast-levenshtein": {
-      "version": "2.0.5",
+      "version": "2.0.6",
       "dev": true
     },
     "fast-luhn": {
@@ -1597,7 +1603,7 @@
       "version": "1.0.0"
     },
     "gauge": {
-      "version": "1.2.7"
+      "version": "2.6.0"
     },
     "gaze": {
       "version": "1.1.2"
@@ -1728,7 +1734,7 @@
       "version": "0.0.42",
       "dependencies": {
         "bluebird": {
-          "version": "3.4.6"
+          "version": "3.4.7"
         },
         "source-map": {
           "version": "0.5.6"
@@ -1749,6 +1755,9 @@
           "version": "0.0.1"
         }
       }
+    },
+    "has-color": {
+      "version": "0.1.7"
     },
     "has-cors": {
       "version": "1.1.0"
@@ -2303,10 +2312,10 @@
       "version": "1.3.1"
     },
     "level-packager": {
-      "version": "1.2.0"
+      "version": "1.2.1"
     },
     "leveldown": {
-      "version": "1.5.0",
+      "version": "1.5.3",
       "dependencies": {
         "abstract-leveldown": {
           "version": "2.6.1"
@@ -2343,6 +2352,9 @@
     "lodash-deep": {
       "version": "1.5.3",
       "dev": true
+    },
+    "lodash-es": {
+      "version": "4.17.4"
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -2619,6 +2631,9 @@
         }
       }
     },
+    "node-abi": {
+      "version": "1.0.3"
+    },
     "node-contains": {
       "version": "1.0.0"
     },
@@ -2638,6 +2653,9 @@
       "dependencies": {
         "minimatch": {
           "version": "3.0.3"
+        },
+        "npmlog": {
+          "version": "3.1.2"
         }
       }
     },
@@ -2647,8 +2665,14 @@
     "node-ninja": {
       "version": "1.0.2",
       "dependencies": {
+        "gauge": {
+          "version": "1.2.7"
+        },
         "minimatch": {
           "version": "3.0.3"
+        },
+        "npmlog": {
+          "version": "2.0.4"
         }
       }
     },
@@ -2711,7 +2735,15 @@
       }
     },
     "npmlog": {
-      "version": "2.0.4"
+      "version": "4.0.2",
+      "dependencies": {
+        "gauge": {
+          "version": "2.7.2"
+        },
+        "supports-color": {
+          "version": "0.2.0"
+        }
+      }
     },
     "nth-check": {
       "version": "1.0.1",
@@ -2918,7 +2950,7 @@
       "dev": true
     },
     "postcss": {
-      "version": "5.2.6",
+      "version": "5.2.8",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
@@ -2960,10 +2992,10 @@
       "version": "3.3.0"
     },
     "prebuild": {
-      "version": "4.5.0",
+      "version": "5.1.2",
       "dependencies": {
         "async": {
-          "version": "1.5.2"
+          "version": "2.1.4"
         },
         "minimist": {
           "version": "1.2.0"
@@ -3138,7 +3170,7 @@
       "version": "1.0.2"
     },
     "react-redux": {
-      "version": "4.4.5"
+      "version": "5.0.1"
     },
     "react-tap-event-plugin": {
       "version": "2.0.1"
@@ -4270,6 +4302,9 @@
     },
     "which-module": {
       "version": "1.0.0"
+    },
+    "wide-align": {
+      "version": "1.1.0"
     },
     "window-size": {
       "version": "0.1.0"

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "react-dom": "15.4.0",
     "react-masonry-component": "4.2.2",
     "react-pure-render": "1.0.2",
-    "react-redux": "4.4.5",
+    "react-redux": "5.0.1",
     "react-tap-event-plugin": "2.0.1",
     "react-virtualized": "7.9.1",
     "redux": "3.0.4",


### PR DESCRIPTION
Reverts Automattic/wp-calypso#10081, which is the revert of #9707.

Our working hypothesis is that things went south because we were missing an explicit mention of `lru-cache` in package.json, and #9707 purged it from `npm-shrinkwrap.json`. `lru-cache` has now been added by #10082.

cc @blowery 