### PR TITLE
Site Settings: Enable site icon management in all environments

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -47,6 +47,7 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,
+		"manage/site-settings/site-icon": true,
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -55,6 +55,7 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,
+		"manage/site-settings/site-icon": true,
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,

--- a/config/production.json
+++ b/config/production.json
@@ -51,6 +51,7 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,
+		"manage/site-settings/site-icon": true,
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -52,6 +52,7 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,
+		"manage/site-settings/site-icon": true,
 		"manage/seo": true,
 		"manage/stats": true,
 		"manage/themes": true,

--- a/config/test.json
+++ b/config/test.json
@@ -67,6 +67,7 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,
+		"manage/site-settings/site-icon": true,
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,


### PR DESCRIPTION
**WARNING: Do not merge until appropriate time.**

This pull request seeks to enable site icon management in all environments.

See milestone: https://github.com/Automattic/wp-calypso/milestone/119