### PR TITLE
Documentation: Highlight scss tagged code-blocks in dev-docs

### DIFF
--- a/server/devdocs/index.js
+++ b/server/devdocs/index.js
@@ -11,6 +11,7 @@ import { find, escape as escapeHTML } from 'lodash';
 import Prism from 'prismjs';
 import 'prismjs/components/prism-jsx';
 import 'prismjs/components/prism-json';
+import 'prismjs/components/prism-scss';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
The PR adds flavour to ` ```scss ` tagged code-blocks in DevDocs.

Some additions that PR #10553 looks to make include ` ```scss ` tags which would not be highlighted by default with `Prism.js`.

Related: #10359 (Initial addition of syntax-highlighting in DevDocs)

### Testing
Since there are currently no ` ```scss ` blocks in the docs my suggestion is to edit a file and insert a ` ```scss ` block.

I added the following block to `reader/list-item/README.md` and then visited http://calypso.localhost:3000/devdocs/client/reader/list-item/README.md

```
```scss
@import 'some/styles';

$primary-color: #333;

.hello-world {
  background-color: #fafafa;
}

.hello-world__title {
  color: $primary-color;
  font-size: 3rem;
}
```
` ``` `

Make sure that it's highlighted as expected and looking pretty! :)