### PR TITLE
Variable placeholders count in ThemesList.

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -42,7 +42,8 @@ export const ThemesList = React.createClass( {
 		translate: React.PropTypes.func,
 		showThemeUpload: React.PropTypes.bool,
 		themeUploadClickRecorder: React.PropTypes.func,
-		onThemeUpload: React.PropTypes.func
+		onThemeUpload: React.PropTypes.func,
+		placeholderCount: React.PropTypes.number
 	},
 
 	fetchNextPage( options ) {
@@ -57,6 +58,7 @@ export const ThemesList = React.createClass( {
 			themeUploadClickRecorder: identity,
 			onThemeUpload: identity,
 			fetchNextPage: noop,
+			placeholderCount: DEFAULT_THEME_QUERY.number,
 			optionsGenerator: () => [],
 			getActionLabel: () => '',
 			isActive: () => false,
@@ -90,7 +92,7 @@ export const ThemesList = React.createClass( {
 	},
 
 	renderLoadingPlaceholders() {
-		return times( DEFAULT_THEME_QUERY.number, function( i ) {
+		return times( this.props.placeholderCount, function( i ) {
 			return <Theme key={ 'placeholder-' + i } theme={ { id: 'placeholder-' + i, name: 'Loading…' } } isPlaceholder={ true } />;
 		} );
 	},

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -50,6 +50,7 @@ const SingleSiteThemeShowcaseWithOptions = ( props ) => {
 				secondaryOption="tryandcustomize"
 				source="showcase"
 				listLabel={ translate( 'Uploaded themes' ) }
+				placeholderCount={ 5 }
 			/>
 		);
 	}

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -198,6 +198,7 @@ const ThemeShowcase = React.createClass( {
 					siteId={ this.props.siteId }
 					listLabel={ this.props.listLabel }
 					showUploadButton={ this.props.showUploadButton }
+					placeholderCount={ this.props.placeholderCount }
 					getScreenshotUrl={ function( theme ) {
 						if ( ! getScreenshotOption( theme ).getUrl ) {
 							return null;

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -50,7 +50,8 @@ const ThemesSelection = React.createClass( {
 		isLastPage: PropTypes.bool,
 		isThemeActive: PropTypes.func,
 		isThemePurchased: PropTypes.func,
-		isInstallingTheme: PropTypes.func
+		isInstallingTheme: PropTypes.func,
+		placeholderCount: PropTypes.number
 	},
 
 	getDefaultProps() {
@@ -135,7 +136,8 @@ const ThemesSelection = React.createClass( {
 					isActive={ this.props.isThemeActive }
 					isPurchased={ this.props.isThemePurchased }
 					isInstalling={ this.props.isInstallingTheme }
-					loading={ this.props.isRequesting } />
+					loading={ this.props.isRequesting }
+					placeholderCount={ this.props.placeholderCount } />
 			</div>
 		);
 	},


### PR DESCRIPTION
### Info
As requested in https://github.com/Automattic/wp-calypso/pull/10926#issuecomment-275100433
User can now see two list because we limited number of placeholders for the first list.

### To test
go to `/design`, select Jetpack site and observe loading. 