### PR TITLE
Stats: Use Redux Stats subtree instead of StatsList for StatsReferrers

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -340,8 +340,6 @@ module.exports = {
 				stat_fields: 'views,visitors,likes,comments,post_titles', domain: siteDomain } );
 			const postsPagesList = new StatsList( {
 				siteID: siteId, statType: 'statsTopPosts', period: activeFilter.period, date: endDate, domain: siteDomain } );
-			const referrersList = new StatsList( {
-				siteID: siteId, statType: 'statsReferrers', period: activeFilter.period, date: endDate, domain: siteDomain } );
 			const clicksList = new StatsList( {
 				siteID: siteId, statType: 'statsClicks', period: activeFilter.period, date: endDate, domain: siteDomain } );
 			const authorsList = new StatsList( {
@@ -362,7 +360,6 @@ module.exports = {
 				activeTabVisitsList,
 				visitsList,
 				postsPagesList,
-				referrersList,
 				clicksList,
 				authorsList,
 				videoPlaysList,
@@ -477,9 +474,7 @@ module.exports = {
 					break;
 
 				case 'referrers':
-					summaryList = new StatsList( {
-						siteID: siteId, statType: 'statsReferrers', period: activeFilter.period,
-						date: endDate, max: 0, domain: siteDomain } );
+					summaryList = fakeStatsList;
 					break;
 
 				case 'clicks':

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -179,7 +179,8 @@ module.exports = React.createClass( {
 								period={ this.props.period }
 								query={ query }
 								date={ queryDate }
-								statType="statsReferrers" />
+								statType="statsReferrers"
+								showSummaryLink />
 							<StatsModule
 								path={ 'clicks' }
 								moduleStrings={ moduleStrings.clicks }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -16,6 +16,7 @@ import DatePicker from './stats-date-picker';
 import Countries from './stats-countries';
 import ChartTabs from './stats-chart-tabs';
 import StatsModule from './stats-module';
+import StatsConnectedModule from './stats-module/connected-list';
 import statsStrings from './stats-strings';
 import titlecase from 'to-title-case';
 import analytics from 'lib/analytics';
@@ -172,14 +173,13 @@ module.exports = React.createClass( {
 								period={ this.props.period }
 								date={ queryDate }
 								beforeNavigate={ this.updateScrollPosition } />
-							<StatsModule
-								path={ 'referrers' }
+							<StatsConnectedModule
+								path="referrers"
 								moduleStrings={ moduleStrings.referrers }
-								site={ site }
-								dataList={ this.props.referrersList }
 								period={ this.props.period }
+								query={ query }
 								date={ queryDate }
-								beforeNavigate={ this.updateScrollPosition } />
+								statType="statsReferrers" />
 							<StatsModule
 								path={ 'clicks' }
 								moduleStrings={ moduleStrings.clicks }

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -16,6 +16,7 @@ import HeaderCake from 'components/header-cake';
 import StatsModule from '../stats-module';
 import statsStringsFactory from '../stats-strings';
 import Countries from '../stats-countries';
+import StatsConnectedModule from '../stats-module/connected-list';
 import StatsVideoSummary from '../stats-video-summary';
 import VideoPlayDetails from '../stats-video-details';
 import Main from 'components/main';
@@ -83,14 +84,14 @@ const StatsSummary = React.createClass( {
 
 			case 'referrers':
 				title = translate( 'Referrers' );
-				summaryView = <StatsModule
+				summaryView = <StatsConnectedModule
 					key="referrers-summary"
-					path={ 'referrers' }
+					path="referrers"
 					moduleStrings={ StatsStrings.referrers }
-					site={ site }
-					dataList={ this.props.summaryList }
 					period={ this.props.period }
-					summary={ true } />;
+					query={ query }
+					statType="statsReferrers"
+					summary />;
 				break;
 
 			case 'clicks':

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -159,7 +159,7 @@ export const getSiteStatsNormalizedData = createSelector(
 		const data = getSiteStatsForQuery( state, siteId, statType, query );
 
 		if ( 'function' === typeof normalizers[ statType ] ) {
-			return normalizers[ statType ].call( this, data, query );
+			return normalizers[ statType ].call( this, data, query, siteId );
 		}
 
 		return data;

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -664,7 +664,6 @@ describe( 'utils', () => {
 		describe( 'statsTags()', () => {
 			it( 'should return an empty array if not data is passed', () => {
 				const parsedData = normalizers.statsTags();
-
 				expect( parsedData ).to.eql( [] );
 			} );
 
@@ -738,6 +737,106 @@ describe( 'utils', () => {
 						value: 740
 					}
 				] );
+			} );
+
+			describe( 'statsReferrers()', () => {
+				it( 'should return an empty array if not data is passed', () => {
+					const parsedData = normalizers.statsReferrers();
+					expect( parsedData ).to.eql( [] );
+				} );
+
+				it( 'should return an empty array if query.period is null', () => {
+					const parsedData = normalizers.statsReferrers( {}, { date: '2016-12-25' } );
+					expect( parsedData ).to.eql( [] );
+				} );
+
+				it( 'should return an empty array if query.date is null', () => {
+					const parsedData = normalizers.statsReferrers( {}, { period: 'day' } );
+					expect( parsedData ).to.eql( [] );
+				} );
+
+				it( 'should return an a properly parsed data array', () => {
+					const parsedData = normalizers.statsReferrers( {
+						date: '2017-01-12',
+						days: {
+							'2017-01-12': {
+								groups: [
+									{
+										group: 'WordPress.com Reader',
+										name: 'WordPress.com Reader',
+										url: 'https://wordpress.com',
+										icon: 'https://secure.gravatar.com/blavatar/236c008da9dc0edb4b3464ecebb3fc1d?s=48',
+										results: {
+											views: 407
+										},
+										total: 407
+									},
+									{
+										group: 'en.support.wordpress.com',
+										icon: 'https://secure.gravatar.com/blavatar/94ea57385f5018d2b84169cab22d3b33?s=48',
+										name: 'en.support.wordpress.com',
+										results: [
+											{ name: 'homepage', url: 'https://en.support.wordpress.com/', views: 42 },
+											{ name: 'start', url: 'https://en.support.wordpress.com/start/', views: 10 }
+										],
+										total: 207
+									}
+								]
+							}
+						}
+					}, {
+						period: 'day',
+						date: '2017-01-12',
+						domain: 'en.blog.wordpress.com'
+					},
+					100 );
+
+					expect( parsedData ).to.eql( [
+						{
+							actionMenu: 0,
+							actions: [],
+							children: undefined,
+							icon: 'https://secure.gravatar.com/blavatar/236c008da9dc0edb4b3464ecebb3fc1d?s=48',
+							label: 'WordPress.com Reader',
+							labelIcon: 'external',
+							link: 'https://wordpress.com',
+							value: 407
+						},
+						{
+							actionMenu: 1,
+							actions: [
+								{
+									data: {
+										domain: 'en.support.wordpress.com',
+										siteID: 100
+									},
+									type: 'spam'
+								}
+							],
+							children: [
+								{
+									children: undefined,
+									label: 'homepage',
+									labelIcon: 'external',
+									link: 'https://en.support.wordpress.com/',
+									value: 42
+								},
+								{
+									children: undefined,
+									label: 'start',
+									labelIcon: 'external',
+									link: 'https://en.support.wordpress.com/start/',
+									value: 10
+								}
+							],
+							icon: 'https://secure.gravatar.com/blavatar/94ea57385f5018d2b84169cab22d3b33?s=48',
+							label: 'en.support.wordpress.com',
+							labelIcon: null,
+							link: undefined,
+							value: 207
+						},
+					] );
+				} );
 			} );
 		} );
 	} );

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -282,5 +282,65 @@ export const normalizers = {
 				children: children
 			};
 		} );
+	},
+
+	/*
+	 * Returns a normalized statsReferrers array, ready for use in stats-module
+	 *
+	 * @param  {Object} data   Stats data
+	 * @param  {Object} query  Stats query
+	 * @param  {Int}    siteId Site ID
+	 * @return {Array}        Parsed publicize data array
+	 */
+	statsReferrers( data, query, siteId ) {
+		if ( ! data || ! query.period || ! query.date ) {
+			return [];
+		}
+
+		const { startOf } = rangeOfPeriod( query.period, query.date );
+		const statsData = get( data, [ 'days', startOf, 'groups' ], [] );
+
+		const parseItem = ( item ) => {
+			let children;
+			if ( item.children && item.children.length > 0 ) {
+				children = item.children.map( parseItem );
+			}
+
+			const record = {
+				label: item.name,
+				value: item.views,
+				link: item.url,
+				labelIcon: children ? null : 'external',
+				children
+			};
+
+			if ( item.icon ) {
+				record.icon = item.icon;
+			}
+
+			return record;
+		};
+
+		return statsData.map( ( item ) => {
+			let actions = [];
+			if (
+				( item.url && -1 !== item.url.indexOf( item.name ) ) ||
+				( ! item.url && item.name === item.group && -1 !== item.name.indexOf( '.' ) )
+			) {
+				actions = [ {
+					type: 'spam',
+					data: {
+						siteID: siteId,
+						domain: item.name
+					}
+				} ];
+			}
+
+			return {
+				...parseItem( { ...item, children: item.results, views: item.total } ),
+				actions,
+				actionMenu: actions.length
+			};
+		} );
 	}
 };


### PR DESCRIPTION
Closes #10624 

In this PR, I moved the parser logic for StatsReferrers from StatsList into the redux stats subtree.
I also updated the referrers stats module to use the StatsConnectedModule Component.

**Testing instructions**

- Navigate to the stats insights page /stats/day/$site
- The Referrers panel should work properly (same as master)
- Click on the header of the panel to navigate to the summary page
- The referrers stats should show up (same as master)