### PR TITLE
Publicize: connections loading placeholder

### DIFF
--- a/client/my-sites/posts/post-share.jsx
+++ b/client/my-sites/posts/post-share.jsx
@@ -15,7 +15,7 @@ import Button from 'components/button';
 import { postTypeSupports } from 'state/post-types/selectors';
 import { isJetpackModuleActive, getSiteSlug } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
-import { getSiteUserConnections } from 'state/sharing/publicize/selectors';
+import { getSiteUserConnections, hasFetchedConnections } from 'state/sharing/publicize/selectors';
 import { fetchConnections as requestConnections, sharePost, dismissShareConfirmation } from 'state/sharing/publicize/actions';
 import { isRequestingSharePost, sharePostFailure, sharePostSuccessMessage } from 'state/sharing/publicize/selectors';
 import PostMetadata from 'lib/post-metadata';
@@ -33,6 +33,7 @@ const PostSharing = React.createClass( {
 		siteId: PropTypes.number,
 		isPublicizeEnabled: PropTypes.bool,
 		connections: PropTypes.array,
+		hasFetchedConnections: PropTypes.bool,
 		requestConnections: PropTypes.func
 	},
 
@@ -156,7 +157,13 @@ const PostSharing = React.createClass( {
 							} ) }
 						</div>
 					</div>
-					{ this.hasConnections() && <div>
+					{ ! this.props.hasFetchedConnections && <div className="posts__post-share-main">
+						<div className="posts__post-share-form is-placeholder">
+						</div>
+						<div className="posts__post-share-services is-placeholder">
+						</div>
+					</div> }
+					{ this.props.hasFetchedConnections && this.hasConnections() && <div>
 						<div>
 							{ this.props.connections
 								.filter( connection => connection.status === 'broken' )
@@ -195,7 +202,7 @@ const PostSharing = React.createClass( {
 							</div>
 						</div>
 					</div> }
-					{ ! this.hasConnections() && <Notice status="is-warning" showDismiss={ false } text={ this.translate( 'Connect an account to get started.' ) }>
+					{ this.props.hasFetchedConnections && ! this.hasConnections() && <Notice status="is-warning" showDismiss={ false } text={ this.translate( 'Connect an account to get started.' ) }>
 						<NoticeAction href={ '/sharing/' + this.props.siteSlug }>
 							{ this.translate( 'Settings' ) }
 						</NoticeAction>
@@ -222,6 +229,7 @@ export default connect(
 			siteId,
 			isPublicizeEnabled,
 			connections: getSiteUserConnections( state, siteId, userId ),
+			hasFetchedConnections: hasFetchedConnections( state, siteId ),
 			requesting: isRequestingSharePost( state, siteId, props.post.ID ),
 			failed: sharePostFailure( state, siteId, props.post.ID ),
 			success: sharePostSuccessMessage( state, siteId, props.post.ID )

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -26,6 +26,13 @@
 			flex-direction: row;
 		}
 	}
+	.posts__post-share-form.is-placeholder, 
+	.posts__post-share-services.is-placeholder {
+		@include placeholder;
+		margin-top: 16px;
+		height: 48px;
+	}
+
 	.posts__post-share-head {
 		padding: 0 24px;
 	}

--- a/client/state/sharing/publicize/reducer.js
+++ b/client/state/sharing/publicize/reducer.js
@@ -62,6 +62,10 @@ export const fetchingConnections = createReducer( {}, {
 	[ PUBLICIZE_CONNECTIONS_REQUEST_FAILURE ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
 } );
 
+export const fetchedConnections = createReducer( {}, {
+	[ PUBLICIZE_CONNECTIONS_RECEIVE ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: true } ),
+} );
+
 // Tracks all known connection objects, indexed by connection ID.
 export const connections = createReducer( {}, {
 	[ PUBLICIZE_CONNECTIONS_RECEIVE ]: ( state, action ) => ( {
@@ -77,6 +81,7 @@ export const connections = createReducer( {}, {
 export default combineReducers( {
 	fetchingConnection,
 	fetchingConnections,
+	fetchedConnections,
 	connections,
 	sharePostStatus
 } );

--- a/client/state/sharing/publicize/selectors.js
+++ b/client/state/sharing/publicize/selectors.js
@@ -98,8 +98,7 @@ export function getRemovableConnections( state, service ) {
  * @return {Array}         Site connections
  */
 export function hasFetchedConnections( state, siteId ) {
-	const { fetchingConnections } = state.sharing.publicize;
-	return fetchingConnections.hasOwnProperty( siteId );
+	return get( state.sharing.publicize.fetchedConnections, [ siteId ], false );
 }
 
 /**
@@ -110,8 +109,7 @@ export function hasFetchedConnections( state, siteId ) {
  * @return {Array}         Site connections
  */
 export function isFetchingConnections( state, siteId ) {
-	const { fetchingConnections } = state.sharing.publicize;
-	return hasFetchedConnections( state, siteId ) && fetchingConnections[ siteId ];
+	return get( state.sharing.publicize.fetchingConnections, [ siteId ], false );
 }
 
 /**

--- a/client/state/sharing/publicize/test/selectors.js
+++ b/client/state/sharing/publicize/test/selectors.js
@@ -236,7 +236,7 @@ describe( '#hasFetchedConnections()', () => {
 		const hasFetched = hasFetchedConnections( {
 			sharing: {
 				publicize: {
-					fetchingConnections: {}
+					fetchedConnections: {}
 				}
 			}
 		}, 2916284 );
@@ -244,26 +244,12 @@ describe( '#hasFetchedConnections()', () => {
 		expect( hasFetched ).to.be.false;
 	} );
 
-	it( 'should return true if connections are currently fetching for a site', () => {
-		const hasFetched = hasFetchedConnections( {
-			sharing: {
-				publicize: {
-					fetchingConnections: {
-						2916284: true
-					}
-				}
-			}
-		}, 2916284 );
-
-		expect( hasFetched ).to.be.true;
-	} );
-
 	it( 'should return true if connections have completed fetching for a site', () => {
 		const hasFetched = hasFetchedConnections( {
 			sharing: {
 				publicize: {
-					fetchingConnections: {
-						2916284: false
+					fetchedConnections: {
+						2916284: true
 					}
 				}
 			}


### PR DESCRIPTION
Per @alisterscott :
> When you open the sharing panel for the very first time an orange warning appears and disappears quickly that says “No social accounts connected” – I managed to capture a recording of this: 
![open-share](https://cloud.githubusercontent.com/assets/3775068/21567524/0791ab3e-cead-11e6-8b1a-6d42e91aca8a.gif)

This PR fixes that.