### PR TITLE
Editor / Reader: Fix broken slideshow gallery jQuery dependency link

### DIFF
--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -29,7 +29,7 @@ const cacheBustQuery = `?v=${ Math.floor( new Date().getTime() / ( 1000 * 60 * 6
 
 const SLIDESHOW_URLS = {
 	CSS: `https://s0.wp.com/wp-content/mu-plugins/shortcodes/css/slideshow-shortcode.css${cacheBustQuery}`,
-	CYCLE_JS: `https://s0.wp.com/wp-content/mu-plugins/shortcodes/js/jquery.cycle.js${cacheBustQuery}`,
+	CYCLE_JS: `https://s0.wp.com/wp-content/mu-plugins/shortcodes/js/jquery.cycle.min.js${cacheBustQuery}`,
 	JS: `https://s0.wp.com/wp-content/mu-plugins/shortcodes/js/slideshow-shortcode.js${cacheBustQuery}`,
 	SPINNER: `https://s0.wp.com/wp-content/mu-plugins/shortcodes/img/slideshow-loader.gif${cacheBustQuery}`
 };

--- a/client/components/gallery-shortcode/index.jsx
+++ b/client/components/gallery-shortcode/index.jsx
@@ -65,7 +65,7 @@ export default React.createClass( {
 			assign( filtered, {
 				scripts: {
 					'jquery-cycle': {
-						src: 'https://s0.wp.com/wp-content/mu-plugins/shortcodes/js/jquery.cycle.js'
+						src: 'https://s0.wp.com/wp-content/mu-plugins/shortcodes/js/jquery.cycle.min.js'
 					},
 					'jetpack-slideshow': {
 						src: 'https://s0.wp.com/wp-content/mu-plugins/shortcodes/js/slideshow-shortcode.js',


### PR DESCRIPTION
Related: https://github.com/Automattic/jetpack/pull/6024
Related: https://github.com/Automattic/wp-calypso/pull/5368

This pull request seeks to resolve an issue where editor slideshow gallery previews (and presumably the same in Reader) do not work because of a broken reference to the jQuery Cycle plugin. Recently the unminified version was removed in favor of a minified copy.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/22374798/aaf0e94c-e475-11e6-8294-ffd0340d87ac.png)|![After](https://cloud.githubusercontent.com/assets/1779930/22374782/9f0e73d8-e475-11e6-88d1-ddf809cf7568.png)

__Testing instructions:__

Verify that gallery slideshow previews display correctly.

1. Navigate to [post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Click Add Media in the editor toolbar
4. Select two or more images
5. Click Continue
6. Change Layout to Slideshow
7. Note that image previews are shown correctly

r148465-wpcom, D3841-code, 3027064-t