### PR TITLE
Reader: remove reader/refresh/stream feature flag

### DIFF
--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -12,14 +12,11 @@ import feedStreamFactory from 'lib/feed-stream-store';
 import { recordTrack } from 'reader/stats';
 import { ensureStoreLoading, trackPageLoad, trackUpdatesLoaded, trackScrollPage } from 'reader/controller-helper';
 import { renderWithReduxStore } from 'lib/react-helpers';
-import config from 'config';
 
 const analyticsPageTitle = 'Reader';
 
 export default {
 	search: function( context ) {
-		const isRefresh = config.isEnabled( 'reader/refresh/stream' );
-
 		var SearchStream = require( 'reader/search-stream' ),
 			basePath = '/read/search',
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Search',
@@ -30,7 +27,7 @@ export default {
 		if ( searchSlug ) {
 			store = feedStreamFactory( 'search:' + searchSlug );
 			ensureStoreLoading( store, context );
-		} else if ( isRefresh ) {
+		} else {
 			store = feedStreamFactory( 'custom_recs_posts_with_images' );
 			ensureStoreLoading( store, context );
 		}

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -179,15 +179,6 @@ export const ReaderSidebar = React.createClass( {
 							)
 						}
 
-						{ ! config.isEnabled( 'reader/refresh/stream' ) && (
-						<li className={ ReaderSidebarHelper.itemLinkClass( '/recommendations', this.props.path, { 'sidebar-streams__recommendations': true } ) }>
-							<a href="/recommendations">
-								<Gridicon icon="thumbs-up" size={ 24 } />
-								<span className="menu-link-text">{ this.props.translate( 'Recommendations' ) }</span>
-							</a>
-						</li> )
-						}
-
 						<li className={ ReaderSidebarHelper.itemLinkClass( '/activities/likes', this.props.path, { 'sidebar-activity__likes': true } ) }>
 							<a href="/activities/likes">
 								<Gridicon icon="star" size={ 24 } />

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -7,7 +7,6 @@ import url from 'url';
 /**
  * Internal Dependencies
  */
-import config from 'config';
 import resizeImageUrl from 'lib/resize-image-url';
 import DISPLAY_TYPES from './display-types';
 
@@ -38,10 +37,9 @@ import removeElementsBySelector from 'lib/post-normalizer/rule-content-remove-el
  * Module vars
  */
 const
-	isRefreshedStream = config.isEnabled( 'reader/refresh/stream' ),
 	READER_CONTENT_WIDTH = 720,
 	DISCOVER_FULL_BLEED_WIDTH = 1082,
-	PHOTO_ONLY_MIN_WIDTH = isRefreshedStream ? 480 : 570,
+	PHOTO_ONLY_MIN_WIDTH = 480,
 	DISCOVER_BLOG_ID = 53424024,
 	GALLERY_MIN_IMAGES = 4,
 	GALLERY_MIN_IMAGE_WIDTH = 350;
@@ -59,14 +57,6 @@ function discoverFullBleedImages( post, dom ) {
 	return post;
 }
 
-function getWordCount( post ) {
-	if ( ! post || ! post.better_excerpt_no_html ) {
-		return 0;
-	}
-
-	return ( post.better_excerpt_no_html.replace( /['";:,.?¿\-!¡]+/g, '' ).match( /\S+/g ) || [] ).length;
-}
-
 function getCharacterCount( post ) {
 	if ( ! post || ! post.better_excerpt_no_html ) {
 		return 0;
@@ -79,9 +69,7 @@ export function imageIsBigEnoughForGallery( image ) {
 	return image.width >= GALLERY_MIN_IMAGE_WIDTH;
 }
 
-const hasShortContent = isRefreshedStream
-	? post => getCharacterCount( post ) <= 100
-	: post => getWordCount( post ) < 100;
+const hasShortContent = post => getCharacterCount( post ) <= 100;
 
 /**
  * Attempt to classify the post into a display type

--- a/config/development.json
+++ b/config/development.json
@@ -134,7 +134,6 @@
 		"reader/list-management": false,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,
-		"reader/refresh/stream": true,
 		"reader/search": true,
 		"reader/start": true,
 		"reader/tags-with-elasticsearch": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -84,7 +84,6 @@
 		"press-this": true,
 		"preview-layout": true,
 		"reader": true,
-		"reader/refresh/stream": true,
 		"reader/related-posts": true,
 		"reader/search": true,
 		"resume-editing": true,

--- a/config/production.json
+++ b/config/production.json
@@ -86,7 +86,6 @@
 		"reader/full-errors": false,
 		"reader/start": true,
 		"reader/tags-with-elasticsearch": false,
-		"reader/refresh/stream": true,
 		"reader/related-posts": true,
 		"reader/search": true,
 		"resume-editing": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -90,7 +90,6 @@
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,
 		"reader/tags-with-elasticsearch": false,
-		"reader/refresh/stream": true,
 		"reader/start": true,
 		"reader/search": true,
 		"resume-editing": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -106,7 +106,6 @@
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/recommendations/posts": true,
-		"reader/refresh/stream": true,
 		"reader/related-posts": true,
 		"reader/search": true,
 		"reader/start": true,


### PR DESCRIPTION
Remove the `reader/refresh/stream` feature flag for the Reader Refresh now that everything has launched.

### To test

Make sure the build succeeds and the Reader works as expected, particularly Search:

http://calypso.localhost:3000/read/search

