### PR TITLE
Reader: Fix timestamp wrapping in FF

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -256,11 +256,11 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 .reader-post-card__tag {
+	flex: 1 0 0;
 	margin-left: 10px;
 	overflow: hidden;
 	position: relative;
 	height: 20px;
-	width: 100%;
 
 	&::after {
 		@include long-content-fade( $size: 10% );


### PR DESCRIPTION
This only happens if timestamp is followed by a tag.

**Before:**
![screenshot 2016-12-19 11 57 30](https://cloud.githubusercontent.com/assets/4924246/21327212/de1a3c76-c5e2-11e6-8a1c-0f64f69a0004.png)

**After:**
![screenshot 2016-12-19 11 57 50](https://cloud.githubusercontent.com/assets/4924246/21327256/0f98337a-c5e3-11e6-9b21-cc6f8fcd1cf6.png)

