### PR TITLE
Reader: async load emoji-text

### DIFF
--- a/client/components/data/query-reader-tag-images/index.jsx
+++ b/client/components/data/query-reader-tag-images/index.jsx
@@ -20,6 +20,14 @@ class QueryReaderTagImages extends Component {
 		this.props.requestTagImages( this.props.tag );
 	}
 
+	componentWillReceiveProps( nextProps ) {
+		if ( ! nextProps.shouldRequestTagImages || this.props.tag === nextProps.tag ) {
+			return;
+		}
+
+		this.props.requestTagImages( nextProps.tag );
+	}
+
 	render() {
 		return null;
 	}

--- a/client/components/data/query-reader-tag-images/index.jsx
+++ b/client/components/data/query-reader-tag-images/index.jsx
@@ -21,7 +21,7 @@ class QueryReaderTagImages extends Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		if ( ! nextProps.shouldRequestTagImages || this.props.tag === nextProps.tag ) {
+		if ( ! nextProps.shouldRequestTagImages ) {
 			return;
 		}
 

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -19,6 +19,7 @@ import smartSetState from 'lib/react-smart-set-state';
 import * as stats from 'reader/stats';
 import HeaderBack from 'reader/header-back';
 
+
 const TagStream = React.createClass( {
 
 	_isMounted: false,
@@ -39,8 +40,18 @@ const TagStream = React.createClass( {
 		};
 	},
 
-	componentDidMount() {
+	componentWillMount() {
+		var self = this;
 		this._isMounted = true;
+		// can't use arrows with asyncRequire
+		asyncRequire( 'emoji-text', function( emojiText ) {
+			if ( self._isMounted ) {
+				self.setState( { emojiText } );
+			}
+		} );
+	},
+
+	componentDidMount() {
 		ReaderTags.on( 'change', this.updateState );
 		TagSubscriptions.on( 'change', this.updateState );
 	},
@@ -66,19 +77,6 @@ const TagStream = React.createClass( {
 			isEmojiTitle: title && twemoji.test( title )
 		};
 		this.smartSetState( newState );
-
-		if ( ! newState.isEmojiTitle ) {
-			return;
-		}
-
-		// If we have a tag title containing emoji, load the emoji-text library
-		// so we can convert the emoji to a search phrase
-		const self = this;
-		asyncRequire( 'emoji-text', ( emojiText ) => {
-			if ( self._isMounted ) {
-				self.setState( { emojiText } );
-			}
-		} );
 	},
 
 	getTitle( props = this.props ) {

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -67,7 +67,7 @@ const TagStream = React.createClass( {
 		};
 		this.smartSetState( newState );
 
-		if ( ! this.state.isEmojiTitle ) {
+		if ( ! newState.isEmojiTitle ) {
 			return;
 		}
 

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import { has } from 'lodash';
 import twemoji from 'twemoji';
-import emojiText from 'emoji-text';
 
 /**
  * Internal Dependencies
@@ -39,6 +38,11 @@ const TagStream = React.createClass( {
 	componentDidMount() {
 		ReaderTags.on( 'change', this.updateState );
 		TagSubscriptions.on( 'change', this.updateState );
+
+		const self = this;
+		asyncRequire( 'emoji-text', ( emojiText ) => {
+			self.setState( { emojiText } );
+		} );
 	},
 
 	componentWillUnmount() {
@@ -96,8 +100,8 @@ const TagStream = React.createClass( {
 		let imageSearchString = this.props.tag;
 
 		// If the tag contains emoji, convert to text equivalent
-		if ( twemoji.test( title ) ) {
-			imageSearchString = emojiText.convert( title, {
+		if ( this.state.emojiText && twemoji.test( title ) ) {
+			imageSearchString = this.state.emojiText.convert( title, {
 				delimiter: ''
 			} );
 		}

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -19,7 +19,6 @@ import smartSetState from 'lib/react-smart-set-state';
 import * as stats from 'reader/stats';
 import HeaderBack from 'reader/header-back';
 
-
 const TagStream = React.createClass( {
 
 	_isMounted: false,

--- a/server/bundler/babel/babel-plugin-transform-wpcalypso-async/README.md
+++ b/server/bundler/babel/babel-plugin-transform-wpcalypso-async/README.md
@@ -33,7 +33,7 @@ asyncRequire( 'components/accordion', ( Accordion ) => {
 } );
 ```
 
-`<AsyncRequire />` will transform its `require` string prop to a function invoking `asyncRequire` when called.
+`<AsyncLoad />` will transform its `require` string prop to a function invoking `asyncRequire` when called.
 
 ```js
 // Before:
@@ -42,7 +42,7 @@ asyncRequire( 'components/accordion', ( Accordion ) => {
 
 // After:
 
-<AsyncLoad require={ function( callback ) { 
+<AsyncLoad require={ function( callback ) {
 	asyncRequire( 'components/accordion', callback );
 } } />
 ```


### PR DESCRIPTION
We currently use the marvellous `emoji-text` library to convert an emoji tag (like 🐶) to a string (like 'dog'). This enables us to show a relevant tag image header for emoji-only tag names, like:

http://calypso.localhost:3000/tag/%F0%9F%90%B6

The downside: the library adds 100kb+ to the Reader tags bundle.

This PR switches to async loading for the library, so we keep this functionality so without bloating the bundle.