### PR TITLE
Themes: Fix Current Theme Bar for Retired Themes

### DIFF
--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { map, pickBy } from 'lodash';
@@ -22,9 +22,9 @@ import QueryActiveTheme from 'components/data/query-active-theme';
  * Show current active theme for a site, with
  * related actions.
  */
-const CurrentTheme = React.createClass( {
+class CurrentTheme extends Component {
 
-	propTypes: {
+	static propTypes = {
 		options: PropTypes.objectOf( PropTypes.shape( {
 			label: PropTypes.string.isRequired,
 			icon: PropTypes.string.isRequired,
@@ -33,9 +33,9 @@ const CurrentTheme = React.createClass( {
 		siteId: PropTypes.number.isRequired,
 		// connected props
 		currentTheme: PropTypes.object
-	},
+	}
 
-	trackClick: trackClick.bind( null, 'current theme' ),
+	trackClick = ( event ) => trackClick( 'current theme', event )
 
 	render() {
 		const { currentTheme, siteId, translate } = this.props,
@@ -73,7 +73,7 @@ const CurrentTheme = React.createClass( {
 			</Card>
 		);
 	}
-} );
+}
 
 const ConnectedCurrentTheme = connectOptions( localize( CurrentTheme ) );
 

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -17,7 +17,6 @@ import { trackClick } from '../helpers';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getActiveTheme, getTheme } from 'state/themes/selectors';
 import QueryActiveTheme from 'components/data/query-active-theme';
-import QueryTheme from 'components/data/query-theme';
 
 /**
  * Show current active theme for a site, with
@@ -39,7 +38,7 @@ const CurrentTheme = React.createClass( {
 	trackClick: trackClick.bind( null, 'current theme' ),
 
 	render() {
-		const { currentTheme, currentThemeId, siteId, siteIdOrWpcom, translate } = this.props,
+		const { currentTheme, siteId, translate } = this.props,
 			placeholderText = <span className="current-theme__placeholder">loading...</span>,
 			text = ( currentTheme && currentTheme.name ) ? currentTheme.name : placeholderText;
 
@@ -50,7 +49,6 @@ const CurrentTheme = React.createClass( {
 		return (
 			<Card className="current-theme">
 				{ siteId && <QueryActiveTheme siteId={ siteId } /> }
-				{ currentThemeId && <QueryTheme siteId={ siteIdOrWpcom } themeId={ currentThemeId } /> }
 				<div className="current-theme__current">
 					<span className="current-theme__label">
 						{ translate( 'Current Theme' ) }
@@ -79,10 +77,8 @@ const CurrentTheme = React.createClass( {
 
 const ConnectedCurrentTheme = connectOptions( localize( CurrentTheme ) );
 
-const CurrentThemeWithOptions = ( { siteId, currentTheme, currentThemeId, siteIdOrWpcom } ) => (
+const CurrentThemeWithOptions = ( { siteId, currentTheme } ) => (
 	<ConnectedCurrentTheme currentTheme={ currentTheme }
-		currentThemeId={ currentThemeId }
-		siteIdOrWpcom={ siteIdOrWpcom }
 		siteId={ siteId }
 		options={ [
 			'customize',
@@ -97,9 +93,7 @@ export default connect(
 		const currentThemeId = getActiveTheme( state, siteId );
 		const siteIdOrWpcom = isJetpackSite( state, siteId ) ? siteId : 'wpcom';
 		return {
-			currentThemeId,
 			currentTheme: getTheme( state, siteIdOrWpcom, currentThemeId ),
-			siteIdOrWpcom
 		};
 	}
 )( CurrentThemeWithOptions );

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -292,9 +292,7 @@ export function requestActiveTheme( siteId ) {
 				dispatch( {
 					type: ACTIVE_THEME_REQUEST_SUCCESS,
 					siteId,
-					themeId: theme.id,
-					themeName: theme.name,
-					themeCost: theme.cost
+					theme
 				} );
 			} ).catch( error => {
 				dispatch( {

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -53,9 +53,9 @@ export const activeThemes = createReducer( {}, {
 		...state,
 		[ siteId ]: getThemeIdFromStylesheet( themeStylesheet )
 	} ),
-	[ ACTIVE_THEME_REQUEST_SUCCESS ]: ( state, { siteId, themeId } ) => ( {
+	[ ACTIVE_THEME_REQUEST_SUCCESS ]: ( state, { siteId, theme } ) => ( {
 		...state,
-		[ siteId ]: themeId
+		[ siteId ]: theme.id
 	} ) },
 	activeThemesSchema
  );

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -626,13 +626,7 @@ describe( 'actions', () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: ACTIVE_THEME_REQUEST_SUCCESS,
 					siteId: 2211667,
-					themeId: 'rebalance',
-					themeName: 'Rebalance',
-					themeCost: {
-						currency: 'USD',
-						number: 0,
-						display: ''
-					}
+					theme: successResponse
 				} );
 			} );
 		} );

--- a/client/state/themes/test/reducer.js
+++ b/client/state/themes/test/reducer.js
@@ -670,12 +670,14 @@ describe( 'reducer', () => {
 			const state = activeThemes( deepFreeze( {} ), {
 				type: ACTIVE_THEME_REQUEST_SUCCESS,
 				siteId: 2211667,
-				themeId: 'rebalance',
-				themeName: 'Rebalance',
-				themeCost: {
-					currency: 'USD',
-					number: 0,
-					display: ''
+				theme: {
+					id: 'rebalance',
+					name: 'Rebalance',
+					cost: {
+						currency: 'USD',
+						number: 0,
+						display: ''
+					}
 				}
 			} );
 
@@ -687,12 +689,14 @@ describe( 'reducer', () => {
 			const state = activeThemes( deepFreeze( { 2211667: 'rebalance' } ), {
 				type: ACTIVE_THEME_REQUEST_SUCCESS,
 				siteId: 2211667,
-				themeId: 'twentysixteen',
-				themeName: 'Twentysixteen',
-				themeCost: {
-					currency: 'USD',
-					number: 0,
-					display: ''
+				theme: {
+					id: 'twentysixteen',
+					name: 'Twenty Sixteen',
+					cost: {
+						currency: 'USD',
+						number: 0,
+						display: ''
+					}
 				}
 			} );
 


### PR DESCRIPTION
This PR:
* Changes the  `ACTIVE_THEME_REQUEST_SUCCESS` action to pass an entire theme object instead of just select fields.
* Changes the `requestActiveTheme()` action to use `receiveTheme()` to store that theme object in our Redux tree. Unfortunately, this requires us to use `getState()` in order to find out whether we're dealing with a Jetpack site (in which case the theme object should be stored in the corresponding subtree) or with a WPCOM one (in which case the theme object should go to the generic `wpcom` subtree).
* Removes the `<QueryTheme />` component from `<CurrentTheme />` since it's no longer needed -- the theme object is now fetched by `<QueryActiveTheme />`.
* Turns `<CurrentTheme />` into an ES6 class.

To test:
* Verify that the current theme bar still works for WPCOM and Jetpack sites if the current theme isn't retired.
  * Check that clicking on the buttons triggers corresponding `[Action: Current Theme Info [object Object]]` events (or `Customize`, or `Support` instead of `Info`, respectively).
* Verify that it also works with a retired theme:
  * In order to activate a retired theme, go to your test site's `wp-admin/wp-admin/themes.php?search=Ecto`. Activate the Ecto theme.
  * In Calypso, check the site's Current Theme Bar. Verify that the theme name is displayed, and that the Customize and Info links work. (Note that the theme sheet itself doesn't work yet -- that's for another PR.)

Fixes #10760. (But we should file an issue for theme sheets for retired themes -- see convo in #10760 for a spec.)