### PR TITLE
Editor: update HTML Toolbar style

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -475,7 +475,7 @@ module.exports = React.createClass( {
 
 		return (
 			<div>
-				{ mode === 'html' &&
+				{ 'html' === mode && config.isEnabled( 'post-editor/html-toolbar' ) &&
 					<EditorHtmlToolbar
 						content={ this.refs.text }
 						onToolbarChangeContent={ this.onToolbarChangeContent }

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -55,6 +55,9 @@ export class EditorHtmlToolbar extends Component {
 	}
 
 	componentWillUnmount() {
+		this.pinToolbarOnScroll.cancel();
+		this.onWindowResize.cancel();
+		this.hideToolbarFadeOnFullScroll.cancel();
 		window.removeEventListener( 'scroll', this.pinToolbarOnScroll );
 		window.removeEventListener( 'resize', this.onWindowResize );
 		this.buttons.removeEventListener( 'scroll', this.hideToolbarFadeOnFullScroll );

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -3,7 +3,6 @@
  */
 import React, { Component, PropTypes } from 'react';
 import {
-	get,
 	map,
 	reduce,
 	throttle,
@@ -103,10 +102,6 @@ export class EditorHtmlToolbar extends Component {
 		this.setState( {
 			isScrolledFull: scrollLeft >= scrollWidth - clientWidth - 10,
 		} );
-	}
-
-	getEditorContent() {
-		return get( this.props, 'editor.text', {} );
 	}
 
 	splitEditorContent() {
@@ -294,11 +289,6 @@ export class EditorHtmlToolbar extends Component {
 
 	closeLinkDialog = () => {
 		this.setState( { showLinkDialog: false } );
-	}
-
-	tagLabel( tag, label ) {
-		const { openTags } = this.state;
-		return -1 === openTags.indexOf( tag ) ? label : `/${ label }`;
 	}
 
 	isTagOpen = tag => -1 !== this.state.openTags.indexOf( tag );

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -13,7 +13,6 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import { isWithinBreakpoint } from 'lib/viewport';
 import AddImageDialog from './add-image-dialog';
 import AddLinkDialog from './add-link-dialog';
@@ -298,10 +297,6 @@ export class EditorHtmlToolbar extends Component {
 	isTagOpen = tag => -1 !== this.state.openTags.indexOf( tag );
 
 	render() {
-		if ( ! config.isEnabled( 'post-editor/html-toolbar' ) ) {
-			return null;
-		}
-
 		const { translate } = this.props;
 		const classes = classNames( 'editor-html-toolbar', {
 			'is-pinned': this.state.isPinned,

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -46,6 +46,7 @@ export class EditorHtmlToolbar extends Component {
 	componentDidMount() {
 		this.pinToolbarOnScroll = throttle( this.pinToolbarOnScroll, 50 );
 		this.hideToolbarFadeOnFullScroll = throttle( this.hideToolbarFadeOnFullScroll, 200 );
+		this.onWindowResize = throttle( this.onWindowResize, 400 );
 
 		window.addEventListener( 'scroll', this.pinToolbarOnScroll );
 		window.addEventListener( 'resize', this.onWindowResize );
@@ -65,8 +66,8 @@ export class EditorHtmlToolbar extends Component {
 	}
 
 	onWindowResize = () => {
-		throttle( this.disablePinOnSmallScreens, 400 );
-		throttle( this.toggleToolbarScrollableOnResize, 200 );
+		this.disablePinOnSmallScreens();
+		this.toggleToolbarScrollableOnResize();
 	}
 
 	pinToolbarOnScroll = () => {
@@ -85,7 +86,7 @@ export class EditorHtmlToolbar extends Component {
 	}
 
 	disablePinOnSmallScreens = () => {
-		if ( isWithinBreakpoint( '<660px' ) ) {
+		if ( this.state.isPinned && isWithinBreakpoint( '<660px' ) ) {
 			this.setState( { isPinned: false } );
 		}
 	}

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -45,13 +45,10 @@ export class EditorHtmlToolbar extends Component {
 
 	componentDidMount() {
 		this.pinToolbarOnScroll = throttle( this.pinToolbarOnScroll, 50 );
-		this.disablePinOnSmallScreens = throttle( this.disablePinOnSmallScreens, 400 );
-		this.toggleToolbarScrollableOnResize = throttle( this.toggleToolbarScrollableOnResize, 200 );
 		this.hideToolbarFadeOnFullScroll = throttle( this.hideToolbarFadeOnFullScroll, 200 );
 
 		window.addEventListener( 'scroll', this.pinToolbarOnScroll );
-		window.addEventListener( 'resize', this.disablePinOnSmallScreens );
-		window.addEventListener( 'resize', this.toggleToolbarScrollableOnResize );
+		window.addEventListener( 'resize', this.onWindowResize );
 		this.buttons.addEventListener( 'scroll', this.hideToolbarFadeOnFullScroll );
 
 		this.toggleToolbarScrollableOnResize();
@@ -59,13 +56,17 @@ export class EditorHtmlToolbar extends Component {
 
 	componentWillUnmount() {
 		window.removeEventListener( 'scroll', this.pinToolbarOnScroll );
-		window.removeEventListener( 'resize', this.disablePinOnSmallScreens );
-		window.removeEventListener( 'resize', this.toggleToolbarScrollableOnResize );
+		window.removeEventListener( 'resize', this.onWindowResize );
 		this.buttons.removeEventListener( 'scroll', this.hideToolbarFadeOnFullScroll );
 	}
 
 	bindButtonsRef = div => {
 		this.buttons = div;
+	}
+
+	onWindowResize = () => {
+		throttle( this.disablePinOnSmallScreens, 400 );
+		throttle( this.toggleToolbarScrollableOnResize, 200 );
 	}
 
 	pinToolbarOnScroll = () => {
@@ -90,18 +91,20 @@ export class EditorHtmlToolbar extends Component {
 	}
 
 	toggleToolbarScrollableOnResize = () => {
-		this.setState( {
-			isScrollable: this.buttons.scrollWidth > this.buttons.clientWidth,
-		} );
+		const isScrollable = this.buttons.scrollWidth > this.buttons.clientWidth;
+		if ( isScrollable !== this.state.isScrollable ) {
+			this.setState( { isScrollable } );
+		}
 	}
 
 	hideToolbarFadeOnFullScroll = event => {
 		const { scrollLeft, scrollWidth, clientWidth } = event.target;
-
 		// 10 is bit of tolerance in case the scroll stops some pixels short of the toolbar width
-		this.setState( {
-			isScrolledFull: scrollLeft >= scrollWidth - clientWidth - 10,
-		} );
+		const isScrolledFull = scrollLeft >= scrollWidth - clientWidth - 10;
+
+		if ( isScrolledFull !== this.state.isScrolledFull ) {
+			this.setState( { isScrolledFull } );
+		}
 	}
 
 	splitEditorContent() {

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -1,16 +1,44 @@
 .editor-html-toolbar {
-	border-color: lighten( $gray, 20% );
-	border-style: solid;
-	border-bottom-width: 1px;
-	box-sizing: border-box;
-	margin: 0 auto;
-	max-width: 700px;
-	width: 100%;
+	min-height: 39px;
 	position: relative;
 
-	@media ( min-width: 930px ) {
-		border-left-width: 1px;
-		border-right-width: 1px;
+	.editor-html-toolbar__wrapper {
+		background-color: rgba( $white, 0.92 );
+		border-color: lighten( $gray, 20% );
+		border-style: solid;
+		border-bottom-width: 1px;
+		box-sizing: border-box;
+		margin: 0 auto;
+		max-width: 700px;
+		position: relative;
+		width: 100%;
+
+		@media ( min-width: 930px ) {
+			border-left-width: 1px;
+			border-right-width: 1px;
+		}
+	}
+
+	&.is-pinned .editor-html-toolbar__wrapper {
+		border-left-width: 0;
+		border-right-width: 0;
+		border-top-width: 0;
+		left: ( $sidebar-width-min + 1 );
+		max-width: none;
+		position: fixed;
+		top: 47px;
+		width: calc( 100% - ( #{ $sidebar-width-min + 1 } ) );
+
+		@include breakpoint( ">960px" ) {
+			left: ( $sidebar-width-max + 1 );
+			width: calc( 100% - ( #{ $sidebar-width-max + 1 } ) );
+		}
+	}
+
+	.editor-html-toolbar__buttons {
+		margin: 0 auto;
+		max-width: 700px;
+		width: 100%;
 	}
 
 	.button {

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -43,8 +43,15 @@
 		width: 100%;
 	}
 
-	&.is-scrollable:not( .is-scrolled-full ) .editor-html-toolbar__buttons::after {
+	&.is-scrollable .editor-html-toolbar__buttons::after {
 		@include long-content-fade();
+
+		height: 36px;
+		margin-top: 1px;
+		transition: width 0.2s;
+	}
+	&.is-scrollable.is-scrolled-full .editor-html-toolbar__buttons::after {
+		width: 0;
 	}
 
 	.button {

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -1,5 +1,5 @@
 .editor-html-toolbar {
-	min-height: 39px;
+	height: 39px;
 	position: relative;
 
 	.editor-html-toolbar__wrapper {
@@ -38,7 +38,13 @@
 	.editor-html-toolbar__buttons {
 		margin: 0 auto;
 		max-width: 700px;
+		overflow-x: auto;
+		white-space: nowrap;
 		width: 100%;
+	}
+
+	&.is-scrollable:not( .is-scrolled-full ) .editor-html-toolbar__buttons::after {
+		@include long-content-fade();
 	}
 
 	.button {


### PR DESCRIPTION
Update the HTML Toolbar style and behaviour to replicate the one of the TinyMCE Toolbar.

In detail:

1. The toolbar now sticks to the top of the page when scrolling.

![jan-27-2017 18-07-42](https://cloud.githubusercontent.com/assets/2070010/22380266/23b383f2-e4bd-11e6-96b0-191677552ead.gif)

2. The toolbar is now a single-line scrollable element, complete of the fading content.

![jan-27-2017 18-10-35](https://cloud.githubusercontent.com/assets/2070010/22380282/366dfcac-e4bd-11e6-8baa-f6e106c37f6b.gif)
_(note: in this GIF there's an open tag in order to activate the "Close Tags" button, or it would be too light to actually show the fade toggle)._

## Testing Instructions

1. Just have a long enough post and scroll down.
The toolbar must follow the scroll right below the masterbar.

2. Just have a small enough window or screen.
The toolbar must be a single line and can be scrolled.
The fading is only applied when the scroll is **not** complete (all the way to the right). Please allow a little bit for the fade to toggle, since it's a 200ms throttled function.

## Cross-Browser Compatibility Checklist

I've yet to try this everywhere, since I'd first love to get a design 👍.
Listed here are the browsers I can test on.

- [x] Chrome 55 / macOS 10.12
- [x] Firefox 50 / macOS 10.12 
- [x] Safari 10 / macOS 10.12
- [x] Chrome 55 / Android 6
- [x] Chrome 56 / Windows 10
- [x] Edge / Windows 10
- [x] Internet Explorer 11 / Windows 10

## Props

To @aduth and anyone from the Calypso initial commit for their astounding work on the TinyMCE toolbar that I basically just copied in total awe.