### PR TITLE
Phone Input: Improvements

### DIFF
--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -42,7 +42,8 @@ var FormFields = React.createClass( {
 		return {
 			checkedRadio: 'first',
 			toggled: false,
-			compactToggled: false
+			compactToggled: false,
+			phoneInput: { countryCode: 'us', value: '' }
 		};
 	},
 
@@ -60,6 +61,10 @@ var FormFields = React.createClass( {
 
 	handleAction: function() {
 		alert( 'Thank you.' );
+	},
+
+	handlePhoneInputChange( data ) {
+		this.setState( { phoneInput: data } );
 	},
 
 	render: function() {
@@ -246,7 +251,7 @@ var FormFields = React.createClass( {
 
 					<FormFieldset>
 						<FormLabel>Form Media Phone Input</FormLabel>
-						<PhoneInput initialCountryCode="us" countriesList={ countriesList } />
+						<PhoneInput countryCode={ this.state.phoneInput.countryCode } value={ this.state.phoneInput.value } countriesList={ countriesList } onChange={ this.handlePhoneInputChange } />
 					</FormFieldset>
 
 					<FormFieldset>

--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -246,7 +246,7 @@ var FormFields = React.createClass( {
 
 					<FormFieldset>
 						<FormLabel>Form Media Phone Input</FormLabel>
-						<PhoneInput selectedCountryCode="us" countriesList={ countriesList } />
+						<PhoneInput initialCountryCode="us" countriesList={ countriesList } />
 					</FormFieldset>
 
 					<FormFieldset>

--- a/client/components/phone-input/data.js
+++ b/client/components/phone-input/data.js
@@ -13,12 +13,17 @@ module.exports = {
 				{
 					match: "(\\d{3})(\\d{3})",
 					replace: "$1 $2",
-					leadingDigitPattern: "[346-9]"
+					leadingDigitPattern: "[137-9]|6[0-8]"
 				},
 				{
-					match: "(180[02])(\\d{4})",
+					match: "(\\d{4})(\\d{4})",
 					replace: "$1 $2",
-					leadingDigitPattern: "1"
+					leadingDigitPattern: "180[02]"
+				},
+				{
+					match: "(\\d{3})(\\d{3})(\\d{3})",
+					replace: "$1 $2 $3",
+					leadingDigitPattern: "690"
 				}
 			]
 		},
@@ -122,7 +127,7 @@ module.exports = {
 					match: "(\\d{2})(\\d{6})",
 					replace: "$1 $2",
 					nationalFormat: "0$1",
-					leadingDigitPattern: "4[139]|[5-7]|9[1-9]"
+					leadingDigitPattern: "4[1349]|[5-7]|9[1-9]"
 				},
 				{
 					match: "(\\d{3})(\\d{5})",
@@ -2470,13 +2475,13 @@ module.exports = {
 					match: "(\\d{5})(\\d{5})",
 					replace: "$1 $2",
 					nationalFormat: "0$1",
-					leadingDigitPattern: "7(?:0|2(?:[0235679]|[14][017-9]|8(?:[0-569]|78)|9[389])|3(?:[05-8]|1(?:[089]|7[5-9])|2(?:[5-8]|[01][089])|3[017-9]|4(?:[07-9]|11)|9(?:[01689]|59|70))|4(?:0[1-9]|1(?:[015-9]|2[089]|4[08])|2(?:09|[1-7][089]|[89])|3(?:[0-8][089]|9)|4(?:[089]|11|7[02-8])|5(?:0[089]|[59]9)|7(?:0[3-9]|11|7[02-8]|[89])|8(?:[0-24-7][089]|[389])|9(?:[0-6][089]|7[08]|[89]))|5(?:[034678]|2[03-9]|5[017-9]|9[7-9])|6(?:0[0-47]|1[0-257-9]|2[0-4]|3[19]|5[4589]|[6-9])|7(?:0[2-9]|[1-79]|8[1-9])|8(?:[0-79]|88[01])|99[4-9])|8(?:0(?:[01589]|6[67])|1(?:[02-57-9]|1[0135-9])|2(?:[236-9]|5[1-9])|3(?:[0357-9]|4[1-9])|[45]|6[02457-9]|7(?:07|[1-69])|8(?:[0-26-9]|44|5[2-9])|9(?:[035-9]|2[2-9]|4[0-8]))|9"
+					leadingDigitPattern: "7(?:0|19[0-5]|2(?:[0235679]|[14][017-9]|8(?:[0-569]|78|8[089])|9[389])|3(?:[05-8]|1(?:[089]|7[5-9])|2(?:[5-8]|[0-49][089])|3[017-9]|4(?:[07-9]|11)|9(?:[01689]|[2345][089]|40|7[0189]))|4(?:[056]|1(?:[0135-9]|[23][089]|2[089]|4[089])|2(?:0[089]|[1-7][089]|[89])|3(?:[0-8][089]|9)|4(?:[089]|11|7[02-8])|7(?:[089]|11|7[02-8])|8(?:[0-24-7][089]|[389])|9(?:[0-7][089]|[89]))|5(?:[0346-9]|1[019]|2(?:[03-9]|[12][089])|5[017-9])|6(?:[06-9]|1[0-257-9]|2[0-5]|3[19]|5[4589])|7(?:0(?:[02-9]|10)|[1-9])|8(?:[0-79]|8(?:0[0189]|11|8[013-9]|9[012]))|9(?:0|7(?:[2-8]|9[7-9])|8[0246-9]|9(?:[04-9]|11|2[234])))|8(?:0(?:[01589]|6[67]|7(?:[2-7]|86|90))|1(?:[02-57-9]|1(?:[0135-9]|22|44)|6[089])|2(?:0[08]|[236-9]|5[1-9])|3(?:[0357-9]|170|28[0-6]|4[1-9])|[45]|6(?:[02457-9]|6(?:[08]|7[02-8]|9[01]))|7(?:0[07]|[1-69])|8(?:[0-26-9]|44|5[2-9])|9(?:[035-9]|19|2[2-9]|4[0-8]))|9"
 				},
 				{
 					match: "(\\d{2})(\\d{4})(\\d{4})",
 					replace: "$1 $2 $3",
 					nationalFormat: "0$1",
-					leadingDigitPattern: "11|2[02]|33|4[04]|79|80[2-46]"
+					leadingDigitPattern: "11|2[02]|33|4[04]|79[1-9]|80[2-46]"
 				},
 				{
 					match: "(\\d{3})(\\d{3})(\\d{4})",
@@ -2593,8 +2598,8 @@ module.exports = {
 					leadingDigitPattern: "[1-8]"
 				},
 				{
-					match: "(\\d{3})(\\d{3})(\\d{3,4})",
-					replace: "$1 $2 $3",
+					match: "(\\d{3})(\\d{3})",
+					replace: "$1 $2",
 					nationalFormat: "0$1",
 					leadingDigitPattern: "9"
 				},
@@ -2605,8 +2610,8 @@ module.exports = {
 					leadingDigitPattern: "9"
 				},
 				{
-					match: "(\\d{3})(\\d{3})",
-					replace: "$1 $2",
+					match: "(\\d{3})(\\d{3})(\\d{3,4})",
+					replace: "$1 $2 $3",
 					nationalFormat: "0$1",
 					leadingDigitPattern: "9"
 				}
@@ -3068,7 +3073,7 @@ module.exports = {
 					match: "(\\d{4})(\\d{4})",
 					replace: "$1-$2",
 					nationalFormat: "$1",
-					leadingDigitPattern: "1(?:5(?:44|66|77|88|99)|6(?:00|44|6[16]|70|88)|8(?:00|33|55|77|99))"
+					leadingDigitPattern: "1(?:5(?:22|44|66|77|88|99)|6(?:00|44|6[16]|70|88)|8(?:00|33|55|77|99))"
 				}
 			],
 			internationalPatterns: [
@@ -3130,7 +3135,7 @@ module.exports = {
 					match: "(\\d{4})(\\d{4})",
 					replace: "$1-$2",
 					nationalFormat: "$1",
-					leadingDigitPattern: "1(?:5(?:44|66|77|88|99)|6(?:00|44|6[16]|70|88)|8(?:00|33|55|77|99))"
+					leadingDigitPattern: "1(?:5(?:22|44|66|77|88|99)|6(?:00|44|6[16]|70|88)|8(?:00|33|55|77|99))"
 				}
 			]
 		},
@@ -3436,7 +3441,7 @@ module.exports = {
 					match: "(\\d{2})(\\d{2})(\\d{2})(\\d{2})",
 					replace: "$1 $2 $3 $4",
 					nationalFormat: "$1",
-					leadingDigitPattern: "9"
+					leadingDigitPattern: "[39]"
 				},
 				{
 					match: "(\\d{2})(\\d{3})(\\d{3})",
@@ -3758,7 +3763,7 @@ module.exports = {
 				{
 					match: "(\\d{3})(\\d{3})(\\d{4})",
 					replace: "$1 $2 $3",
-					leadingDigitPattern: "900"
+					leadingDigitPattern: "[89]00"
 				}
 			]
 		},
@@ -3986,16 +3991,16 @@ module.exports = {
 					leadingDigitPattern: "[12]|9(?:0[3-9]|[1-9])"
 				},
 				{
-					match: "(\\d{3})(\\d{3})(\\d{3,4})",
-					replace: "$1 $2 $3",
-					nationalFormat: "0$1",
-					leadingDigitPattern: "70|8[01]|90[2357-9]"
-				},
-				{
 					match: "(\\d{2})(\\d{3})(\\d{2,3})",
 					replace: "$1 $2 $3",
 					nationalFormat: "0$1",
 					leadingDigitPattern: "[3-6]|7(?:[1-79]|0[1-9])|8[2-9]"
+				},
+				{
+					match: "(\\d{3})(\\d{3})(\\d{3,4})",
+					replace: "$1 $2 $3",
+					nationalFormat: "0$1",
+					leadingDigitPattern: "70|8[01]|90[2357-9]"
 				},
 				{
 					match: "([78]00)(\\d{4})(\\d{4,5})",
@@ -5420,10 +5425,22 @@ module.exports = {
 			nationalPrefix: "0",
 			patterns: [
 				{
+					match: "(20)(\\d)(\\d{4})",
+					replace: "$1 $2 $3",
+					nationalFormat: "0$1",
+					leadingDigitPattern: "202"
+				},
+				{
+					match: "(20)(\\d{3})(\\d{4})",
+					replace: "$1 $2 $3",
+					nationalFormat: "0$1",
+					leadingDigitPattern: "20[013-9]"
+				},
+				{
 					match: "([2-8])(\\d{3,4})(\\d{4})",
 					replace: "$1 $2 $3",
 					nationalFormat: "0$1",
-					leadingDigitPattern: "[2-6]|[78][1-9]"
+					leadingDigitPattern: "2[23-8]|[3-6]|[78][1-9]"
 				},
 				{
 					match: "([89]\\d{2})(\\d{3})(\\d{3})",
@@ -5848,6 +5865,74 @@ module.exports = {
 					leadingDigitPattern: "80"
 				}
 			]
+		},
+		uk: {
+			isoCode: "gb",
+			dialCode: "44",
+			nationalPrefix: "0",
+			patterns: [
+				{
+					match: "(\\d{2})(\\d{4})(\\d{4})",
+					replace: "$1 $2 $3",
+					nationalFormat: "0$1",
+					leadingDigitPattern: "2|5[56]|7(?:0|6(?:[013-9]|2[0-35-9]))"
+				},
+				{
+					match: "(\\d{3})(\\d{3})(\\d{4})",
+					replace: "$1 $2 $3",
+					nationalFormat: "0$1",
+					leadingDigitPattern: "1(?:1|\\d1)|3|9[018]"
+				},
+				{
+					match: "(\\d{5})(\\d{4,5})",
+					replace: "$1 $2",
+					nationalFormat: "0$1",
+					leadingDigitPattern: "1(?:3873|5(?:242|39[456])|697[347]|768[347]|9467)"
+				},
+				{
+					match: "(1\\d{3})(\\d{5,6})",
+					replace: "$1 $2",
+					nationalFormat: "0$1",
+					leadingDigitPattern: "1"
+				},
+				{
+					match: "(7\\d{3})(\\d{6})",
+					replace: "$1 $2",
+					nationalFormat: "0$1",
+					leadingDigitPattern: "7(?:[1-5789]|624)"
+				},
+				{
+					match: "(800)(\\d{4})",
+					replace: "$1 $2",
+					nationalFormat: "0$1",
+					leadingDigitPattern: "8001111"
+				},
+				{
+					match: "(845)(46)(4\\d)",
+					replace: "$1 $2 $3",
+					nationalFormat: "0$1",
+					leadingDigitPattern: "845464"
+				},
+				{
+					match: "(8\\d{2})(\\d{3})(\\d{4})",
+					replace: "$1 $2 $3",
+					nationalFormat: "0$1",
+					leadingDigitPattern: "8(?:4[2-5]|7[0-3])"
+				},
+				{
+					match: "(80\\d)(\\d{3})(\\d{4})",
+					replace: "$1 $2 $3",
+					nationalFormat: "0$1",
+					leadingDigitPattern: "80"
+				},
+				{
+					match: "([58]00)(\\d{6})",
+					replace: "$1 $2",
+					nationalFormat: "0$1",
+					leadingDigitPattern: "[58]00"
+				}
+			],
+			priority: 10
 		}
 	},
 	dialCodeMap: {

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import noop from 'lodash/noop';
 import find from 'lodash/find';
+import identity from 'lodash/identity';
 import includes from 'lodash/includes';
 import React from 'react';
 import classnames from 'classnames';
@@ -17,106 +17,20 @@ import { countries } from './data';
 
 const PhoneInput = React.createClass( {
 	propTypes: {
-		onChange: React.PropTypes.func,
-		value: React.PropTypes.string,
-		initialCountryCode: React.PropTypes.string,
+		onChange: React.PropTypes.func.isRequired,
+		value: React.PropTypes.string.isRequired,
+		countryCode: React.PropTypes.string.isRequired,
 		countriesList: React.PropTypes.object.isRequired
 	},
 
-	getDefaultProps() {
-		return {
-			value: '',
-			onChange: noop,
-			initialCountryCode: 'us'
-		};
-	},
-
-	getInitialState() {
-		const selectedCountry = countries[ this.props.initialCountryCode ];
-		const formattedNumber = formatNumber( this.props.value, selectedCountry );
-		return {
-			selectedCountry,
-			formattedNumber,
-			queryString: '',
-			freezeSelection: false
-		};
-	},
-
-	componentWillReceiveProps( nextProps ) {
-		if ( this.props.value !== nextProps.value && nextProps.value ) {
-			this.setState( this.getFormattedNumberAndCountry( nextProps.value ) );
-		}
-	},
-
-	componentDidUpdate( prevProps, prevState ) {
-		if ( this.state.value && this.state.selectedCountry !== prevState.selectedCountry ) {
-			this.setState( {
-				formattedNumber: formatNumber( this.state.value, this.state.selectedCountry )
-			} );
-		}
-	},
-
-	getFormattedNumberAndCountry( value ) {
-		let formattedNumber = value,
-			selectedCountry = this.state.selectedCountry;
-
-		if ( value ) {
-			if ( includes( [ '+', '1' ], value[ 0 ] ) && ! this.state.freezeSelection ) {
-				selectedCountry = findCountryFromNumber( value ) || this.state.selectedCountry;
-			}
-
-			formattedNumber = formatNumber( value, selectedCountry );
-		}
-
-		return {
-			selectedCountry,
-			formattedNumber
-		};
-	},
-
-	handleInput( event ) {
-		const { value } = event.target;
-		if ( value === this.state.formattedNumber ) {
-			// nothing changed
-			return;
-		}
-
-		event.preventDefault();
-		const { formattedNumber, selectedCountry } = this.getFormattedNumberAndCountry( value );
-
-		let caretPosition = event.target.selectionStart;
-		const oldFormattedText = this.state.formattedNumber;
-		const diff = formattedNumber.length - oldFormattedText.length;
-
-		this.setState( {
-			value,
-			formattedNumber,
-			selectedCountry
-		}, () => {
-			if ( diff > 0 ) {
-				caretPosition = caretPosition - diff;
-			}
-
-			if ( caretPosition > 0 && oldFormattedText.length >= formattedNumber.length ) {
-				this.numberInput.setSelectionRange( caretPosition, caretPosition );
-			}
-		} );
-		this.props.onChange( event );
-	},
-
-	cursorToEnd() {
-		const pos = this.numberInput.value.length - 1;
-		this.numberInput.setSelectionRange( pos, pos );
-	},
-
-	setCountry( countryCode ) {
-		countryCode = countryCode.toLowerCase();
+	getCountry( countryCode = this.props.countryCode ) {
 		let selectedCountry = countries[ countryCode ];
-		// Special cases where the country is in a disputed region and not globally recognized.
-		// At this point this should only be used for: Canary islands, Kosovo, Netherlands Antilles
+
 		if ( ! selectedCountry ) {
 			const data = find( this.props.countriesList.get() || [],
 				country => country.code.toLowerCase() === countryCode );
+			// Special cases where the country is in a disputed region and not globally recognized.
+			// At this point this should only be used for: Canary islands, Kosovo, Netherlands Antilles
 			if ( data ) {
 				selectedCountry = {
 					isoCode: countryCode,
@@ -125,31 +39,93 @@ const PhoneInput = React.createClass( {
 				};
 			}
 		}
+		return selectedCountry;
+	},
 
-		this.setState( {
-			selectedCountry,
-			freezeSelection: true
-		} );
+	getInitialState() {
+		return {
+			freezeSelection: false
+		};
+	},
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.value !== nextProps.value && nextProps.value ) {
+			const country = this.guessCountryFromValue( nextProps.value );
+			if ( country && country.isoCode !== this.getCountry().isoCode ) {
+				this.props.onChange( { countryCode: country.isoCode, value: nextProps.value } );
+			}
+		}
+	},
+
+	componentWillUpdate( nextProps ) {
+		const currentFormat = this.format( this.props ),
+			currentCursorPoint = this.numberInput.selectionStart,
+			nextFormat = this.format( nextProps );
+
+		let newCursorPoint = currentCursorPoint;
+		this.numberInput.value = nextFormat;
+
+		const nonDigitCountOld = currentFormat
+			.substring( 0, currentCursorPoint )
+			.split( '' )
+			.map( char => /\D/.test( char ) )
+			.filter( identity ).length;
+
+		const nonDigitCountNew = nextFormat
+			.substring( 0, currentCursorPoint )
+			.split( '' )
+			.map( char => /\D/.test( char ) )
+			.filter( identity ).length;
+
+		if ( currentFormat !== nextFormat ) {
+			if ( currentCursorPoint >= currentFormat.length ) {
+				newCursorPoint = nextFormat.length;
+			} else {
+				newCursorPoint = currentCursorPoint + nonDigitCountNew - nonDigitCountOld;
+			}
+		}
+		this.numberInput.setSelectionRange( newCursorPoint, newCursorPoint );
+	},
+
+	guessCountryFromValue( value ) {
+		if ( value && includes( [ '+', '1' ], value[ 0 ] ) && ! this.state.freezeSelection ) {
+			return findCountryFromNumber( value ) || this.getCountry();
+		}
+
+		return this.getCountry();
+	},
+
+	format( { value, countryCode } = this.props ) {
+		return formatNumber( value, this.getCountry( countryCode ) );
+	},
+
+	handleInput( event ) {
+		const { value } = event.target;
+		if ( value === this.format() ) {
+			// nothing changed
+			return;
+		}
+
+		event.preventDefault();
+
+		const country = this.guessCountryFromValue( value );
+		this.props.onChange( { value, countryCode: country.isoCode } );
 	},
 
 	handleCountrySelection( event ) {
-		this.setCountry( event.target.value );
-	},
+		const countryCode = event.target.value.toLowerCase();
 
-	getCountry() {
-		return this.state.selectedCountry;
+		this.props.onChange( { countryCode, value: this.props.value } );
+		this.setState( { freezeSelection: true } );
 	},
 
 	render() {
 		return (
 			<div className={ classnames( this.props.className, 'phone-input' ) }>
 				<input
-					placeholder={ formatNumber(
-						( this.state.selectedCountry.nationalPrefix || '' ) + '9876543210', this.state.selectedCountry
-					) }
+					placeholder={ formatNumber( ( this.getCountry().nationalPrefix || '' ) + '9876543210', this.getCountry() ) }
 					onChange={ this.handleInput }
 					name={ this.props.name }
-					value={ this.state.formattedNumber }
 					ref={ c => this.numberInput = c }
 					type="tel" />
 				<div className="phone-input__select-container">
@@ -157,9 +133,9 @@ const PhoneInput = React.createClass( {
 						<FormCountrySelect
 							className="phone-input__country-select"
 							onChange={ this.handleCountrySelection }
-							value={ ( this.state.selectedCountry.isoCode || '' ).toUpperCase() }
+							value={ ( this.getCountry().isoCode || '' ).toUpperCase() }
 							countriesList={ this.props.countriesList } />
-						<CountryFlag countryCode={ this.state.selectedCountry.isoCode } />
+						<CountryFlag countryCode={ this.getCountry().isoCode } />
 					</div>
 				</div>
 			</div>

--- a/client/components/phone-input/phone-number.js
+++ b/client/components/phone-input/phone-number.js
@@ -197,7 +197,11 @@ function processNumber( inputNumber, numberRegion ) {
 export function formatNumber( inputNumber, country ) {
 	const digitCount = stripNonDigits( inputNumber ).length;
 	if ( digitCount < MIN_LENGTH_TO_FORMAT || digitCount < ( country.dialCode || '' ).length ) {
-		return inputNumber;
+		if ( inputNumber[ 0 ] === '+' ) {
+			return '+' + stripNonDigits( inputNumber.substr( 1 ) );
+		} else {
+			return stripNonDigits( inputNumber );
+		}
 	}
 
 	// Some countries don't have their own patterns, but share / follow another country's patterns. Here we switch the

--- a/client/components/phone-input/phone-number.js
+++ b/client/components/phone-input/phone-number.js
@@ -76,7 +76,7 @@ export const findPattern = ( inputNumber, patterns ) => (
 		if ( leadingDigitPattern && inputNumber.search( leadingDigitPattern ) !== 0 ) {
 			return false;
 		}
-		return new RegExp( '^(?:' + match + ')$' ).test( inputNumber )
+		return new RegExp( '^(?:' + match + ')$' ).test( inputNumber );
 	} )
 );
 
@@ -153,7 +153,7 @@ export function applyTemplate( phoneNumber, template, positionTracking = { pos: 
  * prefix. For everything else it will use the `nationalPrefix` for the given region.
  * @param {string} inputNumber - Unformatted number
  * @param {Object} numberRegion - The local/region for which we process the number
- * @returns {{nationalNumber: {string}, prefix: {string}}} - Phone is the national phone number and prefix is to be
+ * @returns {{nationalNumber: string, prefix: string}} - Phone is the national phone number and prefix is to be
  *   shown before the phone number
  */
 function processNumber( inputNumber, numberRegion ) {
@@ -161,7 +161,7 @@ function processNumber( inputNumber, numberRegion ) {
 	const nationalNumber = stripNonDigits( inputNumber )
 		.replace( new RegExp( '^(' + numberRegion.dialCode + ')?(' + numberRegion.nationalPrefix + ')?' ), '' );
 
-	debug( `National Number: ${nationalNumber} for ${inputNumber} in ${numberRegion.isoCode}` );
+	debug( `National Number: ${ nationalNumber } for ${ inputNumber } in ${ numberRegion.isoCode }` );
 
 	if ( inputNumber[ 0 ] === '+' ) {
 		prefix = '+' + numberRegion.dialCode + ' ';
@@ -199,9 +199,8 @@ export function formatNumber( inputNumber, country ) {
 	if ( digitCount < MIN_LENGTH_TO_FORMAT || digitCount < ( country.dialCode || '' ).length ) {
 		if ( inputNumber[ 0 ] === '+' ) {
 			return '+' + stripNonDigits( inputNumber.substr( 1 ) );
-		} else {
-			return stripNonDigits( inputNumber );
 		}
+		return stripNonDigits( inputNumber );
 	}
 
 	// Some countries don't have their own patterns, but share / follow another country's patterns. Here we switch the
@@ -212,19 +211,19 @@ export function formatNumber( inputNumber, country ) {
 
 	const { nationalNumber, prefix } = processNumber( inputNumber, country );
 
-	const patterns = includes( [ '+', '1' ] , inputNumber[ 0 ] ) && country.internationalPatterns || country.patterns || [];
+	const patterns = includes( [ '+', '1' ], inputNumber[ 0 ] ) && country.internationalPatterns || country.patterns || [];
 	const pattern = findPattern( nationalNumber, patterns );
 
 	if ( pattern ) {
-		debug( `Will replace "${nationalNumber}" with "${pattern.match}" and "${pattern.replace}" with prefix "${prefix}"` );
+		debug( `Will replace "${ nationalNumber }" with "${ pattern.match }" and "${ pattern.replace }" with prefix "${ prefix }"` );
 		return prefix + nationalNumber.replace( new RegExp( pattern.match ), pattern.replace );
 	}
 
-	debug( `Couldn't find a ${country.isoCode} pattern for ${inputNumber}` );
+	debug( `Couldn't find a ${ country.isoCode } pattern for ${ inputNumber }` );
 
 	const template = makeTemplate( nationalNumber, patterns );
 	if ( template ) {
-		debug( `Will replace "${nationalNumber}" with "${template}" with prefix "${prefix}"` );
+		debug( `Will replace "${ nationalNumber }" with "${ template }" with prefix "${ prefix }"` );
 		return prefix + applyTemplate( nationalNumber, template );
 	}
 	return inputNumber;

--- a/client/components/phone-input/phone-number.js
+++ b/client/components/phone-input/phone-number.js
@@ -234,3 +234,8 @@ export function toE164( inputNumber, country ) {
 	const { nationalNumber } = processNumber( inputNumber, country );
 	return '+' + country.dialCode + nationalNumber;
 }
+
+export function toIcannFormat( inputNumber, country ) {
+	const { nationalNumber } = processNumber( inputNumber, country );
+	return '+' + country.dialCode + '.' + nationalNumber;
+}

--- a/client/components/phone-input/test/test-phone-number.js
+++ b/client/components/phone-input/test/test-phone-number.js
@@ -208,6 +208,13 @@ describe( 'metadata:', () => {
 				equal( formatNumber( '14256559999', countries.us ), '1 425-655-9999' );
 			} );
 		} );
+
+		describe( 'sanitization', () => {
+			it( 'should strip non-digits on <3 length strings', () => {
+				equal( formatNumber( '1aaaa', countries.us ), '1' );
+				equal( formatNumber( '1a', countries.us ), '1' );
+			} );
+		} );
 	} );
 
 	describe( 'toE164', () => {

--- a/client/components/phone-input/test/test-phone-number.js
+++ b/client/components/phone-input/test/test-phone-number.js
@@ -30,7 +30,7 @@ describe( 'metadata:', () => {
 				describe( 'Dialcode: ' + dialCode, () => {
 					countriesWithDialCode.forEach( country =>
 						it( country.isoCode, () =>
-							ok( country.priority, `"${country.isoCode}" has no priority` ) ) );
+							ok( country.priority, `"${ country.isoCode }" has no priority` ) ) );
 				} );
 			} );
 		} );
@@ -227,7 +227,7 @@ describe( 'metadata:', () => {
 				equal( toE164( '05325556677', countries.tr ), '+905325556677' );
 				equal( toE164( '01234567890', countries.gb ), '+441234567890' );
 				equal( toE164( '012345678', countries.it ), '+39012345678' );
-			} )
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds a bunch of improvements to Phone Input and irons out a couple of bugs.

1. Fixes the sanitization issue where the input had <3 chars.
2. Adds alias support for countries that can be called by multiple short codes (e.g. gb==uk)
3. Improves the way to set and update the selected country within the input. We can supply the initial country code as a prop but we need to call a function to make updates. This allows us to let the component to handle its own state, but allow external changes. 
4. Refactored the code for more clarity.

/cc: @klimeryk @aidvu @dzver 