### PR TITLE
G Suite: Show a compact site-wide notice for G Suite accounts pending ToS acceptance

### DIFF
--- a/client/lib/mixins/analytics/index.js
+++ b/client/lib/mixins/analytics/index.js
@@ -642,6 +642,22 @@ const EVENTS = {
 						section
 					}
 				);
+			},
+
+			fixPendingEmailSiteNoticeClick( siteSlug ) {
+				analytics.ga.recordEvent(
+					'Domain Management',
+					'Clicked "Fix" link in site notice for email requiring action',
+					'Site',
+					siteSlug
+				);
+
+				analytics.tracks.recordEvent(
+					'calypso_domain_management_google_apps_site_fix_click',
+					{
+						site_slug: siteSlug
+					}
+				);
 			}
 		},
 

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -102,7 +102,8 @@ const CurrentSite = React.createClass( {
 					'expiringDomainsCanManage',
 					'expiredDomainsCannotManage',
 					'expiringDomainsCannotManage',
-					'wrongNSMappedDomains'
+					'wrongNSMappedDomains',
+					'pendingGappsTosAcceptanceDomains'
 				] } />
 		);
 	},

--- a/client/my-sites/upgrades/components/domain-warnings/pending-gapps-tos-notice.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/pending-gapps-tos-notice.jsx
@@ -44,7 +44,9 @@ const PendingGappsTosNotice = React.createClass( {
 	},
 
 	getGappsLoginUrl( email, domain ) {
-		return `https://accounts.google.com/AccountChooser?Email=${ email }&service=CPanel&continue=https%3A%2F%2Fadmin.google.com%2F${ domain }%2FAcceptTermsOfService%3Fcontinue%3Dhttps%3A%2F%2Fmail.google.com%2Fmail%2Fu%2F1`;
+		return `https://accounts.google.com/AccountChooser?Email=${ email }&service=CPanel' +
+			'&continue=https%3A%2F%2Fadmin.google.com%2F${ domain }' +
+			'%2FAcceptTermsOfService%3Fcontinue%3Dhttps%3A%2F%2Fmail.google.com%2Fmail%2Fu%2F1`;
 	},
 
 	getNoticeSeverity() {
@@ -81,7 +83,14 @@ const PendingGappsTosNotice = React.createClass( {
 
 	generateLogInClickHandler( { domainName, user, severity, isMultipleDomains } ) {
 		return () => {
-			this.recordEvent( 'pendingAccountLogInClick', { siteSlug: this.props.siteSlug, domainName, user, severity, isMultipleDomains, section: this.props.section } );
+			this.recordEvent( 'pendingAccountLogInClick', {
+				domainName,
+				isMultipleDomains,
+				severity,
+				user,
+				section: this.props.section,
+				siteSlug: this.props.siteSlug
+			} );
 		};
 	},
 
@@ -122,8 +131,8 @@ const PendingGappsTosNotice = React.createClass( {
 	oneDomainNotice() {
 		const severity = this.getNoticeSeverity(),
 			exclamation = this.getExclamation( severity ),
-			domainName = this.props.domains[0].name,
-			users = this.props.domains[0].googleAppsSubscription.pendingUsers;
+			domainName = this.props.domains[ 0 ].name,
+			users = this.props.domains[ 0 ].googleAppsSubscription.pendingUsers;
 
 		return (
 			<Notice
@@ -132,8 +141,10 @@ const PendingGappsTosNotice = React.createClass( {
 				showDismiss={ false }
 				key="pending-gapps-tos-acceptance-domain"
 				text={ this.props.translate(
-					'%(exclamation)s To activate your email {{strong}}%(emails)s{{/strong}}, please log in to G Suite and finish setting it up. {{learnMoreLink}}Learn More{{/learnMoreLink}}',
-					'%(exclamation)s To activate your emails {{strong}}%(emails)s{{/strong}}, please log in to G Suite and finish setting it up. {{learnMoreLink}}Learn More{{/learnMoreLink}}',
+					'%(exclamation)s To activate your email {{strong}}%(emails)s{{/strong}}, please log in to G Suite ' +
+						'and finish setting it up. {{learnMoreLink}}Learn More{{/learnMoreLink}}',
+					'%(exclamation)s To activate your emails {{strong}}%(emails)s{{/strong}}, please log in to G Suite ' +
+						'and finish setting it up. {{learnMoreLink}}Learn More{{/learnMoreLink}}',
 					{
 						count: users.length,
 						args: { exclamation, emails: users.join( ', ' ) },
@@ -141,8 +152,8 @@ const PendingGappsTosNotice = React.createClass( {
 					}
 				) }>
 				<NoticeAction
-					href={ this.getGappsLoginUrl( users[0], domainName ) }
-					onClick={ this.generateLogInClickHandler( { domainName, user: users[0], severity, isMultipleDomains: false } ) }
+					href={ this.getGappsLoginUrl( users[ 0 ], domainName ) }
+					onClick={ this.generateLogInClickHandler( { domainName, user: users[ 0 ], severity, isMultipleDomains: false } ) }
 					external>
 						{ this.props.translate( 'Log in' ) }
 				</NoticeAction>
@@ -160,7 +171,8 @@ const PendingGappsTosNotice = React.createClass( {
 				showDismiss={ false }
 				key="pending-gapps-tos-acceptance-domains">
 				{ this.props.translate(
-					'%(exclamation)s To activate your new email addresses, please log in to G Suite and finish setting them up. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
+					'%(exclamation)s To activate your new email addresses, please log in to G Suite ' +
+						'and finish setting them up. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
 					{
 						args: { exclamation },
 						components: { learnMoreLink }
@@ -171,8 +183,13 @@ const PendingGappsTosNotice = React.createClass( {
 						return <li key={ `pending-gapps-tos-acceptance-domain-${ domainName }` }>
 						<strong>{ users.join( ', ' ) } </strong>
 							<a
-								href={ this.getGappsLoginUrl( users[0], domainName ) }
-								onClick={ this.generateLogInClickHandler( { domainName, user: users[0], severity, isMultipleDomains: true } ) }
+								href={ this.getGappsLoginUrl( users[ 0 ], domainName ) }
+								onClick={ this.generateLogInClickHandler( {
+									domainName,
+									severity,
+									isMultipleDomains: true,
+									user: users[ 0 ]
+								} ) }
 								target="_blank"
 								rel="noopener noreferrer">
 									{ this.props.translate( 'Log in' ) }

--- a/client/my-sites/upgrades/components/domain-warnings/pending-gapps-tos-notice.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/pending-gapps-tos-notice.jsx
@@ -11,7 +11,7 @@ import analyticsMixin from 'lib/mixins/analytics';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import support from 'lib/url/support';
-import paths from 'my-sites/upgrades/paths';
+import { domainManagementEmail } from 'my-sites/upgrades/paths';
 
 const learnMoreLink = <a href={ support.COMPLETING_GOOGLE_APPS_SIGNUP } target="_blank" rel="noopener noreferrer" />,
 	strong = <strong />;
@@ -44,9 +44,9 @@ const PendingGappsTosNotice = React.createClass( {
 	},
 
 	getGappsLoginUrl( email, domain ) {
-		return `https://accounts.google.com/AccountChooser?Email=${ email }&service=CPanel' +
-			'&continue=https%3A%2F%2Fadmin.google.com%2F${ domain }' +
-			'%2FAcceptTermsOfService%3Fcontinue%3Dhttps%3A%2F%2Fmail.google.com%2Fmail%2Fu%2F1`;
+		return `https://accounts.google.com/AccountChooser?Email=${ email }&service=CPanel` +
+			`&continue=https%3A%2F%2Fadmin.google.com%2F${ domain }` +
+			'%2FAcceptTermsOfService%3Fcontinue%3Dhttps%3A%2F%2Fmail.google.com%2Fmail%2Fu%2F1';
 	},
 
 	getNoticeSeverity() {
@@ -103,8 +103,8 @@ const PendingGappsTosNotice = React.createClass( {
 	compactNotice() {
 		const severity = this.getNoticeSeverity(),
 			href = this.props.domains.length === 1
-				? paths.domainManagementEmail( this.props.siteSlug, this.props.domains[ 0 ].name )
-				: paths.domainManagementEmail( this.props.siteSlug );
+				? domainManagementEmail( this.props.siteSlug, this.props.domains[ 0 ].name )
+				: domainManagementEmail( this.props.siteSlug );
 
 		return (
 			<Notice

--- a/client/my-sites/upgrades/components/domain-warnings/pending-gapps-tos-notice.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/pending-gapps-tos-notice.jsx
@@ -10,6 +10,7 @@ import analyticsMixin from 'lib/mixins/analytics';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import support from 'lib/url/support';
+import paths from 'my-sites/upgrades/paths';
 
 const learnMoreLink = <a href={ support.COMPLETING_GOOGLE_APPS_SIGNUP } target="_blank" rel="noopener noreferrer" />,
 	strong = <strong />;
@@ -83,6 +84,40 @@ const PendingGappsTosNotice = React.createClass( {
 		};
 	},
 
+	generateFixClickHandler() {
+		return () => {
+			this.recordEvent( 'fixPendingEmailSiteNoticeClick', this.props.siteSlug );
+		};
+	},
+
+	compactNotice() {
+		const severity = this.getNoticeSeverity(),
+			href = this.props.domains.length === 1
+				? paths.domainManagementEmail( this.props.siteSlug, this.props.domains[ 0 ].name )
+				: paths.domainManagementEmail( this.props.siteSlug );
+
+		return (
+			<Notice
+				isCompact={ this.props.isCompact }
+				status={ `is-${ severity }` }
+				showDismiss={ false }
+				key="pending-gapps-tos-acceptance-domain-compact"
+				text={ this.translate(
+					'Email requires action',
+					'Emails require action',
+					{
+						count: this.props.domains.length
+					}
+				) }>
+				<NoticeAction
+					href={ href }
+					onClick={ this.generateFixClickHandler() }>
+						{ this.translate( 'Fix' ) }
+				</NoticeAction>
+			</Notice>
+		);
+	},
+
 	oneDomainNotice() {
 		const severity = this.getNoticeSeverity(),
 			exclamation = this.getExclamation( severity ),
@@ -149,6 +184,10 @@ const PendingGappsTosNotice = React.createClass( {
 	},
 
 	render() {
+		if ( this.props.isCompact ) {
+			return this.compactNotice();
+		}
+
 		switch ( this.props.domains.length ) {
 			case 0:
 				return null;

--- a/client/my-sites/upgrades/components/domain-warnings/pending-gapps-tos-notice.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/pending-gapps-tos-notice.jsx
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -28,7 +29,7 @@ const PendingGappsTosNotice = React.createClass( {
 	getDefaultProps() {
 		return {
 			isCompact: false
-		}
+		};
 	},
 
 	componentDidMount() {
@@ -68,13 +69,13 @@ const PendingGappsTosNotice = React.createClass( {
 
 		switch ( severity ) {
 			case 'warning':
-				return this.translate( 'Attention!', translationOptions );
+				return this.props.translate( 'Attention!', translationOptions );
 
 			case 'error':
-				return this.translate( 'Urgent!', translationOptions );
+				return this.props.translate( 'Urgent!', translationOptions );
 
 			default:
-				return this.translate( 'You\'re almost there!', translationOptions );
+				return this.props.translate( 'You\'re almost there!', translationOptions );
 		}
 	},
 
@@ -102,7 +103,7 @@ const PendingGappsTosNotice = React.createClass( {
 				status={ `is-${ severity }` }
 				showDismiss={ false }
 				key="pending-gapps-tos-acceptance-domain-compact"
-				text={ this.translate(
+				text={ this.props.translate(
 					'Email requires action',
 					'Emails require action',
 					{
@@ -112,7 +113,7 @@ const PendingGappsTosNotice = React.createClass( {
 				<NoticeAction
 					href={ href }
 					onClick={ this.generateFixClickHandler() }>
-						{ this.translate( 'Fix' ) }
+						{ this.props.translate( 'Fix' ) }
 				</NoticeAction>
 			</Notice>
 		);
@@ -130,7 +131,7 @@ const PendingGappsTosNotice = React.createClass( {
 				status={ `is-${ severity }` }
 				showDismiss={ false }
 				key="pending-gapps-tos-acceptance-domain"
-				text={ this.translate(
+				text={ this.props.translate(
 					'%(exclamation)s To activate your email {{strong}}%(emails)s{{/strong}}, please log in to G Suite and finish setting it up. {{learnMoreLink}}Learn More{{/learnMoreLink}}',
 					'%(exclamation)s To activate your emails {{strong}}%(emails)s{{/strong}}, please log in to G Suite and finish setting it up. {{learnMoreLink}}Learn More{{/learnMoreLink}}',
 					{
@@ -143,7 +144,7 @@ const PendingGappsTosNotice = React.createClass( {
 					href={ this.getGappsLoginUrl( users[0], domainName ) }
 					onClick={ this.generateLogInClickHandler( { domainName, user: users[0], severity, isMultipleDomains: false } ) }
 					external>
-						{ this.translate( 'Log in' ) }
+						{ this.props.translate( 'Log in' ) }
 				</NoticeAction>
 			</Notice>
 		);
@@ -158,7 +159,7 @@ const PendingGappsTosNotice = React.createClass( {
 				status={ `is-${ severity }` }
 				showDismiss={ false }
 				key="pending-gapps-tos-acceptance-domains">
-				{ this.translate(
+				{ this.props.translate(
 					'%(exclamation)s To activate your new email addresses, please log in to G Suite and finish setting them up. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
 					{
 						args: { exclamation },
@@ -174,7 +175,7 @@ const PendingGappsTosNotice = React.createClass( {
 								onClick={ this.generateLogInClickHandler( { domainName, user: users[0], severity, isMultipleDomains: true } ) }
 								target="_blank"
 								rel="noopener noreferrer">
-									{ this.translate( 'Log in' ) }
+									{ this.props.translate( 'Log in' ) }
 							</a>
 						</li>;
 					} )
@@ -201,4 +202,4 @@ const PendingGappsTosNotice = React.createClass( {
 	},
 } );
 
-export default PendingGappsTosNotice;
+export default localize( PendingGappsTosNotice );


### PR DESCRIPTION
We're already showing a notice for G Suite accounts that have not approved Google's Terms of Service. However, that's only in the Domains section of Calypso - if the user does not visit there often, he/she might miss it.
This PR adds a site notice for this issue:

<img width="562" alt="screen shot 2016-12-17 at 21 16 11" src="https://cloud.githubusercontent.com/assets/3392497/21289533/c769eec0-c49f-11e6-981f-37836fbf4e0e.png">

Clicking on the `FIX` link takes you to the G Suite view where you can see more details about the issue and a link to log in to your G Suite account and accept the ToS:
<img width="1258" alt="screen shot 2016-12-17 at 21 17 20" src="https://cloud.githubusercontent.com/assets/3392497/21289534/de82bd94-c49f-11e6-85c8-8ac1d527874e.png">

I've taken this opportunity to fix some ESlint warnings, so please check out the individual commits if you want to see what was actually added and what was simply refactored/fixed.

/cc @Lochlaer ❤️ 