### PR TITLE
QueryManager: Rename sort() to compare()

### DIFF
--- a/client/lib/query-manager/README.md
+++ b/client/lib/query-manager/README.md
@@ -42,10 +42,10 @@ Currently, the following implementations exist:
 
 ## Extending
 
-Depending on the level of customization you need, you'll likely only need to implement the `matches` and `sort` methods.
+Depending on the level of customization you need, you'll likely only need to implement the `matches` and `compare` methods.
 
 - `matches( query: object, item: object )` should return true if the passed item should be included in the query set
-- `sort( itemA: object, itemB: object )` is a sort comparator function, returning -1 to indicate "A before B", 1 to indicate "A after B", or 0 to indicate equality ([see `Array.prototype.sort`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort))
+- `compare( itemA: object, itemB: object )` is a sort comparator function, returning -1 to indicate "A before B", 1 to indicate "A after B", or 0 to indicate equality ([see `Array.prototype.sort`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort))
 
 Sometimes you may need to make further customizations. Some examples include:
 

--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -95,7 +95,7 @@ export default class QueryManager {
 	 * @return {Number}       0 if equal, less than 0 if itemA is first,
 	 *                        greater than 0 if itemB is first.
 	 */
-	sort( query, itemA, itemB ) {
+	compare( query, itemA, itemB ) {
 		if ( itemA === itemB ) {
 			return 0;
 		}
@@ -352,7 +352,7 @@ export default class QueryManager {
 							return 0;
 						}
 
-						return this.sort( query, nextItems[ keyA ], nextItems[ keyB ] );
+						return this.compare( query, nextItems[ keyA ], nextItems[ keyB ] );
 					} );
 				}
 			} );

--- a/client/lib/query-manager/media/index.js
+++ b/client/lib/query-manager/media/index.js
@@ -84,7 +84,7 @@ export default class MediaQueryManager extends PaginatedQueryManager {
 	 * @return {Number}        0 if equal, less than 0 if mediaA is first,
 	 *                         greater than 0 if mediaB is first.
 	 */
-	sort( query, mediaA, mediaB ) {
+	compare( query, mediaA, mediaB ) {
 		let order;
 
 		switch ( query.order_by ) {

--- a/client/lib/query-manager/media/test/index.js
+++ b/client/lib/query-manager/media/test/index.js
@@ -234,13 +234,13 @@ describe( 'MediaQueryManager', () => {
 		} );
 	} );
 
-	describe( '#sort()', () => {
+	describe( '#compare()', () => {
 		context( 'query.order', () => {
 			it( 'should sort descending by default', () => {
 				const sorted = [
 					{ ID: 200 },
 					{ ID: 400 }
-				].sort( manager.sort.bind( manager, {
+				].sort( manager.compare.bind( manager, {
 					order_by: 'ID'
 				} ) );
 
@@ -254,7 +254,7 @@ describe( 'MediaQueryManager', () => {
 				const sorted = [
 					{ ID: 400 },
 					{ ID: 200 }
-				].sort( manager.sort.bind( manager, {
+				].sort( manager.compare.bind( manager, {
 					order_by: 'ID',
 					order: 'ASC'
 				} ) );
@@ -283,7 +283,7 @@ describe( 'MediaQueryManager', () => {
 					const sorted = [
 						olderMedia,
 						newerMedia
-					].sort( manager.sort.bind( manager, {} ) );
+					].sort( manager.compare.bind( manager, {} ) );
 
 					expect( sorted ).to.eql( [
 						newerMedia,
@@ -308,7 +308,7 @@ describe( 'MediaQueryManager', () => {
 					const sorted = [
 						aaMedia,
 						abMedia
-					].sort( manager.sort.bind( manager, {
+					].sort( manager.compare.bind( manager, {
 						order_by: 'title'
 					} ) );
 
@@ -324,7 +324,7 @@ describe( 'MediaQueryManager', () => {
 					const sorted = [
 						{ ID: 200 },
 						{ ID: 400 }
-					].sort( manager.sort.bind( manager, {
+					].sort( manager.compare.bind( manager, {
 						order_by: 'ID'
 					} ) );
 

--- a/client/lib/query-manager/paginated/test/index.js
+++ b/client/lib/query-manager/paginated/test/index.js
@@ -22,7 +22,7 @@ describe( 'PaginatedQueryManager', () => {
 
 	useSandbox( ( _sandbox ) => {
 		sandbox = _sandbox;
-		sandbox.stub( PaginatedQueryManager.prototype, 'sort', ( query, a, b ) => a.ID - b.ID );
+		sandbox.stub( PaginatedQueryManager.prototype, 'compare', ( query, a, b ) => a.ID - b.ID );
 	} );
 
 	beforeEach( () => {

--- a/client/lib/query-manager/post/index.js
+++ b/client/lib/query-manager/post/index.js
@@ -114,7 +114,7 @@ export default class PostQueryManager extends PaginatedQueryManager {
 	 * @return {Number}       0 if equal, less than 0 if postA is first,
 	 *                        greater than 0 if postB is first.
 	 */
-	sort( query, postA, postB ) {
+	compare( query, postA, postB ) {
 		let order;
 
 		switch ( query.order_by ) {

--- a/client/lib/query-manager/post/test/index.js
+++ b/client/lib/query-manager/post/test/index.js
@@ -622,13 +622,13 @@ describe( 'PostQueryManager', () => {
 		} );
 	} );
 
-	describe( '#sort()', () => {
+	describe( '#compare()', () => {
 		context( 'query.order', () => {
 			it( 'should sort descending by default', () => {
 				const sorted = [
 					{ ID: 200 },
 					{ ID: 400 }
-				].sort( manager.sort.bind( manager, {
+				].sort( manager.compare.bind( manager, {
 					order_by: 'ID'
 				} ) );
 
@@ -642,7 +642,7 @@ describe( 'PostQueryManager', () => {
 				const sorted = [
 					{ ID: 200 },
 					{ ID: 400 }
-				].sort( manager.sort.bind( manager, {
+				].sort( manager.compare.bind( manager, {
 					order_by: 'ID',
 					order: 'ASC'
 				} ) );
@@ -669,7 +669,7 @@ describe( 'PostQueryManager', () => {
 					const sorted = [
 						olderPost,
 						newerPost
-					].sort( manager.sort.bind( manager, {} ) );
+					].sort( manager.compare.bind( manager, {} ) );
 
 					expect( sorted ).to.eql( [
 						newerPost,
@@ -692,7 +692,7 @@ describe( 'PostQueryManager', () => {
 					const sorted = [
 						olderPost,
 						newerPost
-					].sort( manager.sort.bind( manager, {
+					].sort( manager.compare.bind( manager, {
 						order_by: 'modified'
 					} ) );
 
@@ -717,7 +717,7 @@ describe( 'PostQueryManager', () => {
 					const sorted = [
 						aPost,
 						zPost
-					].sort( manager.sort.bind( manager, {
+					].sort( manager.compare.bind( manager, {
 						order_by: 'title'
 					} ) );
 
@@ -746,7 +746,7 @@ describe( 'PostQueryManager', () => {
 					const sorted = [
 						unpopularPost,
 						popularPost
-					].sort( manager.sort.bind( manager, {
+					].sort( manager.compare.bind( manager, {
 						order_by: 'comment_count'
 					} ) );
 
@@ -762,7 +762,7 @@ describe( 'PostQueryManager', () => {
 					const sorted = [
 						{ ID: 200 },
 						{ ID: 400 }
-					].sort( manager.sort.bind( manager, {
+					].sort( manager.compare.bind( manager, {
 						order_by: 'ID'
 					} ) );
 

--- a/client/lib/query-manager/term/index.js
+++ b/client/lib/query-manager/term/index.js
@@ -43,7 +43,7 @@ export default class TermQueryManager extends PaginatedQueryManager {
 	 * @return {Number}       0 if equal, less than 0 if termA is first,
 	 *                        greater than 0 if termB is first.
 	 */
-	sort( query, termA, termB ) {
+	compare( query, termA, termB ) {
 		let order;
 
 		switch ( query.order_by ) {

--- a/client/lib/query-manager/term/test/index.js
+++ b/client/lib/query-manager/term/test/index.js
@@ -69,13 +69,13 @@ describe( 'TermQueryManager', () => {
 		} );
 	} );
 
-	describe( '#sort()', () => {
+	describe( '#compare()', () => {
 		context( 'query.order', () => {
 			it( 'should sort ascending by default', () => {
 				const sorted = [
 					{ name: 'Food' },
 					{ name: 'Cars' }
-				].sort( manager.sort.bind( manager, {
+				].sort( manager.compare.bind( manager, {
 					order_by: 'name'
 				} ) );
 
@@ -89,7 +89,7 @@ describe( 'TermQueryManager', () => {
 				const sorted = [
 					{ name: 'Food' },
 					{ name: 'Cars' }
-				].sort( manager.sort.bind( manager, {
+				].sort( manager.compare.bind( manager, {
 					order_by: 'name',
 					order: 'DESC'
 				} ) );
@@ -107,7 +107,7 @@ describe( 'TermQueryManager', () => {
 					const sorted = [
 						{ name: 'Food' },
 						{ name: 'Cars' }
-					].sort( manager.sort.bind( manager, {
+					].sort( manager.compare.bind( manager, {
 						order_by: 'name'
 					} ) );
 
@@ -128,7 +128,7 @@ describe( 'TermQueryManager', () => {
 					const sorted = [
 						DEFAULT_TERM,
 						unusedTerm
-					].sort( manager.sort.bind( manager, {
+					].sort( manager.compare.bind( manager, {
 						order_by: 'count'
 					} ) );
 

--- a/client/lib/query-manager/test/index.js
+++ b/client/lib/query-manager/test/index.js
@@ -82,17 +82,17 @@ describe( 'QueryManager', () => {
 		} );
 	} );
 
-	describe( '#sort()', () => {
+	describe( '#compare()', () => {
 		it( 'should return 0 for equal items', () => {
-			expect( manager.sort( {}, 40, 40 ) ).to.equal( 0 );
+			expect( manager.compare( {}, 40, 40 ) ).to.equal( 0 );
 		} );
 
 		it( 'should return a number less than zero if the first argument is larger', () => {
-			expect( manager.sort( {}, 50, 40 ) ).to.be.lt( 0 );
+			expect( manager.compare( {}, 50, 40 ) ).to.be.lt( 0 );
 		} );
 
 		it( 'should return a number greater than zero if the first argument is smaller', () => {
-			expect( manager.sort( {}, 30, 40 ) ).to.be.gt( 0 );
+			expect( manager.compare( {}, 30, 40 ) ).to.be.gt( 0 );
 		} );
 	} );
 
@@ -366,9 +366,9 @@ describe( 'QueryManager', () => {
 			expect( manager.getItems( {} ) ).to.eql( [ { ID: 144 } ] );
 		} );
 
-		it( 'should sort items appended to query set', () => {
+		it( 'should compare items appended to query set', () => {
 			manager = manager.receive( [ { ID: 140 }, { ID: 160 } ], { query: {} } );
-			sandbox.stub( manager, 'sort', ( query, a, b ) => a.ID - b.ID );
+			sandbox.stub( manager, 'compare', ( query, a, b ) => a.ID - b.ID );
 			manager = manager.receive( { ID: 150 } );
 
 			expect( manager.getItems( {} ) ).to.eql( [ { ID: 140 }, { ID: 150 }, { ID: 160 } ] );


### PR DESCRIPTION
This is really a comparison function, so it should be named that way. We're going to introduce a sort() method that falls back to using compare(). 

The rationale for the latter is that `ThemeQueryManager` currently re-implements `QueryManager`'s `receive` because it cannot provide a simple `compare` method, as it relies too much on the server which uses ElasticSearch to weigh and sort results, so it wants the exact order as received from the server to be retained. The idea is that in the future, it will just override `sort()` with `identity` (and not re-implement `receive` anymore), see https://github.com/Automattic/wp-calypso/pull/10635#issuecomment-272589711

To test:
Check that everything that uses a `QueryManager` still works as before, notably:
* CPTs
* Media
* Themes

(Ideally, unit tests have us covered 😄 )