### PR TITLE
Checkout: Do not redirect if empty cart but domain-only flow

### DIFF
--- a/client/lib/domains/utils.js
+++ b/client/lib/domains/utils.js
@@ -1,9 +1,15 @@
 /**
+ * External dependencies
+ */
+import { isEmpty, map, values } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { type as domainTypes } from './constants';
+import { cartItems } from 'lib/cart-values';
 
-export function getDomainType( domainFromApi ) {
+function getDomainType( domainFromApi ) {
 	if ( domainFromApi.type === 'redirect' ) {
 		return domainTypes.SITE_REDIRECT;
 	}
@@ -18,3 +24,20 @@ export function getDomainType( domainFromApi ) {
 
 	return domainTypes.MAPPED;
 }
+
+function getDomainNameFromReceiptOrCart( receipt, cart ) {
+	if ( receipt && isEmpty( receipt.failed_purchases ) ) {
+		return map( values( receipt.purchases )[ 0 ], 'meta' )[ 0 ];
+	}
+
+	if ( cartItems.hasDomainRegistration( cart ) ) {
+		return cartItems.getDomainRegistrations( cart )[ 0 ].meta;
+	}
+
+	return null;
+}
+
+export {
+	getDomainNameFromReceiptOrCart,
+	getDomainType
+};

--- a/client/lib/domains/utils.js
+++ b/client/lib/domains/utils.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-import { isEmpty, map, values } from 'lodash';
+import { isEmpty, find, values } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { type as domainTypes } from './constants';
 import { cartItems } from 'lib/cart-values';
+import { isDomainRegistration } from 'lib/products-values';
 
 function getDomainType( domainFromApi ) {
 	if ( domainFromApi.type === 'redirect' ) {
@@ -25,13 +26,28 @@ function getDomainType( domainFromApi ) {
 	return domainTypes.MAPPED;
 }
 
+/**
+ * Depending on the current step in checkout, the user's domain can be found in
+ * either the cart or the receipt.
+ *
+ * @param {?Object} receipt - The receipt for the transaction
+ * @param {?Object} cart - The cart for the transaction
+ *
+ * @return {?String} the name of the first domain for the transaction.
+ */
 function getDomainNameFromReceiptOrCart( receipt, cart ) {
-	if ( receipt && isEmpty( receipt.failed_purchases ) ) {
-		return map( values( receipt.purchases )[ 0 ], 'meta' )[ 0 ];
+	let domainRegistration;
+
+	if ( receipt && ! isEmpty( receipt.purchases ) ) {
+		domainRegistration = find( values( receipt.purchases ), isDomainRegistration );
 	}
 
 	if ( cartItems.hasDomainRegistration( cart ) ) {
-		return cartItems.getDomainRegistrations( cart )[ 0 ].meta;
+		domainRegistration = cartItems.getDomainRegistrations( cart )[ 0 ];
+	}
+
+	if ( domainRegistration ) {
+		return domainRegistration.meta;
 	}
 
 	return null;
@@ -39,5 +55,5 @@ function getDomainNameFromReceiptOrCart( receipt, cart ) {
 
 export {
 	getDomainNameFromReceiptOrCart,
-	getDomainType
+	getDomainType,
 };

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -138,13 +138,13 @@ function startFreePremiumTrial( callback, dependencies, data ) {
 }
 
 function fetchSitesUntilSiteAppears( siteSlug, callback ) {
+	if ( sites.select( siteSlug ) ) {
+		callback();
+		return;
+	}
+
 	sites.once( 'change', function() {
-		if ( ! sites.select( siteSlug ) ) {
-			// if the site isn't in the list then bind to change and fetch again again
-			fetchSitesUntilSiteAppears( siteSlug, callback );
-		} else {
-			callback();
-		}
+		fetchSitesUntilSiteAppears( siteSlug, callback );
 	} );
 
 	// this call is deferred because sites.fetching is not set to false until

--- a/client/my-sites/upgrades/checkout-thank-you/failed-purchase-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/failed-purchase-details.jsx
@@ -29,12 +29,12 @@ const FailedPurchaseDetails = ( { failedPurchases, purchases, translate } ) => {
 						);
 					} ) }
 				</ul>
+				<hr />
 			</div>
 		),
 		description = (
 		<div>
 			{ successfulPurchases }
-			<hr />
 			<p>
 				{
 					translate(

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { flatten, find, includes, isEmpty, isEqual, map, reduce, startsWith, values } from 'lodash';
+import { flatten, find, includes, isEmpty, isEqual, reduce, startsWith } from 'lodash';
 import i18n from 'i18n-calypso';
 import page from 'page';
 import React from 'react';
@@ -42,6 +42,7 @@ import {
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'state/ui/selectors';
+import { getDomainNameFromReceiptOrCart } from 'lib/domains/utils';
 import { domainManagementList } from 'my-sites/upgrades/paths';
 import { fetchSitesAndUser } from 'lib/signup/step-actions';
 
@@ -201,9 +202,10 @@ const Checkout = React.createClass( {
 			return selectedSiteSlug
 				? `/plans/${ selectedSiteSlug }/thank-you`
 				: '/checkout/thank-you/plans';
-		} else if ( cart.create_new_blog && ! cartItems.hasPlan( cart ) ) {
-			if ( isEmpty( receipt.failed_purchases ) ) {
-				return domainManagementList( map( values( receipt.purchases )[ 0 ], 'meta' )[ 0 ] );
+		} else if ( cart.create_new_blog ) {
+			const domainName = getDomainNameFromReceiptOrCart( receipt, cart );
+			if ( domainName ) {
+				return domainManagementList( domainName );
 			}
 
 			return '/start/domain-first';

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { flatten, find, includes, isEmpty, isEqual, reduce, startsWith } from 'lodash';
+import { flatten, find, isEmpty, isEqual, reduce, startsWith } from 'lodash';
 import i18n from 'i18n-calypso';
 import page from 'page';
 import React from 'react';
@@ -139,7 +139,7 @@ const Checkout = React.createClass( {
 	},
 
 	redirectIfEmptyCart: function() {
-		const { selectedSiteSlug } = this.props;
+		const { selectedSiteSlug, transaction } = this.props;
 		let redirectTo = '/plans/';
 
 		if ( ! this.state.previousCart && this.props.product ) {
@@ -151,11 +151,14 @@ const Checkout = React.createClass( {
 			return false;
 		}
 
-		// Do not redirect if cart is empty, but we're submitting or received transaction response
-		if ( includes(
-			[ transactionStepTypes.SUBMITTING_WPCOM_REQUEST, transactionStepTypes.RECEIVED_WPCOM_RESPONSE ],
-			this.props.transaction.step.name )
-		) {
+		if ( transactionStepTypes.SUBMITTING_WPCOM_REQUEST === transaction.step.name ) {
+			return false;
+		}
+
+		if ( transactionStepTypes.RECEIVED_WPCOM_RESPONSE === transaction.step.name && isEmpty( transaction.errors ) ) {
+			// If the cart is emptied by the server after the transaction is
+			// complete without errors, do not redirect as we're waiting for
+			// some post-transaction requests to complete.
 			return false;
 		}
 

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -43,7 +43,7 @@ import {
 	getSelectedSiteSlug,
 } from 'state/ui/selectors';
 import { getDomainNameFromReceiptOrCart } from 'lib/domains/utils';
-import { domainManagementList } from 'my-sites/upgrades/paths';
+import { domainManagementList, domainManagementRoot } from 'my-sites/upgrades/paths';
 import { fetchSitesAndUser } from 'lib/signup/step-actions';
 
 const Checkout = React.createClass( {
@@ -208,7 +208,8 @@ const Checkout = React.createClass( {
 				return domainManagementList( domainName );
 			}
 
-			return '/start/domain-first';
+			// TODO: Redirect to Thank You page, but no site slug atm, so we need a new route
+			return domainManagementRoot();
 		}
 
 		if ( ! selectedSiteSlug ) {

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -199,8 +199,13 @@ const Checkout = React.createClass( {
 			return selectedSiteSlug
 				? `/plans/${ selectedSiteSlug }/thank-you`
 				: '/checkout/thank-you/plans';
-		} else if ( cart.create_new_blog && cartItems.hasDomainRegistration( cart ) && ! cartItems.hasPlan( cart ) ) {
-			const domainName = cartItems.getDomainRegistrations( cart )[ 0 ].meta;
+		} else if ( cart.create_new_blog && ! cartItems.hasPlan( cart ) ) {
+			let domainName;
+			if ( cartItems.hasDomainRegistration( cart ) ) {
+				domainName = cartItems.getDomainRegistrations( cart )[ 0 ].meta;
+			} else {
+				domainName = cartItems.getDomainRegistrations( this.state.previousCart )[ 0 ].meta;
+			}
 
 			return domainManagementList( domainName );
 		}

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -155,6 +155,10 @@ const Checkout = React.createClass( {
 			return false;
 		}
 
+		if ( this.state.previousCart.create_new_blog ) {
+			return false;
+		}
+
 		if ( this.state.previousCart ) {
 			redirectTo = getExitCheckoutUrl( this.state.previousCart, selectedSiteSlug );
 		}

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -150,7 +150,11 @@ const Checkout = React.createClass( {
 			return false;
 		}
 
-		if ( includes( [ transactionStepTypes.SUBMITTING_WPCOM_REQUEST, transactionStepTypes.RECEIVED_WPCOM_RESPONSE ], this.props.transaction.step.name ) ) {
+		// Do not redirect if cart is empty, but we're submitting or received transaction response
+		if ( includes(
+			[ transactionStepTypes.SUBMITTING_WPCOM_REQUEST, transactionStepTypes.RECEIVED_WPCOM_RESPONSE ],
+			this.props.transaction.step.name )
+		) {
 			return false;
 		}
 

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -190,6 +190,9 @@ const Checkout = React.createClass( {
 			}
 		} = this.props;
 
+		// The `:receiptId` string is filled in by our callback page after the PayPal checkout
+		const receiptId = receipt ? receipt.receipt_id : ':receiptId';
+
 		if ( cartItems.hasRenewalItem( cart ) ) {
 			renewalItem = cartItems.getRenewalItems( cart )[ 0 ];
 
@@ -199,15 +202,16 @@ const Checkout = React.createClass( {
 				? `/plans/${ selectedSiteSlug }/thank-you`
 				: '/checkout/thank-you/plans';
 		} else if ( cart.create_new_blog && ! cartItems.hasPlan( cart ) ) {
-			return domainManagementList( map( values( receipt.purchases )[ 0 ], 'meta' )[ 0 ] );
+			if ( isEmpty( receipt.failed_purchases ) ) {
+				return domainManagementList( map( values( receipt.purchases )[ 0 ], 'meta' )[ 0 ] );
+			}
+
+			return '/start/domain-first';
 		}
 
 		if ( ! selectedSiteSlug ) {
 			return '/checkout/thank-you/features';
 		}
-
-		// The `:receiptId` string is filled in by our callback page after the PayPal checkout
-		const receiptId = receipt ? receipt.receipt_id : ':receiptId';
 
 		return this.props.selectedFeature && isValidFeatureKey( this.props.selectedFeature )
 			? `/checkout/thank-you/features/${ this.props.selectedFeature }/${ selectedSiteSlug }/${ receiptId }`
@@ -278,7 +282,7 @@ const Checkout = React.createClass( {
 			this.props.clearSitePlans( selectedSiteId );
 		}
 
-		if ( cart.create_new_blog && cartItems.hasDomainRegistration( cart ) ) {
+		if ( cart.create_new_blog && cartItems.hasDomainRegistration( cart ) && isEmpty( receipt.failed_purchases ) ) {
 			notices.info(
 				this.translate( 'Almost done…' )
 			);

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -288,18 +288,20 @@ const Checkout = React.createClass( {
 			this.props.clearSitePlans( selectedSiteId );
 		}
 
-		if ( cart.create_new_blog && cartItems.hasDomainRegistration( cart ) && isEmpty( receipt.failed_purchases ) ) {
+		if ( cart.create_new_blog ) {
 			notices.info(
 				this.translate( 'Almost done…' )
 			);
 
-			const domainName = cartItems.getDomainRegistrations( cart )[ 0 ].meta;
+			const domainName = getDomainNameFromReceiptOrCart( receipt, cart );
 
-			fetchSitesAndUser( domainName, () => {
-				page( redirectPath );
-			} );
+			if ( domainName ) {
+				fetchSitesAndUser( domainName, () => {
+					page( redirectPath );
+				} );
 
-			return;
+				return;
+			}
 		}
 
 		if ( receipt && receipt.receipt_id ) {

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { flatten, find, isEmpty, isEqual, reduce, startsWith } from 'lodash';
+import { flatten, find, includes, isEmpty, isEqual, map, reduce, startsWith, values } from 'lodash';
 import i18n from 'i18n-calypso';
 import page from 'page';
 import React from 'react';
@@ -30,7 +30,6 @@ const analytics = require( 'lib/analytics' ),
 	transactionStepTypes = require( 'lib/store-transactions/step-types' ),
 	upgradesActions = require( 'lib/upgrades/actions' );
 import { getStoredCards } from 'state/stored-cards/selectors';
-
 import {
 	isValidFeatureKey,
 	getUpgradePlanSlugFromPath
@@ -151,11 +150,7 @@ const Checkout = React.createClass( {
 			return false;
 		}
 
-		if ( this.props.transaction.step.name === transactionStepTypes.SUBMITTING_WPCOM_REQUEST ) {
-			return false;
-		}
-
-		if ( this.state.previousCart.create_new_blog ) {
+		if ( includes( [ transactionStepTypes.SUBMITTING_WPCOM_REQUEST, transactionStepTypes.RECEIVED_WPCOM_RESPONSE ], this.props.transaction.step.name ) ) {
 			return false;
 		}
 
@@ -200,14 +195,7 @@ const Checkout = React.createClass( {
 				? `/plans/${ selectedSiteSlug }/thank-you`
 				: '/checkout/thank-you/plans';
 		} else if ( cart.create_new_blog && ! cartItems.hasPlan( cart ) ) {
-			let domainName;
-			if ( cartItems.hasDomainRegistration( cart ) ) {
-				domainName = cartItems.getDomainRegistrations( cart )[ 0 ].meta;
-			} else {
-				domainName = cartItems.getDomainRegistrations( this.state.previousCart )[ 0 ].meta;
-			}
-
-			return domainManagementList( domainName );
+			return domainManagementList( map( values( receipt.purchases )[ 0 ], 'meta' )[ 0 ] );
 		}
 
 		if ( ! selectedSiteSlug ) {


### PR DESCRIPTION
If the transaction finishes, and a new empty cart is loaded we redirect based on the saved previous cart, which can happen if the transaction takes too long for a domain-only purchase, and the purchase has a different redirect which requires the sites to be reloaded, as the newly purchased domain is the site slug.

It's also possible for the `cartItems` to be empty, although the cart has the proper flag. In that case, use `previousCart` to get the domain registration meta.

Dependency: D4340-code

### Review

* [x] Code
* [x] Product