### PR TITLE
Stats: Extract the Post Likes into a generic block

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -30,6 +30,7 @@
 @import 'blocks/plan-thank-you-card/style';
 @import 'blocks/post-edit-button/style';
 @import 'blocks/post-item/style';
+@import 'blocks/post-likes/style';
 @import 'blocks/post-relative-time/style';
 @import 'blocks/post-status/style';
 @import 'blocks/reader-avatar/style';

--- a/client/blocks/post-likes/README.md
+++ b/client/blocks/post-likes/README.md
@@ -1,0 +1,34 @@
+Post Likes
+==========
+
+`<PostLikes />` is a connected React component for rendering the post likes.
+
+## Usage
+
+Render the component passing a siteId and a postId.
+
+```jsx
+function MyAwesomeComponent() {
+	return <PostLikes siteId="10" postId="1143" />;
+}
+```
+
+## Props
+
+### `siteId`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The site ID for which the post likes should be displayed.
+
+### `postId`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The post ID for which the post likes should be displayed.

--- a/client/blocks/post-likes/docs/example.jsx
+++ b/client/blocks/post-likes/docs/example.jsx
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import PostLikes from '../';
+
+function PostLikesExample() {
+	return (
+		<div>
+			<PostLikes siteId={ 3584907 } postId={ 37769 } />
+		</div>
+	);
+}
+
+PostLikesExample.displayName = 'PostLikes';
+
+export default PostLikesExample;

--- a/client/blocks/post-likes/index.jsx
+++ b/client/blocks/post-likes/index.jsx
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ **/
+import React from 'react';
+import { connect } from 'react-redux';
+import { flowRight } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Gravatar from 'components/gravatar';
+import QueryPostLikes from 'components/data/query-post-likes';
+import { isRequestingPostLikes, getPostLikes, countPostLikes } from 'state/selectors';
+import { recordGoogleEvent } from 'state/analytics/actions';
+
+export const PostLikes = props => {
+	const { countLikes, isRequesting, likes, postId, siteId, translate } = props;
+	const trackLikeClick = () => props.recordGoogleEvent( 'Post Likes', 'Clicked on Gravatar' );
+	const getLikeUrl = like => {
+		return like.URL ? like.URL : `https://gravatar.com/${ like.login }`;
+	};
+
+	return (
+		<div className="post-likes">
+			<QueryPostLikes siteId={ siteId } postId={ postId } />
+			{ likes && !! likes.length && likes
+				.map( like =>
+					<a
+						key={ like.ID }
+						href={ getLikeUrl( like ) }
+						rel="noopener noreferrer"
+						target="_blank"
+						className="post-likes__item"
+						onClick={ trackLikeClick }
+					>
+						<Gravatar user={ like } size={ 24 } />
+					</a>
+				).concat(
+					countLikes > likes.length && <span key="placeholder" className="post-likes__placeholder">
+						{ `+ ${ countLikes - likes.length }` }
+					</span>
+				)
+			}
+			{ countLikes === 0 && ! isRequesting && translate( 'There are no likes on this post yet.' ) }
+		</div>
+	);
+};
+
+const connectComponent = connect(
+	( state, { siteId, postId } ) => {
+		const isRequesting = isRequestingPostLikes( state, siteId, postId );
+		const countLikes = countPostLikes( state, siteId, postId );
+		const likes = getPostLikes( state, siteId, postId );
+		return {
+			countLikes,
+			isRequesting,
+			likes,
+		};
+	},
+	{ recordGoogleEvent }
+);
+
+export default flowRight(
+	connectComponent,
+	localize
+)( PostLikes );

--- a/client/blocks/post-likes/style.scss
+++ b/client/blocks/post-likes/style.scss
@@ -1,0 +1,26 @@
+.post-likes {
+	font-size: 13px;
+
+	.post-likes__item {
+		display: inline-block;
+		margin: 2px 8px 2px 0;
+		vertical-align: top;
+		.gravatar {
+			display: block;
+		}
+	}
+
+	.post-likes__placeholder {
+		vertical-align: top;
+		margin-top: 6px;
+		line-height: 14px;
+		border-radius: 12px;
+		display: inline-block;
+		border: solid 1px #87a6bc;
+		color: #87a6bc;
+		padding: 1px 6px;
+		font-weight: 600;
+		font-size: 11px;
+	}
+}
+

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -53,6 +53,7 @@ import ImageEditor from 'blocks/image-editor/docs/example';
 import ReaderPostCard from 'blocks/reader-post-card/docs/example';
 import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu/docs/example';
 import DailyPostButton from 'blocks/daily-post-button/docs/example';
+import PostLikes from 'blocks/post-likes/docs/example';
 
 export default React.createClass( {
 
@@ -126,6 +127,7 @@ export default React.createClass( {
 					<ReaderAvatar />
 					<ReaderPostOptionsMenu />
 					<DailyPostButton />
+					<PostLikes />
 				</Collection>
 			</Main>
 		);

--- a/client/my-sites/stats/stats-post-likes/index.jsx
+++ b/client/my-sites/stats/stats-post-likes/index.jsx
@@ -13,25 +13,20 @@ import { localize } from 'i18n-calypso';
 import Card from 'components/card';
 import Count from 'components/count';
 import Gridicon from 'components/gridicon';
-import Gravatar from 'components/gravatar';
 import StatsModuleContent from '../stats-module/content-text';
 import QueryPostLikes from 'components/data/query-post-likes';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import toggleInfo from '../toggle-info';
-import { isRequestingPostLikes, getPostLikes, countPostLikes } from 'state/selectors';
-import { recordGoogleEvent } from 'state/analytics/actions';
+import { isRequestingPostLikes, countPostLikes } from 'state/selectors';
+import PostLikes from 'blocks/post-likes';
 
-export const PostLikes = props => {
-	const { countLikes, isRequesting, likes, opened, postId, siteId, toggle, translate } = props;
+export const StatsPostLikes = props => {
+	const { countLikes, isRequesting, opened, postId, siteId, toggle, translate } = props;
 	const infoIcon = opened ? 'info' : 'info-outline';
-	const isLoading = isRequesting && ! likes;
+	const isLoading = isRequesting && ! countLikes;
 	const classes = {
 		'is-showing-info': opened,
 		'is-loading': isLoading,
-	};
-	const trackLikeClick = () => props.recordGoogleEvent( 'Stats Post Likes', 'Clicked on Gravatar' );
-	const getLikeUrl = like => {
-		return like.URL ? like.URL : `https://gravatar.com/${ like.login }`;
 	};
 
 	return (
@@ -60,33 +55,9 @@ export const PostLikes = props => {
 				{ translate( 'This panel shows the list of people who like your post.' ) }
 			</StatsModuleContent>
 			<StatsModulePlaceholder isLoading={ isLoading } />
-			{ likes && !! likes.length &&
-				<div className="stats-post-likes__content">
-					{ likes
-							.map( like =>
-								<a
-									key={ like.ID }
-									href={ getLikeUrl( like ) }
-									rel="noopener noreferrer"
-									target="_blank"
-									className="stats-post-likes__like"
-									onClick={ trackLikeClick }
-								>
-									<Gravatar user={ like } size={ 24 } />
-								</a>
-							).concat(
-								countLikes > likes.length && <span key="placeholder" className="stats-post-likes__placeholder">
-									{ `+ ${ countLikes - likes.length }` }
-								</span>
-							)
-					}
-				</div>
-			}
-			{ countLikes === 0 && ! isRequesting &&
-				<div className="stats-post-likes__content">
-					{ translate( 'There are no likes on this post yet.' ) }
-				</div>
-			}
+			<div className="stats-post-likes__content">
+				<PostLikes siteId={ siteId } postId={ postId } />
+			</div>
 		</Card>
 	);
 };
@@ -95,18 +66,15 @@ const connectComponent = connect(
 	( state, { siteId, postId } ) => {
 		const isRequesting = isRequestingPostLikes( state, siteId, postId );
 		const countLikes = countPostLikes( state, siteId, postId );
-		const likes = getPostLikes( state, siteId, postId );
 		return {
 			countLikes,
 			isRequesting,
-			likes,
 		};
-	},
-	{ recordGoogleEvent }
+	}
 );
 
 export default flowRight(
 	connectComponent,
 	toggleInfo,
 	localize
-)( PostLikes );
+)( StatsPostLikes );

--- a/client/my-sites/stats/stats-post-likes/style.scss
+++ b/client/my-sites/stats/stats-post-likes/style.scss
@@ -7,29 +7,10 @@
 		box-sizing: border-box;
 		padding: 8px 24px 16px;
 		color: $gray-dark;
-		font-size: 13px;
 	}
 
-	.stats-post-likes__like {
-		display: inline-block;
-		margin: 2px 8px 2px 0;
-		vertical-align: top;
-		.gravatar {
-			display: block;
-		}
-	}
-
-	.stats-post-likes__placeholder {
-		vertical-align: top;
-		margin-top: 6px;
-		line-height: 14px;
-		border-radius: 12px;
-		display: inline-block;
-		border: solid 1px #87a6bc;
-		color: #87a6bc;
-		padding: 1px 6px;
-		font-weight: 600;
-		font-size: 11px;
+	&.is-loading .stats-post-likes__content {
+		display: none;
 	}
 
 	.module-content-text-info {


### PR DESCRIPTION
In this PR, I'm extracting the component showing the Post Likes into a reusable block.
I also added an example to the devdocs.

**Testing instructions**

 - Navigate to `/stats/post/$postId/$site`
 - Check that the Post Likes Card is still showing the likes as expected
