### PR TITLE
Themes: Add delete option for Jetpack custom themes

### DIFF
--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -40,6 +40,7 @@ const SingleSiteThemeShowcaseWithOptions = ( props ) => {
 					'purchase',
 					'activate',
 					'tryandcustomize',
+					'deleteTheme',
 					'separator',
 					'info',
 					'support',

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
+import { connect } from 'react-redux';
 import i18n from 'i18n-calypso';
 import { has, identity, mapValues, pick, pickBy } from 'lodash';
 
@@ -13,7 +13,8 @@ import config from 'config';
 import {
 	activateTheme,
 	installAndActivate,
-	installAndTryAndCustomize
+	installAndTryAndCustomize,
+	confirmDelete,
 } from 'state/themes/actions';
 import {
 	getThemeSignupUrl as getSignupUrl,
@@ -24,7 +25,7 @@ import {
 	getThemeHelpUrl as getHelpUrl,
 	isThemeActive as isActive,
 	isThemePurchased as isPurchased,
-	isThemePremium as isPremium
+	isThemePremium as isPremium,
 } from 'state/themes/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { hasFeature } from 'state/sites/plans/selectors';
@@ -72,6 +73,13 @@ const activateOnJetpack = {
 			! hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ) // Pressable sites included -- they're always on a Business plan
 		)
 	)
+};
+
+const deleteTheme = {
+	label: i18n.translate( 'Delete' ),
+	action: confirmDelete,
+	hideForSite: ( state, siteId ) => ! isJetpackSite( state, siteId ) || ! config.isEnabled( 'manage/themes/upload' ),
+	hideForTheme: ( state, theme, siteId ) => isActive( state, theme.id, siteId ),
 };
 
 const customize = {
@@ -159,6 +167,7 @@ const ALL_THEME_OPTIONS = {
 	purchase,
 	activate,
 	activateOnJetpack,
+	deleteTheme,
 	tryandcustomize,
 	tryAndCustomizeOnJetpack,
 	signup,

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -37,6 +37,8 @@ import {
 	PUBLICIZE_CONNECTION_UPDATE,
 	PUBLICIZE_CONNECTION_UPDATE_FAILURE,
 	SITE_FRONT_PAGE_SET_FAILURE,
+	THEME_DELETE_FAILURE,
+	THEME_DELETE_SUCCESS,
 	THEME_TRY_AND_CUSTOMIZE_FAILURE,
 } from 'state/action-types';
 
@@ -154,6 +156,20 @@ export const onPublicizeConnectionUpdateFailure = ( dispatch, { error } ) => dis
 	} ) )
 );
 
+const onThemeDeleteSuccess = ( dispatch, { themeName } ) => dispatch(
+	successNotice( translate( 'Deleted theme %(themeName)s.', {
+		args: { themeName },
+		context: 'Themes: Theme delete confirmation',
+	} ), { duration: 5000 } )
+);
+
+const onThemeDeleteFailure = ( dispatch, { themeId } ) => dispatch(
+	errorNotice( translate( 'Problem deleting %(themeId)s. Check theme is not active.', {
+		args: { themeId },
+		context: 'Themes: Theme delete failure',
+	} ) )
+);
+
 /**
  * Handler action type mapping
  */
@@ -188,6 +204,8 @@ export const handlers = {
 	[ PUBLICIZE_CONNECTION_UPDATE_FAILURE ]: onPublicizeConnectionUpdateFailure,
 	[ GUIDED_TRANSFER_HOST_DETAILS_SAVE_SUCCESS ]: dispatchSuccess( translate( 'Thanks for confirming those details!' ) ),
 	[ SITE_FRONT_PAGE_SET_FAILURE ]: dispatchError( translate( 'An error occurred while setting the homepage' ) ),
+	[ THEME_DELETE_FAILURE ]: onThemeDeleteFailure,
+	[ THEME_DELETE_SUCCESS ]: onThemeDeleteSuccess,
 	[ THEME_TRY_AND_CUSTOMIZE_FAILURE ]: dispatchError( translate( 'Customize error, please retry or contact support' ) ),
 };
 

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -650,7 +650,7 @@ export function pollThemeTransferStatus( siteId, transferId, interval = 3000, ti
  *
  * @return {Function} Action thunk
  */
-function deleteTheme( themeId, siteId ) {
+export function deleteTheme( themeId, siteId ) {
 	return dispatch => {
 		dispatch( {
 			type: THEME_DELETE,

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -59,7 +59,11 @@ import {
 } from './utils';
 import i18n from 'i18n-calypso';
 import { getSiteSlug } from 'state/sites/selectors';
-import accept from 'lib/accept';
+
+let accept;
+if ( typeof window !== 'undefined' ) {
+	accept = require( 'lib/accept' ); // This would otherwise break tests (because of a DOM dependency)
+}
 
 const debug = debugFactory( 'calypso:themes:actions' ); //eslint-disable-line no-unused-vars
 

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -18,6 +18,7 @@ import {
 	THEME_ACTIVATE_REQUEST_SUCCESS,
 	THEME_ACTIVATE_REQUEST_FAILURE,
 	THEME_CLEAR_ACTIVATED,
+	THEME_DELETE_SUCCESS,
 	THEME_INSTALL,
 	THEME_INSTALL_SUCCESS,
 	THEME_INSTALL_FAILURE,
@@ -307,6 +308,9 @@ export const queries = ( () => {
 		},
 		[ THEMES_RECEIVE ]: ( state, { siteId, themes } ) => {
 			return applyToManager( state, siteId, 'receive', true, themes );
+		},
+		[ THEME_DELETE_SUCCESS ]: ( state, { siteId, themeId } ) => {
+			return applyToManager( state, siteId, 'removeItem', false, themeId );
 		},
 		[ SERIALIZE ]: ( state ) => {
 			return mapValues( state, ( { data, options } ) => ( { data, options } ) );

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -849,7 +849,7 @@ describe( 'actions', () => {
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.post( '/rest/v1.1/sites/2211667/themes/karuna/delete' )
-				.reply( 200 )
+				.reply( 200, { id: 'karuna', name: 'Karuna' } )
 				.post( '/rest/v1.1/sites/2211667/themes/blahblah/delete' )
 				.reply( 404, { code: 'unknown_theme' } );
 		} );
@@ -860,6 +860,7 @@ describe( 'actions', () => {
 					type: THEME_DELETE_SUCCESS,
 					siteId: 2211667,
 					themeId: 'karuna',
+					themeName: 'Karuna',
 				} );
 			} );
 		} );


### PR DESCRIPTION
Adds a _Delete_ menu item for Jetpack themes in the _Custom themes_ list, plus notices for success and failure.

This will be a simpler review after #10457 lands.

<img width="333" alt="screen shot 2017-01-05 at 21 14 05" src="https://cloud.githubusercontent.com/assets/7767559/21697791/f94a4a3e-d38b-11e6-912c-d3a1252d0c13.png">

![delete-theme](https://cloud.githubusercontent.com/assets/7767559/21764748/93056ee2-d65c-11e6-9a4f-10d8ec113a5c.gif)

**To Test**
* Upload a non-wpcom theme to a jetpack site at http://calypso.localhost:3000/design/upload/{jp_site}
(or install a theme via wp-admin)
* Go to http://calypso.localhost:3000/design/sseear.wpsandbox.me
* Click the ... button for the theme and click 'Delete'

*Expected:* Theme should disappear from the list and a confirmation notice should be displayed for 5 seconds



Still todo:
- [ ] ~_Undo_ action in the success notice~ (can't do undo since this is for uploaded themes)
- [x] Confirmation dialog
- [x] Remove deleted theme from the results on success (#10457)

