### PR TITLE
Reader: cards parallax hack.  

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -92,11 +92,12 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 		&.is-photo {
 
+			// Important needed to override default properties set for other cards
 			.reader-post-card__featured-image {
 				background-attachment: fixed;
-				background-position: center top !important;
+				background-position: center bottom !important;
 				background-repeat: no-repeat;
-				background-size: 56% !important;
+				background-size: 100% !important;
 				height: 225px;
 				margin-right: 0;
 				margin-bottom: 0;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -93,12 +93,16 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		&.is-photo {
 
 			.reader-post-card__featured-image {
-				position: relative;
-					top: 0;
+				background-attachment: fixed;
+				background-position: center top !important;
+				background-repeat: no-repeat;
+				background-size: 56% !important;
 				height: 225px;
 				margin-right: 0;
 				margin-bottom: 0;
 				max-width: 100%;
+				position: relative;
+					top: 0;
 
 				&::before {
 					content: '';

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -95,9 +95,9 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			// Important needed to override default properties set for other cards
 			.reader-post-card__featured-image {
 				background-attachment: fixed;
-				background-position: center bottom !important;
 				background-repeat: no-repeat;
-				background-size: 100% !important;
+				background-size: 830px Auto !important;
+				background-position: 442px center !important;
 				height: 225px;
 				margin-right: 0;
 				margin-bottom: 0;


### PR DESCRIPTION
Note: this should not be merged.  This is just to see what it would look like if we had parallax enabled on photo cards.

Note: spinoff of https://github.com/Automattic/wp-calypso/pull/10216