### PR TITLE
Reader: video card support for VideoPress

### DIFF
--- a/client/lib/post-normalizer/rule-content-detect-media.js
+++ b/client/lib/post-normalizer/rule-content-detect-media.js
@@ -66,9 +66,9 @@ const detectImage = ( image ) => {
  * @returns {string} html src for an iframe that autoplays if from a source we understand.  else null;
  */
 const getAutoplayIframe = ( iframe ) => {
+	const KNOWN_SERVICES = [ 'youtube', 'vimeo', 'videopress' ];
 	const metadata = getEmbedMetadata( iframe.src );
-	if ( ( metadata && ( metadata.service === 'youtube' || metadata.service === 'vimeo' ) ||
-			iframe.src.indexOf( 'videopress.com' ) >= 0 ) ) {
+	if ( metadata && includes( KNOWN_SERVICES, metadata.service ) ) {
 		const autoplayIframe = iframe.cloneNode();
 		if ( autoplayIframe.src.indexOf( '?' ) === -1 ) {
 			autoplayIframe.src += '?autoplay=1';

--- a/client/lib/post-normalizer/rule-content-detect-media.js
+++ b/client/lib/post-normalizer/rule-content-detect-media.js
@@ -67,7 +67,8 @@ const detectImage = ( image ) => {
  */
 const getAutoplayIframe = ( iframe ) => {
 	const metadata = getEmbedMetadata( iframe.src );
-	if ( metadata && ( metadata.service === 'youtube' || metadata.service === 'vimeo' ) ) {
+	if ( ( metadata && ( metadata.service === 'youtube' || metadata.service === 'vimeo' ) ||
+			iframe.src.indexOf( 'videopress.com' ) >= 0 ) ) {
 		const autoplayIframe = iframe.cloneNode();
 		if ( autoplayIframe.src.indexOf( '?' ) === -1 ) {
 			autoplayIframe.src += '?autoplay=1';

--- a/client/state/reader/thumbnails/actions.js
+++ b/client/state/reader/thumbnails/actions.js
@@ -68,6 +68,11 @@ export const requestThumbnail = ( embedUrl ) => ( dispatch ) => {
 			dispatch( receiveThumbnail( embedUrl, thumbnailUrl ) );
 			return Promise.resolve();
 		}
+		case 'videopress': {
+			const thumbnailUrl = `https://thumbs.videopress.com/${ id }?c=1`;
+			dispatch( receiveThumbnail( embedUrl, thumbnailUrl ) );
+			return Promise.resolve();
+		}
 		case 'vimeo': {
 			debug( `Requesting thumbnail for embed ${ embedUrl }` );
 			dispatch( {
@@ -90,12 +95,6 @@ export const requestThumbnail = ( embedUrl ) => ( dispatch ) => {
 				} );
 		}
 		default:
-			if ( embedUrl.indexOf( 'videopress.com' ) >= 0 ) {
-				const regex = /embed\/(\w{8})/;
-				const videoId = embedUrl.match( regex )[ 1 ];
-				const thumbnailUrl = `https://thumbs.videopress.com/${ videoId }?c=1`;
-				dispatch( receiveThumbnail( embedUrl, thumbnailUrl ) );
-			}
 			dispatch( requestFailure( embedUrl, { type: UNSUPPORTED_EMBED } ) );
 			return Promise.resolve();
 	}

--- a/client/state/reader/thumbnails/actions.js
+++ b/client/state/reader/thumbnails/actions.js
@@ -90,6 +90,12 @@ export const requestThumbnail = ( embedUrl ) => ( dispatch ) => {
 				} );
 		}
 		default:
+			if ( embedUrl.indexOf( 'videopress.com' ) >= 0 ) {
+				const regex = /embed\/(\w{8})/;
+				const videoId = embedUrl.match( regex )[ 1 ];
+				const thumbnailUrl = `https://thumbs.videopress.com/${ videoId }?c=1`;
+				dispatch( receiveThumbnail( embedUrl, thumbnailUrl ) );
+			}
 			dispatch( requestFailure( embedUrl, { type: UNSUPPORTED_EMBED } ) );
 			return Promise.resolve();
 	}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1621,7 +1621,7 @@
       "version": "4.0.1"
     },
     "get-video-id": {
-      "version": "2.0.0"
+      "version": "2.1.0"
     },
     "getpass": {
       "version": "0.1.6",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "flag-icon-css": "2.3.0",
     "flux": "2.1.1",
     "fuse.js": "2.6.1",
-    "get-video-id": "2.0.0",
+    "get-video-id": "2.1.0",
     "hard-source-webpack-plugin": "0.0.42",
     "he": "0.5.0",
     "html-loader": "0.4.0",


### PR DESCRIPTION
An interesting thing to note is how I am generating thumbnails.
We have a thumbnail-generating-server located at https://thumbs.videopress.com that if given the param `c=1` it essentially grabs a single thumb for us (server is meant for generating spritesheets).

Todo:
 - [x] Add in VideoPress to `get-video-id` instead of inlining here.
 - [x] is this method of generating thumbnails for videopress ok?

To Test:
 - Load up https://calypso.live/read/feeds/36269469?branch=add/reader/support-for-videopress and confirm that behavior is expected and the thumbnails looks beautiful