### PR TITLE
Site Settings: Bind upgrade click tracking

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -308,7 +308,7 @@ class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
-	trackUpgradeClick() {
+	trackUpgradeClick = () => {
 		this.props.recordTracksEvent( 'calypso_upgrade_nudge_cta_click', { cta_name: 'settings_site_address' } );
 	}
 


### PR DESCRIPTION
Related: #9085

This pull request seeks to resolve an error which occurs when clicking "Add a Custom Address", due to upgrade tracking logic that tries to access the `props` of the component. This is a suspected regression of #9085 (cc @youknowriad) where the component had been upgraded from `React.createClass` to `React.Component`, thus losing auto-binding.

>Uncaught TypeError: Cannot read property 'props' of undefined

__Testing instructions:__

1. Navigate to [site settings](http://calypso.localhost:3000/settings)
2. Select a site
3. Click "Add a Custom Address"
4. Note that you are redirected and there are no errors in console