### PR TITLE
Site Settings: Fix lost site settings dirty fields when site icon is updated

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -40,11 +40,10 @@ import { FEATURE_NO_BRANDING } from 'lib/plans/constants';
 import {
 	isRequestingSiteSettings,
 	isSavingSiteSettings,
-	isSavingSiteSettingsRequest,
 	isSiteSettingsSaveSuccessful,
-	isSiteSettingsSaveRequestSuccessful,
 	getSiteSettings,
 	getSiteSettingsSaveError,
+	getSiteSettingsSaveRequestId
 } from 'state/site-settings/selectors';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import { saveSiteSettings } from 'state/site-settings/actions';
@@ -141,13 +140,15 @@ class SiteSettingsFormGeneral extends Component {
 		}
 
 		if (
-			this.props.isSavingForm &&
-			! nextProps.isSavingForm
+			this.props.isSavingSettings &&
+			! nextProps.isSavingSettings
 		) {
-			if ( nextProps.isFormSaveRequestSuccessful ) {
+			if ( nextProps.isSaveRequestSuccessful ) {
 				nextProps.successNotice( nextProps.translate( 'Settings saved!' ), { id: 'site-settings-save' } );
-				nextProps.clearDirtyFields();
-				nextProps.markSaved();
+				if ( nextProps.saveRequestId === FORM_ID ) {
+					nextProps.clearDirtyFields();
+					nextProps.markSaved();
+				}
 			} else {
 				let text;
 				switch ( nextProps.saveRequestError.error ) {
@@ -862,19 +863,16 @@ const connectComponent = connect(
 		const siteId = getSelectedSiteId( state );
 		const isRequestingSettings = isRequestingSiteSettings( state, siteId );
 		const isSavingSettings = isSavingSiteSettings( state, siteId );
-		const isSavingForm = isSavingSiteSettingsRequest( state, siteId, FORM_ID );
-		const settings = getSiteSettings( state, siteId );
-		const saveRequestError = getSiteSettingsSaveError( state, siteId, FORM_ID );
 		const isSaveRequestSuccessful = isSiteSettingsSaveSuccessful( state, siteId );
-		const isFormSaveRequestSuccessful = isSiteSettingsSaveRequestSuccessful( state, siteId, FORM_ID );
-
+		const settings = getSiteSettings( state, siteId );
+		const saveRequestError = getSiteSettingsSaveError( state, siteId );
+		const saveRequestId = getSiteSettingsSaveRequestId( state, siteId );
 		return {
 			isRequestingSettings: isRequestingSettings && ! settings,
-			isFormSaveRequestSuccessful,
-			isSavingForm,
 			isSavingSettings,
 			isSaveRequestSuccessful,
 			saveRequestError,
+			saveRequestId,
 			settings,
 			siteId
 		};

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -40,7 +40,9 @@ import { FEATURE_NO_BRANDING } from 'lib/plans/constants';
 import {
 	isRequestingSiteSettings,
 	isSavingSiteSettings,
+	isSavingSiteSettingsRequest,
 	isSiteSettingsSaveSuccessful,
+	isSiteSettingsSaveRequestSuccessful,
 	getSiteSettings,
 	getSiteSettingsSaveError,
 } from 'state/site-settings/selectors';
@@ -50,6 +52,8 @@ import { successNotice, errorNotice } from 'state/notices/actions';
 import { removeNotice } from 'state/notices/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import QuerySiteSettings from 'components/data/query-site-settings';
+
+const FORM_ID = 'GENERAL_SETTINGS_FORM';
 
 class SiteSettingsFormGeneral extends Component {
 	getFormSettings( settings ) {
@@ -137,10 +141,10 @@ class SiteSettingsFormGeneral extends Component {
 		}
 
 		if (
-			this.props.isSavingSettings &&
-			! nextProps.isSavingSettings
+			this.props.isSavingForm &&
+			! nextProps.isSavingForm
 		) {
-			if ( nextProps.isSaveRequestSuccessful ) {
+			if ( nextProps.isFormSaveRequestSuccessful ) {
 				nextProps.successNotice( nextProps.translate( 'Settings saved!' ), { id: 'site-settings-save' } );
 				nextProps.clearDirtyFields();
 				nextProps.markSaved();
@@ -191,7 +195,7 @@ class SiteSettingsFormGeneral extends Component {
 	submitForm() {
 		const { fields, site } = this.props;
 		this.props.removeNotice( 'site-settings-save' );
-		this.props.saveSiteSettings( site.ID, fields );
+		this.props.saveSiteSettings( site.ID, fields, FORM_ID );
 	}
 
 	onChangeField( field ) {
@@ -858,11 +862,16 @@ const connectComponent = connect(
 		const siteId = getSelectedSiteId( state );
 		const isRequestingSettings = isRequestingSiteSettings( state, siteId );
 		const isSavingSettings = isSavingSiteSettings( state, siteId );
-		const isSaveRequestSuccessful = isSiteSettingsSaveSuccessful( state, siteId );
+		const isSavingForm = isSavingSiteSettingsRequest( state, siteId, FORM_ID );
 		const settings = getSiteSettings( state, siteId );
-		const saveRequestError = getSiteSettingsSaveError( state, siteId );
+		const saveRequestError = getSiteSettingsSaveError( state, siteId, FORM_ID );
+		const isSaveRequestSuccessful = isSiteSettingsSaveSuccessful( state, siteId );
+		const isFormSaveRequestSuccessful = isSiteSettingsSaveRequestSuccessful( state, siteId, FORM_ID );
+
 		return {
 			isRequestingSettings: isRequestingSettings && ! settings,
+			isFormSaveRequestSuccessful,
+			isSavingForm,
 			isSavingSettings,
 			isSaveRequestSuccessful,
 			saveRequestError,

--- a/client/state/site-settings/actions.js
+++ b/client/state/site-settings/actions.js
@@ -82,11 +82,22 @@ export function requestSiteSettings( siteId ) {
 	};
 }
 
-export function saveSiteSettings( siteId, settings ) {
+/**
+ *
+ * Returns an action thunk which, when invoked, triggers a network request to
+ * save site settings
+ *
+ * @param  {Number} siteId   Site ID
+ * @param  {Object} settings Settings to be saved
+ * @param  {String} id       Save Request id
+ * @return {Function}        Action thunk
+ */
+export function saveSiteSettings( siteId, settings, id = 'default' ) {
 	return ( dispatch ) => {
 		dispatch( {
 			type: SITE_SETTINGS_SAVE,
-			siteId
+			siteId,
+			id
 		} );
 		// Optimistic update
 		dispatch( updateSiteSettings( siteId, settings ) );
@@ -96,14 +107,16 @@ export function saveSiteSettings( siteId, settings ) {
 				dispatch( updateSiteSettings( siteId, normalizeSettings( updated ) ) );
 				dispatch( {
 					type: SITE_SETTINGS_SAVE_SUCCESS,
-					siteId
+					siteId,
+					id
 				} );
 			} )
 			.catch( error => {
 				dispatch( {
 					type: SITE_SETTINGS_SAVE_FAILURE,
 					siteId,
-					error
+					error,
+					id
 				} );
 			} );
 	};

--- a/client/state/site-settings/reducer.js
+++ b/client/state/site-settings/reducer.js
@@ -47,24 +47,15 @@ export const requesting = createReducer( {}, {
 export const saveRequests = createReducer( {}, {
 	[ SITE_SETTINGS_SAVE ]: ( state, { siteId, id } ) => ( {
 		...state,
-		[ siteId ]: {
-			...state[ siteId ],
-			[ id ]: { saving: true, status: 'pending', error: false }
-		}
+		[ siteId ]: { saving: true, status: 'pending', error: false, id }
 	} ),
 	[ SITE_SETTINGS_SAVE_SUCCESS ]: ( state, { siteId, id } ) => ( {
 		...state,
-		[ siteId ]: {
-			...state[ siteId ],
-			[ id ]: { saving: false, status: 'success', error: false }
-		}
+		[ siteId ]: { saving: false, status: 'success', error: false, id }
 	} ),
 	[ SITE_SETTINGS_SAVE_FAILURE ]: ( state, { siteId, error, id } ) => ( {
 		...state,
-		[ siteId ]: {
-			...state[ siteId ],
-			[ id ]: { saving: false, status: 'error', error }
-		}
+		[ siteId ]: { saving: false, status: 'error', error, id }
 	} )
 } );
 

--- a/client/state/site-settings/reducer.js
+++ b/client/state/site-settings/reducer.js
@@ -45,12 +45,27 @@ export const requesting = createReducer( {}, {
  * @return {Object}        Updated state
  */
 export const saveRequests = createReducer( {}, {
-	[ SITE_SETTINGS_SAVE ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: { saving: true, status: 'pending', error: false } } ),
-	[ SITE_SETTINGS_SAVE_SUCCESS ]: ( state, { siteId } ) => ( {
+	[ SITE_SETTINGS_SAVE ]: ( state, { siteId, id } ) => ( {
 		...state,
-		[ siteId ]: { saving: false, status: 'success', error: false }
+		[ siteId ]: {
+			...state[ siteId ],
+			[ id ]: { saving: true, status: 'pending', error: false }
+		}
 	} ),
-	[ SITE_SETTINGS_SAVE_FAILURE ]: ( state, { siteId, error } ) => ( { ...state, [ siteId ]: { saving: false, status: 'error', error } } )
+	[ SITE_SETTINGS_SAVE_SUCCESS ]: ( state, { siteId, id } ) => ( {
+		...state,
+		[ siteId ]: {
+			...state[ siteId ],
+			[ id ]: { saving: false, status: 'success', error: false }
+		}
+	} ),
+	[ SITE_SETTINGS_SAVE_FAILURE ]: ( state, { siteId, error, id } ) => ( {
+		...state,
+		[ siteId ]: {
+			...state[ siteId ],
+			[ id ]: { saving: false, status: 'error', error }
+		}
+	} )
 } );
 
 /**

--- a/client/state/site-settings/selectors.js
+++ b/client/state/site-settings/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { every, get, some } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Returns true if we are requesting settings for the specified site ID, false otherwise.
@@ -22,19 +22,7 @@ export function isRequestingSiteSettings( state, siteId ) {
  * @return {Boolean}        Whether site settings is being requested
  */
 export function isSavingSiteSettings( state, siteId ) {
-	return some( get( state.siteSettings.saveRequests, [ siteId ] ), ( request ) => request.saving );
-}
-
-/**
- * Returns true if we the save settings request for the specified site ID, false otherwise.
- *
- * @param  {Object}  state  Global state tree
- * @param  {Number}  siteId Site ID
- * @param  {String}  id     Save Request id
- * @return {Boolean}        Whether the site settings request is being requested
- */
-export function isSavingSiteSettingsRequest( state, siteId, id = 'default' ) {
-	return get( state.siteSettings.saveRequests, [ siteId, id, 'saving' ] );
+	return get( state.siteSettings.saveRequests, [ siteId, 'saving' ], false );
 }
 
 /**
@@ -42,11 +30,10 @@ export function isSavingSiteSettingsRequest( state, siteId, id = 'default' ) {
  *
  * @param  {Object}  state  Global state tree
  * @param  {Number}  siteId Site ID
- * @param  {String}  id     Save Request id
  * @return {String}         The request status (peding, success or error)
  */
-export function getSiteSettingsSaveRequestStatus( state, siteId, id = 'default' ) {
-	return get( state.siteSettings.saveRequests, [ siteId, id, 'status' ] );
+export function getSiteSettingsSaveRequestStatus( state, siteId ) {
+	return get( state.siteSettings.saveRequests, [ siteId, 'status' ] );
 }
 
 /**
@@ -61,26 +48,14 @@ export function getSiteSettings( state, siteId ) {
 }
 
 /**
- * Returns true fi the all save site settings requests are successful
- *
- * @param  {Object}  state  Global state tree
- * @param  {Number}  siteId Site ID
- * @return {Boolean}        Whether the requests are successful or not
- */
-export function isSiteSettingsSaveSuccessful( state, siteId ) {
-	return every( get( state.siteSettings.saveRequests, [ siteId ] ), ( request ) => request.status === 'success' );
-}
-
-/**
  * Returns true fi the save site settings requests is successful
  *
  * @param  {Object}  state  Global state tree
  * @param  {Number}  siteId Site ID
- * @param  {String}  id     Save Request id
- * @return {Boolean}        Whether the request is successful or not
+ * @return {Boolean}         Whether the requests is successful or not
  */
-export function isSiteSettingsSaveRequestSuccessful( state, siteId, id = 'default' ) {
-	return getSiteSettingsSaveRequestStatus( state, siteId, id ) === 'success';
+export function isSiteSettingsSaveSuccessful( state, siteId ) {
+	return getSiteSettingsSaveRequestStatus( state, siteId ) === 'success';
 }
 
 /**
@@ -88,9 +63,19 @@ export function isSiteSettingsSaveRequestSuccessful( state, siteId, id = 'defaul
  *
  * @param  {Object}  state  Global state tree
  * @param  {Number}  siteId Site ID
- * @param  {String}  id     Save Request id
  * @return {String}         The request error
  */
-export function getSiteSettingsSaveError( state, siteId, id = 'default' ) {
-	return get( state.siteSettings.saveRequests, [ siteId, id, 'error' ], false );
+export function getSiteSettingsSaveError( state, siteId ) {
+	return get( state.siteSettings.saveRequests, [ siteId, 'error' ], false );
+}
+
+/**
+ * Returns the last site settings request ID
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {String}         The request error
+ */
+export function getSiteSettingsSaveRequestId( state, siteId ) {
+	return get( state.siteSettings.saveRequests, [ siteId, 'id' ] );
 }

--- a/client/state/site-settings/selectors.js
+++ b/client/state/site-settings/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { every, get, some } from 'lodash';
 
 /**
  * Returns true if we are requesting settings for the specified site ID, false otherwise.
@@ -22,7 +22,19 @@ export function isRequestingSiteSettings( state, siteId ) {
  * @return {Boolean}        Whether site settings is being requested
  */
 export function isSavingSiteSettings( state, siteId ) {
-	return get( state.siteSettings.saveRequests, [ siteId, 'saving' ], false );
+	return some( get( state.siteSettings.saveRequests, [ siteId ] ), ( request ) => request.saving );
+}
+
+/**
+ * Returns true if we the save settings request for the specified site ID, false otherwise.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @param  {String}  id     Save Request id
+ * @return {Boolean}        Whether the site settings request is being requested
+ */
+export function isSavingSiteSettingsRequest( state, siteId, id = 'default' ) {
+	return get( state.siteSettings.saveRequests, [ siteId, id, 'saving' ] );
 }
 
 /**
@@ -30,10 +42,11 @@ export function isSavingSiteSettings( state, siteId ) {
  *
  * @param  {Object}  state  Global state tree
  * @param  {Number}  siteId Site ID
+ * @param  {String}  id     Save Request id
  * @return {String}         The request status (peding, success or error)
  */
-export function getSiteSettingsSaveRequestStatus( state, siteId ) {
-	return get( state.siteSettings.saveRequests, [ siteId, 'status' ] );
+export function getSiteSettingsSaveRequestStatus( state, siteId, id = 'default' ) {
+	return get( state.siteSettings.saveRequests, [ siteId, id, 'status' ] );
 }
 
 /**
@@ -48,14 +61,26 @@ export function getSiteSettings( state, siteId ) {
 }
 
 /**
+ * Returns true fi the all save site settings requests are successful
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {Boolean}        Whether the requests are successful or not
+ */
+export function isSiteSettingsSaveSuccessful( state, siteId ) {
+	return every( get( state.siteSettings.saveRequests, [ siteId ] ), ( request ) => request.status === 'success' );
+}
+
+/**
  * Returns true fi the save site settings requests is successful
  *
  * @param  {Object}  state  Global state tree
  * @param  {Number}  siteId Site ID
- * @return {Boolean}         Whether the requests is successful or not
+ * @param  {String}  id     Save Request id
+ * @return {Boolean}        Whether the request is successful or not
  */
-export function isSiteSettingsSaveSuccessful( state, siteId ) {
-	return getSiteSettingsSaveRequestStatus( state, siteId ) === 'success';
+export function isSiteSettingsSaveRequestSuccessful( state, siteId, id = 'default' ) {
+	return getSiteSettingsSaveRequestStatus( state, siteId, id ) === 'success';
 }
 
 /**
@@ -63,8 +88,9 @@ export function isSiteSettingsSaveSuccessful( state, siteId ) {
  *
  * @param  {Object}  state  Global state tree
  * @param  {Number}  siteId Site ID
+ * @param  {String}  id     Save Request id
  * @return {String}         The request error
  */
-export function getSiteSettingsSaveError( state, siteId ) {
-	return get( state.siteSettings.saveRequests, [ siteId, 'error' ], false );
+export function getSiteSettingsSaveError( state, siteId, id = 'default' ) {
+	return get( state.siteSettings.saveRequests, [ siteId, id, 'error' ], false );
 }


### PR DESCRIPTION
This is still WIP but will allow us to discuss more for the best way to fix #10412 

**Testing instructions**
 - Navigate to the general settings form
 - Edit the title of the blog
 - Update the site icon
 - Try to navigate away from the form
 - You should be prompted with the "Discard local changes" modal