### PR TITLE
Sites: Add siteSupportsCalypsoSettingsUI() selector

### DIFF
--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -1020,3 +1020,15 @@ export const hasDefaultSiteTitle = ( state, siteId ) => {
 	// we are using startsWith here, as getSiteSlug returns "slug.wordpress.com"
 	return site.name === i18n.translate( 'Site Title' ) || startsWith( slug, site.name );
 };
+
+/**
+ * Returns true if the site supports managing Jetpack settings remotely.
+ * False otherwise.
+ *
+ * @param {Object} state  Global state tree
+ * @param {Object} siteId Site ID
+ * @return {?Boolean}     Whether site supports managing Jetpack settings remotely.
+ */
+export const siteSupportsCalypsoSettingsUI = ( state, siteId ) => {
+	return isJetpackMinimumVersion( state, siteId, '4.5.0' );
+};

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -1029,6 +1029,6 @@ export const hasDefaultSiteTitle = ( state, siteId ) => {
  * @param {Object} siteId Site ID
  * @return {?Boolean}     Whether site supports managing Jetpack settings remotely.
  */
-export const siteSupportsCalypsoSettingsUI = ( state, siteId ) => {
+export const siteSupportsJetpackSettingsUI = ( state, siteId ) => {
 	return isJetpackMinimumVersion( state, siteId, '4.5.0' );
 };

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -47,7 +47,7 @@ import {
 	isJetpackSiteMainNetworkSite,
 	getSiteAdminUrl,
 	getCustomizerUrl,
-	siteSupportsCalypsoSettingsUI
+	siteSupportsJetpackSettingsUI
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -2274,9 +2274,9 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'siteSupportsCalypsoSettingsUI()', () => {
+	describe( 'siteSupportsJetpackSettingsUI()', () => {
 		it( 'should return null if the Jetpack version is not known', () => {
-			const supportsCalypsoSettingsUI = siteSupportsCalypsoSettingsUI( {
+			const supportsCalypsoSettingsUI = siteSupportsJetpackSettingsUI( {
 				sites: {
 					items: {
 						77203074: {
@@ -2292,7 +2292,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should return null if the site is not a Jetpack site', () => {
-			const supportsCalypsoSettingsUI = siteSupportsCalypsoSettingsUI( {
+			const supportsCalypsoSettingsUI = siteSupportsJetpackSettingsUI( {
 				sites: {
 					items: {
 						77203074: {
@@ -2307,7 +2307,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should return false if the Jetpack version is older than 4.5', () => {
-			const supportsCalypsoSettingsUI = siteSupportsCalypsoSettingsUI( {
+			const supportsCalypsoSettingsUI = siteSupportsJetpackSettingsUI( {
 				sites: {
 					items: {
 						77203074: {
@@ -2326,7 +2326,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should return true if the Jetpack version is 4.5', () => {
-			const supportsCalypsoSettingsUI = siteSupportsCalypsoSettingsUI( {
+			const supportsCalypsoSettingsUI = siteSupportsJetpackSettingsUI( {
 				sites: {
 					items: {
 						77203074: {
@@ -2345,7 +2345,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should return true if the Jetpack version is newer than 4.5', () => {
-			const supportsCalypsoSettingsUI = siteSupportsCalypsoSettingsUI( {
+			const supportsCalypsoSettingsUI = siteSupportsJetpackSettingsUI( {
 				sites: {
 					items: {
 						77203074: {

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -46,7 +46,8 @@ import {
 	siteHasMinimumJetpackVersion,
 	isJetpackSiteMainNetworkSite,
 	getSiteAdminUrl,
-	getCustomizerUrl
+	getCustomizerUrl,
+	siteSupportsCalypsoSettingsUI
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -2270,6 +2271,96 @@ describe( 'selectors', () => {
 
 				expect( customizerUrl ).to.equal( 'https://example.com/wp-admin/customize.php' );
 			} );
+		} );
+	} );
+
+	describe( 'siteSupportsCalypsoSettingsUI()', () => {
+		it( 'should return null if the Jetpack version is not known', () => {
+			const supportsCalypsoSettingsUI = siteSupportsCalypsoSettingsUI( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://example.com',
+							jetpack: true,
+						}
+					}
+				}
+			}, 77203074 );
+
+			expect( supportsCalypsoSettingsUI ).to.be.null;
+		} );
+
+		it( 'should return null if the site is not a Jetpack site', () => {
+			const supportsCalypsoSettingsUI = siteSupportsCalypsoSettingsUI( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://example.com',
+						}
+					}
+				}
+			}, 77203074 );
+
+			expect( supportsCalypsoSettingsUI ).to.be.null;
+		} );
+
+		it( 'should return false if the Jetpack version is older than 4.5', () => {
+			const supportsCalypsoSettingsUI = siteSupportsCalypsoSettingsUI( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://example.com',
+							jetpack: true,
+							options: {
+								jetpack_version: '4.4.0'
+							}
+						}
+					}
+				}
+			}, 77203074 );
+
+			expect( supportsCalypsoSettingsUI ).to.be.false;
+		} );
+
+		it( 'should return true if the Jetpack version is 4.5', () => {
+			const supportsCalypsoSettingsUI = siteSupportsCalypsoSettingsUI( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://example.com',
+							jetpack: true,
+							options: {
+								jetpack_version: '4.5.0'
+							}
+						}
+					}
+				}
+			}, 77203074 );
+
+			expect( supportsCalypsoSettingsUI ).to.be.true;
+		} );
+
+		it( 'should return true if the Jetpack version is newer than 4.5', () => {
+			const supportsCalypsoSettingsUI = siteSupportsCalypsoSettingsUI( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://example.com',
+							jetpack: true,
+							options: {
+								jetpack_version: '4.6.0'
+							}
+						}
+					}
+				}
+			}, 77203074 );
+
+			expect( supportsCalypsoSettingsUI ).to.be.true;
 		} );
 	} );
 } );

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -2276,7 +2276,7 @@ describe( 'selectors', () => {
 
 	describe( 'siteSupportsJetpackSettingsUI()', () => {
 		it( 'should return null if the Jetpack version is not known', () => {
-			const supportsCalypsoSettingsUI = siteSupportsJetpackSettingsUI( {
+			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUI( {
 				sites: {
 					items: {
 						77203074: {
@@ -2288,11 +2288,11 @@ describe( 'selectors', () => {
 				}
 			}, 77203074 );
 
-			expect( supportsCalypsoSettingsUI ).to.be.null;
+			expect( supportsJetpackSettingsUI ).to.be.null;
 		} );
 
 		it( 'should return null if the site is not a Jetpack site', () => {
-			const supportsCalypsoSettingsUI = siteSupportsJetpackSettingsUI( {
+			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUI( {
 				sites: {
 					items: {
 						77203074: {
@@ -2303,11 +2303,11 @@ describe( 'selectors', () => {
 				}
 			}, 77203074 );
 
-			expect( supportsCalypsoSettingsUI ).to.be.null;
+			expect( supportsJetpackSettingsUI ).to.be.null;
 		} );
 
 		it( 'should return false if the Jetpack version is older than 4.5', () => {
-			const supportsCalypsoSettingsUI = siteSupportsJetpackSettingsUI( {
+			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUI( {
 				sites: {
 					items: {
 						77203074: {
@@ -2322,11 +2322,11 @@ describe( 'selectors', () => {
 				}
 			}, 77203074 );
 
-			expect( supportsCalypsoSettingsUI ).to.be.false;
+			expect( supportsJetpackSettingsUI ).to.be.false;
 		} );
 
 		it( 'should return true if the Jetpack version is 4.5', () => {
-			const supportsCalypsoSettingsUI = siteSupportsJetpackSettingsUI( {
+			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUI( {
 				sites: {
 					items: {
 						77203074: {
@@ -2341,11 +2341,11 @@ describe( 'selectors', () => {
 				}
 			}, 77203074 );
 
-			expect( supportsCalypsoSettingsUI ).to.be.true;
+			expect( supportsJetpackSettingsUI ).to.be.true;
 		} );
 
 		it( 'should return true if the Jetpack version is newer than 4.5', () => {
-			const supportsCalypsoSettingsUI = siteSupportsJetpackSettingsUI( {
+			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUI( {
 				sites: {
 					items: {
 						77203074: {
@@ -2360,7 +2360,7 @@ describe( 'selectors', () => {
 				}
 			}, 77203074 );
 
-			expect( supportsCalypsoSettingsUI ).to.be.true;
+			expect( supportsJetpackSettingsUI ).to.be.true;
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR introduces a very simple selector to determine whether a site supports managing Jetpack settings remotely, in other words, whether it supports our new Calypso Jetpack Settings UI - `siteSupportsJetpackSettingsUI()`. Basically any site with Jetpack >= 4.5 will support it, because that's when https://github.com/Automattic/jetpack/pull/5418 first lands.

I realize it might seem redundant to have that selector, but since we'll be using this version check dozens of times, it's recommended that we have just one place to change it, and some tests are always helpful.

To test:
* Checkout this branch
* Verify the tests are passing: 
```npm run test-client client/state/sites/test/selectors.js -- --grep="siteSupportsJetpackSettingsUI"```
* Verify that the selector name makes sense 😆 

