### PR TITLE
Sites: Omit post type publish menu items if UI not to be shown

### DIFF
--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -3,11 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import includes from 'lodash/includes';
-import omit from 'lodash/omit';
-import map from 'lodash/map';
-import get from 'lodash/get';
-import mapValues from 'lodash/mapValues';
+import { includes, omit, reduce, get, mapValues } from 'lodash';
 
 /**
  * Internal dependencies
@@ -170,13 +166,19 @@ const PublishMenu = React.createClass( {
 
 	getCustomMenuItems() {
 		const customPostTypes = omit( this.props.postTypes, [ 'post', 'page' ] );
-		return map( customPostTypes, ( postType, postTypeSlug ) => {
+		return reduce( customPostTypes, ( memo, postType, postTypeSlug ) => {
+			// `show_ui` was added in Jetpack 4.5, so explicitly check false
+			// value in case site on earlier version where property is omitted
+			if ( false === postType.show_ui ) {
+				return memo;
+			}
+
 			let buttonLink;
 			if ( config.isEnabled( 'manage/custom-post-types' ) && postType.api_queryable ) {
 				buttonLink = this.props.postTypeLinks[ postTypeSlug ];
 			}
 
-			return {
+			return memo.concat( {
 				name: postType.name,
 				label: decodeEntities( get( postType.labels, 'menu_name', postType.label ) ),
 				className: postType.name,
@@ -193,8 +195,8 @@ const PublishMenu = React.createClass( {
 				wpAdminLink: 'edit.php?post_type=' + postType.name,
 				showOnAllMySites: false,
 				buttonLink
-			};
-		} );
+			} );
+		}, [] );
 	},
 
 	render() {


### PR DESCRIPTION
Related: https://github.com/Automattic/jetpack/pull/5487

This pull request seeks to resolve an issue where sites running Jetpack 4.5 beta (and eventually WordPress.com sites once changes are synced) will show publish menu items in the My Sites sidebar despite having been [registered with `show_ui` set to `false`](https://codex.wordpress.org/Function_Reference/register_post_type).

__Testing instructions:__

Prerequisite: [Install and update to Jetpack 4.5 Beta](https://jetpack.com/beta/)

1. Navigate to My SItes
2. Change to site running Jetpack 4.5 beta or newer
3. Note that post types with `show_ui` of `false` are not shown in Publish sidebar section (e.g. Revisions)

Below is a sample plugin for a basic custom post type if you want to tinker with values. As downloaded, it is public, shown in UI, and whitelisted in the REST API:

- https://cloudup.com/files/i1uX4SkJwwq/download

cc @mtias @lezama @beaulebens @ebinnion 