### PR TITLE
Domains: Don't throw Exceptions for unknown response

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -257,7 +257,6 @@ const MapDomainStep = React.createClass( {
 
 			default:
 				message = translate( 'Sorry, there was a problem processing your request. Please try again in a few minutes.' );
-				break;
 		}
 
 		if ( message ) {

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -256,7 +256,8 @@ const MapDomainStep = React.createClass( {
 				break;
 
 			default:
-				throw new Error( 'Unrecognized error code: ' + error.code );
+				message = translate( 'Sorry, there was a problem processing your request. Please try again in a few minutes.' );
+				break;
 		}
 
 		if ( message ) {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -655,11 +655,9 @@ const RegisterDomainStep = React.createClass( {
 				break;
 
 			case 'server_error':
+			default:
 				message = translate( 'Sorry, there was a problem processing your request. Please try again in a few minutes.' );
 				break;
-
-			default:
-				throw new Error( 'Unrecognized error code: ' + error.code );
 		}
 
 		if ( message ) {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -654,7 +654,6 @@ const RegisterDomainStep = React.createClass( {
 				} );
 				break;
 
-			case 'server_error':
 			default:
 				message = translate( 'Sorry, there was a problem processing your request. Please try again in a few minutes.' );
 				break;

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -656,7 +656,6 @@ const RegisterDomainStep = React.createClass( {
 
 			default:
 				message = translate( 'Sorry, there was a problem processing your request. Please try again in a few minutes.' );
-				break;
 		}
 
 		if ( message ) {


### PR DESCRIPTION
Show the `server_error` instead, so the UI updates and the user knows something went wrong instead of having a UI that looks like it's loading endlessly.

**Domain Search:**
Before:
![screenshot from 2016-12-26 20-54-48](https://cloud.githubusercontent.com/assets/1103398/21486072/f9f36cc6-cbad-11e6-8ad4-6fbcc542554d.png)

After:
![screenshot from 2016-12-26 20-53-25](https://cloud.githubusercontent.com/assets/1103398/21486073/fc685a48-cbad-11e6-9767-82ab0592ad84.png)


**Map a Domain:**
Before (nothing happens, just shows the same form again, although you pushed the button):
![mb](https://cloud.githubusercontent.com/assets/1103398/21486883/dc6d311e-cbbc-11e6-841a-21d8797caafb.png)

After:
![ma](https://cloud.githubusercontent.com/assets/1103398/21486886/f4952de6-cbbc-11e6-80bf-a220f02af13a.png)
