### PR TITLE
Update jetpack-connect selector to only get Jetpack sites

### DIFF
--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -11,6 +11,14 @@ import { isStale } from './utils';
 import { urlToSlug } from 'lib/url';
 import { AUTH_ATTEMPS_TTL } from './constants';
 
+const getJetpackSiteByUrl = ( state, url ) => {
+	const site = getSiteByUrl( state, url );
+	if ( site && ! site.jetpack ) {
+		return null;
+	}
+	return site;
+};
+
 const getConnectingSite = ( state ) => {
 	return get( state, [ 'jetpackConnect', 'jetpackConnectSite' ] );
 };
@@ -34,7 +42,7 @@ const isRemoteSiteOnSitesList = ( state ) => {
 		return false;
 	}
 
-	return !! getSiteByUrl( state, remoteUrl );
+	return !! getJetpackSiteByUrl( state, remoteUrl );
 };
 
 const getSessions = ( state ) => {
@@ -76,14 +84,6 @@ const getFlowType = function( state, siteSlug ) {
 		return sessions[ siteSlug ].flowType;
 	}
 	return false;
-};
-
-const getJetpackSiteByUrl = ( state, url ) => {
-	const site = getSiteByUrl( state, url );
-	if ( site && ! site.jetpack ) {
-		return null;
-	}
-	return site;
 };
 
 const getAuthAttempts = ( state, slug ) => {

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -129,12 +129,13 @@ describe( 'selectors', () => {
 			expect( isRemoteSiteOnSitesList( state ) ).to.be.false;
 		} );
 
-		it( 'should return true if there site is in the sites list', () => {
+		it( 'should return true if the site is in the sites list', () => {
 			const state = {
 				sites: {
 					items: {
 						12345678: {
 							ID: 12345678,
+							jetpack: true,
 							URL: 'https://wordpress.com/'
 						}
 					}


### PR DESCRIPTION
This PR just changes `isRemoteSiteOnSitesList` to use `getJetpackSiteyUrl`, instead of `getSiteByUrl`. If a user has a wp.com site that used this domain, `getSiteByUrl` picks that up as a connected remote site, thus blocking the user from connecting the Jetpack site.

See #6779

**To test**

_I've only tested this on sites already in the conflicted state, but according to the issue, this should reproduce that state_

- Start by creating a WordPress.com site.
- Add a domain mapping to that site, to map it to a domain you already own.
- You can now access this site's settings in Calypso using the new mapped URL in the Calypso URL.
- Change the domain's NS records to point the domain to a new hosting provider.
- Create a new site on that host, and install WordPress.

Now that you have a site with the wp.com/jetpack "conflict"...

- Install and activate Jetpack.
- Try to connect Jetpack - click the Connect button, copy the URL, and append `calypso_env=development` to redirect to `calypso.localhost`.
- Before this PR, you'd see a "Return to site" button which would not do anything, claiming you're already connected
- After this PR, it should correctly see you're not connected yet, and ask you to approve the connection as normal.
- You connect! 🎉

It would also be helpful to run through the connection on a "plain" jetpack site, just to make sure there are no side-effects — that said, the sooner we can deploy this, the better, multiple users have been running into this problem.

cc @johnHackworth @roccotripaldi @tyxla 