### PR TITLE
Image Editor: try to avoid compounding rounding errors

### DIFF
--- a/client/blocks/image-editor/image-editor-crop.jsx
+++ b/client/blocks/image-editor/image-editor-crop.jsx
@@ -336,9 +336,22 @@ class ImageEditorCrop extends Component {
 		const currentTop = top - topBound,
 			currentLeft = left - leftBound,
 			currentWidth = right - left,
-			currentHeight = bottom - top,
-			imageWidth = rightBound - leftBound,
-			imageHeight = bottomBound - topBound;
+			currentHeight = bottom - top;
+
+		const imageWidth = rightBound - leftBound;
+		let imageHeight = bottomBound - topBound;
+
+		const rotated = this.props.degrees % 180 !== 0;
+
+		if ( this.props.originalAspectRatio ) {
+			const { width, height } = this.props.originalAspectRatio;
+			const originalImageWidth = rotated ? height : width;
+			const originalImageHeight = rotated ? width : height;
+
+			// avoid compounding rounding errors
+			const ratio = originalImageHeight / originalImageWidth;
+			imageHeight = imageWidth * ratio;
+		}
 
 		return [
 			currentTop / imageHeight,


### PR DESCRIPTION
Fixes #10464, where sometimes cropped images don't exactly reflect the chosen aspect ratio.

### Testing Instructions
- Navigate to http://calypso.localhost:3000/post
- Select a wpcom public site when prompted
- Open the media modal
- Edit an image
- Select the 1x1 aspect ratio
- Resize and move crop
- Click done
- Image should be perfectly square (not off by 1px)
- Other aspect ratios work as expected.
- No issues with flipping/rotation then cropping.