### PR TITLE
Site Settings: Darken text of form setting explanation

### DIFF
--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -68,7 +68,7 @@
 		font-size: 13px;
 		font-style: italic;
 		font-weight: 400;
-		color: $gray;
+		color: $gray-dark;
 		&.is-indented {
 			margin-left: 24px;
 		}

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -68,7 +68,7 @@
 		font-size: 13px;
 		font-style: italic;
 		font-weight: 400;
-		color: $gray-dark;
+		color: $gray-text;
 		&.is-indented {
 			margin-left: 24px;
 		}


### PR DESCRIPTION
This PR darkens the text of form setting explanations globally within site settings - as originally suggested by @MichaelArestad here: https://github.com/Automattic/wp-calypso/pull/11096#issuecomment-276699019. It will affect several settings cards that use `p.form-setting-explanation` within them.

Before:
![](https://cldup.com/nUfHTayZ90.png)

After:
![](https://cldup.com/umpKoL-GM5.png)