### PR TITLE
Reader: fix Discover excerpts

### DIFF
--- a/client/blocks/reader-post-card/excerpt.jsx
+++ b/client/blocks/reader-post-card/excerpt.jsx
@@ -1,0 +1,33 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal Dependencies
+ */
+import AutoDirection from 'components/auto-direction';
+
+const ReaderPostCardExcerpt = ( { post, isDiscover } )=> {
+	let excerpt = post.better_excerpt || post.excerpt;
+
+	// Force post.excerpt for Discover only
+	if ( isDiscover ) {
+		excerpt = post.excerpt;
+	}
+
+	return (
+		<AutoDirection>
+			<div className="reader-post-card__excerpt"
+				dangerouslySetInnerHTML={ { __html: excerpt } } // eslint-disable-line react/no-danger
+			/>
+		</AutoDirection>
+	);
+};
+
+ReaderPostCardExcerpt.propTypes = {
+	post: React.PropTypes.object.isRequired,
+	isDiscover: React.PropTypes.bool,
+};
+
+export default ReaderPostCardExcerpt;

--- a/client/blocks/reader-post-card/gallery.jsx
+++ b/client/blocks/reader-post-card/gallery.jsx
@@ -12,6 +12,7 @@ import { imageIsBigEnoughForGallery } from 'state/reader/posts/normalization-rul
 import resizeImageUrl from 'lib/resize-image-url';
 import cssSafeUrl from 'lib/css-safe-url';
 import { isFeaturedImageInContent } from 'lib/post-normalizer/utils';
+import ReaderPostCardExcerpt from './excerpt';
 
 const GALLERY_ITEM_THUMBNAIL_WIDTH = 420;
 
@@ -27,7 +28,7 @@ function getGalleryWorthyImages( post ) {
 	return take( worthyImages, numberOfImagesToDisplay );
 }
 
-const PostGallery = ( { post, children } ) => {
+const PostGallery = ( { post, children, isDiscover } ) => {
 	const imagesToDisplay = getGalleryWorthyImages( post );
 	const listItems = map( imagesToDisplay, ( image, index ) => {
 		const imageUrl = resizeImageUrl( image.src, { w: GALLERY_ITEM_THUMBNAIL_WIDTH } );
@@ -55,18 +56,15 @@ const PostGallery = ( { post, children } ) => {
 						<a className="reader-post-card__title-link" href={ post.URL }>{ post.title }</a>
 					</h1>
 				</AutoDirection>
-				<AutoDirection>
-					<div className="reader-post-card__excerpt"
-						dangerouslySetInnerHTML={ { __html: post.better_excerpt || post.excerpt } } // eslint-disable-line react/no-danger
-					/>
-				</AutoDirection>
+				<ReaderPostCardExcerpt post={ post } isDiscover={ isDiscover } />
 				{ children }
 				</div>
 		</div> );
 };
 
 PostGallery.propTypes = {
-	post: React.PropTypes.object.isRequired
+	post: React.PropTypes.object.isRequired,
+	isDiscover: React.PropTypes.bool,
 };
 
 export default PostGallery;

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -145,7 +145,7 @@ export default class ReaderPostCard extends React.Component {
 					{ readerPostActions }
 				</PhotoPost>;
 		} else if ( isGalleryPost ) {
-			readerPostCard = <GalleryPost post={ post } title={ title } >
+			readerPostCard = <GalleryPost post={ post } title={ title } isDiscover={ isDiscover }>
 					{ readerPostActions }
 				</GalleryPost>;
 		} else {

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -149,7 +149,7 @@ export default class ReaderPostCard extends React.Component {
 					{ readerPostActions }
 				</GalleryPost>;
 		} else {
-			readerPostCard = <StandardPost post={ post } title={ title } >
+			readerPostCard = <StandardPost post={ post } title={ title } isDiscover={ isDiscover }>
 					{ isDailyPostChallengeOrPrompt( post ) && <DailyPostButton post={ post } tagName="span" /> }
 					{ discoverFollowButton }
 					{ readerPostActions }

--- a/client/blocks/reader-post-card/standard.jsx
+++ b/client/blocks/reader-post-card/standard.jsx
@@ -9,8 +9,9 @@ import React from 'react';
 import AutoDirection from 'components/auto-direction';
 import FeaturedVideo from './featured-video';
 import FeaturedImage from './featured-image';
+import ReaderPostCardExcerpt from './excerpt';
 
-const StandardPost = ( { post, children } )=> {
+const StandardPost = ( { post, children, isDiscover } )=> {
 	const canonicalMedia = post.canonical_media;
 	let featuredAsset;
 	if ( ! canonicalMedia ) {
@@ -30,14 +31,15 @@ const StandardPost = ( { post, children } )=> {
 						<a className="reader-post-card__title-link" href={ post.URL }>{ post.title }</a>
 					</h1>
 				</AutoDirection>
-				<AutoDirection>
-					<div className="reader-post-card__excerpt"
-						dangerouslySetInnerHTML={ { __html: post.better_excerpt || post.excerpt } } // eslint-disable-line react/no-danger
-					/>
-				</AutoDirection>
+				<ReaderPostCardExcerpt post={ post } isDiscover={ isDiscover } />
 				{ children }
 			</div>
 		</div> );
+};
+
+StandardPost.propTypes = {
+	post: React.PropTypes.object.isRequired,
+	isDiscover: React.PropTypes.bool,
 };
 
 export default StandardPost;


### PR DESCRIPTION
A recent regression caused the wrong excerpt to be used for Discover post cards. Discover always uses the `post.excerpt` rather than `post.better_excerpt`.

Before:

<img width="871" alt="screen shot 2017-01-19 at 17 50 40" src="https://cloud.githubusercontent.com/assets/17325/22118488/eb1d3662-de6f-11e6-806b-ed386f86500a.png">

After:

<img width="855" alt="screen shot 2017-01-19 at 17 51 09" src="https://cloud.githubusercontent.com/assets/17325/22118494/ef79821a-de6f-11e6-9d64-2d8f23abc5e0.png">

cc @kristastevens @fraying 