### PR TITLE
Checkout: Fix undefined JS errors on Thank You page

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -280,7 +280,7 @@ const CheckoutThankYou = React.createClass( {
 			failedPurchases = getFailedPurchases( this.props ),
 			hasFailedPurchases = failedPurchases.length > 0,
 			[ ComponentClass, primaryPurchase, domain ] = this.getComponentAndPrimaryPurchaseAndDomain(),
-			registrarSupportUrl = ( this.isGenericReceipt() || hasFailedPurchases ) ? null : primaryPurchase.registrarSupportUrl;
+			registrarSupportUrl = ( ! ComponentClass || this.isGenericReceipt() || hasFailedPurchases ) ? null : primaryPurchase.registrarSupportUrl;
 
 		if ( ! this.isDataLoaded() ) {
 			return (

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -43,6 +43,9 @@ import {
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'state/ui/selectors';
+import {
+	getSiteOption
+} from 'state/sites/selectors';
 import { domainManagementList } from 'my-sites/upgrades/paths';
 
 const Checkout = React.createClass( {
@@ -182,6 +185,7 @@ const Checkout = React.createClass( {
 
 		const {
 			cart,
+			isDomainOnly,
 			selectedSite,
 			selectedSiteId,
 			selectedSiteSlug
@@ -238,8 +242,7 @@ const Checkout = React.createClass( {
 			return selectedSiteSlug
 				? `/plans/${ selectedSiteSlug }/thank-you`
 				: '/checkout/thank-you/plans';
-		} else if ( selectedSite.options && selectedSite.options.is_domain_only &&
-			cartItems.hasDomainRegistration( cart ) && ! cartItems.hasPlan( cart ) ) {
+		} else if ( isDomainOnly && cartItems.hasDomainRegistration( cart ) && ! cartItems.hasPlan( cart ) ) {
 			// TODO: Use purchased domain name once it is possible to set it as a primary domain when site is created.
 			return domainManagementList( selectedSite.slug );
 		}
@@ -323,12 +326,17 @@ const Checkout = React.createClass( {
 } );
 
 module.exports = connect(
-	state => ( {
-		cards: getStoredCards( state ),
-		selectedSite: getSelectedSite( state ),
-		selectedSiteId: getSelectedSiteId( state ),
-		selectedSiteSlug: getSelectedSiteSlug( state ),
-	} ),
+	state => {
+		const selectedSiteId = getSelectedSiteId( state );
+
+		return {
+			cards: getStoredCards( state ),
+			isDomainOnly: getSiteOption( state, selectedSiteId, 'is_domain_only' ),
+			selectedSite: getSelectedSite( state ),
+			selectedSiteId,
+			selectedSiteSlug: getSelectedSiteSlug( state ),
+		};
+	},
 	{
 		clearPurchases,
 		clearSitePlans,

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -238,7 +238,8 @@ const Checkout = React.createClass( {
 			return selectedSiteSlug
 				? `/plans/${ selectedSiteSlug }/thank-you`
 				: '/checkout/thank-you/plans';
-		} else if ( selectedSite.options.is_domain_only && cartItems.hasDomainRegistration( cart ) && ! cartItems.hasPlan( cart ) ) {
+		} else if ( selectedSite.options && selectedSite.options.is_domain_only &&
+			cartItems.hasDomainRegistration( cart ) && ! cartItems.hasPlan( cart ) ) {
 			// TODO: Use purchased domain name once it is possible to set it as a primary domain when site is created.
 			return domainManagementList( selectedSite.slug );
 		}


### PR DESCRIPTION
When buying a theme from the theme showcase
we would have JS errors and the page was stuck on
purchasing.

Test:
1. Starting at URL: wordpress.com/design/
2. Use the Search field to search for 'Automattic' and the dropdown to filter for 'Premium' themes
3. Choose any theme, click its '...' button and 'Purchase' the theme (using free credits)

Expected:
- Store to redirect back to the theme showcase which is then supposed to show a 'Thank You' modal
- No errors in console