### PR TITLE
Site Settings: Align child settings with the label of the parent

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -482,7 +482,7 @@ class SiteSettingsFormGeneral extends Component {
 					</li>
 					{ !! fields.jetpack_relatedposts_enabled && (
 						<li>
-							<ul id="settings-reading-relatedposts-customize">
+							<ul id="settings-reading-relatedposts-customize" className="site-settings__child-settings">
 								<li>
 									<FormToggle
 										className="is-compact"

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -172,6 +172,10 @@
 			margin-bottom: 8px;
 		}
 	}
+
+	.site-settings__child-settings {
+		margin-left: 36px;
+	}
 }
 
 .site-settings__general-settings {


### PR DESCRIPTION
### Purpose

This PR aligns the child settings toggles with the labels of the parent setting, as suggested by @MichaelArestad in #10463. It introduces a CSS class that we can reuse for other settings groups in the future.

Fixes #10463.

### Preview

#### Before
![](https://cldup.com/R5Sp03fbEJ.png)

#### After
![](https://cldup.com/mqqZcWLUJE.png)

### To test

* Get this branch going locally or on calypso.live
* Go to `/settings/general/$site`, where `$site` is one of your Jetpack sites.
* Verify the toggles in the Related Posts card are aligned as shown on the screenshots.

/cc @MichaelArestad 