### PR TITLE
Themes: refactoring theme card to avoid misalignment

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -147,7 +147,9 @@ const Theme = React.createClass( {
 		return (
 			<Card className={ themeClass }>
 				<div className="theme__content">
+
 					{ this.renderHover() }
+
 					<a href={ this.props.screenshotClickUrl }>
 						{ this.renderInstalling() }
 						{ screenshot
@@ -160,15 +162,16 @@ const Theme = React.createClass( {
 							</div>
 						}
 					</a>
+
 					<div className="theme__info" >
-						<h2>{ name }</h2>
+						<h2 className="theme__info-title">{ name }</h2>
 						{ active &&
-							<span className="theme__active-label">{ this.translate( 'Active', {
+							<span className="theme-badge__active">{ this.translate( 'Active', {
 								context: 'singular noun, the currently active theme'
 							} ) }</span>
 						}
 						{ price && ! purchased &&
-							<span className="price">{ price }</span>
+							<span className="theme-badge__price">{ price }</span>
 						}
 						{ ! isEmpty( this.props.buttonContents )
 							? <TrackInteractions fields="theme.id" >
@@ -178,8 +181,11 @@ const Theme = React.createClass( {
 									active={ this.props.active }
 									onClick={ this.props.onMoreButtonClick }
 									options={ this.props.buttonContents } />
-							</TrackInteractions> : null }
+							</TrackInteractions>
+							: null
+						}
 					</div>
+
 				</div>
 			</Card>
 		);

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -7,28 +7,15 @@ $theme-info-height: 54px;
 	flex-grow: 1; // ...grow allows expansion to fill space after wrap.
 	transition: all 100ms ease-in-out;
 
-	h2 {
-		display: inline-block;
-		color: black;
-		font-weight: 600;
-		padding: 15px 0 15px 15px;
-		margin: inherit;
-		font-family: inherit;
-		font-size: inherit;
-	}
-
-	.price {
-		padding-left: 10px;
-		color: #4FB769;
-		font-size: 90%;
-		font-weight: 600;
-	}
-
 	&.is-active {
 		background: $blue-medium;
 
-		h2 {
+		.theme__info-title {
 			color: $white;
+
+			&:before {
+				@include long-content-fade( $color: $blue-medium );
+			}
 		}
 
 		button {
@@ -55,12 +42,53 @@ $theme-info-height: 54px;
 		}
 	}
 
-
-
 	&.is-placeholder {
 		background-color: lighten( $gray, 20% );
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}
+}
+
+.theme__info {
+	position: absolute;
+		bottom: 0;
+		left: 0;
+		right: 0;
+	height: $theme-info-height;
+	display: flex;
+}
+
+.theme__info-title {
+	flex: 1 1 auto;
+	position: relative;
+	color: $gray-dark;
+	font-size: 14px;
+	font-weight: 600;
+	padding: 16px 14px;
+	margin: inherit;
+	font-family: inherit;
+	overflow: hidden;
+	white-space: nowrap;
+
+	&:before {
+		@include long-content-fade( $color: $white );
+	}
+}
+
+.theme-badge__price {
+	flex: 0 0 auto;
+	padding: 18px 10px 0;
+	color: $alert-green;
+	font-size: 13px;
+	font-weight: 600;
+}
+
+.theme-badge__active {
+	flex: 0 0 auto;
+	padding: 18px 10px 0;
+	color: lighten( $blue-light, 10% );
+	text-transform: uppercase;
+	font-size: 12px;
+	font-weight: 600;
 }
 
 .theme__active-focus {
@@ -112,14 +140,6 @@ $theme-info-height: 54px;
 	}
 }
 
-.theme__active-label {
-	margin-left: 10px;
-	color: lighten( $blue-light, 10% );
-	text-transform: uppercase;
-	font-size: 0.8em;
-	font-weight: 600;
-}
-
 // Calc height according to .theme width
 .theme__content {
 	padding-top: 75%; // 4:3 screenshot ratio
@@ -152,14 +172,6 @@ $theme-info-height: 54px;
 	}
 }
 
-.theme__info {
-	position: absolute;
-		bottom: 0;
-		left: 0;
-		right: 0;
-	height: $theme-info-height;
-}
-
 .theme__installing {
 	background: transparentize($gray-dark, 0.5);
 	width: 100%;
@@ -174,10 +186,10 @@ $theme-info-height: 54px;
 }
 
 .theme__more-button {
-	float: right;
 	border-left: 1px solid $gray-light;
 	height: $theme-info-height;
 	display: flex;
+	flex: 0 0 auto;
 	transition: all 100ms ease-in-out;
 
 	button {

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -5,10 +5,15 @@ $theme-info-height: 54px;
 	margin: 0 10px 20px 10px;
 	width: 230px; // Fixed width gives desired wrapping...
 	flex-grow: 1; // ...grow allows expansion to fill space after wrap.
+	overflow: hidden;
 	transition: all 100ms ease-in-out;
 
 	&.is-active {
 		background: $blue-medium;
+
+		.theme__info {
+			background: $blue-medium;
+		}
 
 		.theme__info-title {
 			color: $white;
@@ -55,6 +60,7 @@ $theme-info-height: 54px;
 		right: 0;
 	height: $theme-info-height;
 	display: flex;
+	background: $white;
 }
 
 .theme__info-title {

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -128,7 +128,7 @@ describe( 'Theme', function() {
 		} );
 
 		it( 'should show a price', function() {
-			assert( this.themeNode.getElementsByClassName( 'price' )[0].textContent === '$50' );
+			assert( this.themeNode.getElementsByClassName( 'theme-badge__price' )[0].textContent === '$50' );
 		} );
 	} );
 } );


### PR DESCRIPTION
Long titles broke the line and the position of the "more" button. This PR both fixes the issue and refactors the CSS code for better maintainability.

Fixes: #10661, #9700, #554.

Before:
  
![screen shot 2017-02-07 at 14 18 20](https://cloud.githubusercontent.com/assets/4389/22694763/57f79ba4-ed40-11e6-9bca-0b4d4c644af1.png)

After:

![screen shot 2017-02-07 at 14 16 46](https://cloud.githubusercontent.com/assets/4389/22694767/5bab1f3c-ed40-11e6-9de8-9ee6fa4d2651.png)

### To test

1. Open My Sites → Themes
2. Find themes with long titles, both with and without price, check they show correctly (or Inspect and edit the label).
3. Make sure it works on active themes too.
4. Set manually the height of a thumbnail to more than the card height (i.e. `400px`) or replace the img with a taller one, or find an old theme with a tall screenshot (i.e. "Hybrid News"), and make sure it doesn't break the card layout.
5. Try to resize at each of the steps above to make sure everything is properly responsive.
6. Check on mobile.