### PR TITLE
Update/prioritize jpc errors

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -245,7 +245,13 @@ const LoggedInForm = React.createClass( {
 		} else if ( siteReceived && ! isActivating ) {
 			this.activateManageAndRedirect();
 		}
-		if ( authorizeError && this.props.authAttempts < MAX_AUTH_ATTEMPTS && ! this.retryingAuth ) {
+		if (
+			authorizeError &&
+			this.props.authAttempts < MAX_AUTH_ATTEMPTS &&
+			! this.retryingAuth &&
+			! props.requestHasXmlrpcError() &&
+			authorizeError.message.indexOf( 'verify_secrets_expired' ) === -1
+		) {
 			const attempts = this.props.authAttempts || 0;
 			this.retryingAuth = true;
 			this.props.retryAuth( queryObject.site, attempts + 1 );

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -332,8 +332,15 @@ const LoggedInForm = React.createClass( {
 	},
 
 	handleResolve() {
-		this.retryingAuth = false;
 		const { queryObject, authorizationCode } = this.props.jetpackConnectAuthorize;
+		const authUrl = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true';
+		this.retryingAuth = false;
+		if ( this.props.requestHasExpiredSecretError() ) {
+			this.props.recordTracksEvent( 'calypso_jpc_resolve_expired_secret_error_click' );
+			window.location.href = queryObject.site + authUrl;
+			return;
+		}
+		this.props.recordTracksEvent( 'calypso_jpc_resolve_xmlrpc_error_click' );
 		this.props.goToXmlrpcErrorFallbackUrl( queryObject, authorizationCode );
 	},
 

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -33,6 +33,7 @@ import {
 	getSSOSessions,
 	isCalypsoStartedConnection,
 	hasXmlrpcError,
+	hasExpiredSecretError,
 	getSiteSelectedPlan,
 	isRemoteSiteOnSitesList,
 	getGlobalSelectedPlan,
@@ -250,7 +251,7 @@ const LoggedInForm = React.createClass( {
 			this.props.authAttempts < MAX_AUTH_ATTEMPTS &&
 			! this.retryingAuth &&
 			! props.requestHasXmlrpcError() &&
-			authorizeError.message.indexOf( 'verify_secrets_expired' ) === -1
+			! props.requestHasExpiredSecretError()
 		) {
 			const attempts = this.props.authAttempts || 0;
 			this.retryingAuth = true;
@@ -396,7 +397,7 @@ const LoggedInForm = React.createClass( {
 		if ( authorizeError.message.indexOf( 'already_connected' ) >= 0 ) {
 			return <JetpackConnectNotices noticeType="alreadyConnected" />;
 		}
-		if ( authorizeError.message.indexOf( 'verify_secrets_expired' ) >= 0 ) {
+		if ( this.props.requestHasExpiredSecretError() ) {
 			return <JetpackConnectNotices noticeType="secretExpired" siteUrl={ queryObject.site } />;
 		}
 		if ( this.props.requestHasXmlrpcError() ) {
@@ -694,6 +695,9 @@ export default connect(
 		const requestHasXmlrpcError = () => {
 			return hasXmlrpcError( state );
 		};
+		const requestHasExpiredSecretError = () => {
+			return hasExpiredSecretError( state );
+		};
 		const selectedPlan = getSiteSelectedPlan( state, siteSlug ) || getGlobalSelectedPlan( state );
 
 		const isFetchingSites = () => {
@@ -708,6 +712,7 @@ export default connect(
 			isAlreadyOnSitesList: isRemoteSiteOnSitesList( state ),
 			isFetchingSites,
 			requestHasXmlrpcError,
+			requestHasExpiredSecretError,
 			calypsoStartedConnection: isCalypsoStartedConnection( state, remoteSiteUrl ),
 			authAttempts: getAuthAttempts( state, siteSlug )
 		};

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -67,6 +67,7 @@ import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import Plans from './plans';
 import CheckoutData from 'components/data/checkout';
+import { externalRedirect } from 'lib/route/path';
 
 /**
  * Constants
@@ -342,7 +343,7 @@ const LoggedInForm = React.createClass( {
 			// In this case, we need to re-issue the secret.
 			// We do this by redirecting to Jetpack client, which will automatically redirect back here.
 			this.props.recordTracksEvent( 'calypso_jpc_resolve_expired_secret_error_click' );
-			window.location.href = queryObject.site + authUrl;
+			externalRedirect( queryObject.site + authUrl );
 			return;
 		}
 		// Otherwise, we assume the site is having trouble receive XMLRPC requests.

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -279,7 +279,6 @@ export default {
 				type: JETPACK_CONNECT_REDIRECT_XMLRPC_ERROR_FALLBACK_URL,
 				url
 			} );
-			tracksEvent( dispatch, 'calyspo_jpc_xmlrpc_error', { error: queryObject.authorizeError } );
 			externalRedirect( url );
 		};
 	},

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -113,6 +113,18 @@ const hasXmlrpcError = function( state ) {
 	);
 };
 
+const hasExpiredSecretError = function( state ) {
+	const authorizeData = getAuthorizationData( state );
+
+	return (
+		authorizeData &&
+		authorizeData.authorizeError &&
+		authorizeData.authorizeError.message &&
+		authorizeData.authorizationCode &&
+		authorizeData.authorizeError.message.indexOf( 'verify_secrets_expired' ) > -1
+	);
+};
+
 const getJetpackPlanSelected = function( state ) {
 	const selectedPlans = state.jetpackConnect.jetpackConnectSelectedPlans;
 	const siteUrl = getAuthorizationRemoteQueryData( state ).site;
@@ -148,6 +160,7 @@ export default {
 	getFlowType,
 	getJetpackSiteByUrl,
 	hasXmlrpcError,
+	hasExpiredSecretError,
 	getJetpackPlanSelected,
 	getSiteSelectedPlan,
 	getGlobalSelectedPlan,


### PR DESCRIPTION
This tightens up JPC error handling by distinguishing between expired secret errors, XMLRPC errors, and all other types of errors.

Here is how this PR will prioritize:
- If we encounter an XMLRPC error we will immediately show a resolve button
-- Clicking button will bypass XMLRPC requests, which can assume are problematic, and attempt to finish the connection on the remote site using legacy functions
-- This will bypass the plans page
- Or, if we encounter an expired secret, we will immediately show a resolve button
-- Clicking button will re-issue the secret on the remote site, and try the flow again
- Or if we encounter any other type of error, immediately and automattically try the request again
-- This has proved to help with various XMLRPC hiccups that seem to happen

To test:
- you'll need to sandbox public-api.wordpress.com, so you can force errors
- you'll need to attempt to connect an unconnected Jetpack site
- return `transport error - HTTP status code was not 200 (502)` to test xmlrpc errors
-- in this case, you should immediately be presented with a Retry button
-- clicking this will bring you back to your site and complete the connection there
- return `verify_secrets_expired`
-- in this case, you should also be presented with a Retry button
-- clicking this will regenerate the secret on your site, and bring you back to calypso
- return`verify_secrets_missiong` to simulate any other error
 -- in this case, calypso will automatically retry



