### PR TITLE
Chat: EOY holiday closure notice

### DIFF
--- a/client/me/help/chat-closure-notice/index.jsx
+++ b/client/me/help/chat-closure-notice/index.jsx
@@ -18,13 +18,13 @@ import { title, upcoming, closed } from './messages';
 const Notice = localize( ( { translate, closedFrom, closedTo, reason } ) =>
 	<div className="chat-closure-notice">
 		<FormSectionHeading>{ title( { translate, closedFrom, closedTo, reason } ) }</FormSectionHeading>
-		<p>
+		<div>
 			{
 				i18n.moment().isBefore( closedFrom )
 					? upcoming( { translate, closedFrom, closedTo, reason } )
 					: closed( { translate, closedFrom, closedTo, reason } )
 			}
-		</p>
+		</div>
 	</div>
 );
 

--- a/client/me/help/chat-closure-notice/messages.jsx
+++ b/client/me/help/chat-closure-notice/messages.jsx
@@ -42,9 +42,18 @@ export const upcoming = ( { translate, reason, closedFrom, closedTo } ) => {
 						p: <p />,
 						dates:
 						<ul>
-							<li>{ translate( 'December 24-26' ) }</li>
-							<li>{ translate( 'December 31' ) }</li>
-							<li>{ translate( 'January 1' ) }</li>
+							<li>{ translate( '%(closed_start_date)s to %(closed_end_date)s', {
+								args: {
+									closed_start_date: closedFrom.format( 'llll' ),
+									closed_end_date: closedFrom.clone().add( 72, 'hours' ).format( 'llll' ),
+								}
+							} ) }</li>
+							<li>{ translate( '%(closed_start_date)s to %(closed_end_date)s', {
+								args: {
+									closed_start_date: closedTo.clone().subtract( 48, 'hours' ).format( 'llll' ),
+									closed_end_date: closedTo.format( 'llll' ),
+								}
+							} ) }</li>
 						</ul>
 					}
 				}

--- a/client/me/help/chat-closure-notice/messages.jsx
+++ b/client/me/help/chat-closure-notice/messages.jsx
@@ -7,6 +7,8 @@ export const title = ( { translate, reason } ) => {
 	switch ( reason ) {
 		case 'thanksgiving':
 			return translate( 'Limited Support For Thanksgiving' );
+		case 'eoy-holidays':
+			return translate( 'Limited support over the holidays' );
 	}
 
 	return null;
@@ -29,12 +31,30 @@ export const upcoming = ( { translate, reason, closedFrom, closedTo } ) => {
 					}
 				}
 			);
+		case 'eoy-holidays':
+			return translate(
+				'{{p}}Live chat will be closed on the following dates for the holidays:{{/p}} ' +
+				'{{dates/}}' +
+				'{{p}}If you need to get in touch with us on those days, you’ll be able to ' +
+				'submit a support request from this page and we will get to it as fast as we can. ' +
+				'Thank you!{{/p}}', {
+					components: {
+						p: <p />,
+						dates:
+						<ul>
+							<li>{ translate( 'December 24-26' ) }</li>
+							<li>{ translate( 'December 31' ) }</li>
+							<li>{ translate( 'January 1' ) }</li>
+						</ul>
+					}
+				}
+			);
 	}
 
 	return null;
 };
 
-export const closed = ( { translate, reason, closedTo } ) => {
+export const closed = ( { translate, reason, closedFrom, closedTo } ) => {
 	switch ( reason ) {
 		case 'thanksgiving':
 			return translate(
@@ -49,6 +69,9 @@ export const closed = ( { translate, reason, closedTo } ) => {
 					}
 				}
 			);
+		case 'eoy-holidays':
+			// Use the same message during closure
+			return upcoming( { translate, reason, closedFrom, closedTo } );
 	}
 
 	return null;

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -223,9 +223,9 @@ export const HelpContactForm = React.createClass( {
 		return (
 			<div className="help-contact-form">
 				<ChatClosureNotice
-					reason="thanksgiving"
-					from="2016-11-24T08:00:00Z"
-					to="2016-11-25T08:00:00Z"
+					reason="eoy-holidays"
+					from="2016-12-24T08:00:00Z"
+					to="2017-01-02T00:00:00Z"
 				/>
 				{ formDescription && ( <p>{ formDescription }</p> ) }
 

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -224,7 +224,7 @@ export const HelpContactForm = React.createClass( {
 			<div className="help-contact-form">
 				<ChatClosureNotice
 					reason="eoy-holidays"
-					from="2016-12-24T08:00:00Z"
+					from="2016-12-24T00:00:00Z"
 					to="2017-01-02T00:00:00Z"
 				/>
 				{ formDescription && ( <p>{ formDescription }</p> ) }


### PR DESCRIPTION
Adds a notice for chat eligible users about upcoming closure.

In the UTC+10 timezone:
![screen shot 2016-12-20 at 10 03 07 pm](https://cloud.githubusercontent.com/assets/416133/21372697/9a64ff9c-c764-11e6-9938-4af17ca09401.png)

### How to test

1. Log in as a plan user who is eligible for live chat support.
1. Head to http://calypso.localhost:3000/help/contact, confirm that the closure notice is displayed.
1. Change your system time to 2 Jan, 2017, then reload the page. Confirm that the closure is not displayed.
1. Reset system time to normal.
1. Log in as a free user who is not eligible for chat. You should not see the notice.

See p2UL9c-38g-p2