### PR TITLE
Reader: rename RefreshPostCard to ReaderPostCard across the board

### DIFF
--- a/client/blocks/reader-post-card/docs/example.jsx
+++ b/client/blocks/reader-post-card/docs/example.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import RefreshPostCard from 'blocks/reader-post-card';
+import ReaderPostCardBlock from 'blocks/reader-post-card';
 import DisplayTypes from 'state/reader/posts/display-types';
 
 const searchItems = [
@@ -132,11 +132,11 @@ const searchItems = [
 	},
 ];
 
-const RefreshCards = () => (
+const ReaderPostCard = () => (
 	<div className="design-assets__group">
 		<div>
 			{ searchItems.map( item => (
-				<RefreshPostCard
+				<ReaderPostCardBlock
 					key={ item.post.global_ID }
 					post={ item.post }
 					site={ item.site }
@@ -146,4 +146,4 @@ const RefreshCards = () => (
 	</div>
 );
 
-export default RefreshCards;
+export default ReaderPostCard;

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -24,7 +24,7 @@ import DailyPostButton from 'blocks/daily-post-button';
 import { isDailyPostChallengeOrPrompt } from 'blocks/daily-post-button/helper';
 import * as DiscoverHelper from 'reader/discover/helper';
 
-export default class RefreshPostCard extends React.Component {
+export default class ReaderPostCard extends React.Component {
 	static propTypes = {
 		post: PropTypes.object.isRequired,
 		site: PropTypes.object,

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -49,7 +49,7 @@ import DismissibleCard from 'blocks/dismissible-card/docs/example';
 import PostEditButton from 'blocks/post-edit-button/docs/example';
 import ReaderAvatar from 'blocks/reader-avatar/docs/example';
 import ImageEditor from 'blocks/image-editor/docs/example';
-import RefreshPostCard from 'blocks/reader-post-card/docs/example';
+import ReaderPostCard from 'blocks/reader-post-card/docs/example';
 import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu/docs/example';
 import DailyPostButton from 'blocks/daily-post-button/docs/example';
 
@@ -117,7 +117,7 @@ export default React.createClass( {
 					<ReaderSiteStreamLink />
 					<ReaderFullPostHeader />
 					<AuthorCompactProfile />
-					<RefreshPostCard />
+					<ReaderPostCard />
 					<PlanPrice />
 					<PlanThankYouCard />
 					<DismissibleCard />


### PR DESCRIPTION
Now the Reader Refresh has launched and we only have one post card component, I wanted the naming to reflect that.

### To test

Ensure post cards still work in Reader streams.

Check that the devdocs example work in:

http://calypso.localhost:3000/devdocs/blocks/reader-post-card