### PR TITLE
Plugins: Fix toggle layout bug on plugin page

### DIFF
--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -121,16 +121,6 @@
 
 }
 
-.plugin-meta__actions .form-toggle__label {
-	display: flex;
-		justify-content: flex-end;
-
-	.form-toggle__switch {
-		float: none;
-		order: 2;
-	}
-}
-
 .plugin-meta__actions .plugin-action__label {
 	@include breakpoint( '<480px' ) {
 		flex-grow: 2;


### PR DESCRIPTION
This PR fixes #11212, where there's some additional styling applied to `FormToggle` in plugin meta, but it's not longer necessary since we've done some changes in #11158. This PR removes the obsolete styles.

Before:
![](https://cldup.com/GDDxO0I0xU.png)

After:
![](https://cldup.com/0eoprrXrc1.png)