### PR TITLE
Editor: Remove serviceConnection dependency

### DIFF
--- a/client/post-editor/editor-sharing/accordion.jsx
+++ b/client/post-editor/editor-sharing/accordion.jsx
@@ -4,8 +4,7 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-import { map, includes } from 'lodash';
+import { map, filter, uniqBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,7 +12,6 @@ import { map, includes } from 'lodash';
 import Accordion from 'components/accordion';
 import FormTextInput from 'components/forms/form-text-input';
 import Gridicon from 'components/gridicon';
-import serviceConnections from 'my-sites/sharing/connections/service-connections';
 import PostMetadata from 'lib/post-metadata';
 import Sharing from './';
 import AccordionSection from 'components/accordion/section';
@@ -26,7 +24,6 @@ import { getEditedPostValue } from 'state/posts/selectors';
 import { isJetpackModuleActive, getSiteOption } from 'state/sites/selectors';
 import { getSiteUserConnections } from 'state/sharing/publicize/selectors';
 import { postTypeSupports } from 'state/post-types/selectors';
-import { fetchConnections as requestConnections } from 'state/sharing/publicize/actions';
 
 const EditorSharingAccordion = React.createClass( {
 	propTypes: {
@@ -46,12 +43,9 @@ const EditorSharingAccordion = React.createClass( {
 		}
 
 		const skipped = PostMetadata.publicizeSkipped( post );
-		const targeted = connections.filter( ( connection ) => {
-			return ! includes( skipped, connection.keyring_connection_ID );
-		} );
-		const targetedServices = serviceConnections.getServicesFromConnections( targeted );
+		const targeted = filter( connections, ( { keyring_connection_ID: ID } ) => ! ( ID in skipped ) );
 
-		return map( targetedServices, 'label' ).join( ', ' );
+		return map( uniqBy( targeted, 'service' ), 'label' ).join( ', ' );
 	},
 
 	renderShortUrl: function() {
@@ -141,9 +135,4 @@ export default connect(
 			isPublicizeEnabled
 		};
 	},
-	( dispatch ) => {
-		return bindActionCreators( {
-			requestConnections
-		}, dispatch );
-	}
 )( EditorSharingAccordion );

--- a/client/post-editor/editor-sharing/accordion.jsx
+++ b/client/post-editor/editor-sharing/accordion.jsx
@@ -4,7 +4,7 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { map, filter, uniqBy } from 'lodash';
+import { includes, reduce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -43,9 +43,15 @@ const EditorSharingAccordion = React.createClass( {
 		}
 
 		const skipped = PostMetadata.publicizeSkipped( post );
-		const targeted = filter( connections, ( { keyring_connection_ID: ID } ) => ! ( ID in skipped ) );
 
-		return map( uniqBy( targeted, 'service' ), 'label' ).join( ', ' );
+		return reduce( connections, ( memo, connection ) => {
+			const { keyring_connection_ID: id, label } = connection;
+			if ( ! includes( skipped, id ) && ! includes( memo, label ) ) {
+				memo.push( label );
+			}
+
+			return memo;
+		}, [] ).join( ', ' );
 	},
 
 	renderShortUrl: function() {

--- a/client/post-editor/editor-sharing/publicize-options.jsx
+++ b/client/post-editor/editor-sharing/publicize-options.jsx
@@ -122,8 +122,6 @@ const EditorSharingPublicizeOptions = React.createClass( {
 		return (
 			<PublicizeServices
 				post={ this.props.post }
-				siteId={ this.props.site.ID }
-				connections={ this.props.connections }
 				newConnectionPopup={ this.newConnectionPopup } />
 		);
 	},

--- a/client/post-editor/editor-sharing/publicize-services.jsx
+++ b/client/post-editor/editor-sharing/publicize-services.jsx
@@ -1,59 +1,72 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { filter, uniqBy } from 'lodash';
 
 /**
  * Internal dependencies
  */
-var serviceConnections = require( 'my-sites/sharing/connections/service-connections' ),
-	EditorSharingPublicizeConnection = require( './publicize-connection' );
+import EditorSharingPublicizeConnection from './publicize-connection';
+import { getCurrentUserId } from 'state/current-user/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteUserConnections } from 'state/sharing/publicize/selectors';
 
-module.exports = React.createClass( {
-	displayName: 'EditorSharingPublicizeServices',
+class EditorSharingPublicizeServices extends Component {
+	static propTypes = {
+		post: PropTypes.object,
+		connections: PropTypes.array.isRequired,
+		newConnectionPopup: PropTypes.func.isRequired
+	};
 
-	propTypes: {
-		post: React.PropTypes.object,
-		siteId: React.PropTypes.number.isRequired,
-		connections: React.PropTypes.array.isRequired,
-		newConnectionPopup: React.PropTypes.func.isRequired
-	},
+	static defaultProps = {
+		post: Object.freeze( {} ),
+	};
 
-	renderServices: function() {
-		var services = serviceConnections.getServicesFromConnections( this.props.connections );
+	renderServices() {
+		const services = uniqBy( this.props.connections.map( ( { label, service } ) => ( { label, service } ) ), 'service' );
 
-		return services.map( function( service ) {
-			return (
-				<li key={ service.ID } className="editor-sharing__publicize-service">
-					<h5 className="editor-sharing__publicize-service-heading">{ service.label }</h5>
-					{ this.renderConnections( service.ID ) }
-				</li>
-			);
-		}, this );
-	},
-
-	renderConnections: function( serviceName ) {
-		const connections = serviceConnections.getConnectionsAvailableToCurrentUser(
-			serviceName,
-			this.props.connections
+		return services.map( ( { label, service } ) =>
+			<li key={ service } className="editor-sharing__publicize-service">
+				<h5 className="editor-sharing__publicize-service-heading">{ label }</h5>
+				{ this.renderConnections( service ) }
+			</li>
 		);
+	}
 
-		return connections.map( function( connection ) {
-			return (
-				<EditorSharingPublicizeConnection
-					key={ connection.ID }
-					post={ this.props.post }
-					connection={ connection }
-					onRefresh={ this.props.newConnectionPopup } />
-			);
-		}, this );
-	},
+	/**
+	 * Displays Publicize connections for the passed service.
+	 *
+	 * @param {String} service Slug of Keyring service.
+	 * @return {Object|DOMElement} React Element.
+	 */
+	renderConnections( service ) {
+		return filter( this.props.connections, { service } ).map( ( connection ) =>
+			<EditorSharingPublicizeConnection
+				key={ connection.ID }
+				post={ this.props.post }
+				connection={ connection }
+				onRefresh={ this.props.newConnectionPopup } />
+		);
+	}
 
-	render: function() {
+	render() {
 		return (
 			<ul className="editor-sharing__publicize-services">
 				{ this.renderServices() }
 			</ul>
 		);
 	}
-} );
+}
+
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const userId = getCurrentUserId( state );
+
+		return {
+			connections: getSiteUserConnections( state, siteId, userId ),
+		};
+	},
+)( EditorSharingPublicizeServices );

--- a/client/post-editor/editor-sharing/publicize-services.jsx
+++ b/client/post-editor/editor-sharing/publicize-services.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { filter, uniqBy } from 'lodash';
+import { map, reduce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,37 +24,31 @@ class EditorSharingPublicizeServices extends Component {
 		post: Object.freeze( {} ),
 	};
 
-	renderServices() {
-		const services = uniqBy( this.props.connections.map( ( { label, service } ) => ( { label, service } ) ), 'service' );
-
-		return services.map( ( { label, service } ) =>
-			<li key={ service } className="editor-sharing__publicize-service">
-				<h5 className="editor-sharing__publicize-service-heading">{ label }</h5>
-				{ this.renderConnections( service ) }
-			</li>
-		);
-	}
-
-	/**
-	 * Displays Publicize connections for the passed service.
-	 *
-	 * @param {String} service Slug of Keyring service.
-	 * @return {Object|DOMElement} React Element.
-	 */
-	renderConnections( service ) {
-		return filter( this.props.connections, { service } ).map( ( connection ) =>
-			<EditorSharingPublicizeConnection
-				key={ connection.ID }
-				post={ this.props.post }
-				connection={ connection }
-				onRefresh={ this.props.newConnectionPopup } />
-		);
-	}
-
 	render() {
+		const services = reduce( this.props.connections, ( memo, connection ) => {
+			if ( connection.label in memo ) {
+				memo[ connection.label ].push( connection );
+			} else {
+				memo[ connection.label ] = [ connection ];
+			}
+
+			return memo;
+		}, {} );
+
 		return (
 			<ul className="editor-sharing__publicize-services">
-				{ this.renderServices() }
+				{ map( services, ( connections, label ) =>
+					<li key={ label } className="editor-sharing__publicize-service">
+						<h5 className="editor-sharing__publicize-service-heading">{ label }</h5>
+						{ connections.map( ( connection ) =>
+							<EditorSharingPublicizeConnection
+								key={ connection.ID }
+								post={ this.props.post }
+								connection={ connection }
+								onRefresh={ this.props.newConnectionPopup } />
+						) }
+					</li>
+				) }
 			</ul>
 		);
 	}

--- a/client/post-editor/editor-sharing/publicize-services.jsx
+++ b/client/post-editor/editor-sharing/publicize-services.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { groupBy, map } from 'lodash';
 
@@ -13,32 +13,28 @@ import { getCurrentUserId } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteUserConnections } from 'state/sharing/publicize/selectors';
 
-class EditorSharingPublicizeServices extends Component {
-	static propTypes = {
-		post: PropTypes.object,
-		connections: PropTypes.array.isRequired,
-		newConnectionPopup: PropTypes.func.isRequired
-	};
-
-	render() {
-		return (
-			<ul className="editor-sharing__publicize-services">
-				{ map( groupBy( this.props.connections, 'label' ), ( connections, label ) =>
-					<li key={ label } className="editor-sharing__publicize-service">
-						<h5 className="editor-sharing__publicize-service-heading">{ label }</h5>
-						{ connections.map( ( connection ) =>
-							<EditorSharingPublicizeConnection
-								key={ connection.ID }
-								post={ this.props.post }
-								connection={ connection }
-								onRefresh={ this.props.newConnectionPopup } />
-						) }
-					</li>
+export const EditorSharingPublicizeServices = ( { connections, post, newConnectionPopup } ) => (
+	<ul className="editor-sharing__publicize-services">
+		{ map( groupBy( connections, 'label' ), ( groupedConnections, label ) =>
+			<li key={ label } className="editor-sharing__publicize-service">
+				<h5 className="editor-sharing__publicize-service-heading">{ label }</h5>
+				{ groupedConnections.map( ( connection ) =>
+					<EditorSharingPublicizeConnection
+						key={ connection.ID }
+						post={ post }
+						connection={ connection }
+						onRefresh={ newConnectionPopup } />
 				) }
-			</ul>
-		);
-	}
-}
+			</li>
+		) }
+	</ul>
+);
+
+EditorSharingPublicizeServices.propTypes = {
+	connections: PropTypes.array.isRequired,
+	post: PropTypes.object,
+	newConnectionPopup: PropTypes.func.isRequired
+};
 
 export default connect(
 	( state ) => {

--- a/client/post-editor/editor-sharing/publicize-services.jsx
+++ b/client/post-editor/editor-sharing/publicize-services.jsx
@@ -20,10 +20,6 @@ class EditorSharingPublicizeServices extends Component {
 		newConnectionPopup: PropTypes.func.isRequired
 	};
 
-	static defaultProps = {
-		post: Object.freeze( {} ),
-	};
-
 	render() {
 		const services = reduce( this.props.connections, ( memo, connection ) => {
 			if ( connection.label in memo ) {

--- a/client/post-editor/editor-sharing/publicize-services.jsx
+++ b/client/post-editor/editor-sharing/publicize-services.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { map, reduce } from 'lodash';
+import { groupBy, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,19 +21,9 @@ class EditorSharingPublicizeServices extends Component {
 	};
 
 	render() {
-		const services = reduce( this.props.connections, ( memo, connection ) => {
-			if ( connection.label in memo ) {
-				memo[ connection.label ].push( connection );
-			} else {
-				memo[ connection.label ] = [ connection ];
-			}
-
-			return memo;
-		}, {} );
-
 		return (
 			<ul className="editor-sharing__publicize-services">
-				{ map( services, ( connections, label ) =>
+				{ map( groupBy( this.props.connections, 'label' ), ( connections, label ) =>
 					<li key={ label } className="editor-sharing__publicize-service">
 						<h5 className="editor-sharing__publicize-service-heading">{ label }</h5>
 						{ connections.map( ( connection ) =>


### PR DESCRIPTION
The benefit these utility functions provide is small and they're easily
replaceable. Changes to `EditorSharingPublicizeServices` are a bit more
verbose since it relies on data provided by `serviceConnection`, which
we now draw from Redux.

This is a forked PR from #8991. See #5046 for big picture.

To test, try writing a post and check if the Sharing module is in working condition.