### PR TITLE
Components: Update overflow on select dropdown component

### DIFF
--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -22,6 +22,7 @@ $compact-header-height: 35;
 .select-dropdown__container {
 	position: relative;
 	display: inline-block;
+	max-width: 100%;
 
 	.select-dropdown.is-open & {
 		z-index: z-index( 'root', '.select-dropdown.is-open .select-dropdown__container' );
@@ -173,7 +174,6 @@ $compact-header-height: 35;
 	font-size: 14px;
 	font-weight: 400;
 	white-space: nowrap;
-	text-overflow: ellipsis;
 	overflow: hidden;
 	cursor: pointer;
 
@@ -234,9 +234,13 @@ $compact-header-height: 35;
 .select-dropdown__item-text {
 	white-space: nowrap;
 	text-overflow: ellipsis;
+	overflow: hidden;
 	color: inherit;
+	display: inline-block;
+	max-width: 100%;
 	position: absolute;
 		left: #{ $side-margin }px;
+		right: #{ $side-margin }px;
 }
 
 .select-dropdown__separator {


### PR DESCRIPTION
This is a fix for two issues. First, with #9532, I added `max-width: 100%;` to `.select-dropdown__container`. Second, for #1742, I fixed that by doing a few things:
- Adding `overflow: hidden;` to `.select-dropdown__item-text`
- Adding a right side margin identical to the left since the item is absolutely positioned.
- Removing `text-overflow: ellipsis;` from `.select-dropdown__item`. With this set of changes, it was creating duplicate ellipses because we had it on `.select-dropdown__item` and `.select-dropdown__item-text`. You can see a bit of this here within the word "Template" using the Orvis theme:

<img width="340" alt="screen shot 2017-01-06 at 7 12 21 am" src="https://cloud.githubusercontent.com/assets/7240478/21720296/7fd2c16e-d3df-11e6-81ed-68a0401718b6.png">

## To test
1. Load up this branch.
2. Activate a theme with a long page template title (I tested with Twenty Twelve) on your site.
3. Open up a new page. Check out the left-hand page template selector to notice the changes. Twenty Twelve has a page template called "Full-width Page Template, No Sidebar" that demonstrates the issues well.

Some other places you can test to make sure this has no adverse effects:
- When adding a media gallery to a post or page, the select dropdown is used for the Layout and Link To fields.
- DevDocs: http://calypso.localhost:3000/devdocs/design/select-dropdown

## Screenshots

<img width="492" alt="fix 1" src="https://cloud.githubusercontent.com/assets/7240478/21720403/1d26a3c2-d3e0-11e6-9441-7ae1c7627ced.png">

<img width="445" alt="fix 2" src="https://cloud.githubusercontent.com/assets/7240478/21720405/203784be-d3e0-11e6-98aa-39316e241fbc.png">

<img width="471" alt="fix 3" src="https://cloud.githubusercontent.com/assets/7240478/21720409/254f59e0-d3e0-11e6-8481-6c8d18762882.png">
