### PR TITLE
Proper check for the passed progress store

### DIFF
--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -91,7 +91,7 @@ export default React.createClass( {
 			initialState: this.props.step ? this.props.step.form : undefined
 		} );
 		let initialState = this.formStateController.getInitialState();
-		if ( this.props.signupProgressStore ) {
+		if ( this.props.signupProgress ) {
 			initialState = this.autoFillUsername( initialState );
 		}
 		this.setState( { form: initialState } );


### PR DESCRIPTION
Since #10795 contains some refactoring that will take a bit more time, this PR fixes the problem at hand.

Copying testing instructions from the original PR:


## To test:

### Test free username:
1. Start Signup
2. Go through Signup
3. Select a domain name which would result a free username suggestion ( e.g. `something123455123` )
4. Choose the free `wordpress.com` address
5. Reach the User step
6. See if the `username` field is properly filled up with the domain slug you wrote.

### To test a taken username:

1. Start Signup
2. Go through Signup
3. Type `kwight` in the domain search box
4. Choose `kwight.me`
5. Choose a random plan
6. Reach the User step
7. See if the username is `kwightweb` or something different than `kwight`

