### PR TITLE
Signup: Send the flow name to the new site endpoint when creating a new site

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -26,6 +26,7 @@ import { getSurveyVertical, getSurveySiteType } from 'state/signup/steps/survey/
 function createSiteWithCart( callback, dependencies, {
 	cartItem,
 	domainItem,
+	flowName,
 	googleAppsCartItem,
 	isPurchasingItem,
 	siteUrl,
@@ -41,7 +42,8 @@ function createSiteWithCart( callback, dependencies, {
 		blog_title: siteTitle,
 		options: {
 			theme: dependencies.theme || themeSlugWithRepo,
-			vertical: surveyVertical || undefined
+			vertical: surveyVertical || undefined,
+			flow: flowName,
 		},
 		validate: false,
 		find_available_url: isPurchasingItem
@@ -203,11 +205,11 @@ module.exports = {
 		} );
 	},
 
-	createSite( callback, { theme }, { site } ) {
+	createSite( callback, { theme }, { site, flowName } ) {
 		var data = {
 			blog_name: site,
 			blog_title: '',
-			options: { theme },
+			options: { theme, flow: flowName },
 			validate: false
 		};
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -111,6 +111,7 @@ const DomainsStep = React.createClass( {
 		registerDomainAnalytics.recordEvent( 'submitDomainStepSelection', suggestion, 'signup' );
 
 		SignupActions.submitSignupStep( Object.assign( {
+			flowName: this.props.flowName,
 			processingMessage: this.translate( 'Adding your domain' ),
 			stepName: this.props.stepName,
 			domainItem,

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -149,6 +149,7 @@ module.exports = React.createClass( {
 			this.resetAnalyticsData();
 
 			SignupActions.submitSignupStep( {
+				flowName: this.props.flowName,
 				processingMessage: this.translate( 'Setting up your site' ),
 				stepName: this.props.stepName,
 				form: this.state.form,


### PR DESCRIPTION
This pull request will send the flow name of the current signup flow when creating a new site. It works together with D3755-code, so that the flow is saved.
    
#### Testing instructions
  
1. Run `git checkout add/flow-to-blog-options` and start your server, or open a [live branch](https://delphin.live/?branch=add/flow-to-blog-options)
2. Open the [`Signup` flow](http://delphin.localhost:1337/start)
3. Create a site
4. Verify that you see the flow name when you look at the options parameter in /me/sites
  
#### Reviews
  
- [ ] Code
- [ ] Product
   
@Automattic/sdev-feed