### PR TITLE
Publicize: Fix wrong connections count making Share Post button disabled

### DIFF
--- a/client/my-sites/posts/post-share.jsx
+++ b/client/my-sites/posts/post-share.jsx
@@ -4,8 +4,7 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import includes from 'lodash/includes';
-import map from 'lodash/map';
+import { includes, map, without } from 'lodash';
 import SocialLogo from 'social-logos';
 
 /**
@@ -110,6 +109,18 @@ const PostSharing = React.createClass( {
 	sharePost: function() {
 		this.props.sharePost( this.props.siteId, this.props.post.ID, this.state.skipped, this.state.message );
 	},
+	isButtonDisabled() {
+		if ( this.props.requesting ) {
+			return true;
+		}
+
+		const activeConnectionIds = without(
+			map( this.props.connections, connection => connection.keyring_connection_ID ),
+			...this.state.skipped
+		);
+
+		return activeConnectionIds.length < 1;
+	},
 	render: function() {
 		if ( ! this.props.isPublicizeEnabled ) {
 			return null;
@@ -153,7 +164,7 @@ const PostSharing = React.createClass( {
 								<Button
 									primary={ true }
 									onClick={ this.sharePost }
-									disabled={ this.props.requesting || ( ( this.props.connections.length || 0 ) - this.state.skipped.length  < 1 ) }
+									disabled={ this.isButtonDisabled() }
 								>
 									{ this.translate( 'Share post' ) }
 								</Button>


### PR DESCRIPTION
It looks like if you reconnect any of your social services after you published your post, then `Share Post` button is disabled also when any of the social services is enabled for sharing.

Current state:
 ![publicize-connection-bug](https://cloud.githubusercontent.com/assets/699132/21263284/2fdc1f38-c396-11e6-9f8e-38c6fc9ae1ca.gif)

In my case I published post, then I had to reconnect Google Plus. When I want to share one of the posts then Google Plus is enabled by default, but `Share Post` button is disabled.

This fix tries to resolve this issues and always compares connections that are marked as skipped with those connections that are currently provided for sharing.

### Testing
1. Make sure you have a post that was published with at least one sharing option enabled.
2. Reconnect one of the sharing options that was enabled at the time the post was shared.
3. Toggle sharing section of your post and make sure `Share Post` is only disabled when data is fetching and all sharing options are disabled. 

/cc @Automattic/sdev-feed 
