### PR TITLE
Taxonomies: Open term posts in WebPreview when possible

### DIFF
--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -162,7 +162,7 @@ class TaxonomyManagerListItem extends Component {
 					}
 					{ ! isJetpack &&
 						<WithPreviewProps
-								href={ this.getTaxonomyLink() }
+								url={ this.getTaxonomyLink() }
 								isPreviewable={ this.props.isPreviewable }>
 							{ ( props ) =>
 								<PopoverMenuItem { ...props }

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -10,36 +10,20 @@ import { get, isUndefined } from 'lodash';
 /**
  * Internal dependencies
  */
-import EllipsisMenu from 'components/ellipsis-menu';
-import PopoverMenuItem from 'components/popover/menu-item';
-import PopoverMenuSeparator from 'components/popover/menu-separator';
-import Gridicon from 'components/gridicon';
 import Count from 'components/count';
 import Dialog from 'components/dialog';
+import EllipsisMenu from 'components/ellipsis-menu';
+import Gridicon from 'components/gridicon';
+import PopoverMenuItem from 'components/popover/menu-item';
+import PopoverMenuSeparator from 'components/popover/menu-separator';
+import Tooltip from 'components/tooltip';
+import WithPreviewProps from 'components/web-preview/with-preview-props';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSettings } from 'state/site-settings/selectors';
 import { getSite, isJetpackSite } from 'state/sites/selectors';
 import { decodeEntities } from 'lib/formatting';
 import { deleteTerm } from 'state/terms/actions';
 import { saveSiteSettings } from 'state/site-settings/actions';
-import { setLayoutFocus } from 'state/ui/layout-focus/actions';
-import { setPreviewUrl, setPreviewType } from 'state/ui/preview/actions';
-import { setUrlScheme } from 'lib/url';
-import Tooltip from 'components/tooltip';
-
-const ViewTaxonomyMenuItem = ( { href, onClick, isPreviewable, children } ) => {
-	const props = {
-		href: isPreviewable ? undefined : href,
-		target: isPreviewable ? undefined : '_blank',
-		icon: isPreviewable ? 'visible' : 'external',
-		onClick: isPreviewable ? onClick : undefined,
-	};
-	return (
-		<PopoverMenuItem { ...props } rel="noopener noreferrer">
-			{ children }
-		</PopoverMenuItem>
-	);
-};
 
 class TaxonomyManagerListItem extends Component {
 	static propTypes = {
@@ -129,16 +113,6 @@ class TaxonomyManagerListItem extends Component {
 		return decodeEntities( term.name ) || translate( 'Untitled' );
 	};
 
-	viewTaxonomyPosts = () => {
-		// Avoid Mixed Content errors by forcing HTTPS, which is a requirement
-		// of previewable sites anyway. 10198-gh-wp-calypso
-		const url = setUrlScheme( this.getTaxonomyLink(), 'https' );
-
-		this.props.setPreviewUrl( url );
-		this.props.setPreviewType( 'site-preview' );
-		this.props.setLayoutFocus( 'preview' );
-	};
-
 	render() {
 		const { canSetAsDefault, isDefault, onClick, term, translate, isJetpack } = this.props;
 		const name = this.getName();
@@ -187,12 +161,17 @@ class TaxonomyManagerListItem extends Component {
 						</PopoverMenuItem>
 					}
 					{ ! isJetpack &&
-						<ViewTaxonomyMenuItem
+						<WithPreviewProps
 								href={ this.getTaxonomyLink() }
-								onClick={ this.viewTaxonomyPosts }
 								isPreviewable={ this.props.isPreviewable }>
-							{ translate( 'View Posts' ) }
-						</ViewTaxonomyMenuItem>
+							{ ( props ) =>
+								<PopoverMenuItem { ...props }
+										icon={ this.props.isPreviewable
+											? 'visible' : 'external' }>
+									{ translate( 'View Posts' ) }
+								</PopoverMenuItem>
+							}
+						</WithPreviewProps>
 					}
 					{ canSetAsDefault && ! isDefault && <PopoverMenuSeparator /> }
 					{ canSetAsDefault && ! isDefault &&
@@ -235,8 +214,5 @@ export default connect(
 	{
 		deleteTerm,
 		saveSiteSettings,
-		setLayoutFocus,
-		setPreviewType,
-		setPreviewUrl,
 	}
 )( localize( TaxonomyManagerListItem ) );

--- a/client/components/web-preview/README.md
+++ b/client/components/web-preview/README.md
@@ -8,3 +8,43 @@ This component facilitates the display of iframed content. See the `propTypes` f
 	onClose={ this.hidePreview }
 	previewUrl={ this.getUrlToIframe() } >
 ```
+
+* * *
+
+WithPreviewProps
+----------------
+
+This is a helper [function-as-children] component responsible for computing props to be used to create a _link_ to a given URL. The point, however, is that this will attempt to render that resource inside WebPreview if the right conditions (_cf._ below) are met. If they aren't met, the fallback is to treat the link as external and open it in a new window.
+
+### Constraints
+
+Calypso is meant to be run over HTTPS when in production. Since WebPreview uses iframes internally, this requires that any URL to be loaded in the iframe be also loaded **via HTTPS** in order to avoid Mixed Content browser errors. Furthermore, WebPreview is designed for **viewing internal resources** — _e.g.,_ the front end of a site — and not the broader Web.
+
+### Usage
+
+With those constraints in mind, usage is the following:
+
+```js
+<WithPreviewProps
+		url={ myFrontEndPreview }
+		isPreviewable={ isMySitePreviewable }>
+	{ ( props ) =>
+		<Button { ...props } icon={ isMySitePreviewable ? 'visible' : 'external' }>
+			View Site
+		</Button>
+	}
+</WithPreviewProps>
+```
+
+`isPreviewable` should be a boolean to determine whether the URL should be loaded in WebPreview or externally. Bear in mind that not all front-end links are previewable — Jetpack sites, for instance, may not be supported for a number of reasons, including absent HTTPS support. As of this writing, a suggestion is to rely on the `getSite` (state/sites/selectors) selector, which relies on `lib/site/computed-attributes` to return a `is_previewable` attribute:
+
+```js
+const site = getSite( state, siteId );
+const isPreviewable = get( site, 'is_previewable' );
+
+<WithPreviewProps url={ url } isPreviewable={ isPreviewable }>
+	{ ( props ) => … }
+</WithPreviewProps>
+```
+
+[function-as-children]: https://medium.com/merrickchristensen/function-as-child-components-5f3920a9ace9

--- a/client/components/web-preview/with-preview-props.jsx
+++ b/client/components/web-preview/with-preview-props.jsx
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { setLayoutFocus } from 'state/ui/layout-focus/actions';
+import { setPreviewUrl, setPreviewType } from 'state/ui/preview/actions';
+import { setUrlScheme } from 'lib/url';
+
+class WithPreviewProps extends Component {
+	static propTypes = {
+		href: PropTypes.string.isRequired,
+		isPreviewable: PropTypes.bool.isRequired,
+		children: PropTypes.func.isRequired,
+		dispatch: PropTypes.func.isRequired,
+	}
+
+	render() {
+		const { children, ...rest } = this.props;
+		return children( makeProps( rest ) );
+	}
+}
+
+function makeProps( { href, isPreviewable, dispatch } ) {
+	return isPreviewable
+		? { onClick: openWebPreview.bind( null, href, dispatch ) }
+		: {
+			href,
+			target: '_blank',
+			rel: 'noopener noreferrer',
+		};
+}
+
+function openWebPreview( href, dispatch ) {
+	// Avoid Mixed Content errors by forcing HTTPS, which is a requirement
+	// of previewable sites anyway. 10198-gh-wp-calypso
+	const url = setUrlScheme( href, 'https' );
+	dispatch( setPreviewUrl( url ) );
+	dispatch( setPreviewType( 'site-preview' ) );
+	dispatch( setLayoutFocus( 'preview' ) );
+}
+
+export default connect()( WithPreviewProps );

--- a/client/components/web-preview/with-preview-props.jsx
+++ b/client/components/web-preview/with-preview-props.jsx
@@ -13,7 +13,7 @@ import { setUrlScheme } from 'lib/url';
 
 class WithPreviewProps extends Component {
 	static propTypes = {
-		href: PropTypes.string.isRequired,
+		url: PropTypes.string.isRequired,
 		isPreviewable: PropTypes.bool.isRequired,
 		children: PropTypes.func.isRequired,
 		dispatch: PropTypes.func.isRequired,
@@ -25,21 +25,20 @@ class WithPreviewProps extends Component {
 	}
 }
 
-function makeProps( { href, isPreviewable, dispatch } ) {
+function makeProps( { url, isPreviewable, dispatch } ) {
 	return isPreviewable
-		? { onClick: openWebPreview.bind( null, href, dispatch ) }
+		? { onClick: openWebPreview.bind( null, url, dispatch ) }
 		: {
-			href,
+			href: url,
 			target: '_blank',
 			rel: 'noopener noreferrer',
 		};
 }
 
-function openWebPreview( href, dispatch ) {
+function openWebPreview( url, dispatch ) {
 	// Avoid Mixed Content errors by forcing HTTPS, which is a requirement
 	// of previewable sites anyway. 10198-gh-wp-calypso
-	const url = setUrlScheme( href, 'https' );
-	dispatch( setPreviewUrl( url ) );
+	dispatch( setPreviewUrl( setUrlScheme( url, 'https' ) ) );
 	dispatch( setPreviewType( 'site-preview' ) );
 	dispatch( setLayoutFocus( 'preview' ) );
 }


### PR DESCRIPTION
If a site has the `is_previewable` computed attribute, use WebPreview. Notably, this entails HTTPS support for that site. Otherwise, fall back to opening a new window.

Props @youknowriad for the original implementation in #10124. This is a second attempt at leveraging WebPreview, see issue #10198.

Closes #10114 

![terms-preview](https://cloud.githubusercontent.com/assets/150562/21389257/9ad561d8-c778-11e6-97bd-673723ab3d3d.gif)

# To test

- Make sure that a **web preview** is opened for wordpress.com sites, including those with custom domains.
- Make sure that no errors are thrown when a web preview is opened.
- Make sure that a **new window** is opened in other cases (Jetpack site, VIP)