### PR TITLE
State: Allow domain to be null in billing transactions schema

### DIFF
--- a/client/state/billing-transactions/schema.js
+++ b/client/state/billing-transactions/schema.js
@@ -45,7 +45,7 @@ export const billingTransactionsSchema = {
 					product: { type: 'string' },
 					interval: { type: 'string' },
 					icon: { type: 'string' },
-					domain: { type: 'string' },
+					domain: { type: [ 'string', 'null' ] },
 				},
 			},
 		},


### PR DESCRIPTION
This PR updates transaction schema to allow domain to be null - as reported here: https://github.com/Automattic/wp-calypso/pull/10684#issuecomment-273231756. This PR is part of the billing reduxification effort - #10554.

To test this:
* Checkout this branch
* Clear your Redux state
* Go to `/me/purchases/billing`
* After transactions load, verify there are no state validation warnings.

@gwwar since I'm unable to reproduce this with my transactions, I'll need you to test it for me.