### PR TITLE
Analytics: Create an abstration for sending events to both GA and Tracks

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -125,6 +125,11 @@ var analytics = {
 		}
 	},
 
+	recordEvent: function( tracksEventName, tracksEventProperties, category, action, label, value ) {
+		analytics.tracks.recordEvent( tracksEventName, tracksEventProperties );
+		analytics.ga.recordEvent( category, action, label, value );
+	},
+
 	tracks: {
 		recordEvent: function( eventName, eventProperties ) {
 			var superProperties;


### PR DESCRIPTION
Currently there is confusion about whether or not we send events to Tracks and Google Analytics - this creates a standard way to create events so that we can send them to both.

This also makes it easier in the future to remove unwanted calls to Google Analytics, or add calls to other tracking services.