### PR TITLE
Reader Stream: use postsStore instead of store prop to avoid conflict or confusion with Redux store

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -165,7 +165,7 @@ module.exports = {
 				React.createElement( StreamComponent, {
 					key: 'following',
 					listName: i18n.translate( 'Followed Sites' ),
-					store: followingStore,
+					postsStore: followingStore,
 					recommendationsStore,
 					showPrimaryFollowButtonOnCards: false,
 					trackScrollPage: trackScrollPage.bind(
@@ -215,7 +215,7 @@ module.exports = {
 		renderWithReduxStore(
 			React.createElement( FeedStream, {
 				key: 'feed-' + context.params.feed_id,
-				store: feedStore,
+				postsStore: feedStore,
 				feedId: +context.params.feed_id,
 				trackScrollPage: trackScrollPage.bind(
 					null,
@@ -251,7 +251,7 @@ module.exports = {
 		renderWithReduxStore(
 			React.createElement( SiteStream, {
 				key: 'site-' + context.params.blog_id,
-				store: feedStore,
+				postsStore: feedStore,
 				siteId: +context.params.blog_id,
 				trackScrollPage: trackScrollPage.bind(
 					null,
@@ -289,7 +289,7 @@ module.exports = {
 					key: 'read-a8c',
 					className: 'is-a8c',
 					listName: 'Automattic',
-					store: feedStore,
+					postsStore: feedStore,
 					trackScrollPage: trackScrollPage.bind(
 						null,
 						basePath,

--- a/client/reader/discover/controller.js
+++ b/client/reader/discover/controller.js
@@ -32,7 +32,7 @@ export default {
 		renderWithReduxStore(
 			React.createElement( SiteStream, {
 				key: 'site-' + blogId,
-				store: feedStore,
+				postsStore: feedStore,
 				siteId: +blogId,
 				title: 'Discover',
 				trackScrollPage: trackScrollPage.bind(

--- a/client/reader/liked-stream/controller.js
+++ b/client/reader/liked-stream/controller.js
@@ -28,7 +28,7 @@ export default {
 		renderWithReduxStore(
 			React.createElement( LikedPostsStream, {
 				key: 'liked',
-				store: likedPostsStore,
+				postsStore: likedPostsStore,
 				trackScrollPage: trackScrollPage.bind(
 					null,
 					basePath,

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -57,7 +57,7 @@ const ListStream = React.createClass( {
 		}
 
 		return (
-			<Stream { ...this.props } store={ this.props.postStore } listName={ title } emptyContent={ emptyContent } showFollowInHeader={ shouldShowFollow }>
+			<Stream { ...this.props } listName={ title } emptyContent={ emptyContent } showFollowInHeader={ shouldShowFollow }>
 				<DocumentHead title={ this.translate( '%s ‹ Reader', { args: title } ) } />
 				<QueryReaderList owner={ this.props.owner } slug={ this.props.slug } />
 				<ListStreamHeader

--- a/client/reader/list/controller.js
+++ b/client/reader/list/controller.js
@@ -34,7 +34,7 @@ export default {
 			React.createElement( ReduxProvider, { store: context.store },
 				React.createElement( ListStream, {
 					key: 'tag-' + context.params.user + '-' + context.params.list,
-					postStore: listStore,
+					postsStore: listStore,
 					owner: encodeURIComponent( context.params.user ),
 					slug: encodeURIComponent( context.params.list ),
 					showPrimaryFollowButtonOnCards: false,

--- a/client/reader/recommendations/controller.js
+++ b/client/reader/recommendations/controller.js
@@ -89,7 +89,7 @@ export default {
 		renderWithReduxStore(
 			React.createElement( RecommendedPostsStream, {
 				key: 'recommendations_posts',
-				store: RecommendedPostsStore,
+				postsStore: RecommendedPostsStore,
 				trackScrollPage: trackScrollPage.bind(
 					null,
 					basePath,

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -44,7 +44,7 @@ export default {
 		renderWithReduxStore(
 			React.createElement( SearchStream, {
 				key: 'search',
-				store: store,
+				postsStore: store,
 				query: searchSlug,
 				trackScrollPage: trackScrollPage.bind(
 					null,

--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -37,7 +37,7 @@ export default {
 		renderWithReduxStore(
 			React.createElement( TagStream, {
 				key: 'tag-' + encodedTag,
-				store: tagStore,
+				postsStore: tagStore,
 				tag: encodedTag,
 				trackScrollPage: trackScrollPage.bind(
 					null,


### PR DESCRIPTION
Whilst working on https://github.com/Automattic/wp-calypso/pull/10944 and `connect`-ing Reader Stream to Redux, I discovered that there was a prop naming conflict: we have the Redux store `store`, and also the posts store `store` for all Reader streams.

In a bid to avoid conflicts or confusion between the two, I have renamed the posts store prop to `postsStore` across the board.

### To test

Check that all Reader streams load correctly with no errors in the console.