### PR TITLE
Google Adwords: Update Adwords texts

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/google-voucher/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/google-voucher/index.jsx
@@ -16,7 +16,7 @@ import PurchaseButton from 'components/purchase-detail/purchase-button';
 import TipInfo from 'components/purchase-detail/tip-info';
 import Dialog from 'components/dialog';
 import analytics from 'lib/analytics';
-import termsAndConditions from './terms-and-conditions';
+import TermsAndConditions from './terms-and-conditions';
 import QuerySiteVouchers from 'components/data/query-site-vouchers';
 import {
 	assignSiteVoucher as assignVoucher
@@ -139,7 +139,7 @@ class GoogleVoucherDetails extends Component {
 				</div>
 
 				<div className="google-voucher-dialog__body">
-					{ termsAndConditions() }
+					<TermsAndConditions />
 				</div>
 
 				<div className="google-voucher-dialog__footer">

--- a/client/my-sites/upgrades/checkout-thank-you/google-voucher/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/google-voucher/index.jsx
@@ -115,7 +115,7 @@ class GoogleVoucherDetails extends Component {
 					text={ this.props.translate( 'Generate code' ) } />
 
 				<TipInfo
-					info={ this.props.translate( 'Offer valid in US and Canada after spending the first $25 on Google AdWords.' ) } />
+					info={ this.props.translate( 'Offer valid in US after spending the first $25 on Google AdWords.' ) } />
 			</div>
 		);
 	}
@@ -199,7 +199,7 @@ class GoogleVoucherDetails extends Component {
 
 				<TipInfo
 					className="google-voucher-advice"
-					info={ this.props.translate( 'Offer valid in US and Canada after spending the first $25 on Google AdWords.' ) } />
+					info={ this.props.translate( 'Offer valid in US after spending the first $25 on Google AdWords.' ) } />
 			</div>
 		);
 	}

--- a/client/my-sites/upgrades/checkout-thank-you/google-voucher/terms-and-conditions.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/google-voucher/terms-and-conditions.jsx
@@ -2,51 +2,89 @@
  * External dependencies
  */
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { localize, moment } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import ExternalLink from 'components/external-link';
 
 /*
  * Constants
  */
-const expirationDate = 'October 31, 2017';
+const expirationDate = '2017-10-31';
 
-const googleTermsAndConditions = () => {
-	return(
-		<div>
-			<h3>{ i18n.translate( 'Terms and conditions for this offer:' ) }</h3>
-			<p>{ i18n.translate( 'In the below terms, “AdWords” may mean AdWords or AdWords Express, as appropriate.' ) }</p>
-			<ol>
-				<li className="google-voucher__terms-and-conditions">{ i18n.translate( 'Offer available to customers with a billing address in the United States only. One promotional code per advertiser.' ) }</li>
+const googleTermsAndConditions = ( { translate } ) =>
+	<div>
+		<h3>{ translate( 'Terms and conditions for this offer:' ) }</h3>
+		<p>{ translate( 'In the below terms, “AdWords” may mean AdWords or AdWords Express, as appropriate.' ) }</p>
+		<ol>
+			<li className="google-voucher__terms-and-conditions">{
+				translate(
+					'Offer available to customers with a billing address in the United States only. ' +
+					'One promotional code per advertiser.'
+				) }
+			</li>
 
-				<li className="google-voucher__terms-and-conditions">{
-					i18n.translate(
-						'To activate this offer: Enter the promotional code in your account before %(expirationDate)s. In order to participate in this offer, you must enter the code within 14 days of your first ad impression being served from your first AdWords account.',
-						{ args: { expirationDate } }
-					) }
-				</li>
+			<li className="google-voucher__terms-and-conditions">{
+				translate(
+					'To activate this offer: Enter the promotional code in your account before %(expirationDate)s. ' +
+					'In order to participate in this offer, ' +
+					'you must enter the code within 14 days of your first ad impression being served from your first AdWords account.', {
+						args: {
+							expirationDate: moment( expirationDate ).format( 'LL' )
+						}
+					}
+				) }
+			</li>
 
-				<li className="google-voucher__terms-and-conditions">{ i18n.translate( 'To earn the credit: After entering the code, your advertising campaigns must accrue costs of at least $25, excluding any taxes, within 30 days. Making a payment of $25 is not sufficient. The tracking of advertising costs towards $25 begins after you’ve entered the code.' ) }</li>
+			<li className="google-voucher__terms-and-conditions">{
+				translate(
+					'To earn the credit: After entering the code, your advertising campaigns must accrue costs of at least $25, ' +
+					'excluding any taxes, within 30 days. Making a payment of $25 is not sufficient. ' +
+					'The tracking of advertising costs towards $25 begins after you’ve entered the code.'
+				) }
+			</li>
 
-				<li className="google-voucher__terms-and-conditions">{ i18n.translate( 'Once 2 and 3 are completed, the credit will typically be applied within 5 days to the Billing Summary of your account.' ) }</li>
+			<li className="google-voucher__terms-and-conditions">{
+				translate(
+					'Once 2 and 3 are completed, the credit will typically be applied within 5 days to the Billing Summary of your account.'
+				) }
+			</li>
 
-				<li className="google-voucher__terms-and-conditions">{ i18n.translate( 'Credits apply to future advertising costs only. Credits cannot be applied to costs accrued before the code was entered.' ) }</li>
+			<li className="google-voucher__terms-and-conditions">{
+				translate(
+					'Credits apply to future advertising costs only. ' +
+					'Credits cannot be applied to costs accrued before the code was entered.'
+				) }
+			</li>
 
-				<li className="google-voucher__terms-and-conditions">{ i18n.translate( 'You won’t receive a notification once your credit is used up and any additional advertising costs will be charged to your form of payment. If you don’t want to continue advertising, you can pause or delete your campaigns at any time.' ) }</li>
+			<li className="google-voucher__terms-and-conditions">{
+				translate(
+					'You won’t receive a notification once your credit is used up and any additional advertising costs ' +
+					'will be charged to your form of payment. ' +
+					'If you don’t want to continue advertising, you can pause or delete your campaigns at any time.'
+				) }
+			</li>
 
-				<li className="google-voucher__terms-and-conditions">{ i18n.translate( 'Your account must be successfully billed by AdWords and remain in good standing in order to qualify for the promotional credit.' ) }</li>
+			<li className="google-voucher__terms-and-conditions">{
+				translate(
+					'Your account must be successfully billed by AdWords ' +
+					'and remain in good standing in order to qualify for the promotional credit.'
+				) }
+			</li>
 
-				<li className="google-voucher__terms-and-conditions">
-					{ i18n.translate( 'Full terms and conditions can be found here ' ) }
-					<a
-						href="http://www.google.com/adwords/coupons/terms.html"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						http://www.google.com/adwords/coupons/terms.html
-					</a>.
-				</li>
-			</ol>
-		</div>
-	);
-};
+			<li className="google-voucher__terms-and-conditions">
+				{ translate( 'Full terms and conditions can be found here ' ) }
+				<ExternalLink
+					href="http://www.google.com/adwords/coupons/terms.html"
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					http://www.google.com/adwords/coupons/terms.html
+				</ExternalLink>.
+			</li>
+		</ol>
+	</div>;
 
-export default googleTermsAndConditions;
+export default localize( googleTermsAndConditions );

--- a/client/my-sites/upgrades/checkout-thank-you/google-voucher/terms-and-conditions.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/google-voucher/terms-and-conditions.jsx
@@ -4,6 +4,11 @@
 import React from 'react';
 import i18n from 'i18n-calypso';
 
+/*
+ * Constants
+ */
+const expirationDate = 'October 31, 2017';
+
 const googleTermsAndConditions = () => {
 	return(
 		<div>
@@ -12,7 +17,12 @@ const googleTermsAndConditions = () => {
 			<ol>
 				<li className="google-voucher__terms-and-conditions">{ i18n.translate( 'Offer available to customers with a billing address in the United States only. One promotional code per advertiser.' ) }</li>
 
-				<li className="google-voucher__terms-and-conditions">{ i18n.translate( 'To activate this offer: Enter the promotional code in your account before December 31 2016. In order to participate in this offer, you must enter the code within 14 days of your first ad impression being served from your first AdWords account.' ) }</li>
+				<li className="google-voucher__terms-and-conditions">{
+					i18n.translate(
+						'To activate this offer: Enter the promotional code in your account before %(expirationDate)s. In order to participate in this offer, you must enter the code within 14 days of your first ad impression being served from your first AdWords account.',
+						{ args: { expirationDate } }
+					) }
+				</li>
 
 				<li className="google-voucher__terms-and-conditions">{ i18n.translate( 'To earn the credit: After entering the code, your advertising campaigns must accrue costs of at least $25, excluding any taxes, within 30 days. Making a payment of $25 is not sufficient. The tracking of advertising costs towards $25 begins after you’ve entered the code.' ) }</li>
 


### PR DESCRIPTION
It updates the Google Adwords credit section according to this new year and other changes. Also, I've taken advantage of this PR and I implemented some refactoring/janitorial improvements.

Issue: #10703

<img src="https://cloud.githubusercontent.com/assets/77539/22038105/b9424666-dcd8-11e6-858f-e76513ea9c81.png" width="300px" />

<img src="https://cloud.githubusercontent.com/assets/77539/22038163/e42e10d0-dcd8-11e6-8d7e-2ee948e7310b.png" width="500px" />

### Testing

1. Go to the plan page of a non-free Site: `http://calypso.localhost:3000/plans/my-plan/<your-site>`
2. Look at `Google AdWords credit` section
3. Start to generate the code clicking in the blue button
4. Pay attention to the texts trying to confirm that the texts have been rightly updated.
