### PR TITLE
Stats: disable state persistence for stats list items.

### DIFF
--- a/client/state/stats/lists/reducer.js
+++ b/client/state/stats/lists/reducer.js
@@ -7,9 +7,7 @@ import merge from 'lodash/merge';
 /**
  * Internal dependencies
  */
-import { isValidStateWithSchema } from 'state/utils';
 import { getSerializedStatsQuery } from './utils';
-import { itemSchema } from './schema';
 import {
 	DESERIALIZE,
 	SERIALIZE,
@@ -69,11 +67,8 @@ export function items( state = {}, action ) {
 				}
 			} );
 
+		case SERIALIZE:
 		case DESERIALIZE:
-			if ( isValidStateWithSchema( state, itemSchema ) ) {
-				return state;
-			}
-
 			return {};
 	}
 

--- a/client/state/stats/lists/test/reducer.js
+++ b/client/state/stats/lists/test/reducer.js
@@ -168,7 +168,7 @@ describe( 'reducer', () => {
 	} );
 
 	describe( 'items()', () => {
-		it( 'should persist state', () => {
+		it( 'should not persist state', () => {
 			const original = deepFreeze( {
 				2916284: {
 					statsStreak: {
@@ -177,30 +177,6 @@ describe( 'reducer', () => {
 				}
 			} );
 			const state = items( original, { type: SERIALIZE } );
-
-			expect( state ).to.eql( original );
-		} );
-
-		it( 'should load valid persisted state', () => {
-			const original = deepFreeze( {
-				2916284: {
-					statsStreak: {
-						'[["endDate","2016-07-01"],["startDate","2016-06-01"]]': streakResponse
-					}
-				}
-			} );
-			const state = items( original, { type: DESERIALIZE } );
-
-			expect( state ).to.eql( original );
-		} );
-
-		it( 'should not load invalid persisted state', () => {
-			const original = deepFreeze( {
-				2916284: {
-					'[["endDate","2016-07-01"],["startDate","2016-06-01"]]': streakResponse
-				}
-			} );
-			const state = items( original, { type: DESERIALIZE } );
 
 			expect( state ).to.eql( {} );
 		} );


### PR DESCRIPTION
This branch is based on a somewhat informed hunch between some investigating that @jblz and I have done in regards to #9529

While attempting to calculate the size of the indexDb instance, Jeff was hitting some oddness around the `statsStreak` persisted data.  In this branch, I have disabled the serialization of the stats list items to see if this might be a possible fix.

__To Test__
Open a site stats insights page, and ensure the "Post Trends" data still loads as expected