### PR TITLE
Reader: make full post site name consistent with post cards

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -308,7 +308,7 @@ export class FullPostView extends React.Component {
 								author={ post.author }
 								siteIcon={ get( site, 'icon.img' ) }
 								feedIcon={ get( feed, 'image' ) }
-								siteName={ post.site_name }
+								siteName={ siteName }
 								siteUrl={ post.site_URL }
 								feedUrl= { get( feed, 'feed_URL' ) }
 								followCount={ site && site.subscribers_count }


### PR DESCRIPTION
In full post, we were always pulling `post.site_name` for the site name shown in the sidebar.

Meanwhile, in the post card, we were also taking the `site` object into account.

This meant that sometimes we showed a site name in the post card, but not in full post view - see #8502.

### To test

Visit http://calypso.localhost:3000/read/feeds/39292676/posts/1177815786 and ensure that the site name 'Global News' is shown in the author profile.

<img width="196" alt="screen shot 2017-01-11 at 16 50 06" src="https://cloud.githubusercontent.com/assets/17325/21841636/0a0de362-d81e-11e6-9438-c21659725c37.png">

Fixes #8502.