### PR TITLE
Settings: Use toggle instead of radio in Related Posts

### DIFF
--- a/assets/stylesheets/_main.scss
+++ b/assets/stylesheets/_main.scss
@@ -294,16 +294,6 @@ object {
 	min-height: 150px;
 }
 
-
-/*
-Disabled blocks of content.
-Used in releated posts settings.
-@todo get rid of it
-*/
-.disabled-block {
-	opacity: 0.5;
-}
-
 /*
 @todo this needs to become a component
 */

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -461,7 +461,7 @@ class SiteSettingsFormGeneral extends Component {
 	}
 
 	relatedPostsOptions() {
-		const { fields, clickTracker, translate, isRequestingSettings } = this.props;
+		const { fields, translate, isRequestingSettings } = this.props;
 		if ( ! fields.jetpack_relatedposts_allowed ) {
 			return null;
 		}
@@ -470,61 +470,52 @@ class SiteSettingsFormGeneral extends Component {
 			<FormFieldset>
 				<ul id="settings-reading-relatedposts">
 					<li>
-						<FormLabel>
-							<FormRadio
-								name="jetpack_relatedposts_enabled"
-								value="0"
-								checked={ 0 === parseInt( fields.jetpack_relatedposts_enabled, 10 ) }
-								onChange={ this.handleRadio }
-								onClick={ clickTracker( 'Related Posts Radio Button' ) } />
-							<span>{ translate( 'Hide related content after posts' ) }</span>
-						</FormLabel>
+						<FormToggle
+							className="is-compact"
+							checked={ !! fields.jetpack_relatedposts_enabled }
+							disabled={ isRequestingSettings }
+							onChange={ this.handleToggle( 'jetpack_relatedposts_enabled' ) }>
+							<span className="site-settings__toggle-label">
+								{ translate( 'Hide related content after posts' ) }
+							</span>
+						</FormToggle>
 					</li>
-					<li>
-						<FormLabel>
-							<FormRadio
-								name="jetpack_relatedposts_enabled"
-								value="1"
-								checked={ 1 === parseInt( fields.jetpack_relatedposts_enabled, 10 ) }
-								onChange={ this.handleRadio }
-								onClick={ clickTracker( 'Related Posts Radio Button' ) } />
-							<span>{ translate( 'Show related content after posts' ) }</span>
-						</FormLabel>
-						<ul
-							id="settings-reading-relatedposts-customize"
-							className={ 1 === parseInt( fields.jetpack_relatedposts_enabled, 10 ) ? null : 'disabled-block' }>
-							<li>
-								<FormToggle
-									className="is-compact"
-									checked={ !! fields.jetpack_relatedposts_show_headline }
-									disabled={ isRequestingSettings }
-									onChange={ this.handleToggle( 'jetpack_relatedposts_show_headline' ) }>
-									<span className="site-settings__toggle-label">
+					{ !! fields.jetpack_relatedposts_enabled && (
+						<li>
+							<ul id="settings-reading-relatedposts-customize">
+								<li>
+									<FormToggle
+										className="is-compact"
+										checked={ !! fields.jetpack_relatedposts_show_headline }
+										disabled={ isRequestingSettings }
+										onChange={ this.handleToggle( 'jetpack_relatedposts_show_headline' ) }>
+										<span className="site-settings__toggle-label">
+											{ translate(
+												'Show a "Related" header to more clearly separate the related section from posts'
+											) }
+										</span>
+									</FormToggle>
+								</li>
+								<li>
+									<FormToggle
+										className="is-compact"
+										checked={ !! fields.jetpack_relatedposts_show_thumbnails }
+										disabled={ isRequestingSettings }
+										onChange={ this.handleToggle( 'jetpack_relatedposts_show_thumbnails' ) }>
+										<span className="site-settings__toggle-label">
 										{ translate(
-											'Show a "Related" header to more clearly separate the related section from posts'
+											'Use a large and visually striking layout'
 										) }
-									</span>
-								</FormToggle>
-							</li>
-							<li>
-								<FormToggle
-									className="is-compact"
-									checked={ !! fields.jetpack_relatedposts_show_thumbnails }
-									disabled={ isRequestingSettings }
-									onChange={ this.handleToggle( 'jetpack_relatedposts_show_thumbnails' ) }>
-									<span className="site-settings__toggle-label">
-									{ translate(
-										'Use a large and visually striking layout'
-									) }
-									</span>
-								</FormToggle>
-							</li>
-						</ul>
-						<RelatedContentPreview
-							enabled={ 1 === parseInt( fields.jetpack_relatedposts_enabled, 10 ) }
-							showHeadline={ fields.jetpack_relatedposts_show_headline }
-							showThumbnails={ fields.jetpack_relatedposts_show_thumbnails } />
-					</li>
+										</span>
+									</FormToggle>
+								</li>
+							</ul>
+							<RelatedContentPreview
+								enabled={ true }
+								showHeadline={ fields.jetpack_relatedposts_show_headline }
+								showThumbnails={ fields.jetpack_relatedposts_show_thumbnails } />
+						</li>
+					) }
 				</ul>
 			</FormFieldset>
 		);

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -511,7 +511,6 @@ class SiteSettingsFormGeneral extends Component {
 								</li>
 							</ul>
 							<RelatedContentPreview
-								enabled={ true }
 								showHeadline={ fields.jetpack_relatedposts_show_headline }
 								showThumbnails={ fields.jetpack_relatedposts_show_thumbnails } />
 						</li>

--- a/client/my-sites/site-settings/related-content-preview.jsx
+++ b/client/my-sites/site-settings/related-content-preview.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
  */
 import FormLabel from 'components/forms/form-label';
 
-const RelatedContentPreview = ( { enabled, showHeadline, showThumbnails, translate } ) => {
+const RelatedContentPreview = ( { showHeadline, showThumbnails, translate } ) => {
 	const posts = [
 		{
 			image: '/calypso/images/related-posts/cat-blog.png',
@@ -44,7 +44,7 @@ const RelatedContentPreview = ( { enabled, showHeadline, showThumbnails, transla
 	];
 
 	return (
-		<div id="settings-reading-relatedposts-preview" className={ ! enabled && 'disabled-block' }>
+		<div id="settings-reading-relatedposts-preview">
 			<FormLabel>{ translate( 'Preview:' ) }</FormLabel>
 
 			<div className="site-settings__related-posts">


### PR DESCRIPTION
### Introduction
This PR updates the Related Posts card in Settings to use a binary toggle instead of the less-intuitive radio buttons. Fixes #10391.

### What this PR does
In more detail, this PR takes care of the following:

* Replaces the Related Posts radio buttons with a single toggle.
* Updates the sub-options to be hidden when the module is disabled.
* Totally removes the opacity changes, since the `RelatedContentPreview` will always be enabled when visible.
* Completely removes the `enabled` prop from `RelatedContentPreview`, since it will no longer be used.
* Cleans up some obsolete CSS (`.disabled-block`).

### Previews

**Disabled module**
![](https://cldup.com/v0sUTRGLAJ.png)

**Enabled module**
![](https://cldup.com/rFvIrisdfZ.png)

### Testing

* Get this branch going locally or on `calypso.live`.
* Go to `/settings/general/$site` where `$site` is one of your Jetpack sites.
* Verify the Related Posts card looks and behaves as described in #10391.
* Play around with the Related posts settings - enable/disable the module and its sub-options and verify they save and retrieve properly.
* Verify no regressions with the Recent Posts settings are introduced with the recent changes.

/cc
@oskosk @roccotripaldi @ryelle @johnHackworth for code review
@rickybanister @MichaelArestad @ashleighaxios for design review