### PR TITLE
Documentation: es6ify component readmes (A-C)

### DIFF
--- a/client/components/animate/README.md
+++ b/client/components/animate/README.md
@@ -5,7 +5,7 @@ Simple interface to introduce animations to components on initial render. Used a
 
 #### How to use:
 
-```js
+```jsx
 import Animate from 'components/animate';
 
 render() {

--- a/client/components/banner/README.md
+++ b/client/components/banner/README.md
@@ -27,7 +27,7 @@ If `dismissPreferenceName` is provided, `href` is only applied if `callToAction`
 
 ## Usage:
 
-```js
+```jsx
 import { PLAN_BUSINESS, FEATURE_ADVANCED_SEO } from 'lib/plans/constants';
 import Banner from 'components/banner';
 
@@ -37,7 +37,7 @@ render() {
 			callToAction="Upgrade now!"
 			description="Obtain more features."
 			dismissPreferenceName="example-banner"
-			dismissTemporary={ true }
+			dismissTemporary
 			event="track_event"
 			feature={ FEATURE_ADVANCED_SEO }
 			href="https://wordpress.com/"

--- a/client/components/bulk-select/README.md
+++ b/client/components/bulk-select/README.md
@@ -5,8 +5,8 @@ This component is used to implement a checkbox which you can use to bulk select 
 
 #### How to use:
 
-```js
-var BulkSelect = require( 'components/bulk-select' );
+```jsx
+import BulkSelect from 'components/bulk-select';
 
 render: function() {
 	return (

--- a/client/components/button-group/README.md
+++ b/client/components/button-group/README.md
@@ -5,9 +5,9 @@ This component is used to group several semantically linked buttons under the sa
 
 #### How to use:
 
-```js
-const  ButtonGroup = require( 'components/button-group' ),
-	Button = require( 'components/button' );
+```jsx
+import ButtonGroup from 'components/button-group';
+import Button from 'components/button';
 
 render: function() {
 	return (

--- a/client/components/button/README.md
+++ b/client/components/button/README.md
@@ -5,7 +5,7 @@ This component is used to implement dang sweet buttons.
 
 #### How to use:
 
-```js
+```jsx
 import Button from 'components/button';
 
 export default function RockOnButton() {

--- a/client/components/card/README.md
+++ b/client/components/card/README.md
@@ -8,9 +8,9 @@ The `CompactCard` component slightly modifies the `Card` component.
 
 #### How to use:
 
-```js
-var Card = require( 'components/card' ),
-	CompactCard = require( 'components/card/compact' );
+```jsx
+import Card from 'components/card';
+import CompactCard from 'components/card/compact';
 
 render: function() {
   return (

--- a/client/components/chart/README.md
+++ b/client/components/chart/README.md
@@ -5,10 +5,10 @@ This module renders a dataset as an HTML-based chart representing the data.
 
 ## Usage
 
-```js
+```jsx
 
-// require the component
-var ElementChart = require( 'my-sites/chart' );
+// import the component
+import ElementChart from 'my-sites/chart';
 
 // And use it inline inside the render method of another component
 render: function() {

--- a/client/components/credit-card-form-fields/README.md
+++ b/client/components/credit-card-form-fields/README.md
@@ -16,21 +16,22 @@ Some of these fields use [masking](https://en.wikipedia.org/wiki/Input_mask), i.
 ## Usage
 
 ```jsx
-import React from 'react';
+import React, { Component } from 'react';
 import CreditCardFormFields from 'components/credit-card-form-fields';
 
-React.createClass( {
-	render: function() {
+class YourComponent extends Component {
+	render() {
 		return (
 			<CreditCardFormFields
 				card={ this.props.card }
 				countriesList={ this.props.countriesList }
 				eventFormName="Credit Card Form"
 				isFieldInvalid={ this.isFieldInvalid }
-				onFieldChange={ this.onFieldChange } />
+				onFieldChange={ this.onFieldChange }
+			/>
 		);
 	}
-} );
+}
 ```
 
 ## Properties


### PR DESCRIPTION
As part of Automattic/wp-calypso#10334 this PR brings the code from a number of component readme files up to scratch with es6 and tags them with `jsx` syntax for better highlighting.

There're a lot more component readmes that would benefit from similar updates but to keep things manageable this PR only covers components starting with A-C.
