### PR TITLE
Plans: Account for Personal Plan in PropTypes.

### DIFF
--- a/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
@@ -43,6 +43,7 @@ class ProductPurchaseFeaturesList extends Component {
 	static propTypes = {
 		plan: PropTypes
 			.oneOf( [ PLAN_FREE,
+				PLAN_PERSONAL,
 				PLAN_PREMIUM,
 				PLAN_BUSINESS,
 				PLAN_JETPACK_FREE,
@@ -223,7 +224,6 @@ class ProductPurchaseFeaturesList extends Component {
 			/>
 		];
 	}
-
 
 	getJetpackBusinessFeatures() {
 		const {	selectedSite } = this.props;


### PR DESCRIPTION
Adds the Personal Plan to the array of accepted plans. The constant already gets [imported](https://github.com/Automattic/wp-calypso/blob/1687e6a960a513142f0dc1a245cd280b9a1be906/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx#L12) and [used](https://github.com/Automattic/wp-calypso/blob/1687e6a960a513142f0dc1a245cd280b9a1be906/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx#L264), it just wasn't declared in PropTypes.

Previously:
<img width="1280" alt="screen shot 2016-12-16 at 1 08 36 pm" src="https://cloud.githubusercontent.com/assets/1398304/21263552/bc626484-c397-11e6-9882-73393a4dddbe.png">

To test, navigate to `/plans/my-plan` on a site that uses the personal plan. The above shown error should not appear.