### PR TITLE
Update/timezones query component

### DIFF
--- a/client/components/data/query-timezones/index.jsx
+++ b/client/components/data/query-timezones/index.jsx
@@ -1,0 +1,27 @@
+
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { requestTimezones } from 'state/timezones/actions';
+
+export class QueryTimezones extends Component {
+	static propTypes = {
+		requestTimezones: PropTypes.func
+	};
+
+	componentDidMount() {
+		this.props.requestTimezones();
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect( null, ( { requestTimezones } ) )( QueryTimezones );

--- a/client/components/data/query-timezones/test/index.jsx
+++ b/client/components/data/query-timezones/test/index.jsx
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { QueryTimezones } from '../';
+
+describe( 'mounting component', () => {
+	it( 'should mount as null', () => {
+		const wrapped = shallow( <QueryTimezones { ...{ requestTimezones: noop } } /> );
+
+		expect( wrapped.equals( null ) ).to.be.true;
+	} );
+} );


### PR DESCRIPTION
This PR adds the `query-timezones` component implemented according to most recently handling data of calypso. More information about this: https://github.com/Automattic/wp-calypso/tree/master/client/state/data-layer/wpcom-http

### Testing

#### Run client tests

- data-layer timezones tests
```
> npm run test-client client/state/data-layer/wpcom/timezones/test/
```

- data query-timezones tests
```
> npm run test-client client/components/data/query-timezones/test/
```

#### Some tests using chrome devtools

You could dispatch a timezones request action straight using the console executing the right action type. it can be achieved using the global `actionTypes` var as well.

```
> dispatch( { type: actionTypes.TIMEZONES_REQUEST } );
```

<img src="https://cloud.githubusercontent.com/assets/77539/22749185/34510a34-ee0b-11e6-87d0-47a57437e5a5.png" width="300px" />

After dispatching the action, you could check that the request has been triggered taking a look to the `network` tab:

<img src="https://cloud.githubusercontent.com/assets/77539/22749292/8fed3c5a-ee0b-11e6-9ae4-0053045fd5d2.png" width="400px" />

And you could confirm that the action is being successful dispatched, paying attention how the set of actions are triggered one by one in the following order:

`WPCOM_HTTP_REQUEST`,
`TIMEZONES_REQUEST`,
`TIMEZONES_REQUEST_SUCCESS`,
`TIMEZONES_RECEIVE`,

<img src="https://cloud.githubusercontent.com/assets/77539/22749471/3654d6a2-ee0c-11e6-9259-48e2e4efa37a.gif" width="500px" />
