### PR TITLE
Reader/fix photo expanding

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -140,7 +140,7 @@ export default class ReaderPostCard extends React.Component {
 
 		let readerPostCard;
 		if ( isPhotoPost ) {
-			readerPostCard = <PhotoPost post= { post }title={ title } onClick={ this.handleCardClick } >
+			readerPostCard = <PhotoPost post={ post } title={ title } onClick={ this.handleCardClick } >
 					{ discoverFollowButton }
 					{ readerPostActions }
 				</PhotoPost>;

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -19,7 +19,6 @@ import GalleryPost from './gallery';
 import PhotoPost from './photo';
 import StandardPost from './standard';
 import FollowButton from 'reader/follow-button';
-import PostStoreActions from 'lib/feed-post-store/actions';
 import DailyPostButton from 'blocks/daily-post-button';
 import { isDailyPostChallengeOrPrompt } from 'blocks/daily-post-button/helper';
 import { getDiscoverBlogName,
@@ -95,14 +94,6 @@ export default class ReaderPostCard extends React.Component {
 		}
 	}
 
-	handlePhotoCardExpanded = () => {
-		stats.recordTrackForPost( 'calypso_reader_photo_expanded', this.props.post );
-
-		// Record page view
-		PostStoreActions.markSeen( this.props.post );
-		stats.recordTrackForPost( 'calypso_reader_article_opened', this.props.post );
-	}
-
 	render() {
 		const {
 			post,
@@ -133,7 +124,7 @@ export default class ReaderPostCard extends React.Component {
 		if ( isDiscover ) {
 			const discoverBlogName = getDiscoverBlogName( post ) || null;
 			discoverFollowButton = discoverBlogName &&
-					<DiscoverFollowButton siteName={ discoverBlogName } followUrl={ getDiscoverFollowUrl( post ) } />;
+				<DiscoverFollowButton siteName={ discoverBlogName } followUrl={ getDiscoverFollowUrl( post ) } />;
 		}
 
 		const readerPostActions = <ReaderPostActions
@@ -149,12 +140,7 @@ export default class ReaderPostCard extends React.Component {
 
 		let readerPostCard;
 		if ( isPhotoPost ) {
-			const { height, width } = post.canonical_media;
-			readerPostCard = <PhotoPost imageUri={ post.canonical_media.src }
-				href={ post.URL }
-				imageSize={ { height, width } }
-				onExpanded={ this.handlePhotoCardExpanded }
-				title={ title } >
+			readerPostCard = <PhotoPost post= { post }title={ title } onClick={ this.handleCardClick } >
 					{ discoverFollowButton }
 					{ readerPostActions }
 				</PhotoPost>;

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -121,7 +121,7 @@ class PostPhoto extends React.Component {
 				</a>
 				<AutoDirection>
 					<h1 className="reader-post-card__title">
-						<a className="reader-post-card__title-link" href={ post.URL }>{ linkTitle }</a>
+						<a className="reader-post-card__title-link" href={ post.URL } onClick={ this.props.onClick }>{ linkTitle }</a>
 					</h1>
 				</AutoDirection>
 			</div>


### PR DESCRIPTION
Fix for #10750 

This correctly links the second click on a photo card to the full post view.

![reader__expand_photo2](https://cloud.githubusercontent.com/assets/744755/22085104/889e01b2-dd87-11e6-8928-727c74de08fb.gif)

I also moved more of the photo only behavior to `photo.jsx`

cc @fraying 