### PR TITLE
Reader: Fix bottom margin on emoji in full post

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -66,6 +66,7 @@
 
 		&.emoji {
 			height: 1em;
+			margin-bottom: 0;
 		}
 	}
 


### PR DESCRIPTION
In Reader full post view, a regression has caused a 12px bottom margin to be applied to emoji, which looks like this:

<img width="384" alt="screen shot 2017-01-03 at 13 58 18" src="https://cloud.githubusercontent.com/assets/17325/21599228/867f1856-d1bd-11e6-8a38-f32983f40d21.png">

This PR restores the frog and cake to their rightful spots:

<img width="418" alt="screen shot 2017-01-03 at 13 58 52" src="https://cloud.githubusercontent.com/assets/17325/21599231/92859454-d1bd-11e6-9676-e0ad5d725f34.png">

Test post: http://calypso.localhost:3000/read/blogs/82798297/posts/94