### PR TITLE
State: Convert CommonJS selector imports to ES6

### DIFF
--- a/client/me/purchases/credit-cards/credit-card-delete.jsx
+++ b/client/me/purchases/credit-cards/credit-card-delete.jsx
@@ -10,8 +10,8 @@ var React = require( 'react' ),
 var StoredCard = require( 'my-sites/upgrades/checkout/stored-card' ),
 	successNotice = require( 'state/notices/actions' ).successNotice,
 	errorNotice = require( 'state/notices/actions' ).errorNotice,
-	deleteStoredCard = require( 'state/stored-cards/actions' ).deleteStoredCard,
-	isDeletingStoredCard = require( 'state/stored-cards/selectors' ).isDeletingStoredCard;
+	deleteStoredCard = require( 'state/stored-cards/actions' ).deleteStoredCard;
+import { isDeletingStoredCard } from 'state/stored-cards/selectors';
 
 const CreditCardDelete = React.createClass( {
 	handleClick: function() {

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -23,7 +23,6 @@ const analytics = require( 'lib/analytics' ),
 	domainMapping = require( 'lib/cart-values/cart-items' ).domainMapping,
 	fetchReceiptCompleted = require( 'state/receipts/actions' ).fetchReceiptCompleted,
 	getExitCheckoutUrl = require( 'lib/checkout' ).getExitCheckoutUrl,
-	getStoredCards = require( 'state/stored-cards/selectors' ).getStoredCards,
 	hasDomainDetails = require( 'lib/store-transactions' ).hasDomainDetails,
 	notices = require( 'notices' ),
 	observe = require( 'lib/mixins/data-observe' ),
@@ -35,6 +34,7 @@ const analytics = require( 'lib/analytics' ),
 	themeItem = require( 'lib/cart-values/cart-items' ).themeItem,
 	transactionStepTypes = require( 'lib/store-transactions/step-types' ),
 	upgradesActions = require( 'lib/upgrades/actions' );
+import { getStoredCards } from 'state/stored-cards/selectors';
 
 import {
 	isValidFeatureKey,

--- a/client/my-sites/upgrades/domain-search/domain-search.jsx
+++ b/client/my-sites/upgrades/domain-search/domain-search.jsx
@@ -13,8 +13,6 @@ var observe = require( 'lib/mixins/data-observe' ),
 	EmptyContent = require( 'components/empty-content' ),
 	fetchSitePlans = require( 'state/sites/plans/actions' ).fetchSitePlans,
 	FreeTrialNotice = require( './free-trial-notice' ),
-	getPlansBySite = require( 'state/sites/plans/selectors' ).getPlansBySite,
-	{ currentUserHasFlag } = require( 'state/current-user/selectors' ),
 	{ DOMAINS_WITH_PLANS_ONLY } = require( 'state/current-user/constants' ),
 	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
 	RegisterDomainStep = require( 'components/domains/register-domain-step' ),
@@ -24,6 +22,8 @@ var observe = require( 'lib/mixins/data-observe' ),
 	cartItems = require( 'lib/cart-values/cart-items' ),
 	analyticsMixin = require( 'lib/mixins/analytics' ),
 	shouldFetchSitePlans = require( 'lib/plans' ).shouldFetchSitePlans;
+import { getPlansBySite } from 'state/sites/plans/selectors';
+import { currentUserHasFlag } from 'state/current-user/selectors';
 
 var DomainSearch = React.createClass( {
 	mixins: [ observe( 'productsList', 'sites' ), analyticsMixin( 'registerDomain' ) ],

--- a/client/my-sites/upgrades/map-domain/index.jsx
+++ b/client/my-sites/upgrades/map-domain/index.jsx
@@ -11,14 +11,13 @@ var page = require( 'page' ),
  */
 var HeaderCake = require( 'components/header-cake' ),
 	MapDomainStep = require( 'components/domains/map-domain-step' ),
-	{ currentUserHasFlag } = require( 'state/current-user/selectors' ),
 	{ DOMAINS_WITH_PLANS_ONLY } = require( 'state/current-user/constants' ),
 	cartItems = require( 'lib/cart-values' ).cartItems,
 	upgradesActions = require( 'lib/upgrades/actions' ),
 	observe = require( 'lib/mixins/data-observe' ),
 	wpcom = require( 'lib/wp' ).undocumented(),
 	paths = require( 'my-sites/upgrades/paths' );
-
+import { currentUserHasFlag } from 'state/current-user/selectors';
 import Notice from 'components/notice';
 
 var MapDomain = React.createClass( {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -16,12 +16,12 @@ var StepWrapper = require( 'signup/step-wrapper' ),
 	SignupActions = require( 'lib/signup/actions' ),
 	MapDomainStep = require( 'components/domains/map-domain-step' ),
 	RegisterDomainStep = require( 'components/domains/register-domain-step' ),
-	{ getCurrentUser, currentUserHasFlag } = require( 'state/current-user/selectors' ),
 	{ DOMAINS_WITH_PLANS_ONLY } = require( 'state/current-user/constants' ),
 	{ getSurveyVertical } = require( 'state/signup/steps/survey/selectors.js' ),
 	analyticsMixin = require( 'lib/mixins/analytics' ),
 	signupUtils = require( 'signup/utils' );
 
+import { getCurrentUser, currentUserHasFlag } from 'state/current-user/selectors';
 import Notice from 'components/notice';
 
 const registerDomainAnalytics = analyticsMixin( 'registerDomain' ),


### PR DESCRIPTION
This pull request seeks to update state selector imports using CommonJS to ES6. Specifically this is to facilitate a migration to global selectors (#5954) using codemods like that suggested at https://github.com/Automattic/wp-calypso/pull/5954#issuecomment-260457603. While a codemod could be adapted to account for CommonJS, it's better to simply update these to the preferred syntax.

Reviewers via `git blame`:

- @stephanethomas (`CreditCardDelete`, `Checkout`)
- @drewblaisdell (`DomainSearch`)
- @umurkontaci (`DomainSearch`, `MapDomain`, `DomainsStep`)