### PR TITLE
Domains: Add checkout page for failed purchases

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/failed-purchase.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/failed-purchase.jsx
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+import { localize } from 'i18n-calypso';
+import PurchaseDetail from 'components/purchase-detail';
+
+const FailedPurchase = ( { failedPurchases, translate } ) => {
+	const classes = {
+		'checkout-thank-you__header': true,
+	};
+
+	const description = (
+		<div>
+			<p>
+				{
+					translate(
+						'Here\'s the list of products we failed to obtain:'
+					)
+				}
+			</p>
+			<ul className="checkout-thank-you__domain-mapping-details-nameservers">
+				{ failedPurchases.map( item => {
+					return <li>{ item.productName }: { item.meta }</li>
+				} ) }
+			</ul>
+			<p>
+				{
+					translate( 'We have filled your account with credits so you can retry the failed purchases. ' +
+						'If the problem persists, please don\'t hesitate to contact support!'
+					)
+				}
+			</p>
+		</div>
+	);
+
+	return (
+		<div>
+			<div className={ classNames( classes ) }>
+				<div className="checkout-thank-you__header-content">
+						<span className="checkout-thank-you__header-icon">
+							<Gridicon icon="notice" size={ 72 }/>
+						</span>
+
+					<div className="checkout-thank-you__header-copy">
+						<h1 className="checkout-thank-you__header-heading">
+							{ translate( 'Ooops...' ) }
+						</h1>
+
+						<h2 className="checkout-thank-you__header-text">
+							{ translate( 'Seems we had some problems obtaining your items.' ) }
+						</h2>
+					</div>
+				</div>
+			</div>
+			<div className="checkout-thank-you__purchase-details-list">
+				<div className="checkout-thank-you__domain-mapping-details">
+					<PurchaseDetail
+						icon="redo"
+						description={ description }
+						target="_blank"
+						rel="noopener noreferrer"
+						isRequired />
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default localize( FailedPurchase );

--- a/client/my-sites/upgrades/checkout-thank-you/failed-purchase.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/failed-purchase.jsx
@@ -9,10 +9,11 @@ import React from 'react';
 import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import PurchaseDetail from 'components/purchase-detail';
+import support from 'lib/url/support';
 
 const FailedPurchase = ( { failedPurchases, translate } ) => {
-	function getDescription() {
-		return <div>
+	const description = (
+		<div>
 			<p>
 				{
 					translate(
@@ -22,18 +23,27 @@ const FailedPurchase = ( { failedPurchases, translate } ) => {
 			</p>
 			<ul className="checkout-thank-you__domain-mapping-details-nameservers">
 				{ failedPurchases.map( item => {
-					return <li key={ `failed-purchase-${ item.productId }` }>{ item.productName }{ item.meta && `: ${ item.meta }` }</li>;
+					return (
+						<li key={ `failed-purchase-${ item.productId }-${ item.meta }` }>
+							{ item.productName }{ item.meta && `: ${ item.meta }` }
+						</li>
+					);
 				} ) }
 			</ul>
 			<p>
 				{
 					translate( 'We have filled your account with credits so you can retry the failed purchases. ' +
-						'If the problem persists, please don\'t hesitate to contact support!'
+						'If the problem persists, please don\'t hesitate to {{a}}contact support{{/a}}!',
+						{
+							components: {
+								a: <a href={ support.CALYPSO_CONTACT } target="_blank" rel="noopener noreferrer" />
+							}
+						}
 					)
 				}
 			</p>
-		</div>;
-	}
+		</div>
+	);
 
 	return (
 		<div>
@@ -58,7 +68,7 @@ const FailedPurchase = ( { failedPurchases, translate } ) => {
 				<div className="checkout-thank-you__domain-mapping-details">
 					<PurchaseDetail
 						icon="redo"
-						description={ getDescription() }
+						description={ description }
 						target="_blank"
 						rel="noopener noreferrer"
 						isRequired />

--- a/client/my-sites/upgrades/checkout-thank-you/failed-purchase.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/failed-purchase.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
 import React from 'react';
 
 /**
@@ -12,10 +11,6 @@ import { localize } from 'i18n-calypso';
 import PurchaseDetail from 'components/purchase-detail';
 
 const FailedPurchase = ( { failedPurchases, translate } ) => {
-	const classes = {
-		'checkout-thank-you__header': true,
-	};
-
 	const description = (
 		<div>
 			<p>
@@ -27,7 +22,7 @@ const FailedPurchase = ( { failedPurchases, translate } ) => {
 			</p>
 			<ul className="checkout-thank-you__domain-mapping-details-nameservers">
 				{ failedPurchases.map( item => {
-					return <li>{ item.productName }: { item.meta }</li>
+					return <li key={ `failed-purchase-${ item.productId }` }>{ item.productName }{ item.meta && `: ${ item.meta }` }</li>;
 				} ) }
 			</ul>
 			<p>
@@ -42,15 +37,15 @@ const FailedPurchase = ( { failedPurchases, translate } ) => {
 
 	return (
 		<div>
-			<div className={ classNames( classes ) }>
+			<div className="checkout-thank-you__header">
 				<div className="checkout-thank-you__header-content">
 						<span className="checkout-thank-you__header-icon">
-							<Gridicon icon="notice" size={ 72 }/>
+							<Gridicon icon="notice" size={ 72 } />
 						</span>
 
 					<div className="checkout-thank-you__header-copy">
 						<h1 className="checkout-thank-you__header-heading">
-							{ translate( 'Ooops...' ) }
+							{ translate( 'Ooops…' ) }
 						</h1>
 
 						<h2 className="checkout-thank-you__header-text">

--- a/client/my-sites/upgrades/checkout-thank-you/failed-purchase.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/failed-purchase.jsx
@@ -11,8 +11,8 @@ import { localize } from 'i18n-calypso';
 import PurchaseDetail from 'components/purchase-detail';
 
 const FailedPurchase = ( { failedPurchases, translate } ) => {
-	const description = (
-		<div>
+	function getDescription() {
+		return <div>
 			<p>
 				{
 					translate(
@@ -32,8 +32,8 @@ const FailedPurchase = ( { failedPurchases, translate } ) => {
 					)
 				}
 			</p>
-		</div>
-	);
+		</div>;
+	}
 
 	return (
 		<div>
@@ -58,7 +58,7 @@ const FailedPurchase = ( { failedPurchases, translate } ) => {
 				<div className="checkout-thank-you__domain-mapping-details">
 					<PurchaseDetail
 						icon="redo"
-						description={ description }
+						description={ getDescription() }
 						target="_blank"
 						rel="noopener noreferrer"
 						isRequired />

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import find from 'lodash/find';
+import { isEmpty, find } from 'lodash';
 import page from 'page';
 import React from 'react';
 import moment from 'moment';
@@ -50,6 +50,7 @@ import Main from 'components/main';
 import PersonalPlanDetails from './personal-plan-details';
 import PremiumPlanDetails from './premium-plan-details';
 import BusinessPlanDetails from './business-plan-details';
+import FailedPurchase from './failed-purchase';
 import PurchaseDetail from 'components/purchase-detail';
 import { getFeatureByKey, shouldFetchSitePlans } from 'lib/plans';
 import SiteRedirectDetails from './site-redirect-details';
@@ -57,7 +58,11 @@ import Notice from 'components/notice';
 import upgradesPaths from 'my-sites/upgrades/paths';
 
 function getPurchases( props ) {
-	return props.receipt.data.purchases;
+	return props.receipt.data && props.receipt.data.purchases;
+}
+
+function getFailedPurchases( props ) {
+	return props.receipt.data && props.receipt.data.failedPurchases;
 }
 
 function findPurchaseAndDomain( purchases, predicate ) {
@@ -144,8 +149,10 @@ const CheckoutThankYou = React.createClass( {
 	},
 
 	redirectIfThemePurchased() {
-		if ( this.props.receipt.hasLoadedFromServer && getPurchases( this.props ).every( isTheme ) ) {
-			const themeId = getPurchases( this.props )[ 0 ].meta;
+		const purchases = getPurchases( this.props );
+
+		if ( this.props.receipt.hasLoadedFromServer && ! isEmpty( purchases ) && purchases.every( isTheme ) ) {
+			const themeId = purchases[ 0 ].meta;
 			this.props.activatedTheme( 'premium/' + themeId, this.props.selectedSite.ID );
 
 			page.redirect( '/design/' + this.props.selectedSite.slug );
@@ -168,6 +175,8 @@ const CheckoutThankYou = React.createClass( {
 				const purchase = find( purchases, isGoogleApps );
 
 				page( upgradesPaths.domainManagementEmail( this.props.selectedSite.slug, purchase.meta ) );
+			} else {
+				page( `/stats/insights/${ this.props.selectedSite.slug }` );
 			}
 		} else {
 			page( `/stats/insights/${ this.props.selectedSite.slug }` );
@@ -176,10 +185,12 @@ const CheckoutThankYou = React.createClass( {
 
 	render() {
 		let purchases = null,
+			failedPurchases = null,
 			wasJetpackPlanPurchased = false,
 			wasOnlyDotcomPlanPurchased = false;
 		if ( this.isDataLoaded() && ! this.isGenericReceipt() ) {
 			purchases = getPurchases( this.props );
+			failedPurchases = getFailedPurchases(this.props );
 			wasJetpackPlanPurchased = purchases.some( isJetpackPlan );
 			wasOnlyDotcomPlanPurchased = purchases.every( isDotComPlan );
 		}
@@ -207,6 +218,12 @@ const CheckoutThankYou = React.createClass( {
 			);
 		}
 
+		let content = this.productRelatedMessages();
+
+		if ( ! isEmpty( failedPurchases ) ) {
+			content = <FailedPurchase failedPurchases={ failedPurchases } />
+		}
+
 		// standard thanks page
 		return (
 			<Main className="checkout-thank-you">
@@ -216,7 +233,7 @@ const CheckoutThankYou = React.createClass( {
 					backText={ this.translate( 'Back to my site' ) } />
 
 				<Card className="checkout-thank-you__content">
-					{ this.productRelatedMessages() }
+					{ content }
 				</Card>
 
 				<Card className="checkout-thank-you__footer">
@@ -286,7 +303,7 @@ const CheckoutThankYou = React.createClass( {
 			);
 		}
 
-		let purchases;
+		let purchases, failedPurchases;
 
 		if ( ! this.isGenericReceipt() ) {
 			purchases = getPurchases( this.props );
@@ -302,13 +319,15 @@ const CheckoutThankYou = React.createClass( {
 				<CheckoutThankYouFeaturesHeader
 					isDataLoaded={ this.isDataLoaded() }
 					isGenericReceipt={ this.isGenericReceipt() }
-					purchases={ purchases } />
+					purchases={ purchases }
+				/>
 
 				{ ComponentClass && (
 					<div className="checkout-thank-you__purchase-details-list">
 						<ComponentClass
 							domain={ domain }
 							purchases={ purchases }
+							failedPurchases={ failedPurchases }
 							registrarSupportUrl={ this.isGenericReceipt() ? null : primaryPurchase.registrarSupportUrl }
 							selectedSite={ selectedSite }
 							selectedFeature={ getFeatureByKey( this.props.selectedFeature ) }

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -58,7 +58,7 @@ import Notice from 'components/notice';
 import upgradesPaths from 'my-sites/upgrades/paths';
 
 function getPurchases( props ) {
-	return props.receipt.data.purchases;
+	return ( props.receipt.data && props.receipt.data.purchases ) || [];
 }
 
 function findPurchaseAndDomain( purchases, predicate ) {

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -1,16 +1,11 @@
 /**
  * External dependencies
  */
-const connect = require( 'react-redux' ).connect,
-	forEach = require( 'lodash/forEach' ),
-	find = require( 'lodash/find' ),
-	i18n = require( 'i18n-calypso' ),
-	isEmpty = require( 'lodash/isEmpty' ),
-	isEqual = require( 'lodash/isEqual' ),
-	page = require( 'page' ),
-	React = require( 'react' ),
-	reduce = require( 'lodash/reduce' ),
-	startsWith = require( 'lodash/startsWith' );
+import { connect } from 'react-redux';
+import { flatten, find, isEmpty, isEqual, reduce, startsWith } from 'lodash';
+import i18n from 'i18n-calypso';
+import page from 'page';
+import React from 'react';
 
 /**
  * Internal dependencies
@@ -168,20 +163,14 @@ const Checkout = React.createClass( {
 	},
 
 	/**
-	 * Purchases are of the format { [siteId]: [ { product_id: ... } ] },
+	 * Purchases are of the format { [siteId]: [ { productId: ... } ] }
 	 * so we need to flatten them to get a list of purchases
 	 *
-	 * @param purchases
-	 * @returns {Array}
+	 * @param {Object} purchases keyed by siteId { [siteId]: [ { productId: ... } ] }
+	 * @returns {Array} of product objects [ { productId: ... }, ... ]
 	 */
 	flattenPurchases: function( purchases ) {
-		let flatPurchases = [];
-
-		forEach( purchases, sitePurchases => {
-			flatPurchases = flatPurchases.concat( sitePurchases );
-		} );
-
-		return flatPurchases;
+		return flatten( Object.values( purchases ) );
 	},
 
 	getCheckoutCompleteRedirectPath: function() {

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -167,13 +167,16 @@ const Checkout = React.createClass( {
 		return true;
 	},
 
-	getPurchasesFromReceipt: function() {
-		const purchases = this.props.transaction.step.data.purchases;
-
+	/**
+	 * Purchases are of the format { [siteId]: [ { product_id: ... } ] },
+	 * so we need to flatten them to get a list of purchases
+	 *
+	 * @param purchases
+	 * @returns {Array}
+	 */
+	flattenPurchases: function( purchases ) {
 		let flatPurchases = [];
 
-		// purchases are of the format { [siteId]: [ { product_id: ... } ] },
-		// so we need to flatten them to get a list of purchases
 		forEach( purchases, sitePurchases => {
 			flatPurchases = flatPurchases.concat( sitePurchases );
 		} );
@@ -247,7 +250,8 @@ const Checkout = React.createClass( {
 
 			this.props.fetchReceiptCompleted( receiptId, {
 				receiptId: receiptId,
-				purchases: this.getPurchasesFromReceipt()
+				purchases: this.flattenPurchases( this.props.transaction.step.data.purchases ),
+				failedPurchases: this.flattenPurchases( this.props.transaction.step.data.failed_purchases ),
 			} );
 		}
 

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -215,7 +215,7 @@ module.exports = {
 	},
 
 	checkoutThankYou: function( context ) {
-		var CheckoutThankYouComponent = require( './checkout-thank-you' ),
+		const CheckoutThankYouComponent = require( './checkout-thank-you' ),
 			basePath = route.sectionify( context.path ),
 			receiptId = Number( context.params.receiptId );
 

--- a/client/state/receipts/assembler.js
+++ b/client/state/receipts/assembler.js
@@ -12,8 +12,17 @@ export function createReceiptObject( data ) {
 				productName: purchase.product_name,
 				productNameShort: purchase.product_name_short,
 				registrarSupportUrl: purchase.registrar_support_url,
-				isEmailVerified: Boolean( purchase.is_email_verified )
+				isEmailVerified: Boolean( purchase.is_email_verified ),
 			};
-		} )
+		} ),
+		failedPurchases: data.failedPurchases && data.failedPurchases.map( purchase => {
+			return {
+				meta: purchase.product_meta,
+				productId: purchase.product_id,
+				productCost: purchase.product_cost,
+				productSlug: purchase.product_slug,
+				productName: purchase.product_name,
+			};
+		} ),
 	};
 }

--- a/client/state/receipts/assembler.js
+++ b/client/state/receipts/assembler.js
@@ -12,16 +12,16 @@ export function createReceiptObject( data ) {
 				productName: purchase.product_name,
 				productNameShort: purchase.product_name_short,
 				registrarSupportUrl: purchase.registrar_support_url,
-				isEmailVerified: Boolean( purchase.is_email_verified ),
+				isEmailVerified: Boolean( purchase.is_email_verified )
 			};
 		} ),
-		failedPurchases: data.failedPurchases && data.failedPurchases.map( purchase => {
+		failedPurchases: data.failedPurchases.map( purchase => {
 			return {
 				meta: purchase.product_meta,
 				productId: purchase.product_id,
 				productCost: purchase.product_cost,
 				productSlug: purchase.product_slug,
-				productName: purchase.product_name,
+				productName: purchase.product_name
 			};
 		} ),
 	};

--- a/client/state/receipts/assembler.js
+++ b/client/state/receipts/assembler.js
@@ -15,7 +15,7 @@ export function createReceiptObject( data ) {
 				isEmailVerified: Boolean( purchase.is_email_verified )
 			};
 		} ),
-		failedPurchases: data.failedPurchases.map( purchase => {
+		failedPurchases: ( data.failedPurchases || [] ).map( purchase => {
 			return {
 				meta: purchase.product_meta,
 				productId: purchase.product_id,


### PR DESCRIPTION
We just show an empty Thank You page when we fail to obtain purchases and refund the user.

Tell the user what happened and show a list of products we failed to obtain.

Test:
1. Buy a domain and change the back-end to fail the registration.
2. You should see a page telling you what happened:
Before:
![failed purchases before](https://cloud.githubusercontent.com/assets/1103398/21574473/af8bde22-cef3-11e6-9c6a-b9f7d2feb0f1.png)

After:
![failed purchases](https://cloud.githubusercontent.com/assets/1103398/21574475/b2f8b4fe-cef3-11e6-8acd-b03eedcddc56.png)

Dependency: D3822-code