### PR TITLE
Import: consolidate translate strings by removing context

### DIFF
--- a/client/my-sites/importer/importer-header.jsx
+++ b/client/my-sites/importer/importer-header.jsx
@@ -79,7 +79,7 @@ export const ImporterHeader = React.createClass( {
 		}
 
 		if ( includes( stopStates, importerState ) ) {
-			return this.translate( 'Importing...', { context: 'verb' } );
+			return this.translate( 'Importing...' );
 		}
 
 		if ( includes( doneStates, importerState ) ) {


### PR DESCRIPTION
Removing context from importing translation in order to take advantage of existing one.