### PR TITLE
Post Editor: Remove redundant/dead route def

### DIFF
--- a/client/post-editor/index.js
+++ b/client/post-editor/index.js
@@ -14,13 +14,6 @@ module.exports = function() {
 	page( '/post', controller.pressThis, sitesController.siteSelection, sitesController.sites );
 	page( '/post/new', () => page.redirect( '/post' ) ); // redirect from beep-beep-boop
 	page( '/post/:site?/:post?', sitesController.siteSelection, sitesController.fetchJetpackSettings, controller.post );
-	page(
-		'/post/:site?/:post?',
-		sitesController.siteSelection,
-		sitesController.fetchJetpackSettings,
-		controller.copyPost,
-		controller.post
-	);
 	page.exit( '/post/:site?/:post?', controller.exitPost );
 
 	page( '/page', sitesController.siteSelection, sitesController.sites );


### PR DESCRIPTION
This is identical to the route def on the line above, with the exception of the `copyPost` controller. Which doesn't exist at all.

FYI @Copons since I think you added these routes (#7451)

(Nevermind the branch name)