### PR TITLE
Paid NUX: show improved experience for people that bought plan + domain

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -185,11 +185,11 @@ const CheckoutThankYou = React.createClass( {
 	render() {
 		let purchases = null,
 			wasJetpackPlanPurchased = false,
-			wasOnlyDotcomPlanPurchased = false;
+			wasDotcomPlanPurchased = false;
 		if ( this.isDataLoaded() && ! this.isGenericReceipt() ) {
 			purchases = getPurchases( this.props );
 			wasJetpackPlanPurchased = purchases.some( isJetpackPlan );
-			wasOnlyDotcomPlanPurchased = purchases.every( isDotComPlan );
+			wasDotcomPlanPurchased = purchases.some( isDotComPlan );
 		}
 
 		const userCreatedMoment = moment( this.props.userDate );
@@ -206,7 +206,7 @@ const CheckoutThankYou = React.createClass( {
 		}
 
 		// streamlined paid NUX thanks page
-		if ( isNewUser && wasOnlyDotcomPlanPurchased ) {
+		if ( isNewUser && wasDotcomPlanPurchased ) {
 			return (
 				<Main className="checkout-thank-you">
 					{ this.renderConfirmationNotice() }


### PR DESCRIPTION
Previously we only showed improved paid NUX thank you page to people that bought a plan during signup but we excluded people that bought both plan and a domain. 

This is what the paid NUX thank you page looks like. Main CTA is "Visit Your Site" which takes the user to their site and gets the Trampoline started. We measured that users who see Trampoilne right after the signup have higher retention values.

<img width="529" alt="screen shot 2017-01-23 at 17 23 42" src="https://cloud.githubusercontent.com/assets/156676/22212391/d152640e-e190-11e6-84a2-fbeb7ed6c717.png">

Test instructions: 
1. boot this branch or use calypso.live
2. sandbox your store
3. go through the signup and pick both paid plan and a domain name
4. pay with test card
5. test if you see the correct thank you page (as pictured above)
6. cancel the domain in network admin so we don't end up paying for it

One thing to note before launching this live: the link "Visit your Site" goes to "websiteslug.wordpress.com" and NOT to the new domain name, as domain + DNS + all that stuff takes some time to become active. We might want to address that somehow so we are not increasing support requests "I bought a premium domain, but I have wordpress.com there". 