### PR TITLE
Remove references to old my-stats and notifications WP.com pages (both retired)

### DIFF
--- a/client/lib/route/legacy-routes.js
+++ b/client/lib/route/legacy-routes.js
@@ -13,7 +13,6 @@ const notEnabled = feature => () => ! config.isEnabled( feature );
 const legacyRoutes = [
 	{ match: /.php$/ },
 	{ match: /^\/?$/, predicate: notEnabled( 'reader' ) },
-	{ match: /^\/notifications/ },
 	{ match: /^\/themes/ },
 	{ match: /^\/manage/ },
 	{ match: /^\/plans/, predicate: notEnabled( 'manage/plans' ) },

--- a/client/lib/route/legacy-routes.js
+++ b/client/lib/route/legacy-routes.js
@@ -13,7 +13,6 @@ const notEnabled = feature => () => ! config.isEnabled( feature );
 const legacyRoutes = [
 	{ match: /.php$/ },
 	{ match: /^\/?$/, predicate: notEnabled( 'reader' ) },
-	{ match: /^\/my-stats/ },
 	{ match: /^\/notifications/ },
 	{ match: /^\/themes/ },
 	{ match: /^\/manage/ },

--- a/client/lib/route/test/legacy-routes.js
+++ b/client/lib/route/test/legacy-routes.js
@@ -28,10 +28,6 @@ describe( 'legacy-routes', function() {
 			expect( isLegacyRoute( '/themes/sometheme' ) ).to.be.true;
 		} );
 
-		it( 'should return true for /notifications', () => {
-			expect( isLegacyRoute( '/notifications' ) ).to.be.true;
-		} );
-
 		it( 'should return false for /settings/general', () => {
 			expect( isLegacyRoute( '/settings/general' ) ).to.be.false;
 		} );

--- a/client/my-sites/posts/post-controls.jsx
+++ b/client/my-sites/posts/post-controls.jsx
@@ -96,11 +96,8 @@ module.exports = React.createClass( {
 				icon: 'external'
 			} );
 
-			if ( config.isEnabled( 'manage/stats' ) ) {
-				statsURL = '/stats/post/' + post.ID + '/' + this.props.site.slug;
-			} else {
-				statsURL = '//wordpress.com/my-stats/?view=post&post=' + post.ID + '&blog=' + post.site_ID;
-			}
+			statsURL = '/stats/post/' + post.ID + '/' + this.props.site.slug;
+
 			availableControls.push( {
 				text: this.translate( 'Stats' ),
 				className: 'post-controls__stats',


### PR DESCRIPTION
This allows us to redirect `/my-stats` traffic to Calypso stats pages, and stop supporting `/notifications` standalone page.

Related change on WP.com were committed today.

Internal ref: p4TIVU-5se-p2