### PR TITLE
Documentation: Add markdown syntax highlighting to code blocks

### DIFF
--- a/client/blocks/upgrade-nudge-expanded/README.md
+++ b/client/blocks/upgrade-nudge-expanded/README.md
@@ -17,7 +17,7 @@ It's meant to comprehensivly describe a plan and give enough reasons to upgrade.
 
 ## Example - minimal
 
-```
+```jsx
 <UpgradeNudgeExpanded
 	plan={ PLAN_BUSINESS }
 	title={ this.translate( 'Upgrade to a Business Plan and Enable Advanced SEO' ) }

--- a/client/components/data/query-active-theme/README.md
+++ b/client/components/data/query-active-theme/README.md
@@ -7,7 +7,7 @@ Query Active Theme is a React component used in managing fetching of a given sit
 
 Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
-```
+```jsx
 import React from 'react';
 import { connect } from 'react-redux';
 import QueryActiveTheme from 'components/data/query-active-theme';

--- a/client/components/data/query-theme/README.md
+++ b/client/components/data/query-theme/README.md
@@ -7,7 +7,7 @@ Query Theme is a React component used in managing the fetching of individual the
 
 Render the component, passing `siteId` and `themeId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
-```
+```jsx
 import React from 'react';
 import { connect } from 'react-redux';
 import QueryTheme from 'components/data/query-theme';

--- a/client/components/empty-content/README.md
+++ b/client/components/empty-content/README.md
@@ -53,7 +53,7 @@ The component also supports a secondary action. This should be used sparingly.
 
 ### Example: Sites
 
-```
+```es6
 ReactDom.render(
 	EmptyContentComponent({
 		title: "You don't have any WordPress sites yet.",

--- a/client/components/empty-content/README.md
+++ b/client/components/empty-content/README.md
@@ -5,7 +5,7 @@ This module provides a consistent rendering component for empty content cases in
 
 ## Usage
 
-```js
+```jsx
 
 // require the component
 var EmptyContentComponent = require( 'components/empty-content' );

--- a/client/components/forms/README.md
+++ b/client/components/forms/README.md
@@ -36,7 +36,7 @@ The `FormInputValidation` component is used to display a validation notice to th
 ### SelectOptGroups
 `SelectOptGroups` allows you to pass structured data to render a select element with `<option>` elements nested inside `<optgroup>` separators. You can use it like this:
 
-```
+```jsx
 var options = [
 	{
 		label: 'Group 1',
@@ -72,7 +72,7 @@ initialSelected = 3;
 
 And this would render:
 
-```
+```html
 <select name="example">
 	<optgroup label="Group 1">
 		<option value="1">Option 1</option>

--- a/client/components/forms/multi-checkbox/README.md
+++ b/client/components/forms/multi-checkbox/README.md
@@ -7,7 +7,7 @@ MultiCheckbox is a React component that can be used in forms to simplify the cre
 
 Below is an example use for the MultiCheckbox component:
 
-```
+```jsx
 var options = [
 	{ value: 1, label: 'One' },
 	{ value: 2, label: 'Two' }

--- a/client/lib/analytics/track-component-view/README.md
+++ b/client/lib/analytics/track-component-view/README.md
@@ -12,7 +12,7 @@ Render the component passing one or both of:
 - Tracks: An `eventName` string and `eventProperties` object
 - MC Stats: `statGroup` and `statName` strings
 
-```
+```jsx
 <ContainerComponent>
 	<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
 </ContainerComponent>

--- a/client/lib/application-passwords-data/README.md
+++ b/client/lib/application-passwords-data/README.md
@@ -3,7 +3,7 @@ Application Passwords Data
 
 This component is a wrapper module for interacting with the wpcom.js `/me` endpoint to retrieve, create, and delete  application passwords for the current user.
 
-```
+```es6
 var AppPasswords = require( 'lib/application-passwords-data' );
 ```
 

--- a/client/lib/connected-applications-data/README.md
+++ b/client/lib/connected-applications-data/README.md
@@ -3,7 +3,7 @@ Connected Applications Data
 
 This component is a wrapper module for interacting with the wpcom.js `/me` endpoint to retrieve a list of connected applications as well as revoke an application's access.
 
-```
+```es6
 var ConnectedApplications = require( 'lib/connected-applications-data' );
 ```
 

--- a/client/lib/detect-history-navigation/README.md
+++ b/client/lib/detect-history-navigation/README.md
@@ -5,7 +5,7 @@ This module determines when a page has been rendered via the history event (back
 
 This can be used alongside the [page.js module](https://www.npmjs.com/package/page) by calling the `start()` method of this module _prior_ to the `start()` method of `page.js`.
 
-```
+```es6
 var page = require( 'page' ),
     detectHistoryNavigation = require( 'detect-history-navigation' );
 

--- a/client/lib/deterministic-stringify/README.md
+++ b/client/lib/deterministic-stringify/README.md
@@ -7,7 +7,7 @@ One important difference between using this module and using node.js's `queystri
 
 This is useful for obtaining a deterministic namespace for query options so that two equivalent queries resolve to the same namespace.
 
-```
+```js
 deterministicStringify( true ); // true
 deterministicStringify( 1 ); // 1
 deterministicStringify( false ); // false

--- a/client/lib/devices/README.md
+++ b/client/lib/devices/README.md
@@ -3,6 +3,6 @@ Current User Devices
 
 This component is a wrapper module for interacting with `wpcom.undocumented().me` to retrieve the current user's devices.
 
-```
+```es6
 import devices from 'lib/devices';
 ```

--- a/client/lib/email-followers/README.md
+++ b/client/lib/email-followers/README.md
@@ -26,7 +26,7 @@ Fetches followers in batches of 100 starting from the given page, which defaults
 
 ###Example Component Code
 
-```
+```es6
 /**
  * External dependencies
  */

--- a/client/lib/followers/README.md
+++ b/client/lib/followers/README.md
@@ -26,7 +26,7 @@ Fetches followers in batches of 100 starting from the given page, which defaults
 
 ###Example Component Code
 
-```
+```es6
 /**
  * External dependencies
  */

--- a/client/lib/local-list/README.md
+++ b/client/lib/local-list/README.md
@@ -4,7 +4,7 @@ Adds local storage caching for api results.  With LocalList, other `list` module
 
 The LocalList creates an array of objects to cache API payloads.  An object itself looks like the following:
 
-```
+```js
 {
 	key: 'someKeyName', // the key sent in calls to set( key, value )
 	createdAt: timestamp, // a timestamp of when this record was saved locally for use in expiring cache or fetch()ing new data
@@ -22,11 +22,15 @@ Setup
 =====
 First require the module:
 
-`LocalList = require( 'local-list' )`
+```es6
+LocalList = require( 'local-list' )
+```
 
 Then create an instance of LocalList:
 
-`this.local = LocalList( { localStoreKey: 'keyUsedInLocalStorage', limit: 25 } );`
+```es6
+this.local = LocalList( { localStoreKey: 'keyUsedInLocalStorage', limit: 25 } );
+```
 
 The configuration options are:
 
@@ -47,7 +51,7 @@ Deletes any local storage for this key, and sets it to an empty array.
 ## set( key, value )
 Saves a record to the local storage array:
 
-```
+```js
 {
 	key: key,
 	createdAt: timestamp,

--- a/client/lib/local-storage/README.md
+++ b/client/lib/local-storage/README.md
@@ -3,7 +3,7 @@ local-storage
 
 This is a very simple polyfill that implements the core methods of localStorage when the native API is either unavailable or not working correctly (e.g., safari in private mode):
 
-```
+```js
 localStorage.setItem( key, value )
 localStorage.getItem( key )
 localStorage.removeItem( key )
@@ -13,6 +13,6 @@ localStorage.length
 
 Just require and call this once into the page (prior to any calls to these methods) and it will either create or augment the `window.localStorage` object as necessary.
 
-```
+```es6
 var localStoragePolyfill = require( 'lib/local-storage' )();
 ```

--- a/client/lib/localforage/README.md
+++ b/client/lib/localforage/README.md
@@ -5,7 +5,7 @@ This exports a localforage proxy object that ensures our configuration has been 
 
 ## Usage:
 
-```
+```es6
 import localforage from 'lib/localforage';
 
 //use localforage as you would normally

--- a/client/lib/mixins/dirty-linked-state/README.md
+++ b/client/lib/mixins/dirty-linked-state/README.md
@@ -10,7 +10,7 @@ Usage
 
 Enable this per component by adding it to its `mixins`:
 
-```
+```jsx
 import dirtyLinkedState from ("lib/mixins/dirty-linked-state");
 app.TodoItem = React.createClass( {
     mixins: [ dirtyLinkedState ],
@@ -26,7 +26,7 @@ Example
 -----
 Before the user types in the field the state object might look like:
 
-```
+```js
 { 
 	blogname: 'default title',
 	blogdescription: 'default description'
@@ -35,7 +35,7 @@ Before the user types in the field the state object might look like:
 
 After typing:
 
-```
+```js
 {
 	blogname: 'new title',
 	blogdescription: 'default description',

--- a/client/lib/mixins/searchable/README.md
+++ b/client/lib/mixins/searchable/README.md
@@ -7,7 +7,7 @@ Pass the collections prototype into Searchable, along with an object to specify 
 
 Adding mixin to a Collection:
 
-```
+```js
 // SomeCollection module
 
 /**
@@ -43,7 +43,7 @@ module.exports = SomeCollection;
 
 Example usage:
 
-```
+```js
 var list = require( 'some-collection' )(),
     results = list.search( 'test' );
 ```
@@ -52,7 +52,7 @@ When you add the mixin, you need to pass in a set of `searchNodes` where you spe
 
 The `searchNodes` parameter is an array that contains strings (for each single node) and/or or a javascript object (to reach a nested node). Objects contain arrays that describe the searchable nodes at the nested level. Nesting can go as deep as you want. An example is in order:
 
-```
+```js
 /*
     given a set of items that looks like this:
  */

--- a/client/lib/mixins/url-search/README.md
+++ b/client/lib/mixins/url-search/README.md
@@ -9,7 +9,7 @@ You would add this mixin to the component that _contains_ the search component, 
 
 In your controller method, retrieve the search parameter from the URL and pass that into the component as a `search` prop. You also need to pass the context object itself into the component:
 
-```
+```js
 var search = search = qs.parse( context.querystring ).s;
 
 ReactDom.render(
@@ -23,7 +23,7 @@ ReactDom.render(
 
 Then in the component, apply the mixin:
 
-```
+```js
 /**
  * Internal dependencies
  */
@@ -39,7 +39,7 @@ module.exports = React.createClass({
 
 Then within your render method, apply the following properties to the `Search` component; `onSearch`, `initialValue`, and `ref` (with a value of "url-search").
 
-```
+```jsx
 	render: function() {
 
 		return (
@@ -49,7 +49,7 @@ Then within your render method, apply the following properties to the `Search` c
 
 _If_ your search component should only be displayed dynamically, you can use `this.getSearchOpen()` to determine whether the search should be open or closed, like so:
 
-```
+```jsx
 	render: function() {
 
 		var containerClass = classNames( {

--- a/client/lib/paygate-loader/README.md
+++ b/client/lib/paygate-loader/README.md
@@ -3,7 +3,7 @@ Paygate Loader
 
 `Paygate` is a library we can use to send Credit card data to the Paygate server and recieve back a token which we then submit to MoneyPress. This class, `PaygateLoader`, takes care of the details of loading the remote `paygate.js` script asynchronously. You can access the `Paygate` class from within the callback of `PaygateLoader.ready` like so:
 
-```
+```es6
 var paygateLoader = require( 'lib/paygate-loader' );
 
 function onSuccess( token ) {

--- a/client/lib/perfmon/README.md
+++ b/client/lib/perfmon/README.md
@@ -17,7 +17,7 @@ You can enable this in development by running `ENABLE_FEATURES=perfmon make run`
 
 You can see how many active placeholders (visible and non visible) there detected during each check by running this in your console:
 
-```
+```js
 localStorage.setItem('debug', 'calypso:perfmon')
 ```
 

--- a/client/lib/plugins/README.md
+++ b/client/lib/plugins/README.md
@@ -9,7 +9,7 @@ The Plugins Store is responsible for keeping each site's plugin list up to date.
 ####The Data
 The Data that is stored in the sites plugin store looks like this:
 
-```
+```js
 {
 	123456 : { // site.ID
 		akismet : { // plugin.slug
@@ -77,7 +77,7 @@ Returns an array of sites that have a particular plugin.
 
 ####Example Component Code:
 
-```
+```es6
 /**
  * External dependencies
  */
@@ -180,7 +180,7 @@ Toggle AutoUpdates for a plugin on a site.
 
 ####Example Component Code:
 
-```
+```es6
 /**
  * External dependencies
  */

--- a/client/lib/plugins/README.md
+++ b/client/lib/plugins/README.md
@@ -180,7 +180,7 @@ Toggle AutoUpdates for a plugin on a site.
 
 ####Example Component Code:
 
-```es6
+```jsx
 /**
  * External dependencies
  */

--- a/client/lib/plugins/wporg-data/README.md
+++ b/client/lib/plugins/wporg-data/README.md
@@ -105,7 +105,7 @@ Triggers api call to fetch the plugin data and update the store.
 
 ####Example Component Code:
 
-```es6
+```jsx
 /**
  * External dependencies
  */

--- a/client/lib/plugins/wporg-data/README.md
+++ b/client/lib/plugins/wporg-data/README.md
@@ -8,7 +8,7 @@ The WPorg Store is responsible for storing the state of plugins from .org so tha
 ####The Data
 The data that is stored in the store looks like this:
 
-```
+```js
 {
 	akismet : { // plugin.slug
 		author: "Automattic",
@@ -46,7 +46,7 @@ Returns a plugin object or null
 
 ####Example Component Code:
 
-```
+```es6
 /**
  * External dependencies
  */
@@ -105,7 +105,7 @@ Triggers api call to fetch the plugin data and update the store.
 
 ####Example Component Code:
 
-```
+```es6
 /**
  * External dependencies
  */

--- a/client/lib/posts/README.md
+++ b/client/lib/posts/README.md
@@ -16,7 +16,7 @@ Caches lists hashed by query. When a new active query is set with the `queryPost
 ## post-counts-store.js
 Keeps track of the number of posts in the active site (a part of the active query) for an authorship scope ('all' or 'mine') and status ('draft', 'publish' etc.).
 Example: `PostCountsStore.get(siteId, 'all')` would return an object like this:
-```
+```js
 {
   "draft": 9
   "publish": 677
@@ -27,7 +27,7 @@ Example: `PostCountsStore.get(siteId, 'all')` would return an object like this:
 ## post-content-images-store.js
 Stores post images hashed by post id.
 `PostContentImagesStore.getAll()` would return an object like this:
-```
+```js
 {
   "7830aeb03d8a434d1ef2afc837c6ae81": {
     "content_images": [...],

--- a/client/lib/products-list/README.md
+++ b/client/lib/products-list/README.md
@@ -3,7 +3,7 @@ Products List
 
 `products-list` is a collection of all the products users can have on WordPress.com, as returned from the `/products` REST API endpoint. It can be required into a file like:
 
-```
+```es6
 var productsList = require( 'lib/products-list' )();
 ```
 

--- a/client/lib/protect-form/README.md
+++ b/client/lib/protect-form/README.md
@@ -6,25 +6,25 @@ This [Higher Order Component](https://medium.com/@dan_abramov/mixins-are-dead-lo
 Usage
 -----
 
-```
+```es6
 import { protectForm } from 'lib/protect-form';
 ```
 
 ... and then later in your component definition like so:
 
-```
-    export default protectForm( MyComponent );
+```es6
+export default protectForm( MyComponent );
 ```
 
 The protect-form HoC provides a `markChanged` prop you can call on the `onChange` event of your form like this:
 
-```
+```jsx
 <form onChange={ this.props.markChanged } onSubmit={ this.handleSubmit }>
 ```
 
 And then very important, you also need to to call the second prop `markSaved` when your form has been successfully submitted. Here is an example onSubmit callback handler.
 
-```
+```es6
     submitForm( event ) {
         event.preventDefault();
         this.saveSettings( this.state ).then( () => {

--- a/client/lib/react-pass-to-children/README.md
+++ b/client/lib/react-pass-to-children/README.md
@@ -7,7 +7,7 @@ Pass to Children is a utility method to assist in creating a React pass-through 
 
 The exposed method expects to receive the current react element instance, and an object of props to pass to the child in addition to the props of the instance itself.
 
-```
+```es6
 var React = require( 'react' ),
 	passToChildren = require( 'lib/react-pass-to-children' );
 

--- a/client/lib/route/README.md
+++ b/client/lib/route/README.md
@@ -9,13 +9,13 @@ Sometimes you want to enforce a canonical URL to a resource. You can use `normal
 as middleware to redirect any pathname ending in `/` to the same path minus the `/`.
 For instance, to redirect `/foo/` to `/foo`:
 
-```javascript
+```es6
 var normalize = require( 'lib/route/normalize' );
 page('/foo/?', normalize, displayFoo );
 ```
 
 Alternatively, to normalize all routes:
-```javascript
+```es6
 var normalize = require( 'normalize' );
 page( '*', normalize );
 ```
@@ -32,7 +32,7 @@ This module is meant to simplify the work of adding query arguments to a URL.
 
 
 #### Example
-```
+```es6
 import addQueryArgs from 'lib/route/add-query-args';
 
 addQueryArgs( { foo: 'bar' }, 'https://wordpress.com' );             // https://wordpress.com?foo=bar

--- a/client/lib/scroll-to/README.md
+++ b/client/lib/scroll-to/README.md
@@ -3,7 +3,7 @@ scroll-to
 A utility module to smoothly scroll to a window position.
 
 ## Usage
-```
+```es6
 import scrollTo from 'lib/scroll-to'; 
 
 scrollTo({

--- a/client/lib/shortcodes/README.md
+++ b/client/lib/shortcodes/README.md
@@ -9,7 +9,7 @@ A single action is made available, `fetch`, which accepts a site ID and shortcod
 
 Here's the typical structure of a store:
 
-```
+```js
 {
 	77203074: {
 		"[gallery ids=\"1,2,3\"]": {

--- a/client/lib/site-stats-sticky-tab/README.md
+++ b/client/lib/site-stats-sticky-tab/README.md
@@ -8,7 +8,7 @@ This enables us to provide direct links to where users were inside their Site St
 ### usage
 * To save the state:
 
-```
+```es6
 var siteStatsStickyTabActions = require( 'lib/site-stats-sticky-tab/actions' );
 /* ...component lifecycle methods: */
 {

--- a/client/lib/stats/stats-list/README.md
+++ b/client/lib/stats/stats-list/README.md
@@ -4,13 +4,13 @@ The `StatsList` module aims to replace all the individual list modules that have
 
 To create an instance of a `StatsList`, you must pass in both a `siteID` and `statType` option.  `statType` is essentially the same as the endpoint name in `wpcom.js`:
 
-```
+```es6
 var clicksList = new StatsList( { siteID: 123, statType: 'statsClicks' } );
 ```
 
 Any additional options passed in are added as options to the api request so the following list would add in a `period` and `max` keys to the api call:
 
-```
+```es6
 var clicksList = new StatsList( { siteID: 123, statType: 'statsClicks', period: 'day', max: 10 } );
 ```
 

--- a/client/lib/store-transactions/README.md
+++ b/client/lib/store-transactions/README.md
@@ -11,7 +11,7 @@ This module contains functions for creating WordPress.com Store transactions usi
 
 ### User with a Stored Card
 
-```
+```es6
 var steps = submit({
 	cart: <CartValue>,
 	payment: {
@@ -23,7 +23,7 @@ var steps = submit({
 
 ### User with a New Card
 
-```
+```es6
 var steps = submit({
 	cart: <CartValue>,
 	payment: {
@@ -41,7 +41,7 @@ var steps = submit({
 
 ### User Paying Fully with Credits
 
-```
+```es6
 var steps = submit({
 	cart: <CartValue>,
 	payment: {

--- a/client/lib/two-step-authorization/README.md
+++ b/client/lib/two-step-authorization/README.md
@@ -3,6 +3,6 @@ Two Step Authorization
 
 This component is meant to be used with `client/me/reauth-required`, and is used to display a dialog that allows a user to reauthorize without logging out and back in.
 
-```
+```es6
 var TwoStepAuthorization = require( 'lib/two-step-authorization' );
 ```

--- a/client/lib/user/README.md
+++ b/client/lib/user/README.md
@@ -4,7 +4,7 @@ Current User
 This component is a wrapper module for interacting with the wpcom.js `/me` endpoint to expose current user object and related methods. User info is currently stored in localstorage.
 
 ## User
-```
+```es6
 var user = require( 'lib/user' )();
 ```
 
@@ -21,7 +21,7 @@ Currently will just check for local cached data and return it if present.
 Clears user stored data and handles relevant redirects based on type of authentication.
 
 ## UserUtilities
-```
+```es6
 var user = require( 'lib/user/utilities' );
 ```
 

--- a/client/lib/users/README.md
+++ b/client/lib/users/README.md
@@ -29,7 +29,7 @@ Actions get triggered by views and stores.
 
 `options` is an object that describes any custom query params you want to pass into the `wpcom.js` [usersList method](https://github.com/Automattic/wpcom.js/blob/master/docs/site.md#siteuserslistquery-fn) which passes parameters into the REST API [`/site/$site/users` endpoint](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/users/). The only required attribute is siteId. Current default values include:
 
-```
+```js
 {
 	number: 100,
 	offset: 0
@@ -38,7 +38,7 @@ Actions get triggered by views and stores.
 
 ###Example Component Code
 
-```
+```es6
 /**
  * External dependencies
  */

--- a/client/lib/viewport/README.md
+++ b/client/lib/viewport/README.md
@@ -5,7 +5,7 @@ This module contains functions to identify the current viewport. This can be use
 
 ### Usage
 
-```
+```es6
 var viewport = require( 'viewport' );
 
 if ( viewport.isDesktop() ) {

--- a/client/my-sites/jetpack-manage-error-page/README.md
+++ b/client/my-sites/jetpack-manage-error-page/README.md
@@ -17,7 +17,7 @@ To display a page that will prompt the user to update Jetpack.
 You'll need to declare `site` which is simply the current site object.
 You can optionally declare `version` to display what version is necessary (defaults to 3.4).
 
-```
+```jsx
 JetpackManageErrorPage = require( 'my-sites/jetpack-manage-error-page' );
 
 <JetpackManageErrorPage
@@ -31,7 +31,7 @@ JetpackManageErrorPage = require( 'my-sites/jetpack-manage-error-page' );
 
 To display a page that will prompt the user to opt-in to Jetpack manage:
 
-```
+```jsx
 <JetpackManageErrorPage
     template="optInManage"
     site={ this.props.site }
@@ -47,7 +47,7 @@ As stated above, this component renders an `emptyContent` component by default. 
 If you initialize the component with a property `featureExample` containing jsx, it will be added in the bottom of the Jetpack Manage Error Page as an example of what the user could be viewing if there weren't any access errors.
 
 
-```
+```jsx
 JetpackManageErrorPage = require( 'my-sites/jetpack-manage-error-page' );
 
 // create the component using properties accepted by EmptyContent

--- a/client/my-sites/stats/README.md
+++ b/client/my-sites/stats/README.md
@@ -52,7 +52,7 @@ Stats List Markup
 We have spent quite a bit of time to create an extensive set of markup for stats lists that provide hooks for default actions, and action menus depending on screen size.  Below is some example markup:
 
 ### A Generic Stats List Item - No Action
-```
+```html
 <li className="module-content-list-item module-content-list-item-normal">
 	<span className="module-content-list-item-wrapper">
 		<span className="module-content-list-item-right">
@@ -64,7 +64,7 @@ We have spent quite a bit of time to create an extensive set of markup for stats
 ```
 
 ### Stats List Item - Link Row Action
-```
+```html
 <li className="module-content-list-item module-content-list-item-link">
 	<span className="module-content-list-item-wrapper">
 		<span className="module-content-list-item-right">
@@ -76,7 +76,7 @@ We have spent quite a bit of time to create an extensive set of markup for stats
 ```
 
 ### Stats List Item - With Additional Action Buttons
-```
+```html
 <li className="module-content-list-item module-content-list-item-link">
 	<span className="module-content-list-item-wrapper">
 		<span className="module-content-list-item-right">
@@ -92,7 +92,7 @@ We have spent quite a bit of time to create an extensive set of markup for stats
 ```
 
 ### Kitchen Sink Example - Avatars, icons in Labels, Nested Lists
-```
+```html
 <li className="module-content-list-item module-content-list-item-link module-content-list-item-large module-content-list-item-toggle is-expanded">
 	<span className="module-content-list-item-wrapper">
 		<span className="module-content-list-item-right">

--- a/client/state/preferences/README.md
+++ b/client/state/preferences/README.md
@@ -8,7 +8,7 @@ They are persisted in `calypso_preferences` key of `/me/settings`.
 
 1. Render `QueryPreferences` from `components/data/query-preferences`
 2. Connect your component specifying proper option keys:
-```
+```es6
 export default connect(
 	( state ) => {
 		return {


### PR DESCRIPTION
While looking over the mixins / HoCs usage I noticed that one of the files could have benefited from syntax highlighting in the `readme` markdown. I went on a bit of a rampage and looked for any code blocks that were missing syntax highlighting and added in the syntax that made sense to me...

The _'rules'_ that I used to determine which syntax to use (with the option of `js`, `jsx` and `es6`) were something like this:
`js` - mostly just for basic objects on their own, i.e:
```js
{
    something: 'objecty',
}
```

`jsx` - this ones quite obvious -use if the block includes `<Jsx />` 

`es6` pretty much anything else that _could_ include es6 syntax... even if it's currently < es6

I've also refrained from doing anything other than adding the ` ```syntax ` to the code blocks in these docs - as tempting as it was to go on an even bigger refactoring rampage!

'Testing' should be very easy here, please just take a look at each `readme` and make sure the syntax highlighting makes sense. If you think any code block should be tagged with a different syntax just holla and I'll make a change!

Also, regarding the refactoring of these `readme`s - I'm quite keen to update any that are not on their way out (mixins hopefully?) - I'll open a separate issue and include the list that I made of the files that could use a face-lift :D

In case you're not convinced...

```
<UpgradeNudgeExpanded
    plan={ PLAN_BUSINESS }
    title={ this.translate( 'Upgrade to a Business Plan and Enable Advanced SEO' ) }
    subtitle={ this.translate( 'By upgrading to a Business Plan you\'ll enable advanced SEO features on your site.' ) }
    highlightedFeature={ FEATURE_ADVANCED_SEO }
    benefits={ [
        this.translate( "Preview your site's posts and pages as they will appear when shared on Facebook, Twitter and the WordPress.com Reader." ),
        this.translate( 'Allow you to control how page titles will appear on Google search results, or when shared on social networks.' ),
        this.translate( 'Modify front page meta data in order to customize how your site appears to search engines.' )
    ] }
/>
```

becomes:

```jsx
<UpgradeNudgeExpanded
    plan={ PLAN_BUSINESS }
    title={ this.translate( 'Upgrade to a Business Plan and Enable Advanced SEO' ) }
    subtitle={ this.translate( 'By upgrading to a Business Plan you\'ll enable advanced SEO features on your site.' ) }
    highlightedFeature={ FEATURE_ADVANCED_SEO }
    benefits={ [
        this.translate( "Preview your site's posts and pages as they will appear when shared on Facebook, Twitter and the WordPress.com Reader." ),
        this.translate( 'Allow you to control how page titles will appear on Google search results, or when shared on social networks.' ),
        this.translate( 'Modify front page meta data in order to customize how your site appears to search engines.' )
    ] }
/>
```

So much prettier! 💅

TIA!