### PR TITLE
Introduce HTTP pipeline for data layer

### DIFF
--- a/client/state/data-layer/wpcom-http/index.js
+++ b/client/state/data-layer/wpcom-http/index.js
@@ -43,8 +43,6 @@ const queueRequest = ( { dispatch }, rawAction, next ) => {
 		body,
 		formData,
 		method: rawMethod,
-		onSuccess,
-		onFailure,
 		onProgress,
 		path,
 		query = {},
@@ -57,15 +55,15 @@ const queueRequest = ( { dispatch }, rawAction, next ) => {
 		query,
 		method === 'POST' && body,
 		( rawError, rawData ) => {
-			const { error, data, shouldAbort } = processEgress( rawError, rawData, action, dispatch );
+			const { error, data, onFailure, onSuccess, shouldAbort } = processEgress( rawError, rawData, action, dispatch );
 
 			if ( true === shouldAbort ) {
 				return null;
 			}
 
 			return !! error
-				? onFailure && dispatch( extendAction( onFailure, failureMeta( error ) ) )
-				: onSuccess && dispatch( extendAction( onSuccess, successMeta( data ) ) );
+				? onFailure.forEach( handler => dispatch( extendAction( handler, failureMeta( error ) ) ) )
+				: onSuccess.forEach( handler => dispatch( extendAction( handler, successMeta( data ) ) ) );
 		}
 	] ) );
 

--- a/client/state/data-layer/wpcom-http/index.js
+++ b/client/state/data-layer/wpcom-http/index.js
@@ -36,7 +36,7 @@ export const queueRequest = ( processOutbound, processInbound ) => ( { dispatch 
 	const action = processOutbound( rawAction, dispatch );
 
 	if ( null === action ) {
-		return next( action );
+		return next( rawAction );
 	}
 
 	const {

--- a/client/state/data-layer/wpcom-http/index.js
+++ b/client/state/data-layer/wpcom-http/index.js
@@ -11,8 +11,8 @@ import { WPCOM_HTTP_REQUEST } from 'state/action-types';
 import { extendAction } from 'state/utils';
 
 import {
-	processEgress,
-	processIngress,
+	processInbound,
+	processOutbound,
 } from './pipeline';
 
 /**
@@ -32,8 +32,8 @@ export const successMeta = data => ( { meta: { dataLayer: { data } } } );
 export const failureMeta = error => ( { meta: { dataLayer: { error } } } );
 export const progressMeta = ( { total, loaded } ) => ( { meta: { dataLayer: { progress: { total, loaded } } } } );
 
-export const queueRequest = ( processIngress, processEgress ) => ( { dispatch }, rawAction, next ) => {
-	const action = processIngress( rawAction, dispatch );
+export const queueRequest = ( processOutbound, processInbound ) => ( { dispatch }, rawAction, next ) => {
+	const action = processOutbound( rawAction, dispatch );
 
 	if ( null === action ) {
 		return next( action );
@@ -61,7 +61,7 @@ export const queueRequest = ( processIngress, processEgress ) => ( { dispatch },
 				nextError,
 				shouldAbort,
 				successes
-			} = processEgress( action, { dispatch }, data, error );
+			} = processInbound( action, { dispatch }, data, error );
 
 			if ( true === shouldAbort ) {
 				return null;
@@ -81,5 +81,5 @@ export const queueRequest = ( processIngress, processEgress ) => ( { dispatch },
 };
 
 export default {
-	[ WPCOM_HTTP_REQUEST ]: [ queueRequest( processIngress, processEgress ) ],
+	[ WPCOM_HTTP_REQUEST ]: [ queueRequest( processOutbound, processInbound ) ],
 };

--- a/client/state/data-layer/wpcom-http/index.js
+++ b/client/state/data-layer/wpcom-http/index.js
@@ -11,8 +11,8 @@ import { WPCOM_HTTP_REQUEST } from 'state/action-types';
 import { extendAction } from 'state/utils';
 
 import {
-	processInbound,
-	processOutbound,
+	processInbound as inboundProcessor,
+	processOutbound as outboundProcessor,
 } from './pipeline';
 
 /**
@@ -81,5 +81,5 @@ export const queueRequest = ( processOutbound, processInbound ) => ( { dispatch 
 };
 
 export default {
-	[ WPCOM_HTTP_REQUEST ]: [ queueRequest( processOutbound, processInbound ) ],
+	[ WPCOM_HTTP_REQUEST ]: [ queueRequest( outboundProcessor, inboundProcessor ) ],
 };

--- a/client/state/data-layer/wpcom-http/index.js
+++ b/client/state/data-layer/wpcom-http/index.js
@@ -32,7 +32,7 @@ export const successMeta = data => ( { meta: { dataLayer: { data } } } );
 export const failureMeta = error => ( { meta: { dataLayer: { error } } } );
 export const progressMeta = ( { total, loaded } ) => ( { meta: { dataLayer: { progress: { total, loaded } } } } );
 
-const queueRequest = ( { dispatch }, rawAction, next ) => {
+export const queueRequest = ( processIngress, processEgress ) => ( { dispatch }, rawAction, next ) => {
 	const action = processIngress( rawAction, dispatch );
 
 	if ( null === action ) {
@@ -81,5 +81,5 @@ const queueRequest = ( { dispatch }, rawAction, next ) => {
 };
 
 export default {
-	[ WPCOM_HTTP_REQUEST ]: [ queueRequest ],
+	[ WPCOM_HTTP_REQUEST ]: [ queueRequest( processIngress, processEgress ) ],
 };

--- a/client/state/data-layer/wpcom-http/index.js
+++ b/client/state/data-layer/wpcom-http/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { compact, get, noop } from 'lodash';
+import { compact, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -9,6 +9,11 @@ import { compact, get, noop } from 'lodash';
 import wpcom from 'lib/wp';
 import { WPCOM_HTTP_REQUEST } from 'state/action-types';
 import { extendAction } from 'state/utils';
+
+import {
+	processEgress,
+	processIngress,
+} from './pipeline';
 
 /**
  * Returns the appropriate fetcher in wpcom given the request method
@@ -21,13 +26,19 @@ import { extendAction } from 'state/utils';
 const fetcherMap = method => get( {
 	GET: wpcom.req.get.bind( wpcom.req ),
 	POST: wpcom.req.post.bind( wpcom.req ),
-}, method, noop );
+}, method, null );
 
 export const successMeta = data => ( { meta: { dataLayer: { data } } } );
 export const failureMeta = error => ( { meta: { dataLayer: { error } } } );
 export const progressMeta = ( { total, loaded } ) => ( { meta: { dataLayer: { progress: { total, loaded } } } } );
 
-const queueRequest = ( { dispatch }, action, next ) => {
+const queueRequest = ( { dispatch }, rawAction, next ) => {
+	const { action } = processIngress( rawAction, dispatch );
+
+	if ( null === action ) {
+		return next( action );
+	}
+
 	const {
 		body,
 		formData,
@@ -45,16 +56,24 @@ const queueRequest = ( { dispatch }, action, next ) => {
 		{ path, formData },
 		query,
 		method === 'POST' && body,
-		( error, data ) => !! error
-			? onFailure && dispatch( extendAction( onFailure, failureMeta( error ) ) )
-			: onSuccess && dispatch( extendAction( onSuccess, successMeta( data ) ) )
+		( rawError, rawData ) => {
+			const { error, data, shouldAbort } = processEgress( rawError, rawData, action, dispatch );
+
+			if ( true === shouldAbort ) {
+				return null;
+			}
+
+			return !! error
+				? onFailure && dispatch( extendAction( onFailure, failureMeta( error ) ) )
+				: onSuccess && dispatch( extendAction( onSuccess, successMeta( data ) ) );
+		}
 	] ) );
 
 	if ( 'POST' === method && onProgress ) {
 		request.upload.onprogress = event => dispatch( extendAction( onProgress, progressMeta( event ) ) );
 	}
 
-	next( action );
+	return next( action );
 };
 
 export default {

--- a/client/state/data-layer/wpcom-http/pipeline/README.md
+++ b/client/state/data-layer/wpcom-http/pipeline/README.md
@@ -8,23 +8,26 @@ This _pipeline_ however intercepts that stream of requests in order to augment i
 
 Requests come into the HTTP layer on Redux actions and leave when the network requests return with either a success or failure.
 Each request is run through the pipeline at these points.
-The initial entry into the HTTP system hits the pipeline ingress.
-The final exit from the the HTTP system hits the pipeline egress.
+The initial entry into the HTTP system is through the outbound pipeline.
+The final exit from the the HTTP system is through the inbound pipeline.
 
-### Ingress
+ - _**Outbound**_ denotes requests on their way _out_ of Calypso.
+ - _**Inbound**_ denotes requests returning from remote servers back _into_ Calypso.
 
-Requests on ingress run through the pipeline as if it were some kind of funnel or chain.
+### Outbound
+
+Outbound requests run through the pipeline as if it were some kind of funnel or chain.
 At this stage we can perform the following kinds of operations on the requests:
  - filter out and drop unnecessary or redundant requests
  - transform them by manipulating their data
  - queue them for later if offline
  - persist them to storage
 
-### Egress
+### Inbound
 
-Requests on egress run through the pipeline to provide a way to follow-up with requests previously sent out.
+Inbound requests run through the pipeline to provide a way to follow-up with requests previously sent out.
 At this stage we can perform the following kinds of operations on the requests:
- - Clean up and close out operations started on ingress
+ - Clean up and close out operations started on inbound
  - Audit and perform accounting on requests as they come back (for example, track failed requests)
 
 ## Detailed Operation
@@ -61,7 +64,7 @@ If the original action contained an `onSuccess` or `onFailure` responder (also a
 
 ### HTTP flow _with_ the pipeline
 
-The pipeline injects itself at the ingress and egress of the actual network operations.
+The pipeline injects itself at the inbound and outbound of the actual network operations.
 It is the gatekeeper and the overseer.
 
 These gates are designed to introduce augmentation, introspection, and optimization into the HTTP layer which are _specifically_ and _only_ related to HTTP requests.
@@ -71,11 +74,11 @@ The HTTP layer is given liberty to execute the requests fed into it in a way tha
 Because of this liberty it must also constrain itself to the language of HTTP to prevent accidentally introducing bugs or breaking assumptions that other code will be making.
 
 <!-- the following diagram was generated in draw.io - it can be edited by pasting in the contents of the SVG itself -->
-![Pipelined HTTP flow](https://cldup.com/JldmoGqrPX.svg)
+![Pipelined HTTP flow](https://cldup.com/lpS7pC7Ksj.svg)
 
-#### Step F: Pipeline ingress
+#### Step F: Outbound pipeline
 
-As Redux actions describing HTTP requests feed into the HTTP middleware the ingress chain gets called with the given action.
+As Redux actions describing HTTP requests feed into the HTTP middleware the outbound chain gets called with the given action.
 The chain can drop the request, modify the request, add additional requests, etc…
 
 For the sake of illustration, let's consider adding a function to make sure that we don't send out requests whose `GET` line exceeds 2,048 characters.
@@ -84,10 +87,10 @@ IE and some other browsers and routers will fail in these conditions.
 This new function finds the sum of the lengths of the URL for the request and the query string and will throw a new error if it exceeds our limit and drop the request if we're in a development environment.
 It will do this in order to and notify a developer that the request will likely fail in production.
 
-#### Step G: Pipeline egress
+#### Step G: Inbound pipeline
 
 Once network requests return or fail they will feed back into the Redux system by way of the associated `onSuccess` and `onFailure` actions if they were provided on the original action.
-Before these are run we have the same kinds of abilities we had to interact with HTTP requests on ingress, except now those abilities relate to the follow-up actions: we can prevent them from running, change which ones run, or add additional actions to run.
+Before these are run we have the same kinds of abilities we had to interact with HTTP requests on outbound, except now those abilities relate to the follow-up actions: we can prevent them from running, change which ones run, or add additional actions to run.
 
 Further, we can introduce additional behaviors to run based on these responses.
 For the sake of illustration, let's consider adding a function to help us know which API endpoints need some help in their error reporting.

--- a/client/state/data-layer/wpcom-http/pipeline/README.md
+++ b/client/state/data-layer/wpcom-http/pipeline/README.md
@@ -1,0 +1,98 @@
+# HTTP pipeline
+
+The HTTP middleware is designed to take liberties in how it performs the actual network transactions requests by various components inside of Calypso.
+On the surface the HTTP middleware proper simply passes along every request which it receives.
+This _pipeline_ however intercepts that stream of requests in order to augment it with: optimizations, request transformations, offline queuing, etc…
+
+## Overview
+
+Requests come into the HTTP layer on Redux actions and leave when the network requests return with either a success or failure.
+Each request is run through the pipeline at these points.
+The initial entry into the HTTP system hits the pipeline ingress.
+The final exit from the the HTTP system hits the pipeline egress.
+
+### Ingress
+
+Requests on ingress run through the pipeline as if it were some kind of funnel or chain.
+At this stage we can perform the following kinds of operations on the requests:
+ - filter out and drop unnecessary or redundant requests
+ - transform them by manipulating their data
+ - queue them for later if offline
+ - persist them to storage
+
+### Egress
+
+Requests on egress run through the pipeline to provide a way to follow-up with requests previously sent out.
+At this stage we can perform the following kinds of operations on the requests:
+ - Clean up and close out operations started on ingress
+ - Audit and perform accounting on requests as they come back (for example, track failed requests)
+
+## Detailed Operation
+
+To understand how this layer works we should start by examining the normal flow of HTTP requests and then see how we can augment that flow by inserting optimizations or processes into the pipeline.
+
+### The basic HTTP flow without the pipeline
+<!-- the following diagram was generated in draw.io - it can be edited by pasting in the contents of the SVG itself -->
+![Basic HTTP flow](https://cldup.com/X4mRbNKSaC.svg)
+
+#### Step A: HTTP request actions are dispatched
+
+Redux middleware can dispatch certain actions which describe HTTP requests to the WordPress.com API.
+These actions include information such as the API path, query arguments, request body, etc…
+The actions flow through the normal Redux dispatch chain and can be inspected with the Redux tools.
+
+#### Step B: HTTP layer intercepts requests
+
+The HTTP middleware handler intercepts the request actions and performs the actual network requests and response-handling.
+It is the piece that ties together outbound requests with the follow-up actions on upload progress, success, and failure events.
+
+#### Step C: Request is sent outbound
+
+When a request goes out "on the wire" there is an implicit tracking of that request in what we could consider a queue.
+At the time of this writing this tracking takes place within a `Promise` and its `then()` and `catch()` methods.
+
+#### Step D: Request returns or fails
+
+Requests come back in and are re-associated with the action that called for them.
+
+#### Step E: Follow-up actions are dispatched
+
+If the original action contained an `onSuccess` or `onFailure` responder (also a Redux action) then that will be dispatched in response according to the success or failure state of the network request.
+
+### HTTP flow _with_ the pipeline
+
+The pipeline injects itself at the ingress and egress of the actual network operations.
+It is the gatekeeper and the overseer.
+
+These gates are designed to introduce augmentation, introspection, and optimization into the HTTP layer which are _specifically_ and _only_ related to HTTP requests.
+
+**This is absolutely _not_ the place to introduce code concerning itself with other concerns.**
+The HTTP layer is given liberty to execute the requests fed into it in a way that it sees fit.
+Because of this liberty it must also constrain itself to the language of HTTP to prevent accidentally introducing bugs or breaking assumptions that other code will be making.
+
+<!-- the following diagram was generated in draw.io - it can be edited by pasting in the contents of the SVG itself -->
+![Pipelined HTTP flow](https://cldup.com/JldmoGqrPX.svg)
+
+#### Step F: Pipeline ingress
+
+As Redux actions describing HTTP requests feed into the HTTP middleware the ingress chain gets called with the given action.
+The chain can drop the request, modify the request, add additional requests, etc…
+
+For the sake of illustration, let's consider adding a function to make sure that we don't send out requests whose `GET` line exceeds 2,048 characters.
+IE and some other browsers and routers will fail in these conditions.
+
+This new function finds the sum of the lengths of the URL for the request and the query string and will throw a new error if it exceeds our limit and drop the request if we're in a development environment.
+It will do this in order to and notify a developer that the request will likely fail in production.
+
+#### Step G: Pipeline egress
+
+Once network requests return or fail they will feed back into the Redux system by way of the associated `onSuccess` and `onFailure` actions if they were provided on the original action.
+Before these are run we have the same kinds of abilities we had to interact with HTTP requests on ingress, except now those abilities relate to the follow-up actions: we can prevent them from running, change which ones run, or add additional actions to run.
+
+Further, we can introduce additional behaviors to run based on these responses.
+For the sake of illustration, let's consider adding a function to help us know which API endpoints need some help in their error reporting.
+
+This new function will only activate itself if the request comes back _from_ the API with an error status code.
+It will then inspect the response to see if there was both a simple "error code" or "error type" such as `INVALID_DOMAIN` as well as a written description like `The given domain (wordpress.com) could not be found in our records`.
+
+In the cases where one of these is missing we can send a new network request to our logging servers so that indicate that some API is giving hazy error messages.

--- a/client/state/data-layer/wpcom-http/pipeline/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/index.js
@@ -1,0 +1,45 @@
+/**
+ * Internal dependencies
+ */
+import removeDuplicateGets from './remove-duplicate-gets';
+
+const ingressChain = [
+	removeDuplicateGets,
+];
+
+const egressChain = [
+
+];
+
+const applyIngressChain = ( { action, dispatch }, nextLink ) =>
+	action !== null
+		? nextLink( { action, dispatch } )
+		: { action, dispatch };
+
+const applyEgressChain = ( { error: rawError, data: rawData, action, dispatch, shouldAbort: shouldHaveAborted }, nextLink ) => {
+	if ( true === shouldHaveAborted ) {
+		return { error: rawError, data: rawData, action, dispatch, shouldHaveAborted };
+	}
+
+	const { error, data, shouldAbort } = nextLink( rawError, rawData, { action, dispatch } );
+
+	return { error, data, action, dispatch, shouldAbort };
+};
+
+export const processIngressChain = chain => ( action, dispatch ) =>
+	chain
+		.reduce( applyIngressChain, { action, dispatch, shouldAbort: false } )
+		.action;
+
+export const processEgressChain = chain => ( { rawError, rawData, action, dispatch } ) => {
+	const { error, data, shouldAbort } = chain.reduce(
+		applyEgressChain,
+		{ error: rawError, data: rawData, action, dispatch, shouldAbort: false },
+	);
+
+	return { error, data, shouldAbort };
+};
+
+export const processIngress = processIngressChain( ingressChain );
+
+export const processEgress = processEgressChain( egressChain );

--- a/client/state/data-layer/wpcom-http/pipeline/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/index.js
@@ -53,24 +53,24 @@ const ingressChain = [
 	removeDuplicateGets,
 ];
 
-const applyIngressChain = ( ingressData, nextLink ) =>
+const applyIngressProcessor = ( ingressData, nextProcessor ) =>
 	ingressData.nextRequest !== null
-		? nextLink( ingressData )
+		? nextProcessor( ingressData )
 		: ingressData;
 
-const applyEgressChain = ( egressData, nextLink ) =>
+const applyEgressProcessor = ( egressData, nextProcessor ) =>
 	egressData.shouldAbort !== true
-		? nextLink( egressData )
+		? nextProcessor( egressData )
 		: egressData;
 
 export const processIngressChain = chain => ( originalRequest, store ) =>
 	chain
-		.reduce( applyIngressChain, { originalRequest, store, nextRequest: originalRequest } )
+		.reduce( applyIngressProcessor, { originalRequest, store, nextRequest: originalRequest } )
 		.nextRequest;
 
 export const processEgressChain = chain => ( originalRequest, store, originalData, originalError ) =>
 	pick(
-		chain.reduce( applyEgressChain, {
+		chain.reduce( applyEgressProcessor, {
 			originalRequest,
 			store,
 			originalData,

--- a/client/state/data-layer/wpcom-http/pipeline/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/index.js
@@ -54,7 +54,7 @@ const ingressChain = [
 ];
 
 const applyIngressChain = ( ingressData, nextLink ) =>
-	ingressData.nextAction !== null
+	ingressData.nextRequest !== null
 		? nextLink( ingressData )
 		: ingressData;
 
@@ -66,7 +66,7 @@ const applyEgressChain = ( egressData, nextLink ) =>
 export const processIngressChain = chain => ( originalRequest, store ) =>
 	chain
 		.reduce( applyIngressChain, { originalRequest, store, nextRequest: originalRequest } )
-		.nextAction;
+		.nextRequest;
 
 export const processEgressChain = chain => ( originalRequest, store, originalData, originalError ) =>
 	pick(
@@ -76,11 +76,11 @@ export const processEgressChain = chain => ( originalRequest, store, originalDat
 			originalData,
 			originalError,
 			nextData: originalData,
-			nextError: originalData,
+			nextError: originalError,
 			failures: compact( [ originalRequest.onFailure ] ),
 			successes: compact( [ originalRequest.onSuccess ] ),
 		} ),
-		[ 'failures', 'successes', 'shouldAbort' ],
+		[ 'failures', 'nextData', 'nextError', 'successes', 'shouldAbort' ],
 	);
 
 export const processIngress = processIngressChain( ingressChain );

--- a/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
@@ -2,5 +2,13 @@
  * Prevent sending multiple identical GET requests
  * while one is still transiting over the network
  *
+ * Note! This doesn't do anything yet
+ *
  * @module state/data-layer/wpcom-http/optimizations/remove-duplicate-gets
  */
+
+export const removeDuplicateGets = ( { action, dispatch } ) => {
+	return { action, dispatch };
+};
+
+export default removeDuplicateGets;

--- a/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
@@ -79,15 +79,15 @@ export const addResponder = ( list, item ) => ( {
  *
  * @see applyDuplicateHandlers
  *
- * @type IngressProcessor
- * @param {IngressData} ingressData
- * @returns {IngressData}
+ * @type OutboundProcessor
+ * @param {OutboundData} outboundData
+ * @returns {OutboundData}
  */
-export const removeDuplicateGets = ingressData => {
-	const { nextRequest } = ingressData;
+export const removeDuplicateGets = outboundData => {
+	const { nextRequest } = outboundData;
 
 	if ( ! isGetRequest( nextRequest ) ) {
-		return ingressData;
+		return outboundData;
 	}
 
 	const key = buildKey( nextRequest );
@@ -97,8 +97,8 @@ export const removeDuplicateGets = ingressData => {
 	requestQueue.set( key, request );
 
 	return queued
-		? { ...ingressData, nextRequest: null }
-		: ingressData;
+		? { ...outboundData, nextRequest: null }
+		: outboundData;
 };
 
 /**
@@ -108,30 +108,30 @@ export const removeDuplicateGets = ingressData => {
  *
  * @see removeDuplicateGets
  *
- * @type EgressProcessor
- * @param {EgressData} egressData
- * @returns {EgressData}
+ * @type InboundProcessor
+ * @param {InboundData} inboundData
+ * @returns {InboundData}
  */
-export const applyDuplicatesHandlers = egressData => {
-	const { originalRequest } = egressData;
+export const applyDuplicatesHandlers = inboundData => {
+	const { originalRequest } = inboundData;
 
 	if ( ! isGetRequest( originalRequest ) ) {
-		return egressData;
+		return inboundData;
 	}
 
 	const key = buildKey( originalRequest );
 	const queued = requestQueue.get( key );
 
 	if ( ! queued ) {
-		return egressData;
+		return inboundData;
 	}
 
 	requestQueue.delete( key );
 
 	const responders = {
-		failures: union( egressData.failures || [], queued.failures ),
-		successes: union( egressData.successes || [], queued.successes ),
+		failures: union( inboundData.failures || [], queued.failures ),
+		successes: union( inboundData.successes || [], queued.successes ),
 	};
 
-	return { ...egressData, ...responders };
+	return { ...inboundData, ...responders };
 };

--- a/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
@@ -1,0 +1,6 @@
+/**
+ * Prevent sending multiple identical GET requests
+ * while one is still transiting over the network
+ *
+ * @module state/data-layer/wpcom-http/optimizations/remove-duplicate-gets
+ */

--- a/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
@@ -3,63 +3,135 @@
  */
 import {
 	compact,
+	get,
 	head,
-	isEqual,
-	pick,
 	sortBy,
 	toPairs,
-	unionBy,
+	union,
 } from 'lodash';
 
 /**
  * Prevent sending multiple identical GET requests
  * while one is still transiting over the network
  *
- * Note! This doesn't do anything yet
+ * Two requests are considered identical if they
+ * are both GET requests and share the same
+ * fundamental properties.
  *
  * @module state/data-layer/wpcom-http/optimizations/remove-duplicate-gets
  */
 
+/** @type {Map} holds in-transit request keys */
 const requestQueue = new Map();
 
-export const buildKey = ( { path, apiVersion, query } ) => JSON.stringify( [
+/**
+ * Empties the duplication queue
+ *
+ * FOR TESTING ONLY!
+ */
+export const clearQueue = () => {
+	if ( 'undefined' !== typeof window ) {
+		throw new Error( '`clearQueue()` is not for use in production - only in testing!' );
+	}
+
+	requestQueue.clear();
+};
+
+/**
+ * Determines if a request object specifies the GET HTTP method
+ *
+ * @param {Object} request the HTTP request action
+ * @returns {Boolean} whether or not the method is GET
+ */
+const isGetRequest = request => 'GET' === get( request, 'method', '' ).toUpperCase();
+
+/**
+ * Generate a deterministic key for comparing request descriptions
+ *
+ * @param {String} path API endpoint path
+ * @param {String} apiNamespace used for endpoint versioning
+ * @param {String} apiVersion used for endpoint versioning
+ * @param {Object<String, *>} query GET query string
+ * @returns {String} unique key up to duplicate request descriptions
+ */
+export const buildKey = ( { path, apiNamespace, apiVersion, query } ) => JSON.stringify( [
 	path,
+	apiNamespace,
 	apiVersion,
 	sortBy( toPairs( query ), head ),
 ] );
 
+/**
+ * Joins a responder action into a unique list of responder actions
+ *
+ * @param {Object<String, Object[]>} list existing responder actions
+ * @param {Object} item new responder action to add
+ * @returns {Object<String, Object[]>} union of existing list and new item
+ */
 export const addResponder = ( list, item ) => ( {
-	failures: unionBy( list.failures, compact( [ item.onFailure ] ), isEqual ),
-	successes: unionBy( list.successes, compact( [ item.onSuccess ] ), isEqual ),
+	failures: union( list.failures, compact( [ item.onFailure ] ) ),
+	successes: union( list.successes, compact( [ item.onSuccess ] ) ),
 } );
 
 /**
+ * Prevents sending duplicate requests when one is
+ * already in transit over the network.
+ *
+ * @see applyDuplicateHandlers
+ *
  * @type IngressProcessor
  * @param {IngressData} ingressData
  * @returns {IngressData}
  */
 export const removeDuplicateGets = ingressData => {
-	const { nextAction: action } = ingressData;
-	const key = buildKey( action );
-	const queued = requestQueue.get( key ) || { failures: [], successes: [] };
-	const request = addResponder( queued, action );
+	const { nextRequest } = ingressData;
+
+	if ( ! isGetRequest( nextRequest ) ) {
+		return ingressData;
+	}
+
+	const key = buildKey( nextRequest );
+	const queued = requestQueue.get( key );
+	const request = addResponder( queued || { failures: [], successes: [] }, nextRequest );
 
 	requestQueue.set( key, request );
 
 	return queued
-		? { ...ingressData, nextAction: null }
+		? { ...ingressData, nextRequest: null }
 		: ingressData;
 };
 
 /**
+ * When requests have been de-duplicated and return
+ * this injects the other responder actions into the
+ * response stream so that each caller gets called
+ *
+ * @see removeDuplicateGets
+ *
  * @type EgressProcessor
+ * @param {EgressData} egressData
+ * @returns {EgressData}
  */
 export const applyDuplicatesHandlers = egressData => {
-	const { originalAction: action } = egressData;
-	const key = buildKey( action );
-	const queued = requestQueue.delete( key );
+	const { originalRequest } = egressData;
 
-	return queued
-		? { ...egressData, ...pick( queued, [ 'failures', 'successes' ] ) }
-		: egressData;
+	if ( ! isGetRequest( originalRequest ) ) {
+		return egressData;
+	}
+
+	const key = buildKey( originalRequest );
+	const queued = requestQueue.get( key );
+
+	if ( ! queued ) {
+		return egressData;
+	}
+
+	requestQueue.delete( key );
+
+	const responders = {
+		failures: union( egressData.failures || [], queued.failures ),
+		successes: union( egressData.successes || [], queued.successes ),
+	};
+
+	return { ...egressData, ...responders };
 };

--- a/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
@@ -1,4 +1,17 @@
 /**
+ * External dependencies
+ */
+import {
+	compact,
+	head,
+	isEqual,
+	pick,
+	sortBy,
+	toPairs,
+	unionBy,
+} from 'lodash';
+
+/**
  * Prevent sending multiple identical GET requests
  * while one is still transiting over the network
  *
@@ -7,8 +20,46 @@
  * @module state/data-layer/wpcom-http/optimizations/remove-duplicate-gets
  */
 
-export const removeDuplicateGets = ( { action, dispatch } ) => {
-	return { action, dispatch };
+const requestQueue = new Map();
+
+export const buildKey = ( { path, apiVersion, query } ) => JSON.stringify( [
+	path,
+	apiVersion,
+	sortBy( toPairs( query ), head ),
+] );
+
+export const mergeRequestHandlers = ( a, b ) => ( {
+	onFailure: unionBy( a.onFailure, b.onFailure, isEqual ),
+	onSuccess: unionBy( a.onSuccess, b.onSuccess, isEqual ),
+} );
+
+/**
+ * @type IngressProcessor
+ */
+export const removeDuplicateGets = ingressData => {
+	const { nextAction: action } = ingressData;
+	const key = buildKey( action );
+	const queued = requestQueue.get( key );
+	const request = queued
+		? mergeRequestHandlers( queued, action )
+		: { onSuccess: compact( [ action.onSuccess ] ), onFailure: compact( [ action.onFailure ] ) };
+
+	requestQueue.set( key, request );
+
+	return queued
+		? { ...ingressData, nextAction: null }
+		: ingressData;
 };
 
-export default removeDuplicateGets;
+/**
+ * @type EgressProcessor
+ */
+export const applyDuplicatesHandlers = egressData => {
+	const { originalAction: action } = egressData;
+	const key = buildKey( action );
+	const queued = requestQueue.delete( key );
+
+	return queued
+		? { ...egressData, ...pick( queued, [ 'failures', 'successes' ] ) }
+		: egressData;
+};

--- a/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
@@ -28,21 +28,21 @@ export const buildKey = ( { path, apiVersion, query } ) => JSON.stringify( [
 	sortBy( toPairs( query ), head ),
 ] );
 
-export const mergeRequestHandlers = ( a, b ) => ( {
-	onFailure: unionBy( a.onFailure, b.onFailure, isEqual ),
-	onSuccess: unionBy( a.onSuccess, b.onSuccess, isEqual ),
+export const addResponder = ( list, item ) => ( {
+	failures: unionBy( list.failures, compact( [ item.onFailure ] ), isEqual ),
+	successes: unionBy( list.successes, compact( [ item.onSuccess ] ), isEqual ),
 } );
 
 /**
  * @type IngressProcessor
+ * @param {IngressData} ingressData
+ * @returns {IngressData}
  */
 export const removeDuplicateGets = ingressData => {
 	const { nextAction: action } = ingressData;
 	const key = buildKey( action );
-	const queued = requestQueue.get( key );
-	const request = queued
-		? mergeRequestHandlers( queued, action )
-		: { onSuccess: compact( [ action.onSuccess ] ), onFailure: compact( [ action.onFailure ] ) };
+	const queued = requestQueue.get( key ) || { failures: [], successes: [] };
+	const request = addResponder( queued, action );
 
 	requestQueue.set( key, request );
 

--- a/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
@@ -5,9 +5,10 @@ import {
 	compact,
 	get,
 	head,
+	isEqual,
 	sortBy,
 	toPairs,
-	union,
+	unionWith,
 } from 'lodash';
 
 /**
@@ -69,8 +70,8 @@ export const buildKey = ( { path, apiNamespace, apiVersion, query } ) => JSON.st
  * @returns {Object<String, Object[]>} union of existing list and new item
  */
 export const addResponder = ( list, item ) => ( {
-	failures: union( list.failures, compact( [ item.onFailure ] ) ),
-	successes: union( list.successes, compact( [ item.onSuccess ] ) ),
+	failures: unionWith( list.failures, compact( [ item.onFailure ] ), isEqual ),
+	successes: unionWith( list.successes, compact( [ item.onSuccess ] ), isEqual ),
 } );
 
 /**
@@ -129,8 +130,8 @@ export const applyDuplicatesHandlers = inboundData => {
 	requestQueue.delete( key );
 
 	const responders = {
-		failures: union( inboundData.failures || [], queued.failures ),
-		successes: union( inboundData.successes || [], queued.successes ),
+		failures: unionWith( inboundData.failures || [], queued.failures, isEqual ),
+		successes: unionWith( inboundData.successes || [], queued.successes, isEqual ),
 	};
 
 	return { ...inboundData, ...responders };

--- a/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
@@ -80,9 +80,8 @@ export const addResponder = ( list, item ) => ( {
  *
  * @see applyDuplicateHandlers
  *
- * @type OutboundProcessor
- * @param {OutboundData} outboundData
- * @returns {OutboundData}
+ * @param {OutboundData} outboundData request info
+ * @returns {OutboundData} filtered request info
  */
 export const removeDuplicateGets = outboundData => {
 	const { nextRequest } = outboundData;
@@ -109,9 +108,8 @@ export const removeDuplicateGets = outboundData => {
  *
  * @see removeDuplicateGets
  *
- * @type InboundProcessor
- * @param {InboundData} inboundData
- * @returns {InboundData}
+ * @param {InboundData} inboundData request info
+ * @returns {InboundData} processed request info
  */
 export const applyDuplicatesHandlers = inboundData => {
 	const { originalRequest } = inboundData;

--- a/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/test/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/test/index.js
@@ -1,0 +1,270 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	addResponder,
+	applyDuplicatesHandlers,
+	buildKey,
+	clearQueue,
+	removeDuplicateGets,
+} from '../';
+
+const failer = { type: 'FAIL' };
+const filler = { type: 'FILL' };
+const succeeder = { type: 'SUCCEED' };
+
+const getSites = {
+	method: 'GET',
+	path: '/sites',
+	apiVersion: 'v1',
+	onSuccess: succeeder,
+	onFailure: failer,
+};
+
+const getPosts = {
+	method: 'GET',
+	path: '/sites/posts',
+	apiVersion: 'v1.2',
+	onSuccess: succeeder,
+	onFailure: failer,
+};
+
+const postLike = {
+	method: 'POST',
+	path: '/sites/posts/like',
+	apiVersion: 'v1.4',
+	onSuccess: succeeder,
+	onFailure: failer,
+};
+
+describe( '#buildKey', () => {
+	it( 'should collapse "duplicate" requests', () => {
+		const duplicates = [ [
+			{ path: '/', apiNamespace: 'wpcom/v2', query: { id: 1, limit: 5 } },
+			{ path: '/', apiNamespace: 'wpcom/v2', query: { limit: 5, id: 1 } },
+		], [
+			{ path: '/' },
+			{ path: '/', query: undefined },
+		], [
+			{ path: '/' },
+			{ path: '/', query: {} },
+		], [
+			{ path: '/' },
+			{ path: '/', apiNamespace: undefined }
+		], [
+			{ path: '/', onSuccess: succeeder },
+			{ path: '/', onSuccess: filler },
+		] ];
+
+		duplicates.forEach( ( [ a, b ] ) => expect( buildKey( a ) ).to.equal( buildKey( b ) ) );
+	} );
+
+	it( 'should differentiate "unique" requests', () => {
+		const uniques = [ [
+			{ path: '/', apiNamespace: 'wp/v1' },
+			{ path: '/', apiNamespace: 'wpcom/v1' },
+		], [
+			{ path: '/', apiNamespace: 'wp/v1' },
+			{ path: '/', apiVersion: 'wp/v1' },
+		], [
+			{ path: '/' },
+			{ path: '/a' },
+		], [
+			{ path: '/', query: { id: 1 } },
+			{ path: '/', query: { id: 2 } },
+		] ];
+
+		uniques.forEach( ( [ a, b ] ) => expect( buildKey( a ) ).to.not.equal( buildKey( b ) ) );
+	} );
+} );
+
+describe( '#addResponder', () => {
+	it( 'should add an `onFailure` action to an empty list', () => {
+		const union = addResponder( {}, { onFailure: failer } );
+
+		expect( union.failures ).to.eql( [ failer ] );
+		expect( union.successes ).to.be.empty;
+	} );
+
+	it( 'should add an `onSuccess` action to an empty list', () => {
+		const union = addResponder( {}, { onSuccess: succeeder } );
+
+		expect( union.failures ).to.be.empty;
+		expect( union.successes ).to.eql( [ succeeder ] );
+	} );
+
+	it( 'should add a "unique" action to an existing list', () => {
+		const union = addResponder( { successes: [ succeeder ] }, { onSuccess: filler } );
+
+		expect( union.successes ).to.eql( [ succeeder, filler ] );
+	} );
+
+	it( 'should merge "duplicate" actions to an existing list', () => {
+		const union = addResponder( { successes: [ succeeder ] }, { onSuccess: succeeder } );
+
+		expect( union.successes ).to.eql( [ succeeder ] );
+	} );
+
+	it( 'should add both `onSuccess` and `onFailure`', () => {
+		const union = addResponder( {
+			failures: [ failer ],
+			successes: [ succeeder ],
+		}, {
+			onFailure: filler,
+			onSuccess: filler,
+		} );
+
+		expect( union.failures ).to.eql( [ failer, filler ] );
+		expect( union.successes ).to.eql( [ succeeder, filler ] );
+	} );
+} );
+
+describe( '#removeDuplicateGets', () => {
+	before( clearQueue );
+
+	it( 'should pass through non-GET requests', () => {
+		const primed = removeDuplicateGets( { nextRequest: postLike } );
+
+		expect( primed.nextRequest ).to.eql( postLike );
+
+		const processed = removeDuplicateGets( { nextRequest: postLike } );
+
+		expect( processed.nextRequest ).to.eql( postLike );
+	} );
+
+	it( 'should pass through new requests', () => {
+		const processed = removeDuplicateGets( { nextRequest: getSites } );
+
+		expect( processed.nextRequest ).to.eql( getSites );
+	} );
+
+	it( 'should pass through "unique" requests', () => {
+		removeDuplicateGets( { nextRequest: getSites } );
+
+		const processed = removeDuplicateGets( { nextRequest: getPosts } );
+
+		expect( processed.nextRequest ).to.eql( getPosts );
+	} );
+
+	it( 'should drop "duplicate" requests', () => {
+		removeDuplicateGets( { nextRequest: getSites } );
+
+		const processed = removeDuplicateGets( { nextRequest: getSites } );
+
+		expect( processed.nextRequest ).to.be.null;
+	} );
+} );
+
+describe( '#applyDuplicateHandlers', () => {
+	before( clearQueue );
+
+	it( 'should return new requests', () => {
+		removeDuplicateGets( { nextRequest: getSites } );
+
+		const processed = applyDuplicatesHandlers( { originalRequest: getSites } );
+
+		expect( processed.failures ).to.eql( [ getSites.onFailure ] );
+		expect( processed.successes ).to.eql( [ getSites.onSuccess ] );
+	} );
+
+	it( 'should collapse "duplicate" requests having same responders', () => {
+		removeDuplicateGets( { nextRequest: getSites } );
+		removeDuplicateGets( { nextRequest: getSites } );
+
+		const processed = applyDuplicatesHandlers( { originalRequest: getSites } );
+
+		expect( processed.failures ).to.eql( [ getSites.onFailure ] );
+		expect( processed.successes ).to.eql( [ getSites.onSuccess ] );
+	} );
+
+	it( 'should spread "duplicate" requests having different responders', () => {
+		removeDuplicateGets( { nextRequest: getSites } );
+		removeDuplicateGets( { nextRequest: { ...getSites, onSuccess: filler } } );
+
+		const processed = applyDuplicatesHandlers( { originalRequest: getSites } );
+
+		expect( processed.failures ).to.eql( [ getSites.onFailure ] );
+		expect( processed.successes ).to.eql( [ getSites.onSuccess, filler ] );
+	} );
+
+	it( 'should pass through "unique" requests', () => {
+		removeDuplicateGets( { nextRequest: getSites } );
+		removeDuplicateGets( { nextRequest: getPosts } );
+
+		const sites = applyDuplicatesHandlers( { originalRequest: getSites } );
+
+		expect( sites.failures ).to.eql( [ failer ] );
+		expect( sites.successes ).to.eql( [ succeeder ] );
+
+		const posts = applyDuplicatesHandlers( { originalRequest: getPosts } );
+
+		expect( posts.failures ).to.eql( [ failer ] );
+		expect( posts.successes ).to.eql( [ succeeder ] );
+	} );
+
+	it( 'should pass through "duplicate" requests which never overlap', () => {
+		removeDuplicateGets( { nextRequest: getSites } );
+
+		const first = applyDuplicatesHandlers( { originalRequest: getSites } );
+
+		expect( first.failures ).to.eql( [ failer ] );
+		expect( first.successes ).to.eql( [ succeeder ] );
+
+		const { nextRequest } = removeDuplicateGets( { nextRequest: getSites } );
+
+		expect( nextRequest ).to.eql( getSites );
+
+		const second = applyDuplicatesHandlers( { originalRequest: getSites } );
+
+		expect( second.failures ).to.eql( [ failer ] );
+		expect( second.successes ).to.eql( [ succeeder ] );
+	} );
+
+
+	it( 'should not collapse non-GET requests', () => {
+		removeDuplicateGets( { nextRequest: postLike } );
+		removeDuplicateGets( { nextRequest: postLike } );
+
+		const processed = applyDuplicatesHandlers( {
+			failures: [ postLike.onFailure ],
+			originalRequest: postLike,
+			successes: [ postLike.onSuccess ],
+		} );
+
+		expect( processed.failures ).to.eql( [ postLike.onFailure ] );
+		expect( processed.successes ).to.eql( [ postLike.onSuccess ] );
+	} );
+
+	it( 'should not wipe out previous responders in the pipeline', () => {
+		removeDuplicateGets( { nextRequest: getSites } );
+		removeDuplicateGets( { nextRequest: getSites } );
+
+		const processed = applyDuplicatesHandlers( {
+			failures: [ filler ],
+			originalRequest: getSites,
+			successes: [ filler ],
+		} );
+
+		expect( processed.failures ).to.eql( [ filler, getSites.onFailure ] );
+		expect( processed.successes ).to.eql( [ filler, getSites.onSuccess ] );
+	} );
+
+	it( 'should combine previous responders with "duplicate" responders in the pipeline', () => {
+		removeDuplicateGets( { nextRequest: getSites } );
+		removeDuplicateGets( { nextRequest: getSites } );
+
+		const processed = applyDuplicatesHandlers( {
+			failures: [ getSites.onFailure ],
+			originalRequest: getSites,
+			successes: [ getSites.onSuccess ],
+		} );
+
+		expect( processed.failures ).to.eql( [ getSites.onFailure ] );
+		expect( processed.successes ).to.eql( [ getSites.onSuccess ] );
+	} );
+} );

--- a/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/test/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/test/index.js
@@ -125,7 +125,7 @@ describe( '#addResponder', () => {
 } );
 
 describe( '#removeDuplicateGets', () => {
-	before( clearQueue );
+	beforeEach( clearQueue );
 
 	it( 'should pass through non-GET requests', () => {
 		const primed = removeDuplicateGets( { nextRequest: postLike } );

--- a/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/test/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/test/index.js
@@ -42,6 +42,14 @@ const postLike = {
 	onFailure: failer,
 };
 
+/**
+ * Make a quick clone of an object for testing
+ *
+ * @param {Object} o object to shallow-clone
+ * @returns {Object} cloned object
+ */
+const cp = o => ( { ...o } );
+
 describe( '#buildKey', () => {
 	it( 'should collapse "duplicate" requests', () => {
 		const duplicates = [ [
@@ -85,38 +93,38 @@ describe( '#buildKey', () => {
 
 describe( '#addResponder', () => {
 	it( 'should add an `onFailure` action to an empty list', () => {
-		const union = addResponder( {}, { onFailure: failer } );
+		const union = addResponder( {}, { onFailure: cp( failer ) } );
 
 		expect( union.failures ).to.eql( [ failer ] );
 		expect( union.successes ).to.be.empty;
 	} );
 
 	it( 'should add an `onSuccess` action to an empty list', () => {
-		const union = addResponder( {}, { onSuccess: succeeder } );
+		const union = addResponder( {}, { onSuccess: cp( succeeder ) } );
 
 		expect( union.failures ).to.be.empty;
 		expect( union.successes ).to.eql( [ succeeder ] );
 	} );
 
 	it( 'should add a "unique" action to an existing list', () => {
-		const union = addResponder( { successes: [ succeeder ] }, { onSuccess: filler } );
+		const union = addResponder( { successes: [ cp( succeeder ) ] }, { onSuccess: cp( filler ) } );
 
 		expect( union.successes ).to.eql( [ succeeder, filler ] );
 	} );
 
 	it( 'should merge "duplicate" actions to an existing list', () => {
-		const union = addResponder( { successes: [ succeeder ] }, { onSuccess: succeeder } );
+		const union = addResponder( { successes: [ cp( succeeder ) ] }, { onSuccess: cp( succeeder ) } );
 
 		expect( union.successes ).to.eql( [ succeeder ] );
 	} );
 
 	it( 'should add both `onSuccess` and `onFailure`', () => {
 		const union = addResponder( {
-			failures: [ failer ],
-			successes: [ succeeder ],
+			failures: [ cp( failer ) ],
+			successes: [ cp( succeeder ) ],
 		}, {
-			onFailure: filler,
-			onSuccess: filler,
+			onFailure: cp( filler ),
+			onSuccess: cp( filler ),
 		} );
 
 		expect( union.failures ).to.eql( [ failer, filler ] );
@@ -128,33 +136,33 @@ describe( '#removeDuplicateGets', () => {
 	beforeEach( clearQueue );
 
 	it( 'should pass through non-GET requests', () => {
-		const primed = removeDuplicateGets( { nextRequest: postLike } );
+		const primed = removeDuplicateGets( { nextRequest: cp( postLike ) } );
 
 		expect( primed.nextRequest ).to.eql( postLike );
 
-		const processed = removeDuplicateGets( { nextRequest: postLike } );
+		const processed = removeDuplicateGets( { nextRequest: cp( postLike ) } );
 
 		expect( processed.nextRequest ).to.eql( postLike );
 	} );
 
 	it( 'should pass through new requests', () => {
-		const processed = removeDuplicateGets( { nextRequest: getSites } );
+		const processed = removeDuplicateGets( { nextRequest: cp( getSites ) } );
 
 		expect( processed.nextRequest ).to.eql( getSites );
 	} );
 
 	it( 'should pass through "unique" requests', () => {
-		removeDuplicateGets( { nextRequest: getSites } );
+		removeDuplicateGets( { nextRequest: cp( getSites ) } );
 
-		const processed = removeDuplicateGets( { nextRequest: getPosts } );
+		const processed = removeDuplicateGets( { nextRequest: cp( getPosts ) } );
 
 		expect( processed.nextRequest ).to.eql( getPosts );
 	} );
 
 	it( 'should drop "duplicate" requests', () => {
-		removeDuplicateGets( { nextRequest: getSites } );
+		removeDuplicateGets( { nextRequest: cp( getSites ) } );
 
-		const processed = removeDuplicateGets( { nextRequest: getSites } );
+		const processed = removeDuplicateGets( { nextRequest: cp( getSites ) } );
 
 		expect( processed.nextRequest ).to.be.null;
 	} );
@@ -164,76 +172,75 @@ describe( '#applyDuplicateHandlers', () => {
 	before( clearQueue );
 
 	it( 'should return new requests', () => {
-		removeDuplicateGets( { nextRequest: getSites } );
+		removeDuplicateGets( { nextRequest: cp( getSites ) } );
 
-		const processed = applyDuplicatesHandlers( { originalRequest: getSites } );
+		const processed = applyDuplicatesHandlers( { originalRequest: cp( getSites ) } );
 
 		expect( processed.failures ).to.eql( [ getSites.onFailure ] );
 		expect( processed.successes ).to.eql( [ getSites.onSuccess ] );
 	} );
 
 	it( 'should collapse "duplicate" requests having same responders', () => {
-		removeDuplicateGets( { nextRequest: getSites } );
-		removeDuplicateGets( { nextRequest: getSites } );
+		removeDuplicateGets( { nextRequest: cp( getSites ) } );
+		removeDuplicateGets( { nextRequest: cp( getSites ) } );
 
-		const processed = applyDuplicatesHandlers( { originalRequest: getSites } );
+		const processed = applyDuplicatesHandlers( { originalRequest: cp( getSites ) } );
 
 		expect( processed.failures ).to.eql( [ getSites.onFailure ] );
 		expect( processed.successes ).to.eql( [ getSites.onSuccess ] );
 	} );
 
 	it( 'should spread "duplicate" requests having different responders', () => {
-		removeDuplicateGets( { nextRequest: getSites } );
-		removeDuplicateGets( { nextRequest: { ...getSites, onSuccess: filler } } );
+		removeDuplicateGets( { nextRequest: cp( getSites ) } );
+		removeDuplicateGets( { nextRequest: { ...getSites, onSuccess: cp( filler ) } } );
 
-		const processed = applyDuplicatesHandlers( { originalRequest: getSites } );
+		const processed = applyDuplicatesHandlers( { originalRequest: cp( getSites ) } );
 
 		expect( processed.failures ).to.eql( [ getSites.onFailure ] );
 		expect( processed.successes ).to.eql( [ getSites.onSuccess, filler ] );
 	} );
 
 	it( 'should pass through "unique" requests', () => {
-		removeDuplicateGets( { nextRequest: getSites } );
-		removeDuplicateGets( { nextRequest: getPosts } );
+		removeDuplicateGets( { nextRequest: cp( getSites ) } );
+		removeDuplicateGets( { nextRequest: cp( getPosts ) } );
 
-		const sites = applyDuplicatesHandlers( { originalRequest: getSites } );
+		const sites = applyDuplicatesHandlers( { originalRequest: cp( getSites ) } );
 
 		expect( sites.failures ).to.eql( [ failer ] );
 		expect( sites.successes ).to.eql( [ succeeder ] );
 
-		const posts = applyDuplicatesHandlers( { originalRequest: getPosts } );
+		const posts = applyDuplicatesHandlers( { originalRequest: cp( getPosts ) } );
 
 		expect( posts.failures ).to.eql( [ failer ] );
 		expect( posts.successes ).to.eql( [ succeeder ] );
 	} );
 
 	it( 'should pass through "duplicate" requests which never overlap', () => {
-		removeDuplicateGets( { nextRequest: getSites } );
+		removeDuplicateGets( { nextRequest: cp( getSites ) } );
 
-		const first = applyDuplicatesHandlers( { originalRequest: getSites } );
+		const first = applyDuplicatesHandlers( { originalRequest: cp( getSites ) } );
 
 		expect( first.failures ).to.eql( [ failer ] );
 		expect( first.successes ).to.eql( [ succeeder ] );
 
-		const { nextRequest } = removeDuplicateGets( { nextRequest: getSites } );
+		const { nextRequest } = removeDuplicateGets( { nextRequest: cp( getSites ) } );
 
 		expect( nextRequest ).to.eql( getSites );
 
-		const second = applyDuplicatesHandlers( { originalRequest: getSites } );
+		const second = applyDuplicatesHandlers( { originalRequest: cp( getSites ) } );
 
 		expect( second.failures ).to.eql( [ failer ] );
 		expect( second.successes ).to.eql( [ succeeder ] );
 	} );
 
-
 	it( 'should not collapse non-GET requests', () => {
-		removeDuplicateGets( { nextRequest: postLike } );
-		removeDuplicateGets( { nextRequest: postLike } );
+		removeDuplicateGets( { nextRequest: cp( postLike ) } );
+		removeDuplicateGets( { nextRequest: cp( postLike ) } );
 
 		const processed = applyDuplicatesHandlers( {
-			failures: [ postLike.onFailure ],
-			originalRequest: postLike,
-			successes: [ postLike.onSuccess ],
+			failures: [ cp( postLike.onFailure ) ],
+			originalRequest: cp( postLike ),
+			successes: [ cp( postLike.onSuccess ) ],
 		} );
 
 		expect( processed.failures ).to.eql( [ postLike.onFailure ] );
@@ -241,13 +248,13 @@ describe( '#applyDuplicateHandlers', () => {
 	} );
 
 	it( 'should not wipe out previous responders in the pipeline', () => {
-		removeDuplicateGets( { nextRequest: getSites } );
-		removeDuplicateGets( { nextRequest: getSites } );
+		removeDuplicateGets( { nextRequest: cp( getSites ) } );
+		removeDuplicateGets( { nextRequest: cp( getSites ) } );
 
 		const processed = applyDuplicatesHandlers( {
-			failures: [ filler ],
-			originalRequest: getSites,
-			successes: [ filler ],
+			failures: [ cp( filler ) ],
+			originalRequest: cp( getSites ),
+			successes: [ cp( filler ) ],
 		} );
 
 		expect( processed.failures ).to.eql( [ filler, getSites.onFailure ] );
@@ -255,13 +262,13 @@ describe( '#applyDuplicateHandlers', () => {
 	} );
 
 	it( 'should combine previous responders with "duplicate" responders in the pipeline', () => {
-		removeDuplicateGets( { nextRequest: getSites } );
-		removeDuplicateGets( { nextRequest: getSites } );
+		removeDuplicateGets( { nextRequest: cp( getSites ) } );
+		removeDuplicateGets( { nextRequest: cp( getSites ) } );
 
 		const processed = applyDuplicatesHandlers( {
-			failures: [ getSites.onFailure ],
-			originalRequest: getSites,
-			successes: [ getSites.onSuccess ],
+			failures: [ cp( getSites.onFailure ) ],
+			originalRequest: cp( getSites ),
+			successes: [ cp( getSites.onSuccess ) ],
 		} );
 
 		expect( processed.failures ).to.eql( [ getSites.onFailure ] );

--- a/client/state/data-layer/wpcom-http/pipeline/test/test.js
+++ b/client/state/data-layer/wpcom-http/pipeline/test/test.js
@@ -1,0 +1,122 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+import {
+	processEgressChain,
+	processIngressChain,
+} from '../';
+
+const succeeder = { type: 'SUCCESS' };
+const failer = { type: 'FAILURE' };
+
+const getSites = {
+	method: 'GET',
+	path: '/',
+	apiVersion: 'v1',
+	onSuccess: succeeder,
+	onFailure: failer,
+};
+
+describe( '#processEgressChain', () => {
+	const aborter = egressData => ( {
+		...egressData,
+		failures: [],
+		shouldAbort: true,
+		successes: [],
+	} );
+
+	const responderDoubler = egressData => ( {
+		...egressData,
+		failures: [ ...egressData.failures, ...egressData.failures ],
+		successes: [ ...egressData.successes, ...egressData.successes ],
+	} );
+
+	it( 'should pass through data given an empty chain', () => {
+		expect(
+			processEgressChain( [] )( getSites, {}, { value: 1 }, { error: 'bad' } )
+		).to.eql( {
+			failures: [ getSites.onFailure ],
+			nextData: { value: 1 },
+			nextError: { error: 'bad' },
+			successes: [ getSites.onSuccess ],
+		} );
+	} );
+
+	it( 'should sequence a single processor', () => {
+		expect(
+			processEgressChain( [ responderDoubler ] )( getSites, {}, {}, {} )
+		).to.eql( {
+			failures: [ getSites.onFailure, getSites.onFailure ],
+			nextData: {},
+			nextError: {},
+			successes: [ getSites.onSuccess, getSites.onSuccess ],
+		} );
+	} );
+
+	it( 'should sequence multiple processors', () => {
+		expect(
+			processEgressChain( [ responderDoubler, responderDoubler ] )( getSites, {}, {}, {} )
+		).to.eql( {
+			failures: ( new Array( 4 ) ).fill( getSites.onFailure ),
+			nextData: {},
+			nextError: {},
+			successes: ( new Array( 4 ) ).fill( getSites.onSuccess ),
+		} );
+	} );
+
+	it( 'should abort the chain as soon as `shouldAbort` is set', () => {
+		expect(
+			processEgressChain( [ aborter, responderDoubler ] )( getSites, {}, {}, {} )
+		).to.eql( {
+			failures: [],
+			nextData: {},
+			nextError: {},
+			successes: [],
+			shouldAbort: true,
+		} );
+	} );
+} );
+
+describe( '#processIngressChain', () => {
+	const aborter = ingressData => ( {
+		...ingressData,
+		nextRequest: null,
+	} );
+
+	const pathDoubler = ingressData => {
+		const { nextRequest } = ingressData;
+		const { path } = nextRequest;
+
+		return {
+			...ingressData,
+			nextRequest: {
+				...nextRequest,
+				path: path + path,
+			}
+		};
+	};
+
+	it( 'should pass requests given an empty chain', () => {
+		expect( processIngressChain( [] )( getSites, {} ) ).to.eql( getSites );
+	} );
+
+	it( 'should sequence a single processor', () => {
+		expect( processIngressChain( [ pathDoubler ] )( getSites, {} ) ).to.eql( {
+			...getSites,
+			path: getSites.path + getSites.path,
+		} );
+	} );
+
+	it( 'should sequence multiple processors', () => {
+		expect( processIngressChain( [ pathDoubler, pathDoubler ] )( getSites, {} ) ).to.eql( {
+			...getSites,
+			path: ( new Array( 4 ) ).fill( getSites.path ).join( '' ),
+		} );
+	} );
+
+	it( 'should abort the chain as soon as the `nextRequest` is `null`', () => {
+		expect( processIngressChain( [ aborter, pathDoubler ] )( getSites, {} ) ).to.be.null;
+	} );
+} );

--- a/client/state/data-layer/wpcom-http/test/index.js
+++ b/client/state/data-layer/wpcom-http/test/index.js
@@ -15,15 +15,15 @@ import {
 	successMeta,
 } from '../';
 
-const processIngress = action => action;
-const processEgress = ( action, store, data, error ) => ( {
+const processInbound = action => action;
+const processOutbound = ( action, store, data, error ) => ( {
 	failures: [ action.onFailure ],
 	nextData: data,
 	nextError: error,
 	successes: [ action.onSuccess ],
 } );
 
-const http = queueRequest( processIngress, processEgress );
+const http = queueRequest( processInbound, processOutbound );
 
 const succeeder = { type: 'SUCCESS' };
 const failer = { type: 'FAIL' };

--- a/client/state/data-layer/wpcom-http/test/index.js
+++ b/client/state/data-layer/wpcom-http/test/index.js
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { spy } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import useNock, { nock } from 'test/helpers/use-nock';
+import { extendAction } from 'state/utils';
+import {
+	failureMeta,
+	queueRequest,
+	successMeta,
+} from '../';
+
+const processIngress = action => action;
+const processEgress = ( action, store, data, error ) => ( {
+	failures: [ action.onFailure ],
+	nextData: data,
+	nextError: error,
+	successes: [ action.onSuccess ],
+} );
+
+const http = queueRequest( processIngress, processEgress );
+
+const succeeder = { type: 'SUCCESS' };
+const failer = { type: 'FAIL' };
+
+const getMe = {
+	method: 'GET',
+	path: '/me',
+	apiVersion: 'v1.1',
+	onFailure: failer,
+	onSuccess: succeeder,
+};
+
+describe( '#queueRequest', () => {
+	let dispatch;
+	let next;
+
+	useNock();
+
+	beforeEach( () => {
+		dispatch = spy();
+		next = spy();
+	} );
+
+	it( 'should call `onSuccess` when a response returns with data', done => {
+		const data = { value: 1 };
+		nock( 'https://public-api.wordpress.com:443' ).get( '/rest/v1.1/me' ).reply( 200, data );
+
+		http( { dispatch }, getMe, next );
+
+		expect( next ).to.have.been.calledWith( getMe );
+
+		setTimeout( () => {
+			expect( dispatch ).to.have.been.calledOnce;
+			expect( dispatch ).to.have.been.calledWith( extendAction( succeeder, successMeta( data ) ) );
+			done();
+		}, 10 );
+	} );
+
+	it( 'should call `onFailure` when a response returns with an error', done => {
+		const error = { error: 'bad' };
+		nock( 'https://public-api.wordpress.com:443' ).get( '/rest/v1.1/me' ).replyWithError( error );
+
+		http( { dispatch }, getMe, next );
+
+		expect( next ).to.have.been.calledWith( getMe );
+
+		setTimeout( () => {
+			expect( dispatch ).to.have.been.calledOnce;
+			expect( dispatch ).to.have.been.calledWith( extendAction( failer, failureMeta( error ) ) );
+			done();
+		}, 10 );
+	} );
+} );

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -126,6 +126,14 @@ const reducers = {
 
 export const reducer = combineReducers( reducers );
 
+/**
+ * @typedef {Object} ReduxStore
+ * @property {!Function} dispatch dispatches actions
+ * @property {!Function} getState returns the current state tree
+ * @property {Function} replaceReducers replaces the state reducers
+ * @property {Function} subscribe attaches an event listener to state changes
+ */
+
 export function createReduxStore( initialState = {} ) {
 	const isBrowser = typeof window === 'object';
 	const isAudioSupported = typeof window === 'object' && typeof window.Audio === 'function';


### PR DESCRIPTION
Introduce a system for automatically augmenting and optimizing
network-layer operations from inside Calypso.

The goal of this new system is to live entirely within the language of
HTTP and perform HTTP-specific transformations on new requests and when
requests return or fail.

See the [README](https://github.com/Automattic/wp-calypso/blob/aae6e1397cd6527ca4f3e6a0d66f5744a28c7901/client/state/data-layer/wpcom-http/pipeline/README.md) for an explanation