### PR TITLE
Posts: Disable Share button for Jetpack sites with Publicize deactivated

### DIFF
--- a/client/my-sites/posts/post-controls.jsx
+++ b/client/my-sites/posts/post-controls.jsx
@@ -5,6 +5,7 @@ var React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	url = require( 'url' );
 import classNames from 'classnames';
+import { connect } from 'react-redux';
 import { noop } from 'lodash';
 
 /**
@@ -14,15 +15,15 @@ var config = require( 'config' ),
 	utils = require( 'lib/posts/utils' ),
 	Gridicon = require( 'components/gridicon'),
 	recordEvent = require( 'lib/analytics' ).ga.recordEvent;
+import { isPublicizeEnabled } from 'state/selectors';
 
-module.exports = React.createClass( {
-	displayName: 'PostControls',
-
+const PostControls = React.createClass( {
 	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		post: React.PropTypes.object.isRequired,
 		editURL: React.PropTypes.string.isRequired,
+		isPublicizeEnabled: React.PropTypes.bool.isRequired,
 		onShowMore: React.PropTypes.func.isRequired,
 		onHideMore: React.PropTypes.func.isRequired,
 		onPublish: React.PropTypes.func,
@@ -115,7 +116,7 @@ module.exports = React.createClass( {
 
 			if ( config.isEnabled( 'republicize' ) ) {
 				availableControls.push( {
-					disabled: this.props.site && this.props.site.options.publicize_permanently_disabled,
+					disabled: ! this.props.isPublicizeEnabled,
 					text: this.translate( 'Share' ),
 					className: 'post-controls__share',
 					onClick: this.props.onToggleShare,
@@ -242,3 +243,9 @@ module.exports = React.createClass( {
 	},
 
 } );
+
+export default connect(
+	( state, props ) => ( {
+		isPublicizeEnabled: isPublicizeEnabled( state, props.site.ID, props.post.type ),
+	} )
+)( PostControls );

--- a/client/my-sites/posts/post-share.jsx
+++ b/client/my-sites/posts/post-share.jsx
@@ -12,8 +12,8 @@ import SocialLogo from 'social-logos';
  */
 import QueryPostTypes from 'components/data/query-post-types';
 import Button from 'components/button';
-import { postTypeSupports } from 'state/post-types/selectors';
-import { isJetpackModuleActive, getSiteSlug } from 'state/sites/selectors';
+import { isPublicizeEnabled } from 'state/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getSiteUserConnections, hasFetchedConnections } from 'state/sharing/publicize/selectors';
 import { fetchConnections as requestConnections, sharePost, dismissShareConfirmation } from 'state/sharing/publicize/actions';
@@ -126,12 +126,6 @@ const PostSharing = React.createClass( {
 			return null;
 		}
 
-		if ( this.props.site && this.props.site.options.publicize_permanently_disabled ) {
-			return ( <div className="posts__post-share-wrapper">
-				<Notice status="is-warning" showDismiss={ false }>{ this.translate( 'Sharing is permanently disabled on this site.' ) }</Notice>
-			</div> );
-		}
-
 		const classes = classNames( 'posts__post-share', {
 			'has-connections': this.hasConnections()
 		} );
@@ -216,16 +210,11 @@ export default connect(
 	( state, props ) => {
 		const siteId = props.site.ID;
 		const userId = getCurrentUserId( state );
-		const postType = props.post.type;
-		const isPublicizeEnabled = (
-			false !== isJetpackModuleActive( state, siteId, 'publicize' ) &&
-			postTypeSupports( state, siteId, postType, 'publicize' )
-		);
 
 		return {
 			siteSlug: getSiteSlug( state, siteId ),
 			siteId,
-			isPublicizeEnabled,
+			isPublicizeEnabled: isPublicizeEnabled( state, siteId, props.post.type ),
 			connections: getSiteUserConnections( state, siteId, userId ),
 			hasFetchedConnections: hasFetchedConnections( state, siteId ),
 			requesting: isRequestingSharePost( state, siteId, props.post.ID ),

--- a/client/post-editor/editor-sharing/accordion.jsx
+++ b/client/post-editor/editor-sharing/accordion.jsx
@@ -22,10 +22,9 @@ import { getCurrentUserId } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
-import { isJetpackModuleActive, getSiteOption } from 'state/sites/selectors';
+import { isJetpackModuleActive } from 'state/sites/selectors';
 import { getSiteUserConnections } from 'state/sharing/publicize/selectors';
-import { hasBrokenSiteUserConnection } from 'state/selectors';
-import { postTypeSupports } from 'state/post-types/selectors';
+import { hasBrokenSiteUserConnection, isPublicizeEnabled } from 'state/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 const EditorSharingAccordion = React.createClass( {
@@ -144,11 +143,6 @@ export default connect(
 		const userId = getCurrentUserId( state );
 		const postId = getEditorPostId( state );
 		const postType = getEditedPostValue( state, siteId, postId, 'type' );
-		const isPublicizeEnabled = (
-			false !== isJetpackModuleActive( state, siteId, 'publicize' ) &&
-			true !== getSiteOption( state, siteId, 'publicize_permanently_disabled' ) &&
-			postTypeSupports( state, siteId, postType, 'publicize' )
-		);
 		const isSharingActive = false !== isJetpackModuleActive( state, siteId, 'sharedaddy' );
 		const isLikesActive = false !== isJetpackModuleActive( state, siteId, 'likes' );
 
@@ -157,7 +151,7 @@ export default connect(
 			hasBrokenConnection: hasBrokenSiteUserConnection( state, siteId, userId ),
 			isSharingActive,
 			isLikesActive,
-			isPublicizeEnabled
+			isPublicizeEnabled: isPublicizeEnabled( state, siteId, postType ),
 		};
 	},
 	{

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -32,6 +32,7 @@ export hasBrokenSiteUserConnection from './has-broken-site-user-connection';
 export isAutomatedTransferActive from './is-automated-transfer-active';
 export isDomainOnlySite from './is-domain-only-site';
 export isPrivateSite from './is-private-site';
+export isPublicizeEnabled from './is-publicize-enabled';
 export isRequestingBillingTransactions from './is-requesting-billing-transactions';
 export isRequestingPostLikes from './is-requesting-post-likes';
 export isRequestingSharingButtons from './is-requesting-sharing-buttons';

--- a/client/state/selectors/is-publicize-enabled.js
+++ b/client/state/selectors/is-publicize-enabled.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import { isJetpackModuleActive, getSiteOption } from 'state/sites/selectors';
+import { postTypeSupports } from 'state/post-types/selectors';
+
+/**
+ * Returns true if Publicize is enabled for the post type and the given site.
+ *
+ * @param {Object} state 	Global state tree
+ * @param {Number} siteId 	Site ID
+ * @param {String} postType Post type slug
+ *
+ * @return {Boolean} True when enabled
+ */
+export default function isPublicizeEnabled( state, siteId, postType ) {
+	return true !== getSiteOption( state, siteId, 'publicize_permanently_disabled' ) &&
+		false !== isJetpackModuleActive( state, siteId, 'publicize' ) &&
+		postTypeSupports( state, siteId, postType, 'publicize' );
+}

--- a/client/state/selectors/test/is-publicize-enabled.js
+++ b/client/state/selectors/test/is-publicize-enabled.js
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isPublicizeEnabled } from '../';
+
+describe( 'isPublicizeEnabled()', () => {
+	const siteId = 2916284;
+	const postType = 'post';
+
+	it( 'should return false when Publicize is permanently disabled', () => {
+		const result = isPublicizeEnabled( {
+			sites: {
+				items: {
+					[ siteId ]: {
+						ID: siteId,
+						options: {
+							publicize_permanently_disabled: true
+						}
+					}
+				}
+			}
+		}, siteId, postType );
+
+		expect( result ).to.be.false;
+	} );
+
+	it( 'should return false for jetpack site with Publicize disabled', () => {
+		const result = isPublicizeEnabled( {
+			sites: {
+				items: {
+					[ siteId ]: {
+						ID: siteId,
+						jetpack: true,
+						options: {
+							active_modules: []
+						}
+					}
+				}
+			}
+		}, siteId, postType );
+
+		expect( result ).to.be.false;
+	} );
+
+	it( 'should return true for jetpack site with Publicize enabled', () => {
+		const result = isPublicizeEnabled( {
+			sites: {
+				items: {
+					[ siteId ]: {
+						ID: siteId,
+						jetpack: true,
+						options: {
+							active_modules: [ 'publicize' ]
+						}
+					}
+				}
+			}
+		}, siteId, postType );
+
+		expect( result ).to.be.true;
+	} );
+
+
+	it( 'should return true for regular site and post type', () => {
+		const result = isPublicizeEnabled( {
+			sites: {
+				items: {
+					[ siteId ]: {
+						ID: siteId,
+					}
+				}
+			}
+		}, siteId, postType );
+
+		expect( result ).to.be.true;
+	} );
+} );


### PR DESCRIPTION
Fixes #10332. Per @beaulebens:

> On a Jetpack site, where Publicize is completely turned off, nothing happens when I click the Share link on the blog post listing. No errors or anything, just literally nothing happens. I’d expect to maybe have a panel slide down that tells me I need to enable Publicize to use this feature (bonus points; allow me to enable it right there).

#### Steps to repeat

1. Log into a Jetpack site, change Publicize setting to off in Jetpack plugin settings (under "Engagement").
2. Log in to WordPress.com, look for the site.
3. Click into Blog Posts, and click on the Share link below any post in the list.

#### Screenshots before
<img width="924" alt="screen shot 2017-01-16 at 15 35 00" src="https://cloud.githubusercontent.com/assets/66797/22001314/5db842f0-dc01-11e6-95ab-8a7c9e544668.png">

<img width="966" alt="screen shot 2017-01-16 at 15 35 15" src="https://cloud.githubusercontent.com/assets/66797/22001318/69e3c5a4-dc01-11e6-8085-da606cdbd818.png">

#### After
![screen shot 2017-01-19 at 10 54 14](https://cloud.githubusercontent.com/assets/699132/22102023/241ef3c2-de36-11e6-9e4a-c30879df8faa.png)


> bonus points; allow me to enable it right there

It would be cool, but I decided to leave it for V2 :)

### Testing
1. Log into a Jetpack site, change Publicize setting to off in Jetpack plugin settings (under "Engagement").
2. Log in to WordPress.com, look for the site.
3. Go to Posts section.
4. Share button should be grayed out and inactive.
5. Log into a Jetpack site, change Publicize setting to on in Jetpack plugin settings (under "Engagement").
6. Go back to Posts section.
7. Share button should be displayed as other active links.
8. Click on the link you should see sharing box.

