### PR TITLE
Reader: Update visit url in reader stream

### DIFF
--- a/client/blocks/reader-post-actions/README.md
+++ b/client/blocks/reader-post-actions/README.md
@@ -12,38 +12,10 @@ function MyPostActions() {
 
 ## Props
 
-### `post`
-
-<table>
-	<tr><th>Type</th><td>Object</td></tr>
-	<tr><th>Required</th><td>Yes</td></tr>
-</table>
-
-The post object being displayed.
-
-### `site`
-
-<table>
-	<tr><th>Type</th><td>Object</td></tr>
-	<tr><th>Required</th><td>No</td></tr>
-</table>
-
-Where available, the site object for the current post. This will only be available for wordpress.com and Jetpack posts. It is used to determine whether the user has permission to edit the current post.
-
-### `onCommentClick`
-
-<table>
-	<tr><th>Type</th><td>Function</td></tr>
-	<tr><th>Required</th><td>No</td></tr>
-</table>
-
-A function to be fired when the comment button is clicked.
-
-### `showEdit`
-
-<table>
-	<tr><th>Type</th><td>Boolean</td></tr>
-	<tr><th>Required</th><td>No</td></tr>
-</table>
-
-Should we show the Edit button?
+| Prop | Type | Required | Description |
+|-----|:----:|:--------:|-------------|
+| `post`| Object | Yes | The post object being displayed |
+| `site` | Object | Yes | Where available, the site object for the current post. This will only be available for wordpress.com and Jetpack posts. It is used to determine whether the user has permission to edit the current post.|
+| `onCommentClick` | Function | No | A function to be fired when the comment button is clicked. |
+| `showEdit` | Boolean | No | Should we show the Edit button? |
+| `visitUrl` | String | No | Url used for the visit link. The link will use the `post` url if this prop is omitted. |

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -31,7 +31,8 @@ const ReaderPostActions = ( props ) => {
 		showMenu,
 		showMenuFollow,
 		iconSize,
-		className
+		className,
+		visitUrl
 	} = props;
 
 	const onEditClick = () => {
@@ -51,7 +52,7 @@ const ReaderPostActions = ( props ) => {
 		<ul className={ listClassnames }>
 			{ showVisit &&
 				<li className="reader-post-actions__item reader-post-actions__visit">
-					<ExternalLink href={ post.URL }
+					<ExternalLink href={ visitUrl || post.URL }
 						target="_blank"
 						icon={ true }
 						showIconFirst={ true }
@@ -111,7 +112,8 @@ ReaderPostActions.propTypes = {
 	showEdit: React.PropTypes.bool,
 	iconSize: React.PropTypes.number,
 	showMenu: React.PropTypes.bool,
-	showMenuFollow: React.PropTypes.bool
+	showMenuFollow: React.PropTypes.bool,
+	visitUrl: React.PropTypes.string
 };
 
 ReaderPostActions.defaultProps = {

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -170,6 +170,7 @@ export default class RefreshPostCard extends React.Component {
 						{ post &&
 							<ReaderPostActions
 								post={ originalPost ? originalPost : post }
+								visitUrl = { post.URL }
 								showVisit={ true }
 								showMenu={ true }
 								showMenuFollow={ ! isDiscoverPost }


### PR DESCRIPTION
This sets the visit url to use the source card url in the stream card actions.
It will default to the `post` url.

Fixes #10164 

