### PR TITLE
Jetpack Connect: Preserve calypso_env when redirecting for remote auth

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -687,7 +687,7 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 		}
 
 		if ( queryObject && queryObject.already_authorized && ! this.props.isAlreadyOnSitesList ) {
-			this.renderMainForm();
+			this.renderForm();
 		}
 
 		if ( this.props.plansFirst && ! this.props.selectedPlan ) {

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -50,7 +50,7 @@ import { JPC_PLANS_PAGE } from './constants';
 const _fetching = {};
 const calypsoEnv = config( 'env_id' ) || process.env.NODE_ENV;
 const apiBaseUrl = 'https://jetpack.wordpress.com';
-const remoteAuthPath = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true';
+const remoteAuthPath = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&calypso_env=' + calypsoEnv;
 const remoteInstallPath = '/wp-admin/plugin-install.php?tab=plugin-information&plugin=jetpack';
 const remoteActivatePath = '/wp-admin/plugins.php';
 const tracksEvent = ( dispatch, eventName, props ) => {


### PR DESCRIPTION
This PR suggests preserving the `calypso_env` when redirecting to Jetpack remote auth. It also fixes a call to unexisting `this.renderMainForm()`.