### PR TITLE
Reader: Center card images

### DIFF
--- a/client/blocks/reader-post-card/featured-image.jsx
+++ b/client/blocks/reader-post-card/featured-image.jsx
@@ -18,7 +18,7 @@ const FeaturedImage = ( { imageUri, href, children, onClick } ) => {
 		backgroundImage: 'url(' + cssSafeUrl( imageUri ) + ')',
 		backgroundSize: 'cover',
 		backgroundRepeat: 'no-repeat',
-		backgroundPosition: 'right center'
+		backgroundPosition: 'center center'
 	};
 
 	return (


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/10218

It doesn't seem like it's off-center only in narrow widths.

**Before:**
![screenshot 2016-12-23 10 11 18](https://cloud.githubusercontent.com/assets/4924246/21460015/b1261ffa-c8f8-11e6-9b4e-dde79de5c5eb.png)

![screenshot 2016-12-23 10 13 38](https://cloud.githubusercontent.com/assets/4924246/21460019/b5069dca-c8f8-11e6-8668-998582362eb2.png)

**After:**
![screenshot 2016-12-23 10 11 25](https://cloud.githubusercontent.com/assets/4924246/21460033/d594d49e-c8f8-11e6-8121-3d75165e2511.png)

![screenshot 2016-12-23 10 13 25](https://cloud.githubusercontent.com/assets/4924246/21460035/d95d02e0-c8f8-11e6-9c9b-de9581403923.png)
