### PR TITLE
Enable API Cache setting in horizon and staging

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -24,6 +24,7 @@
 		"help/courses": true,
 		"jetpack/connect": true,
 		"jetpack/seo-tools": true,
+		"jetpack/api-cache": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
 		"manage/advanced-seo": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -25,7 +25,7 @@
 		"jetpack/connect": true,
 		"jetpack/personalPlan": true,
 		"jetpack/seo-tools": true,
-		"jetpack/api-cache": false,
+		"jetpack/api-cache": true,
 		"jetpack_core_inline_update": true,
 		"manage/advanced-seo": true,
 		"manage/advanced-seo/custom-title": true,


### PR DESCRIPTION
I want more A12s to get access to this feature so we can be sure it doesn't introduce brokenness.