### PR TITLE
State: Avoid double-encoding customizer return URL

### DIFF
--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -976,7 +976,7 @@ export function getCustomizerUrl( state, siteId, panel ) {
 
 	let returnUrl;
 	if ( 'undefined' !== typeof window ) {
-		returnUrl = window.location;
+		returnUrl = window.location.href;
 	}
 
 	return addQueryArgs( {

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -976,7 +976,7 @@ export function getCustomizerUrl( state, siteId, panel ) {
 
 	let returnUrl;
 	if ( 'undefined' !== typeof window ) {
-		returnUrl = encodeURIComponent( window.location );
+		returnUrl = window.location;
 	}
 
 	return addQueryArgs( {

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -2347,7 +2347,7 @@ describe( 'selectors', () => {
 					}
 				}, 77203199 );
 
-				expect( customizerUrl ).to.equal( 'https://example.com/wp-admin/customize.php?return=https%253A%252F%252Fwordpress.com' );
+				expect( customizerUrl ).to.equal( 'https://example.com/wp-admin/customize.php?return=https%3A%2F%2Fwordpress.com' );
 			} );
 		} );
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -2324,7 +2324,11 @@ describe( 'selectors', () => {
 
 		context( 'browser', () => {
 			before( () => {
-				global.window = { location: 'https://wordpress.com' };
+				global.window = {
+					location: {
+						href: 'https://wordpress.com'
+					}
+				};
 			} );
 
 			after( () => {


### PR DESCRIPTION
Fixes #11207

This pull request seeks to resolve an issue where the customizer URL returned from the `getCustomizerUrl` state selector double-encodes the return path, thus preventing a valid redirect.

__Testing instructions:__

Since `calypso.localhost` is not a whitelisted redirect host for Jetpack sites, you'll either need to add this to the whitelist, or trust that based on the tests the behavior is as expected.

You can modify Jetpack redirect whitelist from the following file in your site's hosting:

https://github.com/Automattic/jetpack/blob/1ae11b8/modules/manage.php#L30

([Plugin for testing convenience](https://cloudup.com/files/i_n_CWfHyQj/download))

Ensure that unit tests pass:

```
npm run test-client client/state/sites/test/selectors.js
```