### PR TITLE
Jetpack Settings: Map Jetpack module options from the modules state branch into the settings state branch on fetch

### DIFF
--- a/client/state/jetpack/modules/actions.js
+++ b/client/state/jetpack/modules/actions.js
@@ -101,7 +101,7 @@ export const fetchModuleList = ( siteId ) => {
 					data,
 					( module ) => ( {
 						active: module.activated,
-						...omit( module, 'activated', 'options' )
+						...omit( module, 'activated' )
 					} )
 				);
 

--- a/client/state/jetpack/modules/test/actions.js
+++ b/client/state/jetpack/modules/test/actions.js
@@ -205,7 +205,7 @@ describe( 'actions', () => {
 							API_MODULE_LIST_RESPONSE_FIXTURE.data,
 							( module ) => ( {
 								active: module.activated,
-								...omit( module, 'activated', 'options' )
+								...omit( module, 'activated' )
 							} )
 						)
 					} );

--- a/client/state/jetpack/settings/reducer.js
+++ b/client/state/jetpack/settings/reducer.js
@@ -66,11 +66,17 @@ export const items = createReducer( {}, {
 	[ JETPACK_MODULE_DEACTIVATE_SUCCESS ]: createActivationItemsReducer( false ),
 	[ JETPACK_MODULES_RECEIVE ]: ( state, { siteId, modules } ) => {
 		const modulesActivationState = mapValues( modules, module => module.active );
-
+		// The need for flattening module options into this moduleSettings is temporary.
+		// Once https://github.com/Automattic/jetpack/pull/6002 is released,
+		// the flattening will be done on the server side for the /jetpack/v4/settings/ endpoint
+		const moduleSettings = Object.keys( modules ).reduce( ( allTheSettings, slug ) => {
+			return { ...allTheSettings, ...mapValues( modules[ slug ].options, option => option.current_value ) };
+		}, {} );
 		return Object.assign( {}, state, {
 			[ siteId ]: {
 				...state[ siteId ],
-				...modulesActivationState
+				...modulesActivationState,
+				...moduleSettings
 			}
 		} );
 	},


### PR DESCRIPTION
Part of #9171 

This PR attempts to solve the temporary lack of a readable settings endpoint on Jetpack sites. 

The endpoint should reply with a flat object of settings without a hierarchy of modules -> settings (as the modules endpoint presents them). 

Currently the request to the settings endpoint just provides us with a single key `jetpack_holiday_snow_enabled`.

The changes here can be reverted once Automattic/jetpack/pull/6002 is released.

### Why

This endpoint, with the necessary refactor, although present in Jetpack's master branch, didn't make into the Jetpack 4.5 release.

### Testing 

1. Use the `<QueryJetpackModules />` query component on any settings-related section.
1. Visit the section having selected a Jetpack site as current site.
2. Check the Redux Dev tools, on the State view, look in `jetpack.settings.items[ siteId ]`  and expect to see a bunch of keys corresponding to Jetpack module options:

![image](https://cloud.githubusercontent.com/assets/746152/22260253/4e38b66a-e247-11e6-8e27-377a75a0f241.png)
