### PR TITLE
Stats: prevent _.merge from crashing reducer.

### DIFF
--- a/client/state/stats/lists/reducer.js
+++ b/client/state/stats/lists/reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import merge from 'lodash/merge';
+import { merge, unset } from 'lodash';
 
 /**
  * Internal dependencies
@@ -61,7 +61,12 @@ export function items( state = {}, action ) {
 	switch ( action.type ) {
 		case SITE_STATS_RECEIVE:
 			const queryKey = getSerializedStatsQuery( action.query );
-			return merge( {}, state, {
+
+			// To avoid corrupted stat data with massive arrays
+			// From causing _.merge to crash, first clone, then unset existing data
+			const existingItems = Object.assign( {}, state );
+			unset( existingItems, [ action.siteId, action.statType, queryKey ] );
+			return merge( {}, existingItems, {
 				[ action.siteId ]: {
 					[ action.statType ]: {
 						[ queryKey ]: action.data


### PR DESCRIPTION
Fixes #9529 

Today @jblz did some [troubleshooting](https://github.com/Automattic/wp-calypso/issues/9529#issuecomment-269702795) with his local state tree that was causing calypso to crash in Chrome.  At the end of the troubleshooting, he discovered the issue to be caused by a massive array in the `statsStreak` data that was persisted in `indexDB`.

A screen grab of the malformed data in Jeff's persisted state tree:

<img width="646" alt="screen_shot_2016-12-29_at_1_10_47_pm_png_and_stats__prevent___merge_from_crashing_reducer__by_timmyc_ _pull_request__10326_ _automattic_wp-calypso" src="https://cloud.githubusercontent.com/assets/22080/21557524/2be0439a-cde2-11e6-82a7-e92345568d70.png">

__Steps to Recreate__
- Visit a stats insights page, and note the site.ID for the site you are using
- Then using the site.ID enter the following in the console, this simulates the same massive array we saw in Jeff's indexDB

```
// for site.ID of 121720032
var badArray = new Array(121720032);
// set the site.ID - 1 element to 1
badArray[121720031] = 1;
indexedDB.open('calypso').onsuccess = (e) => { 
	const db = e.target.result; const transaction = db.transaction( 'calypso_store', "readwrite" );
	const store = transaction.objectStore( 'calypso_store' ); store.get( 'redux-state' ).onsuccess = (ee) => { 
		const state = ee.target.result;
		state.stats.lists.items['121720032'].statsStreak['[["endDate","2016-12-31"],["gmtOffset",0],["max",3000],["startDate","2015-12-01"]]'].data = badArray;
		store.put( state, 'redux-state' );
	};
};
```
- Refresh the insights page, and wait for the 💥 

With the ability to reproduce the bug locally, I was able to find the crash was happening when `_.merge` [is called](https://github.com/Automattic/wp-calypso/blob/master/client/state/stats/lists/reducer.js#L64-L70) against the persisted statsStreak data, and the latest data from the API.

This `_.merge` crashes the browser tab, and subsequently, the "bad" data is still in `indexDb`.  Additionally, the query params for `statsStreak` data do not change but once per year, as the dates are based upon the calendar year... as such this problem will continually happen until the calypso `indexDB` is purged manually, or if the persisted data is too old.

The question still remains of _how_ did this malformed array get created in the first place.  @jblz tested the api response via the developer console, and in other browsers/incognito tabs and we could not re-create the massive array.  I plan on investigating a bit more on the API side of things to see if I can reproduce the issue there.

The solution in this PR is to create a clone of the existing `stats.list.items` state tree, and `_.unset` the existing value before calling `_.merge`.  I'm open to other suggestions so feel free to comment with other ideas!

__To Test__
Repeat the steps above locally, and verify the browser tab no longer crashes when using this branch.