### PR TITLE
State: Fix case in siteSupportsJetpackSettingsUi selector name

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -30,7 +30,7 @@ import { saveSiteSettings } from 'state/site-settings/actions';
 import { updateSettings } from 'state/jetpack/settings/actions';
 import { removeNotice, successNotice, errorNotice } from 'state/notices/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite, siteSupportsJetpackSettingsUI } from 'state/sites/selectors';
+import { isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import QueryJetpackSettings from 'components/data/query-jetpack-settings';
 
@@ -166,7 +166,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			};
 
 			const isJetpack = isJetpackSite( state, siteId );
-			const jetpackSettingsUISupported = isJetpack && siteSupportsJetpackSettingsUI( state, siteId );
+			const jetpackSettingsUISupported = isJetpack && siteSupportsJetpackSettingsUi( state, siteId );
 			if ( jetpackSettingsUISupported ) {
 				const jetpackSettings = getJetpackSettings( state, siteId );
 				isSavingSettings = isSavingSettings || isUpdatingJetpackSettings( state, siteId );

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -1038,6 +1038,6 @@ export const hasDefaultSiteTitle = ( state, siteId ) => {
  * @param {Object} siteId Site ID
  * @return {?Boolean}     Whether site supports managing Jetpack settings remotely.
  */
-export const siteSupportsJetpackSettingsUI = ( state, siteId ) => {
+export const siteSupportsJetpackSettingsUi = ( state, siteId ) => {
 	return isJetpackMinimumVersion( state, siteId, '4.5.0' );
 };

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -48,7 +48,7 @@ import {
 	isJetpackSiteMainNetworkSite,
 	getSiteAdminUrl,
 	getCustomizerUrl,
-	siteSupportsJetpackSettingsUI
+	siteSupportsJetpackSettingsUi
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -2319,9 +2319,9 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'siteSupportsJetpackSettingsUI()', () => {
+	describe( 'siteSupportsJetpackSettingsUi()', () => {
 		it( 'should return null if the Jetpack version is not known', () => {
-			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUI( {
+			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUi( {
 				sites: {
 					items: {
 						77203074: {
@@ -2337,7 +2337,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should return null if the site is not a Jetpack site', () => {
-			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUI( {
+			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUi( {
 				sites: {
 					items: {
 						77203074: {
@@ -2352,7 +2352,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should return false if the Jetpack version is older than 4.5', () => {
-			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUI( {
+			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUi( {
 				sites: {
 					items: {
 						77203074: {
@@ -2371,7 +2371,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should return true if the Jetpack version is 4.5', () => {
-			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUI( {
+			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUi( {
 				sites: {
 					items: {
 						77203074: {
@@ -2390,7 +2390,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should return true if the Jetpack version is newer than 4.5', () => {
-			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUI( {
+			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUi( {
 				sites: {
 					items: {
 						77203074: {


### PR DESCRIPTION
This PR fixes the case of the `siteSupportsJetpackSettingsUI` selector, changing it to `siteSupportsJetpackSettingsUi` to conform to our [camel-casing naming recommendations](https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/javascript.md#naming-conventions) - as recommended by @aduth in https://github.com/Automattic/wp-calypso/pull/10697#discussion_r96919839.
