### PR TITLE
Themes: Remove isWpcomTheme selector

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -26,7 +26,7 @@ import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 import Card from 'components/card';
 import { getSelectedSite } from 'state/ui/selectors';
-import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { isUserPaid } from 'state/purchases/selectors';
 import ThanksModal from 'my-sites/themes/thanks-modal';
@@ -42,7 +42,6 @@ import {
 	isPremiumThemeAvailable,
 	getThemeRequestErrors,
 	getThemeForumUrl,
-	isWpcomTheme as isThemeWpcom,
 } from 'state/themes/selectors';
 import { getBackPath } from 'state/themes/themes-ui/selectors';
 import EmptyContentComponent from 'components/empty-content';
@@ -494,7 +493,7 @@ const ThemeSheet = React.createClass( {
 		const analyticsPath = `/theme/:slug${ section ? '/' + section : '' }${ siteID ? '/:site_id' : '' }`;
 		const analyticsPageTitle = `Themes > Details Sheet${ section ? ' > ' + titlecase( section ) : '' }${ siteID ? ' > Site' : '' }`;
 
-		const { name: themeName, description, currentUserId, isJetpack, siteIdOrWpcom } = this.props;
+		const { name: themeName, description, currentUserId, isWpcomTheme } = this.props;
 		const title = themeName && i18n.translate( '%(themeName)s Theme', {
 			args: { themeName }
 		} );
@@ -518,8 +517,9 @@ const ThemeSheet = React.createClass( {
 
 		return (
 			<Main className="theme__sheet">
-				<QueryTheme themeId={ this.props.id } siteId={ siteIdOrWpcom } />
-				{ isJetpack && <QueryTheme themeId={ this.props.id } siteId="wporg" /> }
+				<QueryTheme themeId={ this.props.id } siteId={ 'wpcom' } />
+				{ ! isWpcomTheme && <QueryTheme themeId={ this.props.id } siteId={ siteID } /> }
+				{ ! isWpcomTheme && <QueryTheme themeId={ this.props.id } siteId="wporg" /> }
 				{ currentUserId && <QueryUserPurchases userId={ currentUserId } /> }
 				{ siteID && <QuerySitePurchases siteId={ siteID } /> }
 				{ siteID && <QuerySitePlans siteId={ siteID } /> }
@@ -644,9 +644,8 @@ export default connect(
 	( state, { id } ) => {
 		const selectedSite = getSelectedSite( state );
 		const siteSlug = selectedSite ? getSiteSlug( state, selectedSite.ID ) : '';
-		const isJetpack = selectedSite && isJetpackSite( state, selectedSite.ID );
-		const isWpcomTheme = selectedSite ? isThemeWpcom( state, id, selectedSite.ID ) : true;
-		const siteIdOrWpcom = ( isJetpack && ! isWpcomTheme ) ? selectedSite.ID : 'wpcom';
+		const isWpcomTheme = !! getTheme( state, 'wpcom', id );
+		const siteIdOrWpcom = ! isWpcomTheme ? selectedSite.ID : 'wpcom';
 		const backPath = getBackPath( state );
 		const currentUserId = getCurrentUserId( state );
 		const isCurrentUserPaid = isUserPaid( state, currentUserId );
@@ -659,8 +658,6 @@ export default connect(
 			error,
 			selectedSite,
 			siteSlug,
-			isJetpack,
-			siteIdOrWpcom,
 			backPath,
 			currentUserId,
 			isCurrentUserPaid,

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -518,7 +518,7 @@ const ThemeSheet = React.createClass( {
 		return (
 			<Main className="theme__sheet">
 				<QueryTheme themeId={ this.props.id } siteId={ 'wpcom' } />
-				{ ! isWpcomTheme && <QueryTheme themeId={ this.props.id } siteId={ siteID } /> }
+				{ ! isWpcomTheme && siteID && <QueryTheme themeId={ this.props.id } siteId={ siteID } /> }
 				{ ! isWpcomTheme && <QueryTheme themeId={ this.props.id } siteId="wporg" /> }
 				{ currentUserId && <QueryUserPurchases userId={ currentUserId } /> }
 				{ siteID && <QuerySitePurchases siteId={ siteID } /> }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -645,7 +645,7 @@ export default connect(
 		const selectedSite = getSelectedSite( state );
 		const siteSlug = selectedSite ? getSiteSlug( state, selectedSite.ID ) : '';
 		const isWpcomTheme = !! getTheme( state, 'wpcom', id );
-		const siteIdOrWpcom = ! isWpcomTheme ? selectedSite.ID : 'wpcom';
+		const siteIdOrWpcom = ( selectedSite && ! isWpcomTheme ) ? selectedSite.ID : 'wpcom';
 		const backPath = getBackPath( state );
 		const currentUserId = getCurrentUserId( state );
 		const isCurrentUserPaid = isUserPaid( state, currentUserId );

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -25,7 +25,6 @@ import {
 	isThemeActive as isActive,
 	isThemePremium as isPremium,
 	isPremiumThemeAvailable,
-	isWpcomTheme,
 } from 'state/themes/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { hasFeature } from 'state/sites/plans/selectors';
@@ -117,13 +116,12 @@ const support = {
 	label: i18n.translate( 'Setup' ),
 	icon: 'help',
 	getUrl: getSupportUrl,
-	hideForTheme: ( state, theme, siteId ) => ! isPremium( state, theme.id ) || ! isWpcomTheme( state, theme.id, siteId )
+	hideForTheme: ( state, theme ) => ! isPremium( state, theme.id )
 };
 
 const help = {
 	label: i18n.translate( 'Support' ),
 	getUrl: getHelpUrl,
-	hideForTheme: ( state, theme, siteId ) => ! isWpcomTheme( state, theme.id, siteId )
 };
 
 const ALL_THEME_OPTIONS = {

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -70,9 +70,9 @@ export const getTheme = createSelector(
 /**
  * When wpcom themes are installed on Jetpack sites, the
  * theme id is suffixed with -wpcom. Some operations require
- * the use of this suffixed ID. This util function add the
- * suffix if the theme is a wpcom theme and the site is Jetpack.
- * or not, given siteId and ThemeId.
+ * the use of this suffixed ID. This util function adds the
+ * suffix if the site is jetpack and the theme is not yet
+ * installed on the site.
  *
  * @param {Object} state	Global state tree
  * @param {String} themeId	Theme ID

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -30,26 +30,6 @@ import { DEFAULT_THEME_QUERY } from './constants';
 import { FEATURE_UNLIMITED_PREMIUM_THEMES, PLAN_PREMIUM } from 'lib/plans/constants';
 
 /**
- * When wpcom themes are installed on Jetpack sites, the
- * theme id is suffixed with -wpcom. Some operations require
- * the use of this suffixed ID. This util function add the
- * suffix if the theme is a wpcom theme and the site is Jetpack.
- * or not, given siteId and ThemeId.
- *
- * @param {Object} state	Global state tree
- * @param {String} themeId	Theme ID
- * @param {Number} siteId	Site ID
- * @return {String} 		Potentially suffixed theme ID
- */
-const getSuffixedThemeId = ( state, themeId, siteId ) => {
-	const siteIsJetpack = siteId && isJetpackSite( state, siteId );
-	if ( siteIsJetpack && isWpcomTheme( state, themeId, siteId ) ) {
-		return `${ themeId }-wpcom`;
-	}
-	return themeId;
-};
-
-/**
  * Returns a theme object by site ID, theme ID pair.
  *
  * @param  {Object}  state   Global state tree
@@ -86,6 +66,26 @@ export const getTheme = createSelector(
 	},
 	( state ) => state.themes.queries
 );
+
+/**
+ * When wpcom themes are installed on Jetpack sites, the
+ * theme id is suffixed with -wpcom. Some operations require
+ * the use of this suffixed ID. This util function add the
+ * suffix if the theme is a wpcom theme and the site is Jetpack.
+ * or not, given siteId and ThemeId.
+ *
+ * @param {Object} state	Global state tree
+ * @param {String} themeId	Theme ID
+ * @param {Number} siteId	Site ID
+ * @return {String} 		Potentially suffixed theme ID
+ */
+const getSuffixedThemeId = ( state, themeId, siteId ) => {
+	const siteIsJetpack = siteId && isJetpackSite( state, siteId );
+	if ( siteIsJetpack && ! getTheme( state, siteId, themeId ) ) {
+		return `${ themeId }-wpcom`;
+	}
+	return themeId;
+};
 
 /**
  * Returns theme request error object
@@ -323,23 +323,6 @@ export function isRequestingActiveTheme( state, siteId ) {
  */
 export function isWporgTheme( state, themeId ) {
 	return !! getTheme( state, 'wporg', themeId );
-}
-
-/**
- * Whether a theme is present on WordPress.com.
- *
- * Returns false if themeId is installed on (jetpack) siteId, since
- * installed themes take priority. For example, this can be the case
- * with themes available on both wpcom and .org such as 'twentysixteen'.
- *
- * @param  {Object}  state   Global state tree
- * @param  {Number}  themeId Theme ID
- * @param  {Number}  siteId  Site ID
- * @return {Boolean}         Whether theme available on WordPress.com
- */
-export function isWpcomTheme( state, themeId, siteId ) {
-	return !! ( getTheme( state, 'wpcom', themeId ) &&
-		! getTheme( state, siteId, themeId ) );
 }
 
 /**

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -28,7 +28,6 @@ import {
 	getActiveTheme,
 	isRequestingActiveTheme,
 	isWporgTheme,
-	isWpcomTheme,
 	isThemeActive,
 	isActivatingTheme,
 	hasActivatedTheme,
@@ -1844,66 +1843,6 @@ describe( 'themes selectors', () => {
 			}, 'twentyseventeen' );
 
 			expect( isWporg ).to.be.true;
-		} );
-	} );
-
-	describe( '#isWpcomTheme()', () => {
-		it( 'should return false if theme is not found on WordPress.com', () => {
-			const isWpcom = isWpcomTheme( {
-				themes: {
-					queries: {
-					}
-				}
-			}, 'twentyseventeen', 77203074 );
-
-			expect( isWpcom ).to.be.false;
-		} );
-
-		it( 'should return true if theme is found on WordPress.com', () => {
-			const wpcomTheme = {
-				id: 'twentyseventeen',
-				name: 'Twenty Seventeen',
-				author: 'wordpressdotorg',
-				demo_uri: 'https://wp-themes.com/twentyseventeen',
-				download: 'http://downloads.wordpress.org/theme/twentyseventeen.1.1.zip',
-				taxonomies: {
-					theme_feature: {
-						'custom-header': 'Custom Header'
-					}
-				}
-			};
-			const isWpcom = isWpcomTheme( {
-				themes: {
-					queries: {
-						wpcom: new ThemeQueryManager( {
-							items: { twentyseventeen: wpcomTheme }
-						} ),
-					}
-				}
-			}, 'twentyseventeen', 77203074 );
-
-			expect( isWpcom ).to.be.true;
-		} );
-
-		it( 'should return false if theme is found on WordPress.com and is also installed on site', () => {
-			const theme = {
-				id: 'twentysixteen',
-				name: 'Twenty Sixteen',
-			};
-			const isWpcom = isWpcomTheme( {
-				themes: {
-					queries: {
-						wpcom: new ThemeQueryManager( {
-							items: { twentysixteen: theme }
-						} ),
-						77203074: new ThemeQueryManager( {
-							items: { twentysixteen: theme }
-						} ),
-					}
-				}
-			}, 'twentysixteen', 77203074 );
-
-			expect( isWpcom ).to.be.false;
 		} );
 	} );
 


### PR DESCRIPTION
Because
* Its logic can be replaced by `getTheme( state, 'wpcom', themeId )`
* Its usage had changed over time and as such was now wrongly named

**Visual Differences**
* For any theme that exists on wpcom, we now show the full wpcom info in the theme sheet instead of the info fetched from the jetpack site
* Any theme in the _Uploaded themes_ list now has a _Support_ link to the info sheet

