### PR TITLE
Site Icon: update help text to include minimum size

### DIFF
--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -256,8 +256,11 @@ class SiteIconSetting extends Component {
 				<FormLabel className="site-icon-setting__heading">
 					{ translate( 'Site Icon' ) }
 					<InfoPopover position="bottom right">
-						{ translate( 'Your site icon will be shown across WordPress.com, in your' +
-							' visitors\' browser tabs, and as a home screen app icon.' ) }
+						{ translate(
+							'The Site Icon is used as a browser and app icon for your site.' +
+							' Icons must be square, and at least %s pixels wide and tall.',
+							{ args: [ 512 ] }
+						) }
 					</InfoPopover>
 				</FormLabel>
 				{ React.createElement( buttonProps.href ? 'a' : 'button', {


### PR DESCRIPTION
Fixes #11234

**Before**
<img width="529" alt="screen shot 2017-02-07 at 06 57 30" src="https://cloud.githubusercontent.com/assets/66797/22699832/e3e1ceda-ed15-11e6-93f6-60cc91cb2cac.png">

**After**
<img width="434" alt="screen shot 2017-02-07 at 09 13 19" src="https://cloud.githubusercontent.com/assets/66797/22699846/ecd190de-ed15-11e6-9952-c6a673c1c18c.png">
