### PR TITLE
State: fix schema for reader teams

### DIFF
--- a/client/state/reader/teams/schema.js
+++ b/client/state/reader/teams/schema.js
@@ -1,16 +1,10 @@
 export const itemsSchema = {
-	type: 'object',
-	properties: {
-		number: { type: 'number' },
-		teams: {
-			type: 'array',
-			items: {
-				type: 'object',
-				properties: {
-					title: { type: 'string' },
-					slug: { type: 'string' },
-				}
-			}
+	type: 'array',
+	items: {
+		type: 'object',
+		properties: {
+			title: { type: 'string' },
+			slug: { type: 'string' },
 		}
 	}
 };

--- a/client/state/reader/teams/test/reducer.js
+++ b/client/state/reader/teams/test/reducer.js
@@ -12,13 +12,21 @@ import {
 	READER_TEAMS_RECEIVE,
 	DESERIALIZE,
 } from 'state/action-types';
+import { useSandbox } from 'test/helpers/use-sinon';
 
 const TEAM1 = { slug: 'team one slug', title: 'team one title' };
 const TEAM2 = { slug: 'team two slug', title: 'team two title' };
-const validState = { teams: [ TEAM1 ], };
-const invalidState = { teams: [ 1, 5 ], fish: 'tacos' };
+const validState = [ TEAM1, TEAM2 ];
+const invalidState = [ { slug: 1, title: 'foo bar' } ];
 
 describe( 'reducer', ( ) => {
+	let sandbox;
+
+	useSandbox( newSandbox => {
+		sandbox = newSandbox;
+		sandbox.stub( console, 'warn' );
+	} );
+
 	describe( 'items', () => {
 		it( 'should return an empty list by default', () => {
 			expect( items( undefined, {} ) ).to.deep.equal( [] );


### PR DESCRIPTION
This PR fixes a schema used for the reader teams reducer. It looks like the previous schema was describing the action shape rather than the reducer shape. As a result we would always throw out persisted reader team data and display these warnings in dev:

![screen shot 2017-02-06 at 4 43 32 pm](https://cloud.githubusercontent.com/assets/1270189/22672880/81d1464c-ec8b-11e6-89b3-44528e8d7810.png)

## Testing Instructions
- Update SERIALIZE_THROTTLE in `client/state/initial-state.js` to something small like 500 ms
- Clear indexedDB `indexedDB.deleteDatabase( 'calypso' );`
- Navigate to http://calypso.localhost:3000/
- Wait for teams to load
- In redux dev tools inspect the dispatched `READER_TEAMS_RECEIVE` action, state should update
![screen shot 2017-02-06 at 4 48 34 pm](https://cloud.githubusercontent.com/assets/1270189/22673016/60777db2-ec8c-11e6-9515-3ea0cd385ccc.png)
- Refresh the page
- No warnings should be shown
- Inspecting the first `READER_TEAMS_RECEIVE` does not change items state.
![screen shot 2017-02-06 at 4 59 18 pm](https://cloud.githubusercontent.com/assets/1270189/22673206/aa7590ba-ec8d-11e6-9c82-220269e21b26.png)





