### PR TITLE
Jetpack Settings: Specifically prepend /jetpack/v4 to wpcom.undocumented methods

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -73,7 +73,7 @@ Undocumented.prototype.accountRecoveryReset = function( userData ) {
  */
 Undocumented.prototype.getJetpackJumpstart = function( siteId, fn ) {
 	//@TODO: implement and test this endpoint, it's currently not working
-	return this.wpcom.req.get( { path: '/jetpack-blogs/' + siteId + '/rest-api/' }, { path: '/jumpstart/' }, fn );
+	return this.wpcom.req.get( { path: '/jetpack-blogs/' + siteId + '/rest-api/' }, { path: '/jetpack/v4/jumpstart/' }, fn );
 };
 
 /*
@@ -88,7 +88,7 @@ Undocumented.prototype.updateJetpackJumpstart = function( siteId, active, fn ) {
 	//@TODO: implement and test this endpoint, it's currently not working
 	return this.wpcom.req.post(
 		{ path: '/jetpack-blogs/' + siteId + '/rest-api/' },
-		{ path: '/jumpstart/', body: JSON.stringify( { active } ) },
+		{ path: '/jetpack/v4/jumpstart/', body: JSON.stringify( { active } ) },
 		fn
 	);
 };
@@ -141,7 +141,7 @@ Undocumented.prototype.jetpackModulesDeactivate = function( siteId, moduleSlug, 
  */
 Undocumented.prototype.fetchJetpackModuleSettings = function( siteId, moduleSlug, fn ) {
 	//@TODO: implement and test this endpoint, it's currently not working
-	return this.wpcom.req.get( { path: '/jetpack-blogs/' + siteId + '/rest-api/' }, { path: '/module/' + moduleSlug }, fn );
+	return this.wpcom.req.get( { path: '/jetpack-blogs/' + siteId + '/rest-api/' }, { path: '/jetpack/v4/module/' + moduleSlug }, fn );
 };
 
 /*
@@ -157,7 +157,7 @@ Undocumented.prototype.updateJetpackModuleSettings = function( siteId, moduleSlu
 	//@TODO: implement and test this endpoint, it's currently not working
 	return this.wpcom.req.post(
 		{ path: '/jetpack-blogs/' + siteId + '/rest-api/' },
-		{ path: '/module/' + moduleSlug, body: JSON.stringify( settings ) },
+		{ path: '/jetpack/v4/module/' + moduleSlug, body: JSON.stringify( settings ) },
 		fn
 	);
 };
@@ -251,7 +251,7 @@ Undocumented.prototype.getJetpackConnectionStatus = function( siteId, fn ) {
 	return this.wpcom.req.get( {
 		path: '/jetpack-blogs/' + siteId + '/rest-api/',
 		body: {
-			path: '/connection/'
+			path: '/jetpack/v4/connection/'
 		}
 	}, fn );
 };

--- a/client/state/jetpack-settings/connection/test/actions.js
+++ b/client/state/jetpack-settings/connection/test/actions.js
@@ -31,7 +31,7 @@ describe( 'actions', () => {
 					.persist()
 					.get( '/rest/v1.1/jetpack-blogs/' + siteId + '/rest-api/' )
 					.query( {
-						path: '/connection/'
+						path: '/jetpack/v4/connection/'
 					} )
 					.reply( 200, { data: status }, {
 						'Content-Type': 'application/json'
@@ -69,7 +69,7 @@ describe( 'actions', () => {
 					.persist()
 					.get( '/rest/v1.1/jetpack-blogs/' + siteId + '/rest-api/' )
 					.query( {
-						path: '/connection/'
+						path: '/jetpack/v4/connection/'
 					} )
 					.reply( 400, {
 						message: 'Invalid request.'

--- a/client/state/jetpack-settings/jumpstart/test/actions.js
+++ b/client/state/jetpack-settings/jumpstart/test/actions.js
@@ -33,7 +33,7 @@ describe( 'actions', () => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
 					.post( '/rest/v1.1/jetpack-blogs/' + siteId + '/rest-api/', {
-						path: '/jumpstart/',
+						path: '/jetpack/v4/jumpstart/',
 						body: JSON.stringify( { active: true } )
 					} )
 					.reply( 200, {}, {
@@ -65,7 +65,7 @@ describe( 'actions', () => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
 					.post( '/rest/v1.1/jetpack-blogs/' + siteId + '/rest-api/', {
-						path: '/jumpstart/',
+						path: '/jetpack/v4/jumpstart/',
 						body: JSON.stringify( { active: true } )
 					} )
 					.reply( 400, {
@@ -93,7 +93,7 @@ describe( 'actions', () => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
 					.post( '/rest/v1.1/jetpack-blogs/' + siteId + '/rest-api/', {
-						path: '/jumpstart/',
+						path: '/jetpack/v4/jumpstart/',
 						body: JSON.stringify( { active: false } )
 					} )
 					.reply( 200, {}, {
@@ -125,7 +125,7 @@ describe( 'actions', () => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
 					.post( '/rest/v1.1/jetpack-blogs/' + siteId + '/rest-api/', {
-						path: '/jumpstart/',
+						path: '/jetpack/v4/jumpstart/',
 						body: JSON.stringify( { active: false } )
 					} )
 					.reply( 400, {
@@ -155,7 +155,7 @@ describe( 'actions', () => {
 					.persist()
 					.get( '/rest/v1.1/jetpack-blogs/' + siteId + '/rest-api/' )
 					.query( {
-						path: '/jumpstart/'
+						path: '/jetpack/v4/jumpstart/'
 					} )
 					.reply( 200, {
 						status
@@ -195,7 +195,7 @@ describe( 'actions', () => {
 					.persist()
 					.get( '/rest/v1.1/jetpack-blogs/' + siteId + '/rest-api/' )
 					.query( {
-						path: '/jumpstart/'
+						path: '/jetpack/v4/jumpstart/'
 					} )
 					.reply( 400, {
 						message: 'Invalid request.'

--- a/client/state/jetpack-settings/module-settings/test/actions.js
+++ b/client/state/jetpack-settings/module-settings/test/actions.js
@@ -37,7 +37,7 @@ describe( 'actions', () => {
 					.persist()
 					.get( '/rest/v1.1/jetpack-blogs/' + siteId + '/rest-api/' )
 					.query( {
-						path: '/module/' + moduleSlug
+						path: '/jetpack/v4/module/' + moduleSlug
 					} )
 					.reply( 200, { data: settings }, {
 						'Content-Type': 'application/json'
@@ -78,7 +78,7 @@ describe( 'actions', () => {
 					.persist()
 					.get( '/rest/v1.1/jetpack-blogs/' + siteId + '/rest-api/' )
 					.query( {
-						path: '/module/' + moduleSlug
+						path: '/jetpack/v4/module/' + moduleSlug
 					} )
 					.reply( 400, {
 						message: 'Invalid request.'
@@ -106,7 +106,7 @@ describe( 'actions', () => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
 					.post( '/rest/v1.1/jetpack-blogs/' + siteId + '/rest-api/', {
-						path: '/module/' + moduleSlug,
+						path: '/jetpack/v4/module/' + moduleSlug,
 						body: JSON.stringify( settings )
 					} )
 					.reply( 200, {
@@ -144,7 +144,7 @@ describe( 'actions', () => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
 					.post( '/rest/v1.1/jetpack-blogs/' + siteId + '/rest-api/', {
-						path: '/module/' + moduleSlug,
+						path: '/jetpack/v4/module/' + moduleSlug,
 						body: JSON.stringify( settings )
 					} )
 					.reply( 400, {


### PR DESCRIPTION
This PR updates the Jetpack Settings undocumented methods to specifically prefix the `path` with `/jetpack/v4/`. This change is necessary because of the recent changes in the proxy endpoint.

This was suggested by @nylen in D3588-code, and implemented in the proxy endpoint. This will allow us to hit all REST API endpoints of the Jetpack site, instead of just the Jetpack REST API endpoints.

To test:

* Get this branch going locally.
* Verify all tests pass: `npm run test-client client/state/jetpack-settings/`