### PR TITLE
Theme Actions: Introduce "smart" `activate` and `tryAndCustomize` actions

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -585,8 +585,6 @@ const ThemeSheetWithOptions = ( props ) => {
 		isLoggedIn,
 		isPremium,
 		isPurchased,
-		isJetpack,
-		isWpcomTheme,
 	} = props;
 	const siteId = site ? site.ID : null;
 
@@ -596,8 +594,6 @@ const ThemeSheetWithOptions = ( props ) => {
 		defaultOption = 'signup';
 	} else if ( isActive ) {
 		defaultOption = 'customize';
-	} else if ( isJetpack && isWpcomTheme ) {
-		defaultOption = 'activateOnJetpack';
 	} else if ( isPremium && ! isPurchased ) {
 		defaultOption = 'purchase';
 	} else {
@@ -614,11 +610,9 @@ const ThemeSheetWithOptions = ( props ) => {
 				'tryandcustomize',
 				'purchase',
 				'activate',
-				'activateOnJetpack',
-				'tryAndCustomizeOnJetpack',
 			] }
 			defaultOption={ defaultOption }
-			secondaryOption={ ( isJetpack && isWpcomTheme ) ? 'tryAndCustomizeOnJetpack' : 'tryandcustomize' }
+			secondaryOption={ 'tryandcustomize' }
 			source="showcase-sheet" />
 	);
 };

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -89,8 +89,8 @@ const ConnectedSingleSiteJetpack = connectOptions(
 						<div>
 							<ConnectedThemesSelection
 								options={ [
-									'activateOnJetpack',
-									'tryAndCustomizeOnJetpack',
+									'activate',
+									'tryandcustomize',
 									'customize',
 									'separator',
 									'info',

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -13,7 +13,7 @@ import config from 'config';
 import {
 	activateTheme,
 	installAndActivateTheme,
-	installAndTryAndCustomize,
+	installAndTryAndCustomizeTheme,
 	confirmDelete,
 } from 'state/themes/actions';
 import {

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -12,7 +12,7 @@ import { has, identity, mapValues, pick, pickBy } from 'lodash';
 import config from 'config';
 import {
 	activateTheme,
-	installAndActivate,
+	installAndActivateTheme,
 	installAndTryAndCustomize,
 	confirmDelete,
 } from 'state/themes/actions';

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -11,9 +11,8 @@ import { has, identity, mapValues, pick, pickBy } from 'lodash';
  */
 import config from 'config';
 import {
-	activateTheme,
-	installAndActivateTheme,
-	installAndTryAndCustomizeTheme,
+	activate as activateAction,
+	tryAndCustomize as tryAndCustomizeAction,
 	confirmDelete,
 } from 'state/themes/actions';
 import {
@@ -53,23 +52,9 @@ const purchase = config.isEnabled( 'upgrades/checkout' )
 const activate = {
 	label: i18n.translate( 'Activate' ),
 	header: i18n.translate( 'Activate on:', { comment: 'label for selecting a site on which to activate a theme' } ),
-	action: activateTheme,
+	action: activateAction,
 	hideForTheme: ( state, theme, siteId ) => (
 		isActive( state, theme.id, siteId ) || ( isPremium( state, theme.id ) && ! isPremiumThemeAvailable( state, theme.id, siteId ) )
-	)
-};
-
-const activateOnJetpack = {
-	label: i18n.translate( 'Activate' ),
-	header: i18n.translate( 'Activate on:', { comment: 'label for selecting a site on which to activate a theme' } ),
-	// Append `-wpcom` suffix to the theme ID so the installAndActivate() will install the theme from WordPress.com, not WordPress.org
-	action: ( themeId, siteId, ...args ) => installAndActivate( themeId + '-wpcom', siteId, ...args ),
-	hideForSite: ( state, siteId ) => ! isJetpackSite( state, siteId ),
-	hideForTheme: ( state, theme, siteId ) => (
-		isActive( state, theme.id, siteId ) || (
-			isPremium( state, theme.id ) &&
-			! hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ) // Pressable sites included -- they're always on a Business plan
-		)
 	)
 };
 
@@ -94,24 +79,9 @@ const tryandcustomize = {
 	header: i18n.translate( 'Try & Customize on:', {
 		comment: 'label in the dialog for opening the Customizer with the theme in preview'
 	} ),
-	getUrl: getCustomizeUrl,
+	action: tryAndCustomizeAction,
 	hideForSite: ( state, siteId ) => ! canCurrentUser( state, siteId, 'edit_theme_options' ),
 	hideForTheme: ( state, theme, siteId ) => isActive( state, theme.id, siteId )
-};
-
-const tryAndCustomizeOnJetpack = {
-	label: i18n.translate( 'Try & Customize' ),
-	header: i18n.translate( 'Try & Customize on:', {
-		comment: 'label in the dialog for opening the Customizer with the theme in preview'
-	} ),
-	action: ( themeId, siteId ) => installAndTryAndCustomize( themeId + '-wpcom', siteId ),
-	hideForSite: ( state, siteId ) => ! canCurrentUser( state, siteId, 'edit_theme_options' ) || ! isJetpackSite( state, siteId ),
-	hideForTheme: ( state, theme, siteId ) => (
-		isActive( state, theme.id, siteId ) || (
-			isPremium( state, theme.id ) &&
-			! hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ) // Pressable sites included -- they're always on a Business plan
-		)
-	)
 };
 
 // This is a special option that gets its `action` added by `ThemeShowcase` or `ThemeSheet`,
@@ -161,10 +131,8 @@ const ALL_THEME_OPTIONS = {
 	preview,
 	purchase,
 	activate,
-	activateOnJetpack,
 	deleteTheme,
 	tryandcustomize,
-	tryAndCustomizeOnJetpack,
 	signup,
 	separator,
 	info,

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -313,6 +313,28 @@ export function requestActiveTheme( siteId ) {
 
 /**
  * Triggers a network request to activate a specific theme on a given site.
+ * If it's a Jetpack site, installs the theme prior to activation if it isn't already.
+ *
+ * @param  {String}   themeId   Theme ID
+ * @param  {Number}   siteId    Site ID
+ * @param  {String}   source    The source that is reuquesting theme activation, e.g. 'showcase'
+ * @param  {Boolean}  purchased Whether the theme has been purchased prior to activation
+ * @return {Function}           Action thunk
+ */
+export function activate( themeId, siteId, source = 'unknown', purchased = false ) {
+	return ( dispatch, getState ) => {
+		if ( isJetpackSite( getState(), siteId ) && ! getTheme( getState(), siteId, themeId ) ) {
+			// Suffix themeId here with `-wpcom`. If the suffixed theme is already installed,
+			// installation will silently fail, and it will just be activated.
+			return dispatch( installAndActivateTheme( themeId + '-wpcom', siteId, source, purchased ) );
+		}
+
+		return dispatch( activateTheme( themeId, siteId, source, purchased ) );
+	};
+}
+
+/**
+ * Triggers a network request to activate a specific theme on a given site.
  *
  * @param  {String}   themeId   Theme ID
  * @param  {Number}   siteId    Site ID

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -455,6 +455,26 @@ export function clearActivated( siteId ) {
 }
 
 /**
+ * Switches to the customizer to preview a given theme.
+ * If it's a Jetpack site, installs the theme prior to activation if it isn't already.
+ *
+ * @param  {String}   themeId   Theme ID
+ * @param  {Number}   siteId    Site ID
+ * @return {Function}           Action thunk
+ */
+export function tryAndCustomize( themeId, siteId ) {
+	return ( dispatch, getState ) => {
+		if ( isJetpackSite( getState(), siteId ) && ! getTheme( getState(), siteId, themeId ) ) {
+			// Suffix themeId here with `-wpcom`. If the suffixed theme is already installed,
+			// installation will silently fail, and we just switch to the customizer.
+			return dispatch( installAndTryAndCustomizeTheme( themeId + '-wpcom', siteId ) );
+		}
+
+		return dispatch( tryAndCustomizeTheme( themeId, siteId ) );
+	};
+}
+
+/**
  * Triggers a network request to install theme on Jetpack site.
  * After installataion it switches page to the customizer
  * See installTheme doc for install options.

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -487,7 +487,7 @@ export function tryAndCustomize( themeId, siteId ) {
  * @param  {Boolean}  purchased Whether the theme has been purchased prior to activation
  * @return {Function}           Action thunk
  */
-export function installAndActivate( themeId, siteId, source = 'unknown', purchased = false ) {
+export function installAndActivateTheme( themeId, siteId, source = 'unknown', purchased = false ) {
 	return ( dispatch ) => {
 		return dispatch( installTheme( themeId, siteId ) )
 			.then( () => {

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -504,7 +504,8 @@ export function installAndTryAndCustomizeTheme( themeId, siteId ) {
  */
 export function tryAndCustomizeTheme( themeId, siteId ) {
 	return ( dispatch, getState ) => {
-		const theme = getTheme( getState(), siteId, themeId );
+		const siteIdOrWpcom = isJetpackSite( getState(), siteId ) ? siteId : 'wpcom';
+		const theme = getTheme( getState(), siteIdOrWpcom, themeId );
 		if ( ! theme ) {
 			dispatch( {
 				type: THEME_TRY_AND_CUSTOMIZE_FAILURE,

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -507,12 +507,11 @@ export function tryAndCustomizeTheme( themeId, siteId ) {
 		const siteIdOrWpcom = isJetpackSite( getState(), siteId ) ? siteId : 'wpcom';
 		const theme = getTheme( getState(), siteIdOrWpcom, themeId );
 		if ( ! theme ) {
-			dispatch( {
+			return dispatch( {
 				type: THEME_TRY_AND_CUSTOMIZE_FAILURE,
 				themeId,
 				siteId
 			} );
-			return;
 		}
 		const url = getThemeCustomizeUrl( getState(), theme, siteId );
 		page( url );

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -442,11 +442,11 @@ export function clearActivated( siteId ) {
  * @param  {String}   siteId       Jetpack Site ID
  * @return {Function}              Action thunk
  */
-export function installAndTryAndCustomize( themeId, siteId ) {
+export function installAndTryAndCustomizeTheme( themeId, siteId ) {
 	return ( dispatch ) => {
 		return dispatch( installTheme( themeId, siteId ) )
 			.then( () => {
-				dispatch( tryAndCustomize( themeId, siteId ) );
+				dispatch( tryAndCustomizeTheme( themeId, siteId ) );
 			} );
 	};
 }
@@ -460,7 +460,7 @@ export function installAndTryAndCustomize( themeId, siteId ) {
  * @param  {String}   siteId       Jetpack Site ID
  * @return {Function}              Action thunk
  */
-export function tryAndCustomize( themeId, siteId ) {
+export function tryAndCustomizeTheme( themeId, siteId ) {
 	return ( dispatch, getState ) => {
 		const theme = getTheme( getState(), siteId, themeId );
 		if ( ! theme ) {

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -555,7 +555,7 @@ describe( 'actions', () => {
 			res();
 		} ) );
 
-		it( 'should dispatch THEME_ACTIVATE_REQUEST, installTheme(), and activateTheme()', ( done ) => {
+		it( 'should dispatch installTheme() and activateTheme()', ( done ) => {
 			installAndActivateTheme( 'karuna-wpcom', 2211667 )( stub ).then( () => {
 				expect( stub ).to.have.been.calledWith( matchFunction( installTheme( 'karuna-wpcom', 2211667 ) ) );
 				expect( stub ).to.have.been.calledWith( matchFunction( activateTheme( 'karuna-wpcom', 2211667 ) ) );

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -39,7 +39,7 @@ import {
 	themeActivated,
 	clearActivated,
 	activateTheme,
-	installAndActivate,
+	installAndActivateTheme,
 	requestActiveTheme,
 	receiveTheme,
 	receiveThemes,
@@ -546,14 +546,14 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( '#installAndActivate', () => {
+	describe( '#installAndActivateTheme', () => {
 		const stub = sinon.stub();
 		stub.returns( new Promise( ( res ) => {
 			res();
 		} ) );
 
 		it( 'should dispatch THEME_ACTIVATE_REQUEST, installTheme(), and activateTheme()', ( done ) => {
-			installAndActivate( 'karuna-wpcom', 2211667 )( stub ).then( () => {
+			installAndActivateTheme( 'karuna-wpcom', 2211667 )( stub ).then( () => {
 				expect( stub ).to.have.been.calledWith( matchFunction( installTheme( 'karuna-wpcom', 2211667 ) ) );
 				expect( stub ).to.have.been.calledWith( matchFunction( activateTheme( 'karuna-wpcom', 2211667 ) ) );
 				done();

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -997,7 +997,7 @@ describe( 'actions', () => {
 			}
 			return false;
 		};
-		const getThemeSpy = ( store, siteId, themeId ) => {
+		const getThemeSpy = ( state, siteId, themeId ) => {
 			if ( themeId === 'karuna-wpcom' ) {
 				return { theme: themeId };
 			}

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -991,6 +991,12 @@ describe( 'actions', () => {
 
 	describe( '#tryAndCustomizeTheme', () => {
 		const pageSpy = sinon.spy();
+		const isJetpackSiteSpy = ( state, siteId ) => {
+			if ( siteId === 2211667 ) {
+				return true;
+			}
+			return false;
+		};
 		const getThemeSpy = ( store, siteId, themeId ) => {
 			if ( themeId === 'karuna-wpcom' ) {
 				return { theme: themeId };
@@ -1003,6 +1009,9 @@ describe( 'actions', () => {
 
 		useMockery( ( mockery ) => {
 			mockery.registerMock( 'page', pageSpy );
+			mockery.registerMock( 'state/sites/selectors', {
+				isJetpackSite: isJetpackSiteSpy
+			} );
 			mockery.registerMock( './selectors', {
 				getThemeCustomizeUrl: () => 'customizer/url',
 				getTheme: getThemeSpy,

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -48,8 +48,8 @@ import {
 	pollThemeTransferStatus,
 	initiateThemeTransfer,
 	installTheme,
-	installAndTryAndCustomize,
-	tryAndCustomize,
+	installAndTryAndCustomizeTheme,
+	tryAndCustomizeTheme,
 	deleteTheme,
 } from '../actions';
 import useNock from 'test/helpers/use-nock';
@@ -910,7 +910,7 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( '#tryAndCustomize', () => {
+	describe( '#tryAndCustomizeTheme', () => {
 		const pageSpy = sinon.spy();
 		const getThemeSpy = ( store, siteId, themeId ) => {
 			if ( themeId === 'karuna-wpcom' ) {
@@ -928,7 +928,7 @@ describe( 'actions', () => {
 				getThemeCustomizeUrl: () => 'customizer/url',
 				getTheme: getThemeSpy,
 			} );
-			_tryAndCustomize = require( '../actions' ).tryAndCustomize;
+			_tryAndCustomize = require( '../actions' ).tryAndCustomizeTheme;
 		} );
 
 		it( 'page should be called, when theme is available', () => {
@@ -950,16 +950,16 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( '#installAndTryAndCustomize', () => {
+	describe( '#installAndTryAndCustomizeTheme', () => {
 		const stub = sinon.stub();
 		stub.returns( new Promise( ( res ) => {
 			res();
 		} ) );
 
-		it( 'should dispatch installTheme(), and tryAndCustomize()', ( done ) => {
-			installAndTryAndCustomize( 'karuna-wpcom', 2211667 )( stub ).then( () => {
+		it( 'should dispatch installTheme(), and tryAndCustomizeTheme()', ( done ) => {
+			installAndTryAndCustomizeTheme( 'karuna-wpcom', 2211667 )( stub ).then( () => {
 				expect( stub ).to.have.been.calledWith( matchFunction( installTheme( 'karuna-wpcom', 2211667 ) ) );
-				expect( stub ).to.have.been.calledWith( matchFunction( tryAndCustomize( 'karuna-wpcom', 2211667 ) ) );
+				expect( stub ).to.have.been.calledWith( matchFunction( tryAndCustomizeTheme( 'karuna-wpcom', 2211667 ) ) );
 				done();
 			} );
 		} );


### PR DESCRIPTION
Rename existing actions to be consistent, and introduce new `activate` and `tryAndCustomize` actions that use `getState()` to act as follows (description given for `activate`; `tryAndCustomize` works alike):

* If on WP.com, simply activate the given theme
* If on a Jetpack site
  * and the theme exists, activate
  * and the theme doesn't exist, call `installAndActivate` with the `-wpcom` suffixed `themeId`. If the _suffixed_ version exists, the `install` part will silently fail, and the `activate` part will plainly activate the suffixed theme.

(You'll see this list reflected in the new unit tests.)

To test:
* Make sure that theme activation still works as before in different scenarios (Jetpack in particular).

This is the first step toward #2128. In a subsequent PR, we'll want to remove the [hardwired check](https://github.com/Automattic/wp-calypso/blob/b4813ed232287a77773eba48dcfb081d05f22786/client/my-sites/themes/themes-site-selector-modal.jsx#L104) for `site.jetpack` from `ThemesSiteSelectorModal` and replace by the given option's `hideForSite` and `hideForTheme` predicates instead. (We might have to tweak the TSSM a bit to support that, too.)

See #10959 and convo starting at https://github.com/Automattic/wp-calypso/issues/2128#issuecomment-275214084 for further reference