### PR TITLE
Post Controls: remove a stray "0" output when condition is falsy

### DIFF
--- a/client/my-sites/posts/post-controls.jsx
+++ b/client/my-sites/posts/post-controls.jsx
@@ -195,7 +195,7 @@ export const PostControls = props => {
 
 	return (
 		<div className={ classes }>
-			{ more.length &&
+			{ more.length > 0 &&
 				<ul className="posts__post-controls post-controls__pane post-controls__more-options">
 					{ getControlElements( more ) }
 				</ul>


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/pull/10746#discussion_r97141091

@aduth:
> This condition is causing `0` to be output when there are no "More" items. You can see this on the All Sites Drafts screen:
>
> ![image](https://cloud.githubusercontent.com/assets/1779930/22162923/c7b7d9b6-df1e-11e6-9c95-ebd872b3b474.png)
>
> https://wordpress.com/posts/my/drafts
>
> The way the condition reads, since the first part is not truthy, it uses the value on the left hand of the `&&`, and React will happily output `0`. You need this to either evaluate to a boolean, `null`, or `undefined`.
>
> I suggest changing to `more.length > 0 &&`