### PR TITLE
Render empty layout structure during initialization.

### DIFF
--- a/server/pages/desktop.jade
+++ b/server/pages/desktop.jade
@@ -28,7 +28,13 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class='is-desktop' + ( isFluidWidth ?
 
 	body(class=isRTL ? 'rtl' : '')
 		#wpcom.wpcom-site
-			.wpcom-site__logo.noticon.noticon-wordpress
+			.layout
+				.masterbar
+				.layout__content
+					.wpcom-site__logo.noticon.noticon-wordpress
+					if hasSecondary
+						.layout__secondary
+						ul.sidebar
 		if badge
 			div.environment-badge
 				a(class='bug-report', href=feedbackURL, title='Report an issue', target='_blank')

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -60,7 +60,12 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			#wpcom.wpcom-site!= renderedLayout
 		else
 			#wpcom.wpcom-site
-				.wpcom-site__logo.noticon.noticon-wordpress
+				.layout
+					.masterbar
+					.layout__content
+						.wpcom-site__logo.noticon.noticon-wordpress
+						.layout__secondary
+						ul.sidebar
 		if badge
 			div.environment-badge
 				if abTestHelper

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -64,8 +64,9 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 					.masterbar
 					.layout__content
 						.wpcom-site__logo.noticon.noticon-wordpress
-						.layout__secondary
-						ul.sidebar
+						if hasSecondary
+							.layout__secondary
+							ul.sidebar
 		if badge
 			div.environment-badge
 				if abTestHelper

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -358,6 +358,11 @@ module.exports = function() {
 					if ( config.isEnabled( 'code-splitting' ) ) {
 						req.context = Object.assign( {}, req.context, { chunk: section.name } );
 					}
+
+					if ( section.secondary ) {
+						req.context.hasSecondary = true;
+					}
+
 					next();
 				} );
 


### PR DESCRIPTION
Example:

![screen shot 2017-01-20 at 15 14 16](https://cloud.githubusercontent.com/assets/548849/22152486/7a6564da-df23-11e6-87f3-06cbdf678491.png)
