### PR TITLE
Sharing: Drop the usage of Jetpack.Site.prototype from SharingButtonsAppearance

### DIFF
--- a/client/my-sites/sharing/buttons/appearance.jsx
+++ b/client/my-sites/sharing/buttons/appearance.jsx
@@ -1,115 +1,169 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { flowRight, partial } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var ButtonsPreview = require( './preview' ),
-	ButtonsPreviewPlaceholder = require( './preview-placeholder' ),
-	ButtonsStyle = require( './style' ),
-	analytics = require( 'lib/analytics' );
+import ButtonsPreview from './preview';
+import ButtonsPreviewPlaceholder from './preview-placeholder';
+import ButtonsStyle from './style';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite, isJetpackModuleActive } from 'state/sites/selectors';
+import { isPrivateSite } from 'state/selectors';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
-module.exports = React.createClass( {
-	displayName: 'SharingButtonsAppearance',
+class SharingButtonsAppearance extends Component {
+	static propTypes = {
+		buttons: PropTypes.array,
+		values: PropTypes.object,
+		onChange: PropTypes.func,
+		onButtonsChange: PropTypes.func,
+		onButtonsSave: PropTypes.func,
+		initialized: PropTypes.bool,
+		saving: PropTypes.bool,
+		isJetpack: PropTypes.bool,
+		isLikesModuleActive: PropTypes.bool,
+	}
 
-	propTypes: {
-		site: React.PropTypes.object.isRequired,
-		buttons: React.PropTypes.array,
-		values: React.PropTypes.object,
-		onChange: React.PropTypes.func,
-		onButtonsChange: React.PropTypes.func,
-		onButtonsSave: React.PropTypes.func,
-		initialized: React.PropTypes.bool,
-		saving: React.PropTypes.bool
-	},
+	static defaultProps = {
+		buttons: Object.freeze( [] ),
+		values: Object.freeze( {} ),
+		onChange: function() {},
+		onButtonsChange: function() {},
+		initialized: false,
+		saving: false
+	};
 
-	getDefaultProps: function() {
-		return {
-			buttons: Object.freeze( [] ),
-			values: Object.freeze( {} ),
-			onChange: function() {},
-			onButtonsChange: function() {},
-			initialized: false,
-			saving: false
-		};
-	},
-
-	onReblogsLikesCheckboxClicked: function( event ) {
+	onReblogsLikesCheckboxClicked = event => {
 		this.props.onChange( event.target.name, ! event.target.checked );
-
 		if ( 'disabled_reblogs' === event.target.name ) {
-			analytics.ga.recordEvent( 'Sharing', 'Clicked Show Reblog Button Checkbox', 'checked', event.target.checked ? 1 : 0 );
+			this.props.recordGoogleEvent( 'Sharing', 'Clicked Show Reblog Button Checkbox', 'checked', event.target.checked ? 1 : 0 );
 		} else if ( 'disabled_likes' === event.target.name ) {
-			analytics.ga.recordEvent( 'Sharing', 'Clicked Show Like Button Checkbox', 'checked', event.target.checked ? 1 : 0 );
+			this.props.recordGoogleEvent( 'Sharing', 'Clicked Show Like Button Checkbox', 'checked', event.target.checked ? 1 : 0 );
 		}
-	},
+	};
 
-	getPreviewElement: function() {
+	getPreviewElement() {
 		if ( this.props.initialized ) {
+			const changeLabel = partial( this.props.onChange, 'sharing_label' );
+
 			return (
 				<ButtonsPreview
-					site={ this.props.site }
+					isPrivateSite={ this.props.isPrivate }
 					style={ this.props.values.sharing_button_style }
 					label={ this.props.values.sharing_label }
 					buttons={ this.props.buttons }
-					showLike={ ( ! this.props.site.jetpack || this.props.site.isModuleActive( 'likes' ) ) && ( '' === this.props.values.disabled_likes || false === this.props.values.disabled_likes ) }
-					showReblog={ ! this.props.site.jetpack && ( '' === this.props.values.disabled_reblogs || false === this.props.values.disabled_reblogs ) }
-					onLabelChange={ this.props.onChange.bind( null, 'sharing_label' ) }
+					showLike={
+						( ! this.props.isJetpack || this.props.isLikesModuleActive ) &&
+						( '' === this.props.values.disabled_likes || false === this.props.values.disabled_likes )
+					}
+					showReblog={
+						! this.props.isJetpack &&
+						( '' === this.props.values.disabled_reblogs || false === this.props.values.disabled_reblogs )
+					}
+					onLabelChange={ changeLabel }
 					onButtonsChange={ this.props.onButtonsChange } />
 			);
-		} else {
-			return <ButtonsPreviewPlaceholder />;
 		}
-	},
 
-	getReblogOptionElement: function() {
-		if ( ! this.props.site.jetpack ) {
+		return <ButtonsPreviewPlaceholder />;
+	}
+
+	getReblogOptionElement() {
+		if ( ! this.props.isJetpack ) {
 			return (
 				<label>
-					<input name="disabled_reblogs" type="checkbox" checked={ '' === this.props.values.disabled_reblogs || false === this.props.values.disabled_reblogs } onChange={ this.onReblogsLikesCheckboxClicked } disabled={ ! this.props.initialized } />
-					<span>{ this.translate( 'Show reblog button', { context: 'Sharing options: Checkbox label' } ) }</span>
+					<input
+						name="disabled_reblogs"
+						type="checkbox"
+						checked={ '' === this.props.values.disabled_reblogs || false === this.props.values.disabled_reblogs }
+						onChange={ this.onReblogsLikesCheckboxClicked }
+						disabled={ ! this.props.initialized }
+					/>
+					<span>{ this.props.translate( 'Show reblog button', { context: 'Sharing options: Checkbox label' } ) }</span>
 				</label>
 			);
 		}
-	},
+	}
 
-	getReblogLikeOptionsElement: function() {
-		if ( ! this.props.site.jetpack || this.props.site.isModuleActive( 'likes' ) ) {
+	getReblogLikeOptionsElement() {
+		if ( ( ! this.props.isJetpack || this.props.isLikesModuleActive ) ) {
 			return (
 				<fieldset className="sharing-buttons__fieldset">
 					<legend className="sharing-buttons__fieldset-heading">
-						{ this.translate( 'Reblog & Like', { context: 'Sharing options: Header' } ) }
+						{ this.props.translate( 'Reblog & Like', { context: 'Sharing options: Header' } ) }
 					</legend>
 					{ this.getReblogOptionElement() }
 					<label>
-						<input name="disabled_likes" type="checkbox" checked={ '' === this.props.values.disabled_likes || false === this.props.values.disabled_likes } onChange={ this.onReblogsLikesCheckboxClicked } disabled={ ! this.props.initialized } />
-						<span>{ this.translate( 'Show like button', { context: 'Sharing options: Checkbox label' } ) }</span>
+						<input
+							name="disabled_likes"
+							type="checkbox"
+							checked={ '' === this.props.values.disabled_likes || false === this.props.values.disabled_likes }
+							onChange={ this.onReblogsLikesCheckboxClicked }
+							disabled={ ! this.props.initialized }
+						/>
+						<span>{ this.props.translate( 'Show like button', { context: 'Sharing options: Checkbox label' } ) }</span>
 					</label>
 				</fieldset>
 			);
 		}
-	},
+	}
 
-	render: function() {
+	render() {
+		const changeButtonStyle = partial( this.props.onChange, 'sharing_button_style' );
 		return (
 			<div className="sharing-buttons__panel sharing-buttons-appearance">
 				<p className="sharing-buttons-appearance__description">
-					{ this.translate( 'Allow readers to easily share your posts with others by adding sharing buttons throughout your site.' ) }
+					{ this.props.translate(
+						'Allow readers to easily share your posts with others by adding sharing buttons throughout your site.'
+					) }
 				</p>
 
 				{ this.getPreviewElement() }
 
 				<div className="sharing-buttons__fieldset-group">
-					<ButtonsStyle onChange={ this.props.onChange.bind( null, 'sharing_button_style' ) } value={ this.props.values.sharing_button_style } disabled={ ! this.props.initialized } />
+					<ButtonsStyle
+						onChange={ changeButtonStyle }
+						value={ this.props.values.sharing_button_style }
+						disabled={ ! this.props.initialized }
+					/>
 					{ this.getReblogLikeOptionsElement() }
 				</div>
 
-				<button type="submit" className="button is-primary sharing-buttons__submit" disabled={ this.props.saving || ! this.props.initialized }>
-					{ this.props.saving ? this.translate( 'Saving…' ) : this.translate( 'Save Changes' ) }
+				<button
+					type="submit"
+					className="button is-primary sharing-buttons__submit"
+					disabled={ this.props.saving || ! this.props.initialized }
+				>
+					{ this.props.saving ? this.props.translate( 'Saving…' ) : this.props.translate( 'Save Changes' ) }
 				</button>
 			</div>
 		);
 	}
-} );
+}
+
+const connectComponent = connect(
+	state => {
+		const siteId = getSelectedSiteId( state );
+		const isJetpack = isJetpackSite( state, siteId );
+		const isLikesModuleActive = isJetpackModuleActive( state, siteId, 'likes' );
+		const isPrivate = isPrivateSite( state, siteId );
+
+		return {
+			isJetpack,
+			isLikesModuleActive,
+			isPrivate,
+		};
+	},
+	{ recordGoogleEvent }
+);
+
+export default flowRight(
+	connectComponent,
+	localize,
+)( SharingButtonsAppearance );

--- a/client/my-sites/sharing/buttons/appearance.jsx
+++ b/client/my-sites/sharing/buttons/appearance.jsx
@@ -20,24 +20,34 @@ import { recordGoogleEvent } from 'state/analytics/actions';
 class SharingButtonsAppearance extends Component {
 	static propTypes = {
 		buttons: PropTypes.array,
-		values: PropTypes.object,
+		initialized: PropTypes.bool,
+		isJetpack: PropTypes.bool,
+		isLikesModuleActive: PropTypes.bool,
+		isPrivate: PropTypes.bool,
 		onChange: PropTypes.func,
 		onButtonsChange: PropTypes.func,
 		onButtonsSave: PropTypes.func,
-		initialized: PropTypes.bool,
+		recordGoogleEvent: PropTypes.func,
 		saving: PropTypes.bool,
-		isJetpack: PropTypes.bool,
-		isLikesModuleActive: PropTypes.bool,
+		values: PropTypes.object,
 	}
 
 	static defaultProps = {
 		buttons: Object.freeze( [] ),
 		values: Object.freeze( {} ),
-		onChange: function() {},
-		onButtonsChange: function() {},
+		onChange: () => {},
+		onButtonsChange: () => {},
 		initialized: false,
 		saving: false
 	};
+
+	isLikeButtonEnabled() {
+		return '' === this.props.values.disabled_likes || false === this.props.values.disabled_likes;
+	}
+
+	isReblogButtonEnabled() {
+		return '' === this.props.values.disabled_reblogs || false === this.props.values.disabled_reblogs;
+	}
 
 	onReblogsLikesCheckboxClicked = event => {
 		this.props.onChange( event.target.name, ! event.target.checked );
@@ -60,12 +70,9 @@ class SharingButtonsAppearance extends Component {
 					buttons={ this.props.buttons }
 					showLike={
 						( ! this.props.isJetpack || this.props.isLikesModuleActive ) &&
-						( '' === this.props.values.disabled_likes || false === this.props.values.disabled_likes )
+						this.isLikeButtonEnabled()
 					}
-					showReblog={
-						! this.props.isJetpack &&
-						( '' === this.props.values.disabled_reblogs || false === this.props.values.disabled_reblogs )
-					}
+					showReblog={ ! this.props.isJetpack && this.isReblogButtonEnabled() }
 					onLabelChange={ changeLabel }
 					onButtonsChange={ this.props.onButtonsChange } />
 			);
@@ -81,7 +88,7 @@ class SharingButtonsAppearance extends Component {
 					<input
 						name="disabled_reblogs"
 						type="checkbox"
-						checked={ '' === this.props.values.disabled_reblogs || false === this.props.values.disabled_reblogs }
+						checked={ this.isReblogButtonEnabled() }
 						onChange={ this.onReblogsLikesCheckboxClicked }
 						disabled={ ! this.props.initialized }
 					/>
@@ -103,7 +110,7 @@ class SharingButtonsAppearance extends Component {
 						<input
 							name="disabled_likes"
 							type="checkbox"
-							checked={ '' === this.props.values.disabled_likes || false === this.props.values.disabled_likes }
+							checked={ this.isLikeButtonEnabled() }
 							onChange={ this.onReblogsLikesCheckboxClicked }
 							disabled={ ! this.props.initialized }
 						/>

--- a/client/my-sites/sharing/buttons/buttons.jsx
+++ b/client/my-sites/sharing/buttons/buttons.jsx
@@ -116,7 +116,6 @@ module.exports = protectForm( React.createClass( {
 		return (
 			<form onSubmit={ this.saveChanges } id="sharing-buttons" className="sharing-settings sharing-buttons">
 				<ButtonsAppearance
-					site={ this.props.site }
 					buttons={ this.getPreviewButtons() }
 					values={ settings }
 					onChange={ this.handleChange }

--- a/client/my-sites/sharing/buttons/preview.jsx
+++ b/client/my-sites/sharing/buttons/preview.jsx
@@ -19,7 +19,7 @@ module.exports = React.createClass( {
 	displayName: 'SharingButtonsPreview',
 
 	propTypes: {
-		site: React.PropTypes.object.isRequired,
+		isPrivateSite: React.PropTypes.bool,
 		style: React.PropTypes.oneOf( [ 'icon-text', 'icon', 'text', 'official' ] ),
 		label: React.PropTypes.string,
 		buttons: React.PropTypes.array,
@@ -189,7 +189,7 @@ module.exports = React.createClass( {
 					onButtonsChange={ this.props.onButtonsChange }
 					onClose={ this.hideButtonsTray }
 					active={ null !== this.state.buttonsTrayVisibility }
-					limited={ this.props.site.is_private } />
+					limited={ this.props.isPrivateSite } />
 			</div>
 		);
 	}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -15,6 +15,7 @@
 
 export canCurrentUser from './can-current-user';
 export getSharingButtons from './get-sharing-buttons';
+export isPrivateSite from './is-private-site';
 export isRequestingSharingButtons from './is-requesting-sharing-buttons';
 export isSavingSharingButtons from './is-saving-sharing-buttons';
 export isSharingButtonsSaveSuccessful from './is-sharing-buttons-save-successful';

--- a/client/state/selectors/is-private-site.js
+++ b/client/state/selectors/is-private-site.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import { getRawSite } from 'state/sites/selectors';
+
+/**
+ * Returns true if the site is private
+ *
+ * @param {Object} state Global state tree
+ * @param {Object} siteId Site ID
+ * @return {Boolean} True if site is private
+ */
+export default function isPrivateSite( state, siteId ) {
+	const site = getRawSite( state, siteId );
+	if ( ! site ) {
+		return null;
+	}
+
+	return site.is_private;
+}

--- a/client/state/selectors/test/is-private-site.js
+++ b/client/state/selectors/test/is-private-site.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isPrivateSite } from '../';
+
+describe( 'isPrivateSite()', () => {
+	it( 'should return null if the site is not known', () => {
+		const isPrivate = isPrivateSite( {
+			sites: {
+				items: {
+					2916284: {
+						ID: 2916284,
+						is_private: false
+					}
+				}
+			}
+		}, 2916285 );
+
+		expect( isPrivate ).to.be.null;
+	} );
+
+	it( 'should return false for public sites', () => {
+		const isPrivate = isPrivateSite( {
+			sites: {
+				items: {
+					2916284: {
+						ID: 2916284,
+						is_private: false
+					}
+				}
+			}
+		}, 2916284 );
+
+		expect( isPrivate ).to.be.false;
+	} );
+
+	it( 'should return true for private sites', () => {
+		const isPrivate = isPrivateSite( {
+			sites: {
+				items: {
+					2916284: {
+						ID: 2916284,
+						is_private: true
+					}
+				}
+			}
+		}, 2916284 );
+
+		expect( isPrivate ).to.be.true;
+	} );
+} );


### PR DESCRIPTION
follow-up to #10278
part of #8726

In this PR, I'm dropping the usage of the Jetpack.Site.prototype object from the `SharingButtonsAppearance` and I rely on Redux selectors instead.
Also, I applied some of our latest coding style to this component:
 - React Class
 - localize HoC
 - imports 

**Testing instructions**
 * Open the /sharing/buttons/$site
 * Try to edit and save the appearance of the sharing buttons
 * Try for Jetpack websites as well