### PR TITLE
Site Settings: Direct private sites to Calypso Customizer for site icon

### DIFF
--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -19,6 +19,7 @@ var notices = require( 'notices' ),
 	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
 	Actions = require( 'my-sites/customize/actions' ),
 	themeActivated = require( 'state/themes/actions' ).themeActivated;
+import { getCustomizerFocus } from './panels';
 
 var loadingTimer;
 
@@ -158,17 +159,9 @@ var Customize = React.createClass( {
 			query[ 'frame-nonce' ] = site.options.frame_nonce;
 		}
 
-		// autofocus panels
-		const panels = {
-			widgets: { panel: 'widgets' },
-			fonts: { section: 'jetpack_fonts' },
-			identity: { section: 'title_tagline' },
-			'custom-css': { section: 'jetpack_custom_css' },
-			amp: { section: 'amp_design' },
-		};
-
-		if ( panels.hasOwnProperty( panel ) ) {
-			query.autofocus = panels[ panel ];
+		const focus = getCustomizerFocus( panel );
+		if ( focus ) {
+			Object.assign( query, focus );
 		}
 
 		if ( panel === 'amp' ) {

--- a/client/my-sites/customize/panels.js
+++ b/client/my-sites/customize/panels.js
@@ -1,0 +1,29 @@
+/**
+ * Mapping from Calypso panel slug to tuple of focus key and value.
+ *
+ * @type {Object}
+ */
+export const PANEL_MAPPINGS = {
+	widgets: [ 'panel', 'widgets' ],
+	fonts: [ 'section', 'jetpack_fonts' ],
+	identity: [ 'section', 'title_tagline' ],
+	'custom-css': [ 'section', 'jetpack_custom_css' ],
+	amp: [ 'section', 'amp_design' ]
+};
+
+/**
+ * Given the name of a Calypso customizer panel, returns an object containing
+ * the section or panel to be used in autofocus. Returns null if the panel is
+ * not recognized.
+ *
+ * @param  {String}  panel Calypso panel slug
+ * @return {?Object}       WordPress autofocus argument object
+ */
+export function getCustomizerFocus( panel ) {
+	if ( PANEL_MAPPINGS.hasOwnProperty( panel ) ) {
+		const [ key, value ] = PANEL_MAPPINGS[ panel ];
+		return { [ `autofocus[${ key }]` ]: value };
+	}
+
+	return null;
+}

--- a/client/my-sites/customize/test/panels.js
+++ b/client/my-sites/customize/test/panels.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getCustomizerFocus } from '../panels';
+
+describe( 'panels', () => {
+	describe( 'getCustomizerFocus()', () => {
+		it( 'should return null if passed a falsey value', () => {
+			const arg = getCustomizerFocus();
+
+			expect( arg ).to.be.null;
+		} );
+
+		it( 'should return null if panel is not recognized', () => {
+			const arg = getCustomizerFocus( '__UNKNOWN' );
+
+			expect( arg ).to.be.null;
+		} );
+
+		it( 'should return object of recognized wordpress focus argument', () => {
+			const arg = getCustomizerFocus( 'identity' );
+
+			expect( arg ).to.eql( { 'autofocus[section]': 'title_tagline' } );
+		} );
+	} );
+} );

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -31,6 +31,7 @@ import createSelector from 'lib/create-selector';
 import { fromApi as seoTitleFromApi } from 'components/seo/meta-title-editor/mappings';
 import versionCompare from 'lib/version-compare';
 import getComputedAttributes from 'lib/site/computed-attributes';
+import { getCustomizerFocus } from 'my-sites/customize/panels';
 
 /**
  * Returns a raw site object by its ID.
@@ -959,16 +960,13 @@ export function getSiteAdminUrl( state, siteId, path = '' ) {
  *
  * @param  {Object} state  Global state tree
  * @param  {Number} siteId Site ID
+ * @param  {String} panel  Optional panel to autofocus
  * @return {String}        Customizer URL
  */
-export function getCustomizerUrl( state, siteId ) {
+export function getCustomizerUrl( state, siteId, panel ) {
 	if ( ! isJetpackSite( state, siteId ) ) {
 		const siteSlug = getSiteSlug( state, siteId );
-		if ( ! siteSlug ) {
-			return null;
-		}
-
-		return `/customize/${ siteSlug }`;
+		return [ '' ].concat( compact( [ 'customize', panel, siteSlug ] ) ).join( '/' );
 	}
 
 	const adminUrl = getSiteAdminUrl( state, siteId, 'customize.php' );
@@ -982,7 +980,8 @@ export function getCustomizerUrl( state, siteId ) {
 	}
 
 	return addQueryArgs( {
-		'return': returnUrl
+		'return': returnUrl,
+		...getCustomizerFocus( panel )
 	}, adminUrl );
 }
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -2226,14 +2226,14 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getCustomizerUrl()', () => {
-		it( 'should return null if slug for WordPress.com site is not known', () => {
+		it( 'should return root path if slug for WordPress.com site is not known', () => {
 			const customizerUrl = getCustomizerUrl( {
 				sites: {
 					items: {}
 				}
 			}, 77203199 );
 
-			expect( customizerUrl ).to.be.null;
+			expect( customizerUrl ).to.equal( '/customize' );
 		} );
 
 		it( 'should return customizer URL for WordPress.com site', () => {
@@ -2266,6 +2266,60 @@ describe( 'selectors', () => {
 			}, 77203199 );
 
 			expect( customizerUrl ).to.be.null;
+		} );
+
+		it( 'should return customizer URL for Jetpack site', () => {
+			const customizerUrl = getCustomizerUrl( {
+				sites: {
+					items: {
+						77203199: {
+							ID: 77203199,
+							URL: 'https://example.com',
+							jetpack: true,
+							options: {
+								admin_url: 'https://example.com/wp-admin/'
+							}
+						}
+					}
+				}
+			}, 77203199 );
+
+			expect( customizerUrl ).to.equal( 'https://example.com/wp-admin/customize.php' );
+		} );
+
+		it( 'should prepend panel path parameter for WordPress.com site', () => {
+			const customizerUrl = getCustomizerUrl( {
+				sites: {
+					items: {
+						77203199: {
+							ID: 77203199,
+							URL: 'https://example.com',
+							jetpack: false
+						}
+					}
+				}
+			}, 77203199, 'identity' );
+
+			expect( customizerUrl ).to.equal( '/customize/identity/example.com' );
+		} );
+
+		it( 'should prepend panel path parameter for Jetpack site', () => {
+			const customizerUrl = getCustomizerUrl( {
+				sites: {
+					items: {
+						77203199: {
+							ID: 77203199,
+							URL: 'https://example.com',
+							jetpack: true,
+							options: {
+								admin_url: 'https://example.com/wp-admin/'
+							}
+						}
+					}
+				}
+			}, 77203199, 'identity' );
+
+			expect( customizerUrl ).to.equal( 'https://example.com/wp-admin/customize.php?autofocus%5Bsection%5D=title_tagline' );
 		} );
 
 		context( 'browser', () => {


### PR DESCRIPTION
This pull request seeks to improve site icon flow for users on private sites. Because the image editor cannot support editing images for private sites, we're forced to direct these users through legacy flows. Currently, this means redirecting them to the wp-admin Settings > General screen which itself will soon direct users to the wp-admin Customizer. The changes here improve this experience by navigating users directly to the Calypso Customizer for managing site icon for their private site.

__Implementation notes:__

This refactors the Customizer logic to move logic for generating the autofocus parameter to a common reusable utility. In the process of doing so, I believe I discovered an issue where the autofocus parameter was likely not being generated correctly because it had previously attempted to stringify a nested query object, which does not work:

```
$ node
> require( 'querystring' ).stringify( { autofocus: { section: 'title_tagline' } } );
autofocus=
```

Newly added tests should confirm that the logic works correctly now by returning a flattened object, e.g. `{ 'autofocus[section]': 'title_tagline' }`

__Testing instructions:__

Verify that there are no regressions in behavior of Customize autofocus (Ben, can you lend some guidance here re: #5287)?

1. Navigate to [site settings](http://calypso.localhost:3000/settings)
2. Select a site
3. Note that upon clicking Change under Site Icon...
 - Non-private WordPress.com sites and Jetpack site with Photon enabled will launch media modal
 - Jetpack sites with Photon disabled will direct to the site's Customizer, autofocused to Site Identity
 - Private WordPress.com sites will direct to the Calypso Customizer, autofocused to Site Identity
 - Private WordPress.com sites _if `manage/site-settings/site-icon` disabled_, will direct to wp-admin Settings > General

__Caveats:__

This cannot be merged until the site icon field has been enabled in the Customizer.

__Follow-up Tasks:__

Move `getCustomizerUrl` selector to global selectors directory.