### PR TITLE
Domains: Update Domain Mapping Purchase Nameserver message	

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/domain-mapping-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/domain-mapping-details.jsx
@@ -2,21 +2,23 @@
  * External dependencies
  */
 import React from 'react';
-import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import { localize } from 'i18n-calypso';
 import PurchaseDetail from 'components/purchase-detail';
 import supportUrls from 'lib/url/support';
 
-const DomainMappingDetails = ( { domain, registrarSupportUrl } ) => {
-	const registrarSupportLink = registrarSupportUrl ? <a target="_blank" rel="noopener noreferrer" href={ registrarSupportUrl } /> : <span />;
+const DomainMappingDetails = ( { domain, registrarSupportUrl, translate } ) => {
+	const registrarSupportLink = registrarSupportUrl
+		? <a target="_blank" rel="noopener noreferrer" href={ registrarSupportUrl } />
+		: <span />;
 	const description = (
 		<div>
 			<p>
 				{
-					i18n.translate( 'The domain {{em}}%(domain)s{{/em}} still has to be configured to work with WordPress.com.', {
+					translate( 'Your domain {{em}}%(domain)s{{/em}} has to be configured to work with WordPress.com.', {
 						args: { domain },
 						components: { em: <em /> }
 					} )
@@ -24,9 +26,16 @@ const DomainMappingDetails = ( { domain, registrarSupportUrl } ) => {
 			</p>
 			<p>
 				{
-					i18n.translate(
-						'You will need to log into {{registrarSupportLink}}your registrar\'s site{{/registrarSupportLink}} ' +
-						'and change the "Name Servers" to:',
+					translate(
+						'If you already did this yourself, or if the domain was already configured for you, no further action is needed.'
+					)
+				}
+			</p>
+			<p>
+				{
+					translate(
+						'If not, you will need to log into {{registrarSupportLink}}your registrar\'s site{{/registrarSupportLink}} ' +
+						'(where you purchased the domain originally) and change the "Name Servers" to:',
 						{
 							components: {
 								registrarSupportLink: registrarSupportLink
@@ -40,7 +49,11 @@ const DomainMappingDetails = ( { domain, registrarSupportUrl } ) => {
 				<li>ns2.wordpress.com</li>
 				<li>ns3.wordpress.com</li>
 			</ul>
-			<p>{ i18n.translate( 'Once you make the change, just wait a few hours and the domain should start loading your site automatically.' ) }</p>
+			<p>{
+				translate(
+					'Once you make the change, just wait a few hours and the domain should start loading your site automatically.'
+				)
+			}</p>
 		</div>
 	);
 
@@ -48,16 +61,15 @@ const DomainMappingDetails = ( { domain, registrarSupportUrl } ) => {
 		<div className="checkout-thank-you__domain-mapping-details">
 			<PurchaseDetail
 				icon="cog"
-				title={ i18n.translate( 'Finish setting up your domain' ) }
+				title={ translate( 'Finish setting up your domain' ) }
 				description={ description }
-				buttonText={ i18n.translate( 'Learn more' ) }
+				buttonText={ translate( 'Learn more' ) }
 				href={ supportUrls.MAP_EXISTING_DOMAIN }
 				target="_blank"
 				rel="noopener noreferrer"
-				requiredText={ i18n.translate( 'Almost done! One step remaining…' ) }
 				isRequired />
 		</div>
 	);
 };
 
-export default DomainMappingDetails;
+export default localize( DomainMappingDetails );

--- a/client/my-sites/upgrades/checkout-thank-you/domain-mapping-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/domain-mapping-details.jsx
@@ -61,7 +61,6 @@ const DomainMappingDetails = ( { domain, registrarSupportUrl, translate } ) => {
 		<div className="checkout-thank-you__domain-mapping-details">
 			<PurchaseDetail
 				icon="cog"
-				title={ translate( 'Finish setting up your domain' ) }
 				description={ description }
 				buttonText={ translate( 'Learn more' ) }
 				href={ supportUrls.MAP_EXISTING_DOMAIN }

--- a/client/my-sites/upgrades/checkout-thank-you/header.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/header.jsx
@@ -64,7 +64,7 @@ const CheckoutThankYouHeader = React.createClass( {
 		if ( isDomainMapping( this.props.primaryPurchase ) ) {
 			return this.translate(
 				'Your domain {{strong}}%(domainName)s{{/strong}} was added to your site. ' +
-				"But it isn't working yet – follow the instructions below to complete the set up.", {
+				'It may take a little while to start working – see below for more information.', {
 					args: { domainName: this.props.primaryPurchase.meta },
 					components: { strong: <strong /> }
 				}

--- a/client/my-sites/upgrades/checkout-thank-you/header.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/header.jsx
@@ -17,32 +17,28 @@ import {
 	isSiteRedirect
 } from 'lib/products-values';
 import Gridicon from 'components/gridicon';
+import { localize } from 'i18n-calypso';
 
-const CheckoutThankYouHeader = React.createClass( {
-	propTypes: {
-		isDataLoaded: React.PropTypes.bool.isRequired,
-		primaryPurchase: React.PropTypes.object
-	},
-
+class CheckoutThankYouHeader extends React.Component {
 	getHeading() {
 		if ( ! this.props.isDataLoaded ) {
-			return this.translate( 'Loading…' );
+			return this.props.translate( 'Loading…' );
 		}
 
 		if ( this.props.primaryPurchase && isChargeback( this.props.primaryPurchase ) ) {
-			return this.translate( 'Thank you!' );
+			return this.props.translate( 'Thank you!' );
 		}
 
-		return this.translate( 'Thank you for your purchase!' );
-	},
+		return this.props.translate( 'Thank you for your purchase!' );
+	}
 
 	getText() {
 		if ( ! this.props.isDataLoaded || ! this.props.primaryPurchase ) {
-			return this.translate( 'You will receive an email confirmation shortly.' );
+			return this.props.translate( 'You will receive an email confirmation shortly.' );
 		}
 
 		if ( isPlan( this.props.primaryPurchase ) ) {
-			return this.translate(
+			return this.props.translate(
 				'Your site is now on the {{strong}}%(productName)s{{/strong}} plan. ' +
 				"It's doing somersaults in excitement!", {
 					args: { productName: this.props.primaryPurchase.productName },
@@ -52,7 +48,7 @@ const CheckoutThankYouHeader = React.createClass( {
 		}
 
 		if ( isDomainRegistration( this.props.primaryPurchase ) ) {
-			return this.translate(
+			return this.props.translate(
 				'Your new domain {{strong}}%(domainName)s{{/strong}} is ' +
 				'being set up. Your site is doing somersaults in excitement!', {
 					args: { domainName: this.props.primaryPurchase.meta },
@@ -62,7 +58,7 @@ const CheckoutThankYouHeader = React.createClass( {
 		}
 
 		if ( isDomainMapping( this.props.primaryPurchase ) ) {
-			return this.translate(
+			return this.props.translate(
 				'Your domain {{strong}}%(domainName)s{{/strong}} was added to your site. ' +
 				'It may take a little while to start working – see below for more information.', {
 					args: { domainName: this.props.primaryPurchase.meta },
@@ -72,7 +68,7 @@ const CheckoutThankYouHeader = React.createClass( {
 		}
 
 		if ( isGoogleApps( this.props.primaryPurchase ) ) {
-			return this.translate(
+			return this.props.translate(
 				'Your domain {{strong}}%(domainName)s{{/strong}} is now set up to use G Suite. ' +
 				"It's doing somersaults in excitement!", {
 					args: { domainName: this.props.primaryPurchase.meta },
@@ -83,7 +79,7 @@ const CheckoutThankYouHeader = React.createClass( {
 
 		if ( isGuidedTransfer( this.props.primaryPurchase ) ) {
 			if ( typeof this.props.primaryPurchase.meta === 'string' ) {
-				return this.translate( 'The guided transfer for {{strong}}%(siteName)s{{/strong}} ' +
+				return this.props.translate( 'The guided transfer for {{strong}}%(siteName)s{{/strong}} ' +
 					'will begin very soon. We will be in touch with you via email.', {
 						args: { siteName: this.props.primaryPurchase.meta },
 						components: { strong: <strong /> },
@@ -91,7 +87,7 @@ const CheckoutThankYouHeader = React.createClass( {
 				);
 			}
 
-			return this.translate( 'The guided transfer for your site will ' +
+			return this.props.translate( 'The guided transfer for your site will ' +
 				'begin very soon. We will be in touch with you via email.', {
 					components: { strong: <strong /> },
 				}
@@ -99,7 +95,7 @@ const CheckoutThankYouHeader = React.createClass( {
 		}
 
 		if ( isSiteRedirect( this.props.primaryPurchase ) ) {
-			return this.translate(
+			return this.props.translate(
 				'Your site is now redirecting to {{strong}}%(domainName)s{{/strong}}. ' +
 				"It's doing somersaults in excitement!", {
 					args: { domainName: this.props.primaryPurchase.meta },
@@ -109,10 +105,10 @@ const CheckoutThankYouHeader = React.createClass( {
 		}
 
 		if ( isChargeback( this.props.primaryPurchase ) ) {
-			return this.translate( 'Your chargeback fee is paid. Your site is doing somersaults in excitement!' );
+			return this.props.translate( 'Your chargeback fee is paid. Your site is doing somersaults in excitement!' );
 		}
 
-		return this.translate(
+		return this.props.translate(
 			"You will receive an email confirmation shortly for your purchase of {{strong}}%(productName)s{{/strong}}. What's next?", {
 				args: {
 					productName: this.props.primaryPurchase.productName
@@ -122,7 +118,7 @@ const CheckoutThankYouHeader = React.createClass( {
 				}
 			}
 		);
-	},
+	}
 
 	render() {
 		const classes = {
@@ -150,6 +146,11 @@ const CheckoutThankYouHeader = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
-export default CheckoutThankYouHeader;
+CheckoutThankYouHeader.propTypes = {
+	isDataLoaded: React.PropTypes.bool.isRequired,
+	primaryPurchase: React.PropTypes.object
+};
+
+export default localize( CheckoutThankYouHeader );


### PR DESCRIPTION
Change the Thank You page for domain mapping to take into account the case when the NS are already setup.

Test:
1. Map a domain
2. See different message:


Before:
![4e12029c-baea-11e6-9918-07c99093a399](https://cloud.githubusercontent.com/assets/1103398/21393371/5e1d46f4-c794-11e6-833c-569ff80d509f.png)

After:
![screenshot from 2016-12-21 15-39-11](https://cloud.githubusercontent.com/assets/1103398/21393326/3a0ad0a6-c794-11e6-8839-31de870c0f0a.png)
