### PR TITLE
Stats: Use stats redux subtree for Clicks Stats

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -338,8 +338,6 @@ module.exports = {
 				stat_fields: 'views,visitors,likes,comments,post_titles', domain: siteDomain } );
 			const postsPagesList = new StatsList( {
 				siteID: siteId, statType: 'statsTopPosts', period: activeFilter.period, date: endDate, domain: siteDomain } );
-			const clicksList = new StatsList( {
-				siteID: siteId, statType: 'statsClicks', period: activeFilter.period, date: endDate, domain: siteDomain } );
 
 			siteComponent = SiteStatsComponent;
 			const siteComponentChildren = {
@@ -352,7 +350,6 @@ module.exports = {
 				activeTabVisitsList,
 				visitsList,
 				postsPagesList,
-				clicksList,
 				siteId,
 				period,
 				chartPeriod,
@@ -472,9 +469,7 @@ module.exports = {
 					break;
 
 				case 'clicks':
-					summaryList = new StatsList( {
-						statType: 'statsClicks', siteID: siteId, period: activeFilter.period,
-						date: endDate, max: 0, domain: siteDomain } );
+					summaryList = fakeStatsList;
 					break;
 
 				case 'countryviews':

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -184,14 +184,14 @@ module.exports = React.createClass( {
 								date={ queryDate }
 								statType="statsReferrers"
 								showSummaryLink />
-							<StatsModule
-								path={ 'clicks' }
+							<StatsConnectedModule
+								path="clicks"
 								moduleStrings={ moduleStrings.clicks }
-								site={ site }
-								dataList={ this.props.clicksList }
 								period={ this.props.period }
+								query={ query }
 								date={ queryDate }
-								beforeNavigate={ this.updateScrollPosition } />
+								statType="statsClicks"
+								showSummaryLink />
 							<StatsConnectedModule
 								path="authors"
 								moduleStrings={ moduleStrings.authors }

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -96,14 +96,14 @@ const StatsSummary = React.createClass( {
 
 			case 'clicks':
 				title = translate( 'Clicks' );
-				summaryView = <StatsModule
+				summaryView = <StatsConnectedModule
 					key="clicks-summary"
-					path={ 'clicks' }
+					path="clicks"
 					moduleStrings={ StatsStrings.clicks }
-					site={ site }
-					dataList={ this.props.summaryList }
 					period={ this.props.period }
-					summary={ true } />;
+					query={ query }
+					statType="statsClicks"
+					summary />;
 				break;
 
 			case 'countryviews':

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -875,6 +875,85 @@ describe( 'utils', () => {
 				] );
 			} );
 
+			describe( 'statsClicks()', () => {
+				it( 'should return an empty array if not data is passed', () => {
+					const parsedData = normalizers.statsClicks();
+					expect( parsedData ).to.eql( [] );
+				} );
+
+				it( 'should return an empty array if query.period is null', () => {
+					const parsedData = normalizers.statsClicks( {}, { date: '2016-12-25' } );
+					expect( parsedData ).to.eql( [] );
+				} );
+
+				it( 'should return an empty array if query.date is null', () => {
+					const parsedData = normalizers.statsClicks( {}, { period: 'day' } );
+					expect( parsedData ).to.eql( [] );
+				} );
+
+				it( 'should return an a properly parsed data array', () => {
+					const parsedData = normalizers.statsClicks( {
+						date: '2017-01-12',
+						days: {
+							'2017-01-12': {
+								clicks: [
+									{
+										icon: 'https://secure.gravatar.com/blavatar/94ea57385f5018d2b84169cab22d3b33?s=48',
+										name: 'en.support.wordpress.com',
+										url: null,
+										views: 45,
+										children: [
+											{
+												name: 'en.support.wordpress.com',
+												url: 'https://en.support.wordpress.com/',
+												views: 5
+											}
+										]
+									},
+									{
+										children: null,
+										icon: 'https://secure.gravatar.com/blavatar/3dbcb399a9112e3bb46f706b01c80062?s=48',
+										name: 'en.forums.wordpress.com',
+										url: 'https://en.forums.wordpress.com/',
+										views: 6
+									}
+								]
+							}
+						}
+					}, {
+						period: 'day',
+						date: '2017-01-12'
+					} );
+
+					expect( parsedData ).to.eql( [
+						{
+							children: [
+								{
+									children: null,
+									label: 'en.support.wordpress.com',
+									labelIcon: 'external',
+									link: 'https://en.support.wordpress.com/',
+									value: 5
+								}
+							],
+							icon: 'https://secure.gravatar.com/blavatar/94ea57385f5018d2b84169cab22d3b33?s=48',
+							label: 'en.support.wordpress.com',
+							labelIcon: null,
+							link: null,
+							value: 45
+						},
+						{
+							children: null,
+							icon: 'https://secure.gravatar.com/blavatar/3dbcb399a9112e3bb46f706b01c80062?s=48',
+							label: 'en.forums.wordpress.com',
+							labelIcon: 'external',
+							link: 'https://en.forums.wordpress.com/',
+							value: 6
+						}
+					] );
+				} );
+			} );
+
 			describe( 'statsReferrers()', () => {
 				it( 'should return an empty array if not data is passed', () => {
 					const parsedData = normalizers.statsReferrers();

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -375,6 +375,48 @@ export const normalizers = {
 	},
 
 	/*
+	 * Returns a normalized statsClicks array, ready for use in stats-module
+	 *
+	 * @param  {Object} data   Stats data
+	 * @param  {Object} query  Stats query
+	 * @return {Array}        Parsed data array
+	 */
+	statsClicks( data, query ) {
+		if ( ! data || ! query.period || ! query.date ) {
+			return [];
+		}
+
+		const { startOf } = rangeOfPeriod( query.period, query.date );
+		const statsData = get( data, [ 'days', startOf, 'clicks' ], [] );
+
+		return statsData.map( ( item ) => {
+			const hasChildren = item.children && item.children.length > 0;
+			const newRecord = {
+				label: item.name,
+				value: item.views,
+				children: null,
+				link: item.url,
+				icon: item.icon,
+				labelIcon: hasChildren ? null : 'external'
+			};
+
+			if ( item.children ) {
+				newRecord.children = item.children.map( ( child ) => {
+					return {
+						label: child.name,
+						value: child.views,
+						children: null,
+						link: child.url,
+						labelIcon: 'external'
+					};
+				} );
+			}
+
+			return newRecord;
+		} );
+	},
+
+	/*
 	 * Returns a normalized statsReferrers array, ready for use in stats-module
 	 *
 	 * @param  {Object} data   Stats data


### PR DESCRIPTION
Yet another stats normalizer :)

Closes #10626 

In this PR, I moved the parser logic for statsClicks from StatsList into the redux stats subtree. I also updated the searchTerm stats module to use the StatsConnectedModule Component.

**Testing instructions**

 - Navigate to the stats page /stats/day/$site
 - The Clicks panel should work properly (same as master)
 - Click on the header of the panel to navigate to the summary page
 - The clicks stats should show up (same as master)

