### PR TITLE
Update/data layer/pass actions

### DIFF
--- a/client/state/data-layer/README.md
+++ b/client/state/data-layer/README.md
@@ -57,8 +57,9 @@ Instead the components should be able to request that they require such data and
 ## Implementation
 
 The data layer _intercepts_ Redux actions.
-Once it has performed its behavior, this action will be dropped entirely from the dispatch path.
-This is to prevent two middlewares which can both supply a given request from fighting with each other or duplicating the request; consequently it allows for prioritization of data-fetching needs by means of ordering how the middleware are arranged in the chain. For example, we could start polling from the WP-API for posts but leave all other requests up to the WordPress.com API.
+Once it has performed its behavior, this action will be dropped entirely from the dispatch path unless explicitly forwarded to the next middleware or dispatched again.
+This is to prevent two middlewares which can both supply a given request from fighting with each other or duplicating the request; consequently it allows for prioritization of data-fetching needs by means of ordering how the middleware are arranged in the chain.
+For example, we could start polling from the WP-API for posts but leave all other requests up to the WordPress.com API.
 Note that we can still allow multiple functions within the same middleware to handle the same action.
 The WordPress.com API middleware demonstrates this in building a tree of handlers which can all respond to given action types.
 
@@ -77,11 +78,15 @@ The handlers are functions which take two arguments and whose return value, if a
 The type of a handler follows:
 
 ```js
-// middlewareHandler :: ReduxStore -> ReduxAction -> Any
-const myHandler = ( store, action ) => { … }
+// middlewareHandler :: ReduxStore -> ReduxAction -> BypassingDispatcher -> Any
+const myHandler = ( store, action, next ) => { … }
 ```
 
 Note that the Redux store incorporates four methods, two of which are likely to be used here.
+Also note that there is a distinction between the store's dispatcher and `next` passed in as input arguments.
+When dispatching through the store's `dispatch` function the action will start at the beginning of the entire middleware chain.
+When using `next` there will be data-layer-specific meta information added to the action which will cause all further data-layer middleware in the chain to ignore the action and pass it along untouched.
+This `next` dispatcher exists to prevent triggering endless loops inside the middleware, such as issuing an action from the middleware handler which then triggers the same handler again, which reissues a new action, etc…
 
 ```js
 const {
@@ -117,9 +122,30 @@ const invalidateExisting = ( { dispatch } ) => {
 const requestReticulations = ( store, { splineSet } ) =>
 	requestSplines( store, { type: REQUEST_SPLINES, setId: splineSet } );
 
+const syncChanges = ( { dispatch, getState }, action, next ) => {
+	const oldSpline = getSpline( getState(), action.spline.id );
+
+	wpcom
+		.saveSpline( action.spline )
+		.then( noop ) // no need to respond if successful
+		.catch( () => {
+			// the request failed; give up and reset the
+			// spline to the former state; bypass all
+			// further data-layer middleware by using
+			// next() instead of dispatch()
+			next( reticulateSpline( oldSpline ) );
+		} );
+
+	// pass along action to reducers
+	// and bypass all further
+	// data-layer middleware
+	next( action );
+};
+
 export default {
 	[ REQUEST_RETICULATIONS ]: [ requestReticulations ],
 	[ REQUEST_SPLINES ]: [ invalidateExisting, requestSplines ],
+	[ RETICULATE_SPLINE ]: [ syncChanges ],
 }
 
 // middlware.js

--- a/client/state/data-layer/test/utils.js
+++ b/client/state/data-layer/test/utils.js
@@ -6,9 +6,34 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { mergeHandlers } from '../utils';
+import { local, mergeHandlers } from '../utils';
 
 describe( 'Data Layer', () => {
+	describe( '#local', () => {
+		it( 'should wrap an action with the bypass flag', () => {
+			const action = { type: 'ADD_SPLINE', id: 42 };
+			const localAction = local( action );
+
+			expect( localAction ).to.have.deep.property( 'meta.dataLayer.doBypass', true );
+		} );
+
+		it( 'should not destroy existing meta', () => {
+			const action = {
+				type: 'SHAVE_THE_WHALES',
+				meta: {
+					oceanName: 'ARCTIC',
+					dataLayer: {
+						forceRefresh: true,
+					}
+				}
+			};
+			const localAction = local( action );
+
+			expect( localAction ).to.have.deep.property( 'meta.oceanName', 'ARCTIC' );
+			expect( localAction ).to.have.deep.property( 'meta.dataLayer.forceRefresh', true );
+		} );
+	} );
+
 	describe( '#mergeHandlers', () => {
 		const inc = a => a + 1;
 		const triple = a => a * 3;

--- a/client/state/data-layer/test/wpcom-api-middleware.js
+++ b/client/state/data-layer/test/wpcom-api-middleware.js
@@ -50,6 +50,32 @@ describe( 'WordPress.com API Middleware', () => {
 		expect( adder ).to.not.have.beenCalled;
 	} );
 
+	it( 'should not pass along non-local actions with non data-layer meta', () => {
+		const adder = spy();
+		const handlers = mergeHandlers( {
+			[ 'ADD' ]: [ adder ],
+		} );
+		const action = { type: 'ADD', meta: { semigroup: true } };
+
+		middleware( handlers )( store )( next )( action );
+
+		expect( next ).to.not.have.beenCalled;
+		expect( adder ).to.have.been.calledWith( store, action );
+	} );
+
+	it( 'should not pass along non-local actions with data-layer meta but no bypass', () => {
+		const adder = spy();
+		const handlers = mergeHandlers( {
+			[ 'ADD' ]: [ adder ],
+		} );
+		const action = { type: 'ADD', meta: { dataLayer: { data: 42 } } };
+
+		middleware( handlers )( store )( next )( action );
+
+		expect( next ).to.not.have.beenCalled;
+		expect( adder ).to.have.been.calledWith( store, action );
+	} );
+
 	it( 'should intercept actions in appropriate handler', () => {
 		const adder = spy();
 		const handlers = mergeHandlers( {

--- a/client/state/data-layer/test/wpcom-api-middleware.js
+++ b/client/state/data-layer/test/wpcom-api-middleware.js
@@ -1,0 +1,111 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { spy, stub } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import { middleware } from '../wpcom-api-middleware';
+import { local, mergeHandlers } from '../utils';
+
+describe( 'WordPress.com API Middleware', () => {
+	let next;
+	let store;
+
+	beforeEach( () => {
+		next = spy();
+
+		store = {
+			dispatch: spy(),
+			getState: stub(),
+			replaceReducers: spy(),
+			subscribe: spy(),
+		};
+
+		store.getState.returns( Object.create( null ) );
+	} );
+
+	it( 'should pass along actions without corresponding handlers', () => {
+		const handlers = Object.create( null );
+		const action = { type: 'UNSUPPORTED_ACTION' };
+
+		middleware( handlers )( store )( next )( action );
+
+		expect( store.dispatch ).to.not.have.beenCalled;
+		expect( next ).to.have.been.calledWith( action );
+	} );
+
+	it( 'should pass along local actions untouched', () => {
+		const adder = spy();
+		const handlers = mergeHandlers( {
+			[ 'ADD' ]: [ adder ],
+		} );
+		const action = local( { type: 'ADD' } );
+
+		middleware( handlers )( store )( next )( action );
+
+		expect( next ).to.have.been.calledWith( action );
+		expect( adder ).to.not.have.beenCalled;
+	} );
+
+	it( 'should intercept actions in appropriate handler', () => {
+		const adder = spy();
+		const handlers = mergeHandlers( {
+			[ 'ADD' ]: [ adder ],
+		} );
+		const action = { type: 'ADD' };
+
+		middleware( handlers )( store )( next )( action );
+
+		expect( next ).to.not.have.been.calledWith( action );
+		expect( adder ).to.have.been.calledWith( store, action );
+	} );
+
+	it( 'should allow continuing the action down the chain', () => {
+		const adder = spy( ( _store, _action, _next ) => _next( _action ) );
+		const handlers = mergeHandlers( {
+			[ 'ADD' ]: [ adder ],
+		} );
+		const action = { type: 'ADD' };
+
+		middleware( handlers )( store )( next )( action );
+
+		expect( next ).to.have.been.calledOnce;
+		expect( next ).to.have.been.calledWith( local( action ) );
+		expect( adder ).to.have.been.calledWith( store, action );
+	} );
+
+	it( 'should call all given handlers (same list)', () => {
+		const adder = spy();
+		const doubler = spy();
+		const handlers = mergeHandlers( {
+			[ 'MATHS' ]: [ adder, doubler ],
+		} );
+		const action = { type: 'MATHS' };
+
+		middleware( handlers )( store )( next )( action );
+
+		expect( adder ).to.have.been.calledWith( store, action );
+		expect( doubler ).to.have.been.calledWith( store, action );
+		expect( next ).to.not.have.beenCalled;
+	} );
+
+	it( 'should call all given handlers (different lists)', () => {
+		const adder = spy();
+		const doubler = spy();
+		const handlers = mergeHandlers( {
+			[ 'MATHS' ]: [ adder ],
+		}, {
+			[ 'MATHS' ]: [ doubler ],
+		} );
+		const action = { type: 'MATHS' };
+
+		middleware( handlers )( store )( next )( action );
+
+		expect( adder ).to.have.been.calledWith( store, action );
+		expect( doubler ).to.have.been.calledWith( store, action );
+		expect( next ).to.not.have.beenCalled;
+	} );
+} );

--- a/client/state/data-layer/utils.js
+++ b/client/state/data-layer/utils.js
@@ -7,6 +7,11 @@ import {
 } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import { extendAction } from 'state/utils';
+
+/**
  * Merge handler for lodash.mergeWith
  *
  * Note that a return value of `undefined`
@@ -27,3 +32,13 @@ export const mergeHandlers = ( ...handlers ) =>
 	handlers.length > 1
 		? mergeWith( Object.create( null ), ...handlers, concatHandlers )
 		: handlers[ 0 ];
+
+const doBypassDataLayer = {
+	meta: {
+		dataLayer: {
+			doBypass: true,
+		},
+	},
+};
+
+export const local = action => extendAction( action, doBypassDataLayer );

--- a/client/state/data-layer/wpcom-api-middleware.js
+++ b/client/state/data-layer/wpcom-api-middleware.js
@@ -44,7 +44,7 @@ export const middleware = handlers => store => next => {
 			// if the action indicates that we should
 			// bypass the data layer, then pass it
 			// along the chain untouched
-			if ( true === dataLayer.doBypass ) {
+			if ( dataLayer && true === dataLayer.doBypass ) {
 				return next( action );
 			}
 		}

--- a/client/state/data-layer/wpcom-api-middleware.js
+++ b/client/state/data-layer/wpcom-api-middleware.js
@@ -1,7 +1,8 @@
 /**
  * Internal dependencies
  */
-import handlers from './wpcom';
+import handlerMap from './wpcom';
+import { local } from './utils';
 
 /**
  * WPCOM Middleware API
@@ -9,13 +10,47 @@ import handlers from './wpcom';
  * Intercepts actions requesting data provided by the
  * WordPress.com API and passes them off to the
  * appropriate handler.
+ *
+ * @see state/utils/local indicates that action should bypass data layer
+ *
+ * Note:
+ *
+ * This function has been optimized for speed and has
+ * in turn sacrificed some readability. It's mainly
+ * performing two checks:
+ *
+ *  - Are there handlers defined for the given action type?
+ *  - Is there action meta indicating to bypass these handlers?
+ *
+ * The optimizations reduce function-calling and object
+ * property lookup where possible.
  */
-export const middleware = store => next => action =>
-	// we won't use has( handlers, action.type )
-	// here because of performance implications
-	// this function is run on every dispatch
-	!! handlers[ action.type ]
-		? handlers[ action.type ].forEach( handler => handler( store, action ) )
-		: next( action );
+export const middleware = handlers => store => next => {
+	const localNext = action => next( local( action ) );
 
-export default middleware;
+	return action => {
+		const handlerChain = handlers[ action.type ];
+
+		// if no handler is defined for the action type
+		// then pass it along the chain untouched
+		if ( ! handlerChain ) {
+			return next( action );
+		}
+
+		const meta = action.meta;
+		if ( meta ) {
+			const dataLayer = meta.dataLayer;
+
+			// if the action indicates that we should
+			// bypass the data layer, then pass it
+			// along the chain untouched
+			if ( true === dataLayer.doBypass ) {
+				return next( action );
+			}
+		}
+
+		return handlerChain.forEach( handler => handler( store, action, localNext ) );
+	}
+};
+
+export default middleware( handlerMap );

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -117,7 +117,7 @@ if ( typeof window === 'object' ) {
 	// Browser-specific middlewares
 	middleware.push(
 		require( './analytics/middleware.js' ).analyticsMiddleware,
-		require( './data-layer/wpcom-api-middleware.js' ).middleware,
+		require( './data-layer/wpcom-api-middleware.js' ).default,
 	);
 }
 


### PR DESCRIPTION
**Round 2** of #10287, revert from #10829

**Update**

For some reason when we deployed the code in `state/index.js` was missing a change from the original PR which changed `).middleware` to `).default` when importing the API middleware. This meant that what was supposed to be a piece of middleware in the Redux chain was imported as a function which needed one argument and returned a middleware.

When we injected this failed middleware into the Redux dispatch chain then all Redux actions failed as a result.

This has been fixed by fixing the missing change on the import (require) statement.

---

The data layer was designed to intercept and discard actions requiring
side-effecting and asynchronous actions. This was chosen in part because
we might have situations where multiple middlewares could provide for
the same types of data needs and we only want the first in the chain to
actually handle the requests.

While this choice was reasonable for fetching actions such as
`INSULT_REQUEST` it was less fitting for actions that update data
remotely because the reducers would still need to respond to these
changes before hearing back from APIs etc...

For example, `POST_LIKE` should immediately update the state tree to
indicate that a post has been like, but the API middleware should also
intercept the action and ship the changes to the server. This middleware
now needs to pass the action along after processing.

We want to be careful in these situations not to get stuck in loops
because the continued action could theoretically hit the middleware
again. Further, response from API requests that dispatch new actions
could trigger similar cycles in the control flow graph.

To prevent looping I have created `local()` as a wrapper around actions
to indicate that they should skip all processing by the data layer.
Actions wrapped by `local()` will thus automatically bypass the
middleware and are safe to pass along the chain.

In the example of liking a post the middleware would finish by calling
the following line of code to send the action to the reducers and skip
further handling.

```js
likePost( store, action, next ) {
	...

	// pass along action to reducers
	next( local( action ) );
}
```

You may notice that a new parameter `next` has been given to the
middleware signature. This is the standard `next` from Redux middleware
and is the dispatcher assigned to continue in the dispatching chain.

**Testing**

Unit tests have been added to test the existing and new behaviors. This PR 
introduces functionality without actually using yet. Future PRs will come in
and start to depend on it, especially those which handle data updates and
need to forward requests after handling in the  middleware.

This means there is little to test here other than a straight-forward smoke-test.
Please review the code and look for edge cases that may not have been caught
in the test suite.

**Note**
this predates work in a future PR to add an HTTP middleware layer which will 
open up the door for robust offline action support, queueing, retry policies, 
and batching ✅ 