### PR TITLE
AT: show wpcom plans on plans page instead of JP plans

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -35,6 +35,7 @@ import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 
 class PlanFeaturesHeader extends Component {
 
@@ -77,14 +78,20 @@ class PlanFeaturesHeader extends Component {
 			isPlaceholder,
 			site,
 			translate,
+			isSiteAT
 		} = this.props;
+
 		const isDiscounted = !! discountPrice;
 		const timeframeClasses = classNames( 'plan-features__header-timeframe', {
 			'is-discounted': isDiscounted,
 			'is-placeholder': isPlaceholder
 		} );
 
-		if ( ! site.jetpack || this.props.planType === PLAN_JETPACK_FREE ) {
+		if (
+			isSiteAT ||
+			! site.jetpack ||
+			this.props.planType === PLAN_JETPACK_FREE
+		) {
 			return (
 				<p className={ timeframeClasses }>
 					{ ! isPlaceholder ? billingTimeFrame : '' }
@@ -232,7 +239,8 @@ PlanFeaturesHeader.propTypes = {
 	site: PropTypes.object,
 	isInJetpackConnect: PropTypes.bool,
 	currentSitePlan: PropTypes.object,
-	relatedMonthlyPlan: PropTypes.object
+	relatedMonthlyPlan: PropTypes.object,
+	isSiteAT: PropTypes.bool
 };
 
 PlanFeaturesHeader.defaultProps = {
@@ -244,7 +252,8 @@ PlanFeaturesHeader.defaultProps = {
 	intervalType: 'yearly',
 	site: {},
 	basePlansPath: null,
-	currentSitePlan: {}
+	currentSitePlan: {},
+	isSiteAT: false
 };
 
 export default connect( ( state, ownProps ) => {
@@ -254,6 +263,9 @@ export default connect( ( state, ownProps ) => {
 
 	return Object.assign( {},
 		ownProps,
-		{ currentSitePlan }
+		{
+			currentSitePlan,
+			isSiteAT: isSiteAutomatedTransfer( state, selectedSiteId )
+		}
 	);
 } )( localize( PlanFeaturesHeader ) );

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -28,11 +28,6 @@ import { isEnabled } from 'config';
 import purchasesPaths from 'me/purchases/paths';
 
 class PlansFeaturesMain extends Component {
-
-	isJetpackSite( site, isSiteAutomatedTransfer ) {
-		return ! isSiteAutomatedTransfer && site.jetpack;
-	}
-
 	getPlanFeatures() {
 		const {
 			site,
@@ -43,11 +38,11 @@ class PlansFeaturesMain extends Component {
 			isLandingPage,
 			basePlansPath,
 			selectedFeature,
-			isSiteAutomatedTransfer
+			displayJetpackPlans
 		} = this.props;
 
 		const isPersonalPlanEnabled = isEnabled( 'plans/personal-plan' );
-		if ( this.isJetpackSite( site, isSiteAutomatedTransfer ) && intervalType === 'monthly' ) {
+		if ( displayJetpackPlans && intervalType === 'monthly' ) {
 			const jetpackPlans = [ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL_MONTHLY, PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_BUSINESS_MONTHLY ];
 			if ( hideFreePlan ) {
 				jetpackPlans.shift();
@@ -68,7 +63,7 @@ class PlansFeaturesMain extends Component {
 			);
 		}
 
-		if ( this.isJetpackSite( site, isSiteAutomatedTransfer ) ) {
+		if ( displayJetpackPlans ) {
 			const jetpackPlans = [ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PREMIUM, PLAN_JETPACK_BUSINESS ];
 			if ( hideFreePlan ) {
 				jetpackPlans.shift();
@@ -320,11 +315,11 @@ class PlansFeaturesMain extends Component {
 		const {
 			site,
 			showFAQ,
-			isSiteAutomatedTransfer
+			displayJetpackPlans
 		} = this.props;
 
 		const renderFAQ = () =>
-			this.isJetpackSite( site, isSiteAutomatedTransfer )
+			displayJetpackPlans
 				? this.getJetpackFAQ()
 				: this.getFAQ( site );
 
@@ -352,7 +347,7 @@ PlansFeaturesMain.PropTypes = {
 	hideFreePlan: PropTypes.bool,
 	showFAQ: PropTypes.bool,
 	selectedFeature: PropTypes.string,
-	isSiteAutomatedTransfer: PropTypes.bool
+	displayJetpackPlans: PropTypes.bool
 };
 
 PlansFeaturesMain.defaultProps = {
@@ -361,7 +356,7 @@ PlansFeaturesMain.defaultProps = {
 	hideFreePlan: false,
 	site: {},
 	showFAQ: true,
-	isSiteAutomatedTransfer: false
+	displayJetpackPlans: false
 };
 
 export default localize( PlansFeaturesMain );

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -29,8 +29,8 @@ import purchasesPaths from 'me/purchases/paths';
 
 class PlansFeaturesMain extends Component {
 
-	isJetpackSite( site ) {
-		return site.jetpack;
+	isJetpackSite( site, isSiteAutomatedTransfer ) {
+		return ! isSiteAutomatedTransfer && site.jetpack;
 	}
 
 	getPlanFeatures() {
@@ -42,11 +42,12 @@ class PlansFeaturesMain extends Component {
 			isInSignup,
 			isLandingPage,
 			basePlansPath,
-			selectedFeature
+			selectedFeature,
+			isSiteAutomatedTransfer
 		} = this.props;
 
 		const isPersonalPlanEnabled = isEnabled( 'plans/personal-plan' );
-		if ( this.isJetpackSite( site ) && intervalType === 'monthly' ) {
+		if ( this.isJetpackSite( site, isSiteAutomatedTransfer ) && intervalType === 'monthly' ) {
 			const jetpackPlans = [ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL_MONTHLY, PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_BUSINESS_MONTHLY ];
 			if ( hideFreePlan ) {
 				jetpackPlans.shift();
@@ -67,7 +68,7 @@ class PlansFeaturesMain extends Component {
 			);
 		}
 
-		if ( this.isJetpackSite( site ) ) {
+		if ( this.isJetpackSite( site, isSiteAutomatedTransfer ) ) {
 			const jetpackPlans = [ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PREMIUM, PLAN_JETPACK_BUSINESS ];
 			if ( hideFreePlan ) {
 				jetpackPlans.shift();
@@ -316,9 +317,14 @@ class PlansFeaturesMain extends Component {
 	}
 
 	render() {
-		const { site, showFAQ } = this.props;
+		const {
+			site,
+			showFAQ,
+			isSiteAutomatedTransfer
+		} = this.props;
+
 		const renderFAQ = () =>
-			this.isJetpackSite( site )
+			this.isJetpackSite( site, isSiteAutomatedTransfer )
 				? this.getJetpackFAQ()
 				: this.getFAQ( site );
 
@@ -345,7 +351,8 @@ PlansFeaturesMain.PropTypes = {
 	onUpgradeClick: PropTypes.func,
 	hideFreePlan: PropTypes.bool,
 	showFAQ: PropTypes.bool,
-	selectedFeature: PropTypes.string
+	selectedFeature: PropTypes.string,
+	isSiteAutomatedTransfer: PropTypes.bool
 };
 
 PlansFeaturesMain.defaultProps = {
@@ -353,7 +360,8 @@ PlansFeaturesMain.defaultProps = {
 	intervalType: 'yearly',
 	hideFreePlan: false,
 	site: {},
-	showFAQ: true
+	showFAQ: true,
+	isSiteAutomatedTransfer: false
 };
 
 export default localize( PlansFeaturesMain );

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -19,6 +19,7 @@ import TrackComponentView from 'lib/analytics/track-component-view';
 import UpgradesNavigation from 'my-sites/upgrades/navigation';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
+import isSiteAutomatedTransferSelector from 'state/selectors/is-site-automated-transfer';
 
 const Plans = React.createClass( {
 	propTypes: {
@@ -27,12 +28,14 @@ const Plans = React.createClass( {
 		intervalType: React.PropTypes.string,
 		plans: React.PropTypes.array.isRequired,
 		selectedSite: React.PropTypes.object,
-		selectedSiteId: React.PropTypes.number
+		selectedSiteId: React.PropTypes.number,
+		isSiteAutomatedTransfer: React.PropTypes.bool
 	},
 
 	getDefaultProps() {
 		return {
-			intervalType: 'yearly'
+			intervalType: 'yearly',
+			isSiteAutomatedTransfer: false
 		};
 	},
 
@@ -58,7 +61,12 @@ const Plans = React.createClass( {
 	},
 
 	render() {
-		const { selectedSite, selectedSiteId, translate } = this.props;
+		const {
+			selectedSite,
+			selectedSiteId,
+			translate,
+			isSiteAutomatedTransfer
+		} = this.props;
 
 		if ( this.props.isPlaceholder ) {
 			return this.renderPlaceholder();
@@ -86,6 +94,7 @@ const Plans = React.createClass( {
 							intervalType={ this.props.intervalType }
 							hideFreePlan={ true }
 							selectedFeature={ this.props.selectedFeature }
+							isSiteAutomatedTransfer={ isSiteAutomatedTransfer }
 						/>
 					</div>
 				</Main>
@@ -98,11 +107,13 @@ export default connect(
 	( state ) => {
 		const selectedSiteId = getSelectedSiteId( state );
 		const isPlaceholder = ! selectedSiteId;
+
 		return {
 			isPlaceholder,
 			plans: getPlans( state ),
 			selectedSite: getSelectedSite( state ),
-			selectedSiteId: selectedSiteId
+			selectedSiteId: selectedSiteId,
+			isSiteAutomatedTransfer: isSiteAutomatedTransferSelector( state, selectedSiteId )
 		};
 	}
 )( localize( Plans ) );

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -20,6 +20,7 @@ import UpgradesNavigation from 'my-sites/upgrades/navigation';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import isSiteAutomatedTransferSelector from 'state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'state/sites/selectors';
 
 const Plans = React.createClass( {
 	propTypes: {
@@ -29,13 +30,13 @@ const Plans = React.createClass( {
 		plans: React.PropTypes.array.isRequired,
 		selectedSite: React.PropTypes.object,
 		selectedSiteId: React.PropTypes.number,
-		isSiteAutomatedTransfer: React.PropTypes.bool
+		displayJetpackPlans: React.PropTypes.bool
 	},
 
 	getDefaultProps() {
 		return {
 			intervalType: 'yearly',
-			isSiteAutomatedTransfer: false
+			displayJetpackPlans: false
 		};
 	},
 
@@ -65,7 +66,7 @@ const Plans = React.createClass( {
 			selectedSite,
 			selectedSiteId,
 			translate,
-			isSiteAutomatedTransfer
+			displayJetpackPlans
 		} = this.props;
 
 		if ( this.props.isPlaceholder ) {
@@ -94,7 +95,7 @@ const Plans = React.createClass( {
 							intervalType={ this.props.intervalType }
 							hideFreePlan={ true }
 							selectedFeature={ this.props.selectedFeature }
-							isSiteAutomatedTransfer={ isSiteAutomatedTransfer }
+							displayJetpackPlans={ displayJetpackPlans }
 						/>
 					</div>
 				</Main>
@@ -108,12 +109,15 @@ export default connect(
 		const selectedSiteId = getSelectedSiteId( state );
 		const isPlaceholder = ! selectedSiteId;
 
+		const jetpackSite = isJetpackSite( state, selectedSiteId );
+		const isSiteAutomatedTransfer = isSiteAutomatedTransferSelector( state, selectedSiteId );
+
 		return {
 			isPlaceholder,
 			plans: getPlans( state ),
 			selectedSite: getSelectedSite( state ),
 			selectedSiteId: selectedSiteId,
-			isSiteAutomatedTransfer: isSiteAutomatedTransferSelector( state, selectedSiteId )
+			displayJetpackPlans: ! isSiteAutomatedTransfer && jetpackSite
 		};
 	}
 )( localize( Plans ) );


### PR DESCRIPTION
Originally reported by @alisterscott:

> My Plan shows ‘Business’ plan, but the next tab ‘plans’ shows Jetpack Plans so ‘Professional’ is listed (not business) (AT Site Bugs) 

This PR fixes the above, showing WP.com plans on the `/plans` page instead of Jetpack plans for AT sites.

## Testing instructions

1. With an AT site, navigate to `/plans/<site>` and verify that you see WP.com plans;
2. Click on the "My Plan" nav item and then back on the "Plans" nav item -- do you still see WP.com plans?

Note: the second point in testing instructions won't work until we add the `is_automated_transfer` option to the `/sites/<site>` endpoint as well. /cc @artpi 

