### PR TITLE
Guided Tours: in API docs explain `toursSeen` and query args

### DIFF
--- a/client/layout/guided-tours/docs/API.md
+++ b/client/layout/guided-tours/docs/API.md
@@ -11,7 +11,7 @@ Tour is a React component that declares the top-level of a tour. It defines cond
 * `name`: (string) Unique name of tour in camelCase.
 * `version` (string): Version identifier. We use date string like "20161224".
 * `path` (string or array, optional): Use this prop to limit tour only to some path prefix (or more prefixes if array). Example: `[ '/stats', '/settings' ]`
-* `when` (function, optional): This is a Redux selector function. Use this to define conditions for the tour to start.
+* `when` (function, optional): This is a Redux selector function. Use this to define conditions for the tour to start. Can be overridden by adding a `tour` query argument to the URL like so: `?tour=tourName`, in which case the tour will be triggered even if `when` would evaluate to `false`. This is useful for sending along a tour via email or chat. On the other hand, the framework will try to not trigger a tour multiple times (see `toursSeen` in [ARCHITECTURE.md](./ARCHITECTURE.md)). 
 * `children` (nodes): only supported type is `<Step>`
 
 ### Example


### PR DESCRIPTION
To test:

See the change to the API docs — does this make sense? Is this the right place to write this? 