### PR TITLE
Me: Update Account Password form to use translate from localize.

### DIFF
--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -1,14 +1,17 @@
 /**
  * External dependencies
  */
-import { bindActionCreators, compose } from 'redux';
 import { localize } from 'i18n-calypso';
+import {
+	debounce,
+	flowRight as compose,
+	head,
+	isEmpty
+} from 'lodash';
+import { bindActionCreators } from 'redux';
 var React = require( 'react' ),
 	LinkedStateMixin = require( 'react-addons-linked-state-mixin' ),
 	debug = require( 'debug' )( 'calypso:me:account-password' ),
-	debounce = require( 'lodash/debounce' ),
-	head = require( 'lodash/head' ),
-	isEmpty = require( 'lodash/isEmpty' ),
 	classNames = require( 'classnames' ),
 	connect = require( 'react-redux' ).connect;
 

--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { localize } from 'i18n-calypso';
 var React = require( 'react' ),
 	LinkedStateMixin = require( 'react-addons-linked-state-mixin' ),
 	debug = require( 'debug' )( 'calypso:me:account-password' ),
@@ -76,7 +77,11 @@ const AccountPassword = React.createClass( {
 	},
 
 	submitForm: function( event ) {
-		const { errorNotice: showErrorNotice } = this.props;
+		const {
+			translate,
+			errorNotice: showErrorNotice,
+		} = this.props;
+
 		event.preventDefault();
 
 		this.setState( {
@@ -92,7 +97,7 @@ const AccountPassword = React.createClass( {
 					debug( 'Error saving password: ' + JSON.stringify( error ) );
 
 					// handle error case here
-					showErrorNotice( this.translate( 'There was a problem saving your password. Please, try again.' ) );
+					showErrorNotice( translate( 'There was a problem saving your password. Please, try again.' ) );
 					this.setState( { submittingForm: false } );
 				} else {
 					debug( 'Password saved successfully' + JSON.stringify( response ) );
@@ -106,11 +111,12 @@ const AccountPassword = React.createClass( {
 	},
 
 	renderValidationNotices: function() {
-		var failure = head( this.props.accountPasswordData.getValidationFailures() );
+		const { translate } = this.props;
+		const failure = head( this.props.accountPasswordData.getValidationFailures() );
 
 		if ( this.props.accountPasswordData.passwordValidationSuccess() ) {
 			return (
-				<FormInputValidation text={ this.translate( 'Your password can be saved.' ) } />
+				<FormInputValidation text={ translate( 'Your password can be saved.' ) } />
 			);
 		} else if ( ! isEmpty( failure ) ) {
 			return (
@@ -120,20 +126,20 @@ const AccountPassword = React.createClass( {
 	},
 
 	render: function() {
-		var passwordValueLink = {
-				value: this.state.password,
-				requestChange: this.handlePasswordChange
-			},
-			passwordInputClasses = classNames( {
-				'account-password__password-field': true,
-				'is-error': this.props.accountPasswordData.getValidationFailures().length
-			}
-		);
+		const { translate } = this.props;
+		const passwordValueLink = {
+			value: this.state.password,
+			requestChange: this.handlePasswordChange,
+		};
+		const passwordInputClasses = classNames( {
+			'account-password__password-field': true,
+			'is-error': this.props.accountPasswordData.getValidationFailures().length,
+		} );
 
 		return (
 			<form className="account-password" onSubmit={ this.submitForm }>
 				<FormFieldset>
-					<FormLabel htmlFor="password">{ this.translate( 'New Password' ) }</FormLabel>
+					<FormLabel htmlFor="password">{ translate( 'New Password' ) }</FormLabel>
 					<FormPasswordInput
 						autoCapitalize="off"
 						autoComplete="off"
@@ -148,7 +154,7 @@ const AccountPassword = React.createClass( {
 					{ this.renderValidationNotices() }
 
 					<FormSettingExplanation>
-						{ this.translate(
+						{ translate(
 							"If you can't think of a good password use the button below to generate one."
 						) }
 					</FormSettingExplanation>
@@ -158,7 +164,7 @@ const AccountPassword = React.createClass( {
 					<FormButton
 						disabled={ this.state.pendingValidation || this.props.accountPasswordData.passwordValidationFailed() }
 						onClick={ this.recordClickEvent( 'Save Password Button' ) }>
-						{ this.state.savingPassword ? this.translate( 'Saving…' ) : this.translate( 'Save Password' ) }
+						{ this.state.savingPassword ? translate( 'Saving…' ) : translate( 'Save Password' ) }
 					</FormButton>
 
 					<FormButton
@@ -166,7 +172,7 @@ const AccountPassword = React.createClass( {
 						isPrimary={ false }
 						onClick={ this.recordClickEvent( 'Generate Strong Password Button', this.generateStrongPassword ) }
 						type="button">
-						{ this.translate( 'Generate strong password' ) }
+						{ translate( 'Generate strong password' ) }
 					</FormButton>
 				</FormButtonsBar>
 			</form>
@@ -177,4 +183,4 @@ const AccountPassword = React.createClass( {
 export default connect(
 	null,
 	dispatch => bindActionCreators( { errorNotice }, dispatch )
-)( protectForm( AccountPassword ) );
+)( protectForm( localize( AccountPassword ) ) );

--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { bindActionCreators, compose } from 'redux';
 import { localize } from 'i18n-calypso';
 var React = require( 'react' ),
 	LinkedStateMixin = require( 'react-addons-linked-state-mixin' ),
@@ -9,7 +10,6 @@ var React = require( 'react' ),
 	head = require( 'lodash/head' ),
 	isEmpty = require( 'lodash/isEmpty' ),
 	classNames = require( 'classnames' ),
-	bindActionCreators = require( 'redux' ).bindActionCreators,
 	connect = require( 'react-redux' ).connect;
 
 /**
@@ -180,7 +180,11 @@ const AccountPassword = React.createClass( {
 	}
 } );
 
-export default connect(
-	null,
-	dispatch => bindActionCreators( { errorNotice }, dispatch )
-)( protectForm( localize( AccountPassword ) ) );
+export default compose(
+	connect(
+		null,
+		dispatch => bindActionCreators( { errorNotice }, dispatch ),
+	),
+	localize,
+	protectForm,
+)( AccountPassword );


### PR DESCRIPTION
The changes in this PR are set to replace the usage of this.translate with the same method supplied by the localize HOC.

### Use of `compose()`
As explained in a separate issue (#10138), I've noticed that a common pattern is to do the following:
```es6
export default connect( ... )( localize( SomeComponent ) );
```

The problem with this, is that it's not a pattern that 'scales' well as more HOCs are introduced...
```es6
export default connect( ... )( localize( anotherHoc( andSoOn( SomeComponent ) ) ) );
```

The file changed in this PR seemed a good candidate to demo the use of `compose` so I thought I'd go with the "show, don't tell" approach.

Take a look at the issue (#10138) too, I thought I'd open a discussion on it's use in future PRs that implement two or more higher-order components (HOCs).

Note that there are 2 commits here - just to show a 'before' and 'after' of using `compose`.

### Testing
Nothing should have changed visually or functionally.

- Navigate to [/me/security](http://calypso.localhost:3000/me/security)
- Look at the translated copy items. 'New Password' should still says 'New Password' etc.
- Because protectForm is now 'composed', check that the form is protected:
  - Enter a valid password
  - Attempt to navigate
  - See a warning, as below:
<img width="690" alt="protectedform" src="https://cloud.githubusercontent.com/assets/4335450/21286873/e6c4a2d8-c4b3-11e6-9484-a4aeca802d49.png">
