### PR TITLE
Media Library: try grouping by date (React Virtualized)

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -32,7 +32,7 @@ const MediaLibraryContent = React.createClass( {
 		filter: React.PropTypes.string,
 		filterRequiresUpgrade: React.PropTypes.bool,
 		search: React.PropTypes.string,
-		containerWidth: React.PropTypes.number,
+		disableHeight: React.PropTypes.bool,
 		single: React.PropTypes.bool,
 		scrollable: React.PropTypes.bool,
 		onAddMedia: React.PropTypes.func,
@@ -174,7 +174,7 @@ const MediaLibraryContent = React.createClass( {
 						filter={ this.props.filter }
 						filterRequiresUpgrade={ this.props.filterRequiresUpgrade }
 						search={ this.props.search }
-						containerWidth={ this.props.containerWidth }
+						disableHeight={ this.props.disableHeight }
 						photon={ ! this.props.site.is_private }
 						single={ this.props.single }
 						scrollable={ this.props.scrollable }

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -35,7 +35,7 @@ module.exports = React.createClass( {
 		onScaleChange: React.PropTypes.func,
 		onEditItem: React.PropTypes.func,
 		fullScreenDropZone: React.PropTypes.bool,
-		containerWidth: React.PropTypes.number,
+		disableHeight: React.PropTypes.bool,
 		single: React.PropTypes.bool,
 		scrollable: React.PropTypes.bool
 	},
@@ -122,7 +122,7 @@ module.exports = React.createClass( {
 				filter={ this.props.filter }
 				filterRequiresUpgrade={ this.filterRequiresUpgrade() }
 				search={ this.props.search }
-				containerWidth={ this.props.containerWidth }
+				disableHeight={ this.props.disableHeight }
 				single={ this.props.single }
 				scrollable={ this.props.scrollable }
 				onAddMedia={ this.onAddMedia }

--- a/client/my-sites/media-library/list-item.jsx
+++ b/client/my-sites/media-library/list-item.jsx
@@ -114,7 +114,7 @@ export default React.createClass( {
 		}
 
 		return (
-			<figure className={ classes } onClick={ this.clickItem } { ...props }>
+			<figure className={ classes } onClick={ this.clickItem } title={ title } { ...props }>
 				<span className="media-library__list-item-selected-icon">
 					<Gridicon icon="checkmark" size={ 20 } />
 				</span>

--- a/client/my-sites/media-library/list-item.jsx
+++ b/client/my-sites/media-library/list-item.jsx
@@ -114,22 +114,20 @@ export default React.createClass( {
 		}
 
 		return (
-			<div className={ classes } onClick={ this.clickItem } { ...props }>
+			<figure className={ classes } onClick={ this.clickItem } { ...props }>
 				<span className="media-library__list-item-selected-icon">
 					<Gridicon icon="checkmark" size={ 20 } />
 				</span>
-				<figure className="media-library__list-item-figure" title={ title }>
-					{ this.renderItem() }
-					{ this.renderSpinner() }
-					{ this.props.showGalleryHelp && <EditorMediaModalGalleryHelp /> }
-					<Button type="button" className="media-library__list-item-edit" onClick={ this.editItem }>
-						<span className="screen-reader-text">
-							{ this.translate( 'Edit', { context: 'verb' } ) }
-						</span>
-						<Gridicon icon="pencil" />
-					</Button>
-				</figure>
-			</div>
+				{ this.renderItem() }
+				{ this.renderSpinner() }
+				{ this.props.showGalleryHelp && <EditorMediaModalGalleryHelp /> }
+				<Button type="button" className="media-library__list-item-edit" onClick={ this.editItem }>
+					<span className="screen-reader-text">
+						{ this.translate( 'Edit', { context: 'verb' } ) }
+					</span>
+					<Gridicon icon="pencil" />
+				</Button>
+			</figure>
 		);
 	}
 } );

--- a/client/my-sites/media-library/list-item.jsx
+++ b/client/my-sites/media-library/list-item.jsx
@@ -93,7 +93,7 @@ export default React.createClass( {
 	},
 
 	render: function() {
-		var classes, props, style, title;
+		var classes, props, title;
 
 		classes = classNames( 'media-library__list-item', {
 			'is-placeholder': ! this.props.media,
@@ -104,9 +104,7 @@ export default React.createClass( {
 
 		props = omit( this.props, Object.keys( this.constructor.propTypes ) );
 
-		style = assign( {
-			width: ( this.props.scale * 100 ) + '%'
-		}, this.props.style );
+		props.style = this.props.style;
 
 		if ( this.props.media ) {
 			title = this.props.media.file;
@@ -117,7 +115,7 @@ export default React.createClass( {
 		}
 
 		return (
-			<div className={ classes } style={ style } onClick={ this.clickItem } { ...props }>
+			<div className={ classes } onClick={ this.clickItem } { ...props }>
 				<span className="media-library__list-item-selected-icon">
 					<Gridicon icon="checkmark" size={ 20 } />
 				</span>

--- a/client/my-sites/media-library/list-item.jsx
+++ b/client/my-sites/media-library/list-item.jsx
@@ -4,7 +4,6 @@
 var React = require( 'react' ),
 	classNames = require( 'classnames' ),
 	noop = require( 'lodash/noop' ),
-	assign = require( 'lodash/assign' ),
 	omit = require( 'lodash/omit' ),
 	isEqual = require( 'lodash/isEqual' );
 

--- a/client/my-sites/media-library/list-item.scss
+++ b/client/my-sites/media-library/list-item.scss
@@ -8,8 +8,8 @@
 	&.is-selected::after {
 		content: attr( data-selected-number ) '';
 		position: absolute;
-			right: 8px;
-			bottom: 18px;
+			right: 13px;
+			bottom: 13px;
 		z-index: z-index( '.media-library__list-item', '.media-library__list-item.is-selected::after' );
 		width: 28px;
 		height: 28px;
@@ -49,7 +49,8 @@
 	position: relative;
 	overflow: hidden;
 	height: 0;
-	padding-bottom: 100%;
+	margin: 5px;
+	padding-bottom: calc( 100% - 10px );
 	background-color: lighten( $gray, 20% );
 }
 

--- a/client/my-sites/media-library/list-item.scss
+++ b/client/my-sites/media-library/list-item.scss
@@ -1,15 +1,17 @@
 .media-library__list-item {
+	background-color: lighten( $gray, 20% );
 	position: relative;
 	display: inline-block;
 	cursor: pointer;
 	color: darken( $gray, 10% );
+	overflow: hidden;
 	user-select: none;
 
 	&.is-selected::after {
 		content: attr( data-selected-number ) '';
 		position: absolute;
-			right: 13px;
-			bottom: 13px;
+			right: 8px;
+			bottom: 8px;
 		z-index: z-index( '.media-library__list-item', '.media-library__list-item.is-selected::after' );
 		width: 28px;
 		height: 28px;
@@ -31,7 +33,7 @@
 
 .media-library__list-item-selected-icon .gridicon {
 	position: absolute;
-		bottom: 22px;
+		bottom: 12px;
 		right: 12px;
 	z-index: z-index( '.media-library__list-item', '.media-library__list-item-selected-icon .gridicon' );
 	fill: $white;
@@ -45,26 +47,17 @@
 	display: block;
 }
 
-.media-library__list-item-figure {
-	position: relative;
-	overflow: hidden;
-	height: 0;
-	margin: 5px;
-	padding-bottom: calc( 100% - 10px );
-	background-color: lighten( $gray, 20% );
-}
-
-.media-library__list-item:hover .media-library__list-item-figure {
+.media-library__list-item:hover {
 	box-shadow: 0 0 0 1px $gray,
 				0 2px 4px lighten( $gray, 20% );
 }
 
-.media-library__list-item.is-selected .media-library__list-item-figure {
+.media-library__list-item.is-selected {
 	box-shadow: 0 0 0 2px $blue-medium,
 				0 4px 6px lighten( $gray, 20% );
 }
 
-.media-library__list-item.is-placeholder .media-library__list-item-figure {
+.media-library__list-item.is-placeholder {
 	background-color: lighten( $gray, 20% );
 	animation: loading-fade 1.6s ease-in-out infinite;
 
@@ -78,7 +71,7 @@
 	}
 }
 
-.media-library__list-item.is-transient .media-library__list-item-figure::after {
+.media-library__list-item.is-transient::before {
 	content: '';
 	position: absolute;
 		top: 0;

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -7,9 +7,12 @@ var React = require( 'react' ),
 	filter = require( 'lodash/filter' ),
 	findIndex = require( 'lodash/findIndex' );
 
-import { AutoSizer, InfiniteLoader, Grid, WindowScroller } from 'react-virtualized';
+import AutoSizer from 'react-virtualized/AutoSizer';
+import InfiniteLoader from 'react-virtualized/InfiniteLoader';
+import Grid from 'react-virtualized/Grid';
+import WindowScroller from 'react-virtualized/WindowScroller';
 import { connect } from 'react-redux';
-import fill from 'lodash/fill';
+import { fill } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -264,7 +264,7 @@ export const MediaLibraryList = React.createClass( {
 					isRowLoaded={ this.isRowLoaded }
 					loadMoreRows={ this.loadMoreRows }
 					rowCount={ this._gridItems.length }
-					threshold={ 1 }
+					threshold={ 5 * this._columnCount }
 					minimumBatchSize={ this.props.batchSize }>
 					{ ( args ) => this.renderSizer( args ) }
 				</InfiniteLoader>

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -166,9 +166,11 @@ export const MediaLibraryList = React.createClass( {
 	},
 
 	loadMoreRows: function() {
-		// InfiniteList passes its own parameter which would interfere
-		// with the optional parameters expected by mediaOnFetchNextPage
-		this.props.mediaOnFetchNextPage();
+		if ( ! this.props.mediaFetchingNextPage && this.props.mediaHasNextPage ) {
+			// May be triggered while dispatching an action.
+			// We cannot create a new action while dispatching an old one.
+			setTimeout( this.props.mediaOnFetchNextPage );
+		}
 	},
 
 	render: function() {
@@ -220,7 +222,7 @@ export const MediaLibraryList = React.createClass( {
 									ref={ registerChild }
 									// Trigger update on change.
 									selectedItems={ this.props.mediaLibrarySelectedItems } />
-							)}
+							) }
 						</AutoSizer>
 					) }
 				</InfiniteLoader>

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -33,8 +33,7 @@ export const MediaLibraryList = React.createClass( {
 		filter: React.PropTypes.string,
 		filterRequiresUpgrade: React.PropTypes.bool.isRequired,
 		search: React.PropTypes.string,
-		containerWidth: React.PropTypes.number,
-		rowPadding: React.PropTypes.number,
+		disableHeight: React.PropTypes.bool,
 		mediaScale: React.PropTypes.number.isRequired,
 		photon: React.PropTypes.bool,
 		mediaHasNextPage: React.PropTypes.bool,
@@ -54,8 +53,7 @@ export const MediaLibraryList = React.createClass( {
 			batchSize: 20,
 			media: [],
 			mediaLibrarySelectedItems: Object.freeze( [] ),
-			containerWidth: 0,
-			rowPadding: 10,
+			disableHeight: false,
 			mediaHasNextPage: false,
 			mediaFetchingNextPage: false,
 			mediaOnFetchNextPage: noop,
@@ -208,11 +206,13 @@ export const MediaLibraryList = React.createClass( {
 					threshold={ 1 }
 					minimumBatchSize={ this.props.batchSize }>
 					{ ( { onRowsRendered, registerChild } ) => (
-						<AutoSizer>
+						<AutoSizer disableHeight={ this.props.disableHeight }>
 							{ ( { height, width } ) => (
 								<Grid
 									width={ width }
-									height={ height }
+									height={ this.props.disableHeight
+										? Math.floor( width / this._columnCount ) * this._rowCount
+										: height }
 									columnCount={ this._columnCount }
 									columnWidth={ Math.floor( width / this._columnCount ) }
 									rowCount={ this._rowCount }

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -18,8 +18,7 @@ var MediaActions = require( 'lib/media/actions' ),
 	MediaUtils = require( 'lib/media/utils' ),
 	ListItem = require( './list-item' ),
 	ListNoResults = require( './list-no-results' ),
-	ListNoContent = require( './list-no-content' ),
-	user = require( 'lib/user' )();
+	ListNoContent = require( './list-no-content' );
 
 import ListPlanUpgradeNudge from './list-plan-upgrade-nudge';
 import { getPreference } from 'state/preferences/selectors';
@@ -107,7 +106,7 @@ export const MediaLibraryList = React.createClass( {
 		}
 
 		for ( let i = start; i <= end; i++ ) {
-			let interimIndex = findIndex( selectedItems, {
+			const interimIndex = findIndex( selectedItems, {
 				ID: this.props.media[ i ].ID
 			} );
 
@@ -128,9 +127,9 @@ export const MediaLibraryList = React.createClass( {
 	},
 
 	renderItem: function( { rowIndex, columnIndex, key, style } ) {
-		var media = this.props.media || [];
-		var index = ( rowIndex * this.getItemsPerRow() ) + columnIndex;
-		var item = media[ index ];
+		const media = this.props.media || [];
+		const index = ( rowIndex * this.getItemsPerRow() ) + columnIndex;
+		const item = media[ index ];
 
 		if ( ! item ) {
 			return (
@@ -138,9 +137,9 @@ export const MediaLibraryList = React.createClass( {
 			);
 		}
 
-		var selectedItems = this.props.mediaLibrarySelectedItems;
-		var selectedIndex = findIndex( selectedItems, { ID: item.ID } );
-		var showGalleryHelp = (
+		const selectedItems = this.props.mediaLibrarySelectedItems;
+		const selectedIndex = findIndex( selectedItems, { ID: item.ID } );
+		const showGalleryHelp = (
 			! this.props.single &&
 			selectedIndex !== -1 &&
 			selectedItems.length === 1 &&
@@ -179,13 +178,13 @@ export const MediaLibraryList = React.createClass( {
 	},
 
 	isRowLoaded: function( { index } ) {
-		console.log( 'isRowLoaded', index );
+		window.console.log( 'isRowLoaded', index );
 
 		return !! this.props.media[ index ];
 	},
 
 	loadMoreRows: function( { startIndex, stopIndex } ) {
-		console.log( `Loading rows ${startIndex} - ${stopIndex}.` );
+		window.console.log( `Loading rows ${ startIndex } - ${ stopIndex }.` );
 
 		// InfiniteList passes its own parameter which would interfere
 		// with the optional parameters expected by mediaOnFetchNextPage
@@ -197,7 +196,7 @@ export const MediaLibraryList = React.createClass( {
 			return <ListPlanUpgradeNudge filter={ this.props.filter } site={ this.props.site } />;
 		}
 
-		var media = this.props.media || [];
+		const media = this.props.media || [];
 
 		if ( ! this.props.mediaHasNextPage && media.length === 0 ) {
 			return React.createElement( this.props.search ? ListNoResults : ListNoContent, {
@@ -207,8 +206,8 @@ export const MediaLibraryList = React.createClass( {
 			} );
 		}
 
-		var columnCount = this.getItemsPerRow();
-		var rowCount = Math.ceil( media.length / columnCount );
+		const columnCount = this.getItemsPerRow();
+		const rowCount = Math.ceil( media.length / columnCount );
 
 		return (
 			<div className="media-library__list">

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -161,7 +161,7 @@ export const MediaLibraryList = React.createClass( {
 		);
 	},
 
-	onSectionRendered( { columnStartIndex, columnStopIndex, rowStartIndex, rowStopIndex } ) {
+	onSectionRendered: function( { columnStartIndex, columnStopIndex, rowStartIndex, rowStopIndex } ) {
 		const startIndex = rowStartIndex * this._columnCount + columnStartIndex;
 		const stopIndex = rowStopIndex * this._columnCount + columnStopIndex;
 

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -197,6 +197,8 @@ export const MediaLibraryList = React.createClass( {
 				scrollTop={ scrollTop }
 				// Trigger update on change.
 				selectedItems={ this.props.mediaLibrarySelectedItems }
+				// Never show a hortizontal scrollbar.
+				style={ { overflowX: 'hidden' } }
 				width={ width } />
 		);
 	},

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -119,7 +119,7 @@ export const MediaLibraryList = React.createClass( {
 			left: style.left + this.props.padding,
 			width: style.width - this.props.padding * 2,
 			height: style.height - this.props.padding * 2,
-		}
+		};
 
 		if ( ! item ) {
 			return;

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -161,15 +161,11 @@ export const MediaLibraryList = React.createClass( {
 		);
 	},
 
-	createOnSectionRendered( onRowsRendered ) {
-		const columnCount = this._columnCount;
+	onSectionRendered( { columnStartIndex, columnStopIndex, rowStartIndex, rowStopIndex } ) {
+		const startIndex = rowStartIndex * this._columnCount + columnStartIndex;
+		const stopIndex = rowStopIndex * this._columnCount + columnStopIndex;
 
-		return function( { columnStartIndex, columnStopIndex, rowStartIndex, rowStopIndex } ) {
-			const startIndex = rowStartIndex * columnCount + columnStartIndex;
-			const stopIndex = rowStopIndex * columnCount + columnStopIndex;
-
-			return onRowsRendered( { startIndex, stopIndex } );
-		};
+		return this._onRowsRendered( { startIndex, stopIndex } );
 	},
 
 	isRowLoaded: function( { index } ) {
@@ -184,7 +180,7 @@ export const MediaLibraryList = React.createClass( {
 		}
 	},
 
-	renderGrid: function( { height, onRowsRendered, registerChild, scrollTop, width } ) {
+	renderGrid: function( { height, registerChild, scrollTop, width } ) {
 		const gridSize = Math.floor( width / this._columnCount );
 
 		return (
@@ -194,7 +190,7 @@ export const MediaLibraryList = React.createClass( {
 				columnCount={ this._columnCount }
 				columnWidth={ gridSize }
 				height={ height }
-				onSectionRendered={ this.createOnSectionRendered( onRowsRendered ) }
+				onSectionRendered={ this.onSectionRendered }
 				ref={ registerChild }
 				rowCount={ this._rowCount }
 				rowHeight={ gridSize }
@@ -206,12 +202,15 @@ export const MediaLibraryList = React.createClass( {
 	},
 
 	renderSizer: function( { onRowsRendered, registerChild } ) {
+		this._onRowsRendered = onRowsRendered;
+
 		if ( ! this.props.disableHeight ) {
 			return (
 				<AutoSizer>
 					{ ( { height, width } ) => this.renderGrid( {
-						onRowsRendered, registerChild,
-						height, width
+						registerChild,
+						height,
+						width
 					} ) }
 				</AutoSizer>
 			);
@@ -222,8 +221,9 @@ export const MediaLibraryList = React.createClass( {
 				{ ( { height, scrollTop } ) => (
 					<AutoSizer disableHeight>
 						{ ( { width } ) => this.renderGrid( {
-							onRowsRendered, registerChild,
-							height, scrollTop,
+							registerChild,
+							height,
+							scrollTop,
 							width
 						} ) }
 					</AutoSizer>

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -261,7 +261,7 @@ export const MediaLibraryList = React.createClass( {
 					rowCount={ this._gridItems.length }
 					threshold={ 1 }
 					minimumBatchSize={ this.props.batchSize }>
-					{ this.renderSizer }
+					{ ( args ) => this.renderSizer( args ) }
 				</InfiniteLoader>
 			</div>
 		);

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -9,6 +9,7 @@ var React = require( 'react' ),
 
 import { AutoSizer, InfiniteLoader, Grid } from 'react-virtualized';
 import { connect } from 'react-redux';
+import fill from 'lodash/fill';
 
 /**
  * Internal dependencies
@@ -193,14 +194,12 @@ export const MediaLibraryList = React.createClass( {
 			} );
 		}
 
+		this._gridItems = this.props.media;
+
 		if ( this.props.mediaHasNextPage ) {
-			this._gridItems = this.props.media.concat(
-				Array.apply( null, new Array( this.props.batchSize ) ).map( () => {
-					return { loading: true };
-				} )
+			this._gridItems = this._gridItems.concat(
+				fill( Array( this.props.batchSize ), { loading: true } )
 			);
-		} else {
-			this._gridItems = this.props.media;
 		}
 
 		this._columnCount = Math.floor( 1 / this.props.mediaScale );

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -41,7 +41,8 @@ export const MediaLibraryList = React.createClass( {
 		mediaOnFetchNextPage: React.PropTypes.func,
 		single: React.PropTypes.bool,
 		scrollable: React.PropTypes.bool,
-		onEditItem: React.PropTypes.func
+		onEditItem: React.PropTypes.func,
+		padding: React.PropTypes.number
 	},
 
 	getInitialState: function() {
@@ -59,7 +60,8 @@ export const MediaLibraryList = React.createClass( {
 			mediaOnFetchNextPage: noop,
 			single: false,
 			scrollable: false,
-			onEditItem: noop
+			onEditItem: noop,
+			padding: 5
 		};
 	},
 
@@ -110,7 +112,14 @@ export const MediaLibraryList = React.createClass( {
 		const index = rowIndex * this._columnCount + columnIndex;
 		const item = this._gridItems[ index ];
 
-		style.fontSize = this.props.mediaScale * 225;
+		style = {
+			...style,
+			fontSize: this.props.mediaScale * 225,
+			top: style.top + this.props.padding,
+			left: style.left + this.props.padding,
+			width: style.width - this.props.padding * 2,
+			height: style.height - this.props.padding * 2,
+		}
 
 		if ( ! item ) {
 			return;

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -293,31 +293,39 @@ export const MediaLibraryList = React.createClass( {
 		const items = [];
 
 		this.props.media.forEach( ( item, index, media ) => {
+			// If it's the first item or the day has changed, add a heading.
 			if ( ! index || ! this.props.moment( media[ index - 1 ].date ).isSame( item.date, 'day' ) ) {
+				// Amount of items that don't fill an entire row.
 				const trailing = items.length % this._columnCount;
 
+				// Fill the last row with empty slots.
 				if ( trailing ) {
 					items.push( ...Array( this._columnCount - trailing ) );
 				}
 
+				// Add a heading with the date.
 				items.push( {
 					heading: this.formatDate( item.date ),
 				} );
 
+				// Fill the rest of the row with empty slots.
 				items.push( ...Array( this._columnCount - 1 ) );
 			}
 
 			items.push( item );
 		} );
 
+		// If there are no media, add a placeholder heading.
 		if ( ! this.props.media.length ) {
 			items.push( {
 				heading: '',
 			} );
 
+			// Fill the rest of the row with empty slots.
 			items.push( ...Array( this._columnCount - 1 ) );
 		}
 
+		// If there is more media to come, show placeholders for them.
 		if ( this.props.mediaHasNextPage ) {
 			items.push( ...fill( Array( this.props.batchSize ), {
 				loading: true

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -280,7 +280,10 @@ export const MediaLibraryList = React.createClass( {
 		} else if ( oneWeekAgo.isBefore( moment, 'day' ) ) {
 			return moment.format( 'dddd' );
 		} else if ( oneYearAgo.isBefore( moment, 'day' ) ) {
-			return moment.format( 'D MMMM' );
+			return moment.format( this.props.translate( '%(month)s %(day)s', {
+				comment: 'Date format.',
+				args: { day: 'D', month: 'MMMM' }
+			} ) );
 		}
 
 		return moment.format( 'LL' );

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -68,7 +68,7 @@ export const MediaLibraryList = React.createClass( {
 			scrollable: false,
 			onEditItem: noop,
 			padding: 5,
-			headingHeight: 33
+			headingHeight: 50
 		};
 	},
 
@@ -130,21 +130,23 @@ export const MediaLibraryList = React.createClass( {
 		const index = rowIndex * this._columnCount + columnIndex;
 		const item = this._gridItems[ index ];
 
-		style = {
-			...style,
-			top: style.top + this.props.padding,
-			left: style.left + this.props.padding,
-			width: style.width - this.props.padding * 2,
-			height: style.height - this.props.padding * 2,
-		};
-
 		if ( ! item ) {
 			return;
 		}
 
+		style = {
+			...style,
+			top: style.top + this.props.padding,
+			left: style.left + this.props.padding,
+			width: item.heading
+				? style.width * this._columnCount - this.props.padding * 2
+				: style.width - this.props.padding * 2,
+			height: style.height - this.props.padding * 2,
+		};
+
 		if ( item.heading ) {
 			return (
-				<h3 key={ key } style={ style }>{ item.heading }</h3>
+				<h3 key={ key } style={ style }><span>{ item.heading }</span></h3>
 			);
 		}
 

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -267,18 +267,21 @@ export const MediaLibraryList = React.createClass( {
 	formatDate: function( date ) {
 		const moment = this.props.moment( date );
 		const today = this.props.moment().startOf( 'day' );
-		const yesterday = today.clone().subtract( 1, 'days' );
-		const lastWeek = today.clone().subtract( 7, 'days' );
+		const yesterday = today.clone().subtract( 1, 'day' );
+		const oneWeekAgo = today.clone().subtract( 7, 'days' );
+		const oneYearAgo = today.clone().subtract( 1, 'year' );
 
 		if ( today.isSame( moment, 'day' ) ) {
 			return this.props.translate( 'Today' );
 		} else if ( yesterday.isSame( moment, 'day' ) ) {
 			return this.props.translate( 'Yesterday' );
-		} else if ( lastWeek.isBefore( moment, 'day' ) ) {
+		} else if ( oneWeekAgo.isBefore( moment, 'day' ) ) {
 			return moment.format( 'dddd' );
+		} else if ( oneYearAgo.isBefore( moment, 'day' ) ) {
+			return moment.format( 'D MMMM' );
 		}
 
-		return moment.format( 'D MMMM' );
+		return moment.format( 'LL' );
 	},
 
 	getGridItems: function() {

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -266,21 +266,21 @@ export const MediaLibraryList = React.createClass( {
 		return this._gridSize;
 	},
 
-	formatDate: function( date ) {
-		const moment = this.props.moment( date );
+	formatDate: function( moment ) {
+		const { translate } = this.props;
 		const today = this.props.moment().startOf( 'day' );
 		const yesterday = today.clone().subtract( 1, 'day' );
 		const oneWeekAgo = today.clone().subtract( 7, 'days' );
 		const oneYearAgo = today.clone().subtract( 1, 'year' );
 
-		if ( today.isSame( moment, 'day' ) ) {
-			return this.props.translate( 'Today' );
-		} else if ( yesterday.isSame( moment, 'day' ) ) {
-			return this.props.translate( 'Yesterday' );
-		} else if ( oneWeekAgo.isBefore( moment, 'day' ) ) {
+		if ( moment.isSame( today, 'day' ) ) {
+			return translate( 'Today' );
+		} else if ( moment.isSame( yesterday, 'day' ) ) {
+			return translate( 'Yesterday' );
+		} else if ( moment.isAfter( oneWeekAgo, 'day' ) ) {
 			return moment.format( 'dddd' );
-		} else if ( oneYearAgo.isBefore( moment, 'day' ) ) {
-			return moment.format( this.props.translate( '%(month)s %(day)s', {
+		} else if ( moment.isAfter( oneYearAgo, 'day' ) ) {
+			return moment.format( translate( '%(month)s %(day)s', {
 				comment: 'Date format.',
 				args: { day: 'D', month: 'MMMM' }
 			} ) );
@@ -293,8 +293,10 @@ export const MediaLibraryList = React.createClass( {
 		const items = [];
 
 		this.props.media.forEach( ( item, index, media ) => {
+			const itemMoment = this.props.moment( item.date );
+
 			// If it's the first item or the day has changed, add a heading.
-			if ( ! index || ! this.props.moment( media[ index - 1 ].date ).isSame( item.date, 'day' ) ) {
+			if ( ! index || ! itemMoment.isSame( media[ index - 1 ].date, 'day' ) ) {
 				// Amount of items that don't fill an entire row.
 				const trailing = items.length % this._columnCount;
 
@@ -305,7 +307,7 @@ export const MediaLibraryList = React.createClass( {
 
 				// Add a heading with the date.
 				items.push( {
-					heading: this.formatDate( item.date ),
+					heading: this.formatDate( itemMoment ),
 				} );
 
 				// Fill the rest of the row with empty slots.

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -138,13 +138,13 @@ export const MediaLibraryList = React.createClass( {
 			...style,
 			top: style.top + this.props.padding,
 			left: style.left + this.props.padding,
-			width: item.heading
+			width: 'heading' in item
 				? style.width * this._columnCount - this.props.padding * 2
 				: style.width - this.props.padding * 2,
 			height: style.height - this.props.padding * 2,
 		};
 
-		if ( item.heading ) {
+		if ( 'heading' in item ) {
 			return (
 				<h3 key={ key } style={ style }><span>{ item.heading }</span></h3>
 			);
@@ -259,7 +259,7 @@ export const MediaLibraryList = React.createClass( {
 	getRowHeight: function( { index } ) {
 		const item = this._gridItems[ index * this._columnCount ];
 
-		if ( item && item.heading ) {
+		if ( item && 'heading' in item ) {
 			return this.props.headingHeight;
 		}
 
@@ -306,6 +306,14 @@ export const MediaLibraryList = React.createClass( {
 
 			items.push( item );
 		} );
+
+		if ( ! this.props.media.length ) {
+			items.push( {
+				heading: '',
+			} );
+
+			items.push( ...Array( this._columnCount - 1 ) );
+		}
 
 		if ( this.props.mediaHasNextPage ) {
 			items.push( ...fill( Array( this.props.batchSize ), {

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -113,6 +113,7 @@
 
 .media-library__list {
 	padding: 0 16px;
+	margin: 0 -5px;
 }
 
 .media-library__list-item:hover .media-library__list-item-edit {

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -116,6 +116,27 @@
 	margin: 0 -5px;
 }
 
+.media-library__list h3 {
+	overflow: hidden;
+}
+
+.media-library__list h3 span {
+	padding-right: 5px;
+	position: absolute;
+		bottom: 0;
+
+	&:before {
+		background: lighten( $gray, 20% );
+		content: '';
+		display: block;
+		height: 1px;
+		position: absolute;
+			top: 60%;
+			left: 100%;
+		width: 10000px;
+	}
+}
+
 .media-library__list-item:hover .media-library__list-item-edit {
 	opacity: 1;
 }

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -117,7 +117,10 @@
 }
 
 .media-library__list h3 {
+	color: darken( $gray, 20% );
+	font-size: 11px;
 	overflow: hidden;
+	text-transform: uppercase;
 }
 
 .media-library__list h3 span {
@@ -130,14 +133,14 @@
 		display: block;
 		height: 1px;
 		position: absolute;
-			top: 60%;
+			top: 50%;
 			left: calc( 100% + 5px );
 		width: 10000px;
 	}
 
 	&:empty {
 		background: lighten( $gray, 20% );
-		height: 22px;
+		height: 16px;
 		width: 50px;
 	}
 }

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -121,7 +121,6 @@
 }
 
 .media-library__list h3 span {
-	padding-right: 5px;
 	position: absolute;
 		bottom: 0;
 
@@ -132,8 +131,14 @@
 		height: 1px;
 		position: absolute;
 			top: 60%;
-			left: 100%;
+			left: calc( 100% + 5px );
 		width: 10000px;
+	}
+
+	&:empty {
+		background: lighten( $gray, 20% );
+		height: 22px;
+		width: 50px;
 	}
 }
 

--- a/client/my-sites/media-library/test/list.jsx
+++ b/client/my-sites/media-library/test/list.jsx
@@ -43,7 +43,10 @@ describe( 'MediaLibraryList item selection', function() {
 				get: noop
 			} )
 		} );
-		mockery.registerMock( 'components/infinite-list', EmptyComponent );
+		mockery.registerMock( 'react-virtualized/AutoSizer', EmptyComponent );
+		mockery.registerMock( 'react-virtualized/InfiniteLoader', EmptyComponent );
+		mockery.registerMock( 'react-virtualized/Grid', EmptyComponent );
+		mockery.registerMock( 'react-virtualized/WindowScroller', EmptyComponent );
 		mockery.registerMock( './list-item', EmptyComponent );
 		mockery.registerMock( './list-plan-upgrade-nudge', EmptyComponent );
 

--- a/client/my-sites/media-library/test/list.jsx
+++ b/client/my-sites/media-library/test/list.jsx
@@ -19,13 +19,44 @@ import useMockery from 'test/helpers/use-mockery';
  */
 const DUMMY_SITE_ID = 2916284;
 
-describe( 'MediaLibraryList item selection', function() {
-	let mount, MediaLibrarySelectedData, MediaLibrarySelectedStore,
-		MediaActions, fixtures, Dispatcher, MediaList, wrapper,
-		mediaList, LocalizedMediaList;
+let mount, MediaLibrarySelectedData, MediaLibrarySelectedStore,
+	MediaActions, fixtures, Dispatcher, MediaList, LocalizedMediaList;
 
-	useFakeDom();
-	useMockery();
+useFakeDom();
+useMockery();
+
+before( function() {
+	mockery.registerMock( 'lib/wp', {
+		me: () => ( {
+			get: noop
+		} )
+	} );
+	mockery.registerMock( 'react-virtualized/AutoSizer', EmptyComponent );
+	mockery.registerMock( 'react-virtualized/InfiniteLoader', EmptyComponent );
+	mockery.registerMock( 'react-virtualized/Grid', EmptyComponent );
+	mockery.registerMock( 'react-virtualized/WindowScroller', EmptyComponent );
+	mockery.registerMock( './list-item', EmptyComponent );
+	mockery.registerMock( './list-plan-upgrade-nudge', EmptyComponent );
+
+	mount = require( 'enzyme' ).mount;
+	MediaLibrarySelectedData = require( 'components/data/media-library-selected-data' );
+	MediaLibrarySelectedStore = require( 'lib/media/library-selected-store' );
+	MediaActions = require( 'lib/media/actions' );
+	fixtures = require( './fixtures' );
+	Dispatcher = require( 'dispatcher' );
+
+	Dispatcher.handleServerAction( {
+		type: 'RECEIVE_MEDIA_ITEMS',
+		siteId: DUMMY_SITE_ID,
+		data: fixtures
+	} );
+
+	MediaList = require( '../list' ).MediaLibraryList;
+	LocalizedMediaList = localize( MediaList );
+} );
+
+describe( 'MediaLibraryList item selection', function() {
+	let mediaList, wrapper;
 
 	function toggleItem( itemIndex, shiftClick ) {
 		mediaList.toggleItem( fixtures.media[ itemIndex ], shiftClick );
@@ -38,36 +69,6 @@ describe( 'MediaLibraryList item selection', function() {
 			} )
 		);
 	}
-
-	before( function() {
-		mockery.registerMock( 'lib/wp', {
-			me: () => ( {
-				get: noop
-			} )
-		} );
-		mockery.registerMock( 'react-virtualized/AutoSizer', EmptyComponent );
-		mockery.registerMock( 'react-virtualized/InfiniteLoader', EmptyComponent );
-		mockery.registerMock( 'react-virtualized/Grid', EmptyComponent );
-		mockery.registerMock( 'react-virtualized/WindowScroller', EmptyComponent );
-		mockery.registerMock( './list-item', EmptyComponent );
-		mockery.registerMock( './list-plan-upgrade-nudge', EmptyComponent );
-
-		mount = require( 'enzyme' ).mount;
-		MediaLibrarySelectedData = require( 'components/data/media-library-selected-data' );
-		MediaLibrarySelectedStore = require( 'lib/media/library-selected-store' );
-		MediaActions = require( 'lib/media/actions' );
-		fixtures = require( './fixtures' );
-		Dispatcher = require( 'dispatcher' );
-
-		Dispatcher.handleServerAction( {
-			type: 'RECEIVE_MEDIA_ITEMS',
-			siteId: DUMMY_SITE_ID,
-			data: fixtures
-		} );
-
-		MediaList = require( '../list' ).MediaLibraryList;
-		LocalizedMediaList = localize( MediaList );
-	} );
 
 	beforeEach( function() {
 		MediaActions.setLibrarySelectedItems( DUMMY_SITE_ID, [] );
@@ -193,5 +194,73 @@ describe( 'MediaLibraryList item selection', function() {
 			toggleItem( 4, true ); // Shift+click to select items 0 through 4
 			expectSelectedItems( 4 );
 		} );
+	} );
+} );
+
+describe( 'getGridItems()', () => {
+	let wrapper;
+
+	function getGridItemsWith( { media, nextPage, columnCount } ) {
+		wrapper = mount(
+			<LocalizedMediaList
+				batchSize={ 1 }
+				media={ media }
+				mediaHasNextPage={ nextPage }
+				mediaScale={ 1 / columnCount }
+				site={ { ID: DUMMY_SITE_ID } } />
+		);
+
+		return wrapper.find( MediaList ).get( 0 ).getGridItems();
+	}
+
+	afterEach( () => {
+		wrapper.unmount();
+	} );
+
+	it( 'should return placeholders', function() {
+		expect( getGridItemsWith( {
+			media: [],
+			nextPage: true,
+			columnCount: 2
+		} ) ).to.eql( [
+			{ heading: '' }, undefined,
+			{ loading: true }
+		] );
+	} );
+
+	it( 'should return a heading, media, and placeholders', function() {
+		expect( getGridItemsWith( {
+			media: fixtures.media,
+			nextPage: true,
+			columnCount: 2
+		} ) ).to.eql( [
+			{ heading: 'Today' }, undefined,
+			...fixtures.media,
+			{ loading: true }
+		] );
+	} );
+
+	it( 'should return a heading, media, but no placeholders', function() {
+		expect( getGridItemsWith( {
+			media: fixtures.media,
+			nextPage: false,
+			columnCount: 2
+		} ) ).to.eql( [
+			{ heading: 'Today' }, undefined,
+			...fixtures.media
+		] );
+	} );
+
+	it( 'should return multiple headings', function() {
+		expect( getGridItemsWith( {
+			media: [ ...fixtures.media, { date: '2000-01-01' } ],
+			nextPage: false,
+			columnCount: 4
+		} ) ).to.eql( [
+			{ heading: 'Today' }, undefined, undefined, undefined,
+			...fixtures.media, undefined, undefined,
+			{ heading: 'January 1, 2000' }, undefined, undefined, undefined,
+			{ date: '2000-01-01' }
+		] );
 	} );
 } );

--- a/client/my-sites/media-library/test/list.jsx
+++ b/client/my-sites/media-library/test/list.jsx
@@ -5,6 +5,7 @@ import { expect } from 'chai';
 import { noop, toArray } from 'lodash';
 import React from 'react';
 import mockery from 'mockery';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -20,7 +21,8 @@ const DUMMY_SITE_ID = 2916284;
 
 describe( 'MediaLibraryList item selection', function() {
 	let mount, MediaLibrarySelectedData, MediaLibrarySelectedStore,
-		MediaActions, fixtures, Dispatcher, MediaList, wrapper, mediaList;
+		MediaActions, fixtures, Dispatcher, MediaList, wrapper,
+		mediaList, LocalizedMediaList;
 
 	useFakeDom();
 	useMockery();
@@ -64,6 +66,7 @@ describe( 'MediaLibraryList item selection', function() {
 		} );
 
 		MediaList = require( '../list' ).MediaLibraryList;
+		LocalizedMediaList = localize( MediaList );
 	} );
 
 	beforeEach( function() {
@@ -78,7 +81,7 @@ describe( 'MediaLibraryList item selection', function() {
 		beforeEach( () => {
 			wrapper = mount(
 				<MediaLibrarySelectedData siteId={ DUMMY_SITE_ID }>
-					<MediaList
+					<LocalizedMediaList
 						filterRequiresUpgrade={ false }
 						site={ { ID: DUMMY_SITE_ID } }
 						media={ fixtures.media }
@@ -160,7 +163,7 @@ describe( 'MediaLibraryList item selection', function() {
 		beforeEach( () => {
 			wrapper = mount(
 				<MediaLibrarySelectedData siteId={ DUMMY_SITE_ID }>
-					<MediaList
+					<LocalizedMediaList
 						filterRequiresUpgrade={ false }
 						site={ { ID: DUMMY_SITE_ID } }
 						media={ fixtures.media }

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -32,12 +32,6 @@ export default React.createClass( {
 		};
 	},
 
-	componentDidMount: function() {
-		this.setState( {
-			containerWidth: this.refs.container.clientWidth
-		} );
-	},
-
 	onFilterChange: function( filter ) {
 		let redirect = '/media';
 
@@ -110,7 +104,7 @@ export default React.createClass( {
 	render: function() {
 		const site = this.props.sites.getSelectedSite();
 		return (
-			<div ref="container" className="main main-column media" role="main">
+			<div className="main main-column media" role="main">
 				<SidebarNavigation />
 				{ ( this.state.editedItem || this.state.openedDetails ) &&
 					<Dialog
@@ -145,7 +139,7 @@ export default React.createClass( {
 					site={ site || false }
 					single={ true }
 					onEditItem={ this.openDetailsModal }
-					containerWidth={ this.state.containerWidth } />
+					disableHeight={ true } />
 			</div>
 		);
 	}

--- a/client/post-editor/media-modal/index.scss
+++ b/client/post-editor/media-modal/index.scss
@@ -165,7 +165,7 @@
 	}
 }
 
-.editor-media-modal .media-library__list-item-figure {
+.editor-media-modal .media-library__list-item {
 	background-color: $gray-light;
 	box-shadow: inset 0 0 0 1px lighten( $gray, 25% );
 }

--- a/client/post-editor/media-modal/index.scss
+++ b/client/post-editor/media-modal/index.scss
@@ -165,7 +165,7 @@
 	}
 }
 
-.editor-media-modal .media-library__list-item {
+.editor-media-modal .media-library__list-item:not( .is-placeholder ) {
 	background-color: $gray-light;
 	box-shadow: inset 0 0 0 1px lighten( $gray, 25% );
 }


### PR DESCRIPTION
This PR is similar to #10238, but it **builds on a media library that uses React Virtualized**. See #10285 for more on that.

Branch diff: https://github.com/Automattic/wp-calypso/compare/update/media-library-react-virtualized...try/media-library-date-groups-virtualized

It only groups the media by date, displays the date at the top (wrapped in an `h3` element) in a pretty format ("Today", "Yesterday", day of the week if within 7 days, day and month if within a year, and a full date for the rest). Each group starts on a new line. ~~It has no further styling.~~

![screen shot 2017-01-05 at 12 36 17](https://cloud.githubusercontent.com/assets/4710635/21686802/f32d2e3e-d366-11e6-9fe2-5e3dd35689c3.png)

The original mock up from @adambbecker has smaller groups aligned:

![zoomed-default_grid](https://cloud.githubusercontent.com/assets/4710635/21679086/4f778074-d342-11e6-8f32-c8f257dbaf21.png)

I left a comment regarding that (p5j4vm-1rz-p2):

> I’ve been thinking a bit more about the aligning of images, as it does seem to be in scope of the task. It would indeed be good to align small groups of items together. A disadvantage, though, is that it becomes difficult to scan through, which is why we’re adding these dates in the first place. I think it is best to keep the group label (i.e. the dates) left aligned (and right for RTL languages of course).
>
> An alternative would be to group smaller groups together and have the label be a range of dates. The question is when to start and when to stop. If you have mostly small groups, or the range is big, you might end up with ranges like 17 May – 8 November. To prevent this we could draw the line at the months. This might still look weird if you don’t have much media, which makes me wonder if we should remove the date grouping if there are too few images.
>
> Like this is becomes quite complex, and I’m not sure at all if it’s the right way to go. It’s very unlike a media library of a camera; I think most people just use a few media per post, but I lack the data to know.
>
> Another alternative could be to group the media in “smart” albums and only display the first, which would then link to a list of all the images uploaded that day. Single images would not link to a list and are “loose”, but as soon as there’s more than one uploaded on the same day, it has a list. Like this there will be no gaps at all in he layout, it’s easy to scan, and each tile has a label with the day. This can even be done for other things like the ordering by uploaded post.
>
> I would love to get some feedback on these issues. For now I’ll just leave them grouped by day, starting on a new line.

And:

> I think the “smart” album approach might work quite well if you have tons of media too. When I upload 100+ pictures of an event that I want to link, I’d no longer have to scroll through all of them before I reach older pictures, which is one of the most frustrating bits about the media library. Not only do you have to scroll through all of them, but you have to wait as they load, 20 at the time.