### PR TITLE
State: fix products-list-schema

### DIFF
--- a/client/state/products-list/schema.js
+++ b/client/state/products-list/schema.js
@@ -16,7 +16,7 @@ export const productsListSchema = {
 				product_name: { type: 'string' },
 				product_slug: { type: 'string' },
 				description: { type: 'string' },
-				cost: { type: 'number' },
+				cost: { type: [ 'string', 'null' ] },
 				prices: {
 					type: 'object',
 				},

--- a/client/state/products-list/test/reducer.js
+++ b/client/state/products-list/test/reducer.js
@@ -71,7 +71,7 @@ describe( 'reducer', () => {
 						prices: { USD: 129, AUD: 169 },
 						is_domain_registration: false,
 						description: 'Guided Transfer',
-						cost: 129,
+						cost: '129',
 						cost_display: '$129',
 					}
 				} );
@@ -88,7 +88,7 @@ describe( 'reducer', () => {
 						prices: { USD: 129, AUD: 169 },
 						is_domain_registration: false,
 						description: 'Guided Transfer',
-						cost: 129,
+						cost: '129',
 						cost_display: '$129',
 					}
 				} );


### PR DESCRIPTION
I noticed a minor schema issue while testing another PR. If this type change is unexpected from the endpoint, feel free to close this one in favor of a phab diff. Basically the client always expects `cost` to be a number, but is instead a `string` or `null` value. This means that persisted data is always thrown out for this reducer.

![screen shot 2017-02-07 at 1 39 09 pm](https://cloud.githubusercontent.com/assets/1270189/22712757/d5419b38-ed3a-11e6-853e-a1163ab255c0.png)

## Testing Instructions
- Set `SERIALIZE_THROTTLE` in `client/state/initial-state.js` to something small like 500 ms
- Clear indexedDB `indexedDB.deleteDatabase( 'calypso' );`
- Navigate to http://calypso.localhost:3000/settings/general/:siteId:
- We should see state update with `PRODUCTS_LIST_RECEIVE`
![screen shot 2017-02-07 at 1 41 32 pm](https://cloud.githubusercontent.com/assets/1270189/22712872/34e4e18a-ed3b-11e6-8e1f-34800a810b47.png)
- Refresh the page
- No warnings are shown in console. There are no changes in item data.
![screen shot 2017-02-07 at 1 42 37 pm](https://cloud.githubusercontent.com/assets/1270189/22712911/5324edca-ed3b-11e6-970d-111ae259ac67.png)


