### PR TITLE
Editor: Move cog icon to the right of status, and add hover state

### DIFF
--- a/client/post-editor/editor-status-label/index.jsx
+++ b/client/post-editor/editor-status-label/index.jsx
@@ -83,8 +83,8 @@ export default React.createClass( {
 				role="alert"
 				aria-live="polite"
 			>
-				<Gridicon icon="cog" size={ 18 } />
 				{ this.renderLabel() }
+				<Gridicon icon="cog" size={ 18 } />
 			</button>
 		);
 	},

--- a/client/post-editor/editor-status-label/style.scss
+++ b/client/post-editor/editor-status-label/style.scss
@@ -4,15 +4,16 @@
 	display: block;
 	font-size: 11px;
 	line-height: 1.65;
-	padding-left: 18px;
 	text-align: left;
 	text-transform: uppercase;
 
 	.gridicon {
 		display: inline-block;
 		fill: lighten( $gray, 10% );
-		position: absolute;
-			left: 14px;
+		position: relative;
+			top: -1px;
+			right: -2px;
+		vertical-align: middle;
 	}
 
 	strong {
@@ -38,6 +39,18 @@
 
 		strong {
 			display: block;
+		}
+	}
+
+	&:hover {
+		color: $gray-dark;
+
+		.gridicon {
+			fill: $gray-dark;
+		}
+
+		strong {
+			color: $gray-dark;
 		}
 	}
 }


### PR DESCRIPTION
This PR updates the cog icon to be on the right of the post status.

When an icon and text label sit next to each other, it’s believed to be a better practice to place the icon to the left of the text label (with LTR languages) because the icon is the introduction of the text label. 

However, in this case, the cog and the status are two different things. The cog isn’t a visual aid to the status, but it’s more like an action you can take to the status, therefore it makes more sense to be on the right of the status.

This PR also adds a missing hover state.

![post-status](https://cloud.githubusercontent.com/assets/908665/21916401/3f679a88-d938-11e6-9c09-4c9ee2aa6258.jpg)
