### PR TITLE
Themes: Add eligibility check to upload page

### DIFF
--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -4,6 +4,7 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -67,7 +68,8 @@ const EligibilityWarnings = props => {
 		translate,
 		backUrl,
 		isEligible,
-		eligibilityData
+		eligibilityData,
+		onProceed,
 	} = props;
 
 	const holdsMessage = getHoldsMessages( translate );
@@ -137,7 +139,7 @@ const EligibilityWarnings = props => {
 						{ translate( 'Cancel' ) }
 					</Button>
 
-					<Button primary={ true } disabled={ ! isEligible }>
+					<Button primary={ true } disabled={ ! isEligible } onClick={ onProceed }>
 						{ translate( 'Proceed' ) }
 					</Button>
 				</div>
@@ -149,7 +151,12 @@ const EligibilityWarnings = props => {
 EligibilityWarnings.propTypes = {
 	isEligible: PropTypes.bool.isRequired,
 	backUrl: PropTypes.string,
-	translate: PropTypes.func
+	translate: PropTypes.func,
+	onProceed: PropTypes.func,
+};
+
+EligibilityWarnings.defaultProps = {
+	onProceed: noop,
 };
 
 const mapStateToProps = state => {

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -271,7 +271,7 @@ class Upload extends React.Component {
 					isEligible={ isEligible }
 					backUrl="/design"
 					onProceed={ this.onProceedClick } /> }
-				{ ( ! showEligibility ) && this.renderUploadCard() }
+				{ ! showEligibility && this.renderUploadCard() }
 			</Main>
 		);
 	}

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -60,11 +60,8 @@ class Upload extends React.Component {
 		installing: React.PropTypes.bool,
 	};
 
-	constructor( props ) {
-		super( props );
-		this.state = {
-			showEligibility: true,
-		};
+	state = {
+		showEligibility: true,
 	}
 
 	componentDidMount() {

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -308,10 +308,11 @@ export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
 		const themeId = getUploadedThemeId( state, siteId );
+		const isJetpack = isJetpackSite( state, siteId );
 		return {
 			siteId,
 			selectedSite: getSelectedSite( state ),
-			isJetpackSite: isJetpackSite( state, siteId ),
+			isJetpackSite: isJetpack,
 			inProgress: isUploadInProgress( state, siteId ),
 			complete: isUploadComplete( state, siteId ),
 			failed: hasUploadFailed( state, siteId ),
@@ -321,7 +322,7 @@ export default connect(
 			progressTotal: getUploadProgressTotal( state, siteId ),
 			progressLoaded: getUploadProgressLoaded( state, siteId ),
 			installing: isInstallInProgress( state, siteId ),
-			eligibilityData: getEligibility( state, siteId ),
+			eligibilityData: ( ! isJetpack ) && getEligibility( state, siteId ),
 		};
 	},
 	{ uploadTheme, clearThemeUpload, initiateThemeTransfer },


### PR DESCRIPTION
<img width="860" alt="screen shot 2016-12-16 at 11 54 04" src="https://cloud.githubusercontent.com/assets/7767559/21262293/91668e04-c388-11e6-9c6a-6be75acaa81b.png">

**To Test**
* Go to /design and choose a site
* Click the 'upload theme' button
* Eligibility warnings/errors should show for a wpcom site
* Should not show for a jetpack site
* Proceed button should be active only if there are no errors
* Clicking 'Proceed' should hide the eligibility warnings
* Clicking 'Cancel' should navigate back to /design


**To Do**
- [x] cancel button should go back
- [x] proceed button should hide eligibility panel
- [ ] ~show placeholder whilst eligibility data loads~ Separate PR

(Cancel button is working but is hardcoded to /design and loses site and other state. Improve on this in another PR)
