### PR TITLE
Jetpack Settings: Disable Subscriptions sub-settings instead of hiding

### DIFF
--- a/client/my-sites/site-settings/subscriptions/index.jsx
+++ b/client/my-sites/site-settings/subscriptions/index.jsx
@@ -45,37 +45,33 @@ const Subscriptions = ( {
 					disabled={ isRequestingSettings || isSavingSettings }
 					/>
 
-				{
-					subscriptionsModuleActive && (
-						<div className="subscriptions__module-settings is-indented">
-							<FormToggle
-								className="subscriptions__module-settings-toggle is-compact"
-								checked={ !! fields.stb_enabled }
-								disabled={ isRequestingSettings || isSavingSettings }
-								onChange={ handleToggle( 'stb_enabled' ) }>
-								<span className="site-settings__toggle-label">
-									{ translate( 'Show a "follow blog" option in the comment form' ) }
-								</span>
-							</FormToggle>
+				<div className="subscriptions__module-settings is-indented">
+					<FormToggle
+						className="subscriptions__module-settings-toggle is-compact"
+						checked={ !! fields.stb_enabled }
+						disabled={ isRequestingSettings || isSavingSettings || ! subscriptionsModuleActive }
+						onChange={ handleToggle( 'stb_enabled' ) }>
+						<span className="site-settings__toggle-label">
+							{ translate( 'Show a "follow blog" option in the comment form' ) }
+						</span>
+					</FormToggle>
 
-							<FormToggle
-								className="subscriptions__module-settings-toggle is-compact"
-								checked={ !! fields.stc_enabled }
-								disabled={ isRequestingSettings || isSavingSettings }
-								onChange={ handleToggle( 'stc_enabled' ) }>
-								<span className="site-settings__toggle-label">
-									{ translate( 'Show a "follow comments" option in the comment form.' ) }
-								</span>
-							</FormToggle>
+					<FormToggle
+						className="subscriptions__module-settings-toggle is-compact"
+						checked={ !! fields.stc_enabled }
+						disabled={ isRequestingSettings || isSavingSettings || ! subscriptionsModuleActive }
+						onChange={ handleToggle( 'stc_enabled' ) }>
+						<span className="site-settings__toggle-label">
+							{ translate( 'Show a "follow comments" option in the comment form.' ) }
+						</span>
+					</FormToggle>
 
-							<p className="subscriptions__email-followers">
-								<a href={ '/people/email-followers/' + selectedSiteSlug }>
-									{ translate( 'View your Email Followers' ) }
-								</a>
-							</p>
-						</div>
-					)
-				}
+					<p className="subscriptions__email-followers">
+						<a href={ '/people/email-followers/' + selectedSiteSlug }>
+							{ translate( 'View your Email Followers' ) }
+						</a>
+					</p>
+				</div>
 			</FormFieldset>
 		</Card>
 	);


### PR DESCRIPTION
This PR updates the sub-settings of the Subscriptions card in Discussion Settings to get disabled instead of being hidden when the corresponding module is not active. As suggested by @MichaelArestad and @rickybanister.

#### Preview:

##### DIsabled module
![](https://cldup.com/_wA9260bN5.png)

##### Enabled module
![](https://cldup.com/ESa-eMbb3g.png)

#### To test

* Checkout this branch
* Go to `/settings/discussion/$site` where `$site` is one of your sites.
* Verify settings are not hidden, but are disabled when the module is disabled.
* Verify settings are working as before when module is enabled.

