### PR TITLE
Media: Fix collpased preview in media modal on small screens

### DIFF
--- a/client/post-editor/media-modal/detail/_style.scss
+++ b/client/post-editor/media-modal/detail/_style.scss
@@ -34,13 +34,14 @@
 }
 
 .editor-media-modal-detail__preview-wrapper {
-	flex: 2 0 0%;
+	flex: 0 0 35%;
 	position: relative;
 	border-bottom: 1px solid lighten( $gray, 20% );
 	background-color: $gray-light;
 	box-shadow: inset 0 0 2px 2px rgba( lighten( $gray, 10 ), 0.1 );
 
 	@include breakpoint( ">660px" ) {
+		flex: 2 0 0%;
 		margin: 0 0 16px 24px;
 		border: 0;
 	}


### PR DESCRIPTION
This PR gives default height for the wrapper to avoid it from collapsing on small screens. Fixes #10859

Tested with Chrome, Safari, and Firefox in iOS and Android.

![screen-shot-2017-02-01-at-23 10 15](https://cloud.githubusercontent.com/assets/908665/22530878/be6b91b6-e8d5-11e6-84e5-91faf82192e4.jpg)
