### PR TITLE
AT: check env_id instead of env

### DIFF
--- a/client/state/automated-transfer/enhancer.js
+++ b/client/state/automated-transfer/enhancer.js
@@ -37,7 +37,7 @@ const WHITELIST = [
  */
 export const automatedTransferEnhancer = createStore => ( reducer, initialState, enhancer ) => {
 	const store = createStore( reducer, initialState, enhancer );
-	const isDevOrWPCalypso = [ 'development', 'wpcalypso' ].indexOf( config( 'env' ) ) > -1;
+	const isDevOrWPCalypso = [ 'development', 'wpcalypso' ].indexOf( config( 'env_id' ) ) > -1;
 
 	if ( ! ( config.isEnabled( 'automated-transfer' ) && isDevOrWPCalypso ) ) {
 		return store;

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -114,7 +114,7 @@ export const reducer = combineReducers( {
 } );
 
 // TEMPORARY AT FLOW FIX, NOT INTENDED FOR PROD
-const isDevOrWPCalypso = [ 'development', 'wpcalypso' ].indexOf( config( 'env' ) ) > -1;
+const isDevOrWPCalypso = [ 'development', 'wpcalypso' ].indexOf( config( 'env_id' ) ) > -1;
 const atEnabled = isDevOrWPCalypso && config.isEnabled( 'automated-transfer' );
 
 export function createReduxStore( initialState = {} ) {


### PR DESCRIPTION
Follow up to #10986 this fixes an env check that enables this only on `development` and `wpcalypso`. I used `config( 'env' )` instead of `config( env_id )`.

### Testing Instructions
To simulate behavior:
- In the console type: 

```
dispatch( { type: 'AUTOMATED_TRANSFER_STATUS_SET', siteId: <your current site id>, status: 'start' } )
```
- Try to perform some action, like navigation. If the actions depend on redux state, nothing should happen. In redux dev tools you should see no-ops being fired instead:
<img width="1299" alt="screen shot 2017-01-26 at 4 17 48 pm" src="https://cloud.githubusercontent.com/assets/1270189/22356037/3bfe181c-e3e3-11e6-94ed-3e988aacfd66.png">
- Then type: 

```
dispatch( { type: 'AUTOMATED_TRANSFER_STATUS_SET', siteId: <your current site id>, status: 'complete' } );
```
<img width="1296" alt="screen shot 2017-01-26 at 4 23 29 pm" src="https://cloud.githubusercontent.com/assets/1270189/22356139/fd76bd1e-e3e3-11e6-9b0a-948e506527f2.png">

#### Full Flow Instructions
- Create a new site
- Choose a .blog domain
- Select the buisness plan
- Complete checkout
- Verify email address for domain
- Set domain to primary
- Navigate to plugins, select a custom plugin to upload
- Wait on the page
- No js errors should fire, window should reload when transfer is complete.
