### PR TITLE
Stats: Adjust all time periods add tracking.

### DIFF
--- a/client/my-sites/stats/stats-module/all-time-nav.jsx
+++ b/client/my-sites/stats/stats-module/all-time-nav.jsx
@@ -57,7 +57,7 @@ export const StatsModuleSummaryLinks = props => {
 				<NavTabs label={ translate( 'Summary' ) }>
 					{ options.map( ( item ) => {
 						const onClick = () => {
-							recordStats.apply( this, [ item ] );
+							recordStats( item );
 						};
 						return (
 							<NavItem

--- a/client/my-sites/stats/stats-module/all-time-nav.jsx
+++ b/client/my-sites/stats/stats-module/all-time-nav.jsx
@@ -20,10 +20,6 @@ import { getSiteSlug } from 'state/sites/selectors';
 export const StatsModuleSummaryLinks = props => {
 	const { translate, path, siteSlug, query, period, children } = props;
 
-	const now = moment();
-	const quarter = moment().startOf( 'quarter' );
-	const daysSinceQuarterStart = now.diff( quarter, 'd' );
-
 	const getSummaryPeriodLabel = () => {
 		switch ( period.period ) {
 			case 'day':
@@ -37,14 +33,19 @@ export const StatsModuleSummaryLinks = props => {
 		}
 	};
 
+	const recordStats = ( item ) => {
+		props.recordGoogleEvent( 'Stats', `Clicked Summary Link: ${ path } ${ item.stat }` );
+	};
+
 	const summaryPath = `/stats/day/${ path }/${ siteSlug }?startDate=${ moment().format( 'YYYY-MM-DD' ) }&summarize=1&num=`;
 	const summaryPeriodPath = `/stats/${ period.period }/${ path }/${ siteSlug }?startDate=${ period.endOf.format( 'YYYY-MM-DD' ) }`;
 	const options = [
-		{ value: '0', label: getSummaryPeriodLabel(), path: summaryPeriodPath },
-		{ value: '7', label: translate( 'Last 7 days' ), path: `${ summaryPath }7` },
-		{ value: '30', label: translate( 'Last 30 days' ), path: `${ summaryPath }30` },
-		{ value: `${ daysSinceQuarterStart }`, label: translate( 'Past quarter' ), path: `${ summaryPath }${ daysSinceQuarterStart }` },
-		{ value: '-1', label: translate( 'All Time' ), path: `${ summaryPath }-1` }
+		{ value: '0', label: getSummaryPeriodLabel(), path: summaryPeriodPath, stat: 'Period Summary' },
+		{ value: '7', label: translate( '7 days' ), path: `${ summaryPath }7`, stat: '7 Days' },
+		{ value: '30', label: translate( '30 days' ), path: `${ summaryPath }30`, stat: '30 Days' },
+		{ value: '90', label: translate( 'Quarter' ), path: `${ summaryPath }90`, stat: 'Quarter' },
+		{ value: '365', label: translate( 'Year' ), path: `${ summaryPath }365`, stat: 'Year' },
+		{ value: '-1', label: translate( 'All Time' ), path: `${ summaryPath }-1`, stat: 'All Time' }
 	];
 
 	const numberDays = get( query, 'num', '0' );
@@ -55,8 +56,16 @@ export const StatsModuleSummaryLinks = props => {
 			<SectionNav selectedText={ selected.label }>
 				<NavTabs label={ translate( 'Summary' ) }>
 					{ options.map( ( item ) => {
+						const onClick = () => {
+							recordStats.apply( this, [ item ] );
+						};
 						return (
-							<NavItem path={ item.path } selected={ item.value === selected.value } key={ item.value }>
+							<NavItem
+								path={ item.path }
+								selected={ item.value === selected.value }
+								key={ item.value }
+								onClick={ onClick }
+							>
 								{ item.label }
 							</NavItem>
 						);

--- a/client/my-sites/stats/stats-module/connected-list.jsx
+++ b/client/my-sites/stats/stats-module/connected-list.jsx
@@ -131,9 +131,9 @@ class StatsConnectedModule extends Component {
 					</SectionHeader>
 				}
 				<Card compact className={ cardClasses }>
+					{ isAllTime && <AllTimeNav path={ path } query={ query } period={ period } /> }
 					{ noData && <ErrorPanel message={ moduleStrings.empty } /> }
 					{ hasError && <ErrorPanel /> }
-					{ isAllTime && <AllTimeNav path={ path } query={ query } period={ period } /> }
 					{ this.props.children }
 					<StatsListLegend value={ moduleStrings.value } label={ moduleStrings.item } />
 					<StatsModulePlaceholder isLoading={ isLoading } />


### PR DESCRIPTION
This is a follow-up to #10636 -  In the original PR I accidentally forgot to include the 'Last Year' as a link in the Summary Navigation.  Furthermore, after analyzing the old summary links in Atlas Stats, I realized that Quarter, and Year mapped to the last 90 and 365 days.

As such, I simplified the calculation of `Quarter` in this PR, and added in some event tracking to log how often these links are used.

I also used the same strings that the old Atlas links are using to ease i18n:

<img width="494" alt="my_stats_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/22081235/a3f23056-dd77-11e6-9220-84475cce1c28.png">

__To Test__
- Open up a country summary page
- Interact with all links, ensure they load new data as expected
- you can also set your debug to `calypso:analytics` and verify events are being logged as expected