### PR TITLE
Stats: add statsTopPosts normalizer to state.stats.lists

### DIFF
--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -161,6 +161,134 @@ describe( 'utils', () => {
 			} );
 		} );
 
+		describe( 'statsTopPosts()', () => {
+			it( 'should return an empty array if data is null', () => {
+				const parsedData = normalizers.statsTopPosts();
+
+				expect( parsedData ).to.eql( [] );
+			} );
+
+			it( 'should return an empty array if query.period is null', () => {
+				const parsedData = normalizers.statsTopPosts( {}, { date: '2016-12-25' } );
+
+				expect( parsedData ).to.eql( [] );
+			} );
+
+			it( 'should return an empty array if query.date is null', () => {
+				const parsedData = normalizers.statsTopPosts( {}, { period: 'day' } );
+
+				expect( parsedData ).to.eql( [] );
+			} );
+
+			it( 'should properly parse day period response', () => {
+				const parsedData = normalizers.statsTopPosts( {
+					date: '2017-01-12',
+					days: {
+						'2017-01-12': {
+							postviews: [ {
+								id: 0,
+								href: 'http://en.blog.wordpress.com',
+								date: null,
+								title: 'Home Page / Archives',
+								type: 'homepage',
+								views: 3939
+							} ],
+							total_views: 0
+						}
+					}
+				}, {
+					period: 'day',
+					date: '2017-01-12',
+					domain: 'en.blog.wordpress.com'
+				} );
+
+				expect( parsedData ).to.eql( [ {
+					label: 'Home Page / Archives',
+					value: 3939,
+					page: '/stats/post/0/en.blog.wordpress.com',
+					actions: [ {
+						type: 'link',
+						data: 'http://en.blog.wordpress.com'
+					} ],
+					labelIcon: null,
+					children: null,
+					className: null
+				} ] );
+			} );
+
+			it( 'should properly add published className for posts published in period', () => {
+				const parsedData = normalizers.statsTopPosts( {
+					date: '2017-01-12',
+					days: {
+						'2017-01-12': {
+							postviews: [ {
+								id: 777,
+								href: 'http://en.blog.wordpress.com/2017/01/12/wordpress-com-lightroom/',
+								date: '2017-01-12 15:55:34',
+								title: 'New WordPress.com for Lightroom Makes Publishing Your Photos Easy',
+								type: 'post',
+								views: 774
+							} ],
+							total_views: 0
+						}
+					}
+				}, {
+					period: 'day',
+					date: '2017-01-12',
+					domain: 'en.blog.wordpress.com'
+				} );
+
+				expect( parsedData ).to.eql( [ {
+					label: 'New WordPress.com for Lightroom Makes Publishing Your Photos Easy',
+					value: 774,
+					page: '/stats/post/777/en.blog.wordpress.com',
+					actions: [ {
+						type: 'link',
+						data: 'http://en.blog.wordpress.com/2017/01/12/wordpress-com-lightroom/'
+					} ],
+					labelIcon: null,
+					children: null,
+					className: 'published'
+				}
+				] );
+			} );
+
+			it( 'should properly parse summarized response', () => {
+				const parsedData = normalizers.statsTopPosts( {
+					date: '2017-01-12',
+					summary: {
+						postviews: [ {
+							id: 0,
+							href: 'http://en.blog.wordpress.com',
+							date: null,
+							title: 'Home Page / Archives',
+							type: 'homepage',
+							views: 3939
+						} ],
+						total_views: 0
+					}
+				}, {
+					period: 'day',
+					date: '2017-01-12',
+					domain: 'en.blog.wordpress.com',
+					summarize: 1
+				} );
+
+				expect( parsedData ).to.eql( [ {
+					label: 'Home Page / Archives',
+					value: 3939,
+					page: '/stats/post/0/en.blog.wordpress.com',
+					actions: [ {
+						type: 'link',
+						data: 'http://en.blog.wordpress.com'
+					} ],
+					labelIcon: null,
+					children: null,
+					className: null
+				} ] );
+			} );
+		} );
+
 		describe( 'statsCountryViews()', () => {
 			it( 'should return an empty array if data is null', () => {
 				const parsedData = normalizers.statsCountryViews();


### PR DESCRIPTION
This branch adds in a new `state.stats.lists` normalizer for the `statsTopPosts` endpoint.  When this is in place, we can utilize `QuerySiteStats` and the stats `connected-list` component in the "Posts & Pages" component on stats pages.

The logic here is taken from the `lib/stats/stats-list/parser.js` logic.  I initially tried to remove the need of passing in the `domain` as part of the query object, instead opting to parse the domain from a URL in the payload.... but I remembered we can not rely on that logic for Jetpack domains that are not installed in the root directory ( i.e. http://chickenandribs.org/awesomeblog ).

I also left a TODO note that it would be nice to eventually update `moment` to a newer version to clean up the logic a bit here.  Doing so would require work in `i18n-calypso` and due to limited time on this stats project, I opted to not make that a blocker here.

__To Test__
No visual items to test, just ensure the new tests pass.