### PR TITLE
Editor: Add `xposts` to the list of skipped taxonomies

### DIFF
--- a/client/post-editor/editor-drawer/taxonomies.jsx
+++ b/client/post-editor/editor-drawer/taxonomies.jsx
@@ -22,7 +22,7 @@ import TermTokenField from 'post-editor/term-token-field';
 import TermSelector from 'post-editor/editor-term-selector';
 
 function isSkippedTaxonomy( postType, taxonomy ) {
-	if ( includes( [ 'post_format', 'mentions' ], taxonomy ) ) {
+	if ( includes( [ 'post_format', 'mentions', 'xposts' ], taxonomy ) ) {
 		return true;
 	}
 


### PR DESCRIPTION
Reported in Slack after users were seeing this empty field in the post
editor and were confused at its purpose and utility.

Since I couldn't find any more information about it in a timely manner I
am committing this to quickly fix and defer the issue until we can find
someone who knows what's going on.

My guess is that some backend API change triggered this.

**Before**
![screen shot 2017-01-05 at 1 09 43 am](https://cloud.githubusercontent.com/assets/5431237/21673045/b1ca3c08-d2e3-11e6-8340-1c6cf25c9e7d.png)

**After**
![screen shot 2017-01-05 at 1 09 21 am](https://cloud.githubusercontent.com/assets/5431237/21673042/ac92a464-d2e3-11e6-88d7-c28ad57896ca.png)
