### PR TITLE
State: Update siteSupportsJetpackSettingsUi version to 4.6

### DIFF
--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -1039,5 +1039,5 @@ export const hasDefaultSiteTitle = ( state, siteId ) => {
  * @return {?Boolean}     Whether site supports managing Jetpack settings remotely.
  */
 export const siteSupportsJetpackSettingsUi = ( state, siteId ) => {
-	return isJetpackMinimumVersion( state, siteId, '4.5.0' );
+	return isJetpackMinimumVersion( state, siteId, '4.6.0' );
 };

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -2351,7 +2351,7 @@ describe( 'selectors', () => {
 			expect( supportsJetpackSettingsUI ).to.be.null;
 		} );
 
-		it( 'should return false if the Jetpack version is older than 4.5', () => {
+		it( 'should return false if the Jetpack version is older than 4.6', () => {
 			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUi( {
 				sites: {
 					items: {
@@ -2370,7 +2370,7 @@ describe( 'selectors', () => {
 			expect( supportsJetpackSettingsUI ).to.be.false;
 		} );
 
-		it( 'should return true if the Jetpack version is 4.5', () => {
+		it( 'should return true if the Jetpack version is 4.6', () => {
 			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUi( {
 				sites: {
 					items: {
@@ -2389,7 +2389,7 @@ describe( 'selectors', () => {
 			expect( supportsJetpackSettingsUI ).to.be.true;
 		} );
 
-		it( 'should return true if the Jetpack version is newer than 4.5', () => {
+		it( 'should return true if the Jetpack version is newer than 4.6', () => {
 			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUi( {
 				sites: {
 					items: {

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -2360,7 +2360,7 @@ describe( 'selectors', () => {
 							URL: 'https://example.com',
 							jetpack: true,
 							options: {
-								jetpack_version: '4.4.0'
+								jetpack_version: '4.5.0'
 							}
 						}
 					}
@@ -2379,7 +2379,7 @@ describe( 'selectors', () => {
 							URL: 'https://example.com',
 							jetpack: true,
 							options: {
-								jetpack_version: '4.5.0'
+								jetpack_version: '4.6.0'
 							}
 						}
 					}
@@ -2398,7 +2398,7 @@ describe( 'selectors', () => {
 							URL: 'https://example.com',
 							jetpack: true,
 							options: {
-								jetpack_version: '4.6.0'
+								jetpack_version: '4.7.0'
 							}
 						}
 					}


### PR DESCRIPTION
This PR bumps the minimum Jetpack version to support Jetpack Settings in Calypso to 4.6. Reason: https://github.com/Automattic/jetpack/pull/6002 will be included in 4.6, not in 4.5.

To test:
* Checkout this branch
* Verify all tests still pass:

```
npm run test-client client/state/sites/test/selectors.js -- --grep="siteSupportsJetpackSettingsUi"
```