### PR TITLE
State: Add reducer and selectors for Jetpack settings save status

### DIFF
--- a/client/state/jetpack/settings/reducer.js
+++ b/client/state/jetpack/settings/reducer.js
@@ -90,7 +90,31 @@ export const requests = createReducer( {}, {
 	[ JETPACK_SETTINGS_UPDATE_SUCCESS ]: createRequestsReducer( { updating: false } ),
 } );
 
+/**
+ * `Reducer` function which handles request/response actions
+ * concerning Jetpack settings save requests
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export const saveRequests = createReducer( {}, {
+	[ JETPACK_SETTINGS_UPDATE ]: ( state, { siteId } ) => ( {
+		...state,
+		[ siteId ]: { saving: true, status: 'pending', error: false }
+	} ),
+	[ JETPACK_SETTINGS_UPDATE_SUCCESS ]: ( state, { siteId } ) => ( {
+		...state,
+		[ siteId ]: { saving: false, status: 'success', error: false }
+	} ),
+	[ JETPACK_SETTINGS_UPDATE_FAILURE ]: ( state, { siteId, error } ) => ( {
+		...state,
+		[ siteId ]: { saving: false, status: 'error', error }
+	} )
+} );
+
 export const reducer = combineReducers( {
 	items,
-	requests
+	requests,
+	saveRequests
 } );

--- a/client/state/jetpack/settings/selectors.js
+++ b/client/state/jetpack/settings/selectors.js
@@ -51,3 +51,36 @@ export function getJetpackSettings( state, siteId ) {
 export function getJetpackSetting( state, siteId, setting ) {
 	return get( state.jetpack.settings.items, [ siteId, setting ], null );
 }
+
+/**
+ * Returns the status of the last Jetpack site settings save request
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {String}         The request status (peding, success or error)
+ */
+export function getJetpackSettingsSaveRequestStatus( state, siteId ) {
+	return get( state.jetpack.settings.saveRequests, [ siteId, 'status' ] );
+}
+
+/**
+ * Returns true fi the save Jetpack site settings requests is successful
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {Boolean}         Whether the requests is successful or not
+ */
+export function isJetpackSettingsSaveSuccessful( state, siteId ) {
+	return getJetpackSettingsSaveRequestStatus( state, siteId ) === 'success';
+}
+
+/**
+ * Returns the error returned by the last Jetpack site settings save request
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {String}         The request error
+ */
+export function getJetpackSettingsSaveError( state, siteId ) {
+	return get( state.jetpack.settings.saveRequests, [ siteId, 'error' ], false );
+}

--- a/client/state/jetpack/settings/test/selectors.js
+++ b/client/state/jetpack/settings/test/selectors.js
@@ -8,6 +8,9 @@ import {
 	isUpdatingJetpackSettings,
 	getJetpackSettings,
 	getJetpackSetting,
+	getJetpackSettingsSaveRequestStatus,
+	isJetpackSettingsSaveSuccessful,
+	getJetpackSettingsSaveError,
 } from '../selectors';
 
 import {
@@ -173,6 +176,162 @@ describe( 'selectors', () => {
 				setting = 'unexisting_setting';
 			const output = getJetpackSetting( stateIn, siteId, setting );
 			expect( output ).to.be.null;
+		} );
+	} );
+
+	describe( '#getJetpackSettingsSaveRequestStatus()', () => {
+		it( 'should return undefined if the site is not attached', () => {
+			const state = {
+				jetpack: {
+					settings: {
+						saveRequests: {
+							12345678: { saving: true, status: 'pending' }
+						}
+					}
+				}
+			};
+			const status = getJetpackSettingsSaveRequestStatus( state, 87654321 );
+
+			expect( status ).to.be.undefined;
+		} );
+
+		it( 'should return success if the save request status is success', () => {
+			const state = {
+				jetpack: {
+					settings: {
+						saveRequests: {
+							12345678: { saving: false, status: 'success' }
+						}
+					}
+				}
+			};
+			const status = getJetpackSettingsSaveRequestStatus( state, 12345678 );
+
+			expect( status ).to.eql( 'success' );
+		} );
+
+		it( 'should return error if the save request status is error', () => {
+			const state = {
+				jetpack: {
+					settings: {
+						saveRequests: {
+							12345678: { saving: false, status: 'error' }
+						}
+					}
+				}
+			};
+			const status = getJetpackSettingsSaveRequestStatus( state, 12345678 );
+
+			expect( status ).to.eql( 'error' );
+		} );
+
+		it( 'should return pending if the save request status is pending', () => {
+			const state = {
+				jetpack: {
+					settings: {
+						saveRequests: {
+							12345678: { saving: true, status: 'pending' }
+						}
+					}
+				}
+			};
+			const status = getJetpackSettingsSaveRequestStatus( state, 12345678 );
+
+			expect( status ).to.eql( 'pending' );
+		} );
+	} );
+
+	describe( 'isJetpackSettingsSaveSuccessful()', () => {
+		it( 'should return false if the site is not attached', () => {
+			const state = {
+				jetpack: {
+					settings: {
+						saveRequests: {
+							12345678: { saving: true, status: 'pending' }
+						}
+					}
+				}
+			};
+			const isSuccessful = isJetpackSettingsSaveSuccessful( state, 87654321 );
+
+			expect( isSuccessful ).to.be.false;
+		} );
+
+		it( 'should return true if the save request status is success', () => {
+			const state = {
+				jetpack: {
+					settings: {
+						saveRequests: {
+							12345678: { saving: false, status: 'success' }
+						}
+					}
+				}
+			};
+			const isSuccessful = isJetpackSettingsSaveSuccessful( state, 12345678 );
+
+			expect( isSuccessful ).to.be.true;
+		} );
+
+		it( 'should return false if the save request status is error', () => {
+			const state = {
+				jetpack: {
+					settings: {
+						saveRequests: {
+							12345678: { saving: false, status: 'error' }
+						}
+					}
+				}
+			};
+			const isSuccessful = isJetpackSettingsSaveSuccessful( state, 12345678 );
+
+			expect( isSuccessful ).to.be.false;
+		} );
+	} );
+
+	describe( 'getJetpackSettingsSaveError()', () => {
+		it( 'should return false if the site is not attached', () => {
+			const state = {
+				jetpack: {
+					settings: {
+						saveRequests: {
+							12345678: { saving: true, status: 'pending', error: false }
+						}
+					}
+				}
+			};
+			const error = getJetpackSettingsSaveError( state, 87654321 );
+
+			expect( error ).to.be.false;
+		} );
+
+		it( 'should return false if the save the last request has no error', () => {
+			const state = {
+				jetpack: {
+					settings: {
+						saveRequests: {
+							12345678: { saving: false, status: 'success', error: false }
+						}
+					}
+				}
+			};
+			const error = getJetpackSettingsSaveError( state, 12345678 );
+
+			expect( error ).to.be.false;
+		} );
+
+		it( 'should return the error if the save request status has an error', () => {
+			const state = {
+				jetpack: {
+					settings: {
+						saveRequests: {
+							12345678: { saving: false, status: 'error', error: 'my Error' }
+						}
+					}
+				}
+			};
+			const error = getJetpackSettingsSaveError( state, 12345678 );
+
+			expect( error ).to.eql( 'my Error' );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR introduces reducer and selectors for Jetpack settings save status, similar to the ones that have been already created for [site settings](https://github.com/Automattic/wp-calypso/tree/master/client/state/site-settings). The PR uses the existing Jetpack settings functionality to create a `saveRequests` Redux subtree under `state.jetpack.settings`, and introduces 3 new selectors that correspond to the ones in `site-settings`:

* `getJetpackSettingsSaveRequestStatus`
* `isJetpackSettingsSaveSuccessful`
* `getJetpackSettingsSaveError`

These will be necessary to create a complete settings form wrapper HoC that will allow us to manage both Site Settings and Jetpack Settings, as discussed here: https://github.com/Automattic/wp-calypso/pull/10679#pullrequestreview-16983330.

To test:

* Checkout this branch
* Verify all Jetpack settings tests pass: `npm run test-client client/state/jetpack/settings/`

/cc
* @ryelle as this is essential for #10679
* @oskosk as this is essential for reducing boilerplate in the new JPS cards
* @youknowriad as he worked on creating the `wrapSettingsForm` HoC