### PR TITLE
ThemesSelection: Expose isInstallingTheme() state to Theme components

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -38,6 +38,8 @@ const Theme = React.createClass( {
 		active: React.PropTypes.bool,
 		// If true, the user has 'purchased' the theme
 		purchased: React.PropTypes.bool,
+		// If true, the theme is being installed
+		installing: React.PropTypes.bool,
 		// If true, render a placeholder
 		isPlaceholder: React.PropTypes.bool,
 		// URL the screenshot link points to

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -37,6 +37,7 @@ export const ThemesList = React.createClass( {
 		getActionLabel: React.PropTypes.func,
 		isActive: React.PropTypes.func,
 		isPurchased: React.PropTypes.func,
+		isInstalling: React.PropTypes.func,
 		// i18n function provided by localize()
 		translate: React.PropTypes.func,
 		showThemeUpload: React.PropTypes.bool,
@@ -59,7 +60,8 @@ export const ThemesList = React.createClass( {
 			optionsGenerator: () => [],
 			getActionLabel: () => '',
 			isActive: () => false,
-			isPurchased: () => false
+			isPurchased: () => false,
+			isInstalling: () => false
 		};
 	},
 
@@ -83,7 +85,8 @@ export const ThemesList = React.createClass( {
 			index={ index }
 			theme={ theme }
 			active={ this.props.isActive( theme.id ) }
-			purchased={ this.props.isPurchased( theme.id ) } />;
+			purchased={ this.props.isPurchased( theme.id ) }
+			installing={ this.props.isInstalling( theme.id ) } />;
 	},
 
 	renderLoadingPlaceholders() {

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -19,7 +19,8 @@ import {
 	isRequestingThemesForQuery,
 	isThemesLastPageForQuery,
 	isThemeActive,
-	isThemePurchased
+	isThemePurchased,
+	isInstallingTheme
 } from 'state/themes/selectors';
 import config from 'config';
 import { FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
@@ -44,6 +45,7 @@ const ThemesSelection = React.createClass( {
 		isLastPage: PropTypes.bool,
 		isThemeActive: PropTypes.func,
 		isThemePurchased: PropTypes.func,
+		isInstallingTheme: PropTypes.func
 	},
 
 	componentWillReceiveProps( nextProps ) {
@@ -114,6 +116,7 @@ const ThemesSelection = React.createClass( {
 					getActionLabel={ this.props.getActionLabel }
 					isActive={ this.props.isThemeActive }
 					isPurchased={ this.props.isThemePurchased }
+					isInstalling={ this.props.isInstallingTheme }
 					loading={ this.props.isRequesting } />
 			</div>
 		);
@@ -155,7 +158,8 @@ const ConnectedThemesSelection = connect(
 				// The same is true for the `hasFeature` selector, which relies on the presence of
 				// a `<QuerySitePlans />` component in a parent component.
 				hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES )
-			)
+			),
+			isInstallingTheme: themeId => isInstallingTheme( state, suffixThemeId( themeId ), siteId )
 		};
 	}
 )( ThemesSelection );

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -513,6 +513,17 @@ export function hasActivatedTheme( state, siteId ) {
 }
 
 /**
+ * Whether the theme is currently being installed on the (Jetpack) site.
+ *
+ * @param  {Object}  state   Global state tree
+ * @param  {Number}  siteId  Site ID
+ * @return {Boolean}         True if theme installation is ongoing
+ */
+export function isInstallingTheme( state, siteId ) {
+	return get( state.themes.themeInstalls, siteId, false );
+}
+
+/**
  * Whether a WPCOM theme given by its ID is premium.
  *
  * @param  {Object} state   Global state tree

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -31,6 +31,7 @@ import {
 	isThemeActive,
 	isActivatingTheme,
 	hasActivatedTheme,
+	isInstallingTheme,
 	isThemePremium,
 	isThemePurchased,
 } from '../selectors';
@@ -1574,6 +1575,33 @@ describe( 'themes selectors', () => {
 		);
 
 			expect( isRequesting ).to.be.true;
+		} );
+	} );
+
+	describe( '#isInstallingTheme', () => {
+		it( 'given no site, should return false', () => {
+			const installing = isInstallingTheme( {
+				themes: {
+					themeInstalls: {}
+				}
+			} );
+
+			expect( installing ).to.be.false;
+		} );
+
+		it( 'given a site, should return true if theme is currently being installed', () => {
+			const installing = isInstallingTheme(
+				{
+					themes: {
+						themeInstalls: {
+							2916284: true
+						}
+					}
+				},
+				2916284
+			);
+
+			expect( installing ).to.be.true;
 		} );
 	} );
 


### PR DESCRIPTION
Add an `isInstallingTheme` selector, and use it in `ThemesSelection` (and pass its result down to the `Theme` component).

Similar to `isActive` and `isPurchased`. Will allow us to add visual feedback during theme installation.
Not used yet, but do test the showcase to make sure nothing's broken.