### PR TITLE
Purchases: Cancel Message Says to Contact Support After Refund Window for Domain Registrations

### DIFF
--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -2,7 +2,6 @@
  * External Dependencies
  */
 import { connect } from 'react-redux';
-import moment from 'moment';
 import React from 'react';
 import i18n from 'i18n-calypso';
 
@@ -86,7 +85,7 @@ const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } )
 					)
 				];
 
-				if ( moment().isBefore( moment( includedDomainPurchase.subscribedDate ).add( refundPeriodInDays, 'days' ) ) ) {
+				if ( isRefundable( includedDomainPurchase ) ) {
 					text.push(
 						i18n.translate(
 							'To cancel the domain with the plan and ask for a full refund, ' +
@@ -173,11 +172,16 @@ const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } )
 
 			{ showSupportLink && (
 				<strong className="cancel-purchase__support-information">
-				{ i18n.translate( 'Have a question? {{contactLink}}Ask a Happiness Engineer!{{/contactLink}}', {
-					components: {
-						contactLink: <a href={ support.CALYPSO_CONTACT } />
-					}
-				} ) }
+				{
+					i18n.translate(
+						'Have a question? {{contactLink}}Ask a Happiness Engineer!{{/contactLink}}',
+						{
+							components: {
+								contactLink: <a href={ support.CALYPSO_CONTACT } />
+							}
+						}
+					)
+				}
 				</strong> )
 			}
 		</div>

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -86,7 +86,7 @@ const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } )
 					)
 				];
 
-				if ( moment().isBefore( moment( includedDomainPurchase.subscribedDate ).add( 2, 'days' ) ) ) {
+				if ( moment().isBefore( moment( includedDomainPurchase.subscribedDate ).add( refundPeriodInDays, 'days' ) ) ) {
 					text.push(
 						i18n.translate(
 							'To cancel the domain with the plan and ask for a full refund, ' +

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import { connect } from 'react-redux';
+import moment from 'moment';
 import React from 'react';
 import i18n from 'i18n-calypso';
 
@@ -74,20 +75,30 @@ const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } )
 					),
 					i18n.translate(
 						'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +
-						'minus %(domainCost)s for the domain. To cancel the domain with the plan and ask for a full ' +
-						'refund, please {{contactLink}}contact support{{/contactLink}}.',
+						'minus %(domainCost)s for the domain.',
 						{
 							args: {
 								domainCost: includedDomainPurchase.priceText,
 								planCost: purchase.priceText,
 								refundAmount: purchase.refundText
-							},
-							components: {
-								contactLink: <a href={ support.CALYPSO_CONTACT } />
 							}
 						}
 					)
 				];
+
+				if ( moment().isBefore( moment( includedDomainPurchase.subscribedDate ).add( 2, 'days' ) ) ) {
+					text.push(
+						i18n.translate(
+							'To cancel the domain with the plan and ask for a full refund, ' +
+							'please {{contactLink}}contact support{{/contactLink}}.',
+							{
+								components: {
+									contactLink: <a href={ support.CALYPSO_CONTACT } />
+								}
+							}
+						)
+					);
+				}
 
 				showSupportLink = false;
 			} else {
@@ -164,7 +175,7 @@ const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } )
 				<strong className="cancel-purchase__support-information">
 				{ i18n.translate( 'Have a question? {{contactLink}}Ask a Happiness Engineer!{{/contactLink}}', {
 					components: {
-						contactLink: <a href={ support.CALYPSO_CONTACT }/>
+						contactLink: <a href={ support.CALYPSO_CONTACT } />
 					}
 				} ) }
 				</strong> )


### PR DESCRIPTION
Hide the "contact support for full refund of domain registration" if outside of domain registration refund window.

Dependency: D4195-code

Test:
1. Create a new site, and buy a plan with domain
2. Go to `/me/purchases`
3. Click on plan you just bought
4. Click Cancel & Refund
5. Should see the message to contact support for full refund
<img width="508" alt="screen shot 2017-01-30 at 16 28 23" src="https://cloud.githubusercontent.com/assets/1103398/22429125/d9013a9e-e709-11e6-8005-6b85436849be.png">

1. You need a plan with domain that is within 30 days refund period, but the domain is outside the 2 day refund period.
2. Go to `/me/purchases`
3. Click on the plan
3. Click Cancel & Refund Plan
4. Shouldn't see the message about contacting support for domain registration refund
<img width="545" alt="screen shot 2017-01-30 at 16 28 36" src="https://cloud.githubusercontent.com/assets/1103398/22429122/d2f0b896-e709-11e6-91b9-994b91c42a45.png">

- [x] Code
- [x] Product