### PR TITLE
Stats: Trying to use AsyncLoad for the stats site route

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -340,6 +340,7 @@
 @import 'my-sites/stats/stats-module/style';
 @import 'my-sites/stats/stats-navigation/style';
 @import 'my-sites/stats/stats-overview-placeholder/style';
+@import 'my-sites/stats/stats-page-placeholder/style';
 @import 'my-sites/stats/stats-period-navigation/style';
 @import 'my-sites/stats/stats-post-likes/style';
 @import 'my-sites/stats/stats-post-summary/style';

--- a/client/components/async-load/index.jsx
+++ b/client/components/async-load/index.jsx
@@ -14,18 +14,19 @@ export default class AsyncLoad extends Component {
 		super( ...arguments );
 
 		this.state = {
-			dirty: false,
+			require: null,
 			component: null
 		};
 	}
 
 	componentWillMount() {
+		this.setState( { require: this.props.require } );
 		this.require();
 	}
 
 	componentWillReceiveProps( nextProps ) {
 		if ( this.props.require !== nextProps.require ) {
-			this.setState( { dirty: true } );
+			this.setState( { require: nextProps.require, component: null } );
 		}
 	}
 
@@ -38,13 +39,16 @@ export default class AsyncLoad extends Component {
 	}
 
 	require() {
-		this.props.require( ( component ) => {
-			this.setState( { component, dirty: false } );
+		const requireFunction = this.props.require;
+		requireFunction( ( component ) => {
+			if ( this.state.require === requireFunction ) {
+				this.setState( { component } );
+			}
 		} );
 	}
 
 	render() {
-		if ( this.state.component && ! this.state.dirty ) {
+		if ( this.state.component ) {
 			const props = omit( this.props, [ 'require', 'placeholder' ] );
 			return <this.state.component { ...props } />;
 		}

--- a/client/components/async-load/index.jsx
+++ b/client/components/async-load/index.jsx
@@ -20,13 +20,12 @@ export default class AsyncLoad extends Component {
 	}
 
 	componentWillMount() {
-		this.setState( { require: this.props.require } );
 		this.require();
 	}
 
 	componentWillReceiveProps( nextProps ) {
 		if ( this.props.require !== nextProps.require ) {
-			this.setState( { require: nextProps.require, component: null } );
+			this.setState( { component: null } );
 		}
 	}
 
@@ -41,7 +40,7 @@ export default class AsyncLoad extends Component {
 	require() {
 		const requireFunction = this.props.require;
 		requireFunction( ( component ) => {
-			if ( this.state.require === requireFunction ) {
+			if ( this.props.require === requireFunction ) {
 				this.setState( { component } );
 			}
 		} );

--- a/client/components/async-load/index.jsx
+++ b/client/components/async-load/index.jsx
@@ -14,12 +14,19 @@ export default class AsyncLoad extends Component {
 		super( ...arguments );
 
 		this.state = {
+			dirty: false,
 			component: null
 		};
 	}
 
 	componentWillMount() {
 		this.require();
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.require !== nextProps.require ) {
+			this.setState( { dirty: true } );
+		}
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -32,12 +39,12 @@ export default class AsyncLoad extends Component {
 
 	require() {
 		this.props.require( ( component ) => {
-			this.setState( { component } );
+			this.setState( { component, dirty: false } );
 		} );
 	}
 
 	render() {
-		if ( this.state.component ) {
+		if ( this.state.component && ! this.state.dirty ) {
 			const props = omit( this.props, [ 'require', 'placeholder' ] );
 			return <this.state.component { ...props } />;
 		}

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -20,6 +20,7 @@ import { savePreference } from 'state/preferences/actions';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import Emitter from 'lib/mixins/emitter';
+import AsyncLoad from 'components/async-load';
 const user = userFactory();
 const sites = sitesFactory();
 const analyticsPageTitle = 'Stats';
@@ -183,7 +184,6 @@ module.exports = {
 		let siteId = context.params.site_id;
 		const siteFragment = route.getSiteFragment( context.path );
 		const queryOptions = context.query;
-		const SiteStatsComponent = require( 'my-sites/stats/site' );
 		const filters = getSiteFilters.bind( null, siteId );
 		let date;
 		const charts = function() {
@@ -202,7 +202,6 @@ module.exports = {
 		let numPeriodAgo = 0;
 		const basePath = route.sectionify( context.path );
 		let baseAnalyticsPath;
-		let siteComponent;
 
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 		context.store.dispatch( setTitle( i18n.translate( 'Stats', { textOnly: true } ) ) );
@@ -268,8 +267,9 @@ module.exports = {
 			const siteDomain = ( currentSite && ( typeof currentSite.slug !== 'undefined' ) )
 					? currentSite.slug : siteFragment;
 
-			siteComponent = SiteStatsComponent;
 			const siteComponentChildren = {
+				slug: siteDomain,
+				path: context.pathname,
 				date,
 				charts,
 				chartTab,
@@ -277,12 +277,10 @@ module.exports = {
 				sites,
 				siteId,
 				period,
-				slug: siteDomain,
-				path: context.pathname,
 			};
 
 			renderWithReduxStore(
-				React.createElement( siteComponent, siteComponentChildren ),
+				<AsyncLoad require="my-sites/stats/site" { ...siteComponentChildren } />,
 				document.getElementById( 'primary' ),
 				context.store
 			);

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -21,6 +21,7 @@ import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import Emitter from 'lib/mixins/emitter';
 import AsyncLoad from 'components/async-load';
+import StatsPagePlaceholder from 'my-sites/stats/stats-page-placeholder';
 const user = userFactory();
 const sites = sitesFactory();
 const analyticsPageTitle = 'Stats';
@@ -130,7 +131,7 @@ module.exports = {
 
 		const props = { followList };
 		renderWithReduxStore(
-			<AsyncLoad require="my-sites/stats/stats-insights" { ...props } />,
+			<AsyncLoad require="my-sites/stats/stats-insights" placeholder={ <StatsPagePlaceholder /> } { ...props } />,
 			document.getElementById( 'primary' ),
 			context.store
 		);
@@ -170,7 +171,7 @@ module.exports = {
 				user
 			};
 			renderWithReduxStore(
-				<AsyncLoad require="my-sites/stats/overview" { ...props } />,
+				<AsyncLoad placeholder={ <StatsPagePlaceholder /> } require="my-sites/stats/overview" { ...props } />,
 				document.getElementById( 'primary' ),
 				context.store
 			);
@@ -277,7 +278,7 @@ module.exports = {
 			};
 
 			renderWithReduxStore(
-				<AsyncLoad require="my-sites/stats/site" { ...siteComponentChildren } />,
+				<AsyncLoad placeholder={ <StatsPagePlaceholder /> } require="my-sites/stats/site" { ...siteComponentChildren } />,
 				document.getElementById( 'primary' ),
 				context.store
 			);
@@ -422,7 +423,7 @@ module.exports = {
 				...extraProps
 			};
 			renderWithReduxStore(
-				<AsyncLoad require="my-sites/stats/summary" { ...props } />,
+				<AsyncLoad placeholder={ <StatsPagePlaceholder /> } require="my-sites/stats/summary" { ...props } />,
 				document.getElementById( 'primary' ),
 				context.store
 			);
@@ -460,7 +461,7 @@ module.exports = {
 				context,
 			};
 			renderWithReduxStore(
-				<AsyncLoad require="my-sites/stats/stats-post-detail" { ...props } />,
+				<AsyncLoad placeholder={ <StatsPagePlaceholder /> } require="my-sites/stats/stats-post-detail" { ...props } />,
 				document.getElementById( 'primary' ),
 				context.store
 			);
@@ -520,7 +521,7 @@ module.exports = {
 				followList,
 			};
 			renderWithReduxStore(
-				<AsyncLoad require="my-sites/stats/follows" { ...props } />,
+				<AsyncLoad placeholder={ <StatsPagePlaceholder /> } require="my-sites/stats/follows" { ...props } />,
 				document.getElementById( 'primary' ),
 				context.store
 			);

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -100,12 +100,10 @@ module.exports = {
 	},
 
 	insights: function( context, next ) {
-		const Insights = require( 'my-sites/stats/stats-insights' );
 		const FollowList = require( 'lib/follow-list' );
 		let siteId = context.params.site_id;
 		const basePath = route.sectionify( context.path );
 		const followList = new FollowList();
-		const StatsComponent = Insights;
 
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 		context.store.dispatch( setTitle( i18n.translate( 'Stats', { textOnly: true } ) ) );
@@ -130,17 +128,15 @@ module.exports = {
 
 		analytics.pageView.record( basePath, analyticsPageTitle + ' > Insights' );
 
+		const props = { followList };
 		renderWithReduxStore(
-			React.createElement( StatsComponent, {
-				followList: followList,
-			} ),
+			<AsyncLoad require="my-sites/stats/stats-insights" { ...props } />,
 			document.getElementById( 'primary' ),
 			context.store
 		);
 	},
 
 	overview: function( context, next ) {
-		const StatsComponent = require( './overview' );
 		const filters = function() {
 			return [
 				{ title: i18n.translate( 'Days' ), path: '/stats/day', altPaths: [ '/stats' ], id: 'stats-day', period: 'day' },
@@ -167,13 +163,14 @@ module.exports = {
 			analytics.mc.bumpStat( 'calypso_stats_overview_period', activeFilter.period );
 			analytics.pageView.record( basePath, analyticsPageTitle + ' > ' + titlecase( activeFilter.period ) );
 
+			const props = {
+				period: activeFilter.period,
+				path: context.pathname,
+				sites,
+				user
+			};
 			renderWithReduxStore(
-				React.createElement( StatsComponent, {
-					period: activeFilter.period,
-					sites: sites,
-					path: context.pathname,
-					user: user
-				} ),
+				<AsyncLoad require="my-sites/stats/overview" { ...props } />,
 				document.getElementById( 'primary' ),
 				context.store
 			);
@@ -292,7 +289,6 @@ module.exports = {
 		const siteFragment = route.getSiteFragment( context.path );
 		const queryOptions = context.query;
 		const StatsList = require( 'lib/stats/stats-list' );
-		const StatsSummaryComponent = require( 'my-sites/stats/summary' );
 		const filters = function( contextModule, _siteId ) {
 			return [
 				{ title: i18n.translate( 'Days' ), path: '/stats/' + contextModule + '/' + _siteId,
@@ -412,20 +408,21 @@ module.exports = {
 				analyticsPageTitle + ' > ' + titlecase( activeFilter.period ) + ' > ' + titlecase( context.params.module )
 			);
 
+			const props = {
+				path: context.pathname,
+				sites,
+				statsQueryOptions,
+				date,
+				context,
+				period,
+				siteId,
+				filters,
+				visitsList,
+				summaryList,
+				...extraProps
+			};
 			renderWithReduxStore(
-				React.createElement( StatsSummaryComponent, {
-					date: date,
-					context: context,
-					path: context.pathname,
-					sites: sites,
-					filters: filters,
-					summaryList: summaryList,
-					visitsList: visitsList,
-					siteId: siteId,
-					period: period,
-					statsQueryOptions,
-					...extraProps
-				} ),
+				<AsyncLoad require="my-sites/stats/summary" { ...props } />,
 				document.getElementById( 'primary' ),
 				context.store
 			);
@@ -435,7 +432,6 @@ module.exports = {
 	post: function( context ) {
 		let siteId = context.params.site_id;
 		const postId = parseInt( context.params.post_id, 10 );
-		const StatsPostComponent = require( 'my-sites/stats/stats-post-detail' );
 		const pathParts = context.path.split( '/' );
 		const postOrPage = pathParts[ 2 ] === 'post' ? 'post' : 'page';
 
@@ -458,12 +454,13 @@ module.exports = {
 			analytics.pageView.record( '/stats/' + postOrPage + '/:post_id/:site',
 				analyticsPageTitle + ' > Single ' + titlecase( postOrPage ) );
 
+			const props = {
+				path: context.path,
+				postId,
+				context,
+			};
 			renderWithReduxStore(
-				React.createElement( StatsPostComponent, {
-					postId: postId,
-					context: context,
-					path: context.path,
-				} ),
+				<AsyncLoad require="my-sites/stats/stats-post-detail" { ...props } />,
 				document.getElementById( 'primary' ),
 				context.store
 			);
@@ -473,7 +470,6 @@ module.exports = {
 	follows: function( context, next ) {
 		let siteId = context.params.site_id;
 		const FollowList = require( 'lib/follow-list' );
-		const FollowsComponent = require( 'my-sites/stats/follows' );
 		const validFollowTypes = [ 'wpcom', 'email', 'comment' ];
 		const followType = context.params.follow_type;
 		let pageNum = context.params.page_num;
@@ -512,18 +508,19 @@ module.exports = {
 				analyticsPageTitle + ' > Followers > ' + titlecase( followType )
 			);
 
+			const props = {
+				path: context.path,
+				page: pageNum,
+				perPage: 20,
+				total: 10,
+				domain: siteDomain,
+				sites,
+				siteId,
+				followType,
+				followList,
+			};
 			renderWithReduxStore(
-				React.createElement( FollowsComponent, {
-					path: context.path,
-					sites: sites,
-					siteId: siteId,
-					page: pageNum,
-					perPage: 20,
-					total: 10,
-					followType: followType,
-					followList: followList,
-					domain: siteDomain
-				} ),
+				<AsyncLoad require="my-sites/stats/follows" { ...props } />,
 				document.getElementById( 'primary' ),
 				context.store
 			);

--- a/client/my-sites/stats/stats-page-placeholder/index.jsx
+++ b/client/my-sites/stats/stats-page-placeholder/index.jsx
@@ -8,21 +8,19 @@ import React from 'react';
  */
 import Card from 'components/card';
 
-const StatsPagePlaceholder = () => {
-	return (
-		<div className="main is-wide-layout">
-			<Card className="stats-module is-loading">
-				<div className="module-header">
-					<h3 className="module-header-title" />
-				</div>
-			</Card>
-			<Card className="stats-module stats-page-placeholder__content is-loading">
-				<div className="module-header">
-					<h3 className="module-header-title" />
-				</div>
-			</Card>
-		</div>
-	);
-};
+const StatsPagePlaceholder = (
+	<div className="main is-wide-layout">
+		<Card className="stats-module stats-page-placeholder__header is-loading">
+			<div className="module-header">
+				<h3 className="module-header-title" />
+			</div>
+		</Card>
+		<Card className="stats-module stats-page-placeholder__content is-loading">
+			<div className="module-header">
+				<h3 className="module-header-title" />
+			</div>
+		</Card>
+	</div>
+);
 
-export default StatsPagePlaceholder;
+export default () => StatsPagePlaceholder;

--- a/client/my-sites/stats/stats-page-placeholder/index.jsx
+++ b/client/my-sites/stats/stats-page-placeholder/index.jsx
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+
+const StatsPagePlaceholder = () => {
+	return (
+		<div className="main is-wide-layout">
+			<Card className="stats-module is-loading">
+				<div className="module-header">
+					<h3 className="module-header-title" />
+				</div>
+			</Card>
+			<Card className="stats-module stats-page-placeholder__content is-loading">
+				<div className="module-header">
+					<h3 className="module-header-title" />
+				</div>
+			</Card>
+		</div>
+	);
+};
+
+export default StatsPagePlaceholder;

--- a/client/my-sites/stats/stats-page-placeholder/style.scss
+++ b/client/my-sites/stats/stats-page-placeholder/style.scss
@@ -5,3 +5,11 @@
 		height: 80px;
 	}
 }
+
+.stats-page-placeholder__header.is-loading .module-header {
+	height: auto;
+
+	.module-header-title {
+		height: 50px;
+	}
+}

--- a/client/my-sites/stats/stats-page-placeholder/style.scss
+++ b/client/my-sites/stats/stats-page-placeholder/style.scss
@@ -1,0 +1,7 @@
+.stats-page-placeholder__content.is-loading .module-header {
+	height: auto;
+
+	.module-header-title {
+		height: 80px;
+	}
+}


### PR DESCRIPTION
This tries to address #10958 

In order to use AsyncLoad, I had to use the JSX syntax, so I renamed the file to `.jsx`
This change created a **62 Ko** chunk.

<img width="877" alt="screen shot 2017-01-27 at 14 58 28" src="https://cloud.githubusercontent.com/assets/272444/22373256/29e08dc2-e4a1-11e6-9233-d32f183212ff.png">

**Questions**

How do we decide if it's worth it or not to keep the async load or not? Maybe you could give hints on this @aduth? Is there a way to measure the load time or something like that? 