### PR TITLE
Stats: Drop the global site prop from the stats insights

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -105,9 +105,6 @@ module.exports = {
 		let siteId = context.params.site_id;
 		const basePath = route.sectionify( context.path );
 		const followList = new FollowList();
-		let summaryDate;
-		const summarySites = [];
-		let momentSiteZone = i18n.moment();
 		const StatsComponent = Insights;
 
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
@@ -131,12 +128,6 @@ module.exports = {
 			}
 		}
 
-		if ( site && site.options && typeof site.options.gmt_offset !== 'undefined' ) {
-			momentSiteZone = i18n.moment().utcOffset( site.options.gmt_offset );
-			summaryDate = momentSiteZone.format( 'YYYY-MM-DD' );
-			summarySites.push( { ID: siteId, date: summaryDate } );
-		}
-
 		const siteDomain = ( site && ( typeof site.slug !== 'undefined' ) )
 			? site.slug : route.getSiteFragment( context.path );
 
@@ -146,10 +137,8 @@ module.exports = {
 
 		renderWithReduxStore(
 			React.createElement( StatsComponent, {
-				site: site,
 				followList: followList,
-				commentsList: commentsList,
-				summaryDate: summaryDate
+				commentsList: commentsList
 			} ),
 			document.getElementById( 'primary' ),
 			context.store

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -146,9 +146,7 @@ module.exports = React.createClass( {
 			<Main wideLayout={ true }>
 				<StatsFirstView />
 				<SidebarNavigation />
-				<StatsNavigation
-					section={ period }
-					site={ site } />
+				<StatsNavigation section={ period } />
 				<div id="my-stats-content">
 					<ChartTabs
 						barClick={ this.barClick }

--- a/client/my-sites/stats/stats-comments/index.jsx
+++ b/client/my-sites/stats/stats-comments/index.jsx
@@ -138,7 +138,7 @@ const StatsComments = React.createClass( {
 
 		return (
 			<div>
-				<QuerySiteStats statType="statsCommentFollowers" siteId={ siteId } query={ { max: 7 } } />
+				{ siteId && <QuerySiteStats statType="statsCommentFollowers" siteId={ siteId } query={ { max: 7 } } /> }
 				<SectionHeader label={ translate( 'Comments' ) }></SectionHeader>
 				<Card className={ classes }>
 					<div className="module-content">

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -116,8 +116,8 @@ class StatModuleFollowers extends Component {
 
 		return (
 			<div>
-				<QuerySiteStats statType="statsFollowers" siteId={ siteId } query={ wpcomQuery } />
-				<QuerySiteStats statType="statsFollowers" siteId={ siteId } query={ emailQuery } />
+				{ siteId && <QuerySiteStats statType="statsFollowers" siteId={ siteId } query={ wpcomQuery } /> }
+				{ siteId && <QuerySiteStats statType="statsFollowers" siteId={ siteId } query={ emailQuery } /> }
 				<SectionHeader label={ translate( 'Followers' ) } href={ summaryPageLink } />
 				<Card className={ classNames( ...classes ) }>
 					<div className="followers">

--- a/client/my-sites/stats/stats-navigation/index.jsx
+++ b/client/my-sites/stats/stats-navigation/index.jsx
@@ -1,8 +1,10 @@
 /**
  * External Dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { flowRight } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,51 +13,57 @@ import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 import FollowersCount from 'blocks/followers-count';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 
-class StatsNavigation extends Component {
-	static propTypes = {
-		section: PropTypes.string.isRequired,
-		site: PropTypes.oneOfType( [
-			PropTypes.bool,
-			PropTypes.object
-		] )
-	}
+const StatsNavigation = ( props ) => {
+	const { translate, section, slug } = props;
+	const siteFragment = slug ? '/' + slug : '';
+	const sectionTitles = {
+		insights: translate( 'Insights' ),
+		day: translate( 'Days' ),
+		week: translate( 'Weeks' ),
+		month: translate( 'Months' ),
+		year: translate( 'Years' )
+	};
 
-	render() {
-		const { translate, section, site } = this.props;
-		const siteFragment = site ? '/' + site.slug : '';
-		const sectionTitles = {
-			insights: translate( 'Insights' ),
-			day: translate( 'Days' ),
-			week: translate( 'Weeks' ),
-			month: translate( 'Months' ),
-			year: translate( 'Years' )
+	return (
+		<SectionNav selectedText={ sectionTitles[ section ] }>
+			<NavTabs label={ translate( 'Stats' ) }>
+				<NavItem path={ '/stats/insights' + siteFragment } selected={ section === 'insights' }>
+					{ sectionTitles.insights }
+				</NavItem>
+				<NavItem path={ '/stats/day' + siteFragment } selected={ section === 'day' }>
+					{ sectionTitles.day }
+				</NavItem>
+				<NavItem path={ '/stats/week' + siteFragment } selected={ section === 'week' }>
+					{ sectionTitles.week }
+				</NavItem>
+				<NavItem path={ '/stats/month' + siteFragment } selected={ section === 'month' }>
+					{ sectionTitles.month }
+				</NavItem>
+				<NavItem path={ '/stats/year' + siteFragment } selected={ section === 'year' }>
+					{ sectionTitles.year }
+				</NavItem>
+			</NavTabs>
+			<FollowersCount />
+		</SectionNav>
+	);
+};
+
+StatsNavigation.propTypes = {
+	section: PropTypes.string.isRequired,
+	slug: PropTypes.string,
+};
+
+const connectComponent = connect(
+	state => {
+		return {
+			slug: getSelectedSiteSlug( state )
 		};
-
-
-		return (
-			<SectionNav selectedText={ sectionTitles[ section ] }>
-				<NavTabs label={ translate( 'Stats' ) }>
-					<NavItem path={ '/stats/insights' + siteFragment } selected={ section === 'insights' }>
-						{ sectionTitles.insights }
-					</NavItem>
-					<NavItem path={ '/stats/day' + siteFragment } selected={ section === 'day' }>
-						{ sectionTitles.day }
-					</NavItem>
-					<NavItem path={ '/stats/week' + siteFragment } selected={ section === 'week' }>
-						{ sectionTitles.week }
-					</NavItem>
-					<NavItem path={ '/stats/month' + siteFragment } selected={ section === 'month' }>
-						{ sectionTitles.month }
-					</NavItem>
-					<NavItem path={ '/stats/year' + siteFragment } selected={ section === 'year' }>
-						{ sectionTitles.year }
-					</NavItem>
-				</NavTabs>
-				<FollowersCount />
-			</SectionNav>
-		);
 	}
-}
+);
 
-export default localize( StatsNavigation );
+export default flowRight(
+	connectComponent,
+	localize
+)( StatsNavigation );


### PR DESCRIPTION
In this PR, I'm refactoring the `StatsInsights` component (and all its children) to drop the usage of the global site prop and use the Redux tree instead. 

**Testing instructions**

 - Navigate to the stats insights page `/stats/insights`
 - The navigation (days/weeks/months ...) should work as expected
 - The "Last Post Summary" component should work properly