### PR TITLE
Stats: Reduxify podcasts stats

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -9,7 +9,6 @@ import { find, pick } from 'lodash';
 /**
  * Internal Dependencies
  */
-import config from 'config';
 import userFactory from 'lib/user';
 import sitesFactory from 'lib/sites-list';
 import route from 'lib/route';
@@ -227,7 +226,6 @@ module.exports = {
 		let chartDate;
 		let chartTab;
 		let visitsListFields;
-		let endDate;
 		let chartEndDate;
 		let period;
 		let chartPeriod;
@@ -299,7 +297,6 @@ module.exports = {
 
 			period = rangeOfPeriod( activeFilter.period, date );
 			chartPeriod = rangeOfPeriod( activeFilter.period, chartDate );
-			endDate = period.endOf.format( 'YYYY-MM-DD' );
 			chartEndDate = chartPeriod.endOf.format( 'YYYY-MM-DD' );
 
 			chartTab = queryOptions.tab || 'views';
@@ -353,16 +350,6 @@ module.exports = {
 				slug: siteDomain,
 				path: context.pathname,
 			};
-
-			if ( config.isEnabled( 'manage/stats/podcasts' ) ) {
-				siteComponentChildren.podcastDownloadsList = new StatsList( {
-					siteID: siteId,
-					statType: 'statsPodcastDownloads',
-					period: activeFilter.period,
-					date: endDate,
-					domain: siteDomain
-				} );
-			}
 
 			renderWithReduxStore(
 				React.createElement( siteComponent, siteComponentChildren ),
@@ -491,8 +478,7 @@ module.exports = {
 					break;
 
 				case 'podcastdownloads':
-					summaryList = new StatsList( { statType: 'statsPodcastDownloads', siteID: siteId,
-						period: activeFilter.period, date: endDate, max: 0, domain: siteDomain } );
+					summaryList = fakeStatsList;
 					break;
 			}
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -15,7 +15,6 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import DatePicker from './stats-date-picker';
 import Countries from './stats-countries';
 import ChartTabs from './stats-chart-tabs';
-import StatsModule from './stats-module';
 import StatsConnectedModule from './stats-module/connected-list';
 import statsStrings from './stats-strings';
 import titlecase from 'to-title-case';
@@ -129,14 +128,17 @@ module.exports = React.createClass( {
 				);
 			}
 			if ( config.isEnabled( 'manage/stats/podcasts' ) && site.options.podcasting_archive ) {
-				podcastList = <StatsModule
-					path={ 'podcastdownloads' }
-					moduleStrings={ moduleStrings.podcastdownloads }
-					site={ site }
-					dataList={ this.props.podcastDownloadsList }
-					period={ this.props.period }
-					date={ queryDate }
-					beforeNavigate={ this.updateScrollPosition } />;
+				podcastList = (
+					<StatsConnectedModule
+						path="podcastdownloads"
+						moduleStrings={ moduleStrings.podcastdownloads }
+						period={ this.props.period }
+						date={ queryDate }
+						query={ query }
+						statType="statsPodcastDownloads"
+						showSummaryLink
+					/>
+				);
 			}
 		}
 

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -13,7 +13,6 @@ import { localize } from 'i18n-calypso';
  */
 import observe from 'lib/mixins/data-observe';
 import HeaderCake from 'components/header-cake';
-import StatsModule from '../stats-module';
 import StatsConnectedModule from '../stats-module/connected-list';
 import statsStringsFactory from '../stats-strings';
 import Countries from '../stats-countries';
@@ -65,7 +64,7 @@ const StatsSummary = React.createClass( {
 	},
 
 	render: function() {
-		const { site, translate, statsQueryOptions } = this.props;
+		const { translate, statsQueryOptions } = this.props;
 		const summaryViews = [];
 		let title;
 		let summaryView;
@@ -161,15 +160,14 @@ const StatsSummary = React.createClass( {
 
 			case 'podcastdownloads':
 				title = translate( 'Podcasts' );
-				summaryView = <StatsModule
+				summaryView = <StatsConnectedModule
 					key="podcastdownloads-summary"
-					path={ 'podcastdownloads' }
+					path="podcastdownloads"
 					moduleStrings={ StatsStrings.podcastdownloads }
-					site={ site }
-					dataList={ this.props.summaryList }
 					period={ this.props.period }
-					followList={ this.props.followList }
-					summary={ true } />;
+					query={ query }
+					statType="statsPodcastDownloads"
+					summary />;
 				break;
 
 			case 'videodetails':

--- a/client/state/stats/lists/actions.js
+++ b/client/state/stats/lists/actions.js
@@ -47,8 +47,13 @@ export function requestSiteStats( siteId, statType, query ) {
 			query
 		} );
 
+		const isUndocumented = 'statsPodcastDownloads' === statType;
 		const options = 'statsVideo' === statType ? query.postId : query;
-		return wpcom.site( siteId )[ statType ]( options ).then( data => {
+		const site = isUndocumented
+			? wpcom.undocumented().site( siteId )
+			: wpcom.site( siteId );
+
+		return site[ statType ]( options ).then( data => {
 			dispatch( receiveSiteStats( siteId, statType, query, data ) );
 			dispatch( {
 				type: SITE_STATS_REQUEST_SUCCESS,

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1114,5 +1114,58 @@ describe( 'utils', () => {
 				} );
 			} );
 		} );
+
+		describe( 'statsPodcastDownloads()', () => {
+			it( 'should return an empty array if data is null', () => {
+				const parsedData = normalizers.statsPodcastDownloads();
+
+				expect( parsedData ).to.eql( [] );
+			} );
+
+			it( 'should return an empty array if query.period is null', () => {
+				const parsedData = normalizers.statsPodcastDownloads( {}, { date: '2016-12-25' } );
+
+				expect( parsedData ).to.eql( [] );
+			} );
+
+			it( 'should return an empty array if query.date is null', () => {
+				const parsedData = normalizers.statsPodcastDownloads( {}, { period: 'day' } );
+
+				expect( parsedData ).to.eql( [] );
+			} );
+
+			it( 'should properly parse day period response', () => {
+				const parsedData = normalizers.statsPodcastDownloads( {
+					date: '2017-01-12',
+					days: {
+						'2017-01-12': {
+							downloads: [ {
+								url: 'http://en.blog.wordpress.com/awesome',
+								post_id: 10,
+								title: 'My awesome podcast',
+								downloads: 3939
+							} ]
+						}
+					}
+				}, {
+					period: 'day',
+					date: '2017-01-12'
+				}, 10, {
+					slug: 'en.blog.wordpress.com'
+				} );
+
+				expect( parsedData ).to.eql( [
+					{
+						actions: [ {
+							data: 'http://en.blog.wordpress.com/awesome',
+							type: 'link'
+						} ],
+						label: 'My awesome podcast',
+						page: '/stats/day/podcastdownloads/en.blog.wordpress.com?post=10',
+						value: 3939
+					}
+				] );
+			} );
+		} );
 	} );
 } );

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -510,5 +510,36 @@ export const normalizers = {
 		}
 
 		return result;
+	},
+
+	/*
+	 * Returns a normalized statsPodcastDownloads array, ready for use in stats-module
+	 *
+	 * @param  {Object} data   Stats data
+	 * @param  {Object} query  Stats query
+	 * @param  {Int}    siteId Site ID
+	 * @param  {Object} site   Site Object
+	 * @return {Array}         Parsed data array
+	 */
+	statsPodcastDownloads( data, query, siteId, site ) {
+		if ( ! data || ! query.period || ! query.date ) {
+			return [];
+		}
+
+		const { startOf } = rangeOfPeriod( query.period, query.date );
+		const statsData = get( data, [ 'days', startOf, 'downloads' ], [] );
+
+		return statsData.map( ( item ) => {
+			const detailPage = site ? '/stats/' + query.period + '/podcastdownloads/' + site.slug + '?post=' + item.post_id : null;
+			return {
+				label: item.title,
+				page: detailPage,
+				value: item.downloads,
+				actions: [ {
+					type: 'link',
+					data: item.url
+				} ]
+			};
+		} );
 	}
 };


### PR DESCRIPTION
In this PR, I moved the parser logic for statsPodcastDownloads from StatsList into the redux stats subtree. I also updated the statsPodcastDownloads stats module to use the StatsConnectedModule Component.

@timmyc Do you how can I find a website with some podcast stats?

**Testing instructions**

 - Navigate to the stats page /stats/day/$site (for a site with podcasts enabled)
 - The Clicks panel should work properly (same as master)
 - Click on the header of the panel to navigate to the summary page
 - The clicks stats should show up (same as master)

