### PR TITLE
Signup: Add a domains first flow

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -207,6 +207,13 @@ const flows = {
 		lastModified: '2016-11-29',
 		autoContinue: true,
 	},
+
+	'domain-first': {
+		steps: [ 'domains', 'survey', 'design-type', 'themes', 'plans', 'user' ],
+		destination: getSiteDestination,
+		description: 'An experimental approach for WordPress.com/domains',
+		lastModified: '2016-12-20'
+	},
 };
 
 if ( config( 'env' ) === 'development' ) {


### PR DESCRIPTION
This adds a domains first version of the signup flow. There are no other changes necessary to make this work.

#### Testing instructions
  
1. Run `git checkout add/domain-first-signup-flow` and start your server, or open a [live branch](https://calypso.live/?branch=add/domain-first-signup-flow)
2. Open the [`Domains first` signup up flow](http://calypso.localhost:3000/start/domains-first)
3. Select a paid domain and then go though the flow and make sure that you are not offered the free plan, and that the domain is in your cart at the end of the flow.
  
#### Reviews
  
- [ ] Code
- [ ] Product
   
@Automattic/sdev-feed