### PR TITLE
Ads: Boosted Post Test

### DIFF
--- a/client/layout/guided-tours/config-elements/index.js
+++ b/client/layout/guided-tours/config-elements/index.js
@@ -10,3 +10,4 @@ export Next from './next';
 export Quit from './quit';
 export Step from './step';
 export Tour from './tour';
+export LinkQuit from './link-quit';

--- a/client/layout/guided-tours/config-elements/link-quit.js
+++ b/client/layout/guided-tours/config-elements/link-quit.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import contextTypes from '../context-types';
+
+export default class LinkQuit extends Component {
+	static propTypes = {
+		children: PropTypes.node,
+		primary: PropTypes.bool,
+		subtle: PropTypes.bool,
+		href: PropTypes.string,
+		target: PropTypes.string,
+	};
+
+	static contextTypes = contextTypes;
+
+	constructor( props, context ) {
+		super( props, context );
+	}
+
+	onClick = ( event ) => {
+		this.props.onClick && this.props.onClick( event );
+		const { quit, tour, tourVersion, step, isLastStep } = this.context;
+		quit( { tour, tourVersion, step, isLastStep } );
+	}
+
+	render() {
+		const { children, primary, subtle, href, target } = this.props;
+		const classes = subtle ? 'guided-tours__subtle-button' : '';
+		return (
+			<Button
+				className={ classes }
+				onClick={ this.onClick }
+				primary={ primary }
+				href={ href }
+				target={ target }>
+				{ children || translate( 'Quit' ) }
+			</Button>
+		);
+	}
+}

--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -7,6 +7,7 @@ import { TutorialSitePreviewTour } from 'layout/guided-tours/tours/tutorial-site
 import { DesignShowcaseWelcomeTour } from 'layout/guided-tours/tours/design-showcase-welcome-tour';
 import { ThemeSheetWelcomeTour } from 'layout/guided-tours/tours/theme-sheet-welcome-tour';
 import { SiteTitleTour } from 'layout/guided-tours/tours/site-title-tour';
+import { BoostedPostTour } from 'layout/guided-tours/tours/boosted-post-tour';
 
 export default combineTours( {
 	main: MainTour,
@@ -14,4 +15,5 @@ export default combineTours( {
 	designShowcaseWelcome: DesignShowcaseWelcomeTour,
 	themeSheetWelcomeTour: ThemeSheetWelcomeTour,
 	siteTitle: SiteTitleTour,
+	boostedPostSurvey: BoostedPostTour,
 } );

--- a/client/layout/guided-tours/tours/boosted-post-tour.js
+++ b/client/layout/guided-tours/tours/boosted-post-tour.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { translate } from 'i18n-calypso';
+import { overEvery as and } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	ButtonRow,
+	LinkQuit,
+	makeTour,
+	Quit,
+	Step,
+	Tour,
+} from 'layout/guided-tours/config-elements';
+import {
+	isAbTestInVariant,
+	isEnabled,
+} from 'state/ui/guided-tours/contexts';
+import { isDesktop } from 'lib/viewport';
+
+export const BoostedPostTour = makeTour(
+	<Tour
+		name="boostedPostSurvey"
+		path="/posts/"
+		version="20170127"
+		when={ and(
+			isEnabled( 'boosted-post-survey' ),
+			isDesktop,
+			isAbTestInVariant( 'boostedPostSurvey', 'enabled' )
+		) }
+	>
+		<Step name="init" placement="right">
+			<p>{ translate( 'Wouldn\'t it be nice if your posts reached a wider audience?' ) }</p>
+			<ButtonRow>
+				<LinkQuit
+					primary
+					target="_blank"
+					href="https://jonburke.polldaddy.com/s/boosted-post">
+					{ translate( 'Learn more' ) }
+				</LinkQuit>
+				<Quit>{ translate( 'No, thanks.' ) }</Quit>
+			</ButtonRow>
+		</Step>
+	</Tour>
+);

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -147,5 +147,15 @@ module.exports = {
 		},
 		defaultVariation: 'disabled',
 		allowExistingUsers: true
+	},
+
+	boostedPostSurvey: {
+		datestamp: '20170127',
+		variations: {
+			disabled: 90,
+			enabled: 10
+		},
+		defaultVariation: 'disabled',
+		allowExistingUsers: true
 	}
 };

--- a/config/development.json
+++ b/config/development.json
@@ -32,6 +32,7 @@
 		"ad-tracking": false,
 		"automated-transfer": true,
 		"apple-pay": true,
+		"boosted-post-survey": true,
 		"code-splitting": true,
 		"community-translator": true,
 		"css-hot-reload": true,


### PR DESCRIPTION
This is a test to evaluate the users interest in a potential feature to boost the reach of their content using our paid ad network. 10% of users in AB test `boostedPostSurvey` will see a tour pop up on the Posts page asking them if they are interested in increasing their readership.

Original approach was to start the survey after a use published a post, but there wasn't an easy technical way to start the tour *after* a publish without a page reload. Instead I moved it to the Posts page and added the AB test variant.

Original PR (retracted): https://github.com/Automattic/wp-calypso/pull/10806

To test:
1. Enable `boostedPostSurvey` AB test via dev popup (or add ?tour=boostedPostSurvey to the end of the URL).
1. Go to one of your sites and view the posts.

<img width="1379" alt="screen shot 2017-02-01 at 11 40 04 am" src="https://cloud.githubusercontent.com/assets/273708/22523183/4984cfd2-e873-11e6-8a18-9f52cbc8e882.png">

**Survey Screens**
http://jonburke.polldaddy.com/s/boosted-post

<img width="688" alt="screen shot 2017-02-01 at 11 40 32 am" src="https://cloud.githubusercontent.com/assets/273708/22523193/52637cd4-e873-11e6-866b-e173bd688b3b.png">

<img width="705" alt="screen shot 2017-02-01 at 11 40 23 am" src="https://cloud.githubusercontent.com/assets/273708/22523199/55d6a698-e873-11e6-9603-ac9e51d41b23.png">
