### PR TITLE
Billing: Use DocumentHead instead of setDocumentHeadTitle in billing history

### DIFF
--- a/client/me/billing-history/controller.js
+++ b/client/me/billing-history/controller.js
@@ -2,14 +2,12 @@
  * External dependencies
  */
 import React from 'react';
-import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
 import route from 'lib/route';
-import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import sitesFactory from 'lib/sites-list';
 
@@ -21,8 +19,6 @@ export default {
 		const BillingHistoryComponent = require( './main' );
 		const billingData = require( 'lib/billing-history-data' );
 		const basePath = route.sectionify( context.path );
-
-		context.store.dispatch( setTitle( i18n.translate( 'Billing History', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
 		renderWithReduxStore(
 			React.createElement( BillingHistoryComponent, { billingData: billingData, sites: sites } ),
@@ -41,8 +37,6 @@ export default {
 
 		// Initialize billing data
 		billingData.get();
-
-		context.store.dispatch( setTitle( i18n.translate( 'Billing History', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
 		if ( receiptId ) {
 			analytics.pageView.record( basePath + '/receipt', ANALYTICS_PAGE_TITLE + ' > Billing History > Receipt' );

--- a/client/me/billing-history/main.jsx
+++ b/client/me/billing-history/main.jsx
@@ -19,6 +19,7 @@ import BillingHistoryTable from './billing-history-table';
 import UpcomingChargesTable from './upcoming-charges-table';
 import SectionHeader from 'components/section-header';
 import Main from 'components/main';
+import DocumentHead from 'components/data/document-head';
 import purchasesPaths from 'me/purchases/paths';
 
 const BillingHistory = React.createClass( {
@@ -31,6 +32,7 @@ const BillingHistory = React.createClass( {
 
 		return (
 			<Main className="billing-history">
+				<DocumentHead title={ translate( 'Billing History' ) } />
 				<MeSidebarNavigation />
 				<PurchasesHeader section={ 'billing' } />
 				<Card className="billing-history__receipts">

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -13,6 +13,7 @@ import eventRecorder from 'me/event-recorder';
 import Card from 'components/card';
 import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
+import DocumentHead from 'components/data/document-head';
 import purchasesPaths from 'me/purchases/paths';
 
 const BillingReceipt = React.createClass( {
@@ -25,6 +26,7 @@ const BillingReceipt = React.createClass( {
 
 		return (
 			<Main>
+				<DocumentHead title={ translate( 'Billing History' ) } />
 				<HeaderCake backHref={ purchasesPaths.billingHistory() }>
 					{ translate( 'Billing History' ) }
 				</HeaderCake>


### PR DESCRIPTION
This PR updates the Billing History to use `<DocumentHead />` instead of having to early dispatch a `setDocumentHeadTitle`. There are no changes in the current behavior. 

This PR is part of #10554.

To test:
* Checkout this branch
* Go to `me/purchases/billing` and verify that the proper page title "Billing History" is set.
* Go to `me/purchases/billing/$id`, where `$id` is the ID of a transaction, and verify that the proper page title "Billing History" is set.
