### PR TITLE
Stats: move countries to redux.

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -20,7 +20,7 @@ import { renderWithReduxStore } from 'lib/react-helpers';
 import { savePreference } from 'state/preferences/actions';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
-
+import Emitter from 'lib/mixins/emitter';
 const user = userFactory();
 const sites = sitesFactory();
 const analyticsPageTitle = 'Stats';
@@ -348,8 +348,6 @@ module.exports = {
 				siteID: siteId, statType: 'statsClicks', period: activeFilter.period, date: endDate, domain: siteDomain } );
 			const authorsList = new StatsList( {
 				siteID: siteId, statType: 'statsTopAuthors', period: activeFilter.period, date: endDate, domain: siteDomain } );
-			const countriesList = new StatsList( {
-				siteID: siteId, statType: 'statsCountryViews', period: activeFilter.period, date: endDate, domain: siteDomain } );
 			const videoPlaysList = new StatsList( {
 				siteID: siteId, statType: 'statsVideoPlays', period: activeFilter.period, date: endDate, domain: siteDomain } );
 			const searchTermsList = new StatsList( {
@@ -377,7 +375,6 @@ module.exports = {
 				referrersList,
 				clicksList,
 				authorsList,
-				countriesList,
 				videoPlaysList,
 				siteId,
 				period,
@@ -437,6 +434,7 @@ module.exports = {
 		let summaryList;
 		let visitsList;
 		const followList = new FollowList();
+
 		const validModules = [ 'posts', 'referrers', 'clicks', 'countryviews', 'authors', 'videoplays', 'videodetails', 'podcastdownloads', 'searchterms' ];
 		let momentSiteZone = i18n.moment();
 		const basePath = route.sectionify( context.path );
@@ -478,6 +476,11 @@ module.exports = {
 			const siteDomain = ( site && ( typeof site.slug !== 'undefined' ) )
 				? site.slug : siteFragment;
 			let extraProps = {};
+
+			// When old list summaries are transitioned to redux, we need a "fake" emitter
+			// TODO when all lists are moved to redux, remove this logic
+			const fakeStatsList = Emitter( {} );
+
 			switch ( context.params.module ) {
 
 				case 'posts':
@@ -501,9 +504,7 @@ module.exports = {
 					break;
 
 				case 'countryviews':
-					summaryList = new StatsList( {
-						siteID: siteId, statType: 'statsCountryViews', period: activeFilter.period,
-						date: endDate, max: 0, domain: siteDomain } );
+					summaryList = fakeStatsList;
 					break;
 
 				case 'authors':

--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -1,26 +1,40 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
-import throttle from 'lodash/throttle';
+import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
+import { throttle, map, uniq } from 'lodash';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-const loadScript = require( 'lib/load-script' ).loadScript;
+import { loadScript } from 'lib/load-script';
+import StatsModulePlaceholder from '../stats-module/placeholder';
+import QuerySiteStats from 'components/data/query-site-stats';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import {
+	getSiteStatsNormalizedData
+} from 'state/stats/lists/selectors';
 
-export default React.createClass( {
-	displayName: 'StatsGeochart',
+class StatsGeochart extends Component {
+	static propTypes = {
+		siteId: PropTypes.number,
+		statType: PropTypes.string,
+		query: PropTypes.object,
+		data: PropTypes.array,
+	};
 
-	visualizationsLoaded: false,
-
-	visualization: null,
-
-	propTypes: {
-		data: PropTypes.array.isRequired,
-		dataList: PropTypes.object.isRequired
-	},
+	constructor( props ) {
+		super( props );
+		this.visualizationsLoaded = false;
+		this.visualization = null;
+		this.tick = () => {
+			this.timer = setTimeout( this.loadVisualizations, 1000 );
+		};
+	}
 
 	componentDidMount() {
 		if ( ! window.google ) {
@@ -33,13 +47,13 @@ export default React.createClass( {
 
 		this.resize = throttle( this.resize, 1000 );
 		window.addEventListener( 'resize', this.resize );
-	},
+	}
 
 	componentDidUpdate() {
 		if ( this.visualizationsLoaded ) {
 			this.drawData();
 		}
-	},
+	}
 
 	componentWillUnmount() {
 		if ( this.visualization ) {
@@ -50,34 +64,41 @@ export default React.createClass( {
 			this.resize.cancel();
 		}
 		window.removeEventListener( 'resize', this.resize );
-	},
+	}
 
-	recordEvent() {
+	recordEvent = () => {
 		analytics.ga.recordEvent( 'Stats', 'Clicked Country on Map' );
-	},
+	}
 
-	drawRegionsMap() {
-		if ( this.isMounted() ) {
+	drawRegionsMap = () => {
+		if ( this.refs && this.refs.chart ) {
 			this.visualizationsLoaded = true;
 			this.visualization = new window.google.visualization.GeoChart( this.refs.chart );
 			window.google.visualization.events.addListener( this.visualization, 'regionClick', this.recordEvent );
 
 			this.drawData();
 		}
-	},
+	}
 
-	resize() {
+	resize = () => {
 		if ( this.visualizationsLoaded ) {
 			this.drawData();
 		}
-	},
+	}
 
-	drawData() {
-		const regionCodes = [];
-		const { data, dataList } = this.props;
+	drawData = () => {
+		const { data } = this.props;
 
-		if ( data.length > 1 ) {
-			const chartData = window.google.visualization.arrayToDataTable( data );
+		if ( data && data.length ) {
+			const mapData = map( data, ( country ) => {
+				return [ country.label, country.value ];
+			} );
+			mapData.unshift( [
+				this.props.translate( 'Country' ).toString(),
+				this.props.translate( 'Views' ).toString()
+			] );
+
+			const chartData = window.google.visualization.arrayToDataTable( mapData );
 			const node = this.refs.chart;
 			const width = node.clientWidth;
 
@@ -90,21 +111,17 @@ export default React.createClass( {
 				colorAxis: { colors: [ '#FFF088', '#F34605' ] }
 			};
 
-			dataList.response.data.map( function( country ) {
-				if ( regionCodes.indexOf( country.region ) === -1 ) {
-					regionCodes.push( country.region );
-				}
-			} );
+			const regions = uniq( map( data, 'region' ) );
 
-			if ( 1 === regionCodes.length ) {
-				options.region = regionCodes[ 0 ];
+			if ( 1 === regions.length ) {
+				options.region = regions[ 0 ];
 			}
 
 			this.visualization.draw( chartData, options );
 		}
-	},
+	}
 
-	loadVisualizations() {
+	loadVisualizations = () => {
 		// If google is already in the DOM, don't load it again.
 		if ( window.google ) {
 			window.google.load( 'visualization', '1', { packages: [ 'geochart' ], callback: this.drawRegionsMap } );
@@ -112,13 +129,32 @@ export default React.createClass( {
 		} else {
 			this.tick();
 		}
-	},
-
-	tick() {
-		this.timer = setTimeout( this.loadVisualizations, 1000 );
-	},
+	}
 
 	render() {
-		return <div ref="chart" className="stats-geochart" />;
+		const { siteId, statType, query, data } = this.props;
+		const isLoading = ! data;
+		const classes = classNames( 'stats-geochart', {
+			'is-loading': isLoading
+		} );
+		return (
+			<div>
+				<div ref="chart" className={ classes } />
+				{ siteId && statType && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
+				<StatsModulePlaceholder className="is-block" isLoading={ isLoading } />
+			</div>
+		);
 	}
-} );
+}
+
+export default connect( ( state, ownProps ) => {
+	const siteId = getSelectedSiteId( state );
+	const statType = 'statsCountryViews';
+	const { query } = ownProps;
+
+	return {
+		data: getSiteStatsNormalizedData( state, siteId, statType, query ),
+		siteId,
+		statType,
+	};
+} )( localize( StatsGeochart ) );

--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -89,36 +89,38 @@ class StatsGeochart extends Component {
 	drawData = () => {
 		const { data } = this.props;
 
-		if ( data && data.length ) {
-			const mapData = map( data, ( country ) => {
-				return [ country.label, country.value ];
-			} );
-			mapData.unshift( [
-				this.props.translate( 'Country' ).toString(),
-				this.props.translate( 'Views' ).toString()
-			] );
-
-			const chartData = window.google.visualization.arrayToDataTable( mapData );
-			const node = this.refs.chart;
-			const width = node.clientWidth;
-
-			const options = {
-				width: 100 + '%',
-				height: width <= 480 ? '238' : '480',
-				keepAspectRatio: true,
-				enableRegionInteractivity: true,
-				region: 'world',
-				colorAxis: { colors: [ '#FFF088', '#F34605' ] }
-			};
-
-			const regions = uniq( map( data, 'region' ) );
-
-			if ( 1 === regions.length ) {
-				options.region = regions[ 0 ];
-			}
-
-			this.visualization.draw( chartData, options );
+		if ( ! data || ! data.length ) {
+			return;
 		}
+
+		const mapData = map( data, ( country ) => {
+			return [ country.label, country.value ];
+		} );
+		mapData.unshift( [
+			this.props.translate( 'Country' ).toString(),
+			this.props.translate( 'Views' ).toString()
+		] );
+
+		const chartData = window.google.visualization.arrayToDataTable( mapData );
+		const node = this.refs.chart;
+		const width = node.clientWidth;
+
+		const options = {
+			width: 100 + '%',
+			height: width <= 480 ? '238' : '480',
+			keepAspectRatio: true,
+			enableRegionInteractivity: true,
+			region: 'world',
+			colorAxis: { colors: [ '#FFF088', '#F34605' ] }
+		};
+
+		const regions = uniq( map( data, 'region' ) );
+
+		if ( 1 === regions.length ) {
+			options.region = regions[ 0 ];
+		}
+
+		this.visualization.draw( chartData, options );
 	}
 
 	loadVisualizations = () => {

--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -27,14 +27,8 @@ class StatsGeochart extends Component {
 		data: PropTypes.array,
 	};
 
-	constructor( props ) {
-		super( props );
-		this.visualizationsLoaded = false;
-		this.visualization = null;
-		this.tick = () => {
-			this.timer = setTimeout( this.loadVisualizations, 1000 );
-		};
-	}
+	visualizationsLoaded = false;
+	visualization = null;
 
 	componentDidMount() {
 		if ( ! window.google ) {
@@ -87,7 +81,7 @@ class StatsGeochart extends Component {
 	}
 
 	drawData = () => {
-		const { data } = this.props;
+		const { data, translate } = this.props;
 
 		if ( ! data || ! data.length ) {
 			return;
@@ -97,8 +91,8 @@ class StatsGeochart extends Component {
 			return [ country.label, country.value ];
 		} );
 		mapData.unshift( [
-			this.props.translate( 'Country' ).toString(),
-			this.props.translate( 'Views' ).toString()
+			translate( 'Country' ).toString(),
+			translate( 'Views' ).toString()
 		] );
 
 		const chartData = window.google.visualization.arrayToDataTable( mapData );
@@ -133,6 +127,10 @@ class StatsGeochart extends Component {
 		}
 	}
 
+	tick = () => {
+		this.timer = setTimeout( this.loadVisualizations, 1000 );
+	}
+
 	render() {
 		const { siteId, statType, query, data } = this.props;
 		const isLoading = ! data;
@@ -142,7 +140,7 @@ class StatsGeochart extends Component {
 		return (
 			<div>
 				<div ref="chart" className={ classes } />
-				{ siteId && statType && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
+				{ siteId && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
 				<StatsModulePlaceholder className="is-block" isLoading={ isLoading } />
 			</div>
 		);

--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -135,8 +135,10 @@ class StatsGeochart extends Component {
 		const { siteId, statType, query, data } = this.props;
 		const isLoading = ! data;
 		const classes = classNames( 'stats-geochart', {
-			'is-loading': isLoading
+			'is-loading': isLoading,
+			'has-no-data': data && ! data.length
 		} );
+
 		return (
 			<div>
 				<div ref="chart" className={ classes } />

--- a/client/my-sites/stats/geochart/style.scss
+++ b/client/my-sites/stats/geochart/style.scss
@@ -4,6 +4,10 @@
 .stats-geochart {
 	@extend %mobile-interface-element;
 	margin: 0 24px;
+
+	&.is-loading {
+		display: none;
+	}
 }
 
 .countryviews {

--- a/client/my-sites/stats/geochart/style.scss
+++ b/client/my-sites/stats/geochart/style.scss
@@ -5,7 +5,8 @@
 	@extend %mobile-interface-element;
 	margin: 0 24px;
 
-	&.is-loading {
+	&.is-loading,
+	&.has-no-data {
 		display: none;
 	}
 }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -100,11 +100,16 @@ module.exports = React.createClass( {
 		const site = this.props.sites.getSite( this.props.siteId );
 		const charts = this.props.charts();
 		const queryDate = this.props.date.format( 'YYYY-MM-DD' );
-		const period = this.props.period.period;
+		const { period, endOf } = this.props.period;
 		const moduleStrings = statsStrings();
 		let nonPeriodicModules;
 		let videoList;
 		let podcastList;
+
+		const query = {
+			period: period,
+			date: endOf.format( 'YYYY-MM-DD' )
+		};
 
 		debug( 'Rendering site stats component', this.props );
 
@@ -197,11 +202,10 @@ module.exports = React.createClass( {
 						</div>
 						<div className="stats__module-column">
 							<Countries
-								path={ 'countries' }
-								site={ site }
-								dataList={ this.props.countriesList }
+								path="countries"
 								period={ this.props.period }
-								date={ queryDate } />
+								query={ query }
+								summary={ false } />
 							<StatsModule
 								path={ 'searchterms' }
 								moduleStrings={ moduleStrings.search }

--- a/client/my-sites/stats/stats-countries/index.jsx
+++ b/client/my-sites/stats/stats-countries/index.jsx
@@ -1,153 +1,42 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
-import classNames from 'classnames';
+import React, { PropTypes, Component } from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import statsStrings from '../stats-strings';
 import Geochart from '../geochart';
-import StatsList from '../stats-list';
-import observe from 'lib/mixins/data-observe';
-import DownloadCsv from '../stats-download-csv';
-import DatePicker from '../stats-date-picker';
-import ErrorPanel from '../stats-error';
-import Card from 'components/card';
-import StatsModulePlaceholder from '../stats-module/placeholder';
-import StatsListLegend from '../stats-list/legend';
-import Gridicon from 'components/gridicon';
-import SectionHeader from 'components/section-header';
-import UpgradeNudge from 'my-sites/upgrade-nudge';
+import StatsConnectedModule from '../stats-module/connected-list';
 
-export default React.createClass( {
-	displayName: 'StatCountries',
-
-	mixins: [ observe( 'dataList' ) ],
-
-	propTypes: {
+class StatCountries extends Component {
+	static propTypes = {
 		summary: PropTypes.bool,
-		dataList: PropTypes.object,
 		path: PropTypes.string,
 		period: PropTypes.object,
-		site: PropTypes.oneOfType( [
-			PropTypes.object,
-			PropTypes.boolean
-		] ),
-		date: PropTypes.string
-	},
-
-	data( nextProps ) {
-		var props = nextProps || this.props;
-
-		return props.dataList.response.data;
-	},
-
-	getInitialState() {
-		return { noData: this.props.dataList.isEmpty() };
-	},
-
-	componentWillReceiveProps( nextProps ) {
-		this.setState( { noData: nextProps.dataList.isEmpty() } );
-	},
-
-	getModuleLabel() {
-		if ( ! this.props.summary ) {
-			return this.translate( 'Countries' );
-		}
-
-		return (
-			<DatePicker
-				period={ this.props.period.period }
-				date={ this.props.period.startOf }
-				summary={ true } />
-			);
-	},
+		date: PropTypes.string,
+	};
 
 	render() {
-		let mapData = [
-			[
-				this.translate( 'Country' ).toString(),
-				this.translate( 'Views' ).toString()
-			] ];
-
-		let data = this.data();
-		let viewSummary;
-
-		const { dataList, period, site, date, summary, path } = this.props;
-		const hasError = dataList.isError();
-		const noData = dataList.isEmpty();
-		const isLoading = dataList.isLoading();
-		const summaryPageLink = '/stats/' + period.period + '/countryviews/' + site.slug + '?startDate=' + date;
-		const classes = classNames(
-			'stats-module',
-			'is-countries',
-			{
-				summary: summary,
-				'is-loading': isLoading,
-				'has-no-data': noData,
-				'is-showing-error': hasError || noData
-			}
-		);
-
-		// Loop countries and build array for geochart
-		data.forEach( function( country ) {
-			mapData.push( [ country.label, country.value ] );
-		} );
-
-		if ( ! summary && dataList.response.viewAll ) {
-			viewSummary = (
-				<div key="view-all" className="module-expand">
-					<a href={ summaryPageLink }>{ this.translate( 'View All', { context: 'Stats: Button label to expand a panel' } ) }<span className="right"></span></a>
-				</div>
-			);
-		}
+		const { summary, query, period } = this.props;
+		const moduleStrings = statsStrings();
 
 		return (
-			<div>
-				<SectionHeader label={ this.getModuleLabel() } href={ ! summary ? summaryPageLink : null }>
-					{ this.props.summary
-						? ( <DownloadCsv
-								period={ period }
-								path={ path }
-								site={ site }
-								dataList={ dataList } /> )
-						: null }
-				</SectionHeader>
-					<Card className={ classes }>
-						<div className="countryviews">
-							<div className="module-content">
-								<div className="module-content-text module-content-text-info">
-									<p>{ this.translate( 'Explore the list to see which countries and regions generate the most traffic to your site.' ) }</p>
-									<ul className="documentation">
-										<li><a href="http://en.support.wordpress.com/stats/#views-by-country" target="_blank" rel="noopener noreferrer"><Gridicon icon="info-outline" /> { this.translate( 'About Countries' ) }</a></li>
-									</ul>
-								</div>
-								{ ( noData && ! hasError )
-									? <ErrorPanel className="is-empty-message" message={ this.translate( 'No countries recorded' ) } />
-									: null }
-
-								<Geochart data={ mapData } dataList={ dataList } />
-								<StatsModulePlaceholder className="is-block" isLoading={ isLoading } />
-								<StatsListLegend value={ this.translate( 'Views' ) } label={ this.translate( 'Country' ) } />
-								<StatsModulePlaceholder isLoading={ isLoading } />
-								<StatsList moduleName={ path } data={ data } />
-								{ this.props.summary &&
-									<UpgradeNudge
-										title={ this.translate( 'Add Google Analytics' ) }
-										message={ this.translate( 'Upgrade to a Business Plan for Google Analytics integration.' ) }
-										event="googleAnalytics-stats-countries"
-										feature="google-analytics"
-									/>
-								}
-								{ hasError
-									? <ErrorPanel className={ 'network-error' } />
-									: null }
-							</div>
-							{ viewSummary }
-						</div>
-					</Card>
-			</div>
+			<StatsConnectedModule
+				query={ query }
+				path="countryviews"
+				period={ period }
+				showSummaryLink={ ! summary }
+				summary={ summary }
+				moduleStrings={ moduleStrings.countries }
+				statType="statsCountryViews"
+			>
+				<Geochart query={ query } />
+			</StatsConnectedModule>
 		);
 	}
-} );
+}
+
+export default localize( StatCountries );

--- a/client/my-sites/stats/stats-download-csv/index.jsx
+++ b/client/my-sites/stats/stats-download-csv/index.jsx
@@ -33,8 +33,7 @@ class StatsDownloadCsv extends Component {
 
 	downloadCsv = ( event ) => {
 		event.preventDefault();
-		const { dataList, siteSlug, path, period } = this.props;
-		const data = dataList.csvData();
+		const { siteSlug, path, period, data } = this.props;
 
 		const fileName = [
 			siteSlug,
@@ -87,7 +86,7 @@ const connectComponent = connect( ( state, ownProps ) => {
 		isLoading = dataList.isLoading();
 	} else {
 		data = getSiteStatsCSVData( state, siteId, statType, query );
-		isLoading = isRequestingSiteStatsForQuery( state, siteId, statType, query );
+		isLoading = isRequestingSiteStatsForQuery( state, siteId, statType, query ) && ! data;
 	}
 
 	return { data, siteSlug, siteId, isLoading };

--- a/client/my-sites/stats/stats-download-csv/index.jsx
+++ b/client/my-sites/stats/stats-download-csv/index.jsx
@@ -86,7 +86,7 @@ const connectComponent = connect( ( state, ownProps ) => {
 		isLoading = dataList.isLoading();
 	} else {
 		data = getSiteStatsCSVData( state, siteId, statType, query );
-		isLoading = isRequestingSiteStatsForQuery( state, siteId, statType, query ) && ! data;
+		isLoading = isRequestingSiteStatsForQuery( state, siteId, statType, query ) && ! data.length;
 	}
 
 	return { data, siteSlug, siteId, isLoading };

--- a/client/my-sites/stats/stats-download-csv/index.jsx
+++ b/client/my-sites/stats/stats-download-csv/index.jsx
@@ -55,15 +55,16 @@ class StatsDownloadCsv extends Component {
 	}
 
 	render() {
-		const { siteId, statType, query, translate, isLoading } = this.props;
+		const { data, siteId, statType, query, translate, isLoading } = this.props;
 		try {
 			const isFileSaverSupported = !! new Blob(); // eslint-disable-line no-unused-vars
 		} catch ( e ) {
 			return null;
 		}
+		const disabled = isLoading || ! data.length;
 
 		return (
-			<Button compact onClick={ this.downloadCsv } disabled={ isLoading }>
+			<Button compact onClick={ this.downloadCsv } disabled={ disabled }>
 				{ siteId && statType && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
 				<Gridicon icon="cloud-download" /> { translate( 'Download data as CSV', {
 					context: 'Action shown in stats to download data as csv.'
@@ -86,7 +87,7 @@ const connectComponent = connect( ( state, ownProps ) => {
 		isLoading = dataList.isLoading();
 	} else {
 		data = getSiteStatsCSVData( state, siteId, statType, query );
-		isLoading = isRequestingSiteStatsForQuery( state, siteId, statType, query ) && ! data.length;
+		isLoading = isRequestingSiteStatsForQuery( state, siteId, statType, query );
 	}
 
 	return { data, siteSlug, siteId, isLoading };

--- a/client/my-sites/stats/stats-list/index.jsx
+++ b/client/my-sites/stats/stats-list/index.jsx
@@ -40,27 +40,28 @@ module.exports = React.createClass( {
 				}
 			);
 
-		results = groups.map( function( group, groupIndex ) {
-			var childResults,
-				active,
-				groupTree = parentKey ? [ parentKey ] : [],
-				groupKey,
-				clickHandler = this.props.clickHandler ? this.props.clickHandler : false;
+		if ( groups ) {
+			results = groups.map( function( group, groupIndex ) {
+				var childResults,
+					active,
+					groupTree = parentKey ? [ parentKey ] : [],
+					groupKey,
+					clickHandler = this.props.clickHandler ? this.props.clickHandler : false;
 
-			// Build a unique key for this group
-			groupTree.push( groupIndex );
-			groupKey = groupTree.join( ':' );
+				// Build a unique key for this group
+				groupTree.push( groupIndex );
+				groupKey = groupTree.join( ':' );
 
-			// Determine if child data exists and setup css classes accoridingly
-			active = this.isGroupActive( groupKey );
+				// Determine if child data exists and setup css classes accoridingly
+				active = this.isGroupActive( groupKey );
 
-			// If this group has results, build up the nested child ul/li elements
-			if ( group.children ) {
-				childResults = this.buildLists( group.children, groupKey );
-			}
-
-			return <StatsListItem moduleName={ this.props.moduleName } data={ group } active={ active } children={ childResults } key={ groupKey } itemClickHandler={ clickHandler } followList={ this.props.followList } />;
-		}, this );
+				// If this group has results, build up the nested child ul/li elements
+				if ( group.children ) {
+					childResults = this.buildLists( group.children, groupKey );
+				}
+				return <StatsListItem moduleName={ this.props.moduleName } data={ group } active={ active } children={ childResults } key={ groupKey } itemClickHandler={ clickHandler } followList={ this.props.followList } />;
+			}, this );
+		}
 
 		return ( <ul className={ listClass }>{ results }</ul> );
 	},

--- a/client/my-sites/stats/stats-module/connected-list.js
+++ b/client/my-sites/stats/stats-module/connected-list.js
@@ -59,11 +59,11 @@ class StatsConnectedModule extends Component {
 	}
 
 	getHref() {
-		const { summary, period, path, siteSlug, date } = this.props;
+		const { summary, period, path, siteSlug } = this.props;
 
 		// Some modules do not have view all abilities
 		if ( ! summary && period && path && siteSlug ) {
-			return '/stats/' + period.period + '/' + path + '/' + siteSlug + '?startDate=' + date;
+			return '/stats/' + period.period + '/' + path + '/' + siteSlug + '?startDate=' + period.startOf.format( 'YYYY-MM-DD' );
 		}
 	}
 
@@ -111,6 +111,7 @@ class StatsConnectedModule extends Component {
 				<Card compact className={ cardClasses }>
 					{ noData && <ErrorPanel message={ moduleStrings.empty } /> }
 					{ hasError && <ErrorPanel /> }
+					{ this.props.children }
 					<StatsListLegend value={ moduleStrings.value } label={ moduleStrings.item } />
 					<StatsModulePlaceholder isLoading={ isLoading } />
 					<StatsList moduleName={ path } data={ data } />

--- a/client/my-sites/stats/stats-module/connected-list.js
+++ b/client/my-sites/stats/stats-module/connected-list.js
@@ -4,6 +4,7 @@
 import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -18,6 +19,7 @@ import Card from 'components/card';
 import StatsModulePlaceholder from './placeholder';
 import SectionHeader from 'components/section-header';
 import QuerySiteStats from 'components/data/query-site-stats';
+import UpgradeNudge from 'my-sites/upgrade-nudge';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import {
@@ -37,7 +39,8 @@ class StatsConnectedModule extends Component {
 		data: PropTypes.array,
 		query: PropTypes.object,
 		statType: PropTypes.string,
-		showSummaryLink: PropTypes.bool
+		showSummaryLink: PropTypes.bool,
+		translate: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -80,6 +83,7 @@ class StatsConnectedModule extends Component {
 			statType,
 			query,
 			period,
+			translate,
 		} = this.props;
 
 		const noData = (
@@ -120,6 +124,14 @@ class StatsConnectedModule extends Component {
 					<StatsModulePlaceholder isLoading={ isLoading } />
 					<StatsList moduleName={ path } data={ data } />
 					{ this.props.showSummaryLink && <StatsModuleExpand href={ summaryLink } /> }
+					{ summary && 'countryviews' === path &&
+						<UpgradeNudge
+							title={ translate( 'Add Google Analytics' ) }
+							message={ translate( 'Upgrade to a Business Plan for Google Analytics integration.' ) }
+							event="googleAnalytics-stats-countries"
+							feature="google-analytics"
+						/>
+					}
 				</Card>
 			</div>
 
@@ -138,4 +150,4 @@ export default connect( ( state, ownProps ) => {
 		siteId,
 		siteSlug
 	};
-} )( StatsConnectedModule );
+} )( localize( StatsConnectedModule ) );

--- a/client/my-sites/stats/stats-module/connected-list.js
+++ b/client/my-sites/stats/stats-module/connected-list.js
@@ -13,6 +13,7 @@ import StatsModuleExpand from './expand';
 import StatsList from '../stats-list';
 import StatsListLegend from '../stats-list/legend';
 import DatePicker from '../stats-date-picker';
+import DownloadCsv from '../stats-download-csv';
 import Card from 'components/card';
 import StatsModulePlaceholder from './placeholder';
 import SectionHeader from 'components/section-header';
@@ -77,7 +78,8 @@ class StatsConnectedModule extends Component {
 			moduleStrings,
 			requesting,
 			statType,
-			query
+			query,
+			period,
 		} = this.props;
 
 		const noData = (
@@ -107,7 +109,9 @@ class StatsConnectedModule extends Component {
 		return (
 			<div>
 				{ siteId && statType && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
-				<SectionHeader label={ this.getModuleLabel() } href={ ! summary ? summaryLink : null } />
+				<SectionHeader label={ this.getModuleLabel() } href={ ! summary ? summaryLink : null }>
+					{ summary && <DownloadCsv statType={ statType } query={ query } path={ path } period={ period } /> }
+				</SectionHeader>
 				<Card compact className={ cardClasses }>
 					{ noData && <ErrorPanel message={ moduleStrings.empty } /> }
 					{ hasError && <ErrorPanel /> }

--- a/client/my-sites/stats/stats-module/expand.jsx
+++ b/client/my-sites/stats/stats-module/expand.jsx
@@ -2,8 +2,9 @@
  * External dependencies
  */
 import React, { PureComponent } from 'react';
+import { localize } from 'i18n-calypso';
 
-export default class StatsModuleExpand extends PureComponent {
+class StatsModuleExpand extends PureComponent {
 	static propTypes = {
 		href: React.PropTypes.string
 	};
@@ -16,10 +17,12 @@ export default class StatsModuleExpand extends PureComponent {
 		return (
 			<div className="stats-module__expand">
 				<a href={ this.props.href }>
-					{ this.translate( 'View All', { context: 'Stats: Button label to expand a panel' } ) }
+					{ this.props.translate( 'View All', { context: 'Stats: Button label to expand a panel' } ) }
 					<span className="stats-module__expand-right"></span>
 				</a>
 			</div>
 		);
 	}
 }
+
+export default localize( StatsModuleExpand );

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -2,6 +2,12 @@
 @import 'placeholder';
 @import 'expand';
 
+.stats-module {
+	.upgrade-nudge.card {
+		margin: 16px;
+	}
+}
+
 // Select Dropdown
 .stats-module__select-dropdown-wrapper {
 	padding: 16px;

--- a/client/my-sites/stats/stats-strings.js
+++ b/client/my-sites/stats/stats-strings.js
@@ -1,69 +1,79 @@
-var i18n = require( 'i18n-calypso' );
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
 
 module.exports = function() {
-	var statsStrings = {};
+	const statsStrings = {};
 
 	statsStrings.posts = {
-		title: i18n.translate( 'Posts & Pages', { context: 'Stats: title of module' } ),
-		item: i18n.translate( 'Title', { context: 'Stats: module row header for post title.' } ),
-		value: i18n.translate( 'Views', { context: 'Stats: module row header for number of post views.' } ),
-		empty: i18n.translate( 'No posts or pages viewed', { context: 'Stats: Info box label when the Posts & Pages module is empty' } )
+		title: translate( 'Posts & Pages', { context: 'Stats: title of module' } ),
+		item: translate( 'Title', { context: 'Stats: module row header for post title.' } ),
+		value: translate( 'Views', { context: 'Stats: module row header for number of post views.' } ),
+		empty: translate( 'No posts or pages viewed', { context: 'Stats: Info box label when the Posts & Pages module is empty' } )
 	};
 
 	statsStrings.referrers = {
-		title: i18n.translate( 'Referrers', { context: 'Stats: title of module' } ),
-		item: i18n.translate( 'Referrer', { context: 'Stats: module row header for post referrer.' } ),
-		value: i18n.translate( 'Views', { context: 'Stats: module row header for number of post views by referrer.' } ),
-		empty: i18n.translate( 'No referrers recorded', { context: 'Stats: Info box label when the Referrers module is empty' } )
+		title: translate( 'Referrers', { context: 'Stats: title of module' } ),
+		item: translate( 'Referrer', { context: 'Stats: module row header for post referrer.' } ),
+		value: translate( 'Views', { context: 'Stats: module row header for number of post views by referrer.' } ),
+		empty: translate( 'No referrers recorded', { context: 'Stats: Info box label when the Referrers module is empty' } )
 	};
 
 	statsStrings.clicks = {
-		title: i18n.translate( 'Clicks', { context: 'Stats: title of module' } ),
-		item: i18n.translate( 'Link', { context: 'Stats: module row header for links in posts.' } ),
-		value: i18n.translate( 'Clicks', { context: 'Stats: module row header for number of clicks on a given link in a post.' } ),
-		empty: i18n.translate( 'No clicks recorded', { context: 'Stats: Info box label when the Clicks module is empty' } )
+		title: translate( 'Clicks', { context: 'Stats: title of module' } ),
+		item: translate( 'Link', { context: 'Stats: module row header for links in posts.' } ),
+		value: translate( 'Clicks', { context: 'Stats: module row header for number of clicks on a given link in a post.' } ),
+		empty: translate( 'No clicks recorded', { context: 'Stats: Info box label when the Clicks module is empty' } )
+	};
+
+	statsStrings.countries = {
+		title: translate( 'Countries', { context: 'Stats: title of module' } ),
+		item: translate( 'Country', { context: 'Stats: module row header for views by country.' } ),
+		value: translate( 'Views', { context: 'Stats: module row header for number of views from a country.' } ),
+		empty: translate( 'No countries recorded', { context: 'Stats: Info box label when the Countries module is empty' } )
 	};
 
 	statsStrings.search = {
-		title: i18n.translate( 'Search Terms', { context: 'Stats: title of module' } ),
-		item: i18n.translate( 'Search Term', { context: 'Stats: module row header for search in search terms.' } ),
-		value: i18n.translate( 'Views', { context: 'Stats: module row header for views of a given search in search terms.' } ),
-		empty: i18n.translate( 'No search terms recorded', { context: 'Stats: Info box label when the Search Terms module is empty' } )
+		title: translate( 'Search Terms', { context: 'Stats: title of module' } ),
+		item: translate( 'Search Term', { context: 'Stats: module row header for search in search terms.' } ),
+		value: translate( 'Views', { context: 'Stats: module row header for views of a given search in search terms.' } ),
+		empty: translate( 'No search terms recorded', { context: 'Stats: Info box label when the Search Terms module is empty' } )
 	};
 
 	statsStrings.authors = {
-		title: i18n.translate( 'Authors', { context: 'Stats: title of module' } ),
-		item: i18n.translate( 'Author', { context: 'Stats: module row header for authors.' } ),
-		value: i18n.translate( 'Views', { context: 'Stats: module row header for number of views per author.' } ),
-		empty: i18n.translate( 'No posts or pages viewed', { context: 'Stats: Info box label when the Authors module is empty' } )
+		title: translate( 'Authors', { context: 'Stats: title of module' } ),
+		item: translate( 'Author', { context: 'Stats: module row header for authors.' } ),
+		value: translate( 'Views', { context: 'Stats: module row header for number of views per author.' } ),
+		empty: translate( 'No posts or pages viewed', { context: 'Stats: Info box label when the Authors module is empty' } )
 	};
 
 	statsStrings.videoplays = {
-		title: i18n.translate( 'Videos', { context: 'Stats: title of module' } ),
-		item: i18n.translate( 'Video', { context: 'Stats: module row header for videos.' } ),
-		value: i18n.translate( 'Plays', { context: 'Stats: module row header for number of plays per video.' } ),
-		empty: i18n.translate( 'No videos played', { context: 'Stats: Info box label when the Videos module is empty' } )
+		title: translate( 'Videos', { context: 'Stats: title of module' } ),
+		item: translate( 'Video', { context: 'Stats: module row header for videos.' } ),
+		value: translate( 'Plays', { context: 'Stats: module row header for number of plays per video.' } ),
+		empty: translate( 'No videos played', { context: 'Stats: Info box label when the Videos module is empty' } )
 	};
 
 	statsStrings.podcastdownloads = {
-		title: i18n.translate( 'Podcasts', { context: 'Stats: title of module' } ),
-		item: i18n.translate( 'Episodes', { context: 'Stats: module row header for podcast.' } ),
-		value: i18n.translate( 'Downloads', { context: 'Stats: module row header for number of downloads per podcast episode.' } ),
-		empty: i18n.translate( 'No episodes downloaded', { context: 'Stats: Info box label when the Podcasts module is empty' } )
+		title: translate( 'Podcasts', { context: 'Stats: title of module' } ),
+		item: translate( 'Episodes', { context: 'Stats: module row header for podcast.' } ),
+		value: translate( 'Downloads', { context: 'Stats: module row header for number of downloads per podcast episode.' } ),
+		empty: translate( 'No episodes downloaded', { context: 'Stats: Info box label when the Podcasts module is empty' } )
 	};
 
 	statsStrings.tags = {
-		title: i18n.translate( 'Tags & Categories', { context: 'Stats: title of module' } ),
-		item: i18n.translate( 'Topic', { context: 'Stats: module row header for tags and categories.' } ),
-		value: i18n.translate( 'Views', { context: 'Stats: module row header for number of views per tag or category.' } ),
-		empty: i18n.translate( 'No tagged posts or pages viewed', { context: 'Stats: Info box label when the Tags module is empty' } )
+		title: translate( 'Tags & Categories', { context: 'Stats: title of module' } ),
+		item: translate( 'Topic', { context: 'Stats: module row header for tags and categories.' } ),
+		value: translate( 'Views', { context: 'Stats: module row header for number of views per tag or category.' } ),
+		empty: translate( 'No tagged posts or pages viewed', { context: 'Stats: Info box label when the Tags module is empty' } )
 	};
 
 	statsStrings.publicize = {
-		title: i18n.translate( 'Publicize', { context: 'Stats: title of module' } ),
-		item: i18n.translate( 'Service', { context: 'Stats: module row header for publicize service.' } ),
-		value: i18n.translate( 'Followers', { context: 'Stats: module row header for number of followers on the service.' } ),
-		empty: i18n.translate( 'No publicize followers recorded', { context: 'Stats: Info box label when the publicize module is empty' } )
+		title: translate( 'Publicize', { context: 'Stats: title of module' } ),
+		item: translate( 'Service', { context: 'Stats: module row header for publicize service.' } ),
+		value: translate( 'Followers', { context: 'Stats: module row header for number of followers on the service.' } ),
+		empty: translate( 'No publicize followers recorded', { context: 'Stats: Info box label when the publicize module is empty' } )
 	};
 
 	return statsStrings;

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -72,6 +72,12 @@ const StatsSummary = React.createClass( {
 		let barChart;
 
 		debug( 'Rendering summary-top-posts.jsx', this.props );
+		const { period, endOf } = this.props.period;
+		const query = {
+			period: period,
+			date: endOf.format( 'YYYY-MM-DD' ),
+			max: 0
+		};
 
 		switch ( this.props.context.params.module ) {
 
@@ -102,12 +108,11 @@ const StatsSummary = React.createClass( {
 			case 'countryviews':
 				title = translate( 'Countries' );
 				summaryView = <Countries
-					key="countries-summary"
-					path="countryviews"
-					site={ site }
-					dataList={ this.props.summaryList }
-					period={ this.props.period }
-					summary={ true } />;
+						key="countries-summary"
+						path="countryviews"
+						period={ this.props.period }
+						query={ query }
+						summary={ true } />;
 				break;
 
 			case 'posts':

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -186,5 +186,7 @@ export function getSiteStatsCSVData( state, siteId, statType, query ) {
 		return [];
 	}
 
-	return flatten( map( data, buildExportArray ) );
+	return flatten( map( data, ( item ) => {
+		return buildExportArray( item );
+	} ) );
 }

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -290,22 +290,22 @@ describe( 'utils', () => {
 		} );
 
 		describe( 'statsCountryViews()', () => {
-			it( 'should return an empty array if data is null', () => {
+			it( 'should return null if data is null', () => {
 				const parsedData = normalizers.statsCountryViews();
 
-				expect( parsedData ).to.eql( [] );
+				expect( parsedData ).to.be.null;
 			} );
 
-			it( 'should return an empty array if query.period is null', () => {
+			it( 'should return null if query.period is null', () => {
 				const parsedData = normalizers.statsCountryViews( {}, { date: '2016-12-25' } );
 
-				expect( parsedData ).to.eql( [] );
+				expect( parsedData ).to.be.null;
 			} );
 
-			it( 'should return an empty array if query.date is null', () => {
+			it( 'should return null if query.date is null', () => {
 				const parsedData = normalizers.statsCountryViews( {}, { period: 'day' } );
 
-				expect( parsedData ).to.eql( [] );
+				expect( parsedData ).to.be.null;
 			} );
 
 			it( 'should properly parse day period response', () => {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -177,7 +177,7 @@ export const normalizers = {
 	statsCountryViews: ( data, query = {} ) => {
 		// parsing a country-views response requires a period and date
 		if ( ! data || ! query.period || ! query.date ) {
-			return [];
+			return null;
 		}
 		const { startOf } = rangeOfPeriod( query.period, query.date );
 		const countryInfo = get( data, [ 'country-info' ], {} );


### PR DESCRIPTION
This branch is still in-progress and will be blocked by probably a few more forthcoming branches.

TODO:
- [x] Fix stats normalizer tests
- [x] Add `UpgradeNudge` logic back
- [x] Create selector for state-tree based CSV data - #10509
- [x] Update `<DownloadCSV/>` to use state data - #10510

@youknowriad if you have time and want to check out this branch so far, that would be great.

__To Test__
- Open a site stats day page for a site with visits data
- Note the countries module loads as expected and displays the same data as production
- Try to make sure the loading indicators also show as expected, it helps to have the API sandboxed which slows things down
- Click on the 'View All' link or the title bar to visit the Countries Summary page.  