### PR TITLE
Stats: Use redux subtree for stats video plays

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -344,8 +344,6 @@ module.exports = {
 				siteID: siteId, statType: 'statsClicks', period: activeFilter.period, date: endDate, domain: siteDomain } );
 			const authorsList = new StatsList( {
 				siteID: siteId, statType: 'statsTopAuthors', period: activeFilter.period, date: endDate, domain: siteDomain } );
-			const videoPlaysList = new StatsList( {
-				siteID: siteId, statType: 'statsVideoPlays', period: activeFilter.period, date: endDate, domain: siteDomain } );
 			const searchTermsList = new StatsList( {
 				siteID: siteId, statType: 'statsSearchTerms', period: activeFilter.period, date: endDate, domain: siteDomain } );
 
@@ -362,7 +360,6 @@ module.exports = {
 				postsPagesList,
 				clicksList,
 				authorsList,
-				videoPlaysList,
 				siteId,
 				period,
 				chartPeriod,
@@ -494,8 +491,7 @@ module.exports = {
 					break;
 
 				case 'videoplays':
-					summaryList = new StatsList( { statType: 'statsVideoPlays', siteID: siteId,
-						period: activeFilter.period, date: endDate, max: 0, domain: siteDomain } );
+					summaryList = fakeStatsList;
 					break;
 
 				case 'videodetails':

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -116,14 +116,17 @@ module.exports = React.createClass( {
 		if ( site ) {
 			// Video plays, and tags and categories are not supported in JetPack Stats
 			if ( ! site.jetpack ) {
-				videoList = <StatsModule
-					path={ 'videoplays' }
-					moduleStrings={ moduleStrings.videoplays }
-					site={ site }
-					dataList={ this.props.videoPlaysList }
-					period={ this.props.period }
-					date={ queryDate }
-					beforeNavigate={ this.updateScrollPosition } />;
+				videoList = (
+					<StatsConnectedModule
+						path="videoplays"
+						moduleStrings={ moduleStrings.videoplays }
+						period={ this.props.period }
+						date={ queryDate }
+						query={ query }
+						statType="statsVideoPlays"
+						showSummaryLink
+					/>
+				);
 			}
 			if ( config.isEnabled( 'manage/stats/podcasts' ) && site.options.podcasting_archive ) {
 				podcastList = <StatsModule

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -17,7 +17,6 @@ import StatsModule from '../stats-module';
 import StatsConnectedModule from '../stats-module/connected-list';
 import statsStringsFactory from '../stats-strings';
 import Countries from '../stats-countries';
-import StatsConnectedModule from '../stats-module/connected-list';
 import StatsVideoSummary from '../stats-video-summary';
 import VideoPlayDetails from '../stats-video-details';
 import Main from 'components/main';

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
 import observe from 'lib/mixins/data-observe';
 import HeaderCake from 'components/header-cake';
 import StatsModule from '../stats-module';
+import StatsConnectedModule from '../stats-module/connected-list';
 import statsStringsFactory from '../stats-strings';
 import Countries from '../stats-countries';
 import StatsConnectedModule from '../stats-module/connected-list';
@@ -147,15 +148,14 @@ const StatsSummary = React.createClass( {
 
 			case 'videoplays':
 				title = translate( 'Videos' );
-				summaryView = <StatsModule
+				summaryView = <StatsConnectedModule
 					key="videoplays-summary"
-					path={ 'videoplays' }
+					path="videoplays"
 					moduleStrings={ StatsStrings.videoplays }
-					site={ site }
-					dataList={ this.props.summaryList }
 					period={ this.props.period }
-					followList={ this.props.followList }
-					summary={ true } />;
+					query={ query }
+					statType="statsVideoPlays"
+					summary />;
 				break;
 
 			case 'podcastdownloads':

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -13,6 +13,7 @@ import {
 	normalizers,
 	buildExportArray,
 } from './utils';
+import { getSite } from 'state/sites/selectors';
 
 /**
  * Returns true if currently requesting stats for the statType and query combo, or false
@@ -157,9 +158,9 @@ export function getSiteStatsPostsCountByDay( state, siteId, query, date ) {
 export const getSiteStatsNormalizedData = createSelector(
 	( state, siteId, statType, query ) => {
 		const data = getSiteStatsForQuery( state, siteId, statType, query );
-
 		if ( 'function' === typeof normalizers[ statType ] ) {
-			return normalizers[ statType ].call( this, data, query, siteId );
+			const site = getSite( state, siteId );
+			return normalizers[ statType ].call( this, data, query, siteId, site );
 		}
 
 		return data;

--- a/client/state/stats/lists/test/selectors.js
+++ b/client/state/stats/lists/test/selectors.js
@@ -396,6 +396,9 @@ describe( 'selectors', () => {
 					lists: {
 						items: {}
 					}
+				},
+				sites: {
+					items: {}
 				}
 			}, 2916284, 'stats', {} );
 
@@ -416,6 +419,9 @@ describe( 'selectors', () => {
 							}
 						}
 					}
+				},
+				sites: {
+					items: {}
 				}
 			}, 2916284, 'notReallyStats', {} );
 
@@ -444,6 +450,9 @@ describe( 'selectors', () => {
 							}
 						}
 					}
+				},
+				sites: {
+					items: {}
 				}
 			}, 2916284, 'stats', {} );
 
@@ -464,6 +473,9 @@ describe( 'selectors', () => {
 					lists: {
 						items: {}
 					}
+				},
+				sites: {
+					items: {}
 				}
 			}, 2916284, 'stats', {} );
 
@@ -502,6 +514,9 @@ describe( 'selectors', () => {
 							}
 						}
 					}
+				},
+				sites: {
+					items: {}
 				}
 			}, 2916284, 'statsCountryViews', {
 				date: '2015-12-25',

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -631,6 +631,61 @@ describe( 'utils', () => {
 			} );
 		} );
 
+		describe( 'statsVideoPlays()', () => {
+			it( 'should return an empty array if not data is passed', () => {
+				const parsedData = normalizers.statsVideoPlays();
+
+				expect( parsedData ).to.eql( [] );
+			} );
+
+			it( 'should return an empty array if query.period is null', () => {
+				const parsedData = normalizers.statsVideoPlays( {}, { date: '2016-12-25' } );
+
+				expect( parsedData ).to.eql( [] );
+			} );
+
+			it( 'should return an empty array if query.date is null', () => {
+				const parsedData = normalizers.statsVideoPlays( {}, { period: 'day' } );
+
+				expect( parsedData ).to.eql( [] );
+			} );
+
+			it( 'should properly parse day period response', () => {
+				const parsedData = normalizers.statsVideoPlays( {
+					date: '2017-01-12',
+					days: {
+						'2017-01-12': {
+							plays: [
+								{
+									plays: 32,
+									post_id: 111111111,
+									title: 'Press This!',
+									url: 'http://en.blog.wordpress.com/wp-admin/media.php?action=edit&attachment_id=111111111'
+								}
+							]
+						}
+					}
+				}, {
+					period: 'day',
+					date: '2017-01-12'
+				}, 10, {
+					slug: 'en.blog.wordpress.com'
+				} );
+
+				expect( parsedData ).to.eql( [
+					{
+						actions: [ {
+							data: 'http://en.blog.wordpress.com/wp-admin/media.php?action=edit&attachment_id=111111111',
+							type: 'link'
+						} ],
+						label: 'Press This!',
+						page: '/stats/day/videodetails/en.blog.wordpress.com?post=111111111',
+						value: 32
+					}
+				] );
+			} );
+		} );
+
 		describe( 'statsVideo()', () => {
 			it( 'should return an empty array if not data is passed', () => {
 				const parsedData = normalizers.statsVideo();

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -222,6 +222,36 @@ export const normalizers = {
 	},
 
 	/**
+	 * Returns a normalized statsVideoPlays array, ready for use in stats-module
+	 *
+	 * @param  {Object} data    Stats data
+	 * @param  {Object} query   Stats query
+	 * @param  {Int}    siteId  Site ID
+	 * @param  {Obejct} site    Site object
+	 * @return {Array}          Normalized stats data
+	 */
+	statsVideoPlays( data, query = {}, siteId, site ) {
+		if ( ! data || ! query.period || ! query.date ) {
+			return [];
+		}
+		const { startOf } = rangeOfPeriod( query.period, query.date );
+		const videoPlaysData = get( data, [ 'days', startOf, 'plays' ], [] );
+
+		return videoPlaysData.map( ( item ) => {
+			const detailPage = site ? `/stats/${ query.period }/videodetails/${ site.slug }?post=${ item.post_id }` : null;
+			return {
+				label: item.title,
+				page: detailPage,
+				value: item.plays,
+				actions: [ {
+					type: 'link',
+					data: item.url
+				} ]
+			};
+		} );
+	},
+
+	/**
 	 * Returns a normalized statsVideo array, ready for use in stats-module
 	 *
 	 * @param  {Object} payload Stats response payload


### PR DESCRIPTION
Closes #10627 

In this PR, I moved the parser logic for StatsVideoPlays from StatsList into the redux stats subtree.
I also updated the video plays stats component to use the StatsConnectedModule Component.

**Notes**

- In order to generate the action link, the `normalizer` needs the site slug, I opted for providing the whole site object for now thinking other "normalizers" could make use of those.

**Testing instructions**

 - Navigate to the stats insights page /stats/day/$site
 - The Video Plays panel should work properly (same as master)
 - Click on the header of the panel to navigate to the summary page
 - The video stats stats should show up (same as master)