### PR TITLE
Signup: Bump Site Title AB test percentage to 50%

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -92,8 +92,8 @@ module.exports = {
 	siteTitleStep: {
 		datestamp: '20160928',
 		variations: {
-			showSiteTitleStep: 5,
-			hideSiteTitleStep: 95,
+			showSiteTitleStep: 50,
+			hideSiteTitleStep: 50,
 		},
 		defaultVariation: 'hideSiteTitleStep',
 		allowExistingUsers: false


### PR DESCRIPTION
This PR bumps the Site Title step AB test percentage to 50%.

To test:

1. Checkout branch or use Calypso.live link
2. Start signup
3. Verify there are no JS errors
4. Verify Signup completes with and without the Site Title step.

cc @meremagee 