### PR TITLE
Add/upgrade domain only

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -145,26 +145,26 @@ function isPathAllowedForDomainOnlySite( pathname, domainName ) {
 
 function onSelectedSiteAvailable( context ) {
 	const selectedSite = sites.getSelectedSite();
-	const state = context.store.getState();
+	const getState = () => context.store.getState();
 
 	// Currently, sites are only made available in Redux state by the receive
 	// here (i.e. only selected sites). If a site is already known in state,
 	// avoid receiving since we risk overriding changes made more recently.
-	if ( ! getSite( state, selectedSite.ID ) ) {
+	if ( ! getSite( getState(), selectedSite.ID ) ) {
 		context.store.dispatch( receiveSite( selectedSite ) );
 	}
 
 	context.store.dispatch( setSelectedSiteId( selectedSite.ID ) );
 
-	if ( isDomainOnlySite( state, selectedSite.ID ) &&
+	if ( isDomainOnlySite( getState(), selectedSite.ID ) &&
 		! isPathAllowedForDomainOnlySite( context.pathname, selectedSite.slug ) ) {
 		renderSelectedSiteIsDomainOnly( context, selectedSite );
 		return false;
 	}
 
 	// Update recent sites preference
-	if ( hasReceivedRemotePreferences( state ) ) {
-		const recentSites = getPreference( state, 'recentSites' );
+	if ( hasReceivedRemotePreferences( getState() ) ) {
+		const recentSites = getPreference( getState(), 'recentSites' );
 		if ( selectedSite.ID !== recentSites[ 0 ] ) {
 			context.store.dispatch( savePreference( 'recentSites', uniq( [
 				selectedSite.ID,

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -123,7 +123,7 @@ function renderSelectedSiteIsDomainOnly( reactContext, selectedSite ) {
 			title: i18n.translate( 'This feature is not available for domains' ),
 			line: i18n.translate( 'To use this feature you need to create a site' ),
 			action: i18n.translate( 'Create New Site' ),
-			actionURL: `/start/site-selected/?siteSlug=${ encodeURIComponent( selectedSite.slug ) }`,
+			actionURL: `/start/site-selected/?siteSlug=${ encodeURIComponent( selectedSite.slug ) }&siteId=${ encodeURIComponent( selectedSite.ID ) }`,
 			secondaryAction: i18n.translate( 'Manage Domain' ),
 			secondaryActionURL: domainManagementList( selectedSite.slug )
 		} ),

--- a/client/my-sites/upgrades/domain-management/list/domain-only.jsx
+++ b/client/my-sites/upgrades/domain-management/list/domain-only.jsx
@@ -25,6 +25,7 @@ const DomainOnly = ( { domainName, siteId, translate } ) => (
 DomainOnly.propTypes = {
 	domainName: PropTypes.string.isRequired,
 	translate: PropTypes.func.isRequired,
+	siteId: PropTypes.number.isRequired,
 };
 
 export default localize( DomainOnly );

--- a/client/my-sites/upgrades/domain-management/list/domain-only.jsx
+++ b/client/my-sites/upgrades/domain-management/list/domain-only.jsx
@@ -10,13 +10,13 @@ import React, { PropTypes } from 'react';
 import EmptyContent from 'components/empty-content';
 import { domainManagementEdit } from 'my-sites/upgrades/paths';
 
-const DomainOnly = ( { domainName, translate } ) => (
+const DomainOnly = ( { domainName, siteId, translate } ) => (
 	<EmptyContent
 		title={ translate( '%(domainName)s is not set up yet.', {
 			args: { domainName }
 		} ) }
 		action={ translate( 'Create New Site' ) }
-		actionURL={ `/start/site-selected/?siteSlug=${ encodeURIComponent( domainName ) }` }
+		actionURL={ `/start/site-selected/?siteSlug=${ encodeURIComponent( domainName ) }&siteId=${ encodeURIComponent( siteId ) }` }
 		secondaryAction={ translate( 'Advanced' ) }
 		secondaryActionURL={ domainManagementEdit( domainName, domainName ) }
 		illustration={ '/calypso/images/drake/drake-browser.svg' } />

--- a/client/my-sites/upgrades/domain-management/list/index.jsx
+++ b/client/my-sites/upgrades/domain-management/list/index.jsx
@@ -98,7 +98,9 @@ export const List = React.createClass( {
 				<Main>
 					<SidebarNavigation />
 					<DomainOnly
-						domainName={ this.props.selectedSite.domain } />
+						domainName={ this.props.selectedSite.domain }
+						siteId={ this.props.selectedSite.ID }
+					/>
 				</Main>
 			);
 		}

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -224,9 +224,9 @@ if ( config.isEnabled( 'signup/domain-first-flow' ) ) {
 	};
 
 	flows[ 'site-selected' ] = {
-		steps: [ 'themes-site-selected' ],
+		steps: [ 'themes-site-selected', 'plans-site-selected' ],
 		destination: getSiteDestination,
-		providesDependenciesInQuery: [ 'siteSlug' ],
+		providesDependenciesInQuery: [ 'siteSlug', 'siteId' ],
 		description: 'A flow to test updating an existing site with `Signup`',
 		lastModified: '2017-01-19'
 	};

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -13,6 +13,8 @@ var config = require( 'config' ),
 	SurveyStepComponent = require( 'signup/steps/survey' ),
 	ThemeSelectionComponent = require( 'signup/steps/theme-selection' );
 import UserSignupComponent from 'signup/steps/user';
+import PlansStepWithoutFreePlan from 'signup/steps/plans-without-free';
+
 
 module.exports = {
 	'design-type': DesignTypeComponent,
@@ -25,7 +27,7 @@ module.exports = {
 	'get-dot-blog-plans': GetDotBlogPlansStepComponent,
 	'get-dot-blog-themes': ThemeSelectionComponent,
 	plans: PlansStepComponent,
-	'plans-site-selected': PlansStepComponent,
+	'plans-site-selected': PlansStepWithoutFreePlan,
 	site: SiteComponent,
 	'site-or-domain': SiteOrDomainComponent,
 	'site-title': SiteTitleComponent,

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -25,6 +25,7 @@ module.exports = {
 	'get-dot-blog-plans': GetDotBlogPlansStepComponent,
 	'get-dot-blog-themes': ThemeSelectionComponent,
 	plans: PlansStepComponent,
+	'plans-site-selected': PlansStepComponent,
 	site: SiteComponent,
 	'site-or-domain': SiteOrDomainComponent,
 	'site-title': SiteTitleComponent,

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -34,6 +34,13 @@ module.exports = {
 		apiRequestFunction: stepActions.setThemeOnSite
 	},
 
+	'plans-site-selected': {
+		stepName: 'plans-site-selected',
+		apiRequestFunction: stepActions.addPlanToCart,
+		dependencies: [ 'siteSlug', 'siteId' ],
+		providesDependencies: [ 'cartItem' ]
+	},
+
 	'design-type': {
 		stepName: 'design-type',
 		providesDependencies: [ 'designType' ]

--- a/client/signup/steps/plans-without-free/index.jsx
+++ b/client/signup/steps/plans-without-free/index.jsx
@@ -1,0 +1,11 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Plans from 'signup/steps/plans';
+
+export default ( props ) => <Plans { ...props } hideFreePlan={ true } />;

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -46,16 +46,24 @@ class PlansStep extends Component {
 			} );
 		}
 
-		SignupActions.submitSignupStep( {
+		const step = {
 			processingMessage: isEmpty( cartItem )
 				? translate( 'Free plan selected' )
 				: translate( 'Adding your plan' ),
 			stepName,
 			stepSectionName,
 			cartItem,
-			privacyItem,
 			...additionalStepData
-		}, [], { cartItem, privacyItem } );
+		};
+
+		const providedDependencies = { cartItem };
+
+		if ( privacyItem ) {
+			step.privacyItem = privacyItem;
+			providedDependencies.privacyItem = privacyItem;
+		}
+
+		SignupActions.submitSignupStep( step, [], providedDependencies );
 
 		goToNextStep();
 	}

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -21,6 +21,7 @@ class PlansStep extends Component {
 		super( props );
 
 		this.onSelectPlan = this.onSelectPlan.bind( this );
+		this.plansFeaturesSelection = this.plansFeaturesSelection.bind( this );
 	}
 
 	onSelectPlan( cartItem ) {
@@ -115,10 +116,8 @@ class PlansStep extends Component {
 			'is-wide-layout': true
 		} );
 
-		const renderPlansFeatures = () => ( this.plansFeaturesSelection() );
-
 		return <div className={ classes }>
-			{ renderPlansFeatures() }
+			{ this.plansFeaturesSelection() }
 		</div>;
 	}
 }


### PR DESCRIPTION
This PR aims to allow users to upgrade their "domain only site" to a regular site with plan.
This PR also fixes a few bugs related to previous "featuregate" work ( the first 2 commits ).

#### Testing instructions
  
Run `git checkout add/upgrade-domain-only` and start your server, or open a [live branch](https://calypso.live/?branch=add/upgrade-domain-only)

Flow:
0. Click "Create a new site" on a "domain only site" ( you might want to create one of those first ).
![screen shot 2017-02-07 at 14 30 17](https://cloud.githubusercontent.com/assets/326402/22691212/05849230-ed42-11e6-9429-95141b119827.png)


1. Choose a theme
![screen shot 2017-02-07 at 14 28 01](https://cloud.githubusercontent.com/assets/326402/22691135/af290218-ed41-11e6-8f63-098ddd53b92d.png)

2. Choose a plan ( no free plan )
![screen shot 2017-02-07 at 14 25 26](https://cloud.githubusercontent.com/assets/326402/22691103/7b91cade-ed41-11e6-90a3-9d1ffda06f7b.png)

3. Checkout ( with discounted price due to existing domain )
![screen shot 2017-02-07 at 14 01 11](https://cloud.githubusercontent.com/assets/326402/22691105/7f9db4d0-ed41-11e6-9b82-e7e61f6c35fa.png)

4. Thank you screen AND Site has a plan + no `is_domain_only` option, that requires the server side patch ( D4297 ).
![screen shot 2017-02-07 at 16 48 03](https://cloud.githubusercontent.com/assets/326402/22696027/6268dda4-ed55-11e6-98f8-683b296c12d2.png)


#### Reviews
  
- [x] Code
- [x] Product