### PR TITLE
Site Icon: allow transparent backgrounds for site icons in site picker

### DIFF
--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -55,8 +55,7 @@
 // within a Site item
 .site .site-icon {
 	position: relative;
-	background: lighten( $gray, 20% );
-	border: 1px solid white;
+	border: 1px solid $transparent;
 	height: 30px;
 	width: 30px;
 	overflow: hidden;

--- a/client/components/site-icon/style.scss
+++ b/client/components/site-icon/style.scss
@@ -1,7 +1,5 @@
 .site-icon {
 	position: relative;
-	background: lighten( $gray, 20% );
-	border: 1px solid white;
 	overflow: hidden;
 	align-self: center;
 	margin: 0;
@@ -9,6 +7,8 @@
 
 	// Globe icon for sites without an icon
 	&.is-blank {
+		border: 1px solid $white;
+		background: lighten( $gray, 20% );
 		.gridicon {
 			color: $white;
 			z-index: z-index( 'root', '.site-icon.is-blank .gridicon' );
@@ -17,6 +17,6 @@
 }
 
 .site-icon__img {
-	background: $white;
+	background: $transparent;
 	position: relative;
 }


### PR DESCRIPTION
Site icons allow for transparent PNG files which look great as favicons in browser tabs as these are supported by browsers. For example:

<img width="174" alt="favicon" src="https://cloud.githubusercontent.com/assets/128826/21709383/5dd8351a-d42c-11e6-841e-05645f563076.png">

The Calypso site picker currently doesn't allow a transparent background behind a site icon, and adds a border so this doesn't look as nice. This PR adds a transparent background to sites with site icons in the site picker.

**Before**

<img width="305" alt="before site selector" src="https://cloud.githubusercontent.com/assets/128826/21709466/e51cb24e-d42c-11e6-8516-bd0107449328.png">

**After**

<img width="302" alt="after site selector" src="https://cloud.githubusercontent.com/assets/128826/21709469/ec7c7006-d42c-11e6-9166-4e3abe6b432f.png">

