### PR TITLE
Stats: Fix Post Views Chart for the site's homepage

### DIFF
--- a/client/components/data/query-post-stats/index.jsx
+++ b/client/components/data/query-post-stats/index.jsx
@@ -3,7 +3,7 @@
  */
 import { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { isEqual } from 'lodash';
+import { isEqual, isUndefined } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,7 +28,7 @@ class QueryPostStats extends Component {
 
 	componentWillMount() {
 		const { requestingPostStats, siteId, postId } = this.props;
-		if ( ! requestingPostStats && siteId && postId ) {
+		if ( ! requestingPostStats && siteId && ! isUndefined( postId ) ) {
 			this.requestPostStats( this.props );
 		}
 	}
@@ -40,7 +40,7 @@ class QueryPostStats extends Component {
 	componentWillReceiveProps( nextProps ) {
 		const { siteId, postId, fields, heartbeat } = this.props;
 		if (
-			! ( siteId && postId ) ||
+			! ( siteId && ! isUndefined( postId ) ) ||
 			( siteId === nextProps.siteId &&
 				postId === nextProps.postId &&
 				isEqual( fields, nextProps.fields ) &&


### PR DESCRIPTION
#10399 introduced a bug on the Post Stats Page for the home page of any website (postId = 0). In this PR, I allow `QueryPostStats` to fetch stats for these posts.

**Testing instructions**

 * Navigate to the Post Stats Page of your homepage: `/stats/post/0/$site`
 * The first chart (views) should not be an empty chart.
