### PR TITLE
Localci: only run localci on pull requests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ test:
           if [[ "$CIRCLE_NODE_INDEX" == 0 ]]; then NODE_ENV=test make build-server; fi
           if ( [[ "$CIRCLE_NODE_INDEX" == 1 ]] || [[ "$CIRCLE_NODE_TOTAL" == 1 ]] ) && [[ "$CIRCLE_BRANCH" == "master" ]]; then
             make translate; mkdir -p $CIRCLE_ARTIFACTS/translate; mv calypso-strings.pot $CIRCLE_ARTIFACTS/translate
-          elif [[ "$CIRCLE_NODE_INDEX" == 1 ]] || [[ "$CIRCLE_NODE_TOTAL" == 1 ]]; then
+          elif ( [[ "$CIRCLE_NODE_INDEX" == 1 ]] || [[ "$CIRCLE_NODE_TOTAL" == 1 ]] ) && [[ "$CI_PULL_REQUEST" ]]; then
             git clone https://github.com/Automattic/gp-localci-client.git
             bash gp-localci-client/generate-new-strings-pot.sh $CIRCLE_BRANCH $CIRCLE_SHA1 $CIRCLE_ARTIFACTS/translate
             rm -rf gp-localci-client


### PR DESCRIPTION
Localci works best when in the context of a PR. Trying to limit it to PRs.