### PR TITLE
Framework: remove sitesList.getSelectedSite from my-sites/current-sites

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -38,7 +38,7 @@ const CurrentSite = React.createClass( {
 	},
 
 	componentWillMount() {
-		const selectedSite = this.getSelectedSite();
+		const { selectedSite } = this.props;
 
 		if ( selectedSite && ! selectedSite.jetpack ) {
 			UpgradesActions.fetchDomains( selectedSite.ID );
@@ -59,7 +59,7 @@ const CurrentSite = React.createClass( {
 	},
 
 	componentWillUpdate() {
-		const selectedSite = this.getSelectedSite();
+		const { selectedSite } = this.props;
 
 		if ( selectedSite && this.prevSelectedSite !== selectedSite && ! selectedSite.jetpack ) {
 			UpgradesActions.fetchDomains( selectedSite.ID );
@@ -79,18 +79,15 @@ const CurrentSite = React.createClass( {
 		analytics.ga.recordEvent( 'Sidebar', 'Clicked Switch Site' );
 	},
 
-	getSelectedSite: function() {
-		return this.props.selectedSite || this.props.sites.getPrimary();
-	},
-
 	getDomainWarnings: function() {
-		const domainStore = this.state.domainsStore.getBySite( this.getSelectedSite().ID ),
-			domains = domainStore && domainStore.list || [];
+		const { selectedSite: site } = this.props;
+		const domainStore = this.state.domainsStore.getBySite( site.ID );
+		const domains = domainStore && domainStore.list || [];
 
 		return (
 			<DomainWarnings
 				isCompact
-				selectedSite={ this.getSelectedSite() }
+				selectedSite={ site }
 				domains={ domains }
 				ruleWhiteList={ [
 					'unverifiedDomainsCanManage',
@@ -101,7 +98,8 @@ const CurrentSite = React.createClass( {
 					'expiringDomainsCannotManage',
 					'wrongNSMappedDomains',
 					'pendingGappsTosAcceptanceDomains'
-				] } />
+				] }
+			/>
 		);
 	},
 
@@ -111,7 +109,7 @@ const CurrentSite = React.createClass( {
 	},
 
 	render: function() {
-		const site = this.getSelectedSite();
+		const { selectedSite } = this.props;
 
 		if ( ! this.props.sites.initialized ) {
 			return (
@@ -141,9 +139,9 @@ const CurrentSite = React.createClass( {
 						</Button>
 					</span>
 				}
-				{ this.props.selectedSite
+				{ selectedSite
 					? <Site
-						site={ site }
+						site={ selectedSite }
 						homeLink={ true }
 						externalLink={ true }
 						onClick={ this.previewSite }
@@ -151,8 +149,8 @@ const CurrentSite = React.createClass( {
 						tipTarget="site-card-preview" />
 					: <AllSites sites={ this.props.sites.get() } />
 				}
-				{ ! site.jetpack && this.getDomainWarnings() }
-				<SiteNotice site={ site } />
+				{ ! selectedSite.jetpack && this.getDomainWarnings() }
+				<SiteNotice site={ selectedSite } />
 			</Card>
 		);
 	}
@@ -160,9 +158,12 @@ const CurrentSite = React.createClass( {
 
 // TODO: make this pure when sites can be retrieved from the Redux state
 module.exports = connect(
-	( state ) => ( {
-		selectedSite: getSelectedSite( state ),
-	} ),
+	( state, ownProps ) => {
+		const selectedSite = getSelectedSite( state );
+		return {
+			selectedSite: selectedSite || ownProps.sites.getPrimary()
+		};
+	},
 	{ setLayoutFocus },
 	null,
 	{ pure: false }

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -22,6 +22,7 @@ const AllSites = require( 'my-sites/all-sites' ),
 
 import SiteNotice from './notice';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
+import { getSelectedSite } from 'state/ui/selectors';
 
 const CurrentSite = React.createClass( {
 	displayName: 'CurrentSite',
@@ -79,11 +80,7 @@ const CurrentSite = React.createClass( {
 	},
 
 	getSelectedSite: function() {
-		if ( this.props.sites.get().length === 1 ) {
-			return this.props.sites.getPrimary();
-		}
-
-		return this.props.sites.getSelectedSite();
+		return this.props.selectedSite || this.props.sites.getPrimary();
 	},
 
 	getDomainWarnings: function() {
@@ -114,7 +111,7 @@ const CurrentSite = React.createClass( {
 	},
 
 	render: function() {
-		let site;
+		const site = this.getSelectedSite();
 
 		if ( ! this.props.sites.initialized ) {
 			return (
@@ -134,12 +131,6 @@ const CurrentSite = React.createClass( {
 			);
 		}
 
-		if ( this.props.sites.selected ) {
-			site = this.props.sites.getSelectedSite();
-		} else {
-			site = this.props.sites.getPrimary();
-		}
-
 		return (
 			<Card className="current-site">
 				{ this.props.siteCount > 1 &&
@@ -150,7 +141,7 @@ const CurrentSite = React.createClass( {
 						</Button>
 					</span>
 				}
-				{ this.props.sites.selected
+				{ this.props.selectedSite
 					? <Site
 						site={ site }
 						homeLink={ true }
@@ -168,4 +159,11 @@ const CurrentSite = React.createClass( {
 } );
 
 // TODO: make this pure when sites can be retrieved from the Redux state
-module.exports = connect( null, { setLayoutFocus }, null, { pure: false } )( CurrentSite );
+module.exports = connect(
+	( state ) => ( {
+		selectedSite: getSelectedSite( state ),
+	} ),
+	{ setLayoutFocus },
+	null,
+	{ pure: false }
+)( CurrentSite );


### PR DESCRIPTION
### Aims
As part of #8726, this PR removes the usage of `sitesList.getSelectedSite` from `my-sites/current-sites`

Unlike my previous PRs towards #8726 this one looks only to remove `getSelectedSite`, other methods of `sitesList` (`.getPrimary`, `.get` etc. are still in use for the time being).

### Test Plan

- Navigate to any page that shows the my-sites sidebar (http://calypso.localhost:3000/stats/insights/--your-site-- for example)
- Make sure there are no regressions introduced to the 'current-sites' component (shown below)

<img width="234" alt="screen shot 2017-01-08 at 17 23 58" src="https://cloud.githubusercontent.com/assets/4335450/21747776/4dd16c30-d5c7-11e6-8fb9-f5703f175104.png">
