### PR TITLE
Stats: Create stats normalizer for statsVisits

### DIFF
--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1114,5 +1114,59 @@ describe( 'utils', () => {
 				} );
 			} );
 		} );
+
+		describe( 'statsVisits()', () => {
+			it( 'should return an empty array if not data is passed', () => {
+				const parsedData = normalizers.statsVisits();
+				expect( parsedData ).to.eql( [] );
+			} );
+
+			it( 'should return an empty array if the payload no data attribute', () => {
+				const parsedData = normalizers.statsVisits( { bad: [] } );
+
+				expect( parsedData ).to.eql( [] );
+			} );
+
+			it( 'should return an a properly parsed data array', () => {
+				const parsedData = normalizers.statsVisits( {
+					fields: [ 'period', 'views', 'visitors' ],
+					data: [
+						[ '2016-12-22', 0, 0 ],
+						[ '2016-12-23', 10, 6 ]
+					]
+				} );
+
+				expect( parsedData ).to.eql( [
+					{
+						classNames: [],
+						comments: null,
+						labelDay: 'Dec 22',
+						labelMonth: 'Dec',
+						labelWeek: 'Dec 22',
+						labelYear: '2016',
+						likes: null,
+						period: '2016-12-22',
+						posts: null,
+						views: 0,
+						visitors: 0,
+						visits: null
+					},
+					{
+						classNames: [],
+						comments: null,
+						labelDay: 'Dec 23',
+						labelMonth: 'Dec',
+						labelWeek: 'Dec 23',
+						labelYear: '2016',
+						likes: null,
+						period: '2016-12-23',
+						posts: null,
+						views: 10,
+						visitors: 6,
+						visits: null
+					}
+				] );
+			} );
+		} );
 	} );
 } );

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1167,6 +1167,47 @@ describe( 'utils', () => {
 					}
 				] );
 			} );
+
+			it( 'should parse the weekends properly', () => {
+				const parsedData = normalizers.statsVisits( {
+					fields: [ 'period', 'views', 'visitors' ],
+					data: [
+						[ '2016W11W07', 0, 0 ],
+						[ '2016W10W31', 10, 6 ]
+					]
+				} );
+
+				expect( parsedData ).to.eql( [
+					{
+						classNames: [],
+						comments: null,
+						labelDay: 'Nov 7',
+						labelMonth: 'Nov',
+						labelWeek: 'Nov 7',
+						labelYear: '2016',
+						likes: null,
+						period: '2016-11-07',
+						posts: null,
+						views: 0,
+						visitors: 0,
+						visits: null
+					},
+					{
+						classNames: [],
+						comments: null,
+						labelDay: 'Oct 31',
+						labelMonth: 'Oct',
+						labelWeek: 'Oct 31',
+						labelYear: '2016',
+						likes: null,
+						period: '2016-10-31',
+						posts: null,
+						views: 10,
+						visitors: 6,
+						visits: null
+					}
+				] );
+			} );
 		} );
 	} );
 } );

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -476,6 +476,54 @@ export const normalizers = {
 		} );
 	},
 
+	statsVisits( payload ) {
+		if ( ! payload || ! payload.data ) {
+			return [];
+		}
+
+		const attributes = [ 'visits', 'likes', 'visitors', 'comments', 'posts' ];
+
+		return payload.data.map( function( record ) {
+			// Initialize data
+			const dataRecord = attributes.reduce( ( memo, attribute ) => {
+				memo[ attribute ] = null;
+				return memo;
+			}, {} );
+
+			// Fill Field Values
+			record.forEach( function( value, i ) {
+				// Remove W from weeks
+				if ( 'period' === payload.fields[ i ] ) {
+					value = value.replace( /W/g, '-' );
+				}
+				dataRecord[ payload.fields[ i ] ] = value;
+			} );
+
+			dataRecord.labelDay = '';
+			dataRecord.labelWeek = '';
+			dataRecord.labelMonth = '';
+			dataRecord.labelYear = '';
+			dataRecord.classNames = [];
+
+			if ( dataRecord.period ) {
+				const date = moment( dataRecord.period, 'YYYY-MM-DD' ).locale( 'en' );
+				const localizedDate = moment( dataRecord.period, 'YYYY-MM-DD' );
+				if ( date.isValid() ) {
+					const dayOfWeek = date.toDate().getDay();
+					if ( ( 'day' === payload.unit ) && ( ( 6 === dayOfWeek ) || ( 0 === dayOfWeek ) ) ) {
+						dataRecord.classNames.push( 'is-weekend' );
+					}
+					dataRecord.labelDay = localizedDate.format( 'MMM D' );
+					dataRecord.labelWeek = localizedDate.format( 'MMM D' );
+					dataRecord.labelMonth = localizedDate.format( 'MMM' );
+					dataRecord.labelYear = localizedDate.format( 'YYYY' );
+				}
+			}
+
+			return dataRecord;
+		} );
+	},
+
 	/*
 	 * Returns a normalized statsSearchTerms array, ready for use in stats-module
 	 *


### PR DESCRIPTION
This is the first step to #10622 

Reduxifying `statsVisits` need more changes that other stats endpoints, so I'm splitting the work to multiple PRs. In the current PR, I create the endpoint normalizer in `state/stats/lists/utils`.

**Testing**

Nothing to test, this normalizer is not used yet!