### PR TITLE
Me: Check if re-auth is required before fetching links

### DIFF
--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -71,6 +71,7 @@ TwoStepAuthorization.prototype.validateCode = function( args, callback ) {
 				userSettings.fetchSettings();
 				applicationPasswords.fetch();
 				connectedApplications.fetch();
+				profileLinks.reAuthRequired = false;
 				profileLinks.fetchProfileLinks();
 			}
 

--- a/client/lib/user-profile-links/index.js
+++ b/client/lib/user-profile-links/index.js
@@ -63,7 +63,7 @@ UserProfileLinks.prototype.getProfileLinks = function() {
  * Fetch user profile links from WordPress.com API and store them in UserProfileLinks instance
  */
 UserProfileLinks.prototype.fetchProfileLinks = function() {
-	if ( this.fetchingProfileLinks ) {
+	if ( this.fetchingProfileLinks || this.reAuthRequired ) {
 		return;
 	}
 


### PR DESCRIPTION
This PR fixes a bug where profile links were continued to be fetched during re-authentication of a user with 2FA.

To test:
1. Have 2FA enabled.
1. Sandbox the API and add a `return true;` in `WPCOM_API_Restrict_2FA::does_token_need_refresh()`
1. Navigate to http://calypso.localhost:3000/me. The re-auth modal should show and there shouldn't be more than one profile-links request in the network tab of devtools.
1. Remove the `return true;` statement in the API.
1. Complete re-authentication. There should be only one more profile-links request.

Fixes #10783.