### PR TITLE
Update number of themes placeholders.

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -99,7 +99,7 @@ export const ThemesList = React.createClass( {
 
 	// Invisible trailing items keep all elements same width in flexbox grid.
 	renderTrailingItems() {
-		const NUM_SPACERS = 8; // gives enough spacers for a theoretical 9 column layout
+		const NUM_SPACERS = 11; // gives enough spacers for a theoretical 12 column layout
 		return times( NUM_SPACERS, function( i ) {
 			return <div className="themes-list--spacer" key={ 'themes-list--spacer-' + i } />;
 		} );


### PR DESCRIPTION
### Info
Trailing theme displayed by `ThemesList` was different size then the other themes. This is not really a fix but just temporary patch. Real solution is needed to cover for more scenarios of even wider screens, but it will require longer investigation.

### Before
![image](https://cloud.githubusercontent.com/assets/17271089/22743747/730b7a9c-ee1b-11e6-9844-698ffd9c3cb9.png)

### After
![image](https://cloud.githubusercontent.com/assets/17271089/22743724/6044bff4-ee1b-11e6-80d6-1a9e150ba843.png)

### Testing
You need to check that for any "resonable" number of themes and screen width no theme will be of a wrong size. Probably the easiest way to check this is to have jetpack site with only one theme and then slowly start to make window wider and wider to the point where theme in the top list will have different size then themes in bottom list.