### PR TITLE
Stats: utilize wideLayout in stats components.

### DIFF
--- a/client/my-sites/stats/follows/index.jsx
+++ b/client/my-sites/stats/follows/index.jsx
@@ -56,7 +56,7 @@ const StatsFollows = React.createClass( {
 		const { followType, followersList, followList, perPage, translate } = this.props;
 
 		return (
-			<Main>
+			<Main wideLayout={ true }>
 				<StatsFirstView />
 
 				<div id="my-stats-content" className={ 'follows-detail follows-detail-' + followType }>

--- a/client/my-sites/stats/overview.jsx
+++ b/client/my-sites/stats/overview.jsx
@@ -91,7 +91,7 @@ export default React.createClass( {
 		}, this );
 
 		return (
-			<Main>
+			<Main wideLayout={ true }>
 				<StatsFirstView />
 				<SidebarNavigation />
 				<StatsNavigation section={ this.props.period } />

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -132,7 +132,7 @@ module.exports = React.createClass( {
 		}
 
 		return (
-			<Main>
+			<Main wideLayout={ true }>
 				<StatsFirstView />
 				<SidebarNavigation />
 				<StatsNavigation

--- a/client/my-sites/stats/stats-detail-months/index.jsx
+++ b/client/my-sites/stats/stats-detail-months/index.jsx
@@ -83,7 +83,7 @@ export default React.createClass( {
 				const year = data[ dataKey ][ i ];
 				const cells = [];
 
-				cells.push( <th key={ 'header' + i }>{ i }</th> );
+				cells.push( <td key={ 'header' + i } className="stats-detail__row-label">{ i }</td> );
 
 				for ( let j = 1; j <= 12; j++ ) {
 					const hasData = ( year.months[ j ] || 0 === year.months[ j ] );

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -74,7 +74,7 @@ export default React.createClass( {
 		// TODO: should be refactored into separate components
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<Main>
+			<Main wideLayout={ true }>
 				<StatsFirstView />
 				<SidebarNavigation />
 				<StatsNavigation section="insights" site={ site } />

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -373,6 +373,9 @@ ul.module-header-actions {
 }
 
 // Module Content Table
+.stats-detail__row-label {
+	font-weight: 600;
+}
 
 .module-content-table {
 	position: relative;

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -56,7 +56,7 @@ export default React.createClass( {
 		}
 
 		return (
-			<Main>
+			<Main wideLayout={ true }>
 				<StatsFirstView />
 
 				<HeaderCake onClick={ this.goBack }>

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -216,7 +216,7 @@ const StatsSummary = React.createClass( {
 		summaryViews.push( summaryView );
 
 		return (
-			<Main>
+			<Main wideLayout={ true }>
 				<StatsFirstView />
 				<div id="my-stats-content">
 					<HeaderCake onClick={ this.goBack }>


### PR DESCRIPTION
One frequent criticism of stats in calypso is that the `Main` column is too narrow, and because of that, a large amount of data is crowded into a horizontally narrow space.  This branch try's to increase the real estate to display data by using the `wideLayout` prop on `Main`

__Notes__
By increasing the overall container width, there are definitely some further design considerations that come into play.  Specifically, some components on the Inisghts page like Posting Activity and Post Summary to me have a large amount of white space on wider screens.  It would be nice to follow-up on individual components like these to see if we can update them accordingly.

Another fantastic side-affect of this change is the chart bars in the "Day" view are much wider when space is available.  This was another piece of feedback from users - the bars being too narrow and difficult to interact with.

There is an abundance of lint errors throughout stats files ( they are like 70 years old in calypso years ), so I am opting to only change the needed items in this PR, and hopefully as we work with individual components, we can bring them up to standards whenever possible.

__Before: Insights Page__
![stats_ _fly_fishers_place_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/21594407/15d6ea7a-d0d7-11e6-8eb8-40df9b6e073e.png)

__After: Insights Page__
![stats_ _fly_fishers_place_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/21594418/3e63ecf4-d0d7-11e6-9c93-5a333b5f0696.png)

__Before: Stats Period Page__
![stats_ _fly_fishers_place_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/21594470/e2f7b5c0-d0d7-11e6-86b2-903f0842dec2.png)

__After: Stats Period Page__
![stats_ _fly_fishers_place_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/21594485/04a55574-d0d8-11e6-8e9b-1e0fb5773da8.png)

__Before: Post Summary Page__
![stats_ _fly_fishers_place_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/21594508/33bb615a-d0d8-11e6-9956-5cba2da9ba5d.png)

__After: Post Summary Page__
![stats_ _fly_fishers_place_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/21594518/4f52020c-d0d8-11e6-9d6f-76e4827d150a.png)

