### PR TITLE
Jetpack Settings: Fix siteId in selector docs

### DIFF
--- a/client/state/jetpack-settings/connection/selectors.js
+++ b/client/state/jetpack-settings/connection/selectors.js
@@ -8,7 +8,7 @@ import { get } from 'lodash';
  * Returns null if the site is unknown, or there is no information yet.
  *
  * @param  {Object}   state    Global state tree
- * @param  {String}   siteId   The ID of the site we're querying
+ * @param  {Number}   siteId   The ID of the site we're querying
  * @return {?Boolean}          Whether the connection status is being requested
  */
 export function isRequestingJetpackConnectionStatus( state, siteId ) {
@@ -20,7 +20,7 @@ export function isRequestingJetpackConnectionStatus( state, siteId ) {
  * Returns null if the site is unknown, or status hasn't been received yet.
  *
  * @param  {Object}  state       Global state tree
- * @param  {String}  siteId      The ID of the site we're querying
+ * @param  {Number}  siteId      The ID of the site we're querying
  * @return {?Object}             Details about connection status
  */
 export function getJetpackConnectionStatus( state, siteId ) {
@@ -32,7 +32,7 @@ export function getJetpackConnectionStatus( state, siteId ) {
  * Returns null if the site is unknown, or there is no information yet.
  *
  * @param  {Object}   state    Global state tree
- * @param  {String}   siteId   The ID of the site we're querying
+ * @param  {Number}   siteId   The ID of the site we're querying
  * @return {?Boolean}          Whether the site is in development mode.
  */
 export function isJetpackSiteInDevelopmentMode( state, siteId ) {
@@ -44,7 +44,7 @@ export function isJetpackSiteInDevelopmentMode( state, siteId ) {
  * Returns null if the site is unknown, or there is no information yet.
  *
  * @param  {Object}   state    Global state tree
- * @param  {String}   siteId   The ID of the site we're querying
+ * @param  {Number}   siteId   The ID of the site we're querying
  * @return {?Boolean}          Whether the site is in staging mode.
  */
 export function isJetpackSiteInStagingMode( state, siteId ) {

--- a/client/state/jetpack-settings/jumpstart/selectors.js
+++ b/client/state/jetpack-settings/jumpstart/selectors.js
@@ -8,7 +8,7 @@ import { get } from 'lodash';
  * Returns null if the site is unknown, or there is no information yet.
  *
  * @param  {Object}  state       Global state tree
- * @param  {String}  siteId      The ID of the site we're querying
+ * @param  {Number}  siteId      The ID of the site we're querying
  * @return {?Boolean}            Whether Jumpstart is currently being activated
  */
 export function isActivatingJumpstart( state, siteId ) {
@@ -20,7 +20,7 @@ export function isActivatingJumpstart( state, siteId ) {
  * Returns null if the site is unknown, or there is no information yet.
  *
  * @param  {Object}  state       Global state tree
- * @param  {String}  siteId      The ID of the site we're querying
+ * @param  {Number}  siteId      The ID of the site we're querying
  * @return {?Boolean}            Whether Jumpstart is currently being deactivated
  */
 export function isDeactivatingJumpstart( state, siteId ) {
@@ -32,7 +32,7 @@ export function isDeactivatingJumpstart( state, siteId ) {
  * Returns null if the site is unknown, or there is no information yet.
  *
  * @param  {Object}   state    Global state tree
- * @param  {String}   siteId   The ID of the site we're querying
+ * @param  {Number}   siteId   The ID of the site we're querying
  * @return {?Boolean}          Whether the Jumpstart status is being requested
  */
 export function isRequestingJumpstartStatus( state, siteId ) {
@@ -44,7 +44,7 @@ export function isRequestingJumpstartStatus( state, siteId ) {
  * Returns null if the site is unknown, or status hasn't been received yet.
  *
  * @param  {Object}  state       Global state tree
- * @param  {String}  siteId      The ID of the site we're querying
+ * @param  {Number}  siteId      The ID of the site we're querying
  * @return {?String}             Whether Jumpstart is active
  */
 export function getJumpstartStatus( state, siteId ) {

--- a/client/state/jetpack-settings/module-settings/selectors.js
+++ b/client/state/jetpack-settings/module-settings/selectors.js
@@ -8,7 +8,7 @@ import { get } from 'lodash';
  * Returns null if the status for the queried site and module is unknown.
  *
  * @param  {Object}  state       Global state tree
- * @param  {String}  siteId      The ID of the site we're querying
+ * @param  {Number}  siteId      The ID of the site we're querying
  * @param  {String}  moduleSlug  Slug of the module
  * @return {?Boolean}            Whether module settings are currently being requested
  */
@@ -21,7 +21,7 @@ export function isRequestingModuleSettings( state, siteId, moduleSlug ) {
  * Returns null if the status for the queried site and module is unknown.
  *
  * @param  {Object}  state       Global state tree
- * @param  {String}  siteId      The ID of the site we're querying
+ * @param  {Number}  siteId      The ID of the site we're querying
  * @param  {String}  moduleSlug  Slug of the module
  * @return {?Boolean}            Whether module settings are currently being updated
  */
@@ -34,7 +34,7 @@ export function isUpdatingModuleSettings( state, siteId, moduleSlug ) {
  * Returns null if the site is unknown, or modules have not been fetched yet.
  *
  * @param  {Object}  state   Global state tree
- * @param  {String}  siteId  The ID of the site we're querying
+ * @param  {Number}  siteId  The ID of the site we're querying
  * @return {?Object}         Modules settings
  */
 export function getModulesSettings( state, siteId ) {
@@ -46,7 +46,7 @@ export function getModulesSettings( state, siteId ) {
  * Returns null if the site or module is unknown, or modules have not been fetched yet.
  *
  * @param  {Object}  state       Global state tree
- * @param  {String}  siteId      The ID of the site we're querying
+ * @param  {Number}  siteId      The ID of the site we're querying
  * @param  {String}  moduleSlug  Slug of the module
  * @return {?Object}             Module data
  */

--- a/client/state/jetpack-settings/modules/selectors.js
+++ b/client/state/jetpack-settings/modules/selectors.js
@@ -8,7 +8,7 @@ import { get } from 'lodash';
  * Returns null if the status for the queried site and module is unknown.
  *
  * @param  {Object}  state       Global state tree
- * @param  {String}  siteId      The ID of the site we're querying
+ * @param  {Number}  siteId      The ID of the site we're querying
  * @param  {String}  moduleSlug  Slug of the module
  * @return {?Boolean}            Whether the module is active
  */
@@ -21,7 +21,7 @@ export function isModuleActive( state, siteId, moduleSlug ) {
  * Returns null if the status for the queried site and module is unknown.
  *
  * @param  {Object}  state       Global state tree
- * @param  {String}  siteId      The ID of the site we're querying
+ * @param  {Number}  siteId      The ID of the site we're querying
  * @param  {String}  moduleSlug  Slug of the module
  * @return {?Boolean}            Whether module is currently being activated
  */
@@ -34,7 +34,7 @@ export function isActivatingModule( state, siteId, moduleSlug ) {
  * Returns null if the status for the queried site and module is unknown.
  *
  * @param  {Object}  state       Global state tree
- * @param  {String}  siteId      The ID of the site we're querying
+ * @param  {Number}  siteId      The ID of the site we're querying
  * @param  {String}  moduleSlug  Slug of the module
  * @return {?Boolean}            Whether module is currently being deactivated
  */
@@ -48,7 +48,7 @@ export function isDeactivatingModule( state, siteId, moduleSlug ) {
  * Returns null if the status for queried site and module is unknown.
  *
  * @param  {Object}  state  Global state tree
- * @param  {String}  siteId The ID of the site we're querying
+ * @param  {Number}  siteId The ID of the site we're querying
  * @return {?Boolean}         Whether the list is being requested
  */
 export function isFetchingModules( state, siteId ) {
@@ -60,7 +60,7 @@ export function isFetchingModules( state, siteId ) {
  * Returns null if the site is unknown, or modules have not been fetched yet.
  *
  * @param  {Object}  state   Global state tree
- * @param  {String}  siteId  The ID of the site we're querying
+ * @param  {Number}  siteId  The ID of the site we're querying
  * @return {?Object}         Modules data
  */
 export function getModules( state, siteId ) {
@@ -72,7 +72,7 @@ export function getModules( state, siteId ) {
  * Returns null if the site or module is unknown, or modules have not been fetched yet.
  *
  * @param  {Object}  state       Global state tree
- * @param  {String}  siteId      The ID of the site we're querying
+ * @param  {Number}  siteId      The ID of the site we're querying
  * @param  {String}  moduleSlug  Slug of the module
  * @return {?Object}             Module data
  */


### PR DESCRIPTION
This PR is part of #9171 and it fixes the cases where `siteId` is defined as `String` in the selector docs. We're expecting an integer there, so it should be a `Number` instead. 

There isn't anything to test here, this PR only needs a sanity check.