### PR TITLE
Stats: Use Redux Stats Module for Top Posts Stats

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -336,8 +336,6 @@ module.exports = {
 				siteID: siteId, statType: 'statsVisits', unit: activeFilter.period,
 				quantity: chartQuantity, date: chartEndDate,
 				stat_fields: 'views,visitors,likes,comments,post_titles', domain: siteDomain } );
-			const postsPagesList = new StatsList( {
-				siteID: siteId, statType: 'statsTopPosts', period: activeFilter.period, date: endDate, domain: siteDomain } );
 
 			siteComponent = SiteStatsComponent;
 			const siteComponentChildren = {
@@ -349,7 +347,6 @@ module.exports = {
 				sites,
 				activeTabVisitsList,
 				visitsList,
-				postsPagesList,
 				siteId,
 				period,
 				chartPeriod,
@@ -460,8 +457,7 @@ module.exports = {
 					visitsList = new StatsList( {
 						statType: 'statsVisits', unit: activeFilter.period, siteID: siteId,
 						quantity: 10, date: endDate, domain: siteDomain } );
-					summaryList = new StatsList( { statType: 'statsTopPosts', siteID: siteId,
-						period: activeFilter.period, date: endDate, max: 0, domain: siteDomain } );
+					summaryList = fakeStatsList;
 					break;
 
 				case 'referrers':

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -168,14 +168,14 @@ module.exports = React.createClass( {
 					</StatsPeriodNavigation>
 					<div className="stats__module-list is-events">
 						<div className="stats__module-column">
-							<StatsModule
-								path={ 'posts' }
+							<StatsConnectedModule
+								path="posts"
 								moduleStrings={ moduleStrings.posts }
-								site={ site }
-								dataList={ this.props.postsPagesList }
 								period={ this.props.period }
+								query={ query }
 								date={ queryDate }
-								beforeNavigate={ this.updateScrollPosition } />
+								statType="statsTopPosts"
+								showSummaryLink />
 							<StatsConnectedModule
 								path="referrers"
 								moduleStrings={ moduleStrings.referrers }

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -118,14 +118,14 @@ const StatsSummary = React.createClass( {
 
 			case 'posts':
 				title = translate( 'Posts & Pages' );
-				summaryView = <StatsModule
+				summaryView = <StatsConnectedModule
 					key="posts-summary"
-					path={ 'posts' }
+					path="posts"
 					moduleStrings={ StatsStrings.posts }
-					site={ site }
-					dataList={ this.props.summaryList }
 					period={ this.props.period }
-					summary={ true } />;
+					query={ query }
+					statType="statsTopPosts"
+					summary />;
 				break;
 
 			case 'authors':


### PR DESCRIPTION
In this PR, I am updating Top Posts Stats Module to use the StatsConnectedModule Component, since the normalizer was already in place.

**Testing instructions**

 - Navigate to the stats page /stats/day/$site
 - The Posts and Pages panel should work properly (same as master)
 - Click on the header of the panel to navigate to the summary page
 - The posts and pages stats should show up (same as master)

