### PR TITLE
Date Picker: Update "today" marker and color contrast for better accessibility

### DIFF
--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -32,12 +32,12 @@ $date-picker_nav_button_size: 20px;
 	}
 
 	&:hover {
-		color: lighten( $gray, 10% );
+		color: darken( $gray, 10% );
 	}
 }
 
 .date-picker__day_event {
-	border-color: lighten( $gray, 20 );
+	border-color: lighten( $gray, 10% );
 }
 
 .date-picker__day-text {
@@ -131,7 +131,6 @@ $date-picker_nav_button_size: 20px;
 
 .DayPicker-Caption {
 	display: table-caption;
-	color: $gray;
 	text-align: center;
 	height: $date-picker_caption_height;
 	line-height: $date-picker_caption_height;
@@ -162,12 +161,13 @@ $date-picker_nav_button_size: 20px;
 	font-size: 11px;
 	text-align: center;
 	font-weight: 600;
-	color: lighten( $gray, 20% );
+	color: darken( $gray, 20% );
 	text-transform: uppercase;
 
 	abbr {
 		border-bottom: none;
 		cursor: auto;
+		text-decoration: none;
 	}
 }
 
@@ -189,7 +189,6 @@ $date-picker_nav_button_size: 20px;
 	cursor: pointer;
 	font-size: 11px;
 	font-weight: 600;
-	color: $gray;
 }
 
 .DayPicker--interactionDisabled .DayPicker-Day {
@@ -198,18 +197,17 @@ $date-picker_nav_button_size: 20px;
 
 // Modifiers
 
-.DayPicker-Day--today {
-	&::before {
-		content: '';
-		box-sizing: border-box;
-		width: 24px;
-		height: 24px;
-		position: absolute;
-			left: 50%;
-			top: 50%;
-		margin: -12px 0 0 -12px;
-		border: solid 1px $orange-jazzy;
-		border-radius: 50%;
+.DayPicker-Day--today .date-picker__day:not(.is-selected) {
+	color: $white;
+
+	.date-picker__day-selected {
+		background-color: $gray-dark;
+		opacity: 1;
+		transform: scale( 1 );
+	}
+
+	&:hover .date-picker__day-selected {
+		background-color: darken( $gray, 20% );
 	}
 }
 
@@ -227,7 +225,7 @@ $date-picker_nav_button_size: 20px;
 	font-weight: normal;
 
 	.date-picker__day {
-		color: lighten( $gray, 20% );
+		color: $gray;
 	}
 }
 

--- a/client/components/post-schedule/style.scss
+++ b/client/components/post-schedule/style.scss
@@ -8,7 +8,6 @@
 	position: absolute;
 	z-index: z-index( '.popover', '.post-schedule__header' );
 	top: 47px;
-	color: $gray;
 	font-size: 18px;
 	font-weight: 300;
 	width: 80%;
@@ -26,6 +25,16 @@
 		padding-left: 16px;
 		padding-right: 16px;
 		border: 0;
+		color: $gray-dark;
+	}
+
+	::placeholder {
+		color: $gray-dark;
+	}
+
+	::-moz-placeholder {
+		color: $gray-dark;
+		opacity: 1;
 	}
 }
 
@@ -38,8 +47,7 @@
 	position: relative;
 	text-align: center;
 	font-size: 12px;
-	color: lighten( $gray, 10% );
-	height: 20;
+	height: 20px;
 	line-height: 20px;
 	padding: 0 5px;
 	margin-left: 10px;
@@ -89,7 +97,6 @@ input.post-schedule__clock_time {
 	width: 42px;
 	text-align: center;
 	padding: 0;
-	color: lighten( $gray, 10% );
 	font-size: 12px;
 }
 


### PR DESCRIPTION
Raised by @nickmomrik

> The red/orange color to highlight the current day always makes me double-take, thinking I’ve missed today. … That type of color is typically for an alert, error, or action required.

I’d agree and suggest to update it to a little more clearer highlight. There seems to be a design pattern that indicates “current” — light text on darker background.

![highlight](https://cloud.githubusercontent.com/assets/908665/21390510/3608211c-c77f-11e6-8259-6c367fcb6370.jpg)

By following this pattern, this is my suggestion:

![current-date-before-after](https://cloud.githubusercontent.com/assets/908665/21390524/3f8e6f66-c77f-11e6-99d2-04df55e5a889.jpg)

For hover state:

![current-date-hover-before-after](https://cloud.githubusercontent.com/assets/908665/21390529/477c6d54-c77f-11e6-9589-a1fd8a561a2e.jpg)

/cc @folletto , @mtias

