### PR TITLE
Settings: Add comments label & color scheme settings to discussion tab

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -311,6 +311,7 @@
 @import 'my-sites/site-settings/style';
 @import 'my-sites/site-settings/action-panel/style';
 @import 'my-sites/site-settings/custom-content-types/style';
+@import 'my-sites/site-settings/comment-display-settings/style';
 @import 'my-sites/site-settings/delete-site/style';
 @import 'my-sites/site-settings/delete-site-options/style';
 @import 'my-sites/site-settings/delete-site-warning-dialog/style';

--- a/client/my-sites/site-settings/comment-display-settings/index.jsx
+++ b/client/my-sites/site-settings/comment-display-settings/index.jsx
@@ -1,0 +1,85 @@
+/**
+* External dependencies
+*/
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import FormSelect from 'components/forms/form-select';
+import FormTextInput from 'components/forms/form-text-input';
+import JetpackModuleToggle from '../jetpack-module-toggle';
+import { isJetpackModuleActive } from 'state/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+class CommentDisplaySettings extends Component {
+	shouldEnableSettings() {
+		const { isCommentsModuleActive, submittingForm } = this.props;
+		return !! submittingForm || ! isCommentsModuleActive;
+	}
+
+	render() {
+		const {
+			fields,
+			onChangeField,
+			selectedSiteId,
+			submittingForm,
+			translate,
+		} = this.props;
+
+		return (
+			<FormFieldset className="comment-display-settings">
+				<JetpackModuleToggle
+					siteId={ selectedSiteId }
+					moduleSlug="comments"
+					label={ translate(
+						'Use Jetpack comments. Let readers use their WordPress.com, Twitter, Facebook or Google+ to leave comments ' +
+						'on your posts and pages.'
+					) }
+					disabled={ !! submittingForm }
+					/>
+				<div className="comment-display-settings__module-setting is-indented">
+					<FormLabel htmlFor="highlander_comment_form_prompt">{ translate( 'Comments Label' ) }</FormLabel>
+					<FormTextInput
+						name="highlander_comment_form_prompt"
+						type="text"
+						id="highlander_comment_form_prompt"
+						value={ fields.highlander_comment_form_prompt || '' }
+						onChange={ onChangeField( 'highlander_comment_form_prompt' ) }
+						disabled={ this.shouldEnableSettings() } />
+					<FormSettingExplanation>
+						{ translate( 'A few catchy words to motivate your readers to comment.' ) }
+					</FormSettingExplanation>
+				</div>
+				<div className="comment-display-settings__module-setting is-indented">
+					<FormLabel htmlFor="jetpack_comment_form_color_scheme">{ translate( 'Color Scheme' ) }</FormLabel>
+					<FormSelect
+						name="jetpack_comment_form_color_scheme"
+						value={ fields.jetpack_comment_form_color_scheme || 'light' }
+						onChange={ onChangeField( 'jetpack_comment_form_color_scheme' ) }
+						disabled={ this.shouldEnableSettings() }>
+						<option value="light">{ translate( 'Light' ) }</option>
+						<option value="dark">{ translate( 'Dark' ) }</option>
+						<option value="transparent">{ translate( 'Transparent' ) }</option>
+					</FormSelect>
+				</div>
+			</FormFieldset>
+		);
+	}
+}
+
+export default connect(
+	( state ) => {
+		const selectedSiteId = getSelectedSiteId( state );
+
+		return {
+			selectedSiteId,
+			isCommentsModuleActive: !! isJetpackModuleActive( state, selectedSiteId, 'comments' ),
+		};
+	}
+)( localize( CommentDisplaySettings ) );

--- a/client/my-sites/site-settings/comment-display-settings/index.jsx
+++ b/client/my-sites/site-settings/comment-display-settings/index.jsx
@@ -38,8 +38,8 @@ class CommentDisplaySettings extends Component {
 					siteId={ selectedSiteId }
 					moduleSlug="comments"
 					label={ translate(
-						'Use Jetpack comments. Let readers use their WordPress.com, Twitter, Facebook or Google+ to leave comments ' +
-						'on your posts and pages.'
+						'Use Jetpack Comments. Readers will be able to use their WordPress.com, Twitter, Facebook, or Google+ accounts ' +
+						'to leave comments.'
 					) }
 					disabled={ !! submittingForm }
 					/>

--- a/client/my-sites/site-settings/comment-display-settings/style.scss
+++ b/client/my-sites/site-settings/comment-display-settings/style.scss
@@ -1,0 +1,3 @@
+.comment-display-settings__module-setting.is-indented {
+	margin: 16px 32px;
+}

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -194,10 +194,6 @@
 }
 
 .site-settings__discussion-settings {
-	label:first-of-type {
-		font-weight: normal;
-	}
-
 	.form-toggle__label {
 		display: flex;
 		align-items: center;
@@ -231,6 +227,12 @@
 
 		.form-select {
 			margin-top: 2px;
+		}
+	}
+
+	.site-settings__moderation-settings {
+		.form-label {
+			font-weight: normal;
 		}
 	}
 }

--- a/client/state/jetpack/settings/test/utils.js
+++ b/client/state/jetpack/settings/test/utils.js
@@ -147,6 +147,9 @@ describe( 'utils', () => {
 				'custom-content-types': true,
 				jetpack_testimonial: true,
 				jetpack_portfolio: false,
+				comments: true,
+				highlander_comment_form_prompt: 'Leave a Reply',
+				jetpack_comment_form_color_scheme: 'light',
 			};
 
 			expect( filterSettingsByActiveModules( settings ) ).to.eql( {
@@ -164,6 +167,8 @@ describe( 'utils', () => {
 				wpcom_publish_comments_with_markdown: true,
 				jetpack_testimonial: true,
 				jetpack_portfolio: false,
+				highlander_comment_form_prompt: 'Leave a Reply',
+				jetpack_comment_form_color_scheme: 'light',
 			} );
 		} );
 
@@ -189,6 +194,9 @@ describe( 'utils', () => {
 				'custom-content-types': false,
 				jetpack_testimonial: true,
 				jetpack_portfolio: false,
+				comments: false,
+				highlander_comment_form_prompt: 'Leave a Reply',
+				jetpack_comment_form_color_scheme: 'light',
 			};
 
 			expect( filterSettingsByActiveModules( settings ) ).to.eql( {
@@ -212,6 +220,8 @@ describe( 'utils', () => {
 				wpcom_publish_comments_with_markdown: true,
 				jetpack_testimonial: true,
 				jetpack_portfolio: false,
+				highlander_comment_form_prompt: 'Leave a Reply',
+				jetpack_comment_form_color_scheme: 'light',
 			};
 
 			expect( filterSettingsByActiveModules( settings ) ).to.eql( {

--- a/client/state/jetpack/settings/utils.js
+++ b/client/state/jetpack/settings/utils.js
@@ -80,6 +80,10 @@ export const filterSettingsByActiveModules = ( settings ) => {
 			'jetpack_testimonial',
 			'jetpack_portfolio',
 		],
+		comments: [
+			'highlander_comment_form_prompt',
+			'jetpack_comment_form_color_scheme',
+		]
 	};
 	let filteredSettings = { ...settings };
 


### PR DESCRIPTION
Exactly what it says ^ — adds comments label & color scheme settings to discussion tab for Jetpack sites with JP 4.5+

Note: this PR also contains code from #10679, which lets us combine the settings from wp.com with the settings directly from the jetpack site.

**To test:**

- Visit `/settings/discussion/$site` for a site with Jetpack 4.5
- You should see 2 fields at the top of the second card:
![screen shot 2017-01-24 at 5 01 39 pm](https://cloud.githubusercontent.com/assets/541093/22268808/e30b04d2-e256-11e6-8b45-194bbf13ebd5.png)

- Make a change to the label text or the color scheme, and save
- This should be reflected on your site, you can check quickly by looking in Settings -> Discussion, or `example.com/wp-admin/options-discussion.php`, at the end of the page.

for design @MichaelArestad @rickybanister, for code @tyxla @oskosk @johnHackworth @roccotripaldi 