### PR TITLE
Menus: Fix drag and drop behavior

### DIFF
--- a/client/my-sites/menus/menu-item-list.jsx
+++ b/client/my-sites/menus/menu-item-list.jsx
@@ -57,6 +57,7 @@ var MenuItemList = React.createClass( {
 							editedItem={ this.props.editedItem }
 							setEditItem={ this.props.setEditItem }
 							moveState={ this.props.moveState }
+							draggedItem={ this.props.draggedItem }
 							doMoveItem={ this.props.doMoveItem }
 							addState={ this.props.addState }
 							doAddItem={ this.props.doAddItem }
@@ -183,7 +184,8 @@ var MenuItem = React.createClass( {
 	},
 
 	isBeingDragged: function() {
-		var draggedItem = this.props.dragDrop( 'getDraggedItem' );
+		var draggedItem = this.props.draggedItem;
+
 		return draggedItem &&
 			( draggedItem.id === this.props.item.id ||
 				siteMenus.isAncestor( draggedItem, this.props.item ) );
@@ -394,6 +396,7 @@ var MenuItem = React.createClass( {
 					setEditItem={ this.props.setEditItem }
 					editedItem={ this.props.editedItem }
 					moveState={ this.props.moveState }
+					draggedItem={ this.props.draggedItem }
 					doMoveItem={ this.props.doMoveItem }
 					addState={ this.props.addState }
 					doAddItem={ this.props.doAddItem }

--- a/client/my-sites/menus/menu.jsx
+++ b/client/my-sites/menus/menu.jsx
@@ -38,8 +38,6 @@ var Menu = React.createClass( {
 			this.dragStart( x, y, item );
 		} else if ( 'over' === action ) {
 			this.dragOver( x, y, item );
-		} else if ( 'getDraggedItem' === action ) {
-			return this.state.draggedItem;
 		} else if ( 'end' === action ) {
 			this.draggedItem = null;
 			if ( this.state.draggedItem ) {
@@ -228,6 +226,7 @@ var Menu = React.createClass( {
 						setEditItem={ this.setEditItem }
 						editedItem={ this.getEditItem() }
 						moveState={ this.state.moveState }
+						draggedItem={ this.state.draggedItem }
 						doMoveItem={ this.doMoveItem }
 						addState={ this.state.addState }
 						doAddItem={ this.doAddItem }


### PR DESCRIPTION
This is intended as a fix for #10655. Currently, when you drag and drop a menu item from https://wordpress.com/menus/, the className `is-dragdrop-target` is stuck on the target item even after you drop it. The item only updates when something else causes the item to rerender. 

For example, you can observe the following behavior:
1. Drag and drop an item 
2. Wait to see it doesn't lose the class `is-dragdrop-target`
3. Open notifications from the admin bar
4. See the menu fixes itself

To fix this, I followed a pattern similar to `moveState`. I passed `this.state.draggedItem` down to both `MenuItem` and `MenuItemList`. The item now updates appropriately when dropped. This also removed the need for `dragDrop( 'getDraggedItem' )` in `menu.jsx` since the child component now has a reference to `this.props.dragState` to use instead.

## To test
1. Load up this branch and visit wordpress.com/menus.
2. Try dragging and dropping an item. This should work fine on this branch.

Gif of expected behavior:

![menu](https://cloud.githubusercontent.com/assets/7240478/22293216/06d9381e-e2cc-11e6-83cd-aa713f34531c.gif)