### PR TITLE
DevDocs: Generate a table for displaying proptypes

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -49,6 +49,7 @@
 @import 'blocks/post-relative-time/style';
 @import 'blocks/post-share/style';
 @import 'blocks/post-status/style';
+@import 'blocks/props-viewer/style';
 @import 'blocks/reader-author-link/style';
 @import 'blocks/reader-avatar/style';
 @import 'blocks/reader-combined-card/style';

--- a/client/blocks/props-viewer/README.md
+++ b/client/blocks/props-viewer/README.md
@@ -1,0 +1,31 @@
+Props Viewer
+==========
+
+`<PropsViewer />` is a component that will render a table given a component name and an example component to render.
+
+## Usage
+
+``` jsx
+import PropsViewer from 'blocks/props-viewer';
+
+render() {
+	const anExample = ( <AuthorSelectorExample /> );
+	return ( <PropsViewer component='author-selector' example={ anExample } /> )
+}
+```
+
+where `component` is the slug of the component and `example` is the example component to render.
+
+## Rebuilding the component props object
+
+
+This command will rebuild the json file:
+
+`make server/devdocs/proptypes-index.json`
+
+## Props
+
+| name      | type   | required | description
+|-----------|--------|----------|------------
+| component | string | yes      | The slug of the component to render a table for
+| example   | ReactElement | yes | An example of the component to render

--- a/client/blocks/props-viewer/index.jsx
+++ b/client/blocks/props-viewer/index.jsx
@@ -129,6 +129,28 @@ class PropsViewer extends PureComponent {
 		);
 	}
 
+	rows( component ) {
+		if ( ! component.props ) {
+			return null;
+		}
+
+		return Object.keys( component.props )
+			.sort( this.sortProps )
+			.map( ( propName ) => this.renderRow( component, propName ) );
+	}
+
+	static componentDescription( component ) {
+		if ( component.description ) {
+			return component.description;
+		}
+
+		return 'Add jsdoc to the component see it here';
+	}
+
+	static componentIncludePath( component ) {
+		return `import ${ component.displayName } from '${ component.includePath }';`;
+	}
+
 	/**
 	 * Renders a table if it can
 	 * @param {object} component The component to render for
@@ -141,12 +163,12 @@ class PropsViewer extends PureComponent {
 
 		return (
 			<Card compact={ true } className="props-viewer__card" tagName="div">
-				<p className="props-viewer__description" >{ component.description || 'Add jsdoc to the component see it here' }</p>
+				<p className="props-viewer__description" >{ PropsViewer.componentDescription( component ) }</p>
 				<div className="props-viewer__usage">
 					<div className="props-viewer__example" >
 						<span className="props-viewer__heading">Use It</span>
 						<p><code>
-							import { component.displayName } from '{ component.includePath }';
+							{ PropsViewer.componentIncludePath( component ) }
 						</code></p>
 					</div>
 					<div className="props-viewer__table">
@@ -162,11 +184,7 @@ class PropsViewer extends PureComponent {
 							</tr>
 							</thead>
 							<tbody>
-							{ component.props
-								? Object.keys( component.props )
-									.sort( this.sortProps )
-									.map( ( propName ) => this.renderRow( component, propName ) )
-								: null }
+							{ this.rows( component ) }
 							</tbody>
 						</table>
 					</div>

--- a/client/blocks/props-viewer/index.jsx
+++ b/client/blocks/props-viewer/index.jsx
@@ -1,18 +1,29 @@
 /**
  * External Dependencies
  */
-
 import React, { PropTypes, PureComponent } from 'react';
 
 /**
  * Internal Dependencies
  */
-
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 
 // todo: move this file!
 const components = require( '../../../server/devdocs/proptypes-index.json' );
+
+/**
+ * Finds a non-example component in the library of components
+ * @param {string} slug The slug to search for
+ * @return {Array} An array of component matches
+ */
+export function findRealComponent( slug ) {
+	// remove the last character. As of right now, all plural display names are with just an 's'
+	const singular = slug.slice( 0, -1 );
+	return components.filter( ( component ) => {
+		return ( slug === component.slug || singular === component.slug ) && component.includePath.indexOf( 'example' ) < 0;
+	} );
+}
 
 /**
  * Renders a table of prop-types for auto-documentation
@@ -25,24 +36,11 @@ class PropsViewer extends PureComponent {
 	}
 
 	/**
-	 * Finds a non-example component in the library of components
-	 * @param {string} slug The slug to search for
-	 * @return {Array} An array of component matches
-	 */
-	findRealComponent = ( slug ) => {
-		// remove the last character. As of right now, all plural display names are with just an 's'
-		const singular = slug.slice( 0, -1 );
-		return components.filter( ( component ) => {
-			return ( slug === component.slug || singular === component.slug ) && component.includePath.indexOf( 'example' ) < 0;
-		} );
-	};
-
-	/**
 	 * Set the state of this component to the first matching slug
 	 * @param {string} slug The slug to search for
 	 */
 	setComponent = ( slug ) => {
-		let component = this.findRealComponent( slug );
+		let component = findRealComponent( slug );
 		if ( component.length > 0 ) {
 			component = component[ 0 ];
 		} else {
@@ -90,7 +88,7 @@ class PropsViewer extends PureComponent {
 	 * @param {string} propName The name of the prop to render
 	 * @return {ReactElement} The rendered row
 	 */
-	renderRow = ( component, propName ) => {
+	renderRow( component, propName ) {
 		const prop = component.props[ propName ];
 		let type = 'unknown';
 		if ( prop.type ) {
@@ -117,14 +115,14 @@ class PropsViewer extends PureComponent {
 				<td>{ prop.description }</td>
 			</tr>
 		);
-	};
+	}
 
 	/**
 	 * Renders a table if it can
 	 * @param {object} component The component to render for
 	 * @return {ReactComponent|null} The table or nothing
 	 */
-	renderTable = ( component ) => {
+	renderTable( component ) {
 		if ( ! component ) {
 			return null; //todo: explain why this table is missing
 		}
@@ -163,7 +161,7 @@ class PropsViewer extends PureComponent {
 				</div>
 			</Card>
 		);
-	};
+	}
 
 	render() {
 		const component = this.state.component;

--- a/client/blocks/props-viewer/index.jsx
+++ b/client/blocks/props-viewer/index.jsx
@@ -31,6 +31,18 @@ export function findRealComponent( slug ) {
 class PropsViewer extends PureComponent {
 	static displayName = 'PropsViewer';
 
+	static propTypes = {
+		/**
+		 * The slug of the component being displayed
+		 */
+		component: PropTypes.string.isRequired,
+
+		/**
+		 * The element to display as an example of this component
+		 */
+		example: PropTypes.element.isRequired
+	}
+
 	constructor( props ) {
 		super( props );
 	}
@@ -172,18 +184,6 @@ class PropsViewer extends PureComponent {
 				{ this.renderTable( component ) }
 			</div>
 		);
-	}
-
-	static propTypes = {
-		/**
-		 * The slug of the component being displayed
-		 */
-		component: PropTypes.string.isRequired,
-
-		/**
-		 * The element to display as an example of this component
-		 */
-		example: PropTypes.element.isRequired
 	}
 }
 

--- a/client/blocks/props-viewer/index.jsx
+++ b/client/blocks/props-viewer/index.jsx
@@ -1,0 +1,167 @@
+/**
+ * External Dependencies
+ */
+
+import React, { PropTypes, PureComponent } from 'react';
+
+/**
+ * Internal Dependencies
+ */
+
+import Card from 'components/card';
+import Gridicon from 'components/gridicon';
+
+import styles from './styles.scss';
+
+// todo: move this file!
+const components = require( '../../../server/devdocs/proptypes-index.json' );
+
+class PropsViewer extends PureComponent {
+	constructor( props ) {
+		super( props );
+	}
+
+	/**
+	 * Finds a non-example component in the library of components
+	 * @param {string} slug The slug to search for
+	 * @return {Array} An array of component matches
+	 */
+	findRealComponent = ( slug ) => {
+		// remove the last character. As of right now, all plural display names are with just an 's'
+		const singular = slug.slice( 0, -1 );
+		return components.filter( ( component ) => {
+			return ( slug === component.slug || singular === component.slug ) && component.includePath.indexOf( 'example' ) < 0;
+		} );
+	};
+
+	/**
+	 * Set the state of this component to the first matching slug
+	 * @param {string} slug The slug to search for
+	 */
+	setComponent = ( slug ) => {
+		let component = this.findRealComponent( slug );
+		if ( component.length > 0 ) {
+			component = component[ 0 ];
+		} else {
+			component = null;
+		}
+
+		this.setState( {
+			component
+		} );
+	};
+
+	componentWillMount() {
+		this.setComponent( this.props.component );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		this.setComponent( nextProps.component );
+	}
+
+	render() {
+		const component = this.state.component;
+
+		/**
+		 * Renders a row in the table
+		 * @param {string} propName The name of the prop
+		 * @return {ReactElement} The row
+		 */
+		const row = ( propName ) => {
+			const prop = component.props[ propName ];
+			return (
+				<tr key={ propName } className={ styles.tr } >
+					<td>{ prop.required ? <Gridicon icon="checkmark" /> : <Gridicon icon="cross-small" /> }</td>
+					<td>{ propName }</td>
+					<td>{ prop.type ? prop.type.name : 'not in propTypes' }</td>
+					<td>{ prop.defaultValue ? prop.defaultValue.value : 'undefined' }</td>
+					<td>{ prop.description }</td>
+				</tr>
+			);
+		};
+
+		/**
+		 * Sort prop names by (required, name)
+		 * @param {string} leftName The prop name of the left side
+		 * @param {string} rightName The prop name of the right side
+		 * @return {number} Which side wins
+		 */
+		const sortProps = ( leftName, rightName ) => {
+			const left = component.props[ leftName ];
+			const right = component.props[ rightName ];
+			if ( left.required === right.required ) {
+				return ( leftName.toLowerCase() < rightName.toLowerCase() ? -1 : 1 );
+			}
+
+			if ( left.required ) {
+				return -1;
+			}
+
+			return 1;
+		};
+
+		/**
+		 * Renders a table if it can
+		 * @return {*} The table
+		 */
+		const table = () => {
+			if ( ! component ) {
+				return null; //todo: explain why this table is missing
+			}
+
+			return (
+				<Card compact={ true } tagName="div">
+					<h1 className={ styles.name }>{ component.displayName }</h1>
+					<p className={ styles.description } >{ component.description }</p>
+					<div className={ styles.example }>
+						<p><code>
+							import { component.displayName } from '{ component.includePath }';
+							{ null }
+						</code></p>
+					</div>
+					<div className={ styles.tableWrapper }>
+						<table className={ styles.table }>
+							<thead>
+							<tr>
+								<td>Required</td>
+								<td>Name</td>
+								<td>Type</td>
+								<td>Default</td>
+								<td>Description</td>
+							</tr>
+							</thead>
+							<tbody>
+							{ component.props
+								? Object.keys( component.props )
+									.sort( sortProps )
+									.map( ( propName ) => row( propName ) )
+								: null }
+							</tbody>
+						</table>
+					</div>
+				</Card>
+			);
+		};
+
+		return (
+			<div>
+				{ this.props.example }
+				{ table() }
+			</div>
+		);
+	}
+}
+
+PropsViewer.propTypes = {
+	/**
+	 * The slug of the component being displayed
+	 */
+	component: PropTypes.object.isRequired,
+
+	/**
+	 * The element to display as an example of this component
+	 */
+	example: PropTypes.element.isRequired
+};
+
+export default PropsViewer;

--- a/client/blocks/props-viewer/index.jsx
+++ b/client/blocks/props-viewer/index.jsx
@@ -14,7 +14,12 @@ import Gridicon from 'components/gridicon';
 // todo: move this file!
 const components = require( '../../../server/devdocs/proptypes-index.json' );
 
+/**
+ * Renders a table of prop-types for auto-documentation
+ */
 class PropsViewer extends PureComponent {
+	static displayName = 'PropsViewer';
+
 	constructor( props ) {
 		super( props );
 	}
@@ -57,127 +62,131 @@ class PropsViewer extends PureComponent {
 		this.setComponent( nextProps.component );
 	}
 
-	render() {
+	/**
+	 * Sort prop names by (required, name)
+	 * @param {string} leftName The prop name of the left side
+	 * @param {string} rightName The prop name of the right side
+	 * @return {number} Which side wins
+	 */
+	sortProps = ( leftName, rightName ) => {
 		const component = this.state.component;
 
-		/**
-		 * Renders a row in the table
-		 * @param {string} propName The name of the prop
-		 * @return {ReactElement} The row
-		 */
-		const row = ( propName ) => {
-			const prop = component.props[ propName ];
-			let type = 'unknown';
-			if ( prop.type ) {
-				switch ( prop.type.name ) {
-					default:
-						type = prop.type.name;
-						break;
-					case 'arrayOf':
-					case 'oneOf':
-					case 'oneOfType':
-					case 'objectOf':
-					case 'instanceOf':
-						type = `${ prop.type.name }( ${ prop.type.value.name || 'unknown' } )`;
-						break;
-				}
+		const left = component.props[ leftName ];
+		const right = component.props[ rightName ];
+		if ( left.required === right.required ) {
+			return ( leftName.toLowerCase() < rightName.toLowerCase() ? -1 : 1 );
+		}
+
+		if ( left.required ) {
+			return -1;
+		}
+
+		return 1;
+	};
+
+	/**
+	 * Renders a row in the table
+	 * @param {object} component The component
+	 * @param {string} propName The name of the prop to render
+	 * @return {ReactElement} The rendered row
+	 */
+	renderRow = ( component, propName ) => {
+		const prop = component.props[ propName ];
+		let type = 'unknown';
+		if ( prop.type ) {
+			switch ( prop.type.name ) {
+				default:
+					type = prop.type.name;
+					break;
+				case 'arrayOf':
+				case 'oneOf':
+				case 'oneOfType':
+				case 'objectOf':
+				case 'instanceOf':
+					type = `${ prop.type.name }( ${ prop.type.value.name || 'unknown' } )`;
+					break;
 			}
+		}
 
-			return (
-				<tr key={ propName }>
-					<td>{ prop.required ? <Gridicon icon="checkmark" /> : <Gridicon icon="cross-small" /> }</td>
-					<td>{ propName }</td>
-					<td>{ type }</td>
-					<td>{ prop.defaultValue ? prop.defaultValue.value : 'undefined' }</td>
-					<td>{ prop.description }</td>
-				</tr>
-			);
-		};
+		return (
+			<tr key={ propName }>
+				<td>{ prop.required ? <Gridicon icon="checkmark" /> : <Gridicon icon="cross-small" /> }</td>
+				<td>{ propName }</td>
+				<td>{ type }</td>
+				<td>{ prop.defaultValue ? prop.defaultValue.value : 'undefined' }</td>
+				<td>{ prop.description }</td>
+			</tr>
+		);
+	};
 
-		/**
-		 * Sort prop names by (required, name)
-		 * @param {string} leftName The prop name of the left side
-		 * @param {string} rightName The prop name of the right side
-		 * @return {number} Which side wins
-		 */
-		const sortProps = ( leftName, rightName ) => {
-			const left = component.props[ leftName ];
-			const right = component.props[ rightName ];
-			if ( left.required === right.required ) {
-				return ( leftName.toLowerCase() < rightName.toLowerCase() ? -1 : 1 );
-			}
+	/**
+	 * Renders a table if it can
+	 * @param {object} component The component to render for
+	 * @return {ReactComponent|null} The table or nothing
+	 */
+	renderTable = ( component ) => {
+		if ( ! component ) {
+			return null; //todo: explain why this table is missing
+		}
 
-			if ( left.required ) {
-				return -1;
-			}
-
-			return 1;
-		};
-
-		/**
-		 * Renders a table if it can
-		 * @return {*} The table
-		 */
-		const table = () => {
-			if ( ! component ) {
-				return null; //todo: explain why this table is missing
-			}
-
-			return (
-				<Card compact={ true } className="props-viewer__card" tagName="div">
-					<p className="props-viewer__description" >{ component.description || 'Add jsdoc to the component see it here' }</p>
-					<div className="props-viewer__usage">
-						<div className="props-viewer__example" >
-							<span className="props-viewer__heading">Use It</span>
-							<p><code>
-								import { component.displayName } from '{ component.includePath }';
-							</code></p>
-						</div>
-						<div className="props-viewer__table">
-							<span className="props-viewer__heading">Props</span>
-							<table>
-								<thead>
-								<tr>
-									<td>Required</td>
-									<td>Name</td>
-									<td>Type</td>
-									<td>Default</td>
-									<td>Description</td>
-								</tr>
-								</thead>
-								<tbody>
-								{ component.props
-									? Object.keys( component.props )
-										.sort( sortProps )
-										.map( ( propName ) => row( propName ) )
-									: null }
-								</tbody>
-							</table>
-						</div>
+		return (
+			<Card compact={ true } className="props-viewer__card" tagName="div">
+				<p className="props-viewer__description" >{ component.description || 'Add jsdoc to the component see it here' }</p>
+				<div className="props-viewer__usage">
+					<div className="props-viewer__example" >
+						<span className="props-viewer__heading">Use It</span>
+						<p><code>
+							import { component.displayName } from '{ component.includePath }';
+						</code></p>
 					</div>
-				</Card>
-			);
-		};
+					<div className="props-viewer__table">
+						<span className="props-viewer__heading">Props</span>
+						<table>
+							<thead>
+							<tr>
+								<td>Required</td>
+								<td>Name</td>
+								<td>Type</td>
+								<td>Default</td>
+								<td>Description</td>
+							</tr>
+							</thead>
+							<tbody>
+							{ component.props
+								? Object.keys( component.props )
+									.sort( this.sortProps )
+									.map( ( propName ) => this.renderRow( component, propName ) )
+								: null }
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</Card>
+		);
+	};
+
+	render() {
+		const component = this.state.component;
 
 		return (
 			<div>
 				{ this.props.example }
-				{ table() }
+				{ this.renderTable( component ) }
 			</div>
 		);
 	}
+
+	static propTypes = {
+		/**
+		 * The slug of the component being displayed
+		 */
+		component: PropTypes.string.isRequired,
+
+		/**
+		 * The element to display as an example of this component
+		 */
+		example: PropTypes.element.isRequired
+	}
 }
-
-PropsViewer.propTypes = {
-	/**
-	 * The slug of the component being displayed
-	 */
-	component: PropTypes.object.isRequired,
-
-	/**
-	 * The element to display as an example of this component
-	 */
-	example: PropTypes.element.isRequired
-};
 
 export default PropsViewer;

--- a/client/blocks/props-viewer/index.jsx
+++ b/client/blocks/props-viewer/index.jsx
@@ -11,8 +11,6 @@ import React, { PropTypes, PureComponent } from 'react';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 
-import styles from './styles.scss';
-
 // todo: move this file!
 const components = require( '../../../server/devdocs/proptypes-index.json' );
 
@@ -69,11 +67,27 @@ class PropsViewer extends PureComponent {
 		 */
 		const row = ( propName ) => {
 			const prop = component.props[ propName ];
+			let type = 'unknown';
+			if ( prop.type ) {
+				switch ( prop.type.name ) {
+					default:
+						type = prop.type.name;
+						break;
+					case 'arrayOf':
+					case 'oneOf':
+					case 'oneOfType':
+					case 'objectOf':
+					case 'instanceOf':
+						type = `${ prop.type.name }( ${ prop.type.value.name || 'unknown' } )`;
+						break;
+				}
+			}
+
 			return (
-				<tr key={ propName } className={ styles.tr } >
+				<tr key={ propName }>
 					<td>{ prop.required ? <Gridicon icon="checkmark" /> : <Gridicon icon="cross-small" /> }</td>
 					<td>{ propName }</td>
-					<td>{ prop.type ? prop.type.name : 'not in propTypes' }</td>
+					<td>{ type }</td>
 					<td>{ prop.defaultValue ? prop.defaultValue.value : 'undefined' }</td>
 					<td>{ prop.description }</td>
 				</tr>
@@ -110,34 +124,36 @@ class PropsViewer extends PureComponent {
 			}
 
 			return (
-				<Card compact={ true } tagName="div">
-					<h1 className={ styles.name }>{ component.displayName }</h1>
-					<p className={ styles.description } >{ component.description }</p>
-					<div className={ styles.example }>
-						<p><code>
-							import { component.displayName } from '{ component.includePath }';
-							{ null }
-						</code></p>
-					</div>
-					<div className={ styles.tableWrapper }>
-						<table className={ styles.table }>
-							<thead>
-							<tr>
-								<td>Required</td>
-								<td>Name</td>
-								<td>Type</td>
-								<td>Default</td>
-								<td>Description</td>
-							</tr>
-							</thead>
-							<tbody>
-							{ component.props
-								? Object.keys( component.props )
-									.sort( sortProps )
-									.map( ( propName ) => row( propName ) )
-								: null }
-							</tbody>
-						</table>
+				<Card compact={ true } className="props-viewer__card" tagName="div">
+					<p className="props-viewer__description" >{ component.description || 'Add jsdoc to the component see it here' }</p>
+					<div className="props-viewer__usage">
+						<div className="props-viewer__example" >
+							<span className="props-viewer__heading">Use It</span>
+							<p><code>
+								import { component.displayName } from '{ component.includePath }';
+							</code></p>
+						</div>
+						<div className="props-viewer__table">
+							<span className="props-viewer__heading">Props</span>
+							<table>
+								<thead>
+								<tr>
+									<td>Required</td>
+									<td>Name</td>
+									<td>Type</td>
+									<td>Default</td>
+									<td>Description</td>
+								</tr>
+								</thead>
+								<tbody>
+								{ component.props
+									? Object.keys( component.props )
+										.sort( sortProps )
+										.map( ( propName ) => row( propName ) )
+									: null }
+								</tbody>
+							</table>
+						</div>
 					</div>
 				</Card>
 			);

--- a/client/blocks/props-viewer/index.jsx
+++ b/client/blocks/props-viewer/index.jsx
@@ -48,11 +48,6 @@ class PropsViewer extends PureComponent {
 	 */
 	setComponent = ( slug ) => {
 		let component = findRealComponent( slug );
-		if ( component.length > 0 ) {
-			component = component[ 0 ];
-		} else {
-			component = null;
-		}
 
 		this.setState( {
 			component

--- a/client/blocks/props-viewer/index.jsx
+++ b/client/blocks/props-viewer/index.jsx
@@ -39,11 +39,7 @@ class PropsViewer extends PureComponent {
 		 * The element to display as an example of this component
 		 */
 		example: PropTypes.element.isRequired
-	}
-
-	constructor( props ) {
-		super( props );
-	}
+	};
 
 	/**
 	 * Set the state of this component to the first matching slug

--- a/client/blocks/props-viewer/index.jsx
+++ b/client/blocks/props-viewer/index.jsx
@@ -29,8 +29,6 @@ export function findRealComponent( slug ) {
  * Renders a table of prop-types for auto-documentation
  */
 class PropsViewer extends PureComponent {
-	static displayName = 'PropsViewer';
-
 	static propTypes = {
 		/**
 		 * The slug of the component being displayed

--- a/client/blocks/props-viewer/index.jsx
+++ b/client/blocks/props-viewer/index.jsx
@@ -3,12 +3,11 @@
  */
 import { find } from 'lodash';
 import React, { PropTypes, PureComponent } from 'react';
-import Gridicon from 'gridicons';
 
 /**
  * Internal Dependencies
  */
-import Card from 'components/card';
+import Table from './table';
 
 // todo: move this file!
 const components = require( '../../../server/devdocs/proptypes-index.json' );
@@ -47,7 +46,7 @@ class PropsViewer extends PureComponent {
 	 * @param {string} slug The slug to search for
 	 */
 	setComponent = ( slug ) => {
-		let component = findRealComponent( slug );
+		const component = findRealComponent( slug );
 
 		this.setState( {
 			component
@@ -62,134 +61,13 @@ class PropsViewer extends PureComponent {
 		this.setComponent( nextProps.component );
 	}
 
-	/**
-	 * Sort prop names by (required, name)
-	 * @param {string} leftName The prop name of the left side
-	 * @param {string} rightName The prop name of the right side
-	 * @return {number} Which side wins
-	 */
-	sortProps = ( leftName, rightName ) => {
-		const component = this.state.component;
-
-		const left = component.props[ leftName ];
-		const right = component.props[ rightName ];
-		if ( left.required === right.required ) {
-			return ( leftName.toLowerCase() < rightName.toLowerCase() ? -1 : 1 );
-		}
-
-		if ( left.required ) {
-			return -1;
-		}
-
-		return 1;
-	};
-
-	/**
-	 * Renders a row in the table
-	 * @param {object} component The component
-	 * @param {string} propName The name of the prop to render
-	 * @return {ReactElement} The rendered row
-	 */
-	renderRow( component, propName ) {
-		const prop = component.props[ propName ];
-		let type = 'unknown';
-		if ( prop.type ) {
-			switch ( prop.type.name ) {
-				default:
-					type = prop.type.name;
-					break;
-				case 'arrayOf':
-				case 'oneOf':
-				case 'oneOfType':
-				case 'objectOf':
-				case 'instanceOf':
-					type = `${ prop.type.name }( ${ prop.type.value.name || 'unknown' } )`;
-					break;
-			}
-		}
-
-		return (
-			<tr key={ propName }>
-				<td>{ prop.required ? <Gridicon icon="checkmark" /> : <Gridicon icon="cross-small" /> }</td>
-				<td>{ propName }</td>
-				<td>{ type }</td>
-				<td>{ prop.defaultValue ? prop.defaultValue.value : 'undefined' }</td>
-				<td>{ prop.description }</td>
-			</tr>
-		);
-	}
-
-	rows( component ) {
-		if ( ! component.props ) {
-			return null;
-		}
-
-		return Object.keys( component.props )
-			.sort( this.sortProps )
-			.map( ( propName ) => this.renderRow( component, propName ) );
-	}
-
-	static componentDescription( component ) {
-		if ( component.description ) {
-			return component.description;
-		}
-
-		return 'Add jsdoc to the component see it here';
-	}
-
-	static componentIncludePath( component ) {
-		return `import ${ component.displayName } from '${ component.includePath }';`;
-	}
-
-	/**
-	 * Renders a table if it can
-	 * @param {object} component The component to render for
-	 * @return {ReactComponent|null} The table or nothing
-	 */
-	renderTable( component ) {
-		if ( ! component ) {
-			return null; //todo: explain why this table is missing
-		}
-
-		return (
-			<Card compact={ true } className="props-viewer__card" tagName="div">
-				<p className="props-viewer__description">{ PropsViewer.componentDescription( component ) }</p>
-				<div className="props-viewer__usage">
-					<div className="props-viewer__example" >
-						<span className="props-viewer__heading">Use It</span>
-						<p><code>
-							{ PropsViewer.componentIncludePath( component ) }
-						</code></p>
-					</div>
-					<div className="props-viewer__table">
-						<span className="props-viewer__heading">Props</span>
-						<table>
-							<thead>
-							<tr>
-								<td>Required</td>
-								<td>Name</td>
-								<td>Type</td>
-								<td>Default</td>
-								<td>Description</td>
-							</tr>
-							</thead>
-							<tbody>
-								{ this.rows( component ) }
-							</tbody>
-						</table>
-					</div>
-				</div>
-			</Card>
-		);
-	}
-
 	render() {
 		const component = this.state.component;
 
 		return (
 			<div>
 				{ this.props.example }
-				{ this.renderTable( component ) }
+				{ component ? <Table component={ component } /> : null }
 			</div>
 		);
 	}

--- a/client/blocks/props-viewer/index.jsx
+++ b/client/blocks/props-viewer/index.jsx
@@ -178,7 +178,7 @@ class PropsViewer extends PureComponent {
 							</tr>
 							</thead>
 							<tbody>
-							{ this.rows( component ) }
+								{ this.rows( component ) }
 							</tbody>
 						</table>
 					</div>

--- a/client/blocks/props-viewer/index.jsx
+++ b/client/blocks/props-viewer/index.jsx
@@ -8,9 +8,7 @@ import React, { PropTypes, PureComponent } from 'react';
  * Internal Dependencies
  */
 import Table from './table';
-
-// todo: move this file!
-const components = require( '../../../server/devdocs/proptypes-index.json' );
+import components from '../../../server/devdocs/proptypes-index.json';
 
 /**
  * Finds a non-example component in the library of components

--- a/client/blocks/props-viewer/index.jsx
+++ b/client/blocks/props-viewer/index.jsx
@@ -2,12 +2,12 @@
  * External Dependencies
  */
 import React, { PropTypes, PureComponent } from 'react';
+import Gridicon from 'gridicons';
 
 /**
  * Internal Dependencies
  */
 import Card from 'components/card';
-import Gridicon from 'components/gridicon';
 
 // todo: move this file!
 const components = require( '../../../server/devdocs/proptypes-index.json' );

--- a/client/blocks/props-viewer/index.jsx
+++ b/client/blocks/props-viewer/index.jsx
@@ -157,7 +157,7 @@ class PropsViewer extends PureComponent {
 
 		return (
 			<Card compact={ true } className="props-viewer__card" tagName="div">
-				<p className="props-viewer__description" >{ PropsViewer.componentDescription( component ) }</p>
+				<p className="props-viewer__description">{ PropsViewer.componentDescription( component ) }</p>
 				<div className="props-viewer__usage">
 					<div className="props-viewer__example" >
 						<span className="props-viewer__heading">Use It</span>

--- a/client/blocks/props-viewer/index.jsx
+++ b/client/blocks/props-viewer/index.jsx
@@ -41,28 +41,8 @@ class PropsViewer extends PureComponent {
 		example: PropTypes.element.isRequired
 	};
 
-	/**
-	 * Set the state of this component to the first matching slug
-	 * @param {string} slug The slug to search for
-	 */
-	setComponent = ( slug ) => {
-		const component = findRealComponent( slug );
-
-		this.setState( {
-			component
-		} );
-	};
-
-	componentWillMount() {
-		this.setComponent( this.props.component );
-	}
-
-	componentWillReceiveProps( nextProps ) {
-		this.setComponent( nextProps.component );
-	}
-
 	render() {
-		const component = this.state.component;
+		const component = findRealComponent( this.props.component );
 
 		return (
 			<div>

--- a/client/blocks/props-viewer/index.jsx
+++ b/client/blocks/props-viewer/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External Dependencies
  */
+import { find } from 'lodash';
 import React, { PropTypes, PureComponent } from 'react';
 import Gridicon from 'gridicons';
 
@@ -20,7 +21,7 @@ const components = require( '../../../server/devdocs/proptypes-index.json' );
 export function findRealComponent( slug ) {
 	// remove the last character. As of right now, all plural display names are with just an 's'
 	const singular = slug.slice( 0, -1 );
-	return components.filter( ( component ) => {
+	return find( components, ( component ) => {
 		return ( slug === component.slug || singular === component.slug ) && component.includePath.indexOf( 'example' ) < 0;
 	} );
 }

--- a/client/blocks/props-viewer/row.jsx
+++ b/client/blocks/props-viewer/row.jsx
@@ -1,0 +1,43 @@
+/**
+ * External Dependencies
+ */
+import React, { PropTypes, PureComponent } from 'react';
+import Gridicon from 'gridicons';
+
+class Row extends PureComponent {
+	static propTypes = {
+		component: PropTypes.object.isRequired,
+		propName: PropTypes.string.isRequired
+	};
+
+	render() {
+		const prop = this.props.component.props[ this.props.propName ];
+		let type = 'unknown';
+		if ( prop.type ) {
+			switch ( prop.type.name ) {
+				default:
+					type = prop.type.name;
+					break;
+				case 'arrayOf':
+				case 'oneOf':
+				case 'oneOfType':
+				case 'objectOf':
+				case 'instanceOf':
+					type = `${ prop.type.name }( ${ prop.type.value.name || 'unknown' } )`;
+					break;
+			}
+		}
+
+		return (
+			<tr>
+				<td>{ prop.required ? <Gridicon icon="checkmark" /> : <Gridicon icon="cross-small" /> }</td>
+				<td>{ this.props.propName }</td>
+				<td>{ type }</td>
+				<td>{ prop.defaultValue ? prop.defaultValue.value : 'undefined' }</td>
+				<td>{ prop.description }</td>
+			</tr>
+		);
+	}
+}
+
+export default Row;

--- a/client/blocks/props-viewer/style.scss
+++ b/client/blocks/props-viewer/style.scss
@@ -1,0 +1,39 @@
+.props-viewer__card {
+  color: darken($gray, 10%);
+}
+
+.props-viewer__usage {
+  margin: 28px -25px -17px;
+}
+
+.props-viewer__card p {
+  font-size: 13px;
+  margin: 0;
+}
+
+.props-viewer__description {
+  line-height: 1.4;
+}
+
+.props-viewer__heading {
+  background: $gray-light;
+  border: 1px solid lighten( $gray, 10% );
+  text-transform: uppercase;
+  text-align: left;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.8;
+  color: $gray-dark;
+  padding: 2px 8px;
+  position: absolute;
+  top: -12px;
+}
+
+.props-viewer__example, .props-viewer__table {
+  padding: 24px;
+  flex: 3;
+  background: $gray-light;
+  border: 1px solid lighten( $gray, 10% );
+  font-size: 14px;
+  position: relative;
+}

--- a/client/blocks/props-viewer/style.scss
+++ b/client/blocks/props-viewer/style.scss
@@ -1,39 +1,39 @@
 .props-viewer__card {
-  color: darken($gray, 10%);
+	color: darken( $gray, 10% );
 }
 
 .props-viewer__usage {
-  margin: 28px -25px -17px;
+	margin: 28px -25px -17px;
 }
 
 .props-viewer__card p {
-  font-size: 13px;
-  margin: 0;
+	font-size: 13px;
+	margin: 0;
 }
 
 .props-viewer__description {
-  line-height: 1.4;
+	line-height: 1.4;
 }
 
 .props-viewer__heading {
-  background: $gray-light;
-  border: 1px solid lighten( $gray, 10% );
-  text-transform: uppercase;
-  text-align: left;
-  font-size: 10px;
-  font-weight: 600;
-  line-height: 1.8;
-  color: $gray-dark;
-  padding: 2px 8px;
-  position: absolute;
-  top: -12px;
+	background: $gray-light;
+	border: 1px solid lighten( $gray, 10% );
+	text-transform: uppercase;
+	text-align: left;
+	font-size: 10px;
+	font-weight: 600;
+	line-height: 1.8;
+	color: $gray-dark;
+	padding: 2px 8px;
+	position: absolute;
+	top: -12px;
 }
 
 .props-viewer__example, .props-viewer__table {
-  padding: 24px;
-  flex: 3;
-  background: $gray-light;
-  border: 1px solid lighten( $gray, 10% );
-  font-size: 14px;
-  position: relative;
+	padding: 24px;
+	flex: 3;
+	background: $gray-light;
+	border: 1px solid lighten( $gray, 10% );
+	font-size: 14px;
+	position: relative;
 }

--- a/client/blocks/props-viewer/table.jsx
+++ b/client/blocks/props-viewer/table.jsx
@@ -38,7 +38,7 @@ class Table extends PureComponent {
 		const left = component.props[ leftName ];
 		const right = component.props[ rightName ];
 		if ( left.required === right.required ) {
-			return ( leftName.toLowerCase() < rightName.toLowerCase() ? -1 : 1 );
+			return leftName.toLowerCase().localeCompare( rightName.toLowerCase() );
 		}
 
 		if ( left.required ) {

--- a/client/blocks/props-viewer/table.jsx
+++ b/client/blocks/props-viewer/table.jsx
@@ -86,7 +86,7 @@ class Table extends PureComponent {
 							</tr>
 							</thead>
 							<tbody>
-							{ this.rows() }
+								{ this.rows() }
 							</tbody>
 						</table>
 					</div>

--- a/client/blocks/props-viewer/table.jsx
+++ b/client/blocks/props-viewer/table.jsx
@@ -1,0 +1,99 @@
+/**
+ * External Dependencies
+ */
+import React, { PropTypes, PureComponent } from 'react';
+
+/**
+ * Internal Dependencies
+ */
+import Row from './row';
+import Card from 'components/card';
+
+class Table extends PureComponent {
+	static propTypes = {
+		component: PropTypes.object.isRequired
+	};
+
+	componentDescription() {
+		if ( this.props.component.description ) {
+			return this.props.component.description;
+		}
+
+		return 'Add jsdoc to the component see it here';
+	}
+
+	componentIncludePath() {
+		return `import ${ this.props.component.displayName } from '${ this.props.component.includePath }';`;
+	}
+
+	/**
+	 * Sort prop names by (required, name)
+	 * @param {string} leftName The prop name of the left side
+	 * @param {string} rightName The prop name of the right side
+	 * @return {number} Which side wins
+	 */
+	sortProps = ( leftName, rightName ) => {
+		const component = this.props.component;
+
+		const left = component.props[ leftName ];
+		const right = component.props[ rightName ];
+		if ( left.required === right.required ) {
+			return ( leftName.toLowerCase() < rightName.toLowerCase() ? -1 : 1 );
+		}
+
+		if ( left.required ) {
+			return -1;
+		}
+
+		return 1;
+	};
+
+	rows() {
+		if ( ! this.props.component.props ) {
+			return null;
+		}
+
+		return Object.keys( this.props.component.props )
+			.sort( this.sortProps )
+			.map( ( propName ) => <Row key={ propName } component={ this.props.component } propName={ propName } /> );
+	}
+
+	render() {
+		if ( ! this.props.component ) {
+			return null; //todo: explain why this table is missing
+		}
+
+		return (
+			<Card compact={ true } className="props-viewer__card">
+				<p className="props-viewer__description">{ this.componentDescription() }</p>
+				<div className="props-viewer__usage">
+					<div className="props-viewer__example">
+						<span className="props-viewer__heading">Use It</span>
+						<p><code>
+							{ this.componentIncludePath() }
+						</code></p>
+					</div>
+					<div className="props-viewer__table">
+						<span className="props-viewer__heading">Props</span>
+						<table>
+							<thead>
+							<tr>
+								<td>Required</td>
+								<td>Name</td>
+								<td>Type</td>
+								<td>Default</td>
+								<td>Description</td>
+							</tr>
+							</thead>
+							<tbody>
+							{ this.rows() }
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</Card>
+		);
+	}
+}
+
+export default Table;

--- a/client/blocks/props-viewer/test/index.jsx
+++ b/client/blocks/props-viewer/test/index.jsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import PropsViewer from '../index';
+
+const components = require( '../../../../server/devdocs/proptypes-index.json' );
+
+const findRealComponent = ( slug ) => {
+	// remove the last character. As of right now, all plural display names are with just an 's'
+	const singular = slug.slice( 0, -1 );
+	return components.filter( ( component ) => {
+		return ( slug === component.slug || singular === component.slug ) && component.includePath.indexOf( 'example' ) < 0;
+	} );
+};
+
+describe( 'PropsViewer', () => {
+	context( 'no matching component', () => {
+		it( 'should render only the example', () => {
+			const component = ( <PropsViewer component={ 'no-match-here-go-away' } example={ <div /> } /> );
+			const wrapper = shallow( component );
+			expect( wrapper.childAt( 0 ).matchesElement( <div></div> ) ).to.be.true;
+		} );
+	} );
+
+	context( 'renders a table of propTypes', () => {
+		it( 'can render itself', () => {
+			const example = ( <div>Example goes here</div> );
+			const component = ( <PropsViewer component={ 'props-viewer' } example={ example } /> );
+			const spection = findRealComponent( 'props-viewer' )[ 0 ];
+
+			const wrapper = shallow( component );
+			expect( wrapper.childAt( 0 ).matchesElement( <div>Example goes here</div> ) ).to.be.true;
+
+			const tableWrapper = wrapper.childAt( 1 );
+			expect( tableWrapper.childAt( 0 ).text() ).equals( spection.description );
+
+			const tbody = wrapper.find( 'tbody' );
+			const componentRow = tbody.childAt( 0 );
+
+			expect( componentRow.childAt( 1 ).text() ).equals( 'component' );
+			expect( componentRow.childAt( 2 ).text() ).equals( spection.props.component.type.name );
+			expect( componentRow.childAt( 3 ).text() ).equals( 'undefined' );
+			expect( componentRow.childAt( 4 ).text() ).equals( spection.props.component.description );
+		} );
+	} );
+} );

--- a/client/blocks/props-viewer/test/index.jsx
+++ b/client/blocks/props-viewer/test/index.jsx
@@ -4,12 +4,101 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import PropsViewer, { findRealComponent } from '../index';
+import useMockery from 'test/helpers/use-mockery';
 
 describe( 'PropsViewer', () => {
+	let PropsViewer;
+	useMockery( ( mockery ) => {
+		mockery.registerMock( '../../../server/devdocs/proptypes-index.json', [
+			{
+				description: 'Renders a table of prop-types for auto-documentation',
+				displayName: 'PropsViewer',
+				methods: [
+					{
+						name: 'renderRow',
+						docblock: 'Renders a row in the table\n' +
+						'@param {object} component The component\n' +
+						'@param {string} propName The name of the prop to render\n' +
+						'@return {ReactElement} The rendered row',
+						modifiers: [],
+						params: [
+							{
+								name: 'component',
+								description: 'The component',
+								type: {
+									name: 'object'
+								}
+							},
+							{
+								name: 'propName',
+								description: 'The name of the prop to render',
+								type: {
+									name: 'string'
+								}
+							}
+						],
+						returns: {
+							description: 'The rendered row',
+							type: {
+								name: 'ReactElement'
+							}
+						},
+						description: 'Renders a row in the table'
+					},
+					{
+						name: 'renderTable',
+						docblock: 'Renders a table if it can\n' +
+						'@param {object} component The component to render for\n' +
+						'@return {ReactComponent|null} The table or nothing',
+						modifiers: [],
+						params: [
+							{
+								name: 'component',
+								description: 'The component to render for',
+								type: {
+									name: 'object'
+								}
+							}
+						],
+						returns: {
+							description: 'The table or nothing',
+							type: {
+								name: 'union',
+								value: [
+									'ReactComponent',
+									null
+								]
+							}
+						},
+						description: 'Renders a table if it can'
+					}
+				],
+				props: {
+					component: {
+						type: {
+							name: 'string'
+						},
+						required: true,
+						description: 'The slug of the component being displayed'
+					},
+					example: {
+						type: {
+							name: 'element'
+						},
+						required: true,
+						description: 'The element to display as an example of this component'
+					}
+				},
+				includePath: 'blocks/props-viewer',
+				slug: 'props-viewer'
+			}
+		] );
+		PropsViewer = require( '../index' );
+	} );
+
 	context( 'no matching component', () => {
 		it( 'should render only the example', () => {
-			const component = ( <PropsViewer component={ 'no-match-here-go-away' } example={ <div /> } /> );
+			const component = ( <PropsViewer.default component={ 'no-match-here-go-away' } example={ <div /> } /> );
 			const wrapper = shallow( component );
 			expect( wrapper.childAt( 0 ).matchesElement( <div></div> ) ).to.be.true;
 		} );
@@ -18,22 +107,33 @@ describe( 'PropsViewer', () => {
 	context( 'renders a table of propTypes', () => {
 		it( 'can render itself', () => {
 			const example = ( <div>Example goes here</div> );
-			const component = ( <PropsViewer component={ 'props-viewer' } example={ example } /> );
-			const spection = findRealComponent( 'props-viewer' )[ 0 ];
+			const component = ( <PropsViewer.default component={ 'props-viewer' } example={ example } /> );
+			const componentDescription = PropsViewer.findRealComponent( 'props-viewer' )[ 0 ];
 
 			const wrapper = shallow( component );
 			expect( wrapper.childAt( 0 ).matchesElement( <div>Example goes here</div> ) ).to.be.true;
 
 			const tableWrapper = wrapper.childAt( 1 );
-			expect( tableWrapper.childAt( 0 ).text() ).equals( spection.description );
+			expect( tableWrapper.childAt( 0 ).text() ).equals( componentDescription.description );
 
 			const tbody = wrapper.find( 'tbody' );
 			const componentRow = tbody.childAt( 0 );
 
 			expect( componentRow.childAt( 1 ).text() ).equals( 'component' );
-			expect( componentRow.childAt( 2 ).text() ).equals( spection.props.component.type.name );
+			expect( componentRow.childAt( 2 ).text() ).equals( componentDescription.props.component.type.name );
 			expect( componentRow.childAt( 3 ).text() ).equals( 'undefined' );
-			expect( componentRow.childAt( 4 ).text() ).equals( spection.props.component.description );
+			expect( componentRow.childAt( 4 ).text() ).equals( componentDescription.props.component.description );
+		} );
+	} );
+
+	context( 'reducer', () => {
+		it( 'returns empty array if nothing is found', () => {
+			const description = PropsViewer.findRealComponent( 'no-results' );
+			expect( description ).to.be.empty;
+		} );
+		it( 'returns an item if something is found', () => {
+			const description = PropsViewer.findRealComponent( 'props-viewer' );
+			expect( description.length ).to.equal( 1 );
 		} );
 	} );
 } );

--- a/client/blocks/props-viewer/test/index.jsx
+++ b/client/blocks/props-viewer/test/index.jsx
@@ -4,17 +4,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import PropsViewer from '../index';
-
-const components = require( '../../../../server/devdocs/proptypes-index.json' );
-
-const findRealComponent = ( slug ) => {
-	// remove the last character. As of right now, all plural display names are with just an 's'
-	const singular = slug.slice( 0, -1 );
-	return components.filter( ( component ) => {
-		return ( slug === component.slug || singular === component.slug ) && component.includePath.indexOf( 'example' ) < 0;
-	} );
-};
+import PropsViewer, { findRealComponent } from '../index';
 
 describe( 'PropsViewer', () => {
 	context( 'no matching component', () => {

--- a/client/blocks/props-viewer/test/index.jsx
+++ b/client/blocks/props-viewer/test/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import { render } from 'enzyme';
 import useMockery from 'test/helpers/use-mockery';
 
 describe( 'PropsViewer', () => {
@@ -99,30 +99,30 @@ describe( 'PropsViewer', () => {
 	context( 'no matching component', () => {
 		it( 'should render only the example', () => {
 			const component = ( <PropsViewer.default component={ 'no-match-here-go-away' } example={ <div /> } /> );
-			const wrapper = shallow( component );
-			expect( wrapper.childAt( 0 ).matchesElement( <div></div> ) ).to.be.true;
+			const wrapper = render( component );
+			expect( wrapper.text() ).to.be.empty;
 		} );
 	} );
 
 	context( 'renders a table of propTypes', () => {
 		it( 'can render itself', () => {
-			const example = ( <div>Example goes here</div> );
+			const example = ( <div id="example">Example goes here</div> );
 			const component = ( <PropsViewer.default component={ 'props-viewer' } example={ example } /> );
 			const componentDescription = PropsViewer.findRealComponent( 'props-viewer' );
 
-			const wrapper = shallow( component );
-			expect( wrapper.childAt( 0 ).matchesElement( <div>Example goes here</div> ) ).to.be.true;
+			const wrapper = render( component );
+			expect( wrapper.find( '#example' ).text() ).to.be.equal( 'Example goes here' );
 
-			const tableWrapper = wrapper.childAt( 1 );
-			expect( tableWrapper.childAt( 0 ).text() ).equals( componentDescription.description );
+			const tableWrapper = wrapper.find( '.props-viewer__card' );
+			expect( tableWrapper.find( '.props-viewer__description' ).text() ).equals( componentDescription.description );
 
 			const tbody = wrapper.find( 'tbody' );
-			const componentRow = tbody.childAt( 0 );
+			const componentRow = tbody.find( 'tr' ).children();
 
-			expect( componentRow.childAt( 1 ).text() ).equals( 'component' );
-			expect( componentRow.childAt( 2 ).text() ).equals( componentDescription.props.component.type.name );
-			expect( componentRow.childAt( 3 ).text() ).equals( 'undefined' );
-			expect( componentRow.childAt( 4 ).text() ).equals( componentDescription.props.component.description );
+			expect( componentRow.eq( 1 ).text() ).equals( 'component' );
+			expect( componentRow.eq( 2 ).text() ).equals( componentDescription.props.component.type.name );
+			expect( componentRow.eq( 3 ).text() ).equals( 'undefined' );
+			expect( componentRow.eq( 4 ).text() ).equals( componentDescription.props.component.description );
 		} );
 	} );
 

--- a/client/blocks/props-viewer/test/index.jsx
+++ b/client/blocks/props-viewer/test/index.jsx
@@ -108,7 +108,7 @@ describe( 'PropsViewer', () => {
 		it( 'can render itself', () => {
 			const example = ( <div>Example goes here</div> );
 			const component = ( <PropsViewer.default component={ 'props-viewer' } example={ example } /> );
-			const componentDescription = PropsViewer.findRealComponent( 'props-viewer' )[ 0 ];
+			const componentDescription = PropsViewer.findRealComponent( 'props-viewer' );
 
 			const wrapper = shallow( component );
 			expect( wrapper.childAt( 0 ).matchesElement( <div>Example goes here</div> ) ).to.be.true;
@@ -127,13 +127,13 @@ describe( 'PropsViewer', () => {
 	} );
 
 	context( 'reducer', () => {
-		it( 'returns empty array if nothing is found', () => {
+		it( 'returns undefined if nothing is found', () => {
 			const description = PropsViewer.findRealComponent( 'no-results' );
-			expect( description ).to.be.empty;
+			expect( description ).to.equal( undefined );
 		} );
 		it( 'returns an item if something is found', () => {
 			const description = PropsViewer.findRealComponent( 'props-viewer' );
-			expect( description.length ).to.equal( 1 );
+			expect( description ).to.not.equal( undefined );
 		} );
 	} );
 } );

--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -11,6 +11,7 @@ import {
 	camelCaseToSlug,
 	getComponentName,
 } from 'devdocs/docs-example/util';
+import PropsViewer from 'blocks/props-viewer';
 
 const shouldShowInstance = ( example, filter, component ) => {
 	const name = getComponentName( example );
@@ -64,7 +65,7 @@ const Collection = ( { children, filter, section = 'design', component } ) => {
 				unique={ !! component }
 				url={ exampleLink }
 			>
-				{ example }
+				{ component ? <PropsViewer component={ component } example={ example } /> : example }
 			</DocsExampleWrapper>
 		);
 	} );


### PR DESCRIPTION
Generates a table of proptypes when viewing a component by itself in the DevDocs.

![like](https://cloud.githubusercontent.com/assets/1883296/21620910/a99ada80-d1c4-11e6-93e6-314950f1268f.gif)

#9919 added a json file to the build that uses [react/react-docgen](https://github.com/reactjs/react-docgen) to parse our components and extract the propTypes for each of them. This happens at build time. A later PR may allow this to run similar to how our CSS files are built while developing.

This PR requires that file directly, and doesn't require a server. This has two benefits:

1. It keeps the code simple
2. It doesn't require a running server (offline mode -- as seen above)

A different PR can move the file somewhere in the client path. I'm not particularly happy about a relative path in this code. However, I feel as though that should be separate and not done in this PR.

The styling of this follows @aduth's state selector PR (#9433) style. I've tagged this for design review. I originally experimented with using flex-box instead of a table, but the complexity of the dom and CSS exploded on me. It would be a good future task, though I imagine most developers would be on a desktop device writing code. I could be wrong 😉 ...

There are some interesting possibilities that could come in a future PR near you:

- Instead of using the component's JSDoc for a description, use the readme for that component.
- @retrofox has a really awesome PR (#8482) that could really bring this to life.
- Show an editable example under in the "Use It" box, similar to @enejb's #8284 or my #9289.
- Build the json file if a component changes, similar to how our CSS is currently built.

This work is based on #9289, #9919. There's a fix in #10343 to get some missing components into the index.

---

View live: https://calypso.live/devdocs/blocks?branch=add/proptypes-table