### PR TITLE
Themes: Add id suffix handling to some selectors

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -168,7 +168,7 @@ const ConnectedThemesSelection = connect(
 			themesCount: getThemesFoundForQuery( state, siteIdOrWpcom, query ),
 			isRequesting: isRequestingThemesForQuery( state, siteIdOrWpcom, query ),
 			isLastPage: isThemesLastPageForQuery( state, siteIdOrWpcom, query ),
-			isThemeActive: themeId => isThemeActive( state, suffixThemeId( themeId ), siteId ),
+			isThemeActive: themeId => isThemeActive( state, themeId, siteId ),
 			isThemePurchased: themeId => (
 				// Note: This component assumes that purchase and data is already present in the state tree
 				// (used by the isThemePurchased selector). At the time of implementation there's no caching

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -147,11 +147,6 @@ const ConnectedThemesSelection = connect(
 		const isJetpack = isJetpackSite( state, siteId );
 		const siteIdOrWpcom = ( siteId && isJetpack && ! ( queryWpcom === true ) ) ? siteId : 'wpcom';
 
-		let suffixThemeId = ( themeId ) => themeId;
-		if ( isJetpack && queryWpcom ) {
-			suffixThemeId = ( themeId ) => themeId + '-wpcom';
-		}
-
 		const query = {
 			search,
 			page,
@@ -174,12 +169,12 @@ const ConnectedThemesSelection = connect(
 				// (used by the isThemePurchased selector). At the time of implementation there's no caching
 				// in <QuerySitePurchases /> and a parent component is already rendering it. So to avoid
 				// redundant AJAX requests, we're not rendering the query component locally.
-				isThemePurchased( state, suffixThemeId( themeId ), siteId ) ||
+				isThemePurchased( state, themeId, siteId ) ||
 				// The same is true for the `hasFeature` selector, which relies on the presence of
 				// a `<QuerySitePlans />` component in a parent component.
 				hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES )
 			),
-			isInstallingTheme: themeId => isInstallingTheme( state, suffixThemeId( themeId ), siteId )
+			isInstallingTheme: themeId => isInstallingTheme( state, themeId, siteId )
 		};
 	}
 )( ThemesSelection );

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -498,7 +498,10 @@ export function getActiveTheme( state, siteId ) {
  * @return {Boolean}         True if the theme is active on the site
  */
 export function isThemeActive( state, themeId, siteId ) {
-	return getActiveTheme( state, siteId ) === themeId;
+	const isJetpack = siteId && isJetpackSite( state, siteId );
+	const isThemeWpcom = isWpcomTheme( state, themeId );
+	const themeIdAtTargetSite = ( isJetpack && isThemeWpcom ) ? `${ themeId }-wpcom` : themeId;
+	return getActiveTheme( state, siteId ) === themeIdAtTargetSite;
 }
 
 /**

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -27,6 +27,26 @@ import {
 import { DEFAULT_THEME_QUERY } from './constants';
 
 /**
+ * When wpcom themes are installed on Jetpack sites, the
+ * theme id is suffixed with -wpcom. Some operations require
+ * the use of this suffixed ID. This util function add the
+ * suffix if the theme is a wpcom theme and the site is Jetpack.
+ * or not, given siteId and ThemeId.
+ *
+ * @param {Object} state	Global state tree
+ * @param {Number} siteId	Site ID
+ * @param {String} themeId	Theme ID
+ * @return {String} 		Potentially suffixed theme ID
+ */
+const getSuffixedThemeId = ( state, siteId, themeId ) => {
+	const siteIsJetpack = siteId && isJetpackSite( state, siteId );
+	if ( siteIsJetpack && isWpcomTheme( state, themeId ) ) {
+		return `${ themeId }-wpcom`;
+	}
+	return themeId;
+};
+
+/**
  * Returns a theme object by site ID, theme ID pair.
  *
  * @param  {Object}  state   Global state tree
@@ -498,10 +518,7 @@ export function getActiveTheme( state, siteId ) {
  * @return {Boolean}         True if the theme is active on the site
  */
 export function isThemeActive( state, themeId, siteId ) {
-	const isJetpack = siteId && isJetpackSite( state, siteId );
-	const isThemeWpcom = isWpcomTheme( state, themeId );
-	const themeIdAtTargetSite = ( isJetpack && isThemeWpcom ) ? `${ themeId }-wpcom` : themeId;
-	return getActiveTheme( state, siteId ) === themeIdAtTargetSite;
+	return getActiveTheme( state, siteId ) === getSuffixedThemeId( state, siteId, themeId );
 }
 
 /**

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -34,11 +34,11 @@ import { DEFAULT_THEME_QUERY } from './constants';
  * or not, given siteId and ThemeId.
  *
  * @param {Object} state	Global state tree
- * @param {Number} siteId	Site ID
  * @param {String} themeId	Theme ID
+ * @param {Number} siteId	Site ID
  * @return {String} 		Potentially suffixed theme ID
  */
-const getSuffixedThemeId = ( state, siteId, themeId ) => {
+const getSuffixedThemeId = ( state, themeId, siteId ) => {
 	const siteIsJetpack = siteId && isJetpackSite( state, siteId );
 	if ( siteIsJetpack && isWpcomTheme( state, themeId ) ) {
 		return `${ themeId }-wpcom`;
@@ -518,7 +518,7 @@ export function getActiveTheme( state, siteId ) {
  * @return {Boolean}         True if the theme is active on the site
  */
 export function isThemeActive( state, themeId, siteId ) {
-	return getActiveTheme( state, siteId ) === getSuffixedThemeId( state, siteId, themeId );
+	return getActiveTheme( state, siteId ) === getSuffixedThemeId( state, themeId, siteId );
 }
 
 /**
@@ -552,7 +552,7 @@ export function hasActivatedTheme( state, siteId ) {
  * @return {Boolean}         True if theme installation is ongoing
  */
 export function isInstallingTheme( state, themeId, siteId ) {
-	const suffixedThemeId = getSuffixedThemeId( state, siteId, themeId );
+	const suffixedThemeId = getSuffixedThemeId( state, themeId, siteId );
 	return get( state.themes.themeInstalls, [ siteId, suffixedThemeId ], false );
 }
 

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -552,7 +552,8 @@ export function hasActivatedTheme( state, siteId ) {
  * @return {Boolean}         True if theme installation is ongoing
  */
 export function isInstallingTheme( state, themeId, siteId ) {
-	return get( state.themes.themeInstalls, [ siteId, themeId ], false );
+	const suffixedThemeId = getSuffixedThemeId( state, siteId, themeId );
+	return get( state.themes.themeInstalls, [ siteId, suffixedThemeId ], false );
 }
 
 /**

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -1432,7 +1432,10 @@ describe( 'themes selectors', () => {
 					themes: {
 						activeThemes: {
 							2916284: 'twentysixteen'
-						}
+						},
+						queries: {
+							wpcom: new ThemeQueryManager( {} ),
+						},
 					}
 				},
 			);
@@ -1446,7 +1449,10 @@ describe( 'themes selectors', () => {
 					themes: {
 						activeThemes: {
 							2916284: 'twentysixteen'
-						}
+						},
+						queries: {
+							wpcom: new ThemeQueryManager( {} ),
+						},
 					}
 				}, 'mood'
 			);
@@ -1460,6 +1466,14 @@ describe( 'themes selectors', () => {
 					themes: {
 						activeThemes: {
 							2916284: 'twentysixteen'
+						},
+						queries: {
+							wpcom: new ThemeQueryManager( {} ),
+						},
+					},
+					sites: {
+						items: {
+							2916284: { ID: 2916284, jetpack: false }
 						}
 					}
 				},
@@ -1476,9 +1490,41 @@ describe( 'themes selectors', () => {
 					themes: {
 						activeThemes: {
 							2916284: 'mood'
+						},
+						queries: {
+							wpcom: new ThemeQueryManager( {} ),
+						},
+					},
+					sites: {
+						items: {
+							2916284: { ID: 2916284, jetpack: false }
 						}
 					}
 				}, 'mood', 2916284
+			);
+
+			expect( isActive ).to.be.true;
+		} );
+
+		it( 'given a wpcom theme and a jetpack site on which it is active, should return true', () => {
+			const isActive = isThemeActive(
+				{
+					themes: {
+						activeThemes: {
+							77203074: 'karuna-wpcom'
+						},
+						queries: {
+							wpcom: new ThemeQueryManager( {
+								items: { karuna: { id: 'karuna' } }
+							} ),
+						}
+					},
+					sites: {
+						items: {
+							77203074: { ID: 77203074, URL: 'https://example.net', jetpack: true }
+						}
+					}
+				}, 'karuna', 77203074
 			);
 
 			expect( isActive ).to.be.true;

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -1644,11 +1644,47 @@ describe( 'themes selectors', () => {
 							2916284: {
 								karuna: true
 							}
+						},
+						queries: {
+							wpcom: new ThemeQueryManager( {} ),
+						},
+					},
+					sites: {
+						items: {
+							2916284: { ID: 2916284, jetpack: false }
 						}
 					}
 				},
 				'karuna',
 				2916284
+			);
+
+			expect( installing ).to.be.true;
+		} );
+
+		it( 'given a jetpack site and wpcom theme, should return true if theme is currently being installed', () => {
+			const installing = isInstallingTheme(
+				{
+					themes: {
+						themeInstalls: {
+							77203074: {
+								'karuna-wpcom': true
+							}
+						},
+						queries: {
+							wpcom: new ThemeQueryManager( {
+								items: { karuna: { id: 'karuna' } }
+							} ),
+						}
+					},
+					sites: {
+						items: {
+							77203074: { ID: 77203074, URL: 'https://example.net', jetpack: true }
+						}
+					}
+				},
+				'karuna',
+				77203074
 			);
 
 			expect( installing ).to.be.true;


### PR DESCRIPTION
No visual differences.

Move `-wpcom` suffix handling out of the `theme-selection.jsx` component and into the `isThemeActive` and `isInstallingTheme` selectors.

The motivation for this is that there are other places (#10526) where we will need to know whether a wpcom theme is active on a jetpack site, and we don't want to have to do the suffix wrangling wherever we use the `isThemeActive` selector.

Includes unit tests.

**To Test**
* Go to http://calypso.localhost:3000/design/{jetpack site}
* Pick a theme from the _WordPress.com themes_ list, click on the ... menu and hit _Activate_
* **Expected** The theme should activate as on `master`
* **Expected** We should still see the in-place pulsating dot progress indicator as the theme is installed
* **Expected** We should still see the modal dialog as the theme activates
