### PR TITLE
ATAT: Fix getEligibilityStatus selector

### DIFF
--- a/client/state/automated-transfer/selectors.js
+++ b/client/state/automated-transfer/selectors.js
@@ -61,7 +61,7 @@ export const getEligibility = compose(
  * @param {Object} state global app state
  * @returns {boolean} eligibility status for site
  */
-export const getEligibilityStatus = state => !! get( state, 'lastUpdated', 0 ) && ! get( state, 'eligibilityHolds', [] );
+export const getEligibilityStatus = state => !! get( state, 'lastUpdate', 0 ) && ! get( state, 'eligibilityHolds', [] ).length;
 
 /**
  * Returns eligibility status for transfer


### PR DESCRIPTION
Fix a typo and array length check that was preventing any site from being eligible for automated transfer.

@vindl I've pulled this out of #10485 because it is blocking some other testing that I'm doing, and also seems to make sense as a standalone PR. It will simplify #10485 a bit as well.

**To Test**
* Use a business site with a mapped domain (such a site should be eligible for automated transfer)
* go to http://calypso.localhost:3000/design/upload/{site}
* If there are no errors in the list of conflicts, the _Proceed_ button should be active
