### PR TITLE
Fix: Form Text Input With Affixes don't expand as needed on Safari

### DIFF
--- a/client/components/forms/form-text-input-with-affixes/style.scss
+++ b/client/components/forms/form-text-input-with-affixes/style.scss
@@ -46,8 +46,8 @@
 	padding: 8px 14px;
 	white-space: nowrap;
 	flex: 1 0 auto;
-    font-size: 16px;
-    line-height: 1.5;
+	font-size: 16px;
+	line-height: 1.5;
 }
 
 .form-text-input-with-affixes__prefix {

--- a/client/components/forms/form-text-input-with-affixes/style.scss
+++ b/client/components/forms/form-text-input-with-affixes/style.scss
@@ -46,6 +46,8 @@
 	padding: 8px 14px;
 	white-space: nowrap;
 	flex: 1 0 auto;
+    font-size: 16px;
+    line-height: 1.5;
 }
 
 .form-text-input-with-affixes__prefix {

--- a/client/components/forms/form-text-input-with-affixes/style.scss
+++ b/client/components/forms/form-text-input-with-affixes/style.scss
@@ -45,6 +45,7 @@
 	color: darken( $gray, 20% );
 	padding: 8px 14px;
 	white-space: nowrap;
+	flex: 1 0 auto;
 }
 
 .form-text-input-with-affixes__prefix {


### PR DESCRIPTION
Resolves issue #7044.

Change on style.scss to allow suffix and prefix to expand on Safari.

Also, changes font size and vertical alignment to match with input text. 

Before the fix:
<img width="801" alt="captura de tela 2017-02-03 as 01 53 30" src="https://cloud.githubusercontent.com/assets/472898/22578965/c01acba6-e9b3-11e6-974f-3181bca85150.png">

After the fix:
<img width="750" alt="captura de tela 2017-02-03 as 01 53 59" src="https://cloud.githubusercontent.com/assets/472898/22578969/c86f97be-e9b3-11e6-8b73-463dc774a9aa.png">