### PR TITLE
Reader: Attempt at fixing width detection for images

### DIFF
--- a/client/lib/post-normalizer/rule-content-detect-media.js
+++ b/client/lib/post-normalizer/rule-content-detect-media.js
@@ -7,7 +7,8 @@ import getEmbedMetadata from 'get-video-id';
 /**
  * Internal Dependencies
  */
-import { iframeIsWhitelisted } from './utils';
+import { iframeIsWhitelisted, maxWidthPhotonishURL } from './utils';
+import { READER_CONTENT_WIDTH } from 'state/reader/posts/normalization-rules';
 
 /** Checks whether or not an image is a tracking pixel
 * @param {Node} image - DOM node for an img
@@ -52,7 +53,7 @@ function isCandidateForContentImage( image ) {
 const detectImage = ( image ) => {
 	if ( isCandidateForContentImage( image ) ) {
 		return {
-			src: image.getAttribute( 'src' ),
+			src: maxWidthPhotonishURL( image.getAttribute( 'src' ), READER_CONTENT_WIDTH ),
 			width: image.width,
 			height: image.height,
 			mediaType: 'image',
@@ -146,6 +147,12 @@ export default function detectMedia( post, dom ) {
 	post.content_media = compact( contentMedia );
 	post.content_embeds = filter( post.content_media, m => m.mediaType === 'video' );
 	post.content_images = filter( post.content_media, m => m.mediaType === 'image' );
+
+	// TODO: figure out a more sane way of combining featured_image + content media
+	// so that changes to logic don't need to exist in multiple places
+	if ( post.featured_image ) {
+		post.featured_image = maxWidthPhotonishURL( post.featured_image, READER_CONTENT_WIDTH );
+	}
 
 	return post;
 }

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -35,7 +35,7 @@ import removeElementsBySelector from 'lib/post-normalizer/rule-content-remove-el
 /**
  * Module vars
  */
-const
+export const
 	READER_CONTENT_WIDTH = 720,
 	DISCOVER_FULL_BLEED_WIDTH = 1082,
 	PHOTO_ONLY_MIN_WIDTH = 480,


### PR DESCRIPTION
We have a difficult problem in the reader where we generally have photon or wp images.  These images can have query params that specify changes to the width/height/fit/crop/etc.   This has led us to accidentally [squishing](https://github.com/Automattic/wp-calypso/pull/10096) images sometimes, and other times [discounting](https://github.com/Automattic/wp-calypso/issues/10189) them for potentially beautiful layouts that they deserve because we mistakenly think the image is too small.  We haven't yet quite figured out what to do with our photonish urls for all of our use-cases.

My first thought was: what if we always remove all query params?
I tried that and it ended up not working out in full-post views, especially galleries (squish problem).
In yet other areas of full-post it removed potential crops that the user wanted.

I believe the best way to handle the issue is to treat both FullPost view and Streams separately because they have different needs. 
-  FullPost view should ideally be as close to what the author intended as possible.  If the plugins/themes activated make images look specific ways, we should retain it.
- Streams in a sense is where Reader says takes a post and says: _this is the best way to display it_.  We should strip photon params (or use a max-width if we want to optimize).  The drawback is that we are potentially ignoring a users crop.  I think that the _vast_ majority of the time a photon image has query params its automatically done by a theme + ignoring it is in everybody's best interest. 

To Test:
- make sure this isn't squished: https://calypso.live/read/feeds/42873943/posts/1262017714?branch=try/reader/remove-photon-params
- make sure this issue is solved https://github.com/Automattic/wp-calypso/issues/10189  https://calypso.live/read/blogs/24969815?branch=try/reader/remove-photon-params
- make sure the canonical image chosen is the same as the one on wp