### PR TITLE
ATAT: Start watching theme-initiated transfers for status

### DIFF
--- a/client/state/automated-transfer/reducer.js
+++ b/client/state/automated-transfer/reducer.js
@@ -12,15 +12,20 @@ import {
 	keyedReducer,
 	withSchemaValidation,
 } from 'state/utils';
+import { transferStates } from './constants';
 import { automatedTransfer as schema } from './schema';
 import {
-	AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE as UPDATE,
+	AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE as ELIGIBILITY_UPDATE,
 	AUTOMATED_TRANSFER_STATUS_SET as SET_STATUS,
+	THEME_TRANSFER_INITIATE_SUCCESS as INITIATE,
+	THEME_TRANSFER_STATUS_RECEIVE as TRANSFER_UPDATE,
 } from 'state/action-types';
 
 export const status = ( state = null, action ) => get( {
+	[ ELIGIBILITY_UPDATE ]: action.status,
+	[ INITIATE ]: transferStates.START,
 	[ SET_STATUS ]: action.status,
-	[ UPDATE ]: action.status,
+	[ TRANSFER_UPDATE ]: 'complete' === action.status ? transferStates.COMPLETE : state,
 }, action.type, state );
 
 export const siteReducer = combineReducers( {


### PR DESCRIPTION
This patch starts monitoring the theme transfer actions and updates the
`status` value for the specific actions which indicate changing it.

@seear I could use some help auditing the theme transfer actions to make sure I catch the right ones and make the appropriate updates.

cc: @roundhill @rralian 