### PR TITLE
Jetpack Settings: Add markdown settings to filterSettingsByActiveModules

### DIFF
--- a/client/state/jetpack/settings/utils.js
+++ b/client/state/jetpack/settings/utils.js
@@ -72,7 +72,10 @@ export const filterSettingsByActiveModules = ( settings ) => {
 			'social_notifications_like',
 			'social_notifications_reblog',
 			'social_notifications_subscribe',
-		]
+		],
+		markdown: [
+			'wpcom_publish_comments_with_markdown',
+		],
 	};
 	let filteredSettings = { ...settings };
 


### PR DESCRIPTION
As @youknowriad discovered while manually testing #11049, every time one attempts to save their Jetpack site discussion settings with the Markdown module disabled, they get an error that the module is disabled. We already have a utility to filter out settings for inactive modules, however the markdown settings were missing from it. This PR adds these missing settings.

To test:

* Checkout this branch.
* Select one of your Jetpack sites and disable the Markdown module.
* Go to `/settings/discussion/$site`.
* Change any setting and click the "Save Changes" button.
* Verify the site settings are saved correctly.