### PR TITLE
Checkout: Redirect to domain management after purchasing a domain for a domain-only site

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' ),
+	{ PropTypes } = React,
 	{ connect } = require( 'react-redux' ),
 	defer = require( 'lodash/defer' ),
 	page = require( 'page' ),
@@ -29,6 +30,21 @@ const registerDomainAnalytics = analyticsMixin( 'registerDomain' ),
 	mapDomainAnalytics = analyticsMixin( 'mapDomain' );
 
 const DomainsStep = React.createClass( {
+	propTypes: {
+		domainsWithPlansOnly: PropTypes.bool,
+		flowName: PropTypes.string.isRequired,
+		goToNextStep: PropTypes.func.isRequired,
+		isDomainOnly: PropTypes.bool.isRequired,
+		locale: PropTypes.string,
+		path: PropTypes.string.isRequired,
+		positionInFlow: PropTypes.number.isRequired,
+		queryObject: PropTypes.object,
+		signupProgressStore: PropTypes.array.isRequired,
+		step: PropTypes.object,
+		stepName: PropTypes.string.isRequired,
+		stepSectionName: PropTypes.string,
+	},
+
 	contextTypes: {
 		store: React.PropTypes.object
 	},


### PR DESCRIPTION
This PR updates `Checkout` to redirect the user to domain management after purchasing a domain for a domain-only site. It also adds `propTypes` to `DomainsStep` in signup.

**Note:** The route the user is redirected to is `/domains/manage/:domain/edit/:site_slug`. `:domain` and `:site_slug` are not the same in this PR, but a future API change will ensure that the primary site is set once the user purchases/creates a domain-only site, which will causes these values to be the same.

**Testing**
- Visit `/start/domain-first` in a new session (e.g. incognito).
- Select a domain and submit.
- Select the `Just buy a domain` option.
- Enter valid information for a new user and submit.
- Continue through signup until you land in `Checkout`.
- Purchase the domain.
- Assert that you are redirected to `/domains/manage/:domain/edit/:site_slug` instead of the thank you page.

- [x] Code
- [x] Product