### PR TITLE
Guided Tours: adjust z-index so as not to cover masterbar

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -103,6 +103,7 @@ $z-layers: (
 		'.accessible-focus .select-dropdown.is-open .select-dropdown__container': 170,
 		'.sites-dropdown.is-open .sites-dropdown__wrapper' : 170,
 		'.first-view': 175,
+		'.guided-tours__step.is-scrolling': 175,
 		'.popover.editor-visibility__popover': 179,
 		'.feature-example__gradient': 179,
 		'.global-notices': 179,

--- a/client/layout/guided-tours/config-elements/step.js
+++ b/client/layout/guided-tours/config-elements/step.js
@@ -16,9 +16,10 @@ import Card from 'components/card';
 import pathToSection from 'lib/path-to-section';
 import { ROUTE_SET } from 'state/action-types';
 import {
-	posToCss,
 	getStepPosition,
 	getValidatedArrowPosition,
+	isInScrollableContent,
+	posToCss,
 	query,
 	targetForSlug,
 } from '../positioning';
@@ -231,6 +232,7 @@ export default class Step extends Component {
 			this.props.className,
 			'guided-tours__step',
 			'guided-tours__step-glow',
+			isInScrollableContent( this.props ) && 'is-scrolling',
 			this.context.step === 'init' && 'guided-tours__step-first',
 			isLastStep && 'guided-tours__step-finish',
 			targetSlug && 'guided-tours__step-pointing',

--- a/client/layout/guided-tours/positioning.js
+++ b/client/layout/guided-tours/positioning.js
@@ -1,7 +1,10 @@
 /**
  * External dependencies
  */
-import startsWith from 'lodash/startsWith';
+import {
+	includes,
+	startsWith,
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -171,4 +174,11 @@ function scrollIntoView( target, scrollContainer ) {
 
 	scrollTo( { y, container } );
 	return y;
+}
+
+export function isInScrollableContent( { scrollContainer } ) {
+	return includes( [
+		'body',
+		'.sidebar__region',
+	], scrollContainer );
 }

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -13,6 +13,10 @@
 	animation-name: guided-tours__step-fadein;
 	animation-timing-function: ease-in-out;
 
+	&.is-scrolling {
+		z-index: z-index( 'root', '.guided-tours__step.is-scrolling' );
+	}
+
 	p {
 		color: lighten( $gray, 30 );
 		margin-bottom: 16px;


### PR DESCRIPTION
# Issue

If a GT step is pointing at something that is just above the viewport, the edges of the step will be rendered on top of the masterbar, which creates some spatial dissonance (that is, it goes against the mental model that all of Calypso is a layer under the masterbar, including the tooltips).

# Fix

Currently, a tour step may have a `scrollContainer` prop (see [API.md](https://github.com/Automattic/wp-calypso/blob/master/client/layout/guided-tours/docs/API.md)) that lets Guided Tours correctly reposition it as the user scrolls. As of this writing, occurring values for this prop are `.sidebar__region` and `body`. These would seem like good hints at how authors would like Guided Tours to behave: for each supported `scrollContainer` value, have a corresponding z-index, else default to the current, higher z-index.

# Testing

Ideally, go through every tour in more than one kind of device, try to scroll around or see how otherwise things can break visually.