### PR TITLE
Sites: Replace changed site during updates

### DIFF
--- a/client/lib/site/index.js
+++ b/client/lib/site/index.js
@@ -65,7 +65,12 @@ Site.prototype.set = function( attributes ) {
 
 	for ( var prop in attributes ) {
 		if ( attributes.hasOwnProperty( prop ) && ! isEqual( attributes[ prop ], this[ prop ] ) ) {
-			this[ prop ] = attributes[ prop ];
+			if ( undefined === attributes[ prop ] ) {
+				delete this[ prop ];
+			} else {
+				this[ prop ] = attributes[ prop ];
+			}
+
 			changed = true;
 		}
 	}

--- a/client/lib/site/test/index.js
+++ b/client/lib/site/test/index.js
@@ -11,13 +11,23 @@ describe( 'Calypso Site', () => {
 		const mockSiteData = {
 			ID: 1234,
 			name: 'Hello',
-			description: 'Hunting bugs is fun.'
-		}
+			description: 'Hunting bugs is fun.',
+			icon: {
+				img: 'https://secure.gravatar.com/blavatar/0d6c430459af115394a012d20b6711d6',
+				ico: 'https://secure.gravatar.com/blavatar/662db33e9076ddbb8852ae35a845bfb4'
+			}
+		};
 
 		it( 'attribute changed', () => {
 			const site = Site( mockSiteData );
 			site.set( { name: 'Goodbye' } );
 			expect( site.name ).to.equal( 'Goodbye' );
+		} );
+
+		it( 'attribute unset', () => {
+			const site = Site( mockSiteData );
+			site.set( { icon: undefined } );
+			expect( site ).to.not.have.key( 'icon' );
 		} );
 
 		it( 'change event fires on attribute change', () => {

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -201,7 +201,7 @@ SitesList.prototype.update = function( sites ) {
 		if ( sitesMap[ site.ID ] ) {
 			// Since updates are applied as a patch, ensure key is present for
 			// properties which can be intentionally omitted from site payload.
-			if ( undefined === site.icon ) {
+			if ( ! site.hasOwnProperty( 'icon' ) ) {
 				site.icon = undefined;
 			}
 

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -3,10 +3,7 @@
  */
 import debugModule from 'debug';
 import store from 'store';
-import assign from 'lodash/assign';
-import find from 'lodash/find';
-import isEmpty from 'lodash/isEmpty';
-import some from 'lodash/some';
+import { assign, find, isEmpty, some, isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -196,18 +193,11 @@ SitesList.prototype.update = function( sites ) {
 
 	this.markCollisions( sites );
 	this.data = sites.map( function( site ) {
-		var siteObj, result;
-
-		if ( sitesMap[ site.ID ] ) {
-			// Update existing Site object
-			siteObj = sitesMap[ site.ID ];
-			result = siteObj.set( site );
-			if ( result ) {
-				changed = true;
-			}
+		let siteObj = sitesMap[ site.ID ];
+		if ( siteObj && isEqual( siteObj, site ) ) {
 			delete sitesMap[ site.ID ];
 		} else {
-			// Create new Site object
+			// Create or replace Site object
 			siteObj = this.createSiteObject( site );
 			siteObj.on( 'change', this.propagateChange );
 			changed = true;

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -3,7 +3,10 @@
  */
 import debugModule from 'debug';
 import store from 'store';
-import { assign, find, isEmpty, some, isEqual } from 'lodash';
+import assign from 'lodash/assign';
+import find from 'lodash/find';
+import isEmpty from 'lodash/isEmpty';
+import some from 'lodash/some';
 
 /**
  * Internal dependencies
@@ -193,11 +196,24 @@ SitesList.prototype.update = function( sites ) {
 
 	this.markCollisions( sites );
 	this.data = sites.map( function( site ) {
-		let siteObj = sitesMap[ site.ID ];
-		if ( siteObj && isEqual( siteObj, site ) ) {
+		var siteObj, result;
+
+		if ( sitesMap[ site.ID ] ) {
+			// Since updates are applied as a patch, ensure key is present for
+			// properties which can be intentionally omitted from site payload.
+			if ( undefined === site.icon ) {
+				site.icon = undefined;
+			}
+
+			// Update existing Site object
+			siteObj = sitesMap[ site.ID ];
+			result = siteObj.set( site );
+			if ( result ) {
+				changed = true;
+			}
 			delete sitesMap[ site.ID ];
 		} else {
-			// Create or replace Site object
+			// Create new Site object
 			siteObj = this.createSiteObject( site );
 			siteObj.on( 'change', this.propagateChange );
 			changed = true;

--- a/client/lib/sites-list/test/index.js
+++ b/client/lib/sites-list/test/index.js
@@ -81,6 +81,19 @@ describe( 'SitesList', () => {
 			} );
 		} );
 
+		it( 'updating should reflect removed properties on site', () => {
+			const updatedWithIconOmitted = cloneDeep( updatedData ).map( ( site ) => {
+				delete site.icon;
+				return site;
+			} );
+			sitesList.update( updatedWithIconOmitted );
+			const updatedList = sitesList.get();
+
+			forEach( updatedList, ( site ) => {
+				assert.notProperty( site, 'icon' );
+			} );
+		} );
+
 		it( 'should update attributes properly', () => {
 			sitesList.update( updatedData );
 			const site = sitesList.get()[ 0 ];


### PR DESCRIPTION
Issue noted at https://github.com/Automattic/wp-calypso/pull/10477#issuecomment-271460873, summarized at https://github.com/Automattic/wp-calypso/pull/10477#issuecomment-273295260

This pull request seeks to resolve an issue where fetched site updates after the global SitesList instance is initialized will not reflect properties of a site object that have been removed. This can occur, for example, when a site's icon is removed. The site response lacks an `icon` property when a site does not have an icon assigned.

Instead of applying changes as a patch to the existing site object, the changes here cause a site which has received changes to be replaced in the `sites-list` data set.

__Testing instructions:__

Verify that tests pass:

```
npm run test-client client/lib/sites-list client/lib/site
```

Cherry-pick included 8a1ce4d atop `update/sites-list-sync` branch and repeat steps described at https://github.com/Automattic/wp-calypso/pull/10477#issuecomment-271460873, observing that the icon remains correct after the last step (sites-list polling).