### PR TITLE
Revert "Stats: set default view to day."

### DIFF
--- a/client/components/site-stats-sticky-link/README.md
+++ b/client/components/site-stats-sticky-link/README.md
@@ -1,0 +1,26 @@
+site-stats-sticky-link
+======================
+
+Links the user back to where they were the last time they viewed their site's stats.
+
+Use this component when you want a link to the user's Site Stats page from anywhere in calypso.
+
+Most of the logic is handled in the `site-stats-sticky-tab` library and its store / actions
+
+### usage:
+```jsx
+var SiteStatsStickyLink = require( 'components/site-stats-sticky-link' );
+
+/* ...inside component render method: */
+<SiteStatsStickyLink
+	onClick={ callback }
+	title={ localizedTitle }>{
+		localizedLinkTextAndOrImagesAsChildNodes
+}</SiteStatsStickyLink>
+```
+
+### props:
+All props are optional:
+* `onClick` (function) -- a callback to execute when the user clicks the link.
+* `title` (string) -- copied to the `title` attribute of the resultant link node
+* children will be copied to the child nodes of the resultant link node

--- a/client/components/site-stats-sticky-link/index.jsx
+++ b/client/components/site-stats-sticky-link/index.jsx
@@ -1,0 +1,63 @@
+
+// External dependencies
+var React = require( 'react' );
+
+// Internal dependencies
+var siteStatsStickyTabStore = require( 'lib/site-stats-sticky-tab/store' );
+var sections = require( 'sections-preload' );
+
+var SiteStatsStickyLink = React.createClass( {
+
+	propTypes: {
+		title: React.PropTypes.string,
+		onClick: React.PropTypes.func
+	},
+
+	_preloaded: false,
+
+	getInitialState: function() {
+		return {
+			url: siteStatsStickyTabStore.getUrl()
+		};
+	},
+
+	componentDidMount: function() {
+		siteStatsStickyTabStore.on( 'change', this.handleStatsStickyTabChange );
+	},
+
+	componentWillUnmount: function() {
+		siteStatsStickyTabStore.off( 'change', this.handleStatsStickyTabChange );
+	},
+
+	handleStatsStickyTabChange: function() {
+		var url = siteStatsStickyTabStore.getUrl();
+
+		if ( url !== this.state.url ) {
+			this.setState( {
+				url: url
+			} );
+		}
+	},
+
+	preload: function() {
+		if ( ! this._preloaded ) {
+			this._preloaded = true;
+			sections.preload( 'stats' );
+		}
+	},
+
+	render: function() {
+		return (
+			<a
+				href={ this.state.url }
+				onClick={ this.props.onClick }
+				title={ this.props.title }
+				onMouseEnter={ this.preload }
+			>
+				{ this.props.children }
+			</a>
+		);
+	}
+} );
+
+module.exports = SiteStatsStickyLink;

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
  */
 import Masterbar from './masterbar';
 import Item from './item';
+import Stats from './stats';
 import Publish from './publish';
 import Notifications from './notifications';
 import Gravatar from 'components/gravatar';
@@ -16,9 +17,6 @@ import config from 'config';
 import { preload } from 'sections-preload';
 import ResumeEditing from 'my-sites/resume-editing';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteSlug } from 'state/sites/selectors';
-import { getStatsPathForTab } from 'lib/route/path';
 
 const MasterbarLoggedIn = React.createClass( {
 	propTypes: {
@@ -26,7 +24,6 @@ const MasterbarLoggedIn = React.createClass( {
 		sites: React.PropTypes.object,
 		section: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.bool ] ),
 		setNextLayoutFocus: React.PropTypes.func.isRequired,
-		siteSlug: React.PropTypes.string,
 	},
 
 	getInitialState() {
@@ -66,8 +63,7 @@ const MasterbarLoggedIn = React.createClass( {
 	render() {
 		return (
 			<Masterbar>
-				<Item
-					url={ getStatsPathForTab( 'day', this.props.siteSlug ) }
+				<Stats
 					tipTarget="my-sites"
 					icon={ this.wordpressIcon() }
 					onClick={ this.clickMySites }
@@ -79,7 +75,7 @@ const MasterbarLoggedIn = React.createClass( {
 						? this.translate( 'My Sites', { comment: 'Toolbar, must be shorter than ~12 chars' } )
 						: this.translate( 'My Site', { comment: 'Toolbar, must be shorter than ~12 chars' } )
 					}
-				</Item>
+				</Stats>
 				<Item
 					tipTarget="reader"
 					className="masterbar__reader"
@@ -131,10 +127,4 @@ const MasterbarLoggedIn = React.createClass( {
 } );
 
 // TODO: make this pure when sites can be retrieved from the Redux state
-export default connect( ( state ) => {
-	const siteId = getSelectedSiteId( state );
-
-	return {
-		siteSlug: getSiteSlug( state, siteId )
-	};
-}, { setNextLayoutFocus }, null, { pure: false } )( MasterbarLoggedIn );
+export default connect( null, { setNextLayoutFocus }, null, { pure: false } )( MasterbarLoggedIn );

--- a/client/layout/masterbar/stats.jsx
+++ b/client/layout/masterbar/stats.jsx
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Item from './item';
+import siteStatsStickyTabStore from 'lib/site-stats-sticky-tab/store';
+
+export default React.createClass( {
+	displayName: 'MasterbarStats',
+
+	propTypes: {
+		children: PropTypes.node
+	},
+
+	getInitialState() {
+		return {
+			url: siteStatsStickyTabStore.getUrl()
+		};
+	},
+
+	componentDidMount() {
+		siteStatsStickyTabStore.on( 'change', this.handleStatsStickyTabChange );
+	},
+
+	componentWillUnmount() {
+		siteStatsStickyTabStore.off( 'change', this.handleStatsStickyTabChange );
+	},
+
+	handleStatsStickyTabChange() {
+		var url = siteStatsStickyTabStore.getUrl();
+
+		if ( url !== this.state.url ) {
+			this.setState( {
+				url: url
+			} );
+		}
+	},
+
+	render() {
+		return (
+			<Item { ...this.props } url={ this.state.url }>
+				{ this.props.children }
+			</Item>
+		);
+	}
+} );

--- a/client/lib/desktop/index.js
+++ b/client/lib/desktop/index.js
@@ -7,7 +7,8 @@ var debug = require( 'debug' )( 'calypso:desktop' ),
 /**
  * Internal dependencies
  */
-var paths = require( 'lib/paths' ),
+var siteStatsStickyTabStore = require( 'lib/site-stats-sticky-tab/store' ),
+	paths = require( 'lib/paths' ),
 	user = require( 'lib/user' )(),
 	sites = require( 'lib/sites-list' )(),
 	ipc = require( 'electron' ).ipcRenderer,          // From Electron
@@ -15,7 +16,6 @@ var paths = require( 'lib/paths' ),
 	oAuthToken = require( 'lib/oauth-token' ),
 	userUtilities = require( 'lib/user/utils' ),
 	location = require( 'lib/route/page-notifier' );
-import { getStatsPathForTab } from 'lib/route/path';
 
 /**
  * Module variables
@@ -117,11 +117,9 @@ var Desktop = {
 
 	onShowMySites: function() {
 		debug( 'Showing my sites' );
-		const site = this.getSelectedSite();
-		const siteId = this.isSingle() ? site.slug : null;
 
 		this.clearNotificationBar();
-		page( getStatsPathForTab( 'day', siteId ) );
+		page( siteStatsStickyTabStore.getUrl() );
 	},
 
 	onShowReader: function() {

--- a/client/lib/route/path.js
+++ b/client/lib/route/path.js
@@ -74,7 +74,7 @@ function sectionify( path ) {
 }
 
 function getStatsDefaultSitePage( slug ) {
-	const path = '/stats/day/';
+	const path = '/stats/insights/';
 
 	if ( slug ) {
 		return path + slug;

--- a/client/lib/site-stats-sticky-tab/README.md
+++ b/client/lib/site-stats-sticky-tab/README.md
@@ -1,0 +1,25 @@
+site-stats-sticky-tab
+=====================
+
+`siteStatsStickyTab` is a set of Flux-style modules used to maintain an in-memory (backed by `localStorage`) store of the last Site Stats filter and site-specificity state.
+
+This enables us to provide direct links to where users were inside their Site Stats previously.
+
+### usage
+* To save the state:
+
+```es6
+var siteStatsStickyTabActions = require( 'lib/site-stats-sticky-tab/actions' );
+/* ...component lifecycle methods: */
+{
+	componentDidMount: function() {
+		siteStatsStickyTabActions.saveFilterAndSlug( this.getActiveFilter().id, this.props.site.slug );
+	},
+
+	componentDidUpdate: function() {
+		siteStatsStickyTabActions.saveFilterAndSlug( this.getActiveFilter().id, this.props.site.slug );
+	},
+}
+```
+
+* Displaying the link is handled by the `site-stats-sticky-link` component

--- a/client/lib/site-stats-sticky-tab/actions.js
+++ b/client/lib/site-stats-sticky-tab/actions.js
@@ -1,0 +1,22 @@
+
+// External dependencies
+var Dispatcher = require( 'dispatcher' );
+
+// Internal dependencies
+var constants = require( './constants' );
+
+/**
+ * @param  {[string]} filter   representative of a stats filter behavior, false will be ignored
+ * @param  {[string]} slug     a site's domain (or suboptimally a siteId), false will be ignored
+ */
+function saveFilterAndSlug( filter, slug ) {
+	Dispatcher.handleViewAction( {
+		type: constants.actions.RECEIVE_STATS_FILTER_AND_SLUG,
+		filter: filter,
+		slug: slug
+	} );
+}
+
+module.exports = {
+	saveFilterAndSlug: saveFilterAndSlug
+};

--- a/client/lib/site-stats-sticky-tab/constants.js
+++ b/client/lib/site-stats-sticky-tab/constants.js
@@ -1,0 +1,8 @@
+
+module.exports = {
+	CACHE_KEY_MY_PLACE: 'site-stats-my-place',
+
+	actions: {
+		RECEIVE_STATS_FILTER_AND_SLUG: 'RECEIVE_STATS_FILTER_AND_SLUG'
+	}
+};

--- a/client/lib/site-stats-sticky-tab/store.js
+++ b/client/lib/site-stats-sticky-tab/store.js
@@ -1,0 +1,137 @@
+// External dependencies
+var Dispatcher = require( 'dispatcher' ),
+	Emitter = require( 'lib/mixins/emitter' ),
+	store = require( 'store' ),
+	merge = require( 'lodash/merge' );
+
+// Internal dependencies
+var constants = require( './constants' ),
+	getStatsPathForTab = require( 'lib/route/path' ).getStatsPathForTab,
+	sites = require( 'lib/sites-list' )(),
+	_cachedPlace = getCachedPlace(),
+	siteStatsStickyTabStore;
+
+/**
+ * @param  {[string]} tab      A label representative of a stats section behavior
+ *                             * empty strings are stored as-is
+ *                             * non-strings & `false` will be ignored
+ *                             * prefixes like 'stats-*'' will be dropped
+ *
+ * @param  {[string]} slug     A site's domain (or suboptimally a siteId)
+ *                             * empty strings are stored as-is
+ *                             * non-strings & `false` will be ignored
+ *
+ * @return {[bool]}            true if something changed, false if not
+ */
+function saveMyPlace( tab, slug ) {
+	var newPlace;
+
+	if ( typeof tab !== 'string' ) {
+		tab = false;
+	}
+
+	if ( typeof slug !== 'string' ) {
+		slug = false;
+	}
+
+	if ( tab !== false && _cachedPlace.tab !== tab ) {
+		newPlace = {
+			tab: tab
+		};
+	}
+
+	if ( slug !== false && _cachedPlace.slug !== slug ) {
+		newPlace = newPlace || {};
+		newPlace.slug = slug;
+	}
+
+	if ( newPlace ) {
+		if ( newPlace.tab === 'insights' && ! ( newPlace.slug || _cachedPlace.slug ) ) {
+			// It's currently an invalid state to have insights and no slug
+			if ( _cachedPlace.tab === 'day' ) {
+				return false;
+			}
+			newPlace.tab = 'day';
+		}
+
+		if ( newPlace.slug === '' && _cachedPlace.tab === 'insights' && ! newPlace.tab ) {
+			newPlace.tab = 'day';
+		}
+
+		// Something changed, update the in-memory copy
+		_cachedPlace = merge( _cachedPlace, newPlace );
+
+		// And persist to disk
+		store.set( constants.CACHE_KEY_MY_PLACE, _cachedPlace );
+	}
+
+	return !! newPlace;
+}
+
+function getCachedPlace() {
+	var cached = store.get( constants.CACHE_KEY_MY_PLACE );
+	if ( cached ) {
+		return cached;
+	}
+	return {};
+}
+
+function handleSitesChange() {
+	if ( sites.initialized && sites.fetched ) {
+		// We only need to do this once after the sites list is built
+		sites.off( 'change', handleSitesChange );
+
+		siteStatsStickyTabStore.emit( 'change' );
+	}
+}
+
+function getUrl() {
+	var tab = _cachedPlace.tab,
+		slug = _cachedPlace.slug,
+		site;
+
+	// The site in the store gets priority
+	if ( slug ) {
+		return getStatsPathForTab( tab, slug );
+	}
+
+	// The slug store is empty, is there a selected site?
+	site = sites.getSelectedSite();
+	if ( site && site.slug ) {
+		slug = site.slug;
+	}
+
+	// an empty string here means include no slug in the link
+	if ( ! slug && slug !== '' ) {
+		// The user's primary site is last
+		site = sites.getPrimary();
+		if ( site && site.slug ) {
+			slug = site.slug;
+		}
+	}
+
+	return getStatsPathForTab( tab, slug );
+}
+
+siteStatsStickyTabStore = {
+	getUrl: getUrl
+};
+
+Emitter( siteStatsStickyTabStore );
+
+siteStatsStickyTabStore.dispatchToken = Dispatcher.register( function( payload ) {
+	var action = payload.action;
+
+	switch( action.type ) {
+		case constants.actions.RECEIVE_STATS_FILTER_AND_SLUG:
+			if ( saveMyPlace( action.filter, action.slug ) ) {
+				siteStatsStickyTabStore.emit( 'change' );
+			}
+			break;
+		default:
+	}
+} );
+
+sites.on( 'change', handleSitesChange );
+
+module.exports = siteStatsStickyTabStore;

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -25,6 +25,7 @@ import route from 'lib/route';
 import notices from 'notices';
 import config from 'config';
 import analytics from 'lib/analytics';
+import siteStatsStickyTabActions from 'lib/site-stats-sticky-tab/actions';
 import utils from 'lib/site/utils';
 import trackScrollPage from 'lib/track-scroll-page';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
@@ -161,11 +162,13 @@ module.exports = {
 		if ( ! siteID ) {
 			sites.selectAll();
 			context.store.dispatch( setAllSitesSelected() );
+			siteStatsStickyTabActions.saveFilterAndSlug( false, '' );
 			return next();
 		}
 
 		const onSelectedSiteAvailable = () => {
 			const selectedSite = sites.getSelectedSite();
+			siteStatsStickyTabActions.saveFilterAndSlug( false, selectedSite.slug );
 			context.store.dispatch( receiveSite( selectedSite ) );
 			context.store.dispatch( setSelectedSiteId( selectedSite.ID ) );
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -24,6 +24,7 @@ import SidebarHeading from 'layout/sidebar/heading';
 import SidebarItem from 'layout/sidebar/item';
 import SidebarMenu from 'layout/sidebar/menu';
 import SidebarRegion from 'layout/sidebar/region';
+import SiteStatsStickyLink from 'components/site-stats-sticky-link';
 import { isPersonal, isPremium, isBusiness } from 'lib/products-values';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -31,7 +32,6 @@ import { getThemeCustomizeUrl as getCustomizeUrl } from 'state/themes/selectors'
 import { setNextLayoutFocus, setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { userCan } from 'lib/site/utils';
 import { isJetpackSite } from 'state/sites/selectors';
-import { getStatsPathForTab } from 'lib/route/path';
 
 /**
  * Module variables
@@ -136,7 +136,7 @@ export class MySitesSidebar extends Component {
 	}
 
 	stats() {
-		const site = this.getSelectedSite();
+		var site = this.getSelectedSite();
 
 		if ( site && ! site.capabilities ) {
 			return null;
@@ -146,16 +146,13 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		const siteId = this.isSingle() ? site.slug : null;
-
 		return (
-			<SidebarItem
-				tipTarget="menus"
-				label={ this.props.translate( 'Stats' ) }
-				className={ this.itemLinkClass( '/stats', 'stats' ) }
-				link={ getStatsPathForTab( 'day', siteId ) }
-				onNavigate={ this.onNavigate }
-				icon="stats-alt" />
+			<li className={ this.itemLinkClass( '/stats', 'stats' ) }>
+				<SiteStatsStickyLink onClick={ this.onNavigate }>
+					<Gridicon icon="stats-alt" size={ 24 } />
+					<span className="menu-link-text">{ this.props.translate( 'Stats' ) }</span>
+				</SiteStatsStickyLink>
+			</li>
 		);
 	}
 

--- a/client/my-sites/sidebar/test/sidebar.jsx
+++ b/client/my-sites/sidebar/test/sidebar.jsx
@@ -20,6 +20,7 @@ describe( 'MySitesSidebar', () => {
 		mockery.registerMock( 'layout/sidebar', EmptyComponent );
 		mockery.registerMock( 'post-editor/drafts-button', EmptyComponent );
 		mockery.registerMock( 'components/tooltip', EmptyComponent );
+		mockery.registerMock( 'components/site-stats-sticky-link', EmptyComponent );
 
 		MySitesSidebar = require( '../sidebar' ).MySitesSidebar;
 	} );

--- a/client/my-sites/stats/stats-navigation/index.jsx
+++ b/client/my-sites/stats/stats-navigation/index.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
+import siteStatsStickyTabActions from 'lib/site-stats-sticky-tab/actions';
 import FollowersCount from 'blocks/followers-count';
 
 class StatsNavigation extends Component {
@@ -19,6 +20,16 @@ class StatsNavigation extends Component {
 			PropTypes.bool,
 			PropTypes.object
 		] )
+	}
+
+	componentDidMount() {
+		const slug = this.props.site ? this.props.site.slug : '';
+		siteStatsStickyTabActions.saveFilterAndSlug( this.props.section, slug );
+	}
+
+	componentDidUpdate() {
+		const slug = this.props.site ? this.props.site.slug : '';
+		siteStatsStickyTabActions.saveFilterAndSlug( this.props.section, slug );
 	}
 
 	render() {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#10505

Rolling back to come up with a solution for the missing site slug when clicking 'My Sites' for the first time on multi-blog users.

/cc @aduth 