### PR TITLE
Image Editor: set correct crop after clicking Reset button

### DIFF
--- a/client/blocks/image-editor/image-editor-crop.jsx
+++ b/client/blocks/image-editor/image-editor-crop.jsx
@@ -14,13 +14,15 @@ import {
 	getImageEditorCropBounds,
 	getImageEditorAspectRatio,
 	getImageEditorTransform,
-	getImageEditorCrop
+	getImageEditorCrop,
+	imageEditorHasChanges
 } from 'state/ui/editor/image-editor/selectors';
 import { AspectRatios } from 'state/ui/editor/image-editor/constants';
 import {
 	imageEditorCrop,
 	imageEditorComputedCrop
 } from 'state/ui/editor/image-editor/actions';
+import { defaultCrop } from 'state/ui/editor/image-editor/reducer';
 
 class ImageEditorCrop extends Component {
 	static propTypes = {
@@ -43,7 +45,8 @@ class ImageEditorCrop extends Component {
 		minCropSize: PropTypes.shape( {
 			width: PropTypes.number,
 			height: PropTypes.number
-		} )
+		} ),
+		imageEditorHasChanges: PropTypes.bool
 	};
 
 	static defaultProps = {
@@ -59,7 +62,8 @@ class ImageEditorCrop extends Component {
 		minCropSize: {
 			width: 50,
 			height: 50
-		}
+		},
+		imageEditorHasChanges: false
 	};
 
 	constructor( props ) {
@@ -96,7 +100,8 @@ class ImageEditorCrop extends Component {
 	componentWillReceiveProps( newProps ) {
 		const {
 			bounds,
-			aspectRatio
+			aspectRatio,
+			crop
 		} = this.props;
 
 		if ( ! isEqual( bounds, newProps.bounds ) ) {
@@ -123,6 +128,15 @@ class ImageEditorCrop extends Component {
 
 		if ( aspectRatio !== newProps.aspectRatio ) {
 			this.updateCrop( this.getDefaultState( newProps ), newProps, this.applyCrop );
+		}
+
+		// After clicking the "Reset" button, we need to recompute and set crop.
+		if (
+			! newProps.imageEditorHasChanges &&
+			isEqual( newProps.crop, defaultCrop ) &&
+			! isEqual( crop, newProps.crop )
+		) {
+			this.updateCrop( this.getDefaultState( newProps ), newProps, this.applyComputedCrop );
 		}
 	}
 
@@ -484,7 +498,8 @@ export default connect(
 			bounds,
 			crop,
 			aspectRatio,
-			degrees
+			degrees,
+			imageEditorHasChanges: imageEditorHasChanges( state )
 		};
 	},
 	{


### PR DESCRIPTION
Fixes #9467. Previously, if we set a custom default aspect ratio (like square) and hit the "Reset" button in image editor, it would incorrectly compute the cropping area (although showing a correct one) so that after clicking on the "Done" button, the image would be incorrectly cropped.

We fix it in this PR by computing and setting a new crop after pressing the "Reset" button.

## Testing instructions

1. Navigate to http://calypso.localhost:3000/devdocs/blocks/image-editor and select an image which doesn't have a square shape (as the default aspect ratio set in that image editor is Square);
2. Move the cropping area so the "Reset" button is enabled;
3. Click on the "Reset" button and see if the crop was correctly set;
4. See if the image editor is not in an infinite loop after clicking the "Reset" button (is the browser stuck?)
5. Click on the "Done" button and make sure that the final image is the exact same one as indicated by the cropping area in the image editor;
6. Test this also in Media Modal image editor (in a post/page);
7. You can also use the testing instructions from #9467.