### PR TITLE
Publicize: Make Share Post box wider on smal devices

### DIFF
--- a/client/my-sites/posts/post-share.jsx
+++ b/client/my-sites/posts/post-share.jsx
@@ -151,6 +151,7 @@ const PostSharing = React.createClass( {
 							<div className="posts__post-share-form">
 								{ this.renderMessage() }
 								<Button
+									className="posts__post-share-button"
 									primary={ true }
 									onClick={ this.sharePost }
 									disabled={ this.props.requesting || ( ( this.props.connections.length || 0 ) - this.state.skipped.length  < 1 ) }

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -19,8 +19,12 @@
 	.posts__post-share-main {
 		border-top: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 		display: flex;
-		flex-direction: row;
+		flex-direction: column-reverse;
 		padding: 0 24px 24px;
+
+		@include breakpoint( ">480px" ) {
+			flex-direction: row;
+		}
 	}
 	.posts__post-share-head {
 		padding: 0 24px;
@@ -31,12 +35,16 @@
 	}
 
 	.posts__post-share-services {
-		flex: 2; 
+		flex: 2;
 		flex-direction: column;
 		justify-content: flex-start;
 		display: flex;
 		flex-wrap: wrap;
-		margin: 16px 0 0 20px;
+		margin-top: 16px;
+
+		@include breakpoint( ">480px" ) {
+			margin-left: 20px;
+		}
 	}
 
 	.posts__post-share-services-header {
@@ -55,6 +63,10 @@
 		color: lighten( $gray, 20% );
 		.social-logo {
 			padding-left: 4px;
+		}
+
+		&:first-of-type {
+			margin-top: 8px;
 		}
 
 		&.is-active {
@@ -620,5 +632,13 @@
 
 	.count {
 		margin-left: 8px;
+	}
+}
+
+.posts__post-share-button{
+	width: 100%;
+
+	@include breakpoint( ">480px" ) {
+		width: auto;
 	}
 }


### PR DESCRIPTION
I added three changes to make Share Post box look better on smaller devices:

* There are two rows instead of two columns on small devices to avoid squeezed content.
* `Share Post` is now full width on small devices.
* I added margin under `Connected Services` header to have the same spacing as in the other column.

### Small device

Before:
![screen shot 2016-12-16 at 19 05 31](https://cloud.githubusercontent.com/assets/699132/21273296/2a178a6a-c3c3-11e6-8021-d4545d5a61ff.png)

After
![screen shot 2016-12-16 at 19 04 10](https://cloud.githubusercontent.com/assets/699132/21273300/32749842-c3c3-11e6-97ab-89e28495a76f.png)

### Larger device

Before:
![screen shot 2016-12-16 at 19 05 09](https://cloud.githubusercontent.com/assets/699132/21273315/41d6c9cc-c3c3-11e6-872c-8940ff0b2be4.png)

After:
![screen shot 2016-12-16 at 19 04 31](https://cloud.githubusercontent.com/assets/699132/21273320/470ac970-c3c3-11e6-8b14-87e64651f042.png)

### Testing
1. Pick you site, go to Posts and click share on one of the posts.
2. Test using different resolutions.

/cc @Automattic/sdev-feed 

