### PR TITLE
Ad Tracking: Add DCM Floodlight tracking for sign up events

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -519,7 +519,7 @@ function recordAliasInFloodlight() {
 
 	const params = {
 		src: TRACKING_IDS.dcmFloodlightAdvertiserId,
-		type: 'wpsal0',
+		type: 'wordp0',
 		cat: 'alias0',
 		ord: floodlightCacheBuster()
 	};

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -4,9 +4,11 @@
 import async from 'async';
 import noop from 'lodash/noop';
 import some from 'lodash/some';
+import assign from 'lodash/assign';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:ad-tracking' );
 import { clone, cloneDeep } from 'lodash';
+import cookie from 'cookie';
 
 /**
  * Internal dependencies
@@ -487,11 +489,8 @@ function recordOrderInFloodlight( cart, orderId ) {
 		return;
 	}
 
-	const currentUser = user.get();
+	debug( 'recordOrderInFloodlight: Record purchase' );
 
-	// Originally `u1` was going to be the cost, but because that is already passed as the `cost` parameter
-	// there's no need to include it separately. `u5` is the anonymous user id, but because all purchases
-	// are made by logged in users there's no need to include that either.
 	const params = {
 		src: TRACKING_IDS.dcmFloodlightAdvertiserId,
 		type: 'wpsal0',
@@ -500,7 +499,6 @@ function recordOrderInFloodlight( cart, orderId ) {
 		cost: cart.total_cost,
 		u2: cart.products.map( product => product.product_name ).join( ', ' ),
 		u3: cart.currency,
-		u4: currentUser ? currentUser.ID : 0,
 		ord: orderId
 	};
 
@@ -510,37 +508,98 @@ function recordOrderInFloodlight( cart, orderId ) {
 /**
  * Records the anonymous user id and wpcom user id in DCM Floodlight
  *
- * @param {String} anonymousUserId - The anonymous user id
- * @param {Number} wpcomUserId - The WordPress.com user id
  * @returns {void}
  */
-function recordAliasInFloodlight( anonymousUserId, wpcomUserId ) {
+function recordAliasInFloodlight() {
 	if ( ! config.isEnabled( 'ad-tracking' ) ) {
 		return;
 	}
 
-	if ( ! anonymousUserId ) {
-		debug( 'recordAliasInFloodlight:, Missing anonymousUserId' );
-		return;
-	}
-
-	if ( ! wpcomUserId ) {
-		debug( 'recordAliasInFloodlight:, Missing wpcomUserId' );
-		return;
-	}
-
-	debug( `recordAliasInFloodlight: Aliasing anonymous user id '${ anonymousUserId }' with WordPress.com user id '${ wpcomUserId }'` );
+	debug( 'recordAliasInFloodlight: Aliasing anonymous user id with WordPress.com user id' );
 
 	const params = {
 		src: TRACKING_IDS.dcmFloodlightAdvertiserId,
 		type: 'wpsal0',
 		cat: 'alias0',
-		u4: wpcomUserId,
-		u5: anonymousUserId,
 		ord: floodlightCacheBuster()
 	};
 
 	recordParamsInFloodlight( params );
+}
+
+/**
+ * Record that a user started sign up in DCM Floodlight
+ *
+ * @returns {void}
+ */
+function recordSignupStartInFloodlight() {
+	if ( ! config.isEnabled( 'ad-tracking' ) ) {
+		return;
+	}
+
+	debug( 'DCM Floodlight: Recording sign up start' );
+
+	const params = {
+		src: TRACKING_IDS.dcmFloodlightAdvertiserId,
+		type: 'wordp0',
+		cat: 'signu0',
+		ord: floodlightCacheBuster()
+	};
+
+	recordParamsInFloodlight( params );
+}
+
+/**
+ * Record that a user signed up in DCM Floodlight
+ *
+ * @returns {void}
+ */
+function recordSignupCompletionInFloodlight() {
+	if ( ! config.isEnabled( 'ad-tracking' ) ) {
+		return;
+	}
+
+	debug( 'DCM Floodlight: Recording sign up completion' );
+
+	const params = {
+		src: TRACKING_IDS.dcmFloodlightAdvertiserId,
+		type: 'wordp0',
+		cat: 'signu0',
+		ord: floodlightCacheBuster()
+	};
+
+	recordParamsInFloodlight( params );
+}
+
+/**
+ * Returns an object with DCM Floodlight user params
+ *
+ * @returns {Object} With the WordPress.com user id and/or the logged out Tracks id
+ */
+function floodlightUserParams() {
+	const params = {};
+
+	const currentUser = user.get();
+	if ( currentUser ) {
+		params.u4 = currentUser.ID;
+	}
+
+	const anonymousUserId = tracksAnonymousUserId();
+	if ( anonymousUserId ) {
+		params.u5 = anonymousUserId;
+	}
+
+	return params;
+}
+
+/**
+ * Returns the anoymous id stored in the `tk_ai` cookie
+ *
+ * @returns {String} - The Tracks anonymous user id
+ */
+function tracksAnonymousUserId() {
+	const cookies = cookie.parse( document.cookie );
+	return cookies.tk_ai;
 }
 
 /**
@@ -553,6 +612,9 @@ function recordParamsInFloodlight( params ) {
 	if ( ! config.isEnabled( 'ad-tracking' ) ) {
 		return;
 	}
+
+	// Add in the u4 and u5 params
+	params = assign( params, floodlightUserParams() );
 
 	debug( 'recordParamsInFloodlight:', params );
 
@@ -767,6 +829,24 @@ function isSupportedCurrency( currency ) {
 	return Object.keys( EXCHANGE_RATES ).indexOf( currency ) !== -1;
 }
 
+/**
+ * Record that a user started sign up
+ *
+ * @returns {void}
+ */
+function recordSignupStart() {
+	recordSignupStartInFloodlight();
+}
+
+/**
+ * Record that a user completed sign up
+ *
+ * @returns {void}
+ */
+function recordSignupCompletion() {
+	recordSignupCompletionInFloodlight();
+}
+
 module.exports = {
 	retarget: function( context, next ) {
 		const nextFunction = typeof next === 'function' ? next : noop;
@@ -782,5 +862,7 @@ module.exports = {
 	retargetViewPlans,
 	recordAddToCart,
 	recordViewCheckout,
-	recordOrder
+	recordOrder,
+	recordSignupStart,
+	recordSignupCompletion
 };

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -542,7 +542,7 @@ function recordSignupStartInFloodlight() {
 	const params = {
 		src: TRACKING_IDS.dcmFloodlightAdvertiserId,
 		type: 'wordp0',
-		cat: 'signu0',
+		cat: 'pre-p0',
 		ord: floodlightCacheBuster()
 	};
 

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -325,7 +325,7 @@ var analytics = {
 		// Don't identify the user if we don't have one
 		if ( _user && _user.initialized ) {
 			if ( anonymousUserId ) {
-				recordAliasInFloodlight( anonymousUserId, _user.get().ID );
+				recordAliasInFloodlight();
 			}
 
 			window._tkq.push( [ 'identifyUser', _user.get().ID, _user.get().username ] );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -44,6 +44,7 @@ import * as oauthToken from 'lib/oauth-token';
 import DocumentHead from 'components/data/document-head';
 import { translate } from 'i18n-calypso';
 import SignupActions from 'lib/signup/actions';
+import { recordSignupStart, recordSignupCompletion } from 'lib/analytics/ad-tracking';
 
 /**
  * Constants
@@ -119,6 +120,7 @@ const Signup = React.createClass( {
 			flow: this.props.flowName,
 			ref: this.props.refParameter
 		} );
+		recordSignupStart();
 
 		this.submitQueryDependencies();
 
@@ -201,6 +203,7 @@ const Signup = React.createClass( {
 		debug( 'The flow is completed. Logging you in...' );
 
 		analytics.tracks.recordEvent( 'calypso_signup_complete', { flow: this.props.flowName } );
+		recordSignupCompletion();
 
 		this.signupFlowController.reset();
 		if ( dependencies.cartItem || dependencies.domainItem || this.signupFlowController.shouldAutoContinue() ) {


### PR DESCRIPTION
This PR adds two new DCM Floodlight events: one for when users start the NUX and one for when they complete the NUX.

Along the way, I also refactored how some of the other DCM tracking code works to reduce code duplication with getting and setting the u4 (logged in) and u5 (logged out) user id parameters.

## Testing

Because these changes touch all existing DCM Floodlight tracking, it's necessary to test all of the actions that trigger Floodlights. No need to check the network activity for these; we've tested that in earlier PRs so doesn't add much value here.

1. Set `ad-tracking` to `true` in `development.json`.

2. Enable logging: 

```localStorage.setItem( 'debug', 'calypso:ad-tracking' );```

3. In an incognito window, [start the NUX](calypso.localhost:3000/start/website/en/?ref=homepage). You should see a `pre-p0` event with a `u5` parameter:

![screen shot 2017-01-18 at 10 49 57 am](https://cloud.githubusercontent.com/assets/44436/22071025/e29ff042-dd6b-11e6-8d96-fb64a9d16b3f.png)

4. Complete sign up. You should see a `signu0` event with a `u5` parameter (because the WordPress.com user hasn't been set yet):

![screen shot 2017-01-18 at 10 32 14 am](https://cloud.githubusercontent.com/assets/44436/22070762/1e42ff78-dd6b-11e6-826a-bbe14146ce11.png)

5. After you sign up you'll be redirected to your new site's WordPress.com subdomain. Head back to local Calypso: calypso.localhost:3000.

6. You should now see the the `alias0` alias event with both a `u4` and `u5` parameter:

![screen shot 2017-01-18 at 11 04 16 am](https://cloud.githubusercontent.com/assets/44436/22071687/e6c5e486-dd6d-11e6-9fd9-6d64ad672396.png)

7. Complete a purchase. You should see a `wpsale` event with a `u4` parameter:

![screen shot 2017-01-18 at 10 34 46 am](https://cloud.githubusercontent.com/assets/44436/22070819/56a44020-dd6b-11e6-92b8-b40f11589c03.png)

8. Now we're going to go through the NUX again but as an existing user. Go to My Sites > Add a New Site. You should see a `pre-p0` event with a `u4` param:

![screen shot 2017-01-18 at 10 57 12 am](https://cloud.githubusercontent.com/assets/44436/22071363/e9d03fba-dd6c-11e6-88fa-1e81e2b3cd3b.png)

9. Complete sign up. You should see the `signu0` event with a `u4` param:

![screen shot 2017-01-18 at 10 36 08 am](https://cloud.githubusercontent.com/assets/44436/22070905/86b0743c-dd6b-11e6-82af-be63e13adcd7.png)

10. Celebrate with an ice cold beer 🍻