### PR TITLE
Guided Tours: adjust Insert Menu tour position

### DIFF
--- a/client/layout/guided-tours/tours/editor-insert-menu-tour.js
+++ b/client/layout/guided-tours/tours/editor-insert-menu-tour.js
@@ -53,7 +53,11 @@ export const EditorInsertMenuTour = makeTour(
 			name="init"
 			placement="beside"
 			target=".mce-wpcom-insert-menu"
-			style={ { animationDelay: '10s' } }
+			style={ {
+				animationDelay: '10s',
+				marginTop: '-8px',
+				zIndex: '100000',
+			} }
 		>
 			<p>
 				{ translate(


### PR DESCRIPTION
- Add negative `margin-top` to align the tour arrow to the target.

- Reduce `z-index` to move the tour behind the Media dialog.