### PR TITLE
Framework: Overload resizeImageUrl to use service detection

### DIFF
--- a/client/components/site-icon/index.jsx
+++ b/client/components/site-icon/index.jsx
@@ -3,8 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { get, includes } from 'lodash';
-import { parse as parseUrl } from 'url';
+import { get } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -33,25 +32,10 @@ const SiteIcon = React.createClass( {
 		size: React.PropTypes.number
 	},
 
-	getIconSrcUrl() {
-		const { iconUrl } = this.props;
-		if ( ! iconUrl ) {
-			return;
-		}
-
-		const { host } = parseUrl( iconUrl, true, true );
-		const sizeParam = includes( host, 'gravatar.com' ) ? 's' : 'w';
-
-		return resizeImageUrl( iconUrl, {
-			[ sizeParam ]: this.props.imgSize
-		} );
-	},
-
 	render() {
-		const { site, siteId } = this.props;
+		const { site, siteId, iconUrl, imgSize } = this.props;
 
-		// Set the site icon path if it's available
-		const iconSrc = this.getIconSrcUrl();
+		const iconSrc = resizeImageUrl( iconUrl, imgSize );
 
 		const iconClasses = classNames( {
 			'site-icon': true,

--- a/client/lib/resize-image-url/README.md
+++ b/client/lib/resize-image-url/README.md
@@ -5,14 +5,28 @@ or host.
 
 ## Usage
 
-Pass a URL and object of resizing parameters to the function. The return value
+Pass a URL and either a numeric resize values (pixels width and optional 
+height), or an object of resizing parameters to the function. The return value
 reflects the resized image URL. The function supports WordPress.com, Photon,
 and Gravatar image URLs.
+
+If passing numeric resize values, the function will automatically detect the
+service hosting the URL (WordPress.com, Photon, Gravatar) and append the
+appropriate query arguments. If the passed URL does not match one of these
+services, it will first be processed using [`safeImageUrl`](../safe-image-url),
+which will convert it to a Photon URL automatically before applying the resize
+query arguments.
 
 ```js
 resizeImageUrl( 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?w=1000', { resize: '500,500' } );
 // https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?resize=500%2C500
+
+resizeImageUrl( 'https://1.gravatar.com/avatar/767fc9c115a1b989744c755db47feb60', 200 );
+// https://1.gravatar.com/avatar/767fc9c115a1b989744c755db47feb60?s=200
+
+resizeImageUrl( 'https://example.com/image.gif', 50, 20 );
+// https://i0.wp.com/example.com/image.gif?fit=50%2C20
 ```
 
-Reference the [Photon API documentation](https://developer.wordpress.com/docs/photon/api/)
+If passing an object of query arguments, reference the [Photon API documentation](https://developer.wordpress.com/docs/photon/api/)
 for supported parameters to be passed.

--- a/client/lib/resize-image-url/index.js
+++ b/client/lib/resize-image-url/index.js
@@ -61,6 +61,10 @@ const scaleByFactor = ( value ) => value * IMAGE_SCALE_FACTOR;
  * @returns {String}                   Resize image URL
  */
 export default function resizeImageUrl( imageUrl, resize, height ) {
+	if ( 'string' !== typeof imageUrl ) {
+		return imageUrl;
+	}
+
 	const parsedUrl = parse( imageUrl, true, true );
 	if ( ! REGEXP_VALID_PROTOCOL.test( parsedUrl.protocol ) ) {
 		return imageUrl;

--- a/client/lib/resize-image-url/index.js
+++ b/client/lib/resize-image-url/index.js
@@ -1,8 +1,13 @@
 /**
  * External Dependencies
  */
-import { get, assign, omit, includes, mapValues } from 'lodash';
+import { get, assign, omit, includes, mapValues, findKey } from 'lodash';
 import { parse, format } from 'url';
+
+/**
+ * Internal dependencies
+ */
+import safeImageUrl from 'lib/safe-image-url';
 
 /**
  * Pattern matching valid http(s) URLs
@@ -28,6 +33,16 @@ const IMAGE_SCALE_FACTOR = get( global.window, 'devicePixelRatio', 1 ) > 1 ? 2 :
 const SIZE_PARAMS = [ 'w', 'h', 'resize', 'fit', 's' ];
 
 /**
+ * Mappings of supported safe services to patterns by which they can be matched
+ *
+ * @type {Object}
+ */
+const SERVICE_HOSTNAME_PATTERNS = {
+	photon: /(^i\d\.wp\.com|(^|\.)wordpress\.com)$/,
+	gravatar: /(^|\.)gravatar\.com$/
+};
+
+/**
  * Given a numberic value, returns the value multiplied by image scale factor
  *
  * @param  {Number} value Original value
@@ -39,11 +54,13 @@ const scaleByFactor = ( value ) => value * IMAGE_SCALE_FACTOR;
  * Changes the sizing parameters on a URL. Works for WordPress.com, Photon, and
  * Gravatar images
  *
- * @param   {String} imageUrl Original image url
- * @param   {Object} params   Resize parameters to add
- * @returns {String}          Resize image URL
+ * @param   {String}          imageUrl Original image url
+ * @param   {(Number|Object)} resize   Resize pixel width, or object of query
+ *                                     arguments (assuming Photon or Gravatar)
+ * @param   {?Number}         height   Pixel height if specifying resize width
+ * @returns {String}                   Resize image URL
  */
-export default function resizeImageUrl( imageUrl, params ) {
+export default function resizeImageUrl( imageUrl, resize, height ) {
 	const parsedUrl = parse( imageUrl, true, true );
 	if ( ! REGEXP_VALID_PROTOCOL.test( parsedUrl.protocol ) ) {
 		return imageUrl;
@@ -51,8 +68,25 @@ export default function resizeImageUrl( imageUrl, params ) {
 
 	parsedUrl.query = omit( parsedUrl.query, SIZE_PARAMS );
 
+	if ( 'number' === typeof resize ) {
+		const service = findKey( SERVICE_HOSTNAME_PATTERNS, String.prototype.match.bind( parsedUrl.hostname ) );
+		if ( 'gravatar' === service ) {
+			resize = { s: resize };
+		} else {
+			resize = height > 0
+				? { fit: [ resize, height ].join() }
+				: { w: resize };
+
+			// External URLs are made "safe" (i.e. passed through Photon), so
+			// recurse with an assumed set of query arguments for Photon
+			if ( ! service ) {
+				return resizeImageUrl( safeImageUrl( imageUrl ), resize );
+			}
+		}
+	}
+
 	// Map sizing parameters, multiplying their values by the scale factor
-	assign( parsedUrl.query, mapValues( params, ( value, key ) => {
+	assign( parsedUrl.query, mapValues( resize, ( value, key ) => {
 		if ( 'resize' === key || 'fit' === key ) {
 			return value.split( ',' ).map( scaleByFactor ).join( ',' );
 		} else if ( includes( SIZE_PARAMS, key ) ) {

--- a/client/lib/resize-image-url/test/index.js
+++ b/client/lib/resize-image-url/test/index.js
@@ -34,6 +34,72 @@ describe( 'resizeImageUrl()', () => {
 		expect( resizedUrl ).to.equal( expectedUrl );
 	} );
 
+	context( 'numeric width', () => {
+		context( 'wpcom', () => {
+			it( 'should append width as ?w query argument', () => {
+				const original = 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg';
+				const resized = resizeImageUrl( original, 40 );
+				const expected = 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?w=40';
+				expect( resized ).to.equal( expected );
+			} );
+
+			it( 'should append ?fit query argument if both width and height provided', () => {
+				const original = 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg';
+				const resized = resizeImageUrl( original, 40, 20 );
+				const expected = 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?fit=40%2C20';
+				expect( resized ).to.equal( expected );
+			} );
+		} );
+
+		context( 'photon', () => {
+			it( 'should append width as ?w query argument', () => {
+				const original = 'https://i0.wp.com/example.com/foo.png';
+				const resized = resizeImageUrl( original, 40 );
+				const expected = 'https://i0.wp.com/example.com/foo.png?w=40';
+				expect( resized ).to.equal( expected );
+			} );
+
+			it( 'should append ?fit query argument if both width and height provided', () => {
+				const original = 'https://i0.wp.com/example.com/foo.png';
+				const resized = resizeImageUrl( original, 40, 20 );
+				const expected = 'https://i0.wp.com/example.com/foo.png?fit=40%2C20';
+				expect( resized ).to.equal( expected );
+			} );
+		} );
+
+		context( 'gravatar', () => {
+			it( 'should append width as ?s query argument', () => {
+				const original = 'https://gravatar.com/avatar/00000000000000000000000000000000';
+				const resized = resizeImageUrl( original, 40 );
+				const expected = 'https://gravatar.com/avatar/00000000000000000000000000000000?s=40';
+				expect( resized ).to.equal( expected );
+			} );
+
+			it( 'should ignore height', () => {
+				const original = 'https://gravatar.com/avatar/00000000000000000000000000000000';
+				const resized = resizeImageUrl( original, 40, 20 );
+				const expected = 'https://gravatar.com/avatar/00000000000000000000000000000000?s=40';
+				expect( resized ).to.equal( expected );
+			} );
+		} );
+
+		context( 'external', () => {
+			it( 'should return a Photonized (safe) resized image with width', () => {
+				const original = 'https://example.com/foo.png';
+				const resized = resizeImageUrl( original, 40 );
+				const expected = 'https://i0.wp.com/example.com/foo.png?ssl=1&w=40';
+				expect( resized ).to.equal( expected );
+			} );
+
+			it( 'should return a Photonized (safe) resized image with width and height', () => {
+				const original = 'https://example.com/foo.png';
+				const resized = resizeImageUrl( original, 40, 20 );
+				const expected = 'https://i0.wp.com/example.com/foo.png?ssl=1&fit=40%2C20';
+				expect( resized ).to.equal( expected );
+			} );
+		} );
+	} );
+
 	context( 'standard pixel density', () => {
 		it( 'should append resize argument', () => {
 			const resizedUrl = resizeImageUrl( imageUrl, { resize: '40,40' } );

--- a/client/lib/resize-image-url/test/index.js
+++ b/client/lib/resize-image-url/test/index.js
@@ -11,6 +11,12 @@ describe( 'resizeImageUrl()', () => {
 		resizeImageUrl = require( '..' );
 	} );
 
+	it( 'should return non-string URLs unmodified', () => {
+		expect( resizeImageUrl() ).to.be.undefined;
+		expect( resizeImageUrl( null ) ).to.be.null;
+		expect( resizeImageUrl( 1 ) ).to.equal( 1 );
+	} );
+
 	it( 'should strip original query params', () => {
 		const resizedUrl = resizeImageUrl( imageUrl );
 		expect( resizedUrl ).to.equal( 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg' );


### PR DESCRIPTION
Related: #9850

This pull request seeks to further enhance `resizeImageUrl` to simply accept a numeric pixel width to which the URL should be resized, detecting the service hosting the URL and automatically generating the correct query arguments to be appended to the URL.

From the updated README.md:

>If passing numeric resize values, the function will automatically detect the service hosting the URL (WordPress.com, Photon, Gravatar) and append the appropriate query arguments. If the passed URL does not match one of these services, it will first be processed using safeImageUrl, which will convert it to a Photon URL automatically before applying the resize query arguments.
>
>```
>resizeImageUrl( 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?w=1000', { resize: '500,500' } );
>// https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?resize=500%2C500
>
>resizeImageUrl( 'https://1.gravatar.com/avatar/767fc9c115a1b989744c755db47feb60', 200 );
>// https://1.gravatar.com/avatar/767fc9c115a1b989744c755db47feb60?s=200
>
>resizeImageUrl( 'https://example.com/image.gif', 50, 20 );
>// https://i0.wp.com/example.com/image.gif?fit=50%2C20
>```

__Testing instructions:__

Ideally this should have no impact on existing usage, since the function is simply overloaded and the behavior is only adjusted in the case that a numeric value is specified instead of what had previously only been passed as an object.

Confirm that unit tests pass:

```
npm run test-client client/lib/resize-image-url
```

~If you're feeling ambitious, try to contemplate a situation in which a service would not be detected by `resizeImageUrl` but would be considered safe by `safeImageUrl`, thereby throwing `resizeImageUrl` with numeric resize into an infinite loop.~ Worry quelled, see https://github.com/Automattic/wp-calypso/pull/10264#issuecomment-269993898.