### PR TITLE
Themes: Use Site Title in Delete Confirm

### DIFF
--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -58,7 +58,7 @@ import {
 	normalizeWporgTheme
 } from './utils';
 import i18n from 'i18n-calypso';
-import { getSiteSlug } from 'state/sites/selectors';
+import { getSiteTitle } from 'state/sites/selectors';
 
 let accept;
 if ( typeof window !== 'undefined' ) {
@@ -689,11 +689,11 @@ export function deleteTheme( themeId, siteId ) {
 export function confirmDelete( themeId, siteId ) {
 	return ( dispatch, getState ) => {
 		const { name: themeName } = getTheme( getState(), siteId, themeId );
-		const siteSlug = getSiteSlug( getState(), siteId );
+		const siteTitle = getSiteTitle( getState(), siteId );
 		accept(
 			i18n.translate(
-				'Are you sure you want to delete %(themeName)s from %(siteSlug)s?',
-				{ args: { themeName, siteSlug }, context: 'Themes: theme delete confirmation dialog' }
+				'Are you sure you want to delete %(themeName)s from %(siteTitle)s?',
+				{ args: { themeName, siteTitle }, context: 'Themes: theme delete confirmation dialog' }
 			),
 			( accepted ) => {
 				accepted && dispatch( deleteTheme( themeId, siteId ) );


### PR DESCRIPTION
Instead of site slug. (This is supposed to [fall back to the domain](https://github.com/Automattic/wp-calypso/blob/78e4e260e4bac79c722b1207637faf9980bf85bf/client/state/sites/selectors.js#L260-L280) anyway).

To test: `/design/<jetpacksite>`, in 'Uploaded Themes': Click any themes '...' button, select delete. The confirmation modal should ask about deleting the theme on the site referring to its title, not its slug.