### PR TITLE
State: Refactor extendAction to handle thunks recursively

### DIFF
--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -2,8 +2,6 @@
  * External dependencies
  */
 import deepFreeze from 'deep-freeze';
-import { createStore, applyMiddleware } from 'redux';
-import thunk from 'redux-thunk';
 import { expect } from 'chai';
 import noop from 'lodash/noop';
 import { stub, spy } from 'sinon';
@@ -90,11 +88,7 @@ describe( 'utils', () => {
 		} );
 
 		it( 'should return an updated nested action thunk, merging data on dispatch', () => {
-			const dispatched = [];
-			const { dispatch } = applyMiddleware( thunk, () => ( next ) => ( action ) => {
-				dispatched.push( action );
-				return next( action );
-			} )( createStore )( () => null );
+			const dispatch = spy();
 			const action = extendAction(
 				( thunkDispatch ) => thunkDispatch(
 					( nestedThunkDispatch ) => nestedThunkDispatch( {
@@ -111,8 +105,9 @@ describe( 'utils', () => {
 				}
 			);
 
-			dispatch( action );
-			expect( dispatched ).to.include( {
+			action( dispatch );
+			dispatch.getCall( 0 ).args[ 0 ]( dispatch );
+			expect( dispatch ).to.have.been.calledWithExactly( {
 				type: 'ACTION_TEST',
 				meta: {
 					preserve: true,

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import deepFreeze from 'deep-freeze';
+import { createStore, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
 import { expect } from 'chai';
 import noop from 'lodash/noop';
 import { stub, spy } from 'sinon';
@@ -79,6 +81,38 @@ describe( 'utils', () => {
 
 			action( dispatch );
 			expect( dispatch ).to.have.been.calledWithExactly( {
+				type: 'ACTION_TEST',
+				meta: {
+					preserve: true,
+					ok: true
+				}
+			} );
+		} );
+
+		it( 'should return an updated nested action thunk, merging data on dispatch', () => {
+			const dispatched = [];
+			const { dispatch } = applyMiddleware( thunk, () => ( next ) => ( action ) => {
+				dispatched.push( action );
+				return next( action );
+			} )( createStore )( () => null );
+			const action = extendAction(
+				( thunkDispatch ) => thunkDispatch(
+					( nestedThunkDispatch ) => nestedThunkDispatch( {
+						type: 'ACTION_TEST',
+						meta: {
+							preserve: true
+						}
+					} )
+				),
+				{
+					meta: {
+						ok: true
+					}
+				}
+			);
+
+			dispatch( action );
+			expect( dispatched ).to.include( {
 				type: 'ACTION_TEST',
 				meta: {
 					preserve: true,

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import validator from 'is-my-json-valid';
-import { merge } from 'lodash';
+import { merge, flow, partialRight } from 'lodash';
 
 /**
  * Internal dependencies
@@ -146,7 +146,7 @@ export function extendAction( action, data ) {
 	}
 
 	return ( dispatch ) => {
-		const newDispatch = ( thunkAction ) => dispatch( merge( {}, thunkAction, data ) );
+		const newDispatch = flow( partialRight( extendAction, data ), dispatch );
 		return action( newDispatch );
 	};
 }


### PR DESCRIPTION
This pull request seeks to slightly refactor the `extendAction` state utility to recursively call itself when passed a thunk. This achieves two goals:

- Consolidates merging logic in case we choose to update it in the future
- Accounts for nested thunk action creators (yes, this is possible, but I'm unaware of any case which would justify their use)

Just happened to stumble across this in reviewing #10287 (cc @dmsnell)

__Implementation notes:__

I battled with the unit tests. I'd hoped not to have pulled in Redux, but struggled to wrap my head around testing it otherwise. Suggestions welcome.

__Testing instructions:__

Verify tests pass:

```
npm run test-client client/state/test/utils.js
```