### PR TITLE
Autoconfig: Check for an error before using `data`

### DIFF
--- a/client/state/plugins/premium/actions.js
+++ b/client/state/plugins/premium/actions.js
@@ -213,7 +213,7 @@ function configure( site, plugin, dispatch ) {
 
 	const saveOption = () => {
 		return site.setOption( { option_name: option, option_value: optionValue }, ( error, data ) => {
-			if ( ( 'vaultpress' === plugin.slug ) && versionCompare( plugin.version, '1.8.3', '>' ) ) {
+			if ( ( ! error ) && ( 'vaultpress' === plugin.slug ) && versionCompare( plugin.version, '1.8.3', '>' ) ) {
 				const response = JSON.parse( data.option_value );
 				if ( 'response' === response.action && 'broken' === response.status ) {
 					error = new Error( response.error );


### PR DESCRIPTION
This prevents a JS error about "Cannot read property `option_value` of null", which happens when we try to set the option of a deactivated plugin.

See p7rd6c-zv-p2