### PR TITLE
Billing: Introduce an updated placeholder for TransactionsTable

### DIFF
--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -65,6 +65,18 @@
 	&:last-child {
 		border-bottom: none;
 	}
+
+	&.is-placeholder {
+		height: auto;
+
+		td {
+			padding: 24px;
+		}
+
+		.billing-history__transaction-text {
+			@include placeholder();
+		}
+	}
 }
 
 .billing-history__header-row {

--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -133,13 +133,25 @@ var TransactionsTable = React.createClass( {
 		return description;
 	},
 
+	renderPlaceholder() {
+		return (
+			<tr className="billing-history__transaction is-placeholder">
+				<td className="date">
+					<div className="billing-history__transaction-text" />
+				</td>
+				<td className="billing-history__trans-app">
+					<div className="billing-history__transaction-text" />
+				</td>
+				<td className="billing-history__amount">
+					<div className="billing-history__transaction-text" />
+				</td>
+			</tr>
+		);
+	},
+
 	renderRows: function() {
 		if ( ! this.state.transactions ) {
-			return (
-				<tr className="billing-history__no-results">
-					<td className="billing-history__no-results-cell" colSpan="3">{ this.translate( 'Loading…' ) }</td>
-				</tr>
-			);
+			return this.renderPlaceholder();
 		}
 
 		if ( isEmpty( this.state.transactions ) ) {


### PR DESCRIPTION
This PR introduces an updated pulsating placeholder for billing transactions. Previously, we were displaying just a "Loading..." message, which is not consistent with our [Reactivity and Loading States recommendations](https://github.com/Automattic/wp-calypso/blob/master/docs/reactivity.md).

**Before:**
![](https://cldup.com/XlYTKoIJsz.png)

**After:**
![](https://cldup.com/HkB2pFrGC1.png)

This PR is part of the billing reduxification effort (#10554).

To test:

* Checkout this branch or get it going on calypso.live.
* Clear your Redux state.
* Go to `/me/purchases/billing` to see the updated placeholder.