### PR TITLE
Posts: Cleaner Post Controls component

### DIFF
--- a/client/my-sites/posts/post-controls.jsx
+++ b/client/my-sites/posts/post-controls.jsx
@@ -1,251 +1,243 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' ),
-	url = require( 'url' );
-import classNames from 'classnames';
+import React, { PropTypes, PureComponent } from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import url from 'url';
+import classNames from 'classnames';
 import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
-var config = require( 'config' ),
-	utils = require( 'lib/posts/utils' ),
-	Gridicon = require( 'components/gridicon'),
-	recordEvent = require( 'lib/analytics' ).ga.recordEvent;
+import { isEnabled } from 'config';
+import { ga } from 'lib/analytics';
+import { userCan } from 'lib/posts/utils';
 import { isPublicizeEnabled } from 'state/selectors';
+import Gridicon from 'components/gridicon';
 
-const PostControls = React.createClass( {
-	mixins: [ PureRenderMixin ],
+export class PostControls extends PureComponent {
 
-	propTypes: {
-		post: React.PropTypes.object.isRequired,
-		editURL: React.PropTypes.string.isRequired,
-		isPublicizeEnabled: React.PropTypes.bool.isRequired,
-		onShowMore: React.PropTypes.func.isRequired,
-		onHideMore: React.PropTypes.func.isRequired,
-		onPublish: React.PropTypes.func,
-		onTrash: React.PropTypes.func,
-		onDelete: React.PropTypes.func,
-		onRestore: React.PropTypes.func,
-	},
+	static propTypes = {
+		editURL: PropTypes.string.isRequired,
+		fullWidth: PropTypes.bool,
+		isPublicizeEnabled: PropTypes.bool,
+		onDelete: PropTypes.func,
+		onHideMore: PropTypes.func.isRequired,
+		onPublish: PropTypes.func,
+		onRestore: PropTypes.func,
+		onShowMore: PropTypes.func.isRequired,
+		onToggleShare: PropTypes.func,
+		onTrash: PropTypes.func,
+		post: PropTypes.object.isRequired,
+	};
 
-	view: function() {
-		recordEvent( 'Posts', 'Clicked View Post' );
-	},
+	view() {
+		ga.recordEvent( 'Posts', 'Clicked View Post' );
+	}
 
-	preview: function() {
-		recordEvent( 'Posts', 'Clicked Preview Post' );
-	},
+	preview() {
+		ga.recordEvent( 'Posts', 'Clicked Preview Post' );
+	}
 
-	edit: function() {
-		recordEvent( 'Posts', 'Clicked Edit Post' );
-	},
+	edit() {
+		ga.recordEvent( 'Posts', 'Clicked Edit Post' );
+	}
 
-	copy: function() {
-		recordEvent( 'Posts', 'Clicked Copy Post' );
-	},
+	copy() {
+		ga.recordEvent( 'Posts', 'Clicked Copy Post' );
+	}
 
-	viewStats: function() {
-		recordEvent( 'Posts', 'Clicked View Post Stats' );
-	},
+	viewStats() {
+		ga.recordEvent( 'Posts', 'Clicked View Post Stats' );
+	}
 
-	buildControls: function( controlsArray ) {
-		var postId = this.props.post.ID,
-			controls;
+	getControlElements = controls => controls.map( ( control, index ) =>
+		<li
+			className={ classNames( { 'post-controls__disabled': control.disabled } ) }
+			key={ index }
+		>
+			<a
+				className={ `post-controls__${ control.className }` }
+				href={ control.href }
+				onClick={ control.disabled ? noop : control.onClick }
+				target={ control.target ? control.target : null }
+			>
+				<Gridicon icon={ control.icon } size={ 18 } />
+				<span>
+					{ control.text }
+				</span>
+			</a>
+		</li>
+	);
 
-		controls = controlsArray.map( function( item, i ) {
-			const itemKey = 'controls-' + postId + '-' + i;
-			const disabled = item.disabled || false;
-
-			return (
-				<li className={ classNames( { 'post-controls__disabled': disabled } ) } key={ itemKey }>
-					<a href={ item.href } className={ item.className } onClick={ disabled ? noop : item.onClick } target={ item.target ? item.target : null }>
-						<Gridicon icon={ item.icon } size={ 18 } />
-						<span>{ item.text }</span>
-					</a>
-				</li>
-			);
-		}, this );
-
-		return controls;
-	},
-
-	render: function() {
-		var post = this.props.post,
-			availableControls = [],
-			extraControls = [],
-			parsed, previewURL, statsURL, postControlsClass, mainControls, moreControls, i, moreControlsSpliceIndex;
+	getAvailableControls() {
+		const {
+			editURL,
+			fullWidth,
+			onDelete,
+			onHideMore,
+			onPublish,
+			onRestore,
+			onShowMore,
+			onToggleShare,
+			onTrash,
+			post,
+			site,
+			translate,
+		} = this.props;
+		const controls = { main: [], more: [] };
 
 		// NOTE: Currently Jetpack site posts are not returning `post.capabilities`
 		// and those posts will not have access to post management type controls
 
-		// --- Main Controls (not behind ... more link) ---
-		if ( utils.userCan( 'edit_post', post ) ) {
-			availableControls.push( {
-				text: this.translate( 'Edit' ),
-				className: 'post-controls__edit',
-				href: this.props.editURL,
-				target: null,
+		// Main Controls (not behind ... more link)
+		if ( userCan( 'edit_post', post ) ) {
+			controls.main.push( {
+				className: 'edit',
+				href: editURL,
+				icon: 'pencil',
 				onClick: this.edit,
-				icon: 'pencil'
+				text: translate( 'Edit' ),
 			} );
 		}
 
-		if ( post.status === 'publish' ) {
-			availableControls.push( {
-				text: this.translate( 'View' ),
-				className: 'post-controls__view',
+		if ( 'publish' === post.status ) {
+			controls.main.push( {
+				className: 'view',
 				href: post.URL,
-				target: '_blank',
+				icon: 'external',
 				onClick: this.view,
-				icon: 'external'
+				target: '_blank',
+				text: translate( 'View' ),
 			} );
 
-			statsURL = '/stats/post/' + post.ID + '/' + this.props.site.slug;
-
-			availableControls.push( {
-				text: this.translate( 'Stats' ),
-				className: 'post-controls__stats',
-				href: statsURL,
+			controls.main.push( {
+				className: 'stats',
+				href: `/stats/post/${ post.ID }/${ site.slug }`,
+				icon: 'stats-alt',
 				onClick: this.viewStats,
-				icon: 'stats-alt'
+				text: translate( 'Stats' ),
 			} );
 
-			if ( config.isEnabled( 'republicize' ) ) {
-				availableControls.push( {
+			if ( isEnabled( 'republicize' ) ) {
+				controls.main.push( {
+					className: 'share',
 					disabled: ! this.props.isPublicizeEnabled,
-					text: this.translate( 'Share' ),
-					className: 'post-controls__share',
-					onClick: this.props.onToggleShare,
-					icon: 'share'
+					icon: 'share',
+					onClick: onToggleShare,
+					text: translate( 'Share' ),
 				} );
 			}
-
-		} else if ( post.status !== 'trash' ) {
-			parsed = url.parse( post.URL, true );
-			parsed.query.preview = 'true';
+		} else if ( 'trash' !== post.status ) {
+			const parsedUrl = url.parse( post.URL, true );
+			parsedUrl.query.preview = true;
 			// NOTE: search needs to be cleared in order to rebuild query
 			// http://nodejs.org/api/url.html#url_url_format_urlobj
-			parsed.search = '';
-			previewURL = url.format( parsed );
+			parsedUrl.search = '';
 
-			availableControls.push( {
-				text: this.translate( 'Preview' ),
-				className: 'post-controls__view',
-				href: previewURL,
-				target: '_blank',
+			controls.main.push( {
+				className: 'view',
+				href: url.format( parsedUrl ),
+				icon: 'external',
 				onClick: this.preview,
-				icon: 'external'
+				text: translate( 'Preview' ),
 			} );
 
-			if ( utils.userCan( 'publish_post', post ) ) {
-				availableControls.push( {
-					text: this.translate( 'Publish' ),
-					className: 'post-controls__publish',
-					onClick: this.props.onPublish,
-					icon: 'reader'
+			if ( userCan( 'publish_post', post ) ) {
+				controls.main.push( {
+					className: 'publish',
+					icon: 'reader',
+					onClick: onPublish,
+					text: translate( 'Publish' ),
 				} );
 			}
-		} else if ( utils.userCan( 'delete_post', post ) ) {
-			availableControls.push( {
-				text: this.translate( 'Restore' ),
-				className: 'post-controls__restore',
-				onClick: this.props.onRestore,
-				icon: 'undo'
+		} else if ( userCan( 'delete_post', post ) ) {
+			controls.main.push( {
+				className: 'restore',
+				icon: 'undo',
+				onClick: onRestore,
+				text: translate( 'Restore' ),
 			} );
 		}
 
-		if ( utils.userCan( 'delete_post', post ) ) {
-			if ( post.status === 'trash') {
-				availableControls.push( {
-					text: this.translate( 'Delete Permanently' ),
-					className: 'post-controls__trash is-scary',
-					onClick: this.props.onDelete,
-					icon: 'trash'
+		if ( userCan( 'delete_post', post ) ) {
+			if ( 'trash' === post.status ) {
+				controls.main.push( {
+					className: 'trash is-scary',
+					icon: 'trash',
+					onClick: onDelete,
+					text: translate( 'Delete Permanently' ),
 				} );
 			} else {
-				availableControls.push( {
-					text: this.translate( 'Trash' ),
-					className: 'post-controls__trash',
-					onClick: this.props.onTrash,
-					icon: 'trash'
+				controls.main.push( {
+					className: 'trash',
+					icon: 'trash',
+					onClick: onTrash,
+					text: translate( 'Trash' ),
 				} );
 			}
 		}
 
-		if ( ( post.status === 'publish' || post.status === 'private' ) && utils.userCan( 'edit_post', post ) ) {
-			availableControls.push( {
-				text: this.translate( 'Copy' ),
-				className: 'post-controls__copy',
-				href: `/post/${ this.props.site.slug }?copy=${ post.ID }`,
+		if ( ( 'publish' === post.status || 'private' === post.status ) && userCan( 'edit_post', post ) ) {
+			controls.main.push( {
+				className: 'copy',
+				href: `/post/${ site.slug }?copy=${ post.ID }`,
+				icon: 'clipboard',
 				onClick: this.copy,
-				icon: 'clipboard'
+				text: translate( 'Copy' ),
 			} );
 		}
 
-		// --- Extra Controls (behind ... more link) ---
-		if ( ( availableControls.length > 2 && ! this.props.fullWidth ) || ( availableControls.length > 4 && this.props.fullWidth ) ) {
-			moreControlsSpliceIndex = ( ! this.props.fullWidth ) ? 2 : 4;
-
-			for ( i = moreControlsSpliceIndex; i < availableControls.length; i++ ) {
-				extraControls.push( availableControls[i] );
-			}
-
-			availableControls.splice( moreControlsSpliceIndex );
+		// More Controls (behind ... more link)
+		if ( controls.main.length > 4 && fullWidth ) {
+			controls.more = controls.main.splice( 4 );
+		} else if ( controls.main.length > 2 && ! fullWidth ) {
+			controls.more = controls.main.splice( 2 );
 		}
 
-		// --- Return Controls ---
-		postControlsClass = 'post-controls';
-
-		if ( extraControls.length ) {
-			availableControls.push( {
-				text: this.translate( 'More' ),
-				className: 'post-controls__more',
-				onClick: this.props.onShowMore,
-				icon: 'ellipsis'
+		if ( controls.more.length ) {
+			controls.main.push( {
+				className: 'more',
+				icon: 'ellipsis',
+				onClick: onShowMore,
+				text: translate( 'More' ),
 			} );
 
-			extraControls.push( {
-				text: this.translate( 'Back' ),
-				className: 'post-controls__back',
-				onClick: this.props.onHideMore,
-				icon: 'chevron-left'
+			controls.more.push( {
+				className: 'back',
+				icon: 'chevron-left',
+				onClick: onHideMore,
+				text: translate( 'Back' ),
 			} );
-
-			mainControls = this.buildControls( availableControls );
-			moreControls = this.buildControls( extraControls );
-			postControlsClass += ( extraControls.length <= 2 ) ? ' post-controls--desk-nomore' : '';
-
-			return (
-				<div className={ postControlsClass }>
-					<ul className="post-controls__pane post-controls__more-options">
-						{ moreControls }
-					</ul>
-					<ul className="post-controls__pane post-controls__main-options">
-						{ mainControls }
-					</ul>
-				</div>
-			);
-		} else {
-			mainControls = this.buildControls( availableControls );
-
-			return (
-				<div className={ postControlsClass }>
-					<ul className="post-controls__pane post-controls__main-options">
-						{ mainControls }
-					</ul>
-				</div>
-			);
 		}
-	},
 
-} );
+		return controls;
+	}
 
-export default connect(
-	( state, props ) => ( {
-		isPublicizeEnabled: isPublicizeEnabled( state, props.site.ID, props.post.type ),
-	} )
-)( PostControls );
+	render() {
+		const { main, more } = this.getAvailableControls();
+		const classes = classNames(
+			'post-controls',
+			{ 'post-controls--desk-nomore': more <= 2 }
+		);
+
+		return (
+			<div className={ classes }>
+				{ more.length &&
+					<ul className="posts__post-controls post-controls__pane post-controls__more-options">
+						{ this.getControlElements( more ) }
+					</ul>
+				}
+				<ul className="posts__post-controls post-controls__pane post-controls__main-options">
+					{ this.getControlElements( main ) }
+				</ul>
+			</div>
+		);
+	}
+}
+
+export default connect( ( state, { site, post } ) => ( {
+	isPublicizeEnabled: isPublicizeEnabled( state, site.ID, post.type ),
+} ) )( localize( PostControls ) );


### PR DESCRIPTION
As discussed in #7451 and attempted before-time in #7574, I rewrote the `PostControls` component in ES6 and moved the controls logic out of the render method for improved readability.

_(Please disregard the "Redux-ify" part in the commit message. I'm used to Redux-ify components, but not this time!)_