### PR TITLE
Site Settings: Refactor RelatedContentPreview

### DIFF
--- a/client/my-sites/site-settings/related-content-preview.jsx
+++ b/client/my-sites/site-settings/related-content-preview.jsx
@@ -46,24 +46,25 @@ const RelatedContentPreview = ( { enabled, showHeadline, showThumbnails, transla
 	return (
 		<div id="settings-reading-relatedposts-preview" className={ enabled ? null : 'disabled-block' }>
 			<FormLabel>{ translate( 'Preview:' ) }</FormLabel>
+
 			<div id="jp-relatedposts" className="jp-relatedposts">
-				{ showHeadline
-					? <h3 className="jp-relatedposts-headline">{ translate( 'Related' ) }</h3>
-					: null
+				{
+					showHeadline &&
+					<h3 className="jp-relatedposts-headline">{ translate( 'Related' ) }</h3>
 				}
-				<div className="jp-relatedposts-items jp-relatedposts-items-visual">
+
+				<div className="jp-relatedposts-items">
 					{
 						posts.map( ( post, index ) => {
 							return (
-								<div className="jp-relatedposts-post jp-relatedposts-post0 jp-relatedposts-post-thumbs" data-post-format="image" key={ index }>
-									{ showThumbnails
-										? <a className="jp-relatedposts-post-a" href="#jetpack_relatedposts" rel="nofollow" data-origin="0" data-position="0">
-											<img className="jp-relatedposts-post-img" src={ post.image } width="350" alt={ post.title } scale="0" />
+								<div className="jp-relatedposts-post" key={ index }>
+									{ showThumbnails &&
+										<a className="jp-relatedposts-post-a">
+											<img className="jp-relatedposts-post-img" src={ post.image } alt={ post.title } />
 										</a>
-										: null
 									}
 									<h4 className="jp-relatedposts-post-title">
-										<a className="jp-relatedposts-post-a" href="#jetpack_relatedposts" rel="nofollow" data-origin="0" data-position="0">
+										<a className="jp-relatedposts-post-a">
 											{ post.title }
 										</a>
 									</h4>

--- a/client/my-sites/site-settings/related-content-preview.jsx
+++ b/client/my-sites/site-settings/related-content-preview.jsx
@@ -44,31 +44,31 @@ const RelatedContentPreview = ( { enabled, showHeadline, showThumbnails, transla
 	];
 
 	return (
-		<div id="settings-reading-relatedposts-preview" className={ enabled ? null : 'disabled-block' }>
+		<div id="settings-reading-relatedposts-preview" className={ ! enabled && 'disabled-block' }>
 			<FormLabel>{ translate( 'Preview:' ) }</FormLabel>
 
-			<div id="jp-relatedposts" className="jp-relatedposts">
+			<div className="site-settings__related-posts">
 				{
 					showHeadline &&
-					<h3 className="jp-relatedposts-headline">{ translate( 'Related' ) }</h3>
+					<h3 className="site-settings__related-posts-headline">{ translate( 'Related' ) }</h3>
 				}
 
-				<div className="jp-relatedposts-items">
+				<div className="site-settings__related-posts-items">
 					{
 						posts.map( ( post, index ) => {
 							return (
-								<div className="jp-relatedposts-post" key={ index }>
+								<div className="site-settings__related-posts-post" key={ index }>
 									{ showThumbnails &&
-										<a className="jp-relatedposts-post-a">
-											<img className="jp-relatedposts-post-img" src={ post.image } alt={ post.title } />
+										<a className="site-settings__related-posts-post-a">
+											<img src={ post.image } alt={ post.title } />
 										</a>
 									}
-									<h4 className="jp-relatedposts-post-title">
-										<a className="jp-relatedposts-post-a">
+									<h4 className="site-settings__related-posts-post-title">
+										<a className="site-settings__related-posts-post-a">
 											{ post.title }
 										</a>
 									</h4>
-									<p className="jp-relatedposts-post-context">{ post.topic }</p>
+									<p className="site-settings__related-posts-post-context">{ post.topic }</p>
 								</div>
 							);
 						} )

--- a/client/my-sites/site-settings/related-content-preview.jsx
+++ b/client/my-sites/site-settings/related-content-preview.jsx
@@ -1,70 +1,66 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:my-sites:site-settings' );
+import React from 'react';
+import { localize } from 'i18n-calypso';
 
-var FormLabel = require( 'components/forms/form-label' );
+/**
+ * Internal dependencies
+ */
+import FormLabel from 'components/forms/form-label';
 
-module.exports = React.createClass({
-	displayName: 'RelatedContentPreview',
-
-	componentWillMount: function() {
-		debug( 'Mounting RelatedContent React component.' );
-	},
-
-	render: function() {
-
-		return (
-			<div id="settings-reading-relatedposts-preview" className={ this.props.enabled ? null : 'disabled-block' }>
-				<FormLabel>{ this.translate( 'Preview:' ) }</FormLabel>
-				<div id="jp-relatedposts" className="jp-relatedposts">
-					{ this.props.showHeadline ?
-					<h3 className="jp-relatedposts-headline">{ this.translate( 'Related' ) }</h3>
-					: null }
-					<div className="jp-relatedposts-items jp-relatedposts-items-visual">
-						<div className="jp-relatedposts-post jp-relatedposts-post0 jp-relatedposts-post-thumbs" data-post-format="image">
-							{ this.props.showThumbnails ?
+const RelatedContentPreview = ( { enabled, showHeadline, showThumbnails, translate } ) => {
+	return (
+		<div id="settings-reading-relatedposts-preview" className={ enabled ? null : 'disabled-block' }>
+			<FormLabel>{ translate( 'Preview:' ) }</FormLabel>
+			<div id="jp-relatedposts" className="jp-relatedposts">
+				{ showHeadline ?
+				<h3 className="jp-relatedposts-headline">{ translate( 'Related' ) }</h3>
+				: null }
+				<div className="jp-relatedposts-items jp-relatedposts-items-visual">
+					<div className="jp-relatedposts-post jp-relatedposts-post0 jp-relatedposts-post-thumbs" data-post-format="image">
+						{ showThumbnails ?
+						<a className="jp-relatedposts-post-a" href="#jetpack_relatedposts" rel="nofollow" data-origin="0" data-position="0">
+							<img className="jp-relatedposts-post-img" src="/calypso/images/related-posts/cat-blog.png" width="350" alt={ translate( 'Big iPhone/iPad Update Now Available', { textOnly: true, context: 'Demo content for related posts' } ) } scale="0" />
+						</a>
+						: null }
+						<h4 className="jp-relatedposts-post-title">
 							<a className="jp-relatedposts-post-a" href="#jetpack_relatedposts" rel="nofollow" data-origin="0" data-position="0">
-								<img className="jp-relatedposts-post-img" src="/calypso/images/related-posts/cat-blog.png" width="350" alt={ this.translate( 'Big iPhone/iPad Update Now Available', { textOnly: true, context: 'Demo content for related posts' } ) } scale="0" />
+								{ translate( 'Big iPhone/iPad Update Now Available' ) }
 							</a>
-							: null }
-							<h4 className="jp-relatedposts-post-title">
-								<a className="jp-relatedposts-post-a" href="#jetpack_relatedposts" rel="nofollow" data-origin="0" data-position="0">
-									{ this.translate( 'Big iPhone/iPad Update Now Available' ) }
-								</a>
-							</h4>
-							<p className="jp-relatedposts-post-context">{ this.translate( 'In "Mobile"', { context: 'topic post is located in' } ) }</p>
-						</div>
-						<div className="jp-relatedposts-post jp-relatedposts-post1 jp-relatedposts-post-thumbs" data-post-id="0" data-post-format="image">
-							{ this.props.showThumbnails ?
+						</h4>
+						<p className="jp-relatedposts-post-context">{ translate( 'In "Mobile"', { context: 'topic post is located in' } ) }</p>
+					</div>
+					<div className="jp-relatedposts-post jp-relatedposts-post1 jp-relatedposts-post-thumbs" data-post-id="0" data-post-format="image">
+						{ showThumbnails ?
+						<a className="jp-relatedposts-post-a" href="#jetpack_relatedposts" rel="nofollow" data-origin="0" data-position="0">
+							<img className="jp-relatedposts-post-img" src="/calypso/images/related-posts/devices.jpg" width="350" alt={ translate( 'The WordPress for Android App Gets a Big Facelift', { textOnly: true, context: 'Demo content for related posts' } ) } scale="0" />
+						</a>
+						: null }
+						<h4 className="jp-relatedposts-post-title">
 							<a className="jp-relatedposts-post-a" href="#jetpack_relatedposts" rel="nofollow" data-origin="0" data-position="0">
-								<img className="jp-relatedposts-post-img" src="/calypso/images/related-posts/devices.jpg" width="350" alt={ this.translate( 'The WordPress for Android App Gets a Big Facelift', { textOnly: true, context: 'Demo content for related posts' } ) } scale="0" />
+								{ translate( 'The WordPress for Android App Gets a Big Facelift' ) }
 							</a>
-							: null }
-							<h4 className="jp-relatedposts-post-title">
-								<a className="jp-relatedposts-post-a" href="#jetpack_relatedposts" rel="nofollow" data-origin="0" data-position="0">
-									{ this.translate( 'The WordPress for Android App Gets a Big Facelift' ) }
-								</a>
-							</h4>
-							<p className="jp-relatedposts-post-context">{ this.translate( 'In "Mobile"', { context: 'topic post is located in' } ) }</p>
-						</div>
-						<div className="jp-relatedposts-post jp-relatedposts-post2 jp-relatedposts-post-thumbs" data-post-id="0" data-post-format="image">
-							{ this.props.showThumbnails ?
+						</h4>
+						<p className="jp-relatedposts-post-context">{ translate( 'In "Mobile"', { context: 'topic post is located in' } ) }</p>
+					</div>
+					<div className="jp-relatedposts-post jp-relatedposts-post2 jp-relatedposts-post-thumbs" data-post-id="0" data-post-format="image">
+						{ showThumbnails ?
+						<a className="jp-relatedposts-post-a" href="#jetpack_relatedposts" rel="nofollow" data-origin="0" data-position="0">
+							<img className="jp-relatedposts-post-img" src="/calypso/images/related-posts/mobile-wedding.jpg" width="350" alt={ translate( 'Upgrade Focus: VideoPress For Weddings', { textOnly: true, context: 'Demo content for related posts' } ) } scale="0" />
+						</a>
+						: null }
+						<h4 className="jp-relatedposts-post-title">
 							<a className="jp-relatedposts-post-a" href="#jetpack_relatedposts" rel="nofollow" data-origin="0" data-position="0">
-								<img className="jp-relatedposts-post-img" src="/calypso/images/related-posts/mobile-wedding.jpg" width="350" alt={ this.translate( 'Upgrade Focus: VideoPress For Weddings', { textOnly: true, context: 'Demo content for related posts' } ) } scale="0" />
+								{ translate( 'Upgrade Focus: VideoPress For Weddings' ) }
 							</a>
-							: null }
-							<h4 className="jp-relatedposts-post-title">
-								<a className="jp-relatedposts-post-a" href="#jetpack_relatedposts" rel="nofollow" data-origin="0" data-position="0">
-									{ this.translate( 'Upgrade Focus: VideoPress For Weddings' ) }
-								</a>
-							</h4>
-							<p className="jp-relatedposts-post-context">{ this.translate( 'In "Upgrade"', { context: 'topic post is located in' } ) }</p>
-						</div>
+						</h4>
+						<p className="jp-relatedposts-post-context">{ translate( 'In "Upgrade"', { context: 'topic post is located in' } ) }</p>
 					</div>
 				</div>
 			</div>
-		);
-	}
-});
+		</div>
+	);
+};
+
+export default localize( RelatedContentPreview );

--- a/client/my-sites/site-settings/related-content-preview.jsx
+++ b/client/my-sites/site-settings/related-content-preview.jsx
@@ -10,53 +10,68 @@ import { localize } from 'i18n-calypso';
 import FormLabel from 'components/forms/form-label';
 
 const RelatedContentPreview = ( { enabled, showHeadline, showThumbnails, translate } ) => {
+	const posts = [
+		{
+			image: '/calypso/images/related-posts/cat-blog.png',
+			title: translate( 'Big iPhone/iPad Update Now Available', {
+				textOnly: true,
+				context: 'Demo content for related posts'
+			} ),
+			topic: translate( 'In "Mobile"', {
+				context: 'topic post is located in'
+			} )
+		},
+		{
+			image: '/calypso/images/related-posts/devices.jpg',
+			title: translate( 'The WordPress for Android App Gets a Big Facelift', {
+				textOnly: true,
+				context: 'Demo content for related posts'
+			} ),
+			topic: translate( 'In "Mobile"', {
+				context: 'topic post is located in'
+			} )
+		},
+		{
+			image: '/calypso/images/related-posts/mobile-wedding.jpg',
+			title: translate( 'Upgrade Focus: VideoPress For Weddings', {
+				textOnly: true,
+				context: 'Demo content for related posts'
+			} ),
+			topic: translate( 'In "Upgrade"', {
+				context: 'topic post is located in'
+			} )
+		}
+	];
+
 	return (
 		<div id="settings-reading-relatedposts-preview" className={ enabled ? null : 'disabled-block' }>
 			<FormLabel>{ translate( 'Preview:' ) }</FormLabel>
 			<div id="jp-relatedposts" className="jp-relatedposts">
-				{ showHeadline ?
-				<h3 className="jp-relatedposts-headline">{ translate( 'Related' ) }</h3>
-				: null }
+				{ showHeadline
+					? <h3 className="jp-relatedposts-headline">{ translate( 'Related' ) }</h3>
+					: null
+				}
 				<div className="jp-relatedposts-items jp-relatedposts-items-visual">
-					<div className="jp-relatedposts-post jp-relatedposts-post0 jp-relatedposts-post-thumbs" data-post-format="image">
-						{ showThumbnails ?
-						<a className="jp-relatedposts-post-a" href="#jetpack_relatedposts" rel="nofollow" data-origin="0" data-position="0">
-							<img className="jp-relatedposts-post-img" src="/calypso/images/related-posts/cat-blog.png" width="350" alt={ translate( 'Big iPhone/iPad Update Now Available', { textOnly: true, context: 'Demo content for related posts' } ) } scale="0" />
-						</a>
-						: null }
-						<h4 className="jp-relatedposts-post-title">
-							<a className="jp-relatedposts-post-a" href="#jetpack_relatedposts" rel="nofollow" data-origin="0" data-position="0">
-								{ translate( 'Big iPhone/iPad Update Now Available' ) }
-							</a>
-						</h4>
-						<p className="jp-relatedposts-post-context">{ translate( 'In "Mobile"', { context: 'topic post is located in' } ) }</p>
-					</div>
-					<div className="jp-relatedposts-post jp-relatedposts-post1 jp-relatedposts-post-thumbs" data-post-id="0" data-post-format="image">
-						{ showThumbnails ?
-						<a className="jp-relatedposts-post-a" href="#jetpack_relatedposts" rel="nofollow" data-origin="0" data-position="0">
-							<img className="jp-relatedposts-post-img" src="/calypso/images/related-posts/devices.jpg" width="350" alt={ translate( 'The WordPress for Android App Gets a Big Facelift', { textOnly: true, context: 'Demo content for related posts' } ) } scale="0" />
-						</a>
-						: null }
-						<h4 className="jp-relatedposts-post-title">
-							<a className="jp-relatedposts-post-a" href="#jetpack_relatedposts" rel="nofollow" data-origin="0" data-position="0">
-								{ translate( 'The WordPress for Android App Gets a Big Facelift' ) }
-							</a>
-						</h4>
-						<p className="jp-relatedposts-post-context">{ translate( 'In "Mobile"', { context: 'topic post is located in' } ) }</p>
-					</div>
-					<div className="jp-relatedposts-post jp-relatedposts-post2 jp-relatedposts-post-thumbs" data-post-id="0" data-post-format="image">
-						{ showThumbnails ?
-						<a className="jp-relatedposts-post-a" href="#jetpack_relatedposts" rel="nofollow" data-origin="0" data-position="0">
-							<img className="jp-relatedposts-post-img" src="/calypso/images/related-posts/mobile-wedding.jpg" width="350" alt={ translate( 'Upgrade Focus: VideoPress For Weddings', { textOnly: true, context: 'Demo content for related posts' } ) } scale="0" />
-						</a>
-						: null }
-						<h4 className="jp-relatedposts-post-title">
-							<a className="jp-relatedposts-post-a" href="#jetpack_relatedposts" rel="nofollow" data-origin="0" data-position="0">
-								{ translate( 'Upgrade Focus: VideoPress For Weddings' ) }
-							</a>
-						</h4>
-						<p className="jp-relatedposts-post-context">{ translate( 'In "Upgrade"', { context: 'topic post is located in' } ) }</p>
-					</div>
+					{
+						posts.map( ( post, index ) => {
+							return (
+								<div className="jp-relatedposts-post jp-relatedposts-post0 jp-relatedposts-post-thumbs" data-post-format="image" key={ index }>
+									{ showThumbnails
+										? <a className="jp-relatedposts-post-a" href="#jetpack_relatedposts" rel="nofollow" data-origin="0" data-position="0">
+											<img className="jp-relatedposts-post-img" src={ post.image } width="350" alt={ post.title } scale="0" />
+										</a>
+										: null
+									}
+									<h4 className="jp-relatedposts-post-title">
+										<a className="jp-relatedposts-post-a" href="#jetpack_relatedposts" rel="nofollow" data-origin="0" data-position="0">
+											{ post.title }
+										</a>
+									</h4>
+									<p className="jp-relatedposts-post-context">{ post.topic }</p>
+								</div>
+							);
+						} )
+					}
 				</div>
 			</div>
 		</div>

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -292,7 +292,7 @@
 	margin-top: 16px;
 }
 
-.jp-relatedposts {
+.site-settings__related-posts {
 	position: relative;
 	margin-top: 8px;
 	padding: 16px 8px;
@@ -302,19 +302,19 @@
 
 	@include clear-fix;
 
-	.jp-relatedposts-headline {
+	.site-settings__related-posts-headline {
  		margin: 0 0 1em 8px;
  		font-size: 11px;
  		font-weight: 600;
  	}
 
-	.jp-relatedposts-items {
+	.site-settings__related-posts-items {
 
 
 		@include breakpoint( ">480px" ) {
 			display: flex;
 			flex-wrap: wrap;
-			.jp-relatedposts-post {
+			.site-settings__related-posts-post {
 				width: 50%;
 			}
 		}
@@ -324,30 +324,30 @@
 		}
 	}
 
-	.jp-relatedposts-post .jp-relatedposts-post-title a {
+	.site-settings__related-posts-post .site-settings__related-posts-post-title a {
 		font-weight: normal;
 		text-decoration: none;
 		opacity: 1;
 	}
 
-	.jp-relatedposts-post {
+	.site-settings__related-posts-post {
 		box-sizing: border-box;
 		margin: 0;
 		padding: 0 8px;
 	}
 
-	.jp-relatedposts-post span {
+	.site-settings__related-posts-post span {
 		display: block;
 		max-width: 90%;
 		overflow: hidden;
 		text-overflow: ellipsis;
 	}
 
-	.jp-relatedposts-post .jp-relatedposts-post-context {
+	.site-settings__related-posts-post .site-settings__related-posts-post-context {
 		opacity: .6;
 	}
 
-	.jp-relatedposts-post-a {
+	.site-settings__related-posts-post-a {
 		cursor: pointer;
 	}
 }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -346,6 +346,10 @@
 	.jp-relatedposts-post .jp-relatedposts-post-context {
 		opacity: .6;
 	}
+
+	.jp-relatedposts-post-a {
+		cursor: pointer;
+	}
 }
 
 .jetpack-protect__deactivate,


### PR DESCRIPTION
This PR refactors and improves the `RelatedContentPreview` component in Site Settings, addressing the following:

* Refactors `RelatedContentPreview` as a stateless functional component.
* ES6-ifies the legacy code within `RelatedContentPreview`.
* Updates `this.translate` usages to `i18n-calypso.localize`.
* Separates the content (the demo posts) from the presentation part, so it can be updated more easily.
* Updates the CSS classes to conform to the namespace guidelines.
* Cleans up the markup from unnecessary and unused attributes.
* Fixes all other ESLint warnings and improves overall code formatting.

To test:

* Checkout this branch
* Play with the Related Posts settings in Site Settings/General.
* Verify there are no regressions within the Related Posts preview.