### PR TITLE
QueryManager: Rename `sort` to `compare`, introduce intermediary  `sort`

### DIFF
--- a/client/lib/query-manager/README.md
+++ b/client/lib/query-manager/README.md
@@ -42,10 +42,12 @@ Currently, the following implementations exist:
 
 ## Extending
 
-Depending on the level of customization you need, you'll likely only need to implement the `matches` and `compare` methods.
+Depending on the level of customization you need, you'll likely only need to implement the `matches` and `compare` (or possibly `sort`) methods.
 
 - `matches( query: object, item: object )` should return true if the passed item should be included in the query set
-- `compare( itemA: object, itemB: object )` is a sort comparator function, returning -1 to indicate "A before B", 1 to indicate "A after B", or 0 to indicate equality ([see `Array.prototype.sort`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort))
+- `compare( itemA: object, itemB: object )` is a sort comparator function, returning -1 to indicate "A before B", 1 to indicate "A after B", or 0 to indicate equality ([see `Array.prototype.sort`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)). Note that the latter doesn't work in all browsers and environments!
+- `sort( keys: array, items: array, query: object )` is a sorting function that sorts `keys` by comparing their corresponding `items`. It will normally just use `compare` for the comparison. Its main purpose is to allow for a `QueryManager` to leave
+the order of keys unchanged (and rely on the REST API for ordering) by overriding it with a function that just returns the untouched `keys` argument. This wouldn't be feasible by overloading `compare`, since `Array.prototype.sort` isn't guaranteed to be a stable sort; in some environments ([such as Chrome and node!](https://bugs.chromium.org/p/v8/issues/detail?id=90)), it will change the order of the array's items even if the compare function always returns zero.
 
 Sometimes you may need to make further customizations. Some examples include:
 

--- a/client/lib/query-manager/README.md
+++ b/client/lib/query-manager/README.md
@@ -42,10 +42,10 @@ Currently, the following implementations exist:
 
 ## Extending
 
-Depending on the level of customization you need, you'll likely only need to implement the `matches` and `sort` methods.
+Depending on the level of customization you need, you'll likely only need to implement the `matches` and `compare` methods.
 
 - `matches( query: object, item: object )` should return true if the passed item should be included in the query set
-- `sort( itemA: object, itemB: object )` is a sort comparator function, returning -1 to indicate "A before B", 1 to indicate "A after B", or 0 to indicate equality ([see `Array.prototype.sort`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort))
+- `compare( itemA: object, itemB: object )` is a sort comparator function, returning -1 to indicate "A before B", 1 to indicate "A after B", or 0 to indicate equality ([see `Array.prototype.sort`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort))
 
 Sometimes you may need to make further customizations. Some examples include:
 

--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -95,7 +95,7 @@ export default class QueryManager {
 	 * @return {Number}       0 if equal, less than 0 if itemA is first,
 	 *                        greater than 0 if itemB is first.
 	 */
-	sort( query, itemA, itemB ) {
+	compare( query, itemA, itemB ) {
 		if ( itemA === itemB ) {
 			return 0;
 		}
@@ -352,7 +352,7 @@ export default class QueryManager {
 							return 0;
 						}
 
-						return this.sort( query, nextItems[ keyA ], nextItems[ keyB ] );
+						return this.compare( query, nextItems[ keyA ], nextItems[ keyB ] );
 					} );
 				}
 			} );

--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -104,6 +104,30 @@ export default class QueryManager {
 	}
 
 	/**
+	 * A sorting function that defines the sort order of items under
+	 * consideration of the specified query. This mutates the keys argument and
+	 * doesn't have a return value (because that's how Array.prototype.sort works, see
+	 * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort ).
+	 *
+	 * @param  {Array}  keys  Keys to be sorted
+	 * @param  {Array}  items Items by which to sort
+	 * @param  {Object} query Query object
+	 */
+	sort( keys, items, query ) {
+		keys.sort( ( keyA, keyB ) => {
+			if ( ! items[ keyA ] || ! items[ keyB ] ) {
+				// One of the items has yet to be removed from the
+				// set at this point in iteration, so don't bother
+				// trying to sort.
+				// This is just an optimization, so implementers of an extending class's `sort`
+				// method aren't required to implement this check.
+				return 0;
+			}
+			return this.compare( query, items[ keyA ], items[ keyB ] );
+		} );
+	}
+
+	/**
 	 * Returns a single item by key.
 	 *
 	 * @param  {String} itemKey Item key
@@ -344,16 +368,7 @@ export default class QueryManager {
 					memo[ queryKey ].itemKeys = get( memo, [ queryKey, 'itemKeys' ], [] ).concat( receivedItemKey );
 
 					// Re-sort the set
-					memo[ queryKey ].itemKeys.sort( ( keyA, keyB ) => {
-						if ( ! nextItems[ keyA ] || ! nextItems[ keyB ] ) {
-							// One of the items has yet to be removed from the
-							// set at this point in iteration, so don't bother
-							// trying to sort.
-							return 0;
-						}
-
-						return this.compare( query, nextItems[ keyA ], nextItems[ keyB ] );
-					} );
+					this.sort( memo[ queryKey ].itemKeys, nextItems, query );
 				}
 			} );
 

--- a/client/lib/query-manager/media/index.js
+++ b/client/lib/query-manager/media/index.js
@@ -84,7 +84,7 @@ export default class MediaQueryManager extends PaginatedQueryManager {
 	 * @return {Number}        0 if equal, less than 0 if mediaA is first,
 	 *                         greater than 0 if mediaB is first.
 	 */
-	sort( query, mediaA, mediaB ) {
+	compare( query, mediaA, mediaB ) {
 		let order;
 
 		switch ( query.order_by ) {

--- a/client/lib/query-manager/media/test/index.js
+++ b/client/lib/query-manager/media/test/index.js
@@ -234,13 +234,13 @@ describe( 'MediaQueryManager', () => {
 		} );
 	} );
 
-	describe( '#sort()', () => {
+	describe( '#compare()', () => {
 		context( 'query.order', () => {
 			it( 'should sort descending by default', () => {
 				const sorted = [
 					{ ID: 200 },
 					{ ID: 400 }
-				].sort( manager.sort.bind( manager, {
+				].sort( manager.compare.bind( manager, {
 					order_by: 'ID'
 				} ) );
 
@@ -254,7 +254,7 @@ describe( 'MediaQueryManager', () => {
 				const sorted = [
 					{ ID: 400 },
 					{ ID: 200 }
-				].sort( manager.sort.bind( manager, {
+				].sort( manager.compare.bind( manager, {
 					order_by: 'ID',
 					order: 'ASC'
 				} ) );
@@ -283,7 +283,7 @@ describe( 'MediaQueryManager', () => {
 					const sorted = [
 						olderMedia,
 						newerMedia
-					].sort( manager.sort.bind( manager, {} ) );
+					].sort( manager.compare.bind( manager, {} ) );
 
 					expect( sorted ).to.eql( [
 						newerMedia,
@@ -308,7 +308,7 @@ describe( 'MediaQueryManager', () => {
 					const sorted = [
 						aaMedia,
 						abMedia
-					].sort( manager.sort.bind( manager, {
+					].sort( manager.compare.bind( manager, {
 						order_by: 'title'
 					} ) );
 
@@ -324,7 +324,7 @@ describe( 'MediaQueryManager', () => {
 					const sorted = [
 						{ ID: 200 },
 						{ ID: 400 }
-					].sort( manager.sort.bind( manager, {
+					].sort( manager.compare.bind( manager, {
 						order_by: 'ID'
 					} ) );
 

--- a/client/lib/query-manager/paginated/test/index.js
+++ b/client/lib/query-manager/paginated/test/index.js
@@ -22,7 +22,7 @@ describe( 'PaginatedQueryManager', () => {
 
 	useSandbox( ( _sandbox ) => {
 		sandbox = _sandbox;
-		sandbox.stub( PaginatedQueryManager.prototype, 'sort', ( query, a, b ) => a.ID - b.ID );
+		sandbox.stub( PaginatedQueryManager.prototype, 'compare', ( query, a, b ) => a.ID - b.ID );
 	} );
 
 	beforeEach( () => {

--- a/client/lib/query-manager/post/index.js
+++ b/client/lib/query-manager/post/index.js
@@ -114,7 +114,7 @@ export default class PostQueryManager extends PaginatedQueryManager {
 	 * @return {Number}       0 if equal, less than 0 if postA is first,
 	 *                        greater than 0 if postB is first.
 	 */
-	sort( query, postA, postB ) {
+	compare( query, postA, postB ) {
 		let order;
 
 		switch ( query.order_by ) {

--- a/client/lib/query-manager/post/test/index.js
+++ b/client/lib/query-manager/post/test/index.js
@@ -622,13 +622,13 @@ describe( 'PostQueryManager', () => {
 		} );
 	} );
 
-	describe( '#sort()', () => {
+	describe( '#compare()', () => {
 		context( 'query.order', () => {
 			it( 'should sort descending by default', () => {
 				const sorted = [
 					{ ID: 200 },
 					{ ID: 400 }
-				].sort( manager.sort.bind( manager, {
+				].sort( manager.compare.bind( manager, {
 					order_by: 'ID'
 				} ) );
 
@@ -642,7 +642,7 @@ describe( 'PostQueryManager', () => {
 				const sorted = [
 					{ ID: 200 },
 					{ ID: 400 }
-				].sort( manager.sort.bind( manager, {
+				].sort( manager.compare.bind( manager, {
 					order_by: 'ID',
 					order: 'ASC'
 				} ) );
@@ -669,7 +669,7 @@ describe( 'PostQueryManager', () => {
 					const sorted = [
 						olderPost,
 						newerPost
-					].sort( manager.sort.bind( manager, {} ) );
+					].sort( manager.compare.bind( manager, {} ) );
 
 					expect( sorted ).to.eql( [
 						newerPost,
@@ -692,7 +692,7 @@ describe( 'PostQueryManager', () => {
 					const sorted = [
 						olderPost,
 						newerPost
-					].sort( manager.sort.bind( manager, {
+					].sort( manager.compare.bind( manager, {
 						order_by: 'modified'
 					} ) );
 
@@ -717,7 +717,7 @@ describe( 'PostQueryManager', () => {
 					const sorted = [
 						aPost,
 						zPost
-					].sort( manager.sort.bind( manager, {
+					].sort( manager.compare.bind( manager, {
 						order_by: 'title'
 					} ) );
 
@@ -746,7 +746,7 @@ describe( 'PostQueryManager', () => {
 					const sorted = [
 						unpopularPost,
 						popularPost
-					].sort( manager.sort.bind( manager, {
+					].sort( manager.compare.bind( manager, {
 						order_by: 'comment_count'
 					} ) );
 
@@ -762,7 +762,7 @@ describe( 'PostQueryManager', () => {
 					const sorted = [
 						{ ID: 200 },
 						{ ID: 400 }
-					].sort( manager.sort.bind( manager, {
+					].sort( manager.compare.bind( manager, {
 						order_by: 'ID'
 					} ) );
 

--- a/client/lib/query-manager/term/index.js
+++ b/client/lib/query-manager/term/index.js
@@ -43,7 +43,7 @@ export default class TermQueryManager extends PaginatedQueryManager {
 	 * @return {Number}       0 if equal, less than 0 if termA is first,
 	 *                        greater than 0 if termB is first.
 	 */
-	sort( query, termA, termB ) {
+	compare( query, termA, termB ) {
 		let order;
 
 		switch ( query.order_by ) {

--- a/client/lib/query-manager/term/test/index.js
+++ b/client/lib/query-manager/term/test/index.js
@@ -69,13 +69,13 @@ describe( 'TermQueryManager', () => {
 		} );
 	} );
 
-	describe( '#sort()', () => {
+	describe( '#compare()', () => {
 		context( 'query.order', () => {
 			it( 'should sort ascending by default', () => {
 				const sorted = [
 					{ name: 'Food' },
 					{ name: 'Cars' }
-				].sort( manager.sort.bind( manager, {
+				].sort( manager.compare.bind( manager, {
 					order_by: 'name'
 				} ) );
 
@@ -89,7 +89,7 @@ describe( 'TermQueryManager', () => {
 				const sorted = [
 					{ name: 'Food' },
 					{ name: 'Cars' }
-				].sort( manager.sort.bind( manager, {
+				].sort( manager.compare.bind( manager, {
 					order_by: 'name',
 					order: 'DESC'
 				} ) );
@@ -107,7 +107,7 @@ describe( 'TermQueryManager', () => {
 					const sorted = [
 						{ name: 'Food' },
 						{ name: 'Cars' }
-					].sort( manager.sort.bind( manager, {
+					].sort( manager.compare.bind( manager, {
 						order_by: 'name'
 					} ) );
 
@@ -128,7 +128,7 @@ describe( 'TermQueryManager', () => {
 					const sorted = [
 						DEFAULT_TERM,
 						unusedTerm
-					].sort( manager.sort.bind( manager, {
+					].sort( manager.compare.bind( manager, {
 						order_by: 'count'
 					} ) );
 

--- a/client/lib/query-manager/test/index.js
+++ b/client/lib/query-manager/test/index.js
@@ -82,17 +82,17 @@ describe( 'QueryManager', () => {
 		} );
 	} );
 
-	describe( '#sort()', () => {
+	describe( '#compare()', () => {
 		it( 'should return 0 for equal items', () => {
-			expect( manager.sort( {}, 40, 40 ) ).to.equal( 0 );
+			expect( manager.compare( {}, 40, 40 ) ).to.equal( 0 );
 		} );
 
 		it( 'should return a number less than zero if the first argument is larger', () => {
-			expect( manager.sort( {}, 50, 40 ) ).to.be.lt( 0 );
+			expect( manager.compare( {}, 50, 40 ) ).to.be.lt( 0 );
 		} );
 
 		it( 'should return a number greater than zero if the first argument is smaller', () => {
-			expect( manager.sort( {}, 30, 40 ) ).to.be.gt( 0 );
+			expect( manager.compare( {}, 30, 40 ) ).to.be.gt( 0 );
 		} );
 	} );
 
@@ -366,9 +366,9 @@ describe( 'QueryManager', () => {
 			expect( manager.getItems( {} ) ).to.eql( [ { ID: 144 } ] );
 		} );
 
-		it( 'should sort items appended to query set', () => {
+		it( 'should compare items appended to query set', () => {
 			manager = manager.receive( [ { ID: 140 }, { ID: 160 } ], { query: {} } );
-			sandbox.stub( manager, 'sort', ( query, a, b ) => a.ID - b.ID );
+			sandbox.stub( manager, 'compare', ( query, a, b ) => a.ID - b.ID );
 			manager = manager.receive( { ID: 150 } );
 
 			expect( manager.getItems( {} ) ).to.eql( [ { ID: 140 }, { ID: 150 }, { ID: 160 } ] );

--- a/client/lib/query-manager/theme/index.js
+++ b/client/lib/query-manager/theme/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { cloneDeep, get, isEqual, keyBy, range } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import PaginatedQueryManager from '../paginated';
@@ -14,114 +9,18 @@ import { DEFAULT_THEME_QUERY } from './constants';
  * ThemeQueryManager manages themes which can be queried
  */
 export default class ThemeQueryManager extends PaginatedQueryManager {
+
 	/**
-	 * Signal that an item(s) has been received for tracking. Optionally
-	 * specify that items received are intended for patch application, or that
-	 * they are associated with a query. This function does not mutate the
-	 * instance state. Instead, it returns a new instance of ThemeQueryManager if
-	 * the tracked items have been modified, or the current instance otherwise.
+	 * A sorting function that defines the sort order of items under
+	 * consideration of the specified query.
 	 *
-	 * Note that we implement our own receive() method instead of just relying on
-	 * that of the base class. We choose to override the base class's receive()
-	 * so the results are kept in the order they are received from the endpoint.
+	 * Note that this isn't doing anything so the results are kept in the order they
+	 * are received from the endpoint.
 	 * The themes query REST API endpoint uses ElasticSearch to sort results by
 	 * relevancy, which we cannot easily mimick on the client side.
-	 *
-	 * @param  {(Array|Object)} items              Item(s) to be received
-	 * @param  {Object}         options            Options for receive
-	 * @param  {Boolean}        options.patch      Apply changes as partial
-	 * @param  {Object}         options.query      Query set to set or replace
-	 * @param  {Boolean}        options.mergeQuery Add to existing query set
-	 * @param  {Number}         options.found      Total found items for query
-	 * @return {QueryManager}                      New instance if changed, or
-	 *                                             same instance otherwise
 	 */
-	receive( items, options = {} ) {
-		// Create the updated manager based on this instance, appending the newly received items
-		const nextManager = new this.constructor(
-			{
-				...this.data,
-				items: {
-					...this.data.items,
-					...keyBy( items, this.options.itemKey )
-				},
-				queries: this.data.queries
-			},
-			this.options
-		);
-
-		// If manager is the same instance, assume no changes have been made
-		if ( this === nextManager ) {
-			return nextManager;
-		}
-
-		// If no query was passed, return the QueryManager with only the new items appended
-		if ( ! options.query ) {
-			return nextManager;
-		}
-
-		// If we're already storing the query and associated items, return this instance.
-		if ( isEqual( super.getItems( options.query ), items ) ) {
-			return this;
-		}
-
-		const queryKey = this.constructor.QueryKey.stringify( options.query );
-		const page = options.query.page || this.constructor.DEFAULT_QUERY.page;
-		const perPage = options.query.number || this.constructor.DEFAULT_QUERY.number;
-		const startOffset = ( page - 1 ) * perPage;
-		const nextQuery = get( this.data.queries, queryKey, { itemKeys: [], found: options.found } );
-
-		// Coerce received single item to array
-		if ( ! Array.isArray( items ) ) {
-			items = [ items ];
-		}
-
-		// If the item set for the queried page is identical, there are no
-		// updates to be made
-		const pageItemKeys = items.map( ( item ) => item[ this.options.itemKey ] );
-
-		// If we've reached this point, we know that we've received a paged
-		// set of data where our assumed item set is incorrect.
-		const modifiedNextQuery = cloneDeep( nextQuery );
-
-		// Found count is not always reliable, usually in consideration of user
-		// capabilities. If we receive a set of items with a count not matching
-		// the expected number for the query, we recalculate the found value to
-		// reflect that this is the last set we can expect to receive. Found is
-		// correct only if the count of items matches expected query number.
-		if ( modifiedNextQuery.hasOwnProperty( 'found' ) && perPage !== items.length ) {
-			// Otherwise, found count should be corrected to equal the number
-			// of items received added to the summed per page total. Note that
-			// we can reach this point if receiving the last page of items, but
-			// the updated value should still be correct given this logic.
-			modifiedNextQuery.found = ( ( page - 1 ) * perPage ) + items.length;
-		}
-
-		// If found is known from options, ensure that we fill the end of the
-		// array with undefined entries until found count
-		if ( modifiedNextQuery.hasOwnProperty( 'found' ) ) {
-			modifiedNextQuery.itemKeys = range( 0, modifiedNextQuery.found ).map( ( index ) => {
-				return modifiedNextQuery.itemKeys[ index ];
-			} );
-		}
-
-		// Splice results into their proper place
-		modifiedNextQuery.itemKeys.splice( startOffset, perPage, ...pageItemKeys );
-
-		return new this.constructor(
-			{
-				...this.data,
-				items: {
-					...this.data.items,
-					...keyBy( items, this.options.itemKey )
-				},
-				queries: {
-					...this.data.queries,
-					[ queryKey ]: modifiedNextQuery
-				}
-			},
-			this.options
-		);
+	sort() {
+		return; // Leave the keys argument unchanged.
 	}
 }
 

--- a/client/lib/query-manager/theme/test/index.js
+++ b/client/lib/query-manager/theme/test/index.js
@@ -1,17 +1,34 @@
 /**
  * External dependencies
  */
-//import { expect } from 'chai';
+import { expect } from 'chai';
 
 /**
  * Internal dependencies
  */
-//import ThemeQueryManager from '../';
+import ThemeQueryManager from '../';
 
-/**
- * Constants
- */
+describe( 'ThemeQueryManager', ( ) => {
+	describe( '#sort()', ( ) => {
+		it( 'should leave key order unchanged', ( ) => {
+			const originalKeys = Object.freeze( [
+				'adaline',
+				'fanwood-light',
+				'ixion',
+				'cols',
+				'timepiece',
+				'chalkboard',
+				'handmade',
+				'trvl',
+				'dyad',
+				'little-story',
+				'pachyderm'
+			] );
+			const keys = [ ...originalKeys ];
+			const manager = new ThemeQueryManager();
 
-describe( 'ThemeQueryManager', () => {
-	// TODO
+			manager.sort( keys );
+			expect( keys ).to.deep.equal( originalKeys );
+		} );
+	} );
 } );


### PR DESCRIPTION
...and use that to implement `ThemeQueryManager`.

* `sort` is renamed to `compare`, since it is really a comparison function
* A new `sort` method is introduced, which basically just encapsulates the logic of running `Array.prototype.sort` with the `compare()` method (this logic was previously just inlined in `receive`)
* This new intermediary layer gives us an option to have child classes override it, and we use this to re-implement `ThemeQueryManager` by just overriding it with `identity` in order to preserve the themes sort order as obtained from the server (which uses ElasticSearch to weigh and sort results, and replicating that weighing and sorting on the client side would just be too hard). Note that we couldn't do that by just overriding `compare` (the method formerly known as `sort` 😄 ) because of reasons laid out in the `README.md` as of this PR.

More backstory: https://github.com/Automattic/wp-calypso/pull/10635#issuecomment-272589711

To test:
Check that everything that uses a `QueryManager` still works as before, notably:
* CPTs
* Media
* Themes

(Ideally, unit tests have us covered 😄 )

Supersedes #10692