### PR TITLE
Stats: Reduxify the comments followers stats

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -141,8 +141,6 @@ module.exports = {
 			? site.slug : route.getSiteFragment( context.path );
 
 		const commentsList = new StatsList( { siteID: siteId, statType: 'statsComments', domain: siteDomain } );
-		const commentFollowersList = new StatsList( {
-			siteID: siteId, statType: 'statsCommentFollowers', domain: siteDomain, max: 7 } );
 
 		analytics.pageView.record( basePath, analyticsPageTitle + ' > Insights' );
 
@@ -151,7 +149,6 @@ module.exports = {
 				site: site,
 				followList: followList,
 				commentsList: commentsList,
-				commentFollowersList: commentFollowersList,
 				summaryDate: summaryDate
 			} ),
 			document.getElementById( 'primary' ),

--- a/client/my-sites/stats/stats-comments/index.jsx
+++ b/client/my-sites/stats/stats-comments/index.jsx
@@ -5,7 +5,7 @@ import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { flowRight } from 'lodash';
+import { get, flowRight } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,7 +26,7 @@ import { recordGoogleEvent } from 'state/analytics/actions';
 
 const StatsComments = React.createClass( {
 	propTypes: {
-		commentFollowersData: PropTypes.object,
+		commentFollowersTotal: PropTypes.number,
 		commentsList: PropTypes.object,
 		recordGoogleEvent: PropTypes.func,
 		siteId: PropTypes.number,
@@ -84,9 +84,9 @@ const StatsComments = React.createClass( {
 	},
 
 	renderCommentFollowers() {
-		const { commentFollowersData, siteSlug, translate, numberFormat } = this.props;
+		const { commentFollowersTotal, siteSlug, translate, numberFormat } = this.props;
 
-		if ( ! siteSlug || ! commentFollowersData || ! commentFollowersData.total ) {
+		if ( ! siteSlug || ! commentFollowersTotal ) {
 			return null;
 		}
 
@@ -95,9 +95,8 @@ const StatsComments = React.createClass( {
 		return (
 			<StatsModuleContent className="module-content-text-stat">
 				<p>
-					{ translate( 'Total posts with comment followers:' ) }
-					<a href={ commentFollowURL }>
-						{ numberFormat( commentFollowersData.total ) }
+					{ translate( 'Total posts with comment followers:' ) } <a href={ commentFollowURL }>
+						{ numberFormat( commentFollowersTotal ) }
 					</a>
 				</p>
 			</StatsModuleContent>
@@ -189,7 +188,7 @@ const connectComponent = connect(
 		const siteSlug = getSiteSlug( state, siteId );
 
 		return {
-			commentFollowersData: getSiteStatsNormalizedData( state, siteId, 'statsCommentFollowers', { max: 7 } ),
+			commentFollowersTotal: get( getSiteStatsNormalizedData( state, siteId, 'statsCommentFollowers', { max: 7 } ), 'total' ),
 			siteId,
 			siteSlug
 		};

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -28,7 +28,6 @@ export default React.createClass( {
 	displayName: 'StatsInsights',
 
 	propTypes: {
-		commentFollowersList: PropTypes.object.isRequired,
 		commentsList: PropTypes.object.isRequired,
 		followList: PropTypes.object.isRequired,
 		site: React.PropTypes.oneOfType( [
@@ -40,7 +39,6 @@ export default React.createClass( {
 
 	render() {
 		const {
-			commentFollowersList,
 			commentsList,
 			followList,
 			site,
@@ -93,10 +91,9 @@ export default React.createClass( {
 							<div className="stats__module-column">
 								<Comments
 									path={ 'comments' }
-									site={ site }
 									commentsList={ commentsList }
 									followList={ followList }
-									commentFollowersList={ commentFollowersList } />
+								/>
 								{ tagsList }
 							</div>
 							<div className="stats__module-column">

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -207,6 +207,51 @@ describe( 'utils', () => {
 			} );
 		} );
 
+		describe( 'statsCommentFollowers()', () => {
+			it( 'should return null if no data is provided', () => {
+				const parsedData = normalizers.statsCommentFollowers();
+				expect( parsedData ).to.be.null;
+			} );
+
+			it( 'should properly parse followers response', () => {
+				const parsedData = normalizers.statsCommentFollowers( {
+					page: 1,
+					pages: 1,
+					total: 1,
+					posts: [
+						{
+							id: 0,
+							followers: 20
+						},
+						{
+							id: 1111,
+							title: 'My title',
+							followers: 10,
+							url: 'https://en.blog.wordpress.com/chicken'
+						}
+					]
+				} );
+
+				expect( parsedData ).to.eql( {
+					page: 1,
+					pages: 1,
+					total: 1,
+					posts: [
+						{
+							label: 'All Posts',
+							value: 20
+						},
+						{
+							label: 'My title',
+							labelIcon: 'external',
+							link: 'https://en.blog.wordpress.com/chicken',
+							value: 10
+						}
+					]
+				} );
+			} );
+		} );
+
 		describe( 'statsTopPosts()', () => {
 			it( 'should return an empty array if data is null', () => {
 				const parsedData = normalizers.statsTopPosts();

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -299,6 +299,35 @@ export const normalizers = {
 		return { total_wpcom, total_email, subscribers };
 	},
 
+	statsCommentFollowers( data ) {
+		if ( ! data ) {
+			return null;
+		}
+
+		const page = data.page || 0;
+		const pages = data.pages || 0;
+		const total = data.total || 0;
+		let posts = [];
+		if ( data.posts ) {
+			posts = data.posts.map( ( item ) => {
+				if ( 0 === item.id ) {
+					return {
+						label: 'All Posts',
+						value: item.followers
+					};
+				}
+				return {
+					label: item.title,
+					link: item.url,
+					labelIcon: 'external',
+					value: item.followers
+				};
+			} );
+		}
+
+		return { page, pages, total, posts };
+	},
+
 	/**
 	 * Returns a normalized statsVideo array, ready for use in stats-module
 	 *


### PR DESCRIPTION
 - Create a normalizer for statsCommentsFollowers
 - Use `QueryStatsLists` instead of `StatsLists` on the insights page

**Testing instructions**

 - Navigate to the stats insights page `/stats/insights/$site`
 - The "Total posts with comment followers" on the comments panel should show up correctly
