### PR TITLE
Masterbar: Default My Sites link to Default stats page if no site selected

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -131,10 +132,15 @@ const MasterbarLoggedIn = React.createClass( {
 } );
 
 // TODO: make this pure when sites can be retrieved from the Redux state
-export default connect( ( state ) => {
+export default connect( ( state, ownProps ) => {
 	const siteId = getSelectedSiteId( state );
+	let siteSlug = getSiteSlug( state, siteId );
 
-	return {
-		siteSlug: getSiteSlug( state, siteId )
-	};
+	// fall back to sites list to see if a site is selected
+	if ( ! siteId ) {
+		const site = ownProps.sites.getPrimary();
+		siteSlug = get( site, 'slug' );
+	}
+
+	return { siteSlug };
 }, { setNextLayoutFocus }, null, { pure: false } )( MasterbarLoggedIn );


### PR DESCRIPTION
This fixes a bug that was introduced in #10505 where the 'My Sites' link does not have a site slug appended to it for users with multiple sites.  If a site is not selected in the state tree, this logic falls back to using the `sitesList.getPrimary()` instead.

__To Test__
- Verify when clicking My Sites you are directed to the "Day" view for your default site
- Change sites to a non-default site, then click the Reader
- Verify when Clicking 'My Sites' again, it uses the last site you have selected for the link

/cc @aduth 