### PR TITLE
Plugins: Initiate automated transfer

### DIFF
--- a/client/my-sites/plugins-wpcom/plugin-install-button.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-install-button.jsx
@@ -3,22 +3,78 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
+import page from 'page';
 
 /**
  * Internal dependencies
  */
 import Button from 'components/button';
+import { getSelectedSite } from 'state/ui/selectors';
+import { getEligibility } from 'state/automated-transfer/selectors';
+import { initiateThemeTransfer } from 'state/themes/actions';
+import { setAutomatedTransferStatus } from 'state/automated-transfer/actions';
 
-export const WpcomPluginInstallButton = ( { translate, disabled, plugin, site } ) => {
-	return <Button
-		onClick={ undefined }
-		primary={ true }
-		type="submit"
-		disabled={ disabled }
-		href={ `/plugins/${ plugin.slug }/${ site.slug }/eligibility` }
-	>
-		{ translate( 'Install' ) }
-	</Button>;
+export const WpcomPluginInstallButton = props => {
+	const {
+		translate,
+		disabled,
+		plugin,
+		siteSlug,
+		siteId,
+		eligibilityData,
+		navigateTo,
+		initiateTransfer,
+		setStatus
+	} = props;
+
+	function installButtonAction( event ) {
+		event.preventDefault();
+
+		const hasErrors = !! get( eligibilityData, 'eligibilityHolds', [] ).length;
+		const hasWarnings = !! get( eligibilityData, 'eligibilityWarnings', [] ).length;
+
+		if ( ! hasErrors && ! hasWarnings ) {
+			// No need to show eligibility warnings page, initiate transfer immediately
+			// TODO: refactor to use plugin slug
+			initiateTransfer( siteId, null );
+			setStatus( siteId, 'start' );
+		} else {
+			// Show eligibility warnings before proceeding
+			navigateTo( `/plugins/${ plugin.slug }/${ siteSlug }/eligibility` );
+		}
+	}
+
+	return (
+		<Button
+			onClick={ installButtonAction }
+			primary={ true }
+			disabled={ disabled }
+		>
+			{ translate( 'Install' ) }
+		</Button>
+	);
 };
 
-export default localize( WpcomPluginInstallButton );
+const mapStateToProps = state => {
+	const site = getSelectedSite( state );
+
+	return {
+		siteId: site.ID,
+		siteSlug: site.slug,
+		eligibilityData: getEligibility( state, site.ID )
+	};
+};
+
+const mapDispatchToProps = {
+	setStatus: setAutomatedTransferStatus,
+	initiateTransfer: initiateThemeTransfer,
+};
+
+const withNavigation = WrappedComponent => props => <WrappedComponent { ...{ ...props, navigateTo: page } } />;
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( withNavigation( localize( WpcomPluginInstallButton ) ) );

--- a/client/my-sites/plugins-wpcom/plugin-install-button.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-install-button.jsx
@@ -35,7 +35,7 @@ export const WpcomPluginInstallButton = props => {
 
 		if ( ! hasErrors && ! hasWarnings ) {
 			// No need to show eligibility warnings page, initiate transfer immediately
-			initiateTransfer( siteId, null, plugin );
+			initiateTransfer( siteId, null, plugin.slug );
 		} else {
 			// Show eligibility warnings before proceeding
 			navigateTo( `/plugins/${ plugin.slug }/${ siteSlug }/eligibility` );

--- a/client/my-sites/plugins-wpcom/plugin-install-button.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-install-button.jsx
@@ -35,7 +35,6 @@ export const WpcomPluginInstallButton = props => {
 
 		if ( ! hasErrors && ! hasWarnings ) {
 			// No need to show eligibility warnings page, initiate transfer immediately
-			// TODO: refactor to use plugin slug
 			initiateTransfer( siteId, null, plugin );
 		} else {
 			// Show eligibility warnings before proceeding

--- a/client/my-sites/plugins-wpcom/plugin-install-button.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-install-button.jsx
@@ -14,7 +14,6 @@ import Button from 'components/button';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getEligibility } from 'state/automated-transfer/selectors';
 import { initiateThemeTransfer } from 'state/themes/actions';
-import { setAutomatedTransferStatus } from 'state/automated-transfer/actions';
 
 export const WpcomPluginInstallButton = props => {
 	const {
@@ -25,8 +24,7 @@ export const WpcomPluginInstallButton = props => {
 		siteId,
 		eligibilityData,
 		navigateTo,
-		initiateTransfer,
-		setStatus
+		initiateTransfer
 	} = props;
 
 	function installButtonAction( event ) {
@@ -38,8 +36,7 @@ export const WpcomPluginInstallButton = props => {
 		if ( ! hasErrors && ! hasWarnings ) {
 			// No need to show eligibility warnings page, initiate transfer immediately
 			// TODO: refactor to use plugin slug
-			initiateTransfer( siteId, null );
-			setStatus( siteId, 'start' );
+			initiateTransfer( siteId, null, plugin );
 		} else {
 			// Show eligibility warnings before proceeding
 			navigateTo( `/plugins/${ plugin.slug }/${ siteSlug }/eligibility` );
@@ -68,8 +65,7 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = {
-	setStatus: setAutomatedTransferStatus,
-	initiateTransfer: initiateThemeTransfer,
+	initiateTransfer: initiateThemeTransfer
 };
 
 const withNavigation = WrappedComponent => props => <WrappedComponent { ...{ ...props, navigateTo: page } } />;

--- a/client/my-sites/plugins/plugin-eligibility/index.jsx
+++ b/client/my-sites/plugins/plugin-eligibility/index.jsx
@@ -2,9 +2,9 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,13 +12,17 @@ import { noop } from 'lodash';
 import MainComponent from 'components/main';
 import HeaderCake from 'components/header-cake';
 import EligibilityWarnings from 'blocks/eligibility-warnings';
+import { initiateThemeTransfer as initiateAutomatedTransfer } from 'state/themes/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 class PluginEligibility extends Component {
 	static propTypes = {
 		pluginSlug: PropTypes.string,
+		siteId: PropTypes.number,
 		siteSlug: PropTypes.string,
 		translate: PropTypes.func,
-		navigateTo: PropTypes.func
+		navigateTo: PropTypes.func,
+		initiateAutomatedTransfer: PropTypes.func
 	};
 
 	getBackUrl = () => {
@@ -28,6 +32,12 @@ class PluginEligibility extends Component {
 	};
 
 	goBack = () => this.props.navigateTo( this.getBackUrl() );
+
+	pluginTransferInitiate = () => {
+		// Use theme transfer action until we introduce generic ones that will handle both plugins and themes
+		this.props.initiateAutomatedTransfer( this.props.siteId, null );
+		this.goBack();
+	};
 
 	render() {
 		const { translate } = this.props;
@@ -41,8 +51,7 @@ class PluginEligibility extends Component {
 					{ translate( 'Install plugin' ) }
 				</HeaderCake>
 				<EligibilityWarnings
-					// TODO: Replace with transfer initiate call
-					onProceed={ noop }
+					onProceed={ this.pluginTransferInitiate }
 					backUrl={ this.getBackUrl() }
 				/>
 			</MainComponent>
@@ -53,4 +62,19 @@ class PluginEligibility extends Component {
 // It was 2:45AM, I wanted to deploy, and @dmsnell made me do it... props to @dmsnell :)
 const withNavigation = WrappedComponent => props => <WrappedComponent { ...{ ...props, navigateTo: page } } />;
 
-export default withNavigation( localize( PluginEligibility ) );
+const mapStateToProps = state => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		siteId,
+	};
+};
+
+const mapDispatchToProps = {
+	initiateAutomatedTransfer,
+};
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( withNavigation( localize( PluginEligibility ) ) );

--- a/client/my-sites/plugins/plugin-eligibility/index.jsx
+++ b/client/my-sites/plugins/plugin-eligibility/index.jsx
@@ -12,8 +12,9 @@ import page from 'page';
 import MainComponent from 'components/main';
 import HeaderCake from 'components/header-cake';
 import EligibilityWarnings from 'blocks/eligibility-warnings';
-import { initiateThemeTransfer as initiateAutomatedTransfer } from 'state/themes/actions';
+import { initiateThemeTransfer } from 'state/themes/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { setAutomatedTransferStatus } from 'state/automated-transfer/actions';
 
 class PluginEligibility extends Component {
 	static propTypes = {
@@ -22,7 +23,8 @@ class PluginEligibility extends Component {
 		siteSlug: PropTypes.string,
 		translate: PropTypes.func,
 		navigateTo: PropTypes.func,
-		initiateAutomatedTransfer: PropTypes.func
+		initiateTransfer: PropTypes.func,
+		setStatus: PropTypes.func
 	};
 
 	getBackUrl = () => {
@@ -35,7 +37,9 @@ class PluginEligibility extends Component {
 
 	pluginTransferInitiate = () => {
 		// Use theme transfer action until we introduce generic ones that will handle both plugins and themes
-		this.props.initiateAutomatedTransfer( this.props.siteId, null );
+		// TODO: refactor to use plugin slug
+		this.props.initiateTransfer( this.props.siteId, null );
+		this.props.setStatus( this.props.siteId, 'start' );
 		this.goBack();
 	};
 
@@ -71,7 +75,8 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = {
-	initiateAutomatedTransfer,
+	initiateTransfer: initiateThemeTransfer,
+	setStatus: setAutomatedTransferStatus
 };
 
 export default connect(

--- a/client/my-sites/plugins/plugin-eligibility/index.jsx
+++ b/client/my-sites/plugins/plugin-eligibility/index.jsx
@@ -14,7 +14,6 @@ import HeaderCake from 'components/header-cake';
 import EligibilityWarnings from 'blocks/eligibility-warnings';
 import { initiateThemeTransfer } from 'state/themes/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { setAutomatedTransferStatus } from 'state/automated-transfer/actions';
 
 class PluginEligibility extends Component {
 	static propTypes = {
@@ -23,8 +22,7 @@ class PluginEligibility extends Component {
 		siteSlug: PropTypes.string,
 		translate: PropTypes.func,
 		navigateTo: PropTypes.func,
-		initiateTransfer: PropTypes.func,
-		setStatus: PropTypes.func
+		initiateTransfer: PropTypes.func
 	};
 
 	getBackUrl = () => {
@@ -38,8 +36,7 @@ class PluginEligibility extends Component {
 	pluginTransferInitiate = () => {
 		// Use theme transfer action until we introduce generic ones that will handle both plugins and themes
 		// TODO: refactor to use plugin slug
-		this.props.initiateTransfer( this.props.siteId, null );
-		this.props.setStatus( this.props.siteId, 'start' );
+		this.props.initiateTransfer( this.props.siteId, null, this.props.pluginSlug );
 		this.goBack();
 	};
 
@@ -75,8 +72,7 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = {
-	initiateTransfer: initiateThemeTransfer,
-	setStatus: setAutomatedTransferStatus
+	initiateTransfer: initiateThemeTransfer
 };
 
 export default connect(

--- a/client/my-sites/plugins/plugin-eligibility/index.jsx
+++ b/client/my-sites/plugins/plugin-eligibility/index.jsx
@@ -35,7 +35,6 @@ class PluginEligibility extends Component {
 
 	pluginTransferInitiate = () => {
 		// Use theme transfer action until we introduce generic ones that will handle both plugins and themes
-		// TODO: refactor to use plugin slug
 		this.props.initiateTransfer( this.props.siteId, null, this.props.pluginSlug );
 		this.goBack();
 	};

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -166,11 +166,12 @@ export default React.createClass( {
 		}
 
 		if ( this.props.selectedSite && ! this.props.selectedSite.jetpack ) {
-			return <WpcomPluginInstallButton
-						disabled={ ! this.hasBusinessPlan() }
-						plugin={ this.props.plugin }
-						site={ this.props.selectedSite }
-			/>;
+			return (
+				<WpcomPluginInstallButton
+					disabled={ ! this.hasBusinessPlan() }
+					plugin={ this.props.plugin }
+				/>
+			);
 		}
 	},
 

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -534,16 +534,17 @@ export function clearThemeUpload( siteId ) {
  *
  * @param {Number} siteId -- the site to transfer
  * @param {File} file -- theme zip to upload
+ * @param {String} plugin -- plugin slug
  *
  * @returns {Promise} for testing purposes only
  */
-export function initiateThemeTransfer( siteId, file ) {
+export function initiateThemeTransfer( siteId, file, plugin ) {
 	return dispatch => {
 		dispatch( {
 			type: THEME_TRANSFER_INITIATE_REQUEST,
 			siteId,
 		} );
-		return wpcom.undocumented().initiateTransfer( siteId, null, file, ( event ) => {
+		return wpcom.undocumented().initiateTransfer( siteId, plugin, file, ( event ) => {
 			dispatch( {
 				type: THEME_TRANSFER_INITIATE_PROGRESS,
 				siteId,


### PR DESCRIPTION
Enables initiating automated transfer on plugin installation. The transfer initiation can from two places:

1. Upon clicking `Install` button on plugin detail page, if no eligibility errors and warnings are present.
2. After clicking `Proceed` on eligibility warnings page, provided that there are no eligibility errors present.

Note: we agreed to leverage theme specific transfer action for this purpose. However, it is worth mentioning that this is a temporary solution required to test the AT flow, and it should be refactored in the future.

**Testing instructions:**
1. Use a test site with business plan that is eligible for transfer, but has eligibility warnings.
2. Navigate to plugin detail page and click `Install`. 
3. On eligibility warnings page click `Proceed` and verify that `initiate` endpoint is being called.
4. Use a test site with business plan that is eligible for transfer, and has no eligibility warnings.
5. Navigate to plugin detail page and click `Install`.
6. Verify that `initiate` has been triggered immediately, without showing eligibility warnings page.