### PR TITLE
Implement tracking for theme showcase.

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -176,7 +176,7 @@ const Theme = React.createClass( {
 									index={ this.props.index }
 									theme={ this.props.theme }
 									active={ this.props.active }
-									onClick={ this.props.onMoreButtonClick }
+									onMoreButtonClick={ this.props.onMoreButtonClick }
 									options={ this.props.buttonContents } />
 							</TrackInteractions> : null }
 					</div>

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -29,7 +29,7 @@ class ThemeMoreButton extends React.Component {
 
 	togglePopover() {
 		this.setState( { showPopover: ! this.state.showPopover } );
-		! this.state.showPopover && this.props.onMoreButtonClick( this.props.theme, this.props.index, 'ellipsis_open' );
+		! this.state.showPopover && this.props.onMoreButtonClick( this.props.theme, this.props.index, 'popup_open' );
 	}
 
 	closePopover( action ) {
@@ -41,7 +41,7 @@ class ThemeMoreButton extends React.Component {
 
 	popoverAction( action, label ) {
 		action( this.props.theme );
-		this.props.onMoreButtonClick( this.props.theme, this.props.index, 'ellipsis_' + label );
+		this.props.onMoreButtonClick( this.props.theme, this.props.index, 'popup_' + label );
 	}
 
 	onPopoverActionClick( action, label ) {

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -24,24 +24,36 @@ class ThemeMoreButton extends React.Component {
 		this.togglePopover = this.togglePopover.bind( this );
 		this.closePopover = this.closePopover.bind( this );
 		this.onClick = this.onClick.bind( this );
+		this.onPopoverActionClick = this.onPopoverActionClick.bind( this );
 	}
 
 	togglePopover() {
 		this.setState( { showPopover: ! this.state.showPopover } );
-		! this.state.showPopover && this.props.onClick( this.props.theme.id, this.props.index );
+		! this.state.showPopover && this.props.onMoreButtonClick( this.props.theme, this.props.index, 'ellipsis_open' );
 	}
 
 	closePopover( action ) {
 		this.setState( { showPopover: false } );
-		isFunction( action ) && action( this.props.theme );
+		if ( isFunction( action ) ) {
+			action();
+		}
+	}
+
+	popoverAction( action, label ) {
+		action( this.props.theme );
+		this.props.onMoreButtonClick( this.props.theme, this.props.index, 'ellipsis_' + label );
+	}
+
+	onPopoverActionClick( action, label ) {
+		return this.popoverAction.bind( this, action, label );
 	}
 
 	focus( event ) {
 		event.target.focus();
 	}
 
-	onClick( action ) {
-		return this.closePopover.bind( this, action );
+	onClick( action, label ) {
+		return this.closePopover.bind( this, this.onPopoverActionClick( action, label ) );
 	}
 
 	render() {
@@ -71,7 +83,7 @@ class ThemeMoreButton extends React.Component {
 							return (
 								<a className="theme__more-button-menu-item popover__menu-item"
 									onMouseOver={ this.focus }
-									onClick={ this.onClick( option.action ) }
+									onClick={ this.onClick( option.action, option.label ) }
 									key={ option.label }
 									href={ url }
 									target={ isOutsideCalypso( url ) ? '_blank' : null }>
@@ -81,7 +93,9 @@ class ThemeMoreButton extends React.Component {
 						}
 						if ( option.action ) {
 							return (
-								<PopoverMenuItem key={ option.label } action={ option.action }>
+								<PopoverMenuItem
+									key={ option.label }
+									action={ this.onPopoverActionClick( option.action, option.label ) }>
 									{ option.label }
 								</PopoverMenuItem>
 							);
@@ -101,6 +115,9 @@ ThemeMoreButton.propTypes = {
 	theme: React.PropTypes.object,
 	// Index of theme in results list
 	index: React.PropTypes.number,
+	// More elaborate onClick action, used for tracking.
+	// Made to not interfere with DOM onClick
+	onMoreButtonClick: React.PropTypes.func,
 	// Options to populate the popover menu with
 	options: React.PropTypes.objectOf(
 		React.PropTypes.shape( {

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -45,7 +45,7 @@ class ThemeMoreButton extends React.Component {
 	}
 
 	onPopoverActionClick( action, label ) {
-		return this.popoverAction.bind( this, action, label );
+		return () => this.popoverAction( action, label );
 	}
 
 	focus( event ) {

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -66,14 +66,16 @@ const ThemesSelection = React.createClass( {
 		}
 	},
 
-	recordSearchResultsClick( theme, resultsRank ) {
+	recordSearchResultsClick( theme, resultsRank, action ) {
 		const { query, themes } = this.props;
 		analytics.tracks.recordEvent( 'calypso_themeshowcase_theme_click', {
 			search_term: query.search,
 			theme: theme.id,
 			results_rank: resultsRank + 1,
 			results: themes.map( property( 'id' ) ).join(),
-			page_number: query.page
+			page_number: query.page,
+			theme_on_page: parseInt( ( resultsRank + 1 ) / query.number ),
+			action
 		} );
 	},
 
@@ -89,8 +91,8 @@ const ThemesSelection = React.createClass( {
 
 	onScreenshotClick( theme, resultsRank ) {
 		trackClick( 'theme', 'screenshot' );
-		if ( ! this.props.isThemeActive( theme.id ) ) {
-			this.recordSearchResultsClick( theme, resultsRank );
+		if ( ! this.props.isThemeActive( theme ) ) {
+			this.recordSearchResultsClick( theme, resultsRank, 'screenshot_info' );
 		}
 		this.props.onScreenshotClick && this.props.onScreenshotClick( theme );
 	},
@@ -125,6 +127,7 @@ const ThemesSelection = React.createClass( {
 				<ThemesList themes={ this.props.themes }
 					fetchNextPage={ this.fetchNextPage }
 					getButtonOptions={ this.props.getOptions }
+					onMoreButtonClick={ this.recordSearchResultsClick }
 					onScreenshotClick={ this.onScreenshotClick }
 					getScreenshotUrl={ this.props.getScreenshotUrl }
 					getActionLabel={ this.props.getActionLabel }

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -3,7 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { compact, isEqual, omit, property } from 'lodash';
+import { compact, isEqual, omit, property, snakeCase } from 'lodash';
 
 /**
  * Internal dependencies
@@ -75,7 +75,7 @@ const ThemesSelection = React.createClass( {
 			results: themes.map( property( 'id' ) ).join(),
 			page_number: query.page,
 			theme_on_page: parseInt( ( resultsRank + 1 ) / query.number ),
-			action
+			action: snakeCase( action )
 		} );
 	},
 


### PR DESCRIPTION
### Info 
This PR adds complete tracking information for theme showcase. 
The gathered data covers:

-  screenshot click( Info )
-  ellipsis click, removed in #10937 (because it was broken)
-  ellipsis items click

It uses the event tag `calypso_themeshowcase_theme_click` that was already present in `ThemesSelection` 

Two new fields where added. First one `theme_on_page` which tells from which fetched page comes the selected theme. Second filed named `action` holds information about which action user performed. The set of action tags consist of: 

- screenshot_info
- popup_open
- popup_live_demo
- popup_purchase
- popup_try_customize
- popup_info
- popup_setup
- popup_support

Tracking information is backwards compatible.