### PR TITLE
Editor: allow starting the editor in HTML mode on mobile

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -80,7 +80,6 @@ import wpEmojiPlugin from './plugins/wpemoji/plugin';
  */
 const user = require( 'lib/user' )(),
 	i18n = require( './i18n' ),
-	viewport = require( 'lib/viewport' ),
 	config = require( 'config' );
 import { decodeEntities, wpautop, removep } from 'lib/formatting';
 
@@ -231,10 +230,7 @@ module.exports = React.createClass( {
 
 			this.bindEditorEvents();
 			editor.on( 'SetTextAreaContent', ( event ) => this.setTextAreaContent( event.content ) );
-
-			if ( ! viewport.isMobile() ) {
-				editor.once( 'PostRender', this.toggleEditor.bind( this, { autofocus: ! this.props.isNew } ) );
-			}
+			editor.once( 'PostRender', this.toggleEditor.bind( this, { autofocus: ! this.props.isNew } ) );
 		}.bind( this );
 
 		this.localize();

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -80,6 +80,7 @@ import wpEmojiPlugin from './plugins/wpemoji/plugin';
  */
 const user = require( 'lib/user' )(),
 	i18n = require( './i18n' ),
+	viewport = require( 'lib/viewport' ),
 	config = require( 'config' );
 import { decodeEntities, wpautop, removep } from 'lib/formatting';
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/11071

Removed the check that prevented the editor to start in HTML mode on mobile.
I assume there was a reason for that check but I cannot figure what.
Point is: this doesn't play well with the recently introduced [HTML toolbar](https://github.com/Automattic/wp-calypso/pull/10497), since it renders the Visual toolbar (and, not shown in the screenshot, the editor in Visual mode), no matter what:

![screenshot 2017-01-31 11 06 04](https://cloud.githubusercontent.com/assets/2070010/22460488/58337b60-e7a5-11e6-9999-3c3dd1eef00b.png)

Either way, in my tests I couldn't find any issues related to this.