### PR TITLE
Framework: Fix the console dispatcher middleware by returning the value of the store.dispatch

### DIFF
--- a/client/state/console-dispatch/index.js
+++ b/client/state/console-dispatch/index.js
@@ -81,7 +81,7 @@ export const consoleDispatcher = next => ( reducer, initialState ) => {
 			recordAction( action );
 		}
 
-		store.dispatch( action );
+		return store.dispatch( action );
 	};
 
 	Object.assign( window, store, {


### PR DESCRIPTION
There are some places in Calypso where we rely on the value returned by the Redux dispatch function. This is not a good practice, but let's not break the dispatch API.

By chance, this is not causing any bug in Production, because the console dispatcher middleware is only active on Dev environments.

**Testing instructions**

 - On "dev" environment, go the post's editor
 - Add a category to the post
 - You should not see any Javascript Error on the console