### PR TITLE
Plans: tweak Business-discount info popover

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -91,7 +91,7 @@ class PlanFeaturesHeader extends Component {
 					{ isDiscounted && ! isPlaceholder &&
 						<InfoPopover
 							className="plan-features__header-tip-info"
-							position={ isMobile() ? 'top' : 'right' }>
+							position={ isMobile() ? 'top' : 'left bottom' }>
 							{ translate( 'Discount for first year' ) }
 						</InfoPopover>
 					}

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -277,10 +277,17 @@ $plan-features-sidebar-width: 272px;
 	}
 }
 
-.plan-features__header-tip-info svg {
-	padding: 0 3px;
-	position: absolute;
-	transform: translateY( -33% );
+.info-popover.plan-features__header-tip-info {
+	position: relative;
+	top: 4px;
+	left: 3px;
+	margin-top: -10px;
+	margin-bottom: -10px;
+	display: inline-block;
+}
+
+.popover.plan-features__header-tip-info .popover__inner {
+	white-space: nowrap;
 }
 
 .plan-features__price {


### PR DESCRIPTION
This PR fixes a positioning issue of the Business discount InfoPopover. It changes where it's anchored depending on if it's the first time that the Popover is opened or if it's the second and subsequent opening.

<img src="https://cloud.githubusercontent.com/assets/77539/22037416/cf4312e0-dcd5-11e6-9a0c-3b8623002658.gif" width="300px" />

<img src="https://cloud.githubusercontent.com/assets/77539/22036682/194da63c-dcd3-11e6-9835-79a6c896e788.gif" width="300px" />

Definitely, it has an erratic behavior.

Also, I've changed the default position to `left bottom` instead of `right.

The following is how it looks on prod:
<img src="https://cloud.githubusercontent.com/assets/77539/22035368/7ce791a8-dcce-11e6-8cd1-11b6ca5d96db.png" width="300px" />

... and this is how it looks with the patch:
<img src="https://cloud.githubusercontent.com/assets/77539/22034738/f1d5f48a-dccb-11e6-9146-97381c8dd4bc.png" width="300px" />

I've tweaked some CSS values and also I've set `button left`. We can change this position if we want.

The following are screenshots taken by different browsers and viewport sizes.

<img src="https://cloud.githubusercontent.com/assets/77539/22034745/f6476e36-dccb-11e6-9837-d82a2520ec03.png" width="500px" />

<img src="https://cloud.githubusercontent.com/assets/77539/22034754/fd6f0e8a-dccb-11e6-9a79-8ebb3a441259.png" width="500px" />

<img src="https://cloud.githubusercontent.com/assets/77539/22034761/057a4ec8-dccc-11e6-9718-10c3d3042e82.png" width="500px" />

### FF
<img src="https://cloud.githubusercontent.com/assets/77539/22035057/55db7c2e-dccd-11e6-9fee-db095e841f2d.png" width="300px" />

### Safari
<img src="https://cloud.githubusercontent.com/assets/77539/22035140/9573c0a8-dccd-11e6-96ea-47d07c22893b.png" width="300px" />


