### PR TITLE
Stats: Add Summary Views for Clicks.

### DIFF
--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -78,7 +78,7 @@ class StatsModule extends Component {
 
 	isAllTimeList() {
 		const { summary, statType } = this.props;
-		return summary && includes( [ 'statsCountryViews', 'statsTopPosts', 'statsSearchTerms' ], statType );
+		return summary && includes( [ 'statsCountryViews', 'statsTopPosts', 'statsSearchTerms', 'statsClicks' ], statType );
 	}
 
 	render() {

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -78,7 +78,7 @@ class StatsSummary extends Component {
 					path="clicks"
 					moduleStrings={ StatsStrings.clicks }
 					period={ this.props.period }
-					query={ query }
+					query={ merge( {}, statsQueryOptions, query ) }
 					statType="statsClicks"
 					summary />;
 				break;

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1118,6 +1118,67 @@ describe( 'utils', () => {
 					}
 				] );
 			} );
+
+			it( 'should return an a properly parsed summary data array', () => {
+				const parsedData = normalizers.statsClicks( {
+					date: '2017-01-12',
+					summary: {
+						clicks: [
+							{
+								icon: 'https://secure.gravatar.com/blavatar/94ea57385f5018d2b84169cab22d3b33?s=48',
+								name: 'en.support.wordpress.com',
+								url: null,
+								views: 50,
+								children: [
+									{
+										name: 'en.support.wordpress.com',
+										url: 'https://en.support.wordpress.com/',
+										views: 50
+									}
+								]
+							},
+							{
+								children: null,
+								icon: 'https://secure.gravatar.com/blavatar/3dbcb399a9112e3bb46f706b01c80062?s=48',
+								name: 'en.forums.wordpress.com',
+								url: 'https://en.forums.wordpress.com/',
+								views: 10
+							}
+						]
+					}
+				}, {
+					period: 'day',
+					date: '2017-01-12',
+					summarize: 1
+				} );
+
+				expect( parsedData ).to.eql( [
+					{
+						children: [
+							{
+								children: null,
+								label: 'en.support.wordpress.com',
+								labelIcon: 'external',
+								link: 'https://en.support.wordpress.com/',
+								value: 50
+							}
+						],
+						icon: 'https://secure.gravatar.com/blavatar/94ea57385f5018d2b84169cab22d3b33?s=48',
+						label: 'en.support.wordpress.com',
+						labelIcon: null,
+						link: null,
+						value: 50
+					},
+					{
+						children: null,
+						icon: 'https://secure.gravatar.com/blavatar/3dbcb399a9112e3bb46f706b01c80062?s=48',
+						label: 'en.forums.wordpress.com',
+						labelIcon: 'external',
+						link: 'https://en.forums.wordpress.com/',
+						value: 10
+					}
+				] );
+			} );
 		} );
 
 		describe( 'statsReferrers()', () => {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -510,7 +510,8 @@ export const normalizers = {
 		}
 
 		const { startOf } = rangeOfPeriod( query.period, query.date );
-		const statsData = get( data, [ 'days', startOf, 'clicks' ], [] );
+		const dataPath = query.summarize ? [ 'summary', 'clicks' ] : [ 'days', startOf, 'clicks' ];
+		const statsData = get( data, dataPath, [] );
 
 		return statsData.map( ( item ) => {
 			const hasChildren = item.children && item.children.length > 0;


### PR DESCRIPTION
For #10349 - This branch introduces Summarized views to the Clicks summary page:

![stats_ _trout_bummin_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/22570283/92b0c2f6-e94f-11e6-8f50-78072d29a26c.png)

__To Test__
- Open a clicks summary page: http://calypso.localhost:3000/stats/day/clicks/(YOURSITE) or access via a stats date page
- Use the summarized links up top, optionally compare them to old stats https://wordpress.com/my-stats/?view=clicks&summarize