### PR TITLE
Themes: Site picker for upload page

### DIFF
--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -4,7 +4,7 @@
 import config from 'config';
 import userFactory from 'lib/user';
 import { makeLayout } from 'controller';
-import { makeNavigation, siteSelection } from 'my-sites/controller';
+import { makeNavigation, siteSelection, makeSites } from 'my-sites/controller';
 import { singleSite, multiSite, loggedOut, upload } from './controller';
 import { getSubjects } from './theme-filters';
 import validateFilters from './validate-filters';
@@ -16,6 +16,13 @@ export default function( router ) {
 
 	if ( config.isEnabled( 'manage/themes' ) ) {
 		if ( isLoggedIn ) {
+			if ( config.isEnabled( 'manage/themes/upload' ) ) {
+				router( '/design/upload', makeSites, makeLayout );
+				router(
+					'/design/upload/:site_id?',
+					siteSelection, upload, makeNavigation, makeLayout
+				);
+			}
 			router(
 				`/design/:vertical(${ verticals })?/:tier(free|premium)?`,
 				siteSelection, multiSite, makeNavigation, makeLayout
@@ -32,13 +39,6 @@ export default function( router ) {
 				`/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter/:site_id`,
 				validateFilters, siteSelection, singleSite, makeNavigation, makeLayout
 			);
-			if ( config.isEnabled( 'manage/themes/upload' ) ) {
-				router(
-					'/design/upload/:site_id',
-					siteSelection, upload, makeNavigation, makeLayout
-				);
-				// TODO (seear): make `sites` middleware work for single-tree to allow /design/upload
-			}
 		} else {
 			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, loggedOut, makeLayout );
 			router(


### PR DESCRIPTION
<img width="1207" alt="screen shot 2017-01-26 at 17 10 34" src="https://cloud.githubusercontent.com/assets/7767559/22341883/73979832-e3ea-11e6-83a4-1b33e74bc6e1.png">

Show the site picker page on the /design/upload route when no site is selected.

This PR introduces a new middleware for adding the site picker to the layout without rendering, which is necessary for use with the single-tree-layouts used on the /design routes.

**To Test**
* Go to http://calypso.localhost:3000/design/upload
* **Expected:** The site picker should be displayed, selecting a site should take you to the upload page
* Also check an existing use of the site picker, for example http://calypso.localhost:3000/menus
