### PR TITLE
State: Push the reducer tree and createReduxStore to a chunk

### DIFF
--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -67,7 +67,7 @@ function loadInitialStateFailed( createReduxStore, error ) {
 	return createReduxStore();
 }
 
-export function persistOnChange( reduxStore, serializeState = serialize ) {
+export function persistOnChange( reducer, reduxStore, serializeState = serialize ) {
 	let state;
 	reduxStore.subscribe( throttle( function() {
 		const nextState = reduxStore.getState();
@@ -77,7 +77,7 @@ export function persistOnChange( reduxStore, serializeState = serialize ) {
 
 		state = nextState;
 
-		localforage.setItem( 'redux-state', serializeState( state ) )
+		localforage.setItem( 'redux-state', serializeState( reducer, state ) )
 			.catch( ( setError ) => {
 				debug( 'failed to set redux-store state', setError );
 			} );
@@ -93,7 +93,7 @@ export default function createReduxStoreFromPersistedInitialState( reduxStoreRea
 			localforage.getItem( 'redux-state' )
 				.then( loadInitialState.bind( null, createReduxStore, reducer ) )
 				.catch( loadInitialStateFailed.bind( null, createReduxStore ) )
-				.then( persistOnChange )
+				.then( persistOnChange.bind( null, reducer ) )
 				.then( reduxStoreReady );
 		} else {
 			debug( 'persist-redux is not enabled, building state from scratch' );


### PR DESCRIPTION
This is requested as part of the boot and get pulled into the build chunk, but the reducer tree changes pretty often. This isolates that change and should make the build chunk more stable.

_This is currently exploratory, so it's **both up for review and in progress**. When we get to a happy place, I'll mark it purely for review._

Things to do:
- [ ] Profile a load with the split enabled. _Hypothesis:_ The overall load will be slower because the request for  `client/state` will happen later than current.
- [ ] Teach `asyncRequire` how to pull in named exports so we can use it
- [ ] Investigate what happens when the async load fails. Is the behavior acceptable?