### PR TITLE
Jetpack Settings: Add horizontal rule between settings in ThemeEnhancements

### DIFF
--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -168,6 +168,9 @@ class ThemeEnhancements extends Component {
 
 				<Card className="theme-enhancements__card site-settings">
 					{ this.renderInfiniteScrollSettings() }
+
+					<hr />
+
 					{ this.renderMinilevenSettings() }
 				</Card>
 			</div>

--- a/client/my-sites/site-settings/theme-enhancements/style.scss
+++ b/client/my-sites/site-settings/theme-enhancements/style.scss
@@ -1,5 +1,5 @@
 .theme-enhancements__module-settings.is-indented {
-	margin: 16px 32px;
+	margin: 16px 32px 0;
 }
 
 .theme-enhancements__info-link-container {


### PR DESCRIPTION
As suggested in https://github.com/Automattic/wp-calypso/pull/10920#issuecomment-276992726 by @MichaelArestad, this PR adds a horizontal rule between the two sections of the Theme Enhancements card. It also adjusts the margin below the sub settings to make the vertical spacing within that card consistent.

Before:
![](https://cldup.com/dIdwp_KKZh.png)

After:
![](https://cldup.com/rdnaksUg-c.png)

/cc @MichaelArestad for a quick design 👁 .
