### PR TITLE
Sites: Support settings UI in development versions of Jetpack

### DIFF
--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -1030,5 +1030,5 @@ export const hasDefaultSiteTitle = ( state, siteId ) => {
  * @return {?Boolean}     Whether site supports managing Jetpack settings remotely.
  */
 export const siteSupportsJetpackSettingsUI = ( state, siteId ) => {
-	return isJetpackMinimumVersion( state, siteId, '4.5.0' );
+	return isJetpackMinimumVersion( state, siteId, '4.5-beta1' );
 };

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -2362,5 +2362,24 @@ describe( 'selectors', () => {
 
 			expect( supportsJetpackSettingsUI ).to.be.true;
 		} );
+
+		it( 'should return true if the Jetpack version is 4.5-rc1', () => {
+			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUI( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://example.com',
+							jetpack: true,
+							options: {
+								jetpack_version: '4.5-rc1'
+							}
+						}
+					}
+				}
+			}, 77203074 );
+
+			expect( supportsJetpackSettingsUI ).to.be.true;
+		} );
 	} );
 } );


### PR DESCRIPTION
This PR is a continuation of #10584 and updates the `siteSupportsJetpackSettingsUI` selector to support development and release candidate versions, in order to allow us to develop with Jetpack `4.5-rc1` and subsequent pre-4.5 releases in the meantime.

To test:
* Checkout this branch
* Verify all tests are passing: ` npm run test-client client/state/sites/test/selectors.js -- --grep="siteSupportsJetpackSettingsUI"`