### PR TITLE
Plugins: Fix IE11 error caused by calling includes

### DIFF
--- a/client/my-sites/plugins-wpcom/jetpack-plugin-item.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugin-item.jsx
@@ -3,7 +3,10 @@
  */
 import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
-import { identity } from 'lodash';
+import {
+	identity,
+	includes,
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,7 +36,7 @@ export const JetpackPluginItem = ( {
 			<a href={ plugin.link } className="plugins-wpcom__plugin-link">
 				<div className="plugins-wpcom__plugin-name">
 					{ plugin.name }
-					{ [ 'premium', 'business' ].includes( plugin.plan ) &&
+					{ includes( [ 'premium', 'business' ], plugin.plan ) &&
 						<span className={ planClasses }>
 							{ translatePlan[ plugin.plan ] }
 						</span>


### PR DESCRIPTION
`Array.prototype.includes` is not polyfilled and was causing the plugins
page to crash on IE11. Replacing it with `includes` from `lodash`.

**Testing instructions:**

1. Use IE11.
2. Navigate to `plugins/{siteSlug}` on your WordPress.com test site.
3. Verify that the page loads correctly.
4. Verify that `Business` is shown next to SEO Tools, and Google Analytics.
5. Verify that `Premium` is shown next to Custom Design, and Video Uploads.