### PR TITLE
Stats: Add Today/Yesterday toggle support.

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -177,6 +177,7 @@ module.exports = React.createClass( {
 								query={ query }
 								date={ queryDate }
 								statType="statsTopPosts"
+								showPriorPeriodToggle={ period === 'day' }
 								showSummaryLink />
 							<StatsConnectedModule
 								path="referrers"

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -531,3 +531,7 @@ ul.module-header-actions {
 	justify-content: center;
 	align-items: center;
 }
+
+.stats-module__period-toggle{
+	padding: 10px 24px;
+}


### PR DESCRIPTION
One of the most requested features from the old stats system is the ability to toggle between "Today/Yesterday" at the stat component level.  The common use case cited was being able to quickly compare datasets between the two dates, and being able to see yesterday's "Final" numbers.

While the entire set of the prior day's data can be seen by clicking on the chart bar - this toggle is a more _lightweight_ action that only fetches the data for that particular stats module for yesterday, instead of the entire stats page worth of data.

<img width="465" alt="stats_ _the_wordpress_com_blog_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/22321856/cc04902c-e34c-11e6-90b8-8f2534adfe4d.png">

Currently, I have hard-coded support for the `day` period only.  Since this is in the context of "Today" and "Yesterday" I'm wondering if we should limit it to when viewing only today's day stat page.  Alternatively, we could change the labels on the segmented control to show the dates so it could be used regardless of which day you are actively viewing.  Extending it to other time periods wouldn't be difficult - again just more of thinking through how to properly label the controls ( "This Month / Last Month" or "Jan 2017 / Dec 2016".

Also the feature is only setup on Post & Pages right now, though it could be turned on for all other redux-powered stats components on the 'Day' page.

__To Test__
- Open a site stats day page
- Interact with the Today / Yesterday control
- Note loading state is triggered when the first fetch of 'Yesterday' happens
- Verify the Summary / View All links also point to the correct day