### PR TITLE
allow for serialization at both leading and trailing edges

### DIFF
--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -82,7 +82,7 @@ export function persistOnChange( reduxStore, serializeState = serialize ) {
 			.catch( ( setError ) => {
 				debug( 'failed to set redux-store state', setError );
 			} );
-	}, SERIALIZE_THROTTLE, { leading: false, trailing: true } ) );
+	}, SERIALIZE_THROTTLE, { leading: true, trailing: true } ) );
 
 	return reduxStore;
 }


### PR DESCRIPTION
As @hoverduck figured out, the merging of https://github.com/Automattic/wp-calypso/issues/9298 has exacerbated the issue described in https://github.com/Automattic/wp-calypso/pull/10435 .

Hopefully by allowing serialization to occur at either edge this will alleviate the issue