### PR TITLE
Stats: Move to 3 column layout on period pages.

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -143,12 +143,13 @@ class StatsSite extends Component {
 								statType="statsTopPosts"
 								showSummaryLink />
 							<StatsModule
-								path="referrers"
-								moduleStrings={ moduleStrings.referrers }
+								path="searchterms"
+								moduleStrings={ moduleStrings.search }
 								period={ this.props.period }
 								query={ query }
-								statType="statsReferrers"
+								statType="statsSearchTerms"
 								showSummaryLink />
+							{ videoList }
 						</div>
 						<div className="stats__module-column">
 							<Countries
@@ -157,14 +158,21 @@ class StatsSite extends Component {
 								query={ query }
 								summary={ false } />
 							<StatsModule
-								path="searchterms"
-								moduleStrings={ moduleStrings.search }
+								path="clicks"
+								moduleStrings={ moduleStrings.clicks }
 								period={ this.props.period }
 								query={ query }
-								statType="statsSearchTerms"
+								statType="statsClicks"
 								showSummaryLink />
 						</div>
 						<div className="stats__module-column">
+							<StatsModule
+								path="referrers"
+								moduleStrings={ moduleStrings.referrers }
+								period={ this.props.period }
+								query={ query }
+								statType="statsReferrers"
+								showSummaryLink />
 							<StatsModule
 								path="authors"
 								moduleStrings={ moduleStrings.authors }
@@ -173,14 +181,6 @@ class StatsSite extends Component {
 								statType="statsTopAuthors"
 								className="stats__author-views"
 								showSummaryLink />
-							<StatsModule
-								path="clicks"
-								moduleStrings={ moduleStrings.clicks }
-								period={ this.props.period }
-								query={ query }
-								statType="statsClicks"
-								showSummaryLink />
-							{ videoList }
 							{ podcastList }
 						</div>
 					</div>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -149,21 +149,6 @@ class StatsSite extends Component {
 								query={ query }
 								statType="statsReferrers"
 								showSummaryLink />
-							<StatsModule
-								path="clicks"
-								moduleStrings={ moduleStrings.clicks }
-								period={ this.props.period }
-								query={ query }
-								statType="statsClicks"
-								showSummaryLink />
-							<StatsModule
-								path="authors"
-								moduleStrings={ moduleStrings.authors }
-								period={ this.props.period }
-								query={ query }
-								statType="statsTopAuthors"
-								className="stats__author-views"
-								showSummaryLink />
 						</div>
 						<div className="stats__module-column">
 							<Countries
@@ -177,6 +162,23 @@ class StatsSite extends Component {
 								period={ this.props.period }
 								query={ query }
 								statType="statsSearchTerms"
+								showSummaryLink />
+						</div>
+						<div className="stats__module-column">
+							<StatsModule
+								path="authors"
+								moduleStrings={ moduleStrings.authors }
+								period={ this.props.period }
+								query={ query }
+								statType="statsTopAuthors"
+								className="stats__author-views"
+								showSummaryLink />
+							<StatsModule
+								path="clicks"
+								moduleStrings={ moduleStrings.clicks }
+								period={ this.props.period }
+								query={ query }
+								statType="statsClicks"
 								showSummaryLink />
 							{ videoList }
 							{ podcastList }

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -58,19 +58,21 @@ const StatsInsights = ( props ) => {
 					<div className="stats__module-list">
 						<div className="stats__module-column">
 							<LatestPostSummary />
-							<AllTime />
-							<Comments
-								path={ 'comments' }
-								followList={ followList }
-							/>
+							<MostPopular />
+							{ tagsList }
 						</div>
 						<div className="stats__module-column">
 							<Reach />
 							<Followers
 								path={ 'followers' }
 								followList={ followList } />
-							<MostPopular />
-							{ tagsList }
+						</div>
+						<div className="stats__module-column">
+							<AllTime />
+							<Comments
+								path={ 'comments' }
+								followList={ followList }
+							/>
 							<StatsModule
 								path="publicize"
 								moduleStrings={ moduleStrings.publicize }

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -112,6 +112,7 @@
 // Module Content List Item Hover
 
 @include breakpoint( ">480px" ) {
+	.module-content-list .module-content-list-item-wrapper:hover,
 	.module-content-list-item-link .module-content-list-item-wrapper:hover {
 
 		&,
@@ -126,6 +127,17 @@
 		// Display hidden actions
 		.module-content-list-item-action-hidden {
 			display: inline-block;
+		}
+	}
+
+	// Don't show hover on legend row
+	.module-content-list.module-content-list-legend {
+		.module-content-list-item-wrapper:hover {
+			&,
+			.module-content-list-item-right,
+			.module-content-list-item-right::before {
+				background: none;
+			}
 		}
 	}
 }

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -25,7 +25,7 @@
 
 .card.stats-module {
 	padding: 0;
-	margin-bottom: 16px;
+	margin-bottom: 10px;
 }
 // Site sections
 .stats__module-list {

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -1,14 +1,28 @@
 
 // Module container
-
 @include breakpoint( ">960px" ) {
 	.stats__module-column {
 		float: left;
-		width: 48.8%;
-		width: calc(50% - 0.5em);
+		width: calc(50% - 4px);
+
+		&:nth-child(2) {
+			float: right;
+		}
+	}
+}
+
+@include breakpoint( ">1040px" ) {
+	.stats__module-column {
+		float: right;
+		width: calc(33% - 3px);
+
+		&:first-child {
+			float: left;
+		}
 
 		&:last-child {
-			float: right;
+			left: -10px;
+			position: relative;
 		}
 	}
 }

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -2,25 +2,25 @@
 // Module container
 @include breakpoint( ">960px" ) {
 	.stats__module-column {
-		float: left;
-		width: calc(50% - 4px);
-
-		&:nth-child(2) {
-			float: right;
-		}
-	}
-}
-
-@include breakpoint( ">1040px" ) {
-	.stats__module-column {
 		float: right;
-		width: calc(33% - 3px);
+		width: calc(50% - 4px);
 
 		&:first-child {
 			float: left;
 		}
 
 		&:last-child {
+			clear: right;
+		}
+	}
+}
+
+@include breakpoint( ">1280px" ) {
+	.stats__module-column {
+		width: calc(33% - 3px);
+
+		&:last-child {
+			clear: none;
 			left: -10px;
 			position: relative;
 		}


### PR DESCRIPTION
This branch closes #11094

This branch adds logic to support 3 columns on stats period pages ( Day, Week, Month, Year )

<img width="935" alt="stats_ _fly_fishers_place_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/22534662/5b6a8dea-e8aa-11e6-8bf5-188375f8a5b8.png">

I explored a few different pure flexbox solutions, but due to the varying heights of the stats modules ( because of data / lack of data ) this proved to be a difficult path to take.  I do welcome any others who are more flex-box gifted than I to experiment further though!

The `site.jsx` diff looks confusing, but essentially I have moved the modules into 3 different `.stats__module-column`s.  I wanted to make sure the Countries and Post & Page modules were still shown at the top in both 2 and 3 column views.

I also experimented with bumping the `<Main />` `max-width` to `1280px` and the 3 column layout looked great at this resolution too.  Insights page though really needs to be updated before we bump all of stats up to 1280.

The other minor change was I added the hover state to all rows in stat modules.  Rows without a primary action ( like in Countries ) did not have a hover state.

/cc @folletto 

I have tested this only in Chrome and the chrome device emulator - I need to spend some time with this branch on some devices and other browsers too.