### PR TITLE
Disable size limit when uploading videos for a Jetpack site with VideoPress

### DIFF
--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -366,22 +366,31 @@ describe( 'MediaUtils', function() {
 	} );
 
 	describe( '#isExceedingSiteMaxUploadSize()', function() {
-		var site = {
+		const site = {
+			jetpack: false,
 			options: {
 				max_upload_size: 1024
 			}
 		};
+		const jetpackSite = new JetpackSite( {
+			jetpack: true,
+			modules: [ 'videopress' ],
+			options: {
+				jetpack_version: '3.8.1',
+				max_upload_size: 1024,
+			}
+		} );
 
 		it( 'should return null if the provided `bytes` are not numeric', function() {
-			expect( MediaUtils.isExceedingSiteMaxUploadSize( undefined, site ) ).to.be.null;
+			expect( MediaUtils.isExceedingSiteMaxUploadSize( {}, site ) ).to.be.null;
 		} );
 
 		it( 'should return null if the site `options` are `undefined`', function() {
-			expect( MediaUtils.isExceedingSiteMaxUploadSize( 1024, {} ) ).to.be.null;
+			expect( MediaUtils.isExceedingSiteMaxUploadSize( { size: 1024 }, {} ) ).to.be.null;
 		} );
 
 		it( 'should return null if the site `max_upload_size` is `false`', function() {
-			var isAcceptableSize = MediaUtils.isExceedingSiteMaxUploadSize( 1024, {
+			const isAcceptableSize = MediaUtils.isExceedingSiteMaxUploadSize( { size: 1024 }, {
 				options: {
 					max_upload_size: false
 				}
@@ -390,13 +399,33 @@ describe( 'MediaUtils', function() {
 			expect( isAcceptableSize ).to.be.null;
 		} );
 
+		it( 'should return null if a video is being uploaded for a Jetpack site with VideoPress enabled', function() {
+			expect( MediaUtils.isExceedingSiteMaxUploadSize( { size: 1024, extension: 'mp4' }, jetpackSite ) ).to.be.null;
+		} );
+
+		it( 'should not return null if an image is being uploaded for a Jetpack site with VideoPress enabled', function() {
+			expect( MediaUtils.isExceedingSiteMaxUploadSize( { size: 1024, extension: 'jpg' }, jetpackSite ) ).to.not.be.null;
+		} );
+
+		it( 'should not return null if a video is being uploaded for a Jetpack site with VideoPress disabled', function() {
+			const isAcceptableSize = MediaUtils.isExceedingSiteMaxUploadSize( { size: 1024, extension: 'mp4' }, new JetpackSite( {
+				jetpack: true,
+				options: {
+					jetpack_version: '3.8.1',
+					max_upload_size: 1024,
+				}
+			} ) );
+
+			expect( isAcceptableSize ).to.not.be.null;
+		} );
+
 		it( 'should return false if the provided `bytes` are less than or equal to `max_upload_size`', function() {
-			expect( MediaUtils.isExceedingSiteMaxUploadSize( 512, site ) ).to.be.false;
-			expect( MediaUtils.isExceedingSiteMaxUploadSize( 1024, site ) ).to.be.false;
+			expect( MediaUtils.isExceedingSiteMaxUploadSize( { size: 512 }, site ) ).to.be.false;
+			expect( MediaUtils.isExceedingSiteMaxUploadSize( { size: 1024 }, site ) ).to.be.false;
 		} );
 
 		it( 'should return true if the provided `bytes` are greater than `max_upload_size`', function() {
-			expect( MediaUtils.isExceedingSiteMaxUploadSize( 1025, site ) ).to.be.true;
+			expect( MediaUtils.isExceedingSiteMaxUploadSize( { size: 1025 }, site ) ).to.be.true;
 		} );
 	} );
 

--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -400,11 +400,11 @@ describe( 'MediaUtils', function() {
 		} );
 
 		it( 'should return null if a video is being uploaded for a Jetpack site with VideoPress enabled', function() {
-			expect( MediaUtils.isExceedingSiteMaxUploadSize( { size: 1024, extension: 'mp4' }, jetpackSite ) ).to.be.null;
+			expect( MediaUtils.isExceedingSiteMaxUploadSize( { size: 1024, mime_type: 'video/mp4' }, jetpackSite ) ).to.be.null;
 		} );
 
 		it( 'should not return null if a video is being uploaded for a pre-4.5 Jetpack site with VideoPress enabled', function() {
-			const isAcceptableSize = MediaUtils.isExceedingSiteMaxUploadSize( { size: 1024, extension: 'mp4' }, new JetpackSite( {
+			const isAcceptableSize = MediaUtils.isExceedingSiteMaxUploadSize( { size: 1024, mime_type: 'video/mp4' }, new JetpackSite( {
 				jetpack: true,
 				modules: [ 'videopress' ],
 				options: {
@@ -417,11 +417,11 @@ describe( 'MediaUtils', function() {
 		} );
 
 		it( 'should not return null if an image is being uploaded for a Jetpack site with VideoPress enabled', function() {
-			expect( MediaUtils.isExceedingSiteMaxUploadSize( { size: 1024, extension: 'jpg' }, jetpackSite ) ).to.not.be.null;
+			expect( MediaUtils.isExceedingSiteMaxUploadSize( { size: 1024, mime_type: 'image/jpeg' }, jetpackSite ) ).to.not.be.null;
 		} );
 
 		it( 'should not return null if a video is being uploaded for a Jetpack site with VideoPress disabled', function() {
-			const isAcceptableSize = MediaUtils.isExceedingSiteMaxUploadSize( { size: 1024, extension: 'mp4' }, new JetpackSite( {
+			const isAcceptableSize = MediaUtils.isExceedingSiteMaxUploadSize( { size: 1024, mime_type: 'video/mp4' }, new JetpackSite( {
 				jetpack: true,
 				options: {
 					jetpack_version: '4.5',

--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -376,7 +376,7 @@ describe( 'MediaUtils', function() {
 			jetpack: true,
 			modules: [ 'videopress' ],
 			options: {
-				jetpack_version: '3.8.1',
+				jetpack_version: '4.5',
 				max_upload_size: 1024,
 			}
 		} );
@@ -403,6 +403,19 @@ describe( 'MediaUtils', function() {
 			expect( MediaUtils.isExceedingSiteMaxUploadSize( { size: 1024, extension: 'mp4' }, jetpackSite ) ).to.be.null;
 		} );
 
+		it( 'should not return null if a video is being uploaded for a pre-4.5 Jetpack site with VideoPress enabled', function() {
+			const isAcceptableSize = MediaUtils.isExceedingSiteMaxUploadSize( { size: 1024, extension: 'mp4' }, new JetpackSite( {
+				jetpack: true,
+				modules: [ 'videopress' ],
+				options: {
+					jetpack_version: '3.8.1',
+					max_upload_size: 1024,
+				}
+			} ) );
+
+			expect( isAcceptableSize ).to.not.be.null;
+		} );
+
 		it( 'should not return null if an image is being uploaded for a Jetpack site with VideoPress enabled', function() {
 			expect( MediaUtils.isExceedingSiteMaxUploadSize( { size: 1024, extension: 'jpg' }, jetpackSite ) ).to.not.be.null;
 		} );
@@ -411,7 +424,7 @@ describe( 'MediaUtils', function() {
 			const isAcceptableSize = MediaUtils.isExceedingSiteMaxUploadSize( { size: 1024, extension: 'mp4' }, new JetpackSite( {
 				jetpack: true,
 				options: {
-					jetpack_version: '3.8.1',
+					jetpack_version: '4.5',
 					max_upload_size: 1024,
 				}
 			} ) );

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -318,8 +318,8 @@ const MediaUtils = {
 			return null;
 		}
 
-		if ( site.jetpack && site.isModuleActive( 'videopress' ) && versionCompare( site.options.jetpack_version, '4.5', '>=' ) &&
-			MediaUtils.isSupportedFileTypeInPremium( item, site ) ) {
+		if ( site.jetpack && site.isModuleActive( 'videopress' ) && site.versionCompare( '4.5', '>=' ) &&
+				MediaUtils.isSupportedFileTypeInPremium( item, site ) ) {
 			return null;
 		}
 

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -4,7 +4,7 @@
 import url from 'url';
 import path from 'path';
 import photon from 'photon';
-import { includes, omitBy, uniqueId } from 'lodash';
+import { includes, omitBy, startsWith, uniqueId } from 'lodash';
 import { isUri } from 'valid-url';
 
 /**
@@ -319,7 +319,7 @@ const MediaUtils = {
 		}
 
 		if ( site.jetpack && site.isModuleActive( 'videopress' ) && site.versionCompare( '4.5', '>=' ) &&
-				MediaUtils.isSupportedFileTypeInPremium( item, site ) ) {
+				startsWith( MediaUtils.getMimeType( item ), 'video/' ) ) {
 			return null;
 		}
 

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -318,7 +318,8 @@ const MediaUtils = {
 			return null;
 		}
 
-		if ( site.jetpack && site.isModuleActive( 'videopress' ) && MediaUtils.isSupportedFileTypeInPremium( item, site ) ) {
+		if ( site.jetpack && site.isModuleActive( 'videopress' ) && versionCompare( site.options.jetpack_version, '4.5', '>=' ) &&
+			MediaUtils.isSupportedFileTypeInPremium( item, site ) ) {
 			return null;
 		}
 

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -299,15 +299,26 @@ const MediaUtils = {
 
 	/**
 	 * Returns true if the specified item exceeds the maximum upload size for
-	 * the given site. Returns null if the bytes are invalid or the max upload
-	 * size for the site is unknown. Otherwise, returns true.
+	 * the given site. Returns null if the bytes are invalid, the max upload
+	 * size for the site is unknown or a video is being uploaded for a Jetpack
+	 * site with VideoPress enabled. Otherwise, returns true.
 	 *
-	 * @param  {Number}   bytes A file size to check, as bytes
+	 * @param  {Object}   item  Media object
 	 * @param  {Object}   site  Site object
 	 * @return {?Boolean}       Whether the size exceeds the site maximum
 	 */
-	isExceedingSiteMaxUploadSize: function( bytes, site ) {
-		if ( ! isFinite( bytes ) || ! site || ! site.options || ! site.options.max_upload_size ) {
+	isExceedingSiteMaxUploadSize: function( item, site ) {
+		const bytes = item.size;
+
+		if ( ! site || ! site.options ) {
+			return null;
+		}
+
+		if ( ! isFinite( bytes ) || ! site.options.max_upload_size ) {
+			return null;
+		}
+
+		if ( site.jetpack && site.isModuleActive( 'videopress' ) && MediaUtils.isSupportedFileTypeInPremium( item, site ) ) {
 			return null;
 		}
 

--- a/client/lib/media/validation-store.js
+++ b/client/lib/media/validation-store.js
@@ -68,7 +68,7 @@ MediaValidationStore.validateItem = function( siteId, item ) {
 		}
 	}
 
-	if ( true === MediaUtils.isExceedingSiteMaxUploadSize( item.size, site ) ) {
+	if ( true === MediaUtils.isExceedingSiteMaxUploadSize( item, site ) ) {
 		itemErrors.push( MediaValidationErrors.EXCEEDS_MAX_UPLOAD_SIZE );
 	}
 


### PR DESCRIPTION
Ignore the maximum file upload size limitation when uploading a video for a VideoPress-enabled Jetpack site.

cc @dbtlr