### PR TITLE
Purchases: fix grammar when counting days

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -171,14 +171,18 @@ const ManagePurchase = React.createClass( {
 		}
 		if ( isMonthly( purchase.productSlug ) ) {
 			const expiryMoment = this.moment( purchase.expiryMoment );
-			const daysToExpiry = this.moment( expiryMoment.diff( this.moment() ) ).format( 'D' );
+			const daysToExpiry = Number( this.moment( expiryMoment.diff( this.moment() ) ).format( 'D' ) );
 
-			return this.translate( '%(purchaseName)s will expire and be removed from your site in %(expiry)s days. ',
+			return this.translate(
+				'%(purchaseName)s will expire and be removed from your site in %(daysToExpiry)d day. ',
+				'%(purchaseName)s will expire and be removed from your site in %(daysToExpiry)d days. ',
 				{
+					count: daysToExpiry,
 					args: {
 						purchaseName: getName( purchase ),
-						expiry: daysToExpiry
-					}
+						daysToExpiry: daysToExpiry
+					},
+					comment: '%(daysToExpiry)d will be a plain number like "42"'
 				}
 			);
 		}

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -173,7 +173,7 @@ const ManagePurchase = React.createClass( {
 			const expiryMoment = this.moment( purchase.expiryMoment );
 			const daysToExpiry = this.moment( expiryMoment.diff( this.moment() ) ).format( 'D' );
 
-			return this.translate( '%(purchaseName)s will expire and be removed from your site %(expiry)s days. ',
+			return this.translate( '%(purchaseName)s will expire and be removed from your site in %(expiry)s days. ',
 				{
 					args: {
 						purchaseName: getName( purchase ),


### PR DESCRIPTION
This PR fixes the grammar for a string in `/me/purchases/`.

`this.moment( expiryMoment.diff( this.moment() ) ).format( 'D' )`
returns a simple number, like '4', so this string needs the 'in' in
it to be grammatically correct.

I tweaked the code in this file to go down the `isMonthly(()` to verify that 

![purchases_ _manage_purchase_ _wordpress_com](https://cloud.githubusercontent.com/assets/5952255/22581277/8c41d88e-ea2a-11e6-9788-262b1bf27051.jpg)

becomes 

![purchases_ _manage_purchase_ _wordpress_com](https://cloud.githubusercontent.com/assets/5952255/22581340/e4d00dd6-ea2a-11e6-8024-08e3197c0ade.jpg)
