### PR TITLE
Exporter: Fix a warning for null value in PostTypeOptions select

### DIFF
--- a/client/my-sites/exporter/export-card/select.jsx
+++ b/client/my-sites/exporter/export-card/select.jsx
@@ -77,7 +77,7 @@ const mapStateToProps = ( state, ownProps ) => {
 	const { siteId, postType, fieldName } = ownProps;
 
 	const options = getPostTypeFieldOptions( state, siteId, postType, fieldName );
-	const value = getPostTypeFieldValue( state, siteId, postType, fieldName );
+	const value = getPostTypeFieldValue( state, siteId, postType, fieldName ) || '';
 
 	return {
 		shouldShowPlaceholders: ! options,

--- a/client/my-sites/exporter/export-card/select.jsx
+++ b/client/my-sites/exporter/export-card/select.jsx
@@ -64,7 +64,7 @@ class Select extends Component {
 				disabled={ shouldShowPlaceholders || ! isEnabled }
 				isError={ isEnabled && isError }
 				onChange={ this.setValue }
-				value={ value }
+				value={ value || '' }
 			>
 				<option value="">{ label }</option>
 				{ options }
@@ -77,7 +77,7 @@ const mapStateToProps = ( state, ownProps ) => {
 	const { siteId, postType, fieldName } = ownProps;
 
 	const options = getPostTypeFieldOptions( state, siteId, postType, fieldName );
-	const value = getPostTypeFieldValue( state, siteId, postType, fieldName ) || '';
+	const value = getPostTypeFieldValue( state, siteId, postType, fieldName );
 
 	return {
 		shouldShowPlaceholders: ! options,


### PR DESCRIPTION
This PR fixes a warning that is displayed when the Export settings card is expanded:

![](https://cldup.com/GkWY3RLyhm.png)

This warning is caused by the fact that `getPostTypeFieldValue()` can return a `null` value, and using a `null` as a value of a `<select>` triggers a warning.

**To test:**

* Checkout this branch.
* Go to `/settings/export/$site` where `$site` is one of your WordPress.com sites.
* Click the arrow next to "Export All" to expand the card.
* Verify no warning is displayed anymore.