### PR TITLE
Media: Add "This Post" filter to the editor media modal.

### DIFF
--- a/client/components/data/media-list-data/README.md
+++ b/client/components/data/media-list-data/README.md
@@ -5,7 +5,7 @@ MediaListData is a React component intended to be used as a controller-view to s
 
 ## Usage
 
-Wrap a child component with `<MediaListData />`, passing a `siteId` and optional `filter` and `search` values. [As a controller-view](https://facebook.github.io/flux/docs/overview.html#views-and-controller-views), MediaListData does not render any content of its own; instead, it simply renders the child component.
+Wrap a child component with `<MediaListData />`, passing a `siteId` and optional `filter`, `postId` and `search` values. [As a controller-view](https://facebook.github.io/flux/docs/overview.html#views-and-controller-views), MediaListData does not render any content of its own; instead, it simply renders the child component.
 
 ```jsx
 var React = require( 'react' ),

--- a/client/components/data/media-list-data/index.jsx
+++ b/client/components/data/media-list-data/index.jsx
@@ -27,6 +27,7 @@ module.exports = React.createClass( {
 	propTypes: {
 		siteId: React.PropTypes.number.isRequired,
 		source: React.PropTypes.string,
+		postId: React.PropTypes.number,
 		filter: React.PropTypes.string,
 		search: React.PropTypes.string
 	},
@@ -64,7 +65,13 @@ module.exports = React.createClass( {
 		}
 
 		if ( props.filter ) {
-			query.mime_type = utils.getMimeBaseTypeFromFilter( props.filter );
+			if ( props.filter === 'this-post' ) {
+				if ( props.postId ) {
+					query.post_ID = props.postId;
+				}
+			} else {
+				query.mime_type = utils.getMimeBaseTypeFromFilter( props.filter );
+			}
 		}
 
 		if ( props.source ) {

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -56,6 +56,7 @@ const MediaLibraryContent = React.createClass( {
 		onAddMedia: React.PropTypes.func,
 		onMediaScaleChange: React.PropTypes.func,
 		onEditItem: React.PropTypes.func,
+		postId: React.PropTypes.number
 	},
 
 	getDefaultProps: function() {
@@ -232,6 +233,7 @@ const MediaLibraryContent = React.createClass( {
 		return (
 			<MediaListData
 				siteId={ this.props.site.ID }
+				postId={ this.props.postId }
 				filter={ this.props.filter }
 				search={ this.props.search }
 				source={ this.props.source }>

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -4,9 +4,10 @@
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import {
+	identity,
 	includes,
 	noop,
-	identity
+	pull,
 } from 'lodash';
 
 /**
@@ -46,6 +47,8 @@ export class MediaLibraryFilterBar extends Component {
 	getSearchPlaceholderText() {
 		const { filter, translate } = this.props;
 		switch ( filter ) {
+			case 'this-post':
+				return translate( 'Search media uploaded to this post…' );
 			case 'images':
 				return translate( 'Search images…' );
 			case 'audio':
@@ -63,6 +66,8 @@ export class MediaLibraryFilterBar extends Component {
 		const { translate } = this.props;
 
 		switch ( filter ) {
+			case 'this-post':
+				return translate( 'This Post', { comment: 'Filter label for media list' } );
 			case 'images':
 				return translate( 'Images', { comment: 'Filter label for media list' } );
 			case 'audio':
@@ -100,7 +105,11 @@ export class MediaLibraryFilterBar extends Component {
 			return null;
 		}
 
-		const tabs = [ '', 'images', 'documents', 'videos', 'audio' ];
+		const tabs = [ '', 'this-post', 'images', 'documents', 'videos', 'audio' ];
+
+		if ( ! this.props.post ) {
+			pull( tabs, 'this-post' );
+		}
 
 		return (
 			<SectionNavTabs>

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -32,7 +32,8 @@ export class MediaLibraryFilterBar extends Component {
 		site: React.PropTypes.object,
 		onFilterChange: React.PropTypes.func,
 		onSearch: React.PropTypes.func,
-		translate: React.PropTypes.func
+		translate: React.PropTypes.func,
+		post: React.PropTypes.bool
 	};
 
 	static defaultProps ={
@@ -42,6 +43,7 @@ export class MediaLibraryFilterBar extends Component {
 		onSearch: noop,
 		translate: identity,
 		source: '',
+		post: false
 	};
 
 	getSearchPlaceholderText() {

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -40,7 +40,7 @@ module.exports = React.createClass( {
 		containerWidth: React.PropTypes.number,
 		single: React.PropTypes.bool,
 		scrollable: React.PropTypes.bool,
-		postId: React.PropTypes.number
+		postId: React.PropTypes.number,
 	},
 
 	getDefaultProps: function() {

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -39,7 +39,8 @@ module.exports = React.createClass( {
 		fullScreenDropZone: React.PropTypes.bool,
 		containerWidth: React.PropTypes.number,
 		single: React.PropTypes.bool,
-		scrollable: React.PropTypes.bool
+		scrollable: React.PropTypes.bool,
+		postId: React.PropTypes.number
 	},
 
 	getDefaultProps: function() {
@@ -140,7 +141,8 @@ module.exports = React.createClass( {
 				selectedItems={ this.props.mediaLibrarySelectedItems }
 				onDeleteItem={ this.props.onDeleteItem }
 				onEditItem={ this.props.onEditItem }
-				onViewDetails={ this.props.onViewDetails } />
+				onViewDetails={ this.props.onViewDetails }
+				postId={ this.props.postId } />
 		);
 
 		if ( this.props.site ) {
@@ -169,7 +171,8 @@ module.exports = React.createClass( {
 					search={ this.props.search }
 					onFilterChange={ this.props.onFilterChange }
 					source={ this.props.source }
-					onSearch={ this.doSearch } />
+					onSearch={ this.doSearch }
+					post={ !! this.props.postId } />
 				{ content }
 			</div>
 		);

--- a/client/my-sites/media-library/list-no-content.jsx
+++ b/client/my-sites/media-library/list-no-content.jsx
@@ -26,7 +26,7 @@ class MediaLibraryListNoContent extends Component {
 
 		switch ( filter ) {
 			case 'this-post':
-				return translate( 'There isn\'t any media uploaded to the post.', {
+				return translate( 'There are no media items uploaded to this post.', {
 					comment: 'Media no results'
 				} );
 

--- a/client/my-sites/media-library/list-no-content.jsx
+++ b/client/my-sites/media-library/list-no-content.jsx
@@ -21,6 +21,12 @@ export default React.createClass( {
 
 	getLabel() {
 		switch ( this.props.filter ) {
+			case 'this-post':
+				return this.translate( 'There are no media uploaded to this post.', {
+					textOnly: true,
+					context: 'Media no results'
+				} );
+
 			case 'images':
 				return this.translate( 'You don\'t have any images.', {
 					textOnly: true,

--- a/client/my-sites/media-library/list-no-content.jsx
+++ b/client/my-sites/media-library/list-no-content.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -10,63 +11,60 @@ import EmptyContent from 'components/empty-content';
 import UploadButton from './upload-button';
 import { userCan } from 'lib/site/utils';
 
-export default React.createClass( {
-	displayName: 'MediaLibraryListNoContent',
-
-	propTypes: {
+class MediaLibraryListNoContent extends Component {
+	static propTypes = {
 		site: React.PropTypes.object,
 		filter: React.PropTypes.string,
 		source: React.PropTypes.string,
-	},
+	};
 
 	getLabel() {
-		switch ( this.props.filter ) {
+		const {
+			filter,
+			translate,
+		} = this.props;
+
+		switch ( filter ) {
 			case 'this-post':
-				return this.translate( 'There are no media uploaded to this post.', {
-					textOnly: true,
+				return translate( 'There are no media uploaded to this post.', {
 					context: 'Media no results'
 				} );
 
 			case 'images':
-				return this.translate( 'You don\'t have any images.', {
-					textOnly: true,
+				return translate( 'You don\'t have any images.', {
 					context: 'Media no results'
 				} );
 
 			case 'videos':
-				return this.translate( 'You don\'t have any videos.', {
-					textOnly: true,
+				return translate( 'You don\'t have any videos.', {
 					context: 'Media no results'
 				} );
 
 			case 'audio':
-				return this.translate( 'You don\'t have any audio files.', {
-					textOnly: true,
+				return translate( 'You don\'t have any audio files.', {
 					context: 'Media no results'
 				} );
 
 			case 'documents':
-				return this.translate( 'You don\'t have any documents.', {
-					textOnly: true,
+				return translate( 'You don\'t have any documents.', {
 					context: 'Media no results'
 				} );
 
 			default:
-				return this.translate( 'You don\'t have any media.', {
-					textOnly: true,
+				return translate( 'You don\'t have any media.', {
 					context: 'Media no results'
 				} );
 		}
-	},
+	}
 
 	render() {
 		let line = '', action = '';
 
 		if ( userCan( 'upload_files', this.props.site ) && ! this.props.source ) {
-			line = this.translate( 'Would you like to upload something?' );
+			line = this.props.translate( 'Would you like to upload something?' );
 			action = (
 				<UploadButton className="button is-primary" site={ this.props.site }>
-					{ this.translate( 'Upload Media' ) }
+					{ this.props.translate( 'Upload Media' ) }
 				</UploadButton>
 			);
 		}
@@ -81,4 +79,6 @@ export default React.createClass( {
 			/>
 		);
 	}
-} );
+}
+
+export default localize( MediaLibraryListNoContent );

--- a/client/my-sites/media-library/list-no-content.jsx
+++ b/client/my-sites/media-library/list-no-content.jsx
@@ -26,33 +26,33 @@ class MediaLibraryListNoContent extends Component {
 
 		switch ( filter ) {
 			case 'this-post':
-				return translate( 'There are no media uploaded to this post.', {
-					context: 'Media no results'
+				return translate( 'There isn\'t any media uploaded to the post.', {
+					comment: 'Media no results'
 				} );
 
 			case 'images':
 				return translate( 'You don\'t have any images.', {
-					context: 'Media no results'
+					comment: 'Media no results'
 				} );
 
 			case 'videos':
 				return translate( 'You don\'t have any videos.', {
-					context: 'Media no results'
+					comment: 'Media no results'
 				} );
 
 			case 'audio':
 				return translate( 'You don\'t have any audio files.', {
-					context: 'Media no results'
+					comment: 'Media no results'
 				} );
 
 			case 'documents':
 				return translate( 'You don\'t have any documents.', {
-					context: 'Media no results'
+					comment: 'Media no results'
 				} );
 
 			default:
 				return translate( 'You don\'t have any media.', {
-					context: 'Media no results'
+					comment: 'Media no results'
 				} );
 		}
 	}

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -549,7 +549,7 @@ export default connect(
 		// [TODO]: Migrate toward dropping incoming site prop, accepting only
 		// siteId and forcing descendant components to access via state
 		site: site || getSite( state, siteId ),
-		postId: getEditorPostId( state )
+		postId: getEditorPostId( state ),
 	} ),
 	{
 		setView: setEditorMediaModalView,

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -36,6 +36,7 @@ import accept from 'lib/accept';
 
 import { getMediaModalView } from 'state/ui/media-modal/selectors';
 import { getSite } from 'state/sites/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
 import { resetMediaModalView } from 'state/ui/media-modal/actions';
 import { setEditorMediaModalView } from 'state/ui/editor/actions';
 import { ModalViews } from 'state/ui/media-modal/constants';
@@ -70,7 +71,8 @@ export class EditorMediaModal extends Component {
 		enabledFilters: React.PropTypes.arrayOf( React.PropTypes.string ),
 		view: React.PropTypes.oneOf( values( ModalViews ) ),
 		setView: React.PropTypes.func,
-		resetView: React.PropTypes.func
+		resetView: React.PropTypes.func,
+		postId: React.PropTypes.number,
 	};
 
 	static defaultProps = {
@@ -518,6 +520,7 @@ export class EditorMediaModal extends Component {
 						onDeleteItem={ this.deleteMedia }
 						onViewDetails={ this.props.onViewDetails }
 						mediaLibrarySelectedItems={ this.props.mediaLibrarySelectedItems }
+						postId={ this.props.postId }
 						scrollable />
 				);
 				break;
@@ -545,7 +548,8 @@ export default connect(
 		view: getMediaModalView( state ),
 		// [TODO]: Migrate toward dropping incoming site prop, accepting only
 		// siteId and forcing descendant components to access via state
-		site: site || getSite( state, siteId )
+		site: site || getSite( state, siteId ),
+		postId: getEditorPostId( state )
 	} ),
 	{
 		setView: setEditorMediaModalView,


### PR DESCRIPTION
Adds the ability to filter media in the modal to only show images that are attached to the current post. This ability is present in the core media picker & this fills that gap in Calypso.

fixes #2136

Testing instructions:

* The [media library page](http://calypso.localhost:3000/media) should not have this filter.
* A [new post](http://calypso.localhost:3000/post)'s media modal will not have this filter until the post is auto-saved.
* An existing post's media modal without any media uploaded to it should show "There are no media uploaded to this post." when the filter is enabled.
* An existing post's media modal with media uploaded to it should show these media when the filter is enabled.

Cc @folletto.