### PR TITLE
Only allow api-cache for Jetpack > 4.5

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -686,7 +686,7 @@ class SiteSettingsFormGeneral extends Component {
 		}
 
 		const { site } = this.props;
-		if ( ! site.jetpack || site.versionCompare( '4.2-alpha', '<' ) ) {
+		if ( ! site.jetpack || site.versionCompare( '4.5', '<' ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixes a minor issue where the api-cache setting was visible for versions of Jetpack that didn't support it.