### PR TITLE
Stats: Reduxify StatsVideoSummary and use QuerySiteStats to query video stats

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -477,7 +477,7 @@ module.exports = {
 
 			const siteDomain = ( site && ( typeof site.slug !== 'undefined' ) )
 				? site.slug : siteFragment;
-
+			let extraProps = {};
 			switch ( context.params.module ) {
 
 				case 'posts':
@@ -520,6 +520,7 @@ module.exports = {
 				case 'videodetails':
 					summaryList = new StatsList( { statType: 'statsVideo', post: queryOptions.post,
 						siteID: siteId, period: activeFilter.period, date: endDate, max: 0, domain: siteDomain } );
+					extraProps = { postId: queryOptions.post };
 					break;
 
 				case 'searchterms':
@@ -549,7 +550,8 @@ module.exports = {
 					visitsList: visitsList,
 					followList: followList,
 					siteId: siteId,
-					period: period
+					period: period,
+					...extraProps
 				} ),
 				document.getElementById( 'primary' ),
 				context.store

--- a/client/my-sites/stats/stats-video-summary/index.jsx
+++ b/client/my-sites/stats/stats-video-summary/index.jsx
@@ -1,64 +1,95 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { flowRight } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import observe from 'lib/mixins/data-observe';
 import SummaryChart from '../stats-summary';
+import QuerySiteStats from 'components/data/query-site-stats';
+import { getSiteStatsNormalizedData, isRequestingSiteStatsForQuery } from 'state/stats/lists/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
-const StatsVideoSummary = React.createClass( {
-	propTypes: {
-		dataList: PropTypes.object.isRequired,
-	},
+class StatsVideoSummary extends Component {
+	static propTypes = {
+		query: PropTypes.object,
+		isRequesting: PropTypes.bool,
+		siteId: PropTypes.number,
+		summaryData: PropTypes.array,
+	}
 
-	mixins: [ observe( 'dataList' ) ],
+	state = {
+		selectedBar: null
+	};
 
-	getInitialState: function() {
-		const chartDataLength = this.props.dataList.response.data ? this.props.dataList.response.data.length : null;
-
-		return {
-			selectedBar: chartDataLength ? this.props.dataList.response.data[ chartDataLength - 1 ] : null
-		};
-	},
-
-	componentWillReceiveProps: function( nextProps ) {
-		const chartDataLength = nextProps.dataList.response.data ? nextProps.dataList.response.data.length : null;
+	componentWillReceiveProps( nextProps ) {
+		const chartDataLength = nextProps.summaryData ? nextProps.summaryData.length : null;
 		// Always default to the last bar being selected
 		if ( ! this.state.selectedBar && chartDataLength ) {
 			this.setState( {
-				selectedBar: nextProps.dataList.response.data[ chartDataLength - 1 ]
+				selectedBar: nextProps.summaryData[ chartDataLength - 1 ]
 			} );
 		}
-	},
+	}
 
-	selectBar: function( bar ) {
+	selectBar = bar => {
 		this.setState( {
 			selectedBar: bar
 		} );
-	},
+	};
 
-	render: function() {
-		const { translate } = this.props;
+	render() {
+		const { query, isRequesting, moment, siteId, summaryData, translate } = this.props;
+		const data = summaryData.map( item => {
+			return {
+				...item,
+				period: moment( item.period ).format( 'MMM D' ),
+			};
+		} );
+		let selectedBar = this.state.selectedBar;
+		if ( ! selectedBar && !! data.length ) {
+			selectedBar = data[ data.length - 1 ];
+		}
 
 		return (
-			<SummaryChart
-				isLoading={ this.props.dataList.isLoading() }
-				data={ this.props.dataList.response.data }
-				activeKey="period"
-				dataKey="value"
-				labelKey="period"
-				labelClass="video"
-				sectionClass="is-video"
-				selected={ this.state.selectedBar }
-				onClick={ this.selectBar }
-				tabLabel={ translate( 'Plays' ) }
-			/>
+			<div>
+				<QuerySiteStats siteId={ siteId } statType="statsVideo" query={ query } />
+				<SummaryChart
+					isLoading={ isRequesting && ! summaryData.length }
+					data={ data }
+					activeKey="period"
+					dataKey="value"
+					labelKey="period"
+					labelClass="video"
+					sectionClass="is-video"
+					selected={ selectedBar }
+					onClick={ this.selectBar }
+					tabLabel={ translate( 'Plays' ) }
+				/>
+			</div>
 		);
 	}
-} );
+}
 
-export default localize( StatsVideoSummary );
+const connectComponent = connect(
+	( state, { postId } ) => {
+		const query = { postId };
+		const siteId = getSelectedSiteId( state );
+
+		return {
+			summaryData: getSiteStatsNormalizedData( state, siteId, 'statsVideo', query ) || [],
+			isRequesting: isRequestingSiteStatsForQuery( state, siteId, 'statsVideo', query ),
+			query,
+			siteId,
+		};
+	}
+);
+
+export default flowRight(
+	connectComponent,
+	localize,
+)( StatsVideoSummary );

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -182,7 +182,7 @@ const StatsSummary = React.createClass( {
 				/* eslint-enable wpcalypso/jsx-classname-namespace */
 
 				summaryViews.push( chartTitle );
-				barChart = <StatsVideoSummary key="video-chart" dataList={ this.props.summaryList } />;
+				barChart = <StatsVideoSummary key="video-chart" postId={ this.props.postId } />;
 
 				summaryViews.push( barChart );
 

--- a/client/state/stats/lists/actions.js
+++ b/client/state/stats/lists/actions.js
@@ -47,7 +47,8 @@ export function requestSiteStats( siteId, statType, query ) {
 			query
 		} );
 
-		return wpcom.site( siteId )[ statType ]( query ).then( data => {
+		const options = 'statsVideo' === statType ? query.postId : query;
+		return wpcom.site( siteId )[ statType ]( options ).then( data => {
 			dispatch( receiveSiteStats( siteId, statType, query, data ) );
 			dispatch( {
 				type: SITE_STATS_REQUEST_SUCCESS,

--- a/client/state/stats/lists/test/actions.js
+++ b/client/state/stats/lists/test/actions.js
@@ -21,6 +21,7 @@ import {
 
 const SITE_ID = 2916284;
 const STAT_TYPE = 'statsStreak';
+const STAT_TYPE_VIDEO = 'statsVideo';
 const STREAK_RESPONSE = {
 	streak: {},
 	data: {
@@ -30,6 +31,12 @@ const STREAK_RESPONSE = {
 	}
 };
 const STREAK_QUERY = { startDate: '2015-06-01', endDate: '2016-06-01' };
+const VIDEO_RESPONSE = {
+	data: [
+		[ '2016-11-12', 1 ],
+		[ '2016-11-13', 0 ],
+	]
+};
 
 describe( 'actions', () => {
 	const spy = sinon.spy();
@@ -66,7 +73,9 @@ describe( 'actions', () => {
 				.get( `/rest/v1.1/sites/${ SITE_ID }/stats/country-views` )
 				.reply( 404, {
 					error: 'not_found'
-				} );
+				} )
+				.get( `/rest/v1.1/sites/${ SITE_ID }/stats/video/31533` )
+				.reply( 200, VIDEO_RESPONSE );
 		} );
 
 		it( 'should dispatch a SITE_STATS_REQUEST', () => {
@@ -99,6 +108,18 @@ describe( 'actions', () => {
 					siteId: SITE_ID,
 					statType: STAT_TYPE,
 					query: STREAK_QUERY
+				} );
+			} );
+		} );
+
+		it( 'should dispatch SITE_STATS_REQUEST_SUCCESS action when video stats request succeeds', () => {
+			return requestSiteStats( SITE_ID, STAT_TYPE_VIDEO, { postId: 31533 } )( spy ).then( () => {
+				expect( spy ).to.have.been.calledWith( {
+					type: SITE_STATS_RECEIVE,
+					siteId: SITE_ID,
+					statType: STAT_TYPE_VIDEO,
+					data: VIDEO_RESPONSE,
+					query: { postId: 31533 }
 				} );
 			} );
 		} );

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -502,5 +502,35 @@ describe( 'utils', () => {
 				] );
 			} );
 		} );
+
+		describe( 'statsVideo()', () => {
+			it( 'should return an empty array if not data is passed', () => {
+				const parsedData = normalizers.statsVideo();
+
+				expect( parsedData ).to.eql( [] );
+			} );
+
+			it( 'should return an empty array if not data has no services attribute', () => {
+				const parsedData = normalizers.statsVideo( { bad: [] } );
+
+				expect( parsedData ).to.eql( [] );
+			} );
+
+			it( 'should return an a properly parsed data array', () => {
+				const parsedData = normalizers.statsVideo( {
+					data: [
+						[ '2016-11-12', 1 ],
+						[ '2016-11-13', 0 ]
+					]
+				} );
+
+				expect( parsedData ).to.eql( [
+					{
+						period: '2016-11-13',
+						value: 0,
+					}
+				] );
+			} );
+		} );
 	} );
 } );

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -172,5 +172,15 @@ export const normalizers = {
 			const { label, icon } = PUBLICIZE_SERVICES_LABEL_ICON[ service.service ];
 			return { label, icon, value: service.followers };
 		} );
-	}
+	},
+
+	statsVideo( payload ) {
+		if ( ! payload || ! payload.data ) {
+			return [];
+		}
+
+		return payload.data.map( item => {
+			return { period: item[ 0 ], value: item[ 1 ] };
+		} ).slice( Math.max( payload.data.length - 10, 1 ) );
+	},
 };


### PR DESCRIPTION
In this PR, I'm updating the StatsVideoSummary to use `QuerySiteStats` instead of the `SitesList` to fetch video stats.

My first concern here was that we're mixing different endpoint results in the same subtree `stats/lists` but this has the advantage of simplicity and conciseness. I think for Stats it's probably ok to keep this way since we don't update this subtree (apart from overwriting it with a new state, it's kind of readonly), so we do not really need to know the differences between the different endpoints results.

For comparison, I created a whole new subtree in #10520 to try the more "organised state" approach, but it's also way more verbose and it might not be needed in this specific case.

**Testing instructions**

 - Open the video summary page `/stats/day/videodetails/$site?post=$postId` 
 - Check that the first chart is showing up correctly

