### PR TITLE
Settings: Update FormToggle to align to the top of the label

### DIFF
--- a/client/components/forms/form-toggle/style.scss
+++ b/client/components/forms/form-toggle/style.scss
@@ -15,6 +15,7 @@
 	width: 40px;
 	height: 24px;
 	vertical-align: middle;
+	align-self: flex-start;
 	outline: 0;
 	cursor: pointer;
 	transition: all .4s ease, box-shadow 0s;

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -62,6 +62,10 @@
 		}
 	}
 
+	.form-toggle__switch {
+		margin-top: 3px;
+	}
+
 	p.form-setting-explanation {
 		display: block;
 		margin: 5px 0;


### PR DESCRIPTION
Fixes #10899

Toggles should now be aligned to the top line of the label when the label wraps:

![screen shot 2017-02-10 at 11 25 44 am](https://cloud.githubusercontent.com/assets/541093/22834594/b17c5440-ef83-11e6-8641-4e8d97ff73db.png)

To test:

1. Visit the settings screens where toggles are used, for example, Writing
2. Shrink your screen to force the labels to wrap
3. Toggles should stay top-aligned
4. Check other places where toggles are used (Page & post settings in the editor, followed sites management) to make sure these aren't negatively affected.

@rickybanister @MichaelArestad 