### PR TITLE
Taxonomies: Use custom taxonomies slugs for Jetpack Taxonomies links

### DIFF
--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -18,7 +18,7 @@ import Count from 'components/count';
 import Dialog from 'components/dialog';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSettings } from 'state/site-settings/selectors';
-import { getSite, isJetpackSite } from 'state/sites/selectors';
+import { getTaxonomyPostsUrl } from 'state/sites/selectors';
 import { deleteTerm } from 'state/terms/actions';
 import { saveSiteSettings } from 'state/site-settings/actions';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
@@ -36,9 +36,8 @@ class TaxonomyManagerListItem extends Component {
 		siteId: PropTypes.number,
 		term: PropTypes.object,
 		translate: PropTypes.func,
-		siteUrl: PropTypes.string,
+		postsLink: PropTypes.string,
 		slug: PropTypes.string,
-		isJetpack: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -73,16 +72,6 @@ class TaxonomyManagerListItem extends Component {
 		}
 	};
 
-	getTaxonomyLink() {
-		const { taxonomy, siteUrl, term } = this.props;
-		let taxonomyBase = taxonomy;
-
-		if ( taxonomy === 'post_tag' ) {
-			taxonomyBase = 'tag';
-		}
-		return `${ siteUrl }/${ taxonomyBase }/${ term.slug }/`;
-	}
-
 	tooltipText = () => {
 		const { term, translate } = this.props;
 		const name = this.getName();
@@ -114,13 +103,13 @@ class TaxonomyManagerListItem extends Component {
 	};
 
 	viewPosts = () => {
-		this.props.setPreviewUrl( this.getTaxonomyLink() );
+		this.props.setPreviewUrl( this.props.postsLink );
 		this.props.setPreviewType( 'site-preview' );
 		this.props.setLayoutFocus( 'preview' );
 	};
 
 	render() {
-		const { canSetAsDefault, isDefault, onClick, term, translate, isJetpack } = this.props;
+		const { canSetAsDefault, isDefault, onClick, postsLink, term, translate } = this.props;
 		const className = classNames( 'taxonomy-manager__item', {
 			'is-default': isDefault
 		} );
@@ -165,7 +154,7 @@ class TaxonomyManagerListItem extends Component {
 							{ translate( 'Delete' ) }
 						</PopoverMenuItem>
 					}
-					{ ! isJetpack &&
+					{ postsLink &&
 						<PopoverMenuItem onClick={ this.viewPosts } icon="external">
 							{ translate( 'View Posts' ) }
 						</PopoverMenuItem>
@@ -195,14 +184,13 @@ export default connect(
 		const siteSettings = getSiteSettings( state, siteId );
 		const canSetAsDefault = taxonomy === 'category';
 		const isDefault = canSetAsDefault && get( siteSettings, [ 'default_category' ] ) === term.ID;
-		const siteUrl = get( getSite( state, siteId ), 'URL' );
+		const postsLink = getTaxonomyPostsUrl( state, siteId, taxonomy, term.slug );
 
 		return {
-			isJetpack: isJetpackSite( state, siteId ),
 			isDefault,
 			canSetAsDefault,
 			siteId,
-			siteUrl,
+			postsLink,
 		};
 	},
 	{

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -1020,3 +1020,29 @@ export const hasDefaultSiteTitle = ( state, siteId ) => {
 	// we are using startsWith here, as getSiteSlug returns "slug.wordpress.com"
 	return site.name === i18n.translate( 'Site Title' ) || startsWith( slug, site.name );
 };
+
+/**
+ * Returns the taxonomy posts URL for a site, taxonomy and a slug
+ *
+ * @param  {Object} state    Global state tree
+ * @param  {Number} siteId   Site ID
+ * @param  {String} taxonomy Taxonomy
+ * @param  {String} slug     Term Slug
+ * @return {String}          Taxonomy posts URL
+ */
+export function getTaxonomyPostsUrl( state, siteId, taxonomy, slug ) {
+	const site = getRawSite( state, siteId );
+	if ( ! site ) {
+		return null;
+	}
+	let taxonomyBase = taxonomy;
+	if ( taxonomy === 'post_tag' ) {
+		taxonomyBase = 'tag';
+	}
+	if ( isJetpackSite( state, siteId ) ) {
+		const jetpackBase = getSiteOption( state, siteId, `${ taxonomyBase }_base` );
+		taxonomyBase = jetpackBase || taxonomyBase;
+	}
+
+	return `${ site.URL }/${ taxonomyBase }/${ slug }/`;
+}

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -46,7 +46,8 @@ import {
 	siteHasMinimumJetpackVersion,
 	isJetpackSiteMainNetworkSite,
 	getSiteAdminUrl,
-	getCustomizerUrl
+	getCustomizerUrl,
+	getTaxonomyPostsUrl,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -2270,6 +2271,68 @@ describe( 'selectors', () => {
 
 				expect( customizerUrl ).to.equal( 'https://example.com/wp-admin/customize.php' );
 			} );
+		} );
+	} );
+
+	describe( 'getTaxonomyPostsUrl()', () => {
+		it( 'it should null if the site is not tracked', () => {
+			const state = createStateWithItems( {} );
+			const url = getTaxonomyPostsUrl( state, siteId, 'post_tag', 'chicken' );
+			expect( url ).to.be.null;
+		} );
+
+		it( 'it should return an url with tag instead of post_tag for dotcom websites', () => {
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://example.com',
+					jetpack: false
+				}
+			} );
+			const url = getTaxonomyPostsUrl( state, siteId, 'post_tag', 'chicken' );
+			expect( url ).to.equal( 'https://example.com/tag/chicken/' );
+		} );
+
+		it( 'it should return a category front page url for dotcom websites', () => {
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://example.com',
+					jetpack: false
+				}
+			} );
+			const url = getTaxonomyPostsUrl( state, siteId, 'category', 'chicken' );
+			expect( url ).to.equal( 'https://example.com/category/chicken/' );
+		} );
+
+		it( 'it should use the tag_base option for JetPack websites', () => {
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://example.com',
+					jetpack: true,
+					options: {
+						tag_base: 'awesome_tag_slug'
+					}
+				}
+			} );
+			const url = getTaxonomyPostsUrl( state, siteId, 'post_tag', 'chicken' );
+			expect( url ).to.equal( 'https://example.com/awesome_tag_slug/chicken/' );
+		} );
+
+		it( 'it should use the category_base option for JetPack websites', () => {
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://example.com',
+					jetpack: true,
+					options: {
+						category_base: 'awesome_category_slug'
+					}
+				}
+			} );
+			const url = getTaxonomyPostsUrl( state, siteId, 'category', 'chicken' );
+			expect( url ).to.equal( 'https://example.com/awesome_category_slug/chicken/' );
 		} );
 	} );
 } );


### PR DESCRIPTION
Blocked by code-D3665
closes #9927

On Jetpack sites though, the category/tag "base" can be set via the permalink options, which make the url we are using for view posts potentially incorrect. This PR fixes this and uses the custom taxonomies slugs to compute the "View Posts" taxonomy link for JetPack websites.

**Testing instructions**

 * Go to `$site/wp-admin/options-permalink.php`
 * Customize the tag and category Base path
 * Wait for JetPack to Sync (or trigger a manual sync)
 * Go the taxonomy manager `/taxonomies/category/$site`
 * Check that the "View Posts" links (ellipsis menu) are working properly
 * Check also for tags 