### PR TITLE
Reader: Try changing main stream width to 800px

### DIFF
--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -2,7 +2,7 @@
 
 // Overrides default 720px width
 .is-reader-page .following.main {
-	max-width: 830px;
+	max-width: 800px;
 }
 
 .is-reader-page .reader__card.card.is-placeholder {


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/10221

**Before:**
![screenshot 2016-12-21 20 18 27](https://cloud.githubusercontent.com/assets/4924246/21415135/3baf1120-c7bb-11e6-8ff3-df4edb382834.png)

**After:**
![screenshot 2016-12-21 20 18 47](https://cloud.githubusercontent.com/assets/4924246/21415137/3f029c16-c7bb-11e6-8baa-98df557f064a.png)
