### PR TITLE
experimentation with query-component generator function

### DIFF
--- a/client/components/data/query-reader-feed/index.jsx
+++ b/client/components/data/query-reader-feed/index.jsx
@@ -1,56 +1,15 @@
 /**
- * External dependencies
- */
-import { Component, PropTypes } from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-
-/**
  * Internal dependencies
  */
 import { shouldFeedBeFetched } from 'state/reader/feeds/selectors';
 import { requestFeed } from 'state/reader/feeds/actions';
+import { createQueryComponent } from '../utils';
 
-class QueryReaderFeed extends Component {
-	componentWillMount() {
-		if ( this.props.shouldFeedBeFetched ) {
-			this.props.requestFeed( this.props.feedId );
-		}
-	}
+const QueryReaderFeed = createQueryComponent( {
+	shouldRequest: shouldFeedBeFetched,
+	shouldRequestArg: 'feedId',
+	request: requestFeed,
+	requestArg: 'feedId',
+} );
 
-	componentWillReceiveProps( nextProps ) {
-		if ( ! nextProps.shouldFeedBeFetched || ( this.props.feedId === nextProps.feedId ) ) {
-			return;
-		}
-
-		nextProps.requestFeed( nextProps.feedId );
-	}
-
-	render() {
-		return null;
-	}
-}
-
-QueryReaderFeed.propTypes = {
-	feedId: PropTypes.number,
-	shouldFeedBeFetched: PropTypes.bool,
-	requestFeed: PropTypes.func
-};
-
-QueryReaderFeed.defaultProps = {
-	requestFeed: () => {}
-};
-
-export default connect(
-	( state, ownProps ) => {
-		const { feedId } = ownProps;
-		return {
-			shouldFeedBeFetched: shouldFeedBeFetched( state, feedId )
-		};
-	},
-	( dispatch ) => {
-		return bindActionCreators( {
-			requestFeed
-		}, dispatch );
-	}
-)( QueryReaderFeed );
+export default QueryReaderFeed;

--- a/client/components/data/query-reader-lists/index.jsx
+++ b/client/components/data/query-reader-lists/index.jsx
@@ -1,48 +1,14 @@
 /**
- * External dependencies
- */
-import { Component, PropTypes } from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-
-/**
  * Internal dependencies
  */
 import { isRequestingSubscribedLists } from 'state/reader/lists/selectors';
 import { requestSubscribedLists } from 'state/reader/lists/actions';
+import { createQueryComponent } from '../utils';
 
-class QueryReaderLists extends Component {
-	componentWillMount() {
-		if ( this.props.isRequestingSubscribedLists ) {
-			return;
-		}
+const QueryReaderLists = createQueryComponent( {
+	shouldRequest: ( state ) => ! isRequestingSubscribedLists( state ),
+	request: requestSubscribedLists,
+} );
 
-		this.props.requestSubscribedLists();
-	}
+export default QueryReaderLists;
 
-	render() {
-		return null;
-	}
-}
-
-QueryReaderLists.propTypes = {
-	isRequestingSubscribedLists: PropTypes.bool,
-	requestSubscribedLists: PropTypes.func
-};
-
-QueryReaderLists.defaultProps = {
-	requestSubscribedLists: () => {}
-};
-
-export default connect(
-	( state ) => {
-		return {
-			isRequestingSubscribedLists: isRequestingSubscribedLists( state )
-		};
-	},
-	( dispatch ) => {
-		return bindActionCreators( {
-			requestSubscribedLists
-		}, dispatch );
-	}
-)( QueryReaderLists );

--- a/client/components/data/utils.js
+++ b/client/components/data/utils.js
@@ -31,8 +31,7 @@ class GenericQueryComponent extends Component {
 }
 
 GenericQueryComponent.propTypes = {
-	shouldRequest: PropTypes.func,
-	shouldRequestArg: PropTypes.string,
+	shouldRequest: PropTypes.bool,
 	request: PropTypes.func,
 	requestArg: PropTypes.string,
 };

--- a/client/components/data/utils.js
+++ b/client/components/data/utils.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+class GenericQueryComponent extends Component {
+
+	componentWillMount() {
+		if ( ! this.props.shouldRequest ) {
+			return;
+		}
+
+		this.props.request( this.props[ this.props.requestArg ] );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( ! nextProps.shouldRequest ||
+				this.props[ this.props.requestArg ] === nextProps[ nextProps.requestArg ] ) {
+			return;
+		}
+
+		nextProps.request( nextProps.requestArgs );
+	}
+
+	render() {
+		return null;
+	}
+
+}
+
+GenericQueryComponent.propTypes = {
+	shouldRequest: PropTypes.func,
+	shouldRequestArg: PropTypes.string,
+	request: PropTypes.func,
+	requestArg: PropTypes.string,
+};
+
+export const createQueryComponent = ( {
+	shouldRequest,
+	shouldRequestArg,
+	request,
+	requestArg
+} ) => connect(
+	( state, ownProps ) => ( {
+		shouldRequest: shouldRequest( state, ownProps[ shouldRequestArg ] ),
+		requestArg,
+	} ),
+	( dispatch ) => bindActionCreators( { request }, dispatch ),
+)( GenericQueryComponent );
+


### PR DESCRIPTION
1. Since almost all query components look identical, would it be better if we generated them via a helper function/HoC?
2. Its a bit awkward to need to "render" QueryComponents in our components

This PR aims to test out some ideas around how to move past the need for QueryComponents as we have them now.  Even though I've placed it in "Needs Review", I really mean that the question needs review.  not that I think its ready for landing

### helper function approach
The way I've written it right now, for simple components like QueryReaderLists you can do:
```javascript

import { isRequestingSubscribedLists } from 'state/reader/lists/selectors';
import { requestSubscribedLists } from 'state/reader/lists/actions';		
 
const QueryReaderLists = createQueryComponent( {
	shouldRequest: ( state ) => ! isRequestingSubscribedLists( state ),
	request: requestSubscribedLists,
} );

export QueryReaderLists
```

For more complex components that require components like `QueryFeedReader` it is kind of awkward:

```javascript
const QueryReaderFeed = createQueryComponent( {
	shouldRequest: shouldFeedBeFetched,
	request: requestFeed,
	requestArg: 'feedId',
} );
```

This ends up creating a component that can be used as you would expect:
```jsx
<QueryReaderFeed feedId=`${ feedId }` />
```


### HoC approach
```jsx
// some file with a bunch of json configurations for needs.  
const ReaderLists = {
  shouldRequest: ( state ) => ! isRequestingSubscribedLists( state ),
  request: requestSubscribedLists,
}
...

// the relevant class file
import { ReaderLists, ReaderTeams } from 'state/data-needs';

const ReaderSidebar = class extends Component {
  ...
}
export default needs( ReaderSidebar, [ ReaderLists, ReaderTeams ] ) 
```

open questions:
1. do we need an extra param for `createQueryComponent` that that will give the created component the right name for debugging? That way everything doesn't appear as GenericQueryComponent
2. how much code will this really save & is it worth it?
3. would a HoC be preferable?  `needs( ReaderSidebar, [ ReaderLists, ... ] )`.
3. At this point we can sort of save json configs instead of components and generate all of the components within relevant components.  I don't know if there is any benefit there, but I could imagine querying query components in the same way that we do for selectors now

cc @blowery because we had been discussing this idea in slack a bit