### PR TITLE
Sharing: Prepare Service module for Redux switch

### DIFF
--- a/client/my-sites/sharing/connections/service-connected-accounts.jsx
+++ b/client/my-sites/sharing/connections/service-connected-accounts.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
-import { connect } from 'react-redux';
 import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
@@ -10,44 +9,29 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
-import { recordGoogleEvent } from 'state/analytics/actions';
 
-const SharingServiceConnectedAccounts = ( { children, onAddConnection, recordEvent, service, translate } ) => {
-	const connectAnother = () => {
-		onAddConnection( service );
-		recordEvent( 'Sharing', 'Clicked Connect Another Account Button', service.ID );
-	};
-
-	return (
-		<div className="sharing-service-accounts-detail">
-			<ul className="sharing-service-connected-accounts">
-				{ children }
-			</ul>
-			{ 'publicize' === service.type && (
-				<Button onClick={ connectAnother }>
-					{ translate( 'Connect a different account', { comment: 'Sharing: Publicize connections' } ) }
-				</Button>
-			) }
-		</div>
-	);
-};
+const SharingServiceConnectedAccounts = ( { children, connect, service, translate } ) => (
+	<div className="sharing-service-accounts-detail">
+		<ul className="sharing-service-connected-accounts">
+			{ children }
+		</ul>
+		{ 'publicize' === service.type && (
+			<Button onClick={ connect }>
+				{ translate( 'Connect a different account', { comment: 'Sharing: Publicize connections' } ) }
+			</Button>
+		) }
+	</div>
+);
 
 SharingServiceConnectedAccounts.propTypes = {
-	onAddConnection: PropTypes.func,      // Handler to invoke when adding a new connection
-	recordEvent: PropTypes.func,          // Redux action to track an event
+	connect: PropTypes.func,              // Handler to invoke when adding a new connection
 	service: PropTypes.object.isRequired, // The service object
 	translate: PropTypes.func,
 };
 
 SharingServiceConnectedAccounts.defaultProps = {
-	onAddConnection: () => {},
-	recordEvent: () => {},
+	connect: () => {},
 	translate: identity,
 };
 
-export default connect(
-	null,
-	{
-		recordEvent: recordGoogleEvent,
-	},
-)( localize( SharingServiceConnectedAccounts ) );
+export default localize( SharingServiceConnectedAccounts );

--- a/client/my-sites/sharing/connections/service-connected-accounts.jsx
+++ b/client/my-sites/sharing/connections/service-connected-accounts.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -9,79 +9,44 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Connection from './connection';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
-class SharingServiceConnectedAccounts extends Component {
-	static propTypes = {
-		connections: PropTypes.array,               // Set of connections for the service
-		isDisconnecting: PropTypes.bool,            // Whether a disconnect request is pending
-		isRefreshing: PropTypes.bool,               // Whether a connection refresh is pending
-		onAddConnection: PropTypes.func,            // Handler to invoke when adding a new connection
-		onRefreshConnection: PropTypes.func,        // Handler to invoke when refreshing a connection
-		onRemoveConnection: PropTypes.func,         // Handler to invoke when removing an existing connection
-		onToggleSitewideConnection: PropTypes.func, // Handler to invoke when toggling a connection to be shared sitewide
-		recordGoogleEvent: PropTypes.func,          // Redux action to track an event
-		service: PropTypes.object.isRequired,       // The service object
-		translate: PropTypes.func,
+const SharingServiceConnectedAccounts = ( { children, onAddConnection, recordEvent, service, translate } ) => {
+	const connectAnother = () => {
+		onAddConnection( service );
+		recordEvent( 'Sharing', 'Clicked Connect Another Account Button', service.ID );
 	};
 
-	static defaultProps = {
-		connections: Object.freeze( [] ),
-		isDisconnecting: false,
-		isRefreshing: false,
-		onAddConnection: () => {},
-		onRefreshConnection: () => {},
-		onRemoveConnection: () => {},
-		onToggleSitewideConnection: () => {},
-		translate: identity,
-	};
-
-	connectAnother = () => {
-		this.props.onAddConnection();
-		this.props.recordGoogleEvent( 'Sharing', 'Clicked Connect Another Account Button', this.props.service.ID );
-	};
-
-	getConnectionElements() {
-		return this.props.connections.map( ( connection ) =>
-			<Connection
-				key={ connection.keyring_connection_ID }
-				connection={ connection }
-				isDisconnecting={ this.props.isDisconnecting }
-				isRefreshing={ this.props.isRefreshing }
-				onDisconnect={ this.props.onRemoveConnection }
-				onRefresh={ this.props.onRefreshConnection }
-				onToggleSitewideConnection={ this.props.onToggleSitewideConnection }
-				service={ this.props.service }
-				showDisconnect={ this.props.connections.length > 1 || 'broken' === connection.status } />
-		);
-	}
-
-	getConnectAnotherElement() {
-		if ( 'publicize' === this.props.service.type ) {
-			return (
-				<a onClick={ this.connectAnother } className="button new-account">
-					{ this.props.translate( 'Connect a different account', { comment: 'Sharing: Publicize connections' } ) }
+	return (
+		<div className="sharing-service-accounts-detail">
+			<ul className="sharing-service-connected-accounts">
+				{ children }
+			</ul>
+			{ 'publicize' === service.type && (
+				<a onClick={ connectAnother } className="button new-account">
+					{ translate( 'Connect a different account', { comment: 'Sharing: Publicize connections' } ) }
 				</a>
-			);
-		}
-	}
+			) }
+		</div>
+	);
+};
 
-	render() {
-		return (
-			<div className="sharing-service-accounts-detail">
-				<ul className="sharing-service-connected-accounts">
-					{ this.getConnectionElements() }
-				</ul>
-				{ this.getConnectAnotherElement() }
-			</div>
-		);
-	}
-}
+SharingServiceConnectedAccounts.propTypes = {
+	onAddConnection: PropTypes.func,      // Handler to invoke when adding a new connection
+	recordEvent: PropTypes.func,          // Redux action to track an event
+	service: PropTypes.object.isRequired, // The service object
+	translate: PropTypes.func,
+};
+
+SharingServiceConnectedAccounts.defaultProps = {
+	onAddConnection: () => {},
+	recordEvent: () => {},
+	translate: identity,
+};
 
 export default connect(
 	null,
 	{
-		recordGoogleEvent,
+		recordEvent: recordGoogleEvent,
 	},
 )( localize( SharingServiceConnectedAccounts ) );

--- a/client/my-sites/sharing/connections/service-connected-accounts.jsx
+++ b/client/my-sites/sharing/connections/service-connected-accounts.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 const SharingServiceConnectedAccounts = ( { children, onAddConnection, recordEvent, service, translate } ) => {
@@ -23,9 +24,9 @@ const SharingServiceConnectedAccounts = ( { children, onAddConnection, recordEve
 				{ children }
 			</ul>
 			{ 'publicize' === service.type && (
-				<a onClick={ connectAnother } className="button new-account">
+				<Button onClick={ connectAnother }>
 					{ translate( 'Connect a different account', { comment: 'Sharing: Publicize connections' } ) }
-				</a>
+				</Button>
 			) }
 		</div>
 	);

--- a/client/my-sites/sharing/connections/service.jsx
+++ b/client/my-sites/sharing/connections/service.jsx
@@ -249,6 +249,11 @@ const SharingService = React.createClass( {
 		} ) );
 	},
 
+	connectAnother() {
+		this.props.recordGoogleEvent( 'Sharing', 'Clicked Connect Another Account Button', this.props.service.ID );
+		this.connect();
+	},
+
 	connect: function() {
 		this.setState( { isConnecting: true } );
 		this.props.connections.once( 'create:success', this.onConnectionSuccess );
@@ -308,6 +313,7 @@ const SharingService = React.createClass( {
 				isDisconnecting={ this.state.isDisconnecting }
 				removableConnections={ serviceConnections.getRemovableConnections( this.props.service.ID ) } />
 		);
+
 		return (
 			<li>
 				<AccountDialog
@@ -324,7 +330,7 @@ const SharingService = React.createClass( {
 					expandedSummary={ action } >
 					<div className={ 'sharing-service__content ' + ( serviceConnections.isFetchingAccounts() ? 'is-placeholder' : '' ) }>
 						<ServiceExamples service={ this.props.service } />
-						<ServiceConnectedAccounts onAddConnection={ this.connect } service={ this.props.service }>
+						<ServiceConnectedAccounts connect={ this.connectAnother } service={ this.props.service }>
 							{ connections.map( ( connection ) =>
 								<Connection
 									key={ connection.keyring_connection_ID }

--- a/client/my-sites/sharing/connections/service.jsx
+++ b/client/my-sites/sharing/connections/service.jsx
@@ -328,7 +328,7 @@ const SharingService = React.createClass( {
 					compact
 					summary={ action }
 					expandedSummary={ action } >
-					<div className={ 'sharing-service__content ' + ( serviceConnections.isFetchingAccounts() ? 'is-placeholder' : '' ) }>
+					<div className={ classnames( 'sharing-service__content', { 'is-placeholder': serviceConnections.isFetchingAccounts() } ) }>
 						<ServiceExamples service={ this.props.service } />
 						<ServiceConnectedAccounts connect={ this.connectAnother } service={ this.props.service }>
 							{ connections.map( ( connection ) =>

--- a/client/my-sites/sharing/connections/service.jsx
+++ b/client/my-sites/sharing/connections/service.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { identity, replace } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -11,11 +12,30 @@ import SocialLogo from 'social-logos';
  * Internal dependencies
  */
 import AccountDialog from './account-dialog';
+import {
+	createSiteConnection,
+	deleteSiteConnection,
+	failCreateConnection,
+	fetchConnection,
+	updateSiteConnection,
+} from 'state/sharing/publicize/actions';
+import { errorNotice } from 'state/notices/actions';
+import Connection from './connection';
 import FoldableCard from 'components/foldable-card';
+import { getAvailableExternalAccounts } from 'state/sharing/selectors';
+import { getCurrentUserId } from 'state/current-user/selectors';
+import { getKeyringConnectionsByName } from 'state/sharing/keyring/selectors';
+import {
+	getBrokenSiteUserConnectionsForService,
+	getRemovableConnections,
+	getSiteUserConnectionsForService,
+	isFetchingConnections,
+} from 'state/sharing/publicize/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import notices from 'notices';
 import observe from 'lib/mixins/data-observe';
 import { recordGoogleEvent } from 'state/analytics/actions';
+import { requestKeyringConnections } from 'state/sharing/keyring/actions';
 import ServiceAction from './service-action';
 import ServiceConnectedAccounts from './service-connected-accounts';
 import serviceConnections from './service-connections';
@@ -27,9 +47,22 @@ const SharingService = React.createClass( {
 	displayName: 'SharingService',
 
 	propTypes: {
+		availableExternalAccounts: PropTypes.arrayOf( PropTypes.object ),
+		brokenConnections: PropTypes.arrayOf( PropTypes.object ),
 		connections: PropTypes.object.isRequired,   // A collections-list instance
+		createSiteConnection: PropTypes.func,
+		deleteSiteConnection: PropTypes.func,
+		errorNotice: PropTypes.func,
+		failCreateConnection: PropTypes.func,
+		fetchConnection: PropTypes.func,
+		isFetching: PropTypes.bool,
+		keyringConnections: PropTypes.arrayOf( PropTypes.object ),
+		recordGoogleEvent: PropTypes.func,
+		removableConnections: PropTypes.arrayOf( PropTypes.object ),
+		requestKeyringConnections: PropTypes.func,
 		service: PropTypes.object.isRequired,       // The single service object
 		siteId: PropTypes.number,                   // The site ID for which connections are created
+		siteUserConnections: PropTypes.arrayOf( PropTypes.object ),
 		translate: PropTypes.func,
 	},
 
@@ -47,8 +80,23 @@ const SharingService = React.createClass( {
 
 	getDefaultProps: function() {
 		return {
+			availableExternalAccounts: [],
+			brokenConnections: [],
+			createSiteConnection: () => {},
+			deleteSiteConnection: () => {},
+			errorNotice: () => {},
+			failCreateConnection: () => {},
+			fetchConnection: () => {},
+			isFetching: false,
+			keyringConnections: [],
+			recordGoogleEvent: () => {},
+			requestKeyringConnections: () => {},
+			removableConnections: [],
+			site: Object.freeze( {} ),
 			siteId: 0,
+			siteUserConnections: [],
 			translate: identity,
+			updateSiteConnection: () => {},
 		};
 	},
 
@@ -59,6 +107,23 @@ const SharingService = React.createClass( {
 		this.props.connections.off( 'destroy:error', this.onDisconnectionError );
 		this.props.connections.off( 'refresh:success', this.onRefreshSuccess );
 		this.props.connections.off( 'refresh:error', this.onRefreshError );
+	},
+
+	performAction: function() {
+		const connectionStatus = serviceConnections.getConnectionStatus( this.props.service.ID );
+
+		// Depending on current status, perform an action when user clicks the
+		// service action button
+		if ( 'connected' === connectionStatus && serviceConnections.getRemovableConnections( this.props.service.ID ).length ) {
+			this.disconnect();
+			this.props.recordGoogleEvent( 'Sharing', 'Clicked Disconnect Button', this.props.service.ID );
+		} else if ( 'reconnect' === connectionStatus ) {
+			this.refresh();
+			this.props.recordGoogleEvent( 'Sharing', 'Clicked Reconnect Button', this.props.service.ID );
+		} else {
+			this.connect();
+			this.props.recordGoogleEvent( 'Sharing', 'Clicked Connect Button', this.props.service.ID );
+		}
 	},
 
 	addConnection: function( service, keyringConnectionId, externalUserId ) {
@@ -92,6 +157,19 @@ const SharingService = React.createClass( {
 
 	toggleSitewideConnection: function( connection, isSitewide ) {
 		this.props.connections.update( connection, { shared: isSitewide } );
+	},
+
+	refresh: function( connection ) {
+		this.setState( { isRefreshing: true } );
+		this.props.connections.once( 'refresh:success', this.onRefreshSuccess );
+		this.props.connections.once( 'refresh:error', this.onRefreshError );
+
+		if ( ! connection ) {
+			// When triggering a refresh from the primary action button, find
+			// the first broken connection owned by the current user.
+			connection = serviceConnections.getRefreshableConnections( this.props.service.ID )[ 0 ];
+		}
+		this.props.connections.refresh( connection );
 	},
 
 	onConnectionSuccess: function() {
@@ -193,45 +271,12 @@ const SharingService = React.createClass( {
 		this.props.connections.destroy( connections );
 	},
 
-	refresh: function( connection ) {
-		this.setState( { isRefreshing: true } );
-		this.props.connections.once( 'refresh:success', this.onRefreshSuccess );
-		this.props.connections.once( 'refresh:error', this.onRefreshError );
-
-		if ( ! connection ) {
-			// When triggering a refresh from the primary action button, find
-			// the first broken connection owned by the current user.
-			connection = serviceConnections.getRefreshableConnections( this.props.service.ID )[ 0 ];
-		}
-		this.props.connections.refresh( connection );
-	},
-
-	performAction: function() {
-		const connectionStatus = serviceConnections.getConnectionStatus( this.props.service.ID );
-
-		// Depending on current status, perform an action when user clicks the
-		// service action button
-		if ( 'connected' === connectionStatus && serviceConnections.getRemovableConnections( this.props.service.ID ).length ) {
-			this.disconnect();
-			this.props.recordGoogleEvent( 'Sharing', 'Clicked Disconnect Button', this.props.service.ID );
-		} else if ( 'reconnect' === connectionStatus ) {
-			this.refresh();
-			this.props.recordGoogleEvent( 'Sharing', 'Clicked Reconnect Button', this.props.service.ID );
-		} else {
-			this.connect();
-			this.props.recordGoogleEvent( 'Sharing', 'Clicked Connect Button', this.props.service.ID );
-		}
-	},
-
 	render: function() {
 		const connectionStatus = serviceConnections.getConnectionStatus( this.props.service.ID ),
 			connections = serviceConnections.getConnections( this.props.service.ID );
-		const elementClass = [
-			'sharing-service',
-			this.props.service.ID,
-			connectionStatus,
-			this.state.isOpen ? 'is-open' : ''
-		].join( ' ' );
+		const classNames = classnames( 'sharing-service', this.props.service.ID, connectionStatus, {
+			'is-open': this.state.isOpen,
+		} );
 		const accounts = this.state.isSelectingAccount
 			? serviceConnections.getAvailableExternalAccounts( this.props.service.ID, this.props.siteId )
 			: [];
@@ -253,22 +298,6 @@ const SharingService = React.createClass( {
 			</div>
 		);
 
-		const content = (
-			<div
-				className={ 'sharing-service__content ' + ( serviceConnections.isFetchingAccounts() ? 'is-placeholder' : '' ) }>
-				<ServiceExamples service={ this.props.service } />
-				<ServiceConnectedAccounts
-					connections={ connections }
-					isDisconnecting={ this.state.isDisconnecting }
-					isRefreshing={ this.state.isRefreshing }
-					onAddConnection={ this.connect }
-					onRefreshConnection={ this.refresh }
-					onRemoveConnection={ this.disconnect }
-					onToggleSitewideConnection={ this.toggleSitewideConnection }
-					service={ this.props.service } />
-				<ServiceTip service={ this.props.service } />
-			</div> );
-
 		const action = (
 			<ServiceAction
 				status={ connectionStatus }
@@ -280,31 +309,66 @@ const SharingService = React.createClass( {
 				removableConnections={ serviceConnections.getRemovableConnections( this.props.service.ID ) } />
 		);
 		return (
-			<div>
+			<li>
 				<AccountDialog
 					isVisible={ this.state.isSelectingAccount }
 					service={ this.props.service }
 					accounts={ accounts }
 					onAccountSelected={ this.addConnection } />
 				<FoldableCard
-					className={ elementClass }
+					className={ classNames }
 					header={ header }
 					clickableHeader
 					compact
 					summary={ action }
 					expandedSummary={ action } >
-					{ content }
+					<div className={ 'sharing-service__content ' + ( serviceConnections.isFetchingAccounts() ? 'is-placeholder' : '' ) }>
+						<ServiceExamples service={ this.props.service } />
+						<ServiceConnectedAccounts onAddConnection={ this.connect } service={ this.props.service }>
+							{ connections.map( ( connection ) =>
+								<Connection
+									key={ connection.keyring_connection_ID }
+									connection={ connection }
+									isDisconnecting={ this.state.isDisconnecting }
+									isRefreshing={ this.state.isRefreshing }
+									onDisconnect={ this.disconnect }
+									onRefresh={ this.refresh }
+									onToggleSitewideConnection={ this.toggleSitewideConnection }
+									service={ this.props.service }
+									showDisconnect={ connections.length > 1 || 'broken' === connection.status } />
+							) }
+						</ServiceConnectedAccounts>
+						<ServiceTip service={ this.props.service } />
+					</div>
 				</FoldableCard>
-			</div>
+			</li>
 		);
 	}
 } );
 
 export default connect(
-	( state ) => ( {
-		siteId: getSelectedSiteId( state ),
-	} ),
+	( state, { service } ) => {
+		const siteId = getSelectedSiteId( state );
+		const userId = getCurrentUserId( state );
+
+		return {
+			availableExternalAccounts: getAvailableExternalAccounts( state, service.ID ),
+			brokenConnections: getBrokenSiteUserConnectionsForService( state, siteId, userId, service.ID ),
+			isFetching: isFetchingConnections( state, siteId ),
+			keyringConnections: getKeyringConnectionsByName( state, service.ID ),
+			removableConnections: getRemovableConnections( state, service.ID ),
+			siteId,
+			siteUserConnections: getSiteUserConnectionsForService( state, siteId, userId, service.ID ),
+		};
+	},
 	{
+		createSiteConnection,
+		deleteSiteConnection,
+		errorNotice,
+		failCreateConnection,
+		fetchConnection,
 		recordGoogleEvent,
+		requestKeyringConnections,
+		updateSiteConnection,
 	},
 )( localize( SharingService ) );


### PR DESCRIPTION
This PR introduces the State scaffolding needed to convert `SharingService` towards using Redux as its source of truth. Related to that it also now lets `SharingService` render `Connection`s directly, avoiding having to pass props through `SharingServiceConnectedAccounts`.

See #8991.

To test:
Navigate to http://calypso.localhost:3000/sharing/:site: and connect/disconnect one or multiple accounts. Connections should be created and destroyed without error