### PR TITLE
Hide try&customize for Premium themes on Jetpack.

### DIFF
--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -100,7 +100,12 @@ const tryAndCustomizeOnJetpack = {
 	} ),
 	action: ( themeId, siteId ) => installAndTryAndCustomize( themeId + '-wpcom', siteId ),
 	hideForSite: ( state, siteId ) => ! canCurrentUser( state, siteId, 'edit_theme_options' ) || ! isJetpackSite( state, siteId ),
-	hideForTheme: ( state, theme, siteId ) => isActive( state, theme.id, siteId )
+	hideForTheme: ( state, theme, siteId ) => (
+		isActive( state, theme.id, siteId ) || (
+			isPremium( state, theme.id ) &&
+			! hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ) // Pressable sites included -- they're always on a Business plan
+		)
+	)
 };
 
 // This is a special option that gets its `action` added by `ThemeShowcase` or `ThemeSheet`,


### PR DESCRIPTION
### Info

try&customize is not a valid option for Premium WordPress.com theme on Jetpack site.

### Before
![image](https://cloud.githubusercontent.com/assets/17271089/21725231/caf948ea-d437-11e6-8014-ec64b696ea0f.png)

### After
![image](https://cloud.githubusercontent.com/assets/17271089/21725268/f5de7620-d437-11e6-911e-ef4e1e695dba.png)

^ no option available.