### PR TITLE
Themes: Show theme info for wpcom themes when jetpack site selected

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -485,6 +485,7 @@ const ThemeSheet = React.createClass( {
 		return (
 			<Main className="theme__sheet">
 				<QueryTheme themeId={ this.props.id } siteId={ siteIdOrWpcom } />
+				{ isJetpack && <QueryTheme themeId={ this.props.id } siteId="wpcom" /> }
 				{ isJetpack && <QueryTheme themeId={ this.props.id } siteId="wporg" /> }
 				{ currentUserId && <QueryUserPurchases userId={ currentUserId } /> }
 				{ siteID && <QuerySitePurchases siteId={ siteID } /> }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -546,17 +546,25 @@ const ConnectedThemeSheet = connectOptions(
 );
 
 const ThemeSheetWithOptions = ( props ) => {
-	const { selectedSite: site, isActive, isLoggedIn, isPremium, isPurchased } = props;
+	const {
+		selectedSite: site,
+		isActive,
+		isLoggedIn,
+		isPremium,
+		isPurchased,
+		isJetpack,
+		isWpcomTheme,
+	} = props;
 	const siteId = site ? site.ID : null;
 
 	let defaultOption;
 
-	if ( props.isJetpack && props.isWpcomTheme ) {
-		defaultOption = 'activateOnJetpack';
-	} else if ( ! isLoggedIn ) {
+	if ( ! isLoggedIn ) {
 		defaultOption = 'signup';
 	} else if ( isActive ) {
 		defaultOption = 'customize';
+	} else if ( isJetpack && isWpcomTheme ) {
+		defaultOption = 'activateOnJetpack';
 	} else if ( isPremium && ! isPurchased ) {
 		defaultOption = 'purchase';
 	} else {
@@ -577,7 +585,7 @@ const ThemeSheetWithOptions = ( props ) => {
 				'tryAndCustomizeOnJetpack',
 			] }
 			defaultOption={ defaultOption }
-			secondaryOption={ ( props.isJetpack && props.isWpcomTheme ) ? 'tryAndCustomizeOnJetpack' : 'tryandcustomize' }
+			secondaryOption={ ( isJetpack && isWpcomTheme ) ? 'tryAndCustomizeOnJetpack' : 'tryandcustomize' }
 			source="showcase-sheet" />
 	);
 };
@@ -617,6 +625,9 @@ export default connect(
 		// Fallback to 'wpcom' source for wpcom themes on Jetpack target sites
 		const theme = getTheme( state, siteIdOrWpcom, id ) || getTheme( state, 'wpcom', id );
 		const error = theme ? false : getThemeRequestErrors( state, id, siteIdOrWpcom );
+		const isWpcomTheme = theme && theme.screenshots;
+		const themeIdAtTargetSite = ( isJetpack && isWpcomTheme ) ? `${ id }-wpcom` : id;
+		const isActive = selectedSite && isThemeActive( state, themeIdAtTargetSite, selectedSite.ID );
 
 		return {
 			...theme,
@@ -629,15 +640,15 @@ export default connect(
 			backPath,
 			currentUserId,
 			isCurrentUserPaid,
+			isWpcomTheme,
+			isActive,
 			isLoggedIn: !! currentUserId,
-			isActive: selectedSite && isThemeActive( state, id, selectedSite.ID ),
 			isPremium: isThemePremium( state, id ),
 			isPurchased: selectedSite && (
 				isThemePurchased( state, id, selectedSite.ID ) ||
 				hasFeature( state, selectedSite.ID, FEATURE_UNLIMITED_PREMIUM_THEMES )
 			),
 			forumUrl: selectedSite && getThemeForumUrl( state, id, selectedSite.ID ),
-			isWpcomTheme: theme && theme.screenshots,
 		};
 	}
 )( ThemeSheetWithOptions );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -545,18 +545,13 @@ const ConnectedThemeSheet = connectOptions(
 	}
 );
 
-const isWpcomThemeOnJetpackSite = ( props ) => {
-	// only wpcom themes have the screenshots field
-	return props.isJetpack && props.screenshots;
-};
-
 const ThemeSheetWithOptions = ( props ) => {
 	const { selectedSite: site, isActive, isLoggedIn, isPremium, isPurchased } = props;
 	const siteId = site ? site.ID : null;
 
 	let defaultOption;
 
-	if ( isWpcomThemeOnJetpackSite( props ) ) {
+	if ( props.isJetpack && props.isWpcomTheme ) {
 		defaultOption = 'activateOnJetpack';
 	} else if ( ! isLoggedIn ) {
 		defaultOption = 'signup';
@@ -582,7 +577,7 @@ const ThemeSheetWithOptions = ( props ) => {
 				'tryAndCustomizeOnJetpack',
 			] }
 			defaultOption={ defaultOption }
-			secondaryOption={ isWpcomThemeOnJetpackSite( props ) ? 'tryAndCustomizeOnJetpack' : 'tryandcustomize' }
+			secondaryOption={ ( props.isJetpack && props.isWpcomTheme ) ? 'tryAndCustomizeOnJetpack' : 'tryandcustomize' }
 			source="showcase-sheet" />
 	);
 };
@@ -641,7 +636,8 @@ export default connect(
 				isThemePurchased( state, id, selectedSite.ID ) ||
 				hasFeature( state, selectedSite.ID, FEATURE_UNLIMITED_PREMIUM_THEMES )
 			),
-			forumUrl: selectedSite && getThemeForumUrl( state, id, selectedSite.ID )
+			forumUrl: selectedSite && getThemeForumUrl( state, id, selectedSite.ID ),
+			isWpcomTheme: theme && theme.screenshots,
 		};
 	}
 )( ThemeSheetWithOptions );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -41,7 +41,8 @@ import {
 	isThemePremium,
 	isThemePurchased,
 	getThemeRequestErrors,
-	getThemeForumUrl
+	getThemeForumUrl,
+	isWpcomTheme as isThemeWpcom,
 } from 'state/themes/selectors';
 import { getBackPath } from 'state/themes/themes-ui/selectors';
 import EmptyContentComponent from 'components/empty-content';
@@ -625,7 +626,7 @@ export default connect(
 		// Fallback to 'wpcom' source for wpcom themes on Jetpack target sites
 		const theme = getTheme( state, siteIdOrWpcom, id ) || getTheme( state, 'wpcom', id );
 		const error = theme ? false : getThemeRequestErrors( state, id, siteIdOrWpcom );
-		const isWpcomTheme = theme && theme.screenshots;
+		const isWpcomTheme = isThemeWpcom( state, id );
 		const themeIdAtTargetSite = ( isJetpack && isWpcomTheme ) ? `${ id }-wpcom` : id;
 		const isActive = selectedSite && isThemeActive( state, themeIdAtTargetSite, selectedSite.ID );
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -545,13 +545,20 @@ const ConnectedThemeSheet = connectOptions(
 	}
 );
 
+const isWpcomThemeOnJetpackSite = ( props ) => {
+	// only wpcom themes have the screenshots field
+	return props.isJetpack && props.screenshots;
+};
+
 const ThemeSheetWithOptions = ( props ) => {
 	const { selectedSite: site, isActive, isLoggedIn, isPremium, isPurchased } = props;
 	const siteId = site ? site.ID : null;
 
 	let defaultOption;
 
-	if ( ! isLoggedIn ) {
+	if ( isWpcomThemeOnJetpackSite( props ) ) {
+		defaultOption = 'activateOnJetpack';
+	} else if ( ! isLoggedIn ) {
 		defaultOption = 'signup';
 	} else if ( isActive ) {
 		defaultOption = 'customize';
@@ -570,10 +577,12 @@ const ThemeSheetWithOptions = ( props ) => {
 				'customize',
 				'tryandcustomize',
 				'purchase',
-				'activate'
+				'activate',
+				'activateOnJetpack',
+				'tryAndCustomizeOnJetpack',
 			] }
 			defaultOption={ defaultOption }
-			secondaryOption="tryandcustomize"
+			secondaryOption={ isWpcomThemeOnJetpackSite( props ) ? 'tryAndCustomizeOnJetpack' : 'tryandcustomize' }
 			source="showcase-sheet" />
 	);
 };
@@ -610,7 +619,7 @@ export default connect(
 		const backPath = getBackPath( state );
 		const currentUserId = getCurrentUserId( state );
 		const isCurrentUserPaid = isUserPaid( state, currentUserId );
-		// Fallback to 'wpcom' source here is for wpcom themes on Jetpack target sites
+		// Fallback to 'wpcom' source for wpcom themes on Jetpack target sites
 		const theme = getTheme( state, siteIdOrWpcom, id ) || getTheme( state, 'wpcom', id );
 		const error = theme ? false : getThemeRequestErrors( state, id, siteIdOrWpcom );
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -625,7 +625,6 @@ export default connect(
 		const isCurrentUserPaid = isUserPaid( state, currentUserId );
 		const theme = getTheme( state, siteIdOrWpcom, id );
 		const error = theme ? false : getThemeRequestErrors( state, id, siteIdOrWpcom );
-		const isActive = selectedSite && isThemeActive( state, id, selectedSite.ID );
 
 		return {
 			...theme,
@@ -639,8 +638,8 @@ export default connect(
 			currentUserId,
 			isCurrentUserPaid,
 			isWpcomTheme,
-			isActive,
 			isLoggedIn: !! currentUserId,
+			isActive: selectedSite && isThemeActive( state, id, selectedSite.ID ),
 			isPremium: isThemePremium( state, id ),
 			isPurchased: selectedSite && (
 				isThemePurchased( state, id, selectedSite.ID ) ||

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -78,6 +78,7 @@ const ThemeSheet = React.createClass( {
 		selectedSite: React.PropTypes.object,
 		siteSlug: React.PropTypes.string,
 		backPath: React.PropTypes.string,
+		isWpcomTheme: React.PropTypes.bool,
 		defaultOption: React.PropTypes.shape( {
 			label: React.PropTypes.string,
 			action: React.PropTypes.func,

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -486,7 +486,6 @@ const ThemeSheet = React.createClass( {
 		return (
 			<Main className="theme__sheet">
 				<QueryTheme themeId={ this.props.id } siteId={ siteIdOrWpcom } />
-				{ isJetpack && <QueryTheme themeId={ this.props.id } siteId="wpcom" /> }
 				{ isJetpack && <QueryTheme themeId={ this.props.id } siteId="wporg" /> }
 				{ currentUserId && <QueryUserPurchases userId={ currentUserId } /> }
 				{ siteID && <QuerySitePurchases siteId={ siteID } /> }
@@ -619,14 +618,13 @@ export default connect(
 		const selectedSite = getSelectedSite( state );
 		const siteSlug = selectedSite ? getSiteSlug( state, selectedSite.ID ) : '';
 		const isJetpack = selectedSite && isJetpackSite( state, selectedSite.ID );
-		const siteIdOrWpcom = isJetpack ? selectedSite.ID : 'wpcom';
+		const isWpcomTheme = isThemeWpcom( state, id );
+		const siteIdOrWpcom = ( isJetpack && ! isWpcomTheme ) ? selectedSite.ID : 'wpcom';
 		const backPath = getBackPath( state );
 		const currentUserId = getCurrentUserId( state );
 		const isCurrentUserPaid = isUserPaid( state, currentUserId );
-		// Fallback to 'wpcom' source for wpcom themes on Jetpack target sites
-		const theme = getTheme( state, siteIdOrWpcom, id ) || getTheme( state, 'wpcom', id );
+		const theme = getTheme( state, siteIdOrWpcom, id );
 		const error = theme ? false : getThemeRequestErrors( state, id, siteIdOrWpcom );
-		const isWpcomTheme = isThemeWpcom( state, id );
 		const themeIdAtTargetSite = ( isJetpack && isWpcomTheme ) ? `${ id }-wpcom` : id;
 		const isActive = selectedSite && isThemeActive( state, themeIdAtTargetSite, selectedSite.ID );
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -610,7 +610,8 @@ export default connect(
 		const backPath = getBackPath( state );
 		const currentUserId = getCurrentUserId( state );
 		const isCurrentUserPaid = isUserPaid( state, currentUserId );
-		const theme = getTheme( state, siteIdOrWpcom, id );
+		// Fallback to 'wpcom' source here is for wpcom themes on Jetpack target sites
+		const theme = getTheme( state, siteIdOrWpcom, id ) || getTheme( state, 'wpcom', id );
 		const error = theme ? false : getThemeRequestErrors( state, id, siteIdOrWpcom );
 
 		return {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -625,8 +625,7 @@ export default connect(
 		const isCurrentUserPaid = isUserPaid( state, currentUserId );
 		const theme = getTheme( state, siteIdOrWpcom, id );
 		const error = theme ? false : getThemeRequestErrors( state, id, siteIdOrWpcom );
-		const themeIdAtTargetSite = ( isJetpack && isWpcomTheme ) ? `${ id }-wpcom` : id;
-		const isActive = selectedSite && isThemeActive( state, themeIdAtTargetSite, selectedSite.ID );
+		const isActive = selectedSite && isThemeActive( state, id, selectedSite.ID );
 
 		return {
 			...theme,

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -90,6 +90,7 @@ const ConnectedSingleSiteJetpack = connectOptions(
 								options={ [
 									'activateOnJetpack',
 									'tryAndCustomizeOnJetpack',
+									'customize',
 									'separator',
 									'info',
 									'support',

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -89,7 +89,11 @@ const ConnectedSingleSiteJetpack = connectOptions(
 							<ConnectedThemesSelection
 								options={ [
 									'activateOnJetpack',
-									'tryAndCustomizeOnJetpack'
+									'tryAndCustomizeOnJetpack',
+									'separator',
+									'info',
+									'support',
+									'help',
 								] }
 								search={ search }
 								tier={ wpcomTier }

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -26,6 +26,7 @@ import {
 	isThemeActive as isActive,
 	isThemePurchased as isPurchased,
 	isThemePremium as isPremium,
+	isWpcomTheme,
 } from 'state/themes/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { hasFeature } from 'state/sites/plans/selectors';
@@ -149,12 +150,13 @@ const support = {
 	label: i18n.translate( 'Setup' ),
 	icon: 'help',
 	getUrl: getSupportUrl,
-	hideForTheme: ( state, theme ) => ! isPremium( state, theme.id )
+	hideForTheme: ( state, theme ) => ! isPremium( state, theme.id ) || ! isWpcomTheme( state, theme.id )
 };
 
 const help = {
 	label: i18n.translate( 'Support' ),
 	getUrl: getHelpUrl,
+	hideForTheme: ( state, theme ) => ! isWpcomTheme( state, theme.id )
 };
 
 const ALL_THEME_OPTIONS = {

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -149,16 +149,12 @@ const support = {
 	label: i18n.translate( 'Setup' ),
 	icon: 'help',
 	getUrl: getSupportUrl,
-	// We don't know where support docs for a given theme on a self-hosted WP install are.
-	hideForSite: ( state, siteId ) => isJetpackSite( state, siteId ),
 	hideForTheme: ( state, theme ) => ! isPremium( state, theme.id )
 };
 
 const help = {
 	label: i18n.translate( 'Support' ),
 	getUrl: getHelpUrl,
-	// We don't know where support docs for a given theme on a self-hosted WP install are.
-	hideForSite: ( state, siteId ) => isJetpackSite( state, siteId ),
 };
 
 const ALL_THEME_OPTIONS = {

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -334,17 +334,6 @@ export function isWpcomTheme( state, themeId ) {
 }
 
 /**
- * Whether a theme is present on WordPress.com.
- *
- * @param  {Object}  state   Global state tree
- * @param  {Number}  themeId Theme ID
- * @return {Boolean}         Whether theme available on WordPress.com
- */
-export function isWpcomTheme( state, themeId ) {
-	return !! getTheme( state, 'wpcom', themeId );
-}
-
-/**
  * Returns the URL for a given theme's details sheet.
  *
  * @param  {Object}  state  Global state tree

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -436,12 +436,10 @@ export function getThemeCustomizeUrl( state, theme, siteId ) {
 	}
 
 	if ( isJetpackSite( state, siteId ) ) {
-		// wpcom themes on jetpack sites use suffixed id
-		const themeIdSuffix = isWpcomTheme( state, theme && theme.id ) ? '-wpcom' : '';
 		return getSiteOption( state, siteId, 'admin_url' ) +
 			'customize.php?return=' +
 			encodeURIComponent( window.location ) +
-			( theme ? '&theme=' + theme.id + themeIdSuffix : '' );
+			( theme ? '&theme=' + getSuffixedThemeId( state, theme.id, siteId ) : '' );
 	}
 
 	const customizeUrl = '/customize/' + getSiteSlug( state, siteId );

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -436,10 +436,12 @@ export function getThemeCustomizeUrl( state, theme, siteId ) {
 	}
 
 	if ( isJetpackSite( state, siteId ) ) {
+		// wpcom themes on jetpack sites use suffixed id
+		const themeIdSuffix = ( theme && theme.screenshots ) ? '-wpcom' : '';
 		return getSiteOption( state, siteId, 'admin_url' ) +
 			'customize.php?return=' +
 			encodeURIComponent( window.location ) +
-			( theme ? '&theme=' + theme.id : '' );
+			( theme ? '&theme=' + theme.id + themeIdSuffix : '' );
 	}
 
 	const customizeUrl = '/customize/' + getSiteSlug( state, siteId );

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -334,6 +334,17 @@ export function isWpcomTheme( state, themeId ) {
 }
 
 /**
+ * Whether a theme is present on WordPress.com.
+ *
+ * @param  {Object}  state   Global state tree
+ * @param  {Number}  themeId Theme ID
+ * @return {Boolean}         Whether theme available on WordPress.com
+ */
+export function isWpcomTheme( state, themeId ) {
+	return !! getTheme( state, 'wpcom', themeId );
+}
+
+/**
  * Returns the URL for a given theme's details sheet.
  *
  * @param  {Object}  state  Global state tree
@@ -437,7 +448,7 @@ export function getThemeCustomizeUrl( state, theme, siteId ) {
 
 	if ( isJetpackSite( state, siteId ) ) {
 		// wpcom themes on jetpack sites use suffixed id
-		const themeIdSuffix = ( theme && theme.screenshots ) ? '-wpcom' : '';
+		const themeIdSuffix = isWpcomTheme( state, theme && theme.id ) ? '-wpcom' : '';
 		return getSiteOption( state, siteId, 'admin_url' ) +
 			'customize.php?return=' +
 			encodeURIComponent( window.location ) +

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -65,6 +65,15 @@ export const getTheme = createSelector(
 		if ( siteId === 'wpcom' || siteId === 'wporg' ) {
 			return theme;
 		}
+
+		if ( ! theme ) {
+			// We may be looking up a wpcom theme from a jetpack site
+			const wpcomManager = state.themes.queries.wpcom;
+			if ( wpcomManager ) {
+				return wpcomManager.getItem( themeId );
+			}
+		}
+
 		// We're dealing with a Jetpack site. If we have theme info obtained from the
 		// WordPress.org API, merge it.
 		const wporgTheme = getTheme( state, 'wporg', themeId );

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -372,7 +372,7 @@ export function getThemeDetailsUrl( state, theme, siteId ) {
  * @return {?String}        Theme setup instructions URL
  */
 export function getThemeSupportUrl( state, theme, siteId ) {
-	if ( isJetpackSite( state, siteId ) || ! theme || ! isThemePremium( state, theme.id ) ) {
+	if ( ! theme || ! isThemePremium( state, theme.id ) ) {
 		return null;
 	}
 
@@ -394,7 +394,7 @@ export function getThemeSupportUrl( state, theme, siteId ) {
  * @return {?String}        Theme support page URL
  */
 export function getThemeHelpUrl( state, theme, siteId ) {
-	if ( ! theme || isJetpackSite( state, siteId ) ) {
+	if ( ! theme ) {
 		return null;
 	}
 

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -67,11 +67,7 @@ export const getTheme = createSelector(
 		}
 
 		if ( ! theme ) {
-			// We may be looking up a wpcom theme from a jetpack site
-			const wpcomManager = state.themes.queries.wpcom;
-			if ( wpcomManager ) {
-				return wpcomManager.getItem( themeId );
-			}
+			return null;
 		}
 
 		// We're dealing with a Jetpack site. If we have theme info obtained from the

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -1096,7 +1096,7 @@ describe( 'themes selectors', () => {
 			expect( helpUrl ).to.equal( '/theme/mood/support/example.wordpress.com' );
 		} );
 
-		it( 'given a theme and Jetpack site ID, should return null', () => {
+		it( 'given a theme and Jetpack site ID, should return the help url', () => {
 			const helpUrl = getThemeHelpUrl(
 				{
 					sites: {
@@ -1118,7 +1118,7 @@ describe( 'themes selectors', () => {
 				},
 				77203074
 			);
-			expect( helpUrl ).to.be.null;
+			expect( helpUrl ).to.be.equal( '/theme/twentysixteen/support/example.net' );
 		} );
 	} );
 


### PR DESCRIPTION
<img width="1280" alt="screen shot 2017-01-10 at 15 24 34" src="https://cloud.githubusercontent.com/assets/7767559/21811852/0a756260-d749-11e6-91f2-8a0757562bbf.png">

**With a jetpack site selected, for themes in the _WordPress.com Themes_ list**
* Adds all appropriate actions into ... menu
* Opens info page on screenshot click
* Enables _Activate_ and _Try and Customize_ actions from inside the theme sheet

**To Test**
* Go to http://calypso.localhost:3000/theme/{wpcom theme}/{jetpack site}
* or go to http://calypso.localhost:3000/design/{jetpack site} 
* **Expected:** The menu items in the ... menu should show appropriate options
* click a screen shot of a theme in the wpcom list
* **Expected:** the info sheet should show as per a wpcom site / multisite
