### PR TITLE
Test if unifying the norm-rules and asyncifying all of them helps

### DIFF
--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -7,15 +7,14 @@ const assign = require( 'lodash/assign' ),
 	forEach = require( 'lodash/forEach' ),
 	isEqual = require( 'lodash/isEqual' ),
 	forOwn = require( 'lodash/forOwn' ),
-	clone = require( 'lodash/clone' ),
-	defer = require( 'lodash/defer' );
+	clone = require( 'lodash/clone' );
 
 /**
  * Internal dependencies
  */
 const Dispatcher = require( 'dispatcher' ),
 	emitter = require( 'lib/mixins/emitter' ),
-	{ runFastRules, runSlowRules, asyncRunRules } = require( 'state/reader/posts/normalization-rules' ),
+	{ asyncRunRules } = require( 'state/reader/posts/normalization-rules' ),
 	FeedPostActionType = require( './constants' ).action,
 	FeedStreamActionType = require( 'lib/feed-stream-store/constants' ).action,
 	ReaderSiteBlockActionType = require( 'lib/reader-site-blocks/constants' ).action,
@@ -276,7 +275,8 @@ function normalizePost( feedId, postId, post ) {
 		return;
 	}
 
-	asyncRunRules( post ).then( normalizedPost => setPost( postId, normalizedPost ) );
+	asyncRunRules( post )
+		.then( normalizedPost => setPost( postId, normalizedPost ) );
 }
 
 function markPostSeen( post ) {

--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -15,7 +15,7 @@ const assign = require( 'lodash/assign' ),
  */
 const Dispatcher = require( 'dispatcher' ),
 	emitter = require( 'lib/mixins/emitter' ),
-	{ runFastRules, runSlowRules } = require( 'state/reader/posts/normalization-rules' ),
+	{ runFastRules, runSlowRules, asyncRunRules } = require( 'state/reader/posts/normalization-rules' ),
 	FeedPostActionType = require( './constants' ).action,
 	FeedStreamActionType = require( 'lib/feed-stream-store/constants' ).action,
 	ReaderSiteBlockActionType = require( 'lib/reader-site-blocks/constants' ).action,
@@ -276,12 +276,7 @@ function normalizePost( feedId, postId, post ) {
 		return;
 	}
 
-	const normalizedPost = runFastRules( post );
-	setPost( postId, normalizedPost );
-
-	defer( function() {
-		runSlowRules( normalizedPost ).then( setPost.bind( null, postId ) );
-	} );
+	asyncRunRules( post ).then( normalizedPost => setPost( postId, normalizedPost ) );
 }
 
 function markPostSeen( post ) {

--- a/client/lib/post-normalizer/rule-with-content-dom.js
+++ b/client/lib/post-normalizer/rule-with-content-dom.js
@@ -1,33 +1,14 @@
 /**
  * External Dependencies
  */
-import { defer, reduce, map } from 'lodash';
+import { defer, map } from 'lodash';
 
 /**
  * Internal Dependencies
  */
 import { domForHtml } from './utils';
 
-export default function createDomTransformRunner( transforms ) {
-	return function withContentDOM( post ) {
-		if ( ! post || ! post.content || ! transforms ) {
-			return post;
-		}
-
-		const dom = domForHtml( post.content );
-
-		post = reduce( transforms, ( memo, transform ) => {
-			return transform( memo, dom );
-		}, post );
-
-		post.content = dom.innerHTML;
-		dom.innerHTML = '';
-
-		return post;
-	};
-}
-
-export const promisifyAndDeferTransform = ( transform, dom ) => ( post ) =>
+const promisifyAndDeferTransformWithDom = ( transform, dom ) => ( post ) =>
 	new Promise( ( resolve ) => defer( () => resolve( transform( post, dom ) ) ) );
 
 export const serialReduce = ( transforms, startingValue ) =>
@@ -47,7 +28,7 @@ export const asyncWithContentDom = transforms => post => {
 	}
 
 	const dom = domForHtml( post.content );
-	const postPromise = serialReduce( map( transforms, transform => promisifyAndDeferTransform( transform, dom ) ), post );
+	const postPromise = serialReduce( map( transforms, transform => promisifyAndDeferTransformWithDom( transform, dom ) ), post );
 
 	return postPromise.then( p => {
 		p.content = dom.innerHTML;

--- a/client/lib/post-normalizer/rule-with-content-dom.js
+++ b/client/lib/post-normalizer/rule-with-content-dom.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import reduce from 'lodash/reduce';
+import { defer, reduce, map } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -26,3 +26,34 @@ export default function createDomTransformRunner( transforms ) {
 		return post;
 	};
 }
+
+export const promisifyAndDeferTransform = ( transform, dom ) => ( post ) =>
+	new Promise( ( resolve ) => defer( () => resolve( transform( post, dom ) ) ) );
+
+export const serialReduce = ( transforms, startingValue ) =>
+	transforms.reduce(
+		( promise, fn ) => promise.then( result => fn( result ) ),
+		Promise.resolve( startingValue
+		)
+	);
+
+/**
+ * Returns a promise with the eventual normalized post object
+ * @param transforms
+ */
+export const asyncWithContentDom = transforms => post => {
+	if ( ! post || ! post.content || ! transforms ) {
+		return post;
+	}
+
+	const dom = domForHtml( post.content );
+	const postPromise = serialReduce( map( transforms, transform => promisifyAndDeferTransform( transform, dom ) ), post );
+
+	return postPromise.then( p => {
+		p.content = dom.innerHTML;
+		dom.innerHTML = '';
+
+		return p;
+	} );
+}
+

--- a/client/state/reader/posts/actions.js
+++ b/client/state/reader/posts/actions.js
@@ -18,7 +18,7 @@ import {
 	READER_POSTS_RECEIVE
 } from 'state/action-types';
 import analytics from 'lib/analytics';
-import { runFastRules, runSlowRules } from './normalization-rules';
+import { runFastRules, runSlowRules, asyncRunRules } from './normalization-rules';
 import Dispatcher from 'dispatcher';
 import { action } from 'lib/feed-post-store/constants';
 import wpcom from 'lib/wp';
@@ -100,16 +100,9 @@ export function receivePosts( posts ) {
 		}
 
 		const withoutUndefined = reject( posts, isUndefined );
-		const normalizedPosts = map( withoutUndefined, runFastRules );
 
-		const [ postsToReload, postsToProcess ] = partition( normalizedPosts, '_should_reload' );
-		forEach( postsToReload, post => {
-			delete post._should_reload;
-			dispatch( reloadPost( post ) );
-		} );
-
-		forEach( map( postsToProcess, runSlowRules ), slowPromise => {
-			slowPromise.then( post => {
+		forEach( map( withoutUndefined, asyncRunRules ), promise => {
+			promise.then( post => {
 				dispatch( {
 					type: READER_POSTS_RECEIVE,
 					posts: [ post ]
@@ -120,25 +113,16 @@ export function receivePosts( posts ) {
 					data: post,
 					type: action.RECEIVE_NORMALIZED_FEED_POST
 				} );
+				if ( post._should_reload ) {
+					delete post._should_reload;
+					dispatch( reloadPost( post ) );
+				}
 			} );
 		} );
 
-		dispatch( {
-			type: READER_POSTS_RECEIVE,
-			posts: normalizedPosts
-		} );
 
-		// keep the old feed post store in sync
-		forEach( normalizedPosts, post => {
-			const postForFlux = has( post, '_should_reload' ) ? omit( post, '_should_reload' ) : post;
-			Dispatcher.handleServerAction( {
-				data: postForFlux,
-				type: action.RECEIVE_NORMALIZED_FEED_POST
-			} );
-		} );
+		forEach( filter( withoutUndefined, 'railcar' ), trackRailcarRender );
 
-		forEach( filter( postsToProcess, 'railcar' ), trackRailcarRender );
-
-		return Promise.resolve( normalizedPosts );
+		return Promise.resolve( withoutUndefined );
 	};
 }

--- a/client/state/reader/posts/actions.js
+++ b/client/state/reader/posts/actions.js
@@ -4,11 +4,8 @@
 import {
 	filter,
 	forEach,
-	has,
 	isUndefined,
 	map,
-	omit,
-	partition,
 	reject } from 'lodash';
 
 /**
@@ -18,7 +15,7 @@ import {
 	READER_POSTS_RECEIVE
 } from 'state/action-types';
 import analytics from 'lib/analytics';
-import { runFastRules, runSlowRules, asyncRunRules } from './normalization-rules';
+import { asyncRunRules } from './normalization-rules';
 import Dispatcher from 'dispatcher';
 import { action } from 'lib/feed-post-store/constants';
 import wpcom from 'lib/wp';

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { filter, flow, map, defer } from 'lodash';
+import { filter, map, defer } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -17,7 +17,10 @@ import detectPolls from 'lib/post-normalizer/rule-content-detect-polls';
 import makeEmbedsSafe from 'lib/post-normalizer/rule-content-make-embeds-safe';
 import removeStyles from 'lib/post-normalizer/rule-content-remove-styles';
 import makeImagesSafe from 'lib/post-normalizer/rule-content-make-images-safe';
-import { disableAutoPlayOnMedia, disableAutoPlayOnEmbeds } from 'lib/post-normalizer/rule-content-disable-autoplay';
+import {
+	disableAutoPlayOnMedia,
+	disableAutoPlayOnEmbeds,
+} from 'lib/post-normalizer/rule-content-disable-autoplay';
 import decodeEntities from 'lib/post-normalizer/rule-decode-entities';
 import pickCanonicalImage from 'lib/post-normalizer/rule-pick-canonical-image';
 import makeSiteIdSafeForApi from 'lib/post-normalizer/rule-make-site-id-safe-for-api';
@@ -25,7 +28,7 @@ import pickPrimaryTag from 'lib/post-normalizer/rule-pick-primary-tag';
 import preventWidows from 'lib/post-normalizer/rule-prevent-widows';
 import safeImageProperties from 'lib/post-normalizer/rule-safe-image-properties';
 import stripHtml from 'lib/post-normalizer/rule-strip-html';
-import withContentDom, { asyncWithContentDom, serialReduce } from 'lib/post-normalizer/rule-with-content-dom';
+import { asyncWithContentDom, serialReduce } from 'lib/post-normalizer/rule-with-content-dom';
 import keepValidImages from 'lib/post-normalizer/rule-keep-valid-images';
 import waitForImagesToLoad from 'lib/post-normalizer/rule-wait-for-images-to-load';
 import pickCanonicalMedia from 'lib/post-normalizer/rule-pick-canonical-media';
@@ -109,47 +112,7 @@ export function classifyPost( post ) {
 	return post;
 }
 
-const fastPostNormalizationRules = flow( [
-	decodeEntities,
-	stripHtml,
-	preventWidows,
-	makeSiteIdSafeForApi,
-	pickPrimaryTag,
-	safeImageProperties( READER_CONTENT_WIDTH ),
-	withContentDom( [
-		removeStyles,
-		removeElementsBySelector,
-		makeImagesSafe(),
-		makeEmbedsSafe,
-		disableAutoPlayOnEmbeds,
-		disableAutoPlayOnMedia,
-		detectMedia,
-		detectPolls,
-	] ),
-	createBetterExcerpt,
-	pickCanonicalImage,
-	pickCanonicalMedia,
-	classifyPost,
-] );
-
-export function runFastRules( post ) {
-	if ( ! post ) {
-		return post;
-	}
-	post = Object.assign( {}, post );
-	fastPostNormalizationRules( post );
-	return post;
-}
-
-const slowSyncRules = flow( [
-	keepValidImages( 144, 72 ),
-	pickCanonicalImage,
-	pickCanonicalMedia,
-	classifyPost
-] );
-
 const allRules = [
-	waitForImagesToLoad,
 	decodeEntities,
 	stripHtml,
 	preventWidows,
@@ -184,7 +147,3 @@ export function asyncRunRules( post ) {
 	return serialReduce( map( allRules, promisifyAndDeferTransform ), { ...post } );
 }
 
-export function runSlowRules( post ) {
-	post = Object.assign( {}, post );
-	return waitForImagesToLoad( post ).then( slowSyncRules );
-}


### PR DESCRIPTION
Goals:
- asyncify all normalization rules to that they never block ui
- only run classifyPost once images have loaded to solve https://github.com/Automattic/wp-calypso/issues/9487
