### PR TITLE
Stats: add sparkline to sidebar menu.

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -309,6 +309,7 @@
 @import 'my-sites/sharing/connections/account-dialog';
 @import 'my-sites/sharing/connections/account-dialog-account';
 @import 'my-sites/sharing/connections/services-group';
+@import 'my-sites/sidebar/style';
 @import 'my-sites/sidebar-navigation/style';
 @import 'my-sites/site-indicator/style';
 @import 'my-sites/site-settings/style';

--- a/client/blocks/stats-sparkline/README.md
+++ b/client/blocks/stats-sparkline/README.md
@@ -8,7 +8,7 @@ The `StatsSparkline` block renders an image of a chart representing hourly views
 ```jsx
 import StatsSparkline from 'blocks/stats-sparkline';
 
-<StatsSparkline className="my-awesome-component__sparkline" siteID="777" />
+<StatsSparkline className="my-awesome-component__sparkline" siteId="777" />
 ```
 
 ## Props

--- a/client/blocks/stats-sparkline/README.md
+++ b/client/blocks/stats-sparkline/README.md
@@ -1,0 +1,33 @@
+StatsSparkline
+==============
+
+The `StatsSparkline` block renders an image of a chart representing hourly views for a given site.
+
+## Usage
+
+```jsx
+import StatsSparkline from 'blocks/stats-sparkline';
+
+<StatsSparkline className="my-awesome-component__sparkline" siteID="777" />
+```
+
+## Props
+
+
+### `siteId`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+The site ID to display the sparkline for.
+
+### `className`
+
+<table>
+	<tr><th>Type</th><td>String</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+Optional className that is applied to the sparkline image.

--- a/client/blocks/stats-sparkline/index.jsx
+++ b/client/blocks/stats-sparkline/index.jsx
@@ -7,17 +7,17 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { isJetpackSite, getSiteDomain } from 'state/sites/selectors';
+import { isJetpackSite, getSiteOption } from 'state/sites/selectors';
 
-const StatsSparkline = ( { isJetpack, siteDomain, className, siteId } ) => {
-	if ( ! siteId || ! siteDomain || isJetpack ) {
+const StatsSparkline = ( { isJetpack, siteUrl, className, siteId } ) => {
+	if ( ! siteId || ! siteUrl || isJetpack ) {
 		return null;
 	}
 
 	return (
 		<img
 			className={ className }
-			src={ `https://${ siteDomain }/wp-includes/charts/admin-bar-hours-scale-2x.php?masterbar=1&s=${ siteId }` } />
+			src={ `${ siteUrl }/wp-includes/charts/admin-bar-hours-scale-2x.php?masterbar=1&s=${ siteId }` } />
 	);
 };
 
@@ -25,7 +25,7 @@ StatsSparkline.propTypes = {
 	className: PropTypes.string,
 	siteId: PropTypes.number,
 	isJetpack: PropTypes.bool,
-	siteDomain: PropTypes.string,
+	siteUrl: PropTypes.string,
 };
 
 export default connect(
@@ -34,7 +34,7 @@ export default connect(
 
 		return {
 			isJetpack: isJetpackSite( state, siteId ),
-			siteDomain: getSiteDomain( state, siteId )
+			siteUrl: getSiteOption( state, siteId, 'unmapped_url' )
 		};
 	}
 )( StatsSparkline );

--- a/client/blocks/stats-sparkline/index.jsx
+++ b/client/blocks/stats-sparkline/index.jsx
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { isJetpackSite, getSiteDomain } from 'state/sites/selectors';
+
+const StatsSparkline = ( { isJetpack, siteDomain, className, siteId } ) => {
+	if ( ! siteId || ! siteDomain || isJetpack ) {
+		return null;
+	}
+
+	return (
+		<img
+			className={ className }
+			src={ `https://${ siteDomain }/wp-includes/charts/admin-bar-hours-scale-2x.php?masterbar=1&s=${ siteId }` } />
+	)
+};
+
+StatsSparkline.propTypes = {
+	className: PropTypes.string,
+};
+
+export default connect(
+	( state, ownProps ) => {
+		const { siteId } = ownProps;
+
+		return {
+			isJetpack: isJetpackSite( state, siteId ),
+			siteDomain: getSiteDomain( state, siteId )
+		};
+	}
+)( StatsSparkline );

--- a/client/blocks/stats-sparkline/index.jsx
+++ b/client/blocks/stats-sparkline/index.jsx
@@ -18,7 +18,7 @@ const StatsSparkline = ( { isJetpack, siteDomain, className, siteId } ) => {
 		<img
 			className={ className }
 			src={ `https://${ siteDomain }/wp-includes/charts/admin-bar-hours-scale-2x.php?masterbar=1&s=${ siteId }` } />
-	)
+	);
 };
 
 StatsSparkline.propTypes = {

--- a/client/blocks/stats-sparkline/index.jsx
+++ b/client/blocks/stats-sparkline/index.jsx
@@ -23,6 +23,9 @@ const StatsSparkline = ( { isJetpack, siteDomain, className, siteId } ) => {
 
 StatsSparkline.propTypes = {
 	className: PropTypes.string,
+	siteId: PropTypes.number,
+	isJetpack: PropTypes.bool,
+	siteDomain: PropTypes.string,
 };
 
 export default connect(

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -6,6 +6,7 @@ import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -24,6 +24,11 @@ import SidebarHeading from 'layout/sidebar/heading';
 import SidebarItem from 'layout/sidebar/item';
 import SidebarMenu from 'layout/sidebar/menu';
 import SidebarRegion from 'layout/sidebar/region';
+<<<<<<< 2732bec668974ba4f1c0959c9a454b2691b65e31
+=======
+import SiteStatsStickyLink from 'components/site-stats-sticky-link';
+import StatsSparkline from 'blocks/stats-sparkline';
+>>>>>>> create StatsSparkline block
 import { isPersonal, isPremium, isBusiness } from 'lib/products-values';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -150,6 +150,15 @@ export class MySitesSidebar extends Component {
 
 		const siteId = this.isSingle() ? site.slug : null;
 
+		let sparkline;
+		if ( ! site.jetpack && ! this.isItemLinkSelected( 'stats' ) ) {
+			sparkline = (
+				<img
+					className="sidebar__sparkline"
+					src={ `https://${ site.wpcom_url }/wp-includes/charts/admin-bar-hours-scale-2x.php?masterbar=1` } />
+			);
+		}
+
 		return (
 			<SidebarItem
 				tipTarget="menus"
@@ -157,7 +166,9 @@ export class MySitesSidebar extends Component {
 				className={ this.itemLinkClass( '/stats', 'stats' ) }
 				link={ getStatsPathForTab( 'day', siteId ) }
 				onNavigate={ this.onNavigate }
-				icon="stats-alt" />
+				icon="stats-alt">
+				{ sparkline }
+			</SidebarItem>
 		);
 	}
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -25,11 +25,7 @@ import SidebarHeading from 'layout/sidebar/heading';
 import SidebarItem from 'layout/sidebar/item';
 import SidebarMenu from 'layout/sidebar/menu';
 import SidebarRegion from 'layout/sidebar/region';
-<<<<<<< 2732bec668974ba4f1c0959c9a454b2691b65e31
-=======
-import SiteStatsStickyLink from 'components/site-stats-sticky-link';
 import StatsSparkline from 'blocks/stats-sparkline';
->>>>>>> create StatsSparkline block
 import { isPersonal, isPremium, isBusiness } from 'lib/products-values';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -156,15 +152,6 @@ export class MySitesSidebar extends Component {
 
 		const siteId = this.isSingle() ? site.slug : null;
 
-		let sparkline;
-		if ( ! site.jetpack && ! this.isItemLinkSelected( 'stats' ) ) {
-			sparkline = (
-				<img
-					className="sidebar__sparkline"
-					src={ `https://${ site.wpcom_url }/wp-includes/charts/admin-bar-hours-scale-2x.php?masterbar=1` } />
-			);
-		}
-
 		return (
 			<SidebarItem
 				tipTarget="menus"
@@ -173,7 +160,7 @@ export class MySitesSidebar extends Component {
 				link={ getStatsPathForTab( 'day', siteId ) }
 				onNavigate={ this.onNavigate }
 				icon="stats-alt">
-				{ sparkline }
+				<StatsSparkline className="sidebar__sparkline" siteId={ get( site, 'ID' ) } />
 			</SidebarItem>
 		);
 	}

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -3,10 +3,14 @@
 	height: 24px;
 	position: absolute;
 	right: 16px;
-	top: 6px;
+	top: 8px;
 
 	@include breakpoint( "<660px" ) {
 		top: 13px;
 		right: 32px;
 	}
+}
+
+.sidebar__menu li.stats a:after {
+	background: none;
 }

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -1,0 +1,12 @@
+.sidebar__sparkline {
+	width: 80px;
+	height: 24px;
+	position: absolute;
+	right: 16px;
+	top: 6px;
+
+	@include breakpoint( "<660px" ) {
+		top: 13px;
+		right: 32px;
+	}
+}

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -11,6 +11,7 @@
 	}
 }
 
-.sidebar__menu li.stats a:after {
+.sidebar__menu li.stats a:after,
+.notouch .sidebar__menu li.stats:hover:not(.selected) a:first-child:after  {
 	background: none;
 }

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -11,6 +11,10 @@
 	}
 }
 
+.sidebar__menu li.stats.selected .sidebar__sparkline {
+	display: none;
+}
+
 .sidebar__menu li.stats a:after,
 .notouch .sidebar__menu li.stats:hover:not(.selected) a:first-child:after  {
 	background: none;

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -14,7 +14,7 @@
 .sidebar__menu li.stats.selected .sidebar__sparkline {
 	display: none;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( "<660px" ) {
 		display: block;
 	}
 }

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -7,12 +7,16 @@
 
 	@include breakpoint( "<660px" ) {
 		top: 13px;
-		right: 32px;
+		right: 20px;
 	}
 }
 
 .sidebar__menu li.stats.selected .sidebar__sparkline {
 	display: none;
+
+	@include breakpoint( "<480px" ) {
+		display: block;
+	}
 }
 
 .sidebar__menu li.stats a:after,


### PR DESCRIPTION
Closes #10345

The sparkline, which used to be shown in the masterbar, is a missed feature for many stats users.  From the site masterbar the sparkline is shown next to the Stats link in the "My Sites" menu.  This branch brings the sparkline to the Calypso sidebar.

__Before__
<img width="259" alt="blog_posts_ _fly_fishers_place_ _wordpress_com_and_trout_bummin_ _somewhere_on_a_river_ _in_person_or_in_our_minds_and_wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/21597124/f74e5480-d0f9-11e6-9c44-78eecff8cf9a.png">

__After__
<img width="259" alt="blog_posts_ _fly_fishers_place_ _wordpress_com_and_trout_bummin_ _somewhere_on_a_river_ _in_person_or_in_our_minds_and_wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/21597142/45dcdc0c-d0fa-11e6-9fea-2b8ab4dc59be.png">
