### PR TITLE
SSR: Remove two obsolete mocks

### DIFF
--- a/client/my-sites/theme/test/main.jsx
+++ b/client/my-sites/theme/test/main.jsx
@@ -25,7 +25,6 @@ describe( 'main', function() {
 
 		before( function() {
 			mockery.registerMock( 'my-sites/themes/theme-preview', EmptyComponent );
-			mockery.registerMock( 'my-sites/themes/thanks-modal', EmptyComponent );
 			mockery.registerMock( 'my-sites/themes/themes-site-selector-modal', EmptyComponent );
 			mockery.registerMock( 'components/data/query-user-purchases', EmptyComponent );
 			mockery.registerMock( 'components/data/query-site-purchases', EmptyComponent );

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -106,7 +106,6 @@ var webpackConfig = {
 		new webpack.NormalModuleReplacementPlugin( /^lib\/post-normalizer\/rule-create-better-excerpt$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^components\/seo\/preview-upgrade-nudge$/, 'components/empty-component' ), // Depends on page.js and should never be required server side
 		new webpack.NormalModuleReplacementPlugin( /^components\/popover$/, 'components/empty-component' ), // Depends on BOM and interactions don't work without JS
-		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/thanks-modal$/, 'components/empty-component' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/themes-site-selector-modal$/, 'components/empty-component' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/theme-upload$/, 'components/empty-component' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/single-site$/, 'components/empty-component' ), // Depends on DOM


### PR DESCRIPTION
These were breaking because they use `Popover` -- but that's now being mocked too, so no reason to still mock the consumer components.

To test:
* Restart Calypso. Verify that it runs, and check that the logged-out theme showcase looks sane ( `/design`)
* Verify that unit tests pass. (Just check CircleCI 😄 )