### PR TITLE
PostSchedule: improve Timezone settings

### DIFF
--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -115,7 +115,7 @@ class PostScheduleClock extends Component {
 		const popoverPosition = viewport.isMobile() ? 'top' : 'right';
 		const timezoneText = timezone
 			? `${ timezone.replace( /\_/ig, ' ' ) } ${ tzDateOffset }`
-			: 'UTC' + ( gmtOffset >= 0 ? '+' : '' ) + convertHoursToHHMM( gmtOffset );
+			: `UTC${ convertHoursToHHMM( gmtOffset ) }`;
 
 		const timezoneInfo = translate(
 			'This site timezone (%(timezoneText)s) will be used for publishing. ' +
@@ -178,9 +178,6 @@ class PostScheduleClock extends Component {
 	}
 }
 
-/**
- * Statics
- */
 PostScheduleClock.propTypes = {
 	date: PropTypes.object.isRequired,
 	timezone: PropTypes.string,

--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -15,7 +15,9 @@ import viewport from 'lib/viewport';
  */
 import {
 	isValidGMTOffset,
-	parseAndValidateNumber
+	parseAndValidateNumber,
+	convertHoursToHHMM,
+	convertMinutesToHHMM,
 } from './utils';
 
 /**
@@ -81,10 +83,11 @@ class PostScheduleClock extends Component {
 		this.props.onChange( date, modifiers );
 	}
 
-	renderTimezoneBox() {
+	renderTimezoneSection() {
 		const {
 			date,
 			gmtOffset,
+			siteId,
 			timezone,
 			translate
 		} = this.props;
@@ -93,34 +96,42 @@ class PostScheduleClock extends Component {
 			return;
 		}
 
-		let diffInHours, formatZ;
+		let diffInMinutes, tzDateOffset;
 
 		if ( timezone ) {
 			const tzDate = date.clone().tz( timezone );
-			diffInHours = tzDate.utcOffset() - moment().utcOffset();
-			formatZ = tzDate.format( ' Z ' );
+			tzDateOffset = tzDate.format( 'Z' );
+			diffInMinutes = tzDate.utcOffset() - moment().utcOffset();
 		} else if ( isValidGMTOffset( gmtOffset ) ) {
 			const utcDate = date.clone().utcOffset( gmtOffset );
-			diffInHours = utcDate.utcOffset() - moment().utcOffset();
-			formatZ = utcDate.format( ' Z ' );
+			diffInMinutes = utcDate.utcOffset() - moment().utcOffset();
 		}
 
-		if ( ! diffInHours ) {
+		if ( ! diffInMinutes ) {
 			return;
 		}
 
-		diffInHours = diffInHours / 60;
-		diffInHours = Math.round( diffInHours * 100 ) / 100;
-		diffInHours = ( diffInHours > 0 ? '+' : '' ) + diffInHours + 'h';
-
 		const popoverPosition = viewport.isMobile() ? 'top' : 'right';
+		const timezoneText = timezone
+			? `${ timezone.replace( /\_/ig, ' ' ) } ${ tzDateOffset }`
+			: 'UTC' + ( gmtOffset >= 0 ? '+' : '' ) + convertHoursToHHMM( gmtOffset );
+
+		const timezoneInfo = translate(
+			'This site timezone (%(timezoneText)s) will be used for publishing. ' +
+			'You can change it in {{a}}General Settings{{/a}}.', {
+				args: { timezoneText },
+				components: {
+					a: <a href={ `/settings/general/${ siteId }` } />
+				}
+			}
+		);
 
 		return (
 			<span>
 				<div className="post-schedule__clock-timezone">
 					{
-						translate( 'Site %(diff)s from you', {
-							args: { diff: diffInHours }
+						translate( 'This site timezone is %(diff)sh from your local timezone.', {
+							args: { diff: convertMinutesToHHMM( diffInMinutes ) }
 						} )
 					}
 
@@ -128,11 +139,7 @@ class PostScheduleClock extends Component {
 						className="post-schedule__timezone-info"
 						position={ popoverPosition }
 					>
-						{ timezone
-							? timezone.replace( /(\/)/ig, ' $1 ' )
-							: 'UTC'
-						}
-						{ formatZ }
+						{ timezoneInfo }
 					</InfoPopover>
 				</div>
 			</span>
@@ -164,7 +171,7 @@ class PostScheduleClock extends Component {
 					onKeyDown={ this.adjustMinute }
 					type="text" />
 
-				{ this.renderTimezoneBox() }
+				{ this.renderTimezoneSection() }
 			</div>
 		);
 	}
@@ -177,6 +184,7 @@ PostScheduleClock.propTypes = {
 	date: PropTypes.object.isRequired,
 	timezone: PropTypes.string,
 	gmtOffset: PropTypes.number,
+	siteId: PropTypes.number,
 	onChange: PropTypes.func
 };
 

--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -88,6 +88,7 @@ class PostScheduleClock extends Component {
 			date,
 			gmtOffset,
 			siteId,
+			siteSlug,
 			timezone,
 			translate
 		} = this.props;
@@ -121,7 +122,7 @@ class PostScheduleClock extends Component {
 			'You can change it in {{a}}General Settings{{/a}}.', {
 				args: { timezoneText },
 				components: {
-					a: <a href={ `/settings/general/${ siteId }` } />
+					a: <a href={ `/settings/general/${ siteSlug || siteId }` } />
 				}
 			}
 		);
@@ -185,6 +186,7 @@ PostScheduleClock.propTypes = {
 	timezone: PropTypes.string,
 	gmtOffset: PropTypes.number,
 	siteId: PropTypes.number,
+	siteSlug: PropTypes.string,
 	onChange: PropTypes.func
 };
 

--- a/client/components/post-schedule/index.jsx
+++ b/client/components/post-schedule/index.jsx
@@ -160,6 +160,7 @@ class PostSchedule extends Component {
 				timezone={ this.props.timezone }
 				gmtOffset={ this.props.gmtOffset }
 				siteId={ this.props.site ? this.props.site.ID : null }
+				siteSlug={ this.props.site ? this.props.site.slug : null }
 				onChange={ this.updateDate }
 			/>
 		);

--- a/client/components/post-schedule/index.jsx
+++ b/client/components/post-schedule/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes, Component } from 'react';
-import i18n from 'i18n-calypso';
+import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -18,20 +18,15 @@ import Clock from './clock';
 import Header from './header';
 import utils from './utils';
 
-var user = new User(),
-	noop = () => {};
+const user = new User();
+const noop = () => {};
 
 class PostSchedule extends Component {
-	constructor( props ) {
-		super( props );
-
-		// bounds
-		this.updateDate = this.updateDate.bind( this );
-		this.setViewDate = this.setViewDate.bind( this );
-		this.setCurrentMonth = this.setCurrentMonth.bind( this );
+	constructor() {
+		super( ...arguments );
 
 		this.state = {
-			calendarViewDate: i18n.moment(
+			calendarViewDate: moment(
 				this.props.selectedDay
 					? this.props.selectedDay
 					: new Date()
@@ -79,7 +74,7 @@ class PostSchedule extends Component {
 
 	getEventsFromPosts( postsList = [] ) {
 		return postsList.map( post => {
-			let localDate = this.getDateToUserLocation( post.date );
+			const localDate = this.getDateToUserLocation( post.date );
 
 			return {
 				id: post.ID,
@@ -97,21 +92,21 @@ class PostSchedule extends Component {
 		);
 	}
 
-	setCurrentMonth( date ) {
-		date = i18n.moment( date );
+	setCurrentMonth = ( date ) => {
+		date = moment( date );
 		this.props.onMonthChange( date );
 		this.setState( { calendarViewDate: date } );
 	}
 
-	setViewDate( date ) {
-		this.setState( { calendarViewDate: i18n.moment( date ) } );
+	setViewDate = ( date ) => {
+		this.setState( { calendarViewDate: moment( date ) } );
 	}
 
 	getCurrentDate() {
-		return i18n.moment( this.state.localizedDate || this.getDateToUserLocation() );
+		return moment( this.state.localizedDate || this.getDateToUserLocation() );
 	}
 
-	updateDate( date ) {
+	updateDate = ( date ) => {
 		this.setState( { calendarViewDate: date } );
 
 		this.props.onDateChange( utils.convertDateToGivenOffset(
@@ -121,17 +116,15 @@ class PostSchedule extends Component {
 		) );
 	}
 
-	/** Renders **/
-
 	renderInputChrono() {
-		var lang = user.getLanguage(),
-			date = this.getCurrentDate(),
-			chronoText;
+		const lang = user.getLanguage();
+		const date = this.getCurrentDate();
+		let chronoText;
 
 		if ( this.state.localizedDate ) {
-			let today = i18n.moment().startOf( 'day' ),
-				selected = i18n.moment( date ).startOf( 'day' ),
-				diffInMinutes = selected.diff( today, 'days' );
+			const today = moment().startOf( 'day' );
+			const selected = moment( date ).startOf( 'day' );
+			const diffInMinutes = selected.diff( today, 'days' );
 
 			if ( -7 <= diffInMinutes && diffInMinutes <= 6 ) {
 				chronoText = date.calendar();
@@ -141,7 +134,7 @@ class PostSchedule extends Component {
 		}
 
 		return (
-			<div className="chrono__container">
+			<div className="post-schedule__input-chrono">
 				<InputChrono
 					value={ chronoText }
 					placeholder={ date.calendar() }

--- a/client/components/post-schedule/index.jsx
+++ b/client/components/post-schedule/index.jsx
@@ -159,6 +159,7 @@ class PostSchedule extends Component {
 				date={ date }
 				timezone={ this.props.timezone }
 				gmtOffset={ this.props.gmtOffset }
+				siteId={ this.props.site ? this.props.site.ID : null }
 				onChange={ this.updateDate }
 			/>
 		);
@@ -205,6 +206,7 @@ PostSchedule.propTypes = {
 	posts: PropTypes.array,
 	timezone: PropTypes.string,
 	gmtOffset: PropTypes.number,
+	site: PropTypes.object,
 
 	onDateChange: PropTypes.func,
 	onMonthChange: PropTypes.func

--- a/client/components/post-schedule/style.scss
+++ b/client/components/post-schedule/style.scss
@@ -109,6 +109,7 @@ input.post-schedule__clock-time {
 }
 
 .post-schedule__clock-timezone {
+	text-align: left;
 	margin-top: 10px;
 	padding: 10px 0 0;
 	border-top: 1px solid lighten( $gray, 25% );
@@ -126,5 +127,6 @@ input.post-schedule__clock-time {
 
 	.popover__inner {
 		font-size: 12px;
+		max-width: 250px;
 	}
 }

--- a/client/components/post-schedule/test/index.js
+++ b/client/components/post-schedule/test/index.js
@@ -43,11 +43,11 @@ describe( 'getLocalizedDate', () => {
 
 describe( 'convertHoursToHHMM', () => {
 	it( 'Should convert 3.1 hours to `3:06`', () => {
-		expect( convertHoursToHHMM( 3.1 ) ).to.equal( '3:06' );
+		expect( convertHoursToHHMM( 3.1 ) ).to.equal( '+3:06' );
 	} );
 
 	it( 'Should convert 3 hours to `3`', () => {
-		expect( convertHoursToHHMM( 3 ) ).to.equal( '3' );
+		expect( convertHoursToHHMM( 3 ) ).to.equal( '+3' );
 	} );
 
 	it( 'Should convert -3.1 hours to `-3:06`', () => {
@@ -61,11 +61,11 @@ describe( 'convertHoursToHHMM', () => {
 
 describe( 'convertMinutesToHHMM', () => {
 	it( 'Should convert 186 minutes to `3:06`', () => {
-		expect( convertMinutesToHHMM( 186 ) ).to.equal( '3:06' );
+		expect( convertMinutesToHHMM( 186 ) ).to.equal( '+3:06' );
 	} );
 
 	it( 'Should convert 180 minutes to `3`', () => {
-		expect( convertMinutesToHHMM( 180 ) ).to.equal( '3' );
+		expect( convertMinutesToHHMM( 180 ) ).to.equal( '+3' );
 	} );
 
 	it( 'Should convert -186 minutes to `-3:06`', () => {

--- a/client/components/post-schedule/utils.js
+++ b/client/components/post-schedule/utils.js
@@ -104,5 +104,5 @@ export default {
 	getLocalizedDate,
 	getTimeOffset,
 	isValidGMTOffset,
-	parseAndValidateNumber
+	parseAndValidateNumber,
 };

--- a/client/components/post-schedule/utils.js
+++ b/client/components/post-schedule/utils.js
@@ -62,14 +62,26 @@ const convertDateToGivenOffset = ( date, tz, gmt ) => {
 	return date;
 };
 
+/**
+ * Convert a number of minutes to the hh:mm format,
+ * adding a `+` when the number is greater than zero,
+ * not adding `:00` case (zero minutes).
+ *
+ * @param  {Number} minutes - a number of minutes
+ * @return {String} `hh:mm` format
+ */
 const convertMinutesToHHMM = minutes => {
 	const hours = Math.trunc( minutes / 60 );
+	const sign = minutes > 0 ? '+' : '';
+
 	if ( ! ( minutes / 60 % 1 ) ) {
-		return String( hours );
+		return sign + String( hours );
 	}
 
 	minutes = Math.abs( minutes % 60 );
-	return hours + ':' + ( minutes < 10 ? ( '0' + minutes ) : minutes );
+	const mm = ( minutes < 10 ? ( '0' + minutes ) : minutes );
+
+	return `${ sign }${ hours }:${ mm }`;
 };
 
 const convertHoursToHHMM = hours => convertMinutesToHHMM( hours * 60 );

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -196,6 +196,7 @@ export default React.createClass( {
 				gmtOffset={ gmtOffset }
 				onDateChange={ this.setPostDate }
 				onMonthChange={ this.setCurrentMonth }
+				site={ this.props.site }
 			/>
 		);
 	},


### PR DESCRIPTION
The main purpose of this patch is fix #10522, which improve the timezone piece of the PostSchedule component. Also, this fixes some ESlint warning and tidies the code in general.

### Testing

1) Be sure the site has a different timezone that your computer. The timezone can be edited from General Settings: http://calypso.localhost:3000/settings/general/<site-id>

2) Start to create/edit a post: http://calypso.localhost:3000/post/<site-id>
3) Play changing the post date through of the PostSchedule component.

<img src="https://cloud.githubusercontent.com/assets/77539/21996894/21e726d8-dc0b-11e6-9da9-c1badbdeb60f.png" width="300px" />

4) Take a look to the timezone area opening the (i) popover as well.

<img src="https://cloud.githubusercontent.com/assets/77539/21996914/3c07c0e0-dc0b-11e6-92a0-61a0281f02ad.png" width="500px" />

5) You could go straight to the General Settings page from there.

Depending on the timezone the information there will change. For instance, if you set a UTC zone, you should see something like the following:

<img src="https://cloud.githubusercontent.com/assets/77539/21996631/fa0609c8-dc09-11e6-8c0b-7c4881dcf753.png" width="500px" />


