### PR TITLE
Site Settings: Add "Remove" button for Site Icon 

### DIFF
--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -15,6 +15,7 @@ import MediaLibrarySelectedData from 'components/data/media-library-selected-dat
 import AsyncLoad from 'components/async-load';
 import Dialog from 'components/dialog';
 import { saveSiteSettings } from 'state/site-settings/actions';
+import { isSavingSiteSettings } from 'state/site-settings/selectors';
 import { setEditorMediaModalView } from 'state/ui/editor/actions';
 import { resetAllImageEditorState } from 'state/ui/editor/image-editor/actions';
 import { receiveMedia } from 'state/media/actions';
@@ -138,7 +139,7 @@ class SiteIconSetting extends Component {
 	}
 
 	render() {
-		const { translate, siteId, isJetpack, customizerUrl, generalOptionsUrl, siteSupportsImageEditor } = this.props;
+		const { isJetpack, customizerUrl, generalOptionsUrl, siteSupportsImageEditor } = this.props;
 		const { isModalVisible, hasToggledModal } = this.state;
 		const isIconManagementEnabled = isEnabled( 'manage/site-settings/site-icon' ) && siteSupportsImageEditor;
 
@@ -162,6 +163,8 @@ class SiteIconSetting extends Component {
 			}
 		}
 
+		const { translate, siteId, isSaving } = this.props;
+
 		return (
 			<FormFieldset className="site-icon-setting">
 				<FormLabel className="site-icon-setting__heading">
@@ -177,6 +180,7 @@ class SiteIconSetting extends Component {
 				<Button
 					{ ...buttonProps }
 					className="site-icon-setting__button"
+					disabled={ isSaving }
 					compact>
 					{ translate( 'Change', { context: 'verb' } ) }
 				</Button>
@@ -184,7 +188,8 @@ class SiteIconSetting extends Component {
 					<Button
 						compact
 						onClick={ this.props.removeSiteIcon }
-						className="site-icon-setting__button">
+						className="site-icon-setting__button"
+						disabled={ isSaving }>
 						{ translate( 'Remove' ) }
 					</Button>
 				) }
@@ -223,6 +228,7 @@ export default connect(
 		return {
 			siteId,
 			isJetpack: isJetpackSite( state, siteId ),
+			isSaving: isSavingSiteSettings( state, siteId ),
 			siteSupportsImageEditor: isSiteSupportingImageEditor( state, siteId ),
 			customizerUrl: getCustomizerUrl( state, siteId ),
 			generalOptionsUrl: getSiteAdminUrl( state, siteId, 'options-general.php' ),

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { uniqueId, head, partial, isEqual } from 'lodash';
+import { uniqueId, head, partial, partialRight, isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,6 +14,7 @@ import Button from 'components/button';
 import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
 import AsyncLoad from 'components/async-load';
 import Dialog from 'components/dialog';
+import accept from 'lib/accept';
 import { saveSiteSettings } from 'state/site-settings/actions';
 import { isSavingSiteSettings } from 'state/site-settings/selectors';
 import { setEditorMediaModalView } from 'state/ui/editor/actions';
@@ -134,6 +135,17 @@ class SiteIconSetting extends Component {
 		this.props.resetAllImageEditorState();
 	};
 
+	confirmRemoval = () => {
+		const { translate, siteId, removeSiteIcon } = this.props;
+		const message = translate( 'Are you sure you want to remove the site icon?' );
+
+		accept( message, ( accepted ) => {
+			if ( accepted ) {
+				removeSiteIcon( siteId );
+			}
+		} );
+	};
+
 	preloadModal() {
 		asyncRequire( 'post-editor/media-modal' );
 	}
@@ -187,7 +199,8 @@ class SiteIconSetting extends Component {
 				{ isIconManagementEnabled && hasIcon && (
 					<Button
 						compact
-						onClick={ this.props.removeSiteIcon }
+						scary
+						onClick={ this.confirmRemoval }
 						className="site-icon-setting__button"
 						disabled={ isSaving }>
 						{ translate( 'Remove' ) }
@@ -240,15 +253,7 @@ export default connect(
 		onEditSelectedMedia: partial( setEditorMediaModalView, ModalViews.IMAGE_EDITOR ),
 		resetAllImageEditorState,
 		saveSiteSettings,
-		removeSiteIcon: saveSiteSettings,
+		removeSiteIcon: partialRight( saveSiteSettings, { site_icon: '' } ),
 		receiveMedia
-	},
-	( stateProps, dispatchProps, ownProps ) => {
-		return {
-			...ownProps,
-			...stateProps,
-			...dispatchProps,
-			removeSiteIcon: partial( dispatchProps.saveSiteSettings, stateProps.siteId, { site_icon: '' } )
-		};
 	}
 )( localize( SiteIconSetting ) );

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -33,7 +33,7 @@ import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
 import { isItemBeingUploaded } from 'lib/media/utils';
 import { addQueryArgs } from 'lib/url';
 import { getImageEditorCrop } from 'state/ui/editor/image-editor/selectors';
-import { isSiteSupportingImageEditor } from 'state/selectors';
+import { getSiteIconUrl, isSiteSupportingImageEditor } from 'state/selectors';
 
 class SiteIconSetting extends Component {
 	static propTypes = {
@@ -163,7 +163,7 @@ class SiteIconSetting extends Component {
 			}
 		}
 
-		const { translate, siteId, isSaving } = this.props;
+		const { translate, siteId, isSaving, hasIcon } = this.props;
 
 		return (
 			<FormFieldset className="site-icon-setting">
@@ -184,7 +184,7 @@ class SiteIconSetting extends Component {
 					compact>
 					{ translate( 'Change', { context: 'verb' } ) }
 				</Button>
-				{ isIconManagementEnabled && (
+				{ isIconManagementEnabled && hasIcon && (
 					<Button
 						compact
 						onClick={ this.props.removeSiteIcon }
@@ -228,6 +228,7 @@ export default connect(
 		return {
 			siteId,
 			isJetpack: isJetpackSite( state, siteId ),
+			hasIcon: !! getSiteIconUrl( state, siteId ),
 			isSaving: isSavingSiteSettings( state, siteId ),
 			siteSupportsImageEditor: isSiteSupportingImageEditor( state, siteId ),
 			customizerUrl: getCustomizerUrl( state, siteId ),

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -176,10 +176,18 @@ class SiteIconSetting extends Component {
 				}, <SiteIcon size={ 96 } siteId={ siteId } /> ) }
 				<Button
 					{ ...buttonProps }
-					className="site-icon-setting__change-button"
+					className="site-icon-setting__button"
 					compact>
 					{ translate( 'Change', { context: 'verb' } ) }
 				</Button>
+				{ isIconManagementEnabled && (
+					<Button
+						compact
+						onClick={ this.props.removeSiteIcon }
+						className="site-icon-setting__button">
+						{ translate( 'Remove' ) }
+					</Button>
+				) }
 				{ isIconManagementEnabled && hasToggledModal && (
 					<MediaLibrarySelectedData siteId={ siteId }>
 						<AsyncLoad
@@ -225,6 +233,15 @@ export default connect(
 		onEditSelectedMedia: partial( setEditorMediaModalView, ModalViews.IMAGE_EDITOR ),
 		resetAllImageEditorState,
 		saveSiteSettings,
+		removeSiteIcon: saveSiteSettings,
 		receiveMedia
+	},
+	( stateProps, dispatchProps, ownProps ) => {
+		return {
+			...ownProps,
+			...stateProps,
+			...dispatchProps,
+			removeSiteIcon: partial( dispatchProps.saveSiteSettings, stateProps.siteId, { site_icon: null } )
+		};
 	}
 )( localize( SiteIconSetting ) );

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -248,7 +248,7 @@ export default connect(
 			...ownProps,
 			...stateProps,
 			...dispatchProps,
-			removeSiteIcon: partial( dispatchProps.saveSiteSettings, stateProps.siteId, { site_icon: null } )
+			removeSiteIcon: partial( dispatchProps.saveSiteSettings, stateProps.siteId, { site_icon: '' } )
 		};
 	}
 )( localize( SiteIconSetting ) );

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -141,10 +141,10 @@ class SiteIconSetting extends Component {
 	render() {
 		const { isJetpack, customizerUrl, generalOptionsUrl, siteSupportsImageEditor } = this.props;
 		const { isModalVisible, hasToggledModal } = this.state;
-		const isIconManagementEnabled = isEnabled( 'manage/site-settings/site-icon' ) && siteSupportsImageEditor;
+		const isIconManagementEnabled = isEnabled( 'manage/site-settings/site-icon' );
 
 		let buttonProps;
-		if ( isIconManagementEnabled ) {
+		if ( isIconManagementEnabled && siteSupportsImageEditor ) {
 			buttonProps = {
 				type: 'button',
 				onClick: this.showModal,

--- a/client/my-sites/site-settings/site-icon-setting/style.scss
+++ b/client/my-sites/site-settings/site-icon-setting/style.scss
@@ -21,8 +21,8 @@
 	opacity: 0.8;
 }
 
-.site-icon-setting__change-button {
+.site-icon-setting__button {
 	min-width: 98px;
-	margin-top: 8px;
+	margin-top: 4px;
 	text-align: center;
 }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -158,6 +158,20 @@
 			white-space: nowrap;
 		}
 	}
+
+	.site-icon-setting__icon {
+		@include breakpoint( "<660px") {
+			float: left;
+			margin-right: 8px;
+		}
+	}
+
+	.site-icon-setting__button {
+		@include breakpoint( "<660px") {
+			display: block;
+			margin-bottom: 8px;
+		}
+	}
 }
 
 .site-settings__general-settings {


### PR DESCRIPTION
Closes #10383 

This pull request seeks to enable a user to remove a site icon they had configured. A button is shown if a site icon is present and the site icon feature is active for the current environment.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/21620848/58e718c4-d1c4-11e6-8e95-f73a52103097.png)|![After](https://cloud.githubusercontent.com/assets/1779930/21620759/d88e111e-d1c3-11e6-85e7-618f8437283c.png)

__Testing Instructions:__

Verify that you can remove a configured site icon, and that if no icon is present (or you have locally disabled the site icon feature), no button is shown.

1. Navigate to [site settings](http://calypso.localhost:3000/settings)
2. Select a site
3. Note that...
 - If a site icon (or Blavatar) is configured, a Remove button is shown
 - Otherwise, only a Change button is shown
4. (Optional) If not already configured, set a site icon
5. Click "Remove"
6. Note that the form disables while saving and then the icon is removed successfully (confirm through refresh)

__Caveats:__

~~If the site has a Blavatar configured, the Remove button will be shown but clicking it will have no effect. This requires changes at the REST API that will be made separately to clear the Blavatar even if no changes to the option have occurred.~~ (resolved, r148386-wpcom)