### PR TITLE
Stats: Cleanup Stats Overview component from sitesList and User Lib

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -9,7 +9,6 @@ import { find, pick } from 'lodash';
 /**
  * Internal Dependencies
  */
-import userFactory from 'lib/user';
 import sitesFactory from 'lib/sites-list';
 import route from 'lib/route';
 import analytics from 'lib/analytics';
@@ -21,7 +20,6 @@ import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import AsyncLoad from 'components/async-load';
 import StatsPagePlaceholder from 'my-sites/stats/stats-page-placeholder';
-const user = userFactory();
 const sites = sitesFactory();
 const analyticsPageTitle = 'Stats';
 
@@ -166,8 +164,6 @@ module.exports = {
 			const props = {
 				period: activeFilter.period,
 				path: context.pathname,
-				sites,
-				user
 			};
 			renderWithReduxStore(
 				<AsyncLoad placeholder={ <StatsPagePlaceholder /> } require="my-sites/stats/overview" { ...props } />,

--- a/client/state/selectors/get-visible-sites.js
+++ b/client/state/selectors/get-visible-sites.js
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { getSite } from 'state/sites/selectors';
+
+/**
+ * Get all visible sites
+ *
+ * @param {Object} state  Global state tree
+ * @return {Array}        Sites objects
+ */
+export default function getVisibleSites( state ) {
+	return Object.values( state.sites.items )
+		.filter( site => site.visible === true )
+		.map( site => getSite( state, site.ID ) );
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -54,6 +54,7 @@ export getTimezonesLabel from './get-timezones-label';
 export getTimezonesLabels from './get-timezones-labels';
 export getTimezonesLabelsByContinent from './get-timezones-labels-by-continent';
 export getUpcomingBillingTransactions from './get-upcoming-billing-transactions';
+export getVisibleSites from './get-visible-sites';
 export hasBrokenSiteUserConnection from './has-broken-site-user-connection';
 export isAccountRecoveryResetOptionsReady from './is-account-recovery-reset-options-ready';
 export isActivatingJetpackJumpstart from './is-activating-jetpack-jumpstart';

--- a/client/state/selectors/test/get-visible-sites.js
+++ b/client/state/selectors/test/get-visible-sites.js
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getVisibleSites } from '../';
+
+describe( 'getVisibleSites()', () => {
+	it( 'should return an empty array if no sites in state', () => {
+		const state = {
+			sites: {
+				items: {}
+			}
+		};
+		const sites = getVisibleSites( state );
+		expect( sites ).to.eql( [] );
+	} );
+
+	it( 'should return the visibles sites in state', () => {
+		const state = {
+			sites: {
+				items: {
+					2916284: {
+						ID: 2916284,
+						visible: true,
+						name: 'WordPress.com Example Blog',
+						URL: 'https://example.com',
+						options: {
+							unmapped_url: 'https://example.wordpress.com'
+						}
+					},
+					2916285: {
+						ID: 2916285,
+						visible: false,
+						name: 'WordPress.com Non visible Blog',
+						URL: 'https://example2.com',
+						options: {
+							unmapped_url: 'https://example2.wordpress.com'
+						}
+					}
+				}
+			}
+		};
+		const sites = getVisibleSites( state );
+		expect( sites ).to.eql( [
+			{
+				ID: 2916284,
+				visible: true,
+				name: 'WordPress.com Example Blog',
+				URL: 'https://example.com',
+				title: 'WordPress.com Example Blog',
+				domain: 'example.com',
+				slug: 'example.com',
+				hasConflict: false,
+				is_customizable: false,
+				is_previewable: true,
+				options: {
+					default_post_format: 'standard',
+					unmapped_url: 'https://example.wordpress.com'
+				}
+			}
+		] );
+	} );
+} );

--- a/client/state/selectors/test/get-visible-sites.js
+++ b/client/state/selectors/test/get-visible-sites.js
@@ -27,18 +27,18 @@ describe( 'getVisibleSites()', () => {
 						ID: 2916284,
 						visible: true,
 						name: 'WordPress.com Example Blog',
-						URL: 'https://example.com',
+						URL: 'http://example.com',
 						options: {
-							unmapped_url: 'https://example.wordpress.com'
+							unmapped_url: 'http://example.com'
 						}
 					},
 					2916285: {
 						ID: 2916285,
 						visible: false,
 						name: 'WordPress.com Non visible Blog',
-						URL: 'https://example2.com',
+						URL: 'http://example2.com',
 						options: {
-							unmapped_url: 'https://example2.wordpress.com'
+							unmapped_url: 'http://example2.com'
 						}
 					}
 				}
@@ -50,16 +50,16 @@ describe( 'getVisibleSites()', () => {
 				ID: 2916284,
 				visible: true,
 				name: 'WordPress.com Example Blog',
-				URL: 'https://example.com',
+				URL: 'http://example.com',
 				title: 'WordPress.com Example Blog',
 				domain: 'example.com',
 				slug: 'example.com',
 				hasConflict: false,
 				is_customizable: false,
-				is_previewable: true,
+				is_previewable: false,
 				options: {
 					default_post_format: 'standard',
-					unmapped_url: 'https://example.wordpress.com'
+					unmapped_url: 'http://example.com'
 				}
 			}
 		] );


### PR DESCRIPTION
Just a small PR to clean up the StatsOverview component from the legacy sitesList and userLib dependencies.

**Testing instructions**

 - Navigate to the overview stats pages: `/stats/day` (`/week`, `/month`, `/year`)
 - It should show the sites stats (same as master)