### PR TITLE
Site Settings: Fix related posts main toggle label wording

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -312,7 +312,7 @@ class SiteSettingsFormGeneral extends Component {
 							disabled={ isRequestingSettings }
 							onChange={ handleToggle( 'jetpack_relatedposts_enabled' ) }>
 							<span className="site-settings__toggle-label">
-								{ translate( 'Hide related content after posts' ) }
+								{ translate( 'Show related content after posts' ) }
 							</span>
 						</FormToggle>
 					</li>


### PR DESCRIPTION
This PR fixes the wrong wording of the main toggle label in Related Posts. Currently it says "Hide related content after posts", while it should be the opposite. This has been introduced in #10423.

To test:

* Checkout this branch, or get it going on calypso.live
* Go to `/settings/general/$site`
* Verify the wording of the main toggle label in the Related Posts card is now accurate.