### PR TITLE
Site Settings: Rely dirty checking on comparing persisted/unperstited fields

### DIFF
--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -66,7 +66,6 @@ class GoogleAnalyticsForm extends Component {
 			isSavingSettings,
 			jetpackModuleActive,
 			jetpackVersionSupportsModule,
-			markChanged,
 			showUpgradeNudge,
 			site,
 			translate,
@@ -83,7 +82,7 @@ class GoogleAnalyticsForm extends Component {
 		const isJetpackUnsupported = jetpack && ! jetpackVersionSupportsModule && isEnabled( 'jetpack/google-analytics' );
 
 		return (
-			<form id="site-settings" onSubmit={ handleSubmitForm } onChange={ markChanged }>
+			<form id="site-settings" onSubmit={ handleSubmitForm }>
 
 				{ showUpgradeNudge &&
 					<UpgradeNudge

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -462,7 +462,7 @@ class SiteSettingsFormDiscussion extends Component {
 			translate
 		} = this.props;
 		return (
-			<form id="site-settings" onSubmit={ handleSubmitForm } onChange={ this.props.markChanged }>
+			<form id="site-settings" onSubmit={ handleSubmitForm }>
 				{ this.renderSectionHeader( translate( 'Default Article Settings' ) ) }
 				<Card className="site-settings__discussion-settings">
 					{ this.defaultArticleSettings() }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -377,7 +377,7 @@ class SiteSettingsFormGeneral extends Component {
 
 		return (
 			<CompactCard>
-				<form onChange={ this.props.markChanged }>
+				<form>
 					<ul id="settings-jetpack">
 						<li>
 							<FormToggle
@@ -557,7 +557,7 @@ class SiteSettingsFormGeneral extends Component {
 					</Button>
 				</SectionHeader>
 				<Card>
-					<form onChange={ this.props.markChanged }>
+					<form>
 						{ this.siteOptions() }
 						{ this.blogAddress() }
 						{ this.languageOptions() }
@@ -581,7 +581,7 @@ class SiteSettingsFormGeneral extends Component {
 					</Button>
 				</SectionHeader>
 				<Card>
-					<form onChange={ this.props.markChanged }>
+					<form>
 						{ this.visibilityOptions() }
 					</form>
 				</Card>
@@ -625,7 +625,7 @@ class SiteSettingsFormGeneral extends Component {
 					</Button>
 				</SectionHeader>
 				<Card>
-					<form onChange={ this.props.markChanged }>
+					<form>
 						{ this.relatedPostsOptions() }
 					</form>
 				</Card>

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -49,7 +49,6 @@ class SiteSettingsFormWriting extends Component {
 
 	setCustomPostTypeSetting = ( revision ) => {
 		this.props.updateFields( revision );
-		this.props.markChanged();
 	}
 
 	submitFormAndActivateCustomContentModule = ( event ) => {
@@ -105,7 +104,6 @@ class SiteSettingsFormWriting extends Component {
 			isSavingSettings,
 			jetpackVersionSupportsCustomTypes,
 			onChangeField,
-			markChanged,
 			siteId,
 			trackEvent,
 			translate
@@ -115,7 +113,6 @@ class SiteSettingsFormWriting extends Component {
 			<form
 				id="site-settings"
 				onSubmit={ this.submitFormAndActivateCustomContentModule }
-				onChange={ markChanged }
 				className="site-settings__general-settings"
 			>
 				{ config.isEnabled( 'manage/site-settings/categories' ) &&

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -3,10 +3,9 @@
  */
 import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
-import { flowRight, keys, omit, pick } from 'lodash';
+import { flowRight, isEqual, keys, omit, pick } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import shallowEqual from 'react-pure-render/shallowEqual';
 
 /**
  * Internal dependencies
@@ -51,8 +50,8 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			}
 
 			if (
-				! shallowEqual( prevProps.settings, this.props.settings ) ||
-				! shallowEqual( prevProps.fields, this.props.fields )
+				! isEqual( prevProps.settings, this.props.settings ) ||
+				! isEqual( prevProps.fields, this.props.fields )
 			) {
 				this.updateDirtyFields();
 			}

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -75,12 +75,12 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 		}
 
 		updateDirtyFields() {
-			const unpersistedFields = this.props.fields;
+			const currentFields = this.props.fields;
 			const persistedFields = getFormSettings( this.props.settings );
 
-			// Compute the dirty fields by comparing the persisted and not persisted fields
+			// Compute the dirty fields by comparing the persisted and the current fields
 			const previousDirtyFields = this.props.dirtyFields;
-			const nextDirtyFields = previousDirtyFields.filter( field => unpersistedFields[ field ] !== persistedFields[ field ] );
+			const nextDirtyFields = previousDirtyFields.filter( field => ! isEqual( currentFields[ field ], persistedFields[ field ] ) );
 
 			// Update the dirty fields state without updating their values
 			if ( nextDirtyFields.length === 0 ) {
@@ -89,7 +89,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				this.props.markChanged();
 			}
 			this.props.clearDirtyFields();
-			this.props.updateFields( pick( unpersistedFields, nextDirtyFields ) );
+			this.props.updateFields( pick( currentFields, nextDirtyFields ) );
 
 			// Set the new non dirty fields
 			const nextNonDirtyFields = omit( persistedFields, nextDirtyFields );

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
-import { flowRight, omit, keys, pick } from 'lodash';
+import { flowRight, keys, omit, pick } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import shallowEqual from 'react-pure-render/shallowEqual';
@@ -78,20 +78,23 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 		updateDirtyFields() {
 			const unpersistedFields = this.props.fields;
 			const persistedFields = getFormSettings( this.props.settings );
+
 			// Compute the dirty fields by comparing the persisted and not persisted fields
-			const dirtyFields = Object.keys( unpersistedFields )
-				.filter( field => unpersistedFields[ field ] !== persistedFields[ field ] );
-			// Set the new non dirty fields
-			this.props.replaceFields( omit( persistedFields, dirtyFields ) );
+			const previousDirtyFields = this.props.dirtyFields;
+			const nextDirtyFields = previousDirtyFields.filter( field => unpersistedFields[ field ] !== persistedFields[ field ] );
 
 			// Update the dirty fields state without updating their values
-			this.props.clearDirtyFields();
-			this.props.updateFields( pick( unpersistedFields, dirtyFields ) );
-			if ( dirtyFields.length === 0 ) {
+			if ( nextDirtyFields.length === 0 ) {
 				this.props.markSaved();
 			} else {
 				this.props.markChanged();
 			}
+			this.props.clearDirtyFields();
+			this.props.updateFields( pick( unpersistedFields, nextDirtyFields ) );
+
+			// Set the new non dirty fields
+			const nextNonDirtyFields = omit( persistedFields, nextDirtyFields );
+			this.props.replaceFields( nextNonDirtyFields );
 		}
 
 		// Some Utils

--- a/client/state/site-settings/actions.js
+++ b/client/state/site-settings/actions.js
@@ -88,8 +88,6 @@ export function saveSiteSettings( siteId, settings ) {
 			type: SITE_SETTINGS_SAVE,
 			siteId
 		} );
-		// Optimistic update
-		dispatch( updateSiteSettings( siteId, settings ) );
 
 		return wpcom.undocumented().settings( siteId, 'post', settings )
 			.then( ( { updated } ) => {

--- a/client/state/site-settings/test/actions.js
+++ b/client/state/site-settings/test/actions.js
@@ -129,18 +129,13 @@ describe( 'actions', () => {
 				} );
 		} );
 
-		it( 'should dispatch fetch action and an optimistic update when thunk triggered', () => {
+		it( 'should dispatch fetch action when thunk triggered', () => {
 			saveSiteSettings( 2916284, { settingKey: 'chicken' } )( spy );
 
 			expect( spy ).to.have.been.calledWith( {
 				type: SITE_SETTINGS_SAVE,
 				siteId: 2916284
 			} );
-			expect( spy ).to.have.been.calledWith(
-				updateSiteSettings( 2916284, {
-					settingKey: 'chicken'
-				} )
-			);
 		} );
 
 		it( 'should dispatch update action when request completes', () => {


### PR DESCRIPTION
closes #10412

Before this setting dirtyFields was imperative on Fields Change,
with this PR, dirtyFields are computed by comparing the settings received as a prop
from the redux state and the component state.

--
This way of dirty checking is more "declarative" (which is preferable IMO), but the drawback here is the need to drop the optimistic redux update. 
If we want to keep this optimistic update absolutely (which I think is not that usefull right now), we would have to add some complexity to the redux store, where we would store the persisted and the edited settings directly on the store. I think this is too much not needed complexity.

**Testing instructions**

Scenario 1:
 1- Navigate to the General settings page
 2- Edit a field (title)
 3- Try to navigate away from the page
 4- You should be prompted with the "changes not saved modal"
 5- Save the form and retry to navigate away
 6- The modal should not show up

Scenario 2:
 1- Navigate to the General settings page
 2- Edit a field (title)
 3- Revert the field to the old value
 4- Try to navigate away from the page
 5- The modal should not show up

Scenario 3:
 1- Navigate to the General settings page
 2- Edit a field (title)
 3- Change the site icon (follow all the steps to change it)
 4- Once the site icon is saved and the "Settings saved" notice show up, try to navigate away from the page
 5- You should be prompted with the "changes not saved modal"