### PR TITLE
Related monthly and yearly plans

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -749,3 +749,4 @@ export function getMonthlyPlanByYearly( plan ) {
 			return '';
 	}
 }
+

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -234,7 +234,8 @@ export const PLANS_LIST = {
 			FEATURE_PREMIUM_SUPPORT,
 			FEATURE_MALWARE_SCANNING_DAILY
 		],
-		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
+		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' ),
+		relatedPlan: PLAN_JETPACK_PREMIUM_MONTHLY
 	},
 	[ PLAN_JETPACK_PERSONAL ]: {
 		getTitle: () => i18n.translate( 'Personal' ),
@@ -254,7 +255,8 @@ export const PLANS_LIST = {
 			FEATURE_EASY_SITE_MIGRATION,
 			FEATURE_PREMIUM_SUPPORT
 		],
-		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
+		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' ),
+		relatedPlan: PLAN_JETPACK_PERSONAL_MONTHLY
 	},
 
 	[ PLAN_JETPACK_PREMIUM_MONTHLY ]: {
@@ -275,7 +277,8 @@ export const PLANS_LIST = {
 			FEATURE_PREMIUM_SUPPORT,
 			FEATURE_MALWARE_SCANNING_DAILY
 		],
-		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' )
+		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
+		relatedPlan: PLAN_JETPACK_PREMIUM
 	},
 
 	[ PLAN_JETPACK_PERSONAL_MONTHLY ]: {
@@ -296,7 +299,8 @@ export const PLANS_LIST = {
 			FEATURE_EASY_SITE_MIGRATION,
 			FEATURE_PREMIUM_SUPPORT
 		],
-		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' )
+		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
+		relatedPlan: PLAN_JETPACK_PERSONAL
 	},
 
 	[ PLAN_JETPACK_BUSINESS ]: {
@@ -320,7 +324,8 @@ export const PLANS_LIST = {
 			FEATURE_POLLS_PRO,
 			FEATURE_ADVANCED_SEO
 		],
-		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
+		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' ),
+		relatedPlan: PLAN_JETPACK_BUSINESS_MONTHLY
 
 	},
 	[ PLAN_JETPACK_BUSINESS_MONTHLY ]: {
@@ -344,7 +349,8 @@ export const PLANS_LIST = {
 			FEATURE_POLLS_PRO,
 			FEATURE_ADVANCED_SEO
 		],
-		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' )
+		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
+		relatedPlan: PLAN_JETPACK_BUSINESS
 	}
 };
 

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -17,6 +17,7 @@ const PlanFeaturesActions = ( {
 	className,
 	available = true,
 	current = false,
+	isRelatedToCurrentPlan = false,
 	primaryUpgrade = false,
 	freePlan = false,
 	onUpgradeClick = noop,
@@ -41,6 +42,13 @@ const PlanFeaturesActions = ( {
 			<Button className={ classes } href={ manageHref } disabled={ ! manageHref }>
 				<Gridicon size={ 18 } icon="checkmark" />
 				{ canPurchase ? translate( 'Your plan' ) : translate( 'Current plan' ) }
+			</Button>
+		);
+	}  else if ( isRelatedToCurrentPlan && ! isInSignup ) {
+		upgradeButton = (
+			<Button className={ classes } href={ manageHref } disabled={ ! manageHref }>
+				<Gridicon size={ 18 } icon="checkmark" />
+				{ canPurchase ? translate( 'Your plan (period)' ) : translate( 'Current plan' ) }
 			</Button>
 		);
 	} else if ( available || isPlaceholder ) {

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -18,6 +18,7 @@ const PlanFeaturesActions = ( {
 	available = true,
 	current = false,
 	isRelatedToCurrentPlan = false,
+	isMonthly = false,
 	primaryUpgrade = false,
 	freePlan = false,
 	onUpgradeClick = noop,
@@ -28,6 +29,14 @@ const PlanFeaturesActions = ( {
 	isLandingPage
 } ) => {
 	let upgradeButton;
+
+	const renderRelatedPlanText = () => {
+		if ( ! isMonthly ) {
+			return canPurchase ? translate( 'Your plan (monthly)' ) : translate( 'Current plan (monthly)' );
+		}
+		return canPurchase ? translate( 'Your plan (yearly)' ) : translate( 'Current plan (yearly)' );
+	};
+
 	const classes = classNames(
 		'plan-features__actions-button',
 		{
@@ -44,11 +53,11 @@ const PlanFeaturesActions = ( {
 				{ canPurchase ? translate( 'Your plan' ) : translate( 'Current plan' ) }
 			</Button>
 		);
-	}  else if ( isRelatedToCurrentPlan && ! isInSignup ) {
+	} else if ( isRelatedToCurrentPlan && ! isInSignup ) {
 		upgradeButton = (
 			<Button className={ classes } href={ manageHref } disabled={ ! manageHref }>
 				<Gridicon size={ 18 } icon="checkmark" />
-				{ canPurchase ? translate( 'Your plan (period)' ) : translate( 'Current plan' ) }
+				{ renderRelatedPlanText( canPurchase, isMonthly ) }
 			</Button>
 		);
 	} else if ( available || isPlaceholder ) {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -25,8 +25,7 @@ import {
 	getPlanRawPrice,
 	getPlan,
 	getPlanSlug,
-	getPlanBySlug,
-	isRelatedPlan
+	getPlanBySlug
 } from 'state/plans/selectors';
 import {
 	isPopular,
@@ -163,7 +162,8 @@ class PlanFeatures extends Component {
 				relatedMonthlyPlan,
 				primaryUpgrade,
 				isPlaceholder,
-				isRelatedToCurrentPlan
+				isRelatedToCurrentPlan,
+				monthly
 			} = properties;
 
 			return (
@@ -199,6 +199,7 @@ class PlanFeatures extends Component {
 						isInSignup={ isInSignup }
 						isLandingPage={ isLandingPage }
 						isRelatedToCurrentPlan = { isRelatedToCurrentPlan }
+						isMonthly = { monthly }
 					/>
 					<FoldableCard
 						header={ translate( 'Show features' ) }
@@ -530,8 +531,8 @@ export default connect(
 				const popular = isPopular( plan ) && ! isPaid;
 				const newPlan = isNew( plan ) && ! isPaid;
 				const currentPlan = sitePlan && sitePlan.product_slug;
-				const isRelatedToCurrentPlan = planObject ? isRelatedPlan( state, planProductId, planObject.product_id ) : false;
 
+				const isRelatedToCurrentPlan = planObject ? planConstantObj.relatedPlan === sitePlan.product_slug : false;
 				if ( placeholder || ! planObject || isLoadingSitePlans ) {
 					isPlaceholder = true;
 				}
@@ -571,7 +572,8 @@ export default connect(
 					),
 					rawPrice: getPlanRawPrice( state, planProductId, ! relatedMonthlyPlan && showMonthly ),
 					relatedMonthlyPlan: relatedMonthlyPlan,
-					isRelatedToCurrentPlan
+					isRelatedToCurrentPlan,
+					monthly: isMonthly( plan )
 				};
 			} )
 		);

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -25,7 +25,8 @@ import {
 	getPlanRawPrice,
 	getPlan,
 	getPlanSlug,
-	getPlanBySlug
+	getPlanBySlug,
+	isRelatedPlan
 } from 'state/plans/selectors';
 import {
 	isPopular,
@@ -161,7 +162,8 @@ class PlanFeatures extends Component {
 				rawPrice,
 				relatedMonthlyPlan,
 				primaryUpgrade,
-				isPlaceholder
+				isPlaceholder,
+				isRelatedToCurrentPlan
 			} = properties;
 
 			return (
@@ -196,6 +198,7 @@ class PlanFeatures extends Component {
 						isPlaceholder={ isPlaceholder }
 						isInSignup={ isInSignup }
 						isLandingPage={ isLandingPage }
+						isRelatedToCurrentPlan = { isRelatedToCurrentPlan }
 					/>
 					<FoldableCard
 						header={ translate( 'Show features' ) }
@@ -294,7 +297,8 @@ class PlanFeatures extends Component {
 				onUpgradeClick,
 				planName,
 				primaryUpgrade,
-				isPlaceholder
+				isPlaceholder,
+				isRelatedToCurrentPlan
 			} = properties;
 
 			const classes = classNames(
@@ -317,6 +321,7 @@ class PlanFeatures extends Component {
 						isInSignup={ isInSignup }
 						isLandingPage={ isLandingPage }
 						manageHref={ `/plans/my-plan/${ site.slug }` }
+						isRelatedToCurrentPlan={ isRelatedToCurrentPlan }
 					/>
 				</td>
 			);
@@ -443,7 +448,8 @@ class PlanFeatures extends Component {
 				onUpgradeClick,
 				planName,
 				primaryUpgrade,
-				isPlaceholder
+				isPlaceholder,
+				isRelatedToCurrentPlan
 			} = properties;
 			const classes = classNames(
 				'plan-features__table-item',
@@ -464,6 +470,7 @@ class PlanFeatures extends Component {
 						isInSignup={ isInSignup }
 						isLandingPage={ isLandingPage }
 						manageHref={ `/plans/my-plan/${ site.slug }` }
+						isRelatedToCurrentPlan={ isRelatedToCurrentPlan }
 					/>
 				</td>
 			);
@@ -523,6 +530,7 @@ export default connect(
 				const popular = isPopular( plan ) && ! isPaid;
 				const newPlan = isNew( plan ) && ! isPaid;
 				const currentPlan = sitePlan && sitePlan.product_slug;
+				const isRelatedToCurrentPlan = planObject ? isRelatedPlan( state, planProductId, planObject.product_id ) : false;
 
 				if ( placeholder || ! planObject || isLoadingSitePlans ) {
 					isPlaceholder = true;
@@ -562,7 +570,8 @@ export default connect(
 						newPlan
 					),
 					rawPrice: getPlanRawPrice( state, planProductId, ! relatedMonthlyPlan && showMonthly ),
-					relatedMonthlyPlan: relatedMonthlyPlan
+					relatedMonthlyPlan: relatedMonthlyPlan,
+					isRelatedToCurrentPlan
 				};
 			} )
 		);

--- a/client/state/plans/schema.js
+++ b/client/state/plans/schema.js
@@ -41,7 +41,8 @@ export const itemsSchema = {
 			store: { type: [ 'number', 'null' ] },
 			support_document: { type: 'string' },
 			tagline: { type: 'string' },
-			width: { type: 'number' }
+			width: { type: 'number' },
+			relatedPlan: { type: 'boolean' }
 		}
 	}
 };

--- a/client/state/plans/selectors.js
+++ b/client/state/plans/selectors.js
@@ -77,10 +77,3 @@ export function getPlanSlug( state, productId ) {
 
 	return get( plan, 'product_slug', null );
 }
-
-export function isRelatedPlan( state, productId, relatedPlanProductId ) {
-	const plan = getPlan( state, productId );
-	const relatedPlan = getPlan( state, relatedPlanProductId );
-
-	return plan.relatedPlan === relatedPlan.product_slug;
-}

--- a/client/state/plans/selectors.js
+++ b/client/state/plans/selectors.js
@@ -77,3 +77,10 @@ export function getPlanSlug( state, productId ) {
 
 	return get( plan, 'product_slug', null );
 }
+
+export function isRelatedPlan( state, productId, relatedPlanProductId ) {
+	const plan = getPlan( state, productId );
+	const relatedPlan = getPlan( state, relatedPlanProductId );
+
+	return plan.relatedPlan === relatedPlan.product_slug;
+}


### PR DESCRIPTION
Right now, if your site already have a jetpack plan but you are looking at the plans page with a different billing period selected (your plan is monthly and you are looking at the yearly plans), you just see an empty space where the button should be:

![image](https://cloud.githubusercontent.com/assets/1554855/21777544/8d7648c8-d69f-11e6-9c39-b3163180ded5.png)

This PR binds the monthly and yearly plans for each type of plans, so we can know that the site already have that plan, but in a different billing period:

![image](https://cloud.githubusercontent.com/assets/1554855/21777573/a97a4510-d69f-11e6-835e-3156b8f0aefa.png)

It currently doesn't do anything else (you still can't change to a different billing period), but at least we are not showing an empty white space there until we can develop the period change functionality.

How To Test
====
0. You need a connected jetpack site, with a jetpack plan
1. go to http://calypso.localhost:3000/plans and choose your site
2. Change between the different billing periods and see that the plan is always recogniced

ping @rickybanister @tyxla 