### PR TITLE
Jetpack Settings: Add more tests for isFetchingModules() selector

### DIFF
--- a/client/state/jetpack-settings/modules/test/fixture.js
+++ b/client/state/jetpack-settings/modules/test/fixture.js
@@ -27,6 +27,9 @@ export const requests = {
 			deactivating: false
 		},
 		fetchingModules: true
+	},
+	654321: {
+		fetchingModules: false
 	}
 };
 

--- a/client/state/jetpack-settings/modules/test/selectors.js
+++ b/client/state/jetpack-settings/modules/test/selectors.js
@@ -155,6 +155,32 @@ describe( 'selectors', () => {
 			const output = isFetchingModules( stateIn, siteId );
 			expect( output ).to.be.true;
 		} );
+
+		it( 'should return false if the list of modules is currently not being fetched', () => {
+			const stateIn = {
+					jetpackSettings: {
+						jetpackModules: {
+							requests: REQUESTS_FIXTURE
+						}
+					}
+				},
+				siteId = 654321;
+			const output = isFetchingModules( stateIn, siteId );
+			expect( output ).to.be.false;
+		} );
+
+		it( 'should return null if that site is not known', () => {
+			const stateIn = {
+					jetpackSettings: {
+						jetpackModules: {
+							requests: REQUESTS_FIXTURE
+						}
+					}
+				},
+				siteId = 888888;
+			const output = isFetchingModules( stateIn, siteId );
+			expect( output ).to.be.null;
+		} );
 	} );
 
 	describe( '#getModules', () => {


### PR DESCRIPTION
This PR is part of #9171 and it adds 2 additional tests for the `isFetchingModules()` selector that cover the following cases:

* When the modules are not being fetched
* When the site is not known.

To test:

* Checkout this branch
* Run the following in your console:
```
npm run test-client client/state/jetpack-settings/modules/test/selectors.js -- --grep "isFetchingModules"
```
* Verify all tests pass ✅ .