### PR TITLE
Stats: Updating the stats likes count to link to the post stats page

### DIFF
--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -293,13 +293,11 @@ module.exports = React.createClass( {
 			if ( showLikes ) {
 				likeMeta = (
 					<a
-						href={ post.URL }
+						href={ `/stats/post/${ postId }/${ site.slug }` }
 						className={ classNames( {
 							post__likes: true,
 							'is-empty': ! likeCountDisplay
 						} ) }
-						target="_blank"
-						rel="noopener noreferrer"
 						title={ likeTitle }
 						onClick={ this.analyticsEvents.likeIconClick }
 					>


### PR DESCRIPTION
Another approach would be to display the likes as a popover block, but is it really worth it?

**Testing instructions**

 - Open the posts page `/posts/$site`
 - Click on the "star": the likes count
 - You should be redirected to the post stats page