### PR TITLE
Domains: Properly handle recently mapped domains

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -255,6 +255,13 @@ const MapDomainStep = React.createClass( {
 				message = translate( 'Please enter a domain name or keyword.' );
 				break;
 
+			case 'recently_mapped':
+				message = translate(
+					'This domain was recently in use by someone else and is not available to map yet. ' +
+					'Please try again later or contact support.'
+				);
+				break;
+
 			default:
 				message = translate( 'Sorry, there was a problem processing your request. Please try again in a few minutes.' );
 		}


### PR DESCRIPTION
If a domain was recently mapped, the backend returns a `recently_mapped` reason for its unmappability. However, we don't handle that reason in `map-domain-step`. I've added a handler for it there, using the same copy as in `register-domain-step`.

### Testing
Map a domain using user1. Then remove the mapping. As user2, try to map the same domain - make sure that the correct error message shows up in both domain search and mapping step: `This domain was recently in use by someone else and is not available to map yet. Please try again later or contact support.`.

Reported in `p2MSmN-5Ma-p2`