### PR TITLE
Guided Tours: hide “Editor Insert Menu” tour behind a dev-only feature flag

### DIFF
--- a/client/layout/guided-tours/tours/editor-insert-menu-tour.js
+++ b/client/layout/guided-tours/tours/editor-insert-menu-tour.js
@@ -44,6 +44,7 @@ export const EditorInsertMenuTour = makeTour(
 		path={ [ '/post/', '/page/' ] }
 		version="20161215"
 		when={ and(
+			isEnabled( 'guided-tours/editor-insert-menu' ),
 			isEnabled( 'post-editor/insert-menu' ),
 			hasUserRegisteredBefore( new Date( '2016-12-15' ) ),
 			isDesktop,

--- a/config/development.json
+++ b/config/development.json
@@ -45,6 +45,7 @@
 		"guided-tours/main": true,
 		"guided-tours/tutorial-site-preview": false,
 		"guided-tours/design-showcase-welcome": true,
+		"guided-tours/editor-insert-menu": true,
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,
 		"guided-tours/themes": false,


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/10568

This PR removes the Editor Insert Menu guided tour from anywhere except development as it's not reliable enough, and it keeps reappearing when it's not supposed to anymore.

I've decided to keep it in `development` mostly because it's behaviour is more consistent there, and to have a chance of finding out what's wrong with it.