### PR TITLE
Framework: media modal janitorial

### DIFF
--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -7,6 +7,7 @@ import {
 	includes,
 	noop,
 	map,
+	identity
 } from 'lodash';
 
 /**
@@ -17,7 +18,7 @@ import SectionNavTabs from 'components/section-nav/tabs';
 import Search from 'components/search';
 import FilterItem from './filter-item';
 
-class MediaLibraryFilterBar extends Component {
+export class MediaLibraryFilterBar extends Component {
 	static propTypes = {
 		basePath: React.PropTypes.string,
 		enabledFilters: React.PropTypes.arrayOf( React.PropTypes.string ),
@@ -27,13 +28,15 @@ class MediaLibraryFilterBar extends Component {
 		site: React.PropTypes.object,
 		onFilterChange: React.PropTypes.func,
 		onSearch: React.PropTypes.func,
+		translate: React.PropTypes.func
 	};
 
 	static defaultProps ={
 		filter: '',
 		basePath: '/media',
 		onFilterChange: noop,
-		onSearch: noop
+		onSearch: noop,
+		translate: identity
 	};
 
 	getSearchPlaceholderText() {

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -1,110 +1,100 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	includes = require( 'lodash/includes' ),
-	noop = require( 'lodash/noop' );
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import {
+	includes,
+	noop,
+	map,
+} from 'lodash';
 
 /**
  * Internal dependencies
  */
-var SectionNav = require( 'components/section-nav' ),
-	SectionNavTabs = require( 'components/section-nav/tabs' ),
-	SectionNavTabItem = require( 'components/section-nav/item' ),
-	Search = require( 'components/search' );
+import SectionNav from 'components/section-nav';
+import SectionNavTabs from 'components/section-nav/tabs';
+import Search from 'components/search';
+import FilterItem from './filter-item';
 
-module.exports = React.createClass( {
-	displayName: 'MediaLibraryFilterBar',
-
-	propTypes: {
-		site: React.PropTypes.object,
+class MediaLibraryFilterBar extends Component {
+	static propTypes = {
 		basePath: React.PropTypes.string,
+		enabledFilters: React.PropTypes.arrayOf( React.PropTypes.string ),
 		filter: React.PropTypes.string,
 		filterRequiresUpgrade: React.PropTypes.bool,
-		enabledFilters: React.PropTypes.arrayOf( React.PropTypes.string ),
 		search: React.PropTypes.string,
+		site: React.PropTypes.object,
 		onFilterChange: React.PropTypes.func,
-		onSearch: React.PropTypes.func
-	},
+		onSearch: React.PropTypes.func,
+	};
 
-	getDefaultProps: function() {
-		return {
-			filter: '',
-			basePath: '/media',
-			onFilterChange: noop,
-			onSearch: noop
-		};
-	},
+	static defaultProps ={
+		filter: '',
+		basePath: '/media',
+		onFilterChange: noop,
+		onSearch: noop
+	};
 
-	getSearchPlaceholderText: function() {
-		var placeholderText;
-
-		switch ( this.props.filter ) {
+	getSearchPlaceholderText() {
+		const { filter, translate } = this.props;
+		switch ( filter ) {
 			case 'images':
-				placeholderText = this.translate( 'Search images…', { textOnly: true } );
-				break;
+				return translate( 'Search images…' );
 			case 'audio':
-				placeholderText = this.translate( 'Search audio files…', { textOnly: true } );
-				break;
+				return translate( 'Search audio files…' );
 			case 'videos':
-				placeholderText = this.translate( 'Search videos…', { textOnly: true } );
-				break;
+				return translate( 'Search videos…' );
 			case 'documents':
-				placeholderText = this.translate( 'Search documents…', { textOnly: true } );
-				break;
+				return translate( 'Search documents…' );
 			default:
-				placeholderText = this.translate( 'Search all media…', { textOnly: true } );
-				break;
+				return translate( 'Search all media…' );
 		}
+	}
 
-		return placeholderText;
-	},
-
-	getFilterLabel: function( filter ) {
-		var label;
+	getFilterLabel( filter ) {
+		const { translate } = this.props;
 
 		switch ( filter ) {
 			case 'images':
-				label = this.translate( 'Images', { comment: 'Filter label for media list', textOnly: true } );
-				break;
+				return translate( 'Images', { comment: 'Filter label for media list' } );
 			case 'audio':
-				label = this.translate( 'Audio', { comment: 'Filter label for media list', textOnly: true } );
-				break;
+				return translate( 'Audio', { comment: 'Filter label for media list' } );
 			case 'videos':
-				label = this.translate( 'Videos', { comment: 'Filter label for media list', textOnly: true } );
-				break;
+				return translate( 'Videos', { comment: 'Filter label for media list' } );
 			case 'documents':
-				label = this.translate( 'Documents', { comment: 'Filter label for media list', textOnly: true } );
-				break;
+				return translate( 'Documents', { comment: 'Filter label for media list' } );
 			default:
-				label = this.translate( 'All', { comment: 'Filter label for media list', textOnly: true } );
-				break;
+				return translate( 'All', { comment: 'Filter label for media list' } );
 		}
+	}
 
-		return label;
-	},
+	isFilterDisabled( filter ) {
+		const { enabledFilters } = this.props;
+		return enabledFilters && ( ! filter.length || ! includes( enabledFilters, filter ) );
+	}
 
-	isFilterDisabled: function( filter ) {
-		return this.props.enabledFilters && ( ! filter.length || ! includes( this.props.enabledFilters, filter ) );
-	},
+	changeFilter = filter => {
+		this.props.onFilterChange( filter );
+	};
 
-	renderTabItems: function() {
+	renderTabItems() {
 		const tabs = [ '', 'images', 'documents', 'videos', 'audio' ];
 
-		return tabs.map( function( filter ) {
-			return (
-				<SectionNavTabItem
-					key={ 'filter-tab-' + filter }
-					selected={ this.props.filter === filter }
-					onClick={ this.props.onFilterChange.bind( null, filter ) }
-					disabled={ this.isFilterDisabled( filter ) }>
-					{ this.getFilterLabel( filter ) }
-				</SectionNavTabItem>
-			);
-		}, this );
-	},
+		return map( tabs, filter =>
+			<FilterItem
+				key={ 'filter-tab-' + filter }
+				value={ filter }
+				selected={ this.props.filter === filter }
+				onChange={ this.changeFilter }
+				disabled={ this.isFilterDisabled( filter ) }
+			>
+				{ this.getFilterLabel( filter ) }
+			</FilterItem>
+		);
+	}
 
-	render: function() {
+	render() {
 		return (
 			<SectionNav selectedText={ this.getFilterLabel( this.props.filter ) } hasSearch={ true }>
 				<SectionNavTabs>
@@ -123,4 +113,6 @@ module.exports = React.createClass( {
 			</SectionNav>
 		);
 	}
-} );
+}
+
+export default localize( MediaLibraryFilterBar );

--- a/client/my-sites/media-library/filter-item.jsx
+++ b/client/my-sites/media-library/filter-item.jsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import SectionNavTabItem from 'components/section-nav/item';
+
+class FilterItem extends Component {
+	activate = () => {
+		this.props.onChange( this.props.value );
+	}
+
+	render() {
+		const {
+			isDisabled,
+			selected,
+		} = this.props;
+
+		return (
+			<SectionNavTabItem
+				selected={ selected }
+				onClick={ this.activate }
+				disabled={ isDisabled }
+			>
+				{ this.props.children }
+			</SectionNavTabItem>
+		);
+	}
+}
+
+export default FilterItem;

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -14,7 +14,7 @@ var Content = require( './content' ),
 	MediaLibrarySelectedStore = require( 'lib/media/library-selected-store' ),
 	MediaUtils = require( 'lib/media/utils' ),
 	filterToMimePrefix = require( './filter-to-mime-prefix' ),
-	FilterBar = require( './filter-bar' ),
+	FilterBar = require( './filter-bar' ).default,
 	MediaValidationData = require( 'components/data/media-validation-data' ),
 	urlSearch = require( 'lib/mixins/url-search' );
 import QueryPreferences from 'components/data/query-preferences';

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -1,23 +1,36 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:post-editor:media' );
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
 import { connect } from 'react-redux';
-import { noop, head, some, findIndex, partial, values, map } from 'lodash';
+import {
+	findIndex,
+	head,
+	noop,
+	map,
+	partial,
+	some,
+	values,
+} from 'lodash';
 
 /**
  * Internal dependencies
  */
-var MediaLibrary = require( 'my-sites/media-library' ),
-	analytics = require( 'lib/analytics' ),
-	PostStats = require( 'lib/posts/stats' ),
-	MediaModalSecondaryActions = require( './secondary-actions' ),
-	MediaModalGallery = require( './gallery' ),
-	MediaActions = require( 'lib/media/actions' ),
-	MediaUtils = require( 'lib/media/utils' ),
-	Dialog = require( 'components/dialog' ),
-	accept = require( 'lib/accept' );
+import MediaLibrary from 'my-sites/media-library';
+import analytics from 'lib/analytics';
+import {
+	recordEvent,
+	recordStat
+} from 'lib/posts/stats';
+import MediaModalSecondaryActions from './secondary-actions';
+import MediaModalGallery from './gallery';
+import MediaActions from 'lib/media/actions';
+import MediaUtils from 'lib/media/utils';
+import Dialog from 'components/dialog';
+import accept from 'lib/accept';
+
 import { getMediaModalView } from 'state/ui/media-modal/selectors';
 import { getSite } from 'state/sites/selectors';
 import { resetMediaModalView } from 'state/ui/media-modal/actions';
@@ -27,8 +40,8 @@ import { deleteMedia } from 'state/media/actions';
 import ImageEditor from 'blocks/image-editor';
 import MediaModalDetail from './detail';
 
-export const EditorMediaModal = React.createClass( {
-	propTypes: {
+class EditorMediaModal extends Component {
+	static propTypes = {
 		visible: React.PropTypes.bool,
 		mediaLibrarySelectedItems: React.PropTypes.arrayOf( React.PropTypes.object ),
 		onClose: React.PropTypes.func,
@@ -41,27 +54,26 @@ export const EditorMediaModal = React.createClass( {
 		view: React.PropTypes.oneOf( values( ModalViews ) ),
 		setView: React.PropTypes.func,
 		resetView: React.PropTypes.func
-	},
+	};
 
-	getInitialState: function() {
-		return this.getDefaultState( this.props );
-	},
+	static defaultProps = {
+		visible: false,
+		mediaLibrarySelectedItems: Object.freeze( [] ),
+		onClose: noop,
+		labels: Object.freeze( {} ),
+		setView: noop,
+		resetView: noop,
+		view: ModalViews.LIST,
+		imageEditorProps: {},
+		deleteMedia: () => {}
+	};
 
-	getDefaultProps: function() {
-		return {
-			visible: false,
-			mediaLibrarySelectedItems: Object.freeze( [] ),
-			onClose: noop,
-			labels: Object.freeze( {} ),
-			setView: noop,
-			resetView: noop,
-			view: ModalViews.LIST,
-			imageEditorProps: {},
-			deleteMedia: () => {}
-		};
-	},
+	constructor( props ) {
+		super( ...props );
+		this.state = this.getDefaultState( props );
+	}
 
-	componentWillReceiveProps: function( nextProps ) {
+	componentWillReceiveProps( nextProps ) {
 		if ( nextProps.site && this.props.visible && ! nextProps.visible ) {
 			MediaActions.setLibrarySelectedItems( nextProps.site.ID, [] );
 		}
@@ -71,39 +83,37 @@ export const EditorMediaModal = React.createClass( {
 		}
 
 		if ( nextProps.visible ) {
-			this.replaceState( this.getDefaultState( nextProps ) );
+			this.setState( this.getDefaultState( nextProps ) );
 		} else {
 			this.props.resetView();
 		}
-	},
+	}
 
-	componentDidMount: function() {
-		debug( '%s component mounted.', this.constructor.name );
-
+	componentDidMount() {
 		this.statsTracking = {};
-	},
+	}
 
 	componentWillUnmount() {
 		this.props.resetView();
 		MediaActions.setLibrarySelectedItems( this.props.site.ID, [] );
-	},
+	}
 
-	getDefaultState: function( props ) {
+	getDefaultState( props ) {
 		return {
 			filter: '',
 			detailSelectedIndex: 0,
 			gallerySettings: props.initialGallerySettings
 		};
-	},
+	}
 
-	isDisabled: function() {
+	isDisabled() {
 		return some( this.props.mediaLibrarySelectedItems, function( item ) {
-			var mimePrefix = MediaUtils.getMimePrefix( item );
+			const mimePrefix = MediaUtils.getMimePrefix( item );
 			return item.transient && ( mimePrefix !== 'image' || ModalViews.GALLERY === this.props.view );
 		}.bind( this ) );
-	},
+	}
 
-	confirmSelection: function() {
+	confirmSelection = () => {
 		const { view, mediaLibrarySelectedItems } = this.props;
 
 		let value;
@@ -116,15 +126,15 @@ export const EditorMediaModal = React.createClass( {
 		}
 
 		this.props.onClose( value );
-	},
+	};
 
-	setDetailSelectedIndex: function( index ) {
+	setDetailSelectedIndex = index => {
 		this.setState( {
 			detailSelectedIndex: index
 		} );
-	},
+	};
 
-	setNextAvailableDetailView: function() {
+	setNextAvailableDetailView() {
 		if ( 1 === this.props.mediaLibrarySelectedItems.length ) {
 			// If this is the only selected item, return user to the list
 			this.props.setView( ModalViews.LIST );
@@ -132,9 +142,9 @@ export const EditorMediaModal = React.createClass( {
 			// If this is the last selected item, decrement to the previous
 			this.setDetailSelectedIndex( Math.max( this.getDetailSelectedIndex() - 1, 0 ) );
 		}
-	},
+	}
 
-	confirmDeleteMedia: function( accepted ) {
+	confirmDeleteMedia = accepted => {
 		const { site, mediaLibrarySelectedItems } = this.props;
 
 		if ( ! site || ! accepted ) {
@@ -150,9 +160,9 @@ export const EditorMediaModal = React.createClass( {
 		MediaActions.delete( site.ID, toDelete );
 		analytics.mc.bumpStat( 'editor_media_actions', 'delete_media' );
 		this.props.deleteMedia( site.ID, map( toDelete, 'ID' ) );
-	},
+	};
 
-	deleteMedia: function() {
+	deleteMedia = () => {
 		let selectedCount;
 
 		if ( ModalViews.DETAIL === this.props.view ) {
@@ -161,35 +171,35 @@ export const EditorMediaModal = React.createClass( {
 			selectedCount = this.props.mediaLibrarySelectedItems.length;
 		}
 
-		const confirmMessage = this.translate(
+		const confirmMessage = this.props.translate(
 			'Are you sure you want to permanently delete this item?',
 			'Are you sure you want to permanently delete these items?',
 			{ count: selectedCount }
 		);
 
 		accept( confirmMessage, this.confirmDeleteMedia );
-	},
+	};
 
-	onAddMedia: function() {
-		PostStats.recordStat( 'media_explorer_upload' );
-		PostStats.recordEvent( 'Upload Media' );
-	},
+	onAddMedia = () => {
+		recordStat( 'media_explorer_upload' );
+		recordEvent( 'Upload Media' );
+	};
 
-	onAddAndEditImage: function() {
+	onAddAndEditImage = () => {
 		MediaActions.setLibrarySelectedItems( this.props.site.ID, [] );
 
 		this.props.setView( ModalViews.IMAGE_EDITOR );
-	},
+	};
 
-	restoreOriginalMedia: function( siteId, item ) {
+	restoreOriginalMedia = ( siteId, item ) => {
 		if ( ! siteId || ! item ) {
 			return;
 		}
 
 		MediaActions.update( siteId, { ID: item.ID, media_url: item.guid }, true );
-	},
+	};
 
-	onImageEditorDone( error, blob, imageEditorProps ) {
+	onImageEditorDone = ( error, blob, imageEditorProps ) => {
 		if ( error ) {
 			this.onImageEditorCancel( imageEditorProps );
 
@@ -219,9 +229,9 @@ export const EditorMediaModal = React.createClass( {
 		resetAllImageEditorState();
 
 		this.props.setView( ModalViews.DETAIL );
-	},
+	};
 
-	onImageEditorCancel: function( imageEditorProps ) {
+	onImageEditorCancel = imageEditorProps => {
 		const { mediaLibrarySelectedItems } = this.props;
 
 		const item = mediaLibrarySelectedItems[ this.getDetailSelectedIndex() ];
@@ -236,7 +246,7 @@ export const EditorMediaModal = React.createClass( {
 		const {	resetAllImageEditorState } = imageEditorProps;
 
 		resetAllImageEditorState();
-	},
+	};
 
 	getDetailSelectedIndex() {
 		const { mediaLibrarySelectedItems } = this.props;
@@ -245,26 +255,24 @@ export const EditorMediaModal = React.createClass( {
 			return 0;
 		}
 		return detailSelectedIndex;
-	},
+	}
 
-	onFilterChange: function( filter ) {
+	onFilterChange = filter => {
 		if ( filter !== this.state.filter ) {
 			analytics.mc.bumpStat( 'editor_media_actions', 'filter_' + ( filter || 'all' ) );
 		}
 
-		this.setState( {
-			filter: filter
-		} );
-	},
+		this.setState( { filter } );
+	};
 
-	onScaleChange: function() {
+	onScaleChange = () => {
 		if ( ! this.statsTracking.scale ) {
 			analytics.mc.bumpStat( 'editor_media_actions', 'scale' );
 			this.statsTracking.scale = true;
 		}
-	},
+	};
 
-	onSearch: function( search ) {
+	onSearch = search => {
 		this.setState( {
 			search: search || undefined
 		} );
@@ -273,13 +281,13 @@ export const EditorMediaModal = React.createClass( {
 			analytics.mc.bumpStat( 'editor_media_actions', 'search' );
 			this.statsTracking.search = true;
 		}
-	},
+	};
 
-	onClose: function() {
+	onClose = () => {
 		this.props.onClose();
-	},
+	};
 
-	editItem: function( item ) {
+	editItem( item ) {
 		const { site, mediaLibrarySelectedItems, single } = this.props;
 		if ( ! site ) {
 			return;
@@ -303,24 +311,22 @@ export const EditorMediaModal = React.createClass( {
 		analytics.ga.recordEvent( 'Media', 'Clicked Contextual Edit Button' );
 
 		this.props.setView( ModalViews.DETAIL );
-	},
+	}
 
-	getFirstEnabledFilter: function() {
+	getFirstEnabledFilter() {
 		if ( this.props.enabledFilters ) {
 			return head( this.props.enabledFilters );
 		}
-	},
+	}
 
-	getModalButtons: function() {
-		var isDisabled = this.isDisabled(),
-			selectedItems = this.props.mediaLibrarySelectedItems,
-			buttons;
-
+	getModalButtons() {
 		if ( ModalViews.IMAGE_EDITOR === this.props.view ) {
 			return;
 		}
 
-		buttons = [
+		const isDisabled = this.isDisabled();
+		const selectedItems = this.props.mediaLibrarySelectedItems;
+		const buttons = [
 			<MediaModalSecondaryActions
 				site={ this.props.site }
 				selectedItems={ selectedItems }
@@ -328,7 +334,7 @@ export const EditorMediaModal = React.createClass( {
 				onDelete={ this.deleteMedia } />,
 			{
 				action: 'cancel',
-				label: this.translate( 'Cancel' )
+				label: this.props.translate( 'Cancel' )
 			}
 		];
 
@@ -336,7 +342,7 @@ export const EditorMediaModal = React.createClass( {
 				! some( selectedItems, ( item ) => MediaUtils.getMimePrefix( item ) !== 'image' ) ) {
 			buttons.push( {
 				action: 'confirm',
-				label: this.translate( 'Continue' ),
+				label: this.props.translate( 'Continue' ),
 				isPrimary: true,
 				disabled: isDisabled || ! this.props.site,
 				onClick: partial( this.props.setView, ModalViews.GALLERY )
@@ -344,7 +350,7 @@ export const EditorMediaModal = React.createClass( {
 		} else {
 			buttons.push( {
 				action: 'confirm',
-				label: this.props.labels.confirm || this.translate( 'Insert' ),
+				label: this.props.labels.confirm || this.props.translate( 'Insert' ),
 				isPrimary: true,
 				disabled: isDisabled || 0 === selectedItems.length,
 				onClick: this.confirmSelection
@@ -352,14 +358,18 @@ export const EditorMediaModal = React.createClass( {
 		}
 
 		return buttons;
-	},
+	}
 
-	shouldClose: function() {
+	shouldClose() {
 		return ( ModalViews.IMAGE_EDITOR !== this.props.view );
-	},
+	}
 
-	renderContent: function() {
-		var content;
+	updateSettings = ( gallerySettings ) => {
+		this.setState( { gallerySettings } );
+	};
+
+	renderContent() {
+		let content;
 
 		switch ( this.props.view ) {
 			case ModalViews.DETAIL:
@@ -379,7 +389,7 @@ export const EditorMediaModal = React.createClass( {
 						site={ this.props.site }
 						items={ this.props.mediaLibrarySelectedItems }
 						settings={ this.state.gallerySettings }
-						onUpdateSettings={ ( gallerySettings ) => this.setState( { gallerySettings } ) } />
+						onUpdateSettings={ this.updateSettings } />
 				);
 				break;
 
@@ -425,9 +435,9 @@ export const EditorMediaModal = React.createClass( {
 		}
 
 		return content;
-	},
+	}
 
-	render: function() {
+	render() {
 		return (
 			<Dialog
 				isVisible={ this.props.visible }
@@ -439,7 +449,7 @@ export const EditorMediaModal = React.createClass( {
 			</Dialog>
 		);
 	}
-} );
+}
 
 export default connect(
 	( state, { site, siteId } ) => ( {
@@ -453,4 +463,4 @@ export default connect(
 		resetView: resetMediaModalView,
 		deleteMedia
 	}
-)( EditorMediaModal );
+)( localize( EditorMediaModal ) );

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -13,6 +13,7 @@ import {
 	partial,
 	some,
 	values,
+	identity
 } from 'lodash';
 
 /**
@@ -40,7 +41,7 @@ import { deleteMedia } from 'state/media/actions';
 import ImageEditor from 'blocks/image-editor';
 import MediaModalDetail from './detail';
 
-class EditorMediaModal extends Component {
+export class EditorMediaModal extends Component {
 	static propTypes = {
 		visible: React.PropTypes.bool,
 		mediaLibrarySelectedItems: React.PropTypes.arrayOf( React.PropTypes.object ),
@@ -63,6 +64,7 @@ class EditorMediaModal extends Component {
 		labels: Object.freeze( {} ),
 		setView: noop,
 		resetView: noop,
+		translate: identity,
 		view: ModalViews.LIST,
 		imageEditorProps: {},
 		deleteMedia: () => {}

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -30,7 +30,9 @@ const EMPTY_COMPONENT = React.createClass( {
 } );
 
 describe( 'EditorMediaModal', function() {
-	let spy, i18n, deleteMedia, accept, EditorMediaModal;
+	let spy, translate, deleteMedia, accept, EditorMediaModal;
+
+	translate = require( 'i18n-calypso' ).translate;
 
 	useMockery();
 	useFakeDom();
@@ -41,8 +43,6 @@ describe( 'EditorMediaModal', function() {
 	} );
 
 	before( function() {
-		i18n = require( 'i18n-calypso' );
-
 		// Mockery
 		mockery.registerMock( 'my-sites/media-library', EMPTY_COMPONENT );
 		mockery.registerMock( './detail', { 'default': EMPTY_COMPONENT } );
@@ -62,7 +62,6 @@ describe( 'EditorMediaModal', function() {
 		} );
 
 		EditorMediaModal = require( '../' ).EditorMediaModal;
-		EditorMediaModal.prototype.translate = i18n.translate;
 	} );
 
 	it( 'should prompt to delete a single item from the list view', function( done ) {
@@ -70,7 +69,7 @@ describe( 'EditorMediaModal', function() {
 			tree;
 
 		tree = shallow(
-			<EditorMediaModal site={ DUMMY_SITE } mediaLibrarySelectedItems={ media } />
+			<EditorMediaModal site={ DUMMY_SITE } mediaLibrarySelectedItems={ media } translate={ translate } />
 		).instance();
 		tree.deleteMedia();
 
@@ -83,7 +82,7 @@ describe( 'EditorMediaModal', function() {
 
 	it( 'should prompt to delete multiple items from the list view', function( done ) {
 		var tree = shallow(
-			<EditorMediaModal site={ DUMMY_SITE } mediaLibrarySelectedItems={ DUMMY_MEDIA } />
+			<EditorMediaModal site={ DUMMY_SITE } mediaLibrarySelectedItems={ DUMMY_MEDIA } translate={ translate } />
 		).instance();
 		tree.deleteMedia();
 


### PR DESCRIPTION
It's a PR with janitorial purpose.

- re-write extending from Component class
- use { localize } helper
- replace replaceState by setState
- fix eslint warnings
- etc.

The most significant change among all of these is adding a tidy component named `<FilterItem />` used for avoiding to bind a function to the component property.


### Testing

Play add/remove media files from different places such as site icon, post editor, featured image, etc. Just in case I leave some links

* Since adding a new image or set the featured image: `http://calypso.localhost:3000/post/<your-testing-blog>`
<img src="https://cloud.githubusercontent.com/assets/77539/22691180/f15b0e6c-ed17-11e6-8534-7629ee65bdad.png" width="120px" />

<img src="https://cloud.githubusercontent.com/assets/77539/22691185/f6fa2e66-ed17-11e6-96f9-019fb4d08acd.png" width="200px" />

* Site icon: `http://calypso.localhost:3000/settings/general/<your-testing-blog>`

<img src="https://cloud.githubusercontent.com/assets/77539/22691174/ea781d10-ed17-11e6-8b52-abc8f1590e9a.png" width="200px" />

Everything should be 🆗 
