### PR TITLE
Checkout: Remove upsell for domain-only sites

### DIFF
--- a/client/my-sites/upgrades/cart/cart-plan-ad.jsx
+++ b/client/my-sites/upgrades/cart/cart-plan-ad.jsx
@@ -1,33 +1,40 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 import page from 'page';
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies
  */
 import CartAd from './cart-ad';
 import { cartItems } from 'lib/cart-values';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isDomainOnlySite } from 'state/selectors';
 import { isPlan } from 'lib/products-values';
 import * as upgradesActions from 'lib/upgrades/actions';
 import { PLAN_PREMIUM } from 'lib/plans/constants';
 
-const CartPlanAd = React.createClass( {
+class CartPlanAd extends Component {
 	addToCartAndRedirect( event ) {
 		event.preventDefault();
 		upgradesActions.addItem( cartItems.premiumPlan( PLAN_PREMIUM, { isFreeTrial: false } ) );
 		page( '/checkout/' + this.props.selectedSite.slug );
-	},
+	}
+
 	shouldDisplayAd() {
 		const { cart, selectedSite } = this.props;
 
-		return cart.hasLoadedFromServer &&
+		return ! this.props.isDomainOnlySite &&
+			cart.hasLoadedFromServer &&
 			! cartItems.hasDomainCredit( cart ) &&
 			cartItems.getDomainRegistrations( cart ).length === 1 &&
 			selectedSite.plan &&
 			! isPlan( selectedSite.plan );
-	},
+	}
+
 	render() {
 		if ( ! this.shouldDisplayAd() ) {
 			return null;
@@ -36,15 +43,23 @@ const CartPlanAd = React.createClass( {
 		return (
 			<CartAd>
 				{
-					this.translate( 'Get this domain for free when you upgrade to {{strong}}WordPress.com Premium{{/strong}}!', {
+					this.props.translate( 'Get this domain for free when you upgrade to {{strong}}WordPress.com Premium{{/strong}}!', {
 						components: { strong: <strong /> }
 					} )
 				}
 				{ ' ' }
-				<a href="" onClick={ this.addToCartAndRedirect }>{ this.translate( 'Upgrade Now' ) }</a>
+				<a href="" onClick={ this.addToCartAndRedirect }>{ this.props.translate( 'Upgrade Now' ) }</a>
 			</CartAd>
 		);
 	}
-} );
+}
 
-export default CartPlanAd;
+export default connect(
+	( state ) => {
+		const selectedSiteId = getSelectedSiteId( state );
+
+		return {
+			isDomainOnlySite: isDomainOnlySite( state, selectedSiteId )
+		};
+	}
+)( localize( CartPlanAd ) );


### PR DESCRIPTION
We want to skip the upsell for domain-only sites. Refactor the Component per lint.

Test:
1. Make a domains only site (or fake a return from the server that sets `is_domain_only` to `true`)
2. Go to checkout
3. Make sure you're not seeing the upsell:
![screenshot-calypso localhost_3000-2017-01-18-20-03-06](https://cloud.githubusercontent.com/assets/1103398/22082203/1866b00c-ddc7-11e6-8c49-a1e9d67f06cf.png)

- [x] Code
- [x] Product
