### PR TITLE
Date Picker, Post Schedule: Update some colours to add more contrast for better accessibility

### DIFF
--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -36,7 +36,7 @@ $date-picker_nav_button_size: 20px;
 	}
 }
 
-.date-picker__day_event {
+.date-picker__day_event:not(.is-selected) {
 	border-color: lighten( $gray, 10% );
 }
 
@@ -224,7 +224,7 @@ $date-picker_nav_button_size: 20px;
 	cursor: pointer;
 	font-weight: normal;
 
-	.date-picker__day {
+	.date-picker__day:not(.is-selected) {
 		color: $gray;
 	}
 }

--- a/client/components/post-schedule/style.scss
+++ b/client/components/post-schedule/style.scss
@@ -79,7 +79,6 @@
 .post-schedule__clock {
 	text-align: center;
 	margin: 15px auto 10px;
-	color: $gray;
 	font-size: 12px;
 }
 
@@ -106,7 +105,6 @@ input.post-schedule__clock_time {
 
 .info-popover__tooltip.post-schedule__timezone-info,
 .post-schedule__clock-timezone {
-	color: $gray;
 	line-height: 20px;
 }
 


### PR DESCRIPTION
I've overlooked some elements when I updated colours in #10206.

This PR includes:
* Remove the grey border from the scheduled date (2nd Feb in this example)
* Make sure the date is in white for the scheduled date in previous/next months.
* Darker grey for the site timezone info.

![date-picker](https://cloud.githubusercontent.com/assets/908665/21703586/37f0d464-d3ab-11e6-948a-39c7bc798a7a.jpg)

I intentionally left the the (i) icon for now because it's probably better to fix globally.