### PR TITLE
Connect found themes count to UI

### DIFF
--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -13,17 +13,19 @@ const ConnectedThemeShowcase = connectOptions( ThemeShowcase );
 
 export default props => (
 	<ConnectedThemeShowcase { ...props }
-	options={ [
-		'signup',
-		'preview',
-		'separator',
-		'info',
-		'support',
-		'help'
-	] }
-	defaultOption="signup"
-	getScreenshotOption={ function() {
-		return 'info';
-	} }
-	source="showcase" />
+		options={ [
+			'signup',
+			'preview',
+			'separator',
+			'info',
+			'support',
+			'help'
+		] }
+		defaultOption="signup"
+		getScreenshotOption={ function() {
+			return 'info';
+		} }
+		source="showcase"
+		showUploadButton={ false }
+	/>
 );

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -16,7 +16,9 @@ const MultiSiteThemeShowcase = connectOptions(
 		<div>
 			<SidebarNavigation />
 			<ThemesSiteSelectorModal { ...props } sourcePath="/design">
-				<ThemeShowcase source="showcase" showUploadButton={ false } />
+				<ThemeShowcase
+					source="showcase"
+					showUploadButton={ false } />
 			</ThemesSiteSelectorModal>
 		</div>
 	)

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -21,7 +21,6 @@ import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
 import ThemesSelection from './themes-selection';
 import { addTracking } from './helpers';
-import { translate } from 'i18n-calypso';
 import { hasFeature } from 'state/sites/plans/selectors';
 import { FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
 
@@ -97,7 +96,6 @@ const ConnectedSingleSiteJetpack = connectOptions(
 								filter={ filter }
 								vertical={ vertical }
 								siteId={ siteId /* This is for the options in the '...' menu only */ }
-								listLabel={ translate( 'WordPress.com themes' ) }
 								showUploadButton={ false }
 								getScreenshotUrl={ function( theme ) {
 									if ( ! getScreenshotOption( theme ).getUrl ) {

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -71,7 +71,6 @@ const SingleSiteThemeShowcaseWithOptions = ( props ) => {
 			defaultOption="activate"
 			secondaryOption="tryandcustomize"
 			source="showcase"
-			listLabel={ translate( 'WordPress.com themes' ) }
 		/>
 	);
 };

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -18,6 +18,7 @@ import { hasFeature } from 'state/sites/plans/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import {
 	getThemesForQueryIgnoringPage,
+	getThemesFoundForQuery,
 	isRequestingThemesForQuery,
 	isThemesLastPageForQuery,
 	isThemeActive,
@@ -44,6 +45,7 @@ const ThemesSelection = React.createClass( {
 		] ),
 		showUploadButton: PropTypes.bool,
 		themes: PropTypes.array,
+		themesCount: PropTypes.number,
 		isRequesting: PropTypes.bool,
 		isLastPage: PropTypes.bool,
 		isThemeActive: PropTypes.func,
@@ -109,7 +111,7 @@ const ThemesSelection = React.createClass( {
 	},
 
 	render() {
-		const { siteIdOrWpcom, query, listLabel, showUploadButton } = this.props;
+		const { siteIdOrWpcom, query, listLabel, showUploadButton, themesCount } = this.props;
 
 		return (
 			<div className="themes__selection">
@@ -119,6 +121,7 @@ const ThemesSelection = React.createClass( {
 				{ config.isEnabled( 'manage/themes/upload' ) &&
 					<ThemeUploadCard
 						label={ listLabel }
+						count={ themesCount }
 						href={ showUploadButton ? `/design/upload/${ this.props.siteSlug }` : null }
 					/>
 				}
@@ -162,6 +165,7 @@ const ConnectedThemesSelection = connect(
 			siteIdOrWpcom,
 			siteSlug: getSiteSlug( state, siteId ),
 			themes: getThemesForQueryIgnoringPage( state, siteIdOrWpcom, query ) || [],
+			themesCount: getThemesFoundForQuery( state, siteIdOrWpcom, query ),
 			isRequesting: isRequestingThemesForQuery( state, siteIdOrWpcom, query ),
 			isLastPage: isThemesLastPageForQuery( state, siteIdOrWpcom, query ),
 			isThemeActive: themeId => isThemeActive( state, suffixThemeId( themeId ), siteId ),

--- a/client/my-sites/themes/themes-upload-card/index.jsx
+++ b/client/my-sites/themes/themes-upload-card/index.jsx
@@ -32,7 +32,7 @@ class ThemeUploadCard extends React.Component {
 		return (
 			<div className="themes-upload-card">
 				<SectionHeader
-					label={ this.props.label }
+					label={ this.props.label || translate( 'WordPress.com themes' ) }
 					count={ this.props.count }
 				>
 					{ this.props.href &&

--- a/client/my-sites/themes/themes-upload-card/index.jsx
+++ b/client/my-sites/themes/themes-upload-card/index.jsx
@@ -20,10 +20,6 @@ class ThemeUploadCard extends React.Component {
 		count: PropTypes.number,
 	};
 
-	constructor( props ) {
-		super( props );
-	}
-
 	trackClick = () => trackClick( 'upload theme' );
 
 	render() {


### PR DESCRIPTION
### Info
With this PR in `/design` themes list headers will display found themes counters.
Additionally a default label value was added to `ThemesUploadCard`. This allowed removal of label declaration in various places which is redundant when default is present. 

### Before 
![image](https://cloud.githubusercontent.com/assets/17271089/21796425/0c691426-d709-11e6-83d3-f25e8aeddd1b.png)

### After
![image](https://cloud.githubusercontent.com/assets/17271089/21796447/25e7dedc-d709-11e6-8b16-3207e054d755.png)

### Testing
Open `/design`. Counter should be there. Start searching - counter updates it's value. 