### PR TITLE
Guided Tours: Bail if fresh user prefs missing

### DIFF
--- a/client/state/ui/guided-tours/selectors/index.js
+++ b/client/state/ui/guided-tours/selectors/index.js
@@ -206,9 +206,11 @@ const getRawGuidedTourState = state => get( state, 'ui.guidedTour', false );
 
 export const getGuidedTourState = createSelector(
 	state => {
+		const emptyState = { shouldShow: false };
+
 		if ( ! preferencesLastFetchedTimestamp( state ) ) {
 			debug( 'No fresh user preferences, bailing.' );
-			return {};
+			return emptyState;
 		}
 
 		const tourState = getRawGuidedTourState( state );
@@ -221,10 +223,7 @@ export const getGuidedTourState = createSelector(
 			'found', tour );
 
 		if ( ! tour ) {
-			return {
-				...tourState,
-				shouldShow: false,
-			};
+			return { ...tourState, ...emptyState };
 		}
 
 		return {

--- a/client/state/ui/guided-tours/selectors/index.js
+++ b/client/state/ui/guided-tours/selectors/index.js
@@ -24,7 +24,10 @@ import {
 } from 'state/action-types';
 import { getInitialQueryArguments, getSectionName } from 'state/ui/selectors';
 import { getActionLog } from 'state/ui/action-log/selectors';
-import { getPreference } from 'state/preferences/selectors';
+import {
+	getPreference,
+	preferencesLastFetchedTimestamp
+} from 'state/preferences/selectors';
 import { shouldViewBeVisible } from 'state/ui/first-view/selectors';
 import GuidedToursConfig from 'layout/guided-tours/config';
 import createSelector from 'lib/create-selector';
@@ -203,6 +206,11 @@ const getRawGuidedTourState = state => get( state, 'ui.guidedTour', false );
 
 export const getGuidedTourState = createSelector(
 	state => {
+		if ( ! preferencesLastFetchedTimestamp( state ) ) {
+			debug( 'No fresh user preferences, bailing.' );
+			return {};
+		}
+
 		const tourState = getRawGuidedTourState( state );
 		const tour = findEligibleTour( state );
 		const shouldShow = !! tour;
@@ -225,5 +233,9 @@ export const getGuidedTourState = createSelector(
 			shouldShow,
 		};
 	},
-	[ getRawGuidedTourState, getActionLog ]
+	[
+		getRawGuidedTourState,
+		getActionLog,
+		preferencesLastFetchedTimestamp,
+	]
 );

--- a/client/state/ui/guided-tours/selectors/index.js
+++ b/client/state/ui/guided-tours/selectors/index.js
@@ -132,9 +132,8 @@ const findRequestedTour = state => {
 const findTriggeredTour = state => {
 	if ( ! preferencesLastFetchedTimestamp( state ) ) {
 		debug( 'No fresh user preferences, bailing.' );
-		return undefined;
+		return;
 	}
-	debug( 'Apparently we have fresh user preferences, so NOT bailing.' );
 
 	const toursFromTriggers = uniq( [
 		...getToursFromFeaturesReached( state ),

--- a/client/state/ui/guided-tours/selectors/index.js
+++ b/client/state/ui/guided-tours/selectors/index.js
@@ -130,6 +130,12 @@ const findRequestedTour = state => {
  * "when" isn't right).
  */
 const findTriggeredTour = state => {
+	if ( ! preferencesLastFetchedTimestamp( state ) ) {
+		debug( 'No fresh user preferences, bailing.' );
+		return undefined;
+	}
+	debug( 'Apparently we have fresh user preferences, so NOT bailing.' );
+
 	const toursFromTriggers = uniq( [
 		...getToursFromFeaturesReached( state ),
 		// Right now, only one source from which to derive tours, but we may
@@ -207,11 +213,6 @@ const getRawGuidedTourState = state => get( state, 'ui.guidedTour', false );
 export const getGuidedTourState = createSelector(
 	state => {
 		const emptyState = { shouldShow: false };
-
-		if ( ! preferencesLastFetchedTimestamp( state ) ) {
-			debug( 'No fresh user preferences, bailing.' );
-			return emptyState;
-		}
 
 		const tourState = getRawGuidedTourState( state );
 		const tour = findEligibleTour( state );

--- a/client/state/ui/guided-tours/test/selectors.js
+++ b/client/state/ui/guided-tours/test/selectors.js
@@ -201,6 +201,7 @@ describe( 'selectors', () => {
 					},
 				},
 				preferences: {
+					lastFetchedTimestamp: 1,
 					remoteValues: {
 						'guided-tours-history': [],
 					},
@@ -224,6 +225,7 @@ describe( 'selectors', () => {
 				},
 			},
 			preferences: {
+				lastFetchedTimestamp: 1,
 				remoteValues: {
 					'guided-tours-history': toursHistory,
 				},
@@ -363,6 +365,16 @@ describe( 'selectors', () => {
 				toursHistory: [ testTourSeen, themesTourSeen ],
 				queryArguments: { tour: 'themes', _timestamp: 0 }
 			} );
+			const tour = findEligibleTour( state );
+
+			expect( tour ).to.equal( undefined );
+		} );
+		it( 'should bail if user preferences are stale', () => {
+			const state = makeState( {
+				actionLog: [ navigateToThemes ],
+				userData: { date: ( new Date() ).toJSON() }, // user was created just now
+			} );
+			delete state.preferences.lastFetchedTimestamp;
 			const tour = findEligibleTour( state );
 
 			expect( tour ).to.equal( undefined );


### PR DESCRIPTION
The Guided Tours framework tracks which tours a user has _seen_ (completed or dismissed) by persisting that history using the Preferences API (`state.preferences`). Up to this point, it was missing an explicit check that the preferences available locally (via `getPreferences`) have been successfully pulled from the server and aren't stale. Without the check, GT assumed the history was empty (and thus any tour was good to show again). The check should guard against two issues:

- In the case where Guided Tours runs before the request for fresh preferences (typically in order to satisfy a `<QueryPreferences />` element), we ensure that GT waits for the preferences before deciding on a tour. [fig 1]
- In the case where something is consistently failing between the user and the preferences endpoint (_e.g._ users with 2-factor authentication enabled and a stale token, see #202), Guided Tours will defensively not run at all. [fig 2]

fig 1: 
![waiting-for-prefs-1](https://cloud.githubusercontent.com/assets/150562/22158123/b22f6f28-df32-11e6-968f-a330bae8254a.png)

fig 2: 
![waiting-for-prefs-2](https://cloud.githubusercontent.com/assets/150562/22158130/b7c3a04e-df32-11e6-9662-6b962598b530.png)

# To test

The best is likely to locally revert #10706, set `localStorage.setItem( 'debug', 'calypso:guided*' )` and test with different accounts (without 2FA, with 2FA and fresh token, with 2FA and stale token) and different histories (having seen `editorInsertMenu`, having not seen it).