### PR TITLE
Reader: update Recommendations to use `alg_prefix`

### DIFF
--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -201,7 +201,7 @@ function getStoreForRecommendedPosts( storeId ) {
 				query.algorithm = 'read:recommendations:posts/es/6';
 				break;
 			case 'custom_recs_posts_with_images':
-				query.algorithm = 'read:recommendations:posts/es/7';
+				query.alg_prefix = 'read:recommendations:posts';
 
 				/* Seed FAQ:
 				 * Q: What does it do?


### PR DESCRIPTION
Changing the request parameter to `alg_prefix` instead of requesting a specific algorithm. Using the `alg_prefix` allows us to perform algorithm A/B tests.