### PR TITLE
Reader: add discover properties to post normalizer

### DIFF
--- a/client/lib/post-normalizer/rule-add-discover-properties.js
+++ b/client/lib/post-normalizer/rule-add-discover-properties.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { get, find } from 'lodash';
+
+const DISCOVER_BLOG_ID = 53424024;
+
+/**
+ * Add discover properties to a post
+ * @param  {Object} post - the post to extend
+ * @return {Object}      - the post with discover properties
+ */
+export default function( post ) {
+	const isDiscover = !! ( get( post, 'discover_metadata' ) || DISCOVER_BLOG_ID === get( post, 'site_ID' ) );
+	let discoverFormat;
+
+	if ( isDiscover ) {
+		const formats = get( post, 'discover_metadata.discover_fp_post_formats' );
+		const pickFormat = find( formats, format => format.slug !== 'pick' );
+
+		// if there is no pick format the post is a discover feature
+		discoverFormat = pickFormat ? pickFormat.slug : 'feature';
+	}
+
+	post.is_discover = isDiscover;
+	post.discover_format = discoverFormat;
+
+	return post;
+}
+

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { filter, flow, get, find } from 'lodash';
+import { filter, flow } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -30,6 +30,7 @@ import keepValidImages from 'lib/post-normalizer/rule-keep-valid-images';
 import waitForImagesToLoad from 'lib/post-normalizer/rule-wait-for-images-to-load';
 import pickCanonicalMedia from 'lib/post-normalizer/rule-pick-canonical-media';
 import removeElementsBySelector from 'lib/post-normalizer/rule-content-remove-elements-by-selector';
+import addDiscoverProperties from 'lib/post-normalizer/rule-add-discover-properties';
 
 /**
  * Module vars
@@ -37,7 +38,6 @@ import removeElementsBySelector from 'lib/post-normalizer/rule-content-remove-el
 export const
 	READER_CONTENT_WIDTH = 720,
 	PHOTO_ONLY_MIN_WIDTH = 440,
-	DISCOVER_BLOG_ID = 53424024,
 	GALLERY_MIN_IMAGES = 4,
 	GALLERY_MIN_IMAGE_WIDTH = 350;
 
@@ -103,30 +103,6 @@ export function classifyPost( post ) {
 	}
 
 	post.display_type = displayType;
-
-	return post;
-}
-
-/**
- * Add discover properties to a post
- * @param  {Object} post - the post to extend
- * @return {Object}      - the post with discover properties
- */
-
-export function addDiscoverProperties( post ) {
-	const isDiscover = !! ( get( post, 'discover_metadata' ) || DISCOVER_BLOG_ID === get( post, 'site_ID' ) );
-	let discoverFormat;
-
-	if ( isDiscover ) {
-		const formats = get( post, 'discover_metadata.discover_fp_post_formats' );
-		const pickFormat = find( formats, format => format.slug !== 'pick' );
-
-		// if there is no pick format the post is a discover feature
-		discoverFormat = pickFormat ? pickFormat.slug : 'feature';
-	}
-
-	post.is_discover = isDiscover;
-	post.discover_format = discoverFormat;
 
 	return post;
 }

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { filter, flow } from 'lodash';
+import { filter, flow, get, find } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -107,6 +107,30 @@ export function classifyPost( post ) {
 	return post;
 }
 
+/**
+ * Add discover properties to a post
+ * @param  {Object} post - the post to extend
+ * @return {Object}      - the post with discover properties
+ */
+
+export function addDiscoverProperties( post ) {
+	const isDiscover = !! ( get( post, 'discover_metadata' ) || DISCOVER_BLOG_ID === get( post, 'site_ID' ) );
+	let discoverFormat;
+
+	if ( isDiscover ) {
+		const formats = get( post, 'discover_metadata.discover_fp_post_formats' );
+		const pickFormat = find( formats, format => format.slug !== 'pick' );
+
+		// if there is no pick format the post is a discover feature
+		discoverFormat = pickFormat ? pickFormat.slug : 'feature';
+	}
+
+	post.is_discover = isDiscover;
+	post.discover_format = discoverFormat;
+
+	return post;
+}
+
 const fastPostNormalizationRules = flow( [
 	decodeEntities,
 	stripHtml,
@@ -128,6 +152,7 @@ const fastPostNormalizationRules = flow( [
 	pickCanonicalImage,
 	pickCanonicalMedia,
 	classifyPost,
+	addDiscoverProperties,
 ] );
 
 export function runFastRules( post ) {

--- a/client/state/reader/posts/test/normalization-rules.js
+++ b/client/state/reader/posts/test/normalization-rules.js
@@ -7,7 +7,8 @@ import { expect } from 'chai';
 /**
  * Internal Dependencies
  */
-import { classifyPost, addDiscoverProperties } from '../normalization-rules';
+import { classifyPost } from '../normalization-rules';
+import addDiscoverProperties from 'lib/post-normalizer/rule-add-discover-properties';
 import * as DISPLAY_TYPES from '../display-types';
 import { isFeaturedImageInContent } from 'lib/post-normalizer/utils';
 

--- a/client/state/reader/posts/test/normalization-rules.js
+++ b/client/state/reader/posts/test/normalization-rules.js
@@ -7,7 +7,7 @@ import { expect } from 'chai';
 /**
  * Internal Dependencies
  */
-import { classifyPost } from '../normalization-rules';
+import { classifyPost, addDiscoverProperties } from '../normalization-rules';
 import * as DISPLAY_TYPES from '../display-types';
 import { isFeaturedImageInContent } from 'lib/post-normalizer/utils';
 
@@ -101,6 +101,59 @@ describe( 'normalization-rules', () => {
 				],
 			};
 			expect( isFeaturedImageInContent( post ) ).to.be.not.ok;
+		} );
+	} );
+
+	describe( 'addDiscoverProperties', () => {
+		const discoverSiteId = 53424024;
+		context( 'is_discover', () => {
+			it( 'should always add is_discover properity to the post', () => {
+				expect( addDiscoverProperties( {} ) ).to.have.ownProperty( 'is_discover' );
+			} );
+
+			it( 'should set is_discover to false if the post is not from discover', () => {
+				const nonDiscoverPost = addDiscoverProperties( { site_ID: 1 } );
+				expect( nonDiscoverPost.is_discover ).to.be.false;
+			} );
+
+			it( 'should set is_discover to true if the post has discover_metadata', () => {
+				const discoverPost = addDiscoverProperties( { site_ID: 1, discover_metadata: {} } );
+				expect( discoverPost.is_discover ).to.be.true;
+			} );
+
+			it( 'should set is_discover to true if the post is from discover', () => {
+				const discoverPost = addDiscoverProperties( { site_ID: discoverSiteId } );
+				expect( discoverPost.is_discover ).to.be.true;
+			} );
+		} );
+
+		context( 'discover_format', () => {
+			it( 'should set the discover_format from the discover_metadata if present', () => {
+				const discoverPost = {
+					discover_metadata: {
+						discover_fp_post_formats: [
+							{
+								name: 'Pick',
+								slug: 'pick',
+								id: 346750
+							},
+							{
+								name: 'Standard Pick',
+								slug: 'standard-pick',
+								id: 337879995
+							}
+						],
+					}
+				};
+
+				addDiscoverProperties( discoverPost );
+				expect( discoverPost.discover_format ).to.equal( 'standard-pick' );
+			} );
+
+			it( 'should set the discover_format to "feature" if its from discover but discover_metadata is not present', () => {
+				const discoverFeature = addDiscoverProperties( { site_ID: discoverSiteId } );
+				expect( discoverFeature.discover_format ).to.equal( 'feature' );
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
This normalizes the post with :

- `is_discover` : true iff the post is from discover.wordpress.com
- `discover_format` : any one of the discover.wordpress.com post fomats, currently `standard-pick`, `quote-pick`, `image-pick`, `site-pick`, or `feature`

