### PR TITLE
Build: Async load test helper and rubberband scroller

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -385,11 +385,15 @@ function reduxStoreReady( reduxStore ) {
 	}
 
 	if ( config.isEnabled( 'rubberband-scroll-disable' ) ) {
-		require( 'lib/rubberband-scroll-disable' )( document.body );
+		asyncRequire( 'lib/rubberband-scroll-disable', ( disableRubberbandScroll ) => {
+			disableRubberbandScroll( document.body );
+		} );
 	}
 
 	if ( config.isEnabled( 'dev/test-helper' ) && document.querySelector( '.environment.is-tests' ) ) {
-		require( 'lib/abtest/test-helper' )( document.querySelector( '.environment.is-tests' ) );
+		asyncRequire( 'lib/abtest/test-helper', ( testHelper ) => {
+			testHelper( document.querySelector( '.environment.is-tests' ) );
+		} );
 	}
 
 	/*


### PR DESCRIPTION
Cuts the size of the main build bundle a bit.

To test, enable both of these and verify they still work.