### PR TITLE
Billing: Update BillingHistoryTable to use Redux for receipt email sending

### DIFF
--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -19,6 +19,8 @@ import {
 	ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_FAILED,
 	ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS,
 	ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_FAILED,
+	BILLING_RECEIPT_EMAIL_SEND_FAILURE,
+	BILLING_RECEIPT_EMAIL_SEND_SUCCESS,
 	GRAVATAR_RECEIVE_IMAGE_FAILURE,
 	GRAVATAR_UPLOAD_REQUEST_FAILURE,
 	GRAVATAR_UPLOAD_REQUEST_SUCCESS,
@@ -190,6 +192,10 @@ export const handlers = {
 	[ ACCOUNT_RECOVERY_SETTINGS_RESEND_VALIDATION_FAILED ]: onResentAccountRecoveryEmailValidationFailed,
 	[ ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_SUCCESS ]: onAccountRecoveryPhoneValidationSuccess,
 	[ ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_FAILED ]: onAccountRecoveryPhoneValidationFailed,
+	[ BILLING_RECEIPT_EMAIL_SEND_FAILURE ]: dispatchError( translate(
+		'There was a problem sending your receipt. Please try again later or contact support.'
+	) ),
+	[ BILLING_RECEIPT_EMAIL_SEND_SUCCESS ]: dispatchSuccess( translate( 'Your receipt was sent by email successfully.' ) ),
 	[ GRAVATAR_RECEIVE_IMAGE_FAILURE ]: ( dispatch, action ) => {
 		dispatch( errorNotice( action.errorMessage ) );
 	},


### PR DESCRIPTION
This PR implements the Redux functionality for sending receipt email that was introduced in #11164 into the `BillingHistoryTable` component. It also uses the opportunity to ES6ify the component.

Part of #10554.

To test:

* Checkout this branch.
* Go to `/me/purchases/billing`.
* Click on the "Email Receipt" link of a transaction and verify it works as it did before.
* If you wish to try all cases, use the console dispatcher to dispatch some events (replace `123456` with your receipt ID`:
 * Initiating email sending: `dispatch( { type: 'BILLING_RECEIPT_EMAIL_SEND', receiptId: 123456  } )`
 * Sending successful: `dispatch( { type: 'BILLING_RECEIPT_EMAIL_SEND_SUCCESS', receiptId: 123456  } )`
 * Sending unsuccessful: `dispatch( { type: 'BILLING_RECEIPT_EMAIL_SEND_FAILURE', receiptId: 123456, error: 'An error has occurred'  } )`