### PR TITLE
Framework: Update to Redux 3.6.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -29,11 +29,11 @@
       "version": "0.8.2"
     },
     "ajv": {
-      "version": "4.10.1",
+      "version": "4.10.3",
       "dev": true
     },
     "ajv-keywords": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dev": true
     },
     "align-text": {
@@ -57,6 +57,9 @@
     },
     "anymatch": {
       "version": "1.3.0"
+    },
+    "aproba": {
+      "version": "1.0.4"
     },
     "are-we-there-yet": {
       "version": "1.1.2"
@@ -529,7 +532,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000602"
+      "version": "1.0.30000604"
     },
     "caseless": {
       "version": "0.11.0"
@@ -729,6 +732,9 @@
       "dev": true
     },
     "console-browserify": {
+      "version": "1.1.0"
+    },
+    "console-control-strings": {
       "version": "1.1.0"
     },
     "constant-case": {
@@ -1448,7 +1454,7 @@
       "version": "1.0.2"
     },
     "fast-levenshtein": {
-      "version": "2.0.5",
+      "version": "2.0.6",
       "dev": true
     },
     "fast-luhn": {
@@ -1597,7 +1603,7 @@
       "version": "1.0.0"
     },
     "gauge": {
-      "version": "1.2.7"
+      "version": "2.6.0"
     },
     "gaze": {
       "version": "1.1.2"
@@ -1749,6 +1755,9 @@
           "version": "0.0.1"
         }
       }
+    },
+    "has-color": {
+      "version": "0.1.7"
     },
     "has-cors": {
       "version": "1.1.0"
@@ -2303,10 +2312,10 @@
       "version": "1.3.1"
     },
     "level-packager": {
-      "version": "1.2.0"
+      "version": "1.2.1"
     },
     "leveldown": {
-      "version": "1.5.0",
+      "version": "1.5.3",
       "dependencies": {
         "abstract-leveldown": {
           "version": "2.6.1"
@@ -2343,6 +2352,9 @@
     "lodash-deep": {
       "version": "1.5.3",
       "dev": true
+    },
+    "lodash-es": {
+      "version": "4.17.4"
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -2619,6 +2631,9 @@
         }
       }
     },
+    "node-abi": {
+      "version": "1.0.3"
+    },
     "node-contains": {
       "version": "1.0.0"
     },
@@ -2638,6 +2653,9 @@
       "dependencies": {
         "minimatch": {
           "version": "3.0.3"
+        },
+        "npmlog": {
+          "version": "3.1.2"
         }
       }
     },
@@ -2647,8 +2665,14 @@
     "node-ninja": {
       "version": "1.0.2",
       "dependencies": {
+        "gauge": {
+          "version": "1.2.7"
+        },
         "minimatch": {
           "version": "3.0.3"
+        },
+        "npmlog": {
+          "version": "2.0.4"
         }
       }
     },
@@ -2711,7 +2735,15 @@
       }
     },
     "npmlog": {
-      "version": "2.0.4"
+      "version": "4.0.2",
+      "dependencies": {
+        "gauge": {
+          "version": "2.7.2"
+        },
+        "supports-color": {
+          "version": "0.2.0"
+        }
+      }
     },
     "nth-check": {
       "version": "1.0.1",
@@ -2915,7 +2947,7 @@
       "dev": true
     },
     "postcss": {
-      "version": "5.2.6",
+      "version": "5.2.8",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
@@ -2957,10 +2989,10 @@
       "version": "3.3.0"
     },
     "prebuild": {
-      "version": "4.5.0",
+      "version": "5.1.2",
       "dependencies": {
         "async": {
-          "version": "1.5.2"
+          "version": "2.1.4"
         },
         "minimist": {
           "version": "1.2.0"
@@ -3212,7 +3244,7 @@
       "version": "1.0.1"
     },
     "redux": {
-      "version": "3.0.4"
+      "version": "3.6.0"
     },
     "redux-thunk": {
       "version": "1.0.0"
@@ -3781,6 +3813,9 @@
     "swap-case": {
       "version": "1.1.2"
     },
+    "symbol-observable": {
+      "version": "1.0.4"
+    },
     "symbol-tree": {
       "version": "3.2.1",
       "dev": true
@@ -4264,6 +4299,9 @@
     },
     "which-module": {
       "version": "1.0.0"
+    },
+    "wide-align": {
+      "version": "1.1.0"
     },
     "window-size": {
       "version": "0.1.0"

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "react-redux": "4.4.5",
     "react-tap-event-plugin": "2.0.1",
     "react-virtualized": "8.8.1",
-    "redux": "3.0.4",
+    "redux": "3.6.0",
     "redux-thunk": "1.0.0",
     "rtlcss": "2.0.5",
     "sanitize-html": "1.11.1",


### PR DESCRIPTION
This pull request seeks to update the Redux dependency from 3.0.4 to 3.6.0.

[See changelog](https://github.com/reactjs/redux/releases)

The following changes are particularly relevant for us:

- A couple performance improvements (https://github.com/reactjs/redux/commit/5b586080b43ca233f78d56cbadf706c933fefd19, https://github.com/reactjs/redux/commit/c031c0a8d900e0e95a4915ecc0f96c6fe2d6e92b, https://github.com/reactjs/redux/pull/1701)
- Uses Lodash `isPlainObject` instead of its own internal implementation (should be de-duped with our own Lodash dependency)

__Testing instructions:__

As Redux follows semantic versioning, it's not expected that there are any breaking changes included. Verify that there are no regressions in navigating the application.

Confirm that tests pass:

```
make test
```