### PR TITLE
Clean up site-icon styling

### DIFF
--- a/client/blocks/site-icon/style.scss
+++ b/client/blocks/site-icon/style.scss
@@ -7,7 +7,6 @@
 
 	// Globe icon for sites without an icon
 	&.is-blank {
-		border: 1px solid $white;
 		background: lighten( $gray, 20% );
 		.gridicon {
 			color: $white;

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -55,7 +55,6 @@
 // within a Site item
 .site .site-icon {
 	position: relative;
-	border: 1px solid $transparent;
 	height: 30px;
 	width: 30px;
 	overflow: hidden;
@@ -107,7 +106,7 @@
 	transition: opacity 0.2s;
 	transform: translate3d(0, 0, 0);
 	position: absolute;
-		left: 17px;
+		left: 16px;
 		top: 17px;
 
 	.gridicon {

--- a/client/my-sites/all-sites-icon/style.scss
+++ b/client/my-sites/all-sites-icon/style.scss
@@ -21,8 +21,10 @@
 
 .all-sites-icon .site-icon {
 	align-self: auto;
-	background: $gray;
-	border: none;
 	margin-right: 1px;
 	display: inline-block;
+
+	&.is-blank {
+		background: $gray;
+	}
 }

--- a/client/my-sites/draft/style.scss
+++ b/client/my-sites/draft/style.scss
@@ -41,7 +41,6 @@
 // used on multisite screen to show
 // which site a draft belongs to
 .draft .site-icon {
-	border: none;
 	position: absolute;
 	right: 16px;
 	top: 13px;

--- a/client/my-sites/sidebar-navigation/sidebar-navigation.jsx
+++ b/client/my-sites/sidebar-navigation/sidebar-navigation.jsx
@@ -30,7 +30,7 @@ module.exports = React.createClass( {
 				sectionName="site"
 				sectionTitle={ currentSiteTitle }>
 				{ site ?
-					<SiteIcon site={ site } size={ 30 } /> :
+					<SiteIcon site={ site } /> :
 					<AllSitesIcon sites={ sites.get() } /> }
 			</SidebarNavigation>
 		);

--- a/client/my-sites/sidebar-navigation/style.scss
+++ b/client/my-sites/sidebar-navigation/style.scss
@@ -26,8 +26,6 @@
 	}
 
 	.site-icon {
-		background: lighten( $gray, 20% );
-		border: 1px solid $gray;
 		margin-right: 8px;
 	}
 

--- a/client/my-sites/site-settings/site-icon-setting/style.scss
+++ b/client/my-sites/site-settings/site-icon-setting/style.scss
@@ -13,11 +13,11 @@
 
 .site-icon-setting__icon {
 	cursor: pointer;
+	display: block;
+	margin: 1px;
 }
 
 .site-icon-setting__icon:hover .site-icon {
-	border-style: dashed;
-	border-color: $gray-dark;
 	opacity: 0.8;
 }
 

--- a/client/reader/list-item/style.scss
+++ b/client/reader/list-item/style.scss
@@ -67,10 +67,6 @@
 		position: relative;
 			top: 1px;
 	}
-
-	.site-icon {
-		border: 0;
-	}
 }
 
 .reader-list-item__actions {

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -244,7 +244,7 @@
 		}
 
 		.site-icon {
-			border: 1px solid lighten( $gray, 30% );
+			margin: 1px;
 		}
 
 		.gravatar {


### PR DESCRIPTION
Delete default borders and overrides. Add specificity to all-sites-icon usage, which seems to be the only one overriding background color