### PR TITLE
Jetpack Settings: Add notices for (de)activating Jetpack modules

### DIFF
--- a/client/state/notices/jetpack-modules/constants.js
+++ b/client/state/notices/jetpack-modules/constants.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import {
+	JETPACK_MODULE_ACTIVATE_FAILURE as ACTIVATE_FAILURE,
+	JETPACK_MODULE_ACTIVATE_SUCCESS as ACTIVATE_SUCCESS,
+	JETPACK_MODULE_DEACTIVATE_FAILURE as DEACTIVATE_FAILURE,
+	JETPACK_MODULE_DEACTIVATE_SUCCESS as DEACTIVATE_SUCCESS,
+} from 'state/action-types';
+
+export const MODULE_NOTICES = {
+	'infinite-scroll': {
+		[ ACTIVATE_SUCCESS ]: translate( 'Infinite scroll has been enabled for your theme.' ),
+		[ DEACTIVATE_SUCCESS ]: translate( 'Infinite scroll has been disabled for your theme.' ),
+		[ ACTIVATE_FAILURE ]: translate( 'Infinite scroll could not be enabled for your theme.' ),
+		[ DEACTIVATE_FAILURE ]: translate( 'Infinite scroll could not be disabled for your theme.' ),
+	},
+};

--- a/client/state/notices/jetpack-modules/constants.js
+++ b/client/state/notices/jetpack-modules/constants.js
@@ -15,9 +15,9 @@ import {
 
 export const MODULE_NOTICES = {
 	'infinite-scroll': {
-		[ ACTIVATE_SUCCESS ]: translate( 'Infinite scroll has been enabled for your theme.' ),
-		[ DEACTIVATE_SUCCESS ]: translate( 'Infinite scroll has been disabled for your theme.' ),
-		[ ACTIVATE_FAILURE ]: translate( 'Infinite scroll could not be enabled for your theme.' ),
-		[ DEACTIVATE_FAILURE ]: translate( 'Infinite scroll could not be disabled for your theme.' ),
+		[ ACTIVATE_SUCCESS ]: translate( 'Infinite scroll is now on.' ),
+		[ DEACTIVATE_SUCCESS ]: translate( 'Infinite scroll is now off.' ),
+		[ ACTIVATE_FAILURE ]: translate( 'Infinite scroll could not be switched on.' ),
+		[ DEACTIVATE_FAILURE ]: translate( 'Infinite scroll could not be switched off.' ),
 	},
 };

--- a/client/state/notices/jetpack-modules/index.js
+++ b/client/state/notices/jetpack-modules/index.js
@@ -22,11 +22,11 @@ export const onJetpackModuleActivationActionMessage = ( dispatch, { type, module
 
 	switch ( type ) {
 		case JETPACK_MODULE_ACTIVATE_SUCCESS:
-			message = message || translate( 'Activated successfully.' );
+			message = message || translate( 'Turned on successfully.' );
 			messageType = 'success';
 			break;
 		case JETPACK_MODULE_DEACTIVATE_SUCCESS:
-			message = message || translate( 'Deactivated successfully.' );
+			message = message || translate( 'Turned off successfully.' );
 			messageType = 'success';
 			break;
 		case JETPACK_MODULE_ACTIVATE_FAILURE:

--- a/client/state/notices/jetpack-modules/index.js
+++ b/client/state/notices/jetpack-modules/index.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import {
+	JETPACK_MODULE_ACTIVATE_FAILURE,
+	JETPACK_MODULE_ACTIVATE_SUCCESS,
+	JETPACK_MODULE_DEACTIVATE_FAILURE,
+	JETPACK_MODULE_DEACTIVATE_SUCCESS,
+} from 'state/action-types';
+import { MODULE_NOTICES } from './constants';
+import { successNotice, errorNotice } from 'state/notices/actions';
+
+export const onJetpackModuleActivationActionMessage = ( dispatch, { type, moduleSlug } ) => {
+	const noticeSettings = { duration: 10000 };
+	let message = MODULE_NOTICES[ moduleSlug ] && MODULE_NOTICES[ moduleSlug ][ type ];
+	let messageType;
+
+	switch ( type ) {
+		case JETPACK_MODULE_ACTIVATE_SUCCESS:
+			message = message || translate( 'Activated successfully.' );
+			messageType = 'success';
+			break;
+		case JETPACK_MODULE_DEACTIVATE_SUCCESS:
+			message = message || translate( 'Deactivated successfully.' );
+			messageType = 'success';
+			break;
+		case JETPACK_MODULE_ACTIVATE_FAILURE:
+			message = message || translate( 'An error occurred during activation.' );
+			messageType = 'error';
+			break;
+		case JETPACK_MODULE_DEACTIVATE_FAILURE:
+			message = message || translate( 'An error occurred during deactivation.' );
+			messageType = 'error';
+			break;
+	}
+
+	if ( ! message ) {
+		return;
+	}
+
+	if ( messageType === 'success' ) {
+		dispatch( successNotice( message, noticeSettings ) );
+	} else if ( messageType === 'error' ) {
+		dispatch( errorNotice( message, noticeSettings ) );
+	}
+};

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -23,6 +23,10 @@ import {
 	GRAVATAR_UPLOAD_REQUEST_FAILURE,
 	GRAVATAR_UPLOAD_REQUEST_SUCCESS,
 	GUIDED_TRANSFER_HOST_DETAILS_SAVE_SUCCESS,
+	JETPACK_MODULE_ACTIVATE_SUCCESS,
+	JETPACK_MODULE_DEACTIVATE_SUCCESS,
+	JETPACK_MODULE_ACTIVATE_FAILURE,
+	JETPACK_MODULE_DEACTIVATE_FAILURE,
 	KEYRING_CONNECTION_DELETE,
 	POST_DELETE_FAILURE,
 	POST_DELETE_SUCCESS,
@@ -56,6 +60,7 @@ import {
 	onAccountRecoveryPhoneValidationSuccess,
 	onAccountRecoveryPhoneValidationFailed,
 } from './account-recovery';
+import { onJetpackModuleActivationActionMessage } from './jetpack-modules';
 
 /**
  * Handlers
@@ -190,6 +195,10 @@ export const handlers = {
 	},
 	[ GRAVATAR_UPLOAD_REQUEST_FAILURE ]: dispatchError( translate( 'New Gravatar was not saved.' ) ),
 	[ GRAVATAR_UPLOAD_REQUEST_SUCCESS ]: dispatchSuccess( translate( 'New Gravatar uploaded successfully!' ) ),
+	[ JETPACK_MODULE_ACTIVATE_SUCCESS ]: onJetpackModuleActivationActionMessage,
+	[ JETPACK_MODULE_DEACTIVATE_SUCCESS ]: onJetpackModuleActivationActionMessage,
+	[ JETPACK_MODULE_ACTIVATE_FAILURE ]: onJetpackModuleActivationActionMessage,
+	[ JETPACK_MODULE_DEACTIVATE_FAILURE ]: onJetpackModuleActivationActionMessage,
 	[ KEYRING_CONNECTION_DELETE ]: onPublicizeConnectionDelete,
 	[ POST_DELETE_FAILURE ]: onPostDeleteFailure,
 	[ POST_DELETE_SUCCESS ]: dispatchSuccess( translate( 'Post successfully deleted' ) ),


### PR DESCRIPTION
### Purpose

This PR introduces a universal handler for dispatching notices upon activation and deactivation of Jetpack modules. This will allow us to configure specific notices on a per-module basis when activating/deactivating modules, but it will still default to a generic message if we haven't configured specific notices for a certain module. This PR is part of #9171. 

### Advantages and further configuration
This approach will allow easy configuration of the notices on a per-module basis - if one wishes to specify notices for a certain module, all that needs to be done is to add the following snippet to the `constants.js` file:

```
'module-slug': {
	[ ACTIVATE_SUCCESS ]: translate( 'Message when activation was successful.' ),
	[ DEACTIVATE_SUCCESS ]: translate( 'Message when deactivation was successful.' ),
	[ ACTIVATE_FAILURE ]: translate( 'Message when activation was not successful.' ),
	[ DEACTIVATE_FAILURE ]: translate( 'Message when deactivation was not successful.' ),
},
```

where there are 5 strings to configure:

* `module-name` - the slug of the module - for example `infinite-scroll`, `minileven`, etc.
* 4 separate strings for each of the combinations (success/failure on activation/deactivation).

This PR adds an example set of specific notices for the `infinite-scroll` module. We can use them as basis for creating other specific notices.

### Preview

#### Successful activation of module with specific notices
![](https://cldup.com/PLEd11hmOi.png)

#### Error during activation of module with specific notices
![](https://cldup.com/r1rlqWe0Ub.png)

#### Successful activation of module without specific notices
![](https://cldup.com/_GJXw866SJ.png)

#### Error during deactivation of module without specific notices
![](https://cldup.com/_vJ0xnw0tY.png)

### To test

* Checkout this branch, or get it going on calypso.live
* Load any Calypso page.
* Open the development console in your browser
* Run the following in your console:
  * To test the handler for module with specific notices:
    * `dispatch( { type: 'JETPACK_MODULE_ACTIVATE_SUCCESS', moduleSlug: 'infinite-scroll' } )`
    * `dispatch( { type: 'JETPACK_MODULE_ACTIVATE_FAILURE', moduleSlug: 'infinite-scroll' } )`
    * `dispatch( { type: 'JETPACK_MODULE_DEACTIVATE_SUCCESS', moduleSlug: 'infinite-scroll' } )`
    * `dispatch( { type: 'JETPACK_MODULE_DEACTIVATE_FAILURE', moduleSlug: 'infinite-scroll' } )`
  * To test the handler for a module without specific notices:
    * `dispatch( { type: 'JETPACK_MODULE_ACTIVATE_SUCCESS', moduleSlug: 'minileven' } )`
    * `dispatch( { type: 'JETPACK_MODULE_ACTIVATE_FAILURE', moduleSlug: 'minileven' } )`
    * `dispatch( { type: 'JETPACK_MODULE_DEACTIVATE_SUCCESS', moduleSlug: 'minileven' } )`
    * `dispatch( { type: 'JETPACK_MODULE_DEACTIVATE_FAILURE', moduleSlug: 'minileven' } )`
* Verify that all notice messages and their colors make sense.