### PR TITLE
Plugins: Add plan to mock plugin site data in single plugin page

### DIFF
--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -273,6 +273,14 @@ const SinglePlugin = React.createClass( {
 			name: 'Not a real site',
 			options: {
 				software_version: '1'
+			},
+			plan: {
+				expired: false,
+				free_trial: false,
+				product_id: 2002,
+				product_name_short: 'Free',
+				product_slug: 'jetpack_free',
+				user_is_owner: false,
 			}
 		};
 


### PR DESCRIPTION
This PR fixes #10688, where the single plugin page blows up when Manage is disabled. The reason for this failure is because in the "Manage is disabled" message we also display a mock plugin, but that mock plugin was missing some plan data in the current site information. So this PR adds some necessary sample plan data.

After fixing this, the single plugin page appears properly as it was:

![](https://cldup.com/068Uf9AF8u.png)

To test:
* Checkout this branch
* Go to `/plugins/akismet/$site`, where `$site` is one of your Jetpack sites with disabled Manage.
* Verify the page appears as in the screenshot, and there are no errors in the console, or error notices.

/cc @ockham since I found this while testing his PR 😃 