### PR TITLE
Stats: Add Summarized Referrer Views.

### DIFF
--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -78,7 +78,8 @@ class StatsModule extends Component {
 
 	isAllTimeList() {
 		const { summary, statType } = this.props;
-		return summary && includes( [ 'statsCountryViews', 'statsTopPosts', 'statsSearchTerms', 'statsClicks' ], statType );
+		const summarizedTypes = [ 'statsCountryViews', 'statsTopPosts', 'statsSearchTerms', 'statsClicks', 'statsReferrers' ];
+		return summary && includes( summarizedTypes, statType );
 	}
 
 	render() {

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -66,7 +66,7 @@ class StatsSummary extends Component {
 					path="referrers"
 					moduleStrings={ StatsStrings.referrers }
 					period={ this.props.period }
-					query={ query }
+					query={ merge( {}, statsQueryOptions, query ) }
 					statType="statsReferrers"
 					summary />;
 				break;

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1197,6 +1197,87 @@ describe( 'utils', () => {
 				expect( parsedData ).to.eql( [] );
 			} );
 
+			it( 'should return an a properly parsed summary data array', () => {
+				const parsedData = normalizers.statsReferrers( {
+					date: '2017-01-12',
+					summary: {
+						groups: [
+							{
+								group: 'WordPress.com Reader',
+								name: 'WordPress.com Reader',
+								url: 'https://wordpress.com',
+								icon: 'https://secure.gravatar.com/blavatar/236c008da9dc0edb4b3464ecebb3fc1d?s=48',
+								results: {
+									views: 500
+								},
+								total: 500
+							},
+							{
+								group: 'en.support.wordpress.com',
+								icon: 'https://secure.gravatar.com/blavatar/94ea57385f5018d2b84169cab22d3b33?s=48',
+								name: 'en.support.wordpress.com',
+								results: [
+									{ name: 'homepage', url: 'https://en.support.wordpress.com/', views: 200 },
+									{ name: 'start', url: 'https://en.support.wordpress.com/start/', views: 100 }
+								],
+								total: 300
+							}
+						]
+					}
+				}, {
+					period: 'day',
+					date: '2017-01-12',
+					domain: 'en.blog.wordpress.com',
+					summarize: 1
+				}, 100 );
+
+				expect( parsedData ).to.eql( [
+					{
+						actionMenu: 0,
+						actions: [],
+						children: undefined,
+						icon: 'https://secure.gravatar.com/blavatar/236c008da9dc0edb4b3464ecebb3fc1d?s=48',
+						label: 'WordPress.com Reader',
+						labelIcon: 'external',
+						link: 'https://wordpress.com',
+						value: 500
+					},
+					{
+						actionMenu: 1,
+						actions: [
+							{
+								data: {
+									domain: 'en.support.wordpress.com',
+									siteID: 100
+								},
+								type: 'spam'
+							}
+						],
+						children: [
+							{
+								children: undefined,
+								label: 'homepage',
+								labelIcon: 'external',
+								link: 'https://en.support.wordpress.com/',
+								value: 200
+							},
+							{
+								children: undefined,
+								label: 'start',
+								labelIcon: 'external',
+								link: 'https://en.support.wordpress.com/start/',
+								value: 100
+							}
+						],
+						icon: 'https://secure.gravatar.com/blavatar/94ea57385f5018d2b84169cab22d3b33?s=48',
+						label: 'en.support.wordpress.com',
+						labelIcon: null,
+						link: undefined,
+						value: 300
+					},
+				] );
+			} );
+
 			it( 'should return an a properly parsed data array', () => {
 				const parsedData = normalizers.statsReferrers( {
 					date: '2017-01-12',

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -554,7 +554,8 @@ export const normalizers = {
 		}
 
 		const { startOf } = rangeOfPeriod( query.period, query.date );
-		const statsData = get( data, [ 'days', startOf, 'groups' ], [] );
+		const dataPath = query.summarize ? [ 'summary', 'groups' ] : [ 'days', startOf, 'groups' ];
+		const statsData = get( data, dataPath, [] );
 
 		const parseItem = ( item ) => {
 			let children;


### PR DESCRIPTION
For #10349 - This branch introduces Summarized views to the Referrers summary page:

![fly_fishers_place_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/22574592/b3a4c394-e964-11e6-8474-7285e08aec7f.png)

__To Test__
- Open a clicks summary page: http://calypso.localhost:3000/stats/day/referrers/(YOURSITE) or access via a stats date page
- Use the summarized links up top, optionally compare them to old stats https://wordpress.com/my-stats/?view=referrers&summarize