### PR TITLE
Notifications: Fix typo `postMesssage` -> `postMessage`

### DIFF
--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -214,7 +214,7 @@ export class Notifications extends Component {
 				this.postAuth();
 
 				if ( this.queuedMessage ) {
-					this.postMesssage( this.queuedMessage );
+					this.postMessage( this.queuedMessage );
 					this.queuedMessage = null;
 				}
 


### PR DESCRIPTION
This typo was causing errors because `postMesssage` isn't a function.