### PR TITLE
Import: Disable Cancel button while importing

### DIFF
--- a/client/my-sites/importer/importer-header.jsx
+++ b/client/my-sites/importer/importer-header.jsx
@@ -75,11 +75,11 @@ export const ImporterHeader = React.createClass( {
 		}
 
 		if ( includes( cancelStates, importerState ) ) {
-			return this.translate( 'Cancel', { context: 'verb' } );
+			return this.translate( 'Close', { context: 'verb, to Close a dialog' } );
 		}
 
 		if ( includes( stopStates, importerState ) ) {
-			return this.translate( 'Stop Import', { context: 'verb' } );
+			return this.translate( 'Importing...', { context: 'verb' } );
 		}
 
 		if ( includes( doneStates, importerState ) ) {
@@ -89,9 +89,8 @@ export const ImporterHeader = React.createClass( {
 
 	render: function() {
 		const { importerStatus: { importerState }, icon, isEnabled, title, description } = this.props;
-		const canCancel = isEnabled && ! includes( [ appStates.UPLOADING ], importerState );
-		const isScary = includes( [ ...stopStates, ...cancelStates ], importerState );
-
+		const canCancel = isEnabled && ! includes( [ appStates.UPLOADING, ...stopStates ], importerState );
+		const isScary = includes( [ ...cancelStates ], importerState );
 		return (
 			<header className="importer-service">
 				{ includes( [ 'wordpress', 'medium' ], icon )
@@ -100,7 +99,7 @@ export const ImporterHeader = React.createClass( {
 				<Button
 					className="importer__master-control"
 					disabled={ ! canCancel }
-					isPrimary={ false }
+					isPrimary={ true }
 					scary={ isScary }
 					onClick={ this.controlButtonClicked }
 				>

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -115,7 +115,7 @@ export const ImportingPane = React.createClass( {
 
 	getHeadingText: function() {
 		return this.translate(
-			'Importing should take 15 minutes, sometimes more if your site has a lot of media. ' +
+			'Importing takes 15 minutes or a while longer if your site has a lot of media. ' +
 			'You can safely navigate away from this page if you need to: we\'ll send you a notification when it\'s done.'
 		);
 	},

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -115,15 +115,8 @@ export const ImportingPane = React.createClass( {
 
 	getHeadingText: function() {
 		return this.translate(
-			'Importing may take a while, but you can ' +
-			'safely navigate away from this page if you need ' +
-			'to. If you {{b}}stop the import{{/b}}, your site ' +
-			'will be {{b2}}partially imported{{/b2}}.', {
-				components: {
-					b: <strong />,
-					b2: <strong />
-				}
-			}
+			'Importing should take 15 minutes, sometimes more if your site has a lot of media. ' +
+			'You can safely navigate away from this page if you need to: we\'ll send you a notification when it\'s done.'
 		);
 	},
 

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -79,7 +79,7 @@ export const UploadingPane = React.createClass( {
 							className="importer__start"
 							onClick={ () => startMappingAuthors( this.props.importerStatus.importerId ) }
 						>
-							{ this.translate( 'Start Import' ) }
+							{ this.translate( 'Continue' ) }
 						</Button>
 					</div>
 				);


### PR DESCRIPTION
Hide Stop button during import process to prevent users from causing backfill failures when they needlessly click on it.

**Visual changes**

Before:
![old](https://cloud.githubusercontent.com/assets/1182160/22424638/abd8f320-e6f7-11e6-9b90-f892518e6dff.png)

After:
![new](https://cloud.githubusercontent.com/assets/1182160/22424644/b18b13b6-e6f7-11e6-976d-c14f80c3c77d.png)

