### PR TITLE
Stats: Ensure Data is object in getSiteStatsPostStreakData

### DIFF
--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { forOwn, get, reduce } from 'lodash';
+import { forOwn, get, reduce, isArray } from 'lodash';
 import i18n from 'i18n-calypso';
 
 /**
@@ -58,7 +58,8 @@ export const getSiteStatsPostStreakData = createSelector(
 		const { gmtOffset = 0 } = query;
 		const response = {};
 		const streakData = getSiteStatsForQuery( state, siteId, 'statsStreak', query );
-		if ( streakData && streakData.data ) {
+		// ensure streakData.data exists and it is not an array
+		if ( streakData && streakData.data && ! isArray( streakData.data ) ) {
 			Object.keys( streakData.data ).forEach( ( timestamp ) => {
 				const postDay = i18n.moment.unix( timestamp ).locale( 'en' );
 				const datestamp = postDay.utcOffset( gmtOffset ).format( 'YYYY-MM-DD' );

--- a/client/state/stats/lists/test/selectors.js
+++ b/client/state/stats/lists/test/selectors.js
@@ -155,6 +155,27 @@ describe( 'selectors', () => {
 			} );
 		} );
 
+		it( 'should handle malformed data if matching data for query exists', () => {
+			const stats = getSiteStatsPostStreakData( {
+				stats: {
+					lists: {
+						items: {
+							2916284: {
+								statsStreak: {
+									'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': {
+										streak: {},
+										data: [ 1461889800 ]
+									}
+								}
+							}
+						}
+					}
+				}
+			}, 2916284, { startDate: '2015-06-01', endDate: '2016-06-01' } );
+
+			expect( stats ).to.eql( {} );
+		} );
+
 		it( 'should return post streak data based on the GMT offset of the current site', () => {
 			const state = {
 				stats: {


### PR DESCRIPTION
While investigating issues with @jblz 's state tree in #9529 - we discovered that some `statsStreak.items` data was locally persisted as an array and not an object.  Since the schema for this part of the state tree has to be "flexible" to accommodate the different stats API responses, we need to perhaps be a bit more vigilant in ensuring the data format is what we expect.

In this branch I have added logic to check that the data is not an array in the  `getSiteStatsPostStreakData` selector.

__To Test__
- `npm run test-client client/state/stats`
- And also ensure Post Streak data is shown on the stats insights page as expected