### PR TITLE
Sites: Restore overlay behavior of current site click

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -52,12 +52,7 @@ export default React.createClass( {
 	},
 
 	onSelect( event ) {
-		if ( this.props.homeLink ) {
-			return;
-		}
-
 		this.props.onSelect( event, this.props.site.slug );
-		event.preventDefault(); // this doesn't actually do anything...
 	},
 
 	onMouseEnter( event ) {

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -109,7 +109,6 @@ const CurrentSite = React.createClass( {
 	},
 
 	previewSite: function( event ) {
-		event.preventDefault();
 		analytics.ga.recordEvent( 'Sidebar', 'Clicked View Site' );
 		this.props.onClick && this.props.onClick( event );
 	},

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -109,6 +109,7 @@ const CurrentSite = React.createClass( {
 	},
 
 	previewSite: function( event ) {
+		event.preventDefault();
 		analytics.ga.recordEvent( 'Sidebar', 'Clicked View Site' );
 		this.props.onClick && this.props.onClick( event );
 	},


### PR DESCRIPTION
Fixes #11238
Related: #7724

This pull request seeks to resolve an issue where clicking the `<CurrentSite />` (My Sites) `<Site />` component opens in a new tab instead of a preview overlay.

__Implementation notes:__

As discussed in #11238, we relied on the `preventDefault` of the click to ensure that the overlay was shown instead of opening a new tab (default link behavior).

__Testing instructions:__

Repeat testing instructions from #11238, ensuring that preview is shown in overlay.

There are a number of instances of `<Site />` component, but as far as I can tell, `<CurrentSite />` is the only one where both `homeLink` of `true` and an `onSelect` prop are specified, so should be the only occurrence affected. Nonetheless, it would be good to check for regressions on other usage (Switch Site, New Post, etc).

__Open questions:__

The whole `showHomeLink` behavior (icon shown in screenshot of #1881) seems to not be working either. Unsure whether we want to keep this. It seems it was expected to show while hovering the `<CurrentSite />`? This hasn't been the case for quite a while, and could probably be removed.