### PR TITLE
Themes: Add Activate option to Jetpack sites

### DIFF
--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -23,13 +23,27 @@ import ThemeUploadCard from './themes-upload-card';
 import { addTracking } from './helpers';
 import { translate } from 'i18n-calypso';
 
+const ConnectedThemesSelection = connectOptions(
+	( props ) => {
+		return (
+			<ThemesSelection { ...props }
+				siteId={ null /* Override props.siteId to get themes from WPCOM here */ }
+				getOptions={ function( theme ) {
+					return pickBy(
+						addTracking( props.options ),
+						option => ! ( option.hideForTheme && option.hideForTheme( theme ) )
+					); } }
+			/>
+		);
+	}
+);
+
 export default connectOptions(
 	( props ) => {
 		const {
 			analyticsPath,
 			analyticsPageTitle,
 			getScreenshotOption,
-			options,
 			search,
 			site,
 			siteId,
@@ -75,12 +89,15 @@ export default connectOptions(
 							<ThemeUploadCard
 								label={ translate( 'WordPress.com themes' ) }
 							/>
-							<ThemesSelection
+							<ConnectedThemesSelection
+								options={ [
+									'activateOnJetpack'
+								] }
 								search={ search }
 								tier={ tier }
 								filter={ filter }
 								vertical={ vertical }
-								siteId = { null }
+								siteId = { siteId /* This is for the options in the '...' menu only */ }
 								getScreenshotUrl={ function( theme ) {
 									if ( ! getScreenshotOption( theme ).getUrl ) {
 										return null;
@@ -96,11 +113,6 @@ export default connectOptions(
 								getActionLabel={ function( theme ) {
 									return getScreenshotOption( theme ).label;
 								} }
-								getOptions={ function( theme ) {
-									return pickBy(
-										addTracking( options ),
-										option => ! ( option.hideForTheme && option.hideForTheme( theme ) )
-									); } }
 								trackScrollPage={ props.trackScrollPage }
 							/>
 						</div>

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -10,7 +10,7 @@ import { has, identity, mapValues, pick, pickBy } from 'lodash';
  * Internal dependencies
  */
 import config from 'config';
-import { activateTheme } from 'state/themes/actions';
+import { activateTheme, activateWpcomThemeOnJetpack } from 'state/themes/actions';
 import {
 	getThemeSignupUrl as getSignupUrl,
 	getThemePurchaseUrl as getPurchaseUrl,
@@ -52,6 +52,20 @@ const activate = {
 			isPremium( state, theme.id ) &&
 			! isPurchased( state, theme.id, siteId ) &&
 			! hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES )
+		)
+	)
+};
+
+const activateOnJetpack = {
+	label: i18n.translate( 'Activate' ),
+	header: i18n.translate( 'Activate on:', { comment: 'label for selecting a site on which to activate a theme' } ),
+	action: activateWpcomThemeOnJetpack,
+	hideForSite: ( state, siteId ) => ! isJetpackSite( state, siteId ),
+	hideForTheme: ( state, theme, siteId ) => (
+		isActive( state, theme.id, siteId ) || (
+			isPremium( state, theme.id ) &&
+			! isPurchased( state, theme.id, siteId ) && // Probably not relevant (yet) on Jetpack sites
+			! hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ) // Pressable sites included -- they're always on a Business plan
 		)
 	)
 };
@@ -125,6 +139,7 @@ const ALL_THEME_OPTIONS = {
 	preview,
 	purchase,
 	activate,
+	activateOnJetpack,
 	tryandcustomize,
 	signup,
 	separator,

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -4,7 +4,7 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import i18n from 'i18n-calypso';
-import { has, identity, mapValues, pick, pickBy } from 'lodash';
+import { has, identity, mapValues, pick, pickBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -133,7 +133,6 @@ const ALL_THEME_OPTIONS = {
 	help
 };
 
-const ALL_THEME_ACTIONS = { activate: activateTheme }; // All theme related actions available.
 export const connectOptions = connect(
 	( state, { options: optionNames, siteId } ) => {
 		let options = pick( ALL_THEME_OPTIONS, optionNames );
@@ -168,7 +167,11 @@ export const connectOptions = connect(
 				: {}
 		) );
 	},
-	( dispatch, { siteId, source = 'unknown' } ) => {
+	( dispatch, { options: optionNames, siteId, source = 'unknown' } ) => {
+		const options = pickBy(
+			pick( ALL_THEME_OPTIONS, optionNames ),
+			'action'
+		);
 		let mapAction;
 
 		if ( siteId ) {
@@ -178,14 +181,14 @@ export const connectOptions = connect(
 		}
 
 		return bindActionCreators(
-			mapValues( ALL_THEME_ACTIONS, action => mapAction( action ) ),
+			mapValues( options, ( { action } ) => mapAction( action ) ),
 			dispatch
 		);
 	},
 	( options, actions, ownProps ) => {
 		const { defaultOption, secondaryOption, getScreenshotOption } = ownProps;
 		options = mapValues( options, ( option, name ) => {
-			if ( has( actions, name ) ) {
+			if ( has( option, 'action' ) ) {
 				return { ...option, action: actions[ name ] };
 			}
 			return option;

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -64,7 +64,6 @@ const activateOnJetpack = {
 	hideForTheme: ( state, theme, siteId ) => (
 		isActive( state, theme.id, siteId ) || (
 			isPremium( state, theme.id ) &&
-			! isPurchased( state, theme.id, siteId ) && // Probably not relevant (yet) on Jetpack sites
 			! hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ) // Pressable sites included -- they're always on a Business plan
 		)
 	)

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -372,13 +372,13 @@ export function clearActivated( siteId ) {
  * dispatching THEME_ACTIVATE_REQUEST twice to mark process start and has no handlin
  * of information about installation process except in failure scenario.
  *
- * @param  {Number}   siteId    Site ID
  * @param  {String}   themeId   Theme ID, this should be standard id without -wpcom suffix.
+ * @param  {Number}   siteId    Site ID
  * @param  {String}   source    The source that is reuquesting theme activation, e.g. 'showcase'
  * @param  {Boolean}  purchased Whether the theme has been purchased prior to activation
  * @return {Function}           Action thunk
  */
-export function activateWpcomThemeOnJetpack( siteId, themeId, source = 'unknown', purchased = false ) {
+export function activateWpcomThemeOnJetpack( themeId, siteId, source = 'unknown', purchased = false ) {
 	//Add -wpcom suffix. This suffix tells the endpoint that we want to
 	//install WordPress.com theme. Without the suffix endpoint would look
 	//for theme in .org

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -551,39 +551,39 @@ describe( 'actions', () => {
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
-				.post( '/rest/v1.1/sites/jetpackenabledsite.com/themes/karuna-wpcom/install' )
+				.post( '/rest/v1.1/sites/2211667/themes/karuna-wpcom/install' )
 				.reply( 200, successResponse )
-				.post( '/rest/v1.1/sites/jetpackenabledsite.com/themes/typist-wpcom/install' )
+				.post( '/rest/v1.1/sites/2211667/themes/typist-wpcom/install' )
 				.reply( 400, downloadFailureResponse )
-				.post( '/rest/v1.1/sites/jetpackenabledsite.com/themes/pinboard-wpcom/install' )
+				.post( '/rest/v1.1/sites/2211667/themes/pinboard-wpcom/install' )
 				.reply( 400, alreadyInstalledFailureResponse );
 		} );
 
 		it( 'should dispatch activate theme request action when triggered', () => {
-			activateWpcomThemeOnJetpack( 'jetpackenabledsite.com', 'karuna' )( spy );
+			activateWpcomThemeOnJetpack( 2211667, 'karuna' )( spy );
 
 			expect( spy ).to.have.been.calledWith( {
 				type: THEME_ACTIVATE_REQUEST,
-				siteId: 'jetpackenabledsite.com',
+				siteId: 2211667,
 				themeId: 'karuna-wpcom'
 			} );
 		} );
 
 		it( 'should dispatch wpcom theme activate request success action when request completes', () => {
-			return activateWpcomThemeOnJetpack( 'jetpackenabledsite.com', 'karuna' )( spy ).then( () => {
+			return activateWpcomThemeOnJetpack( 2211667, 'karuna' )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: THEME_ACTIVATE_REQUEST,
-					siteId: 'jetpackenabledsite.com',
+					siteId: 2211667,
 					themeId: 'karuna-wpcom',
 				} );
 			} );
 		} );
 
 		it( 'should dispatch wpcom theme install request failure action when theme was not found', () => {
-			return activateWpcomThemeOnJetpack( 'jetpackenabledsite.com', 'typist' )( spy ).then( () => {
+			return activateWpcomThemeOnJetpack( 2211667, 'typist' )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: THEME_ACTIVATE_REQUEST_FAILURE,
-					siteId: 'jetpackenabledsite.com',
+					siteId: 2211667,
 					themeId: 'typist-wpcom',
 					error: sinon.match( { message: 'Problem downloading theme' } ),
 				} );
@@ -591,10 +591,10 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch wpcom theme install request failure action when theme is already installed', () => {
-			return activateWpcomThemeOnJetpack( 'jetpackenabledsite.com', 'pinboard' )( spy ).then( () => {
+			return activateWpcomThemeOnJetpack( 2211667, 'pinboard' )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: THEME_ACTIVATE_REQUEST_FAILURE,
-					siteId: 'jetpackenabledsite.com',
+					siteId: 2211667,
 					themeId: 'pinboard-wpcom',
 					error: sinon.match( { message: 'The theme is already installed' } ),
 				} );

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -560,7 +560,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch activate theme request action when triggered', () => {
-			activateWpcomThemeOnJetpack( 2211667, 'karuna' )( spy );
+			activateWpcomThemeOnJetpack( 'karuna', 2211667 )( spy );
 
 			expect( spy ).to.have.been.calledWith( {
 				type: THEME_ACTIVATE_REQUEST,
@@ -570,7 +570,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch wpcom theme activate request success action when request completes', () => {
-			return activateWpcomThemeOnJetpack( 2211667, 'karuna' )( spy ).then( () => {
+			return activateWpcomThemeOnJetpack( 'karuna', 2211667 )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: THEME_ACTIVATE_REQUEST,
 					siteId: 2211667,
@@ -580,7 +580,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch wpcom theme install request failure action when theme was not found', () => {
-			return activateWpcomThemeOnJetpack( 2211667, 'typist' )( spy ).then( () => {
+			return activateWpcomThemeOnJetpack( 'typist', 2211667 )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: THEME_ACTIVATE_REQUEST_FAILURE,
 					siteId: 2211667,
@@ -591,7 +591,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch wpcom theme install request failure action when theme is already installed', () => {
-			return activateWpcomThemeOnJetpack( 2211667, 'pinboard' )( spy ).then( () => {
+			return activateWpcomThemeOnJetpack( 'pinboard', 2211667 )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: THEME_ACTIVATE_REQUEST_FAILURE,
 					siteId: 2211667,


### PR DESCRIPTION
Add an 'Install' option to the WPCOM themes list in single-site-jetpack mode.

This requires a bit of preparation, which this PR also does:

* Theme Options: Use options instead of `ALL_THEME_ACTIONS` for binding actions to dispatch(). (This makes the whole thing a little less magic and reliant on an extra constant).
* Theme Options: Add `activateOnJetpack` option
* state/themes/test/actions: Change activateWpcomThemeOnJetpack to use site IDs instead of slugs
* state/themes/actions#activateWpcomThemeOnJetpack: Change argument order to be aligned with `activateTheme`.
* Themes (Single Site Jetpack Mode): Add options to ellipsis menu (by wrapping `ThemesSelection` in `connectOptions` and passing the right props.

To test:
* In single-site-jetpack mode, in the wpcom themes list, verify that free themes have an '...' menu that contains an 'Activate' entry. Click on that Activate entry and verify that you see the thanks modal.
* The theme _is not shown immediately_ in the (upper) 'Custom themes' list -- but they are after a reload!

(Any missing features, like immediately visible newly installed themes, are subject to future iterations but not this PR 😛 )