### PR TITLE
Purchases: Properly format amount in ManagePurchase component

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -280,7 +280,7 @@ const ManagePurchase = React.createClass( {
 			period = productSlug && isMonthly( productSlug ) ? this.translate( 'month' ) : this.translate( 'year' );
 
 		if ( isOneTimePurchase( purchase ) ) {
-			return this.translate( '%(currencySymbol)s%(amount)d %(currencyCode)s {{period}}(one-time){{/period}}', {
+			return this.translate( '%(currencySymbol)s%(amount)f %(currencyCode)s {{period}}(one-time){{/period}}', {
 				args: { amount, currencyCode, currencySymbol },
 				components: {
 					period: <span className="manage-purchase__time-period" />
@@ -292,7 +292,7 @@ const ManagePurchase = React.createClass( {
 			return this.translate( 'Free with Plan' );
 		}
 
-		return this.translate( '%(currencySymbol)s%(amount)d %(currencyCode)s {{period}}/ %(period)s{{/period}}', {
+		return this.translate( '%(currencySymbol)s%(amount)f %(currencyCode)s {{period}}/ %(period)s{{/period}}', {
 			args: {
 				amount,
 				currencyCode,


### PR DESCRIPTION
This PR fixes an issue with displaying the amount in purchases. Previously, we were cutting off the cents values, because we were formatting the amount as an integer. With this PR, cents will be included in the amount, as expected.

To test:

* Purchase a Personal Plan or any other plan with a non-flat price for one of your sites.
* Go to `/me/purchases`
* Click on that purchase to view its details.
* Verify the cents are included properly in the amount.

/cc @gwwar for review; and thanks for the initial ping :+1: