### PR TITLE
State Analytics: fix "property of undefined" error

### DIFF
--- a/client/state/analytics/actions.js
+++ b/client/state/analytics/actions.js
@@ -25,6 +25,7 @@ export const composeAnalytics = ( ...analytics ) => ( {
 	type: ANALYTICS_MULTI_TRACK,
 	meta: {
 		analytics: analytics.map( property( 'meta.analytics' ) )
+		analytics: analytics.map( property( 'meta.analytics[0]' ) )
 	}
 } );
 

--- a/client/state/analytics/actions.js
+++ b/client/state/analytics/actions.js
@@ -1,8 +1,13 @@
-import curry from 'lodash/curry';
-import get from 'lodash/get';
-import isFunction from 'lodash/isFunction';
-import merge from 'lodash/merge';
-import property from 'lodash/property';
+/**
+ * External dependencies
+ */
+import {
+	curry,
+	get,
+	isFunction,
+	merge,
+	property,
+} from 'lodash';
 
 import {
 	ANALYTICS_EVENT_RECORD,
@@ -18,13 +23,15 @@ const mergedMetaData = ( a, b ) => [
 
 const joinAnalytics = ( analytics, action ) =>
 	isFunction( action )
-		? dispatch => { dispatch( analytics ); dispatch( action ); }
+		? dispatch => {
+			dispatch( analytics );
+			dispatch( action );
+		}
 		: merge( {}, action, { meta: { analytics: mergedMetaData( analytics, action ) } } );
 
 export const composeAnalytics = ( ...analytics ) => ( {
 	type: ANALYTICS_MULTI_TRACK,
 	meta: {
-		analytics: analytics.map( property( 'meta.analytics' ) )
 		analytics: analytics.map( property( 'meta.analytics[0]' ) )
 	}
 } );

--- a/client/state/analytics/actions.js
+++ b/client/state/analytics/actions.js
@@ -3,6 +3,7 @@
  */
 import {
 	curry,
+	flatMap,
 	get,
 	isFunction,
 	merge,
@@ -32,7 +33,7 @@ const joinAnalytics = ( analytics, action ) =>
 export const composeAnalytics = ( ...analytics ) => ( {
 	type: ANALYTICS_MULTI_TRACK,
 	meta: {
-		analytics: analytics.map( property( 'meta.analytics[0]' ) )
+		analytics: flatMap( analytics, property( 'meta.analytics' ) ),
 	}
 } );
 

--- a/client/state/analytics/test/actions.js
+++ b/client/state/analytics/test/actions.js
@@ -1,9 +1,17 @@
-import flowRight from 'lodash/flowRight';
+/**
+ * External dependencies
+ */
+import { flowRight } from 'lodash';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 
-import { ANALYTICS_MULTI_TRACK } from 'state/action-types';
-
+/**
+ * Internal dependencies
+ */
+import {
+	ANALYTICS_MULTI_TRACK,
+	ANALYTICS_STAT_BUMP,
+} from 'state/action-types';
 import {
 	composeAnalytics,
 	withAnalytics,
@@ -35,9 +43,20 @@ describe( 'middleware', () => {
 				bumpStat( 'spline_types', 'ocean' ),
 				bumpStat( 'spline_types', 'river' )
 			);
+			const expected = [
+				{
+					type: ANALYTICS_STAT_BUMP,
+					payload: { group: 'spline_types', name: 'ocean' }
+				},
+				{
+					type: ANALYTICS_STAT_BUMP,
+					payload: { group: 'spline_types', name: 'river' }
+				}
+			];
 
 			expect( composite.type ).to.equal( ANALYTICS_MULTI_TRACK );
 			expect( composite.meta.analytics ).to.have.lengthOf( 2 );
+			expect( composite.meta.analytics ).to.deep.equal( expected );
 		} );
 
 		it( 'should compose multiple analytics calls without other actions', () => {


### PR DESCRIPTION
In #10879 I tried to use `composeAnalytics` to dispatch both Tracks and GA event recordings together and I incurred in this bug.

Analytics actions are objects like this:
```js
const action = {
  type: ANALYTICS_EVENT_RECORD,
  meta: {
    analytics: [
      {
        type: ANALYTICS_EVENT_RECORD,
        payload: {
          service: 'tracks',
          properties: { ... }
        }
      }
    ]
  }
};
```
Notice that the `meta.analytics` property is an **array**, with only one element in order to be ready to be "composed".
In the [middleware dispatcher](https://github.com/Automattic/wp-calypso/blob/master/client/state/analytics/middleware.js#L23-L38) there's a `forEach` that takes care of this.

Now, `composeAnalytics` takes any number of analytics actions and lines up all their (single-element) `meta.analytics` into a new `meta.analytics` (now inevitably multi-element) using the following [function](https://github.com/Automattic/wp-calypso/blob/master/client/state/analytics/actions.js#L27):
`meta: { analytics: { action.map( _.property( 'meta.analytics' ) ) } }`.

What happens, though, is that `_.property` takes the whole single-element `meta.analytics` array, **not just its content**, and puts it in the new `meta.analytics` array, which will then become an **array of arrays** (of single objects)
```
{
  ...
  analytics: {
    [
      [
        { firstActionMetaAnalytics }
      ],
      [
        { secondActionMetaAnalytics }
      ]
    ]
  }
}
```

instead of an array of objects as expected by the dispatcher.
```
{
  ...
  analytics: {
    [
      { firstActionMetaAnalytics },
      { secondActionMetaAnalytics }
    ]
  }
}
```

Therefore, the dispatcher won't be able to find the payload properties it needs (which are located one level deeper in the array-of-arrays), and will throw a console error.

---

My fix simply assumes that each action that will be passed to `composeAnalytics` has a single-element `meta.analytics` array, and so it takes the first (**only**) element and puts it into the new `meta.analytics` array:
`meta: { analytics: { action.map( _.property( 'meta.analytics[0]' ) ) } }`.

I've chosen this over a nested `map` since there is no reason to have multi-element `meta.analytics` actions, as that's exactly why we have `composeAnalytics` in the first place.