### PR TITLE
Domains: Fix typo in string

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -242,7 +242,7 @@ const MapDomainStep = React.createClass( {
 				break;
 
 			case 'forbidden_domain':
-				message = translate( 'Only the owner of the domain can map it\'s subdomains.' );
+				message = translate( 'Only the owner of the domain can map its subdomains.' );
 				break;
 
 			case 'invalid_tld':

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -614,7 +614,7 @@ const RegisterDomainStep = React.createClass( {
 				break;
 
 			case 'not_mappable_forbidden_domain':
-				message = translate( 'Only the owner of the domain can map it\'s subdomains.' );
+				message = translate( 'Only the owner of the domain can map its subdomains.' );
 				break;
 
 			case 'not_mappable_invalid_tld':


### PR DESCRIPTION
In both files:

Change

Only the owner of the domain can map it\'s subdomains.

to

Only the owner of the domain can map its subdomains.

cc: @aidvu 