### PR TITLE
Guided Tours: Disable Editor Insert Media tour, except for explicit debugging

### DIFF
--- a/client/layout/guided-tours/tours/editor-insert-menu-tour.js
+++ b/client/layout/guided-tours/tours/editor-insert-menu-tour.js
@@ -16,6 +16,7 @@ import {
 	Quit,
 } from 'layout/guided-tours/config-elements';
 import {
+	isDebuggingGuidedTours,
 	isEnabled,
 	hasUserRegisteredBefore,
 } from 'state/ui/guided-tours/contexts';
@@ -44,6 +45,7 @@ export const EditorInsertMenuTour = makeTour(
 		path={ [ '/post/', '/page/' ] }
 		version="20161215"
 		when={ and(
+			isDebuggingGuidedTours,
 			isEnabled( 'post-editor/insert-menu' ),
 			hasUserRegisteredBefore( new Date( '2016-12-15' ) ),
 			isDesktop,

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -34,6 +34,15 @@ export const isEnabled = feature => () =>
 	config.isEnabled( feature );
 
 /**
+ * Returns true if there is a global `isDebuggingGuidedTours` present with a
+ * truthy value.
+ *
+ * @return {Boolean} True if `window.isDebuggingGuidedTours` truthy
+ */
+export const isDebuggingGuidedTours = () =>
+	!! global.window.isDebuggingGuidedTours;
+
+/**
  * Returns milliseconds since registration date of the current user
  *
  * @param {Object} state Global state tree


### PR DESCRIPTION
Due to ongoing issue #10568 not just applying to users with 2-factor authentication enabled as previously thought, this PR:
- disables `editorInsertMedia` tour immediately for general users;
- introduces a rudimentary mechanism to debug the issue regardless of environment (`window.isDebuggingGuidedTours`).