### PR TITLE
Domains: Update copy for failed purchase checkout page

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/failed-purchase-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/failed-purchase-details.jsx
@@ -13,7 +13,6 @@ import support from 'lib/url/support';
 const FailedPurchaseDetails = ( { failedPurchases, purchases, translate } ) => {
 	const successfulPurchases = purchases.length > 0 && (
 			<div>
-				<hr />
 				<p>
 					{
 						translate(

--- a/client/my-sites/upgrades/checkout-thank-you/failed-purchase-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/failed-purchase-details.jsx
@@ -54,7 +54,7 @@ const FailedPurchaseDetails = ( { failedPurchases, purchases, translate } ) => {
 			<p>
 				{
 					translate( 'We added credits to your account, so you can try adding these items again. ' +
-						'If the problem persists, please don’t hesitate to {{a}}contact support{{/a}}.',
+						'If the problem persists, please don\'t hesitate to {{a}}contact support{{/a}}.',
 						{
 							components: {
 								a: <a href={ support.CALYPSO_CONTACT } target="_blank" rel="noopener noreferrer" />

--- a/client/my-sites/upgrades/checkout-thank-you/failed-purchase-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/failed-purchase-details.jsx
@@ -17,7 +17,7 @@ const FailedPurchaseDetails = ( { failedPurchases, purchases, translate } ) => {
 				<p>
 					{
 						translate(
-							'On the bright side, we managed to obtain these for you:'
+							'These items were added successfully:'
 						)
 					}
 				</p>
@@ -34,10 +34,12 @@ const FailedPurchaseDetails = ( { failedPurchases, purchases, translate } ) => {
 		),
 		description = (
 		<div>
+			{ successfulPurchases }
+			<hr />
 			<p>
 				{
 					translate(
-						'Here\'s the list of products we failed to obtain:'
+						'These items could not be added:'
 					)
 				}
 			</p>
@@ -52,8 +54,8 @@ const FailedPurchaseDetails = ( { failedPurchases, purchases, translate } ) => {
 			</ul>
 			<p>
 				{
-					translate( 'We have filled your account with credits so you can retry the failed purchases. ' +
-						'If the problem persists, please don\'t hesitate to {{a}}contact support{{/a}}!',
+					translate( 'We added credits to your account, so you can try adding these items again. ' +
+						'If the problem persists, please don’t hesitate to {{a}}contact support{{/a}}.',
 						{
 							components: {
 								a: <a href={ support.CALYPSO_CONTACT } target="_blank" rel="noopener noreferrer" />
@@ -62,7 +64,6 @@ const FailedPurchaseDetails = ( { failedPurchases, purchases, translate } ) => {
 					)
 				}
 			</p>
-			{ successfulPurchases }
 		</div>
 	);
 

--- a/client/my-sites/upgrades/checkout-thank-you/header.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/header.jsx
@@ -26,7 +26,7 @@ class CheckoutThankYouHeader extends React.Component {
 		}
 
 		if ( this.props.hasFailedPurchases ) {
-			return this.props.translate( 'Ooops…' );
+			return this.props.translate( 'Some items failed.' );
 		}
 
 		if ( this.props.primaryPurchase && isChargeback( this.props.primaryPurchase ) ) {
@@ -38,7 +38,7 @@ class CheckoutThankYouHeader extends React.Component {
 
 	getText() {
 		if ( this.props.hasFailedPurchases ) {
-			return this.props.translate( 'Seems we had problems obtaining some of your items.' );
+			return this.props.translate( 'Some of the items in your cart could not be added.' );
 		}
 
 		if ( ! this.props.isDataLoaded || ! this.props.primaryPurchase ) {


### PR DESCRIPTION
Update copy per comment here https://github.com/Automattic/wp-calypso/pull/10533#issuecomment-272103679

Test:
1. Add domain to cart
2. Add site redirect to cart
3. Make domain purchase fail on backend

Before:
![new failed after](https://cloud.githubusercontent.com/assets/1103398/21898131/19e4a6d0-d8ec-11e6-89e1-2d59881fbd31.png)

After:
![copy update](https://cloud.githubusercontent.com/assets/1103398/21898138/1d2e63d0-d8ec-11e6-9105-43340f465c82.png)
