### PR TITLE
Revert "Jetpack Settings: Map Jetpack module options from the modules state branch into the settings state branch on fetch"

### DIFF
--- a/client/state/jetpack/modules/actions.js
+++ b/client/state/jetpack/modules/actions.js
@@ -101,7 +101,7 @@ export const fetchModuleList = ( siteId ) => {
 					data,
 					( module ) => ( {
 						active: module.activated,
-						...omit( module, 'activated' )
+						...omit( module, 'activated', 'options' )
 					} )
 				);
 

--- a/client/state/jetpack/modules/test/actions.js
+++ b/client/state/jetpack/modules/test/actions.js
@@ -205,7 +205,7 @@ describe( 'actions', () => {
 							API_MODULE_LIST_RESPONSE_FIXTURE.data,
 							( module ) => ( {
 								active: module.activated,
-								...omit( module, 'activated' )
+								...omit( module, 'activated', 'options' )
 							} )
 						)
 					} );

--- a/client/state/jetpack/settings/reducer.js
+++ b/client/state/jetpack/settings/reducer.js
@@ -66,17 +66,11 @@ export const items = createReducer( {}, {
 	[ JETPACK_MODULE_DEACTIVATE_SUCCESS ]: createActivationItemsReducer( false ),
 	[ JETPACK_MODULES_RECEIVE ]: ( state, { siteId, modules } ) => {
 		const modulesActivationState = mapValues( modules, module => module.active );
-		// The need for flattening module options into this moduleSettings is temporary.
-		// Once https://github.com/Automattic/jetpack/pull/6002 is released,
-		// the flattening will be done on the server side for the /jetpack/v4/settings/ endpoint
-		const moduleSettings = Object.keys( modules ).reduce( ( allTheSettings, slug ) => {
-			return { ...allTheSettings, ...mapValues( modules[ slug ].options, option => option.current_value ) };
-		}, {} );
+
 		return Object.assign( {}, state, {
 			[ siteId ]: {
 				...state[ siteId ],
-				...modulesActivationState,
-				...moduleSettings
+				...modulesActivationState
 			}
 		} );
 	},


### PR DESCRIPTION
Reverts Automattic/wp-calypso#10891

This mapping is no longer neded in the Calypso side of things. Jetpack 4.6 will introduce a new readable `/settings` endpoint which does this work.

#### Testin instructions

1. Clone this branch
1. Visit the settings page for a Jetpack site
1. Under the Writing tab, update any of the Custom Content Type options.
1. Expect it to work

#### Why

Jetpack 4.6 already does this mapping from a modules list with metadata to a simplified settings interface. A readable `/jetpack/v4/settings` endpoint that replies with a flat (non-hierarchized) object with keys matching to module and module options slugs. 

