### PR TITLE
Site Settings: Add site icon analytics

### DIFF
--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { uniqueId, head, partial, partialRight, isEqual } from 'lodash';
+import { uniqueId, head, partial, partialRight, isEqual, flow, compact } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,6 +15,7 @@ import MediaLibrarySelectedData from 'components/data/media-library-selected-dat
 import AsyncLoad from 'components/async-load';
 import Dialog from 'components/dialog';
 import accept from 'lib/accept';
+import { recordGoogleEvent } from 'state/analytics/actions';
 import { saveSiteSettings, updateSiteSettings } from 'state/site-settings/actions';
 import { isSavingSiteSettings } from 'state/site-settings/selectors';
 import { setEditorMediaModalView } from 'state/ui/editor/actions';
@@ -128,7 +129,7 @@ class SiteIconSetting extends Component {
 			return;
 		}
 
-		const { crop, transform } = this.props;
+		const { crop, transform, recordEvent } = this.props;
 		const isImageEdited = ! isEqual( {
 			...crop,
 			...transform
@@ -142,6 +143,8 @@ class SiteIconSetting extends Component {
 			scaleY: 1
 		} );
 
+		recordEvent( 'Completed Site Icon Selection' );
+
 		if ( isImageEdited ) {
 			this.uploadSiteIcon( blob, `cropped-${ selectedItem.file }` );
 		} else {
@@ -153,12 +156,15 @@ class SiteIconSetting extends Component {
 	};
 
 	confirmRemoval = () => {
-		const { translate, siteId, removeSiteIcon } = this.props;
+		const { translate, siteId, removeSiteIcon, recordEvent } = this.props;
 		const message = translate( 'Are you sure you want to remove the site icon?' );
+
+		recordEvent( 'Clicked Remove Site Icon' );
 
 		accept( message, ( accepted ) => {
 			if ( accepted ) {
 				removeSiteIcon( siteId );
+				recordEvent( 'Confirmed Remove Site Icon' );
 			}
 		} );
 	};
@@ -197,6 +203,12 @@ class SiteIconSetting extends Component {
 				buttonProps.target = '_blank';
 			}
 		}
+
+		// Merge analytics click handler into existing button props
+		buttonProps.onClick = flow( compact( [
+			() => this.props.recordEvent( 'Clicked Change Site Icon' ),
+			buttonProps.onClick
+		] ) );
 
 		const { translate, siteId, isSaving, hasIcon } = this.props;
 
@@ -278,6 +290,7 @@ export default connect(
 		};
 	},
 	{
+		recordEvent: ( action ) => recordGoogleEvent( 'Site Settings', action ),
 		onEditSelectedMedia: partial( setEditorMediaModalView, ModalViews.IMAGE_EDITOR ),
 		onCancelEditingIcon: partial( setEditorMediaModalView, ModalViews.LIST ),
 		resetAllImageEditorState,


### PR DESCRIPTION
This pull request seeks to add analytics for actions relating to assigning a site icon.

Specifically, it adds Google Analytics event actions for:

- "Clicked Change Site Icon"
- "Completed Site Icon Selection"
- "Clicked Remove Site Icon"
- "Confirmed Remove Site Icon"

__Testing Instructions:__

Enable analytics logging by entering `localStorage.debug = 'calypso:analytics:ga'` in your console and refreshing the page.

1. Navigate to [site settings](http://calypso.localhost:3000/settings)
2. Select a site
3. Perform site icon flows corresponding to above actions
4. Observe the analytics are logged to console