### PR TITLE
Themes: Fix Content Flash, Part One

### DIFF
--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -107,7 +107,7 @@ export function fetchThemeData( context, next, shouldUseCache = false ) {
 		const cachedData = themesQueryCache.get( cacheKey );
 		if ( cachedData ) {
 			debug( `found theme data in cache key=${ cacheKey }` );
-			context.store.dispatch( receiveThemes( cachedData.themes ), siteId );
+			context.store.dispatch( receiveThemes( cachedData.themes, siteId ) );
 			context.renderCacheKey = context.path + cachedData.timestamp;
 			return next();
 		}


### PR DESCRIPTION
Or at least attempt to. Part one of the fix is a stupid typo. Part two is either dispatching `THEMES_REQUEST_SUCCESS` next to `receiveThemes`, but that's rather ugly (since its more of an implementation detail of `requestThemes`).

The proper fix would probably be to serialize (sub)state to cache (easy) and deserialize it (harder).

Edit: I've decided I'd like to merge the stupid typo fix as-is and think about the caching separately, so I'm opening this for review.