### PR TITLE
Themes: Change string context to comments

### DIFF
--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -714,7 +714,7 @@ export function confirmDelete( themeId, siteId ) {
 				'Delete %(themeName)s',
 				{ args: { themeName }, comment: 'Themes: theme delete dialog confirm button' }
 			),
-			i18n.translate( 'Back', { comment: 'Theme: theme delete dialog back button' } )
+			i18n.translate( 'Back', { context: 'go back (like the back button in a browser)' } )
 		);
 	};
 }

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -705,16 +705,16 @@ export function confirmDelete( themeId, siteId ) {
 		accept(
 			i18n.translate(
 				'Are you sure you want to delete %(themeName)s from %(siteTitle)s?',
-				{ args: { themeName, siteTitle }, context: 'Themes: theme delete confirmation dialog' }
+				{ args: { themeName, siteTitle }, comment: 'Themes: theme delete confirmation dialog' }
 			),
 			( accepted ) => {
 				accepted && dispatch( deleteTheme( themeId, siteId ) );
 			},
 			i18n.translate(
 				'Delete %(themeName)s',
-				{ args: { themeName }, context: 'Themes: theme delete dialog confirm button' }
+				{ args: { themeName }, comment: 'Themes: theme delete dialog confirm button' }
 			),
-			i18n.translate( 'Back', { context: 'Theme: theme delete dialog back button' } )
+			i18n.translate( 'Back', { comment: 'Theme: theme delete dialog back button' } )
 		);
 	};
 }


### PR DESCRIPTION
In line with https://translate.wordpress.com/2016/11/24/context-vs-comment/

And re-use translation for the Back button label by using existing context.