### PR TITLE
State: Bump the console dispatcher to the front

### DIFF
--- a/client/state/index.js
+++ b/client/state/index.js
@@ -111,31 +111,22 @@ export const reducer = combineReducers( {
 	wordads,
 } );
 
-const middleware = [ thunkMiddleware, noticesMiddleware ];
-
-if ( typeof window === 'object' ) {
-	// Browser-specific middlewares
-	middleware.push(
-		require( './analytics/middleware.js' ).analyticsMiddleware,
-		require( './data-layer/wpcom-api-middleware.js' ).default,
-	);
-}
-
 export function createReduxStore( initialState = {} ) {
-	const enhancers = [ applyMiddleware( ...middleware ) ];
+	const isBrowser = typeof window === 'object';
 
-	if ( 'object' === typeof window ) {
-		enhancers.push( sitesSync );
+	const middlewares = [
+		thunkMiddleware,
+		noticesMiddleware,
+		isBrowser && require( './analytics/middleware.js' ).analyticsMiddleware,
+		isBrowser && require( './data-layer/wpcom-api-middleware.js' ).default,
+	].filter( Boolean );
 
-		if ( window.app && window.app.isDebug ) {
-			// this has to be the first enhancer in the chain for the other enhancers to see it
-			enhancers.unshift( consoleDispatcher );
-		}
-
-		if ( window.devToolsExtension ) {
-			enhancers.push( window.devToolsExtension() );
-		}
-	}
+	const enhancers = [
+		isBrowser && window.app && window.app.isDebug && consoleDispatcher,
+		applyMiddleware( ...middlewares ),
+		isBrowser && sitesSync,
+		isBrowser && window.devToolsExtension && window.devToolsExtension()
+	].filter( Boolean );
 
 	return compose( ...enhancers )( createStore )( reducer, initialState );
 }

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -128,7 +128,8 @@ export function createReduxStore( initialState = {} ) {
 		enhancers.push( sitesSync );
 
 		if ( window.app && window.app.isDebug ) {
-			enhancers.push( consoleDispatcher );
+			// this has to be the first enhancer in the chain for the other enhancers to see it
+			enhancers.unshift( consoleDispatcher );
 		}
 
 		if ( window.devToolsExtension ) {


### PR DESCRIPTION
This bumps the console dispatcher to the front of the store dispatcher queue. This allows dispatches from the console dispatcher to be seen by the other store enhancers, like the data middleware.

To test, try dispatching a redux action from the console and catch it in the data middleware. 

Rest of the application should still work as normal.