### PR TITLE
Signup: Design Type - ES6-ify the step

### DIFF
--- a/client/signup/steps/design-type/index.jsx
+++ b/client/signup/steps/design-type/index.jsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
+import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,11 +18,21 @@ import PageImage from '../design-type-with-store/page-image';
 import GridImage from '../design-type-with-store/grid-image';
 
 class DesignTypeStep extends Component {
+	static propTypes = {
+		translate: PropTypes.func
+	};
+
+	static defaultProps = {
+		translate: identity
+	};
+
 	getChoices() {
+		const { translate } = this.props;
+
 		return [
-			{ type: 'blog', label: this.props.translate( 'A list of my latest posts' ), image: <BlogImage /> },
-			{ type: 'page', label: this.props.translate( 'A welcome page for my site' ), image: <PageImage /> },
-			{ type: 'grid', label: this.props.translate( 'A grid of my latest posts' ), image: <GridImage /> },
+			{ type: 'blog', label: translate( 'A list of my latest posts' ), image: <BlogImage /> },
+			{ type: 'page', label: translate( 'A welcome page for my site' ), image: <PageImage /> },
+			{ type: 'grid', label: translate( 'A grid of my latest posts' ), image: <GridImage /> },
 		];
 	}
 

--- a/client/signup/steps/design-type/index.jsx
+++ b/client/signup/steps/design-type/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { identity } from 'lodash';
+import { identity, transform } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,6 +28,14 @@ class DesignTypeStep extends Component {
 		translate: identity
 	};
 
+	choiceHandlers = {};
+
+	componentWillMount() {
+		this.choiceHandlers = transform( this.getChoices(), ( handlers, choice ) => {
+			handlers[ choice.type ] = ( event ) => this.handleChoiceClick( event, choice.type );
+		}, {} );
+	}
+
 	getChoices() {
 		const { translate } = this.props;
 
@@ -45,7 +53,7 @@ class DesignTypeStep extends Component {
 						<Card className="design-type__choice" key={ choice.type }>
 							<a
 								className="design-type__choice-link"
-								onClick={ ( event ) => this.handleChoiceClick( event, choice.type ) }
+								onClick={ this.choiceHandlers[ choice.type ] }
 							>
 								{ choice.image }
 								<h2>{ choice.label }</h2>

--- a/client/signup/steps/design-type/index.jsx
+++ b/client/signup/steps/design-type/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { identity, transform } from 'lodash';
+import { identity, memoize, transform } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,13 +28,11 @@ class DesignTypeStep extends Component {
 		translate: identity
 	};
 
-	choiceHandlers = {};
-
-	componentWillMount() {
-		this.choiceHandlers = transform( this.getChoices(), ( handlers, choice ) => {
+	getChoiceHandlers = memoize( ( ) =>
+		transform( this.getChoices(), ( handlers, choice ) => {
 			handlers[ choice.type ] = ( event ) => this.handleChoiceClick( event, choice.type );
-		}, {} );
-	}
+		}, {} )
+	);
 
 	getChoices() {
 		const { translate } = this.props;
@@ -47,13 +45,15 @@ class DesignTypeStep extends Component {
 	}
 
 	renderChoices() {
+		const choiceHandlers = this.getChoiceHandlers();
+
 		return (
 			<div className="design-type__list">
 				{ this.getChoices().map( ( choice ) => (
 						<Card className="design-type__choice" key={ choice.type }>
 							<a
 								className="design-type__choice-link"
-								onClick={ this.choiceHandlers[ choice.type ] }
+								onClick={ choiceHandlers[ choice.type ] }
 							>
 								{ choice.image }
 								<h2>{ choice.label }</h2>

--- a/client/signup/steps/design-type/index.jsx
+++ b/client/signup/steps/design-type/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -11,27 +12,29 @@ import SignupActions from 'lib/signup/actions';
 import analytics from 'lib/analytics';
 import Card from 'components/card';
 
-export default React.createClass( {
-	displayName: 'DesignType',
+import BlogImage from '../design-type-with-store/blog-image';
+import PageImage from '../design-type-with-store/page-image';
+import GridImage from '../design-type-with-store/grid-image';
 
+class DesignTypeStep extends Component {
 	getChoices() {
 		return [
-			{ type: 'blog', label: this.translate( 'A list of my latest posts' ), image: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 310 230"><rect x="15" y="15" fill="#E8F0F5" width="280" height="70"/><rect x="15" y="98" fill="#C3EF96" width="194" height="85"/><rect x="15" y="195" fill="#C3EF96" width="194" height="35"/></svg> },
-			{ type: 'page', label: this.translate( 'A welcome page for my site' ), image: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 310 230"><rect fill="#E8F0F5" width="310" height="110"/><rect x="114" y="205" fill="#E8F0F5" width="82" height="25"/><rect x="15" y="205" fill="#E8F0F5" width="82" height="25"/><rect x="213" y="205" fill="#E8F0F5" width="82" height="25"/><rect x="15" y="36" fill="#D2DEE6" width="153" height="13"/><rect x="15" y="59" fill="#D2DEE6" width="113" height="13"/><rect x="15" y="82" fill="#C3EF96" width="30" height="13"/><rect x="15" y="125" fill="#C3EF96" width="280" height="65"/></svg> },
-			{ type: 'grid', label: this.translate( 'A grid of my latest posts' ), image: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 310 230"><rect x="15" y="15" fill="#E8F0F5" width="280" height="40"/><rect x="114" y="70" fill="#C3EF96" width="82" height="65"/><rect x="15" y="70" fill="#C3EF96" width="82" height="65"/><rect x="213" y="70" fill="#C3EF96" width="82" height="65"/><rect x="114" y="150" fill="#C3EF96" width="82" height="65"/><rect x="15" y="150" fill="#C3EF96" width="82" height="65"/><rect x="213" y="150" fill="#C3EF96" width="82" height="65"/></svg> },
+			{ type: 'blog', label: this.props.translate( 'A list of my latest posts' ), image: <BlogImage /> },
+			{ type: 'page', label: this.props.translate( 'A welcome page for my site' ), image: <PageImage /> },
+			{ type: 'grid', label: this.props.translate( 'A grid of my latest posts' ), image: <GridImage /> },
 		];
-	},
+	}
 
-	renderChoice( choice ) {
+	renderChoice = ( choice ) => {
 		return (
 			<Card className="design-type__choice" key={ choice.type }>
-				<a className="design-type__choice__link" href="#" onClick={ ( event ) => this.handleChoiceClick( event, choice.type ) }>
+				<a className="design-type__choice-link" href="#" onClick={ ( event ) => this.handleChoiceClick( event, choice.type ) }>
 					{ choice.image }
 					<h2>{ choice.label }</h2>
 				</a>
 			</Card>
 		);
-	},
+	};
 
 	renderChoices() {
 		return (
@@ -40,29 +43,30 @@ export default React.createClass( {
 				<div className="design-type__choice is-spacergif" />
 			</div>
 		);
-	},
+	}
 
 	render() {
+		const { translate } = this.props;
 		return (
-			<div className="design-type__section-wrapper">
+			<div className="design-type">
 				<StepWrapper
 					flowName={ this.props.flowName }
 					stepName={ this.props.stepName }
 					positionInFlow={ this.props.positionInFlow }
-					fallbackHeaderText={ this.translate( 'What would you like your homepage to look like?' ) }
-					fallbackSubHeaderText={ this.translate( 'This will help us figure out what kinds of designs to show you.' ) }
-					subHeaderText={ this.translate( 'First up, what would you like your homepage to look like?' ) }
+					fallbackHeaderText={ translate( 'What would you like your homepage to look like?' ) }
+					fallbackSubHeaderText={ translate( 'This will help us figure out what kinds of designs to show you.' ) }
+					subHeaderText={ translate( 'First up, what would you like your homepage to look like?' ) }
 					signupProgress={ this.props.signupProgress }
 					stepContent={ this.renderChoices() } />
 			</div>
 		);
-	},
+	}
 
 	handleChoiceClick( event, type ) {
 		event.preventDefault();
 		event.stopPropagation();
 		this.handleNextStep( type );
-	},
+	}
 
 	handleNextStep( designType ) {
 		analytics.tracks.recordEvent( 'calypso_triforce_select_design', { category: designType } );
@@ -70,4 +74,6 @@ export default React.createClass( {
 		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], { designType } );
 		this.props.goToNextStep();
 	}
-} );
+}
+
+export default localize( DesignTypeStep );

--- a/client/signup/steps/design-type/index.jsx
+++ b/client/signup/steps/design-type/index.jsx
@@ -82,7 +82,7 @@ class DesignTypeStep extends Component {
 	}
 
 	handleNextStep( designType ) {
-		this.props.recordChosenDesignType( designType );
+		this.props.recordTracksEvent( 'calypso_triforce_select_design', { category: designType } );
 
 		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], { designType } );
 		this.props.goToNextStep();
@@ -91,9 +91,7 @@ class DesignTypeStep extends Component {
 
 export default connect(
 	null,
-	( dispatch ) => ( {
-		recordChosenDesignType: ( designType ) => {
-			dispatch( recordTracksEvent( 'calypso_triforce_select_design', { category: designType } ) );
-		}
-	} )
+	{
+		recordTracksEvent
+	}
 )( localize( DesignTypeStep ) );

--- a/client/signup/steps/design-type/index.jsx
+++ b/client/signup/steps/design-type/index.jsx
@@ -45,7 +45,7 @@ class DesignTypeStep extends Component {
 						<Card className="design-type__choice" key={ choice.type }>
 							<a
 								className="design-type__choice-link"
-								ref="#" onClick={ ( event ) => this.handleChoiceClick( event, choice.type ) }
+								onClick={ ( event ) => this.handleChoiceClick( event, choice.type ) }
 							>
 								{ choice.image }
 								<h2>{ choice.label }</h2>

--- a/client/signup/steps/design-type/index.jsx
+++ b/client/signup/steps/design-type/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { identity } from 'lodash';
 
@@ -10,12 +11,13 @@ import { identity } from 'lodash';
  */
 import StepWrapper from 'signup/step-wrapper';
 import SignupActions from 'lib/signup/actions';
-import analytics from 'lib/analytics';
 import Card from 'components/card';
 
 import BlogImage from '../design-type-with-store/blog-image';
 import PageImage from '../design-type-with-store/page-image';
 import GridImage from '../design-type-with-store/grid-image';
+
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class DesignTypeStep extends Component {
 	static propTypes = {
@@ -36,21 +38,21 @@ class DesignTypeStep extends Component {
 		];
 	}
 
-	renderChoice = ( choice ) => {
-		return (
-			<Card className="design-type__choice" key={ choice.type }>
-				<a className="design-type__choice-link" href="#" onClick={ ( event ) => this.handleChoiceClick( event, choice.type ) }>
-					{ choice.image }
-					<h2>{ choice.label }</h2>
-				</a>
-			</Card>
-		);
-	};
-
 	renderChoices() {
 		return (
 			<div className="design-type__list">
-				{ this.getChoices().map( this.renderChoice ) }
+				{ this.getChoices().map( ( choice ) => (
+						<Card className="design-type__choice" key={ choice.type }>
+							<a
+								className="design-type__choice-link"
+								ref="#" onClick={ ( event ) => this.handleChoiceClick( event, choice.type ) }
+							>
+								{ choice.image }
+								<h2>{ choice.label }</h2>
+							</a>
+						</Card>
+					)
+				) }
 				<div className="design-type__choice is-spacergif" />
 			</div>
 		);
@@ -80,11 +82,18 @@ class DesignTypeStep extends Component {
 	}
 
 	handleNextStep( designType ) {
-		analytics.tracks.recordEvent( 'calypso_triforce_select_design', { category: designType } );
+		this.props.recordChosenDesignType( designType );
 
 		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], { designType } );
 		this.props.goToNextStep();
 	}
 }
 
-export default localize( DesignTypeStep );
+export default connect(
+	null,
+	( dispatch ) => ( {
+		recordChosenDesignType: ( designType ) => {
+			dispatch( recordTracksEvent( 'calypso_triforce_select_design', { category: designType } ) );
+		}
+	} )
+)( localize( DesignTypeStep ) );

--- a/client/signup/steps/design-type/style.scss
+++ b/client/signup/steps/design-type/style.scss
@@ -9,6 +9,7 @@
 	width: 230px;
 	flex-grow: 1;
 	transition: all 100ms ease-in-out;
+	cursor: pointer;
 
 	a, svg {
 		display: block;


### PR DESCRIPTION
This PR brings the older Design Type step code to ES6. This is a part of an ongoing PRs that will bring the whole Signup code to ES6. 

To test:

1. Start Signup
2. Choose the `designTypeWithoutStore` variation of the  `signupStore` AB test
3. Verify the step is working correctly
4. Verify there are no JS errors in the console.