### PR TITLE
Version Bump w.js

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -37,7 +37,7 @@ window.ga = window.ga || function() {
 };
 window.ga.l = +new Date();
 
-loadScript( '//stats.wp.com/w.js?55' ); // W_JS_VER
+loadScript( '//stats.wp.com/w.js?56' ); // W_JS_VER
 loadScript( '//www.google-analytics.com/analytics.js' );
 
 function buildQuerystring( group, name ) {


### PR DESCRIPTION
Some performance enhancement changes have been pushed for Tracks (`w.js`) so we want to bump the version to bust caches.

See:
r150142-wpcom
D4015-code