### PR TITLE
Reader: fix dom tree for photo cards

### DIFF
--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -112,6 +112,8 @@ class PostPhoto extends React.Component {
 							<a className="reader-post-card__title-link" href={ href }>{ linkTitle }</a>
 						</h1>
 					</AutoDirection>
+				</div>
+				<div className="reader-post-card__post-details" >
 					{ children }
 				</div>
 			</div>


### PR DESCRIPTION
This fixes #10717

Resolve goofed DOM from merging #10503 into #10474

Pre-expanded :
![screen shot 2017-01-17 at 3 48 41 pm](https://cloud.githubusercontent.com/assets/744755/22045151/761e7f04-dccd-11e6-970a-976c0aff0e81.png)

Expanded:
![screen shot 2017-01-17 at 3 48 56 pm](https://cloud.githubusercontent.com/assets/744755/22045158/7c9e8428-dccd-11e6-9afd-fc7cb69a5ed4.png)

Narrow:
![screen shot 2017-01-17 at 3 55 36 pm](https://cloud.githubusercontent.com/assets/744755/22045162/81241a6c-dccd-11e6-9c84-0a0a425384fa.png)


cc @fraying 