### PR TITLE
Stats: Cleanup SitesList usage from StatsSite component

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -179,19 +179,8 @@ module.exports = {
 
 	site: function( context, next ) {
 		let siteId = context.params.site_id;
-		const siteFragment = route.getSiteFragment( context.path );
 		const queryOptions = context.query;
-		const filters = getSiteFilters.bind( null, siteId );
 		let date;
-		const charts = function() {
-			return [
-				{ attr: 'views', legendOptions: [ 'visitors' ], gridicon: 'visible',
-					label: i18n.translate( 'Views', { context: 'noun' } ) },
-				{ attr: 'visitors', gridicon: 'user', label: i18n.translate( 'Visitors', { context: 'noun' } ) },
-				{ attr: 'likes', gridicon: 'star', label: i18n.translate( 'Likes', { context: 'noun' } ) },
-				{ attr: 'comments', gridicon: 'comment', label: i18n.translate( 'Comments', { context: 'noun' } ) }
-			];
-		};
 		let chartTab;
 		let period;
 		let siteOffset = 0;
@@ -209,11 +198,12 @@ module.exports = {
 		}
 		siteId = currentSite ? ( currentSite.ID || 0 ) : 0;
 
-		const activeFilter = find( filters(), ( filter ) => {
+		const filters = getSiteFilters( siteId );
+		const activeFilter = find( filters, ( filter ) => {
 			return context.pathname === filter.path || ( filter.altPaths && -1 !== filter.altPaths.indexOf( context.pathname ) );
 		} );
 
-		if ( ! siteFragment || ! activeFilter ) {
+		if ( ! activeFilter ) {
 			next();
 		} else {
 			if ( 0 === siteId ) {
@@ -258,21 +248,13 @@ module.exports = {
 			analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle + ' > ' + titlecase( activeFilter.period ) );
 
 			period = rangeOfPeriod( activeFilter.period, date );
-
 			chartTab = queryOptions.tab || 'views';
 
-			const siteDomain = ( currentSite && ( typeof currentSite.slug !== 'undefined' ) )
-					? currentSite.slug : siteFragment;
-
 			const siteComponentChildren = {
-				slug: siteDomain,
 				path: context.pathname,
 				date,
-				charts,
 				chartTab,
 				context,
-				sites,
-				siteId,
 				period,
 			};
 

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -179,6 +179,7 @@ module.exports = {
 
 	site: function( context, next ) {
 		let siteId = context.params.site_id;
+		const filters = getSiteFilters( siteId );
 		const queryOptions = context.query;
 		let date;
 		let chartTab;
@@ -198,7 +199,6 @@ module.exports = {
 		}
 		siteId = currentSite ? ( currentSite.ID || 0 ) : 0;
 
-		const filters = getSiteFilters( siteId );
 		const activeFilter = find( filters, ( filter ) => {
 			return context.pathname === filter.path || ( filter.altPaths && -1 !== filter.altPaths.indexOf( context.pathname ) );
 		} );

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -2,8 +2,9 @@
  * External dependencies
  */
 import page from 'page';
-import React from 'react';
-import debugFactory from 'debug';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -18,89 +19,62 @@ import ChartTabs from './stats-chart-tabs';
 import StatsModule from './stats-module';
 import statsStrings from './stats-strings';
 import titlecase from 'to-title-case';
-import analytics from 'lib/analytics';
 import StatsFirstView from './stats-first-view';
 import StickyPanel from 'components/sticky-panel';
 import config from 'config';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSiteOption, isJetpackSite } from 'state/sites/selectors';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
-const debug = debugFactory( 'calypso:stats:site' );
-
-module.exports = React.createClass( {
-	displayName: 'StatsSite',
-
-	getInitialState: function() {
-		const scrollPosition = this.props.context.state.scrollPosition || 0;
-
-		return {
-			date: this.props.date,
-			chartDate: this.props.date,
+class StatsSite extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
 			chartTab: this.props.chartTab,
-			tabSwitched: false,
-			period: this.props.period.period,
-			scrollPosition: scrollPosition
+			tabSwitched: false
 		};
-	},
+	}
 
-	componentWillReceiveProps: function( nextProps ) {
-		const newDate = this.moment( nextProps.date );
-		const newState = {
-			date: newDate,
-			chartDate: newDate
-		};
-
-		if ( ! this.state.tabSwitched || ( this.state.period !== nextProps.period.period ) ) {
-			newState.chartTab = nextProps.chartTab;
-			newState.period = nextProps.period.period;
-			newState.tabSwitched = true;
+	componentWillReceiveProps( nextProps ) {
+		if ( ! this.state.tabSwitched && this.state.chartTab !== nextProps.chartTab ) {
+			this.setState( {
+				tabSwitched: true,
+				chartTab: nextProps.chartTab
+			} );
 		}
+	}
 
-		this.setState( newState );
-	},
-
-	scrollTop: function() {
-		if ( window.pageYOffset ) {
-			return window.pageYOffset;
-		}
-		return document.documentElement.clientHeight ? document.documentElement.scrollTop : document.body.scrollTop;
-	},
-
-	componentDidMount: function() {
-		const scrollPosition = this.state.scrollPosition;
-
-		setTimeout( function() {
-			window.scrollTo( 0, scrollPosition );
+	componentDidMount() {
+		setTimeout( () => {
+			window.scrollTo( 0, 0 );
 		} );
-	},
+	}
 
-	updateScrollPosition: function() {
-		this.props.context.state.scrollPosition = this.scrollTop();
-		this.props.context.save();
-	},
-
-	// When user clicks on a bar, set the date to the bar's period
-	chartBarClick: function( bar ) {
-		page.redirect( this.props.path + '?startDate=' + bar.period );
-	},
-
-	barClick: function( bar ) {
-		analytics.ga.recordEvent( 'Stats', 'Clicked Chart Bar' );
+	barClick = ( bar ) => {
+		this.props.recordGoogleEvent( 'Stats', 'Clicked Chart Bar' );
 		page.redirect( this.props.path + '?startDate=' + bar.data.period );
-	},
+	};
 
-	switchChart: function( tab ) {
+	switchChart = ( tab ) => {
 		if ( ! tab.loading && tab.attr !== this.state.chartTab ) {
-			analytics.ga.recordEvent( 'Stats', 'Clicked ' + titlecase( tab.attr ) + ' Tab' );
+			this.props.recordGoogleEvent( 'Stats', 'Clicked ' + titlecase( tab.attr ) + ' Tab' );
 			this.setState( {
 				chartTab: tab.attr,
 				tabSwitched: true
 			} );
 		}
-	},
+	};
 
-	render: function() {
-		const site = this.props.sites.getSite( this.props.siteId );
-		const charts = this.props.charts();
-		const queryDate = this.props.date.format( 'YYYY-MM-DD' );
+	render() {
+		const { date, isJetpack, hasPodcasts, slug, translate } = this.props;
+		const charts = [
+			{ attr: 'views', legendOptions: [ 'visitors' ], gridicon: 'visible',
+				label: translate( 'Views', { context: 'noun' } ) },
+			{ attr: 'visitors', gridicon: 'user', label: translate( 'Visitors', { context: 'noun' } ) },
+			{ attr: 'likes', gridicon: 'star', label: translate( 'Likes', { context: 'noun' } ) },
+			{ attr: 'comments', gridicon: 'comment', label: translate( 'Comments', { context: 'noun' } ) }
+		];
+		const queryDate = date.format( 'YYYY-MM-DD' );
 		const { period, endOf } = this.props.period;
 		const moduleStrings = statsStrings();
 		let videoList;
@@ -111,36 +85,32 @@ module.exports = React.createClass( {
 			date: endOf.format( 'YYYY-MM-DD' )
 		};
 
-		debug( 'Rendering site stats component', this.props );
-
-		if ( site ) {
-			// Video plays, and tags and categories are not supported in JetPack Stats
-			if ( ! site.jetpack ) {
-				videoList = (
-					<StatsModule
-						path="videoplays"
-						moduleStrings={ moduleStrings.videoplays }
-						period={ this.props.period }
-						date={ queryDate }
-						query={ query }
-						statType="statsVideoPlays"
-						showSummaryLink
-					/>
-				);
-			}
-			if ( config.isEnabled( 'manage/stats/podcasts' ) && site.options.podcasting_archive ) {
-				podcastList = (
-					<StatsModule
-						path="podcastdownloads"
-						moduleStrings={ moduleStrings.podcastdownloads }
-						period={ this.props.period }
-						date={ queryDate }
-						query={ query }
-						statType="statsPodcastDownloads"
-						showSummaryLink
-					/>
-				);
-			}
+		// Video plays, and tags and categories are not supported in JetPack Stats
+		if ( ! isJetpack ) {
+			videoList = (
+				<StatsModule
+					path="videoplays"
+					moduleStrings={ moduleStrings.videoplays }
+					period={ this.props.period }
+					date={ queryDate }
+					query={ query }
+					statType="statsVideoPlays"
+					showSummaryLink
+				/>
+			);
+		}
+		if ( config.isEnabled( 'manage/stats/podcasts' ) && hasPodcasts ) {
+			podcastList = (
+				<StatsModule
+					path="podcastdownloads"
+					moduleStrings={ moduleStrings.podcastdownloads }
+					period={ this.props.period }
+					date={ queryDate }
+					query={ query }
+					statType="statsPodcastDownloads"
+					showSummaryLink
+				/>
+			);
 		}
 
 		return (
@@ -158,13 +128,13 @@ module.exports = React.createClass( {
 						chartTab={ this.state.chartTab } />
 					<StickyPanel className="stats__sticky-navigation">
 						<StatsPeriodNavigation
-							date={ this.props.date }
-							period={ this.props.period.period }
-							url={ `/stats/${ this.props.period.period }/${ site.slug }` }
+							date={ date }
+							period={ period }
+							url={ `/stats/${ period }/${ slug }` }
 						>
 							<DatePicker
-								period={ this.props.period.period }
-								date={ this.props.date } />
+								period={ period }
+								date={ date } />
 						</StatsPeriodNavigation>
 					</StickyPanel>
 					<div className="stats__module-list is-events">
@@ -225,4 +195,16 @@ module.exports = React.createClass( {
 			</Main>
 		);
 	}
-} );
+}
+
+export default connect(
+	state => {
+		const siteId = getSelectedSiteId( state );
+		return {
+			isJetpack: isJetpackSite( state, siteId ),
+			hasPodcasts: getSiteOption( state, siteId, 'podcasting_archive' ),
+			slug: getSelectedSiteSlug( state )
+		};
+	},
+	{  recordGoogleEvent }
+)( localize( StatsSite ) );

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -44,12 +44,6 @@ class StatsSite extends Component {
 		}
 	}
 
-	componentDidMount() {
-		setTimeout( () => {
-			window.scrollTo( 0, 0 );
-		} );
-	}
-
 	barClick = ( bar ) => {
 		this.props.recordGoogleEvent( 'Stats', 'Clicked Chart Bar' );
 		page.redirect( this.props.path + '?startDate=' + bar.data.period );


### PR DESCRIPTION
In this PR, I'm cleaning the StatsSite component to avoid using SitesList, Analytics Lib and drop some unused state variables.

**Testing instructions**

 * Navigate to stats period pages: `/stats/day/$site` ...
 * Try switching between chart tabs and periods
 * Everything should work like master (the selected tab is kept when switching periods)
