### PR TITLE
Editor: Copy Page

### DIFF
--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -265,6 +265,19 @@ const Page = React.createClass( {
 		}
 	},
 
+	getCopyItem: function() {
+		const { page: post, site } = this.props;
+		if ( ( 'publish' !== post.status && 'private' !== post.status ) || ! utils.userCan( 'edit_post', post ) ) {
+			return null;
+		}
+		return (
+			<PopoverMenuItem onClick={ this.copyPage } href={ `/page/${ site.slug }?copy=${ post.ID }` }>
+				<Gridicon icon="clipboard" size={ 18 } />
+				{ this.translate( 'Copy' ) }
+			</PopoverMenuItem>
+		);
+	},
+
 	getRestoreItem: function() {
 		if ( this.props.page.status !== 'trash' || ! utils.userCan( 'delete_post', this.props.page ) ) {
 			return null;
@@ -327,6 +340,7 @@ const Page = React.createClass( {
 		const editItem = this.getEditItem();
 		const restoreItem = this.getRestoreItem();
 		const sendToTrashItem = this.getSendToTrashItem();
+		const copyItem = this.getCopyItem();
 		const moreInfoItem = this.popoverMoreInfo();
 		const hasSeparatedItems = (
 			viewItem || publishItem || editItem ||
@@ -348,6 +362,7 @@ const Page = React.createClass( {
 				{ editItem }
 				{ restoreItem }
 				{ sendToTrashItem }
+				{ copyItem }
 				{ moreInfoItem }
 			</PopoverMenu>
 		) : null;
@@ -413,7 +428,11 @@ const Page = React.createClass( {
 		this.setState( { showPageActions: false } );
 		this.updatePostStatus( 'delete' );
 		recordEvent( 'Clicked Delete Page' );
-	}
+	},
+
+	copyPage: function() {
+		recordEvent( 'Clicked Copy Page' );
+	},
 } );
 
 export default connect(

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -360,9 +360,9 @@ const Page = React.createClass( {
 				{ viewItem }
 				{ publishItem }
 				{ editItem }
+				{ copyItem }
 				{ restoreItem }
 				{ sendToTrashItem }
-				{ copyItem }
 				{ moreInfoItem }
 			</PopoverMenu>
 		) : null;

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -136,7 +136,7 @@ function startEditingPostCopy( siteId, postToCopyId, context ) {
 		actions.startEditingNew( siteId, {
 			content: postToCopy.content,
 			title: postToCopy.title,
-			type: 'post',
+			type: postToCopy.type,
 		} );
 		context.store.dispatch( editPost( siteId, null, postAttributes ) );
 		actions.edit( postAttributes );

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -265,11 +265,12 @@ const EditorDrawer = React.createClass( {
 	},
 
 	renderCopyPost: function() {
-		if ( 'post' !== this.props.type ) {
+		const { type } = this.props;
+		if ( 'post' !== type && 'page' !== type ) {
 			return;
 		}
 
-		return <EditorMoreOptionsCopyPost />;
+		return <EditorMoreOptionsCopyPost type={ type } />;
 	},
 
 	renderMoreOptions: function() {

--- a/client/post-editor/editor-more-options/copy-post.jsx
+++ b/client/post-editor/editor-more-options/copy-post.jsx
@@ -5,7 +5,6 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
-import { capitalize } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,6 +32,8 @@ class EditorMoreOptionsCopyPost extends Component {
 		selectedPostId: null,
 		showDialog: false,
 	};
+
+	isPost = () => 'post' === this.props.type;
 
 	openDialog = event => {
 		event.preventDefault();
@@ -80,15 +81,15 @@ class EditorMoreOptionsCopyPost extends Component {
 		return (
 			<AccordionSection className="editor-more-options__copy-post">
 				<EditorDrawerLabel
-					labelText={ translate( 'Copy %s', { args: capitalize( type ), comment: '"Post" or "Page"' } ) }
-					helpText={ translate(
-						"Pick a %s and we'll copy the title, content, tags and categories.",
-						{ args: type, comment: '"post" or "page"' }
-					) }
+					labelText={ this.isPost() ? translate( 'Copy Post' ) : translate( 'Copy Page' ) }
+					helpText={ this.isPost()
+						? translate( "Pick a post and we'll copy the title, content, tags and categories." )
+						: translate( "Pick a page and we'll copy the title, content, tags and categories." )
+					}
 				>
 					<Button borderless compact onClick={ this.openDialog }>
 						<Gridicon icon="clipboard" />
-						{ translate( 'Select a %s to copy', { args: type, comment: '"post" or "page"' } ) }
+						{ this.isPost() ? translate( 'Select a post to copy' ) : translate( 'Select a post to copy' ) }
 					</Button>
 				</EditorDrawerLabel>
 				<Dialog
@@ -99,17 +100,15 @@ class EditorMoreOptionsCopyPost extends Component {
 					additionalClassNames="editor-more-options__copy-post-select-dialog"
 				>
 					<FormSectionHeading>
-						{ translate( 'Select a %s to copy', { args: type, comment: '"post" or "page"' } ) }
+						{ this.isPost() ? translate( 'Select a post to copy' ) : translate( 'Select a page to copy' )
+						}
 					</FormSectionHeading>
 					<p>
-						{ translate(
-							"Pick a %s and we'll copy the title, content, tags and categories.",
-							{ args: type, comment: '"post" or "page"' }
-						) }
+						{ '' }
 					</p>
 					{ siteId &&
 						<PostSelector
-							emptyMessage={ 'post' === type ? translate( 'No posts found' ) : translate( 'No pages found' ) }
+							emptyMessage={ this.isPost() ? translate( 'No posts found' ) : translate( 'No pages found' ) }
 							onChange={ this.setPostToCopy }
 							order="DESC"
 							orderBy="date"

--- a/client/post-editor/editor-more-options/copy-post.jsx
+++ b/client/post-editor/editor-more-options/copy-post.jsx
@@ -89,7 +89,7 @@ class EditorMoreOptionsCopyPost extends Component {
 				>
 					<Button borderless compact onClick={ this.openDialog }>
 						<Gridicon icon="clipboard" />
-						{ this.isPost() ? translate( 'Select a post to copy' ) : translate( 'Select a post to copy' ) }
+						{ this.isPost() ? translate( 'Select a post to copy' ) : translate( 'Select a page to copy' ) }
 					</Button>
 				</EditorDrawerLabel>
 				<Dialog

--- a/client/post-editor/editor-more-options/copy-post.jsx
+++ b/client/post-editor/editor-more-options/copy-post.jsx
@@ -84,7 +84,7 @@ class EditorMoreOptionsCopyPost extends Component {
 					labelText={ this.isPost() ? translate( 'Copy Post' ) : translate( 'Copy Page' ) }
 					helpText={ this.isPost()
 						? translate( "Pick a post and we'll copy the title, content, tags and categories." )
-						: translate( "Pick a page and we'll copy the title, content, tags and categories." )
+						: translate( "Pick a page and we'll copy the title and content." )
 					}
 				>
 					<Button borderless compact onClick={ this.openDialog }>
@@ -106,7 +106,7 @@ class EditorMoreOptionsCopyPost extends Component {
 					<p>
 						{ this.isPost()
 							? translate( "Pick a post and we'll copy the title, content, tags and categories." )
-							: translate( "Pick a page and we'll copy the title, content, tags and categories." )
+							: translate( "Pick a page and we'll copy the title and content." )
 						}
 					</p>
 					{ siteId &&

--- a/client/post-editor/editor-more-options/copy-post.jsx
+++ b/client/post-editor/editor-more-options/copy-post.jsx
@@ -104,7 +104,10 @@ class EditorMoreOptionsCopyPost extends Component {
 						}
 					</FormSectionHeading>
 					<p>
-						{ '' }
+						{ this.isPost()
+							? translate( "Pick a post and we'll copy the title, content, tags and categories." )
+							: translate( "Pick a page and we'll copy the title, content, tags and categories." )
+						}
 					</p>
 					{ siteId &&
 						<PostSelector


### PR DESCRIPTION
In this PR we extend the Copy Post feature (https://github.com/Automattic/wp-calypso/pull/7451) to Pages too.
It works in the exact same way as the Copy Post, with the only exception that the Page List controls look different.

This is what changes visually:

**Page List**

<img width="703" alt="screen shot 2017-01-16 at 18 00 15" src="https://cloud.githubusercontent.com/assets/2070010/21992276/12e60982-dc16-11e6-80e8-902256db2351.png">

**Page Editor Sidebar, More Options Drawer**

<img width="278" alt="screen shot 2017-01-16 at 18 00 38" src="https://cloud.githubusercontent.com/assets/2070010/21992277/12e6847a-dc16-11e6-9a75-e334f081c9ab.png">

**~Post~ Page Selector Dialog**

<img width="520" alt="screen shot 2017-01-16 at 18 00 50" src="https://cloud.githubusercontent.com/assets/2070010/21992275/12e5481c-dc16-11e6-80fd-24c15222d5ca.png">
