### PR TITLE
Signup: update `userFirstSignup` AB.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -111,10 +111,10 @@ module.exports = {
 	},
 
 	userFirstSignup: {
-		datestamp: '20161223',
+		datestamp: '20160124',
 		variations: {
-			userLast: 95,
-			userFirst: 5,
+			userLast: 80,
+			userFirst: 20,
 		},
 		defaultVariation: 'userLast',
 		allowExistingUsers: false,
@@ -129,6 +129,7 @@ module.exports = {
 		defaultVariation: 'withoutMarketingCopy',
 		allowExistingUsers: true
 	},
+
 	jetpackPlansTabs: {
 		datestamp: '20170117',
 		variations: {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -207,19 +207,11 @@ const flows = {
 		lastModified: '2016-11-14'
 	},
 
-	userfirst: {
-		steps: [ 'user' ],
-		destination: '/start/userfirst-secondary',
-		description: 'User-first signup flow',
-		lastModified: '2016-12-23',
-		autoContinue: true,
-	},
-
-	'userfirst-secondary': {
-		steps: [ 'design-type', 'themes', 'domains', 'plans' ],
+	'user-first': {
+		steps: [ 'user', 'design-type', 'themes', 'domains', 'plans' ],
 		destination: getSiteDestination,
-		description: 'Secondary flow for User First signup',
-		lastModified: '2016-12-23'
+		description: 'User-first signup flow',
+		lastModified: '2016-01-18',
 	},
 };
 
@@ -281,15 +273,7 @@ function filterFlowName( flowName ) {
 	 */
 	if ( ! user.get() ) {
 		if ( includes( defaultFlows, flowName ) && abtest( 'userFirstSignup' ) === 'userFirst' ) {
-			return 'userfirst';
-		}
-
-		/**
-		 * Users should not be able to reach `userfirst-secondary` without being logged in, since
-		 * it doesn't contain the `user` step to register a user and site respectively.
- 		 */
-		if ( flowName === 'userfirst-secondary' ) {
-			return 'userfirst';
+			return 'user-first';
 		}
 	}
 


### PR DESCRIPTION
In #10260, the `userFirstSignup` test was added as a proof of concept to collect data about step and flow completion. The test consisted of a flow with only the `/user/` step, which processed user creation before redirecting to the `/user-secondary/` flow to finish Signup as a logged-in user.

This update removes the `/user-secondary/` flow and simply moves the `/user/` step to the front of the `/main/` and `/website/` flows.

To test:

1. Start signup with the `/main/` or `/website/` flow.
2. Try the `userFirst` variation of the `userFirstSignup` AB.
3. Verify that the `/user/` step is first, Signup otherwise works properly, and you can create a site.
4. Verify there are no JS errors in the console