### PR TITLE
Ads: remove ads feature toggles

### DIFF
--- a/client/lib/ads/utils.js
+++ b/client/lib/ads/utils.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import config from 'config';
 import { userCan } from 'lib/site/utils';
 import { isBusiness, isPremium } from 'lib/products-values';
 
@@ -19,8 +18,7 @@ export function canAccessWordads( site ) {
 		const jetpackPremium = site.jetpack && ( isPremium( site.plan ) || isBusiness( site.plan ) );
 		return site.options &&
 			( site.options.wordads || jetpackPremium ) &&
-			userCan( 'manage_options', site ) &&
-			( ! site.jetpack || config.isEnabled( 'manage/ads/jetpack' ) );
+			userCan( 'manage_options', site );
 	}
 
 	return false;

--- a/client/lib/ads/utils.js
+++ b/client/lib/ads/utils.js
@@ -11,7 +11,7 @@ import { isBusiness, isPremium } from 'lib/products-values';
  * @return {boolean}      true if site has WordAds access
  */
 export function canAccessWordads( site ) {
-	if ( site && config.isEnabled( 'manage/ads' ) ) {
+	if ( site ) {
 		if ( isWordadsInstantActivationEligible( site ) ) {
 			return true;
 		}

--- a/client/my-sites/ads/index.js
+++ b/client/my-sites/ads/index.js
@@ -7,13 +7,10 @@ var page = require( 'page' );
  * Internal dependencies
  */
 var controller = require( 'my-sites/controller' ),
-	adsController = require( './controller' ),
-	config = require( 'config' );
+	adsController = require( './controller' );
 
 module.exports = function() {
-	if ( config.isEnabled( 'manage/ads' ) ) {
-		page( '/ads', controller.siteSelection, controller.sites );
-		page( '/ads/:site_id', adsController.redirect );
-		page( '/ads/:section/:site_id', controller.siteSelection, controller.navigation, adsController.layout );
-	}
+	page( '/ads', controller.siteSelection, controller.sites );
+	page( '/ads/:site_id', adsController.redirect );
+	page( '/ads/:section/:site_id', controller.siteSelection, controller.navigation, adsController.layout );
 };

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -183,6 +183,13 @@ sections = [
 		paths: [ '/accept-invite' ],
 		module: 'my-sites/invites',
 		enableLoggedOut: true
+	},
+	{
+		name: 'ads',
+		paths: [ '/ads' ],
+		module: 'my-sites/ads',
+		secondary: true,
+		group: 'sites'
 	}
 ];
 
@@ -206,16 +213,6 @@ if ( config.isEnabled( 'account-recovery' ) ) {
 		module: 'account-recovery',
 		secondary: false,
 		enableLoggedOut: true,
-	} );
-}
-
-if ( config.isEnabled( 'manage/ads' ) ) {
-	sections.push( {
-		name: 'ads',
-		paths: [ '/ads' ],
-		module: 'my-sites/ads',
-		secondary: true,
-		group: 'sites'
 	} );
 }
 

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -21,7 +21,6 @@
 		"fluid-width": true,
 		"help": false,
 		"mailing-lists/unsubscribe": true,
-		"manage/ads/jetpack": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/jetpack": true,

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -21,7 +21,6 @@
 		"fluid-width": true,
 		"help": false,
 		"mailing-lists/unsubscribe": true,
-		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/customize": true,
 		"manage/edit-user": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -28,7 +28,6 @@
 		"jetpack/seo-tools": true,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,
-		"manage/ads/jetpack": true,
 		"manage/advanced-seo": true,
 		"manage/advanced-seo/custom-title": true,
 		"manage/advanced-seo/preview-nudge": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -28,7 +28,6 @@
 		"jetpack/seo-tools": true,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,
-		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/advanced-seo": true,
 		"manage/advanced-seo/custom-title": true,

--- a/config/development.json
+++ b/config/development.json
@@ -60,7 +60,6 @@
 		"happychat": true,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,
-		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/advanced-seo": true,
 		"manage/advanced-seo/custom-title": true,

--- a/config/development.json
+++ b/config/development.json
@@ -60,7 +60,6 @@
 		"happychat": true,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,
-		"manage/ads/jetpack": true,
 		"manage/advanced-seo": true,
 		"manage/advanced-seo/custom-title": true,
 		"manage/advanced-seo/preview-nudge": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -28,7 +28,6 @@
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
 		"manage/add-people": true,
-		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/advanced-seo": true,
 		"manage/advanced-seo/custom-title": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -28,7 +28,6 @@
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
 		"manage/add-people": true,
-		"manage/ads/jetpack": true,
 		"manage/advanced-seo": true,
 		"manage/advanced-seo/custom-title": true,
 		"manage/advanced-seo/preview-nudge": true,

--- a/config/production.json
+++ b/config/production.json
@@ -27,7 +27,6 @@
 		"jetpack/api-cache": false,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,
-		"manage/ads/jetpack": true,
 		"manage/advanced-seo": true,
 		"manage/advanced-seo/custom-title": true,
 		"manage/advanced-seo/preview-nudge": true,

--- a/config/production.json
+++ b/config/production.json
@@ -27,7 +27,6 @@
 		"jetpack/api-cache": false,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,
-		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/advanced-seo": true,
 		"manage/advanced-seo/custom-title": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -31,7 +31,6 @@
 		"jetpack_core_inline_update": true,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,
-		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/advanced-seo": true,
 		"manage/advanced-seo/custom-title": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -31,7 +31,6 @@
 		"jetpack_core_inline_update": true,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,
-		"manage/ads/jetpack": true,
 		"manage/advanced-seo": true,
 		"manage/advanced-seo/custom-title": true,
 		"manage/advanced-seo/preview-nudge": true,

--- a/config/test.json
+++ b/config/test.json
@@ -43,7 +43,6 @@
 		"keyboard-shortcuts": true,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,
-		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/customize": true,
 		"manage/drafts": true,

--- a/config/test.json
+++ b/config/test.json
@@ -43,7 +43,6 @@
 		"keyboard-shortcuts": true,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,
-		"manage/ads/jetpack": true,
 		"manage/customize": true,
 		"manage/drafts": true,
 		"manage/edit-user": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -41,7 +41,6 @@
 		"keyboard-shortcuts": true,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,
-		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/advanced-seo": true,
 		"manage/advanced-seo/custom-title": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -41,7 +41,6 @@
 		"keyboard-shortcuts": true,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,
-		"manage/ads/jetpack": true,
 		"manage/advanced-seo": true,
 		"manage/advanced-seo/custom-title": true,
 		"manage/advanced-seo/preview-nudge": true,


### PR DESCRIPTION
This removes two feature toggles which were enabled in all environments: manage/ads and manage/ads/jetpack

**Testing Instructions**

Make sure WordAds are accessible in Calypso for both a WordPress.com site and a Jetpack site