### PR TITLE
Reader: improve photo-only card classification

### DIFF
--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -62,15 +62,16 @@ const hasShortContent = post => getCharacterCount( post ) <= 100;
  */
 export function classifyPost( post ) {
 	const canonicalImage = post.canonical_image;
-	const imagesForGallery = post.content_images && filter( post.content_images, imageIsBigEnoughForGallery );
+	const imagesForGallery = filter( post.content_images, imageIsBigEnoughForGallery );
 	let displayType = DISPLAY_TYPES.UNCLASSIFIED,
 		canonicalAspect;
 
-	if ( post.canonical_media &&
-			post.canonical_media.mediaType === 'image' &&
-			( ! post.content_images || imagesForGallery.length < GALLERY_MIN_IMAGES ) &&
-			post.canonical_media.width >= PHOTO_ONLY_MIN_WIDTH &&
-			hasShortContent( post ) ) {
+	if ( imagesForGallery.length >= GALLERY_MIN_IMAGES ) {
+		displayType ^= DISPLAY_TYPES.GALLERY;
+	} else if ( post.canonical_media &&
+				post.canonical_media.mediaType === 'image' &&
+				post.canonical_media.width >= PHOTO_ONLY_MIN_WIDTH &&
+				hasShortContent( post ) ) {
 		displayType ^= DISPLAY_TYPES.PHOTO_ONLY;
 	}
 
@@ -95,10 +96,6 @@ export function classifyPost( post ) {
 
 	if ( post.canonical_media && post.canonical_media.mediaType === 'video' ) {
 		displayType ^= DISPLAY_TYPES.FEATURED_VIDEO;
-	}
-
-	if ( post.content_images && imagesForGallery.length >= GALLERY_MIN_IMAGES ) {
-		displayType ^= DISPLAY_TYPES.GALLERY;
 	}
 
 	if ( post.tags && post.tags[ 'p2-xpost' ] ) {

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -36,7 +36,7 @@ import removeElementsBySelector from 'lib/post-normalizer/rule-content-remove-el
  */
 export const
 	READER_CONTENT_WIDTH = 720,
-	PHOTO_ONLY_MIN_WIDTH = 480,
+	PHOTO_ONLY_MIN_WIDTH = 440,
 	DISCOVER_BLOG_ID = 53424024,
 	GALLERY_MIN_IMAGES = 4,
 	GALLERY_MIN_IMAGE_WIDTH = 350;

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -62,12 +62,13 @@ const hasShortContent = post => getCharacterCount( post ) <= 100;
  */
 export function classifyPost( post ) {
 	const canonicalImage = post.canonical_image;
+	const imagesForGallery = post.content_images && filter( post.content_images, imageIsBigEnoughForGallery );
 	let displayType = DISPLAY_TYPES.UNCLASSIFIED,
 		canonicalAspect;
 
 	if ( post.canonical_media &&
 			post.canonical_media.mediaType === 'image' &&
-			( ! post.content_images || post.content_images.length < GALLERY_MIN_IMAGES ) &&
+			( ! post.content_images || imagesForGallery.length < GALLERY_MIN_IMAGES ) &&
 			post.canonical_media.width >= PHOTO_ONLY_MIN_WIDTH &&
 			hasShortContent( post ) ) {
 		displayType ^= DISPLAY_TYPES.PHOTO_ONLY;
@@ -96,7 +97,7 @@ export function classifyPost( post ) {
 		displayType ^= DISPLAY_TYPES.FEATURED_VIDEO;
 	}
 
-	if ( post.content_images && filter( post.content_images, imageIsBigEnoughForGallery ).length >= GALLERY_MIN_IMAGES ) {
+	if ( post.content_images && imagesForGallery.length >= GALLERY_MIN_IMAGES ) {
 		displayType ^= DISPLAY_TYPES.GALLERY;
 	}
 

--- a/client/state/reader/posts/test/normalization-rules.js
+++ b/client/state/reader/posts/test/normalization-rules.js
@@ -43,6 +43,30 @@ describe( 'normalization-rules', () => {
 				better_excerpt_no_html: repeat( 'no ', 100 )
 			}, [ DISPLAY_TYPES.UNCLASSIFIED ] );
 		} );
+
+		it( 'should classify a PHOTO_ONLY post if it has enough images for a gallery, but not all of them are big enough', () => {
+			verifyClassification( {
+				canonical_media: {
+					mediaType: 'image',
+					width: 1000
+				},
+				content_images: [
+					{
+						width: 1000
+					},
+					{
+						width: 150
+					},
+					{
+						width: 150
+					},
+					{
+						width: 150
+					},
+				],
+				better_excerpt_no_html: repeat( 'no ', 5 )
+			}, [ DISPLAY_TYPES.PHOTO_ONLY ] );
+		} );
 	} );
 
 	describe( 'isFeaturedImageInContent', () => {


### PR DESCRIPTION
As discussed in #9366, this PR tries changing the required minimum width for an image to be featured in a photo card from 480px to 440px.

It also fixes a bug in classification. Previously, posts with 5+ images would fail to be classified as PHOTO_ONLY if some of the images were not big enough for a gallery, even if there was a big enough image for a photo card.

### To test

Verify that the 'Dog vs Handbag' post is a photo card:

http://calypso.localhost:3000/read/feeds/55575582?at=2016-11-15T00:00:00Z

This post was being misclassified because of the bug described above.

Also verify that the 'Travel' post is a photo card:

http://calypso.localhost:3000/read/feeds/12974569?at=2016-11-15T00:00:00Z

This post has an image larger than the new minimum of 440px, but smaller than the original minimum of 480px.

There's also a new post classifier test which you can run with:

`npm run test-client client/state/reader/posts`

cc @raoulwegat
