### PR TITLE
Refactor location of themes upload card. 

### DIFF
--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -16,7 +16,7 @@ const MultiSiteThemeShowcase = connectOptions(
 		<div>
 			<SidebarNavigation />
 			<ThemesSiteSelectorModal { ...props } sourcePath="/design">
-				<ThemeShowcase source="showcase" hideUploadButton={ true } />
+				<ThemeShowcase source="showcase" showUploadButton={ false } />
 			</ThemesSiteSelectorModal>
 		</div>
 	)

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -16,7 +16,7 @@ const MultiSiteThemeShowcase = connectOptions(
 		<div>
 			<SidebarNavigation />
 			<ThemesSiteSelectorModal { ...props } sourcePath="/design">
-				<ThemeShowcase source="showcase" />
+				<ThemeShowcase source="showcase" hideUploadButton={ true } />
 			</ThemesSiteSelectorModal>
 		</div>
 	)

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -98,7 +98,7 @@ const ConnectedSingleSiteJetpack = connectOptions(
 								vertical={ vertical }
 								siteId={ siteId /* This is for the options in the '...' menu only */ }
 								listLabel={ translate( 'WordPress.com themes' ) }
-								hideUploadButton={ true }
+								showUploadButton={ false }
 								getScreenshotUrl={ function( theme ) {
 									if ( ! getScreenshotOption( theme ).getUrl ) {
 										return null;

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -20,7 +20,6 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
 import ThemesSelection from './themes-selection';
-import ThemeUploadCard from './themes-upload-card';
 import { addTracking } from './helpers';
 import { translate } from 'i18n-calypso';
 import { hasFeature } from 'state/sites/plans/selectors';
@@ -88,9 +87,6 @@ const ConnectedSingleSiteJetpack = connectOptions(
 						source={ 'list' } />
 					{ config.isEnabled( 'manage/themes/upload' ) &&
 						<div>
-							<ThemeUploadCard
-								label={ translate( 'WordPress.com themes' ) }
-							/>
 							<ConnectedThemesSelection
 								options={ [
 									'activateOnJetpack',
@@ -100,7 +96,9 @@ const ConnectedSingleSiteJetpack = connectOptions(
 								tier={ wpcomTier }
 								filter={ filter }
 								vertical={ vertical }
-								siteId = { siteId /* This is for the options in the '...' menu only */ }
+								siteId={ siteId /* This is for the options in the '...' menu only */ }
+								listLabel={ translate( 'WordPress.com themes' ) }
+								hideUploadButton={ true }
 								getScreenshotUrl={ function( theme ) {
 									if ( ! getScreenshotOption( theme ).getUrl ) {
 										return null;

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -48,8 +48,7 @@ const SingleSiteThemeShowcaseWithOptions = ( props ) => {
 				defaultOption="activate"
 				secondaryOption="tryandcustomize"
 				source="showcase"
-				showUploadButton={ true }
-				uploadLabel={ translate( 'Custom themes' ) }
+				listLabel={ translate( 'Custom themes' ) }
 			/>
 		);
 	}
@@ -72,8 +71,7 @@ const SingleSiteThemeShowcaseWithOptions = ( props ) => {
 			defaultOption="activate"
 			secondaryOption="tryandcustomize"
 			source="showcase"
-			showUploadButton={ true }
-			uploadLabel={ translate( 'WordPress.com themes' ) }
+			listLabel={ translate( 'WordPress.com themes' ) }
 		/>
 	);
 };

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -70,7 +70,7 @@ const ThemeShowcase = React.createClass( {
 		return {
 			tier: '',
 			search: '',
-			showUploadButton: false
+			showUploadButton: true
 		};
 	},
 
@@ -197,7 +197,7 @@ const ThemeShowcase = React.createClass( {
 					vertical={ this.props.vertical }
 					siteId={ this.props.siteId }
 					listLabel={ this.props.listLabel }
-					hideUploadButton={ this.props.hideUploadButton }
+					showUploadButton={ this.props.showUploadButton }
 					getScreenshotUrl={ function( theme ) {
 						if ( ! getScreenshotOption( theme ).getUrl ) {
 							return null;

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -20,7 +20,6 @@ import DocumentHead from 'components/data/document-head';
 import { getFilter, getSortedFilterTerms, stripFilters } from './theme-filters.js';
 import buildUrl from 'lib/mixins/url-search/build-url';
 import { getSiteSlug } from 'state/sites/selectors';
-import ThemeUploadCard from './themes-upload-card';
 import config from 'config';
 
 const ThemesSearchCard = config.isEnabled( 'manage/themes/magic-search' )
@@ -191,18 +190,13 @@ const ThemeShowcase = React.createClass( {
 						tier={ tier }
 						select={ this.onTierSelect } />
 				</StickyPanel>
-				{ this.props.showUploadButton && config.isEnabled( 'manage/themes/upload' ) &&
-					<ThemeUploadCard
-						href={ `/design/upload/${ this.props.siteSlug }` }
-						label={ this.props.uploadLabel }
-					/>
-				}
 				<ThemesSelection
 					search={ search }
 					tier={ this.props.tier }
 					filter={ filter }
 					vertical={ this.props.vertical }
 					siteId={ this.props.siteId }
+					listLabel={ this.props.listLabel }
 					getScreenshotUrl={ function( theme ) {
 						if ( ! getScreenshotOption( theme ).getUrl ) {
 							return null;

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -197,6 +197,7 @@ const ThemeShowcase = React.createClass( {
 					vertical={ this.props.vertical }
 					siteId={ this.props.siteId }
 					listLabel={ this.props.listLabel }
+					hideUploadButton={ this.props.hideUploadButton }
 					getScreenshotUrl={ function( theme ) {
 						if ( ! getScreenshotOption( theme ).getUrl ) {
 							return null;

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -42,12 +42,19 @@ const ThemesSelection = React.createClass( {
 			PropTypes.number,
 			PropTypes.oneOf( [ 'wpcom' ] )
 		] ),
+		showUploadButton: PropTypes.bool,
 		themes: PropTypes.array,
 		isRequesting: PropTypes.bool,
 		isLastPage: PropTypes.bool,
 		isThemeActive: PropTypes.func,
 		isThemePurchased: PropTypes.func,
 		isInstallingTheme: PropTypes.func
+	},
+
+	getDefaultProps() {
+		return {
+			showUploadButton: true
+		};
 	},
 
 	componentWillReceiveProps( nextProps ) {
@@ -102,7 +109,7 @@ const ThemesSelection = React.createClass( {
 	},
 
 	render() {
-		const { siteIdOrWpcom, query, listLabel, hideUploadButton } = this.props;
+		const { siteIdOrWpcom, query, listLabel, showUploadButton } = this.props;
 
 		return (
 			<div className="themes__selection">
@@ -112,7 +119,7 @@ const ThemesSelection = React.createClass( {
 				{ config.isEnabled( 'manage/themes/upload' ) &&
 					<ThemeUploadCard
 						label={ listLabel }
-						href={ hideUploadButton ? null : `/design/upload/${ this.props.siteSlug }` }
+						href={ showUploadButton ? `/design/upload/${ this.props.siteSlug }` : null }
 					/>
 				}
 				<ThemesList themes={ this.props.themes }

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -11,9 +11,11 @@ import { compact, isEqual, omit } from 'lodash';
 import { trackClick } from './helpers';
 import QueryThemes from 'components/data/query-themes';
 import ThemesList from 'components/themes-list';
+import ThemeUploadCard from './themes-upload-card';
 import analytics from 'lib/analytics';
 import { isJetpackSite } from 'state/sites/selectors';
 import { hasFeature } from 'state/sites/plans/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 import {
 	getThemesForQueryIgnoringPage,
 	isRequestingThemesForQuery,
@@ -23,6 +25,7 @@ import {
 	isInstallingTheme
 } from 'state/themes/selectors';
 import config from 'config';
+import { localize } from 'i18n-calypso';
 import { FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
 import { PAGINATION_QUERY_KEYS } from 'lib/query-manager/paginated/constants';
 
@@ -100,13 +103,17 @@ const ThemesSelection = React.createClass( {
 	},
 
 	render() {
-		const { siteIdOrWpcom, query } = this.props;
+		const { siteIdOrWpcom, query, listLabel, hideUploadButton } = this.props;
 
 		return (
 			<div className="themes__selection">
 				<QueryThemes
 					query={ query }
 					siteId={ siteIdOrWpcom } />
+				<ThemeUploadCard
+					label={ listLabel }
+					href={ hideUploadButton ? null : `/design/upload/${ this.props.siteSlug }` }
+				/>
 				<ThemesList themes={ this.props.themes }
 					fetchNextPage={ this.fetchNextPage }
 					getButtonOptions={ this.props.getOptions }
@@ -145,6 +152,7 @@ const ConnectedThemesSelection = connect(
 		return {
 			query,
 			siteIdOrWpcom,
+			siteSlug: getSiteSlug( state, siteId ),
 			themes: getThemesForQueryIgnoringPage( state, siteIdOrWpcom, query ) || [],
 			isRequesting: isRequestingThemesForQuery( state, siteIdOrWpcom, query ),
 			isLastPage: isThemesLastPageForQuery( state, siteIdOrWpcom, query ),
@@ -193,4 +201,4 @@ class ThemesSelectionWithPage extends React.Component {
 	}
 }
 
-export default ThemesSelectionWithPage;
+export default localize( ThemesSelectionWithPage );

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -25,7 +25,6 @@ import {
 	isInstallingTheme
 } from 'state/themes/selectors';
 import config from 'config';
-import { localize } from 'i18n-calypso';
 import { FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
 import { PAGINATION_QUERY_KEYS } from 'lib/query-manager/paginated/constants';
 
@@ -201,4 +200,4 @@ class ThemesSelectionWithPage extends React.Component {
 	}
 }
 
-export default localize( ThemesSelectionWithPage );
+export default ThemesSelectionWithPage;

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -109,10 +109,12 @@ const ThemesSelection = React.createClass( {
 				<QueryThemes
 					query={ query }
 					siteId={ siteIdOrWpcom } />
-				<ThemeUploadCard
-					label={ listLabel }
-					href={ hideUploadButton ? null : `/design/upload/${ this.props.siteSlug }` }
-				/>
+				{ config.isEnabled( 'manage/themes/upload' ) &&
+					<ThemeUploadCard
+						label={ listLabel }
+						href={ hideUploadButton ? null : `/design/upload/${ this.props.siteSlug }` }
+					/>
+				}
 				<ThemesList themes={ this.props.themes }
 					fetchNextPage={ this.fetchNextPage }
 					getButtonOptions={ this.props.getOptions }


### PR DESCRIPTION
### Info
Refactor location of themes upload card. 

This PR does two things:

1. Moves card to the place to which it is logically connected - to the `ThemesSelection`. This allows us to have card always there and no need for additional imports. Useful for WP.com themes on Jetpack list case.

2. Card is now in place where Query component for querying themes is used so we can have direct access to themes count. This is required when we will want to connect found themes counter( in separate PR) to UI in upload card. 

### Testing
Multisite - no lable and no upload
SingleSiteWpcom - label  + upload button
SingleSiteJetpack - firs list has label + uplad, second(wpcom) only label