### PR TITLE
Allow adding G Suite to mapped domains

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -458,6 +458,11 @@ function googleAppsExtraLicenses( properties ) {
 	return assign( item, { extra: { google_apps_users: properties.users } } );
 }
 
+function hasGoogleApps( cart ) {
+	return some( getAll( cart ), isGoogleApps );
+}
+
+
 function customDesignItem() {
 	return {
 		product_slug: 'custom-design'
@@ -788,6 +793,7 @@ module.exports = {
 	hasDomainMapping,
 	hasDomainRegistration,
 	hasFreeTrial,
+	hasGoogleApps,
 	hasNlTld,
 	hasOnlyFreeTrial,
 	hasOnlyProductsOf,

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -2,9 +2,11 @@
  * External dependencies
  */
 import inherits from 'inherits';
-import some from 'lodash/some';
-import includes from 'lodash/includes';
-import find from 'lodash/find';
+import {
+	some,
+	includes,
+	find
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -145,7 +147,7 @@ function isMappedDomain( domain ) {
 
 function getGoogleAppsSupportedDomains( domains ) {
 	return domains.filter( function( domain ) {
-		return ( domain.type === domainTypes.REGISTERED && canAddGoogleApps( domain.name ) );
+		return ( includes( [ domainTypes.REGISTERED, domainTypes.MAPPED ], domain.type ) && canAddGoogleApps( domain.name ) );
 	} );
 }
 

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -606,6 +606,33 @@ Undocumented.prototype.validateDomainContactInformation = function( contactInfor
 };
 
 /**
+ * Validates the specified Google Apps contact information
+ *
+ * @param {Object} contactInformation - user's contact information
+ * @param {Function} callback The callback function
+ * @returns {Promise} A promise that resolves when the request completes
+ * @api public
+ */
+Undocumented.prototype.validateGoogleAppsContactInformation = function( contactInformation, callback ) {
+	const data = mapKeysRecursively( { contactInformation }, snakeCase );
+
+	return this.wpcom.req.post(
+		{ path: '/me/google-apps/validate' },
+		data, ( error, successData ) => {
+			if ( error ) {
+				return callback( error );
+			}
+
+			const newData = mapKeysRecursively( successData, ( key ) => {
+				return ( key === '_headers' ) ? key : camelCase( key );
+			} );
+
+			callback( null, newData );
+		}
+	);
+};
+
+/**
  * Get a list of WordPress.com products
  *
  * @param {Function} fn The callback function

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -309,7 +309,9 @@ const Checkout = React.createClass( {
 			return false;
 		}
 
-		return cart && cartItems.hasDomainRegistration( cart ) && ! hasDomainDetails( transaction );
+		return cart &&
+			! hasDomainDetails( transaction ) &&
+			( cartItems.hasDomainRegistration( cart ) || cartItems.hasGoogleApps( cart ) );
 	},
 
 	render: function() {

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -215,16 +215,14 @@ export default React.createClass( {
 	},
 
 	renderNameFields() {
-		const textOnly = true;
-
 		return (
 			<div>
 				<Input
 					autoFocus
-					label={ this.translate( 'First Name', { textOnly } ) }
+					label={ this.translate( 'First Name') }
 					{ ...this.getFieldProps( 'first-name' ) } />
 
-				<Input label={ this.translate( 'Last Name', { textOnly } ) } { ...this.getFieldProps( 'last-name' ) } />
+				<Input label={ this.translate( 'Last Name' ) } { ...this.getFieldProps( 'last-name' ) } />
 			</div>
 		);
 	},
@@ -238,8 +236,7 @@ export default React.createClass( {
 				{
 					context: 'Domain contact information page',
 					comment: 'Count specifies the number of domain registrations',
-					count: this.getNumberOfDomainRegistrations(),
-					textOnly: true
+					count: this.getNumberOfDomainRegistrations()
 				}
 			) }
 			{ ...this.getFieldProps( 'organization' ) } />;
@@ -247,14 +244,14 @@ export default React.createClass( {
 
 	renderEmailField() {
 		return (
-			<Input label={ this.translate( 'Email', { textOnly: true } ) } { ...this.getFieldProps( 'email' ) } />
+			<Input label={ this.translate( 'Email' ) } { ...this.getFieldProps( 'email' ) } />
 		);
 	},
 
 	renderCountryField() {
 		return (
 			<CountrySelect
-				label={ this.translate( 'Country', { textOnly: true } ) }
+				label={ this.translate( 'Country' ) }
 				countriesList={ countriesList }
 				{ ...this.getFieldProps( 'country-code' ) } />
 		);
@@ -262,12 +259,12 @@ export default React.createClass( {
 
 	renderFaxField() {
 		return (
-			<Input label={ this.translate( 'Fax', { textOnly: true } ) } { ...this.getFieldProps( 'fax' ) } />
+			<Input label={ this.translate( 'Fax' ) } { ...this.getFieldProps( 'fax' ) } />
 		);
 	},
 
 	renderPhoneField() {
-		const label = this.translate( 'Phone', { textOnly: true } );
+		const label = this.translate( 'Phone' );
 
 		if ( abtest( 'domainContactNewPhoneInput' ) === 'enabled' ) {
 			return (
@@ -295,24 +292,22 @@ export default React.createClass( {
 	},
 
 	renderAddressFields() {
-		const textOnly = true;
-
 		return (
 			<div>
-				<Input label={ this.translate( 'Address', { textOnly } ) } maxLength={ 40 } { ...this.getFieldProps( 'address-1' ) }/>
+				<Input label={ this.translate( 'Address' ) } maxLength={ 40 } { ...this.getFieldProps( 'address-1' ) }/>
 
 				<HiddenInput
-					label={ this.translate( 'Address Line 2', { textOnly } ) }
-					text={ this.translate( '+ Add Address Line 2', { textOnly } ) }
+					label={ this.translate( 'Address Line 2' ) }
+					text={ this.translate( '+ Add Address Line 2' ) }
 					maxLength={ 40 }
-					{ ...this.getFieldProps( 'address-2' ) }/>
+					{ ...this.getFieldProps( 'address-2' ) } />
 			</div>
 		);
 	},
 
 	renderCityField() {
 		return (
-			<Input label={ this.translate( 'City', { textOnly: true } ) } { ...this.getFieldProps( 'city' ) } />
+			<Input label={ this.translate( 'City' ) } { ...this.getFieldProps( 'city' ) } />
 		);
 	},
 
@@ -320,14 +315,14 @@ export default React.createClass( {
 		const countryCode = formState.getFieldValue( this.state.form, 'countryCode' );
 
 		return <StateSelect
-			label={ this.translate( 'State', { textOnly: true } ) }
+			label={ this.translate( 'State' ) }
 			countryCode={ countryCode }
-			{ ...this.getFieldProps( 'state' ) }/>;
+			{ ...this.getFieldProps( 'state' ) } />;
 	},
 
 	renderPostalCodeField() {
 		return (
-			<Input label={ this.translate( 'Postal Code', { textOnly: true } ) } { ...this.getFieldProps( 'postal-code' ) } />
+			<Input label={ this.translate( 'Postal Code' ) } { ...this.getFieldProps( 'postal-code' ) } />
 		);
 	},
 
@@ -437,8 +432,7 @@ export default React.createClass( {
 				'only-google-apps-details': needsOnlyGoogleAppsDetails
 			} ),
 			titleOptions = {
-				context: 'Domain contact information page',
-				textOnly: true
+				context: 'Domain contact information page'
 			};
 
 		let title;

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -331,11 +331,11 @@ export default React.createClass( {
 		);
 	},
 
-	fields() {
+	renderDetailsForm() {
 		const needsOnlyGoogleAppsDetails = this.needsOnlyGoogleAppsDetails();
 
 		return (
-			<div>
+			<form>
 				{ this.renderNameFields() }
 				{ ! needsOnlyGoogleAppsDetails && this.renderOrganizationField() }
 				{ ! needsOnlyGoogleAppsDetails && this.renderEmailField() }
@@ -347,7 +347,7 @@ export default React.createClass( {
 				{ this.renderPostalCodeField() }
 
 				{ this.renderSubmitButton() }
-			</div>
+			</form>
 		);
 	},
 
@@ -361,14 +361,6 @@ export default React.createClass( {
 
 	openDialog() {
 		this.setState( { isDialogVisible: true } );
-	},
-
-	content() {
-		return (
-			<form>
-				{ this.fields() }
-			</form>
-		);
 	},
 
 	focusFirstError() {
@@ -462,7 +454,7 @@ export default React.createClass( {
 				<PaymentBox
 					classSet={ classSet }
 					title={ title }>
-					{ this.content() }
+					{ this.renderDetailsForm() }
 				</PaymentBox>
 			</div>
 		);

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -85,17 +85,24 @@ export default React.createClass( {
 	},
 
 	validate( fieldValues, onComplete ) {
-		const domainNames = map( cartItems.getDomainRegistrations( this.props.cart ), 'meta' );
+		if ( this.needsOnlyGoogleAppsDetails() ) {
+			wpcom.validateGoogleAppsContactInformation( fieldValues, this.generateValidationHandler( onComplete ) );
+			return;
+		}
 
 		const allFieldValues = Object.assign( {}, fieldValues );
 		if ( abtest( 'domainContactNewPhoneInput' ) === 'enabled' ) {
 			allFieldValues.phone = toIcannFormat( allFieldValues.phone, countries[ this.state.phoneCountryCode ] );
 		}
+		const domainNames = map( cartItems.getDomainRegistrations( this.props.cart ), 'meta' );
+		wpcom.validateDomainContactInformation( allFieldValues, domainNames, this.generateValidationHandler( onComplete ) );
+	},
 
-		wpcom.validateDomainContactInformation( allFieldValues, domainNames, ( error, data ) => {
+	generateValidationHandler( onComplete ) {
+		return ( error, data ) => {
 			const messages = data && data.messages || {};
 			onComplete( error, messages );
-		} );
+		};
 	},
 
 	setFormState( form ) {

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -385,7 +385,7 @@ export default React.createClass( {
 
 		return (
 			<div>
-				{ this.renderPrivacySection() }
+				{ cartItems.hasDomainRegistration( this.props.cart ) && this.renderPrivacySection() }
 				<PaymentBox
 					classSet={ classSet }
 					title={ this.translate(

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -110,6 +110,10 @@ export default React.createClass( {
 		this.setState( { form } );
 	},
 
+	needsOnlyGoogleAppsDetails() {
+		return cartItems.hasGoogleApps( this.props.cart ) && ! cartItems.hasDomainRegistration( this.props.cart );
+	},
+
 	handleFormControllerError( error ) {
 		throw error;
 	},
@@ -203,6 +207,58 @@ export default React.createClass( {
 		);
 	},
 
+	renderNameFields() {
+		const textOnly = true;
+
+		return (
+			<div>
+				<Input
+					autoFocus
+					label={ this.translate( 'First Name', { textOnly } ) }
+					{ ...this.getFieldProps( 'first-name' ) } />
+
+				<Input label={ this.translate( 'Last Name', { textOnly } ) } { ...this.getFieldProps( 'last-name' ) } />
+			</div>
+		);
+	},
+
+	renderOrganizationField() {
+		return <HiddenInput
+			label={ this.translate( 'Organization' ) }
+			text={ this.translate(
+				'Registering this domain for a company? + Add Organization Name',
+				'Registering these domains for a company? + Add Organization Name',
+				{
+					context: 'Domain contact information page',
+					comment: 'Count specifies the number of domain registrations',
+					count: this.getNumberOfDomainRegistrations(),
+					textOnly: true
+				}
+			) }
+			{ ...this.getFieldProps( 'organization' ) } />;
+	},
+
+	renderEmailField() {
+		return (
+			<Input label={ this.translate( 'Email', { textOnly: true } ) } { ...this.getFieldProps( 'email' ) } />
+		);
+	},
+
+	renderCountryField() {
+		return (
+			<CountrySelect
+				label={ this.translate( 'Country', { textOnly: true } ) }
+				countriesList={ countriesList }
+				{ ...this.getFieldProps( 'country-code' ) } />
+		);
+	},
+
+	renderFaxField() {
+		return (
+			<Input label={ this.translate( 'Fax', { textOnly: true } ) } { ...this.getFieldProps( 'fax' ) } />
+		);
+	},
+
 	renderPhoneField() {
 		const label = this.translate( 'Phone', { textOnly: true } );
 
@@ -231,60 +287,57 @@ export default React.createClass( {
 		);
 	},
 
-	fields() {
-		const countryCode = formState.getFieldValue( this.state.form, 'countryCode' ),
-			fieldProps = ( name ) => this.getFieldProps( name ),
-			textOnly = true;
+	renderAddressFields() {
+		const textOnly = true;
 
 		return (
 			<div>
-				<Input
-					autoFocus
-					label={ this.translate( 'First Name', { textOnly } ) }
-					{ ...fieldProps( 'first-name' ) }/>
-
-				<Input label={ this.translate( 'Last Name', { textOnly } ) } { ...fieldProps( 'last-name' ) }/>
-
-				<HiddenInput
-					label={ this.translate( 'Organization' ) }
-					text={ this.translate(
-						'Registering this domain for a company? + Add Organization Name',
-						'Registering these domains for a company? + Add Organization Name',
-						{
-							context: 'Domain contact information page',
-							comment: 'Count specifies the number of domain registrations',
-							count: this.getNumberOfDomainRegistrations(),
-							textOnly: true
-						}
-					) }
-					{ ...fieldProps( 'organization' ) }/>
-
-				<Input label={ this.translate( 'Email', { textOnly } ) } { ...fieldProps( 'email' ) }/>
-
-				{ this.renderPhoneField() }
-
-				<CountrySelect
-					label={ this.translate( 'Country', { textOnly } ) }
-					countriesList={ countriesList }
-					{ ...fieldProps( 'country-code' ) }/>
-
-				{ this.needsFax() && <Input label={ this.translate( 'Fax', { textOnly } ) } { ...fieldProps( 'fax' ) }/> }
-				<Input label={ this.translate( 'Address', { textOnly } ) } maxLength={ 40 } { ...fieldProps( 'address-1' ) }/>
+				<Input label={ this.translate( 'Address', { textOnly } ) } maxLength={ 40 } { ...this.getFieldProps( 'address-1' ) }/>
 
 				<HiddenInput
 					label={ this.translate( 'Address Line 2', { textOnly } ) }
 					text={ this.translate( '+ Add Address Line 2', { textOnly } ) }
 					maxLength={ 40 }
-					{ ...fieldProps( 'address-2' ) }/>
+					{ ...this.getFieldProps( 'address-2' ) }/>
+			</div>
+		);
+	},
 
-				<Input label={ this.translate( 'City', { textOnly } ) } { ...fieldProps( 'city' ) }/>
+	renderCityField() {
+		return (
+			<Input label={ this.translate( 'City', { textOnly: true } ) } { ...this.getFieldProps( 'city' ) } />
+		);
+	},
 
-				<StateSelect
-					label={ this.translate( 'State', { textOnly: true } ) }
-					countryCode={ countryCode }
-					{ ...fieldProps( 'state' ) }/>
+	renderStateField() {
+		const countryCode = formState.getFieldValue( this.state.form, 'countryCode' );
 
-				<Input label={ this.translate( 'Postal Code', { textOnly } ) } { ...fieldProps( 'postal-code' ) }/>
+		return <StateSelect
+			label={ this.translate( 'State', { textOnly: true } ) }
+			countryCode={ countryCode }
+			{ ...this.getFieldProps( 'state' ) }/>;
+	},
+
+	renderPostalCodeField() {
+		return (
+			<Input label={ this.translate( 'Postal Code', { textOnly: true } ) } { ...this.getFieldProps( 'postal-code' ) } />
+		);
+	},
+
+	fields() {
+		const needsOnlyGoogleAppsDetails = this.needsOnlyGoogleAppsDetails();
+
+		return (
+			<div>
+				{ this.renderNameFields() }
+				{ ! needsOnlyGoogleAppsDetails && this.renderOrganizationField() }
+				{ ! needsOnlyGoogleAppsDetails && this.renderEmailField() }
+				{ ! needsOnlyGoogleAppsDetails && this.renderPhoneField() }
+				{ this.renderCountryField() }
+				{ ! needsOnlyGoogleAppsDetails && this.needsFax() && this.renderFaxField() }
+				{ ! needsOnlyGoogleAppsDetails && this.renderCityField() }
+				{ ! needsOnlyGoogleAppsDetails && this.renderStateField() }
+				{ this.renderPostalCodeField() }
 
 				{ this.renderSubmitButton() }
 			</div>
@@ -378,22 +431,30 @@ export default React.createClass( {
 	},
 
 	render() {
-		const classSet = classNames( {
-			'domain-details': true,
-			selected: true
-		} );
+		const needsOnlyGoogleAppsDetails = this.needsOnlyGoogleAppsDetails(),
+			classSet = classNames( {
+				'domain-details': true,
+				selected: true,
+				'only-google-apps-details': needsOnlyGoogleAppsDetails
+			} ),
+			titleOptions = {
+				context: 'Domain contact information page',
+				textOnly: true
+			};
+
+		let title;
+		if ( needsOnlyGoogleAppsDetails ) {
+			title = this.translate( 'G Suite Account Information', titleOptions );
+		} else {
+			title = this.translate( 'Domain Contact Information', titleOptions );
+		}
 
 		return (
 			<div>
 				{ cartItems.hasDomainRegistration( this.props.cart ) && this.renderPrivacySection() }
 				<PaymentBox
 					classSet={ classSet }
-					title={ this.translate(
-						'Domain Contact Information',
-						{
-							context: 'Domain contact information page',
-							textOnly: true
-						} ) }>
+					title={ title }>
 					{ this.content() }
 				</PaymentBox>
 			</div>

--- a/client/my-sites/upgrades/checkout/style.scss
+++ b/client/my-sites/upgrades/checkout/style.scss
@@ -555,6 +555,12 @@
 					min-width: inherit;
 				}
 			}
+
+			&.only-google-apps-details {
+				.country {
+					width: 66%;
+				}
+			}
 		}
 
 		.hidden-input a {

--- a/client/my-sites/upgrades/domain-management/email/index.jsx
+++ b/client/my-sites/upgrades/domain-management/email/index.jsx
@@ -71,7 +71,7 @@ const Email = React.createClass( {
 	},
 
 	content() {
-		if ( ! ( this.props.domains.hasLoadedFromServer && this.props.googleAppsUsersLoaded ) ) {
+		if ( ! ( this.props.domains.hasLoadedFromServer && this.props.googleAppsUsersLoaded && this.props.products.gapps ) ) {
 			return <Placeholder />;
 		}
 

--- a/client/my-sites/upgrades/domain-management/email/index.jsx
+++ b/client/my-sites/upgrades/domain-management/email/index.jsx
@@ -21,8 +21,7 @@ import paths from 'my-sites/upgrades/paths';
 import {
 	hasGoogleApps,
 	hasGoogleAppsSupportedDomain,
-	getSelectedDomain,
-	hasMappedDomain
+	getSelectedDomain
 } from 'lib/domains';
 import { isPlanFeaturesEnabled } from 'lib/plans';
 
@@ -92,7 +91,6 @@ const Email = React.createClass( {
 		const {
 			selectedSite,
 			selectedDomainName,
-			domains
 			} = this.props;
 		let emptyContentProps;
 
@@ -102,11 +100,6 @@ const Email = React.createClass( {
 				line: this.translate( 'Only domains registered with WordPress.com are eligible for G Suite.' ),
 				secondaryAction: this.translate( 'Add Email Forwarding' ),
 				secondaryActionURL: paths.domainManagementEmailForwarding( selectedSite.slug, selectedDomainName )
-			};
-		} else if ( hasMappedDomain( domains.list ) ) {
-			emptyContentProps = {
-				title: this.translate( 'G Suite is not supported on mapped domains' ),
-				line: this.translate( 'Only domains registered with WordPress.com are eligible for G Suite.' )
 			};
 		} else {
 			emptyContentProps = {


### PR DESCRIPTION
This patch enables purchasing G Suite (aka Google Apps) for mapped domains.
In order to do that, we need to gather some contact information from the user - much less than what's needed for a domain registration, though:
* first name
* last name
* country
* postal code

Email will taken from the user's wpcom account - much less confusion that way (some might think that they should input the email they want to buy, etc.) and room for error (the wpcom email should be valid and active).

<img width="1148" alt="screen shot 2017-01-23 at 06 36 08" src="https://cloud.githubusercontent.com/assets/3392497/22192679/46234c86-e136-11e6-8cea-a21ae9b8c5e6.png">

### Testing
Needs `D3939-code` on the backend to perform the final purchase (the validation endpoint has been already merged).

Verify different cases:
* buying G Suite for a mapped domain
* buying G Suite for a registered domain
* registering a domain (the domain contact form was re-used, so there might be some regression)
* anything else you can think of :)

/cc @Lochlaer 