### PR TITLE
JetpackManageErrorPage: Use selectors instead of computed `site` attributes

### DIFF
--- a/client/my-sites/jetpack-manage-error-page/index.jsx
+++ b/client/my-sites/jetpack-manage-error-page/index.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux'
 import analytics from 'lib/analytics'
 import EmptyContent from 'components/empty-content'
 import FeatureExample from 'components/feature-example'
-import { getSiteSlug, getJetpackSiteRemoteManagementUrl } from 'state/sites/selectors'
+import { getSiteSlug, getJetpackSiteRemoteManagementUrl, isJetpackSite } from 'state/sites/selectors'
 
 const JetpackManageErrorPage = React.createClass( {
 
@@ -37,7 +37,7 @@ const JetpackManageErrorPage = React.createClass( {
 				line: this.translate( 'Jetpack %(version)s or higher is required to see this page.', { args: { version: version } } ),
 				action: this.translate( 'Update Jetpack' ),
 				illustration: null,
-				actionURL: ( this.props.site && this.props.site.jetpack )
+				actionURL: ( this.props.site && this.props.isJetpack )
 					? '../../plugins/jetpack/' + this.props.siteSlug
 					: undefined,
 				version: version
@@ -47,7 +47,7 @@ const JetpackManageErrorPage = React.createClass( {
 				line: this.translate( 'We need you to enable the Manage feature in the Jetpack plugin on your remote site' ),
 				illustration: '/calypso/images/jetpack/jetpack-manage.svg',
 				action: this.translate( 'Enable Jetpack Manage' ),
-				actionURL: ( this.props.site && this.props.site.jetpack )
+				actionURL: ( this.props.site && this.props.isJetpack )
 					? this.props.remoteManagementUrl + ( this.props.section ? '&section=' + this.props.section : '' )
 					: undefined,
 				actionTarget: '_blank'
@@ -86,6 +86,7 @@ const JetpackManageErrorPage = React.createClass( {
 export default connect(
 	( state, { site } ) => ( {
 		siteSlug: getSiteSlug( state, site.ID ),
-		remoteManagementUrl: getJetpackSiteRemoteManagementUrl( state, site.ID )
+		remoteManagementUrl: getJetpackSiteRemoteManagementUrl( state, site.ID ),
+		isJetpack: isJetpackSite( state, site.ID )
 	} )
 )( JetpackManageErrorPage );

--- a/client/my-sites/jetpack-manage-error-page/index.jsx
+++ b/client/my-sites/jetpack-manage-error-page/index.jsx
@@ -13,9 +13,6 @@ import FeatureExample from 'components/feature-example'
 import { getSiteSlug, getJetpackSiteRemoteManagementUrl } from 'state/sites/selectors'
 
 const JetpackManageErrorPage = React.createClass( {
-
-	mixins: [ 'pluginsData' ],
-
 	actionCallbacks: {
 		updateJetpack: 'actionCallbackUpdate',
 		optInManage: 'actionCallbackActivate'

--- a/client/my-sites/jetpack-manage-error-page/index.jsx
+++ b/client/my-sites/jetpack-manage-error-page/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react'
+import { connect } from 'react-redux'
 
 /**
  * Internal dependencies
@@ -9,10 +10,9 @@ import React from 'react'
 import analytics from 'lib/analytics'
 import EmptyContent from 'components/empty-content'
 import FeatureExample from 'components/feature-example'
+import { getSiteSlug, getJetpackSiteRemoteManagementUrl } from 'state/sites/selectors'
 
-module.exports = React.createClass( {
-
-	displayName: 'JetpackManageErrorPage',
+const JetpackManageErrorPage = React.createClass( {
 
 	mixins: [ 'pluginsData' ],
 
@@ -38,7 +38,7 @@ module.exports = React.createClass( {
 				action: this.translate( 'Update Jetpack' ),
 				illustration: null,
 				actionURL: ( this.props.site && this.props.site.jetpack )
-					? '../../plugins/jetpack/' + this.props.site.slug
+					? '../../plugins/jetpack/' + this.props.siteSlug
 					: undefined,
 				version: version
 			},
@@ -48,7 +48,7 @@ module.exports = React.createClass( {
 				illustration: '/calypso/images/jetpack/jetpack-manage.svg',
 				action: this.translate( 'Enable Jetpack Manage' ),
 				actionURL: ( this.props.site && this.props.site.jetpack )
-					? this.props.site.getRemoteManagementURL() + ( this.props.section ? '&section=' + this.props.section : '' )
+					? this.props.remoteManagementUrl + ( this.props.section ? '&section=' + this.props.section : '' )
 					: undefined,
 				actionTarget: '_blank'
 			},
@@ -56,7 +56,7 @@ module.exports = React.createClass( {
 				title: this.translate( 'Domains are not available for this site.' ),
 				line: this.translate( 'You can only purchase domains for sites hosted on WordPress.com at this time.' ),
 				action: this.translate( 'View Plans' ),
-				actionURL: '/plans/' + ( this.props.site ? this.props.site.slug : '' )
+				actionURL: '/plans/' + ( this.props.siteSlug || '' )
 			},
 			'default': {}
 		};
@@ -78,7 +78,14 @@ module.exports = React.createClass( {
 				{ emptyContent }
 				{ featureExample }
 			</div>
-		)
+		);
 	}
 
 } );
+
+export default connect(
+	( state, { site } ) => ( {
+		siteSlug: getSiteSlug( state, site.ID ),
+		remoteManagementUrl: getJetpackSiteRemoteManagementUrl( state, site.ID )
+	} )
+)( JetpackManageErrorPage );

--- a/client/my-sites/jetpack-manage-error-page/index.jsx
+++ b/client/my-sites/jetpack-manage-error-page/index.jsx
@@ -1,16 +1,16 @@
 /**
  * External dependencies
  */
-import React from 'react'
-import { connect } from 'react-redux'
+import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics'
-import EmptyContent from 'components/empty-content'
-import FeatureExample from 'components/feature-example'
-import { getSiteSlug, getJetpackSiteRemoteManagementUrl } from 'state/sites/selectors'
+import analytics from 'lib/analytics';
+import EmptyContent from 'components/empty-content';
+import FeatureExample from 'components/feature-example';
+import { getSiteSlug, getJetpackSiteRemoteManagementUrl } from 'state/sites/selectors';
 
 const JetpackManageErrorPage = React.createClass( {
 	actionCallbacks: {

--- a/client/my-sites/jetpack-manage-error-page/index.jsx
+++ b/client/my-sites/jetpack-manage-error-page/index.jsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -12,73 +13,72 @@ import EmptyContent from 'components/empty-content';
 import FeatureExample from 'components/feature-example';
 import { getSiteSlug, getJetpackSiteRemoteManagementUrl } from 'state/sites/selectors';
 
-const JetpackManageErrorPage = React.createClass( {
-	actionCallbacks: {
+class JetpackManageErrorPage extends Component {
+	static actionCallbacks = {
 		updateJetpack: 'actionCallbackUpdate',
 		optInManage: 'actionCallbackActivate'
-	},
+	}
 
-	actionCallbackActivate() {
+	actionCallbackActivate = () => {
 		analytics.ga.recordEvent( 'Jetpack', 'Activate manage', 'Site', this.props.site ? this.props.site.ID : null );
-	},
+	}
 
-	actionCallbackUpdate() {
+	actionCallbackUpdate = () => {
 		analytics.ga.recordEvent( 'Jetpack', 'Update jetpack', 'Site', this.props.site ? this.props.site.ID : null );
-	},
+	}
 
 	getSettings() {
+		const { remoteManagementUrl, section, siteSlug, template, translate } = this.props;
 		const version = this.props.version || '3.4';
 		const defaults = {
 			updateJetpack: {
-				title: this.translate( 'Your version of Jetpack is out of date.' ),
-				line: this.translate( 'Jetpack %(version)s or higher is required to see this page.', { args: { version: version } } ),
-				action: this.translate( 'Update Jetpack' ),
+				title: translate( 'Your version of Jetpack is out of date.' ),
+				line: translate( 'Jetpack %(version)s or higher is required to see this page.', { args: { version } } ),
+				action: translate( 'Update Jetpack' ),
 				illustration: null,
-				actionURL: '../../plugins/jetpack/' + this.props.siteSlug,
-				version: version
+				actionURL: '../../plugins/jetpack/' + siteSlug,
+				version
 			},
 			optInManage: {
-				title: this.translate( 'Looking to manage this site from WordPress.com?' ),
-				line: this.translate( 'We need you to enable the Manage feature in the Jetpack plugin on your remote site' ),
+				title: translate( 'Looking to manage this site from WordPress.com?' ),
+				line: translate( 'We need you to enable the Manage feature in the Jetpack plugin on your remote site' ),
 				illustration: '/calypso/images/jetpack/jetpack-manage.svg',
-				action: this.translate( 'Enable Jetpack Manage' ),
-				actionURL: this.props.remoteManagementUrl + ( this.props.section ? '&section=' + this.props.section : '' ),
+				action: translate( 'Enable Jetpack Manage' ),
+				actionURL: remoteManagementUrl + ( section ? '&section=' + section : '' ),
 				actionTarget: '_blank'
 			},
 			noDomainsOnJetpack: {
-				title: this.translate( 'Domains are not available for this site.' ),
-				line: this.translate( 'You can only purchase domains for sites hosted on WordPress.com at this time.' ),
-				action: this.translate( 'View Plans' ),
-				actionURL: '/plans/' + ( this.props.siteSlug || '' )
+				title: translate( 'Domains are not available for this site.' ),
+				line: translate( 'You can only purchase domains for sites hosted on WordPress.com at this time.' ),
+				action: translate( 'View Plans' ),
+				actionURL: '/plans/' + ( siteSlug || '' )
 			},
 			'default': {}
 		};
-		return Object.assign( {}, defaults[ this.props.template ] || defaults.default, this.props );
-	},
+		return Object.assign( {}, defaults[ template ] || defaults.default, this.props );
+	}
 
 	render() {
 		const settings = this.getSettings();
-		if ( this.actionCallbacks[ this.props.template ] ) {
-			settings.actionCallback = this[ this.actionCallbacks[ this.props.template ] ];
+		if ( JetpackManageErrorPage.actionCallbacks[ this.props.template ] ) {
+			settings.actionCallback = this[ JetpackManageErrorPage.actionCallbacks[ this.props.template ] ];
 		}
-		const emptyContent = React.createElement( EmptyContent, settings );
 		const featureExample = this.props.featureExample
 			? <FeatureExample>{ this.props.featureExample }</FeatureExample>
 			: null;
 
 		return (
 			<div>
-				{ emptyContent }
+				<EmptyContent { ...settings } />
 				{ featureExample }
 			</div>
 		);
 	}
-
-} );
+}
 
 export default connect(
 	( state, { site } ) => ( {
 		siteSlug: getSiteSlug( state, site.ID ),
 		remoteManagementUrl: getJetpackSiteRemoteManagementUrl( state, site.ID )
 	} )
-)( JetpackManageErrorPage );
+)( localize( JetpackManageErrorPage ) );

--- a/client/my-sites/jetpack-manage-error-page/index.jsx
+++ b/client/my-sites/jetpack-manage-error-page/index.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux'
 import analytics from 'lib/analytics'
 import EmptyContent from 'components/empty-content'
 import FeatureExample from 'components/feature-example'
-import { getSiteSlug, getJetpackSiteRemoteManagementUrl, isJetpackSite } from 'state/sites/selectors'
+import { getSiteSlug, getJetpackSiteRemoteManagementUrl } from 'state/sites/selectors'
 
 const JetpackManageErrorPage = React.createClass( {
 
@@ -37,9 +37,7 @@ const JetpackManageErrorPage = React.createClass( {
 				line: this.translate( 'Jetpack %(version)s or higher is required to see this page.', { args: { version: version } } ),
 				action: this.translate( 'Update Jetpack' ),
 				illustration: null,
-				actionURL: ( this.props.site && this.props.isJetpack )
-					? '../../plugins/jetpack/' + this.props.siteSlug
-					: undefined,
+				actionURL: '../../plugins/jetpack/' + this.props.siteSlug,
 				version: version
 			},
 			optInManage: {
@@ -47,9 +45,7 @@ const JetpackManageErrorPage = React.createClass( {
 				line: this.translate( 'We need you to enable the Manage feature in the Jetpack plugin on your remote site' ),
 				illustration: '/calypso/images/jetpack/jetpack-manage.svg',
 				action: this.translate( 'Enable Jetpack Manage' ),
-				actionURL: ( this.props.site && this.props.isJetpack )
-					? this.props.remoteManagementUrl + ( this.props.section ? '&section=' + this.props.section : '' )
-					: undefined,
+				actionURL: this.props.remoteManagementUrl + ( this.props.section ? '&section=' + this.props.section : '' ),
 				actionTarget: '_blank'
 			},
 			noDomainsOnJetpack: {
@@ -86,7 +82,6 @@ const JetpackManageErrorPage = React.createClass( {
 export default connect(
 	( state, { site } ) => ( {
 		siteSlug: getSiteSlug( state, site.ID ),
-		remoteManagementUrl: getJetpackSiteRemoteManagementUrl( state, site.ID ),
-		isJetpack: isJetpackSite( state, site.ID )
+		remoteManagementUrl: getJetpackSiteRemoteManagementUrl( state, site.ID )
 	} )
 )( JetpackManageErrorPage );

--- a/client/my-sites/themes/jetpack-manage-disabled-message.jsx
+++ b/client/my-sites/themes/jetpack-manage-disabled-message.jsx
@@ -19,7 +19,7 @@ const JetpackManageDisabledMessage = React.createClass( {
 
 	propTypes: {
 		site: PropTypes.shape( {
-			getRemoteManagementURL: PropTypes.func.isRequired,
+			ID: PropTypes.number.isRequired,
 			options: PropTypes.shape( { admin_url: PropTypes.string.isRequired } ).isRequired
 		} ).isRequired
 	},

--- a/client/my-sites/themes/jetpack-upgrade-message.jsx
+++ b/client/my-sites/themes/jetpack-upgrade-message.jsx
@@ -13,7 +13,9 @@ import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 
 const JetpackUpgradeMessage = React.createClass( {
 	propTypes: {
-		site: PropTypes.object
+		site: PropTypes.shape( {
+			options: PropTypes.shape( { admin_url: PropTypes.string.isRequired } ).isRequired
+		} ).isRequired
 	},
 
 	render() {

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -856,7 +856,7 @@ export function verifyJetpackModulesActive( state, siteId, moduleIds ) {
  * @param {Number} siteId Site ID
  * @return {?String} the remote management url for the site
  */
-export function getJetpackSiteRemoteManagementURL( state, siteId ) {
+export function getJetpackSiteRemoteManagementUrl( state, siteId ) {
 	if ( ! isJetpackSite( state, siteId ) ) {
 		return null;
 	}

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -40,7 +40,7 @@ import {
 	hasJetpackSiteJetpackThemesExtendedFeatures,
 	isJetpackSiteSecondaryNetworkSite,
 	verifyJetpackModulesActive,
-	getJetpackSiteRemoteManagementURL,
+	getJetpackSiteRemoteManagementUrl,
 	hasJetpackSiteCustomDomain,
 	getJetpackSiteUpdateFilesDisabledReasons,
 	siteHasMinimumJetpackVersion,
@@ -1865,9 +1865,9 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( '#getJetpackSiteRemoteManagementURL()', () => {
+	describe( '#getJetpackSiteRemoteManagementUrl()', () => {
 		it( 'should return `null` for a non-existing site', () => {
-			const managementUrl = getJetpackSiteRemoteManagementURL( stateWithNoItems, nonExistingSiteId );
+			const managementUrl = getJetpackSiteRemoteManagementUrl( stateWithNoItems, nonExistingSiteId );
 			expect( managementUrl ).to.equal( null );
 		} );
 
@@ -1879,7 +1879,7 @@ describe( 'selectors', () => {
 				}
 			} );
 
-			const managementUrl = getJetpackSiteRemoteManagementURL( state, siteId );
+			const managementUrl = getJetpackSiteRemoteManagementUrl( state, siteId );
 			expect( managementUrl ).to.equal( null );
 		} );
 
@@ -1897,7 +1897,7 @@ describe( 'selectors', () => {
 				}
 			} );
 
-			const managementUrl = getJetpackSiteRemoteManagementURL( state, siteId );
+			const managementUrl = getJetpackSiteRemoteManagementUrl( state, siteId );
 			expect( managementUrl ).to.equal( 'https://jetpacksite.me/wp-admin/admin.php?page=jetpack&configure=manage' );
 		} );
 
@@ -1915,7 +1915,7 @@ describe( 'selectors', () => {
 				}
 			} );
 
-			const managementUrl = getJetpackSiteRemoteManagementURL( state, siteId );
+			const managementUrl = getJetpackSiteRemoteManagementUrl( state, siteId );
 			expect( managementUrl ).to.equal( 'https://jetpacksite.me/wp-admin/admin.php?page=jetpack&configure=json-api' );
 		} );
 	} );


### PR DESCRIPTION
To unblock #8776.

Remove reliance on computed `site` attributes sourced from `lib/site/index.js` and `lib/site/jetpack.js`, instead using only values which are made available on the raw REST API site object, and use selectors where needed.

To test:
* You need a Jetpack site
* Create the conditions which will cause a `JetpackManageErrorPage` to appear:
  * Disable Jetpack Manage, or
  * Temporarily set [this](https://github.com/Automattic/wp-calypso/blob/783cfe8623baa689ecd202664a5df47feda284f1/client/lib/site/jetpack.js#L41) to an inexistent, high JP version
* Navigate to http://calypso.localhost:3000/design/<yourjetpacksite>
* Verify that the two buttons work. Also check analytics.
* Try the same for other sections that use the `JetpackManageErrorPage` component (e.g. http://calypso.localhost:3000/menus/<yourjetpacksite>)

QA:
Since the component is now `connect()`ed to Redux state, I've verified that each occurrence of `<JetpackManageErrorPage />` has a Redux `<Provider />` among its ancestors.

Supersedes #4162, fixes #4160.