### PR TITLE
Do not retry authorization with incomplete data

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -256,7 +256,8 @@ const LoggedInForm = React.createClass( {
 			this.props.authAttempts < MAX_AUTH_ATTEMPTS &&
 			! this.retryingAuth &&
 			! props.requestHasXmlrpcError() &&
-			! props.requestHasExpiredSecretError()
+			! props.requestHasExpiredSecretError() &&
+			queryObject.site
 		) {
 			// Expired secret errors, and XMLRPC errors will be resolved in `handleResolve`.
 			// Any other type of error, we will immediately and automatically retry the request as many times


### PR DESCRIPTION
@josephscott reported an error where he was redirected to an on odd page on jetpack.wordpress.com while attempting to connect his Jetpack site.

I was able to reproduce the error by programatically removing `site` from query args in the url.

See: [ [video](https://cloudup.com/c6QvpfOCuli) ]

I'm not sure how Joseph ended up with no `site` query - I had to force that condition - but I've made our form fail more gracefully if that happens. With this PR, we do not attempt to re-authorize automatically. We simply show an error message and present the manual retry button. Clicking the manual retry button will re-attempt the auth through the legacy flow which does not require `site`

See: [ [video](https://cloudup.com/cpztlhqUIB5) ]
