### PR TITLE
Add upload loading skeleton.

### DIFF
--- a/client/components/section-header/index.jsx
+++ b/client/components/section-header/index.jsx
@@ -27,10 +27,10 @@ export default React.createClass( {
 		return (
 			<CompactCard className={ classes } href={ this.props.href }>
 				<div className="section-header__label">
-					<span>{ this.props.label }</span>
+					<span className="section-header__label-text">{ this.props.label }</span>
 					{
 						'number' === typeof this.props.count &&
-						<Count count={ this.props.count } />
+							<Count count={ this.props.count } />
 					}
 				</div>
 				<div className="section-header__actions">

--- a/client/my-sites/themes/themes-upload-card/index.jsx
+++ b/client/my-sites/themes/themes-upload-card/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -25,8 +26,12 @@ class ThemeUploadCard extends React.Component {
 	render() {
 		const { translate } = this.props;
 
+		const uploadClassName = classNames( 'themes-upload-card', {
+			'is-placeholder': this.props.count === null,
+		} );
+
 		return (
-			<div className="themes-upload-card">
+			<div className={ uploadClassName }>
 				<SectionHeader
 					label={ this.props.label || translate( 'WordPress.com themes' ) }
 					count={ this.props.count }

--- a/client/my-sites/themes/themes-upload-card/style.scss
+++ b/client/my-sites/themes/themes-upload-card/style.scss
@@ -40,4 +40,18 @@
 		}
 	}
 
+	&.is-placeholder {
+		.section-header__label-text,
+		.section-header__actions {
+			color: transparent;
+			background-color: lighten( $gray, 30% );
+			animation: loading-fade 1.6s ease-in-out infinite;
+		}
+		.button {
+			color: transparent;
+			background-color: transparent;
+			border-style: none;
+		}
+	}
+
 }


### PR DESCRIPTION
### Info 
Add loading skeleton for Theme upload card. 

### How it looks
![upload_placeholder](https://cloud.githubusercontent.com/assets/17271089/22290207/dc581a5e-e2ff-11e6-9200-b414aaa03e65.gif)

### Testing
Open `/design` and watch how theme upload behaves when loading themes. 