### PR TITLE
Stats: Update QueryPostStats to allow querying all post stats

### DIFF
--- a/client/components/data/query-post-stats/README.md
+++ b/client/components/data/query-post-stats/README.md
@@ -1,11 +1,11 @@
-Query Post Types
+Query Post Stats
 ================
 
 `<QueryPostStats />` is a React component used in managing network requests for post stats.
 
 ## Usage
 
-Render the component, passing `siteId`, `postId` and `stat`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+Render the component, passing `siteId`, `postId` and `fields`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
 import React from 'react';
@@ -15,7 +15,7 @@ import MyPostStatItem from './stat-item';
 export default function MyPostStatItem( { statValue } ) {
 	return (
 		<div>
-			<QueryPostStats siteId={ 3584907 } postId={ 4533 } stat="views" />
+			<QueryPostStats siteId={ 3584907 } postId={ 4533 } fields={ [ 'views' ] } />
 			<div>{ statValue }</div>
 		</div>
 	);
@@ -42,14 +42,14 @@ The site ID for which the post stat should be requested.
 
 The post ID for which the stat should be requested.
 
-### `stat`
+### `fields`
 
 <table>
 	<tr><th>Type</th><td>String</td></tr>
 	<tr><th>Required</th><td>No</td></tr>
 </table>
 
-The stat key being requested.
+The stats fields being requested.
 
 ### `heartbeat`
 

--- a/client/components/data/query-post-stats/index.jsx
+++ b/client/components/data/query-post-stats/index.jsx
@@ -3,19 +3,33 @@
  */
 import { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import { isEqual } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { isRequestingPostStat } from 'state/stats/posts/selectors';
-import { requestPostStat } from 'state/stats/posts/actions';
+import { isRequestingPostStats } from 'state/stats/posts/selectors';
+import { requestPostStats } from 'state/stats/posts/actions';
 
 class QueryPostStats extends Component {
+	static defaultProps = {
+		requestPostStats: () => {},
+		heartbeat: 0,
+	};
+
+	static propTypes = {
+		siteId: PropTypes.number,
+		postId: PropTypes.number,
+		fields: PropTypes.array,
+		requestingPostStats: PropTypes.bool,
+		requestPostStats: PropTypes.func,
+		heartbeat: PropTypes.number
+	};
+
 	componentWillMount() {
-		const { requestingPostStat, siteId, postId, stat } = this.props;
-		if ( ! requestingPostStat && siteId && postId && stat ) {
-			this.requestPostStat( this.props );
+		const { requestingPostStats, siteId, postId } = this.props;
+		if ( ! requestingPostStats && siteId && postId ) {
+			this.requestPostStats( this.props );
 		}
 	}
 
@@ -24,27 +38,27 @@ class QueryPostStats extends Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		const { siteId, postId, stat, heartbeat } = this.props;
+		const { siteId, postId, fields, heartbeat } = this.props;
 		if (
-			! ( siteId && postId && stat ) ||
+			! ( siteId && postId ) ||
 			( siteId === nextProps.siteId &&
 				postId === nextProps.postId &&
-				stat === nextProps.stat &&
+				isEqual( fields, nextProps.fields ) &&
 				heartbeat === nextProps.heartbeat )
 			) {
 			return;
 		}
 
-		this.requestPostStat( nextProps );
+		this.requestPostStats( nextProps );
 	}
 
-	requestPostStat( props ) {
-		const { siteId, postId, stat, heartbeat } = props;
-		props.requestPostStat( stat, siteId, postId );
+	requestPostStats( props ) {
+		const { siteId, postId, fields, heartbeat } = props;
+		props.requestPostStats( siteId, postId, fields );
 		this.clearInterval();
 		if ( heartbeat ) {
 			this.interval = setInterval( () => {
-				props.requestPostStat( stat, siteId, postId );
+				props.requestPostStats( siteId, postId, fields );
 			}, heartbeat );
 		}
 	}
@@ -60,31 +74,13 @@ class QueryPostStats extends Component {
 	}
 }
 
-QueryPostStats.propTypes = {
-	siteId: PropTypes.number,
-	postId: PropTypes.number,
-	stat: PropTypes.string,
-	requestingPostStat: PropTypes.bool,
-	requestPostStat: PropTypes.func,
-	heartbeat: PropTypes.number
-};
-
-QueryPostStats.defaultProps = {
-	requestPostStat: () => {},
-	heartbeat: 0
-};
-
 export default connect(
-	( state, ownProps ) => {
+	( state, { siteId, postId, fields } ) => {
 		return {
-			requestingPostStat: isRequestingPostStat(
-				state, ownProps.stat, ownProps.siteId, ownProps.postId
+			requestingPostStats: isRequestingPostStats(
+				state, siteId, postId, fields
 			)
 		};
 	},
-	( dispatch ) => {
-		return bindActionCreators( {
-			requestPostStat
-		}, dispatch );
-	}
+	{ requestPostStats }
 )( QueryPostStats );

--- a/client/my-sites/posts/post-total-views.jsx
+++ b/client/my-sites/posts/post-total-views.jsx
@@ -45,7 +45,7 @@ function PostTotalViews( { clickHandler, numberFormat, post, slug, translate, vi
 			} ) }
 			title={ viewsTitle }
 			onClick={ clickHandler }>
-			<QueryPostStats siteId= { siteId } postId={ postId } stat="views" />
+			<QueryPostStats siteId= { siteId } postId={ postId } fields={ [ 'views' ] } />
 			<Gridicon icon="visible" size={ 24 } />
 			<StatUpdateIndicator updateOn={ viewsCountDisplay }>{ viewsCountDisplay }</StatUpdateIndicator>
 		</a>
@@ -63,7 +63,7 @@ PostTotalViews.propTypes = {
 
 export default connect( ( state, ownProps ) => {
 	const { post } = ownProps;
-	const viewCount = getPostStat( state, 'views', post.site_ID, post.ID );
+	const viewCount = getPostStat( state, post.site_ID, post.ID, 'views' );
 
 	return {
 		slug: getSiteSlug( state, post.site_ID ),

--- a/client/state/stats/posts/actions.js
+++ b/client/state/stats/posts/actions.js
@@ -13,19 +13,17 @@ import {
  * Returns an action object to be used in signalling that post stat for a site,
  * post and stat have been received.
  *
- * @param  {String} stat   Stat Key
  * @param  {Number} siteId Site ID
  * @param  {Number} postId Post Id
- * @param  {Number} value  The stat value
+ * @param  {Array}  stats  The received stats
  * @return {Object}        Action object
  */
-export function receivePostStat( stat, siteId, postId, value ) {
+export function receivePostStats( siteId, postId, stats ) {
 	return {
 		type: POST_STATS_RECEIVE,
-		stat,
 		siteId,
 		postId,
-		value
+		stats,
 	};
 }
 
@@ -33,40 +31,39 @@ export function receivePostStat( stat, siteId, postId, value ) {
  * Returns an action thunk which, when invoked, triggers a network request to
  * retrieve post stat for a site and a post.
  *
- * @param  {String} stat   Stat Key
  * @param  {Number} siteId Site ID
  * @param  {Number} postId Post Id
+ * @param  {String} fields Stat Fields to fetch
  * @return {Function}      Action thunk
  */
-export function requestPostStat( stat, siteId, postId ) {
+export function requestPostStats( siteId, postId, fields = [] ) {
 	return ( dispatch ) => {
 		dispatch( {
 			type: POST_STATS_REQUEST,
-			stat,
 			postId,
-			siteId
+			siteId,
+			fields
 		} );
 
-		return wpcom.site( siteId ).statsPostViews( postId, {
-			fields: stat
-		} ).then( data => {
-			if ( stat in data ) {
-				dispatch( receivePostStat( stat, siteId, postId, data[ stat ] ) );
-			}
-			dispatch( {
-				type: POST_STATS_REQUEST_SUCCESS,
-				stat,
-				siteId,
-				postId
+		return wpcom.site( siteId )
+			.statsPostViews( postId, { fields: fields.join() } )
+			.then( stats => {
+				dispatch( receivePostStats( siteId, postId, stats ) );
+				dispatch( {
+					type: POST_STATS_REQUEST_SUCCESS,
+					siteId,
+					postId,
+					fields
+				} );
+			} )
+			.catch( error => {
+				dispatch( {
+					type: POST_STATS_REQUEST_FAILURE,
+					siteId,
+					postId,
+					fields,
+					error
+				} );
 			} );
-		} ).catch( error => {
-			dispatch( {
-				type: POST_STATS_REQUEST_FAILURE,
-				stat,
-				siteId,
-				postId,
-				error
-			} );
-		} );
 	};
 }

--- a/client/state/stats/posts/reducer.js
+++ b/client/state/stats/posts/reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import merge from 'lodash/merge';
+import { get, merge } from 'lodash';
 
 /**
  * Internal dependencies
@@ -34,7 +34,7 @@ export function requesting( state = {}, action ) {
 			return merge( {}, state, {
 				[ action.siteId ]: {
 					[ action.postId ]: {
-						[ action.stat ]: POST_STATS_REQUEST === action.type
+						[ action.fields.join() ]: POST_STATS_REQUEST === action.type
 					}
 				}
 			} );
@@ -58,13 +58,16 @@ export function requesting( state = {}, action ) {
 export function items( state = {}, action ) {
 	switch ( action.type ) {
 		case POST_STATS_RECEIVE:
-			return merge( {}, state, {
+			return {
+				...state,
 				[ action.siteId ]: {
+					...( get( state, [ action.siteId ], {} ) ),
 					[ action.postId ]: {
-						[ action.stat ]: action.value
+						...( get( state, [ action.siteId, action.postId ], {} ) ),
+						...action.stats,
 					}
 				}
-			} );
+			};
 
 		case DESERIALIZE:
 			if ( isValidStateWithSchema( state, itemSchemas ) ) {

--- a/client/state/stats/posts/schema.js
+++ b/client/state/stats/posts/schema.js
@@ -9,12 +9,7 @@ export const items = {
 			patternProperties: {
 				// Post Id
 				'^\\d+$': {
-					type: 'object',
-					additionalProperties: false,
-					patternProperties: {
-						// Stat Key
-						'^[0-9a-zA-Z]+$': { type: 'integer' }
-					}
+					type: 'object'
 				}
 			}
 		}

--- a/client/state/stats/posts/selectors.js
+++ b/client/state/stats/posts/selectors.js
@@ -1,17 +1,20 @@
-import get from 'lodash/get';
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
 
 /**
  * Returns true if current requesting post stat for the specified site ID,
  * post ID and stat key, or * false otherwise.
  *
  * @param  {Object}  state  Global state tree
- * @param  {String}  stat   Stat Key
  * @param  {Number}  siteId Site ID
  * @param  {Number}  postId Post Id
+ * @param  {Object}  fields Stat fields
  * @return {Boolean}        Whether post stat is being requested
  */
-export function isRequestingPostStat( state, stat, siteId, postId ) {
-	return get( state.stats.posts.requesting, [ siteId, postId, stat ], false );
+export function isRequestingPostStats( state, siteId, postId, fields = [] ) {
+	return get( state.stats.posts.requesting, [ siteId, postId, fields.join() ], false );
 }
 
 /**
@@ -19,11 +22,23 @@ export function isRequestingPostStat( state, stat, siteId, postId ) {
  * post ID and stat key
  *
  * @param  {Object}  state  Global state tree
- * @param  {String}  stat   Stat Key
  * @param  {Number}  siteId Site ID
  * @param  {Number}  postId Post Id
- * @return {?Number}        Stat value
+ * @param  {String}  stat   Stat Key
+ * @return {*}              Stat value
  */
-export function getPostStat( state, stat, siteId, postId ) {
+export function getPostStat( state, siteId, postId, stat ) {
 	return get( state.stats.posts.items, [ siteId, postId, stat ], null );
+}
+
+/**
+ * Returns the stats for the for the specified site ID, postId
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @param  {Number}  postId Post Id
+ * @return {Object}         Stats
+ */
+export function getPostStats( state, siteId, postId ) {
+	return get( state.stats.posts.items, [ siteId, postId ], null );
 }

--- a/client/state/stats/posts/test/actions.js
+++ b/client/state/stats/posts/test/actions.js
@@ -15,8 +15,8 @@ import {
 	POST_STATS_REQUEST_SUCCESS
 } from 'state/action-types';
 import {
-	receivePostStat,
-	requestPostStat
+	receivePostStats,
+	requestPostStats
 } from '../actions';
 
 describe( 'actions', () => {
@@ -28,14 +28,13 @@ describe( 'actions', () => {
 
 	describe( '#receivePostStat()', () => {
 		it( 'should return an action object', () => {
-			const action = receivePostStat( 'views', 2916284, 2454, 2 );
+			const action = receivePostStats( 2916284, 2454, { views: 2 } );
 
 			expect( action ).to.eql( {
 				type: POST_STATS_RECEIVE,
-				stat: 'views',
 				siteId: 2916284,
 				postId: 2454,
-				value: 2
+				stats: { views: 2 }
 			} );
 		} );
 	} );
@@ -44,8 +43,8 @@ describe( 'actions', () => {
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
-				.get( '/rest/v1.1/sites/2916284/stats/post/2454?fields=views' )
-				.reply( 200, { views: 2 } )
+				.get( '/rest/v1.1/sites/2916284/stats/post/2454?fields=views%2Cyears' )
+				.reply( 200, { views: 2, years: {} } )
 				.get( '/rest/v1.1/sites/2916285/stats/post/2455?fields=views' )
 				.reply( 403, {
 					error: 'authorization_required',
@@ -54,42 +53,42 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch fetch action when thunk triggered', () => {
-			requestPostStat( 'views', 2916284, 2454 )( spy );
+			requestPostStats( 2916284, 2454, [ 'views', 'years' ] )( spy );
 
 			expect( spy ).to.have.been.calledWith( {
 				type: POST_STATS_REQUEST,
-				stat: 'views',
 				siteId: 2916284,
-				postId: 2454
+				postId: 2454,
+				fields: [ 'views', 'years' ],
 			} );
 		} );
 
 		it( 'should dispatch receive action when request completes', () => {
-			return requestPostStat( 'views', 2916284, 2454 )( spy ).then( () => {
+			return requestPostStats( 2916284, 2454, [ 'views', 'years' ] )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith(
-					receivePostStat( 'views', 2916284, 2454, 2 )
+					receivePostStats( 2916284, 2454, { views: 2, years: {} } )
 				);
 			} );
 		} );
 
 		it( 'should dispatch request success action when request completes', () => {
-			return requestPostStat( 'views', 2916284, 2454 )( spy ).then( () => {
+			return requestPostStats( 2916284, 2454, [ 'views', 'years' ] )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POST_STATS_REQUEST_SUCCESS,
-					stat: 'views',
 					siteId: 2916284,
-					postId: 2454
+					postId: 2454,
+					fields: [ 'views', 'years' ],
 				} );
 			} );
 		} );
 
 		it( 'should dispatch fail action when request fails', () => {
-			return requestPostStat( 'views', 2916285, 2455 )( spy ).then( () => {
+			return requestPostStats( 2916285, 2455, [ 'views' ] )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: POST_STATS_REQUEST_FAILURE,
-					stat: 'views',
 					siteId: 2916285,
 					postId: 2455,
+					fields: [ 'views' ],
 					error: sinon.match( { message: 'User cannot access this private blog.' } )
 				} );
 			} );

--- a/client/state/stats/posts/test/reducer.js
+++ b/client/state/stats/posts/test/reducer.js
@@ -33,14 +33,16 @@ describe( 'reducer', () => {
 		it( 'should set requesting value to true if request in progress', () => {
 			const state = requesting( undefined, {
 				type: POST_STATS_REQUEST,
-				stat: 'views',
 				siteId: 2916284,
-				postId: 2454
+				postId: 2454,
+				fields: [ 'views', 'years' ],
 			} );
 
 			expect( state ).to.eql( {
 				2916284: {
-					2454: { views: true }
+					2454: {
+						'views,years': true
+					}
 				}
 			} );
 		} );
@@ -53,9 +55,9 @@ describe( 'reducer', () => {
 			}	);
 			const state = requesting( previousState, {
 				type: POST_STATS_REQUEST,
-				stat: 'countComments',
 				siteId: 2916284,
-				postId: 2454
+				postId: 2454,
+				fields: [ 'countComments' ],
 			} );
 
 			expect( state ).to.eql( {
@@ -76,9 +78,9 @@ describe( 'reducer', () => {
 			}	);
 			const state = requesting( previousState, {
 				type: POST_STATS_REQUEST,
-				stat: 'views',
 				siteId: 2916284,
-				postId: 2455
+				postId: 2455,
+				fields: [ 'views' ]
 			} );
 
 			expect( state ).to.eql( {
@@ -97,9 +99,9 @@ describe( 'reducer', () => {
 			}	);
 			const state = requesting( previousState, {
 				type: POST_STATS_REQUEST,
-				stat: 'views',
 				siteId: 2916285,
-				postId: 2454
+				postId: 2454,
+				fields: [ 'views' ],
 			} );
 
 			expect( state ).to.eql( {
@@ -120,9 +122,9 @@ describe( 'reducer', () => {
 			}	);
 			const state = requesting( previousState, {
 				type: POST_STATS_REQUEST_SUCCESS,
-				stat: 'views',
 				siteId: 2916284,
-				postId: 2454
+				postId: 2454,
+				fields: [ 'views' ],
 			} );
 
 			expect( state ).to.eql( {
@@ -140,9 +142,9 @@ describe( 'reducer', () => {
 			}	);
 			const state = requesting( previousState, {
 				type: POST_STATS_REQUEST_FAILURE,
-				stat: 'views',
 				siteId: 2916284,
-				postId: 2454
+				postId: 2454,
+				fields: [ 'views' ],
 			} );
 
 			expect( state ).to.eql( {
@@ -189,15 +191,14 @@ describe( 'reducer', () => {
 		it( 'should index post stats by site ID, post id and stat', () => {
 			const state = items( null, {
 				type: POST_STATS_RECEIVE,
-				stat: 'views',
 				siteId: 2916284,
 				postId: 2454,
-				value: 2
+				stats: { views: 2, years: [] },
 			} );
 
 			expect( state ).to.eql( {
 				2916284: {
-					2454: { views: 2 }
+					2454: { views: 2, years: [] }
 				}
 			} );
 		} );
@@ -210,10 +211,9 @@ describe( 'reducer', () => {
 			}	);
 			const state = items( previousState, {
 				type: POST_STATS_RECEIVE,
-				stat: 'countComments',
 				siteId: 2916284,
 				postId: 2454,
-				value: 3
+				stats: { countComments: 3 },
 			} );
 
 			expect( state ).to.eql( {
@@ -234,10 +234,9 @@ describe( 'reducer', () => {
 			}	);
 			const state = items( previousState, {
 				type: POST_STATS_RECEIVE,
-				stat: 'views',
 				siteId: 2916284,
 				postId: 2455,
-				value: 3
+				stats: { views: 3 },
 			} );
 
 			expect( state ).to.eql( {
@@ -256,10 +255,9 @@ describe( 'reducer', () => {
 			}	);
 			const state = items( previousState, {
 				type: POST_STATS_RECEIVE,
-				stat: 'views',
 				siteId: 2916285,
 				postId: 2454,
-				value: 3
+				stats: { views: 3 },
 			} );
 
 			expect( state ).to.eql( {
@@ -280,10 +278,9 @@ describe( 'reducer', () => {
 			}	);
 			const state = items( previousState, {
 				type: POST_STATS_RECEIVE,
-				stat: 'views',
 				siteId: 2916284,
 				postId: 2454,
-				value: 3
+				stats: { views: 3 },
 			} );
 
 			expect( state ).to.eql( {

--- a/client/state/stats/posts/test/selectors.js
+++ b/client/state/stats/posts/test/selectors.js
@@ -7,12 +7,13 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
-	isRequestingPostStat,
-	getPostStat
+	isRequestingPostStats,
+	getPostStat,
+	getPostStats,
 } from '../selectors';
 
 describe( 'selectors', () => {
-	describe( '#isRequestingPostStat()', () => {
+	describe( 'isRequestingPostStats()', () => {
 		it( 'should return false if the stat is not attached', () => {
 			const state = {
 				stats: {
@@ -25,7 +26,7 @@ describe( 'selectors', () => {
 					}
 				}
 			};
-			const isRequesting = isRequestingPostStat( state, 'countComments', 2916284, 2454 );
+			const isRequesting = isRequestingPostStats( state, 2916284, 2454, [ 'countComments' ] );
 
 			expect( isRequesting ).to.be.false;
 		} );
@@ -36,13 +37,13 @@ describe( 'selectors', () => {
 					posts: {
 						requesting: {
 							2916284: {
-								2454: { views: false }
+								2454: { 'views,years': false }
 							}
 						}
 					}
 				}
 			};
-			const isRequesting = isRequestingPostStat( state, 'views', 2916284, 2454 );
+			const isRequesting = isRequestingPostStats( state, 2916284, 2454, [ 'views', 'years' ] );
 
 			expect( isRequesting ).to.be.false;
 		} );
@@ -53,13 +54,13 @@ describe( 'selectors', () => {
 					posts: {
 						requesting: {
 							2916284: {
-								2454: { views: true }
+								2454: { 'views,years': true }
 							}
 						}
 					}
 				}
 			};
-			const isRequesting = isRequestingPostStat( state, 'views', 2916284, 2454 );
+			const isRequesting = isRequestingPostStats( state, 2916284, 2454, [ 'views', 'years' ] );
 
 			expect( isRequesting ).to.be.true;
 		} );
@@ -78,7 +79,7 @@ describe( 'selectors', () => {
 					}
 				}
 			};
-			const statValue = getPostStat( state, 'countComments', 2916284, 2454 );
+			const statValue = getPostStat( state, 2916284, 2454, 'countComments' );
 
 			expect( statValue ).to.be.null;
 		} );
@@ -95,9 +96,45 @@ describe( 'selectors', () => {
 					}
 				}
 			};
-			const statValue = getPostStat( state, 'views', 2916284, 2454 );
+			const statValue = getPostStat( state, 2916284, 2454, 'views' );
 
 			expect( statValue ).to.eql( 2 );
+		} );
+	} );
+
+	describe( 'getPostStats()', () => {
+		it( 'should return null if the site is not tracked', () => {
+			const state = {
+				stats: {
+					posts: {
+						items: {
+							2916284: {
+								2454: { views: 2 }
+							}
+						}
+					}
+				}
+			};
+			const statValue = getPostStats( state, 2916285, 2454 );
+
+			expect( statValue ).to.be.null;
+		} );
+
+		it( 'should return the post stats for a siteId, postId', () => {
+			const state = {
+				stats: {
+					posts: {
+						items: {
+							2916284: {
+								2454: { views: 2 }
+							}
+						}
+					}
+				}
+			};
+			const statValue = getPostStats( state, 2916284, 2454 );
+
+			expect( statValue ).to.eql( { views: 2 } );
 		} );
 	} );
 } );


### PR DESCRIPTION
Part of #10344 

In this PR, I update the `QueryPostStats` and the post stats redux subtree to allow retrieving ALL post stats. These stats will be used later to display a graph of post views (by days, weeks, months and years).

I also update the `StatsPostPerformance` to meet the last coding standards.

**Testing instructions**

 - Open the stats insights page
 - The "Last post summary" section should continue to display the post views count as expected.
