### PR TITLE
Contact Form: fix the contact form to close on insert or update

### DIFF
--- a/client/components/tinymce/plugins/contact-form/plugin.jsx
+++ b/client/components/tinymce/plugins/contact-form/plugin.jsx
@@ -58,6 +58,7 @@ const wpcomContactForm = editor => {
 						onInsert() {
 							const state = store.getState();
 							editor.execCommand( 'mceInsertContent', false, serialize( state.ui.editor.contactForm ) );
+							renderModal( 'hide' );
 						},
 						onChangeTabs( tab ) {
 							renderModal( 'show', tab );
@@ -68,7 +69,7 @@ const wpcomContactForm = editor => {
 							renderModal( 'hide' );
 						},
 						onFieldAdd() {
-							store.dispatch( fieldAdd() )
+							store.dispatch( fieldAdd() );
 						},
 						onFieldRemove( index ) {
 							store.dispatch( fieldRemove( index ) );
@@ -83,7 +84,7 @@ const wpcomContactForm = editor => {
 				),
 				node
 			);
-		};
+		}
 
 		renderModal();
 	} );
@@ -104,4 +105,4 @@ const wpcomContactForm = editor => {
 
 export default () => {
 	tinymce.PluginManager.add( 'wpcom/contactform', wpcomContactForm );
-}
+};


### PR DESCRIPTION
Fixes #11025 where the contact form modal dialog wouldn't close after clicking "Insert" or "Update"

**Before**

![contact form](https://cloud.githubusercontent.com/assets/128826/22444967/033ee7fc-e791-11e6-8af4-17ac3b73909c.gif)

**After**

![contact form after](https://cloud.githubusercontent.com/assets/128826/22445324/a51f3be8-e792-11e6-8504-fd93e23d8c57.gif)

**Testing Instructions**

* Insert a new contact form, make sure modal closes
* Update an existing contact form, make sure modal closes