### PR TITLE
Link the Domain management page for domain-only site to theme selection flow

### DIFF
--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -86,8 +86,9 @@ assign( SignupFlowController.prototype, {
 	},
 
 	_assertFlowProvidedDependenciesFromConfig: function( providedDependencies ) {
-		if ( difference( this._flow.providesDependenciesInQuery, keys( providedDependencies ) ).length > 0 ) {
-			throw new Error( this._flowName + ' did not provide the dependencies it is configured to.' );
+		const dependencyDiff = difference( this._flow.providesDependenciesInQuery, keys( providedDependencies ) );
+		if ( dependencyDiff.length > 0 ) {
+			throw new Error( this._flowName + ' did not provide the query dependencies [' + dependencyDiff + '] it is configured to.' );
 		}
 	},
 

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -123,7 +123,7 @@ function renderSelectedSiteIsDomainOnly( reactContext, selectedSite ) {
 			title: i18n.translate( 'This feature is not available for domains' ),
 			line: i18n.translate( 'To use this feature you need to create a site' ),
 			action: i18n.translate( 'Create New Site' ),
-			actionURL: '//dashboard.wordpress.com/wp-admin/index.php?page=my-blogs',
+			actionURL: `/start/site-selected/?siteSlug=${ encodeURIComponent( selectedSite.slug ) }`,
 			secondaryAction: i18n.translate( 'Manage Domain' ),
 			secondaryActionURL: domainManagementList( selectedSite.slug )
 		} ),

--- a/client/my-sites/upgrades/domain-management/list/domain-only.jsx
+++ b/client/my-sites/upgrades/domain-management/list/domain-only.jsx
@@ -15,8 +15,10 @@ const DomainOnly = ( { domainName, translate } ) => (
 		title={ translate( '%(domainName)s is not set up yet.', {
 			args: { domainName }
 		} ) }
-		action={ translate( 'Advanced' ) }
-		actionURL={ domainManagementEdit( domainName, domainName ) }
+		action={ translate( 'Create New Site' ) }
+		actionURL={ `/start/site-selected/?siteSlug=${ encodeURIComponent( domainName ) }` }
+		secondaryAction={ translate( 'Advanced' ) }
+		secondaryActionURL={ domainManagementEdit( domainName, domainName ) }
 		illustration={ '/calypso/images/drake/drake-browser.svg' } />
 );
 


### PR DESCRIPTION
This PR adds a new button `Create new site` on the domain management page for domain only sites. This new button links to the existing flow for changing the theme of an existing site.

### Testing instructions
- Load the branch locally or use calypso.live
- Go to a domain-only site (or create one from `/start/domain-first`)
- Click "Create new site"
- Assert you are redirected to `/start/site-selected/themes-site-selected`
- Select a theme and assert that you are redirected to your website with the new theme activated
- Do the same thing from the domain-only feature gate page.

### Reviews
- [ ] Code
- [ ] Product