### PR TITLE
Stats: Remove unused stats-lists from site page.

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -352,14 +352,6 @@ module.exports = {
 				siteID: siteId, statType: 'statsVideoPlays', period: activeFilter.period, date: endDate, domain: siteDomain } );
 			const searchTermsList = new StatsList( {
 				siteID: siteId, statType: 'statsSearchTerms', period: activeFilter.period, date: endDate, domain: siteDomain } );
-			const tagsList = new StatsList( { siteID: siteId, statType: 'statsTags', domain: siteDomain } );
-			const commentsList = new StatsList( { siteID: siteId, statType: 'statsComments', domain: siteDomain } );
-			const wpcomFollowersList = new StatsList( {
-				siteID: siteId, statType: 'statsFollowers', type: 'wpcom', domain: siteDomain, max: 7 } );
-			const emailFollowersList = new StatsList( {
-				siteID: siteId, statType: 'statsFollowers', type: 'email', domain: siteDomain, max: 7 } );
-			const commentFollowersList = new StatsList( {
-				siteID: siteId, statType: 'statsCommentFollowers', domain: siteDomain, max: 7 } );
 
 			siteComponent = SiteStatsComponent;
 			const siteComponentChildren = {
@@ -379,11 +371,6 @@ module.exports = {
 				siteId,
 				period,
 				chartPeriod,
-				tagsList,
-				commentsList,
-				wpcomFollowersList,
-				emailFollowersList,
-				commentFollowersList,
 				followList,
 				searchTermsList,
 				slug: siteDomain,

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -102,7 +102,6 @@ module.exports = React.createClass( {
 		const queryDate = this.props.date.format( 'YYYY-MM-DD' );
 		const { period, endOf } = this.props.period;
 		const moduleStrings = statsStrings();
-		let nonPeriodicModules;
 		let videoList;
 		let podcastList;
 
@@ -218,7 +217,6 @@ module.exports = React.createClass( {
 							{ podcastList }
 						</div>
 					</div>
-					{ nonPeriodicModules }
 				</div>
 			</Main>
 		);


### PR DESCRIPTION
There are times when I read old code and have moments of "what the .... is that doing there?" - and this is one of them 💯 

__Stroll Down Memory Lane__
At one time, prior to the Insights tab being launched, Tags, Comments, and Followers ( aka `nonPeriodicModules` ) lived on the Stats Day/Week/Month/Year pages.  When Insights was launched, these modules were still shown on the Stats "period" pages for a while - I believe while A/B testing - but have long since permanently moved to Insights.

But yet these lines of code have remained well after their welcome was long gone... almost like a random friend from college who wanted to crash at your house for a week, but is still there two months later.

Well, old stats lists, it is time you are shown to the door... and take your five un-needed network requests with you.

__To Test__
- Open site stats pages and test out Day, Week, Month, Year.  Verify all works well after the old stats lists have been removed.
- Open the Insights tab.  Verify all is well there too.