### PR TITLE
TaxonomyManager: Add Analytics

### DIFF
--- a/client/blocks/taxonomy-manager/index.jsx
+++ b/client/blocks/taxonomy-manager/index.jsx
@@ -15,6 +15,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getPostTypeTaxonomy } from 'state/post-types/taxonomies/selectors';
 import QueryTaxonomies from 'components/data/query-taxonomies';
 import TermFormDialog from 'blocks/term-form-dialog';
+import { recordGoogleEvent, bumpStat } from 'state/analytics/actions';
 
 export class TaxonomyManager extends Component {
 	static propTypes = {
@@ -22,6 +23,8 @@ export class TaxonomyManager extends Component {
 		labels: PropTypes.object,
 		postType: PropTypes.string,
 		siteId: PropTypes.number,
+		recordGoogleEvent: PropTypes.func,
+		bumpStat: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -38,6 +41,9 @@ export class TaxonomyManager extends Component {
 	};
 
 	newTerm = () => {
+		const { taxonomy } = this.props;
+		this.props.recordGoogleEvent( 'Taxonomy Manager', `Clicked Add ${ taxonomy }` );
+		this.props.bumpStat( 'taxonomy_manager', `clicked_add_${ taxonomy }` );
 		this.setState( {
 			termFormDialogOpened: true,
 			selectedTerm: undefined
@@ -45,6 +51,9 @@ export class TaxonomyManager extends Component {
 	};
 
 	editTerm = term => {
+		const { taxonomy } = this.props;
+		this.props.recordGoogleEvent( 'Taxonomy Manager', `Clicked Edit ${ taxonomy }` );
+		this.props.bumpStat( 'taxonomy_manager', `clicked_edit_${ taxonomy }` );
 		this.setState( {
 			termFormDialogOpened: true,
 			selectedTerm: term
@@ -98,5 +107,6 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const labels = get( getPostTypeTaxonomy( state, siteId, postType, taxonomy ), 'labels', {} );
 		return { labels, siteId };
-	}
+	},
+	{ recordGoogleEvent, bumpStat }
 )( TaxonomyManager );

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -24,6 +24,7 @@ import { getSite, isJetpackSite } from 'state/sites/selectors';
 import { decodeEntities } from 'lib/formatting';
 import { deleteTerm } from 'state/terms/actions';
 import { saveSiteSettings } from 'state/site-settings/actions';
+import { recordGoogleEvent, bumpStat } from 'state/analytics/actions';
 
 class TaxonomyManagerListItem extends Component {
 	static propTypes = {
@@ -39,6 +40,8 @@ class TaxonomyManagerListItem extends Component {
 		slug: PropTypes.string,
 		isJetpack: PropTypes.bool,
 		isPreviewable: PropTypes.bool,
+		recordGoogleEvent: PropTypes.func,
+		bumpStat: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -59,6 +62,8 @@ class TaxonomyManagerListItem extends Component {
 	closeDeleteDialog = action => {
 		if ( action === 'delete' ) {
 			const { siteId, taxonomy, term } = this.props;
+			this.props.recordGoogleEvent( 'Taxonomy Manager', `Deleted ${ taxonomy }` );
+			this.props.bumpStat( 'taxonomy_manager', `delete_${ taxonomy }` );
 			this.props.deleteTerm( siteId, taxonomy, term.ID, term.slug );
 		}
 		this.setState( {
@@ -69,6 +74,8 @@ class TaxonomyManagerListItem extends Component {
 	setAsDefault = () => {
 		const { canSetAsDefault, siteId, term } = this.props;
 		if ( canSetAsDefault ) {
+			this.props.recordGoogleEvent( 'Taxonomy Manager', 'Set Default Category' );
+			this.props.bumpStat( 'taxonomy_manager', 'set_default_category' );
 			this.props.saveSiteSettings( siteId, { default_category: term.ID } );
 		}
 	};
@@ -214,5 +221,7 @@ export default connect(
 	{
 		deleteTerm,
 		saveSiteSettings,
+		recordGoogleEvent,
+		bumpStat,
 	}
 )( localize( TaxonomyManagerListItem ) );

--- a/client/my-sites/site-settings/taxonomies/taxonomy-card.jsx
+++ b/client/my-sites/site-settings/taxonomies/taxonomy-card.jsx
@@ -15,21 +15,36 @@ import { getPostTypeTaxonomy } from 'state/post-types/taxonomies/selectors';
 import { countFoundTermsForQuery, getTerm } from 'state/terms/selectors';
 import { getSiteSettings } from 'state/site-settings/selectors';
 import { decodeEntities } from 'lib/formatting';
+import { recordGoogleEvent, bumpStat } from 'state/analytics/actions';
 
 import CompactCard from 'components/card/compact';
 import QueryTerms from 'components/data/query-terms';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import Gridicon from 'components/gridicon';
 
-const TaxonomyCard = ( { count, defaultTerm, labels, site, taxonomy, translate } ) => {
+const TaxonomyCard = ( {
+		count,
+		defaultTerm,
+		labels,
+		site,
+		taxonomy,
+		translate,
+		recordGoogleEvent: recordGAEvent,
+		bumpStat: recordMCStat
+	} ) => {
 	const settingsLink = site ? `/settings/taxonomies/${ taxonomy }/${ site.slug }` : null;
 	const isLoading = ! labels.name || isUndefined( count );
 	const classes = classNames( 'taxonomies__card-title', {
 		'is-loading': isLoading
 	} );
 
+	const recordAnalytics = () => {
+		recordGAEvent( 'Site Settings', `Clicked Writing Manage ${ taxonomy }` );
+		recordMCStat( 'taxonomy_manager', `manage_${ taxonomy }` );
+	};
+
 	return (
-		<CompactCard href={ settingsLink }>
+		<CompactCard onClick={ recordAnalytics } href={ settingsLink }>
 			{ site && <QuerySiteSettings siteId={ site.ID } /> }
 			{ site && <QueryTerms siteId={ site.ID } taxonomy={ taxonomy }	query={ {} } /> }
 			<h2 className={ classes }>{ labels.name }</h2>
@@ -62,5 +77,6 @@ export default connect(
 			labels,
 			site
 		};
-	}
+	},
+	{ recordGoogleEvent, bumpStat }
 )( localize( TaxonomyCard ) );


### PR DESCRIPTION
This branch adds in some Google Analytics and mc stat tracking for the various use flows of the Taxonomy Manager.

__To Test__
- Set your debug to `calypso:analytics`
- Interact with all aspects of the taxonomy manager.  Click to edit, actually edit a term, delete a term, set a category as default, create new term.  Verify that analytics actions are logged as expected during each.