### PR TITLE
Signup: suspend Site Title AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -81,10 +81,10 @@ module.exports = {
 		allowExistingUsers: true,
 	},
 	siteTitleStep: {
-		datestamp: '20160928',
+		datestamp: '20170102',
 		variations: {
-			showSiteTitleStep: 50,
-			hideSiteTitleStep: 50,
+			showSiteTitleStep: 5,
+			hideSiteTitleStep: 95,
 		},
 		defaultVariation: 'hideSiteTitleStep',
 		allowExistingUsers: false


### PR DESCRIPTION
Now that we've let the Site Title test run at 50/50, we're suspending the test until we make a decision about its future. 

To test:

1. Checkout branch or use Calypso.live link
1. Start signup
1. Verify there are no JS errors
1. Verify Signup completes without the Site Title step.