### PR TITLE
Guided Tours: Fix Site Title Tour step not showing

### DIFF
--- a/client/state/ui/action-log/reducer.js
+++ b/client/state/ui/action-log/reducer.js
@@ -13,6 +13,7 @@ import {
 	THEMES_RECEIVE,
 	PREVIEW_IS_SHOWING,
 	ROUTE_SET,
+	SITE_SETTINGS_RECEIVE,
 } from 'state/action-types';
 
 const relevantTypes = {
@@ -22,6 +23,7 @@ const relevantTypes = {
 	THEMES_RECEIVE,
 	PREVIEW_IS_SHOWING,
 	ROUTE_SET,
+	SITE_SETTINGS_RECEIVE,
 };
 
 const isRelevantAction = ( action ) =>


### PR DESCRIPTION
This PR fixes Site Title Tour that didn't show one of its steps when it was freshly loaded (without the browser cache).

The problem was that the settings section was loading some async data and didn’t show the UI before the data loaded (meaning we had no target for step yet), but we didn’t rerender guided our tours when the data loaded, as we only look for limited action set in action log.

This adds `SITE_SETTINGS_RECEIVE` to actionLog.

To test:
1. Disable browser cache
2. Load http://calypso.localhost:3000/stats/_slug_?tour=siteTitle
3. Let the tour start and click Next on the first step
4. Go to your dev tools (Network tab) and turn on network throttling. Regular 3G worked pretty well
5. Quickly click Settings menu item (don't hover it for too long, because the settings section might get preloaded)
6. Don't do anything and just let it load
7. You should see a tour step once the site title input is visible

If you test the same scenario in production, the step won't show until you do some kind of interaction (like scrolling). 