### PR TITLE
Stats: Try a Unified Followers View

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -342,6 +342,7 @@
 @import 'my-sites/stats/stats-period-navigation/style';
 @import 'my-sites/stats/stats-post-likes/style';
 @import 'my-sites/stats/stats-post-summary/style';
+@import 'my-sites/stats/stats-reach/style';
 @import 'my-sites/stats/stats-site-overview/style';
 @import 'my-sites/stats/stats-tabs/style';
 @import 'my-sites/theme/style';

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -81,6 +81,7 @@ export default React.createClass( {
 				<div id="my-stats-content">
 					<PostingActivity />
 					<LatestPostSummary site={ site } />
+					<Reach />
 					<TodaysStats
 						siteId={ site ? site.ID : null }
 						period="day"
@@ -89,7 +90,6 @@ export default React.createClass( {
 						title={ this.translate( 'Today\'s Stats' ) }
 					/>
 					<AllTime />
-					<Reach />
 					<MostPopular />
 					{ site && <DomainTip siteId={ site.ID } event="stats_insights_domain" /> }
 					<div className="stats-insights__nonperiodic has-recent">

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -13,6 +13,7 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import AllTime from 'my-sites/stats/all-time/';
 import Comments from '../stats-comments';
 import Followers from '../stats-followers';
+import Reach from '../stats-reach';
 import PostingActivity from '../post-trends';
 import TodaysStats from '../stats-site-overview';
 import StatsConnectedModule from '../stats-module/connected-list';
@@ -88,6 +89,7 @@ export default React.createClass( {
 						title={ this.translate( 'Today\'s Stats' ) }
 					/>
 					<AllTime />
+					<Reach />
 					<MostPopular />
 					{ site && <DomainTip siteId={ site.ID } event="stats_insights_domain" /> }
 					<div className="stats-insights__nonperiodic has-recent">

--- a/client/my-sites/stats/stats-reach/index.jsx
+++ b/client/my-sites/stats/stats-reach/index.jsx
@@ -60,6 +60,12 @@ class StatsReach extends Component {
 				<Card className={ classNames( 'stats-module', 'stats__overview' ) }>
 					<StatsTabs borderless>
 						<StatsTab
+							gridicon="user"
+							label={ translate( 'Total' ) }
+							loading={ isLoading }
+							value={ totalFollowers }>
+						</StatsTab>
+						<StatsTab
 							gridicon="my-sites"
 							label={ translate( 'WordPress.com' ) }
 							loading={ isLoadingFollowData }
@@ -76,13 +82,6 @@ class StatsReach extends Component {
 							label={ translate( 'Publicize' ) }
 							loading={ isLoadingPublicize }
 							value={ publicizeFollowCount } />
-						<StatsTab
-							className="all-time__is-best"
-							gridicon="user"
-							label={ translate( 'Total' ) }
-							loading={ isLoading }
-							value={ totalFollowers }>
-						</StatsTab>
 					</StatsTabs>
 				</Card>
 			</div>

--- a/client/my-sites/stats/stats-reach/index.jsx
+++ b/client/my-sites/stats/stats-reach/index.jsx
@@ -1,7 +1,7 @@
 /**
 * External dependencies
 */
-import React, { Component, PropTypes } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { get, reduce } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -21,67 +21,48 @@ import {
 	getSiteStatsNormalizedData
 } from 'state/stats/lists/selectors';
 
-class StatsReach extends Component {
+export const StatsReach = props => {
+	const { translate, siteId, followData, publicizeData, isLoadingPublicize, siteSlug } = props;
 
-	static propTypes = {
-		translate: PropTypes.func,
-		siteId: PropTypes.number,
-		followData: PropTypes.object,
-		publicizeData: PropTypes.array,
-		isLoadingPublicize: PropTypes.bool,
-		siteSlug: PropTypes.string,
-	};
+	const isLoadingFollowData = ! followData;
+	const wpcomFollowCount = get( followData, 'total_wpcom', 0 );
+	const emailFollowCount = get( followData, 'total_email', 0 );
+	const publicizeFollowCount = reduce( publicizeData, ( sum, item ) => {
+		return sum + item.value;
+	}, 0 );
 
-	render() {
-		const {
-			translate,
-			siteId,
-			followData,
-			publicizeData,
-			isLoadingPublicize,
-			siteSlug,
-		} = this.props;
-
-		const isLoadingFollowData = ! followData;
-		const wpcomFollowCount = get( followData, 'total_wpcom', 0 );
-		const emailFollowCount = get( followData, 'total_email', 0 );
-		const publicizeFollowCount = reduce( publicizeData, ( sum, item ) => {
-			return sum + item.value;
-		}, 0 );
-
-		return (
-			<div>
-				{ siteId && <QuerySiteStats siteId={ siteId } statType="statsFollowers" /> }
-				{ siteId && <QuerySiteStats siteId={ siteId } statType="statsPublicize" /> }
-				<SectionHeader label={ translate( 'Followers' ) } />
-				<Card className="stats-module stats-reach__card">
-					<StatsTabs borderless>
-						<StatsTab
-							className="stats-reach__tab"
-							gridicon="my-sites"
-							label={ translate( 'WordPress.com' ) }
-							loading={ isLoadingFollowData }
-							href={ `/people/followers/${ siteSlug }` }
-							value={ wpcomFollowCount } />
-						<StatsTab
-							className="stats-reach__tab"
-							gridicon="mail"
-							label={ translate( 'Email' ) }
-							loading={ isLoadingFollowData }
-							href={ `/people/email-followers/${ siteSlug }` }
-							value={ emailFollowCount } />
-						<StatsTab
-							className="stats-reach__tab"
-							gridicon="share"
-							label={ translate( 'Social' ) }
-							loading={ isLoadingPublicize }
-							value={ publicizeFollowCount } />
-					</StatsTabs>
-				</Card>
-			</div>
-		);
-	}
-}
+	return (
+		<div>
+			{ siteId && <QuerySiteStats siteId={ siteId } statType="statsFollowers" /> }
+			{ siteId && <QuerySiteStats siteId={ siteId } statType="statsPublicize" /> }
+			<SectionHeader label={ translate( 'Followers' ) } />
+			<Card className="stats-module stats-reach__card">
+				<StatsTabs borderless>
+					<StatsTab
+						className="stats-reach__tab"
+						gridicon="my-sites"
+						label={ translate( 'WordPress.com' ) }
+						loading={ isLoadingFollowData }
+						href={ `/people/followers/${ siteSlug }` }
+						value={ wpcomFollowCount } />
+					<StatsTab
+						className="stats-reach__tab"
+						gridicon="mail"
+						label={ translate( 'Email' ) }
+						loading={ isLoadingFollowData }
+						href={ `/people/email-followers/${ siteSlug }` }
+						value={ emailFollowCount } />
+					<StatsTab
+						className="stats-reach__tab"
+						gridicon="share"
+						label={ translate( 'Social' ) }
+						loading={ isLoadingPublicize }
+						value={ publicizeFollowCount } />
+				</StatsTabs>
+			</Card>
+		</div>
+	);
+};
 
 export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );

--- a/client/my-sites/stats/stats-reach/index.jsx
+++ b/client/my-sites/stats/stats-reach/index.jsx
@@ -1,0 +1,107 @@
+/**
+* External dependencies
+*/
+import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import { get, reduce } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import StatsTabs from '../stats-tabs';
+import StatsTab from '../stats-tabs/tab';
+import SectionHeader from 'components/section-header';
+import QuerySiteStats from 'components/data/query-site-stats';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
+import {
+	isRequestingSiteStatsForQuery,
+	getSiteStatsNormalizedData
+} from 'state/stats/lists/selectors';
+
+class StatsReach extends Component {
+
+	static propTypes = {
+		translate: PropTypes.func,
+		siteId: PropTypes.number,
+		followData: PropTypes.object,
+		publicizeData: PropTypes.array,
+		isLoadingPublicize: PropTypes.bool,
+		siteSlug: PropTypes.string,
+	};
+
+	render() {
+		const {
+			translate,
+			siteId,
+			followData,
+			publicizeData,
+			isLoadingPublicize,
+			siteSlug,
+		} = this.props;
+
+		const isLoadingFollowData = ! followData;
+		const isLoading = isLoadingFollowData || isLoadingPublicize;
+		const wpcomFollowCount = get( followData, 'total_wpcom', 0 );
+		const emailFollowCount = get( followData, 'total_email', 0 );
+		const publicizeFollowCount = reduce( publicizeData, ( sum, item ) => {
+			return sum + item.value;
+		}, 0 );
+		const totalFollowers = wpcomFollowCount + emailFollowCount + publicizeFollowCount;
+
+		return (
+			<div>
+				{ siteId && <QuerySiteStats siteId={ siteId } statType="statsFollowers" /> }
+				{ siteId && <QuerySiteStats siteId={ siteId } statType="statsPublicize" /> }
+				<SectionHeader label={ translate( 'Followers' ) } />
+				<Card className={ classNames( 'stats-module', 'stats__overview' ) }>
+					<StatsTabs borderless>
+						<StatsTab
+							gridicon="my-sites"
+							label={ translate( 'WordPress.com' ) }
+							loading={ isLoadingFollowData }
+							href={ `/people/followers/${ siteSlug }` }
+							value={ wpcomFollowCount } />
+						<StatsTab
+							gridicon="mail"
+							label={ translate( 'Email' ) }
+							loading={ isLoadingFollowData }
+							href={ `/people/email-followers/${ siteSlug }` }
+							value={ emailFollowCount } />
+						<StatsTab
+							gridicon="share"
+							label={ translate( 'Publicize' ) }
+							loading={ isLoadingPublicize }
+							value={ publicizeFollowCount } />
+						<StatsTab
+							className="all-time__is-best"
+							gridicon="user"
+							label={ translate( 'Total' ) }
+							loading={ isLoading }
+							value={ totalFollowers }>
+						</StatsTab>
+					</StatsTabs>
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	const followData = getSiteStatsNormalizedData( state, siteId, 'statsFollowers' );
+	const publicizeData = getSiteStatsNormalizedData( state, siteId, 'statsPublicize' );
+	const isLoadingPublicize = isRequestingSiteStatsForQuery( state, siteId, 'statsPublicize' ) && ! publicizeData.length;
+	const siteSlug = getSiteSlug( state, siteId );
+
+	return {
+		siteId,
+		followData,
+		publicizeData,
+		isLoadingPublicize,
+		siteSlug,
+	};
+} )( localize( StatsReach ) );

--- a/client/my-sites/stats/stats-reach/index.jsx
+++ b/client/my-sites/stats/stats-reach/index.jsx
@@ -2,7 +2,6 @@
 * External dependencies
 */
 import React, { Component, PropTypes } from 'react';
-import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { get, reduce } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -44,42 +43,37 @@ class StatsReach extends Component {
 		} = this.props;
 
 		const isLoadingFollowData = ! followData;
-		const isLoading = isLoadingFollowData || isLoadingPublicize;
 		const wpcomFollowCount = get( followData, 'total_wpcom', 0 );
 		const emailFollowCount = get( followData, 'total_email', 0 );
 		const publicizeFollowCount = reduce( publicizeData, ( sum, item ) => {
 			return sum + item.value;
 		}, 0 );
-		const totalFollowers = wpcomFollowCount + emailFollowCount + publicizeFollowCount;
 
 		return (
 			<div>
 				{ siteId && <QuerySiteStats siteId={ siteId } statType="statsFollowers" /> }
 				{ siteId && <QuerySiteStats siteId={ siteId } statType="statsPublicize" /> }
 				<SectionHeader label={ translate( 'Followers' ) } />
-				<Card className={ classNames( 'stats-module', 'stats__overview' ) }>
+				<Card className="stats-module stats-reach__card">
 					<StatsTabs borderless>
 						<StatsTab
-							gridicon="user"
-							label={ translate( 'Total' ) }
-							loading={ isLoading }
-							value={ totalFollowers }>
-						</StatsTab>
-						<StatsTab
+							className="stats-reach__tab"
 							gridicon="my-sites"
 							label={ translate( 'WordPress.com' ) }
 							loading={ isLoadingFollowData }
 							href={ `/people/followers/${ siteSlug }` }
 							value={ wpcomFollowCount } />
 						<StatsTab
+							className="stats-reach__tab"
 							gridicon="mail"
 							label={ translate( 'Email' ) }
 							loading={ isLoadingFollowData }
 							href={ `/people/email-followers/${ siteSlug }` }
 							value={ emailFollowCount } />
 						<StatsTab
+							className="stats-reach__tab"
 							gridicon="share"
-							label={ translate( 'Publicize' ) }
+							label={ translate( 'Social' ) }
 							loading={ isLoadingPublicize }
 							value={ publicizeFollowCount } />
 					</StatsTabs>

--- a/client/my-sites/stats/stats-reach/style.scss
+++ b/client/my-sites/stats/stats-reach/style.scss
@@ -1,0 +1,12 @@
+.stats-tabs .stats-tab {
+	&.stats-reach__tab {
+		@include breakpoint( ">480px" ) {
+			width: 33%;
+		}
+
+		.value {
+			font-size: 24px;
+			padding: 16px 0;
+		}
+	}
+}

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -161,6 +161,52 @@ describe( 'utils', () => {
 			} );
 		} );
 
+		describe( 'statsFollowers()', () => {
+			it( 'should return null if no data is provided', () => {
+				const parsedData = normalizers.statsFollowers();
+				expect( parsedData ).to.be.null;
+			} );
+
+			it( 'should properly parse followers response', () => {
+				const parsedData = normalizers.statsFollowers( {
+					page: 1,
+					pages: 1,
+					total: 1,
+					total_email: 5,
+					total_wpcom: 120,
+					subscribers: [
+						{
+							avatar: null,
+							label: 'wapuu@wordpress.org',
+							ID: 11111111,
+							url: null,
+							follow_data: null,
+							date_subscribed: '2015-04-07T18:53:05+00:00'
+						}
+					]
+				} );
+
+				expect( parsedData ).to.eql( {
+					total_email: 5,
+					total_wpcom: 120,
+					subscribers: [ {
+						label: 'wapuu@wordpress.org',
+						iconClassName: 'avatar-user',
+						icon: null,
+						link: null,
+						value: {
+							type: 'relative-date',
+							value: '2015-04-07T18:53:05+00:00'
+						},
+						actions: [ {
+							type: 'follow',
+							data: false
+						} ]
+					} ]
+				} );
+			} );
+		} );
+
 		describe( 'statsTopPosts()', () => {
 			it( 'should return an empty array if data is null', () => {
 				const parsedData = normalizers.statsTopPosts();

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -50,19 +50,6 @@ function parseAvatar( avatarUrl ) {
 }
 
 /**
- * Parse the avatar URL
- * @param  {String} avatarUrl Raw avatar URL
- * @return {String}           Parsed URL
- */
-function parseAvatar( avatarUrl ) {
-	if ( ! avatarUrl ) {
-		return null;
-	}
-	const [ avatarBaseUrl ] = avatarUrl.split( '?' );
-	return avatarBaseUrl + '?d=mm';
-}
-
-/**
  * Builds data into escaped array for CSV export
  *
  * @param  {Object} data   Normalized stats data object

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -50,6 +50,19 @@ function parseAvatar( avatarUrl ) {
 }
 
 /**
+ * Parse the avatar URL
+ * @param  {String} avatarUrl Raw avatar URL
+ * @return {String}           Parsed URL
+ */
+function parseAvatar( avatarUrl ) {
+	if ( ! avatarUrl ) {
+		return null;
+	}
+	const [ avatarBaseUrl ] = avatarUrl.split( '?' );
+	return avatarBaseUrl + '?d=mm';
+}
+
+/**
  * Builds data into escaped array for CSV export
  *
  * @param  {Object} data   Normalized stats data object
@@ -264,6 +277,39 @@ export const normalizers = {
 				} ]
 			};
 		} );
+	},
+
+	/**
+	 * Returns a normalized statsFollowers object
+	 *
+	 * @param  {Object} data    Stats data
+	 * @return {?Object}         Normalized stats data
+	 */
+	statsFollowers( data ) {
+		if ( ! data ) {
+			return null;
+		}
+		const { total_wpcom, total_email } = data;
+		const subscriberData = get( data, [ 'subscribers' ], [] );
+
+		const subscribers = subscriberData.map( ( item ) => {
+			return {
+				label: item.label,
+				iconClassName: 'avatar-user',
+				icon: parseAvatar( item.avatar ),
+				link: item.url,
+				value: {
+					type: 'relative-date',
+					value: item.date_subscribed
+				},
+				actions: [ {
+					type: 'follow',
+					data: item.follow_data ? item.follow_data.params : false
+				} ]
+			};
+		} );
+
+		return { total_wpcom, total_email, subscribers };
 	},
 
 	/**


### PR DESCRIPTION
I began converting the existing Followers component and data source to Redux, and I figured why not just use some existing patterns on the Insights page and get a "Try" branch going for #10347

This "Reach" component, which I still labeled Followers ( because old habits are hard to break ) utilize the `statsFollowers` normalizer ( 15bdbdd ) and the existing `statsPublicize` normalizer to provide quick numbers around followers across the three buckets of WordPress.com, Email, and Publicize.

WordPress.com and Email followers are linked to the appropriate "People" tab, and I suppose the Publicize number could link to the an anchor on the existing Publicize module on the Insights page.

<img width="935" alt="stats_ _trout_bummin_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/22090661/02d3561a-dda8-11e6-8851-a6a76084c996.png">
( yes these are stats from my personal blog, and yes that one email follower is my Mom <3 )

Anyhow, to test it out, open up the Insights page.  Curious to hear thoughts from @karmatosed and @folletto 

I am going to get a PR going also to update the followers number seen in the navigation bar on the stats page to use the total email + wpcom followers.