### PR TITLE
Domains: Deduplicate code for availability messages

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { cartItems } from 'lib/cart-values';
-import { getFixedDomainSearch, canRegister as checkDomainAvailability } from 'lib/domains';
+import { getFixedDomainSearch, checkDomainAvailability } from 'lib/domains';
 import { getAvailabilityNotice } from 'lib/domains/registration/availability-messages';
 import DomainRegistrationSuggestion from 'components/domains/domain-registration-suggestion';
 import DomainProductPrice from 'components/domains/domain-product-price';

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -21,7 +21,7 @@ import { localize } from 'i18n-calypso';
  */
 import wpcom from 'lib/wp';
 import Notice from 'components/notice';
-import { getFixedDomainSearch, canRegister } from 'lib/domains';
+import { getFixedDomainSearch, checkDomainAvailability } from 'lib/domains';
 import { getAvailabilityNotice } from 'lib/domains/registration/availability-messages';
 import SearchCard from 'components/search-card';
 import DomainRegistrationSuggestion from 'components/domains/domain-registration-suggestion';
@@ -313,7 +313,7 @@ const RegisterDomainStep = React.createClass( {
 						return callback();
 					}
 
-					canRegister( domain, ( error, result ) => {
+					checkDomainAvailability( domain, ( error, result ) => {
 						const timeDiff = Date.now() - timestamp;
 						if ( error ) {
 							this.showValidationErrorMessage( domain, error );

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -70,28 +70,6 @@ function canRegister( domainName, onComplete ) {
 	} );
 }
 
-function canMap( domainName, onComplete ) {
-	if ( ! domainName ) {
-		onComplete( new ValidationError( 'empty_query' ) );
-		return;
-	}
-
-	wpcom.undocumented().isDomainMappable( domainName, function( serverError, data ) {
-		let errorCode;
-		if ( serverError ) {
-			errorCode = serverError.error;
-		} else if ( ! data.is_mappable ) {
-			errorCode = 'not_mappable';
-		}
-
-		if ( errorCode ) {
-			onComplete( new ValidationError( errorCode ) );
-		} else {
-			onComplete( null );
-		}
-	} );
-}
-
 function canRedirect( siteId, domainName, onComplete ) {
 	if ( ! domainName ) {
 		onComplete( new ValidationError( 'empty_query' ) );
@@ -187,7 +165,6 @@ function getTld( domainName ) {
 
 export {
 	canAddGoogleApps,
-	canMap,
 	canRedirect,
 	canRegister,
 	getFixedDomainSearch,

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -31,7 +31,7 @@ function canAddGoogleApps( domainName ) {
 	return ! ( includes( GOOGLE_APPS_INVALID_TLDS, tld ) || includesBannedPhrase );
 }
 
-function canRegister( domainName, onComplete ) {
+function checkDomainAvailability( domainName, onComplete ) {
 	if ( ! domainName ) {
 		onComplete( new ValidationError( 'empty_query' ) );
 		return;
@@ -166,7 +166,7 @@ function getTld( domainName ) {
 export {
 	canAddGoogleApps,
 	canRedirect,
-	canRegister,
+	checkDomainAvailability,
 	getFixedDomainSearch,
 	getGoogleAppsSupportedDomains,
 	getPrimaryDomain,

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -1,0 +1,133 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getTld } from 'lib/domains';
+import support from 'lib/url/support';
+
+function getAvailabilityNotice( domain, error ) {
+	let message,
+		severity = 'error';
+
+	const tld = getTld( domain );
+
+	switch ( error.code ) {
+		case 'available_but_not_registrable':
+			if ( tld ) {
+				message = translate(
+					'To use a domain ending with {{strong}}.%(tld)s{{/strong}} on your site, ' +
+					'you can register it elsewhere first and then add it here. {{a}}Learn more{{/a}}.',
+					{
+						args: { tld },
+						components: {
+							strong: <strong />,
+							a: <a target="_blank" rel="noopener noreferrer" href={ support.MAP_EXISTING_DOMAIN } />
+						}
+					}
+				);
+				severity = 'info';
+			}
+			break;
+		case 'tld_in_maintenance':
+			if ( tld ) {
+				message = translate(
+					'Domains ending with {{strong}}.%(tld)s{{/strong}} are undergoing maintenance. Please check back shortly.',
+					{
+						args: { tld },
+						components: {
+							strong: <strong />
+						}
+					}
+				);
+				severity = 'info';
+			}
+			break;
+		case 'not_available_but_mappable':
+		case 'domain_registration_unavailable':
+			// unavailable domains are displayed in the search results, not as a notice OR
+			// domain registrations are closed, in which case it is handled in parent
+			message = null;
+			break;
+
+		case 'not_mappable_blacklisted_domain':
+			if ( domain.toLowerCase().indexOf( 'wordpress' ) > -1 ) {
+				message = translate(
+					'Due to {{a1}}trademark policy{{/a1}}, ' +
+					'we are not able to allow domains containing {{strong}}WordPress{{/strong}} to be registered or mapped here. ' +
+					'Please {{a2}}contact support{{/a2}} if you have any questions.',
+					{
+						components: {
+							strong: <strong />,
+							a1: <a target="_blank" rel="noopener noreferrer" href="http://wordpressfoundation.org/trademark-policy/" />,
+							a2: <a href={ support.CALYPSO_CONTACT } />
+						}
+					}
+				);
+			} else {
+				message = translate( 'Domain cannot be mapped to a WordPress.com blog because of blacklisted term.' );
+			}
+			break;
+
+		case 'not_mappable_forbidden_subdomain':
+			message = translate( 'Subdomains starting with \'www.\' cannot be mapped to a WordPress.com blog' );
+			break;
+
+		case 'not_mappable_forbidden_domain':
+			message = translate( 'Only the owner of the domain can map its subdomains.' );
+			break;
+
+		case 'not_mappable_invalid_tld':
+		case 'invalid_query':
+			message = translate( 'Sorry, %(domain)s does not appear to be a valid domain name.', {
+				args: { domain: domain }
+			} );
+			break;
+
+		case 'not_mappable_mapped_domain':
+			message = translate( 'This domain is already mapped to a WordPress.com site.' );
+			break;
+
+		case 'not_mappable_restricted_domain':
+			message = translate(
+				'You cannot map another WordPress.com subdomain - try creating a new site or one of the custom domains below.'
+			);
+			break;
+
+		case 'not_mappable_recently_mapped':
+			message = translate( 'This domain was recently in use by someone else and is not available to map yet. ' +
+				'Please try again later or contact support.' );
+			break;
+
+		// Generic error message when domain is not mappable without an explicit unmappability reason
+		case 'not_mappable':
+			message = translate( 'Sorry, this domain cannot be mapped.' );
+			break;
+
+		case 'empty_query':
+			message = translate( 'Please enter a domain name or keyword.' );
+			break;
+
+		case 'empty_results':
+			message = translate( "We couldn't find any available domains for: %(domain)s", {
+				args: { domain }
+			} );
+			break;
+
+		default:
+			message = translate( 'Sorry, there was a problem processing your request. Please try again in a few minutes.' );
+	}
+
+	return {
+		message,
+		severity
+	};
+}
+
+export {
+	getAvailabilityNotice
+};

--- a/client/my-sites/upgrades/map-domain/index.jsx
+++ b/client/my-sites/upgrades/map-domain/index.jsx
@@ -82,7 +82,7 @@ var MapDomain = React.createClass( {
 		upgradesActions.addItem(
 			cartItems.domainRegistration( {
 				productSlug: suggestion.product_slug,
-				domain: suggestion.domain
+				domain: suggestion.domain_name
 			} )
 		);
 


### PR DESCRIPTION
This has created a lot of problems in the past (for example, #10176).
This change deduplicates the code responsible for handling the availability messages. Additionally, it removes a call to `is-mappable` endpoint - we are already calling the superior `is-available` endpoint
(that properly handles .co subdomains, etc.).

_Additionally_, I've fixed an error that prevented registering a domain from the map-domain-step 😅 

### Testing
Make sure that all the cases returned by the `is-availability` endpoint are properly handled in both register-domain-step (domain search) and map-domain-step (domain mapping). Be sure to test from both domain management and signup.

Additionally, check that it is now possible to add a domain registration directly from the domain mapping view (if you search for an available domain there).