### PR TITLE
DevDocs: add syntax highlighting

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -31,3 +31,4 @@
 
 // Devdocs
 @import 'devdocs/design/style';
+@import 'devdocs/design/syntax';

--- a/client/devdocs/design/syntax.scss
+++ b/client/devdocs/design/syntax.scss
@@ -1,0 +1,89 @@
+code[class*="lang-"] {
+    color: #393A34;
+    direction: ltr;
+    text-align: left;
+    white-space: pre;
+    line-height: 1.2em;
+
+    -moz-tab-size: 4;
+    -o-tab-size: 4;
+    tab-size: 4;
+
+    -webkit-hyphens: none;
+    -moz-hyphens: none;
+    -ms-hyphens: none;
+    hyphens: none;
+}
+
+code[class*="lang-"]::selection, code[class*="lang-"] ::selection,
+code[class*="lang-"]::-moz-selection, code[class*="lang-"] ::-moz-selection {
+    background: #b3d4fc;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+    color: #969896; 
+    font-style: italic;
+}
+
+.token.namespace {
+    opacity: .7;
+}
+
+.token.string,
+.token.attr-value {
+    color: #183691;
+}
+
+.token.url,
+.token.symbol,
+.token.number,
+.token.boolean,
+.token.constant,
+.token.property,
+.token.regex,
+.token.variable,
+.token.inserted {
+    color: #0086b3;
+}
+
+.token.atrule,
+.token.attr-name,
+.language-autohotkey .token.selector {
+    color: #00a4db;
+}
+
+.token.function,
+.token.deleted,
+.language-autohotkey .token.tag {
+    color: #9a050f;
+}
+
+.token.tag,
+.token.selector,
+.language-autohotkey .token.keyword {
+    color: #00009f;
+}
+
+.token.important,
+.token.function,
+.token.bold {
+    font-weight: bold;
+}
+
+.token.italic {
+    font-style: italic;
+}
+
+.token.punctuation,
+.token.operator,
+.token.keyword {
+  color: #a71d5d;
+}
+
+.token.entity,
+.token.function {
+	color: #795da3;
+}

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "phone": "git+https://github.com/Automattic/node-phone.git#1.0.8",
     "photon": "2.0.0",
     "postcss-cli": "2.5.1",
+    "prismjs": "^1.6.0",
     "q": "1.0.1",
     "qrcode.react": "0.6.1",
     "qs": "4.0.0",

--- a/server/devdocs/index.js
+++ b/server/devdocs/index.js
@@ -29,12 +29,13 @@ const root = fs.realpathSync( fspath.join( __dirname, '..', '..' ) ),
 const SNIPPET_PAD_LENGTH = 40;
 const DEFAULT_SNIPPET_LENGTH = 100;
 
-/**
- * Configure marked to use Prism for code-block highlighting
- */
+// Configure marked to use Prism for code-block highlighting.
 marked.setOptions( {
 	highlight: function( code, language ) {
-		return Prism.highlight( code, Prism.languages[ language ] );
+		const syntax = Prism.languages[ language ];
+		return syntax
+			? Prism.highlight( code, syntax )
+			: code;
 	}
 } );
 

--- a/server/devdocs/index.js
+++ b/server/devdocs/index.js
@@ -8,6 +8,8 @@ import fspath from 'path';
 import marked from 'marked';
 import lunr from 'lunr';
 import { find, escape as escapeHTML } from 'lodash';
+import Prism from 'prismjs';
+import 'prismjs/components/prism-jsx';
 
 /**
  * Internal dependencies
@@ -26,6 +28,15 @@ const root = fs.realpathSync( fspath.join( __dirname, '..', '..' ) ),
  */
 const SNIPPET_PAD_LENGTH = 40;
 const DEFAULT_SNIPPET_LENGTH = 100;
+
+/**
+ * Configure marked to use Prism for code-block highlighting
+ */
+marked.setOptions( {
+	highlight: function( code, language ) {
+		return Prism.highlight( code, Prism.languages[ language ] );
+	}
+} );
 
 /**
  * Query the index using lunr.

--- a/server/devdocs/index.js
+++ b/server/devdocs/index.js
@@ -10,6 +10,7 @@ import lunr from 'lunr';
 import { find, escape as escapeHTML } from 'lodash';
 import Prism from 'prismjs';
 import 'prismjs/components/prism-jsx';
+import 'prismjs/components/prism-json';
 
 /**
  * Internal dependencies
@@ -28,6 +29,9 @@ const root = fs.realpathSync( fspath.join( __dirname, '..', '..' ) ),
  */
 const SNIPPET_PAD_LENGTH = 40;
 const DEFAULT_SNIPPET_LENGTH = 100;
+
+// Alias `javascript` language to `es6`
+Prism.languages.es6 = Prism.languages.javascript;
 
 // Configure marked to use Prism for code-block highlighting.
 marked.setOptions( {


### PR DESCRIPTION
This PR adds syntax highlighting to the code blocks shown in DevDocs.
Currently code blocks are wrapped in `<pre>` and `<code>` tags via the `marked` package but the content itself is not processed for syntax.
@alisterscott pointed this out in a recent PR of mine (#10329)

This is not a perfect solution however... I've been working with the [EmptyContent DevDoc page](https://wpcalypso.wordpress.com/devdocs/client/components/empty-content/README.md) while developing and noticed that some `.jsx` syntax is not parsed properly.

<img width="567" alt="emptycontent-syntax" src="https://cloud.githubusercontent.com/assets/4335450/21585260/11345068-d111-11e6-8601-2f798b46adfb.png">

In this PR `marked` is configured to use `prismjs` to handle syntax highlighting. 
I've added some styling that is fairly close to GitHubs (at least in terms of colors).

So far I've tried a similar approach with highlight.js too, though this is also lacking in perfect `.jsx` support.

There is certainly an improvement but I wouldn't expect a merge right away until other options are explored.

I thought I'd get this up early in the hopes of starting a conversation - hopefully somebody out there has more experience than I do with highlighting packages :)

### Testing

Test various syntax types, checking that A) they are highlighted and B) they are highlighted correctly (allowing for caveats mentioned in the discussion):
- js: [ButtonGroup](http://calypso.localhost:3000/devdocs/client/components/button-group/README.md) (ignoring jsx here)
- javascript: [UrlPreview](http://calypso.localhost:3000/devdocs/client/blocks/url-preview/README.md) (ignoring jsx here)
- jsx: [EmptyContent](http://calypso.localhost:3000/devdocs/client/components/empty-content/README.md)
- es6: [SyncHandler](http://calypso.localhost:3000/devdocs/client/lib/wp/sync-handler/README.md)
- html: [MultiCheckbox](http://calypso.localhost:3000/devdocs/client/components/forms/multi-checkbox/README.md)
- json: [Extensions](http://calypso.localhost:3000/devdocs/client/extensions/README.md)

Notes: the only other syntax in use in code-blocks is 'text' (from a project-wide search for all instances of ` ``` ` ).