### PR TITLE
Hide "English support only" notice for forum posts

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -501,9 +501,9 @@ const HelpContact = React.createClass( {
 		}
 	},
 
-	getContactFormCommonProps: function() {
+	getContactFormCommonProps: function( variationSlug ) {
 		const { olark, isSubmitting } = this.state;
-		const showHelpLanguagePrompt = ( olark.locale !== i18n.getLocaleSlug() );
+		const showHelpLanguagePrompt = ( olark.locale !== i18n.getLocaleSlug() ) && SUPPORT_FORUM !== variationSlug;
 
 		return {
 			disabled: isSubmitting,
@@ -568,7 +568,7 @@ const HelpContact = React.createClass( {
 		const supportVariation = this.getSupportVariation();
 
 		const contactFormProps = Object.assign(
-			this.getContactFormCommonProps(),
+			this.getContactFormCommonProps( supportVariation ),
 			this.getContactFormPropsVariation( supportVariation ),
 		);
 

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -503,7 +503,16 @@ const HelpContact = React.createClass( {
 
 	getContactFormCommonProps: function( variationSlug ) {
 		const { olark, isSubmitting } = this.state;
-		const showHelpLanguagePrompt = ( olark.locale !== i18n.getLocaleSlug() ) && SUPPORT_FORUM !== variationSlug;
+
+		// Let the user know we only offer support in English.
+		// We only need to show the message if:
+		// 1. The user's locale doesn't match the live chat locale (usually English)
+		// 2. The support request isn't sent to the forums. Because forum support
+		//    requests are sent to the language specific forums (for popular languages)
+		//    we don't tell the user that support is only offered in English.
+		const showHelpLanguagePrompt =
+			( olark.locale !== i18n.getLocaleSlug() ) &&
+			SUPPORT_FORUM !== variationSlug;
 
 		return {
 			disabled: isSubmitting,


### PR DESCRIPTION
This hides the "Note: Support is only available in English at the moment" notice on /help/contact if the user is only eligible for forum support.

Because forum posts are directed to the relevant locale forum (for popular languages), we shouldn't be saying that support is only available in English.

### How to test

#### As a plan user who is eligible for live chat
 - Switch the account language to non-English
 - Go to http://calypso.localhost:3000/help/contact
 - Confirm that the message is displayed below the form (this behaviour is unchanged):

![aide_ _wordpress_com](https://cloud.githubusercontent.com/assets/416133/21761274/9575523c-d69d-11e6-9684-7ecff03b7891.png)

#### As a free user without included support (forum only)

 - Switch the account language to non-English
 - Go to http://calypso.localhost:3000/help/contact
 - No message should be displayed:
![aide_ _wordpress_com](https://cloud.githubusercontent.com/assets/416133/21761302/c4791578-d69d-11e6-97a4-9c64e476d00b.png)

