### PR TITLE
Editor: Correct image rotation by always passing image through Photon

### DIFF
--- a/client/components/tinymce/plugins/media/restrict-size/index.js
+++ b/client/components/tinymce/plugins/media/restrict-size/index.js
@@ -35,11 +35,11 @@ function setImageSrc( img, opening, src, closing ) {
 	}
 
 	const parsed = deserialize( img );
-	if ( parsed.media.transient || ! parsed.media.width || parsed.media.width < MAX_WIDTH ) {
+	if ( parsed.media.transient ) {
 		return img;
 	}
 
-	const url = resize( parsed.media.URL, { w: MAX_WIDTH } );
+	const url = resize( parsed.media.URL, Math.min( parsed.media.width || Infinity, MAX_WIDTH ) );
 	return `${ opening }${ url }" data-wpmedia-src="${ parsed.media.URL }${ closing }`;
 }
 

--- a/client/components/tinymce/plugins/media/restrict-size/test/index.js
+++ b/client/components/tinymce/plugins/media/restrict-size/test/index.js
@@ -79,19 +79,9 @@ describe( 'restrictSize', () => {
 			expect( value ).to.equal( '<p><img class="alignnone size-large wp-image-5823" src="https://wordpress.com/2015/11/forest.jpg?w=680" data-wpmedia-src="https://wordpress.com/2015/11/forest.jpg?w=1024" alt="forest" width="1024" height="683" data-mce-src="https://wordpress.com/2015/11/forest.jpg?w=680" data-mce-selected="1"></p>' );
 		} );
 
-		it( 'should not replace small images', () => {
-			const value = setImages( '<p><img src="https://wordpress.com/2015/11/forest.jpg?w=150" alt="forest" width="150" height="100" class="alignnone size-thumbnail wp-image-5823" data-mce-selected="1"></p>' );
-			expect( value ).to.equal( '<p><img src="https://wordpress.com/2015/11/forest.jpg?w=150" alt="forest" width="150" height="100" class="alignnone size-thumbnail wp-image-5823" data-mce-selected="1"></p>' );
-		} );
-
-		it( 'should not replace images with indeterminate widths', () => {
+		it( 'should replace images with indeterminate widths', () => {
 			const value = setImages( '<p><img src="https://wordpress.com/2015/11/forest.jpg" alt="forest" class="alignnone size-thumbnail wp-image-5823" data-mce-selected="1"></p>' );
-			expect( value ).to.equal( '<p><img src="https://wordpress.com/2015/11/forest.jpg" alt="forest" class="alignnone size-thumbnail wp-image-5823" data-mce-selected="1"></p>' );
-		} );
-
-		it( 'should handle multiple images of mixed replacement needs', () => {
-			const value = setImages( '<p><img src="https://example.com/bird.jpg" width="200" height="174"><img src="https://example.com/forest.jpg?w=1024" width="1024" height="683"></p>' );
-			expect( value ).to.equal( '<p><img src="https://example.com/bird.jpg" width="200" height="174"><img src="https://example.com/forest.jpg?w=680" data-wpmedia-src="https://example.com/forest.jpg?w=1024" width="1024" height="683"></p>' );
+			expect( value ).to.equal( '<p><img src="https://wordpress.com/2015/11/forest.jpg?w=680" data-wpmedia-src="https://wordpress.com/2015/11/forest.jpg" alt="forest" class="alignnone size-thumbnail wp-image-5823" data-mce-selected="1"></p>' );
 		} );
 	} );
 } );


### PR DESCRIPTION
Partial fix for #313, many caveats apply (see section below)

This pull request seeks to correctly display images with rotation EXIF metadata in the post editor for Jetpack sites. The changes here revise the `restrict-size` TinyMCE sub-plugin to pass all images through Photon. The reason this helps fix the rotation is described in more detail in #313:

>The cause appears to be that WordPress strips EXIF rotation data when generating intermediate thumbnail sizes for an image. Since we display the large thumbnail in the editor, it will display in the editor without the proper rotation. On the site, however, Jetpack/Photon instead use the original image passed through Photon and scaled to the desired size. Because it scales the original image, the rotation metadata is correctly preserved.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/22703069/d8a22658-ed30-11e6-969c-bb8ac4c1641d.gif)|![After](https://cloud.githubusercontent.com/assets/1779930/22703068/d8a1a368-ed30-11e6-9068-994a6648bda0.gif)

These changes **do not fix** rotation issues with featured image. Featured image is more complicated because we respect custom theme size and crop. Because the thumbnail resizing is the cause for the rotation issues, we either must choose (a) to ignore custom thumbnail and pass original image through Photon or (b) to respect custom thumbnail at cost of rotation issues.

__Testing instructions:__

Using [example rotated images](https://github.com/recurser/exif-orientation-examples), try inserting images into post content. Observe that rotation is restored after image finishes uploading.

1. Navigate to [post editor](http://calypso.localhost:3000/post)
2. Select a Jetpack site
3. Drag n' drop or otherwise insert image
4. After image finishes uploading, note that rotation is corrected

__Caveats:__

- Rotation is only fixed after the image finishes uploading
- As can be seen by running through [example images](https://github.com/recurser/exif-orientation-examples), this does not appear to help resolve flipped images, only rotated
- Keep in mind that your browser will probably fix rotation itself when viewing an image in a standalone tab