### PR TITLE
Signup: add `subHeaderText` to design-type steps.

### DIFF
--- a/client/signup/steps/design-type-with-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/index.jsx
@@ -159,6 +159,7 @@ class DesignTypeWithStoreStep extends Component {
 						positionInFlow={ this.props.positionInFlow }
 						fallbackHeaderText={ this.props.translate( 'What would you like your homepage to look like?' ) }
 						fallbackSubHeaderText={ this.props.translate( 'This will help us figure out what kinds of designs to show you.' ) }
+						subHeaderText={ this.props.translate( 'First up, what would you like your homepage to look like?' ) }
 						signupProgress={ this.props.signupProgress }
 						stepContent={ this.renderChoices() } />
 				</div>

--- a/client/signup/steps/design-type/index.jsx
+++ b/client/signup/steps/design-type/index.jsx
@@ -51,6 +51,7 @@ export default React.createClass( {
 					positionInFlow={ this.props.positionInFlow }
 					fallbackHeaderText={ this.translate( 'What would you like your homepage to look like?' ) }
 					fallbackSubHeaderText={ this.translate( 'This will help us figure out what kinds of designs to show you.' ) }
+					subHeaderText={ this.translate( 'First up, what would you like your homepage to look like?' ) }
 					signupProgress={ this.props.signupProgress }
 					stepContent={ this.renderChoices() } />
 			</div>


### PR DESCRIPTION
With the removal of the `/survey/` step in #10210, either the `/design-type/` or `/design-type-with-store/` step is now the first step in Signup for most users. Since Signup overwrites the header and subheader of the first step in Signup, there are no longer instructions for users to follow on the step.

![first-step-header](https://cloud.githubusercontent.com/assets/942359/22084569/a24ecb16-dd9e-11e6-859c-d8b89641a509.png)

This PR adds a more helpful sub-header to the steps to follow other first step fallbacks.

![first-step-subheader](https://cloud.githubusercontent.com/assets/942359/22084719/27097f4a-dd9f-11e6-8e27-1e87ac642169.png)

To test:
1. Start Signup with the main flow (/start/).
2. Verify that the sub-header on the first step is helpful.
3. Complete Signup, making sure that there are no errors and that the site is created.