### PR TITLE
Image Editor: Remove custom styles from image edit buttons

### DIFF
--- a/client/post-editor/media-modal/detail/_style.scss
+++ b/client/post-editor/media-modal/detail/_style.scss
@@ -118,35 +118,29 @@
 		@include breakpoint( ">480px" ) {
 			display: block;
 			position: absolute;
-			    top: 8px;
-			    right: 8px;
+				top: 8px;
+				right: 8px;
 
-		    button {
-		    	margin-left: 8px;
-		    }
+			button {
+				margin-left: 8px;
+			}
 		}
 	}
 
 	&.is-mobile {
 		@include breakpoint( "<480px" ) {
 			display: block;
+			text-align: right;
+
 			button {
-				width: 48%;
-	 			margin-bottom: 8px;
+				margin-bottom: 16px;
+				margin-left: 8px;
 
-	 			&:first-child {
-	 				margin-right: 2%;
-	 			}
-
-	 			&:last-child {
-	 				margin-left: 2%;
-	 			}
-	 		}
+				&:first-child {
+					margin-left: 0;
+				}
+			}
 		}
-	}
-
-	button {
-		font-weight: bold;
 	}
 }
 


### PR DESCRIPTION
This PR updates image edit buttons' styles. Fixes #11130. 

![screen-shot-2017-02-03-at-00 25 49](https://cloud.githubusercontent.com/assets/908665/22574901/e849cbf4-e9a9-11e6-9188-f01652c04453.jpg)

![screen-shot-2017-02-02-at-12 23 57](https://cloud.githubusercontent.com/assets/908665/22574900/e8464664-e9a9-11e6-8a43-95a74ea50783.jpg)

