### PR TITLE
Components: Update `react-virtualized` to v8.x (wrapping)

### DIFF
--- a/client/blocks/term-tree-selector/terms.jsx
+++ b/client/blocks/term-tree-selector/terms.jsx
@@ -5,7 +5,7 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { List } from 'react-virtualized';
+import List from 'react-virtualized/List';
 import {
 	debounce,
 	difference,

--- a/client/blocks/term-tree-selector/terms.jsx
+++ b/client/blocks/term-tree-selector/terms.jsx
@@ -391,10 +391,7 @@ const TermTreeSelectorList = React.createClass( {
 
 	cellRendererWrapper: function( { key, style, ...rest } ) {
 		return (
-			<div
-				className="Grid__cell"
-				key={ key }
-				style={ style }>
+			<div key={ key } style={ style }>
 				{ this.renderRow( rest ) }
 			</div>
 		);

--- a/client/blocks/term-tree-selector/terms.jsx
+++ b/client/blocks/term-tree-selector/terms.jsx
@@ -389,7 +389,7 @@ const TermTreeSelectorList = React.createClass( {
 		);
 	},
 
-	cellRendererWrapper: function( { key, style, ...rest } ) {
+	cellRendererWrapper( { key, style, ...rest } ) {
 		return (
 			<div key={ key } style={ style }>
 				{ this.renderRow( rest ) }

--- a/client/blocks/term-tree-selector/terms.jsx
+++ b/client/blocks/term-tree-selector/terms.jsx
@@ -5,7 +5,7 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import VirtualScroll from 'react-virtualized/VirtualScroll';
+import { List } from 'react-virtualized';
 import {
 	debounce,
 	difference,
@@ -82,7 +82,7 @@ const TermTreeSelectorList = React.createClass( {
 	componentWillMount() {
 		this.itemHeights = {};
 		this.hasPerformedSearch = false;
-		this.virtualScroll = null;
+		this.list = null;
 
 		this.termIds = map( this.props.terms, 'ID' );
 		this.getTermChildren = memoize( this.getTermChildren );
@@ -111,7 +111,7 @@ const TermTreeSelectorList = React.createClass( {
 		);
 
 		if ( forceUpdate ) {
-			this.virtualScroll.forceUpdate();
+			this.list.forceUpdate();
 		}
 
 		if ( this.props.terms !== prevProps.terms ) {
@@ -120,12 +120,12 @@ const TermTreeSelectorList = React.createClass( {
 	},
 
 	recomputeRowHeights: function() {
-		if ( ! this.virtualScroll ) {
+		if ( ! this.list ) {
 			return;
 		}
 
-		this.virtualScroll.recomputeRowHeights();
-		this.virtualScroll.forceUpdate();
+		this.list.recomputeRowHeights();
+		this.list.forceUpdate();
 
 		// Compact mode passes the height of the scrollable region as a derived
 		// number, and will not be updated unless our component re-renders
@@ -294,8 +294,8 @@ const TermTreeSelectorList = React.createClass( {
 		this.debouncedSearch();
 	},
 
-	setVirtualScrollRef( ref ) {
-		this.virtualScroll = ref;
+	setListRef( ref ) {
+		this.list = ref;
 	},
 
 	renderItem( item, _recurse = false ) {
@@ -389,6 +389,17 @@ const TermTreeSelectorList = React.createClass( {
 		);
 	},
 
+	cellRendererWrapper: function( { key, style, ...rest } ) {
+		return (
+			<div
+				className="Grid__cell"
+				key={ key }
+				style={ style }>
+				{ this.renderRow( rest ) }
+			</div>
+		);
+	},
+
 	render() {
 		const rowCount = this.getRowCount();
 		const isCompact = this.isCompact();
@@ -416,15 +427,15 @@ const TermTreeSelectorList = React.createClass( {
 						searchTerm={ this.state.searchTerm }
 						onSearch={ this.onSearch } />
 				) }
-				<VirtualScroll
-					ref={ this.setVirtualScrollRef }
+				<List
+					ref={ this.setListRef }
 					width={ this.getResultsWidth() }
 					height={ isCompact ? this.getCompactContainerHeight() : 300 }
 					onRowsRendered={ this.setRequestedPages }
 					rowCount={ rowCount }
 					estimatedRowSize={ ITEM_HEIGHT }
 					rowHeight={ this.getRowHeight }
-					rowRenderer={ this.renderRow }
+					rowRenderer={ this.cellRendererWrapper }
 					noRowsRenderer={ this.renderNoResults }
 					className="term-tree-selector__results" />
 			</div>

--- a/client/blocks/term-tree-selector/terms.jsx
+++ b/client/blocks/term-tree-selector/terms.jsx
@@ -111,7 +111,7 @@ const TermTreeSelectorList = React.createClass( {
 		);
 
 		if ( forceUpdate ) {
-			this.list.forceUpdate();
+			this.list.forceUpdateGrid();
 		}
 
 		if ( this.props.terms !== prevProps.terms ) {
@@ -125,7 +125,6 @@ const TermTreeSelectorList = React.createClass( {
 		}
 
 		this.list.recomputeRowHeights();
-		this.list.forceUpdate();
 
 		// Compact mode passes the height of the scrollable region as a derived
 		// number, and will not be updated unless our component re-renders

--- a/client/components/virtual-list/index.jsx
+++ b/client/components/virtual-list/index.jsx
@@ -4,7 +4,8 @@
 import React, { PropTypes, Component } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { AutoSizer, List } from 'react-virtualized';
+import List from 'react-virtualized/List';
+import AutoSizer from 'react-virtualized/AutoSizer';
 import {
 	debounce,
 	noop,

--- a/client/components/virtual-list/index.jsx
+++ b/client/components/virtual-list/index.jsx
@@ -161,10 +161,7 @@ export class VirtualList extends Component {
 
 	cellRendererWrapper = ( { key, style, ...rest } ) => {
 		return (
-			<div
-				className="Grid__cell"
-				key={ key }
-				style={ style }>
+			<div key={ key } style={ style }>
 				{ this.renderRow( rest ) }
 			</div>
 		);

--- a/client/components/virtual-list/index.jsx
+++ b/client/components/virtual-list/index.jsx
@@ -55,7 +55,7 @@ export class VirtualList extends Component {
 		);
 
 		if ( forceUpdate ) {
-			this.list.forceUpdate();
+			this.list.forceUpdateGrid();
 		}
 
 		if ( this.props.items !== prevProps.items ) {
@@ -69,7 +69,6 @@ export class VirtualList extends Component {
 		}
 
 		this.list.recomputeRowHeights();
-		this.list.forceUpdate();
 	}
 
 	getPageForIndex( index ) {

--- a/client/my-sites/post-selector/selector.jsx
+++ b/client/my-sites/post-selector/selector.jsx
@@ -5,7 +5,8 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import getScrollbarSize from 'dom-helpers/util/scrollbarSize';
-import { AutoSizer, List } from 'react-virtualized';
+import List from 'react-virtualized/List';
+import AutoSizer from 'react-virtualized/AutoSizer';
 import {
 	debounce,
 	memoize,

--- a/client/my-sites/post-selector/selector.jsx
+++ b/client/my-sites/post-selector/selector.jsx
@@ -386,10 +386,7 @@ const PostSelectorPosts = React.createClass( {
 
 	cellRendererWrapper: function( { key, style, ...rest } ) {
 		return (
-			<div
-				className="Grid__cell"
-				key={ key }
-				style={ style }>
+			<div key={ key } style={ style }>
 				{ this.renderRow( rest ) }
 			</div>
 		);

--- a/client/my-sites/post-selector/selector.jsx
+++ b/client/my-sites/post-selector/selector.jsx
@@ -5,8 +5,7 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import getScrollbarSize from 'dom-helpers/util/scrollbarSize';
-import VirtualScroll from 'react-virtualized/VirtualScroll';
-import AutoSizer from 'react-virtualized/AutoSizer';
+import { AutoSizer, List } from 'react-virtualized';
 import {
 	debounce,
 	memoize,
@@ -115,7 +114,7 @@ const PostSelectorPosts = React.createClass( {
 		);
 
 		if ( forceUpdate ) {
-			this.virtualScroll.forceUpdate();
+			this.list.forceUpdate();
 		}
 
 		if ( this.props.posts !== prevProps.posts ) {
@@ -124,11 +123,11 @@ const PostSelectorPosts = React.createClass( {
 	},
 
 	recomputeRowHeights: function() {
-		if ( ! this.virtualScroll ) {
+		if ( ! this.list ) {
 			return;
 		}
 
-		this.virtualScroll.recomputeRowHeights();
+		this.list.recomputeRowHeights();
 
 		// Compact mode passes the height of the scrollable region as a derived
 		// number, and will not be updated unless our component re-renders
@@ -137,10 +136,10 @@ const PostSelectorPosts = React.createClass( {
 		}
 	},
 
-	setVirtualScrollRef( virtualScroll ) {
+	setListRef( ref ) {
 		// Ref callback can be called with null reference, which is desirable
 		// since we'll want to know elsewhere if we can call recompute height
-		this.virtualScroll = virtualScroll;
+		this.list = ref;
 	},
 
 	setItemRef( item, itemRef ) {
@@ -384,6 +383,17 @@ const PostSelectorPosts = React.createClass( {
 		);
 	},
 
+	cellRendererWrapper: function( { key, style, ...rest } ) {
+		return (
+			<div
+				className="Grid__cell"
+				key={ key }
+				style={ style }>
+				{ this.renderRow( rest ) }
+			</div>
+		);
+	},
+
 	render() {
 		const { className, siteId, query } = this.props;
 		const { requestedPages, searchTerm } = this.state;
@@ -416,8 +426,8 @@ const PostSelectorPosts = React.createClass( {
 						key={ JSON.stringify( query ) }
 						disableHeight={ isCompact }>
 						{ ( { height, width } ) => (
-							<VirtualScroll
-								ref={ this.setVirtualScrollRef }
+							<List
+								ref={ this.setListRef }
 								width={ width }
 								height={ isCompact ? this.getCompactContainerHeight() : height }
 								onRowsRendered={ this.setRequestedPages }
@@ -425,7 +435,7 @@ const PostSelectorPosts = React.createClass( {
 								rowCount={ this.getRowCount() }
 								estimatedRowSize={ ITEM_HEIGHT }
 								rowHeight={ this.getRowHeight }
-								rowRenderer={ this.renderRow } />
+								rowRenderer={ this.cellRendererWrapper } />
 						) }
 					</AutoSizer>
 				</div>

--- a/client/my-sites/post-selector/selector.jsx
+++ b/client/my-sites/post-selector/selector.jsx
@@ -384,7 +384,7 @@ const PostSelectorPosts = React.createClass( {
 		);
 	},
 
-	cellRendererWrapper: function( { key, style, ...rest } ) {
+	cellRendererWrapper( { key, style, ...rest } ) {
 		return (
 			<div key={ key } style={ style }>
 				{ this.renderRow( rest ) }

--- a/client/my-sites/post-selector/selector.jsx
+++ b/client/my-sites/post-selector/selector.jsx
@@ -115,7 +115,7 @@ const PostSelectorPosts = React.createClass( {
 		);
 
 		if ( forceUpdate ) {
-			this.list.forceUpdate();
+			this.list.forceUpdateGrid();
 		}
 
 		if ( this.props.posts !== prevProps.posts ) {

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -9,9 +9,7 @@ import includes from 'lodash/includes';
 import difference from 'lodash/difference';
 import range from 'lodash/range';
 import size from 'lodash/size';
-import AutoSizer from 'react-virtualized/AutoSizer';
-import WindowScroller from 'react-virtualized/WindowScroller';
-import VirtualScroll from 'react-virtualized/VirtualScroll';
+import { AutoSizer, List, WindowScroller } from 'react-virtualized';
 
 /**
  * Internal dependencies
@@ -117,6 +115,17 @@ class PostTypeList extends Component {
 		return <PostItem key={ globalId } globalId={ globalId } />;
 	}
 
+	cellRendererWrapper( { key, style, ...rest } ) {
+		return (
+			<div
+				className="Grid__cell"
+				key={ key }
+				style={ style }>
+				{ this.renderPostRow( rest ) }
+			</div>
+		);
+	}
+
 	render() {
 		const { query, siteId, posts } = this.props;
 		const isEmpty = query && posts && ! posts.length && this.isLastPage();
@@ -142,13 +151,13 @@ class PostTypeList extends Component {
 						{ ( { height, scrollTop } ) => (
 							<AutoSizer disableHeight>
 								{ ( { width } ) => (
-									<VirtualScroll
+									<List
 										autoHeight
 										scrollTop={ scrollTop }
 										height={ height }
 										width={ width }
 										onRowsRendered={ this.setRequestedPages }
-										rowRenderer={ this.renderPostRow }
+										rowRenderer={ this.cellRendererWrapper }
 										rowHeight={ POST_ROW_HEIGHT }
 										rowCount={ size( this.props.posts ) } />
 								) }

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -120,10 +120,7 @@ class PostTypeList extends Component {
 
 	cellRendererWrapper( { key, style, ...rest } ) {
 		return (
-			<div
-				className="Grid__cell"
-				key={ key }
-				style={ style }>
+			<div key={ key } style={ style }>
 				{ this.renderPostRow( rest ) }
 			</div>
 		);

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -44,6 +44,7 @@ class PostTypeList extends Component {
 		super( ...arguments );
 
 		this.renderPostRow = this.renderPostRow.bind( this );
+		this.cellRendererWrapper = this.cellRendererWrapper.bind( this );
 		this.renderPlaceholder = this.renderPlaceholder.bind( this );
 		this.setRequestedPages = this.setRequestedPages.bind( this );
 

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -9,7 +9,9 @@ import includes from 'lodash/includes';
 import difference from 'lodash/difference';
 import range from 'lodash/range';
 import size from 'lodash/size';
-import { AutoSizer, List, WindowScroller } from 'react-virtualized';
+import AutoSizer from 'react-virtualized/AutoSizer';
+import WindowScroller from 'react-virtualized/WindowScroller';
+import List from 'react-virtualized/List';
 
 /**
  * Internal dependencies

--- a/client/post-editor/editor-categories-tags/test/accordion.jsx
+++ b/client/post-editor/editor-categories-tags/test/accordion.jsx
@@ -26,7 +26,7 @@ describe( 'EditorCategoriesTagsAccordion', function() {
 		mount = require( 'enzyme' ).mount;
 		i18n = require( 'i18n-calypso' );
 
-		// require needs to be here in order for mocking of VirtualScroll to work
+		// require needs to be here in order for mocking of List to work
 		EditorCategoriesTagsAccordion = require ( 'post-editor/editor-categories-tags/accordion' ).EditorCategoriesTagsAccordion;
 	} );
 

--- a/client/post-editor/editor-categories-tags/test/accordion.jsx
+++ b/client/post-editor/editor-categories-tags/test/accordion.jsx
@@ -21,7 +21,7 @@ describe( 'EditorCategoriesTagsAccordion', function() {
 	before( () => {
 		mockery.registerMock( 'post-editor/editor-term-selector', EmptyComponent );
 		mockery.registerMock( 'components/info-popover', EmptyComponent );
-		mockery.registerMock( 'react-virtualized/VirtualScroll', EmptyComponent );
+		mockery.registerMock( 'react-virtualized/List', EmptyComponent );
 
 		mount = require( 'enzyme' ).mount;
 		i18n = require( 'i18n-calypso' );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -29,11 +29,11 @@
       "version": "0.8.2"
     },
     "ajv": {
-      "version": "4.10.0",
+      "version": "4.10.1",
       "dev": true
     },
     "ajv-keywords": {
-      "version": "1.2.0",
+      "version": "1.4.1",
       "dev": true
     },
     "align-text": {
@@ -569,7 +569,7 @@
       "version": "2.2.0"
     },
     "charenc": {
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dev": true
     },
     "cheerio": {
@@ -805,7 +805,7 @@
       "version": "2.2.5"
     },
     "crypt": {
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dev": true
     },
     "cryptiles": {
@@ -1335,7 +1335,7 @@
       }
     },
     "esprima": {
-      "version": "3.1.2"
+      "version": "3.1.3"
     },
     "esrecurse": {
       "version": "4.1.0",
@@ -1728,7 +1728,7 @@
       "version": "0.0.42",
       "dependencies": {
         "bluebird": {
-          "version": "3.4.6"
+          "version": "3.4.7"
         },
         "source-map": {
           "version": "0.5.6"
@@ -2885,9 +2885,6 @@
     "percentage-regex": {
       "version": "3.0.0"
     },
-    "performance-now": {
-      "version": "0.2.0"
-    },
     "phone": {
       "version": "1.0.8",
       "from": "git+https://github.com/Automattic/node-phone.git#6be6549b03137f2cca01e202250bf2590750119e",
@@ -3045,9 +3042,6 @@
     "querystring-es3": {
       "version": "0.2.1"
     },
-    "raf": {
-      "version": "3.3.0"
-    },
     "randomatic": {
       "version": "1.1.6"
     },
@@ -3154,7 +3148,7 @@
       }
     },
     "react-virtualized": {
-      "version": "7.9.1",
+      "version": "8.8.1",
       "dependencies": {
         "classnames": {
           "version": "2.2.5"

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "react-pure-render": "1.0.2",
     "react-redux": "4.4.5",
     "react-tap-event-plugin": "2.0.1",
-    "react-virtualized": "7.9.1",
+    "react-virtualized": "8.8.1",
     "redux": "3.0.4",
     "redux-thunk": "1.0.0",
     "rtlcss": "2.0.5",


### PR DESCRIPTION
See #9757 for similar work and testing instructions.

This is a "safe" approach which can be found in the upgrade guide. It wraps the cells in an extra `div` which was the 7.x behaviour. Ideally this wrapper should be removed though (maybe better in a later merge), and keys and styles should be added when rendering cells.

~~TODO: look into the post type list which is behaving strangely.~~

Upgrade guide: https://github.com/bvaughn/react-virtualized/blob/master/docs/upgrades/Version8.md