### PR TITLE
Signup: Restore `flowName` being sent to the API when creating a new user

### DIFF
--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -88,6 +88,7 @@ export class UserStep extends Component {
 
 		SignupActions.submitSignupStep( {
 			processingMessage: this.props.translate( 'Creating your account' ),
+			flowName: this.props.flowName,
 			userData,
 			stepName: this.props.stepName,
 			form: formWithoutPassword,


### PR DESCRIPTION
This PR fixes a mishap #10588 where I mistakenly removed the `flowName` being sent to the user creation API endpoint.

To test:

1. Start Signup
2. Go through Signup
3. Complete Signup, but don't click Continue
4. Verify `signup_flow_name` is being sent to the user creation API endpoint with the current flow name. 