### PR TITLE
Contact: Add scaffolding for Directly implementation

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -45,6 +45,7 @@ const wpcom = wpcomLib.undocumented();
 const sites = siteList();
 let savedContactForm = null;
 
+const SUPPORT_DIRECTLY = 'SUPPORT_DIRECTLY';
 const SUPPORT_HAPPYCHAT = 'SUPPORT_HAPPYCHAT';
 const SUPPORT_LIVECHAT = 'SUPPORT_LIVECHAT';
 const SUPPORT_TICKET = 'SUPPORT_TICKET';
@@ -162,6 +163,12 @@ const HelpContact = React.createClass( {
 		this.sendMessageToOperator( message );
 
 		this.clearSavedContactForm();
+	},
+
+	submitDirectlyQuestion: function( contactForm ) {
+		// TODO: open Directly form here
+
+		return contactForm; // TODO: Remove this line once functionality is implemented
 	},
 
 	submitKayakoTicket: function( contactForm ) {
@@ -420,6 +427,11 @@ const HelpContact = React.createClass( {
 		return isHappychatAvailable && olark.isUserEligible;
 	},
 
+	shouldUseDirectly: function() {
+		const isEn = this.props.currentUserLocale === 'en';
+		return config.isEnabled( 'help/directly' ) && isEn;
+	},
+
 	canShowChatbox: function() {
 		const { olark, isChatEnded } = this.state;
 		return isChatEnded || ( olark.details.isConversing && olark.isOperatorAvailable );
@@ -439,6 +451,10 @@ const HelpContact = React.createClass( {
 
 		if ( olark.details.isConversing || ticketSupportEligible ) {
 			return SUPPORT_TICKET;
+		}
+
+		if ( this.shouldUseDirectly() ) {
+			return SUPPORT_DIRECTLY;
 		}
 
 		return SUPPORT_FORUM;
@@ -478,6 +494,27 @@ const HelpContact = React.createClass( {
 					showSubjectField: true,
 					showHowCanWeHelpField: true,
 					showHowYouFeelField: true,
+					showSiteField: hasMoreThanOneSite,
+				};
+
+			case SUPPORT_DIRECTLY:
+				return {
+					onSubmit: this.submitDirectlyQuestion,
+					buttonLabel: translate( 'Ask an Expert' ),
+					formDescription: translate(
+						'Chat with an {{strong}}Expert User{{/strong}} of WordPress.com. ' +
+						'These are other users, like yourself, that have been selected ' +
+						'because of their knowledge to help answer your questions. ' +
+						'{{strong}}Please do not{{/strong}} provide financial or ' +
+						'contact information when submitting this form.',
+						{
+							components: {
+								strong: <strong />
+							}
+						} ),
+					showSubjectField: false,
+					showHowCanWeHelpField: false,
+					showHowYouFeelField: false,
 					showSiteField: hasMoreThanOneSite,
 				};
 

--- a/config/development.json
+++ b/config/development.json
@@ -46,6 +46,7 @@
 		"guided-tours/theme-sheet-welcome": true,
 		"help": true,
 		"help/courses": true,
+		"help/directly": true,
 		"jetpack/connect": true,
 		"jetpack/invites": true,
 		"jetpack/personalPlan": true,


### PR DESCRIPTION
We're starting a trial with [Directly](https://www.directly.com/) to handle support for unpaid customers. This is a small PR that builds scaffolding for the Directly widget integration. It's hidden behind a feature flag and only available on dev/staging environments.

#### To review manually
Sign in to an account that has no paid upgrades. Go to [http://calypso.localhost:3000/help/contact](http://calypso.localhost:3000/help/contact). If your locale is English you should see the following form:

<img width="748" alt="screen shot 2017-02-08 at 11 23 05 am" src="https://cloud.githubusercontent.com/assets/518059/22749053/a6a341de-edf1-11e6-8f76-8fdb0ea78461.png">

Submitting the form will do nothing (yet!).

If your locale is _not_ English, you should see the standard Forum message form.