### PR TITLE
Themes: Use getCustomizeUrl() to implement getThemeCustomizerUrl()

### DIFF
--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -442,17 +442,24 @@ export function getThemePurchaseUrl( state, theme, siteId ) {
 export function getThemeCustomizeUrl( state, theme, siteId ) {
 	const customizerUrl = getCustomizerUrl( state, siteId );
 
-	if ( ! ( siteId && theme && theme.stylesheet ) ) {
+	if ( ! ( siteId && theme ) ) {
 		return customizerUrl;
 	}
 
-	let separator;
+	let separator, identifier;
 	if ( includes( customizerUrl, '?' ) ) {
 		separator = '&';
 	} else {
 		separator = '?';
 	}
-	return customizerUrl + separator + 'theme=' + theme.stylesheet;
+
+	if ( isJetpackSite( state, siteId ) ) {
+		identifier = getSuffixedThemeId( state, theme.id, siteId );
+	} else {
+		identifier = theme.stylesheet;
+	}
+
+	return customizerUrl + separator + 'theme=' + identifier;
 }
 
 /**

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -446,12 +446,8 @@ export function getThemeCustomizeUrl( state, theme, siteId ) {
 		return customizerUrl;
 	}
 
-	let separator, identifier;
-	if ( includes( customizerUrl, '?' ) ) {
-		separator = '&';
-	} else {
-		separator = '?';
-	}
+	const separator = includes( customizerUrl, '?' ) ? '&' : '?';
+	let identifier;
 
 	if ( isJetpackSite( state, siteId ) ) {
 		identifier = getSuffixedThemeId( state, theme.id, siteId );

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -16,6 +16,7 @@ import {
 	hasJetpackSiteJetpackThemesExtendedFeatures
 } from 'state/sites/selectors';
 import { getSitePurchases } from 'state/purchases/selectors';
+import { getCustomizerUrl } from 'state/sites/selectors';
 import { hasFeature, getSitePlanSlug } from 'state/sites/plans/selectors';
 import {
 	getDeserializedThemesQueryDetails,
@@ -439,24 +440,19 @@ export function getThemePurchaseUrl( state, theme, siteId ) {
  * @return {?String}         Customizer URL
  */
 export function getThemeCustomizeUrl( state, theme, siteId ) {
-	if ( ! siteId ) {
-		return '/customize/';
+	const customizerUrl = getCustomizerUrl( state, siteId );
+
+	if ( ! ( siteId && theme && theme.stylesheet ) ) {
+		return customizerUrl;
 	}
 
-	if ( isJetpackSite( state, siteId ) ) {
-		return getSiteOption( state, siteId, 'admin_url' ) +
-			'customize.php?return=' +
-			encodeURIComponent( window.location ) +
-			( theme ? '&theme=' + getSuffixedThemeId( state, theme.id, siteId ) : '' );
+	let separator;
+	if ( includes( customizerUrl, '?' ) ) {
+		separator = '&';
+	} else {
+		separator = '?';
 	}
-
-	const customizeUrl = '/customize/' + getSiteSlug( state, siteId );
-
-	if ( theme && theme.stylesheet ) {
-		return customizeUrl + '?theme=' + theme.stylesheet;
-	}
-
-	return customizeUrl;
+	return customizerUrl + separator + 'theme=' + theme.stylesheet;
 }
 
 /**

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -1281,12 +1281,11 @@ describe( 'themes selectors', () => {
 					},
 					{
 						id: 'twentysixteen',
-						stylesheet: 'pub/twentysixteen'
 					},
 					77203074
 				);
 				expect( customizeUrl ).to.equal(
-					'https://example.net/wp-admin/customize.php?return=https%3A%2F%2Fwordpress.com&theme=pub/twentysixteen'
+					'https://example.net/wp-admin/customize.php?return=https%3A%2F%2Fwordpress.com&theme=twentysixteen'
 				);
 			} );
 		} );
@@ -1310,11 +1309,10 @@ describe( 'themes selectors', () => {
 					},
 					{
 						id: 'twentysixteen',
-						stylesheet: 'pub/twentysixteen'
 					},
 					77203074
 				);
-				expect( customizeUrl ).to.equal( 'https://example.net/wp-admin/customize.php?theme=pub/twentysixteen' );
+				expect( customizeUrl ).to.equal( 'https://example.net/wp-admin/customize.php?theme=twentysixteen' );
 			} );
 		} );
 	} );

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -1206,13 +1206,21 @@ describe( 'themes selectors', () => {
 
 	describe( '#getThemeCustomizeUrl', () => {
 		it( 'given no theme and no site ID, should return the correct customize URL', () => {
-			const customizeUrl = getThemeCustomizeUrl( {} );
+			const customizeUrl = getThemeCustomizeUrl( {
+				sites: {
+					items: {}
+				}
+			} );
 			expect( customizeUrl ).to.equal( '/customize/' );
 		} );
 
 		it( 'given a theme and no site ID, should return the correct customize URL', () => {
 			const customizeUrl = getThemeCustomizeUrl(
-				{},
+				{
+					sites: {
+						items: {}
+					}
+				},
 				{
 					id: 'twentysixteen',
 					stylesheet: 'pub/twentysixteen'

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -1277,6 +1277,13 @@ describe( 'themes selectors', () => {
 									}
 								}
 							}
+						},
+						themes: {
+							queries: {
+								77203074: new ThemeQueryManager( {
+									items: { twentysixteen }
+								} )
+							}
 						}
 					},
 					{
@@ -1304,6 +1311,13 @@ describe( 'themes selectors', () => {
 										admin_url: 'https://example.net/wp-admin/'
 									}
 								}
+							}
+						},
+						themes: {
+							queries: {
+								77203074: new ThemeQueryManager( {
+									items: { twentysixteen }
+								} )
 							}
 						}
 					},

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -1250,29 +1250,72 @@ describe( 'themes selectors', () => {
 			expect( customizeUrl ).to.equal( '/customize/example.wordpress.com?theme=pub/twentysixteen' );
 		} );
 
-		it( 'given a theme and Jetpack site ID, should return the correct customize URL', () => {
-			const customizeUrl = getThemeCustomizeUrl(
-				{
-					sites: {
-						items: {
-							77203074: {
-								ID: 77203074,
-								URL: 'https://example.net',
-								jetpack: true,
-								options: {
-									admin_url: 'https://example.net/wp-admin/'
+		context( 'browser', () => {
+			before( () => {
+				global.window = {
+					location: {
+						href: 'https://wordpress.com'
+					}
+				};
+			} );
+
+			after( () => {
+				delete global.window;
+			} );
+
+			it( 'should return customizer URL for Jetpack site', () => {
+				const customizeUrl = getThemeCustomizeUrl(
+					{
+						sites: {
+							items: {
+								77203074: {
+									ID: 77203074,
+									URL: 'https://example.net',
+									jetpack: true,
+									options: {
+										admin_url: 'https://example.net/wp-admin/'
+									}
 								}
 							}
 						}
-					}
-				},
-				{
-					id: 'twentysixteen',
-					stylesheet: 'pub/twentysixteen'
-				},
-				77203074
-			);
-			expect( customizeUrl ).to.equal( 'https://example.net/wp-admin/customize.php?theme=pub/twentysixteen' );
+					},
+					{
+						id: 'twentysixteen',
+						stylesheet: 'pub/twentysixteen'
+					},
+					77203074
+				);
+				expect( customizeUrl ).to.equal(
+					'https://example.net/wp-admin/customize.php?return=https%3A%2F%2Fwordpress.com&theme=pub/twentysixteen'
+				);
+			} );
+		} );
+
+		context( 'node', () => {
+			it( 'should return customizer URL for Jetpack site', () => {
+				const customizeUrl = getThemeCustomizeUrl(
+					{
+						sites: {
+							items: {
+								77203074: {
+									ID: 77203074,
+									URL: 'https://example.net',
+									jetpack: true,
+									options: {
+										admin_url: 'https://example.net/wp-admin/'
+									}
+								}
+							}
+						}
+					},
+					{
+						id: 'twentysixteen',
+						stylesheet: 'pub/twentysixteen'
+					},
+					77203074
+				);
+				expect( customizeUrl ).to.equal( 'https://example.net/wp-admin/customize.php?theme=pub/twentysixteen' );
+			} );
 		} );
 	} );
 

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -1211,7 +1211,7 @@ describe( 'themes selectors', () => {
 					items: {}
 				}
 			} );
-			expect( customizeUrl ).to.equal( '/customize/' );
+			expect( customizeUrl ).to.equal( '/customize' );
 		} );
 
 		it( 'given a theme and no site ID, should return the correct customize URL', () => {
@@ -1226,7 +1226,7 @@ describe( 'themes selectors', () => {
 					stylesheet: 'pub/twentysixteen'
 				}
 			);
-			expect( customizeUrl ).to.equal( '/customize/' );
+			expect( customizeUrl ).to.equal( '/customize' );
 		} );
 
 		it( 'given a theme and wpcom site ID, should return the correct customize URL', () => {
@@ -1250,8 +1250,7 @@ describe( 'themes selectors', () => {
 			expect( customizeUrl ).to.equal( '/customize/example.wordpress.com?theme=pub/twentysixteen' );
 		} );
 
-		// FIXME: In implementation, get rid of `window` dependency.
-		it.skip( 'given a theme and Jetpack site ID, should return the correct customize URL', () => {
+		it( 'given a theme and Jetpack site ID, should return the correct customize URL', () => {
 			const customizeUrl = getThemeCustomizeUrl(
 				{
 					sites: {
@@ -1259,7 +1258,10 @@ describe( 'themes selectors', () => {
 							77203074: {
 								ID: 77203074,
 								URL: 'https://example.net',
-								jetpack: true
+								jetpack: true,
+								options: {
+									admin_url: 'https://example.net/wp-admin/'
+								}
 							}
 						}
 					}
@@ -1270,7 +1272,7 @@ describe( 'themes selectors', () => {
 				},
 				77203074
 			);
-			expect( customizeUrl ).to.equal( '/customize/example.wordpress.com?theme=pub/twentysixteen' );
+			expect( customizeUrl ).to.equal( 'https://example.net/wp-admin/customize.php?theme=pub/twentysixteen' );
 		} );
 	} );
 

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -1822,7 +1822,6 @@ describe( 'themes selectors', () => {
 
 			expect( isWpcom ).to.be.false;
 		} );
-
 	} );
 
 	describe( '#isPremium()', () => {

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -1250,83 +1250,109 @@ describe( 'themes selectors', () => {
 			expect( customizeUrl ).to.equal( '/customize/example.wordpress.com?theme=pub/twentysixteen' );
 		} );
 
-		context( 'browser', () => {
-			before( () => {
-				global.window = {
-					location: {
-						href: 'https://wordpress.com'
+		context( 'on a Jetpack site', () => {
+			context( 'with a non-WP.com theme', () => {
+				const state = {
+					sites: {
+						items: {
+							77203074: {
+								ID: 77203074,
+								URL: 'https://example.net',
+								jetpack: true,
+								options: {
+									admin_url: 'https://example.net/wp-admin/'
+								}
+							}
+						}
+					},
+					themes: {
+						queries: {
+							77203074: new ThemeQueryManager( {
+								items: { twentysixteen }
+							} )
+						}
 					}
 				};
-			} );
 
-			after( () => {
-				delete global.window;
-			} );
-
-			it( 'should return customizer URL for Jetpack site', () => {
-				const customizeUrl = getThemeCustomizeUrl(
-					{
-						sites: {
-							items: {
-								77203074: {
-									ID: 77203074,
-									URL: 'https://example.net',
-									jetpack: true,
-									options: {
-										admin_url: 'https://example.net/wp-admin/'
-									}
-								}
+				context( 'in the browser', () => {
+					before( () => {
+						global.window = {
+							location: {
+								href: 'https://wordpress.com'
 							}
-						},
-						themes: {
-							queries: {
-								77203074: new ThemeQueryManager( {
-									items: { twentysixteen }
-								} )
+						};
+					} );
+
+					after( () => {
+						delete global.window;
+					} );
+
+					it( 'should return customizer URL with return arg and un-suffixed theme ID', () => {
+						const customizeUrl = getThemeCustomizeUrl( state, { id: 'twentysixteen' }, 77203074 );
+						expect( customizeUrl ).to.equal(
+							'https://example.net/wp-admin/customize.php?return=https%3A%2F%2Fwordpress.com&theme=twentysixteen'
+						);
+					} );
+				} );
+
+				context( 'on the server', () => {
+					it( 'should return customizer URL with un-suffixed theme ID', () => {
+						const customizeUrl = getThemeCustomizeUrl( state, { id: 'twentysixteen' }, 77203074 );
+						expect( customizeUrl ).to.equal( 'https://example.net/wp-admin/customize.php?theme=twentysixteen' );
+					} );
+				} );
+			} );
+
+			context( 'with a WP.com theme', () => {
+				const state = {
+					sites: {
+						items: {
+							77203074: {
+								ID: 77203074,
+								URL: 'https://example.net',
+								jetpack: true,
+								options: {
+									admin_url: 'https://example.net/wp-admin/'
+								}
 							}
 						}
 					},
-					{
-						id: 'twentysixteen',
-					},
-					77203074
-				);
-				expect( customizeUrl ).to.equal(
-					'https://example.net/wp-admin/customize.php?return=https%3A%2F%2Fwordpress.com&theme=twentysixteen'
-				);
-			} );
-		} );
-
-		context( 'node', () => {
-			it( 'should return customizer URL for Jetpack site', () => {
-				const customizeUrl = getThemeCustomizeUrl(
-					{
-						sites: {
-							items: {
-								77203074: {
-									ID: 77203074,
-									URL: 'https://example.net',
-									jetpack: true,
-									options: {
-										admin_url: 'https://example.net/wp-admin/'
-									}
-								}
-							}
-						},
-						themes: {
-							queries: {
-								77203074: new ThemeQueryManager( {
-									items: { twentysixteen }
-								} )
-							}
+					themes: {
+						queries: {
+							wpcom: new ThemeQueryManager( {
+								items: { twentysixteen }
+							} )
 						}
-					},
-					{
-						id: 'twentysixteen',
-					},
-					77203074
-				);
-				expect( customizeUrl ).to.equal( 'https://example.net/wp-admin/customize.php?theme=twentysixteen' );
+					}
+				};
+
+				context( 'in the browser', () => {
+					before( () => {
+						global.window = {
+							location: {
+								href: 'https://wordpress.com'
+							}
+						};
+					} );
+
+					after( () => {
+						delete global.window;
+					} );
+
+					it( 'should return customizer URL with return arg and suffixed theme ID', () => {
+						const customizeUrl = getThemeCustomizeUrl( state, { id: 'twentysixteen' }, 77203074 );
+						expect( customizeUrl ).to.equal(
+							'https://example.net/wp-admin/customize.php?return=https%3A%2F%2Fwordpress.com&theme=twentysixteen-wpcom'
+						);
+					} );
+				} );
+
+				context( 'on the server', () => {
+					it( 'should return customizer URL with suffixed theme ID', () => {
+						const customizeUrl = getThemeCustomizeUrl( state, { id: 'twentysixteen' }, 77203074 );
+						expect( customizeUrl ).to.equal( 'https://example.net/wp-admin/customize.php?theme=twentysixteen-wpcom' );
+					} );
+				} );
 			} );
 		} );
 	} );


### PR DESCRIPTION
Rationale: To de-duplicate implementations. This reduces maintenance effort, e.g. for changes like #11210 which we'd otherwise have to carry over to `getThemeCustomizerUrl`. This also allows us to switch on a previously skipped unit test, *and* to add one to check the `return=` query arg on the client side.

To test: Verify that a theme's 'Customize' option still works in different modes.