### PR TITLE
FollowersCount: Use combined WordPress.com + Email followers

### DIFF
--- a/client/blocks/followers-count/index.jsx
+++ b/client/blocks/followers-count/index.jsx
@@ -11,11 +11,14 @@ import { get } from 'lodash';
  */
 import Button from 'components/button';
 import Count from 'components/count';
-import { getSelectedSite } from 'state/ui/selectors';
+import QuerySiteStats from 'components/data/query-site-stats';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
+import { getSiteStatsNormalizedData } from 'state/stats/lists/selectors';
 
 class FollowersCount extends Component {
 	render() {
-		const { slug, followers, translate } = this.props;
+		const { slug, followers, translate, siteId } = this.props;
 
 		if ( ! followers ) {
 			return null;
@@ -23,7 +26,12 @@ class FollowersCount extends Component {
 
 		return (
 			<div className="followers-count">
-				<Button borderless href={ '/people/followers/' + slug }>
+				{ siteId && <QuerySiteStats statType="stats" siteId={ siteId } /> }
+				<Button
+					borderless
+					href={ '/people/followers/' + slug }
+					title={ translate( 'Total of WordPress and Email Followers' ) }
+					>
 					{ translate( 'Followers' ) } <Count count={ followers } />
 				</Button>
 			</div>
@@ -32,10 +40,11 @@ class FollowersCount extends Component {
 }
 
 export default connect( ( state ) => {
-	const site = getSelectedSite( state );
+	const siteId = getSelectedSiteId( state );
+	const data = getSiteStatsNormalizedData( state, siteId, 'stats' );
 
 	return {
-		slug: get( site, 'slug' ),
-		followers: get( site, 'subscribers_count' ),
+		slug: getSiteSlug( state, siteId ),
+		followers: get( data, 'followersBlog' ),
 	};
 } )( localize( FollowersCount ) );


### PR DESCRIPTION
Based on feedback in the [foums](https://en.forums.wordpress.com/topic/stats-feedback/) the number used in the `<FollowersCount />` component has caused some confusion.  Currently, the component uses the `site.subscribers_count` attribute, which only represents the number of WordPress.com followers.

<img width="940" alt="stats_ _fly_fishers_place_ _wordpress_com_" src="https://cloud.githubusercontent.com/assets/22080/22317530/1c797596-e329-11e6-96cc-6f64ee61f624.png">

In this branch, I am grabbing the `followersBlog` count from the base `/sites/${ siteID }/stats` endpoint.  This figure includes both WordPress.com and email followers.  I also added a `title` to the `<Button />` so if you hover over the count, it explains that the number includes both email and WPCOM followers.

This count now matches nicely with what is shown in the "unified followers" component that was introduced in #10765 

<img width="939" alt="stats_ _fly_fishers_place_ _wordpress_com_" src="https://cloud.githubusercontent.com/assets/22080/22317540/38278d82-e329-11e6-893a-bfc5bf92256d.png">

__To Test__
- Load a stats insights page
- Verify that the Followers number in the stats navigation bar matches the sum of the WPCOM + Email followers shown on the insights page