### PR TITLE
Components: Cap progress bar competion to 100%

### DIFF
--- a/client/components/progress-bar/index.jsx
+++ b/client/components/progress-bar/index.jsx
@@ -26,12 +26,19 @@ module.exports = React.createClass( {
 		isPulsing: React.PropTypes.bool
 	},
 
+	getCompletionPercentage() {
+		const percentage = Math.ceil( this.props.value / this.props.total * 100 );
+
+		// The percentage should not be allowed to be more than 100
+		return Math.min( percentage, 100 );
+	},
+
 	renderBar() {
 		const title = this.props.title
 				? <span className="screen-reader-text">{ this.props.title }</span>
 				: null;
 
-		let styles = { width: Math.ceil( this.props.value / this.props.total * 100 ) + '%' };
+		const styles = { width: this.getCompletionPercentage() + '%' };
 		if ( this.props.color ) {
 			styles.backgroundColor = this.props.color;
 		}

--- a/client/components/progress-bar/test/index.jsx
+++ b/client/components/progress-bar/test/index.jsx
@@ -55,4 +55,9 @@ describe( 'ProgressBar', function() {
 
 		expect( progressBar.find( '.progress-bar__progress' ).props().style.backgroundColor ).to.be.equal( 'red' );
 	} );
+
+	it( 'should not be able to be more than 100% complete', () => {
+		const progressBar = shallow( <ProgressBar value={ 240 }/> );
+		expect( progressBar.find( '.progress-bar__progress' ).props().style.width ).to.be.equal( '100%' );
+	} );
 } );


### PR DESCRIPTION
Before this PR, `ProgressBar` allows the width property to be more than 100 when a high `value` property is passed.

For example, by entering `240` in one of the devdocs examples [here](http://calypso.localhost:3000/devdocs/design/progress-bar), I was able to get this:

![screen shot 2017-01-19 at 11 48 13 am](https://cloud.githubusercontent.com/assets/1126811/22118849/f48bb1fa-de3e-11e6-8bef-102331a19bb8.png)

After this PR, it looks like this:

![screen shot 2017-01-19 at 11 52 04 am](https://cloud.githubusercontent.com/assets/1126811/22118885/142156a0-de3f-11e6-9261-16e61d5160b2.png)

To test:

- `npm run test-client client/components/progress-bar` 
- Manually change the values for the devdocs examples
