### PR TITLE
Calypso Framework: Increase throttle for serializing state

### DIFF
--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -24,7 +24,8 @@ const debug = debugModule( 'calypso:state' );
 
 const DAY_IN_HOURS = 24;
 const HOUR_IN_MS = 3600000;
-export const SERIALIZE_THROTTLE = 500;
+const MINUTE_IN_MS = 1000 * 60;
+export const SERIALIZE_THROTTLE = MINUTE_IN_MS;
 export const MAX_AGE = 7 * DAY_IN_HOURS * HOUR_IN_MS;
 
 function getInitialServerState() {


### PR DESCRIPTION
As of this PR, localforage's setItem microtasks can block the UI thread and its setItem takes between ~500ms-1500ms.
Given that info, 500ms seems like too low of a throttle.  Since nothing is currently relying on
having a very-up-to-date serialized state, this commit increases the throttle to a minute

So what does everyone think?
Is a minute too high? 
Is there a reason to serialize state more frequently?