### PR TITLE
Add translator comments for strings in manage-purchases

### DIFF
--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -48,6 +48,7 @@ class PurchaseNotice extends Component {
 						purchaseName: getName( purchase ),
 						expiry: moment( purchase.expiryMoment ).fromNow(),
 					},
+					comment: '%(expiry)s will be a localized phrase like "in 8 months"',
 				}
 			);
 		}
@@ -62,6 +63,7 @@ class PurchaseNotice extends Component {
 						purchaseName: getName( purchase ),
 						expiry: daysToExpiry,
 					},
+					comment: '%(expiry)s will be a plain number, like 25',
 				}
 			);
 		}
@@ -71,6 +73,7 @@ class PurchaseNotice extends Component {
 				purchaseName: getName( purchase ),
 				expiry: moment( purchase.expiryMoment ).fromNow(),
 			},
+			comment: '%(expiry)s will be a localized phrase like "in a month"',
 		} );
 	}
 
@@ -143,6 +146,7 @@ class PurchaseNotice extends Component {
 							components: {
 								a: editCardDetailsPath ? <a href={ editCardDetailsPath } /> : <span />,
 							},
+							comment: '%(cardExpiry)s will be a localized date like "September 2018"',
 						}
 					) }
 				</Notice>


### PR DESCRIPTION
We do a bunch of cool things with moment.js, so this PR gives translators need a little help knowing what to expect from each one.

#### Testing:
There are no logic changes, but still good form to make sure that everything still works by clicking through on a purchase in http://calypso.localhost:3000/me/purchases/ :
![achats_ _gerer_l achat_ _wordpress_com](https://cloud.githubusercontent.com/assets/5952255/22586325/d3f44078-ea47-11e6-8701-5563787ffa51.jpg)

The goal is for the comments to show up in the `calypso-strings.pot` generated by `npm run translate`. You can check that they're picked up by running `./node_modules/.bin/i18n-calypso --format=pot client/me/purchases/manage-purchase/notices.jsx` in the calypso directory.

It might be easier to see by diffing the output for the file in this branch against master:
```
( export MASK_NUMBERS='s/[:\.\/][0-9][0-9]*//g';
diff \
    <( ./node_modules/.bin/i18n-calypso --format=pot <(git show master:client/me/purchases/manage-purchase/notices.jsx ) | sed $MASK_NUMBERS ) \
    <( ./node_modules/.bin/i18n-calypso --format=pot <(cat client/me/purchases/manage-purchase/notices.jsx ) | sed $MASK_NUMBERS ) )
```
which should show the 4 strings in the diff, like this:

21a22
> #. %(cardExpiry)s will be a localized date like "September 2018"
31a33
> #. %(expiry)s will be a localized phrase like "in a month"
35a38
> #. %(expiry)s will be a plain number, like 25
40a44
> #. %(expiry)s will be a localized phrase like "in 8 months"
