### PR TITLE
Guided Tours: Fix Site Title tour

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -203,6 +203,7 @@ class SiteSettingsFormGeneral extends Component {
 						<FormInput
 							name="blogname"
 							id="blogname"
+							data-tip-target="site-title-input"
 							type="text"
 							value={ fields.blogname || '' }
 							onChange={ this.onChangeField( 'blogname' ) }
@@ -216,6 +217,7 @@ class SiteSettingsFormGeneral extends Component {
 							name="blogdescription"
 							type="text"
 							id="blogdescription"
+							data-tip-target="site-tagline-input"
 							value={ fields.blogdescription || '' }
 							onChange={ this.onChangeField( 'blogdescription' ) }
 							disabled={ isRequestingSettings }


### PR DESCRIPTION
Tip targets were recently removed from the input for title (blogname) and tagline (blogdescription).

# To test

Make sure that the tour can be taken from start to finish:

`http://calypso.localhost:3000/stats/day/SOMEBLOG?tour=siteTitle`