### PR TITLE
Remove WP.com themes list for not capable Jetpack plugins.

### DIFF
--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -22,6 +22,7 @@ import ThemeShowcase from './theme-showcase';
 import ThemesSelection from './themes-selection';
 import { addTracking } from './helpers';
 import { hasFeature } from 'state/sites/plans/selectors';
+import { hasJetpackSiteJetpackThemesExtendedFeatures } from 'state/sites/selectors';
 import { FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
 
 const ConnectedThemesSelection = connectOptions(
@@ -84,7 +85,7 @@ const ConnectedSingleSiteJetpack = connectOptions(
 					<ThanksModal
 						site={ site }
 						source={ 'list' } />
-					{ config.isEnabled( 'manage/themes/upload' ) &&
+					{ config.isEnabled( 'manage/themes/upload' ) && props.showWpcomThemesList &&
 						<div>
 							<ConnectedThemesSelection
 								options={ [
@@ -126,7 +127,8 @@ const ConnectedSingleSiteJetpack = connectOptions(
 export default connect(
 	( state, { siteId, tier } ) => {
 		return {
-			wpcomTier: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ) ? tier : 'free'
+			wpcomTier: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ) ? tier : 'free',
+			showWpcomThemesList: hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId )
 		};
 	}
 )( ConnectedSingleSiteJetpack );

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -50,6 +50,7 @@ import {
 	withAnalytics
 } from 'state/analytics/actions';
 import { getTheme, getActiveTheme, getLastThemeQuery, getThemeCustomizeUrl } from './selectors';
+import { hasJetpackSiteJetpackThemesExtendedFeatures } from 'state/sites/selectors';
 import {
 	getThemeIdFromStylesheet,
 	filterThemesForJetpack,
@@ -107,7 +108,7 @@ export function receiveThemes( themes, siteId ) {
  * @return {Function}             Action thunk
  */
 export function requestThemes( siteId, query = {} ) {
-	return ( dispatch ) => {
+	return ( dispatch, getState ) => {
 		const startTime = new Date().getTime();
 		let siteIdToQuery, queryWithApiVersion;
 
@@ -130,9 +131,8 @@ export function requestThemes( siteId, query = {} ) {
 			let filteredThemes;
 			if ( siteId !== 'wpcom' ) {
 				themes = map( rawThemes, normalizeJetpackTheme );
-				// A Jetpack site's themes endpoint ignores the query, returning an unfiltered list of all installed themes instead,
-				// So we have to filter on the client side instead.
-				filteredThemes = filterThemesForJetpack( themes, query );
+				const filterWpcom = hasJetpackSiteJetpackThemesExtendedFeatures( getState(), siteId );
+				filteredThemes = filterThemesForJetpack( themes, query, filterWpcom );
 				// The Jetpack specific endpoint doesn't return the number of `found` themes, so we calculate it ourselves.
 				found = filteredThemes.length;
 			} else {

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -192,6 +192,17 @@ describe( 'actions', () => {
 		} );
 
 		context( 'with a Jetpack site', () => {
+			const fakeGetState = () => ( {
+				sites: {
+					items: {
+						77203074: {
+							jetpack: true,
+							options: { jetpack_version: '4.4.2' }
+						}
+					}
+				}
+			} );
+
 			it( 'should dispatch fetch action when thunk triggered', () => {
 				requestThemes( 77203074 )( spy );
 
@@ -203,7 +214,7 @@ describe( 'actions', () => {
 			} );
 
 			it( 'should dispatch themes receive action when request completes', () => {
-				return requestThemes( 77203074 )( spy ).then( () => {
+				return requestThemes( 77203074 )( spy, fakeGetState ).then( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: THEMES_RECEIVE,
 						themes: [
@@ -216,7 +227,7 @@ describe( 'actions', () => {
 			} );
 
 			it( 'should dispatch themes request success action when request completes', () => {
-				return requestThemes( 77203074 )( spy ).then( () => {
+				return requestThemes( 77203074 )( spy, fakeGetState ).then( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: THEMES_REQUEST_SUCCESS,
 						siteId: 77203074,
@@ -231,7 +242,7 @@ describe( 'actions', () => {
 			} );
 
 			it( 'should dispatch themes request success action with query results', () => {
-				return requestThemes( 77203074, { search: 'Sixteen' } )( spy ).then( () => {
+				return requestThemes( 77203074, { search: 'Sixteen' } )( spy, fakeGetState ).then( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: THEMES_REQUEST_SUCCESS,
 						siteId: 77203074,
@@ -243,7 +254,6 @@ describe( 'actions', () => {
 					} );
 				} );
 			} );
-
 			it( 'should dispatch fail action when request fails', () => {
 				return requestThemes( 1916284 )( spy ).then( () => {
 					expect( spy ).to.have.been.calledWith( {

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -204,31 +204,34 @@ export function isThemeFromWpcom( themeId ) {
 
 /**
  * Returns a filtered themes array. Filtering is done based on particular themes
- * matching provided query and isWpocmTheme predicate.
+ * matching provided query and isWpocmTheme predicate if filterWpcom is true
  * Themes on Jetpack installed from WordPress.com have -wpcom suffix
- * We filter out all those themes because they will also be visible on
- * second list specific to WordPress.com. This may be too simple aproach
- * so it may revisit it again later.
+ * We can filter out all those themes because they will also be visible on
+ * second list specific to WordPress.com for Jetpack versions from 4.4.2.
+ * This may be too simple aproach so it may revisit it again later.
  *
  * TODO Veriy that wpcom filtering is sufficien.
  *
- * @param  {Array}  themes Array of theme objects
- * @param  {Object} query  Themes query
- * @return {Array}         Filtered themes
+ * @param  {Array}   themes      Array of theme objects
+ * @param  {Object}  query       Themes query
+ * @param  {Boolean} filterWpcom Switch to filter out themes with -wpcom suffix
+ * @return {Array}               Filtered themes
  */
-export function filterThemesForJetpack( themes, query ) {
-	// we can filter wpcom only if we have two lists
-	if ( config.isEnabled( 'manage/themes/upload' ) ) {
-		return filter(
-			themes,
-			theme => ! isThemeFromWpcom( theme.id ) && isThemeMatchingQuery( query, theme )
-		);
-	}
-
-	return filter(
+export function filterThemesForJetpack( themes, query, filterWpcom = false ) {
+	const queryFilteredThemes = filter(
 		themes,
 		theme => isThemeMatchingQuery( query, theme )
 	);
+
+	// we can filter wpcom only if we have two lists
+	if ( config.isEnabled( 'manage/themes/upload' ) && filterWpcom ) {
+		return filter(
+			queryFilteredThemes,
+			theme => ! isWpcomTheme( theme.id )
+		);
+	}
+
+	return queryFilteredThemes;
 }
 
 /**

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -5,7 +5,6 @@ import startsWith from 'lodash/startsWith';
 import {
 	every,
 	endsWith,
-	filter,
 	get,
 	includes,
 	map,
@@ -19,7 +18,6 @@ import {
 /**
  * Internal dependencies
  */
-import config from 'config';
 import { DEFAULT_THEME_QUERY } from './constants';
 
 /**
@@ -200,38 +198,6 @@ export function getSerializedThemesQueryWithoutPage( query, siteId ) {
  */
 export function isThemeFromWpcom( themeId ) {
 	return endsWith( themeId, '-wpcom' );
-}
-
-/**
- * Returns a filtered themes array. Filtering is done based on particular themes
- * matching provided query and isWpocmTheme predicate if filterWpcom is true
- * Themes on Jetpack installed from WordPress.com have -wpcom suffix
- * We can filter out all those themes because they will also be visible on
- * second list specific to WordPress.com for Jetpack versions from 4.4.2.
- * This may be too simple aproach so it may revisit it again later.
- *
- * TODO Veriy that wpcom filtering is sufficien.
- *
- * @param  {Array}   themes      Array of theme objects
- * @param  {Object}  query       Themes query
- * @param  {Boolean} filterWpcom Switch to filter out themes with -wpcom suffix
- * @return {Array}               Filtered themes
- */
-export function filterThemesForJetpack( themes, query, filterWpcom = false ) {
-	const queryFilteredThemes = filter(
-		themes,
-		theme => isThemeMatchingQuery( query, theme )
-	);
-
-	// we can filter wpcom only if we have two lists
-	if ( config.isEnabled( 'manage/themes/upload' ) && filterWpcom ) {
-		return filter(
-			queryFilteredThemes,
-			theme => ! isWpcomTheme( theme.id )
-		);
-	}
-
-	return queryFilteredThemes;
 }
 
 /**


### PR DESCRIPTION
### Info
We can only offer WordPress.com themes installation to users with Jetpack plugin >= 4.4.2 For earlier versions we need to remove WP.com themes lists and do not filter wpcom themes from the first list.

### Testing
You need two Jetpack sites one with version lower than 4.4.2 and one with that one or newer. 
If you don't have Jetpack with proper version you can always change required version in
` hasJetpackSiteJetpackThemesExtendedFeatures`  for testing purposes.

Open `/design` for Jetpack site:
- for >= 4.4.2 two lists of themes will be visible, first list will have wpcom themes filtered
- for < 4.4.2 one list of themes will be visible and it will have all themes installed on that Jetpack site visible
