### PR TITLE
Form-Phone-Media-Input: Add a form input to wrap Phone Input

### DIFF
--- a/client/components/forms/form-phone-media-input/index.jsx
+++ b/client/components/forms/form-phone-media-input/index.jsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+import omit from 'lodash/omit';
+
+/** Internal dependencies */
+import PhoneInput from 'components/phone-input';
+import FormLabel from 'components/forms/form-label';
+import FormInputValidation from 'components/forms/form-input-validation';
+
+export default React.createClass( {
+	displayName: 'FormPhoneMediaInput',
+
+	getDefaultProps: function() {
+		return {
+			isError: false
+		};
+	},
+
+	render: function() {
+		const classes = classnames( this.props.className, {
+			'is-error': this.props.isError
+		} );
+		return (
+			<div className={ classnames( this.props.additionalClasses, 'phone' ) }>
+				<div>
+					<FormLabel htmlFor={ this.props.name }>{ this.props.label }</FormLabel>
+					<PhoneInput
+						{ ...omit( this.props, 'className' ) }
+						ref="input"
+						className={ classes } />
+				</div>
+				{ this.props.errorMessage && <FormInputValidation text={ this.props.errorMessage } isError /> }
+			</div>
+		);
+	}
+} );


### PR DESCRIPTION
Depends on #10312. 

This PR adds a wrapping component to Phone Input similar to our other form components that provides the same styling, html structure and showing error messages.

/cc: @klimeryk @aidvu @dzver 