### PR TITLE
Site Settings: Convert ActionPanel to stateless functional components

### DIFF
--- a/client/my-sites/site-settings/action-panel/body.jsx
+++ b/client/my-sites/site-settings/action-panel/body.jsx
@@ -1,21 +1,14 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
-/**
- * Main
- */
-var ActionPanelBody = React.createClass( {
+const ActionPanelBody = ( { children } ) => {
+	return (
+		<div className="settings-action-panel__body">
+			{ children }
+		</div>
+	);
+};
 
-	render: function() {
-		return (
-			<div className="settings-action-panel__body">
-				{ this.props.children }
-			</div>
-		);
-	}
-
-} );
-
-module.exports = ActionPanelBody;
+export default ActionPanelBody;

--- a/client/my-sites/site-settings/action-panel/figure.jsx
+++ b/client/my-sites/site-settings/action-panel/figure.jsx
@@ -1,37 +1,28 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+import React from 'react';
+import classNames from 'classnames';
 
-/**
- * Main
- */
-var ActionPanelFigure = React.createClass( {
+const ActionPanelFigure = ( { inlineBodyText, children } ) => {
+	const figureClasses = classNames( {
+		'settings-action-panel__figure': true,
+		'is-inline-body-text': inlineBodyText
+	} );
 
-	propTypes: {
-		inlineBodyText: React.PropTypes.bool // above `480px` does figure align with body text (below title)
-	},
+	return (
+		<div className={ figureClasses }>
+			{ children }
+		</div>
+	);
+};
 
-	getDefaultProps: function() {
-		return {
-			inlineBodyText: false
-		};
-	},
+ActionPanelFigure.propTypes = {
+	inlineBodyText: React.PropTypes.bool // above `480px` does figure align with body text (below title)
+};
 
-	render: function() {
-		var figureClasses = classNames( {
-			'settings-action-panel__figure': true,
-			'is-inline-body-text': this.props.inlineBodyText
-		} );
+ActionPanelFigure.defaultProps = {
+	inlineBodyText: false
+};
 
-		return (
-			<div className={ figureClasses }>
-				{ this.props.children }
-			</div>
-		);
-	}
-
-} );
-
-module.exports = ActionPanelFigure;
+export default ActionPanelFigure;

--- a/client/my-sites/site-settings/action-panel/footer.jsx
+++ b/client/my-sites/site-settings/action-panel/footer.jsx
@@ -1,21 +1,14 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
-/**
- * Main
- */
-var ActionPanelFooter = React.createClass( {
+const ActionPanelFooter = ( { children } ) => {
+	return (
+		<div className="settings-action-panel__footer">
+			{ children }
+		</div>
+	);
+};
 
-	render: function() {
-		return (
-			<div className="settings-action-panel__footer">
-				{ this.props.children }
-			</div>
-		);
-	}
-
-} );
-
-module.exports = ActionPanelFooter;
+export default ActionPanelFooter;

--- a/client/my-sites/site-settings/action-panel/index.jsx
+++ b/client/my-sites/site-settings/action-panel/index.jsx
@@ -1,26 +1,19 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var Card = require( 'components/card' );
+import Card from 'components/card';
 
-/**
- * Main
- */
-var ActionPanel = React.createClass( {
+const ActionPanel = ( { children } ) => {
+	return (
+		<Card className="settings-action-panel">
+			{ children }
+		</Card>
+	);
+};
 
-	render: function() {
-		return (
-			<Card className="settings-action-panel">
-				{ this.props.children }
-			</Card>
-		);
-	}
-
-} );
-
-module.exports = ActionPanel;
+export default ActionPanel;

--- a/client/my-sites/site-settings/action-panel/title.jsx
+++ b/client/my-sites/site-settings/action-panel/title.jsx
@@ -1,21 +1,14 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
-/**
- * Main
- */
-var ActionPanelTitle = React.createClass( {
+const ActionPanelTitle = ( { children } ) => {
+	return (
+		<h2 className="settings-action-panel__title">
+			{ children }
+		</h2>
+	);
+};
 
-	render: function() {
-		return (
-			<h2 className="settings-action-panel__title">
-				{ this.props.children }
-			</h2>
-		);
-	}
-
-} );
-
-module.exports = ActionPanelTitle;
+export default ActionPanelTitle;


### PR DESCRIPTION
This PR refactors the `ActionPanel*` simple components to stateless functional components - they have no reason to be classes. Also, it uses the chance to ES6ify them all.

To test:

* Get this branch going
* Load and play a section that uses these components - like `/settings/general/$site` ("Change Site Address", "Start Over" and "Delete Site"). 
* Verify there are no functional changes, nor any regressions.