### PR TITLE
User suggestions: add Redux tests for state/users/suggestions

### DIFF
--- a/client/state/users/suggestions/actions.js
+++ b/client/state/users/suggestions/actions.js
@@ -13,14 +13,14 @@ import {
  * Returns an action object to be used in signalling that user suggestions for a site
  * have been received.
  *
- * @param  {Number} siteId  Site ID
- * @param  {Object} data    User suggestions
- * @return {Object}         Action object
+ * @param  {Number} siteId  	Site ID
+ * @param  {Object} suggestions User suggestions
+ * @return {Object}         	Action object
  */
-export function receiveUserSuggestions( siteId, data ) {
+export function receiveUserSuggestions( siteId, suggestions ) {
 	return {
 		type: USER_SUGGESTIONS_RECEIVE,
-		suggestions: data.suggestions,
+		suggestions,
 		siteId,
 	};
 }
@@ -41,10 +41,11 @@ export function requestUserSuggestions( siteId ) {
 
 		return wpcom.users().suggest( { site_id: siteId } )
 			.then( ( data ) => {
-				dispatch( receiveUserSuggestions( siteId, data ) );
+				dispatch( receiveUserSuggestions( siteId, data.suggestions ) );
 				dispatch( {
 					type: USER_SUGGESTIONS_REQUEST_SUCCESS,
 					siteId,
+					data,
 				} );
 			} )
 			.catch( ( error ) =>

--- a/client/state/users/suggestions/test/actions.js
+++ b/client/state/users/suggestions/test/actions.js
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import sinon from 'sinon';
+import { assert, expect } from 'chai';
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import useNock from 'test/helpers/use-nock';
+import {
+	USER_SUGGESTIONS_RECEIVE,
+	USER_SUGGESTIONS_REQUEST,
+	USER_SUGGESTIONS_REQUEST_SUCCESS,
+} from 'state/action-types';
+import { receiveUserSuggestions, requestUserSuggestions } from '../actions';
+
+const sampleSuccessResponse = require( './sample-response.json' );
+const siteId = 123;
+
+describe( 'actions', () => {
+	const spy = sinon.spy();
+
+	beforeEach( () => {
+		spy.reset();
+	} );
+
+	describe( '#receiveUserSuggestions()', () => {
+		it( 'should return an action object', () => {
+			const suggestions = [];
+			const action = receiveUserSuggestions( siteId, suggestions );
+
+			expect( action ).to.eql( {
+				type: USER_SUGGESTIONS_RECEIVE,
+				siteId,
+				suggestions,
+			} );
+		} );
+	} );
+
+	describe( '#requestUserSuggestions', () => {
+		useNock( nock => {
+			nock( 'https://public-api.wordpress.com:443' )
+				.get( '/rest/v1.1/users/suggest?site_id=' + siteId )
+				.reply( 200, deepFreeze( sampleSuccessResponse ) );
+		} );
+
+		it( 'should dispatch properly when receiving a valid response', () => {
+			const dispatchSpy = sinon.stub();
+			dispatchSpy.withArgs( sinon.match.instanceOf( Promise ) ).returnsArg( 0 );
+			const request = requestUserSuggestions( siteId )( dispatchSpy );
+
+			expect( dispatchSpy ).to.have.been.calledWith( {
+				type: USER_SUGGESTIONS_REQUEST,
+				siteId
+			} );
+
+			return request.then( () => {
+				expect( dispatchSpy ).to.have.been.calledWith( {
+					type: USER_SUGGESTIONS_REQUEST_SUCCESS,
+					data: sampleSuccessResponse,
+					siteId
+				} );
+
+				expect( dispatchSpy ).to.have.been.calledWith( {
+					type: USER_SUGGESTIONS_RECEIVE,
+					suggestions: sampleSuccessResponse.suggestions,
+					siteId
+				} );
+			} ).catch( ( err ) => {
+				assert.fail( err, undefined, 'errback should not have been called' );
+			} );
+		} );
+	} );
+} );

--- a/client/state/users/suggestions/test/reducer.js
+++ b/client/state/users/suggestions/test/reducer.js
@@ -1,0 +1,112 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import {
+	USER_SUGGESTIONS_RECEIVE,
+	USER_SUGGESTIONS_REQUEST,
+	USER_SUGGESTIONS_REQUEST_SUCCESS,
+	SERIALIZE,
+	DESERIALIZE,
+} from 'state/action-types';
+import { items, requesting } from '../reducer';
+
+describe( 'reducer', () => {
+	describe( '#items()', () => {
+		it( 'should default to an empty object', () => {
+			const state = items( undefined, {} );
+			expect( state ).to.eql( {} );
+		} );
+
+		it( 'should insert a new suggestion', () => {
+			const original = {
+				124: [
+					{ user_login: 'wordpress1' }
+				]
+			};
+			const newSuggestion = {
+				user_login: 'wordpress2',
+			};
+			const state = items( original, {
+				type: USER_SUGGESTIONS_RECEIVE,
+				suggestions: [ newSuggestion ],
+				siteId: 123
+			} );
+
+			expect( state[ 123 ][ 0 ] ).to.eql( newSuggestion );
+		} );
+	} );
+
+	describe( '#requesting()', () => {
+		it( 'should default to an empty object', () => {
+			const state = requesting( undefined, {} );
+			expect( state ).to.eql( {} );
+		} );
+
+		it( 'should index requesting state by site ID', () => {
+			const siteId = 123;
+			const state = requesting( undefined, {
+				type: USER_SUGGESTIONS_REQUEST,
+				siteId,
+			} );
+			expect( state ).to.eql( {
+				123: true
+			} );
+		} );
+
+		it( 'should accumulate requesting state for sites', () => {
+			const original = deepFreeze( {
+				124: false
+			} );
+			const state = requesting( original, {
+				type: USER_SUGGESTIONS_REQUEST,
+				siteId: 123
+			} );
+			expect( state ).to.eql( {
+				124: false,
+				123: true
+			} );
+		} );
+
+		it( 'should override previous requesting state', () => {
+			const original = deepFreeze( {
+				124: false,
+				123: true
+			} );
+			const state = requesting( original, {
+				type: USER_SUGGESTIONS_REQUEST_SUCCESS,
+				siteId: 123
+			} );
+
+			expect( state ).to.eql( {
+				124: false,
+				123: false
+			} );
+		} );
+
+		describe( 'persistence', () => {
+			it( 'never persists state', () => {
+				const original = deepFreeze( {
+					124: false,
+					123: true
+				} );
+				const state = requesting( original, { type: SERIALIZE } );
+				expect( state ).to.eql( {} );
+			} );
+
+			it( 'never loads persisted state', () => {
+				const original = deepFreeze( {
+					124: false,
+					123: true
+				} );
+				const state = requesting( original, { type: DESERIALIZE } );
+				expect( state ).to.eql( {} );
+			} );
+		} );
+	} );
+} );

--- a/client/state/users/suggestions/test/sample-response.json
+++ b/client/state/users/suggestions/test/sample-response.json
@@ -1,0 +1,10 @@
+{
+	"suggestions": [
+		{
+			"user_login": "wordpress1"
+		},
+		{
+			"user_login": "wordpress2"
+		}
+	]
+}

--- a/client/state/users/suggestions/test/selectors.js
+++ b/client/state/users/suggestions/test/selectors.js
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getUserSuggestions,
+	isRequestingUserSuggestions
+} from '../selectors';
+
+describe( 'selectors', () => {
+	describe( '#getUserSuggestions()', () => {
+		it( 'should return null if there is no suggestion available', () => {
+			const state = {
+				users: {
+					suggestions: {
+						items: {}
+					}
+				}
+			};
+			expect( getUserSuggestions( state, 123 ) ).to.equal( null );
+		} );
+
+		it( 'should return suggestions if they exist for a site ID', () => {
+			const firstSuggestion = { user_login: 'wordpress1' };
+			const secondSuggestion = { user_login: 'wordpress2' };
+			const state = {
+				users: {
+					suggestions: {
+						items: {
+							123: [
+								firstSuggestion,
+								secondSuggestion
+							]
+						}
+					}
+				}
+			};
+			expect( getUserSuggestions( state, 123 ) ).to.have.length( 2 );
+			expect( getUserSuggestions( state, 124 ) ).to.eql( null );
+		} );
+	} );
+
+	describe( '#isRequestingUserSuggestions()', () => {
+		it( 'should return true if requesting suggestions for the specified site', () => {
+			const state = {
+				users: {
+					suggestions: {
+						requesting: {
+							123: true,
+							124: false,
+						}
+					}
+				}
+			};
+			expect( isRequestingUserSuggestions( state, 123 ) ).to.equal( true );
+			expect( isRequestingUserSuggestions( state, 124 ) ).to.equal( false );
+		} );
+	} );
+} );


### PR DESCRIPTION
Adds tests to the Redux actions, reducers and selectors added by @donnapep in https://github.com/Automattic/wp-calypso/pull/9969.

- [x] Actions
- [x] Reducers
- [x] Selectors

### To test

Run `npm run test-client client/state/users/suggestions`.