### PR TITLE
Reader: fix tag name fades too early on IE11

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -293,7 +293,8 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	overflow: hidden;
 	position: relative;
 	height: 20px;
-
+	width: 100%;
+	
 	&::after {
 		@include long-content-fade( $size: 10% );
 	}


### PR DESCRIPTION
With no width set, IE11 pulled .reader-post-card__tag:after onto the .reader-post-card__tag, partly obsuring it. Resolves #10249

cc @bluefuton 