### PR TITLE
Jetpack Settings: Introduce a card for Subscriptions

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -320,6 +320,7 @@
 @import 'my-sites/site-settings/jetpack-sync-panel/style';
 @import 'my-sites/site-settings/press-this/style';
 @import 'my-sites/site-settings/site-icon-setting/style';
+@import 'my-sites/site-settings/subscriptions/style';
 @import 'my-sites/site-settings/taxonomies/style';
 @import 'my-sites/site-settings/theme-enhancements/style';
 @import 'my-sites/importer/style';

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -23,7 +23,7 @@ import SectionHeader from 'components/section-header';
 import {
 	isJetpackModuleActive,
 	isJetpackSite,
-	siteSupportsJetpackSettingsUI
+	siteSupportsJetpackSettingsUi
 } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import Subscriptions from './subscriptions';
@@ -507,7 +507,7 @@ const connectComponent = connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
 		const isJetpack = isJetpackSite( state, siteId );
-		const jetpackSettingsUISupported = siteSupportsJetpackSettingsUI( state, siteId );
+		const jetpackSettingsUISupported = siteSupportsJetpackSettingsUi( state, siteId );
 		const isLikesModuleActive = isJetpackModuleActive( state, siteId, 'likes' );
 
 		return {

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -20,7 +20,14 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import Card from 'components/card';
 import Button from 'components/button';
 import SectionHeader from 'components/section-header';
-import { isJetpackSite, isJetpackModuleActive } from 'state/sites/selectors';
+import {
+	isJetpackModuleActive,
+	isJetpackSite,
+	siteSupportsJetpackSettingsUI
+} from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import Subscriptions from './subscriptions';
+import QueryJetpackModules from 'components/data/query-jetpack-modules';
 
 class SiteSettingsFormDiscussion extends Component {
 	handleCommentOrder = () => {
@@ -443,7 +450,17 @@ class SiteSettingsFormDiscussion extends Component {
 	}
 
 	render() {
-		const { handleSubmitForm, translate } = this.props;
+		const {
+			fields,
+			handleSubmitForm,
+			handleToggle,
+			siteId,
+			isRequestingSettings,
+			isSavingSettings,
+			isJetpack,
+			jetpackSettingsUISupported,
+			translate
+		} = this.props;
 		return (
 			<form id="site-settings" onSubmit={ handleSubmitForm } onChange={ this.props.markChanged }>
 				{ this.renderSectionHeader( translate( 'Default Article Settings' ) ) }
@@ -463,18 +480,40 @@ class SiteSettingsFormDiscussion extends Component {
 					<hr />
 					{ this.commentBlacklistSettings() }
 				</Card>
+
+				{
+					isJetpack && jetpackSettingsUISupported && (
+						<div>
+							<QueryJetpackModules siteId={ siteId } />
+
+							{ this.renderSectionHeader( translate( 'Subscriptions' ) ) }
+
+							<Subscriptions
+								onSubmitForm={ handleSubmitForm }
+								handleToggle={ handleToggle }
+								isSavingSettings={ isSavingSettings }
+								isRequestingSettings={ isRequestingSettings }
+								fields={ fields }
+							/>
+						</div>
+					)
+				}
 			</form>
 		);
 	}
 }
 
 const connectComponent = connect(
-	( state, { siteId } ) => {
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
 		const isJetpack = isJetpackSite( state, siteId );
+		const jetpackSettingsUISupported = siteSupportsJetpackSettingsUI( state, siteId );
 		const isLikesModuleActive = isJetpackModuleActive( state, siteId, 'likes' );
 
 		return {
+			siteId,
 			isJetpack,
+			jetpackSettingsUISupported,
 			isLikesModuleActive,
 		};
 	}
@@ -507,6 +546,8 @@ const getFormSettings = partialRight( pick, [
 	'admin_url',
 	'wpcom_publish_comments_with_markdown',
 	'markdown_supported',
+	'stb_enabled',
+	'stc_enabled',
 ] );
 
 export default flowRight(

--- a/client/my-sites/site-settings/subscriptions/index.jsx
+++ b/client/my-sites/site-settings/subscriptions/index.jsx
@@ -48,12 +48,6 @@ const Subscriptions = ( {
 				{
 					subscriptionsModuleActive && (
 						<div className="subscriptions__module-settings is-indented">
-							<p>
-								<a href={ '/people/email-followers/' + selectedSiteSlug }>
-									{ translate( 'View your Email Followers' ) }
-								</a>
-							</p>
-
 							<FormToggle
 								className="subscriptions__module-settings-toggle is-compact"
 								checked={ !! fields.stb_enabled }
@@ -73,6 +67,12 @@ const Subscriptions = ( {
 									{ translate( 'Show a "follow comments" option in the comment form.' ) }
 								</span>
 							</FormToggle>
+
+							<p className="subscriptions__email-followers">
+								<a href={ '/people/email-followers/' + selectedSiteSlug }>
+									{ translate( 'View your Email Followers' ) }
+								</a>
+							</p>
 						</div>
 					)
 				}

--- a/client/my-sites/site-settings/subscriptions/index.jsx
+++ b/client/my-sites/site-settings/subscriptions/index.jsx
@@ -1,0 +1,109 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import JetpackModuleToggle from '../jetpack-module-toggle';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormToggle from 'components/forms/form-toggle';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { isModuleActive } from 'state/jetpack/modules/selectors';
+import InfoPopover from 'components/info-popover';
+import ExternalLink from 'components/external-link';
+
+const Subscriptions = ( {
+	fields,
+	handleToggle,
+	isRequestingSettings,
+	isSavingSettings,
+	selectedSiteId,
+	selectedSiteSlug,
+	subscriptionsModuleActive,
+	translate
+} ) => {
+	return (
+		<Card className="subscriptions__card site-settings">
+			<FormFieldset>
+				<div className="subscriptions__info-link-container">
+					<InfoPopover position={ 'left' }>
+						<ExternalLink href={ 'https://jetpack.com/support/subscriptions' } target="_blank">
+							{ translate( 'Learn more about Subscriptions' ) }
+						</ExternalLink>
+					</InfoPopover>
+				</div>
+
+				<JetpackModuleToggle
+					siteId={ selectedSiteId }
+					moduleSlug="subscriptions"
+					label={ translate( 'Allow users to subscribe to your posts and comments and receive notifications via email.' ) }
+					disabled={ isRequestingSettings || isSavingSettings }
+					/>
+
+				{
+					subscriptionsModuleActive && (
+						<div className="subscriptions__module-settings is-indented">
+							<p>
+								<a href={ '/people/email-followers/' + selectedSiteSlug }>
+									{ translate( 'View your Email Followers' ) }
+								</a>
+							</p>
+
+							<FormToggle
+								className="subscriptions__module-settings-toggle is-compact"
+								checked={ !! fields.stb_enabled }
+								disabled={ isRequestingSettings || isSavingSettings }
+								onChange={ handleToggle( 'stb_enabled' ) }>
+								<span className="site-settings__toggle-label">
+									{ translate( 'Show a "follow blog" options in the comment form' ) }
+								</span>
+							</FormToggle>
+
+							<FormToggle
+								className="subscriptions__module-settings-toggle is-compact"
+								checked={ !! fields.stc_enabled }
+								disabled={ isRequestingSettings || isSavingSettings }
+								onChange={ handleToggle( 'stc_enabled' ) }>
+								<span className="site-settings__toggle-label">
+									{ translate( 'Show a "follow comments" option in the comment form.' ) }
+								</span>
+							</FormToggle>
+						</div>
+					)
+				}
+			</FormFieldset>
+		</Card>
+	);
+};
+
+Subscriptions.defaultProps = {
+	isSavingSettings: false,
+	isRequestingSettings: true,
+	fields: {}
+};
+
+Subscriptions.propTypes = {
+	onSubmitForm: PropTypes.func.isRequired,
+	handleToggle: PropTypes.func.isRequired,
+	isSavingSettings: PropTypes.bool,
+	isRequestingSettings: PropTypes.bool,
+	fields: PropTypes.object,
+};
+
+export default connect(
+	( state ) => {
+		const selectedSiteId = getSelectedSiteId( state );
+		const selectedSiteSlug = getSelectedSiteSlug( state );
+
+		return {
+			selectedSiteId,
+			selectedSiteSlug,
+			subscriptionsModuleActive: !! isModuleActive( state, selectedSiteId, 'subscriptions' ),
+		};
+	}
+)( localize( Subscriptions ) );

--- a/client/my-sites/site-settings/subscriptions/index.jsx
+++ b/client/my-sites/site-settings/subscriptions/index.jsx
@@ -54,7 +54,7 @@ const Subscriptions = ( {
 								disabled={ isRequestingSettings || isSavingSettings }
 								onChange={ handleToggle( 'stb_enabled' ) }>
 								<span className="site-settings__toggle-label">
-									{ translate( 'Show a "follow blog" options in the comment form' ) }
+									{ translate( 'Show a "follow blog" option in the comment form' ) }
 								</span>
 							</FormToggle>
 

--- a/client/my-sites/site-settings/subscriptions/style.scss
+++ b/client/my-sites/site-settings/subscriptions/style.scss
@@ -1,0 +1,11 @@
+.subscriptions__module-settings.is-indented {
+	margin: 16px 32px;
+
+	.site-settings__toggle-label {
+		margin-left: 8px;
+	}
+}
+
+.subscriptions__info-link-container {
+	float: right;
+}

--- a/client/my-sites/site-settings/subscriptions/style.scss
+++ b/client/my-sites/site-settings/subscriptions/style.scss
@@ -4,6 +4,10 @@
 	.site-settings__toggle-label {
 		margin-left: 8px;
 	}
+
+	.subscriptions__email-followers {
+		margin-top: 16px;
+	}
 }
 
 .subscriptions__info-link-container {


### PR DESCRIPTION
### Introduction

This PR is part of #9171. It introduces a Subscriptions card under Discussion Settings. This card will be used to manage the settings of the Subscriptions module.

### Preview

**When Subscriptions module is disabled**
![](https://cldup.com/w_LC7hEwbf.png)

**When Subscriptions module is enabled**
![](https://cldup.com/mDpz9_SbqM.png)

### Testing 

* Checkout this branch.
* Select one of your Jetpack sites that has Jetpack 4.5 or newer.
* Go to `/settings/discussion/$site`, where `$site` is the slug of your Jetpack site.
* Verify the Subscriptions card is displayed properly as shown on the previews.
* Play with the main toggle that toggles the Subscriptions module, and verify it saves correctly in your Jetpack site.
* Verify that the module settings are displayed only when the module is active.
* Play with the module settings and verify they save properly in your Jetpack site.
* Verify the link to view the Email Followers works correctly and leads to the right place in Calypso.
* Verify the link of the info popover is working as expected and lead to the right place.
* Test with a Jetpack site with Jetpack 4.4.2 or older and verify the card is not shown.
* Test with a WordPress.com site and verify that the card is not shown at all.