### PR TITLE
SSR: Cache State

### DIFF
--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -13,7 +13,7 @@ import {
 	requestTheme,
 	setBackPath
 } from 'state/themes/actions';
-import { getTheme, getThemeRequestErrors } from 'state/themes/selectors';
+import { getTheme } from 'state/themes/selectors';
 import config from 'config';
 
 const debug = debugFactory( 'calypso:themes' );
@@ -27,26 +27,11 @@ export function fetchThemeDetailsData( context, next ) {
 	const theme = getTheme( context.store.getState(), themeSlug );
 
 	if ( theme ) {
-		debug( 'found theme!', theme.id );
-		context.renderCacheKey = context.path + theme.timestamp;
+		debug( 'found theme in cache!', theme.id );
 		return next();
 	}
 
-	context.store.dispatch( requestTheme( themeSlug, 'wpcom' ) )
-		.then( () => {
-			const themeDetails = getTheme( context.store.getState(), 'wpcom', themeSlug );
-			if ( ! themeDetails ) {
-				const error = getThemeRequestErrors( context.store.getState(), themeSlug, 'wpcom' );
-				debug( `Error fetching theme ${ themeSlug } details: `, error.message || error );
-				context.renderCacheKey = 'theme not found';
-			} else {
-				debug( 'caching', themeSlug );
-				themeDetails.timestamp = Date.now();
-				context.renderCacheKey = context.path + themeDetails.timestamp;
-			}
-			next();
-		} )
-		.catch( next );
+	context.store.dispatch( requestTheme( themeSlug, 'wpcom' ) ).then( next );
 }
 
 export function details( context, next ) {

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -3,7 +3,6 @@
  */
 import { compact, includes, isEmpty, startsWith } from 'lodash';
 import debugFactory from 'debug';
-import Lru from 'lru';
 import React from 'react';
 
 /**
@@ -15,16 +14,11 @@ import LoggedOutComponent from './logged-out';
 import Upload from 'my-sites/themes/theme-upload';
 import trackScrollPage from 'lib/track-scroll-page';
 import { DEFAULT_THEME_QUERY } from 'state/themes/constants';
-import { requestThemes, receiveThemes, setBackPath } from 'state/themes/actions';
+import { requestThemes, setBackPath } from 'state/themes/actions';
 import { getThemesForQuery, getThemesFoundForQuery } from 'state/themes/selectors';
 import { getAnalyticsData } from './helpers';
 
 const debug = debugFactory( 'calypso:themes' );
-const HOUR_IN_MS = 3600000;
-const themesQueryCache = new Lru( {
-	max: 500,
-	maxAge: HOUR_IN_MS
-} );
 
 function getProps( context ) {
 	const { tier, filter, vertical, site_id: siteId } = context.params;
@@ -114,11 +108,10 @@ export function fetchThemeData( context, next ) {
 	const cacheKey = context.pathname;
 
 	if ( shouldUseCache ) {
-		const cachedData = themesQueryCache.get( cacheKey );
-		if ( cachedData ) {
+		const themes = getThemesForQuery( context.store.getState(), siteId, query );
+		if ( themes ) {
 			debug( `found theme data in cache key=${ cacheKey }` );
-			context.store.dispatch( receiveThemes( cachedData.themes, siteId, query, cachedData.found ) );
-			context.renderCacheKey = cacheKey + cachedData.timestamp;
+			context.renderCacheKey = context.path;
 			return next();
 		}
 	}
@@ -126,12 +119,7 @@ export function fetchThemeData( context, next ) {
 	context.store.dispatch( requestThemes( siteId, query ) )
 		.then( () => {
 			if ( shouldUseCache ) {
-				const themes = getThemesForQuery( context.store.getState(), siteId, query );
-				const found = getThemesFoundForQuery( context.store.getState(), siteId, query );
-				const timestamp = Date.now();
-				themesQueryCache.set( cacheKey, { themes, found, timestamp } );
-				context.renderCacheKey = cacheKey + timestamp;
-				debug( `caching theme data key=${ cacheKey }` );
+				context.renderCacheKey = context.path; // + timestamp;
 			}
 			next();
 		} )

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -15,7 +15,7 @@ import Upload from 'my-sites/themes/theme-upload';
 import trackScrollPage from 'lib/track-scroll-page';
 import { DEFAULT_THEME_QUERY } from 'state/themes/constants';
 import { requestThemes, setBackPath } from 'state/themes/actions';
-import { getThemesForQuery, getThemesFoundForQuery } from 'state/themes/selectors';
+import { getThemesForQuery } from 'state/themes/selectors';
 import { getAnalyticsData } from './helpers';
 
 const debug = debugFactory( 'calypso:themes' );
@@ -102,28 +102,16 @@ export function fetchThemeData( context, next ) {
 		page: 1,
 		number: DEFAULT_THEME_QUERY.number,
 	};
-	// context.pathname includes tier, filter, and verticals, but not the query string, so it's a suitable cacheKey
-	// However, we can't guarantee it's normalized -- filters can be in any order, resulting in multiple possible cacheKeys for
-	// the same sets of results.
-	const cacheKey = context.pathname;
 
 	if ( shouldUseCache ) {
 		const themes = getThemesForQuery( context.store.getState(), siteId, query );
 		if ( themes ) {
-			debug( `found theme data in cache key=${ cacheKey }` );
-			context.renderCacheKey = context.path;
+			debug( 'found theme data in cache' );
 			return next();
 		}
 	}
 
-	context.store.dispatch( requestThemes( siteId, query ) )
-		.then( () => {
-			if ( shouldUseCache ) {
-				context.renderCacheKey = context.path; // + timestamp;
-			}
-			next();
-		} )
-		.catch( () => next() );
+	context.store.dispatch( requestThemes( siteId, query ) ).then( next );
 }
 
 // Legacy (Atlas-based Theme Showcase v4) route redirects

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -8,7 +8,7 @@ import qs from 'qs';
 import { execSync } from 'child_process';
 import cookieParser from 'cookie-parser';
 import debugFactory from 'debug';
-import { get } from 'lodash';
+import { get, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,7 +19,9 @@ import utils from 'bundler/utils';
 import sectionsModule from '../../client/sections';
 import { serverRouter } from 'isomorphic-routing';
 import { serverRender } from 'render';
-import { createReduxStore } from 'state';
+import stateCache from 'state-cache';
+import { createReduxStore, reducer } from 'state';
+import { DESERIALIZE } from 'state/action-types';
 
 const debug = debugFactory( 'calypso:pages' );
 
@@ -37,6 +39,12 @@ const staticFiles = [
 ];
 
 const sections = sectionsModule.get();
+
+function getInitialServerState( serializedServerState ) {
+	// Bootstrapped state from a server-render
+	const serverState = reducer( serializedServerState, { type: DESERIALIZE } );
+	return pick( serverState, Object.keys( serializedServerState ) );
+}
 
 /**
  * Generates a hash of a files contents to be used as a version parameter on asset requests.
@@ -111,6 +119,10 @@ function getCurrentCommitShortChecksum() {
 }
 
 function getDefaultContext( request ) {
+	// context.path is set to req.url, see server/isomorphic-routing#getEnhancedContext()
+	const serializeCachedServerState = stateCache.get( request.url ) || {};
+	const cachedServerState = reducer( getInitialServerState( serializeCachedServerState ), { type: DESERIALIZE } );
+
 	const context = Object.assign( {}, request.context, {
 		compileDebug: config( 'env' ) === 'development' ? true : false,
 		urls: generateStaticUrls( request ),
@@ -126,7 +138,7 @@ function getDefaultContext( request ) {
 		isFluidWidth: !! config.isEnabled( 'fluid-width' ),
 		abTestHelper: !! config.isEnabled( 'dev/test-helper' ),
 		devDocsURL: '/devdocs',
-		store: createReduxStore()
+		store: createReduxStore( cachedServerState )
 	} );
 
 	context.app = {

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -3,7 +3,7 @@
  */
 import express from 'express';
 import fs from 'fs';
-import crypto from 'crypto';
+import { createHash } from 'crypto';
 import qs from 'qs';
 import { execSync } from 'child_process';
 import cookieParser from 'cookie-parser';
@@ -52,7 +52,7 @@ function getInitialServerState( serializedServerState ) {
  * @returns {String} A shortened md5 hash of the contents of the file file or a timestamp in the case of failure.
  **/
 function hashFile( path ) {
-	const md5 = crypto.createHash( 'md5' );
+	const md5 = createHash( 'md5' );
 	let data, hash;
 
 	try {

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -17,6 +17,9 @@ import {
 	getDocumentHeadMeta,
 	getDocumentHeadLink
 } from 'state/document-head/selectors';
+import { reducer } from 'state';
+import { SERIALIZE } from 'state/action-types';
+import stateCache from 'state-cache';
 
 const debug = debugFactory( 'calypso:server-render' );
 const markupCache = new Lru( { max: 3000 } );
@@ -91,7 +94,11 @@ export function serverRender( req, res ) {
 			reduxSubtrees = reduxSubtrees.concat( [ 'ui', 'themes' ] );
 		}
 
+		// Send state to client. Don't we need to serialize here?
 		context.initialReduxState = pick( context.store.getState(), reduxSubtrees );
+		// And cache on the server, too
+		const serverState = reducer( context.initialReduxState, { type: SERIALIZE } );
+		stateCache.set( context.path, serverState );
 	}
 
 	context.head = { title, metas, links };

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -80,7 +80,7 @@ export function serverRender( req, res ) {
 	}
 
 	if ( config.isEnabled( 'server-side-rendering' ) && context.layout && ! context.user ) {
-		const key = context.renderCacheKey || JSON.stringify( context.layout );
+		const key = context.path || JSON.stringify( context.layout );
 		Object.assign( context, render( context.layout, key ) );
 	}
 
@@ -98,7 +98,8 @@ export function serverRender( req, res ) {
 		context.initialReduxState = pick( context.store.getState(), reduxSubtrees );
 		// And cache on the server, too
 		const serverState = reducer( context.initialReduxState, { type: SERIALIZE } );
-		stateCache.set( context.path, serverState );
+		// context.pathname is the path void of the query string, which seems a good choice for a cache key
+		stateCache.set( context.pathname, serverState );
 	}
 
 	context.head = { title, metas, links };

--- a/server/state-cache/index.js
+++ b/server/state-cache/index.js
@@ -1,0 +1,12 @@
+/**
+ * External Dependencies
+ */
+import Lru from 'lru';
+
+const HOUR_IN_MS = 3600000;
+const stateCache = new Lru( {
+	max: 500,
+	maxAge: HOUR_IN_MS
+} );
+
+export default stateCache;


### PR DESCRIPTION
_tl;dr: Simplify server-side API data caching by leveraging Redux state serialization._

Previously, controllers of SSR'd sections were responsible for caching API data. But there's a better way: We're already sending Redux state to the client at server-render time, so why not also cache on the server side, and use that as the initial state when creating the Redux store for the next request (given that this is in logged-out mode, i.e. the cache key -- the route -- maps one-to-one to the state).

Previously, we'd be just [copying](https://github.com/Automattic/wp-calypso/blob/master/client/state/themes/actions.js#L174-L180) the `.then()` callback from the `requestThemes` action. So instead of doing this, I took a step back and came up with the present solution.

Furthermore, this PR removes `renderCacheKey` and just uses `context.path` for _markup_ cache. Previously, we were using concatenated path and API data (~sate) cache timestamp as key. Creating the markup cache key isn't the section controller's responsibility now. (If we still need the timestamp, we can add it back when caching in `server/render`.)

To test:
* Verify that Calypso still works.
* Enable `debug` for the server. I forgot how to do that 😊  Alternatively:
* Put a `console.log` [here](https://github.com/Automattic/wp-calypso/pull/10988/files#diff-b2d6784517d1151d7e75f0287d0c6478R134) to inspect `cachedServerState` (or `get( cachedServerState, 'themes.queries.wpcom.data')`), load `/themes` in your browser, watch your node console, reload `/themes` in your browser, compare.

TODO:
* Add logged-out check before using cached state as initial state in `server/pages`