### PR TITLE
Upgrades: Allow domains management for Jetpack sites

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -290,7 +290,7 @@ module.exports = {
 		const basePath = route.sectionify( context.path );
 		const selectedSite = sites.getSelectedSite();
 
-		if ( selectedSite && selectedSite.jetpack ) {
+		if ( '/domains/manage' !== basePath && selectedSite && selectedSite.jetpack ) {
 			renderWithReduxStore( (
 				<Main>
 					<JetpackManageErrorPage

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -311,10 +311,6 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		if ( site.jetpack ) {
-			return null;
-		}
-
 		return (
 			<SidebarItem
 				label={ this.props.translate( 'Domains' ) }

--- a/client/my-sites/upgrades/domain-management/list/index.jsx
+++ b/client/my-sites/upgrades/domain-management/list/index.jsx
@@ -222,7 +222,11 @@ export const List = React.createClass( {
 	},
 
 	changePrimaryButton() {
-		if ( ! this.props.domains.list || this.props.domains.list.length < 2 ) {
+		if (
+			! this.props.domains.list ||
+			this.props.domains.list.length < 2 ||
+			this.props.selectedSite.jetpack
+		) {
 			return null;
 		}
 
@@ -237,7 +241,10 @@ export const List = React.createClass( {
 	},
 
 	addDomainButton() {
-		if ( ! config.isEnabled( 'upgrades/domain-search' ) ) {
+		if (
+			! config.isEnabled( 'upgrades/domain-search' ) ||
+			this.props.selectedSite.jetpack
+		) {
 			return null;
 		}
 

--- a/client/my-sites/upgrades/navigation.jsx
+++ b/client/my-sites/upgrades/navigation.jsx
@@ -70,7 +70,7 @@ const PlansNavigation = React.createClass( {
 					<NavItem path={ `/plans/${ site.slug }` } key="plans" selected={ path === '/plans' || path === '/plans/monthly' }>
 						{ this.translate( 'Plans' ) }
 					</NavItem>
-					{ ! isJetpack && userCanManageOptions &&
+					{ userCanManageOptions &&
 						<NavItem path={ `/domains/manage/${ site.slug }` } key="domains"
 							selected={ path === '/domains/manage' || path === '/domains/add' }>
 							{ this.translate( 'Domains' ) }


### PR DESCRIPTION
This is a rough pass at allowing domain management for Jetpack sites. Since we will be moving domains from WPCOM sites to Jetpack sites to fix #6779, which is a high priority issue. We currently have some [clashing functionality in Calypso](https://github.com/Automattic/wp-calypso/blob/master/client/lib/sites-list/list.js#L153-L166), but this does not address the root problem.

So, to address the root problem, we will move domain mapping records from a WPCOM site to a Jetpack site when a Jetpack site connects.

The issue we ran into with this is that, for domains registered on WP.com, users can no longer manage those domains since domain management is not allowed on Jetpack sites.

This PR is a hacky approach to fixing that, and will need some eyes from the store team. cc @matthusby 

See D3971-code for WPCOM patch.