### PR TITLE
Jetpack: "My Plan" go to dashboard link

### DIFF
--- a/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-return-to-dashboard.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-return-to-dashboard.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -10,13 +11,15 @@ import { localize } from 'i18n-calypso';
 import PurchaseDetail from 'components/purchase-detail';
 
 export default localize( ( { selectedSite, translate } ) => {
+	const adminURL = get( selectedSite, 'options.admin_url', '' );
+
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
 				icon="house"
 				title={ translate( 'Return to your site\'s dashboard' ) }
 				buttonText={ translate( 'Go back to %(site)s', { args: { site: selectedSite.name } } ) }
-				href={ `${selectedSite.URL}/wp-admin/` }
+				href={ adminURL }
 			/>
 		</div>
 	);


### PR DESCRIPTION
Updates the _go back to dashboard_ button to use the Admin URL instead of the Site URL for Jetpack sites.

Fixes #9383 