### PR TITLE
Themes: Enable item removal in ThemeQueryManager

### DIFF
--- a/client/lib/query-manager/theme/index.js
+++ b/client/lib/query-manager/theme/index.js
@@ -9,6 +9,7 @@ import { cloneDeep, get, isEqual, keyBy, range } from 'lodash';
 import PaginatedQueryManager from '../paginated';
 import ThemeQueryKey from './key';
 import { DEFAULT_THEME_QUERY } from './constants';
+import { DELETE_PATCH_KEY } from 'lib/query-manager';
 
 /**
  * ThemeQueryManager manages themes which can be queried
@@ -122,6 +123,29 @@ export default class ThemeQueryManager extends PaginatedQueryManager {
 			},
 			this.options
 		);
+	}
+
+	/**
+	 * Removes multiple items given an array of item keys, returning a new
+	 * instance of QueryManager if the tracked items have changed, or the
+	 * current instance otherwise.
+	 *
+	 * This method is overridden to call the parent receive() method, which
+	 * maintains the ability to delete items, unlike the cut-down receive()
+	 * method in this class.
+	 *
+	 * @param  {String[]}     itemKeys Keys of items to remove
+	 * @return {QueryManager}          New instance if changed, or same
+	 *                                 instance otherwise
+	 */
+	removeItems( itemKeys = [] ) {
+		return PaginatedQueryManager.prototype.receive.call( this,
+			itemKeys.map( ( itemKey ) => {
+				return {
+					[ this.options.itemKey ]: itemKey,
+					[ DELETE_PATCH_KEY ]: true
+				};
+			} ), { patch: true } );
 	}
 }
 

--- a/client/lib/query-manager/theme/test/index.js
+++ b/client/lib/query-manager/theme/test/index.js
@@ -1,17 +1,57 @@
 /**
  * External dependencies
  */
-//import { expect } from 'chai';
+import { expect } from 'chai';
 
 /**
  * Internal dependencies
  */
-//import ThemeQueryManager from '../';
+import ThemeQueryManager from '../';
 
 /**
  * Constants
  */
 
 describe( 'ThemeQueryManager', () => {
-	// TODO
+	let manager;
+
+	beforeEach( () => {
+		manager = new ThemeQueryManager();
+	} );
+
+	describe( '#removeItem()', () => {
+		it( 'should remove an item by its item key', () => {
+			manager = manager.receive( [ { ID: 144 } ] );
+			const newManager = manager.removeItem( 144 );
+
+			expect( manager ).to.not.equal( newManager );
+			expect( manager.getItems() ).to.eql( [ { ID: 144 } ] );
+			expect( newManager.getItems() ).to.eql( [] );
+		} );
+
+		it( 'should return the same instance if no items removed', () => {
+			manager = manager.receive( [ { ID: 144 } ] );
+			const newManager = manager.removeItem( 152 );
+
+			expect( manager ).to.equal( newManager );
+		} );
+	} );
+
+	describe( '#removeItems()', () => {
+		it( 'should remove an array of items by their item keys', () => {
+			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ] );
+			const newManager = manager.removeItems( [ 144, 152 ] );
+
+			expect( manager ).to.not.equal( newManager );
+			expect( manager.getItems() ).to.eql( [ { ID: 144 }, { ID: 152 } ] );
+			expect( newManager.getItems() ).to.eql( [] );
+		} );
+
+		it( 'should return the same instance if no items removed', () => {
+			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ] );
+			const newManager = manager.removeItems( [ 160, 168 ] );
+
+			expect( manager ).to.equal( newManager );
+		} );
+	} );
 } );

--- a/client/lib/query-manager/theme/test/index.js
+++ b/client/lib/query-manager/theme/test/index.js
@@ -35,6 +35,16 @@ describe( 'ThemeQueryManager', () => {
 
 			expect( manager ).to.equal( newManager );
 		} );
+
+		it( 'should decrement the found count', () => {
+			const query = { term: 'blah' };
+			manager = manager.receive( [ { ID: 122 }, { ID: 133 }, { ID: 144 }, { ID: 155 } ], { query } );
+			expect( manager.getFound( query ) ).to.equal( 4 );
+
+			const newManager = manager.removeItem( 144 );
+			expect( manager ).to.not.equal( newManager );
+			expect( newManager.getFound( query ) ).to.equal( 3 );
+		} );
 	} );
 
 	describe( '#removeItems()', () => {


### PR DESCRIPTION
No visual differences. Includes unit tests.

Implements a `removeItems()` method for `ThemeQueryManager` that doesn't rely on the parent `receive` method, which has already been overridden.

At a later date we should re-implement `ThemeQueryManager` without relying on a parent class at all, since we are only benefitting from a couple of getters.
