### PR TITLE
Domains: Remove notice announcing .blog available for registration

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -135,7 +135,6 @@ const RegisterDomainStep = React.createClass( {
 
 		return {
 			clickedExampleSuggestion: false,
-			dotBlogNotice: true,
 			lastQuery: suggestion,
 			lastDomainSearched: null,
 			lastDomainError: null,
@@ -216,10 +215,6 @@ const RegisterDomainStep = React.createClass( {
 		return ! this.props.defaultSuggestions && ! this.props.defaultSuggestionsError;
 	},
 
-	dismissDotBlogNotice() {
-		this.setState( { dotBlogNotice: false } );
-	},
-
 	render: function() {
 		const queryObject = getQueryObject( this.props );
 		return (
@@ -240,18 +235,6 @@ const RegisterDomainStep = React.createClass( {
 							maxLength={ 60 }
 						/>
 					</div>
-				{
-					this.state.dotBlogNotice && ! this.props.isSignupStep &&
-					<Notice
-						text={ this.props.translate(
-							'New! {{strong}}.blog{{/strong}} domains are now available for registration.',
-							{ components: { strong: <strong /> } }
-						) }
-						status={ 'is-info' }
-						showDismiss={ true }
-						onDismissClick={ this.dismissDotBlogNotice }
-					/>
-				}
 				{
 					this.state.notice &&
 					<Notice text={ this.state.notice } status={ `is-${ this.state.noticeSeverity }` } showDismiss={ false } />


### PR DESCRIPTION
Go to `Domains -> Add`

Before:
![before](https://cloud.githubusercontent.com/assets/1103398/21781060/2aba0ce2-d6ae-11e6-8f7f-c7cc5b4e5ebf.png)

After:
![after](https://cloud.githubusercontent.com/assets/1103398/21781042/15ea9f5c-d6ae-11e6-992e-2094557f2b6f.png)
