### PR TITLE
State: Add site-settings selectors

### DIFF
--- a/client/state/selectors/get-site-gmt-offset.js
+++ b/client/state/selectors/get-site-gmt-offset.js
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns the site's UTC offset as a number.
+ *
+ * @param  {Object}  state - Global state tree
+ * @param  {Number}  siteId - Site ID
+ * @return {?Number} site UTC offset
+ */
+export default function getSiteGmtOffset( state, siteId ) {
+	const gmt = get( state.siteSettings.items, [ siteId, 'gmt_offset' ], null );
+	return gmt ? Number( gmt ) : gmt;
+}

--- a/client/state/selectors/get-site-timezone-name.js
+++ b/client/state/selectors/get-site-timezone-name.js
@@ -1,0 +1,31 @@
+
+/**
+ * Internal dependencies
+ */
+import {
+	getSiteGmtOffset,
+	getSiteTimezoneValue
+} from 'state/selectors';
+
+/**
+ * Returns either the site's timezone name (eg 'America/Araguaina').
+ * if defined, or site's UTC offset ( eg 'UTC-3' ) in that order of preference.
+ *
+ * @param  {Object}  state - Global state tree
+ * @param  {Number}  siteId - Site ID
+ * @return {?String} site setting timezone
+ */
+export default function getSiteTimezoneName( state, siteId ) {
+	const timezone_string = getSiteTimezoneValue( state, siteId );
+	if ( timezone_string ) {
+		return timezone_string;
+	}
+
+	const gmt_offset = getSiteGmtOffset( state, siteId );
+
+	if ( gmt_offset === null ) {
+		return null;
+	}
+
+	return `UTC${ ( /\-/.test( gmt_offset ) ? '' : '+' ) }${ gmt_offset }`;
+}

--- a/client/state/selectors/get-site-timezone-value.js
+++ b/client/state/selectors/get-site-timezone-value.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns the site's timezone value, in the format of 'America/Araguaina.'
+ * See also: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+ *
+ * @param  {Object}  state - Global state tree
+ * @param  {Number}  siteId - Site ID
+ * @return {?String} site setting timezone
+ */
+export default function getSiteTimezoneValue( state, siteId ) {
+	const timezone = get( state.siteSettings.items, [ siteId, 'timezone_string' ], null );
+	return timezone && timezone.length ? timezone : null;
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -39,6 +39,7 @@ export getPostLikes from './get-post-likes';
 export getRawOffsets from './get-raw-offsets';
 export getReaderTeams from './get-reader-teams';
 export getSharingButtons from './get-sharing-buttons';
+export getSiteGmtOffset from './get-site-gmt-offset';
 export getSiteIconId from './get-site-icon-id';
 export getSiteIconUrl from './get-site-icon-url';
 export getSiteStatsQueryDate from './get-site-stats-query-date';

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -43,6 +43,7 @@ export getSiteIconId from './get-site-icon-id';
 export getSiteIconUrl from './get-site-icon-url';
 export getSiteStatsQueryDate from './get-site-stats-query-date';
 export getTimezones from './get-timezones';
+export getSiteTimezoneValue from './get-site-timezone-value';
 export getTimezonesByContinent from './get-timezones-by-continent';
 export getTimezonesLabel from './get-timezones-label';
 export getTimezonesLabels from './get-timezones-labels';

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -44,6 +44,7 @@ export getSiteIconId from './get-site-icon-id';
 export getSiteIconUrl from './get-site-icon-url';
 export getSiteStatsQueryDate from './get-site-stats-query-date';
 export getTimezones from './get-timezones';
+export getSiteTimezoneName from './get-site-timezone-name';
 export getSiteTimezoneValue from './get-site-timezone-value';
 export getTimezonesByContinent from './get-timezones-by-continent';
 export getTimezonesLabel from './get-timezones-label';

--- a/client/state/selectors/test/get-site-gmt-offset.js
+++ b/client/state/selectors/test/get-site-gmt-offset.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteGmtOffset } from '../';
+
+describe( 'getSiteGmtOffset()', () => {
+	it( 'should return null if the site has never been fetched', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {}
+			}
+		};
+
+		const offset = getSiteGmtOffset( stateTree, 2916284 );
+		expect( offset ).to.be.null;
+	} );
+
+	it( 'should return null if the site-settings has never been fetched', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {
+					2916284: {}
+				}
+			}
+		};
+
+		const offset = getSiteGmtOffset( stateTree, 2916284 );
+		expect( offset ).to.be.null;
+	} );
+
+	it( 'should return the site-settings utc offset', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {
+					2916284: {
+						gmt_offset: '11'
+					}
+				}
+			}
+		};
+
+		const offset = getSiteGmtOffset( stateTree, 2916284 );
+		expect( offset ).to.eql( 11 );
+	} );
+} );

--- a/client/state/selectors/test/get-site-timezone-name.js
+++ b/client/state/selectors/test/get-site-timezone-name.js
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteTimezoneName } from '../';
+
+describe( 'getSiteTimezoneName()', () => {
+	it( 'should return null if the site has never been fetched', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {}
+			}
+		};
+
+		const timezone = getSiteTimezoneName( stateTree, 2916284 );
+		expect( timezone ).to.be.null;
+	} );
+
+	it( 'should return null if the site-settings has never been fetched', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {
+					2916284: {}
+				}
+			}
+		};
+
+		const timezone = getSiteTimezoneName( stateTree, 2916284 );
+		expect( timezone ).to.be.null;
+	} );
+
+	it( 'should return site-settings timezone as the first priority', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {
+					2916284: {
+						timezone_string: 'Europe/Skopje',
+						gmt_offset: 11
+					}
+				}
+			}
+		};
+
+		const timezone = getSiteTimezoneName( stateTree, 2916284 );
+		expect( timezone ).to.eql( 'Europe/Skopje' );
+	} );
+
+	it( 'should return site-settings UTC offset if timezone_string is empty', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {
+					2916284: {
+						timezone_string: '',
+						gmt_offset: '11'
+					}
+				}
+			}
+		};
+
+		const timezone = getSiteTimezoneName( stateTree, 2916284 );
+		expect( timezone ).to.eql( 'UTC+11' );
+	} );
+
+	it( 'should return site-settings UTC offset for negative value', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {
+					2916284: {
+						timezone_string: '',
+						gmt_offset: '-11'
+					}
+				}
+			}
+		};
+
+		const timezone = getSiteTimezoneName( stateTree, 2916284 );
+		expect( timezone ).to.eql( 'UTC-11' );
+	} );
+} );

--- a/client/state/selectors/test/get-site-timezone-value.js
+++ b/client/state/selectors/test/get-site-timezone-value.js
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteTimezoneValue } from '../';
+
+describe( 'getSiteTimezoneValue()', () => {
+	it( 'should return null if the site has never been fetched', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {}
+			}
+		};
+
+		const timezone = getSiteTimezoneValue( stateTree, 2916284 );
+		expect( timezone ).to.be.null;
+	} );
+
+	it( 'should return null if the site-settings has never been fetched', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {
+					2916284: {}
+				}
+			}
+		};
+
+		const timezone = getSiteTimezoneValue( stateTree, 2916284 );
+		expect( timezone ).to.be.null;
+	} );
+
+	it( 'should return null if the timezone_string is an empty string', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {
+					2916284: {
+						timezone_string: ''
+					}
+				}
+			}
+		};
+
+		const timezone = getSiteTimezoneValue( stateTree, 2916284 );
+		expect( timezone ).to.be.null;
+	} );
+
+	it( 'should return site-settings timezone', () => {
+		const stateTree = {
+			siteSettings: {
+				items: {
+					2916284: {
+						timezone_string: 'Europe/Skopje'
+					}
+				}
+			}
+		};
+
+		const timezone = getSiteTimezoneValue( stateTree, 2916284 );
+		expect( timezone ).to.eql( 'Europe/Skopje' );
+	} );
+} );


### PR DESCRIPTION
This PR adds three sie-selectors related with timezone stuff.

### Testing

run the state/selectors test

```cli
npm run test-client client/state/selectors/
```

Among all selectors, you're going to run the new ones.