### PR TITLE
Boosted Post Survey: Turning feature live

### DIFF
--- a/client/layout/guided-tours/config-elements/link-quit.js
+++ b/client/layout/guided-tours/config-elements/link-quit.js
@@ -3,6 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { translate } from 'i18n-calypso';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -33,7 +34,10 @@ export default class LinkQuit extends Component {
 
 	render() {
 		const { children, primary, subtle, href, target } = this.props;
-		const classes = subtle ? 'guided-tours__subtle-button' : '';
+		const classes = classNames( 'guided-tours__button-link', {
+			'guided-tours__subtle-button': subtle
+		} );
+
 		return (
 			<Button
 				className={ classes }

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -88,6 +88,9 @@
 	.button {
 		width: 48%;
 	}
+	.guided-tours__button-link {
+		text-align: center;
+	}
 	.button:nth-child(1) {
 		margin-right: 4%;
 	}

--- a/client/layout/guided-tours/tours/boosted-post-tour.js
+++ b/client/layout/guided-tours/tours/boosted-post-tour.js
@@ -19,6 +19,7 @@ import {
 import {
 	isAbTestInVariant,
 	isEnabled,
+	isSelectedSitePlanPaid,
 } from 'state/ui/guided-tours/contexts';
 import { isDesktop } from 'lib/viewport';
 
@@ -30,11 +31,24 @@ export const BoostedPostTour = makeTour(
 		when={ and(
 			isEnabled( 'boosted-post-survey' ),
 			isDesktop,
-			isAbTestInVariant( 'boostedPostSurvey', 'enabled' )
+			isSelectedSitePlanPaid,
+			isAbTestInVariant( 'boostedPostSurvey', 'enabled' ),
 		) }
 	>
 		<Step name="init" placement="right">
-			<p>{ translate( 'Wouldn\'t it be nice if your posts reached a wider audience?' ) }</p>
+			<p>
+				{
+					translate(
+						'{{strong}}Want to reach a bigger audience?{{/strong}} ' +
+							'Take our survey and help shape a new feature.',
+						{
+							components: {
+								strong: <strong />,
+							}
+						}
+					)
+				}
+			</p>
 			<ButtonRow>
 				<LinkQuit
 					primary

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -11,7 +11,10 @@ import {
 import { getLastAction } from 'state/ui/action-log/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { canCurrentUser } from 'state/selectors';
-import { hasDefaultSiteTitle } from 'state/sites/selectors';
+import {
+	hasDefaultSiteTitle,
+	isCurrentPlanPaid,
+} from 'state/sites/selectors';
 
 const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
 
@@ -130,6 +133,17 @@ export const isAbTestInVariant = ( testName, variant ) => () =>
 export const hasSelectedSiteDefaultSiteTitle = state => {
 	const siteId = getSelectedSiteId( state );
 	return siteId ? hasDefaultSiteTitle( state, siteId ) : false;
+};
+
+/**
+ * Returns true if the selected site has a paid plan
+ *
+ * @param {Object} state Global state tree
+ * @return {Boolean} True if selected site is on a paid plan, false otherwise.
+ */
+export const isSelectedSitePlanPaid = state => {
+	const siteId = getSelectedSiteId( state );
+	return siteId ? isCurrentPlanPaid( state, siteId ) : false;
 };
 
 /**

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -15,6 +15,7 @@
 	"features": {
 		"ad-tracking": false,
 		"apple-pay": false,
+		"boosted-post-survey": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,

--- a/config/production.json
+++ b/config/production.json
@@ -13,6 +13,7 @@
 	"features": {
 		"ad-tracking": true,
 		"apple-pay": true,
+		"boosted-post-survey": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -15,6 +15,7 @@
 	"features": {
 		"ad-tracking": false,
 		"apple-pay": true,
+		"boosted-post-survey": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,

--- a/config/test.json
+++ b/config/test.json
@@ -29,6 +29,7 @@
 	"features": {
 		"ad-tracking": false,
 		"apple-pay": true,
+		"boosted-post-survey": true,
 		"catch-js-errors": false,
 		"code-splitting": true,
 		"community-translator": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -16,6 +16,7 @@
 		"ad-tracking": false,
 		"automated-transfer": true,
 		"apple-pay": true,
+		"boosted-post-survey": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,


### PR DESCRIPTION
Simple PR to turn Boosted Post Survey live on other platforms.

Development PR: https://github.com/Automattic/wp-calypso/pull/10837

To test:
1. Enable `boostedPostSurvey` AB test via dev popup (or add ?tour=boostedPostSurvey to the end of the URL).
1. Go to one of your sites and view the posts.

<img width="1379" alt="screen shot 2017-02-01 at 11 40 04 am" src="https://cloud.githubusercontent.com/assets/273708/22523183/4984cfd2-e873-11e6-8a18-9f52cbc8e882.png">

**Survey Screens**
http://jonburke.polldaddy.com/s/boosted-post

<img width="688" alt="screen shot 2017-02-01 at 11 40 32 am" src="https://cloud.githubusercontent.com/assets/273708/22523193/52637cd4-e873-11e6-866b-e173bd688b3b.png">

<img width="705" alt="screen shot 2017-02-01 at 11 40 23 am" src="https://cloud.githubusercontent.com/assets/273708/22523199/55d6a698-e873-11e6-9603-ac9e51d41b23.png">
