### PR TITLE
PostSchedule: implement minimal redux connection

### DIFF
--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -89,18 +89,18 @@ class PostScheduleClock extends Component {
 			gmtOffset,
 			siteId,
 			siteSlug,
-			timezone,
+			timezone_string,
 			translate
 		} = this.props;
 
-		if ( ! ( timezone || isValidGMTOffset( gmtOffset ) ) ) {
+		if ( ! ( timezone_string || isValidGMTOffset( gmtOffset ) ) ) {
 			return;
 		}
 
 		let diffInMinutes, tzDateOffset;
 
-		if ( timezone ) {
-			const tzDate = date.clone().tz( timezone );
+		if ( timezone_string ) {
+			const tzDate = date.clone().tz( timezone_string );
 			tzDateOffset = tzDate.format( 'Z' );
 			diffInMinutes = tzDate.utcOffset() - moment().utcOffset();
 		} else if ( isValidGMTOffset( gmtOffset ) ) {
@@ -113,8 +113,8 @@ class PostScheduleClock extends Component {
 		}
 
 		const popoverPosition = viewport.isMobile() ? 'top' : 'right';
-		const timezoneText = timezone
-			? `${ timezone.replace( /\_/ig, ' ' ) } ${ tzDateOffset }`
+		const timezoneText = timezone_string
+			? `${ timezone_string.replace( /\_/ig, ' ' ) } ${ tzDateOffset }`
 			: `UTC${ convertHoursToHHMM( gmtOffset ) }`;
 
 		const timezoneInfo = translate(
@@ -180,7 +180,7 @@ class PostScheduleClock extends Component {
 
 PostScheduleClock.propTypes = {
 	date: PropTypes.object.isRequired,
-	timezone: PropTypes.string,
+	timezone_string: PropTypes.string,
 	gmtOffset: PropTypes.number,
 	siteId: PropTypes.number,
 	siteSlug: PropTypes.string,

--- a/client/components/post-schedule/index.jsx
+++ b/client/components/post-schedule/index.jsx
@@ -2,11 +2,18 @@
  * External dependencies
  */
 import React, { PropTypes, Component } from 'react';
+import { connect } from 'react-redux';
 import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import {
+	getSiteGmtOffset,
+	getSiteTimezone,
+	getSiteTimezoneString,
+} from 'state/selectors';
+
 import InputChrono from 'components/input-chrono';
 import DatePicker from 'components/date-picker';
 import User from 'lib/user';
@@ -87,7 +94,7 @@ class PostSchedule extends Component {
 	getDateToUserLocation( date ) {
 		return utils.convertDateToUserLocation(
 			date || new Date(),
-			this.props.timezone,
+			this.props.timezone_string,
 			this.props.gmtOffset
 		);
 	}
@@ -111,7 +118,7 @@ class PostSchedule extends Component {
 
 		this.props.onDateChange( utils.convertDateToGivenOffset(
 			date,
-			this.props.timezone,
+			this.props.timezone_string,
 			this.props.gmtOffset
 		) );
 	}
@@ -157,7 +164,7 @@ class PostSchedule extends Component {
 		return (
 			<Clock
 				date={ date }
-				timezone={ this.props.timezone }
+				timezone_string={ this.props.timezone_string }
 				gmtOffset={ this.props.gmtOffset }
 				siteId={ this.props.site ? this.props.site.ID : null }
 				siteSlug={ this.props.site ? this.props.site.slug : null }
@@ -206,6 +213,7 @@ PostSchedule.propTypes = {
 	events: PropTypes.array,
 	posts: PropTypes.array,
 	timezone: PropTypes.string,
+	timezone_string: PropTypes.string,
 	gmtOffset: PropTypes.number,
 	site: PropTypes.object,
 
@@ -220,4 +228,10 @@ PostSchedule.defaultProps = {
 	onMonthChange: noop
 };
 
-export default PostSchedule;
+export default connect(
+	( state, { site } ) => ( {
+		gmtOffset: getSiteGmtOffset( state, site.ID ),
+		timezone_string: getSiteTimezoneString( state, site.ID ),
+		timezone: getSiteTimezone( state, site.ID ),
+	} )
+)( PostSchedule );

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -171,9 +171,7 @@ export default React.createClass( {
 	},
 
 	renderPostScheduler: function() {
-		const tz = siteUtils.timezone( this.props.site ),
-			gmtOffset = siteUtils.gmtOffset( this.props.site ),
-			postDate = this.props.post && this.props.post.date
+		const postDate = this.props.post && this.props.post.date
 				? this.props.post.date
 				: null;
 
@@ -181,8 +179,6 @@ export default React.createClass( {
 			<AsyncLoad
 				require="components/post-schedule"
 				selectedDay={ postDate }
-				timezone={ tz }
-				gmtOffset={ gmtOffset }
 				onDateChange={ this.setPostDate }
 				onMonthChange={ this.setCurrentMonth }
 				site={ this.props.site }


### PR DESCRIPTION
**DO NOT MERGE**
This PR depends on #11017

This PR implements a minimal connection between the `PostSchedule` component and the state tree. For now, only the timezones values are gotten from state tree and propagated to the component. 
It fixes a delay bug when the timezone is edited from the site settings - general page and its new value is not propagated into the PostSchedule.

<img src="https://cloud.githubusercontent.com/assets/77539/22389102/bd3dd1a8-e4c2-11e6-89ac-524c4f7e8eba.gif" width="500px" />
