### PR TITLE
Reader: Add ABTest for search on following

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -413,6 +413,7 @@
 @import 'post-editor/editor-word-count/style';
 @import 'post-editor/media-modal/style';
 @import 'reader/discover/style';
+@import 'reader/following/style';
 @import 'reader/following-edit/style';
 @import 'reader/stream/style';
 @import 'reader/list-gap/style';

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -166,6 +166,7 @@ module.exports = {
 			hide: 50
 		},
 		defaultVariation: 'hide',
-		allowExistingUsers: true
+		allowExistingUsers: true,
+		allowAnyLocale: true
 	}
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -157,5 +157,15 @@ module.exports = {
 		},
 		defaultVariation: 'disabled',
 		allowExistingUsers: true
+	},
+
+	readerSearchOnFollowing: {
+		datestamp: '20170206',
+		variations: {
+			show: 50,
+			hide: 50
+		},
+		defaultVariation: 'hide',
+		allowExistingUsers: true
 	}
 };

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -44,7 +44,7 @@ const FollowingStream = ( props ) => {
 						onSearch={ handleSearch }
 						autoFocus={ false }
 						delaySearch={ true }
-						delayTimeout={ 1000 }
+						delayTimeout={ 500 }
 						placeholder={ props.translate( 'Search billions of WordPress.com posts…' ) } />
 				</CompactCard>
 			}

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -22,7 +22,7 @@ function handleSearch( query ) {
 	recordTrack( 'calypso_reader_search_from_following', {
 		query
 	} );
-	page( '/read/search?q=' + encodeURIComponent( query ) );
+	page( '/read/search?q=' + encodeURIComponent( query ) + '&focus=1' );
 }
 
 const shouldShowSearchOnFollowing = getABTestVariation( 'readerSearchOnFollowing' ) === 'show';

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -34,7 +34,7 @@ const FollowingStream = ( props ) => {
 	if ( suggestions[ lang ] ) {
 		const pickedSuggestions = sampleSize( suggestions[ lang ], 3 );
 		suggestionList = initial( flatMap( pickedSuggestions, query =>
-			[ <Suggestion suggestion={ query } />, ', ' ] ) );
+			[ <Suggestion suggestion={ query } source="following" />, ', ' ] ) );
 	}
 	return (
 		<Stream { ...props }>

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -2,16 +2,45 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
+import page from 'page';
 
 /**
  * Internal dependencies
  */
 import Stream from 'reader/stream';
+import CompactCard from 'components/card/compact';
+import SearchInput from 'components/search';
+import { recordTrack } from 'reader/stats';
+import { getABTestVariation } from 'lib/abtest';
+
+function handleSearch( query ) {
+	recordTrack( 'calypso_reader_search_from_following', {
+		query
+	} );
+	page( '/read/search?q=' + encodeURIComponent( query ) );
+}
+
+const shouldShowSearchOnFollowing = getABTestVariation( 'readerSearchOnFollowing' ) === 'show';
 
 const FollowingStream = ( props ) => {
 	return (
-		<Stream { ...props } />
+		<Stream { ...props }>
+			{ shouldShowSearchOnFollowing &&
+				<CompactCard className="following__search">
+					<SearchInput
+						onSearch={ handleSearch }
+						autoFocus={ false }
+						delaySearch={ true }
+						delayTimeout={ 2000 }
+						placeholder={ props.translate( 'Search billions of WordPress.com posts…' ) } />
+				</CompactCard>
+			}
+			{ shouldShowSearchOnFollowing &&
+				<hr className="search-stream__fixed-area-separator" />
+			}
+		</Stream>
 	);
 };
 
-export default FollowingStream;
+export default localize( FollowingStream );

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -5,4 +5,5 @@
 .following__search.card.is-compact {
 	padding: 0;
 	margin-bottom: 16px;
+	box-shadow: 0 0 0 2px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
 }

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -1,0 +1,7 @@
+.following .search {
+	margin-bottom: 0;
+}
+
+.following__search.card.is-compact {
+	padding: 0;
+}

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -4,4 +4,5 @@
 
 .following__search.card.is-compact {
 	padding: 0;
+	margin-bottom: 16px;
 }

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -203,7 +203,7 @@ class SearchStream extends Component {
 		}
 
 		const sugList = initial( flatMap( this.state.suggestions, query =>
-			[ <Suggestion suggestion={ query } />, ', ' ] ) );
+			[ <Suggestion suggestion={ query } source="search" />, ', ' ] ) );
 
 		const documentTitle = this.props.translate(
 			'%s ‹ Reader', { args: this.state.title || this.props.translate( 'Search' ) }

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -225,7 +225,7 @@ class SearchStream extends Component {
 							initialValue={ this.props.query }
 							onSearch={ this.updateQuery }
 							onSearchClose={ this.scrollToTop }
-							autoFocus={ ! this.props.query }
+							autoFocus={ this.props.autoFocusInput }
 							delaySearch={ true }
 							delayTimeout={ 500 }
 							placeholder={ searchPlaceholderText } />

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -29,7 +29,7 @@
 	background-color: $white;
 	position: fixed;
 	top: 0px;
-	padding-top: 75px;
+	padding-top: 77px;
 	z-index: 20;
 }
 

--- a/client/reader/search-stream/suggestion.jsx
+++ b/client/reader/search-stream/suggestion.jsx
@@ -8,9 +8,9 @@ import React, { PropTypes } from 'react';
  */
 import { recordTrack } from 'reader/stats';
 
-export function Suggestion( { suggestion } ) {
+export function Suggestion( { suggestion, source } ) {
 	const handleSuggestionClick = () => {
-		recordTrack( 'calypso_reader_search_suggestion_click', { suggestion } );
+		recordTrack( 'calypso_reader_search_suggestion_click', { suggestion, source } );
 	};
 
 	return (

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -41,6 +41,8 @@ export default {
 			recordTrack( 'calypso_reader_search_loaded' );
 		}
 
+		const autoFocusInput = ( ! searchSlug ) || context.query.focus === '1';
+
 		renderWithReduxStore(
 			React.createElement( SearchStream, {
 				key: 'search',
@@ -56,6 +58,7 @@ export default {
 				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
 				showBack: false,
 				showPrimaryFollowButtonOnCards: true,
+				autoFocusInput,
 				onQueryChange: function( newValue ) {
 					let searchUrl = '/read/search';
 					if ( newValue ) {


### PR DESCRIPTION
This adds a new ABTest that shows the search box at the top of the following stream. To test it, enable the 'show' variation of the readerSearchOnFollowing abtest.