### PR TITLE
Jetpack Connect: Fix alignment of help button in authorize no-args error page

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -617,7 +617,7 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 
 	renderNoQueryArgsError() {
 		return (
-			<Main>
+			<Main className="jetpack-connect__main-error">
 				<EmptyContent
 					illustration="/calypso/images/drake/drake-whoops.svg"
 					title={ this.translate(

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -28,6 +28,20 @@
 	}
 }
 
+.jetpack-connect__main-error {
+	.logged-out-form__links {
+		margin-top: 15px;
+		text-align: center;
+
+		.logged-out-form__link-item {
+			.gridicon {
+				position: relative;
+				top: 4px;
+			}
+		}
+	}
+}
+
 .jetpack-connect__site-url-entry-container {
 	max-width: 400px;
 }


### PR DESCRIPTION
This PR fixes #10088, where the help button in the authorize page (when accessed directly without starting the connection flow) was not aligned properly.

**Before:**

![](https://cldup.com/P-viUbjMF4.png)

**After:**

![](https://cldup.com/YJ9agbFnRh.png)

**To test:**

* Get this branch going locally.
* Open `http://calypso.localhost:3000/jetpack/connect/authorize`
* Verify the help button appears properly aligned as in the "after" screenshot.