### PR TITLE
Fix versionCompare bug showing api cache for 4.5+

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -686,7 +686,7 @@ class SiteSettingsFormGeneral extends Component {
 		}
 
 		const { site } = this.props;
-		if ( ! site.jetpack || site.versionCompare( '4.5', '<' ) ) {
+		if ( ! site.jetpack || site.versionCompare( '4.4', '<=' ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
For some reason, versionCompare wasn't considering 4.5-beta to be 4.5+