### PR TITLE
Jetpack Connect: SSO: Fixes auto-auth after SSO login

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -9,6 +9,7 @@ import urlModule from 'url';
 import i18n from 'i18n-calypso';
 import Gridicon from 'gridicons';
 const debug = require( 'debug' )( 'calypso:jetpack-connect:authorize-form' );
+import cookie from 'cookie';
 
 /**
  * Internal dependencies
@@ -662,8 +663,15 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 	},
 
 	isSSO() {
-		const site = urlToSlug( this.props.jetpackConnectAuthorize.queryObject.site );
-		return !! ( this.props.jetpackSSOSessions && this.props.jetpackSSOSessions[ site ] );
+		const cookies = cookie.parse( document.cookie );
+		const query = this.props.jetpackConnectAuthorize.queryObject;
+		return (
+			query.from &&
+			'sso' === query.from &&
+			cookies.jetpack_sso_approved &&
+			query.client_id &&
+			query.client_id === cookies.jetpack_sso_approved
+		);
 	},
 
 	renderNoQueryArgsError() {

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -8,13 +8,13 @@ import debugModule from 'debug';
 import get from 'lodash/get';
 import map from 'lodash/map';
 import Gridicon from 'gridicons';
+import cookie from 'cookie';
 
 /**
  * Internal dependencies
  */
 import Main from 'components/main';
 import StepHeader from '../step-header';
-import observe from 'lib/mixins/data-observe';
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import Gravatar from 'components/gravatar';
@@ -45,8 +45,6 @@ const debug = debugModule( 'calypso:jetpack-connect:sso' );
 
 const JetpackSSOForm = React.createClass( {
 	displayName: 'JetpackSSOForm',
-
-	mixins: [ observe( 'userModule' ) ],
 
 	getInitialState() {
 		return {
@@ -80,6 +78,12 @@ const JetpackSSOForm = React.createClass( {
 
 		const { siteId, ssoNonce } = this.props;
 		const siteUrl = get( this.props, 'blogDetails.URL' );
+		const cookieOptions = {
+			maxAge: 300,
+			path: '/',
+		};
+		document.cookie = cookie.serialize( 'jetpack_sso_approved', siteId, cookieOptions );
+
 		debug( 'Approving sso' );
 		this.props.authorizeSSO( siteId, ssoNonce, siteUrl );
 	},

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -282,9 +282,9 @@ export function jetpackAuthAttempts( state = {}, action ) {
 export function jetpackSSO( state = {}, action ) {
 	switch ( action.type ) {
 		case JETPACK_CONNECT_SSO_VALIDATION_REQUEST:
-			return Object.assign( state, { isValidating: true } );
+			return Object.assign( {}, state, { isValidating: true } );
 		case JETPACK_CONNECT_SSO_VALIDATION_SUCCESS:
-			return Object. assign( state, {
+			return Object. assign( {}, state, {
 				isValidating: false,
 				validationError: false,
 				nonceValid: action.success,
@@ -292,28 +292,16 @@ export function jetpackSSO( state = {}, action ) {
 				sharedDetails: action.sharedDetails
 			} );
 		case JETPACK_CONNECT_SSO_VALIDATION_ERROR:
-			return Object. assign( state, { isValidating: false, validationError: action.error, nonceValid: false } );
+			return Object.assign( {}, state, { isValidating: false, validationError: action.error, nonceValid: false } );
 		case JETPACK_CONNECT_SSO_AUTHORIZE_REQUEST:
-			return Object.assign( state, { isAuthorizing: true } );
+			return Object.assign( {}, state, { isAuthorizing: true } );
 		case JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS:
-			return Object. assign( state, { isAuthorizing: false, authorizationError: false, ssoUrl: action.ssoUrl } );
+			return Object.assign( {}, state, { isAuthorizing: false, authorizationError: false, ssoUrl: action.ssoUrl } );
 		case JETPACK_CONNECT_SSO_AUTHORIZE_ERROR:
-			return Object. assign( state, { isAuthorizing: false, authorizationError: action.error, ssoUrl: false } );
+			return Object.assign( {}, state, { isAuthorizing: false, authorizationError: action.error, ssoUrl: false } );
 		case SERIALIZE:
 		case DESERIALIZE:
 			return {};
-	}
-	return state;
-}
-
-export function jetpackSSOSessions( state = {}, action ) {
-	switch ( action.type ) {
-		case JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS:
-			return Object.assign( {}, state, buildUrlSessionObj( action.siteUrl ) );
-		case SERIALIZE:
-			return state;
-		case DESERIALIZE:
-			return ! isStale( state.timestamp ) ? state : {};
 	}
 	return state;
 }
@@ -336,7 +324,6 @@ export function jetpackConnectSelectedPlans( state = {}, action ) {
 
 export default combineReducers( {
 	jetpackConnectSite,
-	jetpackSSOSessions,
 	jetpackSSO,
 	jetpackConnectAuthorize,
 	jetpackConnectSessions,

--- a/client/state/jetpack-connect/test/reducer.js
+++ b/client/state/jetpack-connect/test/reducer.js
@@ -40,7 +40,6 @@ import {
 import reducer, {
 	jetpackConnectAuthorize,
 	jetpackSSO,
-	jetpackSSOSessions,
 	jetpackConnectSessions,
 	jetpackConnectSite,
 	jetpackAuthAttempts
@@ -86,7 +85,6 @@ describe( 'reducer', () => {
 			'jetpackConnectAuthorize',
 			'jetpackConnectSessions',
 			'jetpackSSO',
-			'jetpackSSOSessions',
 			'jetpackConnectSelectedPlans',
 			'jetpackAuthAttempts'
 		] );
@@ -334,76 +332,6 @@ describe( 'reducer', () => {
 				url: 'https://example.wordpress.com'
 			} );
 			const state = jetpackConnectSite( originalState, {
-				type: DESERIALIZE
-			} );
-
-			expect( state ).to.be.eql( {} );
-		} );
-	} );
-
-	describe( '#jetpackSSOSessions()', () => {
-		it( 'should default to an empty object', () => {
-			const state = jetpackSSOSessions( undefined, {} );
-			expect( state ).to.eql( {} );
-		} );
-
-		it( 'should store an integer timestamp when creating new session', () => {
-			const nowTime = Date.now();
-			const state = jetpackSSOSessions( undefined, {
-				type: JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS,
-				ssoUrl: 'https://example.wordpress.com?action=jetpack-sso&result=success&sso_nonce={$nonce}&user_id={$user_id}',
-				siteUrl: 'https://example.wordpress.com'
-			} );
-
-			expect( state ).to.have.property( 'example.wordpress.com' )
-				.to.be.a( 'object' );
-			expect( state[ 'example.wordpress.com' ] ).to.have.property( 'timestamp' )
-				.to.be.at.least( nowTime );
-		} );
-
-		it( 'should convert forward slashes to double colon when creating a new session', () => {
-			const state = jetpackSSOSessions( undefined, {
-				type: JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS,
-				ssoUrl: 'https://example.wordpress.com/example123?action=jetpack-sso&result=success&sso_nonce={$nonce}&user_id={$user_id}',
-				siteUrl: 'https://example.wordpress.com/example123'
-			} );
-
-			expect( state ).to.have.property( 'example.wordpress.com::example123' )
-				.to.be.a( 'object' );
-		} );
-
-		it( 'should persist state', () => {
-			const originalState = deepFreeze( {
-				ssoUrl: 'https://example.wordpress.com?action=jetpack-sso&result=success&sso_nonce={$nonce}&user_id={$user_id}',
-				siteUrl: 'https://example.wordpress.com'
-			} );
-			const state = jetpackSSOSessions( originalState, {
-				type: SERIALIZE
-			} );
-
-			expect( state ).to.be.eql( originalState );
-		} );
-
-		it( 'should load valid persisted state', () => {
-			const originalState = deepFreeze( {
-				ssoUrl: 'https://example.wordpress.com?action=jetpack-sso&result=success&sso_nonce={$nonce}&user_id={$user_id}',
-				siteUrl: 'https://example.wordpress.com',
-				timestamp: Date.now()
-			} );
-			const state = jetpackSSOSessions( originalState, {
-				type: DESERIALIZE
-			} );
-
-			expect( state ).to.be.eql( originalState );
-		} );
-
-		it( 'should not load stale state', () => {
-			const originalState = deepFreeze( {
-				ssoUrl: 'https://example.wordpress.com?action=jetpack-sso&result=success&sso_nonce={$nonce}&user_id={$user_id}',
-				siteUrl: 'https://example.wordpress.com',
-				timestamp: 1
-			} );
-			const state = jetpackSSOSessions( originalState, {
 				type: DESERIALIZE
 			} );
 


### PR DESCRIPTION
During JPPHP testing, @gravityrail and I noticed that the auto-auth flow was broken after SSO.

I'm marking this as high because it's currently a horrible flow for our JPPHP users as well as any non-connected user trying to login with SSO.

After some digging today, I noticed a few things:

1) The root cause seemed to be that the `JetpackSSOSessions` state wasn't being persisted after approving SSO and being redirected. I was able to fix this by moving from the `JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS` action to the `JETPACK_CONNECT_SSO_AUTHORIZE_REQUEST` action. Doing this before the API request came back seems to give it enough time to save properly.

2) Once I did that though, I noticed that the SSO component wasn't re-rendering. :tableflip: After some more digging, I was able to figure out that this was because I was mutating the original state object instead of returning a new state object. So, now all of the actions in `jetpackSSO` get a new state object. "You get a fresh object. You get a fresh object. etc."

**Update**: After even more testing, it seems that relying on redux at all is not the way to go. From what I could tell, we persist changes to state every minute, so it's not a real-time thing. Therefore, since we redirect right after we get data, we need to find some other way to store that the user clicked the button. To do this, I decided to use a cookie.

To test:

- Checkout branch
- Log in to a test WP.com account. Ensure there is a user on the Jetpack site with a matching email to the WP.com account, and make sure that the Jetpack user is not connected to a WP.com user.
- Now, go to `$site.com/wp-admin`and click the "Log in with WordPress.com" button.
- You should land on a fancy Calypso page
- Click "Approve"
- You should see a refresh of sorts, land back on a Calypso page, and then be redirected to the `wp-admin` of `$site`.
