### PR TITLE
Reader: add basic placeholder for full post view

### DIFF
--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -15,10 +15,11 @@ import ReaderSiteStreamLink from 'blocks/reader-site-stream-link';
 import ReaderFollowButton from 'reader/follow-button';
 import { getStreamUrl } from 'reader/route';
 import { areEqualIgnoringWhitespaceAndCase } from 'lib/string';
+import AuthorCompactProfilePlaceholder from './placeholder';
 
 const AuthorCompactProfile = React.createClass( {
 	propTypes: {
-		author: React.PropTypes.object.isRequired,
+		author: React.PropTypes.object,
 		siteName: React.PropTypes.string,
 		siteUrl: React.PropTypes.string,
 		feedUrl: React.PropTypes.string,
@@ -34,7 +35,7 @@ const AuthorCompactProfile = React.createClass( {
 		const { author, siteIcon, feedIcon, siteName, siteUrl, feedUrl, followCount, feedId, siteId, post } = this.props;
 
 		if ( ! author ) {
-			return null;
+			return <AuthorCompactProfilePlaceholder />;
 		}
 
 		const hasAuthorName = has( author, 'name' );

--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -40,7 +40,8 @@ const AuthorCompactProfile = React.createClass( {
 
 		const hasAuthorName = has( author, 'name' );
 		const hasMatchingAuthorAndSiteNames = hasAuthorName && areEqualIgnoringWhitespaceAndCase( siteName, author.name );
-		const classes = classnames( 'author-compact-profile', {
+		const classes = classnames( {
+			'author-compact-profile': true,
 			'has-author-link': ! hasMatchingAuthorAndSiteNames,
 			'has-author-icon': siteIcon || feedIcon || ( author && author.has_avatar )
 		} );

--- a/client/blocks/author-compact-profile/placeholder.jsx
+++ b/client/blocks/author-compact-profile/placeholder.jsx
@@ -12,7 +12,7 @@ const AuthorCompactProfilePlaceholder = () => {
 	return (
 		<div className="author-compact-profile is-placeholder">
 			<div className="author-compact-profile__avatar-link">
-				<ReaderAvatar showBlankGravatar={ true } />
+				<ReaderAvatar showPlaceholder={ true } />
 			</div>
 			<div className="author-compact-profile__site-link is-placeholder">
 				Site name

--- a/client/blocks/author-compact-profile/placeholder.jsx
+++ b/client/blocks/author-compact-profile/placeholder.jsx
@@ -6,11 +6,14 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import ReaderAvatar from 'blocks/reader-avatar';
 
 const AuthorCompactProfilePlaceholder = () => {
 	return (
 		<div className="author-compact-profile is-placeholder">
-			<div className="gravatar author-compact-profile__avatar-placeholder"></div>
+			<div className="author-compact-profile__avatar-link">
+				<ReaderAvatar showBlankGravatar={ true } />
+			</div>
 			<div className="author-compact-profile__site-link is-placeholder">
 				Site name
 			</div>

--- a/client/blocks/author-compact-profile/placeholder.jsx
+++ b/client/blocks/author-compact-profile/placeholder.jsx
@@ -6,13 +6,12 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import ReaderAvatar from 'blocks/reader-avatar';
 
 const AuthorCompactProfilePlaceholder = () => {
 	return (
 		<div className="author-compact-profile is-placeholder">
-			<ReaderAvatar author={ null } />
-			<div className="author-compact-profile__site-link-placeholder">
+			<div className="gravatar author-compact-profile__avatar-placeholder"></div>
+			<div className="author-compact-profile__site-link is-placeholder">
 				Site name
 			</div>
 			<div className="author-compact-profile__follow">

--- a/client/blocks/author-compact-profile/placeholder.jsx
+++ b/client/blocks/author-compact-profile/placeholder.jsx
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import ReaderAvatar from 'blocks/reader-avatar';
+
+const AuthorCompactProfilePlaceholder = () => {
+	return (
+		<div className="author-compact-profile is-placeholder">
+			<ReaderAvatar author={ null } />
+			<div className="author-compact-profile__site-link-placeholder">
+				Site name
+			</div>
+			<div className="author-compact-profile__follow">
+				<div className="author-compact-profile__follow-count is-placeholder">
+					Number of followers
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default AuthorCompactProfilePlaceholder;

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -106,3 +106,14 @@
 .author-compact-profile__follow-count.is-placeholder {
 	@include placeholder();
 }
+
+.author-compact-profile__site-link.is-placeholder {
+	@include breakpoint( ">660px" ) {
+		margin-left: 50px;
+		margin-right: 50px;
+	}
+}
+
+.author-compact-profile__follow-count.is-placeholder {
+	padding: 0;
+}

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -106,22 +106,3 @@
 .author-compact-profile__follow-count.is-placeholder {
 	@include placeholder();
 }
-
-// .author-compact-profile__site-link.is-placeholder {
-// 	@include breakpoint( ">660px" ) {
-// 		margin-left: 20%;
-// 		margin-right: 20%;
-// 	}
-// }
-
-// .author-compact-profile__avatar-placeholder {
-// 	width: 32px;
-// 	height: 32px;
-// 	margin-right: 10px;
-
-// 	@include breakpoint( ">660px" ) {
-// 		width: 96px;
-// 		height: 96px;
-// 		margin-right: 0;
-// 	}
-// }

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -103,26 +103,25 @@
 
 // Placeholders
 .author-compact-profile__site-link.is-placeholder,
-.author-compact-profile__avatar-placeholder,
 .author-compact-profile__follow-count.is-placeholder {
 	@include placeholder();
 }
 
-.author-compact-profile__site-link.is-placeholder {
-	@include breakpoint( ">660px" ) {
-		margin-left: 20%;
-		margin-right: 20%;
-	}
-}
+// .author-compact-profile__site-link.is-placeholder {
+// 	@include breakpoint( ">660px" ) {
+// 		margin-left: 20%;
+// 		margin-right: 20%;
+// 	}
+// }
 
-.author-compact-profile__avatar-placeholder {
-	width: 32px;
-	height: 32px;
-	margin-right: 10px;
+// .author-compact-profile__avatar-placeholder {
+// 	width: 32px;
+// 	height: 32px;
+// 	margin-right: 10px;
 
-	@include breakpoint( ">660px" ) {
-		width: 96px;
-		height: 96px;
-		margin-right: 0;
-	}
-}
+// 	@include breakpoint( ">660px" ) {
+// 		width: 96px;
+// 		height: 96px;
+// 		margin-right: 0;
+// 	}
+// }

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -100,3 +100,9 @@
 	color: lighten( $gray, 10% );
 	padding: 5px;
 }
+
+// Placeholders
+.author-compact-profile__site-link-placeholder,
+.author-compact-profile__follow-count.is-placeholder {
+	@include placeholder();
+}

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -102,7 +102,27 @@
 }
 
 // Placeholders
-.author-compact-profile__site-link-placeholder,
+.author-compact-profile__site-link.is-placeholder,
+.author-compact-profile__avatar-placeholder,
 .author-compact-profile__follow-count.is-placeholder {
 	@include placeholder();
+}
+
+.author-compact-profile__site-link.is-placeholder {
+	@include breakpoint( ">660px" ) {
+		margin-left: 20%;
+		margin-right: 20%;
+	}
+}
+
+.author-compact-profile__avatar-placeholder {
+	width: 32px;
+	height: 32px;
+	margin-right: 10px;
+
+	@include breakpoint( ">660px" ) {
+		width: 96px;
+		height: 96px;
+		margin-right: 0;
+	}
 }

--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -12,7 +12,7 @@ import SiteIcon from 'components/site-icon';
 import { localize } from 'i18n-calypso';
 import classnames from 'classnames';
 
-const ReaderAvatar = ( { author, siteIcon, feedIcon, siteUrl, preferGravatar = false, showBlankGravatar = false } ) => {
+const ReaderAvatar = ( { author, siteIcon, feedIcon, siteUrl, preferGravatar = false, showPlaceholder = false } ) => {
 	let fakeSite;
 	if ( siteIcon ) {
 		fakeSite = {
@@ -51,12 +51,12 @@ const ReaderAvatar = ( { author, siteIcon, feedIcon, siteUrl, preferGravatar = f
 		{
 			'has-site-and-author-icon': hasBothIcons,
 			'has-site-icon': hasSiteIcon,
-			'has-gravatar': hasAvatar
+			'has-gravatar': hasAvatar || showPlaceholder
 		}
 	);
 
 	const siteIconElement = hasSiteIcon && <SiteIcon key="site-icon" size={ 96 } site={ fakeSite } />;
-	const feedIconElement = hasAvatar || showBlankGravatar && <Gravatar key="feed-icon" user={ author } size={ hasBothIcons ? 32 : 96 } />;
+	const feedIconElement = hasAvatar || showPlaceholder && <Gravatar key="feed-icon" user={ author } size={ hasBothIcons ? 32 : 96 } />;
 	const iconElements = [ siteIconElement, feedIconElement ];
 
 	return (
@@ -72,7 +72,7 @@ ReaderAvatar.propTypes = {
 	feedIcon: React.PropTypes.string,
 	siteUrl: React.PropTypes.string,
 	preferGravatar: React.PropTypes.bool,
-	showBlankGravatar: React.PropTypes.bool
+	showPlaceholder: React.PropTypes.bool
 };
 
 export default localize( ReaderAvatar );

--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -12,7 +12,7 @@ import SiteIcon from 'components/site-icon';
 import { localize } from 'i18n-calypso';
 import classnames from 'classnames';
 
-const ReaderAvatar = ( { author, siteIcon, feedIcon, siteUrl, preferGravatar = false } ) => {
+const ReaderAvatar = ( { author, siteIcon, feedIcon, siteUrl, preferGravatar = false, showBlankGravatar = false } ) => {
 	let fakeSite;
 	if ( siteIcon ) {
 		fakeSite = {
@@ -56,7 +56,7 @@ const ReaderAvatar = ( { author, siteIcon, feedIcon, siteUrl, preferGravatar = f
 	);
 
 	const siteIconElement = hasSiteIcon && <SiteIcon key="site-icon" size={ 96 } site={ fakeSite } />;
-	const feedIconElement = hasAvatar && <Gravatar key="feed-icon" user={ author } size={ hasBothIcons ? 32 : 96 } />;
+	const feedIconElement = hasAvatar || showBlankGravatar && <Gravatar key="feed-icon" user={ author } size={ hasBothIcons ? 32 : 96 } />;
 	const iconElements = [ siteIconElement, feedIconElement ];
 
 	return (
@@ -71,7 +71,8 @@ ReaderAvatar.propTypes = {
 	siteIcon: React.PropTypes.string,
 	feedIcon: React.PropTypes.string,
 	siteUrl: React.PropTypes.string,
-	preferGravatar: React.PropTypes.bool
+	preferGravatar: React.PropTypes.bool,
+	showBlankGravatar: React.PropTypes.bool
 };
 
 export default localize( ReaderAvatar );

--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -56,7 +56,7 @@ const ReaderAvatar = ( { author, siteIcon, feedIcon, siteUrl, preferGravatar = f
 	);
 
 	const siteIconElement = hasSiteIcon && <SiteIcon key="site-icon" size={ 96 } site={ fakeSite } />;
-	const feedIconElement = hasAvatar || showPlaceholder && <Gravatar key="feed-icon" user={ author } size={ hasBothIcons ? 32 : 96 } />;
+	const feedIconElement = ( hasAvatar || showPlaceholder ) && <Gravatar key="feed-icon" user={ author } size={ hasBothIcons ? 32 : 96 } />;
 	const iconElements = [ siteIconElement, feedIconElement ];
 
 	return (

--- a/client/blocks/reader-full-post/header-tags.jsx
+++ b/client/blocks/reader-full-post/header-tags.jsx
@@ -9,8 +9,8 @@ const ReaderFullPostHeaderTags = ( { tags } ) => {
 	const tagsToDisplay = take( values( tags ), numberOfTagsToDisplay );
 	const listItems = map( tagsToDisplay, tag => {
 		return (
-			<li key={ `post-tag-${tag.slug}` } className="reader-full-post__header-tag-list-item">
-					<a href={ `/tag/${tag.slug}` } className="reader-full-post__header-tag-list-item-link">{ tag.name }</a>
+			<li key={ `post-tag-${ tag.slug }` } className="reader-full-post__header-tag-list-item">
+				<a href={ `/tag/${ tag.slug }` } className="reader-full-post__header-tag-list-item-link">{ tag.name }</a>
 			</li>
 		);
 	} );

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -15,6 +15,7 @@ import PostTime from 'reader/post-time';
 import ReaderFullPostHeaderTags from './header-tags';
 import Gridicon from 'components/gridicon';
 import { isDiscoverPost } from 'reader/discover/helper';
+import ReaderFullPostHeaderPlaceholder from './placeholders/header';
 
 const ReaderFullPostHeader = ( { post, referralPost } ) => {
 	const handlePermalinkClick = ( { } ) => {
@@ -31,6 +32,10 @@ const ReaderFullPostHeader = ( { post, referralPost } ) => {
 	}
 
 	const externalHref = isDiscoverPost( referralPost ) ? referralPost.URL : post.URL;
+
+	if ( ! post || post._state === 'pending' ) {
+		return <ReaderFullPostHeaderPlaceholder />;
+	}
 
 	/* eslint-disable react/jsx-no-target-blank */
 	return (

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -261,7 +261,7 @@ export class FullPostView extends React.Component {
 		}
 
 		const externalHref = isDiscoverPost( referralPost ) ? referralPost.URL : post.URL;
-		const isLoading = true; //! post || post._state === 'pending';
+		const isLoading = ! post || post._state === 'pending';
 
 		/*eslint-disable react/no-danger */
 		/*eslint-disable react/jsx-no-target-blank */

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -261,7 +261,7 @@ export class FullPostView extends React.Component {
 		}
 
 		const externalHref = isDiscoverPost( referralPost ) ? referralPost.URL : post.URL;
-		const isLoading = ! post || post._state === 'pending';
+		const isLoading = true; //! post || post._state === 'pending';
 
 		/*eslint-disable react/no-danger */
 		/*eslint-disable react/jsx-no-target-blank */
@@ -281,7 +281,8 @@ export class FullPostView extends React.Component {
 				</div>
 				<div className="reader-full-post__content">
 					<div className="reader-full-post__sidebar">
-						{ post.author &&
+						{ isLoading && <AuthorCompactProfile author={ null } /> }
+						{ ! isLoading && post.author &&
 							<AuthorCompactProfile
 								author={ post.author }
 								siteIcon={ get( site, 'icon.img' ) }
@@ -411,7 +412,7 @@ export default class FullPostFluxContainer extends React.Component {
 	}
 
 	static propTypes = {
-		blogId: React.PropTypes.string.isRequired,
+		blogId: React.PropTypes.string,
 		postId: React.PropTypes.string.isRequired,
 		onClose: React.PropTypes.func.isRequired,
 		onPostNotFound: React.PropTypes.func.isRequired,

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -54,20 +54,11 @@ import DocumentHead from 'components/data/document-head';
 import ReaderFullPostUnavailable from './unavailable';
 import ReaderFullPostBack from './back';
 import { isFeaturedImageInContent } from 'lib/post-normalizer/utils';
+import ReaderFullPostContentPlaceholder from './placeholders/content';
 
 export class FullPostView extends React.Component {
 	constructor( props ) {
 		super( props );
-		[
-			'handleBack',
-			'handleCommentClick',
-			'handleVisitSiteClick',
-			'handleLike',
-			'handleRelatedPostFromSameSiteClicked',
-			'handleRelatedPostFromOtherSiteClicked',
-		].forEach( fn => {
-			this[ fn ] = this[ fn ].bind( this );
-		} );
 		this.hasScrolledToCommentAnchor = false;
 	}
 
@@ -127,7 +118,7 @@ export class FullPostView extends React.Component {
 		KeyboardShortcuts.off( 'like-selection', this.handleLike );
 	}
 
-	handleBack( event ) {
+	handleBack = ( event ) => {
 		event.preventDefault();
 		recordAction( 'full_post_close' );
 		recordGaEvent( 'Closed Full Post Dialog' );
@@ -136,14 +127,14 @@ export class FullPostView extends React.Component {
 		this.props.onClose && this.props.onClose();
 	}
 
-	handleCommentClick() {
+	handleCommentClick = () => {
 		recordAction( 'click_comments' );
 		recordGaEvent( 'Clicked Post Comment Button' );
 		recordTrackForPost( 'calypso_reader_full_post_comments_button_clicked', this.props.post );
 		this.scrollToComments();
 	}
 
-	handleLike() {
+	handleLike = () => {
 		const { site_ID: siteId, ID: postId } = this.props.post;
 		let liked;
 
@@ -161,15 +152,15 @@ export class FullPostView extends React.Component {
 				{ context: 'full-post', event_source: 'keyboard' } );
 	}
 
-	handleRelatedPostFromSameSiteClicked() {
+	handleRelatedPostFromSameSiteClicked = () => {
 		recordTrackForPost( 'calypso_reader_related_post_from_same_site_clicked', this.props.post );
 	}
 
-	handleVisitSiteClick() {
+	handleVisitSiteClick = () => {
 		recordPermalinkClick( 'full_post_visit_link', this.props.post );
 	}
 
-	handleRelatedPostFromOtherSiteClicked() {
+	handleRelatedPostFromOtherSiteClicked = () => {
 		recordTrackForPost( 'calypso_reader_related_post_from_other_site_clicked', this.props.post );
 	}
 
@@ -270,6 +261,7 @@ export class FullPostView extends React.Component {
 		}
 
 		const externalHref = isDiscoverPost( referralPost ) ? referralPost.URL : post.URL;
+		const isLoading = ! post || post._state === 'pending';
 
 		/*eslint-disable react/no-danger */
 		/*eslint-disable react/jsx-no-target-blank */
@@ -322,6 +314,7 @@ export class FullPostView extends React.Component {
 						{ post.featured_image && ! isFeaturedImageInContent( post ) &&
 							<FeaturedImage src={ post.featured_image } />
 						}
+						{ isLoading && <ReaderFullPostContentPlaceholder / > }
 						{ post.use_excerpt
 							? <PostExcerpt content={ post.better_excerpt ? post.better_excerpt : post.excerpt } />
 							: <EmbedContainer>
@@ -333,20 +326,17 @@ export class FullPostView extends React.Component {
 							</EmbedContainer>
 						}
 
-						{ post.use_excerpt && ! isDiscoverPost( post )
-							? <PostExcerptLink siteName={ siteName } postUrl={ post.URL } />
-							: null
+						{ post.use_excerpt && ! isDiscoverPost( post ) &&
+							<PostExcerptLink siteName={ siteName } postUrl={ post.URL } />
 						}
-						{ isDiscoverSitePick( post )
-							? <DiscoverSiteAttribution
+						{ isDiscoverSitePick( post ) &&
+							<DiscoverSiteAttribution
 									attribution={ post.discover_metadata.attribution }
 									siteUrl={ getSiteUrl( post ) }
 									followUrl={ getSourceFollowUrl( post ) } />
-							: null
 						}
-						{ isDailyPostChallengeOrPrompt( post )
-							? <DailyPostButton post={ post } tagName="span" />
-							: null
+						{ isDailyPostChallengeOrPrompt( post ) &&
+							<DailyPostButton post={ post } tagName="span" />
 						}
 
 						<ReaderPostActions post={ post } site={ site } onCommentClick={ this.handleCommentClick } />

--- a/client/blocks/reader-full-post/placeholders/content.jsx
+++ b/client/blocks/reader-full-post/placeholders/content.jsx
@@ -6,19 +6,8 @@ import React from 'react';
 const ReaderFullPostContentPlaceholder = () => {
 	return (
 		<div className="reader-full-post__story-content is-placeholder">
-			<p className="reader-full-post__story-content-placeholder-text">
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit,
-			sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-			Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
-			nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
-			reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
-
-			<p className="reader-full-post__story-content-placeholder-text">
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit,
-			sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-			Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
-			nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
-			reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+			<p className="reader-full-post__story-content-placeholder-text"></p>
+			<p className="reader-full-post__story-content-placeholder-text"></p>
 		</div>
 	);
 };

--- a/client/blocks/reader-full-post/placeholders/content.jsx
+++ b/client/blocks/reader-full-post/placeholders/content.jsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+const ReaderFullPostContentPlaceholder = () => {
+	return (
+		<div className="reader-full-post__story-content is-placeholder">
+			<p className="reader-full-post__story-content-placeholder-text">
+			Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+			sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+			Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+			nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+			reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+
+			<p className="reader-full-post__story-content-placeholder-text">
+			Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+			sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+			Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+			nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+			reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+		</div>
+	);
+};
+
+export default ReaderFullPostContentPlaceholder;

--- a/client/blocks/reader-full-post/placeholders/header.jsx
+++ b/client/blocks/reader-full-post/placeholders/header.jsx
@@ -2,19 +2,18 @@
  * External dependencies
  */
 import React from 'react';
-import { localize } from 'i18n-calypso';
 
-const ReaderFullPostHeaderPlaceholder = ( { translate } ) => {
+const ReaderFullPostHeaderPlaceholder = () => {
 	return (
 		<div className="reader-full-post__header is-placeholder">
-			<h1 className="reader-full-post__header-title is-placeholder">{ translate( 'Post loading…' ) }</h1>
+			<h1 className="reader-full-post__header-title is-placeholder">Post loading…</h1>
 			<div className="reader-full-post__header-meta">
 				<span className="reader-full-post__header-date is-placeholder">
-					{ translate( 'Post date' ) }
+					Post date
 				</span>
 			</div>
 		</div>
 	);
 };
 
-export default localize( ReaderFullPostHeaderPlaceholder );
+export default ReaderFullPostHeaderPlaceholder;

--- a/client/blocks/reader-full-post/placeholders/header.jsx
+++ b/client/blocks/reader-full-post/placeholders/header.jsx
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+const ReaderFullPostHeaderPlaceholder = ( { translate } ) => {
+	return (
+		<div className="reader-full-post__header is-placeholder">
+			<h1 className="reader-full-post__header-title is-placeholder">{ translate( 'Post loading…' ) }</h1>
+			<div className="reader-full-post__header-meta">
+				<span className="reader-full-post__header-date is-placeholder">
+					{ translate( 'Post date' ) }
+				</span>
+			</div>
+		</div>
+	);
+};
+
+export default localize( ReaderFullPostHeaderPlaceholder );

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -561,4 +561,5 @@
 .reader-full-post__story-content-placeholder-text {
 	@include placeholder();
 	margin-bottom: 16px;
+	min-height: 200px;
 }

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -545,3 +545,20 @@
 .reader-full-post__unavailable-message {
 	margin-top: 1em;
 }
+
+// Placeholders
+.reader-full-post__header-title,
+.reader-full-post__header-date {
+	&.is-placeholder {
+		@include placeholder();
+	}
+}
+
+.reader-full-post__header-date.is-placeholder {
+	margin-top: 4px;
+}
+
+.reader-full-post__story-content-placeholder-text {
+	@include placeholder();
+	margin-bottom: 16px;
+}

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -189,8 +189,11 @@
 		white-space: nowrap;
 
 		&::after {
-			@include long-content-fade( $size: 15% );
 			height: 40px;
+		}
+
+		&:not( .is-placeholder )::after {
+			@include long-content-fade( $size: 15% );
 		}
 	}
 

--- a/client/components/gravatar/style.scss
+++ b/client/components/gravatar/style.scss
@@ -6,8 +6,7 @@
 	border-radius: 50%;
 
 	&.is-placeholder {
-		background: lighten( $gray, 20% );
 		display: inline-block;
-		animation: pulse-light 0.8s ease-in-out infinite;
+		@include placeholder();
 	}
 }


### PR DESCRIPTION
This PR adds a loading placeholder shown before the post is available in full post view.

![2017-01-05 14_28_22](https://cloud.githubusercontent.com/assets/17325/21668159/4f035fe4-d353-11e6-90db-5340181d72a7.gif)

It's pretty tricky to make a placeholder that fits all cases, because the content can be so different. I've used a pretty common scenario: post has a gravatar but no site icon, and a date but no tags.

Fixes #9668.