### PR TITLE
Guided Tours: prevent Editor Insert Menu tour from showing when editor mode is HTML

### DIFF
--- a/client/layout/guided-tours/config-elements/index.js
+++ b/client/layout/guided-tours/config-elements/index.js
@@ -10,3 +10,4 @@ export Next from './next';
 export Quit from './quit';
 export Step from './step';
 export Tour from './tour';
+export VisualEditorStep from './visual-editor-step';

--- a/client/layout/guided-tours/config-elements/visual-editor-step.js
+++ b/client/layout/guided-tours/config-elements/visual-editor-step.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getPreference } from 'state/preferences/selectors';
+import Step from './step';
+
+export class VisualEditorStep extends Step {
+	componentDidMount() {
+		super.componentDidMount();
+		this.interval = setInterval( () => {
+			this.onScrollOrResize();
+		}, 2000 );
+	}
+
+	componentWillUnmount() {
+		super.componentWillUnmount();
+		clearInterval( this.interval );
+	}
+
+	render() {
+		if ( this.props.isEditorModeVisual ) {
+			return super.render();
+		}
+		return null;
+	}
+}
+
+export default connect( state => ( {
+	isEditorModeVisual: 'tinymce' === getPreference( state, 'editor-mode' ),
+} ) )( VisualEditorStep );

--- a/client/layout/guided-tours/tours/editor-insert-menu-tour.js
+++ b/client/layout/guided-tours/tours/editor-insert-menu-tour.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
 import { overEvery as and } from 'lodash';
 
@@ -19,6 +20,7 @@ import {
 	isEnabled,
 	hasUserRegisteredBefore,
 } from 'state/ui/guided-tours/contexts';
+import { getPreference } from 'state/preferences/selectors';
 import { isDesktop } from 'lib/viewport';
 import Gridicon from 'components/gridicon';
 
@@ -36,7 +38,18 @@ class RepositioningStep extends Step {
 		clearInterval( this.interval );
 	}
 
+	render() {
+		if ( this.props.isEditorModeVisual ) {
+			return super.render();
+		}
+		return null;
+	}
+
 }
+
+const ConnectedStep = connect( state => ( {
+	isEditorModeVisual: 'html' !== getPreference( state, 'editor-mode' ),
+} ) )( RepositioningStep );
 
 export const EditorInsertMenuTour = makeTour(
 	<Tour
@@ -49,7 +62,7 @@ export const EditorInsertMenuTour = makeTour(
 			isDesktop,
 		) }
 	>
-		<RepositioningStep
+		<ConnectedStep
 			arrow="left-top"
 			name="init"
 			placement="beside"
@@ -77,6 +90,6 @@ export const EditorInsertMenuTour = makeTour(
 			<ButtonRow>
 				<Quit primary>{ translate( 'Got it' ) }</Quit>
 			</ButtonRow>
-		</RepositioningStep>
+		</ConnectedStep>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/editor-insert-menu-tour.js
+++ b/client/layout/guided-tours/tours/editor-insert-menu-tour.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
 import { overEvery as and } from 'lodash';
 
@@ -12,44 +11,16 @@ import { overEvery as and } from 'lodash';
 import {
 	ButtonRow,
 	makeTour,
-	Step,
-	Tour,
 	Quit,
+	Tour,
+	VisualEditorStep,
 } from 'layout/guided-tours/config-elements';
 import {
 	isEnabled,
 	hasUserRegisteredBefore,
 } from 'state/ui/guided-tours/contexts';
-import { getPreference } from 'state/preferences/selectors';
 import { isDesktop } from 'lib/viewport';
 import Gridicon from 'components/gridicon';
-
-class RepositioningStep extends Step {
-
-	componentDidMount() {
-		super.componentDidMount();
-		this.interval = setInterval( () => {
-			this.onScrollOrResize();
-		}, 2000 );
-	}
-
-	componentWillUnmount() {
-		super.componentWillUnmount();
-		clearInterval( this.interval );
-	}
-
-	render() {
-		if ( this.props.isEditorModeVisual ) {
-			return super.render();
-		}
-		return null;
-	}
-
-}
-
-const ConnectedStep = connect( state => ( {
-	isEditorModeVisual: 'html' !== getPreference( state, 'editor-mode' ),
-} ) )( RepositioningStep );
 
 export const EditorInsertMenuTour = makeTour(
 	<Tour
@@ -62,7 +33,7 @@ export const EditorInsertMenuTour = makeTour(
 			isDesktop,
 		) }
 	>
-		<ConnectedStep
+		<VisualEditorStep
 			arrow="left-top"
 			name="init"
 			placement="beside"
@@ -90,6 +61,6 @@ export const EditorInsertMenuTour = makeTour(
 			<ButtonRow>
 				<Quit primary>{ translate( 'Got it' ) }</Quit>
 			</ButtonRow>
-		</ConnectedStep>
+		</VisualEditorStep>
 	</Tour>
 );


### PR DESCRIPTION
This bug consists in the Editor Insert Menu tour losing its anchor (a visual editor button) and moving out of place when the editor is not in visual mode.

Since the GT only check for the `when` conditions once, I had to connect this tour to always have a fresh state of the `editor-mode` preference.
This way, if the editor starts in HTML mode (or even if the user switches to it while the tour is shown or about to show), the tour re-renders as `null`.
Once the `editor-mode` changes to anything else than `html`, the tour is rendered again.