### PR TITLE
Domains: Remove "new" label from .blog

### DIFF
--- a/client/components/domains/domain-suggestion-flag/index.jsx
+++ b/client/components/domains/domain-suggestion-flag/index.jsx
@@ -11,7 +11,7 @@ import { localize } from 'i18n-calypso';
 import Notice from 'components/notice';
 
 function DomainSuggestionFlag( { domain, translate } ) {
-	const newTLDs = [ 'blog' ];
+	const newTLDs = [];
 
 	if ( newTLDs.some(
 		( tld ) => endsWith( domain, tld ) && domain.substring( 0, domain.length - ( tld.length + 1 ) ).indexOf( '.' ) === -1


### PR DESCRIPTION
This removes the new label from .blog domain suggestions.