### PR TITLE
Reader: fix unfollowing

### DIFF
--- a/client/lib/reader-feed-subscriptions/actions.js
+++ b/client/lib/reader-feed-subscriptions/actions.js
@@ -9,7 +9,7 @@ import Dispatcher from 'dispatcher';
  */
 import wpcom from 'lib/wp';
 import { action as ActionTypes } from './constants';
-import FeedSubscriptionHelper from './helper';
+import { prepareSiteUrl } from './helper';
 import { isRequestInflight, requestTracker } from 'lib/inflight';
 import FeedSubscriptionStore from './index';
 import { action as SiteStoreActionTypes } from 'lib/reader-site-store/constants';
@@ -23,7 +23,7 @@ const FeedSubscriptionActions = {
 			return;
 		}
 
-		const preparedUrl = FeedSubscriptionHelper.prepareSiteUrl( url );
+		const preparedUrl = prepareSiteUrl( url );
 
 		if ( fetchMeta ) {
 			meta = 'feed,site';
@@ -52,7 +52,7 @@ const FeedSubscriptionActions = {
 			return;
 		}
 
-		const preparedUrl = FeedSubscriptionHelper.prepareSiteUrl( url );
+		const preparedUrl = prepareSiteUrl( url );
 
 		Dispatcher.handleViewAction( {
 			type: ActionTypes.UNFOLLOW_READER_FEED,

--- a/client/lib/reader-feed-subscriptions/helper.js
+++ b/client/lib/reader-feed-subscriptions/helper.js
@@ -1,9 +1,4 @@
 /**
- * External Dependencies
- */
-
-
-/**
  * Internal Dependencies
  */
 import untrailingslashit from 'lib/route/untrailingslashit';


### PR DESCRIPTION
When FeedSubscriptionHelper got es6ified all of the functions became named exports but the `default` was left out.  That meant anything referencing FeedSubscriptionHelper was left out to dry and errored.

This fixes all usages to use the named exports instead.

fixes: https://github.com/Automattic/wp-calypso/issues/11180 

To Test:
- [ ] try to unfollow something from `following/edit`