### PR TITLE
Site Settings for Jetpack: link to enable module always uses HTTPS

### DIFF
--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -22,7 +22,7 @@ import {
 	isJetpackBusiness
 } from 'lib/products-values';
 import { removeNotice, errorNotice } from 'state/notices/actions';
-import { isJetpackModuleActive, isJetpackMinimumVersion } from 'state/sites/selectors';
+import { getSiteOption, isJetpackModuleActive, isJetpackMinimumVersion } from 'state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { isEnabled } from 'config';
@@ -66,6 +66,7 @@ class GoogleAnalyticsForm extends Component {
 			handleSubmitForm,
 			isRequestingSettings,
 			isSavingSettings,
+			jetpackManagementUrl,
 			jetpackModuleActive,
 			jetpackVersionSupportsModule,
 			showUpgradeNudge,
@@ -112,7 +113,7 @@ class GoogleAnalyticsForm extends Component {
 						status="is-warning"
 						showDismiss={ false }
 						text={ translate( 'The Google Analytics module is disabled in Jetpack.' ) } >
-						<NoticeAction href={ '//' + site.domain + '/wp-admin/admin.php?page=jetpack#/engagement' }>
+						<NoticeAction href={ jetpackManagementUrl + 'admin.php?page=jetpack#/engagement' }>
 							{ translate( 'Enable' ) }
 						</NoticeAction>
 					</Notice>
@@ -197,6 +198,7 @@ const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSelectedSiteSlug( state );
 	const isGoogleAnalyticsEligible = site && site.plan && hasBusinessPlan( site.plan );
+	const jetpackManagementUrl = getSiteOption( state, siteId, 'admin_url' );
 	const jetpackModuleActive = isJetpackModuleActive( state, siteId, 'google-analytics' );
 	const jetpackVersionSupportsModule = isJetpackMinimumVersion( state, siteId, '4.6-alpha' );
 	const siteIsJetpack = isJetpackSite( state, siteId );
@@ -211,6 +213,7 @@ const mapStateToProps = ( state ) => {
 		siteIsJetpack,
 		showUpgradeNudge: ! isGoogleAnalyticsEligible,
 		enableForm: isGoogleAnalyticsEligible && googleAnalyticsEnabled,
+		jetpackManagementUrl,
 		jetpackModuleActive,
 		jetpackVersionSupportsModule,
 	};

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -34,7 +34,7 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import CountedTextarea from 'components/forms/counted-textarea';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { getSeoTitleFormatsForSite, isJetpackMinimumVersion } from 'state/sites/selectors';
+import { getSiteOption, getSeoTitleFormatsForSite, isJetpackMinimumVersion } from 'state/sites/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { toApi as seoTitleToApi } from 'components/seo/meta-title-editor/mappings';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -367,6 +367,7 @@ export const SeoForm = React.createClass( {
 	render() {
 		const { showAdvancedSeo,
 			showWebsiteMeta,
+			jetpackManagementUrl,
 			jetpackVersionSupportsSeo,
 		} = this.props;
 		const {
@@ -475,7 +476,7 @@ export const SeoForm = React.createClass( {
 							'SEO Tools module is disabled in Jetpack.'
 						) }
 					>
-						<NoticeAction href={ '//' + domain + '/wp-admin/admin.php?page=jetpack#/engagement' }>
+						<NoticeAction href={ jetpackManagementUrl + 'admin.php?page=jetpack#/engagement' }>
 							{ this.translate( 'Enable' ) }
 						</NoticeAction>
 					</Notice>
@@ -592,7 +593,7 @@ export const SeoForm = React.createClass( {
 								'Site Verification Services are disabled in Jetpack.'
 							) }
 						>
-							<NoticeAction href={ '//' + domain + '/wp-admin/admin.php?page=jetpack#/engagement' }>
+							<NoticeAction href={ jetpackManagementUrl + 'admin.php?page=jetpack#/engagement' }>
 								{ this.translate( 'Enable' ) }
 							</NoticeAction>
 						</Notice>
@@ -737,6 +738,7 @@ const mapStateToProps = ( state, ownProps ) => {
 	// SEO Tools are available with Business plan on WordPress.com, and with Premium plan on Jetpack sites
 	const isAdvancedSeoEligible = site && site.plan && hasBusinessPlan( site.plan );
 	const siteId = get( site, 'ID', 0 );
+	const jetpackManagementUrl = getSiteOption( state, siteId, 'admin_url' );
 	const jetpackVersionSupportsSeo = isJetpackMinimumVersion( state, siteId, '4.4-beta1' );
 	const isAdvancedSeoSupported = site && ( ! site.jetpack || ( site.jetpack && jetpackVersionSupportsSeo ) );
 
@@ -745,6 +747,7 @@ const mapStateToProps = ( state, ownProps ) => {
 		storedTitleFormats: getSeoTitleFormatsForSite( getSelectedSite( state ) ),
 		showAdvancedSeo: isAdvancedSeoEligible && isAdvancedSeoSupported,
 		showWebsiteMeta: !! get( site, 'options.advanced_seo_front_page_description', '' ),
+		jetpackManagementUrl,
 		jetpackVersionSupportsSeo: jetpackVersionSupportsSeo,
 	};
 };


### PR DESCRIPTION
Replaces the site URL with the administration URL from the site options, on the enable link for SEO tools and Google Analytics on Jetpack sites.

Fixes #10606 