### PR TITLE
Reader: fix canonical misses caused by dedupe too early

### DIFF
--- a/client/lib/post-normalizer/rule-wait-for-images-to-load.js
+++ b/client/lib/post-normalizer/rule-wait-for-images-to-load.js
@@ -8,7 +8,6 @@ import {
 	forEach,
 	map,
 	pull,
-	uniq
 } from 'lodash';
 
 /**
@@ -74,7 +73,7 @@ export default function waitForImagesToLoad( post ) {
 			resolve( post );
 		}
 
-		let imagesToCheck = [];
+		const imagesToCheck = [];
 
 		if ( thumbIsLikelyImage( post.post_thumbnail ) ) {
 			imagesToCheck.push( post.post_thumbnail.URL );
@@ -90,9 +89,6 @@ export default function waitForImagesToLoad( post ) {
 			resolve( post );
 			return;
 		}
-
-		// dedupe the set of images
-		imagesToCheck = uniq( imagesToCheck );
 
 		// convert to image objects to start the load process
 		let promises = map( imagesToCheck, promiseForURL );

--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -168,9 +168,9 @@ export function isCandidateForCanonicalImage( image ) {
  */
 export function isFeaturedImageInContent( post ) {
 	if ( thumbIsLikelyImage( post.post_thumbnail ) ) {
-		const featuredImageUrl = url.parse( post.post_thumbnail.URL, true, true );
+		const featuredImageUrl = url.parse( post.post_thumbnail.URL );
 		const indexOfContentImage = findIndex( post.images, img => {
-			const imgUrl = url.parse( img.src, true, true );
+			const imgUrl = url.parse( img.src );
 			return imgUrl.pathname === featuredImageUrl.pathname;
 		}, 1 ); // skip first element in post.images because it is always the featuredImage
 


### PR DESCRIPTION
We had a recent regression where `isFeaturedInContent` started missing some cases.
This sequence of events caused it:

1. grab all images
2. mess with some of their query params
3. *uniqify* the list
4. save images to post.images
5. etc.....

If the featuredImage occurred twice, then it would be deduped in step 3 and we wouldn't contain both the featuredImage version and the content version in `post.images`.

This PR removes the dedupe step.

So, is there a compelling reason to keep the `uniq`?


To Test:
-  go to post https://wordpress.com/read/feeds/34575/posts/1286396993
