### PR TITLE
Page: Add hierarchical ordering to listing

### DIFF
--- a/client/components/post-list-fetcher/index.jsx
+++ b/client/components/post-list-fetcher/index.jsx
@@ -28,6 +28,7 @@ function queryPosts( props ) {
 		type: props.type || 'post',
 		siteID: props.siteID,
 		status: props.status,
+        hierarchical: props.hierarchical,
 		author: props.author,
 		search: props.search,
 		exclude_tree: props.excludeTree,
@@ -72,6 +73,7 @@ function shouldQueryPosts( props, nextProps ) {
 
 	return props.type !== nextProps.type ||
 		props.status !== nextProps.status ||
+        props.hierarchical !== nextProps.hierarchical ||
 		props.author !== nextProps.author ||
 		props.search !== nextProps.search ||
 		props.excludeTree !== nextProps.excludeTree ||
@@ -91,6 +93,7 @@ PostListFetcher = React.createClass( {
 		children: React.PropTypes.element.isRequired,
 		type: React.PropTypes.string,
 		status: React.PropTypes.string,
+        hierarchical: React.PropTypes.bool,
 		author: React.PropTypes.number,
 		search: React.PropTypes.string,
 		siteID: React.PropTypes.any,

--- a/client/lib/posts/post-list-store.js
+++ b/client/lib/posts/post-list-store.js
@@ -32,6 +32,7 @@ const _defaultQuery = {
 	siteID: false,
 	type: 'post',
 	status: 'publish',
+    hierarchical: false,
 	orderBy: 'date',
 	order: 'DESC',
 	author: false,
@@ -223,7 +224,11 @@ export default function( id ) {
 			_activeList.page++;
 		}
 		_activeList.postIds = priorList;
-		sort();
+
+		// do not sort pages
+        if( ! ( _activeList.query.type === 'page' && _activeList.query.hierarchical ) ) {
+            sort();
+        }
 	}
 
 	// Merge updated posts
@@ -257,7 +262,11 @@ export default function( id ) {
 
 		if ( newPostIds.length ) {
 			_activeList.postIds = _activeList.postIds.concat( newPostIds );
-			sort();
+
+            // do not sort pages
+            if( ! ( _activeList.query.type === 'page' && _activeList.query.hierarchical ) ) {
+                sort();
+            }
 		}
 	}
 
@@ -337,6 +346,7 @@ export default function( id ) {
 			const query = _activeList.query;
 
 			params.status = query.status;
+            params.hierarchical = query.hierarchical;
 			params.order_by = query.orderBy;
 			params.order = query.order;
 			params.author = query.author;
@@ -369,6 +379,7 @@ export default function( id ) {
 			const query = _activeList.query;
 
 			params.status = query.status;
+            params.hierarchical = query.hierarchical;
 			params.author = query.author;
 			params.type = query.type;
 

--- a/client/my-sites/pages/controller.js
+++ b/client/my-sites/pages/controller.js
@@ -22,6 +22,7 @@ var controller = {
 		var Pages = require( 'my-sites/pages/main' ),
 			siteID = route.getSiteFragment( context.path ),
 			status = context.params.status,
+            hierarchical = true,
 			search = context.query.s,
 			basePath = route.sectionify( context.path ),
 			analyticsPageTitle = 'Pages',
@@ -49,6 +50,7 @@ var controller = {
 				context: context,
 				siteID: siteID,
 				status: status,
+                hierarchical: hierarchical,
 				sites: sites,
 				search: search,
 				trackScrollPage: trackScrollPage.bind(

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -27,6 +27,7 @@ var PageList = React.createClass( {
 	propTypes: {
 		context: React.PropTypes.object,
 		search: React.PropTypes.string,
+        hierarchical: React.PropTypes.bool,
 		sites: React.PropTypes.object,
 		siteID: React.PropTypes.any
 	},
@@ -37,6 +38,7 @@ var PageList = React.createClass( {
 				type="page"
 				siteID={ this.props.siteID }
 				status={ mapStatus( this.props.status ) }
+				hierarchical={ this.props.hierarchical }
 				search={ this.props.search }>
 				<Pages
 					{ ...omit( this.props, 'children' ) }
@@ -59,6 +61,7 @@ var Pages = React.createClass( {
 		page: React.PropTypes.number.isRequired,
 		posts: React.PropTypes.array.isRequired,
 		search: React.PropTypes.string,
+        hierarchical: React.PropTypes.bool,
 		siteID: React.PropTypes.any,
 		sites: React.PropTypes.object.isRequired,
 		trackScrollPage: React.PropTypes.func.isRequired,
@@ -71,6 +74,7 @@ var Pages = React.createClass( {
 			loading: false,
 			hasRecentError: false,
 			lastPage: false,
+			hierarchical: false,
 			page: 0,
 			posts: [],
 			trackScrollPage: function() {}
@@ -203,7 +207,7 @@ var Pages = React.createClass( {
 
 		// pages have loaded, sites have loaded, and we have a site instance or are viewing all-sites
 		if ( pages.length && this.props.sites.initialized ) {
-			if ( ! this.props.search ) {
+            if ( ! ( this.props.search || this.props.hierarchical ) ) {
 				// we're listing in reverse chrono. use the markers.
 				pages = this._insertTimeMarkers( pages );
 			}
@@ -211,10 +215,10 @@ var Pages = React.createClass( {
 				if ( ! ( 'site_ID' in page ) ) {
 					return page;
 				}
-					// Get the site the page belongs to
+				// Get the site the page belongs to
 				var site = this.props.sites.getSite( page.site_ID );
 
-					// Render each page
+				// Render each page
 				return (
 						<Page key={ 'page-' + page.global_ID } page={ page } site={ site } multisite={ this.props.siteID === false } />
 					);
@@ -243,7 +247,9 @@ var Pages = React.createClass( {
 
 		return (
 			<div id="pages" className="page-list">
-				{ rows }
+				<div className="page-list__nested-itmes">
+					{ rows }
+				</div>
 				{ this.props.lastPage && pages.length ? <div className="infinite-scroll-end" /> : null }
 			</div>
 		);

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -314,12 +314,7 @@ const Page = React.createClass( {
 		var page = this.props.page,
 			title = page.title || this.translate( '(no title)' ),
 			site = this.props.site || {},
-			canEdit = utils.userCan( 'edit_post', this.props.page ),
-			depthIndicator;
-
-		if ( page.parent ) {
-			depthIndicator = '— ';
-		}
+			canEdit = utils.userCan( 'edit_post', this.props.page );
 
 		const setAsHomepageItem = this.getSetAsHomepageItem();
 		const viewItem = this.getViewItem();
@@ -362,8 +357,13 @@ const Page = React.createClass( {
 			ref="popoverMenuButton" />
 		) : null;
 
+		// calculate depth (children indentation)
+        const indentStyle = {
+            marginLeft: 2 * page.depth + 'em'
+        };
+
 		return (
-			<CompactCard className="page">
+			<CompactCard className="page" style={indentStyle}>
 				{ this.props.multisite ? <SiteIcon site={ site } size={ 34 } /> : null }
 				<a className="page__title"
 					href={ canEdit ? helpers.editLinkForPage( page, site ) : page.URL }
@@ -372,7 +372,6 @@ const Page = React.createClass( {
 						this.translate( 'View %(title)s', { textOnly: true, args: { title: page.title } } ) }
 					onClick={ this.analyticsEvents.pageTitle }
 					>
-					{ depthIndicator }
 					{ this.props.isFrontPage ? <Gridicon icon="house" size={ 18 } /> : null }
 					{ title }
 				</a>
@@ -387,7 +386,6 @@ const Page = React.createClass( {
 					{ this.buildUpdateTemplate() }
 				</ReactCSSTransitionGroup>
 			</CompactCard>
-
 		);
 	},
 

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -18,6 +18,11 @@
 			opacity: 0.3;
 		}
 	}
+
+	.page-list__nested-itmes {
+		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		0 1px 2px lighten( $gray, 30% );
+	}
 }
 
 .page-list__header {

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -119,6 +119,16 @@ class PostTypeList extends Component {
 	}
 
 	cellRendererWrapper( { key, style, ...rest } ) {
+
+        // indent if the entry has depth field
+		if(rest && rest.index ) {
+            const entry = this.props.posts[ rest.index ];
+
+            if(entry && entry.depth) {
+                style.marginLeft = `${entry.depth * 2}rem`;
+            }
+		}
+
 		return (
 			<div key={ key } style={ style }>
 				{ this.renderPostRow( rest ) }

--- a/client/my-sites/types/controller.jsx
+++ b/client/my-sites/types/controller.jsx
@@ -15,12 +15,19 @@ export function redirect() {
 }
 
 export function list( context, next ) {
+	const queryParams = {
+        type: context.params.type,
+        status: mapPostStatus( context.params.status ),
+        search: context.query.s
+	};
+
+	// use hierarchical ordering for pages
+	if(queryParams.type === 'page') {
+		queryParams.hierarchical = 1;
+	}
+
 	context.primary = (
-		<Types query={ {
-			type: context.params.type,
-			status: mapPostStatus( context.params.status ),
-			search: context.query.s
-		} } />
+		<Types query={ queryParams } />
 	);
 
 	next();


### PR DESCRIPTION
I added hierarchical support for pages. In order for this to work `D3508-code` has to be merged on the API side. Client side sorting and time markers were disabled for pages. 
This is my first Calypso PR please feel free to guide me if I missed something :)

Example
<img width="823" alt="screen shot 2017-01-08 at 11 16 47 pm" src="https://cloud.githubusercontent.com/assets/2129455/21753935/380a051e-d5ff-11e6-9750-d36f9f89a691.png">

Updates
* Add field `hierarchical` to API request
* Disable client side sorting of pages
* Disable time markers used for chronological ordering
* Add indentation for children pages similar to taxonomies

Thanks