### PR TITLE
Stats: Add all-time summaries for Countries.

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import page from 'page';
 import i18n from 'i18n-calypso';
-import { find } from 'lodash';
+import { find, pick } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -460,6 +460,14 @@ module.exports = {
 			// TODO when all lists are moved to redux, remove this logic
 			const fakeStatsList = Emitter( {} );
 
+			let statsQueryOptions = {};
+
+			// All Time Summary Support
+			if ( queryOptions.summarize && queryOptions.num ) {
+				statsQueryOptions = pick( queryOptions, [ 'num', 'summarize' ] );
+				statsQueryOptions.period = 'day';
+			}
+
 			switch ( context.params.module ) {
 
 				case 'posts':
@@ -528,6 +536,7 @@ module.exports = {
 					followList: followList,
 					siteId: siteId,
 					period: period,
+					statsQueryOptions,
 					...extraProps
 				} ),
 				document.getElementById( 'primary' ),

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -3,6 +3,7 @@
  */
 import React, { PropTypes, Component } from 'react';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 
 class StatsDatePicker extends Component {
 	static propTypes = {
@@ -12,7 +13,35 @@ class StatsDatePicker extends Component {
 		] ),
 		period: PropTypes.string.isRequired,
 		summary: PropTypes.bool,
+		query: PropTypes.object,
 	};
+
+	dateForSummarize() {
+		const { query, moment, translate } = this.props;
+		const localizedDate = moment();
+		let formattedDate;
+
+		switch ( query.num ) {
+			case '-1':
+				formattedDate = translate( 'All Time' );
+				break;
+
+			default:
+				formattedDate = translate(
+					'%(number)s days ending %(endDate)s (Summarized)',
+					{
+						context: 'Date range for which stats are being displayed',
+						args: {
+							// LL is a date localized by momentjs
+							number: parseInt( query.num ),
+							endDate: localizedDate.format( 'LL' )
+						}
+					}
+				);
+		}
+
+		return formattedDate;
+	}
 
 	dateForDisplay() {
 		const { date, moment, period, translate } = this.props;
@@ -51,13 +80,14 @@ class StatsDatePicker extends Component {
 	}
 
 	render() {
-		const { summary, translate } = this.props;
+		const { summary, translate, query } = this.props;
+		const isSummarizeQuery = get( query, 'summarize' );
 
 		const sectionTitle = translate( 'Stats for {{period/}}', {
 			components: {
 				period: (
 					<span className="period">
-						<span className="date">{ this.dateForDisplay() }</span>
+						<span className="date">{ isSummarizeQuery ? this.dateForSummarize() : this.dateForDisplay() }</span>
 					</span>
 				)
 			},

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -19,15 +19,13 @@ class StatsDatePicker extends Component {
 	dateForSummarize() {
 		const { query, moment, translate } = this.props;
 		const localizedDate = moment();
-		let formattedDate;
 
 		switch ( query.num ) {
 			case '-1':
-				formattedDate = translate( 'All Time' );
-				break;
+				return translate( 'All Time' );
 
 			default:
-				formattedDate = translate(
+				return translate(
 					'%(number)s days ending %(endDate)s (Summarized)',
 					{
 						context: 'Date range for which stats are being displayed',
@@ -39,8 +37,6 @@ class StatsDatePicker extends Component {
 					}
 				);
 		}
-
-		return formattedDate;
 	}
 
 	dateForDisplay() {

--- a/client/my-sites/stats/stats-download-csv/index.jsx
+++ b/client/my-sites/stats/stats-download-csv/index.jsx
@@ -29,6 +29,8 @@ class StatsDownloadCsv extends Component {
 		query: PropTypes.object,
 		statType: PropTypes.string,
 		siteId: PropTypes.number,
+		className: PropTypes.string,
+		borderless: PropTypes.bool,
 	}
 
 	downloadCsv = ( event ) => {
@@ -55,7 +57,7 @@ class StatsDownloadCsv extends Component {
 	}
 
 	render() {
-		const { data, siteId, statType, query, translate, isLoading } = this.props;
+		const { data, siteId, statType, query, translate, isLoading, borderless, className } = this.props;
 		try {
 			const isFileSaverSupported = !! new Blob(); // eslint-disable-line no-unused-vars
 		} catch ( e ) {
@@ -64,7 +66,7 @@ class StatsDownloadCsv extends Component {
 		const disabled = isLoading || ! data.length;
 
 		return (
-			<Button compact onClick={ this.downloadCsv } disabled={ disabled }>
+			<Button compact onClick={ this.downloadCsv } disabled={ disabled } borderless={ borderless } className={ className }>
 				{ siteId && statType && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
 				<Gridicon icon="cloud-download" /> { translate( 'Download data as CSV', {
 					context: 'Action shown in stats to download data as csv.'

--- a/client/my-sites/stats/stats-download-csv/index.jsx
+++ b/client/my-sites/stats/stats-download-csv/index.jsx
@@ -29,7 +29,6 @@ class StatsDownloadCsv extends Component {
 		query: PropTypes.object,
 		statType: PropTypes.string,
 		siteId: PropTypes.number,
-		className: PropTypes.string,
 		borderless: PropTypes.bool,
 	}
 
@@ -57,7 +56,7 @@ class StatsDownloadCsv extends Component {
 	}
 
 	render() {
-		const { data, siteId, statType, query, translate, isLoading, borderless, className } = this.props;
+		const { data, siteId, statType, query, translate, isLoading, borderless } = this.props;
 		try {
 			const isFileSaverSupported = !! new Blob(); // eslint-disable-line no-unused-vars
 		} catch ( e ) {
@@ -66,7 +65,7 @@ class StatsDownloadCsv extends Component {
 		const disabled = isLoading || ! data.length;
 
 		return (
-			<Button compact onClick={ this.downloadCsv } disabled={ disabled } borderless={ borderless } className={ className }>
+			<Button compact onClick={ this.downloadCsv } disabled={ disabled } borderless={ borderless }>
 				{ siteId && statType && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
 				<Gridicon icon="cloud-download" /> { translate( 'Download data as CSV', {
 					context: 'Action shown in stats to download data as csv.'

--- a/client/my-sites/stats/stats-module/all-time-nav.jsx
+++ b/client/my-sites/stats/stats-module/all-time-nav.jsx
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ **/
+import React from 'react';
+import { connect } from 'react-redux';
+import { flowRight } from 'lodash';
+import { localize, moment } from 'i18n-calypso';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import SelectDropdown from 'components/select-dropdown';
+import { recordGoogleEvent } from 'state/analytics/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
+
+export const StatsModuleSummaryLinks = props => {
+	const { translate, path, siteSlug, query } = props;
+
+	const now = moment();
+	const quarter = moment().startOf( 'quarter' );
+	const daysSinceQuarterStart = now.diff( quarter, 'd' );
+	const options = [
+		{ value: '0', label: translate( 'Summary Views' ) },
+		{ value: '7', label: translate( 'Last 7 Days' ) },
+		{ value: '30', label: translate( 'Last 30 Days' ) },
+		{ value: `${ daysSinceQuarterStart }`, label: translate( 'This Quarter' ) },
+		{ value: '-1', label: translate( 'All Time' ) }
+	];
+
+	const onSelect = ( item ) => {
+		if ( item.value !== '0' ) {
+			page( `/stats/day/${ path }/${ siteSlug }?startDate=${ moment().format( 'YYYY-MM-DD' ) }&summarize=1&num=${ item.value }` );
+		}
+	};
+
+	return (
+		<SelectDropdown
+			compact={ true }
+			initialSelected={ query.num }
+			options={ options }
+			onSelect={ onSelect } />
+	);
+};
+
+const connectComponent = connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSiteSlug( state, siteId );
+
+	return { siteSlug };
+}, { recordGoogleEvent } );
+
+export default flowRight(
+	connectComponent,
+	localize
+)( StatsModuleSummaryLinks );

--- a/client/my-sites/stats/stats-module/all-time-nav.jsx
+++ b/client/my-sites/stats/stats-module/all-time-nav.jsx
@@ -22,10 +22,10 @@ export const StatsModuleSummaryLinks = props => {
 	const quarter = moment().startOf( 'quarter' );
 	const daysSinceQuarterStart = now.diff( quarter, 'd' );
 	const options = [
-		{ value: '0', label: translate( 'Summary Views' ) },
-		{ value: '7', label: translate( 'Last 7 Days' ) },
-		{ value: '30', label: translate( 'Last 30 Days' ) },
-		{ value: `${ daysSinceQuarterStart }`, label: translate( 'This Quarter' ) },
+		{ value: '0', label: translate( 'Summary' ) },
+		{ value: '7', label: translate( 'Last 7 days' ) },
+		{ value: '30', label: translate( 'Last 30 days' ) },
+		{ value: `${ daysSinceQuarterStart }`, label: translate( 'the past quarter' ) },
 		{ value: '-1', label: translate( 'All Time' ) }
 	];
 
@@ -37,7 +37,7 @@ export const StatsModuleSummaryLinks = props => {
 
 	return (
 		<SelectDropdown
-			compact={ true }
+			compact
 			initialSelected={ query.num }
 			options={ options }
 			onSelect={ onSelect } />

--- a/client/my-sites/stats/stats-module/all-time-nav.jsx
+++ b/client/my-sites/stats/stats-module/all-time-nav.jsx
@@ -3,44 +3,74 @@
  **/
 import React from 'react';
 import { connect } from 'react-redux';
-import { flowRight } from 'lodash';
+import { flowRight, find, get } from 'lodash';
 import { localize, moment } from 'i18n-calypso';
-import page from 'page';
 
 /**
  * Internal dependencies
  */
-import SelectDropdown from 'components/select-dropdown';
+import SectionNav from 'components/section-nav';
+import NavTabs from 'components/section-nav/tabs';
+import NavItem from 'components/section-nav/item';
+import DatePicker from '../stats-date-picker';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 
 export const StatsModuleSummaryLinks = props => {
-	const { translate, path, siteSlug, query } = props;
+	const { translate, path, siteSlug, query, period, children } = props;
 
 	const now = moment();
 	const quarter = moment().startOf( 'quarter' );
 	const daysSinceQuarterStart = now.diff( quarter, 'd' );
-	const options = [
-		{ value: '0', label: translate( 'Summary' ) },
-		{ value: '7', label: translate( 'Last 7 days' ) },
-		{ value: '30', label: translate( 'Last 30 days' ) },
-		{ value: `${ daysSinceQuarterStart }`, label: translate( 'the past quarter' ) },
-		{ value: '-1', label: translate( 'All Time' ) }
-	];
 
-	const onSelect = ( item ) => {
-		if ( item.value !== '0' ) {
-			page( `/stats/day/${ path }/${ siteSlug }?startDate=${ moment().format( 'YYYY-MM-DD' ) }&summarize=1&num=${ item.value }` );
+	const getSummaryPeriodLabel = () => {
+		switch ( period.period ) {
+			case 'day':
+				return translate( 'Day Summary' );
+			case 'week':
+				return translate( 'Week Summary' );
+			case 'month':
+				return translate( 'Month Summary' );
+			case 'year':
+				return translate( 'Year Summary' );
 		}
 	};
 
+	const summaryPath = `/stats/day/${ path }/${ siteSlug }?startDate=${ moment().format( 'YYYY-MM-DD' ) }&summarize=1&num=`;
+	const summaryPeriodPath = `/stats/${ period.period }/${ path }/${ siteSlug }?startDate=${ period.endOf.format( 'YYYY-MM-DD' ) }`;
+	const options = [
+		{ value: '0', label: getSummaryPeriodLabel(), path: summaryPeriodPath },
+		{ value: '7', label: translate( 'Last 7 days' ), path: `${ summaryPath }7` },
+		{ value: '30', label: translate( 'Last 30 days' ), path: `${ summaryPath }30` },
+		{ value: `${ daysSinceQuarterStart }`, label: translate( 'Past quarter' ), path: `${ summaryPath }${ daysSinceQuarterStart }` },
+		{ value: '-1', label: translate( 'All Time' ), path: `${ summaryPath }-1` }
+	];
+
+	const numberDays = get( query, 'num', '0' );
+	const selected = find( options, { value: numberDays } );
+
 	return (
-		<SelectDropdown
-			compact
-			initialSelected={ query.num }
-			options={ options }
-			onSelect={ onSelect } />
+		<div className="stats-module__all-time-nav">
+			<SectionNav selectedText={ selected.label }>
+				<NavTabs label={ translate( 'Summary' ) }>
+					{ options.map( ( item ) => {
+						return (
+							<NavItem path={ item.path } selected={ item.value === selected.value } key={ item.value }>
+								{ item.label }
+							</NavItem>
+						);
+					} ) }
+				</NavTabs>
+				{ children }
+			</SectionNav>
+			<DatePicker
+				period={ period.period }
+				date={ period.startOf }
+				path={ path }
+				query={ query }
+				summary={ false } />
+		</div>
 	);
 };
 

--- a/client/my-sites/stats/stats-module/connected-list.jsx
+++ b/client/my-sites/stats/stats-module/connected-list.jsx
@@ -5,6 +5,7 @@ import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,6 +21,7 @@ import StatsModulePlaceholder from './placeholder';
 import SectionHeader from 'components/section-header';
 import QuerySiteStats from 'components/data/query-site-stats';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
+import AllTimeNav from './all-time-nav';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import {
@@ -52,12 +54,15 @@ class StatsConnectedModule extends Component {
 		if ( ! this.props.summary ) {
 			return this.props.moduleStrings.title;
 		}
+		const { period, startOf } = this.props.period;
+		const { path, query } = this.props;
 
 		return (
 			<DatePicker
-				period={ this.props.period.period }
-				date={ this.props.period.startOf }
-				path={ this.props.path }
+				period={ period }
+				date={ startOf }
+				path={ path }
+				query={ query }
 				summary={ true } />
 			);
 	}
@@ -69,6 +74,11 @@ class StatsConnectedModule extends Component {
 		if ( ! summary && period && path && siteSlug ) {
 			return '/stats/' + period.period + '/' + path + '/' + siteSlug + '?startDate=' + period.startOf.format( 'YYYY-MM-DD' );
 		}
+	}
+
+	isAllTimeList() {
+		const { summary, statType } = this.props;
+		return summary && includes( [ 'statsCountryViews' ], statType );
 	}
 
 	render() {
@@ -110,12 +120,14 @@ class StatsConnectedModule extends Component {
 
 		const summaryLink = this.getHref();
 		const displaySummaryLink = data && data.length >= 10;
+		const isAllTime = this.isAllTimeList();
 
 		return (
 			<div>
 				{ siteId && statType && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
 				<SectionHeader label={ this.getModuleLabel() } href={ ! summary ? summaryLink : null }>
-					{ summary && <DownloadCsv statType={ statType } query={ query } path={ path } period={ period } /> }
+					{ isAllTime && <AllTimeNav path={ path } query={ query } /> }
+					{ summary && ! isAllTime && <DownloadCsv statType={ statType } query={ query } path={ path } period={ period } /> }
 				</SectionHeader>
 				<Card compact className={ cardClasses }>
 					{ noData && <ErrorPanel message={ moduleStrings.empty } /> }

--- a/client/my-sites/stats/stats-module/connected-list.jsx
+++ b/client/my-sites/stats/stats-module/connected-list.jsx
@@ -136,6 +136,17 @@ class StatsConnectedModule extends Component {
 					<StatsListLegend value={ moduleStrings.value } label={ moduleStrings.item } />
 					<StatsModulePlaceholder isLoading={ isLoading } />
 					<StatsList moduleName={ path } data={ data } />
+					{
+						summary &&
+						isAllTime &&
+						<DownloadCsv
+							statType={ statType }
+							query={ query }
+							path={ path }
+							period={ period }
+							borderless
+							className="stats-module__download-footer" />
+					}
 					{ this.props.showSummaryLink && displaySummaryLink && <StatsModuleExpand href={ summaryLink } /> }
 					{ summary && 'countryviews' === path &&
 						<UpgradeNudge

--- a/client/my-sites/stats/stats-module/connected-list.jsx
+++ b/client/my-sites/stats/stats-module/connected-list.jsx
@@ -125,28 +125,19 @@ class StatsConnectedModule extends Component {
 		return (
 			<div>
 				{ siteId && statType && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
-				<SectionHeader label={ this.getModuleLabel() } href={ ! summary ? summaryLink : null }>
-					{ isAllTime && <AllTimeNav path={ path } query={ query } /> }
-					{ summary && ! isAllTime && <DownloadCsv statType={ statType } query={ query } path={ path } period={ period } /> }
-				</SectionHeader>
+				{ ! isAllTime &&
+					<SectionHeader label={ this.getModuleLabel() } href={ ! summary ? summaryLink : null }>
+						{ summary && <DownloadCsv statType={ statType } query={ query } path={ path } period={ period } /> }
+					</SectionHeader>
+				}
 				<Card compact className={ cardClasses }>
 					{ noData && <ErrorPanel message={ moduleStrings.empty } /> }
 					{ hasError && <ErrorPanel /> }
+					{ isAllTime && <AllTimeNav path={ path } query={ query } period={ period } /> }
 					{ this.props.children }
 					<StatsListLegend value={ moduleStrings.value } label={ moduleStrings.item } />
 					<StatsModulePlaceholder isLoading={ isLoading } />
 					<StatsList moduleName={ path } data={ data } />
-					{
-						summary &&
-						isAllTime &&
-						<DownloadCsv
-							statType={ statType }
-							query={ query }
-							path={ path }
-							period={ period }
-							borderless
-							className="stats-module__download-footer" />
-					}
 					{ this.props.showSummaryLink && displaySummaryLink && <StatsModuleExpand href={ summaryLink } /> }
 					{ summary && 'countryviews' === path &&
 						<UpgradeNudge
@@ -157,6 +148,14 @@ class StatsConnectedModule extends Component {
 						/>
 					}
 				</Card>
+				{ isAllTime &&
+					<DownloadCsv
+						statType={ statType }
+						query={ query }
+						path={ path }
+						borderless
+						period={ period } />
+				}
 			</div>
 
 		);

--- a/client/my-sites/stats/stats-module/connected-list.jsx
+++ b/client/my-sites/stats/stats-module/connected-list.jsx
@@ -149,12 +149,14 @@ class StatsConnectedModule extends Component {
 					}
 				</Card>
 				{ isAllTime &&
-					<DownloadCsv
-						statType={ statType }
-						query={ query }
-						path={ path }
-						borderless
-						period={ period } />
+					<div className="stats-module__footer-actions">
+						<DownloadCsv
+							statType={ statType }
+							query={ query }
+							path={ path }
+							borderless
+							period={ period } />
+					</div>
 				}
 			</div>
 

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -518,3 +518,7 @@ ul.module-header-actions {
 		@include long-content-fade( $color: $white, $size: 15% );
 	}
 }
+
+.stats-module__download-footer {
+	margin-left: 16px;
+}

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -519,6 +519,8 @@ ul.module-header-actions {
 	}
 }
 
-.stats-module__download-footer {
-	margin-left: 16px;
+.stats-module__all-time-nav{
+	.stats-section-title {
+		margin: 0 16px 16px 16px;
+	}
 }

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -524,3 +524,10 @@ ul.module-header-actions {
 		margin: 0 16px 16px 16px;
 	}
 }
+
+.stats-module__footer-actions {
+	display: flex;
+	flex-direction: row;
+	justify-content: center;
+	align-items: center;
+}

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -112,7 +112,7 @@ const StatsSummary = React.createClass( {
 						key="countries-summary"
 						path="countryviews"
 						period={ this.props.period }
-						query={ merge( statsQueryOptions, query ) }
+						query={ merge( {}, statsQueryOptions, query ) }
 						summary={ true } />;
 				break;
 

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import page from 'page';
 import debugFactory from 'debug';
-import { find } from 'lodash';
+import { find, merge } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -65,7 +65,7 @@ const StatsSummary = React.createClass( {
 	},
 
 	render: function() {
-		const { site, translate } = this.props;
+		const { site, translate, statsQueryOptions } = this.props;
 		const summaryViews = [];
 		let title;
 		let summaryView;
@@ -112,7 +112,7 @@ const StatsSummary = React.createClass( {
 						key="countries-summary"
 						path="countryviews"
 						period={ this.props.period }
-						query={ query }
+						query={ merge( statsQueryOptions, query ) }
 						summary={ true } />;
 				break;
 


### PR DESCRIPTION
This branch seeks to add in "Summarized" views of Country Stats.  This was one of the gaps between Atlas Stats and Calypso stats as it provides users a way to view "All Time" and "Last x Days" of key stats.

![wordpress_com](https://cloud.githubusercontent.com/assets/22080/21949768/bd691e0e-d9a9-11e6-95ad-f529b96dffc1.png)

I am marking this PR as 'Design Review' since I'm not really certain if the choice of a `<SelectDropdown/>` for this navigation bit is the best option, and I'm hoping to get further direction on where to put the displaced download button.  The wording shown ( i.e. "Stats for last X days ending" ) on these summary views was borrowed from what was used in Atlas stats on these pages.  

__To Test__
- Navigate to a Site Stats page, and click the 'View All' link under Countries
- Next use the Summary links in the right corner.  Verify stats are updated for each time period as expected.  Bonus points for verifying if these numbers jive with Atlas stats

__TODO__
- [ ] Determine where to display the download csv button
- [ ] Add analytics events