### PR TITLE
Reader: expand photo cards on click

### DIFF
--- a/client/blocks/reader-post-card/featured-image.jsx
+++ b/client/blocks/reader-post-card/featured-image.jsx
@@ -22,7 +22,7 @@ const FeaturedImage = ( { imageUri, href, children, onClick } ) => {
 	};
 
 	return (
-		<a className="reader-post-card__featured-image" href={ href } style={ featuredImageStyle } onClick={ onClick } >
+		<a className="reader-post-card__featured-image" href={ href } style={ featuredImageStyle } onClick={ onClick }>
 			{ children }
 		</a>
 	);

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -149,7 +149,11 @@ export default class ReaderPostCard extends React.Component {
 			featuredAsset = <FeaturedVideo { ...post.canonical_media } videoEmbed={ post.canonical_media } />;
 		} else {
 			featuredAsset = isPhotoOnly
-				? <PostPhoto imageUri={ post.canonical_media.src } href={ post.URL } imageHeight={ post.canonical_media.height } />
+				? <PostPhoto
+					imageUri={ post.canonical_media.src }
+					href={ post.URL }
+					imageHeight={ post.canonical_media.height }
+					imageWidth={ post.canonical_media.width } />
 				: <FeaturedImage imageUri={ post.canonical_media.src } href={ post.URL } />;
 		}
 

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -148,8 +148,9 @@ export default class ReaderPostCard extends React.Component {
 		} else if ( post.canonical_media.mediaType === 'video' ) {
 			featuredAsset = <FeaturedVideo { ...post.canonical_media } videoEmbed={ post.canonical_media } />;
 		} else {
-			const ImageComponent = isPhotoOnly ? PostPhoto : FeaturedImage;
-			featuredAsset = <ImageComponent imageUri={ post.canonical_media.src } href={ post.URL } />;
+			featuredAsset = isPhotoOnly
+				? <PostPhoto imageUri={ post.canonical_media.src } href={ post.URL } imageHeight={ post.canonical_media.height } />
+				: <FeaturedImage imageUri={ post.canonical_media.src } href={ post.URL } />;
 		}
 
 		return (

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -20,6 +20,7 @@ import FeaturedVideo from './featured-video';
 import FeaturedImage from './featured-image';
 import FollowButton from 'reader/follow-button';
 import PostGallery from './gallery';
+import PostPhoto from './photo';
 import DailyPostButton from 'blocks/daily-post-button';
 import { isDailyPostChallengeOrPrompt } from 'blocks/daily-post-button/helper';
 import * as DiscoverHelper from 'reader/discover/helper';
@@ -147,7 +148,8 @@ export default class ReaderPostCard extends React.Component {
 		} else if ( post.canonical_media.mediaType === 'video' ) {
 			featuredAsset = <FeaturedVideo { ...post.canonical_media } videoEmbed={ post.canonical_media } />;
 		} else {
-			featuredAsset = <FeaturedImage imageUri={ post.canonical_media.src } href={ post.URL } />;
+			const ImageComponent = isPhotoOnly ? PostPhoto : FeaturedImage;
+			featuredAsset = <ImageComponent imageUri={ post.canonical_media.src } href={ post.URL } />;
 		}
 
 		return (

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -44,7 +44,7 @@ class PostPhoto extends React.Component {
 		};
 
 		const classes = classnames( {
-			'reader-post-card__featured-image': true, // Will need changing to __photo after styles are rejigged
+			'reader-post-card__photo': true,
 			'is-expanded': this.state.isExpanded
 		} );
 

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -28,7 +28,7 @@ class PostPhoto extends React.Component {
 
 	// might need to debounce this
 	getViewportHeight() {
-		return Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+		return Math.max( document.documentElement.clientHeight, window.innerHeight || 0 );
 	}
 
 	render() {
@@ -47,7 +47,7 @@ class PostPhoto extends React.Component {
 
 		if ( this.state.isExpanded ) {
 			const viewportHeight = this.getViewportHeight();
-			featuredImageStyle.height = Math.min( viewportHeight, imageHeight );
+			featuredImageStyle.height = Math.min( viewportHeight - 100, imageHeight );
 		}
 
 		const classes = classnames( {

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -12,12 +12,9 @@ import cssSafeUrl from 'lib/css-safe-url';
 
 class PostPhoto extends React.Component {
 
-	constructor( props ) {
-		super( props );
-		this.state = {
-			isExpanded: false
-		};
-	}
+	state = {
+		isExpanded: false
+	};
 
 	handleClick = ( event ) => {
 		if ( this.state.isExpanded ) {

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -1,0 +1,68 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { noop } from 'lodash';
+import classnames from 'classnames';
+
+/**
+ * Internal Dependencies
+ */
+import cssSafeUrl from 'lib/css-safe-url';
+
+class PostPhoto extends React.Component {
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			isExpanded: false
+		};
+	}
+
+	handleClick = ( event ) => {
+		if ( this.state.isExpanded ) {
+			return;
+		}
+
+		// If the photo's not expanded, don't open full post yet
+		event.preventDefault();
+		this.setState( { isExpanded: true } );
+	}
+
+	render() {
+		const { imageUri, href, children } = this.props;
+
+		if ( imageUri === undefined ) {
+			return null;
+		}
+
+		const featuredImageStyle = {
+			backgroundImage: 'url(' + cssSafeUrl( imageUri ) + ')',
+			backgroundSize: 'cover',
+			backgroundRepeat: 'no-repeat',
+			backgroundPosition: 'right center'
+		};
+
+		const classes = classnames( {
+			'reader-post-card__featured-image': true, // Will need changing to __photo after styles are rejigged
+			'is-expanded': this.state.isExpanded
+		} );
+
+		return (
+			<a className={ classes } href={ href } style={ featuredImageStyle } onClick={ this.handleClick }>
+				{ children }
+			</a>
+		);
+	}
+}
+
+PostPhoto.propTypes = {
+	imageUri: React.PropTypes.string,
+	href: React.PropTypes.string,
+};
+
+PostPhoto.defaultProps = {
+	onClick: noop,
+};
+
+export default PostPhoto;

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -26,10 +26,14 @@ class PostPhoto extends React.Component {
 		this.setState( { isExpanded: true } );
 	}
 
-	// might need to debounce this
+	// might need to put into state to respond to resizes + debounce
 	getViewportHeight() {
 		return Math.max( document.documentElement.clientHeight, window.innerHeight || 0 );
 	}
+
+	// getAspectRatio() {
+	// 	return this.props.imageWidth / this.props.imageHeight;
+	// }
 
 	render() {
 		const { imageUri, href, children, imageHeight } = this.props;
@@ -47,7 +51,10 @@ class PostPhoto extends React.Component {
 
 		if ( this.state.isExpanded ) {
 			const viewportHeight = this.getViewportHeight();
-			featuredImageStyle.height = Math.min( viewportHeight - 176, imageHeight );
+			//const aspectRatio = this.getAspectRatio();
+
+			const newImageHeight = Math.min( this.props.imageHeight, viewportHeight - 176 );
+			featuredImageStyle.height = Math.min( newImageHeight, imageHeight );
 		}
 
 		const classes = classnames( {

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -26,8 +26,13 @@ class PostPhoto extends React.Component {
 		this.setState( { isExpanded: true } );
 	}
 
+	// might need to debounce this
+	getViewportHeight() {
+		return Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+	}
+
 	render() {
-		const { imageUri, href, children } = this.props;
+		const { imageUri, href, children, imageHeight } = this.props;
 
 		if ( imageUri === undefined ) {
 			return null;
@@ -39,6 +44,11 @@ class PostPhoto extends React.Component {
 			backgroundRepeat: 'no-repeat',
 			backgroundPosition: 'right center'
 		};
+
+		if ( this.state.isExpanded ) {
+			const viewportHeight = this.getViewportHeight();
+			featuredImageStyle.height = Math.min( viewportHeight, imageHeight );
+		}
 
 		const classes = classnames( {
 			'reader-post-card__photo': true,
@@ -55,6 +65,7 @@ class PostPhoto extends React.Component {
 
 PostPhoto.propTypes = {
 	imageUri: React.PropTypes.string,
+	imageHeight: React.PropTypes.number,
 	href: React.PropTypes.string,
 };
 

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -47,7 +47,7 @@ class PostPhoto extends React.Component {
 
 		if ( this.state.isExpanded ) {
 			const viewportHeight = this.getViewportHeight();
-			featuredImageStyle.height = Math.min( viewportHeight - 100, imageHeight );
+			featuredImageStyle.height = Math.min( viewportHeight - 176, imageHeight );
 		}
 
 		const classes = classnames( {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -97,27 +97,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 		&.is-photo {
 
-			.reader-post-card__featured-image {
-				position: relative;
-					top: 0;
-				height: 225px;
-				margin-right: 0;
-				margin-bottom: 0;
-				max-width: 100%;
-
-				&::before {
-					content: '';
-					background: linear-gradient( to bottom, rgba( 0, 0, 0, 0 ) 36%, rgba( 0, 0, 0, 0.37 ) 73%, rgba( 0, 0, 0, 1 ) 100% );
-					height: 225px;
-					opacity: .4;
-					position: absolute;
-						bottom: 0;
-						left: 0;
-					width: 100%;
-					z-index: z-index( 'root', '.reader-post-card__featured-image' );
-				}
-			}
-
 			.reader-post-card__post {
 				flex-direction: column;
 			}
@@ -201,6 +180,54 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 	.reader-post-actions {
 		margin: 4px 0 0;
+	}
+}
+
+.reader-post-card__photo {
+	border: 1px solid lighten( $gray, 20% );
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-basis: auto;
+	flex-grow: 1;
+	margin-right: 20px;
+	cursor: pointer;
+
+	@media #{$reader-post-card-breakpoint-medium} {
+		height: 100px;
+		max-width: none;
+		width: 100%;
+		margin-bottom: 10px;
+	}
+
+	@media #{$reader-post-card-breakpoint-small} {
+		height: 100px;
+		max-width: none;
+		width: 100%;
+		margin-bottom: 10px;
+	}
+
+	&.is-expanded {
+		border: 1px solid red;
+	}
+
+	position: relative;
+		top: 0;
+	height: 225px;
+	margin-right: 0;
+	margin-bottom: 0;
+	max-width: 100%;
+
+	&::before {
+		content: '';
+		background: linear-gradient( to bottom, rgba( 0, 0, 0, 0 ) 36%, rgba( 0, 0, 0, 0.37 ) 73%, rgba( 0, 0, 0, 1 ) 100% );
+		height: 225px;
+		opacity: .4;
+		position: absolute;
+			bottom: 0;
+			left: 0;
+		width: 100%;
+		z-index: z-index( 'root', '.reader-post-card__photo' );
 	}
 }
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -23,6 +23,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 .reader-post-card.card {
+
 	border-bottom: 1px solid lighten( $gray, 30% );
 	box-shadow: none;
 	margin: 0 15px;
@@ -82,6 +83,10 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 			&:hover .reader-post-card__play-icon {
 				opacity: 1;
+			}
+
+			&.is-expanded {
+				border: 1px solid red;
 			}
 		}
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -211,7 +211,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 	&.is-expanded {
 		background-size: contain !important; //Overrides default background-size: cover set in all cards;
-		height: 100vh;
+		//height: 100vh;
 	}
 
 	&::before {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -210,8 +210,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	}
 
 	&.is-expanded {
-		//background-size: contain !important; //Overrides default background-size: cover set in all cards;
-		//height: 100vh;
+		background-position: center center !important;
 	}
 
 	&::before {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -84,10 +84,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			&:hover .reader-post-card__play-icon {
 				opacity: 1;
 			}
-
-			&.is-expanded {
-				border: 1px solid red;
-			}
 		}
 
 		.reader-post-card__play-icon {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -210,7 +210,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	}
 
 	&.is-expanded {
-		background-size: contain !important; //Overrides default background-size: cover set in all cards;
+		//background-size: contain !important; //Overrides default background-size: cover set in all cards;
 		//height: 100vh;
 	}
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -188,6 +188,12 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	flex-grow: 1;
 	margin-right: 20px;
 	cursor: pointer;
+	position: relative;
+		top: 0;
+	height: 225px;
+	margin-right: 0;
+	margin-bottom: 0;
+	max-width: 100%;
 
 	@media #{$reader-post-card-breakpoint-medium} {
 		height: 100px;
@@ -204,15 +210,9 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	}
 
 	&.is-expanded {
-		border: 1px solid red;
+		background-size: 100% !important; //Overrides default background-size: cover set in all cards;
+		height: 100vh;
 	}
-
-	position: relative;
-		top: 0;
-	height: 225px;
-	margin-right: 0;
-	margin-bottom: 0;
-	max-width: 100%;
 
 	&::before {
 		content: '';

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -210,7 +210,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	}
 
 	&.is-expanded {
-		background-size: 100% !important; //Overrides default background-size: cover set in all cards;
+		background-size: contain !important; //Overrides default background-size: cover set in all cards;
 		height: 100vh;
 	}
 


### PR DESCRIPTION
@fraying suggests in https://github.com/Automattic/wp-calypso/issues/10188 that photos should expand to their full size in the stream on the first click (and open the full post on a subsequent click).

This PR creates a new photo component that includes that functionality.

![8c046f72-c6a7-11e6-9f19-7a1b73fd3e93](https://cloud.githubusercontent.com/assets/17325/21409568/e6de81e6-c83f-11e6-9bdb-0a140d8b7fae.jpg)

cc @jancavan 