### PR TITLE
Site Settings: Update the discussion tab to use separate cards

### DIFF
--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -1,32 +1,32 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:my-sites:site-settings' );
+import React from 'react';
+import debugFactory from 'debug';
+const debug = debugFactory( 'calypso:my-sites:site-settings' );
 
 /**
  * Internal dependencies
  */
-var formBase = require( './form-base' ),
-	dirtyLinkedState = require( 'lib/mixins/dirty-linked-state' ),
-	FormFieldset = require( 'components/forms/form-fieldset' ),
-	FormLabel = require( 'components/forms/form-label' ),
-	FormLegend = require( 'components/forms/form-legend' ),
-	FormTextarea = require( 'components/forms/form-textarea' ),
-	FormTextInput = require( 'components/forms/form-text-input' ),
-	FormCheckbox = require( 'components/forms/form-checkbox' ),
-	FormSelect = require( 'components/forms/form-select' ),
-	FormSettingExplanation = require( 'components/forms/form-setting-explanation' ),
-	Card = require( 'components/card' ),
-	Button = require( 'components/button' ),
-	SectionHeader = require( 'components/section-header' );
+import formBase from './form-base';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormLegend from 'components/forms/form-legend';
+import FormTextarea from 'components/forms/form-textarea';
+import FormTextInput from 'components/forms/form-text-input';
+import FormToggle from 'components/forms/form-toggle';
+import FormSelect from 'components/forms/form-select';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import Card from 'components/card';
+import Button from 'components/button';
+import SectionHeader from 'components/section-header';
 import { protectForm } from 'lib/protect-form';
 
 module.exports = protectForm( React.createClass( {
 
 	displayName: 'SiteSettingsFormDiscussion',
 
-	mixins: [ dirtyLinkedState, formBase ],
+	mixins: [ formBase ],
 
 	discussionAttributes: [
 		'default_pingback_flag',
@@ -58,7 +58,7 @@ module.exports = protectForm( React.createClass( {
 	],
 
 	getSettingsFromSite: function( siteInstance ) {
-		var site = siteInstance || this.props.site,
+		const site = siteInstance || this.props.site,
 			settings = {};
 
 		if ( site.settings ) {
@@ -73,7 +73,7 @@ module.exports = protectForm( React.createClass( {
 	},
 
 	resetState: function() {
-		var clearSettings = { fetchingSettings: true };
+		const clearSettings = { fetchingSettings: true };
 		this.discussionAttributes.forEach( function( attribute ) {
 			clearSettings[ attribute ] = '';
 		} );
@@ -81,201 +81,262 @@ module.exports = protectForm( React.createClass( {
 		debug( 'resetting state' );
 	},
 
-	defaultArticleSettings: function() {
+	setDirtyField( key ) {
+		const newState = {};
+		const dirtyFields = this.state.dirtyFields || [];
+		if ( dirtyFields.indexOf( key ) === -1 ) {
+			newState.dirtyFields = [ ...dirtyFields, key ];
+		}
+		this.setState( newState );
+	},
+
+	handleText( event ) {
+		const currentTargetName = event.currentTarget.name,
+			currentTargetValue = event.currentTarget.value;
+
+		this.setDirtyField( currentTargetName );
+		this.setState( { [ currentTargetName ]: currentTargetValue } );
+	},
+
+	handleToggle( name ) {
+		return () => {
+			this.recordEvent.bind( this, `Toggled ${ name }` );
+			this.setDirtyField( name );
+			this.setState( { [ name ]: ! this.state[ name ] } );
+		};
+	},
+
+	handleCommentOrder() {
+		this.recordEvent.bind( this, 'Toggled Comment Order on Page' );
+		this.setDirtyField( 'comment_order' );
+		this.setState( { comment_order: this.state.comment_order === 'desc' ? 'asc' : 'desc' } );
+	},
+
+	defaultArticleSettings() {
 		return (
 			<FormFieldset>
-				<FormLegend>{ this.translate( 'Default article settings' ) }</FormLegend>
-				<FormLabel>
-					<FormCheckbox
-						name="default_pingback_flag"
-						checkedLink={ this.linkState( 'default_pingback_flag' ) }
-						disabled={ this.state.fetchingSettings }
-						onClick={ this.recordEvent.bind( this, 'Clicked Attempt to Notify Checkbox' ) } />
+				<FormToggle
+					className="is-compact"
+					checked={ !! this.state.default_pingback_flag }
+					disabled={ this.state.fetchingSettings }
+					onChange={ this.handleToggle( 'default_pingback_flag' ) }>
 					<span>{ this.translate( 'Attempt to notify any blogs linked to from the article' ) }</span>
-				</FormLabel>
-				<FormLabel>
-					<FormCheckbox
-						name="default_ping_status"
-						checkedLink={ this.linkState( 'default_ping_status' ) }
-						disabled={ this.state.fetchingSettings }
-						onClick={ this.recordEvent.bind( this, 'Clicked Allow Link Notifications Checkbox' ) } />
+				</FormToggle>
+				<FormToggle
+					className="is-compact"
+					checked={ !! this.state.default_ping_status }
+					disabled={ this.state.fetchingSettings }
+					onChange={ this.handleToggle( 'default_ping_status' ) }>
 					<span>{ this.translate( 'Allow link notifications from other blogs (pingbacks and trackbacks)' ) }</span>
-				</FormLabel>
-				<FormLabel>
-					<FormCheckbox
-						name="default_comment_status"
-						checkedLink={ this.linkState( 'default_comment_status' ) }
-						disabled={ this.state.fetchingSettings }
-						onClick={ this.recordEvent.bind( this, 'Clicked Allow People to Post Comments Checkbox' ) } />
+				</FormToggle>
+				<FormToggle
+					className="is-compact"
+					checked={ !! this.state.default_comment_status }
+					disabled={ this.state.fetchingSettings }
+					onChange={ this.handleToggle( 'default_comment_status' ) }>
 					<span>{ this.translate( 'Allow people to post comments on new articles' ) }</span>
-				</FormLabel>
+				</FormToggle>
 				<FormSettingExplanation>
-						{ this.translate( '(These settings may be overridden for individual articles.)' ) }
+					{ this.translate( '(These settings may be overridden for individual articles.)' ) }
 				</FormSettingExplanation>
 			</FormFieldset>
 		);
 	},
 
-	otherCommentSettings: function() {
+	otherCommentSettings() {
 		const markdownSupported = this.state.markdown_supported;
 		return (
-			<FormFieldset className="has-divider">
-				<FormLabel>{ this.translate( 'Other comment settings' ) }</FormLabel>
-				<FormLabel>
-					<FormCheckbox
-						name="require_name_email"
-						checkedLink={ this.linkState( 'require_name_email' ) }
-						disabled={ this.state.fetchingSettings }
-						onClick={ this.recordEvent.bind( this, 'Clicked Comment Author Must Fill Checkbox' ) } />
+			<FormFieldset>
+				<FormToggle
+					className="is-compact"
+					checked={ !! this.state.require_name_email }
+					disabled={ this.state.fetchingSettings }
+					onChange={ this.handleToggle( 'require_name_email' ) }>
 					<span>{ this.translate( 'Comment author must fill out name and e-mail' ) }</span>
-				</FormLabel>
-				<FormLabel>
-					<FormCheckbox
-						name="comment_registration"
-						checkedLink={ this.linkState( 'comment_registration' ) }
-						disabled={ this.state.fetchingSettings }
-						onClick={ this.recordEvent.bind( this, 'Clicked Users Must Be Registered Checkbox' ) } />
+				</FormToggle>
+				<FormToggle
+					className="is-compact"
+					checked={ !! this.state.comment_registration }
+					disabled={ this.state.fetchingSettings }
+					onChange={ this.handleToggle( 'comment_registration' ) }>
 					<span>{ this.translate( 'Users must be registered and logged in to comment' ) }</span>
-				</FormLabel>
-				<FormLabel>
-					<FormCheckbox
-						name="close_comments_for_old_posts"
-						checkedLink={ this.linkState( 'close_comments_for_old_posts' ) }
-						disabled={ this.state.fetchingSettings }
-						onClick={ this.recordEvent.bind( this, 'Clicked Automatically Close Days Checkbox' ) } />
-					<span>{
-						this.translate(
-							'Automatically close comments on articles older than {{numberOfDays /}} day',
-							'Automatically close comments on articles older than {{numberOfDays /}} days', {
-								count: this.state.close_comments_days_old || 2,
+				</FormToggle>
+				<FormToggle
+					className="is-compact"
+					checked={ !! this.state.close_comments_for_old_posts }
+					disabled={ this.state.fetchingSettings }
+					onChange={ this.handleToggle( 'close_comments_for_old_posts' ) }>
+					<span>
+						{
+							this.translate(
+								'Automatically close comments on articles older than {{numberOfDays /}} day',
+								'Automatically close comments on articles older than {{numberOfDays /}} days', {
+									count: this.state.close_comments_days_old || 2,
+									components: {
+										numberOfDays: this.renderInputNumberDays()
+									}
+								}
+							)
+						}
+					</span>
+				</FormToggle>
+				<FormToggle
+					className="is-compact"
+					checked={ !! this.state.thread_comments }
+					disabled={ this.state.fetchingSettings }
+					onChange={ this.handleToggle( 'thread_comments' ) }>
+					<span>
+						{
+							this.translate( 'Enable threaded (nested) comments up to {{number /}} levels deep', {
 								components: {
-									numberOfDays: <FormTextInput
-										name="close_comments_days_old"
-										type="number"
-										min="0"
-										step="1"
-										id="close_comments_days_old"
-										className="small-text"
-										valueLink={ this.linkState( 'close_comments_days_old' ) }
-										disabled={ this.state.fetchingSettings }
-										onClick={ this.recordEvent.bind( this, 'Clicked Automatically Close Days Field' ) }
-										onKeyPress={ this.recordEventOnce.bind( this, 'typedAutoCloseDays', 'Typed in Automatically Close Days Field' ) } />
+									number: this.renderInputThreadDepth()
 								}
 							} )
-						}</span>
-				</FormLabel>
-				<FormLabel>
-					<FormCheckbox
-						name="thread_comments"
-						checkedLink={ this.linkState( 'thread_comments' ) }
-						disabled={ this.state.fetchingSettings }
-						onClick={ this.recordEvent.bind( this, 'Clicked Enable Threaded Checkbox' ) } />
-					<span>{
-						this.translate( 'Enable threaded (nested) comments up to {{number /}} levels deep', {
-							components: {
-								number: <FormSelect
-									className="is-compact"
-									name="thread_comments_depth"
-									valueLink={ this.linkState( 'thread_comments_depth' ) }
-									disabled={ this.state.fetchingSettings }
-									onClick={ this.recordClickEventAndStop.bind( this, 'Selected Comment Nesting Level' ) }>
-										{ [ 2, 3, 4, 5, 6, 7, 8, 9, 10 ].map( level =>
-											<option value={ level } key={ 'comment-depth-' + level }>{ level }</option>
-										) }
-								</FormSelect>
-							}
-						} )
-						}</span>
-				</FormLabel>
-				<FormLabel>
-					<FormCheckbox
-						name="page_comments"
-						id="page_comments"
-						checkedLink={ this.linkState( 'page_comments' ) }
-						disabled={ this.state.fetchingSettings }
-						onClick={ this.recordEvent.bind( this, 'Clicked Break Comments Into Pages Checkbox' ) } />
-					<span>{
-						this.translate( 'Break comments into pages with {{numComments /}} top level comments per page and the {{firstOrLast /}} page displayed by default', {
-							components: {
-								numComments: <FormTextInput
-									name="comments_per_page"
-									type="number"
-									step="1"
-									min="0"
-									id="comments_per_page"
-									valueLink={ this.linkState( 'comments_per_page' ) }
-									className="small-text"
-									disabled={ this.state.fetchingSettings }
-									onClick={ this.recordEvent.bind( this, 'Clicked Comments Per Page Field' ) }
-									onKeyPress={ this.recordEventOnce.bind( this, 'typedCommentsPerPage', 'Typed in Comments Per Page Field' ) } />,
-								firstOrLast: <FormSelect
-									className="is-compact"
-									name="default_comments_page"
-									valueLink={ this.linkState( 'default_comments_page' ) }
-									disabled={ this.state.fetchingSettings }
-									onClick={ this.recordClickEventAndStop.bind( this, 'Selected Comment Page Display Default' ) }>
-										<option value="newest">{ this.translate( 'last' ) }</option>
-										<option value="oldest">{ this.translate( 'first' ) }</option>
-								</FormSelect>
-							}
-						} )
-						}</span>
-				</FormLabel>
-				{ markdownSupported &&
-					<FormLabel>
-						<FormCheckbox
-							name="wpcom_publish_comments_with_markdown"
-							checkedLink={ this.linkState( 'wpcom_publish_comments_with_markdown' ) }
-							disabled={ this.state.fetchingSettings }
-							onClick={ this.recordEvent.bind( this, 'Clicked Markdown for Comments Checkbox' ) } />
-						<span>{ this.translate( 'Enable Markdown for comments. {{a}}Learn more about markdown{{/a}}.', {
-								components: {
-									a: <a href="http://en.support.wordpress.com/markdown-quick-reference/" target="_blank" rel="noopener noreferrer" />
+						}
+					</span>
+				</FormToggle>
+				<FormToggle
+					className="is-compact"
+					checked={ !! this.state.page_comments }
+					disabled={ this.state.fetchingSettings }
+					onChange={ this.handleToggle( 'page_comments' ) }>
+					<span>
+						{
+							this.translate(
+								'Break comments into pages with {{numComments /}} top level comments per page and the ' +
+								'{{firstOrLast /}} page displayed by default',
+								{
+									components: {
+										numComments: this.renderInputNumComments(),
+										firstOrLast: this.renderInputDisplayDefault()
+									}
 								}
-							} ) }</span>
-					</FormLabel>
-				}
-				<FormLabel>
-					<span>{
-						this.translate( 'Comments should be displayed with the {{olderOrNewer /}} comments at the top of each page', {
-							components: {
-								olderOrNewer: <FormSelect
-									className="is-compact"
-									name="comment_order"
-									valueLink={ this.linkState( 'comment_order' ) }
-									disabled={ this.state.fetchingSettings }
-									onClick={ this.recordEvent.bind( this, 'Selected Comment Order on Page' ) }>
-										<option value="asc">{ this.translate( 'older', { textOnly: true } ) }</option>
-										<option value="desc">{ this.translate( 'newer', { textOnly: true } ) }</option>
-								</FormSelect>
+							)
+						}
+					</span>
+				</FormToggle>
+				{ markdownSupported &&
+					<FormToggle
+						className="is-compact"
+						checked={ !! this.state.wpcom_publish_comments_with_markdown }
+						disabled={ this.state.fetchingSettings }
+						onChange={ this.handleToggle( 'wpcom_publish_comments_with_markdown' ) }>
+						<span>
+							{
+								this.translate( 'Enable Markdown for comments. {{a}}Learn more about markdown{{/a}}.', {
+									components: {
+										a: <a
+											href="http://en.support.wordpress.com/markdown-quick-reference/"
+											target="_blank"
+											rel="noopener noreferrer" />
+									}
+								} )
 							}
-						} )
-						}</span>
-				</FormLabel>
+						</span>
+					</FormToggle>
+				}
+				<FormToggle
+					className="is-compact"
+					checked={ 'asc' === this.state.comment_order }
+					disabled={ this.state.fetchingSettings }
+					onChange={ this.handleCommentOrder }>
+					<span>{ this.translate( 'Comments should be displayed with the older comments at the top of each page' ) }</span>
+				</FormToggle>
 			</FormFieldset>
 		);
 	},
 
-	emailMeSettings: function() {
+	renderInputNumberDays() {
+		return (
+			<FormTextInput
+				name="close_comments_days_old"
+				type="number"
+				min="0"
+				step="1"
+				id="close_comments_days_old"
+				className="small-text"
+				value={ this.state.close_comments_days_old }
+				onChange={ this.handleText }
+				disabled={ this.state.fetchingSettings }
+				onClick={ this.recordEvent.bind( this, 'Clicked Automatically Close Days Field' ) }
+				onKeyPress={ this.recordEventOnce.bind(
+					this,
+					'typedAutoCloseDays',
+					'Typed in Automatically Close Days Field'
+				) } />
+		);
+	},
+
+	renderInputThreadDepth() {
+		return (
+			<FormSelect
+				className="is-compact"
+				name="thread_comments_depth"
+				value={ this.state.thread_comments_depth }
+				onChange={ this.handleText }
+				disabled={ this.state.fetchingSettings }
+				onClick={ this.recordClickEventAndStop.bind( this, 'Selected Comment Nesting Level' ) }>
+					{ [ 2, 3, 4, 5, 6, 7, 8, 9, 10 ].map( level =>
+						<option value={ level } key={ 'comment-depth-' + level }>{ level }</option>
+					) }
+			</FormSelect>
+		);
+	},
+
+	renderInputNumComments() {
+		return (
+			<FormTextInput
+				name="comments_per_page"
+				type="number"
+				step="1"
+				min="0"
+				id="comments_per_page"
+				value={ this.state.comments_per_page }
+				onChange={ this.handleText }
+				className="small-text"
+				disabled={ this.state.fetchingSettings }
+				onClick={ this.recordEvent.bind( this, 'Clicked Comments Per Page Field' ) }
+				onKeyPress={ this.recordEventOnce.bind(
+					this,
+					'typedCommentsPerPage',
+					'Typed in Comments Per Page Field'
+				) } />
+		);
+	},
+
+	renderInputDisplayDefault() {
+		return (
+			<FormSelect
+				className="is-compact"
+				name="default_comments_page"
+				value={ this.state.default_comments_page }
+				onChange={ this.handleText }
+				disabled={ this.state.fetchingSettings }
+				onClick={ this.recordClickEventAndStop.bind( this, 'Selected Comment Page Display Default' ) }>
+					<option value="newest">{ this.translate( 'last' ) }</option>
+					<option value="oldest">{ this.translate( 'first' ) }</option>
+			</FormSelect>
+		);
+	},
+
+	emailMeSettings() {
 		return (
 			<FormFieldset>
 				<FormLegend>{ this.translate( 'E-mail me whenever' ) }</FormLegend>
-				<FormLabel className="short-settings">
-					<FormCheckbox
-						name="comments_notify"
-						checkedLink={ this.linkState( 'comments_notify' ) }
-						disabled={ this.state.fetchingSettings }
-						onClick={ this.recordEvent.bind( this, 'Clicked Anyone Posts a Comment Checkbox' ) } />
+				<FormToggle
+					className="is-compact"
+					checked={ !! this.state.comments_notify }
+					disabled={ this.state.fetchingSettings }
+					onChange={ this.handleToggle( 'comments_notify' ) }>
 					<span>{ this.translate( 'Anyone posts a comment' ) }</span>
-				</FormLabel>
-				<FormLabel className="short-settings">
-					<FormCheckbox
-						name="moderation_notify"
-						checkedLink={ this.linkState( 'moderation_notify' ) }
-						disabled={ this.state.fetchingSettings }
-						onClick={ this.recordEvent.bind( this, 'Clicked a Comment is Held Checkbox' ) } />
+				</FormToggle>
+				<FormToggle
+					className="is-compact"
+					checked={ !! this.state.moderation_notify }
+					disabled={ this.state.fetchingSettings }
+					onChange={ this.handleToggle( 'moderation_notify' ) }>
 					<span>{ this.translate( 'A comment is held for moderation' ) }</span>
-				</FormLabel>
+				</FormToggle>
 				{ this.emailMeLikes() }
 				{ this.emailMeReblogs() }
 				{ this.emailMeFollows() }
@@ -283,167 +344,195 @@ module.exports = protectForm( React.createClass( {
 		);
 	},
 
-	emailMeLikes: function() {
+	emailMeLikes() {
 		// likes are only supported on jetpack sites with the Likes module activated
 		if ( this.props.site.jetpack && ! this.props.site.isModuleActive( 'likes' ) ) {
 			return null;
 		}
 
 		return (
-			<FormLabel className="short-settings">
-				<FormCheckbox
-					name="social_notifications_like"
-					checkedLink={ this.linkState( 'social_notifications_like' ) }
-					disabled={ this.state.fetchingSettings }
-					onClick={ this.recordEvent.bind( this, 'Clicked Someone Likes Checkbox' ) } />
+			<FormToggle
+				className="is-compact"
+				checked={ !! this.state.social_notifications_like }
+				disabled={ this.state.fetchingSettings }
+				onChange={ this.handleToggle( 'social_notifications_like' ) }>
 				<span>{ this.translate( 'Someone likes one of my posts' ) }</span>
-			</FormLabel>
+			</FormToggle>
 		);
 	},
 
-	emailMeReblogs: function() {
+	emailMeReblogs() {
 		// reblogs are not supported on Jetpack sites
 		if ( this.props.site.jetpack ) {
 			return null;
 		}
 
 		return (
-			<FormLabel className="short-settings">
-				<FormCheckbox
-					name="social_notifications_reblog"
-					checkedLink={ this.linkState( 'social_notifications_reblog' ) }
-					disabled={ this.state.fetchingSettings }
-					onClick={ this.recordEvent.bind( this, 'Clicked Someone Reblogs Checkbox' ) } />
+			<FormToggle
+				className="is-compact"
+				checked={ !! this.state.social_notifications_reblog }
+				disabled={ this.state.fetchingSettings }
+				onChange={ this.handleToggle( 'social_notifications_reblog' ) }>
 				<span>{ this.translate( 'Someone reblogs one of my posts' ) }</span>
-			</FormLabel>
+			</FormToggle>
 		);
 	},
 
-	emailMeFollows: function() {
+	emailMeFollows() {
 		// follows are not supported on Jetpack sites
 		if ( this.props.site.jetpack ) {
 			return null;
 		}
 
 		return (
-			<FormLabel className="short-settings">
-				<FormCheckbox
-					name="social_notifications_subscribe"
-					checkedLink={ this.linkState( 'social_notifications_subscribe' ) }
-					disabled={ this.state.fetchingSettings }
-					onClick={ this.recordEvent.bind( this, 'Clicked Someone Follows Checkbox' ) } />
+			<FormToggle
+				className="is-compact"
+				checked={ !! this.state.social_notifications_subscribe }
+				disabled={ this.state.fetchingSettings }
+				onChange={ this.handleToggle( 'social_notifications_subscribe' ) }>
 				<span>{ this.translate( 'Someone follows my blog' ) }</span>
-			</FormLabel>
+			</FormToggle>
 		);
 	},
 
-	beforeCommentSettings: function() {
+	beforeCommentSettings() {
 		return (
 			<FormFieldset>
 				<FormLegend>{ this.translate( 'Before a comment appears' ) }</FormLegend>
-				<FormLabel className="short-settings">
-					<FormCheckbox
-						name="comment_moderation"
-						checkedLink={ this.linkState( 'comment_moderation' ) }
-						disabled={ this.state.fetchingSettings }
-						onClick={ this.recordEvent.bind( this, 'Clicked Comment Manually Approved Checkbox' ) } />
+				<FormToggle
+					className="is-compact"
+					checked={ !! this.state.comment_moderation }
+					disabled={ this.state.fetchingSettings }
+					onChange={ this.handleToggle( 'comment_moderation' ) }>
 					<span>{ this.translate( 'Comment must be manually approved' ) }</span>
-				</FormLabel>
-				<FormLabel className="short-settings">
-					<FormCheckbox
-						name="comment_whitelist"
-						checkedLink={ this.linkState( 'comment_whitelist' ) }
-						disabled={ this.state.fetchingSettings }
-						onClick={ this.recordEvent.bind( this, 'Clicked Comment Previously Approved Checkbox' ) } />
+				</FormToggle>
+				<FormToggle
+					className="is-compact"
+					checked={ !! this.state.comment_whitelist }
+					disabled={ this.state.fetchingSettings }
+					onChange={ this.handleToggle( 'comment_whitelist' ) }>
 					<span>{ this.translate( 'Comment author must have a previously approved comment' ) }</span>
-				</FormLabel>
+				</FormToggle>
 			</FormFieldset>
 		);
 	},
 
-	commentModerationSettings: function() {
+	commentModerationSettings() {
 		return (
-			<FormFieldset className="has-divider">
-				<FormLabel htmlFor="moderation_keys">{ this.translate( 'Comment Moderation' ) }</FormLabel>
+			<FormFieldset>
+				<FormLegend>{ this.translate( 'Comment Moderation' ) }</FormLegend>
 				<p>{
-					this.translate( 'Hold a comment in the queue if it contains {{numberOfLinks /}} or more links. (A common characteristic of comment spam is a large number of hyperlinks.)', {
-						components: {
-							numberOfLinks: <FormTextInput
-								name="comment_max_links"
-								type="number"
-								step="1"
-								min="0"
-								className="small-text"
-								valueLink={ this.linkState( 'comment_max_links' ) }
-								disabled={ this.state.fetchingSettings }
-								onClick={ this.recordEvent.bind( this, 'Clicked Comment Queue Link Count Field' ) }
-								onKeyPress={ this.recordEventOnce.bind( this, 'typedCommentQueue', 'Typed In Comment Queue Link Count Field' ) } />
-						}
-					} )
-				}</p>
-				<p>{
-					this.translate( 'When a comment contains any of these words in its content, name, URL, e-mail, or IP, it will be held in the {{link}}moderation queue{{/link}}. One word or IP per line. It will match inside words, so "press" will match "WordPress".',
+					this.translate(
+						'Hold a comment in the queue if it contains {{numberOfLinks /}} or more links. ' +
+						'(A common characteristic of comment spam is a large number of hyperlinks.)',
 						{
 							components: {
-								link: <a href={ this.state.admin_url + 'edit-comments.php?comment_status=moderated' } target="_blank" rel="noopener noreferrer" />
+								numberOfLinks: this.renderInputNumLinks()
 							}
 						}
 					)
-					}</p>
-				<p>
-					<FormTextarea
-						name="moderation_keys"
-						id="moderation_keys"
-						valueLink={ this.linkState( 'moderation_keys' ) }
-						disabled={ this.state.fetchingSettings }
-						autoCapitalize="none"
-						onClick={ this.recordEvent.bind( this, 'Clicked Moderation Queue Field' ) }
-						onKeyPress={ this.recordEventOnce.bind( this, 'typedModerationKeys', 'Typed In Moderation Queue Field' ) }>
-					</FormTextarea>
-				</p>
+				}</p>
+				<FormLabel htmlFor="moderation_keys">{
+					this.translate(
+						'When a comment contains any of these words in its content, name, URL, e-mail, or IP, it will be ' +
+						'held in the {{link}}moderation queue{{/link}}. One word or IP per line. It will match inside words, so "press" ' +
+						'will match "WordPress".',
+						{
+							components: {
+								link: <a
+									href={ this.state.admin_url + 'edit-comments.php?comment_status=moderated' }
+									target="_blank"
+									rel="noopener noreferrer" />
+							}
+						}
+					)
+				}</FormLabel>
+				<FormTextarea
+					name="moderation_keys"
+					id="moderation_keys"
+					value={ this.state.moderation_keys }
+					onChange={ this.handleText }
+					disabled={ this.state.fetchingSettings }
+					autoCapitalize="none"
+					onClick={ this.recordEvent.bind( this, 'Clicked Moderation Queue Field' ) }
+					onKeyPress={ this.recordEventOnce.bind( this, 'typedModerationKeys', 'Typed In Moderation Queue Field' ) }>
+				</FormTextarea>
 			</FormFieldset>
 		);
 	},
 
-	commentBlacklistSettings: function() {
+	commentBlacklistSettings() {
 		return (
 			<FormFieldset>
-				<FormLabel htmlFor="blacklist_keys">{ this.translate( 'Comment Blacklist' ) }</FormLabel>
-				<p>{ this.translate( 'When a comment contains any of these words in its content, name, URL, e-mail, or IP, it will be marked as spam. One word or IP per line. It will match inside words, so "press" will match "WordPress".' ) }</p>
-				<p>
-					<FormTextarea
-						name="blacklist_keys"
-						id="blacklist_keys"
-						valueLink={ this.linkState( 'blacklist_keys' ) }
-						disabled={ this.state.fetchingSettings }
-						autoCapitalize="none"
-						onClick={ this.recordEvent.bind( this, 'Clicked Blacklist Field' ) }
-						onKeyPress={ this.recordEventOnce.bind( this, 'typedBlacklistKeys', 'Typed In Blacklist Field' ) }>
-					</FormTextarea>
-				</p>
+				<FormLegend>{ this.translate( 'Comment Blacklist' ) }</FormLegend>
+				<FormLabel htmlFor="blacklist_keys">{ this.translate(
+					'When a comment contains any of these words in its content, name, URL, e-mail, or IP, it will be marked as spam. ' +
+					'One word or IP per line. It will match inside words, so "press" will match "WordPress".'
+				) }</FormLabel>
+				<FormTextarea
+					name="blacklist_keys"
+					id="blacklist_keys"
+					value={ this.state.blacklist_keys }
+					onChange={ this.handleText }
+					disabled={ this.state.fetchingSettings }
+					autoCapitalize="none"
+					onClick={ this.recordEvent.bind( this, 'Clicked Blacklist Field' ) }
+					onKeyPress={ this.recordEventOnce.bind( this, 'typedBlacklistKeys', 'Typed In Blacklist Field' ) }>
+				</FormTextarea>
 			</FormFieldset>
 		);
 	},
 
-	render: function() {
+	renderInputNumLinks() {
 		return (
+			<FormTextInput
+				name="comment_max_links"
+				type="number"
+				step="1"
+				min="0"
+				className="small-text"
+				value={ this.state.comment_max_links }
+				onChange={ this.handleText }
+				disabled={ this.state.fetchingSettings }
+				onClick={ this.recordEvent.bind( this, 'Clicked Comment Queue Link Count Field' ) }
+				onKeyPress={ this.recordEventOnce.bind( this, 'typedCommentQueue', 'Typed In Comment Queue Link Count Field' ) } />
+		);
+	},
 
-			<form id="site-settings" onSubmit={ this.handleSubmitForm } onChange={ this.props.markChanged }>
-				<SectionHeader label={ this.translate( 'Discussion Settings' ) }>
+	renderSectionHeader( title, showButton = true ) {
+		return (
+			<SectionHeader label={ title }>
+				{ showButton &&
 					<Button
-						primary
 						compact
-						disabled={ this.state.fetchingSettings || this.state.submittingForm }
-						onClick={ this.handleSubmitForm }>
+						primary
+						onClick={ this.handleSubmitForm }
+						disabled={ this.state.fetchingSettings || this.state.submittingForm }>
 						{ this.state.submittingForm ? this.translate( 'Saving…' ) : this.translate( 'Save Settings' ) }
 					</Button>
-				</SectionHeader>
-				<Card className="discussion-settings">
+				}
+			</SectionHeader>
+		);
+	},
+
+	render() {
+		return (
+			<form id="site-settings" onSubmit={ this.handleSubmitForm } onChange={ this.props.markChanged }>
+				{ this.renderSectionHeader( this.translate( 'Default Article Settings' ) ) }
+				<Card className="site-settings__discussion-settings">
 					{ this.defaultArticleSettings() }
+				</Card>
+
+				{ this.renderSectionHeader( this.translate( 'Comments' ) ) }
+				<Card className="site-settings__discussion-settings">
 					{ this.otherCommentSettings() }
+					<hr />
 					{ this.emailMeSettings() }
+					<hr />
 					{ this.beforeCommentSettings() }
+					<hr />
 					{ this.commentModerationSettings() }
+					<hr />
 					{ this.commentBlacklistSettings() }
 				</Card>
 			</form>

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -255,7 +255,7 @@ module.exports = protectForm( React.createClass( {
 				step="1"
 				id="close_comments_days_old"
 				className="small-text"
-				value={ this.state.close_comments_days_old }
+				value={ 'undefined' === typeof this.state.close_comments_days_old ? 14 : this.state.close_comments_days_old }
 				onChange={ this.handleText }
 				disabled={ this.state.fetchingSettings }
 				onClick={ this.recordEvent.bind( this, 'Clicked Automatically Close Days Field' ) }
@@ -291,7 +291,7 @@ module.exports = protectForm( React.createClass( {
 				step="1"
 				min="0"
 				id="comments_per_page"
-				value={ this.state.comments_per_page }
+				value={ 'undefined' === typeof this.state.comments_per_page ? 50 : this.state.comments_per_page }
 				onChange={ this.handleText }
 				className="small-text"
 				disabled={ this.state.fetchingSettings }
@@ -491,7 +491,7 @@ module.exports = protectForm( React.createClass( {
 				step="1"
 				min="0"
 				className="small-text"
-				value={ this.state.comment_max_links }
+				value={ 'undefined' === typeof this.state.comment_max_links ? 2 : this.state.comment_max_links }
 				onChange={ this.handleText }
 				disabled={ this.state.fetchingSettings }
 				onClick={ this.recordEvent.bind( this, 'Clicked Comment Queue Link Count Field' ) }

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:my-sites:site-settings' );
 
 /**
  * Internal dependencies
@@ -22,10 +21,9 @@ import Button from 'components/button';
 import SectionHeader from 'components/section-header';
 import { protectForm } from 'lib/protect-form';
 
-module.exports = protectForm( React.createClass( {
+const debug = debugFactory( 'calypso:my-sites:site-settings' );
 
-	displayName: 'SiteSettingsFormDiscussion',
-
+const SiteSettingsFormDiscussion = protectForm( React.createClass( {
 	mixins: [ formBase ],
 
 	discussionAttributes: [
@@ -57,14 +55,14 @@ module.exports = protectForm( React.createClass( {
 		'markdown_supported',
 	],
 
-	getSettingsFromSite: function( siteInstance ) {
+	getSettingsFromSite( siteInstance ) {
 		const site = siteInstance || this.props.site,
 			settings = {};
 
 		if ( site.settings ) {
-			this.discussionAttributes.map( function( attribute ) {
+			this.discussionAttributes.map( attribute => {
 				settings[ attribute ] = site.settings[ attribute ];
-			}, this );
+			} );
 		}
 
 		settings.fetchingSettings = site.fetchingSettings;
@@ -72,9 +70,9 @@ module.exports = protectForm( React.createClass( {
 		return settings;
 	},
 
-	resetState: function() {
+	resetState() {
 		const clearSettings = { fetchingSettings: true };
-		this.discussionAttributes.forEach( function( attribute ) {
+		this.discussionAttributes.forEach( attribute => {
 			clearSettings[ attribute ] = '';
 		} );
 		this.replaceState( clearSettings );
@@ -539,3 +537,5 @@ module.exports = protectForm( React.createClass( {
 		);
 	}
 } ) );
+
+export default SiteSettingsFormDiscussion;

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -144,7 +144,7 @@ const SiteSettingsFormDiscussion = protectForm( React.createClass( {
 	otherCommentSettings() {
 		const markdownSupported = this.state.markdown_supported;
 		return (
-			<FormFieldset>
+			<FormFieldset className="site-settings__other-comment-settings">
 				<FormToggle
 					className="is-compact"
 					checked={ !! this.state.require_name_email }
@@ -307,6 +307,7 @@ const SiteSettingsFormDiscussion = protectForm( React.createClass( {
 			<FormSelect
 				className="is-compact"
 				name="default_comments_page"
+				style={ { marginTop: '4px' } }
 				value={ this.state.default_comments_page }
 				onChange={ this.handleText }
 				disabled={ this.state.fetchingSettings }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -182,6 +182,24 @@
 	hr {
 		margin: 0 -24px 1.5em;
 	}
+
+	.site-settings__other-comment-settings {
+		.form-toggle__label {
+			align-items: flex-start;
+		}
+
+		.form-toggle__switch {
+			margin-top: 5px;
+		}
+
+		.form-toggle__switch + span {
+			line-height: 26px;
+		}
+
+		.form-select {
+			margin-top: 2px;
+		}
+	}
 }
 
 .site-settings__site-options {

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -160,6 +160,30 @@
 	}
 }
 
+.site-settings__discussion-settings {
+	label:first-of-type {
+		font-weight: normal;
+	}
+
+	.form-toggle__label {
+		display: flex;
+		align-items: center;
+	}
+
+	.form-toggle__switch {
+		flex: 1 0 auto;
+	}
+
+	.form-toggle__switch + span {
+		flex: 0 1 100%;
+		margin-left: 12px;
+	}
+
+	hr {
+		margin: 0 -24px 1.5em;
+	}
+}
+
 .site-settings__site-options {
 	padding-bottom: 24px;
 


### PR DESCRIPTION
This PR refactors the existing discussion settings into separate cards, & switches the checkboxes to toggles (see #9171). It doesn't add the new settings from that issue (that'll be another PR).

![screen shot 2016-12-19 at 4 39 12 pm](https://cloud.githubusercontent.com/assets/541093/21330080/b9e21c80-c609-11e6-90cd-82ded2850d8a.png)

**To test**

1. Check out this PR
2. Visit your discussion settings at `/settings/discussion/$site` for a Jetpack site
3. Make any changes
4. See that those changes were saved on your Jetpack site in wp-admin, Settings > Discussion

Please also test this on wp.com sites! There are 2 more "Email me whenever" settings for wp.com sites.

1. Check out this PR
2. Visit your discussion settings at `/settings/discussion/$site` for a wp.com site
3. Make any changes
4. See that those changes were saved by reloading the page, or verifying on the production settings page.

Note 1: I've moved the form away from the `dirtyLinkedState` mixin because toggles would not be supported (and linkedState is deprecated as of React v15).

Note 2: The events being tracked are different now - I switched to "Toggled x" instead of "Clicked x", as the event string; and the events for the toggles are not being tracked as english sentences anymore, instead "Toggled page_comments". Happy to change this if needed, but the toggle doesn't actually have a click handler, so it's not as simple as the `FormCheckbox` code. 

cc @oskosk @tyxla @roccotripaldi @johnHackworth for code & @rickybanister @MichaelArestad for design :)