### PR TITLE
Site Settings: Remove parentheses from discussion form explanation

### DIFF
--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -63,7 +63,7 @@ class SiteSettingsFormDiscussion extends Component {
 					<span>{ translate( 'Allow people to post comments on new articles' ) }</span>
 				</FormToggle>
 				<FormSettingExplanation>
-					{ translate( '(These settings may be overridden for individual articles.)' ) }
+					{ translate( 'These settings may be overridden for individual articles.' ) }
 				</FormSettingExplanation>
 			</FormFieldset>
 		);


### PR DESCRIPTION
This PR removes the parentheses from the form setting explanation in Default Article Settings in Discussion settings, as suggested by @folletto in https://github.com/Automattic/wp-calypso/pull/11127#issuecomment-276919829.

Before:
![](https://cldup.com/pNWhCjoFLK.png)

After:
![](https://cldup.com/VLYS4AcJL2.png)