### PR TITLE
Signup: Fix username suggestions not working

### DIFF
--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { map, forEach, head, includes, keys } from 'lodash';
 import debugModule from 'debug';
 import classNames from 'classnames';
@@ -45,8 +45,8 @@ export default React.createClass( {
 
 	displayName: 'SignupForm',
 
-	contextTypes: {
-		store: React.PropTypes.object
+	propTypes: {
+		suggestedUsername: PropTypes.string.isRequired
 	},
 
 	getInitialState() {
@@ -68,13 +68,10 @@ export default React.createClass( {
 	},
 
 	autoFillUsername( form ) {
-		// Fetch the suggested username from local storage
-		const suggestedUsername = this.context.store.getState().signup.optionalDependencies.suggestedUsername;
-
 		return mergeFormWithValue( {
 			form,
 			fieldName: 'username',
-			fieldValue: suggestedUsername || undefined
+			fieldValue: this.props.suggestedUsername || ''
 		} );
 	},
 
@@ -90,11 +87,11 @@ export default React.createClass( {
 			hideFieldErrorsOnChange: true,
 			initialState: this.props.step ? this.props.step.form : undefined
 		} );
-		let initialState = this.formStateController.getInitialState();
-		if ( this.props.signupProgress ) {
-			initialState = this.autoFillUsername( initialState );
-		}
-		this.setState( { form: initialState } );
+
+		const initialState = this.formStateController.getInitialState();
+		const stateWithFilledUsername = this.autoFillUsername( initialState );
+
+		this.setState( { form: stateWithFilledUsername } );
 	},
 
 	componentDidMount() {

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -186,7 +186,9 @@ const LoggedOutForm = React.createClass( {
 					save={ this.save }
 					submitForm={ this.submitForm }
 					submitButtonText={ this.translate( 'Sign Up and Connect Jetpack' ) }
-					footerLink={ this.renderFooterLink() } />
+					footerLink={ this.renderFooterLink() }
+					suggestedUsername={ userData && userData.username ? userData.username : '' }
+				/>
 				{ userData && this.loginUser() }
 			</div>
 		);

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -84,7 +84,7 @@ export class UserStep extends Component {
 			}
 		};
 
-		this.props.recordTrackEvent( 'calypso_signup_user_step_submit', analyticsData );
+		this.props.recordTracksEvent( 'calypso_signup_user_step_submit', analyticsData );
 
 		SignupActions.submitSignupStep( {
 			processingMessage: this.props.translate( 'Creating your account' ),
@@ -172,9 +172,7 @@ export default connect(
 	( state ) => ( {
 		suggestedUsername: getSuggestedUsername( state )
 	} ),
-	( dispatch ) => ( {
-		recordTrackEvent: ( event, data ) => {
-			dispatch( recordTracksEvent( event, data ) );
-		}
-	} )
+	{
+		recordTracksEvent
+	}
 )( localize( UserStep ) );

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import analytics from 'lib/analytics';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { identity, omit, get } from 'lodash';
 
@@ -13,6 +13,9 @@ import StepWrapper from 'signup/step-wrapper';
 import SignupForm from 'components/signup-form';
 import signupUtils from 'signup/utils';
 import SignupActions from 'lib/signup/actions';
+import { getSuggestedUsername } from 'state/signup/optional-dependencies/selectors';
+
+import { recordTracksEvent } from 'state/analytics/actions';
 
 export class UserStep extends Component {
 	static propTypes = {
@@ -23,6 +26,7 @@ export class UserStep extends Component {
 
 	static defaultProps = {
 		translate: identity,
+		suggestedUsername: identity
 	};
 
 	state = {
@@ -80,7 +84,7 @@ export class UserStep extends Component {
 			}
 		};
 
-		analytics.tracks.recordEvent( 'calypso_signup_user_step_submit', analyticsData );
+		this.props.recordTrackEvent( 'calypso_signup_user_step_submit', analyticsData );
 
 		SignupActions.submitSignupStep( {
 			processingMessage: this.props.translate( 'Creating your account' ),
@@ -143,6 +147,7 @@ export class UserStep extends Component {
 				save={ this.save }
 				submitForm={ this.submitForm }
 				submitButtonText={ this.submitButtonText() }
+				suggestedUsername={ this.props.suggestedUsername }
 			/>
 		);
 	}
@@ -163,4 +168,13 @@ export class UserStep extends Component {
 	}
 }
 
-export default localize( UserStep );
+export default connect(
+	( state ) => ( {
+		suggestedUsername: getSuggestedUsername( state )
+	} ),
+	( dispatch ) => ( {
+		recordTrackEvent: ( event, data ) => {
+			dispatch( recordTracksEvent( event, data ) );
+		}
+	} )
+)( localize( UserStep ) );

--- a/client/state/signup/optional-dependencies/selectors.js
+++ b/client/state/signup/optional-dependencies/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import get from 'lodash/get';
+import { get } from 'lodash';
 
 export function getSuggestedUsername( state ) {
 	return get( state, 'signup.optionalDependencies.suggestedUsername', '' );

--- a/client/state/signup/optional-dependencies/selectors.js
+++ b/client/state/signup/optional-dependencies/selectors.js
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import get from 'lodash/get';
+
+export function getSuggestedUsername( state ) {
+	return get( state, 'signup.optionalDependencies.suggestedUsername', '' );
+}

--- a/client/state/signup/optional-dependencies/test/selectors.js
+++ b/client/state/signup/optional-dependencies/test/selectors.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getSuggestedUsername } from '../selectors';
+
+describe( 'selectors', () => {
+	it( 'should return string if no username suggestions', () => {
+		expect( getSuggestedUsername( { signup: undefined } ) ).to.be.eql( '' );
+	} );
+
+	it( 'should return suggestedUsername', () => {
+		expect( getSuggestedUsername( {
+			signup: {
+				optionalDependencies: { suggestedUsername: 'testUsernameSuggestion' }
+			}
+		} ) ).to.be.eql( 'testUsernameSuggestion' );
+	} );
+} );


### PR DESCRIPTION
Username suggestions were broken due to a prop name change in #10599.

This PR improves the fetching of the suggested username to use Redux and properly just pass the prop to `SignupForm`

## To test:

### Test free username:
1. Start Signup
2. Go through Signup
3. Select a domain name which would result a free username suggestion ( e.g. `something123455123` )
4. Choose the free `wordpress.com` address
5. Reach the User step
6. See if the `username` field is properly filled up with the domain slug you wrote.

### To test a taken username:

1. Start Signup
2. Go through Signup
3. Type `kwight` in the domain search box
4. Choose `kwight.me`
5. Choose a random plan
6. Reach the User step
7. See if the username is `kwightweb` or something different than `kwight`

Todo:
* The unit tests are broken for the PR. Will work on fixing them.

cc @kwight :) 