### PR TITLE
Site Settings: Enable Site Icon feature in wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -77,6 +77,7 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,
+		"manage/site-settings/site-icon": true,
 		"manage/stats": true,
 		"manage/stats/podcasts": true,
 		"manage/themes": true,


### PR DESCRIPTION
This pull request seeks to enable Site Icon management in the wpcalypso environment.

__Testing Instructions:__

Confirm feature name matches that in `development.json`