### PR TITLE
DocumentHead: Update title when site changes

### DIFF
--- a/client/state/document-head/selectors.js
+++ b/client/state/document-head/selectors.js
@@ -80,7 +80,11 @@ export const getDocumentHeadFormattedTitle = createSelector(
 
 		return title + 'WordPress.com';
 	},
-	( state ) => [ state.ui.selectedSiteId, state.documentHead ]
+	( state ) => [
+		state.documentHead,
+		state.ui.section,
+		state.ui.selectedSiteId,
+	]
 );
 
 /**

--- a/client/state/document-head/selectors.js
+++ b/client/state/document-head/selectors.js
@@ -80,7 +80,7 @@ export const getDocumentHeadFormattedTitle = createSelector(
 
 		return title + 'WordPress.com';
 	},
-	( state ) => state.documentHead
+	( state ) => [ state.ui.selectedSiteId, state.documentHead ]
 );
 
 /**


### PR DESCRIPTION
Currently, switching between sites leaves the `document.title` intact.

It seems to be this way because [the prop](https://github.com/Automattic/wp-calypso/blob/97bae59f88d43babddaa2412449cf8d79d56612b/client/components/data/document-head/index.jsx#L93) that the `DocumentHead` component relies on to change is provided by a memoized / cached [selector](https://github.com/Automattic/wp-calypso/blob/97bae59f88d43babddaa2412449cf8d79d56612b/client/state/document-head/selectors.js#L56-L84) & the observed state key isn't changing.

This change adds `state.ui.selectedSiteId` to the paths which trigger a recalculation by this selector & a prop update for the component.

**To Test:**
* Verify current behavior:
  * Visit any site-dependent section (Posts, Pages, Stats, etc.)
  * Note the title in the browser
  * Switch to a different site (or "All Sites")
  * Note the title in the browser __did not__ change
* Verify fix:
  * Switch to this branch
  * Visit any site-dependent section (Posts, Pages, Stats, etc.)
  * Note the title in the browser
  * Switch to a different site (or "All Sites")
  * Note the title in the browser __did__ change
  * Verify the title in the browser is correct

Related #8224 