### PR TITLE
Reader: adding schema for serialization of teams

### DIFF
--- a/client/state/reader/teams/reducer.js
+++ b/client/state/reader/teams/reducer.js
@@ -10,11 +10,12 @@ import {
 	READER_TEAMS_REQUEST,
 	READER_TEAMS_RECEIVE,
 } from 'state/action-types';
+import { itemsSchema } from './schema';
 import { createReducer } from 'state/utils';
 
 export const items = createReducer( [], {
 	[ READER_TEAMS_RECEIVE ]: ( state, action ) => action.payload.teams,
-} );
+}, itemsSchema );
 
 export const isRequesting = createReducer( false, {
 	[ READER_TEAMS_REQUEST ]: () => true,

--- a/client/state/reader/teams/schema.js
+++ b/client/state/reader/teams/schema.js
@@ -1,0 +1,17 @@
+export const itemsSchema = {
+	type: 'object',
+	properties: {
+		number: { type: 'number' },
+		teams: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					title: { type: 'string' },
+					slug: { type: 'string' },
+				}
+			}
+		}
+	}
+};
+

--- a/client/state/reader/teams/test/reducer.js
+++ b/client/state/reader/teams/test/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -10,10 +10,13 @@ import { items, isRequesting } from '../reducer';
 import {
 	READER_TEAMS_REQUEST,
 	READER_TEAMS_RECEIVE,
+	DESERIALIZE,
 } from 'state/action-types';
 
 const TEAM1 = { slug: 'team one slug', title: 'team one title' };
 const TEAM2 = { slug: 'team two slug', title: 'team two title' };
+const validState = { teams: [ TEAM1 ], };
+const invalidState = { teams: [ 1, 5 ], fish: 'tacos' };
 
 describe( 'reducer', ( ) => {
 	describe( 'items', () => {
@@ -43,6 +46,19 @@ describe( 'reducer', ( ) => {
 			).to.deep.equal( [ TEAM1, TEAM2 ] );
 		} );
 
+		it( 'deserialize: should succeed with good data', () => {
+			assert.deepEqual( validState, items( validState, { type: DESERIALIZE } ) );
+		} );
+
+		it( 'deserialize: should ignore bad data', () => {
+			let state;
+			try {
+				state = items( invalidState, { type: DESERIALIZE } );
+				assert.fail();
+			} catch ( err ) {
+				assert.deepEqual( [], state );
+			}
+		} );
 	} );
 
 	describe( 'isRequesting', () => {


### PR DESCRIPTION
This PR seeks to add the schema for ReaderTeams.  That way they can be solved offline + have its schema validated.

https://github.com/Automattic/wp-calypso/issues/10984

To Test:
- run `npm run test-client client/state/reader/teams `