### PR TITLE
Server: Use production react in the server bundle for prod

### DIFF
--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -44,6 +44,9 @@ function getExternals() {
 	externals[ 'devdocs/components-usage-stats.json' ] = 'commonjs devdocs/components-usage-stats.json';
 	// Exclude server/bundler/assets, since the files it requires don't exist until the bundler has run
 	externals[ 'bundler/assets' ] = 'commonjs bundler/assets';
+	// Map React to the minimized version
+	externals[ 'react-with-addons' ] = 'commonjs react/dist/react-with-addons.min';
+	externals.react = 'commonjs react/dist/react.min';
 
 	return externals;
 }

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -44,9 +44,12 @@ function getExternals() {
 	externals[ 'devdocs/components-usage-stats.json' ] = 'commonjs devdocs/components-usage-stats.json';
 	// Exclude server/bundler/assets, since the files it requires don't exist until the bundler has run
 	externals[ 'bundler/assets' ] = 'commonjs bundler/assets';
-	// Map React to the minimized version
-	externals[ 'react-with-addons' ] = 'commonjs react/dist/react-with-addons.min';
-	externals.react = 'commonjs react/dist/react.min';
+	// Map React and redux to the minimized version in production
+	if ( config( 'env' ) === 'production' ) {
+		externals[ 'react-with-addons' ] = 'commonjs react/dist/react-with-addons.min';
+		externals.react = 'commonjs react/dist/react.min';
+		externals.redux = 'commonjs redux/dist/redux.min';
+	}
 
 	return externals;
 }


### PR DESCRIPTION
See https://twitter.com/eldh/status/821257104694579200

Currently we're running the debug build of react in our server process. This should switch it to be the production build, which should cut down render times a fair bit.