### PR TITLE
Stats: Use redux subtree for Top Authors Stats

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -342,8 +342,6 @@ module.exports = {
 				siteID: siteId, statType: 'statsTopPosts', period: activeFilter.period, date: endDate, domain: siteDomain } );
 			const clicksList = new StatsList( {
 				siteID: siteId, statType: 'statsClicks', period: activeFilter.period, date: endDate, domain: siteDomain } );
-			const authorsList = new StatsList( {
-				siteID: siteId, statType: 'statsTopAuthors', period: activeFilter.period, date: endDate, domain: siteDomain } );
 			const searchTermsList = new StatsList( {
 				siteID: siteId, statType: 'statsSearchTerms', period: activeFilter.period, date: endDate, domain: siteDomain } );
 
@@ -359,7 +357,6 @@ module.exports = {
 				visitsList,
 				postsPagesList,
 				clicksList,
-				authorsList,
 				siteId,
 				period,
 				chartPeriod,
@@ -485,9 +482,7 @@ module.exports = {
 					break;
 
 				case 'authors':
-					summaryList = new StatsList( {
-						statType: 'statsTopAuthors', siteID: siteId, period: activeFilter.period,
-						date: endDate, max: 0, domain: siteDomain } );
+					summaryList = fakeStatsList;
 					break;
 
 				case 'videoplays':

--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -211,7 +211,6 @@ module.exports = {
 		let siteId = context.params.site_id;
 		const siteFragment = route.getSiteFragment( context.path );
 		const queryOptions = context.query;
-		const FollowList = require( 'lib/follow-list' );
 		const SiteStatsComponent = require( 'my-sites/stats/site' );
 		const StatsList = require( 'lib/stats/stats-list' );
 		const filters = getSiteFilters.bind( null, siteId );
@@ -330,7 +329,6 @@ module.exports = {
 			const siteDomain = ( currentSite && ( typeof currentSite.slug !== 'undefined' ) )
 					? currentSite.slug : siteFragment;
 
-			const followList = new FollowList();
 			const activeTabVisitsList = new StatsList( {
 				siteID: siteId, statType: 'statsVisits', unit: activeFilter.period,
 				quantity: chartQuantity, date: chartEndDate, stat_fields: visitsListFields, domain: siteDomain } );
@@ -360,7 +358,6 @@ module.exports = {
 				siteId,
 				period,
 				chartPeriod,
-				followList,
 				searchTermsList,
 				slug: siteDomain,
 				path: context.pathname,
@@ -389,7 +386,6 @@ module.exports = {
 		const siteFragment = route.getSiteFragment( context.path );
 		const queryOptions = context.query;
 		const StatsList = require( 'lib/stats/stats-list' );
-		const FollowList = require( 'lib/follow-list' );
 		const StatsSummaryComponent = require( 'my-sites/stats/summary' );
 		const filters = function( contextModule, _siteId ) {
 			return [
@@ -409,7 +405,6 @@ module.exports = {
 		let period;
 		let summaryList;
 		let visitsList;
-		const followList = new FollowList();
 
 		const validModules = [ 'posts', 'referrers', 'clicks', 'countryviews', 'authors', 'videoplays', 'videodetails', 'podcastdownloads', 'searchterms' ];
 		let momentSiteZone = i18n.moment();
@@ -520,7 +515,6 @@ module.exports = {
 					filters: filters,
 					summaryList: summaryList,
 					visitsList: visitsList,
-					followList: followList,
 					siteId: siteId,
 					period: period,
 					...extraProps

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -192,16 +192,16 @@ module.exports = React.createClass( {
 								period={ this.props.period }
 								date={ queryDate }
 								beforeNavigate={ this.updateScrollPosition } />
-							<StatsModule
-								path={ 'authors' }
+							<StatsConnectedModule
+								path="authors"
 								moduleStrings={ moduleStrings.authors }
-								site={ site }
-								dataList={ this.props.authorsList }
 								period={ this.props.period }
 								date={ queryDate }
+								query={ query }
+								statType="statsTopAuthors"
 								followList={ this.props.followList }
 								className="stats__author-views"
-								beforeNavigate={ this.updateScrollPosition } />
+								showSummaryLink />
 						</div>
 						<div className="stats__module-column">
 							<Countries

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -199,7 +199,6 @@ module.exports = React.createClass( {
 								date={ queryDate }
 								query={ query }
 								statType="statsTopAuthors"
-								followList={ this.props.followList }
 								className="stats__author-views"
 								showSummaryLink />
 						</div>

--- a/client/my-sites/stats/stats-module/connected-list.jsx
+++ b/client/my-sites/stats/stats-module/connected-list.jsx
@@ -41,6 +41,8 @@ class StatsConnectedModule extends Component {
 		statType: PropTypes.string,
 		showSummaryLink: PropTypes.bool,
 		translate: PropTypes.func,
+		// This should be removed when we reduxify the followed sites list
+		followList: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -84,6 +86,7 @@ class StatsConnectedModule extends Component {
 			query,
 			period,
 			translate,
+			followList,
 		} = this.props;
 
 		const noData = (
@@ -123,7 +126,7 @@ class StatsConnectedModule extends Component {
 					{ this.props.children }
 					<StatsListLegend value={ moduleStrings.value } label={ moduleStrings.item } />
 					<StatsModulePlaceholder isLoading={ isLoading } />
-					<StatsList moduleName={ path } data={ data } />
+					<StatsList moduleName={ path } data={ data } followList={ followList } />
 					{ this.props.showSummaryLink && displaySummaryLink && <StatsModuleExpand href={ summaryLink } /> }
 					{ summary && 'countryviews' === path &&
 						<UpgradeNudge

--- a/client/my-sites/stats/stats-module/connected-list.jsx
+++ b/client/my-sites/stats/stats-module/connected-list.jsx
@@ -41,8 +41,6 @@ class StatsConnectedModule extends Component {
 		statType: PropTypes.string,
 		showSummaryLink: PropTypes.bool,
 		translate: PropTypes.func,
-		// This should be removed when we reduxify the followed sites list
-		followList: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -86,7 +84,6 @@ class StatsConnectedModule extends Component {
 			query,
 			period,
 			translate,
-			followList,
 		} = this.props;
 
 		const noData = (
@@ -126,7 +123,7 @@ class StatsConnectedModule extends Component {
 					{ this.props.children }
 					<StatsListLegend value={ moduleStrings.value } label={ moduleStrings.item } />
 					<StatsModulePlaceholder isLoading={ isLoading } />
-					<StatsList moduleName={ path } data={ data } followList={ followList } />
+					<StatsList moduleName={ path } data={ data } />
 					{ this.props.showSummaryLink && displaySummaryLink && <StatsModuleExpand href={ summaryLink } /> }
 					{ summary && 'countryviews' === path &&
 						<UpgradeNudge

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -132,16 +132,19 @@ const StatsSummary = React.createClass( {
 				title = translate( 'Authors' );
 				// TODO: should be refactored so that className doesn't have to be passed in
 				/* eslint-disable wpcalypso/jsx-classname-namespace */
-				summaryView = <StatsModule
-					key="authors-summary"
-					path={ 'authors' }
-					moduleStrings={ StatsStrings.authors }
-					site={ site }
-					dataList={ this.props.summaryList }
-					period={ this.props.period }
-					followList={ this.props.followList }
-					className="stats__author-views"
-					summary={ true } />;
+				summaryView = (
+					<StatsConnectedModule
+						key="authors-summary"
+						path="authors"
+						moduleStrings={ StatsStrings.authors }
+						period={ this.props.period }
+						query={ query }
+						statType="statsTopAuthors"
+						followList={ this.props.followList }
+						className="stats__author-views"
+						summary={ true }
+					/>
+				);
 				/* eslint-enable wpcalypso/jsx-classname-namespace */
 				break;
 

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -140,7 +140,6 @@ const StatsSummary = React.createClass( {
 						period={ this.props.period }
 						query={ query }
 						statType="statsTopAuthors"
-						followList={ this.props.followList }
 						className="stats__author-views"
 						summary={ true }
 					/>

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -716,6 +716,89 @@ describe( 'utils', () => {
 			} );
 		} );
 
+		describe( 'statsTopAuthors()', () => {
+			it( 'should return an empty array if not data is passed', () => {
+				const parsedData = normalizers.statsTopAuthors();
+
+				expect( parsedData ).to.eql( [] );
+			} );
+
+			it( 'should return an empty array if query.period is null', () => {
+				const parsedData = normalizers.statsTopAuthors( {}, { date: '2016-12-25' } );
+
+				expect( parsedData ).to.eql( [] );
+			} );
+
+			it( 'should return an empty array if query.date is null', () => {
+				const parsedData = normalizers.statsTopAuthors( {}, { period: 'day' } );
+
+				expect( parsedData ).to.eql( [] );
+			} );
+
+			it( 'should return an a properly parsed data array', () => {
+				const parsedData = normalizers.statsTopAuthors( {
+					date: '2017-01-17',
+					days: {
+						'2017-01-17': {
+							authors: [
+								{
+									name: 'Timmy Crawford',
+									avatar: 'https://0.gravatar.com/avatar/9929daa7594d5afa910a777ccb9e88e4?s=64&size=G',
+									follow_data: { params: {} },
+									posts: [
+										{ id: 30, title: 'Chicken', url: 'http://en.blog.wordpress.com/chicken', views: 6 },
+										{ id: 32, title: 'Ribs', url: 'http://en.blog.wordpress.com/ribs', views: 10 }
+									]
+								}
+							]
+						}
+					}
+				}, {
+					period: 'day',
+					date: '2017-01-17',
+					domain: 'en.blog.wordpress.com'
+				}, 10, {
+					slug: 'en.blog.wordpress.com'
+				} );
+
+				expect( parsedData ).to.eql( [
+					{
+						actions: [ {
+							data: {},
+							type: 'follow'
+						} ],
+						children: [
+							{
+								actions: [ {
+									data: 'http://en.blog.wordpress.com/chicken',
+									type: 'link'
+								} ],
+								children: null,
+								label: 'Chicken',
+								page: '/stats/post/30/en.blog.wordpress.com',
+								value: 6
+							},
+							{
+								actions: [ {
+									data: 'http://en.blog.wordpress.com/ribs',
+									type: 'link'
+								} ],
+								children: null,
+								label: 'Ribs',
+								page: '/stats/post/32/en.blog.wordpress.com',
+								value: 10
+							},
+						],
+						className: 'module-content-list-item-large',
+						icon: 'https://0.gravatar.com/avatar/9929daa7594d5afa910a777ccb9e88e4?d=mm',
+						iconClassName: 'avatar-user',
+						label: 'Timmy Crawford',
+						value: undefined
+					}
+				] );
+			} );
+		} );
+
 		describe( 'statsTags()', () => {
 			it( 'should return an empty array if not data is passed', () => {
 				const parsedData = normalizers.statsTags();

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -744,7 +744,6 @@ describe( 'utils', () => {
 								{
 									name: 'Timmy Crawford',
 									avatar: 'https://0.gravatar.com/avatar/9929daa7594d5afa910a777ccb9e88e4?s=64&size=G',
-									follow_data: { params: {} },
 									posts: [
 										{ id: 30, title: 'Chicken', url: 'http://en.blog.wordpress.com/chicken', views: 6 },
 										{ id: 32, title: 'Ribs', url: 'http://en.blog.wordpress.com/ribs', views: 10 }
@@ -763,10 +762,6 @@ describe( 'utils', () => {
 
 				expect( parsedData ).to.eql( [
 					{
-						actions: [ {
-							data: {},
-							type: 'follow'
-						} ],
 						children: [
 							{
 								actions: [ {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -303,11 +303,7 @@ export const normalizers = {
 				icon: parseAvatar( item.avatar ),
 				children: null,
 				value: item.views,
-				className: 'module-content-list-item-large',
-				actions: [ {
-					type: 'follow',
-					data: item.follow_data ? item.follow_data.params : false
-				} ]
+				className: 'module-content-list-item-large'
 			};
 
 			if ( item.posts && item.posts.length > 0 ) {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -37,6 +37,19 @@ export function rangeOfPeriod( period, date ) {
 }
 
 /**
+ * Parse the avatar URL
+ * @param  {String} avatarUrl Raw avatanr URL
+ * @return {String}           Parsed URL
+ */
+function parseAvatar( avatarUrl ) {
+	if ( ! avatarUrl ) {
+		return null;
+	}
+	const [ avatarBaseUrl ] = avatarUrl.split( '?' );
+	return avatarBaseUrl + '?d=mm';
+}
+
+/**
  * Builds data into escaped array for CSV export
  *
  * @param  {Object} data   Normalized stats data object
@@ -265,6 +278,55 @@ export const normalizers = {
 		return payload.data.map( item => {
 			return { period: item[ 0 ], value: item[ 1 ] };
 		} ).slice( Math.max( payload.data.length - 10, 1 ) );
+	},
+
+	/**
+	 * Returns a normalized statsTopAuthors array, ready for use in stats-module
+	 *
+	 * @param  {Object} data   Stats data
+	 * @param  {Object} query  Stats query
+	 * @param  {Int}    siteId Site ID
+	 * @param  {Object} site   Site Object
+	 * @return {Array}       Normalized stats data
+	 */
+	statsTopAuthors( data, query = {}, siteId, site ) {
+		if ( ! data || ! query.period || ! query.date ) {
+			return [];
+		}
+		const { startOf } = rangeOfPeriod( query.period, query.date );
+		const authorsData = get( data, [ 'days', startOf, 'authors' ], [] );
+
+		return authorsData.map( ( item ) => {
+			const record = {
+				label: item.name,
+				iconClassName: 'avatar-user',
+				icon: parseAvatar( item.avatar ),
+				children: null,
+				value: item.views,
+				className: 'module-content-list-item-large',
+				actions: [ {
+					type: 'follow',
+					data: item.follow_data ? item.follow_data.params : false
+				} ]
+			};
+
+			if ( item.posts && item.posts.length > 0 ) {
+				record.children = item.posts.map( ( child ) => {
+					return {
+						label: child.title,
+						value: child.views,
+						page: site ? '/stats/post/' + child.id + '/' + site.slug : null,
+						actions: [ {
+							type: 'link',
+							data: child.url
+						} ],
+						children: null
+					};
+				} );
+			}
+
+			return record;
+		} );
 	},
 
 	/**

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -38,7 +38,7 @@ export function rangeOfPeriod( period, date ) {
 
 /**
  * Parse the avatar URL
- * @param  {String} avatarUrl Raw avatanr URL
+ * @param  {String} avatarUrl Raw avatar URL
  * @return {String}           Parsed URL
  */
 function parseAvatar( avatarUrl ) {


### PR DESCRIPTION
Closes #10627 

In this PR, I moved the parser logic for StatsTopAuthors from StatsList into the redux stats subtree.
I also updated the authors stats module to use the StatsConnectedModule Component.

**Notes**

- In order to generate the action link, the `normalizer` needs the site slug, I opted for providing the whole site object for now thinking other "normalizers" could make use of those.

- I thought about reduxifying the `followList` and the `follow-action` in a separate PR, The problem I'm facing for now is that I'm not sure we currently track the site's is_following flag on the redux tree. Also, I'm afraid we would have several API calls (one for each site) if we try to reduxify this now. Unless I missed it, I have not found a way to retrieve all the followed sites in one API call.

**Testing instructions**

 - Navigate to the stats insights page /stats/day/$site
 - The Authors panel should work properly (same as master)
 - Click on the header of the panel to navigate to the summary page
 - The authors stats should show up (same as master)