### PR TITLE
Post Controls: modularization and reduxification

### DIFF
--- a/client/my-sites/posts/post-controls/index.jsx
+++ b/client/my-sites/posts/post-controls/index.jsx
@@ -224,9 +224,9 @@ PostControls.propTypes = {
 };
 
 const mapStateToProps = ( state, { site, post } ) => ( {
-	canUserDeletePost: canCurrentUser( state, site.ID, 'delete_post' ),
-	canUserEditPost: canCurrentUser( state, site.ID, 'edit_post' ),
-	canUserPublishPost: canCurrentUser( state, site.ID, 'publish_post' ),
+	canUserDeletePost: canCurrentUser( state, site.ID, 'delete_posts' ),
+	canUserEditPost: canCurrentUser( state, site.ID, 'edit_posts' ),
+	canUserPublishPost: canCurrentUser( state, site.ID, 'publish_posts' ),
 	isPublicizeEnabled: isPublicizeEnabled( state, site.ID, post.type ),
 } );
 

--- a/client/my-sites/posts/post-controls/index.jsx
+++ b/client/my-sites/posts/post-controls/index.jsx
@@ -12,8 +12,10 @@ import classNames from 'classnames';
  */
 import { isEnabled } from 'config';
 import { ga } from 'lib/analytics';
-import { userCan } from 'lib/posts/utils';
-import { isPublicizeEnabled } from 'state/selectors';
+import {
+	canCurrentUser,
+	isPublicizeEnabled,
+} from 'state/selectors';
 import PostControl from './post-control';
 
 const view = () => ga.recordEvent( 'Posts', 'Clicked View Post' );
@@ -24,6 +26,9 @@ const viewStats = () => ga.recordEvent( 'Posts', 'Clicked View Post Stats' );
 
 const getAvailableControls = props => {
 	const {
+		canUserDeletePost,
+		canUserEditPost,
+		canUserPublishPost,
 		editURL,
 		fullWidth,
 		onDelete,
@@ -43,7 +48,7 @@ const getAvailableControls = props => {
 	// and those posts will not have access to post management type controls
 
 	// Main Controls (not behind ... more link)
-	if ( userCan( 'edit_post', post ) ) {
+	if ( canUserEditPost ) {
 		controls.main.push( {
 			className: 'edit',
 			href: editURL,
@@ -95,7 +100,7 @@ const getAvailableControls = props => {
 			text: translate( 'Preview' ),
 		} );
 
-		if ( userCan( 'publish_post', post ) ) {
+		if ( canUserPublishPost ) {
 			controls.main.push( {
 				className: 'publish',
 				icon: 'reader',
@@ -103,7 +108,7 @@ const getAvailableControls = props => {
 				text: translate( 'Publish' ),
 			} );
 		}
-	} else if ( userCan( 'delete_post', post ) ) {
+	} else if ( canUserDeletePost ) {
 		controls.main.push( {
 			className: 'restore',
 			icon: 'undo',
@@ -112,7 +117,7 @@ const getAvailableControls = props => {
 		} );
 	}
 
-	if ( userCan( 'delete_post', post ) ) {
+	if ( canUserDeletePost ) {
 		if ( 'trash' === post.status ) {
 			controls.main.push( {
 				className: 'trash is-scary',
@@ -130,7 +135,7 @@ const getAvailableControls = props => {
 		}
 	}
 
-	if ( ( 'publish' === post.status || 'private' === post.status ) && userCan( 'edit_post', post ) ) {
+	if ( ( 'publish' === post.status || 'private' === post.status ) && canUserEditPost ) {
 		controls.main.push( {
 			className: 'copy',
 			href: `/post/${ site.slug }?copy=${ post.ID }`,
@@ -192,6 +197,9 @@ export const PostControls = props => {
 };
 
 PostControls.propTypes = {
+	canUserDeletePost: PropTypes.bool,
+	canUserEditPost: PropTypes.bool,
+	canUserPublishPost: PropTypes.bool,
 	editURL: PropTypes.string.isRequired,
 	fullWidth: PropTypes.bool,
 	isPublicizeEnabled: PropTypes.bool,
@@ -208,5 +216,8 @@ PostControls.propTypes = {
 };
 
 export default connect( ( state, { site, post } ) => ( {
+	canUserDeletePost: canCurrentUser( state, site.ID, 'delete_post' ),
+	canUserEditPost: canCurrentUser( state, site.ID, 'edit_post' ),
+	canUserPublishPost: canCurrentUser( state, site.ID, 'publish_post' ),
 	isPublicizeEnabled: isPublicizeEnabled( state, site.ID, post.type ),
 } ) )( localize( PostControls ) );

--- a/client/my-sites/posts/post-controls/index.jsx
+++ b/client/my-sites/posts/post-controls/index.jsx
@@ -11,18 +11,16 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import { isEnabled } from 'config';
-import { ga } from 'lib/analytics';
+import {
+	composeAnalytics,
+	recordGoogleEvent,
+	recordTracksEvent,
+} from 'state/analytics/actions';
 import {
 	canCurrentUser,
 	isPublicizeEnabled,
 } from 'state/selectors';
 import PostControl from './post-control';
-
-const view = () => ga.recordEvent( 'Posts', 'Clicked View Post' );
-const preview = () => ga.recordEvent( 'Posts', 'Clicked Preiew Post' );
-const edit = () => ga.recordEvent( 'Posts', 'Clicked Edit Post' );
-const copy = () => ga.recordEvent( 'Posts', 'Clicked Copy Post' );
-const viewStats = () => ga.recordEvent( 'Posts', 'Clicked View Post Stats' );
 
 const getAvailableControls = props => {
 	const {
@@ -39,6 +37,11 @@ const getAvailableControls = props => {
 		onToggleShare,
 		onTrash,
 		post,
+		recordCopyPost,
+		recordEditPost,
+		recordPreviewPost,
+		recordViewPost,
+		recordViewPostStats,
 		site,
 		translate,
 	} = props;
@@ -53,7 +56,7 @@ const getAvailableControls = props => {
 			className: 'edit',
 			href: editURL,
 			icon: 'pencil',
-			onClick: edit,
+			onClick: recordEditPost,
 			text: translate( 'Edit' ),
 		} );
 	}
@@ -63,7 +66,7 @@ const getAvailableControls = props => {
 			className: 'view',
 			href: post.URL,
 			icon: 'external',
-			onClick: view,
+			onClick: recordViewPost,
 			target: '_blank',
 			text: translate( 'View' ),
 		} );
@@ -72,7 +75,7 @@ const getAvailableControls = props => {
 			className: 'stats',
 			href: `/stats/post/${ post.ID }/${ site.slug }`,
 			icon: 'stats-alt',
-			onClick: viewStats,
+			onClick: recordViewPostStats,
 			text: translate( 'Stats' ),
 		} );
 
@@ -96,7 +99,7 @@ const getAvailableControls = props => {
 			className: 'view',
 			href: url.format( parsedUrl ),
 			icon: 'external',
-			onClick: preview,
+			onClick: recordPreviewPost,
 			text: translate( 'Preview' ),
 		} );
 
@@ -140,7 +143,7 @@ const getAvailableControls = props => {
 			className: 'copy',
 			href: `/post/${ site.slug }?copy=${ post.ID }`,
 			icon: 'clipboard',
-			onClick: copy,
+			onClick: recordCopyPost,
 			text: translate( 'Copy' ),
 		} );
 	}
@@ -211,13 +214,43 @@ PostControls.propTypes = {
 	onToggleShare: PropTypes.func,
 	onTrash: PropTypes.func,
 	post: PropTypes.object.isRequired,
+	recordCopyPost: PropTypes.func,
+	recordEditPost: PropTypes.func,
+	recordPreviewPost: PropTypes.func,
+	recordViewPost: PropTypes.func,
+	recordViewPostStats: PropTypes.func,
 	site: PropTypes.object,
 	translate: PropTypes.func,
 };
 
-export default connect( ( state, { site, post } ) => ( {
+const mapStateToProps = ( state, { site, post } ) => ( {
 	canUserDeletePost: canCurrentUser( state, site.ID, 'delete_post' ),
 	canUserEditPost: canCurrentUser( state, site.ID, 'edit_post' ),
 	canUserPublishPost: canCurrentUser( state, site.ID, 'publish_post' ),
 	isPublicizeEnabled: isPublicizeEnabled( state, site.ID, post.type ),
-} ) )( localize( PostControls ) );
+} );
+
+const mapDispatchToProps = dispatch => ( {
+	recordCopyPost: () => dispatch( composeAnalytics(
+		recordGoogleEvent( 'Posts', 'Clicked Copy Post' ),
+		recordTracksEvent( 'calypso_post_controls_copy_post_click' ),
+	) ),
+	recordEditPost: () => dispatch( composeAnalytics(
+		recordGoogleEvent( 'Posts', 'Clicked Edit Post' ),
+		recordTracksEvent( 'calypso_post_controls_edit_post_click' ),
+	) ),
+	recordPreviewPost: () => dispatch( composeAnalytics(
+		recordGoogleEvent( 'Posts', 'Clicked Preview Post' ),
+		recordTracksEvent( 'calypso_post_controls_preview_post_click' ),
+	) ),
+	recordViewPost: () => dispatch( composeAnalytics(
+		recordGoogleEvent( 'Posts', 'Clicked View Post' ),
+		recordTracksEvent( 'calypso_post_controls_view_post_click' ),
+	) ),
+	recordViewPostStats: () => dispatch( composeAnalytics(
+		recordGoogleEvent( 'Posts', 'Clicked View Post Stats' ),
+		recordTracksEvent( 'calypso_post_controls_view_post_stats_click' ),
+	) ),
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( PostControls ) );

--- a/client/my-sites/posts/post-controls/index.jsx
+++ b/client/my-sites/posts/post-controls/index.jsx
@@ -6,7 +6,6 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import url from 'url';
 import classNames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,7 +14,7 @@ import { isEnabled } from 'config';
 import { ga } from 'lib/analytics';
 import { userCan } from 'lib/posts/utils';
 import { isPublicizeEnabled } from 'state/selectors';
-import Gridicon from 'components/gridicon';
+import PostControl from './post-control';
 
 const view = () => ga.recordEvent( 'Posts', 'Clicked View Post' );
 const preview = () => ga.recordEvent( 'Posts', 'Clicked Preiew Post' );
@@ -167,25 +166,6 @@ const getAvailableControls = props => {
 	return controls;
 };
 
-const getControlElements = controls => controls.map( ( control, index ) =>
-	<li
-		className={ classNames( { 'post-controls__disabled': control.disabled } ) }
-		key={ index }
-	>
-		<a
-			className={ `post-controls__${ control.className }` }
-			href={ control.href }
-			onClick={ control.disabled ? noop : control.onClick }
-			target={ control.target ? control.target : null }
-		>
-			<Gridicon icon={ control.icon } size={ 18 } />
-			<span>
-				{ control.text }
-			</span>
-		</a>
-	</li>
-);
-
 export const PostControls = props => {
 	const { main, more } = getAvailableControls( props );
 	const classes = classNames(
@@ -197,11 +177,15 @@ export const PostControls = props => {
 		<div className={ classes }>
 			{ more.length > 0 &&
 				<ul className="posts__post-controls post-controls__pane post-controls__more-options">
-					{ getControlElements( more ) }
+					{ more.map( ( control, index ) =>
+						<PostControl control={ control } key={ index } />
+					) }
 				</ul>
 			}
 			<ul className="posts__post-controls post-controls__pane post-controls__main-options">
-				{ getControlElements( main ) }
+				{ main.map( ( control, index ) =>
+					<PostControl control={ control } key={ index } />
+				) }
 			</ul>
 		</div>
 	);

--- a/client/my-sites/posts/post-controls/post-control.jsx
+++ b/client/my-sites/posts/post-controls/post-control.jsx
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+
+export const PostControl = ( { control } ) =>
+	<li className={ classNames( { 'post-controls__disabled': control.disabled } ) } >
+		<a
+			className={ `post-controls__${ control.className }` }
+			href={ control.href }
+			onClick={ control.disabled ? noop : control.onClick }
+			target={ control.target ? control.target : null }
+		>
+			<Gridicon icon={ control.icon } size={ 18 } />
+			<span>
+				{ control.text }
+			</span>
+		</a>
+	</li>;
+
+export default PostControl;

--- a/client/state/analytics/actions.js
+++ b/client/state/analytics/actions.js
@@ -24,7 +24,7 @@ const joinAnalytics = ( analytics, action ) =>
 export const composeAnalytics = ( ...analytics ) => ( {
 	type: ANALYTICS_MULTI_TRACK,
 	meta: {
-		analytics: analytics.map( property( 'meta.analytics' ) )
+		analytics: analytics.map( property( 'meta.analytics[0]' ) )
 	}
 } );
 


### PR DESCRIPTION
Follow up from https://github.com/Automattic/wp-calypso/pull/10746

- Move the single control items into their own `PostControl` component in order to make `PostControls` more readable.
- Reduxification of user capabilities checks.
- Reduxification of events tracking.