### PR TITLE
Add translation for package name at sidebar as noted by #10187

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -366,7 +366,7 @@ export class MySitesSidebar extends Component {
 			linkClass += ' is-paid-plan';
 		}
 
-		let planName = site.plan.product_name_short;
+		let planName = this.props.translate( site.plan.product_name_short );
 
 		if ( productsValues.isFreeTrial( site.plan ) ) {
 			planName = this.props.translate( 'Trial', {


### PR DESCRIPTION
Plans: translate name for "Free" plan in sidebar menu context as in issue #10187 

Just a simple commit while I get used to the whole environment