### PR TITLE
Purchases: Improve how PayPal Direct is shown in purchase detail

### DIFF
--- a/client/components/payment-logo/style.scss
+++ b/client/components/payment-logo/style.scss
@@ -23,6 +23,10 @@
 		background-image: url( '/calypso/images/upgrades/cc-visa.svg' );
 	}
 
+	&.is-placeholder {
+		background-image: url( '/calypso/images/upgrades/cc-placeholder.svg' );
+	}
+
 	&.is-paypal {
 		background-image: url( '/calypso/images/upgrades/paypal.svg' );
 		background-size: 70px;

--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -72,6 +72,10 @@ function createPurchaseObject( purchase ) {
 		return Object.assign( {}, object, { payment } );
 	}
 
+	if ( 'paypal_direct' === purchase.payment_type ) {
+		object.payment.expiryMoment = purchase.payment_expiry ? i18n.moment( purchase.payment_expiry, 'MM/YY' ) : null;
+	}
+
 	return object;
 }
 

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -68,7 +68,7 @@ function hasIncludedDomain( purchase ) {
 }
 
 function hasPaymentMethod( purchase ) {
-	return isPaidWithPaypal( purchase ) || isPaidWithCreditCard( purchase );
+	return isPaidWithPaypal( purchase ) || isPaidWithCreditCard( purchase ) || isPaidWithPayPalDirect( purchase );
 }
 
 function hasPrivateRegistration( purchase ) {
@@ -190,6 +190,10 @@ function isPaidWithCreditCard( purchase ) {
 	return 'credit_card' === purchase.payment.type && hasCreditCardData( purchase );
 }
 
+function isPaidWithPayPalDirect( purchase ) {
+	return 'paypal_direct' === purchase.payment.type && purchase.payment.expiryMoment;
+}
+
 function hasCreditCardData( purchase ) {
 	return Boolean( purchase.payment.creditCard.expiryMoment );
 }
@@ -209,6 +213,10 @@ function paymentLogoType( purchase ) {
 
 	if ( isPaidWithPaypal( purchase ) ) {
 		return 'paypal';
+	}
+
+	if ( isPaidWithPayPalDirect( purchase ) ) {
+		return 'placeholder';
 	}
 
 	return null;
@@ -252,6 +260,7 @@ export {
 	hasPrivateRegistration,
 	isCancelable,
 	isPaidWithCreditCard,
+	isPaidWithPayPalDirect,
 	isPaidWithPaypal,
 	isExpired,
 	isExpiring,

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -26,6 +26,7 @@ import {
 	isIncludedWithPlan,
 	isOneTimePurchase,
 	isPaidWithCreditCard,
+	isPaidWithPayPalDirect,
 	isRedeemable,
 	isRefundable,
 	isRenewable,
@@ -324,6 +325,12 @@ const ManagePurchase = React.createClass( {
 
 			if ( isPaidWithCreditCard( purchase ) ) {
 				paymentInfo = purchase.payment.creditCard.number;
+			} else if ( isPaidWithPayPalDirect( purchase ) ) {
+				paymentInfo = this.translate( 'expiring %(cardExpiry)s', {
+					args: {
+						cardExpiry: purchase.payment.expiryMoment.format( 'MMMM YYYY' )
+					},
+				} );
 			}
 
 			return (


### PR DESCRIPTION
PayPal Direct is legacy payment method, but we still have some purchases that use it for auto renewals. Currently it is shown as PayPal, but that is confusing to user, because the payment was made by payment card through our site.

Before:
![image](https://cloud.githubusercontent.com/assets/203105/21678993/be95744e-d341-11e6-8522-ecd0cb02ccbe.png)

After:
![image](https://cloud.githubusercontent.com/assets/203105/21679004/cf4e46b2-d341-11e6-9599-4d172d067424.png)

We don't know the card type or last four digits, so it unfortunately can't be displayed same way as other payment cards.

To test this, apply D3862-code, and open "Me -> Purchases -> Premium plan" for test user jan701021 in store sandboxed mode.