### PR TITLE
Reader: Update styles for gap indicator

### DIFF
--- a/client/reader/list-gap/_style.scss
+++ b/client/reader/list-gap/_style.scss
@@ -1,37 +1,45 @@
 .reader-list-gap {
-	margin-bottom: 16px;
-	padding: 16px 0;
-	text-align: center;
-	position: relative;
+	border-bottom: 1px solid lighten( $gray, 30% );
 	cursor: pointer;
+	margin-bottom: 16px;
+	padding: 30px 0;
+	position: relative;
+	text-align: center;
+
+	@include breakpoint( "<660px" ) {
+		margin: 0 15px;
+	}
 
 	&.is-selected {
 		box-shadow: 0 0 0 1px $gray,
 					0 2px 4px lighten( $gray, 20 );
 	}
 
-	&:before {
+	&::before,
+	&::after {
 		content: "";
 		display: block;
 		position: absolute;
-			top: 28px;
-		width: 100%;
-		height: 16px;
-		background:
-			linear-gradient( 45deg, transparent 33.333%, $gray 33.333%, $gray 66.667%, transparent 66.667% ),
-			linear-gradient( -45deg, transparent 33.333%, $gray 33.333%, $gray 66.667%, transparent 66.667% );
-		background-size: 13px 30px;
-		opacity: 0.2;
+			left: 0;
+  			right: 0;
 	}
 
-	&:after {
-		content: "";
-		display: block;
-		position: absolute;
-			top: 28px;
-		width: 100%;
+	&::before {
+		background: linear-gradient(-135deg, lighten( $gray, 30% ) 8px, transparent 0) 0 8px, linear-gradient( 135deg, lighten( $gray, 30% ) 8px, transparent 0) 0 8px;
+		background-position: top left;
+		background-repeat: repeat-x;
+		background-size: 16px 16px;
 		height: 16px;
-		background: linear-gradient( to bottom, rgba( lighten( $gray, 30% ), 0 ) 0% ,rgba( lighten( $gray, 30% ), 1 ) 100% );
+		top: 46%;
+	}
+
+	&::after {
+		background: linear-gradient(-135deg, $white 8px, transparent 0) 0 8px, linear-gradient( 135deg, $white 8px, transparent 0) 0 8px;
+		background-position: top left;
+		background-repeat: repeat-x;
+		background-size: 16px 16px;
+		height: 16px;
+		top: 44%;
 	}
 }
 


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/10012

**Before:**
![screenshot 2016-12-20 11 21 02](https://cloud.githubusercontent.com/assets/4924246/21370182/6328ef20-c6bf-11e6-9113-aeb77057bb17.png)

**After:**
![screenshot 2016-12-20 14 18 41](https://cloud.githubusercontent.com/assets/4924246/21370189/68463170-c6bf-11e6-82c6-574351cbb6bf.png)

![screenshot 2016-12-20 14 18 53](https://cloud.githubusercontent.com/assets/4924246/21370191/6a050568-c6bf-11e6-9246-1c74db7f1345.png)

**To test:**
1. Load http://wpcalypso.wordpress.com/?at=2016-11-01
2. Wait for the "new posts" pill to appear. click that pill!
3. Scroll down 40 posts and see the indicator
