### PR TITLE
Stats: Reduxify the stats comments component on the stats insights page

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -100,7 +100,6 @@ module.exports = {
 
 	insights: function( context, next ) {
 		const Insights = require( 'my-sites/stats/stats-insights' );
-		const StatsList = require( 'lib/stats/stats-list' );
 		const FollowList = require( 'lib/follow-list' );
 		let siteId = context.params.site_id;
 		const basePath = route.sectionify( context.path );
@@ -128,17 +127,11 @@ module.exports = {
 			}
 		}
 
-		const siteDomain = ( site && ( typeof site.slug !== 'undefined' ) )
-			? site.slug : route.getSiteFragment( context.path );
-
-		const commentsList = new StatsList( { siteID: siteId, statType: 'statsComments', domain: siteDomain } );
-
 		analytics.pageView.record( basePath, analyticsPageTitle + ' > Insights' );
 
 		renderWithReduxStore(
 			React.createElement( StatsComponent, {
 				followList: followList,
-				commentsList: commentsList
 			} ),
 			document.getElementById( 'primary' ),
 			context.store

--- a/client/my-sites/stats/stats-comments/comment-tab.jsx
+++ b/client/my-sites/stats/stats-comments/comment-tab.jsx
@@ -7,43 +7,38 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import observe from 'lib/mixins/data-observe';
 import StatsList from '../stats-list';
 import StatsListLegend from '../stats-list/legend';
 
-export default React.createClass( {
-	displayName: 'StatsCommentTab',
+const StatsCommentTab = ( props ) => {
+	const { data, followList, isActive, name, value, label } = props;
+	let statsList;
 
-	mixins: [ observe( 'dataList' ) ],
-
-	propTypes: {
-		dataList: PropTypes.object,
-		dataKey: PropTypes.string,
-		followList: PropTypes.object,
-		name: PropTypes.string,
-		value: PropTypes.string,
-		label: PropTypes.string,
-		isActive: PropTypes.bool
-	},
-
-	render() {
-		const { dataList, dataKey, followList, isActive, name, value, label } = this.props;
-		let statsList;
-
-		if ( dataList.response.data && dataList.response.data[ dataKey ] ) {
-			statsList = <StatsList
-							moduleName={ name }
-							data={ dataList.response.data[ dataKey ] }
-							followList={ followList } />;
-		}
-
-		const classes = classNames( 'stats-comments__tab-content', { 'is-active': isActive } );
-
-		return (
-			<div className={ classes }>
-				<StatsListLegend value={ value } label={ label } />
-				{ statsList }
-			</div>
-		);
+	if ( data ) {
+		statsList = <StatsList
+			moduleName={ name }
+			data={ data }
+			followList={ followList }
+		/>;
 	}
-} );
+
+	const classes = classNames( 'stats-comments__tab-content', { 'is-active': isActive } );
+
+	return (
+		<div className={ classes }>
+			<StatsListLegend value={ value } label={ label } />
+			{ statsList }
+		</div>
+	);
+};
+
+StatsCommentTab.propTypes = {
+	data: PropTypes.array,
+	followList: PropTypes.object,
+	name: PropTypes.string,
+	value: PropTypes.string,
+	label: PropTypes.string,
+	isActive: PropTypes.bool
+};
+
+export default StatsCommentTab;

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -28,7 +28,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, getSiteOption } from 'state/sites/selectors';
 
 const StatsInsights = ( props ) => {
-	const { commentsList, followList, gmtOffset, isJetpack, moment, siteId, translate } = props;
+	const { followList, gmtOffset, isJetpack, moment, siteId, translate } = props;
 	const moduleStrings = statsStrings();
 
 	let momentSiteZone = moment();
@@ -73,7 +73,6 @@ const StatsInsights = ( props ) => {
 						<div className="stats__module-column">
 							<Comments
 								path={ 'comments' }
-								commentsList={ commentsList }
 								followList={ followList }
 							/>
 							{ tagsList }
@@ -96,7 +95,6 @@ const StatsInsights = ( props ) => {
 };
 
 StatsInsights.propTypes = {
-	commentsList: PropTypes.object.isRequired,
 	followList: PropTypes.object.isRequired,
 	moment: PropTypes.func,
 	translate: PropTypes.func,

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -252,6 +252,63 @@ describe( 'utils', () => {
 			} );
 		} );
 
+		describe( 'statsComments()', () => {
+			it( 'should return null if no data is provided', () => {
+				const parsedData = normalizers.statsComments();
+				expect( parsedData ).to.be.null;
+			} );
+
+			it( 'should properly parse comments stats response', () => {
+				const parsedData = normalizers.statsComments( {
+					authors: [
+						{
+							name: 'John',
+							comments: 12,
+							link: '?user_id=1662656',
+							gravatar: 'https://secure.gravatar.com/blavatar/5a83891a81b057fed56930a6aaaf7b3c?s=48',
+							follow_data: null,
+						}
+					],
+					posts: [
+						{
+							id: 1111,
+							name: 'My title',
+							comments: 10,
+							link: 'https://en.blog.wordpress.com/chicken',
+						}
+					]
+				} );
+
+				expect( parsedData ).to.eql( {
+					posts: [ {
+						actions: [
+							{
+								data: 'https://en.blog.wordpress.com/chicken',
+								type: 'link'
+							}
+						],
+						label: 'My title',
+						page: null,
+						value: 10
+					} ],
+					authors: [ {
+						actions: [
+							{
+								data: false,
+								type: 'follow'
+							}
+						],
+						className: 'module-content-list-item-large',
+						icon: 'https://secure.gravatar.com/blavatar/5a83891a81b057fed56930a6aaaf7b3c?d=mm',
+						iconClassName: 'avatar-user',
+						label: 'John',
+						link: 'nulledit-comments.php?user_id=1662656',
+						value: 12
+					} ]
+				} );
+			} );
+		} );
+
 		describe( 'statsTopPosts()', () => {
 			it( 'should return an empty array if data is null', () => {
 				const parsedData = normalizers.statsTopPosts();

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -330,6 +330,50 @@ export const normalizers = {
 		return { page, pages, total, posts };
 	},
 
+	statsComments( data, query, siteId, site ) {
+		if ( ! data ) {
+			return null;
+		}
+		const adminUrl = site ? site.options.admin_url : null;
+
+		let authors = [];
+		if ( data.authors ) {
+			authors = data.authors.map( ( author ) => {
+				return {
+					label: author.name,
+					value: author.comments,
+					iconClassName: 'avatar-user',
+					icon: parseAvatar( author.gravatar ),
+					link: adminUrl + 'edit-comments.php' + author.link,
+					className: 'module-content-list-item-large',
+					actions: [
+						{
+							type: 'follow',
+							data: author.follow_data ? author.follow_data.params : false
+						}
+					]
+				};
+			} );
+		}
+
+		let posts = [];
+		if ( data.posts ) {
+			posts = data.posts.map( ( post ) => {
+				return {
+					label: post.name,
+					value: post.comments,
+					page: site ? '/stats/post/' + post.id + '/' + site.slug : null,
+					actions: [ {
+						type: 'link',
+						data: post.link
+					} ]
+				};
+			} );
+		}
+
+		return { authors, posts };
+	},
+
 	/**
 	 * Returns a normalized statsVideo array, ready for use in stats-module
 	 *


### PR DESCRIPTION
In this PR, I create a normalizer for the `statsComments` (It may be the last stats normalizer to port) and I use the `QueryStatsList` on the Comments component on the Stats Insights Page.

**Testing instructions**

 - Navigate to the stats insights page
 - Make sure the comments component is showing the comments stats as expected.