### PR TITLE
Editor: improve copy of Guided Tour for new insert menu

### DIFF
--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -26,6 +26,11 @@
 		}
 	}
 
+	.gridicon {
+		vertical-align: middle;
+		margin-top: -4px;
+	}
+
 	.gridicon[height="16"] {
 		position: relative;
 		top: 2px;
@@ -106,11 +111,6 @@
 	font-style: italic;
 	line-height: 24px;
 	min-height: 24px;
-
-	.gridicon {
-		vertical-align: middle;
-		margin-top: -4px;
-	}
 
 	.external-link {
 		font-style: normal;

--- a/client/layout/guided-tours/tours/editor-insert-menu-tour.js
+++ b/client/layout/guided-tours/tours/editor-insert-menu-tour.js
@@ -20,6 +20,7 @@ import {
 	hasUserRegisteredBefore,
 } from 'state/ui/guided-tours/contexts';
 import { isDesktop } from 'lib/viewport';
+import Gridicon from 'components/gridicon';
 
 class RepositioningStep extends Step {
 
@@ -64,8 +65,9 @@ export const EditorInsertMenuTour = makeTour(
 				) }
 			</p>
 			<p>
-				{ translate( 'Click here to see everything you can add.', {
-					comment: 'Description of the Guided Tour for the Editor Insert Menu button.'
+				{ translate( 'Click {{icon/}} to add media and other kinds of content.', {
+					components: { icon: <Gridicon icon="chevron-down" /> },
+					comment: 'Refers to the Insert Content button and dropdown in the post editor.'
 				} ) }
 			</p>
 			<ButtonRow>


### PR DESCRIPTION
Improves upon #9699

# Before

<img width="500" alt="screen shot 2016-12-16 at 19 46 52" src="https://cloud.githubusercontent.com/assets/150562/21276254/73fc7988-c3c8-11e6-869a-64343c015c0f.png">

# After

<img width="500" alt="screen shot 2016-12-16 at 19 44 26" src="https://cloud.githubusercontent.com/assets/150562/21276170/1674ef70-c3c8-11e6-98bf-5056feb90a46.png">
