### PR TITLE
Themes: Add mobile view styling for themes upload card.

### DIFF
--- a/client/my-sites/themes/themes-upload-card/style.scss
+++ b/client/my-sites/themes/themes-upload-card/style.scss
@@ -12,6 +12,32 @@
 	}
 
 	.button {
+		color: $gray-dark;
 		float: right;
+
+		&.is-compact {
+			.gridicon {
+				top: 6px;
+				padding-right: 4px;
+			}
+		}
 	}
+
+	@include breakpoint( "<480px" ) {
+		.card {
+			padding-left: 15px;
+			padding-right: 15px;
+		}
+
+		.button {
+			font-size: 0;
+
+			&.is-compact {
+				.gridicon {
+					padding: 0;
+				}
+			}
+		}
+	}
+
 }


### PR DESCRIPTION
### Info
Current upload card was lacking styling appropriate for mobile screen widths.

### Before
![image](https://cloud.githubusercontent.com/assets/17271089/22063672/4bf8751e-dd80-11e6-96b1-206b378bc148.png)

### New
![image](https://cloud.githubusercontent.com/assets/17271089/22063706/7ef34fa2-dd80-11e6-894e-548c6f79cc1c.png)

^ old not rebased label :/, will be _Uploaded themes_ after merge.

### Testing
Open `/design` and observe themes upload card while changing view from desktop to mobile. 