### PR TITLE
Editor: add Insert Content to the HTML toolbar

### DIFF
--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -438,56 +438,58 @@ export class EditorHtmlToolbar extends Component {
 		return (
 			<div className={ classes }>
 				<div className="editor-html-toolbar__wrapper">
-					<div
-						className="editor-html-toolbar__buttons"
-						ref={ this.bindButtonsRef }
-					>
-						<div className="editor-html-toolbar__button-insert-content" ref={ this.bindInsertContentButtonsRef }>
-							<Button
-								borderless
-								className="editor-html-toolbar__button-insert-media"
-								compact
+					<div className="editor-html-toolbar__wrapper-buttons">
+						<div
+							className="editor-html-toolbar__buttons"
+							ref={ this.bindButtonsRef }
+						>
+							<div className="editor-html-toolbar__button-insert-content" ref={ this.bindInsertContentButtonsRef }>
+								<Button
+									borderless
+									className="editor-html-toolbar__button-insert-media"
+									compact
+									onClick={ this.openMediaModal }
+								>
+									<Gridicon icon="add-outline" />
+								</Button>
+								<Button
+									borderless
+									className="editor-html-toolbar__button-insert-content-dropdown"
+									compact
+									onClick={ this.toggleInsertContentMenu }
+								>
+									<Gridicon icon={ this.state.showInsertContentMenu ? 'chevron-up' : 'chevron-down' } />
+								</Button>
+							</div>
+							{ map( buttons, ( { disabled, label, onClick }, tag ) =>
+								<Button
+									borderless
+									className={ `editor-html-toolbar__button-${ tag } ${ this.isTagOpen( tag ) ? 'is-tag-open' : '' }` }
+									compact
+									disabled={ disabled }
+									key={ tag }
+									onClick={ onClick }
+								>
+									{ label || tag }
+								</Button>
+							) }
+						</div>
+
+						<div className={ insertContentClasses }>
+							<div
+								className="editor-html-toolbar__insert-content-dropdown-item"
 								onClick={ this.openMediaModal }
 							>
-								<Gridicon icon="add-outline" />
-							</Button>
-							<Button
-								borderless
-								className="editor-html-toolbar__button-insert-content-dropdown"
-								compact
-								onClick={ this.toggleInsertContentMenu }
+								<Gridicon icon="add-image" />
+								<span>{ translate( 'Add Media' ) }</span>
+							</div>
+							<div
+								className="editor-html-toolbar__insert-content-dropdown-item"
+								onClick={ this.openContactFormDialog }
 							>
-								<Gridicon icon={ this.state.showInsertContentMenu ? 'chevron-up' : 'chevron-down' } />
-							</Button>
-						</div>
-						{ map( buttons, ( { disabled, label, onClick }, tag ) =>
-							<Button
-								borderless
-								className={ `editor-html-toolbar__button-${ tag } ${ this.isTagOpen( tag ) ? 'is-tag-open' : '' }` }
-								compact
-								disabled={ disabled }
-								key={ tag }
-								onClick={ onClick }
-							>
-								{ label || tag }
-							</Button>
-						) }
-					</div>
-
-					<div className={ insertContentClasses }>
-						<div
-							className="editor-html-toolbar__insert-content-dropdown-item"
-							onClick={ this.openMediaModal }
-						>
-							<Gridicon icon="add-image" />
-							<span>{ translate( 'Add Media' ) }</span>
-						</div>
-						<div
-							className="editor-html-toolbar__insert-content-dropdown-item"
-							onClick={ this.openContactFormDialog }
-						>
-							<Gridicon icon="mention" />
-							<span>{ translate( 'Add Contact Form' ) }</span>
+								<Gridicon icon="mention" />
+								<span>{ translate( 'Add Contact Form' ) }</span>
+							</div>
 						</div>
 					</div>
 				</div>

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -17,6 +17,7 @@ import { isWithinBreakpoint } from 'lib/viewport';
 import AddImageDialog from './add-image-dialog';
 import AddLinkDialog from './add-link-dialog';
 import Button from 'components/button';
+import EditorMediaModal from 'post-editor/editor-media-modal';
 
 /**
  * Module constants
@@ -40,6 +41,7 @@ export class EditorHtmlToolbar extends Component {
 		selectedText: '',
 		showImageDialog: false,
 		showLinkDialog: false,
+		showMediaModal: false,
 	};
 
 	componentDidMount() {
@@ -277,6 +279,10 @@ export class EditorHtmlToolbar extends Component {
 		this.setState( { openTags: [] } );
 	}
 
+	onInsertMedia = media => {
+		this.insertCustomContent( media );
+	}
+
 	openImageDialog = () => {
 		this.setState( { showImageDialog: true } );
 	}
@@ -297,6 +303,14 @@ export class EditorHtmlToolbar extends Component {
 		this.setState( { showLinkDialog: false } );
 	}
 
+	openMediaModal = () => {
+		this.setState( { showMediaModal: true } );
+	}
+
+	closeMediaModal = () => {
+		this.setState( { showMediaModal: false } );
+	}
+
 	isTagOpen = tag => -1 !== this.state.openTags.indexOf( tag );
 
 	render() {
@@ -308,6 +322,10 @@ export class EditorHtmlToolbar extends Component {
 		} );
 
 		const buttons = {
+			media: {
+				label: '+',
+				onClick: this.openMediaModal,
+			},
 			strong: {
 				label: 'b',
 				onClick: this.onClickBold,
@@ -386,6 +404,11 @@ export class EditorHtmlToolbar extends Component {
 					onInsert={ this.onClickLink }
 					selectedText={ this.state.selectedText }
 					shouldDisplay={ this.state.showLinkDialog }
+				/>
+				<EditorMediaModal
+					onClose={ this.closeMediaModal }
+					onInsertMedia={ this.onInsertMedia }
+					visible={ this.state.showMediaModal }
 				/>
 			</div>
 		);

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -84,6 +84,86 @@
 	}
 }
 
+.editor-html-toolbar__button-insert-content {
+	display: inline-block;
+	height: 38px;
+
+	.editor-html-toolbar__button-insert-media.button {
+		border-right-color: transparent;
+		height: 38px;
+		margin: 0;
+		padding: 6px 7px 8px 7px;
+		.gridicon {
+			height: 24px;
+			width: 24px;
+		}
+	}
+
+	.editor-html-toolbar__button-insert-content-dropdown.button {
+		border-right: 1px solid lighten( $gray, 30% );
+		height: 38px;
+		margin: 0;
+		min-width: auto;
+		padding: 10px 5px 14px 5px;
+		.gridicon {
+			color: $gray;
+			height: 14px;
+			width: 14px;
+		}
+	}
+
+	&:hover {
+		.editor-html-toolbar__button-insert-media.button {
+			border-right-color: lighten( $gray, 30% );
+		}
+		.button .gridicon {
+			color: lighten( $gray, 10% );
+		}
+		.button:hover .gridicon {
+			color: $gray-dark;
+		}
+	}
+}
+
+.editor-html-toolbar__insert-content-dropdown {
+	background-color: $white;
+	border: 1px solid lighten( $gray, 20% );
+	border-radius: 0 0 4px 4px;
+	display: none;
+	left: 0;
+	position: absolute;
+	top: 38px;
+	width: 185px;
+
+	&.is-visible {
+		display: block;
+	}
+
+	.editor-html-toolbar__insert-content-dropdown-item {
+		cursor: pointer;
+		height: 24px;
+		padding: 9px 16px;
+
+		.gridicon {
+			color: $gray;
+		}
+		span {
+			color: darken( $gray, 30% );
+			display: inline-block;
+			font-size: 14px;
+			margin-left: 8px;
+			margin-top: 2px;
+			vertical-align: top;
+		}
+
+		&:hover {
+			.gridicon, span {
+				color: $blue-medium;
+			}
+		}
+	}
+}
+
 .editor-html-toolbar__button-strong {
 	font-weight: bold;
 }

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -35,9 +35,14 @@
 		}
 	}
 
-	.editor-html-toolbar__buttons {
+	.editor-html-toolbar__wrapper-buttons {
 		margin: 0 auto;
 		max-width: 700px;
+		position: relative;
+		width: 100%;
+	}
+
+	.editor-html-toolbar__buttons {
 		overflow-x: auto;
 		white-space: nowrap;
 		width: 100%;


### PR DESCRIPTION
Add the Insert Content dropdown and modals to the HTML toolbar.

The split button and the dropdown look the same as their Visual toolbar equivalent but don't share any code. Any addition or modification done to one will need an update to the other.

The media and Contact Form modals, on the other hand, are exactly the same used for the Visual toolbar.
As long as their onInsert methods return a string (HTML or shortcode or whatever really) they should work ok.

One quirk about the Contact Form is that it actually returns an object that must be [serialized](https://github.com/Automattic/wp-calypso/blob/master/client/components/tinymce/plugins/contact-form/plugin.jsx#L60) before entering the text area. It's needed for both visual and HTML toolbars, though, so again, should anything change there, the HTML toolbar needs to be updated tool.

One design quirk is that the caret used here is not the same used in the Visual toolbar.
Here is a proper Gridicon, while the TinyMCE button uses a CSS content.
It's possible to notice the difference when switching between the two modes, since one is a little bit bolder than the other.

## Design

![https://cldup.com/QhxoEcICWh.png](https://cldup.com/QhxoEcICWh.png)

![https://cldup.com/BsfXSiTXSl.gif](https://cldup.com/BsfXSiTXSl.gif)

## Task List

- [x] Media Modal
- [x] Contact Form Modal
- [x] Same UI as Visual mode