### PR TITLE
Reader: expanded photo cards - two heads are better than one

### DIFF
--- a/client/blocks/reader-post-card/featured-image.jsx
+++ b/client/blocks/reader-post-card/featured-image.jsx
@@ -22,7 +22,7 @@ const FeaturedImage = ( { imageUri, href, children, onClick } ) => {
 	};
 
 	return (
-		<a className="reader-post-card__featured-image" href={ href } style={ featuredImageStyle } onClick={ onClick } >
+		<a className="reader-post-card__featured-image" href={ href } style={ featuredImageStyle } onClick={ onClick }>
 			{ children }
 		</a>
 	);

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -97,6 +97,10 @@ export default class ReaderPostCard extends React.Component {
 		}
 	}
 
+	handlePhotoCardExpanded = () => {
+		stats.recordTrackForPost( 'calypso_reader_photo_expanded', this.props.post );
+	}
+
 	render() {
 		const {
 			post,
@@ -152,7 +156,7 @@ export default class ReaderPostCard extends React.Component {
 				? <PostPhoto imageUri={ post.canonical_media.src } href={ post.URL } imageSize={ {
 					height: post.canonical_media.height,
 					width: post.canonical_media.width,
-				} } />
+				} } onExpanded={ this.handlePhotoCardExpanded } />
 				: <FeaturedImage imageUri={ post.canonical_media.src } href={ post.URL } />;
 		}
 

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -148,8 +148,9 @@ export default class ReaderPostCard extends React.Component {
 		} else if ( post.canonical_media.mediaType === 'video' ) {
 			featuredAsset = <FeaturedVideo { ...post.canonical_media } videoEmbed={ post.canonical_media } />;
 		} else {
-			const ImageComponent = isPhotoOnly ? PostPhoto : FeaturedImage;
-			featuredAsset = <ImageComponent imageUri={ post.canonical_media.src } href={ post.URL } />;
+			featuredAsset = isPhotoOnly
+				? <PostPhoto imageUri={ post.canonical_media.src } href={ post.URL } imageHeight={ post.canonical_media.height } />
+				: <FeaturedImage imageUri={ post.canonical_media.src } href={ post.URL } />;
 		}
 
 		return (

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -20,6 +20,7 @@ import FeaturedVideo from './featured-video';
 import FeaturedImage from './featured-image';
 import FollowButton from 'reader/follow-button';
 import PostGallery from './gallery';
+import PostPhoto from './photo';
 import DailyPostButton from 'blocks/daily-post-button';
 import { isDailyPostChallengeOrPrompt } from 'blocks/daily-post-button/helper';
 import * as DiscoverHelper from 'reader/discover/helper';
@@ -147,7 +148,8 @@ export default class ReaderPostCard extends React.Component {
 		} else if ( post.canonical_media.mediaType === 'video' ) {
 			featuredAsset = <FeaturedVideo { ...post.canonical_media } videoEmbed={ post.canonical_media } />;
 		} else {
-			featuredAsset = <FeaturedImage imageUri={ post.canonical_media.src } href={ post.URL } />;
+			const ImageComponent = isPhotoOnly ? PostPhoto : FeaturedImage;
+			featuredAsset = <ImageComponent imageUri={ post.canonical_media.src } href={ post.URL } />;
 		}
 
 		return (

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -149,7 +149,10 @@ export default class ReaderPostCard extends React.Component {
 			featuredAsset = <FeaturedVideo { ...post.canonical_media } videoEmbed={ post.canonical_media } />;
 		} else {
 			featuredAsset = isPhotoOnly
-				? <PostPhoto imageUri={ post.canonical_media.src } href={ post.URL } imageHeight={ post.canonical_media.height } />
+				? <PostPhoto imageUri={ post.canonical_media.src } href={ post.URL } imageSize={ {
+					height: post.canonical_media.height,
+					width: post.canonical_media.width,
+				} } />
 				: <FeaturedImage imageUri={ post.canonical_media.src } href={ post.URL } />;
 		}
 

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -44,7 +44,7 @@ class PostPhoto extends React.Component {
 		};
 
 		const classes = classnames( {
-			'reader-post-card__featured-image': true, // Will need changing to __photo after styles are rejigged
+			'reader-post-card__photo': true,
 			'is-expanded': this.state.isExpanded
 		} );
 

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -28,7 +28,7 @@ class PostPhoto extends React.Component {
 
 	// might need to debounce this
 	getViewportHeight() {
-		return Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+		return Math.max( document.documentElement.clientHeight, window.innerHeight || 0 );
 	}
 
 	render() {
@@ -47,7 +47,7 @@ class PostPhoto extends React.Component {
 
 		if ( this.state.isExpanded ) {
 			const viewportHeight = this.getViewportHeight();
-			featuredImageStyle.height = Math.min( viewportHeight, imageHeight );
+			featuredImageStyle.height = Math.min( viewportHeight - 100, imageHeight );
 		}
 
 		const classes = classnames( {

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -12,12 +12,9 @@ import cssSafeUrl from 'lib/css-safe-url';
 
 class PostPhoto extends React.Component {
 
-	constructor( props ) {
-		super( props );
-		this.state = {
-			isExpanded: false
-		};
-	}
+	state = {
+		isExpanded: false
+	};
 
 	handleClick = ( event ) => {
 		if ( this.state.isExpanded ) {

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -1,0 +1,68 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { noop } from 'lodash';
+import classnames from 'classnames';
+
+/**
+ * Internal Dependencies
+ */
+import cssSafeUrl from 'lib/css-safe-url';
+
+class PostPhoto extends React.Component {
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			isExpanded: false
+		};
+	}
+
+	handleClick = ( event ) => {
+		if ( this.state.isExpanded ) {
+			return;
+		}
+
+		// If the photo's not expanded, don't open full post yet
+		event.preventDefault();
+		this.setState( { isExpanded: true } );
+	}
+
+	render() {
+		const { imageUri, href, children } = this.props;
+
+		if ( imageUri === undefined ) {
+			return null;
+		}
+
+		const featuredImageStyle = {
+			backgroundImage: 'url(' + cssSafeUrl( imageUri ) + ')',
+			backgroundSize: 'cover',
+			backgroundRepeat: 'no-repeat',
+			backgroundPosition: 'right center'
+		};
+
+		const classes = classnames( {
+			'reader-post-card__featured-image': true, // Will need changing to __photo after styles are rejigged
+			'is-expanded': this.state.isExpanded
+		} );
+
+		return (
+			<a className={ classes } href={ href } style={ featuredImageStyle } onClick={ this.handleClick }>
+				{ children }
+			</a>
+		);
+	}
+}
+
+PostPhoto.propTypes = {
+	imageUri: React.PropTypes.string,
+	href: React.PropTypes.string,
+};
+
+PostPhoto.defaultProps = {
+	onClick: noop,
+};
+
+export default PostPhoto;

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -27,12 +27,15 @@ class PostPhoto extends React.Component {
 	}
 
 	// might need to debounce this
-	getViewportHeight() {
-		return Math.max( document.documentElement.clientHeight, window.innerHeight || 0 );
+	getViewportHeight = () =>
+		Math.max( document.documentElement.clientHeight, window.innerHeight || 0 );
+
+	getCardWidth = () => {
+		return 800;
 	}
 
 	render() {
-		const { imageUri, href, children, imageHeight } = this.props;
+		const { imageUri, href, children, imageSize } = this.props;
 
 		if ( imageUri === undefined ) {
 			return null;
@@ -42,12 +45,19 @@ class PostPhoto extends React.Component {
 			backgroundImage: 'url(' + cssSafeUrl( imageUri ) + ')',
 			backgroundSize: 'cover',
 			backgroundRepeat: 'no-repeat',
-			backgroundPosition: 'right center'
+			backgroundPosition: 'center'
 		};
 
 		if ( this.state.isExpanded ) {
 			const viewportHeight = this.getViewportHeight();
-			featuredImageStyle.height = Math.min( viewportHeight - 176, imageHeight );
+			const cardWidth = this.getCardWidth();
+			const { width: naturalWidth, height: naturalHeight } = imageSize;
+
+			const newHeight = Math.min(
+				( naturalHeight / naturalWidth ) * cardWidth,
+				viewportHeight - 176
+			);
+			featuredImageStyle.height = newHeight;
 		}
 
 		const classes = classnames( {

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -32,9 +32,11 @@ class PostPhoto extends React.Component {
 		Math.max( document.documentElement.clientHeight, window.innerHeight || 0 );
 
 	setCardWidth = () => {
-		const cardWidth = this.widthDivRef.getClientRects()[ 0 ].width;
-		if ( cardWidth > 0 ) {
-			this.setState( { cardWidth } );
+		if ( this.widthDivRef ) {
+			const cardWidth = this.widthDivRef.getClientRects()[ 0 ].width;
+			if ( cardWidth > 0 ) {
+				this.setState( { cardWidth } );
+			}
 		}
 	}
 
@@ -44,6 +46,7 @@ class PostPhoto extends React.Component {
 
 	componentDidMount() {
 		this.resizeListener = window.addEventListener( 'resize', debounce( this.setCardWidth, 50 ) );
+		this.setCardWidth();
 	}
 
 	componentWillUnmount() {
@@ -73,7 +76,7 @@ class PostPhoto extends React.Component {
 				( naturalHeight / naturalWidth ) * cardWidth,
 				viewportHeight - 176
 			);
-//			console.error( naturalHeight, naturalWidth, viewportHeight, ( naturalHeight / naturalWidth ) * cardWidth );
+
 			featuredImageStyle.height = newHeight;
 		}
 

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -25,6 +25,7 @@ class PostPhoto extends React.Component {
 		// If the photo's not expanded, don't open full post yet
 		event.preventDefault();
 		this.setState( { isExpanded: true } );
+		this.props.onExpanded();
 	}
 
 	// might need to debounce this
@@ -98,10 +99,13 @@ PostPhoto.propTypes = {
 	imageUri: React.PropTypes.string,
 	imageHeight: React.PropTypes.number,
 	href: React.PropTypes.string,
+	onClick: React.PropTypes.func,
+	onExpanded: React.PropTypes.func,
 };
 
 PostPhoto.defaultProps = {
 	onClick: noop,
+	onExpanded: noop,
 };
 
 export default PostPhoto;

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -28,7 +28,6 @@ class PostPhoto extends React.Component {
 		this.props.onExpanded();
 	}
 
-	// might need to debounce this
 	getViewportHeight = () =>
 		Math.max( document.documentElement.clientHeight, window.innerHeight || 0 );
 

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -26,8 +26,13 @@ class PostPhoto extends React.Component {
 		this.setState( { isExpanded: true } );
 	}
 
+	// might need to debounce this
+	getViewportHeight() {
+		return Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+	}
+
 	render() {
-		const { imageUri, href, children } = this.props;
+		const { imageUri, href, children, imageHeight } = this.props;
 
 		if ( imageUri === undefined ) {
 			return null;
@@ -39,6 +44,11 @@ class PostPhoto extends React.Component {
 			backgroundRepeat: 'no-repeat',
 			backgroundPosition: 'right center'
 		};
+
+		if ( this.state.isExpanded ) {
+			const viewportHeight = this.getViewportHeight();
+			featuredImageStyle.height = Math.min( viewportHeight, imageHeight );
+		}
 
 		const classes = classnames( {
 			'reader-post-card__photo': true,
@@ -55,6 +65,7 @@ class PostPhoto extends React.Component {
 
 PostPhoto.propTypes = {
 	imageUri: React.PropTypes.string,
+	imageHeight: React.PropTypes.number,
 	href: React.PropTypes.string,
 };
 

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import React from 'react';
-import { noop } from 'lodash';
+import { noop, debounce } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -13,7 +13,8 @@ import cssSafeUrl from 'lib/css-safe-url';
 class PostPhoto extends React.Component {
 
 	state = {
-		isExpanded: false
+		isExpanded: false,
+		cardWidth: 800,
 	};
 
 	handleClick = ( event ) => {
@@ -30,8 +31,23 @@ class PostPhoto extends React.Component {
 	getViewportHeight = () =>
 		Math.max( document.documentElement.clientHeight, window.innerHeight || 0 );
 
-	getCardWidth = () => {
-		return 800;
+	setCardWidth = () => {
+		const cardWidth = this.widthDivRef.getClientRects()[ 0 ].width;
+		if ( cardWidth > 0 ) {
+			this.setState( { cardWidth } );
+		}
+	}
+
+	handleWidthDivLoaded = ( ref ) => {
+		this.widthDivRef = ref;
+	}
+
+	componentDidMount() {
+		this.resizeListener = window.addEventListener( 'resize', debounce( this.setCardWidth, 50 ) );
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'resize', this.resizeListener );
 	}
 
 	render() {
@@ -50,13 +66,14 @@ class PostPhoto extends React.Component {
 
 		if ( this.state.isExpanded ) {
 			const viewportHeight = this.getViewportHeight();
-			const cardWidth = this.getCardWidth();
+			const cardWidth = this.state.cardWidth;
 			const { width: naturalWidth, height: naturalHeight } = imageSize;
 
 			const newHeight = Math.min(
 				( naturalHeight / naturalWidth ) * cardWidth,
 				viewportHeight - 176
 			);
+//			console.error( naturalHeight, naturalWidth, viewportHeight, ( naturalHeight / naturalWidth ) * cardWidth );
 			featuredImageStyle.height = newHeight;
 		}
 
@@ -67,6 +84,7 @@ class PostPhoto extends React.Component {
 
 		return (
 			<a className={ classes } href={ href } style={ featuredImageStyle } onClick={ this.handleClick }>
+				<div ref={ this.handleWidthDivLoaded } style={ { width: '100%' } }></div>
 				{ children }
 			</a>
 		);

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -47,7 +47,7 @@ class PostPhoto extends React.Component {
 
 		if ( this.state.isExpanded ) {
 			const viewportHeight = this.getViewportHeight();
-			featuredImageStyle.height = Math.min( viewportHeight - 100, imageHeight );
+			featuredImageStyle.height = Math.min( viewportHeight - 176, imageHeight );
 		}
 
 		const classes = classnames( {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -97,27 +97,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 		&.is-photo {
 
-			.reader-post-card__featured-image {
-				position: relative;
-					top: 0;
-				height: 225px;
-				margin-right: 0;
-				margin-bottom: 0;
-				max-width: 100%;
-
-				&::before {
-					content: '';
-					background: linear-gradient( to bottom, rgba( 0, 0, 0, 0 ) 36%, rgba( 0, 0, 0, 0.37 ) 73%, rgba( 0, 0, 0, 1 ) 100% );
-					height: 225px;
-					opacity: .4;
-					position: absolute;
-						bottom: 0;
-						left: 0;
-					width: 100%;
-					z-index: z-index( 'root', '.reader-post-card__featured-image' );
-				}
-			}
-
 			.reader-post-card__post {
 				flex-direction: column;
 			}
@@ -201,6 +180,54 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 	.reader-post-actions {
 		margin: 4px 0 0;
+	}
+}
+
+.reader-post-card__photo {
+	border: 1px solid lighten( $gray, 20% );
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-basis: auto;
+	flex-grow: 1;
+	margin-right: 20px;
+	cursor: pointer;
+
+	@media #{$reader-post-card-breakpoint-medium} {
+		height: 100px;
+		max-width: none;
+		width: 100%;
+		margin-bottom: 10px;
+	}
+
+	@media #{$reader-post-card-breakpoint-small} {
+		height: 100px;
+		max-width: none;
+		width: 100%;
+		margin-bottom: 10px;
+	}
+
+	&.is-expanded {
+		border: 1px solid red;
+	}
+
+	position: relative;
+		top: 0;
+	height: 225px;
+	margin-right: 0;
+	margin-bottom: 0;
+	max-width: 100%;
+
+	&::before {
+		content: '';
+		background: linear-gradient( to bottom, rgba( 0, 0, 0, 0 ) 36%, rgba( 0, 0, 0, 0.37 ) 73%, rgba( 0, 0, 0, 1 ) 100% );
+		height: 225px;
+		opacity: .4;
+		position: absolute;
+			bottom: 0;
+			left: 0;
+		width: 100%;
+		z-index: z-index( 'root', '.reader-post-card__photo' );
 	}
 }
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -210,7 +210,11 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	}
 
 	&.is-expanded {
-		background-position: center center !important;
+		background-position: center !important;
+		min-width: 100%;
+		max-height: 100%;
+		max-width: 100%;
+		background-size: cover;
 	}
 
 	&::before {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -23,6 +23,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 .reader-post-card.card {
+
 	border-bottom: 1px solid lighten( $gray, 30% );
 	box-shadow: none;
 	margin: 0 15px;
@@ -82,6 +83,10 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 			&:hover .reader-post-card__play-icon {
 				opacity: 1;
+			}
+
+			&.is-expanded {
+				border: 1px solid red;
 			}
 		}
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -211,7 +211,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 	&.is-expanded {
 		background-size: contain !important; //Overrides default background-size: cover set in all cards;
-		height: 100vh;
+		//height: 100vh;
 	}
 
 	&::before {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -219,7 +219,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			bottom: 0;
 			left: 0;
 		width: 100%;
-		z-index: z-index( 'root', '.reader-post-card__photo' );
 	}
 }
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -210,8 +210,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	}
 
 	&.is-expanded {
-		//background-size: contain !important; //Overrides default background-size: cover set in all cards;
-		//height: 100vh;
+		background-position: center center !important;
 	}
 
 	&::before {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -84,10 +84,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			&:hover .reader-post-card__play-icon {
 				opacity: 1;
 			}
-
-			&.is-expanded {
-				border: 1px solid red;
-			}
 		}
 
 		.reader-post-card__play-icon {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -210,7 +210,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	}
 
 	&.is-expanded {
-		background-size: contain !important; //Overrides default background-size: cover set in all cards;
+		//background-size: contain !important; //Overrides default background-size: cover set in all cards;
 		//height: 100vh;
 	}
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -188,6 +188,12 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	flex-grow: 1;
 	margin-right: 20px;
 	cursor: pointer;
+	position: relative;
+		top: 0;
+	height: 225px;
+	margin-right: 0;
+	margin-bottom: 0;
+	max-width: 100%;
 
 	@media #{$reader-post-card-breakpoint-medium} {
 		height: 100px;
@@ -204,15 +210,9 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	}
 
 	&.is-expanded {
-		border: 1px solid red;
+		background-size: 100% !important; //Overrides default background-size: cover set in all cards;
+		height: 100vh;
 	}
-
-	position: relative;
-		top: 0;
-	height: 225px;
-	margin-right: 0;
-	margin-bottom: 0;
-	max-width: 100%;
 
 	&::before {
 		content: '';

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -210,7 +210,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	}
 
 	&.is-expanded {
-		background-size: 100% !important; //Overrides default background-size: cover set in all cards;
+		background-size: contain !important; //Overrides default background-size: cover set in all cards;
 		height: 100vh;
 	}
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -196,23 +196,16 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	max-width: 100%;
 
 	@media #{$reader-post-card-breakpoint-medium} {
-		height: 100px;
-		max-width: none;
-		width: 100%;
 		margin-bottom: 10px;
 	}
 
 	@media #{$reader-post-card-breakpoint-small} {
-		height: 100px;
-		max-width: none;
-		width: 100%;
 		margin-bottom: 10px;
 	}
 
 	&.is-expanded {
 		background-position: center !important;
 		min-width: 100%;
-		max-height: 100%;
 		max-width: 100%;
 		background-size: cover;
 	}

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -203,11 +203,19 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		margin-bottom: 10px;
 	}
 
+	&:hover {
+		cursor: zoom-in;
+	}
+
 	&.is-expanded {
 		background-position: center !important;
 		min-width: 100%;
 		max-width: 100%;
 		background-size: cover;
+
+		&:hover {
+			cursor: pointer;
+		}
 	}
 
 	&::before {


### PR DESCRIPTION
a fork of: https://github.com/Automattic/wp-calypso/pull/10215

The solution attempted here is use the aspect ratio of the image to figure out the height the photo should be displayed at.
The math is: `(naturalHeight/naturalWidth) * actuallyAvailableWidth` --> height
TODO:
- [x] behavior as expected? @fraying 
- [x] too many hacks? @bluefuton 
- [x] tracks event added: `calypso_reader_photo_expanded`