### PR TITLE
Stats: Remove s querystring from gravatar country urls

### DIFF
--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -339,7 +339,7 @@ describe( 'utils', () => {
 						label: 'United States',
 						value: 1,
 						region: '021',
-						icon: 'https://secure.gravatar.com/blavatar/9f4faa5ad0c723474f7a6d810172447c?s=48'
+						icon: 'https://secure.gravatar.com/blavatar/9f4faa5ad0c723474f7a6d810172447c'
 					}
 				] );
 			} );
@@ -375,7 +375,7 @@ describe( 'utils', () => {
 						label: 'United States',
 						value: 10,
 						region: '021',
-						icon: 'https://secure.gravatar.com/blavatar/9f4faa5ad0c723474f7a6d810172447c?s=48'
+						icon: 'https://secure.gravatar.com/blavatar/9f4faa5ad0c723474f7a6d810172447c'
 					}
 				] );
 			} );
@@ -410,7 +410,7 @@ describe( 'utils', () => {
 						label: 'United States',
 						value: 100,
 						region: '021',
-						icon: 'https://secure.gravatar.com/blavatar/9f4faa5ad0c723474f7a6d810172447c?s=48'
+						icon: 'https://secure.gravatar.com/blavatar/9f4faa5ad0c723474f7a6d810172447c'
 					}
 				] );
 			} );
@@ -446,7 +446,7 @@ describe( 'utils', () => {
 						label: 'United States',
 						value: 100,
 						region: '021',
-						icon: 'https://secure.gravatar.com/blavatar/9f4faa5ad0c723474f7a6d810172447c?s=48'
+						icon: 'https://secure.gravatar.com/blavatar/9f4faa5ad0c723474f7a6d810172447c'
 					}
 				] );
 			} );
@@ -502,7 +502,7 @@ describe( 'utils', () => {
 					},
 					'country-info': {
 						US: {
-							flag_icon: 'https://secure.gravatar.com/blavatar/5a83891a81b057fed56930a6aaaf7b3c?s=48',
+							flag_icon: 'https://secure.gravatar.com/blavatar/5a83891a81b057fed56930a6aaaf7b3c',
 							flat_flag_icon: 'https://s-ssl.wordpress.com/i/stats/square-grey.png',
 							country_full: 'US’A',
 							map_region: '021'
@@ -557,7 +557,7 @@ describe( 'utils', () => {
 						label: 'United States',
 						value: 100,
 						region: '021',
-						icon: 'https://secure.gravatar.com/blavatar/9f4faa5ad0c723474f7a6d810172447c?s=48'
+						icon: 'https://secure.gravatar.com/blavatar/9f4faa5ad0c723474f7a6d810172447c'
 					}
 				] );
 			} );

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -192,7 +192,8 @@ export const normalizers = {
 
 		return map( countryData, ( viewData ) => {
 			const country = countryInfo[ viewData.country_code ];
-			const icon = country.flat_flag_icon.match( /grey\.png/ ) ? null : country.flat_flag_icon;
+			// removing `s` querystring from gravatar as it is breaking images
+			const icon = country.flat_flag_icon.match( /grey\.png/ ) ? null : country.flat_flag_icon.replace( /\?s=48/, '' );
 
 			// ’ in country names causes google's geo viz to break
 			return {


### PR DESCRIPTION
Originally reported in p56BUd-fJ-p2 via a tweet https://twitter.com/Tompluspl/status/820586859369787392 - some country flag images in the Countries module were showing the default gravatar image instead of the appropriate flag.

After some testing, I discovered that by removing the `?s=48` query string from the affected gravatar URLs that the proper country flag is then returned.  This branch adds a simple `replace` call on the icon to remove `s=48`.  There is css that already resizes the image to 24x24 so all the flag sizes still remain the same on the stats page.

__To Test__
I had difficulties reproducing this issue 100% of the time, which leads me to believe it might be some issues with gravatar at certain data centers or CDNs.  The countries it seems to break with more frequently are Ireland, Poland, and Australia.

View a site stats page and ensure all country flags show as expected.