### PR TITLE
Site Settings: Fix reference to api cache toggle handling method

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -497,7 +497,7 @@ class SiteSettingsFormGeneral extends Component {
 	}
 
 	renderApiCache() {
-		const { fields, translate, isRequestingSettings } = this.props;
+		const { fields, translate, isRequestingSettings, handleToggle } = this.props;
 
 		if ( ! this.showApiCacheCheckbox() ) {
 			return null;
@@ -509,7 +509,7 @@ class SiteSettingsFormGeneral extends Component {
 					className="is-compact"
 					checked={ !! fields.api_cache }
 					disabled={ isRequestingSettings }
-					onChange={ this.handleToggle( 'api_cache' ) }>
+					onChange={ handleToggle( 'api_cache' ) }>
 					<span className="site-settings__toggle-label">
 						{ translate(
 							'Use synchronized data to boost performance'


### PR DESCRIPTION
This fixes a bug where `/settings/general/$site` (where `$site` is a Jetpack site) is broken. This probably occurred because both related PRs were worked on at the same time (#9085, #10306).

To test:
* Checkout this branch
* Go to `/settings/general/$site` (where `$site` is a Jetpack site).
* Verify the General tab is loaded correctly and works as before.