### PR TITLE
Reader: Force line breaks in full-post recs

### DIFF
--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -76,6 +76,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	flex-grow: 1;
 	list-style-type: none;
 	margin-top: -3px;
+	min-width: 0;
 
 	&:first-child {
 		margin-right: 15px;
@@ -269,7 +270,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		margin-top: 40px;
 
 		.reader-related-card-v2__post {
-			max-height: 205px;
+			max-height: 211px;
 
 			@include breakpoint( "<960px" ) {
 				max-height: 249px;
@@ -351,12 +352,12 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 .reader-related-card-v2__byline-author {
 	margin-top: -5px;
-	word-break: break-word;
+	word-wrap: break-word;
 }
 
 .reader-related-card-v2__byline-site {
 	margin-top: -4px;
-	word-break: break-word;
+	word-wrap: break-word;
 }
 
 .reader-related-card-v2__byline-author,
@@ -441,7 +442,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 .reader-related-card-v2__excerpt {
 	line-height: 1.6;
-	word-break: break-word;
+	word-wrap: break-word;
 
 	&::after {
 		@include long-content-fade( $size: 20% );
@@ -456,6 +457,8 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		display: -webkit-box;
 		-webkit-box-orient: vertical;
 		max-height: none;
+		-webkit-line-clamp: initial;
+		word-wrap: break-word;
 	}
 }
 


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/10194

Unfortunately, I was only able to get the exact same rec to show up once, but I believe the bug was caused by the lines of code in the rec which overflowed outside of the container, particularly:

```Installasi wordpress dalam tutorial ini saya menggunakan WordPress CMS versi 4.6.1 (Terbaru saat tutorial ini dibuat) dan Sistem Operasi Elementary Freya (berbasis Linux Ubuntu 14.04). Sedangkan cara installasi yang saya pakai adalah menggunakan console/terminal.
Sebelum ke langkah-langkah installasi, pastikan requirement oleh wordpress sudah terpenuhi. Pastikan anda sudah install beberapa hal berikut :
 */
define('AUTH_KEY', '^407[he.ygi[l(H{9d4ms&lt;0$oyMOTu3F@@.;=aY1EvTA;K}U&gt;(0$OT}I^%ueeQ@&amp;');
define('SECURE_AUTH_KEY', '/RmC$p4G9C9(PlJkXe0[x11gbrnu@JWDl4jZ7f?rdTU5T1hXA@q$cJv[^6G/Gk|#');
define('LOGGED_IN_KEY', 'q7q$;M@8:!mFD=_[nNg$7Q_}_}PX8pNt?:O)z&amp;]YbxL0h3HpIxw]U:2z6Y^IhU*_');
define('NONCE_KEY', 'Ad,bk#aa1=O7`QutB!&amp;dIOY|I3lt/[&amp;vO=_%,KXl9u~Vk3U6&amp;tLT&gt;04C(UPEl~{@');
define('AUTH_SALT', 'Yzj-cJ%@/A3Rt1~6j8*9FNLIC`SBJLJK&amp;0A}f*$jdAyl,^S!*e[@Z(-!tihk}Ltj');
define('SECURE_AUTH_SALT', '7n!2D+nywdFN?sn2.A=msh)_M@ _wzj)I`24aG=qP86k2ICO}6X A^&lt;Y4C$Ir3u5');
define('LOGGED_IN_SALT', 'A;+KoBrQ_y[fWJ`MNFGL{}lb8ZdT&amp;?6~&amp;9]i=`]YuZ$y0;!Ub{SI09B%7&amp;f0 y9O');
define('NONCE_SALT', 'lix=bpc|d8inGX;6L(}y(?UsO-E|Vq4Wc4YfyPbpOLpPu)a`d&lt;?_)_D:|IfJ,l=m');
```

So I had to just copy/paste that content using Inspect.

This PR forces line breaks in links or unbreakable strings.

**Before:**
![screenshot 2016-12-22 20 27 48](https://cloud.githubusercontent.com/assets/4924246/21447234/92973b68-c886-11e6-8f13-b599b9ab168c.png)

**After:**
![screenshot 2016-12-22 20 27 53](https://cloud.githubusercontent.com/assets/4924246/21447235/97f863d4-c886-11e6-87d3-3becc8b23775.png)

I've also made text-only recs match the height of those with images in other browsers.

**Before:**
![screenshot 2016-12-22 20 26 46](https://cloud.githubusercontent.com/assets/4924246/21447273/489880ac-c887-11e6-889f-ef49a642f913.png)

**After:**
![screenshot 2016-12-22 20 26 57](https://cloud.githubusercontent.com/assets/4924246/21447277/4e467ba8-c887-11e6-84cf-90b909732e35.png)

