### PR TITLE
Build: Teach Webpack how to minimize our JS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ env-config.sh
 /build
 
 /public/*.js
+/public/*.js.map
 /public/style*.css
 /public/style*.css.map
 /public/editor*.css

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ build-desktop: build-server build-css
 # the `clean` rule deletes all the files created from `make build`, but not
 # those created by `make install`
 clean:
-	@rm -rf public/style*.css public/style-debug.css.map public/*.js server/devdocs/search-index.js server/devdocs/proptypes-index.json server/devdocs/components-usage-stats.json public/directly.css public/editor.css build/* server/bundler/*.json .babel-cache
+	@rm -rf public/style*.css public/style-debug.css.map public/*.js public/*.js.map server/devdocs/search-index.js server/devdocs/proptypes-index.json server/devdocs/components-usage-stats.json public/directly.css public/editor.css build/* server/bundler/*.json .babel-cache
 
 # the `distclean` rule deletes all the files created from `make install`
 distclean: clean

--- a/server/bundler/bin/bundler.js
+++ b/server/bundler/bin/bundler.js
@@ -106,4 +106,15 @@ webpack( webpackConfig, function( error, stats ) {
 	assets = utils.getAssets( stats.toJson() );
 
 	fs.writeFileSync( path.join( __dirname, '..', 'assets.json' ), JSON.stringify( assets, null, '\t' ) );
+
+	if ( ! process.env.WEBPACK_OUTPUT_JSON ) {
+		// sort by size to make parallel minification go a bit quicker. don't get stuck doing the big stuff last.
+		files = assets.sort( function( a, b ) {
+			return b.size - a.size;
+		} ).map( function( chunk ) {
+			return path.join( process.cwd(), 'public', chunk.file );
+		} );
+
+		minify( files );
+	}
 });

--- a/server/bundler/bin/bundler.js
+++ b/server/bundler/bin/bundler.js
@@ -106,13 +106,4 @@ webpack( webpackConfig, function( error, stats ) {
 	assets = utils.getAssets( stats.toJson() );
 
 	fs.writeFileSync( path.join( __dirname, '..', 'assets.json' ), JSON.stringify( assets, null, '\t' ) );
-
-	// sort by size to make parallel minification go a bit quicker. don't get stuck doing the big stuff last.
-	files = assets.sort( function( a, b ) {
-		return b.size - a.size;
-	} ).map( function( chunk ) {
-		return path.join( process.cwd(), 'public', chunk.file );
-	} );
-
-	minify( files );
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -215,4 +215,25 @@ if ( config.isEnabled( 'webpack/persistent-caching' ) ) {
 
 webpackConfig.module.loaders = [ jsLoader ].concat( webpackConfig.module.loaders );
 
+if ( calypsoEnv !== 'development' ) {
+	webpackConfig.devtool = 'source-map';
+	webpackConfig.plugins.push( new webpack.optimize.UglifyJsPlugin( {
+		minimize: true,
+		compress: {
+			warnings: false,
+			conditionals: true,
+			unused: true,
+			comparisons: true,
+			sequences: true,
+			dead_code: true,
+			evaluate: true,
+			if_return: true,
+			join_vars: true,
+			negate_iife: false,
+			screw_ie8: true
+		},
+		sourceMap: true
+	} ) );
+}
+
 module.exports = webpackConfig;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -216,7 +216,7 @@ if ( config.isEnabled( 'webpack/persistent-caching' ) ) {
 webpackConfig.module.loaders = [ jsLoader ].concat( webpackConfig.module.loaders );
 
 if ( process.env.WEBPACK_OUTPUT_JSON ) {
-	webpackConfig.devtool = 'source-map';
+	webpackConfig.devtool = 'cheap-module-source-map';
 	webpackConfig.plugins.push( new webpack.optimize.UglifyJsPlugin( {
 		minimize: true,
 		compress: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -215,7 +215,7 @@ if ( config.isEnabled( 'webpack/persistent-caching' ) ) {
 
 webpackConfig.module.loaders = [ jsLoader ].concat( webpackConfig.module.loaders );
 
-if ( calypsoEnv !== 'development' ) {
+if ( process.env.WEBPACK_OUTPUT_JSON ) {
 	webpackConfig.devtool = 'source-map';
 	webpackConfig.plugins.push( new webpack.optimize.UglifyJsPlugin( {
 		minimize: true,


### PR DESCRIPTION
Follow-on from #10559 to make the bundle analyzer report actual production bundle sizes. Previously, it would report the sizes for unminified bundles, which in some cases are quite a bit larger than minified bundles, both in raw terms and after gzip.

~~This PR does not yet teach our server code to never use -min files, so it actually breaks calypso proper. It's only currently useful for the bundle analyzer.~~ We skip that at the moment and use process env flag to minify production files when computing bundle stats.

### Testing
1. Run `make run` and make sure it works as before.
2. Run `make analyze-bundles` and make sure it works. It takes a while to run.

Sample output:
![screen shot 2017-04-19 at 08 46 26](https://cloud.githubusercontent.com/assets/699132/25166662/b68a675e-24dc-11e7-894d-a2e03866e5ff.png)
