### PR TITLE
Plans: Improve renew warnings for monthly plans

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -159,7 +159,7 @@ const ManagePurchase = React.createClass( {
 
 	getExpiringText( purchase ) {
 		if ( purchase.expiryStatus === 'manualRenew' ) {
-			return this.translate( '%(purchaseName)s will expire and be removed from your site in %(expiry)s. ' +
+			return this.translate( '%(purchaseName)s will expire and be removed from your site %(expiry)s. ' +
 				'Please, add a credit card if you want it to autorenew. ',
 				{
 					args: {
@@ -173,7 +173,7 @@ const ManagePurchase = React.createClass( {
 			const expiryMoment = this.moment( purchase.expiryMoment );
 			const daysToExpiry = this.moment( expiryMoment.diff( this.moment() ) ).format( 'D' );
 
-			return this.translate( '%(purchaseName)s will expire and be removed from your site in %(expiry)s days. ',
+			return this.translate( '%(purchaseName)s will expire and be removed from your site %(expiry)s days. ',
 				{
 					args: {
 						purchaseName: getName( purchase ),

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -159,7 +159,7 @@ const ManagePurchase = React.createClass( {
 
 	getExpiringText( purchase ) {
 		if ( purchase.expiryStatus === 'manualRenew' ) {
-			return this.translate( '%(purchaseName)s will expire and be removed from your site in %(expiry)s days. ' +
+			return this.translate( '%(purchaseName)s will expire and be removed from your site in %(expiry)s. ' +
 				'Please, add a credit card if you want it to autorenew. ',
 				{
 					args: {

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -157,10 +157,45 @@ const ManagePurchase = React.createClass( {
 		);
 	},
 
+	getExpiringText( purchase ) {
+		if ( purchase.expiryStatus === 'manualRenew' ) {
+			return this.translate( '%(purchaseName)s will expire and be removed from your site in %(expiry)s days. ' +
+				'Please, add a credit card if you want it to autorenew. ',
+				{
+					args: {
+						purchaseName: getName( purchase ),
+						expiry: this.moment( purchase.expiryMoment ).fromNow()
+					}
+				}
+			);
+		}
+		if ( isMonthly( purchase.productSlug ) ) {
+			const expiryMoment = this.moment( purchase.expiryMoment );
+			const daysToExpiry = this.moment( expiryMoment.diff( this.moment() ) ).format( 'D' );
+
+			return this.translate( '%(purchaseName)s will expire and be removed from your site in %(expiry)s days. ',
+				{
+					args: {
+						purchaseName: getName( purchase ),
+						expiry: daysToExpiry
+					}
+				}
+			);
+		}
+
+		return this.translate( '%(purchaseName)s will expire and be removed from your site %(expiry)s.',
+			{
+				args: {
+					purchaseName: getName( purchase ),
+					expiry: this.moment( purchase.expiryMoment ).fromNow()
+				}
+			}
+		);
+	},
+
 	renderPurchaseExpiringNotice() {
 		const purchase = getPurchase( this.props );
 		let noticeStatus = 'is-info';
-
 		if ( ! isExpiring( purchase ) ) {
 			return null;
 		}
@@ -174,14 +209,7 @@ const ManagePurchase = React.createClass( {
 				className="manage-purchase__purchase-expiring-notice"
 				showDismiss={ false }
 				status={ noticeStatus }
-				text={ this.translate( '%(purchaseName)s will expire and be removed from your site %(expiry)s.',
-					{
-						args: {
-							purchaseName: getName( purchase ),
-							expiry: this.moment( purchase.expiryMoment ).fromNow()
-						}
-					}
-				) }>
+				text={ this.getExpiringText( purchase ) }>
 				{ this.renderRenewNoticeAction() }
 			</Notice>
 		);


### PR DESCRIPTION
Right now, when we calculate if a plan is expiring, we just check if the expiring date is sooner than 3 months. This creates some weird situations for monthly plans, where you can purchase a monthly plan for just a month, and get immediately being told with a big bold red notice that your plan is about to expire.

While technically true, it feels odd to show that kind of warning to a knowing user, so this PR changes the messages we show up to the user in this cases.

How To Test
=========
0. You need a sandbox running `D3838-code` and a jetpack site connected to wp.com
1. Purchase a monthly plan with credits, so it doesn't have an associated credit card
2. Go to https://calypso.localhost:3000/plans/my-plan/{site} and click on "renew now". In the payment page, you should get this warning:
![image](https://cloud.githubusercontent.com/assets/1554855/21616713/eff6f716-d1e2-11e6-8899-7e0b7aa53281.png)

3. Add a credit card number. You shouldn't see any notice now:
![image](https://cloud.githubusercontent.com/assets/1554855/21616689/c97b891c-d1e2-11e6-8687-643f164943fe.png)

ping @rickybanister @tyxla  @roccotripaldi 

