### PR TITLE
Framework: Replace click-outside by react-click-outside

### DIFF
--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -5,7 +5,7 @@ import React, { PropTypes, Component } from 'react';
 import ReactDom from 'react-dom';
 import debugFactory from 'debug';
 import classNames from 'classnames';
-import clickOutside from 'click-outside';
+import wrapWithClickOutside from 'react-click-outside';
 import uid from 'component-uid';
 
 /**
@@ -63,7 +63,6 @@ class Popover extends Component {
 		// bound methods
 		this.setDOMBehavior = this.setDOMBehavior.bind( this );
 		this.setPosition = this.setPosition.bind( this );
-		this.onClickout = this.onClickout.bind( this );
 		this.onKeydown = this.onKeydown.bind( this );
 		this.onWindowChange = this.onWindowChange.bind( this );
 
@@ -121,7 +120,6 @@ class Popover extends Component {
 
 	componentWillUnmount() {
 		this.debug( 'unmounting .... ' );
-		this.unbindClickoutHandler();
 		this.unbindDebouncedReposition();
 		this.unbindEscKeyListener();
 		unbindWindowListeners();
@@ -166,31 +164,7 @@ class Popover extends Component {
 		this.close( true );
 	}
 
-	// --- cliclout side ---
-	bindClickoutHandler( el = this.domContainer ) {
-		if ( ! el ) {
-			this.debug( 'no element to bind clickout side ' );
-			return null;
-		}
-
-		if ( this._clickoutHandlerReference ) {
-			this.debug( 'clickout event already bound' );
-			return null;
-		}
-
-		this.debug( 'binding `clickout` event' );
-		this._clickoutHandlerReference = clickOutside( el, this.onClickout );
-	}
-
-	unbindClickoutHandler() {
-		if ( this._clickoutHandlerReference ) {
-			this.debug( 'unbinding `clickout` listener ...' );
-			this._clickoutHandlerReference();
-			this._clickoutHandlerReference = null;
-		}
-	}
-
-	onClickout( event ) {
+	handleClickOutside( event ) {
 		let shouldClose = (
 			this.domContext &&
 			this.domContext.contains &&
@@ -234,13 +208,10 @@ class Popover extends Component {
 
 	setDOMBehavior( domContainer ) {
 		if ( ! domContainer ) {
-			this.unbindClickoutHandler();
 			return null;
 		}
 
 		this.debug( 'setting DOM behavior' );
-
-		this.bindClickoutHandler( domContainer );
 
 		// store DOM element referencies
 		this.domContainer = domContainer;
@@ -343,8 +314,6 @@ class Popover extends Component {
 	}
 
 	hide() {
-		// unbind clickout-side event every time the component is hidden.
-		this.unbindClickoutHandler();
 		this.setState( { show: false } );
 		this.clearShowTimer();
 	}
@@ -404,4 +373,4 @@ class Popover extends Component {
 	}
 }
 
-export default Popover;
+export default wrapWithClickOutside( Popover );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -29,11 +29,11 @@
       "version": "0.8.2"
     },
     "ajv": {
-      "version": "4.10.4",
+      "version": "4.11.2",
       "dev": true
     },
     "ajv-keywords": {
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dev": true
     },
     "align-text": {
@@ -623,9 +623,6 @@
       "version": "2.1.0",
       "dev": true
     },
-    "click-outside": {
-      "version": "2.0.1"
-    },
     "clipboard": {
       "version": "1.5.3"
     },
@@ -847,7 +844,7 @@
       "dev": true
     },
     "cssom": {
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dev": true
     },
     "cssstyle": {
@@ -1149,7 +1146,7 @@
       "version": "1.3.0"
     },
     "es-abstract": {
-      "version": "1.6.1",
+      "version": "1.7.0",
       "dev": true
     },
     "es-to-primitive": {
@@ -2660,9 +2657,6 @@
     },
     "node-abi": {
       "version": "1.0.3"
-    },
-    "node-contains": {
-      "version": "1.0.0"
     },
     "node-dir": {
       "version": "0.1.16",
@@ -4201,7 +4195,7 @@
           "dev": true
         },
         "filesize": {
-          "version": "3.4.1",
+          "version": "3.4.3",
           "dev": true
         },
         "finalhandler": {
@@ -4241,8 +4235,18 @@
           "dev": true
         },
         "serve-static": {
-          "version": "1.11.1",
-          "dev": true
+          "version": "1.11.2",
+          "dev": true,
+          "dependencies": {
+            "ms": {
+              "version": "0.7.2",
+              "dev": true
+            },
+            "send": {
+              "version": "0.14.2",
+              "dev": true
+            }
+          }
         },
         "supports-color": {
           "version": "2.0.0",
@@ -4313,7 +4317,7 @@
           "dev": true
         },
         "filesize": {
-          "version": "3.4.1",
+          "version": "3.4.3",
           "dev": true
         },
         "isarray": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "chalk": "1.0.0",
     "chrono-node": "^1.0.6",
     "classnames": "1.1.1",
-    "click-outside": "2.0.1",
     "clipboard": "1.5.3",
     "commander": "2.3.0",
     "component-closest": "0.1.4",


### PR DESCRIPTION
Second stab at #5181.

The only remaining component to use `click-outside` is `Popover`, which this PR modifies to use `react-click-outside` instead. `click-outside` is then removed from `package.json`. `react-click-outside` works much better with React in general, and with server-side rendering in particular.

However, we cannot drop [our stubbing](https://github.com/Automattic/wp-calypso/blob/fffa03b3406ec5421d87e949221e8b0a09bdbd87/webpack.config.node.js#L108) quite yet, since `Popover` [still makes use](https://github.com/Automattic/wp-calypso/blob/fffa03b3406ec5421d87e949221e8b0a09bdbd87/client/components/popover/util.js) of `window` directly. In the long run, maybe we should use a ready-made React tooltip component after all (see #4072). Or we guard that code with `typeof 'window' !== 'undefined'` checks.

To test:
* Verify that `Popovers` still work as before -- especially that they disappear when clicking outside 😄 