### PR TITLE
Jetpack Settings: Include all settings in filterSettingsByActiveModules

### DIFF
--- a/client/state/jetpack/settings/test/utils.js
+++ b/client/state/jetpack/settings/test/utils.js
@@ -127,46 +127,85 @@ describe( 'utils', () => {
 	describe( 'filterSettingsByActiveModules()', () => {
 		it( 'should remove module activation state and retain all module settings for enabled modules', () => {
 			const settings = {
+				example_setting: true,
 				'infinite-scroll': true,
 				infinite_scroll: false,
 				infinite_scroll_google_analytics: true,
+				minileven: true,
+				wp_mobile_excerpt: true,
+				wp_mobile_featured_images: true,
+				wp_mobile_app_promos: false,
+				subscriptions: true,
+				stb_enabled: true,
+				stc_enabled: false,
+				likes: true,
+				social_notifications_like: false,
+				social_notifications_reblog: true,
+				social_notifications_subscribe: false,
+				markdown: true,
+				wpcom_publish_comments_with_markdown: true,
 			};
 
 			expect( filterSettingsByActiveModules( settings ) ).to.eql( {
+				example_setting: true,
 				infinite_scroll: false,
 				infinite_scroll_google_analytics: true,
+				wp_mobile_excerpt: true,
+				wp_mobile_featured_images: true,
+				wp_mobile_app_promos: false,
+				stb_enabled: true,
+				stc_enabled: false,
+				social_notifications_like: false,
+				social_notifications_reblog: true,
+				social_notifications_subscribe: false,
+				wpcom_publish_comments_with_markdown: true,
 			} );
 		} );
 
 		it( 'should omit all module settings for disabled modules', () => {
 			const settings = {
-				'infinite-scroll': true,
+				example_setting: true,
+				'infinite-scroll': false,
 				infinite_scroll: false,
 				infinite_scroll_google_analytics: true,
 				minileven: false,
 				wp_mobile_excerpt: true,
 				wp_mobile_featured_images: true,
 				wp_mobile_app_promos: false,
+				subscriptions: false,
+				stb_enabled: true,
+				stc_enabled: false,
+				likes: false,
+				social_notifications_like: false,
+				social_notifications_reblog: true,
+				social_notifications_subscribe: false,
+				markdown: false,
+				wpcom_publish_comments_with_markdown: true,
 			};
 
 			expect( filterSettingsByActiveModules( settings ) ).to.eql( {
-				infinite_scroll: false,
-				infinite_scroll_google_analytics: true,
+				example_setting: true,
 			} );
 		} );
 
 		it( 'should omit all module settings for modules with unknown activation state', () => {
 			const settings = {
-				'infinite-scroll': true,
+				example_setting: true,
 				infinite_scroll: false,
 				infinite_scroll_google_analytics: true,
+				wp_mobile_excerpt: true,
+				wp_mobile_featured_images: true,
+				wp_mobile_app_promos: false,
 				stb_enabled: true,
 				stc_enabled: false,
+				social_notifications_like: false,
+				social_notifications_reblog: true,
+				social_notifications_subscribe: false,
+				wpcom_publish_comments_with_markdown: true,
 			};
 
 			expect( filterSettingsByActiveModules( settings ) ).to.eql( {
-				infinite_scroll: false,
-				infinite_scroll_google_analytics: true,
+				example_setting: true,
 			} );
 		} );
 	} );


### PR DESCRIPTION
This PR improves the `filterSettingsByActiveModules()` utility tests to test against all target modules and their corresponding settings. Previously, only random settings were included, so not all cases were covered in tests.

To test:
* Checkout this branch
* Verify all tests of `filterSettingsByActiveModules()` still pass:

```
npm run test-client client/state/jetpack/settings/test/utils.js -- --grep "filterSettingsByActiveModules"
```