### PR TITLE
Fix: Flag automated transfer as active on attempt not confirmation

### DIFF
--- a/client/state/automated-transfer/reducer.js
+++ b/client/state/automated-transfer/reducer.js
@@ -17,13 +17,15 @@ import { automatedTransfer as schema } from './schema';
 import {
 	AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE as ELIGIBILITY_UPDATE,
 	AUTOMATED_TRANSFER_STATUS_SET as SET_STATUS,
-	THEME_TRANSFER_INITIATE_SUCCESS as INITIATE,
+	THEME_TRANSFER_INITIATE_REQUEST as INITIATE,
+	THEME_TRANSFER_INITIATE_FAILURE as INITIATE_FAILURE,
 	THEME_TRANSFER_STATUS_RECEIVE as TRANSFER_UPDATE,
 } from 'state/action-types';
 
 export const status = ( state = null, action ) => get( {
 	[ ELIGIBILITY_UPDATE ]: action.status,
 	[ INITIATE ]: transferStates.START,
+	[ INITIATE_FAILURE ]: transferStates.INQUIRING,
 	[ SET_STATUS ]: action.status,
 	[ TRANSFER_UPDATE ]: 'complete' === action.status ? transferStates.COMPLETE : state,
 }, action.type, state );


### PR DESCRIPTION
Resolves #11139 

Previously we were waiting to hear back from the WordPress.com servers
for the "initiate" request to start an automated transfer before we
flagged a given site as having actually started the transfer.

Now we will watch the requst action instead of the success action for
making this decision, meaning that the state should change immediately
after starting the transfer in Calypso.

If the request fails, we will reset the state to indicate that we have
queried the eligibility endpoint but aren't transfering yet.