### PR TITLE
Plugins: don't block click outside AT progress bar if AT status is falsy

### DIFF
--- a/client/my-sites/plugins/plugin-automated-transfer/index.jsx
+++ b/client/my-sites/plugins/plugin-automated-transfer/index.jsx
@@ -84,7 +84,7 @@ class PluginAutomatedTransfer extends Component {
 	handleClickOutside( event ) {
 		const { status } = this.props;
 		const { CONFLICTS, COMPLETE } = transferStates;
-		if ( CONFLICTS !== status && COMPLETE !== status ) {
+		if ( status && CONFLICTS !== status && COMPLETE !== status ) {
 			event.preventDefault();
 			event.stopImmediatePropagation();
 			this.setState( { clickOutside: true } );


### PR DESCRIPTION
Fix a bug where the click outside block was active even if the AT status didn't exist (which is the default scenario when opening the plugin page).

cc @dmsnell @drw158 