### PR TITLE
Menus: Fix creating items on newly created menus

### DIFF
--- a/client/my-sites/menus/menu-item-list.jsx
+++ b/client/my-sites/menus/menu-item-list.jsx
@@ -34,7 +34,8 @@ var MenuItemList = React.createClass( {
 		if ( 0 === this.props.depth ) {
 			return <EmptyMenu doAddItem={ this.props.doAddItem }
 						depth={ this.props.depth + 1 }
-						addState={ this.props.addState } />;
+						addState={ this.props.addState }
+						itemTypes={ this.props.itemTypes } />;
 		}
 		return null;
 	},


### PR DESCRIPTION
This PR fixes adding menu items to newly created menus.

**Testing instructions**

 - Navigate to menus page , `/menus/$site`
 - Select "New menu" from the second select box
 - Try adding a new item to this menu
 - You should not see any error

