### PR TITLE
Site Settings: Revise site icon help tooltip text

### DIFF
--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -205,7 +205,8 @@ class SiteIconSetting extends Component {
 				<FormLabel className="site-icon-setting__heading">
 					{ translate( 'Site Icon' ) }
 					<InfoPopover position="bottom right">
-						{ translate( 'A browser and app icon for your site.' ) }
+						{ translate( 'Your site icon will be shown across WordPress.com, in your' +
+							' visitors\' browser tabs, and as a home screen app icon.' ) }
 					</InfoPopover>
 				</FormLabel>
 				{ React.createElement( buttonProps.href ? 'a' : 'button', {


### PR DESCRIPTION
Closes #10451

This pull request seeks to modify the help text shown when tapping the info button adjacent the "Site Icon" form label, in hopes of better reflecting the fact that the site icon is used across the WordPress.com interface (Reader, administration, etc.).

Before|After
---|---
A browser and app icon for your site.|Your site icon will be shown across WordPress.com, in your visitors' browser tabs, and as a home screen app icon.

![Revised](https://cloud.githubusercontent.com/assets/1779930/22125350/51397618-de61-11e6-8d1a-afc190659edb.png)

Note: The original ("Before") text is reused from the equivalent Customizer field.

__Testing instructions:__

1. Navigate to [site settings](https://calypso.localhost:3000/settings/general)
2. Select a site
3. Tap the info button adjacent the Site Icon form label
4. Observe the tooltip shown includes the revised text