### PR TITLE
CircleCI config: fix master pot generation

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ test:
           # make the build-server and i18n string data in parallel
           if [[ "$CIRCLE_NODE_INDEX" == 0 ]]; then NODE_ENV=test make build-server; fi
           if ( [[ "$CIRCLE_NODE_INDEX" == 1 ]] || [[ "$CIRCLE_NODE_TOTAL" == 1 ]] ) && [[ "$CIRCLE_BRANCH" == "master" ]]; then
-            make translate
+            make translate; mkdir -p $CIRCLE_ARTIFACTS/translate; mv calypso-strings.pot $CIRCLE_ARTIFACTS/translate
           elif [[ "$CIRCLE_NODE_INDEX" == 1 ]] || [[ "$CIRCLE_NODE_TOTAL" == 1 ]]; then
             git clone https://github.com/Automattic/gp-localci-client.git
             bash gp-localci-client/generate-new-strings-pot.sh $CIRCLE_BRANCH $CIRCLE_SHA1 $CIRCLE_ARTIFACTS/translate


### PR DESCRIPTION
We forgot to move the master-generated pot to the artifacts directory in 25c6210c84244bb865b77a03e64fedd46c65e7d7.