### PR TITLE
Break all long words within comments, fixes #7261

### DIFF
--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -49,6 +49,7 @@
 
 			white-space: pre-wrap;
 			word-wrap: break-word;
+			word-break: break-all;
 		}
 
 		textarea {


### PR DESCRIPTION
Was #8763 by @zdravkov — moved here since no reply yet and we can get this in now.