### PR TITLE
Follow Button: fix padding at smaller breakpoints

### DIFF
--- a/client/blocks/follow-button/style.scss
+++ b/client/blocks/follow-button/style.scss
@@ -1,6 +1,6 @@
 $follow-button-gray-disabled: lighten( $gray, 20% );
 
-.follow-button {
+.follow-button, button.follow-button {
 
 	.gridicon__follow {
 		opacity: 1;
@@ -101,7 +101,6 @@ $follow-button-gray-disabled: lighten( $gray, 20% );
 }
 
 .follow-button__label {
-
 	@include breakpoint( "<660px" ) {
 		display: none;
 	}

--- a/client/blocks/follow-button/style.scss
+++ b/client/blocks/follow-button/style.scss
@@ -1,6 +1,7 @@
 $follow-button-gray-disabled: lighten( $gray, 20% );
 
-.follow-button, button.follow-button {
+.follow-button,
+button.follow-button {
 
 	.gridicon__follow {
 		opacity: 1;


### PR DESCRIPTION
As noted in #10125, the recent move of the FollowButton from `blocks` to `components` caused a small regression: extra right padding was added to the button at smaller breakpoints.

Before:

<img width="295" alt="screen shot 2016-12-19 at 16 01 47" src="https://cloud.githubusercontent.com/assets/17325/21299938/fad9e218-c604-11e6-91b1-7bf1f2fe9470.png">

After:

<img width="271" alt="screen shot 2016-12-19 at 16 01 28" src="https://cloud.githubusercontent.com/assets/17325/21299941/026a6566-c605-11e6-8fd2-17862cd81898.png">


### To test

Visit http://calypso.localhost:3000/devdocs/blocks/follow-button and check that the icon is centred.

cc @hoverduck 

Fixes #10125.