### PR TITLE
Reader Cleanup: update excerpts to ignore any leading breaklines

### DIFF
--- a/client/lib/post-normalizer/rule-create-better-excerpt.js
+++ b/client/lib/post-normalizer/rule-create-better-excerpt.js
@@ -1,9 +1,8 @@
 /**
  * External Dependencies
  */
-import forEach from 'lodash/forEach';
 import striptags from 'striptags';
-import trim from 'lodash/trim';
+import { trim, toArray, forEach } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -11,13 +10,43 @@ import trim from 'lodash/trim';
 import { domForHtml } from './utils';
 import { stripHTML } from 'lib/formatting';
 
+/**
+ *  removes an html element from the dom
+ */
+function removeElement( element ) {
+	element.parentNode && element.parentNode.removeChild( element );
+}
+
+/**
+ *  Trims any empty starting br tags.  Recurses into non-empty tags.
+ *  will remove all of the leading brs it can find.
+ */
+function stripLeadingBreaklines( dom ) {
+	if ( ! dom ) {
+		return;
+	}
+
+	// first element is breakline actually returns the node in case of success
+	while ( firstElementIsBreakline( dom ) ) {
+		removeElement( firstElementIsBreakline( dom ) );
+	}
+}
+
+/**
+ *  Returns the node if first element ( checking nested ) is a br
+ *  else returns falsy
+ */
+function firstElementIsBreakline( dom ) {
+	if ( dom.childNodes.length === 0 ) {
+		return dom.nodeName === 'BR' && dom;
+	}
+
+	return firstElementIsBreakline( dom.firstChild );
+}
+
 export function formatExcerpt( content ) {
 	if ( ! content ) {
 		return '';
-	}
-
-	function removeElement( element ) {
-		element.parentNode && element.parentNode.removeChild( element );
 	}
 
 	// Spin up a new DOM for the linebreak markup
@@ -31,23 +60,16 @@ export function formatExcerpt( content ) {
 	// limit to paras and brs
 	dom.innerHTML = striptags( dom.innerHTML, [ 'p', 'br' ] );
 
-	// Strip any empty p and br elements from the beginning of the content
-	forEach( dom.querySelectorAll( 'p,br' ), function( element ) {
-		// is this element non-empty? bail on our iteration.
-		if ( element.childNodes.length > 0 && trim( element.textContent ).length > 0 ) {
-			return false;
-		}
-		element.parentNode && element.parentNode.removeChild( element );
-	} );
+	// strip any p's that are empty
+	toArray( dom.querySelectorAll( 'p' ) )
+		.filter( element => trim( element.textContent ).length === 0 )
+		.forEach( removeElement );
 
-	// now strip any p's that are empty and remove styles
-	forEach( dom.querySelectorAll( 'p' ), function( element ) {
-		if ( trim( element.textContent ).length === 0 ) {
-			element.parentNode && element.parentNode.removeChild( element );
-		} else {
-			element.removeAttribute( 'style' );
-		}
-	} );
+	// remove styles for all p's that remain
+	toArray( dom.querySelectorAll( 'p' ) )
+		.forEach( element => element.removeAttribute( 'style' ) );
+
+	stripLeadingBreaklines( dom );
 
 	// now limit it to the first three elements
 	forEach( dom.querySelectorAll( '#__better_excerpt__ > p, #__better_excerpt__ > br' ), function( element, index ) {

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -906,13 +906,33 @@ describe( 'index', function() {
 			} );
 		}
 
-		it( 'strips empty elements and leading and trailing brs', function( done ) {
+		it( 'strips empty elements and leading brs', function( done ) {
 			assertExcerptBecomes( `<br>
 <p>&nbsp;</p>
 <p class="wp-caption-text">caption</p>
 <p><img src="http://example.com/image.jpg"></p>
 <p><a href="http://wikipedia.org">Giraffes</a> are <br>great</p>
 <p></p>`, '<p>Giraffes are <br>great</p>', done );
+		} );
+
+		it( 'strips leading brs even if they are nested', function( done ) {
+			assertExcerptBecomes(
+				'<p><br>deep meaning lies within</p>',
+				'<p>deep meaning lies within</p>',
+				done
+			);
+		} );
+
+		it( 'strips multiple leading brs even if nested', function( done ) {
+			assertExcerptBecomes(
+				'<p><br><br><br></p><br><p><br></p>deep meaning lies within',
+				'deep meaning lies within',
+				done
+			);
+		} );
+
+		it( 'only trims break if there is no preceding text', function( done ) {
+			assertExcerptBecomes( '<p>one<br>two</p>', '<p>one<br>two</p>', done );
 		} );
 
 		it( 'limits the excerpt to 3 elements', function( done ) {
@@ -925,10 +945,6 @@ describe( 'index', function() {
 				'<p>one</p><p>two</p><br>',
 				done
 			);
-		} );
-
-		it( 'only trims top-level breaks', function( done ) {
-			assertExcerptBecomes( '<p></p><p>one<br>two</p>', '<p>one<br>two</p>', done );
 		} );
 
 		it( 'removes style tags', done => {


### PR DESCRIPTION
As pointed out in #10271, we are sometimes forgetting to exclude leading breaklines. This is frustrating for authors/readers when there is valuable vertical space wasted!

We already have [code](https://github.com/Automattic/wp-calypso/blob/master/client/lib/post-normalizer/rule-create-better-excerpt.js#L34) that attempts to strip leading breaklines but this PR teaches it to check for nested breaklines.

Example of a pattern that would be missed before this PR:

```html
<p>
  <br> 
  okapi okapi versace
  ....
</p>
```
