### PR TITLE
Component: add `query-timezones` data component

### DIFF
--- a/client/components/data/query-timezones/index.jsx
+++ b/client/components/data/query-timezones/index.jsx
@@ -1,0 +1,30 @@
+
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { requestTimezones } from 'state/timezones/actions';
+
+export class QueryTimezones extends Component {
+	static propTypes = {
+		requestingTimezones: PropTypes.bool,
+		requestTimezones: PropTypes.func
+	};
+
+	componentDidMount() {
+		this.props.requestTimezones();
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export const mapDispatchToProps = ( { requestTimezones } );
+
+export default connect( null, mapDispatchToProps )( QueryTimezones );

--- a/client/components/data/query-timezones/test/index.jsx
+++ b/client/components/data/query-timezones/test/index.jsx
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { spy } from 'sinon';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { requestTimezones as requestingTimezonesAction } from 'state/timezones/actions';
+import {
+	QueryTimezones as QueryTimezones,
+	mapDispatchToProps,
+} from '../';
+
+describe( 'mounting component', () => {
+	it( 'should mount as null', () => {
+		const wrapped = shallow( <QueryTimezones { ...{ requestTimezones: noop } } /> );
+
+		expect( wrapped.equals( null ) ).to.be.true;
+	} );
+} );
+
+describe( 'request', () => {
+	it( 'should issue timezones request when called', () => {
+		const dispatch = spy();
+		const { requestTimezones } = mapDispatchToProps;
+
+		dispatch( requestTimezones() );
+		expect( dispatch ).to.have.been.calledWith( requestingTimezonesAction() );
+	} );
+} );

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2136,16 +2136,6 @@ Undocumented.prototype.getExport = function( siteId, exportId, fn ) {
 	}, fn );
 };
 
-Undocumented.prototype.timezones = function( params, fn ) {
-	if ( typeof params === 'function' ) {
-		fn = params;
-		params = {};
-	}
-
-	let query = Object.assign( {}, params, { apiNamespace: 'wpcom/v2' } );
-	return this.wpcom.req.get( '/timezones', query, fn );
-};
-
 /**
  * Check different info about WordPress and Jetpack status on a url
  *

--- a/client/state/data-layer/wpcom-http/actions.js
+++ b/client/state/data-layer/wpcom-http/actions.js
@@ -7,6 +7,7 @@ import { WPCOM_HTTP_REQUEST } from 'state/action-types';
  * Returns a valid WordPress.com API HTTP Request action object
  *
  * @param {string} [apiVersion] specific API version for request
+ * @param {string} [apiNamespace] specific API namespace for request
  * @param {Object} [body] JSON-serializable body for POST requests
  * @param {string} method name of HTTP method to use
  * @param {string} path WordPress.com API path with %s and %d placeholders, e.g. /sites/%s
@@ -21,6 +22,7 @@ import { WPCOM_HTTP_REQUEST } from 'state/action-types';
  */
 export const http = ( {
 	apiVersion = 'v1',
+	apiNamespace = 'wpcom/v2',
 	body = {},
 	method,
 	path,
@@ -35,7 +37,7 @@ export const http = ( {
 	body,
 	method,
 	path,
-	query: { ...query, apiVersion },
+	query: { ...query, apiVersion, apiNamespace },
 	formData,
 	onSuccess: onSuccess || action,
 	onFailure: onFailure || action,

--- a/client/state/data-layer/wpcom/timezones/index.js
+++ b/client/state/data-layer/wpcom/timezones/index.js
@@ -10,7 +10,8 @@ import {
 /**
  * Internal dependencies
  */
-import wpcom from 'lib/wp';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 
 import { TIMEZONES_REQUEST } from 'state/action-types';
 
@@ -25,7 +26,7 @@ import {
  * keys are the values and whose values are the labels.
  *
  * @example
- * valueLabelToObject( [ { value: 'foo', label: 'bar' }, { value: 'biz', label: 'bat' } ] )
+ * timezonePairsToMap( [ { value: 'foo', label: 'bar' }, { value: 'biz', label: 'bat' } ] )
  * // returns { foo: 'bar', biz: 'bat' }
  *
  * @param {ValueLabelRecord[]} pairs - timezone values and display labels
@@ -47,20 +48,58 @@ export const fromApi = ( { manual_utc_offsets, timezones, timezones_by_continent
 	byContinents: mapValues( timezones_by_continent, zones => map( zones, ( { value } ) => ( value ) ) )
 } );
 
-/*
- * Start a request to WordPress.com server to get the timezones data
+/**
+ * Dispaches a request to fetch timezones data from WordPress WP REST API
+ * https://public-api.wordpress.com/wpcom/v2/timezones
+ *
+ * @param {Function} dispatch - Redux dispatcher
+ * @param {Object} action - Redux action
+ * @param {Function} next - data-layer-bypassing dispatcher
+ * @returns {Object} original action
  */
-export const fetchTimezones = ( { dispatch } ) => (
-	wpcom.req.get( '/timezones', { apiNamespace: 'wpcom/v2' } )
-		.then( data => {
-			dispatch( timezonesRequestSuccess() );
-			dispatch( timezonesReceive( fromApi( data ) ) );
-		} )
-		.catch( error => {
-			dispatch( timezonesRequestFailure( error ) );
-		} )
-);
+export const requestTimezones = ( { dispatch }, action, next ) => {
+	dispatch( http( {
+		apiNamespace: 'wpcom/v2',
+		method: 'GET',
+		path: '/timezones',
+		onSuccess: action,
+		onFailure: action,
+	} ) );
+
+	return next( action );
+};
+
+/**
+ * Dispatches returned timezones data
+ *
+ * @param {Function} dispatch - Redux dispatcher
+ * @param {Object} action - Redux action
+ * @param {Function} next - dispatches to next middleware in chain
+ * @param {Object} timezones - raw data from timezones endpoint response
+ */
+export const receiveTimezones = ( { dispatch }, action, next, timezones ) => {
+	dispatch( timezonesRequestSuccess() );
+	dispatch( timezonesReceive( fromApi( timezones ) ) );
+};
+
+/**
+ * Dispatches returned error from timezones request
+ *
+ * @param {Function} dispatch - Redux dispatcher
+ * @param {Object} action - Redux action
+ * @param {Function} next - dispatches to next middleware in chain
+ * @param {Object} rawError - raw error from HTTP request
+ */
+export const receiveError = ( { dispatch }, action, next, rawError ) => {
+	const error = rawError instanceof Error
+		? rawError.message
+		: rawError;
+
+	dispatch( timezonesRequestFailure( error ) );
+};
+
+export const dispatchTimezonesRequest = dispatchRequest( requestTimezones, receiveTimezones, receiveError );
 
 export default {
-	[ TIMEZONES_REQUEST ]: [ fetchTimezones ],
+	[ TIMEZONES_REQUEST ]: [ dispatchTimezonesRequest ],
 };

--- a/client/state/data-layer/wpcom/timezones/test/index.js
+++ b/client/state/data-layer/wpcom/timezones/test/index.js
@@ -2,76 +2,90 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import { spy } from 'sinon';
 
 /**
  * Internal dependencies
  */
-import { useSandbox } from 'test/helpers/use-sinon';
-import useNock from 'test/helpers/use-nock';
+import { http } from 'state/data-layer/wpcom-http/actions';
+
+// import { useSandbox } from 'test/helpers/use-sinon';
+// import useNock from 'test/helpers/use-nock';
 
 import {
-	timezonesRequestSuccess,
-	timezonesReceive,
+	timezonesReceive as timezonesReceiveAction,
+	timezonesRequestSuccess as timezonesRequestSuccessAction,
+	timezonesRequestFailure as timezonesRequestFailureAction,
 } from 'state/timezones/actions';
-
-const WP_REST_API = {
-	hostname: 'https://public-api.wordpress.com',
-	namespace: '/wpcom/v2',
-	endpoint: '/timezones'
-};
 
 /*
  * Util functions
  */
-import { fetchTimezones } from '../';
+import {
+	requestTimezones,
+	receiveTimezones,
+	receiveError,
+} from '../';
 
-describe( 'request', () => {
-	let dispatch;
-	useSandbox( sandbox => ( dispatch = sandbox.spy() ) );
+describe( 'successful requests', () => {
+	describe( 'requestTimezones', () => {
+		it( 'should dispatch HTTP request to timezones endpoint', () => {
+			const action = { type: 'DUMMY' };
+			const dispatch = spy();
+			const next = spy();
 
-	describe( 'successful requests', () => {
-		useNock( ( nock ) => {
-			nock( WP_REST_API.hostname )
-				.persist()
-				.get( WP_REST_API.namespace + WP_REST_API.endpoint )
-				.reply( 200, {
-					found: 100,
-					manual_utc_offsets: [
-						{ value: 'UTC+0', label: 'UTC' },
-						{ value: 'UTC+13.75', label: 'UTC+13:45' },
-						{ value: 'UTC+14', label: 'UTC+14' },
-					],
-					timezones: [
+			requestTimezones( { dispatch }, action, next );
+
+			expect( dispatch ).to.have.been.calledOnce;
+			expect( dispatch ).to.have.been.calledWith( http( {
+				apiNamespace: 'wpcom/v2',
+				method: 'GET',
+				path: '/timezones',
+				onSuccess: action,
+				onFailure: action,
+			} ) );
+		} );
+
+		it( 'should pass the original action along the middleware chain', () => {
+			const action = { type: 'DUMMY' };
+			const dispatch = spy();
+			const next = spy();
+
+			requestTimezones( { dispatch }, action, next );
+
+			expect( next ).to.have.been.calledWith( action );
+		} );
+	} );
+
+	describe( 'receiveTimezones', () => {
+		it( 'should dispatch timezones updates', () => {
+			const endpointResponseData = {
+				found: 100,
+				manual_utc_offsets: [
+					{ value: 'UTC+0', label: 'UTC' },
+					{ value: 'UTC+13.75', label: 'UTC+13:45' },
+					{ value: 'UTC+14', label: 'UTC+14' },
+				],
+				timezones: [
+					{ value: 'Asia/Aqtobe', label: 'Aqtobe' },
+					{ value: 'America/Boa_Vista', label: 'Boa Vista' },
+					{ value: 'Indian/Comoro', label: 'Comoro' },
+				],
+				timezones_by_continent: {
+					Asia: [
 						{ value: 'Asia/Aqtobe', label: 'Aqtobe' },
-						{ value: 'America/Boa_Vista', label: 'Boa Vista' },
-						{ value: 'Indian/Comoro', label: 'Comoro' },
 					],
-					timezones_by_continent: {
-						Asia: [
-							{ value: 'Asia/Aqtobe', label: 'Aqtobe' },
-						],
-						America: [
-							{ value: 'America/Blanc-Sablon', label: 'Blanc-Sablon' },
-							{ value: 'America/Boa_Vista', label: 'Boa Vista' },
-						],
-						Indian: [
-							{ value: 'Indian/Comoro', label: 'Comoro' },
-						]
-					}
-				} );
-		} );
+					America: [
+						{ value: 'America/Blanc-Sablon', label: 'Blanc-Sablon' },
+						{ value: 'America/Boa_Vista', label: 'Boa Vista' },
+					],
+					Indian: [
+						{ value: 'Indian/Comoro', label: 'Comoro' },
+					]
+				}
+			};
 
-		it( 'should dispatch SUCCESS action when request completes', () => {
-			const action = timezonesRequestSuccess();
-
-			return fetchTimezones( { dispatch } )
-				.then( () => (
-					expect( dispatch ).to.have.been.calledWith( action )
-				) );
-		} );
-
-		it( 'should dispatch RECEIVE action when request completes', () => {
-			const responseData = {
+			const receiveActionData = {
 				rawOffsets: {
 					'UTC+0': 'UTC',
 					'UTC+13.75': 'UTC+13:45',
@@ -97,12 +111,31 @@ describe( 'request', () => {
 				},
 			};
 
-			const action = timezonesReceive( responseData );
+			const action = timezonesReceiveAction( receiveActionData );
+			const dispatch = spy();
+			const next = spy();
 
-			return fetchTimezones( { dispatch } )
-				.then( () => (
-					expect( dispatch ).to.have.been.calledWith( action )
-				) );
+			receiveTimezones( { dispatch }, action, next, endpointResponseData );
+
+			expect( dispatch ).to.have.been.calledTwice;
+			expect( dispatch ).to.have.been.calledWith( timezonesRequestSuccessAction() );
+			expect( dispatch ).to.have.been.calledWith( timezonesReceiveAction( receiveActionData ) );
+		} );
+	} );
+} );
+
+describe( 'failed requests', () => {
+	describe( '#receiveError', () => {
+		it( 'should dispatch error', () => {
+			const error = 'Internal Server Error';
+			const action = timezonesRequestFailureAction( error );
+			const dispatch = spy();
+			const next = spy();
+
+			receiveError( { dispatch }, action, next, error );
+
+			expect( dispatch ).to.have.been.calledOnce;
+			expect( dispatch ).to.have.been.calledWith( timezonesRequestFailureAction( error ) );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds the `query-timezones` component implemented according to most recently handling data of calypso. More information about this: https://github.com/Automattic/wp-calypso/tree/master/client/state/data-layer/wpcom-http

### Testing

#### Run client tests

- data-layer timezones tests
```
> npm run test-client client/state/data-layer/wpcom/timezones/test/
```

- data query-timezones tests
```
> npm run test-client client/components/data/query-timezones/test/
```

#### Some tests using chrome devtools

You could dispatch a timezones request action straight using the console executing the right action type. it can be achieved using the global `actionTypes` var as well.

```
> dispatch( { type: actionTypes.TIMEZONES_REQUEST } );
```

<img src="https://cloud.githubusercontent.com/assets/77539/22749185/34510a34-ee0b-11e6-87d0-47a57437e5a5.png" width="300px" />

After dispatching the action, you could check that the request has been triggered taking a look to the `network` tab:

<img src="https://cloud.githubusercontent.com/assets/77539/22749292/8fed3c5a-ee0b-11e6-9ae4-0053045fd5d2.png" width="400px" />

And you could confirm that the action is being successful dispatched, paying attention how the set of actions are triggered one by one in the following order:

`WPCOM_HTTP_REQUEST`,
`TIMEZONES_REQUEST`,
`TIMEZONES_REQUEST_SUCCESS`,
`TIMEZONES_RECEIVE`,

<img src="https://cloud.githubusercontent.com/assets/77539/22749471/3654d6a2-ee0c-11e6-9259-48e2e4efa37a.gif" width="500px" />




