### PR TITLE
Export: ES6ify SiteSettingsExport and remove site prop

### DIFF
--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -91,7 +91,7 @@ export class SiteSettingsComponent extends Component {
 			case 'import':
 				return <ImportSettings site={ site } />;
 			case 'export':
-				return <ExportSettings site={ site } />;
+				return <ExportSettings />;
 			case 'guidedTransfer':
 				return <GuidedTransfer hostSlug={ hostSlug } />;
 		}

--- a/client/my-sites/site-settings/section-export.jsx
+++ b/client/my-sites/site-settings/section-export.jsx
@@ -1,30 +1,43 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
-import i18n from 'i18n-calypso';
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import EmptyContent from 'components/empty-content';
 import ExporterContainer from 'my-sites/exporter';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 
-export default class SiteSettingsExport extends Component {
-	render() {
-		if ( this.props.site.jetpack ) {
-			return (
-				<EmptyContent
-					illustration="/calypso/images/drake/drake-jetpack.svg"
-					title={ i18n.translate( 'Want to export your site?' ) }
-					line={ i18n.translate( `Visit your site's wp-admin for all your import and export needs.` ) }
-					action={ i18n.translate( 'Export %(siteTitle)s', { args: { siteTitle: this.props.site.title } } ) }
-					actionURL={ this.props.site.options.admin_url + 'export.php' }
-					actionTarget="_blank"
-				/>
-			);
-		}
-
-		return <ExporterContainer site={ this.props.site } />;
+const SiteSettingsExport = ( { isJetpack, site, translate } ) => {
+	if ( isJetpack ) {
+		return (
+			<EmptyContent
+				illustration="/calypso/images/drake/drake-jetpack.svg"
+				title={ translate( 'Want to export your site?' ) }
+				line={ translate( 'Visit your site\'s wp-admin for all your import and export needs.' ) }
+				action={ translate( 'Export %(siteTitle)s', { args: { siteTitle: site.title } } ) }
+				actionURL={ site.options.admin_url + 'export.php' }
+				actionTarget="_blank"
+			/>
+		);
 	}
-}
+
+	return <ExporterContainer />;
+};
+
+export default connect(
+	( state ) => {
+		const selectedSiteId = getSelectedSiteId( state );
+		const site = getSelectedSite( state );
+
+		return {
+			isJetpack: selectedSiteId && isJetpackSite( state, selectedSiteId ),
+			site,
+		};
+	}
+)( localize( SiteSettingsExport ) );


### PR DESCRIPTION
I've noticed that `SiteSettingsExport` no longer uses the `site` prop that gets passed to it. So we can safely remove it if we connect the component. I'm also using the opportunity to refactor that component to a stateless functional component.

To test:

* Checkout this branch
* Go to /settings/export/$site for a WP.com site and verify there are no regressions with the Export functionality
* Go to /settings/export/$site for a Jetpack site and verify there are no regressions with the error message that's displayed there.

/cc @jordwest @Tug for a quick review as they've worked on this one before.