### PR TITLE
Jetpack Settings: Use mapValues instead of map in fetchModuleList()

### DIFF
--- a/client/state/jetpack-settings/modules/actions.js
+++ b/client/state/jetpack-settings/modules/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { omit, map } from 'lodash';
+import { omit, mapValues } from 'lodash';
 
 /**
  * Internal dependencies
@@ -97,7 +97,7 @@ export const fetchModuleList = ( siteId ) => {
 
 		return wp.undocumented().getJetpackModules( siteId )
 			.then( ( { data } ) => {
-				const modules = map(
+				const modules = mapValues(
 					data,
 					( module ) => ( {
 						active: module.activated,

--- a/client/state/jetpack-settings/modules/test/actions.js
+++ b/client/state/jetpack-settings/modules/test/actions.js
@@ -3,7 +3,7 @@
  */
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { omit, map } from 'lodash';
+import { omit, mapValues } from 'lodash';
 
 /**
  * Internal dependencies
@@ -201,7 +201,7 @@ describe( 'actions', () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: JETPACK_MODULES_RECEIVE,
 						siteId,
-						modules: map(
+						modules: mapValues(
 							API_MODULE_LIST_RESPONSE_FIXTURE.data,
 							( module ) => ( {
 								active: module.activated,


### PR DESCRIPTION
In #10077 we introduced a small issue with `fetchModulesList()` - we should use `mapValues()` instead of `map()`, because we expect to store objects instead of arrays.

/cc @oskosk 