### PR TITLE
Invites: Allow invite form for Jetpack sites in dev environment

### DIFF
--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -23,6 +23,7 @@ import InvitePeople from './invite-people';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
+import config from 'config';
 
 /**
  * Module variables
@@ -88,7 +89,7 @@ function renderInvitePeople( context ) {
 		sites.once( 'change', () => page( context.path ) );
 	}
 
-	if ( isJetpack ) {
+	if ( isJetpack && ! config.isEnabled( 'jetpack/invites' ) ) {
 		const currentLayoutFocus = getCurrentLayoutFocus( context.store.getState() );
 		context.store.dispatch( setNextLayoutFocus( currentLayoutFocus ) );
 		page.redirect( '/people/team/' + site.slug );

--- a/config/development.json
+++ b/config/development.json
@@ -51,6 +51,7 @@
 		"help": true,
 		"help/courses": true,
 		"jetpack/connect": true,
+		"jetpack/invites": true,
 		"jetpack/personalPlan": true,
 		"jetpack/seo-tools": true,
 		"jetpack/sso": true,


### PR DESCRIPTION
This PR allows the invites form to be displayed for Jetpack sites if the current environment is `development`.

To test:

- Checkout branch
- To go `calypso.localhost:3000/people/new/$site` where `$site` is a Jetpack site.
- Ensure invites form loads
- Go to `wordpress.com/people/new/$site` where `$site` is a Jetpack site
- Ensure you're redirected to `/people/team/$site`

cc @nickdaugherty who may be helping with Jetpack invites.