### PR TITLE
Plugins: Add query component to eligibility warnings

### DIFF
--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -5,7 +5,7 @@ import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop, isEmpty } from 'lodash';
+import { get, map, noop, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,9 +18,9 @@ import Gridicon from 'components/gridicon';
 import SectionHeader from 'components/section-header';
 import QueryEligibility from 'components/data/query-atat-eligibility';
 
-// Mapping eligibility hold constant to messages that will be shown to the user
+// Mapping eligibility holds to messages that will be shown to the user
 // TODO: update supportUrls and maybe create similar mapping for warnings
-function getHoldsMessages( translate ) {
+function getHoldMessages( translate ) {
 	return {
 		PLACEHOLDER: {
 			title: '',
@@ -83,15 +83,9 @@ const EligibilityWarnings = props => {
 		isPlaceholder,
 	} = props;
 
-	const holdsMessage = getHoldsMessages( translate );
-
-	const holds = ( eligibilityData && eligibilityData.eligibilityHolds )
-		? eligibilityData.eligibilityHolds
-		: [ 'PLACEHOLDER' ];
-
-	const warnings = ( eligibilityData && eligibilityData.eligibilityWarnings )
-		? eligibilityData.eligibilityWarnings
-		: [];
+	const holdMessages = getHoldMessages( translate );
+	const holds = get( eligibilityData, 'eligibilityHolds', [ 'PLACEHOLDER', 'PLACEHOLDER' ] );
+	const warnings = get( eligibilityData, 'eligibilityWarnings', [] );
 
 	const classes = classNames( {
 		'eligibility-warnings__message': true,
@@ -103,27 +97,27 @@ const EligibilityWarnings = props => {
 			<QueryEligibility siteId={ siteId } />
 			<SectionHeader label={ translate( 'Conflicts' ) } />
 
-			{ holds.map( ( error ) =>
-				<Card key={ holdsMessage[ error ].title } className={ classes }>
+			{ map( holds, ( error, index ) =>
+				<Card key={ index } className={ classes }>
 					<Gridicon icon="notice" className="eligibility-warnings__error-icon" />
 					<div className="eligibility-warnings__message-content">
 						<div className="eligibility-warnings__message-title">
-							{ translate( 'Error: %(title)s', { args: { title: holdsMessage[ error ].title } } ) }
+							{ translate( 'Error: %(title)s', { args: { title: holdMessages[ error ].title } } ) }
 						</div>
 						<div className="eligibility-warnings__message-description">
-							{ holdsMessage[ error ].description }
+							{ holdMessages[ error ].description }
 						</div>
 					</div>
 					<div className="eligibility-warnings__message-action">
-						<Button href={ holdsMessage[ error ].supportUrl } target="_blank" rel="noopener noreferrer">
+						<Button href={ holdMessages[ error ].supportUrl } target="_blank" rel="noopener noreferrer">
 							{ translate( 'Resolve' ) }
 						</Button>
 					</div>
 				</Card>
 			) }
 
-			{ warnings.map( ( { name, description, supportUrl } ) =>
-				<Card key={ name } className={ classes }>
+			{ map( warnings, ( { name, description, supportUrl }, index ) =>
+				<Card key={ index } className={ classes }>
 					<Gridicon icon="notice" className="eligibility-warnings__warning-icon" />
 					<div className="eligibility-warnings__message-content">
 						<div className="eligibility-warnings__message-title">
@@ -158,7 +152,6 @@ const EligibilityWarnings = props => {
 						}
 					) }
 				</div>
-
 				<div className="eligibility-warnings__buttons">
 					<Button href={ backUrl }>
 						{ translate( 'Cancel' ) }

--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -5,14 +5,14 @@ import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, map, noop, isEmpty } from 'lodash';
+import { get, map, noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Button from 'components/button';
 import Card from 'components/card';
-import { getEligibility } from 'state/automated-transfer/selectors';
+import { getEligibility, getIsEligible } from 'state/automated-transfer/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import Gridicon from 'components/gridicon';
 import SectionHeader from 'components/section-header';
@@ -69,8 +69,6 @@ function getHoldMessages( translate ) {
 		}
 	};
 }
-
-const checkEligibility = eligibilityData => isEmpty( eligibilityData.eligibilityHolds );
 
 const EligibilityWarnings = props => {
 	const {
@@ -184,7 +182,7 @@ const mapStateToProps = state => {
 	return {
 		siteId,
 		eligibilityData,
-		isEligible: dataLoaded && checkEligibility( eligibilityData ),
+		isEligible: getIsEligible( state, siteId ),
 		isPlaceholder: ! dataLoaded,
 	};
 };

--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -12,7 +12,7 @@ import { get, map, noop } from 'lodash';
  */
 import Button from 'components/button';
 import Card from 'components/card';
-import { getEligibility, getIsEligible } from 'state/automated-transfer/selectors';
+import { getEligibility, isEligibleForAutomatedTransfer } from 'state/automated-transfer/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import Gridicon from 'components/gridicon';
 import SectionHeader from 'components/section-header';
@@ -182,7 +182,7 @@ const mapStateToProps = state => {
 	return {
 		siteId,
 		eligibilityData,
-		isEligible: getIsEligible( state, siteId ),
+		isEligible: isEligibleForAutomatedTransfer( state, siteId ),
 		isPlaceholder: ! dataLoaded,
 	};
 };

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -19,10 +19,7 @@
 }
 
 .is-placeholder .eligibility-warnings__message-action .button {
-    color: $gray-light;
-    background-color: $gray-light;
-    cursor: default;
-    pointer-events: none;
+    display: none;
 }
 
 .eligibility-warnings .card {

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -5,6 +5,26 @@
     line-height: 1.5;
 }
 
+.is-placeholder {
+    @include placeholder();
+}
+
+.is-placeholder .eligibility-warnings__message-content {
+    color: $gray-light;
+    background-color: $gray-light;
+}
+
+.is-placeholder .eligibility-warnings__error-icon{
+    color: $gray-light;
+}
+
+.is-placeholder .eligibility-warnings__message-action .button {
+    color: $gray-light;
+    background-color: $gray-light;
+    cursor: default;
+    pointer-events: none;
+}
+
 .eligibility-warnings .card {
     margin: 0;
     display: flex;

--- a/client/my-sites/plugins/plugin-eligibility/index.jsx
+++ b/client/my-sites/plugins/plugin-eligibility/index.jsx
@@ -4,6 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import page from 'page';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -30,7 +31,6 @@ class PluginEligibility extends Component {
 
 	render() {
 		const { translate } = this.props;
-		const isEligible = false;
 
 		return (
 			<MainComponent>
@@ -41,7 +41,8 @@ class PluginEligibility extends Component {
 					{ translate( 'Install plugin' ) }
 				</HeaderCake>
 				<EligibilityWarnings
-					isEligible={ isEligible }
+					// TODO: Replace with transfer initiate call
+					onProceed={ noop }
 					backUrl={ this.getBackUrl() }
 				/>
 			</MainComponent>

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -37,6 +37,7 @@ import {
 	isBusiness,
 	isEnterprise
 } from 'lib/products-values';
+import QueryEligibility from 'components/data/query-atat-eligibility';
 
 export default React.createClass( {
 	OUT_OF_DATE_YEARS: 2,
@@ -328,6 +329,9 @@ export default React.createClass( {
 
 		return (
 			<div className="plugin-meta">
+				{ config.isEnabled( 'automated-transfer' ) && this.props.selectedSite.ID &&
+					<QueryEligibility siteId={ this.props.selectedSite.ID } />
+				}
 				<Card>
 					{ this.displayBanner() }
 					<div className={ cardClasses } >

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -329,7 +329,7 @@ export default React.createClass( {
 
 		return (
 			<div className="plugin-meta">
-				{ config.isEnabled( 'automated-transfer' ) && this.props.selectedSite.ID &&
+				{ config.isEnabled( 'automated-transfer' ) && this.props.selectedSite &&
 					<QueryEligibility siteId={ this.props.selectedSite.ID } />
 				}
 				<Card>

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { includes, find, isEmpty } from 'lodash';
+import { includes, find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -40,7 +40,6 @@ import {
 import { getTheme } from 'state/themes/selectors';
 import { connectOptions } from 'my-sites/themes/theme-options';
 import QueryEligibility from 'components/data/query-atat-eligibility';
-import { getEligibility } from 'state/automated-transfer/selectors';
 import EligibilityWarnings from 'blocks/eligibility-warnings';
 
 const debug = debugFactory( 'calypso:themes:theme-upload' );
@@ -59,7 +58,6 @@ class Upload extends React.Component {
 		progressLoaded: React.PropTypes.number,
 		installing: React.PropTypes.bool,
 		isJetpackSite: React.PropTypes.bool,
-		isEligible: React.PropTypes.bool,
 	};
 
 	state = {
@@ -253,7 +251,6 @@ class Upload extends React.Component {
 			siteId,
 			selectedSite,
 			themeId,
-			isEligible,
 		} = this.props;
 
 		const showEligibility = ! this.props.isJetpackSite && this.state.showEligibility;
@@ -268,7 +265,6 @@ class Upload extends React.Component {
 					source="upload" />
 				<HeaderCake onClick={ this.onBackClick }>{ translate( 'Upload theme' ) }</HeaderCake>
 				{ showEligibility && <EligibilityWarnings
-					isEligible={ isEligible }
 					backUrl="/design"
 					onProceed={ this.onProceedClick } /> }
 				{ ! showEligibility && this.renderUploadCard() }
@@ -289,10 +285,6 @@ const UploadWithOptions = ( props ) => {
 	);
 };
 
-const isEligible = ( ( eligibilityData ) => {
-	return isEmpty( eligibilityData.eligibilityHolds );
-} );
-
 export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
@@ -310,7 +302,6 @@ export default connect(
 			progressTotal: getUploadProgressTotal( state, siteId ),
 			progressLoaded: getUploadProgressLoaded( state, siteId ),
 			installing: isInstallInProgress( state, siteId ),
-			isEligible: isEligible( getEligibility( state, siteId ) ),
 		};
 	},
 	{ uploadTheme, clearThemeUpload, initiateThemeTransfer },

--- a/client/state/automated-transfer/selectors.js
+++ b/client/state/automated-transfer/selectors.js
@@ -41,10 +41,30 @@ export const getEligibilityData = state => get( state, 'eligibility', { lastUpda
  * Returns eligibility info for transfer
  *
  * @param {Object} state global app state
- * @param {number} siteId requested site for tranfer info
+ * @param {number} siteId requested site for transfer info
  * @returns {object} eligibility data if available else empty info
  */
 export const getEligibility = compose(
 	getEligibilityData,
 	getAutomatedTransfer,
+);
+
+/**
+ * Helper to get eligibility status from local transfer state sub-tree
+ *
+ * @param {Object} state global app state
+ * @returns {boolean} eligibility status for site
+ */
+export const getEligibilityStatus = state => !! get( state, 'lastUpdated', 0 ) && ! get( state, 'eligibilityHolds', [] );
+
+/**
+ * Returns eligibility status for transfer
+ *
+ * @param {Object} state global app state
+ * @param {number} siteId requested site for transfer info
+ * @returns {boolean} True if current site is eligible for transfer, otherwise false
+ */
+export const getIsEligible = compose(
+	getEligibilityStatus,
+	getEligibility
 );

--- a/client/state/automated-transfer/selectors.js
+++ b/client/state/automated-transfer/selectors.js
@@ -50,7 +50,7 @@ export const getEligibility = compose(
 );
 
 /**
- * Helper to get eligibility status from local transfer state sub-tree
+ * Helper to infer eligibility status from local transfer state sub-tree
  *
  * @param {Object} state global app state
  * @returns {boolean} eligibility status for site
@@ -64,7 +64,7 @@ export const getEligibilityStatus = state => !! get( state, 'lastUpdated', 0 ) &
  * @param {number} siteId requested site for transfer info
  * @returns {boolean} True if current site is eligible for transfer, otherwise false
  */
-export const getIsEligible = compose(
+export const isEligibleForAutomatedTransfer = compose(
 	getEligibilityStatus,
 	getEligibility
 );


### PR DESCRIPTION
Previously, in order to show the eligibility warnings from plugin detail page, the data fetch action had to be dispatched manually. In this PR the existing `QueryEligibility` component was used to load the required data. Additionally, `EligibilityWarnings` component's appearance has been modified to show placeholders while data is being loaded. 

**Testing instructions:** 

1. Use a dotcom test site with a business plan.
2. Navigate to plugin detail page and click `Install`. 
3. Verify that correct errors and warnings are displayed. 
4. Navigate to Themes, and click on `Upload theme`.
5. Verify that correct errors and warnings are displayed.

_Note_: The easiest way to see the placeholder would be to delete local storage, and navigate directly to `design/upload/{siteSlug}`.

**Visual changes:**

* Eligibility warnings placeholder

![placeholder](https://cloud.githubusercontent.com/assets/1182160/21393355/4d79dc72-c794-11e6-87a3-6460a1c92cb6.png)

* Loaded errors and warnings

![loaded](https://cloud.githubusercontent.com/assets/1182160/21372154/cd3d509e-c715-11e6-9124-41396486af33.png)


