### PR TITLE
Site Settings: Auto-enable custom content types module, remove its toggle

### DIFF
--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -51,12 +51,16 @@ class CustomContentTypes extends Component {
 	}
 
 	renderToggle( name, label ) {
-		const { fields, handleToggle } = this.props;
+		const {
+			activatingCustomContentTypesModule,
+			fields,
+			handleToggle
+		} = this.props;
 		return (
 			<FormToggle
 				className="custom-content-types__module-settings-toggle is-compact"
 				checked={ !! fields[ name ] }
-				disabled={ this.isFormPending() }
+				disabled={ this.isFormPending() || activatingCustomContentTypesModule }
 				onChange={ handleToggle( name ) }
 			>
 				{ label }

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -11,15 +11,36 @@ import { connect } from 'react-redux';
 import SectionHeader from 'components/section-header';
 import Card from 'components/card';
 import Button from 'components/button';
-import JetpackModuleToggle from '../jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormToggle from 'components/forms/form-toggle';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackModuleActive } from 'state/selectors';
-import InfoPopover from 'components/info-popover';
-import ExternalLink from 'components/external-link';
+import { isJetpackModuleActive, isActivatingJetpackModule } from 'state/selectors';
+import { activateModule } from 'state/jetpack/modules/actions';
 
 class CustomContentTypes extends Component {
+	componentDidUpdate() {
+		const {
+			activatingCustomContentTypesModule,
+			customContentTypesModuleActive,
+			fields,
+			siteId
+		} = this.props;
+
+		if ( customContentTypesModuleActive !== false ) {
+			return;
+		}
+
+		if ( ! fields.jetpack_portfolio && ! fields.jetpack_testimonial ) {
+			return;
+		}
+
+		if ( activatingCustomContentTypesModule ) {
+			return;
+		}
+
+		this.props.activateModule( siteId, 'custom-content-types', true );
+	}
+
 	isFormPending() {
 		const {
 			isRequestingSettings,
@@ -29,13 +50,13 @@ class CustomContentTypes extends Component {
 		return isRequestingSettings || isSavingSettings;
 	}
 
-	renderToggle( name, isDisabled, label ) {
+	renderToggle( name, label ) {
 		const { fields, handleToggle } = this.props;
 		return (
 			<FormToggle
 				className="custom-content-types__module-settings-toggle is-compact"
 				checked={ !! fields[ name ] }
-				disabled={ this.isFormPending() || isDisabled }
+				disabled={ this.isFormPending() }
 				onChange={ handleToggle( name ) }
 			>
 				{ label }
@@ -68,39 +89,10 @@ class CustomContentTypes extends Component {
 		);
 	}
 
-	renderModuleToggle() {
-		const {
-			siteId,
-			translate
-		} = this.props;
-		const formPending = this.isFormPending();
-
-		return (
-			<div>
-				<div className="custom-content-types__info-link-container">
-					<InfoPopover position={ 'left' }>
-						<ExternalLink href={ 'https://jetpack.com/support/custom-content-types' } target="_blank">
-							{ translate( 'Learn more about Custom Content Types' ) }
-						</ExternalLink>
-					</InfoPopover>
-				</div>
-
-				<JetpackModuleToggle
-					siteId={ siteId }
-					moduleSlug="custom-content-types"
-					label={ translate( 'Display different types of content on your site with custom content types.' ) }
-					disabled={ formPending }
-					/>
-			</div>
-		);
-	}
-
 	renderContentTypeSettings( fieldName, fieldLabel, fieldDescription ) {
-		const { customContentTypesModuleActive } = this.props;
-
 		return (
 			<div className="custom-content-types__module-settings is-indented">
-				{ this.renderToggle( fieldName, ! customContentTypesModuleActive, fieldLabel ) }
+				{ this.renderToggle( fieldName, fieldLabel ) }
 				<p className="form-setting-explanation">
 					{ fieldDescription }
 				</p>
@@ -173,7 +165,6 @@ class CustomContentTypes extends Component {
 
 				<Card className="custom-content-types__card site-settings">
 					<FormFieldset>
-						{ this.renderModuleToggle() }
 						{ this.renderTestimonialSettings() }
 						{ this.renderPortfolioSettings() }
 					</FormFieldset>
@@ -205,7 +196,11 @@ export default connect(
 		return {
 			siteId,
 			site,
-			customContentTypesModuleActive: !! isJetpackModuleActive( state, siteId, 'custom-content-types' ),
+			customContentTypesModuleActive: isJetpackModuleActive( state, siteId, 'custom-content-types' ),
+			activatingCustomContentTypesModule: isActivatingJetpackModule( state, siteId, 'custom-content-types' ),
 		};
+	},
+	{
+		activateModule
 	}
 )( localize( CustomContentTypes ) );

--- a/client/my-sites/site-settings/custom-content-types/style.scss
+++ b/client/my-sites/site-settings/custom-content-types/style.scss
@@ -1,11 +1,7 @@
 .custom-content-types__module-settings.is-indented {
-	margin: 16px 32px;
+	margin-bottom: 24px;
 
 	&:last-child {
 		margin-bottom: 0;
 	}
-}
-
-.custom-content-types__info-link-container {
-	float: right;
 }

--- a/client/state/jetpack/modules/actions.js
+++ b/client/state/jetpack/modules/actions.js
@@ -20,12 +20,13 @@ import {
 } from 'state/action-types';
 import wp from 'lib/wp';
 
-export const activateModule = ( siteId, moduleSlug ) => {
+export const activateModule = ( siteId, moduleSlug, silent = false ) => {
 	return ( dispatch ) => {
 		dispatch( {
 			type: JETPACK_MODULE_ACTIVATE,
 			siteId,
-			moduleSlug
+			moduleSlug,
+			silent
 		} );
 
 		return wp.undocumented().jetpackModuleActivate( siteId, moduleSlug )
@@ -33,25 +34,28 @@ export const activateModule = ( siteId, moduleSlug ) => {
 				dispatch( {
 					type: JETPACK_MODULE_ACTIVATE_SUCCESS,
 					siteId,
-					moduleSlug
+					moduleSlug,
+					silent
 				} );
 			} ).catch( error => {
 				dispatch( {
 					type: JETPACK_MODULE_ACTIVATE_FAILURE,
 					siteId,
 					moduleSlug,
+					silent,
 					error: error.message
 				} );
 			} );
 	};
 };
 
-export const deactivateModule = ( siteId, moduleSlug ) => {
+export const deactivateModule = ( siteId, moduleSlug, silent = false ) => {
 	return ( dispatch ) => {
 		dispatch( {
 			type: JETPACK_MODULE_DEACTIVATE,
 			siteId,
-			moduleSlug
+			moduleSlug,
+			silent
 		} );
 
 		return wp.undocumented().jetpackModuleDeactivate( siteId, moduleSlug )
@@ -59,13 +63,15 @@ export const deactivateModule = ( siteId, moduleSlug ) => {
 				dispatch( {
 					type: JETPACK_MODULE_DEACTIVATE_SUCCESS,
 					siteId,
-					moduleSlug
+					moduleSlug,
+					silent
 				} );
 			} ).catch( error => {
 				dispatch( {
 					type: JETPACK_MODULE_DEACTIVATE_FAILURE,
 					siteId,
 					moduleSlug,
+					silent,
 					error: error.message
 				} );
 			} );

--- a/client/state/jetpack/modules/test/actions.js
+++ b/client/state/jetpack/modules/test/actions.js
@@ -40,14 +40,16 @@ describe( 'actions', () => {
 
 	describe( '#activateJetpackModule', () => {
 		const siteId = 123456;
+		const silent = true;
 
 		it( 'should dispatch JETPACK_MODULE_ACTIVATE when trying to activate a module', () => {
-			activateModule( siteId, 'module-a' )( spy );
+			activateModule( siteId, 'module-a', silent )( spy );
 
 			expect( spy ).to.have.been.calledWith( {
 				type: JETPACK_MODULE_ACTIVATE,
 				siteId,
-				moduleSlug: 'module-a'
+				moduleSlug: 'module-a',
+				silent
 			} );
 		} );
 
@@ -67,12 +69,13 @@ describe( 'actions', () => {
 			} );
 
 			it( 'should dispatch JETPACK_MODULE_ACTIVATE_SUCCESS when API activates a module', () => {
-				const result = activateModule( siteId, 'module-a' )( spy );
+				const result = activateModule( siteId, 'module-a', silent )( spy );
 				return result.then( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: JETPACK_MODULE_ACTIVATE_SUCCESS,
 						siteId,
-						moduleSlug: 'module-a'
+						moduleSlug: 'module-a',
+						silent
 					} );
 				} );
 			} );
@@ -92,12 +95,13 @@ describe( 'actions', () => {
 			} );
 
 			it( 'should dispatch JETPACK_MODULE_ACTIVATE_FAILURE when activating a module fails', () => {
-				const result = activateModule( siteId, 'module-a' )( spy );
+				const result = activateModule( siteId, 'module-a', silent )( spy );
 				return result.then( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: JETPACK_MODULE_ACTIVATE_FAILURE,
 						siteId,
 						moduleSlug: 'module-a',
+						silent,
 						error: 'The Jetpack Module is already activated.'
 					} );
 				} );
@@ -107,14 +111,16 @@ describe( 'actions', () => {
 
 	describe( '#deactivateJetpackModule', () => {
 		const siteId = 123456;
+		const silent = true;
 
 		it( 'should dispatch JETPACK_MODULE_DEACTIVATE when trying to deactivate a module', () => {
-			deactivateModule( siteId, 'module-b' )( spy );
+			deactivateModule( siteId, 'module-b', silent )( spy );
 
 			expect( spy ).to.have.been.calledWith( {
 				type: JETPACK_MODULE_DEACTIVATE,
 				siteId,
-				moduleSlug: 'module-b'
+				moduleSlug: 'module-b',
+				silent
 			} );
 		} );
 
@@ -134,12 +140,13 @@ describe( 'actions', () => {
 			} );
 
 			it( 'should dispatch JETPACK_MODULE_DEACTIVATE_SUCCESS when API deactivates a module', () => {
-				const result = deactivateModule( siteId, 'module-b' )( spy );
+				const result = deactivateModule( siteId, 'module-b', silent )( spy );
 				return result.then( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: JETPACK_MODULE_DEACTIVATE_SUCCESS,
 						siteId,
-						moduleSlug: 'module-b'
+						moduleSlug: 'module-b',
+						silent
 					} );
 				} );
 			} );
@@ -159,12 +166,13 @@ describe( 'actions', () => {
 			} );
 
 			it( 'should dispatch JETPACK_MODULE_DEACTIVATE_FAILURE when deactivating a module fails', () => {
-				const result = deactivateModule( siteId, 'module-b' )( spy );
+				const result = deactivateModule( siteId, 'module-b', silent )( spy );
 				return result.then( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: JETPACK_MODULE_DEACTIVATE_FAILURE,
 						siteId,
 						moduleSlug: 'module-b',
+						silent,
 						error: 'The Jetpack Module is already deactivated.'
 					} );
 				} );

--- a/client/state/notices/jetpack-modules/index.js
+++ b/client/state/notices/jetpack-modules/index.js
@@ -15,7 +15,11 @@ import {
 import { MODULE_NOTICES } from './constants';
 import { successNotice, errorNotice } from 'state/notices/actions';
 
-export const onJetpackModuleActivationActionMessage = ( dispatch, { type, moduleSlug } ) => {
+export const onJetpackModuleActivationActionMessage = ( dispatch, { type, moduleSlug, silent } ) => {
+	if ( silent ) {
+		return;
+	}
+
 	const noticeSettings = { duration: 10000 };
 	let message = MODULE_NOTICES[ moduleSlug ] && MODULE_NOTICES[ moduleSlug ][ type ];
 	let messageType;


### PR DESCRIPTION
### Purpose & rationale

This PR removes the main module (de)activation toggle from the Custom Content Types module and changes the component to automatically enable the module if there's at least one post type enabled. Rationale for this change: the module itself provides no additional functionality when all of the post types are disabled, so its main toggle can provide only confusion to the users.

### Development notes
The PR introduces a mechanism for silently toggling Jetpack modules (because we don't want to display a notice to the user that we're activating the Custom Content Types module), and uses that mechanism to disable the notice when auto-activating the module. (De)activation tests have been updated to reflect these changes.

### Preview

Removing the main module toggle makes the card much simpler and cleaner compared to the previous version.

**Before**
![](https://cldup.com/gsNEC1MjkA.png)

**After**
![](https://cldup.com/yor0mT7Egh.png)

### Testing
* Checkout this branch.
* Select one of your Jetpack sites - let's call it `$site`.
* Test with one or more post types enabled and module disabled:
  * Enable one or more post types from the Custom Content Types module.
  * Disable the Custom Content Types module from your wp-admin.
  * Go to `/settings/writing/$site`.
  * Verify the module gets auto-enabled.
  * Verify the module settings are loaded correctly.
  * Play with the module settings and verify they're saved correctly.
* Test with post types disabled and module disabled:
  * Disable all post types from the Custom Content Types module.
  * Disable the Custom Content Types module from your wp-admin.
  * Go to `/settings/writing/$site`.
  * Verify the module does not get auto-enabled.
  * Verify the module settings are off, but can be toggled.
  * Play with the module settings and verify they're saved correctly.
* Test with module enabled:
  * Enable one or more post types from the Custom Content Types module.
  * Enable the Custom Content Types module from your wp-admin.
  * Go to `/settings/writing/$site`.
  * Verify the state of all post types is retrieved and saved correctly.
  * Verify the module is not auto-enabled.

### Review
/cc 
@rickybanister @MichaelArestad for design review
@oskosk @ryelle @roccotripaldi @johnHackworth for code review