### PR TITLE
Send proper data to track when themes selection click.

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -3,7 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { compact, isEqual, omit } from 'lodash';
+import { compact, isEqual, omit, property } from 'lodash';
 
 /**
  * Internal dependencies
@@ -75,7 +75,7 @@ const ThemesSelection = React.createClass( {
 			search_term: query.search,
 			theme,
 			results_rank: resultsRank + 1,
-			results: themes,
+			results: themes.map( property( 'id' ) ).toString(),
 			page_number: query.page
 		} );
 	},

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -65,10 +65,6 @@ const ThemesSelection = React.createClass( {
 		}
 	},
 
-	onMoreButtonClick( theme, resultsRank ) {
-		this.recordSearchResultsClick( theme, resultsRank );
-	},
-
 	recordSearchResultsClick( theme, resultsRank ) {
 		const { query, themes } = this.props;
 		analytics.tracks.recordEvent( 'calypso_themeshowcase_theme_click', {
@@ -128,7 +124,6 @@ const ThemesSelection = React.createClass( {
 				<ThemesList themes={ this.props.themes }
 					fetchNextPage={ this.fetchNextPage }
 					getButtonOptions={ this.props.getOptions }
-					onMoreButtonClick={ this.onMoreButtonClick }
 					onScreenshotClick={ this.onScreenshotClick }
 					getScreenshotUrl={ this.props.getScreenshotUrl }
 					getActionLabel={ this.props.getActionLabel }

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -75,7 +75,7 @@ const ThemesSelection = React.createClass( {
 			search_term: query.search,
 			theme: theme.id,
 			results_rank: resultsRank + 1,
-			results: themes.map( property( 'id' ) ).toString(),
+			results: themes.map( property( 'id' ) ).join(),
 			page_number: query.page
 		} );
 	},

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -73,7 +73,7 @@ const ThemesSelection = React.createClass( {
 		const { query, themes } = this.props;
 		analytics.tracks.recordEvent( 'calypso_themeshowcase_theme_click', {
 			search_term: query.search,
-			theme,
+			theme: theme.id,
 			results_rank: resultsRank + 1,
 			results: themes.map( property( 'id' ) ).toString(),
 			page_number: query.page


### PR DESCRIPTION
### Info
Themes selection click was sending unsupported data to Analytics.
Fixed by sending only what we need to send and not whole objects that are unsupported.

Related to #10927