### PR TITLE
Framework: addition of createActionThunk to dispatch FSA actions

### DIFF
--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -312,8 +312,7 @@ export const createActionThunk = ( {
 					error: false,
 					meta,
 				} );
-			} )
-		.catch(
+			},
 			error => {
 				dispatch( {
 					type: failureAction,

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -268,3 +268,59 @@ export const withSchemaValidation = ( schema, reducer ) => ( state, action ) => 
 
 	return reducer( state, action );
 };
+
+/**
+ * A function that creates action thunks to for performing side-effects in a generic way.
+ * The created thunk will dispatch [FSA](https://github.com/acdlite/flux-standard-action) compliant actions.
+ *
+ * @example
+ * const requestTeams = ( siteId ) => createActionThunk( {
+ *	dataFetch: () => wpcom.undocumented().me().blockSite( siteId ),
+ *	meta: { siteId },
+ * 	requestAction: 'READER_SITE_BLOCK_REQUEST',
+ * 	successAction: 'READER_SITE_BLOCK_REQUEST_SUCCESS',
+ * 	failureAction: 'READER_SITE_BLOCK_REQUEST_FAILURE',
+ * } );
+ *
+ * @param {Function} - dataFetch a 0-argument function for fetching data
+ * @param {Object} meta - extra data to include in the resulting dispatches
+ * @param {Object} requestAction - the action to dispatch when the request has been initiated
+ * @param {Object} successAction - the action to dispatch if the request succeeds. defaults to requestAction_SUCCESS
+ * @param {Object} failureAction - the action to dispatch if the request fails. defaults to requestAction_FAILURE
+ *
+ * @returns {Function} Action thunk for performing side-effects with redux
+ */
+export const createActionThunk = ( {
+	dataFetch,
+	meta = {},
+	requestAction,
+	successAction = `${ requestAction }_SUCCESS`,
+	failureAction = `${ requestAction }_FAILURE`,
+} ) => dispatch => {
+
+	dispatch( {
+		type: requestAction,
+		meta,
+	} );
+
+	return dataFetch()
+		.then(
+			data => {
+				dispatch( {
+					type: successAction,
+					payload: data,
+					error: false,
+					meta,
+				} );
+			} )
+		.catch(
+			error => {
+				dispatch( {
+					type: failureAction,
+					error,
+					meta,
+				} );
+			}
+		);
+};
+


### PR DESCRIPTION
This PR aims to create a new utility function in `client/state/utils` for the creation of action thunks.
It creates a new function `createActionThunk` that enables the terse-yet-readable creation of side-effecting thunks.

It has a couple of goals:
1. standardize a way that we can create action thunks.  All action thunks will dispatch [FSA](https://github.com/acdlite/flux-standard-action) compliant actions to guarantee a common basic shape.
2. There is a lot of boilerplate when creation both these actions _and_ their tests even though most of ours follow the same pattern. 1. dispatch requesting, then dispatch success/failure based on an api response.  By recognizing this, and having a well-tested helper function, I think we remove the need for mocking/testing the individual actions.
3. by adding a level of indirection and standardizing the way thunks are built, I think it will ease the eventual transition to a 100% transparent middleware solution like https://github.com/Automattic/wp-calypso/pull/10327

Here are some examples of what it would look like to create action thunks using the helper:
1. [get reader teams](https://github.com/Automattic/wp-calypso/blob/4927a01007de4d4fba18f6d007d673d6e269ad59/client/state/reader/teams/actions.js):
```javascript
export const requestTeams = () => createActionThunk( {
	requestAction: READER_TEAMS_REQUEST,
	successAction: READER_TEAMS_REQUEST_SUCCESS,
	failureAction: READER_TEAMS_REQUEST_FAILURE,
	dataFetch: () => wpcomUndocumented.readTeams(),
} );
```
2. In the case of recently merged [reader site-blocking](https://github.com/Automattic/wp-calypso/pull/10649/files#diff-88383c4359a65b1eb24e457c51ebb77dR20):
```javascript
export const requestSiteBlock = ( siteId ) => createActionThunk( { 
  type: READER_SITE_BLOCK_REQUEST,
  dataFetch: () => wpcom.undocumented().me().blockSite( siteId ),
  meta: { siteId },
} );
```

I expect this to save about 70 lines of code per action.