### PR TITLE
Testing: Warn against likely erroneous test path

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1793,6 +1793,9 @@
         }
       }
     },
+    "has-color": {
+      "version": "0.1.7"
+    },
     "has-cors": {
       "version": "1.1.0"
     },
@@ -2688,6 +2691,9 @@
       "dependencies": {
         "minimatch": {
           "version": "3.0.3"
+        },
+        "npmlog": {
+          "version": "3.1.2"
         }
       }
     },
@@ -2767,7 +2773,15 @@
       }
     },
     "npmlog": {
-      "version": "4.0.2"
+      "version": "4.0.2",
+      "dependencies": {
+        "gauge": {
+          "version": "2.7.2"
+        },
+        "supports-color": {
+          "version": "0.2.0"
+        }
+      }
     },
     "nth-check": {
       "version": "1.0.1",
@@ -3255,6 +3269,10 @@
           "version": "2.2.2"
         }
       }
+    },
+    "readline-sync": {
+      "version": "1.4.5",
+      "dev": true
     },
     "readline2": {
       "version": "1.0.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1492,7 +1492,7 @@
       "version": "2.1.1"
     },
     "fbjs": {
-      "version": "0.8.8",
+      "version": "0.8.9",
       "dependencies": {
         "core-js": {
           "version": "1.2.7"
@@ -1792,9 +1792,6 @@
           "version": "0.0.1"
         }
       }
-    },
-    "has-color": {
-      "version": "0.1.7"
     },
     "has-cors": {
       "version": "1.1.0"
@@ -2691,9 +2688,6 @@
       "dependencies": {
         "minimatch": {
           "version": "3.0.3"
-        },
-        "npmlog": {
-          "version": "3.1.2"
         }
       }
     },
@@ -2773,15 +2767,7 @@
       }
     },
     "npmlog": {
-      "version": "4.0.2",
-      "dependencies": {
-        "gauge": {
-          "version": "2.7.2"
-        },
-        "supports-color": {
-          "version": "0.2.0"
-        }
-      }
+      "version": "4.0.2"
     },
     "nth-check": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -183,6 +183,7 @@
     "react-addons-test-utils": "15.4.0",
     "react-hot-loader": "1.3.0",
     "react-test-env": "0.2.0",
+    "readline-sync": "1.4.5",
     "sinon": "1.17.6",
     "sinon-chai": "2.8.0",
     "socket.io": "1.4.5",

--- a/test/runner.js
+++ b/test/runner.js
@@ -76,7 +76,6 @@ files = files.reduce( ( memo, filePath ) => {
 				path.basename( filePath )
 			);
 
-			console.warn( pathGuess );
 			if ( fs.existsSync( pathGuess ) ) {
 				console.warn(
 					chalk.red.bold( 'WARNING:' ),

--- a/test/runner.js
+++ b/test/runner.js
@@ -89,7 +89,11 @@ files = files.reduce( ( memo, filePath ) => {
 					chalk.blue( filePath )
 				);
 
-				if ( true === readlineSync.keyInYN( 'Y to continue, any other key to abort: ' ) ) {
+				// if we are in an interactive shell
+				// then ask the developer if the guessed file
+				// was the intended file and allow that guess
+				// to replace the accidentally-requested file
+				if ( process.stdout.isTTY && true === readlineSync.keyInYN( 'Y to continue, any other key to abort: ' ) ) {
 					return memo.concat( pathGuess );
 				}
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -81,11 +81,11 @@ files = files.reduce( ( memo, filePath ) => {
 					chalk.red.bold( 'WARNING:' ),
 					chalk.yellow(
 						'It appears that you\'re trying to use the test runner ' +
-						'on a file under test, not the test file itself.\n'
+						'on a file under test, not the test file itself.'
 					),
-					chalk.green( 'Did you mean to run against…\n\t' ),
+					chalk.green( '\n Did you mean to run against…\n  ' ),
 					chalk.blue( pathGuess ),
-					chalk.green( '\n…instead of…\n\t' ),
+					chalk.green( '\n …instead of…\n  ' ),
 					chalk.blue( filePath )
 				);
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -89,7 +89,7 @@ files = files.reduce( ( memo, filePath ) => {
 					chalk.blue( filePath )
 				);
 
-				if ( 'Y' === readlineSync.question( 'Y to continue, N to abort: ' ).toUpperCase() ) {
+				if ( true === readlineSync.keyInYN( 'Y to continue, any other key to abort: ' ) ) {
 					return memo.concat( pathGuess );
 				}
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -65,6 +65,14 @@ files = files.reduce( ( memo, filePath ) => {
 
 	// Append individual file argument
 	if ( /\.jsx?$/i.test( filePath ) ) {
+		if ( ! filePath.includes( '/test/' ) ) {
+			console.warn(
+				chalk.red.bold( 'WARNING:' ),
+				chalk.yellow( 'It appears you\'re trying to use the test runner on a file under test, not a test file.\n  Try:' ),
+				chalk.green( `npm run test-client ${ filePath.replace( /\/([^\/]*)$/, '/test/$1' ) }\n` )
+			);
+		}
+
 		return memo.concat( filePath );
 	}
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -69,7 +69,7 @@ files = files.reduce( ( memo, filePath ) => {
 			console.warn(
 				chalk.red.bold( 'WARNING:' ),
 				chalk.yellow( 'It appears you\'re trying to use the test runner on a file under test, not a test file.\n  Try:' ),
-				chalk.green( `npm run test-client ${ filePath.replace( /\/([^\/]*)$/, '/test/$1' ) }\n` )
+				chalk.green( `npm run test-${ process.env.TEST_ROOT } ${ filePath.replace( /\/([^\/]*)$/, '/test/$1' ) }\n` )
 			);
 		}
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-'use strict'; // eslint-disable-line strict
+/* eslint-disable strict, no-process-exit */
+'use strict';
 let files;
 
 require( 'babel-register' );
@@ -93,7 +94,7 @@ files = files.reduce( ( memo, filePath ) => {
 					return memo.concat( pathGuess );
 				}
 
-				process.exit( 1 ); // eslint-disable-line no-process-exit
+				process.exit( 1 );
 			}
 
 			console.warn(
@@ -102,7 +103,7 @@ files = files.reduce( ( memo, filePath ) => {
 				chalk.blue( filePath )
 			);
 
-			process.exit( 1 ); // eslint-disable-line no-process-exit
+			process.exit( 1 );
 		}
 
 		return memo.concat( filePath );
@@ -131,6 +132,6 @@ mocha.addFile( path.join( __dirname, 'load-suite.js' ) );
 
 mocha.run( function( failures ) {
 	process.on( 'exit', function() {
-		process.exit( failures ); //eslint-disable-line no-process-exit
+		process.exit( failures );
 	} );
 } );


### PR DESCRIPTION
This pull request seeks to improve the test runner script to detect if an individual file argument passed is likely incorrect in that it is not the child of a test directory.

![Warning](https://cloud.githubusercontent.com/assets/1779930/21738965/ba82dd12-d45c-11e6-92cd-87d14ac04735.png)

__Testing instructions:__

Verify that a warning is shown only if trying to run the test script with an individual js(x) file that does not contain tests.