### PR TITLE
AT: redirect themes to design after transfer

### DIFF
--- a/client/state/automated-transfer/middleware.js
+++ b/client/state/automated-transfer/middleware.js
@@ -11,8 +11,12 @@ import {
 const clearBrowserStorageAndRefresh = ( dispatch, { status } ) => {
 	if ( typeof window !== 'undefined' && status === 'complete' ) {
 		localStorage.clear();
-		const reloadPage = window.location.reload.bind( window.location );
-		localforage.clear().then( reloadPage, reloadPage );
+		const isThemeUpload = window.location.pathname.indexOf( '/design/upload' ) === 0;
+		const destination = isThemeUpload
+			? window.location.pathname.split( '/upload' ).join( '' )
+			: window.location.pathname;
+		const goToDestination = () => window.location.href = destination;
+		localforage.clear().then( goToDestination, goToDestination );
 	}
 };
 


### PR DESCRIPTION
Follow up to #10986 Changes here will redirect you to /design/:site: if a transfer completed on the themes upload page.

### Testing Instructions:

To simulate a transfer:
- Checkout locally
- Navigate to theme uploads
- Type into console:
```javascript
dispatch( { type: 'AUTOMATED_TRANSFER_STATUS_SET', siteId: <your-site-id>, status: 'start' } )
```

- Note that we should see no-op actions firing from the redux debug tab
<img width="1299" alt="screen shot 2017-01-26 at 4 17 48 pm" src="https://cloud.githubusercontent.com/assets/1270189/22356037/3bfe181c-e3e3-11e6-94ed-3e988aacfd66.png">

- Type into console
```javascript
dispatch( { type: 'AUTOMATED_TRANSFER_STATUS_SET', siteId: <your-site-id>, status: 'complete' } )
```
- Page should redirect to /design/:siteid:
- Repeating this flow on plugins install, should just refresh the current page.