### PR TITLE
Prevent user accessing paths on domain only site

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -119,8 +119,6 @@ function isPathAllowedForDomainOnlySite( pathname, site ) {
 	const urlPrefixesWhiteListForDomainOnlySite = [
 		'/domains/manage/',
 		'/checkout/',
-		'/customize/',
-		'/domains/landing-page',
 	];
 
 	const isPathWhiteListedForDomainOnlySite = urlPrefixesWhiteListForDomainOnlySite

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -32,6 +32,7 @@ import trackScrollPage from 'lib/track-scroll-page';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
+import { domainManagementList } from 'my-sites/upgrades/paths';
 
 /**
  * Module vars
@@ -128,9 +129,9 @@ function onSelectedSiteAvailable( context ) {
 
 	const state = context.store.getState();
 
-	if ( isDomainOnlySite( state, selectedSite.ID )
-		&& ! isPathAllowedForDomainOnlySite( context.pathname ) ) {
-		page.redirect( '/domains/manage/' + selectedSite.slug );
+	if ( isDomainOnlySite( state, selectedSite.ID ) &&
+		! isPathAllowedForDomainOnlySite( context.pathname ) ) {
+		page.redirect( domainManagementList( selectedSite.slug ) );
 		return false;
 	}
 


### PR DESCRIPTION
For a domain only site, we allow users to visit only certain parts of site management.
 
Based on @scruffian's work [on the prototype](https://github.com/Automattic/wp-calypso/pull/10427/files#diff-f11e4a0f3fa89aa5176d3244e323a240R176)

#### Testing instructions
  
1. Run `git checkout add/redirect-not-in-whitelist-for-domain-only-site` and start your server, or open a [live branch](https://calypso.live/?branch=add/redirect-not-in-whitelist-for-domain-only-site)
2. Get to a state where you have a domain only site ( via the [prototype](https://github.com/Automattic/wp-calypso/pull/10427), or otherwise )
3. Open the [http://calypso.localhost:3000/domains/manage/myyury.wordpress.com](http://calypso.localhost:3000/domains/manage/myyury.wordpress.com) where `myyury.wordpress.com` is the domain only site.
4. Check that you are redirected back to that page when you try visit pages that are not:
```
	'/domains/manage/',
	'/checkout/',
```
5. Validate cold start as well, by, for example visiting directly the disallowed links such as: `http://calypso.localhost:3000/design/myyury.wordpress.com`
  
 
#### Reviews
  
- [x] Code
- [ ] Product
