### PR TITLE
Reader: remove tiled gallery captions from excerpts

### DIFF
--- a/client/lib/post-normalizer/rule-create-better-excerpt.js
+++ b/client/lib/post-normalizer/rule-create-better-excerpt.js
@@ -54,8 +54,9 @@ export function formatExcerpt( content ) {
 	dom.id = '__better_excerpt__';
 	dom.innerHTML = content;
 
-	// Ditch any photo captions with the wp-caption-text class, styles, scripts
-	forEach( dom.querySelectorAll( '.wp-caption-text, style, script, blockquote[class^="instagram-"], figure' ), removeElement );
+	// Ditch any photo captions, styles, scripts
+	const stripSelectors = '.wp-caption-text, style, script, blockquote[class^="instagram-"], figure, .tiled-gallery';
+	forEach( dom.querySelectorAll( stripSelectors ), removeElement );
 
 	// limit to paras and brs
 	dom.innerHTML = striptags( dom.innerHTML, [ 'p', 'br', 'sup', 'sub' ] );


### PR DESCRIPTION
As reported in https://github.com/Automattic/wp-calypso/issues/10241, posts with tiled galleries can have the caption text included in the post excerpt:

<img width="847" alt="screen shot 2017-01-11 at 16 21 44" src="https://cloud.githubusercontent.com/assets/17325/21840779/4829aa40-d81a-11e6-9c83-b170bd3a595b.png">

This PR removes tiled gallery content from the post excerpt. Fixes #10241.

After:

<img width="843" alt="screen shot 2017-01-11 at 16 21 31" src="https://cloud.githubusercontent.com/assets/17325/21840793/571a539c-d81a-11e6-8a47-0ba12977bf4b.png">

### To test

Compare before: https://wpcalypso.wordpress.com/read/feeds/23059853

...and after: http://calypso.localhost:3000/read/feeds/23059853

cc @thepelkus-too