### PR TITLE
Jetpack Settings: Sync modules activation state

### DIFF
--- a/client/state/jetpack/modules/actions.js
+++ b/client/state/jetpack/modules/actions.js
@@ -101,7 +101,7 @@ export const fetchModuleList = ( siteId ) => {
 					data,
 					( module ) => ( {
 						active: module.activated,
-						...omit( module, 'activated' )
+						...omit( module, 'activated', 'options' )
 					} )
 				);
 

--- a/client/state/jetpack/modules/reducer.js
+++ b/client/state/jetpack/modules/reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import { merge } from 'lodash';
+import { forEach, merge, pickBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,7 +17,8 @@ import {
 	JETPACK_MODULES_RECEIVE,
 	JETPACK_MODULES_REQUEST,
 	JETPACK_MODULES_REQUEST_FAILURE,
-	JETPACK_MODULES_REQUEST_SUCCESS
+	JETPACK_MODULES_REQUEST_SUCCESS,
+	JETPACK_SETTINGS_UPDATE_SUCCESS,
 } from 'state/action-types';
 import { createReducer } from 'state/utils';
 
@@ -61,6 +62,29 @@ const createModuleListRequestReducer = ( fetchingModules ) => {
 	};
 };
 
+const createSettingsItemsReducer = () => {
+	return ( state, { siteId, settings } ) => {
+		let updatedState = state;
+		const moduleActivationState = pickBy( settings, ( settingValue, settingName ) => {
+			return state[ siteId ].hasOwnProperty( settingName );
+		} );
+
+		forEach( moduleActivationState, ( active, moduleSlug ) => {
+			updatedState = Object.assign( {}, updatedState, {
+				[ siteId ]: {
+					...updatedState[ siteId ],
+					[ moduleSlug ]: {
+						...updatedState[ siteId ][ moduleSlug ],
+						active
+					}
+				}
+			} );
+		} );
+
+		return updatedState;
+	};
+};
+
 /**
  * `Reducer` function which handles request/response actions
  * concerning Jetpack modules data updates
@@ -72,7 +96,8 @@ const createModuleListRequestReducer = ( fetchingModules ) => {
 export const items = createReducer( {}, {
 	[ JETPACK_MODULE_ACTIVATE_SUCCESS ]: createItemsReducer( true ),
 	[ JETPACK_MODULE_DEACTIVATE_SUCCESS ]: createItemsReducer( false ),
-	[ JETPACK_MODULES_RECEIVE ]: createItemsListReducer()
+	[ JETPACK_MODULES_RECEIVE ]: createItemsListReducer(),
+	[ JETPACK_SETTINGS_UPDATE_SUCCESS ]: createSettingsItemsReducer()
 } );
 
 /**

--- a/client/state/jetpack/modules/reducer.js
+++ b/client/state/jetpack/modules/reducer.js
@@ -18,6 +18,7 @@ import {
 	JETPACK_MODULES_REQUEST,
 	JETPACK_MODULES_REQUEST_FAILURE,
 	JETPACK_MODULES_REQUEST_SUCCESS,
+	JETPACK_SETTINGS_RECEIVE,
 	JETPACK_SETTINGS_UPDATE_SUCCESS,
 } from 'state/action-types';
 import { createReducer } from 'state/utils';
@@ -97,6 +98,7 @@ export const items = createReducer( {}, {
 	[ JETPACK_MODULE_ACTIVATE_SUCCESS ]: createItemsReducer( true ),
 	[ JETPACK_MODULE_DEACTIVATE_SUCCESS ]: createItemsReducer( false ),
 	[ JETPACK_MODULES_RECEIVE ]: createItemsListReducer(),
+	[ JETPACK_SETTINGS_RECEIVE ]: createSettingsItemsReducer(),
 	[ JETPACK_SETTINGS_UPDATE_SUCCESS ]: createSettingsItemsReducer()
 } );
 

--- a/client/state/jetpack/modules/test/actions.js
+++ b/client/state/jetpack/modules/test/actions.js
@@ -205,7 +205,7 @@ describe( 'actions', () => {
 							API_MODULE_LIST_RESPONSE_FIXTURE.data,
 							( module ) => ( {
 								active: module.activated,
-								...omit( module, 'activated' )
+								...omit( module, 'activated', 'options' )
 							} )
 						)
 					} );

--- a/client/state/jetpack/modules/test/reducer.js
+++ b/client/state/jetpack/modules/test/reducer.js
@@ -18,6 +18,7 @@ import {
 	JETPACK_MODULES_REQUEST,
 	JETPACK_MODULES_REQUEST_FAILURE,
 	JETPACK_MODULES_REQUEST_SUCCESS,
+	JETPACK_SETTINGS_UPDATE_SUCCESS,
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
@@ -90,6 +91,41 @@ describe( 'reducer', () => {
 				};
 			const stateOut = itemsReducer( deepFreeze( stateIn ), action );
 			expect( stateOut[ siteId ] ).to.eql( MODULES_FIXTURE[ siteId ] );
+		} );
+
+		it( 'should update modules activation state when updating settings', () => {
+			const siteId = 123456,
+				stateIn = {
+					123456: {
+						'related-posts': {
+							module: 'related-posts',
+							active: false,
+						},
+						'infinite-scroll': {
+							module: 'infinite-scroll',
+							active: true,
+						}
+					}
+				},
+				action = {
+					type: JETPACK_SETTINGS_UPDATE_SUCCESS,
+					siteId,
+					settings: {
+						'related-posts': true,
+						'infinite-scroll': false,
+					}
+				};
+			const stateOut = itemsReducer( deepFreeze( stateIn ), action );
+			expect( stateOut[ siteId ] ).to.eql( {
+				'related-posts': {
+					module: 'related-posts',
+					active: true,
+				},
+				'infinite-scroll': {
+					module: 'infinite-scroll',
+					active: false,
+				}
+			} );
 		} );
 	} );
 

--- a/client/state/jetpack/modules/test/reducer.js
+++ b/client/state/jetpack/modules/test/reducer.js
@@ -18,6 +18,7 @@ import {
 	JETPACK_MODULES_REQUEST,
 	JETPACK_MODULES_REQUEST_FAILURE,
 	JETPACK_MODULES_REQUEST_SUCCESS,
+	JETPACK_SETTINGS_RECEIVE,
 	JETPACK_SETTINGS_UPDATE_SUCCESS,
 	SERIALIZE,
 	DESERIALIZE
@@ -109,6 +110,41 @@ describe( 'reducer', () => {
 				},
 				action = {
 					type: JETPACK_SETTINGS_UPDATE_SUCCESS,
+					siteId,
+					settings: {
+						'related-posts': true,
+						'infinite-scroll': false,
+					}
+				};
+			const stateOut = itemsReducer( deepFreeze( stateIn ), action );
+			expect( stateOut[ siteId ] ).to.eql( {
+				'related-posts': {
+					module: 'related-posts',
+					active: true,
+				},
+				'infinite-scroll': {
+					module: 'infinite-scroll',
+					active: false,
+				}
+			} );
+		} );
+
+		it( 'should update modules activation state when receiving new settings', () => {
+			const siteId = 123456,
+				stateIn = {
+					123456: {
+						'related-posts': {
+							module: 'related-posts',
+							active: false,
+						},
+						'infinite-scroll': {
+							module: 'infinite-scroll',
+							active: true,
+						}
+					}
+				},
+				action = {
+					type: JETPACK_SETTINGS_RECEIVE,
 					siteId,
 					settings: {
 						'related-posts': true,

--- a/client/state/jetpack/settings/reducer.js
+++ b/client/state/jetpack/settings/reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import { merge } from 'lodash';
+import { mapValues, merge } from 'lodash';
 
 /**
  * Internal dependencies
@@ -10,6 +10,7 @@ import { merge } from 'lodash';
 import {
 	JETPACK_MODULE_ACTIVATE_SUCCESS,
 	JETPACK_MODULE_DEACTIVATE_SUCCESS,
+	JETPACK_MODULES_RECEIVE,
 	JETPACK_SETTINGS_RECEIVE,
 	JETPACK_SETTINGS_REQUEST,
 	JETPACK_SETTINGS_REQUEST_FAILURE,
@@ -60,6 +61,16 @@ export const items = createReducer( {}, {
 	[ JETPACK_SETTINGS_UPDATE_SUCCESS ]: createItemsReducer(),
 	[ JETPACK_MODULE_ACTIVATE_SUCCESS ]: createActivationItemsReducer( true ),
 	[ JETPACK_MODULE_DEACTIVATE_SUCCESS ]: createActivationItemsReducer( false ),
+	[ JETPACK_MODULES_RECEIVE ]: ( state, { siteId, modules } ) => {
+		const modulesActivationState = mapValues( modules, module => module.active );
+
+		return Object.assign( {}, state, {
+			[ siteId ]: {
+				...state[ siteId ],
+				...modulesActivationState
+			}
+		} );
+	}
 } );
 
 /**

--- a/client/state/jetpack/settings/reducer.js
+++ b/client/state/jetpack/settings/reducer.js
@@ -8,6 +8,8 @@ import { merge } from 'lodash';
  * Internal dependencies
  */
 import {
+	JETPACK_MODULE_ACTIVATE_SUCCESS,
+	JETPACK_MODULE_DEACTIVATE_SUCCESS,
 	JETPACK_SETTINGS_RECEIVE,
 	JETPACK_SETTINGS_REQUEST,
 	JETPACK_SETTINGS_REQUEST_FAILURE,
@@ -34,6 +36,17 @@ const createItemsReducer = () => {
 	};
 };
 
+const createActivationItemsReducer = ( active ) => {
+	return ( state, { siteId, moduleSlug } ) => {
+		return Object.assign( {}, state, {
+			[ siteId ]: {
+				...state[ siteId ],
+				[ moduleSlug ]: active,
+			}
+		} );
+	};
+};
+
 /**
  * `Reducer` function which handles request/response actions
  * concerning Jetpack settings updates
@@ -44,7 +57,9 @@ const createItemsReducer = () => {
  */
 export const items = createReducer( {}, {
 	[ JETPACK_SETTINGS_RECEIVE ]: createItemsReducer(),
-	[ JETPACK_SETTINGS_UPDATE_SUCCESS ]: createItemsReducer()
+	[ JETPACK_SETTINGS_UPDATE_SUCCESS ]: createItemsReducer(),
+	[ JETPACK_MODULE_ACTIVATE_SUCCESS ]: createActivationItemsReducer( true ),
+	[ JETPACK_MODULE_DEACTIVATE_SUCCESS ]: createActivationItemsReducer( false ),
 } );
 
 /**

--- a/client/state/jetpack/settings/test/reducer.js
+++ b/client/state/jetpack/settings/test/reducer.js
@@ -8,6 +8,8 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import {
+	JETPACK_MODULE_ACTIVATE_SUCCESS,
+	JETPACK_MODULE_DEACTIVATE_SUCCESS,
 	JETPACK_SETTINGS_RECEIVE,
 	JETPACK_SETTINGS_REQUEST,
 	JETPACK_SETTINGS_REQUEST_FAILURE,
@@ -107,6 +109,50 @@ describe( 'reducer', () => {
 			const stateOut = itemsReducer( deepFreeze( stateIn ), action );
 			expect( stateOut ).to.eql( {
 				12345678: { ...SETTINGS_FIXTURE[ siteId ], test_setting: 123 }
+			} );
+		} );
+
+		it( 'should mark the module as active upon successful module activation', () => {
+			const siteId = 12345678,
+				stateIn = {
+					12345678: {
+						setting_123: 'test',
+						'module-a': false
+					}
+				},
+				action = {
+					type: JETPACK_MODULE_ACTIVATE_SUCCESS,
+					siteId,
+					moduleSlug: 'module-a'
+				};
+			const stateOut = itemsReducer( deepFreeze( stateIn ), action );
+			expect( stateOut ).to.eql( {
+				12345678: {
+					setting_123: 'test',
+					'module-a': true
+				}
+			} );
+		} );
+
+		it( 'should mark the module as inactive upon successful module deactivation', () => {
+			const siteId = 12345678,
+				stateIn = {
+					12345678: {
+						setting_123: 'test',
+						'module-a': true
+					}
+				},
+				action = {
+					type: JETPACK_MODULE_DEACTIVATE_SUCCESS,
+					siteId,
+					moduleSlug: 'module-a'
+				};
+			const stateOut = itemsReducer( deepFreeze( stateIn ), action );
+			expect( stateOut ).to.eql( {
+				12345678: {
+					setting_123: 'test',
+					'module-a': false
+				}
 			} );
 		} );
 

--- a/client/state/jetpack/settings/test/reducer.js
+++ b/client/state/jetpack/settings/test/reducer.js
@@ -10,6 +10,7 @@ import deepFreeze from 'deep-freeze';
 import {
 	JETPACK_MODULE_ACTIVATE_SUCCESS,
 	JETPACK_MODULE_DEACTIVATE_SUCCESS,
+	JETPACK_MODULES_RECEIVE,
 	JETPACK_SETTINGS_RECEIVE,
 	JETPACK_SETTINGS_REQUEST,
 	JETPACK_SETTINGS_REQUEST_FAILURE,
@@ -152,6 +153,37 @@ describe( 'reducer', () => {
 				12345678: {
 					setting_123: 'test',
 					'module-a': false
+				}
+			} );
+		} );
+
+		it( 'should update the module activation state upon receiving new modules', () => {
+			const siteId = 12345678,
+				stateIn = {
+					12345678: {
+						setting_123: 'test',
+						'module-a': true,
+						'module-b': false
+					}
+				},
+				action = {
+					type: JETPACK_MODULES_RECEIVE,
+					siteId,
+					modules: {
+						'module-a': {
+							active: false
+						},
+						'module-b': {
+							active: true
+						}
+					}
+				};
+			const stateOut = itemsReducer( deepFreeze( stateIn ), action );
+			expect( stateOut ).to.eql( {
+				12345678: {
+					setting_123: 'test',
+					'module-a': false,
+					'module-b': true,
 				}
 			} );
 		} );


### PR DESCRIPTION
This PR attempts to synchronize the modules activation state between the two trees that this data might exist in (`modules` and `settings`). While our actions and selectors will not use data from multiple sources, keeping both trees as up to date as possible is recommended.

This PR proposes syncing in the following cases:

* Sync settings after activating/deactivating modules successfully.
* Sync settings when receiving modules.
* Sync modules when updating settings completed successfully.
* Sync modules when receiving settings.

This will guarantee we'll have as fresh activation state as possible.

This PR also removes the `options` from the `modules` tree, for the following reasons:
* We will be using `settings` to retrieve and manipulate any module options, and there's no need to arbitrarily store those.
* There's no practical need to synchronize those between the two trees.

To test:

* Checkout this branch
* Verify all Jetpack Settings tests pass: `npm run test-client client/state/jetpack/`