### PR TITLE
Stats: add csv selector

### DIFF
--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { forOwn, get, reduce, isArray } from 'lodash';
+import { forOwn, get, reduce, isArray, map, flatten } from 'lodash';
 import i18n from 'i18n-calypso';
 
 /**
@@ -10,7 +10,8 @@ import i18n from 'i18n-calypso';
 import createSelector from 'lib/create-selector';
 import {
 	getSerializedStatsQuery,
-	normalizers
+	normalizers,
+	buildExportArray,
 } from './utils';
 
 /**
@@ -149,6 +150,7 @@ export function getSiteStatsPostsCountByDay( state, siteId, query, date ) {
  *
  * @param  {Object}  state    Global state tree
  * @param  {Number}  siteId   Site ID
+ * @param  {String}  statType Type of stat
  * @param  {Object}  query    Stats query object
  * @return {*}                Normalized Data for the query, typically an array or object
  */
@@ -168,3 +170,24 @@ export const getSiteStatsNormalizedData = createSelector(
 		return [ siteId, statType, serializedQuery ].join();
 	}
 );
+
+/**
+ * Returns an array of stats data ready for csv export
+ *
+ * @param  {Object}  state    Global state tree
+ * @param  {Number}  siteId   Site ID
+ * @param  {String}  statType Type of stat
+ * @param  {Object}  query    Stats query object
+ * @return {Array}            Array of stats data ready for CSV export
+ */
+export function getSiteStatsCSVData( state, siteId, statType, query ) {
+	const data = getSiteStatsNormalizedData( state, siteId, statType, query );
+	if ( ! data || ! isArray( data ) ) {
+		return [];
+	}
+
+	const csvData = map( data, ( item ) => {
+		return buildExportArray( item );
+	} );
+	return flatten( csvData );
+}

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -186,8 +186,5 @@ export function getSiteStatsCSVData( state, siteId, statType, query ) {
 		return [];
 	}
 
-	const csvData = map( data, ( item ) => {
-		return buildExportArray( item );
-	} );
-	return flatten( csvData );
+	return flatten( map( data, buildExportArray ) );
 }

--- a/client/state/stats/lists/test/selectors.js
+++ b/client/state/stats/lists/test/selectors.js
@@ -13,7 +13,8 @@ import {
 	getSiteStatsPostsCountByDay,
 	getSiteStatsTotalPostsForStreakQuery,
 	getSiteStatsNormalizedData,
-	isRequestingSiteStatsForQuery
+	isRequestingSiteStatsForQuery,
+	getSiteStatsCSVData,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -453,6 +454,61 @@ describe( 'selectors', () => {
 				viewsBestDay: '2010-09-29',
 				viewsBestDayTotal: 100
 			} );
+		} );
+	} );
+
+	describe( 'getSiteStatsCSVData()', () => {
+		it( 'should return an empty array if no matching query results exist', () => {
+			const stats = getSiteStatsCSVData( {
+				stats: {
+					lists: {
+						items: {}
+					}
+				}
+			}, 2916284, 'stats', {} );
+
+			expect( stats ).to.eql( [] );
+		} );
+
+		it( 'should return normalized data, if normalizer exists', () => {
+			const stats = getSiteStatsCSVData( {
+				stats: {
+					lists: {
+						items: {
+							2916284: {
+								statsCountryViews: {
+									'[["date","2015-12-25"],["period","day"]]': {
+										date: '2015-12-25',
+										days: {
+											'2015-12-25': {
+												views: [ {
+													country_code: 'US',
+													views: 1
+												} ],
+												other_views: 0,
+												total_views: 1
+											}
+										},
+										'country-info': {
+											US: {
+												flag_icon: 'https://secure.gravatar.com/blavatar/5a83891a81b057fed56930a6aaaf7b3c?s=48',
+												flat_flag_icon: 'https://secure.gravatar.com/blavatar/9f4faa5ad0c723474f7a6d810172447c?s=48',
+												country_full: 'United States',
+												map_region: '021'
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}, 2916284, 'statsCountryViews', {
+				date: '2015-12-25',
+				period: 'day',
+			} );
+
+			expect( stats ).to.eql( [ [ '"United States"', 1 ] ] );
 		} );
 	} );
 } );

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -10,9 +10,61 @@ import {
 	getSerializedStatsQuery,
 	normalizers,
 	rangeOfPeriod,
+	buildExportArray,
 } from '../utils';
 
 describe( 'utils', () => {
+	describe( 'buildExportArray()', () => {
+		it( 'should an empty array if data not supplied', () => {
+			const data = buildExportArray( {} );
+
+			expect( data ).to.eql( [] );
+		} );
+
+		it( 'should parse simple object to csv', () => {
+			const data = buildExportArray( {
+				label: 'Chicken',
+				value: 10
+			} );
+
+			expect( data ).to.eql( [ [ '"Chicken"', 10 ] ] );
+		} );
+
+		it( 'should escape simple object to csv', () => {
+			const data = buildExportArray( {
+				label: 'Chicken and "Ribs"',
+				value: 10
+			} );
+
+			expect( data ).to.eql( [ [ '"Chicken and ""Ribs""', 10 ] ] );
+		} );
+
+		it( 'should recurse child data', () => {
+			const data = buildExportArray( {
+				label: 'BBQ',
+				value: 10,
+				children: [ {
+					label: 'Chicken',
+					value: 5
+				}, {
+					label: 'Ribs',
+					value: 2,
+					children: [ {
+						label: 'Babyback',
+						value: 1
+					} ]
+				} ]
+			} );
+
+			expect( data ).to.eql( [
+				[ '"BBQ"', 10 ],
+				[ '"BBQ > Chicken"', 5 ],
+				[ '"BBQ > Ribs"', 2 ],
+				[ '"BBQ > Ribs > Babyback"', 1 ]
+			] );
+		} );
+	} );
+
 	describe( 'rangeOfPeriod()', () => {
 		it( 'should return a period object for day', () => {
 			const period = rangeOfPeriod( 'day', '2016-06-01' );

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { sortBy, toPairs, camelCase, mapKeys, isNumber, get, filter, map } from 'lodash';
+import { sortBy, toPairs, camelCase, mapKeys, isNumber, get, filter, map, concat, flatten } from 'lodash';
 import { moment } from 'i18n-calypso';
 
 /**
@@ -34,6 +34,32 @@ export function rangeOfPeriod( period, date ) {
 		startOf: startOf.format( 'YYYY-MM-DD' ),
 		endOf: endOf.format( 'YYYY-MM-DD' )
 	};
+}
+
+/**
+ * Builds data into escaped array for CSV export
+ *
+ * @param  {Object} data   Normalized stats data object
+ * @param  {String} parent Label of parent
+ * @return {Array}         CSV Row
+ */
+export function buildExportArray( data, parent = null ) {
+	if ( ! data || ! data.label || ! data.value ) {
+		return [];
+	}
+	const label = parent ? ( parent + ' > ' + data.label ) : data.label;
+	const escapedLabel = label.replace( /\"/, '""' );
+	let exportData = [ [ '"' + escapedLabel + '"', data.value ] ];
+
+	if ( data.children ) {
+		const childData = map( data.children, ( child ) => {
+			return buildExportArray( child, label );
+		} );
+
+		exportData = concat( exportData, flatten( childData ) );
+	}
+
+	return exportData;
 }
 
 /**


### PR DESCRIPTION
This PR is needed for #10476 to move forward - it brings some existing CSV export logic from the legacy `stats-list` into a redux selector.  Currently there is no visual or functional paths to test this within Calypso, so just verify that tests pass.