### PR TITLE
Checkout: Update Paypal Express to work with domain-only sites

### DIFF
--- a/client/my-sites/upgrades/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/paypal-payment-box.jsx
@@ -79,10 +79,18 @@ module.exports = React.createClass( {
 			disabled: true
 		} );
 
+		let cancelUrl = origin + '/checkout/';
+
+		if ( this.props.selectedSite ) {
+			cancelUrl += this.props.selectedSite.slug;
+		} else {
+			cancelUrl += 'no-site';
+		}
+
 		dataForApi = assign( {}, this.state, {
 			successUrl: origin + this.props.redirectTo(),
-			cancelUrl: origin + '/checkout/' + this.props.selectedSite.slug,
-			cart: cart,
+			cancelUrl,
+			cart,
 			domainDetails: transaction.domainDetails
 		} );
 


### PR DESCRIPTION
This pull request updates the `Secure Payment With Paypal` page to support purchases made in the `domains-only` flow.
 
#### Testing instructions
 
1. Run `git checkout fix/paypal-domain-only-sites` and start your server, or open a [live branch](https://calypso.live/?branch=fix/paypal-domain-only-sites)
2. Open the new [`Signup` page](http://calypso.localhost:3000/start/domain-first) in incognito mode
3. Proceed to the `Secure Payment With Paypal` page
4. Submit the form
 
#### Reviews
 
- [x] Code
- [x] Product