### PR TITLE
Site Settings: Use Redux selected site in PressThis

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -211,7 +211,7 @@ const SiteSettingsFormWriting = React.createClass( {
 								context: 'name of browser bookmarklet tool'
 							} ), false )
 						}
-						<PressThis site={ this.props.site } />
+						<PressThis />
 					</div>
 				) }
 			</form>

--- a/client/my-sites/site-settings/press-this/index.jsx
+++ b/client/my-sites/site-settings/press-this/index.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 import Card from 'components/card';
 import PressThisLink from './link';
 import { recordGoogleEvent } from 'state/analytics/actions';
+import { getSelectedSite } from 'state/ui/selectors';
 
 class PressThis extends Component {
 	static propTypes = {
@@ -63,7 +64,9 @@ class PressThis extends Component {
 }
 
 export default connect(
-	null,
+	( state ) => ( {
+		site: getSelectedSite( state )
+	} ),
 	{
 		recordGoogleEvent
 	}


### PR DESCRIPTION
This PR updates `PressThis` to take the selected site from the Redux state, and not from a prop.

To test:

* Checkout this branch.
* Go to `/settings/writing/$site` where `$site` is one of your sites.
* Verify the Press This bookmarklet works properly and there are no regressions.