### PR TITLE
Sharing: Default to current site when fetching Publicize Connections

### DIFF
--- a/client/components/data/query-publicize-connections/README.md
+++ b/client/components/data/query-publicize-connections/README.md
@@ -5,7 +5,7 @@ Query Publicize Connections
 
 ## Usage
 
-Render the component, optionally passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+Render the component, passing `siteId` or `selectedSite`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
 import React from 'react';
@@ -35,4 +35,13 @@ export default function MyConnectionsList( { connections } ) {
 	<tr><th>Required</th><td>No</td></tr>
 </table>
 
-The site ID for which Publicize connections should be requested. Default: ID of selected site.
+The site ID for which Publicize connections should be requested.
+
+### `selectedSite`
+
+<table>
+	<tr><th>Type</th><td>Boolean</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+Whether Publicize connections should be requested for the selected site.

--- a/client/components/data/query-publicize-connections/README.md
+++ b/client/components/data/query-publicize-connections/README.md
@@ -5,7 +5,7 @@ Query Publicize Connections
 
 ## Usage
 
-Render the component, passing `siteId` or `selectedSite`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+Render the component, passing `siteId` or the boolean attribute `selectedSite`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
 import React from 'react';

--- a/client/components/data/query-publicize-connections/README.md
+++ b/client/components/data/query-publicize-connections/README.md
@@ -5,7 +5,7 @@ Query Publicize Connections
 
 ## Usage
 
-Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+Render the component, optionally passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
 import React from 'react';
@@ -15,16 +15,12 @@ import MyConnectionsListItem from './list-item';
 export default function MyConnectionsList( { connections } ) {
 	return (
 		<div>
-			<QueryPublicizeConnections
-				siteId={ 3584907 }
-				query={ { search: 'Themes' } } />
-			{ connections.map( ( connection ) => {
-				return (
-					<MyConnectionsListItem
-						key={ connection.ID }
-						connection={ connection } />
-				);
-			} }
+			<QueryPublicizeConnections siteId={ 3584907 } />
+			{ connections.map( ( connection ) => (
+				<MyConnectionsListItem
+					key={ connection.ID }
+					connection={ connection } />
+			) ) }
 		</div>
 	);
 }
@@ -39,4 +35,4 @@ export default function MyConnectionsList( { connections } ) {
 	<tr><th>Required</th><td>No</td></tr>
 </table>
 
-The site ID for which Publicize connections should be requested.
+The site ID for which Publicize connections should be requested. Default: ID of selected site.

--- a/client/components/data/query-publicize-connections/index.jsx
+++ b/client/components/data/query-publicize-connections/index.jsx
@@ -3,13 +3,13 @@
  */
 import { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
  */
 import { isFetchingConnections as isRequestingConnections } from 'state/sharing/publicize/selectors';
 import { fetchConnections as requestConnections } from 'state/sharing/publicize/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 class QueryPublicizeConnections extends Component {
 	componentWillMount() {
@@ -44,14 +44,15 @@ QueryPublicizeConnections.defaultProps = {
 };
 
 export default connect(
-	( state, ownProps ) => {
+	( state, { siteId } ) => {
+		siteId = siteId || getSelectedSiteId( state );
+
 		return {
-			requestingConnections: isRequestingConnections( state, ownProps.siteId )
+			requestingConnections: isRequestingConnections( state, siteId ),
+			siteId,
 		};
 	},
-	( dispatch ) => {
-		return bindActionCreators( {
-			requestConnections
-		}, dispatch );
+	{
+		requestConnections,
 	}
 )( QueryPublicizeConnections );

--- a/client/components/data/query-publicize-connections/index.jsx
+++ b/client/components/data/query-publicize-connections/index.jsx
@@ -12,20 +12,16 @@ import { fetchConnections as requestConnections } from 'state/sharing/publicize/
 import { getSelectedSiteId } from 'state/ui/selectors';
 
 class QueryPublicizeConnections extends Component {
-	componentWillMount() {
+	componentDidMount() {
 		if ( ! this.props.requestingConnections && this.props.siteId ) {
 			this.props.requestConnections( this.props.siteId );
 		}
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.requestingConnections ||
-				! nextProps.siteId ||
-				( this.props.siteId === nextProps.siteId ) ) {
-			return;
+	componentDidUpdate( { siteId } ) {
+		if ( siteId !== this.props.siteId && ! this.props.requestingConnections ) {
+			this.props.requestConnections( this.props.siteId );
 		}
-
-		nextProps.requestConnections( nextProps.siteId );
 	}
 
 	render() {

--- a/client/components/data/query-publicize-connections/index.jsx
+++ b/client/components/data/query-publicize-connections/index.jsx
@@ -19,7 +19,7 @@ class QueryPublicizeConnections extends Component {
 	}
 
 	componentDidUpdate( { siteId } ) {
-		if ( siteId !== this.props.siteId && ! this.props.requestingConnections ) {
+		if ( this.props.siteId && siteId !== this.props.siteId && ! this.props.requestingConnections ) {
 			this.props.requestConnections( this.props.siteId );
 		}
 	}

--- a/client/components/data/query-publicize-connections/index.jsx
+++ b/client/components/data/query-publicize-connections/index.jsx
@@ -34,18 +34,22 @@ class QueryPublicizeConnections extends Component {
 }
 
 QueryPublicizeConnections.propTypes = {
-	siteId: PropTypes.number,
+	requestConnections: PropTypes.func,
 	requestingConnections: PropTypes.bool,
-	requestConnections: PropTypes.func
+	selectedSite: PropTypes.bool,
+	siteId: PropTypes.number,
 };
 
 QueryPublicizeConnections.defaultProps = {
-	requestConnections: () => {}
+	requestConnections: () => {},
+	requestingConnections: false,
+	selectedSite: false,
+	siteId: 0,
 };
 
 export default connect(
-	( state, { siteId } ) => {
-		siteId = siteId || getSelectedSiteId( state );
+	( state, { siteId, selectedSite } ) => {
+		siteId = siteId || ( selectedSite && getSelectedSiteId( state ) );
 
 		return {
 			requestingConnections: isRequestingConnections( state, siteId ),


### PR DESCRIPTION
This PR removes the implicit requirement to pass a site ID to retrieve Publicize connections.
While docs suggested that passing `siteId` is not required, it would send the request without it.

Not sure how bad of an idea it is to introduce the behavior of having a fallback in query components. Is there any potential fallout that you can think of?

In the readme I also removed the `query` prop passed to the component, I couldn't find any reference to it.

/cc @aduth as he did the only commit on this, @gwwar 