### PR TITLE
Theme Options: Merge Jetpack Options into WP.com Ones

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -599,7 +599,7 @@ const ThemeSheetWithOptions = ( props ) => {
 	} else if ( isActive ) {
 		defaultOption = 'customize';
 	} else if ( isJetpack && isWpcomTheme ) {
-		defaultOption = 'activateOnJetpack';
+		defaultOption = 'activate';
 	} else if ( isPremium && ! isPurchased ) {
 		defaultOption = 'purchase';
 	} else {
@@ -616,11 +616,9 @@ const ThemeSheetWithOptions = ( props ) => {
 				'tryandcustomize',
 				'purchase',
 				'activate',
-				'activateOnJetpack',
-				'tryAndCustomizeOnJetpack',
 			] }
 			defaultOption={ defaultOption }
-			secondaryOption={ ( isJetpack && isWpcomTheme ) ? 'tryAndCustomizeOnJetpack' : 'tryandcustomize' }
+			secondaryOption={ 'tryandcustomize' }
 			source="showcase-sheet" />
 	);
 };

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -89,8 +89,8 @@ const ConnectedSingleSiteJetpack = connectOptions(
 						<div>
 							<ConnectedThemesSelection
 								options={ [
-									'activateOnJetpack',
-									'tryAndCustomizeOnJetpack',
+									'activate',
+									'tryandcustomize',
 									'customize',
 									'separator',
 									'info',


### PR DESCRIPTION
See convo starting at https://github.com/Automattic/wp-calypso/issues/2128#issuecomment-275214084 for background.

This has some downsides: We don't have access to the state-bound `action` fields in `mapDispatchToProps`, where we want to bind to `dispatch`. So we'd need to do stuff in `mergeProps`, but that's another can of worms (mostly in terms of performance). We'd also need to change `ThemesSiteSelectorModal` to deal with the new type of actions.

Long story short, this PR is FYI @seear and @budzanowski, but I don't think I'll pursue this any further.
Theme options are such a special beast that I think we have two choices:
1. Merge at action level (see original convo referenced above), using `getState()`
2. Base theme options directly on `redux` instead of `react-redux`. Why? Because we could more arbitrarily make use of `dispatch` and `state` (and mix and match them to suit us, like we need to with this PR) than we can with `react-redux`'s `connect`. I think this means essentially shifting the line where we mix those two from action to options; I've considered this before due to some other stuff that seemed to go against `react-redux`'s ideas.

Option 1 is obviously the easier one. Maybe we'll just add a generalized `activate` action (need to come up with a good name for it) that conditionally calls either `installAndActivate` (for JP sites) or `activateTheme` (otherwise).