### PR TITLE
Guided Tours: Improvements for API docs

### DIFF
--- a/client/layout/guided-tours/docs/API.md
+++ b/client/layout/guided-tours/docs/API.md
@@ -221,16 +221,16 @@ combineTours( {
 
 One of the features of Guided Tours is the ability to target DOM elements in Calypso. Targeting can be achieved in two ways:
 
-- `data-tip-target` attribute on the target element
+- `data-tip-target` attribute on the target element (recommended)
 - using any CSS selector
 
-To find the DOM node, `document.querySelector` is used. By default, the query used is `[data-tip-target="${target}"]`. However, if `target` starts with a dot or a space character, it will be treated like a standard selector and be passed directly to the function, thereby allowing you to target elements that do no set a `data-tip-target` attribute.
+To find the DOM node, `document.querySelector` is used. By default, the query used is `[data-tip-target="${target}"]`. However, if `target` starts with a dot or a space character, it will be treated like a standard selector and be passed directly to the function, thereby allowing you to target elements that do no set a `data-tip-target` attribute. We run the query selector on every render so it possible to move elements around.
 
 ### [data-tip-target]
 
-Mark a target by adding `data-tip-target="some-name"` attribute to it with your value. Please be specific to avoid conflicts and use dash-case.
+Mark a target by adding `data-tip-target="some-name"` attribute to it with your value. Please be specific to avoid conflicts and use dash-case. In your tour, just insert the value of your desired `[data-tip-target]` into the `target` prop.
 
-In your tour, just insert the value of your desired `[data-tip-target]` into the `target` prop.
+Using this method over CSS classes has several benefits, some of them are more explicit tagging of elements and decoupling the logic from CSS which should generally be used for styling. It is also less likely to be changed by somebody else as it has uncommon name and can be easily traced to Guided Tours Framework.
 
 Example: you want to position a step of your tour to point to some input element.
 
@@ -244,7 +244,7 @@ Example: you want to position a step of your tour to point to some input element
 
 ### CSS selector
 
-There are cases when it might be a better idea to target an element by a CSS selector.
+There are cases when it might be a better idea to target an element by a CSS selector. You might use some classes to get elements in certain state or you might not be 100% in control of the markup (think controls of an external library).
 
 You declare that you are using a CSS selector by starting a value of the `target` prop with a dot or a space character. Only one element can be used as a target: the first one matching the selector will be used.
 

--- a/client/layout/guided-tours/docs/API.md
+++ b/client/layout/guided-tours/docs/API.md
@@ -4,7 +4,7 @@ Guided Tours are declared in JSX as a tree of elements. All of them are availabl
 
 ## Tour
 
-Tour is a React component that declares the top-level of a tour. It consists of series of Step elements and it also defines when tour should start by setting appropriate props.
+Tour is a React component that declares the top-level of a tour. It consists of a series of Step elements and defines when a tour should start by setting appropriate props.
 
 ### Props
 
@@ -34,7 +34,7 @@ Step is a React component that defines a single Step of a tour. It is represente
 ### Props
 
 * `name`: (string) Unique identifier of the step, used for addressing a step from `Next` or `Continue`. Use `init` to indicate the step that the tour should start with.
-* `target`: (string, optional) Target which this step belongs to and which will be used for positioning. See [Targeting elements in Calypso](#targeting-elements-in-calypso) section for more info about the format.
+* `target`: (string, optional) Target which this step belongs to and which will be used for positioning. See [Targeting elements in Calypso](#targeting-elements-in-calypso) for more info about the format.
 * `placement`: (string, optional) Placement. Possible values: `below`, `above`, `beside`, `center`, `middle`, `right`.
 * `arrow`: (string, optional) If defined, the step will be rendered with an arrow on its border pointing in a given direction. Available: 'top-left', 'top-center', 'top-right', 'right-top', 'right-middle', 'right-bottom', 'bottom-left', 'bottom-center', 'bottom-right', 'left-top', 'left-middle', 'left-bottom'.
 * `style`: (object, optional) Will be used as the step's inline style. Use sparingly and with caution for minor tweaks in positioning or z-indexes and avoid changing the look and feel of Guided Tours. If you use this in a way that could benefit all of Guided Tours globally, please consider creating an issue. Example: `style={{backgroundColor: 'red'}}`
@@ -88,7 +88,7 @@ Continue is a React component that you can use in Step to programmatically conti
 ### Props
 
 * `step`: (string) Name of the step the tour will advance to.
-* `target`: (string, optional) DOM node that would be watched. See [Targeting elements in Calypso](#targeting-elements-in-calypso) section for more info about the format.
+* `target`: (string, optional) DOM node that would be watched. See [Targeting elements in Calypso](#targeting-elements-in-calypso) for more info about the format.
 * `click`: (bool, optional) If true, `onClick` will be listened on `target` DOM node.
 * `hidden`: (bool, optional) If true, this will not render anything in Step, while functionality remains.
 * `icon`: (string, optional) Name of Gridicon to show in custom message.
@@ -219,18 +219,18 @@ combineTours( {
 
 ## Targeting elements in Calypso
 
-In few places in GT you need to target a DOM elements in Calypso. There are currently two ways to do this:
+One of the features of Guided Tours is the ability to target DOM elements in Calypso. Targeting can be achieved in two ways:
 
 - `data-tip-target` attribute on the target element
-- using any css selector
+- using any CSS selector
 
 To find the DOM node, `document.querySelector` is used. By default, the query used is `[data-tip-target="${target}"]`. However, if `target` starts with a dot or a space character, it will be treated like a standard selector and be passed directly to the function, thereby allowing you to target elements that do no set a `data-tip-target` attribute.
 
 ### [data-tip-target]
 
-You mark a target by adding `data-tip-target="some-name"` attribute to it with your value. Please be specific to avoid conflicts and use dash-case.
+Mark a target by adding `data-tip-target="some-name"` attribute to it with your value. Please be specific to avoid conflicts and use dash-case.
 
-In your tour, just put a value of your desired `[data-tip-target]` into the `target` prop.
+In your tour, just insert the value of your desired `[data-tip-target]` into the `target` prop.
 
 Example: you want to position a step of your tour to point to some input element.
 
@@ -246,7 +246,7 @@ Example: you want to position a step of your tour to point to some input element
 
 There are cases when it might be a better idea to target an element by a CSS selector.
 
-You declare that you are using a CSS selector by starting a value of the `target` prop with a dot or a space character. Only single element can be used as a target - it will be the first one matching the selector.
+You declare that you are using a CSS selector by starting a value of the `target` prop with a dot or a space character. Only one element can be used as a target: the first one matching the selector will be used.
 
 Some examples:
 

--- a/client/layout/guided-tours/docs/API.md
+++ b/client/layout/guided-tours/docs/API.md
@@ -230,7 +230,7 @@ To find the DOM node, `document.querySelector` is used. By default, the query us
 
 You mark a target by adding `data-tip-target="some-name"` attribute to it with your value. Please be specific to avoid conflicts and use dash-case.
 
-In tour you just put a value of your `[data-tip-target]` into `target` prop.
+In your tour, just put a value of your desired `[data-tip-target]` into the `target` prop.
 
 Example: you want to position a step of your tour to point to some input element.
 
@@ -246,7 +246,7 @@ Example: you want to position a step of your tour to point to some input element
 
 There are cases when it might be a better idea to target an element by a CSS selector.
 
-You declare that you are using a css selector by starting a value of `target` prop with a dot or a space character. Only single element can be used as a target - it will be the first one matching the selector.
+You declare that you are using a CSS selector by starting a value of the `target` prop with a dot or a space character. Only single element can be used as a target - it will be the first one matching the selector.
 
 Some examples:
 

--- a/client/layout/guided-tours/docs/API.md
+++ b/client/layout/guided-tours/docs/API.md
@@ -34,7 +34,7 @@ Step is a React component that defines a single Step of a tour. It is represente
 ### Props
 
 * `name`: (string) Unique identifier of the step, used for addressing a step from `Next` or `Continue`. Use `init` to indicate the step that the tour should start with.
-* `target`: (string, optional) Target which this step belongs to and which will be used for positioning. The value of this prop is used to look up the corresponding DOM node. By default, the query used is `[data-tip-target="${target}"]`. However, if `target` starts with a dot or a space character, it will be treated like a standard selector and be passed directly to `document.querySelector`, thereby allowing you to target elements that do no set a `data-tip-target` attribute.
+* `target`: (string, optional) Target which this step belongs to and which will be used for positioning. See "Targeting elements in Calypso" for info about the format.
 * `placement`: (string, optional) Placement. Possible values: `below`, `above`, `beside`, `center`, `middle`, `right`.
 * `arrow`: (string, optional) If defined, the step will be rendered with an arrow on its border pointing in a given direction. Available: 'top-left', 'top-center', 'top-right', 'right-top', 'right-middle', 'right-bottom', 'bottom-left', 'bottom-center', 'bottom-right', 'left-top', 'left-middle', 'left-bottom'.
 * `style`: (object, optional) Will be used as the step's inline style. Use sparingly and with caution for minor tweaks in positioning or z-indexes and avoid changing the look and feel of Guided Tours. If you use this in a way that could benefit all of Guided Tours globally, please consider creating an issue. Example: `style={{backgroundColor: 'red'}}`
@@ -88,7 +88,7 @@ Continue is a React component that you can use in Step to programmatically conti
 ### Props
 
 * `step`: (string) Name of the step the tour will advance to.
-* `target`: (string, optional) Name of `[data-tip-target]` that would be watched.
+* `target`: (string, optional) Name of `[data-tip-target]` that would be watched. See "Targeting elements in Calypso" for info about the format.
 * `click`: (bool, optional) If true, `onClick` will be listened on `target` DOM node.
 * `hidden`: (bool, optional) If true, this will not render anything in Step, while functionality remains.
 * `icon`: (string, optional) Name of Gridicon to show in custom message.
@@ -223,3 +223,46 @@ In few places in GT you need to target a DOM elements in Calypso. There are curr
 
 - `data-tip-target` attribute on the target element
 - using any css selector
+
+By default, the query used is `[data-tip-target="${target}"]`. However, if `target` starts with a dot or a space character, it will be treated like a standard selector and be passed directly to `document.querySelector`, thereby allowing you to target elements that do no set a `data-tip-target` attribute.
+
+### [data-tip-target]
+
+You mark a target by adding `data-tip-target="some-name"` attribute to it with your value. Please be specific to avoid conflicts and use dash-case.
+
+In tour you just put a value of your `[data-tip-target]` into `target` prop.
+
+Example: you want to position a step of your tour to point to some input element.
+
+```jsx
+// code somewhere in Calypso
+<input type="text" name="example" value={ … } data-tip-target="my-example-input" />
+
+// in your tour
+<Step name="example-step" target="my-example-input">…</Step>
+```
+
+### CSS selector
+
+There are cases when it might be a better idea to target an element by a CSS selector.
+
+You declare that you are using a css selector by starting a value of `target` prop with a dot or a space character. This value will be internally passed directly to `document.querySelector`.
+
+Some examples:
+
+```jsx
+// select by class
+<Step target=".sidebar-activity__likes">
+
+// use a combo of classes to determine state - this selects the active item from masterbar
+<Step target=".masterbar__item.is-active">
+
+// detect state (has-thumbnail) and select a child (featured image)
+<Step target=".reader-post-card.has-thumbnail:first-child .reader-post-card__featured-image">
+
+// target id (notice the required space before #)
+<Step target=" #header">
+
+// target element (again, space at the beginning)
+<Step target=" body">
+```

--- a/client/layout/guided-tours/docs/API.md
+++ b/client/layout/guided-tours/docs/API.md
@@ -246,7 +246,7 @@ Example: you want to position a step of your tour to point to some input element
 
 There are cases when it might be a better idea to target an element by a CSS selector.
 
-You declare that you are using a css selector by starting a value of `target` prop with a dot or a space character.
+You declare that you are using a css selector by starting a value of `target` prop with a dot or a space character. Only single element can be used as a target - it will be the first one matching the selector.
 
 Some examples:
 
@@ -258,7 +258,7 @@ Some examples:
 <Step target=".masterbar__item.is-active">
 
 // detect state (has-thumbnail) and select a child (featured image)
-<Step target=".reader-post-card.has-thumbnail:first-child .reader-post-card__featured-image">
+<Step target=".reader-post-card.has-thumbnail .reader-post-card__featured-image">
 
 // target id (notice the required space before #)
 <Step target=" #header">

--- a/client/layout/guided-tours/docs/API.md
+++ b/client/layout/guided-tours/docs/API.md
@@ -88,7 +88,7 @@ Continue is a React component that you can use in Step to programmatically conti
 ### Props
 
 * `step`: (string) Name of the step the tour will advance to.
-* `target`: (string, optional) Name of `[data-tip-target]` that would be watched. See [Targeting elements in Calypso](#targeting-elements-in-calypso) section for more info about the format.
+* `target`: (string, optional) DOM node that would be watched. See [Targeting elements in Calypso](#targeting-elements-in-calypso) section for more info about the format.
 * `click`: (bool, optional) If true, `onClick` will be listened on `target` DOM node.
 * `hidden`: (bool, optional) If true, this will not render anything in Step, while functionality remains.
 * `icon`: (string, optional) Name of Gridicon to show in custom message.

--- a/client/layout/guided-tours/docs/API.md
+++ b/client/layout/guided-tours/docs/API.md
@@ -4,21 +4,21 @@ Guided Tours are declared in JSX as a tree of elements. All of them are availabl
 
 ## Tour
 
-Tour is a React component that declares the top-level of a tour. It defines conditions for starting a tour and contains `<Step>` elements as children (at least one is required).
+Tour is a React component that declares the top-level of a tour. It consists of series of Step elements and it also defines when tour should start by setting appropriate props.
 
 ### Props
 
 * `name`: (string) Unique name of tour in camelCase.
 * `version` (string): Version identifier. We use date string like "20161224".
-* `path` (string or array, optional): Use this prop to limit tour only to some path prefix (or more prefixes if array). Example: `[ '/stats', '/settings' ]`
-* `when` (function, optional): This is a Redux selector function. Use this to define conditions for the tour to start. Can be overridden by adding a `tour` query argument to the URL like so: `?tour=tourName`, in which case the tour will be triggered even if `when` would evaluate to `false`. This is useful for sending along a tour via email or chat. On the other hand, the framework will try to not trigger a tour multiple times (see `toursSeen` in [ARCHITECTURE.md](./ARCHITECTURE.md)). 
+* `path` (string or array, optional): Use this prop to limit tour only to some path prefix (or more prefixes if array). Example: `path={ [ '/stats', '/settings' ] }`
+* `when` (function, optional): This is a Redux selector function. Use this to define conditions for the tour to start. Can be overridden by adding a `tour` query argument to the URL like so: `?tour=tourName`, in which case the tour will be triggered even if `when` would evaluate to `false`. This is useful for sending along a tour via email or chat. On the other hand, the framework will try to not trigger a tour multiple times (see `toursSeen` in [ARCHITECTURE.md](./ARCHITECTURE.md)).
 * `children` (nodes): only supported type is `<Step>`
 
 ### Example
 
 ```jsx
 // tour with a single step
-<Tour path="/me" name="exampleTour">
+<Tour path="/me" name="exampleTour" when={ isNewUser }>
   <Step>
     …
   </Step>
@@ -38,7 +38,7 @@ Step is a React component that defines a single Step of a tour. It is represente
 * `placement`: (string, optional) Placement. Possible values: `below`, `above`, `beside`, `center`, `middle`, `right`.
 * `arrow`: (string, optional) If defined, the step will be rendered with an arrow on its border pointing in a given direction. Available: 'top-left', 'top-center', 'top-right', 'right-top', 'right-middle', 'right-bottom', 'bottom-left', 'bottom-center', 'bottom-right', 'left-top', 'left-middle', 'left-bottom'.
 * `style`: (object, optional) Will be used as the step's inline style. Use sparingly and with caution for minor tweaks in positioning or z-indexes and avoid changing the look and feel of Guided Tours. If you use this in a way that could benefit all of Guided Tours globally, please consider creating an issue. Example: `style={{backgroundColor: 'red'}}`
-* `when`: (function, optional) This is a Redux selector that can prevent a step from showing when it evaluates to false. When using `when` you should also set the `next` prop to tell Guided Tours the name of the step it should skip to. If you omit this prop, step will be rendered as expected.
+* `when`: (function, optional) This is a Redux selector that can prevent a step from showing when it evaluates to false. When using `when` you should also set the `next` prop to tell Guided Tours the name of the step it should skip to. If you omit this prop, step will be rendered as expected. Example usage would be to show a certain step only for non-mobile environments: `when={ not( isMobile ) }`
 * `next`: (string, optional) Define this to tell Guided Tours the name of the step it should skip to when `when` evaluates to false.
 * `children`: (node) Contents of the step. Usually a paragraph of instructions and some controls for the tour. See below for available options. Note that all text content needs to be wrapped in `<p>` so it gets proper styling.
 
@@ -216,3 +216,10 @@ combineTours( {
   thirdTour: ThirdTour,
 } );
 ```
+
+## Targeting elements in Calypso
+
+In few places in GT you need to target a DOM elements in Calypso. There are currently two ways to do this:
+
+- `data-tip-target` attribute on the target element
+- using any css selector

--- a/client/layout/guided-tours/docs/API.md
+++ b/client/layout/guided-tours/docs/API.md
@@ -34,7 +34,7 @@ Step is a React component that defines a single Step of a tour. It is represente
 ### Props
 
 * `name`: (string) Unique identifier of the step, used for addressing a step from `Next` or `Continue`. Use `init` to indicate the step that the tour should start with.
-* `target`: (string, optional) Target which this step belongs to and which will be used for positioning. See "Targeting elements in Calypso" for info about the format.
+* `target`: (string, optional) Target which this step belongs to and which will be used for positioning. See [Targeting elements in Calypso](#targeting-elements-in-calypso) section for more info about the format.
 * `placement`: (string, optional) Placement. Possible values: `below`, `above`, `beside`, `center`, `middle`, `right`.
 * `arrow`: (string, optional) If defined, the step will be rendered with an arrow on its border pointing in a given direction. Available: 'top-left', 'top-center', 'top-right', 'right-top', 'right-middle', 'right-bottom', 'bottom-left', 'bottom-center', 'bottom-right', 'left-top', 'left-middle', 'left-bottom'.
 * `style`: (object, optional) Will be used as the step's inline style. Use sparingly and with caution for minor tweaks in positioning or z-indexes and avoid changing the look and feel of Guided Tours. If you use this in a way that could benefit all of Guided Tours globally, please consider creating an issue. Example: `style={{backgroundColor: 'red'}}`
@@ -88,7 +88,7 @@ Continue is a React component that you can use in Step to programmatically conti
 ### Props
 
 * `step`: (string) Name of the step the tour will advance to.
-* `target`: (string, optional) Name of `[data-tip-target]` that would be watched. See "Targeting elements in Calypso" for info about the format.
+* `target`: (string, optional) Name of `[data-tip-target]` that would be watched. See [Targeting elements in Calypso](#targeting-elements-in-calypso) section for more info about the format.
 * `click`: (bool, optional) If true, `onClick` will be listened on `target` DOM node.
 * `hidden`: (bool, optional) If true, this will not render anything in Step, while functionality remains.
 * `icon`: (string, optional) Name of Gridicon to show in custom message.
@@ -224,7 +224,7 @@ In few places in GT you need to target a DOM elements in Calypso. There are curr
 - `data-tip-target` attribute on the target element
 - using any css selector
 
-By default, the query used is `[data-tip-target="${target}"]`. However, if `target` starts with a dot or a space character, it will be treated like a standard selector and be passed directly to `document.querySelector`, thereby allowing you to target elements that do no set a `data-tip-target` attribute.
+To find the DOM node, `document.querySelector` is used. By default, the query used is `[data-tip-target="${target}"]`. However, if `target` starts with a dot or a space character, it will be treated like a standard selector and be passed directly to the function, thereby allowing you to target elements that do no set a `data-tip-target` attribute.
 
 ### [data-tip-target]
 
@@ -246,7 +246,7 @@ Example: you want to position a step of your tour to point to some input element
 
 There are cases when it might be a better idea to target an element by a CSS selector.
 
-You declare that you are using a css selector by starting a value of `target` prop with a dot or a space character. This value will be internally passed directly to `document.querySelector`.
+You declare that you are using a css selector by starting a value of `target` prop with a dot or a space character.
 
 Some examples:
 

--- a/client/layout/guided-tours/docs/API.md
+++ b/client/layout/guided-tours/docs/API.md
@@ -248,7 +248,7 @@ There are cases when it might be a better idea to target an element by a CSS sel
 
 We treat the `target` prop as a CSS selector if it contains `.`, `#`, or a space character.
 
-Some examples:
+#### Some examples
 
 ```jsx
 // select by class
@@ -262,9 +262,13 @@ Some examples:
 
 // target id
 <Step target="#header">
+```
 
+#### One special case
+
+```jsx
 // target element
 <Step target=" body">
 ```
 
-Notice the space before "body" in the last example. It is required there, otherwise the framework will be looking for `[data-tip-target="body"]` and not using the value as a CSS selector. The space will force the CSS selector mode.
+Notice the space before "body" in the last example. **This is a hack** that forces the framework to use the value directly as a CSS selector and not as `[data-tip-target="body"]`. Please consider using any other way (CSS class, ID, custom attribute…) before settling with this one.

--- a/client/layout/guided-tours/docs/API.md
+++ b/client/layout/guided-tours/docs/API.md
@@ -224,7 +224,7 @@ One of the features of Guided Tours is the ability to target DOM elements in Cal
 - `data-tip-target` attribute on the target element (recommended)
 - using any CSS selector
 
-To find the DOM node, `document.querySelector` is used. By default, the query used is `[data-tip-target="${target}"]`. However, if `target` starts with a dot or a space character, it will be treated like a standard selector and be passed directly to the function, thereby allowing you to target elements that do no set a `data-tip-target` attribute. We run the query selector on every render so it possible to move elements around.
+To find the DOM node, `document.querySelector` is used. By default, the query used is `[data-tip-target="${target}"]`. However, if `target` contains a `.`, `#`, or a space character, we assume it's a CSS selector and it will be treated like a standard selector and be passed directly to the function, thereby allowing you to target elements that do no set a `data-tip-target` attribute. We run the query selector on every render so it possible to move elements around.
 
 ### [data-tip-target]
 
@@ -246,7 +246,7 @@ Example: you want to position a step of your tour to point to some input element
 
 There are cases when it might be a better idea to target an element by a CSS selector. You might use some classes to get elements in certain state or you might not be 100% in control of the markup (think controls of an external library).
 
-You declare that you are using a CSS selector by starting a value of the `target` prop with a dot or a space character. Only one element can be used as a target: the first one matching the selector will be used.
+We treat the `target` prop as a CSS selector if it contains `.`, `#`, or a space character.
 
 Some examples:
 
@@ -260,9 +260,11 @@ Some examples:
 // detect state (has-thumbnail) and select a child (featured image)
 <Step target=".reader-post-card.has-thumbnail .reader-post-card__featured-image">
 
-// target id (notice the required space before #)
-<Step target=" #header">
+// target id
+<Step target="#header">
 
-// target element (again, space at the beginning)
+// target element
 <Step target=" body">
 ```
+
+Notice the space before "body" in the last example. It is required there, otherwise the framework will be looking for `[data-tip-target="body"]` and not using the value as a CSS selector. The space will force the CSS selector mode.


### PR DESCRIPTION
I had some things stashed that didn't make it to our first PR, so I'm adding those now.

It addresses few comments from the original PR and extracts documentation about element targeting into its own section and adds links to it.