### PR TITLE
Jetpack Settings: Disable Related Posts sub-settings instead of hiding

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -316,41 +316,40 @@ class SiteSettingsFormGeneral extends Component {
 							</span>
 						</FormToggle>
 					</li>
-					{ !! fields.jetpack_relatedposts_enabled && (
-						<li>
-							<ul id="settings-reading-relatedposts-customize" className="site-settings__child-settings">
-								<li>
-									<FormToggle
-										className="is-compact"
-										checked={ !! fields.jetpack_relatedposts_show_headline }
-										disabled={ isRequestingSettings }
-										onChange={ handleToggle( 'jetpack_relatedposts_show_headline' ) }>
-										<span className="site-settings__toggle-label">
-											{ translate(
-												'Show a "Related" header to more clearly separate the related section from posts'
-											) }
-										</span>
-									</FormToggle>
-								</li>
-								<li>
-									<FormToggle
-										className="is-compact"
-										checked={ !! fields.jetpack_relatedposts_show_thumbnails }
-										disabled={ isRequestingSettings }
-										onChange={ handleToggle( 'jetpack_relatedposts_show_thumbnails' ) }>
-										<span className="site-settings__toggle-label">
-											{ translate(
-												'Use a large and visually striking layout'
-											) }
-										</span>
-									</FormToggle>
-								</li>
-							</ul>
-							<RelatedContentPreview
-								showHeadline={ fields.jetpack_relatedposts_show_headline }
-								showThumbnails={ fields.jetpack_relatedposts_show_thumbnails } />
-						</li>
-					) }
+					<li>
+						<ul id="settings-reading-relatedposts-customize" className="site-settings__child-settings">
+							<li>
+								<FormToggle
+									className="is-compact"
+									checked={ !! fields.jetpack_relatedposts_show_headline }
+									disabled={ isRequestingSettings || ! fields.jetpack_relatedposts_enabled }
+									onChange={ handleToggle( 'jetpack_relatedposts_show_headline' ) }>
+									<span className="site-settings__toggle-label">
+										{ translate(
+											'Show a "Related" header to more clearly separate the related section from posts'
+										) }
+									</span>
+								</FormToggle>
+							</li>
+							<li>
+								<FormToggle
+									className="is-compact"
+									checked={ !! fields.jetpack_relatedposts_show_thumbnails }
+									disabled={ isRequestingSettings || ! fields.jetpack_relatedposts_enabled }
+									onChange={ handleToggle( 'jetpack_relatedposts_show_thumbnails' ) }>
+									<span className="site-settings__toggle-label">
+										{ translate(
+											'Use a large and visually striking layout'
+										) }
+									</span>
+								</FormToggle>
+							</li>
+						</ul>
+						<RelatedContentPreview
+							showHeadline={ fields.jetpack_relatedposts_show_headline }
+							showThumbnails={ fields.jetpack_relatedposts_show_thumbnails }
+						/>
+					</li>
 				</ul>
 			</FormFieldset>
 		);

--- a/client/my-sites/site-settings/related-content-preview.jsx
+++ b/client/my-sites/site-settings/related-content-preview.jsx
@@ -45,7 +45,7 @@ const RelatedContentPreview = ( { showHeadline, showThumbnails, translate } ) =>
 
 	return (
 		<div id="settings-reading-relatedposts-preview">
-			<FormLabel>{ translate( 'Preview:' ) }</FormLabel>
+			<FormLabel>{ translate( 'Example:' ) }</FormLabel>
 
 			<div className="site-settings__related-posts">
 				{

--- a/client/my-sites/site-settings/related-content-preview.jsx
+++ b/client/my-sites/site-settings/related-content-preview.jsx
@@ -45,7 +45,7 @@ const RelatedContentPreview = ( { showHeadline, showThumbnails, translate } ) =>
 
 	return (
 		<div id="settings-reading-relatedposts-preview">
-			<FormLabel>{ translate( 'Example:' ) }</FormLabel>
+			<FormLabel>{ translate( 'Example' ) }</FormLabel>
 
 			<div className="site-settings__related-posts">
 				{


### PR DESCRIPTION
This PR updates the sub-settings of the Related Posts card in General Settings to get disabled instead of being hidden when the corresponding module is not active. As suggested by @MichaelArestad and @rickybanister.

#### Preview:

##### DIsabled module
![](https://cldup.com/Ic32iXe6HR.png)

##### Enabled module
![](https://cldup.com/wevqNDia61.png)

#### To test

* Checkout this branch.
* Go to `/settings/general/$site` where `$site` is one of your sites.
* Verify settings are not hidden, but are disabled when the module is disabled.
* Verify settings are working as before when module is enabled.

