### PR TITLE
Themes: Split the theme sheet component

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -74,7 +74,7 @@ const ThemeSheet = React.createClass( {
 		// comment near the connect() function at the bottom of this file.
 		return {
 			section: '',
-			defaultOption: {}
+			defaultOption: {},
 		};
 	},
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -52,6 +52,8 @@ const ThemeSheet = React.createClass( {
 		isLoggedIn: React.PropTypes.bool,
 		isActive: React.PropTypes.bool,
 		isPurchased: React.PropTypes.bool,
+		isJetpack: React.PropTypes.bool,
+		isPremium: React.PropTypes.bool,
 		selectedSite: React.PropTypes.object,
 		siteSlug: React.PropTypes.string,
 		backPath: React.PropTypes.string,
@@ -208,7 +210,7 @@ const ThemeSheet = React.createClass( {
 		const analyticsPath = `/theme/:slug${ section ? '/' + section : '' }${ siteID ? '/:site_id' : '' }`;
 		const analyticsPageTitle = `Themes > Details Sheet${ section ? ' > ' + titlecase( section ) : '' }${ siteID ? ' > Site' : '' }`;
 
-		const { currentUserId, isJetpack, siteIdOrWpcom, theme } = this.props;
+		const { currentUserId, isJetpack, isPremium, siteIdOrWpcom, theme } = this.props;
 		const title = theme.name && i18n.translate( '%(themeName)s Theme', {
 			args: { themeName: theme.name }
 		} );
@@ -255,7 +257,8 @@ const ThemeSheet = React.createClass( {
 				</HeaderCake>
 				<ThemeSheetContent
 					section={ section }
-					jetpack={ isJetpack }
+					isJetpack={ isJetpack }
+					isPremium={ isPremium }
 					demo_uri={ theme.demo_uri }
 					togglePreview={ this.togglePreview }
 					siteSlug={ this.props.siteSlug }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -19,6 +19,7 @@ import HeaderCake from 'components/header-cake';
 import SectionHeader from 'components/section-header';
 import ThemeDownloadCard from './theme-download-card';
 import ThemesRelatedCard from './themes-related-card';
+import ThemeSheetContent from './theme-sheet-content'
 import Button from 'components/button';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
@@ -505,18 +506,7 @@ const ThemeSheet = React.createClass( {
 					backText={ i18n.translate( 'All Themes' ) }>
 					{ this.renderButton() }
 				</HeaderCake>
-				<div className="theme__sheet-columns">
-					<div className="theme__sheet-column-left">
-						<div className="theme__sheet-content">
-							{ this.renderSectionNav( section ) }
-							{ this.renderSectionContent( section ) }
-							<div className="theme__sheet-footer-line"><Gridicon icon="my-sites" /></div>
-						</div>
-					</div>
-					<div className="theme__sheet-column-right">
-						{ this.renderScreenshot() }
-					</div>
-				</div>
+				<ThemeSheetContent section={ section } />
 			</Main>
 		);
 	},

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1,6 +1,3 @@
-/* eslint-disable react/no-danger  */
-// FIXME!!!^ we want to ensure we have sanitised data…
-
 /**
  * External dependencies
  */
@@ -8,7 +5,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import i18n from 'i18n-calypso';
 import titlecase from 'to-title-case';
-import { isArray } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,16 +12,8 @@ import { isArray } from 'lodash';
 import QueryTheme from 'components/data/query-theme';
 import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
-import SectionHeader from 'components/section-header';
-import ThemeDownloadCard from './theme-download-card';
-import ThemesRelatedCard from './themes-related-card';
-import ThemeSheetContent from './theme-sheet-content'
+import ThemeSheetContent from './theme-sheet-content';
 import Button from 'components/button';
-import SectionNav from 'components/section-nav';
-import NavTabs from 'components/section-nav/tabs';
-import NavItem from 'components/section-nav/item';
-import Card from 'components/card';
-import Gridicon from 'components/gridicon';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
@@ -51,7 +39,6 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import DocumentHead from 'components/data/document-head';
 import { decodeEntities } from 'lib/formatting';
 import { getTheme } from 'state/themes/selectors';
-import { isValidTerm } from 'my-sites/themes/theme-filters';
 import { hasFeature } from 'state/sites/plans/selectors';
 import { FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
 
@@ -60,18 +47,8 @@ const ThemeSheet = React.createClass( {
 
 	propTypes: {
 		id: React.PropTypes.string,
-		name: React.PropTypes.string,
-		author: React.PropTypes.string,
-		screenshot: React.PropTypes.string,
-		screenshots: React.PropTypes.array,
-		price: React.PropTypes.string,
-		description: React.PropTypes.string,
-		descriptionLong: React.PropTypes.string,
-		supportDocumentation: React.PropTypes.string,
-		download: React.PropTypes.string,
-		taxonomies: React.PropTypes.object,
-		stylesheet: React.PropTypes.string,
 		// Connected props
+		theme: React.PropTypes.object,
 		isLoggedIn: React.PropTypes.bool,
 		isActive: React.PropTypes.bool,
 		isPurchased: React.PropTypes.bool,
@@ -115,9 +92,9 @@ const ThemeSheet = React.createClass( {
 		// component used by the theme showcase's list view). However, these extra details
 		// aren't present for a Jetpack site.
 		if ( this.props.isJetpack ) {
-			return !! this.props.name;
+			return !! this.props.theme.name;
 		}
-		return !! this.props.screenshots;
+		return !! this.props.theme.screenshots;
 	},
 
 	onButtonClick() {
@@ -130,29 +107,16 @@ const ThemeSheet = React.createClass( {
 		secondaryOption && secondaryOption.action && secondaryOption.action( this.props );
 	},
 
-	getValidSections() {
-		const validSections = [];
-		validSections.push( '' ); // Default section
-		this.props.supportDocumentation && validSections.push( 'setup' );
-		validSections.push( 'support' );
-		return validSections;
-	},
-
-	validateSection( section ) {
-		if ( this.getValidSections().indexOf( section ) === -1 ) {
-			return this.getValidSections()[ 0 ];
-		}
-		return section;
-	},
-
 	togglePreview() {
 		this.setState( { showPreview: ! this.state.showPreview } );
 	},
 
 	renderBar() {
+		const { theme } = this.props;
+
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
-		const title = this.props.name || placeholder;
-		const tag = this.props.author ? i18n.translate( 'by %(author)s', { args: { author: this.props.author } } ) : placeholder;
+		const title = this.props.theme.name || placeholder;
+		const tag = theme.author ? i18n.translate( 'by %(author)s', { args: { author: theme.author } } ) : placeholder;
 
 		return (
 			<div className="theme__sheet-bar">
@@ -160,219 +124,6 @@ const ThemeSheet = React.createClass( {
 				<span className="theme__sheet-bar-tag">{ tag }</span>
 			</div>
 		);
-	},
-
-	getFullLengthScreenshot() {
-		if ( this.isLoaded() ) {
-			return this.props.screenshots[ 0 ];
-		}
-		return null;
-	},
-
-	renderPreviewButton() {
-		return (
-			<a className="theme__sheet-preview-link" onClick={ this.togglePreview } data-tip-target="theme-sheet-preview">
-				<Gridicon icon="themes" size={ 18 } />
-				<span className="theme__sheet-preview-link-text">
-					{ i18n.translate( 'Open Live Demo', { context: 'Individual theme live preview button' } ) }
-				</span>
-			</a>
-		);
-	},
-
-	renderScreenshot() {
-		let screenshot;
-		if ( this.props.isJetpack ) {
-			screenshot = this.props.screenshot;
-		} else {
-			screenshot = this.getFullLengthScreenshot();
-		}
-		const img = screenshot && <img className="theme__sheet-img" src={ screenshot + '?=w680' } />;
-		return (
-			<div className="theme__sheet-screenshot">
-				{ this.props.demo_uri && this.renderPreviewButton() }
-				{ img }
-			</div>
-		);
-	},
-
-	renderSectionNav( currentSection ) {
-		const filterStrings = {
-			'': i18n.translate( 'Overview', { context: 'Filter label for theme content' } ),
-			setup: i18n.translate( 'Setup', { context: 'Filter label for theme content' } ),
-			support: i18n.translate( 'Support', { context: 'Filter label for theme content' } ),
-		};
-
-		const { siteSlug, id } = this.props;
-		const sitePart = siteSlug ? `/${ siteSlug }` : '';
-
-		const nav = (
-			<NavTabs label="Details" >
-				{ this.getValidSections().map( ( section ) => (
-					<NavItem key={ section }
-						path={ `/theme/${ id }${ section ? '/' + section : '' }${ sitePart }` }
-						selected={ section === currentSection }>
-						{ filterStrings[ section ] }
-					</NavItem>
-				) ) }
-			</NavTabs>
-		);
-
-		return (
-			<SectionNav className="theme__sheet-section-nav" selectedText={ filterStrings[ currentSection ] }>
-				{ this.isLoaded() && nav }
-			</SectionNav>
-		);
-	},
-
-	renderSectionContent( section ) {
-		return {
-			'': this.renderOverviewTab(),
-			setup: this.renderSetupTab(),
-			support: this.renderSupportTab(),
-		}[ section ];
-	},
-
-	renderDescription() {
-		if ( this.props.descriptionLong ) {
-			return (
-				<div dangerouslySetInnerHTML={ { __html: this.props.descriptionLong } } />
-			);
-		}
-		// description doesn't contain any formatting, so we don't need to dangerouslySetInnerHTML
-		return <div>{ this.props.description }</div>;
-	},
-
-	renderOverviewTab() {
-		return (
-			<div>
-				<Card className="theme__sheet-content">
-					{ this.renderDescription() }
-				</Card>
-				{ this.renderFeaturesCard() }
-				{ this.renderDownload() }
-				{ ! this.props.isJetpack && this.renderRelatedThemes() }
-			</div>
-		);
-	},
-
-	renderSetupTab() {
-		return (
-			<div>
-				<Card className="theme__sheet-content">
-					<div dangerouslySetInnerHTML={ { __html: this.props.supportDocumentation } } />
-				</Card>
-			</div>
-		);
-	},
-
-	renderContactUsCard( isPrimary = false ) {
-		return (
-			<Card className="theme__sheet-card-support">
-				<Gridicon icon="help-outline" size={ 48 } />
-				<div className="theme__sheet-card-support-details">
-					{ i18n.translate( 'Need extra help?' ) }
-					<small>{ i18n.translate( 'Get in touch with our support team' ) }</small>
-				</div>
-				<Button primary={ isPrimary } href={ '/help/contact/' }>Contact us</Button>
-			</Card>
-		);
-	},
-
-	renderThemeForumCard( isPrimary = false ) {
-		if ( ! this.props.forumUrl ) {
-			return null;
-		}
-
-		const description = this.props.isPremium
-			? i18n.translate( 'Get in touch with the theme author' )
-			: i18n.translate( 'Get help from volunteers and staff' );
-
-		return (
-			<Card className="theme__sheet-card-support">
-				<Gridicon icon="comment" size={ 48 } />
-				<div className="theme__sheet-card-support-details">
-					{ i18n.translate( 'Have a question about this theme?' ) }
-					<small>{ description }</small>
-				</div>
-				<Button primary={ isPrimary } href={ this.props.forumUrl }>Visit forum</Button>
-			</Card>
-		);
-	},
-
-	renderCssSupportCard() {
-		return (
-			<Card className="theme__sheet-card-support">
-				<Gridicon icon="briefcase" size={ 48 } />
-				<div className="theme__sheet-card-support-details">
-					{ i18n.translate( 'Need CSS help? ' ) }
-					<small>{ i18n.translate( 'Get help from the experts in our CSS forum' ) }</small>
-				</div>
-				<Button href="//en.forums.wordpress.com/forum/css-customization">Visit forum</Button>
-			</Card>
-		);
-	},
-
-	renderSupportTab() {
-		if ( this.props.isCurrentUserPaid ) {
-			return (
-				<div>
-					{ this.renderContactUsCard( true ) }
-					{ this.renderThemeForumCard() }
-					{ this.renderCssSupportCard() }
-				</div>
-			);
-		}
-
-		return (
-			<div>
-				{ this.renderThemeForumCard( true ) }
-				{ this.renderCssSupportCard() }
-			</div>
-		);
-	},
-
-	renderFeaturesCard() {
-		const { isJetpack, siteSlug, taxonomies } = this.props;
-		if ( ! taxonomies || ! isArray( taxonomies.theme_feature ) ) {
-			return null;
-		}
-
-		const themeFeatures = taxonomies.theme_feature.map( function( item ) {
-			const term = isValidTerm( item.slug ) ? item.slug : `feature:${ item.slug }`;
-			return (
-				<li key={ 'theme-features-item-' + item.slug }>
-					{ isJetpack
-						? <a>{ item.name }</a>
-						: <a href={ `/design/filter/${ term }/${ siteSlug || '' }` }>{ item.name }</a>
-					}
-				</li>
-			);
-		} );
-
-		return (
-			<div>
-				<SectionHeader label={ i18n.translate( 'Features' ) } />
-				<Card>
-					<ul className="theme__sheet-features-list">
-						{ themeFeatures }
-					</ul>
-				</Card>
-			</div>
-		);
-	},
-
-	renderDownload() {
-		// Don't render download button:
-		// * If it's a premium theme
-		// * If it's on a Jetpack site, and the theme object doesn't have a 'download' attr
-		//   Note that not having a 'download' attr would be permissible for a theme on WPCOM
-		//   since we don't provide any for some themes found on WordPress.org (notably the 'Twenties').
-		//   The <ThemeDownloadCard /> component can handle that case.
-		if ( this.props.isPremium || ( this.props.isJetpack && ! this.props.download ) ) {
-			return null;
-		}
-		return <ThemeDownloadCard theme={ this.props.id } href={ this.props.download } />;
 	},
 
 	getDefaultOptionLabel() {
@@ -392,7 +143,7 @@ const ThemeSheet = React.createClass( {
 		const showSecondaryButton = secondaryOption && ! isActive && isLoggedIn;
 		return (
 			<ThemePreview showPreview={ this.state.showPreview }
-				theme={ this.props }
+				theme={ this.props.theme }
 				onClose={ this.togglePreview }
 				primaryButtonLabel={ this.getDefaultOptionLabel() }
 				getPrimaryButtonHref={ defaultOption.getUrl }
@@ -424,12 +175,8 @@ const ThemeSheet = React.createClass( {
 		);
 	},
 
-	renderRelatedThemes() {
-		return <ThemesRelatedCard currentTheme={ this.props.id } />;
-	},
-
 	renderPrice() {
-		let price = this.props.price;
+		let price = this.props.theme.price;
 		if ( ! this.isLoaded() || this.props.isActive || this.props.isPurchased ) {
 			price = '';
 		} else if ( ! this.props.isPremium ) {
@@ -446,7 +193,7 @@ const ThemeSheet = React.createClass( {
 
 		return (
 			<Button className="theme__sheet-primary-button"
-				href={ getUrl ? getUrl( this.props ) : null }
+				href={ getUrl ? getUrl( this.props.theme ) : null }
 				onClick={ this.onButtonClick }>
 				{ this.isLoaded() ? label : placeholder }
 				{ this.renderPrice() }
@@ -455,29 +202,29 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderSheet() {
-		const section = this.validateSection( this.props.section );
+		const { section } = this.props;
 		const siteID = this.props.selectedSite && this.props.selectedSite.ID;
 
 		const analyticsPath = `/theme/:slug${ section ? '/' + section : '' }${ siteID ? '/:site_id' : '' }`;
 		const analyticsPageTitle = `Themes > Details Sheet${ section ? ' > ' + titlecase( section ) : '' }${ siteID ? ' > Site' : '' }`;
 
-		const { name: themeName, description, currentUserId, isJetpack, siteIdOrWpcom } = this.props;
-		const title = themeName && i18n.translate( '%(themeName)s Theme', {
-			args: { themeName }
+		const { currentUserId, isJetpack, siteIdOrWpcom, theme } = this.props;
+		const title = theme.name && i18n.translate( '%(themeName)s Theme', {
+			args: { themeName: theme.name }
 		} );
 		const canonicalUrl = `https://wordpress.com/theme/${ this.props.id }`; // TODO: use getDetailsUrl() When it becomes availavle
 
 		const metas = [
 			{ property: 'og:url', content: canonicalUrl },
-			{ property: 'og:image', content: this.props.screenshot },
+			{ property: 'og:image', content: theme.screenshot },
 			{ property: 'og:type', content: 'website' }
 		];
 
-		if ( description ) {
+		if ( theme.description ) {
 			metas.push( {
 				name: 'description',
 				property: 'og:description',
-				content: decodeEntities( description )
+				content: decodeEntities( theme.description )
 			} );
 		}
 
@@ -506,7 +253,16 @@ const ThemeSheet = React.createClass( {
 					backText={ i18n.translate( 'All Themes' ) }>
 					{ this.renderButton() }
 				</HeaderCake>
-				<ThemeSheetContent section={ section } />
+				<ThemeSheetContent
+					section={ section }
+					jetpack={ isJetpack }
+					demo_uri={ theme.demo_uri }
+					togglePreview={ this.togglePreview }
+					siteSlug={ this.props.siteSlug }
+					id={ this.props.id }
+					isLoaded={ this.isLoaded() }
+					isCurrentUserPaid={ this.props.isCurrentUserPaid }
+					theme={ theme } />
 			</Main>
 		);
 	},
@@ -553,7 +309,7 @@ const ThemeSheetWithOptions = ( props ) => {
 	return (
 		<ConnectedThemeSheet { ...props }
 			siteId={ siteId }
-			theme={ props /* TODO: Have connectOptions() only use theme ID */ }
+			theme={ props.theme /* TODO: Have connectOptions() only use theme ID */ }
 			options={ [
 				'signup',
 				'customize',
@@ -603,7 +359,7 @@ export default connect(
 		const error = theme ? false : getThemeRequestErrors( state, id, siteIdOrWpcom );
 
 		return {
-			...theme,
+			theme,
 			id,
 			error,
 			selectedSite,

--- a/client/my-sites/theme/theme-sheet-content/index.jsx
+++ b/client/my-sites/theme/theme-sheet-content/index.jsx
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import React from 'react';
-import { isArray } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,11 +14,8 @@ import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 import Card from 'components/card';
-import { isValidTerm } from 'my-sites/themes/theme-filters';
-import SectionHeader from 'components/section-header';
-import ThemeDownloadCard from '../theme-download-card';
-import ThemesRelatedCard from '../themes-related-card';
 import Button from 'components/button';
+import Overview from './theme-content-sections/overview';
 
 class ThemeSheetContent extends React.Component {
 	static propTypes = {
@@ -118,56 +114,7 @@ class ThemeSheetContent extends React.Component {
 
 	renderOverviewTab() {
 		return (
-			<div>
-				<Card className="theme__sheet-content">
-					{ this.renderDescription() }
-				</Card>
-				{ this.renderFeaturesCard() }
-				{ this.renderDownload() }
-				{ ! this.props.isJetpack && <ThemesRelatedCard currentTheme={ this.props.id } /> }
-			</div>
-		);
-	}
-
-	renderDescription() {
-		if ( this.props.theme.descriptionLong ) {
-			return (
-				<div dangerouslySetInnerHTML={ { __html: this.props.theme.descriptionLong } } />
-			);
-		}
-		// description doesn't contain any formatting, so we don't need to dangerouslySetInnerHTML
-		return <div>{ this.props.theme.description }</div>;
-	}
-
-	renderFeaturesCard() {
-		const { isJetpack, siteSlug, translate } = this.props;
-		const { taxonomies } = this.props.theme;
-
-		if ( ! taxonomies || ! isArray( taxonomies.theme_feature ) ) {
-			return null;
-		}
-
-		const themeFeatures = taxonomies.theme_feature.map( function( item ) {
-			const term = isValidTerm( item.slug ) ? item.slug : `feature:${ item.slug }`;
-			return (
-				<li key={ 'theme-features-item-' + item.slug }>
-					{ isJetpack
-						? <a>{ item.name }</a>
-						: <a href={ `/design/filter/${ term }/${ siteSlug || '' }` }>{ item.name }</a>
-					}
-				</li>
-			);
-		} );
-
-		return (
-			<div>
-				<SectionHeader label={ translate( 'Features' ) } />
-				<Card>
-					<ul className="theme__sheet-features-list">
-						{ themeFeatures }
-					</ul>
-				</Card>
-			</div>
+			<Overview { ...this.props } />
 		);
 	}
 
@@ -176,19 +123,6 @@ class ThemeSheetContent extends React.Component {
 			return this.props.theme.screenshots[ 0 ];
 		}
 		return null;
-	}
-
-	renderDownload() {
-		// Don't render download button:
-		// * If it's a premium theme
-		// * If it's on a Jetpack site, and the theme object doesn't have a 'download' attr
-		//   Note that not having a 'download' attr would be permissible for a theme on WPCOM
-		//   since we don't provide any for some themes found on WordPress.org (notably the 'Twenties').
-		//   The <ThemeDownloadCard /> component can handle that case.
-		if ( this.props.isPremium || ( this.props.isJetpack && ! this.props.theme.download ) ) {
-			return null;
-		}
-		return <ThemeDownloadCard theme={ this.props.id } href={ this.props.theme.download } />;
 	}
 
 	renderSetupTab() {

--- a/client/my-sites/theme/theme-sheet-content/index.jsx
+++ b/client/my-sites/theme/theme-sheet-content/index.jsx
@@ -10,9 +10,7 @@ import React from 'react';
  */
 import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
-import SectionNav from 'components/section-nav';
-import NavTabs from 'components/section-nav/tabs';
-import NavItem from 'components/section-nav/item';
+import Navigation from './theme-content-sections/navigation';
 import Overview from './theme-content-sections/overview';
 import Setup from './theme-content-sections/setup';
 import Support from './theme-content-sections/support';
@@ -63,52 +61,6 @@ class ThemeSheetContent extends React.Component {
 		theme: React.PropTypes.object,
 	};
 
-	getValidSections() {
-		const { theme } = this.props;
-		const validSections = [];
-		validSections.push( '' ); // Default section
-		theme && theme.supportDocumentation && validSections.push( 'setup' );
-		validSections.push( 'support' );
-		return validSections;
-	}
-
-	validateSection( section ) {
-		if ( this.getValidSections().indexOf( section ) === -1 ) {
-			return this.getValidSections()[ 0 ];
-		}
-		return section;
-	}
-
-	renderSectionNav( currentSection ) {
-		const { translate, siteSlug, id, isLoaded } = this.props;
-
-		const filterStrings = {
-			'': translate( 'Overview', { context: 'Filter label for theme content' } ),
-			setup: translate( 'Setup', { context: 'Filter label for theme content' } ),
-			support: translate( 'Support', { context: 'Filter label for theme content' } ),
-		};
-
-		const sitePart = siteSlug ? `/${ siteSlug }` : '';
-
-		const nav = (
-			<NavTabs label="Details" >
-				{ this.getValidSections().map( ( section ) => (
-					<NavItem key={ section }
-						path={ `/theme/${ id }${ section ? '/' + section : '' }${ sitePart }` }
-						selected={ section === currentSection }>
-						{ filterStrings[ section ] }
-					</NavItem>
-				) ) }
-			</NavTabs>
-		);
-
-		return (
-			<SectionNav className="theme__sheet-section-nav" selectedText={ filterStrings[ currentSection ] }>
-				{ isLoaded && nav }
-			</SectionNav>
-		);
-	}
-
 	renderSectionContent( section ) {
 		return {
 			'': <Overview { ...this.props } />,
@@ -118,14 +70,19 @@ class ThemeSheetContent extends React.Component {
 	}
 
 	render() {
-		const section = this.validateSection( this.props.section );
-		const { isJetpack, isLoaded, theme, togglePreview } = this.props;
+		const { id, isJetpack, isLoaded, theme, section, siteSlug } = this.props;
 
 		return (
 			<div className="theme__sheet-columns">
 				<div className="theme__sheet-column-left">
 					<div className="theme__sheet-content">
-						{ this.renderSectionNav( section ) }
+						<Navigation
+							siteSlug={ siteSlug }
+							id={ id }
+							isLoaded={ isLoaded }
+							currentSection={ section }
+							theme={ theme }
+						/>
 						{ this.renderSectionContent( section ) }
 						<div className="theme__sheet-footer-line"><Gridicon icon="my-sites" /></div>
 					</div>
@@ -135,7 +92,6 @@ class ThemeSheetContent extends React.Component {
 						isJetpack={ isJetpack }
 						isLoaded={ isLoaded }
 						theme={ theme }
-						togglePreview={ togglePreview }
 					/>
 				</div>
 			</div>

--- a/client/my-sites/theme/theme-sheet-content/index.jsx
+++ b/client/my-sites/theme/theme-sheet-content/index.jsx
@@ -13,10 +13,9 @@ import { localize } from 'i18n-calypso';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
-import Card from 'components/card';
-import Button from 'components/button';
 import Overview from './theme-content-sections/overview';
 import Setup from './theme-content-sections/setup';
+import Support from './theme-content-sections/support';
 
 class ThemeSheetContent extends React.Component {
 	static propTypes = {
@@ -107,16 +106,10 @@ class ThemeSheetContent extends React.Component {
 
 	renderSectionContent( section ) {
 		return {
-			'': this.renderOverviewTab(),
+			'': <Overview { ...this.props } />,
 			setup: <Setup documentation={ this.props.theme.supportDocumentation } />,
-			support: this.renderSupportTab(),
+			support: <Support { ...this.props } />,
 		}[ section ];
-	}
-
-	renderOverviewTab() {
-		return (
-			<Overview { ...this.props } />
-		);
 	}
 
 	getFullLengthScreenshot() {
@@ -124,78 +117,6 @@ class ThemeSheetContent extends React.Component {
 			return this.props.theme.screenshots[ 0 ];
 		}
 		return null;
-	}
-
-	renderContactUsCard( isPrimary = false ) {
-		const { translate } = this.props;
-
-		return (
-			<Card className="theme__sheet-card-support">
-				<Gridicon icon="help-outline" size={ 48 } />
-				<div className="theme__sheet-card-support-details">
-					{ translate( 'Need extra help?' ) }
-					<small>{ translate( 'Get in touch with our support team' ) }</small>
-				</div>
-				<Button primary={ isPrimary } href={ '/help/contact/' }>Contact us</Button>
-			</Card>
-		);
-	}
-
-	renderThemeForumCard( isPrimary = false ) {
-		const { translate } = this.props;
-
-		if ( ! this.props.theme.forumUrl ) {
-			return null;
-		}
-
-		const description = this.props.isPremium
-			? translate( 'Get in touch with the theme author' )
-			: translate( 'Get help from volunteers and staff' );
-
-		return (
-			<Card className="theme__sheet-card-support">
-				<Gridicon icon="comment" size={ 48 } />
-				<div className="theme__sheet-card-support-details">
-					{ translate( 'Have a question about this theme?' ) }
-					<small>{ description }</small>
-				</div>
-				<Button primary={ isPrimary } href={ this.props.theme.forumUrl }>Visit forum</Button>
-			</Card>
-		);
-	}
-
-	renderCssSupportCard() {
-		const { translate } = this.props;
-
-		return (
-			<Card className="theme__sheet-card-support">
-				<Gridicon icon="briefcase" size={ 48 } />
-				<div className="theme__sheet-card-support-details">
-					{ translate( 'Need CSS help? ' ) }
-					<small>{ translate( 'Get help from the experts in our CSS forum' ) }</small>
-				</div>
-				<Button href="//en.forums.wordpress.com/forum/css-customization">Visit forum</Button>
-			</Card>
-		);
-	}
-
-	renderSupportTab() {
-		if ( this.props.isCurrentUserPaid ) {
-			return (
-				<div>
-					{ this.renderContactUsCard( true ) }
-					{ this.renderThemeForumCard() }
-					{ this.renderCssSupportCard() }
-				</div>
-			);
-		}
-
-		return (
-			<div>
-				{ this.renderThemeForumCard( true ) }
-				{ this.renderCssSupportCard() }
-			</div>
-		);
 	}
 
 	render() {

--- a/client/my-sites/theme/theme-sheet-content/index.jsx
+++ b/client/my-sites/theme/theme-sheet-content/index.jsx
@@ -13,7 +13,7 @@ import Navigation from './theme-content-sections/navigation';
 import Overview from './theme-content-sections/overview';
 import Setup from './theme-content-sections/setup';
 import Support from './theme-content-sections/support';
-import Screenshot from './theme-content-sections/screenshot'
+import Screenshot from './theme-content-sections/screenshot';
 
 class ThemeSheetContent extends React.Component {
 	static propTypes = {

--- a/client/my-sites/theme/theme-sheet-content/index.jsx
+++ b/client/my-sites/theme/theme-sheet-content/index.jsx
@@ -17,6 +17,40 @@ import Overview from './theme-content-sections/overview';
 import Setup from './theme-content-sections/setup';
 import Support from './theme-content-sections/support';
 
+const PreviewButton = localize(
+	( { theme, togglePreview, translate } ) => {
+		if ( ! theme.demo_uri ) {
+			return null;
+		}
+
+		return (
+			<a className="theme__sheet-preview-link" onClick={ togglePreview } data-tip-target="theme-sheet-preview">
+				<Gridicon icon="themes" size={ 18 } />
+				<span className="theme__sheet-preview-link-text">
+					{ translate( 'Open Live Demo', { context: 'Individual theme live preview button' } ) }
+				</span>
+			</a>
+		);
+	}
+);
+
+const Screenshot = ( { isLoaded, isJetpack, theme, togglePreview } ) => {
+	const fullLengthScreenshot = () =>
+		isLoaded ? theme.screenshots[ 0 ] : null;
+	const screenshot = isJetpack ? theme.screenshot : fullLengthScreenshot();
+	const img = screenshot && <img className="theme__sheet-img" src={ screenshot + '?=w680' } />;
+
+	return (
+		<div className="theme__sheet-screenshot">
+			<PreviewButton
+				togglePreview={ togglePreview }
+				theme={ theme }
+			/>
+			{ img }
+		</div>
+	);
+};
+
 class ThemeSheetContent extends React.Component {
 	static propTypes = {
 		section: React.PropTypes.string,
@@ -43,35 +77,6 @@ class ThemeSheetContent extends React.Component {
 			return this.getValidSections()[ 0 ];
 		}
 		return section;
-	}
-
-	renderScreenshot() {
-		let screenshot;
-		if ( this.props.isJetpack ) {
-			screenshot = this.props.theme.screenshot;
-		} else {
-			screenshot = this.getFullLengthScreenshot();
-		}
-		const img = screenshot && <img className="theme__sheet-img" src={ screenshot + '?=w680' } />;
-		return (
-			<div className="theme__sheet-screenshot">
-				{ this.props.theme.demo_uri && this.renderPreviewButton() }
-				{ img }
-			</div>
-		);
-	}
-
-	renderPreviewButton() {
-		const { togglePreview, translate } = this.props;
-
-		return (
-			<a className="theme__sheet-preview-link" onClick={ togglePreview } data-tip-target="theme-sheet-preview">
-				<Gridicon icon="themes" size={ 18 } />
-				<span className="theme__sheet-preview-link-text">
-					{ translate( 'Open Live Demo', { context: 'Individual theme live preview button' } ) }
-				</span>
-			</a>
-		);
 	}
 
 	renderSectionNav( currentSection ) {
@@ -112,15 +117,9 @@ class ThemeSheetContent extends React.Component {
 		}[ section ];
 	}
 
-	getFullLengthScreenshot() {
-		if ( this.props.isLoaded ) {
-			return this.props.theme.screenshots[ 0 ];
-		}
-		return null;
-	}
-
 	render() {
 		const section = this.validateSection( this.props.section );
+		const { isJetpack, isLoaded, theme, togglePreview } = this.props;
 
 		return (
 			<div className="theme__sheet-columns">
@@ -132,7 +131,12 @@ class ThemeSheetContent extends React.Component {
 					</div>
 				</div>
 				<div className="theme__sheet-column-right">
-					{ this.renderScreenshot() }
+					<Screenshot
+						isJetpack={ isJetpack }
+						isLoaded={ isLoaded }
+						theme={ theme }
+						togglePreview={ togglePreview }
+					/>
 				</div>
 			</div>
 		);

--- a/client/my-sites/theme/theme-sheet-content/index.jsx
+++ b/client/my-sites/theme/theme-sheet-content/index.jsx
@@ -16,6 +16,7 @@ import NavItem from 'components/section-nav/item';
 import Card from 'components/card';
 import Button from 'components/button';
 import Overview from './theme-content-sections/overview';
+import Setup from './theme-content-sections/setup';
 
 class ThemeSheetContent extends React.Component {
 	static propTypes = {
@@ -107,7 +108,7 @@ class ThemeSheetContent extends React.Component {
 	renderSectionContent( section ) {
 		return {
 			'': this.renderOverviewTab(),
-			setup: this.renderSetupTab(),
+			setup: <Setup documentation={ this.props.theme.supportDocumentation } />,
 			support: this.renderSupportTab(),
 		}[ section ];
 	}
@@ -123,16 +124,6 @@ class ThemeSheetContent extends React.Component {
 			return this.props.theme.screenshots[ 0 ];
 		}
 		return null;
-	}
-
-	renderSetupTab() {
-		return (
-			<div>
-				<Card className="theme__sheet-content">
-					<div dangerouslySetInnerHTML={ { __html: this.props.theme.supportDocumentation } } />
-				</Card>
-			</div>
-		);
 	}
 
 	renderContactUsCard( isPrimary = false ) {

--- a/client/my-sites/theme/theme-sheet-content/index.jsx
+++ b/client/my-sites/theme/theme-sheet-content/index.jsx
@@ -9,45 +9,11 @@ import React from 'react';
  * Internal dependencies
  */
 import Gridicon from 'components/gridicon';
-import { localize } from 'i18n-calypso';
 import Navigation from './theme-content-sections/navigation';
 import Overview from './theme-content-sections/overview';
 import Setup from './theme-content-sections/setup';
 import Support from './theme-content-sections/support';
-
-const PreviewButton = localize(
-	( { theme, togglePreview, translate } ) => {
-		if ( ! theme.demo_uri ) {
-			return null;
-		}
-
-		return (
-			<a className="theme__sheet-preview-link" onClick={ togglePreview } data-tip-target="theme-sheet-preview">
-				<Gridicon icon="themes" size={ 18 } />
-				<span className="theme__sheet-preview-link-text">
-					{ translate( 'Open Live Demo', { context: 'Individual theme live preview button' } ) }
-				</span>
-			</a>
-		);
-	}
-);
-
-const Screenshot = ( { isLoaded, isJetpack, theme, togglePreview } ) => {
-	const fullLengthScreenshot = () =>
-		isLoaded ? theme.screenshots[ 0 ] : null;
-	const screenshot = isJetpack ? theme.screenshot : fullLengthScreenshot();
-	const img = screenshot && <img className="theme__sheet-img" src={ screenshot + '?=w680' } />;
-
-	return (
-		<div className="theme__sheet-screenshot">
-			<PreviewButton
-				togglePreview={ togglePreview }
-				theme={ theme }
-			/>
-			{ img }
-		</div>
-	);
-};
+import Screenshot from './theme-content-sections/screenshot'
 
 class ThemeSheetContent extends React.Component {
 	static propTypes = {
@@ -70,7 +36,7 @@ class ThemeSheetContent extends React.Component {
 	}
 
 	render() {
-		const { id, isJetpack, isLoaded, theme, section, siteSlug } = this.props;
+		const { id, isJetpack, isLoaded, theme, section, siteSlug, togglePreview } = this.props;
 
 		return (
 			<div className="theme__sheet-columns">
@@ -92,6 +58,7 @@ class ThemeSheetContent extends React.Component {
 						isJetpack={ isJetpack }
 						isLoaded={ isLoaded }
 						theme={ theme }
+						togglePreview={ togglePreview }
 					/>
 				</div>
 			</div>
@@ -99,4 +66,4 @@ class ThemeSheetContent extends React.Component {
 	}
 }
 
-export default localize( ThemeSheetContent );
+export default ThemeSheetContent;

--- a/client/my-sites/theme/theme-sheet-content/index.jsx
+++ b/client/my-sites/theme/theme-sheet-content/index.jsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+class ThemeSheetContent extents React.Component {
+	static propTypes = {
+		section: React.PropTypes.string,
+	};
+
+	render () {
+		const { section } = this.props;
+
+		return (
+			<div className="theme__sheet-columns">
+				<div className="theme__sheet-column-left">
+					<div className="theme__sheet-content">
+						{ this.renderSectionNav( section ) }
+						{ this.renderSectionContent( section ) }
+						<div className="theme__sheet-footer-line"><Gridicon icon="my-sites" /></div>
+					</div>
+				</div>
+				<div className="theme__sheet-column-right">
+					{ this.renderScreenshot() }
+				</div>
+			</div>
+		);
+	};
+}

--- a/client/my-sites/theme/theme-sheet-content/index.jsx
+++ b/client/my-sites/theme/theme-sheet-content/index.jsx
@@ -1,15 +1,280 @@
+/* eslint-disable react/no-danger  */
+
 /**
  * External dependencies
  */
 import React from 'react';
+import { isArray } from 'lodash';
 
-class ThemeSheetContent extents React.Component {
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+import { localize } from 'i18n-calypso';
+import SectionNav from 'components/section-nav';
+import NavTabs from 'components/section-nav/tabs';
+import NavItem from 'components/section-nav/item';
+import Card from 'components/card';
+import { isValidTerm } from 'my-sites/themes/theme-filters';
+import SectionHeader from 'components/section-header';
+import ThemeDownloadCard from '../theme-download-card';
+import ThemesRelatedCard from '../themes-related-card';
+import Button from 'components/button';
+
+class ThemeSheetContent extends React.Component {
 	static propTypes = {
 		section: React.PropTypes.string,
+		isJetpack: React.PropTypes.bool,
+		togglePreview: React.PropTypes.func,
+		siteSlug: React.PropTypes.string,
+		id: React.PropTypes.string,
+		isLoaded: React.PropTypes.bool,
+		isCurrentUserPaid: React.PropTypes.bool,
+		theme: React.PropTypes.object,
 	};
 
-	render () {
-		const { section } = this.props;
+	getValidSections() {
+		const { theme } = this.props;
+		const validSections = [];
+		validSections.push( '' ); // Default section
+		theme && theme.supportDocumentation && validSections.push( 'setup' );
+		validSections.push( 'support' );
+		return validSections;
+	}
+
+	validateSection( section ) {
+		if ( this.getValidSections().indexOf( section ) === -1 ) {
+			return this.getValidSections()[ 0 ];
+		}
+		return section;
+	}
+
+	renderScreenshot() {
+		let screenshot;
+		if ( this.props.isJetpack ) {
+			screenshot = this.props.theme.screenshot;
+		} else {
+			screenshot = this.getFullLengthScreenshot();
+		}
+		const img = screenshot && <img className="theme__sheet-img" src={ screenshot + '?=w680' } />;
+		return (
+			<div className="theme__sheet-screenshot">
+				{ this.props.theme.demo_uri && this.renderPreviewButton() }
+				{ img }
+			</div>
+		);
+	}
+
+	renderPreviewButton() {
+		const { togglePreview, translate } = this.props;
+
+		return (
+			<a className="theme__sheet-preview-link" onClick={ togglePreview } data-tip-target="theme-sheet-preview">
+				<Gridicon icon="themes" size={ 18 } />
+				<span className="theme__sheet-preview-link-text">
+					{ translate( 'Open Live Demo', { context: 'Individual theme live preview button' } ) }
+				</span>
+			</a>
+		);
+	}
+
+	renderSectionNav( currentSection ) {
+		const { translate, siteSlug, id, isLoaded } = this.props;
+
+		const filterStrings = {
+			'': translate( 'Overview', { context: 'Filter label for theme content' } ),
+			setup: translate( 'Setup', { context: 'Filter label for theme content' } ),
+			support: translate( 'Support', { context: 'Filter label for theme content' } ),
+		};
+
+		const sitePart = siteSlug ? `/${ siteSlug }` : '';
+
+		const nav = (
+			<NavTabs label="Details" >
+				{ this.getValidSections().map( ( section ) => (
+					<NavItem key={ section }
+						path={ `/theme/${ id }${ section ? '/' + section : '' }${ sitePart }` }
+						selected={ section === currentSection }>
+						{ filterStrings[ section ] }
+					</NavItem>
+				) ) }
+			</NavTabs>
+		);
+
+		return (
+			<SectionNav className="theme__sheet-section-nav" selectedText={ filterStrings[ currentSection ] }>
+				{ isLoaded && nav }
+			</SectionNav>
+		);
+	}
+
+	renderSectionContent( section ) {
+		return {
+			'': this.renderOverviewTab(),
+			setup: this.renderSetupTab(),
+			support: this.renderSupportTab(),
+		}[ section ];
+	}
+
+	renderOverviewTab() {
+		return (
+			<div>
+				<Card className="theme__sheet-content">
+					{ this.renderDescription() }
+				</Card>
+				{ this.renderFeaturesCard() }
+				{ this.renderDownload() }
+				{ ! this.props.isJetpack && <ThemesRelatedCard currentTheme={ this.props.id } /> }
+			</div>
+		);
+	}
+
+	renderDescription() {
+		if ( this.props.theme.descriptionLong ) {
+			return (
+				<div dangerouslySetInnerHTML={ { __html: this.props.theme.descriptionLong } } />
+			);
+		}
+		// description doesn't contain any formatting, so we don't need to dangerouslySetInnerHTML
+		return <div>{ this.props.theme.description }</div>;
+	}
+
+	renderFeaturesCard() {
+		const { isJetpack, siteSlug, translate } = this.props;
+		const { taxonomies } = this.props.theme;
+
+		if ( ! taxonomies || ! isArray( taxonomies.theme_feature ) ) {
+			return null;
+		}
+
+		const themeFeatures = taxonomies.theme_feature.map( function( item ) {
+			const term = isValidTerm( item.slug ) ? item.slug : `feature:${ item.slug }`;
+			return (
+				<li key={ 'theme-features-item-' + item.slug }>
+					{ isJetpack
+						? <a>{ item.name }</a>
+						: <a href={ `/design/filter/${ term }/${ siteSlug || '' }` }>{ item.name }</a>
+					}
+				</li>
+			);
+		} );
+
+		return (
+			<div>
+				<SectionHeader label={ translate( 'Features' ) } />
+				<Card>
+					<ul className="theme__sheet-features-list">
+						{ themeFeatures }
+					</ul>
+				</Card>
+			</div>
+		);
+	}
+
+	getFullLengthScreenshot() {
+		if ( this.props.isLoaded ) {
+			return this.props.theme.screenshots[ 0 ];
+		}
+		return null;
+	}
+
+	renderDownload() {
+		// Don't render download button:
+		// * If it's a premium theme
+		// * If it's on a Jetpack site, and the theme object doesn't have a 'download' attr
+		//   Note that not having a 'download' attr would be permissible for a theme on WPCOM
+		//   since we don't provide any for some themes found on WordPress.org (notably the 'Twenties').
+		//   The <ThemeDownloadCard /> component can handle that case.
+		if ( this.props.isPremium || ( this.props.isJetpack && ! this.props.theme.download ) ) {
+			return null;
+		}
+		return <ThemeDownloadCard theme={ this.props.id } href={ this.props.theme.download } />;
+	}
+
+	renderSetupTab() {
+		return (
+			<div>
+				<Card className="theme__sheet-content">
+					<div dangerouslySetInnerHTML={ { __html: this.props.theme.supportDocumentation } } />
+				</Card>
+			</div>
+		);
+	}
+
+	renderContactUsCard( isPrimary = false ) {
+		const { translate } = this.props;
+
+		return (
+			<Card className="theme__sheet-card-support">
+				<Gridicon icon="help-outline" size={ 48 } />
+				<div className="theme__sheet-card-support-details">
+					{ translate( 'Need extra help?' ) }
+					<small>{ translate( 'Get in touch with our support team' ) }</small>
+				</div>
+				<Button primary={ isPrimary } href={ '/help/contact/' }>Contact us</Button>
+			</Card>
+		);
+	}
+
+	renderThemeForumCard( isPrimary = false ) {
+		const { translate } = this.props;
+
+		if ( ! this.props.theme.forumUrl ) {
+			return null;
+		}
+
+		const description = this.props.isPremium
+			? translate( 'Get in touch with the theme author' )
+			: translate( 'Get help from volunteers and staff' );
+
+		return (
+			<Card className="theme__sheet-card-support">
+				<Gridicon icon="comment" size={ 48 } />
+				<div className="theme__sheet-card-support-details">
+					{ translate( 'Have a question about this theme?' ) }
+					<small>{ description }</small>
+				</div>
+				<Button primary={ isPrimary } href={ this.props.theme.forumUrl }>Visit forum</Button>
+			</Card>
+		);
+	}
+
+	renderCssSupportCard() {
+		const { translate } = this.props;
+
+		return (
+			<Card className="theme__sheet-card-support">
+				<Gridicon icon="briefcase" size={ 48 } />
+				<div className="theme__sheet-card-support-details">
+					{ translate( 'Need CSS help? ' ) }
+					<small>{ translate( 'Get help from the experts in our CSS forum' ) }</small>
+				</div>
+				<Button href="//en.forums.wordpress.com/forum/css-customization">Visit forum</Button>
+			</Card>
+		);
+	}
+
+	renderSupportTab() {
+		if ( this.props.isCurrentUserPaid ) {
+			return (
+				<div>
+					{ this.renderContactUsCard( true ) }
+					{ this.renderThemeForumCard() }
+					{ this.renderCssSupportCard() }
+				</div>
+			);
+		}
+
+		return (
+			<div>
+				{ this.renderThemeForumCard( true ) }
+				{ this.renderCssSupportCard() }
+			</div>
+		);
+	}
+
+	render() {
+		const section = this.validateSection( this.props.section );
 
 		return (
 			<div className="theme__sheet-columns">
@@ -25,5 +290,7 @@ class ThemeSheetContent extents React.Component {
 				</div>
 			</div>
 		);
-	};
+	}
 }
+
+export default localize( ThemeSheetContent );

--- a/client/my-sites/theme/theme-sheet-content/theme-content-sections/navigation.jsx
+++ b/client/my-sites/theme/theme-sheet-content/theme-content-sections/navigation.jsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import SectionNav from 'components/section-nav';
+import NavTabs from 'components/section-nav/tabs';
+import NavItem from 'components/section-nav/item';
+import { localize } from 'i18n-calypso';
+
+const Navigation = ( { translate, theme, siteSlug, id, isLoaded, currentSection } ) => {
+	const filterStrings = {
+		'': translate( 'Overview', { context: 'Filter label for theme content' } ),
+		setup: translate( 'Setup', { context: 'Filter label for theme content' } ),
+		support: translate( 'Support', { context: 'Filter label for theme content' } ),
+	};
+
+	const sitePart = siteSlug ? `/${ siteSlug }` : '';
+	const validSections = [];
+	validSections.push( '' ); // Default section
+	theme && theme.supportDocumentation && validSections.push( 'setup' );
+	validSections.push( 'support' );
+
+	let section = currentSection;
+	if ( validSections.indexOf( currentSection ) === -1 ) {
+		section = validSections[ 0 ];
+	}
+
+	const nav = (
+		<NavTabs label="Details" >
+			{ validSections.map( ( sec ) => (
+				<NavItem key={ sec }
+					path={ `/theme/${ id }${ sec ? '/' + sec : '' }${ sitePart }` }
+					selected={ sec === section }>
+					{ filterStrings[ sec ] }
+				</NavItem>
+			) ) }
+		</NavTabs>
+	);
+
+	return (
+		<SectionNav className="theme__sheet-section-nav" selectedText={ filterStrings[ section ] }>
+			{ isLoaded && nav }
+		</SectionNav>
+	);
+};
+
+export default localize( Navigation );

--- a/client/my-sites/theme/theme-sheet-content/theme-content-sections/overview.jsx
+++ b/client/my-sites/theme/theme-sheet-content/theme-content-sections/overview.jsx
@@ -13,15 +13,18 @@ import Card from 'components/card';
 import { localize } from 'i18n-calypso';
 import SectionHeader from 'components/section-header';
 import { isValidTerm } from 'my-sites/themes/theme-filters';
-import ThemesRelatedCard from '../themes-related-card';
-import ThemeDownloadCard from '../theme-download-card';
+import ThemesRelatedCard from '../../themes-related-card';
+import ThemeDownloadCard from '../../theme-download-card';
 
-const DescriptionLong = ( description ) =>
-	<div dangerouslySetInnerHTML={ { __html: description } } />;
-
-// description doesn't contain any formatting, so we don't need to dangerouslySetInnerHTML
-const Description = ( description ) =>
-	<div>{ description }</div>;
+const Description = ( descriptionLong, description ) => (
+	<Card className="theme__sheet-content">
+		{ descriptionLong
+			? <div dangerouslySetInnerHTML={ { __html: descriptionLong } } />
+			// description doesn't contain any formatting, so we don't need to dangerouslySetInnerHTML
+			: <div>{ description }</div>
+		}
+	</Card>
+);
 
 const ThemeFeatures = ( taxonomies, isJetpack, siteSlug ) => (
 	taxonomies.theme_feature.map( function( item ) {
@@ -38,8 +41,8 @@ const ThemeFeatures = ( taxonomies, isJetpack, siteSlug ) => (
 );
 
 const Features = localize(
-	( isJetpack, siteSlug, taxonomies, translate ) => {
-		if ( ! taxonomies && ! isArray( taxonomies.theme_feature ) ) {
+	( { translate }, isJetpack, siteSlug, taxonomies ) => {
+		if ( ! taxonomies || ! isArray( taxonomies.theme_feature ) ) {
 			return null;
 		}
 
@@ -60,38 +63,36 @@ const Features = localize(
 	}
 );
 
-const Download = ( props ) => {
-	const { isPremium, isJetpack, theme, id } = props;
+const Download = ( isPremium, isJetpack, download, id ) => {
 	// Don't render download button:
 	// * If it's a premium theme
 	// * If it's on a Jetpack site, and the theme object doesn't have a 'download' attr
 	//   Note that not having a 'download' attr would be permissible for a theme on WPCOM
 	//   since we don't provide any for some themes found on WordPress.org (notably the 'Twenties').
 	//   The <ThemeDownloadCard /> component can handle that case.
-	if ( isPremium || ( isJetpack && ! theme.download ) ) {
+	if ( isPremium || ( isJetpack && ! download ) ) {
 		return null;
 	}
-	return <ThemeDownloadCard theme={ id } href={ theme.download } />;
+	return <ThemeDownloadCard theme={ id } href={ download } />;
 };
 
-const Overview = ( { descriptionLong, description, isJetpack, isPremium, id, taxonomies, siteSlug, theme } ) => (
+
+const Overview = ( { isJetpack, isPremium, id, siteSlug, theme } ) => (
 	<div>
-		<Card className="theme__sheet-content">
-			{ descriptionLong
-				? <DescriptionLong description={ descriptionLong } />
-				: <Description description={ description } />
-			}
-		</Card>
+		<Description
+			descriptionLong={ theme.descriptionLong }
+			description={ theme.description }
+		/>
 		<Features
 			isJetpack={ isJetpack }
 			siteSlug={ siteSlug }
-			taxonomies={ taxonomies }
+			taxonomies={ theme.taxonomies }
 		/>
 		<Download
 			id={ id }
 			isPremium={ isPremium }
 			isJetpack={ isJetpack }
-			theme={ theme }
+			download={ theme.download }
 		/>
 		{ ! isJetpack && <ThemesRelatedCard currentTheme={ id } /> }
 	</div>

--- a/client/my-sites/theme/theme-sheet-content/theme-content-sections/overview.jsx
+++ b/client/my-sites/theme/theme-sheet-content/theme-content-sections/overview.jsx
@@ -1,0 +1,100 @@
+/* eslint-disable react/no-danger  */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { isArray } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import { localize } from 'i18n-calypso';
+import SectionHeader from 'components/section-header';
+import { isValidTerm } from 'my-sites/themes/theme-filters';
+import ThemesRelatedCard from '../themes-related-card';
+import ThemeDownloadCard from '../theme-download-card';
+
+const DescriptionLong = ( description ) =>
+	<div dangerouslySetInnerHTML={ { __html: description } } />;
+
+// description doesn't contain any formatting, so we don't need to dangerouslySetInnerHTML
+const Description = ( description ) =>
+	<div>{ description }</div>;
+
+const ThemeFeatures = ( taxonomies, isJetpack, siteSlug ) => (
+	taxonomies.theme_feature.map( function( item ) {
+		const term = isValidTerm( item.slug ) ? item.slug : `feature:${ item.slug }`;
+		return (
+			<li key={ 'theme-features-item-' + item.slug }>
+				{ isJetpack
+					? <a>{ item.name }</a>
+					: <a href={ `/design/filter/${ term }/${ siteSlug || '' }` }>{ item.name }</a>
+				}
+			</li>
+		);
+	} )
+);
+
+const Features = localize(
+	( isJetpack, siteSlug, taxonomies, translate ) => {
+		if ( ! taxonomies && ! isArray( taxonomies.theme_feature ) ) {
+			return null;
+		}
+
+		return (
+			<div>
+				<SectionHeader label={ translate( 'Features' ) } />
+				<Card>
+					<ul className="theme__sheet-features-list">
+						<ThemeFeatures
+							taxonomies={ taxonomies }
+							isJetpack={ isJetpack }
+							siteSlug={ siteSlug }
+						/>
+					</ul>
+				</Card>
+			</div>
+		);
+	}
+);
+
+const Download = ( props ) => {
+	const { isPremium, isJetpack, theme, id } = props;
+	// Don't render download button:
+	// * If it's a premium theme
+	// * If it's on a Jetpack site, and the theme object doesn't have a 'download' attr
+	//   Note that not having a 'download' attr would be permissible for a theme on WPCOM
+	//   since we don't provide any for some themes found on WordPress.org (notably the 'Twenties').
+	//   The <ThemeDownloadCard /> component can handle that case.
+	if ( isPremium || ( isJetpack && ! theme.download ) ) {
+		return null;
+	}
+	return <ThemeDownloadCard theme={ id } href={ theme.download } />;
+};
+
+const Overview = ( { descriptionLong, description, isJetpack, isPremium, id, taxonomies, siteSlug, theme } ) => (
+	<div>
+		<Card className="theme__sheet-content">
+			{ descriptionLong
+				? <DescriptionLong description={ descriptionLong } />
+				: <Description description={ description } />
+			}
+		</Card>
+		<Features
+			isJetpack={ isJetpack }
+			siteSlug={ siteSlug }
+			taxonomies={ taxonomies }
+		/>
+		<Download
+			id={ id }
+			isPremium={ isPremium }
+			isJetpack={ isJetpack }
+			theme={ theme }
+		/>
+		{ ! isJetpack && <ThemesRelatedCard currentTheme={ id } /> }
+	</div>
+);
+
+export default Overview;

--- a/client/my-sites/theme/theme-sheet-content/theme-content-sections/overview.jsx
+++ b/client/my-sites/theme/theme-sheet-content/theme-content-sections/overview.jsx
@@ -78,7 +78,6 @@ const Download = ( { isPremium, isJetpack, download, id } ) => {
 	return <ThemeDownloadCard theme={ id } href={ download } />;
 };
 
-
 const Overview = ( { isJetpack, isPremium, id, siteSlug, theme } ) => (
 	<div>
 		<Description

--- a/client/my-sites/theme/theme-sheet-content/theme-content-sections/overview.jsx
+++ b/client/my-sites/theme/theme-sheet-content/theme-content-sections/overview.jsx
@@ -16,7 +16,7 @@ import { isValidTerm } from 'my-sites/themes/theme-filters';
 import ThemesRelatedCard from '../../themes-related-card';
 import ThemeDownloadCard from '../../theme-download-card';
 
-const Description = ( descriptionLong, description ) => (
+const Description = ( { descriptionLong, description } ) => (
 	<Card className="theme__sheet-content">
 		{ descriptionLong
 			? <div dangerouslySetInnerHTML={ { __html: descriptionLong } } />
@@ -26,22 +26,24 @@ const Description = ( descriptionLong, description ) => (
 	</Card>
 );
 
-const ThemeFeatures = ( taxonomies, isJetpack, siteSlug ) => (
-	taxonomies.theme_feature.map( function( item ) {
-		const term = isValidTerm( item.slug ) ? item.slug : `feature:${ item.slug }`;
-		return (
-			<li key={ 'theme-features-item-' + item.slug }>
-				{ isJetpack
-					? <a>{ item.name }</a>
-					: <a href={ `/design/filter/${ term }/${ siteSlug || '' }` }>{ item.name }</a>
-				}
-			</li>
-		);
-	} )
+const ThemeFeatures = ( { taxonomies, isJetpack, siteSlug } ) => (
+	<div>
+		{ taxonomies.theme_feature.map( function( item ) {
+			const term = isValidTerm( item.slug ) ? item.slug : `feature:${ item.slug }`;
+			return (
+				<li key={ 'theme-features-item-' + item.slug }>
+					{ isJetpack
+						? <a>{ item.name }</a>
+						: <a href={ `/design/filter/${ term }/${ siteSlug || '' }` }>{ item.name }</a>
+					}
+				</li>
+			);
+		} ) }
+	</div>
 );
 
 const Features = localize(
-	( { translate }, isJetpack, siteSlug, taxonomies ) => {
+	( { translate, isJetpack, siteSlug, taxonomies } ) => {
 		if ( ! taxonomies || ! isArray( taxonomies.theme_feature ) ) {
 			return null;
 		}
@@ -63,7 +65,7 @@ const Features = localize(
 	}
 );
 
-const Download = ( isPremium, isJetpack, download, id ) => {
+const Download = ( { isPremium, isJetpack, download, id } ) => {
 	// Don't render download button:
 	// * If it's a premium theme
 	// * If it's on a Jetpack site, and the theme object doesn't have a 'download' attr

--- a/client/my-sites/theme/theme-sheet-content/theme-content-sections/screenshot.jsx
+++ b/client/my-sites/theme/theme-sheet-content/theme-content-sections/screenshot.jsx
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+import { localize } from 'i18n-calypso';
+
+const PreviewButton = localize(
+	( { theme, togglePreview, translate } ) => {
+		if ( ! theme.demo_uri ) {
+			return null;
+		}
+
+		return (
+			<a className="theme__sheet-preview-link" onClick={ togglePreview } data-tip-target="theme-sheet-preview">
+				<Gridicon icon="themes" size={ 18 } />
+				<span className="theme__sheet-preview-link-text">
+					{ translate( 'Open Live Demo', { context: 'Individual theme live preview button' } ) }
+				</span>
+			</a>
+		);
+	}
+);
+
+const Screenshot = ( { isLoaded, isJetpack, theme, togglePreview } ) => {
+	const fullLengthScreenshot = isLoaded ? theme.screenshots[ 0 ] : null;
+	const screenshot = isJetpack ? theme.screenshot : fullLengthScreenshot;
+	const img = screenshot && <img className="theme__sheet-img" src={ screenshot + '?=w680' } />;
+
+	return (
+		<div className="theme__sheet-screenshot">
+			<PreviewButton
+				togglePreview={ togglePreview }
+				theme={ theme }
+			/>
+			{ img }
+		</div>
+	);
+};
+
+export default Screenshot;

--- a/client/my-sites/theme/theme-sheet-content/theme-content-sections/setup.jsx
+++ b/client/my-sites/theme/theme-sheet-content/theme-content-sections/setup.jsx
@@ -1,0 +1,20 @@
+/* eslint-disable react/no-danger  */
+// documentation comes from endpoint and is sanitized
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+
+const Setup = ( { documentation } ) => (
+	<Card className="theme__sheet-content">
+		<div dangerouslySetInnerHTML={ { __html: documentation } } />
+	</Card>
+);
+
+export default Setup;

--- a/client/my-sites/theme/theme-sheet-content/theme-content-sections/support.jsx
+++ b/client/my-sites/theme/theme-sheet-content/theme-content-sections/support.jsx
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
+import { localize } from 'i18n-calypso';
+
+const ContactUs = localize(
+	( { isCurrentUserPaid, translate, isPrimary } ) => {
+		if ( ! isCurrentUserPaid ) {
+			//Contact is only shown for paying users
+			return null;
+		}
+
+		return (
+			<Card className="theme__sheet-card-support">
+				<Gridicon icon="help-outline" size={ 48 } />
+				<div className="theme__sheet-card-support-details">
+					{ translate( 'Need extra help?' ) }
+					<small>{ translate( 'Get in touch with our support team' ) }</small>
+				</div>
+				<Button primary={ isPrimary } href={ '/help/contact/' }>Contact us</Button>
+			</Card>
+		);
+	}
+);
+
+const Forum = localize(
+	( { translate, forumUrl, isPremium, isPrimary = false } ) => {
+
+		if ( ! forumUrl ) {
+			return null;
+		}
+
+		const description = isPremium
+			? translate( 'Get in touch with the theme author' )
+			: translate( 'Get help from volunteers and staff' );
+
+		return (
+			<Card className="theme__sheet-card-support">
+				<Gridicon icon="comment" size={ 48 } />
+				<div className="theme__sheet-card-support-details">
+					{ translate( 'Have a question about this theme?' ) }
+					<small>{ description }</small>
+				</div>
+				<Button primary={ isPrimary } href={ forumUrl }>Visit forum</Button>
+			</Card>
+		);
+	}
+);
+
+const CssSupport = localize(
+	( { translate } ) => (
+		<Card className="theme__sheet-card-support">
+			<Gridicon icon="briefcase" size={ 48 } />
+			<div className="theme__sheet-card-support-details">
+				{ translate( 'Need CSS help? ' ) }
+				<small>{ translate( 'Get help from the experts in our CSS forum' ) }</small>
+			</div>
+			<Button href="//en.forums.wordpress.com/forum/css-customization">Visit forum</Button>
+		</Card>
+	)
+);
+
+const Support = ( { isCurrentUserPaid, isPremium, theme } ) => (
+	<div>
+		<ContactUs
+			isCurrentUserPaid={ isCurrentUserPaid }
+			isPrimary={ true }
+		/>
+		<Forum
+			forumUrl={ theme.forumUrl }
+			isPremium={ isPremium }
+		/>
+		<CssSupport />
+	</div>
+);
+
+export default Support;


### PR DESCRIPTION
No visual differences.

Simplify the theme sheet component by splitting it into multiple components. Preparation for making theme sheets and associated actions work for wpcom themes on jetpack sites.

Next step: Split new theme-sheet-content compont into one component for each of the three main sections (overview, setup, support).
