### PR TITLE
Framework: update the select element font-weight to be bold

### DIFF
--- a/assets/stylesheets/shared/_forms.scss
+++ b/assets/stylesheets/shared/_forms.scss
@@ -211,7 +211,7 @@ select {
 	outline: 0;
 	overflow: hidden;
 	font-size: 14px;
-	font-weight: 600;
+	font-weight: bold;
 	text-overflow: ellipsis;
 	text-decoration: none;
 	vertical-align: top;

--- a/assets/stylesheets/shared/_forms.scss
+++ b/assets/stylesheets/shared/_forms.scss
@@ -211,7 +211,7 @@ select {
 	outline: 0;
 	overflow: hidden;
 	font-size: 14px;
-	font-weight: bold;
+	font-weight: 700;
 	text-overflow: ellipsis;
 	text-decoration: none;
 	vertical-align: top;


### PR DESCRIPTION
- Previous value was 600
- In Safari on OSX the select list displays a square icon instead of a tick when this value is <=600 which is the previous value.
- Tested on Chrome, Firefox, Safari, IE11 and Mobile

Before (Safari OSX)

<img width="303" alt="before" src="https://cloud.githubusercontent.com/assets/128826/21702950/673db742-d3fa-11e6-9d13-1b67508f0ed4.png">

After (Safari OSX)

<img width="273" alt="after bold" src="https://cloud.githubusercontent.com/assets/128826/21707545/d3583e2c-d41b-11e6-904b-8197b19b9026.png">

Fixes #10444