### PR TITLE
Sites: Hide sections and certain actions for domain-only sites

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -18,12 +18,15 @@ import { preload } from 'sections-preload';
 import ResumeEditing from 'my-sites/resume-editing';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteSlug } from 'state/sites/selectors';
+import { getSiteSlug, getSiteBySlug } from 'state/sites/selectors';
 import { getStatsPathForTab } from 'lib/route/path';
 import { getCurrentUser } from 'state/current-user/selectors';
+import isDomainOnlySite from 'state/selectors/is-domain-only-site';
+import { domainManagementEdit } from 'my-sites/upgrades/paths';
 
 const MasterbarLoggedIn = React.createClass( {
 	propTypes: {
+		isDomainOnlySite: React.PropTypes.bool,
 		user: React.PropTypes.object,
 		sites: React.PropTypes.object,
 		section: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.bool ] ),
@@ -66,16 +69,23 @@ const MasterbarLoggedIn = React.createClass( {
 	},
 
 	render() {
+		const { isDomainOnlySite, siteSlug } = this.props,
+			mySitesUrl = isDomainOnlySite
+				// The site slug for a domain-only site is equal to its only
+				// domain, so we can use it for the domain parameter here.
+				? domainManagementEdit( siteSlug, siteSlug )
+				: getStatsPathForTab( 'day', siteSlug );
+
 		return (
 			<Masterbar>
 				<Item
-					url={ getStatsPathForTab( 'day', this.props.siteSlug ) }
+					url={ mySitesUrl }
 					tipTarget="my-sites"
 					icon={ this.wordpressIcon() }
 					onClick={ this.clickMySites }
 					isActive={ this.isActive( 'sites' ) }
 					tooltip={ this.translate( 'View a list of your sites and access their dashboards', { textOnly: true } ) }
-					preloadSection={ () => preload( 'stats' ) }
+					preloadSection={ () => preload( isDomainOnlySite ? 'upgrades' : 'stats' ) }
 				>
 					{ this.props.user.get().visible_site_count > 1
 						? this.translate( 'My Sites', { comment: 'Toolbar, must be shorter than ~12 chars' } )
@@ -134,14 +144,24 @@ const MasterbarLoggedIn = React.createClass( {
 
 // TODO: make this pure when sites can be retrieved from the Redux state
 export default connect( ( state ) => {
-	const siteId = getSelectedSiteId( state );
+	let siteId = getSelectedSiteId( state );
 	let siteSlug = getSiteSlug( state, siteId );
 
 	// If siteId has not been set in redux, fall back to currentUser.primarySiteSlug
 	if ( ! siteId ) {
 		const currentUser = getCurrentUser( state );
 		siteSlug = get( currentUser, 'primarySiteSlug' );
+
+		// Now we can look up the site ID from its slug
+		const site = getSiteBySlug( state, siteSlug );
+
+		if ( site ) {
+			siteId = site.ID;
+		}
 	}
 
-	return { siteSlug };
+	return {
+		siteSlug,
+		isDomainOnlySite: isDomainOnlySite( state, siteId ),
+	};
 }, { setNextLayoutFocus }, null, { pure: false } )( MasterbarLoggedIn );

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -30,6 +30,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getThemeCustomizeUrl as getCustomizeUrl } from 'state/themes/selectors';
 import { setNextLayoutFocus, setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { userCan } from 'lib/site/utils';
+import { isDomainOnlySite } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getStatsPathForTab } from 'lib/route/path';
 
@@ -46,6 +47,7 @@ export class MySitesSidebar extends Component {
 		path: PropTypes.string,
 		sites: PropTypes.object,
 		currentUser: PropTypes.object,
+		isDomainOnly: PropTypes.bool,
 		isJetpack: PropTypes.bool,
 	};
 
@@ -709,20 +711,18 @@ export class MySitesSidebar extends Component {
 		);
 	}
 
-	render() {
-		var publish = !! this.publish(),
+	renderSidebarMenus() {
+		if ( this.props.isDomainOnly ) {
+			return null;
+		}
+
+		const publish = !! this.publish(),
 			appearance = ( !! this.themes() || !! this.menus() ),
 			configuration = ( !! this.sharing() || !! this.users() || !! this.siteSettings() || !! this.plugins() || !! this.upgrades() ),
 			vip = !! this.vip();
 
 		return (
-			<Sidebar>
-				<SidebarRegion>
-				<CurrentSite
-					sites={ this.props.sites }
-					siteCount={ this.props.currentUser.visible_site_count }
-					onClick={ this.onPreviewSite }
-				/>
+			<div>
 				<SidebarMenu>
 					<ul>
 						{ this.stats() }
@@ -779,6 +779,20 @@ export class MySitesSidebar extends Component {
 					</SidebarMenu>
 					: null
 				}
+			</div>
+		);
+	}
+
+	render() {
+		return (
+			<Sidebar>
+				<SidebarRegion>
+					<CurrentSite
+						sites={ this.props.sites }
+						siteCount={ this.props.currentUser.visible_site_count }
+						onClick={ this.onPreviewSite }
+					/>
+					{ this.renderSidebarMenus() }
 				</SidebarRegion>
 				<SidebarFooter>
 					{ this.addNewSite() }
@@ -793,6 +807,7 @@ function mapStateToProps( state ) {
 	return {
 		currentUser: getCurrentUser( state ),
 		customizeUrl: getCustomizeUrl( state, null, selectedSiteId ),
+		isDomainOnly: isDomainOnlySite( state, selectedSiteId ),
 		isJetpack: isJetpackSite( state, selectedSiteId )
 	};
 }

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -27,6 +27,7 @@ export getPastBillingTransaction from './get-past-billing-transaction';
 export getSiteIconId from './get-site-icon-id';
 export getSiteIconUrl from './get-site-icon-url';
 export isAutomatedTransferActive from './is-automated-transfer-active';
+export isDomainOnlySite from './is-domain-only-site';
 export isPrivateSite from './is-private-site';
 export isRequestingBillingTransactions from './is-requesting-billing-transactions';
 export isRequestingPostLikes from './is-requesting-post-likes';

--- a/client/state/selectors/is-domain-only-site.js
+++ b/client/state/selectors/is-domain-only-site.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getRawSite } from 'state/sites/selectors';
+
+/**
+ * Returns true if site is a Domain-only site, false if the site is a regular site,
+ * or null if the site is unknown.
+ *
+ * @param  {Object}   state  Global state tree
+ * @param  {Number}   siteId Site ID
+ * @return {?Boolean}        Whether site is a Domain-only site
+ */
+export default function isDomainOnlySite( state, siteId ) {
+	const site = getRawSite( state, siteId );
+	if ( ! site ) {
+		return null;
+	}
+
+	return get( site, 'options.is_domain_only', false );
+}

--- a/client/state/selectors/is-domain-only-site.js
+++ b/client/state/selectors/is-domain-only-site.js
@@ -18,6 +18,7 @@ import { getRawSite } from 'state/sites/selectors';
  */
 export default function isDomainOnlySite( state, siteId ) {
 	const site = getRawSite( state, siteId );
+
 	if ( ! site ) {
 		return null;
 	}

--- a/client/state/selectors/test/is-domain-only-site.js
+++ b/client/state/selectors/test/is-domain-only-site.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isDomainOnlySite } from '../';
+
+describe( '#isDomainOnlySite()', () => {
+	const siteId = 77203074;
+
+	it( 'should return null if the site is unknown', () => {
+		const result = isDomainOnlySite( {
+			sites: {
+				items: {}
+			}
+		}, siteId );
+
+		expect( result ).to.be.null;
+	} );
+
+	it( 'it should return false if the site does not have the domain only option set to true', () => {
+		const result = isDomainOnlySite( {
+			sites: {
+				items: {
+					[ siteId ]: { ID: siteId, URL: 'https://example.wordpress.com', options: {
+						is_domain_only: false
+					} }
+				}
+			}
+		}, siteId );
+
+		expect( result ).to.be.false;
+	} );
+
+	it( 'it should return false if the site has the domain only option set to true', () => {
+		const result = isDomainOnlySite( {
+			sites: {
+				items: {
+					[ siteId ]: { ID: siteId, URL: 'https://example.wordpress.com', options: {
+						is_domain_only: true
+					} }
+				}
+			}
+		}, siteId );
+
+		expect( result ).to.be.true;
+	} );
+} );

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -434,6 +434,22 @@ export const getSeoTitle = ( state, type, data ) => {
 };
 
 /**
+ * Returns a site object by its slug.
+ *
+ * @param  {Object}  state     Global state tree
+ * @param  {String}  siteSlug  Site URL
+ * @return {?Object}           Site object
+ */
+export const getSiteBySlug = createSelector(
+	( state, siteSlug ) => (
+		find( state.sites.items, ( item, siteId ) => (
+			getSiteSlug( state, siteId ) === siteSlug
+		) ) || null
+	),
+	( state ) => state.sites.items
+);
+
+/**
  * Returns a site object by its URL.
  *
  * @param  {Object}  state Global state tree
@@ -442,15 +458,8 @@ export const getSeoTitle = ( state, type, data ) => {
  */
 export function getSiteByUrl( state, url ) {
 	const slug = urlToSlug( url );
-	const site = find( state.sites.items, ( item, siteId ) => {
-		return getSiteSlug( state, siteId ) === slug;
-	} );
 
-	if ( ! site ) {
-		return null;
-	}
-
-	return site;
+	return getSiteBySlug( state, slug );
 }
 
 /**

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -24,6 +24,7 @@ import {
 	isSitePreviewable,
 	isRequestingSites,
 	isRequestingSite,
+	getSiteBySlug,
 	getSiteByUrl,
 	getSitePlan,
 	isCurrentSitePlan,
@@ -748,6 +749,50 @@ describe( 'selectors', () => {
 			}, 2916284 );
 
 			expect( isRequesting ).to.be.false;
+		} );
+	} );
+
+	describe( '#getSiteBySlug()', () => {
+		it( 'should return null if a site cannot be found', () => {
+			const site = getSiteBySlug( {
+				sites: {
+					items: {}
+				}
+			}, 'testtwosites2014.wordpress.com' );
+
+			expect( site ).to.be.null;
+		} );
+
+		it( 'should return a matched site', () => {
+			const state = {
+				sites: {
+					items: {
+						77203199: {
+							ID: 77203199,
+							URL: 'https://testtwosites2014.wordpress.com'
+						}
+					}
+				}
+			};
+			const site = getSiteBySlug( state, 'testtwosites2014.wordpress.com' );
+
+			expect( site ).to.equal( state.sites.items[ 77203199 ] );
+		} );
+
+		it( 'should return a matched site with nested path', () => {
+			const state = {
+				sites: {
+					items: {
+						77203199: {
+							ID: 77203199,
+							URL: 'https://testtwosites2014.wordpress.com/path/to/site'
+						}
+					}
+				}
+			};
+			const site = getSiteBySlug( state, 'testtwosites2014.wordpress.com::path::to::site' );
+
+			expect( site ).to.equal( state.sites.items[ 77203199 ] );
 		} );
 	} );
 


### PR DESCRIPTION
For domain-only sites, we should display an empty sidebar. This PR adds this change based on work done by @scruffian in #10427.

### Before

<img width="279" alt="screen shot 2017-01-16 at 14 32 19" src="https://cloud.githubusercontent.com/assets/699132/21984916/a1363d60-dbf8-11e6-8677-9e1d23301855.png">


### After

<img width="311" alt="screen shot 2017-01-16 at 14 31 41" src="https://cloud.githubusercontent.com/assets/699132/21984901/8e9ef606-dbf8-11e6-9be8-ea87fdc7267a.png">


### Testing
1. Open Calypso http://calypso.localhost:3000/ or use Calypso live (link in the comment below).
2. Visit /start/domain-first while logged out.
3. Select a domain.
4. Complete signup for a new account.
5. Purchase the domain.
6. Go to My Sites.
7. You should see an empty sidebar.
8. Create a new regular site.
9. Go to My Sites and select a regular site.
10. You should see all links in the sidebar as usual.

### Review

* [ ] Code
* [ ] Producr

