### PR TITLE
Fix themes search analytics warning.

### DIFF
--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -163,7 +163,7 @@ export function requestThemes( siteId, query = {} ) {
 						tier: query.tier,
 						response_time_in_ms: responseTime,
 						result_count: found,
-						results_first_page: filteredThemes.map( property( 'id' ) )
+						results_first_page: filteredThemes.map( property( 'id' ) ).toString()
 					}
 				);
 				dispatch( trackShowcaseSearch );

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -163,7 +163,7 @@ export function requestThemes( siteId, query = {} ) {
 						tier: query.tier,
 						response_time_in_ms: responseTime,
 						result_count: found,
-						results_first_page: filteredThemes.map( property( 'id' ) ).toString()
+						results_first_page: filteredThemes.map( property( 'id' ) ).join()
 					}
 				);
 				dispatch( trackShowcaseSearch );


### PR DESCRIPTION
### Info
PR #6237 introduced warning about sending nested props which are unsupported.
Themes search analytics was sending found themes in an Array - and this is unsupported.
In the end somewhere probably `.toString()` was executed on our prop so it looked alright on Tracks page.
![pasted image at 2017_01_25 13_05](https://cloud.githubusercontent.com/assets/17271089/22290614/289f34e0-e302-11e6-9c80-9d2dae8a60d2.png)
 It looks like we just need to add `.toString()` when sending data to analytics.

### Testing
Open `/design` start searching. 
No `Nested properties are not supported by Tracks. Check...` warning should be issued. 