### PR TITLE
Theme Sheet: Add Tracks events to Support and CSS buttons

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -54,6 +54,7 @@ import { getTheme } from 'state/themes/selectors';
 import { isValidTerm } from 'my-sites/themes/theme-filters';
 import { hasFeature } from 'state/sites/plans/selectors';
 import { FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 const ThemeSheet = React.createClass( {
 	displayName: 'ThemeSheet',
@@ -144,6 +145,25 @@ const ThemeSheet = React.createClass( {
 			return this.getValidSections()[ 0 ];
 		}
 		return section;
+	},
+
+	trackButtonClick( context ) {
+		this.props.recordTracksEvent( 'calypso_theme_sheet_button_click', {
+			theme_name: this.props.id,
+			button_context: context
+		} );
+	},
+
+	trackContactUsClick() {
+		this.trackButtonClick( 'help' );
+	},
+
+	trackThemeForumClick() {
+		this.trackButtonClick( 'theme_forum' );
+	},
+
+	trackCssClick() {
+		this.trackButtonClick( 'css_forum' );
 	},
 
 	togglePreview() {
@@ -275,7 +295,12 @@ const ThemeSheet = React.createClass( {
 					{ i18n.translate( 'Need extra help?' ) }
 					<small>{ i18n.translate( 'Get in touch with our support team' ) }</small>
 				</div>
-				<Button primary={ isPrimary } href={ '/help/contact/' }>Contact us</Button>
+				<Button
+					primary={ isPrimary }
+					href={ '/help/contact/' }
+					onClick={ this.trackContactUsClick }>
+					{ i18n.translate( 'Contact us' ) }
+				</Button>
 			</Card>
 		);
 	},
@@ -296,7 +321,12 @@ const ThemeSheet = React.createClass( {
 					{ i18n.translate( 'Have a question about this theme?' ) }
 					<small>{ description }</small>
 				</div>
-				<Button primary={ isPrimary } href={ this.props.forumUrl }>Visit forum</Button>
+				<Button
+					primary={ isPrimary }
+					href={ this.props.forumUrl }
+					onClick={ this.trackThemeForumClick }>
+					{ i18n.translate( 'Visit forum' ) }
+				</Button>
 			</Card>
 		);
 	},
@@ -309,7 +339,11 @@ const ThemeSheet = React.createClass( {
 					{ i18n.translate( 'Need CSS help? ' ) }
 					<small>{ i18n.translate( 'Get help from the experts in our CSS forum' ) }</small>
 				</div>
-				<Button href="//en.forums.wordpress.com/forum/css-customization">Visit forum</Button>
+				<Button
+					href="//en.forums.wordpress.com/forum/css-customization"
+					onClick={ this.trackCssClick }>
+					{ i18n.translate( 'Visit forum' ) }
+				</Button>
 			</Card>
 		);
 	},
@@ -648,5 +682,8 @@ export default connect(
 			),
 			forumUrl: selectedSite && getThemeForumUrl( state, id, selectedSite.ID ),
 		};
+	},
+	{
+		recordTracksEvent,
 	}
 )( ThemeSheetWithOptions );


### PR DESCRIPTION
This is a fix for #10262. It adds Tracks events to both the Support and CSS
links within a theme sheet. The event is recorded in Tracks along with the theme
name.

## To test
1. Load this branch and visit http://calypso.localhost:3000/
2. Click "My Sites" -> Themes
3. Select a theme from the list
4. From the theme sheet, click the "Support" tab
5. Click either the "Need extra help?" Contact Us button or the "Need CSS help?" Visit Forum button.

You can use `localStorage.setItem('debug', 'calypso:analytics');` to log out the Tracks events to your console. You should see either `calypso_theme_help_button_click` or `calypso_theme_css_button_click` called with the property `theme_name` passed in.