### PR TITLE
Signup: update dependency name to `themeSlugWithRepo`

### DIFF
--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -100,7 +100,7 @@ class ThemeSelectionStep extends Component {
 	};
 
 	render = () => {
-		const defaultDependencies = this.props.useHeadstart ? { theme: 'pub/twentysixteen' } : undefined;
+		const defaultDependencies = this.props.useHeadstart ? { themeSlugWithRepo: 'pub/twentysixteen' } : undefined;
 
 		const pressableWrapperClassName = classNames( {
 			'theme-selection__pressable-wrapper': true,


### PR DESCRIPTION
Fixes #10857.

In #10798, the `theme` dependency was renamed to `themeSlugWithRepo`. This updates a missed instance of the dependency, which set a fallback theme to be used when the step is skipped.

To test:

1. Start Signup (`/start/`).
2. Navigate to the `/themes/` step and try to "skip for now".
3. Finish Signup and make sure that TwentySixteen is set as your site's theme.
4. Navigate back to Signup.
5. Choose a theme on the `/themes/` step.
6. Finish Signup and make sure that the theme is properly set on your new site.