### PR TITLE
Documentation: add missing closing code fence to EmptyContent & update syntax

### DIFF
--- a/client/components/empty-content/README.md
+++ b/client/components/empty-content/README.md
@@ -1,26 +1,26 @@
 Empty Content
 =============
 
-This module provides a consistent rendering component for empty content cases in Calypso's sections. Empty content should be used to display an alternate layout when the user has no data of a given resource. Not to be confused with subsets of data being contextually empty (searches, filters, etc.). The component accepts a set of predefined properties.
+This module provides a consistent rendering component for empty content cases in Calypso's sections. EmptyContent should be used to display an alternate layout when the user has no data of a given resource. Not to be confused with subsets of data being contextually empty (searches, filters, etc.). The component accepts a set of predefined properties.
 
 ## Usage
 
 ```jsx
 
-// require the component
-var EmptyContentComponent = require( 'components/empty-content' );
+// import the component
+import EmptyContentComponent from 'components/empty-content';
 
 // Render the component
 ReactDom.render(
-	EmptyContentComponent({
+	EmptyContentComponent( {
 		title: "You don't have any content yet.",
 		line: 'Would you like to create some?'
-	}),
+	} ),
 	document.getElementById( 'primary' )
 );
 
 // Or as an inline component
-var EmptyContent = require( 'components/empty-content' );
+import EmptyContent from 'components/empty-content';
 
 // And use it inline inside the render method of another component
 render: function() {
@@ -55,12 +55,12 @@ The component also supports a secondary action. This should be used sparingly.
 
 ```es6
 ReactDom.render(
-	EmptyContentComponent({
+	EmptyContentComponent( {
 		title: "You don't have any WordPress sites yet.",
 		line: 'Would you like to start one?',
 		action: 'Create Site',
 		actionURL: config( 'signup_url' ) + '?ref=calypso-section'
-	}),
+	} ),
 	document.getElementById( 'primary' )
 );
 ```

--- a/client/components/empty-content/README.md
+++ b/client/components/empty-content/README.md
@@ -63,3 +63,4 @@ ReactDom.render(
 	}),
 	document.getElementById( 'primary' )
 );
+```


### PR DESCRIPTION
I recently reported a non-bug (#10356).
I thought there was an issue with the es6 code-blocks being rendered as plain text rather than being interpreted properly by `marked`.
Turns out it was just missing the closing ` ``` `! 👍

This PR adds the closing code-fence needed to properly render this code block and also brings the syntax of those code blocks up to scratch (es6, guidelines).

### Testing 
Check out the final code block of [EmptyContent](http://calypso.localhost:3000/devdocs/client/components/empty-content/README.md) in the DevDocs

It should now looks like so:
<img width="836" alt="screen shot 2017-01-03 at 21 17 35" src="https://cloud.githubusercontent.com/assets/4335450/21604932/160cb302-d1fa-11e6-82dc-ca358429d29f.png">


TY :)