### PR TITLE
AT: Fix eligibility warnings view when switching sites

### DIFF
--- a/client/my-sites/plugins-wpcom/plugin-install-button.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-install-button.jsx
@@ -38,7 +38,7 @@ export const WpcomPluginInstallButton = props => {
 			initiateTransfer( siteId, null, plugin.slug );
 		} else {
 			// Show eligibility warnings before proceeding
-			navigateTo( `/plugins/${ plugin.slug }/${ siteSlug }/eligibility` );
+			navigateTo( `/plugins/${ plugin.slug }/eligibility/${ siteSlug }` );
 		}
 	}
 

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -77,7 +77,7 @@ module.exports = function() {
 		);
 
 		if ( config.isEnabled( 'automated-transfer' ) ) {
-			page( '/plugins/:plugin/:site_id/eligibility',
+			page( '/plugins/:plugin/eligibility/:site_id',
 				controller.siteSelection,
 				controller.navigation,
 				pluginsController.eligibility


### PR DESCRIPTION
Ref: https://github.com/Automattic/wp-calypso/issues/10511

Previously, switching sites while viewing eligibility warnings page would result in a blank page being shown.
Now, the eligibility warnings will be shown correctly for given site.

**Testing instructions:**
1. Visit /plugins for a .com site and attempt to install a new one.
2. When you see the eligibility warnings, switch the site.
3. Verify that new warnings are displayed correctly.
