### PR TITLE
Reader: Fix pushing page views from full post and cards

### DIFF
--- a/client/blocks/daily-post-button/index.jsx
+++ b/client/blocks/daily-post-button/index.jsx
@@ -58,6 +58,7 @@ class DailyPostButton extends React.Component {
 
 	static propTypes = {
 		post: React.PropTypes.object.isRequired,
+		site: React.PropTypes.object.isRequired,
 		position: React.PropTypes.string,
 		tagName: React.PropTypes.string,
 	}
@@ -96,7 +97,7 @@ class DailyPostButton extends React.Component {
 		recordGaEvent( 'Clicked on Daily Post challenge' );
 		recordTrackForPost( 'calypso_reader_daily_post_challenge_site_picked', this.props.post );
 
-		markPostSeen( this.props.post );
+		markPostSeen( this.props.post, this.props.site );
 
 		page( `/post/${ siteSlug }?${ qs.stringify( pingbackAttributes ) }` );
 		return true;

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -38,7 +38,6 @@ import PostExcerptLink from 'reader/post-excerpt-link';
 import { siteNameFromSiteAndPost } from 'reader/utils';
 import KeyboardShortcuts from 'lib/keyboard-shortcuts';
 import ReaderPostActions from 'blocks/reader-post-actions';
-import { state as SiteState } from 'lib/reader-site-store/constants';
 import PostStoreActions from 'lib/feed-post-store/actions';
 import { RelatedPostsFromSameSite, RelatedPostsFromOtherSites } from 'components/related-posts-v2';
 import { getStreamUrlFromPost } from 'reader/route';
@@ -227,9 +226,9 @@ export class FullPostView extends React.Component {
 		const { post, site } = this.props;
 
 		if ( post && post._state !== 'pending' &&
-			site && site.state === SiteState.COMPLETE &&
+			site && site.ID &&
 			! this.hasSentPageView ) {
-			PostStoreActions.markSeen( post );
+			PostStoreActions.markSeen( post, site );
 			this.hasSentPageView = true;
 		}
 
@@ -358,7 +357,7 @@ export class FullPostView extends React.Component {
 									followUrl={ getSourceFollowUrl( post ) } />
 						}
 						{ isDailyPostChallengeOrPrompt( post ) &&
-							<DailyPostButton post={ post } tagName="span" />
+							<DailyPostButton post={ post } site={ site } tagName="span" />
 						}
 
 						<ReaderPostActions post={ post } site={ site } onCommentClick={ this.handleCommentClick } />

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -360,7 +360,7 @@ export class FullPostView extends React.Component {
 							<DailyPostButton post={ post } site={ site } tagName="span" />
 						}
 
-						<ReaderPostActions post={ post } site={ site } onCommentClick={ this.handleCommentClick } />
+						<ReaderPostActions post={ post } site={ site } onCommentClick={ this.handleCommentClick } fullPost={ true } />
 
 						{ showRelatedPosts &&
 							<RelatedPostsFromSameSite siteId={ +post.site_ID } postId={ +post.ID }

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -32,7 +32,8 @@ const ReaderPostActions = ( props ) => {
 		showMenuFollow,
 		iconSize,
 		className,
-		visitUrl
+		visitUrl,
+		fullPost,
 	} = props;
 
 	const onEditClick = () => {
@@ -88,7 +89,9 @@ const ReaderPostActions = ( props ) => {
 						key="like-button"
 						siteId={ +post.site_ID }
 						postId={ +post.ID }
-						fullPost={ true }
+						post={ post }
+						site={ site }
+						fullPost={ fullPost }
 						tagName="div"
 						forceCounter={ true }
 						iconSize={ iconSize }
@@ -113,7 +116,8 @@ ReaderPostActions.propTypes = {
 	iconSize: React.PropTypes.number,
 	showMenu: React.PropTypes.bool,
 	showMenuFollow: React.PropTypes.bool,
-	visitUrl: React.PropTypes.string
+	visitUrl: React.PropTypes.string,
+	fullPost: React.PropTypes.bool,
 };
 
 ReaderPostActions.defaultProps = {

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -140,7 +140,7 @@ export default class ReaderPostCard extends React.Component {
 
 		let readerPostCard;
 		if ( isPhotoPost ) {
-			readerPostCard = <PhotoPost post={ post } title={ title } onClick={ this.handleCardClick } >
+			readerPostCard = <PhotoPost post={ post } site={ site } title={ title } onClick={ this.handleCardClick } >
 					{ discoverFollowButton }
 					{ readerPostActions }
 				</PhotoPost>;
@@ -150,7 +150,7 @@ export default class ReaderPostCard extends React.Component {
 				</GalleryPost>;
 		} else {
 			readerPostCard = <StandardPost post={ post } title={ title } isDiscover={ isDiscover }>
-					{ isDailyPostChallengeOrPrompt( post ) && <DailyPostButton post={ post } tagName="span" /> }
+					{ isDailyPostChallengeOrPrompt( post ) && <DailyPostButton post={ post } site={ site } tagName="span" /> }
 					{ discoverFollowButton }
 					{ readerPostActions }
 				</StandardPost>;

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -129,9 +129,11 @@ export default class ReaderPostCard extends React.Component {
 
 		const readerPostActions = <ReaderPostActions
 			post={ originalPost ? originalPost : post }
+			site={ site }
 			visitUrl = { post.URL }
 			showVisit={ true }
 			showMenu={ true }
+			fullPost= { false }
 			showMenuFollow={ ! isDiscover }
 			onCommentClick={ onCommentClick }
 			showEdit={ false }

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -150,7 +150,7 @@ export default class ReaderPostCard extends React.Component {
 				</GalleryPost>;
 		} else {
 			readerPostCard = <StandardPost post={ post } title={ title } isDiscover={ isDiscover }>
-					{ isDailyPostChallengeOrPrompt( post ) && <DailyPostButton post={ post } site={ site } tagName="span" /> }
+					{ isDailyPostChallengeOrPrompt( post ) && site && <DailyPostButton post={ post } site={ site } tagName="span" /> }
 					{ discoverFollowButton }
 					{ readerPostActions }
 				</StandardPost>;
@@ -168,4 +168,3 @@ export default class ReaderPostCard extends React.Component {
 		);
 	}
 }
-

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -32,11 +32,11 @@ class PostPhoto extends React.Component {
 	}
 
 	onExpanded = () => {
-		const { post } = this.props.post;
+		const { post, site } = this.props;
 		stats.recordTrackForPost( 'calypso_reader_photo_expanded', post );
 
 		// Record page view
-		PostStoreActions.markSeen( post );
+		PostStoreActions.markSeen( post, site );
 		stats.recordTrackForPost( 'calypso_reader_article_opened', post );
 	}
 
@@ -145,6 +145,7 @@ class PostPhoto extends React.Component {
 
 PostPhoto.propTypes = {
 	post: React.PropTypes.object,
+	site: React.PropTypes.object,
 	title: React.PropTypes.string,
 	onClick: React.PropTypes.func,
 };

--- a/client/lib/feed-post-store/actions.js
+++ b/client/lib/feed-post-store/actions.js
@@ -80,12 +80,14 @@ FeedPostActions = {
 		}, postKey ) );
 	},
 
-	markSeen: function( post, source ) {
+	markSeen: function( post, site, source ) {
 		defer( function() {
 			Dispatcher.handleViewAction( {
 				type: ACTION.MARK_FEED_POST_SEEN,
 				data: {
-					post, source
+					post,
+					site,
+					source
 				}
 			} );
 		} );

--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -287,17 +287,18 @@ function markPostSeen( post, site ) {
 	if ( ! post ) {
 		return;
 	}
+
 	const originalPost = post;
 
 	if ( ! post._seen ) {
-		post = Object.assign( { _seen: true }, post );
+		post = Object.assign( {}, post, { _seen: true } );
 	}
 
 	if ( post.site_ID ) {
 		// they have a site ID, let's try to push a page view
-		const isNotAdmin = ! get( site, 'capabilities.manage_options', false ) ;
+		const isAdmin = ! get( site, 'capabilities.manage_options', false );
 		if ( site && site.ID ) {
-			if ( site.is_private || isNotAdmin ) {
+			if ( site.is_private || ! isAdmin ) {
 				stats.pageViewForPost( site.ID, site.URL, post.ID, site.is_private );
 			}
 		}

--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -296,7 +296,7 @@ function markPostSeen( post, site ) {
 
 	if ( post.site_ID ) {
 		// they have a site ID, let's try to push a page view
-		const isAdmin = ! get( site, 'capabilities.manage_options', false );
+		const isAdmin = !! get( site, 'capabilities.manage_options', false );
 		if ( site && site.ID ) {
 			if ( site.is_private || ! isAdmin ) {
 				stats.pageViewForPost( site.ID, site.URL, post.ID, site.is_private );

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -3,13 +3,14 @@ const React = require( 'react' );
 const postStore = require( 'lib/feed-post-store' );
 
 const LikeButtonContainer = require( 'blocks/like-button' );
+const { markSeen } = require( 'lib/feed-post-store/actions' );
 
 import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
 
 const ReaderLikeButton = React.createClass( {
 
 	recordLikeToggle: function( liked ) {
-		const post = postStore.get( {
+		const post = this.props.post || postStore.get( {
 			blogId: this.props.siteId,
 			postId: this.props.postId
 		} );
@@ -18,6 +19,9 @@ const ReaderLikeButton = React.createClass( {
 		recordGaEvent( liked ? 'Clicked Like Post' : 'Clicked Unlike Post' );
 		recordTrackForPost( liked ? 'calypso_reader_article_liked' : 'calypso_reader_article_unliked', post,
 				{ context: this.props.fullPost ? 'full-post' : 'card' } );
+		if ( liked && ! this.props.fullPost && ! post._seen ) {
+			markSeen( post, this.props.site );
+		}
 	},
 
 	render: function() {


### PR DESCRIPTION
Pass along the site object we have instead of trying to pull it from the SiteStore.

Since we moved sites to redux, this store doesn't actually get filled out very often. This breaks the markSeen action handler, which relies on the site store having data.