### PR TITLE
Themes: Add isWpcomTheme selector

### DIFF
--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -298,6 +298,17 @@ export function isWporgTheme( state, themeId ) {
 }
 
 /**
+ * Whether a theme is present on WordPress.com.
+ *
+ * @param  {Object}  state   Global state tree
+ * @param  {Number}  themeId Theme ID
+ * @return {Boolean}         Whether theme available on WordPress.com
+ */
+export function isWpcomTheme( state, themeId ) {
+	return !! getTheme( state, 'wpcom', themeId );
+}
+
+/**
  * Returns the URL for a given theme's details sheet.
  *
  * @param  {Object}  state  Global state tree

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -28,6 +28,7 @@ import {
 	getActiveTheme,
 	isRequestingActiveTheme,
 	isWporgTheme,
+	isWpcomTheme,
 	isThemeActive,
 	isActivatingTheme,
 	hasActivatedTheme,
@@ -1644,6 +1645,56 @@ describe( 'themes selectors', () => {
 			}, 'twentyseventeen' );
 
 			expect( isWporg ).to.be.true;
+		} );
+	} );
+
+	describe( '#isWpcomTheme()', () => {
+		it( 'should return false if theme is not found on WordPress.com', () => {
+			const isWpcom = isWpcomTheme( {
+				themes: {
+					queries: {
+					}
+				}
+			}, 'twentyseventeen' );
+
+			expect( isWpcom ).to.be.false;
+		} );
+
+		it( 'should return false if theme is no theme id supplied', () => {
+			const isWpcom = isWpcomTheme( {
+				themes: {
+					queries: {
+					}
+				}
+			} );
+
+			expect( isWpcom ).to.be.false;
+		} );
+
+		it( 'should return true if theme is found on WordPress.com', () => {
+			const wpcomTheme = {
+				id: 'twentyseventeen',
+				name: 'Twenty Seventeen',
+				author: 'wordpressdotorg',
+				demo_uri: 'https://wp-themes.com/twentyseventeen',
+				download: 'http://downloads.wordpress.org/theme/twentyseventeen.1.1.zip',
+				taxonomies: {
+					theme_feature: {
+						'custom-header': 'Custom Header'
+					}
+				}
+			};
+			const isWpcom = isWpcomTheme( {
+				themes: {
+					queries: {
+						wpcom: new ThemeQueryManager( {
+							items: { twentyseventeen: wpcomTheme }
+						} ),
+					}
+				}
+			}, 'twentyseventeen' );
+
+			expect( isWpcom ).to.be.true;
 		} );
 	} );
 

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -198,7 +198,7 @@ export function getSerializedThemesQueryWithoutPage( query, siteId ) {
  * @param  {string}  themeId Theme id
  * @return {Boolean}         Wheter theme is a wpcom theme
  */
-export function isWpcomTheme( themeId ) {
+export function isThemeFromWpcom( themeId ) {
 	return endsWith( themeId, '-wpcom' );
 }
 
@@ -221,7 +221,7 @@ export function filterThemesForJetpack( themes, query ) {
 	if ( config.isEnabled( 'manage/themes/upload' ) ) {
 		return filter(
 			themes,
-			theme => ! isWpcomTheme( theme.id ) && isThemeMatchingQuery( query, theme )
+			theme => ! isThemeFromWpcom( theme.id ) && isThemeMatchingQuery( query, theme )
 		);
 	}
 


### PR DESCRIPTION
To determine whether a theme is available on wpcom. Now that we show a list of custom themes plus a list of wpcom themes for jetpack sites, it will be useful to know the source for a theme.

Prerequisite for #10526.

No visual changes. Includes unit tests. Selector not yet in use.
