### PR TITLE
Signup: Update signup to make it possible to provide dependencies in query

### DIFF
--- a/client/lib/signup/actions.js
+++ b/client/lib/signup/actions.js
@@ -57,6 +57,18 @@ const SignupActions = {
 			errors: undefined === errors ? [] : errors,
 			providedDependencies: providedDependencies
 		} );
+	},
+
+	/**
+	 * Action for providing dependencies not associated with a step.
+	 *
+	 * @param {object} providedDependencies - Object containing dependencies
+	 */
+	provideDependencies( providedDependencies ) {
+		Dispatcher.handleViewAction( {
+			type: 'PROVIDE_SIGNUP_DEPENDENCIES',
+			providedDependencies
+		} );
 	}
 };
 

--- a/client/lib/signup/dependency-store.js
+++ b/client/lib/signup/dependency-store.js
@@ -53,8 +53,10 @@ SignupDependencyStore.dispatchToken = Dispatcher.register( function( payload ) {
 	if ( SignupDependencyStore.reduxStore ) {
 		switch ( action.type ) {
 			case 'PROCESSED_SIGNUP_STEP':
+			case 'PROVIDE_SIGNUP_DEPENDENCIES':
 			case 'SUBMIT_SIGNUP_STEP':
-				if ( assertValidDependencies( action ) ) {
+				if ( action.type === 'PROVIDE_SIGNUP_DEPENDENCIES' || assertValidDependencies( action ) ) {
+					// any dependency from `PROVIDE_SIGNUP_DEPENDENCIES` is valid as it is not associated with a step
 					SignupDependencyStore.reduxStore.dispatch( {
 						type: SIGNUP_DEPENDENCY_STORE_UPDATE,
 						data: action.providedDependencies

--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -61,6 +61,12 @@ function SignupFlowController( options ) {
 		this._resetStoresIfUserHasLoggedIn();
 	}
 
+	if ( this._flow.providesDependenciesInQuery ) {
+		this._assertFlowProvidedDependenciesFromConfig( options.providedDependencies );
+
+		SignupActions.provideDependencies( options.providedDependencies );
+	}
+
 	store.set( STORAGE_KEY, options.flowName );
 }
 
@@ -76,6 +82,12 @@ assign( SignupFlowController.prototype, {
 		if ( user.get() && find( SignupProgressStore.get(), { stepName: 'user' } ) ) {
 			SignupProgressStore.reset();
 			SignupDependencyStore.reset();
+		}
+	},
+
+	_assertFlowProvidedDependenciesFromConfig: function( providedDependencies ) {
+		if ( difference( this._flow.providesDependenciesInQuery, keys( providedDependencies ) ).length > 0 ) {
+			throw new Error( this._flowName + ' did not provide the dependencies it is configured to.' );
 		}
 	},
 
@@ -121,10 +133,15 @@ assign( SignupFlowController.prototype, {
 		return wpcom.isTokenLoaded() || user.get();
 	},
 
+	/**
+	 * Returns a list of the dependencies provided in the flow configuration.
+	 *
+	 * @return {array} a list of dependency names
+	 */
 	_getFlowProvidesDependencies: function() {
 		return flatten( compact( map( this._flow.steps, function( step ) {
 			return steps[ step ].providesDependencies;
-		} ) ) );
+		} ) ) ).concat( this._flow.providesDependenciesInQuery );
 	},
 
 	_process: function() {

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -44,7 +44,10 @@ function createSiteWithCart( callback, dependencies, {
 		blog_name: siteUrl,
 		blog_title: siteTitle,
 		options: {
-			theme: dependencies.theme || themeSlugWithRepo,
+			// the theme can be provided in this step's dependencies or the
+			// step object itself depending on if the theme is provided in a
+			// query. See `getThemeSlug` in `DomainsStep`.
+			theme: dependencies.themeSlugWithRepo || themeSlugWithRepo,
 			vertical: surveyVertical || undefined,
 			// the API wants the `is_domain_only` flag provided as a number
 			is_domain_only: dependencies.designType === 'domain' ? 1 : 0
@@ -271,11 +274,11 @@ module.exports = {
 		} );
 	},
 
-	createSite( callback, { theme }, { site } ) {
+	createSite( callback, { themeSlugWithRepo }, { site } ) {
 		var data = {
 			blog_name: site,
 			blog_title: '',
-			options: { theme },
+			options: { theme: themeSlugWithRepo },
 			validate: false
 		};
 

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -90,9 +90,9 @@ function createSiteWithCart( callback, dependencies, {
 		};
 
 		if ( ! user.get() && isFreeThemePreselected ) {
-			setThemeOnSite( addToCartAndProceed, { siteSlug }, { themeSlug } );
+			setThemeOnSite( addToCartAndProceed, { siteSlug, themeSlug } );
 		} else if ( user.get() && isFreeThemePreselected ) {
-			fetchSitesAndUser( siteSlug, setThemeOnSite.bind( this, addToCartAndProceed, { siteSlug }, { themeSlug } ) );
+			fetchSitesAndUser( siteSlug, setThemeOnSite.bind( this, addToCartAndProceed, { siteSlug, themeSlug } ) );
 		} else if ( user.get() ) {
 			fetchSitesAndUser( siteSlug, addToCartAndProceed );
 		} else {
@@ -147,7 +147,7 @@ function fetchSitesAndUser( siteSlug, onComplete ) {
 	], onComplete );
 }
 
-function setThemeOnSite( callback, { siteSlug }, { themeSlug } ) {
+function setThemeOnSite( callback, { siteSlug, themeSlug } ) {
 	if ( isEmpty( themeSlug ) ) {
 		defer( callback );
 

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -6,6 +6,7 @@ import defer from 'lodash/defer';
 import isEmpty from 'lodash/isEmpty';
 import async from 'async';
 import { parse as parseURL } from 'url';
+import { startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,7 +34,6 @@ function createSiteWithCart( callback, dependencies, {
 	googleAppsCartItem,
 	isPurchasingItem,
 	siteUrl,
-	themeSlug,
 	themeSlugWithRepo,
 	themeItem
 } ) {
@@ -65,7 +65,7 @@ function createSiteWithCart( callback, dependencies, {
 
 		const siteSlug = parsedBlogURL.hostname;
 		const siteId = response.blog_details.blogid;
-		const isFreeThemePreselected = themeSlug && ! themeItem;
+		const isFreeThemePreselected = startsWith( themeSlugWithRepo, 'pub' ) && ! themeItem;
 		const providedDependencies = {
 			siteId,
 			siteSlug,
@@ -90,9 +90,9 @@ function createSiteWithCart( callback, dependencies, {
 		};
 
 		if ( ! user.get() && isFreeThemePreselected ) {
-			setThemeOnSite( addToCartAndProceed, { siteSlug, themeSlug } );
+			setThemeOnSite( addToCartAndProceed, { siteSlug, themeSlugWithRepo } );
 		} else if ( user.get() && isFreeThemePreselected ) {
-			fetchSitesAndUser( siteSlug, setThemeOnSite.bind( this, addToCartAndProceed, { siteSlug, themeSlug } ) );
+			fetchSitesAndUser( siteSlug, setThemeOnSite.bind( this, addToCartAndProceed, { siteSlug, themeSlugWithRepo } ) );
 		} else if ( user.get() ) {
 			fetchSitesAndUser( siteSlug, addToCartAndProceed );
 		} else {
@@ -147,14 +147,14 @@ function fetchSitesAndUser( siteSlug, onComplete ) {
 	], onComplete );
 }
 
-function setThemeOnSite( callback, { siteSlug, themeSlug } ) {
-	if ( isEmpty( themeSlug ) ) {
+function setThemeOnSite( callback, { siteSlug, themeSlugWithRepo } ) {
+	if ( isEmpty( themeSlugWithRepo ) ) {
 		defer( callback );
 
 		return;
 	}
 
-	wpcom.undocumented().changeTheme( siteSlug, { theme: themeSlug }, function( errors ) {
+	wpcom.undocumented().changeTheme( siteSlug, { theme: themeSlugWithRepo.split( '/' )[ 1 ] }, function( errors ) {
 		callback( isEmpty( errors ) ? undefined : [ errors ] );
 	} );
 }

--- a/client/lib/signup/test/dependency-store.js
+++ b/client/lib/signup/test/dependency-store.js
@@ -49,4 +49,15 @@ describe( 'dependency-store', function() {
 
 		assert.deepEqual( SignupDependencyStore.get(), { bearer_token: 'TOKEN2' } );
 	} );
+
+	it( 'should store dependencies if they are provided in the `PROVIDE_SIGNUP_DEPENDENCIES` action', () => {
+		const dependencies = {
+			foo: 'bar',
+			baz: 'test'
+		};
+
+		SignupActions.provideDependencies( dependencies );
+
+		assert.deepEqual( SignupDependencyStore.get(), { bearer_token: 'TOKEN2', ...dependencies } );
+	} );
 } );

--- a/client/lib/signup/test/flow-controller.js
+++ b/client/lib/signup/test/flow-controller.js
@@ -34,10 +34,7 @@ describe( 'flow-controller', function() {
 	} );
 
 	afterEach( function() {
-		if ( signupFlowController ) {
-			signupFlowController.reset();
-		}
-
+		signupFlowController.reset();
 		SignupDependencyStore.reset();
 		SignupProgressStore.reset();
 	} );

--- a/client/lib/signup/test/flow-controller.js
+++ b/client/lib/signup/test/flow-controller.js
@@ -157,4 +157,26 @@ describe( 'flow-controller', function() {
 			} );
 		} );
 	} );
+
+	describe( 'controlling a flow w/ dependencies provided in query', function() {
+		it( 'should throw an error if the given flow requires dependencies from query but none are given', function() {
+			assert.throws( function() {
+				SignupFlowController( {
+					flowName: 'flowWithProvidedDependencies'
+				} );
+			} );
+		} );
+
+		it( 'should run `onComplete` once all steps are submitted without an error', function( done ) {
+			signupFlowController = SignupFlowController( {
+				flowName: 'flowWithProvidedDependencies',
+				providedDependencies: { siteSlug: 'foo' },
+				onComplete: ary( done, 0 )
+			} );
+
+			SignupActions.submitSignupStep( {
+				stepName: 'stepRequiringSiteSlug'
+			} );
+		} );
+	} );
 } );

--- a/client/lib/signup/test/signup/config/flows.js
+++ b/client/lib/signup/test/signup/config/flows.js
@@ -21,6 +21,11 @@ var flows = {
 
 	flowWithDelay: {
 		steps: [ 'delayedStep', 'stepA' ]
+	},
+
+	flowWithProvidedDependencies: {
+		steps: [ 'stepRequiringSiteSlug' ],
+		providesDependenciesInQuery: [ 'siteSlug' ]
 	}
 };
 

--- a/client/lib/signup/test/signup/config/steps.js
+++ b/client/lib/signup/test/signup/config/steps.js
@@ -12,6 +12,11 @@ module.exports = {
 		stepName: 'stepB'
 	},
 
+	stepRequiringSiteSlug: {
+		stepName: 'stepRequiringSiteSlug',
+		dependencies: [ 'siteSlug' ]
+	},
+
 	asyncStep: {
 		stepName: 'asyncStep',
 		apiRequestFunction: function( callback, dependencies, stepData ) {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -230,6 +230,14 @@ if ( config.isEnabled( 'signup/domain-first-flow' ) ) {
 		description: 'An experimental approach for WordPress.com/domains',
 		lastModified: '2017-01-16'
 	};
+
+	flows[ 'site-selected' ] = {
+		steps: [ 'theme' ],
+		destination: getSiteDestination,
+		providesDependenciesInQuery: [ 'siteSlug' ],
+		description: 'A flow to test updating an existing site with `Signup`',
+		lastModified: '2017-01-19'
+	};
 }
 
 if ( config( 'env' ) === 'development' ) {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -232,7 +232,7 @@ if ( config.isEnabled( 'signup/domain-first-flow' ) ) {
 	};
 
 	flows[ 'site-selected' ] = {
-		steps: [ 'themes' ],
+		steps: [ 'themes-site-selected' ],
 		destination: getSiteDestination,
 		providesDependenciesInQuery: [ 'siteSlug' ],
 		description: 'A flow to test updating an existing site with `Signup`',

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -232,7 +232,7 @@ if ( config.isEnabled( 'signup/domain-first-flow' ) ) {
 	};
 
 	flows[ 'site-selected' ] = {
-		steps: [ 'theme' ],
+		steps: [ 'themes' ],
 		destination: getSiteDestination,
 		providesDependenciesInQuery: [ 'siteSlug' ],
 		description: 'A flow to test updating an existing site with `Signup`',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -32,5 +32,6 @@ module.exports = {
 	'survey-user': UserSignupComponent,
 	test: config( 'env' ) === 'development' ? require( 'signup/steps/test-step' ) : undefined,
 	themes: ThemeSelectionComponent,
+	'themes-site-selected': ThemeSelectionComponent,
 	user: UserSignupComponent
 };

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -21,7 +21,17 @@ module.exports = {
 	themes: {
 		stepName: 'themes',
 		dependencies: [ 'siteSlug' ],
-		providesDependencies: [ 'themeSlugWithRepo' ]
+		providesDependencies: [ 'themeSlug', 'themeSlugWithRepo' ]
+	},
+
+	// `themes` does not update the theme for an existing site as we normally
+	// do this when the site is created. In flows where a site is merely being
+	// updated, we need to use a different API request function.
+	'themes-site-selected': {
+		stepName: 'themes-site-selected',
+		dependencies: [ 'siteSlug', 'themeSlug' ],
+		providesDependencies: [ 'themeSlug', 'themeSlugWithRepo' ],
+		apiRequestFunction: stepActions.setThemeOnSite
 	},
 
 	'design-type': {
@@ -121,7 +131,7 @@ module.exports = {
 			designType: 'blog'
 		},
 		dependencies: [ 'siteSlug' ],
-		providesDependencies: [ 'themeSlugWithRepo' ]
+		providesDependencies: [ 'themeSlug', 'themeSlugWithRepo' ]
 	},
 
 	// Currently, this step explicitly submits other steps to skip them, and

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -21,7 +21,7 @@ module.exports = {
 	themes: {
 		stepName: 'themes',
 		dependencies: [ 'siteSlug' ],
-		providesDependencies: [ 'theme' ]
+		providesDependencies: [ 'themeSlugWithRepo' ]
 	},
 
 	'design-type': {
@@ -67,7 +67,7 @@ module.exports = {
 		stepName: 'domains',
 		apiRequestFunction: stepActions.createSiteWithCart,
 		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
-		dependencies: [ 'theme' ],
+		dependencies: [ 'themeSlugWithRepo' ],
 		delayApiRequestUntilComplete: true
 	},
 
@@ -75,7 +75,7 @@ module.exports = {
 		stepName: 'domains-with-plan',
 		apiRequestFunction: stepActions.createSiteWithCartAndStartFreeTrial,
 		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
-		dependencies: [ 'theme' ],
+		dependencies: [ 'themeSlugWithRepo' ],
 		delayApiRequestUntilComplete: true
 	},
 
@@ -92,7 +92,7 @@ module.exports = {
 		props: {
 			isDomainOnly: true
 		},
-		dependencies: [ 'theme', 'designType' ],
+		dependencies: [ 'themeSlugWithRepo', 'designType' ],
 		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
 		delayApiRequestUntilComplete: true
 	},
@@ -121,7 +121,7 @@ module.exports = {
 			designType: 'blog'
 		},
 		dependencies: [ 'siteSlug' ],
-		providesDependencies: [ 'theme' ]
+		providesDependencies: [ 'themeSlugWithRepo' ]
 	},
 
 	// Currently, this step explicitly submits other steps to skip them, and

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -21,7 +21,7 @@ module.exports = {
 	themes: {
 		stepName: 'themes',
 		dependencies: [ 'siteSlug' ],
-		providesDependencies: [ 'themeSlug', 'themeSlugWithRepo' ]
+		providesDependencies: [ 'themeSlugWithRepo' ]
 	},
 
 	// `themes` does not update the theme for an existing site as we normally
@@ -29,8 +29,8 @@ module.exports = {
 	// updated, we need to use a different API request function.
 	'themes-site-selected': {
 		stepName: 'themes-site-selected',
-		dependencies: [ 'siteSlug', 'themeSlug' ],
-		providesDependencies: [ 'themeSlug', 'themeSlugWithRepo' ],
+		dependencies: [ 'siteSlug', 'themeSlugWithRepo' ],
+		providesDependencies: [ 'themeSlugWithRepo' ],
 		apiRequestFunction: stepActions.setThemeOnSite
 	},
 
@@ -131,7 +131,7 @@ module.exports = {
 			designType: 'blog'
 		},
 		dependencies: [ 'siteSlug' ],
-		providesDependencies: [ 'themeSlug', 'themeSlugWithRepo' ]
+		providesDependencies: [ 'themeSlugWithRepo' ]
 	},
 
 	// Currently, this step explicitly submits other steps to skip them, and

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -18,6 +18,7 @@ import assign from 'lodash/assign';
 import matchesProperty from 'lodash/matchesProperty';
 import indexOf from 'lodash/indexOf';
 import { setSurvey } from 'state/signup/steps/survey/actions';
+import { pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -124,8 +125,17 @@ const Signup = React.createClass( {
 
 		this.submitQueryDependencies();
 
+		const flow = flows.getFlow( this.props.flowName );
+
+		let providedDependencies;
+
+		if ( flow.providesDependenciesInQuery ) {
+			providedDependencies = pick( this.props.queryObject, flow.providesDependenciesInQuery );
+		}
+
 		this.signupFlowController = new SignupFlowController( {
 			flowName: this.props.flowName,
+			providedDependencies,
 			reduxStore: this.context.store,
 			onComplete: function( dependencies, destination ) {
 				const timeSinceLoading = this.state.loadingScreenStartTime
@@ -145,7 +155,7 @@ const Signup = React.createClass( {
 
 		this.loadProgressFromStore();
 
-		const flowSteps = flows.getFlow( this.props.flowName ).steps;
+		const flowSteps = flow.steps;
 		const flowStepsInProgressStore = filter(
 			SignupProgressStore.get(),
 			step => ( -1 !== flowSteps.indexOf( step.stepName ) ),

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -54,7 +54,9 @@ export default class SiteOrDomain extends Component {
 		if ( designType === 'domain' ) {
 			// we can skip the next two steps in the `domain-first` flow if the
 			// user is only purchasing a domain
-			SignupActions.submitSignupStep( { stepName: 'themes', wasSkipped: true }, [], { themeSlugWithRepo: 'pub/twentysixteen' } );
+			SignupActions.submitSignupStep( { stepName: 'themes', wasSkipped: true }, [], {
+				themeSlugWithRepo: 'pub/twentysixteen'
+			} );
 			SignupActions.submitSignupStep( { stepName: 'plans', wasSkipped: true }, [], { cartItem: null, privacyItem: null } );
 			goToStep( 'user' );
 		} else {

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -54,7 +54,7 @@ export default class SiteOrDomain extends Component {
 		if ( designType === 'domain' ) {
 			// we can skip the next two steps in the `domain-first` flow if the
 			// user is only purchasing a domain
-			SignupActions.submitSignupStep( { stepName: 'themes', wasSkipped: true }, [], { theme: 'pub/twentysixteen' } );
+			SignupActions.submitSignupStep( { stepName: 'themes', wasSkipped: true }, [], { themeSlugWithRepo: 'pub/twentysixteen' } );
 			SignupActions.submitSignupStep( { stepName: 'plans', wasSkipped: true }, [], { cartItem: null, privacyItem: null } );
 			goToStep( 'user' );
 		} else {

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -51,7 +51,7 @@ class ThemeSelectionStep extends Component {
 			processingMessage: this.props.translate( 'Adding your theme' ),
 			repoSlug
 		}, null, {
-			theme: repoSlug
+			themeSlugWithRepo: repoSlug
 		} );
 
 		this.props.goToNextStep();

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -51,6 +51,7 @@ class ThemeSelectionStep extends Component {
 			processingMessage: this.props.translate( 'Adding your theme' ),
 			repoSlug
 		}, null, {
+			themeSlug: theme.slug,
 			themeSlugWithRepo: repoSlug
 		} );
 

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -51,7 +51,6 @@ class ThemeSelectionStep extends Component {
 			processingMessage: this.props.translate( 'Adding your theme' ),
 			repoSlug
 		}, null, {
-			themeSlug: theme.slug,
 			themeSlugWithRepo: repoSlug
 		} );
 


### PR DESCRIPTION
This PR updates signup to allow a flow itself to specify that it provides a dependency in the query string. This allows us to provide a dependency like `siteSlug` to update an existing site with the `/start` flow (instead of creating one).

It also:

- Renames the `theme` dependency to `themeSlugWithRepo` to make it clearer what that dependency contains.
- Adds tests.
- Adds a `site-selected` flow that we can use to test this, and later, update to allow users to set up an existing domain-only site.

**Testing**
*`site-selected`*
- While logged in, visit `/start/site-selected?siteSlug=[site_slug]` where `[site_slug]` is the slug for a site for which your account is the owner.
- Select a theme.
- Once the signup "completes", click `Continue`.
- Assert that you are taken to your site and that it now has the theme you selected in the second step.

*The main flow*
- Visit `/start` in a new browser session.
- Proceed through signup and assert that you can complete it as before.

- [x] Code
- [x] Product