### PR TITLE
Framework: Unmount Layout component when transitioning from single to multi-tree rendering

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -410,7 +410,7 @@ function reduxStoreReady( reduxStore ) {
 
 		if ( isMultiTreeLayout && previousLayoutIsSingleTree ) {
 			debug( 'Re-rendering multi-tree layout' );
-
+			ReactDom.unmountComponentAtNode( document.getElementById( 'wpcom' ) );
 			renderLayout( context.store );
 		} else if ( ! isMultiTreeLayout && ! previousLayoutIsSingleTree ) {
 			debug( 'Unmounting multi-tree layout' );

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -39,11 +39,7 @@ const MasterbarItemNew = React.createClass( {
 	},
 
 	toggleSitesPopover( isShowingPopover = ! this.state.isShowingPopover ) {
-		// Setting state in the context of a touchTap event (i.e. SitePicker
-		// Site onSelect) prevents link navigation from proceeding
-		setTimeout( this.setState.bind( this, {
-			isShowingPopover: isShowingPopover
-		} ), 0 );
+		this.setState( { isShowingPopover } );
 	},
 
 	onClick( event ) {


### PR DESCRIPTION
Fixes #10628. Apparently, React would still get confused by a previously rendered `Layout` component present in `wpcom`, so we're now unmounting it when transitioning from single-tree-rendered sections to multi-tree ones.

To test:
* Verify that #10628 is fixed.
* Verify that other transitions aren't broken (meaning no console errors, no weird rendering errors such as missing sidebars, or sidebars painted in the wrong place)
  * Land on `/design`. In the sidebar, select 'Switch Site', and scroll to the very bottom to 'Add a New Site' > 'New WP.com site'.
  * Land on a non-`/design` section, navigate to 'Themes', click on a theme to get its theme sheet, navigate back
  * Logged-out `/design`, any theme: 'Pick this design'.