### PR TITLE
Jetpack Settings: Introduce a Publishing Tools card under Writing

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -320,6 +320,7 @@
 @import 'my-sites/site-settings/jetpack-module-toggle/style';
 @import 'my-sites/site-settings/jetpack-sync-panel/style';
 @import 'my-sites/site-settings/press-this/style';
+@import 'my-sites/site-settings/publishing-tools/style';
 @import 'my-sites/site-settings/site-icon-setting/style';
 @import 'my-sites/site-settings/subscriptions/style';
 @import 'my-sites/site-settings/taxonomies/style';

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -231,6 +231,7 @@ class SiteSettingsFormWriting extends Component {
 								context: 'name of browser bookmarklet tool'
 							} ), false )
 						}
+
 						<PressThis />
 					</div>
 				) }

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -210,13 +210,14 @@ class SiteSettingsFormWriting extends Component {
 								isSavingSettings={ isSavingSettings }
 								isRequestingSettings={ isRequestingSettings }
 								fields={ fields }
-								/>
+							/>
 
 							{ config.isEnabled( 'press-this' ) &&
 								<PublishingTools
-									submittingForm={ this.state.submittingForm }
-									onSubmitForm={ this.handleSubmitForm }
-									fetchingSettings={ this.state.fetchingSettings }
+									onSubmitForm={ this.submitFormAndActivateCustomContentModule }
+									isSavingSettings={ isSavingSettings }
+									isRequestingSettings={ isRequestingSettings }
+									fields={ fields }
 								/>
 							}
 						</div>
@@ -265,7 +266,8 @@ const getFormSettings = partialRight( pick, [
 	'infinite_scroll_google_analytics',
 	'wp_mobile_excerpt',
 	'wp_mobile_featured_images',
-	'wp_mobile_app_promos'
+	'wp_mobile_app_promos',
+	'post_by_email_address'
 ] );
 
 export default flowRight(

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -30,6 +30,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestPostTypes } from 'state/post-types/actions';
 import CustomPostTypeFieldset from './custom-post-types-fieldset';
 import ThemeEnhancements from './theme-enhancements';
+import PublishingTools from './publishing-tools';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 
 class SiteSettingsFormWriting extends Component {
@@ -210,11 +211,19 @@ class SiteSettingsFormWriting extends Component {
 								isRequestingSettings={ isRequestingSettings }
 								fields={ fields }
 								/>
+
+							{ config.isEnabled( 'press-this' ) &&
+								<PublishingTools
+									submittingForm={ this.state.submittingForm }
+									onSubmitForm={ this.handleSubmitForm }
+									fetchingSettings={ this.state.fetchingSettings }
+								/>
+							}
 						</div>
 					)
 				}
 
-				{ config.isEnabled( 'press-this' ) && (
+				{ config.isEnabled( 'press-this' ) && ! ( this.props.isJetpackSite || this.props.jetpackSettingsUISupported ) && (
 					<div>
 						{
 							this.renderSectionHeader( translate( 'Press This', {

--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -18,6 +18,8 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isModuleActive } from 'state/jetpack/modules/selectors';
+import { regeneratePostByEmail } from 'state/jetpack/settings/actions';
+import { isRegeneratingPostByEmail } from 'state/jetpack/settings/selectors';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
 import ClipboardButtonInput from 'components/clipboard-button-input';
@@ -25,7 +27,7 @@ import PressThis from '../press-this';
 
 class PublishingTools extends Component {
 	onRegenerateButtonClick = () => {
-		// TODO: integrate regeneration
+		this.props.regeneratePostByEmail( this.props.selectedSiteId );
 	}
 
 	isFormPending() {
@@ -62,7 +64,7 @@ class PublishingTools extends Component {
 	}
 
 	renderPostByEmailSettings() {
-		const { fields, translate } = this.props;
+		const { fields, translate, regeneratingPostByEmail } = this.props;
 		const isFormPending = this.isFormPending();
 
 		return (
@@ -72,15 +74,15 @@ class PublishingTools extends Component {
 				</FormLabel>
 				<ClipboardButtonInput
 					className="publishing-tools__email-address"
-					disabled={ isFormPending }
+					disabled={ regeneratingPostByEmail }
 					value={ fields.post_by_email_address !== 'regenerate' ? fields.post_by_email_address : '' }
 				/>
 				<Button
 					compact
 					onClick={ this.onRegenerateButtonClick }
-					disabled={ isFormPending }
+					disabled={ isFormPending || regeneratingPostByEmail }
 				>
-					{ isFormPending
+					{ regeneratingPostByEmail
 						? translate( 'Regenerating…' )
 						: translate( 'Regenerate address' )
 					}
@@ -166,10 +168,15 @@ PublishingTools.propTypes = {
 export default connect(
 	( state ) => {
 		const selectedSiteId = getSelectedSiteId( state );
+		const regeneratingPostByEmail = isRegeneratingPostByEmail( state, selectedSiteId );
 
 		return {
 			selectedSiteId,
+			regeneratingPostByEmail,
 			postByEmailAddressModuleActive: !! isModuleActive( state, selectedSiteId, 'post-by-email' ),
 		};
+	},
+	{
+		regeneratePostByEmail
 	}
 )( localize( PublishingTools ) );

--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -26,6 +26,19 @@ import ClipboardButtonInput from 'components/clipboard-button-input';
 import PressThis from '../press-this';
 
 class PublishingTools extends Component {
+	componentDidUpdate() {
+		const {
+			fields,
+			postByEmailAddressModuleActive,
+			regeneratingPostByEmail,
+			selectedSiteId
+		} = this.props;
+
+		if ( postByEmailAddressModuleActive && regeneratingPostByEmail === null && ! fields.post_by_email_address ) {
+			this.props.regeneratePostByEmail( selectedSiteId );
+		}
+	}
+
 	onRegenerateButtonClick = () => {
 		this.props.regeneratePostByEmail( this.props.selectedSiteId );
 	}

--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -66,6 +66,7 @@ class PublishingTools extends Component {
 	renderPostByEmailSettings() {
 		const { fields, translate, regeneratingPostByEmail } = this.props;
 		const isFormPending = this.isFormPending();
+		const email = fields.post_by_email_address && fields.post_by_email_address !== 'regenerate' ? fields.post_by_email_address : '';
 
 		return (
 			<div className="publishing-tools__module-settings is-indented">
@@ -75,7 +76,7 @@ class PublishingTools extends Component {
 				<ClipboardButtonInput
 					className="publishing-tools__email-address"
 					disabled={ regeneratingPostByEmail }
-					value={ fields.post_by_email_address !== 'regenerate' ? fields.post_by_email_address : '' }
+					value={ email }
 				/>
 				<Button
 					compact

--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -17,7 +17,7 @@ import FormLegend from 'components/forms/form-legend';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isModuleActive } from 'state/jetpack/modules/selectors';
+import { isJetpackModuleActive } from 'state/selectors';
 import { regeneratePostByEmail } from 'state/jetpack/settings/actions';
 import { isRegeneratingPostByEmail } from 'state/jetpack/settings/selectors';
 import InfoPopover from 'components/info-popover';
@@ -56,10 +56,11 @@ class PublishingTools extends Component {
 		const { fields, translate, postByEmailAddressModuleActive, regeneratingPostByEmail } = this.props;
 		const isFormPending = this.isFormPending();
 		const email = fields.post_by_email_address && fields.post_by_email_address !== 'regenerate' ? fields.post_by_email_address : '';
+		const labelClassName = regeneratingPostByEmail || ! postByEmailAddressModuleActive ? 'is-disabled' : null;
 
 		return (
 			<div className="publishing-tools__module-settings is-indented">
-				<FormLabel>
+				<FormLabel className={ labelClassName }>
 					{ translate( 'Email Address' ) }
 				</FormLabel>
 				<ClipboardButtonInput
@@ -162,7 +163,7 @@ export default connect(
 		return {
 			selectedSiteId,
 			regeneratingPostByEmail,
-			postByEmailAddressModuleActive: !! isModuleActive( state, selectedSiteId, 'post-by-email' ),
+			postByEmailAddressModuleActive: !! isJetpackModuleActive( state, selectedSiteId, 'post-by-email' ),
 		};
 	},
 	{

--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -52,30 +52,6 @@ class PublishingTools extends Component {
 		return isRequestingSettings || isSavingSettings;
 	}
 
-	renderHeader() {
-		const {
-			onSubmitForm,
-			isSavingSettings,
-			translate
-		} = this.props;
-
-		return (
-			<SectionHeader label={ translate( 'Publishing Tools' ) }>
-				<Button
-					compact
-					primary
-					onClick={ onSubmitForm }
-					disabled={ this.isFormPending() }
-				>
-					{ isSavingSettings
-						? translate( 'Saving…' )
-						: translate( 'Save Settings' )
-					}
-				</Button>
-			</SectionHeader>
-		);
-	}
-
 	renderPostByEmailSettings() {
 		const { fields, translate, regeneratingPostByEmail } = this.props;
 		const isFormPending = this.isFormPending();
@@ -152,9 +128,11 @@ class PublishingTools extends Component {
 	}
 
 	render() {
+		const { translate } = this.props;
+
 		return (
 			<div>
-				{ this.renderHeader() }
+				<SectionHeader label={ translate( 'Publishing Tools' ) } />
 
 				<Card className="publishing-tools__card site-settings">
 					{ this.renderPostByEmailModule() }

--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -53,7 +53,7 @@ class PublishingTools extends Component {
 	}
 
 	renderPostByEmailSettings() {
-		const { fields, translate, regeneratingPostByEmail } = this.props;
+		const { fields, translate, postByEmailAddressModuleActive, regeneratingPostByEmail } = this.props;
 		const isFormPending = this.isFormPending();
 		const email = fields.post_by_email_address && fields.post_by_email_address !== 'regenerate' ? fields.post_by_email_address : '';
 
@@ -64,13 +64,13 @@ class PublishingTools extends Component {
 				</FormLabel>
 				<ClipboardButtonInput
 					className="publishing-tools__email-address"
-					disabled={ regeneratingPostByEmail }
+					disabled={ regeneratingPostByEmail || ! postByEmailAddressModuleActive }
 					value={ email }
 				/>
 				<Button
 					compact
 					onClick={ this.onRegenerateButtonClick }
-					disabled={ isFormPending || regeneratingPostByEmail }
+					disabled={ isFormPending || regeneratingPostByEmail || ! postByEmailAddressModuleActive }
 				>
 					{ regeneratingPostByEmail
 						? translate( 'Regenerating…' )
@@ -84,7 +84,6 @@ class PublishingTools extends Component {
 	renderPostByEmailModule() {
 		const {
 			selectedSiteId,
-			postByEmailAddressModuleActive,
 			translate
 		} = this.props;
 		const formPending = this.isFormPending();
@@ -106,9 +105,7 @@ class PublishingTools extends Component {
 					disabled={ formPending }
 					/>
 
-				{
-					postByEmailAddressModuleActive && this.renderPostByEmailSettings()
-				}
+				{ this.renderPostByEmailSettings() }
 			</FormFieldset>
 		);
 	}

--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -1,0 +1,211 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { pick } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import SectionHeader from 'components/section-header';
+import Card from 'components/card';
+import Button from 'components/button';
+import JetpackModuleToggle from '../jetpack-module-toggle';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import QueryJetpackModules from 'components/data/query-jetpack-modules';
+import QueryJetpackSettings from 'components/data/query-jetpack-settings';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isModuleActive, isFetchingModules } from 'state/jetpack/modules/selectors';
+import {
+	getJetpackSettings,
+	isRequestingJetpackSettings,
+	isUpdatingJetpackSettings
+} from 'state/jetpack/settings/selectors';
+import { fetchSettings, updateSettings } from 'state/jetpack/settings/actions';
+import InfoPopover from 'components/info-popover';
+import ExternalLink from 'components/external-link';
+import ClipboardButtonInput from 'components/clipboard-button-input';
+
+class PublishingTools extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = this.buildRegeneratingState( false );
+
+		this.refreshSettings = this.refreshSettings.bind( this );
+		this.onRegenerateButtonClick = this.onRegenerateButtonClick.bind( this );
+	}
+
+	buildRegeneratingState( regenerating = false ) {
+		return {
+			regenerating
+		};
+	}
+
+	refreshSettings() {
+		const { selectedSiteId } = this.props;
+
+		this.props.fetchSettings( selectedSiteId ).then( () => {
+			this.setState( this.buildRegeneratingState( false ) );
+		} );
+	}
+
+	onRegenerateButtonClick() {
+		const { selectedSiteId } = this.props;
+
+		this.setState( this.buildRegeneratingState( true ) );
+
+		this.props.updateSettings( selectedSiteId, {
+			post_by_email_address: 'regenerate'
+		} ).then( this.refreshSettings );
+	}
+
+	isFormPending() {
+		const {
+			fetchingSettings,
+			fetchingModuleData,
+			submittingForm,
+			updatingSettings
+		} = this.props;
+
+		return fetchingSettings || fetchingModuleData || submittingForm || updatingSettings || this.state.regenerating;
+	}
+
+	renderHeader() {
+		const {
+			onSubmitForm,
+			submittingForm,
+			translate
+		} = this.props;
+
+		return (
+			<SectionHeader label={ translate( 'Publishing Tools' ) }>
+				<Button
+					compact
+					primary
+					onClick={ onSubmitForm }
+					disabled={ this.isFormPending() }
+				>
+					{ submittingForm
+						? translate( 'Saving…' )
+						: translate( 'Save Settings' )
+					}
+				</Button>
+			</SectionHeader>
+		);
+	}
+
+	renderPostByEmailSettings() {
+		const { moduleSettings, translate } = this.props;
+		const isFormPending = this.isFormPending();
+		const email = moduleSettings && moduleSettings.post_by_email_address;
+
+		return (
+			<div className="publishing-tools__module-settings is-indented">
+				<FormLabel>
+					{ translate( 'Email Address' ) }
+				</FormLabel>
+				<ClipboardButtonInput
+					className="publishing-tools__email-address"
+					disabled={ isFormPending }
+					value={ email !== 'regenerate' ? email : '' }
+				/>
+				<Button
+					compact
+					onClick={ this.onRegenerateButtonClick }
+					disabled={ isFormPending }
+				>
+					{ isFormPending
+						? translate( 'Regenerating…' )
+						: translate( 'Regenerate address' )
+					}
+				</Button>
+			</div>
+		);
+	}
+
+	renderPostByEmailModule() {
+		const {
+			selectedSiteId,
+			postByEmailAddressModuleActive,
+			translate
+		} = this.props;
+		const formPending = this.isFormPending();
+
+		return (
+			<FormFieldset>
+				<div className="publishing-tools__info-link-container">
+					<InfoPopover position={ 'left' }>
+						<ExternalLink icon={ true } href={ 'https://jetpack.com/support/post-by-email/' } target="_blank">
+							{ translate( 'Learn more about Post by Email' ) }
+						</ExternalLink>
+					</InfoPopover>
+				</div>
+
+				<JetpackModuleToggle
+					siteId={ selectedSiteId }
+					moduleSlug="post-by-email"
+					label={ translate( 'Publish posts by sending an email.' ) }
+					disabled={ formPending }
+					/>
+
+				{
+					postByEmailAddressModuleActive && this.renderPostByEmailSettings()
+				}
+			</FormFieldset>
+		);
+	}
+
+	render() {
+		const { selectedSiteId } = this.props;
+
+		return (
+			<div>
+				<QueryJetpackModules siteId={ selectedSiteId } />
+				<QueryJetpackSettings siteId={ selectedSiteId } />
+
+				{ this.renderHeader() }
+
+				<Card className="publishing-tools__card site-settings">
+					{ this.renderPostByEmailModule() }
+				</Card>
+			</div>
+		);
+	}
+}
+
+PublishingTools.defaultProps = {
+	submittingForm: false,
+};
+
+PublishingTools.propTypes = {
+	onSubmitForm: PropTypes.func.isRequired,
+	fetchingSettings: PropTypes.bool.isRequired,
+	submittingForm: PropTypes.bool,
+};
+
+export default connect(
+	( state ) => {
+		const selectedSiteId = getSelectedSiteId( state );
+		const fetchingModules = isFetchingModules( state, selectedSiteId );
+		const fetchingSettings = isRequestingJetpackSettings( state, selectedSiteId );
+		const moduleSettings = pick( getJetpackSettings( state, selectedSiteId ), [
+			'post_by_email_address',
+		] );
+
+		return {
+			selectedSiteId,
+			postByEmailAddressModuleActive: !! isModuleActive( state, selectedSiteId, 'post-by-email' ),
+			moduleSettings,
+			fetchingModuleData: !! ( fetchingModules || fetchingSettings ),
+			updatingSettings: isUpdatingJetpackSettings( state, selectedSiteId ),
+		};
+	},
+	{
+		fetchSettings,
+		updateSettings
+	}
+)( localize( PublishingTools ) );

--- a/client/my-sites/site-settings/publishing-tools/style.scss
+++ b/client/my-sites/site-settings/publishing-tools/style.scss
@@ -15,6 +15,12 @@
 .publishing-tools__module-settings.is-indented {
 	margin: 16px 32px;
 
+	.form-label {
+		&.is-disabled {
+			opacity: 0.3;
+		}
+	}
+
 	.form-toggle__switch {
 		margin-right: 8px;
 	}

--- a/client/my-sites/site-settings/publishing-tools/style.scss
+++ b/client/my-sites/site-settings/publishing-tools/style.scss
@@ -1,3 +1,17 @@
+.publishing-tools__card {
+	.press-this {
+		.card {
+			margin: 0;
+			padding: 0;
+			box-shadow: none;
+		}
+
+		.pressthis {
+			margin-bottom: 0;
+		}
+	}
+}
+
 .publishing-tools__module-settings.is-indented {
 	margin: 16px 32px;
 

--- a/client/my-sites/site-settings/publishing-tools/style.scss
+++ b/client/my-sites/site-settings/publishing-tools/style.scss
@@ -1,0 +1,16 @@
+.publishing-tools__module-settings.is-indented {
+	margin: 16px 32px;
+
+	.form-toggle__switch {
+		margin-right: 8px;
+	}
+
+	.publishing-tools__email-address {
+		display: block;
+		margin-bottom: 8px;
+	}
+}
+
+.publishing-tools__info-link-container {
+	float: right;
+}

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -192,6 +192,10 @@
 		flex: 0 1 100%;
 		margin-left: 12px;
 	}
+
+	hr {
+		margin: 0 -24px 1.5em;
+	}
 }
 
 .site-settings__discussion-settings {


### PR DESCRIPTION
### Introduction

This PR is part of #9171. It introduces a Publishing Tools card under Writing Settings. This card will be used to manage the settings of the Post by Email module, and will also shelter the Press This block.

### Preview

**Post by Email disabled**
![](https://cldup.com/BL4L6ykGGY.png)

**Post by Email enabled**
![](https://cldup.com/tpMWWNjVX0.png)

**Post by Email enabled, regenerating**
![](https://cldup.com/MST6txDdut.png)

### Testing 

* Checkout this branch.
* Select one of your Jetpack sites that has Jetpack 4.5 or newer.
* Go to `/settings/writing/$site`, where `$site` is the slug of your Jetpack site.
* Verify the Publishing Tools card is displayed properly as shown on the previews.
* Play with the main toggle that toggles the Post by Email module, and verify it saves correctly in your Jetpack site.
* Verify that the Post by Email settings are displayed only when the Post by Email module is active.
* Try copying the email address and verify it works properly.
* Click "Regenerate Address" and verify it disables just the Post by Email form and nothing else. Verify it loads a new email shortly after.
* Verify the link of the info popover is working as expected and lead to the right place.
* Test with a Jetpack site with Jetpack 4.4.2 or older and verify the card is not shown.
* Test with a WordPress.com site and verify that the card is not shown at all, 
* Test with a WordPress.com site and verify that the Press This block is shown as a separate card.

### Final notes

This PR has borrowed the Redux functionality from #10811, but I'll remove it once #10811 is merged.