### PR TITLE
Post Editor: introduce HTML quick tags toolbar

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -385,6 +385,7 @@
 @import 'post-editor/editor-fieldset/style';
 @import 'post-editor/editor-forbidden/style';
 @import 'post-editor/editor-ground-control/style';
+@import 'post-editor/editor-html-toolbar/style';
 @import 'post-editor/editor-location/style';
 @import 'post-editor/editor-mobile-navigation/style';
 @import 'post-editor/editor-notice/style';

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -445,7 +445,7 @@ module.exports = React.createClass( {
 			this.props.onTextEditorChange( content );
 		}
 
-		this.setState( { content: content }, this.doAutosizeUpdate );
+		this.setState( { content }, this.doAutosizeUpdate );
 	},
 
 	localize: function() {

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -41,6 +41,7 @@ import wptextpatternPlugin from './plugins/wptextpattern/plugin';
 import toolbarPinPlugin from './plugins/toolbar-pin/plugin';
 import insertMenuPlugin from './plugins/insert-menu/plugin';
 import embedReversalPlugin from './plugins/embed-reversal/plugin';
+import EditorHtmlToolbar from 'post-editor/editor-html-toolbar';
 
 [
 	wpcomPlugin,
@@ -439,6 +440,14 @@ module.exports = React.createClass( {
 		this.setState( { content: content }, this.doAutosizeUpdate );
 	},
 
+	onToolbarChangeContent: function( content ) {
+		if ( this.props.onTextEditorChange ) {
+			this.props.onTextEditorChange( content );
+		}
+
+		this.setState( { content: content }, this.doAutosizeUpdate );
+	},
+
 	localize: function() {
 		const userData = user.get();
 		let i18nStrings = i18n;
@@ -458,20 +467,29 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
+		const { mode } = this.props;
 		const className = classnames( {
 			tinymce: true,
-			'is-visible': this.props.mode === 'html'
+			'is-visible': mode === 'html'
 		} );
 
 		return (
-			<textarea
-				ref="text"
-				className={ className }
-				id={ this._id }
-				onChange={ this.onTextAreaChange }
-				tabIndex={ this.props.tabIndex }
-				value={ this.state.content }
-			/>
+			<div>
+				{ mode === 'html' &&
+					<EditorHtmlToolbar
+						content={ this.refs.text }
+						onToolbarChangeContent={ this.onToolbarChangeContent }
+					/>
+				}
+				<textarea
+					ref="text"
+					className={ className }
+					id={ this._id }
+					onChange={ this.onTextAreaChange }
+					tabIndex={ this.props.tabIndex }
+					value={ this.state.content }
+				/>
+			</div>
 		);
 	}
 } );

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -69,7 +69,6 @@
 		background-color: rgba( $white, 0.92 );
 		border-color: lighten( $gray, 20% );
 		border-style: solid;
-		border-width: 1px 0;
 		padding: 0;
 		overflow-x: auto;
 		margin: 0 auto;

--- a/client/post-editor/editor-html-toolbar/add-image-dialog.jsx
+++ b/client/post-editor/editor-html-toolbar/add-image-dialog.jsx
@@ -1,0 +1,125 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
+
+export class AddImageDialog extends Component {
+
+	static propTypes = {
+		onClose: PropTypes.func,
+		onInsert: PropTypes.func,
+		shouldDisplay: PropTypes.bool,
+		translate: PropTypes.func,
+	};
+
+	state = {
+		imageAlt: '',
+		imageTitle: '',
+		imageUrl: '',
+	};
+
+	setImageAlt = event => {
+		this.setState( { imageAlt: event.target.value } );
+	}
+
+	setImageTitle = event => {
+		this.setState( { imageTitle: event.target.value } );
+	}
+
+	setImageUrl = event => {
+		this.setState( { imageUrl: event.target.value } );
+	}
+
+	onCloseDialog = () => {
+		this.setState( {
+			imageAlt: '',
+			imageTitle: '',
+			imageUrl: '',
+		} );
+		this.props.onClose();
+	}
+
+	onInsertImage = () => {
+		const {
+			imageAlt: alt,
+			imageTitle: title,
+			imageUrl: src,
+		} = this.state;
+		this.props.onInsert( { alt, src, title } );
+		this.onCloseDialog();
+	}
+
+	render() {
+		const {
+			shouldDisplay,
+			translate,
+		} = this.props;
+		const {
+			imageAlt,
+			imageTitle,
+			imageUrl,
+		} = this.state;
+
+		const buttons = [ {
+			action: 'cancel',
+			label: translate( 'Cancel' ),
+		}, {
+			action: 'add-image',
+			isPrimary: true,
+			label: translate( 'Add Image' ),
+			onClick: this.onInsertImage,
+		} ];
+
+		return (
+			<Dialog
+				autoFocus={ false }
+				isVisible={ shouldDisplay }
+				buttons={ buttons }
+				onClose={ this.onCloseDialog }
+				additionalClassNames="editor-html-toolbar__dialog"
+			>
+				<FormFieldset>
+					<FormLabel htmlFor="image_url">
+						{ translate( 'URL' ) }
+					</FormLabel>
+					<FormTextInput
+						name="image_url"
+						onChange={ this.setImageUrl }
+						value={ imageUrl }
+					/>
+				</FormFieldset>
+				<FormFieldset>
+					<FormLabel htmlFor="image_title">
+						{ translate( 'Title' ) }
+					</FormLabel>
+					<FormTextInput
+						name="image_title"
+						onChange={ this.setImageTitle }
+						value={ imageTitle }
+					/>
+				</FormFieldset>
+				<FormFieldset>
+					<FormLabel htmlFor="image_alt">
+						{ translate( 'Alt Text' ) }
+					</FormLabel>
+					<FormTextInput
+						name="image_alt"
+						onChange={ this.setImageAlt }
+						value={ imageAlt }
+					/>
+				</FormFieldset>
+			</Dialog>
+		);
+	}
+}
+
+export default localize( AddImageDialog );

--- a/client/post-editor/editor-html-toolbar/add-link-dialog.jsx
+++ b/client/post-editor/editor-html-toolbar/add-link-dialog.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -21,6 +21,15 @@ const REGEXP_URL = /^(https?|ftp):\/\/[A-Z0-9.-]+\.[A-Z]{2,4}[^ "]*$/i;
 const REGEXP_STANDALONE_URL = /^(?:[a-z]+:|#|\?|\.|\/)/;
 
 export class AddLinkDialog extends Component {
+
+	static propTypes = {
+		onClose: PropTypes.func,
+		onInsert: PropTypes.func,
+		selectedText: PropTypes.string,
+		shouldDisplay: PropTypes.bool,
+		siteId: PropTypes.number,
+		translate: PropTypes.func,
+	};
 
 	state = {
 		linkNewTab: false,
@@ -71,15 +80,11 @@ export class AddLinkDialog extends Component {
 	}
 
 	setLinkText = event => {
-		this.setState( {
-			linkText: event.target.value,
-		} );
+		this.setState( { linkText: event.target.value } );
 	}
 
 	setLinkNewTab = event => {
-		this.setState( {
-			linkNewTab: event.target.checked,
-		} );
+		this.setState( { linkNewTab: event.target.checked } );
 	}
 
 	onSelectPost = post => {

--- a/client/post-editor/editor-html-toolbar/add-link-dialog.jsx
+++ b/client/post-editor/editor-html-toolbar/add-link-dialog.jsx
@@ -1,0 +1,200 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'state/ui/selectors';
+import Dialog from 'components/dialog';
+import FormCheckbox from 'components/forms/form-checkbox';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
+import PostSelector from 'my-sites/post-selector';
+
+const REGEXP_EMAIL = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i;
+const REGEXP_URL = /^(https?|ftp):\/\/[A-Z0-9.-]+\.[A-Z]{2,4}[^ "]*$/i;
+const REGEXP_STANDALONE_URL = /^(?:[a-z]+:|#|\?|\.|\/)/;
+
+export class AddLinkDialog extends Component {
+
+	state = {
+		linkNewTab: false,
+		linkText: '',
+		linkUrl: '',
+		selectedPost: { id: null, url: null },
+	};
+
+	componentWillReceiveProps( newProps ) {
+		this.setState( {
+			linkUrl: this.inferUrl( newProps.selectedText ),
+			linkText: newProps.selectedText,
+		} );
+	}
+
+	correctUrl() {
+		const url = this.state.linkUrl.trim();
+		if ( REGEXP_EMAIL.test( url ) ) {
+			return `mailto:${ url }`;
+		}
+		if ( ! REGEXP_STANDALONE_URL.test( url ) ) {
+			return `http://${ url }`;
+		}
+		return url;
+	}
+
+	inferUrl( selectedText ) {
+		if ( REGEXP_EMAIL.test( selectedText ) ) {
+			return 'mailto:' + selectedText;
+		} else if ( REGEXP_URL.test( selectedText ) ) {
+			return selectedText.replace( /&amp;|&#0?38;/gi, '&' );
+		}
+		return '';
+	}
+
+	bindLinkUrlRef = input => {
+		this.linkUrl = input;
+	}
+
+	setLinkUrl = event => {
+		const { selectedPost } = this.state;
+		this.setState( {
+			linkUrl: event.target.value,
+			selectedPost: selectedPost.url === event.target.value
+				? selectedPost
+				: { id: null, url: null },
+		} );
+	}
+
+	setLinkText = event => {
+		this.setState( {
+			linkText: event.target.value,
+		} );
+	}
+
+	setLinkNewTab = event => {
+		this.setState( {
+			linkNewTab: event.target.checked,
+		} );
+	}
+
+	onSelectPost = post => {
+		this.setState( {
+			linkUrl: post.URL,
+			selectedPost: { id: post.ID, url: post.URL }
+		} );
+	};
+
+	onCloseDialog = () => {
+		this.setState( {
+			linkNewTab: false,
+			linkText: '',
+			linkUrl: '',
+			selectedPost: { id: null, url: null },
+		} );
+		this.props.onClose();
+	}
+
+	onInsertLink = () => {
+		const {
+			linkNewTab,
+			linkText,
+		} = this.state;
+		this.props.onInsert( {
+			href: this.correctUrl(),
+			target: linkNewTab ? '_blank' : '',
+		}, linkText );
+		this.onCloseDialog();
+	}
+
+	render() {
+		const {
+			shouldDisplay,
+			siteId,
+			translate
+		} = this.props;
+		const {
+			linkNewTab,
+			linkText,
+			linkUrl,
+			selectedPost,
+		} = this.state;
+
+		const buttons = [ {
+			action: 'cancel',
+			label: translate( 'Cancel' ),
+		}, {
+			action: 'add-link',
+			isPrimary: true,
+			label: translate( 'Add Link' ),
+			onClick: this.onInsertLink,
+		} ];
+
+		return (
+			<Dialog
+				autoFocus={ false }
+				isVisible={ shouldDisplay }
+				buttons={ buttons }
+				onClose={ this.onCloseDialog }
+				additionalClassNames="editor-html-toolbar__dialog"
+			>
+				<FormFieldset>
+					<FormLabel htmlFor="link_url">
+						{ translate( 'URL' ) }
+					</FormLabel>
+					<FormTextInput
+						name="link_url"
+						onChange={ this.setLinkUrl }
+						ref={ this.bindLinkUrlRef }
+						value={ linkUrl }
+					/>
+				</FormFieldset>
+				<FormFieldset>
+					<FormLabel htmlFor="link_text">
+						{ translate( 'Link Text' ) }
+					</FormLabel>
+					<FormTextInput
+						name="link_text"
+						onChange={ this.setLinkText }
+						value={ linkText }
+					/>
+				</FormFieldset>
+				<FormFieldset>
+					<FormLabel>
+						<FormCheckbox
+							checked={ linkNewTab }
+							name="link_new_tab"
+							onChange={ this.setLinkNewTab }
+						/>
+						<span>
+							{ translate( 'Open link in a new window/tab' ) }
+						</span>
+					</FormLabel>
+				</FormFieldset>
+				<FormFieldset>
+					<FormLabel>
+						<span>{ translate( 'Link to existing content' ) }</span>
+					</FormLabel>
+					<PostSelector
+						emptyMessage={ translate( 'No posts found' ) }
+						onChange={ this.onSelectPost }
+						order="DESC"
+						orderBy="date"
+						selected={ selectedPost.id }
+						showTypeLabels
+						siteId={ siteId }
+						type="any"
+					/>
+				</FormFieldset>
+			</Dialog>
+		);
+	}
+}
+
+export default connect( state => ( {
+	siteId: getSelectedSiteId( state ),
+} ) )( localize( AddLinkDialog ) );

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -123,10 +123,8 @@ export class EditorHtmlToolbar extends Component {
 			selectionEnd,
 			selectionStart,
 		} } = this.props;
-		const { openTags } = this.state;
 		if ( selectionEnd === selectionStart ) {
-			const isTagOpen = -1 !== openTags.indexOf( tag.name );
-			isTagOpen ? this.insertHtmlTagClose( tag ) : this.insertHtmlTagOpen( tag );
+			this.isTagOpen( tag.name ) ? this.insertHtmlTagClose( tag ) : this.insertHtmlTagOpen( tag );
 		} else {
 			this.insertHtmlTagOpenClose( tag );
 		}
@@ -223,58 +221,52 @@ export class EditorHtmlToolbar extends Component {
 		return -1 === openTags.indexOf( tag ) ? label : `/${ label }`;
 	}
 
+	isTagOpen = tag => -1 !== this.state.openTags.indexOf( tag );
+
 	render() {
 		if ( ! config.isEnabled( 'post-editor/html-toolbar' ) ) {
 			return null;
 		}
 		const { translate } = this.props;
 		const buttons = {
-			bold: {
-				label: this.tagLabel( 'strong', 'b' ),
+			strong: {
+				label: 'b',
 				onClick: this.onClickBold,
 			},
-			italic: {
-				label: this.tagLabel( 'em', 'i' ),
+			em: {
+				label: 'i',
 				onClick: this.onClickItalic,
 			},
-			link: {
+			a: {
 				label: 'link',
 				onClick: this.openLinkDialog,
 			},
-			quote: {
-				label: this.tagLabel( 'blockquote', 'b-quote' ),
+			blockquote: {
+				label: 'b-quote',
 				onClick: this.onClickQuote,
 			},
 			del: {
-				label: this.tagLabel( 'del', 'del' ),
 				onClick: this.onClickDelete,
 			},
 			ins: {
-				label: this.tagLabel( 'ins', 'ins' ),
 				onClick: this.onClickInsert,
 			},
-			image: {
-				label: 'img',
+			img: {
 				onClick: this.openImageDialog,
 			},
-			unorderedList: {
-				label: this.tagLabel( 'ul', 'ul' ),
+			ul: {
 				onClick: this.onClickUnorderedList,
 			},
-			orderedList: {
-				label: this.tagLabel( 'ol', 'ol' ),
+			ol: {
 				onClick: this.onClickOrderedList,
 			},
-			listItem: {
-				label: this.tagLabel( 'li', 'li' ),
+			li: {
 				onClick: this.onClickListItem,
 			},
 			code: {
-				label: this.tagLabel( 'code', 'code' ),
 				onClick: this.onClickCode,
 			},
 			more: {
-				label: 'more',
 				onClick: this.onClickMore,
 			},
 			closeTags: {
@@ -289,13 +281,13 @@ export class EditorHtmlToolbar extends Component {
 				{ map( buttons, ( { disabled, label, onClick }, tag ) =>
 					<Button
 						borderless
-						className={ `editor-html-toolbar__button-${ tag }` }
+						className={ `editor-html-toolbar__button-${ tag } ${ this.isTagOpen( tag ) ? 'is-tag-open' : '' }` }
 						compact
 						disabled={ disabled }
 						key={ tag }
 						onClick={ onClick }
 					>
-						{ label }
+						{ label || tag }
 					</Button>
 				) }
 				<AddImageDialog

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -65,14 +65,15 @@ export class EditorHtmlToolbar extends Component {
 	);
 
 	openHtmlTag = ( { name, attributes = {}, options = {} } ) =>
-		( options.newLine ? '\n' : '' ) +
+		( options.paragraph ? '\n' : '' ) +
+		( options.indent ? '\t' : '' ) +
 		`<${ name }${ this.attributesToString( attributes ) }>` +
-		( options.newLine ? '\n\t' : '' );
+		( options.paragraph ? '\n' : '' );
 
 	closeHtmlTag = ( { name, options = {} } ) =>
-		( options.newLine ? '\n' : '' ) +
 		`</${ name }>` +
-		( options.newLine ? '\n\n' : '' );
+		( options.newLineAfter ? '\n' : '' ) +
+		( options.paragraph ? '\n\n' : '' );
 
 	insertHtmlTagOpen( tag ) {
 		const { openTags } = this.state;
@@ -96,7 +97,9 @@ export class EditorHtmlToolbar extends Component {
 	insertHtmlTagSelfClosed( tag ) {
 		const { before, inner, after } = this.splitEditorContent();
 		const selfClosedTag = `<${ tag.name }${ this.attributesToString( tag.attributes ) } />`;
-		const content = tag.options && tag.options.newLine ? '\n' + selfClosedTag + '\n\n' : selfClosedTag;
+		const content = tag.options && tag.options.paragraph
+			? '\n' + selfClosedTag + '\n\n'
+			: selfClosedTag;
 		this.updateEditorContent( before + inner + content + after );
 	}
 
@@ -105,9 +108,14 @@ export class EditorHtmlToolbar extends Component {
 		this.updateEditorContent( before + this.openHtmlTag( tag ) + tag.options.text + this.closeHtmlTag( tag ) + after );
 	}
 
-	insertCustomContent( content ) {
+	insertCustomContent( content, options = {} ) {
 		const { before, inner, after } = this.splitEditorContent();
-		this.updateEditorContent( before + inner + content + after );
+		this.updateEditorContent(
+			before + inner +
+			( options.paragraph ? '\n' : '' ) +
+			content +
+			( options.paragraph ? '\n\n' : '' ) +
+			after );
 	}
 
 	insertHtmlTag( tag ) {
@@ -143,7 +151,7 @@ export class EditorHtmlToolbar extends Component {
 	};
 
 	onClickQuote = () => {
-		this.insertHtmlTag( { name: 'blockquote' } );
+		this.insertHtmlTag( { name: 'blockquote', options: { paragraph: true } } );
 	}
 
 	onClickDelete = () => {
@@ -161,15 +169,15 @@ export class EditorHtmlToolbar extends Component {
 	}
 
 	onClickUnorderedList = () => {
-		this.insertHtmlTag( { name: 'ul', options: { newLine: true } } );
+		this.insertHtmlTag( { name: 'ul', options: { paragraph: true } } );
 	}
 
 	onClickOrderedList = () => {
-		this.insertHtmlTag( { name: 'ol', options: { newLine: true } } );
+		this.insertHtmlTag( { name: 'ol', options: { paragraph: true } } );
 	}
 
 	onClickListItem = () => {
-		this.insertHtmlTag( { name: 'li' } );
+		this.insertHtmlTag( { name: 'li', options: { indent: true, newLineAfter: true } } );
 	}
 
 	onClickCode = () => {
@@ -177,7 +185,7 @@ export class EditorHtmlToolbar extends Component {
 	}
 
 	onClickMore = () => {
-		this.insertCustomContent( '<!--more-->' );
+		this.insertCustomContent( '<!--more-->', { paragraph: true } );
 	}
 
 	onClickCloseTags = () => {

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -182,20 +182,12 @@ export class EditorHtmlToolbar extends Component {
 	}
 
 	onClickCloseTags = () => {
-		const { content: {
-			selectionEnd,
-			value,
-		} } = this.props;
 		const closedTags = reduce(
 			this.state.openTags,
 			( tags, openTag ) => this.closeHtmlTag( { name: openTag } ) + tags,
 			''
 		);
-		this.updateEditorContent(
-			value.substring( 0, selectionEnd ) +
-			closedTags +
-			value.substring( selectionEnd, value.length )
-		);
+		this.insertCustomContent( closedTags );
 		this.setState( { openTags: [] } );
 	}
 

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -2,17 +2,20 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import { reduce } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Button from 'components/button';
 
-export default class EditorHtmlToolbar extends Component {
+export class EditorHtmlToolbar extends Component {
 
 	static propTypes = {
 		content: PropTypes.object,
-		onToolbarChangeContent: React.PropTypes.func,
+		moment: PropTypes.func,
+		onToolbarChangeContent: PropTypes.func,
 	};
 
 	state = {
@@ -32,20 +35,27 @@ export default class EditorHtmlToolbar extends Component {
 		this.props.content.focus();
 	}
 
-	insertHtmlTag( tag ) {
+	attributesToString = ( attributes = {} ) => reduce(
+		attributes,
+		( attributesString, attributeValue, attributeName ) => ` ${ attributeName }="${ attributeValue }"`,
+		''
+	);
+
+	insertHtmlTag( tag, attributes = {} ) {
 		const { content: {
 			selectionEnd,
 			selectionStart,
 			value,
 		} } = this.props;
 		const { openTags } = this.state;
+		const attributesString = this.attributesToString( attributes );
 
 		if ( selectionEnd === selectionStart ) {
 			const isTagOpen = -1 !== openTags.indexOf( tag );
 
 			this.updateContent(
 				value.substring( 0, selectionStart ) +
-				`<${ isTagOpen ? '/' : '' }${ tag }>` +
+				`<${ isTagOpen ? '/' : '' }${ tag }${ isTagOpen ? '' : attributesString }>` +
 				value.substring( selectionStart, value.length )
 			);
 
@@ -61,7 +71,7 @@ export default class EditorHtmlToolbar extends Component {
 		} else {
 			this.updateContent(
 				value.substring( 0, selectionStart ) +
-				`<${ tag }>` +
+				`<${ tag }${ attributesString }>` +
 				value.substring( selectionStart, selectionEnd ) +
 				`</${ tag }>` +
 				value.substring( selectionEnd, value.length )
@@ -75,6 +85,38 @@ export default class EditorHtmlToolbar extends Component {
 
 	handleClickItalic = () => {
 		this.insertHtmlTag( 'em' );
+	}
+
+	handleClickQuote = () => {
+		this.insertHtmlTag( 'blockquote' );
+	}
+
+	handleClickDelete = () => {
+		this.insertHtmlTag( 'del', {
+			datetime: this.props.moment().format(),
+		} );
+	}
+
+	handleClickInsert = () => {
+		this.insertHtmlTag( 'ins', {
+			datetime: this.props.moment().format(),
+		} );
+	}
+
+	handleClickCode = () => {
+		this.insertHtmlTag( 'code' );
+	}
+
+	handleClickMore = () => {
+		const { content: {
+			selectionEnd,
+			value,
+		} } = this.props;
+		this.updateContent(
+			value.substring( 0, selectionEnd ) +
+			'<!--more-->' +
+			value.substring( selectionEnd, value.length )
+		);
 	}
 
 	tagLabel( tag, label ) {
@@ -99,7 +141,44 @@ export default class EditorHtmlToolbar extends Component {
 				>
 					{ this.tagLabel( 'em', 'i' ) }
 				</Button>
+				<Button
+					className="editor-html-toolbar__button-quote"
+					compact
+					onClick={ this.handleClickQuote }
+				>
+					{ this.tagLabel( 'blockquote', 'b-quote' ) }
+				</Button>
+				<Button
+					className="editor-html-toolbar__button-delete"
+					compact
+					onClick={ this.handleClickDelete }
+				>
+					{ this.tagLabel( 'del', 'del' ) }
+				</Button>
+				<Button
+					className="editor-html-toolbar__button-insert"
+					compact
+					onClick={ this.handleClickInsert }
+				>
+					{ this.tagLabel( 'ins', 'ins' ) }
+				</Button>
+				<Button
+					className="editor-html-toolbar__button-code"
+					compact
+					onClick={ this.handleClickCode }
+				>
+					{ this.tagLabel( 'code', 'code' ) }
+				</Button>
+				<Button
+					className="editor-html-toolbar__button-more"
+					compact
+					onClick={ this.handleClickMore }
+				>
+					more
+				</Button>
 			</div>
 		);
 	}
 }
+
+export default localize( EditorHtmlToolbar );

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import AddImageDialog from './add-image-dialog';
 import AddLinkDialog from './add-link-dialog';
 import Button from 'components/button';
 
@@ -23,6 +24,7 @@ export class EditorHtmlToolbar extends Component {
 	state = {
 		openTags: [],
 		selectedText: '',
+		showImageDialog: false,
 		showLinkDialog: false,
 	};
 
@@ -144,6 +146,18 @@ export class EditorHtmlToolbar extends Component {
 		} );
 	}
 
+	handleClickImage = attributes => {
+		const { content: {
+			selectionEnd,
+			value,
+		} } = this.props;
+		this.updateContent(
+			value.substring( 0, selectionEnd ) +
+			`<img${ this.attributesToString( attributes ) } />` +
+			value.substring( selectionEnd, value.length )
+		);
+	}
+
 	handleClickUnorderedList = () => {
 		this.insertHtmlTag( 'ul', {}, {
 			newLine: true,
@@ -197,6 +211,14 @@ export class EditorHtmlToolbar extends Component {
 	tagLabel( tag, label ) {
 		const { openTags } = this.state;
 		return -1 === openTags.indexOf( tag ) ? label : `/${ label }`;
+	}
+
+	openImageDialog = () => {
+		this.setState( { showImageDialog: true } );
+	}
+
+	closeImageDialog = () => {
+		this.setState( { showImageDialog: false } );
 	}
 
 	openLinkDialog = () => {
@@ -257,6 +279,13 @@ export class EditorHtmlToolbar extends Component {
 					{ this.tagLabel( 'ins', 'ins' ) }
 				</Button>
 				<Button
+					className="editor-html-toolbar__button-image"
+					compact
+					onClick={ this.openImageDialog }
+				>
+					img
+				</Button>
+				<Button
 					className="editor-html-toolbar__button-unordered-list"
 					compact
 					onClick={ this.handleClickUnorderedList }
@@ -299,6 +328,11 @@ export class EditorHtmlToolbar extends Component {
 					{ translate( 'Close Tags' ) }
 				</Button>
 
+				<AddImageDialog
+					onClose={ this.closeImageDialog }
+					onInsert={ this.handleClickImage }
+					shouldDisplay={ this.state.showImageDialog }
+				/>
 				<AddLinkDialog
 					onClose={ this.closeLinkDialog }
 					onInsert={ this.handleClickLink }

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import { isMobile } from 'lib/viewport';
 import AddImageDialog from './add-image-dialog';
 import AddLinkDialog from './add-link-dialog';
@@ -224,6 +225,9 @@ export class EditorHtmlToolbar extends Component {
 	}
 
 	render() {
+		if ( ! config.isEnabled( 'post-editor/html-toolbar' ) ) {
+			return null;
+		}
 		const { translate } = this.props;
 		const buttons = {
 			bold: {

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+
+export default class EditorHtmlToolbar extends Component {
+
+	static propTypes = {
+		content: PropTypes.object,
+		onToolbarChangeContent: React.PropTypes.func,
+	};
+
+	state = {
+		openTags: [],
+	};
+
+	setCursorPosition( previousSelectionEnd, insertedContentLength ) {
+		this.props.content.selectionEnd = this.props.content.selectionStart =
+			previousSelectionEnd + insertedContentLength;
+	}
+
+	updateContent( newContent ) {
+		const { content: { selectionEnd, value }, onToolbarChangeContent } = this.props;
+		this.props.content.value = newContent;
+		onToolbarChangeContent( newContent );
+		this.setCursorPosition( selectionEnd, newContent.length - value.length );
+		this.props.content.focus();
+	}
+
+	insertHtmlTag( tag ) {
+		const { content: {
+			selectionEnd,
+			selectionStart,
+			value,
+		} } = this.props;
+		const { openTags } = this.state;
+
+		if ( selectionEnd === selectionStart ) {
+			const isTagOpen = -1 !== openTags.indexOf( tag );
+
+			this.updateContent(
+				value.substring( 0, selectionStart ) +
+				`<${ isTagOpen ? '/' : '' }${ tag }>` +
+				value.substring( selectionStart, value.length )
+			);
+
+			if ( isTagOpen ) {
+				this.setState( {
+					openTags: openTags.filter( openTag => openTag !== tag ),
+				} );
+			} else {
+				this.setState( {
+					openTags: openTags.concat( tag ),
+				} );
+			}
+		} else {
+			this.updateContent(
+				value.substring( 0, selectionStart ) +
+				`<${ tag }>` +
+				value.substring( selectionStart, selectionEnd ) +
+				`</${ tag }>` +
+				value.substring( selectionEnd, value.length )
+			);
+		}
+	}
+
+	handleClickBold = () => {
+		this.insertHtmlTag( 'strong' );
+	}
+
+	handleClickItalic = () => {
+		this.insertHtmlTag( 'em' );
+	}
+
+	tagLabel( tag, label ) {
+		const { openTags } = this.state;
+		return -1 === openTags.indexOf( tag ) ? label : `/${ label }`;
+	}
+
+	render() {
+		return (
+			<div className="editor-html-toolbar">
+				<Button
+					className="editor-html-toolbar__button-bold"
+					compact
+					onClick={ this.handleClickBold }
+				>
+					{ this.tagLabel( 'strong', 'b' ) }
+				</Button>
+				<Button
+					className="editor-html-toolbar__button-italic"
+					compact
+					onClick={ this.handleClickItalic }
+				>
+					{ this.tagLabel( 'em', 'i' ) }
+				</Button>
+			</div>
+		);
+	}
+}

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import { reduce } from 'lodash';
+import { map, reduce } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -197,11 +197,6 @@ export class EditorHtmlToolbar extends Component {
 		this.setState( { openTags: [] } );
 	}
 
-	tagLabel( tag, label ) {
-		const { openTags } = this.state;
-		return -1 === openTags.indexOf( tag ) ? label : `/${ label }`;
-	}
-
 	openImageDialog = () => {
 		this.setState( { showImageDialog: true } );
 	}
@@ -222,102 +217,80 @@ export class EditorHtmlToolbar extends Component {
 		this.setState( { showLinkDialog: false } );
 	}
 
+	tagLabel( tag, label ) {
+		const { openTags } = this.state;
+		return -1 === openTags.indexOf( tag ) ? label : `/${ label }`;
+	}
+
 	render() {
 		const { translate } = this.props;
+		const buttons = {
+			bold: {
+				label: this.tagLabel( 'strong', 'b' ),
+				onClick: this.onClickBold,
+			},
+			italic: {
+				label: this.tagLabel( 'em', 'i' ),
+				onClick: this.onClickItalic,
+			},
+			link: {
+				label: 'link',
+				onClick: this.openLinkDialog,
+			},
+			quote: {
+				label: this.tagLabel( 'blockquote', 'b-quote' ),
+				onClick: this.onClickQuote,
+			},
+			del: {
+				label: this.tagLabel( 'del', 'del' ),
+				onClick: this.onClickDelete,
+			},
+			ins: {
+				label: this.tagLabel( 'ins', 'ins' ),
+				onClick: this.onClickInsert,
+			},
+			image: {
+				label: 'img',
+				onClick: this.openImageDialog,
+			},
+			unorderedList: {
+				label: this.tagLabel( 'ul', 'ul' ),
+				onClick: this.onClickUnorderedList,
+			},
+			orderedList: {
+				label: this.tagLabel( 'ol', 'ol' ),
+				onClick: this.onClickOrderedList,
+			},
+			listItem: {
+				label: this.tagLabel( 'li', 'li' ),
+				onClick: this.onClickListItem,
+			},
+			code: {
+				label: this.tagLabel( 'code', 'code' ),
+				onClick: this.onClickCode,
+			},
+			more: {
+				label: 'more',
+				onClick: this.onClickMore,
+			},
+			closeTags: {
+				label: translate( 'Close Tags' ),
+				onClick: this.onClickCloseTags,
+			},
+		};
+
 		return (
 			<div className="editor-html-toolbar">
-				<Button
-					className="editor-html-toolbar__button-bold"
-					compact
-					onClick={ this.onClickBold }
-				>
-					{ this.tagLabel( 'strong', 'b' ) }
-				</Button>
-				<Button
-					className="editor-html-toolbar__button-italic"
-					compact
-					onClick={ this.onClickItalic }
-				>
-					{ this.tagLabel( 'em', 'i' ) }
-				</Button>
-				<Button
-					className="editor-html-toolbar__button-link"
-					compact
-					onClick={ this.openLinkDialog }
-				>
-					link
-				</Button>
-				<Button
-					className="editor-html-toolbar__button-quote"
-					compact
-					onClick={ this.onClickQuote }
-				>
-					{ this.tagLabel( 'blockquote', 'b-quote' ) }
-				</Button>
-				<Button
-					className="editor-html-toolbar__button-delete"
-					compact
-					onClick={ this.onClickDelete }
-				>
-					{ this.tagLabel( 'del', 'del' ) }
-				</Button>
-				<Button
-					className="editor-html-toolbar__button-insert"
-					compact
-					onClick={ this.onClickInsert }
-				>
-					{ this.tagLabel( 'ins', 'ins' ) }
-				</Button>
-				<Button
-					className="editor-html-toolbar__button-image"
-					compact
-					onClick={ this.openImageDialog }
-				>
-					img
-				</Button>
-				<Button
-					className="editor-html-toolbar__button-unordered-list"
-					compact
-					onClick={ this.onClickUnorderedList }
-				>
-					{ this.tagLabel( 'ul', 'ul' ) }
-				</Button>
-				<Button
-					className="editor-html-toolbar__button-ordered-list"
-					compact
-					onClick={ this.onClickOrderedList }
-				>
-					{ this.tagLabel( 'ol', 'ol' ) }
-				</Button>
-				<Button
-					className="editor-html-toolbar__button-list-item"
-					compact
-					onClick={ this.onClickListItem }
-				>
-					{ this.tagLabel( 'li', 'li' ) }
-				</Button>
-				<Button
-					className="editor-html-toolbar__button-code"
-					compact
-					onClick={ this.onClickCode }
-				>
-					{ this.tagLabel( 'code', 'code' ) }
-				</Button>
-				<Button
-					className="editor-html-toolbar__button-more"
-					compact
-					onClick={ this.onClickMore }
-				>
-					more
-				</Button>
-				<Button
-					className="editor-html-toolbar__button-close-tags"
-					compact
-					onClick={ this.onClickCloseTags }
-				>
-					{ translate( 'Close Tags' ) }
-				</Button>
-
+				{ map( buttons, ( { label, onClick }, tag ) =>
+					<Button
+						className={ `editor-html-toolbar__button-${ tag }` }
+						compact
+						key={ tag }
+						onClick={ onClick }
+					>
+						{ label }
+					</Button>
+				) }
 				<AddImageDialog
 					onClose={ this.closeImageDialog }
 					onInsert={ this.onClickImage }

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { isMobile } from 'lib/viewport';
 import AddImageDialog from './add-image-dialog';
 import AddLinkDialog from './add-link-dialog';
 import Button from 'components/button';
@@ -284,7 +285,7 @@ export class EditorHtmlToolbar extends Component {
 				{ map( buttons, ( { label, onClick }, tag ) =>
 					<Button
 						className={ `editor-html-toolbar__button-${ tag }` }
-						compact
+						compact={ ! isMobile() }
 						key={ tag }
 						onClick={ onClick }
 					>

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -9,7 +9,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import config from 'config';
-import { isMobile } from 'lib/viewport';
 import AddImageDialog from './add-image-dialog';
 import AddLinkDialog from './add-link-dialog';
 import Button from 'components/button';
@@ -281,8 +280,9 @@ export class EditorHtmlToolbar extends Component {
 			<div className="editor-html-toolbar">
 				{ map( buttons, ( { disabled, label, onClick }, tag ) =>
 					<Button
+						borderless
 						className={ `editor-html-toolbar__button-${ tag }` }
-						compact={ ! isMobile() }
+						compact
 						disabled={ disabled }
 						key={ tag }
 						onClick={ onClick }

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -271,6 +271,7 @@ export class EditorHtmlToolbar extends Component {
 				onClick: this.onClickMore,
 			},
 			closeTags: {
+				disabled: ! this.state.openTags.length,
 				label: translate( 'Close Tags' ),
 				onClick: this.onClickCloseTags,
 			},
@@ -278,10 +279,11 @@ export class EditorHtmlToolbar extends Component {
 
 		return (
 			<div className="editor-html-toolbar">
-				{ map( buttons, ( { label, onClick }, tag ) =>
+				{ map( buttons, ( { disabled, label, onClick }, tag ) =>
 					<Button
 						className={ `editor-html-toolbar__button-${ tag }` }
 						compact={ ! isMobile() }
+						disabled={ disabled }
 						key={ tag }
 						onClick={ onClick }
 					>

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -127,7 +127,21 @@ export class EditorHtmlToolbar extends Component {
 	}
 
 	handleClickLink = ( attributes, text ) => {
-		this.insertHtmlTag( 'a', attributes, { text } );
+		if ( text ) {
+			this.insertHtmlTag( 'a', attributes, { text } );
+		} else {
+			const { content: {
+				selectionEnd,
+				value,
+			} } = this.props;
+			this.updateContent(
+				value.substring( 0, selectionEnd ) +
+				this.openHtmlTag( 'a', attributes ) +
+				this.closeHtmlTag( 'a' ) +
+				value.substring( selectionEnd, value.length )
+			);
+			this.setCursorPosition( this.props.content.selectionEnd, -4 );
+		}
 	};
 
 	handleClickQuote = () => {

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -269,7 +269,7 @@ export class EditorHtmlToolbar extends Component {
 			more: {
 				onClick: this.onClickMore,
 			},
-			closeTags: {
+			'close-tags': {
 				disabled: ! this.state.openTags.length,
 				label: translate( 'close tags' ),
 				onClick: this.onClickCloseTags,

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -271,7 +271,7 @@ export class EditorHtmlToolbar extends Component {
 			},
 			closeTags: {
 				disabled: ! this.state.openTags.length,
-				label: translate( 'Close Tags' ),
+				label: translate( 'close tags' ),
 				onClick: this.onClickCloseTags,
 			},
 		};

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -19,8 +19,19 @@
 		height: 26px;
 		margin: 6px 0;
 		padding: 4px 12px;
+		position: relative;
 		text-transform: lowercase;
 		min-width: 30px;
+
+		&.is-tag-open {
+			padding-left: 16px;
+			padding-right: 8px;
+			&::before {
+				content: '/';
+				left: 12px;
+				position: absolute;
+			}
+		}
 
 		&:hover {
 			color: $gray-dark;
@@ -32,13 +43,13 @@
 	}
 }
 
-.editor-html-toolbar__button-bold {
+.editor-html-toolbar__button-strong {
 	font-weight: bold;
 }
-.editor-html-toolbar__button-italic {
+.editor-html-toolbar__button-em {
 	font-style: italic;
 }
-.editor-html-toolbar__button-link.button {
+.editor-html-toolbar__button-a.button {
 	color: $blue-wordpress;
 	text-decoration: underline;
 }

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -15,11 +15,16 @@
 
 	.button {
 		border-right: 1px solid lighten( $gray, 30% );
+		color: darken( $gray, 20% );
 		height: 26px;
 		margin: 6px 0;
 		padding: 4px 12px;
 		text-transform: lowercase;
 		min-width: 30px;
+
+		&:hover {
+			color: $gray-dark;
+		}
 
 		&:last-child {
 			border: none;

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -35,3 +35,18 @@
 .editor-html-toolbar__button-code {
 	font-family: $code;
 }
+
+.editor-html-toolbar__dialog .dialog__content {
+	min-width: 40vw;
+}
+.editor-html-toolbar__dialog .post-selector {
+	margin-bottom: 16px;
+}
+@include breakpoint( "<660px" ) {
+	.editor-html-toolbar__dialog {
+		width: 90%;
+	}
+	.editor-html-toolbar__dialog .dialog__content {
+		min-width: none;
+	}
+}

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -4,14 +4,14 @@
 	border-bottom-width: 1px;
 	box-sizing: border-box;
 	margin: 0 auto;
-	max-width: 100%;
+	max-width: 700px;
+	width: 100%;
 	padding: 0 2px;
 	position: relative;
 
-	@include breakpoint( ">960px" ) {
+	@media ( min-width: 930px ) {
 		border-left-width: 1px;
 		border-right-width: 1px;
-		width: 700px;
 	}
 
 	.button {
@@ -26,10 +26,14 @@
 .editor-html-toolbar__button-italic {
 	font-style: italic;
 }
-.editor-html-toolbar__button-delete {
+.editor-html-toolbar__button-link.button {
+	color: $blue-wordpress;
+	text-decoration: underline;
+}
+.editor-html-toolbar__button-del {
 	text-decoration: line-through;
 }
-.editor-html-toolbar__button-insert {
+.editor-html-toolbar__button-ins {
 	text-decoration: underline;
 }
 .editor-html-toolbar__button-code {

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -6,7 +6,6 @@
 	margin: 0 auto;
 	max-width: 700px;
 	width: 100%;
-	padding: 0 2px;
 	position: relative;
 
 	@media ( min-width: 930px ) {
@@ -15,8 +14,15 @@
 	}
 
 	.button {
-		margin: 4px 2px;
+		border-right: 1px solid lighten( $gray, 30% );
+		height: 38px;
+		padding: 4px 12px;
 		text-transform: lowercase;
+		min-width: 30px;
+
+		&:last-child {
+			border: none;
+		}
 	}
 }
 

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -26,3 +26,12 @@
 .editor-html-toolbar__button-italic {
 	font-style: italic;
 }
+.editor-html-toolbar__button-delete {
+	text-decoration: line-through;
+}
+.editor-html-toolbar__button-insert {
+	text-decoration: underline;
+}
+.editor-html-toolbar__button-code {
+	font-family: $code;
+}

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -1,0 +1,28 @@
+.editor-html-toolbar {
+	border-color: lighten( $gray, 20% );
+	border-style: solid;
+	border-bottom-width: 1px;
+	box-sizing: border-box;
+	margin: 0 auto;
+	max-width: 100%;
+	padding: 0 2px;
+	position: relative;
+
+	@include breakpoint( ">960px" ) {
+		border-left-width: 1px;
+		border-right-width: 1px;
+		width: 700px;
+	}
+
+	.button {
+		margin: 4px 2px;
+		text-transform: lowercase;
+	}
+}
+
+.editor-html-toolbar__button-bold {
+	font-weight: bold;
+}
+.editor-html-toolbar__button-italic {
+	font-style: italic;
+}

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -15,7 +15,8 @@
 
 	.button {
 		border-right: 1px solid lighten( $gray, 30% );
-		height: 38px;
+		height: 26px;
+		margin: 6px 0;
 		padding: 4px 12px;
 		text-transform: lowercase;
 		min-width: 30px;

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -62,6 +62,9 @@
 .editor-html-toolbar__button-code {
 	font-family: $code;
 }
+.editor-html-toolbar__button-close-tags.button[disabled]:hover {
+	color: lighten( $gray, 30% );
+}
 
 .editor-html-toolbar__dialog .dialog__content {
 	min-width: 40vw;

--- a/config/development.json
+++ b/config/development.json
@@ -116,6 +116,7 @@
 		"persist-redux": true,
 		"plans/personal-plan": true,
 		"post-editor-github-link": false,
+		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
 		"post-editor/insert-menu": true,
 		"post-editor/media-advanced": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -75,6 +75,7 @@
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
+		"post-editor/html-toolbar": true,
 		"post-editor/insert-menu": true,
 		"press-this": true,
 		"preview-layout": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -91,6 +91,7 @@
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
+		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
 		"post-editor/insert-menu": true,
 		"press-this": true,


### PR DESCRIPTION
My take on https://github.com/Automattic/wp-calypso/issues/308

## Porting of the WP Admin HTML editor toolbar.

**WP Admin**
<img width="730" alt="screen shot 2017-01-09 at 15 14 15" src="https://cloud.githubusercontent.com/assets/2070010/21769308/552b04ca-d67e-11e6-899c-65b51d94adf9.png">

**Calypso**
<img width="713" alt="screen shot 2017-01-17 at 17 37 13" src="https://cloud.githubusercontent.com/assets/2070010/22029843/0928cd14-dcdc-11e6-9983-d47d8873bae6.png">
<img width="331" alt="screen shot 2017-01-17 at 17 38 21" src="https://cloud.githubusercontent.com/assets/2070010/22029844/0928ffc8-dcdc-11e6-9b93-e7ef2c4ecb02.png">

I've tried to replicate the WP Admin behaviour as much as possible, while also taking advantage of Calypso perks.
The HTML toolbar works on the same `<textarea>` ref of TinyMCE. Any change done with the HTML toolbar is instantly available in Visual mode, using the same `onEditorContentChange` function.

The toolbar currently supports:
- open tag (`<strong>`)
- close tag (`</strong>`)
- open and close tag around selected text (`<strong>selected text</strong>`)
- open and close tag with inner text (`<a href="#">link</a>`)
- self closed tags (`<img src="#" />`)
- custom content (`<!--more-->`)

It also supports tag attributes and an extensible `options` object, for now used to add newlines where needed (e.g. for `<ul>` and `<ol>`).

The "Close Tags" button closes any open tag (saved in the component state) in reverse order of insertion. It is disabled when there are no open tags to close.

The "Insert Link" dialog is pretty much a stripped down carbon copy of the TinyMCE plugin. I could have modified the TinyMCE plugin instead, but it felt more hacky than copying it.

At this time, I've yet to tackle the "Proofread" button (it currently is a TinyMCE plugin using After the Deadline), so any suggestion would be much appreciated.

The toolbar is hidden behind a development-only feature flag, so keep it in mind when running it.

This PR does not take into account the various Add Media / Contact Form / etc. dialogs, to avoid bloating it more than strictly needed.

## Cool Gif (with the old design)

![jan-09-2017 20-47-19](https://cloud.githubusercontent.com/assets/2070010/21780709/eb2c5f7c-d6ac-11e6-9b7e-bc19aa440b05.gif)

## Buttons

- [x] Bold
- [x] Italic
- [x] Link
- [x] Blockquote
- [x] Deleted
- [x] Inserted
- [x] Image
- [x] Unordered List
- [x] Ordered List
- [x] List Item
- [x] Code
- [x] More
- [x] Close Tags
~Proofread~

## Clean up

- [x] DRY-fy the component
- [x] Browsers compatibility
    - ✅ Chrome 55 / macOS 10.12
    - ✅ Chrome 55 / Windows 10
    - ✅ Chrome 55 / Android 6.0
    - ✅ Safari 10 / macOS 10.12
    - ✅ Firefox 50.1 / macOS 10.12
    - ✅ Internet Explorer 11 / Windows 10
    - ✅ Edge / Windows 10
