### PR TITLE
Support: Add link for video tutorials

### DIFF
--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -100,6 +100,14 @@ const Help = React.createClass( {
 						</p>
 					</div>
 				</CompactCard>
+				<CompactCard className="help__support-link" href="https://en.support.wordpress.com/video-tutorials/" target="__blank">
+					<div className="help__support-link-section">
+						<h2 className="help__support-link-title">{ this.translate( 'Quick help video tutorials' ) }</h2>
+						<p className="help__support-link-content">
+							{ this.translate( 'These short videos will demonstrate some of our most popular features.' ) }
+						</p>
+					</div>
+				</CompactCard>
 				<CompactCard className="help__support-link" href="https://dailypost.wordpress.com/blogging-university/" target="__blank">
 					<div className="help__support-link-section">
 						<h2 className="help__support-link-title">


### PR DESCRIPTION
See original issue in #10182 for a bit of context. This PR adds a link to our video tutorials at
https://en.support.wordpress.com/video-tutorials/ to the Help page.

Here's the text that was added:

> Quick Help Video Tutorials
> These short videos will demonstrate some of our most popular features.

## To test
1. Load up this branch.
2. Visit http://calypso.localhost:3000/help

You should see a link to our video tutorials in the list towards the bottom of the page:

<img width="793" alt="screen shot 2016-12-29 at 10 21 21 am" src="https://cloud.githubusercontent.com/assets/7240478/21549635/d3c9a222-cdb0-11e6-9868-b2d03f526e0a.png">

We're building up quite a list of items on this page. I'd argue that five is about as many options as we want to present. Rather than add additional items in the future, we should collect some stats on what links users are finding most valuable and then include only those links.