### PR TITLE
me/account: Replace this.translate usage with that provided by localize

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -143,8 +143,8 @@ const Account = React.createClass( {
 	},
 
 	thankTranslationContributors() {
-		const { translate } = this.props;
-		const locale = this.props.userSettings.getSetting( 'language' );
+		const { translate, userSettings } = this.props;
+		const locale = userSettings.getSetting( 'language' );
 		if ( ! locale || locale === 'en' ) {
 			return;
 		}
@@ -457,7 +457,7 @@ const Account = React.createClass( {
 	 * These form fields are displayed when there is not a username change in progress.
 	 */
 	renderAccountFields() {
-		const { translate } = this.props;
+		const { translate, userSettings } = this.props;
 
 		return (
 			<div className="account__settings-form" key="settingsForm">
@@ -518,7 +518,7 @@ const Account = React.createClass( {
 
 				<FormButton
 					isSubmitting={ this.state.submittingForm }
-					disabled={ ! this.props.userSettings.hasUnsavedSettings() || this.getDisabledState() || this.hasEmailValidationError() }
+					disabled={ ! userSettings.hasUnsavedSettings() || this.getDisabledState() || this.hasEmailValidationError() }
 					onClick={ this.recordClickEvent( 'Save Account Settings Button' ) }
 				>
 					{ this.state.submittingForm ? translate( 'Saving…' ) : translate( 'Save Account Settings' ) }


### PR DESCRIPTION
Similar to #10137, this PR replaces the use of this.translate with the method provided by the localize HOC.

I also made some slight refactoring changes along the way, mostly just destructuring values from `this.props` along with `translate` and minor stylistic changes, as well as an improvement to a map function.

### Testing
Nothing should have changed visually or functionally.

- Navigate to [/me/account](http://calypso.localhost:3000/me/account)
- Look at the translated copy items. 'Username' should still say 'Username'
- Because protectForm is now 'composed', check that the form is protected:
  - Change some fields
  - Attempt to navigate
  - You should see a warning to show that you have unsaved changes.
- Also check that the changed-username fields show correctly:
  - Change the username field
  - make sure that this is successfully translated.
