### PR TITLE
Add/upload upgrade nudge

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -62,6 +62,7 @@ export const FEATURE_NO_BRANDING = 'no-wp-branding';
 export const FEATURE_ADVANCED_SEO = 'advanced-seo';
 export const FEATURE_BUSINESS_ONBOARDING = 'business-onboarding';
 export const FEATURE_UPLOAD_PLUGINS = 'upload-plugins';
+export const FEATURE_UPLOAD_THEMES = 'upload-themes';
 
 // jetpack features constants
 export const FEATURE_STANDARD_SECURITY_TOOLS = 'standard-security-tools';
@@ -202,6 +203,7 @@ export const PLANS_LIST = {
 			FEATURE_BUSINESS_ONBOARDING,
 			isEnabled( 'manage/advanced-seo' ) && FEATURE_ADVANCED_SEO,
 			isEnabled( 'automated-transfer' ) && FEATURE_UPLOAD_PLUGINS,
+			isEnabled( 'automated-transfer' ) && FEATURE_UPLOAD_THEMES,
 			FEATURE_GOOGLE_ANALYTICS,
 			FEATURE_NO_BRANDING
 		] ),
@@ -649,6 +651,12 @@ export const FEATURES_LIST = {
 		getSlug: () => FEATURE_UPLOAD_PLUGINS,
 		getTitle: () => i18n.translate( 'Install Plugins' ),
 		getDescription: () => i18n.translate( 'Install custom plugins on your site.' )
+	},
+
+	[ FEATURE_UPLOAD_THEMES ]: {
+		getSlug: () => FEATURE_UPLOAD_THEMES,
+		getTitle: () => i18n.translate( 'Upload themes' ),
+		getDescription: () => i18n.translate( 'Upload custom themes on your site.' )
 	},
 
 	[ FEATURE_WORDADS_INSTANT ]: {

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -276,7 +276,8 @@ class Upload extends React.Component {
 				{ ! isBusiness && ! isJetpack && <Banner
 					feature={ FEATURE_UPLOAD_THEMES }
 					plan={ PLAN_BUSINESS }
-					title={ translate( 'Upgrade to the Business plan to upload themes.' ) } /> }
+					title={ translate( 'To upload themes, upgrade to Business Plan' ) }
+					description={ translate( 'Unlimited themes, advanced customization, no ads, live chat support, and more!' ) } /> }
 				{ upgradeJetpack && <JetpackManageErrorPage
 					template="updateJetpack"
 					siteId={ siteId }

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -39,12 +39,12 @@ import {
 } from 'state/themes/upload-theme/selectors';
 import { getTheme } from 'state/themes/selectors';
 import { connectOptions } from 'my-sites/themes/theme-options';
-import UpgradeNudge from 'my-sites/upgrade-nudge';
 import EligibilityWarnings from 'blocks/eligibility-warnings';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import { getBackPath } from 'state/themes/themes-ui/selectors';
 import { hasFeature } from 'state/sites/plans/selectors';
-import { FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
+import Banner from 'components/banner';
+import { PLAN_BUSINESS, FEATURE_UNLIMITED_PREMIUM_THEMES, FEATURE_UPLOAD_THEMES } from 'lib/plans/constants';
 
 const debug = debugFactory( 'calypso:themes:theme-upload' );
 
@@ -273,11 +273,10 @@ class Upload extends React.Component {
 					site={ selectedSite }
 					source="upload" />
 				<HeaderCake backHref={ backPath }>{ translate( 'Upload theme' ) }</HeaderCake>
-				{ ! isBusiness && ! isJetpack && <UpgradeNudge
-					feature={ FEATURE_UNLIMITED_PREMIUM_THEMES }
-					title={ translate( 'Upgrade to the Business plan to upload themes.' ) }
-					message={ translate( 'Upgrade to remove the footer credit, add Google Analytics and more' ) }
-					icon="customize" /> }
+				{ ! isBusiness && ! isJetpack && <Banner
+					feature={ FEATURE_UPLOAD_THEMES }
+					plan={ PLAN_BUSINESS }
+					title={ translate( 'Upgrade to the Business plan to upload themes.' ) } /> }
 				{ upgradeJetpack && <JetpackManageErrorPage
 					template="updateJetpack"
 					siteId={ siteId }

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -38,7 +38,6 @@ import {
 } from 'state/themes/upload-theme/selectors';
 import { getTheme } from 'state/themes/selectors';
 import { connectOptions } from 'my-sites/themes/theme-options';
-import QueryEligibility from 'components/data/query-atat-eligibility';
 import EligibilityWarnings from 'blocks/eligibility-warnings';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import { getBackPath } from 'state/themes/themes-ui/selectors';
@@ -258,7 +257,6 @@ class Upload extends React.Component {
 
 		return (
 			<Main>
-				<QueryEligibility siteId={ siteId } />
 				<QueryActiveTheme siteId={ siteId } />
 				{ themeId && complete && <QueryTheme siteId={ siteId } themeId={ themeId } /> }
 				<ThanksModal

--- a/client/my-sites/themes/theme-upload/style.scss
+++ b/client/my-sites/themes/theme-upload/style.scss
@@ -49,3 +49,9 @@
 	color: $gray;
 }
 
+.theme-upload {
+	&.is-disabled {
+		opacity: 0.2;
+		pointer-events: none;
+	}
+}


### PR DESCRIPTION
### Info
This PR adds upgrade nude to theme upload page for sites that are not on Business plan.
We are targeting following logic:
- The banner should always be shown if site plan is ! Business
- If the eligibility check pass → show disabled upload form
- If the eligibility check does NOT pass → show eligibility form with buttons disabled

Site is Business and Eligibility shows warnings:
![image](https://cloud.githubusercontent.com/assets/17271089/22461949/b00aa0a6-e7ab-11e6-87dd-1f002600cca5.png)

Site is ! Business and Eligibility shows warnings/errors:
![image](https://cloud.githubusercontent.com/assets/17271089/22462236/ca1e64a4-e7ac-11e6-8107-faba3d3fc123.png)

Last example is ! Business and Eligibility pass and is artificial for now as Eligibility component will be shown just for _no Business error_
![image](https://cloud.githubusercontent.com/assets/17271089/22462403/7358bbfa-e7ad-11e6-9468-9f665f735886.png)

Removal of Business check from eligibility should be handled in separate PR. 

### More
The` QueryEligibility` was removed from upload because it is now used directly in `EligibilityWarnings` component. 

### Testing

Go to `/upload` on various Business and ! Business sites, and verify presence of Upgrade nudge. 

### TODO

- [ ] Verify that the wording on Upgrade Nudge is correct
- [ ] Who/where to handle EligibilityWarnings without Business check
- [ ] Verify that `hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES )` is correct check here