### PR TITLE
Themes: Update Thanks Modal

### DIFF
--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -87,17 +87,14 @@ const ThanksModal = React.createClass( {
 	},
 
 	renderThemeInfo() {
-		const { detailsUrl } = this.props;
-		if ( detailsUrl ) {
-			return (
-				translate( '{{a}}Learn more about{{/a}} this theme.', {
-					components: {
-						a: <a href={ detailsUrl }
-							onClick={ this.onLinkClick( 'theme info' ) } />
-					}
-				} )
-			);
-		}
+		return (
+			translate( '{{a}}Learn more about{{/a}} this theme.', {
+				components: {
+					a: <a href={ this.props.detailsUrl }
+						onClick={ this.onLinkClick( 'theme info' ) } />
+				}
+			} )
+		);
 	},
 
 	renderWporgAuthorInfo( authorUri ) {

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -62,12 +62,7 @@ const ThanksModal = React.createClass( {
 	},
 
 	renderWpcomInfo() {
-		const features = translate( "Discover this theme's {{a}}awesome features.{{/a}}", {
-			components: {
-				a: <a href={ this.props.detailsUrl }
-					onClick={ this.onLinkClick( 'features' ) } />
-			}
-		} );
+		const features = this.renderThemeInfo();
 		const customize = translate( '{{a}}Customize{{/a}} this design.', {
 			components: {
 				a: <a href={ this.props.customizeUrl }
@@ -91,17 +86,16 @@ const ThanksModal = React.createClass( {
 		);
 	},
 
-	renderWporgThemeInfo( themeUri ) {
-		if ( themeUri ) {
+	renderThemeInfo() {
+		const { detailsUrl } = this.props;
+		if ( detailsUrl ) {
 			return (
-				<li>
-					{ translate( 'Learn more about this {{a}}awesome theme{{/a}}.', {
-						components: {
-							a: <a href={ themeUri }
-								onClick={ this.onLinkClick( 'org theme' ) } />
-						}
-					} ) }
-				</li>
+				translate( '{{a}}Learn more about{{/a}} this theme.', {
+					components: {
+						a: <a href={ detailsUrl }
+							onClick={ this.onLinkClick( 'theme info' ) } />
+					}
+				} )
 			);
 		}
 	},
@@ -121,30 +115,15 @@ const ThanksModal = React.createClass( {
 		}
 	},
 
-	renderWporgForumInfo() {
-		return (
-			<li>
-				{ translate( 'If you need support, visit the WordPress.org {{a}}Themes forum{{/a}}.', {
-					components: {
-						a: <a href="https://wordpress.org/support/forum/themes-and-templates"
-							onClick={ this.onLinkClick( 'org forum' ) } />
-					}
-				} ) }
-			</li>
-		);
-	},
-
 	renderJetpackInfo() {
 		const {
-			theme_uri: themeUri,
 			author_uri: authorUri
 		} = this.props.currentTheme;
 
 		return (
 			<ul>
-				{ themeUri ? this.renderWporgThemeInfo( themeUri ) : null }
+				<li>{ this.renderThemeInfo() }</li>
 				{ authorUri ? this.renderWporgAuthorInfo( authorUri ) : null }
-				{ ! themeUri || ! authorUri ? this.renderWporgForumInfo() : null }
 			</ul>
 		);
 	},

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -19,7 +19,8 @@ import {
 	getThemeCustomizeUrl,
 	getThemeForumUrl,
 	isActivatingTheme,
-	hasActivatedTheme
+	hasActivatedTheme,
+	isWpcomTheme
 } from 'state/themes/selectors';
 import { clearActivated } from 'state/themes/actions';
 
@@ -75,52 +76,47 @@ const ThanksModal = React.createClass( {
 					{ this.props.source === 'list' ? features : customize }
 				</li>
 			<li>
-				{ translate( 'Have questions? Stop by our {{a}}support forums.{{/a}}', {
-					components: {
-						a: <a href={ this.props.forumUrl }
-							onClick={ this.onLinkClick( 'support' ) } />
-					}
-				} ) }
+				{ this.renderSupportInfo() }
 			</li>
 			</ul>
 		);
 	},
 
 	renderThemeInfo() {
-		return (
-			translate( '{{a}}Learn more about{{/a}} this theme.', {
-				components: {
-					a: <a href={ this.props.detailsUrl }
-						onClick={ this.onLinkClick( 'theme info' ) } />
-				}
-			} )
-		);
+		return translate( '{{a}}Learn more about{{/a}} this theme.', {
+			components: {
+				a: <a href={ this.props.detailsUrl }
+					onClick={ this.onLinkClick( 'theme info' ) } />
+			}
+		} );
 	},
 
-	renderWporgAuthorInfo( authorUri ) {
-		if ( authorUri ) {
-			return (
-				<li>
-					{ translate( 'Have questions? {{a}}Contact the theme author.{{/a}}', {
-						components: {
-							a: <a href={ authorUri }
-								onClick={ this.onLinkClick( 'org author' ) } />
-						}
-					} ) }
-				</li>
-			);
+	renderSupportInfo() {
+		const { author_uri: authorUri } = this.props.currentTheme;
+
+		// For WP.com theme, authorUri is wp.com/themes or automattic.com, which isn't too helpful
+		if ( authorUri && ! this.props.isThemeWpcom ) {
+			return translate( 'Have questions? {{a}}Contact the theme author.{{/a}}', {
+				components: {
+					a: <a href={ authorUri }
+						onClick={ this.onLinkClick( 'org author' ) } />
+				}
+			} );
 		}
+
+		return translate( 'Have questions? Stop by our {{a}}support forums.{{/a}}', {
+			components: {
+				a: <a href={ this.props.forumUrl }
+					onClick={ this.onLinkClick( 'support' ) } />
+			}
+		} );
 	},
 
 	renderJetpackInfo() {
-		const {
-			author_uri: authorUri
-		} = this.props.currentTheme;
-
 		return (
 			<ul>
 				<li>{ this.renderThemeInfo() }</li>
-				{ authorUri ? this.renderWporgAuthorInfo( authorUri ) : null }
+				<li>{ this.renderSupportInfo() }</li>
 			</ul>
 		);
 	},
@@ -186,7 +182,8 @@ export default connect(
 			customizeUrl: site && getThemeCustomizeUrl( state, currentTheme, site.ID ),
 			forumUrl: getThemeForumUrl( state, currentThemeId ),
 			isActivating: !! ( site && isActivatingTheme( state, site.ID ) ),
-			hasActivated: !! ( site && hasActivatedTheme( state, site.ID ) )
+			hasActivated: !! ( site && hasActivatedTheme( state, site.ID ) ),
+			isThemeWpcom: isWpcomTheme( state, currentThemeId )
 		};
 	},
 	{ clearActivated }

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -180,7 +180,7 @@ export default connect(
 			currentTheme,
 			detailsUrl: site && getThemeDetailsUrl( state, currentTheme, site.ID ),
 			customizeUrl: site && getThemeCustomizeUrl( state, currentTheme, site.ID ),
-			forumUrl: getThemeForumUrl( state, currentThemeId ),
+			forumUrl: site && getThemeForumUrl( state, currentThemeId, site.ID ),
 			isActivating: !! ( site && isActivatingTheme( state, site.ID ) ),
 			hasActivated: !! ( site && hasActivatedTheme( state, site.ID ) ),
 			isThemeWpcom: isWpcomTheme( state, currentThemeId )

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -62,18 +62,11 @@ const ThanksModal = React.createClass( {
 		};
 	},
 
-	renderWpcomInfo() {
-		const features = this.renderThemeInfo();
-		const customize = translate( '{{a}}Customize{{/a}} this design.', {
-			components: {
-				a: <a href={ this.props.customizeUrl }
-					onClick={ this.onLinkClick( 'customize' ) } />
-			}
-		} );
+	renderBody() {
 		return (
 			<ul>
 				<li>
-					{ this.props.source === 'list' ? features : customize }
+					{ this.props.source === 'list' ? this.renderThemeInfo() : this.renderCustomizeInfo() }
 				</li>
 			<li>
 				{ this.renderSupportInfo() }
@@ -87,6 +80,15 @@ const ThanksModal = React.createClass( {
 			components: {
 				a: <a href={ this.props.detailsUrl }
 					onClick={ this.onLinkClick( 'theme info' ) } />
+			}
+		} );
+	},
+
+	renderCustomizeInfo() {
+		return translate( '{{a}}Customize{{/a}} this design.', {
+			components: {
+				a: <a href={ this.props.customizeUrl }
+					onClick={ this.onLinkClick( 'customize' ) } />
 			}
 		} );
 	},
@@ -131,7 +133,7 @@ const ThanksModal = React.createClass( {
 						}
 					} ) }
 				</h1>
-				{ this.renderWpcomInfo() }
+				{ this.renderBody() }
 			</div>
 		);
 	},

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -97,7 +97,7 @@ const ThanksModal = React.createClass( {
 		const { author_uri: authorUri } = this.props.currentTheme;
 
 		if ( this.props.forumUrl ) {
-			return translate( 'Have questions? Stop by our {{a}}support forums.{{/a}}', {
+			return translate( 'Have questions? Stop by our {{a}}support forums{{/a}}.', {
 				components: {
 					a: <a href={ this.props.forumUrl }
 						onClick={ this.onLinkClick( 'support' ) } />

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -115,15 +115,6 @@ const ThanksModal = React.createClass( {
 		return null;
 	},
 
-	renderJetpackInfo() {
-		return (
-			<ul>
-				<li>{ this.renderThemeInfo() }</li>
-				<li>{ this.renderSupportInfo() }</li>
-			</ul>
-		);
-	},
-
 	renderContent() {
 		const {
 			name: themeName,
@@ -140,9 +131,7 @@ const ThanksModal = React.createClass( {
 						}
 					} ) }
 				</h1>
-				<ul>
-					{ this.props.site.jetpack ? this.renderJetpackInfo() : this.renderWpcomInfo() }
-				</ul>
+				{ this.renderWpcomInfo() }
 			</div>
 		);
 	},

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -94,8 +94,16 @@ const ThanksModal = React.createClass( {
 	renderSupportInfo() {
 		const { author_uri: authorUri } = this.props.currentTheme;
 
-		// For WP.com theme, authorUri is wp.com/themes or automattic.com, which isn't too helpful
-		if ( authorUri && ! this.props.isThemeWpcom ) {
+		if ( this.props.forumUrl ) {
+			return translate( 'Have questions? Stop by our {{a}}support forums.{{/a}}', {
+				components: {
+					a: <a href={ this.props.forumUrl }
+						onClick={ this.onLinkClick( 'support' ) } />
+				}
+			} );
+		}
+
+		if ( authorUri ) {
 			return translate( 'Have questions? {{a}}Contact the theme author.{{/a}}', {
 				components: {
 					a: <a href={ authorUri }
@@ -104,12 +112,7 @@ const ThanksModal = React.createClass( {
 			} );
 		}
 
-		return translate( 'Have questions? Stop by our {{a}}support forums.{{/a}}', {
-			components: {
-				a: <a href={ this.props.forumUrl }
-					onClick={ this.onLinkClick( 'support' ) } />
-			}
-		} );
+		return null;
 	},
 
 	renderJetpackInfo() {

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -480,18 +480,17 @@ export function getThemeSignupUrl( state, theme ) {
  * @param  {String}  siteId  Site ID
  * @return {?String}         Theme forum URL
  */
-export function getThemeForumUrl( state, themeId, siteId ) {
-	if ( isJetpackSite( state, siteId ) ) {
-		if ( isWporgTheme( state, themeId ) ) {
-			return '//wordpress.org/support/theme/' + themeId;
-		}
-		return null;
-	}
-
+export function getThemeForumUrl( state, themeId ) {
 	if ( isThemePremium( state, themeId ) ) {
 		return '//premium-themes.forums.wordpress.com/forum/' + themeId;
 	}
-	return '//en.forums.wordpress.com/forum/themes';
+	if ( isWpcomTheme( state, themeId ) ) {
+		return '//en.forums.wordpress.com/forum/themes';
+	}
+	if ( isWporgTheme( state, themeId ) ) {
+		return '//wordpress.org/support/theme/' + themeId;
+	}
+	return null;
 }
 
 /**

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -1454,7 +1454,30 @@ describe( 'themes selectors', () => {
 		} );
 
 		context( 'on a Jetpack site', () => {
-			it( 'given a theme that\'s not found on WP.org, should return null', () => {
+			it( 'given a theme that\'s found on neither WP.com nor WP.org, should return null', () => {
+				const forumUrl = getThemeForumUrl(
+					{
+						sites: {
+							items: {
+								77203074: {
+									ID: 77203074,
+									URL: 'https://example.net',
+									jetpack: true
+								}
+							}
+						},
+						themes: {
+							queries: {}
+						}
+					},
+					'twentysixteen',
+					77203074
+				);
+
+				expect( forumUrl ).to.be.null;
+			} );
+
+			it( 'given a theme that\'s found on WP.com, should return the generic WP.com themes support forum URL', () => {
 				const forumUrl = getThemeForumUrl(
 					{
 						sites: {
@@ -1478,7 +1501,7 @@ describe( 'themes selectors', () => {
 					77203074
 				);
 
-				expect( forumUrl ).to.be.null;
+				expect( forumUrl ).to.equal( '//en.forums.wordpress.com/forum/themes' );
 			} );
 
 			it( 'given a theme that\'s found on WP.org, should return the correspoding WP.org theme forum URL', () => {


### PR DESCRIPTION
Link to theme sheets for Jetpack sites, too.
Simplify some methods.
Remove line about WP.org theme forums -- we displayed that conditionally if there was no theme info link. Since we now always provide a theme info link, I think we can drop the other one.

Fixes #11046

To test: Verify that #11046 is fixed and nothing else breaks 😄
More specifically:
* Check that the thanks modal's URLs point to all the right locations:
  * try dotcom themes, dotorg-only themes, and themes that are in neither repo
* Try activating both from the list and theme sheet
  * From the list, the thanks modal's upper bullet point should point to theme info (i.e. the sheet)
  * From the sheet, it should point to the customizer