### PR TITLE
SiteSettings: Improve site settings timezone propagation

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -45,7 +45,8 @@ class SiteSettingsFormGeneral extends Component {
 
 	onTimezoneSelect = timezone => {
 		this.props.updateFields( {
-			timezone_string: timezone
+			timezone_string: timezone,
+			timezone_value: timezone,
 		} );
 	};
 
@@ -467,7 +468,7 @@ class SiteSettingsFormGeneral extends Component {
 				</FormLabel>
 
 				<Timezone
-					selectedZone={ fields.timezone_string }
+					selectedZone={ fields.timezone_value }
 					disabled={ isRequestingSettings }
 					onSelect={ this.onTimezoneSelect }
 				/>
@@ -743,6 +744,7 @@ class SiteSettingsFormGeneral extends Component {
 							}
 					</Button>
 				</SectionHeader>
+
 				<Card>
 					<form>
 						{ this.siteOptions() }
@@ -881,6 +883,7 @@ export default wrapSettingsForm( settings => {
 		blogdescription: '',
 		lang_id: '',
 		timezone_string: '',
+		timezone_value: '',
 		date_format: '',
 		time_format: '',
 		start_of_week: 0,
@@ -908,6 +911,7 @@ export default wrapSettingsForm( settings => {
 		lang_id: settings.lang_id,
 		blog_public: settings.blog_public,
 		timezone_string: settings.timezone_string,
+		timezone_value: settings.timezone_value,
 		date_format: settings.date_format,
 		time_format: settings.time_format,
 		start_of_week: settings.start_of_week,
@@ -928,19 +932,6 @@ export default wrapSettingsForm( settings => {
 			jetpack_relatedposts_show_headline: settings.jetpack_relatedposts_show_headline,
 			jetpack_relatedposts_show_thumbnails: settings.jetpack_relatedposts_show_thumbnails
 		} );
-	}
-
-	// handling `gmt_offset` and `timezone_string` values
-	const gmt_offset = settings.gmt_offset;
-
-	if (
-		! settings.timezone_string &&
-		typeof gmt_offset === 'string' &&
-		gmt_offset.length
-	) {
-		formSettings.timezone_string = 'UTC' +
-			( /\-/.test( gmt_offset ) ? '' : '+' ) +
-			gmt_offset;
 	}
 
 	return formSettings;

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -19,6 +19,7 @@ import {
 	getSiteSettingsSaveError,
 	getSiteSettings
 } from 'state/site-settings/selectors';
+import { getSiteTimezoneValue } from 'state/selectors';
 import {
 	isRequestingJetpackSettings,
 	isUpdatingJetpackSettings,
@@ -110,7 +111,13 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			const { fields, settingsFields, siteId, jetpackSettingsUISupported } = this.props;
 			this.props.removeNotice( 'site-settings-save' );
 
-			this.props.saveSiteSettings( siteId, pick( fields, settingsFields.site ) );
+			let settings = pick( fields, settingsFields.site );
+
+			// Omit `timezone` since this value isn't used to save site settings data.
+			settings = omit( settings, 'timezone_value' );
+
+			this.props.saveSiteSettings( siteId, settings );
+
 			if ( jetpackSettingsUISupported ) {
 				this.props.updateSettings( siteId, pick( fields, settingsFields.jetpack ) );
 			}
@@ -206,6 +213,10 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				settingsFields.jetpack = keys( jetpackSettings );
 				isRequestingSettings = isRequestingSettings || ( isRequestingJetpackSettings( state, siteId ) && ! jetpackSettings );
 			}
+
+			// Add custom `timezone_value` field
+			settings = { ...settings, timezone_value: getSiteTimezoneValue( state, siteId ) };
+			settingsFields.site.push( 'timezone_value' );
 
 			return {
 				isRequestingSettings,


### PR DESCRIPTION
~This PR depends on #11016.~

This PR aims improve the timezone propagation using state/selectors removing unnecessary code from the form wrapper component.

### Testing

1) Go to a site settings page: `http://calypso.localhost:3000/settings/general/<your testing site>`
2) Look at `Set Timezone` section.
3) Edit the timezone value.

- [ ] Set timezone through of a location
- [ ] Set timezone through a static zone (UTC+...)

Everything should be ok. The timezone should be saved and updated rightly. 

`updated: 2017-02-24` by @retrofox