### PR TITLE
Purchases: Update the cancelation survey so that it shows different reasons for Jetpack subscribers.

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -19,25 +19,43 @@ const CancelPurchaseForm = React.createClass( {
 		surveyStep: React.PropTypes.number.isRequired,
 		showSurvey: React.PropTypes.bool.isRequired,
 		defaultContent: React.PropTypes.node.isRequired,
-		onInputChange: React.PropTypes.func.isRequired
+		onInputChange: React.PropTypes.func.isRequired,
+		isJetpack: React.PropTypes.bool.isRequired
 	},
 
 	getInitialState() {
 		// shuffle reason order, but keep anotherReasonOne last
-		const questionOneOrder = shuffle( [
+		var questionOneOrder = shuffle( [
 			'couldNotInstall',
 			'tooHard',
 			'didNotInclude',
 			'onlyNeedFree'
 		] );
-		questionOneOrder.push( 'anotherReasonOne' );
 
-		const questionTwoOrder = shuffle( [
+		var questionTwoOrder = shuffle( [
 			'stayingHere',
 			'otherWordPress',
 			'differentService',
 			'noNeed'
 		] );
+
+		// set different reason groupings for Jetpack subscribers
+		if ( this.props.isJetpack ) {
+			questionOneOrder = shuffle( [
+				'couldNotActivate',
+				'wpTooHard',
+				'didNotInclude',
+				'onlyNeedFree'
+			] );
+
+			questionTwoOrder = shuffle( [
+				'stayingHere',
+				'otherPlugin',
+				'noNeed'
+			] );
+		}
+
+		questionOneOrder.push( 'anotherReasonOne' );
 		questionTwoOrder.push( 'anotherReasonTwo' );
 
 		return {
@@ -205,6 +223,49 @@ const CancelPurchaseForm = React.createClass( {
 			</FormLabel>
 		);
 
+		// Survey questions only for Jetpack subscriptions
+		const couldNotActivateInput = (
+			<FormTextInput
+				className="cancel-purchase-form__reason-input"
+				name="couldNotActivateInput"
+				id="couldNotActivateInput"
+				value={ this.state.questionOneText }
+				onChange={ this.onTextOneChange }
+				placeholder={ this.translate( 'Where did you run into problems?' ) } />
+		);
+		reasons.couldNotActivate = (
+			<FormLabel key="couldNotActivate">
+				<FormRadio
+					name="couldNotActivate"
+					value="couldNotActivate"
+					checked={ 'couldNotActivate' === this.state.questionOneRadio }
+					onChange={ this.onRadioOneChange } />
+				<span>{ this.translate( 'I was unable to activate or use the product.' ) }</span>
+				{ 'couldNotActivate' === this.state.questionOneRadio && couldNotActivateInput }
+			</FormLabel>
+		);
+
+		const wpTooHardInput = (
+			<FormTextInput
+				className="cancel-purchase-form__reason-input"
+				name="wpTooHardInput"
+				id="wpTooHardInput"
+				value={ this.state.questionOneText }
+				onChange={ this.onTextOneChange }
+				placeholder={ this.translate( 'Where did you run into problems?' ) } />
+		);
+		reasons.wpTooHard = (
+			<FormLabel key="wpTooHard">
+				<FormRadio
+					name="wpTooHard"
+					value="wpTooHard"
+					checked={ 'wpTooHard' === this.state.questionOneRadio }
+					onChange={ this.onRadioOneChange } />
+				<span>{ this.translate( 'WordPress was too hard to use.' ) }</span>
+				{ 'wpTooHard' === this.state.questionOneRadio && wpTooHardInput }
+			</FormLabel>
+		);
+
 		const { questionOneOrder } = this.state,
 			orderedReasons = questionOneOrder.map( question => reasons[ question ] );
 
@@ -310,6 +371,28 @@ const CancelPurchaseForm = React.createClass( {
 					onChange={ this.onRadioTwoChange } />
 				<span>{ this.translate( 'Another reason…' ) }</span>
 				{ 'anotherReasonTwo' === this.state.questionTwoRadio && anotherReasonTwoInput }
+			</FormLabel>
+		);
+
+		// Survey questions only for Jetpack subscriptions
+		const otherPluginInput = (
+			<FormTextInput
+				className="cancel-purchase-form__reason-input"
+				name="otherPluginInput"
+				id="otherPluginInput"
+				value={ this.state.questionTwoText }
+				onChange={ this.onTextTwoChange }
+				placeholder={ this.translate( 'Mind telling us which one(s)?' ) } />
+		);
+		reasons.otherPlugin = (
+			<FormLabel key="otherPlugin">
+				<FormRadio
+					name="otherPlugin"
+					value="otherPlugin"
+					checked={ 'otherPlugin' === this.state.questionTwoRadio }
+					onChange={ this.onRadioTwoChange } />
+				<span>{ this.translate( 'I found a better plugin or service.' ) }</span>
+				{ 'otherPlugin' === this.state.questionTwoRadio && otherPluginInput }
 			</FormLabel>
 		);
 

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -43,7 +43,6 @@ const CancelPurchaseForm = React.createClass( {
 		if ( this.props.isJetpack ) {
 			questionOneOrder = shuffle( [
 				'couldNotActivate',
-				'wpTooHard',
 				'didNotInclude',
 				'onlyNeedFree'
 			] );
@@ -51,6 +50,7 @@ const CancelPurchaseForm = React.createClass( {
 			questionTwoOrder = shuffle( [
 				'stayingHere',
 				'otherPlugin',
+				'leavingWP',
 				'noNeed'
 			] );
 		}
@@ -245,27 +245,6 @@ const CancelPurchaseForm = React.createClass( {
 			</FormLabel>
 		);
 
-		const wpTooHardInput = (
-			<FormTextInput
-				className="cancel-purchase-form__reason-input"
-				name="wpTooHardInput"
-				id="wpTooHardInput"
-				value={ this.state.questionOneText }
-				onChange={ this.onTextOneChange }
-				placeholder={ this.translate( 'Where did you run into problems?' ) } />
-		);
-		reasons.wpTooHard = (
-			<FormLabel key="wpTooHard">
-				<FormRadio
-					name="wpTooHard"
-					value="wpTooHard"
-					checked={ 'wpTooHard' === this.state.questionOneRadio }
-					onChange={ this.onRadioOneChange } />
-				<span>{ this.translate( 'WordPress was too hard to use.' ) }</span>
-				{ 'wpTooHard' === this.state.questionOneRadio && wpTooHardInput }
-			</FormLabel>
-		);
-
 		const { questionOneOrder } = this.state,
 			orderedReasons = questionOneOrder.map( question => reasons[ question ] );
 
@@ -393,6 +372,27 @@ const CancelPurchaseForm = React.createClass( {
 					onChange={ this.onRadioTwoChange } />
 				<span>{ this.translate( 'I found a better plugin or service.' ) }</span>
 				{ 'otherPlugin' === this.state.questionTwoRadio && otherPluginInput }
+			</FormLabel>
+		);
+
+		const leavingWPInput = (
+			<FormTextInput
+				className="cancel-purchase-form__reason-input"
+				name="leavingWPInput"
+				id="leavingWPInput"
+				value={ this.state.questionTwoText }
+				onChange={ this.onTextTwoChange }
+				placeholder={ this.translate( 'Any particular reason(s)?' ) } />
+		);
+		reasons.leavingWP = (
+			<FormLabel key="leavingWP">
+				<FormRadio
+					name="leavingWP"
+					value="leavingWP"
+					checked={ 'leavingWP' === this.state.questionTwoRadio }
+					onChange={ this.onRadioTwoChange } />
+				<span>{ this.translate( 'I\'m moving my site off of WordPress.' ) }</span>
+				{ 'leavingWP' === this.state.questionTwoRadio && leavingWPInput }
 			</FormLabel>
 		);
 

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -25,14 +25,14 @@ const CancelPurchaseForm = React.createClass( {
 
 	getInitialState() {
 		// shuffle reason order, but keep anotherReasonOne last
-		var questionOneOrder = shuffle( [
+		let questionOneOrder = shuffle( [
 			'couldNotInstall',
 			'tooHard',
 			'didNotInclude',
 			'onlyNeedFree'
 		] );
 
-		var questionTwoOrder = shuffle( [
+		let questionTwoOrder = shuffle( [
 			'stayingHere',
 			'otherWordPress',
 			'differentService',

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -16,7 +16,7 @@ import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form
 import { getIncludedDomain, getName, hasIncludedDomain, isRemovable } from 'lib/purchases';
 import { getPurchase, isDataLoading } from '../utils';
 import Gridicon from 'components/gridicon';
-import { isDomainRegistration, isPlan, isGoogleApps } from 'lib/products-values';
+import { isDomainRegistration, isPlan, isGoogleApps, isJetpackPlan } from 'lib/products-values';
 import notices from 'notices';
 import purchasePaths from '../paths';
 import { removePurchase } from 'state/purchases/actions';
@@ -313,6 +313,7 @@ const RemovePurchase = React.createClass( {
 						showSurvey={ config.isEnabled( 'upgrades/removal-survey' ) }
 						defaultContent={ this.renderPlanDialogsText() }
 						onInputChange={ this.onSurveyChange }
+						isJetpack={ isJetpackPlan( getPurchase( this.props ) ) }
 					/>
 				</Dialog>
 			</div>


### PR DESCRIPTION
This change adds a few new cancelation responses specific to Jetpack plan subscribers and displays them accordingly during the cancelation process to only such subscribers. Currently, both Jetpack and WordPress.com subscribers see the same exact cancelation reasons, although they are primarily meant for WordPress.com subscribers. There is no change to what WordPress.com subscribers see.

Test plan:
* Log in to an account that has both a WordPress.com paid subscription and a Jetpack paid subscription.

* Go to /me/purchases and attempt to cancel each of the subscriptions.

* Confirm that, when attempting to cancel the Jetpack subscription, you are presented with the new reasons added via this change.

* Confirm that, when attempting to cancel the WordPress.com subscription, you are presented with the standard reasons.

* Make sure that you can toggle each reason as expected and that the placeholder text appears where/as it should.

* Confirm that each of the cancelations is successful (the product is removed) and finishes as expected.