### PR TITLE
Components: Fix controlled component warning in JetpackModuleToggle

### DIFF
--- a/client/my-sites/site-settings/jetpack-module-toggle/index.jsx
+++ b/client/my-sites/site-settings/jetpack-module-toggle/index.jsx
@@ -54,11 +54,12 @@ class JetpackModuleToggle extends Component {
 		if ( ! this.props.isJetpackSite ) {
 			return null;
 		}
+
 		return (
 			<span className="jetpack-module-toggle">
 				<CompactFormToggle
 					id={ `${ this.props.siteId }-${ this.props.moduleSlug }-toggle` }
-					checked={ this.props.checked }
+					checked={ this.props.checked || false }
 					toggling={ this.props.toggling }
 					onChange={ this.handleChange }
 					disabled={ this.props.disabled || this.props.toggleDisabled } >


### PR DESCRIPTION
This PR fixes a warning with the `JetpackModuleToggle`:

![](https://cldup.com/wbR7aRAt-X.png)

To test:

* Checkout this branch
* Embed `JetpackModuleToggle` somewhere, like this:

```
<JetpackModuleToggle
	siteId={ 12345678 }
	moduleSlug="infinite-scroll"
	label={ translate( 'Add support for infinite scroll to your theme.' ) }
	disabled={ false }
/>
```

* Verify the warning no longer appears.