### PR TITLE
Support: Add seo and marketing video to help courses

### DIFF
--- a/client/me/help/help-courses/course-videos.jsx
+++ b/client/me/help/help-courses/course-videos.jsx
@@ -19,8 +19,14 @@ export default localize( ( props ) => {
 
 	return (
 		<div className="help-courses__course-videos">
-			<Card compact className="help-courses__course-videos-label">{ translate( 'Latest course' ) }</Card>
-			{ videos.map( ( video, key ) => <CourseVideo { ...video } key={ key }/> ) }
+			<Card compact className="help-courses__course-videos-label">
+				{ translate(
+					'Latest course',
+					'Latest courses',
+					{ count: videos.length }
+				) }
+			</Card>
+			{ videos.map( ( video, key ) => <CourseVideo { ...video } key={ key } /> ) }
 		</div>
 	);
 } );

--- a/client/me/help/help-courses/index.jsx
+++ b/client/me/help/help-courses/index.jsx
@@ -41,7 +41,7 @@ function getCourses() {
 					title: i18n.translate( 'Everything You Need to Know About SEO and Marketing for Your Website' ),
 					description: i18n.translate(
 						'You will leave this 60-minute session with a plan for optimizing your site for search engines ' +
-						'and an overview of basic tactics for increasing your traffic. Our Happiness Engineers will provide a' +
+						'and an overview of basic tactics for increasing your traffic. Our Happiness Engineers will provide a ' +
 						'foundation for making sure that your site meets current SEO standards. We\'ll also discuss how to ' +
 						'maximize tools like Google Analytics and Webmaster Tools.'
 					),

--- a/client/me/help/help-courses/index.jsx
+++ b/client/me/help/help-courses/index.jsx
@@ -37,6 +37,17 @@ function getCourses() {
 			],
 			videos: [
 				{
+					date: i18n.moment( new Date( 'Thur, 2 Feb 2017 17:00:00 +0000' ) ),
+					title: i18n.translate( 'Everything You Need to Know About SEO and Marketing for Your Website' ),
+					description: i18n.translate(
+						'You will leave this 60-minute session with a plan for optimizing your site for search engines ' +
+						'and an overview of basic tactics for increasing your traffic. Our Happiness Engineers will provide a' +
+						'foundation for making sure that your site meets current SEO standards. We\'ll also discuss how to ' +
+						'maximize tools like Google Analytics and Webmaster Tools.'
+					),
+					youtubeId: 'FU7uxbngrq4'
+				},
+				{
 					date: i18n.moment( new Date( 'Fri, 2 Sep 2016 01:00:00 +0000' ) ),
 					title: i18n.translate( 'How to Make a Business Site on WordPress.com' ),
 					description: i18n.translate(


### PR DESCRIPTION
This pull request adds the youtube video containing the latest help course video for seo and marketing.

### How to test
1. Navigate to http://calypso.localhost:3000/help/courses
2. Notice that the new video appears in the "Latest course" section

### What to expect

<img width="730" alt="screen shot 2017-02-09 at 2 59 11 pm" src="https://cloud.githubusercontent.com/assets/1854440/22800848/a99aa0c0-eed8-11e6-939c-334edf52753b.png">


