### PR TITLE
Themes: Use redux state for upload page back button

### DIFF
--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -55,6 +55,7 @@ function getProps( context ) {
 }
 
 export function upload( context, next ) {
+	// Store previous path to return to only if it was main showcase page
 	if ( startsWith( context.prevPath, '/design' ) &&
 		! startsWith( context.prevPath, '/design/upload' ) ) {
 		context.store.dispatch( setBackPath( context.prevPath ) );

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import compact from 'lodash/compact';
+import { compact, startsWith } from 'lodash';
 import debugFactory from 'debug';
 import Lru from 'lru';
 import React from 'react';
@@ -15,7 +15,7 @@ import LoggedOutComponent from './logged-out';
 import Upload from 'my-sites/themes/theme-upload';
 import trackScrollPage from 'lib/track-scroll-page';
 import { DEFAULT_THEME_QUERY } from 'state/themes/constants';
-import { requestThemes, receiveThemes } from 'state/themes/actions';
+import { requestThemes, receiveThemes, setBackPath } from 'state/themes/actions';
 import { getThemesForQuery } from 'state/themes/selectors';
 import { getAnalyticsData } from './helpers';
 
@@ -55,6 +55,11 @@ function getProps( context ) {
 }
 
 export function upload( context, next ) {
+	if ( startsWith( context.prevPath, '/design' ) &&
+		! startsWith( context.prevPath, '/design/upload' ) ) {
+		context.store.dispatch( setBackPath( context.prevPath ) );
+	}
+
 	context.primary = <Upload />;
 	next();
 }

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -42,6 +42,7 @@ import { connectOptions } from 'my-sites/themes/theme-options';
 import QueryEligibility from 'components/data/query-atat-eligibility';
 import EligibilityWarnings from 'blocks/eligibility-warnings';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
+import { getBackPath } from 'state/themes/themes-ui/selectors';
 
 const debug = debugFactory( 'calypso:themes:theme-upload' );
 
@@ -60,6 +61,7 @@ class Upload extends React.Component {
 		installing: React.PropTypes.bool,
 		isJetpackSite: React.PropTypes.bool,
 		upgradeJetpack: React.PropTypes.bool,
+		backPath: React.PropTypes.string,
 	};
 
 	state = {
@@ -145,10 +147,6 @@ class Upload extends React.Component {
 			? this.props.uploadTheme : this.props.initiateThemeTransfer;
 		action( siteId, file );
 	}
-
-	onBackClick = () => {
-		window.history.back();
-	};
 
 	renderDropZone() {
 		const { translate } = this.props;
@@ -266,14 +264,14 @@ class Upload extends React.Component {
 				<ThanksModal
 					site={ selectedSite }
 					source="upload" />
-				<HeaderCake onClick={ this.onBackClick }>{ translate( 'Upload theme' ) }</HeaderCake>
+				<HeaderCake backHref={ this.props.backPath }>{ translate( 'Upload theme' ) }</HeaderCake>
 				{ upgradeJetpack && <JetpackManageErrorPage
 					template="updateJetpack"
 					siteId={ siteId }
 					featureExample={ this.renderUploadCard() }
 					version="4.4.2" /> }
 				{ showEligibility && <EligibilityWarnings
-					backUrl="/design"
+					backUrl={ this.props.backPath }
 					onProceed={ this.onProceedClick } /> }
 				{ ! upgradeJetpack && ! showEligibility && this.renderUploadCard() }
 			</Main>
@@ -313,6 +311,7 @@ export default connect(
 			progressLoaded: getUploadProgressLoaded( state, siteId ),
 			installing: isInstallInProgress( state, siteId ),
 			upgradeJetpack: isJetpack && ! hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ),
+			backPath: getBackPath( state ),
 		};
 	},
 	{ uploadTheme, clearThemeUpload, initiateThemeTransfer },

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -24,8 +24,7 @@ import { localize } from 'i18n-calypso';
 import notices from 'notices';
 import debugFactory from 'debug';
 import { uploadTheme, clearThemeUpload, initiateThemeTransfer } from 'state/themes/actions';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite, hasJetpackSiteJetpackThemesExtendedFeatures } from 'state/sites/selectors';
 import {
 	isUploadInProgress,
@@ -296,6 +295,8 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const themeId = getUploadedThemeId( state, siteId );
 		const isJetpack = isJetpackSite( state, siteId );
+		const siteSlug = getSelectedSiteSlug( state );
+		const backPath = getBackPath( state );
 
 		return {
 			siteId,
@@ -311,7 +312,7 @@ export default connect(
 			progressLoaded: getUploadProgressLoaded( state, siteId ),
 			installing: isInstallInProgress( state, siteId ),
 			upgradeJetpack: isJetpack && ! hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ),
-			backPath: getBackPath( state ),
+			backPath: includes( backPath, siteSlug ) ? backPath : `/design/${ siteSlug }`,
 		};
 	},
 	{ uploadTheme, clearThemeUpload, initiateThemeTransfer },

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -24,7 +24,7 @@ import { localize } from 'i18n-calypso';
 import notices from 'notices';
 import debugFactory from 'debug';
 import { uploadTheme, clearThemeUpload, initiateThemeTransfer } from 'state/themes/actions';
-import { getSelectedSiteId, getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { isJetpackSite, hasJetpackSiteJetpackThemesExtendedFeatures } from 'state/sites/selectors';
 import {
 	isUploadInProgress,
@@ -295,9 +295,6 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const themeId = getUploadedThemeId( state, siteId );
 		const isJetpack = isJetpackSite( state, siteId );
-		const siteSlug = getSelectedSiteSlug( state );
-		const backPath = getBackPath( state );
-
 		return {
 			siteId,
 			selectedSite: getSelectedSite( state ),
@@ -312,7 +309,7 @@ export default connect(
 			progressLoaded: getUploadProgressLoaded( state, siteId ),
 			installing: isInstallInProgress( state, siteId ),
 			upgradeJetpack: isJetpack && ! hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ),
-			backPath: includes( backPath, siteSlug ) ? backPath : `/design/${ siteSlug }`,
+			backPath: getBackPath( state ),
 		};
 	},
 	{ uploadTheme, clearThemeUpload, initiateThemeTransfer },

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -251,6 +251,7 @@ class Upload extends React.Component {
 			selectedSite,
 			themeId,
 			upgradeJetpack,
+			backPath,
 		} = this.props;
 
 		const showEligibility = ! this.props.isJetpackSite && this.state.showEligibility;
@@ -263,14 +264,14 @@ class Upload extends React.Component {
 				<ThanksModal
 					site={ selectedSite }
 					source="upload" />
-				<HeaderCake backHref={ this.props.backPath }>{ translate( 'Upload theme' ) }</HeaderCake>
+				<HeaderCake backHref={ backPath }>{ translate( 'Upload theme' ) }</HeaderCake>
 				{ upgradeJetpack && <JetpackManageErrorPage
 					template="updateJetpack"
 					siteId={ siteId }
 					featureExample={ this.renderUploadCard() }
 					version="4.4.2" /> }
 				{ showEligibility && <EligibilityWarnings
-					backUrl={ this.props.backPath }
+					backUrl={ backPath }
 					onProceed={ this.onProceedClick } /> }
 				{ ! upgradeJetpack && ! showEligibility && this.renderUploadCard() }
 			</Main>

--- a/client/state/themes/themes-ui/selectors.js
+++ b/client/state/themes/themes-ui/selectors.js
@@ -1,4 +1,20 @@
+/**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+
 // Returns destination for theme sheet 'back' button
 export function getBackPath( state ) {
-	return state.themes.themesUI.backPath;
+	const backPath = state.themes.themesUI.backPath;
+	const siteSlug = getSelectedSiteSlug( state );
+
+	if ( includes( backPath, siteSlug ) ) {
+		return backPath;
+	}
+	return `/design/${ siteSlug }`;
 }

--- a/client/state/themes/themes-ui/selectors.js
+++ b/client/state/themes/themes-ui/selectors.js
@@ -13,7 +13,7 @@ export function getBackPath( state ) {
 	const backPath = state.themes.themesUI.backPath;
 	const siteSlug = getSelectedSiteSlug( state );
 
-	if ( includes( backPath, siteSlug ) ) {
+	if ( ! siteSlug || includes( backPath, siteSlug ) ) {
 		return backPath;
 	}
 	return `/design/${ siteSlug }`;

--- a/client/state/themes/themes-ui/test/selectors.js
+++ b/client/state/themes/themes-ui/test/selectors.js
@@ -23,6 +23,28 @@ describe( 'selectors', () => {
 			expect( getBackPath( state ) ).to.eql( '/design' );
 		} );
 
+		it( 'should return stored path if it includes current selected site', () => {
+			const state = {
+				themes: {
+					themesUI: {
+						backPath: '/design/premium/example.wordpress.com?s=blue',
+					}
+				},
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.wordpress.com',
+						}
+					}
+				},
+				ui: {
+					selectedSiteId: 2916284,
+				}
+			};
+			expect( getBackPath( state ) ).to.eql( '/design/premium/example.wordpress.com?s=blue' );
+		} );
+
 		it( 'should return default path with selected site if selected site not in stored path', () => {
 			const state = {
 				themes: {

--- a/client/state/themes/themes-ui/test/selectors.js
+++ b/client/state/themes/themes-ui/test/selectors.js
@@ -15,11 +15,34 @@ describe( 'selectors', () => {
 			const state = {
 				themes: {
 					themesUI: {
-						backPath: '/design'
+						backPath: '/design',
 					}
-				}
+				},
+				ui: {}
 			};
 			expect( getBackPath( state ) ).to.eql( '/design' );
+		} );
+
+		it( 'should return default path with selected site if selected site not in stored path', () => {
+			const state = {
+				themes: {
+					themesUI: {
+						backPath: '/design/premium',
+					}
+				},
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.wordpress.com',
+						}
+					}
+				},
+				ui: {
+					selectedSiteId: 2916284,
+				}
+			};
+			expect( getBackPath( state ) ).to.eql( '/design/example.wordpress.com' );
 		} );
 	} );
 } );


### PR DESCRIPTION
![back_path](https://cloud.githubusercontent.com/assets/7767559/22327634/15aee3c2-e3b0-11e6-91d2-d1efc6fbcf04.gif)

Allow the theme upload page _Back_ button to return to any previous theme query state.

Use the same back path state in the upload page as we use for the theme info sheets. Only set the path state if the previous page was '/design' (but not '/design/upload').

Use path for <- back button and 'cancel' button on the eligibility form.

~~**Note** @folletto If the active site is changed whilst on the upload page, the `back` button will not take user to /design page for the new active site. If we want that behaviour, we will have to use a different approach.~~

Also fixes #11039 and #8500
