### PR TITLE
Editor: Avoid sidebar header shrink

### DIFF
--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -23,6 +23,7 @@
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
+		flex-shrink: 0;
 		padding: 8px;
 	}
 }


### PR DESCRIPTION
Fixes: #10168
Related: #5987

This pull request seeks to resolve an issue where the editor sidebar shrinks if many accordions are open, enough to cause scroll in the sidebar. More importantly, it also appears to resolve an issue in Safari where the sidebar cannot be scrolled.

__Testing instructions:__

Repeat testing instructions in Safari and in your preferred browser:

1. Navigate to [post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Expand enough accordions in sidebar to cause scroll
4. Scroll the sidebar

cc @nellofn 