### PR TITLE
Notifications: Use a more appropriate cache-busting technique

### DIFF
--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -28,6 +28,8 @@ import userLib from 'lib/user';
 /**
  * Module variables
  */
+const NOTIFICATIONS_CLIENT_VERSION = 'r149809-wpcom-3-g8e6976f';
+
 const user = userLib();
 const widgetDomain = 'https://widgets.wp.com';
 
@@ -311,7 +313,6 @@ export class Notifications extends Component {
 		}
 
 		const localeSlug = get( user.get(), 'localeSlug', config( 'i18n_default_locale_slug' ) );
-		const now = new Date();
 
 		/** * @type {string} holds the URL for the notifications client for the iframe */
 		const widgetUrl = compact( [
@@ -325,9 +326,7 @@ export class Notifications extends Component {
 			// the flipped copy
 			user.isRTL() && 'rtl.html',
 			`?locale=${ localeSlug }`,
-			// bust cache every hour
-			// @TODO replace this with a strong process that doesn't make users download so much data
-			`&cache_buster=${ now.getFullYear() }${ now.getMonth() + 1 }${ now.getDate() }${ now.getHours() }`,
+			`&cache_buster=${ NOTIFICATIONS_CLIENT_VERSION }`,
 		] ).join( '' );
 
 		return (


### PR DESCRIPTION
Previously in Calypso we were implementing a wasteful cache-busting
algorithm: invalidate the cached copy of the notifications client iframe
contents every hour. This leads to needless re-downloads of around half
a megabyte of code when in reality it doesn't change very frequently.

In the past the decision was made to enforce a time-based algorithm so
that we could make sure that it was automatically updated in case
someone forgot to make a corresponding Calypso PR when updating the
notifications client.

Now, the notifications client build process has been automated with a
nag to update this value whenever it changes and the time-based
procedure has been replaced with a content-based procedure.

This should result in better performance for users who have previously
had to redownload the same copies of the notifications code over and
over again.