### PR TITLE
Janitorial: remove 'mailing-lists/unsubscribe' feature toggle

### DIFF
--- a/client/mailing-lists/index.js
+++ b/client/mailing-lists/index.js
@@ -6,14 +6,11 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import controller from './controller';
 
 export default function() {
-	if ( config.isEnabled( 'mailing-lists/unsubscribe' ) ) {
-		// not putting category or email address in params, since `page`
-		// currently double-decodes the URI before doing route matching
-		// https://github.com/visionmedia/page.js/issues/306
-		page( '/mailing-lists/unsubscribe', controller.unsubscribe );
-	}
-};
+	// not putting category or email address in params, since `page`
+	// currently double-decodes the URI before doing route matching
+	// https://github.com/visionmedia/page.js/issues/306
+	page( '/mailing-lists/unsubscribe', controller.unsubscribe );
+}

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -190,6 +190,12 @@ sections = [
 		module: 'my-sites/ads',
 		secondary: true,
 		group: 'sites'
+	},
+	{
+		name: 'mailing-lists',
+		paths: [ '/mailing-lists' ],
+		module: 'mailing-lists',
+		enableLoggedOut: true
 	}
 ];
 
@@ -344,15 +350,6 @@ if ( config.isEnabled( 'oauth' ) ) {
 		paths: [ '/login', '/authorize', '/api/oauth/token' ],
 		module: 'auth',
 		secondary: false,
-		enableLoggedOut: true
-	} );
-}
-
-if ( config.isEnabled( 'mailing-lists/unsubscribe' ) ) {
-	sections.push( {
-		name: 'mailing-lists',
-		paths: [ '/mailing-lists' ],
-		module: 'mailing-lists',
 		enableLoggedOut: true
 	} );
 }

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -25,7 +25,6 @@
 		"jetpack/connect": true,
 		"jetpack/personalPlan": true,
 		"jetpack/seo-tools": true,
-		"mailing-lists/unsubscribe": true,
 		"manage/advanced-seo": true,
 		"manage/advanced-seo/custom-title": true,
 		"manage/advanced-seo/preview-nudge": true,

--- a/config/development.json
+++ b/config/development.json
@@ -54,7 +54,6 @@
 		"jetpack/api-cache": true,
 		"keyboard-shortcuts": true,
 		"happychat": true,
-		"mailing-lists/unsubscribe": true,
 		"manage/advanced-seo": true,
 		"manage/advanced-seo/custom-title": true,
 		"manage/advanced-seo/preview-nudge": true,

--- a/config/production.json
+++ b/config/production.json
@@ -24,7 +24,6 @@
 		"jetpack/personalPlan": true,
 		"jetpack/seo-tools": true,
 		"jetpack/api-cache": false,
-		"mailing-lists/unsubscribe": true,
 		"manage/advanced-seo": true,
 		"manage/advanced-seo/custom-title": true,
 		"manage/advanced-seo/preview-nudge": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -27,7 +27,6 @@
 		"jetpack/seo-tools": true,
 		"jetpack/api-cache": false,
 		"jetpack_core_inline_update": true,
-		"mailing-lists/unsubscribe": true,
 		"manage/advanced-seo": true,
 		"manage/advanced-seo/custom-title": true,
 		"manage/advanced-seo/preview-nudge": true,

--- a/config/test.json
+++ b/config/test.json
@@ -41,7 +41,6 @@
 		"jetpack/personalPlan": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
-		"mailing-lists/unsubscribe": true,
 		"manage/customize": true,
 		"manage/drafts": true,
 		"manage/edit-user": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -36,7 +36,6 @@
 		"jetpack_core_inline_update": true,
 		"jetpack/google-analytics": true,
 		"keyboard-shortcuts": true,
-		"mailing-lists/unsubscribe": true,
 		"manage/advanced-seo": true,
 		"manage/advanced-seo/custom-title": true,
 		"manage/advanced-seo/preview-nudge": true,


### PR DESCRIPTION
This removes the feature toggle `mailing-lists/unsubscribe` which was enabled in every environment bar horizon anyway.

**Testing Instructions**

Ensure you can still access http://calypso.localhost:3000/mailing-lists/unsubscribe