### PR TITLE
Fix/plan name translation

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -366,7 +366,7 @@ export class MySitesSidebar extends Component {
 			linkClass += ' is-paid-plan';
 		}
 
-		let planName = site.plan.product_name_short;
+		let planName = this.props.translate( site.plan.product_name_short );
 
 		if ( productsValues.isFreeTrial( site.plan ) ) {
 			planName = this.props.translate( 'Trial', {

--- a/client/state/data-layer/wpcom/batch.js
+++ b/client/state/data-layer/wpcom/batch.js
@@ -1,0 +1,49 @@
+/**
+ * Internal dependencies
+ */
+import wpcom from 'lib/wp';
+
+const FLUSH_TIMEOUT = 50;
+
+const createQueue = () => {
+	let requests = [];
+
+	const flush = () => {
+		if ( ! requests.length ) {
+			return;
+		}
+		const requestsToTrigger = requests;
+		requests = [];
+		const batch = wpcom.batch();
+		requestsToTrigger.forEach( request => batch.add( request.url ) );
+		batch.run( ( err, responses ) => {
+			if ( err ) {
+				return requestsToTrigger.forEach( request => request.reject( err ) );
+			}
+			requestsToTrigger.forEach( request => {
+				const response = responses[ request.url ];
+				// The Batch API should always return the status_code even for successfull responses
+				// That way, we could check the value of the status code to switch between reject/resolve
+				if ( response.status_code ) {
+					request.reject( response );
+				} else {
+					request.resolve( response );
+				}
+			} );
+		} );
+	};
+
+	const request = url => {
+		return new Promise( ( resolve, reject ) =>
+			requests.push( { url, resolve, reject } )
+		);
+	};
+
+	setInterval( flush, FLUSH_TIMEOUT );
+
+	return {
+		request
+	};
+};
+
+export default createQueue();

--- a/client/state/data-layer/wpcom/test/batch.js
+++ b/client/state/data-layer/wpcom/test/batch.js
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import useNock from 'test/helpers/use-nock';
+import queue from '../batch';
+
+describe( 'wpcom-api', () => {
+	describe( 'request', () => {
+		useNock( nock => (
+			nock( 'https://public-api.wordpress.com:443' )
+				.persist()
+				.get( '/rest/v1.1/batch?urls%5B%5D=%2FendpointOne&urls%5B%5D=%2FendpointTwo' )
+				.reply( 200, {
+					'/endpointOne': {
+						response1: 'batched'
+					},
+					'/endpointTwo': {
+						response2: 'batched'
+					}
+				} )
+				.get( '/rest/v1.1/batch?urls%5B%5D=%2FendpointFail' )
+				.reply( 200, {
+					'/endpointFail': {
+						status_code: 400,
+						error: 'Bad Request'
+					}
+				} )
+				.get( '/rest/v1.1/batch?urls%5B%5D=%2FendpointOne' )
+				.reply( 200, {
+					'/endpointOne': {
+						response1: 'unbatched'
+					}
+				} )
+				.get( '/rest/v1.1/batch?urls%5B%5D=%2FendpointTwo' )
+				.reply( 200, {
+					'/endpointTwo': {
+						response2: 'unbatched'
+					}
+				} )
+		) );
+
+		it( 'should batch requests into one API call', () => {
+			return Promise.all( [
+				queue.request( '/endpointOne' ),
+				queue.request( '/endpointTwo' )
+			] ).then( ( [ response1, response2 ] ) => {
+				expect( response1 ).to.eql( {
+					response1: 'batched'
+				} );
+				expect( response2 ).to.eql( {
+					response2: 'batched'
+				} );
+			} );
+		} );
+
+		it( 'should fail when we provide a status code', () => {
+			return queue.request( '/endpointFail' ).catch( response => {
+				expect( response ).to.eql( {
+					status_code: 400,
+					error: 'Bad Request'
+				} );
+			} );
+		} );
+
+		it( 'should not batch requests if the delay is high enough', () => {
+			const delay = timeout => new Promise( resolve => setTimeout( resolve, timeout ) );
+			queue.request( '/endpointOne' );
+			return delay( 60 )
+				.then( () => queue.request( '/endpointTwo' ) )
+				.then( response => {
+					expect( response ).to.eql( {
+						response2: 'unbatched'
+					} );
+				} );
+		} );
+	} );
+} );


### PR DESCRIPTION
Fixes the lack of translation for Plans: translate name for "Free" plan in sidebar menu context as reported in issue #10187 


