### PR TITLE
Site Settings: Mark fields as changed when changing in wrapSettingsForm

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -90,18 +90,20 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				currentTargetValue = event.currentTarget.value;
 
 			this.props.updateFields( { [ currentTargetName ]: currentTargetValue } );
+			this.props.markChanged();
 		};
 
 		handleToggle = name => () => {
 			this.props.trackEvent( `Toggled ${ name }` );
 			this.props.updateFields( { [ name ]: ! this.props.fields[ name ] } );
+			this.props.markChanged();
 		};
 
 		onChangeField = field => event => {
-			const { updateFields } = this.props;
-			updateFields( {
+			this.props.updateFields( {
 				[ field ]: event.target.value
 			} );
+			this.props.markChanged();
 		};
 
 		uniqueEventTracker = message => () => {


### PR DESCRIPTION
This PR fixes #10670, where it was reported by @drw158 that the Settings: Discussion form does not alert users when changing to another Settings tab with unsaved settings. 

This appears to have been introduced in #9899, which reduxified the Discussion form.

The solution proposed in this PR is to mark each field as changed when handling a change in any of the fields.

To test:
* Checkout this branch
* Go to `/settings/discussion/$site`, where `$site` is one of your sites.
* Change any setting, do not click "Save Changes".
* Switch to another tab and verify you're presented with an alert that prevents you from losing unsaved changes.

/cc
* @drw158 as the initial reporter of the issue
* @youknowriad because he worked on the Reduxification of the discussion form (#9899)
* @ryelle because she also worked on the Discussion tab recently.