### PR TITLE
People: remove 'manage/add-people' feature toggle

### DIFF
--- a/client/my-sites/people/index.js
+++ b/client/my-sites/people/index.js
@@ -23,15 +23,13 @@ module.exports = function() {
 			);
 		} );
 
-		if ( config.isEnabled( 'manage/add-people' ) ) {
-			page(
-				'/people/new/:site_id',
-				peopleController.enforceSiteEnding,
-				controller.siteSelection,
-				controller.navigation,
-				peopleController.invitePeople
-			);
-		}
+		page(
+			'/people/new/:site_id',
+			peopleController.enforceSiteEnding,
+			controller.siteSelection,
+			controller.navigation,
+			peopleController.invitePeople
+		);
 
 		page(
 			'/people/edit/:site_id/:user_login',

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -13,7 +13,6 @@ import Button from 'components/button';
 import ButtonGroup from 'components/button-group';
 import Gridicon from 'components/gridicon';
 import Tooltip from 'components/tooltip';
-import config from 'config';
 
 export default React.createClass( {
 	displayName: 'PeopleListSectionHeader',
@@ -28,7 +27,7 @@ export default React.createClass( {
 	getInitialState() {
 		return {
 			addPeopleTooltip: false
-		}
+		};
 	},
 
 	getDefaultProps() {
@@ -58,9 +57,7 @@ export default React.createClass( {
 			return wpAdminUrl + 'user-new.php';
 		}
 
-		return config.isEnabled( 'manage/add-people' )
-			? '/people/new/' + siteSlug
-			: wpAdminUrl + 'users.php?page=wpcom-invite-users';
+		return '/people/new/' + siteSlug;
 	},
 
 	render() {

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -461,7 +461,7 @@ export class MySitesSidebar extends Component {
 			usersLink = site.options.admin_url + 'users.php';
 		}
 
-		if ( site.options && ( ! config.isEnabled( 'manage/add-people' ) || site.jetpack ) ) {
+		if ( site.options && site.jetpack ) {
 			addPeopleLink = ( site.jetpack )
 				? site.options.admin_url + 'user-new.php'
 				: site.options.admin_url + 'users.php?page=wpcom-invite-users';

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -27,7 +27,6 @@
 		"jetpack/personalPlan": true,
 		"jetpack/seo-tools": true,
 		"mailing-lists/unsubscribe": true,
-		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/advanced-seo": true,

--- a/config/development.json
+++ b/config/development.json
@@ -59,7 +59,6 @@
 		"keyboard-shortcuts": true,
 		"happychat": true,
 		"mailing-lists/unsubscribe": true,
-		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/advanced-seo": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -27,7 +27,6 @@
 		"jetpack/seo-tools": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
-		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/advanced-seo": true,

--- a/config/production.json
+++ b/config/production.json
@@ -26,7 +26,6 @@
 		"jetpack/seo-tools": true,
 		"jetpack/api-cache": false,
 		"mailing-lists/unsubscribe": true,
-		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/advanced-seo": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -30,7 +30,6 @@
 		"jetpack/api-cache": false,
 		"jetpack_core_inline_update": true,
 		"mailing-lists/unsubscribe": true,
-		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/advanced-seo": true,

--- a/config/test.json
+++ b/config/test.json
@@ -42,7 +42,6 @@
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
 		"mailing-lists/unsubscribe": true,
-		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/customize": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -40,7 +40,6 @@
 		"jetpack/google-analytics": true,
 		"keyboard-shortcuts": true,
 		"mailing-lists/unsubscribe": true,
-		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/advanced-seo": true,


### PR DESCRIPTION
Removes the unnecessary feature toggle `manage/add-people`

**Testing Instructions**

* Make sure you can still add a person to a WordPress.com site
* Make sure you can still use the add person link to a Jetpack site
