### PR TITLE
Contact Form 7 Extension

### DIFF
--- a/client/extensions/contact-form-7/index.js
+++ b/client/extensions/contact-form-7/index.js
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { navigation, siteSelection } from 'my-sites/controller';
+import { renderWithReduxStore } from 'lib/react-helpers';
+import Main from 'components/main';
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+import FAQ from 'components/faq';
+import FAQItem from 'components/faq/faq-item';
+
+const render = ( context ) => {
+	renderWithReduxStore( (
+		<Main className="hello-dolly__main">
+			<SectionHeader label="Contact Form 7">🐑</SectionHeader>
+			<Card>
+				<p style={ { fontSize: 18, fontWeight: 300 } }>This is not just an extension, it symbolizes the hope and enthusiasm of an entire generation summed up in two words sung most famously by Louis Armstrong.</p>
+				<hr />
+				<p>This section is the home for the <strong>Contact Form 7</strong> extension.</p>
+				<p>Extensions are set up to function in a semi-isolated environment, with their own URL path and code-chunk magic (using the power of webpack) to assure code is loaded only when needed. Think of extensions as individual "apps" you can access in Calypso to interact with your plugin functionality in a focused way.</p>
+			</Card>
+			<FAQ>
+				<FAQItem
+					question="How can I get started?"
+					answer={ [
+						'Head over to the "extensions" folder in the repository where we have a more comprehensive ',
+						'README file to walk you through the process. ',
+						<a href="https://github.com/Automattic/wp-calypso/tree/master/client/extensions" key="get-started">Get Started</a>
+					] }
+				/>
+				<FAQItem
+					question="Learning about Calypso"
+					answer={ [
+						'You can browse our docs without leaving the running application, just go to the Devdocs section. ',
+						'Tip: press the keys "gd" to navigate there from any page! ',
+						<a href="/devdocs" key="go-devdocs">Go to Devdocs</a>
+					] }
+				/>
+				<FAQItem
+					question="Have more questions?"
+					answer={ [
+						'Let\'s talk! Visit the ',
+						<a href="https://github.com/Automattic/wp-calypso/" key="go-repo">Calypso GitHub repository</a>,
+						' and open an issue.'
+					] }
+				/>
+			</FAQ>
+		</Main>
+	), document.getElementById( 'primary' ), context.store );
+};
+
+export default function() {
+	page( '/contact-form-7/:site?', siteSelection, navigation, render );
+}

--- a/client/extensions/contact-form-7/package.json
+++ b/client/extensions/contact-form-7/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "contact-form-7",
+	"author": "Takayuki Miyoshi",
+	"description": "Contact Form 7",
+	"version": "0.0.1",
+	"env_id": [ "development", "wpcalypso" ],
+	"section": {
+		"name": "contact-form-7",
+		"paths": [ "/contact-form-7" ],
+		"module": "contact-form-7",
+		"group": "sites",
+		"secondary": true,
+		"enableLoggedOut": true
+	}
+}


### PR DESCRIPTION
Hello,

I'm the author of Contact Form 7 plugin. I got an email from Andy Peatling last month about Calypso becoming "plugins aware".

I'm new to Calypso or React so I'm learning bit by bit. I could run Calypso locally and added contact-form-7 extension for starters.

I'm opening this PR as an "introductory pull request" in Andy's message. Yes, I have tons of questions. My first question is this: Should I implement full contact form editor UI that the WordPress plugin provides in this Calypso extension? Or you just expect light features like dashboard?