### PR TITLE
Domains: Register Domain Step: Move resetting state function into componentWillReceiveProps

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -139,6 +139,11 @@ const RegisterDomainStep = React.createClass( {
 	},
 
 	componentWillReceiveProps( nextProps ) {
+		// Reset state on site change
+		if ( nextProps.selectedSite && nextProps.selectedSite.slug !== ( this.props.selectedSite || {} ).slug ) {
+			this.setState( this.getInitialState() );
+		}
+
 		if ( this.props.defaultSuggestionsError === nextProps.defaultSuggestionsError ||
 			( ! this.props.defaultSuggestionsError && ! nextProps.defaultSuggestionsError ) ) {
 			return;
@@ -187,7 +192,6 @@ const RegisterDomainStep = React.createClass( {
 
 	componentDidUpdate: function( prevProps ) {
 		if ( this.props.selectedSite && this.props.selectedSite.domain !== prevProps.selectedSite.domain ) {
-			this.setState( this.getInitialState() );
 			this.focusSearchCard();
 		}
 	},


### PR DESCRIPTION
This PR moves a call from `componentDidUpdate` to `componentWillReceiveProps`. The purpose of the call is to reset the state when selectedSite changes, but we should not call `setState` within `componentDidUpdate` as it would trigger a re-render.

This PR shouldn't have visible side effects.

/cc: @klimeryk @aidvu @dzver