### PR TITLE
Stats: Enable Summary Views for Search Terms

### DIFF
--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -78,7 +78,7 @@ class StatsModule extends Component {
 
 	isAllTimeList() {
 		const { summary, statType } = this.props;
-		return summary && includes( [ 'statsCountryViews', 'statsTopPosts' ], statType );
+		return summary && includes( [ 'statsCountryViews', 'statsTopPosts', 'statsSearchTerms' ], statType );
 	}
 
 	render() {

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -203,7 +203,7 @@ const StatsSummary = React.createClass( {
 					path="searchterms"
 					moduleStrings={ StatsStrings.search }
 					period={ this.props.period }
-					query={ query }
+					query={ merge( {}, statsQueryOptions, query ) }
 					statType="statsSearchTerms"
 					summary />;
 				break;

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1204,6 +1204,49 @@ describe( 'utils', () => {
 					}
 				] );
 			} );
+
+			it( 'should return an a properly parsed summarized data array', () => {
+				const parsedData = normalizers.statsSearchTerms( {
+					date: '2017-01-12',
+					summary: {
+						encrypted_search_terms: 400,
+						search_terms: [
+							{
+								term: 'chicken',
+								views: 200
+							},
+							{
+								term: 'ribs',
+								views: 100
+							}
+						]
+					}
+				}, {
+					period: 'day',
+					date: '2017-01-12',
+					summarize: 1,
+					num: 90
+				} );
+
+				expect( parsedData ).to.eql( [
+					{
+						className: 'user-selectable',
+						label: 'chicken',
+						value: 200
+					},
+					{
+						className: 'user-selectable',
+						label: 'ribs',
+						value: 100
+					},
+					{
+						label: 'Unknown Search Terms',
+						labelIcon: 'external',
+						link: 'http://en.support.wordpress.com/stats/#search-engine-terms',
+						value: 400
+					}
+				] );
+			} );
 		} );
 
 		describe( 'statsVisits()', () => {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -599,12 +599,9 @@ export const normalizers = {
 		}
 
 		const { startOf } = rangeOfPeriod( query.period, query.date );
-		const dataPath = query.summarize ? [ 'summary', 'search_terms' ] : [ 'days', startOf, 'search_terms' ];
-
-		const searchTerms = get( data, dataPath, [] );
-		dataPath.pop();
-		dataPath.push( 'encrypted_search_terms' );
-		const encryptedSearchTerms = get( data, dataPath, false );
+		const dataPath = query.summarize ? [ 'summary' ] : [ 'days', startOf ];
+		const searchTerms = get( data, dataPath.concat( [ 'search_terms' ] ), [] );
+		const encryptedSearchTerms = get( data, dataPath.concat( [ 'encrypted_search_terms' ] ), false );
 
 		const result = searchTerms.map( ( day ) => {
 			return {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -599,8 +599,12 @@ export const normalizers = {
 		}
 
 		const { startOf } = rangeOfPeriod( query.period, query.date );
-		const searchTerms = get( data, [ 'days', startOf, 'search_terms' ], [] );
-		const encryptedSearchTerms = get( data, [ 'days', startOf, 'encrypted_search_terms' ], false );
+		const dataPath = query.summarize ? [ 'summary', 'search_terms' ] : [ 'days', startOf, 'search_terms' ];
+
+		const searchTerms = get( data, dataPath, [] );
+		dataPath.pop();
+		dataPath.push( 'encrypted_search_terms' );
+		const encryptedSearchTerms = get( data, dataPath, false );
 
 		const result = searchTerms.map( ( day ) => {
 			return {


### PR DESCRIPTION
This branch activates Summary Views for Search Terms.

![stats_ _trout_bummin_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/22443308/4d2c6162-e6f3-11e6-9be1-cb3236116ae1.png)

__To Test__
- Visite a site stats page
- Click the Search Terms header
- Use the summary page links at top - verify the data is the same as seen in [Atlas Stats](https://wordpress.com/my-stats/?view=searchterms&summarize&numdays=-1) for the same time periods.
- Use the download csv button and verify data downloads as expected