### PR TITLE
Domains: Add warning if TXT record contains non-ASCII characters

### DIFF
--- a/client/components/forms/form-input-validation/index.jsx
+++ b/client/components/forms/form-input-validation/index.jsx
@@ -15,6 +15,7 @@ export default React.createClass( {
 
 	propTypes: {
 		isError: React.PropTypes.bool,
+		isWarning: React.PropTypes.bool,
 		text: React.PropTypes.string,
 		icon: React.PropTypes.string
 	},
@@ -26,10 +27,11 @@ export default React.createClass( {
 	render() {
 		const classes = classNames( {
 			'form-input-validation': true,
+			'is-warning': this.props.isWarning,
 			'is-error': this.props.isError
 		} );
 
-		const icon = this.props.isError ? 'notice-outline' : 'checkmark';
+		const icon = this.props.isError || this.props.isWarning ? 'notice-outline' : 'checkmark';
 
 		return (
 			<div className={ classes }>

--- a/client/components/forms/form-input-validation/style.scss
+++ b/client/components/forms/form-input-validation/style.scss
@@ -10,6 +10,11 @@
 	&.is-error {
 		color: $alert-red;
 	}
+
+	&.is-warning{
+		color: $alert-yellow;
+	}
+
 	.gridicon {
 		float: left;
 		margin-left: -34px;

--- a/client/my-sites/upgrades/domain-management/dns/txt-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/txt-record.jsx
@@ -12,6 +12,7 @@ import FormInputValidation from 'components/forms/form-input-validation';
 import FormLabel from 'components/forms/form-label';
 import FormTextarea from 'components/forms/form-textarea';
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
+import Gridicon from 'components/gridicon';
 
 const TxtRecord = React.createClass( {
 	statics: {
@@ -34,7 +35,8 @@ const TxtRecord = React.createClass( {
 		const classes = classnames( { 'is-hidden': ! this.props.show } ),
 			isValid = this.props.isValid,
 			isNameValid = isValid( 'name' ),
-			isDataValid = isValid( 'data' );
+			isDataValid = isValid( 'data' ),
+			hasNonAsciiData = ! /^[\u0000-\u007f]*$/.test( this.props.fieldValues.data );
 
 		return (
 			<div className={ classes }>
@@ -42,12 +44,17 @@ const TxtRecord = React.createClass( {
 					<FormLabel>{ this.translate( 'Name', { context: 'Dns Record' } ) }</FormLabel>
 					<FormTextInputWithAffixes
 						name="name"
-						placeholder={ this.translate( 'Enter subdomain (optional)', { context: 'Placeholder shown when entering the optional subdomain part of a new DNS record' } ) }
+						placeholder={
+							this.translate(
+								'Enter subdomain (optional)',
+								{ context: 'Placeholder shown when entering the optional subdomain part of a new DNS record' }
+							)
+						}
 						isError={ ! isNameValid }
 						onChange={ this.props.onChange }
 						value={ this.props.fieldValues.name }
 						suffix={ '.' + this.props.selectedDomainName } />
-					{ ! isNameValid ? <FormInputValidation text={ this.translate( 'Invalid Name' ) } isError={ true } /> : null }
+					{ ! isNameValid && <FormInputValidation text={ this.translate( 'Invalid Name' ) } isError={ true } /> }
 				</FormFieldset>
 
 				<FormFieldset>
@@ -57,7 +64,12 @@ const TxtRecord = React.createClass( {
 						onChange={ this.props.onChange }
 						value={ this.props.fieldValues.data }
 						placeholder={ this.translate( 'e.g. %(example)s', { args: { example: 'v=spf1 include:example.com ~all' } } ) } />
-					{ ! isDataValid ? <FormInputValidation text={ this.translate( 'Invalid TXT Record' ) } isError={ true } /> : null }
+					{ hasNonAsciiData && (
+						<div className="form-input-validation dns__warning">
+							<span><Gridicon size={ 24 } icon="notice" /> { this.translate( 'TXT Record has non-ASCII data' ) }</span>
+						</div>
+					) }
+					{ ! isDataValid && <FormInputValidation text={ this.translate( 'Invalid TXT Record' ) } isError={ true } /> }
 				</FormFieldset>
 			</div>
 		);

--- a/client/my-sites/upgrades/domain-management/dns/txt-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/txt-record.jsx
@@ -12,7 +12,6 @@ import FormInputValidation from 'components/forms/form-input-validation';
 import FormLabel from 'components/forms/form-label';
 import FormTextarea from 'components/forms/form-textarea';
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
-import Gridicon from 'components/gridicon';
 
 const TxtRecord = React.createClass( {
 	statics: {
@@ -36,7 +35,7 @@ const TxtRecord = React.createClass( {
 			isValid = this.props.isValid,
 			isNameValid = isValid( 'name' ),
 			isDataValid = isValid( 'data' ),
-			hasNonAsciiData = ! /^[\u0000-\u007f]*$/.test( this.props.fieldValues.data );
+			hasNonAsciiData = /[^\u0000-\u007f]/.test( this.props.fieldValues.data );
 
 		return (
 			<div className={ classes }>
@@ -54,7 +53,7 @@ const TxtRecord = React.createClass( {
 						onChange={ this.props.onChange }
 						value={ this.props.fieldValues.name }
 						suffix={ '.' + this.props.selectedDomainName } />
-					{ ! isNameValid && <FormInputValidation text={ this.translate( 'Invalid Name' ) } isError={ true } /> }
+					{ ! isNameValid && <FormInputValidation text={ this.translate( 'Invalid Name' ) } isError /> }
 				</FormFieldset>
 
 				<FormFieldset>
@@ -64,12 +63,8 @@ const TxtRecord = React.createClass( {
 						onChange={ this.props.onChange }
 						value={ this.props.fieldValues.data }
 						placeholder={ this.translate( 'e.g. %(example)s', { args: { example: 'v=spf1 include:example.com ~all' } } ) } />
-					{ hasNonAsciiData && (
-						<div className="form-input-validation dns__warning">
-							<span><Gridicon size={ 24 } icon="notice" /> { this.translate( 'TXT Record has non-ASCII data' ) }</span>
-						</div>
-					) }
-					{ ! isDataValid && <FormInputValidation text={ this.translate( 'Invalid TXT Record' ) } isError={ true } /> }
+					{ hasNonAsciiData && <FormInputValidation text={ this.translate( 'TXT Record has non-ASCII data' ) } isWarning /> }
+					{ ! isDataValid && <FormInputValidation text={ this.translate( 'Invalid TXT Record' ) } isError /> }
 				</FormFieldset>
 			</div>
 		);

--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -590,6 +590,10 @@ input[type=radio].domain-management-list-item__radio {
 	.is-hidden {
 		display: none;
 	}
+
+	.dns__warning {
+		color: $alert-yellow;
+	}
 }
 
 .email-forwarding__form {

--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -590,10 +590,6 @@ input[type=radio].domain-management-list-item__radio {
 	.is-hidden {
 		display: none;
 	}
-
-	.dns__warning {
-		color: $alert-yellow;
-	}
 }
 
 .email-forwarding__form {


### PR DESCRIPTION
They are valid, but sometimes things like UTF-8 double quotes get replace when people copy-paste, and this breaks the records, or there are zero-width spaces...

Test:
1. Edit DNS
2. Add TXT Record
3. Input character like ©
4. See warning:
![txt warning](https://cloud.githubusercontent.com/assets/1103398/21869019/d772e230-d855-11e6-957e-7d9223bd6cf1.png)
