### PR TITLE
Revert "State: Update siteSupportsJetpackSettingsUi version to 4.6"

### DIFF
--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -1039,5 +1039,5 @@ export const hasDefaultSiteTitle = ( state, siteId ) => {
  * @return {?Boolean}     Whether site supports managing Jetpack settings remotely.
  */
 export const siteSupportsJetpackSettingsUi = ( state, siteId ) => {
-	return isJetpackMinimumVersion( state, siteId, '4.6.0' );
+	return isJetpackMinimumVersion( state, siteId, '4.5.0' );
 };

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -2351,7 +2351,26 @@ describe( 'selectors', () => {
 			expect( supportsJetpackSettingsUI ).to.be.null;
 		} );
 
-		it( 'should return false if the Jetpack version is older than 4.6', () => {
+		it( 'should return false if the Jetpack version is older than 4.5', () => {
+			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUi( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://example.com',
+							jetpack: true,
+							options: {
+								jetpack_version: '4.4.0'
+							}
+						}
+					}
+				}
+			}, 77203074 );
+
+			expect( supportsJetpackSettingsUI ).to.be.false;
+		} );
+
+		it( 'should return true if the Jetpack version is 4.5', () => {
 			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUi( {
 				sites: {
 					items: {
@@ -2367,10 +2386,10 @@ describe( 'selectors', () => {
 				}
 			}, 77203074 );
 
-			expect( supportsJetpackSettingsUI ).to.be.false;
+			expect( supportsJetpackSettingsUI ).to.be.true;
 		} );
 
-		it( 'should return true if the Jetpack version is 4.6', () => {
+		it( 'should return true if the Jetpack version is newer than 4.5', () => {
 			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUi( {
 				sites: {
 					items: {
@@ -2380,25 +2399,6 @@ describe( 'selectors', () => {
 							jetpack: true,
 							options: {
 								jetpack_version: '4.6.0'
-							}
-						}
-					}
-				}
-			}, 77203074 );
-
-			expect( supportsJetpackSettingsUI ).to.be.true;
-		} );
-
-		it( 'should return true if the Jetpack version is newer than 4.6', () => {
-			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUi( {
-				sites: {
-					items: {
-						77203074: {
-							ID: 77203074,
-							URL: 'https://example.com',
-							jetpack: true,
-							options: {
-								jetpack_version: '4.7.0'
 							}
 						}
 					}


### PR DESCRIPTION
This PR Reverts Automattic/wp-calypso#10881 and needs to land when https://github.com/Automattic/wp-calypso/pull/10891 lands.