### PR TITLE
Editor: Remove extra translations

### DIFF
--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -143,25 +143,14 @@ export default React.createClass( {
 	},
 
 	getVerificationNoticeLabel: function() {
-		const primaryButtonState = getPublishButtonStatus( this.props.site, this.props.post, this.props.savedPost );
-		let buttonLabels;
+		const primaryButtonState = getPublishButtonStatus( this.props.site, this.props.post, this.props.savedPost ),
+			buttonLabels = {
+				update: i18n.translate( 'To update, check your email and confirm your address.' ),
+				schedule: i18n.translate( 'To schedule, check your email and confirm your address.' ),
+				publish: i18n.translate( 'To publish, check your email and confirm your address.' ),
+				requestReview: i18n.translate( 'To submit for review, check your email and confirm your address.' ),
+			};
 
-		// TODO: switch entirely to new wording once translations catch up
-		if ( i18n.getLocaleSlug() === 'en' ) {
-			buttonLabels = {
-				update: this.translate( 'To update, check your email and confirm your address.' ),
-				schedule: this.translate( 'To schedule, check your email and confirm your address.' ),
-				publish: this.translate( 'To publish, check your email and confirm your address.' ),
-				requestReview: this.translate( 'To submit for review, check your email and confirm your address.' ),
-			};
-		} else {
-			buttonLabels = {
-				update: this.translate( 'To update, please confirm your email address.' ),
-				schedule: this.translate( 'To schedule, please confirm your email address.' ),
-				publish: this.translate( 'To publish, please confirm your email address.' ),
-				requestReview: this.translate( 'To submit for review, please confirm your email address.' ),
-			};
-		}
 		return buttonLabels[ primaryButtonState ];
 	},
 


### PR DESCRIPTION
These extra translations have been here since June. We don't need them anymore.

To test:
- Create a new account with a non english locale
- Create a new post
- Check that the warning about not having a verified email address appears in the correct language:


<img width="282" alt="screen shot 2017-01-13 at 11 07 33" src="https://cloud.githubusercontent.com/assets/275961/21928067/a7858bf0-d980-11e6-835f-f7df1fd1ca40.png">