### PR TITLE
Reader: Add a MC beacon when we push a page view

### DIFF
--- a/client/blocks/daily-post-button/test/index.jsx
+++ b/client/blocks/daily-post-button/test/index.jsx
@@ -31,6 +31,7 @@ describe( 'DailyPostButton', () => {
 			recordTrackForPost: noop,
 		};
 		mockery.registerMock( 'reader/stats', statsMocks );
+		mockery.registerMock( 'lib/analytics', stub() );
 		mockery.registerMock( 'lib/sites-list', () => sitesListMock );
 		mockery.registerMock( 'page', pageSpy );
 		mockery.registerMock( 'components/sites-popover', SitesPopover );

--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -300,6 +300,7 @@ function markPostSeen( post, site ) {
 		if ( site && site.ID ) {
 			if ( site.is_private || ! isAdmin ) {
 				stats.pageViewForPost( site.ID, site.URL, post.ID, site.is_private );
+				stats.bumpStat( 'reader_pageviews', site.is_private ? 'private_view' : 'public_view' );
 			}
 		}
 	}

--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -20,7 +20,8 @@ const Dispatcher = require( 'dispatcher' ),
 	FeedPostActionType = require( './constants' ).action,
 	FeedStreamActionType = require( 'lib/feed-stream-store/constants' ).action,
 	ReaderSiteBlockActionType = require( 'lib/reader-site-blocks/constants' ).action,
-	stats = require( 'reader/stats' );
+	stats = require( 'reader/stats' ),
+	mc = require( 'lib/analytics' ).mc;
 
 let _posts = {},
 	_postsForBlogs = {};
@@ -300,7 +301,7 @@ function markPostSeen( post, site ) {
 		if ( site && site.ID ) {
 			if ( site.is_private || ! isAdmin ) {
 				stats.pageViewForPost( site.ID, site.URL, post.ID, site.is_private );
-				stats.bumpStat( 'reader_pageviews', site.is_private ? 'private_view' : 'public_view' );
+				mc.bumpStat( 'reader_pageviews', site.is_private ? 'private_view' : 'public_view' );
 			}
 		}
 	}


### PR DESCRIPTION
This should allow us to notice more quickly when page view volume changes.

To test, take the actions that generate a page view and check the debug log to make sure the new stat is firing.