### PR TITLE
Framework: bump wpcom-xhr-request@1.1.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1492,7 +1492,7 @@
       "version": "2.1.1"
     },
     "fbjs": {
-      "version": "0.8.8",
+      "version": "0.8.9",
       "dependencies": {
         "core-js": {
           "version": "1.2.7"
@@ -4450,7 +4450,12 @@
       "version": "1.3.0"
     },
     "wpcom": {
-      "version": "5.3.0"
+      "version": "5.3.0",
+      "dependencies": {
+        "wpcom-xhr-request": {
+          "version": "1.0.0"
+        }
+      }
     },
     "wpcom-oauth": {
       "version": "0.3.3",
@@ -4487,7 +4492,7 @@
       "version": "3.0.0"
     },
     "wpcom-xhr-request": {
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     "wrap-ansi": {
       "version": "2.1.0"

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "wpcom": "5.3.0",
     "wpcom-oauth": "0.3.3",
     "wpcom-proxy-request": "3.0.0",
-    "wpcom-xhr-request": "1.0.0"
+    "wpcom-xhr-request": "1.1.0"
   },
   "engines": {
     "node": "6.9.4",


### PR DESCRIPTION
I've had problems trying to edit images using the desktop app. After doing some research we (actually was @youknowriad :+1 ) realized that we weren't handling uploading files using the `xhr` request handler.
Calypso web app uses by default the `proxy` handler, not in the desktop app. But both handlers are added into this repository.

In short, @youknowriad did [a PR into the wpcom-xhr-request repository](https://github.com/Automattic/wpcom-xhr-request/pull/26) which fixes the problem. We did a new release `@1.1.0` and now we are bumping it into calypso. These changes will be propagated to the desktop app to in this way fix the original issue.

### Testing

Pull this banch into wp-destop app. Run and test the whole app paying attention editing images. For instance, from the post editor -> media gallery