### PR TITLE
Domains: Add case for forbidden_domain error message

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -243,9 +243,7 @@ const MapDomainStep = React.createClass( {
 				break;
 
 			case 'forbidden_domain':
-				message = translate( 'Sorry, you do not have the correct permissions to map %(domain)s.', {
-					args: { domain }
-				} );
+				message = translate( 'Only the owner of the domain can map it\'s subdomains.' );
 				break;
 
 			case 'invalid_tld':

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -614,6 +614,12 @@ const RegisterDomainStep = React.createClass( {
 				message = translate( 'Subdomains starting with \'www.\' cannot be mapped to a WordPress.com blog' );
 				break;
 
+			case 'not_mappable_forbidden_domain':
+				message = translate( 'Sorry, you do not have the correct permissions to map %(domain)s.', {
+					args: { domain }
+				} );
+				break;
+
 			case 'not_mappable_invalid_tld':
 			case 'invalid_query':
 				message = translate( 'Sorry, %(domain)s does not appear to be a valid domain name.', {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -615,9 +615,7 @@ const RegisterDomainStep = React.createClass( {
 				break;
 
 			case 'not_mappable_forbidden_domain':
-				message = translate( 'Sorry, you do not have the correct permissions to map %(domain)s.', {
-					args: { domain }
-				} );
+				message = translate( 'Only the owner of the domain can map it\'s subdomains.' );
 				break;
 
 			case 'not_mappable_invalid_tld':


### PR DESCRIPTION
Handle `is_availability` forbidden_domain response properly.

Test:
Search for a subdomain of a domain that is owned by another user.

Before: It would error in console.
After: A proper notice is show.