### PR TITLE
Settings: Pass another prop back through `getFormSettings` function for Jetpack site settings

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -31,7 +31,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 		};
 
 		componentWillMount() {
-			this.props.replaceFields( getFormSettings( this.props.settings, this.props ) );
+			this.props.replaceFields( getFormSettings( this.props.settings, this.props.jetpackSettings ) );
 		}
 
 		componentWillReceiveProps( nextProps ) {
@@ -39,8 +39,8 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				nextProps.clearDirtyFields();
 			}
 
-			if ( nextProps.settings !== this.props.settings ) {
-				let newState = getFormSettings( nextProps.settings, nextProps );
+			if ( nextProps.settings !== this.props.settings || nextProps.jetpackSettings !== this.props.jetpackSettings ) {
+				let newState = getFormSettings( nextProps.settings, nextProps.jetpackSettings );
 				//If we have any fields that the user has updated,
 				//do not wipe out those fields from the poll update.
 				newState = omit( newState, nextProps.dirtyFields );

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -31,7 +31,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 		};
 
 		componentWillMount() {
-			this.props.replaceFields( getFormSettings( this.props.settings ) );
+			this.props.replaceFields( getFormSettings( this.props.settings, this.props ) );
 		}
 
 		componentWillReceiveProps( nextProps ) {
@@ -40,7 +40,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			}
 
 			if ( nextProps.settings !== this.props.settings ) {
-				let newState = getFormSettings( nextProps.settings );
+				let newState = getFormSettings( nextProps.settings, nextProps );
 				//If we have any fields that the user has updated,
 				//do not wipe out those fields from the poll update.
 				newState = omit( newState, nextProps.dirtyFields );


### PR DESCRIPTION
In most cases we can assume the settings fields for a given form are in `props.settings`, but for settings on Jetpack sites, we need to combine those with fields fetched from the Jetpack site. This PR adds another parameter to `getFormSettings`, `props.jetpackSettings`. The developer using `getFormSettings` can now combine fields from settings and jetpackSettings into a single fields state.

See #10680, where we need to pull extra fields for discussion settings, for an example of how/why this parameter is used.

**To test**, check that there are no regressions in `/settings/discussion/$site` and `/settings/general/$site` for wp.com or Jetpack sites.

