### PR TITLE
Site Settings: Display site icon modal only if site supports image editing

### DIFF
--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -32,12 +32,14 @@ import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
 import { isItemBeingUploaded } from 'lib/media/utils';
 import { addQueryArgs } from 'lib/url';
 import { getImageEditorCrop } from 'state/ui/editor/image-editor/selectors';
+import { isSiteSupportingImageEditor } from 'state/selectors';
 
 class SiteIconSetting extends Component {
 	static propTypes = {
 		translate: PropTypes.func,
 		siteId: PropTypes.number,
 		isJetpack: PropTypes.bool,
+		siteSupportsImageEditor: PropTypes.bool,
 		customizerUrl: PropTypes.string,
 		generalOptionsUrl: PropTypes.string,
 		onEditSelectedMedia: PropTypes.func,
@@ -136,9 +138,9 @@ class SiteIconSetting extends Component {
 	}
 
 	render() {
-		const { translate, siteId, isJetpack, customizerUrl, generalOptionsUrl } = this.props;
+		const { translate, siteId, isJetpack, customizerUrl, generalOptionsUrl, siteSupportsImageEditor } = this.props;
 		const { isModalVisible, hasToggledModal } = this.state;
-		const isIconManagementEnabled = isEnabled( 'manage/site-settings/site-icon' );
+		const isIconManagementEnabled = isEnabled( 'manage/site-settings/site-icon' ) && siteSupportsImageEditor;
 
 		let buttonProps;
 		if ( isIconManagementEnabled ) {
@@ -213,6 +215,7 @@ export default connect(
 		return {
 			siteId,
 			isJetpack: isJetpackSite( state, siteId ),
+			siteSupportsImageEditor: isSiteSupportingImageEditor( state, siteId ),
 			customizerUrl: getCustomizerUrl( state, siteId ),
 			generalOptionsUrl: getSiteAdminUrl( state, siteId, 'options-general.php' ),
 			crop: getImageEditorCrop( state )

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -23,3 +23,4 @@ export isPrivateSite from './is-private-site';
 export isRequestingSharingButtons from './is-requesting-sharing-buttons';
 export isSavingSharingButtons from './is-saving-sharing-buttons';
 export isSharingButtonsSaveSuccessful from './is-sharing-buttons-save-successful';
+export isSiteSupportingImageEditor from './is-site-supporting-image-editor';

--- a/client/state/selectors/is-site-supporting-image-editor.js
+++ b/client/state/selectors/is-site-supporting-image-editor.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import { isJetpackModuleActive } from 'state/sites/selectors';
+import { isPrivateSite } from './';
+
+/**
+ * Returns false only if the site is known to not support editing images, or
+ * true otherwise.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {Boolean}        Whether site supports editing images
+ */
+export default function isSiteSupportingImageEditor( state, siteId ) {
+	return (
+		true !== isPrivateSite( state, siteId ) &&
+		false !== isJetpackModuleActive( state, siteId, 'photon' )
+	);
+}

--- a/client/state/selectors/test/is-site-supporting-image-editor.js
+++ b/client/state/selectors/test/is-site-supporting-image-editor.js
@@ -1,0 +1,95 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isSiteSupportingImageEditor } from '../';
+
+describe( 'isSiteSupportingImageEditor()', () => {
+	it( 'should return true if site is not tracked', () => {
+		const siteSupportsImageEditor = isSiteSupportingImageEditor( {
+			sites: {
+				items: {}
+			}
+		}, 2916284 );
+
+		expect( siteSupportsImageEditor ).to.be.true;
+	} );
+
+	it( 'should return true if site is public and not jetpack site', () => {
+		const siteSupportsImageEditor = isSiteSupportingImageEditor( {
+			sites: {
+				items: {
+					2916284: {
+						ID: 2916284,
+						name: 'example',
+						is_private: false,
+						jetpack: false
+					}
+				}
+			}
+		}, 2916284 );
+
+		expect( siteSupportsImageEditor ).to.be.true;
+	} );
+
+	it( 'should return false if site is private', () => {
+		const siteSupportsImageEditor = isSiteSupportingImageEditor( {
+			sites: {
+				items: {
+					2916284: {
+						ID: 2916284,
+						name: 'example',
+						is_private: true,
+						jetpack: false
+					}
+				}
+			}
+		}, 2916284 );
+
+		expect( siteSupportsImageEditor ).to.be.false;
+	} );
+
+	it( 'should return true if site is public and jetpack and has photon enabled', () => {
+		const siteSupportsImageEditor = isSiteSupportingImageEditor( {
+			sites: {
+				items: {
+					2916284: {
+						ID: 2916284,
+						name: 'example',
+						is_private: false,
+						jetpack: true,
+						options: {
+							active_modules: [ 'publicize', 'photon' ]
+						}
+					}
+				}
+			}
+		}, 2916284 );
+
+		expect( siteSupportsImageEditor ).to.be.true;
+	} );
+
+	it( 'should return false if site is public and jetpack but has photon disabled', () => {
+		const siteSupportsImageEditor = isSiteSupportingImageEditor( {
+			sites: {
+				items: {
+					2916284: {
+						ID: 2916284,
+						name: 'example',
+						is_private: false,
+						jetpack: true,
+						options: {
+							active_modules: [ 'publicize' ]
+						}
+					}
+				}
+			}
+		}, 2916284 );
+
+		expect( siteSupportsImageEditor ).to.be.false;
+	} );
+} );


### PR DESCRIPTION
Closes #10363 

This pull request seeks to check whether the current site supports image editing before offering the media modal flow for selecting a site icon. As described in #10363, private sites and Jetpack sites where Photon is not enabled cannot have their images edited. While the fallback flow currently redirects to "legacy" screens, it's hoped that in the near future this will redirect to the customizer within Calypso.

__Testing instructions:__

Verify that the media modal is only shown when choosing a site icon if the current site supports image editing.

1. Navigate to [site settings](http://calypso.localhost:3000/settings)
2. Select a site
3. Click Change under Site Icon
4. Note that...
 - If site is private or a Jetpack site without Photon module enabled, you are redirected to either wp-admin General settings (private WordPress.com site) or the Jetpack site's Customizer
 - Otherwise, the media modal is shown

__Caveats:__

If trying to switch your Photon setting in testing, I've noticed there's a small delay between when this is reflected in Calypso. You may need to give it a few minutes for this change to take effect.