### PR TITLE
Add windows zip mime type to theme upload check.

### DIFF
--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -140,10 +140,10 @@ class Upload extends React.Component {
 		// DropZone supplies an array, FilePicker supplies a FileList
 		const file = files[ 0 ] || files.item( 0 );
 
-		const validFileTyle = file.type === 'application/zip' || file.type === 'application/x-zip-compressed';
+		const validFileType = file.type === 'application/zip' || file.type === 'application/x-zip-compressed';
 		debug( 'file mime: ', file.type );
 
-		if ( ! validFileTyle ) {
+		if ( ! validFileType ) {
 			notices.error( errorMessage );
 			return;
 		}

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -139,7 +139,11 @@ class Upload extends React.Component {
 
 		// DropZone supplies an array, FilePicker supplies a FileList
 		const file = files[ 0 ] || files.item( 0 );
-		if ( file.type !== 'application/zip' ) {
+
+		const validFileTyle = file.type === 'application/zip' || file.type === 'application/x-zip-compressed';
+		debug( 'file mime', file.type );
+
+		if ( ! validFileTyle ) {
 			notices.error( errorMessage );
 			return;
 		}

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -141,7 +141,7 @@ class Upload extends React.Component {
 		const file = files[ 0 ] || files.item( 0 );
 
 		const validFileTyle = file.type === 'application/zip' || file.type === 'application/x-zip-compressed';
-		debug( 'file mime', file.type );
+		debug( 'file mime: ', file.type );
 
 		if ( ! validFileTyle ) {
 			notices.error( errorMessage );


### PR DESCRIPTION
### Info
When uploading theme mime type of file is detected and checked if this is a zip.
On nix machines zip is detected as `application/zip`. On Windows it is detected as `application/x-zip-compressed` and this PR ads this type to valid mime types.

fixes #11060 

### Testing
Verify that #11060 scenario now works.

@hoverduck could you please verify that this fixes error you have found?
