### PR TITLE
Checkout: Fix error thrown because of missing domain in cart

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -151,7 +151,8 @@ const analytics = {
 			if ( process.env.NODE_ENV !== 'production' ) {
 				for ( const key in eventProperties ) {
 					if ( isObjectLike( eventProperties[ key ] ) && typeof console !== 'undefined' ) {
-						console.error( `Nested properties are not supported by Tracks. Check '${ key }' on`, eventProperties ); //eslint-disable-line no-console
+						console.error( `Unable to record event "${ eventName }" because nested properties are not supported by Tracks. Check '${ key }' on`, eventProperties ); //eslint-disable-line no-console
+
 						return;
 					}
 				}

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -197,6 +197,7 @@ const Checkout = React.createClass( {
 				: '/checkout/thank-you/plans';
 		} else if ( cart.create_new_blog && cartItems.hasDomainRegistration( cart ) && ! cartItems.hasPlan( cart ) ) {
 			const domainName = cartItems.getDomainRegistrations( cart )[ 0 ].meta;
+
 			return domainManagementList( domainName );
 		}
 
@@ -276,7 +277,7 @@ const Checkout = React.createClass( {
 			this.props.clearSitePlans( selectedSiteId );
 		}
 
-		if ( cart.create_new_blog ) {
+		if ( cart.create_new_blog && cartItems.hasDomainRegistration( cart ) ) {
 			notices.info(
 				this.translate( 'Almost done…' )
 			);
@@ -286,6 +287,7 @@ const Checkout = React.createClass( {
 			fetchSitesAndUser( domainName, () => {
 				page( redirectPath );
 			} );
+
 			return;
 		}
 


### PR DESCRIPTION
This pull request fixes an error thrown at the end of the `domains-only` flow when the shopping cart doesn't contain any domain registration (supposedly because at some point the cart will be cleared after a successful purchase, then the poller will retrieve it and the `Checkout` page be re-rendered):

```
checkout.jsx:304 Uncaught TypeError: Cannot read property 'meta' of undefined
  at Object.handleCheckoutCompleteRedirect (checkout.jsx:304)
  at eval (transaction-steps-mixin.jsx:149)
  at eval (_baseDelay.js:18)
```

This pull request also refines an error message introduced in https://github.com/Automattic/wp-calypso/pull/6237 to include the name of the event that isn't compliant, as otherwise it's very difficult to find which part of our code triggered that event:

```
Unable to record event "calypso_checkout_product_purchase" because nested properties are not supported by Tracks. Check 'extra' on Object {product_id: 16, product_name: "Private Registration", product_slug: "private_whois", meta: "example.com", cost: 8…}
```
  
#### Testing instructions
 
1. Run `git checkout fix/domains-only-flow` and start your server, or open a [live branch](https://calypso.live/?branch=fix/domains-only-flow)
2. Open the new [`Signup` page](http://calypso.localhost:3000/start/domain-first) in incognito mode
3. Proceed to the `Contact Information` page
4. Use administration tools to add free credits to the new user account
5. Proceed and purchase the domain with the credits
6. Check that you see the new Tracks error messages in your browser's console
7. Check that you are redirected to the [`Domains` page](http://calypso.localhost:3000/domains/manage/:domain)
8. Check that no `Cannot read property 'meta' of undefined` error is present in your browser's console

#### Reviews
 
- [x] Code
- [ ] Product
- [x] Tests