### PR TITLE
Guided Tours: update feature flags

### DIFF
--- a/client/layout/guided-tours/docs/TUTORIAL.md
+++ b/client/layout/guided-tours/docs/TUTORIAL.md
@@ -101,7 +101,7 @@ Now add that tour to the [tour list](../config.js):
 +    tutorialSitePreview: TutorialSitePreviewTour,
 ```
 
-And add a [feature flag](https://github.com/Automattic/wp-calypso/blob/1cdd7380bb457dd4653fad1f27a6a53065d64c24/config/development.json#L46-L49) for the appropriate environment(s), such as `"guided-tours/tutorial-site-preview": true,`.
+And add a [feature flag](https://github.com/Automattic/wp-calypso/blob/master/config/development.json) for the appropriate environment(s), such as `"guided-tours/tutorial-site-preview": true,`.
 
 **Important:** use the feature flag to ensure that the tour is only triggered in environments where all the required features are available. E.g. especially the `desktop` environment may differ from general Calypso because of the different context that it runs in and the different release cycles. 
 

--- a/client/layout/guided-tours/docs/TUTORIAL.md
+++ b/client/layout/guided-tours/docs/TUTORIAL.md
@@ -103,6 +103,8 @@ Now add that tour to the [tour list](../config.js):
 
 And add a [feature flag](https://github.com/Automattic/wp-calypso/blob/1cdd7380bb457dd4653fad1f27a6a53065d64c24/config/development.json#L46-L49) for the appropriate environment(s), such as `"guided-tours/tutorial-site-preview": true,`.
 
+**Important:** use the feature flag to ensure that the tour is only triggered in environments where all the required features are available. E.g. especially the `desktop` environment may differ from general Calypso because of the different context that it runs in and the different release cycles. 
+
 ### The Tour element
 
 Now in between the `makeTour` parantheses, create the tour element:

--- a/client/layout/guided-tours/tours/main-tour.js
+++ b/client/layout/guided-tours/tours/main-tour.js
@@ -34,6 +34,8 @@ import scrollTo from 'lib/scroll-to';
 const scrollSidebarToTop = () =>
 	scrollTo( { y: 0, container: getScrollableSidebar() } );
 
+// note that this tour checks for a non-existent feature flag.
+// this is kept as an example, while making sure it never gets triggered
 export const MainTour = makeTour(
 	<Tour name="main" version="20160601" path="/" when={ and( isNewUser, isEnabled( 'guided-tours/main' ) ) }>
 		<Step name="init" placement="right">

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -193,7 +193,7 @@ Layout = React.createClass( {
 			<div className={ sectionClass }>
 				<DocumentHead />
 				<QueryPreferences />
-				{ config.isEnabled( 'guided-tours' ) ? <GuidedTours /> : null }
+				{ <GuidedTours /> }
 				{ config.isEnabled( 'keyboard-shortcuts' ) ? <KeyboardShortcutsMenu /> : null }
 				{ this.renderMasterbar() }
 				{ config.isEnabled( 'support-user' ) && <SupportUser /> }

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -22,7 +22,6 @@
 		"fluid-width": true,
 		"help": true,
 		"help/courses": true,
-		"guided-tours": true,
 		"jetpack/connect": true,
 		"jetpack/personalPlan": true,
 		"jetpack/seo-tools": true,

--- a/config/development.json
+++ b/config/development.json
@@ -41,7 +41,6 @@
 		"devdocs/components-usage-stats": false,
 		"dev/test-helper": true,
 		"guided-tours/main": true,
-		"guided-tours/tutorial-site-preview": false,
 		"guided-tours/design-showcase-welcome": true,
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,

--- a/config/development.json
+++ b/config/development.json
@@ -40,7 +40,6 @@
 		"devdocs/redirect-loggedout-homepage": true,
 		"devdocs/components-usage-stats": false,
 		"dev/test-helper": true,
-		"guided-tours/main": true,
 		"guided-tours/design-showcase-welcome": true,
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,

--- a/config/development.json
+++ b/config/development.json
@@ -44,7 +44,6 @@
 		"guided-tours/design-showcase-welcome": true,
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,
-		"guided-tours/themes": false,
 		"help": true,
 		"help/courses": true,
 		"jetpack/connect": true,

--- a/config/development.json
+++ b/config/development.json
@@ -40,7 +40,6 @@
 		"devdocs/redirect-loggedout-homepage": true,
 		"devdocs/components-usage-stats": false,
 		"dev/test-helper": true,
-		"guided-tours": true,
 		"guided-tours/main": true,
 		"guided-tours/tutorial-site-preview": false,
 		"guided-tours/design-showcase-welcome": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -19,7 +19,6 @@
 		"code-splitting": true,
 		"community-translator": true,
 		"devdocs": false,
-		"guided-tours": true,
 		"happychat": false,
 		"help": true,
 		"help/courses": true,

--- a/config/production.json
+++ b/config/production.json
@@ -17,7 +17,6 @@
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,
-		"guided-tours": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -20,7 +20,6 @@
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,
-		"guided-tours": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -24,7 +24,6 @@
 		"devdocs/redirect-loggedout-homepage": false,
 		"devdocs/components-usage-stats": false,
 		"dev/test-helper": true,
-		"guided-tours/main": false,
 		"guided-tours/design-showcase-welcome": true,
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -24,7 +24,6 @@
 		"devdocs/redirect-loggedout-homepage": false,
 		"devdocs/components-usage-stats": false,
 		"dev/test-helper": true,
-		"guided-tours": true,
 		"guided-tours/main": false,
 		"guided-tours/design-showcase-welcome": true,
 		"guided-tours/site-title": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -28,7 +28,6 @@
 		"guided-tours/design-showcase-welcome": true,
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,
-		"guided-tours/themes": true,
 		"help": true,
 		"help/courses": true,
 		"jetpack/connect": true,


### PR DESCRIPTION
This PR removes a few unused feature flags. 

Guided Tours the framework will be available in all environments. Individual tours will need to check whether the features they need will be available in, e.g., the `desktop` environment. 

The `main` tour will use a non-existent feature flag. This is deliberate, as it is an example / showcase tour that we never want to be triggered, but still keep with a realistic trigger function as an example. 