### PR TITLE
Stats: Reduxify the Stats Followers Page

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -494,12 +494,10 @@ module.exports = {
 		let siteId = context.params.site_id;
 		const FollowList = require( 'lib/follow-list' );
 		const FollowsComponent = require( 'my-sites/stats/follows' );
-		const StatsList = require( 'lib/stats/stats-list' );
 		const validFollowTypes = [ 'wpcom', 'email', 'comment' ];
 		const followType = context.params.follow_type;
 		let pageNum = context.params.page_num;
 		const followList = new FollowList();
-		let followersList;
 		const basePath = route.sectionify( context.path );
 
 		let site = sites.getSite( siteId );
@@ -529,19 +527,6 @@ module.exports = {
 				pageNum = 1;
 			}
 
-			switch ( followType ) {
-				case 'comment':
-					followersList = new StatsList( {
-						siteID: siteId, statType: 'statsCommentFollowers', domain: siteDomain, max: 20, page: pageNum } );
-					break;
-
-				case 'email':
-				case 'wpcom':
-					followersList = new StatsList( {
-						siteID: siteId, statType: 'statsFollowers', domain: siteDomain, max: 20, page: pageNum, type: followType } );
-					break;
-			}
-
 			analytics.pageView.record(
 				basePath.replace( '/' + pageNum, '' ),
 				analyticsPageTitle + ' > Followers > ' + titlecase( followType )
@@ -555,7 +540,6 @@ module.exports = {
 					page: pageNum,
 					perPage: 20,
 					total: 10,
-					followersList: followersList,
 					followType: followType,
 					followList: followList,
 					domain: siteDomain

--- a/client/my-sites/stats/follows/index.jsx
+++ b/client/my-sites/stats/follows/index.jsx
@@ -1,59 +1,59 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
+import { flowRight } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Followers from '../stats-followers-page';
 import HeaderCake from 'components/header-cake';
-import analytics from 'lib/analytics';
 import Main from 'components/main';
 import StatsFirstView from '../stats-first-view';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
-const StatsFollows = React.createClass( {
-	propTypes: {
+class StatsFollows extends Component {
+	static propTypes = {
 		followType: PropTypes.string,
 		followList: PropTypes.object,
-		follwersList: PropTypes.object,
 		page: PropTypes.number,
 		perPage: PropTypes.number,
 		slug: PropTypes.string,
 		translate: PropTypes.func,
-	},
+	};
 
-	goBack() {
+	goBack = () => {
 		page( '/stats/insights/' + this.props.slug );
-	},
+	};
 
 	componentDidMount() {
 		window.scrollTo( 0, 0 );
-	},
+	}
 
-	paginationHandler( pageNum ) {
+	paginationHandler = ( pageNum ) => {
 		let path = '/stats/follows/' + this.props.followType + '/';
 		if ( pageNum > 1 ) {
 			path += pageNum + '/';
 		}
 		path += this.props.slug;
-		analytics.ga.recordEvent( 'Stats', 'Used Pagination on Followers Page', pageNum );
+		this.props.recordGoogleEvent( 'Stats', 'Used Pagination on Followers Page', pageNum );
 		page( path );
-	},
+	};
 
-	changeFilter( selection ) {
+	changeFilter = ( selection ) => {
 		const filter = selection.value;
 
 		page( '/stats/follows/' + filter + '/' + this.props.slug );
-	},
+	};
 
 	render() {
-		const { followType, followersList, followList, perPage, translate } = this.props;
+		const { followType, followList, perPage, translate } = this.props;
 
 		return (
 			<Main wideLayout={ true }>
@@ -65,7 +65,6 @@ const StatsFollows = React.createClass( {
 					</HeaderCake>
 					<Followers
 						path={ followType + '-follow-summary' }
-						followersList={ followersList }
 						followType={ followType }
 						followList={ followList }
 						page={ this.props.page }
@@ -76,12 +75,20 @@ const StatsFollows = React.createClass( {
 			</Main>
 		);
 	}
-} );
+}
 
-export default connect( ( state ) => {
-	const siteId = getSelectedSiteId( state );
+const connectComponent = connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
 
-	return {
-		slug: getSiteSlug( state, siteId )
-	};
-} )( localize( StatsFollows ) );
+		return {
+			slug: getSiteSlug( state, siteId )
+		};
+	},
+	{ recordGoogleEvent }
+);
+
+export default flowRight(
+	connectComponent,
+	localize
+)( StatsFollows );

--- a/client/my-sites/stats/stats-followers-page/index.jsx
+++ b/client/my-sites/stats/stats-followers-page/index.jsx
@@ -1,91 +1,72 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+import React, { Component } from 'react';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { get, flowRight } from 'lodash';
 
 /**
  * Internal dependencies
  */
-var StatsList = require( '../stats-list' ),
-	StatsListLegend = require( '../stats-list/legend' ),
-	StatsModuleSelectDropdown = require( '../stats-module/select-dropdown' ),
-	StatsModulePlaceholder = require( '../stats-module/placeholder' ),
-	ErrorPanel = require( '../stats-error' ),
-	Pagination = require( '../pagination' ),
-	analytics = require( 'lib/analytics' ),
-	Card = require( 'components/card' ),
-	SectionHeader = require( 'components/section-header' ),
-	Button = require( 'components/button' );
-import observe from 'lib/mixins/data-observe';
+import StatsList from '../stats-list';
+import StatsListLegend from '../stats-list/legend';
+import StatsModuleSelectDropdown from '../stats-module/select-dropdown';
+import StatsModulePlaceholder from '../stats-module/placeholder';
+import ErrorPanel from '../stats-error';
+import Pagination from '../pagination';
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+import Button from 'components/button';
+import QuerySiteStats from 'components/data/query-site-stats';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import {
+	isRequestingSiteStatsForQuery,
+	getSiteStatsNormalizedData,
+	hasSiteStatsQueryFailed
+} from 'state/stats/lists/selectors';
 
-const StatModuleFollowersPage = React.createClass( {
-	mixins: [ observe( 'followersList' ) ],
-
-	data: function( nextProps ) {
-		var props = nextProps || this.props;
-		return props.followersList.response.data;
-	},
-
-	getInitialState: function() {
-		return {
-			activeFilter: 'wpcom-followers',
-			noData: this.props.followersList.isEmpty( 'subscribers' )
-		};
-	},
-
-	componentWillReceiveProps: function( nextProps ) {
-		this.setState( {
-			noData: nextProps.followersList.isEmpty( 'subscribers' )
-		} );
-	},
-
-	filterSelect: function() {
-		const { translate } = this.props;
-		var selectFilter,
-			options = [
-				{
-					value: 'wpcom',
-					label: translate( 'WordPress.com Followers' )
-				},
-				{
-					value: 'email',
-					label: translate( 'Email Followers' )
-				}
-			];
-
-		if ( 'comment' !== this.props.followType ) {
-			selectFilter = <StatsModuleSelectDropdown options={ options } onSelect={ this.props.changeFilter } />;
+class StatModuleFollowersPage extends Component {
+	filterSelect() {
+		const { changeFilter, followType, translate } = this.props;
+		if ( 'comment' === followType ) {
+			return null;
 		}
 
-		return selectFilter;
-	},
+		const options = [
+			{
+				value: 'wpcom',
+				label: translate( 'WordPress.com Followers' )
+			},
+			{
+				value: 'email',
+				label: translate( 'Email Followers' )
+			}
+		];
 
-	recordDownloadClick: function() {
-		analytics.ga.recordEvent( 'Stats', 'Clicked Download Email Followers CSV link' );
-	},
+		return <StatsModuleSelectDropdown options={ options } onSelect={ changeFilter } initialSelected={ followType } />;
+	}
 
-	render: function() {
-		const { translate } = this.props;
-		var data = this.data(),
-			hasError = this.props.followersList.isError(),
-			noData = this.props.followersList.isEmpty( 'subscribers' ),
-			isLoading = this.props.followersList.isLoading(),
-			followers,
-			labelLegend,
-			valueLegend,
-			pagination,
-			paginationSummary,
-			startIndex,
-			endIndex,
-			emailExportUrl,
-			itemType,
-			classes;
-
-		classes = [
+	render() {
+		const {
+			data,
+			followList,
+			followType,
+			hasError,
+			numberFormat,
+			page,
+			pageClick,
+			query,
+			perPage,
+			requestingFollowers,
+			siteId,
+			statsType,
+			translate
+		} = this.props;
+		const noData = followType === 'comment' ? ! get( data, 'posts' ) : ! get( data, 'subscribers' );
+		const isLoading = requestingFollowers && noData;
+		const classes = [
 			'stats-module',
 			'summary',
 			'is-followers-page',
@@ -96,36 +77,41 @@ const StatModuleFollowersPage = React.createClass( {
 			}
 		];
 
-		switch ( this.props.followType ) {
+		let itemType;
+		let total;
+		switch ( followType ) {
 			case 'comment':
 				itemType = translate( 'Comments' );
+				total = get( data, 'total' );
 				break;
 
 			case 'email':
 				itemType = translate( 'Email' );
+				total = get( data, 'total_email' );
 				break;
 
 			case 'wpcom':
 				itemType = translate( 'WordPress.com' );
+				total = get( data, 'total_wpcom' );
 				break;
 		}
 
-		if ( data.total ) {
-			startIndex = this.props.perPage * ( this.props.page - 1 ) + 1;
-			endIndex = this.props.perPage * this.props.page;
-
-			if ( endIndex > data.total ) {
-				endIndex = data.total;
+		let paginationSummary;
+		if ( total ) {
+			const startIndex = perPage * ( page - 1 ) + 1;
+			let endIndex = perPage * page;
+			if ( endIndex > total ) {
+				endIndex = total;
 			}
 
 			paginationSummary = translate( 'Showing %(startIndex)s - %(endIndex)s of %(total)s %(itemType)s followers', {
 				context: 'pagination',
 				comment: '"Showing [start index] - [end index] of [total] [item]" Example: Showing 21 - 40 of 300 WordPress.com followers',
 				args: {
-					startIndex: this.numberFormat( startIndex ),
-					endIndex: this.numberFormat( endIndex ),
-					total: this.numberFormat( data.total ),
-					itemType: itemType
+					startIndex: numberFormat( startIndex ),
+					endIndex: numberFormat( endIndex ),
+					total: numberFormat( total ),
+					itemType
 				}
 			} );
 
@@ -136,8 +122,11 @@ const StatModuleFollowersPage = React.createClass( {
 			);
 		}
 
-		pagination = <Pagination page={ this.props.page } perPage={ this.props.perPage } total={ data.total } pageClick={ this.props.pageClick } />;
+		const pagination = <Pagination page={ page } perPage={ perPage } total={ total } pageClick={ pageClick } />;
 
+		let followers;
+		let labelLegend;
+		let valueLegend;
 		if ( data && data.posts ) {
 			followers = <StatsList data={ data.posts } moduleName="Followers" />;
 			labelLegend = translate( 'Post', {
@@ -145,17 +134,18 @@ const StatModuleFollowersPage = React.createClass( {
 			} );
 			valueLegend = translate( 'Followers' );
 		} else if ( data && data.subscribers ) {
-			followers = <StatsList data={ data.subscribers } followList={ this.props.followList } moduleName="Followers" />;
+			followers = <StatsList data={ data.subscribers } followList={ followList } moduleName="Followers" />;
 			labelLegend = translate( 'Follower' );
 			valueLegend = translate( 'Since' );
 		}
 
-		if ( 'email' === this.props.followType ) {
-			emailExportUrl = 'https://dashboard.wordpress.com/wp-admin/index.php?page=stats&blog=' + this.props.siteId + '&blog_subscribers=csv&type=email';
-		}
+		const emailExportUrl = followType === 'email'
+			? 'https://dashboard.wordpress.com/wp-admin/index.php?page=stats&blog=' + siteId + '&blog_subscribers=csv&type=email'
+			: null;
 
 		return (
 			<div className="followers">
+				<QuerySiteStats statType={ statsType } siteId={ siteId } query={ query } />
 				<SectionHeader label={ translate( 'Followers' ) }>
 					{ emailExportUrl
 						? ( <Button compact href={ emailExportUrl }>{ translate( 'Download Data as CSV' ) }</Button> )
@@ -165,7 +155,9 @@ const StatModuleFollowersPage = React.createClass( {
 					<div className="module-content">
 						{ this.filterSelect() }
 
-						{ ( noData && ! hasError ) ? <ErrorPanel className="is-empty-message" message={ translate( 'No followers' ) } /> : null }
+						{ noData && ! hasError && ! isLoading &&
+							<ErrorPanel className="is-empty-message" message={ translate( 'No followers' ) } />
+						}
 
 						{ paginationSummary }
 
@@ -185,12 +177,36 @@ const StatModuleFollowersPage = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
-export default connect( ( state ) => {
+const connectComponent = connect( ( state, { followType, page, perPage } ) => {
+	let statsType;
+	let query;
+	if ( followType === 'comment' ) {
+		statsType = 'statsCommentFollowers';
+		query = {};
+	} else {
+		statsType = 'statsFollowers';
+		query = { type: followType };
+	}
+	query = {
+		...query,
+		max: perPage,
+		page
+	};
 	const siteId = getSelectedSiteId( state );
 
 	return {
-		siteId
+		requestingFollowers: isRequestingSiteStatsForQuery( state, siteId, statsType, query ),
+		data: getSiteStatsNormalizedData( state, siteId, statsType, query ),
+		hasError: hasSiteStatsQueryFailed( state, siteId, statsType, query ),
+		query,
+		siteId,
+		statsType
 	};
-} )( localize( StatModuleFollowersPage ) );
+} );
+
+export default flowRight(
+	connectComponent,
+	localize
+)( StatModuleFollowersPage );

--- a/client/my-sites/stats/stats-module/select-dropdown.jsx
+++ b/client/my-sites/stats/stats-module/select-dropdown.jsx
@@ -8,27 +8,17 @@ import React, { PropTypes } from 'react';
  */
 import SelectDropdown from 'components/select-dropdown';
 
-export default React.createClass( {
-	displayName: 'StatsModuleSelectDropdown',
+const StatsModuleSelectDropdown = ( { initialSelected, options, onSelect = () => {} } ) => {
+	return (
+		<div className="stats-module__select-dropdown-wrapper">
+			<SelectDropdown options={ options } onSelect={ onSelect } initialSelected={ initialSelected } />
+		</div>
+	);
+};
 
-	propTypes: {
-		options: PropTypes.array,
-		onSelect: PropTypes.func
-	},
+StatsModuleSelectDropdown.propTypes = {
+	options: PropTypes.array,
+	onSelect: PropTypes.func
+};
 
-	getDefaultProps() {
-		return {
-			onSelect: () => {}
-		}
-	},
-
-	render() {
-		const { onSelect, options } = this.props;
-
-		return (
-			<div className="stats-module__select-dropdown-wrapper">
-				<SelectDropdown options={ options } onSelect={ onSelect } />
-			</div>
-		);
-	}
-} );
+export default StatsModuleSelectDropdown;


### PR DESCRIPTION
In this PR I'm using the `QueryStatsList` instead of `StatsList` object emitter for the stats followers pages:

**Testing instructions**

 - Check that the comment followers page is working properly: `/stats/follows/comment/$site`
 - Check that the email/wpcom followers page is working properly: `/stats/follows/wpcom/$site`