### PR TITLE
Signup: remove `domainSuggestionPopover` AB

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -11,7 +11,6 @@ import { connect } from 'react-redux';
 import PremiumPopover from 'components/plans/premium-popover';
 import { currentUserHasFlag, getCurrentUser } from 'state/current-user/selectors';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
-import { abtest } from 'lib/abtest';
 
 const DomainProductPrice = React.createClass( {
 	propTypes: {
@@ -85,15 +84,13 @@ const DomainProductPrice = React.createClass( {
 			return <div className="domain-product-price is-placeholder">{ this.translate( 'Loading…' ) }</div>;
 		}
 
-		const showPopover = abtest( 'domainSuggestionPopover' ) === 'showPopover';
-
 		switch ( this.props.rule ) {
 			case 'FREE_DOMAIN':
-				return showPopover && this.renderFree();
+				return this.renderFree();
 			case 'FREE_WITH_PLAN':
 				return this.renderFreeWithPlan();
 			case 'INCLUDED_IN_PREMIUM':
-				return showPopover && this.renderIncludedInPremium();
+				return this.renderIncludedInPremium();
 			case 'PRICE':
 			default:
 				return this.renderPrice();

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -53,15 +53,6 @@ module.exports = {
 		defaultVariation: 'hideThemeUpload',
 		allowExistingUsers: false,
 	},
-	domainSuggestionPopover: {
-		datestamp: '20160809',
-		variations: {
-			showPopover: 80,
-			hidePopover: 20,
-		},
-		defaultVariation: 'showPopover',
-		allowExistingUsers: false,
-	},
 	designShowcaseWelcomeTour: {
 		datestamp: '20161206',
 		variations: {


### PR DESCRIPTION
Removing 'Included with WordPress.com Premium' from the domain suggestion results causes both a drop in Signup completion and purchasing conversion, across the board. A better test might leave the 'Included with WordPress.com Premium/Free' text and remove just the popover.