### PR TITLE
Site settings: updated Jetpack toggle spacing and child-settings indentation

### DIFF
--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -95,7 +95,7 @@ class CustomContentTypes extends Component {
 
 	renderContentTypeSettings( fieldName, fieldLabel, fieldDescription ) {
 		return (
-			<div className="site-settings__child-settings">
+			<div className="custom-content-types__module-settings site-settings__child-settings">
 				{ this.renderToggle( fieldName, fieldLabel ) }
 				<p className="form-setting-explanation">
 					{ fieldDescription }

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -95,7 +95,7 @@ class CustomContentTypes extends Component {
 
 	renderContentTypeSettings( fieldName, fieldLabel, fieldDescription ) {
 		return (
-			<div className="custom-content-types__module-settings site-settings__child-settings">
+			<div className="custom-content-types__module-settings">
 				{ this.renderToggle( fieldName, fieldLabel ) }
 				<p className="form-setting-explanation">
 					{ fieldDescription }

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -95,7 +95,7 @@ class CustomContentTypes extends Component {
 
 	renderContentTypeSettings( fieldName, fieldLabel, fieldDescription ) {
 		return (
-			<div className="custom-content-types__module-settings is-indented">
+			<div className="site-settings__child-settings">
 				{ this.renderToggle( fieldName, fieldLabel ) }
 				<p className="form-setting-explanation">
 					{ fieldDescription }

--- a/client/my-sites/site-settings/custom-content-types/style.scss
+++ b/client/my-sites/site-settings/custom-content-types/style.scss
@@ -1,0 +1,7 @@
+.custom-content-types__module-settings {
+	margin-bottom: 24px;
+
+	&:last-child {
+		margin-bottom: 0;
+	}
+}

--- a/client/my-sites/site-settings/custom-content-types/style.scss
+++ b/client/my-sites/site-settings/custom-content-types/style.scss
@@ -1,7 +1,0 @@
-.custom-content-types__module-settings.is-indented {
-	margin-bottom: 24px;
-
-	&:last-child {
-		margin-bottom: 0;
-	}
-}

--- a/client/my-sites/site-settings/jetpack-module-toggle/style.scss
+++ b/client/my-sites/site-settings/jetpack-module-toggle/style.scss
@@ -1,7 +1,7 @@
 .jetpack-module-toggle .form-toggle__label *:not( .form-toggle__switch ) {
-	margin-left: 8px;
+	margin-left: 12px;
 }
 
 .jetpack-module-toggle p.form-setting-explanation.is-indented {
-	margin-left: 32px;
+	margin-left: 36px;
 }

--- a/client/my-sites/site-settings/jetpack-module-toggle/style.scss
+++ b/client/my-sites/site-settings/jetpack-module-toggle/style.scss
@@ -1,7 +1,3 @@
-.jetpack-module-toggle .form-toggle__label *:not( .form-toggle__switch ) {
-	margin-left: 12px;
-}
-
 .jetpack-module-toggle p.form-setting-explanation.is-indented {
 	margin-left: 36px;
 }

--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -59,7 +59,7 @@ class PublishingTools extends Component {
 		const labelClassName = regeneratingPostByEmail || ! postByEmailAddressModuleActive ? 'is-disabled' : null;
 
 		return (
-			<div className="publishing-tools__module-settings is-indented">
+			<div className="site-settings__child-settings">
 				<FormLabel className={ labelClassName }>
 					{ translate( 'Email Address' ) }
 				</FormLabel>

--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -59,7 +59,7 @@ class PublishingTools extends Component {
 		const labelClassName = regeneratingPostByEmail || ! postByEmailAddressModuleActive ? 'is-disabled' : null;
 
 		return (
-			<div className="site-settings__child-settings">
+			<div className="publishing-tools__module-settings site-settings__child-settings">
 				<FormLabel className={ labelClassName }>
 					{ translate( 'Email Address' ) }
 				</FormLabel>

--- a/client/my-sites/site-settings/publishing-tools/style.scss
+++ b/client/my-sites/site-settings/publishing-tools/style.scss
@@ -12,23 +12,9 @@
 	}
 }
 
-.publishing-tools__module-settings.is-indented {
-	margin: 16px 32px;
-
-	.form-label {
-		&.is-disabled {
-			opacity: 0.3;
-		}
-	}
-
-	.form-toggle__switch {
-		margin-right: 8px;
-	}
-
-	.publishing-tools__email-address {
-		display: block;
-		margin-bottom: 8px;
-	}
+.publishing-tools__email-address {
+	display: block;
+	margin-bottom: 8px;
 }
 
 .publishing-tools__info-link-container {

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -403,5 +403,5 @@
 }
 
 .site-settings__child-settings {
-	margin: 8px 36px 0;
+	margin: 16px 36px 0;
 }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -172,10 +172,6 @@
 			margin-bottom: 8px;
 		}
 	}
-
-	.site-settings__child-settings {
-		margin-left: 36px;
-	}
 }
 
 .site-settings__general-settings, .site-settings__writing-settings {
@@ -395,4 +391,17 @@
 
 .site-settings__taxonomies {
 	margin-bottom: 17px;
+}
+
+// Site settings group styles
+.site-settings__module-settings {
+	.form-label {
+		&.is-disabled {
+			opacity: 0.3;
+		}
+	}
+}
+
+.site-settings__child-settings {
+	margin: 8px 36px 0;
 }

--- a/client/my-sites/site-settings/subscriptions/index.jsx
+++ b/client/my-sites/site-settings/subscriptions/index.jsx
@@ -45,7 +45,7 @@ const Subscriptions = ( {
 					disabled={ isRequestingSettings || isSavingSettings }
 					/>
 
-				<div className="subscriptions__module-settings is-indented">
+				<div className="site-settings__child-settings">
 					<FormToggle
 						className="subscriptions__module-settings-toggle is-compact"
 						checked={ !! fields.stb_enabled }

--- a/client/my-sites/site-settings/subscriptions/index.jsx
+++ b/client/my-sites/site-settings/subscriptions/index.jsx
@@ -28,7 +28,7 @@ const Subscriptions = ( {
 	translate
 } ) => {
 	return (
-		<Card className="subscriptions__card site-settings">
+		<Card className="subscriptions site-settings">
 			<FormFieldset>
 				<div className="subscriptions__info-link-container">
 					<InfoPopover position={ 'left' }>
@@ -45,7 +45,7 @@ const Subscriptions = ( {
 					disabled={ isRequestingSettings || isSavingSettings }
 					/>
 
-				<div className="site-settings__child-settings">
+				<div className="subscriptions__module-settings site-settings__child-settings">
 					<FormToggle
 						className="subscriptions__module-settings-toggle is-compact"
 						checked={ !! fields.stb_enabled }

--- a/client/my-sites/site-settings/subscriptions/style.scss
+++ b/client/my-sites/site-settings/subscriptions/style.scss
@@ -1,9 +1,5 @@
-.subscriptions__module-settings.is-indented {
-	margin: 16px 32px;
-
-	.subscriptions__email-followers {
-		margin-top: 16px;
-	}
+.subscriptions__email-followers {
+	margin-top: 16px;
 }
 
 .subscriptions__info-link-container {

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -93,7 +93,7 @@ class ThemeEnhancements extends Component {
 					disabled={ formPending }
 					/>
 
-				<div className="theme-enhancements__module-settings is-indented">
+				<div className="site-settings__child-settings">
 					{
 						this.renderToggle( 'infinite_scroll', ! infiniteScrollModuleActive, translate(
 							'Scroll infinitely (Shows 7 posts on each load)'
@@ -134,7 +134,7 @@ class ThemeEnhancements extends Component {
 					disabled={ formPending }
 					/>
 
-				<div className="theme-enhancements__module-settings is-indented">
+				<div className="site-settings__child-settings">
 					{
 						this.renderToggle( 'wp_mobile_excerpt', ! minilevenModuleActive, translate(
 							'Show excerpts on front page and on archive pages instead of full posts'

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -93,7 +93,7 @@ class ThemeEnhancements extends Component {
 					disabled={ formPending }
 					/>
 
-				<div className="site-settings__child-settings">
+				<div className="theme-enhancements__module-settings site-settings__child-settings">
 					{
 						this.renderToggle( 'infinite_scroll', ! infiniteScrollModuleActive, translate(
 							'Scroll infinitely (Shows 7 posts on each load)'
@@ -134,7 +134,7 @@ class ThemeEnhancements extends Component {
 					disabled={ formPending }
 					/>
 
-				<div className="site-settings__child-settings">
+				<div className="theme-enhancements__module-settings site-settings__child-settings">
 					{
 						this.renderToggle( 'wp_mobile_excerpt', ! minilevenModuleActive, translate(
 							'Show excerpts on front page and on archive pages instead of full posts'

--- a/client/my-sites/site-settings/theme-enhancements/style.scss
+++ b/client/my-sites/site-settings/theme-enhancements/style.scss
@@ -1,7 +1,3 @@
-.theme-enhancements__module-settings.is-indented {
-	margin: 16px 32px 0;
-}
-
 .theme-enhancements__info-link-container {
 	float: right;
 }


### PR DESCRIPTION
As per @rickybanister's good catch in https://github.com/Automattic/wp-calypso/pull/11237

#### Changes
* changed module toggle spacing from `8px` to `12px` to be consistent with other toggles
* changed child settings indent spacing from `32px` to `36px`
* factored out repeated child settings styles to just use a single style

#### Before
![image](https://cloud.githubusercontent.com/assets/1123119/22706838/fe51de00-ed2d-11e6-8407-f1c37b20b928.png)


#### After
![image](https://cloud.githubusercontent.com/assets/1123119/22707039/af551f82-ed2e-11e6-912e-5ebca2e5a758.png)
