### PR TITLE
DevDocs/Proptype Index: Generate slug/displayname and capture inline comments

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,7 @@
 .vscode
 assets/
 bin/
+!bin/generate-proptypes-index.js
 build/
 docs/
 public/

--- a/server/devdocs/bin/generate-proptypes-index.js
+++ b/server/devdocs/bin/generate-proptypes-index.js
@@ -30,6 +30,16 @@ const camelCaseToSlug = ( name ) => {
 		.replace( /^-/, '' );
 };
 
+const slugToCamelCase = name => {
+	if ( ! name ) {
+		return name;
+	}
+
+	return name
+		.replace( /-([a-z])/g, s => s[ 1 ].toUpperCase() )
+		.replace( /^\w/, s => s.toUpperCase() );
+};
+
 /**
  * Wraps fs.readFile in a Promise
  * @param {string} filePath The path to of the file to read
@@ -73,6 +83,11 @@ const parseDocument = ( docObj ) => {
 		parsed.includePath = docObj.includePath;
 		if ( parsed.displayName ) {
 			parsed.slug = camelCaseToSlug( parsed.displayName );
+		}
+		else {
+			// we have to figure it out -- use the directory name to get the slug
+			parsed.slug = path.basename( docObj.includePath );
+			parsed.displayName = slugToCamelCase( parsed.slug );
 		}
 		return parsed;
 	} catch ( error ) {

--- a/server/devdocs/bin/generate-proptypes-index.js
+++ b/server/devdocs/bin/generate-proptypes-index.js
@@ -7,38 +7,14 @@
 /**
  * External Dependencies
  */
-
+require( 'babel-register' );
 const fs = require( 'fs' );
 const path = require( 'path' );
 const reactDocgen = require( 'react-docgen' );
+const util = require( 'client/devdocs/docs-example/util' );
 
 const root = path.dirname( path.join( __dirname, '..', '..' ) );
 const pathSwap = new RegExp(path.sep, 'g');
-
-/**
- * Converts a camel cased string into a slug
- * @param {String} name The camel cased string to slugify
- * @return {String}
- */
-const camelCaseToSlug = ( name ) => {
-	if ( ! name ) {
-		return name;
-	}
-
-	return name
-		.replace( /\.?([A-Z])/g, ( x, y ) => '-' + y.toLowerCase() )
-		.replace( /^-/, '' );
-};
-
-const slugToCamelCase = name => {
-	if ( ! name ) {
-		return name;
-	}
-
-	return name
-		.replace( /-([a-z])/g, s => s[ 1 ].toUpperCase() )
-		.replace( /^\w/, s => s.toUpperCase() );
-};
 
 /**
  * Wraps fs.readFile in a Promise
@@ -82,12 +58,12 @@ const parseDocument = ( docObj ) => {
 		const parsed = reactDocgen.parse( docObj.document );
 		parsed.includePath = docObj.includePath;
 		if ( parsed.displayName ) {
-			parsed.slug = camelCaseToSlug( parsed.displayName );
+			parsed.slug = util.camelCaseToSlug( parsed.displayName );
 		}
 		else {
 			// we have to figure it out -- use the directory name to get the slug
 			parsed.slug = path.basename( docObj.includePath );
-			parsed.displayName = slugToCamelCase( parsed.slug );
+			parsed.displayName = util.slugToCamelCase( parsed.slug );
 		}
 		return parsed;
 	} catch ( error ) {
@@ -122,6 +98,7 @@ const writeFile = ( contents ) => {
 };
 
 const main = ( () => {
+	console.log( 'building: proptypes-index.json' );
 	const fileList = process
 		.argv
 		.splice( 2, process.argv.length )

--- a/server/devdocs/bin/generate-proptypes-index.js
+++ b/server/devdocs/bin/generate-proptypes-index.js
@@ -4,6 +4,8 @@
  * This file generates an index of proptypes by component displayname, slug and folder name
  */
 
+const startTime = process.hrtime();
+
 /**
  * External Dependencies
  */
@@ -98,7 +100,7 @@ const writeFile = ( contents ) => {
 };
 
 const main = ( () => {
-	console.log( 'building: proptypes-index.json' );
+	console.log( 'Building: proptypes-index.json' );
 	const fileList = process
 		.argv
 		.splice( 2, process.argv.length )
@@ -117,4 +119,7 @@ const main = ( () => {
 			.map( parseDocument )
 	);
 	writeFile( documents );
+
+	const elapsed = process.hrtime( startTime )[ 1 ] / 1000000;
+	console.log( `Time: ${ process.hrtime( startTime )[0] }s ${ elapsed.toFixed( 3 ) }ms` );
 } )();


### PR DESCRIPTION
While working on #10342, I discovered more than a few components were lacking a "DisplayName" property and React DocGen left it out. We also discovered that there were several components that have inline comments, instead of docblocks, which would be helpful to have.

This PR generates a DisplayName based on the directory name and generates a matching slug. It also captures inline comments and displays some output/timing.

Related to #9919