### PR TITLE
Jetpack Settings: Disable Theme Enhancements sub-settings instead of hiding

### DIFF
--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -29,13 +29,13 @@ class ThemeEnhancements extends Component {
 		return isRequestingSettings || isSavingSettings;
 	}
 
-	renderToggle( name, label ) {
+	renderToggle( name, isDisabled, label ) {
 		const { fields, handleToggle } = this.props;
 		return (
 			<FormToggle
 				className="theme-enhancements__module-settings-toggle is-compact"
 				checked={ !! fields[ name ] }
-				disabled={ this.isFormPending() }
+				disabled={ this.isFormPending() || isDisabled }
 				onChange={ handleToggle( name ) }>
 				<span className="site-settings__toggle-label">
 					{ label }
@@ -94,22 +94,18 @@ class ThemeEnhancements extends Component {
 					disabled={ formPending }
 					/>
 
-				{
-					infiniteScrollModuleActive && (
-						<div className="theme-enhancements__module-settings is-indented">
-							{
-								this.renderToggle( 'infinite_scroll', translate(
-									'Scroll infinitely (Shows 7 posts on each load)'
-								) )
-							}
-							{
-								this.renderToggle( 'infinite_scroll_google_analytics', translate(
-									'Track each infinite Scroll post load as a page view in Google Analytics'
-								) )
-							}
-						</div>
-					)
-				}
+				<div className="theme-enhancements__module-settings is-indented">
+					{
+						this.renderToggle( 'infinite_scroll', ! infiniteScrollModuleActive, translate(
+							'Scroll infinitely (Shows 7 posts on each load)'
+						) )
+					}
+					{
+						this.renderToggle( 'infinite_scroll_google_analytics', ! infiniteScrollModuleActive, translate(
+							'Track each infinite Scroll post load as a page view in Google Analytics'
+						) )
+					}
+				</div>
 			</FormFieldset>
 		);
 	}
@@ -139,27 +135,23 @@ class ThemeEnhancements extends Component {
 					disabled={ formPending }
 					/>
 
-				{
-					minilevenModuleActive && (
-						<div className="theme-enhancements__module-settings is-indented">
-							{
-								this.renderToggle( 'wp_mobile_excerpt', translate(
-									'Show excerpts on front page and on archive pages instead of full posts'
-								) )
-							}
-							{
-								this.renderToggle( 'wp_mobile_featured_images', translate(
-									'Hide all featured images'
-								) )
-							}
-							{
-								this.renderToggle( 'wp_mobile_app_promos', translate(
-									'Show an ad for the WordPress mobile apps in the footer of the mobile theme'
-								) )
-							}
-						</div>
-					)
-				}
+				<div className="theme-enhancements__module-settings is-indented">
+					{
+						this.renderToggle( 'wp_mobile_excerpt', ! minilevenModuleActive, translate(
+							'Show excerpts on front page and on archive pages instead of full posts'
+						) )
+					}
+					{
+						this.renderToggle( 'wp_mobile_featured_images', ! minilevenModuleActive, translate(
+							'Hide all featured images'
+						) )
+					}
+					{
+						this.renderToggle( 'wp_mobile_app_promos', ! minilevenModuleActive, translate(
+							'Show an ad for the WordPress mobile apps in the footer of the mobile theme'
+						) )
+					}
+				</div>
 			</FormFieldset>
 		);
 	}

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -148,7 +148,12 @@ class ThemeEnhancements extends Component {
 					}
 					{
 						this.renderToggle( 'wp_mobile_app_promos', ! minilevenModuleActive, translate(
-							'Show an ad for the WordPress mobile apps in the footer of the mobile theme'
+							'Show an ad for the {{link}}WordPress mobile apps{{/link}} in the footer of the mobile theme',
+							{
+								components: {
+									link: <a href="https://apps.wordpress.com/" />
+								}
+							}
 						) )
 					}
 				</div>


### PR DESCRIPTION
This PR updates the sub-settings of the Theme Enhancements card in Writing Settings to get disabled instead of being hidden when the corresponding module is not active. As suggested by @MichaelArestad and @rickybanister.

#### Preview:

##### DIsabled modules
![](https://cldup.com/1JT7O-Lokr.png)

##### Enabled modules
![](https://cldup.com/xooEycTu4h.png)

#### To test

* Checkout this branch
* Go to `/settings/writing/$site` where `$site` is one of your sites.
* Verify settings are not hidden, but are disabled when the modules are disabled.
* Verify settings are working as before with enabled modules.

