### PR TITLE
Framework: tune serialize throttle

### DIFF
--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -24,8 +24,7 @@ const debug = debugModule( 'calypso:state' );
 
 const DAY_IN_HOURS = 24;
 const HOUR_IN_MS = 3600000;
-const MINUTE_IN_MS = 1000 * 60;
-export const SERIALIZE_THROTTLE = MINUTE_IN_MS;
+export const SERIALIZE_THROTTLE = 5000;
 export const MAX_AGE = 7 * DAY_IN_HOURS * HOUR_IN_MS;
 
 function getInitialServerState() {


### PR DESCRIPTION
Follow up to #10435 where `SERIALIZE_THROTTLE` was bumped up to 1 min. We were finding that the stale data was a bit distracting, and that persistence performance was likely worsened by a bug where state did not have reference equality even when app state did not change. https://github.com/Automattic/wp-calypso/pull/10761

Profiling Findings:
Persistence disabled: https://github.com/Automattic/wp-calypso/pull/10836#issuecomment-274628155
Persistence enabled 500ms: https://github.com/Automattic/wp-calypso/pull/10836#issuecomment-274636273
Persistence enabled 1000ms: https://github.com/Automattic/wp-calypso/pull/10836#issuecomment-274645017

If the related persistence microtask is around 15ms, maybe we can bring the throttle back down to 5 seconds. Assuming a 30fps budget, we have ~33ms per frame, and the costs here would be to eat away 3ms per frame. If you're getting totally different results @blowery or @samouri let me know which feed you're working with.

Thinking on this some more, I probably also need to do a few passes with state at fixed sizes. If this has a huge impact on how long it takes to persist to browser storage, we can update our throttle/eviction strategy to be size based.

~~@samouri what type of load were you putting on client while profiling? I'm having a tough time seeing it come up in timeline. Clicking around from the docker image I'm not seeing much of anything. Plenty of jank, but not from setItem. Closest I could find was using keyboard shortcuts through reader posts, but nothing that dramatic:~~
![screen shot 2017-01-20 at 5 03 43 pm](https://cloud.githubusercontent.com/assets/1270189/22170461/76387ad2-df32-11e6-8282-123d1f6e39ec.png)


