### PR TITLE
Copy Post: fix missing title and visibility in post controls

### DIFF
--- a/client/my-sites/posts/post-controls.jsx
+++ b/client/my-sites/posts/post-controls.jsx
@@ -171,7 +171,7 @@ module.exports = React.createClass( {
 			}
 		}
 
-		if ( post.status === 'publish' && utils.userCan( 'edit_post', post ) ) {
+		if ( ( post.status === 'publish' || post.status === 'private' ) && utils.userCan( 'edit_post', post ) ) {
 			availableControls.push( {
 				text: this.translate( 'Copy' ),
 				className: 'post-controls__copy',

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -127,6 +127,7 @@ function startEditingPostCopy( siteId, postToCopyId, context ) {
 			'metadata',
 			'post_thumbnail',
 			'terms',
+			'title',
 			'type'
 		);
 		postAttributes.tags = map( postToCopy.tags, 'name' );


### PR DESCRIPTION
Two extremely quick fixes:

- Add back `title` in the post attributes to copy. It got likely lost in one of the last rebase before merging.

- Make the Copy Post feature available for private posts to, in order to be consistent with the `<PostSelector>` default behaviour (it shows `publish` and `private` posts).