### PR TITLE
Domain only site: Handle sidebar navigation in mobile

### DIFF
--- a/client/components/sidebar-navigation/index.jsx
+++ b/client/components/sidebar-navigation/index.jsx
@@ -19,6 +19,12 @@ class SidebarNavigation extends React.Component {
 
 	toggleSidebar( event ) {
 		event.preventDefault();
+
+		if ( this.props.backToSites ) {
+			this.props.setLayoutFocus( 'sites' );
+			return; 
+		}
+
 		this.props.setLayoutFocus( 'sidebar' );
 	}
 
@@ -39,6 +45,7 @@ class SidebarNavigation extends React.Component {
 }
 
 SidebarNavigation.propTypes = {
+	backToSites: PropTypes.bool,
 	title: PropTypes.string,
 	linkClassName: PropTypes.string,
 	sectionTitle: PropTypes.string,

--- a/client/my-sites/sidebar-navigation/sidebar-navigation.jsx
+++ b/client/my-sites/sidebar-navigation/sidebar-navigation.jsx
@@ -26,6 +26,7 @@ module.exports = React.createClass( {
 
 		return (
 			<SidebarNavigation
+				backToSites={ this.props.backToSites }
 				linkClassName={ allSitesClass }
 				sectionName="site"
 				sectionTitle={ currentSiteTitle }>

--- a/client/my-sites/upgrades/domain-management/list/index.jsx
+++ b/client/my-sites/upgrades/domain-management/list/index.jsx
@@ -96,7 +96,7 @@ export const List = React.createClass( {
 		if ( this.props.isDomainOnly ) {
 			return (
 				<Main>
-					<SidebarNavigation />
+					<SidebarNavigation backToSites={ true } />
 					<DomainOnly
 						domainName={ this.props.selectedSite.domain } />
 				</Main>


### PR DESCRIPTION
Domain only sites don't have any content in the sidebar, so when users navigate back to the sidebar we should just show them the site picker.

To reproduce the issue, open a domain-only site and click the back chevron at the top of the domain management screen - you'll see an empty sidebar with no way to get back to the main screen.

Looking for feedback on this approach.