### PR TITLE
Stats: Enable All Time nav for Posts & Pages

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -454,9 +454,6 @@ module.exports = {
 			switch ( context.params.module ) {
 
 				case 'posts':
-					visitsList = new StatsList( {
-						statType: 'statsVisits', unit: activeFilter.period, siteID: siteId,
-						quantity: 10, date: endDate, domain: siteDomain } );
 					summaryList = fakeStatsList;
 					break;
 

--- a/client/my-sites/stats/stats-module/connected-list.jsx
+++ b/client/my-sites/stats/stats-module/connected-list.jsx
@@ -78,7 +78,7 @@ class StatsConnectedModule extends Component {
 
 	isAllTimeList() {
 		const { summary, statType } = this.props;
-		return summary && includes( [ 'statsCountryViews' ], statType );
+		return summary && includes( [ 'statsCountryViews', 'statsTopPosts' ], statType );
 	}
 
 	render() {

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -123,7 +123,7 @@ const StatsSummary = React.createClass( {
 					path="posts"
 					moduleStrings={ StatsStrings.posts }
 					period={ this.props.period }
-					query={ query }
+					query={ merge( {}, statsQueryOptions, query ) }
 					statType="statsTopPosts"
 					summary />;
 				break;


### PR DESCRIPTION
This branch brings the new "All Time" navigation to the Posts & Pages Summary page:

<img width="935" alt="stats_ _trout_bummin_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/22131416/299fd4ce-de68-11e6-9449-eb71d176b0bc.png">

Ideally, it would be nice to ship #10753 prior to this - to fix the incorrect `num` passed on Quarter link, and also the addition of the Year link.

__To Test__
- Visit a site stats page for any time period
- Click on "Posts & Pages" heading to launch summary page
- Interact with the new summary links, verify the numbers are the same as Atlas stats https://wordpress.com/my-stats/?view=postviews&summarize&numdays=90