### PR TITLE
Plans: Show the old thank you page for jetpack plans

### DIFF
--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -178,6 +178,13 @@ function isPlan( product ) {
 	);
 }
 
+function isDotComPlan( product ) {
+	return (
+		isPlan( product ) &&
+		! isJetpackPlan( product )
+	);
+}
+
 function isPrivateRegistration( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
@@ -352,6 +359,7 @@ module.exports = {
 	isDomainProduct,
 	isDomainRedemption,
 	isDomainRegistration,
+	isDotComPlan,
 	isEnterprise,
 	isFreeJetpackPlan,
 	isFreePlan,

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -34,6 +34,7 @@ import {
 	isDomainProduct,
 	isDomainRedemption,
 	isDomainRegistration,
+	isDotComPlan,
 	isGoogleApps,
 	isGuidedTransfer,
 	isJetpackPlan,
@@ -180,7 +181,7 @@ const CheckoutThankYou = React.createClass( {
 		if ( this.isDataLoaded() && ! this.isGenericReceipt() ) {
 			purchases = getPurchases( this.props );
 			wasJetpackPlanPurchased = purchases.some( isJetpackPlan );
-			wasOnlyDotcomPlanPurchased = purchases.every( isPlan );
+			wasOnlyDotcomPlanPurchased = purchases.every( isDotComPlan );
 		}
 
 		const userCreatedMoment = moment( this.props.userDate );


### PR DESCRIPTION
When https://github.com/Automattic/wp-calypso/pull/7606 test was deployed to the 100% of the users, it introduced a regression: It was being applied also to jetpack plans purchased, so we were showing the new thank-you page for new users who have just connected a jetpack site and purchased a jetpack plan. 
![image](https://cloud.githubusercontent.com/assets/1554855/21351186/87637832-c6bb-11e6-8209-9d7ef99ed9a7.png)

As you can see in the image above,  the new page doesn't include the "set up your plan" button that allows jetpack users to set up their akismet & vaultpress keys automattically from calypso. So this change forced users to configure their newly bought plan manually. 

This PRs fixed the problem, making the new thank-you page viewable only by users who have purchased a non-jetpack plan.  They should see the old version of the page, with the setup button:

![image](https://cloud.githubusercontent.com/assets/1554855/21351240/db483c94-c6bb-11e6-9775-0aa74ee26096.png)


How to test
=========
1. Connect a jetpack site to a newly created user (for example, sign out from wp.com, and then go to https://wordpress.com/jetpack/connect and introduce there a self-hosted test site of your own. Once you are asked to login or create a new account, create a new user). 
2. Go to http://calypso.localhost:3000/plans/ and select your newly connected jetpack site
3. Purchase any plan. Once you pay, you should see the old thank you screen

ping @tyxla  @lsinger  @marekhrabe 