### PR TITLE
Feature Docs: Replace mutating loop counter with proper key

### DIFF
--- a/client/components/feature-example/docs/example.jsx
+++ b/client/components/feature-example/docs/example.jsx
@@ -35,10 +35,9 @@ module.exports = React.createClass( {
 			name: 'Not a real site'
 		};
 
-		let n = 0;
 		return plugins.map( plugin => {
 			return <PluginItem
-				key={ 'plugin-item-mock-' + n++ }
+				key={ `plugin-item-mock-${ plugin.slug }` }
 				plugin={ plugin }
 				sites={ [] }
 				selectedSite={ selectedSite }


### PR DESCRIPTION
Previously in the Feature docs example code there was a list of plugins
whose `key` was set using an outside loop counter `let n = 0; n++`

This has a number of drawbacks and isn't actually necessary at all.

Now it has been replaced with assigning a key based on the plugin slugs
and remove the external counter.

cc: @johnHackworth 