### PR TITLE
Reader: FullPost jk shortcuts

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -243,7 +243,7 @@ export class FullPostView extends React.Component {
 		if ( getLastStore() ) {
 			const store = getLastStore();
 			FeedStreamStoreActions.selectNextItem( store.getID() );
-			showSelectedPost( { store } );
+			showSelectedPost( { store, postKey: store.getSelectedPost() } );
 		}
 	}
 
@@ -251,7 +251,7 @@ export class FullPostView extends React.Component {
 		if ( getLastStore() ) {
 			const store = getLastStore();
 			FeedStreamStoreActions.selectPrevItem( store.getID() );
-			showSelectedPost( { store } );
+			showSelectedPost( { store, postKey: store.getSelectedPost() } );
 		}
 	}
 

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -60,16 +60,13 @@ import { getLastStore } from 'reader/controller-helper';
 import { showSelectedPost } from 'reader/utils';
 
 export class FullPostView extends React.Component {
-	constructor( props ) {
-		super( props );
-		this.hasScrolledToCommentAnchor = false;
-	}
-
 	static propTypes = {
 		post: React.PropTypes.object.isRequired,
 		onClose: React.PropTypes.func.isRequired,
 		referralPost: React.PropTypes.object,
 	}
+
+	hasScrolledToCommentAnchor = false;
 
 	componentDidMount() {
 		KeyboardShortcuts.on( 'close-full-post', this.handleBack );
@@ -173,7 +170,7 @@ export class FullPostView extends React.Component {
 	}
 
 	// Does the URL contain the anchor #comments? If so, scroll to comments if we're not already there.
-	checkForCommentAnchor() {
+	checkForCommentAnchor = () => {
 		const hash = window.location.hash.substr( 1 );
 		if ( hash.indexOf( 'comments' ) > -1 ) {
 			this.hasCommentAnchor = true;
@@ -181,7 +178,7 @@ export class FullPostView extends React.Component {
 	}
 
 	// Scroll to the top of the comments section.
-	scrollToComments() {
+	scrollToComments = () => {
 		if ( ! this.props.post ) {
 			return;
 		}
@@ -216,7 +213,7 @@ export class FullPostView extends React.Component {
 		}, 0 );
 	}
 
-	parseEmoji() {
+	parseEmoji = () => {
 		if ( ! this.refs.article ) {
 			return;
 		}
@@ -226,7 +223,7 @@ export class FullPostView extends React.Component {
 		} );
 	}
 
-	attemptToSendPageView() {
+	attemptToSendPageView = () => {
 		const { post, site } = this.props;
 
 		if ( post && post._state !== 'pending' &&

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -56,19 +56,13 @@ import ReaderFullPostBack from './back';
 import { isFeaturedImageInContent } from 'lib/post-normalizer/utils';
 import ReaderFullPostContentPlaceholder from './placeholders/content';
 import * as FeedStreamStoreActions from 'lib/feed-stream-store/actions';
-import feedStreamFactory from 'lib/feed-stream-store';
-import { getLastStoreId } from 'reader/controller-helper';
+import { getLastStore } from 'reader/controller-helper';
 import { showSelectedPost } from 'reader/utils';
 
 export class FullPostView extends React.Component {
 	constructor( props ) {
 		super( props );
 		this.hasScrolledToCommentAnchor = false;
-
-		const storeId = getLastStoreId();
-		if ( storeId ) {
-			this.feedStore = feedStreamFactory( storeId );
-		}
 	}
 
 	static propTypes = {
@@ -249,16 +243,18 @@ export class FullPostView extends React.Component {
 	}
 
 	goToNextPost = () => {
-		if ( this.feedStore ) {
-			FeedStreamStoreActions.selectNextItem( getLastStoreId() );
-			showSelectedPost( { store: this.feedStore } );
+		if ( getLastStore() ) {
+			const store = getLastStore();
+			FeedStreamStoreActions.selectNextItem( store.getID() );
+			showSelectedPost( { store } );
 		}
 	}
 
 	goToPreviousPost = () => {
-		if ( this.feedStore ) {
-			FeedStreamStoreActions.selectPrevItem( getLastStoreId() );
-			showSelectedPost( { store: this.feedStore } );
+		if ( getLastStore() ) {
+			const store = getLastStore();
+			FeedStreamStoreActions.selectPrevItem( store.getID() );
+			showSelectedPost( { store } );
 		}
 	}
 

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -240,16 +240,16 @@ export class FullPostView extends React.Component {
 	}
 
 	goToNextPost = () => {
-		if ( getLastStore() ) {
-			const store = getLastStore();
+		const store = getLastStore();
+		if ( store ) {
 			FeedStreamStoreActions.selectNextItem( store.getID() );
 			showSelectedPost( { store, postKey: store.getSelectedPost() } );
 		}
 	}
 
 	goToPreviousPost = () => {
-		if ( getLastStore() ) {
-			const store = getLastStore();
+		const store = getLastStore();
+		if ( store ) {
 			FeedStreamStoreActions.selectPrevItem( store.getID() );
 			showSelectedPost( { store, postKey: store.getSelectedPost() } );
 		}

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -188,6 +188,13 @@ export default class FeedStream {
 			this.selectedIndex = nextIndex;
 			this.emitChange();
 		}
+
+		// If we are getting close to the end of the loaded stream, or are already at the end,
+		// start fetching new posts
+		if (	nextIndex + 4 > this.postKeys.length ||
+					nextIndex === -1 ) {
+			FeedStreamActions.fetchNextPage( this.getID() );
+		}
 	}
 
 	selectPrevItem() {

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -192,8 +192,7 @@ export default class FeedStream {
 
 		// If we are getting close to the end of the loaded stream, or are already at the end,
 		// start fetching new posts
-		if (	nextIndex + 4 > this.postKeys.length ||
-					nextIndex === -1 ) {
+		if ( nextIndex + 4 > this.postKeys.length || nextIndex === -1 ) {
 			const fetchNextPage = () => FeedStreamActions.fetchNextPage( this.getID() );
 			defer( fetchNextPage );
 		}

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -8,7 +8,8 @@ import {
 	forEach,
 	get,
 	map,
-	noop
+	noop,
+	defer,
 } from 'lodash';
 import moment from 'moment';
 import url from 'url';
@@ -193,7 +194,8 @@ export default class FeedStream {
 		// start fetching new posts
 		if (	nextIndex + 4 > this.postKeys.length ||
 					nextIndex === -1 ) {
-			FeedStreamActions.fetchNextPage( this.getID() );
+			const fetchNextPage = () => FeedStreamActions.fetchNextPage( this.getID() );
+			defer( fetchNextPage );
 		}
 	}
 

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -26,6 +26,7 @@ import * as FeedStreamActions from './actions';
 import { action as ActionTypes } from './constants';
 import PollerPool from 'lib/data-poller';
 import XPostHelper from 'reader/xpost-helper';
+import { setLastStoreId } from 'reader/controller-helper';
 
 const debug = debugFactory( 'calypso:feed-store:post-list-store' );
 
@@ -115,7 +116,7 @@ export default class FeedStream {
 				this.setIsFetchingNextPage( true );
 				break;
 			case ActionTypes.SELECT_ITEM:
-				this.selectItem( action.selectedIndex );
+				this.selectItem( action.selectedIndex, action.id );
 				break;
 			case ActionTypes.SELECT_NEXT_ITEM:
 				this.selectNextItem( action.selectedIndex );
@@ -210,11 +211,12 @@ export default class FeedStream {
 		}
 	}
 
-	selectItem( selectedIndex ) {
+	selectItem( selectedIndex, id ) {
 		if ( selectedIndex >= 0 &&
 			selectedIndex < this.postKeys.length &&
 			this.isValidPostOrGap( this.postKeys[ selectedIndex ] ) ) {
 			this.selectedIndex = selectedIndex;
+			setLastStoreId( id )
 			this.emitChange();
 		}
 	}

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -190,9 +190,10 @@ export default class FeedStream {
 			this.emitChange();
 		}
 
+		const PREFETCH_THRESHOLD = 10;
 		// If we are getting close to the end of the loaded stream, or are already at the end,
 		// start fetching new posts
-		if ( nextIndex + 4 > this.postKeys.length || nextIndex === -1 ) {
+		if ( nextIndex + PREFETCH_THRESHOLD > this.postKeys.length || nextIndex === -1 ) {
 			const fetchNextPage = () => FeedStreamActions.fetchNextPage( this.getID() );
 			defer( fetchNextPage );
 		}

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -216,7 +216,7 @@ export default class FeedStream {
 			selectedIndex < this.postKeys.length &&
 			this.isValidPostOrGap( this.postKeys[ selectedIndex ] ) ) {
 			this.selectedIndex = selectedIndex;
-			setLastStoreId( id )
+			setLastStoreId( id );
 			this.emitChange();
 		}
 	}

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -27,6 +27,7 @@ import { action as ActionTypes } from './constants';
 import PollerPool from 'lib/data-poller';
 import XPostHelper from 'reader/xpost-helper';
 import { setLastStoreId } from 'reader/controller-helper';
+import * as stats from 'reader/stats';
 
 const debug = debugFactory( 'calypso:feed-store:post-list-store' );
 
@@ -197,7 +198,12 @@ export default class FeedStream {
 		if ( nextIndex + PREFETCH_THRESHOLD > this.postKeys.length || nextIndex === -1 ) {
 			const fetchNextPage = () => FeedStreamActions.fetchNextPage( this.getID() );
 			defer( fetchNextPage );
+			this.onKeyboardFetchPerformed();
 		}
+	}
+
+	onKeyboardFetchPerformed() {
+		stats.recordTrack( 'calypso_reader_fullpost_keyboard_fetch' );
 	}
 
 	selectPrevItem() {

--- a/client/lib/feed-stream-store/test/index.js
+++ b/client/lib/feed-stream-store/test/index.js
@@ -1,15 +1,24 @@
 /**
  * External Dependencies
  */
-var expect = require( 'chai' ).expect,
-	useFilesystemMocks = require( 'test/helpers/use-filesystem-mocks' ),
-	sinon = require( 'sinon' ),
-	set = require( 'lodash/set' );
+import { expect } from 'chai';
+import sinon from 'sinon';
+import set from 'lodash/set';
 
-var PostListStore, FeedPostStore, FeedSubscriptionStore;
+/**
+ * Internal Dependencies
+ */
+import useFilesystemMocks from 'test/helpers/use-filesystem-mocks';
+import useMockery from 'test/helpers/use-mockery';
+
+let PostListStore, FeedPostStore, FeedSubscriptionStore;
 
 describe( 'FeedPostList', function() {
 	useFilesystemMocks( __dirname );
+
+	useMockery( mockery => {
+		mockery.registerMock( 'reader/stats', { recordTrack: sinon.spy() } );
+	} );
 
 	before( function() {
 		PostListStore = require( '../feed-stream' );

--- a/client/reader/controller-helper.js
+++ b/client/reader/controller-helper.js
@@ -12,6 +12,14 @@ import { recordTrack } from 'reader/stats';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import * as FeedStreamStoreActions from 'lib/feed-stream-store/actions';
 
+let storeId;
+export function getLastStoreId() {
+	return storeId;
+}
+export function setLastStoreId( id ) {
+	storeId = id;
+}
+
 export function ensureStoreLoading( store, context ) {
 	if ( store.getPage() === 1 ) {
 		if ( context && context.query && context.query.at ) {

--- a/client/reader/controller-helper.js
+++ b/client/reader/controller-helper.js
@@ -11,13 +11,18 @@ import analytics from 'lib/analytics';
 import { recordTrack } from 'reader/stats';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import * as FeedStreamStoreActions from 'lib/feed-stream-store/actions';
+import feedStreamFactory from 'lib/feed-stream-store';
 
 let storeId;
-export function getLastStoreId() {
-	return storeId;
-}
 export function setLastStoreId( id ) {
 	storeId = id;
+}
+
+export function getLastStore() {
+	if ( storeId ) {
+		return feedStreamFactory( storeId );
+	}
+	return null;
 }
 
 export function ensureStoreLoading( store, context ) {

--- a/client/reader/post-byline/test/index.jsx
+++ b/client/reader/post-byline/test/index.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { assert, expect } from 'chai';
 import { spy } from 'sinon';
-import { each, omit } from 'lodash';
+import { each, omit, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,6 +24,7 @@ describe( 'PostByline', () => {
 
 	useMockery( ( mockery ) => {
 		mockery.registerMock( 'reader/stats', statsSpies );
+		mockery.registerMock( 'lib/analytics', { ga: { recordEvent: noop } } );
 	} );
 
 	before( () => {

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -70,7 +70,7 @@ const SearchCardAdapter = ( isRecommendations ) => class extends Component {
 
 	onCardClick = ( post ) => {
 		recordTrackForPost( 'calypso_reader_searchcard_clicked', post );
-		this.props.handleClick( post, {} );
+		this.props.handleClick( { post } );
 	}
 
 	onCommentClick = () => {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -437,12 +437,12 @@ export default class ReaderStream extends React.Component {
 		}
 	}
 
-	showFullPost( post, options = {} ) {
+	showFullPost = ( post, options = {} ) => {
 		const hashtag = options.comments ? '#comments' : '';
-		let query = '';
+		let query = `?storeId=${ this.props.store.id }`;
 		if ( post.referral ) {
 			const { blogId, postId } = post.referral;
-			query = `?ref_blog=${ blogId }&ref_post=${ postId }`;
+			query += `ref_blog=${ blogId }&ref_post=${ postId }`;
 		}
 		const method = options && options.replaceHistory ? 'replace' : 'show';
 		if ( post.feed_ID && post.feed_item_ID ) {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -441,7 +441,6 @@ export default class ReaderStream extends React.Component {
 			key={ itemKey }
 			ref={ itemKey }
 			isSelected={ isSelected }
-			handleXPostClick={ showPost }
 			handleClick={ showPost }
 			postKey={ postKey }
 			store={ this.props.store }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -435,7 +435,8 @@ export default class ReaderStream extends React.Component {
 		}
 
 		const itemKey = this.getPostRef( postKey );
-		const showPost = this.enhanceWithPostSelectionMetadata( showSelectedPost, postKey, this.props.store );
+		const showPost = this.enhanceWithPostSelectionMetadata( showSelectedPost,
+			postKey, this.props.store );
 
 		return <PostLifecycle
 			key={ itemKey }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -435,8 +435,12 @@ export default class ReaderStream extends React.Component {
 		}
 
 		const itemKey = this.getPostRef( postKey );
-		const showPost = this.enhanceWithPostSelectionMetadata( showSelectedPost,
-			postKey, this.props.store );
+		const showPost = ( args ) => showSelectedPost( {
+			...args,
+			postKey,
+			store: this.props.store,
+			index,
+		} );
 
 		return <PostLifecycle
 			key={ itemKey }
@@ -454,17 +458,6 @@ export default class ReaderStream extends React.Component {
 			followSource={ this.props.followSource }
 		/>;
 	}
-
-	// input fn must only take a single object-like argument.
-	// output is a function that is identical to the input fn except that its option
-	// argument will also have postKey and store, and index in it
-	enhanceWithPostSelectionMetadata = ( fn, postKey, store ) => args =>
-		fn( {
-			...args,
-			postKey,
-			store,
-			index: this.state.posts.indexOf( postKey )
-		} );
 
 	render() {
 		const store = this.props.store,

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -72,7 +72,7 @@ export default class PostLifecycle extends React.PureComponent {
 						isSelected={ this.props.isSelected }
 						xMetadata={ xMetadata }
 						xPostedTo={ this.props.store.getSitesCrossPostedTo( xMetadata.commentURL || xMetadata.postURL ) }
-						handleClick={ this.props.handleXPostClick } />;
+						handleClick={ this.props.handleClick } />;
 				}
 
 				return <PostClass

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -35,7 +35,9 @@ class ReaderPostCardAdapter extends React.Component {
 				}
 			};
 		}
-		this.props.handleClick && this.props.handleClick( referredPost || postToOpen );
+		this.props.handleClick && this.props.handleClick( {
+			post: referredPost || postToOpen
+		} );
 	}
 
 	onCommentClick = () => {
@@ -43,7 +45,10 @@ class ReaderPostCardAdapter extends React.Component {
 		recordGaEvent( 'Clicked Post Comment Button' );
 		recordTrackForPost( 'calypso_reader_post_comments_button_clicked', this.props.post );
 
-		this.props.handleClick && this.props.handleClick( this.props.post, { comments: true } );
+		this.props.handleClick && this.props.handleClick( {
+			post: this.props.post,
+			comments: true
+		} );
 	}
 
 	// take what the stream hands to a card and adapt it

--- a/client/reader/utils.js
+++ b/client/reader/utils.js
@@ -1,10 +1,20 @@
-const url = require( 'url' );
+/**
+ * External Dependencies
+ */
+import url from 'url';
+import page from 'page';
 
-const i18n = require( 'i18n-calypso' ),
-	SiteState = require( 'lib/reader-site-store/constants' ).state,
-	FeedDisplayHelper = require( 'reader/lib/feed-display-helper' );
+/**
+ * Internal Dependencies
+ */
+import i18n from 'i18n-calypso';
+import { state as SiteState } from 'lib/reader-site-store/constants';
+import FeedDisplayHelper from 'reader/lib/feed-display-helper';
+import PostStore from 'lib/feed-post-store';
 
-function siteNameFromSiteAndPost( site, post ) {
+import XPostHelper, { isXPost } from 'reader/xpost-helper';
+
+export function siteNameFromSiteAndPost( site, post ) {
 	let siteName;
 
 	if ( site && ( site.title || site.domain ) ) {
@@ -34,7 +44,7 @@ function siteNameFromSiteAndPost( site, post ) {
  * @param  {Object} post A Reader post
  * @return {Object}      A site like object
  */
-function siteishFromSiteAndPost( site, post ) {
+export function siteishFromSiteAndPost( site, post ) {
 	if ( site ) {
 		return site.toJS();
 	}
@@ -52,11 +62,11 @@ function siteishFromSiteAndPost( site, post ) {
 	};
 }
 
-function isSpecialClick( event ) {
+export function isSpecialClick( event ) {
 	return event.button > 0 || event.metaKey || event.controlKey || event.shiftKey || event.altKey;
 }
 
-function isPostNotFound( post ) {
+export function isPostNotFound( post ) {
 	if ( post === undefined ) {
 		return false;
 	}
@@ -64,9 +74,75 @@ function isPostNotFound( post ) {
 	return post.statusCode === 404;
 }
 
-module.exports = {
-	siteNameFromSiteAndPost,
-	siteishFromSiteAndPost,
-	isSpecialClick,
-	isPostNotFound
-};
+export function showSelectedPost( { store, replaceHistory, selectedGap } ) {
+	if ( ! store || ! store.getSelectedPost() ) {
+		return;
+	}
+
+	const postKey = store.getSelectedPost();
+
+	if ( postKey.isGap === true ) {
+		return selectedGap.handleClick();
+	}
+
+	// rec block
+	if ( postKey.isRecommendationBlock ) {
+		return;
+	}
+
+	const post = PostStore.get( postKey );
+
+	if ( isXPost( post ) && ! replaceHistory ) {
+		return showFullXPost( XPostHelper.getXPostMetadata( post ) );
+	}
+
+	// normal
+	let mappedPost;
+	if ( !! postKey.feedId ) {
+		mappedPost = {
+			feed_ID: postKey.feedId,
+			feed_item_ID: postKey.postId
+		};
+	} else {
+		mappedPost = {
+			site_ID: postKey.blogId,
+			ID: postKey.postId
+		};
+	}
+
+	showFullPost( {
+		post: mappedPost,
+		replaceHistory,
+	} );
+}
+
+export function showFullXPost( xMetadata ) {
+	if ( xMetadata.blogId && xMetadata.postId ) {
+		const mappedPost = {
+			site_ID: xMetadata.blogId,
+			ID: xMetadata.postId
+		};
+
+		showFullPost( {
+			post: mappedPost,
+		} );
+	} else {
+		window.open( xMetadata.postURL );
+	}
+}
+
+export function showFullPost( { post, replaceHistory, comments } ) {
+	const hashtag = comments ? '#comments' : '';
+	let query = '';
+	if ( post.referral ) {
+		const { blogId, postId } = post.referral;
+		query += `ref_blog=${ blogId }&ref_post=${ postId }`;
+	}
+
+	const method = replaceHistory ? 'replace' : 'show';
+	if ( post.feed_ID && post.feed_item_ID ) {
+		page[ method ]( `/read/feeds/${ post.feed_ID }/posts/${ post.feed_item_ID }${ hashtag }${ query }` );
+	} else {
+		page[ method ]( `/read/blogs/${ post.site_ID }/posts/${ post.ID }${ hashtag }${ query }` );
+	}
+}

--- a/client/reader/utils.js
+++ b/client/reader/utils.js
@@ -3,6 +3,7 @@
  */
 import url from 'url';
 import page from 'page';
+import { isNumber } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -12,8 +13,8 @@ import { state as SiteState } from 'lib/reader-site-store/constants';
 import FeedDisplayHelper from 'reader/lib/feed-display-helper';
 import PostStore from 'lib/feed-post-store';
 import { selectItem } from 'lib/feed-stream-store/actions';
-
 import XPostHelper, { isXPost } from 'reader/xpost-helper';
+import { setLastStoreId } from 'reader/controller-helper';
 
 export function siteNameFromSiteAndPost( site, post ) {
 	let siteName;
@@ -80,8 +81,10 @@ export function showSelectedPost( { store, replaceHistory, selectedGap, postKey,
 		return;
 	}
 
-	if ( store && index ) {
+	if ( store && isNumber( index ) ) {
 		selectItem( store.getID(), index );
+	} else if ( ! store ) {
+		setLastStoreId( undefined );
 	}
 
 	if ( postKey.isGap === true ) {

--- a/client/reader/utils.js
+++ b/client/reader/utils.js
@@ -11,6 +11,7 @@ import i18n from 'i18n-calypso';
 import { state as SiteState } from 'lib/reader-site-store/constants';
 import FeedDisplayHelper from 'reader/lib/feed-display-helper';
 import PostStore from 'lib/feed-post-store';
+import { selectItem } from 'lib/feed-stream-store/actions';
 
 import XPostHelper, { isXPost } from 'reader/xpost-helper';
 
@@ -74,12 +75,14 @@ export function isPostNotFound( post ) {
 	return post.statusCode === 404;
 }
 
-export function showSelectedPost( { store, replaceHistory, selectedGap } ) {
-	if ( ! store || ! store.getSelectedPost() ) {
+export function showSelectedPost( { store, replaceHistory, selectedGap, postKey, index } ) {
+	if ( ! postKey ) {
 		return;
 	}
 
-	const postKey = store.getSelectedPost();
+	if ( store && index ) {
+		selectItem( store.getID(), index );
+	}
 
 	if ( postKey.isGap === true ) {
 		return selectedGap.handleClick();

--- a/client/reader/xpost-helper.js
+++ b/client/reader/xpost-helper.js
@@ -6,6 +6,7 @@ import url from 'url';
 /**
  * Internal dependencies
  */
+import { X_POST } from 'lib/feed-post-store/display-types';
 
 export default {
 	/**
@@ -43,3 +44,7 @@ export default {
 		return xPostMetadata;
 	}
 };
+
+export function isXPost( post ) {
+	return post && post.display_type & X_POST;
+}


### PR DESCRIPTION
Support for j/k navigation in fullpost! : https://github.com/Automattic/wp-calypso/issues/10097

TODO:
- [x] is the query string approach any good? maybe throw currentStream into redux instead?
- [x] remove the duplication between stream/fullpost
- [x] how should this handle xposts?
- [x] fetch new posts when near end of a store