### PR TITLE
React modal close on esc

### DIFF
--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -21,7 +21,8 @@ import ImageEditorCanvas from './image-editor-canvas';
 import ImageEditorToolbar from './image-editor-toolbar';
 import ImageEditorButtons from './image-editor-buttons';
 import MediaUtils from 'lib/media/utils';
-import closeOnEsc from 'lib/mixins/close-on-esc';
+// import closeOnEsc from 'lib/mixins/close-on-esc';
+import CloseOnEscape from 'components/close-on-escape';
 import {
 	resetImageEditorState,
 	resetAllImageEditorState,
@@ -42,7 +43,7 @@ import {
 import { getDefaultAspectRatio } from './utils';
 
 const ImageEditor = React.createClass( {
-	mixins: [ closeOnEsc( 'onCancel' ) ],
+	// mixins: [ closeOnEsc( 'onCancel' ) ],
 
 	propTypes: {
 		// Component props
@@ -225,6 +226,7 @@ const ImageEditor = React.createClass( {
 			<div className={ classes }>
 				{ this.state.canvasError && this.renderError() }
 
+				<CloseOnEscape onEscape={ this.onCancel } />
 				<QuerySites siteId={ siteId } />
 
 				<figure>

--- a/client/components/close-on-escape/index.jsx
+++ b/client/components/close-on-escape/index.jsx
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { filter, last, noop } from 'lodash';
+import { Component, PropTypes } from 'react';
+
+let components = [];
+
+function onKeydown( event ) {
+	if ( components.length > 0 && event.keyCode === 27 && ! isInput( event.target ) ) { // ESC
+		const component = last( components );
+		component.onEscape();
+	}
+}
+
+function isInput( element ) {
+	return -1 !== [ 'INPUT', 'TEXTAREA' ].indexOf( element.nodeName );
+}
+
+function addKeydownListener() {
+	document.addEventListener( 'keydown', onKeydown, true );
+}
+
+function removeKeydownListener() {
+	document.removeEventListener( 'keydown', onKeydown, true );
+}
+
+function startCloseOnEscForComponent( component, onEscape ) {
+	components.push( { component, onEscape } );
+	if ( components.length > 0 ) {
+		addKeydownListener();
+	}
+}
+
+function stopCloseOnEscForComponent( component ) {
+	components = filter( components, item => item.component !== component );
+	if ( components.length < 1 ) {
+		removeKeydownListener();
+	}
+}
+
+export default class CloseOnEscape extends Component {
+
+	static propTypes = {
+		onEscape: PropTypes.func,
+	};
+
+	static defaultProps = {
+		onEscape: noop,
+	};
+
+	componentDidMount = () => {
+		startCloseOnEscForComponent( this, this.props.onEscape );
+	};
+
+	componentWillUnmount = () => {
+		stopCloseOnEscForComponent( this, this.props.onEscape );
+	};
+
+	render() {
+		return null;
+	}
+
+}

--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -5,6 +5,8 @@ import React, { Component } from 'react';
 import Modal from 'react-modal';
 import classnames from 'classnames';
 
+import CloseOnEscape from 'components/close-on-escape';
+
 class DialogBase extends Component {
 	static defaultProps = {
 		baseClassName: 'dialog',
@@ -24,13 +26,16 @@ class DialogBase extends Component {
 			);
 
 		return (
-			<Modal isOpen={ this.props.isVisible }
+			<Modal
+				isOpen={ this.props.isVisible }
 				onRequestClose={ this._close }
 				closeTimeoutMS= { this.props.leaveTimeout }
 				contentLabel={ this.props.label }
 				overlayClassName={ backdropClassName } // We use flex here which react-modal doesn't
 				className={ dialogClassName }
-				role="dialog">
+				role="dialog"
+			>
+				<CloseOnEscape onEscape={ this._close } />
 				<div className={ classnames( this.props.className, contentClassName ) } ref="content" tabIndex="-1">
 					{ this.props.children }
 				</div>


### PR DESCRIPTION
This PR can be ignored for the most part, it's meant only to demo the application of #10268 (Changes to close-on-esc behaviour) to  #10819 (implementing React-model) to avoid a regression where scenarios with 'stacked' dialogs need to  close one-by-one.

It seems that if/when #10268 is merged, #10819 could use it to effectively keep instances of dialogs/modals in an ordered stack.

There's no intention to merge - in fact I did intend to base the PR off of my own branch - whoops!

FAO @ockham & @gwwar :)