### PR TITLE
Reader: Stop resizing images in content

### DIFF
--- a/client/lib/post-normalizer/rule-content-make-images-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-images-safe.js
@@ -60,7 +60,7 @@ function isCandidateForContentImage( imageUrl ) {
 	} );
 }
 
-export default function( maxWidth ) {
+export default function( maxWidth = false ) {
 	return function makeImagesSafe( post, dom ) {
 		let content_images = [],
 			images;

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -162,7 +162,7 @@ const fastPostNormalizationRules = flow( [
 	withContentDom( [
 		removeStyles,
 		removeElementsBySelector,
-		makeImagesSafe( READER_CONTENT_WIDTH ),
+		makeImagesSafe(),
 		discoverFullBleedImages,
 		makeEmbedsSafe,
 		disableAutoPlayOnEmbeds,


### PR DESCRIPTION
This was a misguided attempt to get bigger images for features, from a long time ago.
Sadly, it breaks things that use photon or the wp image api to make images a specific size.

Fixes #10091

This doesn't make the gallery responsive to window resizing; that will have to come in another PR.

To test, open a variety of full posts in the Reader. Make sure the images look how you would expect.