### PR TITLE
Update notice shown when purchasing domain from 'get-dot-blog' signup

### DIFF
--- a/client/my-sites/upgrades/checkout/secure-payment-form.jsx
+++ b/client/my-sites/upgrades/checkout/secure-payment-form.jsx
@@ -210,7 +210,7 @@ const SecurePaymentForm = React.createClass( {
 
 		return (
 			<Notice icon="notice" showDismiss={ false }>
-				{ preventWidows( this.translate( 'This is the payment information you entered on get.blog, ' +
+				{ preventWidows( this.translate( 'You can reuse the payment information you entered on get.blog, ' +
 					'a WordPress.com service. Confirm your order below.' ), 4 ) }
 			</Notice>
 		);


### PR DESCRIPTION
Fixes #8853.

This is a simple copy change in a notice. Check that the copy is updated.

### Testing Instructions
- Boot a local environment with this branch and visit http://calypso.localhost:3000/start/get-dot-blog?domain=example.com (Or on calypso.live at https://calypso.live/start/get-dot-blog?domain=example.com&branch=update/copy-notice-from-get-dot-blog).
- Go through the flow up until checkout.
- Check that the notice is updated to:

<img width="747" alt="screen shot 2016-12-28 at 16 35 41" src="https://cloud.githubusercontent.com/assets/230230/21516454/c63d47ca-cd1b-11e6-99e7-117c9c7a89de.png">

### Reviews
- [x] Product
- [x] Code


