### PR TITLE
Stats: Make the period navigation sticky in stats pages

### DIFF
--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -72,10 +72,10 @@ module.exports = React.createClass( {
 		if ( this.state.isSticky ) {
 			// Offset to account for Master Bar by finding body visual top
 			// relative the current scroll position
-			offset = document.getElementById( 'content' ).getBoundingClientRect().top;
+			offset = document.getElementById( 'header' ).getBoundingClientRect().height;
 
 			return {
-				top: offset + window.pageYOffset,
+				top: offset,
 				width: this.state.blockWidth
 			};
 		}

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -20,6 +20,7 @@ import statsStrings from './stats-strings';
 import titlecase from 'to-title-case';
 import analytics from 'lib/analytics';
 import StatsFirstView from './stats-first-view';
+import StickyPanel from 'components/sticky-panel';
 import config from 'config';
 
 const debug = debugFactory( 'calypso:stats:site' );
@@ -155,15 +156,17 @@ module.exports = React.createClass( {
 						queryDate={ queryDate }
 						period={ this.props.period }
 						chartTab={ this.state.chartTab } />
-					<StatsPeriodNavigation
-						date={ this.props.date }
-						period={ this.props.period.period }
-						url={ `/stats/${ this.props.period.period }/${ site.slug }` }
-					>
-						<DatePicker
+					<StickyPanel className="stats__sticky-navigation">
+						<StatsPeriodNavigation
+							date={ this.props.date }
 							period={ this.props.period.period }
-							date={ this.props.date } />
-					</StatsPeriodNavigation>
+							url={ `/stats/${ this.props.period.period }/${ site.slug }` }
+						>
+							<DatePicker
+								period={ this.props.period.period }
+								date={ this.props.date } />
+						</StatsPeriodNavigation>
+					</StickyPanel>
 					<div className="stats__module-list is-events">
 						<div className="stats__module-column">
 							<StatsModule

--- a/client/my-sites/stats/stats-period-navigation/style.scss
+++ b/client/my-sites/stats/stats-period-navigation/style.scss
@@ -3,6 +3,7 @@
 	justify-content: space-between;
 	align-items: center;
 	margin: 1.5em 0;
+	padding: 0 20px;
 
 	.stats-period-navigation__children {
 		text-align: center;

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -38,3 +38,14 @@
 		}
 	}
 }
+
+
+.stats__sticky-navigation.is-sticky .sticky-panel__content {
+	background: white;
+	box-shadow: 0 2px 5px rgba( 0, 0, 0, 0.1 ),
+		0 0 56px rgba( 0, 0, 0, 0.075 );
+
+	.stats-period-navigation {
+		margin: 1em 0;
+	}
+}

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -46,6 +46,6 @@
 		0 0 56px rgba( 0, 0, 0, 0.075 );
 
 	.stats-period-navigation {
-		margin: 1em 0;
+		margin: 9px 0;
 	}
 }


### PR DESCRIPTION
Closes #10992 

In this PR, I'm using StickyPanel to make the period navigation sticky in Stats Pages.

<img width="1153" alt="screen shot 2017-02-06 at 10 05 55" src="https://cloud.githubusercontent.com/assets/272444/22640791/68f5feec-ec54-11e6-87d5-83c5447a58d1.png">


**Testing instructions**

* Navigate to the stats period pages `/stats/day/$site`
* Scroll the page and notice that the period navigation panel gets sticky when it hits the top of the page