### PR TITLE
Jetpack: Invites: Remove unnecessary flags after launching features

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -482,10 +482,6 @@ class SiteSettingsFormGeneral extends Component {
 	}
 
 	renderJetpackSyncPanel() {
-		if ( ! config.isEnabled( 'jetpack/sync-panel' ) ) {
-			return null;
-		}
-
 		const { site } = this.props;
 		if ( ! site.jetpack || site.versionCompare( '4.2-alpha', '<' ) ) {
 			return null;

--- a/client/signup/index.web.js
+++ b/client/signup/index.web.js
@@ -85,8 +85,6 @@ module.exports = function() {
 		);
 	}
 
-	if ( config.isEnabled( 'jetpack/sso' ) ) {
-		page( '/jetpack/sso/:siteId?/:ssoNonce?', jetpackConnectController.sso );
-		page( '/jetpack/sso/*', jetpackConnectController.sso );
-	}
+	page( '/jetpack/sso/:siteId?/:ssoNonce?', jetpackConnectController.sso );
+	page( '/jetpack/sso/*', jetpackConnectController.sso );
 };

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -177,6 +177,12 @@ sections = [
 		module: 'my-sites/plans',
 		secondary: true,
 		group: 'sites'
+	},
+	{
+		name: 'accept-invite',
+		paths: [ '/accept-invite' ],
+		module: 'my-sites/invites',
+		enableLoggedOut: true
 	}
 ];
 
@@ -332,15 +338,6 @@ if ( config.isEnabled( 'help' ) ) {
 		module: 'me/help',
 		secondary: true,
 		group: 'me'
-	} );
-}
-
-if ( config.isEnabled( 'accept-invite' ) ) {
-	sections.push( {
-		name: 'accept-invite',
-		paths: [ '/accept-invite' ],
-		module: 'my-sites/invites',
-		enableLoggedOut: true
 	} );
 }
 

--- a/config/development.json
+++ b/config/development.json
@@ -54,7 +54,6 @@
 		"jetpack/invites": true,
 		"jetpack/personalPlan": true,
 		"jetpack/seo-tools": true,
-		"jetpack/sso": true,
 		"jetpack_core_inline_update": true,
 		"jetpack/google-analytics": true,
 		"jetpack/api-cache": true,

--- a/config/development.json
+++ b/config/development.json
@@ -28,7 +28,6 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",
 	"features": {
-		"accept-invite": true,
 		"account-recovery": true,
 		"ad-tracking": false,
 		"automated-transfer": true,

--- a/config/development.json
+++ b/config/development.json
@@ -57,7 +57,6 @@
 		"jetpack/sso": true,
 		"jetpack_core_inline_update": true,
 		"jetpack/google-analytics": true,
-		"jetpack/sync-panel": true,
 		"jetpack/api-cache": true,
 		"keyboard-shortcuts": true,
 		"happychat": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -13,7 +13,6 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"features": {
-		"accept-invite": true,
 		"ad-tracking": false,
 		"apple-pay": false,
 		"catch-js-errors": true,

--- a/config/production.json
+++ b/config/production.json
@@ -25,7 +25,6 @@
 		"jetpack/connect": true,
 		"jetpack/personalPlan": true,
 		"jetpack/seo-tools": true,
-		"jetpack/sso": true,
 		"jetpack/api-cache": false,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,

--- a/config/production.json
+++ b/config/production.json
@@ -11,7 +11,6 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"features": {
-		"accept-invite": true,
 		"ad-tracking": true,
 		"apple-pay": true,
 		"catch-js-errors": true,

--- a/config/production.json
+++ b/config/production.json
@@ -26,7 +26,6 @@
 		"jetpack/personalPlan": true,
 		"jetpack/seo-tools": true,
 		"jetpack/sso": true,
-		"jetpack/sync-panel": true,
 		"jetpack/api-cache": false,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -14,7 +14,6 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",
 	"features": {
-		"accept-invite": true,
 		"ad-tracking": false,
 		"apple-pay": true,
 		"catch-js-errors": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -28,7 +28,6 @@
 		"jetpack/connect": true,
 		"jetpack/personalPlan": true,
 		"jetpack/seo-tools": true,
-		"jetpack/sso": true,
 		"jetpack/api-cache": false,
 		"jetpack_core_inline_update": true,
 		"mailing-lists/unsubscribe": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -29,7 +29,6 @@
 		"jetpack/personalPlan": true,
 		"jetpack/seo-tools": true,
 		"jetpack/sso": true,
-		"jetpack/sync-panel": true,
 		"jetpack/api-cache": false,
 		"jetpack_core_inline_update": true,
 		"mailing-lists/unsubscribe": true,

--- a/config/test.json
+++ b/config/test.json
@@ -27,7 +27,6 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"features": {
-		"accept-invite": true,
 		"ad-tracking": false,
 		"apple-pay": true,
 		"catch-js-errors": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -37,7 +37,6 @@
 		"jetpack/personalPlan": true,
 		"jetpack/seo-tools": true,
 		"jetpack/sso": true,
-		"jetpack/sync-panel": true,
 		"jetpack/api-cache": true,
 		"jetpack_core_inline_update": true,
 		"jetpack/google-analytics": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -36,7 +36,6 @@
 		"jetpack/connect": true,
 		"jetpack/personalPlan": true,
 		"jetpack/seo-tools": true,
-		"jetpack/sso": true,
 		"jetpack/api-cache": true,
 		"jetpack_core_inline_update": true,
 		"jetpack/google-analytics": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -13,7 +13,6 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"features": {
-		"accept-invite": true,
 		"ad-tracking": false,
 		"automated-transfer": true,
 		"apple-pay": true,


### PR DESCRIPTION
In a review by @alisterscott, the following were pointed out as unnecessary flags. This PR removes them.

To test:

- Run through the Jetpack SSO flow and make sure it works in `wpcalypso` environment
- Run through the invite flow and make sure it works in `wpcalypso` environment
- Go to `/settings/general/$site` where `$site` is a Jetpack site, and ensure you can run a full sync