### PR TITLE
Site Settings: Show indicator while icon upload in progress

### DIFF
--- a/client/blocks/site-icon/index.jsx
+++ b/client/blocks/site-icon/index.jsx
@@ -9,17 +9,19 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import Spinner from 'components/spinner';
 import QuerySites from 'components/data/query-sites';
 import { getSite } from 'state/sites/selectors';
-import { getSiteIconUrl } from 'state/selectors';
+import { getSiteIconUrl, getSiteIconId, isTransientMedia } from 'state/selectors';
 import resizeImageUrl from 'lib/resize-image-url';
 import Gridicon from 'components/gridicon';
 
-function SiteIcon( { siteId, site, iconUrl, size, imgSize } ) {
+function SiteIcon( { siteId, site, iconUrl, size, imgSize, isTransientIcon } ) {
 	const iconSrc = resizeImageUrl( iconUrl, imgSize );
 
 	const classes = classNames( 'site-icon', {
-		'is-blank': ! iconSrc
+		'is-blank': ! iconSrc,
+		'is-transient': isTransientIcon
 	} );
 
 	const style = {
@@ -36,6 +38,7 @@ function SiteIcon( { siteId, site, iconUrl, size, imgSize } ) {
 				? <img className="site-icon__img" src={ iconSrc } />
 				: <Gridicon icon="globe" size={ Math.round( size / 1.3 ) } />
 			}
+			{ isTransientIcon && <Spinner /> }
 		</div>
 	);
 }
@@ -45,7 +48,8 @@ SiteIcon.propTypes = {
 	site: PropTypes.object,
 	iconUrl: PropTypes.string,
 	size: PropTypes.number,
-	imgSize: PropTypes.number
+	imgSize: PropTypes.number,
+	isTransientIcon: PropTypes.bool
 };
 
 SiteIcon.defaultProps = {
@@ -69,8 +73,11 @@ export default connect( ( state, { site, siteId, imgSize } ) => {
 		};
 	}
 
+	const iconId = getSiteIconId( state, stateSite.ID );
+
 	return {
 		site: stateSite,
-		iconUrl: getSiteIconUrl( state, stateSite.ID, imgSize )
+		iconUrl: getSiteIconUrl( state, stateSite.ID, imgSize ),
+		isTransientIcon: isTransientMedia( state, stateSite.ID, iconId )
 	};
 } )( SiteIcon );

--- a/client/blocks/site-icon/style.scss
+++ b/client/blocks/site-icon/style.scss
@@ -16,6 +16,22 @@
 	}
 }
 
+.site-icon.is-transient .spinner {
+	position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+	background-color: rgba( $white, 0.75 );
+
+	.spinner__image {
+		position: absolute;
+			top: 50%;
+			left: 50%;
+		transform: translate( -50%, -50% );
+	}
+}
+
 .site-icon__img {
 	background: $transparent;
 	position: relative;

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -36,3 +36,4 @@ export isRequestingSharingButtons from './is-requesting-sharing-buttons';
 export isSavingSharingButtons from './is-saving-sharing-buttons';
 export isSharingButtonsSaveSuccessful from './is-sharing-buttons-save-successful';
 export isSiteSupportingImageEditor from './is-site-supporting-image-editor';
+export isTransientMedia from './is-transient-media';

--- a/client/state/selectors/is-transient-media.js
+++ b/client/state/selectors/is-transient-media.js
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getMediaItem } from './';
+
+export default function isTransientMedia( state, siteId, mediaId ) {
+	return !! get( getMediaItem( state, siteId, mediaId ), 'transient' );
+}

--- a/client/state/selectors/test/is-transient-media.js
+++ b/client/state/selectors/test/is-transient-media.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isTransientMedia } from '../';
+
+describe( 'isTransientMedia()', () => {
+	it( 'should return false if the media is not known', () => {
+		const isTransient = isTransientMedia( {
+			media: {
+				items: {}
+			}
+		}, 2916284, 42 );
+
+		expect( isTransient ).to.be.false;
+	} );
+
+	it( 'should return false if the media has no transient flag', () => {
+		const isTransient = isTransientMedia( {
+			media: {
+				items: {
+					2916284: {
+						42: { ID: 42, title: 'flowers' }
+					}
+				}
+			}
+		}, 2916284, 42 );
+
+		expect( isTransient ).to.be.false;
+	} );
+
+	it( 'should return the true if truthy transient flag on media', () => {
+		const isTransient = isTransientMedia( {
+			media: {
+				items: {
+					2916284: {
+						42: { ID: 42, title: 'flowers', 'transient': true }
+					}
+				}
+			}
+		}, 2916284, 42 );
+
+		expect( isTransient ).to.be.true;
+	} );
+} );


### PR DESCRIPTION
Closes #10452 

This pull request seeks to show an indicator while the site icon edits have yet to be uploaded, prior to saving site settings. Previously there was no indication that anything was happening during this step.

![indicator](https://cloud.githubusercontent.com/assets/1779930/21731566/f58f25bc-d422-11e6-95f3-a4c4d22a193b.gif)

__Testing instructions:__

Repeat testing instructions from #10452, ensuring "What I expected" from issue holds true with these changes.