### PR TITLE
Framework: Provide a simple API to use the batch endpoint for all GET requests

### DIFF
--- a/client/state/data-layer/wpcom/batch.js
+++ b/client/state/data-layer/wpcom/batch.js
@@ -1,0 +1,49 @@
+/**
+ * Internal dependencies
+ */
+import wpcom from 'lib/wp';
+
+const FLUSH_TIMEOUT = 50;
+
+const createQueue = () => {
+	let requests = [];
+
+	const flush = () => {
+		if ( ! requests.length ) {
+			return;
+		}
+		const requestsToTrigger = requests;
+		requests = [];
+		const batch = wpcom.batch();
+		requestsToTrigger.forEach( request => batch.add( request.url ) );
+		batch.run( ( err, responses ) => {
+			if ( err ) {
+				return requestsToTrigger.forEach( request => request.reject( err ) );
+			}
+			requestsToTrigger.forEach( request => {
+				const response = responses[ request.url ];
+				// The Batch API should always return the status_code even for successfull responses
+				// That way, we could check the value of the status code to switch between reject/resolve
+				if ( response.status_code ) {
+					request.reject( response );
+				} else {
+					request.resolve( response );
+				}
+			} );
+		} );
+	};
+
+	const request = url => {
+		return new Promise( ( resolve, reject ) =>
+			requests.push( { url, resolve, reject } )
+		);
+	};
+
+	setInterval( flush, FLUSH_TIMEOUT );
+
+	return {
+		request
+	};
+};
+
+export default createQueue();

--- a/client/state/data-layer/wpcom/batch.js
+++ b/client/state/data-layer/wpcom/batch.js
@@ -1,49 +1,44 @@
 /**
+ * External dependencies
+ */
+import { throttle } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import wpcom from 'lib/wp';
 
 const FLUSH_TIMEOUT = 50;
+let requests = [];
 
-const createQueue = () => {
-	let requests = [];
-
-	const flush = () => {
-		if ( ! requests.length ) {
-			return;
+export const flush = throttle( () => {
+	if ( ! requests.length ) {
+		return;
+	}
+	const requestsToTrigger = requests;
+	requests = [];
+	const batch = wpcom.batch();
+	requestsToTrigger.forEach( request => batch.add( request.url ) );
+	batch.run( ( err, responses ) => {
+		if ( err ) {
+			return requestsToTrigger.forEach( request => request.reject( err ) );
 		}
-		const requestsToTrigger = requests;
-		requests = [];
-		const batch = wpcom.batch();
-		requestsToTrigger.forEach( request => batch.add( request.url ) );
-		batch.run( ( err, responses ) => {
-			if ( err ) {
-				return requestsToTrigger.forEach( request => request.reject( err ) );
+		requestsToTrigger.forEach( request => {
+			const response = responses[ request.url ];
+			// The Batch API should always return the status_code even for successfull responses
+			// That way, we could check the value of the status code to switch between reject/resolve
+			if ( response.status_code ) {
+				request.reject( response );
+			} else {
+				request.resolve( response );
 			}
-			requestsToTrigger.forEach( request => {
-				const response = responses[ request.url ];
-				// The Batch API should always return the status_code even for successfull responses
-				// That way, we could check the value of the status code to switch between reject/resolve
-				if ( response.status_code ) {
-					request.reject( response );
-				} else {
-					request.resolve( response );
-				}
-			} );
 		} );
-	};
+	} );
+}, FLUSH_TIMEOUT, { leading: false } );
 
-	const request = url => {
-		return new Promise( ( resolve, reject ) =>
-			requests.push( { url, resolve, reject } )
-		);
-	};
-
-	setInterval( flush, FLUSH_TIMEOUT );
-
-	return {
-		request
-	};
+export const request = url => {
+	return new Promise( ( resolve, reject ) => {
+		requests.push( { url, resolve, reject } );
+		flush();
+	} );
 };
-
-export default createQueue();

--- a/client/state/data-layer/wpcom/test/batch.js
+++ b/client/state/data-layer/wpcom/test/batch.js
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import useNock from 'test/helpers/use-nock';
+import queue from '../batch';
+
+describe( 'wpcom-api', () => {
+	describe( 'request', () => {
+		useNock( nock => (
+			nock( 'https://public-api.wordpress.com:443' )
+				.persist()
+				.get( '/rest/v1.1/batch?urls%5B%5D=%2FendpointOne&urls%5B%5D=%2FendpointTwo' )
+				.reply( 200, {
+					'/endpointOne': {
+						response1: 'batched'
+					},
+					'/endpointTwo': {
+						response2: 'batched'
+					}
+				} )
+				.get( '/rest/v1.1/batch?urls%5B%5D=%2FendpointFail' )
+				.reply( 200, {
+					'/endpointFail': {
+						status_code: 400,
+						error: 'Bad Request'
+					}
+				} )
+				.get( '/rest/v1.1/batch?urls%5B%5D=%2FendpointOne' )
+				.reply( 200, {
+					'/endpointOne': {
+						response1: 'unbatched'
+					}
+				} )
+				.get( '/rest/v1.1/batch?urls%5B%5D=%2FendpointTwo' )
+				.reply( 200, {
+					'/endpointTwo': {
+						response2: 'unbatched'
+					}
+				} )
+		) );
+
+		it( 'should batch requests into one API call', () => {
+			return Promise.all( [
+				queue.request( '/endpointOne' ),
+				queue.request( '/endpointTwo' )
+			] ).then( ( [ response1, response2 ] ) => {
+				expect( response1 ).to.eql( {
+					response1: 'batched'
+				} );
+				expect( response2 ).to.eql( {
+					response2: 'batched'
+				} );
+			} );
+		} );
+
+		it( 'should fail when we provide a status code', () => {
+			return queue.request( '/endpointFail' ).catch( response => {
+				expect( response ).to.eql( {
+					status_code: 400,
+					error: 'Bad Request'
+				} );
+			} );
+		} );
+
+		it( 'should not batch requests if the delay is high enough', () => {
+			const delay = timeout => new Promise( resolve => setTimeout( resolve, timeout ) );
+			queue.request( '/endpointOne' );
+			return delay( 60 )
+				.then( () => queue.request( '/endpointTwo' ) )
+				.then( response => {
+					expect( response ).to.eql( {
+						response2: 'unbatched'
+					} );
+				} );
+		} );
+	} );
+} );

--- a/client/state/data-layer/wpcom/test/batch.js
+++ b/client/state/data-layer/wpcom/test/batch.js
@@ -7,7 +7,7 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import useNock from 'test/helpers/use-nock';
-import queue from '../batch';
+import { request } from '../batch';
 
 describe( 'wpcom-api', () => {
 	describe( 'request', () => {
@@ -46,8 +46,8 @@ describe( 'wpcom-api', () => {
 
 		it( 'should batch requests into one API call', () => {
 			return Promise.all( [
-				queue.request( '/endpointOne' ),
-				queue.request( '/endpointTwo' )
+				request( '/endpointOne' ),
+				request( '/endpointTwo' )
 			] ).then( ( [ response1, response2 ] ) => {
 				expect( response1 ).to.eql( {
 					response1: 'batched'
@@ -59,7 +59,7 @@ describe( 'wpcom-api', () => {
 		} );
 
 		it( 'should fail when we provide a status code', () => {
-			return queue.request( '/endpointFail' ).catch( response => {
+			return request( '/endpointFail' ).catch( response => {
 				expect( response ).to.eql( {
 					status_code: 400,
 					error: 'Bad Request'
@@ -69,9 +69,9 @@ describe( 'wpcom-api', () => {
 
 		it( 'should not batch requests if the delay is high enough', () => {
 			const delay = timeout => new Promise( resolve => setTimeout( resolve, timeout ) );
-			queue.request( '/endpointOne' );
+			request( '/endpointOne' );
 			return delay( 60 )
-				.then( () => queue.request( '/endpointTwo' ) )
+				.then( () => request( '/endpointTwo' ) )
 				.then( response => {
 					expect( response ).to.eql( {
 						response2: 'unbatched'


### PR DESCRIPTION
In this PR, I add a batch queue to the data layer. This queue batches multiple GET requests into one API call.

**Usage**

Replace your `wpcom`API call by a `batch.request`call, for example:

```js 
import wpcom from 'lib/wp';
wpcom.site( siteId ).statsPostViews( postId, { fields: stat } ).then( data => console.log( data) );
```

becomes

```js 
import { request } from 'state/data-layer/wpcom/batch';
const path = `/sites/${ siteId }/stats/post/${ postId }?fields=${ stat }`;
request( path ).then( data => console.log( data ) );
```

**Questions**

- On the `batch` API,  when an URL returns an error, the status_code is included in the response, but when it's successful, it's not. It might be better if it behaves consistently and always include an "envelope" to the response.

