### PR TITLE
Domains: Don't allow management of domains undergoing maintenance

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { cartItems } from 'lib/cart-values';
-import { getFixedDomainSearch, canMap, canRegister } from 'lib/domains';
+import { getFixedDomainSearch, canMap, canRegister, getTld } from 'lib/domains';
 import DomainRegistrationSuggestion from 'components/domains/domain-registration-suggestion';
 import DomainProductPrice from 'components/domains/domain-product-price';
 import analyticsMixin from 'lib/mixins/analytics';
@@ -186,14 +186,13 @@ const MapDomainStep = React.createClass( {
 	handleValidationErrorMessage: function( domain, error ) {
 		let message;
 		const severity = 'error',
-			lastIndexOfDot = domain.lastIndexOf( '.' ),
-			tld = lastIndexOfDot !== -1 && domain.substring( lastIndexOfDot ),
+			tld = getTld( domain ),
 			translate = this.props.translate;
 
 		switch ( error.code ) {
 			case 'tld_in_maintenance':
 				if ( tld ) {
-					message = translate( 'Sorry, %(tld)s TLD is in maintenance, and we cannot check availability for it.', {
+					message = translate( 'Sorry, .%(tld)s TLD is in maintenance, and we cannot check availability for it.', {
 						args: { tld }
 					} );
 				}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -21,7 +21,7 @@ import { localize } from 'i18n-calypso';
  */
 import wpcom from 'lib/wp';
 import Notice from 'components/notice';
-import { getFixedDomainSearch, canRegister } from 'lib/domains';
+import { getFixedDomainSearch, canRegister, getTld } from 'lib/domains';
 import SearchCard from 'components/search-card';
 import DomainRegistrationSuggestion from 'components/domains/domain-registration-suggestion';
 import DomainMappingSuggestion from 'components/domains/domain-mapping-suggestion';
@@ -549,15 +549,14 @@ const RegisterDomainStep = React.createClass( {
 	showValidationErrorMessage: function( domain, error ) {
 		let message,
 			severity = 'error';
-		const lastIndexOfDot = domain.lastIndexOf( '.' ),
-			tld = lastIndexOfDot !== -1 && domain.substring( lastIndexOfDot ),
+		const tld = getTld( domain ),
 			translate = this.props.translate;
 
 		switch ( error.code ) {
 			case 'available_but_not_registrable':
 				if ( tld ) {
 					message = translate(
-						'To use a domain ending with {{strong}}%(tld)s{{/strong}} on your site, ' +
+						'To use a domain ending with {{strong}}.%(tld)s{{/strong}} on your site, ' +
 						'you can register it elsewhere first and then add it here. {{a}}Learn more{{/a}}.',
 						{
 							args: { tld },
@@ -573,7 +572,7 @@ const RegisterDomainStep = React.createClass( {
 			case 'tld_in_maintenance':
 				if ( tld ) {
 					message = translate(
-						'Domains ending with {{strong}}%(tld)s{{/strong}} are undergoing maintenance. Please check back shortly.',
+						'Domains ending with {{strong}}.%(tld)s{{/strong}} are undergoing maintenance. Please check back shortly.',
 						{
 							args: { tld },
 							components: {

--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -13,7 +13,8 @@ const type = keyMirror( {
 const registrar = {
 	OPENHRS: 'OpenHRS',
 	OPENSRS: 'OpenSRS',
-	WWD: 'WWD'
+	WWD: 'WWD',
+	MAINTENANCE: 'Registrar TLD Maintenance'
 };
 
 export default {

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -179,6 +179,12 @@ function hasMappedDomain( domains ) {
 	return getMappedDomains( domains ).length > 0;
 }
 
+function getTld( domain ) {
+	const lastIndexOfDot = domain.name.lastIndexOf( '.' );
+
+	return lastIndexOfDot !== -1 && domain.name.substring( lastIndexOfDot + 1 );
+}
+
 export {
 	canAddGoogleApps,
 	canMap,
@@ -190,6 +196,7 @@ export {
 	getSelectedDomain,
 	getRegisteredDomains,
 	getMappedDomains,
+	getTld,
 	hasGoogleApps,
 	hasGoogleAppsSupportedDomain,
 	hasMappedDomain,

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -179,10 +179,10 @@ function hasMappedDomain( domains ) {
 	return getMappedDomains( domains ).length > 0;
 }
 
-function getTld( domain ) {
-	const lastIndexOfDot = domain.name.lastIndexOf( '.' );
+function getTld( domainName ) {
+	const lastIndexOfDot = domainName.lastIndexOf( '.' );
 
-	return lastIndexOfDot !== -1 && domain.name.substring( lastIndexOfDot + 1 );
+	return lastIndexOfDot !== -1 && domainName.substring( lastIndexOfDot + 1 );
 }
 
 export {

--- a/client/my-sites/upgrades/domain-management/components/domain/maintenance-card.jsx
+++ b/client/my-sites/upgrades/domain-management/components/domain/maintenance-card.jsx
@@ -7,12 +7,11 @@ import React from 'react' ;
  * Internal dependencies
  */
 import { localize } from 'i18n-calypso';
-import { getSelectedDomain, getTld } from 'lib/domains';
+import { getTld } from 'lib/domains';
 import EmptyContent from 'components/empty-content';
 
-const MaintenanceCard = ( { domains, selectedDomainName, translate } ) => {
-	const domain = getSelectedDomain( { domains, selectedDomainName } ),
-		tld = getTld( domain.name );
+const MaintenanceCard = ( { selectedDomainName, translate } ) => {
+	const tld = getTld( selectedDomainName );
 
 	return (
 		<EmptyContent

--- a/client/my-sites/upgrades/domain-management/components/domain/maintenance-card.jsx
+++ b/client/my-sites/upgrades/domain-management/components/domain/maintenance-card.jsx
@@ -12,7 +12,7 @@ import EmptyContent from 'components/empty-content';
 
 const MaintenanceCard = ( { domains, selectedDomainName, translate } ) => {
 	const domain = getSelectedDomain( { domains, selectedDomainName } ),
-		tld = getTld( domain );
+		tld = getTld( domain.name );
 
 	return (
 		<EmptyContent

--- a/client/my-sites/upgrades/domain-management/components/domain/maintenance-card.jsx
+++ b/client/my-sites/upgrades/domain-management/components/domain/maintenance-card.jsx
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import React from 'react' ;
+
+/**
+ * Internal dependencies
+ */
+import { localize } from 'i18n-calypso';
+import { getSelectedDomain } from 'lib/domains';
+import Notice from 'components/notice';
+
+const MaintenanceCard = ( { domains, selectedDomainName, translate } ) => {
+	const domain = getSelectedDomain( { domains, selectedDomainName } ),
+		lastIndexOfDot = domain.name.lastIndexOf( '.' ),
+		tld = lastIndexOfDot !== -1 && domain.name.substring( lastIndexOfDot );
+
+	return (
+		<Notice
+			status="is-info"
+			showDismiss={ false }
+			text={ translate( 'Domains ending with {{strong}}%(tld)s{{/strong}} are undergoing maintenance, ' +
+				'and no changes are allowed during that time. Please check back shortly.', {
+					components: { strong: <strong /> },
+					args: { tld }
+				} ) }
+		/>
+	);
+};
+
+export default localize( MaintenanceCard );

--- a/client/my-sites/upgrades/domain-management/components/domain/maintenance-card.jsx
+++ b/client/my-sites/upgrades/domain-management/components/domain/maintenance-card.jsx
@@ -7,24 +7,21 @@ import React from 'react' ;
  * Internal dependencies
  */
 import { localize } from 'i18n-calypso';
-import { getSelectedDomain } from 'lib/domains';
-import Notice from 'components/notice';
+import { getSelectedDomain, getTld } from 'lib/domains';
+import EmptyContent from 'components/empty-content';
 
 const MaintenanceCard = ( { domains, selectedDomainName, translate } ) => {
 	const domain = getSelectedDomain( { domains, selectedDomainName } ),
-		lastIndexOfDot = domain.name.lastIndexOf( '.' ),
-		tld = lastIndexOfDot !== -1 && domain.name.substring( lastIndexOfDot );
+		tld = getTld( domain );
 
 	return (
-		<Notice
-			status="is-info"
-			showDismiss={ false }
-			text={ translate( 'Domains ending with {{strong}}%(tld)s{{/strong}} are undergoing maintenance, ' +
-				'and no changes are allowed during that time. Please check back shortly.', {
-					components: { strong: <strong /> },
-					args: { tld }
-				} ) }
-		/>
+		<EmptyContent
+			title={ translate( '{{strong}}.%(tld)s{{/strong}} is undergoing maintenance', {
+				components: { strong: <strong /> },
+				args: { tld }
+			} ) }
+			line={ translate( 'No changes are allowed during that time. Please check back shortly.' ) }
+			illustration={ '/calypso/images/drake/drake-whoops.svg' } />
 	);
 };
 

--- a/client/my-sites/upgrades/domain-management/edit/index.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/index.jsx
@@ -10,6 +10,7 @@ import page from 'page';
 import DomainMainPlaceholder from 'my-sites/upgrades/domain-management/components/domain/main-placeholder';
 import Header from 'my-sites/upgrades/domain-management/components/header';
 import Main from 'components/main';
+import MaintenanceCard from 'my-sites/upgrades/domain-management/components/domain/maintenance-card';
 import MappedDomain from './mapped-domain';
 import RegisteredDomain from './registered-domain';
 import SiteRedirect from './site-redirect';
@@ -27,16 +28,22 @@ const Edit = React.createClass( {
 			return <DomainMainPlaceholder goBack={ this.goToDomainManagement } />;
 		}
 
+		let content = <Details
+			domain={ domain }
+			selectedSite={ this.props.selectedSite }
+			settingPrimaryDomain={ this.props.domains.settingPrimaryDomain }
+		/>;
+
+		if ( domain.type === domainTypes.REGISTERED && domain.registrar === 'Registrar TLD Maintenance' ) {
+			content = <MaintenanceCard { ...this.props } />;
+		}
+
 		return (
 			<Main className="domain-management-edit">
 				<Header onClick={ this.goToDomainManagement } selectedDomainName={ this.props.selectedDomainName }>
 					{ this.translate( 'Domain Settings' ) }
 				</Header>
-
-				<Details
-					domain={ domain }
-					selectedSite={ this.props.selectedSite }
-					settingPrimaryDomain={ this.props.domains.settingPrimaryDomain } />
+				{ content }
 			</Main>
 		);
 	},

--- a/client/my-sites/upgrades/domain-management/edit/index.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/index.jsx
@@ -18,11 +18,13 @@ import WpcomDomain from './wpcom-domain';
 import { type as domainTypes } from 'lib/domains/constants';
 import paths from 'my-sites/upgrades/paths';
 import { getSelectedDomain } from 'lib/domains';
+import { registrar as registrarNames } from 'lib/domains/constants';
 
 const Edit = React.createClass( {
 	render() {
 		const domain = this.props.domains && getSelectedDomain( this.props ),
-			Details = this.getDetailsForType( domain && domain.type );
+			Details = this.getDetailsForType( domain && domain.type ),
+			{ MAINTENANCE } = registrarNames;
 
 		if ( ! domain || ! Details ) {
 			return <DomainMainPlaceholder goBack={ this.goToDomainManagement } />;
@@ -34,7 +36,7 @@ const Edit = React.createClass( {
 			settingPrimaryDomain={ this.props.domains.settingPrimaryDomain }
 		/>;
 
-		if ( domain.type === domainTypes.REGISTERED && domain.registrar === 'Registrar TLD Maintenance' ) {
+		if ( domain.type === domainTypes.REGISTERED && domain.registrar === MAINTENANCE ) {
 			content = <MaintenanceCard { ...this.props } />;
 		}
 

--- a/client/my-sites/upgrades/domain-management/edit/index.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/index.jsx
@@ -8,44 +8,34 @@ import page from 'page';
  * Internal dependencies
  */
 import DomainMainPlaceholder from 'my-sites/upgrades/domain-management/components/domain/main-placeholder';
+import { getSelectedDomain } from 'lib/domains';
 import Header from 'my-sites/upgrades/domain-management/components/header';
+import { localize } from 'i18n-calypso';
 import Main from 'components/main';
 import MaintenanceCard from 'my-sites/upgrades/domain-management/components/domain/maintenance-card';
 import MappedDomain from './mapped-domain';
-import RegisteredDomain from './registered-domain';
-import SiteRedirect from './site-redirect';
-import WpcomDomain from './wpcom-domain';
-import { type as domainTypes } from 'lib/domains/constants';
 import paths from 'my-sites/upgrades/paths';
-import { getSelectedDomain } from 'lib/domains';
+import RegisteredDomain from './registered-domain';
 import { registrar as registrarNames } from 'lib/domains/constants';
+import SiteRedirect from './site-redirect';
+import { type as domainTypes } from 'lib/domains/constants';
+import WpcomDomain from './wpcom-domain';
 
 const Edit = React.createClass( {
 	render() {
 		const domain = this.props.domains && getSelectedDomain( this.props ),
-			Details = this.getDetailsForType( domain && domain.type ),
-			{ MAINTENANCE } = registrarNames;
+			Details = this.getDetailsForType( domain && domain.type );
 
 		if ( ! domain || ! Details ) {
 			return <DomainMainPlaceholder goBack={ this.goToDomainManagement } />;
 		}
 
-		let content = <Details
-			domain={ domain }
-			selectedSite={ this.props.selectedSite }
-			settingPrimaryDomain={ this.props.domains.settingPrimaryDomain }
-		/>;
-
-		if ( domain.type === domainTypes.REGISTERED && domain.registrar === MAINTENANCE ) {
-			content = <MaintenanceCard { ...this.props } />;
-		}
-
 		return (
 			<Main className="domain-management-edit">
 				<Header onClick={ this.goToDomainManagement } selectedDomainName={ this.props.selectedDomainName }>
-					{ this.translate( 'Domain Settings' ) }
+					{ this.props.translate( 'Domain Settings' ) }
 				</Header>
-				{ content }
+				{ this.renderDetails( domain, Details ) }
 			</Main>
 		);
 	},
@@ -69,9 +59,23 @@ const Edit = React.createClass( {
 		}
 	},
 
+	renderDetails( domain, Details ) {
+		const { MAINTENANCE } = registrarNames;
+
+		if ( domain.type === domainTypes.REGISTERED && domain.registrar === MAINTENANCE ) {
+			return <MaintenanceCard { ...this.props } />;
+		}
+
+		return <Details
+			domain={ domain }
+			selectedSite={ this.props.selectedSite }
+			settingPrimaryDomain={ this.props.domains.settingPrimaryDomain }
+		/>;
+	},
+
 	goToDomainManagement() {
 		page( paths.domainManagementList( this.props.selectedSite.slug ) );
 	}
 } );
 
-export default Edit;
+export default localize( Edit );


### PR DESCRIPTION
Show a message instead of the usual domain management panel when a TLD is undergoing maintenance.

Test:
1. Go to Domains
2. Open a domain currently under maintenance
3. You should see:
![drake](https://cloud.githubusercontent.com/assets/1103398/21354653/3e8ad708-c6cb-11e6-984d-3b91d3d6bab5.png)

Before:
![maintenance before](https://cloud.githubusercontent.com/assets/1103398/21244760/573c9142-c31f-11e6-8809-83959f7d8866.png)
