### PR TITLE
Site Settings: Show error notice when icon fails to upload

### DIFF
--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -35,6 +35,7 @@ import { isItemBeingUploaded } from 'lib/media/utils';
 import { addQueryArgs } from 'lib/url';
 import { getImageEditorCrop, getImageEditorTransform } from 'state/ui/editor/image-editor/selectors';
 import { getSiteIconUrl, isSiteSupportingImageEditor } from 'state/selectors';
+import { errorNotice } from 'state/notices/actions';
 
 class SiteIconSetting extends Component {
 	static propTypes = {
@@ -85,7 +86,7 @@ class SiteIconSetting extends Component {
 	}
 
 	uploadSiteIcon( blob, fileName ) {
-		const { siteId } = this.props;
+		const { siteId, translate } = this.props;
 
 		// Upload media using a manually generated ID so that we can continue
 		// to reference it within this function
@@ -105,7 +106,13 @@ class SiteIconSetting extends Component {
 			}
 
 			MediaStore.off( 'change', checkUploadComplete );
-			this.saveSiteIconSetting( siteId, media );
+
+			// Check whether upload was successful
+			if ( media ) {
+				this.saveSiteIconSetting( siteId, media );
+			} else {
+				this.props.errorNotice( translate( 'An error occurred while uploading the file.' ) );
+			}
 		};
 
 		MediaStore.on( 'change', checkUploadComplete );
@@ -284,6 +291,7 @@ export default connect(
 		saveSiteSettings,
 		updateSiteIcon: ( siteId, mediaId ) => updateSiteSettings( siteId, { site_icon: mediaId } ),
 		removeSiteIcon: partialRight( saveSiteSettings, { site_icon: '' } ),
-		receiveMedia
+		receiveMedia,
+		errorNotice
 	}
 )( localize( SiteIconSetting ) );

--- a/client/state/media/actions.js
+++ b/client/state/media/actions.js
@@ -85,6 +85,10 @@ export function failMediaRequest( siteId, query ) {
  * Returns an action object used in signalling that media item(s) for the site
  * are to be deleted.
  *
+ * TODO: When network layer behavior is attached to this action type, remember
+ * to ignore media IDs for "transient" items (upload in progress) by validating
+ * numeric ID.
+ *
  * @param  {Number}         siteId   Site ID
  * @param  {(Array|Number)} mediaIds ID(s) of media to be deleted
  * @return {Object}                  Action object


### PR DESCRIPTION
This pull request seeks to improve the handling of a failed media upload in the site icon flow. Currently if a media fails to upload, we still try to receive it into Redux state and use it as the site icon, resulting in the icon resetting to the initial value with no indication aside from a console error. The changes here make it such that if the icon upload fails, a global error notice is shown to indicate the failure, and no attempt is made to use the media as the icon.

__Testing instructions:__

This was discovered in testing site icon usage in the desktop application. It may also be possible to test by toggling "Offline" in Chrome Network tab at point of clicking "Done" in Site Icon flow. If desktop app is available for testing, simply change into `calypso` directory and checkout this branch before starting desktop app with `make run`.

1. Navigate to [site settings](http://calypso.localhost:3000/settings)
2. Select a site
3. Click Change below Site Icon field
4. Select an image and click Continue
5. Crop image such that it is changed from the original image
6. Click Done
7. Note that if media fails to upload, an error notice is shown