### PR TITLE
Jetpack Settings: Handle updates action in the settings reducer

### DIFF
--- a/client/state/jetpack-settings/settings/reducer.js
+++ b/client/state/jetpack-settings/settings/reducer.js
@@ -26,6 +26,14 @@ const createRequestsReducer = ( data ) => {
 	};
 };
 
+const createItemsReducer = () => {
+	return ( state, { siteId, settings } ) => {
+		return merge( {}, state, {
+			[ siteId ]: settings
+		} );
+	};
+};
+
 /**
  * `Reducer` function which handles request/response actions
  * concerning Jetpack settings updates
@@ -35,11 +43,8 @@ const createRequestsReducer = ( data ) => {
  * @return {Array}         Updated state
  */
 export const items = createReducer( {}, {
-	[ JETPACK_SETTINGS_RECEIVE ]: ( state, { siteId, settings } ) => {
-		return merge( {}, state, {
-			[ siteId ]: settings
-		} );
-	}
+	[ JETPACK_SETTINGS_RECEIVE ]: createItemsReducer(),
+	[ JETPACK_SETTINGS_UPDATE_SUCCESS ]: createItemsReducer()
 } );
 
 /**

--- a/client/state/jetpack-settings/settings/test/reducer.js
+++ b/client/state/jetpack-settings/settings/test/reducer.js
@@ -78,7 +78,7 @@ describe( 'reducer', () => {
 			} );
 		} );
 
-		it( 'should update settings in the items object', () => {
+		it( 'should replace settings in the items object when settings are already loaded for a site', () => {
 			const siteId = 12345678,
 				stateIn = {
 					12345678: SETTINGS_FIXTURE[ siteId ]
@@ -87,6 +87,22 @@ describe( 'reducer', () => {
 					type: JETPACK_SETTINGS_RECEIVE,
 					siteId,
 					settings: { ...SETTINGS_FIXTURE[ siteId ], test_setting: 123 }
+				};
+			const stateOut = itemsReducer( deepFreeze( stateIn ), action );
+			expect( stateOut ).to.eql( {
+				12345678: { ...SETTINGS_FIXTURE[ siteId ], test_setting: 123 }
+			} );
+		} );
+
+		it( 'should update settings in the items object', () => {
+			const siteId = 12345678,
+				stateIn = {
+					12345678: SETTINGS_FIXTURE[ siteId ]
+				},
+				action = {
+					type: JETPACK_SETTINGS_UPDATE_SUCCESS,
+					siteId,
+					settings: { test_setting: 123 }
 				};
 			const stateOut = itemsReducer( deepFreeze( stateIn ), action );
 			expect( stateOut ).to.eql( {


### PR DESCRIPTION
Updates the `state/jetpack-settings/settings` reducer to handle this action.

#### Testing instructions

1. Run `npm run test-client client/state/jetpack-settings/settings/``
2. Expect the tests to pass


#### Why 

We were not reducing this action, thus updating a setting through the action creators didn't have any effect on the state after the API request was successful.