### PR TITLE
Domains: Create a page for domain only sites in place of Domains list

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -113,7 +113,7 @@ function renderNoVisibleSites( context ) {
 
 function isPathAllowedForDomainOnlySite( pathname, domainName ) {
 	const urlPrefixesWhiteListForDomainOnlySite = [
-		`/domains/manage/${ domainName }`,
+		domainManagementList( domainName ),
 		'/checkout/',
 	];
 

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -111,9 +111,9 @@ function renderNoVisibleSites( context ) {
 	);
 }
 
-function isPathAllowedForDomainOnlySite( pathname ) {
+function isPathAllowedForDomainOnlySite( pathname, domainName ) {
 	const urlPrefixesWhiteListForDomainOnlySite = [
-		'/domains/manage/',
+		`/domains/manage/${ domainName }`,
 		'/checkout/',
 	];
 
@@ -128,7 +128,7 @@ function onSelectedSiteAvailable( context ) {
 	const state = context.store.getState();
 
 	if ( isDomainOnlySite( state, selectedSite.ID ) &&
-		! isPathAllowedForDomainOnlySite( context.pathname ) ) {
+		! isPathAllowedForDomainOnlySite( context.pathname, selectedSite.slug ) ) {
 		page.redirect( domainManagementList( selectedSite.slug ) );
 		return false;
 	}

--- a/client/my-sites/upgrades/domain-management/list/domain-only.jsx
+++ b/client/my-sites/upgrades/domain-management/list/domain-only.jsx
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import EmptyContent from 'components/empty-content';
+import { domainManagementEdit } from 'my-sites/upgrades/paths';
+
+const DomainOnly = ( { domainName, translate } ) => (
+	<EmptyContent
+		title={ translate( '%(domainName)s is not set up yet.', {
+			args: { domainName }
+		} ) }
+		action={ translate( 'Advanced' ) }
+		actionURL={ domainManagementEdit( domainName, domainName ) }
+		illustration={ '/calypso/images/drake/drake-browser.svg' } />
+);
+
+DomainOnly.propTypes = {
+	domainName: PropTypes.string.isRequired,
+	translate: PropTypes.func.isRequired,
+};
+
+export default localize( DomainOnly );

--- a/client/my-sites/upgrades/domain-management/list/index.jsx
+++ b/client/my-sites/upgrades/domain-management/list/index.jsx
@@ -13,6 +13,7 @@ import { connect } from 'react-redux';
 import analyticsMixin from 'lib/mixins/analytics';
 import config from 'config';
 import DomainWarnings from 'my-sites/upgrades/components/domain-warnings';
+import DomainOnly from './domain-only';
 import ListItem from './item';
 import ListItemPlaceholder from './item-placeholder';
 import Main from 'components/main';
@@ -35,6 +36,7 @@ import NoticeAction from 'components/notice/notice-action';
 import { hasDomainCredit } from 'state/sites/plans/selectors';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { isDomainOnlySite } from 'state/selectors';
 import { isPlanFeaturesEnabled } from 'lib/plans';
 import DomainToPlanNudge from 'blocks/domain-to-plan-nudge';
 
@@ -87,11 +89,21 @@ export const List = React.createClass( {
 	},
 
 	render() {
-		const headerText = this.translate( 'Domains', { context: 'A navigation label.' } );
-
 		if ( ! this.props.domains ) {
 			return null;
 		}
+
+		if ( this.props.isDomainOnly ) {
+			return (
+				<Main>
+					<SidebarNavigation />
+					<DomainOnly
+						domainName={ this.props.selectedSite.domain } />
+				</Main>
+			);
+		}
+
+		const headerText = this.translate( 'Domains', { context: 'A navigation label.' } );
 
 		return (
 			<Main wideLayout={ isPlanFeaturesEnabled() }>
@@ -338,8 +350,11 @@ export const List = React.createClass( {
 } );
 
 export default connect( ( state, ownProps ) => {
+	const siteId = ownProps.selectedSite.ID;
+
 	return {
-		hasDomainCredit: !! ownProps.selectedSite && hasDomainCredit( state, ownProps.selectedSite.ID )
+		hasDomainCredit: !! ownProps.selectedSite && hasDomainCredit( state, siteId ),
+		isDomainOnly: isDomainOnlySite( state, siteId ),
 	};
 }, ( dispatch ) => {
 	return {


### PR DESCRIPTION
This will use the route `/domains/manage/:siteName` that in regular sites displays a list of domains. There should be Advanced button which links to the domain management tools that live in `/domains/manage/:domainName/edit/:siteName`.

<img width="1221" alt="screen shot 2017-01-18 at 15 36 49" src="https://cloud.githubusercontent.com/assets/699132/22078204/8c63e6a6-ddb7-11e6-9915-cc406fc79f41.png">

In the prototype we have also another button which navigates to the upgrade flow. I omitted it on purpose from this change. I think it makes more sense to add it later when we have upgrade flow implemented.

This PR assumes that domain only site has the primary domain set to the purchased domain.

I also added change to make sure that all domain settings pages for non-primary domains are redirected to the landing page.

### Testing
1. Open http://calypso.localhost:3000/ or Calypso live branch (link below).
2. Click My Sites.
3. Select a domain only site.
4. You should see a new landing page.
5. Click on Advanced link.
6. You should see Domain Settings page where you can manage the domain.
7. Click back link.
8. You should be on the landing page again.
9. Switch to another regular site.
10. Go to Domains page.
11. You should see list of domains as usual.

### Review

* [x] Code
* [x] Product