### PR TITLE
Editor: extend copy feature to more post and page statuses

### DIFF
--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -8,6 +8,7 @@ var React = require( 'react' ),
 
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -267,7 +268,10 @@ const Page = React.createClass( {
 
 	getCopyItem: function() {
 		const { page: post, site } = this.props;
-		if ( ( 'publish' !== post.status && 'private' !== post.status ) || ! utils.userCan( 'edit_post', post ) ) {
+		if (
+			! includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], post.status ) ||
+			! utils.userCan( 'edit_post', post )
+		) {
 			return null;
 		}
 		return (

--- a/client/my-sites/posts/post-controls.jsx
+++ b/client/my-sites/posts/post-controls.jsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import url from 'url';
 import classNames from 'classnames';
-import { noop } from 'lodash';
+import { includes, noop } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
@@ -131,7 +131,10 @@ const getAvailableControls = props => {
 		}
 	}
 
-	if ( ( 'publish' === post.status || 'private' === post.status ) && userCan( 'edit_post', post ) ) {
+	if (
+		includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], post.status ) &&
+		userCan( 'edit_post', post )
+	) {
 		controls.main.push( {
 			className: 'copy',
 			href: `/post/${ site.slug }?copy=${ post.ID }`,

--- a/client/post-editor/editor-more-options/copy-post.jsx
+++ b/client/post-editor/editor-more-options/copy-post.jsx
@@ -117,6 +117,7 @@ class EditorMoreOptionsCopyPost extends Component {
 							orderBy="date"
 							selected={ selectedPostId }
 							siteId={ siteId }
+							status="draft,future,pending,private,publish"
 							type={ type }
 						/>
 					}


### PR DESCRIPTION
Extends the Copy feature introduced in https://github.com/Automattic/wp-calypso/pull/7451 to `draft`, `future`, `pending`, `private`, and `publish` statuses.
Previously it was only enabled on `private` and `publish`.