### PR TITLE
Fix Accordion interaction test example

### DIFF
--- a/docs/react-component-unit-testing.md
+++ b/docs/react-component-unit-testing.md
@@ -53,6 +53,7 @@ Example test from `client/components/Accordion`
 
 ```javascript
 import { shallow } from 'enzyme';
+import { expect } from 'chai';
 
 it( 'should accept an onToggle function handler to be invoked when toggled', function( done ) {
   const wrapper = shallow( <Accordion title="Section" onToggle={ finishTest }>Content</Accordion> );

--- a/docs/react-component-unit-testing.md
+++ b/docs/react-component-unit-testing.md
@@ -56,21 +56,21 @@ import { shallow } from 'enzyme';
 import { expect } from 'chai';
 
 it( 'should accept an onToggle function handler to be invoked when toggled', function( done ) {
-  const wrapper = shallow( <Accordion title="Section" onToggle={ finishTest }>Content</Accordion> );
+	const wrapper = shallow( <Accordion title="Section" onToggle={ finishTest }>Content</Accordion> );
 
-  // Simulate a click event to toggle expanding state
-  wrapper.find( '.accordion__toggle' ).simulate( 'click' );
+	// Simulate a click event to toggle expanding state
+	wrapper.find( '.accordion__toggle' ).simulate( 'click' );
 
-  function finishTest( isExpanded ) {
-    // Check that it received the toggled state (the component is initially collapsed/not expanded)
-    expect( isExpanded ).to.be.true;
+	function finishTest( isExpanded ) {
+		// Check that it received the toggled state (the component is initially collapsed/not expanded)
+		expect( isExpanded ).to.be.true;
 
-    process.nextTick( function() {
-      // Check that the component is expanded
-      expect( wrapper ).to.have.state( 'isExpanded' ).be.true;
-      done();
-    } );
-  }
+		process.nextTick( function() {
+			// Check that the component is expanded
+			expect( wrapper ).to.have.state( 'isExpanded' ).be.true;
+			done();
+		} );
+	}
 } );
 ```
 
@@ -112,22 +112,22 @@ So we test it like this:
 ```javascript
 
 this.props = {
-    themes: [
-        {
-            name: 'kubrick',
-            screenshot: '/theme/kubrick/screenshot.png',
-        },
-        {
-            name: 'picard',
-            screenshot: '/theme/picard/screenshot.png',
-        }
-    ]
+	themes: [
+		{
+			name: 'kubrick',
+			screenshot: '/theme/kubrick/screenshot.png',
+		},
+		{
+			name: 'picard',
+			screenshot: '/theme/picard/screenshot.png',
+		}
+	]
 };
 
 var shallowRenderer = React.addons.TestUtils.createRenderer();
 
 shallowRenderer.render(
-    React.createElement( ThemesList, this.props )
+	React.createElement( ThemesList, this.props )
 );
 
 this.themesList = shallowRenderer.getRenderOutput();

--- a/docs/react-component-unit-testing.md
+++ b/docs/react-component-unit-testing.md
@@ -54,15 +54,18 @@ Example test from `client/components/Accordion`
 ```javascript
 import { shallow } from 'enzyme';
 
-it( 'should toggled', function( done ) {
+it( 'should accept an onToggle function handler to be invoked when toggled', function( done ) {
   const wrapper = shallow( <Accordion title="Section" onToggle={ finishTest }>Content</Accordion> );
 
+  // Simulate a click event to toggle expanding state
   wrapper.find( '.accordion__toggle' ).simulate( 'click' );
 
   function finishTest( isExpanded ) {
+    // Check that it received the toggled state (the component is initially collapsed/not expanded)
     expect( isExpanded ).to.be.true;
 
     process.nextTick( function() {
+      // Check that the component is expanded
       expect( wrapper ).to.have.state( 'isExpanded' ).be.true;
       done();
     } );

--- a/docs/react-component-unit-testing.md
+++ b/docs/react-component-unit-testing.md
@@ -54,19 +54,20 @@ Example test from `client/components/Accordion`
 ```javascript
 import { shallow } from 'enzyme';
 
-const wrapper = shallow( <Accordion title="Section" onToggle={ finishTest }>Content</Accordion> );
+it( 'should toggled', function( done ) {
+  const wrapper = shallow( <Accordion title="Section" onToggle={ finishTest }>Content</Accordion> );
 
-wrapper.find( '.accordion__toggle' ).simulate( 'click' );
-);
+  wrapper.find( '.accordion__toggle' ).simulate( 'click' );
 
-function finishTest( isExpanded ) {
-	expect( isExpanded ).to.be.ok;
+  function finishTest( isExpanded ) {
+    expect( isExpanded ).to.be.true;
 
-	process.nextTick( function() {
-		expect( tree.isExpanded() ).to.be.ok;
-		done();
-	} );
-}
+    process.nextTick( function() {
+      expect( wrapper ).to.have.state( 'isExpanded' ).be.true;
+      done();
+    } );
+  }
+} );
 ```
 
 ## [Techniques for avoiding calling other than the targeted code](#techniques-for-avoiding-calling-other-code)


### PR DESCRIPTION
Fixed several issues in old test example (it's actually copied from current unit test code with a little modification):

- Include entire `it` function so it's easier to understand, especially know where `done` is from.
- Remove redundant ');'
- to.be.true is more suitable with `isExpanded`
- `wrapper` instead of `tree`