### PR TITLE
Plans: Set the Document Title on `Current Plan` render

### DIFF
--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -16,6 +16,7 @@ import {
 } from 'state/sites/plans/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
+import DocumentHead from 'components/data/document-head';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import PlansNavigation from 'my-sites/upgrades/navigation';
 import ProductPurchaseFeatures from 'blocks/product-purchase-features';
@@ -98,7 +99,8 @@ class CurrentPlan extends Component {
 			context,
 			currentPlan,
 			isExpiring,
-			isJetpack
+			isJetpack,
+			translate,
 		} = this.props;
 
 		const currentPlanSlug = selectedSite.plan.product_slug,
@@ -108,6 +110,7 @@ class CurrentPlan extends Component {
 
 		return (
 			<Main className="current-plan" wideLayout>
+				<DocumentHead title={ translate( 'Plans', { textOnly: true } ) } />
 				<QuerySites siteId={ selectedSiteId } />
 				<QuerySitePlans siteId={ selectedSiteId } />
 				{ selectedSiteId && ! isJetpack && <QuerySiteDomains siteId={ selectedSiteId } /> }


### PR DESCRIPTION
I noticed this as I was working on #10818.

When I select a site that has a currnet plan and navigate from one section to another using the `Plan` sidebar item:

<img width="285" alt="screen shot 2017-01-23 at 8 48 59 pm" src="https://cloud.githubusercontent.com/assets/1587282/22230807/be4dcff2-e1ad-11e6-8661-a96908213456.png">

...I expect the Document Title to be updated as it is when said navigation points to `/plans` (as opposed to `/plans/my-plan`).

Instead, the title is not updated and remains as a reference to the previous section.

Further, if I browse directly to `/plans/my-plan`, it only sets the title to `WordPress.com` -- no section is set.

This change adds the `DocumentHead` component to the render method of the `CurrentPlan` component & fixes the aforementioned.

**To Test:**
* Verify current behavior:
  * Select a site with a current plan subscription
  * Visit any site-dependent section (Posts, Pages, Stats, etc.)
  * Note the title in the browser
  * Click the `Plans` link
  * Note the title in the browser __did not__ change
* Verify fix:
  * Switch to this branch
  * Select a site with a current plan subscription
  * Visit any site-dependent section (Posts, Pages, Stats, etc.)
  * Note the title in the browser
  * Click the `Plans` link
  * Note the title in the browser __did__ change and is accurate