### PR TITLE
Credits: Updated repo urls for redux & react-redux

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1141,7 +1141,7 @@ Copyright © 2013 Habla, Inc. Habla Inc. (dba Olark)
 Permission kindly granted by Ben Congleton, of Olark.
 ```
 
-### https://github.com/rackt/redux/
+### https://github.com/reactjs/redux/
 #### client/state
 ```text
 The MIT License (MIT)
@@ -1169,7 +1169,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-### https://github.com/rackt/react-redux
+### https://github.com/reactjs/react-redux
 ```text
 The MIT License (MIT)
 


### PR DESCRIPTION
I noticed that the `redux` & `react-redux` references were referencing their previous homes at github/rackt/.
They've both since moved in to github/reactjs/.  

Usually the old urls would just forward through to the new location but it seems that somebody has opened an account with the username of 'rackt' and created a repo called redux! 😒