### PR TITLE
Proper padding for design elements

### DIFF
--- a/client/blocks/product-purchase-features/product-purchase-features-list/style.scss
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/style.scss
@@ -19,22 +19,3 @@
 	border-radius: 0;
 	margin: 0;
 }
-
-.product-purchase-features-list__item .purchase-detail .purchase-detail__content {
-	@include breakpoint( "1040px-1280px" ) {
-		padding-right: 87px;
-	}
-}
-
-.product-purchase-features-list__item .purchase-detail .purchase-detail__icon {
-	@include breakpoint( "1040px-1280px" ) {
-		right: 4px;
-	}
-}
-
-.product-purchase-features-list__item .purchase-detail .button:not( .clipboard-button ) {
-	@include breakpoint( "<660px" ) {
-		width: 100%;
-		text-align: center;
-	}
-}

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -144,9 +144,7 @@
 }
 
 .purchase-detail__button {
-	&[href] {
-		text-align: center;
-	}
+	text-align: center;
 
 	&:not(.clipboard-button) {
 		width: 80%;

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -8,10 +8,6 @@
 		border-bottom: none;
 	}
 
-	.button:not(.clipboard-button) {
-		width: 80%;
-	}
-
 	@include breakpoint( ">660px" ) {
 		border: 1px solid lighten( $gray, 30% );
 		border-radius: 3px;
@@ -40,10 +36,6 @@
 		.purchase-detail__button {
 			border: none;
 			width: 40%;
-
-			@include breakpoint( "<660px" ) {
-				margin: 0 auto;
-			}
 		}
 
 		.purchase-detail__description {
@@ -80,12 +72,11 @@
 	background: darken( $gray, 20% );
 	border-radius: 50%;
 	color: $white;
-	margin: 0 auto;
-	margin-bottom: 10px;
+	margin: 0 auto 10px;
 	padding: 16px;
 
 	@include breakpoint( ">660px" ) {
-		margin-top: -36px;
+		margin-top: -40px;
 		position: absolute;
 			right: 32px;
 			top: 50%;
@@ -135,13 +126,12 @@
 .purchase-detail__info {
 	flex: 1;
 	margin-left: 8px;
-	margin-top: 0;
+	margin-top: 8px;
 	max-width: 260px;
 	display: inline-block;
-	margin-top: 8px;
 
 	@include breakpoint( ">660px" ) {
-		margin-top: 0px;
+		margin-top: 0;
 	}
 }
 
@@ -151,4 +141,19 @@
 	margin-right: 4px;
 	float: left;
 	height: 14px;
+}
+
+.purchase-detail__button {
+	&[href] {
+		text-align: center;
+	}
+
+	&:not(.clipboard-button) {
+		width: 80%;
+	}
+
+	@include breakpoint( "<660px" ) {
+		display: block;
+		margin: 0 auto;
+	}
 }

--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -104,6 +104,10 @@
 			color: $alert-red;
 		}
 	}
+
+	.button.is-compact {
+		white-space: pre;
+	}
 }
 
 .current-plan__header-expires-in {

--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -106,7 +106,7 @@
 	}
 
 	.button.is-compact {
-		white-space: pre;
+		flex-shrink: 0;
 	}
 }
 

--- a/client/my-sites/upgrades/checkout-thank-you/google-voucher/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/google-voucher/index.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import ClipboardButtonInput from 'components/clipboard-button-input';
 import PurchaseDetails from 'components/purchase-detail';
 import PurchaseButton from 'components/purchase-detail/purchase-button';
@@ -142,16 +143,20 @@ class GoogleVoucherDetails extends Component {
 				</div>
 
 				<div className="google-voucher-dialog__footer">
-					<PurchaseButton
+					<Button
 						className="google-vouchers-dialog__cancel-button"
-						primary={ false }
 						onClick={ this.onDialogCancel }
-						text={ this.props.translate( 'Cancel' ) } />
+					>
+						{ this.props.translate( 'Cancel' ) }
+					</Button>
 
-					<PurchaseButton
+					<Button
 						className="google-vouchers-dialog__agree-button"
 						onClick={ this.onAcceptTermsAndConditions }
-						text={ this.props.translate( 'Agree' ) } />
+						primary={ true }
+					>
+						{ this.props.translate( 'Agree' ) }
+					</Button>
 				</div>
 			</Dialog>
 		);


### PR DESCRIPTION
Reverts some of the special styles that `purchase-detail` received in `purchase-feature-list` to use default paddings. Also displays buttons appropriately now on small screens.

Fixes #7660.

Correct padding for icons:
<img width="481" alt="screen shot 2016-12-16 at 1 12 37 pm" src="https://cloud.githubusercontent.com/assets/1398304/21263005/ac62fec0-c394-11e6-925c-789537a63f26.png">

Button doesn't wrap:
<img width="448" alt="screen shot 2016-12-16 at 1 12 56 pm" src="https://cloud.githubusercontent.com/assets/1398304/21263002/a70d921e-c394-11e6-914f-5e819040b9a7.png">

Links and buttons are center aligned:
<img width="415" alt="screen shot 2016-12-16 at 1 09 15 pm" src="https://cloud.githubusercontent.com/assets/1398304/21263004/a91a31d4-c394-11e6-9f92-a467db2694d3.png">

To test, go to `/plans/my-plan/` on desktop and mobile. You could also purchase a new plan to verify that purchase details outside of the plans list still look good.