### PR TITLE
Reader: Make sure photo card images are entirely shown when expanded

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -161,7 +161,7 @@ export default class ReaderPostCard extends React.Component {
 				? <PostPhoto imageUri={ post.canonical_media.src } href={ post.URL } imageSize={ {
 					height: post.canonical_media.height,
 					width: post.canonical_media.width,
-				} } onExpanded={ this.handlePhotoCardExpanded } />
+				} } onExpanded={ this.handlePhotoCardExpanded } title={ title } />
 				: <FeaturedImage imageUri={ post.canonical_media.src } href={ post.URL } />;
 		}
 
@@ -173,11 +173,13 @@ export default class ReaderPostCard extends React.Component {
 					{ ! isGallery && featuredAsset }
 					{ isGallery && <PostGallery post={ post } /> }
 					<div className="reader-post-card__post-details">
-						<AutoDirection>
-							<h1 className="reader-post-card__title">
-								<a className="reader-post-card__title-link" href={ post.URL }>{ title }</a>
-							</h1>
-						</AutoDirection>
+						{ ! isPhotoOnly &&
+							<AutoDirection>
+								<h1 className="reader-post-card__title">
+									<a className="reader-post-card__title-link" href={ post.URL }>{ title }</a>
+								</h1>
+							</AutoDirection>
+						}
 						{ showExcerpt && (
 								<AutoDirection>
 									<div className="reader-post-card__excerpt"

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -161,12 +161,12 @@ export default class ReaderPostCard extends React.Component {
 				? <PostPhoto imageUri={ post.canonical_media.src } href={ post.URL } imageSize={ {
 					height: post.canonical_media.height,
 					width: post.canonical_media.width,
-				} } onExpanded={ this.handlePhotoCardExpanded } title={ title } />
+				} } onExpanded={ this.handlePhotoCardExpanded } title={ title } onClick={ this.handleCardClick } />
 				: <FeaturedImage imageUri={ post.canonical_media.src } href={ post.URL } />;
 		}
 
 		return (
-			<Card className={ classes } onClick={ this.handleCardClick }>
+			<Card className={ classes } onClick={ ! isPhotoOnly && this.handleCardClick }>
 				<PostByline post={ post } site={ site } feed={ feed } showSiteName={ showSiteName } />
 				{ showPrimaryFollowButton && followUrl && <FollowButton siteUrl={ followUrl } followSource={ followSource } /> }
 				<div className="reader-post-card__post">

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -66,18 +66,19 @@ class PostPhoto extends React.Component {
 			backgroundRepeat: 'no-repeat',
 			backgroundPosition: 'center'
 		};
-
+		let newWidth, newHeight;
 		if ( this.state.isExpanded ) {
 			const viewportHeight = this.getViewportHeight();
 			const cardWidth = this.state.cardWidth;
 			const { width: naturalWidth, height: naturalHeight } = imageSize;
 
-			const newHeight = Math.min(
+			newHeight = Math.min(
 				( naturalHeight / naturalWidth ) * cardWidth,
 				viewportHeight - 176
 			);
-
+			newWidth = ( naturalWidth / naturalHeight ) * newHeight;
 			featuredImageStyle.height = newHeight;
+			featuredImageStyle.width = newWidth;
 		}
 
 		const classes = classnames( {
@@ -85,11 +86,20 @@ class PostPhoto extends React.Component {
 			'is-expanded': this.state.isExpanded
 		} );
 
+		const divStyle = this.state.isExpanded
+			? { height: newHeight, width: newWidth, margin: 'auto' }
+			: {};
+
 		return (
-			<a className={ classes } href={ href } style={ featuredImageStyle } onClick={ this.handleClick }>
-				<div ref={ this.handleWidthDivLoaded } style={ { width: '100%' } }></div>
-				{ children }
-			</a>
+			<div style={ divStyle }>
+				<a className={ classes } href={ href } style={ featuredImageStyle } onClick={ this.handleClick }>
+					<div ref={ this.handleWidthDivLoaded } style={ { width: '100%' } }></div>
+					{ children }
+				</a>
+				<h1 className="reader-post-card__title">
+					<a className="reader-post-card__title-link" href={ this.props.href }>{ this.props.title }</a>
+				</h1>
+			</div>
 		);
 	}
 }

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -62,7 +62,7 @@ class PostPhoto extends React.Component {
 
 		const featuredImageStyle = {
 			backgroundImage: 'url(' + cssSafeUrl( imageUri ) + ')',
-			backgroundSize: 'cover',
+			backgroundSize: this.state.isExpanded ? 'contain' : 'cover',
 			backgroundRepeat: 'no-repeat',
 			backgroundPosition: 'center'
 		};

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -96,7 +96,7 @@ class PostPhoto extends React.Component {
 		} );
 
 		const divStyle = this.state.isExpanded
-			? { height: newHeight, width: newWidth, margin: 'auto', paddingBottom: '20px' }
+			? { height: newHeight, width: newWidth, margin: 'auto', paddingBottom: '12px' }
 			: {};
 
 		return (

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -96,7 +96,7 @@ class PostPhoto extends React.Component {
 		} );
 
 		const divStyle = this.state.isExpanded
-			? { height: newHeight, width: newWidth, margin: 'auto', paddingBottom: '12px' }
+			? { height: newHeight, width: newWidth, margin: '0 auto' }
 			: {};
 
 		return (

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -9,6 +9,7 @@ import classnames from 'classnames';
  * Internal Dependencies
  */
 import cssSafeUrl from 'lib/css-safe-url';
+import AutoDirection from 'components/auto-direction';
 
 class PostPhoto extends React.Component {
 
@@ -104,9 +105,11 @@ class PostPhoto extends React.Component {
 					<div ref={ this.handleWidthDivLoaded } style={ { width: '100%' } }></div>
 					{ children }
 				</a>
-				<h1 className="reader-post-card__title">
-					<a className="reader-post-card__title-link" href={ this.props.href }>{ this.props.title }</a>
-				</h1>
+				<AutoDirection>
+					<h1 className="reader-post-card__title">
+						<a className="reader-post-card__title-link" href={ this.props.href }>{ this.props.title }</a>
+					</h1>
+				</AutoDirection>
 			</div>
 		);
 	}

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -19,10 +19,10 @@ class PostPhoto extends React.Component {
 
 	handleClick = ( event ) => {
 		if ( this.state.isExpanded ) {
+			this.props.onClick( event );
 			return;
 		}
 
-		// If the photo's not expanded, don't open full post yet
 		event.preventDefault();
 		this.setState( { isExpanded: true } );
 		this.props.onExpanded();
@@ -30,6 +30,15 @@ class PostPhoto extends React.Component {
 
 	getViewportHeight = () =>
 		Math.max( document.documentElement.clientHeight, window.innerHeight || 0 );
+
+	/* We want photos to be able to expand to be essentially full-screen
+	 * We settled on viewport height - 176px because the
+	 *  - masterbar is 47px tall
+	 *  - card header is 74px tall
+	 *  - card footer is 55px tall
+	 * 47 + 74 + 55 = 176
+	 */
+	getMaxPhotoHeight = () => this.getViewportHeight() - 176;
 
 	setCardWidth = () => {
 		if ( this.widthDivRef ) {
@@ -68,13 +77,12 @@ class PostPhoto extends React.Component {
 		};
 		let newWidth, newHeight;
 		if ( this.state.isExpanded ) {
-			const viewportHeight = this.getViewportHeight();
 			const cardWidth = this.state.cardWidth;
 			const { width: naturalWidth, height: naturalHeight } = imageSize;
 
 			newHeight = Math.min(
 				( naturalHeight / naturalWidth ) * cardWidth,
-				viewportHeight - 176
+				this.getMaxPhotoHeight(),
 			);
 			newWidth = ( naturalWidth / naturalHeight ) * newHeight;
 			featuredImageStyle.height = newHeight;
@@ -87,11 +95,11 @@ class PostPhoto extends React.Component {
 		} );
 
 		const divStyle = this.state.isExpanded
-			? { height: newHeight, width: newWidth, margin: 'auto' }
+			? { height: newHeight, width: newWidth, margin: 'auto', paddingBottom: '20px' }
 			: {};
 
 		return (
-			<div style={ divStyle }>
+			<div style={ divStyle } >
 				<a className={ classes } href={ href } style={ featuredImageStyle } onClick={ this.handleClick }>
 					<div ref={ this.handleWidthDivLoaded } style={ { width: '100%' } }></div>
 					{ children }

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -104,7 +104,8 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 			.reader-post-card__post-details {
 				flex: 0 auto; // IE11 Photo card actions hidden
-				margin-top: -10px;
+				margin: 0;
+				padding-top: 11px;
 			}
 
 			.reader-post-card__title {
@@ -112,7 +113,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 				font-family: $sans;
 				font-size: 10px;
 				position: relative;
-					bottom: 22px;
+					bottom: 30px;
 					left: 20px;
 				text-shadow: 0 1px rgba(0, 0, 0, 0.3);
 				white-space: nowrap;
@@ -120,6 +121,8 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 				text-overflow: ellipsis;
 				overflow: hidden;
 				z-index: z-index( 'root', '.reader-post-card__title' );
+				margin-bottom: -15px; // relative elements need a negative margin so they don't create bottom padding
+				height: 15px;
 			}
 
 			.reader-post-card__title .reader-post-card__title-link {
@@ -129,7 +132,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			}
 
 			.reader-post-actions {
-				margin: 7px 0 0;
+				margin: 0;
 			}
 
 			.reader-post-actions .reader-post-actions__visit {
@@ -195,14 +198,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	margin-bottom: 0;
 	max-width: 100%;
 	width: 100%;
-
-	@media #{$reader-post-card-breakpoint-medium} {
-		padding-bottom: 10px;
-	}
-
-	@media #{$reader-post-card-breakpoint-small} {
-		padding-bottom: 10px;
-	}
 
 	&:hover {
 		cursor: zoom-in;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -197,11 +197,11 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	width: 100%;
 
 	@media #{$reader-post-card-breakpoint-medium} {
-		margin-bottom: 10px;
+		padding-bottom: 10px;
 	}
 
 	@media #{$reader-post-card-breakpoint-small} {
-		margin-bottom: 10px;
+		padding-bottom: 10px;
 	}
 
 	&:hover {

--- a/client/components/auto-direction/index.jsx
+++ b/client/components/auto-direction/index.jsx
@@ -123,16 +123,13 @@ const setChildDirection = ( child ) => {
  */
 const AutoDirection = ( props ) => {
 	const { children } = props;
-	const directionedChildren = React.Children.map( children, setChildDirection );
+	const directionedChild = setChildDirection( children );
 
-	return <div>{ directionedChildren }</div>;
+	return directionedChild;
 };
 
 AutoDirection.propTypes = {
-	children: PropTypes.oneOfType( [
-		PropTypes.arrayOf( PropTypes.node ),
-		PropTypes.node
-	] )
+	children: PropTypes.node,
 };
 
 export default AutoDirection;


### PR DESCRIPTION
Switch the containment from cover to contain when expanding. This allows the image to always be shown entirely.