### PR TITLE
Stats: set default view to day - take two

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -9,7 +9,6 @@ import { connect } from 'react-redux';
  */
 import Masterbar from './masterbar';
 import Item from './item';
-import Stats from './stats';
 import Publish from './publish';
 import Notifications from './notifications';
 import Gravatar from 'components/gravatar';
@@ -17,6 +16,9 @@ import config from 'config';
 import { preload } from 'sections-preload';
 import ResumeEditing from 'my-sites/resume-editing';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
+import { getStatsPathForTab } from 'lib/route/path';
 
 const MasterbarLoggedIn = React.createClass( {
 	propTypes: {
@@ -24,6 +26,7 @@ const MasterbarLoggedIn = React.createClass( {
 		sites: React.PropTypes.object,
 		section: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.bool ] ),
 		setNextLayoutFocus: React.PropTypes.func.isRequired,
+		siteSlug: React.PropTypes.string,
 	},
 
 	getInitialState() {
@@ -63,7 +66,8 @@ const MasterbarLoggedIn = React.createClass( {
 	render() {
 		return (
 			<Masterbar>
-				<Stats
+				<Item
+					url={ getStatsPathForTab( 'day', this.props.siteSlug ) }
 					tipTarget="my-sites"
 					icon={ this.wordpressIcon() }
 					onClick={ this.clickMySites }
@@ -75,7 +79,7 @@ const MasterbarLoggedIn = React.createClass( {
 						? this.translate( 'My Sites', { comment: 'Toolbar, must be shorter than ~12 chars' } )
 						: this.translate( 'My Site', { comment: 'Toolbar, must be shorter than ~12 chars' } )
 					}
-				</Stats>
+				</Item>
 				<Item
 					tipTarget="reader"
 					className="masterbar__reader"
@@ -127,4 +131,10 @@ const MasterbarLoggedIn = React.createClass( {
 } );
 
 // TODO: make this pure when sites can be retrieved from the Redux state
-export default connect( null, { setNextLayoutFocus }, null, { pure: false } )( MasterbarLoggedIn );
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		siteSlug: getSiteSlug( state, siteId )
+	};
+}, { setNextLayoutFocus }, null, { pure: false } )( MasterbarLoggedIn );

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,6 +20,7 @@ import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getStatsPathForTab } from 'lib/route/path';
+import { getCurrentUser } from 'state/current-user/selectors';
 
 const MasterbarLoggedIn = React.createClass( {
 	propTypes: {
@@ -133,8 +135,13 @@ const MasterbarLoggedIn = React.createClass( {
 // TODO: make this pure when sites can be retrieved from the Redux state
 export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
+	let siteSlug = getSiteSlug( state, siteId );
 
-	return {
-		siteSlug: getSiteSlug( state, siteId )
-	};
+	// If siteId has not been set in redux, fall back to currentUser.primarySiteSlug
+	if ( ! siteId ) {
+		const currentUser = getCurrentUser( state );
+		siteSlug = get( currentUser, 'primarySiteSlug' );
+	}
+
+	return { siteSlug };
 }, { setNextLayoutFocus }, null, { pure: false } )( MasterbarLoggedIn );

--- a/client/lib/desktop/index.js
+++ b/client/lib/desktop/index.js
@@ -7,8 +7,7 @@ var debug = require( 'debug' )( 'calypso:desktop' ),
 /**
  * Internal dependencies
  */
-var siteStatsStickyTabStore = require( 'lib/site-stats-sticky-tab/store' ),
-	paths = require( 'lib/paths' ),
+var paths = require( 'lib/paths' ),
 	user = require( 'lib/user' )(),
 	sites = require( 'lib/sites-list' )(),
 	ipc = require( 'electron' ).ipcRenderer,          // From Electron
@@ -16,6 +15,7 @@ var siteStatsStickyTabStore = require( 'lib/site-stats-sticky-tab/store' ),
 	oAuthToken = require( 'lib/oauth-token' ),
 	userUtilities = require( 'lib/user/utils' ),
 	location = require( 'lib/route/page-notifier' );
+import { getStatsPathForTab } from 'lib/route/path';
 
 /**
  * Module variables
@@ -117,9 +117,11 @@ var Desktop = {
 
 	onShowMySites: function() {
 		debug( 'Showing my sites' );
+		const site = this.getSelectedSite();
+		const siteId = this.isSingle() ? site.slug : null;
 
 		this.clearNotificationBar();
-		page( siteStatsStickyTabStore.getUrl() );
+		page( getStatsPathForTab( 'day', siteId ) );
 	},
 
 	onShowReader: function() {

--- a/client/lib/route/path.js
+++ b/client/lib/route/path.js
@@ -74,7 +74,7 @@ function sectionify( path ) {
 }
 
 function getStatsDefaultSitePage( slug ) {
-	const path = '/stats/insights/';
+	const path = '/stats/day/';
 
 	if ( slug ) {
 		return path + slug;

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -24,7 +24,6 @@ import SidebarHeading from 'layout/sidebar/heading';
 import SidebarItem from 'layout/sidebar/item';
 import SidebarMenu from 'layout/sidebar/menu';
 import SidebarRegion from 'layout/sidebar/region';
-import SiteStatsStickyLink from 'components/site-stats-sticky-link';
 import { isPersonal, isPremium, isBusiness } from 'lib/products-values';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -32,6 +31,7 @@ import { getThemeCustomizeUrl as getCustomizeUrl } from 'state/themes/selectors'
 import { setNextLayoutFocus, setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { userCan } from 'lib/site/utils';
 import { isJetpackSite } from 'state/sites/selectors';
+import { getStatsPathForTab } from 'lib/route/path';
 
 /**
  * Module variables
@@ -136,7 +136,7 @@ export class MySitesSidebar extends Component {
 	}
 
 	stats() {
-		var site = this.getSelectedSite();
+		const site = this.getSelectedSite();
 
 		if ( site && ! site.capabilities ) {
 			return null;
@@ -146,13 +146,16 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
+		const siteId = this.isSingle() ? site.slug : null;
+
 		return (
-			<li className={ this.itemLinkClass( '/stats', 'stats' ) }>
-				<SiteStatsStickyLink onClick={ this.onNavigate }>
-					<Gridicon icon="stats-alt" size={ 24 } />
-					<span className="menu-link-text">{ this.props.translate( 'Stats' ) }</span>
-				</SiteStatsStickyLink>
-			</li>
+			<SidebarItem
+				tipTarget="menus"
+				label={ this.props.translate( 'Stats' ) }
+				className={ this.itemLinkClass( '/stats', 'stats' ) }
+				link={ getStatsPathForTab( 'day', siteId ) }
+				onNavigate={ this.onNavigate }
+				icon="stats-alt" />
 		);
 	}
 


### PR DESCRIPTION
#10505 had to be reverted due to some issues with the masterbar link not having a site slug included when a site had yet to be selected in Redux.  After chatting with @aduth, we agreed that my initial proposed fix in #10566 wasn't ideal due to reliance upon `sites-list`.

__Notes__
In this branch, I opted to pursue a state tree only solution, which as we know is tricky when relying upon site data.  For example, if you land on the reader with an un-primed localStore/indexDb, the `site` object for a user's default site is not yet populated in the state tree.  The solution proposed here is to fall back on the `primarySiteSlug` attribute of `currentUser`.  The only oddity seen because of this is mapped domains are expressed in their `${site}.wordpress.com` format in this field.

The prior branch had commits to remove all of the "stats-sticky-tab" logic, here I'm opting to just focus on the target of the links and will remove un-used code in a follow-up PR.

__To Test__
- Open this branch locally, from the reader, click 'My Sites'.
- If a site had been selected prior, you should be viewing the Day stats page for that site. If a prior site was not selected, you will see a Day summary for **your default site**.
- Change the selected site from this view, and select the "Insights" tab for this new site. Then click the Reader link.
- Click 'My Sites' again, and note you should be shown the day tab for the site you just selected

Additional Test Flow:
- Clear out `localStore`
- Start from the reader on an empty localStore, click 'My Sites'
- Verify that you are linked to the 'Day' view for your default site.  Note that if your default site has a mapped domain, the wordpress.com version of said mapped domain will be used in the URL.

Ideally, it would be good to test both flows with a multi-site account, and a single site account.  I also tested with mapped domains, un-mapped domains, and jetpack sites as my default site.