### PR TITLE
Filter premium themes on wpcom list for jetpack.

### DIFF
--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { pickBy } from 'lodash';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -22,6 +23,8 @@ import ThemesSelection from './themes-selection';
 import ThemeUploadCard from './themes-upload-card';
 import { addTracking } from './helpers';
 import { translate } from 'i18n-calypso';
+import { hasFeature } from 'state/sites/plans/selectors';
+import { FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
 
 const ConnectedThemesSelection = connectOptions(
 	( props ) => {
@@ -37,7 +40,7 @@ const ConnectedThemesSelection = connectOptions(
 	}
 );
 
-export default connectOptions(
+const ConnectedSingleSiteJetpack = connectOptions(
 	( props ) => {
 		const {
 			analyticsPath,
@@ -46,7 +49,7 @@ export default connectOptions(
 			search,
 			site,
 			siteId,
-			tier,
+			wpcomTier,
 			filter,
 			vertical
 		} = props;
@@ -94,7 +97,7 @@ export default connectOptions(
 									'tryAndCustomizeOnJetpack'
 								] }
 								search={ search }
-								tier={ tier }
+								tier={ wpcomTier }
 								filter={ filter }
 								vertical={ vertical }
 								siteId = { siteId /* This is for the options in the '...' menu only */ }
@@ -123,3 +126,11 @@ export default connectOptions(
 		);
 	}
 );
+
+export default connect(
+	( state, { siteId, tier } ) => {
+		return {
+			wpcomTier: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ) ? tier : 'free'
+		};
+	}
+)( ConnectedSingleSiteJetpack );


### PR DESCRIPTION
### Info
It is not possible to install Premium WordPress.com theme on Jetpack so we should hide those themes.
Does themes should still be visible for Pressable.

### Before
![image](https://cloud.githubusercontent.com/assets/17271089/21741586/2a7b7952-d4db-11e6-810a-209e65e33567.png)

### After
![image](https://cloud.githubusercontent.com/assets/17271089/21741592/4cbfcb80-d4db-11e6-9362-c6f6df638ff2.png)

### Testing
Open Jetpack site. `WordPress.com` themes list should not have Premium themes visible.