### PR TITLE
Fix broken/incorrect site icons for SEO Previews

### DIFF
--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -36,8 +36,16 @@ import {
 import { recordTracksEvent } from 'state/analytics/actions';
 
 const PREVIEW_IMAGE_WIDTH = 512;
-const largeBlavatar = site => `${ get( site, 'icon.img', '//gravatar.com/avatar/' ) }?s=${ PREVIEW_IMAGE_WIDTH }`;
 const hasBusinessPlan = overSome( isBusiness, isEnterprise );
+
+const largeBlavatar = site => {
+	const siteIcon = get( site, 'icon.img' );
+	if ( ! siteIcon ) {
+		return null;
+	}
+
+	return `${ siteIcon }?s=${ PREVIEW_IMAGE_WIDTH }`;
+};
 
 const getPostImage = ( post ) => {
 	if ( ! post ) {

--- a/client/components/seo/facebook-preview/index.jsx
+++ b/client/components/seo/facebook-preview/index.jsx
@@ -42,9 +42,11 @@ export class FacebookPreview extends PureComponent {
 		return (
 			<div className={ `facebook-preview facebook-preview__${ type }` }>
 				<div className="facebook-preview__content">
-					<div className="facebook-preview__image">
-						<img src={ image } />
-					</div>
+					{ image &&
+						<div className="facebook-preview__image">
+							<img src={ image } />
+						</div>
+					}
 					<div className="facebook-preview__body">
 						<div className="facebook-preview__title">
 							{ facebookTitle( title || '' ) }

--- a/client/components/seo/style.scss
+++ b/client/components/seo/style.scss
@@ -218,7 +218,6 @@
 	float: left;
 	width: 125px;
 	height: 125px;
-	border-right: 1px solid #E1E8ED;
 }
 
 .twitter-card-preview__large_image_summary
@@ -242,6 +241,8 @@
 .twitter-card-preview__summary
 .twitter-card-preview__body {
 	margin-left: 125px;
+	border-left: 1px solid #E1E8ED;
+	height: 100%;
 }
 
 .twitter-card-preview__large_image_summary


### PR DESCRIPTION
Fixes the Facebook and Twitter previews to not show a site icon if it doesn’t exist.

There’s an exception for Twitter: Its previews appear to leave a blank space for the image, so I’ve replicated that:

<img width="781" alt="screen shot 2017-01-10 at 11 19 29 am" src="https://cloud.githubusercontent.com/assets/789137/21821251/aee1e1c4-d727-11e6-9e5d-4fe9d1ab1f47.png">

<img width="843" alt="screen shot 2017-01-10 at 11 19 36 am" src="https://cloud.githubusercontent.com/assets/789137/21821252/aee41bc4-d727-11e6-9b1e-c17b81f70e08.png">

**To Test**
View a site's Twitter and Facebook previews:
 * If the site doesn't have a site icon, the Facebook preview shouldn't show an image at all, and the Twitter preview should have an empty space.
 * If the site does have a site icon, it should display normally.

Fixes #9650