### PR TITLE
Account Recovery: Add reset password with transaction id page

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -11,6 +11,7 @@
 @import 'account-recovery/forgot-username/forgot-username-form/style';
 @import 'account-recovery/lost-password/lost-password-form/style';
 @import 'account-recovery/reset-password/reset-password-form/style';
+@import 'account-recovery/reset-password/transaction-id-form/style';
 @import 'account-recovery/style';
 @import 'auth/style';
 @import 'blocks/app-promo/style';

--- a/client/account-recovery/controller.js
+++ b/client/account-recovery/controller.js
@@ -10,6 +10,8 @@ import page from 'page';
 import LostPasswordPage from 'account-recovery/lost-password';
 import ForgotUsernamePage from 'account-recovery/forgot-username';
 import ResetPasswordPage from 'account-recovery/reset-password';
+import ResetPasswordForm from 'account-recovery/reset-password/reset-password-form';
+import TransactionIdForm from 'account-recovery/reset-password/transaction-id-form';
 import { getCurrentUser } from 'state/current-user/selectors';
 
 export function lostPassword( context, next ) {
@@ -22,6 +24,26 @@ export function forgotUsername( context, next ) {
 	next();
 }
 
+export function resetPassword( context, next ) {
+	context.primary = (
+		<ResetPasswordPage basePath={ context.path }>
+			<ResetPasswordForm />
+		</ResetPasswordPage>
+	);
+
+	next();
+}
+
+export function resetPasswordByTransactionId( context, next ) {
+	context.primary = (
+		<ResetPasswordPage basePath={ context.path }>
+			<TransactionIdForm />
+		</ResetPasswordPage>
+	);
+
+	next();
+}
+
 export function redirectLoggedIn( context, next ) {
 	const currentUser = getCurrentUser( context.store.getState() );
 
@@ -29,14 +51,6 @@ export function redirectLoggedIn( context, next ) {
 		page.redirect( '/' );
 		return;
 	}
-
-	next();
-}
-
-export function resetPassword( context, next ) {
-	context.primary = <ResetPasswordPage basePath={ context.path } />;
-
-	//TODO: Redirect to LostPasswordPage if we don't have the correct state
 
 	next();
 }

--- a/client/account-recovery/index.js
+++ b/client/account-recovery/index.js
@@ -5,6 +5,7 @@ import {
 	lostPassword,
 	forgotUsername,
 	resetPassword,
+	resetPasswordByTransactionId,
 	redirectLoggedIn
 } from './controller';
 
@@ -13,4 +14,5 @@ export default function( router ) {
 	router( '/account-recovery', redirectLoggedIn, lostPassword );
 	router( '/account-recovery/forgot-username', redirectLoggedIn, forgotUsername );
 	router( '/account-recovery/reset-password', redirectLoggedIn, resetPassword );
+	router( '/account-recovery/reset-password/transaction-id', redirectLoggedIn, resetPasswordByTransactionId );
 }

--- a/client/account-recovery/reset-password/index.jsx
+++ b/client/account-recovery/reset-password/index.jsx
@@ -11,12 +11,11 @@ import classnames from 'classnames';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import Main from 'components/main';
 import DocumentHead from 'components/data/document-head';
-import ResetPasswordForm from './reset-password-form';
 
-export default localize( ( { className, translate, basePath } ) => (
+export default localize( ( { className, translate, basePath, children } ) => (
 	<Main className={ classnames( 'reset-password', className ) }>
 		<PageViewTracker path={ basePath } title="Account Recovery > Reset Password" />
 		<DocumentHead title={ translate( 'Reset Password ‹ Account Recovery' ) } />
-		<ResetPasswordForm />
+		{ children }
 	</Main>
 ) );

--- a/client/account-recovery/reset-password/transaction-id-form/index.jsx
+++ b/client/account-recovery/reset-password/transaction-id-form/index.jsx
@@ -1,0 +1,104 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import { identity } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import support from 'lib/url/support';
+import Card from 'components/card';
+import Button from 'components/button';
+import FormLabel from 'components/forms/form-label';
+import FormInput from 'components/forms/form-text-input';
+
+export class TransactionIdFormComponent extends Component {
+	static defaultProps = {
+		translate: identity,
+	};
+
+	state = {
+		isSubmitting: false,
+		transactionId: '',
+	}
+
+	submitForm = () => {
+		this.setState( { isSubmitting: true } );
+	};
+
+	onTransactionIdChanged = ( event ) => {
+		this.setState( { transactionId: event.target.value } );
+	};
+
+	render() {
+		const { translate } = this.props;
+		const { isSubmitting, transactionId } = this.state;
+		const isPrimaryButtonDisabled = ! transactionId || isSubmitting;
+
+		return (
+			<div>
+				<h2 className="transaction-id-form__title">
+					{ translate( 'Account recovery' ) }
+				</h2>
+				<p>
+					{ translate(
+						'Please provide the following information to verify your identity. ' +
+						'Without {{strong}}proper validating information{{/strong}}, ' +
+						'we might not be able to help you recover your account. ' +
+						'Read more about the process {{helpLink}}here{{/helpLink}}.',
+						{
+							components: {
+								strong: <strong />,
+								helpLink: <a href={ support.ACCOUNT_RECOVERY } />
+							}
+						}
+					) }
+				</p>
+				<Card>
+					<FormLabel htmlFor="transactionId">
+						{ translate( 'Transaction ID' ) }
+					</FormLabel>
+					<p className="transaction-id-form__transaction-id-description">
+						{ translate(
+							'If you have purchased any upgrades on WordPress.com, this number ' +
+							'will be in your receipt from PayPal or in your PayPal account. ' +
+							'{{helpLink}}Need help to find your transaction id?{{/helpLink}}',
+							{
+								components: {
+									helpLink: <a href={ support.ACCOUNT_RECOVERY } />
+								}
+							}
+						) }
+					</p>
+					<FormInput
+						id="transactionId"
+						className="transaction-id-form__transaction-id-input"
+						onChange={ this.onTransactionIdChanged }
+						value={ transactionId }
+						disabled={ isSubmitting } />
+
+					<Button
+						className="transaction-id-form__continue-button"
+						onClick={ this.submitForm }
+						disabled={ isPrimaryButtonDisabled }
+						primary
+					>
+						{ translate( 'Continue' ) }
+					</Button>
+
+					<Button
+						className="transaction-id-form__skip-button"
+						onClick={ this.skip }
+						disabled={ isSubmitting }
+					>
+						{ translate( 'Skip this question' ) }
+					</Button>
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default localize( TransactionIdFormComponent );

--- a/client/account-recovery/reset-password/transaction-id-form/style.scss
+++ b/client/account-recovery/reset-password/transaction-id-form/style.scss
@@ -1,0 +1,31 @@
+.transaction-id-form__title {
+	font-size: 20px;
+	font-weight: 600;
+	margin-bottom: 4px;
+}
+
+//Use a more specific selector here so we don't have to use !important to overide any css
+.transaction-id-form__transaction-id-input.form-text-input {
+	margin-top: 4px;
+	margin-bottom: 8px;
+}
+
+.transaction-id-form__continue-button.button {
+	margin-top: 16px;
+	@include breakpoint( ">480px" ) {
+		margin-right: 8px;
+	}
+}
+
+.transaction-id-form__skip-button.button {
+	margin-top: 16px;
+}
+
+.transaction-id-form__continue-button.button,
+.transaction-id-form__skip-button.button {
+	width: 100%;
+
+	@include breakpoint( ">480px" ) {
+		width: calc( 50% - 4px );
+	}
+}

--- a/client/account-recovery/reset-password/transaction-id-form/test/index.jsx
+++ b/client/account-recovery/reset-password/transaction-id-form/test/index.jsx
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow, mount } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+import { TransactionIdFormComponent } from '..';
+
+describe( 'TransactionIdForm', () => {
+	it( 'should render as expected', () => {
+		const wrapper = shallow( <TransactionIdFormComponent /> );
+
+		expect( wrapper ).to.have.state( 'isSubmitting' ).to.be.false;
+		expect( wrapper.find( '.transaction-id-form__transaction-id-input' ).prop( 'disabled' ) ).to.not.be.ok;
+		expect( wrapper.find( '.transaction-id-form__continue-button' ).prop( 'disabled' ) ).to.be.ok;
+		expect( wrapper.find( '.transaction-id-form__skip-button' ).prop( 'disabled' ) ).to.not.be.ok;
+	} );
+
+	context( 'events', () => {
+		useFakeDom();
+
+		it( 'continue button should be disabled if transaction id is blank', function() {
+			const wrapper = mount( <TransactionIdFormComponent className="test__test" /> );
+
+			wrapper.find( '.transaction-id-form__transaction-id-input' ).node.value = '';
+			wrapper.find( '.transaction-id-form__transaction-id-input' ).simulate( 'change' );
+			expect( wrapper.find( '.transaction-id-form__transaction-id-input' ).prop( 'disabled' ) ).to.not.be.ok;
+			expect( wrapper.find( '.transaction-id-form__continue-button' ).prop( 'disabled' ) ).to.be.ok;
+		} );
+
+		it( 'should be disabled when continue button clicked', function() {
+			const wrapper = mount( <TransactionIdFormComponent className="test__test" /> );
+
+			wrapper.find( '.transaction-id-form__transaction-id-input' ).node.value = 'test';
+			wrapper.find( '.transaction-id-form__transaction-id-input' ).simulate( 'change' );
+			wrapper.find( '.transaction-id-form__continue-button' ).simulate( 'click' );
+
+			expect( wrapper ).to.have.state( 'isSubmitting' ).to.be.true;
+			expect( wrapper.find( '.transaction-id-form__transaction-id-input' ).prop( 'disabled' ) ).to.be.ok;
+			expect( wrapper.find( '.transaction-id-form__continue-button' ).prop( 'disabled' ) ).to.be.ok;
+		} );
+	} );
+} );


### PR DESCRIPTION
# Account Recovery: add a reset password using transaction id page

This pull request adds a screen to the account recovery flow that will allow a user to reset their password using a previous transaction id. This page doesn't actually do anything since the redux state tree hasn't been connected yet.

### How to test
#### Functionality
1. Make sure your logged out and navigate to http://calypso.localhost:3000/account-recovery/reset-password/transaction-id
2. Enter a transaction id
3. Click "Continue"
4. Notice that the form is disabled

#### What to expect
![screen shot 2017-01-10 at 1 12 45 pm](https://cloud.githubusercontent.com/assets/1854440/21818676/bb2ecb4a-d736-11e6-91f9-b0df43ad45e3.png)

![screen shot 2017-01-10 at 1 13 26 pm](https://cloud.githubusercontent.com/assets/1854440/21818678/bd64c77a-d736-11e6-8067-f41771fba906.png)
