### PR TITLE
state/themes/actions: Compose `activateWpcomThemeOnJetpack` from `installTheme` and `activateTheme`

### DIFF
--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -59,6 +59,7 @@ const activate = {
 const activateOnJetpack = {
 	label: i18n.translate( 'Activate' ),
 	header: i18n.translate( 'Activate on:', { comment: 'label for selecting a site on which to activate a theme' } ),
+	// Append `-wpcom` suffix to the theme ID so the installAndActivate() will install the theme from WordPress.com, not WordPress.org
 	action: ( themeId, siteId, ...args ) => installAndActivate( themeId + '-wpcom', siteId, ...args ),
 	hideForSite: ( state, siteId ) => ! isJetpackSite( state, siteId ),
 	hideForTheme: ( state, theme, siteId ) => (

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -59,7 +59,7 @@ const activate = {
 const activateOnJetpack = {
 	label: i18n.translate( 'Activate' ),
 	header: i18n.translate( 'Activate on:', { comment: 'label for selecting a site on which to activate a theme' } ),
-	action: installAndActivate,
+	action: ( themeId, siteId, ...args ) => installAndActivate( themeId + '-wpcom', siteId, ...args ),
 	hideForSite: ( state, siteId ) => ! isJetpackSite( state, siteId ),
 	hideForTheme: ( state, theme, siteId ) => (
 		isActive( state, theme.id, siteId ) || (

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -10,7 +10,7 @@ import { has, identity, mapValues, pick, pickBy } from 'lodash';
  * Internal dependencies
  */
 import config from 'config';
-import { activateTheme, activateWpcomThemeOnJetpack } from 'state/themes/actions';
+import { activateTheme, installAndActivate } from 'state/themes/actions';
 import {
 	getThemeSignupUrl as getSignupUrl,
 	getThemePurchaseUrl as getPurchaseUrl,
@@ -59,7 +59,7 @@ const activate = {
 const activateOnJetpack = {
 	label: i18n.translate( 'Activate' ),
 	header: i18n.translate( 'Activate on:', { comment: 'label for selecting a site on which to activate a theme' } ),
-	action: activateWpcomThemeOnJetpack,
+	action: installAndActivate,
 	hideForSite: ( state, siteId ) => ! isJetpackSite( state, siteId ),
 	hideForTheme: ( state, theme, siteId ) => (
 		isActive( state, theme.id, siteId ) || (

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -418,6 +418,8 @@ export function installAndActivate( themeId, siteId, source = 'unknown', purchas
 	return ( dispatch ) => {
 		return dispatch( installTheme( themeId, siteId ) )
 			.then( () => {
+				// This will be called even if `installTheme` silently fails. We rely on
+				// `activateTheme`'s own error handling here.
 				dispatch( activateTheme( themeId, siteId, source, purchased ) );
 			} );
 	};

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -404,37 +404,33 @@ export function clearActivated( siteId ) {
 }
 
 /**
- * Triggers a network request to activate a specific wpcom theme on a given Jetpack site.
- * First step of the process is the installation of the theme on Jetpack site.
- * Second step is the actuall activation.
+ * Triggers a network request to install and activate a specific theme on a given
+ * Jetpack site. If the themeId parameter is suffixed with '-wpcom', install the
+ * theme from WordPress.com. Otherwise, install from WordPress.org.
  *
- * @param  {String}   themeId   Theme ID, this should be standard id without -wpcom suffix.
+ * @param  {String}   themeId   Theme ID. If suffixed with '-wpcom', install theme from WordPress.com
  * @param  {Number}   siteId    Site ID
  * @param  {String}   source    The source that is reuquesting theme activation, e.g. 'showcase'
  * @param  {Boolean}  purchased Whether the theme has been purchased prior to activation
  * @return {Function}           Action thunk
  */
 export function installAndActivate( themeId, siteId, source = 'unknown', purchased = false ) {
-	//Add -wpcom suffix. This suffix tells the endpoint that we want to
-	//install WordPress.com theme. Without the suffix endpoint would look
-	//for theme in .org
-	const suffixedThemeId = themeId + '-wpcom';
 	return ( dispatch ) => {
 		// To the user, this is presented as just activation -- the install part is hidden.
 		// Thus, we want to trigger any UI changes that apply to activation here, too.
 		dispatch( {
 			type: THEME_ACTIVATE_REQUEST,
-			themeId: suffixedThemeId,
+			themeId,
 			siteId,
 		} );
-		return dispatch( installTheme( suffixedThemeId, siteId ) )
+		return dispatch( installTheme( themeId, siteId ) )
 			.then( () => {
-				dispatch( activateTheme( suffixedThemeId, siteId, source, purchased ) );
+				dispatch( activateTheme( themeId, siteId, source, purchased ) );
 			} )
 			.catch( () => {
 				dispatch( {
 					type: THEME_ACTIVATE_REQUEST_FAILURE,
-					themeId: suffixedThemeId,
+					themeId,
 					siteId,
 				} );
 			} );

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -427,10 +427,10 @@ export function activateWpcomThemeOnJetpack( themeId, siteId, source = 'unknown'
 			themeId: suffixedThemeId,
 			siteId,
 		} );
-		dispatch( installTheme( suffixedThemeId, siteId ) )
+		return dispatch( installTheme( suffixedThemeId, siteId ) )
 			.then( () => {
-				dispatch( activateTheme( suffixedThemeId, siteId, source, purchased )
-			); } )
+				dispatch( activateTheme( suffixedThemeId, siteId, source, purchased ) );
+			} )
 			.catch( () => {
 				dispatch( {
 					type: THEME_ACTIVATE_REQUEST_FAILURE,

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -408,10 +408,6 @@ export function clearActivated( siteId ) {
  * First step of the process is the installation of the theme on Jetpack site.
  * Second step is the actuall activation.
  *
- * Warning: this is working but not final version. It has a built in hack in form of
- * dispatching THEME_ACTIVATE_REQUEST twice to mark process start and has no handlin
- * of information about installation process except in failure scenario.
- *
  * @param  {String}   themeId   Theme ID, this should be standard id without -wpcom suffix.
  * @param  {Number}   siteId    Site ID
  * @param  {String}   source    The source that is reuquesting theme activation, e.g. 'showcase'
@@ -423,23 +419,23 @@ export function activateWpcomThemeOnJetpack( themeId, siteId, source = 'unknown'
 	//install WordPress.com theme. Without the suffix endpoint would look
 	//for theme in .org
 	const suffixedThemeId = themeId + '-wpcom';
-	return dispatch => {
+	return ( dispatch ) => {
+		// To the user, this is presented as just activation -- the install part is hidden.
+		// Thus, we want to trigger any UI changes that apply to activation here, too.
 		dispatch( {
 			type: THEME_ACTIVATE_REQUEST,
 			themeId: suffixedThemeId,
 			siteId,
 		} );
-
-		return wpcom.undocumented().installThemeOnJetpack( siteId, suffixedThemeId )
+		dispatch( installTheme( suffixedThemeId, siteId ) )
 			.then( () => {
-				return activateTheme( suffixedThemeId, siteId, source, purchased )( dispatch );
-			} )
-			.catch( ( error ) => {
+				dispatch( activateTheme( suffixedThemeId, siteId, source, purchased )
+			); } )
+			.catch( () => {
 				dispatch( {
 					type: THEME_ACTIVATE_REQUEST_FAILURE,
 					themeId: suffixedThemeId,
 					siteId,
-					error
 				} );
 			} );
 	};

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -414,7 +414,7 @@ export function clearActivated( siteId ) {
  * @param  {Boolean}  purchased Whether the theme has been purchased prior to activation
  * @return {Function}           Action thunk
  */
-export function activateWpcomThemeOnJetpack( themeId, siteId, source = 'unknown', purchased = false ) {
+export function installAndActivate( themeId, siteId, source = 'unknown', purchased = false ) {
 	//Add -wpcom suffix. This suffix tells the endpoint that we want to
 	//install WordPress.com theme. Without the suffix endpoint would look
 	//for theme in .org

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -426,13 +426,6 @@ export function installAndActivate( themeId, siteId, source = 'unknown', purchas
 		return dispatch( installTheme( themeId, siteId ) )
 			.then( () => {
 				dispatch( activateTheme( themeId, siteId, source, purchased ) );
-			} )
-			.catch( () => {
-				dispatch( {
-					type: THEME_ACTIVATE_REQUEST_FAILURE,
-					themeId,
-					siteId,
-				} );
 			} );
 	};
 }

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -416,13 +416,6 @@ export function clearActivated( siteId ) {
  */
 export function installAndActivate( themeId, siteId, source = 'unknown', purchased = false ) {
 	return ( dispatch ) => {
-		// To the user, this is presented as just activation -- the install part is hidden.
-		// Thus, we want to trigger any UI changes that apply to activation here, too.
-		dispatch( {
-			type: THEME_ACTIVATE_REQUEST,
-			themeId,
-			siteId,
-		} );
 		return dispatch( installTheme( themeId, siteId ) )
 			.then( () => {
 				dispatch( activateTheme( themeId, siteId, source, purchased ) );

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -535,27 +535,8 @@ describe( 'actions', () => {
 			res();
 		} ) );
 
-		beforeEach( () => {
-			stub.reset();
-		} );
-
-		it( 'should dispatch activate theme request action when triggered', () => {
-			installAndActivate( 'karuna', 2211667 )( stub );
-
-			expect( stub ).to.have.been.calledWith( {
-				type: THEME_ACTIVATE_REQUEST,
-				siteId: 2211667,
-				themeId: 'karuna'
-			} );
-		} );
-
 		it( 'should dispatch THEME_ACTIVATE_REQUEST, installTheme(), and activateTheme()', ( done ) => {
 			installAndActivate( 'karuna-wpcom', 2211667 )( stub ).then( () => {
-				expect( stub ).to.have.been.calledWith( {
-					type: THEME_ACTIVATE_REQUEST,
-					themeId: 'karuna-wpcom',
-					siteId: 2211667,
-				} );
 				expect( stub ).to.have.been.calledWith( matchFunction( installTheme( 'karuna-wpcom', 2211667 ) ) );
 				expect( stub ).to.have.been.calledWith( matchFunction( activateTheme( 'karuna-wpcom', 2211667 ) ) );
 				done();

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -561,22 +561,6 @@ describe( 'actions', () => {
 				done();
 			} );
 		} );
-
-		it( 'should dispatch wpcom theme install request failure action when theme install fails', () => {
-			// Fail on attempted install
-			stub.withArgs( matchFunction( installTheme( 'pinboard', 2211667 ) ) )
-				.returns( new Promise( ( res, rej ) => {
-					rej();
-				} ) );
-
-			return installAndActivate( 'pinboard', 2211667 )( stub ).then( () => {
-				expect( stub ).to.have.been.calledWith( {
-					type: THEME_ACTIVATE_REQUEST_FAILURE,
-					siteId: 2211667,
-					themeId: 'pinboard'
-				} );
-			} );
-		} );
 	} );
 
 	describe( '#requestActiveTheme', () => {

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -35,7 +35,7 @@ import {
 	themeActivated,
 	clearActivated,
 	activateTheme,
-	activateWpcomThemeOnJetpack,
+	installAndActivate,
 	requestActiveTheme,
 	receiveTheme,
 	receiveThemes,
@@ -518,7 +518,7 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( '#activateWpcomThemeOnJetpack', () => {
+	describe( '#installAndActivate', () => {
 		function isEqualFunction( f1, f2 ) {
 			// TODO: Also compare params!
 			return f1.toString() === f2.toString();
@@ -540,7 +540,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch activate theme request action when triggered', () => {
-			activateWpcomThemeOnJetpack( 'karuna', 2211667 )( stub );
+			installAndActivate( 'karuna', 2211667 )( stub );
 
 			expect( stub ).to.have.been.calledWith( {
 				type: THEME_ACTIVATE_REQUEST,
@@ -550,7 +550,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch THEME_ACTIVATE_REQUEST, installTheme(), and activateTheme()', ( done ) => {
-			activateWpcomThemeOnJetpack( 'karuna', 2211667 )( stub ).then( () => {
+			installAndActivate( 'karuna', 2211667 )( stub ).then( () => {
 				expect( stub ).to.have.been.calledWith( {
 					type: THEME_ACTIVATE_REQUEST,
 					themeId: 'karuna-wpcom',
@@ -569,7 +569,7 @@ describe( 'actions', () => {
 					rej();
 				} ) );
 
-			return activateWpcomThemeOnJetpack( 'pinboard', 2211667 )( stub ).then( () => {
+			return installAndActivate( 'pinboard', 2211667 )( stub ).then( () => {
 				expect( stub ).to.have.been.calledWith( {
 					type: THEME_ACTIVATE_REQUEST_FAILURE,
 					siteId: 2211667,

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -545,12 +545,12 @@ describe( 'actions', () => {
 			expect( stub ).to.have.been.calledWith( {
 				type: THEME_ACTIVATE_REQUEST,
 				siteId: 2211667,
-				themeId: 'karuna-wpcom'
+				themeId: 'karuna'
 			} );
 		} );
 
 		it( 'should dispatch THEME_ACTIVATE_REQUEST, installTheme(), and activateTheme()', ( done ) => {
-			installAndActivate( 'karuna', 2211667 )( stub ).then( () => {
+			installAndActivate( 'karuna-wpcom', 2211667 )( stub ).then( () => {
 				expect( stub ).to.have.been.calledWith( {
 					type: THEME_ACTIVATE_REQUEST,
 					themeId: 'karuna-wpcom',
@@ -564,7 +564,7 @@ describe( 'actions', () => {
 
 		it( 'should dispatch wpcom theme install request failure action when theme install fails', () => {
 			// Fail on attempted install
-			stub.withArgs( matchFunction( installTheme( 'pinboard-wpcom', 2211667 ) ) )
+			stub.withArgs( matchFunction( installTheme( 'pinboard', 2211667 ) ) )
 				.returns( new Promise( ( res, rej ) => {
 					rej();
 				} ) );
@@ -573,7 +573,7 @@ describe( 'actions', () => {
 				expect( stub ).to.have.been.calledWith( {
 					type: THEME_ACTIVATE_REQUEST_FAILURE,
 					siteId: 2211667,
-					themeId: 'pinboard-wpcom'
+					themeId: 'pinboard'
 				} );
 			} );
 		} );

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -519,88 +519,61 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#activateWpcomThemeOnJetpack', () => {
-		const successResponse = {
-			id: 'karuna-wpcom',
-			screenshot: '//i0.wp.com/budzanowski.wpsandbox.me/wp-content/themes/karuna-wpcom/screenshot.png',
-			active: false,
-			name: 'Karuna',
-			theme_uri: 'https://wordpress.com/themes/karuna/',
-			description: 'Karuna is a clean business theme designed with health and wellness-focused sites in mind.' +
-				' With bright, bold colors, prominent featured images, and support for customer testimonials',
-			author: 'Automattic',
-			author_uri: 'http://wordpress.com/themes/',
-			version: '1.1.0',
-			autoupdate: false,
-			log: [
-				[
-					'Unpacking the package&#8230;',
-					'Installing the theme&#8230;',
-					'Theme installed successfully.'
-				]
-			]
-		};
+		function isEqualFunction( f1, f2 ) {
+			// TODO: Also compare params!
+			return f1.toString() === f2.toString();
+		}
 
-		const downloadFailureResponse = {
-			status: 400,
-			code: 'problem_fetching_theme',
-			message: 'Problem downloading theme'
-		};
+		function matchFunction( fn ) {
+			return sinon.match( ( value ) => (
+				isEqualFunction( value, fn )
+			) );
+		}
 
-		const alreadyInstalledFailureResponse = {
-			status: 400,
-			code: 'theme_already_installed',
-			message: 'The theme is already installed'
-		};
+		const stub = sinon.stub();
+		stub.returns( new Promise( ( res ) => {
+			res();
+		} ) );
 
-		useNock( ( nock ) => {
-			nock( 'https://public-api.wordpress.com:443' )
-				.persist()
-				.post( '/rest/v1.1/sites/2211667/themes/karuna-wpcom/install' )
-				.reply( 200, successResponse )
-				.post( '/rest/v1.1/sites/2211667/themes/typist-wpcom/install' )
-				.reply( 400, downloadFailureResponse )
-				.post( '/rest/v1.1/sites/2211667/themes/pinboard-wpcom/install' )
-				.reply( 400, alreadyInstalledFailureResponse );
+		beforeEach( () => {
+			stub.reset();
 		} );
 
 		it( 'should dispatch activate theme request action when triggered', () => {
-			activateWpcomThemeOnJetpack( 'karuna', 2211667 )( spy );
+			activateWpcomThemeOnJetpack( 'karuna', 2211667 )( stub );
 
-			expect( spy ).to.have.been.calledWith( {
+			expect( stub ).to.have.been.calledWith( {
 				type: THEME_ACTIVATE_REQUEST,
 				siteId: 2211667,
 				themeId: 'karuna-wpcom'
 			} );
 		} );
 
-		it( 'should dispatch wpcom theme activate request success action when request completes', () => {
-			return activateWpcomThemeOnJetpack( 'karuna', 2211667 )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
+		it( 'should dispatch THEME_ACTIVATE_REQUEST, installTheme(), and activateTheme()', ( done ) => {
+			activateWpcomThemeOnJetpack( 'karuna', 2211667 )( stub ).then( () => {
+				expect( stub ).to.have.been.calledWith( {
 					type: THEME_ACTIVATE_REQUEST,
-					siteId: 2211667,
 					themeId: 'karuna-wpcom',
+					siteId: 2211667,
 				} );
+				expect( stub ).to.have.been.calledWith( matchFunction( installTheme( 'karuna-wpcom', 2211667 ) ) );
+				expect( stub ).to.have.been.calledWith( matchFunction( activateTheme( 'karuna-wpcom', 2211667 ) ) );
+				done();
 			} );
 		} );
 
-		it( 'should dispatch wpcom theme install request failure action when theme was not found', () => {
-			return activateWpcomThemeOnJetpack( 'typist', 2211667 )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
-					type: THEME_ACTIVATE_REQUEST_FAILURE,
-					siteId: 2211667,
-					themeId: 'typist-wpcom',
-					error: sinon.match( { message: 'Problem downloading theme' } ),
-				} );
-			} );
-		} );
+		it( 'should dispatch wpcom theme install request failure action when theme install fails', () => {
+			// Fail on attempted install
+			stub.withArgs( matchFunction( installTheme( 'pinboard-wpcom', 2211667 ) ) )
+				.returns( new Promise( ( res, rej ) => {
+					rej();
+				} ) );
 
-		it( 'should dispatch wpcom theme install request failure action when theme is already installed', () => {
-			return activateWpcomThemeOnJetpack( 'pinboard', 2211667 )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
+			return activateWpcomThemeOnJetpack( 'pinboard', 2211667 )( stub ).then( () => {
+				expect( stub ).to.have.been.calledWith( {
 					type: THEME_ACTIVATE_REQUEST_FAILURE,
 					siteId: 2211667,
-					themeId: 'pinboard-wpcom',
-					error: sinon.match( { message: 'The theme is already installed' } ),
+					themeId: 'pinboard-wpcom'
 				} );
 			} );
 		} );


### PR DESCRIPTION
Compose `activateWpcomThemeOnJetpack` from `installTheme` and `activateTheme`, and change unit tests accordingly to verify that composition.

This has the side effect that a failed installation (e.g because a theme is already installed) is caught inside `installTheme`, and `activateTheme` proceeds regardless, meaning that clicking on `Activate` in the wpcom themes list in `single-site-jetpack` will now work even if the theme had been already installed.

Furthermore:
* Rename `activateWpcomThemeOnJetpack` to `installAndActivateTheme`. Rationale:
  * We might allow installation of WP.org themes too at some point (and we can use the same functions without change), so we drop the 'Wpcom' part
  * We don't just activate but also install, so add 'install'
  * Installation doesn't make sense on WP.com but only on a Jetpack site, so we drop the 'OnJetpack' part
  * The new name is more consistent with our other (short) action names such as 'activateTheme' or 'requestTheme'.
* Don't auto-append the `-wpcom` suffix anymore.
  * The action also makes sense for themes without that suffix -- they'd be installed from WordPress.org instead. Hence, leave it to the consumer to append or omit the suffix.
* As per [discussion](https://github.com/Automattic/wp-calypso/pull/10161#discussion_r93454893) resulting from the review, I've removed the (unreachable) `.catch()` (that `dispatch()`ed `THEME_ACTIVATE_REQUEST_FAILURE`), and consequently, the `THEME_ACTIVATE_REQUEST` `dispatch`, too. This will result in a slight regression until we add UI state to reflect ongoing installation (as discussed during our team chat today).