### PR TITLE
Domains: Display Settings item in sidebar for domain-only sites

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -717,7 +717,18 @@ export class MySitesSidebar extends Component {
 
 	renderSidebarMenus() {
 		if ( this.props.isDomainOnly ) {
-			return null;
+			return (
+				<SidebarMenu>
+					<ul>
+						<SidebarItem
+							className={ this.itemLinkClass( '/domains', 'settings' ) }
+							icon="cog"
+							label={ this.props.translate( 'Settings' ) }
+							link={ '/domains/manage' + this.siteSuffix() }
+							onNavigate={ this.onNavigate } />
+					</ul>
+				</SidebarMenu>
+			);
 		}
 
 		const publish = !! this.publish(),

--- a/server/bundler/css-hot-reload.js
+++ b/server/bundler/css-hot-reload.js
@@ -35,7 +35,7 @@ function setup( io ) {
 			return;
 		}
 
-		io.of( '/css-hot-reload' ).emit( 'css-hot-reload', 
+		io.of( '/css-hot-reload' ).emit( 'css-hot-reload',
 			{ status: 'building' } );
 
 		debug( 'spawning %o', 'make build-css --jobs ' + cores );
@@ -82,17 +82,17 @@ function setup( io ) {
 			changedFiles = updateChangedCssFiles();
 			if ( 0 !== changedFiles.length ) {
 				debug( chalk.green( 'css reload' ) );
-				io.of( '/css-hot-reload' ).emit( 'css-hot-reload', 
+				io.of( '/css-hot-reload' ).emit( 'css-hot-reload',
 					{ status: 'reload', changedFiles: changedFiles } );
 			} else {
 				debug( chalk.green( 'css up to date' ) );
-				io.of( '/css-hot-reload' ).emit( 'css-hot-reload', 
+				io.of( '/css-hot-reload' ).emit( 'css-hot-reload',
 					{ status: 'up-to-date' } );
 			}
 		} else {
 			// 'make build-css' failed
 			debug( chalk.red( 'css build failed' ) );
-			io.of( '/css-hot-reload' ).emit( 'css-hot-reload', 
+			io.of( '/css-hot-reload' ).emit( 'css-hot-reload',
 				{ status: 'build-failed', error: errors } );
 		}
 	}
@@ -115,24 +115,24 @@ function setup( io ) {
 	}
 
 	// Initialize publicCssFiles
-	
+
 	fs.readdirSync( PUBLIC_DIR ).forEach( function( file ) {
 		if ( '.css' === file.slice( -4 ) ) {
 			var fullPath = path.join( PUBLIC_DIR, file );
 			publicCssFiles[ fullPath ] = md5File.sync( fullPath );
 		}
 	} );
-	
+
 	// Watch .scss files
 
-	var watcher = chokidar.watch( SCSS_PATHS, { 
-		ignored: /^.*\.(js[x]?|md|json)$/,
+	var watcher = chokidar.watch( SCSS_PATHS, {
+		ignored: /^.*\.(js[x]?|md|json|unison\.tmp)$/,
 		usePolling: false,
 		persistent: true
 	} );
 
-	// The add/addDir events are fired during initialization generating an 
-	// avalanche of refreshes on the client so we stick to the change events 
+	// The add/addDir events are fired during initialization generating an
+	// avalanche of refreshes on the client so we stick to the change events
 	// only for now until we can exclude the initial add/addDir events.
 	watcher.on( 'all', function( event, path ) {
 		if ( 'change' === event && path.match( /^.*\.scss$/ ) ) {


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/wp-calypso/pull/10775 that updates the sidebar for domain-only sites to display a `Settings` menu item. This fixes an issue on mobile devices where users would open the sidebar from the `Domain Management` page but wouldn't be able to collapse it (and wouldn't be able to get back to this page) because of the empty sidebar.

<img width="736" alt="screenshot" src="https://cloud.githubusercontent.com/assets/594356/22468446/9779027c-e7c8-11e6-99f6-a44f428fa6c1.png">

#### Testing instructions

1. Run `git checkout add/navigation-domain-only-sites` and start your server, or open a [live branch](https://calypso.live/?branch=add/navigation-domain-only-sites)
2. Open the [`Home` page](http://calypso.localhost:3000/) on a mobile device (or an emulator)
3. Log in with an account with a domain-only site
4. Navigate to `My Sites` by clicking the first icon in the top bar
5. Check that you are presented with the sidebar
6. Click the `Settings` menu item
7. Check that the `Domain Management` page is displayed

#### Additional notes

This pull request also refines which files are monitored by the CSS hot reload process to exclude [unison](https://www.cis.upenn.edu/~bcpierce/unison/) temporary files and avoid such errors:

```
Error: watch client/my-sites/sidebar/.unison.sidebar.jsx.76a52f110a76c2bf520b19a0255ec473.unison.tmp ENOSPC
  at exports._errnoException (util.js:1022:11)
  at FSWatcher.start (fs.js:1429:19)
  at Object.fs.watch (fs.js:1456:11)
  at createFsWatchInstance (/var/sources/node_modules/chokidar/lib/nodefs-handler.js:37:15)
  at setFsWatchListener (/var/sources/node_modules/chokidar/lib/nodefs-handler.js:80:15)
  at FSWatcher.NodeFsHandler._watchWithNodeFs (/var/sources/node_modules/chokidar/lib/nodefs-handler.js:228:14)
  at FSWatcher.NodeFsHandler._handleFile (/var/sources/node_modules/chokidar/lib/nodefs-handler.js:255:21)
  at FSWatcher.<anonymous> (/var/sources/node_modules/chokidar/lib/nodefs-handler.js:473:21)
  at FSReqWrap.oncomplete (fs.js:123:15)
Makefile:95: recipe for target 'run' failed
make: *** [run] Error 1
```

#### Reviews

- [x] Code
- [x] Product