### PR TITLE
SiteSettings: reduxify site settings timezone stuff

### DIFF
--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -89,18 +89,18 @@ class PostScheduleClock extends Component {
 			gmtOffset,
 			siteId,
 			siteSlug,
-			timezone,
+			timezone_string,
 			translate
 		} = this.props;
 
-		if ( ! ( timezone || isValidGMTOffset( gmtOffset ) ) ) {
+		if ( ! ( timezone_string || isValidGMTOffset( gmtOffset ) ) ) {
 			return;
 		}
 
 		let diffInMinutes, tzDateOffset;
 
-		if ( timezone ) {
-			const tzDate = date.clone().tz( timezone );
+		if ( timezone_string ) {
+			const tzDate = date.clone().tz( timezone_string );
 			tzDateOffset = tzDate.format( 'Z' );
 			diffInMinutes = tzDate.utcOffset() - moment().utcOffset();
 		} else if ( isValidGMTOffset( gmtOffset ) ) {
@@ -113,8 +113,8 @@ class PostScheduleClock extends Component {
 		}
 
 		const popoverPosition = viewport.isMobile() ? 'top' : 'right';
-		const timezoneText = timezone
-			? `${ timezone.replace( /\_/ig, ' ' ) } ${ tzDateOffset }`
+		const timezoneText = timezone_string
+			? `${ timezone_string.replace( /\_/ig, ' ' ) } ${ tzDateOffset }`
 			: `UTC${ convertHoursToHHMM( gmtOffset ) }`;
 
 		const timezoneInfo = translate(
@@ -180,7 +180,7 @@ class PostScheduleClock extends Component {
 
 PostScheduleClock.propTypes = {
 	date: PropTypes.object.isRequired,
-	timezone: PropTypes.string,
+	timezone_string: PropTypes.string,
 	gmtOffset: PropTypes.number,
 	siteId: PropTypes.number,
 	siteSlug: PropTypes.string,

--- a/client/components/post-schedule/index.jsx
+++ b/client/components/post-schedule/index.jsx
@@ -2,11 +2,18 @@
  * External dependencies
  */
 import React, { PropTypes, Component } from 'react';
+import { connect } from 'react-redux';
 import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import {
+	getSiteGmtOffset,
+	getSiteTimezone,
+	getSiteTimezoneString,
+} from 'state/selectors';
+
 import InputChrono from 'components/input-chrono';
 import DatePicker from 'components/date-picker';
 import User from 'lib/user';
@@ -87,7 +94,7 @@ class PostSchedule extends Component {
 	getDateToUserLocation( date ) {
 		return utils.convertDateToUserLocation(
 			date || new Date(),
-			this.props.timezone,
+			this.props.timezone_string,
 			this.props.gmtOffset
 		);
 	}
@@ -111,7 +118,7 @@ class PostSchedule extends Component {
 
 		this.props.onDateChange( utils.convertDateToGivenOffset(
 			date,
-			this.props.timezone,
+			this.props.timezone_string,
 			this.props.gmtOffset
 		) );
 	}
@@ -157,7 +164,7 @@ class PostSchedule extends Component {
 		return (
 			<Clock
 				date={ date }
-				timezone={ this.props.timezone }
+				timezone_string={ this.props.timezone_string }
 				gmtOffset={ this.props.gmtOffset }
 				siteId={ this.props.site ? this.props.site.ID : null }
 				siteSlug={ this.props.site ? this.props.site.slug : null }
@@ -206,6 +213,7 @@ PostSchedule.propTypes = {
 	events: PropTypes.array,
 	posts: PropTypes.array,
 	timezone: PropTypes.string,
+	timezone_string: PropTypes.string,
 	gmtOffset: PropTypes.number,
 	site: PropTypes.object,
 
@@ -220,4 +228,10 @@ PostSchedule.defaultProps = {
 	onMonthChange: noop
 };
 
-export default PostSchedule;
+export default connect(
+	( state, { site } ) => ( {
+		gmtOffset: getSiteGmtOffset( state, site.ID ),
+		timezone_string: getSiteTimezoneString( state, site.ID ),
+		timezone: getSiteTimezone( state, site.ID ),
+	} )
+)( PostSchedule );

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -41,6 +41,7 @@ class SiteSettingsFormGeneral extends Component {
 
 	onTimezoneSelect = timezone => {
 		this.props.updateFields( {
+			timezone: timezone,
 			timezone_string: timezone
 		} );
 	};
@@ -469,7 +470,7 @@ class SiteSettingsFormGeneral extends Component {
 				</FormLabel>
 
 				<Timezone
-					selectedZone={ fields.timezone_string }
+					selectedZone={ fields.timezone }
 					disabled={ isRequestingSettings }
 					onSelect={ this.onTimezoneSelect }
 				/>
@@ -556,6 +557,7 @@ class SiteSettingsFormGeneral extends Component {
 							}
 					</Button>
 				</SectionHeader>
+
 				<Card>
 					<form onChange={ this.props.markChanged }>
 						{ this.siteOptions() }
@@ -690,6 +692,7 @@ export default wrapSettingsForm( settings => {
 		blogname: '',
 		blogdescription: '',
 		lang_id: '',
+		timezone: '',
 		timezone_string: '',
 		blog_public: '',
 		admin_url: '',
@@ -714,6 +717,7 @@ export default wrapSettingsForm( settings => {
 
 		lang_id: settings.lang_id,
 		blog_public: settings.blog_public,
+		timezone: settings.timezone,
 		timezone_string: settings.timezone_string,
 		jetpack_relatedposts_allowed: settings.jetpack_relatedposts_allowed,
 		jetpack_sync_non_public_post_stati: settings.jetpack_sync_non_public_post_stati,
@@ -732,19 +736,6 @@ export default wrapSettingsForm( settings => {
 			jetpack_relatedposts_show_headline: settings.jetpack_relatedposts_show_headline,
 			jetpack_relatedposts_show_thumbnails: settings.jetpack_relatedposts_show_thumbnails
 		} );
-	}
-
-	// handling `gmt_offset` and `timezone_string` values
-	const gmt_offset = settings.gmt_offset;
-
-	if (
-		! settings.timezone_string &&
-		typeof gmt_offset === 'string' &&
-		gmt_offset.length
-	) {
-		formSettings.timezone_string = 'UTC' +
-			( /\-/.test( gmt_offset ) ? '' : '+' ) +
-			gmt_offset;
 	}
 
 	return formSettings;

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -19,6 +19,7 @@ import {
 	getSiteSettingsSaveError,
 	getSiteSettings
 } from 'state/site-settings/selectors';
+import { getSiteTimezone } from 'state/selectors';
 import {
 	isRequestingJetpackSettings,
 	isUpdatingJetpackSettings,
@@ -91,7 +92,13 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			const { fields, settingsFields, site, jetpackSettingsUISupported } = this.props;
 			this.props.removeNotice( 'site-settings-save' );
 
-			this.props.saveSiteSettings( site.ID, pick( fields, settingsFields.site ) );
+			let settings = pick( fields, settingsFields.site );
+
+			// Omit `timezone` since this value isn't used to save site settings data.
+			settings = omit( settings, 'timezone' );
+
+			this.props.saveSiteSettings( site.ID, settings );
+
 			if ( jetpackSettingsUISupported ) {
 				this.props.updateSettings( site.ID, pick( fields, settingsFields.jetpack ) );
 			}
@@ -175,6 +182,10 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				settingsFields.jetpack = keys( jetpackSettings );
 				isRequestingSettings = isRequestingSettings || ( isRequestingJetpackSettings( state, siteId ) && ! jetpackSettings );
 			}
+
+			// Add custom `timezone` field
+			settings = { ...settings, timezone: getSiteTimezone( state, siteId ) };
+			settingsFields.site.push( 'timezone' );
 
 			return {
 				isRequestingSettings,

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -171,9 +171,7 @@ export default React.createClass( {
 	},
 
 	renderPostScheduler: function() {
-		const tz = siteUtils.timezone( this.props.site ),
-			gmtOffset = siteUtils.gmtOffset( this.props.site ),
-			postDate = this.props.post && this.props.post.date
+		const postDate = this.props.post && this.props.post.date
 				? this.props.post.date
 				: null;
 
@@ -181,8 +179,6 @@ export default React.createClass( {
 			<AsyncLoad
 				require="components/post-schedule"
 				selectedDay={ postDate }
-				timezone={ tz }
-				gmtOffset={ gmtOffset }
 				onDateChange={ this.setPostDate }
 				onMonthChange={ this.setCurrentMonth }
 				site={ this.props.site }

--- a/client/state/selectors/get-site-gmt-offset.js
+++ b/client/state/selectors/get-site-gmt-offset.js
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Return the site setting `gmt_offset` value from the state-tree
+ *
+ * @param  {Object}  state - Global state tree
+ * @param  {Number}  siteId - Site ID
+ * @return {?String} site setting timezone
+ */
+export default function getSiteGmtOffset( state, siteId ) {
+	const gmt = get( state.siteSettings.items, [ siteId, 'gmt_offset' ], null );
+	return gmt ? Number( gmt ) : gmt;
+}

--- a/client/state/selectors/get-site-timezone-string.js
+++ b/client/state/selectors/get-site-timezone-string.js
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Return the site setting `timezone_string` value from the state-tree
+ *
+ * @param  {Object}  state - Global state tree
+ * @param  {Number}  siteId - Site ID
+ * @return {?String} site setting timezone
+ */
+export default function getSiteTimezoneString( state, siteId ) {
+	const timezone = get( state.siteSettings.items, [ siteId, 'timezone_string' ], null );
+	return timezone && timezone.length ? timezone : null;
+}

--- a/client/state/selectors/get-site-timezone.js
+++ b/client/state/selectors/get-site-timezone.js
@@ -1,0 +1,31 @@
+
+/**
+ * Internal dependencies
+ */
+import {
+	getSiteGmtOffset,
+	getSiteTimezoneString
+} from 'state/selectors';
+
+/**
+ * Return the site setting `timezone` according to the timezone_string
+ * and the gmt_offset setting values.
+ *
+ * @param  {Object}  state - Global state tree
+ * @param  {Number}  siteId - Site ID
+ * @return {?String} site setting timezone
+ */
+export default function getSiteTimezone( state, siteId ) {
+	const timezone_string = getSiteTimezoneString( state, siteId );
+	if ( timezone_string ) {
+		return timezone_string;
+	}
+
+	const gmt_offset = getSiteGmtOffset( state, siteId );
+
+	if ( gmt_offset === null ) {
+		return null;
+	}
+
+	return `UTC${ ( /\-/.test( gmt_offset ) ? '' : '+' ) }${ gmt_offset }`;
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -35,6 +35,7 @@ export getSiteGmtOffset from './get-site-gmt-offset';
 export getSiteIconId from './get-site-icon-id';
 export getSiteIconUrl from './get-site-icon-url';
 export getSiteTimezoneString from './get-site-timezone-string';
+export getSiteTimezone from './get-site-timezone';
 export getTimezonesByContinent from './get-timezones-by-continent';
 export getUpcomingBillingTransactions from './get-upcoming-billing-transactions';
 export hasBrokenSiteUserConnection from './has-broken-site-user-connection';

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -31,6 +31,7 @@ export getPastBillingTransaction from './get-past-billing-transaction';
 export getPastBillingTransactions from './get-past-billing-transactions';
 export getPostLikes from './get-post-likes';
 export getSharingButtons from './get-sharing-buttons';
+export getSiteGmtOffset from './get-site-gmt-offset';
 export getSiteIconId from './get-site-icon-id';
 export getSiteIconUrl from './get-site-icon-url';
 export getSiteTimezoneString from './get-site-timezone-string';

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -33,6 +33,7 @@ export getPostLikes from './get-post-likes';
 export getSharingButtons from './get-sharing-buttons';
 export getSiteIconId from './get-site-icon-id';
 export getSiteIconUrl from './get-site-icon-url';
+export getSiteTimezoneString from './get-site-timezone-string';
 export getTimezonesByContinent from './get-timezones-by-continent';
 export getUpcomingBillingTransactions from './get-upcoming-billing-transactions';
 export hasBrokenSiteUserConnection from './has-broken-site-user-connection';

--- a/client/state/selectors/test/get-site-gmt-offset.js
+++ b/client/state/selectors/test/get-site-gmt-offset.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteGmtOffset } from '../';
+
+describe( 'getSiteGmtOffset()', () => {
+	it( 'should return null if the site has never been fetched', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {}
+			}
+		};
+
+		const offset = getSiteGmtOffset( stateTree, 2916284 );
+		expect( offset ).to.be.null;
+	} );
+
+	it( 'should return null if the site-settings has never been fetched', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {
+					2916284: {}
+				}
+			}
+		};
+
+		const offset = getSiteGmtOffset( stateTree, 2916284 );
+		expect( offset ).to.be.null;
+	} );
+
+	it( 'should return the site-settings utc offset', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {
+					2916284: {
+						gmt_offset: '11'
+					}
+				}
+			}
+		};
+
+		const offset = getSiteGmtOffset( stateTree, 2916284 );
+		expect( offset ).to.eql( 11 );
+	} );
+} );

--- a/client/state/selectors/test/get-site-timezone-string.js
+++ b/client/state/selectors/test/get-site-timezone-string.js
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteTimezoneString } from '../';
+
+describe( 'getSiteTimezoneString()', () => {
+	it( 'should return null if the site has never been fetched', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {}
+			}
+		};
+
+		const timezone = getSiteTimezoneString( stateTree, 2916284 );
+		expect( timezone ).to.be.null;
+	} );
+
+	it( 'should return null if the site-settings has never been fetched', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {
+					2916284: {}
+				}
+			}
+		};
+
+		const timezone = getSiteTimezoneString( stateTree, 2916284 );
+		expect( timezone ).to.be.null;
+	} );
+
+	it( 'should return null if the timezone_string is an empty string', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {
+					2916284: {
+						timezone_string: ''
+					}
+				}
+			}
+		};
+
+		const timezone = getSiteTimezoneString( stateTree, 2916284 );
+		expect( timezone ).to.be.null;
+	} );
+
+	it( 'should return site-settings timezone', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {
+					2916284: {
+						timezone_string: 'Europe/Skopje'
+					}
+				}
+			}
+		};
+
+		const timezone = getSiteTimezoneString( stateTree, 2916284 );
+		expect( timezone ).to.eql( 'Europe/Skopje' );
+	} );
+} );

--- a/client/state/selectors/test/get-site-timezone.js
+++ b/client/state/selectors/test/get-site-timezone.js
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteTimezone } from '../';
+
+describe( 'getSiteTimezone()', () => {
+	it( 'should return null if the site has never been fetched', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {}
+			}
+		};
+
+		const timezone = getSiteTimezone( stateTree, 2916284 );
+		expect( timezone ).to.be.null;
+	} );
+
+	it( 'should return null if the site-settings has never been fetched', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {
+					2916284: {}
+				}
+			}
+		};
+
+		const timezone = getSiteTimezone( stateTree, 2916284 );
+		expect( timezone ).to.be.null;
+	} );
+
+	it( 'should return site-settings timezone as the first priority', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {
+					2916284: {
+						timezone_string: 'Europe/Skopje',
+						gmt_offset: 11
+					}
+				}
+			}
+		};
+
+		const timezone = getSiteTimezone( stateTree, 2916284 );
+		expect( timezone ).to.eql( 'Europe/Skopje' );
+	} );
+
+	it( 'should return site-settings UTC offset if timezone_string is empty', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {
+					2916284: {
+						timezone_string: '',
+						gmt_offset: '11'
+					}
+				}
+			}
+		};
+
+		const timezone = getSiteTimezone( stateTree, 2916284 );
+		expect( timezone ).to.eql( 'UTC+11' );
+	} );
+
+	it( 'should return site-settings UTC offset for negative value', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {
+					2916284: {
+						timezone_string: '',
+						gmt_offset: '-11'
+					}
+				}
+			}
+		};
+
+		const timezone = getSiteTimezone( stateTree, 2916284 );
+		expect( timezone ).to.eql( 'UTC-11' );
+	} );
+} );


### PR DESCRIPTION
### DO NOT MERGE!

This PR contains different patches about timezones improvements, and its purpose is to be useful to test and take a look at the whole work around of this.

The following are the patches/PRs that we will have to merge one by one:

- [ ] (1) Add site-settings selectors: https://github.com/Automattic/wp-calypso/pull/11016
- [ ] (2) Improve site settings timezone propagation: https://github.com/Automattic/wp-calypso/pull/11017
- [ ] (3) PostSchedule: implement minimal redux connection: https://github.com/Automattic/wp-calypso/pull/11018