### PR TITLE
TinyMCE: Update empty paragraph regex to match core.

### DIFF
--- a/client/components/tinymce/plugins/wpcom/plugin.js
+++ b/client/components/tinymce/plugins/wpcom/plugin.js
@@ -15,6 +15,7 @@ var translate = require( 'i18n-calypso' ).translate;
  * Internal dependencies
  */
 var formatting = require( 'lib/formatting' );
+import { removeEmptySpacesInParagraphs } from './wpcom-utils';
 
 /* eslint-disable */
 function wpcomPlugin( editor ) {
@@ -290,14 +291,7 @@ function wpcomPlugin( editor ) {
 	// Remove spaces from empty paragraphs.
 	editor.on( 'BeforeSetContent', function( event ) {
 		if ( event.content ) {
-			var paragraph = tinymce.Env.webkit ? '<p><br /></p>' : '<p></p>';
-
-			event.content = event.content.replace( /<p>([^<>]+)<\/p>/gi, function( tag, text ) {
-				if ( /^(&nbsp;|\s|\u00a0|\ufeff)+$/i.test( text ) ) {
-					return paragraph;
-				}
-				return tag;
-			} );
+			event.content = removeEmptySpacesInParagraphs( event.content );
 		}
 	} );
 

--- a/client/components/tinymce/plugins/wpcom/plugin.js
+++ b/client/components/tinymce/plugins/wpcom/plugin.js
@@ -289,10 +289,15 @@ function wpcomPlugin( editor ) {
 
 	// Remove spaces from empty paragraphs.
 	editor.on( 'BeforeSetContent', function( event ) {
-		var paragraph = tinymce.Env.webkit ? '<p><br /></p>' : '<p></p>';
-
 		if ( event.content ) {
-			event.content = event.content.replace( /<p>(?:&nbsp;|\u00a0|\uFEFF|\s)+<\/p>/gi, paragraph );
+			var paragraph = tinymce.Env.webkit ? '<p><br /></p>' : '<p></p>';
+
+			event.content = event.content.replace( /<p>([^<>]+)<\/p>/gi, function( tag, text ) {
+				if ( /^(&nbsp;|\s|\u00a0|\ufeff)+$/i.test( text ) ) {
+					return paragraph;
+				}
+				return tag;
+			} );
 		}
 	} );
 

--- a/client/components/tinymce/plugins/wpcom/test/utils.js
+++ b/client/components/tinymce/plugins/wpcom/test/utils.js
@@ -9,7 +9,6 @@ import { assert } from 'chai';
 import { removeEmptySpacesInParagraphs } from '../wpcom-utils';
 
 describe( 'remove empty spaces in paragraphs', () => {
-
 	it( 'should not modify paragraphs with content', () => {
 		const content = '<p>Chicken &amp; Ribs</p>';
 
@@ -43,5 +42,4 @@ describe( 'remove empty spaces in paragraphs', () => {
 		const content = '<p>chicken\u00a0ribs</p>';
 		assert.equal( content, removeEmptySpacesInParagraphs( content ) );
 	} );
-
 } );

--- a/client/components/tinymce/plugins/wpcom/test/utils.js
+++ b/client/components/tinymce/plugins/wpcom/test/utils.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { removeEmptySpacesInParagraphs } from '../wpcom-utils';
+
+describe( 'remove empty spaces in paragraphs', () => {
+
+	it( 'should not modify paragraphs with content', () => {
+		const content = '<p>Chicken &amp; Ribs</p>';
+
+		assert.equal( content, removeEmptySpacesInParagraphs( content ) );
+	} );
+
+	it( 'should remove &nbsp; from empty paragraphs', () => {
+		const content = '<p>&nbsp;</p>';
+
+		assert.equal( '<p><br /></p>', removeEmptySpacesInParagraphs( content ) );
+	} );
+
+	it( 'should not remove &nbsp; from paragraphs with content', () => {
+		const content = '<p>chicken&nbsp;ribs</p>';
+
+		assert.equal( content, removeEmptySpacesInParagraphs( content ) );
+	} );
+
+	it( 'should remove &nbsp; from paragraphs without content and not ones with content', () => {
+		const content = '<div>&nbsp;</div><p>&nbsp;</p><p>chicken&nbsp;ribs</p>';
+
+		assert.equal( '<div>&nbsp;</div><p><br /></p><p>chicken&nbsp;ribs</p>', removeEmptySpacesInParagraphs( content ) );
+	} );
+
+	it( 'should remove unicode spaces from empty paragraphs', () => {
+		const content = '<p>\u00a0\ufeff\ufeff\ufeff</p>';
+		assert.equal( '<p><br /></p>', removeEmptySpacesInParagraphs( content ) );
+	} );
+
+	it( 'should note remove unicode spaces from paragraphs with content', () => {
+		const content = '<p>chicken\u00a0ribs</p>';
+		assert.equal( content, removeEmptySpacesInParagraphs( content ) );
+	} );
+
+} );

--- a/client/components/tinymce/plugins/wpcom/wpcom-utils.js
+++ b/client/components/tinymce/plugins/wpcom/wpcom-utils.js
@@ -1,0 +1,18 @@
+/**
+ * Removes empty spaces from empty paragraphs
+ * This logic is borrowed from core's TinyMCE Plugin
+ *
+ * @see https://core.trac.wordpress.org/browser/trunk/src/wp-includes/js/tinymce/plugins/wordpress/plugin.js#L133
+ *
+ * @param  {String}   content TinyMCE Editor content
+ * @return {String}           Content with strings removed from empty paragraphs
+ */
+export function removeEmptySpacesInParagraphs( content ) {
+	return content.replace( /<p>([^<>]+)<\/p>/gi, function( tag, text ) {
+		if ( text === '&nbsp;' || ! /\S/.test( text ) ) {
+			return '<p><br /></p>';
+		}
+
+		return tag;
+	} );
+}

--- a/client/components/tinymce/plugins/wpcom/wpcom-utils.js
+++ b/client/components/tinymce/plugins/wpcom/wpcom-utils.js
@@ -2,7 +2,7 @@
  * Removes empty spaces from empty paragraphs
  * This logic is borrowed from core's TinyMCE Plugin
  *
- * @see https://core.trac.wordpress.org/browser/trunk/src/wp-includes/js/tinymce/plugins/wordpress/plugin.js#L133
+ * @see https://core.trac.wordpress.org/changeset/39204
  *
  * @param  {String}   content TinyMCE Editor content
  * @return {String}           Content with strings removed from empty paragraphs


### PR DESCRIPTION
Fixes #9265

There is some logic in the TinyMCE `wpcom` plugin that replaces empty paragraphs on `BeforeSetContent` - this was causing an endless loop for various special strings, one of which was reported in #9265, but was also reported at https://core.trac.wordpress.org/ticket/35890 and fixed in https://core.trac.wordpress.org/changeset/36597.  This branch takes the core fix, and updates the calypso version of this logic.

__To Test__
The easiest way to test this out is to login as the user in 2908969-t, and edit the page in question.  If you do so on production first, you will note that your browser tab will eventually crash.  Then test this branch locally and note the page will load in the editor - albeit a bit slowly as there are over 25k words in the post.

hat tip to @azaozz to the original fix in core!