### PR TITLE
Stats: Use QuerySiteStats instead of StatsList for the Stats Tabs

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -222,10 +222,8 @@ module.exports = {
 				{ attr: 'comments', gridicon: 'comment', label: i18n.translate( 'Comments', { context: 'noun' } ) }
 			];
 		};
-		let chartDate;
 		let chartTab;
 		let period;
-		let chartPeriod;
 		let siteOffset = 0;
 		let momentSiteZone = i18n.moment();
 		let numPeriodAgo = 0;
@@ -268,7 +266,6 @@ module.exports = {
 				siteOffset = currentSite.options.gmt_offset;
 			}
 			momentSiteZone = i18n.moment().utcOffset( siteOffset );
-			chartDate = rangeOfPeriod( activeFilter.period, momentSiteZone.clone().locale( 'en' ) ).endOf;
 			if ( queryOptions.startDate && i18n.moment( queryOptions.startDate ).isValid ) {
 				date = i18n.moment( queryOptions.startDate ).locale( 'en' );
 				numPeriodAgo = getNumPeriodAgo( momentSiteZone, date, activeFilter.period );
@@ -292,7 +289,6 @@ module.exports = {
 			analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle + ' > ' + titlecase( activeFilter.period ) );
 
 			period = rangeOfPeriod( activeFilter.period, date );
-			chartPeriod = rangeOfPeriod( activeFilter.period, chartDate );
 
 			chartTab = queryOptions.tab || 'views';
 
@@ -303,13 +299,11 @@ module.exports = {
 			const siteComponentChildren = {
 				date,
 				charts,
-				chartDate,
 				chartTab,
 				context,
 				sites,
 				siteId,
 				period,
-				chartPeriod,
 				slug: siteDomain,
 				path: context.pathname,
 			};

--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -211,7 +211,6 @@ module.exports = {
 		const siteFragment = route.getSiteFragment( context.path );
 		const queryOptions = context.query;
 		const SiteStatsComponent = require( 'my-sites/stats/site' );
-		const StatsList = require( 'lib/stats/stats-list' );
 		const filters = getSiteFilters.bind( null, siteId );
 		let date;
 		const charts = function() {
@@ -225,8 +224,6 @@ module.exports = {
 		};
 		let chartDate;
 		let chartTab;
-		let visitsListFields;
-		let chartEndDate;
 		let period;
 		let chartPeriod;
 		let siteOffset = 0;
@@ -234,7 +231,6 @@ module.exports = {
 		let numPeriodAgo = 0;
 		const basePath = route.sectionify( context.path );
 		let baseAnalyticsPath;
-		let chartQuantity = 10;
 		let siteComponent;
 
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
@@ -297,42 +293,11 @@ module.exports = {
 
 			period = rangeOfPeriod( activeFilter.period, date );
 			chartPeriod = rangeOfPeriod( activeFilter.period, chartDate );
-			chartEndDate = chartPeriod.endOf.format( 'YYYY-MM-DD' );
 
 			chartTab = queryOptions.tab || 'views';
-			visitsListFields = chartTab;
-			// If we are on the default Tab, grab visitors too
-			if ( 'views' === visitsListFields ) {
-				visitsListFields = 'views,visitors';
-			}
-
-			switch ( activeFilter.period ) {
-				case 'day':
-					chartQuantity = 30;
-					break;
-				case 'month':
-					chartQuantity = 12;
-					break;
-				case 'week':
-					chartQuantity = 13;
-					break;
-				case 'year':
-					break;
-				default:
-					chartQuantity = 10;
-					break;
-			}
 
 			const siteDomain = ( currentSite && ( typeof currentSite.slug !== 'undefined' ) )
 					? currentSite.slug : siteFragment;
-
-			const activeTabVisitsList = new StatsList( {
-				siteID: siteId, statType: 'statsVisits', unit: activeFilter.period,
-				quantity: chartQuantity, date: chartEndDate, stat_fields: visitsListFields, domain: siteDomain } );
-			const visitsList = new StatsList( {
-				siteID: siteId, statType: 'statsVisits', unit: activeFilter.period,
-				quantity: chartQuantity, date: chartEndDate,
-				stat_fields: 'views,visitors,likes,comments,post_titles', domain: siteDomain } );
 
 			siteComponent = SiteStatsComponent;
 			const siteComponentChildren = {
@@ -342,8 +307,6 @@ module.exports = {
 				chartTab,
 				context,
 				sites,
-				activeTabVisitsList,
-				visitsList,
 				siteId,
 				period,
 				chartPeriod,

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -151,8 +151,6 @@ module.exports = React.createClass( {
 					site={ site } />
 				<div id="my-stats-content">
 					<ChartTabs
-						visitsList={ this.props.visitsList }
-						activeTabVisitsList={ this.props.activeTabVisitsList }
 						barClick={ this.barClick }
 						switchTab={ this.switchChart }
 						charts={ charts }

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -1,9 +1,11 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
-import { find } from 'lodash';
+import { find, flowRight } from 'lodash';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -12,42 +14,42 @@ import ElementChart from 'components/chart';
 import Legend from 'components/chart/legend';
 import StatTabs from '../stats-tabs';
 import analytics from 'lib/analytics';
-import observe from 'lib/mixins/data-observe';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import Card from 'components/card';
+import QuerySiteStats from 'components/data/query-site-stats';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import {
+	isRequestingSiteStatsForQuery,
+	getSiteStatsNormalizedData
+} from 'state/stats/lists/selectors';
 
-export default React.createClass( {
-	displayName: 'StatModuleChartTabs',
-
-	mixins: [ observe( 'visitsList', 'activeTabVisitsList' ) ],
-
-	getInitialState: function() {
-		var activeTab = this.getActiveTab(),
-			activeCharts = activeTab.legendOptions ? activeTab.legendOptions.slice() : [];
-
-		return {
+class StatModuleChartTabs extends Component {
+	constructor( props ) {
+		super( props );
+		const activeTab = this.getActiveTab();
+		const activeCharts = activeTab.legendOptions ? activeTab.legendOptions.slice() : [];
+		this.state = {
 			activeLegendCharts: activeCharts,
 			activeTab: activeTab
 		};
-	},
+	}
 
-	componentWillReceiveProps: function( nextProps ) {
-		var activeTab = this.getActiveTab( nextProps ),
-			activeCharts = activeTab.legendOptions ? activeTab.legendOptions.slice() : [];
-
+	componentWillReceiveProps( nextProps ) {
+		const activeTab = this.getActiveTab( nextProps );
+		const activeCharts = activeTab.legendOptions ? activeTab.legendOptions.slice() : [];
 		if ( activeTab !== this.state.activeTab ) {
 			this.setState( {
 				activeLegendCharts: activeCharts,
 				activeTab: activeTab
 			} );
 		}
-	},
+	}
 
-	buildTooltipData: function( item ) {
-		var tooltipData = [],
-			date = this.moment( item.data.period ),
-			dateLabel;
+	buildTooltipData( item ) {
+		const tooltipData = [];
+		const date = this.props.moment( item.data.period );
 
+		let dateLabel;
 		switch ( this.props.period.period ) {
 			case 'day':
 				dateLabel = date.format( 'LL' );
@@ -72,8 +74,8 @@ export default React.createClass( {
 		switch ( this.props.chartTab ) {
 			case 'comments':
 				tooltipData.push( {
-					label: this.translate( 'Comments' ),
-					value: this.numberFormat( item.value ),
+					label: this.props.translate( 'Comments' ),
+					value: this.props.numberFormat( item.value ),
 					className: 'is-comments',
 					icon: 'comment'
 				} );
@@ -81,8 +83,8 @@ export default React.createClass( {
 
 			case 'likes':
 				tooltipData.push( {
-					label: this.translate( 'Likes' ),
-					value: this.numberFormat( item.value ),
+					label: this.props.translate( 'Likes' ),
+					value: this.props.numberFormat( item.value ),
 					className: 'is-likes',
 					icon: 'star'
 				} );
@@ -90,20 +92,20 @@ export default React.createClass( {
 
 			default:
 				tooltipData.push( {
-					label: this.translate( 'Views' ),
-					value: this.numberFormat( item.data.views ),
+					label: this.props.translate( 'Views' ),
+					value: this.props.numberFormat( item.data.views ),
 					className: 'is-views',
 					icon: 'visible'
 				} );
 				tooltipData.push( {
-					label: this.translate( 'Visitors' ),
-					value: this.numberFormat( item.data.visitors ),
+					label: this.props.translate( 'Visitors' ),
+					value: this.props.numberFormat( item.data.visitors ),
 					className: 'is-visitors',
 					icon: 'user'
 				} );
 				tooltipData.push( {
-					label: this.translate( 'Views Per Visitor' ),
-					value: this.numberFormat( ( item.data.views / item.data.visitors ), { decimals: 2 } ),
+					label: this.props.translate( 'Views Per Visitor' ),
+					value: this.props.numberFormat( ( item.data.views / item.data.visitors ), { decimals: 2 } ),
 					className: 'is-views-per-visitor',
 					icon: 'chevron-right'
 				} );
@@ -112,19 +114,21 @@ export default React.createClass( {
 					// only show two post titles
 					if ( item.data.post_titles.length > 2 ) {
 						tooltipData.push( {
-							label: this.translate( 'Posts Published' ),
-							value: this.numberFormat( item.data.post_titles.length ),
+							label: this.props.translate( 'Posts Published' ),
+							value: this.props.numberFormat( item.data.post_titles.length ),
 							className: 'is-published-nolist',
 							icon: 'posts'
 						} );
 					} else {
 						tooltipData.push( {
-							label: this.translate( 'Post Published', 'Posts Published', { textOnly: true, count: item.data.post_titles.length } ) + ':',
+							label: this.props.translate( 'Post Published', 'Posts Published', {
+								textOnly: true, count: item.data.post_titles.length
+							} ) + ':',
 							className: 'is-published',
 							icon: 'posts',
 							value: ''
 						} );
-						item.data.post_titles.forEach( function( post_title ) {
+						item.data.post_titles.forEach( ( post_title ) => {
 							tooltipData.push( {
 								className: 'is-published-item',
 								label: post_title
@@ -136,13 +140,12 @@ export default React.createClass( {
 		}
 
 		return tooltipData;
-	},
+	}
 
-	onLegendClick: function( chartItem ) {
-		var activeLegendCharts = this.state.activeLegendCharts,
-			chartIndex = activeLegendCharts.indexOf( chartItem ),
-			gaEvent = 'Toggled Nested Chart ' + chartItem,
-			gaEventAction;
+	onLegendClick = ( chartItem ) => {
+		const activeLegendCharts = this.state.activeLegendCharts;
+		const chartIndex = activeLegendCharts.indexOf( chartItem );
+		let gaEventAction;
 		if ( -1 === chartIndex ) {
 			activeLegendCharts.push( chartItem );
 			gaEventAction = ' on';
@@ -150,96 +153,157 @@ export default React.createClass( {
 			activeLegendCharts.splice( chartIndex );
 			gaEventAction = ' off';
 		}
-
-		analytics.ga.recordEvent( 'Stats', gaEvent + gaEventAction );
+		analytics.ga.recordEvent( 'Stats', `Toggled Nested Chart ${ chartItem } ${ gaEventAction }` );
 		this.setState( {
-			activeLegendCharts: activeLegendCharts
+			activeLegendCharts
 		} );
-	},
+	};
 
-	getActiveTab: function( nextProps ) {
+	getActiveTab( nextProps ) {
 		const props = nextProps || this.props;
 		return find( props.charts, { attr: props.chartTab } ) || props.charts[ 0 ];
-	},
+	}
 
-	buildChartData: function() {
-		var chartData,
-			labelKey,
-			dataList = 'visitsList',
-			activeTab = this.props.chartTab;
+	getLoadedData() {
+		const { quickQueryData, fullQueryData, fullQueryRequesting } = this.props;
+		return fullQueryRequesting ? quickQueryData : fullQueryData;
+	}
 
-		labelKey = 'label' + this.props.period.period.charAt( 0 ).toUpperCase() + this.props.period.period.slice( 1 );
-
-		if ( this.props.visitsList.isLoading() ) {
-			dataList = 'activeTabVisitsList';
+	buildChartData() {
+		const data = this.getLoadedData();
+		if ( ! data ) {
+			return [];
 		}
 
-		chartData = this.props[ dataList ].response.data.map( function( record ) {
-			var chartDataItem,
-				recordClassName,
-				className,
-				nestedValue;
-
+		const activeTab = this.props.chartTab;
+		const labelKey = 'label' + this.props.period.period.charAt( 0 ).toUpperCase() + this.props.period.period.slice( 1 );
+		return data.map( ( record ) => {
+			let recordClassName;
 			if ( record.classNames && record.classNames.length ) {
 				recordClassName = record.classNames.join( ' ' );
 			}
 
+			let nestedValue;
 			if ( this.state.activeLegendCharts.length ) {
 				nestedValue = record[ this.state.activeLegendCharts[ 0 ] ];
 			}
 
-			className = classNames( recordClassName, {
+			const className = classNames( recordClassName, {
 				'is-selected': record.period === this.props.queryDate
 			} );
 
-			chartDataItem = {
+			const item = {
 				label: record[ labelKey ],
 				value: record[ activeTab ],
-				nestedValue: nestedValue,
-				className: className,
-				data: record
+				data: record,
+				nestedValue,
+				className,
 			};
+			item.tooltipData = this.buildTooltipData( item );
 
-			chartDataItem.tooltipData = this.buildTooltipData( chartDataItem );
-			return chartDataItem;
-		}, this );
+			return item;
+		} );
+	}
 
-		return chartData;
-	},
-
-	render: function() {
-		var data = this.buildChartData(),
-			activeTab = this.getActiveTab(),
-			visitsList = this.props.visitsList,
-			availableCharts = [],
-			activeTabLoading = this.props.activeTabVisitsList.isLoading() && this.props.visitsList.isLoading(),
-			classes;
-
-		classes = [
+	render() {
+		const { fullQuery, quickQuery, quickQueryRequesting, fullQueryRequesting, siteId } = this.props;
+		const chartData = this.buildChartData();
+		const activeTab = this.getActiveTab();
+		let availableCharts = [];
+		const data = this.getLoadedData();
+		const activeTabLoading = quickQueryRequesting && fullQueryRequesting && ! ( data && data.length );
+		const classes = [
 			'stats-module',
 			'is-chart-tabs',
 			{
 				'is-loading': activeTabLoading
 			}
 		];
-
-		if ( visitsList.isLoading() ) {
-			visitsList = this.props.activeTabVisitsList;
-		}
-
 		if ( activeTab.legendOptions ) {
 			availableCharts = activeTab.legendOptions;
 		}
 
 		return (
 			<div>
-				<Card className={ classNames.apply( null, classes ) }>
-					<Legend tabs={ this.props.charts } activeTab={ activeTab } availableCharts={ availableCharts } activeCharts={ this.state.activeLegendCharts } clickHandler={ this.onLegendClick } />
+				{ siteId && <QuerySiteStats statType="statsVisits" siteId={ siteId } query={ quickQuery } /> }
+				{ siteId && <QuerySiteStats statType="statsVisits" siteId={ siteId } query={ fullQuery } /> }
+				<Card className={ classNames( ...classes ) }>
+					<Legend
+						tabs={ this.props.charts }
+						activeTab={ activeTab }
+						availableCharts={ availableCharts }
+						activeCharts={ this.state.activeLegendCharts }
+						clickHandler={ this.onLegendClick }
+					/>
 					<StatsModulePlaceholder className="is-chart" isLoading={ activeTabLoading } />
-					<ElementChart loading={ activeTabLoading } data={ data } barClick={ this.props.barClick } />
-					<StatTabs dataList={ visitsList } tabs={ this.props.charts } switchTab={ this.props.switchTab } selectedTab={ this.props.chartTab } activeIndex={ this.props.queryDate } activeKey="period" />
+					<ElementChart loading={ activeTabLoading } data={ chartData } barClick={ this.props.barClick } />
+					<StatTabs
+						data={ data }
+						tabs={ this.props.charts }
+						switchTab={ this.props.switchTab }
+						selectedTab={ this.props.chartTab }
+						activeIndex={ this.props.queryDate }
+						activeKey="period"
+					/>
 				</Card>
 			</div>
 		);
 	}
-} );
+}
+
+const connectComponent = connect(
+	( state, { period: periodObject, chartTab } ) => {
+		const { period, endOf } = periodObject;
+		let quantity;
+		switch ( period ) {
+			case 'day':
+				quantity = 30;
+				break;
+			case 'month':
+				quantity = 12;
+				break;
+			case 'week':
+				quantity = 13;
+				break;
+			case 'year':
+				break;
+			default:
+				quantity = 10;
+				break;
+		}
+		let quickQueryFields = chartTab;
+		// If we are on the default Tab, grab visitors too
+		if ( 'views' === quickQueryFields ) {
+			quickQueryFields = 'views,visitors';
+		}
+		const query = {
+			unit: period,
+			date: endOf.format( 'YYYY-MM-DD' ),
+			quantity
+		};
+		const quickQuery = {
+			...query,
+			stat_fields: quickQueryFields
+		};
+		const fullQuery = {
+			...query,
+			stat_fields: 'views,visitors,likes,comments,post_titles'
+		};
+
+		const siteId = getSelectedSiteId( state );
+		return {
+			quickQueryRequesting: isRequestingSiteStatsForQuery( state, siteId, 'statsVisits', quickQuery ),
+			quickQueryData: getSiteStatsNormalizedData( state, siteId, 'statsVisits', quickQuery ),
+			fullQueryRequesting: isRequestingSiteStatsForQuery( state, siteId, 'statsVisits', fullQuery ),
+			fullQueryData: getSiteStatsNormalizedData( state, siteId, 'statsVisits', fullQuery ),
+			quickQuery,
+			fullQuery,
+			siteId
+		};
+	}
+);
+
+export default flowRight(
+	connectComponent,
+	localize
+)( StatModuleChartTabs );

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -13,7 +13,6 @@ import { localize } from 'i18n-calypso';
 import ElementChart from 'components/chart';
 import Legend from 'components/chart/legend';
 import StatTabs from '../stats-tabs';
-import analytics from 'lib/analytics';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import Card from 'components/card';
 import QuerySiteStats from 'components/data/query-site-stats';
@@ -22,6 +21,7 @@ import {
 	isRequestingSiteStatsForQuery,
 	getSiteStatsNormalizedData
 } from 'state/stats/lists/selectors';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 class StatModuleChartTabs extends Component {
 	constructor( props ) {
@@ -153,7 +153,7 @@ class StatModuleChartTabs extends Component {
 			activeLegendCharts.splice( chartIndex );
 			gaEventAction = ' off';
 		}
-		analytics.ga.recordEvent( 'Stats', `Toggled Nested Chart ${ chartItem } ${ gaEventAction }` );
+		this.props.recordGoogleEvent( 'Stats', `Toggled Nested Chart ${ chartItem } ${ gaEventAction }` );
 		this.setState( {
 			activeLegendCharts
 		} );
@@ -300,7 +300,8 @@ const connectComponent = connect(
 			fullQuery,
 			siteId
 		};
-	}
+	},
+	{ recordGoogleEvent }
 );
 
 export default flowRight(

--- a/client/my-sites/stats/stats-tabs/index.jsx
+++ b/client/my-sites/stats/stats-tabs/index.jsx
@@ -24,14 +24,14 @@ export default React.createClass( {
 	},
 
 	render() {
-		const { children, dataList, activeIndex, activeKey, tabs, switchTab, selectedTab, borderless } = this.props;
+		const { children, data, activeIndex, activeKey, tabs, switchTab, selectedTab, borderless } = this.props;
 		let statsTabs;
 
-		if ( dataList ) {
-			const data = find( dataList.response.data, { [ activeKey ]: activeIndex } );
+		if ( data ) {
+			const activeData = find( data, { [ activeKey ]: activeIndex } );
 
-			statsTabs = tabs.map( function( tab ) {
-				const hasData = data && ( data[ tab.attr ] >= 0 ) && ( data[ tab.attr ] !== null );
+			statsTabs = tabs.map( ( tab ) => {
+				const hasData = activeData && ( activeData[ tab.attr ] >= 0 ) && ( activeData[ tab.attr ] !== null );
 
 				const tabOptions = {
 					attr: tab.attr,
@@ -41,7 +41,7 @@ export default React.createClass( {
 					loading: ! hasData,
 					selected: selectedTab === tab.attr,
 					tabClick: switchTab,
-					value: hasData ? data[ tab.attr ] : null
+					value: hasData ? activeData[ tab.attr ] : null
 				};
 
 				return <StatTab key={ tabOptions.attr } { ...tabOptions } />;
@@ -49,7 +49,7 @@ export default React.createClass( {
 		}
 
 		return (
-			<ul className={ classNames( 'stats-tabs', { 'is-enabled': !! dataList }, { 'is-borderless': borderless } ) }>
+			<ul className={ classNames( 'stats-tabs', { 'is-enabled': !! data }, { 'is-borderless': borderless } ) }>
 				{ statsTabs || children }
 			</ul>
 		);


### PR DESCRIPTION
In this PR I drop the usage fo StatsList for the `statsVisits` normalizer.

**Testing instructions**

 - Navigate through the stats periods pages: `/stats/week/$site`, `/stats/month/$site`...
 - Check that the first chart is showing properly (same as master)
 - Navigate using the tabs under the chart
 - For sites with a lot of visits, check that the two first tabs (views, visitors) are loading quickly while the two other tabs (likes and comments) are loading int the background.