### PR TITLE
State: Remove jetpack tautology from subtrees

### DIFF
--- a/client/state/jetpack/reducer.js
+++ b/client/state/jetpack/reducer.js
@@ -7,13 +7,13 @@ import { combineReducers } from 'redux';
  * Internal dependencies
  */
 import { reducer as connection } from './connection/reducer';
-import { reducer as jetpackJumpstart } from './jumpstart/reducer';
+import { reducer as jumpstart } from './jumpstart/reducer';
 import { reducer as jetpackModules } from './modules/reducer';
 import { reducer as settings } from './settings/reducer';
 
 export default combineReducers( {
 	connection,
-	jetpackJumpstart,
+	jumpstart,
 	jetpackModules,
 	settings
 } );

--- a/client/state/jetpack/reducer.js
+++ b/client/state/jetpack/reducer.js
@@ -8,12 +8,12 @@ import { combineReducers } from 'redux';
  */
 import { reducer as connection } from './connection/reducer';
 import { reducer as jumpstart } from './jumpstart/reducer';
-import { reducer as jetpackModules } from './modules/reducer';
+import { reducer as modules } from './modules/reducer';
 import { reducer as settings } from './settings/reducer';
 
 export default combineReducers( {
 	connection,
 	jumpstart,
-	jetpackModules,
+	modules,
 	settings
 } );

--- a/client/state/jetpack/reducer.js
+++ b/client/state/jetpack/reducer.js
@@ -6,13 +6,13 @@ import { combineReducers } from 'redux';
 /**
  * Internal dependencies
  */
-import { reducer as jetpackConnection } from './connection/reducer';
+import { reducer as connection } from './connection/reducer';
 import { reducer as jetpackJumpstart } from './jumpstart/reducer';
 import { reducer as jetpackModules } from './modules/reducer';
 import { reducer as settings } from './settings/reducer';
 
 export default combineReducers( {
-	jetpackConnection,
+	connection,
 	jetpackJumpstart,
 	jetpackModules,
 	settings

--- a/client/state/selectors/get-jetpack-connection-status.js
+++ b/client/state/selectors/get-jetpack-connection-status.js
@@ -12,5 +12,5 @@ import { get } from 'lodash';
  * @return {?Object}             Details about connection status
  */
 export default function getJetpackConnectionStatus( state, siteId ) {
-	return get( state.jetpack.jetpackConnection.items, [ siteId ], null );
+	return get( state.jetpack.connection.items, [ siteId ], null );
 }

--- a/client/state/selectors/get-jetpack-jumpstart-status.js
+++ b/client/state/selectors/get-jetpack-jumpstart-status.js
@@ -12,5 +12,5 @@ import { get } from 'lodash';
  * @return {?String}             Whether Jumpstart is active
  */
 export default function getJetpackJumpstartStatus( state, siteId ) {
-	return get( state.jetpack.jetpackJumpstart.items, [ siteId ], null );
+	return get( state.jetpack.jumpstart.items, [ siteId ], null );
 }

--- a/client/state/selectors/get-jetpack-module.js
+++ b/client/state/selectors/get-jetpack-module.js
@@ -13,5 +13,5 @@ import { get } from 'lodash';
  * @return {?Object}             Module data
  */
 export default function getJetpackModule( state, siteId, moduleSlug ) {
-	return get( state.jetpack.jetpackModules.items, [ siteId, moduleSlug ], null );
+	return get( state.jetpack.modules.items, [ siteId, moduleSlug ], null );
 }

--- a/client/state/selectors/get-jetpack-modules.js
+++ b/client/state/selectors/get-jetpack-modules.js
@@ -12,5 +12,5 @@ import { get } from 'lodash';
  * @return {?Object}         Modules data
  */
 export default function getJetpackModules( state, siteId ) {
-	return get( state.jetpack.jetpackModules.items, [ siteId ], null );
+	return get( state.jetpack.modules.items, [ siteId ], null );
 }

--- a/client/state/selectors/is-activating-jetpack-jumpstart.js
+++ b/client/state/selectors/is-activating-jetpack-jumpstart.js
@@ -12,5 +12,5 @@ import { get } from 'lodash';
  * @return {?Boolean}            Whether Jumpstart is currently being activated
  */
 export default function isActivatingJetpackJumpstart( state, siteId ) {
-	return get( state.jetpack.jetpackJumpstart.requests, [ siteId, 'activating' ], null );
+	return get( state.jetpack.jumpstart.requests, [ siteId, 'activating' ], null );
 }

--- a/client/state/selectors/is-activating-jetpack-module.js
+++ b/client/state/selectors/is-activating-jetpack-module.js
@@ -13,5 +13,5 @@ import { get } from 'lodash';
  * @return {?Boolean}            Whether module is currently being activated
  */
 export default function isActivatingJetpackModule( state, siteId, moduleSlug ) {
-	return get( state.jetpack.jetpackModules.requests, [ siteId, moduleSlug, 'activating' ], null );
+	return get( state.jetpack.modules.requests, [ siteId, moduleSlug, 'activating' ], null );
 }

--- a/client/state/selectors/is-deactivating-jetpack-jumpstart.js
+++ b/client/state/selectors/is-deactivating-jetpack-jumpstart.js
@@ -12,5 +12,5 @@ import { get } from 'lodash';
  * @return {?Boolean}            Whether Jumpstart is currently being deactivated
  */
 export default function isDeactivatingJetpackJumpstart( state, siteId ) {
-	return get( state.jetpack.jetpackJumpstart.requests, [ siteId, 'deactivating' ], null );
+	return get( state.jetpack.jumpstart.requests, [ siteId, 'deactivating' ], null );
 }

--- a/client/state/selectors/is-deactivating-jetpack-module.js
+++ b/client/state/selectors/is-deactivating-jetpack-module.js
@@ -13,5 +13,5 @@ import { get } from 'lodash';
  * @return {?Boolean}            Whether module is currently being deactivated
  */
 export default function isDeactivatingJetpackModule( state, siteId, moduleSlug ) {
-	return get( state.jetpack.jetpackModules.requests, [ siteId, moduleSlug, 'deactivating' ], null );
+	return get( state.jetpack.modules.requests, [ siteId, moduleSlug, 'deactivating' ], null );
 }

--- a/client/state/selectors/is-fetching-jetpack-modules.js
+++ b/client/state/selectors/is-fetching-jetpack-modules.js
@@ -13,5 +13,5 @@ import { get } from 'lodash';
  * @return {?Boolean}         Whether the list is being requested
  */
 export default function isFetchingJetpackModules( state, siteId ) {
-	return get( state.jetpack.jetpackModules.requests, [ siteId, 'fetchingModules' ], null );
+	return get( state.jetpack.modules.requests, [ siteId, 'fetchingModules' ], null );
 }

--- a/client/state/selectors/is-jetpack-module-active.js
+++ b/client/state/selectors/is-jetpack-module-active.js
@@ -13,5 +13,5 @@ import { get } from 'lodash';
  * @return {?Boolean}            Whether the module is active
  */
 export default function isJetpackModuleActive( state, siteId, moduleSlug ) {
-	return get( state.jetpack.jetpackModules.items, [ siteId, moduleSlug, 'active' ], null );
+	return get( state.jetpack.modules.items, [ siteId, moduleSlug, 'active' ], null );
 }

--- a/client/state/selectors/is-requesting-jetpack-connection-status.js
+++ b/client/state/selectors/is-requesting-jetpack-connection-status.js
@@ -12,5 +12,5 @@ import { get } from 'lodash';
  * @return {?Boolean}          Whether the connection status is being requested
  */
 export default function isRequestingJetpackConnectionStatus( state, siteId ) {
-	return get( state.jetpack.jetpackConnection.requests, [ siteId ], null );
+	return get( state.jetpack.connection.requests, [ siteId ], null );
 }

--- a/client/state/selectors/is-requesting-jetpack-jumpstart-status.js
+++ b/client/state/selectors/is-requesting-jetpack-jumpstart-status.js
@@ -12,5 +12,5 @@ import { get } from 'lodash';
  * @return {?Boolean}          Whether the Jumpstart status is being requested
  */
 export default function isRequestingJetpackJumpstartStatus( state, siteId ) {
-	return get( state.jetpack.jetpackJumpstart.requests, [ siteId, 'requesting' ], null );
+	return get( state.jetpack.jumpstart.requests, [ siteId, 'requesting' ], null );
 }

--- a/client/state/selectors/test/get-jetpack-connection-status.js
+++ b/client/state/selectors/test/get-jetpack-connection-status.js
@@ -13,7 +13,7 @@ describe( 'getJetpackConnectionStatus()', () => {
 	it( 'should return connection status for a known site', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackConnection: {
+					connection: {
 						items: ITEMS_FIXTURE
 					}
 				}
@@ -26,7 +26,7 @@ describe( 'getJetpackConnectionStatus()', () => {
 	it( 'should return null for an unknown site', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackConnection: {
+					connection: {
 						items: ITEMS_FIXTURE
 					}
 				}

--- a/client/state/selectors/test/get-jetpack-jumpstart-status.js
+++ b/client/state/selectors/test/get-jetpack-jumpstart-status.js
@@ -13,7 +13,7 @@ describe( 'getJetpackJumpstartStatus()', () => {
 	it( 'should return jumpstart status for a known site', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackJumpstart: {
+					jumpstart: {
 						items: ITEMS_FIXTURE
 					}
 				}
@@ -26,7 +26,7 @@ describe( 'getJetpackJumpstartStatus()', () => {
 	it( 'should return null for an unknown site', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackJumpstart: {
+					jumpstart: {
 						items: ITEMS_FIXTURE
 					}
 				}

--- a/client/state/selectors/test/get-jetpack-module.js
+++ b/client/state/selectors/test/get-jetpack-module.js
@@ -13,7 +13,7 @@ describe( 'getJetpackModule()', () => {
 	it( 'should return data for a specified module for a known site', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackModules: {
+					modules: {
 						items: {
 							123456: MODULE_DATA_FIXTURE
 						}
@@ -28,7 +28,7 @@ describe( 'getJetpackModule()', () => {
 	it( 'should return null for an unknown site', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackModules: {
+					modules: {
 						items: {
 							654321: MODULE_DATA_FIXTURE
 						}
@@ -43,7 +43,7 @@ describe( 'getJetpackModule()', () => {
 	it( 'should return null for an unknown module', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackModules: {
+					modules: {
 						items: {
 							123456: MODULE_DATA_FIXTURE
 						}

--- a/client/state/selectors/test/get-jetpack-modules.js
+++ b/client/state/selectors/test/get-jetpack-modules.js
@@ -13,7 +13,7 @@ describe( 'getJetpackModules()', () => {
 	it( 'should return data for all modules for a known site', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackModules: {
+					modules: {
 						items: {
 							123456: MODULE_DATA_FIXTURE
 						}
@@ -28,7 +28,7 @@ describe( 'getJetpackModules()', () => {
 	it( 'should return null for an unknown site', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackModules: {
+					modules: {
 						items: {
 							654321: MODULE_DATA_FIXTURE
 						}

--- a/client/state/selectors/test/is-activating-jetpack-jumpstart.js
+++ b/client/state/selectors/test/is-activating-jetpack-jumpstart.js
@@ -13,7 +13,7 @@ describe( 'isActivatingJetpackJumpstart()', () => {
 	it( 'should return true if jumpstart is currently being activated', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackJumpstart: {
+					jumpstart: {
 						requests: REQUESTS_FIXTURE
 					}
 				}
@@ -26,7 +26,7 @@ describe( 'isActivatingJetpackJumpstart()', () => {
 	it( 'should return false if jumpstart is currently not being activated', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackJumpstart: {
+					jumpstart: {
 						requests: REQUESTS_FIXTURE
 					}
 				}
@@ -39,7 +39,7 @@ describe( 'isActivatingJetpackJumpstart()', () => {
 	it( 'should return null if that site is not known yet', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackJumpstart: {
+					jumpstart: {
 						requests: REQUESTS_FIXTURE
 					}
 				}

--- a/client/state/selectors/test/is-activating-jetpack-module.js
+++ b/client/state/selectors/test/is-activating-jetpack-module.js
@@ -13,7 +13,7 @@ describe( 'isActivatingJetpackModule()', () => {
 	it( 'should return true if module is currently being activated', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackModules: {
+					modules: {
 						requests: REQUESTS_FIXTURE
 					}
 				}
@@ -26,7 +26,7 @@ describe( 'isActivatingJetpackModule()', () => {
 	it( 'should return false if module is currently not being activated', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackModules: {
+					modules: {
 						requests: REQUESTS_FIXTURE
 					}
 				}
@@ -39,7 +39,7 @@ describe( 'isActivatingJetpackModule()', () => {
 	it( 'should return null if that module is not known', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackModules: {
+					modules: {
 						requests: REQUESTS_FIXTURE
 					}
 				}

--- a/client/state/selectors/test/is-deactivating-jetpack-jumpstart.js
+++ b/client/state/selectors/test/is-deactivating-jetpack-jumpstart.js
@@ -13,7 +13,7 @@ describe( 'isDeactivatingJetpackJumpstart()', () => {
 	it( 'should return true if jumpstart is currently being deactivated', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackJumpstart: {
+					jumpstart: {
 						requests: REQUESTS_FIXTURE
 					}
 				}
@@ -26,7 +26,7 @@ describe( 'isDeactivatingJetpackJumpstart()', () => {
 	it( 'should return false if jumpstart is currently not being deactivated', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackJumpstart: {
+					jumpstart: {
 						requests: REQUESTS_FIXTURE
 					}
 				}
@@ -39,7 +39,7 @@ describe( 'isDeactivatingJetpackJumpstart()', () => {
 	it( 'should return null if that site is not known yet', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackJumpstart: {
+					jumpstart: {
 						requests: REQUESTS_FIXTURE
 					}
 				}

--- a/client/state/selectors/test/is-deactivating-jetpack-module.js
+++ b/client/state/selectors/test/is-deactivating-jetpack-module.js
@@ -13,7 +13,7 @@ describe( 'isDeactivatingJetpackModule()', () => {
 	it( 'should return true if module is currently being deactivated', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackModules: {
+					modules: {
 						requests: REQUESTS_FIXTURE
 					}
 				}
@@ -26,7 +26,7 @@ describe( 'isDeactivatingJetpackModule()', () => {
 	it( 'should return false if module is currently not being deactivated', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackModules: {
+					modules: {
 						requests: REQUESTS_FIXTURE
 					}
 				}
@@ -39,7 +39,7 @@ describe( 'isDeactivatingJetpackModule()', () => {
 	it( 'should return null if that module is not known', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackModules: {
+					modules: {
 						requests: REQUESTS_FIXTURE
 					}
 				}

--- a/client/state/selectors/test/is-fetching-jetpack-modules.js
+++ b/client/state/selectors/test/is-fetching-jetpack-modules.js
@@ -13,7 +13,7 @@ describe( 'isFetchingJetpackModules()', () => {
 	it( 'should return true if the list of modules is being fetched', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackModules: {
+					modules: {
 						requests: REQUESTS_FIXTURE
 					}
 				}
@@ -26,7 +26,7 @@ describe( 'isFetchingJetpackModules()', () => {
 	it( 'should return false if the list of modules is currently not being fetched', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackModules: {
+					modules: {
 						requests: REQUESTS_FIXTURE
 					}
 				}
@@ -39,7 +39,7 @@ describe( 'isFetchingJetpackModules()', () => {
 	it( 'should return null if that site is not known', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackModules: {
+					modules: {
 						requests: REQUESTS_FIXTURE
 					}
 				}

--- a/client/state/selectors/test/is-jetpack-module-active.js
+++ b/client/state/selectors/test/is-jetpack-module-active.js
@@ -13,7 +13,7 @@ describe( 'isJetpackModuleActive()', () => {
 	it( 'should return true if the module is currently active', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackModules: {
+					modules: {
 						items: MODULES_FIXTURE
 					}
 				}
@@ -26,7 +26,7 @@ describe( 'isJetpackModuleActive()', () => {
 	it( 'should return false if the module is currently not active', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackModules: {
+					modules: {
 						items: MODULES_FIXTURE
 					}
 				}
@@ -39,7 +39,7 @@ describe( 'isJetpackModuleActive()', () => {
 	it( 'should return null if that module is not known', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackModules: {
+					modules: {
 						items: MODULES_FIXTURE
 					}
 				}

--- a/client/state/selectors/test/is-jetpack-site-in-development-mode.js
+++ b/client/state/selectors/test/is-jetpack-site-in-development-mode.js
@@ -13,7 +13,7 @@ describe( 'isJetpackSiteInDevelopmentMode()', () => {
 	it( 'should return true if the site is in development mode', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackConnection: {
+					connection: {
 						items: ITEMS_FIXTURE
 					}
 				}
@@ -26,7 +26,7 @@ describe( 'isJetpackSiteInDevelopmentMode()', () => {
 	it( 'should return false if the site is not in development mode', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackConnection: {
+					connection: {
 						items: ITEMS_FIXTURE
 					}
 				}
@@ -39,7 +39,7 @@ describe( 'isJetpackSiteInDevelopmentMode()', () => {
 	it( 'should return null if the site is not known yet', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackConnection: {
+					connection: {
 						items: ITEMS_FIXTURE
 					}
 				}

--- a/client/state/selectors/test/is-jetpack-site-in-staging-mode.js
+++ b/client/state/selectors/test/is-jetpack-site-in-staging-mode.js
@@ -13,7 +13,7 @@ describe( 'isJetpackSiteInStagingMode()', () => {
 	it( 'should return true if the site is in staging mode', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackConnection: {
+					connection: {
 						items: ITEMS_FIXTURE
 					}
 				}
@@ -26,7 +26,7 @@ describe( 'isJetpackSiteInStagingMode()', () => {
 	it( 'should return false if the site is not in staging mode', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackConnection: {
+					connection: {
 						items: ITEMS_FIXTURE
 					}
 				}
@@ -39,7 +39,7 @@ describe( 'isJetpackSiteInStagingMode()', () => {
 	it( 'should return null if the site is not known yet', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackConnection: {
+					connection: {
 						items: ITEMS_FIXTURE
 					}
 				}

--- a/client/state/selectors/test/is-requesting-jetpack-connection-status.js
+++ b/client/state/selectors/test/is-requesting-jetpack-connection-status.js
@@ -13,7 +13,7 @@ describe( 'isRequestingJetpackConnectionStatus()', () => {
 	it( 'should return true if the connection status is being fetched', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackConnection: {
+					connection: {
 						requests: REQUESTS_FIXTURE
 					}
 				}
@@ -26,7 +26,7 @@ describe( 'isRequestingJetpackConnectionStatus()', () => {
 	it( 'should return false if the connection status is not being fetched', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackConnection: {
+					connection: {
 						requests: REQUESTS_FIXTURE
 					}
 				}
@@ -39,7 +39,7 @@ describe( 'isRequestingJetpackConnectionStatus()', () => {
 	it( 'should return null if the site is not known yet', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackConnection: {
+					connection: {
 						requests: REQUESTS_FIXTURE
 					}
 				}

--- a/client/state/selectors/test/is-requesting-jetpack-jumpstart-status.js
+++ b/client/state/selectors/test/is-requesting-jetpack-jumpstart-status.js
@@ -13,7 +13,7 @@ describe( 'isRequestingJetpackJumpstartStatus()', () => {
 	it( 'should return true if the jumpstart status is being fetched', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackJumpstart: {
+					jumpstart: {
 						requests: REQUESTS_FIXTURE
 					}
 				}
@@ -26,7 +26,7 @@ describe( 'isRequestingJetpackJumpstartStatus()', () => {
 	it( 'should return false if the jumpstart status is not being fetched', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackJumpstart: {
+					jumpstart: {
 						requests: REQUESTS_FIXTURE
 					}
 				}
@@ -39,7 +39,7 @@ describe( 'isRequestingJetpackJumpstartStatus()', () => {
 	it( 'should return null if the site is not known yet', () => {
 		const stateIn = {
 				jetpack: {
-					jetpackJumpstart: {
+					jumpstart: {
 						requests: REQUESTS_FIXTURE
 					}
 				}


### PR DESCRIPTION
After updating the Jetpack Settings Redux tree from `jetpackSettings` to `jetpack`, some of the subtrees retained the tautology in the names, as follows:

* `state.jetpack.jetpackConnection`
* `state.jetpack.jetpackJumpstart`
* `state.jetpack.jetpackModules`

This PR removes the `jetpack` prefix from the subtrees, which results in shorter Redux tree names for Jetpack Settings and a consistent naming pattern for those subtrees in general. So these trees are now updated to:

* `state.jetpack.connection`
* `state.jetpack.jumpstart`
* `state.jetpack.modules`

To test:

* Checkout this branch
* Verify all state tests still pass: `npm run test-client client/state/`