### PR TITLE
Signup: ES6ify the SignupThemesList component, part of the Themes Step

### DIFF
--- a/client/signup/steps/theme-selection/signup-themes-list.jsx
+++ b/client/signup/steps/theme-selection/signup-themes-list.jsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import noop from 'lodash/noop';
-import i18n from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -12,48 +12,48 @@ import getThemes from 'lib/signup/themes';
 import ThemesList from 'components/themes-list';
 import { abtest } from 'lib/abtest';
 
-module.exports = React.createClass( {
-	displayName: 'SignupThemesList',
+class SignupThemesList extends Component {
 
-	propTypes: {
+	static propTypes = {
 		surveyQuestion: React.PropTypes.string,
 		designType: React.PropTypes.string,
 		handleScreenshotClick: React.PropTypes.func,
 		handleThemeUpload: React.PropTypes.func,
 		showThemeUpload: React.PropTypes.bool
-	},
+	};
 
-	getDefaultProps() {
-		return {
-			surveyQuestion: null,
-			designType: null,
-			handleScreenshotClick: noop,
-			handleThemeUpload: noop,
-			showThemeUpload: 'showThemeUpload' === abtest( 'signupThemeUpload' ) && i18n.getLocaleSlug() === 'en'
-		};
-	},
+	static defaultProps = {
+		surveyQuestion: null,
+		designType: null,
+		handleScreenshotClick: noop,
+		handleThemeUpload: noop,
+		showThemeUpload: 'showThemeUpload' === abtest( 'signupThemeUpload' )
+	};
 
 	shouldComponentUpdate( nextProps ) {
 		return ( nextProps.surveyQuestion !== this.props.surveyQuestion || nextProps.designType !== this.props.designType );
-	},
+	}
 
 	getComputedThemes() {
 		return getThemes( this.props.surveyQuestion, this.props.designType );
-	},
+	}
 
 	getScreenshotUrl( theme ) {
 		return `https://i1.wp.com/s0.wp.com/wp-content/themes/${ theme.repo }/${ theme.slug }/screenshot.png?w=660`;
-	},
+	}
 
 	render() {
-		const actionLabel = this.translate( 'Pick' );
+		const actionLabel = this.props.translate( 'Pick' );
 		const getActionLabel = () => actionLabel;
+
 		const themes = this.getComputedThemes().map( theme => {
-			return Object.assign( theme, {
+			return {
+				...theme,
 				id: theme.slug,
-				screenshot: this.getScreenshotUrl( theme )
-			} );
+				screenshot: this.getScreenshotUrl( theme ),
+			};
 		} );
+
 		return (
 			<ThemesList
 				getButtonOptions= { noop }
@@ -66,5 +66,7 @@ module.exports = React.createClass( {
 			/>
 		);
 	}
-} );
+}
+
+export default localize( SignupThemesList );
 

--- a/client/signup/steps/theme-selection/signup-themes-list.jsx
+++ b/client/signup/steps/theme-selection/signup-themes-list.jsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import noop from 'lodash/noop';
 import { localize } from 'i18n-calypso';
+import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,11 +16,12 @@ import { abtest } from 'lib/abtest';
 class SignupThemesList extends Component {
 
 	static propTypes = {
-		surveyQuestion: React.PropTypes.string,
-		designType: React.PropTypes.string,
-		handleScreenshotClick: React.PropTypes.func,
-		handleThemeUpload: React.PropTypes.func,
-		showThemeUpload: React.PropTypes.bool
+		surveyQuestion: PropTypes.string,
+		designType: PropTypes.string,
+		handleScreenshotClick: PropTypes.func,
+		handleThemeUpload: PropTypes.func,
+		showThemeUpload: PropTypes.bool,
+		translate: PropTypes.func
 	};
 
 	static defaultProps = {
@@ -27,7 +29,8 @@ class SignupThemesList extends Component {
 		designType: null,
 		handleScreenshotClick: noop,
 		handleThemeUpload: noop,
-		showThemeUpload: 'showThemeUpload' === abtest( 'signupThemeUpload' )
+		showThemeUpload: 'showThemeUpload' === abtest( 'signupThemeUpload' ),
+		translate: identity
 	};
 
 	shouldComponentUpdate( nextProps ) {


### PR DESCRIPTION
This PR brings the `SignupThemesList` component code to ES6. 

This is a part of an ongoing PRs that will bring the whole Signup code to ES6. 

To test:

1. Start Signup
2. Verify the Themes step is working correctly
3. Verify there are no JS errors in the console.
4. Finish Signup
5. Verify the chosen theme is applied to the registered site.

Bonus checks: Verify the Upload theme option and the following Perssable flow is working as expected.

cc @vindl as you worked with the step lately. 