### PR TITLE
wpcom: restore timezones() undocumented method

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -48,6 +48,16 @@ function Undocumented( wpcom ) {
 	this.wpcom = wpcom;
 }
 
+Undocumented.prototype.timezones = function( params, fn ) {
+	if ( typeof params === 'function' ) {
+		fn = params;
+		params = {};
+	}
+
+	let query = Object.assign( {}, params, { apiNamespace: 'wpcom/v2' } );
+	return this.wpcom.req.get( '/timezones', query, fn );
+};
+
 Undocumented.prototype.site = function( id ) {
 	return new Site( id, this.wpcom );
 };


### PR DESCRIPTION
This method is still being used by site settings page. We will have other improvements before to remove it definitely.

### Testing

The site settings page should be available: http://calypso.localhost:3000/settings/general/<your-testing-blog>
