### PR TITLE
Remove the 2FA-block from the recovery phone setup

### DIFF
--- a/client/me/security-checkup/index.jsx
+++ b/client/me/security-checkup/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -10,13 +10,11 @@ import { localize } from 'i18n-calypso';
  */
 import Main from 'components/main';
 import CompactCard from 'components/card/compact';
-import Notice from 'components/notice';
 import QueryAccountRecoverySettings from 'components/data/query-account-recovery-settings';
 import MeSidebarNavigation from 'me/sidebar-navigation';
 import SecuritySectionNav from 'me/security-section-nav';
 import ReauthRequired from 'me/reauth-required';
 import twoStepAuthorization from 'lib/two-step-authorization';
-import observe from 'lib/mixins/data-observe';
 import RecoveryEmail from './recovery-email';
 import RecoveryPhone from './recovery-phone';
 import RecoveryEmailValidationNotice from './recovery-email-validation-notice';
@@ -48,29 +46,8 @@ import {
 
 import { getCurrentUserEmail } from 'state/current-user/selectors';
 
-const SecurityCheckup = React.createClass( {
-	displayName: 'SecurityCheckup',
-
-	mixins: [ observe( 'userSettings' ) ],
-
-	componentDidMount: function() {
-		this.props.userSettings.getSettings();
-	},
-
-	render: function() {
-		const twoStepEnabled = this.props.userSettings.isTwoStepEnabled();
-
-		const {
-			translate,
-		} = this.props;
-
-		const twoStepNoticeMessage = translate(
-			'To edit your SMS Number, go to {{a}}Two-Step Authentication{{/a}}.', {
-				components: {
-					a: <a href="/me/security/two-step" />
-				},
-			} );
-
+class SecurityCheckup extends Component {
+	render() {
 		return (
 			<Main className="security-checkup">
 				<QueryAccountRecoverySettings />
@@ -111,15 +88,7 @@ const SecurityCheckup = React.createClass( {
 						updatePhone={ this.props.updateAccountRecoveryPhone }
 						deletePhone={ this.props.deleteAccountRecoveryPhone }
 						isLoading={ this.props.accountRecoveryPhoneActionInProgress }
-						disabled={ twoStepEnabled }
 					/>
-					{ twoStepEnabled &&
-						<Notice
-							status="is-error"
-							text={ twoStepNoticeMessage }
-							showDismiss={ false }
-						/>
-					}
 					{ this.props.shouldPromptPhoneValidationNotice &&
 						<RecoveryPhoneValidationNotice
 							onResend={ this.props.resendAccountRecoveryPhoneValidation }
@@ -132,8 +101,8 @@ const SecurityCheckup = React.createClass( {
 
 			</Main>
 		);
-	},
-} );
+	}
+}
 
 export default connect(
 	( state ) => ( {

--- a/client/me/security-checkup/index.jsx
+++ b/client/me/security-checkup/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -46,63 +46,58 @@ import {
 
 import { getCurrentUserEmail } from 'state/current-user/selectors';
 
-class SecurityCheckup extends Component {
-	render() {
-		return (
-			<Main className="security-checkup">
-				<QueryAccountRecoverySettings />
+const SecurityCheckup = ( props ) => (
+	<Main className="security-checkup">
+		<QueryAccountRecoverySettings />
 
-				<MeSidebarNavigation />
+		<MeSidebarNavigation />
 
-				<SecuritySectionNav path={ this.props.path } />
+		<SecuritySectionNav path={ props.path } />
 
-				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+		<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 
-				<CompactCard>
-					<p className="security-checkup__text">
-						{ this.props.translate( 'Keep your account safe by adding a backup email address and phone number. ' +
-								'If you ever have problems accessing your account, WordPress.com will use what ' +
-								'you enter here to verify your identity.' ) }
-					</p>
-				</CompactCard>
+		<CompactCard>
+			<p className="security-checkup__text">
+				{ props.translate( 'Keep your account safe by adding a backup email address and phone number. ' +
+						'If you ever have problems accessing your account, WordPress.com will use what ' +
+						'you enter here to verify your identity.' ) }
+			</p>
+		</CompactCard>
 
-				<CompactCard>
-					<RecoveryEmail
-						primaryEmail={ this.props.primaryEmail }
-						email={ this.props.accountRecoveryEmail }
-						updateEmail={ this.props.updateAccountRecoveryEmail }
-						deleteEmail={ this.props.deleteAccountRecoveryEmail }
-						isLoading={ this.props.accountRecoveryEmailActionInProgress }
-					/>
-					{ this.props.shouldPromptEmailValidationNotice &&
-						<RecoveryEmailValidationNotice
-							onResend={ this.props.resendAccountRecoveryEmailValidation }
-							hasSent={ this.props.hasSentEmailValidation }
-						/>
-					}
-				</CompactCard>
+		<CompactCard>
+			<RecoveryEmail
+				primaryEmail={ props.primaryEmail }
+				email={ props.accountRecoveryEmail }
+				updateEmail={ props.updateAccountRecoveryEmail }
+				deleteEmail={ props.deleteAccountRecoveryEmail }
+				isLoading={ props.accountRecoveryEmailActionInProgress }
+			/>
+			{ props.shouldPromptEmailValidationNotice &&
+				<RecoveryEmailValidationNotice
+					onResend={ props.resendAccountRecoveryEmailValidation }
+					hasSent={ props.hasSentEmailValidation }
+				/>
+			}
+		</CompactCard>
 
-				<CompactCard>
-					<RecoveryPhone
-						phone={ this.props.accountRecoveryPhone }
-						updatePhone={ this.props.updateAccountRecoveryPhone }
-						deletePhone={ this.props.deleteAccountRecoveryPhone }
-						isLoading={ this.props.accountRecoveryPhoneActionInProgress }
-					/>
-					{ this.props.shouldPromptPhoneValidationNotice &&
-						<RecoveryPhoneValidationNotice
-							onResend={ this.props.resendAccountRecoveryPhoneValidation }
-							onValidate={ this.props.validateAccountRecoveryPhone }
-							hasSent={ this.props.hasSentPhoneValidation }
-							isValidating={ this.props.validatingAccountRecoveryPhone }
-						/>
-					}
-				</CompactCard>
-
-			</Main>
-		);
-	}
-}
+		<CompactCard>
+			<RecoveryPhone
+				phone={ props.accountRecoveryPhone }
+				updatePhone={ props.updateAccountRecoveryPhone }
+				deletePhone={ props.deleteAccountRecoveryPhone }
+				isLoading={ props.accountRecoveryPhoneActionInProgress }
+			/>
+			{ props.shouldPromptPhoneValidationNotice &&
+				<RecoveryPhoneValidationNotice
+					onResend={ props.resendAccountRecoveryPhoneValidation }
+					onValidate={ props.validateAccountRecoveryPhone }
+					hasSent={ props.hasSentPhoneValidation }
+					isValidating={ props.validatingAccountRecoveryPhone }
+				/>
+			}
+		</CompactCard>
+	</Main>
+);
 
 export default connect(
 	( state ) => ( {


### PR DESCRIPTION
## Summary
Since the deployment of #10226, the recovery phone number is now fully-separated from the 2FA number. Thus, there is simply no reason to block a user with a 2FA number from updating one's recovery phone anymore.

As a plus, the security-checkup component is fully ES6 class after this.

## Test plan
It requires D3890 to be fully functional, so please make sure you have it deployed to your development environment.

* Log in as a user configured with a 2FA number 
* Visit calypso.localhost:3000/me/security/checkup
* There shouldn't be any error notice as before, and add / update / remove recovery phone numbers should work as expected.