### PR TITLE
Dialog: Use `react-modal` to implement

### DIFF
--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -1,11 +1,7 @@
 /**
  * External dependencies
  */
-var ReactDom = require( 'react-dom' ),
-	React = require( 'react' ),
-	clickOutside = require( 'click-outside' ),
-	closest = require( 'component-closest' ),
-	noop = require( 'lodash/noop' ),
+var React = require( 'react' ),
 	classnames = require( 'classnames' );
 
 import Modal from 'react-modal';
@@ -14,7 +10,6 @@ import Modal from 'react-modal';
  * Internal dependencies
  */
 var closeOnEsc = require( 'lib/mixins/close-on-esc' ),
-	Card = require( 'components/card' ),
 	trapFocus = require( 'lib/mixins/trap-focus' );
 
 var DialogBase = React.createClass( {
@@ -26,42 +21,14 @@ var DialogBase = React.createClass( {
 		return {
 			baseClassName: 'dialog',
 			isFullScreen: true,
-			autoFocus: true,
-			onClickOutside: noop
+			autoFocus: true
 		};
 	},
-
-	// componentDidMount: function() {
-	// 	// set focus after a short timeout in order to avoid
-	// 	// interrupting any CSS transitions (Chrome issue)
-	// 	this._focusTimeout = setTimeout( function() {
-	// 		this._focusTimeout = false;
-	// 		if ( this.props.autoFocus ) {
-	// 			ReactDom.findDOMNode( this.refs.content ).focus();
-	// 		}
-	//
-	// 		this._unbindClickHandler = clickOutside( ReactDom.findDOMNode( this.refs.dialog ), this._onBackgroundClick );
-	// 	}.bind( this ), 10 );
-	// 	document.documentElement.classList.add( 'no-scroll' );
-	// },
-
-	// componentWillUnmount: function() {
-	// 	if ( this._focusTimeout ) {
-	// 		clearTimeout( this._focusTimeout );
-	// 		this._focusTimeout = false;
-	// 	}
-	//
-	// 	if ( this._unbindClickHandler ) {
-	// 		this._unbindClickHandler();
-	// 		this._unbindClickHandler = null;
-	// 	}
-	// 	document.documentElement.classList.remove( 'no-scroll' );
-	// },
 
 	render: function() {
 		var baseClassName = this.props.baseClassName,
 			backdropClassName = baseClassName + '__backdrop',
-			dialogClassName = baseClassName,
+			dialogClassName = classnames( baseClassName, 'card' ), // Previous implementation used a `<Card />`, styling relies on this
 			contentClassName = baseClassName + '__content';
 
 		if ( this.props.additionalClassNames ) {
@@ -131,27 +98,6 @@ var DialogBase = React.createClass( {
 
 		return classes;
 	},
-
-	// _onBackgroundClick: function( event ) {
-	// 	// In cases of Dialogception (Dialog inside a Dialog), we want to
-	// 	// prevent a click outside the currently visible Dialog from closing
-	// 	// any dialogs below.
-	// 	var isBackdropOrLowerStackingContext = (
-	// 		! this.refs ||
-	// 		ReactDom.findDOMNode( this.refs.backdrop ).contains( event.target ) || // Clicked on this dialog's backdrop
-	// 		! closest( event.target, '.dialog__backdrop', true ) // Clicked offscreen, but not from another dialog
-	// 	);
-	//
-	// 	if ( ! isBackdropOrLowerStackingContext ) {
-	// 		return;
-	// 	}
-	//
-	// 	const shouldStayOpen = this.props.onClickOutside( event );
-	//
-	// 	if ( ! shouldStayOpen ) {
-	// 		this._close();
-	// 	}
-	// },
 
 	_onButtonClick: function( button ) {
 		if ( button.onClick ) {

--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -1,27 +1,23 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import Modal from 'react-modal';
 import classnames from 'classnames';
 
-var DialogBase = React.createClass( {
+class DialogBase extends Component {
+	static defaultProps = {
+		baseClassName: 'dialog',
+		isFullScreen: true,
+		autoFocus: true
+	}
 
-	displayName: 'DialogBase',
-
-	getDefaultProps: function() {
-		return {
-			baseClassName: 'dialog',
-			isFullScreen: true,
-			autoFocus: true
-		};
-	},
-
-	render: function() {
-		var baseClassName = this.props.baseClassName,
-			backdropClassName = baseClassName + '__backdrop',
-			dialogClassName = classnames( baseClassName, 'card' ), // Previous implementation used a `<Card />`, styling relies on this
+	render() {
+		const baseClassName = this.props.baseClassName,
 			contentClassName = baseClassName + '__content';
+
+		let backdropClassName = baseClassName + '__backdrop',
+			dialogClassName = classnames( baseClassName, 'card' ); // Previous implementation used a `<Card />`, styling relies on this
 
 		if ( this.props.additionalClassNames ) {
 			dialogClassName = classnames( this.props.additionalClassNames, dialogClassName );
@@ -45,10 +41,10 @@ var DialogBase = React.createClass( {
 				{ this._renderButtonsBar() }
 			</Modal>
 		);
-	},
+	}
 
-	_renderButtonsBar: function() {
-		var baseClassName = this.props.baseClassName,
+	_renderButtonsBar() {
+		const baseClassName = this.props.baseClassName,
 			buttonsClassName = baseClassName + '__action-buttons';
 
 		if ( ! this.props.buttons ) {
@@ -60,14 +56,14 @@ var DialogBase = React.createClass( {
 				{ this.props.buttons.map( this._renderButton, this ) }
 			</div>
 		);
-	},
+	}
 
-	_renderButton: function( button, index ) {
+	_renderButton( button, index ) {
 		if ( React.isValidElement( button ) ) {
 			return React.cloneElement( button, { key: 'dialog-button-' + index } );
 		}
 
-		let classes = this._getButtonClasses( button ),
+		const classes = this._getButtonClasses( button ),
 			clickHandler = this._onButtonClick.bind( this, button );
 
 		return (
@@ -75,10 +71,10 @@ var DialogBase = React.createClass( {
 				<span className={ this.props.baseClassName + '__button-label' }>{ button.label }</span>
 			</button>
 		);
-	},
+	}
 
-	_getButtonClasses: function( button ) {
-		var classes = button.className || 'button';
+	_getButtonClasses( button ) {
+		let classes = button.className || 'button';
 
 		if ( button.isPrimary || this.props.buttons.length === 1 ) {
 			classes += ' is-primary';
@@ -89,22 +85,22 @@ var DialogBase = React.createClass( {
 		}
 
 		return classes;
-	},
+	}
 
-	_onButtonClick: function( button ) {
+	_onButtonClick = ( button ) => {
 		if ( button.onClick ) {
 			button.onClick( this._close.bind( this, button.action ) );
 			return;
 		}
 
 		this._close( button.action );
-	},
+	}
 
-	_close: function( action ) {
+	_close = ( action ) => {
 		if ( this.props.onDialogClose ) {
 			this.props.onDialogClose( action );
 		}
 	}
-} );
+}
 
-module.exports = DialogBase;
+export default DialogBase;

--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -8,6 +8,8 @@ var ReactDom = require( 'react-dom' ),
 	noop = require( 'lodash/noop' ),
 	classnames = require( 'classnames' );
 
+import Modal from 'react-modal';
+
 /**
  * Internal dependencies
  */
@@ -29,32 +31,32 @@ var DialogBase = React.createClass( {
 		};
 	},
 
-	componentDidMount: function() {
-		// set focus after a short timeout in order to avoid
-		// interrupting any CSS transitions (Chrome issue)
-		this._focusTimeout = setTimeout( function() {
-			this._focusTimeout = false;
-			if ( this.props.autoFocus ) {
-				ReactDom.findDOMNode( this.refs.content ).focus();
-			}
+	// componentDidMount: function() {
+	// 	// set focus after a short timeout in order to avoid
+	// 	// interrupting any CSS transitions (Chrome issue)
+	// 	this._focusTimeout = setTimeout( function() {
+	// 		this._focusTimeout = false;
+	// 		if ( this.props.autoFocus ) {
+	// 			ReactDom.findDOMNode( this.refs.content ).focus();
+	// 		}
+	//
+	// 		this._unbindClickHandler = clickOutside( ReactDom.findDOMNode( this.refs.dialog ), this._onBackgroundClick );
+	// 	}.bind( this ), 10 );
+	// 	document.documentElement.classList.add( 'no-scroll' );
+	// },
 
-			this._unbindClickHandler = clickOutside( ReactDom.findDOMNode( this.refs.dialog ), this._onBackgroundClick );
-		}.bind( this ), 10 );
-		document.documentElement.classList.add( 'no-scroll' );
-	},
-
-	componentWillUnmount: function() {
-		if ( this._focusTimeout ) {
-			clearTimeout( this._focusTimeout );
-			this._focusTimeout = false;
-		}
-
-		if ( this._unbindClickHandler ) {
-			this._unbindClickHandler();
-			this._unbindClickHandler = null;
-		}
-		document.documentElement.classList.remove( 'no-scroll' );
-	},
+	// componentWillUnmount: function() {
+	// 	if ( this._focusTimeout ) {
+	// 		clearTimeout( this._focusTimeout );
+	// 		this._focusTimeout = false;
+	// 	}
+	//
+	// 	if ( this._unbindClickHandler ) {
+	// 		this._unbindClickHandler();
+	// 		this._unbindClickHandler = null;
+	// 	}
+	// 	document.documentElement.classList.remove( 'no-scroll' );
+	// },
 
 	render: function() {
 		var baseClassName = this.props.baseClassName,
@@ -71,14 +73,18 @@ var DialogBase = React.createClass( {
 		}
 
 		return (
-			<div className={ backdropClassName } ref="backdrop">
-				<Card className={ dialogClassName } role="dialog" ref="dialog">
-					<div className={ classnames( this.props.className, contentClassName ) } ref="content" tabIndex="-1">
-						{ this.props.children }
-					</div>
-					{ this._renderButtonsBar() }
-				</Card>
-			</div>
+			<Modal isOpen={ this.props.isVisible }
+				onRequestClose={ this._close }
+				closeTimeoutMS= { this.props.leaveTimeout }
+				contentLabel={ 'Abc' }
+				overlayClassName={ backdropClassName } // We use flex here which react-modal doesn't
+				className={ dialogClassName }
+				role="dialog">
+				<div className={ classnames( this.props.className, contentClassName ) } ref="content" tabIndex="-1">
+					{ this.props.children }
+				</div>
+				{ this._renderButtonsBar() }
+			</Modal>
 		);
 	},
 
@@ -126,26 +132,26 @@ var DialogBase = React.createClass( {
 		return classes;
 	},
 
-	_onBackgroundClick: function( event ) {
-		// In cases of Dialogception (Dialog inside a Dialog), we want to
-		// prevent a click outside the currently visible Dialog from closing
-		// any dialogs below.
-		var isBackdropOrLowerStackingContext = (
-			! this.refs ||
-			ReactDom.findDOMNode( this.refs.backdrop ).contains( event.target ) || // Clicked on this dialog's backdrop
-			! closest( event.target, '.dialog__backdrop', true ) // Clicked offscreen, but not from another dialog
-		);
-
-		if ( ! isBackdropOrLowerStackingContext ) {
-			return;
-		}
-
-		const shouldStayOpen = this.props.onClickOutside( event );
-
-		if ( ! shouldStayOpen ) {
-			this._close();
-		}
-	},
+	// _onBackgroundClick: function( event ) {
+	// 	// In cases of Dialogception (Dialog inside a Dialog), we want to
+	// 	// prevent a click outside the currently visible Dialog from closing
+	// 	// any dialogs below.
+	// 	var isBackdropOrLowerStackingContext = (
+	// 		! this.refs ||
+	// 		ReactDom.findDOMNode( this.refs.backdrop ).contains( event.target ) || // Clicked on this dialog's backdrop
+	// 		! closest( event.target, '.dialog__backdrop', true ) // Clicked offscreen, but not from another dialog
+	// 	);
+	//
+	// 	if ( ! isBackdropOrLowerStackingContext ) {
+	// 		return;
+	// 	}
+	//
+	// 	const shouldStayOpen = this.props.onClickOutside( event );
+	//
+	// 	if ( ! shouldStayOpen ) {
+	// 		this._close();
+	// 	}
+	// },
 
 	_onButtonClick: function( button ) {
 		if ( button.onClick ) {

--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -14,19 +14,14 @@ class DialogBase extends Component {
 	}
 
 	render() {
-		const baseClassName = this.props.baseClassName,
-			contentClassName = baseClassName + '__content';
-
-		let backdropClassName = baseClassName + '__backdrop',
-			dialogClassName = classnames( baseClassName, 'card' ); // Previous implementation used a `<Card />`, styling relies on this
-
-		if ( this.props.additionalClassNames ) {
-			dialogClassName = classnames( this.props.additionalClassNames, dialogClassName );
-		}
-
-		if ( this.props.isFullScreen ) {
-			backdropClassName = classnames( 'is-full-screen', backdropClassName );
-		}
+		const { additionalClassNames, baseClassName, isFullScreen } = this.props,
+			contentClassName = baseClassName + '__content',
+			// Previous implementation used a `<Card />`, styling still relies on the 'card' class being present
+			dialogClassName = classnames( baseClassName, 'card', additionalClassNames ),
+			backdropClassName = classnames(
+				baseClassName + '__backdrop',
+				{ 'is-full-screen': !! isFullScreen },
+			);
 
 		return (
 			<Modal isOpen={ this.props.isVisible }

--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -1,19 +1,11 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classnames = require( 'classnames' );
-
+import React from 'react';
 import Modal from 'react-modal';
-
-/**
- * Internal dependencies
- */
-var closeOnEsc = require( 'lib/mixins/close-on-esc' ),
-	trapFocus = require( 'lib/mixins/trap-focus' );
+import classnames from 'classnames';
 
 var DialogBase = React.createClass( {
-	mixins: [ closeOnEsc( '_close' ), trapFocus ],
 
 	displayName: 'DialogBase',
 

--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -9,7 +9,8 @@ class DialogBase extends Component {
 	static defaultProps = {
 		baseClassName: 'dialog',
 		isFullScreen: true,
-		autoFocus: true
+		autoFocus: true,
+		label: ''
 	}
 
 	render() {
@@ -31,7 +32,7 @@ class DialogBase extends Component {
 			<Modal isOpen={ this.props.isVisible }
 				onRequestClose={ this._close }
 				closeTimeoutMS= { this.props.leaveTimeout }
-				contentLabel={ 'Abc' }
+				contentLabel={ this.props.label }
 				overlayClassName={ backdropClassName } // We use flex here which react-modal doesn't
 				className={ dialogClassName }
 				role="dialog">

--- a/client/components/dialog/index.jsx
+++ b/client/components/dialog/index.jsx
@@ -36,19 +36,13 @@ class Dialog extends Component {
 	}
 
 	render() {
-		const {
-			isVisible
-		} = this.props;
-
 		return (
 			<RootChild>
-				{ isVisible && (
-					<DialogBase
-						{ ...this.props }
-						ref={ this.checkOnClosed }
-						key="dialog"
-						onDialogClose={ this.onDialogClose } />
-				) }
+				<DialogBase
+					{ ...this.props }
+					ref={ this.checkOnClosed }
+					key="dialog"
+					onDialogClose={ this.onDialogClose } />
 			</RootChild>
 		);
 	}

--- a/client/components/dialog/index.jsx
+++ b/client/components/dialog/index.jsx
@@ -26,9 +26,7 @@ export default React.createClass( {
 	getDefaultProps: function() {
 		return {
 			isVisible: false,
-			enterTimeout: 200,
 			leaveTimeout: 200,
-			transitionLeave: true,
 			onClosed: noop,
 			onClickOutside: noop
 		};

--- a/client/components/dialog/index.jsx
+++ b/client/components/dialog/index.jsx
@@ -14,19 +14,15 @@ class Dialog extends Component {
 	static propTypes = {
 		isVisible: PropTypes.bool,
 		baseClassName: PropTypes.string,
-		enterTimeout: PropTypes.number,
 		leaveTimeout: PropTypes.number,
-		transitionLeave: PropTypes.bool,
 		onClose: PropTypes.func,
 		onClosed: PropTypes.func,
-		onClickOutside: PropTypes.func
 	}
 
 	static defaultProps = {
 		isVisible: false,
 		leaveTimeout: 200,
 		onClosed: noop,
-		onClickOutside: noop
 	}
 
 	checkOnClosed = ( ref ) => {

--- a/client/components/dialog/index.jsx
+++ b/client/components/dialog/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import { defer, noop } from 'lodash';
 
 /**
@@ -10,34 +10,32 @@ import { defer, noop } from 'lodash';
 import RootChild from 'components/root-child';
 import DialogBase from './dialog-base';
 
-export default React.createClass( {
-	propTypes: {
-		isVisible: React.PropTypes.bool,
-		baseClassName: React.PropTypes.string,
-		enterTimeout: React.PropTypes.number,
-		leaveTimeout: React.PropTypes.number,
-		transitionLeave: React.PropTypes.bool,
-		onClose: React.PropTypes.func,
-		onClosed: React.PropTypes.func,
-		onClickOutside: React.PropTypes.func
-	},
+class Dialog extends Component {
+	static propTypes = {
+		isVisible: PropTypes.bool,
+		baseClassName: PropTypes.string,
+		enterTimeout: PropTypes.number,
+		leaveTimeout: PropTypes.number,
+		transitionLeave: PropTypes.bool,
+		onClose: PropTypes.func,
+		onClosed: PropTypes.func,
+		onClickOutside: PropTypes.func
+	}
 
-	getDefaultProps: function() {
-		return {
-			isVisible: false,
-			leaveTimeout: 200,
-			onClosed: noop,
-			onClickOutside: noop
-		};
-	},
+	static defaultProps = {
+		isVisible: false,
+		leaveTimeout: 200,
+		onClosed: noop,
+		onClickOutside: noop
+	}
 
-	checkOnClosed( ref ) {
+	checkOnClosed = ( ref ) => {
 		if ( null === ref ) {
 			defer( this.props.onClosed );
 		}
-	},
+	}
 
-	render: function() {
+	render() {
 		const {
 			isVisible
 		} = this.props;
@@ -53,11 +51,13 @@ export default React.createClass( {
 				) }
 			</RootChild>
 		);
-	},
+	}
 
-	onDialogClose: function( action ) {
+	onDialogClose = ( action ) => {
 		if ( this.props.onClose ) {
 			this.props.onClose( action );
 		}
 	}
-} );
+}
+
+export default Dialog;

--- a/client/components/dialog/index.jsx
+++ b/client/components/dialog/index.jsx
@@ -42,28 +42,18 @@ export default React.createClass( {
 
 	render: function() {
 		const {
-			isVisible,
-			baseClassName,
-			transitionLeave,
-			enterTimeout,
-			leaveTimeout
+			isVisible
 		} = this.props;
 
 		return (
 			<RootChild>
-				<CSSTransitionGroup
-					transitionName={ baseClassName || 'dialog' }
-					transitionLeave={ transitionLeave }
-					transitionEnterTimeout={ enterTimeout }
-					transitionLeaveTimeout={ leaveTimeout }>
-					{ isVisible && (
-						<DialogBase
-							{ ...this.props }
-							ref={ this.checkOnClosed }
-							key="dialog"
-							onDialogClose={ this.onDialogClose } />
-					) }
-				</CSSTransitionGroup>
+				{ isVisible && (
+					<DialogBase
+						{ ...this.props }
+						ref={ this.checkOnClosed }
+						key="dialog"
+						onDialogClose={ this.onDialogClose } />
+				) }
 			</RootChild>
 		);
 	},

--- a/client/components/dialog/index.jsx
+++ b/client/components/dialog/index.jsx
@@ -7,7 +7,6 @@ import { defer, noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import CSSTransitionGroup from 'react-addons-css-transition-group';
 import RootChild from 'components/root-child';
 import DialogBase from './dialog-base';
 

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -116,7 +116,6 @@ export default React.createClass( {
 					<Dialog
 						isVisible={ true }
 						additionalClassNames="editor-media-modal"
-						onClickOutside={ this.closeDetailsModal }
 						onClose={ this.closeDetailsModal }
 					>
 					{ this.state.openedDetails &&

--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog.jsx
@@ -101,8 +101,7 @@ class DisconnectJetpackDialog extends Component {
 			<Dialog
 				isVisible={ this.state.showJetpackDisconnectDialog }
 				buttons={ deactivationButtons }
-				onClose={ this.close }
-				transitionLeave={ false }>
+				onClose={ this.close }>
 				<h1>{ translate( 'Disconnect Jetpack' ) }</h1>
 				<p>{ this.renderInfo() }</p>
 			</Dialog>

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	closest = require( 'component-closest' ),
 	debug = require( 'debug' )( 'calypso:post-editor:media' );
 import { connect } from 'react-redux';
 import { noop, head, some, findIndex, partial, values, map } from 'lodash';
@@ -355,11 +354,8 @@ export const EditorMediaModal = React.createClass( {
 		return buttons;
 	},
 
-	preventClose: function( event ) {
-		if ( ModalViews.IMAGE_EDITOR === this.props.view ||
-			closest( event.target, '.popover.is-dialog-visible' ) ) {
-			return true;
-		}
+	shouldClose: function() {
+		return ( ModalViews.IMAGE_EDITOR !== this.props.view );
 	},
 
 	renderContent: function() {
@@ -438,7 +434,7 @@ export const EditorMediaModal = React.createClass( {
 				buttons={ this.getModalButtons() }
 				onClose={ this.onClose }
 				additionalClassNames="editor-media-modal"
-				onClickOutside={ this.preventClose }>
+				shouldCloseOnOverlayClick={ this.shouldClose() }>
 				{ this.renderContent() }
 			</Dialog>
 		);

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -59,11 +59,7 @@ import {
 } from './utils';
 import i18n from 'i18n-calypso';
 import { getSiteTitle } from 'state/sites/selectors';
-
-let accept;
-if ( typeof window !== 'undefined' ) {
-	accept = require( 'lib/accept' ); // This would otherwise break tests (because of a DOM dependency)
-}
+import accept from 'lib/accept';
 
 const debug = debugFactory( 'calypso:themes:actions' ); //eslint-disable-line no-unused-vars
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,2113 +4,4091 @@
   "dependencies": {
     "abab": {
       "version": "1.0.3",
+      "from": "abab@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
       "dev": true
     },
     "abbrev": {
-      "version": "1.0.9"
+      "version": "1.0.9",
+      "from": "abbrev@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
     },
     "abstract-leveldown": {
-      "version": "2.4.1"
+      "version": "2.4.1",
+      "from": "abstract-leveldown@>=2.4.0 <2.5.0",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.4.1.tgz"
     },
     "accepts": {
-      "version": "1.2.13"
+      "version": "1.2.13",
+      "from": "accepts@>=1.2.12 <1.3.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz"
     },
     "acorn": {
-      "version": "3.3.0"
+      "version": "3.3.0",
+      "from": "acorn@>=3.1.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
     },
     "acorn-globals": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "from": "acorn-globals@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.0.0.tgz"
     },
     "acorn-jsx": {
       "version": "3.0.1",
+      "from": "acorn-jsx@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "dev": true
     },
     "after": {
-      "version": "0.8.2"
+      "version": "0.8.2",
+      "from": "after@>=0.8.1 <0.9.0",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
       "version": "4.10.4",
+      "from": "ajv@4.10.4",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.10.4.tgz",
       "dev": true
     },
     "ajv-keywords": {
       "version": "1.5.0",
+      "from": "ajv-keywords@1.5.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.0.tgz",
       "dev": true
     },
     "align-text": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "from": "align-text@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
     },
     "amdefine": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "amdefine@>=0.0.4",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
     },
     "ansi": {
-      "version": "0.3.1"
+      "version": "0.3.1",
+      "from": "ansi@>=0.3.1 <0.4.0",
+      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
     },
     "ansi-escapes": {
       "version": "1.4.0",
+      "from": "ansi-escapes@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "dev": true
     },
     "ansi-regex": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "from": "ansi-regex@2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
     },
     "ansi-styles": {
-      "version": "2.2.1"
+      "version": "2.2.1",
+      "from": "ansi-styles@>=2.2.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
     },
     "anymatch": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "from": "anymatch@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz"
     },
     "aproba": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "from": "aproba@1.0.4",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz"
     },
     "are-we-there-yet": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "from": "are-we-there-yet@>=1.1.2 <1.2.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
     },
     "argparse": {
       "version": "1.0.9",
+      "from": "argparse@>=1.0.7 <2.0.0",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "dev": true
     },
     "arr-diff": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "arr-diff@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
     },
     "arr-flatten": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "arr-flatten@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
     },
     "array-differ": {
       "version": "1.0.0",
+      "from": "array-differ@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
       "dev": true
     },
     "array-equal": {
       "version": "1.0.0",
+      "from": "array-equal@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "dev": true
     },
     "array-find-index": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "array-find-index@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
     },
     "array-flatten": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "from": "array-flatten@1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
     },
     "array-index": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "array-index@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz"
     },
     "array-union": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "array-union@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz"
     },
     "array-uniq": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "from": "array-uniq@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
     },
     "array-unique": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "from": "array-unique@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
     },
     "arraybuffer.slice": {
-      "version": "0.0.6"
+      "version": "0.0.6",
+      "from": "arraybuffer.slice@0.0.6",
+      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
     },
     "arrify": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "arrify@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
     },
     "asap": {
-      "version": "2.0.5"
+      "version": "2.0.5",
+      "from": "asap@>=2.0.3 <2.1.0",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
     },
     "asn1": {
-      "version": "0.2.3"
+      "version": "0.2.3",
+      "from": "asn1@>=0.2.3 <0.3.0",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
     },
     "assert": {
-      "version": "1.4.1"
+      "version": "1.4.1",
+      "from": "assert@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz"
     },
     "assert-plus": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "from": "assert-plus@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
     },
     "assertion-error": {
       "version": "1.0.2",
+      "from": "assertion-error@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "dev": true
     },
     "ast-types": {
-      "version": "0.9.2"
+      "version": "0.9.2",
+      "from": "ast-types@0.9.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.2.tgz"
     },
     "async": {
-      "version": "0.9.0"
+      "version": "0.9.0",
+      "from": "async@0.9.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
     },
     "async-each": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "async-each@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz"
     },
     "async-foreach": {
-      "version": "0.1.3"
+      "version": "0.1.3",
+      "from": "async-foreach@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
     },
     "asynckit": {
-      "version": "0.4.0"
+      "version": "0.4.0",
+      "from": "asynckit@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
     },
     "atob": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "from": "atob@1.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.2.tgz"
     },
     "autoprefixer": {
-      "version": "6.3.5"
+      "version": "6.3.5",
+      "from": "autoprefixer@6.3.5",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.3.5.tgz"
     },
     "autosize": {
-      "version": "3.0.15"
+      "version": "3.0.15",
+      "from": "autosize@3.0.15",
+      "resolved": "https://registry.npmjs.org/autosize/-/autosize-3.0.15.tgz"
     },
     "aws-sign2": {
-      "version": "0.6.0"
+      "version": "0.6.0",
+      "from": "aws-sign2@>=0.6.0 <0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
     },
     "aws4": {
-      "version": "1.5.0"
+      "version": "1.5.0",
+      "from": "aws4@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz"
     },
     "babel-code-frame": {
       "version": "6.20.0",
+      "from": "babel-code-frame@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.20.0.tgz",
       "dependencies": {
         "chalk": {
-          "version": "1.1.3"
+          "version": "1.1.3",
+          "from": "chalk@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
         },
         "supports-color": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "from": "supports-color@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
         }
       }
     },
     "babel-core": {
       "version": "6.9.1",
+      "from": "babel-core@6.9.1",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.9.1.tgz",
       "dependencies": {
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         }
       }
     },
     "babel-eslint": {
       "version": "6.1.2",
+      "from": "babel-eslint@6.1.2",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.2.tgz",
       "dev": true
     },
     "babel-generator": {
       "version": "6.21.0",
+      "from": "babel-generator@>=6.9.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.21.0.tgz",
       "dependencies": {
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         }
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
-      "version": "6.18.0"
+      "version": "6.18.0",
+      "from": "babel-helper-builder-binary-assignment-operator-visitor@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.18.0.tgz"
     },
     "babel-helper-builder-react-jsx": {
-      "version": "6.21.1"
+      "version": "6.21.1",
+      "from": "babel-helper-builder-react-jsx@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.21.1.tgz"
     },
     "babel-helper-call-delegate": {
-      "version": "6.18.0"
+      "version": "6.18.0",
+      "from": "babel-helper-call-delegate@>=6.18.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.18.0.tgz"
     },
     "babel-helper-define-map": {
-      "version": "6.18.0"
+      "version": "6.18.0",
+      "from": "babel-helper-define-map@>=6.18.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.18.0.tgz"
     },
     "babel-helper-explode-assignable-expression": {
-      "version": "6.18.0"
+      "version": "6.18.0",
+      "from": "babel-helper-explode-assignable-expression@>=6.18.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.18.0.tgz"
     },
     "babel-helper-function-name": {
-      "version": "6.18.0"
+      "version": "6.18.0",
+      "from": "babel-helper-function-name@>=6.18.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz"
     },
     "babel-helper-get-function-arity": {
-      "version": "6.18.0"
+      "version": "6.18.0",
+      "from": "babel-helper-get-function-arity@>=6.18.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz"
     },
     "babel-helper-hoist-variables": {
-      "version": "6.18.0"
+      "version": "6.18.0",
+      "from": "babel-helper-hoist-variables@>=6.18.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.18.0.tgz"
     },
     "babel-helper-optimise-call-expression": {
-      "version": "6.18.0"
+      "version": "6.18.0",
+      "from": "babel-helper-optimise-call-expression@>=6.18.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.18.0.tgz"
     },
     "babel-helper-regex": {
-      "version": "6.18.0"
+      "version": "6.18.0",
+      "from": "babel-helper-regex@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.18.0.tgz"
     },
     "babel-helper-remap-async-to-generator": {
-      "version": "6.20.3"
+      "version": "6.20.3",
+      "from": "babel-helper-remap-async-to-generator@>=6.16.2 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.20.3.tgz"
     },
     "babel-helper-replace-supers": {
-      "version": "6.18.0"
+      "version": "6.18.0",
+      "from": "babel-helper-replace-supers@>=6.18.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.18.0.tgz"
     },
     "babel-helpers": {
-      "version": "6.16.0"
+      "version": "6.16.0",
+      "from": "babel-helpers@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz"
     },
     "babel-loader": {
-      "version": "6.2.4"
+      "version": "6.2.4",
+      "from": "babel-loader@6.2.4",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.2.4.tgz"
     },
     "babel-messages": {
-      "version": "6.8.0"
+      "version": "6.8.0",
+      "from": "babel-messages@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
     },
     "babel-plugin-add-module-exports": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "from": "babel-plugin-add-module-exports@0.2.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.2.1.tgz"
     },
     "babel-plugin-check-es2015-constants": {
-      "version": "6.8.0"
+      "version": "6.8.0",
+      "from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz"
     },
     "babel-plugin-lodash": {
-      "version": "3.2.0"
+      "version": "3.2.0",
+      "from": "babel-plugin-lodash@3.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.2.0.tgz"
     },
     "babel-plugin-syntax-async-functions": {
-      "version": "6.13.0"
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-async-functions@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz"
     },
     "babel-plugin-syntax-async-generators": {
-      "version": "6.13.0"
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-async-generators@>=6.5.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz"
     },
     "babel-plugin-syntax-class-properties": {
-      "version": "6.13.0"
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-class-properties@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz"
     },
     "babel-plugin-syntax-exponentiation-operator": {
-      "version": "6.13.0"
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-exponentiation-operator@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz"
     },
     "babel-plugin-syntax-export-extensions": {
-      "version": "6.13.0"
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-export-extensions@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz"
     },
     "babel-plugin-syntax-jsx": {
-      "version": "6.8.0"
+      "version": "6.8.0",
+      "from": "babel-plugin-syntax-jsx@6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.8.0.tgz"
     },
     "babel-plugin-syntax-object-rest-spread": {
-      "version": "6.13.0"
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-object-rest-spread@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz"
     },
     "babel-plugin-syntax-trailing-function-commas": {
-      "version": "6.20.0"
+      "version": "6.20.0",
+      "from": "babel-plugin-syntax-trailing-function-commas@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.20.0.tgz"
     },
     "babel-plugin-transform-async-generator-functions": {
-      "version": "6.17.0"
+      "version": "6.17.0",
+      "from": "babel-plugin-transform-async-generator-functions@>=6.17.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.17.0.tgz"
     },
     "babel-plugin-transform-async-to-generator": {
-      "version": "6.16.0"
+      "version": "6.16.0",
+      "from": "babel-plugin-transform-async-to-generator@>=6.16.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.16.0.tgz"
     },
     "babel-plugin-transform-class-properties": {
-      "version": "6.9.1"
+      "version": "6.9.1",
+      "from": "babel-plugin-transform-class-properties@6.9.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.9.1.tgz"
     },
     "babel-plugin-transform-es2015-arrow-functions": {
-      "version": "6.8.0"
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
-      "version": "6.8.0"
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.21.0"
+      "version": "6.21.0",
+      "from": "babel-plugin-transform-es2015-block-scoping@>=6.9.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.21.0.tgz"
     },
     "babel-plugin-transform-es2015-classes": {
-      "version": "6.18.0"
+      "version": "6.18.0",
+      "from": "babel-plugin-transform-es2015-classes@>=6.9.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.18.0.tgz"
     },
     "babel-plugin-transform-es2015-computed-properties": {
-      "version": "6.8.0"
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-destructuring": {
-      "version": "6.19.0"
+      "version": "6.19.0",
+      "from": "babel-plugin-transform-es2015-destructuring@>=6.9.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.19.0.tgz"
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
-      "version": "6.8.0"
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-for-of": {
-      "version": "6.18.0"
+      "version": "6.18.0",
+      "from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.18.0.tgz"
     },
     "babel-plugin-transform-es2015-function-name": {
-      "version": "6.9.0"
+      "version": "6.9.0",
+      "from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz"
     },
     "babel-plugin-transform-es2015-literals": {
-      "version": "6.8.0"
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.18.0"
+      "version": "6.18.0",
+      "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.6.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.18.0.tgz"
     },
     "babel-plugin-transform-es2015-object-super": {
-      "version": "6.8.0"
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-parameters": {
-      "version": "6.21.0"
+      "version": "6.21.0",
+      "from": "babel-plugin-transform-es2015-parameters@>=6.9.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.21.0.tgz"
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
-      "version": "6.18.0"
+      "version": "6.18.0",
+      "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.18.0.tgz"
     },
     "babel-plugin-transform-es2015-spread": {
-      "version": "6.8.0"
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-sticky-regex": {
-      "version": "6.8.0"
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-template-literals": {
-      "version": "6.8.0"
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-es2015-template-literals@>=6.6.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
-      "version": "6.18.0"
+      "version": "6.18.0",
+      "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.18.0.tgz"
     },
     "babel-plugin-transform-es2015-unicode-regex": {
-      "version": "6.11.0"
+      "version": "6.11.0",
+      "from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz"
     },
     "babel-plugin-transform-exponentiation-operator": {
-      "version": "6.8.0"
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-exponentiation-operator@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.8.0.tgz"
     },
     "babel-plugin-transform-export-extensions": {
-      "version": "6.8.0"
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-export-extensions@6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.8.0.tgz"
     },
     "babel-plugin-transform-imports": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "babel-plugin-transform-imports@1.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-imports/-/babel-plugin-transform-imports-1.1.0.tgz"
     },
     "babel-plugin-transform-object-rest-spread": {
-      "version": "6.20.2"
+      "version": "6.20.2",
+      "from": "babel-plugin-transform-object-rest-spread@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.20.2.tgz"
     },
     "babel-plugin-transform-react-display-name": {
-      "version": "6.8.0"
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-react-display-name@6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.8.0.tgz"
     },
     "babel-plugin-transform-react-jsx": {
-      "version": "6.8.0"
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-react-jsx@6.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.8.0.tgz"
     },
     "babel-plugin-transform-regenerator": {
-      "version": "6.21.0"
+      "version": "6.21.0",
+      "from": "babel-plugin-transform-regenerator@>=6.9.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.21.0.tgz"
     },
     "babel-plugin-transform-runtime": {
-      "version": "6.9.0"
+      "version": "6.9.0",
+      "from": "babel-plugin-transform-runtime@6.9.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.9.0.tgz"
     },
     "babel-plugin-transform-strict-mode": {
-      "version": "6.18.0"
+      "version": "6.18.0",
+      "from": "babel-plugin-transform-strict-mode@>=6.18.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.18.0.tgz"
     },
     "babel-preset-es2015": {
-      "version": "6.9.0"
+      "version": "6.9.0",
+      "from": "babel-preset-es2015@6.9.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.9.0.tgz"
     },
     "babel-preset-stage-2": {
-      "version": "6.5.0"
+      "version": "6.5.0",
+      "from": "babel-preset-stage-2@6.5.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.5.0.tgz"
     },
     "babel-preset-stage-3": {
-      "version": "6.17.0"
+      "version": "6.17.0",
+      "from": "babel-preset-stage-3@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.17.0.tgz"
     },
     "babel-register": {
       "version": "6.9.0",
+      "from": "babel-register@6.9.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.9.0.tgz",
       "dependencies": {
         "source-map": {
-          "version": "0.1.32"
+          "version": "0.1.32",
+          "from": "source-map@0.1.32",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz"
         },
         "source-map-support": {
-          "version": "0.2.10"
+          "version": "0.2.10",
+          "from": "source-map-support@>=0.2.10 <0.3.0",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz"
         }
       }
     },
     "babel-runtime": {
-      "version": "6.20.0"
+      "version": "6.20.0",
+      "from": "babel-runtime@>=6.9.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
     },
     "babel-template": {
-      "version": "6.16.0"
+      "version": "6.16.0",
+      "from": "babel-template@>=6.9.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
     },
     "babel-traverse": {
-      "version": "6.21.0"
+      "version": "6.21.0",
+      "from": "babel-traverse@>=6.9.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.21.0.tgz"
     },
     "babel-types": {
-      "version": "6.21.0"
+      "version": "6.21.0",
+      "from": "babel-types@>=6.9.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz"
     },
     "babylon": {
-      "version": "6.15.0"
+      "version": "6.15.0",
+      "from": "babylon@6.15.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz"
     },
     "backo2": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "backo2@1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
     },
     "balanced-match": {
-      "version": "0.4.2"
+      "version": "0.4.2",
+      "from": "balanced-match@>=0.4.1 <0.5.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
     },
     "base62": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "from": "base62@0.1.1",
+      "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
     },
     "Base64": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "from": "Base64@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
     },
     "base64-arraybuffer": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "from": "base64-arraybuffer@0.1.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
     },
     "base64-js": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "from": "base64-js@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz"
     },
     "base64id": {
       "version": "0.1.0",
+      "from": "base64id@0.1.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
       "dev": true
     },
     "basic-auth": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "basic-auth@1.0.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz"
     },
     "batch": {
       "version": "0.5.3",
+      "from": "batch@0.5.3",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
       "dev": true
     },
+    "bcrypt-pbkdf": {
+      "version": "1.0.0",
+      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+      "optional": true
+    },
     "benchmark": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "benchmark@1.0.0",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
     },
     "better-assert": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "better-assert@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz"
     },
     "big.js": {
-      "version": "3.1.3"
+      "version": "3.1.3",
+      "from": "big.js@>=3.1.3 <4.0.0",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
     },
     "binary-extensions": {
-      "version": "1.8.0"
+      "version": "1.8.0",
+      "from": "binary-extensions@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz"
     },
     "bindings": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "from": "bindings@>=1.2.1 <1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
     },
     "bl": {
       "version": "1.0.3",
+      "from": "bl@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
       "dependencies": {
         "readable-stream": {
-          "version": "2.0.6"
+          "version": "2.0.6",
+          "from": "readable-stream@>=2.0.5 <2.1.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         }
       }
     },
     "blessed": {
       "version": "0.1.81",
+      "from": "blessed@>=0.1.81 <0.2.0",
+      "resolved": "https://registry.npmjs.org/blessed/-/blessed-0.1.81.tgz",
       "dev": true
     },
     "blob": {
-      "version": "0.0.4"
+      "version": "0.0.4",
+      "from": "blob@0.0.4",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
     },
     "block-stream": {
-      "version": "0.0.9"
+      "version": "0.0.9",
+      "from": "block-stream@*",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
     },
     "bluebird": {
-      "version": "2.11.0"
+      "version": "2.11.0",
+      "from": "bluebird@>=2.10.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz"
     },
     "body-parser": {
       "version": "1.15.2",
+      "from": "body-parser@>=1.13.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.2.tgz",
       "dependencies": {
         "qs": {
-          "version": "6.2.0"
+          "version": "6.2.0",
+          "from": "qs@6.2.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
         }
       }
     },
     "boolbase": {
       "version": "1.0.0",
+      "from": "boolbase@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "dev": true
     },
     "boom": {
-      "version": "2.10.1"
+      "version": "2.10.1",
+      "from": "boom@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
     },
     "bounding-client-rect": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "from": "bounding-client-rect@1.0.5",
+      "resolved": "https://registry.npmjs.org/bounding-client-rect/-/bounding-client-rect-1.0.5.tgz"
     },
     "brace-expansion": {
-      "version": "1.1.6"
+      "version": "1.1.6",
+      "from": "brace-expansion@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
     },
     "braces": {
-      "version": "1.8.5"
+      "version": "1.8.5",
+      "from": "braces@>=1.8.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
     },
     "browser-filesaver": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "browser-filesaver@1.1.0",
+      "resolved": "https://registry.npmjs.org/browser-filesaver/-/browser-filesaver-1.1.0.tgz"
     },
     "browser-stdout": {
       "version": "1.3.0",
+      "from": "browser-stdout@1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "dev": true
     },
     "browserify-zlib": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "from": "browserify-zlib@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
     },
     "browserslist": {
-      "version": "1.3.6"
+      "version": "1.3.6",
+      "from": "browserslist@>=1.3.0 <1.4.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.3.6.tgz"
     },
     "buffer": {
-      "version": "4.9.1"
+      "version": "4.9.1",
+      "from": "buffer@>=4.9.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz"
     },
     "buffer-shims": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "buffer-shims@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
     },
     "builtin-modules": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "from": "builtin-modules@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
     },
     "builtin-status-codes": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "builtin-status-codes@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-2.0.0.tgz"
     },
     "bytes": {
-      "version": "2.4.0"
+      "version": "2.4.0",
+      "from": "bytes@2.4.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
     },
     "caller-path": {
       "version": "0.1.0",
+      "from": "caller-path@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "dev": true
     },
     "callsite": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "callsite@1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
     },
     "callsites": {
       "version": "0.2.0",
+      "from": "callsites@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "dev": true
     },
     "camel-case": {
-      "version": "1.2.2"
+      "version": "1.2.2",
+      "from": "camel-case@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz"
     },
     "camelcase": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "from": "camelcase@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
     },
     "camelcase-keys": {
       "version": "2.1.0",
+      "from": "camelcase-keys@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "dependencies": {
         "camelcase": {
-          "version": "2.1.1"
+          "version": "2.1.1",
+          "from": "camelcase@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
         }
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000611"
+      "version": "1.0.30000611",
+      "from": "caniuse-db@1.0.30000611",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000611.tgz"
     },
     "caseless": {
-      "version": "0.11.0"
+      "version": "0.11.0",
+      "from": "caseless@>=0.11.0 <0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
     },
     "center-align": {
-      "version": "0.1.3"
+      "version": "0.1.3",
+      "from": "center-align@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
     },
     "chai": {
       "version": "3.5.0",
+      "from": "chai@3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "dev": true
     },
     "chai-enzyme": {
       "version": "0.5.2",
+      "from": "chai-enzyme@0.5.2",
+      "resolved": "https://registry.npmjs.org/chai-enzyme/-/chai-enzyme-0.5.2.tgz",
       "dev": true
     },
     "chalk": {
       "version": "1.0.0",
+      "from": "chalk@1.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
       "dependencies": {
         "ansi-regex": {
-          "version": "1.1.1"
+          "version": "1.1.1",
+          "from": "ansi-regex@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
         },
         "has-ansi": {
-          "version": "1.0.3"
+          "version": "1.0.3",
+          "from": "has-ansi@>=1.0.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz"
         },
         "strip-ansi": {
-          "version": "2.0.1"
+          "version": "2.0.1",
+          "from": "strip-ansi@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
         },
         "supports-color": {
-          "version": "1.3.1"
+          "version": "1.3.1",
+          "from": "supports-color@>=1.3.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
         }
       }
     },
     "change-case": {
-      "version": "2.3.1"
+      "version": "2.3.1",
+      "from": "change-case@>=2.3.0 <2.4.0",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.3.1.tgz"
     },
     "character-parser": {
-      "version": "2.2.0"
+      "version": "2.2.0",
+      "from": "character-parser@>=2.1.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz"
     },
     "charenc": {
       "version": "0.0.2",
+      "from": "charenc@0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
       "dev": true
     },
     "cheerio": {
       "version": "0.20.0",
+      "from": "cheerio@>=0.20.0 <0.21.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.20.0.tgz",
       "dev": true,
       "dependencies": {
+        "acorn": {
+          "version": "2.7.0",
+          "from": "acorn@>=2.4.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+          "dev": true
+        },
+        "acorn-globals": {
+          "version": "1.0.9",
+          "from": "acorn-globals@>=1.0.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
+          "dev": true,
+          "optional": true
+        },
         "entities": {
           "version": "1.1.1",
+          "from": "entities@>=1.1.1 <1.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
           "dev": true
+        },
+        "jsdom": {
+          "version": "7.2.2",
+          "from": "jsdom@>=7.0.2 <8.0.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-7.2.2.tgz",
+          "dev": true,
+          "optional": true
+        },
+        "webidl-conversions": {
+          "version": "2.0.1",
+          "from": "webidl-conversions@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-2.0.1.tgz",
+          "dev": true,
+          "optional": true
         }
       }
     },
     "chokidar": {
-      "version": "1.6.1"
+      "version": "1.6.1",
+      "from": "chokidar@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz"
     },
     "chrono-node": {
-      "version": "1.2.5"
+      "version": "1.2.5",
+      "from": "chrono-node@>=1.0.6 <2.0.0",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-1.2.5.tgz"
     },
     "circular-json": {
       "version": "0.3.1",
+      "from": "circular-json@>=0.3.1 <0.4.0",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
       "dev": true
     },
     "classnames": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "from": "classnames@1.1.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-1.1.1.tgz"
     },
     "clean-css": {
       "version": "3.4.23",
+      "from": "clean-css@>=3.4.0 <3.5.0",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.23.tgz",
       "dependencies": {
         "commander": {
-          "version": "2.8.1"
+          "version": "2.8.1",
+          "from": "commander@>=2.8.0 <2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz"
         },
         "source-map": {
-          "version": "0.4.4"
+          "version": "0.4.4",
+          "from": "source-map@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
         }
       }
     },
     "cli-cursor": {
       "version": "1.0.2",
+      "from": "cli-cursor@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "dev": true
     },
     "cli-width": {
       "version": "2.1.0",
+      "from": "cli-width@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
       "dev": true
     },
     "click-outside": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "from": "click-outside@2.0.1",
+      "resolved": "https://registry.npmjs.org/click-outside/-/click-outside-2.0.1.tgz"
     },
     "clipboard": {
-      "version": "1.5.3"
+      "version": "1.5.3",
+      "from": "clipboard@1.5.3",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.5.3.tgz"
     },
     "cliui": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "from": "cliui@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz"
     },
     "clone": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "clone@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
     },
     "clone-regexp": {
       "version": "1.0.0",
+      "from": "clone-regexp@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.0.tgz",
       "dev": true
     },
     "co": {
       "version": "4.6.0",
+      "from": "co@>=4.6.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "dev": true
     },
     "code-point-at": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "code-point-at@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
     },
     "collapse-white-space": {
       "version": "1.0.2",
+      "from": "collapse-white-space@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.2.tgz",
       "dev": true
     },
     "color-diff": {
       "version": "0.1.7",
+      "from": "color-diff@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/color-diff/-/color-diff-0.1.7.tgz",
       "dev": true
     },
     "colorguard": {
       "version": "1.2.0",
+      "from": "colorguard@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/colorguard/-/colorguard-1.2.0.tgz",
       "dev": true,
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
+          "from": "chalk@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
+          "from": "supports-color@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "dev": true
         },
         "yargs": {
           "version": "1.3.3",
+          "from": "yargs@>=1.2.6 <2.0.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz",
           "dev": true
         }
       }
     },
     "colors": {
-      "version": "0.6.2"
+      "version": "0.6.2",
+      "from": "colors@>=0.6.0-1 <0.7.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
     },
     "combined-stream": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "from": "combined-stream@>=1.0.5 <1.1.0",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
     },
     "commander": {
-      "version": "2.3.0"
+      "version": "2.3.0",
+      "from": "commander@2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
     },
     "component-bind": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "component-bind@1.0.0",
+      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
     },
     "component-closest": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "from": "component-closest@0.1.4",
+      "resolved": "https://registry.npmjs.org/component-closest/-/component-closest-0.1.4.tgz"
     },
     "component-emitter": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "from": "component-emitter@1.2.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz"
     },
     "component-event": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "from": "component-event@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.1.4.tgz"
     },
     "component-file-picker": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "from": "component-file-picker@0.2.1",
+      "resolved": "https://registry.npmjs.org/component-file-picker/-/component-file-picker-0.2.1.tgz"
     },
     "component-inherit": {
-      "version": "0.0.3"
+      "version": "0.0.3",
+      "from": "component-inherit@0.0.3",
+      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
     },
     "component-matches-selector": {
-      "version": "0.1.6"
+      "version": "0.1.6",
+      "from": "component-matches-selector@>=0.1.5 <0.2.0",
+      "resolved": "https://registry.npmjs.org/component-matches-selector/-/component-matches-selector-0.1.6.tgz"
     },
     "component-query": {
-      "version": "0.0.3"
+      "version": "0.0.3",
+      "from": "component-query@*",
+      "resolved": "https://registry.npmjs.org/component-query/-/component-query-0.0.3.tgz"
     },
     "component-uid": {
-      "version": "0.0.2"
+      "version": "0.0.2",
+      "from": "component-uid@0.0.2",
+      "resolved": "https://registry.npmjs.org/component-uid/-/component-uid-0.0.2.tgz"
     },
     "concat-map": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "from": "concat-map@0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
     },
     "concat-stream": {
       "version": "1.5.2",
+      "from": "concat-stream@>=1.5.0 <1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
       "dependencies": {
         "readable-stream": {
-          "version": "2.0.6"
+          "version": "2.0.6",
+          "from": "readable-stream@>=2.0.0 <2.1.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         }
       }
     },
     "configstore": {
       "version": "0.3.2",
+      "from": "configstore@>=0.3.1 <0.4.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
       "dev": true,
       "dependencies": {
         "graceful-fs": {
           "version": "3.0.11",
+          "from": "graceful-fs@>=3.0.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
           "dev": true
         },
         "object-assign": {
           "version": "2.1.1",
+          "from": "object-assign@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
           "dev": true
         }
       }
     },
     "connect-history-api-fallback": {
       "version": "1.1.0",
+      "from": "connect-history-api-fallback@1.1.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.1.0.tgz",
       "dev": true
     },
     "console-browserify": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "console-browserify@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz"
     },
     "console-control-strings": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "console-control-strings@1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
     },
     "constant-case": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "from": "constant-case@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz"
     },
     "constantinople": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "from": "constantinople@>=3.0.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.0.tgz"
     },
     "constants-browserify": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "from": "constants-browserify@0.0.1",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
     },
     "content-disposition": {
-      "version": "0.5.0"
+      "version": "0.5.0",
+      "from": "content-disposition@0.5.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz"
     },
     "content-type": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "content-type@>=1.0.2 <1.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
     },
     "convert-source-map": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "from": "convert-source-map@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz"
     },
     "cookie": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "from": "cookie@0.1.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
     },
     "cookie-parser": {
-      "version": "1.3.2"
+      "version": "1.3.2",
+      "from": "cookie-parser@1.3.2",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.2.tgz"
     },
     "cookie-signature": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "from": "cookie-signature@1.0.4",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.4.tgz"
     },
     "cookiejar": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "from": "cookiejar@>=2.0.6 <3.0.0",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.0.tgz"
     },
     "copy-webpack-plugin": {
       "version": "3.0.1",
+      "from": "copy-webpack-plugin@3.0.1",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-3.0.1.tgz",
       "dependencies": {
         "glob": {
-          "version": "6.0.4"
+          "version": "6.0.4",
+          "from": "glob@>=6.0.4 <7.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz"
         },
         "minimatch": {
-          "version": "3.0.3"
+          "version": "3.0.3",
+          "from": "minimatch@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
         }
       }
     },
     "core-js": {
-      "version": "2.4.1"
+      "version": "2.4.1",
+      "from": "core-js@>=2.4.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
     },
     "core-util-is": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "core-util-is@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
     "cosmiconfig": {
       "version": "1.1.0",
+      "from": "cosmiconfig@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-1.1.0.tgz",
       "dev": true,
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
+          "from": "minimist@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "dev": true
         }
       }
     },
     "crc32": {
-      "version": "0.2.2"
+      "version": "0.2.2",
+      "from": "crc32@0.2.2",
+      "resolved": "https://registry.npmjs.org/crc32/-/crc32-0.2.2.tgz"
     },
     "creditcards": {
-      "version": "2.1.2"
+      "version": "2.1.2",
+      "from": "creditcards@2.1.2",
+      "resolved": "https://registry.npmjs.org/creditcards/-/creditcards-2.1.2.tgz"
     },
     "creditcards-types": {
-      "version": "1.6.0"
+      "version": "1.6.0",
+      "from": "creditcards-types@>=1.6.0 <1.7.0",
+      "resolved": "https://registry.npmjs.org/creditcards-types/-/creditcards-types-1.6.0.tgz"
     },
     "cross-spawn": {
       "version": "4.0.2",
+      "from": "cross-spawn@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
       "dev": true
     },
     "cross-spawn-async": {
-      "version": "2.2.5"
+      "version": "2.2.5",
+      "from": "cross-spawn-async@>=2.1.9 <3.0.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz"
     },
     "crypt": {
       "version": "0.0.2",
+      "from": "crypt@0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "dev": true
     },
     "cryptiles": {
-      "version": "2.0.5"
+      "version": "2.0.5",
+      "from": "cryptiles@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
     },
     "crypto-browserify": {
-      "version": "3.2.8"
+      "version": "3.2.8",
+      "from": "crypto-browserify@>=3.2.6 <3.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz"
     },
     "css-color-names": {
       "version": "0.0.3",
+      "from": "css-color-names@0.0.3",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz",
       "dev": true
     },
     "css-rule-stream": {
       "version": "1.1.0",
+      "from": "css-rule-stream@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/css-rule-stream/-/css-rule-stream-1.1.0.tgz",
       "dev": true
     },
     "css-select": {
       "version": "1.2.0",
+      "from": "css-select@>=1.2.0 <1.3.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "dev": true
     },
     "css-tokenize": {
       "version": "1.0.1",
+      "from": "css-tokenize@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/css-tokenize/-/css-tokenize-1.0.1.tgz",
       "dev": true
     },
     "css-what": {
       "version": "2.1.0",
+      "from": "css-what@>=2.1.0 <2.2.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
       "dev": true
     },
     "cssom": {
       "version": "0.3.1",
+      "from": "cssom@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.1.tgz",
       "dev": true
     },
     "cssstyle": {
       "version": "0.2.37",
+      "from": "cssstyle@>=0.2.36 <0.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
       "dev": true
     },
     "currently-unhandled": {
-      "version": "0.4.1"
+      "version": "0.4.1",
+      "from": "currently-unhandled@>=0.4.1 <0.5.0",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz"
     },
     "d": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "from": "d@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
     },
     "dashdash": {
       "version": "1.14.1",
+      "from": "dashdash@>=1.12.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "date-now": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "from": "date-now@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
     },
     "debug": {
-      "version": "2.2.0"
+      "version": "2.2.0",
+      "from": "debug@2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
     },
     "decamelize": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "from": "decamelize@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
     },
     "deep-eql": {
       "version": "0.1.3",
+      "from": "deep-eql@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "dev": true,
       "dependencies": {
         "type-detect": {
           "version": "0.1.1",
+          "from": "type-detect@0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
           "dev": true
         }
       }
     },
     "deep-equal": {
       "version": "1.0.1",
+      "from": "deep-equal@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "dev": true
     },
     "deep-extend": {
-      "version": "0.4.1"
+      "version": "0.4.1",
+      "from": "deep-extend@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
     },
     "deep-freeze": {
       "version": "0.0.1",
+      "from": "deep-freeze@0.0.1",
+      "resolved": "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz",
       "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
+      "from": "deep-is@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "dev": true
     },
     "defaults-deep": {
       "version": "0.2.3",
+      "from": "defaults-deep@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/defaults-deep/-/defaults-deep-0.2.3.tgz",
       "dev": true,
       "dependencies": {
         "lazy-cache": {
           "version": "0.2.7",
+          "from": "lazy-cache@>=0.2.3 <0.3.0",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
           "dev": true
         }
       }
     },
     "deferred-leveldown": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "from": "deferred-leveldown@>=1.2.1 <1.3.0",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.1.tgz"
     },
     "define-properties": {
       "version": "1.1.2",
+      "from": "define-properties@>=1.1.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "dev": true
     },
     "del": {
       "version": "2.2.2",
+      "from": "del@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "dev": true,
       "dependencies": {
         "globby": {
           "version": "5.0.0",
+          "from": "globby@>=5.0.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
           "dev": true
         }
       }
     },
     "delayed-stream": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "delayed-stream@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
     },
     "delegate": {
-      "version": "3.1.1"
+      "version": "3.1.1",
+      "from": "delegate@>=3.1.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.1.1.tgz"
     },
     "delegates": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "delegates@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
     },
     "depd": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "depd@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
     },
     "desandro-matches-selector": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "from": "desandro-matches-selector@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/desandro-matches-selector/-/desandro-matches-selector-2.0.1.tgz"
     },
     "destroy": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "from": "destroy@1.0.3",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
     },
     "detect-indent": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "from": "detect-indent@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz"
     },
     "diff": {
       "version": "1.4.0",
+      "from": "diff@>=1.3.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
       "dev": true
     },
     "disparity": {
       "version": "2.0.0",
+      "from": "disparity@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/disparity/-/disparity-2.0.0.tgz",
       "dev": true
     },
     "doctrine": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "doctrine@2.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz"
     },
     "doctypes": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "doctypes@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz"
     },
     "doiuse": {
       "version": "2.5.0",
+      "from": "doiuse@>=2.3.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/doiuse/-/doiuse-2.5.0.tgz",
       "dev": true,
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
+          "from": "source-map@>=0.4.2 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dev": true
         }
       }
     },
     "dom-helpers": {
-      "version": "2.4.0"
+      "version": "2.4.0",
+      "from": "dom-helpers@2.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-2.4.0.tgz"
     },
     "dom-scroll-into-view": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "dom-scroll-into-view@1.0.1",
+      "resolved": "https://registry.npmjs.org/dom-scroll-into-view/-/dom-scroll-into-view-1.0.1.tgz"
     },
     "dom-serializer": {
       "version": "0.1.0",
+      "from": "dom-serializer@>=0.0.0 <1.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "dependencies": {
         "domelementtype": {
-          "version": "1.1.3"
+          "version": "1.1.3",
+          "from": "domelementtype@>=1.1.1 <1.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
         },
         "entities": {
-          "version": "1.1.1"
+          "version": "1.1.1",
+          "from": "entities@>=1.1.1 <1.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
         }
       }
     },
     "domain-browser": {
-      "version": "1.1.7"
+      "version": "1.1.7",
+      "from": "domain-browser@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
     },
     "domelementtype": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "from": "domelementtype@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
     },
     "domhandler": {
-      "version": "2.3.0"
+      "version": "2.3.0",
+      "from": "domhandler@>=2.3.0 <2.4.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
     },
     "domutils": {
-      "version": "1.5.1"
+      "version": "1.5.1",
+      "from": "domutils@>=1.5.0 <1.6.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
     },
     "dot-case": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "from": "dot-case@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.2.tgz"
     },
     "draft-js": {
-      "version": "0.8.1"
+      "version": "0.8.1",
+      "from": "draft-js@0.8.1",
+      "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.8.1.tgz"
     },
     "duplexer": {
       "version": "0.1.1",
+      "from": "duplexer@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "dev": true
     },
     "duplexer2": {
-      "version": "0.0.2"
+      "version": "0.0.2",
+      "from": "duplexer2@>=0.0.2 <0.1.0",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
     },
     "duplexify": {
       "version": "3.5.0",
+      "from": "duplexify@>=3.2.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
       "dev": true,
       "dependencies": {
         "end-of-stream": {
           "version": "1.0.0",
+          "from": "end-of-stream@1.0.0",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
           "dev": true
         },
         "once": {
           "version": "1.3.3",
+          "from": "once@>=1.3.0 <1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "dev": true
         },
         "readable-stream": {
           "version": "2.2.2",
+          "from": "readable-stream@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "dev": true
         }
       }
     },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "optional": true
+    },
     "editions": {
       "version": "1.3.3",
+      "from": "editions@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.3.tgz",
       "dev": true
     },
     "ee-first": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "from": "ee-first@1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
     },
     "ejs": {
       "version": "2.5.5",
+      "from": "ejs@2.5.5",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.5.tgz",
       "dev": true
     },
+    "element-class": {
+      "version": "0.2.2",
+      "from": "element-class@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/element-class/-/element-class-0.2.2.tgz"
+    },
     "email-validator": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "email-validator@1.0.1",
+      "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-1.0.1.tgz"
     },
     "emitter-component": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "emitter-component@1.0.0",
+      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.0.0.tgz"
     },
     "emoji-text": {
-      "version": "0.2.6"
+      "version": "0.2.6",
+      "from": "emoji-text@0.2.6",
+      "resolved": "https://registry.npmjs.org/emoji-text/-/emoji-text-0.2.6.tgz"
     },
     "emojis-list": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "from": "emojis-list@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
     },
     "encodeurl": {
       "version": "1.0.1",
+      "from": "encodeurl@1.0.1",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
       "dev": true
     },
     "encoding": {
-      "version": "0.1.12"
+      "version": "0.1.12",
+      "from": "encoding@>=0.1.11 <0.2.0",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz"
     },
     "end-of-stream": {
       "version": "1.1.0",
+      "from": "end-of-stream@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
       "dependencies": {
         "once": {
-          "version": "1.3.3"
+          "version": "1.3.3",
+          "from": "once@>=1.3.0 <1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
         }
       }
     },
     "engine.io": {
       "version": "1.6.8",
+      "from": "engine.io@1.6.8",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.8.tgz",
       "dev": true,
       "dependencies": {
         "accepts": {
           "version": "1.1.4",
+          "from": "accepts@1.1.4",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
           "dev": true
         },
         "mime-db": {
           "version": "1.12.0",
+          "from": "mime-db@>=1.12.0 <1.13.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
           "dev": true
         },
         "mime-types": {
           "version": "2.0.14",
+          "from": "mime-types@>=2.0.4 <2.1.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
           "dev": true
         },
         "negotiator": {
           "version": "0.4.9",
+          "from": "negotiator@0.4.9",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
           "dev": true
         }
       }
     },
     "engine.io-client": {
       "version": "1.6.8",
+      "from": "engine.io-client@1.6.8",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.8.tgz",
       "dependencies": {
         "component-emitter": {
-          "version": "1.1.2"
+          "version": "1.1.2",
+          "from": "component-emitter@1.1.2",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
         }
       }
     },
     "engine.io-parser": {
       "version": "1.2.4",
+      "from": "engine.io-parser@1.2.4",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
       "dependencies": {
         "after": {
-          "version": "0.8.1"
+          "version": "0.8.1",
+          "from": "after@0.8.1",
+          "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
         },
         "has-binary": {
-          "version": "0.1.6"
+          "version": "0.1.6",
+          "from": "has-binary@0.1.6",
+          "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz"
         },
         "isarray": {
-          "version": "0.0.1"
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         }
       }
     },
     "enhanced-resolve": {
       "version": "0.9.1",
+      "from": "enhanced-resolve@>=0.9.0 <0.10.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
       "dependencies": {
         "memory-fs": {
-          "version": "0.2.0"
+          "version": "0.2.0",
+          "from": "memory-fs@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
         }
       }
     },
     "entities": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "entities@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
     },
     "env-hash": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "env-hash@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/env-hash/-/env-hash-1.1.0.tgz"
     },
     "enzyme": {
       "version": "2.4.1",
+      "from": "enzyme@2.4.1",
+      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-2.4.1.tgz",
       "dev": true
     },
     "errno": {
       "version": "0.1.4",
+      "from": "errno@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "dependencies": {
         "prr": {
-          "version": "0.0.0"
+          "version": "0.0.0",
+          "from": "prr@>=0.0.0 <0.1.0",
+          "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
         }
       }
     },
     "error-ex": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "from": "error-ex@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
     },
     "es-abstract": {
       "version": "1.6.1",
+      "from": "es-abstract@>=1.6.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.6.1.tgz",
       "dev": true
     },
     "es-to-primitive": {
       "version": "1.1.1",
+      "from": "es-to-primitive@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "dev": true
     },
     "es3ify": {
       "version": "0.1.4",
+      "from": "es3ify@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/es3ify/-/es3ify-0.1.4.tgz",
       "dependencies": {
         "esprima-fb": {
-          "version": "3001.1.0-dev-harmony-fb"
+          "version": "3001.1.0-dev-harmony-fb",
+          "from": "esprima-fb@>=3001.1.0-dev-harmony-fb <3001.2.0",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
         }
       }
     },
     "es5-ext": {
-      "version": "0.10.12"
+      "version": "0.10.12",
+      "from": "es5-ext@>=0.10.11 <0.11.0",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
     },
     "es6-iterator": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "es6-iterator@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
     },
     "es6-map": {
       "version": "0.1.4",
+      "from": "es6-map@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz",
       "dev": true
     },
     "es6-set": {
       "version": "0.1.4",
+      "from": "es6-set@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
       "dev": true
     },
     "es6-symbol": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "from": "es6-symbol@>=3.0.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
     },
     "es6-templates": {
-      "version": "0.2.3"
+      "version": "0.2.3",
+      "from": "es6-templates@>=0.2.2 <0.3.0",
+      "resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz"
     },
     "es6-weak-map": {
       "version": "2.0.1",
+      "from": "es6-weak-map@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
       "dev": true
     },
     "escape-html": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "escape-html@1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
     },
     "escape-regexp": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "from": "escape-regexp@0.0.1",
+      "resolved": "https://registry.npmjs.org/escape-regexp/-/escape-regexp-0.0.1.tgz"
     },
     "escape-regexp-component": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "escape-regexp-component@1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
     },
     "escape-string-regexp": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "from": "escape-string-regexp@1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
     },
     "escodegen": {
       "version": "1.8.1",
+      "from": "escodegen@>=1.6.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "dev": true,
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
+          "from": "esprima@>=2.7.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
           "dev": true
         },
         "estraverse": {
           "version": "1.9.3",
+          "from": "estraverse@>=1.9.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
           "dev": true
+        },
+        "source-map": {
+          "version": "0.2.0",
+          "from": "source-map@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "dev": true,
+          "optional": true
         }
       }
     },
     "escope": {
       "version": "3.6.0",
+      "from": "escope@>=3.6.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "dev": true
     },
     "esformatter": {
       "version": "0.7.3",
+      "from": "esformatter@0.7.3",
+      "resolved": "https://registry.npmjs.org/esformatter/-/esformatter-0.7.3.tgz",
       "dev": true,
       "dependencies": {
         "debug": {
           "version": "0.7.4",
+          "from": "debug@>=0.7.4 <0.8.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
           "dev": true
         },
         "espree": {
           "version": "1.12.3",
+          "from": "espree@>=1.12.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-1.12.3.tgz",
           "dev": true
         },
         "glob": {
           "version": "5.0.15",
+          "from": "glob@>=5.0.3 <6.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "dev": true
         },
         "minimist": {
           "version": "1.2.0",
+          "from": "minimist@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "dev": true
         },
         "semver": {
           "version": "2.2.1",
+          "from": "semver@>=2.2.1 <2.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz",
           "dev": true
         },
         "strip-json-comments": {
           "version": "0.1.3",
+          "from": "strip-json-comments@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "1.3.1",
+          "from": "supports-color@>=1.3.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
           "dev": true
         },
         "user-home": {
           "version": "2.0.0",
+          "from": "user-home@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
           "dev": true
         }
       }
     },
     "esformatter-braces": {
       "version": "1.2.1",
+      "from": "esformatter-braces@1.2.1",
+      "resolved": "https://registry.npmjs.org/esformatter-braces/-/esformatter-braces-1.2.1.tgz",
       "dev": true
     },
     "esformatter-collapse-objects-a8c": {
       "version": "0.1.0",
+      "from": "esformatter-collapse-objects-a8c@0.1.0",
+      "resolved": "https://registry.npmjs.org/esformatter-collapse-objects-a8c/-/esformatter-collapse-objects-a8c-0.1.0.tgz",
       "dev": true,
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
+          "from": "esprima@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
           "dev": true
         },
         "rocambole": {
           "version": "0.5.1",
+          "from": "rocambole@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.5.1.tgz",
           "dev": true
         }
       }
     },
     "esformatter-dot-notation": {
       "version": "1.3.1",
+      "from": "esformatter-dot-notation@1.3.1",
+      "resolved": "https://registry.npmjs.org/esformatter-dot-notation/-/esformatter-dot-notation-1.3.1.tgz",
       "dev": true,
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
+          "from": "esprima@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
           "dev": true
         },
         "rocambole": {
           "version": "0.6.0",
+          "from": "rocambole@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.6.0.tgz",
           "dev": true
         }
       }
     },
     "esformatter-quotes": {
       "version": "1.0.3",
+      "from": "esformatter-quotes@1.0.3",
+      "resolved": "https://registry.npmjs.org/esformatter-quotes/-/esformatter-quotes-1.0.3.tgz",
       "dev": true
     },
     "esformatter-semicolons": {
       "version": "1.1.1",
+      "from": "esformatter-semicolons@1.1.1",
+      "resolved": "https://registry.npmjs.org/esformatter-semicolons/-/esformatter-semicolons-1.1.1.tgz",
       "dev": true
     },
     "esformatter-special-bangs": {
       "version": "1.0.1",
+      "from": "esformatter-special-bangs@1.0.1",
+      "resolved": "https://registry.npmjs.org/esformatter-special-bangs/-/esformatter-special-bangs-1.0.1.tgz",
       "dev": true
     },
     "eslint": {
       "version": "3.8.1",
+      "from": "eslint@3.8.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.8.1.tgz",
       "dev": true,
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
+          "from": "chalk@>=1.1.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dev": true
         },
         "doctrine": {
           "version": "1.5.0",
+          "from": "doctrine@>=1.2.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "dev": true
         },
         "strip-bom": {
           "version": "3.0.0",
+          "from": "strip-bom@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
+          "from": "supports-color@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "dev": true
         },
         "user-home": {
           "version": "2.0.0",
+          "from": "user-home@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
           "dev": true
         }
       }
     },
     "eslint-config-wpcalypso": {
       "version": "0.6.0",
+      "from": "eslint-config-wpcalypso@0.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-wpcalypso/-/eslint-config-wpcalypso-0.6.0.tgz",
       "dev": true
     },
     "eslint-plugin-react": {
       "version": "6.4.1",
+      "from": "eslint-plugin-react@6.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.4.1.tgz",
       "dev": true,
       "dependencies": {
         "doctrine": {
           "version": "1.5.0",
+          "from": "doctrine@>=1.2.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "dev": true
         }
       }
     },
     "eslint-plugin-wpcalypso": {
       "version": "3.0.2",
+      "from": "eslint-plugin-wpcalypso@3.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-wpcalypso/-/eslint-plugin-wpcalypso-3.0.2.tgz",
       "dev": true
     },
     "esmangle-evaluator": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "esmangle-evaluator@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.1.tgz"
     },
     "espree": {
       "version": "3.3.2",
+      "from": "espree@>=3.3.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.3.2.tgz",
       "dev": true,
       "dependencies": {
         "acorn": {
           "version": "4.0.4",
+          "from": "acorn@>=4.0.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz",
           "dev": true
         }
       }
     },
     "esprima": {
-      "version": "3.1.3"
+      "version": "3.1.3",
+      "from": "esprima@3.1.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
     },
     "esrecurse": {
       "version": "4.1.0",
+      "from": "esrecurse@>=4.1.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
       "dev": true,
       "dependencies": {
         "estraverse": {
           "version": "4.1.1",
+          "from": "estraverse@>=4.1.0 <4.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
           "dev": true
         }
       }
     },
     "estraverse": {
       "version": "4.2.0",
+      "from": "estraverse@>=4.2.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "dev": true
     },
     "estree-walker": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "from": "estree-walker@0.2.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz"
     },
     "esutils": {
-      "version": "2.0.2"
+      "version": "2.0.2",
+      "from": "esutils@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
     },
     "etag": {
-      "version": "1.7.0"
+      "version": "1.7.0",
+      "from": "etag@>=1.7.0 <1.8.0",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
     },
     "ev-emitter": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "from": "ev-emitter@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/ev-emitter/-/ev-emitter-1.0.3.tgz"
     },
     "event-emitter": {
       "version": "0.3.4",
+      "from": "event-emitter@>=0.3.4 <0.4.0",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
       "dev": true
     },
     "event-stream": {
       "version": "0.5.3",
+      "from": "event-stream@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-0.5.3.tgz",
       "dev": true,
       "dependencies": {
         "optimist": {
           "version": "0.2.8",
+          "from": "optimist@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.2.8.tgz",
           "dev": true
         }
       }
     },
     "eventemitter3": {
       "version": "1.2.0",
+      "from": "eventemitter3@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
       "dev": true
     },
     "events": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "events@1.0.2",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
     },
     "execall": {
       "version": "1.0.0",
+      "from": "execall@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
       "dev": true
     },
     "execspawn": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "execspawn@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/execspawn/-/execspawn-1.0.1.tgz"
+    },
+    "exenv": {
+      "version": "1.2.0",
+      "from": "exenv@1.2.0",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.0.tgz"
     },
     "exit-hook": {
       "version": "1.1.1",
+      "from": "exit-hook@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
       "dev": true
     },
     "expand-brackets": {
-      "version": "0.1.5"
+      "version": "0.1.5",
+      "from": "expand-brackets@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
     },
     "expand-range": {
-      "version": "1.8.2"
+      "version": "1.8.2",
+      "from": "expand-range@>=1.8.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
     },
     "expand-template": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "from": "expand-template@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.0.3.tgz"
     },
     "expand-year": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "expand-year@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/expand-year/-/expand-year-1.0.0.tgz"
     },
     "exports-loader": {
-      "version": "0.6.2"
+      "version": "0.6.2",
+      "from": "exports-loader@0.6.2",
+      "resolved": "https://registry.npmjs.org/exports-loader/-/exports-loader-0.6.2.tgz"
     },
     "express": {
       "version": "4.13.3",
+      "from": "express@4.13.3",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.13.3.tgz",
       "dependencies": {
         "cookie": {
-          "version": "0.1.3"
+          "version": "0.1.3",
+          "from": "cookie@0.1.3",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
         },
         "cookie-signature": {
-          "version": "1.0.6"
+          "version": "1.0.6",
+          "from": "cookie-signature@1.0.6",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
         },
         "depd": {
-          "version": "1.0.1"
+          "version": "1.0.1",
+          "from": "depd@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
         }
       }
     },
     "extend": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "from": "extend@>=3.0.0 <3.1.0",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
     },
     "extglob": {
-      "version": "0.3.2"
+      "version": "0.3.2",
+      "from": "extglob@>=0.3.1 <0.4.0",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
     },
     "extsprintf": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "extsprintf@1.0.2",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
     },
     "falafel": {
       "version": "1.2.0",
+      "from": "falafel@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
       "dependencies": {
         "acorn": {
-          "version": "1.2.2"
+          "version": "1.2.2",
+          "from": "acorn@>=1.0.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
         },
         "isarray": {
-          "version": "0.0.1"
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         }
       }
     },
     "fast-future": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "fast-future@>=1.0.2 <1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz"
     },
     "fast-levenshtein": {
       "version": "2.0.6",
+      "from": "fast-levenshtein@2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "dev": true
     },
     "fast-luhn": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "from": "fast-luhn@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-luhn/-/fast-luhn-1.0.3.tgz"
     },
     "fastparse": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "from": "fastparse@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz"
     },
     "fbemitter": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "from": "fbemitter@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-2.1.1.tgz"
     },
     "fbjs": {
       "version": "0.8.8",
+      "from": "fbjs@>=0.8.3 <0.9.0",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.8.tgz",
       "dependencies": {
         "core-js": {
-          "version": "1.2.7"
+          "version": "1.2.7",
+          "from": "core-js@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
         }
       }
     },
     "figures": {
       "version": "1.7.0",
+      "from": "figures@>=1.3.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "dev": true,
       "dependencies": {
         "escape-string-regexp": {
           "version": "1.0.5",
+          "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "dev": true
         }
       }
     },
     "file-entry-cache": {
       "version": "2.0.0",
+      "from": "file-entry-cache@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "dev": true
     },
     "filename-regex": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "filename-regex@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
     },
     "filesize": {
-      "version": "3.2.1"
+      "version": "3.2.1",
+      "from": "filesize@3.2.1",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.2.1.tgz"
     },
     "fill-range": {
-      "version": "2.2.3"
+      "version": "2.2.3",
+      "from": "fill-range@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
     },
     "finalhandler": {
-      "version": "0.4.0"
+      "version": "0.4.0",
+      "from": "finalhandler@0.4.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz"
     },
     "find-up": {
       "version": "1.1.2",
+      "from": "find-up@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "dependencies": {
         "path-exists": {
-          "version": "2.1.0"
+          "version": "2.1.0",
+          "from": "path-exists@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
         }
       }
     },
     "findup": {
       "version": "0.1.5",
+      "from": "findup@>=0.1.5 <0.2.0",
+      "resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
       "dependencies": {
         "commander": {
-          "version": "2.1.0"
+          "version": "2.1.0",
+          "from": "commander@>=2.1.0 <2.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
         }
       }
     },
     "finished": {
       "version": "1.2.2",
+      "from": "finished@>=1.2.2 <1.3.0",
+      "resolved": "https://registry.npmjs.org/finished/-/finished-1.2.2.tgz",
       "dependencies": {
         "ee-first": {
-          "version": "1.0.3"
+          "version": "1.0.3",
+          "from": "ee-first@1.0.3",
+          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.3.tgz"
         }
       }
     },
     "fizzy-ui-utils": {
-      "version": "2.0.3"
+      "version": "2.0.3",
+      "from": "fizzy-ui-utils@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fizzy-ui-utils/-/fizzy-ui-utils-2.0.3.tgz"
     },
     "flag-icon-css": {
-      "version": "2.3.0"
+      "version": "2.3.0",
+      "from": "flag-icon-css@2.3.0",
+      "resolved": "https://registry.npmjs.org/flag-icon-css/-/flag-icon-css-2.3.0.tgz"
     },
     "flat-cache": {
       "version": "1.2.2",
+      "from": "flat-cache@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
       "dev": true
     },
     "flatten": {
       "version": "1.0.2",
+      "from": "flatten@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
       "dev": true
     },
     "flux": {
       "version": "2.1.1",
+      "from": "flux@2.1.1",
+      "resolved": "https://registry.npmjs.org/flux/-/flux-2.1.1.tgz",
       "dependencies": {
         "core-js": {
-          "version": "1.2.7"
+          "version": "1.2.7",
+          "from": "core-js@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
         },
         "fbjs": {
-          "version": "0.1.0-alpha.7"
+          "version": "0.1.0-alpha.7",
+          "from": "fbjs@0.1.0-alpha.7",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.1.0-alpha.7.tgz"
         },
         "whatwg-fetch": {
-          "version": "0.9.0"
+          "version": "0.9.0",
+          "from": "whatwg-fetch@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz"
         }
       }
     },
     "for-in": {
-      "version": "0.1.6"
+      "version": "0.1.6",
+      "from": "for-in@>=0.1.5 <0.2.0",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz"
     },
     "for-own": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "from": "for-own@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz"
     },
     "foreach": {
-      "version": "2.0.5"
+      "version": "2.0.5",
+      "from": "foreach@>=2.0.5 <3.0.0",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
     },
     "foreachasync": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "from": "foreachasync@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz"
     },
     "forever-agent": {
-      "version": "0.6.1"
+      "version": "0.6.1",
+      "from": "forever-agent@>=0.6.1 <0.7.0",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
     },
     "form-data": {
-      "version": "2.1.2"
+      "version": "2.1.2",
+      "from": "form-data@>=2.1.1 <2.2.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz"
     },
     "formatio": {
       "version": "1.1.1",
+      "from": "formatio@1.1.1",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
       "dev": true
     },
     "formidable": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "from": "formidable@1.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz"
     },
     "forwarded": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "from": "forwarded@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
     },
     "fresh": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "from": "fresh@0.3.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
     },
     "fs-extra": {
-      "version": "0.26.7"
+      "version": "0.26.7",
+      "from": "fs-extra@>=0.26.4 <0.27.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz"
     },
     "fs.realpath": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "fs.realpath@^1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+    },
+    "fsevents": {
+      "version": "1.0.17",
+      "from": "fsevents@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.17.tgz",
+      "optional": true,
+      "dependencies": {
+        "abbrev": {
+          "version": "1.0.9",
+          "from": "abbrev@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.0.0",
+          "from": "ansi-regex@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "from": "ansi-styles@>=2.2.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "optional": true
+        },
+        "aproba": {
+          "version": "1.0.4",
+          "from": "aproba@>=1.0.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.2",
+          "from": "are-we-there-yet@>=1.1.2 <1.2.0",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+          "optional": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "from": "asn1@>=0.2.3 <0.3.0",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "from": "assert-plus@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "from": "asynckit@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "from": "aws-sign2@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.5.0",
+          "from": "aws4@>=1.2.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "from": "balanced-match@>=0.4.1 <0.5.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.0",
+          "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+          "optional": true
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "from": "block-stream@*",
+          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
+        },
+        "boom": {
+          "version": "2.10.1",
+          "from": "boom@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+        },
+        "brace-expansion": {
+          "version": "1.1.6",
+          "from": "brace-expansion@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "from": "buffer-shims@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "from": "caseless@>=0.11.0 <0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "optional": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "from": "chalk@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "optional": true,
+          "dependencies": {
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "optional": true
+            }
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "from": "code-point-at@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "from": "combined-stream@>=1.0.5 <1.1.0",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+        },
+        "commander": {
+          "version": "2.9.0",
+          "from": "commander@>=2.9.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "optional": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "from": "concat-map@0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "from": "console-control-strings@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "from": "core-util-is@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "from": "cryptiles@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "optional": true
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "from": "dashdash@>=1.12.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "from": "assert-plus@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "optional": true
+        },
+        "deep-extend": {
+          "version": "0.4.1",
+          "from": "deep-extend@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "from": "delayed-stream@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "from": "delegates@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+          "optional": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "optional": true
+        },
+        "extend": {
+          "version": "3.0.0",
+          "from": "extend@>=3.0.0 <3.1.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "from": "extsprintf@1.0.2",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "from": "forever-agent@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.2",
+          "from": "form-data@>=2.1.1 <2.2.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+          "optional": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "from": "fs.realpath@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+        },
+        "fstream": {
+          "version": "1.0.10",
+          "from": "fstream@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz"
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "from": "fstream-ignore@>=1.0.5 <1.1.0",
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.2",
+          "from": "gauge@>=2.7.1 <2.8.0",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.2.tgz",
+          "optional": true
+        },
+        "generate-function": {
+          "version": "2.0.0",
+          "from": "generate-function@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+          "optional": true
+        },
+        "generate-object-property": {
+          "version": "1.2.0",
+          "from": "generate-object-property@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+          "optional": true
+        },
+        "getpass": {
+          "version": "0.1.6",
+          "from": "getpass@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "from": "assert-plus@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.1",
+          "from": "glob@>=7.0.5 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "from": "graceful-fs@>=4.1.2 <5.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+        },
+        "graceful-readlink": {
+          "version": "1.0.1",
+          "from": "graceful-readlink@>=1.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+          "optional": true
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "from": "har-validator@>=2.0.6 <2.1.0",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "optional": true
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "from": "has-ansi@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "optional": true
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "from": "has-unicode@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "from": "hawk@>=3.1.3 <3.2.0",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "optional": true
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "from": "hoek@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "from": "http-signature@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "optional": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "from": "inflight@>=1.0.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "from": "inherits@>=2.0.1 <2.1.0",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+        },
+        "ini": {
+          "version": "1.3.4",
+          "from": "ini@>=1.3.0 <1.4.0",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
+        },
+        "is-my-json-valid": {
+          "version": "2.15.0",
+          "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+          "optional": true
+        },
+        "is-property": {
+          "version": "1.0.2",
+          "from": "is-property@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+          "optional": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "from": "is-typedarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "from": "isstream@>=0.1.2 <0.2.0",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "from": "jodid25519@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+          "optional": true
+        },
+        "jsbn": {
+          "version": "0.1.0",
+          "from": "jsbn@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "from": "json-schema@0.2.3",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "optional": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "optional": true
+        },
+        "jsonpointer": {
+          "version": "4.0.1",
+          "from": "jsonpointer@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.3.1",
+          "from": "jsprim@>=1.2.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+          "optional": true
+        },
+        "mime-db": {
+          "version": "1.25.0",
+          "from": "mime-db@>=1.25.0 <1.26.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
+        },
+        "mime-types": {
+          "version": "2.1.13",
+          "from": "mime-types@>=2.1.7 <2.2.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz"
+        },
+        "minimatch": {
+          "version": "3.0.3",
+          "from": "minimatch@>=3.0.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "from": "minimist@0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.32",
+          "from": "node-pre-gyp@>=0.6.29 <0.7.0",
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.32.tgz",
+          "optional": true
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "from": "nopt@>=3.0.6 <3.1.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "optional": true
+        },
+        "npmlog": {
+          "version": "4.0.2",
+          "from": "npmlog@>=4.0.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
+          "optional": true
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "from": "number-is-nan@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "from": "oauth-sign@>=0.8.1 <0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.0",
+          "from": "object-assign@>=4.1.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "from": "once@>=1.3.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "from": "pinkie@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "optional": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "from": "pinkie-promise@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "from": "punycode@>=1.4.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "optional": true
+        },
+        "qs": {
+          "version": "6.3.0",
+          "from": "qs@>=6.3.0 <6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
+          "optional": true
+        },
+        "rc": {
+          "version": "1.1.6",
+          "from": "rc@>=1.1.6 <1.2.0",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+          "optional": true,
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "from": "minimist@>=1.2.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.2",
+          "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+          "optional": true
+        },
+        "request": {
+          "version": "2.79.0",
+          "from": "request@>=2.79.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+          "optional": true
+        },
+        "rimraf": {
+          "version": "2.5.4",
+          "from": "rimraf@>=2.5.4 <2.6.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
+        },
+        "semver": {
+          "version": "5.3.0",
+          "from": "semver@>=5.3.0 <5.4.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "from": "set-blocking@>=2.0.0 <2.1.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "from": "signal-exit@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "from": "sntp@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "optional": true
+        },
+        "sshpk": {
+          "version": "1.10.1",
+          "from": "sshpk@>=1.7.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "from": "assert-plus@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "optional": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "from": "string-width@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "from": "stringstream@>=0.0.4 <0.1.0",
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "from": "strip-ansi@>=3.0.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "from": "strip-json-comments@>=1.0.4 <1.1.0",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "optional": true
+        },
+        "supports-color": {
+          "version": "0.2.0",
+          "from": "supports-color@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "from": "tar@>=2.2.1 <2.3.0",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+        },
+        "tar-pack": {
+          "version": "3.3.0",
+          "from": "tar-pack@>=3.3.0 <3.4.0",
+          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
+          "optional": true,
+          "dependencies": {
+            "once": {
+              "version": "1.3.3",
+              "from": "once@>=1.3.3 <1.4.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "optional": true
+            },
+            "readable-stream": {
+              "version": "2.1.5",
+              "from": "readable-stream@>=2.1.4 <2.2.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+              "optional": true
+            }
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "from": "tough-cookie@>=2.3.0 <2.4.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "optional": true
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "from": "tunnel-agent@>=0.4.1 <0.5.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "optional": true
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "from": "tweetnacl@>=0.14.0 <0.15.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "from": "uid-number@>=0.0.6 <0.1.0",
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "from": "util-deprecate@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "from": "uuid@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "from": "verror@1.3.6",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.0",
+          "from": "wide-align@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
+          "optional": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "from": "wrappy@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "from": "xtend@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "optional": true
+        }
+      }
     },
     "fstream": {
-      "version": "1.0.10"
+      "version": "1.0.10",
+      "from": "fstream@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz"
     },
     "function-bind": {
       "version": "1.1.0",
+      "from": "function-bind@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
       "dev": true
     },
     "fuse.js": {
-      "version": "2.6.1"
+      "version": "2.6.1",
+      "from": "fuse.js@2.6.1",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-2.6.1.tgz"
     },
     "gather-stream": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "gather-stream@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/gather-stream/-/gather-stream-1.0.0.tgz"
     },
     "gauge": {
       "version": "2.7.2",
+      "from": "gauge@2.7.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.2.tgz",
       "dependencies": {
         "supports-color": {
-          "version": "0.2.0"
+          "version": "0.2.0",
+          "from": "supports-color@0.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
         }
       }
     },
     "gaze": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "from": "gaze@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz"
     },
     "generate-function": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "generate-function@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
     },
     "generate-object-property": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "from": "generate-object-property@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
     },
     "get-caller-file": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "get-caller-file@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz"
     },
     "get-document": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "get-document@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/get-document/-/get-document-1.0.0.tgz"
     },
     "get-size": {
-      "version": "2.0.2"
+      "version": "2.0.2",
+      "from": "get-size@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/get-size/-/get-size-2.0.2.tgz"
     },
     "get-stdin": {
-      "version": "4.0.1"
+      "version": "4.0.1",
+      "from": "get-stdin@>=4.0.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
     },
     "get-video-id": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "from": "get-video-id@2.1.0",
+      "resolved": "https://registry.npmjs.org/get-video-id/-/get-video-id-2.1.0.tgz"
     },
     "getpass": {
       "version": "0.1.6",
+      "from": "getpass@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "ghreleases": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "from": "ghreleases@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/ghreleases/-/ghreleases-1.0.5.tgz"
     },
     "ghrepos": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "ghrepos@>=2.0.0 <2.1.0",
+      "resolved": "https://registry.npmjs.org/ghrepos/-/ghrepos-2.0.0.tgz"
     },
     "ghutils": {
-      "version": "3.2.1"
+      "version": "3.2.1",
+      "from": "ghutils@>=3.2.0 <3.3.0",
+      "resolved": "https://registry.npmjs.org/ghutils/-/ghutils-3.2.1.tgz"
     },
     "github-from-package": {
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "from": "github-from-package@0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz"
     },
     "glob": {
-      "version": "7.0.3"
+      "version": "7.0.3",
+      "from": "glob@7.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz"
     },
     "glob-base": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "from": "glob-base@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
     },
     "glob-parent": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "glob-parent@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
     },
     "globals": {
-      "version": "9.14.0"
+      "version": "9.14.0",
+      "from": "globals@>=9.0.0 <10.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
     },
     "globby": {
       "version": "3.0.1",
+      "from": "globby@>=3.0.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-3.0.1.tgz",
       "dependencies": {
         "glob": {
-          "version": "5.0.15"
+          "version": "5.0.15",
+          "from": "glob@>=5.0.3 <6.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
         },
         "pinkie": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "from": "pinkie@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
         },
         "pinkie-promise": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "from": "pinkie-promise@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz"
         }
       }
     },
     "globjoin": {
       "version": "0.1.4",
+      "from": "globjoin@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
       "dev": true
     },
     "globule": {
       "version": "1.1.0",
+      "from": "globule@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz",
       "dependencies": {
         "glob": {
-          "version": "7.1.1"
+          "version": "7.1.1",
+          "from": "glob@~7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
         },
         "lodash": {
-          "version": "4.16.6"
+          "version": "4.16.6",
+          "from": "lodash@>=4.16.4 <4.17.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz"
         },
         "minimatch": {
-          "version": "3.0.3"
+          "version": "3.0.3",
+          "from": "minimatch@>=3.0.2 <3.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
         }
       }
     },
     "good-listener": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "from": "good-listener@>=1.1.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.1.tgz"
     },
     "got": {
       "version": "3.3.1",
+      "from": "got@>=3.2.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-3.3.1.tgz",
       "dev": true,
       "dependencies": {
         "object-assign": {
           "version": "3.0.0",
+          "from": "object-assign@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
           "dev": true
         }
       }
     },
     "graceful-fs": {
-      "version": "4.1.11"
+      "version": "4.1.11",
+      "from": "graceful-fs@>=4.1.2 <5.0.0",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
     },
     "graceful-readlink": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "graceful-readlink@>=1.0.0",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
     },
     "growl": {
       "version": "1.9.2",
+      "from": "growl@1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "dev": true
     },
     "gzip-size": {
       "version": "3.0.0",
+      "from": "gzip-size@3.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
       "dev": true
     },
     "har-validator": {
       "version": "2.0.6",
+      "from": "har-validator@>=2.0.6 <2.1.0",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "dependencies": {
         "chalk": {
-          "version": "1.1.3"
+          "version": "1.1.3",
+          "from": "chalk@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
         },
         "commander": {
-          "version": "2.9.0"
+          "version": "2.9.0",
+          "from": "commander@>=2.9.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
         },
         "supports-color": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "from": "supports-color@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
         }
       }
     },
     "hard-source-webpack-plugin": {
       "version": "0.0.42",
+      "from": "hard-source-webpack-plugin@0.0.42",
+      "resolved": "https://registry.npmjs.org/hard-source-webpack-plugin/-/hard-source-webpack-plugin-0.0.42.tgz",
       "dependencies": {
         "bluebird": {
-          "version": "3.4.7"
+          "version": "3.4.7",
+          "from": "bluebird@3.4.7",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz"
         },
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.6 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         }
       }
     },
     "has": {
       "version": "1.0.1",
+      "from": "has@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "dev": true
     },
     "has-ansi": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "has-ansi@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
     },
     "has-binary": {
       "version": "0.1.7",
+      "from": "has-binary@0.1.7",
+      "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
       "dependencies": {
         "isarray": {
-          "version": "0.0.1"
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         }
       }
     },
     "has-cors": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "has-cors@1.1.0",
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz"
     },
     "has-flag": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "has-flag@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
     },
     "has-unicode": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "from": "has-unicode@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
     },
     "hawk": {
-      "version": "3.1.3"
+      "version": "3.1.3",
+      "from": "hawk@>=3.1.3 <3.2.0",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
     },
     "he": {
-      "version": "0.5.0"
+      "version": "0.5.0",
+      "from": "he@0.5.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-0.5.0.tgz"
     },
     "hoek": {
-      "version": "2.16.3"
+      "version": "2.16.3",
+      "from": "hoek@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
     },
     "hoist-non-react-statics": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "from": "hoist-non-react-statics@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz"
     },
     "home-or-tmp": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "home-or-tmp@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz"
     },
     "hosted-git-info": {
-      "version": "2.1.5"
+      "version": "2.1.5",
+      "from": "hosted-git-info@>=2.1.4 <3.0.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
     },
     "html": {
       "version": "1.0.0",
+      "from": "html@1.0.0",
+      "resolved": "https://registry.npmjs.org/html/-/html-1.0.0.tgz",
       "dev": true
     },
     "html-loader": {
       "version": "0.4.0",
+      "from": "html-loader@0.4.0",
+      "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-0.4.0.tgz",
       "dependencies": {
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.3 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         }
       }
     },
     "html-minifier": {
       "version": "1.5.0",
+      "from": "html-minifier@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-1.5.0.tgz",
       "dependencies": {
         "async": {
-          "version": "0.2.10"
+          "version": "0.2.10",
+          "from": "async@>=0.2.6 <0.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "commander": {
-          "version": "2.9.0"
+          "version": "2.9.0",
+          "from": "commander@>=2.9.0 <2.10.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
         },
         "he": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "from": "he@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/he/-/he-1.0.0.tgz"
         },
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         },
         "uglify-js": {
-          "version": "2.6.4"
+          "version": "2.6.4",
+          "from": "uglify-js@>=2.6.0 <2.7.0",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz"
         }
       }
     },
     "html-tags": {
       "version": "1.1.1",
+      "from": "html-tags@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-1.1.1.tgz",
       "dev": true
     },
     "htmlparser2": {
-      "version": "3.8.3"
+      "version": "3.8.3",
+      "from": "htmlparser2@>=3.8.0 <3.9.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz"
     },
     "http-browserify": {
-      "version": "1.7.0"
+      "version": "1.7.0",
+      "from": "http-browserify@>=1.3.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz"
     },
     "http-errors": {
       "version": "1.5.1",
+      "from": "http-errors@>=1.5.0 <1.6.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
       "dependencies": {
         "inherits": {
-          "version": "2.0.3"
+          "version": "2.0.3",
+          "from": "inherits@2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
         }
       }
     },
     "http-proxy": {
       "version": "1.16.2",
+      "from": "http-proxy@>=1.11.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
       "dev": true
     },
     "http-signature": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "from": "http-signature@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
     },
     "https-browserify": {
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "from": "https-browserify@0.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
     },
     "hyperquest": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "from": "hyperquest@>=1.2.0 <1.3.0",
+      "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-1.2.0.tgz"
     },
     "i18n-calypso": {
       "version": "1.7.0",
+      "from": "i18n-calypso@1.7.0",
+      "resolved": "https://registry.npmjs.org/i18n-calypso/-/i18n-calypso-1.7.0.tgz",
       "dependencies": {
         "async": {
-          "version": "1.5.2"
+          "version": "1.5.2",
+          "from": "async@>=1.5.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "commander": {
-          "version": "2.9.0"
+          "version": "2.9.0",
+          "from": "commander@>=2.9.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
         },
         "glob": {
-          "version": "7.1.1"
+          "version": "7.1.1",
+          "from": "glob@^7.0.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
         },
         "minimatch": {
-          "version": "3.0.3"
+          "version": "3.0.3",
+          "from": "minimatch@^3.0.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
         }
       }
     },
     "iconv-lite": {
-      "version": "0.4.13"
+      "version": "0.4.13",
+      "from": "iconv-lite@0.4.13",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
     },
     "ieee754": {
-      "version": "1.1.8"
+      "version": "1.1.8",
+      "from": "ieee754@>=1.1.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
     },
     "ignore": {
       "version": "3.2.0",
+      "from": "ignore@>=3.1.5 <4.0.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.0.tgz",
       "dev": true
     },
     "imagesloaded": {
-      "version": "4.1.1"
+      "version": "4.1.1",
+      "from": "imagesloaded@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/imagesloaded/-/imagesloaded-4.1.1.tgz"
     },
     "immediate": {
-      "version": "3.0.6"
+      "version": "3.0.6",
+      "from": "immediate@>=3.0.5 <3.1.0",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz"
     },
     "immutable": {
-      "version": "3.7.6"
+      "version": "3.7.6",
+      "from": "immutable@3.7.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz"
     },
     "imports-loader": {
-      "version": "0.6.5"
+      "version": "0.6.5",
+      "from": "imports-loader@0.6.5",
+      "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.6.5.tgz"
     },
     "imurmurhash": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "from": "imurmurhash@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
     },
     "in-publish": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "in-publish@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz"
     },
     "indent-string": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "from": "indent-string@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz"
     },
     "indexes-of": {
       "version": "1.0.1",
+      "from": "indexes-of@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
       "dev": true
     },
     "indexof": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "from": "indexof@0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
     },
     "infinity-agent": {
       "version": "2.0.3",
+      "from": "infinity-agent@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz",
       "dev": true
     },
     "inflight": {
-      "version": "1.0.6"
+      "version": "1.0.6",
+      "from": "inflight@>=1.0.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
     },
     "inherits": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "from": "inherits@2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
     },
     "ini": {
-      "version": "1.3.4"
+      "version": "1.3.4",
+      "from": "ini@>=1.3.0 <1.4.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
     },
     "inline-process-browser": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "inline-process-browser@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-1.0.0.tgz"
     },
     "inquirer": {
       "version": "0.12.0",
+      "from": "inquirer@>=0.12.0 <0.13.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "dev": true
     },
     "interpolate-components": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "interpolate-components@1.1.0",
+      "resolved": "https://registry.npmjs.org/interpolate-components/-/interpolate-components-1.1.0.tgz"
     },
     "interpret": {
-      "version": "0.6.6"
+      "version": "0.6.6",
+      "from": "interpret@>=0.6.4 <0.7.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
     },
     "invariant": {
-      "version": "2.2.2"
+      "version": "2.2.2",
+      "from": "invariant@>=2.2.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz"
     },
     "invert-kv": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "invert-kv@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
     },
     "ipaddr.js": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "from": "ipaddr.js@1.0.5",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz"
     },
     "irregular-plurals": {
       "version": "1.2.0",
+      "from": "irregular-plurals@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.2.0.tgz",
       "dev": true
     },
     "is-arrayish": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "from": "is-arrayish@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
     },
     "is-binary-path": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "is-binary-path@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz"
     },
     "is-buffer": {
-      "version": "1.1.4"
+      "version": "1.1.4",
+      "from": "is-buffer@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
     },
     "is-builtin-module": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "is-builtin-module@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
     },
     "is-callable": {
       "version": "1.1.3",
+      "from": "is-callable@>=1.1.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
       "dev": true
     },
     "is-date-object": {
       "version": "1.0.1",
+      "from": "is-date-object@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "dev": true
     },
     "is-dotfile": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "is-dotfile@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
     },
     "is-equal-shallow": {
-      "version": "0.1.3"
+      "version": "0.1.3",
+      "from": "is-equal-shallow@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
     },
     "is-expression": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "from": "is-expression@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-2.1.0.tgz"
     },
     "is-extendable": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "from": "is-extendable@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
     },
     "is-extglob": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "is-extglob@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
     },
     "is-finite": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "is-finite@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
     },
     "is-fullwidth-code-point": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
     },
     "is-glob": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "from": "is-glob@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
     },
     "is-integer": {
-      "version": "1.0.6"
+      "version": "1.0.6",
+      "from": "is-integer@>=1.0.4 <1.1.0",
+      "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz"
     },
     "is-lower-case": {
-      "version": "1.1.3"
+      "version": "1.1.3",
+      "from": "is-lower-case@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz"
     },
     "is-my-json-valid": {
-      "version": "2.13.1"
+      "version": "2.13.1",
+      "from": "is-my-json-valid@2.13.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
     },
     "is-npm": {
       "version": "1.0.0",
+      "from": "is-npm@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
       "dev": true
     },
     "is-number": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "from": "is-number@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
     },
     "is-path-cwd": {
       "version": "1.0.0",
+      "from": "is-path-cwd@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "dev": true
     },
     "is-path-in-cwd": {
       "version": "1.0.0",
+      "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "dev": true
     },
     "is-path-inside": {
       "version": "1.0.0",
+      "from": "is-path-inside@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "dev": true
     },
     "is-plain-obj": {
       "version": "1.1.0",
+      "from": "is-plain-obj@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "dev": true
     },
     "is-plain-object": {
       "version": "2.0.1",
+      "from": "is-plain-object@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.1.tgz",
       "dev": true,
       "dependencies": {
         "isobject": {
           "version": "1.0.2",
+          "from": "isobject@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
           "dev": true
         }
       }
     },
     "is-posix-bracket": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
     },
     "is-primitive": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "is-primitive@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
     },
     "is-promise": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "from": "is-promise@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz"
     },
     "is-property": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "is-property@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
     },
     "is-redirect": {
       "version": "1.0.0",
+      "from": "is-redirect@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "dev": true
     },
     "is-regex": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "from": "is-regex@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz"
     },
     "is-regexp": {
       "version": "1.0.0",
+      "from": "is-regexp@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
       "dev": true
     },
     "is-resolvable": {
       "version": "1.0.0",
+      "from": "is-resolvable@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "dev": true
     },
     "is-stream": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "is-stream@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
     },
     "is-subset": {
       "version": "0.1.1",
+      "from": "is-subset@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
       "dev": true
     },
     "is-supported-regexp-flag": {
       "version": "1.0.0",
+      "from": "is-supported-regexp-flag@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.0.tgz",
       "dev": true
     },
     "is-symbol": {
       "version": "1.0.1",
+      "from": "is-symbol@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
       "dev": true
     },
     "is-typedarray": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "is-typedarray@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
     },
     "is-upper-case": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "from": "is-upper-case@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz"
     },
     "is-utf8": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "from": "is-utf8@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
     },
     "is-valid-month": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "is-valid-month@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/is-valid-month/-/is-valid-month-1.0.0.tgz"
     },
     "isarray": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "isarray@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
     },
     "isexe": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "from": "isexe@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
     },
     "isobject": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "from": "isobject@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
     },
     "isomorphic-fetch": {
-      "version": "2.2.1"
+      "version": "2.2.1",
+      "from": "isomorphic-fetch@>=2.1.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz"
     },
     "isstream": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "from": "isstream@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
     },
     "jade": {
       "version": "1.11.0",
@@ -2119,816 +4097,1290 @@
     },
     "jade-attrs": {
       "version": "2.0.0",
+      "from": "jade-attrs@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/jade-attrs/-/jade-attrs-2.0.0.tgz",
       "dependencies": {
         "jade-runtime": {
-          "version": "1.1.0"
+          "version": "1.1.0",
+          "from": "jade-runtime@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/jade-runtime/-/jade-runtime-1.1.0.tgz"
         }
       }
     },
     "jade-code-gen": {
       "version": "0.0.4",
+      "from": "jade-code-gen@0.0.4",
+      "resolved": "https://registry.npmjs.org/jade-code-gen/-/jade-code-gen-0.0.4.tgz",
       "dependencies": {
         "jade-runtime": {
-          "version": "1.1.0"
+          "version": "1.1.0",
+          "from": "jade-runtime@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/jade-runtime/-/jade-runtime-1.1.0.tgz"
         }
       }
     },
     "jade-error": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "from": "jade-error@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jade-error/-/jade-error-1.2.0.tgz"
     },
     "jade-filters": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "jade-filters@1.1.0",
+      "resolved": "https://registry.npmjs.org/jade-filters/-/jade-filters-1.1.0.tgz"
     },
     "jade-lexer": {
       "version": "0.0.9",
+      "from": "jade-lexer@0.0.9",
+      "resolved": "https://registry.npmjs.org/jade-lexer/-/jade-lexer-0.0.9.tgz",
       "dependencies": {
         "acorn": {
-          "version": "2.7.0"
+          "version": "2.7.0",
+          "from": "acorn@>=2.7.0 <2.8.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
         },
         "is-expression": {
-          "version": "1.0.2"
+          "version": "1.0.2",
+          "from": "is-expression@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-1.0.2.tgz"
         }
       }
     },
     "jade-linker": {
-      "version": "0.0.3"
+      "version": "0.0.3",
+      "from": "jade-linker@0.0.3",
+      "resolved": "https://registry.npmjs.org/jade-linker/-/jade-linker-0.0.3.tgz"
     },
     "jade-load": {
-      "version": "0.0.4"
+      "version": "0.0.4",
+      "from": "jade-load@0.0.4",
+      "resolved": "https://registry.npmjs.org/jade-load/-/jade-load-0.0.4.tgz"
     },
     "jade-parser": {
-      "version": "0.0.9"
+      "version": "0.0.9",
+      "from": "jade-parser@0.0.9",
+      "resolved": "https://registry.npmjs.org/jade-parser/-/jade-parser-0.0.9.tgz"
     },
     "jade-runtime": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "jade-runtime@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/jade-runtime/-/jade-runtime-2.0.0.tgz"
     },
     "jade-strip-comments": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "jade-strip-comments@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jade-strip-comments/-/jade-strip-comments-1.0.0.tgz"
     },
     "jade-walk": {
-      "version": "0.0.3"
+      "version": "0.0.3",
+      "from": "jade-walk@>=0.0.3 <0.0.4",
+      "resolved": "https://registry.npmjs.org/jade-walk/-/jade-walk-0.0.3.tgz"
     },
     "jed": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "jed@1.0.2",
+      "resolved": "https://registry.npmjs.org/jed/-/jed-1.0.2.tgz"
+    },
+    "jodid25519": {
+      "version": "1.0.2",
+      "from": "jodid25519@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+      "optional": true
     },
     "jquery": {
-      "version": "1.11.3"
+      "version": "1.11.3",
+      "from": "jquery@1.11.3",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.11.3.tgz"
     },
     "js-base64": {
-      "version": "2.1.9"
+      "version": "2.1.9",
+      "from": "js-base64@>=2.1.9 <3.0.0",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
     },
     "js-stringify": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "js-stringify@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz"
     },
     "js-tokens": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "js-tokens@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
     },
     "js-yaml": {
       "version": "3.7.0",
+      "from": "js-yaml@>=3.5.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
       "dev": true,
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
+          "from": "esprima@>=2.6.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
           "dev": true
         }
       }
     },
+    "jsbn": {
+      "version": "0.1.0",
+      "from": "jsbn@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+      "optional": true
+    },
     "jsdom": {
       "version": "9.4.1",
+      "from": "jsdom@9.4.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.4.1.tgz",
       "dev": true,
       "dependencies": {
         "acorn": {
           "version": "2.7.0",
+          "from": "acorn@>=2.4.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
           "dev": true
         },
         "acorn-globals": {
           "version": "1.0.9",
+          "from": "acorn-globals@>=1.0.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
           "dev": true
         }
       }
     },
     "jsesc": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "from": "jsesc@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz"
     },
     "jshashes": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "from": "jshashes@1.0.5",
+      "resolved": "https://registry.npmjs.org/jshashes/-/jshashes-1.0.5.tgz"
     },
     "json-loader": {
-      "version": "0.5.4"
+      "version": "0.5.4",
+      "from": "json-loader@0.5.4",
+      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.4.tgz"
     },
     "json-schema": {
-      "version": "0.2.3"
+      "version": "0.2.3",
+      "from": "json-schema@0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
     },
     "json-stable-stringify": {
       "version": "1.0.1",
+      "from": "json-stable-stringify@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "dev": true
     },
     "json-stringify-safe": {
-      "version": "5.0.1"
+      "version": "5.0.1",
+      "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
     },
     "json3": {
-      "version": "3.3.2"
+      "version": "3.3.2",
+      "from": "json3@3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
     },
     "json5": {
-      "version": "0.4.0"
+      "version": "0.4.0",
+      "from": "json5@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
     },
     "jsonfile": {
-      "version": "2.4.0"
+      "version": "2.4.0",
+      "from": "jsonfile@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz"
     },
     "jsonfilter": {
       "version": "1.1.2",
+      "from": "jsonfilter@>=1.1.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfilter/-/jsonfilter-1.1.2.tgz",
       "dev": true,
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
+          "from": "minimist@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "dev": true
         }
       }
     },
     "jsonify": {
       "version": "0.0.0",
+      "from": "jsonify@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "dev": true
     },
     "jsonist": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "from": "jsonist@>=1.3.0 <1.4.0",
+      "resolved": "https://registry.npmjs.org/jsonist/-/jsonist-1.3.0.tgz"
     },
     "jsonparse": {
       "version": "0.0.5",
+      "from": "jsonparse@0.0.5",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
       "dev": true
     },
     "jsonpointer": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "jsonpointer@2.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
     },
     "JSONStream": {
       "version": "0.8.4",
+      "from": "JSONStream@>=0.8.4 <0.9.0",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
       "dev": true
     },
     "jsprim": {
-      "version": "1.3.1"
+      "version": "1.3.1",
+      "from": "jsprim@>=1.2.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz"
     },
     "jstimezonedetect": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "from": "jstimezonedetect@1.0.5",
+      "resolved": "https://registry.npmjs.org/jstimezonedetect/-/jstimezonedetect-1.0.5.tgz"
     },
     "jstransform": {
       "version": "3.0.0",
+      "from": "jstransform@>=3.0.0 <3.1.0",
+      "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-3.0.0.tgz",
       "dependencies": {
         "esprima-fb": {
-          "version": "3001.1.0-dev-harmony-fb"
+          "version": "3001.1.0-dev-harmony-fb",
+          "from": "esprima-fb@~3001.1.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
         },
         "source-map": {
-          "version": "0.1.31"
+          "version": "0.1.31",
+          "from": "source-map@0.1.31",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz"
         }
       }
     },
     "jstransformer": {
-      "version": "0.0.3"
+      "version": "0.0.3",
+      "from": "jstransformer@0.0.3",
+      "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-0.0.3.tgz"
     },
     "jsx-ast-utils": {
       "version": "1.3.5",
+      "from": "jsx-ast-utils@>=1.3.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.3.5.tgz",
       "dev": true
     },
     "key-mirror": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "key-mirror@1.0.1",
+      "resolved": "https://registry.npmjs.org/key-mirror/-/key-mirror-1.0.1.tgz"
     },
     "keymaster": {
-      "version": "1.6.2"
+      "version": "1.6.2",
+      "from": "keymaster@1.6.2",
+      "resolved": "https://registry.npmjs.org/keymaster/-/keymaster-1.6.2.tgz"
     },
     "kind-of": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "from": "kind-of@>=3.0.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz"
     },
     "klaw": {
-      "version": "1.3.1"
+      "version": "1.3.1",
+      "from": "klaw@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz"
     },
     "latest-version": {
       "version": "1.0.1",
+      "from": "latest-version@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz",
       "dev": true
     },
     "lazy-cache": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "from": "lazy-cache@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
     },
     "lcid": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "lcid@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
     },
     "ldjson-stream": {
       "version": "1.2.1",
+      "from": "ldjson-stream@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/ldjson-stream/-/ldjson-stream-1.2.1.tgz",
       "dev": true
     },
     "level": {
-      "version": "1.5.0"
+      "version": "1.5.0",
+      "from": "level@>=1.4.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/level/-/level-1.5.0.tgz"
     },
     "level-codec": {
-      "version": "6.1.0"
+      "version": "6.1.0",
+      "from": "level-codec@>=6.1.0 <6.2.0",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-6.1.0.tgz"
     },
     "level-errors": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "from": "level-errors@>=1.0.3 <1.1.0",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.4.tgz"
     },
     "level-iterator-stream": {
-      "version": "1.3.1"
+      "version": "1.3.1",
+      "from": "level-iterator-stream@>=1.3.0 <1.4.0",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz"
     },
     "level-packager": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "from": "level-packager@1.2.1",
+      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-1.2.1.tgz"
     },
     "leveldown": {
       "version": "1.5.3",
+      "from": "leveldown@1.5.3",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.5.3.tgz",
       "dependencies": {
         "abstract-leveldown": {
-          "version": "2.6.1"
+          "version": "2.6.1",
+          "from": "abstract-leveldown@>=2.6.1 <2.7.0",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.1.tgz"
         }
       }
     },
     "levelup": {
-      "version": "1.3.3"
+      "version": "1.3.3",
+      "from": "levelup@>=1.3.0 <1.4.0",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.3.tgz"
     },
     "levn": {
       "version": "0.3.0",
+      "from": "levn@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "dev": true
     },
     "lie": {
-      "version": "3.0.2"
+      "version": "3.0.2",
+      "from": "lie@3.0.2",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.0.2.tgz"
     },
     "load-json-file": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "load-json-file@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
     },
     "loader-utils": {
       "version": "0.2.16",
+      "from": "loader-utils@>=0.2.11 <0.3.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz",
       "dependencies": {
         "json5": {
-          "version": "0.5.1"
+          "version": "0.5.1",
+          "from": "json5@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
         }
       }
     },
     "localforage": {
-      "version": "1.4.3"
+      "version": "1.4.3",
+      "from": "localforage@1.4.3",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.4.3.tgz"
     },
     "lodash": {
-      "version": "4.15.0"
+      "version": "4.15.0",
+      "from": "lodash@4.15.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
     },
     "lodash-deep": {
       "version": "1.5.3",
+      "from": "lodash-deep@1.5.3",
+      "resolved": "https://registry.npmjs.org/lodash-deep/-/lodash-deep-1.5.3.tgz",
       "dev": true
     },
     "lodash._baseassign": {
       "version": "3.2.0",
+      "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "dev": true
     },
     "lodash._basecopy": {
       "version": "3.0.1",
+      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "dev": true
     },
     "lodash._basecreate": {
       "version": "3.0.3",
+      "from": "lodash._basecreate@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
       "dev": true
     },
     "lodash._getnative": {
       "version": "3.9.1",
+      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "dev": true
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
+      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "dev": true
     },
     "lodash.assign": {
-      "version": "4.2.0"
+      "version": "4.2.0",
+      "from": "lodash.assign@>=4.0.8 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
     },
     "lodash.create": {
       "version": "3.1.1",
+      "from": "lodash.create@3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "dev": true
     },
     "lodash.debounce": {
-      "version": "4.0.8"
+      "version": "4.0.8",
+      "from": "lodash.debounce@>=4.0.6 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz"
     },
     "lodash.flatten": {
-      "version": "4.4.0"
+      "version": "4.4.0",
+      "from": "lodash.flatten@>=4.4.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz"
     },
     "lodash.isarguments": {
       "version": "3.1.0",
+      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "dev": true
     },
     "lodash.isarray": {
       "version": "3.0.4",
+      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "dev": true
     },
     "lodash.kebabcase": {
-      "version": "4.1.1"
+      "version": "4.1.1",
+      "from": "lodash.kebabcase@>=4.0.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz"
     },
     "lodash.keys": {
       "version": "3.1.2",
+      "from": "lodash.keys@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "dev": true
     },
     "lodash.omit": {
-      "version": "4.5.0"
+      "version": "4.5.0",
+      "from": "lodash.omit@>=4.3.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz"
     },
     "lodash.pad": {
-      "version": "4.5.1"
+      "version": "4.5.1",
+      "from": "lodash.pad@>=4.1.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz"
     },
     "lodash.padend": {
-      "version": "4.6.1"
+      "version": "4.6.1",
+      "from": "lodash.padend@>=4.1.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz"
     },
     "lodash.padstart": {
-      "version": "4.6.1"
+      "version": "4.6.1",
+      "from": "lodash.padstart@>=4.1.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz"
     },
     "lodash.pickby": {
       "version": "4.6.0",
+      "from": "lodash.pickby@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
       "dev": true
     },
     "log-symbols": {
       "version": "1.0.2",
+      "from": "log-symbols@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
       "dev": true
     },
     "lolex": {
       "version": "1.3.2",
+      "from": "lolex@1.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
       "dev": true
     },
     "longest": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "longest@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
     },
     "loose-envify": {
       "version": "1.3.1",
+      "from": "loose-envify@1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "dependencies": {
         "js-tokens": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "from": "js-tokens@3.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
         }
       }
     },
     "loud-rejection": {
-      "version": "1.6.0"
+      "version": "1.6.0",
+      "from": "loud-rejection@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz"
     },
     "lower-case": {
-      "version": "1.1.3"
+      "version": "1.1.3",
+      "from": "lower-case@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz"
     },
     "lower-case-first": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "lower-case-first@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz"
     },
     "lowercase-keys": {
       "version": "1.0.0",
+      "from": "lowercase-keys@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
       "dev": true
     },
     "lru": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "from": "lru@3.1.0",
+      "resolved": "https://registry.npmjs.org/lru/-/lru-3.1.0.tgz"
     },
     "lru-cache": {
-      "version": "4.0.2"
+      "version": "4.0.2",
+      "from": "lru-cache@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz"
     },
     "lunr": {
-      "version": "0.5.7"
+      "version": "0.5.7",
+      "from": "lunr@0.5.7",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-0.5.7.tgz"
     },
     "map-obj": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "map-obj@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
     },
     "marked": {
-      "version": "0.3.5"
+      "version": "0.3.5",
+      "from": "marked@0.3.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz"
     },
     "masonry-layout": {
-      "version": "4.1.1"
+      "version": "4.1.1",
+      "from": "masonry-layout@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/masonry-layout/-/masonry-layout-4.1.1.tgz"
     },
     "md5": {
       "version": "2.2.1",
+      "from": "md5@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
       "dev": true
     },
     "md5-file": {
       "version": "3.1.0",
+      "from": "md5-file@3.1.0",
+      "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-3.1.0.tgz",
       "dev": true
     },
     "media-typer": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "from": "media-typer@0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
     },
     "memory-fs": {
       "version": "0.3.0",
+      "from": "memory-fs@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
       "dependencies": {
         "readable-stream": {
-          "version": "2.2.2"
+          "version": "2.2.2",
+          "from": "readable-stream@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
         }
       }
     },
     "meow": {
       "version": "3.7.0",
+      "from": "meow@>=3.7.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "dependencies": {
         "minimist": {
-          "version": "1.2.0"
+          "version": "1.2.0",
+          "from": "minimist@>=1.1.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         }
       }
     },
     "merge-descriptors": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "merge-descriptors@1.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.0.tgz"
     },
     "methods": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "from": "methods@>=1.1.1 <1.2.0",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
     },
     "micromatch": {
-      "version": "2.3.11"
+      "version": "2.3.11",
+      "from": "micromatch@>=2.1.5 <3.0.0",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
     },
     "mime": {
-      "version": "1.3.4"
+      "version": "1.3.4",
+      "from": "mime@1.3.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
     },
     "mime-db": {
-      "version": "1.26.0"
+      "version": "1.26.0",
+      "from": "mime-db@1.26.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
     },
     "mime-types": {
-      "version": "2.1.14"
+      "version": "2.1.14",
+      "from": "mime-types@2.1.14",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz"
     },
     "minimatch": {
-      "version": "2.0.10"
+      "version": "2.0.10",
+      "from": "minimatch@>=2.0.3 <3.0.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
     },
     "minimist": {
-      "version": "0.0.8"
+      "version": "0.0.8",
+      "from": "minimist@0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
     },
     "mixedindentlint": {
       "version": "1.1.1",
+      "from": "mixedindentlint@1.1.1",
+      "resolved": "https://registry.npmjs.org/mixedindentlint/-/mixedindentlint-1.1.1.tgz",
       "dev": true,
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
+          "from": "minimist@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "dev": true
         }
       }
     },
     "mkdirp": {
-      "version": "0.5.1"
+      "version": "0.5.1",
+      "from": "mkdirp@>=0.5.1 <0.6.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
     },
     "mocha": {
       "version": "3.1.0",
+      "from": "mocha@3.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.1.0.tgz",
       "dev": true,
       "dependencies": {
         "commander": {
           "version": "2.9.0",
+          "from": "commander@2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
+          "from": "escape-string-regexp@1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "dev": true
         },
         "glob": {
           "version": "7.0.5",
+          "from": "glob@7.0.5",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.3",
+          "from": "minimatch@>=3.0.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "3.1.2",
+          "from": "supports-color@3.1.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "dev": true
         }
       }
     },
     "mocha-junit-reporter": {
       "version": "1.12.0",
+      "from": "mocha-junit-reporter@1.12.0",
+      "resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-1.12.0.tgz",
       "dev": true
     },
     "mockery": {
       "version": "1.7.0",
+      "from": "mockery@1.7.0",
+      "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
       "dev": true
     },
     "moment": {
-      "version": "2.10.6"
+      "version": "2.10.6",
+      "from": "moment@2.10.6",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
     },
     "moment-timezone": {
-      "version": "0.4.0"
+      "version": "0.4.0",
+      "from": "moment-timezone@0.4.0",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.0.tgz"
     },
     "morgan": {
       "version": "1.2.0",
+      "from": "morgan@1.2.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.2.0.tgz",
       "dependencies": {
         "bytes": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "from": "bytes@1.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
         },
         "depd": {
-          "version": "0.4.2"
+          "version": "0.4.2",
+          "from": "depd@0.4.2",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.2.tgz"
         }
       }
     },
     "mout": {
       "version": "1.0.0",
+      "from": "mout@>=0.9.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/mout/-/mout-1.0.0.tgz",
       "dev": true
     },
     "ms": {
-      "version": "0.7.1"
+      "version": "0.7.1",
+      "from": "ms@0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
     },
     "multimatch": {
       "version": "2.1.0",
+      "from": "multimatch@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
       "dev": true,
       "dependencies": {
         "minimatch": {
           "version": "3.0.3",
+          "from": "minimatch@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "dev": true
         }
       }
     },
     "mute-stream": {
       "version": "0.0.5",
+      "from": "mute-stream@0.0.5",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
       "dev": true
     },
     "nan": {
-      "version": "2.4.0"
+      "version": "2.4.0",
+      "from": "nan@>=2.4.0 <2.5.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
     },
     "natives": {
       "version": "1.1.0",
+      "from": "natives@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
       "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
+      "from": "natural-compare@>=1.4.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "dev": true
     },
     "ncname": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "ncname@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz"
     },
     "negotiator": {
-      "version": "0.5.3"
+      "version": "0.5.3",
+      "from": "negotiator@0.5.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
     },
     "neo-async": {
-      "version": "1.8.2"
+      "version": "1.8.2",
+      "from": "neo-async@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-1.8.2.tgz"
     },
     "nested-error-stacks": {
       "version": "1.0.2",
+      "from": "nested-error-stacks@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.2.tgz",
       "dev": true
     },
     "nock": {
       "version": "8.0.0",
+      "from": "nock@8.0.0",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-8.0.0.tgz",
       "dev": true,
       "dependencies": {
         "qs": {
           "version": "6.3.0",
+          "from": "qs@>=6.0.2 <7.0.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
           "dev": true
         }
       }
     },
     "node-abi": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "from": "node-abi@1.0.3",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-1.0.3.tgz"
     },
     "node-contains": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "node-contains@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/node-contains/-/node-contains-1.0.0.tgz"
     },
     "node-dir": {
       "version": "0.1.16",
+      "from": "node-dir@>=0.1.10 <0.2.0",
+      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.16.tgz",
       "dependencies": {
         "minimatch": {
-          "version": "3.0.3"
+          "version": "3.0.3",
+          "from": "minimatch@>=3.0.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
         }
       }
     },
     "node-fetch": {
-      "version": "1.6.3"
+      "version": "1.6.3",
+      "from": "node-fetch@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz"
     },
     "node-gyp": {
       "version": "3.5.0",
+      "from": "node-gyp@3.5.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.5.0.tgz",
       "dependencies": {
         "minimatch": {
-          "version": "3.0.3"
+          "version": "3.0.3",
+          "from": "minimatch@>=3.0.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
         }
       }
     },
     "node-libs-browser": {
-      "version": "0.6.0"
+      "version": "0.6.0",
+      "from": "node-libs-browser@>=0.4.0 <=0.6.0",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.6.0.tgz"
     },
     "node-ninja": {
       "version": "1.0.2",
+      "from": "node-ninja@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/node-ninja/-/node-ninja-1.0.2.tgz",
       "dependencies": {
         "gauge": {
-          "version": "1.2.7"
+          "version": "1.2.7",
+          "from": "gauge@1.2.7",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz"
         },
         "minimatch": {
-          "version": "3.0.3"
+          "version": "3.0.3",
+          "from": "minimatch@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
         },
         "npmlog": {
-          "version": "2.0.4"
+          "version": "2.0.4",
+          "from": "npmlog@2.0.4",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz"
         }
       }
     },
     "node-sass": {
       "version": "3.7.0",
+      "from": "node-sass@3.7.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.7.0.tgz",
       "dependencies": {
         "chalk": {
-          "version": "1.1.3"
+          "version": "1.1.3",
+          "from": "chalk@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
         },
         "supports-color": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "from": "supports-color@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
         }
       }
     },
     "nodemon": {
       "version": "1.4.1",
+      "from": "nodemon@1.4.1",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.4.1.tgz",
       "dev": true,
       "dependencies": {
         "lru-cache": {
           "version": "2.7.3",
+          "from": "lru-cache@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
           "dev": true
         },
         "minimatch": {
           "version": "0.3.0",
+          "from": "minimatch@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "dev": true
         }
       }
     },
     "noop-logger": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "from": "noop-logger@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz"
     },
     "nopt": {
-      "version": "3.0.6"
+      "version": "3.0.6",
+      "from": "nopt@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
     },
     "normalize-package-data": {
-      "version": "2.3.5"
+      "version": "2.3.5",
+      "from": "normalize-package-data@>=2.3.4 <3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
     },
     "normalize-path": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "from": "normalize-path@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
     },
     "normalize-range": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "from": "normalize-range@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
     },
     "normalize-selector": {
       "version": "0.2.0",
+      "from": "normalize-selector@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
       "dev": true
     },
     "npm-path": {
       "version": "1.1.0",
+      "from": "npm-path@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-1.1.0.tgz",
       "dev": true
     },
     "npm-run": {
       "version": "1.1.1",
+      "from": "npm-run@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run/-/npm-run-1.1.1.tgz",
       "dev": true,
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
+          "from": "minimist@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "dev": true
         }
       }
     },
     "npmlog": {
-      "version": "4.0.2"
+      "version": "4.0.2",
+      "from": "npmlog@4.0.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz"
     },
     "nth-check": {
       "version": "1.0.1",
+      "from": "nth-check@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "dev": true
     },
     "num2fraction": {
-      "version": "1.2.2"
+      "version": "1.2.2",
+      "from": "num2fraction@>=1.2.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
     },
     "number-is-nan": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "number-is-nan@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
     },
     "nwmatcher": {
       "version": "1.3.9",
+      "from": "nwmatcher@>=1.3.7 <2.0.0",
+      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.9.tgz",
       "dev": true
     },
     "oauth-sign": {
-      "version": "0.8.2"
+      "version": "0.8.2",
+      "from": "oauth-sign@>=0.8.1 <0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
     },
     "object-assign": {
-      "version": "4.1.1"
+      "version": "4.1.1",
+      "from": "object-assign@4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
     },
     "object-component": {
-      "version": "0.0.3"
+      "version": "0.0.3",
+      "from": "object-component@0.0.3",
+      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
     },
     "object-is": {
       "version": "1.0.1",
+      "from": "object-is@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
       "dev": true
     },
     "object-keys": {
-      "version": "1.0.11"
+      "version": "1.0.11",
+      "from": "object-keys@>=1.0.6 <2.0.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
     },
     "object.assign": {
       "version": "4.0.4",
+      "from": "object.assign@>=4.0.3 <5.0.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
       "dev": true
     },
     "object.omit": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "from": "object.omit@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz"
     },
     "object.values": {
       "version": "1.0.4",
+      "from": "object.values@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
       "dev": true
     },
     "on-finished": {
-      "version": "2.3.0"
+      "version": "2.3.0",
+      "from": "on-finished@>=2.3.0 <2.4.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
     },
     "once": {
-      "version": "1.4.0"
+      "version": "1.4.0",
+      "from": "once@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
     },
     "onecolor": {
       "version": "3.0.4",
+      "from": "onecolor@>=3.0.4 <4.0.0",
+      "resolved": "https://registry.npmjs.org/onecolor/-/onecolor-3.0.4.tgz",
       "dev": true
     },
     "onetime": {
       "version": "1.1.0",
+      "from": "onetime@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "dev": true
     },
     "opener": {
       "version": "1.4.2",
+      "from": "opener@1.4.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.2.tgz",
       "dev": true
     },
     "optimist": {
-      "version": "0.6.1"
+      "version": "0.6.1",
+      "from": "optimist@>=0.6.0 <0.7.0",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz"
     },
     "optionator": {
       "version": "0.8.2",
+      "from": "optionator@>=0.8.2 <0.9.0",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "dev": true,
       "dependencies": {
         "wordwrap": {
           "version": "1.0.0",
+          "from": "wordwrap@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
           "dev": true
         }
       }
     },
     "options": {
-      "version": "0.0.6"
+      "version": "0.0.6",
+      "from": "options@>=0.0.5",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
     },
     "os-browserify": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "from": "os-browserify@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
     },
     "os-homedir": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "os-homedir@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
     },
     "os-locale": {
-      "version": "1.4.0"
+      "version": "1.4.0",
+      "from": "os-locale@>=1.4.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
     },
     "os-tmpdir": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "os-tmpdir@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
     },
     "osenv": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "from": "osenv@>=0.0.0 <1.0.0",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
     },
     "outlayer": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "from": "outlayer@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/outlayer/-/outlayer-2.1.0.tgz"
     },
     "package-json": {
       "version": "1.2.0",
+      "from": "package-json@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz",
       "dev": true
     },
     "page": {
       "version": "1.6.4",
+      "from": "page@1.6.4",
+      "resolved": "https://registry.npmjs.org/page/-/page-1.6.4.tgz",
       "dependencies": {
         "isarray": {
-          "version": "0.0.1"
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "path-to-regexp": {
-          "version": "1.2.1"
+          "version": "1.2.1",
+          "from": "path-to-regexp@>=1.2.1 <1.3.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.2.1.tgz"
         }
       }
     },
     "pako": {
-      "version": "0.2.9"
+      "version": "0.2.9",
+      "from": "pako@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
     },
     "param-case": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "from": "param-case@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz"
     },
     "parse-glob": {
-      "version": "3.0.4"
+      "version": "3.0.4",
+      "from": "parse-glob@>=3.0.4 <4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
     },
     "parse-int": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "parse-int@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-int/-/parse-int-1.0.2.tgz"
     },
     "parse-json": {
-      "version": "2.2.0"
+      "version": "2.2.0",
+      "from": "parse-json@>=2.2.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
     },
     "parse-year": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "parse-year@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-year/-/parse-year-1.0.0.tgz"
     },
     "parse5": {
       "version": "1.5.1",
+      "from": "parse5@>=1.5.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
       "dev": true
     },
     "parsejson": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "from": "parsejson@0.0.1",
+      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz"
     },
     "parseqs": {
-      "version": "0.0.2"
+      "version": "0.0.2",
+      "from": "parseqs@0.0.2",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz"
     },
     "parseuri": {
-      "version": "0.0.4"
+      "version": "0.0.4",
+      "from": "parseuri@0.0.4",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz"
     },
     "parseurl": {
-      "version": "1.3.1"
+      "version": "1.3.1",
+      "from": "parseurl@>=1.3.0 <1.4.0",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
     },
     "pascal-case": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "from": "pascal-case@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz"
     },
     "path-array": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "path-array@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz"
     },
     "path-browserify": {
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "from": "path-browserify@0.0.0",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
     },
     "path-case": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "from": "path-case@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz"
     },
     "path-exists": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "path-exists@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
     },
     "path-is-absolute": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
     },
     "path-is-inside": {
       "version": "1.0.2",
+      "from": "path-is-inside@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "dev": true
     },
     "path-to-regexp": {
-      "version": "0.1.7"
+      "version": "0.1.7",
+      "from": "path-to-regexp@0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
     },
     "path-type": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "path-type@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
     },
     "pbkdf2-compat": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "from": "pbkdf2-compat@2.0.1",
+      "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
     },
     "percentage-regex": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "from": "percentage-regex@3.0.0",
+      "resolved": "https://registry.npmjs.org/percentage-regex/-/percentage-regex-3.0.0.tgz"
     },
     "phone": {
       "version": "1.0.8",
@@ -2936,678 +5388,1069 @@
       "resolved": "git+https://github.com/Automattic/node-phone.git#6be6549b03137f2cca01e202250bf2590750119e"
     },
     "photon": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "photon@2.0.0",
+      "resolved": "https://registry.npmjs.org/photon/-/photon-2.0.0.tgz"
     },
     "pify": {
-      "version": "2.3.0"
+      "version": "2.3.0",
+      "from": "pify@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
     },
     "pinkie": {
-      "version": "2.0.4"
+      "version": "2.0.4",
+      "from": "pinkie@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
     },
     "pinkie-promise": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
     },
     "pipetteur": {
       "version": "2.0.3",
+      "from": "pipetteur@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/pipetteur/-/pipetteur-2.0.3.tgz",
       "dev": true
     },
     "plur": {
       "version": "2.1.2",
+      "from": "plur@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
       "dev": true
     },
     "pluralize": {
       "version": "1.2.1",
+      "from": "pluralize@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
       "dev": true
     },
     "postcss": {
       "version": "5.2.10",
+      "from": "postcss@5.2.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.10.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
+          "from": "chalk@>=1.1.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "supports-color": {
-              "version": "2.0.0"
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.6 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         }
       }
     },
     "postcss-cli": {
-      "version": "2.5.1"
+      "version": "2.5.1",
+      "from": "postcss-cli@2.5.1",
+      "resolved": "https://registry.npmjs.org/postcss-cli/-/postcss-cli-2.5.1.tgz"
     },
     "postcss-less": {
       "version": "0.14.0",
+      "from": "postcss-less@>=0.14.0 <0.15.0",
+      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-0.14.0.tgz",
       "dev": true
     },
     "postcss-reporter": {
       "version": "1.4.1",
+      "from": "postcss-reporter@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-1.4.1.tgz",
       "dev": true
     },
     "postcss-resolve-nested-selector": {
       "version": "0.1.1",
+      "from": "postcss-resolve-nested-selector@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
       "dev": true
     },
     "postcss-scss": {
       "version": "0.1.9",
+      "from": "postcss-scss@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-0.1.9.tgz",
       "dev": true
     },
     "postcss-selector-parser": {
       "version": "2.2.2",
+      "from": "postcss-selector-parser@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.2.tgz",
       "dev": true
     },
     "postcss-value-parser": {
-      "version": "3.3.0"
+      "version": "3.3.0",
+      "from": "postcss-value-parser@>=3.2.3 <4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
     },
     "prebuild": {
       "version": "5.1.2",
+      "from": "prebuild@5.1.2",
+      "resolved": "https://registry.npmjs.org/prebuild/-/prebuild-5.1.2.tgz",
       "dependencies": {
         "async": {
-          "version": "2.1.4"
+          "version": "2.1.4",
+          "from": "async@2.1.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz"
         },
         "minimist": {
-          "version": "1.2.0"
+          "version": "1.2.0",
+          "from": "minimist@>=1.1.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         }
       }
     },
     "prelude-ls": {
       "version": "1.1.2",
+      "from": "prelude-ls@>=1.1.2 <1.2.0",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "dev": true
     },
     "prepend-http": {
       "version": "1.0.4",
+      "from": "prepend-http@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "dev": true
     },
     "preserve": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "from": "preserve@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
     },
     "prismjs": {
-      "version": "1.6.0"
+      "version": "1.6.0",
+      "from": "prismjs@1.6.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.6.0.tgz",
+      "dependencies": {
+        "clipboard": {
+          "version": "1.5.16",
+          "from": "clipboard@>=1.5.5 <2.0.0",
+          "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.5.16.tgz",
+          "optional": true
+        }
+      }
     },
     "private": {
-      "version": "0.1.6"
+      "version": "0.1.6",
+      "from": "private@>=0.1.6 <0.2.0",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
     },
     "process": {
-      "version": "0.11.9"
+      "version": "0.11.9",
+      "from": "process@>=0.11.0 <0.12.0",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.9.tgz"
     },
     "process-nextick-args": {
-      "version": "1.0.7"
+      "version": "1.0.7",
+      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
     },
     "progress": {
       "version": "1.1.8",
+      "from": "progress@>=1.1.8 <2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "dev": true
     },
     "progress-event": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "progress-event@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/progress-event/-/progress-event-1.0.0.tgz"
     },
     "promise": {
-      "version": "7.1.1"
+      "version": "7.1.1",
+      "from": "promise@>=7.1.1 <8.0.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz"
     },
     "propagate": {
       "version": "0.4.0",
+      "from": "propagate@0.4.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.4.0.tgz",
       "dev": true
     },
     "protochain": {
       "version": "1.0.5",
+      "from": "protochain@>=1.0.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/protochain/-/protochain-1.0.5.tgz",
       "dev": true
     },
     "proxy-addr": {
-      "version": "1.0.10"
+      "version": "1.0.10",
+      "from": "proxy-addr@>=1.0.8 <1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz"
     },
     "prr": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "prr@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz"
     },
     "ps-tree": {
       "version": "0.0.3",
+      "from": "ps-tree@>=0.0.3 <0.1.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-0.0.3.tgz",
       "dev": true
     },
     "pseudomap": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "pseudomap@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
     },
     "pump": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "pump@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz"
     },
     "punycode": {
-      "version": "1.4.1"
+      "version": "1.4.1",
+      "from": "punycode@>=1.4.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
     },
     "q": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "q@1.0.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
     },
     "qr.js": {
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "from": "qr.js@0.0.0",
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz"
     },
     "qrcode.react": {
-      "version": "0.6.1"
+      "version": "0.6.1",
+      "from": "qrcode.react@0.6.1",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-0.6.1.tgz"
     },
     "qs": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "from": "qs@4.0.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
     },
     "querystring": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "from": "querystring@0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
     },
     "querystring-es3": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "from": "querystring-es3@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
     },
     "randomatic": {
-      "version": "1.1.6"
+      "version": "1.1.6",
+      "from": "randomatic@>=1.1.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz"
     },
     "range-parser": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "from": "range-parser@>=1.0.2 <1.1.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
     },
     "raw-body": {
-      "version": "2.1.7"
+      "version": "2.1.7",
+      "from": "raw-body@>=2.1.7 <2.2.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz"
     },
     "rc": {
       "version": "1.1.6",
+      "from": "rc@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
       "dependencies": {
         "minimist": {
-          "version": "1.2.0"
+          "version": "1.2.0",
+          "from": "minimist@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         }
       }
     },
     "react": {
-      "version": "15.4.0"
+      "version": "15.4.0",
+      "from": "react@15.4.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-15.4.0.tgz"
     },
     "react-addons-create-fragment": {
-      "version": "15.4.0"
+      "version": "15.4.0",
+      "from": "react-addons-create-fragment@15.4.0",
+      "resolved": "https://registry.npmjs.org/react-addons-create-fragment/-/react-addons-create-fragment-15.4.0.tgz"
     },
     "react-addons-css-transition-group": {
-      "version": "15.4.0"
+      "version": "15.4.0",
+      "from": "react-addons-css-transition-group@15.4.0",
+      "resolved": "https://registry.npmjs.org/react-addons-css-transition-group/-/react-addons-css-transition-group-15.4.0.tgz"
     },
     "react-addons-linked-state-mixin": {
-      "version": "15.4.0"
+      "version": "15.4.0",
+      "from": "react-addons-linked-state-mixin@15.4.0",
+      "resolved": "https://registry.npmjs.org/react-addons-linked-state-mixin/-/react-addons-linked-state-mixin-15.4.0.tgz"
     },
     "react-addons-shallow-compare": {
-      "version": "15.4.0"
+      "version": "15.4.0",
+      "from": "react-addons-shallow-compare@15.4.0",
+      "resolved": "https://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.4.0.tgz"
     },
     "react-addons-test-utils": {
       "version": "15.4.0",
+      "from": "react-addons-test-utils@15.4.0",
+      "resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.4.0.tgz",
       "dev": true
     },
     "react-addons-update": {
-      "version": "15.4.0"
+      "version": "15.4.0",
+      "from": "react-addons-update@15.4.0",
+      "resolved": "https://registry.npmjs.org/react-addons-update/-/react-addons-update-15.4.0.tgz"
     },
     "react-click-outside": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "from": "react-click-outside@2.1.0",
+      "resolved": "https://registry.npmjs.org/react-click-outside/-/react-click-outside-2.1.0.tgz"
     },
     "react-day-picker": {
-      "version": "2.4.1"
+      "version": "2.4.1",
+      "from": "react-day-picker@2.4.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-2.4.1.tgz"
     },
     "react-docgen": {
       "version": "2.13.0",
+      "from": "react-docgen@2.13.0",
+      "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-2.13.0.tgz",
       "dependencies": {
         "async": {
-          "version": "1.5.2"
+          "version": "1.5.2",
+          "from": "async@>=1.4.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "babylon": {
-          "version": "5.8.38"
+          "version": "5.8.38",
+          "from": "babylon@>=5.8.3 <5.9.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz"
         },
         "commander": {
-          "version": "2.9.0"
+          "version": "2.9.0",
+          "from": "commander@>=2.9.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
         }
       }
     },
     "react-dom": {
-      "version": "15.4.0"
+      "version": "15.4.0",
+      "from": "react-dom@15.4.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.4.0.tgz"
     },
     "react-element-to-jsx-string": {
       "version": "3.2.0",
+      "from": "react-element-to-jsx-string@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/react-element-to-jsx-string/-/react-element-to-jsx-string-3.2.0.tgz",
       "dev": true
     },
     "react-hot-api": {
       "version": "0.4.7",
+      "from": "react-hot-api@>=0.4.5 <0.5.0",
+      "resolved": "https://registry.npmjs.org/react-hot-api/-/react-hot-api-0.4.7.tgz",
       "dev": true
     },
     "react-hot-loader": {
       "version": "1.3.0",
+      "from": "react-hot-loader@1.3.0",
+      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-1.3.0.tgz",
       "dev": true,
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
+          "from": "source-map@>=0.4.4 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dev": true
         }
       }
     },
     "react-is-deprecated": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "from": "react-is-deprecated@0.1.2",
+      "resolved": "https://registry.npmjs.org/react-is-deprecated/-/react-is-deprecated-0.1.2.tgz"
     },
     "react-masonry-component": {
-      "version": "4.2.2"
+      "version": "4.2.2",
+      "from": "react-masonry-component@4.2.2",
+      "resolved": "https://registry.npmjs.org/react-masonry-component/-/react-masonry-component-4.2.2.tgz"
+    },
+    "react-modal": {
+      "version": "1.6.5",
+      "from": "react-modal@latest",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-1.6.5.tgz"
     },
     "react-pure-render": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "react-pure-render@1.0.2",
+      "resolved": "https://registry.npmjs.org/react-pure-render/-/react-pure-render-1.0.2.tgz"
     },
     "react-redux": {
-      "version": "4.4.5"
+      "version": "4.4.5",
+      "from": "react-redux@4.4.5",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-4.4.5.tgz"
     },
     "react-test-env": {
       "version": "0.2.0",
+      "from": "react-test-env@0.2.0",
+      "resolved": "https://registry.npmjs.org/react-test-env/-/react-test-env-0.2.0.tgz",
       "dev": true,
       "dependencies": {
         "lodash.assign": {
           "version": "4.1.0",
+          "from": "lodash.assign@4.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.1.0.tgz",
           "dev": true
         }
       }
     },
     "react-virtualized": {
       "version": "8.8.1",
+      "from": "react-virtualized@8.8.1",
+      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-8.8.1.tgz",
       "dependencies": {
         "classnames": {
-          "version": "2.2.5"
+          "version": "2.2.5",
+          "from": "classnames@>=2.2.3 <3.0.0",
+          "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz"
         }
       }
     },
     "read-all-stream": {
       "version": "3.1.0",
+      "from": "read-all-stream@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
       "dev": true,
       "dependencies": {
         "readable-stream": {
           "version": "2.2.2",
+          "from": "readable-stream@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "dev": true
         }
       }
     },
     "read-file-stdin": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "from": "read-file-stdin@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/read-file-stdin/-/read-file-stdin-0.2.1.tgz"
     },
     "read-pkg": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "read-pkg@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
     },
     "read-pkg-up": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "read-pkg-up@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
     },
     "readable-stream": {
       "version": "1.1.14",
+      "from": "readable-stream@>=1.0.33 <2.0.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "dependencies": {
         "isarray": {
-          "version": "0.0.1"
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         }
       }
     },
     "readdirp": {
       "version": "2.1.0",
+      "from": "readdirp@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "dependencies": {
         "minimatch": {
-          "version": "3.0.3"
+          "version": "3.0.3",
+          "from": "minimatch@>=3.0.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
         },
         "readable-stream": {
-          "version": "2.2.2"
+          "version": "2.2.2",
+          "from": "readable-stream@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
         }
       }
     },
     "readline2": {
       "version": "1.0.1",
+      "from": "readline2@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "dev": true
     },
     "recast": {
       "version": "0.11.18",
+      "from": "recast@>=0.11.12 <0.12.0",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.18.tgz",
       "dependencies": {
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         }
       }
     },
     "redent": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "redent@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz"
     },
     "reduce-component": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "reduce-component@1.0.1",
+      "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz"
     },
     "redux": {
-      "version": "3.0.4"
+      "version": "3.0.4",
+      "from": "redux@3.0.4",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-3.0.4.tgz"
     },
     "redux-thunk": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "redux-thunk@1.0.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-1.0.0.tgz"
     },
     "regenerate": {
-      "version": "1.3.2"
+      "version": "1.3.2",
+      "from": "regenerate@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
     },
     "regenerator-runtime": {
-      "version": "0.10.1"
+      "version": "0.10.1",
+      "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz"
     },
     "regenerator-transform": {
-      "version": "0.9.8"
+      "version": "0.9.8",
+      "from": "regenerator-transform@0.9.8",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.8.tgz"
     },
     "regex-cache": {
-      "version": "0.4.3"
+      "version": "0.4.3",
+      "from": "regex-cache@>=0.4.2 <0.5.0",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
     },
     "regexp-quote": {
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "from": "regexp-quote@0.0.0",
+      "resolved": "https://registry.npmjs.org/regexp-quote/-/regexp-quote-0.0.0.tgz"
     },
     "regexpu-core": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "regexpu-core@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz"
     },
     "registry-url": {
       "version": "3.1.0",
+      "from": "registry-url@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "dev": true
     },
     "regjsgen": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "from": "regjsgen@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
     },
     "regjsparser": {
       "version": "0.1.5",
+      "from": "regjsparser@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "dependencies": {
         "jsesc": {
-          "version": "0.5.0"
+          "version": "0.5.0",
+          "from": "jsesc@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
         }
       }
     },
     "relateurl": {
-      "version": "0.2.7"
+      "version": "0.2.7",
+      "from": "relateurl@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz"
     },
     "repeat-element": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "from": "repeat-element@>=1.1.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
     },
     "repeat-string": {
-      "version": "1.6.1"
+      "version": "1.6.1",
+      "from": "repeat-string@>=1.5.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
     },
     "repeating": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "from": "repeating@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
     },
     "request": {
       "version": "2.79.0",
+      "from": "request@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
       "dependencies": {
         "qs": {
-          "version": "6.3.0"
+          "version": "6.3.0",
+          "from": "qs@>=6.3.0 <6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
         },
         "uuid": {
-          "version": "3.0.1"
+          "version": "3.0.1",
+          "from": "uuid@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
         }
       }
     },
     "require-directory": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "from": "require-directory@>=2.1.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
     },
     "require-from-string": {
       "version": "1.2.1",
+      "from": "require-from-string@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
       "dev": true
     },
     "require-main-filename": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "require-main-filename@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
     },
     "require-uncached": {
       "version": "1.0.3",
+      "from": "require-uncached@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "dev": true
     },
     "requireindex": {
       "version": "1.1.0",
+      "from": "requireindex@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
       "dev": true
     },
     "requires-port": {
       "version": "1.0.0",
+      "from": "requires-port@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "dev": true
     },
     "resolve": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "from": "resolve@>=1.1.6 <2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz"
     },
     "resolve-from": {
       "version": "1.0.1",
+      "from": "resolve-from@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
       "dev": true
     },
     "restore-cursor": {
       "version": "1.0.1",
+      "from": "restore-cursor@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "dev": true
     },
     "right-align": {
-      "version": "0.1.3"
+      "version": "0.1.3",
+      "from": "right-align@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
     },
     "rimraf": {
       "version": "2.5.4",
+      "from": "rimraf@>=2.2.8 <3.0.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
       "dependencies": {
         "glob": {
-          "version": "7.1.1"
+          "version": "7.1.1",
+          "from": "glob@>=7.0.5 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
         },
         "minimatch": {
-          "version": "3.0.3"
+          "version": "3.0.3",
+          "from": "minimatch@>=3.0.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
         }
       }
     },
     "ripemd160": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "from": "ripemd160@0.2.0",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
     },
     "rocambole": {
       "version": "0.7.0",
+      "from": "rocambole@>=0.6.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.7.0.tgz",
       "dev": true,
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
+          "from": "esprima@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
           "dev": true
         }
       }
     },
     "rocambole-indent": {
       "version": "2.0.4",
+      "from": "rocambole-indent@>=2.0.4 <3.0.0",
+      "resolved": "https://registry.npmjs.org/rocambole-indent/-/rocambole-indent-2.0.4.tgz",
       "dev": true,
       "dependencies": {
         "mout": {
           "version": "0.11.1",
+          "from": "mout@>=0.11.0 <0.12.0",
+          "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
           "dev": true
         }
       }
     },
     "rocambole-linebreak": {
       "version": "1.0.2",
+      "from": "rocambole-linebreak@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/rocambole-linebreak/-/rocambole-linebreak-1.0.2.tgz",
       "dev": true,
       "dependencies": {
         "semver": {
           "version": "4.3.6",
+          "from": "semver@>=4.3.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "dev": true
         }
       }
     },
     "rocambole-node": {
       "version": "1.0.0",
+      "from": "rocambole-node@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/rocambole-node/-/rocambole-node-1.0.0.tgz",
       "dev": true
     },
     "rocambole-token": {
       "version": "1.2.1",
+      "from": "rocambole-token@>=1.1.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/rocambole-token/-/rocambole-token-1.2.1.tgz",
       "dev": true
     },
     "rocambole-whitespace": {
       "version": "1.0.0",
+      "from": "rocambole-whitespace@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/rocambole-whitespace/-/rocambole-whitespace-1.0.0.tgz",
       "dev": true
     },
     "rtlcss": {
       "version": "2.0.5",
+      "from": "rtlcss@2.0.5",
+      "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-2.0.5.tgz",
       "dependencies": {
         "strip-json-comments": {
-          "version": "2.0.1"
+          "version": "2.0.1",
+          "from": "strip-json-comments@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
         }
       }
     },
     "run-async": {
       "version": "0.1.0",
+      "from": "run-async@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "dev": true
     },
     "rx-lite": {
       "version": "3.1.2",
+      "from": "rx-lite@>=3.1.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
       "dev": true
     },
     "samsam": {
       "version": "1.1.2",
+      "from": "samsam@1.1.2",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
       "dev": true
     },
     "sanitize-html": {
-      "version": "1.11.1"
+      "version": "1.11.1",
+      "from": "sanitize-html@1.11.1",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.11.1.tgz"
     },
     "sass-graph": {
       "version": "2.1.2",
+      "from": "sass-graph@>=2.1.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.1.2.tgz",
       "dependencies": {
         "cliui": {
-          "version": "3.2.0"
+          "version": "3.2.0",
+          "from": "cliui@>=3.2.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz"
         },
         "window-size": {
-          "version": "0.2.0"
+          "version": "0.2.0",
+          "from": "window-size@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz"
         },
         "yargs": {
-          "version": "4.8.1"
+          "version": "4.8.1",
+          "from": "yargs@>=4.7.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz"
         }
       }
     },
     "sax": {
       "version": "1.2.1",
+      "from": "sax@>=1.1.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "dev": true
     },
     "seed-random": {
-      "version": "2.2.0"
+      "version": "2.2.0",
+      "from": "seed-random@2.2.0",
+      "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz"
     },
     "select": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "select@>=1.0.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.0.tgz"
     },
     "semver": {
-      "version": "5.1.0"
+      "version": "5.1.0",
+      "from": "semver@5.1.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
     },
     "semver-diff": {
       "version": "2.1.0",
+      "from": "semver-diff@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "dev": true
     },
     "send": {
       "version": "0.13.0",
+      "from": "send@0.13.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.13.0.tgz",
       "dependencies": {
         "depd": {
-          "version": "1.0.1"
+          "version": "1.0.1",
+          "from": "depd@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
         },
         "http-errors": {
-          "version": "1.3.1"
+          "version": "1.3.1",
+          "from": "http-errors@>=1.3.1 <1.4.0",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
         },
         "statuses": {
-          "version": "1.2.1"
+          "version": "1.2.1",
+          "from": "statuses@>=1.2.1 <1.3.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
         }
       }
     },
     "sentence-case": {
-      "version": "1.1.3"
+      "version": "1.1.3",
+      "from": "sentence-case@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz"
     },
     "serializerr": {
       "version": "1.0.3",
+      "from": "serializerr@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/serializerr/-/serializerr-1.0.3.tgz",
       "dev": true
     },
     "serve-index": {
       "version": "1.8.0",
+      "from": "serve-index@>=1.7.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz",
       "dev": true,
       "dependencies": {
         "accepts": {
           "version": "1.3.3",
+          "from": "accepts@>=1.3.3 <1.4.0",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "dev": true
         },
         "escape-html": {
           "version": "1.0.3",
+          "from": "escape-html@>=1.0.3 <1.1.0",
+          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "dev": true
         },
         "negotiator": {
           "version": "0.6.1",
+          "from": "negotiator@0.6.1",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
           "dev": true
         }
       }
     },
     "serve-static": {
       "version": "1.10.3",
+      "from": "serve-static@>=1.10.0 <1.11.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
       "dependencies": {
         "destroy": {
-          "version": "1.0.4"
+          "version": "1.0.4",
+          "from": "destroy@>=1.0.4 <1.1.0",
+          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
         },
         "escape-html": {
-          "version": "1.0.3"
+          "version": "1.0.3",
+          "from": "escape-html@>=1.0.3 <1.1.0",
+          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
         },
         "http-errors": {
-          "version": "1.3.1"
+          "version": "1.3.1",
+          "from": "http-errors@>=1.3.1 <1.4.0",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
         },
         "send": {
-          "version": "0.13.2"
+          "version": "0.13.2",
+          "from": "send@0.13.2",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz"
         },
         "statuses": {
-          "version": "1.2.1"
+          "version": "1.2.1",
+          "from": "statuses@>=1.2.1 <1.3.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
         }
       }
     },
     "set-blocking": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "set-blocking@>=2.0.0 <2.1.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
     },
     "set-immediate-shim": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "set-immediate-shim@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
     },
     "setimmediate": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "from": "setimmediate@>=1.0.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
     },
     "setprototypeof": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "setprototypeof@1.0.2",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz"
     },
     "sha.js": {
-      "version": "2.2.6"
+      "version": "2.2.6",
+      "from": "sha.js@2.2.6",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
     },
     "shebang-regex": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "shebang-regex@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
     },
     "shelljs": {
       "version": "0.6.1",
+      "from": "shelljs@>=0.6.0 <0.7.0",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
       "dev": true
     },
     "sigmund": {
       "version": "1.0.1",
+      "from": "sigmund@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.2"
+      "version": "3.0.2",
+      "from": "signal-exit@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
     },
     "simple-get": {
-      "version": "1.4.3"
+      "version": "1.4.3",
+      "from": "simple-get@>=1.4.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz"
     },
     "simple-mime": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "from": "simple-mime@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/simple-mime/-/simple-mime-0.1.0.tgz"
     },
     "sinon": {
       "version": "1.17.6",
+      "from": "sinon@1.17.6",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.6.tgz",
       "dev": true
     },
     "sinon-chai": {
       "version": "2.8.0",
+      "from": "sinon-chai@2.8.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.8.0.tgz",
       "dev": true
     },
     "slash": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "slash@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
     },
     "slice-ansi": {
       "version": "0.0.4",
+      "from": "slice-ansi@0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "dev": true
     },
     "snake-case": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "from": "snake-case@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz"
     },
     "sntp": {
-      "version": "1.0.9"
+      "version": "1.0.9",
+      "from": "sntp@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
     },
     "social-logos": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "social-logos@1.0.1",
+      "resolved": "https://registry.npmjs.org/social-logos/-/social-logos-1.0.1.tgz"
     },
     "socket.io": {
       "version": "1.4.5",
+      "from": "socket.io@1.4.5",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.4.5.tgz",
       "dev": true
     },
     "socket.io-adapter": {
       "version": "0.4.0",
+      "from": "socket.io-adapter@0.4.0",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
       "dev": true,
       "dependencies": {
         "component-emitter": {
           "version": "1.1.2",
+          "from": "component-emitter@1.1.2",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
           "dev": true
         },
         "isarray": {
           "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "dev": true
         },
         "json3": {
           "version": "3.2.6",
+          "from": "json3@3.2.6",
+          "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
           "dev": true
         },
         "socket.io-parser": {
           "version": "2.2.2",
+          "from": "socket.io-parser@2.2.2",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
           "dev": true,
           "dependencies": {
             "debug": {
               "version": "0.7.4",
+              "from": "debug@0.7.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
               "dev": true
             }
           }
@@ -3615,532 +6458,840 @@
       }
     },
     "socket.io-client": {
-      "version": "1.4.5"
+      "version": "1.4.5",
+      "from": "socket.io-client@1.4.5",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.4.5.tgz"
     },
     "socket.io-parser": {
       "version": "2.2.6",
+      "from": "socket.io-parser@2.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
       "dependencies": {
         "component-emitter": {
-          "version": "1.1.2"
+          "version": "1.1.2",
+          "from": "component-emitter@1.1.2",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
         },
         "isarray": {
-          "version": "0.0.1"
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         }
       }
     },
     "sortobject": {
       "version": "1.1.1",
+      "from": "sortobject@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sortobject/-/sortobject-1.1.1.tgz",
       "dev": true
     },
     "source-list-map": {
-      "version": "0.1.8"
+      "version": "0.1.8",
+      "from": "source-list-map@0.1.8",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz"
     },
     "source-map": {
-      "version": "0.1.39"
+      "version": "0.1.39",
+      "from": "source-map@0.1.39",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.39.tgz"
     },
     "source-map-loader": {
-      "version": "0.1.5"
+      "version": "0.1.5",
+      "from": "source-map-loader@0.1.5",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.1.5.tgz"
     },
     "source-map-support": {
       "version": "0.3.2",
+      "from": "source-map-support@0.3.2",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.2.tgz",
       "dependencies": {
         "source-map": {
-          "version": "0.1.32"
+          "version": "0.1.32",
+          "from": "source-map@0.1.32",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz"
         }
       }
     },
     "spdx-correct": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "spdx-correct@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
     },
     "spdx-expression-parse": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
     },
     "spdx-license-ids": {
-      "version": "1.2.2"
+      "version": "1.2.2",
+      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
     },
     "specificity": {
       "version": "0.2.1",
+      "from": "specificity@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.2.1.tgz",
       "dev": true
     },
     "split2": {
       "version": "0.2.1",
+      "from": "split2@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-0.2.1.tgz",
       "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
+      "from": "sprintf-js@>=1.0.2 <1.1.0",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "dev": true
     },
     "sshpk": {
       "version": "1.10.2",
+      "from": "sshpk@1.10.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "statuses": {
-      "version": "1.3.1"
+      "version": "1.3.1",
+      "from": "statuses@>=1.3.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
     },
     "stdin": {
       "version": "0.0.1",
+      "from": "stdin@*",
+      "resolved": "https://registry.npmjs.org/stdin/-/stdin-0.0.1.tgz",
       "dev": true
     },
     "store": {
-      "version": "1.3.16"
+      "version": "1.3.16",
+      "from": "store@1.3.16",
+      "resolved": "https://registry.npmjs.org/store/-/store-1.3.16.tgz"
     },
     "stream-browserify": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "stream-browserify@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
     },
     "stream-cache": {
       "version": "0.0.2",
+      "from": "stream-cache@>=0.0.1 <0.1.0",
+      "resolved": "https://registry.npmjs.org/stream-cache/-/stream-cache-0.0.2.tgz",
       "dev": true
     },
     "stream-combiner": {
       "version": "0.2.2",
+      "from": "stream-combiner@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
       "dev": true
     },
     "stream-shift": {
       "version": "1.0.0",
+      "from": "stream-shift@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "dev": true
     },
     "string_decoder": {
-      "version": "0.10.31"
+      "version": "0.10.31",
+      "from": "string_decoder@>=0.10.0 <0.11.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
     },
     "string-length": {
       "version": "1.0.1",
+      "from": "string-length@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
       "dev": true
     },
     "string-width": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "string-width@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
     },
     "stringify-object": {
       "version": "2.4.0",
+      "from": "stringify-object@>=2.3.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-2.4.0.tgz",
       "dev": true
     },
     "stringstream": {
-      "version": "0.0.5"
+      "version": "0.0.5",
+      "from": "stringstream@>=0.0.4 <0.1.0",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
     },
     "strip-ansi": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "from": "strip-ansi@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
     },
     "strip-bom": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "strip-bom@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
     },
     "strip-indent": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "strip-indent@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
     },
     "strip-json-comments": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "from": "strip-json-comments@>=1.0.4 <1.1.0",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
     },
     "striptags": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "from": "striptags@2.1.1",
+      "resolved": "https://registry.npmjs.org/striptags/-/striptags-2.1.1.tgz"
     },
     "stylehacks": {
       "version": "2.3.1",
+      "from": "stylehacks@>=2.3.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-2.3.1.tgz",
       "dev": true,
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
+          "from": "chalk@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dev": true
         },
         "minimist": {
           "version": "1.2.0",
+          "from": "minimist@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
+          "from": "supports-color@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "dev": true
         }
       }
     },
     "stylelint": {
       "version": "6.9.0",
+      "from": "stylelint@>=6.5.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-6.9.0.tgz",
       "dev": true,
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
+          "from": "chalk@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dev": true
         },
         "entities": {
           "version": "1.1.1",
+          "from": "entities@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
           "dev": true
         },
         "get-stdin": {
           "version": "5.0.1",
+          "from": "get-stdin@>=5.0.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
           "dev": true
         },
         "globby": {
           "version": "5.0.0",
+          "from": "globby@>=5.0.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
           "dev": true
         },
         "htmlparser2": {
           "version": "3.9.2",
+          "from": "htmlparser2@>=3.9.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
           "dev": true
         },
         "readable-stream": {
           "version": "2.2.2",
+          "from": "readable-stream@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
+          "from": "resolve-from@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
+          "from": "supports-color@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "dev": true
         }
       }
     },
     "sugarss": {
       "version": "0.1.6",
+      "from": "sugarss@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-0.1.6.tgz",
       "dev": true
     },
     "superagent": {
       "version": "2.1.0",
+      "from": "superagent@2.1.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-2.1.0.tgz",
       "dependencies": {
         "async": {
-          "version": "1.5.2"
+          "version": "1.5.2",
+          "from": "async@>=1.5.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "form-data": {
-          "version": "1.0.0-rc4"
+          "version": "1.0.0-rc4",
+          "from": "form-data@1.0.0-rc4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
         },
         "qs": {
-          "version": "6.3.0"
+          "version": "6.3.0",
+          "from": "qs@>=6.1.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
         },
         "readable-stream": {
-          "version": "2.2.2"
+          "version": "2.2.2",
+          "from": "readable-stream@>=2.0.5 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
         }
       }
     },
     "supertest": {
       "version": "2.0.0",
+      "from": "supertest@2.0.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-2.0.0.tgz",
       "dev": true
     },
     "supports-color": {
-      "version": "3.2.3"
+      "version": "3.2.3",
+      "from": "supports-color@3.2.3",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
     },
     "svg-tags": {
       "version": "1.0.0",
+      "from": "svg-tags@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
       "dev": true
     },
     "swap-case": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "from": "swap-case@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz"
     },
     "symbol-tree": {
       "version": "3.2.1",
+      "from": "symbol-tree@>=3.1.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.1.tgz",
       "dev": true
     },
     "sync-exec": {
       "version": "0.5.0",
+      "from": "sync-exec@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/sync-exec/-/sync-exec-0.5.0.tgz",
       "dev": true
     },
     "synesthesia": {
       "version": "1.0.1",
+      "from": "synesthesia@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/synesthesia/-/synesthesia-1.0.1.tgz",
       "dev": true
     },
     "table": {
       "version": "3.8.3",
+      "from": "table@>=3.7.8 <4.0.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "dev": true,
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
+          "from": "chalk@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
+          "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "dev": true
         },
         "string-width": {
           "version": "2.0.0",
+          "from": "string-width@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
+          "from": "supports-color@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "dev": true
         }
       }
     },
     "tapable": {
-      "version": "0.1.10"
+      "version": "0.1.10",
+      "from": "tapable@>=0.1.8 <0.2.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
     },
     "tar": {
-      "version": "2.2.1"
+      "version": "2.2.1",
+      "from": "tar@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
     },
     "tar-fs": {
-      "version": "1.15.0"
+      "version": "1.15.0",
+      "from": "tar-fs@>=1.7.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.0.tgz"
     },
     "tar-stream": {
       "version": "1.5.2",
+      "from": "tar-stream@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
       "dependencies": {
         "readable-stream": {
-          "version": "2.2.2"
+          "version": "2.2.2",
+          "from": "readable-stream@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
         }
       }
     },
     "text-table": {
       "version": "0.2.0",
+      "from": "text-table@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "dev": true
     },
     "through": {
-      "version": "2.3.8"
+      "version": "2.3.8",
+      "from": "through@>=2.3.6 <2.4.0",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "through2": {
       "version": "0.6.5",
+      "from": "through2@>=0.6.3 <0.7.0",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
       "dependencies": {
         "isarray": {
-          "version": "0.0.1"
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "readable-stream": {
-          "version": "1.0.34"
+          "version": "1.0.34",
+          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         }
       }
     },
     "timed-out": {
       "version": "2.0.0",
+      "from": "timed-out@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
       "dev": true
     },
     "timers-browserify": {
-      "version": "1.4.2"
+      "version": "1.4.2",
+      "from": "timers-browserify@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
     },
     "tiny-emitter": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "tiny-emitter@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-1.1.0.tgz"
     },
     "tinymce": {
-      "version": "4.3.12"
+      "version": "4.3.12",
+      "from": "tinymce@4.3.12",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-4.3.12.tgz"
     },
     "title-case": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "from": "title-case@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.2.tgz"
     },
     "title-case-minors": {
-      "version": "0.0.2"
+      "version": "0.0.2",
+      "from": "title-case-minors@0.0.2",
+      "resolved": "https://registry.npmjs.org/title-case-minors/-/title-case-minors-0.0.2.tgz"
     },
     "to-array": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "from": "to-array@0.1.4",
+      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz"
     },
     "to-camel-case": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "to-camel-case@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/to-camel-case/-/to-camel-case-1.0.0.tgz"
     },
     "to-capital-case": {
       "version": "0.1.1",
+      "from": "to-capital-case@0.1.1",
+      "resolved": "https://registry.npmjs.org/to-capital-case/-/to-capital-case-0.1.1.tgz",
       "dependencies": {
         "to-no-case": {
-          "version": "0.1.1"
+          "version": "0.1.1",
+          "from": "to-no-case@0.1.1",
+          "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-0.1.1.tgz"
         }
       }
     },
     "to-fast-properties": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
     },
     "to-no-case": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "to-no-case@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz"
     },
     "to-space-case": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "to-space-case@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz"
     },
     "to-title-case": {
-      "version": "0.1.5"
+      "version": "0.1.5",
+      "from": "to-title-case@0.1.5",
+      "resolved": "https://registry.npmjs.org/to-title-case/-/to-title-case-0.1.5.tgz"
     },
     "token-stream": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "from": "token-stream@0.0.1",
+      "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-0.0.1.tgz"
     },
     "touch": {
       "version": "1.0.0",
+      "from": "touch@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
       "dev": true,
       "dependencies": {
         "nopt": {
           "version": "1.0.10",
+          "from": "nopt@>=1.0.10 <1.1.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dev": true
         }
       }
     },
     "tough-cookie": {
-      "version": "2.3.2"
+      "version": "2.3.2",
+      "from": "tough-cookie@>=2.3.0 <2.4.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
     },
     "tr46": {
       "version": "0.0.3",
+      "from": "tr46@>=0.0.3 <0.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "dev": true
     },
     "tracekit": {
-      "version": "0.4.3"
+      "version": "0.4.3",
+      "from": "tracekit@0.4.3",
+      "resolved": "https://registry.npmjs.org/tracekit/-/tracekit-0.4.3.tgz"
     },
     "traverse": {
       "version": "0.6.6",
+      "from": "traverse@>=0.6.6 <0.7.0",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "dev": true
     },
     "trim-newlines": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "trim-newlines@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
     },
     "tryit": {
       "version": "1.0.3",
+      "from": "tryit@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
       "dev": true
     },
     "tty-browserify": {
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "from": "tty-browserify@0.0.0",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
     },
     "tunnel-agent": {
-      "version": "0.4.3"
+      "version": "0.4.3",
+      "from": "tunnel-agent@>=0.4.1 <0.5.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
     },
     "tween.js": {
-      "version": "16.3.1"
+      "version": "16.3.1",
+      "from": "tween.js@16.3.1",
+      "resolved": "https://registry.npmjs.org/tween.js/-/tween.js-16.3.1.tgz"
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "from": "tweetnacl@>=0.14.0 <0.15.0",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "optional": true
     },
     "twemoji": {
-      "version": "1.3.2"
+      "version": "1.3.2",
+      "from": "twemoji@1.3.2",
+      "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-1.3.2.tgz"
     },
     "type-check": {
       "version": "0.3.2",
+      "from": "type-check@>=0.3.2 <0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "dev": true
     },
     "type-detect": {
       "version": "1.0.0",
+      "from": "type-detect@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
       "dev": true
     },
     "type-is": {
-      "version": "1.6.14"
+      "version": "1.6.14",
+      "from": "type-is@>=1.6.13 <1.7.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz"
     },
     "typedarray": {
-      "version": "0.0.6"
+      "version": "0.0.6",
+      "from": "typedarray@>=0.0.5 <0.1.0",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
     "ua-parser-js": {
-      "version": "0.7.12"
+      "version": "0.7.12",
+      "from": "ua-parser-js@>=0.7.9 <0.8.0",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz"
     },
     "uglify-js": {
       "version": "2.7.0",
+      "from": "uglify-js@2.7.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.0.tgz",
       "dependencies": {
         "async": {
-          "version": "0.2.10"
+          "version": "0.2.10",
+          "from": "async@>=0.2.6 <0.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         }
       }
     },
     "uglify-to-browserify": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
     },
     "uid": {
-      "version": "0.0.2"
+      "version": "0.0.2",
+      "from": "uid@0.0.2",
+      "resolved": "https://registry.npmjs.org/uid/-/uid-0.0.2.tgz"
     },
     "ultron": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "ultron@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
     },
     "uniq": {
       "version": "1.0.1",
+      "from": "uniq@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "dev": true
     },
     "unpipe": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "unpipe@1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
     },
     "unquoted-property-validator": {
       "version": "1.0.0",
+      "from": "unquoted-property-validator@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/unquoted-property-validator/-/unquoted-property-validator-1.0.0.tgz",
       "dev": true
     },
     "unreachable-branch-transform": {
       "version": "0.3.0",
+      "from": "unreachable-branch-transform@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.3.0.tgz",
       "dependencies": {
         "ast-types": {
-          "version": "0.8.15"
+          "version": "0.8.15",
+          "from": "ast-types@0.8.15",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz"
         },
         "esprima-fb": {
-          "version": "15001.1001.0-dev-harmony-fb"
+          "version": "15001.1001.0-dev-harmony-fb",
+          "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
         },
         "recast": {
-          "version": "0.10.43"
+          "version": "0.10.43",
+          "from": "recast@>=0.10.1 <0.11.0",
+          "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz"
         },
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         }
       }
     },
     "unzip-response": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "unzip-response@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz"
     },
     "update-notifier": {
       "version": "0.3.2",
+      "from": "update-notifier@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.3.2.tgz",
       "dev": true
     },
     "upper-case": {
-      "version": "1.1.3"
+      "version": "1.1.3",
+      "from": "upper-case@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz"
     },
     "upper-case-first": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "from": "upper-case-first@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz"
     },
     "uppercamelcase": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "uppercamelcase@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/uppercamelcase/-/uppercamelcase-1.1.0.tgz"
     },
     "url": {
       "version": "0.10.3",
+      "from": "url@>=0.10.1 <0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
       "dependencies": {
         "punycode": {
-          "version": "1.3.2"
+          "version": "1.3.2",
+          "from": "punycode@1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
         }
       }
     },
     "url-template": {
-      "version": "2.0.8"
+      "version": "2.0.8",
+      "from": "url-template@>=2.0.6 <2.1.0",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz"
     },
     "user-home": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "from": "user-home@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
     },
     "utf8": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "from": "utf8@2.1.0",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz"
     },
     "util": {
-      "version": "0.10.3"
+      "version": "0.10.3",
+      "from": "util@>=0.10.3 <0.11.0",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
     },
     "util-deprecate": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "util-deprecate@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
     },
     "util-extend": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "from": "util-extend@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz"
     },
     "utils-merge": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "utils-merge@1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
     },
     "uuid": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "from": "uuid@2.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
     },
     "valid-url": {
-      "version": "1.0.9"
+      "version": "1.0.9",
+      "from": "valid-url@1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz"
     },
     "validate-npm-package-license": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
     },
     "vary": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "vary@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
     },
     "verror": {
-      "version": "1.3.6"
+      "version": "1.3.6",
+      "from": "verror@1.3.6",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
     },
     "vm-browserify": {
-      "version": "0.0.4"
+      "version": "0.0.4",
+      "from": "vm-browserify@0.0.4",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
     },
     "void-elements": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "from": "void-elements@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz"
     },
     "walk": {
-      "version": "2.3.4"
+      "version": "2.3.4",
+      "from": "walk@2.3.4",
+      "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.4.tgz"
     },
     "watchpack": {
-      "version": "0.2.9"
+      "version": "0.2.9",
+      "from": "watchpack@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz"
     },
     "webidl-conversions": {
       "version": "3.0.1",
+      "from": "webidl-conversions@>=3.0.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "dev": true
     },
     "webpack": {
       "version": "1.13.1",
+      "from": "webpack@1.13.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.13.1.tgz",
       "dependencies": {
         "async": {
-          "version": "1.5.2"
+          "version": "1.5.2",
+          "from": "async@>=1.3.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         },
         "uglify-js": {
           "version": "2.6.4",
+          "from": "uglify-js@>=2.6.0 <2.7.0",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
           "dependencies": {
             "async": {
-              "version": "0.2.10"
+              "version": "0.2.10",
+              "from": "async@>=0.2.6 <0.3.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             }
           }
         }
@@ -4148,397 +7299,610 @@
     },
     "webpack-bundle-analyzer": {
       "version": "2.2.1",
+      "from": "webpack-bundle-analyzer@2.2.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.2.1.tgz",
       "dev": true,
       "dependencies": {
         "accepts": {
           "version": "1.3.3",
+          "from": "accepts@1.3.3",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "dev": true
         },
         "acorn": {
           "version": "4.0.4",
+          "from": "acorn@4.0.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
+          "from": "chalk@1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dev": true
         },
         "commander": {
           "version": "2.9.0",
+          "from": "commander@2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "dev": true
         },
         "content-disposition": {
           "version": "0.5.1",
+          "from": "content-disposition@0.5.1",
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
           "dev": true
         },
         "cookie": {
           "version": "0.3.1",
+          "from": "cookie@0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
           "dev": true
         },
         "cookie-signature": {
           "version": "1.0.6",
+          "from": "cookie-signature@1.0.6",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
           "dev": true
         },
         "destroy": {
           "version": "1.0.4",
+          "from": "destroy@1.0.4",
+          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
           "dev": true
         },
         "escape-html": {
           "version": "1.0.3",
+          "from": "escape-html@1.0.3",
+          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "dev": true
         },
         "express": {
           "version": "4.14.0",
+          "from": "express@4.14.0",
+          "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
           "dev": true
         },
         "filesize": {
           "version": "3.3.0",
+          "from": "filesize@3.3.0",
+          "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.3.0.tgz",
           "dev": true
         },
         "finalhandler": {
           "version": "0.5.0",
+          "from": "finalhandler@0.5.0",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
           "dev": true
         },
         "ipaddr.js": {
           "version": "1.2.0",
+          "from": "ipaddr.js@1.2.0",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz",
           "dev": true
         },
         "lodash": {
           "version": "4.17.4",
+          "from": "lodash@4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "dev": true
         },
         "merge-descriptors": {
           "version": "1.0.1",
+          "from": "merge-descriptors@1.0.1",
+          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "dev": true
         },
         "negotiator": {
           "version": "0.6.1",
+          "from": "negotiator@0.6.1",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
           "dev": true
         },
         "proxy-addr": {
           "version": "1.1.3",
+          "from": "proxy-addr@1.1.3",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.3.tgz",
           "dev": true
         },
         "qs": {
           "version": "6.2.0",
+          "from": "qs@6.2.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
           "dev": true
         },
         "range-parser": {
           "version": "1.2.0",
+          "from": "range-parser@1.2.0",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
           "dev": true
         },
         "send": {
           "version": "0.14.1",
+          "from": "send@0.14.1",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
           "dev": true
         },
         "serve-static": {
           "version": "1.11.1",
+          "from": "serve-static@1.11.1",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
+          "from": "supports-color@2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "dev": true
         },
         "vary": {
           "version": "1.1.0",
+          "from": "vary@1.1.0",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
           "dev": true
         }
       }
     },
     "webpack-core": {
       "version": "0.6.9",
+      "from": "webpack-core@>=0.6.0 <0.7.0",
+      "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
       "dependencies": {
         "source-map": {
-          "version": "0.4.4"
+          "version": "0.4.4",
+          "from": "source-map@>=0.4.1 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
         }
       }
     },
     "webpack-dashboard": {
       "version": "0.2.0",
+      "from": "webpack-dashboard@0.2.0",
+      "resolved": "https://registry.npmjs.org/webpack-dashboard/-/webpack-dashboard-0.2.0.tgz",
       "dev": true,
       "dependencies": {
         "accepts": {
           "version": "1.3.3",
+          "from": "accepts@1.3.3",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "dev": true
         },
         "base64-arraybuffer": {
           "version": "0.1.5",
+          "from": "base64-arraybuffer@0.1.5",
+          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
           "dev": true
         },
         "base64id": {
           "version": "1.0.0",
+          "from": "base64id@1.0.0",
+          "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
           "dev": true
         },
         "commander": {
           "version": "2.9.0",
+          "from": "commander@>=2.9.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "dev": true
         },
         "component-emitter": {
           "version": "1.1.2",
+          "from": "component-emitter@1.1.2",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
           "dev": true
         },
         "cookie": {
           "version": "0.3.1",
+          "from": "cookie@0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
           "dev": true
         },
         "debug": {
           "version": "2.3.3",
+          "from": "debug@2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "dev": true
         },
         "engine.io": {
           "version": "1.8.2",
+          "from": "engine.io@1.8.2",
+          "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.2.tgz",
           "dev": true
         },
         "engine.io-client": {
           "version": "1.8.2",
+          "from": "engine.io-client@1.8.2",
+          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.2.tgz",
           "dev": true,
           "dependencies": {
             "component-emitter": {
               "version": "1.2.1",
+              "from": "component-emitter@1.2.1",
+              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
               "dev": true
             }
           }
         },
         "engine.io-parser": {
           "version": "1.3.2",
+          "from": "engine.io-parser@1.3.2",
+          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
           "dev": true
         },
         "filesize": {
           "version": "3.3.0",
+          "from": "filesize@>=3.3.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.3.0.tgz",
           "dev": true
         },
         "isarray": {
           "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "dev": true
         },
         "ms": {
           "version": "0.7.2",
+          "from": "ms@0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
           "dev": true
         },
         "negotiator": {
           "version": "0.6.1",
+          "from": "negotiator@0.6.1",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.0",
+          "from": "object-assign@4.1.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "dev": true
         },
         "parsejson": {
           "version": "0.0.3",
+          "from": "parsejson@0.0.3",
+          "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
           "dev": true
         },
         "parseqs": {
           "version": "0.0.5",
+          "from": "parseqs@0.0.5",
+          "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
           "dev": true
         },
         "parseuri": {
           "version": "0.0.5",
+          "from": "parseuri@0.0.5",
+          "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
           "dev": true
         },
         "socket.io": {
           "version": "1.7.2",
+          "from": "socket.io@>=1.4.8 <2.0.0",
+          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.2.tgz",
           "dev": true
         },
         "socket.io-adapter": {
           "version": "0.5.0",
+          "from": "socket.io-adapter@0.5.0",
+          "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
           "dev": true
         },
         "socket.io-client": {
           "version": "1.7.2",
+          "from": "socket.io-client@>=1.4.8 <2.0.0",
+          "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.2.tgz",
           "dev": true,
           "dependencies": {
             "component-emitter": {
               "version": "1.2.1",
+              "from": "component-emitter@1.2.1",
+              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
               "dev": true
             }
           }
         },
         "socket.io-parser": {
           "version": "2.3.1",
+          "from": "socket.io-parser@2.3.1",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
           "dev": true,
           "dependencies": {
             "debug": {
               "version": "2.2.0",
+              "from": "debug@2.2.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dev": true
             },
             "ms": {
               "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "dev": true
             }
           }
         },
         "ws": {
           "version": "1.1.1",
+          "from": "ws@1.1.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
           "dev": true
         },
         "xmlhttprequest-ssl": {
           "version": "1.5.3",
+          "from": "xmlhttprequest-ssl@1.5.3",
+          "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
           "dev": true
         }
       }
     },
     "webpack-dev-middleware": {
       "version": "1.2.0",
+      "from": "webpack-dev-middleware@1.2.0",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.2.0.tgz",
       "dependencies": {
         "memory-fs": {
-          "version": "0.2.0"
+          "version": "0.2.0",
+          "from": "memory-fs@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
         }
       }
     },
     "webpack-dev-server": {
       "version": "1.11.0",
+      "from": "webpack-dev-server@1.11.0",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.11.0.tgz",
       "dev": true
     },
     "webpack-sources": {
       "version": "0.1.4",
+      "from": "webpack-sources@0.1.4",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.4.tgz",
       "dependencies": {
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.3 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         }
       }
     },
     "wemoji": {
-      "version": "0.1.9"
+      "version": "0.1.9",
+      "from": "wemoji@>=0.1.9 <0.2.0",
+      "resolved": "https://registry.npmjs.org/wemoji/-/wemoji-0.1.9.tgz"
     },
     "whatwg-fetch": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "from": "whatwg-fetch@>=0.10.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.1.tgz"
     },
     "whatwg-url": {
       "version": "3.1.0",
+      "from": "whatwg-url@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-3.1.0.tgz",
       "dev": true
     },
+    "whatwg-url-compat": {
+      "version": "0.6.5",
+      "from": "whatwg-url-compat@>=0.6.5 <0.7.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz",
+      "dev": true,
+      "optional": true
+    },
     "which": {
-      "version": "1.2.12"
+      "version": "1.2.12",
+      "from": "which@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz"
     },
     "which-module": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "which-module@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
     },
     "wide-align": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "from": "wide-align@1.1.0",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
     },
     "window-size": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "from": "window-size@0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
     },
     "with": {
-      "version": "5.1.1"
+      "version": "5.1.1",
+      "from": "with@>=5.0.0 <6.0.0",
+      "resolved": "https://registry.npmjs.org/with/-/with-5.1.1.tgz"
     },
     "wordwrap": {
-      "version": "0.0.2"
+      "version": "0.0.2",
+      "from": "wordwrap@0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
     },
     "wp-error": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "from": "wp-error@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/wp-error/-/wp-error-1.3.0.tgz"
     },
     "wpcom": {
-      "version": "5.3.0"
+      "version": "5.3.0",
+      "from": "wpcom@5.3.0",
+      "resolved": "https://registry.npmjs.org/wpcom/-/wpcom-5.3.0.tgz"
     },
     "wpcom-oauth": {
       "version": "0.3.3",
+      "from": "wpcom-oauth@0.3.3",
+      "resolved": "https://registry.npmjs.org/wpcom-oauth/-/wpcom-oauth-0.3.3.tgz",
       "dependencies": {
         "cookiejar": {
-          "version": "1.3.0"
+          "version": "1.3.0",
+          "from": "cookiejar@1.3.0",
+          "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-1.3.0.tgz"
         },
         "extend": {
-          "version": "1.2.1"
+          "version": "1.2.1",
+          "from": "extend@>=1.2.1 <1.3.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz"
         },
         "formidable": {
-          "version": "1.0.14"
+          "version": "1.0.14",
+          "from": "formidable@1.0.14",
+          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz"
         },
         "methods": {
-          "version": "0.0.1"
+          "version": "0.0.1",
+          "from": "methods@0.0.1",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz"
         },
         "mime": {
-          "version": "1.2.5"
+          "version": "1.2.5",
+          "from": "mime@1.2.5",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.5.tgz"
         },
         "qs": {
-          "version": "0.6.5"
+          "version": "0.6.5",
+          "from": "qs@0.6.5",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.5.tgz"
         },
         "superagent": {
           "version": "0.17.0",
+          "from": "superagent@0.17.0",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-0.17.0.tgz",
           "dependencies": {
             "debug": {
-              "version": "0.7.4"
+              "version": "0.7.4",
+              "from": "debug@>=0.7.2 <0.8.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
             }
           }
         }
       }
     },
     "wpcom-proxy-request": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "from": "wpcom-proxy-request@3.0.0",
+      "resolved": "https://registry.npmjs.org/wpcom-proxy-request/-/wpcom-proxy-request-3.0.0.tgz"
     },
     "wpcom-xhr-request": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "wpcom-xhr-request@1.0.0",
+      "resolved": "https://registry.npmjs.org/wpcom-xhr-request/-/wpcom-xhr-request-1.0.0.tgz"
     },
     "wrap-ansi": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "from": "wrap-ansi@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
     },
     "wrappy": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "wrappy@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
     },
     "write": {
       "version": "0.2.1",
+      "from": "write@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "dev": true
     },
     "write-file-stdout": {
       "version": "0.0.2",
+      "from": "write-file-stdout@0.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-stdout/-/write-file-stdout-0.0.2.tgz",
       "dev": true
     },
     "ws": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "from": "ws@1.0.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz"
     },
     "wtf-8": {
       "version": "1.0.0",
+      "from": "wtf-8@1.0.0",
+      "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
       "dev": true
     },
     "xdg-basedir": {
       "version": "1.0.1",
+      "from": "xdg-basedir@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz",
       "dev": true
     },
     "xgettext-js": {
       "version": "1.0.0",
+      "from": "xgettext-js@1.0.0",
+      "resolved": "https://registry.npmjs.org/xgettext-js/-/xgettext-js-1.0.0.tgz",
       "dependencies": {
         "babylon": {
-          "version": "6.8.4"
+          "version": "6.8.4",
+          "from": "babylon@6.8.4",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.4.tgz"
         }
       }
     },
     "xml": {
       "version": "1.0.1",
+      "from": "xml@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
       "dev": true
     },
     "xml-char-classes": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "from": "xml-char-classes@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz"
     },
     "xml-name-validator": {
       "version": "2.0.1",
+      "from": "xml-name-validator@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
       "dev": true
     },
     "xmlhttprequest-ssl": {
-      "version": "1.5.1"
+      "version": "1.5.1",
+      "from": "xmlhttprequest-ssl@1.5.1",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz"
     },
     "xtend": {
-      "version": "4.0.1"
+      "version": "4.0.1",
+      "from": "xtend@>=4.0.0 <4.1.0",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
     "y18n": {
-      "version": "3.2.1"
+      "version": "3.2.1",
+      "from": "y18n@>=3.2.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
     },
     "yallist": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "yallist@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
     },
     "yargs": {
-      "version": "3.10.0"
+      "version": "3.10.0",
+      "from": "yargs@>=3.10.0 <3.11.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
     },
     "yargs-parser": {
       "version": "2.4.1",
+      "from": "yargs-parser@>=2.4.1 <3.0.0",
+      "resolved": "https://registry.npmjs.com/yargs-parser/-/yargs-parser-2.4.1.tgz",
       "dependencies": {
         "camelcase": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "from": "camelcase@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
         }
       }
     },
     "yeast": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "from": "yeast@0.1.2",
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz"
     },
     "zero-fill": {
-      "version": "2.2.3"
+      "version": "2.2.3",
+      "from": "zero-fill@>=2.2.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/zero-fill/-/zero-fill-2.2.3.tgz"
     }
   }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,4091 +4,2125 @@
   "dependencies": {
     "abab": {
       "version": "1.0.3",
-      "from": "abab@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
       "dev": true
     },
     "abbrev": {
-      "version": "1.0.9",
-      "from": "abbrev@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
+      "version": "1.0.9"
     },
     "abstract-leveldown": {
-      "version": "2.4.1",
-      "from": "abstract-leveldown@>=2.4.0 <2.5.0",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.4.1.tgz"
+      "version": "2.4.1"
     },
     "accepts": {
-      "version": "1.2.13",
-      "from": "accepts@>=1.2.12 <1.3.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz"
+      "version": "1.2.13"
     },
     "acorn": {
-      "version": "3.3.0",
-      "from": "acorn@>=3.1.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
+      "version": "3.3.0"
     },
     "acorn-globals": {
-      "version": "3.0.0",
-      "from": "acorn-globals@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.0.0.tgz"
+      "version": "3.0.0"
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "from": "acorn-jsx@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "dev": true
     },
     "after": {
-      "version": "0.8.2",
-      "from": "after@>=0.8.1 <0.9.0",
-      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
+      "version": "0.8.2"
     },
     "ajv": {
       "version": "4.10.4",
-      "from": "ajv@4.10.4",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.10.4.tgz",
       "dev": true
     },
     "ajv-keywords": {
       "version": "1.5.0",
-      "from": "ajv-keywords@1.5.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.0.tgz",
       "dev": true
     },
     "align-text": {
-      "version": "0.1.4",
-      "from": "align-text@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+      "version": "0.1.4"
     },
     "amdefine": {
-      "version": "1.0.1",
-      "from": "amdefine@>=0.0.4",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "ansi": {
-      "version": "0.3.1",
-      "from": "ansi@>=0.3.1 <0.4.0",
-      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
+      "version": "0.3.1"
     },
     "ansi-escapes": {
       "version": "1.4.0",
-      "from": "ansi-escapes@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "dev": true
     },
     "ansi-regex": {
-      "version": "2.1.1",
-      "from": "ansi-regex@2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+      "version": "2.1.1"
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "from": "ansi-styles@>=2.2.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+      "version": "2.2.1"
     },
     "anymatch": {
-      "version": "1.3.0",
-      "from": "anymatch@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz"
+      "version": "1.3.0"
     },
     "aproba": {
-      "version": "1.0.4",
-      "from": "aproba@1.0.4",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz"
+      "version": "1.0.4"
     },
     "are-we-there-yet": {
-      "version": "1.1.2",
-      "from": "are-we-there-yet@>=1.1.2 <1.2.0",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "argparse": {
       "version": "1.0.9",
-      "from": "argparse@>=1.0.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "dev": true
     },
     "arr-diff": {
-      "version": "2.0.0",
-      "from": "arr-diff@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "arr-flatten": {
-      "version": "1.0.1",
-      "from": "arr-flatten@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "array-differ": {
       "version": "1.0.0",
-      "from": "array-differ@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
       "dev": true
     },
     "array-equal": {
       "version": "1.0.0",
-      "from": "array-equal@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "dev": true
     },
     "array-find-index": {
-      "version": "1.0.2",
-      "from": "array-find-index@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "array-flatten": {
-      "version": "1.1.1",
-      "from": "array-flatten@1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
+      "version": "1.1.1"
     },
     "array-index": {
-      "version": "1.0.0",
-      "from": "array-index@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "array-union": {
-      "version": "1.0.2",
-      "from": "array-union@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "array-uniq": {
-      "version": "1.0.3",
-      "from": "array-uniq@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
+      "version": "1.0.3"
     },
     "array-unique": {
-      "version": "0.2.1",
-      "from": "array-unique@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+      "version": "0.2.1"
     },
     "arraybuffer.slice": {
-      "version": "0.0.6",
-      "from": "arraybuffer.slice@0.0.6",
-      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
+      "version": "0.0.6"
     },
     "arrify": {
-      "version": "1.0.1",
-      "from": "arrify@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "asap": {
-      "version": "2.0.5",
-      "from": "asap@>=2.0.3 <2.1.0",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
+      "version": "2.0.5"
     },
     "asn1": {
-      "version": "0.2.3",
-      "from": "asn1@>=0.2.3 <0.3.0",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+      "version": "0.2.3"
     },
     "assert": {
-      "version": "1.4.1",
-      "from": "assert@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz"
+      "version": "1.4.1"
     },
     "assert-plus": {
-      "version": "0.2.0",
-      "from": "assert-plus@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+      "version": "0.2.0"
     },
     "assertion-error": {
       "version": "1.0.2",
-      "from": "assertion-error@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "dev": true
     },
     "ast-types": {
-      "version": "0.9.2",
-      "from": "ast-types@0.9.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.2.tgz"
+      "version": "0.9.4"
     },
     "async": {
-      "version": "0.9.0",
-      "from": "async@0.9.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+      "version": "0.9.0"
     },
     "async-each": {
-      "version": "1.0.1",
-      "from": "async-each@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "async-foreach": {
-      "version": "0.1.3",
-      "from": "async-foreach@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
+      "version": "0.1.3"
     },
     "asynckit": {
-      "version": "0.4.0",
-      "from": "asynckit@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+      "version": "0.4.0"
     },
     "atob": {
-      "version": "1.1.2",
-      "from": "atob@1.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "autoprefixer": {
-      "version": "6.3.5",
-      "from": "autoprefixer@6.3.5",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.3.5.tgz"
+      "version": "6.3.5"
     },
     "autosize": {
-      "version": "3.0.15",
-      "from": "autosize@3.0.15",
-      "resolved": "https://registry.npmjs.org/autosize/-/autosize-3.0.15.tgz"
+      "version": "3.0.15"
     },
     "aws-sign2": {
-      "version": "0.6.0",
-      "from": "aws-sign2@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+      "version": "0.6.0"
     },
     "aws4": {
-      "version": "1.5.0",
-      "from": "aws4@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz"
+      "version": "1.5.0"
     },
     "babel-code-frame": {
-      "version": "6.20.0",
-      "from": "babel-code-frame@>=6.8.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.20.0.tgz",
+      "version": "6.22.0",
       "dependencies": {
         "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+          "version": "1.1.3"
         },
         "supports-color": {
-          "version": "2.0.0",
-          "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+          "version": "2.0.0"
         }
       }
     },
     "babel-core": {
       "version": "6.9.1",
-      "from": "babel-core@6.9.1",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.9.1.tgz",
       "dependencies": {
         "source-map": {
-          "version": "0.5.6",
-          "from": "source-map@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+          "version": "0.5.6"
         }
       }
     },
     "babel-eslint": {
       "version": "6.1.2",
-      "from": "babel-eslint@6.1.2",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.2.tgz",
       "dev": true
     },
     "babel-generator": {
-      "version": "6.21.0",
-      "from": "babel-generator@>=6.9.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.21.0.tgz",
+      "version": "6.22.0",
       "dependencies": {
         "source-map": {
-          "version": "0.5.6",
-          "from": "source-map@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+          "version": "0.5.6"
         }
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
-      "version": "6.18.0",
-      "from": "babel-helper-builder-binary-assignment-operator-visitor@>=6.8.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.18.0.tgz"
+      "version": "6.22.0"
     },
     "babel-helper-builder-react-jsx": {
-      "version": "6.21.1",
-      "from": "babel-helper-builder-react-jsx@>=6.8.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.21.1.tgz"
+      "version": "6.22.0"
     },
     "babel-helper-call-delegate": {
-      "version": "6.18.0",
-      "from": "babel-helper-call-delegate@>=6.18.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.18.0.tgz"
+      "version": "6.22.0"
     },
     "babel-helper-define-map": {
-      "version": "6.18.0",
-      "from": "babel-helper-define-map@>=6.18.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.18.0.tgz"
+      "version": "6.22.0"
     },
     "babel-helper-explode-assignable-expression": {
-      "version": "6.18.0",
-      "from": "babel-helper-explode-assignable-expression@>=6.18.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.18.0.tgz"
+      "version": "6.22.0"
     },
     "babel-helper-function-name": {
-      "version": "6.18.0",
-      "from": "babel-helper-function-name@>=6.18.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz"
+      "version": "6.22.0"
     },
     "babel-helper-get-function-arity": {
-      "version": "6.18.0",
-      "from": "babel-helper-get-function-arity@>=6.18.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz"
+      "version": "6.22.0"
     },
     "babel-helper-hoist-variables": {
-      "version": "6.18.0",
-      "from": "babel-helper-hoist-variables@>=6.18.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.18.0.tgz"
+      "version": "6.22.0"
     },
     "babel-helper-optimise-call-expression": {
-      "version": "6.18.0",
-      "from": "babel-helper-optimise-call-expression@>=6.18.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.18.0.tgz"
+      "version": "6.22.0"
     },
     "babel-helper-regex": {
-      "version": "6.18.0",
-      "from": "babel-helper-regex@>=6.8.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.18.0.tgz"
+      "version": "6.22.0"
     },
     "babel-helper-remap-async-to-generator": {
-      "version": "6.20.3",
-      "from": "babel-helper-remap-async-to-generator@>=6.16.2 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.20.3.tgz"
+      "version": "6.22.0"
     },
     "babel-helper-replace-supers": {
-      "version": "6.18.0",
-      "from": "babel-helper-replace-supers@>=6.18.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.18.0.tgz"
+      "version": "6.22.0"
     },
     "babel-helpers": {
-      "version": "6.16.0",
-      "from": "babel-helpers@>=6.8.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz"
+      "version": "6.22.0"
     },
     "babel-loader": {
-      "version": "6.2.4",
-      "from": "babel-loader@6.2.4",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.2.4.tgz"
+      "version": "6.2.4"
     },
     "babel-messages": {
-      "version": "6.8.0",
-      "from": "babel-messages@>=6.8.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-add-module-exports": {
-      "version": "0.2.1",
-      "from": "babel-plugin-add-module-exports@0.2.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.2.1.tgz"
+      "version": "0.2.1"
     },
     "babel-plugin-check-es2015-constants": {
-      "version": "6.8.0",
-      "from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-lodash": {
-      "version": "3.2.0",
-      "from": "babel-plugin-lodash@3.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.2.0.tgz"
+      "version": "3.2.0"
     },
     "babel-plugin-syntax-async-functions": {
-      "version": "6.13.0",
-      "from": "babel-plugin-syntax-async-functions@>=6.8.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz"
+      "version": "6.13.0"
     },
     "babel-plugin-syntax-async-generators": {
-      "version": "6.13.0",
-      "from": "babel-plugin-syntax-async-generators@>=6.5.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz"
+      "version": "6.13.0"
     },
     "babel-plugin-syntax-class-properties": {
-      "version": "6.13.0",
-      "from": "babel-plugin-syntax-class-properties@>=6.8.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz"
+      "version": "6.13.0"
     },
     "babel-plugin-syntax-exponentiation-operator": {
-      "version": "6.13.0",
-      "from": "babel-plugin-syntax-exponentiation-operator@>=6.8.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz"
+      "version": "6.13.0"
     },
     "babel-plugin-syntax-export-extensions": {
-      "version": "6.13.0",
-      "from": "babel-plugin-syntax-export-extensions@>=6.8.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz"
+      "version": "6.13.0"
     },
     "babel-plugin-syntax-jsx": {
-      "version": "6.8.0",
-      "from": "babel-plugin-syntax-jsx@6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.8.0.tgz"
+      "version": "6.8.0"
     },
     "babel-plugin-syntax-object-rest-spread": {
-      "version": "6.13.0",
-      "from": "babel-plugin-syntax-object-rest-spread@>=6.8.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz"
+      "version": "6.13.0"
     },
     "babel-plugin-syntax-trailing-function-commas": {
-      "version": "6.20.0",
-      "from": "babel-plugin-syntax-trailing-function-commas@>=6.3.13 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.20.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-async-generator-functions": {
-      "version": "6.17.0",
-      "from": "babel-plugin-transform-async-generator-functions@>=6.17.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.17.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-async-to-generator": {
-      "version": "6.16.0",
-      "from": "babel-plugin-transform-async-to-generator@>=6.16.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.16.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-class-properties": {
-      "version": "6.9.1",
-      "from": "babel-plugin-transform-class-properties@6.9.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.9.1.tgz"
+      "version": "6.9.1"
     },
     "babel-plugin-transform-es2015-arrow-functions": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.21.0",
-      "from": "babel-plugin-transform-es2015-block-scoping@>=6.9.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.21.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-classes": {
-      "version": "6.18.0",
-      "from": "babel-plugin-transform-es2015-classes@>=6.9.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.18.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-computed-properties": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-destructuring": {
-      "version": "6.19.0",
-      "from": "babel-plugin-transform-es2015-destructuring@>=6.9.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.19.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-for-of": {
-      "version": "6.18.0",
-      "from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.18.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-function-name": {
-      "version": "6.9.0",
-      "from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-literals": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.18.0",
-      "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.6.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.18.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-object-super": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-parameters": {
-      "version": "6.21.0",
-      "from": "babel-plugin-transform-es2015-parameters@>=6.9.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.21.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
-      "version": "6.18.0",
-      "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.18.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-spread": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-sticky-regex": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-template-literals": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-es2015-template-literals@>=6.6.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
-      "version": "6.18.0",
-      "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.18.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-unicode-regex": {
-      "version": "6.11.0",
-      "from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-exponentiation-operator": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-exponentiation-operator@>=6.3.13 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.8.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-export-extensions": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-export-extensions@6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.8.0.tgz"
+      "version": "6.8.0"
     },
     "babel-plugin-transform-imports": {
-      "version": "1.1.0",
-      "from": "babel-plugin-transform-imports@1.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-imports/-/babel-plugin-transform-imports-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "babel-plugin-transform-object-rest-spread": {
-      "version": "6.20.2",
-      "from": "babel-plugin-transform-object-rest-spread@>=6.3.13 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.20.2.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-react-display-name": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-react-display-name@6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.8.0.tgz"
+      "version": "6.8.0"
     },
     "babel-plugin-transform-react-jsx": {
-      "version": "6.8.0",
-      "from": "babel-plugin-transform-react-jsx@6.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.8.0.tgz"
+      "version": "6.8.0"
     },
     "babel-plugin-transform-regenerator": {
-      "version": "6.21.0",
-      "from": "babel-plugin-transform-regenerator@>=6.9.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.21.0.tgz"
+      "version": "6.22.0"
     },
     "babel-plugin-transform-runtime": {
-      "version": "6.9.0",
-      "from": "babel-plugin-transform-runtime@6.9.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.9.0.tgz"
+      "version": "6.9.0"
     },
     "babel-plugin-transform-strict-mode": {
-      "version": "6.18.0",
-      "from": "babel-plugin-transform-strict-mode@>=6.18.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.18.0.tgz"
+      "version": "6.22.0"
     },
     "babel-preset-es2015": {
-      "version": "6.9.0",
-      "from": "babel-preset-es2015@6.9.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.9.0.tgz"
+      "version": "6.9.0"
     },
     "babel-preset-stage-2": {
-      "version": "6.5.0",
-      "from": "babel-preset-stage-2@6.5.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.5.0.tgz"
+      "version": "6.5.0"
     },
     "babel-preset-stage-3": {
-      "version": "6.17.0",
-      "from": "babel-preset-stage-3@>=6.3.13 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.17.0.tgz"
+      "version": "6.22.0"
     },
     "babel-register": {
       "version": "6.9.0",
-      "from": "babel-register@6.9.0",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.9.0.tgz",
       "dependencies": {
         "source-map": {
-          "version": "0.1.32",
-          "from": "source-map@0.1.32",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz"
+          "version": "0.1.32"
         },
         "source-map-support": {
-          "version": "0.2.10",
-          "from": "source-map-support@>=0.2.10 <0.3.0",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz"
+          "version": "0.2.10"
         }
       }
     },
     "babel-runtime": {
-      "version": "6.20.0",
-      "from": "babel-runtime@>=6.9.1 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
+      "version": "6.22.0"
     },
     "babel-template": {
-      "version": "6.16.0",
-      "from": "babel-template@>=6.9.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
+      "version": "6.22.0"
     },
     "babel-traverse": {
-      "version": "6.21.0",
-      "from": "babel-traverse@>=6.9.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.21.0.tgz"
+      "version": "6.22.1"
     },
     "babel-types": {
-      "version": "6.21.0",
-      "from": "babel-types@>=6.9.1 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz"
+      "version": "6.22.0"
     },
     "babylon": {
-      "version": "6.15.0",
-      "from": "babylon@6.15.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz"
+      "version": "6.15.0"
     },
     "backo2": {
-      "version": "1.0.2",
-      "from": "backo2@1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "balanced-match": {
-      "version": "0.4.2",
-      "from": "balanced-match@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+      "version": "0.4.2"
     },
     "base62": {
-      "version": "0.1.1",
-      "from": "base62@0.1.1",
-      "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
+      "version": "0.1.1"
     },
     "Base64": {
-      "version": "0.2.1",
-      "from": "Base64@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
+      "version": "0.2.1"
     },
     "base64-arraybuffer": {
-      "version": "0.1.2",
-      "from": "base64-arraybuffer@0.1.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
+      "version": "0.1.2"
     },
     "base64-js": {
-      "version": "1.2.0",
-      "from": "base64-js@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz"
+      "version": "1.2.0"
     },
     "base64id": {
       "version": "0.1.0",
-      "from": "base64id@0.1.0",
-      "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
       "dev": true
     },
     "basic-auth": {
-      "version": "1.0.0",
-      "from": "basic-auth@1.0.0",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "batch": {
       "version": "0.5.3",
-      "from": "batch@0.5.3",
-      "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
       "dev": true
     },
-    "bcrypt-pbkdf": {
-      "version": "1.0.0",
-      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
-      "optional": true
-    },
     "benchmark": {
-      "version": "1.0.0",
-      "from": "benchmark@1.0.0",
-      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "better-assert": {
-      "version": "1.0.2",
-      "from": "better-assert@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "big.js": {
-      "version": "3.1.3",
-      "from": "big.js@>=3.1.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+      "version": "3.1.3"
     },
     "binary-extensions": {
-      "version": "1.8.0",
-      "from": "binary-extensions@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz"
+      "version": "1.8.0"
     },
     "bindings": {
-      "version": "1.2.1",
-      "from": "bindings@>=1.2.1 <1.3.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
+      "version": "1.2.1"
     },
     "bl": {
       "version": "1.0.3",
-      "from": "bl@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
       "dependencies": {
         "readable-stream": {
-          "version": "2.0.6",
-          "from": "readable-stream@>=2.0.5 <2.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+          "version": "2.0.6"
         }
       }
     },
     "blessed": {
       "version": "0.1.81",
-      "from": "blessed@>=0.1.81 <0.2.0",
-      "resolved": "https://registry.npmjs.org/blessed/-/blessed-0.1.81.tgz",
       "dev": true
     },
     "blob": {
-      "version": "0.0.4",
-      "from": "blob@0.0.4",
-      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
+      "version": "0.0.4"
     },
     "block-stream": {
-      "version": "0.0.9",
-      "from": "block-stream@*",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
+      "version": "0.0.9"
     },
     "bluebird": {
-      "version": "2.11.0",
-      "from": "bluebird@>=2.10.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz"
+      "version": "2.11.0"
     },
     "body-parser": {
-      "version": "1.15.2",
-      "from": "body-parser@>=1.13.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.2.tgz",
+      "version": "1.16.0",
       "dependencies": {
+        "debug": {
+          "version": "2.6.0"
+        },
+        "ms": {
+          "version": "0.7.2"
+        },
         "qs": {
-          "version": "6.2.0",
-          "from": "qs@6.2.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
+          "version": "6.2.1"
         }
       }
     },
     "boolbase": {
       "version": "1.0.0",
-      "from": "boolbase@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "dev": true
     },
     "boom": {
-      "version": "2.10.1",
-      "from": "boom@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+      "version": "2.10.1"
     },
     "bounding-client-rect": {
-      "version": "1.0.5",
-      "from": "bounding-client-rect@1.0.5",
-      "resolved": "https://registry.npmjs.org/bounding-client-rect/-/bounding-client-rect-1.0.5.tgz"
+      "version": "1.0.5"
     },
     "brace-expansion": {
-      "version": "1.1.6",
-      "from": "brace-expansion@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+      "version": "1.1.6"
     },
     "braces": {
-      "version": "1.8.5",
-      "from": "braces@>=1.8.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
+      "version": "1.8.5"
     },
     "browser-filesaver": {
-      "version": "1.1.0",
-      "from": "browser-filesaver@1.1.0",
-      "resolved": "https://registry.npmjs.org/browser-filesaver/-/browser-filesaver-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "browser-stdout": {
       "version": "1.3.0",
-      "from": "browser-stdout@1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "dev": true
     },
     "browserify-zlib": {
-      "version": "0.1.4",
-      "from": "browserify-zlib@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
+      "version": "0.1.4"
     },
     "browserslist": {
-      "version": "1.3.6",
-      "from": "browserslist@>=1.3.0 <1.4.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.3.6.tgz"
+      "version": "1.3.6"
     },
     "buffer": {
-      "version": "4.9.1",
-      "from": "buffer@>=4.9.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz"
+      "version": "4.9.1"
     },
     "buffer-shims": {
-      "version": "1.0.0",
-      "from": "buffer-shims@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "builtin-modules": {
-      "version": "1.1.1",
-      "from": "builtin-modules@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+      "version": "1.1.1"
     },
     "builtin-status-codes": {
-      "version": "2.0.0",
-      "from": "builtin-status-codes@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "bytes": {
-      "version": "2.4.0",
-      "from": "bytes@2.4.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
+      "version": "2.4.0"
     },
     "caller-path": {
       "version": "0.1.0",
-      "from": "caller-path@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "dev": true
     },
     "callsite": {
-      "version": "1.0.0",
-      "from": "callsite@1.0.0",
-      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "callsites": {
       "version": "0.2.0",
-      "from": "callsites@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "dev": true
     },
     "camel-case": {
-      "version": "1.2.2",
-      "from": "camel-case@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz"
+      "version": "1.2.2"
     },
     "camelcase": {
-      "version": "1.2.1",
-      "from": "camelcase@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+      "version": "1.2.1"
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "from": "camelcase-keys@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "dependencies": {
         "camelcase": {
-          "version": "2.1.1",
-          "from": "camelcase@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
+          "version": "2.1.1"
         }
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000611",
-      "from": "caniuse-db@1.0.30000611",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000611.tgz"
+      "version": "1.0.30000613"
     },
     "caseless": {
-      "version": "0.11.0",
-      "from": "caseless@>=0.11.0 <0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+      "version": "0.11.0"
     },
     "center-align": {
-      "version": "0.1.3",
-      "from": "center-align@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
+      "version": "0.1.3"
     },
     "chai": {
       "version": "3.5.0",
-      "from": "chai@3.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "dev": true
     },
     "chai-enzyme": {
       "version": "0.5.2",
-      "from": "chai-enzyme@0.5.2",
-      "resolved": "https://registry.npmjs.org/chai-enzyme/-/chai-enzyme-0.5.2.tgz",
       "dev": true
     },
     "chalk": {
       "version": "1.0.0",
-      "from": "chalk@1.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
       "dependencies": {
         "ansi-regex": {
-          "version": "1.1.1",
-          "from": "ansi-regex@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+          "version": "1.1.1"
         },
         "has-ansi": {
-          "version": "1.0.3",
-          "from": "has-ansi@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz"
+          "version": "1.0.3"
         },
         "strip-ansi": {
-          "version": "2.0.1",
-          "from": "strip-ansi@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
+          "version": "2.0.1"
         },
         "supports-color": {
-          "version": "1.3.1",
-          "from": "supports-color@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+          "version": "1.3.1"
         }
       }
     },
     "change-case": {
-      "version": "2.3.1",
-      "from": "change-case@>=2.3.0 <2.4.0",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.3.1.tgz"
+      "version": "2.3.1"
     },
     "character-parser": {
-      "version": "2.2.0",
-      "from": "character-parser@>=2.1.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz"
+      "version": "2.2.0"
     },
     "charenc": {
       "version": "0.0.2",
-      "from": "charenc@0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
       "dev": true
     },
     "cheerio": {
       "version": "0.20.0",
-      "from": "cheerio@>=0.20.0 <0.21.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.20.0.tgz",
       "dev": true,
       "dependencies": {
-        "acorn": {
-          "version": "2.7.0",
-          "from": "acorn@>=2.4.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
-          "dev": true
-        },
-        "acorn-globals": {
-          "version": "1.0.9",
-          "from": "acorn-globals@>=1.0.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
-          "dev": true,
-          "optional": true
-        },
         "entities": {
           "version": "1.1.1",
-          "from": "entities@>=1.1.1 <1.2.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
           "dev": true
-        },
-        "jsdom": {
-          "version": "7.2.2",
-          "from": "jsdom@>=7.0.2 <8.0.0",
-          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-7.2.2.tgz",
-          "dev": true,
-          "optional": true
-        },
-        "webidl-conversions": {
-          "version": "2.0.1",
-          "from": "webidl-conversions@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-2.0.1.tgz",
-          "dev": true,
-          "optional": true
         }
       }
     },
     "chokidar": {
-      "version": "1.6.1",
-      "from": "chokidar@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz"
+      "version": "1.6.1"
     },
     "chrono-node": {
-      "version": "1.2.5",
-      "from": "chrono-node@>=1.0.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-1.2.5.tgz"
+      "version": "1.2.5"
     },
     "circular-json": {
       "version": "0.3.1",
-      "from": "circular-json@>=0.3.1 <0.4.0",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
       "dev": true
     },
     "classnames": {
-      "version": "1.1.1",
-      "from": "classnames@1.1.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-1.1.1.tgz"
+      "version": "1.1.1"
     },
     "clean-css": {
-      "version": "3.4.23",
-      "from": "clean-css@>=3.4.0 <3.5.0",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.23.tgz",
+      "version": "3.4.24",
       "dependencies": {
         "commander": {
-          "version": "2.8.1",
-          "from": "commander@>=2.8.0 <2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz"
+          "version": "2.8.1"
         },
         "source-map": {
-          "version": "0.4.4",
-          "from": "source-map@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+          "version": "0.4.4"
         }
       }
     },
     "cli-cursor": {
       "version": "1.0.2",
-      "from": "cli-cursor@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "dev": true
     },
     "cli-width": {
       "version": "2.1.0",
-      "from": "cli-width@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
       "dev": true
     },
     "click-outside": {
-      "version": "2.0.1",
-      "from": "click-outside@2.0.1",
-      "resolved": "https://registry.npmjs.org/click-outside/-/click-outside-2.0.1.tgz"
+      "version": "2.0.1"
     },
     "clipboard": {
-      "version": "1.5.3",
-      "from": "clipboard@1.5.3",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.5.3.tgz"
+      "version": "1.5.3"
     },
     "cliui": {
-      "version": "2.1.0",
-      "from": "cliui@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz"
+      "version": "2.1.0"
     },
     "clone": {
-      "version": "1.0.2",
-      "from": "clone@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "clone-regexp": {
       "version": "1.0.0",
-      "from": "clone-regexp@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.0.tgz",
       "dev": true
     },
     "co": {
       "version": "4.6.0",
-      "from": "co@>=4.6.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "dev": true
     },
     "code-point-at": {
-      "version": "1.1.0",
-      "from": "code-point-at@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "collapse-white-space": {
       "version": "1.0.2",
-      "from": "collapse-white-space@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.2.tgz",
       "dev": true
     },
     "color-diff": {
       "version": "0.1.7",
-      "from": "color-diff@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/color-diff/-/color-diff-0.1.7.tgz",
       "dev": true
     },
     "colorguard": {
       "version": "1.2.0",
-      "from": "colorguard@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/colorguard/-/colorguard-1.2.0.tgz",
       "dev": true,
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "dev": true
         },
         "yargs": {
           "version": "1.3.3",
-          "from": "yargs@>=1.2.6 <2.0.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz",
           "dev": true
         }
       }
     },
     "colors": {
-      "version": "0.6.2",
-      "from": "colors@>=0.6.0-1 <0.7.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+      "version": "0.6.2"
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "from": "combined-stream@>=1.0.5 <1.1.0",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+      "version": "1.0.5"
     },
     "commander": {
-      "version": "2.3.0",
-      "from": "commander@2.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
+      "version": "2.3.0"
     },
     "component-bind": {
-      "version": "1.0.0",
-      "from": "component-bind@1.0.0",
-      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "component-closest": {
-      "version": "0.1.4",
-      "from": "component-closest@0.1.4",
-      "resolved": "https://registry.npmjs.org/component-closest/-/component-closest-0.1.4.tgz"
+      "version": "0.1.4"
     },
     "component-emitter": {
-      "version": "1.2.0",
-      "from": "component-emitter@1.2.0",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz"
+      "version": "1.2.0"
     },
     "component-event": {
-      "version": "0.1.4",
-      "from": "component-event@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.1.4.tgz"
+      "version": "0.1.4"
     },
     "component-file-picker": {
-      "version": "0.2.1",
-      "from": "component-file-picker@0.2.1",
-      "resolved": "https://registry.npmjs.org/component-file-picker/-/component-file-picker-0.2.1.tgz"
+      "version": "0.2.1"
     },
     "component-inherit": {
-      "version": "0.0.3",
-      "from": "component-inherit@0.0.3",
-      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
+      "version": "0.0.3"
     },
     "component-matches-selector": {
-      "version": "0.1.6",
-      "from": "component-matches-selector@>=0.1.5 <0.2.0",
-      "resolved": "https://registry.npmjs.org/component-matches-selector/-/component-matches-selector-0.1.6.tgz"
+      "version": "0.1.6"
     },
     "component-query": {
-      "version": "0.0.3",
-      "from": "component-query@*",
-      "resolved": "https://registry.npmjs.org/component-query/-/component-query-0.0.3.tgz"
+      "version": "0.0.3"
     },
     "component-uid": {
-      "version": "0.0.2",
-      "from": "component-uid@0.0.2",
-      "resolved": "https://registry.npmjs.org/component-uid/-/component-uid-0.0.2.tgz"
+      "version": "0.0.2"
     },
     "concat-map": {
-      "version": "0.0.1",
-      "from": "concat-map@0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+      "version": "0.0.1"
     },
     "concat-stream": {
       "version": "1.5.2",
-      "from": "concat-stream@>=1.5.0 <1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
       "dependencies": {
         "readable-stream": {
-          "version": "2.0.6",
-          "from": "readable-stream@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+          "version": "2.0.6"
         }
       }
     },
     "configstore": {
       "version": "0.3.2",
-      "from": "configstore@>=0.3.1 <0.4.0",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
       "dev": true,
       "dependencies": {
         "graceful-fs": {
           "version": "3.0.11",
-          "from": "graceful-fs@>=3.0.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
           "dev": true
         },
         "object-assign": {
           "version": "2.1.1",
-          "from": "object-assign@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
           "dev": true
         }
       }
     },
     "connect-history-api-fallback": {
       "version": "1.1.0",
-      "from": "connect-history-api-fallback@1.1.0",
-      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.1.0.tgz",
       "dev": true
     },
     "console-browserify": {
-      "version": "1.1.0",
-      "from": "console-browserify@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "console-control-strings": {
-      "version": "1.1.0",
-      "from": "console-control-strings@1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "constant-case": {
-      "version": "1.1.2",
-      "from": "constant-case@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "constantinople": {
-      "version": "3.1.0",
-      "from": "constantinople@>=3.0.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.0.tgz"
+      "version": "3.1.0"
     },
     "constants-browserify": {
-      "version": "0.0.1",
-      "from": "constants-browserify@0.0.1",
-      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+      "version": "0.0.1"
     },
     "content-disposition": {
-      "version": "0.5.0",
-      "from": "content-disposition@0.5.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz"
+      "version": "0.5.0"
     },
     "content-type": {
-      "version": "1.0.2",
-      "from": "content-type@>=1.0.2 <1.1.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "convert-source-map": {
-      "version": "1.3.0",
-      "from": "convert-source-map@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz"
+      "version": "1.3.0"
     },
     "cookie": {
-      "version": "0.1.2",
-      "from": "cookie@0.1.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+      "version": "0.1.2"
     },
     "cookie-parser": {
-      "version": "1.3.2",
-      "from": "cookie-parser@1.3.2",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.2.tgz"
+      "version": "1.3.2"
     },
     "cookie-signature": {
-      "version": "1.0.4",
-      "from": "cookie-signature@1.0.4",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.4.tgz"
+      "version": "1.0.4"
     },
     "cookiejar": {
-      "version": "2.1.0",
-      "from": "cookiejar@>=2.0.6 <3.0.0",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.0.tgz"
+      "version": "2.1.0"
     },
     "copy-webpack-plugin": {
       "version": "3.0.1",
-      "from": "copy-webpack-plugin@3.0.1",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-3.0.1.tgz",
       "dependencies": {
         "glob": {
-          "version": "6.0.4",
-          "from": "glob@>=6.0.4 <7.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz"
+          "version": "6.0.4"
         },
         "minimatch": {
-          "version": "3.0.3",
-          "from": "minimatch@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+          "version": "3.0.3"
         }
       }
     },
     "core-js": {
-      "version": "2.4.1",
-      "from": "core-js@>=2.4.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+      "version": "2.4.1"
     },
     "core-util-is": {
-      "version": "1.0.2",
-      "from": "core-util-is@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "cosmiconfig": {
       "version": "1.1.0",
-      "from": "cosmiconfig@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-1.1.0.tgz",
       "dev": true,
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.2.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "dev": true
         }
       }
     },
     "crc32": {
-      "version": "0.2.2",
-      "from": "crc32@0.2.2",
-      "resolved": "https://registry.npmjs.org/crc32/-/crc32-0.2.2.tgz"
+      "version": "0.2.2"
     },
     "creditcards": {
-      "version": "2.1.2",
-      "from": "creditcards@2.1.2",
-      "resolved": "https://registry.npmjs.org/creditcards/-/creditcards-2.1.2.tgz"
+      "version": "2.1.2"
     },
     "creditcards-types": {
-      "version": "1.6.0",
-      "from": "creditcards-types@>=1.6.0 <1.7.0",
-      "resolved": "https://registry.npmjs.org/creditcards-types/-/creditcards-types-1.6.0.tgz"
+      "version": "1.6.0"
     },
     "cross-spawn": {
       "version": "4.0.2",
-      "from": "cross-spawn@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
       "dev": true
     },
     "cross-spawn-async": {
-      "version": "2.2.5",
-      "from": "cross-spawn-async@>=2.1.9 <3.0.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz"
+      "version": "2.2.5"
     },
     "crypt": {
       "version": "0.0.2",
-      "from": "crypt@0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "dev": true
     },
     "cryptiles": {
-      "version": "2.0.5",
-      "from": "cryptiles@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+      "version": "2.0.5"
     },
     "crypto-browserify": {
-      "version": "3.2.8",
-      "from": "crypto-browserify@>=3.2.6 <3.3.0",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz"
+      "version": "3.2.8"
     },
     "css-color-names": {
       "version": "0.0.3",
-      "from": "css-color-names@0.0.3",
-      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz",
       "dev": true
     },
     "css-rule-stream": {
       "version": "1.1.0",
-      "from": "css-rule-stream@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/css-rule-stream/-/css-rule-stream-1.1.0.tgz",
       "dev": true
     },
     "css-select": {
       "version": "1.2.0",
-      "from": "css-select@>=1.2.0 <1.3.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "dev": true
     },
     "css-tokenize": {
       "version": "1.0.1",
-      "from": "css-tokenize@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/css-tokenize/-/css-tokenize-1.0.1.tgz",
       "dev": true
     },
     "css-what": {
       "version": "2.1.0",
-      "from": "css-what@>=2.1.0 <2.2.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
       "dev": true
     },
     "cssom": {
       "version": "0.3.1",
-      "from": "cssom@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.1.tgz",
       "dev": true
     },
     "cssstyle": {
       "version": "0.2.37",
-      "from": "cssstyle@>=0.2.36 <0.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
       "dev": true
     },
     "currently-unhandled": {
-      "version": "0.4.1",
-      "from": "currently-unhandled@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz"
+      "version": "0.4.1"
     },
     "d": {
-      "version": "0.1.1",
-      "from": "d@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+      "version": "0.1.1"
     },
     "dashdash": {
       "version": "1.14.1",
-      "from": "dashdash@>=1.12.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+          "version": "1.0.0"
         }
       }
     },
     "date-now": {
-      "version": "0.1.4",
-      "from": "date-now@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+      "version": "0.1.4"
     },
     "debug": {
-      "version": "2.2.0",
-      "from": "debug@2.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+      "version": "2.2.0"
     },
     "decamelize": {
-      "version": "1.2.0",
-      "from": "decamelize@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+      "version": "1.2.0"
     },
     "deep-eql": {
       "version": "0.1.3",
-      "from": "deep-eql@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "dev": true,
       "dependencies": {
         "type-detect": {
           "version": "0.1.1",
-          "from": "type-detect@0.1.1",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
           "dev": true
         }
       }
     },
     "deep-equal": {
       "version": "1.0.1",
-      "from": "deep-equal@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "dev": true
     },
     "deep-extend": {
-      "version": "0.4.1",
-      "from": "deep-extend@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
+      "version": "0.4.1"
     },
     "deep-freeze": {
       "version": "0.0.1",
-      "from": "deep-freeze@0.0.1",
-      "resolved": "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz",
       "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
-      "from": "deep-is@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "dev": true
     },
     "defaults-deep": {
       "version": "0.2.3",
-      "from": "defaults-deep@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/defaults-deep/-/defaults-deep-0.2.3.tgz",
       "dev": true,
       "dependencies": {
         "lazy-cache": {
           "version": "0.2.7",
-          "from": "lazy-cache@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
           "dev": true
         }
       }
     },
     "deferred-leveldown": {
-      "version": "1.2.1",
-      "from": "deferred-leveldown@>=1.2.1 <1.3.0",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.1.tgz"
+      "version": "1.2.1"
     },
     "define-properties": {
       "version": "1.1.2",
-      "from": "define-properties@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "dev": true
     },
     "del": {
       "version": "2.2.2",
-      "from": "del@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "dev": true,
       "dependencies": {
         "globby": {
           "version": "5.0.0",
-          "from": "globby@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
           "dev": true
         }
       }
     },
     "delayed-stream": {
-      "version": "1.0.0",
-      "from": "delayed-stream@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "delegate": {
-      "version": "3.1.1",
-      "from": "delegate@>=3.1.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.1.1.tgz"
+      "version": "3.1.1"
     },
     "delegates": {
-      "version": "1.0.0",
-      "from": "delegates@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "depd": {
-      "version": "1.1.0",
-      "from": "depd@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "desandro-matches-selector": {
-      "version": "2.0.1",
-      "from": "desandro-matches-selector@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/desandro-matches-selector/-/desandro-matches-selector-2.0.1.tgz"
+      "version": "2.0.1"
     },
     "destroy": {
-      "version": "1.0.3",
-      "from": "destroy@1.0.3",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
+      "version": "1.0.3"
     },
     "detect-indent": {
-      "version": "4.0.0",
-      "from": "detect-indent@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz"
+      "version": "4.0.0"
     },
     "diff": {
       "version": "1.4.0",
-      "from": "diff@>=1.3.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
       "dev": true
     },
     "disparity": {
       "version": "2.0.0",
-      "from": "disparity@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/disparity/-/disparity-2.0.0.tgz",
       "dev": true
     },
     "doctrine": {
-      "version": "2.0.0",
-      "from": "doctrine@2.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "doctypes": {
-      "version": "1.1.0",
-      "from": "doctypes@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "doiuse": {
       "version": "2.5.0",
-      "from": "doiuse@>=2.3.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/doiuse/-/doiuse-2.5.0.tgz",
       "dev": true,
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
-          "from": "source-map@>=0.4.2 <0.5.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dev": true
         }
       }
     },
     "dom-helpers": {
-      "version": "2.4.0",
-      "from": "dom-helpers@2.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-2.4.0.tgz"
+      "version": "2.4.0"
     },
     "dom-scroll-into-view": {
-      "version": "1.0.1",
-      "from": "dom-scroll-into-view@1.0.1",
-      "resolved": "https://registry.npmjs.org/dom-scroll-into-view/-/dom-scroll-into-view-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "dom-serializer": {
       "version": "0.1.0",
-      "from": "dom-serializer@>=0.0.0 <1.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "dependencies": {
         "domelementtype": {
-          "version": "1.1.3",
-          "from": "domelementtype@>=1.1.1 <1.2.0",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+          "version": "1.1.3"
         },
         "entities": {
-          "version": "1.1.1",
-          "from": "entities@>=1.1.1 <1.2.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+          "version": "1.1.1"
         }
       }
     },
     "domain-browser": {
-      "version": "1.1.7",
-      "from": "domain-browser@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
+      "version": "1.1.7"
     },
     "domelementtype": {
-      "version": "1.3.0",
-      "from": "domelementtype@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+      "version": "1.3.0"
     },
     "domhandler": {
-      "version": "2.3.0",
-      "from": "domhandler@>=2.3.0 <2.4.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
+      "version": "2.3.0"
     },
     "domutils": {
-      "version": "1.5.1",
-      "from": "domutils@>=1.5.0 <1.6.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
+      "version": "1.5.1"
     },
     "dot-case": {
-      "version": "1.1.2",
-      "from": "dot-case@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "draft-js": {
-      "version": "0.8.1",
-      "from": "draft-js@0.8.1",
-      "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.8.1.tgz"
+      "version": "0.8.1"
     },
     "duplexer": {
       "version": "0.1.1",
-      "from": "duplexer@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "dev": true
     },
     "duplexer2": {
-      "version": "0.0.2",
-      "from": "duplexer2@>=0.0.2 <0.1.0",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
+      "version": "0.0.2"
     },
     "duplexify": {
       "version": "3.5.0",
-      "from": "duplexify@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
       "dev": true,
       "dependencies": {
         "end-of-stream": {
           "version": "1.0.0",
-          "from": "end-of-stream@1.0.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
           "dev": true
         },
         "once": {
           "version": "1.3.3",
-          "from": "once@>=1.3.0 <1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "dev": true
         },
         "readable-stream": {
           "version": "2.2.2",
-          "from": "readable-stream@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "dev": true
         }
       }
     },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "optional": true
-    },
     "editions": {
       "version": "1.3.3",
-      "from": "editions@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.3.tgz",
       "dev": true
     },
     "ee-first": {
-      "version": "1.1.1",
-      "from": "ee-first@1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+      "version": "1.1.1"
     },
     "ejs": {
       "version": "2.5.5",
-      "from": "ejs@2.5.5",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.5.tgz",
       "dev": true
     },
     "element-class": {
-      "version": "0.2.2",
-      "from": "element-class@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/element-class/-/element-class-0.2.2.tgz"
+      "version": "0.2.2"
     },
     "email-validator": {
-      "version": "1.0.1",
-      "from": "email-validator@1.0.1",
-      "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "emitter-component": {
-      "version": "1.0.0",
-      "from": "emitter-component@1.0.0",
-      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "emoji-text": {
-      "version": "0.2.6",
-      "from": "emoji-text@0.2.6",
-      "resolved": "https://registry.npmjs.org/emoji-text/-/emoji-text-0.2.6.tgz"
+      "version": "0.2.6"
     },
     "emojis-list": {
-      "version": "2.1.0",
-      "from": "emojis-list@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
+      "version": "2.1.0"
     },
     "encodeurl": {
       "version": "1.0.1",
-      "from": "encodeurl@1.0.1",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
       "dev": true
     },
     "encoding": {
-      "version": "0.1.12",
-      "from": "encoding@>=0.1.11 <0.2.0",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz"
+      "version": "0.1.12"
     },
     "end-of-stream": {
       "version": "1.1.0",
-      "from": "end-of-stream@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
       "dependencies": {
         "once": {
-          "version": "1.3.3",
-          "from": "once@>=1.3.0 <1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+          "version": "1.3.3"
         }
       }
     },
     "engine.io": {
       "version": "1.6.8",
-      "from": "engine.io@1.6.8",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.8.tgz",
       "dev": true,
       "dependencies": {
         "accepts": {
           "version": "1.1.4",
-          "from": "accepts@1.1.4",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
           "dev": true
         },
         "mime-db": {
           "version": "1.12.0",
-          "from": "mime-db@>=1.12.0 <1.13.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
           "dev": true
         },
         "mime-types": {
           "version": "2.0.14",
-          "from": "mime-types@>=2.0.4 <2.1.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
           "dev": true
         },
         "negotiator": {
           "version": "0.4.9",
-          "from": "negotiator@0.4.9",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
           "dev": true
         }
       }
     },
     "engine.io-client": {
       "version": "1.6.8",
-      "from": "engine.io-client@1.6.8",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.8.tgz",
       "dependencies": {
         "component-emitter": {
-          "version": "1.1.2",
-          "from": "component-emitter@1.1.2",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+          "version": "1.1.2"
         }
       }
     },
     "engine.io-parser": {
       "version": "1.2.4",
-      "from": "engine.io-parser@1.2.4",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
       "dependencies": {
         "after": {
-          "version": "0.8.1",
-          "from": "after@0.8.1",
-          "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
+          "version": "0.8.1"
         },
         "has-binary": {
-          "version": "0.1.6",
-          "from": "has-binary@0.1.6",
-          "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz"
+          "version": "0.1.6"
         },
         "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+          "version": "0.0.1"
         }
       }
     },
     "enhanced-resolve": {
       "version": "0.9.1",
-      "from": "enhanced-resolve@>=0.9.0 <0.10.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
       "dependencies": {
         "memory-fs": {
-          "version": "0.2.0",
-          "from": "memory-fs@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
+          "version": "0.2.0"
         }
       }
     },
     "entities": {
-      "version": "1.0.0",
-      "from": "entities@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "env-hash": {
-      "version": "1.1.0",
-      "from": "env-hash@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/env-hash/-/env-hash-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "enzyme": {
       "version": "2.4.1",
-      "from": "enzyme@2.4.1",
-      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-2.4.1.tgz",
       "dev": true
     },
     "errno": {
       "version": "0.1.4",
-      "from": "errno@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "dependencies": {
         "prr": {
-          "version": "0.0.0",
-          "from": "prr@>=0.0.0 <0.1.0",
-          "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+          "version": "0.0.0"
         }
       }
     },
     "error-ex": {
-      "version": "1.3.0",
-      "from": "error-ex@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
+      "version": "1.3.0"
     },
     "es-abstract": {
       "version": "1.6.1",
-      "from": "es-abstract@>=1.6.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.6.1.tgz",
       "dev": true
     },
     "es-to-primitive": {
       "version": "1.1.1",
-      "from": "es-to-primitive@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "dev": true
     },
     "es3ify": {
       "version": "0.1.4",
-      "from": "es3ify@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/es3ify/-/es3ify-0.1.4.tgz",
       "dependencies": {
         "esprima-fb": {
-          "version": "3001.1.0-dev-harmony-fb",
-          "from": "esprima-fb@>=3001.1.0-dev-harmony-fb <3001.2.0",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
+          "version": "3001.1.0-dev-harmony-fb"
         }
       }
     },
     "es5-ext": {
-      "version": "0.10.12",
-      "from": "es5-ext@>=0.10.11 <0.11.0",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
+      "version": "0.10.12"
     },
     "es6-iterator": {
-      "version": "2.0.0",
-      "from": "es6-iterator@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "es6-map": {
       "version": "0.1.4",
-      "from": "es6-map@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz",
       "dev": true
     },
     "es6-set": {
       "version": "0.1.4",
-      "from": "es6-set@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
       "dev": true
     },
     "es6-symbol": {
-      "version": "3.1.0",
-      "from": "es6-symbol@>=3.0.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
+      "version": "3.1.0"
     },
     "es6-templates": {
-      "version": "0.2.3",
-      "from": "es6-templates@>=0.2.2 <0.3.0",
-      "resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz"
+      "version": "0.2.3"
     },
     "es6-weak-map": {
       "version": "2.0.1",
-      "from": "es6-weak-map@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
       "dev": true
     },
     "escape-html": {
-      "version": "1.0.2",
-      "from": "escape-html@1.0.2",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "escape-regexp": {
-      "version": "0.0.1",
-      "from": "escape-regexp@0.0.1",
-      "resolved": "https://registry.npmjs.org/escape-regexp/-/escape-regexp-0.0.1.tgz"
+      "version": "0.0.1"
     },
     "escape-regexp-component": {
-      "version": "1.0.2",
-      "from": "escape-regexp-component@1.0.2",
-      "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "escape-string-regexp": {
-      "version": "1.0.3",
-      "from": "escape-string-regexp@1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+      "version": "1.0.3"
     },
     "escodegen": {
       "version": "1.8.1",
-      "from": "escodegen@>=1.6.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "dev": true,
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
-          "from": "esprima@>=2.7.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
           "dev": true
         },
         "estraverse": {
           "version": "1.9.3",
-          "from": "estraverse@>=1.9.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
           "dev": true
-        },
-        "source-map": {
-          "version": "0.2.0",
-          "from": "source-map@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-          "dev": true,
-          "optional": true
         }
       }
     },
     "escope": {
       "version": "3.6.0",
-      "from": "escope@>=3.6.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "dev": true
     },
     "esformatter": {
       "version": "0.7.3",
-      "from": "esformatter@0.7.3",
-      "resolved": "https://registry.npmjs.org/esformatter/-/esformatter-0.7.3.tgz",
       "dev": true,
       "dependencies": {
         "debug": {
           "version": "0.7.4",
-          "from": "debug@>=0.7.4 <0.8.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
           "dev": true
         },
         "espree": {
           "version": "1.12.3",
-          "from": "espree@>=1.12.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-1.12.3.tgz",
           "dev": true
         },
         "glob": {
           "version": "5.0.15",
-          "from": "glob@>=5.0.3 <6.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "dev": true
         },
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "dev": true
         },
         "semver": {
           "version": "2.2.1",
-          "from": "semver@>=2.2.1 <2.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz",
           "dev": true
         },
         "strip-json-comments": {
           "version": "0.1.3",
-          "from": "strip-json-comments@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "1.3.1",
-          "from": "supports-color@>=1.3.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
           "dev": true
         },
         "user-home": {
           "version": "2.0.0",
-          "from": "user-home@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
           "dev": true
         }
       }
     },
     "esformatter-braces": {
       "version": "1.2.1",
-      "from": "esformatter-braces@1.2.1",
-      "resolved": "https://registry.npmjs.org/esformatter-braces/-/esformatter-braces-1.2.1.tgz",
       "dev": true
     },
     "esformatter-collapse-objects-a8c": {
       "version": "0.1.0",
-      "from": "esformatter-collapse-objects-a8c@0.1.0",
-      "resolved": "https://registry.npmjs.org/esformatter-collapse-objects-a8c/-/esformatter-collapse-objects-a8c-0.1.0.tgz",
       "dev": true,
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
-          "from": "esprima@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
           "dev": true
         },
         "rocambole": {
           "version": "0.5.1",
-          "from": "rocambole@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.5.1.tgz",
           "dev": true
         }
       }
     },
     "esformatter-dot-notation": {
       "version": "1.3.1",
-      "from": "esformatter-dot-notation@1.3.1",
-      "resolved": "https://registry.npmjs.org/esformatter-dot-notation/-/esformatter-dot-notation-1.3.1.tgz",
       "dev": true,
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
-          "from": "esprima@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
           "dev": true
         },
         "rocambole": {
           "version": "0.6.0",
-          "from": "rocambole@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.6.0.tgz",
           "dev": true
         }
       }
     },
     "esformatter-quotes": {
       "version": "1.0.3",
-      "from": "esformatter-quotes@1.0.3",
-      "resolved": "https://registry.npmjs.org/esformatter-quotes/-/esformatter-quotes-1.0.3.tgz",
       "dev": true
     },
     "esformatter-semicolons": {
       "version": "1.1.1",
-      "from": "esformatter-semicolons@1.1.1",
-      "resolved": "https://registry.npmjs.org/esformatter-semicolons/-/esformatter-semicolons-1.1.1.tgz",
       "dev": true
     },
     "esformatter-special-bangs": {
       "version": "1.0.1",
-      "from": "esformatter-special-bangs@1.0.1",
-      "resolved": "https://registry.npmjs.org/esformatter-special-bangs/-/esformatter-special-bangs-1.0.1.tgz",
       "dev": true
     },
     "eslint": {
       "version": "3.8.1",
-      "from": "eslint@3.8.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.8.1.tgz",
       "dev": true,
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dev": true
         },
         "doctrine": {
           "version": "1.5.0",
-          "from": "doctrine@>=1.2.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "dev": true
         },
         "strip-bom": {
           "version": "3.0.0",
-          "from": "strip-bom@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "dev": true
         },
         "user-home": {
           "version": "2.0.0",
-          "from": "user-home@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
           "dev": true
         }
       }
     },
     "eslint-config-wpcalypso": {
       "version": "0.6.0",
-      "from": "eslint-config-wpcalypso@0.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-wpcalypso/-/eslint-config-wpcalypso-0.6.0.tgz",
       "dev": true
     },
     "eslint-plugin-react": {
       "version": "6.4.1",
-      "from": "eslint-plugin-react@6.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.4.1.tgz",
       "dev": true,
       "dependencies": {
         "doctrine": {
           "version": "1.5.0",
-          "from": "doctrine@>=1.2.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "dev": true
         }
       }
     },
     "eslint-plugin-wpcalypso": {
       "version": "3.0.2",
-      "from": "eslint-plugin-wpcalypso@3.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-wpcalypso/-/eslint-plugin-wpcalypso-3.0.2.tgz",
       "dev": true
     },
     "esmangle-evaluator": {
-      "version": "1.0.1",
-      "from": "esmangle-evaluator@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "espree": {
       "version": "3.3.2",
-      "from": "espree@>=3.3.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.3.2.tgz",
       "dev": true,
       "dependencies": {
         "acorn": {
           "version": "4.0.4",
-          "from": "acorn@>=4.0.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz",
           "dev": true
         }
       }
     },
     "esprima": {
-      "version": "3.1.3",
-      "from": "esprima@3.1.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
+      "version": "3.1.3"
     },
     "esrecurse": {
       "version": "4.1.0",
-      "from": "esrecurse@>=4.1.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
       "dev": true,
       "dependencies": {
         "estraverse": {
           "version": "4.1.1",
-          "from": "estraverse@>=4.1.0 <4.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
           "dev": true
         }
       }
     },
     "estraverse": {
       "version": "4.2.0",
-      "from": "estraverse@>=4.2.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "dev": true
     },
     "estree-walker": {
-      "version": "0.2.1",
-      "from": "estree-walker@0.2.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz"
+      "version": "0.2.1"
     },
     "esutils": {
-      "version": "2.0.2",
-      "from": "esutils@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+      "version": "2.0.2"
     },
     "etag": {
-      "version": "1.7.0",
-      "from": "etag@>=1.7.0 <1.8.0",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
+      "version": "1.7.0"
     },
     "ev-emitter": {
-      "version": "1.0.3",
-      "from": "ev-emitter@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/ev-emitter/-/ev-emitter-1.0.3.tgz"
+      "version": "1.0.3"
     },
     "event-emitter": {
       "version": "0.3.4",
-      "from": "event-emitter@>=0.3.4 <0.4.0",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
       "dev": true
     },
     "event-stream": {
       "version": "0.5.3",
-      "from": "event-stream@>=0.5.0 <0.6.0",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-0.5.3.tgz",
       "dev": true,
       "dependencies": {
         "optimist": {
           "version": "0.2.8",
-          "from": "optimist@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.2.8.tgz",
           "dev": true
         }
       }
     },
     "eventemitter3": {
       "version": "1.2.0",
-      "from": "eventemitter3@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
       "dev": true
     },
     "events": {
-      "version": "1.0.2",
-      "from": "events@1.0.2",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "execall": {
       "version": "1.0.0",
-      "from": "execall@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
       "dev": true
     },
     "execspawn": {
-      "version": "1.0.1",
-      "from": "execspawn@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/execspawn/-/execspawn-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "exenv": {
-      "version": "1.2.0",
-      "from": "exenv@1.2.0",
-      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.0.tgz"
+      "version": "1.2.0"
     },
     "exit-hook": {
       "version": "1.1.1",
-      "from": "exit-hook@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
       "dev": true
     },
     "expand-brackets": {
-      "version": "0.1.5",
-      "from": "expand-brackets@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
+      "version": "0.1.5"
     },
     "expand-range": {
-      "version": "1.8.2",
-      "from": "expand-range@>=1.8.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
+      "version": "1.8.2"
     },
     "expand-template": {
-      "version": "1.0.3",
-      "from": "expand-template@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.0.3.tgz"
+      "version": "1.0.3"
     },
     "expand-year": {
-      "version": "1.0.0",
-      "from": "expand-year@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/expand-year/-/expand-year-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "exports-loader": {
-      "version": "0.6.2",
-      "from": "exports-loader@0.6.2",
-      "resolved": "https://registry.npmjs.org/exports-loader/-/exports-loader-0.6.2.tgz"
+      "version": "0.6.2"
     },
     "express": {
       "version": "4.13.3",
-      "from": "express@4.13.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.13.3.tgz",
       "dependencies": {
         "cookie": {
-          "version": "0.1.3",
-          "from": "cookie@0.1.3",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
+          "version": "0.1.3"
         },
         "cookie-signature": {
-          "version": "1.0.6",
-          "from": "cookie-signature@1.0.6",
-          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+          "version": "1.0.6"
         },
         "depd": {
-          "version": "1.0.1",
-          "from": "depd@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
+          "version": "1.0.1"
         }
       }
     },
     "extend": {
-      "version": "3.0.0",
-      "from": "extend@>=3.0.0 <3.1.0",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+      "version": "3.0.0"
     },
     "extglob": {
-      "version": "0.3.2",
-      "from": "extglob@>=0.3.1 <0.4.0",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+      "version": "0.3.2"
     },
     "extsprintf": {
-      "version": "1.0.2",
-      "from": "extsprintf@1.0.2",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "falafel": {
       "version": "1.2.0",
-      "from": "falafel@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
       "dependencies": {
         "acorn": {
-          "version": "1.2.2",
-          "from": "acorn@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+          "version": "1.2.2"
         },
         "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+          "version": "0.0.1"
         }
       }
     },
     "fast-future": {
-      "version": "1.0.2",
-      "from": "fast-future@>=1.0.2 <1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "from": "fast-levenshtein@2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "dev": true
     },
     "fast-luhn": {
-      "version": "1.0.3",
-      "from": "fast-luhn@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-luhn/-/fast-luhn-1.0.3.tgz"
+      "version": "1.0.3"
     },
     "fastparse": {
-      "version": "1.1.1",
-      "from": "fastparse@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz"
+      "version": "1.1.1"
     },
     "fbemitter": {
-      "version": "2.1.1",
-      "from": "fbemitter@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-2.1.1.tgz"
+      "version": "2.1.1"
     },
     "fbjs": {
       "version": "0.8.8",
-      "from": "fbjs@>=0.8.3 <0.9.0",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.8.tgz",
       "dependencies": {
         "core-js": {
-          "version": "1.2.7",
-          "from": "core-js@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
+          "version": "1.2.7"
         }
       }
     },
     "figures": {
       "version": "1.7.0",
-      "from": "figures@>=1.3.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "dev": true,
       "dependencies": {
         "escape-string-regexp": {
           "version": "1.0.5",
-          "from": "escape-string-regexp@>=1.0.5 <2.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "dev": true
         }
       }
     },
     "file-entry-cache": {
       "version": "2.0.0",
-      "from": "file-entry-cache@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "dev": true
     },
     "filename-regex": {
-      "version": "2.0.0",
-      "from": "filename-regex@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "filesize": {
-      "version": "3.2.1",
-      "from": "filesize@3.2.1",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.2.1.tgz"
+      "version": "3.2.1"
     },
     "fill-range": {
-      "version": "2.2.3",
-      "from": "fill-range@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
+      "version": "2.2.3"
     },
     "finalhandler": {
-      "version": "0.4.0",
-      "from": "finalhandler@0.4.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz"
+      "version": "0.4.0"
     },
     "find-up": {
       "version": "1.1.2",
-      "from": "find-up@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "dependencies": {
         "path-exists": {
-          "version": "2.1.0",
-          "from": "path-exists@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+          "version": "2.1.0"
         }
       }
     },
     "findup": {
       "version": "0.1.5",
-      "from": "findup@>=0.1.5 <0.2.0",
-      "resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
       "dependencies": {
         "commander": {
-          "version": "2.1.0",
-          "from": "commander@>=2.1.0 <2.2.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
+          "version": "2.1.0"
         }
       }
     },
     "finished": {
       "version": "1.2.2",
-      "from": "finished@>=1.2.2 <1.3.0",
-      "resolved": "https://registry.npmjs.org/finished/-/finished-1.2.2.tgz",
       "dependencies": {
         "ee-first": {
-          "version": "1.0.3",
-          "from": "ee-first@1.0.3",
-          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.3.tgz"
+          "version": "1.0.3"
         }
       }
     },
     "fizzy-ui-utils": {
-      "version": "2.0.3",
-      "from": "fizzy-ui-utils@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/fizzy-ui-utils/-/fizzy-ui-utils-2.0.3.tgz"
+      "version": "2.0.3"
     },
     "flag-icon-css": {
-      "version": "2.3.0",
-      "from": "flag-icon-css@2.3.0",
-      "resolved": "https://registry.npmjs.org/flag-icon-css/-/flag-icon-css-2.3.0.tgz"
+      "version": "2.3.0"
     },
     "flat-cache": {
       "version": "1.2.2",
-      "from": "flat-cache@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
       "dev": true
     },
     "flatten": {
       "version": "1.0.2",
-      "from": "flatten@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
       "dev": true
     },
     "flux": {
       "version": "2.1.1",
-      "from": "flux@2.1.1",
-      "resolved": "https://registry.npmjs.org/flux/-/flux-2.1.1.tgz",
       "dependencies": {
         "core-js": {
-          "version": "1.2.7",
-          "from": "core-js@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
+          "version": "1.2.7"
         },
         "fbjs": {
-          "version": "0.1.0-alpha.7",
-          "from": "fbjs@0.1.0-alpha.7",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.1.0-alpha.7.tgz"
+          "version": "0.1.0-alpha.7"
         },
         "whatwg-fetch": {
-          "version": "0.9.0",
-          "from": "whatwg-fetch@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz"
+          "version": "0.9.0"
         }
       }
     },
     "for-in": {
-      "version": "0.1.6",
-      "from": "for-in@>=0.1.5 <0.2.0",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz"
+      "version": "0.1.6"
     },
     "for-own": {
-      "version": "0.1.4",
-      "from": "for-own@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz"
+      "version": "0.1.4"
     },
     "foreach": {
-      "version": "2.0.5",
-      "from": "foreach@>=2.0.5 <3.0.0",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
+      "version": "2.0.5"
     },
     "foreachasync": {
-      "version": "3.0.0",
-      "from": "foreachasync@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz"
+      "version": "3.0.0"
     },
     "forever-agent": {
-      "version": "0.6.1",
-      "from": "forever-agent@>=0.6.1 <0.7.0",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+      "version": "0.6.1"
     },
     "form-data": {
-      "version": "2.1.2",
-      "from": "form-data@>=2.1.1 <2.2.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz"
+      "version": "2.1.2"
     },
     "formatio": {
       "version": "1.1.1",
-      "from": "formatio@1.1.1",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
       "dev": true
     },
     "formidable": {
-      "version": "1.1.1",
-      "from": "formidable@1.1.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz"
+      "version": "1.1.1"
     },
     "forwarded": {
-      "version": "0.1.0",
-      "from": "forwarded@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
+      "version": "0.1.0"
     },
     "fresh": {
-      "version": "0.3.0",
-      "from": "fresh@0.3.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
+      "version": "0.3.0"
     },
     "fs-extra": {
-      "version": "0.26.7",
-      "from": "fs-extra@>=0.26.4 <0.27.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz"
+      "version": "0.26.7"
     },
     "fs.realpath": {
-      "version": "1.0.0",
-      "from": "fs.realpath@^1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-    },
-    "fsevents": {
-      "version": "1.0.17",
-      "from": "fsevents@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.17.tgz",
-      "optional": true,
-      "dependencies": {
-        "abbrev": {
-          "version": "1.0.9",
-          "from": "abbrev@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.0.0",
-          "from": "ansi-regex@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "from": "ansi-styles@>=2.2.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "optional": true
-        },
-        "aproba": {
-          "version": "1.0.4",
-          "from": "aproba@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.2",
-          "from": "are-we-there-yet@>=1.1.2 <1.2.0",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-          "optional": true
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "from": "asn1@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "from": "assert-plus@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "from": "asynckit@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "from": "aws-sign2@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.5.0",
-          "from": "aws4@>=1.2.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "from": "balanced-match@>=0.4.1 <0.5.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.0",
-          "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
-          "optional": true
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "from": "block-stream@*",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
-        },
-        "boom": {
-          "version": "2.10.1",
-          "from": "boom@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-        },
-        "brace-expansion": {
-          "version": "1.1.6",
-          "from": "brace-expansion@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "from": "buffer-shims@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "from": "caseless@>=0.11.0 <0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "optional": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "optional": true,
-          "dependencies": {
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "optional": true
-            }
-          }
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "from": "code-point-at@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "from": "combined-stream@>=1.0.5 <1.1.0",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
-        },
-        "commander": {
-          "version": "2.9.0",
-          "from": "commander@>=2.9.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "optional": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "from": "concat-map@0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "from": "console-control-strings@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "from": "core-util-is@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "from": "cryptiles@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "optional": true
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "from": "dashdash@>=1.12.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "from": "assert-plus@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.2.0",
-          "from": "debug@>=2.2.0 <2.3.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "optional": true
-        },
-        "deep-extend": {
-          "version": "0.4.1",
-          "from": "deep-extend@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "from": "delayed-stream@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "from": "delegates@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "optional": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "optional": true
-        },
-        "extend": {
-          "version": "3.0.0",
-          "from": "extend@>=3.0.0 <3.1.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "from": "extsprintf@1.0.2",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "from": "forever-agent@>=0.6.1 <0.7.0",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.2",
-          "from": "form-data@>=2.1.1 <2.2.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
-          "optional": true
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "from": "fs.realpath@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-        },
-        "fstream": {
-          "version": "1.0.10",
-          "from": "fstream@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz"
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "from": "fstream-ignore@>=1.0.5 <1.1.0",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.2",
-          "from": "gauge@>=2.7.1 <2.8.0",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.2.tgz",
-          "optional": true
-        },
-        "generate-function": {
-          "version": "2.0.0",
-          "from": "generate-function@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-          "optional": true
-        },
-        "generate-object-property": {
-          "version": "1.2.0",
-          "from": "generate-object-property@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-          "optional": true
-        },
-        "getpass": {
-          "version": "0.1.6",
-          "from": "getpass@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "from": "assert-plus@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.1",
-          "from": "glob@>=7.0.5 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-        },
-        "graceful-readlink": {
-          "version": "1.0.1",
-          "from": "graceful-readlink@>=1.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-          "optional": true
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "from": "har-validator@>=2.0.6 <2.1.0",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "optional": true
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "from": "has-ansi@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "optional": true
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "from": "has-unicode@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "from": "hawk@>=3.1.3 <3.2.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "optional": true
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "from": "hoek@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "from": "http-signature@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "optional": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "from": "inflight@>=1.0.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "from": "inherits@>=2.0.1 <2.1.0",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-        },
-        "ini": {
-          "version": "1.3.4",
-          "from": "ini@>=1.3.0 <1.4.0",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
-        },
-        "is-my-json-valid": {
-          "version": "2.15.0",
-          "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-          "optional": true
-        },
-        "is-property": {
-          "version": "1.0.2",
-          "from": "is-property@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-          "optional": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "from": "is-typedarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "from": "isstream@>=0.1.2 <0.2.0",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "from": "jodid25519@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-          "optional": true
-        },
-        "jsbn": {
-          "version": "0.1.0",
-          "from": "jsbn@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "from": "json-schema@0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "optional": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "optional": true
-        },
-        "jsonpointer": {
-          "version": "4.0.1",
-          "from": "jsonpointer@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.3.1",
-          "from": "jsprim@>=1.2.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
-          "optional": true
-        },
-        "mime-db": {
-          "version": "1.25.0",
-          "from": "mime-db@>=1.25.0 <1.26.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
-        },
-        "mime-types": {
-          "version": "2.1.13",
-          "from": "mime-types@>=2.1.7 <2.2.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz"
-        },
-        "minimatch": {
-          "version": "3.0.3",
-          "from": "minimatch@>=3.0.2 <4.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "from": "minimist@0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "from": "mkdirp@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-        },
-        "ms": {
-          "version": "0.7.1",
-          "from": "ms@0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.32",
-          "from": "node-pre-gyp@>=0.6.29 <0.7.0",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.32.tgz",
-          "optional": true
-        },
-        "nopt": {
-          "version": "3.0.6",
-          "from": "nopt@>=3.0.6 <3.1.0",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "optional": true
-        },
-        "npmlog": {
-          "version": "4.0.2",
-          "from": "npmlog@>=4.0.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
-          "optional": true
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "from": "number-is-nan@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "from": "oauth-sign@>=0.8.1 <0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.0",
-          "from": "object-assign@>=4.1.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "from": "once@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "from": "pinkie@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "optional": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "from": "pinkie-promise@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "from": "process-nextick-args@>=1.0.6 <1.1.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "from": "punycode@>=1.4.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "optional": true
-        },
-        "qs": {
-          "version": "6.3.0",
-          "from": "qs@>=6.3.0 <6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
-          "optional": true
-        },
-        "rc": {
-          "version": "1.1.6",
-          "from": "rc@>=1.1.6 <1.2.0",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-          "optional": true,
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "from": "minimist@>=1.2.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.2",
-          "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-          "optional": true
-        },
-        "request": {
-          "version": "2.79.0",
-          "from": "request@>=2.79.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-          "optional": true
-        },
-        "rimraf": {
-          "version": "2.5.4",
-          "from": "rimraf@>=2.5.4 <2.6.0",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
-        },
-        "semver": {
-          "version": "5.3.0",
-          "from": "semver@>=5.3.0 <5.4.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "from": "set-blocking@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "from": "signal-exit@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "from": "sntp@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "optional": true
-        },
-        "sshpk": {
-          "version": "1.10.1",
-          "from": "sshpk@>=1.7.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "from": "assert-plus@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "optional": true
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "from": "string-width@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "from": "stringstream@>=0.0.4 <0.1.0",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "from": "strip-ansi@>=3.0.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-        },
-        "strip-json-comments": {
-          "version": "1.0.4",
-          "from": "strip-json-comments@>=1.0.4 <1.1.0",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-          "optional": true
-        },
-        "supports-color": {
-          "version": "0.2.0",
-          "from": "supports-color@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "from": "tar@>=2.2.1 <2.3.0",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
-        },
-        "tar-pack": {
-          "version": "3.3.0",
-          "from": "tar-pack@>=3.3.0 <3.4.0",
-          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
-          "optional": true,
-          "dependencies": {
-            "once": {
-              "version": "1.3.3",
-              "from": "once@>=1.3.3 <1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-              "optional": true
-            },
-            "readable-stream": {
-              "version": "2.1.5",
-              "from": "readable-stream@>=2.1.4 <2.2.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-              "optional": true
-            }
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "from": "tough-cookie@>=2.3.0 <2.4.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "optional": true
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "from": "tunnel-agent@>=0.4.1 <0.5.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "optional": true
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "from": "tweetnacl@>=0.14.0 <0.15.0",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "from": "uid-number@>=0.0.6 <0.1.0",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "from": "util-deprecate@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "from": "uuid@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "from": "verror@1.3.6",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.0",
-          "from": "wide-align@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
-          "optional": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "from": "wrappy@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "optional": true
-        }
-      }
+      "version": "1.0.0"
     },
     "fstream": {
-      "version": "1.0.10",
-      "from": "fstream@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz"
+      "version": "1.0.10"
     },
     "function-bind": {
       "version": "1.1.0",
-      "from": "function-bind@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
       "dev": true
     },
     "fuse.js": {
-      "version": "2.6.1",
-      "from": "fuse.js@2.6.1",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-2.6.1.tgz"
+      "version": "2.6.1"
     },
     "gather-stream": {
-      "version": "1.0.0",
-      "from": "gather-stream@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/gather-stream/-/gather-stream-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "gauge": {
       "version": "2.7.2",
-      "from": "gauge@2.7.2",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.2.tgz",
       "dependencies": {
         "supports-color": {
-          "version": "0.2.0",
-          "from": "supports-color@0.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+          "version": "0.2.0"
         }
       }
     },
     "gaze": {
-      "version": "1.1.2",
-      "from": "gaze@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "generate-function": {
-      "version": "2.0.0",
-      "from": "generate-function@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "generate-object-property": {
-      "version": "1.2.0",
-      "from": "generate-object-property@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+      "version": "1.2.0"
     },
     "get-caller-file": {
-      "version": "1.0.2",
-      "from": "get-caller-file@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "get-document": {
-      "version": "1.0.0",
-      "from": "get-document@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/get-document/-/get-document-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "get-size": {
-      "version": "2.0.2",
-      "from": "get-size@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/get-size/-/get-size-2.0.2.tgz"
+      "version": "2.0.2"
     },
     "get-stdin": {
-      "version": "4.0.1",
-      "from": "get-stdin@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+      "version": "4.0.1"
     },
     "get-video-id": {
-      "version": "2.1.0",
-      "from": "get-video-id@2.1.0",
-      "resolved": "https://registry.npmjs.org/get-video-id/-/get-video-id-2.1.0.tgz"
+      "version": "2.1.0"
     },
     "getpass": {
       "version": "0.1.6",
-      "from": "getpass@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+          "version": "1.0.0"
         }
       }
     },
     "ghreleases": {
-      "version": "1.0.5",
-      "from": "ghreleases@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ghreleases/-/ghreleases-1.0.5.tgz"
+      "version": "1.0.5"
     },
     "ghrepos": {
-      "version": "2.0.0",
-      "from": "ghrepos@>=2.0.0 <2.1.0",
-      "resolved": "https://registry.npmjs.org/ghrepos/-/ghrepos-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "ghutils": {
-      "version": "3.2.1",
-      "from": "ghutils@>=3.2.0 <3.3.0",
-      "resolved": "https://registry.npmjs.org/ghutils/-/ghutils-3.2.1.tgz"
+      "version": "3.2.1"
     },
     "github-from-package": {
-      "version": "0.0.0",
-      "from": "github-from-package@0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz"
+      "version": "0.0.0"
     },
     "glob": {
-      "version": "7.0.3",
-      "from": "glob@7.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz"
+      "version": "7.0.3"
     },
     "glob-base": {
-      "version": "0.3.0",
-      "from": "glob-base@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+      "version": "0.3.0"
     },
     "glob-parent": {
-      "version": "2.0.0",
-      "from": "glob-parent@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "globals": {
-      "version": "9.14.0",
-      "from": "globals@>=9.0.0 <10.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
+      "version": "9.14.0"
     },
     "globby": {
       "version": "3.0.1",
-      "from": "globby@>=3.0.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-3.0.1.tgz",
       "dependencies": {
         "glob": {
-          "version": "5.0.15",
-          "from": "glob@>=5.0.3 <6.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
+          "version": "5.0.15"
         },
         "pinkie": {
-          "version": "1.0.0",
-          "from": "pinkie@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+          "version": "1.0.0"
         },
         "pinkie-promise": {
-          "version": "1.0.0",
-          "from": "pinkie-promise@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz"
+          "version": "1.0.0"
         }
       }
     },
     "globjoin": {
       "version": "0.1.4",
-      "from": "globjoin@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
       "dev": true
     },
     "globule": {
       "version": "1.1.0",
-      "from": "globule@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz",
       "dependencies": {
         "glob": {
-          "version": "7.1.1",
-          "from": "glob@~7.1.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+          "version": "7.1.1"
         },
         "lodash": {
-          "version": "4.16.6",
-          "from": "lodash@>=4.16.4 <4.17.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz"
+          "version": "4.16.6"
         },
         "minimatch": {
-          "version": "3.0.3",
-          "from": "minimatch@>=3.0.2 <3.1.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+          "version": "3.0.3"
         }
       }
     },
     "good-listener": {
-      "version": "1.2.1",
-      "from": "good-listener@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.1.tgz"
+      "version": "1.2.1"
     },
     "got": {
       "version": "3.3.1",
-      "from": "got@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-3.3.1.tgz",
       "dev": true,
       "dependencies": {
         "object-assign": {
           "version": "3.0.0",
-          "from": "object-assign@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
           "dev": true
         }
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "from": "graceful-fs@>=4.1.2 <5.0.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+      "version": "4.1.11"
     },
     "graceful-readlink": {
-      "version": "1.0.1",
-      "from": "graceful-readlink@>=1.0.0",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "growl": {
       "version": "1.9.2",
-      "from": "growl@1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "dev": true
     },
     "gzip-size": {
       "version": "3.0.0",
-      "from": "gzip-size@3.0.0",
-      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
       "dev": true
     },
     "har-validator": {
       "version": "2.0.6",
-      "from": "har-validator@>=2.0.6 <2.1.0",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "dependencies": {
         "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+          "version": "1.1.3"
         },
         "commander": {
-          "version": "2.9.0",
-          "from": "commander@>=2.9.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+          "version": "2.9.0"
         },
         "supports-color": {
-          "version": "2.0.0",
-          "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+          "version": "2.0.0"
         }
       }
     },
     "hard-source-webpack-plugin": {
       "version": "0.0.42",
-      "from": "hard-source-webpack-plugin@0.0.42",
-      "resolved": "https://registry.npmjs.org/hard-source-webpack-plugin/-/hard-source-webpack-plugin-0.0.42.tgz",
       "dependencies": {
         "bluebird": {
-          "version": "3.4.7",
-          "from": "bluebird@3.4.7",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz"
+          "version": "3.4.7"
         },
         "source-map": {
-          "version": "0.5.6",
-          "from": "source-map@>=0.5.6 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+          "version": "0.5.6"
         }
       }
     },
     "has": {
       "version": "1.0.1",
-      "from": "has@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "dev": true
     },
     "has-ansi": {
-      "version": "2.0.0",
-      "from": "has-ansi@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "has-binary": {
       "version": "0.1.7",
-      "from": "has-binary@0.1.7",
-      "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+          "version": "0.0.1"
         }
       }
     },
     "has-cors": {
-      "version": "1.1.0",
-      "from": "has-cors@1.1.0",
-      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "has-flag": {
-      "version": "1.0.0",
-      "from": "has-flag@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "has-unicode": {
-      "version": "2.0.1",
-      "from": "has-unicode@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
+      "version": "2.0.1"
     },
     "hawk": {
-      "version": "3.1.3",
-      "from": "hawk@>=3.1.3 <3.2.0",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+      "version": "3.1.3"
     },
     "he": {
-      "version": "0.5.0",
-      "from": "he@0.5.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-0.5.0.tgz"
+      "version": "0.5.0"
     },
     "hoek": {
-      "version": "2.16.3",
-      "from": "hoek@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+      "version": "2.16.3"
     },
     "hoist-non-react-statics": {
-      "version": "1.2.0",
-      "from": "hoist-non-react-statics@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz"
+      "version": "1.2.0"
     },
     "home-or-tmp": {
-      "version": "1.0.0",
-      "from": "home-or-tmp@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "hosted-git-info": {
-      "version": "2.1.5",
-      "from": "hosted-git-info@>=2.1.4 <3.0.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
+      "version": "2.1.5"
     },
     "html": {
       "version": "1.0.0",
-      "from": "html@1.0.0",
-      "resolved": "https://registry.npmjs.org/html/-/html-1.0.0.tgz",
       "dev": true
     },
     "html-loader": {
       "version": "0.4.0",
-      "from": "html-loader@0.4.0",
-      "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-0.4.0.tgz",
       "dependencies": {
         "source-map": {
-          "version": "0.5.6",
-          "from": "source-map@>=0.5.3 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+          "version": "0.5.6"
         }
       }
     },
     "html-minifier": {
       "version": "1.5.0",
-      "from": "html-minifier@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-1.5.0.tgz",
       "dependencies": {
         "async": {
-          "version": "0.2.10",
-          "from": "async@>=0.2.6 <0.3.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+          "version": "0.2.10"
         },
         "commander": {
-          "version": "2.9.0",
-          "from": "commander@>=2.9.0 <2.10.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+          "version": "2.9.0"
         },
         "he": {
-          "version": "1.0.0",
-          "from": "he@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/he/-/he-1.0.0.tgz"
+          "version": "1.0.0"
         },
         "source-map": {
-          "version": "0.5.6",
-          "from": "source-map@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+          "version": "0.5.6"
         },
         "uglify-js": {
-          "version": "2.6.4",
-          "from": "uglify-js@>=2.6.0 <2.7.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz"
+          "version": "2.6.4"
         }
       }
     },
     "html-tags": {
       "version": "1.1.1",
-      "from": "html-tags@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-1.1.1.tgz",
       "dev": true
     },
     "htmlparser2": {
-      "version": "3.8.3",
-      "from": "htmlparser2@>=3.8.0 <3.9.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz"
+      "version": "3.8.3"
     },
     "http-browserify": {
-      "version": "1.7.0",
-      "from": "http-browserify@>=1.3.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz"
+      "version": "1.7.0"
     },
     "http-errors": {
       "version": "1.5.1",
-      "from": "http-errors@>=1.5.0 <1.6.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
       "dependencies": {
         "inherits": {
-          "version": "2.0.3",
-          "from": "inherits@2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+          "version": "2.0.3"
         }
       }
     },
     "http-proxy": {
       "version": "1.16.2",
-      "from": "http-proxy@>=1.11.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
       "dev": true
     },
     "http-signature": {
-      "version": "1.1.1",
-      "from": "http-signature@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
+      "version": "1.1.1"
     },
     "https-browserify": {
-      "version": "0.0.0",
-      "from": "https-browserify@0.0.0",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
+      "version": "0.0.0"
     },
     "hyperquest": {
-      "version": "1.2.0",
-      "from": "hyperquest@>=1.2.0 <1.3.0",
-      "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-1.2.0.tgz"
+      "version": "1.2.0"
     },
     "i18n-calypso": {
       "version": "1.7.0",
-      "from": "i18n-calypso@1.7.0",
-      "resolved": "https://registry.npmjs.org/i18n-calypso/-/i18n-calypso-1.7.0.tgz",
       "dependencies": {
         "async": {
-          "version": "1.5.2",
-          "from": "async@>=1.5.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+          "version": "1.5.2"
         },
         "commander": {
-          "version": "2.9.0",
-          "from": "commander@>=2.9.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+          "version": "2.9.0"
         },
         "glob": {
-          "version": "7.1.1",
-          "from": "glob@^7.0.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+          "version": "7.1.1"
         },
         "minimatch": {
-          "version": "3.0.3",
-          "from": "minimatch@^3.0.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+          "version": "3.0.3"
         }
       }
     },
     "iconv-lite": {
-      "version": "0.4.13",
-      "from": "iconv-lite@0.4.13",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+      "version": "0.4.15"
     },
     "ieee754": {
-      "version": "1.1.8",
-      "from": "ieee754@>=1.1.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
+      "version": "1.1.8"
     },
     "ignore": {
       "version": "3.2.0",
-      "from": "ignore@>=3.1.5 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.0.tgz",
       "dev": true
     },
     "imagesloaded": {
-      "version": "4.1.1",
-      "from": "imagesloaded@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/imagesloaded/-/imagesloaded-4.1.1.tgz"
+      "version": "4.1.1"
     },
     "immediate": {
-      "version": "3.0.6",
-      "from": "immediate@>=3.0.5 <3.1.0",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz"
+      "version": "3.0.6"
     },
     "immutable": {
-      "version": "3.7.6",
-      "from": "immutable@3.7.6",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz"
+      "version": "3.7.6"
     },
     "imports-loader": {
-      "version": "0.6.5",
-      "from": "imports-loader@0.6.5",
-      "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.6.5.tgz"
+      "version": "0.6.5"
     },
     "imurmurhash": {
-      "version": "0.1.4",
-      "from": "imurmurhash@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
+      "version": "0.1.4"
     },
     "in-publish": {
-      "version": "2.0.0",
-      "from": "in-publish@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "indent-string": {
-      "version": "2.1.0",
-      "from": "indent-string@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz"
+      "version": "2.1.0"
     },
     "indexes-of": {
       "version": "1.0.1",
-      "from": "indexes-of@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
       "dev": true
     },
     "indexof": {
-      "version": "0.0.1",
-      "from": "indexof@0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+      "version": "0.0.1"
     },
     "infinity-agent": {
       "version": "2.0.3",
-      "from": "infinity-agent@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz",
       "dev": true
     },
     "inflight": {
-      "version": "1.0.6",
-      "from": "inflight@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+      "version": "1.0.6"
     },
     "inherits": {
-      "version": "2.0.1",
-      "from": "inherits@2.0.1",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+      "version": "2.0.1"
     },
     "ini": {
-      "version": "1.3.4",
-      "from": "ini@>=1.3.0 <1.4.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+      "version": "1.3.4"
     },
     "inline-process-browser": {
-      "version": "1.0.0",
-      "from": "inline-process-browser@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "inquirer": {
       "version": "0.12.0",
-      "from": "inquirer@>=0.12.0 <0.13.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "dev": true
     },
     "interpolate-components": {
-      "version": "1.1.0",
-      "from": "interpolate-components@1.1.0",
-      "resolved": "https://registry.npmjs.org/interpolate-components/-/interpolate-components-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "interpret": {
-      "version": "0.6.6",
-      "from": "interpret@>=0.6.4 <0.7.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
+      "version": "0.6.6"
     },
     "invariant": {
-      "version": "2.2.2",
-      "from": "invariant@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz"
+      "version": "2.2.2"
     },
     "invert-kv": {
-      "version": "1.0.0",
-      "from": "invert-kv@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "ipaddr.js": {
-      "version": "1.0.5",
-      "from": "ipaddr.js@1.0.5",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz"
+      "version": "1.0.5"
     },
     "irregular-plurals": {
       "version": "1.2.0",
-      "from": "irregular-plurals@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.2.0.tgz",
       "dev": true
     },
     "is-arrayish": {
-      "version": "0.2.1",
-      "from": "is-arrayish@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+      "version": "0.2.1"
     },
     "is-binary-path": {
-      "version": "1.0.1",
-      "from": "is-binary-path@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "is-buffer": {
-      "version": "1.1.4",
-      "from": "is-buffer@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
+      "version": "1.1.4"
     },
     "is-builtin-module": {
-      "version": "1.0.0",
-      "from": "is-builtin-module@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "is-callable": {
       "version": "1.1.3",
-      "from": "is-callable@>=1.1.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
       "dev": true
     },
     "is-date-object": {
       "version": "1.0.1",
-      "from": "is-date-object@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "dev": true
     },
     "is-dotfile": {
-      "version": "1.0.2",
-      "from": "is-dotfile@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "is-equal-shallow": {
-      "version": "0.1.3",
-      "from": "is-equal-shallow@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+      "version": "0.1.3"
     },
     "is-expression": {
-      "version": "2.1.0",
-      "from": "is-expression@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-2.1.0.tgz"
+      "version": "2.1.0"
     },
     "is-extendable": {
-      "version": "0.1.1",
-      "from": "is-extendable@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+      "version": "0.1.1"
     },
     "is-extglob": {
-      "version": "1.0.0",
-      "from": "is-extglob@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "is-finite": {
-      "version": "1.0.2",
-      "from": "is-finite@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "is-glob": {
-      "version": "2.0.1",
-      "from": "is-glob@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+      "version": "2.0.1"
     },
     "is-integer": {
-      "version": "1.0.6",
-      "from": "is-integer@>=1.0.4 <1.1.0",
-      "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz"
+      "version": "1.0.6"
     },
     "is-lower-case": {
-      "version": "1.1.3",
-      "from": "is-lower-case@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz"
+      "version": "1.1.3"
     },
     "is-my-json-valid": {
-      "version": "2.13.1",
-      "from": "is-my-json-valid@2.13.1",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
+      "version": "2.13.1"
     },
     "is-npm": {
       "version": "1.0.0",
-      "from": "is-npm@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
       "dev": true
     },
     "is-number": {
-      "version": "2.1.0",
-      "from": "is-number@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+      "version": "2.1.0"
     },
     "is-path-cwd": {
       "version": "1.0.0",
-      "from": "is-path-cwd@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "dev": true
     },
     "is-path-in-cwd": {
       "version": "1.0.0",
-      "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "dev": true
     },
     "is-path-inside": {
       "version": "1.0.0",
-      "from": "is-path-inside@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "dev": true
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "from": "is-plain-obj@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "dev": true
     },
     "is-plain-object": {
       "version": "2.0.1",
-      "from": "is-plain-object@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.1.tgz",
       "dev": true,
       "dependencies": {
         "isobject": {
           "version": "1.0.2",
-          "from": "isobject@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
           "dev": true
         }
       }
     },
     "is-posix-bracket": {
-      "version": "0.1.1",
-      "from": "is-posix-bracket@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+      "version": "0.1.1"
     },
     "is-primitive": {
-      "version": "2.0.0",
-      "from": "is-primitive@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "is-promise": {
-      "version": "2.1.0",
-      "from": "is-promise@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz"
+      "version": "2.1.0"
     },
     "is-property": {
-      "version": "1.0.2",
-      "from": "is-property@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "is-redirect": {
       "version": "1.0.0",
-      "from": "is-redirect@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "dev": true
     },
     "is-regex": {
-      "version": "1.0.3",
-      "from": "is-regex@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz"
+      "version": "1.0.3"
     },
     "is-regexp": {
       "version": "1.0.0",
-      "from": "is-regexp@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
       "dev": true
     },
     "is-resolvable": {
       "version": "1.0.0",
-      "from": "is-resolvable@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "dev": true
     },
     "is-stream": {
-      "version": "1.1.0",
-      "from": "is-stream@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "is-subset": {
       "version": "0.1.1",
-      "from": "is-subset@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
       "dev": true
     },
     "is-supported-regexp-flag": {
       "version": "1.0.0",
-      "from": "is-supported-regexp-flag@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.0.tgz",
       "dev": true
     },
     "is-symbol": {
       "version": "1.0.1",
-      "from": "is-symbol@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
       "dev": true
     },
     "is-typedarray": {
-      "version": "1.0.0",
-      "from": "is-typedarray@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "is-upper-case": {
-      "version": "1.1.2",
-      "from": "is-upper-case@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "is-utf8": {
-      "version": "0.2.1",
-      "from": "is-utf8@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+      "version": "0.2.1"
     },
     "is-valid-month": {
-      "version": "1.0.0",
-      "from": "is-valid-month@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/is-valid-month/-/is-valid-month-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "isarray": {
-      "version": "1.0.0",
-      "from": "isarray@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "isexe": {
-      "version": "1.1.2",
-      "from": "isexe@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "isobject": {
-      "version": "2.1.0",
-      "from": "isobject@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
+      "version": "2.1.0"
     },
     "isomorphic-fetch": {
-      "version": "2.2.1",
-      "from": "isomorphic-fetch@>=2.1.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz"
+      "version": "2.2.1"
     },
     "isstream": {
-      "version": "0.1.2",
-      "from": "isstream@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+      "version": "0.1.2"
     },
     "jade": {
       "version": "1.11.0",
@@ -4097,1290 +2131,811 @@
     },
     "jade-attrs": {
       "version": "2.0.0",
-      "from": "jade-attrs@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/jade-attrs/-/jade-attrs-2.0.0.tgz",
       "dependencies": {
         "jade-runtime": {
-          "version": "1.1.0",
-          "from": "jade-runtime@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/jade-runtime/-/jade-runtime-1.1.0.tgz"
+          "version": "1.1.0"
         }
       }
     },
     "jade-code-gen": {
       "version": "0.0.4",
-      "from": "jade-code-gen@0.0.4",
-      "resolved": "https://registry.npmjs.org/jade-code-gen/-/jade-code-gen-0.0.4.tgz",
       "dependencies": {
         "jade-runtime": {
-          "version": "1.1.0",
-          "from": "jade-runtime@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/jade-runtime/-/jade-runtime-1.1.0.tgz"
+          "version": "1.1.0"
         }
       }
     },
     "jade-error": {
-      "version": "1.2.0",
-      "from": "jade-error@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jade-error/-/jade-error-1.2.0.tgz"
+      "version": "1.2.0"
     },
     "jade-filters": {
-      "version": "1.1.0",
-      "from": "jade-filters@1.1.0",
-      "resolved": "https://registry.npmjs.org/jade-filters/-/jade-filters-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "jade-lexer": {
       "version": "0.0.9",
-      "from": "jade-lexer@0.0.9",
-      "resolved": "https://registry.npmjs.org/jade-lexer/-/jade-lexer-0.0.9.tgz",
       "dependencies": {
         "acorn": {
-          "version": "2.7.0",
-          "from": "acorn@>=2.7.0 <2.8.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
+          "version": "2.7.0"
         },
         "is-expression": {
-          "version": "1.0.2",
-          "from": "is-expression@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-1.0.2.tgz"
+          "version": "1.0.2"
         }
       }
     },
     "jade-linker": {
-      "version": "0.0.3",
-      "from": "jade-linker@0.0.3",
-      "resolved": "https://registry.npmjs.org/jade-linker/-/jade-linker-0.0.3.tgz"
+      "version": "0.0.3"
     },
     "jade-load": {
-      "version": "0.0.4",
-      "from": "jade-load@0.0.4",
-      "resolved": "https://registry.npmjs.org/jade-load/-/jade-load-0.0.4.tgz"
+      "version": "0.0.4"
     },
     "jade-parser": {
-      "version": "0.0.9",
-      "from": "jade-parser@0.0.9",
-      "resolved": "https://registry.npmjs.org/jade-parser/-/jade-parser-0.0.9.tgz"
+      "version": "0.0.9"
     },
     "jade-runtime": {
-      "version": "2.0.0",
-      "from": "jade-runtime@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/jade-runtime/-/jade-runtime-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "jade-strip-comments": {
-      "version": "1.0.0",
-      "from": "jade-strip-comments@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jade-strip-comments/-/jade-strip-comments-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "jade-walk": {
-      "version": "0.0.3",
-      "from": "jade-walk@>=0.0.3 <0.0.4",
-      "resolved": "https://registry.npmjs.org/jade-walk/-/jade-walk-0.0.3.tgz"
+      "version": "0.0.3"
     },
     "jed": {
-      "version": "1.0.2",
-      "from": "jed@1.0.2",
-      "resolved": "https://registry.npmjs.org/jed/-/jed-1.0.2.tgz"
-    },
-    "jodid25519": {
-      "version": "1.0.2",
-      "from": "jodid25519@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-      "optional": true
+      "version": "1.0.2"
     },
     "jquery": {
-      "version": "1.11.3",
-      "from": "jquery@1.11.3",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.11.3.tgz"
+      "version": "1.11.3"
     },
     "js-base64": {
-      "version": "2.1.9",
-      "from": "js-base64@>=2.1.9 <3.0.0",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+      "version": "2.1.9"
     },
     "js-stringify": {
-      "version": "1.0.2",
-      "from": "js-stringify@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "js-tokens": {
-      "version": "2.0.0",
-      "from": "js-tokens@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
+      "version": "3.0.0"
     },
     "js-yaml": {
       "version": "3.7.0",
-      "from": "js-yaml@>=3.5.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
       "dev": true,
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
-          "from": "esprima@>=2.6.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
           "dev": true
         }
       }
     },
-    "jsbn": {
-      "version": "0.1.0",
-      "from": "jsbn@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-      "optional": true
-    },
     "jsdom": {
       "version": "9.4.1",
-      "from": "jsdom@9.4.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.4.1.tgz",
       "dev": true,
       "dependencies": {
         "acorn": {
           "version": "2.7.0",
-          "from": "acorn@>=2.4.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
           "dev": true
         },
         "acorn-globals": {
           "version": "1.0.9",
-          "from": "acorn-globals@>=1.0.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
           "dev": true
         }
       }
     },
     "jsesc": {
-      "version": "1.3.0",
-      "from": "jsesc@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz"
+      "version": "1.3.0"
     },
     "jshashes": {
-      "version": "1.0.5",
-      "from": "jshashes@1.0.5",
-      "resolved": "https://registry.npmjs.org/jshashes/-/jshashes-1.0.5.tgz"
+      "version": "1.0.5"
     },
     "json-loader": {
-      "version": "0.5.4",
-      "from": "json-loader@0.5.4",
-      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.4.tgz"
+      "version": "0.5.4"
     },
     "json-schema": {
-      "version": "0.2.3",
-      "from": "json-schema@0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+      "version": "0.2.3"
     },
     "json-stable-stringify": {
       "version": "1.0.1",
-      "from": "json-stable-stringify@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "dev": true
     },
     "json-stringify-safe": {
-      "version": "5.0.1",
-      "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+      "version": "5.0.1"
     },
     "json3": {
-      "version": "3.3.2",
-      "from": "json3@3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
+      "version": "3.3.2"
     },
     "json5": {
-      "version": "0.4.0",
-      "from": "json5@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+      "version": "0.4.0"
     },
     "jsonfile": {
-      "version": "2.4.0",
-      "from": "jsonfile@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz"
+      "version": "2.4.0"
     },
     "jsonfilter": {
       "version": "1.1.2",
-      "from": "jsonfilter@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfilter/-/jsonfilter-1.1.2.tgz",
       "dev": true,
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "dev": true
         }
       }
     },
     "jsonify": {
       "version": "0.0.0",
-      "from": "jsonify@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "dev": true
     },
     "jsonist": {
-      "version": "1.3.0",
-      "from": "jsonist@>=1.3.0 <1.4.0",
-      "resolved": "https://registry.npmjs.org/jsonist/-/jsonist-1.3.0.tgz"
+      "version": "1.3.0"
     },
     "jsonparse": {
       "version": "0.0.5",
-      "from": "jsonparse@0.0.5",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
       "dev": true
     },
     "jsonpointer": {
-      "version": "2.0.0",
-      "from": "jsonpointer@2.0.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "JSONStream": {
       "version": "0.8.4",
-      "from": "JSONStream@>=0.8.4 <0.9.0",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
       "dev": true
     },
     "jsprim": {
-      "version": "1.3.1",
-      "from": "jsprim@>=1.2.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz"
+      "version": "1.3.1"
     },
     "jstimezonedetect": {
-      "version": "1.0.5",
-      "from": "jstimezonedetect@1.0.5",
-      "resolved": "https://registry.npmjs.org/jstimezonedetect/-/jstimezonedetect-1.0.5.tgz"
+      "version": "1.0.5"
     },
     "jstransform": {
       "version": "3.0.0",
-      "from": "jstransform@>=3.0.0 <3.1.0",
-      "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-3.0.0.tgz",
       "dependencies": {
         "esprima-fb": {
-          "version": "3001.1.0-dev-harmony-fb",
-          "from": "esprima-fb@~3001.1.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
+          "version": "3001.1.0-dev-harmony-fb"
         },
         "source-map": {
-          "version": "0.1.31",
-          "from": "source-map@0.1.31",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz"
+          "version": "0.1.31"
         }
       }
     },
     "jstransformer": {
-      "version": "0.0.3",
-      "from": "jstransformer@0.0.3",
-      "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-0.0.3.tgz"
+      "version": "0.0.3"
     },
     "jsx-ast-utils": {
       "version": "1.3.5",
-      "from": "jsx-ast-utils@>=1.3.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.3.5.tgz",
       "dev": true
     },
     "key-mirror": {
-      "version": "1.0.1",
-      "from": "key-mirror@1.0.1",
-      "resolved": "https://registry.npmjs.org/key-mirror/-/key-mirror-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "keymaster": {
-      "version": "1.6.2",
-      "from": "keymaster@1.6.2",
-      "resolved": "https://registry.npmjs.org/keymaster/-/keymaster-1.6.2.tgz"
+      "version": "1.6.2"
     },
     "kind-of": {
-      "version": "3.1.0",
-      "from": "kind-of@>=3.0.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz"
+      "version": "3.1.0"
     },
     "klaw": {
-      "version": "1.3.1",
-      "from": "klaw@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz"
+      "version": "1.3.1"
     },
     "latest-version": {
       "version": "1.0.1",
-      "from": "latest-version@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz",
       "dev": true
     },
     "lazy-cache": {
-      "version": "1.0.4",
-      "from": "lazy-cache@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+      "version": "1.0.4"
     },
     "lcid": {
-      "version": "1.0.0",
-      "from": "lcid@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "ldjson-stream": {
       "version": "1.2.1",
-      "from": "ldjson-stream@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ldjson-stream/-/ldjson-stream-1.2.1.tgz",
       "dev": true
     },
     "level": {
-      "version": "1.5.0",
-      "from": "level@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/level/-/level-1.5.0.tgz"
+      "version": "1.5.0"
     },
     "level-codec": {
-      "version": "6.1.0",
-      "from": "level-codec@>=6.1.0 <6.2.0",
-      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-6.1.0.tgz"
+      "version": "6.1.0"
     },
     "level-errors": {
-      "version": "1.0.4",
-      "from": "level-errors@>=1.0.3 <1.1.0",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.4.tgz"
+      "version": "1.0.4"
     },
     "level-iterator-stream": {
-      "version": "1.3.1",
-      "from": "level-iterator-stream@>=1.3.0 <1.4.0",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz"
+      "version": "1.3.1"
     },
     "level-packager": {
-      "version": "1.2.1",
-      "from": "level-packager@1.2.1",
-      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-1.2.1.tgz"
+      "version": "1.2.1"
     },
     "leveldown": {
       "version": "1.5.3",
-      "from": "leveldown@1.5.3",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.5.3.tgz",
       "dependencies": {
         "abstract-leveldown": {
-          "version": "2.6.1",
-          "from": "abstract-leveldown@>=2.6.1 <2.7.0",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.1.tgz"
+          "version": "2.6.1"
         }
       }
     },
     "levelup": {
-      "version": "1.3.3",
-      "from": "levelup@>=1.3.0 <1.4.0",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.3.tgz"
+      "version": "1.3.3"
     },
     "levn": {
       "version": "0.3.0",
-      "from": "levn@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "dev": true
     },
     "lie": {
-      "version": "3.0.2",
-      "from": "lie@3.0.2",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.0.2.tgz"
+      "version": "3.0.2"
     },
     "load-json-file": {
-      "version": "1.1.0",
-      "from": "load-json-file@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "loader-utils": {
       "version": "0.2.16",
-      "from": "loader-utils@>=0.2.11 <0.3.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz",
       "dependencies": {
         "json5": {
-          "version": "0.5.1",
-          "from": "json5@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+          "version": "0.5.1"
         }
       }
     },
     "localforage": {
-      "version": "1.4.3",
-      "from": "localforage@1.4.3",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.4.3.tgz"
+      "version": "1.4.3"
     },
     "lodash": {
-      "version": "4.15.0",
-      "from": "lodash@4.15.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
+      "version": "4.15.0"
     },
     "lodash-deep": {
       "version": "1.5.3",
-      "from": "lodash-deep@1.5.3",
-      "resolved": "https://registry.npmjs.org/lodash-deep/-/lodash-deep-1.5.3.tgz",
       "dev": true
     },
     "lodash._baseassign": {
       "version": "3.2.0",
-      "from": "lodash._baseassign@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "dev": true
     },
     "lodash._basecopy": {
       "version": "3.0.1",
-      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "dev": true
     },
     "lodash._basecreate": {
       "version": "3.0.3",
-      "from": "lodash._basecreate@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
       "dev": true
     },
     "lodash._getnative": {
       "version": "3.9.1",
-      "from": "lodash._getnative@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "dev": true
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
-      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "dev": true
     },
     "lodash.assign": {
-      "version": "4.2.0",
-      "from": "lodash.assign@>=4.0.8 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
+      "version": "4.2.0"
     },
     "lodash.create": {
       "version": "3.1.1",
-      "from": "lodash.create@3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "dev": true
     },
     "lodash.debounce": {
-      "version": "4.0.8",
-      "from": "lodash.debounce@>=4.0.6 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz"
+      "version": "4.0.8"
     },
     "lodash.flatten": {
-      "version": "4.4.0",
-      "from": "lodash.flatten@>=4.4.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz"
+      "version": "4.4.0"
     },
     "lodash.isarguments": {
       "version": "3.1.0",
-      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "dev": true
     },
     "lodash.isarray": {
       "version": "3.0.4",
-      "from": "lodash.isarray@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "dev": true
     },
     "lodash.kebabcase": {
-      "version": "4.1.1",
-      "from": "lodash.kebabcase@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz"
+      "version": "4.1.1"
     },
     "lodash.keys": {
       "version": "3.1.2",
-      "from": "lodash.keys@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "dev": true
     },
     "lodash.omit": {
-      "version": "4.5.0",
-      "from": "lodash.omit@>=4.3.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz"
+      "version": "4.5.0"
     },
     "lodash.pad": {
-      "version": "4.5.1",
-      "from": "lodash.pad@>=4.1.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz"
+      "version": "4.5.1"
     },
     "lodash.padend": {
-      "version": "4.6.1",
-      "from": "lodash.padend@>=4.1.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz"
+      "version": "4.6.1"
     },
     "lodash.padstart": {
-      "version": "4.6.1",
-      "from": "lodash.padstart@>=4.1.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz"
+      "version": "4.6.1"
     },
     "lodash.pickby": {
       "version": "4.6.0",
-      "from": "lodash.pickby@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
       "dev": true
     },
     "log-symbols": {
       "version": "1.0.2",
-      "from": "log-symbols@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
       "dev": true
     },
     "lolex": {
       "version": "1.3.2",
-      "from": "lolex@1.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
       "dev": true
     },
     "longest": {
-      "version": "1.0.1",
-      "from": "longest@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "loose-envify": {
-      "version": "1.3.1",
-      "from": "loose-envify@1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "dependencies": {
-        "js-tokens": {
-          "version": "3.0.0",
-          "from": "js-tokens@3.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
-        }
-      }
+      "version": "1.3.1"
     },
     "loud-rejection": {
-      "version": "1.6.0",
-      "from": "loud-rejection@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz"
+      "version": "1.6.0"
     },
     "lower-case": {
-      "version": "1.1.3",
-      "from": "lower-case@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz"
+      "version": "1.1.3"
     },
     "lower-case-first": {
-      "version": "1.0.2",
-      "from": "lower-case-first@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "lowercase-keys": {
       "version": "1.0.0",
-      "from": "lowercase-keys@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
       "dev": true
     },
     "lru": {
-      "version": "3.1.0",
-      "from": "lru@3.1.0",
-      "resolved": "https://registry.npmjs.org/lru/-/lru-3.1.0.tgz"
+      "version": "3.1.0"
     },
     "lru-cache": {
-      "version": "4.0.2",
-      "from": "lru-cache@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz"
+      "version": "4.0.2"
     },
     "lunr": {
-      "version": "0.5.7",
-      "from": "lunr@0.5.7",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-0.5.7.tgz"
+      "version": "0.5.7"
     },
     "map-obj": {
-      "version": "1.0.1",
-      "from": "map-obj@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "marked": {
-      "version": "0.3.5",
-      "from": "marked@0.3.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz"
+      "version": "0.3.5"
     },
     "masonry-layout": {
-      "version": "4.1.1",
-      "from": "masonry-layout@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/masonry-layout/-/masonry-layout-4.1.1.tgz"
+      "version": "4.1.1"
     },
     "md5": {
       "version": "2.2.1",
-      "from": "md5@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
       "dev": true
     },
     "md5-file": {
       "version": "3.1.0",
-      "from": "md5-file@3.1.0",
-      "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-3.1.0.tgz",
       "dev": true
     },
     "media-typer": {
-      "version": "0.3.0",
-      "from": "media-typer@0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+      "version": "0.3.0"
     },
     "memory-fs": {
       "version": "0.3.0",
-      "from": "memory-fs@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
       "dependencies": {
         "readable-stream": {
-          "version": "2.2.2",
-          "from": "readable-stream@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          "version": "2.2.2"
         }
       }
     },
     "meow": {
       "version": "3.7.0",
-      "from": "meow@>=3.7.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "from": "minimist@>=1.1.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+          "version": "1.2.0"
         }
       }
     },
     "merge-descriptors": {
-      "version": "1.0.0",
-      "from": "merge-descriptors@1.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "methods": {
-      "version": "1.1.2",
-      "from": "methods@>=1.1.1 <1.2.0",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "micromatch": {
-      "version": "2.3.11",
-      "from": "micromatch@>=2.1.5 <3.0.0",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
+      "version": "2.3.11"
     },
     "mime": {
-      "version": "1.3.4",
-      "from": "mime@1.3.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+      "version": "1.3.4"
     },
     "mime-db": {
-      "version": "1.26.0",
-      "from": "mime-db@1.26.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
+      "version": "1.26.0"
     },
     "mime-types": {
-      "version": "2.1.14",
-      "from": "mime-types@2.1.14",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz"
+      "version": "2.1.14"
     },
     "minimatch": {
-      "version": "2.0.10",
-      "from": "minimatch@>=2.0.3 <3.0.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
+      "version": "2.0.10"
     },
     "minimist": {
-      "version": "0.0.8",
-      "from": "minimist@0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+      "version": "0.0.8"
     },
     "mixedindentlint": {
       "version": "1.1.1",
-      "from": "mixedindentlint@1.1.1",
-      "resolved": "https://registry.npmjs.org/mixedindentlint/-/mixedindentlint-1.1.1.tgz",
       "dev": true,
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.2.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "dev": true
         }
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "from": "mkdirp@>=0.5.1 <0.6.0",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+      "version": "0.5.1"
     },
     "mocha": {
       "version": "3.1.0",
-      "from": "mocha@3.1.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.1.0.tgz",
       "dev": true,
       "dependencies": {
         "commander": {
           "version": "2.9.0",
-          "from": "commander@2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "from": "escape-string-regexp@1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "dev": true
         },
         "glob": {
           "version": "7.0.5",
-          "from": "glob@7.0.5",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.3",
-          "from": "minimatch@>=3.0.2 <4.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "3.1.2",
-          "from": "supports-color@3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "dev": true
         }
       }
     },
     "mocha-junit-reporter": {
       "version": "1.12.0",
-      "from": "mocha-junit-reporter@1.12.0",
-      "resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-1.12.0.tgz",
       "dev": true
     },
     "mockery": {
       "version": "1.7.0",
-      "from": "mockery@1.7.0",
-      "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
       "dev": true
     },
     "moment": {
-      "version": "2.10.6",
-      "from": "moment@2.10.6",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
+      "version": "2.10.6"
     },
     "moment-timezone": {
-      "version": "0.4.0",
-      "from": "moment-timezone@0.4.0",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.0.tgz"
+      "version": "0.4.0"
     },
     "morgan": {
       "version": "1.2.0",
-      "from": "morgan@1.2.0",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.2.0.tgz",
       "dependencies": {
         "bytes": {
-          "version": "1.0.0",
-          "from": "bytes@1.0.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
+          "version": "1.0.0"
         },
         "depd": {
-          "version": "0.4.2",
-          "from": "depd@0.4.2",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.2.tgz"
+          "version": "0.4.2"
         }
       }
     },
     "mout": {
       "version": "1.0.0",
-      "from": "mout@>=0.9.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/mout/-/mout-1.0.0.tgz",
       "dev": true
     },
     "ms": {
-      "version": "0.7.1",
-      "from": "ms@0.7.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+      "version": "0.7.1"
     },
     "multimatch": {
       "version": "2.1.0",
-      "from": "multimatch@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
       "dev": true,
       "dependencies": {
         "minimatch": {
           "version": "3.0.3",
-          "from": "minimatch@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "dev": true
         }
       }
     },
     "mute-stream": {
       "version": "0.0.5",
-      "from": "mute-stream@0.0.5",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
       "dev": true
     },
     "nan": {
-      "version": "2.4.0",
-      "from": "nan@>=2.4.0 <2.5.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
+      "version": "2.4.0"
     },
     "natives": {
       "version": "1.1.0",
-      "from": "natives@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
       "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
-      "from": "natural-compare@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "dev": true
     },
     "ncname": {
-      "version": "1.0.0",
-      "from": "ncname@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "negotiator": {
-      "version": "0.5.3",
-      "from": "negotiator@0.5.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
+      "version": "0.5.3"
     },
     "neo-async": {
-      "version": "1.8.2",
-      "from": "neo-async@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-1.8.2.tgz"
+      "version": "1.8.2"
     },
     "nested-error-stacks": {
       "version": "1.0.2",
-      "from": "nested-error-stacks@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.2.tgz",
       "dev": true
     },
     "nock": {
       "version": "8.0.0",
-      "from": "nock@8.0.0",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-8.0.0.tgz",
       "dev": true,
       "dependencies": {
         "qs": {
           "version": "6.3.0",
-          "from": "qs@>=6.0.2 <7.0.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
           "dev": true
         }
       }
     },
     "node-abi": {
-      "version": "1.0.3",
-      "from": "node-abi@1.0.3",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-1.0.3.tgz"
+      "version": "1.0.3"
     },
     "node-contains": {
-      "version": "1.0.0",
-      "from": "node-contains@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/node-contains/-/node-contains-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "node-dir": {
       "version": "0.1.16",
-      "from": "node-dir@>=0.1.10 <0.2.0",
-      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.16.tgz",
       "dependencies": {
         "minimatch": {
-          "version": "3.0.3",
-          "from": "minimatch@>=3.0.2 <4.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+          "version": "3.0.3"
         }
       }
     },
     "node-fetch": {
-      "version": "1.6.3",
-      "from": "node-fetch@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz"
+      "version": "1.6.3"
     },
     "node-gyp": {
       "version": "3.5.0",
-      "from": "node-gyp@3.5.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.5.0.tgz",
       "dependencies": {
         "minimatch": {
-          "version": "3.0.3",
-          "from": "minimatch@>=3.0.2 <4.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+          "version": "3.0.3"
         }
       }
     },
     "node-libs-browser": {
-      "version": "0.6.0",
-      "from": "node-libs-browser@>=0.4.0 <=0.6.0",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.6.0.tgz"
+      "version": "0.6.0"
     },
     "node-ninja": {
       "version": "1.0.2",
-      "from": "node-ninja@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/node-ninja/-/node-ninja-1.0.2.tgz",
       "dependencies": {
         "gauge": {
-          "version": "1.2.7",
-          "from": "gauge@1.2.7",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz"
+          "version": "1.2.7"
         },
         "minimatch": {
-          "version": "3.0.3",
-          "from": "minimatch@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+          "version": "3.0.3"
         },
         "npmlog": {
-          "version": "2.0.4",
-          "from": "npmlog@2.0.4",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz"
+          "version": "2.0.4"
         }
       }
     },
     "node-sass": {
       "version": "3.7.0",
-      "from": "node-sass@3.7.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.7.0.tgz",
       "dependencies": {
         "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+          "version": "1.1.3"
         },
         "supports-color": {
-          "version": "2.0.0",
-          "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+          "version": "2.0.0"
         }
       }
     },
     "nodemon": {
       "version": "1.4.1",
-      "from": "nodemon@1.4.1",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.4.1.tgz",
       "dev": true,
       "dependencies": {
         "lru-cache": {
           "version": "2.7.3",
-          "from": "lru-cache@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
           "dev": true
         },
         "minimatch": {
           "version": "0.3.0",
-          "from": "minimatch@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "dev": true
         }
       }
     },
     "noop-logger": {
-      "version": "0.1.1",
-      "from": "noop-logger@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz"
+      "version": "0.1.1"
     },
     "nopt": {
-      "version": "3.0.6",
-      "from": "nopt@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
+      "version": "3.0.6"
     },
     "normalize-package-data": {
-      "version": "2.3.5",
-      "from": "normalize-package-data@>=2.3.4 <3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
+      "version": "2.3.5"
     },
     "normalize-path": {
-      "version": "2.0.1",
-      "from": "normalize-path@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
+      "version": "2.0.1"
     },
     "normalize-range": {
-      "version": "0.1.2",
-      "from": "normalize-range@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
+      "version": "0.1.2"
     },
     "normalize-selector": {
       "version": "0.2.0",
-      "from": "normalize-selector@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
       "dev": true
     },
     "npm-path": {
       "version": "1.1.0",
-      "from": "npm-path@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-1.1.0.tgz",
       "dev": true
     },
     "npm-run": {
       "version": "1.1.1",
-      "from": "npm-run@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run/-/npm-run-1.1.1.tgz",
       "dev": true,
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "dev": true
         }
       }
     },
     "npmlog": {
-      "version": "4.0.2",
-      "from": "npmlog@4.0.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz"
+      "version": "4.0.2"
     },
     "nth-check": {
       "version": "1.0.1",
-      "from": "nth-check@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "dev": true
     },
     "num2fraction": {
-      "version": "1.2.2",
-      "from": "num2fraction@>=1.2.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
+      "version": "1.2.2"
     },
     "number-is-nan": {
-      "version": "1.0.1",
-      "from": "number-is-nan@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "nwmatcher": {
       "version": "1.3.9",
-      "from": "nwmatcher@>=1.3.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.9.tgz",
       "dev": true
     },
     "oauth-sign": {
-      "version": "0.8.2",
-      "from": "oauth-sign@>=0.8.1 <0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+      "version": "0.8.2"
     },
     "object-assign": {
-      "version": "4.1.1",
-      "from": "object-assign@4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+      "version": "4.1.1"
     },
     "object-component": {
-      "version": "0.0.3",
-      "from": "object-component@0.0.3",
-      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
+      "version": "0.0.3"
     },
     "object-is": {
       "version": "1.0.1",
-      "from": "object-is@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
       "dev": true
     },
     "object-keys": {
-      "version": "1.0.11",
-      "from": "object-keys@>=1.0.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
+      "version": "1.0.11"
     },
     "object.assign": {
       "version": "4.0.4",
-      "from": "object.assign@>=4.0.3 <5.0.0",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
       "dev": true
     },
     "object.omit": {
-      "version": "2.0.1",
-      "from": "object.omit@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz"
+      "version": "2.0.1"
     },
     "object.values": {
       "version": "1.0.4",
-      "from": "object.values@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
       "dev": true
     },
     "on-finished": {
-      "version": "2.3.0",
-      "from": "on-finished@>=2.3.0 <2.4.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
+      "version": "2.3.0"
     },
     "once": {
-      "version": "1.4.0",
-      "from": "once@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+      "version": "1.4.0"
     },
     "onecolor": {
       "version": "3.0.4",
-      "from": "onecolor@>=3.0.4 <4.0.0",
-      "resolved": "https://registry.npmjs.org/onecolor/-/onecolor-3.0.4.tgz",
       "dev": true
     },
     "onetime": {
       "version": "1.1.0",
-      "from": "onetime@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "dev": true
     },
     "opener": {
       "version": "1.4.2",
-      "from": "opener@1.4.2",
-      "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.2.tgz",
       "dev": true
     },
     "optimist": {
-      "version": "0.6.1",
-      "from": "optimist@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz"
+      "version": "0.6.1"
     },
     "optionator": {
       "version": "0.8.2",
-      "from": "optionator@>=0.8.2 <0.9.0",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "dev": true,
       "dependencies": {
         "wordwrap": {
           "version": "1.0.0",
-          "from": "wordwrap@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
           "dev": true
         }
       }
     },
     "options": {
-      "version": "0.0.6",
-      "from": "options@>=0.0.5",
-      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+      "version": "0.0.6"
     },
     "os-browserify": {
-      "version": "0.1.2",
-      "from": "os-browserify@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+      "version": "0.1.2"
     },
     "os-homedir": {
-      "version": "1.0.2",
-      "from": "os-homedir@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "os-locale": {
-      "version": "1.4.0",
-      "from": "os-locale@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
+      "version": "1.4.0"
     },
     "os-tmpdir": {
-      "version": "1.0.2",
-      "from": "os-tmpdir@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "osenv": {
-      "version": "0.1.4",
-      "from": "osenv@>=0.0.0 <1.0.0",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
+      "version": "0.1.4"
     },
     "outlayer": {
-      "version": "2.1.0",
-      "from": "outlayer@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/outlayer/-/outlayer-2.1.0.tgz"
+      "version": "2.1.0"
     },
     "package-json": {
       "version": "1.2.0",
-      "from": "package-json@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz",
       "dev": true
     },
     "page": {
       "version": "1.6.4",
-      "from": "page@1.6.4",
-      "resolved": "https://registry.npmjs.org/page/-/page-1.6.4.tgz",
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+          "version": "0.0.1"
         },
         "path-to-regexp": {
-          "version": "1.2.1",
-          "from": "path-to-regexp@>=1.2.1 <1.3.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.2.1.tgz"
+          "version": "1.2.1"
         }
       }
     },
     "pako": {
-      "version": "0.2.9",
-      "from": "pako@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
+      "version": "0.2.9"
     },
     "param-case": {
-      "version": "1.1.2",
-      "from": "param-case@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "parse-glob": {
-      "version": "3.0.4",
-      "from": "parse-glob@>=3.0.4 <4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
+      "version": "3.0.4"
     },
     "parse-int": {
-      "version": "1.0.2",
-      "from": "parse-int@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-int/-/parse-int-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "parse-json": {
-      "version": "2.2.0",
-      "from": "parse-json@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
+      "version": "2.2.0"
     },
     "parse-year": {
-      "version": "1.0.0",
-      "from": "parse-year@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-year/-/parse-year-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "parse5": {
       "version": "1.5.1",
-      "from": "parse5@>=1.5.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
       "dev": true
     },
     "parsejson": {
-      "version": "0.0.1",
-      "from": "parsejson@0.0.1",
-      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz"
+      "version": "0.0.1"
     },
     "parseqs": {
-      "version": "0.0.2",
-      "from": "parseqs@0.0.2",
-      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz"
+      "version": "0.0.2"
     },
     "parseuri": {
-      "version": "0.0.4",
-      "from": "parseuri@0.0.4",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz"
+      "version": "0.0.4"
     },
     "parseurl": {
-      "version": "1.3.1",
-      "from": "parseurl@>=1.3.0 <1.4.0",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+      "version": "1.3.1"
     },
     "pascal-case": {
-      "version": "1.1.2",
-      "from": "pascal-case@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "path-array": {
-      "version": "1.0.1",
-      "from": "path-array@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "path-browserify": {
-      "version": "0.0.0",
-      "from": "path-browserify@0.0.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+      "version": "0.0.0"
     },
     "path-case": {
-      "version": "1.1.2",
-      "from": "path-case@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "path-exists": {
-      "version": "1.0.0",
-      "from": "path-exists@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "path-is-absolute": {
-      "version": "1.0.1",
-      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "from": "path-is-inside@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "dev": true
     },
     "path-to-regexp": {
-      "version": "0.1.7",
-      "from": "path-to-regexp@0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+      "version": "0.1.7"
     },
     "path-type": {
-      "version": "1.1.0",
-      "from": "path-type@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "pbkdf2-compat": {
-      "version": "2.0.1",
-      "from": "pbkdf2-compat@2.0.1",
-      "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
+      "version": "2.0.1"
     },
     "percentage-regex": {
-      "version": "3.0.0",
-      "from": "percentage-regex@3.0.0",
-      "resolved": "https://registry.npmjs.org/percentage-regex/-/percentage-regex-3.0.0.tgz"
+      "version": "3.0.0"
     },
     "phone": {
       "version": "1.0.8",
@@ -5388,1069 +2943,681 @@
       "resolved": "git+https://github.com/Automattic/node-phone.git#6be6549b03137f2cca01e202250bf2590750119e"
     },
     "photon": {
-      "version": "2.0.0",
-      "from": "photon@2.0.0",
-      "resolved": "https://registry.npmjs.org/photon/-/photon-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "pify": {
-      "version": "2.3.0",
-      "from": "pify@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+      "version": "2.3.0"
     },
     "pinkie": {
-      "version": "2.0.4",
-      "from": "pinkie@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+      "version": "2.0.4"
     },
     "pinkie-promise": {
-      "version": "2.0.1",
-      "from": "pinkie-promise@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+      "version": "2.0.1"
     },
     "pipetteur": {
       "version": "2.0.3",
-      "from": "pipetteur@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pipetteur/-/pipetteur-2.0.3.tgz",
       "dev": true
     },
     "plur": {
       "version": "2.1.2",
-      "from": "plur@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
       "dev": true
     },
     "pluralize": {
       "version": "1.2.1",
-      "from": "pluralize@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
       "dev": true
     },
     "postcss": {
-      "version": "5.2.10",
-      "from": "postcss@5.2.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.10.tgz",
+      "version": "5.2.11",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+              "version": "2.0.0"
             }
           }
         },
         "source-map": {
-          "version": "0.5.6",
-          "from": "source-map@>=0.5.6 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+          "version": "0.5.6"
         }
       }
     },
     "postcss-cli": {
-      "version": "2.5.1",
-      "from": "postcss-cli@2.5.1",
-      "resolved": "https://registry.npmjs.org/postcss-cli/-/postcss-cli-2.5.1.tgz"
+      "version": "2.5.1"
     },
     "postcss-less": {
       "version": "0.14.0",
-      "from": "postcss-less@>=0.14.0 <0.15.0",
-      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-0.14.0.tgz",
       "dev": true
     },
     "postcss-reporter": {
       "version": "1.4.1",
-      "from": "postcss-reporter@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-1.4.1.tgz",
       "dev": true
     },
     "postcss-resolve-nested-selector": {
       "version": "0.1.1",
-      "from": "postcss-resolve-nested-selector@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
       "dev": true
     },
     "postcss-scss": {
       "version": "0.1.9",
-      "from": "postcss-scss@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-0.1.9.tgz",
       "dev": true
     },
     "postcss-selector-parser": {
       "version": "2.2.2",
-      "from": "postcss-selector-parser@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.2.tgz",
       "dev": true
     },
     "postcss-value-parser": {
-      "version": "3.3.0",
-      "from": "postcss-value-parser@>=3.2.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      "version": "3.3.0"
     },
     "prebuild": {
       "version": "5.1.2",
-      "from": "prebuild@5.1.2",
-      "resolved": "https://registry.npmjs.org/prebuild/-/prebuild-5.1.2.tgz",
       "dependencies": {
         "async": {
-          "version": "2.1.4",
-          "from": "async@2.1.4",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz"
+          "version": "2.1.4"
         },
         "minimist": {
-          "version": "1.2.0",
-          "from": "minimist@>=1.1.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+          "version": "1.2.0"
         }
       }
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "from": "prelude-ls@>=1.1.2 <1.2.0",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "dev": true
     },
     "prepend-http": {
       "version": "1.0.4",
-      "from": "prepend-http@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "dev": true
     },
     "preserve": {
-      "version": "0.2.0",
-      "from": "preserve@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+      "version": "0.2.0"
     },
     "prismjs": {
-      "version": "1.6.0",
-      "from": "prismjs@1.6.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.6.0.tgz",
-      "dependencies": {
-        "clipboard": {
-          "version": "1.5.16",
-          "from": "clipboard@>=1.5.5 <2.0.0",
-          "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.5.16.tgz",
-          "optional": true
-        }
-      }
+      "version": "1.6.0"
     },
     "private": {
-      "version": "0.1.6",
-      "from": "private@>=0.1.6 <0.2.0",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+      "version": "0.1.6"
     },
     "process": {
-      "version": "0.11.9",
-      "from": "process@>=0.11.0 <0.12.0",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.9.tgz"
+      "version": "0.11.9"
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+      "version": "1.0.7"
     },
     "progress": {
       "version": "1.1.8",
-      "from": "progress@>=1.1.8 <2.0.0",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "dev": true
     },
     "progress-event": {
-      "version": "1.0.0",
-      "from": "progress-event@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/progress-event/-/progress-event-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "promise": {
-      "version": "7.1.1",
-      "from": "promise@>=7.1.1 <8.0.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz"
+      "version": "7.1.1"
     },
     "propagate": {
       "version": "0.4.0",
-      "from": "propagate@0.4.0",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.4.0.tgz",
       "dev": true
     },
     "protochain": {
       "version": "1.0.5",
-      "from": "protochain@>=1.0.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/protochain/-/protochain-1.0.5.tgz",
       "dev": true
     },
     "proxy-addr": {
-      "version": "1.0.10",
-      "from": "proxy-addr@>=1.0.8 <1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz"
+      "version": "1.0.10"
     },
     "prr": {
-      "version": "1.0.1",
-      "from": "prr@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "ps-tree": {
       "version": "0.0.3",
-      "from": "ps-tree@>=0.0.3 <0.1.0",
-      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-0.0.3.tgz",
       "dev": true
     },
     "pseudomap": {
-      "version": "1.0.2",
-      "from": "pseudomap@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "pump": {
-      "version": "1.0.2",
-      "from": "pump@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "punycode": {
-      "version": "1.4.1",
-      "from": "punycode@>=1.4.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+      "version": "1.4.1"
     },
     "q": {
-      "version": "1.0.1",
-      "from": "q@1.0.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "qr.js": {
-      "version": "0.0.0",
-      "from": "qr.js@0.0.0",
-      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz"
+      "version": "0.0.0"
     },
     "qrcode.react": {
-      "version": "0.6.1",
-      "from": "qrcode.react@0.6.1",
-      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-0.6.1.tgz"
+      "version": "0.6.1"
     },
     "qs": {
-      "version": "4.0.0",
-      "from": "qs@4.0.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
+      "version": "4.0.0"
     },
     "querystring": {
-      "version": "0.2.0",
-      "from": "querystring@0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+      "version": "0.2.0"
     },
     "querystring-es3": {
-      "version": "0.2.1",
-      "from": "querystring-es3@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+      "version": "0.2.1"
     },
     "randomatic": {
-      "version": "1.1.6",
-      "from": "randomatic@>=1.1.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz"
+      "version": "1.1.6"
     },
     "range-parser": {
-      "version": "1.0.3",
-      "from": "range-parser@>=1.0.2 <1.1.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
+      "version": "1.0.3"
     },
     "raw-body": {
-      "version": "2.1.7",
-      "from": "raw-body@>=2.1.7 <2.2.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz"
+      "version": "2.2.0"
     },
     "rc": {
       "version": "1.1.6",
-      "from": "rc@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "from": "minimist@>=1.2.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+          "version": "1.2.0"
         }
       }
     },
     "react": {
-      "version": "15.4.0",
-      "from": "react@15.4.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-15.4.0.tgz"
+      "version": "15.4.0"
     },
     "react-addons-create-fragment": {
-      "version": "15.4.0",
-      "from": "react-addons-create-fragment@15.4.0",
-      "resolved": "https://registry.npmjs.org/react-addons-create-fragment/-/react-addons-create-fragment-15.4.0.tgz"
+      "version": "15.4.0"
     },
     "react-addons-css-transition-group": {
-      "version": "15.4.0",
-      "from": "react-addons-css-transition-group@15.4.0",
-      "resolved": "https://registry.npmjs.org/react-addons-css-transition-group/-/react-addons-css-transition-group-15.4.0.tgz"
+      "version": "15.4.0"
     },
     "react-addons-linked-state-mixin": {
-      "version": "15.4.0",
-      "from": "react-addons-linked-state-mixin@15.4.0",
-      "resolved": "https://registry.npmjs.org/react-addons-linked-state-mixin/-/react-addons-linked-state-mixin-15.4.0.tgz"
+      "version": "15.4.0"
     },
     "react-addons-shallow-compare": {
-      "version": "15.4.0",
-      "from": "react-addons-shallow-compare@15.4.0",
-      "resolved": "https://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.4.0.tgz"
+      "version": "15.4.0"
     },
     "react-addons-test-utils": {
       "version": "15.4.0",
-      "from": "react-addons-test-utils@15.4.0",
-      "resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.4.0.tgz",
       "dev": true
     },
     "react-addons-update": {
-      "version": "15.4.0",
-      "from": "react-addons-update@15.4.0",
-      "resolved": "https://registry.npmjs.org/react-addons-update/-/react-addons-update-15.4.0.tgz"
+      "version": "15.4.0"
     },
     "react-click-outside": {
-      "version": "2.1.0",
-      "from": "react-click-outside@2.1.0",
-      "resolved": "https://registry.npmjs.org/react-click-outside/-/react-click-outside-2.1.0.tgz"
+      "version": "2.1.0"
     },
     "react-day-picker": {
-      "version": "2.4.1",
-      "from": "react-day-picker@2.4.1",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-2.4.1.tgz"
+      "version": "2.4.1"
     },
     "react-docgen": {
       "version": "2.13.0",
-      "from": "react-docgen@2.13.0",
-      "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-2.13.0.tgz",
       "dependencies": {
         "async": {
-          "version": "1.5.2",
-          "from": "async@>=1.4.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+          "version": "1.5.2"
         },
         "babylon": {
-          "version": "5.8.38",
-          "from": "babylon@>=5.8.3 <5.9.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz"
+          "version": "5.8.38"
         },
         "commander": {
-          "version": "2.9.0",
-          "from": "commander@>=2.9.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+          "version": "2.9.0"
         }
       }
     },
     "react-dom": {
-      "version": "15.4.0",
-      "from": "react-dom@15.4.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.4.0.tgz"
+      "version": "15.4.0"
     },
     "react-element-to-jsx-string": {
       "version": "3.2.0",
-      "from": "react-element-to-jsx-string@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/react-element-to-jsx-string/-/react-element-to-jsx-string-3.2.0.tgz",
       "dev": true
     },
     "react-hot-api": {
       "version": "0.4.7",
-      "from": "react-hot-api@>=0.4.5 <0.5.0",
-      "resolved": "https://registry.npmjs.org/react-hot-api/-/react-hot-api-0.4.7.tgz",
       "dev": true
     },
     "react-hot-loader": {
       "version": "1.3.0",
-      "from": "react-hot-loader@1.3.0",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-1.3.0.tgz",
       "dev": true,
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
-          "from": "source-map@>=0.4.4 <0.5.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dev": true
         }
       }
     },
     "react-is-deprecated": {
-      "version": "0.1.2",
-      "from": "react-is-deprecated@0.1.2",
-      "resolved": "https://registry.npmjs.org/react-is-deprecated/-/react-is-deprecated-0.1.2.tgz"
+      "version": "0.1.2"
     },
     "react-masonry-component": {
-      "version": "4.2.2",
-      "from": "react-masonry-component@4.2.2",
-      "resolved": "https://registry.npmjs.org/react-masonry-component/-/react-masonry-component-4.2.2.tgz"
+      "version": "4.2.2"
     },
     "react-modal": {
-      "version": "1.6.5",
-      "from": "react-modal@latest",
-      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-1.6.5.tgz"
+      "version": "1.6.5"
     },
     "react-pure-render": {
-      "version": "1.0.2",
-      "from": "react-pure-render@1.0.2",
-      "resolved": "https://registry.npmjs.org/react-pure-render/-/react-pure-render-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "react-redux": {
-      "version": "4.4.5",
-      "from": "react-redux@4.4.5",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-4.4.5.tgz"
+      "version": "4.4.5"
     },
     "react-test-env": {
       "version": "0.2.0",
-      "from": "react-test-env@0.2.0",
-      "resolved": "https://registry.npmjs.org/react-test-env/-/react-test-env-0.2.0.tgz",
       "dev": true,
       "dependencies": {
         "lodash.assign": {
           "version": "4.1.0",
-          "from": "lodash.assign@4.1.0",
-          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.1.0.tgz",
           "dev": true
         }
       }
     },
     "react-virtualized": {
       "version": "8.8.1",
-      "from": "react-virtualized@8.8.1",
-      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-8.8.1.tgz",
       "dependencies": {
         "classnames": {
-          "version": "2.2.5",
-          "from": "classnames@>=2.2.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz"
+          "version": "2.2.5"
         }
       }
     },
     "read-all-stream": {
       "version": "3.1.0",
-      "from": "read-all-stream@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
       "dev": true,
       "dependencies": {
         "readable-stream": {
           "version": "2.2.2",
-          "from": "readable-stream@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "dev": true
         }
       }
     },
     "read-file-stdin": {
-      "version": "0.2.1",
-      "from": "read-file-stdin@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/read-file-stdin/-/read-file-stdin-0.2.1.tgz"
+      "version": "0.2.1"
     },
     "read-pkg": {
-      "version": "1.1.0",
-      "from": "read-pkg@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "read-pkg-up": {
-      "version": "1.0.1",
-      "from": "read-pkg-up@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "readable-stream": {
       "version": "1.1.14",
-      "from": "readable-stream@>=1.0.33 <2.0.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+          "version": "0.0.1"
         }
       }
     },
     "readdirp": {
       "version": "2.1.0",
-      "from": "readdirp@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "dependencies": {
         "minimatch": {
-          "version": "3.0.3",
-          "from": "minimatch@>=3.0.2 <4.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+          "version": "3.0.3"
         },
         "readable-stream": {
-          "version": "2.2.2",
-          "from": "readable-stream@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          "version": "2.2.2"
         }
       }
     },
     "readline2": {
       "version": "1.0.1",
-      "from": "readline2@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "dev": true
     },
     "recast": {
-      "version": "0.11.18",
-      "from": "recast@>=0.11.12 <0.12.0",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.18.tgz",
+      "version": "0.11.20",
       "dependencies": {
         "source-map": {
-          "version": "0.5.6",
-          "from": "source-map@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+          "version": "0.5.6"
         }
       }
     },
     "redent": {
-      "version": "1.0.0",
-      "from": "redent@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "reduce-component": {
-      "version": "1.0.1",
-      "from": "reduce-component@1.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "redux": {
-      "version": "3.0.4",
-      "from": "redux@3.0.4",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.0.4.tgz"
+      "version": "3.0.4"
     },
     "redux-thunk": {
-      "version": "1.0.0",
-      "from": "redux-thunk@1.0.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "regenerate": {
-      "version": "1.3.2",
-      "from": "regenerate@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
+      "version": "1.3.2"
     },
     "regenerator-runtime": {
-      "version": "0.10.1",
-      "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz"
+      "version": "0.10.1"
     },
     "regenerator-transform": {
-      "version": "0.9.8",
-      "from": "regenerator-transform@0.9.8",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.8.tgz"
+      "version": "0.9.8"
     },
     "regex-cache": {
-      "version": "0.4.3",
-      "from": "regex-cache@>=0.4.2 <0.5.0",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
+      "version": "0.4.3"
     },
     "regexp-quote": {
-      "version": "0.0.0",
-      "from": "regexp-quote@0.0.0",
-      "resolved": "https://registry.npmjs.org/regexp-quote/-/regexp-quote-0.0.0.tgz"
+      "version": "0.0.0"
     },
     "regexpu-core": {
-      "version": "2.0.0",
-      "from": "regexpu-core@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "registry-url": {
       "version": "3.1.0",
-      "from": "registry-url@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "dev": true
     },
     "regjsgen": {
-      "version": "0.2.0",
-      "from": "regjsgen@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+      "version": "0.2.0"
     },
     "regjsparser": {
       "version": "0.1.5",
-      "from": "regjsparser@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "dependencies": {
         "jsesc": {
-          "version": "0.5.0",
-          "from": "jsesc@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+          "version": "0.5.0"
         }
       }
     },
     "relateurl": {
-      "version": "0.2.7",
-      "from": "relateurl@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz"
+      "version": "0.2.7"
     },
     "repeat-element": {
-      "version": "1.1.2",
-      "from": "repeat-element@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "repeat-string": {
-      "version": "1.6.1",
-      "from": "repeat-string@>=1.5.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+      "version": "1.6.1"
     },
     "repeating": {
-      "version": "2.0.1",
-      "from": "repeating@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
+      "version": "2.0.1"
     },
     "request": {
       "version": "2.79.0",
-      "from": "request@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
       "dependencies": {
         "qs": {
-          "version": "6.3.0",
-          "from": "qs@>=6.3.0 <6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
+          "version": "6.3.0"
         },
         "uuid": {
-          "version": "3.0.1",
-          "from": "uuid@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+          "version": "3.0.1"
         }
       }
     },
     "require-directory": {
-      "version": "2.1.1",
-      "from": "require-directory@>=2.1.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
+      "version": "2.1.1"
     },
     "require-from-string": {
       "version": "1.2.1",
-      "from": "require-from-string@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
       "dev": true
     },
     "require-main-filename": {
-      "version": "1.0.1",
-      "from": "require-main-filename@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "require-uncached": {
       "version": "1.0.3",
-      "from": "require-uncached@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "dev": true
     },
     "requireindex": {
       "version": "1.1.0",
-      "from": "requireindex@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
       "dev": true
     },
     "requires-port": {
       "version": "1.0.0",
-      "from": "requires-port@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "dev": true
     },
     "resolve": {
-      "version": "1.2.0",
-      "from": "resolve@>=1.1.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz"
+      "version": "1.2.0"
     },
     "resolve-from": {
       "version": "1.0.1",
-      "from": "resolve-from@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
       "dev": true
     },
     "restore-cursor": {
       "version": "1.0.1",
-      "from": "restore-cursor@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "dev": true
     },
     "right-align": {
-      "version": "0.1.3",
-      "from": "right-align@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
+      "version": "0.1.3"
     },
     "rimraf": {
       "version": "2.5.4",
-      "from": "rimraf@>=2.2.8 <3.0.0",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
       "dependencies": {
         "glob": {
-          "version": "7.1.1",
-          "from": "glob@>=7.0.5 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+          "version": "7.1.1"
         },
         "minimatch": {
-          "version": "3.0.3",
-          "from": "minimatch@>=3.0.2 <4.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+          "version": "3.0.3"
         }
       }
     },
     "ripemd160": {
-      "version": "0.2.0",
-      "from": "ripemd160@0.2.0",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
+      "version": "0.2.0"
     },
     "rocambole": {
       "version": "0.7.0",
-      "from": "rocambole@>=0.6.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.7.0.tgz",
       "dev": true,
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
-          "from": "esprima@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
           "dev": true
         }
       }
     },
     "rocambole-indent": {
       "version": "2.0.4",
-      "from": "rocambole-indent@>=2.0.4 <3.0.0",
-      "resolved": "https://registry.npmjs.org/rocambole-indent/-/rocambole-indent-2.0.4.tgz",
       "dev": true,
       "dependencies": {
         "mout": {
           "version": "0.11.1",
-          "from": "mout@>=0.11.0 <0.12.0",
-          "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
           "dev": true
         }
       }
     },
     "rocambole-linebreak": {
       "version": "1.0.2",
-      "from": "rocambole-linebreak@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/rocambole-linebreak/-/rocambole-linebreak-1.0.2.tgz",
       "dev": true,
       "dependencies": {
         "semver": {
           "version": "4.3.6",
-          "from": "semver@>=4.3.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "dev": true
         }
       }
     },
     "rocambole-node": {
       "version": "1.0.0",
-      "from": "rocambole-node@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/rocambole-node/-/rocambole-node-1.0.0.tgz",
       "dev": true
     },
     "rocambole-token": {
       "version": "1.2.1",
-      "from": "rocambole-token@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/rocambole-token/-/rocambole-token-1.2.1.tgz",
       "dev": true
     },
     "rocambole-whitespace": {
       "version": "1.0.0",
-      "from": "rocambole-whitespace@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/rocambole-whitespace/-/rocambole-whitespace-1.0.0.tgz",
       "dev": true
     },
     "rtlcss": {
       "version": "2.0.5",
-      "from": "rtlcss@2.0.5",
-      "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-2.0.5.tgz",
       "dependencies": {
         "strip-json-comments": {
-          "version": "2.0.1",
-          "from": "strip-json-comments@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+          "version": "2.0.1"
         }
       }
     },
     "run-async": {
       "version": "0.1.0",
-      "from": "run-async@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "dev": true
     },
     "rx-lite": {
       "version": "3.1.2",
-      "from": "rx-lite@>=3.1.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
       "dev": true
     },
     "samsam": {
       "version": "1.1.2",
-      "from": "samsam@1.1.2",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
       "dev": true
     },
     "sanitize-html": {
-      "version": "1.11.1",
-      "from": "sanitize-html@1.11.1",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.11.1.tgz"
+      "version": "1.11.1"
     },
     "sass-graph": {
       "version": "2.1.2",
-      "from": "sass-graph@>=2.1.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.1.2.tgz",
       "dependencies": {
         "cliui": {
-          "version": "3.2.0",
-          "from": "cliui@>=3.2.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz"
+          "version": "3.2.0"
         },
         "window-size": {
-          "version": "0.2.0",
-          "from": "window-size@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz"
+          "version": "0.2.0"
         },
         "yargs": {
-          "version": "4.8.1",
-          "from": "yargs@>=4.7.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz"
+          "version": "4.8.1"
         }
       }
     },
     "sax": {
       "version": "1.2.1",
-      "from": "sax@>=1.1.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "dev": true
     },
     "seed-random": {
-      "version": "2.2.0",
-      "from": "seed-random@2.2.0",
-      "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz"
+      "version": "2.2.0"
     },
     "select": {
-      "version": "1.1.0",
-      "from": "select@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "semver": {
-      "version": "5.1.0",
-      "from": "semver@5.1.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+      "version": "5.1.0"
     },
     "semver-diff": {
       "version": "2.1.0",
-      "from": "semver-diff@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "dev": true
     },
     "send": {
       "version": "0.13.0",
-      "from": "send@0.13.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.13.0.tgz",
       "dependencies": {
         "depd": {
-          "version": "1.0.1",
-          "from": "depd@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
+          "version": "1.0.1"
         },
         "http-errors": {
-          "version": "1.3.1",
-          "from": "http-errors@>=1.3.1 <1.4.0",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
+          "version": "1.3.1"
         },
         "statuses": {
-          "version": "1.2.1",
-          "from": "statuses@>=1.2.1 <1.3.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+          "version": "1.2.1"
         }
       }
     },
     "sentence-case": {
-      "version": "1.1.3",
-      "from": "sentence-case@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz"
+      "version": "1.1.3"
     },
     "serializerr": {
       "version": "1.0.3",
-      "from": "serializerr@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/serializerr/-/serializerr-1.0.3.tgz",
       "dev": true
     },
     "serve-index": {
       "version": "1.8.0",
-      "from": "serve-index@>=1.7.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz",
       "dev": true,
       "dependencies": {
         "accepts": {
           "version": "1.3.3",
-          "from": "accepts@>=1.3.3 <1.4.0",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "dev": true
         },
         "escape-html": {
           "version": "1.0.3",
-          "from": "escape-html@>=1.0.3 <1.1.0",
-          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "dev": true
         },
         "negotiator": {
           "version": "0.6.1",
-          "from": "negotiator@0.6.1",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
           "dev": true
         }
       }
     },
     "serve-static": {
       "version": "1.10.3",
-      "from": "serve-static@>=1.10.0 <1.11.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
       "dependencies": {
         "destroy": {
-          "version": "1.0.4",
-          "from": "destroy@>=1.0.4 <1.1.0",
-          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+          "version": "1.0.4"
         },
         "escape-html": {
-          "version": "1.0.3",
-          "from": "escape-html@>=1.0.3 <1.1.0",
-          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+          "version": "1.0.3"
         },
         "http-errors": {
-          "version": "1.3.1",
-          "from": "http-errors@>=1.3.1 <1.4.0",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
+          "version": "1.3.1"
         },
         "send": {
-          "version": "0.13.2",
-          "from": "send@0.13.2",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz"
+          "version": "0.13.2"
         },
         "statuses": {
-          "version": "1.2.1",
-          "from": "statuses@>=1.2.1 <1.3.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+          "version": "1.2.1"
         }
       }
     },
     "set-blocking": {
-      "version": "2.0.0",
-      "from": "set-blocking@>=2.0.0 <2.1.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "set-immediate-shim": {
-      "version": "1.0.1",
-      "from": "set-immediate-shim@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "setimmediate": {
-      "version": "1.0.5",
-      "from": "setimmediate@>=1.0.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
+      "version": "1.0.5"
     },
     "setprototypeof": {
-      "version": "1.0.2",
-      "from": "setprototypeof@1.0.2",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "sha.js": {
-      "version": "2.2.6",
-      "from": "sha.js@2.2.6",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+      "version": "2.2.6"
     },
     "shebang-regex": {
-      "version": "1.0.0",
-      "from": "shebang-regex@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "shelljs": {
       "version": "0.6.1",
-      "from": "shelljs@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
       "dev": true
     },
     "sigmund": {
       "version": "1.0.1",
-      "from": "sigmund@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.2",
-      "from": "signal-exit@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+      "version": "3.0.2"
     },
     "simple-get": {
-      "version": "1.4.3",
-      "from": "simple-get@>=1.4.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz"
+      "version": "1.4.3"
     },
     "simple-mime": {
-      "version": "0.1.0",
-      "from": "simple-mime@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/simple-mime/-/simple-mime-0.1.0.tgz"
+      "version": "0.1.0"
     },
     "sinon": {
       "version": "1.17.6",
-      "from": "sinon@1.17.6",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.6.tgz",
       "dev": true
     },
     "sinon-chai": {
       "version": "2.8.0",
-      "from": "sinon-chai@2.8.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.8.0.tgz",
       "dev": true
     },
     "slash": {
-      "version": "1.0.0",
-      "from": "slash@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "from": "slice-ansi@0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "dev": true
     },
     "snake-case": {
-      "version": "1.1.2",
-      "from": "snake-case@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "sntp": {
-      "version": "1.0.9",
-      "from": "sntp@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+      "version": "1.0.9"
     },
     "social-logos": {
-      "version": "1.0.1",
-      "from": "social-logos@1.0.1",
-      "resolved": "https://registry.npmjs.org/social-logos/-/social-logos-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "socket.io": {
       "version": "1.4.5",
-      "from": "socket.io@1.4.5",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.4.5.tgz",
       "dev": true
     },
     "socket.io-adapter": {
       "version": "0.4.0",
-      "from": "socket.io-adapter@0.4.0",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
       "dev": true,
       "dependencies": {
         "component-emitter": {
           "version": "1.1.2",
-          "from": "component-emitter@1.1.2",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
           "dev": true
         },
         "isarray": {
           "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "dev": true
         },
         "json3": {
           "version": "3.2.6",
-          "from": "json3@3.2.6",
-          "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
           "dev": true
         },
         "socket.io-parser": {
           "version": "2.2.2",
-          "from": "socket.io-parser@2.2.2",
-          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
           "dev": true,
           "dependencies": {
             "debug": {
               "version": "0.7.4",
-              "from": "debug@0.7.4",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
               "dev": true
             }
           }
@@ -6458,840 +3625,532 @@
       }
     },
     "socket.io-client": {
-      "version": "1.4.5",
-      "from": "socket.io-client@1.4.5",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.4.5.tgz"
+      "version": "1.4.5"
     },
     "socket.io-parser": {
       "version": "2.2.6",
-      "from": "socket.io-parser@2.2.6",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
       "dependencies": {
         "component-emitter": {
-          "version": "1.1.2",
-          "from": "component-emitter@1.1.2",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+          "version": "1.1.2"
         },
         "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+          "version": "0.0.1"
         }
       }
     },
     "sortobject": {
       "version": "1.1.1",
-      "from": "sortobject@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sortobject/-/sortobject-1.1.1.tgz",
       "dev": true
     },
     "source-list-map": {
-      "version": "0.1.8",
-      "from": "source-list-map@0.1.8",
-      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz"
+      "version": "0.1.8"
     },
     "source-map": {
-      "version": "0.1.39",
-      "from": "source-map@0.1.39",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.39.tgz"
+      "version": "0.1.39"
     },
     "source-map-loader": {
-      "version": "0.1.5",
-      "from": "source-map-loader@0.1.5",
-      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.1.5.tgz"
+      "version": "0.1.5"
     },
     "source-map-support": {
       "version": "0.3.2",
-      "from": "source-map-support@0.3.2",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.2.tgz",
       "dependencies": {
         "source-map": {
-          "version": "0.1.32",
-          "from": "source-map@0.1.32",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz"
+          "version": "0.1.32"
         }
       }
     },
     "spdx-correct": {
-      "version": "1.0.2",
-      "from": "spdx-correct@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "spdx-expression-parse": {
-      "version": "1.0.4",
-      "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+      "version": "1.0.4"
     },
     "spdx-license-ids": {
-      "version": "1.2.2",
-      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+      "version": "1.2.2"
     },
     "specificity": {
       "version": "0.2.1",
-      "from": "specificity@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.2.1.tgz",
       "dev": true
     },
     "split2": {
       "version": "0.2.1",
-      "from": "split2@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-0.2.1.tgz",
       "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "from": "sprintf-js@>=1.0.2 <1.1.0",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "dev": true
     },
     "sshpk": {
       "version": "1.10.2",
-      "from": "sshpk@1.10.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+          "version": "1.0.0"
         }
       }
     },
     "statuses": {
-      "version": "1.3.1",
-      "from": "statuses@>=1.3.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+      "version": "1.3.1"
     },
     "stdin": {
       "version": "0.0.1",
-      "from": "stdin@*",
-      "resolved": "https://registry.npmjs.org/stdin/-/stdin-0.0.1.tgz",
       "dev": true
     },
     "store": {
-      "version": "1.3.16",
-      "from": "store@1.3.16",
-      "resolved": "https://registry.npmjs.org/store/-/store-1.3.16.tgz"
+      "version": "1.3.16"
     },
     "stream-browserify": {
-      "version": "1.0.0",
-      "from": "stream-browserify@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "stream-cache": {
       "version": "0.0.2",
-      "from": "stream-cache@>=0.0.1 <0.1.0",
-      "resolved": "https://registry.npmjs.org/stream-cache/-/stream-cache-0.0.2.tgz",
       "dev": true
     },
     "stream-combiner": {
       "version": "0.2.2",
-      "from": "stream-combiner@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
       "dev": true
     },
     "stream-shift": {
       "version": "1.0.0",
-      "from": "stream-shift@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "dev": true
     },
     "string_decoder": {
-      "version": "0.10.31",
-      "from": "string_decoder@>=0.10.0 <0.11.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+      "version": "0.10.31"
     },
     "string-length": {
       "version": "1.0.1",
-      "from": "string-length@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
       "dev": true
     },
     "string-width": {
-      "version": "1.0.2",
-      "from": "string-width@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "stringify-object": {
       "version": "2.4.0",
-      "from": "stringify-object@>=2.3.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-2.4.0.tgz",
       "dev": true
     },
     "stringstream": {
-      "version": "0.0.5",
-      "from": "stringstream@>=0.0.4 <0.1.0",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+      "version": "0.0.5"
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "from": "strip-ansi@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+      "version": "3.0.1"
     },
     "strip-bom": {
-      "version": "2.0.0",
-      "from": "strip-bom@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "strip-indent": {
-      "version": "1.0.1",
-      "from": "strip-indent@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "strip-json-comments": {
-      "version": "1.0.4",
-      "from": "strip-json-comments@>=1.0.4 <1.1.0",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+      "version": "1.0.4"
     },
     "striptags": {
-      "version": "2.1.1",
-      "from": "striptags@2.1.1",
-      "resolved": "https://registry.npmjs.org/striptags/-/striptags-2.1.1.tgz"
+      "version": "2.1.1"
     },
     "stylehacks": {
       "version": "2.3.1",
-      "from": "stylehacks@>=2.3.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-2.3.1.tgz",
       "dev": true,
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dev": true
         },
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.2.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "dev": true
         }
       }
     },
     "stylelint": {
       "version": "6.9.0",
-      "from": "stylelint@>=6.5.1 <7.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-6.9.0.tgz",
       "dev": true,
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dev": true
         },
         "entities": {
           "version": "1.1.1",
-          "from": "entities@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
           "dev": true
         },
         "get-stdin": {
           "version": "5.0.1",
-          "from": "get-stdin@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
           "dev": true
         },
         "globby": {
           "version": "5.0.0",
-          "from": "globby@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
           "dev": true
         },
         "htmlparser2": {
           "version": "3.9.2",
-          "from": "htmlparser2@>=3.9.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
           "dev": true
         },
         "readable-stream": {
           "version": "2.2.2",
-          "from": "readable-stream@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
           "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
-          "from": "resolve-from@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "dev": true
         }
       }
     },
     "sugarss": {
       "version": "0.1.6",
-      "from": "sugarss@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-0.1.6.tgz",
       "dev": true
     },
     "superagent": {
       "version": "2.1.0",
-      "from": "superagent@2.1.0",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-2.1.0.tgz",
       "dependencies": {
         "async": {
-          "version": "1.5.2",
-          "from": "async@>=1.5.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+          "version": "1.5.2"
         },
         "form-data": {
-          "version": "1.0.0-rc4",
-          "from": "form-data@1.0.0-rc4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
+          "version": "1.0.0-rc4"
         },
         "qs": {
-          "version": "6.3.0",
-          "from": "qs@>=6.1.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
+          "version": "6.3.0"
         },
         "readable-stream": {
-          "version": "2.2.2",
-          "from": "readable-stream@>=2.0.5 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          "version": "2.2.2"
         }
       }
     },
     "supertest": {
       "version": "2.0.0",
-      "from": "supertest@2.0.0",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-2.0.0.tgz",
       "dev": true
     },
     "supports-color": {
-      "version": "3.2.3",
-      "from": "supports-color@3.2.3",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+      "version": "3.2.3"
     },
     "svg-tags": {
       "version": "1.0.0",
-      "from": "svg-tags@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
       "dev": true
     },
     "swap-case": {
-      "version": "1.1.2",
-      "from": "swap-case@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "symbol-tree": {
       "version": "3.2.1",
-      "from": "symbol-tree@>=3.1.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.1.tgz",
       "dev": true
     },
     "sync-exec": {
       "version": "0.5.0",
-      "from": "sync-exec@>=0.5.0 <0.6.0",
-      "resolved": "https://registry.npmjs.org/sync-exec/-/sync-exec-0.5.0.tgz",
       "dev": true
     },
     "synesthesia": {
       "version": "1.0.1",
-      "from": "synesthesia@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/synesthesia/-/synesthesia-1.0.1.tgz",
       "dev": true
     },
     "table": {
       "version": "3.8.3",
-      "from": "table@>=3.7.8 <4.0.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "dev": true,
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "dev": true
         },
         "string-width": {
           "version": "2.0.0",
-          "from": "string-width@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "dev": true
         }
       }
     },
     "tapable": {
-      "version": "0.1.10",
-      "from": "tapable@>=0.1.8 <0.2.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
+      "version": "0.1.10"
     },
     "tar": {
-      "version": "2.2.1",
-      "from": "tar@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+      "version": "2.2.1"
     },
     "tar-fs": {
-      "version": "1.15.0",
-      "from": "tar-fs@>=1.7.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.0.tgz"
+      "version": "1.15.0"
     },
     "tar-stream": {
       "version": "1.5.2",
-      "from": "tar-stream@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
       "dependencies": {
         "readable-stream": {
-          "version": "2.2.2",
-          "from": "readable-stream@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          "version": "2.2.2"
         }
       }
     },
     "text-table": {
       "version": "0.2.0",
-      "from": "text-table@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "dev": true
     },
     "through": {
-      "version": "2.3.8",
-      "from": "through@>=2.3.6 <2.4.0",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      "version": "2.3.8"
     },
     "through2": {
       "version": "0.6.5",
-      "from": "through2@>=0.6.3 <0.7.0",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+          "version": "0.0.1"
         },
         "readable-stream": {
-          "version": "1.0.34",
-          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+          "version": "1.0.34"
         }
       }
     },
     "timed-out": {
       "version": "2.0.0",
-      "from": "timed-out@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
       "dev": true
     },
     "timers-browserify": {
-      "version": "1.4.2",
-      "from": "timers-browserify@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
+      "version": "1.4.2"
     },
     "tiny-emitter": {
-      "version": "1.1.0",
-      "from": "tiny-emitter@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "tinymce": {
-      "version": "4.3.12",
-      "from": "tinymce@4.3.12",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-4.3.12.tgz"
+      "version": "4.3.12"
     },
     "title-case": {
-      "version": "1.1.2",
-      "from": "title-case@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "title-case-minors": {
-      "version": "0.0.2",
-      "from": "title-case-minors@0.0.2",
-      "resolved": "https://registry.npmjs.org/title-case-minors/-/title-case-minors-0.0.2.tgz"
+      "version": "0.0.2"
     },
     "to-array": {
-      "version": "0.1.4",
-      "from": "to-array@0.1.4",
-      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz"
+      "version": "0.1.4"
     },
     "to-camel-case": {
-      "version": "1.0.0",
-      "from": "to-camel-case@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/to-camel-case/-/to-camel-case-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "to-capital-case": {
       "version": "0.1.1",
-      "from": "to-capital-case@0.1.1",
-      "resolved": "https://registry.npmjs.org/to-capital-case/-/to-capital-case-0.1.1.tgz",
       "dependencies": {
         "to-no-case": {
-          "version": "0.1.1",
-          "from": "to-no-case@0.1.1",
-          "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-0.1.1.tgz"
+          "version": "0.1.1"
         }
       }
     },
     "to-fast-properties": {
-      "version": "1.0.2",
-      "from": "to-fast-properties@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "to-no-case": {
-      "version": "1.0.2",
-      "from": "to-no-case@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "to-space-case": {
-      "version": "1.0.0",
-      "from": "to-space-case@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "to-title-case": {
-      "version": "0.1.5",
-      "from": "to-title-case@0.1.5",
-      "resolved": "https://registry.npmjs.org/to-title-case/-/to-title-case-0.1.5.tgz"
+      "version": "0.1.5"
     },
     "token-stream": {
-      "version": "0.0.1",
-      "from": "token-stream@0.0.1",
-      "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-0.0.1.tgz"
+      "version": "0.0.1"
     },
     "touch": {
       "version": "1.0.0",
-      "from": "touch@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
       "dev": true,
       "dependencies": {
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@>=1.0.10 <1.1.0",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dev": true
         }
       }
     },
     "tough-cookie": {
-      "version": "2.3.2",
-      "from": "tough-cookie@>=2.3.0 <2.4.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
+      "version": "2.3.2"
     },
     "tr46": {
       "version": "0.0.3",
-      "from": "tr46@>=0.0.3 <0.1.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "dev": true
     },
     "tracekit": {
-      "version": "0.4.3",
-      "from": "tracekit@0.4.3",
-      "resolved": "https://registry.npmjs.org/tracekit/-/tracekit-0.4.3.tgz"
+      "version": "0.4.3"
     },
     "traverse": {
       "version": "0.6.6",
-      "from": "traverse@>=0.6.6 <0.7.0",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "dev": true
     },
     "trim-newlines": {
-      "version": "1.0.0",
-      "from": "trim-newlines@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "tryit": {
       "version": "1.0.3",
-      "from": "tryit@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
       "dev": true
     },
     "tty-browserify": {
-      "version": "0.0.0",
-      "from": "tty-browserify@0.0.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+      "version": "0.0.0"
     },
     "tunnel-agent": {
-      "version": "0.4.3",
-      "from": "tunnel-agent@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+      "version": "0.4.3"
     },
     "tween.js": {
-      "version": "16.3.1",
-      "from": "tween.js@16.3.1",
-      "resolved": "https://registry.npmjs.org/tween.js/-/tween.js-16.3.1.tgz"
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "from": "tweetnacl@>=0.14.0 <0.15.0",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "optional": true
+      "version": "16.3.1"
     },
     "twemoji": {
-      "version": "1.3.2",
-      "from": "twemoji@1.3.2",
-      "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-1.3.2.tgz"
+      "version": "1.3.2"
     },
     "type-check": {
       "version": "0.3.2",
-      "from": "type-check@>=0.3.2 <0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "dev": true
     },
     "type-detect": {
       "version": "1.0.0",
-      "from": "type-detect@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
       "dev": true
     },
     "type-is": {
-      "version": "1.6.14",
-      "from": "type-is@>=1.6.13 <1.7.0",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz"
+      "version": "1.6.14"
     },
     "typedarray": {
-      "version": "0.0.6",
-      "from": "typedarray@>=0.0.5 <0.1.0",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+      "version": "0.0.6"
     },
     "ua-parser-js": {
-      "version": "0.7.12",
-      "from": "ua-parser-js@>=0.7.9 <0.8.0",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz"
+      "version": "0.7.12"
     },
     "uglify-js": {
       "version": "2.7.0",
-      "from": "uglify-js@2.7.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.0.tgz",
       "dependencies": {
         "async": {
-          "version": "0.2.10",
-          "from": "async@>=0.2.6 <0.3.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+          "version": "0.2.10"
         },
         "source-map": {
-          "version": "0.5.6",
-          "from": "source-map@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+          "version": "0.5.6"
         }
       }
     },
     "uglify-to-browserify": {
-      "version": "1.0.2",
-      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "uid": {
-      "version": "0.0.2",
-      "from": "uid@0.0.2",
-      "resolved": "https://registry.npmjs.org/uid/-/uid-0.0.2.tgz"
+      "version": "0.0.2"
     },
     "ultron": {
-      "version": "1.0.2",
-      "from": "ultron@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "uniq": {
       "version": "1.0.1",
-      "from": "uniq@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "dev": true
     },
     "unpipe": {
-      "version": "1.0.0",
-      "from": "unpipe@1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "unquoted-property-validator": {
       "version": "1.0.0",
-      "from": "unquoted-property-validator@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/unquoted-property-validator/-/unquoted-property-validator-1.0.0.tgz",
       "dev": true
     },
     "unreachable-branch-transform": {
       "version": "0.3.0",
-      "from": "unreachable-branch-transform@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.3.0.tgz",
       "dependencies": {
         "ast-types": {
-          "version": "0.8.15",
-          "from": "ast-types@0.8.15",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz"
+          "version": "0.8.15"
         },
         "esprima-fb": {
-          "version": "15001.1001.0-dev-harmony-fb",
-          "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+          "version": "15001.1001.0-dev-harmony-fb"
         },
         "recast": {
-          "version": "0.10.43",
-          "from": "recast@>=0.10.1 <0.11.0",
-          "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz"
+          "version": "0.10.43"
         },
         "source-map": {
-          "version": "0.5.6",
-          "from": "source-map@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+          "version": "0.5.6"
         }
       }
     },
     "unzip-response": {
-      "version": "1.0.2",
-      "from": "unzip-response@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "update-notifier": {
       "version": "0.3.2",
-      "from": "update-notifier@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.3.2.tgz",
       "dev": true
     },
     "upper-case": {
-      "version": "1.1.3",
-      "from": "upper-case@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz"
+      "version": "1.1.3"
     },
     "upper-case-first": {
-      "version": "1.1.2",
-      "from": "upper-case-first@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "uppercamelcase": {
-      "version": "1.1.0",
-      "from": "uppercamelcase@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/uppercamelcase/-/uppercamelcase-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "url": {
       "version": "0.10.3",
-      "from": "url@>=0.10.1 <0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
       "dependencies": {
         "punycode": {
-          "version": "1.3.2",
-          "from": "punycode@1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+          "version": "1.3.2"
         }
       }
     },
     "url-template": {
-      "version": "2.0.8",
-      "from": "url-template@>=2.0.6 <2.1.0",
-      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz"
+      "version": "2.0.8"
     },
     "user-home": {
-      "version": "1.1.1",
-      "from": "user-home@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+      "version": "1.1.1"
     },
     "utf8": {
-      "version": "2.1.0",
-      "from": "utf8@2.1.0",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz"
+      "version": "2.1.0"
     },
     "util": {
-      "version": "0.10.3",
-      "from": "util@>=0.10.3 <0.11.0",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+      "version": "0.10.3"
     },
     "util-deprecate": {
-      "version": "1.0.2",
-      "from": "util-deprecate@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "util-extend": {
-      "version": "1.0.3",
-      "from": "util-extend@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz"
+      "version": "1.0.3"
     },
     "utils-merge": {
-      "version": "1.0.0",
-      "from": "utils-merge@1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "uuid": {
-      "version": "2.0.1",
-      "from": "uuid@2.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+      "version": "2.0.1"
     },
     "valid-url": {
-      "version": "1.0.9",
-      "from": "valid-url@1.0.9",
-      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz"
+      "version": "1.0.9"
     },
     "validate-npm-package-license": {
-      "version": "3.0.1",
-      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+      "version": "3.0.1"
     },
     "vary": {
-      "version": "1.0.1",
-      "from": "vary@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "verror": {
-      "version": "1.3.6",
-      "from": "verror@1.3.6",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+      "version": "1.3.6"
     },
     "vm-browserify": {
-      "version": "0.0.4",
-      "from": "vm-browserify@0.0.4",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
+      "version": "0.0.4"
     },
     "void-elements": {
-      "version": "2.0.1",
-      "from": "void-elements@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz"
+      "version": "2.0.1"
     },
     "walk": {
-      "version": "2.3.4",
-      "from": "walk@2.3.4",
-      "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.4.tgz"
+      "version": "2.3.4"
     },
     "watchpack": {
-      "version": "0.2.9",
-      "from": "watchpack@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz"
+      "version": "0.2.9"
     },
     "webidl-conversions": {
       "version": "3.0.1",
-      "from": "webidl-conversions@>=3.0.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "dev": true
     },
     "webpack": {
       "version": "1.13.1",
-      "from": "webpack@1.13.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.13.1.tgz",
       "dependencies": {
         "async": {
-          "version": "1.5.2",
-          "from": "async@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+          "version": "1.5.2"
         },
         "source-map": {
-          "version": "0.5.6",
-          "from": "source-map@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+          "version": "0.5.6"
         },
         "uglify-js": {
           "version": "2.6.4",
-          "from": "uglify-js@>=2.6.0 <2.7.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
           "dependencies": {
             "async": {
-              "version": "0.2.10",
-              "from": "async@>=0.2.6 <0.3.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+              "version": "0.2.10"
             }
           }
         }
@@ -7299,610 +4158,397 @@
     },
     "webpack-bundle-analyzer": {
       "version": "2.2.1",
-      "from": "webpack-bundle-analyzer@2.2.1",
-      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.2.1.tgz",
       "dev": true,
       "dependencies": {
         "accepts": {
           "version": "1.3.3",
-          "from": "accepts@1.3.3",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "dev": true
         },
         "acorn": {
           "version": "4.0.4",
-          "from": "acorn@4.0.4",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dev": true
         },
         "commander": {
           "version": "2.9.0",
-          "from": "commander@2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "dev": true
         },
         "content-disposition": {
           "version": "0.5.1",
-          "from": "content-disposition@0.5.1",
-          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
           "dev": true
         },
         "cookie": {
           "version": "0.3.1",
-          "from": "cookie@0.3.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
           "dev": true
         },
         "cookie-signature": {
           "version": "1.0.6",
-          "from": "cookie-signature@1.0.6",
-          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
           "dev": true
         },
         "destroy": {
           "version": "1.0.4",
-          "from": "destroy@1.0.4",
-          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
           "dev": true
         },
         "escape-html": {
           "version": "1.0.3",
-          "from": "escape-html@1.0.3",
-          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "dev": true
         },
         "express": {
           "version": "4.14.0",
-          "from": "express@4.14.0",
-          "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
           "dev": true
         },
         "filesize": {
-          "version": "3.3.0",
-          "from": "filesize@3.3.0",
-          "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.3.0.tgz",
+          "version": "3.4.1",
           "dev": true
         },
         "finalhandler": {
           "version": "0.5.0",
-          "from": "finalhandler@0.5.0",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
           "dev": true
         },
         "ipaddr.js": {
           "version": "1.2.0",
-          "from": "ipaddr.js@1.2.0",
-          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz",
           "dev": true
         },
         "lodash": {
           "version": "4.17.4",
-          "from": "lodash@4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "dev": true
         },
         "merge-descriptors": {
           "version": "1.0.1",
-          "from": "merge-descriptors@1.0.1",
-          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "dev": true
         },
         "negotiator": {
           "version": "0.6.1",
-          "from": "negotiator@0.6.1",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
           "dev": true
         },
         "proxy-addr": {
           "version": "1.1.3",
-          "from": "proxy-addr@1.1.3",
-          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.3.tgz",
           "dev": true
         },
         "qs": {
           "version": "6.2.0",
-          "from": "qs@6.2.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
           "dev": true
         },
         "range-parser": {
           "version": "1.2.0",
-          "from": "range-parser@1.2.0",
-          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
           "dev": true
         },
         "send": {
           "version": "0.14.1",
-          "from": "send@0.14.1",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
           "dev": true
         },
         "serve-static": {
           "version": "1.11.1",
-          "from": "serve-static@1.11.1",
-          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "from": "supports-color@2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "dev": true
         },
         "vary": {
           "version": "1.1.0",
-          "from": "vary@1.1.0",
-          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
           "dev": true
         }
       }
     },
     "webpack-core": {
       "version": "0.6.9",
-      "from": "webpack-core@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
       "dependencies": {
         "source-map": {
-          "version": "0.4.4",
-          "from": "source-map@>=0.4.1 <0.5.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+          "version": "0.4.4"
         }
       }
     },
     "webpack-dashboard": {
       "version": "0.2.0",
-      "from": "webpack-dashboard@0.2.0",
-      "resolved": "https://registry.npmjs.org/webpack-dashboard/-/webpack-dashboard-0.2.0.tgz",
       "dev": true,
       "dependencies": {
         "accepts": {
           "version": "1.3.3",
-          "from": "accepts@1.3.3",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "dev": true
         },
         "base64-arraybuffer": {
           "version": "0.1.5",
-          "from": "base64-arraybuffer@0.1.5",
-          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
           "dev": true
         },
         "base64id": {
           "version": "1.0.0",
-          "from": "base64id@1.0.0",
-          "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
           "dev": true
         },
         "commander": {
           "version": "2.9.0",
-          "from": "commander@>=2.9.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "dev": true
         },
         "component-emitter": {
           "version": "1.1.2",
-          "from": "component-emitter@1.1.2",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
           "dev": true
         },
         "cookie": {
           "version": "0.3.1",
-          "from": "cookie@0.3.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
           "dev": true
         },
         "debug": {
           "version": "2.3.3",
-          "from": "debug@2.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "dev": true
         },
         "engine.io": {
           "version": "1.8.2",
-          "from": "engine.io@1.8.2",
-          "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.2.tgz",
           "dev": true
         },
         "engine.io-client": {
           "version": "1.8.2",
-          "from": "engine.io-client@1.8.2",
-          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.2.tgz",
           "dev": true,
           "dependencies": {
             "component-emitter": {
               "version": "1.2.1",
-              "from": "component-emitter@1.2.1",
-              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
               "dev": true
             }
           }
         },
         "engine.io-parser": {
           "version": "1.3.2",
-          "from": "engine.io-parser@1.3.2",
-          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
           "dev": true
         },
         "filesize": {
-          "version": "3.3.0",
-          "from": "filesize@>=3.3.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.3.0.tgz",
+          "version": "3.4.1",
           "dev": true
         },
         "isarray": {
           "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "dev": true
         },
         "ms": {
           "version": "0.7.2",
-          "from": "ms@0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
           "dev": true
         },
         "negotiator": {
           "version": "0.6.1",
-          "from": "negotiator@0.6.1",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.0",
-          "from": "object-assign@4.1.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "dev": true
         },
         "parsejson": {
           "version": "0.0.3",
-          "from": "parsejson@0.0.3",
-          "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
           "dev": true
         },
         "parseqs": {
           "version": "0.0.5",
-          "from": "parseqs@0.0.5",
-          "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
           "dev": true
         },
         "parseuri": {
           "version": "0.0.5",
-          "from": "parseuri@0.0.5",
-          "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
           "dev": true
         },
         "socket.io": {
           "version": "1.7.2",
-          "from": "socket.io@>=1.4.8 <2.0.0",
-          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.2.tgz",
           "dev": true
         },
         "socket.io-adapter": {
           "version": "0.5.0",
-          "from": "socket.io-adapter@0.5.0",
-          "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
           "dev": true
         },
         "socket.io-client": {
           "version": "1.7.2",
-          "from": "socket.io-client@>=1.4.8 <2.0.0",
-          "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.2.tgz",
           "dev": true,
           "dependencies": {
             "component-emitter": {
               "version": "1.2.1",
-              "from": "component-emitter@1.2.1",
-              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
               "dev": true
             }
           }
         },
         "socket.io-parser": {
           "version": "2.3.1",
-          "from": "socket.io-parser@2.3.1",
-          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
           "dev": true,
           "dependencies": {
             "debug": {
               "version": "2.2.0",
-              "from": "debug@2.2.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dev": true
             },
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "dev": true
             }
           }
         },
         "ws": {
           "version": "1.1.1",
-          "from": "ws@1.1.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
           "dev": true
         },
         "xmlhttprequest-ssl": {
           "version": "1.5.3",
-          "from": "xmlhttprequest-ssl@1.5.3",
-          "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
           "dev": true
         }
       }
     },
     "webpack-dev-middleware": {
       "version": "1.2.0",
-      "from": "webpack-dev-middleware@1.2.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.2.0.tgz",
       "dependencies": {
         "memory-fs": {
-          "version": "0.2.0",
-          "from": "memory-fs@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
+          "version": "0.2.0"
         }
       }
     },
     "webpack-dev-server": {
       "version": "1.11.0",
-      "from": "webpack-dev-server@1.11.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.11.0.tgz",
       "dev": true
     },
     "webpack-sources": {
       "version": "0.1.4",
-      "from": "webpack-sources@0.1.4",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.4.tgz",
       "dependencies": {
         "source-map": {
-          "version": "0.5.6",
-          "from": "source-map@>=0.5.3 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+          "version": "0.5.6"
         }
       }
     },
     "wemoji": {
-      "version": "0.1.9",
-      "from": "wemoji@>=0.1.9 <0.2.0",
-      "resolved": "https://registry.npmjs.org/wemoji/-/wemoji-0.1.9.tgz"
+      "version": "0.1.9"
     },
     "whatwg-fetch": {
-      "version": "2.0.1",
-      "from": "whatwg-fetch@>=0.10.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.1.tgz"
+      "version": "2.0.2"
     },
     "whatwg-url": {
       "version": "3.1.0",
-      "from": "whatwg-url@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-3.1.0.tgz",
       "dev": true
     },
-    "whatwg-url-compat": {
-      "version": "0.6.5",
-      "from": "whatwg-url-compat@>=0.6.5 <0.7.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz",
-      "dev": true,
-      "optional": true
-    },
     "which": {
-      "version": "1.2.12",
-      "from": "which@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz"
+      "version": "1.2.12"
     },
     "which-module": {
-      "version": "1.0.0",
-      "from": "which-module@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "wide-align": {
-      "version": "1.1.0",
-      "from": "wide-align@1.1.0",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "window-size": {
-      "version": "0.1.0",
-      "from": "window-size@0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+      "version": "0.1.0"
     },
     "with": {
-      "version": "5.1.1",
-      "from": "with@>=5.0.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/with/-/with-5.1.1.tgz"
+      "version": "5.1.1"
     },
     "wordwrap": {
-      "version": "0.0.2",
-      "from": "wordwrap@0.0.2",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+      "version": "0.0.2"
     },
     "wp-error": {
-      "version": "1.3.0",
-      "from": "wp-error@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/wp-error/-/wp-error-1.3.0.tgz"
+      "version": "1.3.0"
     },
     "wpcom": {
-      "version": "5.3.0",
-      "from": "wpcom@5.3.0",
-      "resolved": "https://registry.npmjs.org/wpcom/-/wpcom-5.3.0.tgz"
+      "version": "5.3.0"
     },
     "wpcom-oauth": {
       "version": "0.3.3",
-      "from": "wpcom-oauth@0.3.3",
-      "resolved": "https://registry.npmjs.org/wpcom-oauth/-/wpcom-oauth-0.3.3.tgz",
       "dependencies": {
         "cookiejar": {
-          "version": "1.3.0",
-          "from": "cookiejar@1.3.0",
-          "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-1.3.0.tgz"
+          "version": "1.3.0"
         },
         "extend": {
-          "version": "1.2.1",
-          "from": "extend@>=1.2.1 <1.3.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz"
+          "version": "1.2.1"
         },
         "formidable": {
-          "version": "1.0.14",
-          "from": "formidable@1.0.14",
-          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz"
+          "version": "1.0.14"
         },
         "methods": {
-          "version": "0.0.1",
-          "from": "methods@0.0.1",
-          "resolved": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz"
+          "version": "0.0.1"
         },
         "mime": {
-          "version": "1.2.5",
-          "from": "mime@1.2.5",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.5.tgz"
+          "version": "1.2.5"
         },
         "qs": {
-          "version": "0.6.5",
-          "from": "qs@0.6.5",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.5.tgz"
+          "version": "0.6.5"
         },
         "superagent": {
           "version": "0.17.0",
-          "from": "superagent@0.17.0",
-          "resolved": "https://registry.npmjs.org/superagent/-/superagent-0.17.0.tgz",
           "dependencies": {
             "debug": {
-              "version": "0.7.4",
-              "from": "debug@>=0.7.2 <0.8.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+              "version": "0.7.4"
             }
           }
         }
       }
     },
     "wpcom-proxy-request": {
-      "version": "3.0.0",
-      "from": "wpcom-proxy-request@3.0.0",
-      "resolved": "https://registry.npmjs.org/wpcom-proxy-request/-/wpcom-proxy-request-3.0.0.tgz"
+      "version": "3.0.0"
     },
     "wpcom-xhr-request": {
-      "version": "1.0.0",
-      "from": "wpcom-xhr-request@1.0.0",
-      "resolved": "https://registry.npmjs.org/wpcom-xhr-request/-/wpcom-xhr-request-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "wrap-ansi": {
-      "version": "2.1.0",
-      "from": "wrap-ansi@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
+      "version": "2.1.0"
     },
     "wrappy": {
-      "version": "1.0.2",
-      "from": "wrappy@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "write": {
       "version": "0.2.1",
-      "from": "write@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "dev": true
     },
     "write-file-stdout": {
       "version": "0.0.2",
-      "from": "write-file-stdout@0.0.2",
-      "resolved": "https://registry.npmjs.org/write-file-stdout/-/write-file-stdout-0.0.2.tgz",
       "dev": true
     },
     "ws": {
-      "version": "1.0.1",
-      "from": "ws@1.0.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "wtf-8": {
       "version": "1.0.0",
-      "from": "wtf-8@1.0.0",
-      "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
       "dev": true
     },
     "xdg-basedir": {
       "version": "1.0.1",
-      "from": "xdg-basedir@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz",
       "dev": true
     },
     "xgettext-js": {
       "version": "1.0.0",
-      "from": "xgettext-js@1.0.0",
-      "resolved": "https://registry.npmjs.org/xgettext-js/-/xgettext-js-1.0.0.tgz",
       "dependencies": {
         "babylon": {
-          "version": "6.8.4",
-          "from": "babylon@6.8.4",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.4.tgz"
+          "version": "6.8.4"
         }
       }
     },
     "xml": {
       "version": "1.0.1",
-      "from": "xml@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
       "dev": true
     },
     "xml-char-classes": {
-      "version": "1.0.0",
-      "from": "xml-char-classes@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "xml-name-validator": {
       "version": "2.0.1",
-      "from": "xml-name-validator@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
       "dev": true
     },
     "xmlhttprequest-ssl": {
-      "version": "1.5.1",
-      "from": "xmlhttprequest-ssl@1.5.1",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz"
+      "version": "1.5.1"
     },
     "xtend": {
-      "version": "4.0.1",
-      "from": "xtend@>=4.0.0 <4.1.0",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      "version": "4.0.1"
     },
     "y18n": {
-      "version": "3.2.1",
-      "from": "y18n@>=3.2.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
+      "version": "3.2.1"
     },
     "yallist": {
-      "version": "2.0.0",
-      "from": "yallist@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "yargs": {
-      "version": "3.10.0",
-      "from": "yargs@>=3.10.0 <3.11.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+      "version": "3.10.0"
     },
     "yargs-parser": {
       "version": "2.4.1",
-      "from": "yargs-parser@>=2.4.1 <3.0.0",
-      "resolved": "https://registry.npmjs.com/yargs-parser/-/yargs-parser-2.4.1.tgz",
       "dependencies": {
         "camelcase": {
-          "version": "3.0.0",
-          "from": "camelcase@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+          "version": "3.0.0"
         }
       }
     },
     "yeast": {
-      "version": "0.1.2",
-      "from": "yeast@0.1.2",
-      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz"
+      "version": "0.1.2"
     },
     "zero-fill": {
-      "version": "2.2.3",
-      "from": "zero-fill@>=2.2.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/zero-fill/-/zero-fill-2.2.3.tgz"
+      "version": "2.2.3"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "react-docgen": "2.13.0",
     "react-dom": "15.4.0",
     "react-masonry-component": "4.2.2",
+    "react-modal": "1.6.5",
     "react-pure-render": "1.0.2",
     "react-redux": "4.4.5",
     "react-virtualized": "8.8.1",


### PR DESCRIPTION
Rationale: Lets us avoid SSR-incompatible dependencies, mixins, and removes some implementation burden.  `react-modal` seems to be pretty well-maintained and official-ish (lives in the `reactjs` GitHub org).

To test:
* Check that Dialog still works in all (heh) contexts. Some examples:
 * Site Selector Modal: `/design`, clicking any theme action
 * `lib/accept`, e.g. `/design/<jetpacksite>`, delete theme
 * `/media` section/image editor, since it's using one of the more obscure props that are being replaced (see 'Notes' below)
* Specifically, check that
  * Styling is unchanged with respect to `master`/production
  * Dialog buttons work
  * Clicking outside the dialog closes it
  * Hitting Esc closes it

Notes:
* This loses `Dialog`'s `enterTimeout, `transitionLeave`, and `onClickOutside` props.
  * `enterTimeout` wasn't used at all
  * `transitionLeave` defaulted to `true` and was only set (to `false`) by `disconnect-jetpack-dialog.jsx`. I've removed it.
  * `onClickOutside` was used twice
    * one of which was incorrect and without effect AFAICS (`my-sites/media/main.jsx`)
    * I changed the other to use `react-modal`'s `shouldCloseOnOverlayClick` prop, but that still lost a criterion which I hope was only for "outside" detection (`post-editor/media-modal/index.jsx`)