### PR TITLE
Stats: Fix JS error when the post is not fetched yet on the Weeks Stats component

### DIFF
--- a/client/my-sites/stats/stats-detail-weeks/index.jsx
+++ b/client/my-sites/stats/stats-detail-weeks/index.jsx
@@ -37,7 +37,7 @@ const StatsPostDetailWeeks = ( props ) => {
 	};
 
 	if ( stats && stats.weeks ) {
-		const publishDate = post.post_date ? moment( post.post_date ) : null;
+		const publishDate = post && post.post_date ? moment( post.post_date ) : null;
 		highest = stats.highest_week_average;
 		tableHeader = (
 			<thead>


### PR DESCRIPTION
I noticed a small error on the console on the Post Recent Weeks component when the post hasn't loaded yet. It's not blocking, but who likes errors :) 

**testing instructions**

 * Navigate to the post stats page: `/stats/post/$postId/$site` on a cold cache
 * You should not see any error on the console