### PR TITLE
Site Settings: Apply image editor props only in site icon flow

### DIFF
--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -45,19 +45,24 @@ class SiteIconSetting extends Component {
 		customizerUrl: PropTypes.string,
 		generalOptionsUrl: PropTypes.string,
 		onEditSelectedMedia: PropTypes.func,
+		onCancelEditingIcon: PropTypes.func,
 		resetAllImageEditorState: PropTypes.func,
 		crop: PropTypes.object
 	};
 
 	state = {
 		isModalVisible: false,
-		hasToggledModal: false
+		hasToggledModal: false,
+		isEditingSiteIcon: false
 	};
 
 	toggleModal = ( isModalVisible ) => {
+		const { isEditingSiteIcon } = this.state;
+
 		this.setState( {
 			isModalVisible,
-			hasToggledModal: true
+			hasToggledModal: true,
+			isEditingSiteIcon: isModalVisible ? isEditingSiteIcon : false
 		} );
 	};
 
@@ -67,6 +72,7 @@ class SiteIconSetting extends Component {
 
 	editSelectedMedia = ( value ) => {
 		if ( value ) {
+			this.setState( { isEditingSiteIcon: true } );
 			this.props.onEditSelectedMedia();
 		} else {
 			this.hideModal();
@@ -152,13 +158,19 @@ class SiteIconSetting extends Component {
 		} );
 	};
 
+	cancelEditingSiteIcon = () => {
+		this.props.onCancelEditingIcon();
+		this.props.resetAllImageEditorState();
+		this.setState( { isEditingSiteIcon: false } );
+	};
+
 	preloadModal() {
 		asyncRequire( 'post-editor/media-modal' );
 	}
 
 	render() {
 		const { isJetpack, customizerUrl, generalOptionsUrl, siteSupportsImageEditor } = this.props;
-		const { isModalVisible, hasToggledModal } = this.state;
+		const { isModalVisible, hasToggledModal, isEditingSiteIcon } = this.state;
 		const isIconManagementEnabled = isEnabled( 'manage/site-settings/site-icon' );
 
 		let buttonProps;
@@ -224,10 +236,13 @@ class SiteIconSetting extends Component {
 							siteId={ siteId }
 							onClose={ this.editSelectedMedia }
 							enabledFilters={ [ 'images' ] }
-							imageEditorProps={ {
-								allowedAspectRatios: [ AspectRatios.ASPECT_1X1 ],
-								onDone: this.setSiteIcon
-							} }
+							{ ...( isEditingSiteIcon ? {
+								imageEditorProps: {
+									allowedAspectRatios: [ AspectRatios.ASPECT_1X1 ],
+									onDone: this.setSiteIcon,
+									onCancel: this.cancelEditingSiteIcon
+								}
+							} : {} ) }
 							visible={ isModalVisible }
 							labels={ {
 								confirm: translate( 'Continue' )
@@ -258,6 +273,7 @@ export default connect(
 	},
 	{
 		onEditSelectedMedia: partial( setEditorMediaModalView, ModalViews.IMAGE_EDITOR ),
+		onCancelEditingIcon: partial( setEditorMediaModalView, ModalViews.LIST ),
 		resetAllImageEditorState,
 		saveSiteSettings,
 		removeSiteIcon: partialRight( saveSiteSettings, { site_icon: '' } ),


### PR DESCRIPTION
Fixes #10470 
Closes #10449 

This pull request seeks to better apply image editing behavior only in the context of site icon flow. It both prevents confirmation of an edited image outside this flow as being used as the site icon, and includes editor cancel behavior to return to the list screen.

__Testing instructions:__

1. Navigate to [site settings](http://calypso.localhost:3000/settings)
2. Select a site
3. Click Change under Site Icon
4. Hover an image and click the edit (pencil) button
5. Click Edit Image
6. Edit the image
7. Note that site icon constraints are not applied (1x1 aspect ratio)
8. Click Done
9. Note that you are returned to the detail view for the edited image
10. Click Continue
11. Note that site icon constraints are applied (1x1 aspect ratio)
14. Click Done
15. Note that the site icon is saved
16. Click Change under Site Icon
17. Select an image
18. Click Continue
19. Click Cancel
20. Note you're returned to media library list view