### PR TITLE
Plugins: Fix eligibility warning styles

### DIFF
--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -87,7 +87,7 @@ const EligibilityWarnings = props => {
 
 	const classes = classNames( {
 		'eligibility-warnings__message': true,
-		'is-placeholder': isPlaceholder,
+		'eligibility-warnings__placeholder': isPlaceholder,
 	} );
 
 	return (

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -5,20 +5,20 @@
     line-height: 1.5;
 }
 
-.is-placeholder {
+.eligibility-warnings__placeholder {
     @include placeholder();
 }
 
-.is-placeholder .eligibility-warnings__message-content {
+.eligibility-warnings__placeholder .eligibility-warnings__message-content {
     color: $gray-light;
     background-color: $gray-light;
 }
 
-.is-placeholder .eligibility-warnings__error-icon{
+.eligibility-warnings__placeholder .eligibility-warnings__error-icon{
     color: $gray-light;
 }
 
-.is-placeholder .eligibility-warnings__message-action .button {
+.eligibility-warnings__placeholder .eligibility-warnings__message-action .button {
     display: none;
 }
 


### PR DESCRIPTION
Placeholder style class name was to general and it was causing
layout issues in the media modal. Renamed to a more specific
name for this use-case in order to fix this.

**Before fix:**

![cbe0690c-c850-11e6-9e26-4cf44c3fa040](https://cloud.githubusercontent.com/assets/1182160/21440715/9f361930-c894-11e6-872c-1774bad0fef1.png)

**Testing instructions:** 
1. Navigate to media modal and verify that ghosting below individual items is no longer present.
2. Navigate to `/theme/uploads/{siteSlug}` and verify that the eligibility warning style is preserved.