### PR TITLE
Media Section: Fix updating of the image name in UI

### DIFF
--- a/client/post-editor/media-modal/detail/detail-title.jsx
+++ b/client/post-editor/media-modal/detail/detail-title.jsx
@@ -69,10 +69,6 @@ export default React.createClass( {
 				title: this.state.title
 			} );
 		}
-
-		if ( this.isMounted() ) {
-			this.resetTitle();
-		}
 	}, 0 ),
 
 	resetTitle() {

--- a/client/post-editor/media-modal/detail/detail-title.jsx
+++ b/client/post-editor/media-modal/detail/detail-title.jsx
@@ -69,11 +69,15 @@ export default React.createClass( {
 	saveTitle: debounce( function() {
 		// This function is debounced to prevent the case where two consecutive
 		// save attempts would be made as a consequence of the blur in `onKeyUp`
-		if ( this.props.site && this.props.item && this.state.title && this.state.title !== this.props.item.title ) {
-			MediaActions.update( this.props.site.ID, {
-				ID: this.props.item.ID,
-				title: this.state.title
-			} );
+		if ( this.props.site && this.props.item && 'title' in this.state && this.state.title !== this.props.item.title ) {
+			if ( this.state.title ) {
+				MediaActions.update( this.props.site.ID, {
+					ID: this.props.item.ID,
+					title: this.state.title
+				} );
+			} else {
+				this.resetTitle();
+			}
 		}
 	}, 0 ),
 

--- a/client/post-editor/media-modal/detail/detail-title.jsx
+++ b/client/post-editor/media-modal/detail/detail-title.jsx
@@ -63,7 +63,7 @@ export default React.createClass( {
 	saveTitle: debounce( function() {
 		// This function is debounced to prevent the case where two consecutive
 		// save attempts would be made as a consequence of the blur in `onKeyUp`
-		if ( this.props.site && this.props.item && 'title' in this.state && this.state.title !== this.props.item.title ) {
+		if ( this.props.site && this.props.item && this.state.title && this.state.title !== this.props.item.title ) {
 			MediaActions.update( this.props.site.ID, {
 				ID: this.props.item.ID,
 				title: this.state.title

--- a/client/post-editor/media-modal/detail/detail-title.jsx
+++ b/client/post-editor/media-modal/detail/detail-title.jsx
@@ -25,6 +25,12 @@ export default React.createClass( {
 		return {};
 	},
 
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.item.ID !== this.props.item.ID ) {
+			this.resetTitle();
+		}
+	},
+
 	getTitleValue() {
 		if ( 'title' in this.state ) {
 			return this.state.title;


### PR DESCRIPTION
This PR closes #9233.

**Before**

![2c6aa7a2-a5c8-11e6-9bc7-9d1bb5356eff](https://cloud.githubusercontent.com/assets/1783033/22637306/defe153a-ec49-11e6-9041-da9e4d0be3f4.gif)

**After**

![ynljvdnupz](https://cloud.githubusercontent.com/assets/1783033/22637330/f8a3d48e-ec49-11e6-809e-d522d20ae61d.gif)

**Testing Instructions**

1. Navigate to [/media](http://calypso.localhost:3000/media/)
2. Choose an image and click the edit icon
3. Update the image name and move out of the field (or hit enter)

/cc @alisterscott, @iamtakashi
