### PR TITLE
Sites: fix current-site to show all sites when in all sites view

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -36,6 +36,9 @@ const CurrentSite = React.createClass( {
 		sites: React.PropTypes.object.isRequired,
 		siteCount: React.PropTypes.number.isRequired,
 		setLayoutFocus: React.PropTypes.func.isRequired,
+		selectedSiteId: React.PropTypes.number,
+		selectedSite: React.PropTypes.object,
+		isJetpack: React.PropTypes.bool
 	},
 
 	componentWillMount() {
@@ -77,8 +80,13 @@ const CurrentSite = React.createClass( {
 	},
 
 	getDomainWarnings: function() {
-		const { selectedSite: site } = this.props;
-		const domainStore = this.state.domainsStore.getBySite( site.ID );
+		const { selectedSiteId, selectedSite: site } = this.props;
+
+		if ( ! selectedSiteId ) {
+			return null;
+		}
+
+		const domainStore = this.state.domainsStore.getBySite( selectedSiteId );
 		const domains = domainStore && domainStore.list || [];
 
 		return (
@@ -155,13 +163,12 @@ const CurrentSite = React.createClass( {
 
 // TODO: make this pure when sites can be retrieved from the Redux state
 module.exports = connect(
-	( state, ownProps ) => {
+	( state ) => {
 		const selectedSiteId = getSelectedSiteId( state );
-		const selectedSite = getSelectedSite( state );
 
 		return {
 			selectedSiteId,
-			selectedSite: selectedSite || ownProps.sites.getPrimary(),
+			selectedSite: getSelectedSite( state ),
 			isJetpack: isJetpackSite( state, selectedSiteId )
 		};
 	},


### PR DESCRIPTION
Fixes a regression introduced in #10481, where we render the primary site in an all sites view.

### Testing Instructions

#### Multi-Site User:
- As a multi-site user navigate to a page that supports an all-sites view: eg, http://calypso.localhost:3000/pages http://calypso.localhost:3000/plugins http://calypso.localhost:3000/stats etc
- We should see an all sites component render in the sidebar instead of the primary site:
<img width="281" alt="screen shot 2017-01-12 at 1 25 23 pm" src="https://cloud.githubusercontent.com/assets/1270189/21909061/32811b86-d8cb-11e6-9536-7c2c6e2e75a7.png">

#### Single Site User
- As a single-site user navigate to a page that supports an all-sites view: eg, http://calypso.localhost:3000/pages http://calypso.localhost:3000/plugins http://calypso.localhost:3000/stats etc
- We should be redirected to the site specific route:  http://calypso.localhost:3000/plugins/:site:
- The expected site should render

- Any sites with domain notices should render normally:
<img width="279" alt="screen shot 2017-01-12 at 1 25 34 pm" src="https://cloud.githubusercontent.com/assets/1270189/21909167/96a27b5a-d8cb-11e6-9c37-c6a595dadb22.png">
- Pages that force you to select a site should work normally by taking you to the site selector, eg http://calypso.localhost:3000/post http://calypso.localhost:3000/plans


cc @spen 