### PR TITLE
ATAT State: Refactor selector and describe meaning of `status`

### DIFF
--- a/client/my-sites/plugins/plugin-automated-transfer/index.jsx
+++ b/client/my-sites/plugins/plugin-automated-transfer/index.jsx
@@ -11,10 +11,8 @@ import wrapWithClickOutside from 'react-click-outside';
  */
 import { transferStates } from 'state/automated-transfer/constants';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import {
-	getAutomatedTransferStatus,
-	isAutomatedTransferTransferring,
-} from 'state/automated-transfer/selectors';
+import { getAutomatedTransferStatus } from 'state/automated-transfer/selectors';
+import { isAutomatedTransferActive } from 'state/selectors';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 
@@ -72,7 +70,7 @@ class PluginAutomatedTransfer extends Component {
 	}
 
 	getNoticeText = () => {
-		const { START, SETUP, CONFLICTS } = transferStates;
+		const { START, CONFLICTS } = transferStates;
 		const { plugin, transferState, translate } = this.props;
 		const { clickOutside, transferComplete } = this.state;
 
@@ -84,7 +82,6 @@ class PluginAutomatedTransfer extends Component {
 		}
 		switch ( transferState ) {
 			case START: return translate( 'Installing %(plugin)s…', { args: { plugin: plugin.name } } );
-			case SETUP : return translate( 'Now configuring your site. This may take a few minutes.' );
 			case CONFLICTS: return translate( 'Sorry, we found some conflicts to fix before proceeding.' );
 		}
 	}
@@ -162,12 +159,11 @@ class PluginAutomatedTransfer extends Component {
 }
 
 const mapStateToProps = state => {
-	const site = getSelectedSiteId( state );
-	const transferState = getAutomatedTransferStatus( state, site );
-	const isTransferring = isAutomatedTransferTransferring( state, site );
+	const siteId = getSelectedSiteId( state );
+
 	return {
-		isTransferring,
-		transferState,
+		transferState: getAutomatedTransferStatus( state, siteId ),
+		isTransferring: isAutomatedTransferActive( state, siteId ),
 	};
 };
 

--- a/client/state/automated-transfer/README.md
+++ b/client/state/automated-transfer/README.md
@@ -1,0 +1,23 @@
+# Automated Transfer State Information
+
+Automated transfers are ongoing stateful processes.
+The information in this state subtree tracks that process and provides the necessary information to represent it visually.
+
+All automated transfer information is stored as a single possible transfer per site.
+That is to say, state information is keyed by site ID and if records for multiple actual transfer attempts exist on the server only one will exist in Calypso (this shall be the most recent data available).
+
+## Data types and meaning
+
+### `status`
+
+The status of an automated transfer represents where in the transfer process a given site may be.
+The highest-level values of the status are _has never attempted to transfer_, _is transferring_, and _has transferred_.
+However, inside of _is transferring_ there are many sub-states that are more granular in the process tracking.
+
+| status | meaning |
+|:-:|---|
+| `COMPLETE` | Records exist for a transfer but it has previously finished |
+| `CONFLICTS` | No transfer can be created because there are known conflicts preventing a success transfer |
+| `INQUIRING` | Calypso has requested information about starting a transfer but none has actually been created |
+| `START` | A transfer has been created and is currently in progress |
+| _falsey_ | No information about any transfers exists in Calypso |

--- a/client/state/automated-transfer/selectors.js
+++ b/client/state/automated-transfer/selectors.js
@@ -4,13 +4,7 @@
 import {
 	flowRight as compose,
 	get,
-	includes,
 } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { transferStates } from 'state/automated-transfer/constants';
 
 export const getAutomatedTransfer = ( state, siteId ) =>
 	get( state, [ 'automatedTransfer', siteId ], {} );
@@ -73,27 +67,4 @@ export const getEligibilityStatus = state => !! get( state, 'lastUpdated', 0 ) &
 export const isEligibleForAutomatedTransfer = compose(
 	getEligibilityStatus,
 	getEligibility
-);
-
-/**
- * Helper to get transferring state from local transfer status
- *
- * @param {string|null} status automated transfer status
- * @returns {bool} transferring check
- */
-const getIsTransferring = status => includes(
-	[ transferStates.START, transferStates.SETUP ],
-	status,
-);
-
-/**
- * Checks if the site is currently transferring
- *
- * @param {Object} state global app state
- * @param {number} siteId requested site for tranfer info
- * @returns {bool} transferring check
- */
-export const isAutomatedTransferTransferring = compose(
-	getIsTransferring,
-	getAutomatedTransferStatus,
 );

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -23,6 +23,7 @@ export getMediaItem from './get-media-item';
 export getMediaUrl from './get-media-url';
 export getSiteIconId from './get-site-icon-id';
 export getSiteIconUrl from './get-site-icon-url';
+export isAutomatedTransferActive from './is-automated-transfer-active';
 export isPrivateSite from './is-private-site';
 export isRequestingPostLikes from './is-requesting-post-likes';
 export isRequestingSharingButtons from './is-requesting-sharing-buttons';

--- a/client/state/selectors/is-automated-transfer-active.js
+++ b/client/state/selectors/is-automated-transfer-active.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import {
+	flowRight as compose,
+} from 'lodash';
+
+/**
+ * Internal Dependencies
+ */
+import { transferStates } from 'state/automated-transfer/constants';
+import { getAutomatedTransferStatus } from 'state/automated-transfer/selectors';
+
+/**
+ * Maps automated transfer status value to indication if transfer is active
+ *
+ * @param {String} status name of current state in automated transfer
+ * @returns {?boolean} is transfer currently active? null if unknown
+ */
+export const isActive = status =>
+	status
+		? status === transferStates.START
+		: null;
+
+/**
+ * Indicates whether or not an automated transfer is active for a given site
+ *
+ * @param {Object} state app state
+ * @param {Number} siteId site of interest
+ * @returns {?boolean} whether or not transfer is active, or null if not known
+ */
+export const isAutomatedTransferActive = compose(
+	isActive,
+	getAutomatedTransferStatus,
+);
+
+export default isAutomatedTransferActive;

--- a/client/state/selectors/test/is-automated-transfer-active.js
+++ b/client/state/selectors/test/is-automated-transfer-active.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { transferStates } from 'state/automated-transfer/constants';
+
+import { isActive } from '../is-automated-transfer-active';
+
+describe( 'Automated Transfer', () => {
+	describe( 'isActive()', () => {
+		it( 'should return `null` if no information is available', () => {
+			expect( isActive( null ) ).to.be.null;
+			expect( isActive( '' ) ).to.be.null; // plausible that the status could wind up as an empty string
+		} );
+
+		it( 'should return `true` for active transfer states', () => {
+			expect( isActive( transferStates.START ) ).to.be.true;
+		} );
+
+		it( 'should return `false` for non-active transfer states', () => {
+			expect( isActive( transferStates.COMPLETE ) ).to.be.false;
+			expect( isActive( transferStates.CONFLICTS ) ).to.be.false;
+			expect( isActive( transferStates.INQUIRING ) ).to.be.false;
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR provides a new global selector:

```js
isAutomatedTransferActive( state, siteId )
```

This selector provides a boolean return value indicating if an automated
transfer is currently in progress for the given site (by site id) and
`null` if no information is currently available inside of Calypso.

This will tie into further work which will handle initiating transfers
and polling for their status updates.

cc: @roundhill @rralian 

cc: @aduth I didn't see any return value listed in the selector search for this. the parameter arguments and types were there, but no return. I tried replacing `@returns` with `@return` but that didn't help. do you have any idea what could be going on?