### PR TITLE
Billing: Introduce a better receipt page placeholder

### DIFF
--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -73,14 +73,16 @@ const BillingReceipt = React.createClass( {
 	},
 
 	renderPlaceholder() {
-		const { translate } = this.props;
-
 		return (
-			<Card compact className="billing-history__receipt-card">
-				<div className="billing-history__receipt">
-					<div className="billing-history__receipt-loading">
-						{ translate( 'Loading…' ) }
-					</div>
+			<Card compact className="billing-history__receipt-card is-placeholder">
+				<div className="billing-history__app-overview">
+					<div className="billing-history__placeholder-image" />
+					<div className="billing-history__placeholder-title" />
+				</div>
+
+				<div className="billing-history__receipt-links">
+					<div className="billing-history__placeholder-link" />
+					<div className="billing-history__placeholder-link" />
 				</div>
 			</Card>
 		);

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -465,11 +465,13 @@
 		}
 
 		.billing-history__placeholder-image {
+			flex-shrink: 0;
 			width: 65px;
 			margin-right: 26px;
 		}
 
 		.billing-history__placeholder-title {
+			flex-shrink: 1;
 			width: 100%;
 		}
 	}

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -453,6 +453,41 @@
 	margin: 0;
 }
 
+.billing-history__receipt-card.is-placeholder {
+	.billing-history__app-overview {
+		display: flex;
+		margin-bottom: 16px;
+
+		.billing-history__placeholder-image,
+		.billing-history__placeholder-title {
+			@include placeholder();
+			height: 65px;
+		}
+
+		.billing-history__placeholder-image {
+			width: 65px;
+			margin-right: 26px;
+		}
+
+		.billing-history__placeholder-title {
+			width: 100%;
+		}
+	}
+
+	.billing-history__receipt-links {
+		padding: 0 40px 10px;
+
+		.billing-history__placeholder-link {
+			@include placeholder();
+			margin-bottom: 12px;
+
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
+	}
+}
+
 @media print {
 	.is-section-billing {
 		#secondary,


### PR DESCRIPTION
### Purpose

This PR updates the `Loading...` placeholder of the receipt page to the pulsating one that we use throughout Calypso. This is one of the last items of the billing reduxification effort - #10554.

### Preview

**The previous placeholder**
![](https://cldup.com/vsgyQh11NR.png)

**The new pulsating placeholder**
![](https://cldup.com/HAzX1htirE.png)

**A regular receipt page (for design reference)**
![](https://cldup.com/B8-uIK3tpE.png)

### To test

* Checkout this branch
* Load `/me/purchases/billing/$receiptId`, where `$receiptId` is a receipt page, or navigate to Me > Purchases > Billing History and click on a transaction.
* Clear your Redux state
* Verify the new placeholder appears as on the attached preview.

/cc
@gwwar for code review
@folletto for design review