### PR TITLE
Config: remove the  fil locale

### DIFF
--- a/config/_shared.json
+++ b/config/_shared.json
@@ -43,7 +43,6 @@
 		{ "value": 429, "langSlug": "eu", "name": "eu - Euskara", "wpLocale": "eu" },
 		{ "value": 21, "langSlug": "fa", "name": "fa - فارسی", "wpLocale": "fa_IR", "rtl": true },
 		{ "value": 22, "langSlug": "fi", "name": "fi - Suomi", "wpLocale": "fi" },
-		{ "value": 473, "langSlug": "fil", "name": "fil - Filipino", "wpLocale": "" },
 		{ "value": 23, "langSlug": "fo", "name": "fo - Føroyskt", "wpLocale": "fo" },
 		{ "value": 24, "langSlug": "fr", "name": "fr - Français", "wpLocale": "fr_FR", "popular": 5 },
 		{ "value": 478, "langSlug": "fr-be", "name": "fr-be - Français de Belgique", "wpLocale": "fr_BE" },


### PR DESCRIPTION
We've removed Filipino from our supported locales on wp.com (Tagalog is to be used instead).

Testing: check that 'fil' isn't available in the language dropdown for the ui language in user settings, or for the blog language in blog settings.

Internal: pxLjZ-37R-p2