### PR TITLE
Stats: Fix the default selected period in the video summary component

### DIFF
--- a/client/my-sites/stats/stats-video-summary/index.jsx
+++ b/client/my-sites/stats/stats-video-summary/index.jsx
@@ -26,16 +26,6 @@ class StatsVideoSummary extends Component {
 		selectedBar: null
 	};
 
-	componentWillReceiveProps( nextProps ) {
-		const chartDataLength = nextProps.summaryData ? nextProps.summaryData.length : null;
-		// Always default to the last bar being selected
-		if ( ! this.state.selectedBar && chartDataLength ) {
-			this.setState( {
-				selectedBar: nextProps.summaryData[ chartDataLength - 1 ]
-			} );
-		}
-	}
-
 	selectBar = bar => {
 		this.setState( {
 			selectedBar: bar


### PR DESCRIPTION
In my previous PR #10561, I forgot to drop the former `componentWillReceiveProps` logic. This was causing the default selected bar on the summary chart for videos to not be selected properly.

**Testing instructions**

- Navigate to the video stats summary: `/stats/day/videodetails/$site?post=$videoId`
- Make sure the last bar in the chart is "orange" (selected)
