### PR TITLE
Stats: Add Post Likes to Post Stats Summary Page

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -337,6 +337,7 @@
 @import 'my-sites/stats/stats-navigation/style';
 @import 'my-sites/stats/stats-overview-placeholder/style';
 @import 'my-sites/stats/stats-period-navigation/style';
+@import 'my-sites/stats/stats-post-likes/style';
 @import 'my-sites/stats/stats-post-summary/style';
 @import 'my-sites/stats/stats-site-overview/style';
 @import 'my-sites/stats/stats-tabs/style';

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -512,3 +512,20 @@ ul.module-header-actions {
 		@include long-content-fade( $color: $white, $size: 15% );
 	}
 }
+
+.stats-post-likes {
+	.stats-post-likes__content {
+		box-sizing: border-box;
+		padding: 8px 24px;
+		color: $gray-dark;
+		font-size: 13px;
+	}
+
+	.count {
+		margin-left: 8px;
+	}
+
+	.gravatar {
+		margin-right: 8px;
+	}
+}

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -512,20 +512,3 @@ ul.module-header-actions {
 		@include long-content-fade( $color: $white, $size: 15% );
 	}
 }
-
-.stats-post-likes {
-	.stats-post-likes__content {
-		box-sizing: border-box;
-		padding: 8px 24px;
-		color: $gray-dark;
-		font-size: 13px;
-	}
-
-	.count {
-		margin-left: 8px;
-	}
-
-	.gravatar {
-		margin-right: 8px;
-	}
-}

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -2,8 +2,10 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
 import page from 'page';
 import { localize } from 'i18n-calypso';
+import { flowRight } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,6 +19,8 @@ import HeaderCake from 'components/header-cake';
 import { decodeEntities } from 'lib/formatting';
 import Main from 'components/main';
 import StatsFirstView from '../stats-first-view';
+import PostLikes from '../stats-post-likes';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 const StatsPostDetail = React.createClass( {
 	mixins: [ observe( 'postViewsList' ) ],
@@ -77,9 +81,22 @@ const StatsPostDetail = React.createClass( {
 					postViewsList={ this.props.postViewsList } />
 
 				<PostWeeks postViewsList={ this.props.postViewsList } />
+
+				{ post && <PostLikes postId={ post.ID } siteId={ this.props.siteId } /> }
 			</Main>
 		);
 	}
 } );
 
-export default localize( StatsPostDetail );
+const connectComponent = connect(
+	state => {
+		return {
+			siteId: getSelectedSiteId( state ),
+		};
+	}
+);
+
+export default flowRight(
+	connectComponent,
+	localize,
+)( StatsPostDetail );

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -68,6 +68,8 @@ const StatsPostDetail = React.createClass( {
 
 				<PostSummary siteId={ this.props.siteId } postId={ this.props.postId } />
 
+				{ !! this.props.postId && <PostLikes siteId={ this.props.siteId } postId={ this.props.postId } /> }
+
 				<PostMonths
 					dataKey="years"
 					title={ this.props.translate( 'Months and Years' ) }
@@ -81,8 +83,6 @@ const StatsPostDetail = React.createClass( {
 					postViewsList={ this.props.postViewsList } />
 
 				<PostWeeks postViewsList={ this.props.postViewsList } />
-
-				{ post && <PostLikes postId={ post.ID } siteId={ this.props.siteId } /> }
 			</Main>
 		);
 	}

--- a/client/my-sites/stats/stats-post-likes/index.jsx
+++ b/client/my-sites/stats/stats-post-likes/index.jsx
@@ -1,0 +1,88 @@
+/**
+ * External dependencies
+ **/
+import React from 'react';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import { flowRight } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Count from 'components/count';
+import Gridicon from 'components/gridicon';
+import Gravatar from 'components/gravatar';
+import StatsModuleContent from '../stats-module/content-text';
+import QueryPostLikes from 'components/data/query-post-likes';
+import StatsModulePlaceholder from '../stats-module/placeholder';
+import toggleInfo from '../toggle-info';
+import { isRequestingPostLikes, getPostLikes, countPostLikes } from 'state/selectors';
+
+export const PostLikes = ( { countLikes, isRequesting, likes, opened, postId, siteId, toggle, translate } ) => {
+	const infoIcon = opened ? 'info' : 'info-outline';
+	const classes = {
+		'is-showing-info': opened,
+	};
+
+	return (
+		<Card className={ classNames( 'stats-module', 'stats-post-likes', 'is-expanded', classes ) }>
+			<QueryPostLikes siteId={ siteId } postId={ postId } />
+			<div className="module-header">
+				<h4 className="module-header-title">
+					{ translate( 'Post Likes' ) }
+					{ countLikes !== null && <Count count={ countLikes } /> }
+				</h4>
+				<ul className="module-header-actions">
+					<li className="module-header-action toggle-info">
+						<a
+							href="#"
+							className="module-header-action-link"
+							aria-label={ translate( 'Show or hide panel information', { textOnly: true, context: 'Stats panel action' } ) }
+							title={ translate( 'Show or hide panel information', { textOnly: true, context: 'Stats panel action' } ) }
+							onClick={ toggle }
+						>
+							<Gridicon icon={ infoIcon } />
+						</a>
+					</li>
+				</ul>
+			</div>
+			<StatsModuleContent className="module-content-text-info">
+				<p>{ translate( 'This panel shows the list of people who likes your post.' ) }</p>
+			</StatsModuleContent>
+			<StatsModulePlaceholder isLoading={ isRequesting && ! likes } />
+			{ likes && !! likes.length &&
+				<div className="stats-post-likes__content">
+					{ likes.map( like =>
+						<Gravatar key={ like.ID } user={ like } />
+					) }
+				</div>
+			}
+			{ countLikes === 0 && ! isRequesting &&
+				<div className="stats-post-likes__content">
+					{ translate( 'This post has not likes yet!' ) }
+				</div>
+			}
+		</Card>
+	);
+};
+
+const connectComponent = connect(
+	( state, { siteId, postId } ) => {
+		const isRequesting = isRequestingPostLikes( state, siteId, postId );
+		const countLikes = countPostLikes( state, siteId, postId );
+		const likes = getPostLikes( state, siteId, postId );
+		return {
+			countLikes,
+			isRequesting,
+			likes,
+		};
+	}
+);
+
+export default flowRight(
+	connectComponent,
+	toggleInfo,
+	localize
+)( PostLikes );

--- a/client/my-sites/stats/stats-post-likes/index.jsx
+++ b/client/my-sites/stats/stats-post-likes/index.jsx
@@ -55,13 +55,15 @@ export const PostLikes = ( { countLikes, isRequesting, likes, opened, postId, si
 			{ likes && !! likes.length &&
 				<div className="stats-post-likes__content">
 					{ likes.map( like =>
-						<Gravatar key={ like.ID } user={ like } />
+						<a key={ like.ID } href={ like.URL } rel="noopener noreferrer" target="_blank">
+							<Gravatar user={ like } />
+						</a>
 					) }
 				</div>
 			}
 			{ countLikes === 0 && ! isRequesting &&
 				<div className="stats-post-likes__content">
-					{ translate( 'This post has not likes yet!' ) }
+					{ translate( 'There are no likes on this post yet.' ) }
 				</div>
 			}
 		</Card>

--- a/client/my-sites/stats/stats-post-likes/index.jsx
+++ b/client/my-sites/stats/stats-post-likes/index.jsx
@@ -54,7 +54,7 @@ export const PostLikes = props => {
 				</ul>
 			</div>
 			<StatsModuleContent className="module-content-text-info">
-				<p>{ translate( 'This panel shows the list of people who likes your post.' ) }</p>
+				{ translate( 'This panel shows the list of people who like your post.' ) }
 			</StatsModuleContent>
 			<StatsModulePlaceholder isLoading={ isLoading } />
 			{ likes && !! likes.length &&
@@ -69,7 +69,7 @@ export const PostLikes = props => {
 									className="stats-post-likes__like"
 									onClick={ trackLikeClick }
 								>
-									<Gravatar user={ like } />
+									<Gravatar user={ like } size={ 24 } />
 								</a>
 							).concat(
 								countLikes > likes.length && <span key="placeholder" className="stats-post-likes__placeholder">

--- a/client/my-sites/stats/stats-post-likes/index.jsx
+++ b/client/my-sites/stats/stats-post-likes/index.jsx
@@ -30,6 +30,9 @@ export const PostLikes = props => {
 		'is-loading': isLoading,
 	};
 	const trackLikeClick = () => props.recordGoogleEvent( 'Stats Post Likes', 'Clicked on Gravatar' );
+	const getLikeUrl = like => {
+		return like.URL ? like.URL : `https://gravatar.com/${ like.login }`;
+	};
 
 	return (
 		<Card className={ classNames( 'stats-module', 'stats-post-likes', 'is-expanded', classes ) }>
@@ -63,7 +66,7 @@ export const PostLikes = props => {
 							.map( like =>
 								<a
 									key={ like.ID }
-									href={ `https://gravatar.com/${ like.login }` }
+									href={ getLikeUrl( like ) }
 									rel="noopener noreferrer"
 									target="_blank"
 									className="stats-post-likes__like"

--- a/client/my-sites/stats/stats-post-likes/style.scss
+++ b/client/my-sites/stats/stats-post-likes/style.scss
@@ -10,25 +10,29 @@
 		font-size: 13px;
 	}
 
-	.gravatar {
-	}
-
 	.stats-post-likes__like {
 		display: inline-block;
-		margin: 0 8px 6px 0;
+		margin: 2px 8px 2px 0;
 		vertical-align: top;
+		.gravatar {
+			display: block;
+		}
 	}
 
 	.stats-post-likes__placeholder {
-		height: 32px;
-		line-height: 30px;
-		border-radius: 16px;
-		display: inline-block;
-		border: solid 1px $gray;
-		color: $gray;
-		padding: 0 8px;
 		vertical-align: top;
-		box-sizing: border-box;
-		margin: 0 8px 6px 0;
+		margin-top: 6px;
+		line-height: 14px;
+		border-radius: 12px;
+		display: inline-block;
+		border: solid 1px #87a6bc;
+		color: #87a6bc;
+		padding: 1px 6px;
+		font-weight: 600;
+		font-size: 11px;
+	}
+
+	.module-content-text-info {
+		padding: 16px;
 	}
 }

--- a/client/my-sites/stats/stats-post-likes/style.scss
+++ b/client/my-sites/stats/stats-post-likes/style.scss
@@ -1,0 +1,34 @@
+.stats-post-likes {
+	.count {
+		margin-left: 8px;
+	}
+
+	.stats-post-likes__content {
+		box-sizing: border-box;
+		padding: 8px 24px;
+		color: $gray-dark;
+		font-size: 13px;
+	}
+
+	.gravatar {
+	}
+
+	.stats-post-likes__like {
+		display: inline-block;
+		margin: 0 8px 6px 0;
+		vertical-align: top;
+	}
+
+	.stats-post-likes__placeholder {
+		height: 32px;
+		line-height: 30px;
+		border-radius: 16px;
+		display: inline-block;
+		border: solid 1px $gray;
+		color: $gray;
+		padding: 0 8px;
+		vertical-align: top;
+		box-sizing: border-box;
+		margin: 0 8px 6px 0;
+	}
+}

--- a/client/my-sites/stats/stats-post-likes/style.scss
+++ b/client/my-sites/stats/stats-post-likes/style.scss
@@ -5,7 +5,7 @@
 
 	.stats-post-likes__content {
 		box-sizing: border-box;
-		padding: 8px 24px;
+		padding: 8px 24px 16px;
 		color: $gray-dark;
 		font-size: 13px;
 	}

--- a/client/my-sites/stats/toggle-info.jsx
+++ b/client/my-sites/stats/toggle-info.jsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+const toggleInfo = WrappedComponent => class ToggleComponent extends Component {
+	state = {
+		open: false
+	};
+
+	toggle = event => {
+		event.preventDefault();
+		this.setState( {
+			open: ! this.state.open
+		} );
+	};
+
+	render() {
+		return (
+			<WrappedComponent { ...this.props } toggle={ this.toggle } opened={ this.state.open } />
+		);
+	}
+};
+
+export default toggleInfo;


### PR DESCRIPTION
Part of #10348

In this PR, I'm adding a new component to the Post Stats Summary Page. This component shows the Gravatars of the post likes and the total.

<img width="729" alt="screen shot 2017-01-02 at 16 37 14" src="https://cloud.githubusercontent.com/assets/272444/21591991/c7b1d8f4-d109-11e6-9899-246f66e5d92b.png">

Questions:

 * What if we have a huge number of likes, should we limit the Gravatars to something like the 100 first likes.
 * I used a `toggleInfo` HoC as a replacement to the old `toggle` mixin used on other stats components. The mixin used to store its state on local storage using the npm library `store`. Should I persist this state. I personally don't think it's worth it, and even if it is, I don't think we should add this to the global state tree, maybe we just keep a behaviour similar to the mixin (calling localstorage directly on the component).

Testing instructions

 - try opening the stats summary page for different posts and see how the new component behaves.
`/stats/post/$postId/$siteId`