### PR TITLE
Editor: Resolve issue where editor never loads on empty cache

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -208,16 +208,24 @@ module.exports = {
 		//    have permission to view the site)
 		//  - Sites are initialized _and_ fetched, but the selected site has
 		//    not yet been selected, so is not available in global state yet
+		let unsubscribe;
 		function startEditingOnSiteSelected() {
 			const siteId = getSelectedSiteId( context.store.getState() );
-
-			if ( siteId ) {
-				startEditing( siteId );
-			} else {
-				sites.once( 'change', startEditingOnSiteSelected );
+			if ( ! siteId ) {
+				return false;
 			}
+
+			if ( unsubscribe ) {
+				unsubscribe();
+			}
+
+			startEditing( siteId );
+			return true;
 		}
-		startEditingOnSiteSelected();
+
+		if ( ! startEditingOnSiteSelected() ) {
+			unsubscribe = context.store.subscribe( startEditingOnSiteSelected );
+		}
 
 		renderEditor( context, postType );
 	},


### PR DESCRIPTION
This pull request seeks to resolve an issue where, if a user visits the post editor with an empty cache, the post editor can take a very long time to load, or worse, never loads. Due to a number of [documented conditions](https://github.com/Automattic/wp-calypso/blob/42f8c17966d969a03e203bf2d5b6db369720c3ae/client/post-editor/controller.js#L202-L220), the editor must wait until the selected site has been made available before starting to edit the post. Previously, this was bound as a handler to the `sites-list` change event. However, and perhaps due to more recent refactoring of the selected site logic, it's been found that scenarios can occur where the site is available to be selected (i.e. becomes selected) but the change event is not emitted.

Because the check is based upon the presence of a selected site ID in Redux state, the changes here hook to the store's `subscribe` method instead of the `sites-list` change event. This way we can become more reliably aware when the selected site ID has been made available in state.

__Testing instructions:__

1. Navigate to the [post editor](http://calypso.localhost:3000)
2. Select a site, if prompted
3. Clear all caches, including IndexedDB
   - In Chrome DevTools, find "Clear selected" under Application > Clear storage (ensuring that all checkboxes are selected)
   - Otherwise, in your browser's DevTools console, enter: `localStorage.clear(); indexedDB.deleteDatabase( 'calypso' );`
4. Refresh the page
5. Observe that the editor eventually loads
   - Much faster than in master (which either never loads or waits for next site polling), caveat being that `/me/sites` can still feel a bit slow for users with many sites