### PR TITLE
Media Section: Change the description field to a multiline input

### DIFF
--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -133,7 +133,7 @@ module.exports = React.createClass( {
 				{ this.renderImageAltText() }
 				<EditorMediaModalFieldset legend={ this.translate( 'Description' ) }>
 					<TrackInputChanges onNewValue={ this.bumpStat.bind( this, 'description' ) }>
-						<FormTextInput name="description" value={ this.getItemValue( 'description' ) } onChange={ this.onChange } />
+						<FormTextarea name="description" value={ this.getItemValue( 'description' ) } onChange={ this.onChange } />
 					</TrackInputChanges>
 				</EditorMediaModalFieldset>
 				<EditorMediaModalFieldset legend={ this.translate( 'URL' ) }>


### PR DESCRIPTION
This PR closes #10853.

**Before**

![ca225b3c-e15c-11e6-9fcc-1e59b6b039a4](https://cloud.githubusercontent.com/assets/1783033/22726422/02975fb8-eddc-11e6-9599-e0b41ef689ac.png)

**After**

![after](https://cloud.githubusercontent.com/assets/1783033/22726428/088ece24-eddc-11e6-9d01-4e885860f3b0.png)

**Testing Instructions**

1. Navigate to [/media](http://calypso.localhost:3000/media/)
2. Choose an image and click the edit icon

cc @aduth, @gwwar 