### PR TITLE
Jetpack Settings: Update items reducer state traversal method for Jetpack modules when syncing with Jetpack settings. 

### DIFF
--- a/client/state/jetpack/modules/reducer.js
+++ b/client/state/jetpack/modules/reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import { forEach, merge, pickBy } from 'lodash';
+import { forEach, get, merge, pickBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -67,7 +67,7 @@ const createSettingsItemsReducer = () => {
 	return ( state, { siteId, settings } ) => {
 		let updatedState = state;
 		const moduleActivationState = pickBy( settings, ( settingValue, settingName ) => {
-			return state[ siteId ].hasOwnProperty( settingName );
+			return get( state, [ siteId, settingName ] ) !== undefined;
 		} );
 
 		forEach( moduleActivationState, ( active, moduleSlug ) => {


### PR DESCRIPTION
Part of #9171.

Fetching jetpack settings with `state/jetpack/settings/actions#fetchSettings` won't succeed even though the network request is successful. 

This is due to an intent to use `hasOwnProperty` on a unloaded site's property.

![image](https://cloud.githubusercontent.com/assets/746152/21939246/a59f1f64-d99d-11e6-853a-a3279b816dcd.png)


#### Changes proposed in this Pull Request:

Uses `lodash.get` for traversing the state tree, instead of `.hasOwnProperty`.

#### Testing instructions:

* Use `<QueryJetpackSettings />` anywhere in a settings tab and visit this tab for a jetpack site of yours.
* Check the Redux Dev Tools and confirm you see  the `JETPACK_SETTINGS_RECEIVE` action, dispatched.



