### PR TITLE
Site Settings: Introduce JetpackModuleToggle component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -315,6 +315,7 @@
 @import 'my-sites/site-settings/delete-site/style';
 @import 'my-sites/site-settings/delete-site-options/style';
 @import 'my-sites/site-settings/delete-site-warning-dialog/style';
+@import 'my-sites/site-settings/jetpack-module-toggle/style';
 @import 'my-sites/site-settings/jetpack-sync-panel/style';
 @import 'my-sites/site-settings/site-icon-setting/style';
 @import 'my-sites/site-settings/taxonomies/style';

--- a/client/my-sites/site-settings/jetpack-module-toggle/index.jsx
+++ b/client/my-sites/site-settings/jetpack-module-toggle/index.jsx
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+/**
+ * Internal dependencies
+ */
+import { localize } from 'i18n-calypso';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+
+import {
+	activateModule,
+	deactivateModule
+} from 'state/jetpack-settings/modules/actions';
+import {
+	isModuleActive,
+	isActivatingModule,
+	isDeactivatingModule,
+	getModule
+} from 'state/jetpack-settings/modules/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+
+class JetpackModuleToggle extends Component {
+	static defaultProps = {
+		disabled: false,
+		toggleDisabled: false,
+		checked: false,
+		isJetpackSite: false
+	};
+
+	static propTypes = {
+		siteId: PropTypes.number.isRequired,
+		moduleSlug: PropTypes.string.isRequired,
+		label: PropTypes.string.isRequired,
+		checked: PropTypes.bool,
+		disabled: PropTypes.bool,
+		toggleDisabled: PropTypes.bool,
+		isJetpackSite: PropTypes.bool,
+		activateModule: PropTypes.func,
+		deactivateModule: PropTypes.func
+	};
+
+	handleChange = () => {
+		if ( ! this.props.checked ) {
+			this.props.activateModule( this.props.siteId, this.props.moduleSlug );
+		} else {
+			this.props.deactivateModule( this.props.siteId, this.props.moduleSlug );
+		}
+	}
+
+	render() {
+		if ( ! this.props.isJetpackSite ) {
+			return null;
+		}
+		return (
+			<span className="jetpack-module-toggle">
+				<CompactFormToggle
+					id={ `${ this.props.siteId }-${ this.props.moduleSlug }-toggle` }
+					checked={ this.props.checked }
+					toggling={ this.props.toggling }
+					onChange={ this.handleChange }
+					disabled={ this.props.disabled || this.props.toggleDisabled } >
+					<span>{ this.props.label }</span>
+					{
+						this.props.description && (
+							<FormSettingExplanation isIndented>
+								{ this.props.description }
+							</FormSettingExplanation>
+						)
+					}
+				</CompactFormToggle>
+			</span>
+		);
+	}
+}
+
+export default connect( ( state, ownProps ) => {
+	const active = isModuleActive( state, ownProps.siteId, ownProps.moduleSlug );
+	const activating = isActivatingModule( state, ownProps.siteId, ownProps.moduleSlug );
+	const moduleDetails = getModule( state, ownProps.siteId, ownProps.moduleSlug );
+	const deactivating = isDeactivatingModule( state, ownProps.siteId, ownProps.moduleSlug );
+	const moduleDetailsNotLoaded = moduleDetails === null;
+	const toggling = activating || deactivating;
+	return {
+		moduleDetails,
+		checked: ( active && ! deactivating ) || ( ! active && activating ),
+		toggling,
+		toggleDisabled: moduleDetailsNotLoaded || toggling,
+		isJetpackSite: isJetpackSite( state, ownProps.siteId )
+	};
+}, {
+	activateModule,
+	deactivateModule
+} )( localize( JetpackModuleToggle ) );

--- a/client/my-sites/site-settings/jetpack-module-toggle/style.scss
+++ b/client/my-sites/site-settings/jetpack-module-toggle/style.scss
@@ -1,0 +1,7 @@
+.jetpack-module-toggle .form-toggle__label *:not( .form-toggle__switch ) {
+	margin-left: 8px;
+}
+
+.jetpack-module-toggle p.form-setting-explanation.is-indented {
+	margin-left: 32px;
+}


### PR DESCRIPTION
This PR introduces the `JetpackModuleToggle` component that we'll be able to use within Jetpack Settings. I've kindly borrowed it from @oskosk, who implemented it in #9802 (thanks @oskosk for that!). I've done a quick change there to allow it to be disabled from outside.

This PR is part of the Jetpack Module Settings effort (#9171).

To test:

* Checkout this branch
* Insert the component anywhere in Site Settings, like this:

```
import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';

...

<JetpackModuleToggle siteId={ 123456 } moduleSlug="infinite-scroll" label={ "Some label" } />
```

* Verify it activates and deactivates the specified module properly for the specified site.
* Play around with its props and verify it works as expected.