### PR TITLE
Billing: Update billing-history components to use Redux

### DIFF
--- a/client/me/billing-history/controller.js
+++ b/client/me/billing-history/controller.js
@@ -30,18 +30,14 @@ export default {
 
 	transaction( context ) {
 		const Receipt = require( './receipt' );
-		const billingData = require( 'lib/billing-history-data' );
 		const receiptId = context.params.receiptId;
 		const basePath = route.sectionify( context.path );
-
-		// Initialize billing data
-		billingData.get();
 
 		if ( receiptId ) {
 			analytics.pageView.record( basePath + '/receipt', ANALYTICS_PAGE_TITLE + ' > Billing History > Receipt' );
 
 			renderWithReduxStore(
-				React.createElement( Receipt, { transaction: billingData.getTransaction( receiptId ) } ),
+				React.createElement( Receipt, { transactionId: receiptId } ),
 				document.getElementById( 'primary' ),
 				context.store
 			);

--- a/client/me/billing-history/controller.js
+++ b/client/me/billing-history/controller.js
@@ -17,11 +17,10 @@ const sites = sitesFactory();
 export default {
 	billingHistory( context ) {
 		const BillingHistoryComponent = require( './main' );
-		const billingData = require( 'lib/billing-history-data' );
 		const basePath = route.sectionify( context.path );
 
 		renderWithReduxStore(
-			React.createElement( BillingHistoryComponent, { billingData: billingData, sites: sites } ),
+			React.createElement( BillingHistoryComponent, { sites: sites } ),
 			document.getElementById( 'primary' ),
 			context.store
 		);

--- a/client/me/billing-history/main.jsx
+++ b/client/me/billing-history/main.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { isEmpty } from 'lodash';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -20,32 +20,33 @@ import UpcomingChargesTable from './upcoming-charges-table';
 import SectionHeader from 'components/section-header';
 import Main from 'components/main';
 import DocumentHead from 'components/data/document-head';
+import QueryBillingTransactions from 'components/data/query-billing-transactions';
 import purchasesPaths from 'me/purchases/paths';
+import { getBillingTransactions } from 'state/selectors';
 
 const BillingHistory = React.createClass( {
-	mixins: [ observe( 'billingData', 'sites' ), eventRecorder ],
+	mixins: [ observe( 'sites' ), eventRecorder ],
 
 	render() {
-		const { billingData, sites, translate } = this.props;
-		const data = billingData.get();
-		const hasBillingHistory = ! isEmpty( data.billingHistory );
+		const { transactions, sites, translate } = this.props;
 
 		return (
 			<Main className="billing-history">
 				<DocumentHead title={ translate( 'Billing History' ) } />
 				<MeSidebarNavigation />
+				<QueryBillingTransactions />
 				<PurchasesHeader section={ 'billing' } />
 				<Card className="billing-history__receipts">
-					<BillingHistoryTable transactions={ data.billingHistory } />
+					<BillingHistoryTable transactions={ transactions.past } />
 				</Card>
 				<Card href={ purchasesPaths.purchasesRoot() }>
 					{ translate( 'Go to "Purchases" to add or cancel a plan.' ) }
 				</Card>
-				{ hasBillingHistory &&
+				{ transactions.past &&
 					<div>
 						<SectionHeader label={ translate( 'Upcoming Charges' ) } />
 						<Card className="billing-history__upcoming-charges">
-							<UpcomingChargesTable sites={ sites } transactions={ data.upcomingCharges } />
+							<UpcomingChargesTable sites={ sites } transactions={ transactions.upcoming } />
 						</Card>
 					</div>
 				}
@@ -57,4 +58,8 @@ const BillingHistory = React.createClass( {
 	}
 } );
 
-export default localize( BillingHistory );
+export default connect(
+	( state ) => ( {
+		transactions: getBillingTransactions( state )
+	} ),
+)( localize( BillingHistory ) );

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -23,16 +23,17 @@ const BillingReceipt = React.createClass( {
 
 	render() {
 		const { transaction, translate } = this.props;
+		if ( ! transaction ) {
+			return this.renderPlaceholder();
+		}
+
 		const title = translate( 'Visit %(url)s', { args: { url: transaction.url } } );
 		const serviceLink = <a href={ transaction.url } title={ title } />;
 
 		return (
 			<Main>
-				<DocumentHead title={ translate( 'Billing History' ) } />
-				<QueryBillingTransactions />
-				<HeaderCake backHref={ purchasesPaths.billingHistory() }>
-					{ translate( 'Billing History' ) }
-				</HeaderCake>
+				{ this.renderTitle() }
+
 				<Card compact className="billing-history__receipt-card">
 					<div className="billing-history__app-overview">
 						<img src={ transaction.icon } title={ transaction.service } />
@@ -128,6 +129,37 @@ const BillingReceipt = React.createClass( {
 				<strong>{ translate( 'Payment Method' ) }</strong>
 				<span>{ text }</span>
 			</li>
+		);
+	},
+
+	renderTitle() {
+		const { translate } = this.props;
+
+		return (
+			<div>
+				<DocumentHead title={ translate( 'Billing History' ) } />
+				<QueryBillingTransactions />
+				<HeaderCake backHref={ purchasesPaths.billingHistory() }>
+					{ translate( 'Billing History' ) }
+				</HeaderCake>
+			</div>
+		);
+	},
+
+	renderPlaceholder() {
+		const { translate } = this.props;
+
+		return (
+			<Main>
+				{ this.renderTitle() }
+				<Card compact className="billing-history__receipt-card">
+					<div className="billing-history__receipt">
+						<div className="billing-history__receipt-loading">
+							{ translate( 'Loading…' ) }
+						</div>
+					</div>
+				</Card>
+			</Main>
 		);
 	},
 

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -2,22 +2,24 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import tableRows from './table-rows';
-import observe from 'lib/mixins/data-observe';
 import eventRecorder from 'me/event-recorder';
 import Card from 'components/card';
 import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
 import DocumentHead from 'components/data/document-head';
+import QueryBillingTransactions from 'components/data/query-billing-transactions';
 import purchasesPaths from 'me/purchases/paths';
+import { getPastBillingTransaction } from 'state/selectors';
 
 const BillingReceipt = React.createClass( {
-	mixins: [ observe( 'billingData' ), eventRecorder ],
+	mixins: [ eventRecorder ],
 
 	render() {
 		const { transaction, translate } = this.props;
@@ -27,6 +29,7 @@ const BillingReceipt = React.createClass( {
 		return (
 			<Main>
 				<DocumentHead title={ translate( 'Billing History' ) } />
+				<QueryBillingTransactions />
 				<HeaderCake backHref={ purchasesPaths.billingHistory() }>
 					{ translate( 'Billing History' ) }
 				</HeaderCake>
@@ -190,4 +193,8 @@ const BillingReceipt = React.createClass( {
 	}
 } );
 
-export default localize( BillingReceipt );
+export default connect(
+	( state, ownProps ) => ( {
+		transaction: getPastBillingTransaction( state, ownProps.transactionId )
+	} ),
+)( localize( BillingReceipt ) );

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -354,6 +354,10 @@
 		font-size: 20px;
 	}
 
+	.billing-history__receipt-loading {
+		color: $gray;
+	}
+
 	.billing-history__receipt-line-items {
 		margin: 0;
 		padding: 0;


### PR DESCRIPTION
This PR updates `BillingHistory` and `BillingReceipt` to use the new `billing-transactions` Redux functionality. It also adds a simple placeholder to `BillingReceipt`, which was borrowed from the one in `BillingHistory` - this will show a `Loading...` message in the rare cases when the transaction is not loaded. 

This PR is part of #10554.

To test:

* Checkout this branch
* Go to `/me/purchases/billing` and verify purchases are loaded properly. There should be no functional changes.
* Click on "View Receipt" link in a purchase of your choice.
* Verify the receipt page works like before, and it displays all transaction data properly.
* Try the above with a clean Redux state and verify everything works as expected.