### PR TITLE
Site Settings: Reduxify Writing Settings Form

### DIFF
--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -178,7 +178,7 @@
 	}
 }
 
-.site-settings__general-settings {
+.site-settings__general-settings, .site-settings__writing-settings {
 	.form-toggle__label {
 		display: flex;
 		align-items: center;

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -95,6 +95,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 		handleToggle = name => () => {
 			this.props.trackEvent( `Toggled ${ name }` );
 			this.props.updateFields( { [ name ]: ! this.props.fields[ name ] } );
+			this.props.markChanged();
 		};
 
 		onChangeField = field => event => {


### PR DESCRIPTION
Part of my janitorial PRs to reduxify SiteSettings endpoint completely, I'm moving the Writing Settings Form to use the redux approach. This includes :

 - Use wrapSettingsForm HoC
 - Drop the usage of `formBase`
 - Use React Component Class
 - Use FormToggle instead of FormCheckbox

**Testing instructions**

 - Navigate to the Writing Settings Form: `/settings/writing/$site`
 - Try to update the different settings
 - Try with jetpack websites as well
 - The form should continue to work as expected