### PR TITLE
Signup: Fix missing isDomainOnly property error on Domains step

### DIFF
--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -77,6 +77,9 @@ module.exports = {
 		stepName: 'domains',
 		apiRequestFunction: stepActions.createSiteWithCart,
 		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
+		props: {
+			isDomainOnly: false
+		},
 		dependencies: [ 'themeSlugWithRepo' ],
 		delayApiRequestUntilComplete: true
 	},
@@ -86,6 +89,9 @@ module.exports = {
 		apiRequestFunction: stepActions.createSiteWithCartAndStartFreeTrial,
 		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
 		dependencies: [ 'themeSlugWithRepo' ],
+		props: {
+			isDomainOnly: false
+		},
 		delayApiRequestUntilComplete: true
 	},
 
@@ -93,6 +99,9 @@ module.exports = {
 		stepName: 'domains-theme-preselected',
 		apiRequestFunction: stepActions.createSiteWithCart,
 		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
+		props: {
+			isDomainOnly: false
+		},
 		delayApiRequestUntilComplete: true
 	},
 


### PR DESCRIPTION
There was a missing required `isDomainOnly` property on the domains step configuration. This PR fixes the error.

To test:

1. Start signup
2. Reach the domains step
3. Verify there is no error about missing required `isDomainOnly` property in the console
4. Finish signup and verify it's working properly