### PR TITLE
Signup: Change signup flow for domain only sites

### DIFF
--- a/client/lib/cart/store/cart-synchronizer.js
+++ b/client/lib/cart/store/cart-synchronizer.js
@@ -56,12 +56,12 @@ function preprocessCartForServer( cart ) {
 	return newCart;
 }
 
-function CartSynchronizer( siteID, wpcom ) {
+function CartSynchronizer( cartKey, wpcom ) {
 	if ( ! ( this instanceof CartSynchronizer ) ) {
-		return new CartSynchronizer( siteID, wpcom );
+		return new CartSynchronizer( cartKey, wpcom );
 	}
 
-	this._siteID = siteID;
+	this._cartKey = cartKey;
 	this._wpcom = wpcom;
 	this._latestValue = null;
 	this._hasLoadedFromServer = false;
@@ -151,7 +151,7 @@ CartSynchronizer.prototype._processQueuedChanges = function() {
 };
 
 CartSynchronizer.prototype._postToServer = function( callback ) {
-	this._wpcom.cart( this._siteID, 'POST', preprocessCartForServer( this._latestValue ), function( error, newValue ) {
+	this._wpcom.cart( this._cartKey, 'POST', preprocessCartForServer( this._latestValue ), function( error, newValue ) {
 		if ( error ) {
 			callback( error );
 			return;
@@ -170,7 +170,7 @@ CartSynchronizer.prototype.fetch = function() {
 };
 
 CartSynchronizer.prototype._getFromServer = function( callback ) {
-	this._wpcom.cart( this._siteID, 'GET', function( error, newValue ) {
+	this._wpcom.cart( this._cartKey, 'GET', function( error, newValue ) {
 		if ( error ) {
 			callback( error );
 			return;

--- a/client/lib/cart/store/index.js
+++ b/client/lib/cart/store/index.js
@@ -22,7 +22,7 @@ var UpgradesActionTypes = require( 'lib/upgrades/constants' ).action,
 	applyCoupon = cartValues.applyCoupon,
 	cartItems = cartValues.cartItems;
 
-var _selectedSiteID = null,
+var _cartItem = null,
 	_synchronizer = null,
 	_poller = null;
 
@@ -51,11 +51,11 @@ function setSelectedSite() {
 	var selectedSite = sites.getSelectedSite();
 
 	if ( ! selectedSite ) {
-		_selectedSiteID = null;
+		_cartItem = null;
 		return;
 	}
 
-	if ( _selectedSiteID === selectedSite.ID ) {
+	if ( _cartItem === selectedSite.ID ) {
 		return;
 	}
 
@@ -64,9 +64,9 @@ function setSelectedSite() {
 		_synchronizer.off( 'change', emitChange );
 	}
 
-	_selectedSiteID = selectedSite.ID;
+	_cartItem = selectedSite.ID;
 
-	_synchronizer = cartSynchronizer( selectedSite.ID, wpcom );
+	_synchronizer = cartSynchronizer( _cartItem, wpcom );
 	_synchronizer.on( 'change', emitChange );
 
 	_poller = PollerPool.add( CartStore, _synchronizer._poll.bind( _synchronizer ) );

--- a/client/lib/cart/store/index.js
+++ b/client/lib/cart/store/index.js
@@ -22,7 +22,7 @@ var UpgradesActionTypes = require( 'lib/upgrades/constants' ).action,
 	applyCoupon = cartValues.applyCoupon,
 	cartItems = cartValues.cartItems;
 
-var _cartItem = null,
+var _cartKey = null,
 	_synchronizer = null,
 	_poller = null;
 
@@ -50,13 +50,14 @@ function hasPendingServerUpdates() {
 function setSelectedSite() {
 	var selectedSite = sites.getSelectedSite();
 
-	if ( ! selectedSite ) {
-		_cartItem = null;
+	if ( _cartKey === selectedSite.ID ) {
 		return;
 	}
 
-	if ( _cartItem === selectedSite.ID ) {
-		return;
+	if ( ! selectedSite ) {
+		_cartKey = 'no-site';
+	} else {
+		_cartKey = selectedSite.ID;
 	}
 
 	if ( _synchronizer && _poller ) {
@@ -64,9 +65,7 @@ function setSelectedSite() {
 		_synchronizer.off( 'change', emitChange );
 	}
 
-	_cartItem = selectedSite.ID;
-
-	_synchronizer = cartSynchronizer( _cartItem, wpcom );
+	_synchronizer = cartSynchronizer( _cartKey, wpcom );
 	_synchronizer.on( 'change', emitChange );
 
 	_poller = PollerPool.add( CartStore, _synchronizer._poll.bind( _synchronizer ) );

--- a/client/lib/cart/store/test/cart-synchronizer.js
+++ b/client/lib/cart/store/test/cart-synchronizer.js
@@ -10,7 +10,7 @@ import CartSynchronizer from '../cart-synchronizer';
 import FakeWPCOM from './fake-wpcom';
 import useFilesystemMocks from 'test/helpers/use-filesystem-mocks';
 
-var TEST_SITE_ID = 91234567890;
+var TEST_CART_KEY = 91234567890;
 
 var poller = {
 	add: function() {}
@@ -31,7 +31,7 @@ describe( 'cart-synchronizer', function() {
 	describe( '*before* the first fetch from the server', function() {
 		it( 'should *not* allow the value to be read', function() {
 			var wpcom = FakeWPCOM(),
-				synchronizer = CartSynchronizer( TEST_SITE_ID, wpcom, poller );
+				synchronizer = CartSynchronizer( TEST_CART_KEY, wpcom, poller );
 
 			assert.throws( () => {
 				synchronizer.getLatestValue();
@@ -40,8 +40,8 @@ describe( 'cart-synchronizer', function() {
 
 		it( 'should enqueue local changes and POST them after fetching', function() {
 			var wpcom = FakeWPCOM(),
-				synchronizer = CartSynchronizer( TEST_SITE_ID, wpcom, poller ),
-				serverCart = emptyCart( TEST_SITE_ID );
+				synchronizer = CartSynchronizer( TEST_CART_KEY, wpcom, poller ),
+				serverCart = emptyCart( TEST_CART_KEY );
 
 			synchronizer.fetch();
 			synchronizer.update( applyCoupon( 'foo' ) );
@@ -63,8 +63,8 @@ describe( 'cart-synchronizer', function() {
 	describe( '*after* the first fetch from the server', function() {
 		it( 'should allow the value to be read', function() {
 			var wpcom = FakeWPCOM(),
-				synchronizer = CartSynchronizer( TEST_SITE_ID, wpcom, poller ),
-				serverCart = emptyCart( TEST_SITE_ID );
+				synchronizer = CartSynchronizer( TEST_CART_KEY, wpcom, poller ),
+				serverCart = emptyCart( TEST_CART_KEY );
 
 			synchronizer.fetch();
 			wpcom.resolveRequest( 0, serverCart );
@@ -75,8 +75,8 @@ describe( 'cart-synchronizer', function() {
 
 	it( 'should make local changes visible immediately', function() {
 		var wpcom = FakeWPCOM(),
-			synchronizer = CartSynchronizer( TEST_SITE_ID, wpcom, poller ),
-			serverCart = emptyCart( TEST_SITE_ID );
+			synchronizer = CartSynchronizer( TEST_CART_KEY, wpcom, poller ),
+			serverCart = emptyCart( TEST_CART_KEY );
 
 		synchronizer.fetch();
 		wpcom.resolveRequest( 0, serverCart );

--- a/client/lib/signup/cart.js
+++ b/client/lib/signup/cart.js
@@ -12,8 +12,8 @@ var wpcom = require( 'lib/wp' ),
 	cartItems = cartValues.cartItems;
 
 module.exports = {
-	addToCart: function( siteSlug, newCartItems, callback ) {
-		wpcom.undocumented().cart( siteSlug, function( error, data ) {
+	addToCart: function( cartKey, newCartItems, callback ) {
+		wpcom.undocumented().cart( cartKey, function( error, data ) {
 			if ( error ) {
 				return callback( error );
 			}
@@ -33,7 +33,7 @@ module.exports = {
 				newCart = cartValues.fillInAllCartItemAttributes( addFunction( newCart ), productsList.get() );
 			} );
 
-			wpcom.undocumented().cart( siteSlug, 'POST', newCart, function( postError ) {
+			wpcom.undocumented().cart( cartKey, 'POST', newCart, function( postError ) {
 				callback( postError );
 			} );
 		} );

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -28,6 +28,19 @@ import {
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import { getSurveyVertical, getSurveySiteType } from 'state/signup/steps/survey/selectors';
 
+function createCart( callback, dependencies, data ) {
+	const { designType } = dependencies;
+	const { domainItem, themeItem } = data;
+
+	if ( designType === 'domain' ) {
+		// TODO: Find a way to create cart without a site
+		// SignupCart.addToCart depends on the site's slug
+		callback( undefined, [ null, null, domainItem, themeItem ] );
+	} else {
+		createSiteWithCart( callback, dependencies, data );
+	}
+}
+
 function createSiteWithCart( callback, dependencies, {
 	cartItem,
 	domainItem,
@@ -49,8 +62,6 @@ function createSiteWithCart( callback, dependencies, {
 			// query. See `getThemeSlug` in `DomainsStep`.
 			theme: dependencies.themeSlugWithRepo || themeSlugWithRepo,
 			vertical: surveyVertical || undefined,
-			// the API wants the `is_domain_only` flag provided as a number
-			is_domain_only: dependencies.designType === 'domain' ? 1 : 0
 		},
 		validate: false,
 		find_available_url: isPurchasingItem
@@ -222,7 +233,9 @@ function getUsernameSuggestion( username, reduxState ) {
 }
 
 module.exports = {
-	createSiteWithCart: createSiteWithCart,
+	createCart,
+
+	createSiteWithCart,
 
 	createSiteWithCartAndStartFreeTrial( callback, dependencies, data ) {
 		createSiteWithCart( ( error, providedDependencies ) => {

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -321,6 +321,8 @@ module.exports = {
 		} );
 	},
 
+	fetchSitesAndUser: fetchSitesAndUser,
+
 	setThemeOnSite: setThemeOnSite,
 
 	getUsernameSuggestion: getUsernameSuggestion

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -33,9 +33,15 @@ function createCart( callback, dependencies, data ) {
 	const { domainItem, themeItem } = data;
 
 	if ( designType === 'domain' ) {
-		// TODO: Find a way to create cart without a site
-		// SignupCart.addToCart depends on the site's slug
-		callback( undefined, [ null, null, domainItem, themeItem ] );
+		const cartKey = 'no-site';
+		const providedDependencies = {
+			siteId: null,
+			siteSlug: cartKey,
+			domainItem,
+			themeItem
+		};
+
+		SignupCart.addToCart( cartKey, [ domainItem ], error => callback( error, providedDependencies ) );
 	} else {
 		createSiteWithCart( callback, dependencies, data );
 	}

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -643,14 +643,14 @@ Undocumented.prototype.getSitePlans = function( siteDomain, fn ) {
 /**
  * GET/POST cart
  *
- * @param {string} [siteDomain] The site's slug
+ * @param {string} [cartKey] The cart's key
  * @param {string} [method] The request method
  * @param {object} [data] The REQUEST data
  * @param {Function} fn The callback function
  * @api public
  */
-Undocumented.prototype.cart = function( siteDomain, method, data, fn ) {
-	debug( '/sites/:site_id:/shopping-cart query' );
+Undocumented.prototype.cart = function( cartKey, method, data, fn ) {
+	debug( '/me/shopping-cart/:cart-key query' );
 	if ( arguments.length === 2 ) {
 		fn = method;
 		method = 'GET';
@@ -661,7 +661,7 @@ Undocumented.prototype.cart = function( siteDomain, method, data, fn ) {
 		data = {};
 	}
 	return this._sendRequestWithLocale( {
-		path: '/sites/' + siteDomain + '/shopping-cart',
+		path: '/me/shopping-cart/' + cartKey,
 		method: method,
 		body: data
 	}, fn );

--- a/client/my-sites/upgrades/cart/cart-plan-ad.jsx
+++ b/client/my-sites/upgrades/cart/cart-plan-ad.jsx
@@ -31,6 +31,7 @@ class CartPlanAd extends Component {
 			cart.hasLoadedFromServer &&
 			! cartItems.hasDomainCredit( cart ) &&
 			cartItems.getDomainRegistrations( cart ).length === 1 &&
+			selectedSite &&
 			selectedSite.plan &&
 			! isPlan( selectedSite.plan );
 	}

--- a/client/my-sites/upgrades/cart/cart-plan-ad.jsx
+++ b/client/my-sites/upgrades/cart/cart-plan-ad.jsx
@@ -4,7 +4,7 @@
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 
 /**
  * Internal dependencies
@@ -53,6 +53,15 @@ class CartPlanAd extends Component {
 		);
 	}
 }
+
+CartPlanAd.propTypes = {
+	cart: PropTypes.object.isRequired,
+	isDomainOnlySite: PropTypes.bool,
+	selectedSite: PropTypes.oneOfType( [
+		PropTypes.bool,
+		PropTypes.object
+	] )
+};
 
 export default connect(
 	( state ) => {

--- a/client/my-sites/upgrades/cart/secondary-cart.jsx
+++ b/client/my-sites/upgrades/cart/secondary-cart.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -17,6 +17,14 @@ import observe from 'lib/mixins/data-observe';
 import CartBodyLoadingPlaceholder from 'my-sites/upgrades/cart/cart-body/loading-placeholder';
 
 const SecondaryCart = React.createClass( {
+	propTypes: {
+		cart: PropTypes.object.isRequired,
+		selectedSite: PropTypes.oneOfType( [
+			PropTypes.bool,
+			PropTypes.object
+		] )
+	},
+
 	mixins: [ CartMessagesMixin, observe( 'sites' ) ],
 
 	render() {

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -277,7 +277,12 @@ const Checkout = React.createClass( {
 		}
 
 		if ( cart.create_new_blog ) {
+			notices.info(
+				this.translate( 'Almost done…' )
+			);
+
 			const domainName = cartItems.getDomainRegistrations( cart )[ 0 ].meta;
+
 			fetchSitesAndUser( domainName, () => {
 				page( redirectPath );
 			} );

--- a/client/my-sites/upgrades/checkout/pay-button.jsx
+++ b/client/my-sites/upgrades/checkout/pay-button.jsx
@@ -43,7 +43,7 @@ var PayButton = React.createClass( {
 				if ( this.props.transactionStep.error || ! this.props.transactionStep.data.success ) {
 					state = this.beforeSubmit();
 				} else {
-					state = this.completed();
+					state = this.completing();
 				}
 				break;
 
@@ -123,13 +123,6 @@ var PayButton = React.createClass( {
 		return {
 			disabled: true,
 			text: text
-		};
-	},
-
-	completed: function() {
-		return {
-			disabled: true,
-			text: this.translate( 'Purchase complete', { context: 'Loading state on /checkout' } )
 		};
 	},
 

--- a/client/my-sites/upgrades/checkout/secure-payment-form.jsx
+++ b/client/my-sites/upgrades/checkout/secure-payment-form.jsx
@@ -40,8 +40,9 @@ const SecurePaymentForm = React.createClass( {
 	mixins: [ TransactionStepsMixin ],
 
 	propTypes: {
+		handleCheckoutCompleteRedirect: React.PropTypes.func.isRequired,
 		products: React.PropTypes.object.isRequired,
-		redirectTo: React.PropTypes.func.isRequired
+		redirectTo: React.PropTypes.func.isRequired,
 	},
 
 	getInitialState() {

--- a/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
+++ b/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
@@ -5,8 +5,7 @@ var React = require( 'react' ), // eslint-disable-line no-unused-vars
 	debug = require( 'debug' )( 'calypso:my-sites:upgrades:checkout:transaction-steps-mixin' ),
 	pick = require( 'lodash/pick' ),
 	defer = require( 'lodash/defer' ),
-	isEqual = require( 'lodash/isEqual' ),
-	page = require( 'page' );
+	isEqual = require( 'lodash/isEqual' );
 
 /**
  * Internal dependencies
@@ -140,7 +139,7 @@ var TransactionStepsMixin = {
 
 		defer( () => {
 			// The Thank You page throws a rendering error if this is not in a defer.
-			page( this.props.redirectTo() );
+			this.props.handleCheckoutCompleteRedirect();
 		} );
 	}
 };

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -214,6 +214,40 @@ module.exports = {
 		);
 	},
 
+	sitelessCheckout: function( context ) {
+		const Checkout = require( './checkout' ),
+			CheckoutData = require( 'components/data/checkout' ),
+			CartData = require( 'components/data/cart' ),
+			SecondaryCart = require( './cart/secondary-cart' );
+
+		analytics.pageView.record( '/checkout/no-site', 'Checkout' );
+
+		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+		context.store.dispatch( setTitle( i18n.translate( 'Checkout' ) ) );
+
+		renderWithReduxStore(
+			(
+				<CheckoutData>
+					<Checkout
+						productsList={ productsList }
+					/>
+				</CheckoutData>
+			),
+			document.getElementById( 'primary' ),
+			context.store
+		);
+
+		renderWithReduxStore(
+			(
+				<CartData>
+					<SecondaryCart />
+				</CartData>
+			),
+			document.getElementById( 'secondary' ),
+			context.store
+		);
+	},
+
 	checkoutThankYou: function( context ) {
 		const CheckoutThankYouComponent = require( './checkout-thank-you' ),
 			basePath = route.sectionify( context.path ),

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -252,6 +252,11 @@ module.exports = function() {
 		);
 
 		page(
+			'/checkout/no-site',
+			upgradesController.sitelessCheckout
+		);
+
+		page(
 			'/checkout/:domain/:product?',
 			controller.siteSelection,
 			upgradesController.checkout

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -107,7 +107,7 @@ module.exports = {
 
 	'domain-only': {
 		stepName: 'domain-only',
-		apiRequestFunction: stepActions.createSiteWithCart,
+		apiRequestFunction: stepActions.createCart,
 		props: {
 			isDomainOnly: true
 		},


### PR DESCRIPTION
That change allows to create a site only on checkout.
Requires backend patch to make it work: `D4196`.

![screen shot 2017-02-01 at 19 17 44](https://cloud.githubusercontent.com/assets/326402/22517832/235bf976-e8b3-11e6-8742-0622a82cde8b.png)


### Testing
1. Apply `D4196` patch.
2. Open http://calypso.localhost:3000/start/domain-first.
3. Pick domain name.
4. Select domain only flow.
5. Create your account.
6. You should see checkout page with the following url: http://calypso.localhost:3000/checkout/no-site.
7. After checkout you should be redirected to the domain management of the the purchased domain: `http://calypso.localhost:3000/domains/manage/domain.live`


### Testing cart is empty after checkout:
1. Complete checkout according the steps above
2. Restart the domain only flow with the same user, you should be able to complete it with a *new* domain.
-or-
GET the `no-site` (the "copy as cURL") shopping cart from the API and see it has no products.
You can do so on chrome by copying the request from the network tab and executing on a shell:
```shell
curl 'https://public-api.wordpress.com/rest/v1.1/me/shopping-cart/no-site?http_envelope=1&locale=en' -H ....
```
