### PR TITLE
Jetpack Connect: Authorize Form

### DIFF
--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -15,10 +15,7 @@ import JetpackConnect from './index';
 import JetpackConnectAuthorizeForm from './authorize-form';
 import { setSection } from 'state/ui/actions';
 import { renderWithReduxStore } from 'lib/react-helpers';
-import {
-	JETPACK_CONNECT_QUERY_SET,
-	JETPACK_CONNECT_QUERY_UPDATE
-} from 'state/action-types';
+import { JETPACK_CONNECT_QUERY_SET } from 'state/action-types';
 import userFactory from 'lib/user';
 import jetpackSSOForm from './sso';
 import i18nUtils from 'lib/i18n-utils';
@@ -104,16 +101,6 @@ export default {
 			context.store.dispatch( {
 				type: JETPACK_CONNECT_QUERY_SET,
 				queryObject: context.query
-			} );
-			page.redirect( context.pathname );
-		}
-
-		if ( ! isEmpty( context.query ) && context.query.update_nonce ) {
-			debug( 'updating nonce', context.query );
-			context.store.dispatch( {
-				type: JETPACK_CONNECT_QUERY_UPDATE,
-				property: '_wp_nonce',
-				value: context.query.update_nonce
 			} );
 			page.redirect( context.pathname );
 		}


### PR DESCRIPTION
Whenever an action changes the current user's identity - login, change account, new account -
we are losing `queryObject` from Redux state. To fix this, let's add all `queryObject` args
to `redirect_to` URL, so we retain them when we redirect.

The follow flows are currently broken in production:
- logged in to wpcom, click "Create New Account" on jetpack/connect/authorize
- logged in to wpcom, click "Already Have An Account" on jetpack/connect/authorize
- logged out of wpcom, create new account

I'm not sure when the flows regressed. It may not have been any code changes that caused this, but rather how browsers handle local DB during page refresh. We first noticed it today when @kraftbj reported an increase of support tickets of folks having trouble connecting.

This PR will fix it. Test it out:

- apply this patch to your local calypso
- from wp-admin, try to connect an unconnected Jetpack site
 - you'll need to set `calypso_env=development` either [here](https://github.com/Automattic/jetpack/blob/master/class.jetpack.php#L3964), or through your wpcom sandbox
- ensure you can connect your site using any of the flows listed above
