### PR TITLE
Reader: fix for safari photo cards width being too great

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -194,6 +194,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	margin-right: 0;
 	margin-bottom: 0;
 	max-width: 100%;
+	width: 100%;
 
 	@media #{$reader-post-card-breakpoint-medium} {
 		margin-bottom: 10px;
@@ -352,6 +353,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 	.reader-post-card__post-details {
 		flex: 1 auto;
+		width: 100%;
 	}
 
 	@media #{$reader-post-card-breakpoint-large} {


### PR DESCRIPTION
Fix for https://github.com/Automattic/wp-calypso/issues/10246
