### PR TITLE
Ads: Updated TOS link

### DIFF
--- a/client/my-sites/ads/form-settings.jsx
+++ b/client/my-sites/ads/form-settings.jsx
@@ -381,8 +381,8 @@ const AdsFormSettings = React.createClass( {
 						name="tos"
 						checkedLink={ this.linkState( 'tos' ) }
 						disabled={ this.state.isLoading || 'signed' === this.state.tos } />
-					<span>{ this.props.translate( 'I have read and agree to the {{a}}WordAds Terms of Service{{/a}}.', {
-						components: { a: <a href="https://wordpress.com/tos-wordads/" target="_blank" rel="noopener noreferrer" /> }
+					<span>{ this.props.translate( 'I have read and agree to the {{a}}Automattic Ads Terms of Service{{/a}}.', {
+						components: { a: <a href="https://wordpress.com/automattic-ads-tos/" target="_blank" rel="noopener noreferrer" /> }
 					} ) }</span>
 				</FormLabel>
 			</FormFieldset>


### PR DESCRIPTION
Update TOS link to the new Automattic Ads Terms of Service

To test:
1. Open Calypso, go to site with WordAds enabled. (e.g. http://calypso.localhost:3000/ads/settings/derek.blog)
2. Go to Settings tab.
3. TOS link at bottom should say `I have read and agree to the Automattic Ads Terms of Service.` and link to new Ads TOS: https://wordpress.com/automattic-ads-tos/

<img width="698" alt="screen shot 2017-01-18 at 11 50 56 am" src="https://cloud.githubusercontent.com/assets/273708/22084494/6e3145d6-dd74-11e6-97a1-5a370670f160.png">
