### PR TITLE
Purchases: Hide site slug for domain-only sites

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -41,6 +41,7 @@ function getPurchasesBySite( purchases, sites ) {
 				 * there will be no site with this ID in `sites`, so
 				 * we fall back on the domain. */
 				slug: siteObject ? siteObject.slug : currentValue.domain,
+				isDomainOnly: siteObject ? siteObject.options.is_domain_only : false,
 				title: currentValue.siteName || currentValue.domain || '',
 				purchases: [ currentValue ],
 				domain: siteObject ? siteObject.domain : currentValue.domain

--- a/client/me/purchases/list/index.jsx
+++ b/client/me/purchases/list/index.jsx
@@ -52,6 +52,7 @@ const PurchasesList = React.createClass( {
 						name={ site.title }
 						domain={ site.domain }
 						slug={ site.slug }
+						isDomainOnly={ site.isDomainOnly }
 						purchases={ site.purchases } />
 				)
 			);

--- a/client/me/purchases/list/site/index.jsx
+++ b/client/me/purchases/list/site/index.jsx
@@ -12,7 +12,7 @@ import i18n from 'i18n-calypso';
 import PurchaseItem from '../item';
 import SectionHeader from 'components/section-header';
 
-const PurchasesSite = ( { isPlaceholder, name, purchases, slug, domain } ) => {
+const PurchasesSite = ( { isDomainOnly, isPlaceholder, name, purchases, slug, domain } ) => {
 	let items, label = name;
 
 	if ( isPlaceholder ) {
@@ -34,7 +34,9 @@ const PurchasesSite = ( { isPlaceholder, name, purchases, slug, domain } ) => {
 	return (
 		<div className={ classNames( 'purchases-site', { 'is-placeholder': isPlaceholder } ) }>
 			<SectionHeader label={ label }>
-				<span className="purchases-site__slug">{ domain }</span>
+				{ ! isDomainOnly && (
+					<span className="purchases-site__slug">{ domain }</span>
+				) }
 			</SectionHeader>
 
 			{ items }
@@ -44,6 +46,7 @@ const PurchasesSite = ( { isPlaceholder, name, purchases, slug, domain } ) => {
 
 PurchasesSite.propTypes = {
 	domain: React.PropTypes.string,
+	isDomainOnly: React.PropTypes.bool,
 	isPlaceholder: React.PropTypes.bool,
 	name: React.PropTypes.string,
 	purchases: React.PropTypes.array,


### PR DESCRIPTION
**Before**
![screen shot 2017-01-17 at 5 17 48 pm](https://cloud.githubusercontent.com/assets/1130674/22047082/afcee5e8-dcd9-11e6-8080-7ade9aea552d.png)

**After**
![screen shot 2017-01-17 at 5 16 55 pm](https://cloud.githubusercontent.com/assets/1130674/22047090/b72504b2-dcd9-11e6-9899-78eb9fe86c1b.png)

**Note:** I wanted to use the `isDomainOnlySite` selector that @gziolo created recently, but wasn't able to here yet as `state.sites.items` isn't fully populated when the user visits `/me/purchases`.

**Testing**
- Visit `/me/purchases`.
- Assert that domain-only sites do not have a site slug displayed by their title per above.
- Assert that normal sites still have the slug displayed.

- [x] Code
- [x] Product