### PR TITLE
Pass parameters renderPage in the correct order.

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -68,8 +68,8 @@ function renderSinglePlugin( context, siteUrl ) {
 			pluginSlug,
 			siteUrl,
 		} ),
-		document.getElementById( 'primary' ),
-		context
+		context,
+		document.getElementById( 'primary' )
 	);
 }
 
@@ -154,8 +154,8 @@ function renderPluginsBrowser( context ) {
 			sites,
 			search: searchTerm
 		} ),
-		document.getElementById( 'primary' ),
-		context
+		context,
+		document.getElementById( 'primary' )
 	);
 }
 
@@ -169,8 +169,8 @@ function renderPluginWarnings( context ) {
 			siteSlug: site.slug,
 			pluginSlug
 		} ),
-		document.getElementById( 'primary' ),
-		context
+		context,
+		document.getElementById( 'primary' )
 	);
 }
 
@@ -191,8 +191,8 @@ function renderProvisionPlugins( context ) {
 		React.createElement( PlanSetup, {
 			whitelist: context.query.only || false
 		} ),
-		document.getElementById( 'primary' ),
-		context
+		context,
+		document.getElementById( 'primary' )
 	);
 }
 


### PR DESCRIPTION
This PR addresses production issue #11184 for displaying details of jetpack plugin details.

The last two parameters to the renderPage function were reversed resulting in an error and rendering failure.

This PR resolves this issue only for this one particular page - there may be other issues where the same refactoring is passing these two parameters incorrectly.