### PR TITLE
Signup: Implement `FormTextInputWithAction` in Survey Other substep

### DIFF
--- a/client/components/forms/form-text-input-with-action/index.jsx
+++ b/client/components/forms/form-text-input-with-action/index.jsx
@@ -46,43 +46,38 @@ export default class FormTextInputWithAction extends Component {
 	}
 
 	handleFocus = ( e ) => {
-		this.props.onFocus( e );
-		if ( e.defaultPrevented ) {
-			return;
-		}
 		this.setState( {
 			focused: true,
 		} );
+
+		this.props.onFocus( e );
 	};
 
 	handleBlur = ( e ) => {
-		this.props.onBlur( e );
-		if ( e.defaultPrevented ) {
-			return;
-		}
 		this.setState( {
 			focused: false,
 		} );
+
+		this.props.onBlur( e );
 	};
 
 	handleKeyDown = ( e ) => {
 		this.props.onKeyDown( e );
-		if ( e.defaultPrevented ) {
-			return;
-		}
 		if ( e.which === 13 && this.getValue() !== '' ) {
-			this.props.onAction( e );
+			this.handleAction( e );
 		}
 	};
 
 	handleChange = ( e ) => {
-		this.props.onChange( e );
-		if ( e.defaultPrevented ) {
-			return;
-		}
 		this.setState( {
 			value: e.target.value,
 		} );
+
+		this.props.onChange( e.target.value, e );
+	};
+
+	handleAction = ( e ) => {
+		this.props.onAction( this.getValue(), e );
 	};
 
 	getValue() {
@@ -117,7 +112,7 @@ export default class FormTextInputWithAction extends Component {
 				<FormButton
 					className="form-text-input-with-action__button is-compact"
 					disabled={ this.props.disabled || this.getValue() === '' }
-					onClick={ this.props.onAction }
+					onClick={ this.handleAction }
 				>
 					{ this.props.action }
 				</FormButton>

--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -15,8 +15,8 @@ import analytics from 'lib/analytics';
 import verticals from './verticals';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
-import TextInput from 'components/forms/form-text-input';
 import signupUtils from 'signup/utils';
+import FormTextInputWithAction from 'components/forms/form-text-input-with-action';
 
 import { setSurvey } from 'state/signup/steps/survey/actions';
 
@@ -51,7 +51,7 @@ const SurveyStep = React.createClass( {
 				key={ vertical.value }
 				data-value={ vertical.value }
 				data-label={ vertical.label() }
-				onClick={ this.handleNextStep }
+				onClick={ this.handleVerticalButton }
 			>
 				<span
 					className="survey__vertical-label"
@@ -69,19 +69,13 @@ const SurveyStep = React.createClass( {
 		const otherWriteIn = this.getOtherWriteIn();
 		return (
 			<div className="survey__other">
-				<TextInput className="survey__other-write-in"
-					placeholder={ this.translate( 'Please describe what your site is about' ) }
+				<FormTextInputWithAction
+					action={ this.translate( 'Continue' ) }
 					defaultValue={ otherWriteIn }
+					placeholder={ this.translate( 'Please describe what your site is about' ) }
+					onAction={ this.handleVerticalOther }
 					onChange={ this.handleOtherWriteIn }
-					ref={ ( input ) => input && input.focus() } />
-				<Button className="survey__other-button" primary compact
-					disabled={ otherWriteIn.length === 0 }
-					data-value="a8c.24"
-					data-label="Uncategorized"
-					onClick={ this.handleNextStep }
-				>
-					{ this.translate( 'Continue' ) }
-				</Button>
+				/>
 				<p className="survey__other-copy">{ this.translate( 'e.g. ’yoga’, ‘classic cars’' ) }</p>
 			</div>
 		);
@@ -123,22 +117,31 @@ const SurveyStep = React.createClass( {
 		);
 	},
 
-	handleOtherWriteIn( e ) {
-		this.setState( {
-			otherWriteIn: e.target.value.replace( /^\W+|\W+$/g, '' ),
-		} );
+	handleVerticalButton( e ) {
+		const { value, label } = e.target.dataset;
+		this.submitStep( label, value );
 	},
 
 	handleOther() {
 		page( signupUtils.getStepUrl( this.props.flowName, this.props.stepName, 'other', this.props.locale ) );
 	},
 
-	handleNextStep( e ) {
-		const { value, label } = e.target.dataset;
-		const otherWriteIn = ( value === 'a8c.24' && this.getOtherWriteIn().length !== 0 )
-			? this.getOtherWriteIn()
+	handleVerticalOther( otherTextValue ) {
+		const otherText = otherTextValue.replace( /^\W+|\W+$/g, '' );
+		const otherWriteIn = otherText.length !== 0
+			? otherText
 			: undefined;
 
+		this.submitStep( 'Uncategorized', 'a8c.24', otherWriteIn );
+	},
+
+	handleOtherWriteIn( value ) {
+		this.setState( {
+			otherWriteIn: value.replace( /^\W+|\W+$/g, '' ),
+		} );
+	},
+
+	submitStep( label, value, otherWriteIn = '' ) {
 		analytics.tracks.recordEvent( 'calypso_survey_site_type', { type: this.props.surveySiteType } );
 		analytics.tracks.recordEvent( 'calypso_survey_category_chosen', {
 			category_id: value,


### PR DESCRIPTION
The `FormTextInputWithAction` component ( #8638 ) was created as a spinoff of the Other sub-step and now we're implementing it back into the step.

Updated the component a bit, because it didn't properly pass the value to the parent.

To test:

1. Checkout branch or use Calypso.live link
2. Start Signup at `/start/surveystep` to access the Survey step, since it's not available in the main flow at the moment
3. Choose `Other`
4. Type text, verify there are no JS errors.
5. Submit the Survey step
6. Verify that the dependency store has the correct text ( in the Redux store -> IndexedDB -> Signup -> `dependencyStore` ) value and the correct parameters have been set to the analytics events
7. Verify no JS errors are shown in the console
8. Finish Signup
9. Verify the proper Verticals have been sent to Site creation

Bonus steps: Verify if `.blog` domains are suggested properly for the respective verticals.

cc @michaeldcain @coreh 