### PR TITLE
Jetpack Settings: Sanitize and normalize when fetching and updating settings

### DIFF
--- a/client/state/jetpack/settings/actions.js
+++ b/client/state/jetpack/settings/actions.js
@@ -11,6 +11,7 @@ import {
 	JETPACK_SETTINGS_UPDATE_FAILURE
 } from 'state/action-types';
 import wp from 'lib/wp';
+import { normalizeSettings, sanitizeSettings } from './utils';
 
 /**
  * Fetch the Jetpack settings for a certain site.
@@ -27,7 +28,7 @@ export const fetchSettings = ( siteId ) => {
 
 		return wp.undocumented().fetchJetpackSettings( siteId )
 			.then( ( response ) => {
-				const settings = response.data || {};
+				const settings = normalizeSettings( response.data ) || {};
 				dispatch( {
 					type: JETPACK_SETTINGS_RECEIVE,
 					siteId,
@@ -62,7 +63,7 @@ export const updateSettings = ( siteId, settings ) => {
 			settings
 		} );
 
-		return wp.undocumented().updateJetpackSettings( siteId, settings )
+		return wp.undocumented().updateJetpackSettings( siteId, sanitizeSettings( settings ) )
 			.then( () => {
 				dispatch( {
 					type: JETPACK_SETTINGS_UPDATE_SUCCESS,

--- a/client/state/jetpack/settings/test/actions.js
+++ b/client/state/jetpack/settings/test/actions.js
@@ -17,7 +17,8 @@ import {
 } from 'state/action-types';
 import { fetchSettings, updateSettings } from '../actions';
 import {
-	settings as SETTINGS_FIXTURE
+	settings as SETTINGS_FIXTURE,
+	normalizedSettings as NORMALIZED_SETTINGS_FIXTURE
 } from './fixture';
 import { useSandbox } from 'test/helpers/use-sinon';
 import useNock from 'test/helpers/use-nock';
@@ -57,7 +58,7 @@ describe( 'actions', () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: JETPACK_SETTINGS_RECEIVE,
 						siteId,
-						settings: settings[ siteId ]
+						settings: NORMALIZED_SETTINGS_FIXTURE[ siteId ]
 					} );
 
 					expect( spy ).to.have.been.calledWith( {
@@ -112,21 +113,21 @@ describe( 'actions', () => {
 			} );
 
 			it( 'should return a fetch action object when called', () => {
-				updateSettings( siteId, settings[ siteId ] )( spy );
+				updateSettings( siteId, NORMALIZED_SETTINGS_FIXTURE[ siteId ] )( spy );
 
 				expect( spy ).to.have.been.calledWith( {
 					type: JETPACK_SETTINGS_UPDATE,
 					siteId,
-					settings: settings[ siteId ]
+					settings: NORMALIZED_SETTINGS_FIXTURE[ siteId ]
 				} );
 			} );
 
 			it( 'should return a receive action when request successfully completes', () => {
-				return updateSettings( siteId, settings[ siteId ] )( spy ).then( () => {
+				return updateSettings( siteId, NORMALIZED_SETTINGS_FIXTURE[ siteId ] )( spy ).then( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: JETPACK_SETTINGS_UPDATE_SUCCESS,
 						siteId,
-						settings: settings[ siteId ]
+						settings: NORMALIZED_SETTINGS_FIXTURE[ siteId ]
 					} );
 				} );
 			} );
@@ -148,11 +149,11 @@ describe( 'actions', () => {
 			} );
 
 			it( 'should return a receive action when an error occurs', () => {
-				return updateSettings( siteId, settings[ siteId ] )( spy ).then( () => {
+				return updateSettings( siteId, NORMALIZED_SETTINGS_FIXTURE[ siteId ] )( spy ).then( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: JETPACK_SETTINGS_UPDATE_FAILURE,
 						siteId,
-						settings: settings[ siteId ],
+						settings: NORMALIZED_SETTINGS_FIXTURE[ siteId ],
 						error: 'Invalid option: setting_1'
 					} );
 				} );

--- a/client/state/jetpack/settings/test/fixture.js
+++ b/client/state/jetpack/settings/test/fixture.js
@@ -2,7 +2,9 @@ export const settings = {
 	12345678: {
 		setting_1: 4321,
 		setting_2: false,
-		setting_10: 'test'
+		setting_10: 'test',
+		wp_mobile_excerpt: 'disabled',
+		wp_mobile_featured_images: 'enabled',
 	},
 	87654321: {
 		setting_1: 1234,
@@ -10,6 +12,15 @@ export const settings = {
 		setting_3: {
 			setting_4: 'some_value',
 		}
+	}
+};
+
+export const normalizedSettings = {
+	...settings,
+	12345678: {
+		...settings[ 12345678 ],
+		wp_mobile_excerpt: false,
+		wp_mobile_featured_images: true,
 	}
 };
 

--- a/client/state/jetpack/settings/test/utils.js
+++ b/client/state/jetpack/settings/test/utils.js
@@ -1,0 +1,115 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { normalizeSettings, sanitizeSettings } from '../utils';
+
+describe( 'utils', () => {
+	describe( 'normalizeSettings()', () => {
+		it( 'should not modify random settings', () => {
+			const settings = {
+				some_random_setting: 'example'
+			};
+
+			expect( normalizeSettings( settings ) ).to.eql( {
+				some_random_setting: 'example'
+			} );
+		} );
+
+		it( 'should convert wp_mobile_excerpt to true if it is "enabled"', () => {
+			const settings = {
+				wp_mobile_excerpt: 'enabled'
+			};
+
+			expect( normalizeSettings( settings ) ).to.eql( {
+				wp_mobile_excerpt: true
+			} );
+		} );
+
+		it( 'should convert wp_mobile_excerpt to false if it is "disabled"', () => {
+			const settings = {
+				wp_mobile_excerpt: 'disabled'
+			};
+
+			expect( normalizeSettings( settings ) ).to.eql( {
+				wp_mobile_excerpt: false
+			} );
+		} );
+
+		it( 'should convert wp_mobile_featured_images to true if it is "enabled"', () => {
+			const settings = {
+				wp_mobile_featured_images: 'enabled'
+			};
+
+			expect( normalizeSettings( settings ) ).to.eql( {
+				wp_mobile_featured_images: true
+			} );
+		} );
+
+		it( 'should convert wp_mobile_featured_images to false if it is "disabled"', () => {
+			const settings = {
+				wp_mobile_featured_images: 'disabled'
+			};
+
+			expect( normalizeSettings( settings ) ).to.eql( {
+				wp_mobile_featured_images: false
+			} );
+		} );
+	} );
+
+	describe( 'sanitizeSettings()', () => {
+		it( 'should not modify random settings', () => {
+			const settings = {
+				some_random_setting: 'example'
+			};
+
+			expect( sanitizeSettings( settings ) ).to.eql( {
+				some_random_setting: 'example'
+			} );
+		} );
+
+		it( 'should convert wp_mobile_excerpt to "enabled" if it is true', () => {
+			const settings = {
+				wp_mobile_excerpt: true
+			};
+
+			expect( sanitizeSettings( settings ) ).to.eql( {
+				wp_mobile_excerpt: 'enabled'
+			} );
+		} );
+
+		it( 'should convert wp_mobile_excerpt to "disabled" if it is false', () => {
+			const settings = {
+				wp_mobile_excerpt: false
+			};
+
+			expect( sanitizeSettings( settings ) ).to.eql( {
+				wp_mobile_excerpt: 'disabled'
+			} );
+		} );
+
+		it( 'should convert wp_mobile_featured_images to "enabled" if it is true', () => {
+			const settings = {
+				wp_mobile_featured_images: true
+			};
+
+			expect( sanitizeSettings( settings ) ).to.eql( {
+				wp_mobile_featured_images: 'enabled'
+			} );
+		} );
+
+		it( 'should convert wp_mobile_featured_images to "disabled" if it is false', () => {
+			const settings = {
+				wp_mobile_featured_images: false
+			};
+
+			expect( sanitizeSettings( settings ) ).to.eql( {
+				wp_mobile_featured_images: 'disabled'
+			} );
+		} );
+	} );
+} );

--- a/client/state/jetpack/settings/utils.js
+++ b/client/state/jetpack/settings/utils.js
@@ -1,0 +1,41 @@
+/**
+ * Normalize settings for use in Redux.
+ *
+ * @param  {Object}   settings   Raw settings.
+ * @return {Object}              Normalized settings.
+ */
+export const normalizeSettings = ( settings ) => {
+	return Object.keys( settings ).reduce( ( memo, key ) => {
+		switch ( key ) {
+			case 'wp_mobile_excerpt':
+			case 'wp_mobile_featured_images':
+				memo[ key ] = settings[ key ] === 'enabled';
+				break;
+			default:
+				memo[ key ] = settings[ key ];
+		}
+
+		return memo;
+	}, {} );
+};
+
+/**
+ * Sanitize settings for updating in the Jetpack site.
+ *
+ * @param  {Object}   settings   Settings.
+ * @return {Object}              Normalized settings.
+ */
+export const sanitizeSettings = ( settings ) => {
+	return Object.keys( settings ).reduce( ( memo, key ) => {
+		switch ( key ) {
+			case 'wp_mobile_excerpt':
+			case 'wp_mobile_featured_images':
+				memo[ key ] = !! settings [ key ] ? 'enabled' : 'disabled';
+				break;
+			default:
+				memo[ key ] = settings[ key ];
+		}
+
+		return memo;
+	}, {} );
+};


### PR DESCRIPTION
There isn't a consistent way to store boolean values in the WordPress database. As a consequence, there are cases in Jetpack when some module settings boolean values are not stored consistently. One example is when some of the settings of the `minileven` module stored as `enabled` or `disabled` instead of `0` or `1` like it's other boolean module settings. 

So, this PR introduces a mechanism for normalization (when retrieving the settings) and sanitization (when updating the settings) of such fields. This is done with 2 new utility methods (`normalizeSettings` and `sanitizeSettings`) and tests for them. Also, the PR implements this in the settings actions (and respectively in their tests).

There isn't a very practical way to test this right now, as managing these module settings is still n progress in #10083. So, to test this, checkout this branch and verify all jetpack settings test are passing:

```
npm run test-client client/state/jetpack/settings/
```