### PR TITLE
Taxonomy Manager: Add the term to the delete message when deleting a term

### DIFF
--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -121,6 +121,7 @@ class TaxonomyManagerListItem extends Component {
 
 	render() {
 		const { canSetAsDefault, isDefault, onClick, term, translate, isJetpack } = this.props;
+		const name = this.getName();
 		const className = classNames( 'taxonomy-manager__item', {
 			'is-default': isDefault
 		} );
@@ -135,7 +136,7 @@ class TaxonomyManagerListItem extends Component {
 					<Gridicon icon={ isDefault ? 'checkmark-circle' : 'folder' } />
 				</span>
 				<span className="taxonomy-manager__label" onClick={ onClick }>
-					<span>{ this.getName() }</span>
+					<span>{ name }</span>
 					{ isDefault &&
 					<span className="taxonomy-manager__default-label">
 							{ translate( 'default', { context: 'label for terms marked as default' } ) }
@@ -182,7 +183,7 @@ class TaxonomyManagerListItem extends Component {
 					buttons={ deleteDialogButtons }
 					onClose={ this.closeDeleteDialog }
 				>
-					<p>{ translate( 'Are you sure you want to permanently delete this item?' ) }</p>
+					<p>{ translate( 'Are you sure you want to permanently delete \'%(name)s\'?', { args: { name } } ) }</p>
 				</Dialog>
 			</div>
 		);


### PR DESCRIPTION
This adds the term being deleted to the delete message when deleting a term to help users feel confident they are deleting the correct term.

**Before**

![before](https://cloud.githubusercontent.com/assets/128826/21339061/a2c49f82-c6c7-11e6-90ce-9b2210f50539.gif)

**After**

![after](https://cloud.githubusercontent.com/assets/128826/21339067/ab2b60e8-c6c7-11e6-820c-03bab840427d.gif)
