### PR TITLE
State: Normalize Jetpack settings when obtaining from modules

### DIFF
--- a/client/state/jetpack/settings/reducer.js
+++ b/client/state/jetpack/settings/reducer.js
@@ -23,6 +23,7 @@ import {
 	JETPACK_SETTINGS_UPDATE_FAILURE
 } from 'state/action-types';
 import { createReducer } from 'state/utils';
+import { normalizeSettings } from './utils';
 
 const createRequestsReducer = ( data ) => {
 	return ( state, { siteId } ) => {
@@ -76,7 +77,7 @@ export const items = createReducer( {}, {
 			[ siteId ]: {
 				...state[ siteId ],
 				...modulesActivationState,
-				...moduleSettings
+				...normalizeSettings( moduleSettings )
 			}
 		} );
 	},

--- a/client/state/jetpack/settings/test/reducer.js
+++ b/client/state/jetpack/settings/test/reducer.js
@@ -192,6 +192,41 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		it( 'should update module settings with normalized ones when receiving new modules', () => {
+			const siteId = 12345678,
+				stateIn = {
+					12345678: {
+						setting_123: 'test',
+					}
+				},
+				action = {
+					type: JETPACK_MODULES_RECEIVE,
+					siteId,
+					modules: {
+						minileven: {
+							active: true,
+							options: {
+								wp_mobile_excerpt: {
+									current_value: 'enabled',
+								},
+								some_other_option: {
+									current_value: '123',
+								},
+							}
+						}
+					}
+				};
+			const stateOut = itemsReducer( deepFreeze( stateIn ), action );
+			expect( stateOut ).to.eql( {
+				12345678: {
+					setting_123: 'test',
+					minileven: true,
+					wp_mobile_excerpt: true,
+					some_other_option: '123'
+				}
+			} );
+		} );
+
 		it( 'should update the post_by_email_address setting after a successful post by email update', () => {
 			const siteId = 12345678,
 				stateIn = {


### PR DESCRIPTION
In #10891 we changed Jetpack settings to be obtained when receiving modules. However, we're receiving them in a raw state, so they need to be normalized. Lacking this causes some unexpected bugs, for example:

* Go to `/settings/writing/$site` for a Jetpack site.
* Enable the "Optimize your site with a mobile-friendly theme for tablets and phones." module.
* Disable the "Hide all featured images" option.
* Click "Save Changes".
* Refresh the page and you'll see the "Hide all featured images" option is still displayed as enabled (while in reality it's disabled).

This PR tackles this by simply normalizing the settings when obtaining them from the modules. Also, it includes tests for that.

To test:
* Checkout this branch
* Verify the Jetpack settings reducer tests pass: 

```
npm run test-client client/state/jetpack/settings/test/reducer.js
```
* Go to `/settings/writing/$site` for a Jetpack site.
* Enable the "Optimize your site with a mobile-friendly theme for tablets and phones." module.
* Disable the "Hide all featured images" option.
* Click "Save Changes".
* Refresh the page.
* Verify the "Hide all featured images" now appears disabled as expected.

/cc @osk