### PR TITLE
Reader: use post.content when counting post characters

### DIFF
--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import { filter, flow } from 'lodash';
+import stripTags from 'striptags';
 
 /**
  * Internal Dependencies
@@ -42,11 +43,11 @@ export const
 	GALLERY_MIN_IMAGE_WIDTH = 350;
 
 function getCharacterCount( post ) {
-	if ( ! post || ! post.better_excerpt_no_html ) {
+	if ( ! post ) {
 		return 0;
 	}
 
-	return post.better_excerpt_no_html.length;
+	return stripTags( post.content ).length;
 }
 
 export function imageIsBigEnoughForGallery( image ) {


### PR DESCRIPTION
We currently use `post.better_excerpt` when counting the number of characters in a post. This causes problems when counting chars in poetry, because better excerpt only retains the first few paragraphs.

This PR uses `post.content` with HTML stripped to count characters instead.

Fixes #11062.

### To test

Check that all posts are correctly classified in 'Postcards from the Reader':

http://calypso.localhost:3000/read/blogs/122463145

Check that none of the posts on this feed are photo-only:

http://calypso.localhost:3000/read/feeds/55911728