### PR TITLE
Billing: Implement more specific transaction selectors

### DIFF
--- a/client/me/billing-history/main.jsx
+++ b/client/me/billing-history/main.jsx
@@ -23,13 +23,13 @@ import DocumentHead from 'components/data/document-head';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryBillingTransactions from 'components/data/query-billing-transactions';
 import purchasesPaths from 'me/purchases/paths';
-import { getBillingTransactions } from 'state/selectors';
+import { getPastBillingTransactions, getUpcomingBillingTransactions } from 'state/selectors';
 
 const BillingHistory = React.createClass( {
 	mixins: [ observe( 'sites' ), eventRecorder ],
 
 	render() {
-		const { transactions, sites, translate } = this.props;
+		const { pastTransactions, upcomingTransactions, sites, translate } = this.props;
 
 		return (
 			<Main className="billing-history">
@@ -39,16 +39,16 @@ const BillingHistory = React.createClass( {
 				<QueryBillingTransactions />
 				<PurchasesHeader section={ 'billing' } />
 				<Card className="billing-history__receipts">
-					<BillingHistoryTable transactions={ transactions.past } />
+					<BillingHistoryTable transactions={ pastTransactions } />
 				</Card>
 				<Card href={ purchasesPaths.purchasesRoot() }>
 					{ translate( 'Go to "Purchases" to add or cancel a plan.' ) }
 				</Card>
-				{ transactions.past &&
+				{ pastTransactions &&
 					<div>
 						<SectionHeader label={ translate( 'Upcoming Charges' ) } />
 						<Card className="billing-history__upcoming-charges">
-							<UpcomingChargesTable sites={ sites } transactions={ transactions.upcoming } />
+							<UpcomingChargesTable sites={ sites } transactions={ upcomingTransactions } />
 						</Card>
 					</div>
 				}
@@ -62,6 +62,7 @@ const BillingHistory = React.createClass( {
 
 export default connect(
 	( state ) => ( {
-		transactions: getBillingTransactions( state )
+		pastTransactions: getPastBillingTransactions( state ),
+		upcomingTransactions: getUpcomingBillingTransactions( state ),
 	} ),
 )( localize( BillingHistory ) );

--- a/client/state/selectors/get-past-billing-transaction.js
+++ b/client/state/selectors/get-past-billing-transaction.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { get, find } from 'lodash';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
-import { getBillingTransactions } from './';
+import { getPastBillingTransactions } from './';
 
 /**
  * Returns a past billing transaction.
@@ -19,14 +19,9 @@ import { getBillingTransactions } from './';
  */
 const getPastBillingTransaction = createSelector(
 	( state, id ) => {
-		const pastTransactions = get( getBillingTransactions( state ), [ 'past' ], null );
-		if ( ! pastTransactions ) {
-			return null;
-		}
-
-		return find( pastTransactions, { id } ) || null;
+		return find( getPastBillingTransactions( state ), { id } ) || null;
 	},
-	getBillingTransactions
+	getPastBillingTransactions
 );
 
 export default getPastBillingTransaction;

--- a/client/state/selectors/get-past-billing-transactions.js
+++ b/client/state/selectors/get-past-billing-transactions.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import { getBillingTransactions } from './';
+
+/**
+ * Returns all past billing transactions.
+ * Returns null if the billing transactions have not been fetched yet.
+ *
+ * @param  {Object}  state   Global state tree
+ * @return {?Array}          An array of past transactions
+ */
+const getPastBillingTransactions = createSelector(
+	( state ) => {
+		return get( getBillingTransactions( state ), [ 'past' ], null );
+	},
+	getBillingTransactions
+);
+
+export default getPastBillingTransactions;

--- a/client/state/selectors/get-upcoming-billing-transactions.js
+++ b/client/state/selectors/get-upcoming-billing-transactions.js
@@ -9,12 +9,12 @@ import { get } from 'lodash';
 import { getBillingTransactions } from './';
 
 /**
- * Returns all past billing transactions.
+ * Returns all upcoming billing transactions.
  * Returns null if the billing transactions have not been fetched yet.
  *
  * @param  {Object}  state   Global state tree
- * @return {?Array}          An array of past transactions
+ * @return {?Array}          An array of upcoming transactions
  */
-export default function getPastBillingTransactions( state ) {
-	return get( getBillingTransactions( state ), 'past', null );
+export default function getUpcomingBillingTransactions( state ) {
+	return get( getBillingTransactions( state ), 'upcoming', null );
 }

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -25,6 +25,7 @@ export getMediaItem from './get-media-item';
 export getMediaUrl from './get-media-url';
 export getPastBillingTransaction from './get-past-billing-transaction';
 export getPastBillingTransactions from './get-past-billing-transactions';
+export getUpcomingBillingTransactions from './get-upcoming-billing-transactions';
 export getSiteIconId from './get-site-icon-id';
 export getSiteIconUrl from './get-site-icon-url';
 export hasBrokenSiteUserConnection from './has-broken-site-user-connection';

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -24,6 +24,7 @@ export getSharingButtons from './get-sharing-buttons';
 export getMediaItem from './get-media-item';
 export getMediaUrl from './get-media-url';
 export getPastBillingTransaction from './get-past-billing-transaction';
+export getPastBillingTransactions from './get-past-billing-transactions';
 export getSiteIconId from './get-site-icon-id';
 export getSiteIconUrl from './get-site-icon-url';
 export hasBrokenSiteUserConnection from './has-broken-site-user-connection';

--- a/client/state/selectors/test/get-past-billing-transactions.js
+++ b/client/state/selectors/test/get-past-billing-transactions.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { moment } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getPastBillingTransactions } from '../';
+
+describe( 'getPastBillingTransactions()', () => {
+	it( 'should return the past billing transactions', () => {
+		const state = {
+			billingTransactions: {
+				items: {
+					past: [
+						{
+							id: '12345678',
+							amount: '$1.23',
+							date: '2016-12-12T11:22:33+0000',
+						}
+					],
+					upcoming: [
+						{
+							id: '87654321',
+							amount: '$4.56',
+							date: '2016-13-12T11:22:33+0000',
+						}
+					]
+				}
+			}
+		};
+		const expected = state.billingTransactions.items.past.map( ( transaction ) => {
+			transaction.date = moment( transaction.date ).toDate();
+			return transaction;
+		} );
+		const output = getPastBillingTransactions( state );
+		expect( output ).to.eql( expected );
+	} );
+
+	it( 'should return null if billing transactions have not been fetched yet', () => {
+		const output = getPastBillingTransactions( {
+			billingTransactions: {
+				items: {}
+			}
+		} );
+		expect( output ).to.be.null;
+	} );
+} );

--- a/client/state/selectors/test/get-upcoming-billing-transactions.js
+++ b/client/state/selectors/test/get-upcoming-billing-transactions.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { moment } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getUpcomingBillingTransactions } from '../';
+
+describe( 'getUpcomingBillingTransactions()', () => {
+	it( 'should return the upcoming billing transactions', () => {
+		const state = {
+			billingTransactions: {
+				items: {
+					past: [
+						{
+							id: '12345678',
+							amount: '$1.23',
+							date: '2016-12-12T11:22:33+0000',
+						}
+					],
+					upcoming: [
+						{
+							id: '87654321',
+							amount: '$4.56',
+							date: '2016-13-12T11:22:33+0000',
+						}
+					]
+				}
+			}
+		};
+		const expected = state.billingTransactions.items.upcoming.map( ( transaction ) => {
+			transaction.date = moment( transaction.date ).toDate();
+			return transaction;
+		} );
+		const output = getUpcomingBillingTransactions( state );
+		expect( output ).to.eql( expected );
+	} );
+
+	it( 'should return null if billing transactions have not been fetched yet', () => {
+		const output = getUpcomingBillingTransactions( {
+			billingTransactions: {
+				items: {}
+			}
+		} );
+		expect( output ).to.be.null;
+	} );
+} );


### PR DESCRIPTION
This PR:

* Introduces 2 new selectors, allowing selection of billing transactions by type:
  * `getPastBillingTransactions`
  * `getUpcomingBillingTransactions`
* Updates the `getPastBillingTransaction` selector to use `getPastBillingTransactions`
* Updates the `BillingHistory` component to use the new selectors.

This was recommended by @gwwar here: https://github.com/Automattic/wp-calypso/pull/10654#discussion_r96278885. Also, this PR is part of the Billing History reduxification effort - #10554.

To test:

* Checkout this branch
* Verify all global selectors tests pass: `npm run test-client client/state/selectors/`
* Verify all past and upcoming transactions still appear properly in `me/purchases/billing`
* Test the last step with an empty Redux state.