### PR TITLE
Stats: Only show view all link when >= 10 records

### DIFF
--- a/client/my-sites/stats/stats-module/connected-list.js
+++ b/client/my-sites/stats/stats-module/connected-list.js
@@ -109,6 +109,7 @@ class StatsConnectedModule extends Component {
 		);
 
 		const summaryLink = this.getHref();
+		const displaySummaryLink = data && data.length >= 10;
 
 		return (
 			<div>
@@ -123,7 +124,7 @@ class StatsConnectedModule extends Component {
 					<StatsListLegend value={ moduleStrings.value } label={ moduleStrings.item } />
 					<StatsModulePlaceholder isLoading={ isLoading } />
 					<StatsList moduleName={ path } data={ data } />
-					{ this.props.showSummaryLink && <StatsModuleExpand href={ summaryLink } /> }
+					{ this.props.showSummaryLink && displaySummaryLink && <StatsModuleExpand href={ summaryLink } /> }
 					{ summary && 'countryviews' === path &&
 						<UpgradeNudge
 							title={ translate( 'Add Google Analytics' ) }


### PR DESCRIPTION
With the Countries module now using `connected-list` I noticed that the 'View All' link in the footer was being shown when there were less than 10 records for periods.  This branch adds a check to see if the list has 10 records in order to display the 'View All' link.

Granted there could be some instances where there are only 10 total records for a period - this is still a step in the right direction.  In the old `stats-list` implementations we did have logic that looked at `total_views` from the payload to determine if this link should be displayed or not.  I think this is a good solution for now.

__Before__
<img width="467" alt="stats_ _trout_bummin_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/21967657/06289150-db40-11e6-95ca-78b30680e7ef.png">

__After__
<img width="466" alt="stats_ _trout_bummin_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/21967668/265572cc-db40-11e6-83ac-705670df2d69.png">

__To Test__
View a site stats page for a site with not much traffic, not the Countries module does not show the 'View All' link.  Then do the same for a site with a fair amount of traffic and confirm that it is shown when more data exists.