### PR TITLE
Editor: Fix date issues in EditPostStatus

### DIFF
--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -36,7 +36,8 @@ class EditPostStatus extends Component {
 		savedPost: PropTypes.object,
 		site: PropTypes.object,
 		translate: PropTypes.func,
-		type: PropTypes.string
+		type: PropTypes.string,
+		postDate: PropTypes.string,
 	};
 
 	constructor( props ) {
@@ -113,7 +114,7 @@ class EditPostStatus extends Component {
 			this.props.site.options.admin_url;
 
 		const fullDate = postScheduleUtils.convertDateToUserLocation(
-			( postUtils.getEditedTime( this.props.post ) || new Date() ),
+			( this.props.postDate || new Date() ),
 			siteUtils.timezone( this.props.site ),
 			siteUtils.gmtOffset( this.props.site )
 		).format( 'll LT' );
@@ -188,8 +189,8 @@ class EditPostStatus extends Component {
 	renderPostSchedulePopover() {
 		const tz = siteUtils.timezone( this.props.site ),
 			gmt = siteUtils.gmtOffset( this.props.site ),
-			selectedDay = this.props.post && this.props.post.date
-				? this.props.moment( this.props.post.date )
+			selectedDay = this.props.postDate
+				? this.props.moment( this.props.postDate )
 				: null;
 
 		return (

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -312,6 +312,9 @@ export default React.createClass( {
 	},
 
 	render: function() {
+		const postDate = this.props.post && this.props.post.date
+				? this.props.post.date
+				: null;
 		return (
 			<Card className="editor-ground-control">
 				<Site
@@ -347,6 +350,7 @@ export default React.createClass( {
 					this.state.showAdvanceStatus &&
 						<EditPostStatus
 							savedPost={ this.props.savedPost }
+							postDate={ postDate }
 							type={ this.props.type }
 							onSave={ this.props.onSave }
 							onTrashingPost={ this.props.onTrashingPost }

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -312,6 +312,7 @@ export default React.createClass( {
 	},
 
 	render: function() {
+		// TODO: REDUX - remove this logic and prop for EditPostStatus when date is moved to redux
 		const postDate = this.props.post && this.props.post.date
 				? this.props.post.date
 				: null;


### PR DESCRIPTION
This branch seeks to fix an issue with the `<EditPostStatus />` component that currently prevents the date picker from working ( fixes #10297 ).  I spent some time trying to figure out _when_ this stopped working, but wasn't able to find the exact point in time yet, I think it maybe related to #8539.

Turns out the instance of the `PostSchedule` inside `EditPostStatus` was using `this.props.post.date` as the value to display within the post scheduler.  The problem is that `this.props.post` for the component is being populated by edits in the redux state tree [[#](https://github.com/Automattic/wp-calypso/blob/master/client/post-editor/edit-post-status/index.jsx#L253)], whereas the action for modifying the post's date is being tracked in the flux `post-edit-store` [[#](https://github.com/Automattic/wp-calypso/blob/master/client/post-editor/editor-ground-control/index.jsx#L127)].

The same issue is also affecting the date display inside of `EditPostStatus` - since it too currently is using the date from the redux edits object:

![new_post_ _testingtimmy2_wordpress_com_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/21531316/d4a0d04a-ccfb-11e6-8951-315ae4616299.png)

I took a shortcut to fix the bug in this branch by passing in the `post.date` as a prop to `EditPostStatus`, but in a follow-up PR I'd like to make `EditorGroundControl` a `connect`ed component, and move the date tracking into the redux state.  There is much logic around the editor that keys off of the date to change verbiage/iconography for scheduled posts though, so that will be a bit of an involved PR.

Worth noting, using the post scheduler instance to the right of the Publish button works fine - this is perhaps why the issue has gone unnoticed:

![new_post_ _testingtimmy2_wordpress_com_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/21531352/386adec2-ccfc-11e6-8dae-cfb80c16ce30.png)

__To Test__
- Open a new post in the editor
- In the sidebar, click the cog icon to expand the `EditPostStatus` component
- Click on the date label to expose the `PostSchedule` popover
- Select a date other than today, verify the date is highlighted on the calendar, and the date label changes
- Additionally launch the `PostSchedule` via the button next to the Publish button, verify the same steps work as expected.

Worth noting there is still some logic that toggles the "Future" label vs clock gridicon that is based upon the `this.props.savedPost`.  So that will not update until you save the post which I found a bit confusing too.

