### PR TITLE
Framework: Remove sitesList from Pages view

### DIFF
--- a/client/my-sites/pages/controller.js
+++ b/client/my-sites/pages/controller.js
@@ -7,8 +7,7 @@ var React = require( 'react' ),
 /**
  * Internal Dependencies
  */
-var sites = require( 'lib/sites-list' )(),
-	route = require( 'lib/route' ),
+var route = require( 'lib/route' ),
 	analytics = require( 'lib/analytics' ),
 	titlecase = require( 'to-title-case' ),
 	trackScrollPage = require( 'lib/track-scroll-page' ),
@@ -27,19 +26,15 @@ var controller = {
 			analyticsPageTitle = 'Pages',
 			baseAnalyticsPath;
 
-		status = ( ! status || status === siteID ) ? '' : status;
 		context.store.dispatch( setTitle( i18n.translate( 'Pages', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+
+		status = ( ! status || status === siteID ) ? 'published' : status;
+		analyticsPageTitle += ' > ' + titlecase( status );
 
 		if ( siteID ) {
 			baseAnalyticsPath = basePath + '/:site';
 		} else {
 			baseAnalyticsPath = basePath;
-		}
-
-		if ( status.length ) {
-			analyticsPageTitle += ' > ' + titlecase( status );
-		} else {
-			analyticsPageTitle += ' > Published';
 		}
 
 		analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
@@ -49,7 +44,6 @@ var controller = {
 				context: context,
 				siteID: siteID,
 				status: status,
-				sites: sites,
 				search: search,
 				trackScrollPage: trackScrollPage.bind(
 					null,

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -20,6 +20,7 @@ var PageList = require( './page-list' ),
 	Main = require( 'components/main' ),
 	PagesFirstView = require( './first-view' );
 import { getSelectedSite } from 'state/ui/selectors';
+import QuerySites from 'components/data/query-sites';
 
 const statuses = [ 'published', 'drafts', 'scheduled', 'trashed' ];
 
@@ -71,6 +72,7 @@ const Pages = React.createClass( {
 		};
 		return (
 			<Main classname="pages">
+				<QuerySites allSites={ true } />
 				<PagesFirstView />
 				<SidebarNavigation />
 				<SectionNav selectedText={ filterStrings[ status ] }>

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -3,6 +3,7 @@
  */
 var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:my-sites:pages:pages' );
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -12,48 +13,50 @@ var PageList = require( './page-list' ),
 	NavTabs = require( 'components/section-nav/tabs' ),
 	NavItem = require( 'components/section-nav/item' ),
 	Search = require( 'components/search' ),
-	observe = require( 'lib/mixins/data-observe' ),
 	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
 	URLSearch = require( 'lib/mixins/url-search' ),
 	config = require( 'config' ),
 	notices = require( 'notices' ),
 	Main = require( 'components/main' ),
 	PagesFirstView = require( './first-view' );
+import { getSelectedSite } from 'state/ui/selectors';
 
 const statuses = [ 'published', 'drafts', 'scheduled', 'trashed' ];
 
-module.exports = React.createClass( {
+const Pages = React.createClass( {
 
 	displayName: 'Pages',
 
-	mixins: [ observe( 'sites' ), URLSearch ],
+	mixins: [ URLSearch ],
 
 	propTypes: {
-		trackScrollPage: React.PropTypes.func.isRequired
+		perPage: React.PropTypes.number,
+		site: React.PropTypes.object,
+		status: React.PropTypes.string,
+		trackScrollPage: React.PropTypes.func.isRequired,
 	},
 
 	getDefaultProps: function() {
 		return {
-			perPage: 20
+			perPage: 20,
+			status: 'published',
 		};
 	},
 
 	componentWillMount: function() {
-		var selectedSite = this.props.sites.getSelectedSite();
-		this._setWarning( selectedSite );
+		this._setWarning( this.props.site );
 	},
 
 	componentDidMount: function() {
 		debug( 'Pages React component mounted.' );
 	},
 
-	componentWillReceiveProps: function( nextProps ) {
-		var selectedSite = nextProps.sites.getSelectedSite();
-		this._setWarning( selectedSite );
+	componentWillReceiveProps: function( { site } ) {
+		this._setWarning( site );
 	},
 
 	render: function() {
-		const status = this.props.status || 'published';
+		const { status } = this.props;
 		const filterStrings = {
 			published: this.translate( 'Published', { context: 'Filter label for pages list' } ),
 			drafts: this.translate( 'Drafts', { context: 'Filter label for pages list' } ),
@@ -90,7 +93,8 @@ module.exports = React.createClass( {
 	},
 
 	getNavItems( filterStrings, currentStatus ) {
-		const siteFilter = this.props.sites.selected ? '/' + this.props.sites.selected : '';
+		const siteFilter = this.props.site ? '/' + this.props.site.slug : '';
+
 		return statuses.map( function( status ) {
 			let path = `/pages${ siteFilter }`;
 			if ( status !== 'publish' ) {
@@ -116,3 +120,9 @@ module.exports = React.createClass( {
 		}
 	}
 } );
+
+export default connect(
+	( state ) => ( {
+		site: getSelectedSite( state ),
+	} ),
+)( Pages );

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -31,7 +31,6 @@ import {
 	isFrontPage,
 	isPostsPage,
 } from 'state/pages/selectors';
-import QuerySites from 'components/data/query-sites';
 import { setFrontPage } from 'state/sites/actions';
 import { userCan } from 'lib/site/utils';
 import { updateSitesList } from './helpers';
@@ -365,7 +364,6 @@ const Page = React.createClass( {
 
 		return (
 			<CompactCard className="page">
-				{ ! this.props.site && <QuerySites siteId={ page.site_ID } /> }
 				{ this.props.multisite ? <SiteIcon site={ site } size={ 34 } /> : null }
 				<a className="page__title"
 					href={ canEdit ? helpers.editLinkForPage( page, site ) : page.URL }

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -26,11 +26,12 @@ var updatePostStatus = require( 'lib/mixins/update-post-status' ),
 
 import MenuSeparator from 'components/popover/menu-separator';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { hasStaticFrontPage } from 'state/sites/selectors';
+import { getSite, hasStaticFrontPage } from 'state/sites/selectors';
 import {
 	isFrontPage,
 	isPostsPage,
 } from 'state/pages/selectors';
+import QuerySites from 'components/data/query-sites';
 import { setFrontPage } from 'state/sites/actions';
 import { userCan } from 'lib/site/utils';
 import { updateSitesList } from './helpers';
@@ -364,6 +365,7 @@ const Page = React.createClass( {
 
 		return (
 			<CompactCard className="page">
+				{ ! this.props.site && <QuerySites siteId={ page.site_ID } /> }
 				{ this.props.multisite ? <SiteIcon site={ site } size={ 34 } /> : null }
 				<a className="page__title"
 					href={ canEdit ? helpers.editLinkForPage( page, site ) : page.URL }
@@ -423,6 +425,7 @@ export default connect(
 			hasStaticFrontPage: hasStaticFrontPage( state, props.page.site_ID ),
 			isFrontPage: isFrontPage( state, props.page.site_ID, props.page.ID ),
 			isPostsPage: isPostsPage( state, props.page.site_ID, props.page.ID ),
+			site: getSite( state, props.page.site_ID ),
 		};
 	},
 	( dispatch ) => bindActionCreators( {


### PR DESCRIPTION
This PR aims to help facilitate progress in removing `sitesList` from Calypso. There wasn't a concrete example to point to in last week's framework hangout, so I'm hoping this could be used as one in the next hangout.

It removes `sitesList` from the Pages menu, and in doing so fixed a bug where the `isFrontPage` check didn't return an accurate result.

Before:
<img width="366" alt="screen shot 2016-12-23 at 10 12 54 am" src="https://cloud.githubusercontent.com/assets/1398304/21450898/21789740-c8fb-11e6-9f08-e847e7f109e4.png">

After:
<img width="397" alt="screen shot 2016-12-23 at 10 13 06 am" src="https://cloud.githubusercontent.com/assets/1398304/21450900/25e2a564-c8fb-11e6-96cd-9b0cb8da800c.png">

To test, go to [/pages](http://calypso.localhost:3000/pages/) to verify pages of visible sites are being loaded, as well as site data like site icon and url. Then select a site and view Pages for that site.

I'll be AFK until 1/8, so if this gets approved during that time, please feel free to merge and not wait for me.

See #8726.