### PR TITLE
Routing: redirect from /checkout to /plans

### DIFF
--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -256,5 +256,8 @@ module.exports = function() {
 			controller.siteSelection,
 			upgradesController.checkout
 		);
+
+		// Visting /checkout without a plan or product should be redirected to /plans
+		page( '/checkout', '/plans' );
 	}
 };


### PR DESCRIPTION
A nice easy one :)

## Aims
Solves #9842, where visiting `/checkout` without any further url segments would show nothing other than the page layout.
Redirects to 'plans' as suggested by @lancewillett :)

## Testing
Directly enter the following urls into your browser...
- `http://calypso.localhost:3000/checkout`: should redirect to `/plans`
- `http://calypso.localhost:3000/checkout/`: should redirect to `/plans`

Existing routes should not be effected:
`/checkout/thank-you/:site/:receiptId?`
`/checkout/features/:feature/:domain/:plan_name?`
`/checkout/thank-you/features/:feature/:site/:receiptId?`