### PR TITLE
Stats: Reduxify the Video Stats Page completely

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -19,7 +19,6 @@ import { renderWithReduxStore } from 'lib/react-helpers';
 import { savePreference } from 'state/preferences/actions';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
-import Emitter from 'lib/mixins/emitter';
 import AsyncLoad from 'components/async-load';
 import StatsPagePlaceholder from 'my-sites/stats/stats-page-placeholder';
 const user = userFactory();
@@ -289,27 +288,21 @@ module.exports = {
 		let siteId = context.params.site_id;
 		const siteFragment = route.getSiteFragment( context.path );
 		const queryOptions = context.query;
-		const StatsList = require( 'lib/stats/stats-list' );
-		const filters = function( contextModule, _siteId ) {
-			return [
-				{ title: i18n.translate( 'Days' ), path: '/stats/' + contextModule + '/' + _siteId,
-					altPaths: [ '/stats/day/' + contextModule + '/' + _siteId ], id: 'stats-day',
-						period: 'day', back: '/stats/' + _siteId },
-				{ title: i18n.translate( 'Weeks' ), path: '/stats/week/' + contextModule + '/' + _siteId,
-					id: 'stats-week', period: 'week', back: '/stats/week/' + _siteId },
-				{ title: i18n.translate( 'Months' ), path: '/stats/month/' + contextModule + '/' + _siteId,
-					id: 'stats-month', period: 'month', back: '/stats/month/' + _siteId },
-				{ title: i18n.translate( 'Years' ), path: '/stats/year/' + contextModule + '/' + _siteId,
-					id: 'stats-year', period: 'year', back: '/stats/year/' + _siteId }
-			];
-		}.bind( null, context.params.module, siteId );
+		const contextModule = context.params.module;
+		const filters = [
+			{ path: '/stats/' + contextModule + '/' + siteId,
+				altPaths: [ '/stats/day/' + contextModule + '/' + siteId ], id: 'stats-day',
+				period: 'day' },
+			{ path: '/stats/week/' + contextModule + '/' + siteId, id: 'stats-week', period: 'week' },
+			{ path: '/stats/month/' + contextModule + '/' + siteId, id: 'stats-month', period: 'month' },
+			{ path: '/stats/year/' + contextModule + '/' + siteId, id: 'stats-year', period: 'year' }
+		];
 		let date;
-		let endDate;
 		let period;
-		let summaryList;
-		let visitsList;
 
-		const validModules = [ 'posts', 'referrers', 'clicks', 'countryviews', 'authors', 'videoplays', 'videodetails', 'podcastdownloads', 'searchterms' ];
+		const validModules = [
+			'posts', 'referrers', 'clicks', 'countryviews', 'authors', 'videoplays', 'videodetails', 'podcastdownloads', 'searchterms'
+		];
 		let momentSiteZone = i18n.moment();
 		const basePath = route.sectionify( context.path );
 
@@ -319,7 +312,7 @@ module.exports = {
 		}
 		siteId = site ? ( site.ID || 0 ) : 0;
 
-		const activeFilter = find( filters(), ( filter ) => {
+		const activeFilter = find( filters, ( filter ) => {
 			return context.pathname === filter.path || ( filter.altPaths && -1 !== filter.altPaths.indexOf( context.pathname ) );
 		} );
 
@@ -345,15 +338,8 @@ module.exports = {
 				date = momentSiteZone.endOf( activeFilter.period );
 			}
 			period = rangeOfPeriod( activeFilter.period, date );
-			endDate = period.endOf.format( 'YYYY-MM-DD' );
 
-			const siteDomain = ( site && ( typeof site.slug !== 'undefined' ) )
-				? site.slug : siteFragment;
-			let extraProps = {};
-
-			// When old list summaries are transitioned to redux, we need a "fake" emitter
-			// TODO when all lists are moved to redux, remove this logic
-			const fakeStatsList = Emitter( {} );
+			const extraProps = context.params.module === 'videodetails' ? { postId: parseInt( queryOptions.post, 10 ) } : {};
 
 			let statsQueryOptions = {};
 
@@ -363,47 +349,6 @@ module.exports = {
 				statsQueryOptions.period = 'day';
 			}
 
-			switch ( context.params.module ) {
-
-				case 'posts':
-					summaryList = fakeStatsList;
-					break;
-
-				case 'referrers':
-					summaryList = fakeStatsList;
-					break;
-
-				case 'clicks':
-					summaryList = fakeStatsList;
-					break;
-
-				case 'countryviews':
-					summaryList = fakeStatsList;
-					break;
-
-				case 'authors':
-					summaryList = fakeStatsList;
-					break;
-
-				case 'videoplays':
-					summaryList = fakeStatsList;
-					break;
-
-				case 'videodetails':
-					summaryList = new StatsList( { statType: 'statsVideo', post: queryOptions.post,
-						siteID: siteId, period: activeFilter.period, date: endDate, max: 0, domain: siteDomain } );
-					extraProps = { postId: queryOptions.post };
-					break;
-
-				case 'searchterms':
-					summaryList = fakeStatsList;
-					break;
-
-				case 'podcastdownloads':
-					summaryList = fakeStatsList;
-					break;
-			}
-
 			analytics.pageView.record(
 				basePath,
 				analyticsPageTitle + ' > ' + titlecase( activeFilter.period ) + ' > ' + titlecase( context.params.module )
@@ -411,15 +356,10 @@ module.exports = {
 
 			const props = {
 				path: context.pathname,
-				sites,
 				statsQueryOptions,
 				date,
 				context,
 				period,
-				siteId,
-				filters,
-				visitsList,
-				summaryList,
 				...extraProps
 			};
 			renderWithReduxStore(

--- a/client/my-sites/stats/geochart/README.md
+++ b/client/my-sites/stats/geochart/README.md
@@ -1,20 +1,19 @@
 Stats Geochart
-================
+==============
 This component creates the geochart used in the Countries module.  It utilizes the [geo chart](https://developers.google.com/chart/interactive/docs/gallery/geochart) provided by Google.
 
 #### How to use:
 
 ```js
-var GeoChart = require( 'my-sites/stats/geochart' );
+import GeoChart from 'my-sites/stats/geochart';
 
-render: function() {
+const MyComponent = () => {
     return (
-  		<GeoChart data={ <Array> } dataList={ <StatsList Object> } />
+  		<GeoChart query={ <Object> } />
     );
-}
+};
 ```
 
 #### Required Props
 
-* `data`: An array of country data using the format [specified](https://developers.google.com/chart/interactive/docs/gallery/geochart#Data_Format) by the Google geo chart
-* `dataList`: Is an instance of a StatsList that would likely hold a repsonse from the /site/<siteID>/stats/country-views endpoint
+* `query`: A query object used as a prop for `QuerySiteStats` component

--- a/client/my-sites/stats/post-trends/README.md
+++ b/client/my-sites/stats/post-trends/README.md
@@ -5,15 +5,11 @@ This module provides a React component to visualize frequency of posting in a Gi
 #### How to use:
 
 ```js
-var PostTrends = require( 'post-trends' );
+import PostTrends from 'my-sites/stats/post-trends';
 
-render: function() {
+const MyComponent = () => {
     return (
-  		<PostTrends streakList={ streakList } />
+  		<PostTrends />
     );
-}
+};
 ```
-
-#### Required Props
-
-* `streakList`: A `StatsList` object containing the parsed response to the streak api.

--- a/client/my-sites/stats/stats-download-csv/README.md
+++ b/client/my-sites/stats/stats-download-csv/README.md
@@ -1,22 +1,22 @@
 Download CSV
-================
+============
 The download csv component creates a download link that allows a stats-list to be exported as a csv file.  [browser-filesaver](https://github.com/tmpvar/browser-filesaver) performs the HTML5 file saving operations behind the scenes
 
 #### How to use:
 
 ```js
-var DownloadCsv = require( 'my-sites/stats/download-csv' );
+import DownloadCsv from 'my-sites/stats/download-csv';
 
-render: function() {
+const MyComponent = () => {
     return (
-		<DownloadCsv period={ <period Object> } path={ <path String> } site={ <site Object> } dataList={ <dataList Object> } />;
+			<DownloadCsv statType={ <statType String> } query={ <query Object> } path={ <path String> } period={ <period Object> } />;
     );
-}
+};
 ```
 
 #### Required Props
 
 * `period`: The period object is set by the stats controller and contains the type of period, and start/end date range that helps output a pretty file name for the CSV export
 * `path`: The path is the stats summary section being used.  Used for the csv file name along with recording the event in analytics.
-* `site`: The Site instance
-* `dataList`: Is an instance of a StatsList containing the data to be exported
+* `statType`: The statType to download
+* `query`: A query object used to request the stats data

--- a/client/my-sites/stats/stats-site-overview/README.md
+++ b/client/my-sites/stats/stats-site-overview/README.md
@@ -6,11 +6,11 @@ This component creates Stats Overview which is what renders each site section on
 #### How to use:
 
 ```js
-var StatsOverview = require( 'my-sites/stats/overview' );
+import StatsOverview from 'my-sites/stats/overview';
 
-render: function() {
+const MyComponent = () => {
     return (
-  		<StatsOverview site={ <Object> } summaryData={ <StatsList Object> path={ <String> } } />
+  		<StatsOverview site={ <Object> } path={ <String> } } />
     );
 }
 ```
@@ -18,5 +18,4 @@ render: function() {
 #### Required Props
 
 * `site`: A Site Object
-* `summaryData`: Is an instance of a StatsList that would hold a repsonse from the /site/<siteID>/stats/visits endpoint
 * `path`: String used to build out the various links to the site

--- a/client/my-sites/stats/stats-video-details/index.jsx
+++ b/client/my-sites/stats/stats-video-details/index.jsx
@@ -3,6 +3,8 @@
  */
 import React from 'react';
 import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -12,33 +14,49 @@ import StatsListLegend from '../stats-list/legend';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatsModuleHeader from '../stats-module/header';
 import Card from 'components/card';
+import QuerySiteStats from 'components/data/query-site-stats';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import {
+	isRequestingSiteStatsForQuery,
+	getSiteStatsNormalizedData
+} from 'state/stats/lists/selectors';
 
-export default React.createClass( {
-	displayName: 'StatModuleVideoDetails',
+const StatModuleVideoDetails = ( props ) => {
+	const { data, query, requesting, siteId, translate } = props;
+	const isLoading = requesting && ! data;
 
-	render: function() {
-		const isLoading = this.props.summaryList.isLoading();
+	const classes = classNames(
+		'stats-module',
+		'is-expanded',
+		'summary',
+		{
+			'is-loading': isLoading,
+			'has-no-data': ! data
+		}
+	);
 
-		const classes = classNames(
-			'stats-module',
-			'is-expanded',
-			'summary',
-			{
-				'is-loading': isLoading,
-				'has-no-data': this.props.summaryList.isEmpty()
-			}
-		);
+	return (
+		<Card className={ classes }>
+			{ siteId && <QuerySiteStats statType="statsVideo" siteId={ siteId } query={ query } /> }
+			<StatsModuleHeader title={ translate( 'Video Embeds' ) } showActions={ false } />
+			<StatsListLegend label={ translate( 'Page' ) } />
+			<StatsModulePlaceholder isLoading={ isLoading } />
+			<StatsList
+				moduleName="Video Details"
+				data={ data ? data.pages : [] }
+			/>
+		</Card>
+	);
+};
 
-		return (
-			<Card className={ classes }>
-				<StatsModuleHeader title={ this.translate( 'Video Embeds' ) } showActions={ false } />
-				<StatsListLegend label={ this.translate( 'Page' ) } />
-				<StatsModulePlaceholder isLoading={ isLoading } />
-				<StatsList
-					moduleName="Video Details"
-					data={ this.props.summaryList.response.pages ? this.props.summaryList.response.pages : [] }
-				/>
-			</Card>
-		);
-	}
-} );
+export default connect( ( state, {  postId } ) => {
+	const siteId = getSelectedSiteId( state );
+	const query = { postId };
+
+	return {
+		requesting: isRequestingSiteStatsForQuery( state, siteId, 'statsVideo', query ),
+		data: getSiteStatsNormalizedData( state, siteId, 'statsVideo', query ),
+		query,
+		siteId
+	};
+} )( localize( StatModuleVideoDetails ) );

--- a/client/my-sites/stats/stats-video-summary/index.jsx
+++ b/client/my-sites/stats/stats-video-summary/index.jsx
@@ -19,7 +19,7 @@ class StatsVideoSummary extends Component {
 		query: PropTypes.object,
 		isRequesting: PropTypes.bool,
 		siteId: PropTypes.number,
-		summaryData: PropTypes.array,
+		summaryData: PropTypes.object,
 	}
 
 	state = {
@@ -34,12 +34,12 @@ class StatsVideoSummary extends Component {
 
 	render() {
 		const { query, isRequesting, moment, siteId, summaryData, translate } = this.props;
-		const data = summaryData.map( item => {
+		const data = summaryData && summaryData.data ? summaryData.data.map( item => {
 			return {
 				...item,
 				period: moment( item.period ).format( 'MMM D' ),
 			};
-		} );
+		} ) : [];
 		let selectedBar = this.state.selectedBar;
 		if ( ! selectedBar && !! data.length ) {
 			selectedBar = data[ data.length - 1 ];
@@ -49,7 +49,7 @@ class StatsVideoSummary extends Component {
 			<div>
 				<QuerySiteStats siteId={ siteId } statType="statsVideo" query={ query } />
 				<SummaryChart
-					isLoading={ isRequesting && ! summaryData.length }
+					isLoading={ isRequesting && ! data.length }
 					data={ data }
 					activeKey="period"
 					dataKey="value"
@@ -71,7 +71,7 @@ const connectComponent = connect(
 		const siteId = getSelectedSiteId( state );
 
 		return {
-			summaryData: getSiteStatsNormalizedData( state, siteId, 'statsVideo', query ) || [],
+			summaryData: getSiteStatsNormalizedData( state, siteId, 'statsVideo', query ),
 			isRequesting: isRequestingSiteStatsForQuery( state, siteId, 'statsVideo', query ),
 			query,
 			siteId,

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -840,16 +840,10 @@ describe( 'utils', () => {
 		} );
 
 		describe( 'statsVideo()', () => {
-			it( 'should return an empty array if not data is passed', () => {
+			it( 'should return null if not data is passed', () => {
 				const parsedData = normalizers.statsVideo();
 
-				expect( parsedData ).to.eql( [] );
-			} );
-
-			it( 'should return an empty array if not data has no data attribute', () => {
-				const parsedData = normalizers.statsVideo( { bad: [] } );
-
-				expect( parsedData ).to.eql( [] );
+				expect( parsedData ).to.eql( null );
 			} );
 
 			it( 'should return an a properly parsed data array', () => {
@@ -857,15 +851,36 @@ describe( 'utils', () => {
 					data: [
 						[ '2016-11-12', 1 ],
 						[ '2016-11-13', 0 ]
+					],
+					pages: [
+						'https://vip.wordpress.com/category/themes/',
+						'http://freewordpressthemes.ru/p2-theme-for-the-blog-inspired-twitter.html',
+						'http://www.themepremium.com/blog-with-the-speed-of-your-thought-with-the-p2-theme/'
 					]
 				} );
 
-				expect( parsedData ).to.eql( [
-					{
-						period: '2016-11-13',
-						value: 0,
-					}
-				] );
+				expect( parsedData ).to.eql( {
+					data: [
+						{
+							period: '2016-11-13',
+							value: 0,
+						}
+					],
+					pages: [
+						{
+							label: 'https://vip.wordpress.com/category/themes/',
+							link: 'https://vip.wordpress.com/category/themes/',
+						},
+						{
+							label: 'http://freewordpressthemes.ru/p2-theme-for-the-blog-inspired-twitter.html',
+							link: 'http://freewordpressthemes.ru/p2-theme-for-the-blog-inspired-twitter.html',
+						},
+						{
+							label: 'http://www.themepremium.com/blog-with-the-speed-of-your-thought-with-the-p2-theme/',
+							link: 'http://www.themepremium.com/blog-with-the-speed-of-your-thought-with-the-p2-theme/',
+						}
+					]
+				} );
 			} );
 		} );
 

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -381,13 +381,28 @@ export const normalizers = {
 	 * @return {Array}          Parsed data array
 	 */
 	statsVideo( payload ) {
-		if ( ! payload || ! payload.data ) {
-			return [];
+		if ( ! payload ) {
+			return null;
 		}
 
-		return payload.data.map( item => {
-			return { period: item[ 0 ], value: item[ 1 ] };
-		} ).slice( Math.max( payload.data.length - 10, 1 ) );
+		let data = [];
+		if ( payload.data ) {
+			data = payload.data.map( ( item ) => {
+				return { period: item[ 0 ], value: item[ 1 ] };
+			} ).slice( Math.max( payload.data.length - 10, 1 ) );
+		}
+
+		let pages = [];
+		if ( payload.pages ) {
+			pages = payload.pages.map( ( item ) => {
+				return {
+					label: item,
+					link: item
+				};
+			} );
+		}
+
+		return { pages, data };
 	},
 
 	/**


### PR DESCRIPTION
No more `statsList` 🎉 🍾 

In this PR, I'm reduxifying the last components using the old StatsList emitter. This concerns the video details stats page.

**Testing instructions**

 * Navigate to a video stats page: `/stats/week/videodetails/$site?post=$mediaId`
 * The two components should show up correctly
 * The title on the "header cake" shows the video title.