### PR TITLE
Sites: Unset site icon state if removing while Blavatar assigned

### DIFF
--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -144,7 +144,8 @@ export function items( state = {}, action ) {
 			// accounting for the fact that a non-existent icon property is
 			// equivalent to setting the media icon as null
 			const site = state[ siteId ];
-			if ( ! site || get( site.icon, 'media_id', null ) === mediaId ) {
+			if ( ! site || ( ! site.icon && null === mediaId ) ||
+					( site.icon && site.icon.media_id === mediaId ) ) {
 				return state;
 			}
 

--- a/client/state/sites/test/reducer.js
+++ b/client/state/sites/test/reducer.js
@@ -384,6 +384,33 @@ describe( 'reducer', () => {
 			expect( state ).to.equal( original );
 		} );
 
+		it( 'should return site having blavatar with unset icon property if received null icon setting', () => {
+			const original = deepFreeze( {
+				2916284: {
+					ID: 2916284,
+					name: 'WordPress.com Example Blog',
+					icon: {
+						img: 'https://secure.gravatar.com/blavatar/0d6c430459af115394a012d20b6711d6',
+						ico: 'https://secure.gravatar.com/blavatar/0d6c430459af115394a012d20b6711d6'
+					}
+				}
+			} );
+			const state = items( original, {
+				type: SITE_SETTINGS_RECEIVE,
+				siteId: 2916284,
+				settings: {
+					site_icon: null
+				}
+			} );
+
+			expect( state ).to.eql( {
+				2916284: {
+					ID: 2916284,
+					name: 'WordPress.com Example Blog'
+				}
+			} );
+		} );
+
 		it( 'should return site with unset icon property if received null icon setting', () => {
 			const original = deepFreeze( {
 				2916284: {


### PR DESCRIPTION
This pull request seeks to resolve an issue where attempting to Remove an assigned site icon will not be reflected immediately in the UI if the site currently has a Blavatar assigned.

__Implementation notes:__

The sites reducer manages both removal and updating of site icons. Previously we'd relied on the behavior of [`_.get`](https://lodash.com/docs/4.17.4#get)'s default value behavior for checking whether to shortcut if attempting to remove an icon for a site which does not yet have one. However, since the shape of the `icon` property for a site which has a Blavatar assigned would trigger the default value, the reducer would incorrectly shortcut with the same state.

__Testing instructions:__

Verify that removing a Blavatar is reflected in the UI.

1. Prerequisite: Assign a Blavatar from wp-admin Settings > General (this field will soon become unavailable)
2. Navigate to [site settings](http://calypso.localhost:3000/settings)
3. Select the site for which the Blavatar was assigned
4. Once Site Icon shown, click Remove
5. Note that the site icon is, in fact, removed (showing default globe icon)

Ensure that tests pass:

```
npm run test-client client/state/sites/test/reducer.js
```

Tests for this behavior are quite thorough and should cover against regressions.