### PR TITLE
Billing: ES6ify and modernize BillingHistory and BillingReceipt

### DIFF
--- a/client/me/billing-history/main.jsx
+++ b/client/me/billing-history/main.jsx
@@ -1,33 +1,32 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	isEmpty = require( 'lodash/isEmpty' );
+import React from 'react';
+import { isEmpty } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var observe = require( 'lib/mixins/data-observe' ),
-	Card = require( 'components/card' ),
-	MeSidebarNavigation = require( 'me/sidebar-navigation' ),
-	config = require( 'config' ),
-	CreditCards = require( 'me/purchases/credit-cards' ),
-	eventRecorder = require( 'me/event-recorder' ),
-	PurchasesHeader = require( '../purchases/list/header' ),
-	BillingHistoryTable = require( './billing-history-table' ),
-	UpcomingChargesTable = require( './upcoming-charges-table' ),
-	SectionHeader = require( 'components/section-header' );
-
+import observe from 'lib/mixins/data-observe';
+import Card from 'components/card';
+import MeSidebarNavigation from 'me/sidebar-navigation';
+import config from 'config';
+import CreditCards from 'me/purchases/credit-cards';
+import eventRecorder from 'me/event-recorder';
+import PurchasesHeader from '../purchases/list/header';
+import BillingHistoryTable from './billing-history-table';
+import UpcomingChargesTable from './upcoming-charges-table';
+import SectionHeader from 'components/section-header';
 import Main from 'components/main';
 import purchasesPaths from 'me/purchases/paths';
 
-module.exports = React.createClass( {
-	displayName: 'BillingHistory',
-
+const BillingHistory = React.createClass( {
 	mixins: [ observe( 'billingData', 'sites' ), eventRecorder ],
 
-	render: function() {
-		var data = this.props.billingData.get();
+	render() {
+		const { billingData, sites, translate } = this.props;
+		const data = billingData.get();
 		const hasBillingHistory = ! isEmpty( data.billingHistory );
 
 		return (
@@ -38,18 +37,22 @@ module.exports = React.createClass( {
 					<BillingHistoryTable transactions={ data.billingHistory } />
 				</Card>
 				<Card href={ purchasesPaths.purchasesRoot() }>
-					{ this.translate( 'Go to "Purchases" to add or cancel a plan.' ) }
+					{ translate( 'Go to "Purchases" to add or cancel a plan.' ) }
 				</Card>
 				{ hasBillingHistory &&
 					<div>
-						<SectionHeader label={ this.translate( 'Upcoming Charges' ) } />
+						<SectionHeader label={ translate( 'Upcoming Charges' ) } />
 						<Card className="billing-history__upcoming-charges">
-							<UpcomingChargesTable sites={ this.props.sites } transactions={ data.upcomingCharges } />
+							<UpcomingChargesTable sites={ sites } transactions={ data.upcomingCharges } />
 						</Card>
-					</div> }
+					</div>
+				}
 				{ config.isEnabled( 'upgrades/credit-cards' ) &&
-					<CreditCards /> }
+					<CreditCards />
+				}
 			</Main>
 		);
 	}
 } );
+
+export default localize( BillingHistory );

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -1,50 +1,50 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var tableRows = require( './table-rows' ),
-	observe = require( 'lib/mixins/data-observe' ),
-	eventRecorder = require( 'me/event-recorder' );
-
+import tableRows from './table-rows';
+import observe from 'lib/mixins/data-observe';
+import eventRecorder from 'me/event-recorder';
 import Card from 'components/card';
 import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
 import purchasesPaths from 'me/purchases/paths';
 
-module.exports = React.createClass( {
-	displayName: 'BillingReceipt',
-
+const BillingReceipt = React.createClass( {
 	mixins: [ observe( 'billingData' ), eventRecorder ],
 
-	render: function() {
-		const transaction = this.props.transaction;
-		const title = this.translate( 'Visit %(url)s', { args: { url: transaction.url } } );
-		const serviceLink = <a href={ transaction.url } title={ title }/>;
+	render() {
+		const { transaction, translate } = this.props;
+		const title = translate( 'Visit %(url)s', { args: { url: transaction.url } } );
+		const serviceLink = <a href={ transaction.url } title={ title } />;
 
 		return (
 			<Main>
 				<HeaderCake backHref={ purchasesPaths.billingHistory() }>
-					{ this.translate( 'Billing History' ) }
+					{ translate( 'Billing History' ) }
 				</HeaderCake>
 				<Card compact className="billing-history__receipt-card">
 					<div className="billing-history__app-overview">
 						<img src={ transaction.icon } title={ transaction.service } />
 						<h2> {
-							this.translate( '{{link}}%(service)s{{/link}} {{small}}by %(organization)s{{/small}}',
+							translate( '{{link}}%(service)s{{/link}} {{small}}by %(organization)s{{/small}}',
 								{
 									components: {
 										link: serviceLink,
-										small: <small/>
+										small: <small />
 									},
 									args: {
 										service: transaction.service,
 										organization: transaction.org,
 									},
-									comment: 'This string is "Service by Organization". The {{link}} and {{small}} add html styling and attributes. Screenshot: https://cloudup.com/isX-WEFYlOs'
+									comment: 'This string is "Service by Organization". ' +
+										'The {{link}} and {{small}} add html styling and attributes. ' +
+										'Screenshot: https://cloudup.com/isX-WEFYlOs'
 								} )
 							}
 							<div className="billing-history__transaction-date">{ tableRows.formatDate( transaction.date ) }</div>
@@ -52,18 +52,22 @@ module.exports = React.createClass( {
 					</div>
 					<ul className="billing-history__receipt-details group">
 						<li>
-							<strong>{ this.translate( 'Receipt ID' ) }</strong>
+							<strong>{ translate( 'Receipt ID' ) }</strong>
 							<span>{ transaction.id }</span>
 						</li>
 						{ this.ref() }
 						{ this.paymentMethod() }
-						{ transaction.cc_num !== 'XXXX' ? this.renderBillingDetails( transaction ) : null }
+						{ transaction.cc_num !== 'XXXX' ? this.renderBillingDetails() : null }
 					</ul>
-					{ this.renderLineItems( transaction ) }
+					{ this.renderLineItems() }
 				</Card>
 				<Card compact className="billing-history__receipt-links">
-					<a href={ transaction.support } className="button is-primary" onClick={ this.recordClickEvent( 'Contact {appName} Support in Billing History Receipt' ) }>
-						{ this.translate( 'Contact %(transactionService)s Support', {
+					<a
+						href={ transaction.support }
+						className="button is-primary"
+						onClick={ this.recordClickEvent( 'Contact {appName} Support in Billing History Receipt' ) }
+					>
+						{ translate( 'Contact %(transactionService)s Support', {
 							args: {
 								transactionService: transaction.service
 							},
@@ -75,69 +79,71 @@ module.exports = React.createClass( {
 						onClick={ this.recordClickEvent( 'Print Receipt Button in Billing History Receipt', this.printReceipt ) }
 						className="button is-secondary"
 					>
-						{ this.translate( 'Print Receipt' ) }
+						{ translate( 'Print Receipt' ) }
 					</a>
 				</Card>
 			</Main>
 		);
 	},
 
-	printReceipt: function( event ) {
+	printReceipt( event ) {
 		event.preventDefault();
 		window.print();
 	},
 
-	ref: function() {
-		if ( ! this.props.transaction.pay_ref ) {
+	ref() {
+		const { transaction, translate } = this.props;
+
+		if ( ! transaction.pay_ref ) {
 			return null;
 		}
 
 		return (
 			<li>
-				<strong>{ this.translate( 'Transaction ID' ) }</strong>
-				<span>{ this.props.transaction.pay_ref }</span>
+				<strong>{ translate( 'Transaction ID' ) }</strong>
+				<span>{ transaction.pay_ref }</span>
 			</li>
 		);
 	},
 
-	paymentMethod: function() {
-		var transaction = this.props.transaction,
-			text;
+	paymentMethod() {
+		const { transaction, translate } = this.props;
+		let text;
 
 		if ( transaction.pay_part === 'paypal_express' ) {
-			text = this.translate( 'PayPal' );
+			text = translate( 'PayPal' );
 		} else if ( 'NOT STORED' === transaction.cc_type.toUpperCase() ) {
-			text = this.translate( 'Credit Card' );
+			text = translate( 'Credit Card' );
 		} else {
-			text = transaction.cc_type.toUpperCase() + this.translate( ' ending in ' ) + transaction.cc_num;
+			text = transaction.cc_type.toUpperCase() + translate( ' ending in ' ) + transaction.cc_num;
 		}
 
 		return (
 			<li>
-				<strong>{ this.translate( 'Payment Method' ) }</strong>
+				<strong>{ translate( 'Payment Method' ) }</strong>
 				<span>{ text }</span>
 			</li>
 		);
 	},
 
-	renderBillingDetails: function( transaction ) {
-		if ( ! this.props.transaction.cc_name && ! this.props.transaction.cc_email ) {
+	renderBillingDetails() {
+		const { transaction, translate } = this.props;
+		if ( ! transaction.cc_name && ! transaction.cc_email ) {
 			return null;
 		}
 
 		return (
 			<li className="billing-history__billing-details">
-				<strong>{ this.translate( 'Billing Details' ) }</strong>
+				<strong>{ translate( 'Billing Details' ) }</strong>
 				<div contentEditable="true">{ transaction.cc_name }</div>
 				<div contentEditable="true">{ transaction.cc_email }</div>
 			</li>
 		);
 	},
 
-	renderLineItems: function( transaction ) {
-		var items, creditBadge;
-
-		items = transaction.items.map( function( item ) {
+	renderLineItems() {
+		const { transaction, translate } = this.props;
+		const items = transaction.items.map( ( item ) => {
 			return (
 				<tr key={ item.id }>
 					<td className="billing-history__receipt-item-name">
@@ -147,28 +153,26 @@ module.exports = React.createClass( {
 					</td>
 					<td className={ 'billing-history__receipt-amount ' + transaction.credit }>
 						{ item.amount }
-						{ transaction.credit ? creditBadge : '' }
+						{ transaction.credit && <span className="billing-history__credit-badge">{ translate( 'Refund' ) }</span> }
 					</td>
 				</tr>
 			);
 		} );
 
-		creditBadge = <span className="billing-history__credit-badge">{ this.translate( 'Refund' ) }</span>;
-
 		return (
 			<div className="billing-history__receipt">
-				<h4>{ this.translate( 'Order Summary' ) }</h4>
+				<h4>{ translate( 'Order Summary' ) }</h4>
 				<table className="billing-history__receipt-line-items">
 					<thead>
 						<tr>
-							<th className="billing-history__receipt-desc">{ this.translate( 'Description' ) }</th>
-							<th className="billing-history__receipt-amount">{ this.translate( 'Amount' ) }</th>
+							<th className="billing-history__receipt-desc">{ translate( 'Description' ) }</th>
+							<th className="billing-history__receipt-amount">{ translate( 'Amount' ) }</th>
 						</tr>
 					</thead>
 					<tfoot>
 						<tr>
 							<td className="billing-history__receipt-desc">
-								<strong>{ this.translate( 'Total' ) }:</strong>
+								<strong>{ translate( 'Total' ) }:</strong>
 							</td>
 							<td className={ 'billing-history__receipt-amount billing-history__total-amount ' + transaction.credit }>
 								{ transaction.amount }
@@ -183,3 +187,5 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+export default localize( BillingReceipt );


### PR DESCRIPTION
This PR ES6ifies and modernizes the `BillingHistory` and `BillingReceipt` components and removes most of the ESLint warnings. There are no functional changes, only syntactic sugar and improvements.

This PR is part of the billing history reduxification effort (#10554).

To test:

* Checkout this branch
* Verify there are no changes or regressions in the Billing History page - `/me/purchases/billing`
* Verify there are no changes or regressions in the Billing Receipt page - `/me/purchases/billing/$transactionId`