### PR TITLE
Reader: Fix Follow button color Lists and FeedHeader

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -50,6 +50,7 @@ $z-layers: (
 		'.reader-feed-header': 0,
 		'.reader-feed-header__back-and-follow': 0,
 		'.reader-related-card-v2.card': 0,
+		'.list-stream__header-follow': 0,
 		'.post-trends__title': 1,
 		'.plugin-item__label': 1,
 		'.wp-editor-tools': 1,
@@ -210,6 +211,9 @@ $z-layers: (
 		'.reader-related-card-v2__meta': 1
 	),
 	'.reader-related-card-v2__meta': (
+		'.follow-button': 1
+	),
+	'.list-stream__header-follow': (
 		'.follow-button': 1
 	),
 

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -129,11 +129,11 @@
 		padding: 0;
 
 		.gridicon {
-			fill: $blue-wordpress;
+			fill: $blue-medium;
 		}
 
 		.follow-button__label {
-			color: $blue-wordpress;
+			color: $blue-medium;
 
 			@include breakpoint( "<660px" ) {
 				display: inline-block;

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -74,10 +74,11 @@
 	align-items: stretch;
 	display: flex;
 	margin-left: auto;
-	z-index: 1;
+	z-index: z-index( 'root', '.list-stream__header-follow' );
 
 	.follow-button {
 		padding: 0;
+		z-index: z-index( '.list-stream__header-follow', '.follow-button' );
 
 		.gridicon {
 			fill: $blue-medium;

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -70,7 +70,7 @@
 	}
 }
 
-.list-stream__header-follow {
+.list-stream__header-follow .follow-button {
 	align-items: stretch;
 	display: flex;
 	margin-left: auto;
@@ -78,6 +78,25 @@
 
 	.follow-button {
 		padding: 0;
+	}
+
+	.gridicon {
+		fill: $blue-medium;
+	}
+
+	.follow-button__label {
+		color: $blue-medium;
+	}
+
+	&.is-following {
+
+		.gridicon {
+			fill: $alert-green;
+		}
+
+		.follow-button__label {
+			color: $alert-green;
+		}
 	}
 }
 

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -70,7 +70,7 @@
 	}
 }
 
-.list-stream__header-follow .follow-button {
+.list-stream__header-follow {
 	align-items: stretch;
 	display: flex;
 	margin-left: auto;
@@ -78,24 +78,24 @@
 
 	.follow-button {
 		padding: 0;
-	}
-
-	.gridicon {
-		fill: $blue-medium;
-	}
-
-	.follow-button__label {
-		color: $blue-medium;
-	}
-
-	&.is-following {
 
 		.gridicon {
-			fill: $alert-green;
+			fill: $blue-medium;
 		}
 
 		.follow-button__label {
-			color: $alert-green;
+			color: $blue-medium;
+		}
+
+		&.is-following {
+
+			.gridicon {
+				fill: $alert-green;
+			}
+
+			.follow-button__label {
+				color: $alert-green;
+			}
 		}
 	}
 }


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/10086

**Before:**
![screenshot 2016-12-15 11 52 10](https://cloud.githubusercontent.com/assets/4924246/21239824/797c9e9e-c2bd-11e6-9416-ab2fa58dd4c6.png)

**After:**
![screenshot 2016-12-15 11 55 36](https://cloud.githubusercontent.com/assets/4924246/21239827/7be5cd18-c2bd-11e6-8171-394fd7015a7b.png)

Also fixed it in the FeedHeader where it was using `$blue-wordpress` instead of `$blue-medium`:

**Before:**
![screenshot 2016-12-15 11 24 59](https://cloud.githubusercontent.com/assets/4924246/21239844/8cab41c8-c2bd-11e6-8017-9d0615617983.png)

**After:**
![screenshot 2016-12-15 11 25 53](https://cloud.githubusercontent.com/assets/4924246/21239852/92ee7136-c2bd-11e6-80a5-d8b64d7a239e.png)

