### PR TITLE
Revert "Site Settings: Enable site icon management in all environments"

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -47,7 +47,6 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,
-		"manage/site-settings/site-icon": true,
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -55,7 +55,6 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,
-		"manage/site-settings/site-icon": true,
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,

--- a/config/production.json
+++ b/config/production.json
@@ -51,7 +51,6 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,
-		"manage/site-settings/site-icon": true,
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -52,7 +52,6 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,
-		"manage/site-settings/site-icon": true,
 		"manage/seo": true,
 		"manage/stats": true,
 		"manage/themes": true,

--- a/config/test.json
+++ b/config/test.json
@@ -67,7 +67,6 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,
-		"manage/site-settings/site-icon": true,
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#11044