### PR TITLE
Update the data layer to allow for passing actions through middleware

### DIFF
--- a/client/state/data-layer/test/utils.js
+++ b/client/state/data-layer/test/utils.js
@@ -6,9 +6,34 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { mergeHandlers } from '../utils';
+import { local, mergeHandlers } from '../utils';
 
 describe( 'Data Layer', () => {
+	describe( '#local', () => {
+		it( 'should wrap an action with the bypass flag', () => {
+			const action = { type: 'ADD_SPLINE', id: 42 };
+			const localAction = local( action );
+
+			expect( localAction ).to.have.deep.property( 'meta.dataLayer.doBypass', true );
+		} );
+
+		it( 'should not destroy existing meta', () => {
+			const action = {
+				type: 'SHAVE_THE_WHALES',
+				meta: {
+					oceanName: 'ARCTIC',
+					dataLayer: {
+						forceRefresh: true,
+					}
+				}
+			};
+			const localAction = local( action );
+
+			expect( localAction ).to.have.deep.property( 'meta.oceanName', 'ARCTIC' );
+			expect( localAction ).to.have.deep.property( 'meta.dataLayer.forceRefresh', true );
+		} );
+	} );
+
 	describe( '#mergeHandlers', () => {
 		const inc = a => a + 1;
 		const triple = a => a * 3;

--- a/client/state/data-layer/test/wpcom-api-middleware.js
+++ b/client/state/data-layer/test/wpcom-api-middleware.js
@@ -1,0 +1,112 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { spy, stub } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import { middleware } from '../wpcom-api-middleware';
+import { local, mergeHandlers } from '../utils';
+
+describe( 'WordPress.com API Middleware', () => {
+	let next;
+	let store;
+
+	beforeEach( () => {
+		next = spy();
+
+		store = {
+			dispatch: spy(),
+			getState: stub(),
+			replaceReducers: spy(),
+			subscribe: spy(),
+		};
+
+		store.getState.returns( Object.create( null ) );
+	} );
+
+	it( 'should pass along actions without corresponding handlers', () => {
+		const handlers = Object.create( null );
+		const action = { type: 'UNSUPPORTED_ACTION' };
+
+		middleware( handlers )( store )( next )( action );
+
+		expect( store.dispatch ).to.not.have.beenCalled;
+		expect( next ).to.have.been.calledWith( action );
+	} );
+
+	it( 'should pass along local actions untouched', () => {
+		const adder = spy();
+		const handlers = mergeHandlers( {
+			[ 'ADD' ]: [ adder ],
+		} );
+		const action = local( { type: 'ADD' } );
+
+		middleware( handlers )( store )( next )( action );
+
+		expect( next ).to.have.been.calledWith( action );
+		expect( adder ).to.not.have.beenCalled;
+	} );
+
+	it( 'should intercept actions in appropriate handler', () => {
+		const adder = spy();
+		const handlers = mergeHandlers( {
+			[ 'ADD' ]: [ adder ],
+		} );
+		const action = { type: 'ADD' };
+
+		middleware( handlers )( store )( next )( action );
+
+		expect( next ).to.not.have.been.calledWith( action );
+		expect( adder ).to.have.been.calledWith( store, action, next );
+	} );
+
+	it( 'should allow continuing the action down the chain', () => {
+		const sentinel = { type: 'SENTINEL' };
+		const adder = spy( () => next( sentinel ) );
+		const handlers = mergeHandlers( {
+			[ 'ADD' ]: [ adder ],
+		} );
+		const action = { type: 'ADD' };
+
+		middleware( handlers )( store )( next )( action );
+
+		expect( next ).to.have.been.calledOnce;
+		expect( next ).to.have.been.calledWith( sentinel );
+		expect( adder ).to.have.been.calledWith( store, action, next );
+	} );
+
+	it( 'should call all given handlers (same list)', () => {
+		const adder = spy();
+		const doubler = spy();
+		const handlers = mergeHandlers( {
+			[ 'MATHS' ]: [ adder, doubler ],
+		} );
+		const action = { type: 'MATHS' };
+
+		middleware( handlers )( store )( next )( action );
+
+		expect( adder ).to.have.been.calledWith( store, action, next );
+		expect( doubler ).to.have.been.calledWith( store, action, next );
+		expect( next ).to.not.have.beenCalled;
+	} );
+
+	it( 'should call all given handlers (different lists)', () => {
+		const adder = spy();
+		const doubler = spy();
+		const handlers = mergeHandlers( {
+			[ 'MATHS' ]: [ adder ],
+		}, {
+			[ 'MATHS' ]: [ doubler ],
+		} );
+		const action = { type: 'MATHS' };
+
+		middleware( handlers )( store )( next )( action );
+
+		expect( adder ).to.have.been.calledWith( store, action, next );
+		expect( doubler ).to.have.been.calledWith( store, action, next );
+		expect( next ).to.not.have.beenCalled;
+	} );
+} );

--- a/client/state/data-layer/test/wpcom-api-middleware.js
+++ b/client/state/data-layer/test/wpcom-api-middleware.js
@@ -60,12 +60,11 @@ describe( 'WordPress.com API Middleware', () => {
 		middleware( handlers )( store )( next )( action );
 
 		expect( next ).to.not.have.been.calledWith( action );
-		expect( adder ).to.have.been.calledWith( store, action, next );
+		expect( adder ).to.have.been.calledWith( store, action );
 	} );
 
 	it( 'should allow continuing the action down the chain', () => {
-		const sentinel = { type: 'SENTINEL' };
-		const adder = spy( () => next( sentinel ) );
+		const adder = spy( ( _store, _action, _next ) => _next( _action ) );
 		const handlers = mergeHandlers( {
 			[ 'ADD' ]: [ adder ],
 		} );
@@ -74,8 +73,8 @@ describe( 'WordPress.com API Middleware', () => {
 		middleware( handlers )( store )( next )( action );
 
 		expect( next ).to.have.been.calledOnce;
-		expect( next ).to.have.been.calledWith( sentinel );
-		expect( adder ).to.have.been.calledWith( store, action, next );
+		expect( next ).to.have.been.calledWith( local( action ) );
+		expect( adder ).to.have.been.calledWith( store, action );
 	} );
 
 	it( 'should call all given handlers (same list)', () => {
@@ -88,8 +87,8 @@ describe( 'WordPress.com API Middleware', () => {
 
 		middleware( handlers )( store )( next )( action );
 
-		expect( adder ).to.have.been.calledWith( store, action, next );
-		expect( doubler ).to.have.been.calledWith( store, action, next );
+		expect( adder ).to.have.been.calledWith( store, action );
+		expect( doubler ).to.have.been.calledWith( store, action );
 		expect( next ).to.not.have.beenCalled;
 	} );
 
@@ -105,8 +104,8 @@ describe( 'WordPress.com API Middleware', () => {
 
 		middleware( handlers )( store )( next )( action );
 
-		expect( adder ).to.have.been.calledWith( store, action, next );
-		expect( doubler ).to.have.been.calledWith( store, action, next );
+		expect( adder ).to.have.been.calledWith( store, action );
+		expect( doubler ).to.have.been.calledWith( store, action );
 		expect( next ).to.not.have.beenCalled;
 	} );
 } );

--- a/client/state/data-layer/utils.js
+++ b/client/state/data-layer/utils.js
@@ -7,6 +7,11 @@ import {
 } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import { extendAction } from 'state/utils';
+
+/**
  * Merge handler for lodash.mergeWith
  *
  * Note that a return value of `undefined`
@@ -27,3 +32,13 @@ export const mergeHandlers = ( ...handlers ) =>
 	handlers.length > 1
 		? mergeWith( Object.create( null ), ...handlers, concatHandlers )
 		: handlers[ 0 ];
+
+const doBypassDataLayer = {
+	meta: {
+		dataLayer: {
+			doBypass: true,
+		},
+	},
+};
+
+export const local = action => extendAction( action, doBypassDataLayer );

--- a/client/state/data-layer/wpcom-api-middleware.js
+++ b/client/state/data-layer/wpcom-api-middleware.js
@@ -1,7 +1,8 @@
 /**
  * Internal dependencies
  */
-import handlerTree from './wpcom';
+import handlerMap from './wpcom';
+import { local } from './utils';
 
 /**
  * WPCOM Middleware API
@@ -24,28 +25,32 @@ import handlerTree from './wpcom';
  * The optimizations reduce function-calling and object
  * property lookup where possible.
  */
-export const middleware = handlers => store => next => action => {
-	const handlerChain = handlers[ action.type ];
+export const middleware = handlers => store => next => {
+	const localNext = action => next( local( action ) );
 
-	// if no handler is defined for the action type
-	// then pass it along the chain untouched
-	if ( ! handlerChain ) {
-		return next( action );
-	}
+	return action => {
+		const handlerChain = handlers[ action.type ];
 
-	const meta = action.meta;
-	if ( meta ) {
-		const dataLayer = meta.dataLayer;
-
-		// if the action indicates that we should
-		// bypass the data layer, then pass it
-		// along the chain untouched
-		if ( true === dataLayer.doBypass ) {
+		// if no handler is defined for the action type
+		// then pass it along the chain untouched
+		if ( ! handlerChain ) {
 			return next( action );
 		}
-	}
 
-	return handlerChain.forEach( handler => handler( store, action, next ) )
+		const meta = action.meta;
+		if ( meta ) {
+			const dataLayer = meta.dataLayer;
+
+			// if the action indicates that we should
+			// bypass the data layer, then pass it
+			// along the chain untouched
+			if ( true === dataLayer.doBypass ) {
+				return next( action );
+			}
+		}
+
+		return handlerChain.forEach( handler => handler( store, action, localNext ) );
+	}
 };
 
-export default middleware( handlerTree );
+export default middleware( handlerMap );


### PR DESCRIPTION
The data layer was designed to intercept and discard actions requiring
side-effecting and asynchronous actions. This was chosen in part because
we might have situations where multiple middlewares could provide for
the same types of data needs and we only want the first in the chain to
actually handle the requests.

While this choice was reasonable for fetching actions such as
`INSULT_REQUEST` it was less fitting for actions that update data
remotely because the reducers would still need to respond to these
changes before hearing back from APIs etc...

For example, `POST_LIKE` should immediately update the state tree to
indicate that a post has been like, but the API middleware should also
intercept the action and ship the changes to the server. This middleware
now needs to pass the action along after processing.

We want to be careful in these situations not to get stuck in loops
because the continued action could theoretically hit the middleware
again. Further, response from API requests that dispatch new actions
could trigger similar cycles in the control flow graph.

To prevent looping I have created `local()` as a wrapper around actions
to indicate that they should skip all processing by the data layer.
Actions wrapped by `local()` will thus automatically bypass the
middleware and are safe to pass along the chain.

In the example of liking a post the middleware would finish by calling
the following line of code to send the action to the reducers and skip
further handling.

```js
likePost( store, action, next ) {
	...

	// pass along action to reducers
	next( local( action ) );
}
```

You may notice that a new parameter `next` has been given to the
middleware signature. This is the standard `next` from Redux middleware
and is the dispatcher assigned to continue in the dispatching chain.

**Testing**

Unit tests have been added to test the existing and new behaviors. This PR 
introduces functionality without actually using yet. Future PRs will come in
and start to depend on it, especially those which handle data updates and
need to forward requests after handling in the  middleware.

This means there is little to test here other than a straight-forward smoke-test.
Please review the code and look for edge cases that may not have been caught
in the test suite.

**Note**
this predates work in a future PR to add an HTTP middleware layer which will 
open up the door for robust offline action support, queueing, retry policies, 
and batching ✅ 