### PR TITLE
Editor: fix dialogs overflow on small screens

### DIFF
--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -66,17 +66,22 @@
 	color: lighten( $gray, 30% );
 }
 
-.editor-html-toolbar__dialog .dialog__content {
-	min-width: 40vw;
-}
-.editor-html-toolbar__dialog .post-selector {
-	margin-bottom: 16px;
-}
-@include breakpoint( "<660px" ) {
-	.editor-html-toolbar__dialog {
-		width: 90%;
+.editor-html-toolbar__dialog {
+	max-height: 90%;
+	overflow-y: auto;
+
+	.dialog__content {
+		min-width: 40vw;
 	}
-	.editor-html-toolbar__dialog .dialog__content {
-		min-width: none;
+	.post-selector {
+		margin-bottom: 16px;
+	}
+
+	@include breakpoint( "<660px" ) {
+		width: 90%;
+
+		.dialog__content {
+			min-width: none;
+		}
 	}
 }


### PR DESCRIPTION
Fixed an issue where HTML toolbar dialogs couldn't be scrolled if their content was longer than the screen height.

| Before | After |
| --- | --- |
| ![jan-31-2017 12-54-59](https://cloud.githubusercontent.com/assets/2070010/22463888/814dc0e6-e7b4-11e6-813f-31aa78d86aee.gif) | ![jan-31-2017 12-49-52](https://cloud.githubusercontent.com/assets/2070010/22463788/f58ac806-e7b3-11e6-9957-ab0837d608dc.gif) |

