### PR TITLE
Site Settings: Reduxify the analytics settings form

### DIFF
--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -79,11 +79,7 @@ class GoogleAnalyticsForm extends Component {
 			jetpack = false,
 		} = site;
 
-		let placeholderText = '';
-		if ( isRequestingSettings ) {
-			placeholderText = translate( 'Loading' );
-		}
-
+		const placeholderText = isRequestingSettings ? translate( 'Loading' ) : '';
 		const isJetpackUnsupported = jetpack && ! jetpackVersionSupportsModule && isEnabled( 'jetpack/google-analytics' );
 
 		return (

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -1,17 +1,14 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import notices from 'notices';
-import debugFactory from 'debug';
-import { overSome } from 'lodash';
+import { flowRight, partialRight, pick, overSome } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import formBase from './form-base';
-import { protectForm } from 'lib/protect-form';
+import wrapSettingsForm from './wrap-settings-form';
 import Card from 'components/card';
 import Button from 'components/button';
 import SectionHeader from 'components/section-header';
@@ -24,99 +21,56 @@ import {
 	isEnterprise,
 	isJetpackBusiness
 } from 'lib/products-values';
+import { removeNotice, errorNotice } from 'state/notices/actions';
 import { isJetpackModuleActive, isJetpackMinimumVersion } from 'state/sites/selectors';
 import { isEnabled } from 'config';
 import { FEATURE_GOOGLE_ANALYTICS } from 'lib/plans/constants';
 
-const debug = debugFactory( 'calypso:my-sites:site-settings' );
 const validateGoogleAnalyticsCode = code => ! code || code.match( /^UA-\d+-\d+$/i );
 const hasBusinessPlan = overSome( isBusiness, isEnterprise, isJetpackBusiness );
 
-const GoogleAnalyticsForm = React.createClass( {
+class GoogleAnalyticsForm extends Component {
+	state = {
+		isCodeValid: true
+	};
 
-	displayName: 'SiteSettingsFormAnalytics',
-
-	mixins: [ formBase ],
-
-	getInitialState() {
-		return {
-			isCodeValid: true
-		};
-	},
-
-	resetState() {
-		this.replaceState( {
-			wga: {
-				code: null
-			},
-			fetchingSettings: true
-		} );
-		debug( 'resetting state' );
-	},
-
-	getSettingsFromSite( siteInstance ) {
-		const site = siteInstance || this.props.site;
-		const settings = {
-			wga: {
-				code: ''
-			},
-			fetchingSettings: site.fetchingSettings
-		};
-
-		if ( site.settings ) {
-			debug( 'site settings fetched' );
-			settings.wga = site.settings.wga;
-		}
-
-		return settings;
-	},
-
-	handleCodeChange( event ) {
+	handleCodeChange = ( event ) => {
 		const code = event.target.value;
 		const isCodeValid = validateGoogleAnalyticsCode( code );
-		let notice = this.state.notice;
-
-		if ( ! isCodeValid && ! notice ) {
-			notice = notices.error( this.translate( 'Invalid Google Analytics Tracking ID.' ) );
-		} else if ( isCodeValid && notice ) {
-			notices.removeNotice( notice );
-			notice = null;
+		if ( ! isCodeValid ) {
+			this.props.errorNotice(
+				this.props.translate( 'Invalid Google Analytics Tracking ID.' ),
+				{ id: 'google-analytics-validation' }
+			);
+		} else if ( isCodeValid ) {
+			this.props.removeNotice( 'google-analytics-validation' );
 		}
-
 		this.setState( {
-			wga: {
-				code: event.target.value
-			},
-			isCodeValid: isCodeValid,
-			notice: notice
+			isCodeValid
 		} );
-	},
+		this.props.updateFields( { wga: { code } } );
+	};
 
 	isSubmitButtonDisabled() {
-		return this.state.fetchingSettings || this.state.submittingForm || ! this.state.isCodeValid || ! this.props.enableForm;
-	},
-
-	onClickAnalyticsInput() {
-		this.recordEvent( 'Clicked Analytics Key Field' );
-	},
-
-	onKeyPressAnalyticsInput() {
-		this.recordEventOnce( 'typedAnalyticsKey', 'Typed In Analytics Key Field' );
-	},
+		const { isRequestingSettings, isSavingSettings } = this.props;
+		return isRequestingSettings || isSavingSettings || ! this.state.isCodeValid || ! this.props.enableForm;
+	}
 
 	form() {
-		var placeholderText = '';
-
-		if ( this.state.fetchingSettings ) {
-			placeholderText = this.translate( 'Loading' );
-		}
-
 		const {
-			site,
 			enableForm,
-			showUpgradeNudge,
+			eventTracker,
+			fields,
+			handleSubmitForm,
+			isRequestingSettings,
+			isSavingSettings,
 			jetpackModuleActive,
 			jetpackVersionSupportsModule,
+			markChanged,
+			showUpgradeNudge,
+			site,
+			translate,
+			uniqueEventTracker,
 		} = this.props;
 
 		const {
@@ -125,17 +79,22 @@ const GoogleAnalyticsForm = React.createClass( {
 			jetpack = false,
 		} = site;
 
+		let placeholderText = '';
+		if ( isRequestingSettings ) {
+			placeholderText = translate( 'Loading' );
+		}
+
 		const isJetpackUnsupported = jetpack && ! jetpackVersionSupportsModule && isEnabled( 'jetpack/google-analytics' );
 
 		return (
-			<form id="site-settings" onSubmit={ this.handleSubmitForm } onChange={ this.props.markChanged }>
+			<form id="site-settings" onSubmit={ handleSubmitForm } onChange={ markChanged }>
 
 				{ showUpgradeNudge &&
 					<UpgradeNudge
-						title={ this.translate( 'Add Google Analytics' ) }
+						title={ translate( 'Add Google Analytics' ) }
 						message={ jetpack
-							? this.translate( 'Upgrade to the Professional Plan and include your own analytics tracking ID.' )
-							: this.translate( 'Upgrade to the Business Plan and include your own analytics tracking ID.' )
+							? translate( 'Upgrade to the Professional Plan and include your own analytics tracking ID.' )
+							: translate( 'Upgrade to the Business Plan and include your own analytics tracking ID.' )
 						}
 						feature={ FEATURE_GOOGLE_ANALYTICS }
 						event="google_analytics_settings"
@@ -148,9 +107,9 @@ const GoogleAnalyticsForm = React.createClass( {
 					<Notice
 						status="is-warning"
 						showDismiss={ false }
-						text={ this.translate( 'Google Analytics require a newer version of Jetpack.' ) } >
+						text={ translate( 'Google Analytics require a newer version of Jetpack.' ) } >
 						<NoticeAction href={ `/plugins/jetpack/${ slug }` }>
-							{ this.translate( 'Update Now' ) }
+							{ translate( 'Update Now' ) }
 						</NoticeAction>
 					</Notice>
 				}
@@ -159,63 +118,64 @@ const GoogleAnalyticsForm = React.createClass( {
 					<Notice
 						status="is-warning"
 						showDismiss={ false }
-						text={ this.translate( 'The Google Analytics module is disabled in Jetpack.' ) } >
+						text={ translate( 'The Google Analytics module is disabled in Jetpack.' ) } >
 						<NoticeAction href={ '//' + domain + '/wp-admin/admin.php?page=jetpack#/engagement' }>
-							{ this.translate( 'Enable' ) }
+							{ translate( 'Enable' ) }
 						</NoticeAction>
 					</Notice>
 				}
 
-				<SectionHeader label={ this.translate( 'Analytics Settings' ) }>
+				<SectionHeader label={ translate( 'Analytics Settings' ) }>
 					<Button
 						primary
 						compact
 						disabled={ this.isSubmitButtonDisabled() }
-						onClick={ this.handleSubmitForm }
-						>{
-							this.state.submittingForm
-									? this.translate( 'Saving…' )
-									: this.translate( 'Save Settings' )
+						onClick={ handleSubmitForm }
+					>
+						{
+							isSavingSettings
+									? translate( 'Saving…' )
+									: translate( 'Save Settings' )
 						}
 					</Button>
 				</SectionHeader>
 				<Card className="analytics-settings">
 					<fieldset>
-						<label htmlFor="wgaCode">{ this.translate( 'Google Analytics Tracking ID', { context: 'site setting' } ) }</label>
+						<label htmlFor="wgaCode">{ translate( 'Google Analytics Tracking ID', { context: 'site setting' } ) }</label>
 						<input
 							name="wgaCode"
 							id="wgaCode"
 							type="text"
-							value={ this.state.wga.code }
+							value={ fields.wga ? fields.wga.code : '' }
 							onChange={ this.handleCodeChange }
 							placeholder={ placeholderText }
-							disabled={ this.state.fetchingSettings || ! enableForm }
-							onClick={ this.onClickAnalyticsInput }
-							onKeyPress={ this.onKeyPressAnalyticsInput }
+							disabled={ isRequestingSettings || ! enableForm }
+							onClick={ eventTracker( 'Clicked Analytics Key Field' ) }
+							onKeyPress={ uniqueEventTracker( 'Typed In Analytics Key Field' ) }
 						/>
 						<ExternalLink
-							icon={ true }
+							icon
 							href="https://support.google.com/analytics/answer/1032385?hl=en"
 							target="_blank"
 							rel="noopener noreferrer"
 						>
-							{ this.translate( 'Where can I find my Tracking ID?' ) }
+							{ translate( 'Where can I find my Tracking ID?' ) }
 						</ExternalLink>
 					</fieldset>
 					<p>
-						{ this.translate(
+						{ translate(
 							'Google Analytics is a free service that complements our {{a}}built-in stats{{/a}} with different insights into your traffic.' +
 							' WordPress.com stats and Google Analytics use different methods to identify and track activity on your site, so they will ' +
 							'normally show slightly different totals for your visits, views, etc.',
 							{
 								components: {
-									a: <a href={ '/stats/' + this.props.site.domain } />
+									a: <a href={ '/stats/' + domain } />
 								}
 							}
 						) }
 					</p>
 					<p>
-					{ this.translate( 'Learn more about using {{a}}Google Analytics with WordPress.com{{/a}}.',
+					{ translate( 'Learn more about using {{a}}Google Analytics with WordPress.com{{/a}}.',
 						{
 							components: {
 								a: <a href="http://en.support.wordpress.com/google-analytics/" target="_blank" rel="noopener noreferrer" />
@@ -226,7 +186,7 @@ const GoogleAnalyticsForm = React.createClass( {
 				</Card>
 			</form>
 		);
-	},
+	}
 
 	render() {
 		// we need to check that site has loaded first... a placeholder would be better,
@@ -237,7 +197,7 @@ const GoogleAnalyticsForm = React.createClass( {
 		// Only show Google Analytics for business users.
 		return this.form();
 	}
-} );
+}
 
 const mapStateToProps = ( state, ownProps ) => {
 	const { site } = ownProps;
@@ -259,9 +219,16 @@ const mapStateToProps = ( state, ownProps ) => {
 	};
 };
 
-export default connect(
+const connectComponent = connect(
 	mapStateToProps,
-	null,
+	{ errorNotice, removeNotice },
 	null,
 	{ pure: false }
-)( protectForm( GoogleAnalyticsForm ) );
+);
+
+const getFormSettings = partialRight( pick, [ 'wga' ] );
+
+export default flowRight(
+	connectComponent,
+	wrapSettingsForm( getFormSettings ),
+)( GoogleAnalyticsForm );


### PR DESCRIPTION
One more site settings form reduxified using the `wrapSettingsForm` HoC instead of `formBase`

**Testing instructions**

 - Navigate to the analytics settings page: `/settings/analytics/$site` on a site with a premium plan
 - Try to update the Google Analytics ID
 - The form should behave properly
 - The settings should persist
 - A notice should appear if we type in an invalid Google ID
 - We can try on a Jetpack site as well