### PR TITLE
Theme: fix upload area visual styling and cursor

### DIFF
--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -160,7 +160,7 @@ class Upload extends React.Component {
 			'Drop files or click here to upload'
 		);
 		const uploadInstructionsText = translate(
-			"Only single .zip files are accepted."
+			'Only single .zip files are accepted.'
 		);
 
 		const themeUploadClass = classNames( 'theme-upload', {

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -156,14 +156,11 @@ class Upload extends React.Component {
 
 	renderDropZone() {
 		const { translate, isBusiness, isJetpack } = this.props;
-		const uploadPromptText = translate(
-			'Do you have a custom theme to upload to your site?'
-		);
-		const uploadInstructionsText = translate(
-			"Make sure it's a single zip file, and upload it here."
-		);
 		const dropText = translate(
 			'Drop files or click here to upload'
+		);
+		const uploadInstructionsText = translate(
+			"Only single .zip files are accepted."
 		);
 
 		const themeUploadClass = classNames( 'theme-upload', {
@@ -172,8 +169,6 @@ class Upload extends React.Component {
 
 		return (
 			<div className={ themeUploadClass }>
-				<span className="theme-upload__title">{ uploadPromptText }</span>
-				<span className="theme-upload__instructions">{ uploadInstructionsText }</span>
 				<div className="theme-upload__dropzone">
 					<DropZone onFilesDrop={ this.onFileSelect } />
 					<FilePicker accept="application/zip" onPick={ this.onFileSelect } >
@@ -182,6 +177,7 @@ class Upload extends React.Component {
 							icon="cloud-upload"
 							size={ 48 } />
 						{ dropText }
+						<span className="theme-upload__dropzone-instructions">{ uploadInstructionsText }</span>
 					</FilePicker>
 				</div>
 			</div>

--- a/client/my-sites/themes/theme-upload/style.scss
+++ b/client/my-sites/themes/theme-upload/style.scss
@@ -1,28 +1,43 @@
-.theme-upload__title {
-	display: block;
-	color: darken( $gray, 20 );
-}
-
-.theme-upload__instructions {
-	display: block;
-	font-style: italic;
-}
-
 .theme-upload__dropzone {
 	position: relative;
 	background-color: $gray-light;
 	border: 2px dashed $gray;
-	margin: 20px 0;
+	transition: all 200ms ease-out, color 100ms ease-out;
+	cursor: pointer;
+
+	svg * {
+		transition: color 100ms ease-out;
+	}
 
 	.file-picker {
-		color: darken( $gray, 20 );
+		color: $gray-dark;
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
 		align-items: center;
 		height: 180px;
 	}
+
+	&:hover {
+		border-color: $gray-dark;
+		transform: translate3d( 0, -1px, 0 );
+		box-shadow: 0 2px 4px lighten( $gray, 20% );
+
+		.theme-upload__dropzone-icon {
+			color: $gray-dark;
+		}
+	}
 }
+
+.theme-upload__dropzone-icon {
+	color: $gray;
+}
+
+.theme-upload__dropzone-instructions {
+	font-style: italic;
+	font-size: 12px;
+}
+
 
 .theme-upload__theme-sheet {
 	span {
@@ -43,10 +58,6 @@
 .theme-upload__theme-name {
 	font-size: 24px;
 	font-weight: 600;
-}
-
-.theme-upload__dropzone-icon {
-	color: $gray;
 }
 
 .theme-upload {


### PR DESCRIPTION
Updating the styling of the theme upload drop/click area, fixes #11037.

Before:

![screen shot 2017-02-06 at 21 47 39](https://cloud.githubusercontent.com/assets/4389/22667758/130e409a-ecb6-11e6-9529-b9946862d4fb.png)


After (with hover):

![screen shot 2017-02-06 at 21 46 53](https://cloud.githubusercontent.com/assets/4389/22667766/195a2a22-ecb6-11e6-87cd-f41d40c6cdf3.png)


![screen shot 2017-02-06 at 21 47 01](https://cloud.githubusercontent.com/assets/4389/22667771/1dcf4fd8-ecb6-11e6-9ec4-a65d4261b8ef.png)

### To test

1. Open My Sites → Themes → Upload.
2. Try to hover the form with the mouse, click to open.
3. Make sure the hover style works and the mouse cursor is the `pointer`.