### PR TITLE
Reader Fix: remove from parent node for crossbrowser compat

### DIFF
--- a/client/lib/post-normalizer/rule-content-make-images-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-images-safe.js
@@ -70,7 +70,7 @@ function makeImageSafe( post, image, maxWidth ) {
 	// trickery to remove it from the dom / not load the image
 	// TODO: test if this is necessary
 	if ( ! safeSource || imageShouldBeRemovedFromContent( imgSource ) ) {
-		image.remove();
+		image.parentNode.removeChild( image );
 		// fun fact: removing the node from the DOM will not prevent it from loading. You actually have to
 		// change out the src to change what loads. The following is a 1x1 transparent gif as a data URL
 		image.setAttribute( 'src', TRANSPARENT_GIF );


### PR DESCRIPTION
fixes an issue @aduth found [here](https://github.com/Automattic/wp-calypso/pull/9283#discussion_r97586394).

The post normalizer rule `make-content-images-safe` uses a dom function `element.remove()` that  doesn't work for all browsers.

This PR aims to resolve that issue by utilizing `removeChild` instead.

To Test:
- [ ] ~~find a post with an image that should be removed and make sure it doesn't error (im looking for one now)~~ set shouldRemove field to true and verify images get removed