### PR TITLE
Reader: Add space under images full-post

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -168,6 +168,14 @@
 	color: $gray-dark;
 }
 
+.reader-full-post__story-content img {
+	margin-bottom: 12px;
+}
+
+.reader-full-post__story-content figure img {
+	margin-bottom: 0;
+}
+
 .reader-full-post .author-compact-profile {
 	display: inline-flex;
 	flex-direction: column;


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/10054

Example posts:
https://wpcalypso.wordpress.com/read/feeds/10080096/posts/1260487444

**Before:**
![screenshot 2016-12-22 11 49 56](https://cloud.githubusercontent.com/assets/4924246/21438628/dca86bfc-c83e-11e6-93aa-c63971979009.png)

**After:**
![screenshot 2016-12-22 11 51 23](https://cloud.githubusercontent.com/assets/4924246/21438631/e02d07ba-c83e-11e6-8b10-492ea7472f25.png)

https://wpcalypso.wordpress.com/read/feeds/8890400/posts/1250245193

**Before:**
![screenshot 2016-12-22 12 02 17](https://cloud.githubusercontent.com/assets/4924246/21438647/f0cb428a-c83e-11e6-8c7f-2dc9234604bf.png)

**After:**
![screenshot 2016-12-22 12 02 29](https://cloud.githubusercontent.com/assets/4924246/21438651/f39a9178-c83e-11e6-90eb-e3c20933b6bf.png)

