### PR TITLE
JPC: Add more info to the error tracking in jpc

### DIFF
--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -367,6 +367,9 @@ export default {
 				debug( 'Authorize error', error );
 				tracksEvent( dispatch, 'calypso_jpc_authorize_error', {
 					error_code: error.code,
+					error_name: error.name,
+					error_message: error.message,
+					status: error.status,
 					error: JSON.stringify( error ),
 					site: client_id
 				} );


### PR DESCRIPTION
Quick PR to add further info to the authorize error events we are tracking