### PR TITLE
Components: Update FormToggle to be toggled on label click

### DIFF
--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -82,7 +82,9 @@ export default class FormToggle extends PureComponent {
 						aria-label={ this.props[ 'aria-label' ] }
 						tabIndex={ this.props.disabled ? -1 : 0 }
 						></span>
-					{ this.props.children }
+					<span className="form-toggle__label-content">
+						{ this.props.children }
+					</span>
 				</label>
 			</span>
 		);

--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -31,6 +31,7 @@ export default class FormToggle extends PureComponent {
 
 		this.onKeyDown = this.onKeyDown.bind( this );
 		this.onClick = this.onClick.bind( this );
+		this.onLabelClick = this.onLabelClick.bind( this );
 	}
 
 	componentWillMount() {
@@ -52,6 +53,18 @@ export default class FormToggle extends PureComponent {
 
 	onClick() {
 		if ( ! this.props.disabled ) {
+			this.props.onChange();
+		}
+	}
+
+	onLabelClick( event ) {
+		if ( this.props.disabled ) {
+			return;
+		}
+
+		const nodeName = event.target.nodeName.toLowerCase();
+		if ( nodeName !== 'a' && nodeName !== 'input' && nodeName !== 'select' ) {
+			event.preventDefault();
 			this.props.onChange();
 		}
 	}
@@ -82,7 +95,7 @@ export default class FormToggle extends PureComponent {
 						aria-label={ this.props[ 'aria-label' ] }
 						tabIndex={ this.props.disabled ? -1 : 0 }
 						></span>
-					<span className="form-toggle__label-content">
+					<span className="form-toggle__label-content" onClick={ this.onLabelClick }>
 						{ this.props.children }
 					</span>
 				</label>

--- a/client/components/forms/form-toggle/style.scss
+++ b/client/components/forms/form-toggle/style.scss
@@ -47,6 +47,11 @@
 	.is-disabled & {
 		cursor: default;
 	}
+
+	.form-toggle__label-content {
+		flex: 0 1 100%;
+		margin-left: 12px;
+	}
 }
 
 .form-toggle {

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -36,10 +36,9 @@ class CustomContentTypes extends Component {
 				className="custom-content-types__module-settings-toggle is-compact"
 				checked={ !! fields[ name ] }
 				disabled={ this.isFormPending() || isDisabled }
-				onChange={ handleToggle( name ) }>
-				<span className="site-settings__toggle-label">
-					{ label }
-				</span>
+				onChange={ handleToggle( name ) }
+			>
+				{ label }
 			</FormToggle>
 		);
 	}

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -310,10 +310,9 @@ class SiteSettingsFormGeneral extends Component {
 							className="is-compact"
 							checked={ !! fields.jetpack_relatedposts_enabled }
 							disabled={ isRequestingSettings }
-							onChange={ handleToggle( 'jetpack_relatedposts_enabled' ) }>
-							<span className="site-settings__toggle-label">
-								{ translate( 'Show related content after posts' ) }
-							</span>
+							onChange={ handleToggle( 'jetpack_relatedposts_enabled' ) }
+						>
+							{ translate( 'Show related content after posts' ) }
 						</FormToggle>
 					</li>
 					<li>
@@ -323,12 +322,11 @@ class SiteSettingsFormGeneral extends Component {
 									className="is-compact"
 									checked={ !! fields.jetpack_relatedposts_show_headline }
 									disabled={ isRequestingSettings || ! fields.jetpack_relatedposts_enabled }
-									onChange={ handleToggle( 'jetpack_relatedposts_show_headline' ) }>
-									<span className="site-settings__toggle-label">
-										{ translate(
-											'Show a "Related" header to more clearly separate the related section from posts'
-										) }
-									</span>
+									onChange={ handleToggle( 'jetpack_relatedposts_show_headline' ) }
+								>
+									{ translate(
+										'Show a "Related" header to more clearly separate the related section from posts'
+									) }
 								</FormToggle>
 							</li>
 							<li>
@@ -336,12 +334,11 @@ class SiteSettingsFormGeneral extends Component {
 									className="is-compact"
 									checked={ !! fields.jetpack_relatedposts_show_thumbnails }
 									disabled={ isRequestingSettings || ! fields.jetpack_relatedposts_enabled }
-									onChange={ handleToggle( 'jetpack_relatedposts_show_thumbnails' ) }>
-									<span className="site-settings__toggle-label">
-										{ translate(
-											'Use a large and visually striking layout'
-										) }
-									</span>
+									onChange={ handleToggle( 'jetpack_relatedposts_show_thumbnails' ) }
+								>
+									{ translate(
+										'Use a large and visually striking layout'
+									) }
 								</FormToggle>
 							</li>
 						</ul>
@@ -383,12 +380,11 @@ class SiteSettingsFormGeneral extends Component {
 								className="is-compact"
 								checked={ !! fields.jetpack_sync_non_public_post_stati }
 								disabled={ isRequestingSettings }
-								onChange={ handleToggle( 'jetpack_sync_non_public_post_stati' ) }>
-								<span className="site-settings__toggle-label">
-									{ translate(
-										'Allow synchronization of Posts and Pages with non-public post statuses'
-									) }
-								</span>
+								onChange={ handleToggle( 'jetpack_sync_non_public_post_stati' ) }
+							>
+								{ translate(
+									'Allow synchronization of Posts and Pages with non-public post statuses'
+								) }
 							</FormToggle>
 							<FormSettingExplanation>
 								{ translate( '(e.g. drafts, scheduled, private, etc\u2026)' ) }
@@ -442,12 +438,11 @@ class SiteSettingsFormGeneral extends Component {
 							className="is-compact"
 							checked={ !! fields.holidaysnow }
 							disabled={ isRequestingSettings }
-							onChange={ handleToggle( 'holidaysnow' ) }>
-							<span className="site-settings__toggle-label">
-								{ translate(
-									'Show falling snow on my blog until January 4th.'
-								) }
-							</span>
+							onChange={ handleToggle( 'holidaysnow' ) }
+						>
+							{ translate(
+								'Show falling snow on my blog until January 4th.'
+							) }
 						</FormToggle>
 					</li>
 				</ul>
@@ -504,12 +499,11 @@ class SiteSettingsFormGeneral extends Component {
 					className="is-compact"
 					checked={ !! fields.api_cache }
 					disabled={ isRequestingSettings }
-					onChange={ handleToggle( 'api_cache' ) }>
-					<span className="site-settings__toggle-label">
-						{ translate(
-							'Use synchronized data to boost performance'
-						) }
-					</span>
+					onChange={ handleToggle( 'api_cache' ) }
+				>
+					{ translate(
+						'Use synchronized data to boost performance'
+					) }
 				</FormToggle>
 			</CompactCard>
 		);

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -111,7 +111,7 @@ class SiteSettingsFormWriting extends Component {
 									onChange={ handleToggle( 'wpcom_publish_posts_with_markdown' ) }
 									disabled={ isRequestingSettings }
 								>
-									<span className="site-settings__toggle-label">{
+									{
 										translate( 'Use markdown for posts and pages. {{a}}Learn more about markdown{{/a}}.', {
 											components: {
 												a: (
@@ -123,7 +123,7 @@ class SiteSettingsFormWriting extends Component {
 												)
 											}
 										} )
-									}</span>
+									}
 								</FormToggle>
 							</FormLabel>
 						</FormFieldset>

--- a/client/my-sites/site-settings/jetpack-module-toggle/index.jsx
+++ b/client/my-sites/site-settings/jetpack-module-toggle/index.jsx
@@ -62,8 +62,9 @@ class JetpackModuleToggle extends Component {
 					checked={ this.props.checked || false }
 					toggling={ this.props.toggling }
 					onChange={ this.handleChange }
-					disabled={ this.props.disabled || this.props.toggleDisabled } >
-					<span className="site-settings__toggle-label">{ this.props.label }</span>
+					disabled={ this.props.disabled || this.props.toggleDisabled }
+				>
+					{ this.props.label }
 					{
 						this.props.description && (
 							<FormSettingExplanation isIndented>

--- a/client/my-sites/site-settings/jetpack-module-toggle/style.scss
+++ b/client/my-sites/site-settings/jetpack-module-toggle/style.scss
@@ -5,8 +5,3 @@
 .jetpack-module-toggle p.form-setting-explanation.is-indented {
 	margin-left: 32px;
 }
-
-.jetpack-module-toggle .site-settings__toggle-label {
-	flex: 0 1 100%;
-	margin-left: 12px;
-}

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -188,11 +188,6 @@
 		flex: 1 0 auto;
 	}
 
-	.site-settings__toggle-label {
-		flex: 0 1 100%;
-		margin-left: 12px;
-	}
-
 	hr {
 		margin: 0 -24px 1.5em;
 	}

--- a/client/my-sites/site-settings/subscriptions/index.jsx
+++ b/client/my-sites/site-settings/subscriptions/index.jsx
@@ -50,20 +50,18 @@ const Subscriptions = ( {
 						className="subscriptions__module-settings-toggle is-compact"
 						checked={ !! fields.stb_enabled }
 						disabled={ isRequestingSettings || isSavingSettings || ! subscriptionsModuleActive }
-						onChange={ handleToggle( 'stb_enabled' ) }>
-						<span className="site-settings__toggle-label">
-							{ translate( 'Show a "follow blog" option in the comment form' ) }
-						</span>
+						onChange={ handleToggle( 'stb_enabled' ) }
+					>
+						{ translate( 'Show a "follow blog" option in the comment form' ) }
 					</FormToggle>
 
 					<FormToggle
 						className="subscriptions__module-settings-toggle is-compact"
 						checked={ !! fields.stc_enabled }
 						disabled={ isRequestingSettings || isSavingSettings || ! subscriptionsModuleActive }
-						onChange={ handleToggle( 'stc_enabled' ) }>
-						<span className="site-settings__toggle-label">
-							{ translate( 'Show a "follow comments" option in the comment form.' ) }
-						</span>
+						onChange={ handleToggle( 'stc_enabled' ) }
+					>
+						{ translate( 'Show a "follow comments" option in the comment form.' ) }
 					</FormToggle>
 
 					<p className="subscriptions__email-followers">

--- a/client/my-sites/site-settings/subscriptions/style.scss
+++ b/client/my-sites/site-settings/subscriptions/style.scss
@@ -1,10 +1,6 @@
 .subscriptions__module-settings.is-indented {
 	margin: 16px 32px;
 
-	.site-settings__toggle-label {
-		margin-left: 8px;
-	}
-
 	.subscriptions__email-followers {
 		margin-top: 16px;
 	}

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -36,10 +36,9 @@ class ThemeEnhancements extends Component {
 				className="theme-enhancements__module-settings-toggle is-compact"
 				checked={ !! fields[ name ] }
 				disabled={ this.isFormPending() || isDisabled }
-				onChange={ handleToggle( name ) }>
-				<span className="site-settings__toggle-label">
-					{ label }
-				</span>
+				onChange={ handleToggle( name ) }
+			>
+				{ label }
 			</FormToggle>
 		);
 	}


### PR DESCRIPTION
### Purpose

This PR fixes #10949, where @rickybanister recommended that labels belonging to `FormToggle` should also toggle them, just like they naturally do for form checkboxes. 

### Details

There are several pitfalls, like having links in the label, or nested form fields (`select` or `input` in our case) - this PR also takes care of that. 

In addition, while implementing new Jetpack Settings cards we introduced additional wrappers for the label text where necessary. This PR improves this by adding that wrapper directly in the `FormToggle` component. This helps us with implementing the toggle-on-label-click functionality, but it also helps with keeping `FormToggle` instances clean from unnecessary wrappers for labels which we were repetitively adding.

In a nutshell, this PR takes care of:

* Wrapping the label text directly in `FormToggle` (including the styles).
* Cleaning up the now obsolete form toggle label wrappers, and all related styles.
* Implement the toggle-on-label-click functionality, while ignoring nested links, inputs and select fields.

### Testing

* Checkout this branch or get it going on calypso.live
* Go to any Settings page that has a toggle field.
* Play with any toggle label and verify it toggles the field correctly.
* Verify clicking a link within a `FormToggle` label does not toggle the field (there are such links in the Writing tab).
* Verify clicking an input field within a `FormToggle` label does not toggle the field (there are such fields in the Discussion tab).
* Verify clicking a select field within a `FormToggle` label does not toggle the field (there are such fields in the Discussion tab).
* Verify clicking any part of the toggle label (with the exception of the links, inputs and selects) properly toggle the field, including the part after the link/select/input. Test this with any `FormToggle` you can think of.
