### PR TITLE
Disconnect Jetpack: Compare site ID instead of site and selected Site as objects

### DIFF
--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog.jsx
@@ -54,7 +54,7 @@ class DisconnectJetpackDialog extends Component {
 
 		if ( site ) {
 			SitesListActions.disconnect( site );
-			if ( selectedSite === site && this.props.redirect ) {
+			if ( selectedSite.ID === site.ID && this.props.redirect ) {
 				page.redirect( this.props.redirect );
 				return;
 			}
@@ -62,7 +62,7 @@ class DisconnectJetpackDialog extends Component {
 			this.props.sites.getSelectedOrAllWithPlugins().forEach( siteItem => SitesListActions.disconnect( siteItem ) );
 		}
 
-		if ( selectedSite === site ) {
+		if ( selectedSite.ID === site.ID ) {
 			page.redirect( '/sites' );
 		}
 	}


### PR DESCRIPTION
Fixes a bug reported by @dereksmart where you were not redirected to /sites after disconnecting Jetpack

Changes to what the site is changes what the selected site was. 
So we were comparing a Jetpack site object to a regular JS object. 
This resulted in the redirect never being fired as expected. 

This PR fixes this by comparing the IDs which should be the same. 

To test:
Disconnect a Jetpack site from site settings and notice that you get redirected to /sites 
which lets you choose a site. Since the disconnected site is not available to be managed from calypso any more. 

Also test that disconnecting from /plugins and /plugins/jetpack works as expected. 