### PR TITLE
Jetpack: Fix remote management URL

### DIFF
--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -103,7 +103,7 @@ JetpackSite.prototype.verifyModulesActive = function( moduleIds, callback ) {
 };
 
 JetpackSite.prototype.getRemoteManagementURL = function() {
-	var configure = versionCompare( this.options.jetpack_version, 3.4 ) ? 'manage' : 'json-api';
+	var configure = versionCompare( this.options.jetpack_version, 3.4, '>=' ) ? 'manage' : 'json-api';
 	return this.options.admin_url + 'admin.php?page=jetpack&configure=' + configure;
 };
 

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -863,7 +863,7 @@ export function getJetpackSiteRemoteManagementUrl( state, siteId ) {
 
 	const siteJetpackVersion = getSiteOption( state, siteId, 'jetpack_version' ),
 		siteAdminUrl = getSiteOption( state, siteId, 'admin_url' ),
-		configure = versionCompare( siteJetpackVersion, '3.4' ) < 0 ? 'manage' : 'json-api';
+		configure = versionCompare( siteJetpackVersion, '3.4', '>=' ) ? 'manage' : 'json-api';
 
 	return siteAdminUrl + 'admin.php?page=jetpack&configure=' + configure;
 }

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -1898,7 +1898,7 @@ describe( 'selectors', () => {
 			} );
 
 			const managementUrl = getJetpackSiteRemoteManagementUrl( state, siteId );
-			expect( managementUrl ).to.equal( 'https://jetpacksite.me/wp-admin/admin.php?page=jetpack&configure=manage' );
+			expect( managementUrl ).to.equal( 'https://jetpacksite.me/wp-admin/admin.php?page=jetpack&configure=json-api' );
 		} );
 
 		it( 'it should return the correct url for versions of jetpack greater than or equal to 3.4', () => {
@@ -1916,7 +1916,7 @@ describe( 'selectors', () => {
 			} );
 
 			const managementUrl = getJetpackSiteRemoteManagementUrl( state, siteId );
-			expect( managementUrl ).to.equal( 'https://jetpacksite.me/wp-admin/admin.php?page=jetpack&configure=json-api' );
+			expect( managementUrl ).to.equal( 'https://jetpacksite.me/wp-admin/admin.php?page=jetpack&configure=manage' );
 		} );
 	} );
 


### PR DESCRIPTION
The check was backwards in state/sites/selectors#getJetpackSiteRemoteManagementUrl, and even more broken in lib/site/jetpack#getRemoteManagementURL.

FYI @Tug 