### PR TITLE
Stats: Unify the way we retrieve the site's slug on stats

### DIFF
--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -198,8 +198,9 @@ describe( 'utils', () => {
 					}
 				}, {
 					period: 'day',
-					date: '2017-01-12',
-					domain: 'en.blog.wordpress.com'
+					date: '2017-01-12'
+				}, 10, {
+					slug: 'en.blog.wordpress.com'
 				} );
 
 				expect( parsedData ).to.eql( [ {
@@ -234,8 +235,9 @@ describe( 'utils', () => {
 					}
 				}, {
 					period: 'day',
-					date: '2017-01-12',
-					domain: 'en.blog.wordpress.com'
+					date: '2017-01-12'
+				}, 10, {
+					slug: 'en.blog.wordpress.com'
 				} );
 
 				expect( parsedData ).to.eql( [ {
@@ -270,8 +272,9 @@ describe( 'utils', () => {
 				}, {
 					period: 'day',
 					date: '2017-01-12',
-					domain: 'en.blog.wordpress.com',
 					summarize: 1
+				}, 10, {
+					slug: 'en.blog.wordpress.com'
 				} );
 
 				expect( parsedData ).to.eql( [ {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -125,9 +125,11 @@ export const normalizers = {
 	 *
 	 * @param  {Object} data    Stats data
 	 * @param  {Object} query   Stats query
+	 * @param  {Int}    siteId  Site ID
+	 * @param  {Obejct} site    Site object
 	 * @return {Object?}        Normalized stats data
 	 */
-	statsTopPosts: ( data, query ) => {
+	statsTopPosts: ( data, query, siteId, site ) => {
 		if ( ! data || ! query.period || ! query.date ) {
 			return [];
 		}
@@ -137,7 +139,7 @@ export const normalizers = {
 		const viewData = get( data, dataPath, [] );
 
 		return map( viewData, ( item ) => {
-			const detailPage = `/stats/post/${ item.id }/${ query.domain }`;
+			const detailPage = site ? `/stats/post/${ item.id }/${ site.slug }` : null;
 			let inPeriod = false;
 
 			// Archive and home pages do not have dates


### PR DESCRIPTION
I'm updating the way we retrieve the site's slug on stats normalizers. Instead of relying on an extra "domain" attribute in the query object, we use the `getSite` selector because the domain attribute is not relevant in the query object (and is a duplicate of `siteId`)

**Testing instructions**

- Nothing for now, topPosts are still relying on StatsList for now