### PR TITLE
Revert "Framework: Replace click-outside by react-click-outside"

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -29,11 +29,11 @@
       "version": "0.8.2"
     },
     "ajv": {
-      "version": "4.11.2",
+      "version": "4.10.4",
       "dev": true
     },
     "ajv-keywords": {
-      "version": "1.5.1",
+      "version": "1.5.0",
       "dev": true
     },
     "align-text": {
@@ -623,6 +623,9 @@
       "version": "2.1.0",
       "dev": true
     },
+    "click-outside": {
+      "version": "2.0.1"
+    },
     "clipboard": {
       "version": "1.5.3"
     },
@@ -844,7 +847,7 @@
       "dev": true
     },
     "cssom": {
-      "version": "0.3.2",
+      "version": "0.3.1",
       "dev": true
     },
     "cssstyle": {
@@ -1146,7 +1149,7 @@
       "version": "1.3.0"
     },
     "es-abstract": {
-      "version": "1.7.0",
+      "version": "1.6.1",
       "dev": true
     },
     "es-to-primitive": {
@@ -2657,6 +2660,9 @@
     },
     "node-abi": {
       "version": "1.0.3"
+    },
+    "node-contains": {
+      "version": "1.0.0"
     },
     "node-dir": {
       "version": "0.1.16",
@@ -4195,7 +4201,7 @@
           "dev": true
         },
         "filesize": {
-          "version": "3.4.3",
+          "version": "3.4.1",
           "dev": true
         },
         "finalhandler": {
@@ -4235,18 +4241,8 @@
           "dev": true
         },
         "serve-static": {
-          "version": "1.11.2",
-          "dev": true,
-          "dependencies": {
-            "ms": {
-              "version": "0.7.2",
-              "dev": true
-            },
-            "send": {
-              "version": "0.14.2",
-              "dev": true
-            }
-          }
+          "version": "1.11.1",
+          "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
@@ -4317,7 +4313,7 @@
           "dev": true
         },
         "filesize": {
-          "version": "3.4.3",
+          "version": "3.4.1",
           "dev": true
         },
         "isarray": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "chalk": "1.0.0",
     "chrono-node": "^1.0.6",
     "classnames": "1.1.1",
+    "click-outside": "2.0.1",
     "clipboard": "1.5.3",
     "commander": "2.3.0",
     "component-closest": "0.1.4",


### PR DESCRIPTION
Reverts Automattic/wp-calypso#10905

This seems to break the "Publish" button in the master bar -- I'm not redirected to the post editor when selecting a site from the dropdown :confused: