### PR TITLE
Site Settings: Make wrapSettingsForm compatible with Jetpack Settings

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -16,6 +16,7 @@ import {
 	isRequestingSiteSettings,
 	isSavingSiteSettings,
 	isSiteSettingsSaveSuccessful,
+	getSiteSettingsSaveError,
 	getSiteSettings
 } from 'state/site-settings/selectors';
 import {
@@ -65,13 +66,11 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 					nextProps.clearDirtyFields();
 					nextProps.markSaved();
 				} else {
-					let text;
-					switch ( nextProps.saveRequestError.error ) {
+					let text = nextProps.translate( 'There was a problem saving your changes. Please try again.' );
+					switch ( nextProps.siteSettingsSaveError ) {
 						case 'invalid_ip':
 							text = nextProps.translate( 'One of your IP Addresses was invalid. Please try again.' );
 							break;
-						default:
-							text = nextProps.translate( 'There was a problem saving your changes. Please try again.' );
 					}
 					nextProps.errorNotice( text, { id: 'site-settings-save' } );
 				}
@@ -161,6 +160,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			let isSavingSettings = isSavingSiteSettings( state, siteId );
 			let isSaveRequestSuccessful = isSiteSettingsSaveSuccessful( state, siteId );
 			let settings = getSiteSettings( state, siteId );
+			const siteSettingsSaveError = getSiteSettingsSaveError( state, siteId );
 			const settingsFields = {
 				site: keys( settings ),
 			};
@@ -179,6 +179,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				isRequestingSettings,
 				isSavingSettings,
 				isSaveRequestSuccessful,
+				siteSettingsSaveError,
 				settings,
 				settingsFields,
 				siteId,

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -156,10 +156,10 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 	const connectComponent = connect(
 		state => {
 			const siteId = getSelectedSiteId( state );
-			let isRequestingSettings = isRequestingSiteSettings( state, siteId );
 			let isSavingSettings = isSavingSiteSettings( state, siteId );
 			let isSaveRequestSuccessful = isSiteSettingsSaveSuccessful( state, siteId );
 			let settings = getSiteSettings( state, siteId );
+			let isRequestingSettings = isRequestingSiteSettings( state, siteId ) && ! settings;
 			const siteSettingsSaveError = getSiteSettingsSaveError( state, siteId );
 			const settingsFields = {
 				site: keys( settings ),
@@ -168,11 +168,11 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			const isJetpack = isJetpackSite( state, siteId );
 			if ( isJetpack ) {
 				const jetpackSettings = getJetpackSettings( state, siteId );
-				isRequestingSettings = isRequestingSettings || isRequestingJetpackSettings( state, siteId );
 				isSavingSettings = isSavingSettings || isUpdatingJetpackSettings( state, siteId );
 				isSaveRequestSuccessful = isSaveRequestSuccessful && isJetpackSettingsSaveSuccessful( state, siteId );
 				settings = { ...settings, ...jetpackSettings };
 				settingsFields.jetpack = keys( jetpackSettings );
+				isRequestingSettings = isRequestingSettings || ( isRequestingJetpackSettings( state, siteId ) && ! jetpackSettings );
 			}
 
 			return {

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -88,11 +88,11 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 		};
 
 		submitForm = () => {
-			const { fields, settingsFields, site, isJetpack } = this.props;
+			const { fields, settingsFields, site, jetpackSettingsUISupported } = this.props;
 			this.props.removeNotice( 'site-settings-save' );
 
 			this.props.saveSiteSettings( site.ID, pick( fields, settingsFields.site ) );
-			if ( isJetpack ) {
+			if ( jetpackSettingsUISupported ) {
 				this.props.updateSettings( site.ID, pick( fields, settingsFields.jetpack ) );
 			}
 		};
@@ -144,7 +144,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				<div>
 					<QuerySiteSettings siteId={ this.props.siteId } />
 					{
-						this.props.isJetpack &&
+						this.props.jetpackSettingsUISupported &&
 						<QueryJetpackSettings siteId={ this.props.siteId } />
 					}
 					<SettingsForm { ...this.props } { ...utils } />
@@ -184,7 +184,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				settings,
 				settingsFields,
 				siteId,
-				isJetpack
+				jetpackSettingsUISupported
 			};
 		},
 		dispatch => {

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -30,7 +30,7 @@ import { saveSiteSettings } from 'state/site-settings/actions';
 import { updateSettings } from 'state/jetpack/settings/actions';
 import { removeNotice, successNotice, errorNotice } from 'state/notices/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
+import { isJetpackSite, siteSupportsJetpackSettingsUI } from 'state/sites/selectors';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import QueryJetpackSettings from 'components/data/query-jetpack-settings';
 
@@ -166,7 +166,8 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			};
 
 			const isJetpack = isJetpackSite( state, siteId );
-			if ( isJetpack ) {
+			const jetpackSettingsUISupported = isJetpack && siteSupportsJetpackSettingsUI( state, siteId );
+			if ( jetpackSettingsUISupported ) {
 				const jetpackSettings = getJetpackSettings( state, siteId );
 				isSavingSettings = isSavingSettings || isUpdatingJetpackSettings( state, siteId );
 				isSaveRequestSuccessful = isSaveRequestSuccessful && isJetpackSettingsSaveSuccessful( state, siteId );


### PR DESCRIPTION
This PR attempts to make `wrapSettingsForm` compatible with Jetpack Settings. 

So, this PR addresses my thoughts here: https://github.com/Automattic/wp-calypso/pull/10679#pullrequestreview-16983330, specifically:

* We use `<QueryJetpackSettings />` to query all Jetpack settings.
* We use the `getJetpackSettings` selector to obtain the Jetpack settings.
* We use `updateSettings` to save the Jetpack settings.
* Take into consideration Jetpack settings being currently requested by using `isRequestingJetpackSettings`
* Take into consideration Jetpack settings currently being saved by using `isUpdatingJetpackSettings`
* Take into consideration whether Jetpack settings have been saved correctly by using `isJetpackSettingsSaveSuccessful`
* Selectors/reducer are introduced in a separate PR - #10694 

I have the following concerns that haven't been addressed in this PR:
* As stated in https://github.com/Automattic/wp-calypso/pull/10679#pullrequestreview-16983330 we will probably need to limit the wrapper to use just one type of settings, not both.
* Currently, we'll simply save all Jetpack settings that belong to this settings form. This is fine, however if a module setting corresponds to a module that's disabled, saving Jetpack settings will always fail.

@youknowriad @ryelle @oskosk I'd love to see some opinions on this approach, and how we can make it better.