### PR TITLE
Site Settings: Consider image rotation and flip in deciding icon as edited

### DIFF
--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -33,7 +33,7 @@ import MediaStore from 'lib/media/store';
 import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
 import { isItemBeingUploaded } from 'lib/media/utils';
 import { addQueryArgs } from 'lib/url';
-import { getImageEditorCrop } from 'state/ui/editor/image-editor/selectors';
+import { getImageEditorCrop, getImageEditorTransform } from 'state/ui/editor/image-editor/selectors';
 import { getSiteIconUrl, isSiteSupportingImageEditor } from 'state/selectors';
 
 class SiteIconSetting extends Component {
@@ -117,15 +117,21 @@ class SiteIconSetting extends Component {
 			return;
 		}
 
-		const { crop } = this.props;
-		const isImageCropped = ! isEqual( crop, {
+		const { crop, transform } = this.props;
+		const isImageEdited = ! isEqual( {
+			...crop,
+			...transform
+		}, {
 			topRatio: 0,
 			leftRatio: 0,
 			widthRatio: 1,
-			heightRatio: 1
+			heightRatio: 1,
+			degrees: 0,
+			scaleX: 1,
+			scaleY: 1
 		} );
 
-		if ( isImageCropped ) {
+		if ( isImageEdited ) {
 			this.uploadSiteIcon( blob, `cropped-${ selectedItem.file }` );
 		} else {
 			this.saveSiteIconSetting( siteId, selectedItem );
@@ -246,7 +252,8 @@ export default connect(
 			siteSupportsImageEditor: isSiteSupportingImageEditor( state, siteId ),
 			customizerUrl: getCustomizerUrl( state, siteId ),
 			generalOptionsUrl: getSiteAdminUrl( state, siteId, 'options-general.php' ),
-			crop: getImageEditorCrop( state )
+			crop: getImageEditorCrop( state ),
+			transform: getImageEditorTransform( state )
 		};
 	},
 	{


### PR DESCRIPTION
Fixes #10448

This pull request seeks to resolve an issue where an image is perfectly square but rotated or flipped, assigning as site icon will use the original image instead of respecting the rotation or flip.

__Testing instructions:__

Repeat steps to reproduce from #10448, verifying that flip/rotation is respected in assigning site icon. Conversely, an un-rotated/flipped and square image should still attempt to reuse the existing media (issue described at #10464 notwithstanding).