### PR TITLE
Post Editor: remove undefined `site` console warnings

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -46,7 +46,7 @@ export default React.createClass( {
 		onMouseLeave: React.PropTypes.func,
 		isSelected: React.PropTypes.bool,
 		isHighlighted: React.PropTypes.bool,
-		site: React.PropTypes.object.isRequired,
+		site: React.PropTypes.object,
 		homeLink: React.PropTypes.bool,
 		showHomeIcon: React.PropTypes.bool
 	},

--- a/client/post-editor/editor-more-options/copy-post.jsx
+++ b/client/post-editor/editor-more-options/copy-post.jsx
@@ -67,10 +67,6 @@ class EditorMoreOptionsCopyPost extends Component {
 	render() {
 		const { translate, siteId } = this.props;
 
-		if ( ! siteId ) {
-			return null;
-		}
-
 		const buttons = [ {
 			action: 'cancel',
 			label: translate( 'Cancel' ),
@@ -81,6 +77,7 @@ class EditorMoreOptionsCopyPost extends Component {
 			disabled: ! this.state.selectedPostId,
 			onClick: this.goToNewDraft,
 		} ];
+
 		return (
 			<AccordionSection className="editor-more-options__copy-post">
 				<EditorDrawerLabel
@@ -104,14 +101,16 @@ class EditorMoreOptionsCopyPost extends Component {
 					<p>
 						{ translate( "Pick a post and we'll copy the title, content, tags and categories. " ) }
 					</p>
-					<PostSelector
-						siteId={ siteId }
-						emptyMessage={ translate( 'No posts found' ) }
-						orderBy="date"
-						order="DESC"
-						onChange={ this.setPostToCopy }
-						selected={ this.state.selectedPostId }
-					/>
+					{ siteId &&
+						<PostSelector
+							siteId={ siteId }
+							emptyMessage={ translate( 'No posts found' ) }
+							orderBy="date"
+							order="DESC"
+							onChange={ this.setPostToCopy }
+							selected={ this.state.selectedPostId }
+						/>
+					}
 				</Dialog>
 			</AccordionSection>
 		);

--- a/client/post-editor/editor-more-options/copy-post.jsx
+++ b/client/post-editor/editor-more-options/copy-post.jsx
@@ -22,8 +22,8 @@ import PostSelector from 'my-sites/post-selector';
 class EditorMoreOptionsCopyPost extends Component {
 
 	static propTypes = {
-		siteId: PropTypes.number.isRequired,
-		siteSlug: PropTypes.string.isRequired,
+		siteId: PropTypes.number,
+		siteSlug: PropTypes.string,
 		translate: PropTypes.func,
 	};
 
@@ -66,6 +66,11 @@ class EditorMoreOptionsCopyPost extends Component {
 
 	render() {
 		const { translate, siteId } = this.props;
+
+		if ( ! siteId ) {
+			return null;
+		}
+
 		const buttons = [ {
 			action: 'cancel',
 			label: translate( 'Cancel' ),


### PR DESCRIPTION
Removed `isRequired` from site-related props in `<Site>` and `<EditorMoreOptionsCopyPost>` to avoid console warning about it when opening the post editor with an empty cache.

**Testing instructions:**

- Navigate to the post editor: http://calypso.localhost:3000/post/{siteSlug}.
- In the browser's DevTools console, enter: `localStorage.clear(); indexedDB.deleteDatabase( 'calypso' );`.
- Refresh the page.
- There should be no site-related console warnings.

Additionally, again with an empty cache, refresh the site list (i.e. http://calypso.localhost:3000/post) to observe the behaviour of `<Site>`.

See: https://github.com/Automattic/wp-calypso/pull/10782#issuecomment-273833323