### PR TITLE
Stats: add icon to Post & Pages items.

### DIFF
--- a/client/lib/stats/stats-list/stats-parser.js
+++ b/client/lib/stats/stats-list/stats-parser.js
@@ -687,7 +687,7 @@ StatsParser.prototype.statsTopPosts = function( payload ) {
 					type: 'link',
 					data: item.href
 				} ],
-				labelIcon: null,
+				labelIcon: 'stats',
 				children: null,
 				className: inPeriod ? 'published' : null
 			};


### PR DESCRIPTION
For #10345

This is another step to help make Post Summary Stat pages more discoverable.  Here we add a simple gridicon for items in the __Post & Pages__ stat component.  Much like other stat components that have a default action, this simple icon denotes further stats are available - and it is very similar to what was shown in Atlas stats:

__Before__
<img width="357" alt="stats_ _fly_fishers_place_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/21597272/aa1a7e02-d0fc-11e6-9c1e-782e00385529.png">

__After__
<img width="357" alt="stats_ _fly_fishers_place_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/21597277/cb0d7722-d0fc-11e6-8799-c7eb5eadac38.png">
