### PR TITLE
me/account: Replace Redux.compose with lodash.flowRight

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -7,11 +7,14 @@ import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import i18n, { localize } from 'i18n-calypso';
 import Debug from 'debug';
 import emailValidator from 'email-validator';
-import debounce from 'lodash/debounce';
-import map from 'lodash/map';
-import size from 'lodash/size';
+import {
+	debounce,
+	flowRight as compose,
+	map,
+	size,
+} from 'lodash';
 import { connect } from 'react-redux';
-import { bindActionCreators, compose } from 'redux';
+import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
A discussion on Issue #10138 led to a conclusion that Redux.compose is not to be used in the way that I used it in PR #10139 since the composing of a component with HoCs doesn't necessarily relate directly to Redux.
Instead using `flowRight` from lodash is preferred - imported with an alias to keep with the idiomatic `compose` naming.

Please follow the same testing steps as in #10139:

### Testing
Nothing should have changed visually or functionally.

- Navigate to [/me/account](http://calypso.localhost:3000/me/account)
- Look at the translated copy items. 'Username' should still say 'Username'
- Because protectForm is now 'composed', check that the form is protected:
  - Change some fields
  - Attempt to navigate
  - You should see a warning to show that you have unsaved changes.
- Also check that the changed-username fields show correctly:
  - Change the username field
  - make sure that this is successfully translated.