### PR TITLE
Stats: Use the redux stats subtree for the search Terms stats

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -340,8 +340,6 @@ module.exports = {
 				siteID: siteId, statType: 'statsTopPosts', period: activeFilter.period, date: endDate, domain: siteDomain } );
 			const clicksList = new StatsList( {
 				siteID: siteId, statType: 'statsClicks', period: activeFilter.period, date: endDate, domain: siteDomain } );
-			const searchTermsList = new StatsList( {
-				siteID: siteId, statType: 'statsSearchTerms', period: activeFilter.period, date: endDate, domain: siteDomain } );
 
 			siteComponent = SiteStatsComponent;
 			const siteComponentChildren = {
@@ -358,7 +356,6 @@ module.exports = {
 				siteId,
 				period,
 				chartPeriod,
-				searchTermsList,
 				slug: siteDomain,
 				path: context.pathname,
 			};
@@ -499,8 +496,7 @@ module.exports = {
 					break;
 
 				case 'searchterms':
-					summaryList = new StatsList( { siteID: siteId, statType: 'statsSearchTerms',
-						period: activeFilter.period, date: endDate, max: 0, domain: siteDomain } );
+					summaryList = fakeStatsList;
 					break;
 
 				case 'podcastdownloads':

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -208,14 +208,14 @@ module.exports = React.createClass( {
 								period={ this.props.period }
 								query={ query }
 								summary={ false } />
-							<StatsModule
-								path={ 'searchterms' }
+							<StatsConnectedModule
+								path="searchterms"
 								moduleStrings={ moduleStrings.search }
-								site={ site }
-								dataList={ this.props.searchTermsList }
 								period={ this.props.period }
 								date={ queryDate }
-								beforeNavigate={ this.updateScrollPosition } />
+								query={ query }
+								statType="statsSearchTerms"
+								showSummaryLink />
 							{ videoList }
 							{ podcastList }
 						</div>

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -200,14 +200,14 @@ const StatsSummary = React.createClass( {
 
 			case 'searchterms':
 				title = translate( 'Search Terms' );
-				summaryView = <StatsModule
+				summaryView = <StatsConnectedModule
 					key="search-terms-summary"
-					path={ 'searchterms' }
+					path="searchterms"
 					moduleStrings={ StatsStrings.search }
-					site={ site }
-					dataList={ this.props.summaryList }
 					period={ this.props.period }
-					summary={ true } />;
+					query={ query }
+					statType="statsSearchTerms"
+					summary />;
 				break;
 		}
 

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -974,6 +974,66 @@ describe( 'utils', () => {
 					] );
 				} );
 			} );
+
+			describe( 'statsSearchTerms()', () => {
+				it( 'should return an empty array if not data is passed', () => {
+					const parsedData = normalizers.statsSearchTerms();
+					expect( parsedData ).to.eql( [] );
+				} );
+
+				it( 'should return an empty array if query.period is null', () => {
+					const parsedData = normalizers.statsSearchTerms( {}, { date: '2016-12-25' } );
+					expect( parsedData ).to.eql( [] );
+				} );
+
+				it( 'should return an empty array if query.date is null', () => {
+					const parsedData = normalizers.statsSearchTerms( {}, { period: 'day' } );
+					expect( parsedData ).to.eql( [] );
+				} );
+
+				it( 'should return an a properly parsed data array', () => {
+					const parsedData = normalizers.statsSearchTerms( {
+						date: '2017-01-12',
+						days: {
+							'2017-01-12': {
+								encrypted_search_terms: 221,
+								search_terms: [
+									{
+										term: 'chicken',
+										views: 3
+									},
+									{
+										term: 'ribs',
+										views: 10
+									}
+								]
+							}
+						}
+					}, {
+						period: 'day',
+						date: '2017-01-12'
+					} );
+
+					expect( parsedData ).to.eql( [
+						{
+							className: 'user-selectable',
+							label: 'chicken',
+							value: 3
+						},
+						{
+							className: 'user-selectable',
+							label: 'ribs',
+							value: 10
+						},
+						{
+							label: 'Unknown Search Terms',
+							labelIcon: 'external',
+							link: 'http://en.support.wordpress.com/stats/#search-engine-terms',
+							value: 221
+						}
+					] );
+				} );
+			} );
 		} );
 	} );
 } );

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { sortBy, toPairs, camelCase, mapKeys, isNumber, get, filter, map, concat, flatten } from 'lodash';
-import { moment } from 'i18n-calypso';
+import { moment, translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -270,7 +270,7 @@ export const normalizers = {
 	 * Returns a normalized statsVideo array, ready for use in stats-module
 	 *
 	 * @param  {Object} payload Stats response payload
-	 * @return {Array}          Parsed publicize data array
+	 * @return {Array}          Parsed data array
 	 */
 	statsVideo( payload ) {
 		if ( ! payload || ! payload.data ) {
@@ -331,7 +331,7 @@ export const normalizers = {
 	 * Returns a normalized statsTags array, ready for use in stats-module
 	 *
 	 * @param  {Object} data Stats data
-	 * @return {Array}       Parsed publicize data array
+	 * @return {Array}       Parsed data array
 	 */
 	statsTags( data ) {
 		if ( ! data || ! data.tags ) {
@@ -380,7 +380,7 @@ export const normalizers = {
 	 * @param  {Object} data   Stats data
 	 * @param  {Object} query  Stats query
 	 * @param  {Int}    siteId Site ID
-	 * @return {Array}        Parsed publicize data array
+	 * @return {Array}         Parsed data array
 	 */
 	statsReferrers( data, query, siteId ) {
 		if ( ! data || ! query.period || ! query.date ) {
@@ -432,5 +432,41 @@ export const normalizers = {
 				actionMenu: actions.length
 			};
 		} );
+	},
+
+	/*
+	 * Returns a normalized statsSearchTerms array, ready for use in stats-module
+	 *
+	 * @param  {Object} data   Stats data
+	 * @param  {Object} query  Stats query
+	 * @return {Array}         Parsed data array
+	 */
+	statsSearchTerms( data, query ) {
+		if ( ! data || ! query.period || ! query.date ) {
+			return [];
+		}
+
+		const { startOf } = rangeOfPeriod( query.period, query.date );
+		const searchTerms = get( data, [ 'days', startOf, 'search_terms' ], [] );
+		const encryptedSearchTerms = get( data, [ 'days', startOf, 'encrypted_search_terms' ], false );
+
+		const result = searchTerms.map( ( day ) => {
+			return {
+				label: day.term,
+				className: 'user-selectable',
+				value: day.views
+			};
+		} );
+
+		if ( encryptedSearchTerms ) {
+			result.push( {
+				label: translate( 'Unknown Search Terms' ),
+				value: encryptedSearchTerms,
+				link: 'http://en.support.wordpress.com/stats/#search-engine-terms',
+				labelIcon: 'external'
+			} );
+		}
+
+		return result;
 	}
 };


### PR DESCRIPTION
Closes #10633 

In this PR, I moved the parser logic for statsSearchTerms from StatsList into the redux stats subtree. I also updated the searchTerm stats module to use the StatsConnectedModule Component.

**Notes**

 - I had to use `translate` directly on the normalizer (the alternative would be to flag the label untranslated and translate on the component side?)

**Testing instructions**

 - Navigate to the stats page /stats/day/$site
 - The Search Terms panel should work properly (same as master)
 - Click on the header of the panel to navigate to the summary page
 - The search terms stats should show up (same as master)

