### PR TITLE
Reader: Fix Follow button in Manage Following

### DIFF
--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -160,7 +160,7 @@
 		&.is-valid {
 
 			.gridicon {
-				fill: $gray-dark;
+				fill: $blue-medium;
 
 				&:hover,
 				&:active {
@@ -177,7 +177,7 @@
 			}
 
 			.follow-button__label {
-				color: $gray-dark;
+				color: $blue-medium;
 			}
 
 			.following-edit__list-title {
@@ -371,4 +371,30 @@
 
 .is-section-reader .main.following-edit .empty-content {
 	margin-top: -40px;
+}
+
+.following-edit .reader-list-item__actions {
+	top: 21px;
+}
+
+.following-edit .reader-list-item__actions .follow-button {
+
+	.gridicon {
+		fill: $blue-medium;
+	}
+
+	.follow-button__label {
+		color: $blue-medium;
+	}
+
+	&.is-following {
+
+		.gridicon {
+			fill: $alert-green;
+		}
+
+		.follow-button__label {
+			color: $alert-green;
+		}
+	}
 }


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/10100

**Before:**
![screenshot 2016-12-15 15 21 40](https://cloud.githubusercontent.com/assets/4924246/21245894/30a47db4-c2da-11e6-8c0d-66ab54b3fd19.png)

**After:**
![screenshot 2016-12-15 15 21 32](https://cloud.githubusercontent.com/assets/4924246/21245898/3256cb76-c2da-11e6-928a-5504576efc29.png)

Also fixed:

- Vertical alignment of Follow button
- Color when you unfollow (and it changes back to Follow):

**Before:**
![screenshot 2016-12-15 15 22 30](https://cloud.githubusercontent.com/assets/4924246/21245940/6764f7e8-c2da-11e6-9cfa-7e795c2f8273.png)

**After:**
![screenshot 2016-12-15 15 22 40](https://cloud.githubusercontent.com/assets/4924246/21245945/70a6c0a2-c2da-11e6-9b92-9557d8bede62.png)

