### PR TITLE
State: Use urlToSlug() in getSiteByUrl() selector

### DIFF
--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -441,7 +441,7 @@ export const getSeoTitle = ( state, type, data ) => {
  * @return {?Object}       Site object
  */
 export function getSiteByUrl( state, url ) {
-	const slug = withoutHttp( url ).replace( /\//g, '::' );
+	const slug = urlToSlug( url );
 	const site = find( state.sites.items, ( item, siteId ) => {
 		return getSiteSlug( state, siteId ) === slug;
 	} );


### PR DESCRIPTION
This PR updates the `getSiteByUrl()` selector to use `urlToSlug()` when generating a slug from a URL. This is a recommended approach, since `urlToSlug()` already has tests.

To test:

* Checkout this branch
* Run the following in your console:
```
npm run test-client client/state/sites/test/selectors.js -- --grep "getSiteByUrl"
```
* Verify all tests are passing ✅ .