### PR TITLE
Stats: add Settings page.

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -72,6 +72,7 @@ function getNumPeriodAgo( momentSiteZone, date, period ) {
 function getSiteFilters( siteId ) {
 	const filters = [
 		{ title: i18n.translate( 'Insights' ), path: '/stats/insights/' + siteId, id: 'stats-insights' },
+		{ title: i18n.translate( 'Settings' ), path: '/stats/settings/' + siteId, id: 'stats-settings' },
 		{ title: i18n.translate( 'Days' ), path: '/stats/day/' + siteId, id: 'stats-day', period: 'day' },
 		{ title: i18n.translate( 'Weeks' ), path: '/stats/week/' + siteId, id: 'stats-week', period: 'week' },
 		{ title: i18n.translate( 'Months' ), path: '/stats/month/' + siteId, id: 'stats-month', period: 'month' },
@@ -97,6 +98,15 @@ module.exports = {
 		} else {
 			next();
 		}
+	},
+
+	settings: function( context ) {
+		const Settings = require( './stats-settings' );
+		renderWithReduxStore(
+			React.createElement( Settings ),
+			document.getElementById( 'primary' ),
+			context.store
+		);
 	},
 
 	insights: function( context, next ) {

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -19,6 +19,9 @@ module.exports = function() {
 		page( '/stats/month', controller.siteSelection, controller.navigation, statsController.overview );
 		page( '/stats/year', controller.siteSelection, controller.navigation, statsController.overview );
 
+		// Stat Settings Page
+		page( '/stats/settings/:site_id', controller.siteSelection, controller.navigation, statsController.settings );
+
 		// Stat Insights Page
 		page( '/stats/insights/:site_id', controller.siteSelection, controller.navigation, statsController.insights );
 

--- a/client/my-sites/stats/stats-navigation/index.jsx
+++ b/client/my-sites/stats/stats-navigation/index.jsx
@@ -12,6 +12,7 @@ import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 import siteStatsStickyTabActions from 'lib/site-stats-sticky-tab/actions';
 import FollowersCount from 'blocks/followers-count';
+import { isEnabled } from 'config';
 
 class StatsNavigation extends Component {
 	static propTypes = {
@@ -40,9 +41,9 @@ class StatsNavigation extends Component {
 			day: translate( 'Days' ),
 			week: translate( 'Weeks' ),
 			month: translate( 'Months' ),
-			year: translate( 'Years' )
+			year: translate( 'Years' ),
+			settings: translate( 'Settings' ),
 		};
-
 
 		return (
 			<SectionNav selectedText={ sectionTitles[ section ] }>
@@ -62,6 +63,12 @@ class StatsNavigation extends Component {
 					<NavItem path={ '/stats/year' + siteFragment } selected={ section === 'year' }>
 						{ sectionTitles.year }
 					</NavItem>
+					{
+						isEnabled( 'stats/settings' ) &&
+						<NavItem path={ '/stats/settings' + siteFragment } selected={ section === 'settings' }>
+							{ sectionTitles.settings }
+						</NavItem>
+					}
 				</NavTabs>
 				<FollowersCount />
 			</SectionNav>

--- a/client/my-sites/stats/stats-settings/index.jsx
+++ b/client/my-sites/stats/stats-settings/index.jsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import StatsNavigation from '../stats-navigation';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import Main from 'components/main';
+
+class StatsSettings extends Component {
+	render() {
+		return (
+			<Main wideLayout={ true }>
+				<SidebarNavigation />
+				<StatsNavigation section="settings" />
+			</Main>
+		);
+	}
+}
+
+ export default StatsSettings;

--- a/config/development.json
+++ b/config/development.json
@@ -146,6 +146,7 @@
 		"settings/security/monitor/wp-note": true,
 		"settings/security/scan": true,
 		"support-user": true,
+		"stats/settings": true,
 		"sync-handler": true,
 		"ui/first-view": true,
 		"ui/first-view/reset-route": true,


### PR DESCRIPTION
For #10350

<img width="940" alt="stats_ _codep2_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/21728370/bec71db4-d3fa-11e6-8462-deae6ccfe70a.png">

A few new stats features revolve around giving the user some more control of their stats experience.  This PR is a start to explore/discuss this concept further.  This branch adds in a new "tab" to the `<StatsNavigation />` for "Settings".

I had considered just using a simple "cog" `GridIcon` displayed on the right side of the followers count, but wanted to explore this named tab first.  Design feedback appreciated.

Currently, the `StatsSettings` page is blank, but the first feature to be added will be a preference for which stats tab is the "default" for a given site: Insights, Day, Week, Month, Year.  Settings like the default tab will be persisted via the [Preferences](https://github.com/Automattic/wp-calypso/tree/master/client/state/preferences) state.

The StatsSettings tab is also behind a feature flag and currently only enabled in `development` mode.

__To Test__
- Open Stats, note the new Settings tab
- Click on it and verify a blank page is shown

/cc @karmatosed for more design ideas