### PR TITLE
Themes: Fix content flash for server-rendered theme 404 page

### DIFF
--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -35,7 +35,11 @@ import {
 	getThemeIdFromStylesheet
 } from './utils';
 import { createReducer, isValidStateWithSchema } from 'state/utils';
-import { queriesSchema, activeThemesSchema } from './schema';
+import {
+	queriesSchema,
+	activeThemesSchema,
+	themeRequestErrorsSchema,
+} from './schema';
 import themesUI from './themes-ui/reducer';
 import uploadTheme from './upload-theme/reducer';
 
@@ -211,7 +215,7 @@ export const themeRequestErrors = createReducer( {}, {
 		...state,
 		[ siteId ]: omit( state[ siteId ], themeId ),
 	} )
-} );
+}, themeRequestErrorsSchema );
 
 /**
  * Returns the updated theme query requesting state after an action has been

--- a/client/state/themes/schema.js
+++ b/client/state/themes/schema.js
@@ -83,3 +83,28 @@ export const activeThemesSchema = {
 		}
 	}
 };
+
+export const themeRequestErrorsSchema = {
+	type: 'object',
+	patternProperties: {
+		// Site ID
+		'^(wpcom|wporg|\\d+)$': {
+			type: 'object',
+			patternProperties: {
+				// Theme ID
+				'^\\w+$': {
+					type: 'object',
+					properties: {
+						path: { type: 'string' },
+						method: { type: 'string' },
+						name: { type: 'string' },
+						statusCode: { type: 'number' },
+						status: { type: 'number' },
+						message: { type: 'string' },
+						error: { type: 'string' },
+					}
+				}
+			}
+		}
+	}
+};

--- a/client/state/themes/test/reducer.js
+++ b/client/state/themes/test/reducer.js
@@ -565,6 +565,20 @@ describe( 'reducer', () => {
 	} );
 
 	describe( '#themeRequestErrors()', () => {
+		const themeError = deepFreeze( {
+			wpcom: {
+				blah: {
+					path: '\rest\v1.2\themes\blah',
+					method: 'GET',
+					name: 'ThemeNotFoundError',
+					statusCode: 404,
+					status: 404,
+					message: 'The specified theme was not found',
+					error: 'theme_not_found',
+				}
+			}
+		} );
+
 		it( 'should default to an empty object', () => {
 			const state = themeRequestErrors( undefined, {} );
 
@@ -634,28 +648,20 @@ describe( 'reducer', () => {
 			} );
 		} );
 
-		it( 'never persists state', () => {
-			const state = themeRequestErrors( deepFreeze( {
-				2916284: {
-					twentysixteen: null
-				}
-			} ), {
+		it( 'persists state', () => {
+			const state = themeRequestErrors( themeError, {
 				type: SERIALIZE
 			} );
 
-			expect( state ).to.deep.equal( {} );
+			expect( state ).to.deep.equal( themeError );
 		} );
 
-		it( 'never loads persisted state', () => {
-			const state = themeRequestErrors( deepFreeze( {
-				2916284: {
-					twentysixteen: null
-				}
-			} ), {
+		it( 'loads persisted state', () => {
+			const state = themeRequestErrors( themeError, {
 				type: DESERIALIZE
 			} );
 
-			expect( state ).to.deep.equal( {} );
+			expect( state ).to.deep.equal( themeError );
 		} );
 	} );
 


### PR DESCRIPTION
**Before**
![404_before](https://cloud.githubusercontent.com/assets/7767559/22650309/89289a5e-ec76-11e6-8034-121a079cd47a.gif)

**After**
![404_after](https://cloud.githubusercontent.com/assets/7767559/22650313/8ebf8784-ec76-11e6-929f-d687d05a1a65.gif)


Add a schema for theme request errors, which allows an error return from a request for an individual theme to be bootstrapped from the server to the client on a server render of an invalid theme page.

The theme sheet component can use this error to immediately render the theme 404 page instead of showing loading placeholders whilst a client theme fetch is attempted.