### PR TITLE
Stats: Make Post Trends Visualization always start on Mondays.

### DIFF
--- a/client/my-sites/stats/post-trends/month.jsx
+++ b/client/my-sites/stats/post-trends/month.jsx
@@ -1,29 +1,27 @@
 /**
  * External dependencies
  */
-var i18n = require( 'i18n-calypso' ),
-	React = require( 'react' );
+import { moment } from 'i18n-calypso';
+import React, { PropTypes, Component } from 'react';
 
 /**
  * Internal dependencies
  */
-var Week = require( './week' );
+import Week from './week';
 
-module.exports = React.createClass( {
+export default class PostTrendsMonth extends Component {
+	static propTypes = {
+		startDate: PropTypes.object.isRequired,
+		streakData: PropTypes.object,
+		max: PropTypes.number,
+		userLocale: PropTypes.string,
+	};
 
-	displayName: 'PostTrendsMonth',
-
-	propTypes: {
-		startDate: React.PropTypes.object.isRequired,
-		streakData: React.PropTypes.object,
-		max: React.PropTypes.number
-	},
-
-	getWeekComponents: function() {
-		var monthStart = i18n.moment( this.props.startDate ),
-			monthEnd = i18n.moment( monthStart ).endOf( 'month' ),
-			weekStart = i18n.moment( monthStart ).startOf( 'week' ),
-			weeks = [];
+	getWeekComponents() {
+		const monthStart = moment( this.props.startDate ).locale( 'en' );
+		const monthEnd = moment( monthStart ).endOf( 'month' );
+		const weekStart = moment( monthStart ).startOf( 'week' );
+		const weeks = [];
 
 		// Stat weeks start on Monday and end on Sunday
 		if ( 0 === monthStart.day() ) {
@@ -36,7 +34,7 @@ module.exports = React.createClass( {
 			weeks.push(
 				<Week
 					key={ weekStart.format( 'YYYYMMDD' ) }
-					startDate={ i18n.moment( weekStart ) }
+					startDate={ moment( weekStart ) }
 					month={ monthStart }
 					streakData={ this.props.streakData }
 					max={ this.props.max }
@@ -46,9 +44,9 @@ module.exports = React.createClass( {
 		} while ( weekStart.isBefore( monthEnd, 'day' ) || weekStart.isSame( monthEnd, 'day' ) );
 
 		return weeks;
-	},
+	}
 
-	render: function() {
+	render() {
 		return (
 			<div className="post-trends__month">
 				<div key="weeks" className="post-trends__weeks">{ this.getWeekComponents() }</div>
@@ -56,5 +54,4 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-
-} );
+}

--- a/client/my-sites/stats/post-trends/month.jsx
+++ b/client/my-sites/stats/post-trends/month.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import React, { PropTypes, Component } from 'react';
 
 /**
@@ -9,15 +9,16 @@ import React, { PropTypes, Component } from 'react';
  */
 import Week from './week';
 
-export default class PostTrendsMonth extends Component {
+class PostTrendsMonth extends Component {
 	static propTypes = {
 		startDate: PropTypes.object.isRequired,
 		streakData: PropTypes.object,
 		max: PropTypes.number,
-		userLocale: PropTypes.string,
+		moment: PropTypes.func,
 	};
 
 	getWeekComponents() {
+		const { moment } = this.props;
 		const monthStart = moment( this.props.startDate ).locale( 'en' );
 		const monthEnd = moment( monthStart ).endOf( 'month' );
 		const weekStart = moment( monthStart ).startOf( 'week' );
@@ -55,3 +56,5 @@ export default class PostTrendsMonth extends Component {
 		);
 	}
 }
+
+export default localize( PostTrendsMonth );

--- a/client/my-sites/stats/post-trends/week.jsx
+++ b/client/my-sites/stats/post-trends/week.jsx
@@ -1,48 +1,46 @@
 /**
  * External dependencies
  */
-import i18n from 'i18n-calypso';
-import React, { PropTypes } from 'react';
+import { moment } from 'i18n-calypso';
+import React, { PropTypes, Component } from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import Day from './day';
+import { getCurrentUserLocale } from 'state/current-user/selectors';
 
-export default React.createClass( {
+class PostTrendsWeek extends Component {
 
-	displayName: 'PostTrendsWeek',
-
-	propTypes: {
+	static propTypes = {
 		startDate: PropTypes.object.isRequired,
 		month: PropTypes.object.isRequired,
 		max: PropTypes.number,
-		streakData: PropTypes.object
-	},
+		streakData: PropTypes.object,
+	};
 
-	getDefaultProps() {
-		return {
-			streakData: {},
-			max: 0
-		};
-	},
+	static defaultProps = {
+		streakData: {},
+		max: 0,
+	};
 
 	getDayComponents() {
 		const days = [];
 		const { month, startDate, streakData, max } = this.props;
 
 		for ( let i = 0; i < 7; i++ ) {
-			const dayDate = i18n.moment( startDate ).locale( 'en' ).add( i, 'day' );
+			const dayDate = moment( startDate ).locale( 'en' ).add( i, 'day' );
 			const postCount = streakData[ dayDate.format( 'YYYY-MM-DD' ) ] || 0;
-			let classNames = [];
+			const classNames = [];
 			let level = Math.ceil( ( postCount / max ) * 4 );
 
 			if (
-				dayDate.isBefore( i18n.moment( month ).startOf( 'month' ) ) ||
-				dayDate.isAfter( i18n.moment( month ).endOf( 'month' ) )
+				dayDate.isBefore( moment( month ).startOf( 'month' ) ) ||
+				dayDate.isAfter( moment( month ).endOf( 'month' ) )
 			) {
 				classNames.push( 'is-outside-month' );
-			} else if ( dayDate.isAfter( i18n.moment().endOf( 'day' ) ) ) {
+			} else if ( dayDate.isAfter( moment().endOf( 'day' ) ) ) {
 				classNames.push( 'is-after-today' );
 			} else if ( level ) {
 				if ( level > 4 ) {
@@ -55,14 +53,14 @@ export default React.createClass( {
 			days.push(
 				<Day key={ dayDate.format( 'MMDD' ) }
 					className={ classNames.join( ' ' ) }
-					label={ dayDate.format( 'L' ) }
+					label={ dayDate.locale( this.props.userLocale ).format( 'L' ) }
 					postCount={ postCount }
 				/>
 			);
 		}
 
 		return days;
-	},
+	}
 
 	render() {
 		return (
@@ -70,4 +68,11 @@ export default React.createClass( {
 		);
 	}
 
-} );
+}
+
+export default connect(
+	( state ) => ( { userLocale: getCurrentUserLocale( state ) } ),
+	{},
+	null,
+	{ pure: false }
+)( PostTrendsWeek );

--- a/client/my-sites/stats/post-trends/week.jsx
+++ b/client/my-sites/stats/post-trends/week.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
 
@@ -18,6 +18,8 @@ class PostTrendsWeek extends Component {
 		month: PropTypes.object.isRequired,
 		max: PropTypes.number,
 		streakData: PropTypes.object,
+		moment: PropTypes.func,
+		userLocale: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -27,7 +29,7 @@ class PostTrendsWeek extends Component {
 
 	getDayComponents() {
 		const days = [];
-		const { month, startDate, streakData, max } = this.props;
+		const { month, startDate, streakData, max, moment, userLocale } = this.props;
 
 		for ( let i = 0; i < 7; i++ ) {
 			const dayDate = moment( startDate ).locale( 'en' ).add( i, 'day' );
@@ -53,7 +55,7 @@ class PostTrendsWeek extends Component {
 			days.push(
 				<Day key={ dayDate.format( 'MMDD' ) }
 					className={ classNames.join( ' ' ) }
-					label={ dayDate.locale( this.props.userLocale ).format( 'L' ) }
+					label={ dayDate.locale( userLocale ).format( 'L' ) }
 					postCount={ postCount }
 				/>
 			);
@@ -71,8 +73,5 @@ class PostTrendsWeek extends Component {
 }
 
 export default connect(
-	( state ) => ( { userLocale: getCurrentUserLocale( state ) } ),
-	{},
-	null,
-	{ pure: false }
-)( PostTrendsWeek );
+	( state ) => ( { userLocale: getCurrentUserLocale( state ) } )
+)( localize( PostTrendsWeek ) );


### PR DESCRIPTION
Fixes #6138 - The "Posting Activity" visualization on the Stats Insights page is _supposed_ to start the week columns on Mondays, but due to some moment.js locale mishaps, in certain locales, the start of the week shows as Tuesdays.  Since this visualization, specifically the day "boxes", are quite small - it makes sense to ensure we start the week on a consistent day - and who doesn't love Mondays?!

While fixing the issue, I opted to update a few of the components in this visualization to current standards as well by removing `createClass` and such.  This branch is best tested on a site with post data in the visualization.  en.blog.worpdress.com is a great one to use.

__To Test__
1. Starting at URL: https://wordpress.com/stats/insights/ with interface language set to the en locale.
2. Take note of layout of the posting activity heatmap. Specifically, the top row indicate dates falling on a Monday.

![stats_ _wordpress_com](https://cloud.githubusercontent.com/assets/11873759/16176605/fb45ff70-3612-11e6-9970-d2fa05727b1f.png)

3. Go to Account settings: https://wordpress.com/me/account/
4. Change the interface language to any other language than en, then view Insights page again.
5. Verify the top row represents Monday's still, and the label when you mouse over is localized