### PR TITLE
Avoid showing "registered by other user" when it's not true (AKA: bad calypso, stop lying to our users)

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -687,7 +687,7 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 		}
 
 		if ( queryObject && queryObject.already_authorized && ! this.props.isAlreadyOnSitesList ) {
-			this.renderMainForm();
+			this.renderForm();
 		}
 
 		if ( this.props.plansFirst && ! this.props.selectedPlan ) {

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -19,6 +19,7 @@ import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import SignupForm from 'components/signup-form';
 import WpcomLoginForm from 'signup/wpcom-login-form';
 import config from 'config';
+import QuerySites from 'components/data/query-sites';
 import {
 	createAccount,
 	authorize,
@@ -95,6 +96,7 @@ const SiteCard = React.createClass( {
 
 		return (
 			<CompactCard className="jetpack-connect__site">
+				<QuerySites allSites />
 				<Site site={ site } />
 			</CompactCard>
 		);
@@ -246,6 +248,8 @@ const LoggedInForm = React.createClass( {
 			this.props.authorize( queryObject );
 		} else if ( siteReceived && ! isActivating ) {
 			this.activateManageAndRedirect();
+		} else if ( this.props.isAlreadyOnSitesList && queryObject.already_authorized && ! isActivating ) {
+			this.activateManageAndRedirect();
 		}
 		if (
 			authorizeError &&
@@ -305,9 +309,16 @@ const LoggedInForm = React.createClass( {
 		} = this.props.jetpackConnectAuthorize;
 
 		if ( ! this.props.isAlreadyOnSitesList &&
+			! this.props.isFetchingSites(),
 			queryObject.already_authorized ) {
 			return this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
 		}
+
+		if ( this.props.isAlreadyOnSitesList &&
+			queryObject.already_authorized ) {
+			return this.activateManageAndRedirect();
+		}
+
 		if ( activateManageSecret && ! manageActivated ) {
 			return this.activateManageAndRedirect();
 		}
@@ -315,7 +326,7 @@ const LoggedInForm = React.createClass( {
 			return this.handleResolve();
 		}
 		if ( this.props.isAlreadyOnSitesList ) {
-			return this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
+			return this.activateManageAndRedirect();
 		}
 
 		return this.props.authorize( queryObject );
@@ -394,7 +405,7 @@ const LoggedInForm = React.createClass( {
 
 	renderNotices() {
 		const { authorizeError, queryObject, isAuthorizing, authorizeSuccess } = this.props.jetpackConnectAuthorize;
-		if ( queryObject.already_authorized && ! this.props.isAlreadyOnSitesList ) {
+		if ( queryObject.already_authorized && ! this.props.isFetchingSites() && ! this.props.isAlreadyOnSitesList ) {
 			return <JetpackConnectNotices noticeType="alreadyConnectedByOtherUser" />;
 		}
 
@@ -437,6 +448,7 @@ const LoggedInForm = React.createClass( {
 		} = this.props.jetpackConnectAuthorize;
 
 		if ( ! this.props.isAlreadyOnSitesList &&
+			! this.props.isFetchingSites() &&
 			queryObject.already_authorized ) {
 			return this.translate( 'Go back to your site' );
 		}
@@ -730,7 +742,7 @@ export default connect(
 			requestHasXmlrpcError,
 			requestHasExpiredSecretError,
 			calypsoStartedConnection: isCalypsoStartedConnection( state, remoteSiteUrl ),
-			authAttempts: getAuthAttempts( state, siteSlug )
+			authAttempts: getAuthAttempts( state, siteSlug ),
 		};
 	},
 	dispatch => bindActionCreators( {

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -50,7 +50,7 @@ import { JPC_PLANS_PAGE } from './constants';
 const _fetching = {};
 const calypsoEnv = config( 'env_id' ) || process.env.NODE_ENV;
 const apiBaseUrl = 'https://jetpack.wordpress.com';
-const remoteAuthPath = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true';
+const remoteAuthPath = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&calypso_env=' + calypsoEnv;
 const remoteInstallPath = '/wp-admin/plugin-install.php?tab=plugin-information&plugin=jetpack';
 const remoteActivatePath = '/wp-admin/plugins.php';
 const tracksEvent = ( dispatch, eventName, props ) => {


### PR DESCRIPTION
Ok, this is tricky... When a user tries to connect a self-hosted site using a (self-hosted) user that already is connected to a (different) wp.com account, we are showing this warning: 

![pasted image at 2016_12_28 17_25](https://cloud.githubusercontent.com/assets/1554855/21526909/d7a28974-cd27-11e6-90ef-3a08b5a5bea1.png)

Which is the expected behavior. The problem comes when, fulfilling a specific set of conditions, we are showing this warning even if the user is the one who has the site already connected to their account. This was happening because if the user has just logged it, we loading the sites list into the redux subtree in the authorization component.

How to test:
======
1. Be sure to have a self-hosted site connected to your wp.com account
2. Log in to your self-hosted site wp-admin
3. Log out of your wp.com account
4. Go to https://calypso.live/jetpack/connect/vaultpress?branch=fix/jetpack_plans_Redirection and pick a plan
5. When asked, log into your wp.com account
6. You should see a spinner and after some seconds you should be redirected to the checkout with the plan you selected in 4 already in the cart

