### PR TITLE
Reader: style sub and sup elements in content

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -197,6 +197,29 @@
 			}
 		}
 	}
+
+	sup, sub {
+		vertical-align: baseline;
+		position: relative;
+		font-size: 0.83em;
+	}
+
+	sup {
+		top: -0.4em;
+	}
+
+	sub {
+		bottom: -0.2em;
+	}
+
+	table th,
+	table td {
+		padding: 10px;
+	}
+
+	img:first-child {
+		margin-top: 0;
+	}
 }
 
 // Discover-Specific Full Post View Styles
@@ -263,28 +286,6 @@
 			}
 		}
 	}
-
-	sup, sub {
-		position: relative;
-		font-size: 0.83em;
-	}
-
-	sup {
-		top: -0.5em;
-	}
-
-	sub {
-		bottom: -0.5em;
-	}
-
-	table th,
-	table td {
-		padding: 10px;
-	}
-
-	img:first-child {
-		margin-top: 0;
-	}
 }
 
 // Daily Post-Specific Full Post View Styles
@@ -349,5 +350,5 @@
 }
 
 .is-reader-page .reader-full-post__story-content {
-	padding-top: 0!important;
+	padding-top: 0 !important;
 }

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -404,8 +404,23 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	margin-top: 9px;
 	word-break: break-word;
 	position: relative;
+
 	p {
 		margin: 0;
+	}
+
+	sup, sub {
+		vertical-align: baseline;
+		position: relative;
+		font-size: 0.83em;
+	}
+
+	sup {
+		top: -0.4em;
+	}
+
+	sub {
+		bottom: -0.2em;
 	}
 }
 

--- a/client/lib/post-normalizer/rule-create-better-excerpt.js
+++ b/client/lib/post-normalizer/rule-create-better-excerpt.js
@@ -29,7 +29,7 @@ export function formatExcerpt( content ) {
 	forEach( dom.querySelectorAll( '.wp-caption-text, style, script, blockquote[class^="instagram-"], figure' ), removeElement );
 
 	// limit to paras and brs
-	dom.innerHTML = striptags( dom.innerHTML, [ 'p', 'br' ] );
+	dom.innerHTML = striptags( dom.innerHTML, [ 'p', 'br', 'sup', 'sub' ] );
 
 	// Strip any empty p and br elements from the beginning of the content
 	forEach( dom.querySelectorAll( 'p,br' ), function( element ) {


### PR DESCRIPTION
The Reader does not currently respect `<sup>` and `<sub>` elements in content. This PR fixes that 🎉 

This was previously fixed (pre-Refresh) in https://github.com/Automattic/wp-calypso/pull/2937.

Before:

<img width="747" alt="screen shot 2017-01-03 at 11 27 23" src="https://cloud.githubusercontent.com/assets/17325/21597984/fd640f46-d1a7-11e6-8a3e-cccadcd64ba1.png">

After:

<img width="765" alt="screen shot 2017-01-03 at 11 26 51" src="https://cloud.githubusercontent.com/assets/17325/21597985/0308e034-d1a8-11e6-89fa-8b6b5065113b.png">

### To test

Take a look at my test post 'Alphabet sup' in the stream:

https://calypso.localhost:3000/read/feeds/40474296

...and in the full post view:

https://wpcalypso.wordpress.com/read/feeds/40474296/posts/1282650679

Ensure that superscript and subscript styles are applied as per the 'after' screenshot.

Tested in Chrome/OS X and IE11/Win7.
