### PR TITLE
Reader: Allow colons in search strings

### DIFF
--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -109,7 +109,7 @@ function getStoreForTag( storeId ) {
 }
 
 function getStoreForSearch( storeId ) {
-	const slug = storeId.split( ':' )[ 1 ];
+	const slug = storeId.substring( storeId.indexOf( ':' ) + 1 );
 	const stream = new PagedStream( {
 		id: storeId,
 		fetcher: fetcher,


### PR DESCRIPTION
Parse the slug by looking for the first , instead of splitting on colons.