### PR TITLE
Billing: Remove unused instances of eventRecorder mixin

### DIFF
--- a/client/me/billing-history/main.jsx
+++ b/client/me/billing-history/main.jsx
@@ -13,7 +13,6 @@ import Card from 'components/card';
 import MeSidebarNavigation from 'me/sidebar-navigation';
 import config from 'config';
 import CreditCards from 'me/purchases/credit-cards';
-import eventRecorder from 'me/event-recorder';
 import PurchasesHeader from '../purchases/list/header';
 import BillingHistoryTable from './billing-history-table';
 import UpcomingChargesTable from './upcoming-charges-table';
@@ -26,7 +25,7 @@ import purchasesPaths from 'me/purchases/paths';
 import { getPastBillingTransactions, getUpcomingBillingTransactions } from 'state/selectors';
 
 const BillingHistory = React.createClass( {
-	mixins: [ observe( 'sites' ), eventRecorder ],
+	mixins: [ observe( 'sites' ) ],
 
 	render() {
 		const { pastTransactions, upcomingTransactions, sites, translate } = this.props;

--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -12,15 +12,12 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var TransactionsHeader = require( './transactions-header' ),
-	tableRows = require( './table-rows' ),
-	eventRecorder = require( 'me/event-recorder' );
+	tableRows = require( './table-rows' );
 
 import SearchCard from 'components/search-card';
 
 var TransactionsTable = React.createClass( {
 	displayName: 'TransactionsTable',
-
-	mixins: [ eventRecorder ],
 
 	getInitialState: function() {
 		var initialTransactions;


### PR DESCRIPTION
This PR removes several instances of `eventRecorder` within `/me/billing-history` that are not used at all. No testing is required, just make sure that no `record*` methods from the mixin are being used in `main.jsx` and `transactions-table.jsx`. This PR is part of #10554.