### PR TITLE
Taxonomies: Open term posts on a WebPreview

### DIFF
--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -113,7 +113,7 @@ class TaxonomyManagerListItem extends Component {
 		return decodeEntities( term.name ) || translate( 'Untitled' );
 	};
 
-	viewPosts = () => () => {
+	viewPosts = () => {
 		this.props.setPreviewUrl( this.getTaxonomyLink() );
 		this.props.setPreviewType( 'site-preview' );
 		this.props.setLayoutFocus( 'preview' );
@@ -166,7 +166,7 @@ class TaxonomyManagerListItem extends Component {
 						</PopoverMenuItem>
 					}
 					{ ! isJetpack &&
-						<PopoverMenuItem onClick={ this.viewPosts() } icon="external">
+						<PopoverMenuItem onClick={ this.viewPosts } icon="external">
 							{ translate( 'View Posts' ) }
 						</PopoverMenuItem>
 					}

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -21,6 +21,8 @@ import { getSiteSettings } from 'state/site-settings/selectors';
 import { getSite, isJetpackSite } from 'state/sites/selectors';
 import { deleteTerm } from 'state/terms/actions';
 import { saveSiteSettings } from 'state/site-settings/actions';
+import { setLayoutFocus } from 'state/ui/layout-focus/actions';
+import { setPreviewUrl, setPreviewType } from 'state/ui/preview/actions';
 import { decodeEntities } from 'lib/formatting';
 import Tooltip from 'components/tooltip';
 
@@ -111,6 +113,12 @@ class TaxonomyManagerListItem extends Component {
 		return decodeEntities( term.name ) || translate( 'Untitled' );
 	};
 
+	viewPosts = () => () => {
+		this.props.setPreviewUrl( this.getTaxonomyLink() );
+		this.props.setPreviewType( 'site-preview' );
+		this.props.setLayoutFocus( 'preview' );
+	};
+
 	render() {
 		const { canSetAsDefault, isDefault, onClick, term, translate, isJetpack } = this.props;
 		const className = classNames( 'taxonomy-manager__item', {
@@ -158,7 +166,7 @@ class TaxonomyManagerListItem extends Component {
 						</PopoverMenuItem>
 					}
 					{ ! isJetpack &&
-						<PopoverMenuItem href={ this.getTaxonomyLink() } icon="external">
+						<PopoverMenuItem onClick={ this.viewPosts() } icon="external">
 							{ translate( 'View Posts' ) }
 						</PopoverMenuItem>
 					}
@@ -197,5 +205,11 @@ export default connect(
 			siteUrl,
 		};
 	},
-	{ deleteTerm, saveSiteSettings }
+	{
+		deleteTerm,
+		saveSiteSettings,
+		setLayoutFocus,
+		setPreviewType,
+		setPreviewUrl,
+	}
 )( localize( TaxonomyManagerListItem ) );


### PR DESCRIPTION
This PR addresses the issue #10114

When you click on "View Posts" in the taxonomy manager, the posts url is opened in a WebPreview Component. I'm not very familiar with WebPreview and its behavior. So, Is this the desired behavior here?

<img width="1673" alt="screen shot 2016-12-16 at 15 15 12" src="https://cloud.githubusercontent.com/assets/272444/21265729/ff52ed94-c3a2-11e6-90db-81abad1589ee.png">


**Testing instructions**

 - Go to the taxonomy manager `/settings/taxonomies/category/$site`
 - Click on the Ellipsis menu of a given category
 - Click "View Posts"
 - The posts page should appear in a WebPreview