### PR TITLE
Installing theme visual indication.

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -71,6 +71,7 @@ $z-layers: (
 		'.signup-processing-screen__processing-step.is-processing:before': 1,
 		'.accessible-focus .theme__more-button button:focus': 1,
 		'.domain-suggestion.is-clickable:hover': 1,
+		'.is-installing .theme': 2,
 		'.reader-update-notice': 2,
 		'.people-list-item .card__link-indicator': 2,
 		'.updated-confirmation': 2,

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -13,6 +13,7 @@ import Card from 'components/card';
 import ThemeMoreButton from './more-button';
 import Gridicon from 'components/gridicon';
 import TrackInteractions from 'components/track-interactions';
+import PulsingDot from 'components/pulsing-dot';
 
 /**
  * Component
@@ -67,6 +68,7 @@ const Theme = React.createClass( {
 		return nextProps.theme.id !== this.props.theme.id ||
 			( nextProps.active !== this.props.active ) ||
 			( nextProps.purchased !== this.props.purchased ) ||
+			( nextProps.installing !== this.props.installing ) ||
 			! isEqual( Object.keys( nextProps.buttonContents ), Object.keys( this.props.buttonContents ) ) ||
 			( nextProps.screenshotClickUrl !== this.props.screenshotClickUrl ) ||
 			( nextProps.onScreenshotClick !== this.props.onScreenshotClick ) ||
@@ -109,6 +111,16 @@ const Theme = React.createClass( {
 		}
 	},
 
+	renderInstalling() {
+		if ( this.props.installing ) {
+			return (
+				<div className="theme__installing" >
+					<PulsingDot active={ true } />
+				</div>
+			);
+		}
+	},
+
 	render() {
 		const {
 			name,
@@ -137,6 +149,7 @@ const Theme = React.createClass( {
 				<div className="theme__content">
 					{ this.renderHover() }
 					<a href={ this.props.screenshotClickUrl }>
+						{ this.renderInstalling() }
 						{ screenshot
 							? <img className="theme__img"
 								src={ screenshot + '?w=' + screenshotWidth }

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -55,6 +55,8 @@ $theme-info-height: 54px;
 		}
 	}
 
+
+
 	&.is-placeholder {
 		background-color: lighten( $gray, 20% );
 		animation: loading-fade 1.6s ease-in-out infinite;
@@ -156,6 +158,16 @@ $theme-info-height: 54px;
 		left: 0;
 		right: 0;
 	height: $theme-info-height;
+}
+
+.theme__installing {
+	background: transparentize($gray-dark, 0.5);
+	width: 100%;
+	left: 0;
+	top: 0;
+	bottom: 54px;
+	position: absolute;
+	z-index: z-index( 'root', '.is-installing .theme' );
 }
 
 .theme__more-button {

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -165,9 +165,12 @@ $theme-info-height: 54px;
 	width: 100%;
 	left: 0;
 	top: 0;
-	bottom: 54px;
+	bottom: $theme-info-height;
 	position: absolute;
 	z-index: z-index( 'root', '.is-installing .theme' );
+	.pulsing-dot {
+		top: 50%;
+	}
 }
 
 .theme__more-button {

--- a/client/components/themes-list/test/index.jsx
+++ b/client/components/themes-list/test/index.jsx
@@ -17,7 +17,7 @@ describe( 'ThemesList', function() {
 	useMockery( mockery => {
 		React = require( 'react' );
 		TestUtils = require( 'react-addons-test-utils' );
-
+		mockery.registerMock( 'components/pulsing-dot', React.createClass( { render: () => <div/> } ) );
 		mockery.registerMock( './more-button', React.createClass( { render: () => <div/> } ) );
 		ThemesList = require( '../' ).ThemesList;
 	} );

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -516,11 +516,12 @@ export function hasActivatedTheme( state, siteId ) {
  * Whether the theme is currently being installed on the (Jetpack) site.
  *
  * @param  {Object}  state   Global state tree
+ * @param  {String}  themeId Theme ID for which we check installing state
  * @param  {Number}  siteId  Site ID
  * @return {Boolean}         True if theme installation is ongoing
  */
-export function isInstallingTheme( state, siteId ) {
-	return get( state.themes.themeInstalls, siteId, false );
+export function isInstallingTheme( state, themeId, siteId ) {
+	return get( state.themes.themeInstalls, [ siteId, themeId ], false );
 }
 
 /**

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -1594,10 +1594,13 @@ describe( 'themes selectors', () => {
 				{
 					themes: {
 						themeInstalls: {
-							2916284: true
+							2916284: {
+								karuna: true
+							}
 						}
 					}
 				},
+				'karuna',
 				2916284
 			);
 


### PR DESCRIPTION
### Info
This is for WP.com theme installation on Jetpack site. Because it may take significant amount of time(for example flaky connection) for theme to install we need to give user visual clue that the process is ongoing.

### How it looks
Theme gets grayed out and pulsating dot appears.
![installing](https://cloud.githubusercontent.com/assets/17271089/21890126/849d20da-d8cc-11e6-9afb-295b87086ceb.gif)

### Testing open Jetpack site and click `Try&Customize` from the ellipsis menu.