### PR TITLE
Editor: Make TinyMCE editor mentions plugin available behind a feature flag

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -44,6 +44,7 @@ import insertMenuPlugin from './plugins/insert-menu/plugin';
 import embedReversalPlugin from './plugins/embed-reversal/plugin';
 import EditorHtmlToolbar from 'post-editor/editor-html-toolbar';
 import isIE11 from 'lib/detect-ie11';
+import mentionsPlugin from './plugins/mentions/plugin';
 
 [
 	wpcomPlugin,
@@ -137,6 +138,11 @@ const PLUGINS = [
 
 if ( config.isEnabled( 'post-editor/insert-menu' ) ) {
 	PLUGINS.push( 'wpcom/insertmenu' );
+}
+
+if ( config.isEnabled( 'post-editor/mentions' ) ) {
+	mentionsPlugin();
+	PLUGINS.push( 'wpcom/mentions' );
 }
 
 const CONTENT_CSS = [

--- a/client/components/tinymce/plugins/mentions/mentions.jsx
+++ b/client/components/tinymce/plugins/mentions/mentions.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import ReactDomServer from 'react-dom/server';
 import { connect } from 'react-redux';
-import { findIndex, get, head, includes, last, pick } from 'lodash';
+import { escapeRegExp, findIndex, get, head, includes, last, pick } from 'lodash';
 import tinymce from 'tinymce/tinymce';
 
 /**
@@ -80,12 +80,10 @@ export class Mentions extends Component {
 
 	getMatchingSuggestions( suggestions, query ) {
 		if ( query ) {
-			suggestions = suggestions.filter( ( { user_login: userLogin, display_name: displayName } ) => {
-				// Start of string or preceded by a space.
-				const matcher = new RegExp( `^${ query }|\\s${ query }`, 'ig' );
+			query = escapeRegExp( query );
+			const matcher = new RegExp( `^${ query }|\\s${ query }`, 'ig' ); // Start of string or preceded by a space.
 
-				return matcher.test( `${ userLogin } ${ displayName }` );
-			} );
+			suggestions = suggestions.filter( ( { user_login: login, display_name: name } ) => matcher.test( `${ login } ${ name }` ) );
 		}
 
 		return suggestions.slice( 0, 10 );

--- a/client/components/tinymce/plugins/mentions/mentions.jsx
+++ b/client/components/tinymce/plugins/mentions/mentions.jsx
@@ -244,7 +244,7 @@ export class Mentions extends Component {
 		return (
 			<div ref={ this.setPopoverContext }>
 				<QueryUsersSuggestions siteId={ siteId } />
-				{ this.matchingSuggestions.length && showPopover &&
+				{ this.matchingSuggestions.length > 0 && showPopover &&
 					<SuggestionList
 						query={ query }
 						suggestions={ this.matchingSuggestions }

--- a/client/components/tinymce/plugins/mentions/plugin.jsx
+++ b/client/components/tinymce/plugins/mentions/plugin.jsx
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import tinymce from 'tinymce/tinymce';
+import ReactDom from 'react-dom';
+import React from 'react';
+import { Provider as ReduxProvider } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import Mentions from './mentions';
+import { getSelectedSite } from 'state/ui/selectors';
+
+/**
+ * Module variables
+ */
+const { ENTER } = tinymce.util.VK;
+
+function mentions( editor ) {
+	const node = document.createElement( 'div' );
+	let isRendered = false;
+
+	editor.on( 'init focus', () => {
+		const store = editor.getParam( 'redux_store' );
+		const selectedSite = getSelectedSite( store.getState() );
+
+		if ( ! isRendered && selectedSite && ! selectedSite.single_user_site ) {
+			node.setAttribute( 'class', 'mentions__container' );
+			editor.getContainer().appendChild( node );
+
+			ReactDom.render(
+				<ReduxProvider store={ store }>
+					<Mentions editor={ editor } node={ node } />
+				</ReduxProvider>,
+				node
+			);
+
+			isRendered = true;
+		}
+
+		if ( isRendered && selectedSite && selectedSite.single_user_site ) {
+			ReactDom.unmountComponentAtNode( node );
+			isRendered = false;
+		}
+	} );
+
+	// Cancel Enter key press if the popover is visible.
+	// Doing this in the Mentions component is too late.
+	editor.on( 'keydown', ( event ) => {
+		if ( document.querySelector( '.mentions__suggestions' ) && event.keyCode === ENTER ) {
+			event.preventDefault();
+		}
+	} );
+}
+
+export default () => {
+	tinymce.PluginManager.add( 'wpcom/mentions', mentions );
+};

--- a/client/components/tinymce/plugins/mentions/style.scss
+++ b/client/components/tinymce/plugins/mentions/style.scss
@@ -26,6 +26,10 @@ $avatar-margin: 10px;
 		color: white;
 	}
 
+	.rtl & {
+		direction: ltr; // Required to get the '@' on the correct side.
+	}
+
 	@include breakpoint( ">480px" ) {
 		line-height: 24px;
 	}
@@ -66,10 +70,4 @@ $avatar-margin: 10px;
 .mentions__highlight {
 	font-weight: 400;
 	background: rgba( $blue-light, 0.25 );
-}
-
-.rtl {
-	.mentions__suggestion {
-		direction: ltr; // required to get the '@' on the correct side
-	}
 }

--- a/client/components/tinymce/plugins/mentions/style.scss
+++ b/client/components/tinymce/plugins/mentions/style.scss
@@ -1,0 +1,75 @@
+$avatar-size: 24px;
+$avatar-margin: 10px;
+
+.mce-container .mentions__container {
+	position: absolute;
+}
+
+.mentions__suggestions {
+	width: 70%;
+
+	.popover__arrow {
+		display: none;
+	}
+
+	@include breakpoint( ">480px" ) {
+		width: 20%;
+		min-width: 29em;
+	}
+}
+
+.mentions__suggestion {
+	padding: 8px 10px;
+
+	&.is-selected .mentions__highlight,
+	&:hover .mentions__highlight {
+		color: white;
+	}
+
+	@include breakpoint( ">480px" ) {
+		line-height: 24px;
+	}
+}
+
+.mentions__avatar {
+	border-radius: 50%;
+	width: $avatar-size;
+	height: $avatar-size;
+	float: left;
+	margin: 0 $avatar-margin 0 0;
+}
+
+.mentions__username,
+.mentions__fullname {
+	float: left;
+	display: inline-block;
+	font-weight: 400;
+}
+
+.mentions__username {
+	padding-top: 10px;
+	margin: -10px 0 0 0;
+}
+
+.mentions__fullname {
+	clear: left;
+	margin-left: $avatar-size + $avatar-margin;
+	font-size: 11px;
+
+	@include breakpoint( ">480px" ) {
+		float: right;
+		clear: none;
+		margin-left: 0;
+	}
+}
+
+.mentions__highlight {
+	font-weight: 400;
+	background: rgba( $blue-light, 0.25 );
+}
+
+.rtl {
+	.mentions__suggestion {
+		direction: ltr; // required to get the '@' on the correct side
+	}
+}

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -4,6 +4,7 @@
 @import 'plugins/wpcom-help/style';
 @import 'plugins/wpcom-charmap/style';
 @import 'plugins/contact-form/style';
+@import 'plugins/mentions/style';
 
 .tinymce {
 	display: none;

--- a/client/state/users/suggestions/selectors.js
+++ b/client/state/users/suggestions/selectors.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * Returns true if requesting user suggestions for the specified site ID, or
  * false otherwise.
  *
@@ -7,7 +12,7 @@
  * @return {Boolean}         Whether user suggestions are being requested
  */
 export function isRequestingUserSuggestions( state, siteId ) {
-	return !! state.users.suggestions.requesting[ siteId ];
+	return get( state.users.suggestions.requesting, [ siteId ], false );
 }
 
 /**
@@ -15,8 +20,8 @@ export function isRequestingUserSuggestions( state, siteId ) {
  *
  * @param  {Object}  state   Global state tree
  * @param  {Number}  siteId  Site ID
- * @return {?Object}         Site user suggestions
+ * @return {Array}           Site user suggestions
  */
 export function getUserSuggestions( state, siteId ) {
-	return state.users.suggestions.items[ siteId ] || null;
+	return get( state.users.suggestions.items, [ siteId ], [] );
 }

--- a/client/state/users/suggestions/test/selectors.js
+++ b/client/state/users/suggestions/test/selectors.js
@@ -13,7 +13,7 @@ import {
 
 describe( 'selectors', () => {
 	describe( '#getUserSuggestions()', () => {
-		it( 'should return null if there is no suggestion available', () => {
+		it( 'should return empty array if there is no suggestion available', () => {
 			const state = {
 				users: {
 					suggestions: {
@@ -21,7 +21,7 @@ describe( 'selectors', () => {
 					}
 				}
 			};
-			expect( getUserSuggestions( state, 123 ) ).to.equal( null );
+			expect( getUserSuggestions( state, 123 ) ).to.eql( [] );
 		} );
 
 		it( 'should return suggestions if they exist for a site ID', () => {
@@ -40,7 +40,6 @@ describe( 'selectors', () => {
 				}
 			};
 			expect( getUserSuggestions( state, 123 ) ).to.have.length( 2 );
-			expect( getUserSuggestions( state, 124 ) ).to.eql( null );
 		} );
 	} );
 

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -63,6 +63,7 @@
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,
 		"post-editor/image-editor": true,
+		"post-editor/mentions": false,
 		"press-this": false,
 		"preview-layout": true,
 		"reader": true,

--- a/config/development.json
+++ b/config/development.json
@@ -116,6 +116,7 @@
 		"post-editor/image-editor": true,
 		"post-editor/insert-menu": true,
 		"post-editor/media-advanced": false,
+		"post-editor/mentions": true,
 		"press-this": true,
 		"push-notifications": true,
 		"reader": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -74,6 +74,7 @@
 		"plans/personal-plan": true,
 		"post-editor/image-editor": true,
 		"post-editor/insert-menu": true,
+		"post-editor/mentions": true,
 		"press-this": true,
 		"preview-layout": true,
 		"reader": true,

--- a/config/production.json
+++ b/config/production.json
@@ -67,7 +67,6 @@
 		"post-editor/author-selector": true,
 		"post-editor/insert-menu": true,
 		"post-editor/image-editor": true,
-		"post-editor/mentions": false,
 		"press-this": true,
 		"preview-layout": true,
 		"push-notifications": true,

--- a/config/production.json
+++ b/config/production.json
@@ -67,6 +67,7 @@
 		"post-editor/author-selector": true,
 		"post-editor/insert-menu": true,
 		"post-editor/image-editor": true,
+		"post-editor/mentions": false,
 		"press-this": true,
 		"preview-layout": true,
 		"push-notifications": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -73,6 +73,7 @@
 		"post-editor/html-toolbar": true,
 		"post-editor/insert-menu": true,
 		"post-editor/image-editor": true,
+		"post-editor/mentions": true,
 		"press-this": true,
 		"preview-layout": true,
 		"push-notifications": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -73,6 +73,7 @@
 		"post-editor/html-toolbar": true,
 		"post-editor/insert-menu": true,
 		"post-editor/image-editor": true,
+		"post-editor/mentions": false,
 		"press-this": true,
 		"preview-layout": true,
 		"push-notifications": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -73,7 +73,6 @@
 		"post-editor/html-toolbar": true,
 		"post-editor/insert-menu": true,
 		"post-editor/image-editor": true,
-		"post-editor/mentions": true,
 		"press-this": true,
 		"preview-layout": true,
 		"push-notifications": true,

--- a/config/test.json
+++ b/config/test.json
@@ -85,6 +85,7 @@
 		"plans/personal-plan": true,
 		"post-editor-github-link": false,
 		"post-editor/media-advanced": true,
+		"post-editor/mentions": false,
 		"press-this": true,
 		"reader": true,
 		"reader/full-errors": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -86,6 +86,7 @@
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
 		"post-editor/insert-menu": true,
+		"post-editor/mentions": true,
 		"press-this": true,
 		"preview-layout": true,
 		"reader": true,


### PR DESCRIPTION
To facilitate merging, this PR separates out the integration of the TinyMCE editor mentions plugin from PR #8028, which adds support for mentions to the editor. Mentions are turned on in the `development`, `wpcalypso` and `horizon` environments.

Dependent on PRs #9969 and #10142.

### Testing
Scenarios:
- Site with a single user
- Site with multiple users
- Switching back and forth between sites
- Testing with mentions turned off: `DISABLE_FEATURES=post-editor/mentions make run`

cc @mtias

![mentions](https://cloud.githubusercontent.com/assets/1190420/20303834/46b0e8e6-aafb-11e6-9c3f-b28c677a3f57.gif) 