### PR TITLE
Add a button to easily add Site Redirect from Domain Management

### DIFF
--- a/client/components/button-group/index.jsx
+++ b/client/components/button-group/index.jsx
@@ -12,7 +12,7 @@ export default React.createClass( {
 		children( props ) {
 			let error = null;
 			React.Children.forEach( props.children, ( child ) => {
-				if ( ! child.props || child.props.type !== 'button' ) {
+				if ( child && ( ! child.props || child.props.type !== 'button' ) ) {
 					error = new Error( 'All children elements should be a Button.' );
 				}
 			} );

--- a/client/lib/mixins/analytics/index.js
+++ b/client/lib/mixins/analytics/index.js
@@ -670,6 +670,14 @@ const EVENTS = {
 
 				analytics.tracks.recordEvent( 'calypso_domain_management_list_add_domain_click' );
 			},
+			addRedirectClick() {
+				analytics.ga.recordEvent(
+					'Domain Management',
+					'Clicked "Add Redirect" Button in List'
+				);
+
+				analytics.tracks.recordEvent( 'calypso_domain_management_list_add_redirect_click' );
+			},
 			enablePrimaryDomainMode() {
 				analytics.ga.recordEvent(
 					'Domain Management',

--- a/client/my-sites/upgrades/domain-management/list/index.jsx
+++ b/client/my-sites/upgrades/domain-management/list/index.jsx
@@ -3,8 +3,7 @@
  */
 import page from 'page';
 import React from 'react';
-import times from 'lodash/times';
-import findIndex from 'lodash/findIndex';
+import { times, findIndex, some } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -19,6 +18,7 @@ import Main from 'components/main';
 import paths from 'my-sites/upgrades/paths';
 import SectionHeader from 'components/section-header';
 import Button from 'components/button';
+import ButtonGroup from 'components/button-group';
 import UpgradesNavigation from 'my-sites/upgrades/navigation';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import Gridicon from 'components/gridicon';
@@ -37,6 +37,7 @@ import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { isPlanFeaturesEnabled } from 'lib/plans';
 import DomainToPlanNudge from 'blocks/domain-to-plan-nudge';
+import { type as domainTypes } from 'lib/domains/constants';
 
 export const List = React.createClass( {
 	mixins: [ analyticsMixin( 'domainManagement', 'list' ) ],
@@ -179,6 +180,11 @@ export const List = React.createClass( {
 		this.recordEvent( 'changePrimary', this.props.domains.list[ previousDomainIndex ] );
 	},
 
+	clickAddRedirect() {
+		this.recordEvent( 'addRedirectClick' );
+		page( `/domains/add/site-redirect/${ this.props.selectedSite.slug }` );
+	},
+
 	clickAddDomain() {
 		this.recordEvent( 'addDomainClick' );
 		page( `/domains/add/${ this.props.selectedSite.slug }` );
@@ -215,7 +221,10 @@ export const List = React.createClass( {
 		}
 		return (
 			<div>
-				{ this.changePrimaryButton() }
+				<ButtonGroup>
+					{ this.changePrimaryButton() }
+					{ this.addRedirectButton() }
+				</ButtonGroup>
 				{ this.addDomainButton() }
 			</div>
 		);
@@ -232,6 +241,21 @@ export const List = React.createClass( {
 				className="domain-management-list__change-primary-button"
 				onClick={ this.enableChangePrimaryDomainMode }>
 				{ this.translate( 'Change Primary', { context: 'Button label for changing primary domain' } ) }
+			</Button>
+		);
+	},
+
+	addRedirectButton() {
+		const isRedirect = ( domain ) => domain.type === domainTypes.SITE_REDIRECT;
+		if ( ! this.props.domains.hasLoadedFromServer || some( this.props.domains.list, isRedirect ) ) {
+			return null;
+		}
+
+		return (
+			<Button
+				compact
+				onClick={ this.clickAddRedirect }>
+				{ this.translate( 'Add Redirect' ) }
 			</Button>
 		);
 	},

--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -76,6 +76,10 @@
 	margin-bottom: 0;
 }
 
+.domain-management-list__add-a-domain {
+	margin-left: 8px;
+}
+
 .domain-management-list-item {
 	&.busy {
 		background-color: $gray-light;


### PR DESCRIPTION
As discussed in https://github.com/Automattic/wp-calypso/issues/9517, the Site Redirect upgrade is well hidden - it could be only found through an obscure and hard to spot link in Site's Settings or through a direct link (usually from our support pages).
This PR adds it more prominently in Domain Management list:

<img width="964" alt="screen shot 2016-12-28 at 21 54 30" src="https://cloud.githubusercontent.com/assets/3392497/21531796/11345758-cd4b-11e6-811c-2a5d62df4f0f.png">

I've opted to group the `Change Primary` and `Add Redirect` buttons together to make it seem like there are only two buttons in the header. Also, while it might seem more obvious to group the `Add Redirect` button with the `Add Domain`, I want `Add Domain` to be unequivocally the primary action. Grouping it with another button would lessen its impact and could lead to more missed clicks, etc.

Additionally, when the site _has_ a redirect already, I'm hiding the button:
<img width="962" alt="screen shot 2016-12-28 at 21 55 19" src="https://cloud.githubusercontent.com/assets/3392497/21531805/1fb9cd8a-cd4b-11e6-84ac-e30c5613f728.png">
