### PR TITLE
Checkout: Fix wrong page displayed at the end of domain-only signup flow

### DIFF
--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { flatten, find, isEmpty, isEqual, reduce, startsWith } from 'lodash';
+import { flatten, find, includes, isEmpty, isEqual, reduce, startsWith } from 'lodash';
 import i18n from 'i18n-calypso';
 import page from 'page';
 import React from 'react';
@@ -151,7 +151,7 @@ const Checkout = React.createClass( {
 			return false;
 		}
 
-		if ( this.props.transaction.step.name === transactionStepTypes.SUBMITTING_WPCOM_REQUEST ) {
+		if ( includes( [ transactionStepTypes.SUBMITTING_WPCOM_REQUEST, transactionStepTypes.RECEIVED_WPCOM_RESPONSE ], this.props.transaction.step.name ) ) {
 			return false;
 		}
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -22,7 +22,7 @@
       "version": "3.1.0",
       "dependencies": {
         "acorn": {
-          "version": "4.0.4"
+          "version": "4.0.11"
         }
       }
     },
@@ -31,7 +31,7 @@
       "dev": true
     },
     "after": {
-      "version": "0.8.2"
+      "version": "0.8.1"
     },
     "ajv": {
       "version": "4.11.2",
@@ -47,9 +47,6 @@
     "amdefine": {
       "version": "1.0.1"
     },
-    "ansi": {
-      "version": "0.3.1"
-    },
     "ansi-escapes": {
       "version": "1.4.0",
       "dev": true
@@ -64,7 +61,7 @@
       "version": "1.3.0"
     },
     "aproba": {
-      "version": "1.0.4"
+      "version": "1.1.0"
     },
     "are-we-there-yet": {
       "version": "1.1.2"
@@ -92,9 +89,6 @@
     },
     "array-flatten": {
       "version": "1.1.1"
-    },
-    "array-index": {
-      "version": "1.0.0"
     },
     "array-union": {
       "version": "1.0.2"
@@ -128,10 +122,10 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.9.4"
+      "version": "0.9.5"
     },
     "async": {
-      "version": "0.9.0"
+      "version": "2.1.4"
     },
     "async-each": {
       "version": "1.0.1"
@@ -155,7 +149,7 @@
       "version": "0.6.0"
     },
     "aws4": {
-      "version": "1.5.0"
+      "version": "1.6.0"
     },
     "babel-code-frame": {
       "version": "6.22.0",
@@ -439,10 +433,10 @@
       "version": "1.2.1"
     },
     "bl": {
-      "version": "1.0.3",
+      "version": "1.2.0",
       "dependencies": {
         "readable-stream": {
-          "version": "2.0.6"
+          "version": "2.2.2"
         }
       }
     },
@@ -543,7 +537,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000618"
+      "version": "1.0.30000622"
     },
     "caseless": {
       "version": "0.11.0"
@@ -863,7 +857,8 @@
       "version": "0.4.1"
     },
     "d": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
@@ -1019,7 +1014,8 @@
       "dev": true
     },
     "duplexer2": {
-      "version": "0.0.2"
+      "version": "0.0.2",
+      "dev": true
     },
     "duplexify": {
       "version": "3.5.0",
@@ -1113,9 +1109,6 @@
     "engine.io-parser": {
       "version": "1.2.4",
       "dependencies": {
-        "after": {
-          "version": "0.8.1"
-        },
         "has-binary": {
           "version": "0.1.6"
         },
@@ -1170,10 +1163,12 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.12"
+      "version": "0.10.12",
+      "dev": true
     },
     "es6-iterator": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "es6-map": {
       "version": "0.1.4",
@@ -1184,7 +1179,8 @@
       "dev": true
     },
     "es6-symbol": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "dev": true
     },
     "es6-templates": {
       "version": "0.2.3"
@@ -1353,7 +1349,7 @@
       "version": "1.0.1"
     },
     "espree": {
-      "version": "3.3.2",
+      "version": "3.4.0",
       "dev": true,
       "dependencies": {
         "acorn": {
@@ -1415,9 +1411,6 @@
     "execall": {
       "version": "1.0.0",
       "dev": true
-    },
-    "execspawn": {
-      "version": "1.0.1"
     },
     "exenv": {
       "version": "1.2.0"
@@ -1628,12 +1621,7 @@
       "version": "1.0.0"
     },
     "gauge": {
-      "version": "2.7.2",
-      "dependencies": {
-        "supports-color": {
-          "version": "0.2.0"
-        }
-      }
+      "version": "2.7.3"
     },
     "gaze": {
       "version": "1.1.2"
@@ -1666,15 +1654,6 @@
           "version": "1.0.0"
         }
       }
-    },
-    "ghreleases": {
-      "version": "1.0.5"
-    },
-    "ghrepos": {
-      "version": "2.0.0"
-    },
-    "ghutils": {
-      "version": "3.2.1"
     },
     "github-from-package": {
       "version": "0.0.0"
@@ -1818,7 +1797,7 @@
       "version": "1.0.0"
     },
     "hosted-git-info": {
-      "version": "2.1.5"
+      "version": "2.2.0"
     },
     "html": {
       "version": "1.0.0",
@@ -1879,9 +1858,6 @@
     },
     "https-browserify": {
       "version": "0.0.0"
-    },
-    "hyperquest": {
-      "version": "1.2.0"
     },
     "i18n-calypso": {
       "version": "1.7.0",
@@ -2204,14 +2180,8 @@
       "version": "3.0.1"
     },
     "js-yaml": {
-      "version": "3.7.0",
-      "dev": true,
-      "dependencies": {
-        "esprima": {
-          "version": "2.7.3",
-          "dev": true
-        }
-      }
+      "version": "3.8.1",
+      "dev": true
     },
     "jsdom": {
       "version": "9.4.1",
@@ -2269,9 +2239,6 @@
       "version": "0.0.0",
       "dev": true
     },
-    "jsonist": {
-      "version": "1.3.0"
-    },
     "jsonparse": {
       "version": "0.0.5",
       "dev": true
@@ -2304,7 +2271,7 @@
       "version": "0.0.3"
     },
     "jsx-ast-utils": {
-      "version": "1.3.5",
+      "version": "1.4.0",
       "dev": true
     },
     "key-mirror": {
@@ -2334,7 +2301,7 @@
       "dev": true
     },
     "level": {
-      "version": "1.5.0"
+      "version": "1.6.0"
     },
     "level-codec": {
       "version": "6.1.0"
@@ -2349,7 +2316,7 @@
       "version": "1.2.1"
     },
     "leveldown": {
-      "version": "1.5.3",
+      "version": "1.6.0",
       "dependencies": {
         "abstract-leveldown": {
           "version": "2.6.1"
@@ -2437,15 +2404,6 @@
     },
     "lodash.omit": {
       "version": "4.5.0"
-    },
-    "lodash.pad": {
-      "version": "4.5.1"
-    },
-    "lodash.padend": {
-      "version": "4.6.1"
-    },
-    "lodash.padstart": {
-      "version": "4.6.1"
     },
     "lodash.pickby": {
       "version": "4.6.0",
@@ -2633,7 +2591,7 @@
       "dev": true
     },
     "nan": {
-      "version": "2.4.0"
+      "version": "2.5.1"
     },
     "natives": {
       "version": "1.1.0",
@@ -2667,7 +2625,7 @@
       }
     },
     "node-abi": {
-      "version": "1.2.1"
+      "version": "1.3.2"
     },
     "node-contains": {
       "version": "1.0.0"
@@ -2693,20 +2651,6 @@
     },
     "node-libs-browser": {
       "version": "0.6.0"
-    },
-    "node-ninja": {
-      "version": "1.0.2",
-      "dependencies": {
-        "gauge": {
-          "version": "1.2.7"
-        },
-        "minimatch": {
-          "version": "3.0.3"
-        },
-        "npmlog": {
-          "version": "2.0.4"
-        }
-      }
     },
     "node-sass": {
       "version": "3.7.0",
@@ -2914,9 +2858,6 @@
     "pascal-case": {
       "version": "1.1.2"
     },
-    "path-array": {
-      "version": "1.0.1"
-    },
     "path-browserify": {
       "version": "0.0.0"
     },
@@ -2975,7 +2916,7 @@
       "dev": true
     },
     "postcss": {
-      "version": "5.2.11",
+      "version": "5.2.12",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
@@ -3016,12 +2957,9 @@
     "postcss-value-parser": {
       "version": "3.3.0"
     },
-    "prebuild": {
-      "version": "5.1.2",
+    "prebuild-install": {
+      "version": "2.1.0",
       "dependencies": {
-        "async": {
-          "version": "2.1.4"
-        },
         "minimist": {
           "version": "1.2.0"
         }
@@ -3042,7 +2980,7 @@
       "version": "1.6.0"
     },
     "private": {
-      "version": "0.1.6"
+      "version": "0.1.7"
     },
     "process": {
       "version": "0.11.9"
@@ -3265,7 +3203,7 @@
       "dev": true
     },
     "recast": {
-      "version": "0.11.20",
+      "version": "0.11.21",
       "dependencies": {
         "source-map": {
           "version": "0.5.6"
@@ -3470,14 +3408,14 @@
       }
     },
     "sax": {
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dev": true
     },
     "seed-random": {
       "version": "2.2.0"
     },
     "select": {
-      "version": "1.1.0"
+      "version": "1.1.2"
     },
     "semver": {
       "version": "5.1.0"
@@ -3577,9 +3515,6 @@
     "simple-get": {
       "version": "1.4.3"
     },
-    "simple-mime": {
-      "version": "0.1.0"
-    },
     "sinon": {
       "version": "1.17.6",
       "dev": true
@@ -3661,7 +3596,12 @@
       "version": "0.1.39"
     },
     "source-map-loader": {
-      "version": "0.1.5"
+      "version": "0.1.5",
+      "dependencies": {
+        "async": {
+          "version": "0.9.2"
+        }
+      }
     },
     "source-map-support": {
       "version": "0.3.2",
@@ -4097,9 +4037,6 @@
         }
       }
     },
-    "url-template": {
-      "version": "2.0.8"
-    },
     "user-home": {
       "version": "1.1.1"
     },
@@ -4111,9 +4048,6 @@
     },
     "util-deprecate": {
       "version": "1.0.2"
-    },
-    "util-extend": {
-      "version": "1.0.3"
     },
     "utils-merge": {
       "version": "1.0.0"
@@ -4143,7 +4077,12 @@
       "version": "2.3.4"
     },
     "watchpack": {
-      "version": "0.2.9"
+      "version": "0.2.9",
+      "dependencies": {
+        "async": {
+          "version": "0.9.2"
+        }
+      }
     },
     "webidl-conversions": {
       "version": "3.0.1",
@@ -4177,7 +4116,7 @@
           "dev": true
         },
         "acorn": {
-          "version": "4.0.4",
+          "version": "4.0.11",
           "dev": true
         },
         "chalk": {
@@ -4284,6 +4223,10 @@
       "dependencies": {
         "accepts": {
           "version": "1.3.3",
+          "dev": true
+        },
+        "after": {
+          "version": "0.8.2",
           "dev": true
         },
         "base64-arraybuffer": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "async": "0.9.0",
+    "async": "2.1.4",
     "atob": "1.1.2",
     "autoprefixer": "6.3.5",
     "autosize": "3.0.15",


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/wp-calypso/issues/11199.
 
#### Testing instructions
 
1. Run `git checkout fix/domain-only-redirect` and start your server, or open a [live branch](https://calypso.live/?branch=fix/domain-only-redirect)
2. Open the new [`Signup` page](http://calypso.localhost:3000/start/domain-first) in incognito mode
3. Proceed to the `Contact Information` page
4. Use administration tools to add free credits to the new user account
5. Proceed and purchase the domain with the credits
 
#### Reviews
 
- [ ] Code
- [ ] Product