### PR TITLE
Fix lint warnings about invalid classname.

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -90,7 +90,7 @@ export const ThemesList = React.createClass( {
 	renderTrailingItems() {
 		const NUM_SPACERS = 11; // gives enough spacers for a theoretical 12 column layout
 		return times( NUM_SPACERS, function( i ) {
-			return <div className="themes-list--spacer" key={ 'themes-list--spacer-' + i } />;
+			return <div className="themes-list__spacer" key={ 'themes-list__spacer-' + i } />;
 		} );
 	},
 

--- a/client/components/themes-list/style.scss
+++ b/client/components/themes-list/style.scss
@@ -11,7 +11,7 @@
 	}
 }
 
-.themes-list--spacer {
+.themes-list__spacer {
 	width: 230px;
 	height: 0px;
 	margin: 0 10px;


### PR DESCRIPTION
This pull request fixes a lint warning about a classname that doesn't fit within our coding guidelines

I noticed this while peeking at #11257