### PR TITLE
Sharing: Drop the usage of Jetpack.Site.prototype from SharingButtonsOptions

### DIFF
--- a/client/my-sites/sharing/buttons/buttons.jsx
+++ b/client/my-sites/sharing/buttons/buttons.jsx
@@ -124,7 +124,6 @@ module.exports = protectForm( React.createClass( {
 					initialized={ this.isInitialized( [ 'settings', 'buttons' ] ) }
 					saving={ this.state.isSaving } />
 				<ButtonsOptions
-					site={ this.props.site }
 					postTypes={ this.props.postTypes.get( this.props.site.ID ) }
 					buttons={ this.props.buttons.get( this.props.site.ID ) }
 					values={ settings }

--- a/client/my-sites/sharing/buttons/options.jsx
+++ b/client/my-sites/sharing/buttons/options.jsx
@@ -1,63 +1,62 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import { get, some, xor } from 'lodash';
+import React, { Component, PropTypes } from 'react';
+import { flowRight, get, partial, some, xor } from 'lodash';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import MultiCheckbox from 'components/forms/multi-checkbox';
-import analytics from 'lib/analytics';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite, isJetpackMinimumVersion } from 'state/sites/selectors';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
-module.exports = React.createClass( {
-	displayName: 'SharingButtonsOptions',
+class SharingButtonsOptions extends Component {
+	static propTypes = {
+		buttons: PropTypes.array,
+		initialized: PropTypes.bool,
+		isJetpack: PropTypes.bool,
+		isTwitterButtonAllowed: PropTypes.bool,
+		onChange: PropTypes.func,
+		postTypes: PropTypes.array,
+		recordGoogleEvent: PropTypes.func,
+		saving: PropTypes.bool,
+		values: PropTypes.object,
+	};
 
-	propTypes: {
-		site: React.PropTypes.object.isRequired,
-		buttons: React.PropTypes.array,
-		postTypes: React.PropTypes.array,
-		values: React.PropTypes.object,
-		onChange: React.PropTypes.func,
-		initialized: React.PropTypes.bool,
-		saving: React.PropTypes.bool
-	},
+	static defaultProps = {
+		values: Object.freeze( {} ),
+		onChange: () => {},
+		initialized: false,
+		saving: false
+	};
 
-	getDefaultProps: function() {
-		return {
-			values: Object.freeze( {} ),
-			onChange: function() {},
-			initialized: false,
-			saving: false
-		};
-	},
-
-	getSanitizedTwitterUsername: function( username ) {
+	getSanitizedTwitterUsername( username ) {
 		return username ? '@' + username.replace( /\W/g, '' ).substr( 0, 15 ) : '';
-	},
+	}
 
-	trackTwitterViaAnalyticsEvent: function() {
-		analytics.ga.recordEvent( 'Sharing', 'Focussed Twitter Username Field' );
-	},
+	trackTwitterViaAnalyticsEvent = () => {
+		this.props.recordGoogleEvent( 'Sharing', 'Focussed Twitter Username Field' );
+	};
 
-	handleMultiCheckboxChange: function( name, event ) {
-		var delta = xor( this.props.values.sharing_show, event.value ),
-			checked;
-
+	handleMultiCheckboxChange = ( name, event ) => {
+		const delta = xor( this.props.values.sharing_show, event.value );
 		this.props.onChange( name, event.value.length ? event.value : null );
-
 		if ( delta.length ) {
-			checked = -1 !== event.value.indexOf( delta[0] );
-			analytics.ga.recordEvent( 'Sharing', 'Clicked Show Sharing Buttons On Page Checkbox', delta[0], checked ? 1 : 0 );
+			const checked = -1 !== event.value.indexOf( delta[ 0 ] );
+			this.props.recordGoogleEvent( 'Sharing', 'Clicked Show Sharing Buttons On Page Checkbox', delta[ 0 ], checked ? 1 : 0 );
 		}
-	},
+	};
 
-	handleTwitterViaChange: function( event ) {
+	handleTwitterViaChange = event => {
 		this.props.onChange( event.target.name, this.getSanitizedTwitterUsername( event.target.value ) );
-	},
+	};
 
-	handleChange: function( event ) {
-		var value;
+	handleChange = event => {
+		let value;
 		if ( 'checkbox' === event.target.type ) {
 			value = event.target.checked;
 		} else {
@@ -65,28 +64,41 @@ module.exports = React.createClass( {
 		}
 
 		if ( 'jetpack_comment_likes_enabled' === event.target.name ) {
-			analytics.ga.recordEvent( 'Sharing', 'Clicked Comment Likes On For All Posts Checkbox', 'checked', event.target.checked ? 1 : 0 );
+			this.props.recordGoogleEvent(
+				'Sharing', 'Clicked Comment Likes On For All Posts Checkbox', 'checked', event.target.checked ? 1 : 0
+			);
 		}
 
 		this.props.onChange( event.target.name, value );
-	},
+	};
 
-	getPostTypeLabel: function( postType ) {
-		var label;
+	getPostTypeLabel( postType ) {
+		let label;
 
 		switch ( postType.name ) {
-			case 'index': label = this.translate( 'Front Page, Archive Pages, and Search Results', { context: 'jetpack' } ); break;
-			case 'post': label = this.translate( 'Posts' ); break;
-			case 'page': label = this.translate( 'Pages' ); break;
-			case 'attachment': label = this.translate( 'Media' ); break;
-			case 'portfolio': label = this.translate( 'Portfolio Items' ); break;
-			default: label = postType.label;
+			case 'index':
+				label = this.props.translate( 'Front Page, Archive Pages, and Search Results', { context: 'jetpack' } );
+				break;
+			case 'post':
+				label = this.props.translate( 'Posts' );
+				break;
+			case 'page':
+				label = this.props.translate( 'Pages' );
+				break;
+			case 'attachment':
+				label = this.props.translate( 'Media' );
+				break;
+			case 'portfolio':
+				label = this.props.translate( 'Portfolio Items' );
+				break;
+			default:
+				label = postType.label;
 		}
 
 		return label;
-	},
+	}
 
-	getDisplayOptions: function() {
+	getDisplayOptions() {
 		return [
 			{ name: 'index' }
 		].concat( this.props.postTypes ).map( function( postType ) {
@@ -95,41 +107,39 @@ module.exports = React.createClass( {
 				label: this.getPostTypeLabel( postType )
 			};
 		}, this );
-	},
+	}
 
-	isTwitterButtonEnabled: function() {
+	isTwitterButtonEnabled() {
 		return some( this.props.buttons, { ID: 'twitter', enabled: true } );
-	},
+	}
 
-	getTwitterViaOptionElement: function() {
-		var option;
-
-		if ( ! this.isTwitterButtonEnabled() || ( this.props.site.jetpack && this.props.site.versionCompare( '3.4-dev', '<' ) ) ) {
+	getTwitterViaOptionElement() {
+		if ( ! this.isTwitterButtonEnabled() || ! this.props.isTwitterButtonAllowed ) {
 			return;
 		}
 
-		option = this.props.site.jetpack ? 'jetpack-twitter-cards-site-tag' : 'twitter_via';
+		const option = this.props.isJetpack ? 'jetpack-twitter-cards-site-tag' : 'twitter_via';
 
 		return (
 			<fieldset className="sharing-buttons__fieldset">
-				<legend className="sharing-buttons__fieldset-heading">{ this.translate( 'Twitter username' ) }</legend>
+				<legend className="sharing-buttons__fieldset-heading">{ this.props.translate( 'Twitter username' ) }</legend>
 				<input
 					name={ option }
 					type="text"
-					placeholder={ '@' + this.translate( 'username', { textOnly: true } ) }
+					placeholder={ '@' + this.props.translate( 'username', { textOnly: true } ) }
 					value={ this.getSanitizedTwitterUsername( this.props.values[ option ] ) }
 					onChange={ this.handleTwitterViaChange }
 					onFocus={ this.trackTwitterViaAnalyticsEvent }
 					disabled={ ! this.props.initialized } />
 				<p className="sharing-buttons__fieldset-detail">
-					{ this.translate( 'This will be included in tweets when people share using the Twitter button.' ) }
+					{ this.props.translate( 'This will be included in tweets when people share using the Twitter button.' ) }
 				</p>
 			</fieldset>
 		);
-	},
+	}
 
-	getCommentLikesOptionElement: function() {
-		if ( this.props.site.jetpack ) {
+	getCommentLikesOptionElement() {
+		if ( this.props.isJetpack ) {
 			return;
 		}
 
@@ -138,7 +148,7 @@ module.exports = React.createClass( {
 		return (
 			<fieldset className="sharing-buttons__fieldset">
 				<legend className="sharing-buttons__fieldset-heading">
-					{ this.translate( 'Comment Likes', { context: 'Sharing options: Header' } ) }
+					{ this.props.translate( 'Comment Likes', { context: 'Sharing options: Header' } ) }
 				</legend>
 				<label>
 					<input name="jetpack_comment_likes_enabled"
@@ -147,34 +157,65 @@ module.exports = React.createClass( {
 						onChange={ this.handleChange }
 						disabled={ ! this.props.initialized }
 					/>
-					<span>{ this.translate( 'On for all posts', { context: 'Sharing options: Comment Likes' } ) }</span>
+					<span>{ this.props.translate( 'On for all posts', { context: 'Sharing options: Comment Likes' } ) }</span>
 				</label>
 			</fieldset>
 		);
-	},
+	}
 
-	render: function() {
+	render() {
+		const changeSharingPostTypes = partial( this.handleMultiCheckboxChange, 'sharing_show' );
+
 		return (
 			<div className="sharing-buttons__panel">
-				<h4>{ this.translate( 'Options' ) }</h4>
+				<h4>{ this.props.translate( 'Options' ) }</h4>
 				<div className="sharing-buttons__fieldset-group">
 					<fieldset className="sharing-buttons__fieldset">
 						<legend className="sharing-buttons__fieldset-heading">
-							{ this.translate( 'Show sharing buttons on', {
+							{ this.props.translate( 'Show sharing buttons on', {
 								context: 'Sharing options: Header',
 								comment: 'Possible values are: "Front page, Archive Pages, and Search Results", "Posts", "Pages", "Media"'
 							} ) }
 						</legend>
-						<MultiCheckbox name="sharing_show" options={ this.getDisplayOptions() } checked={ this.props.values.sharing_show } onChange={ this.handleMultiCheckboxChange.bind( null, 'sharing_show' ) } disabled={ ! this.props.initialized } />
+						<MultiCheckbox
+							name="sharing_show"
+							options={ this.getDisplayOptions() }
+							checked={ this.props.values.sharing_show }
+							onChange={ changeSharingPostTypes }
+							disabled={ ! this.props.initialized }
+						/>
 					</fieldset>
 					{ this.getCommentLikesOptionElement() }
 					{ this.getTwitterViaOptionElement() }
 				</div>
 
-				<button type="submit" className="button is-primary sharing-buttons__submit" disabled={ this.props.saving || ! this.props.initialized }>
-					{ this.props.saving ? this.translate( 'Saving…' ) : this.translate( 'Save Changes' ) }
+				<button
+					type="submit"
+					className="button is-primary sharing-buttons__submit"
+					disabled={ this.props.saving || ! this.props.initialized }
+				>
+					{ this.props.saving ? this.props.translate( 'Saving…' ) : this.props.translate( 'Save Changes' ) }
 				</button>
 			</div>
 		);
 	}
-} );
+}
+
+const connectComponent = connect(
+	state => {
+		const siteId = getSelectedSiteId( state );
+		const isJetpack = isJetpackSite( state, siteId );
+		const isTwitterButtonAllowed = ! isJetpack || isJetpackMinimumVersion( state, siteId, '3.4-dev' );
+
+		return {
+			isJetpack,
+			isTwitterButtonAllowed
+		};
+	},
+	{ recordGoogleEvent }
+);
+
+export default flowRight(
+	connectComponent,
+	localize
+)( SharingButtonsOptions );

--- a/client/my-sites/sharing/buttons/options.jsx
+++ b/client/my-sites/sharing/buttons/options.jsx
@@ -24,6 +24,7 @@ class SharingButtonsOptions extends Component {
 		postTypes: PropTypes.array,
 		recordGoogleEvent: PropTypes.func,
 		saving: PropTypes.bool,
+		translate: PropTypes.func,
 		values: PropTypes.object,
 	};
 
@@ -114,65 +115,69 @@ class SharingButtonsOptions extends Component {
 	}
 
 	getTwitterViaOptionElement() {
-		if ( ! this.isTwitterButtonEnabled() || ! this.props.isTwitterButtonAllowed ) {
+		const { isJetpack, initialized, isTwitterButtonAllowed, translate, values } = this.props;
+		if ( ! this.isTwitterButtonEnabled() || ! isTwitterButtonAllowed ) {
 			return;
 		}
 
-		const option = this.props.isJetpack ? 'jetpack-twitter-cards-site-tag' : 'twitter_via';
+		const option = isJetpack ? 'jetpack-twitter-cards-site-tag' : 'twitter_via';
 
 		return (
 			<fieldset className="sharing-buttons__fieldset">
-				<legend className="sharing-buttons__fieldset-heading">{ this.props.translate( 'Twitter username' ) }</legend>
+				<legend className="sharing-buttons__fieldset-heading">{ translate( 'Twitter username' ) }</legend>
 				<input
 					name={ option }
 					type="text"
-					placeholder={ '@' + this.props.translate( 'username', { textOnly: true } ) }
-					value={ this.getSanitizedTwitterUsername( this.props.values[ option ] ) }
+					placeholder={ '@' + translate( 'username', { textOnly: true } ) }
+					value={ this.getSanitizedTwitterUsername( values[ option ] ) }
 					onChange={ this.handleTwitterViaChange }
 					onFocus={ this.trackTwitterViaAnalyticsEvent }
-					disabled={ ! this.props.initialized } />
+					disabled={ ! initialized } />
 				<p className="sharing-buttons__fieldset-detail">
-					{ this.props.translate( 'This will be included in tweets when people share using the Twitter button.' ) }
+					{ translate( 'This will be included in tweets when people share using the Twitter button.' ) }
 				</p>
 			</fieldset>
 		);
 	}
 
 	getCommentLikesOptionElement() {
-		if ( this.props.isJetpack ) {
+		const { isJetpack, initialized, translate, values } = this.props;
+
+		if ( isJetpack ) {
 			return;
 		}
 
-		const checked = get( this.props.values, 'jetpack_comment_likes_enabled', false );
+		const checked = get( values, 'jetpack_comment_likes_enabled', false );
 
 		return (
 			<fieldset className="sharing-buttons__fieldset">
 				<legend className="sharing-buttons__fieldset-heading">
-					{ this.props.translate( 'Comment Likes', { context: 'Sharing options: Header' } ) }
+					{ translate( 'Comment Likes', { context: 'Sharing options: Header' } ) }
 				</legend>
 				<label>
 					<input name="jetpack_comment_likes_enabled"
 						type="checkbox"
 						checked={ checked }
 						onChange={ this.handleChange }
-						disabled={ ! this.props.initialized }
+						disabled={ ! initialized }
 					/>
-					<span>{ this.props.translate( 'On for all posts', { context: 'Sharing options: Comment Likes' } ) }</span>
+					<span>{ translate( 'On for all posts', { context: 'Sharing options: Comment Likes' } ) }</span>
 				</label>
 			</fieldset>
 		);
 	}
 
 	render() {
+		const { initialized, saving, translate, values } = this.props;
 		const changeSharingPostTypes = partial( this.handleMultiCheckboxChange, 'sharing_show' );
 
 		return (
 			<div className="sharing-buttons__panel">
-				<h4>{ this.props.translate( 'Options' ) }</h4>
+				<h4>{ translate( 'Options' ) }</h4>
 				<div className="sharing-buttons__fieldset-group">
 					<fieldset className="sharing-buttons__fieldset">
 						<legend className="sharing-buttons__fieldset-heading">
-							{ this.props.translate( 'Show sharing buttons on', {
+							{ translate( 'Show sharing buttons on', {
 								context: 'Sharing options: Header',
 								comment: 'Possible values are: "Front page, Archive Pages, and Search Results", "Posts", "Pages", "Media"'
 							} ) }
@@ -180,9 +185,9 @@ class SharingButtonsOptions extends Component {
 						<MultiCheckbox
 							name="sharing_show"
 							options={ this.getDisplayOptions() }
-							checked={ this.props.values.sharing_show }
+							checked={ values.sharing_show }
 							onChange={ changeSharingPostTypes }
-							disabled={ ! this.props.initialized }
+							disabled={ ! initialized }
 						/>
 					</fieldset>
 					{ this.getCommentLikesOptionElement() }
@@ -192,9 +197,9 @@ class SharingButtonsOptions extends Component {
 				<button
 					type="submit"
 					className="button is-primary sharing-buttons__submit"
-					disabled={ this.props.saving || ! this.props.initialized }
+					disabled={ saving || ! initialized }
 				>
-					{ this.props.saving ? this.props.translate( 'Saving…' ) : this.props.translate( 'Save Changes' ) }
+					{ saving ? translate( 'Saving…' ) : translate( 'Save Changes' ) }
 				</button>
 			</div>
 		);


### PR DESCRIPTION
follow-up to #10278
part of #8726

In this PR, I'm dropping the usage of the Jetpack.Site.prototype object from the `SharingButtonsOptions` and I rely on Redux selectors instead.
Also, I applied some of our latest coding styles to this component:
 - React Class
 - localize HoC
 - imports 

**Testing instructions**
 * Open the /sharing/buttons/$site
 * Try to edit and save the options of the sharing buttons (the second Card)
 * Try for Jetpack websites as well