### PR TITLE
Site Settings: Check failure for Jetpack site settings save

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -22,7 +22,7 @@ import {
 import {
 	isRequestingJetpackSettings,
 	isUpdatingJetpackSettings,
-	isJetpackSettingsSaveSuccessful,
+	isJetpackSettingsSaveFailure,
 	getJetpackSettings
 } from 'state/selectors';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
@@ -186,7 +186,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			if ( jetpackSettingsUISupported ) {
 				const jetpackSettings = getJetpackSettings( state, siteId );
 				isSavingSettings = isSavingSettings || isUpdatingJetpackSettings( state, siteId );
-				isSaveRequestSuccessful = isSaveRequestSuccessful && isJetpackSettingsSaveSuccessful( state, siteId );
+				isSaveRequestSuccessful = isSaveRequestSuccessful && ! isJetpackSettingsSaveFailure( state, siteId );
 				settings = { ...settings, ...jetpackSettings };
 				settingsFields.jetpack = keys( jetpackSettings );
 				isRequestingSettings = isRequestingSettings || ( isRequestingJetpackSettings( state, siteId ) && ! jetpackSettings );

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -52,7 +52,7 @@ export isDeactivatingJetpackModule from './is-deactivating-jetpack-module';
 export isDomainOnlySite from './is-domain-only-site';
 export isFetchingJetpackModules from './is-fetching-jetpack-modules';
 export isJetpackModuleActive from './is-jetpack-module-active';
-export isJetpackSettingsSaveSuccessful from './is-jetpack-settings-save-successful';
+export isJetpackSettingsSaveFailure from './is-jetpack-settings-save-failure';
 export isJetpackSiteInDevelopmentMode from './is-jetpack-site-in-development-mode';
 export isJetpackSiteInStagingMode from './is-jetpack-site-in-staging-mode';
 export isPrivateSite from './is-private-site';

--- a/client/state/selectors/is-jetpack-settings-save-failure.js
+++ b/client/state/selectors/is-jetpack-settings-save-failure.js
@@ -10,6 +10,6 @@ import { getJetpackSettingsSaveRequestStatus } from './';
  * @param  {Number}  siteId Site ID
  * @return {Boolean}         Whether the requests is successful or not
  */
-export default function isJetpackSettingsSaveSuccessful( state, siteId ) {
-	return getJetpackSettingsSaveRequestStatus( state, siteId ) === 'success';
+export default function isJetpackSettingsSaveFailure( state, siteId ) {
+	return getJetpackSettingsSaveRequestStatus( state, siteId ) === 'error';
 }

--- a/client/state/selectors/test/is-jetpack-settings-save-failure.js
+++ b/client/state/selectors/test/is-jetpack-settings-save-failure.js
@@ -6,9 +6,9 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { isJetpackSettingsSaveSuccessful } from '../';
+import { isJetpackSettingsSaveFailure } from '../';
 
-describe( 'isJetpackSettingsSaveSuccessful()', () => {
+describe( 'isJetpackSettingsSaveFailure()', () => {
 	it( 'should return false if the site is not attached', () => {
 		const state = {
 			jetpack: {
@@ -19,12 +19,12 @@ describe( 'isJetpackSettingsSaveSuccessful()', () => {
 				}
 			}
 		};
-		const isSuccessful = isJetpackSettingsSaveSuccessful( state, 87654321 );
+		const isFailure = isJetpackSettingsSaveFailure( state, 87654321 );
 
-		expect( isSuccessful ).to.be.false;
+		expect( isFailure ).to.be.false;
 	} );
 
-	it( 'should return true if the save request status is success', () => {
+	it( 'should return false if the save request status is success', () => {
 		const state = {
 			jetpack: {
 				settings: {
@@ -34,12 +34,12 @@ describe( 'isJetpackSettingsSaveSuccessful()', () => {
 				}
 			}
 		};
-		const isSuccessful = isJetpackSettingsSaveSuccessful( state, 12345678 );
+		const isFailure = isJetpackSettingsSaveFailure( state, 12345678 );
 
-		expect( isSuccessful ).to.be.true;
+		expect( isFailure ).to.be.false;
 	} );
 
-	it( 'should return false if the save request status is error', () => {
+	it( 'should return true if the save request status is error', () => {
 		const state = {
 			jetpack: {
 				settings: {
@@ -49,8 +49,8 @@ describe( 'isJetpackSettingsSaveSuccessful()', () => {
 				}
 			}
 		};
-		const isSuccessful = isJetpackSettingsSaveSuccessful( state, 12345678 );
+		const isFailure = isJetpackSettingsSaveFailure( state, 12345678 );
 
-		expect( isSuccessful ).to.be.false;
+		expect( isFailure ).to.be.true;
 	} );
 } );


### PR DESCRIPTION
This pull request seeks to resolve an issue observed at https://github.com/Automattic/wp-calypso/pull/11044#issuecomment-277763303 where a successful site settings save request would behave as a failure, when the setting saved is not a Jetpack-specific setting (e.g. site icon).

![Error](https://cloud.githubusercontent.com/assets/1779930/22659779/fcb8d3da-ec6c-11e6-8ecc-bf59fd728333.png)

Context for the issue is described at https://github.com/Automattic/wp-calypso/pull/10697#issuecomment-277768266. The changes here make it such that a request is only assumed to be a failure in the Jetpack settings path if the status is explicitly known to be in an error state. Previously because there was a lack of status, the success selector would return a falsey value.

__Testing instructions:__

Verify that you can assign a site icon for a Jetpack site successfully.

1. Navigate to [site settings](http://calypso.localhost:3000/settings)
2. Select a site
3. Click Change site icon
4. Assign a site icon
5. Note that success notice is shown after finished assigning
6. Click Remove site icon and confirm deletion
7. Note that success notice is shown after finished removing

Would be good to check for regressions where the failure check is relevant for Jetpack settings, though I'm not aware of merged flows where this is used (cc @ryelle @tyxla )