### PR TITLE
Media: Fix media modal bug

### DIFF
--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -289,7 +289,7 @@ export class EditorMediaModal extends Component {
 		this.props.onClose();
 	};
 
-	editItem( item ) {
+	editItem = item => {
 		const { site, mediaLibrarySelectedItems, single } = this.props;
 		if ( ! site ) {
 			return;
@@ -313,7 +313,7 @@ export class EditorMediaModal extends Component {
 		analytics.ga.recordEvent( 'Media', 'Clicked Contextual Edit Button' );
 
 		this.props.setView( ModalViews.DETAIL );
-	}
+	};
 
 	getFirstEnabledFilter() {
 		if ( this.props.enabledFilters ) {


### PR DESCRIPTION
This bug happens when the `pencil` button is clicked. It was introduced in https://github.com/Automattic/wp-calypso/pull/11226 PR.

<img src="https://cloud.githubusercontent.com/assets/77539/22752506/87d86ad8-ee17-11e6-8cce-151d16c14bcd.gif" width="500px" />

Also, I've renamed the methods tied to the Component events trying to be more clear in what the event/method is doing.

### Testing

Try to edit a media item from the media gallery clicking on the `pencil` button. The media item edition dialog should be opened.