### PR TITLE
Remove the feature toggles `/me/security/` and `/me/security/account-recovery`

### DIFF
--- a/client/me/security-section-nav/index.jsx
+++ b/client/me/security-section-nav/index.jsx
@@ -10,8 +10,7 @@ var React = require( 'react' ),
  */
 var SectionNav = require( 'components/section-nav' ),
 	NavTabs = require( 'components/section-nav/tabs' ),
-	NavItem = require( 'components/section-nav/item' ),
-	config = require( 'config' );
+	NavItem = require( 'components/section-nav/item' );
 
 module.exports = React.createClass( {
 	propTypes: {
@@ -31,15 +30,12 @@ module.exports = React.createClass( {
 			{
 				title: i18n.translate( 'Connected Applications', { textOnly: true } ),
 				path: '/me/security/connected-applications',
-			}
-		];
-
-		if ( config.isEnabled( 'me/security/account-recovery' ) ) {
-			tabs.push( {
+			},
+			{
 				title: i18n.translate( 'Account Recovery', { textOnly: true } ),
 				path: '/me/security/account-recovery',
-			} );
-		}
+			},
+		];
 
 		return tabs;
 	},

--- a/client/me/security/index.js
+++ b/client/me/security/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import config from 'config';
 import page from 'page';
 
 /**
@@ -11,14 +10,9 @@ import meController from 'me/controller';
 import controller from './controller';
 
 export default function() {
-	if ( config.isEnabled( 'me/security' ) ) {
-		page( '/me/security', meController.sidebar, controller.password );
-		page( '/me/security/two-step', meController.sidebar, controller.twoStep );
-		page( '/me/security/connected-applications', meController.sidebar, controller.connectedApplications );
-		page( '/me/security/connected-applications/:application_id', meController.sidebar, controller.connectedApplication );
-	}
-
-	if ( config.isEnabled( 'me/security/account-recovery' ) ) {
-		page( '/me/security/account-recovery', meController.sidebar, controller.accountRecovery );
-	}
-};
+	page( '/me/security', meController.sidebar, controller.password );
+	page( '/me/security/two-step', meController.sidebar, controller.twoStep );
+	page( '/me/security/connected-applications', meController.sidebar, controller.connectedApplications );
+	page( '/me/security/connected-applications/:application_id', meController.sidebar, controller.connectedApplication );
+	page( '/me/security/account-recovery', meController.sidebar, controller.accountRecovery );
+}

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -127,7 +127,7 @@ const MeSidebar = React.createClass( {
 
 						<SidebarItem
 							selected={ selected === 'security' }
-							link={ config.isEnabled( 'me/security' ) ? '/me/security' : '//wordpress.com/me/security' }
+							link={ '/me/security' }
 							label={ this.translate( 'Security' ) }
 							icon="lock"
 							onNavigate={ this.onNavigate }

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -52,8 +52,6 @@
 		"me/my-profile": true,
 		"me/next-steps": true,
 		"me/notifications": true,
-		"me/security": true,
-		"me/security/account-recovery": true,
 		"me/trophies": false,
 		"oauth": true,
 		"olark": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -64,8 +64,6 @@
 		"me/my-profile": true,
 		"me/next-steps": true,
 		"me/notifications": true,
-		"me/security": true,
-		"me/security/account-recovery": true,
 		"me/trophies": false,
 		"oauth": true,
 		"olark": true,

--- a/config/development.json
+++ b/config/development.json
@@ -114,8 +114,6 @@
 		"me/my-profile": true,
 		"me/next-steps": true,
 		"me/notifications": true,
-		"me/security": true,
-		"me/security/account-recovery": true,
 		"me/trophies": false,
 		"preview-layout": true,
 		"paladin": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -71,7 +71,6 @@
 		"me/my-profile": true,
 		"me/next-steps": true,
 		"me/notifications": true,
-		"me/security": true,
 		"me/trophies": false,
 		"network-connection": true,
 		"notifications2beta": true,

--- a/config/production.json
+++ b/config/production.json
@@ -71,8 +71,6 @@
 		"me/my-profile": true,
 		"me/next-steps": true,
 		"me/notifications": true,
-		"me/security": true,
-		"me/security/account-recovery": true,
 		"me/trophies": false,
 		"olark": true,
 		"perfmon": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -74,8 +74,6 @@
 		"me/my-profile": true,
 		"me/next-steps": true,
 		"me/notifications": true,
-		"me/security": true,
-		"me/security/account-recovery": true,
 		"me/trophies": false,
 		"notifications2beta": true,
 		"olark": true,

--- a/config/test.json
+++ b/config/test.json
@@ -82,8 +82,6 @@
 		"me/my-profile": true,
 		"me/next-steps": true,
 		"me/notifications": true,
-		"me/security": true,
-		"me/security/account-recovery": true,
 		"me/trophies": false,
 		"network-connection": true,
 		"notifications2beta": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -93,8 +93,6 @@
 		"me/my-profile": true,
 		"me/next-steps": true,
 		"me/notifications": true,
-		"me/security": true,
-		"me/security/account-recovery": true,
 		"me/trophies": false,
 		"network-connection": true,
 		"notifications2beta": true,


### PR DESCRIPTION
## Summary
This PR removes the feature toggles:

* /me/security
* /me/security/account-recovery

since the both should be fully working in production environments by now.

## Test Plan

* From `/me/`, you should be able to see and access the **Security** tab.
* From `/me/security`, you should be able to see and access the **account recovery** tab.
