### PR TITLE
State: Exit with error in lint when new non-global exported selector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,10 @@ node_modules: package.json | node-version
 test: build
 	@$(NPM) test
 
-lint: node_modules/eslint node_modules/eslint-plugin-react node_modules/babel-eslint mixedindentlint
+selectorhandslap:
+	@if [[ ! -z "$$(git diff --name-only $$(git merge-base $$(git rev-parse --abbrev-ref HEAD) master)..HEAD -G '^export' | grep 'selectors\.js$$')" ]]; then ( echo "Selectors must be implemented in \`client/state/selectors\`" && exit 1 ); fi;
+
+lint: node_modules/eslint node_modules/eslint-plugin-react node_modules/babel-eslint mixedindentlint selectorhandslap
 	@$(NPM) run lint
 
 eslint: lint
@@ -210,5 +213,5 @@ shrinkwrap: node-version
 FORCE:
 
 .PHONY: build build-development build-server build-dll build-desktop build-desktop-mac-app-store build-horizon build-stage build-production build-wpcalypso
-.PHONY: run install test clean distclean translate route node-version
+.PHONY: run install test clean distclean translate route node-version selectorhandslap
 .PHONY: githooks githooks-commit githooks-push


### PR DESCRIPTION
This pull request seeks to gently discourage new selector additions outside of the newly introduced global state directory (#5954). It adds a new Makefile target which is executed alongside `make lint`, so that the CircleCI build for a branch will fail under the following conditions:

- A file ending in `selectors.js` has been modified in the current branch whose changes include revisions having a line starting with `export`

__Testing instructions:__

1. No changes

Run `make selectorhandslap`

Observe no output to terminal

2. Changes not including exports

In a new or existing `state/**/selectors.js` file, make a change to any line of code except a line beginning in `export`. Commit this change locally.

Run `make selectorhandslap`

Observe no output to terminal

3. Changes including exports

In a new or existing `state/**/selectors.js` file, make a change to an existing selector's export (e.g. its name) or add a new exported selector. Commit this change locally.

Run `make selectorhandslap`

Observe an exit status 1 with error message