### PR TITLE
Stats: Fix Preview https mixed content warning.

### DIFF
--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -5,7 +5,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import page from 'page';
 import { localize } from 'i18n-calypso';
-import { flowRight, get } from 'lodash';
+import { flowRight } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,7 +28,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import Button from 'components/button';
 import WebPreview from 'components/web-preview';
 import { getSiteSlug, isJetpackSite, getSite } from 'state/sites/selectors';
-import { getSitePost, isRequestingSitePost } from 'state/posts/selectors';
+import { getSitePost, isRequestingSitePost, getPostPreviewUrl } from 'state/posts/selectors';
 
 class StatsPostDetail extends Component {
 	static propTypes = {
@@ -43,6 +43,7 @@ class StatsPostDetail extends Component {
 		post: PropTypes.object,
 		siteSlug: PropTypes.string,
 		showViewLink: PropTypes.bool,
+		previewUrl: PropTypes.string,
 	};
 
 	state = {
@@ -73,11 +74,20 @@ class StatsPostDetail extends Component {
 	}
 
 	render() {
-		const { isRequestingPost, isRequestingStats, countViews, post, postId, siteId, translate, siteSlug, showViewLink } = this.props;
+		const {
+			isRequestingPost,
+			isRequestingStats,
+			countViews,
+			post,
+			postId,
+			siteId,
+			translate,
+			siteSlug,
+			showViewLink,
+			previewUrl
+		} = this.props;
 		const postOnRecord = post && post.title !== null;
 		const isLoading = isRequestingStats && ! countViews;
-		const postUrl = get( post, 'URL' );
-
 		let title;
 		if ( postOnRecord ) {
 			if ( typeof post.title === 'string' && post.title.length ) {
@@ -148,8 +158,8 @@ class StatsPostDetail extends Component {
 				<WebPreview
 					showPreview={ this.state.showPreview }
 					defaultViewportDevice="tablet"
-					previewUrl={ `${ postUrl }?demo=true&iframe=true&theme_preview=true` }
-					externalUrl={ postUrl }
+					previewUrl={ `${ previewUrl }?demo=true&iframe=true&theme_preview=true` }
+					externalUrl={ previewUrl }
 					onClose={ this.closePreview }
 					loadingMessage="Beep beep boop…"
 				>
@@ -175,6 +185,7 @@ const connectComponent = connect(
 			isRequestingStats: isRequestingPostStats( state, siteId, postId ),
 			siteSlug: getSiteSlug( state, siteId ),
 			showViewLink: ! isJetpack && site.is_previewable,
+			previewUrl: getPostPreviewUrl( state, siteId, postId ),
 			siteId,
 		};
 	}

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -17,6 +17,7 @@ import {
 	normalizePostForEditing,
 	normalizePostForDisplay
 } from './utils';
+import { getSite } from 'state/sites/selectors';
 import { DEFAULT_POST_QUERY, DEFAULT_NEW_POST_VALUES } from './constants';
 import addQueryArgs from 'lib/route/add-query-args';
 
@@ -445,6 +446,13 @@ export function getPostPreviewUrl( state, siteId, postId ) {
 		previewUrl = addQueryArgs( {
 			preview: true
 		}, previewUrl );
+	}
+
+	// Support mapped domains https
+	const site = getSite( state, siteId );
+	if ( site && site.options ) {
+		const { is_mapped_domain, unmapped_url } = site.options;
+		previewUrl = is_mapped_domain ? previewUrl.replace( site.URL, unmapped_url ) : previewUrl;
 	}
 
 	return previewUrl;

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -1378,6 +1378,40 @@ describe( 'selectors', () => {
 			expect( previewUrl ).to.equal( 'https://example.com/post-url' );
 		} );
 
+		it( 'should change http to https if mapped domain', () => {
+			const previewUrl = getPostPreviewUrl( {
+				posts: {
+					queries: {
+						2916284: new PostQueryManager( {
+							items: {
+								841: {
+									ID: 841,
+									site_ID: 2916284,
+									global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+									status: 'publish',
+									URL: 'http://example.com/post-url'
+								}
+							}
+						} )
+					}
+				},
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'http://example.com',
+							options: {
+								unmapped_url: 'https://example.wordpress.com',
+								is_mapped_domain: true
+							}
+						}
+					}
+				}
+			}, 2916284, 841 );
+
+			expect( previewUrl ).to.equal( 'https://example.wordpress.com/post-url' );
+		} );
+
 		it( 'should append preview query argument to non-published posts', () => {
 			const previewUrl = getPostPreviewUrl( {
 				posts: {


### PR DESCRIPTION
In #11022 a new 'View Post' button was added to the `<HeaderCake />` on the `<StatsPostDetail />` pages:

![stats_ _testingtimmy2_wordpress_com_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/22708620/da04a142-ed2b-11e6-98ae-95738ad64451.png)

Unfortunately, for mapped domains in production, the web preview is not currently working due to the `post.URL` being non-ssl, whereas calypso is served over SSL.  This branch adds logic that is [currently in use](https://github.com/Automattic/wp-calypso/blob/master/client/lib/posts/utils.js#L45-L49) in the `post-edit-store` to work around this issue.

__To Test__
- Verify the new test is passing
- Open a stats post detail page on a mapped domain, verify the 'View Post' link is working, and the base domain src of the iframe is `https://YOURAWESOMETESTSITE.wordpress.com`