### PR TITLE
Domains: Render feature gate instead of redirect for domain only sites

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -113,6 +113,26 @@ function renderNoVisibleSites( context ) {
 	);
 }
 
+function renderSelectedSiteIsDomainOnly( reactContext, selectedSite ) {
+	const EmptyContentComponent = require( 'components/empty-content' );
+	const { store: reduxStore } = reactContext;
+
+	removeSidebar( reactContext );
+
+	renderWithReduxStore(
+		React.createElement( EmptyContentComponent, {
+			title: i18n.translate( 'This feature is not available for domains' ),
+			line: i18n.translate( 'To use this feature you need to create a site' ),
+			action: i18n.translate( 'Create New Site' ),
+			actionURL: '//dashboard.wordpress.com/wp-admin/index.php?page=my-blogs',
+			secondaryAction: i18n.translate( 'Manage Domain' ),
+			secondaryActionURL: domainManagementList( selectedSite.slug )
+		} ),
+		document.getElementById( 'primary' ),
+		reduxStore
+	);
+}
+
 function isPathAllowedForDomainOnlySite( pathname, domainName ) {
 	const urlPrefixesWhiteListForDomainOnlySite = [
 		domainManagementList( domainName ),
@@ -137,7 +157,7 @@ function onSelectedSiteAvailable( context ) {
 
 	if ( isDomainOnlySite( state, selectedSite.ID ) &&
 		! isPathAllowedForDomainOnlySite( context.pathname, selectedSite.slug ) ) {
-		page.redirect( domainManagementList( selectedSite.slug ) );
+		renderSelectedSiteIsDomainOnly( context, selectedSite );
 		return false;
 	}
 

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -6,7 +6,6 @@ import ReactDom from 'react-dom';
 import React from 'react';
 import i18n from 'i18n-calypso';
 import { uniq } from 'lodash';
-import startsWith from 'lodash/startsWith';
 
 /**
  * Internal Dependencies
@@ -31,7 +30,7 @@ import utils from 'lib/site/utils';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
-import { domainManagementList } from 'my-sites/upgrades/paths';
+import { domainManagementList, domainManagementEdit, domainManagementDns } from 'my-sites/upgrades/paths';
 import SitesComponent from 'my-sites/sites';
 
 /**
@@ -134,12 +133,14 @@ function renderSelectedSiteIsDomainOnly( reactContext, selectedSite ) {
 }
 
 function isPathAllowedForDomainOnlySite( pathname, domainName ) {
-	const urlPrefixesWhiteListForDomainOnlySite = [
+	const urlWhiteListForDomainOnlySite = [
 		domainManagementList( domainName ),
-		'/checkout/',
+		domainManagementEdit( domainName ),
+		domainManagementDns( domainName ),
+		`/checkout/${ domainName }`,
 	];
 
-	return urlPrefixesWhiteListForDomainOnlySite.some( path => startsWith( pathname, path ) );
+	return urlWhiteListForDomainOnlySite.indexOf( pathname ) > -1;
 }
 
 function onSelectedSiteAvailable( context ) {

--- a/client/my-sites/upgrades/paths.js
+++ b/client/my-sites/upgrades/paths.js
@@ -13,6 +13,9 @@ function domainManagementList( siteName ) {
 }
 
 function domainManagementEdit( siteName, domainName, slug ) {
+	// the site slug and domain name are equivalent for domain-only sites,
+	// which can omit the latter in this case.
+	domainName = domainName || siteName;
 	slug = slug || 'edit';
 
 	// Encodes only real domain names and not parameter placeholders


### PR DESCRIPTION
For domain only site, certain features are disabled
instead of redirecting we should render a page
that explains that.

This replaces #10840

![screen shot 2017-02-01 at 14 11 45](https://cloud.githubusercontent.com/assets/326402/22506325/832954be-e888-11e6-8e43-02a7cd10382a.png)
  
#### Testing instructions
  
1. Run `git checkoutadd/fgate-domain-only-site` and start your server, or open a [live branch](https://calypso.live/?branch=add/fgate-domain-only-site)
2. Open some restricted page for a domain only site, for example click the 'Write Button' on the masterbar [`Post` page](http://calypso.localhost:3000/post/)
3. Check that you displayed with an empty content page that saying you need to upgrade as shown at the screenshot
  
#### Reviews
  
- [x] Code
- [x] Product
