### PR TITLE
Support: Update live course dates

### DIFF
--- a/client/me/help/help-courses/index.jsx
+++ b/client/me/help/help-courses/index.jsx
@@ -31,16 +31,20 @@ function getCourses() {
 			),
 			schedule: [
 				{
-					date: i18n.moment( new Date( 'Tues, 20 Dec 2016 17:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/249f9f7e54a2043534538d7d4481ef37'
+					date: i18n.moment( new Date( 'Tues, 3 Jan 2017 17:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/98bfc0551c58cf6c7510d14dfea9e911'
 				},
 				{
-					date: i18n.moment( new Date( 'Tues, 27 Dec 2016 17:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/c92e44425fd03f4dd746f627e8486654'
+					date: i18n.moment( new Date( 'Thur, 5 Jan 2017 21:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/ea2de9284e4d3e8a8c34be5db4a05ad8'
 				},
 				{
-					date: i18n.moment( new Date( 'Thur, 29 Dec 2016 21:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/17dc6cf9fae20b9366858a512be5123a'
+					date: i18n.moment( new Date( 'Tues, 10 Jan 2017 17:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/884569b846d17e4b66858a512be5123a'
+				},
+				{
+					date: i18n.moment( new Date( 'Thur, 12 Jan 2017 21:00:00 +0000' ) ),
+					registrationUrl: 'https://zoom.us/webinar/register/38423895b79000597c24e00bf0acd2b8'
 				},
 			],
 			videos: [


### PR DESCRIPTION
This updates the live course dates at wordpress.com/help/courses for
Business customers to include dates through the middle of January.

The following dates and times were added:

- 1/3 Tuesday 9AM PST:
https://zoom.us/webinar/register/98bfc0551c58cf6c7510d14dfea9e911
- 1/5 Thursday 1PM PST: 
https://zoom.us/webinar/register/ea2de9284e4d3e8a8c34be5db4a05ad8
- 1/10 Tuesday 9AM PST: 
https://zoom.us/webinar/register/884569b846d17e4b66858a512be5123a
- 1/12 Thursday 1PM PST: 
https://zoom.us/webinar/register/38423895b79000597c24e00bf0acd2b8

## To test
1. Load this branch on an account with a Business plan.
2. Visit http://calypso.localhost:3000/help/courses. You should see the above dates, times, and register links localized to your timezone.

Screenshot:

<img width="720" alt="screen shot 2016-12-31 at 11 45 36 am" src="https://cloud.githubusercontent.com/assets/7240478/21578869/fe3417e6-cf4e-11e6-8921-3e15ad01145f.png">

cc @isocialtish 