### PR TITLE
Sparkline: Add Hourly High Tooltip

### DIFF
--- a/client/blocks/stats-sparkline/index.jsx
+++ b/client/blocks/stats-sparkline/index.jsx
@@ -3,21 +3,37 @@
  */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { get, mapValues, sortBy } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import QuerySiteStats from 'components/data/query-site-stats';
 import { isJetpackSite, getSiteOption } from 'state/sites/selectors';
+import { getSiteStatsNormalizedData } from 'state/stats/lists/selectors';
 
-const StatsSparkline = ( { isJetpack, siteUrl, className, siteId } ) => {
+const StatsSparkline = ( { isJetpack, siteUrl, className, siteId, highestViews, translate } ) => {
 	if ( ! siteId || ! siteUrl || isJetpack ) {
 		return null;
 	}
 
+	const title = highestViews
+		? translate(
+			'Highest hourly views %(highestViews)s',
+			{
+				args: { highestViews }
+			}
+		) : null;
+
 	return (
-		<img
-			className={ className }
-			src={ `${ siteUrl }/wp-includes/charts/admin-bar-hours-scale-2x.php?masterbar=1&s=${ siteId }` } />
+		<span>
+			{ siteId && <QuerySiteStats siteId={ siteId } statType="statsInsights" /> }
+			<img
+				className={ className }
+				title={ title }
+				src={ `${ siteUrl }/wp-includes/charts/admin-bar-hours-scale-2x.php?masterbar=1&s=${ siteId }` } />
+		</span>
 	);
 };
 
@@ -31,10 +47,12 @@ StatsSparkline.propTypes = {
 export default connect(
 	( state, ownProps ) => {
 		const { siteId } = ownProps;
-
+		const hourlyData = get( getSiteStatsNormalizedData( state, siteId, 'statsInsights' ), 'hourlyViews', [] );
+		const hourlyViews = sortBy( mapValues( hourlyData ) );
 		return {
 			isJetpack: isJetpackSite( state, siteId ),
-			siteUrl: getSiteOption( state, siteId, 'unmapped_url' )
+			siteUrl: getSiteOption( state, siteId, 'unmapped_url' ),
+			highestViews: hourlyViews.length ? hourlyViews[ hourlyViews.length - 1 ] : 0
 		};
 	}
-)( StatsSparkline );
+)( localize( StatsSparkline ) );

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -151,16 +151,18 @@ export class MySitesSidebar extends Component {
 		}
 
 		const siteId = this.isSingle() ? site.slug : null;
-
+		const statsLink = getStatsPathForTab( 'day', siteId );
 		return (
 			<SidebarItem
 				tipTarget="menus"
 				label={ this.props.translate( 'Stats' ) }
 				className={ this.itemLinkClass( '/stats', 'stats' ) }
-				link={ getStatsPathForTab( 'day', siteId ) }
+				link={ statsLink }
 				onNavigate={ this.onNavigate }
 				icon="stats-alt">
-				<StatsSparkline className="sidebar__sparkline" siteId={ get( site, 'ID' ) } />
+				<a href={ statsLink }>
+					<StatsSparkline className="sidebar__sparkline" siteId={ get( site, 'ID' ) } />
+				</a>
 			</SidebarItem>
 		);
 	}

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -675,14 +675,16 @@ describe( 'utils', () => {
 					highest_hour: 11,
 					highest_day_percent: 10,
 					highest_day_of_week: 6,
-					highest_hour_percent: 5
+					highest_hour_percent: 5,
+					hourly_views: []
 				} );
 
 				expect( stats ).to.eql( {
 					day: 'Sunday',
 					hour: '11:00 AM',
 					hourPercent: 5,
-					percent: 10
+					percent: 10,
+					hourlyViews: []
 				} );
 			} );
 		} );

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -116,7 +116,8 @@ export const normalizers = {
 			highest_hour,
 			highest_day_percent,
 			highest_day_of_week,
-			highest_hour_percent
+			highest_hour_percent,
+			hourly_views,
 		} = data;
 
 		// Adjust Day of Week from 0 = Monday to 0 = Sunday (for Moment)
@@ -129,7 +130,8 @@ export const normalizers = {
 			day: moment().day( dayOfWeek ).format( 'dddd' ),
 			percent: Math.round( highest_day_percent ),
 			hour: moment().hour( highest_hour ).startOf( 'hour' ).format( 'LT' ),
-			hourPercent: Math.round( highest_hour_percent )
+			hourPercent: Math.round( highest_hour_percent ),
+			hourlyViews: hourly_views,
 		};
 	},
 


### PR DESCRIPTION
The old version of the Sparkline graphic that was shown in the masterbar displayed a number indicating the highest views per hour from the dataset shown [example](https://en.blog.wordpress.com/wp-includes/charts/admin-bar-hours-scale-2x.php?).  This label added context to the small chart, and users have complained that without this number being shown, the chart does not provide as much value.

This branch adds a simple `title` attribute to the sparkline image that contains the highest number of hourly views ( when an hour exists over 0 views ).  I originally started to use `<Tooltip />` for this, but the sparkline is also shown in the wpcom-generated 'Calypso Sidebar' so we do not have access to the `<Tooltip />` component there ( or react at all ).  As such, I opted for the _built-in_ tooltip.

![plans_ _fly_fishers_place_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/22445874/7b1f43b8-e6fe-11e6-98ef-d98c142ac132.png)

__To Test__
- Open calypso and navigate to a non-stats page
- Hover over the sparkline

__Other Interesting Things__
We currently are not linking the sparkline image.  So - at the very minimum we should probably link this to the stats page... but we now have access to the last 48 hours of visists data via the API, so maybe we should consider building a "full size" visualization that the sparkline links to on the Insights page.