### PR TITLE
Image Editor: store the original image aspect ratio, fix rotation crop bug

### DIFF
--- a/client/blocks/image-editor/image-editor-canvas.jsx
+++ b/client/blocks/image-editor/image-editor-canvas.jsx
@@ -131,7 +131,7 @@ class ImageEditorCanvas extends Component {
 			window.addEventListener( 'resize', this.onWindowResize );
 		}
 
-		this.props.setImageEditorImageHasLoaded();
+		this.props.setImageEditorImageHasLoaded( this.image.width, this.image.height );
 	}
 
 	componentWillUnmount() {

--- a/client/blocks/image-editor/image-editor-crop.jsx
+++ b/client/blocks/image-editor/image-editor-crop.jsx
@@ -23,6 +23,7 @@ import {
 	imageEditorComputedCrop
 } from 'state/ui/editor/image-editor/actions';
 import { defaultCrop } from 'state/ui/editor/image-editor/reducer';
+import { getImageEditorOriginalAspectRatio } from 'state/selectors';
 
 class ImageEditorCrop extends Component {
 	static propTypes = {
@@ -152,7 +153,6 @@ class ImageEditorCrop extends Component {
 		}
 
 		const rotated = props.degrees % 180 !== 0,
-			bounds = props.bounds,
 			newState = Object.assign( {}, this.state, newValues ),
 			newWidth = newState.right - newState.left,
 			newHeight = newState.bottom - newState.top;
@@ -164,8 +164,15 @@ class ImageEditorCrop extends Component {
 
 		switch ( aspectRatio ) {
 			case AspectRatios.ORIGINAL:
-				imageWidth = bounds.rightBound - bounds.leftBound;
-				imageHeight = bounds.bottomBound - bounds.topBound;
+				//image not loaded yet
+				if ( ! this.props.originalAspectRatio ) {
+					this.setState( newValues, callback );
+					return;
+				}
+
+				const { width, height } = this.props.originalAspectRatio;
+				imageWidth = rotated ? height : width;
+				imageHeight = rotated ? width : height;
 
 				break;
 
@@ -499,6 +506,7 @@ export default connect(
 			crop,
 			aspectRatio,
 			degrees,
+			originalAspectRatio: getImageEditorOriginalAspectRatio( state ),
 			imageEditorHasChanges: imageEditorHasChanges( state )
 		};
 	},

--- a/client/state/selectors/get-image-editor-original-aspect-ratio.js
+++ b/client/state/selectors/get-image-editor-original-aspect-ratio.js
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns the original aspect ratio of the image loaded in the image editor.
+ * This is based on the original image's width/height when it was loaded.
+ *
+ * @param  {Object}  state   Global state tree
+ * @return {?Object}         Original image dimensions, if known
+ */
+export default function getImageEditorOriginalAspectRatio( state ) {
+	return get( state, 'ui.editor.imageEditor.originalAspectRatio', null );
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -18,6 +18,7 @@ export canCurrentUser from './can-current-user';
 export countPostLikes from './count-post-likes';
 export editedPostHasContent from './edited-post-has-content';
 export getBillingTransactions from './get-billing-transactions';
+export getImageEditorOriginalAspectRatio from './get-image-editor-original-aspect-ratio';
 export getMenuItemTypes from './get-menu-item-types';
 export getPostLikes from './get-post-likes';
 export getSharingButtons from './get-sharing-buttons';

--- a/client/state/selectors/test/get-image-editor-original-aspect-ratio.js
+++ b/client/state/selectors/test/get-image-editor-original-aspect-ratio.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getImageEditorOriginalAspectRatio } from '../';
+
+describe( 'getImageEditorOriginalAspectRatio()', () => {
+	it( 'should return null if the image has not loaded yet', () => {
+		const originalAspectRatio = getImageEditorOriginalAspectRatio( {
+			ui: {
+				editor: {
+					imageEditor: {
+						originalAspectRatio: null
+					}
+				}
+			}
+		} );
+
+		expect( originalAspectRatio ).to.equal( null );
+	} );
+
+	it( 'should return the original aspect ratio', () => {
+		const originalAspectRatio = getImageEditorOriginalAspectRatio( {
+			ui: {
+				editor: {
+					imageEditor: {
+						originalAspectRatio: { width: 100, height: 200 }
+					}
+				}
+			}
+		} );
+
+		expect( originalAspectRatio ).to.eql( { width: 100, height: 200 } );
+	} );
+} );

--- a/client/state/ui/editor/image-editor/actions.js
+++ b/client/state/ui/editor/image-editor/actions.js
@@ -102,7 +102,7 @@ export function imageEditorCrop( topRatio, leftRatio, widthRatio, heightRatio ) 
 export function setImageEditorImageHasLoaded( width, height ) {
 	return {
 		type: IMAGE_EDITOR_IMAGE_HAS_LOADED,
-		width: width,
-		height: height
+		width,
+		height
 	};
 }

--- a/client/state/ui/editor/image-editor/actions.js
+++ b/client/state/ui/editor/image-editor/actions.js
@@ -99,8 +99,10 @@ export function imageEditorCrop( topRatio, leftRatio, widthRatio, heightRatio ) 
 	};
 }
 
-export function setImageEditorImageHasLoaded() {
+export function setImageEditorImageHasLoaded( width, height ) {
 	return {
-		type: IMAGE_EDITOR_IMAGE_HAS_LOADED
+		type: IMAGE_EDITOR_IMAGE_HAS_LOADED,
+		width: width,
+		height: height
 	};
 }

--- a/client/state/ui/editor/image-editor/reducer.js
+++ b/client/state/ui/editor/image-editor/reducer.js
@@ -19,6 +19,7 @@ import {
 	IMAGE_EDITOR_STATE_RESET_ALL,
 	IMAGE_EDITOR_IMAGE_HAS_LOADED
 } from 'state/action-types';
+import { createReducer } from 'state/utils';
 import { AspectRatios } from './constants';
 
 export const defaultTransform = {
@@ -67,6 +68,13 @@ export function hasChanges( state = false, action ) {
 
 	return state;
 }
+
+export const originalAspectRatio = createReducer( null, {
+	[ IMAGE_EDITOR_IMAGE_HAS_LOADED ]: ( state, { width, height } ) => {
+		return { width, height };
+	},
+	[ IMAGE_EDITOR_STATE_RESET_ALL ]: () => null
+} );
 
 export function imageIsLoading( state = true, action ) {
 	switch ( action.type ) {
@@ -180,5 +188,6 @@ export default combineReducers( {
 	cropBounds,
 	crop,
 	aspectRatio,
+	originalAspectRatio,
 	imageIsLoading
 } );

--- a/client/state/ui/editor/image-editor/test/actions.js
+++ b/client/state/ui/editor/image-editor/test/actions.js
@@ -178,10 +178,12 @@ describe( 'actions', () => {
 
 	describe( '#setImageEditorImageHasLoaded()', () => {
 		it( 'should return an action object', () => {
-			const action = setImageEditorImageHasLoaded();
+			const action = setImageEditorImageHasLoaded( 123, 456 );
 
 			expect( action ).to.eql( {
-				type: IMAGE_EDITOR_IMAGE_HAS_LOADED
+				type: IMAGE_EDITOR_IMAGE_HAS_LOADED,
+				width: 123,
+				height: 456
 			} );
 		} );
 	} );

--- a/client/state/ui/editor/image-editor/test/reducer.js
+++ b/client/state/ui/editor/image-editor/test/reducer.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
@@ -28,7 +29,8 @@ import reducer, {
 	cropBounds,
 	crop,
 	aspectRatio,
-	imageIsLoading
+	imageIsLoading,
+	originalAspectRatio
 } from '../reducer';
 
 describe( 'reducer', () => {
@@ -40,7 +42,8 @@ describe( 'reducer', () => {
 			'cropBounds',
 			'crop',
 			'aspectRatio',
-			'imageIsLoading'
+			'imageIsLoading',
+			'originalAspectRatio'
 		] );
 	} );
 
@@ -485,6 +488,33 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.be.true;
+		} );
+	} );
+
+	describe( '#originalAspectRatio()', () => {
+		it( 'should default to null', () => {
+			const state = originalAspectRatio( undefined, {} );
+
+			expect( state ).to.equal( null );
+		} );
+
+		it( 'should update when an image is loaded', () => {
+			const state = originalAspectRatio( undefined, {
+				type: IMAGE_EDITOR_IMAGE_HAS_LOADED,
+				width: 100,
+				height: 200
+			} );
+
+			expect( state ).to.eql( { width: 100, height: 200 } );
+		} );
+
+		it( 'should reset to null on reset all', () => {
+			const originalState = deepFreeze( { width: 100, height: 100 } );
+			const state = originalAspectRatio( originalState, {
+				type: IMAGE_EDITOR_STATE_RESET_ALL
+			} );
+
+			expect( state ).to.equal( null );
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #9738 where the crop area would be incorrect, when selecting the original aspect ratio and then rotating the image.

Originally reported in https://horizonfeedback.wordpress.com/2016/11/30/call-for-testing-image-editing/comment-page-1/#comment-264 

### Testing Instructions
1. Navigate to http://calypso.localhost:3000/post
2. Select a site
3. Open the media modal
4. Edit an image
5. Set aspect ratio to Original
6. Rotate

The crop should cover the entire image. Resizing then rotating should work like the other aspect ratios.
