### PR TITLE
Themes: removed search "More" button from Jetpack sites

### DIFF
--- a/client/my-sites/themes/themes-search-card/index.jsx
+++ b/client/my-sites/themes/themes-search-card/index.jsx
@@ -78,8 +78,9 @@ const ThemesSearchCard = React.createClass( {
 		return (
 			<div className="themes__search-card" data-tip-target="themes-search-card">
 				<SectionNav selectedText={ this.getSelectedTierFormatted( tiers ) }>
+					{ ! isJetpack &&
 					<NavTabs>
-						{ ! isJetpack && this.getTierNavItems( selectedTiers ) }
+						{ this.getTierNavItems( selectedTiers ) }
 
 						{ isPremiumThemesEnabled && <hr className="section-nav__hr" /> }
 
@@ -90,10 +91,13 @@ const ThemesSearchCard = React.createClass( {
 							{ this.props.translate( 'More' ) + ' ' }
 						</NavItem> }
 					</NavTabs>
+					}
 
 					<Search
 						pinned
 						fitsContainer
+						isOpen={ isJetpack }
+						hideClose={ isJetpack }
 						onSearch={ this.props.onSearch }
 						initialValue={ this.props.search }
 						ref="url-search"
@@ -131,18 +135,20 @@ const ThemesSearchCard = React.createClass( {
 					delaySearch={ true }
 				/>
 
-				{ isPremiumThemesEnabled && ! isJetpack && <ThemesSelectDropdown
-										tier={ this.props.tier }
-										options={ tiers }
-										onSelect={ this.props.select } /> }
-				{ isPremiumThemesEnabled && <a className="button more"
-												href={ getExternalThemesUrl( this.props.site ) }
-												target="_blank"
-												rel="noopener noreferrer"
-												onClick={ this.onMore }>
+				{ isPremiumThemesEnabled && ! isJetpack &&
+					<ThemesSelectDropdown
+						tier={ this.props.tier }
+						options={ tiers }
+						onSelect={ this.props.select } /> }
+				{ config.isEnabled( 'manage/themes/upload' ) && ! isJetpack &&
+					<a className="button more"
+						href={ getExternalThemesUrl( this.props.site ) }
+						target="_blank"
+						rel="noopener noreferrer"
+						onClick={ this.onMore }>
 
-												{ this.props.translate( 'More' ) }
-											</a> }
+						{ this.props.translate( 'More' ) }
+					</a> }
 			</div>
 		);
 	}


### PR DESCRIPTION
This PR addresses two things:

1. Removes "More" button from Jetpack once we have upload available (under feature flag) #11041
2. Fixes the mobile menu for Jetpack that was "cut" without the filter options.

Before:

![screen shot 2017-02-06 at 19 43 29](https://cloud.githubusercontent.com/assets/4389/22663465/97c6bc3e-eca4-11e6-9ba6-c238435f1bdd.png)

![screen shot 2017-02-06 at 19 43 44](https://cloud.githubusercontent.com/assets/4389/22663470/9a416f40-eca4-11e6-8e56-01dada86a7ef.png)

This PR:

![screen shot 2017-02-06 at 19 44 13](https://cloud.githubusercontent.com/assets/4389/22663485/a79901da-eca4-11e6-8230-a616fb701e08.png)

![screen shot 2017-02-06 at 19 44 07](https://cloud.githubusercontent.com/assets/4389/22663487/ab7a644c-eca4-11e6-8549-8fa81a13e0c1.png)

To test:

1. Set the environmental variable in `development` to `"manage/themes/magic-search": false`
2. Open My Sites → Design
3. Open a Jetpack site, verify "More" isn't there
4. Do a search to make sure it still works
5. Open a .com site, verify both "All" filter and "More" is there
6. Do a search to make sure it still works
7. Open "All Sites"
8. Do a search to make sure it still works
9. Repeat all of the above on mobile