### PR TITLE
Themes (single-site-jetpack): Highlight active theme in WPCOM themes list

### DIFF
--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -113,7 +113,7 @@ export default connectOptions(
 									return getScreenshotOption( theme ).label;
 								} }
 								trackScrollPage={ props.trackScrollPage }
-								queryWpcom= { true }
+								queryWpcom={ true }
 							/>
 						</div>
 					}

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -27,7 +27,6 @@ const ConnectedThemesSelection = connectOptions(
 	( props ) => {
 		return (
 			<ThemesSelection { ...props }
-				siteId={ null /* Override props.siteId to get themes from WPCOM here */ }
 				getOptions={ function( theme ) {
 					return pickBy(
 						addTracking( props.options ),
@@ -114,6 +113,7 @@ export default connectOptions(
 									return getScreenshotOption( theme ).label;
 								} }
 								trackScrollPage={ props.trackScrollPage }
+								queryWpcom= { true }
 							/>
 						</div>
 					}

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -122,9 +122,14 @@ const ThemesSelection = React.createClass( {
 } );
 
 const ConnectedThemesSelection = connect(
-	( state, { search, tier, siteId, page, vertical, filter } ) => {
+	( state, { filter, page, search, tier, vertical, siteId, queryWpcom } ) => {
 		const isJetpack = isJetpackSite( state, siteId );
-		const siteIdOrWpcom = ( siteId && isJetpack ) ? siteId : 'wpcom';
+		const siteIdOrWpcom = ( siteId && isJetpack && ! ( queryWpcom === true ) ) ? siteId : 'wpcom';
+
+		let suffixThemeId = ( themeId ) => themeId;
+		if ( isJetpack && queryWpcom ) {
+			suffixThemeId = ( themeId ) => themeId + '-wpcom';
+		}
 
 		const query = {
 			search,
@@ -140,13 +145,13 @@ const ConnectedThemesSelection = connect(
 			themes: getThemesForQueryIgnoringPage( state, siteIdOrWpcom, query ) || [],
 			isRequesting: isRequestingThemesForQuery( state, siteIdOrWpcom, query ),
 			isLastPage: isThemesLastPageForQuery( state, siteIdOrWpcom, query ),
-			isThemeActive: themeId => isThemeActive( state, themeId, siteId ),
+			isThemeActive: themeId => isThemeActive( state, suffixThemeId( themeId ), siteId ),
 			isThemePurchased: themeId => (
 				// Note: This component assumes that purchase and data is already present in the state tree
 				// (used by the isThemePurchased selector). At the time of implementation there's no caching
 				// in <QuerySitePurchases /> and a parent component is already rendering it. So to avoid
 				// redundant AJAX requests, we're not rendering the query component locally.
-				isThemePurchased( state, themeId, siteId ) ||
+				isThemePurchased( state, suffixThemeId( themeId ), siteId ) ||
 				// The same is true for the `hasFeature` selector, which relies on the presence of
 				// a `<QuerySitePlans />` component in a parent component.
 				hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES )


### PR DESCRIPTION
This additional `suffixThemeId()` wrapped around individual selectors' arguments inside `ThemesSelection`'s `connect()` call is kind of a gross hack (and only relevant to the WPCOM list in single-site-jetpack mode), but I'm not sure if we can do a lot better as long as we have to work with those `-wpcom` suffices. Maybe we can encapsulate/contain it a bit more. 

Maybe use a `suffix` string prop instead of `queryWpcom`, default to `''`, and always append that prop (so we get at least rid of the ternary/`queryWpcom` handling logic)?

Any ideas @budzanowski @seear?