### PR TITLE
Google Analytics: Enable on Jetpack Sites

### DIFF
--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -199,7 +199,7 @@ const mapStateToProps = ( state, ownProps ) => {
 
 	const isGoogleAnalyticsEligible = site && site.plan && hasBusinessPlan( site.plan );
 	const jetpackModuleActive = isJetpackModuleActive( state, site.ID, 'google-analytics' );
-	const jetpackVersionSupportsModule = isJetpackMinimumVersion( state, site.ID, '4.5-beta1' );
+	const jetpackVersionSupportsModule = isJetpackMinimumVersion( state, site.ID, '4.6-alpha' );
 	const googleAnalyticsEnabled = site && (
 		! site.jetpack ||
 		( site.jetpack && jetpackModuleActive && jetpackVersionSupportsModule && isEnabled( 'jetpack/google-analytics' ) )

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -23,6 +23,7 @@
 		"help": true,
 		"help/courses": true,
 		"jetpack/connect": true,
+		"jetpack/google-analytics": true,
 		"jetpack/personalPlan": true,
 		"manage/custom-post-types": true,
 		"manage/customize": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -24,6 +24,7 @@
 		"help/courses": true,
 		"jetpack/connect": true,
 		"jetpack/api-cache": true,
+		"jetpack/google-analytics": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
 		"manage/custom-post-types": true,

--- a/config/production.json
+++ b/config/production.json
@@ -21,6 +21,7 @@
 		"help": true,
 		"help/courses": true,
 		"jetpack/connect": true,
+		"jetpack/google-analytics": true,
 		"jetpack/personalPlan": true,
 		"jetpack/api-cache": false,
 		"manage/custom-post-types": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -23,6 +23,7 @@
 		"help": true,
 		"help/courses": true,
 		"jetpack/connect": true,
+		"jetpack/google-analytics": true,
 		"jetpack/personalPlan": true,
 		"jetpack/api-cache": true,
 		"jetpack_core_inline_update": true,


### PR DESCRIPTION
Enables Google Analytics for Jetpack sites on all environments from Jetpack version 4.6-alpha onwards.

cc: @jeherve @dereksmart @beaulebens 