### PR TITLE
Discussion Settings: add "Enable markdown for comments" for Jetpack sites

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -327,6 +327,7 @@
 @import 'my-sites/site-settings/action-panel/style';
 @import 'my-sites/site-settings/custom-content-types/style';
 @import 'my-sites/site-settings/comment-display-settings/style';
+@import 'my-sites/site-settings/comment-markdown-toggle/style';
 @import 'my-sites/site-settings/date-time-format/style';
 @import 'my-sites/site-settings/delete-site/style';
 @import 'my-sites/site-settings/delete-site-options/style';

--- a/client/my-sites/site-settings/comment-markdown-toggle/index.jsx
+++ b/client/my-sites/site-settings/comment-markdown-toggle/index.jsx
@@ -1,0 +1,59 @@
+/**
+* External dependencies
+*/
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import CompactFormToggle from 'components/forms/form-toggle/compact';
+import ExternalLink from 'components/external-link';
+import InfoPopover from 'components/info-popover';
+import { isJetpackModuleActive } from 'state/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+class CommentDisplaySettings extends Component {
+	shouldEnableSettings() {
+		const { isMarkdownModuleActive, submittingForm } = this.props;
+		return !! submittingForm || ! isMarkdownModuleActive;
+	}
+
+	render() {
+		const {
+			fields,
+			handleToggle,
+			translate,
+		} = this.props;
+
+		return (
+			<div className="markdown-toggle">
+				<div className="markdown-toggle__info-link-container">
+					<InfoPopover position={ 'left' }>
+						<ExternalLink href="http://en.support.wordpress.com/markdown-quick-reference/" target="_blank">
+							{ this.props.translate( 'Learn more about markdown' ) }
+						</ExternalLink>
+					</InfoPopover>
+				</div>
+				<CompactFormToggle
+					checked={ !! fields.wpcom_publish_comments_with_markdown }
+					disabled={ this.shouldEnableSettings() }
+					onChange={ handleToggle( 'wpcom_publish_comments_with_markdown' ) }>
+					<span>{ translate( 'Enable Markdown for comments.' ) }</span>
+				</CompactFormToggle>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state ) => {
+		const selectedSiteId = getSelectedSiteId( state );
+
+		return {
+			selectedSiteId,
+			isMarkdownModuleActive: !! isJetpackModuleActive( state, selectedSiteId, 'markdown' ),
+		};
+	}
+)( localize( CommentDisplaySettings ) );

--- a/client/my-sites/site-settings/comment-markdown-toggle/index.jsx
+++ b/client/my-sites/site-settings/comment-markdown-toggle/index.jsx
@@ -60,7 +60,7 @@ class CommentDisplaySettings extends Component {
 				<div className="comment-markdown-toggle__info-link-container">
 					<InfoPopover position={ 'left' }>
 						<ExternalLink href="http://en.support.wordpress.com/markdown-quick-reference/" target="_blank">
-							{ this.props.translate( 'Learn more about markdown' ) }
+							{ this.props.translate( 'Learn more about Markdown' ) }
 						</ExternalLink>
 					</InfoPopover>
 				</div>

--- a/client/my-sites/site-settings/comment-markdown-toggle/style.scss
+++ b/client/my-sites/site-settings/comment-markdown-toggle/style.scss
@@ -1,3 +1,3 @@
-.markdown-toggle__info-link-container {
+.comment-markdown-toggle__info-link-container {
 	float: right;
 }

--- a/client/my-sites/site-settings/comment-markdown-toggle/style.scss
+++ b/client/my-sites/site-settings/comment-markdown-toggle/style.scss
@@ -1,0 +1,3 @@
+.markdown-toggle__info-link-container {
+	float: right;
+}

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -11,6 +11,7 @@ import { flowRight, pick } from 'lodash';
 import Button from 'components/button';
 import Card from 'components/card';
 import CommentDisplaySettings from './comment-display-settings';
+import CommentMarkdownToggle from './comment-markdown-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormLegend from 'components/forms/form-legend';
@@ -93,7 +94,13 @@ class SiteSettingsFormDiscussion extends Component {
 	}
 
 	otherCommentSettings() {
-		const { fields, handleToggle, isRequestingSettings, translate } = this.props;
+		const {
+			fields,
+			handleToggle,
+			isRequestingSettings,
+			isSavingSettings,
+			translate
+		} = this.props;
 		return (
 			<FormFieldset className="site-settings__other-comment-settings">
 				<CompactFormToggle
@@ -165,6 +172,10 @@ class SiteSettingsFormDiscussion extends Component {
 					onChange={ this.handleCommentOrder }>
 					<span>{ translate( 'Comments should be displayed with the older comments at the top of each page' ) }</span>
 				</CompactFormToggle>
+				<CommentMarkdownToggle
+					handleToggle={ handleToggle }
+					submittingForm={ isRequestingSettings || isSavingSettings }
+					fields={ fields } />
 			</FormFieldset>
 		);
 	}

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -96,6 +96,7 @@ class SiteSettingsFormDiscussion extends Component {
 		const {
 			fields,
 			handleToggle,
+			isJetpack,
 			isRequestingSettings,
 			isSavingSettings,
 			translate
@@ -171,11 +172,13 @@ class SiteSettingsFormDiscussion extends Component {
 					onChange={ this.handleCommentOrder }>
 					<span>{ translate( 'Comments should be displayed with the older comments at the top of each page' ) }</span>
 				</CompactFormToggle>
-				<CommentMarkdownToggle
-					handleToggle={ handleToggle }
-					isSavingSettings={ isSavingSettings }
-					isRequestingSettings={ isRequestingSettings }
-					fields={ fields } />
+				{ isJetpack &&
+					<CommentMarkdownToggle
+						handleToggle={ handleToggle }
+						isSavingSettings={ isSavingSettings }
+						isRequestingSettings={ isRequestingSettings }
+						fields={ fields } />
+				}
 			</FormFieldset>
 		);
 	}

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -83,7 +83,6 @@ class SiteSettingsFormDiscussion extends Component {
 
 		return (
 			<div>
-				<QueryJetpackModules siteId={ this.props.siteId } />
 				<CommentDisplaySettings
 					onChangeField={ onChangeField }
 					submittingForm={ isRequestingSettings || isSavingSettings }
@@ -174,7 +173,8 @@ class SiteSettingsFormDiscussion extends Component {
 				</CompactFormToggle>
 				<CommentMarkdownToggle
 					handleToggle={ handleToggle }
-					submittingForm={ isRequestingSettings || isSavingSettings }
+					isSavingSettings={ isSavingSettings }
+					isRequestingSettings={ isRequestingSettings }
 					fields={ fields } />
 			</FormFieldset>
 		);
@@ -464,6 +464,7 @@ class SiteSettingsFormDiscussion extends Component {
 		} = this.props;
 		return (
 			<form id="site-settings" onSubmit={ handleSubmitForm }>
+				<QueryJetpackModules siteId={ siteId } />
 				{ this.renderSectionHeader( translate( 'Default Article Settings' ) ) }
 				<Card className="site-settings__discussion-settings">
 					{ this.defaultArticleSettings() }
@@ -552,6 +553,8 @@ const getFormSettings = settings => {
 		'moderation_keys',
 		'blacklist_keys',
 		'admin_url',
+		'markdown',
+		'wpcom_publish_comments_with_markdown',
 		'highlander_comment_form_prompt',
 		'jetpack_comment_form_color_scheme',
 		'subscriptions',


### PR DESCRIPTION
This PR is just to start discussion for this setting. The mockup:

![screen shot 2017-01-19 at 12 42 03 pm](https://cloud.githubusercontent.com/assets/541093/22118342/63403d5e-de45-11e6-8389-75dc747f6851.png)

But I have two issues: First, the Markdown module might be disabled, which doesn't affect the value of this setting (you can have markdown enabled for comments even if the markdown module is off, so that when you turn on markdown it's enabled).

- We could use an approach like #9802 or #10083, where there's a separate toggle for enabling the Markdown module, and "Enable Markdown for comments" is folded under that & only appears when the module is on.
- The other option is to leave it as one toggle, and turn on the markdown module when this "enable for comments" is set. However, there's a tech issue where if the option is saved before the module is enabled, the option will error because the module is disabled.

_(For what it's worth, we're going to have the same problem with the "Enable pop-up business cards over commenters' Gravatars" setting.)_

My other issue is much more minor 😄  if we go with the mockup above, what should happen with that info icon? Right now for wp.com sites, the setting links off to "[Learn more about markdown](http://en.support.wordpress.com/markdown-quick-reference/)"

@MichaelArestad @rickybanister 

---------------

![screen shot 2017-02-22 at 11 09 14 am](https://cloud.githubusercontent.com/assets/541093/23220588/782abc42-f8f0-11e6-847e-48db3175f302.png)

This PR is ready to be tested now.

**To test, part 1**

1. Make sure you have markdown disabled on your Jetpack site
2. Visit `/settings/discussion/$site`
3. Click "Enable Markdown for comments", click "Save settings"
4. Verify that markdown is now enabled, and the comments setting is checked in wp-admin

**part 2**

1. Make sure you have markdown _enabled_ on your Jetpack site
2. Visit `/settings/discussion/$site`
3. Change the setting for "Enable Markdown for comments", and save
4. Verify the change saved in wp-admin too

**part 3**

1. Lastly, make sure this works for WordPress.com sites
2. Visit `/settings/discussion/$site`
3. Change the setting for "Enable Markdown for comments", and save
4. Verify the change saved in calypso production