### PR TITLE
AT: ignore other actions when at transfer is in progress

### DIFF
--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -70,7 +70,7 @@ SitesList.prototype.get = function() {
  * @api public
  */
 SitesList.prototype.fetch = function() {
-	if ( ! userUtils.isLoggedIn() || this.fetching ) {
+	if ( ! userUtils.isLoggedIn() || this.fetching || this.ignoreUpdates ) {
 		return;
 	}
 
@@ -86,9 +86,20 @@ SitesList.prototype.fetch = function() {
 			return;
 		}
 
+		if ( this.ignoreUpdates ) {
+			this.fetching = false;
+			return;
+		}
+
 		this.sync( data );
 		this.fetching = false;
 	}.bind( this ) );
+};
+
+// FOR NUCLEAR AUTOMATED TRANSFER OPTION
+// See: https://github.com/Automattic/wp-calypso/pull/10986
+SitesList.prototype.pauseFetching = function() {
+	this.ignoreUpdates = true;
 };
 
 SitesList.prototype.sync = function( data ) {

--- a/client/state/automated-transfer/enhancer.js
+++ b/client/state/automated-transfer/enhancer.js
@@ -1,0 +1,68 @@
+/**
+ * Internal dependencies
+ */
+import { isAutomatedTransferActive } from 'state/selectors/';
+import {
+	AUTOMATED_TRANSFER_ELIGIBILITY_REQUEST,
+	AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE,
+	AUTOMATED_TRANSFER_STATUS_SET,
+	THEME_TRANSFER_INITIATE_FAILURE,
+	THEME_TRANSFER_INITIATE_PROGRESS,
+	THEME_TRANSFER_INITIATE_REQUEST,
+	THEME_TRANSFER_INITIATE_SUCCESS,
+	THEME_TRANSFER_STATUS_FAILURE,
+	THEME_TRANSFER_STATUS_RECEIVE
+} from 'state/action-types';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import config from 'config';
+
+const WHITELIST = [
+	AUTOMATED_TRANSFER_ELIGIBILITY_REQUEST,
+	AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE,
+	AUTOMATED_TRANSFER_STATUS_SET,
+	THEME_TRANSFER_INITIATE_FAILURE,
+	THEME_TRANSFER_INITIATE_PROGRESS,
+	THEME_TRANSFER_INITIATE_REQUEST,
+	THEME_TRANSFER_INITIATE_SUCCESS,
+	THEME_TRANSFER_STATUS_FAILURE,
+	THEME_TRANSFER_STATUS_RECEIVE
+];
+
+/**
+ * Redux store enhancer that updates dispatch to ignore actions when an
+ * automated transfer is in progress.
+ *
+ * @param  {Function} createStore Original store creator
+ * @return {Function}             Modified store creator
+ */
+export const automatedTransferEnhancer = createStore => ( reducer, initialState, enhancer ) => {
+	const store = createStore( reducer, initialState, enhancer );
+	const isDevOrWPCalypso = [ 'development', 'wpcalypso' ].indexOf( config( 'env' ) ) > -1;
+
+	if ( ! ( config.isEnabled( 'automated-transfer' ) && isDevOrWPCalypso ) ) {
+		return store;
+	}
+
+	return {
+		...store,
+		dispatch( action ) {
+			const state = store.getState();
+			const selectedSiteId = getSelectedSiteId( state );
+			const transferActive = isAutomatedTransferActive( state, selectedSiteId );
+
+			if ( ! transferActive || WHITELIST.indexOf( action.type ) > -1 ) {
+				//dispatch normally
+				store.dispatch( action );
+				return action;
+			}
+			const noopAction = {
+				type: '@@calypso/noop-transfer-in-progress',
+				originalAction: action
+			};
+			store.dispatch( noopAction );
+			return noopAction;
+		}
+	};
+};
+
+export default automatedTransferEnhancer;

--- a/client/state/automated-transfer/enhancer.js
+++ b/client/state/automated-transfer/enhancer.js
@@ -43,6 +43,8 @@ export const automatedTransferEnhancer = createStore => ( reducer, initialState,
 		return store;
 	}
 
+	const sites = require( 'lib/sites-list' )();
+
 	return {
 		...store,
 		dispatch( action ) {
@@ -55,6 +57,7 @@ export const automatedTransferEnhancer = createStore => ( reducer, initialState,
 				store.dispatch( action );
 				return action;
 			}
+			sites.pauseFetching();
 			const noopAction = {
 				type: '@@calypso/noop-transfer-in-progress',
 				originalAction: action

--- a/client/state/automated-transfer/middleware.js
+++ b/client/state/automated-transfer/middleware.js
@@ -1,0 +1,35 @@
+/**
+ * Internal dependencies
+ */
+import localforage from 'lib/localforage';
+import {
+	THEME_TRANSFER_STATUS_RECEIVE,
+	AUTOMATED_TRANSFER_STATUS_SET,
+	AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE
+} from 'state/action-types';
+
+const clearBrowserStorageAndRefresh = ( dispatch, { status } ) => {
+	if ( typeof window !== 'undefined' && status === 'complete' ) {
+		localStorage.clear();
+		const reloadPage = window.location.reload.bind( window.location );
+		localforage.clear().then( reloadPage, reloadPage );
+	}
+};
+
+export const handlers = {
+	[ THEME_TRANSFER_STATUS_RECEIVE ]: clearBrowserStorageAndRefresh,
+	[ AUTOMATED_TRANSFER_STATUS_SET ]: clearBrowserStorageAndRefresh,
+	[ AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE ]: clearBrowserStorageAndRefresh
+};
+
+/**
+ * Middleware
+ */
+
+export default ( { dispatch, getState } ) => ( next ) => ( action ) => {
+	if ( handlers.hasOwnProperty( action.type ) ) {
+		handlers[ action.type ]( dispatch, action, getState );
+	}
+
+	return next( action );
+};

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -57,6 +57,8 @@ import themes from './themes/reducer';
 import ui from './ui/reducer';
 import users from './users/reducer';
 import wordads from './wordads/reducer';
+import automatedTransferEnhancer from './automated-transfer/enhancer';
+import config from 'config';
 
 /**
  * Module variables
@@ -111,6 +113,10 @@ export const reducer = combineReducers( {
 	wordads,
 } );
 
+// TEMPORARY AT FLOW FIX, NOT INTENDED FOR PROD
+const isDevOrWPCalypso = [ 'development', 'wpcalypso' ].indexOf( config( 'env' ) ) > -1;
+const atEnabled = isDevOrWPCalypso && config.isEnabled( 'automated-transfer' );
+
 export function createReduxStore( initialState = {} ) {
 	const isBrowser = typeof window === 'object';
 
@@ -119,12 +125,14 @@ export function createReduxStore( initialState = {} ) {
 		noticesMiddleware,
 		isBrowser && require( './analytics/middleware.js' ).analyticsMiddleware,
 		isBrowser && require( './data-layer/wpcom-api-middleware.js' ).default,
+		isBrowser && atEnabled && require( './automated-transfer/middleware.js' ).default
 	].filter( Boolean );
 
 	const enhancers = [
 		isBrowser && window.app && window.app.isDebug && consoleDispatcher,
 		applyMiddleware( ...middlewares ),
 		isBrowser && sitesSync,
+		isBrowser && atEnabled && automatedTransferEnhancer,
 		isBrowser && window.devToolsExtension && window.devToolsExtension()
 	].filter( Boolean );
 


### PR DESCRIPTION
This is a hacky workaround to get a happy flow for automated transfer. Fixes #10977

Changes here include modifying store dispatches to ignore actions when a transfer is in progress, ignore SitesList fetches, and middleware to nuke local browser storage and refresh the page when a transfer completes. 

This is intended to be **_temporary_**, and is only meant as a placeholder in order for us to continue development on automated transfers. Before we ship AT to users, we should find an alternate fix. The store enhancer is too costly to use in a prod environment. 

### Testing Instructions
To simulate behavior:
- In the console type: 

```
dispatch( { type: 'AUTOMATED_TRANSFER_STATUS_SET', siteId: <your current site id>, status: 'start' } )
```
- Try to perform some action, like navigation. If the actions depend on redux state, nothing should happen. In redux dev tools you should see no-ops being fired instead:
<img width="1299" alt="screen shot 2017-01-26 at 4 17 48 pm" src="https://cloud.githubusercontent.com/assets/1270189/22356037/3bfe181c-e3e3-11e6-94ed-3e988aacfd66.png">
- Then type: 

```
dispatch( { type: 'AUTOMATED_TRANSFER_STATUS_SET', siteId: <your current site id>, status: 'complete' } );
```
<img width="1296" alt="screen shot 2017-01-26 at 4 23 29 pm" src="https://cloud.githubusercontent.com/assets/1270189/22356139/fd76bd1e-e3e3-11e6-9b0a-948e506527f2.png">

#### Full Flow Instructions
- Create a new site
- Choose a .blog domain
- Select the buisness plan
- Complete checkout
- Verify email address for domain
- Set domain to primary
- Navigate to plugins, select a custom plugin to upload
- Wait on the page
- No js errors should fire, window should reload when transfer is complete.
