### PR TITLE
Reader: Remove stray ); from photo cards

### DIFF
--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -113,7 +113,7 @@ class PostPhoto extends React.Component {
 						</h1>
 					</AutoDirection>
 					{ children }
-				</div> );
+				</div>
 			</div>
 		);
 	}


### PR DESCRIPTION
bad:
<img width="762" alt="photo_blogs_ _reader_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/14350/22042695/442948a0-dcda-11e6-9018-a32c77950eb4.png">

good:
<img width="748" alt="photo_blogs_ _reader_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/14350/22042717/596ce460-dcda-11e6-85d8-5f9fde4edf5b.png">


