### PR TITLE
Theme Actions: Compute found field for Jetpack sites

### DIFF
--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -137,6 +137,8 @@ export function requestThemes( siteId, query = {} ) {
 				// A Jetpack site's themes endpoint ignores the query, returning an unfiltered list of all installed themes instead,
 				// So we have to filter on the client side instead.
 				filteredThemes = filterThemesForJetpack( themes, query );
+				// The Jetpack specific endpoint doesn't return the number of `found` themes, so we calculate it ourselves.
+				found = filteredThemes.length;
 			} else {
 				themes = map( rawThemes, normalizeWpcomTheme );
 				filteredThemes = themes;

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -118,7 +118,7 @@ describe( 'actions', () => {
 				} )
 				.get( '/rest/v1/sites/77203074/themes' )
 				.reply( 200, {
-					found: 2,
+					// The endpoint doesn't return `found` for Jetpack sites
 					themes: [
 						{ ID: 'twentyfifteen', name: 'Twenty Fifteen' },
 						{ ID: 'twentysixteen', name: 'Twenty Sixteen' }
@@ -127,7 +127,7 @@ describe( 'actions', () => {
 				.get( '/rest/v1/sites/77203074/themes' )
 				.query( { search: 'Sixteen' } )
 				.reply( 200, {
-					found: 1,
+					// The endpoint doesn't return `found` for Jetpack sites
 					themes: [ { ID: 'twentysixteen', name: 'Twenty Sixteen' } ]
 				} )
 				.get( '/rest/v1/sites/1916284/themes' )


### PR DESCRIPTION
This is required for QueryManager, which accepts a `found` argument in order for its `getFound()` method to work.
Even though we return Jetpack sites' themes lists unpaginated, we still need this for the `isThemesLastPageForQuery()` selector to work.

This fixes a bug in production which @folletto found today (and might've been introduced by #10709 which re-implemented `ThemeQueryManager`): In Jetpack-site mode (`/design/<jetpacksite>`), Calypso would try to keep fetching new themes from the network, which was visible by loading placeholders (and could be seen in Redux Devtools, too).

![cap-](https://cloud.githubusercontent.com/assets/96308/22210749/19ee1a88-e18b-11e6-8873-cb054feb22a6.gif)

To test:
* In `development.json`, set `"manage/themes/upload"` to `false`, and *restart Calypso*. Then, verify that that bug is no longer present.

Follow-up: I think we should add `found` to the JP endpoint reply.
