### PR TITLE
Reader/discover site card

### DIFF
--- a/client/blocks/reader-post-card/excerpt.jsx
+++ b/client/blocks/reader-post-card/excerpt.jsx
@@ -8,11 +8,11 @@ import React from 'react';
  */
 import AutoDirection from 'components/auto-direction';
 
-const ReaderPostCardExcerpt = ( { post, isDiscover } )=> {
+const ReaderPostCardExcerpt = ( { post } )=> {
 	let excerpt = post.better_excerpt || post.excerpt;
 
 	// Force post.excerpt for Discover only
-	if ( isDiscover ) {
+	if ( post.is_discover ) {
 		excerpt = post.excerpt;
 	}
 
@@ -26,8 +26,7 @@ const ReaderPostCardExcerpt = ( { post, isDiscover } )=> {
 };
 
 ReaderPostCardExcerpt.propTypes = {
-	post: React.PropTypes.object.isRequired,
-	isDiscover: React.PropTypes.bool,
+	post: React.PropTypes.object.isRequired
 };
 
 export default ReaderPostCardExcerpt;

--- a/client/blocks/reader-post-card/gallery.jsx
+++ b/client/blocks/reader-post-card/gallery.jsx
@@ -28,7 +28,7 @@ function getGalleryWorthyImages( post ) {
 	return take( worthyImages, numberOfImagesToDisplay );
 }
 
-const PostGallery = ( { post, children, isDiscover } ) => {
+const PostGallery = ( { post, children } ) => {
 	const imagesToDisplay = getGalleryWorthyImages( post );
 	const listItems = map( imagesToDisplay, ( image, index ) => {
 		const imageUrl = resizeImageUrl( image.src, { w: GALLERY_ITEM_THUMBNAIL_WIDTH } );
@@ -56,7 +56,7 @@ const PostGallery = ( { post, children, isDiscover } ) => {
 						<a className="reader-post-card__title-link" href={ post.URL }>{ post.title }</a>
 					</h1>
 				</AutoDirection>
-				<ReaderPostCardExcerpt post={ post } isDiscover={ isDiscover } />
+				<ReaderPostCardExcerpt post={ post } />
 				{ children }
 				</div>
 		</div> );

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -41,7 +41,7 @@ export default class ReaderPostCard extends React.Component {
 		} ),
 		showSiteName: PropTypes.bool,
 		followSource: PropTypes.string,
-		showDiscoverFlag: PropTypes.bool,
+		isDiscoverStream: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -107,7 +107,6 @@ export default class ReaderPostCard extends React.Component {
 			isSelected,
 			showSiteName,
 			followSource,
-			isDiscoverStream,
 		} = this.props;
 
 		const isPhotoPost = !! ( post.display_type & DisplayTypes.PHOTO_ONLY );
@@ -163,6 +162,7 @@ export default class ReaderPostCard extends React.Component {
 
 		// set up post byline
 		let postByline;
+
 		if ( isDiscover && ! isEmpty( discoverPick ) ) {
 			// create a post like object with some props from the discover post
 			const postForByline = Object.assign( {},

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -19,6 +19,7 @@ import GalleryPost from './gallery';
 import PhotoPost from './photo';
 import StandardPost from './standard';
 import QuotePost from './quote';
+import SitePost from './site';
 import FollowButton from 'reader/follow-button';
 import DailyPostButton from 'blocks/daily-post-button';
 import { isDailyPostChallengeOrPrompt } from 'blocks/daily-post-button/helper';
@@ -115,6 +116,7 @@ export default class ReaderPostCard extends React.Component {
 		const isGalleryPost = !! ( post.display_type & DisplayTypes.GALLERY );
 		const isDiscover = post.is_discover;
 		const isQuotePost = isDiscoverStream && 'quote-pick' === post.discover_format && get( discoverPick, 'post' );
+		const isSitePost = isDiscoverStream && 'site-pick' === post.discover_format && get( discoverPick, 'site' );
 		const title = truncate( post.title, { length: 140, separator: /,? +/ } );
 		const classes = classnames( 'reader-post-card', {
 			'has-thumbnail': !! post.canonical_media,
@@ -122,6 +124,7 @@ export default class ReaderPostCard extends React.Component {
 			'is-gallery': isGalleryPost,
 			'is-selected': isSelected,
 			'is-quote': isQuotePost,
+			'is-site': isSitePost,
 			'is-discover': isDiscover
 		} );
 
@@ -161,6 +164,10 @@ export default class ReaderPostCard extends React.Component {
 					{ discoverFollowButton }
 					{ readerPostActions }
 				</QuotePost>;
+		} else if ( isSitePost ) {
+			readerPostCard = <SitePost post={ post } site={ get( discoverPick, 'site' ) || site } >
+					{ readerPostActions }
+				</SitePost>;
 		} else {
 			readerPostCard = <StandardPost post={ post } title={ title } >
 					{ isDailyPostChallengeOrPrompt( post ) && site && <DailyPostButton post={ post } site={ site } tagName="span" /> }

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import React, { PropTypes } from 'react';
-import { noop, truncate } from 'lodash';
+import { noop, truncate, get, isEmpty } from 'lodash';
 import classnames from 'classnames';
 import ReactDom from 'react-dom';
 import closest from 'component-closest';
@@ -23,7 +23,6 @@ import DailyPostButton from 'blocks/daily-post-button';
 import { isDailyPostChallengeOrPrompt } from 'blocks/daily-post-button/helper';
 import { getDiscoverBlogName,
 	getSourceFollowUrl as getDiscoverFollowUrl,
-	isDiscoverPost
 } from 'reader/discover/helper';
 import DiscoverFollowButton from 'reader/discover/follow-button';
 
@@ -48,9 +47,8 @@ export default class ReaderPostCard extends React.Component {
 	};
 
 	propagateCardClick = () => {
-		// If we have an original post available (e.g. for a Discover pick), send the original post
-		// to the full post view
-		const postToOpen = this.props.discoverPick ? this.props.discoverPick : this.props.post;
+		// If we have an discover pick post available, send the discover pick to the full post view
+		const postToOpen = get( this.props, 'discoverPick.post' ) || this.props.post;
 		this.props.onClick( postToOpen );
 	}
 
@@ -109,7 +107,7 @@ export default class ReaderPostCard extends React.Component {
 
 		const isPhotoPost = !! ( post.display_type & DisplayTypes.PHOTO_ONLY );
 		const isGalleryPost = !! ( post.display_type & DisplayTypes.GALLERY );
-		const isDiscover = isDiscoverPost( post );
+		const isDiscover = post.is_discover;
 		const title = truncate( post.title, { length: 140, separator: /,? +/ } );
 		const classes = classnames( 'reader-post-card', {
 			'has-thumbnail': !! post.canonical_media,
@@ -128,7 +126,7 @@ export default class ReaderPostCard extends React.Component {
 		}
 
 		const readerPostActions = <ReaderPostActions
-			post={ discoverPick ? discoverPick : post }
+			post={ get( discoverPick, 'post' ) || post }
 			site={ site }
 			visitUrl = { post.URL }
 			showVisit={ true }
@@ -158,11 +156,27 @@ export default class ReaderPostCard extends React.Component {
 				</StandardPost>;
 		}
 
+		// set up post byline
+		let postByline;
+		if ( isDiscover && ! isEmpty( discoverPick ) ) {
+			// create a post like object with some props from the discover post
+			const postForByline = Object.assign( {},
+				discoverPick.post || {},
+				{
+					date: post.date,
+					URL: post.URL,
+					primary_tag: post.primary_tag,
+				} );
+			postByline = <PostByline post={ postForByline } site={ discoverPick.site } showSiteName={ true } />;
+		} else {
+			postByline = <PostByline post={ post } site={ site } feed={ feed } showSiteName={ showSiteName || isDiscover } />;
+		}
+
 		const followUrl = feed ? feed.feed_URL : post.site_URL;
 
 		return (
 			<Card className={ classes } onClick={ ! isPhotoPost && this.handleCardClick }>
-				<PostByline post={ post } site={ site } feed={ feed } showSiteName={ showSiteName } />
+				{ postByline }
 				{ showPrimaryFollowButton && followUrl && <FollowButton siteUrl={ followUrl } followSource={ followSource } /> }
 				{ readerPostCard }
 				{ this.props.children }

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -36,7 +36,7 @@ export default class ReaderPostCard extends React.Component {
 		onClick: PropTypes.func,
 		onCommentClick: PropTypes.func,
 		showPrimaryFollowButton: PropTypes.bool,
-		originalPost: PropTypes.object, // used for Discover only
+		discoverPick: PropTypes.object,
 		showSiteName: PropTypes.bool,
 		followSource: PropTypes.string,
 	};
@@ -50,7 +50,7 @@ export default class ReaderPostCard extends React.Component {
 	propagateCardClick = () => {
 		// If we have an original post available (e.g. for a Discover pick), send the original post
 		// to the full post view
-		const postToOpen = this.props.originalPost ? this.props.originalPost : this.props.post;
+		const postToOpen = this.props.discoverPick ? this.props.discoverPick : this.props.post;
 		this.props.onClick( postToOpen );
 	}
 
@@ -97,7 +97,7 @@ export default class ReaderPostCard extends React.Component {
 	render() {
 		const {
 			post,
-			originalPost,
+			discoverPick,
 			site,
 			feed,
 			onCommentClick,
@@ -128,7 +128,7 @@ export default class ReaderPostCard extends React.Component {
 		}
 
 		const readerPostActions = <ReaderPostActions
-			post={ originalPost ? originalPost : post }
+			post={ discoverPick ? discoverPick : post }
 			site={ site }
 			visitUrl = { post.URL }
 			showVisit={ true }

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -10,6 +10,8 @@ import closest from 'component-closest';
 /**
  * Internal Dependencies
  */
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
 import Card from 'components/card';
 import DisplayTypes from 'state/reader/posts/display-types';
 import * as stats from 'reader/stats';
@@ -26,7 +28,7 @@ import { getDiscoverBlogName,
 } from 'reader/discover/helper';
 import DiscoverFollowButton from 'reader/discover/follow-button';
 
-export default class ReaderPostCard extends React.Component {
+class ReaderPostCard extends React.Component {
 	static propTypes = {
 		post: PropTypes.object.isRequired,
 		site: PropTypes.object,
@@ -35,9 +37,13 @@ export default class ReaderPostCard extends React.Component {
 		onClick: PropTypes.func,
 		onCommentClick: PropTypes.func,
 		showPrimaryFollowButton: PropTypes.bool,
-		discoverPick: PropTypes.object,
+		discoverPick: PropTypes.shape( {
+			post: PropTypes.object,
+			site: PropTypes.object,
+		} ),
 		showSiteName: PropTypes.bool,
 		followSource: PropTypes.string,
+		showDiscoverFlag: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -103,6 +109,8 @@ export default class ReaderPostCard extends React.Component {
 			isSelected,
 			showSiteName,
 			followSource,
+			showDiscoverFlag,
+			translate
 		} = this.props;
 
 		const isPhotoPost = !! ( post.display_type & DisplayTypes.PHOTO_ONLY );
@@ -176,6 +184,11 @@ export default class ReaderPostCard extends React.Component {
 
 		return (
 			<Card className={ classes } onClick={ ! isPhotoPost && this.handleCardClick }>
+				{ isDiscover && showDiscoverFlag &&
+					<div className="reader-post-card__discover-post-flag" >
+						<Gridicon icon="my-sites" size={ 16 } /> { translate( 'Featured on Discover' ) }
+					</div>
+				}
 				{ postByline }
 				{ showPrimaryFollowButton && followUrl && <FollowButton siteUrl={ followUrl } followSource={ followSource } /> }
 				{ readerPostCard }
@@ -184,3 +197,5 @@ export default class ReaderPostCard extends React.Component {
 		);
 	}
 }
+
+export default localize( ReaderPostCard );

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -107,6 +107,7 @@ export default class ReaderPostCard extends React.Component {
 			isSelected,
 			showSiteName,
 			followSource,
+			isDiscoverStream,
 		} = this.props;
 
 		const isPhotoPost = !! ( post.display_type & DisplayTypes.PHOTO_ONLY );
@@ -163,7 +164,7 @@ export default class ReaderPostCard extends React.Component {
 		// set up post byline
 		let postByline;
 
-		if ( isDiscover && ! isEmpty( discoverPick ) ) {
+		if ( isDiscoverStream && ! isEmpty( discoverPick ) ) {
 			// create a post like object with some props from the discover post
 			const postForByline = Object.assign( {},
 				discoverPick.post || {},

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -10,8 +10,6 @@ import closest from 'component-closest';
 /**
  * Internal Dependencies
  */
-import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
 import Card from 'components/card';
 import DisplayTypes from 'state/reader/posts/display-types';
 import * as stats from 'reader/stats';
@@ -28,7 +26,7 @@ import { getDiscoverBlogName,
 } from 'reader/discover/helper';
 import DiscoverFollowButton from 'reader/discover/follow-button';
 
-class ReaderPostCard extends React.Component {
+export default class ReaderPostCard extends React.Component {
 	static propTypes = {
 		post: PropTypes.object.isRequired,
 		site: PropTypes.object,
@@ -109,8 +107,7 @@ class ReaderPostCard extends React.Component {
 			isSelected,
 			showSiteName,
 			followSource,
-			showDiscoverFlag,
-			translate
+			isDiscoverStream,
 		} = this.props;
 
 		const isPhotoPost = !! ( post.display_type & DisplayTypes.PHOTO_ONLY );
@@ -184,11 +181,6 @@ class ReaderPostCard extends React.Component {
 
 		return (
 			<Card className={ classes } onClick={ ! isPhotoPost && this.handleCardClick }>
-				{ isDiscover && showDiscoverFlag &&
-					<div className="reader-post-card__discover-post-flag" >
-						<Gridicon icon="my-sites" size={ 16 } /> { translate( 'Featured on Discover' ) }
-					</div>
-				}
 				{ postByline }
 				{ showPrimaryFollowButton && followUrl && <FollowButton siteUrl={ followUrl } followSource={ followSource } /> }
 				{ readerPostCard }
@@ -198,4 +190,3 @@ class ReaderPostCard extends React.Component {
 	}
 }
 
-export default localize( ReaderPostCard );

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -18,6 +18,7 @@ import PostByline from './byline';
 import GalleryPost from './gallery';
 import PhotoPost from './photo';
 import StandardPost from './standard';
+import QuotePost from './quote';
 import FollowButton from 'reader/follow-button';
 import DailyPostButton from 'blocks/daily-post-button';
 import { isDailyPostChallengeOrPrompt } from 'blocks/daily-post-button/helper';
@@ -113,12 +114,14 @@ export default class ReaderPostCard extends React.Component {
 		const isPhotoPost = !! ( post.display_type & DisplayTypes.PHOTO_ONLY );
 		const isGalleryPost = !! ( post.display_type & DisplayTypes.GALLERY );
 		const isDiscover = post.is_discover;
+		const isQuotePost = isDiscoverStream && 'quote-pick' === post.discover_format && get( discoverPick, 'post' );
 		const title = truncate( post.title, { length: 140, separator: /,? +/ } );
 		const classes = classnames( 'reader-post-card', {
 			'has-thumbnail': !! post.canonical_media,
 			'is-photo': isPhotoPost,
 			'is-gallery': isGalleryPost,
 			'is-selected': isSelected,
+			'is-quote': isQuotePost,
 			'is-discover': isDiscover
 		} );
 
@@ -153,6 +156,11 @@ export default class ReaderPostCard extends React.Component {
 			readerPostCard = <GalleryPost post={ post } title={ title } >
 					{ readerPostActions }
 				</GalleryPost>;
+		} else if ( isQuotePost ) {
+			readerPostCard = <QuotePost post={ post }>
+					{ discoverFollowButton }
+					{ readerPostActions }
+				</QuotePost>;
 		} else {
 			readerPostCard = <StandardPost post={ post } title={ title } >
 					{ isDailyPostChallengeOrPrompt( post ) && site && <DailyPostButton post={ post } site={ site } tagName="span" /> }

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -124,7 +124,7 @@ export default class ReaderPostCard extends React.Component {
 
 		let discoverFollowButton;
 
-		if ( isDiscover ) {
+		if ( isDiscover && ! isDiscoverStream ) {
 			const discoverBlogName = getDiscoverBlogName( post ) || null;
 			discoverFollowButton = discoverBlogName &&
 				<DiscoverFollowButton siteName={ discoverBlogName } followUrl={ getDiscoverFollowUrl( post ) } />;
@@ -178,7 +178,13 @@ export default class ReaderPostCard extends React.Component {
 			postByline = <PostByline post={ post } site={ site } feed={ feed } showSiteName={ showSiteName || isDiscover } />;
 		}
 
-		const followUrl = feed ? feed.feed_URL : post.site_URL;
+		let followUrl;
+
+		if ( isDiscoverStream && discoverPick && ( discoverPick.post || discoverPick.site ) ) {
+			followUrl = discoverPick.site ? discoverPick.site.URL : discoverPick.post.site_URL;
+		} else {
+			followUrl = feed ? feed.feed_URL : post.site_URL;
+		}
 
 		return (
 			<Card className={ classes } onClick={ ! isPhotoPost && this.handleCardClick }>

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -150,11 +150,11 @@ export default class ReaderPostCard extends React.Component {
 					{ readerPostActions }
 				</PhotoPost>;
 		} else if ( isGalleryPost ) {
-			readerPostCard = <GalleryPost post={ post } title={ title } isDiscover={ isDiscover }>
+			readerPostCard = <GalleryPost post={ post } title={ title } >
 					{ readerPostActions }
 				</GalleryPost>;
 		} else {
-			readerPostCard = <StandardPost post={ post } title={ title } isDiscover={ isDiscover }>
+			readerPostCard = <StandardPost post={ post } title={ title } >
 					{ isDailyPostChallengeOrPrompt( post ) && site && <DailyPostButton post={ post } site={ site } tagName="span" /> }
 					{ discoverFollowButton }
 					{ readerPostActions }

--- a/client/blocks/reader-post-card/quote.jsx
+++ b/client/blocks/reader-post-card/quote.jsx
@@ -1,0 +1,21 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+
+/**
+ * Interal Dependencies
+ */
+import ReaderPostCardExcerpt from './excerpt';
+
+const QuotePost = ( { post, children } ) => {
+	return (
+		<div className="reader-post-card__post" >
+			<div className="reader-post-card__post-details">
+				<ReaderPostCardExcerpt post={ post } />
+				{ children }
+			</div>
+		</div> );
+};
+
+export default QuotePost;

--- a/client/blocks/reader-post-card/site.jsx
+++ b/client/blocks/reader-post-card/site.jsx
@@ -1,0 +1,47 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal Dependencies
+ */
+import AutoDirection from 'components/auto-direction';
+import FeaturedImage from './featured-image';
+import ReaderPostCardExcerpt from './excerpt';
+import SiteIcon from 'blocks/site-icon';
+
+const SitePost = ( { post, site, children } )=> {
+	const canonicalMedia = post.canonical_media;
+	let featuredAsset;
+	if ( ! canonicalMedia ) {
+		featuredAsset = <a className="reader-post-card__featured-image no-image" href={ post.URL }>
+			<SiteIcon key="site-icon" size={ 96 } site={ site } />
+		</a>;
+	} else {
+		featuredAsset = <FeaturedImage imageUri={ canonicalMedia.src } href={ post.URL }>
+			<SiteIcon key="site-icon" size={ 96 } site={ site } />
+		</FeaturedImage>;
+	}
+
+	return (
+		<div className="reader-post-card__post" >
+			{ featuredAsset }
+			<div className="reader-post-card__post-details">
+				<AutoDirection>
+					<h1 className="reader-post-card__title">
+						<a className="reader-post-card__title-link" href={ post.URL }>{ post.title }</a>
+					</h1>
+				</AutoDirection>
+				<ReaderPostCardExcerpt post={ post } />
+				{ children }
+			</div>
+		</div> );
+};
+
+SitePost.propTypes = {
+	post: React.PropTypes.object.isRequired,
+	site: React.PropTypes.object.isRequired
+};
+
+export default SitePost;

--- a/client/blocks/reader-post-card/standard.jsx
+++ b/client/blocks/reader-post-card/standard.jsx
@@ -11,7 +11,7 @@ import FeaturedVideo from './featured-video';
 import FeaturedImage from './featured-image';
 import ReaderPostCardExcerpt from './excerpt';
 
-const StandardPost = ( { post, children, isDiscover } )=> {
+const StandardPost = ( { post, children } )=> {
 	const canonicalMedia = post.canonical_media;
 	let featuredAsset;
 	if ( ! canonicalMedia ) {
@@ -31,15 +31,14 @@ const StandardPost = ( { post, children, isDiscover } )=> {
 						<a className="reader-post-card__title-link" href={ post.URL }>{ post.title }</a>
 					</h1>
 				</AutoDirection>
-				<ReaderPostCardExcerpt post={ post } isDiscover={ isDiscover } />
+				<ReaderPostCardExcerpt post={ post } />
 				{ children }
 			</div>
 		</div> );
 };
 
 StandardPost.propTypes = {
-	post: React.PropTypes.object.isRequired,
-	isDiscover: React.PropTypes.bool,
+	post: React.PropTypes.object.isRequired
 };
 
 export default StandardPost;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -700,3 +700,19 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 .is-section-devdocs .reader-post-card__featured-image {
 	bottom: 16px;
 }
+
+.reader-post-card__discover-post-flag {
+	display: inline-block;
+	color: lighten( $gray, 10% );
+	font-size: 14px;
+	font-weight: 600;
+	letter-spacing: 0.01em;
+	margin-bottom: 18px;
+	text-transform: uppercase;
+
+	.gridicon {
+		fill: lighten( $gray, 10% );
+		position: relative;
+		top: 3px;
+	}
+}

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -701,18 +701,3 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	bottom: 16px;
 }
 
-.reader-post-card__discover-post-flag {
-	display: inline-block;
-	color: lighten( $gray, 10% );
-	font-size: 14px;
-	font-weight: 600;
-	letter-spacing: 0.01em;
-	margin-bottom: 18px;
-	text-transform: uppercase;
-
-	.gridicon {
-		fill: lighten( $gray, 10% );
-		position: relative;
-		top: 3px;
-	}
-}

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -182,6 +182,31 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		font-style: italic;
 
 	}
+
+	&.is-site {
+		.reader-post-card__byline {
+			display: none;
+		}
+
+		.reader-post-card__post {
+			margin-top: 0px;
+		//	height: 192px;
+		}
+
+		.reader-post-card__excerpt {
+			min-height: 72px;
+		}
+
+		.reader-post-card__featured-image {
+			&.no-image {
+				background-color: lighten( $gray, 20% );
+			}
+
+			.site-icon {
+				border: 4px solid lighten( $gray, 30% );
+			}
+		}
+	}
 	.reader-post-actions {
 		margin: 4px 0 0;
 	}

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -177,6 +177,11 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		}
 	}
 
+	&.is-quote .reader-post-card__excerpt {
+		font-size: 22px;
+		font-style: italic;
+
+	}
 	.reader-post-actions {
 		margin: 4px 0 0;
 	}
@@ -700,4 +705,3 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 .is-section-devdocs .reader-post-card__featured-image {
 	bottom: 16px;
 }
-

--- a/client/reader/discover/controller.js
+++ b/client/reader/discover/controller.js
@@ -44,7 +44,7 @@ export default {
 				),
 				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
 				suppressSiteNameLink: true,
-				showPrimaryFollowButtonOnCards: false,
+				showPrimaryFollowButtonOnCards: true,
 				isDiscoverStream: true,
 				showBack: false,
 				className: 'is-discover-stream is-site-stream',

--- a/client/reader/discover/controller.js
+++ b/client/reader/discover/controller.js
@@ -45,6 +45,7 @@ export default {
 				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
 				suppressSiteNameLink: true,
 				showPrimaryFollowButtonOnCards: false,
+				isDiscoverStream: true,
 				showBack: false,
 				className: 'is-discover-stream is-site-stream',
 			} ),

--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -52,13 +52,13 @@ export function hasSource( post ) {
 export function getSourceData( post ) {
 	const sourceData = get( post, 'discover_metadata.featured_post_wpcom_data' );
 
-	if ( sourceData && ! isDiscoverSitePick( post ) ) {
+	if ( sourceData ) {
 		return {
 			blogId: get( sourceData, 'blog_id' ),
 			postId: get( sourceData, 'post_id' )
 		};
 	}
-	return null;
+	return {};
 }
 
 export function getLinkProps( linkUrl ) {

--- a/client/reader/discover/test/helper.js
+++ b/client/reader/discover/test/helper.js
@@ -100,16 +100,20 @@ describe( 'helper', () => {
 	} );
 
 	describe( 'getSourceData', () => {
-		it( 'returns null if the post is not a discover post', () => {
-			assert.isNull( helper.getSourceData( fixtures.nonDiscoverPost ) );
+		it( 'returns empty object if the post is not a discover post', () => {
+			assert.deepEqual( {}, helper.getSourceData( fixtures.nonDiscoverPost ) );
 		} );
 
-		it( 'returns null if the post is external', () => {
-			assert.isNull( helper.getSourceData( fixtures.externalDiscoverPost ) );
+		it( 'returns empty object if the post is external', () => {
+			assert.deepEqual( {}, helper.getSourceData( fixtures.externalDiscoverPost ) );
 		} );
 
-		it( 'returns null if the post is a discover site pick', () => {
-			assert.isNull( helper.getSourceData( fixtures.discoverSiteFormat ) );
+		it( 'returns blog id if the post is a discover site pick', () => {
+			const fixtureData = {
+				blogId: get( fixtures.discoverSiteFormat, 'discover_metadata.featured_post_wpcom_data.blog_id' ),
+				postId: undefined,
+			};
+			assert.deepEqual( fixtureData, helper.getSourceData( fixtures.discoverSiteFormat ) );
 		} );
 
 		it( 'returns the post and blog id', () => {

--- a/client/reader/route/index.js
+++ b/client/reader/route/index.js
@@ -1,20 +1,27 @@
+/**
+ * Internal dependencies
+ */
+
+import config from 'config';
+
 const FEED_URL_BASE = '/read/feeds/';
 const SITE_URL_BASE = '/read/blogs/';
 
-const PRETTY_FEED_URLS = {
-	12733228: '/discover'
-};
+const DISCOVER_SITE_ID = config( 'discover_blog_id' );
+const DISCOVER_FEED_ID = config( 'discover_feed_id' );
 
-const PRETTY_SITE_URLS = {
-	53424024: '/discover'
-};
+const prettyFeedUrls = {};
+prettyFeedUrls[ DISCOVER_FEED_ID ] = '/discover';
+
+const prettySiteUrls = {};
+prettySiteUrls[ DISCOVER_SITE_ID ] = '/discover';
 
 export function getPrettySiteUrl( siteID ) {
-	return PRETTY_SITE_URLS[ siteID ];
+	return prettySiteUrls[ siteID ];
 }
 
 export function getPrettyFeedUrl( feedID ) {
-	return PRETTY_FEED_URLS[ feedID ];
+	return prettyFeedUrls[ feedID ];
 }
 
 export function getSiteUrl( siteID ) {

--- a/client/reader/route/test/index.js
+++ b/client/reader/route/test/index.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-var expect = require( 'chai' ).expect;
-
+import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-var route = require( '../' );
+import * as route from '../';
+import config from 'config';
 
 describe( 'index', function() {
 	describe( 'getStreamUrlFromPost', function() {
@@ -25,7 +25,7 @@ describe( 'index', function() {
 		} );
 
 		it( 'should return pretty URL for discover', function() {
-			expect( route.getSiteUrl( 53424024 ) ).to.equal( '/discover' );
+			expect( route.getSiteUrl( config( 'discover_blog_id' ) ) ).to.equal( '/discover' );
 		} );
 	} );
 
@@ -35,7 +35,7 @@ describe( 'index', function() {
 		} );
 
 		it( 'should return pretty URL for discover', function() {
-			expect( route.getFeedUrl( 12733228 ) ).to.equal( '/discover' );
+			expect( route.getFeedUrl( config( 'discover_feed_id' ) ) ).to.equal( '/discover' );
 		} );
 	} );
 } );

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -9,7 +9,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import DocumentHead from 'components/data/document-head';
 import RefreshFeedHeader from 'blocks/reader-feed-header';
 import FeedFeatured from './featured';
@@ -40,11 +39,13 @@ class SiteStream extends React.Component {
 		siteId: React.PropTypes.number.isRequired,
 		className: React.PropTypes.string,
 		showBack: React.PropTypes.bool,
+		isDiscoverStream: React.PropTypes.bool,
 	};
 
 	static defaultProps = {
 		showBack: true,
 		className: 'is-site-stream',
+		isDiscoverStream: false,
 	};
 
 	constructor( props ) {
@@ -134,8 +135,7 @@ class SiteStream extends React.Component {
 
 	render() {
 		const site = this.state.site,
-			emptyContent = ( <EmptyContent /> ),
-			isDiscoverStream = this.props.siteId === config( 'discover_blog_id' );
+			emptyContent = ( <EmptyContent /> );
 		let title = this.state.title,
 			featuredStore = null,
 			featuredContent = null;
@@ -161,7 +161,7 @@ class SiteStream extends React.Component {
 				emptyContent={ emptyContent }
 				showPostHeader={ false }
 				showSiteNameOnCards={ false }
-				isDiscoverStream={ isDiscoverStream }>
+				isDiscoverStream={ this.props.isDiscoverStream }>
 				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: title } ) } />
 				<RefreshFeedHeader site={ site } feed={ this.state.feed } showBack={ this.props.showBack } />
 				{ featuredContent }

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import DocumentHead from 'components/data/document-head';
 import RefreshFeedHeader from 'blocks/reader-feed-header';
 import FeedFeatured from './featured';
@@ -38,7 +39,7 @@ class SiteStream extends React.Component {
 	static propTypes = {
 		siteId: React.PropTypes.number.isRequired,
 		className: React.PropTypes.string,
-		showBack: React.PropTypes.bool
+		showBack: React.PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -133,7 +134,8 @@ class SiteStream extends React.Component {
 
 	render() {
 		const site = this.state.site,
-			emptyContent = ( <EmptyContent /> );
+			emptyContent = ( <EmptyContent /> ),
+			isDiscoverStream = this.props.siteId === config( 'discover_blog_id' );
 		let title = this.state.title,
 			featuredStore = null,
 			featuredContent = null;
@@ -158,7 +160,8 @@ class SiteStream extends React.Component {
 				listName={ title }
 				emptyContent={ emptyContent }
 				showPostHeader={ false }
-				showSiteNameOnCards={ false }>
+				showSiteNameOnCards={ false }
+				isDiscoverStream={ isDiscoverStream }>
 				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: title } ) } />
 				<RefreshFeedHeader site={ site } feed={ this.state.feed } showBack={ this.props.showBack } />
 				{ featuredContent }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -456,7 +456,7 @@ class ReaderStream extends React.Component {
 			showPostHeader={ this.props.showPostHeader }
 			showFollowInHeader={ this.props.showFollowInHeader }
 			showPrimaryFollowButtonOnCards={ this.props.showPrimaryFollowButtonOnCards }
-			showDiscoverFlagOnCards={ ! this.props.isDiscoverStream }
+			isDiscoverStream={ this.props.isDiscoverStream }
 			showSiteName={ this.props.showSiteNameOnCards }
 			cardClassForPost={ this.cardClassForPost }
 			followSource={ this.props.followSource }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -119,6 +119,7 @@ class ReaderStream extends React.Component {
 		cardFactory: PropTypes.func,
 		placeholderFactory: PropTypes.func,
 		followSource: PropTypes.string,
+		isDiscoverStream: PropTypes.bool,
 	}
 
 	static defaultProps = {
@@ -129,7 +130,8 @@ class ReaderStream extends React.Component {
 		className: '',
 		showDefaultEmptyContentIfMissing: true,
 		showPrimaryFollowButtonOnCards: true,
-		showMobileBackToSidebar: true
+		showMobileBackToSidebar: true,
+		isDiscoverStream: false,
 	};
 
 	getStateFromStores( store = this.props.postsStore, recommendationsStore = this.props.recommendationsStore ) {
@@ -443,7 +445,6 @@ class ReaderStream extends React.Component {
 			store: this.props.postsStore,
 			index,
 		} );
-
 		return <PostLifecycle
 			key={ itemKey }
 			ref={ itemKey }
@@ -455,6 +456,7 @@ class ReaderStream extends React.Component {
 			showPostHeader={ this.props.showPostHeader }
 			showFollowInHeader={ this.props.showFollowInHeader }
 			showPrimaryFollowButtonOnCards={ this.props.showPrimaryFollowButtonOnCards }
+			showDiscoverFlagOnCards={ ! this.props.isDiscoverStream }
 			showSiteName={ this.props.showSiteNameOnCards }
 			cardClassForPost={ this.cardClassForPost }
 			followSource={ this.props.followSource }

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -17,7 +17,7 @@ import XPostHelper from 'reader/xpost-helper';
 export default class PostLifecycle extends React.PureComponent {
 	static propTypes = {
 		postKey: PropTypes.object,
-		showDiscoverFlagOnCards: PropTypes.bool
+		isDiscoverStream: PropTypes.bool
 	}
 
 	state = {
@@ -87,7 +87,7 @@ export default class PostLifecycle extends React.PureComponent {
 					handleClick={ this.props.handleClick }
 					showPrimaryFollowButtonOnCards={ this.props.showPrimaryFollowButtonOnCards }
 					showSiteName={ this.props.showSiteName }
-					showDiscoverFlag={ this.props.showDiscoverFlagOnCards }
+					isDiscoverStream={ this.props.isDiscoverStream }
 				/>;
 		}
 	}

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -16,7 +16,8 @@ import XPostHelper from 'reader/xpost-helper';
 
 export default class PostLifecycle extends React.PureComponent {
 	static propTypes = {
-		postKey: PropTypes.object
+		postKey: PropTypes.object,
+		showDiscoverFlagOnCards: PropTypes.bool
 	}
 
 	state = {
@@ -86,6 +87,7 @@ export default class PostLifecycle extends React.PureComponent {
 					handleClick={ this.props.handleClick }
 					showPrimaryFollowButtonOnCards={ this.props.showPrimaryFollowButtonOnCards }
 					showSiteName={ this.props.showSiteName }
+					showDiscoverFlag={ this.props.showDiscoverFlagOnCards }
 				/>;
 		}
 	}

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -81,7 +81,7 @@ class ReaderPostCardAdapter extends React.Component {
 				showPrimaryFollowButton={ this.props.showPrimaryFollowButtonOnCards }
 				followSource={ this.props.followSource }
 				showSiteName={ this.props.showSiteName }
-				showDiscoverFlag={ this.props.showDiscoverFlag }>
+				isDiscoverStream={ this.props.isDiscoverStream }>
 				{ feedId && <QueryReaderFeed feedId={ feedId } includeMeta={ false } /> }
 				{ ! isExternal && siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }
 				{ discoverPickSiteId && <QueryReaderSite siteId={ discoverPickSiteId } includeMeta={ false } /> }

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -80,7 +80,8 @@ class ReaderPostCardAdapter extends React.Component {
 				isSelected={ this.props.isSelected }
 				showPrimaryFollowButton={ this.props.showPrimaryFollowButtonOnCards }
 				followSource={ this.props.followSource }
-				showSiteName={ this.props.showSiteName }>
+				showSiteName={ this.props.showSiteName }
+				showDiscoverFlag={ this.props.showDiscoverFlag }>
 				{ feedId && <QueryReaderFeed feedId={ feedId } includeMeta={ false } /> }
 				{ ! isExternal && siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }
 				{ discoverPickSiteId && <QueryReaderSite siteId={ discoverPickSiteId } includeMeta={ false } /> }

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -99,17 +99,24 @@ const ConnectedReaderPostCardAdapter = connect(
 		// set up the discover pick
 		let discoverPick = null;
 		if ( get( ownProps, 'post.is_discover' ) ) {
-			// copy over discoverPick from feed store
+			// copy discoverPick from feed store
 			const discoverPickPost = get( ownProps, 'discoverPick.post' );
 
-			// add discoverPick site from state
-			const { blogId } = getDiscoverSourceData( ownProps.post );
-			const discoverPickSite = blogId ? getSite( state, blogId ) : null;
+			// limit discover pick site to discover stream
+			if ( ownProps.isDiscoverStream ) {
+				// add discoverPick site from state
+				const { blogId } = getDiscoverSourceData( ownProps.post );
+				const discoverPickSite = blogId ? getSite( state, blogId ) : null;
 
-			if ( discoverPickPost || discoverPickSite ) {
+				if ( discoverPickPost || discoverPickSite ) {
+					discoverPick = {
+						post: discoverPickPost,
+						site: discoverPickSite,
+					};
+				}
+			} else if ( discoverPickPost ) {
 				discoverPick = {
-					post: discoverPickPost,
-					site: discoverPickSite,
+					post: discoverPickPost
 				};
 			}
 		}

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -27,7 +27,7 @@ class ReaderPostCardAdapter extends React.Component {
 
 	onClick = ( postToOpen ) => {
 		let referredPost;
-		if ( this.props.originalPost && isDiscoverPost( this.props.post ) && ! isDiscoverSitePick( this.props.post ) ) {
+		if ( this.props.discoverPick && isDiscoverPost( this.props.post ) && ! isDiscoverSitePick( this.props.post ) ) {
 			referredPost = { ...postToOpen,
 				referral: {
 					blogId: discoverBlogId,
@@ -65,7 +65,7 @@ class ReaderPostCardAdapter extends React.Component {
 		return (
 			<ReaderPostCard
 				post={ this.props.post }
-				originalPost={ this.props.originalPost }
+				discoverPick={ this.props.discoverPick }
 				site={ this.props.site }
 				feed={ this.props.feed }
 				onClick={ this.onClick }
@@ -89,7 +89,7 @@ const ConnectedReaderPostCardAdapter = connect(
 		return {
 			site: isExternal ? null : getSite( state, siteId ),
 			feed: getFeed( state, feedId ),
-			originalPost: ownProps.originalPost
+			discoverPick: ownProps.discoverPick
 		};
 	}
 )( ReaderPostCardAdapter );
@@ -109,10 +109,10 @@ export default class ReaderPostCardAdapterFluxContainer extends React.Component 
 		const nonSiteDiscoverPick = isDiscoverPost( post ) && ! isDiscoverSitePick( post );
 
 		// If it's a discover post (but not a site pick), we want the original post too
-		const originalPost = nonSiteDiscoverPick ? FeedPostStore.get( getDiscoverSourceData( post ) ) : null;
+		const discoverPick = nonSiteDiscoverPick ? FeedPostStore.get( getDiscoverSourceData( post ) ) : null;
 
 		return {
-			originalPost
+			discoverPick
 		};
 	}
 
@@ -135,6 +135,6 @@ export default class ReaderPostCardAdapterFluxContainer extends React.Component 
 	render() {
 		return ( <ConnectedReaderPostCardAdapter
 					{ ...this.props }
-					originalPost={ this.state.originalPost } /> );
+					discoverPick={ this.state.discoverPick } /> );
 	}
 }

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -1,5 +1,6 @@
 {
 	"discover_blog_id": 53424024,
+	"discover_feed_id": 41325786,
 	"daily_post_blog_id": 489937,
 	"oauth_client_id": false,
 	"happychat_url": "https://happychat.io/customer",

--- a/config/client.json
+++ b/config/client.json
@@ -26,6 +26,7 @@
   "siftscience_key",
   "facebook_api_key",
   "discover_blog_id",
+  "discover_feed_id",
   "daily_post_blog_id",
   "support-user",
   "sync-handler-defaults",


### PR DESCRIPTION
Fixes #10303

Adds a site card to the discover stream

Site with blavatar:
![screen shot 2017-02-08 at 11 46 07 am](https://cloud.githubusercontent.com/assets/744755/22760622/253197a2-ee0c-11e6-8c6c-8c19e8425bb9.png)

Site with default blavatar:
![screen shot 2017-02-08 at 2 30 38 pm](https://cloud.githubusercontent.com/assets/744755/22760642/39749c8c-ee0c-11e6-9754-51fd1100fbea.png)

Cards in context with others:
![screen shot 2017-02-08 at 2 44 02 pm](https://cloud.githubusercontent.com/assets/744755/22761013/d22c7930-ee0d-11e6-90d8-99f2ea5f044d.png)


I doubt discover picks will end up without featured images but just in case I added a gray background to where the image _should_ go:
![screen shot 2017-02-08 at 2 32 17 pm](https://cloud.githubusercontent.com/assets/744755/22760782/d638e21c-ee0c-11e6-8b94-b5ddd467972d.png)


The min height of a site card is set to the height of a card with a 3 line excerpt.












