### PR TITLE
Import: Enable Medium importer feature flags

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -32,6 +32,7 @@
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/export": true,
+		"manage/import/medium": true,
 		"manage/jetpack": true,
 		"manage/menus": true,
 		"manage/menus-jetpack": true,

--- a/config/test.json
+++ b/config/test.json
@@ -46,6 +46,7 @@
 		"manage/drafts": true,
 		"manage/edit-user": true,
 		"manage/export": true,
+		"manage/import/medium": true,
 		"manage/jetpack": true,
 		"manage/media": true,
 		"manage/menus": true,


### PR DESCRIPTION
Enabling Medium importer in `stage` and `test` environments in order to prepare it for internal testing. It is already enabled in `development` and `wpcalypso`.