### PR TITLE
Sharing: Fix the name of the function for the selector isSharingButtonsSaveSuccesfful

### DIFF
--- a/client/state/selectors/is-sharing-buttons-save-successful.js
+++ b/client/state/selectors/is-sharing-buttons-save-successful.js
@@ -10,6 +10,6 @@ import { get } from 'lodash';
  * @param  {Number}  siteId Site ID
  * @return {Boolean}        Whether the request is successful or not
  */
-export default function isSiteSettingsSaveSuccessful( state, siteId ) {
+export default function isSharingButtonsSaveSuccessful( state, siteId ) {
 	return get( state.sites.sharingButtons.saveRequests, [ siteId, 'status' ] ) === 'success';
 }


### PR DESCRIPTION
In this PR, I'm just renaming a wrong function name (copy/paste 🙃)
Thanks @aduth for catching that.

**Testing instructions**

This has no effect since the function is exported as "default"