### PR TITLE
State: Ensure that all unhandled actions return same state

### DIFF
--- a/client/state/preview/reducer.js
+++ b/client/state/preview/reducer.js
@@ -43,8 +43,7 @@ function siteReducer( newState = siteInitialState, action ) {
 	return state;
 }
 
-export default function( newState = initialState, action ) {
-	const state = Object.assign( {}, initialState, newState );
+export default function( state = initialState, action ) {
 	switch ( action.type ) {
 		case ActionTypes.PREVIEW_MARKUP_RECEIVE:
 		case ActionTypes.PREVIEW_CUSTOMIZATIONS_CLEAR:

--- a/client/state/test/index.js
+++ b/client/state/test/index.js
@@ -21,6 +21,18 @@ describe( 'index', () => {
 			expect( reduxStoreWithEmptyState ).to.eql( reduxStoreNoArgs );
 		} );
 
+		it( 'should return same state on unhandled action', () => {
+			// If you're here investigating why tests are failing, you should
+			// ensure that your reducer is not returning a new state object if
+			// it's not handling the action (i.e. that nothing has changed)
+			const store = createReduxStore();
+			const originalState = store.getState();
+
+			store.dispatch( { type: '__GARBAGE' } );
+
+			expect( store.getState() ).to.equal( originalState );
+		} );
+
 		it( 'is instantiated with initialState', () => {
 			const user = { ID: 1234, display_name: 'test user', username: 'testuser' };
 			const initialState = {


### PR DESCRIPTION
Related: #4690

This pull request seeks to resolve an issue where dispatching an intentionally unhandled action causes state to have changed. Since we rely on strict comparison between state for performance reasons (e.g. [persistence bypassing](https://github.com/Automattic/wp-calypso/blob/345594e557a57e31783b664c010ef942ec8cb88b/client/state/initial-state.js#L75)), it's important that state is updated only when there are in-fact changes.

__Testing instructions:__

Verify that tests pass:

```
npm run test-client
```

Since there are no tests for preview state, well... I guess repeat steps from #4690?

__Follow-up tasks:__

- [ ] Write tests for preview state