### PR TITLE
Billing: Use PageViewTracker for analytics

### DIFF
--- a/client/me/billing-history/controller.js
+++ b/client/me/billing-history/controller.js
@@ -6,36 +6,27 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
-import route from 'lib/route';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import sitesFactory from 'lib/sites-list';
 
-const ANALYTICS_PAGE_TITLE = 'Me';
 const sites = sitesFactory();
 
 export default {
 	billingHistory( context ) {
 		const BillingHistoryComponent = require( './main' );
-		const basePath = route.sectionify( context.path );
 
 		renderWithReduxStore(
 			React.createElement( BillingHistoryComponent, { sites: sites } ),
 			document.getElementById( 'primary' ),
 			context.store
 		);
-
-		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Billing History' );
 	},
 
 	transaction( context ) {
 		const Receipt = require( './receipt' );
 		const receiptId = context.params.receiptId;
-		const basePath = route.sectionify( context.path );
 
 		if ( receiptId ) {
-			analytics.pageView.record( basePath + '/receipt', ANALYTICS_PAGE_TITLE + ' > Billing History > Receipt' );
-
 			renderWithReduxStore(
 				React.createElement( Receipt, { transactionId: receiptId } ),
 				document.getElementById( 'primary' ),

--- a/client/me/billing-history/main.jsx
+++ b/client/me/billing-history/main.jsx
@@ -20,6 +20,7 @@ import UpcomingChargesTable from './upcoming-charges-table';
 import SectionHeader from 'components/section-header';
 import Main from 'components/main';
 import DocumentHead from 'components/data/document-head';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryBillingTransactions from 'components/data/query-billing-transactions';
 import purchasesPaths from 'me/purchases/paths';
 import { getBillingTransactions } from 'state/selectors';
@@ -33,6 +34,7 @@ const BillingHistory = React.createClass( {
 		return (
 			<Main className="billing-history">
 				<DocumentHead title={ translate( 'Billing History' ) } />
+				<PageViewTracker path="/me/purchases/billing" title="Me > Billing History" />
 				<MeSidebarNavigation />
 				<QueryBillingTransactions />
 				<PurchasesHeader section={ 'billing' } />

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -14,6 +14,7 @@ import Card from 'components/card';
 import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
 import DocumentHead from 'components/data/document-head';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryBillingTransactions from 'components/data/query-billing-transactions';
 import purchasesPaths from 'me/purchases/paths';
 import { getPastBillingTransaction } from 'state/selectors';
@@ -138,6 +139,7 @@ const BillingReceipt = React.createClass( {
 		return (
 			<div>
 				<DocumentHead title={ translate( 'Billing History' ) } />
+				<PageViewTracker path="/me/purchases/billing/:receiptId" title="Me > Billing History > Receipt" />
 				<QueryBillingTransactions />
 				<HeaderCake backHref={ purchasesPaths.billingHistory() }>
 					{ translate( 'Billing History' ) }

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -139,7 +139,7 @@ const BillingReceipt = React.createClass( {
 		return (
 			<div>
 				<DocumentHead title={ translate( 'Billing History' ) } />
-				<PageViewTracker path="/me/purchases/billing/:receiptId" title="Me > Billing History > Receipt" />
+				<PageViewTracker path="/me/purchases/billing/receipt" title="Me > Billing History > Receipt" />
 				<QueryBillingTransactions />
 				<HeaderCake backHref={ purchasesPaths.billingHistory() }>
 					{ translate( 'Billing History' ) }


### PR DESCRIPTION
This PR updates the billing history to use `PageViewTracker` instead of `lib/analytics`. This PR is part of the billing reduxification effort - #10554.

To test:
* Checkout this branch
* Load the main Billing History page - `/me/purchases/billing` and verify that a `ANALYTICS_PAGE_VIEW_RECORD` action is dispatched with the expected `url` and `title`.
* Load a receipt in Billing - `/me/purchases/billing/$transactionId` and verify that a `ANALYTICS_PAGE_VIEW_RECORD` action is dispatched with the expected `url` and `title`.