### PR TITLE
Remove unavailable keyboard shortcuts from shortcut menu

### DIFF
--- a/client/lib/keyboard-shortcuts/global.js
+++ b/client/lib/keyboard-shortcuts/global.js
@@ -28,7 +28,6 @@ function GlobalShortcuts( sites ) {
 
 GlobalShortcuts.prototype.bindShortcuts = function() {
 	KeyboardShortcuts.on( 'go-to-reader', this.goToReader.bind( this ) );
-	KeyboardShortcuts.on( 'go-to-my-comments', this.goToMyComments.bind( this ) );
 	KeyboardShortcuts.on( 'go-to-my-likes', this.goToMyLikes.bind( this ) );
 	KeyboardShortcuts.on( 'go-to-stats', this.goToStats.bind( this ) );
 	KeyboardShortcuts.on( 'go-to-blog-posts', this.goToBlogPosts.bind( this ) );
@@ -41,10 +40,6 @@ GlobalShortcuts.prototype.bindShortcuts = function() {
 
 GlobalShortcuts.prototype.goToReader = function() {
 	page( '/' );
-};
-
-GlobalShortcuts.prototype.goToMyComments = function() {
-	page( '/activities/comments' );
 };
 
 GlobalShortcuts.prototype.goToMyLikes = function() {

--- a/client/lib/keyboard-shortcuts/key-bindings.js
+++ b/client/lib/keyboard-shortcuts/key-bindings.js
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import i18n from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
 import Emitter from 'lib/mixins/emitter';
 
 function KeyBindings() {
@@ -15,13 +22,6 @@ KeyBindings.prototype.emitLanguageChange = function() {
 };
 
 KeyBindings.prototype.get = function() {
-	let descriptionCtrlKey = 'ctrl';
-
-	if ( typeof navigator !== 'undefined' && navigator.userAgent.indexOf( 'Mac OS X' ) !== -1 ) {
-		// the ctrl key in the description is platform dependent and displays the command symbol on OS X
-		descriptionCtrlKey = '\u2318';
-	}
-
 	return {
 		listNavigation: [
 			{
@@ -80,15 +80,6 @@ KeyBindings.prototype.get = function() {
 				description: {
 					keys: [ 'g', 'r' ],
 					text: i18n.translate( 'Go to Reader' )
-				}
-			},
-			{
-				eventName: 'go-to-my-comments',
-				keys: [ 'g', 'c' ],
-				type: 'sequence',
-				description: {
-					keys: [ 'g', 'c' ],
-					text: i18n.translate( 'Go to My Comments' )
 				}
 			},
 			{
@@ -156,17 +147,6 @@ KeyBindings.prototype.get = function() {
 				}
 			},
 			{
-				eventName: 'reply-to-section',
-				keys: [
-					[ 'control', 'enter' ],
-					[ 'command', 'enter' ]
-				],
-				description: {
-					keys: [ descriptionCtrlKey, 'enter' ],
-					text: i18n.translate( 'Reply to post' )
-				}
-			},
-			{
 				eventName: 'close-full-post',
 				keys: [ 'esc' ],
 				description: {
@@ -209,4 +189,4 @@ KeyBindings.prototype.get = function() {
 	};
 };
 
-module.exports = new KeyBindings();
+export default new KeyBindings();


### PR DESCRIPTION
@designsimply spotted that we were showing two unavailable keyboard shortcuts in the shortcut menu (accessed with <kbd>Shift</kbd> and <kbd>/</kbd>):

![e3c40ee0-b570-11e6-8b13-0535fecd07c5](https://cloud.githubusercontent.com/assets/17325/21759535/cf6d9918-d67f-11e6-935c-81508bb70803.png)

This PR removes these two shortcuts from the menu. We have no plans to reintroduce the shortcuts themselves at the moment.

<img width="730" alt="screen shot 2017-01-09 at 15 10 28" src="https://cloud.githubusercontent.com/assets/17325/21759540/e071eef8-d67f-11e6-8d06-2b6284c4de8e.png">

### To test

Bring up the Keyboard Shortcuts menu with <kbd>Shift</kbd> and <kbd>/</kbd> and ensure that all of the displayed shortcuts work as expected.

Fixes #9676. 