### PR TITLE
JetpackManageErrorPage: Accept site ID instead of object prop

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -295,7 +295,7 @@ module.exports = {
 				<Main>
 					<JetpackManageErrorPage
 						template="noDomainsOnJetpack"
-						site={ sites.getSelectedSite() }
+						siteId={ sites.getSelectedSite().ID }
 					/>
 				</Main>
 			), document.getElementById( 'primary' ), context.store );

--- a/client/my-sites/jetpack-manage-error-page/README.md
+++ b/client/my-sites/jetpack-manage-error-page/README.md
@@ -22,7 +22,7 @@ import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 
 <JetpackManageErrorPage
     template="updateJetpack"
-    site={ JetpackSite }
+    siteId={ jetpackSiteId }
     version="3.4"
 />
 ```
@@ -34,7 +34,7 @@ To display a page that will prompt the user to opt-in to Jetpack manage:
 ```jsx
 <JetpackManageErrorPage
     template="optInManage"
-    site={ this.props.site }
+    siteId={ this.props.siteId }
 />
 ```
 

--- a/client/my-sites/jetpack-manage-error-page/index.jsx
+++ b/client/my-sites/jetpack-manage-error-page/index.jsx
@@ -20,11 +20,11 @@ class JetpackManageErrorPage extends Component {
 	}
 
 	actionCallbackActivate = () => {
-		analytics.ga.recordEvent( 'Jetpack', 'Activate manage', 'Site', this.props.site ? this.props.site.ID : null );
+		analytics.ga.recordEvent( 'Jetpack', 'Activate manage', 'Site', this.props.siteId );
 	}
 
 	actionCallbackUpdate = () => {
-		analytics.ga.recordEvent( 'Jetpack', 'Update jetpack', 'Site', this.props.site ? this.props.site.ID : null );
+		analytics.ga.recordEvent( 'Jetpack', 'Update jetpack', 'Site', this.props.siteId );
 	}
 
 	getSettings() {
@@ -77,8 +77,8 @@ class JetpackManageErrorPage extends Component {
 }
 
 export default connect(
-	( state, { site } ) => ( {
-		siteSlug: getSiteSlug( state, site.ID ),
-		remoteManagementUrl: getJetpackSiteRemoteManagementUrl( state, site.ID )
+	( state, { siteId } ) => ( {
+		siteSlug: getSiteSlug( state, siteId ),
+		remoteManagementUrl: getJetpackSiteRemoteManagementUrl( state, siteId )
 	} )
 )( localize( JetpackManageErrorPage ) );

--- a/client/my-sites/jetpack-manage-error-page/index.jsx
+++ b/client/my-sites/jetpack-manage-error-page/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -13,7 +13,7 @@ import EmptyContent from 'components/empty-content';
 import FeatureExample from 'components/feature-example';
 import { getSiteSlug, getJetpackSiteRemoteManagementUrl } from 'state/sites/selectors';
 
-class JetpackManageErrorPage extends Component {
+class JetpackManageErrorPage extends PureComponent {
 	static actionCallbacks = {
 		updateJetpack: 'actionCallbackUpdate',
 		optInManage: 'actionCallbackActivate'

--- a/client/my-sites/menus/main.jsx
+++ b/client/my-sites/menus/main.jsx
@@ -224,7 +224,7 @@ var Menus = React.createClass( {
 				<JetpackManageErrorPage
 					template="optInManage"
 					title={ this.translate( 'Looking to manage this site\'s menus?' ) }
-					site={ site }
+					siteId={ site.ID }
 					section="menus"
 					secondaryAction={ this.translate( 'Open Classic Menu Editor' ) }
 					secondaryActionURL={ site.options.admin_url + 'nav-menus.php' }

--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -63,7 +63,7 @@ export default React.createClass( {
 					<SidebarNavigation />
 					<JetpackManageErrorPage
 						template="updateJetpack"
-						site={ site }
+						siteId={ site.ID }
 						version="3.7"
 					/>
 				</Main>

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -182,7 +182,7 @@ const PlansSetup = React.createClass( {
 		this.trackConfigFinished( 'calypso_plans_autoconfig_error_wordpresscom' );
 		return (
 			<JetpackManageErrorPage
-				site={ this.props.selectedSite }
+				siteId={ this.props.siteId }
 				title={ this.props.translate( 'Oh no! You need to select a jetpack site to be able to setup your plan' ) }
 				illustration={ '/calypso/images/jetpack/jetpack-manage.svg' } />
 		);
@@ -210,7 +210,7 @@ const PlansSetup = React.createClass( {
 
 		return (
 			<JetpackManageErrorPage
-				site={ this.props.selectedSite }
+				siteId={ this.props.siteId }
 				action={ translate( 'Contact Support' ) }
 				actionURL={ support.JETPACK_CONTACT_SUPPORT }
 				title={ translate( 'Oh no! We can\'t install plugins on this site.' ) }

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -332,6 +332,7 @@ const PluginsMain = React.createClass( {
 			category,
 			search,
 			selectedSite,
+			selectedSiteId,
 		} = this.props;
 
 		if ( selectedSite && ! this.props.selectedSiteIsJetpack ) {
@@ -368,7 +369,7 @@ const PluginsMain = React.createClass( {
 					<SidebarNavigation />
 					<JetpackManageErrorPage
 						template="optInManage"
-						site={ selectedSite }
+						siteId={ selectedSiteId }
 						title={ this.translate( 'Looking to manage this site\'s plugins?' ) }
 						section="plugins"
 						featureExample={ this.getMockPluginItems() } />
@@ -431,6 +432,7 @@ export default connect(
 
 		return {
 			selectedSite,
+			selectedSiteId: selectedSite && selectedSite.ID,
 			selectedSiteSlug: getSelectedSiteSlug( state ),
 			selectedSiteIsJetpack: selectedSite && isJetpackSite( state, selectedSite.ID ),
 			canSelectedJetpackSiteManage: selectedSite && canJetpackSiteManage( state, selectedSite.ID ),

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -346,7 +346,7 @@ const SinglePlugin = React.createClass( {
 					<JetpackManageErrorPage
 						template="optInManage"
 						title={ this.translate( 'Looking to manage this site\'s plugins?' ) }
-						site={ selectedSite }
+						siteId={ selectedSite.ID }
 						section="plugins"
 						featureExample={ this.getMockPlugin() } />
 				</MainComponent>

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -301,7 +301,7 @@ const PluginsBrowser = React.createClass( {
 				<JetpackManageErrorPage
 					template="optInManage"
 					title={ this.translate( 'Looking to manage this site\'s plugins?' ) }
-					site={ selectedSite }
+					siteId={ selectedSite.ID }
 					section="plugins"
 					illustration="/calypso/images/jetpack/jetpack-manage.svg"
 					featureExample={ this.getMockPluginItems() } />

--- a/client/my-sites/site-settings/section-security.jsx
+++ b/client/my-sites/site-settings/section-security.jsx
@@ -41,7 +41,7 @@ module.exports = React.createClass( {
 					template="optInManage"
 					title= { this.translate( 'Looking to manage this site\'s security settings?' ) }
 					section="security-settings"
-					site={ site }
+					siteId={ site.ID }
 				/>
 			);
 		}
@@ -50,7 +50,7 @@ module.exports = React.createClass( {
 			return (
 				<JetpackManageErrorPage
 					template="updateJetpack"
-					site={ site }
+					siteId={ site.ID }
 					version="3.4"
 				/>
 			);

--- a/client/my-sites/themes/jetpack-manage-disabled-message.jsx
+++ b/client/my-sites/themes/jetpack-manage-disabled-message.jsx
@@ -62,7 +62,7 @@ const JetpackManageDisabledMessage = React.createClass( {
 				<JetpackManageErrorPage
 					template="optInManage"
 					title={ this.props.translate( 'Looking to manage this site\'s themes?' ) }
-					site={ this.props.site }
+					siteId={ this.props.site.ID }
 					section="themes"
 					secondaryAction={ this.props.translate( 'Open Site Theme Browser' ) }
 					secondaryActionURL={ this.props.site.options.admin_url + 'themes.php' }

--- a/client/my-sites/themes/jetpack-upgrade-message.jsx
+++ b/client/my-sites/themes/jetpack-upgrade-message.jsx
@@ -24,7 +24,7 @@ const JetpackUpgradeMessage = React.createClass( {
 				<SidebarNavigation />
 				<JetpackManageErrorPage
 					template="updateJetpack"
-					site={ this.props.site }
+					siteId={ this.props.site.ID }
 					version="3.7"
 					secondaryAction={ this.props.translate( 'Open Site Theme Browser' ) }
 					secondaryActionURL={ this.props.site.options.admin_url + 'themes.php' }


### PR DESCRIPTION
We're only really using the ID already, so this will allow for consumers to pass just the site ID (as obtained e.g. from the `getSelectedSiteId()` selector).

To test:
* Make sure the component still works. It's used in a number of places (see diff). Code-wise, I think it's fine to rely on the presence of `.ID` pretty much everywhere, since it's only rendered when a (Jetpack) site is given.

Preparation for #8776.

