### PR TITLE
Domain Contact Form: Implement New Phone Input AB Test

### DIFF
--- a/bin/build-metadata.js
+++ b/bin/build-metadata.js
@@ -30,6 +30,7 @@ var priorityData = {
 	CA: 5,
 	DO: 3,
 	PR: 1,
+	um: -99,
 	// dial code: +7
 	RU: 10,
 	KZ: 1,
@@ -44,16 +45,24 @@ var priorityData = {
 	// dial code: +47
 	NO: 10,
 	SJ: 1,
+	bv: -99,
 	// dial code: +61
 	AU: 10,
 	CX: 5,
 	CC: 1,
+	hm: -99,
+	// dial code: +64
+	nz: 10,
+	pn: -99,
 	// dial code: +290
 	SH: 10,
 	TA: 1,
 	// dial code: +358
 	FI: 10,
 	AX: 1,
+	// dial code: +500
+	fk: 10,
+	gs: -99,
 	// dial code: +590
 	GP: 10,
 	MF: 5,
@@ -267,7 +276,45 @@ function injectHardCodedValues( libPhoneNumberData ) {
 		kv: {
 			isoCode: 'kv',
 			dialCode: '383',
-			nationalPrefix: '0'
+			nationalPrefix: '0',
+			priority: priorityData.kv
+		},
+		um: {
+			isoCode: 'um',
+			dialCode: '1',
+			nationalPrefix: '',
+			patternRegion: 'us',
+			priority: priorityData.um
+		},
+		bv: {
+			isoCode: 'bv',
+			dialCode: '47',
+			nationalPrefix: '',
+			priority: priorityData.bv
+		},
+		tf: {
+			isoCode: 'tf',
+			dialCode: '262',
+			nationalPrefix: '0',
+			priority: priorityData.tf
+		},
+		hm: {
+			isoCode: 'hm',
+			dialCode: '61',
+			nationalPrefix: '0',
+			priority: priorityData.hm
+		},
+		pn: {
+			isoCode: 'pn',
+			dialCode: '64',
+			nationalPrefix: '0',
+			priority: priorityData.pn
+		},
+		gs: {
+			isoCode: 'gs',
+			nationalPrefix: '',
+			dialCode: '500',
+			priority: priorityData.gs
 		}
 	}, libPhoneNumberData );
 }

--- a/bin/build-metadata.js
+++ b/bin/build-metadata.js
@@ -261,6 +261,17 @@ function processLibPhoneNumberMetadata( libPhoneNumberData ) {
 	return data;
 }
 
+// Political correction
+function injectHardCodedValues( libPhoneNumberData ) {
+	return Object.assign( {}, {
+		kv: {
+			isoCode: 'kv',
+			dialCode: '383',
+			nationalPrefix: '0'
+		}
+	}, libPhoneNumberData );
+}
+
 /**
  * Creates aliases. E.g. allows `uk` to be found by both `gb` and `uk`.
  * @param data
@@ -326,6 +337,7 @@ function generateFullDataset( metadata ) {
 
 getLibPhoneNumberData()
 	.then( processLibPhoneNumberMetadata )
+	.then( injectHardCodedValues )
 	.then( generateDeepRemoveEmptyArraysFromObject( [ 'patterns', 'internationalPatterns' ] ) )
 	.then( insertCountryAliases )
 	.then( removeAllNumberKeys )

--- a/bin/build-metadata.js
+++ b/bin/build-metadata.js
@@ -30,7 +30,7 @@ var priorityData = {
 	CA: 5,
 	DO: 3,
 	PR: 1,
-	um: -99,
+	UM: -99,
 	// dial code: +7
 	RU: 10,
 	KZ: 1,
@@ -45,15 +45,15 @@ var priorityData = {
 	// dial code: +47
 	NO: 10,
 	SJ: 1,
-	bv: -99,
+	BV: -99,
 	// dial code: +61
 	AU: 10,
 	CX: 5,
 	CC: 1,
-	hm: -99,
+	HM: -99,
 	// dial code: +64
-	nz: 10,
-	pn: -99,
+	NZ: 10,
+	PN: -99,
 	// dial code: +290
 	SH: 10,
 	TA: 1,
@@ -61,8 +61,8 @@ var priorityData = {
 	FI: 10,
 	AX: 1,
 	// dial code: +500
-	fk: 10,
-	gs: -99,
+	FK: 10,
+	GS: -99,
 	// dial code: +590
 	GP: 10,
 	MF: 5,
@@ -273,48 +273,48 @@ function processLibPhoneNumberMetadata( libPhoneNumberData ) {
 // Political correction
 function injectHardCodedValues( libPhoneNumberData ) {
 	return Object.assign( {}, {
-		kv: {
-			isoCode: 'kv',
+		KV: {
+			isoCode: 'KV',
 			dialCode: '383',
 			nationalPrefix: '0',
-			priority: priorityData.kv
+			priority: priorityData.KV
 		},
-		um: {
-			isoCode: 'um',
+		UM: {
+			isoCode: 'UM',
 			dialCode: '1',
 			nationalPrefix: '',
 			patternRegion: 'us',
-			priority: priorityData.um
+			priority: priorityData.UM
 		},
-		bv: {
-			isoCode: 'bv',
+		BV: {
+			isoCode: 'BV',
 			dialCode: '47',
 			nationalPrefix: '',
-			priority: priorityData.bv
+			priority: priorityData.BV
 		},
-		tf: {
-			isoCode: 'tf',
+		TF: {
+			isoCode: 'TF',
 			dialCode: '262',
 			nationalPrefix: '0',
-			priority: priorityData.tf
+			priority: priorityData.TF
 		},
-		hm: {
-			isoCode: 'hm',
+		HM: {
+			isoCode: 'HM',
 			dialCode: '61',
 			nationalPrefix: '0',
-			priority: priorityData.hm
+			priority: priorityData.HM
 		},
-		pn: {
-			isoCode: 'pn',
+		PN: {
+			isoCode: 'PN',
 			dialCode: '64',
 			nationalPrefix: '0',
-			priority: priorityData.pn
+			priority: priorityData.PN
 		},
-		gs: {
-			isoCode: 'gs',
+		GS: {
+			isoCode: 'GS',
 			nationalPrefix: '',
 			dialCode: '500',
-			priority: priorityData.gs
+			priority: priorityData.GS
 		}
 	}, libPhoneNumberData );
 }

--- a/client/components/forms/form-country-select/index.jsx
+++ b/client/components/forms/form-country-select/index.jsx
@@ -23,6 +23,7 @@ export default localize( React.createClass( {
 				key: idx,
 				label: name,
 				code,
+				disabled: code ? '' : 'disabled'
 			}
 		) );
 	},

--- a/client/components/phone-input/data.js
+++ b/client/components/phone-input/data.js
@@ -2,6 +2,11 @@
 /* eslint-disable */
 module.exports = {
 	countries: {
+		kv: {
+			isoCode: "kv",
+			dialCode: "383",
+			nationalPrefix: "0"
+		},
 		AC: {
 			isoCode: "AC",
 			dialCode: "247"
@@ -6381,6 +6386,9 @@ module.exports = {
 		],
 		382: [
 			"ME"
+		],
+		383: [
+			"kv"
 		],
 		385: [
 			"HR"

--- a/client/components/phone-input/data.js
+++ b/client/components/phone-input/data.js
@@ -2,43 +2,43 @@
 /* eslint-disable */
 module.exports = {
 	countries: {
-		kv: {
-			isoCode: "kv",
+		KV: {
+			isoCode: "KV",
 			dialCode: "383",
 			nationalPrefix: "0"
 		},
-		um: {
-			isoCode: "um",
+		UM: {
+			isoCode: "UM",
 			dialCode: "1",
 			nationalPrefix: "",
 			patternRegion: "us",
 			priority: -99
 		},
-		bv: {
-			isoCode: "bv",
+		BV: {
+			isoCode: "BV",
 			dialCode: "47",
 			nationalPrefix: "",
 			priority: -99
 		},
-		tf: {
-			isoCode: "tf",
+		TF: {
+			isoCode: "TF",
 			dialCode: "262",
 			nationalPrefix: "0"
 		},
-		hm: {
-			isoCode: "hm",
+		HM: {
+			isoCode: "HM",
 			dialCode: "61",
 			nationalPrefix: "0",
 			priority: -99
 		},
-		pn: {
-			isoCode: "pn",
+		PN: {
+			isoCode: "PN",
 			dialCode: "64",
 			nationalPrefix: "0",
 			priority: -99
 		},
-		gs: {
-			isoCode: "gs",
+		GS: {
+			isoCode: "GS",
 			nationalPrefix: "",
 			dialCode: "500",
 			priority: -99
@@ -1851,7 +1851,9 @@ module.exports = {
 		},
 		FK: {
 			isoCode: "FK",
-			dialCode: "500"
+			dialCode: "500",
+			priority: 10,
+			patternRegion: "FK"
 		},
 		FM: {
 			isoCode: "FM",
@@ -4247,7 +4249,8 @@ module.exports = {
 					nationalFormat: "0$1",
 					leadingDigitPattern: "2(?:10|74)|5|[89]0"
 				}
-			]
+			],
+			priority: 10
 		},
 		OM: {
 			isoCode: "OM",
@@ -6037,7 +6040,7 @@ module.exports = {
 		1: [
 			"US",
 			"CA",
-			"um"
+			"UM"
 		],
 		7: [
 			"RU",
@@ -6095,7 +6098,7 @@ module.exports = {
 		47: [
 			"NO",
 			"SJ",
-			"bv"
+			"BV"
 		],
 		48: [
 			"PL"
@@ -6134,7 +6137,7 @@ module.exports = {
 			"AU",
 			"CX",
 			"CC",
-			"hm"
+			"HM"
 		],
 		62: [
 			"ID"
@@ -6144,7 +6147,7 @@ module.exports = {
 		],
 		64: [
 			"NZ",
-			"pn"
+			"PN"
 		],
 		65: [
 			"SG"
@@ -6324,7 +6327,7 @@ module.exports = {
 			"MG"
 		],
 		262: [
-			"tf"
+			"TF"
 		],
 		263: [
 			"ZW"
@@ -6431,7 +6434,7 @@ module.exports = {
 			"ME"
 		],
 		383: [
-			"kv"
+			"KV"
 		],
 		385: [
 			"HR"
@@ -6456,7 +6459,7 @@ module.exports = {
 		],
 		500: [
 			"FK",
-			"gs"
+			"GS"
 		],
 		501: [
 			"BZ"

--- a/client/components/phone-input/data.js
+++ b/client/components/phone-input/data.js
@@ -7,6 +7,42 @@ module.exports = {
 			dialCode: "383",
 			nationalPrefix: "0"
 		},
+		um: {
+			isoCode: "um",
+			dialCode: "1",
+			nationalPrefix: "",
+			patternRegion: "us",
+			priority: -99
+		},
+		bv: {
+			isoCode: "bv",
+			dialCode: "47",
+			nationalPrefix: "",
+			priority: -99
+		},
+		tf: {
+			isoCode: "tf",
+			dialCode: "262",
+			nationalPrefix: "0"
+		},
+		hm: {
+			isoCode: "hm",
+			dialCode: "61",
+			nationalPrefix: "0",
+			priority: -99
+		},
+		pn: {
+			isoCode: "pn",
+			dialCode: "64",
+			nationalPrefix: "0",
+			priority: -99
+		},
+		gs: {
+			isoCode: "gs",
+			nationalPrefix: "",
+			dialCode: "500",
+			priority: -99
+		},
 		AC: {
 			isoCode: "AC",
 			dialCode: "247"
@@ -6000,7 +6036,8 @@ module.exports = {
 	dialCodeMap: {
 		1: [
 			"US",
-			"CA"
+			"CA",
+			"um"
 		],
 		7: [
 			"RU",
@@ -6057,7 +6094,8 @@ module.exports = {
 		],
 		47: [
 			"NO",
-			"SJ"
+			"SJ",
+			"bv"
 		],
 		48: [
 			"PL"
@@ -6095,7 +6133,8 @@ module.exports = {
 		61: [
 			"AU",
 			"CX",
-			"CC"
+			"CC",
+			"hm"
 		],
 		62: [
 			"ID"
@@ -6104,7 +6143,8 @@ module.exports = {
 			"PH"
 		],
 		64: [
-			"NZ"
+			"NZ",
+			"pn"
 		],
 		65: [
 			"SG"
@@ -6283,6 +6323,9 @@ module.exports = {
 		261: [
 			"MG"
 		],
+		262: [
+			"tf"
+		],
 		263: [
 			"ZW"
 		],
@@ -6412,7 +6455,8 @@ module.exports = {
 			"LI"
 		],
 		500: [
-			"FK"
+			"FK",
+			"gs"
 		],
 		501: [
 			"BZ"

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -3,7 +3,6 @@
  */
 import find from 'lodash/find';
 import identity from 'lodash/identity';
-import includes from 'lodash/includes';
 import React from 'react';
 import classnames from 'classnames';
 
@@ -111,7 +110,8 @@ const PhoneInput = React.createClass( {
 		if ( ! value || value.length < MIN_LENGTH_TO_FORMAT || this.state.freezeSelection ) {
 			return false;
 		}
-		return includes( [ '+', '1' ], value[ 0 ] );
+		const dialCode = this.getCountry().countryDialCode || this.getCountry().dialCode;
+		return value[ 0 ] === '+' || ( value[ 0 ] === '1' && dialCode === '1' );
 	},
 
 	/**

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -194,7 +194,7 @@ const PhoneInput = React.createClass( {
 		return (
 			<div className={ classnames( this.props.className, 'phone-input' ) }>
 				<input
-					placeholder={ this.format( '9876543210' ) }
+					placeholder={ this.translate( 'Phone' ) }
 					onChange={ this.handleInput }
 					name={ this.props.name }
 					ref={ c => this.numberInput = c }

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -202,6 +202,7 @@ const PhoneInput = React.createClass( {
 				<div className="phone-input__select-container">
 					<div className="phone-input__select-inner-container">
 						<FormCountrySelect
+							tabIndex={ -1 }
 							className="phone-input__country-select"
 							onChange={ this.handleCountrySelection }
 							value={ ( this.getCountry().isoCode ) }

--- a/client/components/phone-input/style.scss
+++ b/client/components/phone-input/style.scss
@@ -1,6 +1,7 @@
 .phone-input__flag-icon {
 	pointer-events: none;
-	width: 24px;
+	max-width: 24px;
+	max-height: 18px;
 	align-self: center;
 	box-shadow: 0 0 1px lighten( $gray, 20% );
 }

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -130,4 +130,13 @@ module.exports = {
 		allowExistingUsers: true
 	},
 
+	domainContactNewPhoneInput: {
+		datestamp: '20170105',
+		variations: {
+			disabled: 50,
+			enabled: 50
+		},
+		defaultVariation: 'disabled',
+		allowExistingUsers: true
+	}
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -131,7 +131,7 @@ module.exports = {
 	},
 
 	domainContactNewPhoneInput: {
-		datestamp: '20170105',
+		datestamp: '20170123',
 		variations: {
 			disabled: 50,
 			enabled: 50

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -49,7 +49,7 @@ export default React.createClass( {
 			form: null,
 			isDialogVisible: false,
 			submissionCount: 0,
-			phoneCountryCode: 'us'
+			phoneCountryCode: 'US'
 		};
 	},
 
@@ -126,7 +126,7 @@ export default React.createClass( {
 			if ( abtest( 'domainContactNewPhoneInput' ) === 'enabled' ) {
 				if ( ! formState.getFieldValue( this.state.form, 'phone' ) ) {
 					this.setState( {
-						phoneCountryCode: event.target.value.toLowerCase()
+						phoneCountryCode: event.target.value
 					} );
 				}
 			}
@@ -145,7 +145,7 @@ export default React.createClass( {
 		} );
 
 		this.setState( {
-			phoneCountryCode: countryCode.toLowerCase()
+			phoneCountryCode: countryCode
 		} );
 	},
 
@@ -364,7 +364,7 @@ export default React.createClass( {
 
 		const allFieldValues = Object.assign( {}, formState.getAllFieldValues( this.state.form ) );
 		if ( abtest( 'domainContactNewPhoneInput' ) === 'enabled' ) {
-			allFieldValues.phone = toIcannFormat( allFieldValues.phone, countries[ this.state.phoneCountryCode.toLowerCase() ] );
+			allFieldValues.phone = toIcannFormat( allFieldValues.phone, countries[ this.state.phoneCountryCode ] );
 		}
 		setDomainDetails( allFieldValues );
 	},


### PR DESCRIPTION
🎉  Fixes #10369.
The time has come.

This PR puts the new phone input to Domain Contact Form with 50% variation on AB test.

### Teaser
![](http://g.recordit.co/wCPCQuRURA.gif)

### Testing
0. Turn on the abtest `domainContactNewPhoneInput`.

- [ ] **Test 1**

1. Sign up as a new user
2. Register a domain.
4. While the input is empty, change the country. 
5. Ensure the country field changes in phone field.
6. Fill the phone input in your local format (national or international)
7. Change the country field again, the phone field should stay the same.
8. Register the domain
10. Add another domain to cart
11. Ensure the phone number field loads nicely.
12. Cancel the domain, remove the other domain from cart.

- [ ] **Test 2**

1. Switch to an existing user with a domain
2. Add a domain to cart.
3. In contact form, ensure the phone number looks correct.
4. Remove the domain from cart.

/cc: @wensco @aidvu @klimeryk 