### PR TITLE
Framework: Skip Photon for blob and data images in safeImageUrl

### DIFF
--- a/client/lib/safe-image-url/README.md
+++ b/client/lib/safe-image-url/README.md
@@ -1,7 +1,16 @@
-safe-image-url
+safeImageUrl
 =======
-This is a small module that takes a URL to a supposed image and returns
-a safe version of it, guaranteed to be hosted by Automattic. If the URL
-appears to be from an Automattic-controlled CDN, it is simply flipped to
-a protocol-relative URL. If it is not on an Automattic-controlled CDN, the
-URL is changed to route through photon.
+
+This is a small module that takes a URL to a supposed image and returns a safe
+version of it, guaranteed to be hosted by Automattic. If the URL appears to be
+from an Automattic-controlled CDN, it is simply upgraded to HTTPS if necessary.
+If it is not on an Automattic-controlled CDN, the URL is routed through photon.
+
+## Example
+
+```js
+import safeImageUrl from 'lib/safe-image-url';
+
+safeImageUrl( '//example.com/foo.png' );
+// "https://i1.wp.com/example.com/foo.png"
+```

--- a/client/lib/safe-image-url/index.js
+++ b/client/lib/safe-image-url/index.js
@@ -1,44 +1,52 @@
 /**
  * External Dependencies
  */
-var photon = require( 'photon' ),
-	uri = require( 'url' );
+import photon from 'photon';
+import { parse as parseUrl } from 'url';
 
 /**
- * Internal Dependencies
+ * Pattern matching URLs to be left unmodified.
+ *
+ * @type {RegExp}
  */
+let REGEX_EXEMPT_URL;
+if ( 'object' === typeof location ) {
+	REGEX_EXEMPT_URL = new RegExp( `^(/(?!/)|data:image/[^;]+;|blob:${ location.origin }/)` );
+} else {
+	REGEX_EXEMPT_URL = /^(\/(?!\/)|data:image\/[^;]+;)/;
+}
+
+/**
+ * Pattern matching Automattic-controlled hostnames
+ *
+ * @type {RegExp}
+ */
+const REGEXP_A8C_HOST = /^([-a-zA-Z0-9_]+\.)*(gravatar\.com|wordpress\.com|wp\.com|a8c\.com)$/;
 
 /**
  * Generate a safe version of the provided URL
  *
- * Images that Calypso uses have to be provided by
- * a trusted TLS host. To do this, we check the host
- * of the URL against a whitelist, and run the image
+ * Images that Calypso uses have to be provided by a trusted TLS host. To do
+ * this, we check the host of the URL against a whitelist, and run the image
  * through photon if the host name does not match.
- *
- * We special case gravatar, because we control them.
  *
  * @param  {string} url The URL to secure
  * @return {string}     The secured URL, or null if we couldn't make it safe
  */
-function safeImageURL( url ) {
+export default function safeImageUrl( url ) {
 	if ( typeof url !== 'string' ) {
 		return null;
 	}
 
-	// if it's relative, return it
-	if ( /^\/[^/]/.test( url ) ) {
+	if ( REGEX_EXEMPT_URL.test( url ) ) {
 		return url;
 	}
 
-	const parsed = uri.parse( url, false, true );
-
-	if ( /^([-a-zA-Z0-9_]+\.)*(gravatar.com|wordpress.com|wp.com|a8c.com)$/.test( parsed.hostname ) ) {
-		// wp-hosted domains can be safely promoted to ssl
+	const { hostname } = parseUrl( url, false, true );
+	if ( REGEXP_A8C_HOST.test( hostname ) ) {
+		// Safely promote Automattic domains to HTTPS
 		return url.replace( /^http:/, 'https:' );
 	}
 
 	return photon( url );
 }
-
-module.exports = safeImageURL;

--- a/client/lib/safe-image-url/test/index.js
+++ b/client/lib/safe-image-url/test/index.js
@@ -1,68 +1,68 @@
 /**
  * External dependencies
  */
-const expect = require( 'chai' ).expect;
+import { expect } from 'chai';
 
 /**
  * Internal Dependencies
  */
-const safeImage = require( '../' );
+import safeImageUrl from '../';
 
-describe( 'index', function() {
-	it( 'should ignore a relative url', function() {
-		expect( safeImage( '/foo' ) ).to.eql( '/foo' );
+describe( 'safeImageUrl()', () => {
+	it( 'should ignore a relative url', () => {
+		expect( safeImageUrl( '/foo' ) ).to.equal( '/foo' );
 	} );
 
-	it( 'should make a non-wpcom http url safe', function() {
-		expect( safeImage( 'http://example.com/foo' ) ).to.eql( 'https://i1.wp.com/example.com/foo' );
+	it( 'should make a non-wpcom http url safe', () => {
+		expect( safeImageUrl( 'http://example.com/foo' ) ).to.equal( 'https://i1.wp.com/example.com/foo' );
 	} );
 
-	it( 'should make a non-wpcom https url safe', function() {
-		expect( safeImage( 'https://example.com/foo' ) ).to.eql( 'https://i1.wp.com/example.com/foo?ssl=1' );
+	it( 'should make a non-wpcom https url safe', () => {
+		expect( safeImageUrl( 'https://example.com/foo' ) ).to.equal( 'https://i1.wp.com/example.com/foo?ssl=1' );
 	} );
 
-	it( 'should make wp-com like subdomain url safe', function() {
-		expect( safeImage( 'https://wordpress.com.example.com/foo' ) ).to.eql(
+	it( 'should make wp-com like subdomain url safe', () => {
+		expect( safeImageUrl( 'https://wordpress.com.example.com/foo' ) ).to.equal(
 			'https://i0.wp.com/wordpress.com.example.com/foo?ssl=1'
 		);
 	} );
 
-	it( 'should make domain ending by wp-com url safe', function() {
-		expect( safeImage( 'https://examplewordpress.com/foo' ) ).to.eql(
+	it( 'should make domain ending by wp-com url safe', () => {
+		expect( safeImageUrl( 'https://examplewordpress.com/foo' ) ).to.equal(
 			'https://i0.wp.com/examplewordpress.com/foo?ssl=1'
 		);
 	} );
 
-	it( 'should make a non-wpcom protocol relative url safe', function() {
-		expect( safeImage( '//example.com/foo' ) ).to.eql( 'https://i1.wp.com/example.com/foo' );
+	it( 'should make a non-wpcom protocol relative url safe', () => {
+		expect( safeImageUrl( '//example.com/foo' ) ).to.equal( 'https://i1.wp.com/example.com/foo' );
 	} );
 
-	it( 'should promote an http wpcom url to https', function() {
-		expect( safeImage( 'http://files.wordpress.com/' ) ).to.eql( 'https://files.wordpress.com/' );
-		expect( safeImage( 'http://wordpress.com/' ) ).to.eql( 'https://wordpress.com/' );
+	it( 'should promote an http wpcom url to https', () => {
+		expect( safeImageUrl( 'http://files.wordpress.com/' ) ).to.equal( 'https://files.wordpress.com/' );
+		expect( safeImageUrl( 'http://wordpress.com/' ) ).to.equal( 'https://wordpress.com/' );
 	} );
 
-	it( 'should leave https wpcom url alone', function() {
-		expect( safeImage( 'https://files.wordpress.com/' ) ).to.eql( 'https://files.wordpress.com/' );
-		expect( safeImage( 'https://wordpress.com/' ) ).to.eql( 'https://wordpress.com/' );
-		expect( safeImage( 'https://blog-en.files.wordpress.com/' ) ).to.eql( 'https://blog-en.files.wordpress.com/' );
+	it( 'should leave https wpcom url alone', () => {
+		expect( safeImageUrl( 'https://files.wordpress.com/' ) ).to.equal( 'https://files.wordpress.com/' );
+		expect( safeImageUrl( 'https://wordpress.com/' ) ).to.equal( 'https://wordpress.com/' );
+		expect( safeImageUrl( 'https://blog-en.files.wordpress.com/' ) ).to.equal( 'https://blog-en.files.wordpress.com/' );
 	} );
 
-	it( 'should promote an http gravatar url to https', function() {
-		expect( safeImage( 'http://files.gravatar.com/' ) ).to.eql( 'https://files.gravatar.com/' );
-		expect( safeImage( 'http://gravatar.com/' ) ).to.eql( 'https://gravatar.com/' );
+	it( 'should promote an http gravatar url to https', () => {
+		expect( safeImageUrl( 'http://files.gravatar.com/' ) ).to.equal( 'https://files.gravatar.com/' );
+		expect( safeImageUrl( 'http://gravatar.com/' ) ).to.equal( 'https://gravatar.com/' );
 	} );
 
-	it( 'should leave https gravatar url alone', function() {
-		expect( safeImage( 'https://files.gravatar.com/' ) ).to.eql( 'https://files.gravatar.com/' );
-		expect( safeImage( 'https://gravatar.com/' ) ).to.eql( 'https://gravatar.com/' );
+	it( 'should leave https gravatar url alone', () => {
+		expect( safeImageUrl( 'https://files.gravatar.com/' ) ).to.equal( 'https://files.gravatar.com/' );
+		expect( safeImageUrl( 'https://gravatar.com/' ) ).to.equal( 'https://gravatar.com/' );
 	} );
 
-	it( 'should return null for urls with querystrings', function() {
-		expect( safeImage( 'https://example.com/foo?bar' ) ).to.be.null;
-		expect( safeImage( 'https://example.com/foo.jpg?bar' ) ).to.be.null;
-		expect( safeImage( 'https://example.com/foo.jpeg?bar' ) ).to.be.null;
-		expect( safeImage( 'https://example.com/foo.gif?bar' ) ).to.be.null;
-		expect( safeImage( 'https://example.com/foo.png?bar' ) ).to.be.null;
+	it( 'should return null for urls with querystrings', () => {
+		expect( safeImageUrl( 'https://example.com/foo?bar' ) ).to.be.null;
+		expect( safeImageUrl( 'https://example.com/foo.jpg?bar' ) ).to.be.null;
+		expect( safeImageUrl( 'https://example.com/foo.jpeg?bar' ) ).to.be.null;
+		expect( safeImageUrl( 'https://example.com/foo.gif?bar' ) ).to.be.null;
+		expect( safeImageUrl( 'https://example.com/foo.png?bar' ) ).to.be.null;
 	} );
 } );

--- a/client/lib/safe-image-url/test/index.js
+++ b/client/lib/safe-image-url/test/index.js
@@ -3,66 +3,122 @@
  */
 import { expect } from 'chai';
 
-/**
- * Internal Dependencies
- */
-import safeImageUrl from '../';
-
 describe( 'safeImageUrl()', () => {
-	it( 'should ignore a relative url', () => {
-		expect( safeImageUrl( '/foo' ) ).to.equal( '/foo' );
+	let safeImageUrl;
+
+	function commonTests() {
+		it( 'should ignore a relative url', () => {
+			expect( safeImageUrl( '/foo' ) ).to.equal( '/foo' );
+		} );
+
+		it( 'should ignore a data url', () => {
+			const dataImageUrl = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+			expect( safeImageUrl( dataImageUrl ) ).to.equal( dataImageUrl );
+		} );
+
+		it( 'should make a non-whitelisted protocol safe', () => {
+			[ 'javascript:alert("foo")', 'data:application/json;base64,', 'about:config' ].forEach( ( url ) => {
+				expect( safeImageUrl( url ) ).to.match( /^https:\/\/i[0-2]\.wp.com\// );
+			} );
+		} );
+
+		it( 'should make a non-wpcom http url safe', () => {
+			expect( safeImageUrl( 'http://example.com/foo' ) ).to.equal( 'https://i1.wp.com/example.com/foo' );
+		} );
+
+		it( 'should make a non-wpcom https url safe', () => {
+			expect( safeImageUrl( 'https://example.com/foo' ) ).to.equal( 'https://i1.wp.com/example.com/foo?ssl=1' );
+		} );
+
+		it( 'should make wp-com like subdomain url safe', () => {
+			expect( safeImageUrl( 'https://wordpress.com.example.com/foo' ) ).to.equal(
+				'https://i0.wp.com/wordpress.com.example.com/foo?ssl=1'
+			);
+		} );
+
+		it( 'should make safe variations of urls testing extremes of safe patterns', () => {
+			expect( [
+				'https://examplewordpress.com/foo',
+				'https://wordpresscom/foo',
+				'https://wordpress.com.example.com/foo'
+			].map( safeImageUrl ) ).to.eql( [
+				'https://i0.wp.com/examplewordpress.com/foo?ssl=1',
+				'https://i0.wp.com/wordpresscom/foo?ssl=1',
+				'https://i0.wp.com/wordpress.com.example.com/foo?ssl=1'
+			] );
+		} );
+
+		it( 'should make a non-wpcom protocol relative url safe', () => {
+			expect( safeImageUrl( '//example.com/foo' ) ).to.equal( 'https://i1.wp.com/example.com/foo' );
+		} );
+
+		it( 'should promote an http wpcom url to https', () => {
+			expect( safeImageUrl( 'http://files.wordpress.com/' ) ).to.equal( 'https://files.wordpress.com/' );
+			expect( safeImageUrl( 'http://wordpress.com/' ) ).to.equal( 'https://wordpress.com/' );
+		} );
+
+		it( 'should leave https wpcom url alone', () => {
+			expect( safeImageUrl( 'https://files.wordpress.com/' ) ).to.equal( 'https://files.wordpress.com/' );
+			expect( safeImageUrl( 'https://wordpress.com/' ) ).to.equal( 'https://wordpress.com/' );
+			expect( safeImageUrl( 'https://blog-en.files.wordpress.com/' ) ).to.equal( 'https://blog-en.files.wordpress.com/' );
+		} );
+
+		it( 'should promote an http gravatar url to https', () => {
+			expect( safeImageUrl( 'http://files.gravatar.com/' ) ).to.equal( 'https://files.gravatar.com/' );
+			expect( safeImageUrl( 'http://gravatar.com/' ) ).to.equal( 'https://gravatar.com/' );
+		} );
+
+		it( 'should leave https gravatar url alone', () => {
+			expect( safeImageUrl( 'https://files.gravatar.com/' ) ).to.equal( 'https://files.gravatar.com/' );
+			expect( safeImageUrl( 'https://gravatar.com/' ) ).to.equal( 'https://gravatar.com/' );
+		} );
+
+		it( 'should return null for urls with querystrings', () => {
+			expect( safeImageUrl( 'https://example.com/foo?bar' ) ).to.be.null;
+			expect( safeImageUrl( 'https://example.com/foo.jpg?bar' ) ).to.be.null;
+			expect( safeImageUrl( 'https://example.com/foo.jpeg?bar' ) ).to.be.null;
+			expect( safeImageUrl( 'https://example.com/foo.gif?bar' ) ).to.be.null;
+			expect( safeImageUrl( 'https://example.com/foo.png?bar' ) ).to.be.null;
+		} );
+	}
+
+	context( 'browser', () => {
+		before( () => {
+			global.location = { origin: 'https://wordpress.com' };
+			delete require.cache[ require.resolve( '../' ) ];
+			safeImageUrl = require( '../' );
+		} );
+
+		after( () => {
+			delete global.location;
+			delete require.cache[ require.resolve( '../' ) ];
+		} );
+
+		it( 'should ignore a blob url for current origin', () => {
+			const originalUrl = 'blob:https://wordpress.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71';
+			expect( safeImageUrl( originalUrl ) ).to.equal( originalUrl );
+		} );
+
+		it( 'should make a blob url for other origin safe', () => {
+			const originalUrl = 'blob:http://example.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71';
+			const expectedUrl = 'https://i1.wp.com/http//example.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71';
+			expect( safeImageUrl( originalUrl ) ).to.equal( expectedUrl );
+		} );
+
+		commonTests();
 	} );
 
-	it( 'should make a non-wpcom http url safe', () => {
-		expect( safeImageUrl( 'http://example.com/foo' ) ).to.equal( 'https://i1.wp.com/example.com/foo' );
-	} );
+	context( 'node', () => {
+		before( () => {
+			safeImageUrl = require( '../' );
+		} );
 
-	it( 'should make a non-wpcom https url safe', () => {
-		expect( safeImageUrl( 'https://example.com/foo' ) ).to.equal( 'https://i1.wp.com/example.com/foo?ssl=1' );
-	} );
+		it( 'should make a blob url safe', () => {
+			const originalUrl = 'blob:http://example.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71';
+			const expectedUrl = 'https://i1.wp.com/http//example.com/ddd1d6b0-f31b-4937-ae9e-97f1d660cf71';
+			expect( safeImageUrl( originalUrl ) ).to.equal( expectedUrl );
+		} );
 
-	it( 'should make wp-com like subdomain url safe', () => {
-		expect( safeImageUrl( 'https://wordpress.com.example.com/foo' ) ).to.equal(
-			'https://i0.wp.com/wordpress.com.example.com/foo?ssl=1'
-		);
-	} );
-
-	it( 'should make domain ending by wp-com url safe', () => {
-		expect( safeImageUrl( 'https://examplewordpress.com/foo' ) ).to.equal(
-			'https://i0.wp.com/examplewordpress.com/foo?ssl=1'
-		);
-	} );
-
-	it( 'should make a non-wpcom protocol relative url safe', () => {
-		expect( safeImageUrl( '//example.com/foo' ) ).to.equal( 'https://i1.wp.com/example.com/foo' );
-	} );
-
-	it( 'should promote an http wpcom url to https', () => {
-		expect( safeImageUrl( 'http://files.wordpress.com/' ) ).to.equal( 'https://files.wordpress.com/' );
-		expect( safeImageUrl( 'http://wordpress.com/' ) ).to.equal( 'https://wordpress.com/' );
-	} );
-
-	it( 'should leave https wpcom url alone', () => {
-		expect( safeImageUrl( 'https://files.wordpress.com/' ) ).to.equal( 'https://files.wordpress.com/' );
-		expect( safeImageUrl( 'https://wordpress.com/' ) ).to.equal( 'https://wordpress.com/' );
-		expect( safeImageUrl( 'https://blog-en.files.wordpress.com/' ) ).to.equal( 'https://blog-en.files.wordpress.com/' );
-	} );
-
-	it( 'should promote an http gravatar url to https', () => {
-		expect( safeImageUrl( 'http://files.gravatar.com/' ) ).to.equal( 'https://files.gravatar.com/' );
-		expect( safeImageUrl( 'http://gravatar.com/' ) ).to.equal( 'https://gravatar.com/' );
-	} );
-
-	it( 'should leave https gravatar url alone', () => {
-		expect( safeImageUrl( 'https://files.gravatar.com/' ) ).to.equal( 'https://files.gravatar.com/' );
-		expect( safeImageUrl( 'https://gravatar.com/' ) ).to.equal( 'https://gravatar.com/' );
-	} );
-
-	it( 'should return null for urls with querystrings', () => {
-		expect( safeImageUrl( 'https://example.com/foo?bar' ) ).to.be.null;
-		expect( safeImageUrl( 'https://example.com/foo.jpg?bar' ) ).to.be.null;
-		expect( safeImageUrl( 'https://example.com/foo.jpeg?bar' ) ).to.be.null;
-		expect( safeImageUrl( 'https://example.com/foo.gif?bar' ) ).to.be.null;
-		expect( safeImageUrl( 'https://example.com/foo.png?bar' ) ).to.be.null;
+		commonTests();
 	} );
 } );


### PR DESCRIPTION
This pull request primarily seeks to return `blob:` and `data:image/` URLs unmodified if passed to `safeImageUrl`, since these are used for either inline images or in-progress media uploads.

It also generally refactors the module, upgrading to ES6 and adding a README example.

__Testing instructions:__

Verify that all Mocha tests pass as expected:

```
npm run test-client client/lib/safe-image-url
```