### PR TITLE
Docs: Add glossary.md to explain UI names

### DIFF
--- a/docs/guide/glossary.md
+++ b/docs/guide/glossary.md
@@ -28,7 +28,7 @@ The Calypso sidebar shows up on the left of most screens in Calypso, and is the 
 
 <img alt="Actionbar" width="227" src="https://cldup.com/Arufy8bsZT.png" />
 
-The actionbar shows up only on the frontend of sites. It is there to provide contextual actions, based on whether you're signed or not, and what you're looking at. In all configurations, you'll see a follow button, and an overflow button with expanded information. If you're signed in, you'll also see a customize button (if on the posts page), or an edit button, (if on a single post or page). The actionbar shows up when a page first loads, then disappears when you scroll down. Scroll up to reveal it again.
+The actionbar shows up only on the frontend of sites. It is there to provide contextual actions, based on whether you're signed in or not, and what you're looking at. In all configurations, you'll see a follow button, and an overflow button with expanded information. If you're signed in, you'll also see a customize button (if on the posts page), or an edit button, (if on a single post or page). The actionbar shows up when a page first loads, then disappears when you scroll down. Scroll up to reveal it again.
 
 **Environment Badge**
 

--- a/docs/guide/glossary.md
+++ b/docs/guide/glossary.md
@@ -1,0 +1,39 @@
+# Glossary of Terms
+
+This is a glossary of terms used in Calypso, and what they mean.
+
+## Calypso Interface
+
+**Masterbar**
+
+![Masterbar](https://cldup.com/zmCbSX8oag.png)
+
+The masterbar is the top-level navigation bar across the Calypso interface, across all breakpoints and devices. On wide viewports, a "Write" label appears. On smaller viewports, all labels disappear.
+
+**Frontend Masterbar**
+
+![Frontend masterbar](https://cldup.com/P9uWMEyC2k.png)
+
+This is the front-facing counterpart to the masterbar, shown on individual sites when a user is logged in. The frontend masterbar is different from the masterbar in that it has a dark background color, and isn't as tall on most viewports.
+
+This UI element has previously been referred to as "the adminbar", or "the toolbar".
+
+**Calypso Sidebar**
+
+<img alt="Calypso sidebar" width="273" src="https://cldup.com/HwbutWmlWa.png" />
+
+The Calypso sidebar shows up on the left of most screens in Calypso, and is the home to secondary navigation. On small viewports the Calypso sidebar slides to the left of the main column.
+
+**Actionbar**
+
+<img alt="Actionbar" width="227" src="https://cldup.com/Arufy8bsZT.png" />
+
+The actionbar shows up only on the frontend of sites. It is there to provide contextual actions, based on whether you're signed or not, and what you're looking at. In all configurations, you'll see a follow button, and an overflow button with expanded information. If you're signed in, you'll also see a customize button (if on the posts page), or an edit button, (if on a single post or page). The actionbar shows up when a page first loads, then disappears when you scroll down. Scroll up to reveal it again.
+
+**Environment Badge**
+
+<img alt="Environment badge" width="121" src="https://cldup.com/9vn3YjN1pk.png" />
+
+In development environments, when you're developing Calypso, you'll see a badge in the bottom right corner.
+
+Previous: [The Technology Behind Calypso](tech-behind-calypso.md) Next: [Contributing to Calypso](../../.github/CONTRIBUTING.md)

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -5,6 +5,7 @@ Learn Calypso step-by-step. A work in progress…
 * [Development Values](0-values.md)
 * [Hello, World!](hello-world.md)
 * [The Technology Behind Calypso](tech-behind-calypso.md)
+* [Glossary of Terms](glossary.md)
 * More, soon!
 
 Next: [Development Values](0-values.md)

--- a/docs/guide/tech-behind-calypso.md
+++ b/docs/guide/tech-behind-calypso.md
@@ -102,4 +102,4 @@ The way we use Git with Calypso is described in the [Git Workflow document](../g
 * [webpack](http://webpack.github.io) – building a JavaScript bundle of all of our modules and making sure loading them works just fine
 * [make](http://www.gnu.org/software/make/manual/make.html) – our build tool of choice
 
-Previous: [Hello, World!](hello-world.md) Next: [Contributing to Calypso](../../.github/CONTRIBUTING.md)
+Previous: [Hello, World!](hello-world.md) Next: [Glossary of Terms](glossary.md)


### PR DESCRIPTION
We have a lot of different self-invented words for UI elements in Calypso. Let's document them, explain why they are named as such. This PR contains the first stab at doing just that.

The document lives at http://calypso.localhost:3000/devdocs/docs/guide/glossary.md

Note: the screenshots are 2x, and I couldn't get the markdown method for setting width and heights to work, hence the actual HTML.

Screenshot:

![screencapture-calypso-localhost-3000-devdocs-docs-guide-glossary-md-1483440302089](https://cloud.githubusercontent.com/assets/1204802/21605618/997c3eec-d1aa-11e6-902a-7517115cdae9.png)
