### PR TITLE
Checkout: Make sure that cart's messages are displayed

### DIFF
--- a/client/my-sites/upgrades/cart/cart-messages-mixin.jsx
+++ b/client/my-sites/upgrades/cart/cart-messages-mixin.jsx
@@ -11,6 +11,12 @@ import notices from 'notices';
 import { getNewMessages } from 'lib/cart-values';
 
 module.exports = {
+	componentDidMount() {
+		// Makes sure that we display any messages from the current cart
+		// that might have been delivered when the cart was unmounted
+		this.displayCartMessages( this.props.cart );
+	},
+
 	componentWillReceiveProps( nextProps ) {
 		if ( ! nextProps.cart.hasLoadedFromServer ) {
 			return;


### PR DESCRIPTION
The change proposed in this PR ensures that when a shopping cart-like component (using the `cart-messages-mixin`) is re-mounted, the messages from the cart are shown. Without this patch, these messages would not be presented to the user (we only checked for new messages in `componentWillReceiveProps` which is [not called when the component is mounted](https://facebook.github.io/react/docs/react-component.html).

### Testing

This PR requires `D3223-code` on the backend. To make testing easier, I'd recommend hacking the backend to always return an error, for example, for a domain registration (as I've demonstrated below). Instructions on how to do that are with the backend patch.

Before:
![v7jlyiipcy](https://cloud.githubusercontent.com/assets/3392497/21876677/6dd504e0-d885-11e6-8311-fd72fe53fc71.gif)

After:
![m1quu6je3g](https://cloud.githubusercontent.com/assets/3392497/21876668/47e5cc24-d885-11e6-810f-bd5c1ca6d521.gif)