### PR TITLE
Select the first user by default from list when transferring the domain

### DIFF
--- a/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-user/index.jsx
+++ b/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-user/index.jsx
@@ -205,7 +205,7 @@ class TransferOtherUser extends React.Component {
 										{ this.getUserDisplayName( user ) }
 									</option>
 								) )
-								: ( <option value="">{ translate( '-- Site has no administrators --' ) }</option> )
+								: ( <option value="">{ translate( '-- Site has no other administrators --' ) }</option> )
 							}
 						</FormSelect>
 					</FormFieldset>

--- a/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-user/index.jsx
+++ b/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-user/index.jsx
@@ -39,14 +39,16 @@ class TransferOtherUser extends React.Component {
 			React.PropTypes.bool
 		] ).isRequired,
 		wapiDomainInfo: React.PropTypes.object.isRequired,
+		users: React.PropTypes.array.isRequired,
 		currentUser: React.PropTypes.object.isRequired
 	};
 
 	constructor( props ) {
 		super( props );
 
+		const defaultUser = head( this.filterAvailableUsers( props.users ) );
 		this.state = {
-			selectedUserId: '',
+			selectedUserId: defaultUser ? defaultUser.ID : '',
 			showConfirmationDialog: false,
 			disableDialogButtons: false
 		};


### PR DESCRIPTION
As reported in #10158, when there's only one other admin, the `Transfer Domain` button remains disabled. That's because, by default, the `selectedUserId` is empty and is only updated when we receive new props or the user changes the selection. Assuming, there are no updates to the props and there's only one other admin on the list, it's not possible to trigger the change event and enable the button.
This PR addresses this issue.
It also makes a small improvement (hopefully) to the message shown when there are no other admins on the site - from `Site has no administrators` to `Site has no other administrators`. `other` being the key word here - one that should make it clear that we need one more admin to actually have someone to transfer the domain to.

### Testing

* Verify that the `Transfer Domain` button is and remains disabled when there's only one admin on site.
* Verify that the `Transfer Domain` button is enabled from the start when there's only one other admin.
* Verify that the `Transfer Domain` button is enabled from the start, and remains enabled when changing the selected admin (when there are more than one other admin on site).

In the last two cases, make sure that the right user's ID is sent to the backend.

Only one user, button enabled:
<img width="747" alt="screen shot 2016-12-26 at 22 04 29" src="https://cloud.githubusercontent.com/assets/3392497/21486659/9fc1e22c-cbb8-11e6-88aa-daf1a96b6d91.png">

Updated copy when there are no other admins on site:
<img width="751" alt="screen shot 2016-12-26 at 22 02 51" src="https://cloud.githubusercontent.com/assets/3392497/21486665/b58ae6e4-cbb8-11e6-968e-7cbb5dab421c.png">
