### PR TITLE
JPC: Load plans list in plans page

### DIFF
--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -263,7 +263,7 @@ class Plans extends Component {
 			( ! this.props.showFirst && ! this.props.canPurchasePlans ) ||
 			( ! this.props.showFirst && this.hasPlan( this.props.selectedSite ) )
 		) {
-			return null;
+			return <QueryPlans />;
 		}
 
 		return (


### PR DESCRIPTION
JPC Plans page wasn't loading the plan list if the plan has been already selected

How to test
=========
0. Use a incognito mode window for this test
1. login to your (unconnected) self-hosted site
2. go to https://calypso.live/jetpack/connect/personal?branch=fix/jpc_plans_query
3. enter the url of your site
4. you should be prompted to login into wordpress.com. enter your user
5. You should be redirected to a shopping cart with the personal plan already there waiting to be paid