### PR TITLE
Happychat: Don't auto-add protocol

### DIFF
--- a/client/components/happychat/timeline.jsx
+++ b/client/components/happychat/timeline.jsx
@@ -48,7 +48,7 @@ const messageWithLinks = ( { message, key, links } ) => {
 		let target = null;
 
 		href = addSchemeIfMissing( href, 'http' );
-		if ( isExternal( url ) ) {
+		if ( isExternal( href ) ) {
 			rel = 'noopener noreferrer';
 			target = '_blank';
 		} else if ( typeof window !== 'undefined' ) {

--- a/client/components/happychat/timeline.jsx
+++ b/client/components/happychat/timeline.jsx
@@ -47,8 +47,8 @@ const messageWithLinks = ( { message, key, links } ) => {
 		let rel = null;
 		let target = null;
 
+		href = addSchemeIfMissing( href, 'http' );
 		if ( isExternal( url ) ) {
-			href = addSchemeIfMissing( href, 'http' );
 			rel = 'noopener noreferrer';
 			target = '_blank';
 		} else if ( typeof window !== 'undefined' ) {

--- a/client/components/happychat/timeline.jsx
+++ b/client/components/happychat/timeline.jsx
@@ -42,6 +42,7 @@ const messageParagraph = ( { message, key } ) => <p key={ key }>{ message }</p>;
  */
 const messageWithLinks = ( { message, key, links } ) => {
 	const children = links.reduce( ( { parts, last }, [ url, startIndex, length ] ) => {
+		const text = url;
 		let href = url;
 		let rel = null;
 		let target = null;
@@ -60,7 +61,7 @@ const messageWithLinks = ( { message, key, links } ) => {
 			parts = parts.concat( <span key={ parts.length }>{ message.slice( last, startIndex ) }</span> );
 		}
 
-		parts = parts.concat( <a key={ parts.length } href={ href } rel={ rel } target={ target }>{ href }</a> );
+		parts = parts.concat( <a key={ parts.length } href={ href } rel={ rel } target={ target }>{ text }</a> );
 
 		return { parts, last: startIndex + length };
 	}, { parts: [], last: 0 } );

--- a/client/lib/url/test/index.js
+++ b/client/lib/url/test/index.js
@@ -149,6 +149,12 @@ describe( 'isExternal', () => {
 			const actual = isExternal( urlWithoutHttp );
 			expect( actual ).to.be.true;
 		} );
+
+		it( 'should return true for subdomains', () => {
+			const source = '//ns1.example.com';
+			const actual = isExternal( source );
+			expect( actual ).to.be.true;
+		} );
 	} );
 
 	describe( 'without global.window (test against config hostname)', () => {


### PR DESCRIPTION
This fixes an issue where sending a link-like message auto-prepends http://. This isn't applicable to eg DNS records such as nameservers, and causes confusion.

This change will print the link text as is, only auto-adding the protocol to the href.

### Before

<img width="272" alt="screen shot 2017-02-03 at 3 14 55 pm" src="https://cloud.githubusercontent.com/assets/416133/22580365/8e5b4bfc-ea23-11e6-9d4e-1bd1a9a614f9.png">

### After

<img width="283" alt="screen shot 2017-02-03 at 3 13 51 pm" src="https://cloud.githubusercontent.com/assets/416133/22580352/68be50ce-ea23-11e6-814a-8249594c910d.png">

## How to test

1. Check out the branch or use the calypso live link below.
2. Log in to the staging HUD.
3. Start a chat from /help/contact
4. Send a message (one from each HUD and Calypso) containing a domain without a protocol (eg example.com)
5. Confirm that the protocol is not added to the link text

cc @deancroyal @ehti 