### PR TITLE
Publicize: Better handle all sites view

### DIFF
--- a/client/my-sites/posts/post-share.jsx
+++ b/client/my-sites/posts/post-share.jsx
@@ -12,9 +12,8 @@ import SocialLogo from 'social-logos';
  */
 import QueryPostTypes from 'components/data/query-post-types';
 import Button from 'components/button';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { postTypeSupports } from 'state/post-types/selectors';
-import { isJetpackModuleActive } from 'state/sites/selectors';
+import { isJetpackModuleActive, getSiteSlug } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getSiteUserConnections } from 'state/sharing/publicize/selectors';
 import { fetchConnections as requestConnections, sharePost, dismissShareConfirmation } from 'state/sharing/publicize/actions';
@@ -210,7 +209,7 @@ const PostSharing = React.createClass( {
 
 export default connect(
 	( state, props ) => {
-		const siteId = getSelectedSiteId( state );
+		const siteId = props.site.ID;
 		const userId = getCurrentUserId( state );
 		const postType = props.post.type;
 		const isPublicizeEnabled = (
@@ -219,7 +218,7 @@ export default connect(
 		);
 
 		return {
-			siteSlug: getSelectedSiteSlug( state ),
+			siteSlug: getSiteSlug( state, siteId ),
 			siteId,
 			isPublicizeEnabled,
 			connections: getSiteUserConnections( state, siteId, userId ),


### PR DESCRIPTION
On all sites View, in the post section, "Share" was using bad site id.
Because of this, by @ryanboren : 
> Here’s what sharing looks like from the all posts view for a site that doesn’t have publicize connected. Click settings.
> That takes me to https://wpcalypso.wordpress.com/sharing/null

## testing instructions

- go to /posts/my
- Find a post from site where NO sharing account is connected
- Click Share under a post
- When you see "no social accounts connected", click "Settings"
- Verify that you are redirected to sharing settings of a proper site
