### PR TITLE
Signup: Remove Survey step from Signup flows and remove the AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -62,15 +62,6 @@ module.exports = {
 		defaultVariation: 'showPopover',
 		allowExistingUsers: false,
 	},
-	domainDotBlogSubdomain: {
-		datestamp: '20161208',
-		variations: {
-			excludeDotBlogSubdomain: 50,
-			includeDotBlogSubdomain: 50,
-		},
-		defaultVariation: 'excludeDotBlogSubdomain',
-		allowAnyLocale: true,
-	},
 	designShowcaseWelcomeTour: {
 		datestamp: '20161206',
 		variations: {
@@ -107,16 +98,6 @@ module.exports = {
 		},
 		defaultVariation: 'showPlansAfterAuth',
 		allowExistingUsers: true
-	},
-
-	noSurveyStep: {
-		datestamp: '20161202',
-		variations: {
-			showSurveyStep: 50,
-			hideSurveyStep: 50,
-		},
-		defaultVariation: 'showSurveyStep',
-		allowAnyLocale: true,
 	},
 
 	siteTitleTour: {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -58,7 +58,7 @@ const flows = {
 	},
 
 	business: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'user' ],
+		steps: [ 'design-type', 'themes', 'domains', 'user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/business/' + dependencies.siteSlug;
 		},
@@ -70,7 +70,7 @@ const flows = {
 	},
 
 	premium: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'user' ],
+		steps: [ 'design-type', 'themes', 'domains', 'user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/premium/' + dependencies.siteSlug;
 		},
@@ -82,7 +82,7 @@ const flows = {
 	},
 
 	free: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'user' ],
+		steps: [ 'design-type', 'themes', 'domains', 'user' ],
 		destination: getSiteDestination,
 		description: 'Create an account and a blog and default to the free plan.',
 		lastModified: '2016-06-02'
@@ -103,6 +103,13 @@ const flows = {
 	},
 
 	main: {
+		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		destination: getSiteDestination,
+		description: 'The current best performing flow in AB tests',
+		lastModified: '2016-05-23'
+	},
+
+	surveystep: {
 		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'The current best performing flow in AB tests',
@@ -110,28 +117,28 @@ const flows = {
 	},
 
 	sitetitle: {
-		steps: [ 'survey', 'site-title', 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'site-title', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'The current best performing flow in AB tests',
 		lastModified: '2016-05-23'
 	},
 
 	website: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'This flow was originally used for the users who clicked "Create Website" on the two-button homepage. It is now linked to from the default homepage CTA as the main flow was slightly behind given translations.',
 		lastModified: '2016-05-23'
 	},
 
 	blog: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'This flow was originally used for the users who clicked "Create Blog" on the two-button homepage. It is now used from blog-specific landing pages so that verbiage in survey steps refers to "blog" instead of "website".',
 		lastModified: '2016-05-23'
 	},
 
 	personal: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'user' ],
+		steps: [ 'design-type', 'themes', 'domains', 'user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/personal/' + dependencies.siteSlug;
 		},
@@ -154,21 +161,21 @@ const flows = {
 	},
 
 	'delta-blog': {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'A copy of the `blog` flow for the Delta email campaigns. Half of users who go through this flow receive a blogging-specific drip email series.',
 		lastModified: '2016-03-09'
 	},
 
 	'delta-site': {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'A copy of the `website` flow for the Delta email campaigns. Half of users who go through this flow receive a website-specific drip email series.',
 		lastModified: '2016-03-09'
 	},
 
 	desktop: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getPostsDestination,
 		description: 'Signup flow for desktop app',
 		lastModified: '2016-05-30'
@@ -182,7 +189,7 @@ const flows = {
 	},
 
 	pressable: {
-		steps: [ 'survey', 'design-type-with-store', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'design-type-with-store', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'Signup flow for testing the pressable-store step',
 		lastModified: '2016-06-27'
@@ -209,7 +216,7 @@ const flows = {
 	},
 
 	'domain-first': {
-		steps: [ 'domains', 'survey', 'design-type', 'themes', 'plans', 'user' ],
+		steps: [ 'domains', 'design-type', 'themes', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'An experimental approach for WordPress.com/domains',
 		lastModified: '2016-12-20'
@@ -328,16 +335,15 @@ const Flows = {
 		}
 
 		/**
-		 * This is called on Signup start (page initialization),
-		 * before the steps are rendered. Used if there is a need
-		 * to filter the first step in the flow.
+		 * If there is need to test the first step in a flow,
+		 * the best way to do it is to check for:
+		 *
+		 * 	if ( '' === stepName ) { ... }
+		 *
+		 * This will be fired at the beginning of the signup flow.
 		 */
-		if ( '' === stepName ) {
-			abtest( 'noSurveyStep' );
-		}
-
 		if ( 'main' === flowName ) {
-			if ( 'survey' === stepName ) {
+			if ( '' === stepName ) {
 				abtest( 'siteTitleStep' );
 			}
 		}
@@ -359,13 +365,8 @@ const Flows = {
 		// Only do this on the main flow
 		if ( 'main' === flowName ) {
 			if ( getABTestVariation( 'siteTitleStep' ) === 'showSiteTitleStep' ) {
-				return Flows.insertStepIntoFlow( 'site-title', flow, 'survey' );
+				return Flows.insertStepIntoFlow( 'site-title', flow );
 			}
-		}
-
-		// no matter the flow
-		if ( getABTestVariation( 'noSurveyStep' ) === 'hideSurveyStep' ) {
-			return Flows.removeStepFromFlow( 'survey', flow );
 		}
 
 		return flow;

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -22,8 +22,6 @@ var StepWrapper = require( 'signup/step-wrapper' ),
 	analyticsMixin = require( 'lib/mixins/analytics' ),
 	signupUtils = require( 'signup/utils' );
 
-import { abtest, getABTestVariation } from 'lib/abtest';
-
 import Notice from 'components/notice';
 
 const registerDomainAnalytics = analyticsMixin( 'registerDomain' ),
@@ -152,12 +150,7 @@ const DomainsStep = React.createClass( {
 
 	domainForm: function() {
 		const initialState = this.props.step ? this.props.step.domainForm : this.state.domainForm;
-
-		const includeDotBlogSubdomain = ( this.props.flowName === 'subdomain' ) ||
-			(
-				getABTestVariation( 'noSurveyStep' ) === 'showSurveyStep' &&
-				abtest( 'domainDotBlogSubdomain' ) === 'includeDotBlogSubdomain'
-			);
+		const includeDotBlogSubdomain = ( this.props.flowName === 'subdomain' );
 
 		return (
 			<RegisterDomainStep

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes }from 'react';
-import { connect }from 'react-redux';
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
 import classNames from 'classnames';
 
 /**

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes }from 'react';
+import { connect }from 'react-redux';
 import classNames from 'classnames';
 
 /**
@@ -14,15 +15,17 @@ import PressableThemeStep from './pressable-theme';
 import StepWrapper from 'signup/step-wrapper';
 import Button from 'components/button';
 
-module.exports = React.createClass( {
+import { getSurveyVertical } from 'state/signup/steps/survey/selectors';
+
+const ThemeSelectionStep = React.createClass( {
 	displayName: 'ThemeSelection',
 
 	propTypes: {
-		designType: React.PropTypes.string,
-		goToNextStep: React.PropTypes.func.isRequired,
-		signupDependencies: React.PropTypes.object.isRequired,
-		stepName: React.PropTypes.string.isRequired,
-		useHeadstart: React.PropTypes.bool,
+		designType: PropTypes.string,
+		goToNextStep: PropTypes.func.isRequired,
+		signupDependencies: PropTypes.object.isRequired,
+		stepName: PropTypes.string.isRequired,
+		useHeadstart: PropTypes.bool,
 	},
 
 	getInitialState() {
@@ -71,7 +74,7 @@ module.exports = React.createClass( {
 	renderThemesList() {
 		return (
 			<SignupThemesList
-				surveyQuestion={ this.props.signupDependencies.surveyQuestion }
+				surveyQuestion={ this.props.chosenSurveyVertical }
 				designType={ this.props.designType || this.props.signupDependencies.designType }
 				handleScreenshotClick={ this.handleScreenshotClick }
 				handleThemeUpload={ this.handleThemeUpload }
@@ -135,3 +138,11 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+export default connect(
+	( state ) => {
+		return {
+			chosenSurveyVertical: getSurveyVertical( state )
+		};
+	}
+)( ThemeSelectionStep );

--- a/client/signup/test/flows.js
+++ b/client/signup/test/flows.js
@@ -89,7 +89,7 @@ describe( 'Signup Flows Configuration', () => {
 
 		it( 'should check AB variation in main flow', () => {
 			assert.equal( flows.getABTestFilteredFlow( 'main', 'testflow' ), 'testflow' );
-			assert.equal( getABTestVariationSpy.callCount, 3 );
+			assert.equal( getABTestVariationSpy.callCount, 1 );
 			assert.equal( flows.insertStepIntoFlow.callCount, 0 );
 		} );
 
@@ -100,8 +100,8 @@ describe( 'Signup Flows Configuration', () => {
 			};
 
 			assert.equal( flows.getABTestFilteredFlow( 'main', myFlow ), myFlow );
-			assert.equal( getABTestVariationSpy.callCount, 4 );
-			assert.equal( flows.insertStepIntoFlow.callCount, 1 );
+			assert.equal( getABTestVariationSpy.callCount, 2 );
+			assert.equal( flows.insertStepIntoFlow.callCount, 0 );
 		} );
 	} );
 


### PR DESCRIPTION
This PR removes the Survey step from the signup flows and the associated AB test. Also retiring: `domainDotBlogSubdomain` AB test.

In order to properly test data that's coming from the Survey step in other steps, I've created a new flow - `surveystep` that has the survey step. It can be accessed by visiting `/start/surveystep`.

To test:

1. Checkout branch or use Calypso.live link
2. Start Signup
3. Verify the Survey step is not appearing as a first step
4. Complete signup and verify the site has been created successfully
5. Verify there are no JS errors in the console

cc @meremagee @michaeldcain 