### PR TITLE
Add setting to toggle enabling API Cache for Jetpack sites

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -68,7 +68,9 @@ class SiteSettingsFormGeneral extends Component {
 			amp_is_supported: settings.amp_is_supported,
 			amp_is_enabled: settings.amp_is_enabled,
 
-			holidaysnow: !! settings.holidaysnow
+			holidaysnow: !! settings.holidaysnow,
+
+			api_cache: settings.api_cache,
 		};
 
 		if ( settings.jetpack_relatedposts_allowed ) {
@@ -112,6 +114,7 @@ class SiteSettingsFormGeneral extends Component {
 			holidaysnow: false,
 			amp_is_supported: false,
 			amp_is_enabled: false,
+			api_cache: false,
 		} );
 		this.props.replaceFields( this.getFormSettings( this.props.settings ) );
 	}
@@ -655,12 +658,12 @@ class SiteSettingsFormGeneral extends Component {
 
 	renderApiCache() {
 		// Note that years and months below are zero indexed
-		const { fields, site, translate, isRequestingSettings } = this.props;
+		const { fields, translate, isRequestingSettings } = this.props;
 			// today = moment(),
 			// startDate = moment( { year: today.year(), month: 11, day: 1 } ),
 			// endDate = moment( { year: today.year(), month: 0, day: 4 } );
 
-		if ( ! site.jetpack || site.versionCompare( '4.2-alpha', '<' ) ) {
+		if ( ! this.showApiCacheCheckbox() ) {
 			return null;
 		}
 
@@ -679,6 +682,19 @@ class SiteSettingsFormGeneral extends Component {
 				</FormToggle>
 			</CompactCard>
 		);
+	}
+
+	showApiCacheCheckbox() {
+		if ( ! config.isEnabled( 'jetpack/sync-panel' ) ) {
+			return false;
+		}
+
+		const { site } = this.props;
+		if ( ! site.jetpack || site.versionCompare( '4.2-alpha', '<' ) ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	render() {
@@ -786,7 +802,7 @@ class SiteSettingsFormGeneral extends Component {
 					? <div>
 						<SectionHeader label={ translate( 'Jetpack' ) }>
 							{ this.jetpackDisconnectOption() }
-							{ this.showPublicPostTypesCheckbox()
+							{ this.showPublicPostTypesCheckbox() || this.showApiCacheCheckbox()
 								? <Button
 									compact={ true }
 									onClick={ this.handleSubmitForm }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -653,6 +653,34 @@ class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
+	renderApiCache() {
+		// Note that years and months below are zero indexed
+		const { fields, site, translate, isRequestingSettings } = this.props;
+			// today = moment(),
+			// startDate = moment( { year: today.year(), month: 11, day: 1 } ),
+			// endDate = moment( { year: today.year(), month: 0, day: 4 } );
+
+		if ( ! site.jetpack || site.versionCompare( '4.2-alpha', '<' ) ) {
+			return null;
+		}
+
+		return (
+			<CompactCard>
+				<FormToggle
+					className="is-compact"
+					checked={ !! fields.api_cache }
+					disabled={ isRequestingSettings }
+					onChange={ this.handleToggle( 'api_cache' ) }>
+					<span className="site-settings__toggle-label">
+						{ translate(
+							'Use synchronized data to boost performance'
+						) }
+					</span>
+				</FormToggle>
+			</CompactCard>
+		);
+	}
+
 	render() {
 		const { isRequestingSettings, isSavingSettings, site, translate } = this.props;
 		if ( site.jetpack && ! site.hasMinimumJetpackVersion ) {
@@ -775,6 +803,7 @@ class SiteSettingsFormGeneral extends Component {
 						</SectionHeader>
 
 						{ this.renderJetpackSyncPanel() }
+						{ this.renderApiCache() }
 						{ this.syncNonPublicPostTypes() }
 
 						<CompactCard href={ '../security/' + site.slug }>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -657,11 +657,7 @@ class SiteSettingsFormGeneral extends Component {
 	}
 
 	renderApiCache() {
-		// Note that years and months below are zero indexed
 		const { fields, translate, isRequestingSettings } = this.props;
-			// today = moment(),
-			// startDate = moment( { year: today.year(), month: 11, day: 1 } ),
-			// endDate = moment( { year: today.year(), month: 0, day: 4 } );
 
 		if ( ! this.showApiCacheCheckbox() ) {
 			return null;
@@ -685,7 +681,7 @@ class SiteSettingsFormGeneral extends Component {
 	}
 
 	showApiCacheCheckbox() {
-		if ( ! config.isEnabled( 'jetpack/sync-panel' ) ) {
+		if ( ! config.isEnabled( 'jetpack/api-cache' ) ) {
 			return false;
 		}
 

--- a/config/development.json
+++ b/config/development.json
@@ -55,6 +55,7 @@
 		"jetpack/sso": true,
 		"jetpack_core_inline_update": true,
 		"jetpack/sync-panel": true,
+		"jetpack/api-cache": true,
 		"keyboard-shortcuts": true,
 		"happychat": true,
 		"mailing-lists/unsubscribe": true,

--- a/config/production.json
+++ b/config/production.json
@@ -27,6 +27,7 @@
 		"jetpack/seo-tools": true,
 		"jetpack/sso": true,
 		"jetpack/sync-panel": true,
+		"jetpack/api-cache": false,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,
 		"manage/ads": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -30,6 +30,7 @@
 		"jetpack/seo-tools": true,
 		"jetpack/sso": true,
 		"jetpack/sync-panel": true,
+		"jetpack/api-cache": false,
 		"jetpack_core_inline_update": true,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -38,6 +38,7 @@
 		"jetpack/seo-tools": true,
 		"jetpack/sso": true,
 		"jetpack/sync-panel": true,
+		"jetpack/api-cache": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
 		"mailing-lists/unsubscribe": true,


### PR DESCRIPTION
This enables the experimental API Cache feature for Jetpack 4.5

See: https://github.com/Automattic/jetpack/pull/6004