### PR TITLE
post-schedule:clock: janitorial

### DIFF
--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import i18n from 'i18n-calypso';
+import { localize, moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -23,10 +23,10 @@ const noop = () => {};
 /**
  * Check if the given value is useful to use in time format
  * @param {String} value - time value to check
- * @return {String} checked value
+ * @return {String} checked value or `false`
  */
 function checkTimeValue( value ) {
-	if ( value !== '0' && value !== '00' && ( value[0] === '0' || Number( value ) > 99 ) ) {
+	if ( value !== '0' && value !== '00' && ( value[ 0 ] === '0' || Number( value ) > 99 ) ) {
 		value = value.substr( 1 );
 	}
 
@@ -38,17 +38,23 @@ function checkTimeValue( value ) {
 }
 
 class PostScheduleClock extends Component {
+	constructor() {
+		super( ...arguments );
 
-	handleKeyDown( field, event ) {
-		var operation = event.keyCode - 39,
-			value = Number( event.target.value ),
-			modifiers = this.getTimeValues();
+		// bounds
+		this.adjustHour = event => this.handleKeyDown( event, 'hour' );
+		this.adjustMinute = event => this.handleKeyDown( event, 'minute' );
+	}
+
+	handleKeyDown( event, field ) {
+		const operation = event.keyCode - 39;
+		const modifiers = this.getTimeValues();
 
 		if ( ! ( -1 === operation || 1 === operation ) ) {
 			return null;
 		}
 
-		value -= operation;
+		let value = Number( event.target.value ) - operation;
 
 		if ( 'hour' === field ) {
 			value = value > 23 ? 0 : value;
@@ -60,13 +66,18 @@ class PostScheduleClock extends Component {
 
 		modifiers[ field ] = value;
 
-		this.setTime( modifiers );
+		this.setTime( event, modifiers );
 	}
 
 	getTimeValues() {
-		var modifiers = {},
-			hour = checkTimeValue( this.refs.timeHourRef.value ),
-			minute = checkTimeValue( this.refs.timeMinuteRef.value );
+		const {
+			hourReference,
+			minuteRef
+		} = this.refs;
+
+		const hour = checkTimeValue( hourReference.value );
+		const minute = checkTimeValue( minuteRef.value );
+		const modifiers = {};
 
 		if ( false !== hour && hour < 24 ) {
 			modifiers.hour = Number( hour );
@@ -79,57 +90,32 @@ class PostScheduleClock extends Component {
 		return modifiers;
 	}
 
-	setTime( modifiers ) {
-		let date = i18n.moment( this.props.date ).set( modifiers );
+	setTime = ( event, modifiers = this.getTimeValues() ) => {
+		const date = moment( this.props.date ).set( modifiers );
 		this.props.onChange( date, modifiers );
 	}
 
-	render() {
-		return (
-			<div className="post-schedule__clock">
-				<input
-					className="post-schedule__clock_time"
-					name="post-schedule__clock_hour"
-					ref="timeHourRef"
-					value={ this.props.date.format( 'HH' ) }
-					onChange={ () => {
-						this.setTime( this.getTimeValues() );
-					} }
-					onKeyDown={ this.handleKeyDown.bind( this, 'hour' ) }
-					type="text" />
-
-				<span className="post-schedule__clock-divisor">:</span>
-
-				<input
-					className="post-schedule__clock_time"
-					name="post-schedule__clock_minute"
-					ref="timeMinuteRef"
-					value={ this.props.date.format( 'mm' ) }
-					onChange={ () => {
-						this.setTime( this.getTimeValues() );
-					} }
-					onKeyDown={ this.handleKeyDown.bind( this, 'minute' ) }
-					type="text" />
-
-				{ this.renderTimezoneBox() }
-			</div>
-		);
-	}
-
 	renderTimezoneBox() {
-		if ( ! ( this.props.timezone || utils.isValidGMTOffset( this.props.gmtOffset ) ) ) {
+		const {
+			date,
+			gmtOffset,
+			timezone,
+			translate
+		} = this.props;
+
+		if ( ! ( timezone || utils.isValidGMTOffset( gmtOffset ) ) ) {
 			return;
 		}
 
 		let diffInHours, formatZ;
 
-		if ( this.props.timezone ) {
-			let tzDate = this.props.date.clone().tz( this.props.timezone );
-			diffInHours = tzDate.utcOffset() - i18n.moment().utcOffset();
+		if ( timezone ) {
+			const tzDate = date.clone().tz( timezone );
+			diffInHours = tzDate.utcOffset() - moment().utcOffset();
 			formatZ = tzDate.format( ' Z ' );
-		} else if ( utils.isValidGMTOffset( this.props.gmtOffset ) ) {
-			let utcDate = this.props.date.clone().utcOffset( this.props.gmtOffset );
-			diffInHours = utcDate.utcOffset() - i18n.moment().utcOffset();
+		} else if ( utils.isValidGMTOffset( gmtOffset ) ) {
+			const utcDate = date.clone().utcOffset( gmtOffset );
+			diffInHours = utcDate.utcOffset() - moment().utcOffset();
 			formatZ = utcDate.format( ' Z ' );
 		}
 
@@ -147,7 +133,7 @@ class PostScheduleClock extends Component {
 			<span>
 				<div className="post-schedule__clock-timezone">
 					{
-						i18n.translate( 'Site %(diff)s from you', {
+						translate( 'Site %(diff)s from you', {
 							args: { diff: diffInHours }
 						} )
 					}
@@ -156,8 +142,8 @@ class PostScheduleClock extends Component {
 						className="post-schedule__timezone-info"
 						position={ popoverPosition }
 					>
-						{ this.props.timezone
-							? this.props.timezone.replace( /(\/)/ig, ' $1 ' )
+						{ timezone
+							? timezone.replace( /(\/)/ig, ' $1 ' )
 							: 'UTC'
 						}
 						{ formatZ }
@@ -166,7 +152,37 @@ class PostScheduleClock extends Component {
 			</span>
 		);
 	}
-};
+
+	render() {
+		const { date } = this.props;
+
+		return (
+			<div className="post-schedule__clock">
+				<input
+					className="post-schedule__clock-time"
+					name="post-schedule__clock_hour"
+					ref="hourReference"
+					value={ date.format( 'HH' ) }
+					onChange={ this.setTime }
+					onKeyDown={ this.adjustHour }
+					type="text" />
+
+				<span className="post-schedule__clock-divisor">:</span>
+
+				<input
+					className="post-schedule__clock-time"
+					name="post-schedule__clock_minute"
+					ref="minuteRef"
+					value={ date.format( 'mm' ) }
+					onChange={ this.setTime }
+					onKeyDown={ this.adjustMinute }
+					type="text" />
+
+				{ this.renderTimezoneBox() }
+			</div>
+		);
+	}
+}
 
 /**
  * Statics
@@ -182,4 +198,4 @@ PostScheduleClock.defaultProps = {
 	onChange: noop
 };
 
-export default PostScheduleClock;
+export default localize( PostScheduleClock );

--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -13,29 +13,15 @@ import viewport from 'lib/viewport';
 /**
  * Local dependencies
  */
-import utils from './utils';
+import {
+	isValidGMTOffset,
+	parseAndValidateNumber
+} from './utils';
 
 /**
  * Globals
  */
 const noop = () => {};
-
-/**
- * Check if the given value is useful to use in time format
- * @param {String} value - time value to check
- * @return {String} checked value or `false`
- */
-function checkTimeValue( value ) {
-	if ( value !== '0' && value !== '00' && ( value[ 0 ] === '0' || Number( value ) > 99 ) ) {
-		value = value.substr( 1 );
-	}
-
-	if ( ! ( isNaN( Number( value ) ) || Number( value ) < 0 || value.length > 2 ) ) {
-		return value;
-	}
-
-	return false;
-}
 
 class PostScheduleClock extends Component {
 	constructor() {
@@ -75,8 +61,8 @@ class PostScheduleClock extends Component {
 			minuteRef
 		} = this.refs;
 
-		const hour = checkTimeValue( hourReference.value );
-		const minute = checkTimeValue( minuteRef.value );
+		const hour = parseAndValidateNumber( hourReference.value );
+		const minute = parseAndValidateNumber( minuteRef.value );
 		const modifiers = {};
 
 		if ( false !== hour && hour < 24 ) {
@@ -103,7 +89,7 @@ class PostScheduleClock extends Component {
 			translate
 		} = this.props;
 
-		if ( ! ( timezone || utils.isValidGMTOffset( gmtOffset ) ) ) {
+		if ( ! ( timezone || isValidGMTOffset( gmtOffset ) ) ) {
 			return;
 		}
 
@@ -113,7 +99,7 @@ class PostScheduleClock extends Component {
 			const tzDate = date.clone().tz( timezone );
 			diffInHours = tzDate.utcOffset() - moment().utcOffset();
 			formatZ = tzDate.format( ' Z ' );
-		} else if ( utils.isValidGMTOffset( gmtOffset ) ) {
+		} else if ( isValidGMTOffset( gmtOffset ) ) {
 			const utcDate = date.clone().utcOffset( gmtOffset );
 			diffInHours = utcDate.utcOffset() - moment().utcOffset();
 			formatZ = utcDate.format( ' Z ' );

--- a/client/components/post-schedule/style.scss
+++ b/client/components/post-schedule/style.scss
@@ -88,7 +88,7 @@ hr.post-schedule__hr {
 	margin: 0 -16px;
 }
 
-input.post-schedule__clock_time {
+input.post-schedule__clock-time {
 	height: 26px;
 	line-height: 26px;
 	display: inline-block;

--- a/client/components/post-schedule/test/index.js
+++ b/client/components/post-schedule/test/index.js
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	isValidGMTOffset,
+	getLocalizedDate,
+	convertHoursToHHMM,
+	convertMinutesToHHMM,
+	parseAndValidateNumber,
+} from '../utils';
+
+describe( 'gmtOffset', () => {
+	it( 'Should return true for a valid gtm offset', () => {
+		expect( isValidGMTOffset( 2 ) ).to.be.true;
+	} );
+
+	it( 'Should return true for a valid gtm offset', () => {
+		expect( isValidGMTOffset( '2' ) ).to.be.false;
+	} );
+} );
+
+describe( 'getLocalizedDate', () => {
+	it( 'Should return a date localized at Amsterdam (utc: 60 minutes)', () => {
+		const nowInAmsterdam = getLocalizedDate( new Date(), 'Europe/Amsterdam' );
+		expect( nowInAmsterdam.utcOffset() ).to.equal( 60 );
+	} );
+
+	it( 'Should return a date localized at New York (utc: -300 minutes)', () => {
+		const nowInNewYork = getLocalizedDate( new Date(), 'America/New_York' );
+		expect( nowInNewYork.utcOffset() ).to.equal( -300 );
+	} );
+
+	it( 'Should return a date localized at UTC+3:30 (utc: 210 minutes)', () => {
+		const NowAtUTC3_30 = getLocalizedDate( new Date(), false, 210 );
+		expect( NowAtUTC3_30.utcOffset() ).to.equal( 210 );
+	} );
+} );
+
+describe( 'convertHoursToHHMM', () => {
+	it( 'Should convert 3.1 hours to `3:06`', () => {
+		expect( convertHoursToHHMM( 3.1 ) ).to.equal( '3:06' );
+	} );
+
+	it( 'Should convert 3 hours to `3`', () => {
+		expect( convertHoursToHHMM( 3 ) ).to.equal( '3' );
+	} );
+
+	it( 'Should convert -3.1 hours to `-3:06`', () => {
+		expect( convertHoursToHHMM( -3.1 ) ).to.equal( '-3:06' );
+	} );
+
+	it( 'Should convert -3 hours to `3`', () => {
+		expect( convertHoursToHHMM( -3 ) ).to.equal( '-3' );
+	} );
+} );
+
+describe( 'convertMinutesToHHMM', () => {
+	it( 'Should convert 186 minutes to `3:06`', () => {
+		expect( convertMinutesToHHMM( 186 ) ).to.equal( '3:06' );
+	} );
+
+	it( 'Should convert 180 minutes to `3`', () => {
+		expect( convertMinutesToHHMM( 180 ) ).to.equal( '3' );
+	} );
+
+	it( 'Should convert -186 minutes to `-3:06`', () => {
+		expect( convertMinutesToHHMM( -186 ) ).to.equal( '-3:06' );
+	} );
+
+	it( 'Should convert -180 minutes to `-3`', () => {
+		expect( convertMinutesToHHMM( -180 ) ).to.equal( '-3' );
+	} );
+
+	it( 'Should convert 0 minutes to `0`', () => {
+		expect( convertMinutesToHHMM( 0 ) ).to.equal( '0' );
+	} );
+
+	it( 'Should convert -0 minutes to `0`', () => {
+		expect( convertMinutesToHHMM( -0 ) ).to.equal( '0' );
+	} );
+} );
+
+describe( 'parseAndValidateNumber', () => {
+	it( 'Should return `false` when the value is a string', () => {
+		expect( parseAndValidateNumber( 'ab' ) ).to.be.false;
+	} );
+
+	it( 'Should return `false` when the value is a negative number', () => {
+		expect( parseAndValidateNumber( -10 ) ).to.be.false;
+	} );
+
+	it( 'Should return a 4 when the value is `04`', () => {
+		expect( parseAndValidateNumber( '04' ) ).to.equal( 4 );
+	} );
+
+	it( 'Should return a 99 when the value is `99`', () => {
+		expect( parseAndValidateNumber( '99' ) ).to.equal( 99 );
+	} );
+} );
+


### PR DESCRIPTION
* It just fix some `eslint` warnings using `const` and/or `let` instead of `var`, do not bind function into the properties, do not use arrow functions either, etc.
* use `localize` helper
* destruct this.props object

### Testing

1 - Go to devdocs page of PostSchedule: http://calypso.localhost:3000/devdocs/blocks/post-schedule

2 - Play into the clock changing hours and minutes of the time. 

Everything should be ok.

![post-schedule-clock](https://cloud.githubusercontent.com/assets/77539/21826015/b04f7a20-d764-11e6-8d2b-e16af2da168e.gif)

Also, I've added unit tests. To run them:

```cli
> npm run test-client client/components/post-schedule/test/index.js 
```

### Live testing branch

https://calypso.live/devdocs/blocks/post-schedule?branch=improve/post-schedule-clock