### PR TITLE
Domains: Signup: Fix broken 'map here' link

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -3,7 +3,6 @@
  */
 const React = require( 'react' ),
 	classNames = require( 'classnames' ),
-	page = require( 'page' ),
 	times = require( 'lodash/times' );
 
 import Notice from 'components/notice';
@@ -14,8 +13,6 @@ import Notice from 'components/notice';
 const DomainRegistrationSuggestion = require( 'components/domains/domain-registration-suggestion' ),
 	DomainMappingSuggestion = require( 'components/domains/domain-mapping-suggestion' ),
 	DomainSuggestion = require( 'components/domains/domain-suggestion' ),
-	cartItems = require( 'lib/cart-values' ).cartItems,
-	upgradesActions = require( 'lib/upgrades/actions' ),
 	{ isNextDomainFree } = require( 'lib/cart-values/cart-items' );
 
 var DomainSearchResults = React.createClass( {
@@ -73,7 +70,7 @@ var DomainSearchResults = React.createClass( {
 					onButtonClick={ this.props.onClickResult.bind( null, availableDomain ) } />
 				);
 		} else if ( suggestions.length !== 0 && this.isDomainMappable() && this.props.products.domain_map ) {
-			const components = { a: <a href="#" onClick={ this.addMappingAndRedirect } />, small: <small /> };
+			const components = { a: <a href="#" onClick={ this.handleAddMapping } />, small: <small /> };
 
 			if ( this.props.domainsWithPlansOnly ) {
 				mappingOffer = this.translate( '{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}}' +
@@ -110,20 +107,9 @@ var DomainSearchResults = React.createClass( {
 		);
 	},
 
-	addMappingAndRedirect: function( event ) {
+	handleAddMapping: function( event ) {
 		event.preventDefault();
-
-		if ( this.props.onAddMapping ) {
-			return this.props.onAddMapping( this.props.lastDomainSearched );
-		}
-
-		upgradesActions.addItem( cartItems.domainMapping( { domain: this.props.lastDomainSearched } ) );
-
-		page( '/checkout/' + this.props.selectedSite.slug );
-	},
-
-	onClickResult: function( suggestion ) {
-		this.props.onClickResult( suggestion );
+		this.props.onAddMapping( { domain_name: this.props.lastDomainSearched } );
 	},
 
 	placeholders: function() {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -407,7 +407,7 @@ const RegisterDomainStep = React.createClass( {
 						cart={ this.props.cart }
 						selectedSite={ this.props.selectedSite }
 						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-						onButtonClick={ this.addRemoveDomainToCart.bind( null, suggestion ) } />
+						onButtonClick={ this.props.onAddDomain.bind( null, suggestion ) } />
 				);
 			}, this );
 
@@ -432,9 +432,7 @@ const RegisterDomainStep = React.createClass( {
 
 	allSearchResults: function() {
 		const lastDomainSearched = this.state.lastDomainSearched,
-			matchesSearchedDomain = function( suggestion ) {
-				return suggestion.domain_name === lastDomainSearched;
-			},
+			matchesSearchedDomain = ( suggestion ) => ( suggestion.domain_name === lastDomainSearched ),
 			availableDomain = this.state.lastDomainError ? undefined : find( this.state.searchResults, matchesSearchedDomain ),
 			onAddMapping = ( domain ) => this.props.onAddMapping( domain, this.state );
 
@@ -464,7 +462,7 @@ const RegisterDomainStep = React.createClass( {
 				lastDomainSearched={ lastDomainSearched }
 				lastDomainError = { this.state.lastDomainError }
 				onAddMapping={ onAddMapping }
-				onClickResult={ this.addRemoveDomainToCart }
+				onClickResult={ this.props.onAddDomain }
 				onClickMapping={ this.goToMapDomainStep }
 				suggestions={ suggestions }
 				products={ this.props.products }
@@ -497,11 +495,6 @@ const RegisterDomainStep = React.createClass( {
 		this.recordEvent( 'mapDomainButtonClick', this.props.analyticsSection );
 
 		page( this.getMapDomainUrl() );
-	},
-
-	addRemoveDomainToCart: function( suggestion, event ) {
-		event.preventDefault();
-		return this.props.onAddDomain( suggestion );
 	},
 
 	showValidationErrorMessage: function( domain, error ) {

--- a/client/my-sites/upgrades/domain-search/domain-search.jsx
+++ b/client/my-sites/upgrades/domain-search/domain-search.jsx
@@ -83,6 +83,11 @@ var DomainSearch = React.createClass( {
 		}
 	},
 
+	handleAddMapping( suggestion ) {
+		upgradesActions.addItem( cartItems.domainMapping( { domain: suggestion.domain_name } ) );
+		page( '/checkout/' + this.props.sites.getSelectedSite().slug );
+	},
+
 	addDomain( suggestion ) {
 		this.recordEvent( 'addDomainButtonClick', suggestion.domain_name, 'domains' );
 		const items = [
@@ -138,6 +143,7 @@ var DomainSearch = React.createClass( {
 							domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 							onDomainsAvailabilityChange={ this.handleDomainsAvailabilityChange }
 							onAddDomain={ this.handleAddRemoveDomain }
+							onAddMapping={ this.handleAddMapping }
 							cart={ this.props.cart }
 							selectedSite={ selectedSite }
 							offerMappingOption

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -146,10 +146,10 @@ const DomainsStep = React.createClass( {
 	},
 
 	handleAddMapping: function( sectionName, domain, state ) {
-		const domainItem = cartItems.domainMapping( { domain } );
+		const domainItem = cartItems.domainMapping( { domain: domain.domain_name } );
 		const isPurchasingItem = true;
 
-		mapDomainAnalytics.recordEvent( 'addDomainButtonClick', domain, 'signup' );
+		mapDomainAnalytics.recordEvent( 'addDomainButtonClick', domain.domain_name, 'signup' );
 
 		SignupActions.submitSignupStep( Object.assign( {
 			processingMessage: this.translate( 'Adding your domain mapping' ),
@@ -157,7 +157,7 @@ const DomainsStep = React.createClass( {
 			[ sectionName ]: state,
 			domainItem,
 			isPurchasingItem,
-			siteUrl: domain,
+			siteUrl: domain.domain_name,
 			stepSectionName: this.props.stepSectionName
 		}, this.getThemeArgs() ) );
 


### PR DESCRIPTION
This PR fixes an [issue](https://github.com/Automattic/wp-calypso/pull/10475#issuecomment-274917805) introduced in #10475. 

The behaviour of the edited components is super weird, `domain-search-results` would behave completely differently when there's a prop `onAddMapping`. In #10475, I made some changes in `register-domain-step` to default that prop to `lodash.noop` to get rid of `if` checks. But since `register-domain-step` passes that prop to `domain-search-results` and `domain-search-results` behaves differently if that prop exists (calls the function in the prop and returns), clicking the "map here" link in the search notice became noop.

I fixed this by making sure `domain-search-results` doesn't behave differently depending on the existence of a prop and passing this logic to the parent. 

Now `domain-search` handles this logic for domain search and `domains` handles this for signup. I also changed their signatures so they would match each other.

#### Testing
##### Existing user
- Go to domain search, search for a registered domain
- Click "map here" link in the notice
- Ensure the domain mapping is added to cart
- Go back, add a domain registration to cart
- Ensure both are added to cart

##### New user
- Search for a registered domain
- Click "map here" link in the notice
- Continue signup
- Ensure domain mapping ends up in your cart


