### PR TITLE
Themes: For themes with identical IDs, prioritize locally installed version

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -653,7 +653,7 @@ export default connect(
 		const selectedSite = getSelectedSite( state );
 		const siteSlug = selectedSite ? getSiteSlug( state, selectedSite.ID ) : '';
 		const isJetpack = selectedSite && isJetpackSite( state, selectedSite.ID );
-		const isWpcomTheme = isThemeWpcom( state, id );
+		const isWpcomTheme = selectedSite ? isThemeWpcom( state, id, selectedSite.ID ) : true;
 		const siteIdOrWpcom = ( isJetpack && ! isWpcomTheme ) ? selectedSite.ID : 'wpcom';
 		const backPath = getBackPath( state );
 		const currentUserId = getCurrentUserId( state );

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -150,13 +150,13 @@ const support = {
 	label: i18n.translate( 'Setup' ),
 	icon: 'help',
 	getUrl: getSupportUrl,
-	hideForTheme: ( state, theme ) => ! isPremium( state, theme.id ) || ! isWpcomTheme( state, theme.id )
+	hideForTheme: ( state, theme, siteId ) => ! isPremium( state, theme.id ) || ! isWpcomTheme( state, theme.id, siteId )
 };
 
 const help = {
 	label: i18n.translate( 'Support' ),
 	getUrl: getHelpUrl,
-	hideForTheme: ( state, theme ) => ! isWpcomTheme( state, theme.id )
+	hideForTheme: ( state, theme, siteId ) => ! isWpcomTheme( state, theme.id, siteId )
 };
 
 const ALL_THEME_OPTIONS = {

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -40,7 +40,7 @@ import { DEFAULT_THEME_QUERY } from './constants';
  */
 const getSuffixedThemeId = ( state, themeId, siteId ) => {
 	const siteIsJetpack = siteId && isJetpackSite( state, siteId );
-	if ( siteIsJetpack && isWpcomTheme( state, themeId ) ) {
+	if ( siteIsJetpack && isWpcomTheme( state, themeId, siteId ) ) {
 		return `${ themeId }-wpcom`;
 	}
 	return themeId;
@@ -329,8 +329,9 @@ export function isWporgTheme( state, themeId ) {
  * @param  {Number}  themeId Theme ID
  * @return {Boolean}         Whether theme available on WordPress.com
  */
-export function isWpcomTheme( state, themeId ) {
-	return !! getTheme( state, 'wpcom', themeId );
+export function isWpcomTheme( state, themeId, siteId ) {
+	return getTheme( state, 'wpcom', themeId ) &&
+		! getTheme( state, siteId, themeId );
 }
 
 /**

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -325,8 +325,13 @@ export function isWporgTheme( state, themeId ) {
 /**
  * Whether a theme is present on WordPress.com.
  *
+ * Returns false if themeId is installed on (jetpack) siteId, since
+ * installed themes take priority. For example, this can be the case
+ * with themes available on both wpcom and .org such as 'twentysixteen'.
+ *
  * @param  {Object}  state   Global state tree
  * @param  {Number}  themeId Theme ID
+ * @param  {Number}  siteId  Site ID
  * @return {Boolean}         Whether theme available on WordPress.com
  */
 export function isWpcomTheme( state, themeId, siteId ) {

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -335,8 +335,8 @@ export function isWporgTheme( state, themeId ) {
  * @return {Boolean}         Whether theme available on WordPress.com
  */
 export function isWpcomTheme( state, themeId, siteId ) {
-	return getTheme( state, 'wpcom', themeId ) &&
-		! getTheme( state, siteId, themeId );
+	return !! ( getTheme( state, 'wpcom', themeId ) &&
+		! getTheme( state, siteId, themeId ) );
 }
 
 /**

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -1737,18 +1737,7 @@ describe( 'themes selectors', () => {
 					queries: {
 					}
 				}
-			}, 'twentyseventeen' );
-
-			expect( isWpcom ).to.be.false;
-		} );
-
-		it( 'should return false if theme is no theme id supplied', () => {
-			const isWpcom = isWpcomTheme( {
-				themes: {
-					queries: {
-					}
-				}
-			} );
+			}, 'twentyseventeen', 77203074 );
 
 			expect( isWpcom ).to.be.false;
 		} );
@@ -1774,10 +1763,32 @@ describe( 'themes selectors', () => {
 						} ),
 					}
 				}
-			}, 'twentyseventeen' );
+			}, 'twentyseventeen', 77203074 );
 
 			expect( isWpcom ).to.be.true;
 		} );
+
+		it( 'should return false if theme is found on WordPress.com and is also installed on site', () => {
+			const theme = {
+				id: 'twentysixteen',
+				name: 'Twenty Sixteen',
+			};
+			const isWpcom = isWpcomTheme( {
+				themes: {
+					queries: {
+						wpcom: new ThemeQueryManager( {
+							items: { twentysixteen: theme }
+						} ),
+						77203074: new ThemeQueryManager( {
+							items: { twentysixteen: theme }
+						} ),
+					}
+				}
+			}, 'twentysixteen', 77203074 );
+
+			expect( isWpcom ).to.be.false;
+		} );
+
 	} );
 
 	describe( '#isPremium()', () => {


### PR DESCRIPTION
Fixes #11020 

Solve an ambiguity on the showcase for themes that can be both installed on a jetpack site and available on wpcom, for example _Twenty Sixteen_. This PR gives priority to the locally installed version for any theme operations such as _activate_ or _try & customize_.

To test, test issue #11020 

Merging this PR will leave actions from these ambiguous themes doing the wrong thing in the bottom list, but we can solve that either with #10972, or filtering those themes from the bottom list in a new PR.

