### PR TITLE
Stats: Reduxify the followers component in the insights page

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -141,10 +141,6 @@ module.exports = {
 			? site.slug : route.getSiteFragment( context.path );
 
 		const commentsList = new StatsList( { siteID: siteId, statType: 'statsComments', domain: siteDomain } );
-		const wpcomFollowersList = new StatsList( {
-			siteID: siteId, statType: 'statsFollowers', type: 'wpcom', domain: siteDomain, max: 7 } );
-		const emailFollowersList = new StatsList( {
-			siteID: siteId, statType: 'statsFollowers', type: 'email', domain: siteDomain, max: 7 } );
 		const commentFollowersList = new StatsList( {
 			siteID: siteId, statType: 'statsCommentFollowers', domain: siteDomain, max: 7 } );
 
@@ -155,8 +151,6 @@ module.exports = {
 				site: site,
 				followList: followList,
 				commentsList: commentsList,
-				wpcomFollowersList: wpcomFollowersList,
-				emailFollowersList: emailFollowersList,
 				commentFollowersList: commentFollowersList,
 				summaryDate: summaryDate
 			} ),

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -87,7 +87,9 @@ class StatModuleFollowers extends Component {
 			hasEmailQueryFailed,
 			hasWpcomQueryFailed,
 			translate,
-			numberFormat
+			numberFormat,
+			emailQuery,
+			wpcomQuery
 		} = this.props;
 		const isLoading = requestingWpcomFollowers || requestingEmailFollowers;
 		const hasEmailFollowers = !! get( emailData, 'subscribers', [] ).length;
@@ -114,13 +116,13 @@ class StatModuleFollowers extends Component {
 
 		return (
 			<div>
-				<QuerySiteStats statType="statsFollowers" siteId={ siteId } query={ { type: 'wpcom', max: 7 } } />
-				<QuerySiteStats statType="statsFollowers" siteId={ siteId } query={ { type: 'email', max: 7 } } />
+				<QuerySiteStats statType="statsFollowers" siteId={ siteId } query={ wpcomQuery } />
+				<QuerySiteStats statType="statsFollowers" siteId={ siteId } query={ emailQuery } />
 				<SectionHeader label={ translate( 'Followers' ) } href={ summaryPageLink } />
 				<Card className={ classNames( ...classes ) }>
 					<div className="followers">
 						<div className="module-content">
-							{ noData && ! hasError &&
+							{ noData && ! hasError && ! isLoading &&
 								<ErrorPanel className="is-empty-message" message={ translate( 'No followers' ) } />
 							}
 
@@ -157,8 +159,8 @@ class StatModuleFollowers extends Component {
 							<StatsModulePlaceholder isLoading={ isLoading } />
 						</div>
 						{ (
-								( wpcomData && wpcomData.subscribers.length !== wpcomData.total_subscribers ) ||
-								( emailData && emailData.subscribers.length !== emailData.total_subscribers )
+								( wpcomData && wpcomData.subscribers.length !== wpcomData.total_wpcom ) ||
+								( emailData && emailData.subscribers.length !== emailData.total_email )
 							) &&
 							<div key="view-all" className="module-expand">
 								<a href={ summaryPageLink }>
@@ -178,8 +180,8 @@ const connectComponent = connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
 		const siteSlug = getSiteSlug( state, siteId );
-		const emailQuery = { type: 'email', max: 7 };
-		const wpcomQuery = { type: 'wpcom', max: 7 };
+		const emailQuery = { type: 'email', max: 10 };
+		const wpcomQuery = { type: 'wpcom', max: 10 };
 
 		return {
 			requestingEmailFollowers: isRequestingSiteStatsForQuery( state, siteId, 'statsFollowers', emailQuery ),
@@ -188,6 +190,8 @@ const connectComponent = connect(
 			requestingWpcomFollowers: isRequestingSiteStatsForQuery( state, siteId, 'statsFollowers', wpcomQuery ),
 			wpcomData: getSiteStatsNormalizedData( state, siteId, 'statsFollowers', wpcomQuery ),
 			hasWpcomQueryFailed: hasSiteStatsQueryFailed( state, siteId, 'statsFollowers', wpcomQuery ),
+			emailQuery,
+			wpcomQuery,
 			siteId,
 			siteSlug
 		};

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -1,50 +1,40 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+import React, { Component } from 'react';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { flowRight, get } from 'lodash';
 
 /**
  * Internal dependencies
  */
-var StatsListLegend = require( '../stats-list/legend' ),
-	StatsModuleSelectDropdown = require( '../stats-module/select-dropdown' ),
-	StatsModulePlaceholder = require( '../stats-module/placeholder' ),
-	StatsList = require( '../stats-list' ),
-	observe = require( 'lib/mixins/data-observe' ),
-	ErrorPanel = require( '../stats-error' ),
-	analytics = require( 'lib/analytics' ),
-	Card = require( 'components/card' ),
-	SectionHeader = require( 'components/section-header' );
+import StatsListLegend from '../stats-list/legend';
+import StatsModuleSelectDropdown from '../stats-module/select-dropdown';
+import StatsModulePlaceholder from '../stats-module/placeholder';
+import StatsList from '../stats-list';
+import ErrorPanel from '../stats-error';
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+import QuerySiteStats from 'components/data/query-site-stats';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
+import {
+	isRequestingSiteStatsForQuery,
+	getSiteStatsNormalizedData,
+	hasSiteStatsQueryFailed
+} from 'state/stats/lists/selectors';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
-module.exports = React.createClass( {
-	displayName: 'StatModuleFollowers',
+class StatModuleFollowers extends Component {
+	state = {
+		activeFilter: 'wpcom-followers',
+	};
 
-	mixins: [ observe( 'wpcomFollowersList', 'emailFollowersList' ) ],
-
-	data: function( list ) {
-		if ( list && this.props[ list ] ) {
-			return this.props[ list ].response.data;
-		}
-	},
-
-	getInitialState: function() {
-		return {
-			activeFilter: 'wpcom-followers',
-			noData: ( this.props.wpcomFollowersList.isEmpty( 'subscribers' ) && this.props.emailFollowersList.isEmpty( 'subscribers' ) )
-		};
-	},
-
-	componentWillReceiveProps: function( nextProps ) {
-		this.setState( {
-			noData: ( nextProps.wpcomFollowersList.isEmpty( 'subscribers' ) && nextProps.emailFollowersList.isEmpty( 'subscribers' ) )
-		} );
-	},
-
-	changeFilter: function( selection ) {
-		var gaEvent,
-			filter = selection.value;
-
+	changeFilter = ( selection ) => {
+		const filter = selection.value;
+		let gaEvent;
 		if ( filter !== this.state.activeFilter ) {
 			switch ( filter ) {
 				case 'wpcom-followers':
@@ -54,61 +44,59 @@ module.exports = React.createClass( {
 					gaEvent = 'Clicked Email Followers Toggle';
 					break;
 			}
-
 			if ( gaEvent ) {
-				analytics.ga.recordEvent( 'Stats', gaEvent );
+				this.props.recordGoogleEvent( 'Stats', gaEvent );
 			}
 
 			this.setState( {
 				activeFilter: filter
 			} );
 		}
-	},
+	};
 
-	filterSelect: function() {
-		var selectFilter,
-			options = [
-				{
-					value: 'wpcom-followers',
-					label: this.translate( 'WordPress.com Followers' )
-				},
-				{
-					value: 'email-followers',
-					label: this.translate( 'Email Followers' )
-				}
-			];
-
-		if ( ( ! this.props.wpcomFollowersList.isEmpty( 'subscribers' ) ) && ( ! this.props.emailFollowersList.isEmpty( 'subscribers' ) ) ) {
-			selectFilter = <StatsModuleSelectDropdown options={ options } onSelect={ this.changeFilter } />;
+	filterSelect() {
+		const { emailData, wpcomData } = this.props;
+		const hasEmailFollowers = !! get( emailData, 'subscribers', [] ).length;
+		const hasWpcomFollowers = !! get( wpcomData, 'subscribers', [] ).length;
+		if ( ! hasWpcomFollowers || ! hasEmailFollowers ) {
+			return null;
 		}
 
-		return selectFilter;
-	},
+		const options = [
+			{
+				value: 'wpcom-followers',
+				label: this.props.translate( 'WordPress.com Followers' )
+			},
+			{
+				value: 'email-followers',
+				label: this.props.translate( 'Email Followers' )
+			}
+		];
 
-	render: function() {
-		var wpcomData = this.data( 'wpcomFollowersList' ),
-			emailData = this.data( 'emailFollowersList' ),
-			noData = this.props.wpcomFollowersList.isEmpty( 'subscribers' ) && this.props.emailFollowersList.isEmpty( 'subscribers' ),
-			hasError = ( this.props.wpcomFollowersList.isError() || this.props.emailFollowersList.isError() ),
-			isLoading = this.props.wpcomFollowersList.isLoading() || this.props.emailFollowersList.isLoading(),
-			wpcomFollowers,
-			emailFollowers,
-			wpcomTotalFollowers,
-			emailTotalFollowers,
-			summaryPageLink,
-			viewSummary,
-			activeFilter,
-			activeFilterClass,
-			classes;
+		return <StatsModuleSelectDropdown options={ options } onSelect={ this.changeFilter } />;
+	}
 
-		activeFilter = this.state.activeFilter;
-		if ( this.props.wpcomFollowersList.isEmpty( 'subscribers' ) ) {
-			activeFilter = 'email-followers';
-		}
-
-		activeFilterClass = 'tab-' + activeFilter;
-
-		classes = [
+	render() {
+		const {
+			siteId,
+			siteSlug,
+			wpcomData,
+			emailData,
+			requestingWpcomFollowers,
+			requestingEmailFollowers,
+			hasEmailQueryFailed,
+			hasWpcomQueryFailed,
+			translate,
+			numberFormat
+		} = this.props;
+		const isLoading = requestingWpcomFollowers || requestingEmailFollowers;
+		const hasEmailFollowers = !! get( emailData, 'subscribers', [] ).length;
+		const hasWpcomFollowers = !! get( wpcomData, 'subscribers', [] ).length;
+		const noData = ! hasWpcomFollowers && ! hasEmailFollowers;
+		const activeFilter = ! hasWpcomFollowers ? 'email-followers' : this.state.activeFilter;
+		const activeFilterClass = 'tab-' + activeFilter;
+		const hasError = hasEmailQueryFailed || hasWpcomQueryFailed;
+		const classes = [
 			'stats-module',
 			'is-followers',
 			activeFilterClass,
@@ -119,72 +107,95 @@ module.exports = React.createClass( {
 			}
 		];
 
-		const summaryPageSlug = this.props.site ? this.props.site.slug : '';
-		if ( 'email-followers' === activeFilter ) {
-			summaryPageLink = '/stats/follows/email/' + summaryPageSlug;
-		} else {
-			summaryPageLink = '/stats/follows/wpcom/' + summaryPageSlug;
-		}
-
-		if ( wpcomData && wpcomData.subscribers ) {
-			wpcomFollowers = <StatsList moduleName="wpcomFollowers" data={ wpcomData.subscribers } followList={ this.props.followList } />;
-		}
-
-		if ( emailData && emailData.subscribers ) {
-			emailFollowers = <StatsList moduleName="EmailFollowers" data={ emailData.subscribers } />;
-		}
-
-		if ( wpcomData && wpcomData.total ) {
-			wpcomTotalFollowers = <p>{ this.translate( 'Total WordPress.com Followers' ) }: { this.numberFormat( wpcomData.total ) }</p>;
-		}
-
-		if ( emailData && emailData.total ) {
-			emailTotalFollowers = <p>{ this.translate( 'Total Email Followers' ) }: { this.numberFormat( emailData.total ) }</p>;
-		}
-
-		if ( ( wpcomData && wpcomData.viewAll ) || ( emailData && emailData.viewAll ) ) {
-			viewSummary = (
-				<div key="view-all" className="module-expand">
-					<a href={ summaryPageLink }>{ this.translate( 'View All', { context: 'Stats: Button label to expand a panel' } ) }<span className="right"></span></a>
-				</div>
-				);
-		}
+		const summaryPageSlug = siteSlug || '';
+		const summaryPageLink = 'email-followers' === activeFilter
+			? '/stats/follows/email/' + summaryPageSlug
+			: '/stats/follows/wpcom/' + summaryPageSlug;
 
 		return (
 			<div>
-				<SectionHeader label={ this.translate( 'Followers' ) } href={ summaryPageLink } />
-				<Card className={ classNames.apply( null, classes ) }>
+				<QuerySiteStats statType="statsFollowers" siteId={ siteId } query={ { type: 'wpcom', max: 7 } } />
+				<QuerySiteStats statType="statsFollowers" siteId={ siteId } query={ { type: 'email', max: 7 } } />
+				<SectionHeader label={ translate( 'Followers' ) } href={ summaryPageLink } />
+				<Card className={ classNames( ...classes ) }>
 					<div className="followers">
 						<div className="module-content">
-							{ noData && ! hasError ? <ErrorPanel className="is-empty-message" message={ this.translate( 'No followers' ) } /> : null }
+							{ noData && ! hasError &&
+								<ErrorPanel className="is-empty-message" message={ translate( 'No followers' ) } />
+							}
 
 							{ this.filterSelect() }
 
 							<div className="tab-content wpcom-followers stats-async-metabox-wrapper">
 								<div className="module-content-text module-content-text-stat">
-									{ wpcomTotalFollowers }
+									{ wpcomData && !! wpcomData.total_wpcom &&
+										<p>{ translate( 'Total WordPress.com Followers' ) }: { numberFormat( wpcomData.total_wpcom ) }</p>
+									}
 								</div>
-								<StatsListLegend value={ this.translate( 'Since' ) } label={ this.translate( 'Follower' ) } />
-								{ wpcomFollowers }
-								{ this.props.wpcomFollowersList.isError() ? <ErrorPanel className="is-error" /> : null }
+								<StatsListLegend value={ translate( 'Since' ) } label={ translate( 'Follower' ) } />
+								{ hasWpcomFollowers &&
+									<StatsList moduleName="wpcomFollowers"
+										data={ wpcomData.subscribers }
+										followList={ this.props.followList }
+									/>
+								}
+								{ hasWpcomQueryFailed && <ErrorPanel className="is-error" /> }
 							</div>
 
 							<div className="tab-content email-followers stats-async-metabox-wrapper">
 								<div className="module-content-text module-content-text-stat">
-									{ emailTotalFollowers }
+									{ emailData && !! emailData.total_email &&
+										<p>{ translate( 'Total Email Followers' ) }: { numberFormat( emailData.total_email ) }</p>
+									}
 								</div>
 
-								<StatsListLegend value={ this.translate( 'Since' ) } label={ this.translate( 'Follower' ) } />
-								{ emailFollowers }
-								{ this.props.emailFollowersList.isError() ? <ErrorPanel className={ 'network-error' } /> : null }
+								<StatsListLegend value={ translate( 'Since' ) } label={ translate( 'Follower' ) } />
+								{ hasEmailFollowers && <StatsList moduleName="EmailFollowers" data={ emailData.subscribers } /> }
+								{ hasEmailQueryFailed && <ErrorPanel className={ 'network-error' } /> }
 							</div>
 
 							<StatsModulePlaceholder isLoading={ isLoading } />
 						</div>
-						{ viewSummary }
+						{ (
+								( wpcomData && wpcomData.subscribers.length !== wpcomData.total_subscribers ) ||
+								( emailData && emailData.subscribers.length !== emailData.total_subscribers )
+							) &&
+							<div key="view-all" className="module-expand">
+								<a href={ summaryPageLink }>
+									{ translate( 'View All', { context: 'Stats: Button label to expand a panel' } ) }
+									<span className="right"></span>
+								</a>
+							</div>
+						}
 					</div>
 				</Card>
 			</div>
 		);
 	}
-} );
+}
+
+const connectComponent = connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const siteSlug = getSiteSlug( state, siteId );
+		const emailQuery = { type: 'email', max: 7 };
+		const wpcomQuery = { type: 'wpcom', max: 7 };
+
+		return {
+			requestingEmailFollowers: isRequestingSiteStatsForQuery( state, siteId, 'statsFollowers', emailQuery ),
+			emailData: getSiteStatsNormalizedData( state, siteId, 'statsFollowers', emailQuery ),
+			hasEmailQueryFailed: hasSiteStatsQueryFailed( state, siteId, 'statsFollowers', emailQuery ),
+			requestingWpcomFollowers: isRequestingSiteStatsForQuery( state, siteId, 'statsFollowers', wpcomQuery ),
+			wpcomData: getSiteStatsNormalizedData( state, siteId, 'statsFollowers', wpcomQuery ),
+			hasWpcomQueryFailed: hasSiteStatsQueryFailed( state, siteId, 'statsFollowers', wpcomQuery ),
+			siteId,
+			siteSlug
+		};
+	},
+	{ recordGoogleEvent }
+);
+
+export default flowRight(
+	connectComponent,
+	localize
+)( StatModuleFollowers );

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -30,27 +30,23 @@ export default React.createClass( {
 	propTypes: {
 		commentFollowersList: PropTypes.object.isRequired,
 		commentsList: PropTypes.object.isRequired,
-		emailFollowersList: PropTypes.object.isRequired,
 		followList: PropTypes.object.isRequired,
 		site: React.PropTypes.oneOfType( [
 			React.PropTypes.bool,
 			React.PropTypes.object
 		] ),
 		summaryDate: PropTypes.string,
-		wpcomFollowersList: PropTypes.object
 	},
 
 	render() {
 		const {
 			commentFollowersList,
 			commentsList,
-			emailFollowersList,
 			followList,
 			site,
-			wpcomFollowersList } = this.props;
+		} = this.props;
 
 		const moduleStrings = statsStrings();
-
 
 		let momentSiteZone = i18n.moment();
 
@@ -107,8 +103,6 @@ export default React.createClass( {
 								<Followers
 									path={ 'followers' }
 									site={ site }
-									wpcomFollowersList={ wpcomFollowersList }
-									emailFollowersList={ emailFollowersList }
 									followList={ followList } />
 								<StatsConnectedModule
 									path="publicize"

--- a/client/state/stats/lists/reducer.js
+++ b/client/state/stats/lists/reducer.js
@@ -21,7 +21,7 @@ import {
 
 /**
  * Returns the updated requests state after an action has been dispatched. The
- * state maps site ID, post ID and stat keys to whether a request status.
+ * state maps site ID, post ID and stat keys to the request stats.
  *
  * @param  {Object} state  Current state
  * @param  {Object} action Action payload

--- a/client/state/stats/lists/reducer.js
+++ b/client/state/stats/lists/reducer.js
@@ -7,12 +7,12 @@ import { merge, unset } from 'lodash';
 /**
  * Internal dependencies
  */
+import { createReducer } from 'state/utils';
 import { isValidStateWithSchema } from 'state/utils';
 import { getSerializedStatsQuery } from './utils';
 import { itemSchema } from './schema';
 import {
 	DESERIALIZE,
-	SERIALIZE,
 	SITE_STATS_RECEIVE,
 	SITE_STATS_REQUEST,
 	SITE_STATS_REQUEST_FAILURE,
@@ -21,33 +21,44 @@ import {
 
 /**
  * Returns the updated requests state after an action has been dispatched. The
- * state maps site ID, post ID and stat keys to whether a request is in progress.
+ * state maps site ID, post ID and stat keys to whether a request status.
  *
  * @param  {Object} state  Current state
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export function requesting( state = {}, action ) {
-	switch ( action.type ) {
-		case SITE_STATS_REQUEST:
-		case SITE_STATS_REQUEST_SUCCESS:
-		case SITE_STATS_REQUEST_FAILURE:
-			const queryKey = getSerializedStatsQuery( action.query );
-			return merge( {}, state, {
-				[ action.siteId ]: {
-					[ action.statType ]: {
-						[ queryKey ]: SITE_STATS_REQUEST === action.type
-					}
+export const requests = createReducer( {}, {
+	[ SITE_STATS_REQUEST ]: ( state, { siteId, statType, query } ) => {
+		const queryKey = getSerializedStatsQuery( query );
+		return merge( {}, state, {
+			[ siteId ]: {
+				[ statType ]: {
+					[ queryKey ]: { requesting: true, status: 'pending' }
 				}
-			} );
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
+			}
+		} );
+	},
+	[ SITE_STATS_REQUEST_SUCCESS ]: ( state, { siteId, statType, query } ) => {
+		const queryKey = getSerializedStatsQuery( query );
+		return merge( {}, state, {
+			[ siteId ]: {
+				[ statType ]: {
+					[ queryKey ]: { requesting: false, status: 'success' }
+				}
+			}
+		} );
+	},
+	[ SITE_STATS_REQUEST_FAILURE ]: ( state, { siteId, statType, query } ) => {
+		const queryKey = getSerializedStatsQuery( query );
+		return merge( {}, state, {
+			[ siteId ]: {
+				[ statType ]: {
+					[ queryKey ]: { requesting: false, status: 'error' }
+				}
+			}
+		} );
 	}
-
-	return state;
-}
+} );
 
 /**
  * Returns the updated items state after an action has been dispatched. The
@@ -86,6 +97,6 @@ export function items( state = {}, action ) {
 }
 
 export default combineReducers( {
-	requesting,
+	requests,
 	items
 } );

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -27,7 +27,22 @@ import { getSite } from 'state/sites/selectors';
  */
 export function isRequestingSiteStatsForQuery( state, siteId, statType, query ) {
 	const serializedQuery = getSerializedStatsQuery( query );
-	return !! get( state.stats.lists.requesting, [ siteId, statType, serializedQuery ] );
+	return !! get( state.stats.lists.requests, [ siteId, statType, serializedQuery, 'requesting' ] );
+}
+
+/**
+ * Returns true if the stats request for the statType and query combo has failed, or false
+ * otherwise.
+ *
+ * @param  {Object}  state    Global state tree
+ * @param  {Number}  siteId   Site ID
+ * @param  {String}  statType Type of stat
+ * @param  {Object}  query    Stats query object
+ * @return {Boolean}          Whether stats are being requested
+ */
+export function hasSiteStatsQueryFailed( state, siteId, statType, query ) {
+	const serializedQuery = getSerializedStatsQuery( query );
+	return get( state.stats.lists.requests, [ siteId, statType, serializedQuery, 'status' ] ) === 'error';
 }
 
 /**

--- a/client/state/stats/lists/test/reducer.js
+++ b/client/state/stats/lists/test/reducer.js
@@ -18,7 +18,7 @@ import {
 } from 'state/action-types';
 import reducer, {
 	items,
-	requesting
+	requests
 } from '../reducer';
 
 /**
@@ -48,20 +48,20 @@ describe( 'reducer', () => {
 
 	it( 'should include expected keys in return value', () => {
 		expect( reducer( undefined, {} ) ).to.have.keys( [
-			'requesting',
+			'requests',
 			'items'
 		] );
 	} );
 
-	describe( 'requesting()', () => {
+	describe( 'requests()', () => {
 		it( 'should default to an empty object', () => {
-			const state = requesting( undefined, {} );
+			const state = requests( undefined, {} );
 
 			expect( state ).to.eql( {} );
 		} );
 
 		it( 'should track stats list request fetching', () => {
-			const state = requesting( undefined, {
+			const state = requests( undefined, {
 				type: SITE_STATS_REQUEST,
 				siteId: 2916284,
 				statType: 'statsStreak',
@@ -71,7 +71,7 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( {
 				2916284: {
 					statsStreak: {
-						'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': true
+						'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': { requesting: true, status: 'pending' }
 					}
 				}
 			} );
@@ -81,12 +81,12 @@ describe( 'reducer', () => {
 			const original = deepFreeze( {
 				2916284: {
 					statsStreak: {
-						'[["endDate","2016-07-01"],["startDate","2016-06-01"]]': true
+						'[["endDate","2016-07-01"],["startDate","2016-06-01"]]': { requesting: true, status: 'pending' }
 					}
 				}
 			} );
 
-			const state = requesting( original, {
+			const state = requests( original, {
 				type: SITE_STATS_REQUEST,
 				siteId: 2916284,
 				statType: 'statsStreak',
@@ -96,15 +96,15 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( {
 				2916284: {
 					statsStreak: {
-						'[["endDate","2016-07-01"],["startDate","2016-06-01"]]': true,
-						'[["endDate","2015-06-01"],["startDate","2014-06-01"]]': true
+						'[["endDate","2016-07-01"],["startDate","2016-06-01"]]': { requesting: true, status: 'pending' },
+						'[["endDate","2015-06-01"],["startDate","2014-06-01"]]': { requesting: true, status: 'pending' }
 					}
 				}
 			} );
 		} );
 
 		it( 'should track stats request success', () => {
-			const state = requesting( undefined, {
+			const state = requests( undefined, {
 				type: SITE_STATS_REQUEST_SUCCESS,
 				siteId: 2916284,
 				statType: 'statsStreak',
@@ -114,14 +114,14 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( {
 				2916284: {
 					statsStreak: {
-						'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': false
+						'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': { requesting: false, status: 'success' }
 					}
 				}
 			} );
 		} );
 
 		it( 'should track stats request failure', () => {
-			const state = requesting( undefined, {
+			const state = requests( undefined, {
 				type: SITE_STATS_REQUEST_FAILURE,
 				siteId: 2916284,
 				statType: 'statsStreak',
@@ -132,7 +132,7 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( {
 				2916284: {
 					statsStreak: {
-						'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': false
+						'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': { requesting: false, status: 'error' }
 					}
 				}
 			} );
@@ -142,12 +142,12 @@ describe( 'reducer', () => {
 			const original = deepFreeze( {
 				2916284: {
 					statsStreak: {
-						'[["endDate","2016-07-01"],["startDate","2016-06-01"]]': true
+						'[["endDate","2016-07-01"],["startDate","2016-06-01"]]': { requesting: true, status: 'pending' }
 					}
 				}
 			} );
 
-			const state = requesting( original, { type: SERIALIZE } );
+			const state = requests( original, { type: SERIALIZE } );
 
 			expect( state ).to.eql( {} );
 		} );
@@ -156,12 +156,12 @@ describe( 'reducer', () => {
 			const original = deepFreeze( {
 				2916284: {
 					statsStreak: {
-						'[["endDate","2016-07-01"],["startDate","2016-06-01"]]': true
+						'[["endDate","2016-07-01"],["startDate","2016-06-01"]]': { requesting: true, status: 'pending' }
 					}
 				}
 			} );
 
-			const state = requesting( original, { type: DESERIALIZE } );
+			const state = requests( original, { type: DESERIALIZE } );
 
 			expect( state ).to.eql( {} );
 		} );

--- a/client/state/stats/lists/test/selectors.js
+++ b/client/state/stats/lists/test/selectors.js
@@ -15,6 +15,7 @@ import {
 	getSiteStatsNormalizedData,
 	isRequestingSiteStatsForQuery,
 	getSiteStatsCSVData,
+	hasSiteStatsQueryFailed,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -30,7 +31,7 @@ describe( 'selectors', () => {
 			const requesting = isRequestingSiteStatsForQuery( {
 				stats: {
 					lists: {
-						requesting: {}
+						requests: {}
 					}
 				}
 			}, 2916284, 'statsStreak', {} );
@@ -42,10 +43,10 @@ describe( 'selectors', () => {
 			const requesting = isRequestingSiteStatsForQuery( {
 				stats: {
 					lists: {
-						requesting: {
+						requests: {
 							2916284: {
 								statsStreak: {
-									'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': false
+									'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': { requesting: false }
 								}
 							}
 						}
@@ -60,10 +61,10 @@ describe( 'selectors', () => {
 			const requesting = isRequestingSiteStatsForQuery( {
 				stats: {
 					lists: {
-						requesting: {
+						requests: {
 							2916284: {
 								statsStreak: {
-									'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': true
+									'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': { requesting: true }
 								}
 							}
 						}
@@ -72,6 +73,56 @@ describe( 'selectors', () => {
 			}, 2916284, 'statsStreak', { startDate: '2015-06-01', endDate: '2016-06-01' } );
 
 			expect( requesting ).to.be.true;
+		} );
+	} );
+
+	describe( 'hasSiteStatsQueryFailed()', () => {
+		it( 'should return false if no request exists', () => {
+			const hasFailed = hasSiteStatsQueryFailed( {
+				stats: {
+					lists: {
+						requests: {}
+					}
+				}
+			}, 2916284, 'statsStreak', {} );
+
+			expect( hasFailed ).to.be.false;
+		} );
+
+		it( 'should return false if the request status is success', () => {
+			const hasFailed = hasSiteStatsQueryFailed( {
+				stats: {
+					lists: {
+						requests: {
+							2916284: {
+								statsStreak: {
+									'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': { requesting: false, status: 'success' }
+								}
+							}
+						}
+					}
+				}
+			}, 2916284, 'statsStreak', { startDate: '2015-06-01', endDate: '2016-06-01' } );
+
+			expect( hasFailed ).to.be.false;
+		} );
+
+		it( 'should return true if the request status is error', () => {
+			const hasFailed = hasSiteStatsQueryFailed( {
+				stats: {
+					lists: {
+						requests: {
+							2916284: {
+								statsStreak: {
+									'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': { requesting: false, status: 'error' }
+								}
+							}
+						}
+					}
+				}
+			}, 2916284, 'statsStreak', { startDate: '2015-06-01', endDate: '2016-06-01' } );
+
+			expect( hasFailed ).to.be.true;
 		} );
 	} );
 


### PR DESCRIPTION
In this PR I'm using the `QueryStatsList` instead of `StatsList` for the followers component on the stats insights page.

I had to track the status of the request on the Redux state as well (whether it has failed or succeeded).

**Testing instructions**

 - Navigate to the stats insight page `/stats/insights/$site`
 - The followers component should work exactly like on master.