### PR TITLE
Jetpack Ads: Always allow Jetpack Premium users to view ads pages.

### DIFF
--- a/client/lib/ads/utils.js
+++ b/client/lib/ads/utils.js
@@ -16,8 +16,9 @@ export function canAccessWordads( site ) {
 			return true;
 		}
 
+		const jetpackPremium = site.jetpack && ( isPremium( site.plan ) || isBusiness( site.plan ) );
 		return site.options &&
-			site.options.wordads &&
+			( site.options.wordads || jetpackPremium ) &&
 			userCan( 'manage_options', site ) &&
 			( ! site.jetpack || config.isEnabled( 'manage/ads/jetpack' ) );
 	}


### PR DESCRIPTION
This update is to fix the race condition of Premium Jetpack users getting accepted into WordAds faster than Calypso updates the status in the site settings object. This update allows Jetpack Premium users to view the earnings/settings Ads pages before the setting is updated.

**Background**
Jetpack Premium users are silently auto-accepted into the WordAds program when they toggle the Ads module in Jetpack 4.5. They are then presented with a link "view your earnings" that will lead them to their Ads earnings page. However, the user can activate the module and go to the page faster than the API can update and Calypso can pull down the updated settings.

Calypso will _eventually_ pull the new site settings and the sidebar link will show up, but in the mean time we don't want to bounce the users from the page.

**Jetpack Settings**
<img width="737" alt="screen shot 2016-12-16 at 2 15 32 pm" src="https://cloud.githubusercontent.com/assets/273708/21280334/3c2db93c-c39a-11e6-8333-92f0266de86f.png">

**Before settings update**
<img width="1204" alt="screen shot 2016-12-16 at 2 22 23 pm" src="https://cloud.githubusercontent.com/assets/273708/21280505/325d3aa8-c39b-11e6-81b5-0ce7099f16c0.png">

**After settings update**
<img width="1227" alt="screen shot 2016-12-16 at 2 21 49 pm" src="https://cloud.githubusercontent.com/assets/273708/21280513/3a2eee84-c39b-11e6-9cb8-b96c23f4e8fa.png">

**Testing**
1. Activate Jetpack 4.5 Beta and sign up for premium or professional.
2. Activate Ads module under `Engagement` in Jetpack Settings.
3. Click on `view your earnings` link.