### PR TITLE
Reader: Improve auto direction of html content

### DIFF
--- a/client/components/auto-direction/index.jsx
+++ b/client/components/auto-direction/index.jsx
@@ -84,11 +84,10 @@ const getContent = ( reactElement ) => {
 			return '';
 		}
 
-		const examinedLength = Math.floor( MAX_LENGTH_OF_TEXT_TO_EXAMINE * 1.25 );
 		const taglessIndex = getTaglessIndex( html );
-		const startIndex = taglessIndex + examinedLength < html.length ? taglessIndex : 0;
+		const startIndex = taglessIndex + MAX_LENGTH_OF_TEXT_TO_EXAMINE < html.length ? taglessIndex : 0;
 
-		return stripHTML( html.substring( startIndex, startIndex + examinedLength ) );
+		return stripHTML( html.substring( startIndex, startIndex + MAX_LENGTH_OF_TEXT_TO_EXAMINE ) );
 	}
 
 	// This child is some kind of input


### PR DESCRIPTION
HTML content sometimes starts with a lot of tags, more than what we examine, so after stripTags
we are getting an empty string, which is useless for deciding direction, this is an attempt to find the
first character not within a tag and start there.

Example to such scenario: https://wordpress.com/read/feeds/4460857/posts/1259782611

| Before  | After  |
|---|---|
| ![screen shot 2017-01-15 at 15 35 18](https://cloud.githubusercontent.com/assets/326402/21962907/69b32814-db38-11e6-8229-d0895a4f0644.png) |  ![screen shot 2017-01-15 at 15 35 01](https://cloud.githubusercontent.com/assets/326402/21962904/66c0505a-db38-11e6-9577-9e62b5b7e462.png)  |

// cc @ranh who reported that

 #### Testing instructions
  
1. Run `git checkout fix/autodirection-html` and start your server, or open a [live branch](https://calypso.live/?branch=fix/autodirection-html)
2. Open the [`full post` page](http://calypso.localhost:3000/read/feeds/4460857/posts/1259782611)
3. Check that RTL is detected in that case
4. Check few other posts to see it's still working as expected
    
#### Reviews
  
- [ ] Code
- [ ] Product
