### PR TITLE
Reader: update tag-header to reflect the latest changes in reader con…

### DIFF
--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -18,7 +18,7 @@ import cssSafeUrl from 'lib/css-safe-url';
 import { decodeEntities } from 'lib/formatting';
 import Gridicon from 'components/gridicon';
 
-const TAG_HEADER_WIDTH = 830;
+const TAG_HEADER_WIDTH = 800;
 const TAG_HEADER_HEIGHT = 140;
 
 class TagStreamHeader extends React.Component {


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/10222 we updated the reader content width to `800px`.

We also need to update the for `TAG_HEADER_WIDTH` in `client/reader/tag-stream/header.jsx`.

This most likely isn't noticeable to anyone without a magnifying glass and only affects the size of the image requested from photon.
