### PR TITLE
Signup: User First signup AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -113,8 +113,8 @@ module.exports = {
 	userFirstSignup: {
 		datestamp: '20161223',
 		variations: {
-			userLast: 95,
-			userFirst: 5,
+			userLast: 99,
+			userFirst: 1,
 		},
 		defaultVariation: 'userLast',
 		allowExistingUsers: false,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -109,4 +109,14 @@ module.exports = {
 		defaultVariation: 'disabled',
 		allowExistingUsers: true,
 	},
+
+	userFirstSignup: {
+		datestamp: '20161223',
+		variations: {
+			userLast: 95,
+			userFirst: 5,
+		},
+		defaultVariation: 'userLast',
+		allowExistingUsers: false,
+	},
 };

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -279,7 +279,7 @@ function filterFlowName( flowName ) {
 		 * it doesn't contain the `user` step to register a user and site respectively.
  		 */
 		if ( flowName === 'userfirst-secondary' ) {
-			return 'main';
+			return 'userfirst';
 		}
 	}
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -266,8 +266,21 @@ function filterDesignTypeInFlow( flow ) {
 function filterFlowName( flowName ) {
 	const defaultFlows = [ 'main', 'website' ];
 
-	if ( includes( defaultFlows, flowName ) && abtest( 'userFirstSignup' ) === 'userFirst' ) {
-		return 'userfirst';
+	/**
+	 * Only run the User First Signup for logged out users.
+	 */
+	if ( ! user.get() ) {
+		if ( includes( defaultFlows, flowName ) && abtest( 'userFirstSignup' ) === 'userFirst' ) {
+			return 'userfirst';
+		}
+
+		/**
+		 * Users should not be able to reach `userfirst-secondary` without being logged in, since
+		 * it doesn't contain the `user` step to register a user and site respectively.
+ 		 */
+		if ( flowName === 'userfirst-secondary' ) {
+			return 'main';
+		}
 	}
 
 	return flowName;

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -209,10 +209,17 @@ const flows = {
 
 	userfirst: {
 		steps: [ 'user' ],
-		destination: '/start',
+		destination: '/start/userfirst-secondary',
 		description: 'User-first signup flow',
-		lastModified: '2016-11-29',
+		lastModified: '2016-12-23',
 		autoContinue: true,
+	},
+
+	'userfirst-secondary': {
+		steps: [ 'design-type', 'themes', 'domains', 'plans' ],
+		destination: getSiteDestination,
+		description: 'Secondary flow for User First signup',
+		lastModified: '2016-12-23'
 	},
 
 	'domain-first': {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -258,7 +258,11 @@ function filterDesignTypeInFlow( flow ) {
 
 function filterFlowName( flowName ) {
 	const defaultFlows = [ 'main', 'website' ];
-	// do nothing. No flows to filter at the moment.
+
+	if ( includes( defaultFlows, flowName ) && abtest( 'userFirstSignup' ) === 'userFirst' ) {
+		return 'userfirst';
+	}
+
 	return flowName;
 }
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -36,7 +36,10 @@ export default React.createClass( {
 		/**
 		 * Update the step sub-header if they only want to create an account, without a site.
 		 */
-		if ( 1 === signupUtils.getFlowSteps( props.flowName ).length ) {
+		if (
+			1 === signupUtils.getFlowSteps( props.flowName ).length &&
+			'userfirst' !== props.flowName
+		) {
 			subHeaderText = this.translate( 'Welcome to the wonderful WordPress.com community' );
 		}
 


### PR DESCRIPTION
This PR aims to enable an AB test for User First signup.

We're testing a new flow for user signup, which would put the user creation first and then continue the signup as an already logged in user. 

This would allow to put new things that require users to be logged in to work, like Guided Tours, Checkout during signup, etc.

To test:

1. Checkout branch or use Calypso.live link
2. Start signup
3. Try both AB test variations for `userFirstSignup`
4. Verify Signup is working properly and you can create a site.
6. Verify there are no JS errors in the console

cc @meremagee 