### PR TITLE
Framework: data-layer: implement a parameters control in the http() helper.

### DIFF
--- a/client/state/data-layer/wpcom-http/actions.js
+++ b/client/state/data-layer/wpcom-http/actions.js
@@ -3,10 +3,75 @@
  */
 import { WPCOM_HTTP_REQUEST } from 'state/action-types';
 
+export const apiVersionPattern = /^v(?:(\d+)\.)?(\d+)$/;
+export const apiNamespacePattern = /^([a-z]+)\/?v(\d+)$/;
+
+const noVersionAndNamespaceUndefined = ( { apiNamespace, apiVersion } ) => {
+	if ( typeof apiNamespace === 'undefined' && typeof apiVersion === 'undefined' ) {
+		throw new TypeError(
+			'One of `apiNamespace` and `apiVersion` must be defined (see wpcom.js/README.md)'
+		);
+	}
+};
+
+const noVersionAndNamespaceConflicts = ( { apiNamespace, apiVersion } ) => {
+	if ( apiNamespace && apiVersion ) {
+		throw new TypeError(
+			'Cannot simultaneously define `apiNamespace` and `apiVersion` (see wpcom.js/README.md)'
+		);
+	}
+};
+
+const hasViableVersion = ( { apiVersion, apiNamespace } ) => {
+	if ( ! apiVersion && apiNamespace ) {
+		return;
+	}
+
+	if ( ! ( apiVersion && apiVersionPattern.test( apiVersion ) ) ) {
+		throw new TypeError(
+			`Given 'apiVersion' of '${ apiVersion }' doesn't match pattern: v1, v1.1, v2, etc…`
+		);
+	}
+};
+
+const hasViableNamespace = ( { apiVersion, apiNamespace } ) => {
+	if ( apiVersion ) {
+		return;
+	}
+
+	if ( ! apiNamespacePattern.test( apiNamespace ) ) {
+		throw new TypeError(
+			`Given 'apiNamespace' of '${ apiNamespace }' doesn't match pattern: wp/v1, wp/v2, wpcom/v2, etc…`
+		);
+	}
+};
+
+const noUndefinedPath = ( { path } ) => {
+	if ( ! path || typeof path !== 'string' ) {
+		throw new TypeError( `{ path: ${ path } } param is invalid.` );
+	}
+};
+
+const noUnknownMethodName = ( { method } ) => {
+	if ( ! method || ( method !== 'GET' && method !== 'POST' ) ) {
+		throw new TypeError( `{ method: ${ method } } param is invalid.` );
+	}
+};
+
+const validators = [
+	noVersionAndNamespaceConflicts,
+	noVersionAndNamespaceUndefined,
+	hasViableVersion,
+	hasViableNamespace,
+	noUndefinedPath,
+	noUnknownMethodName,
+];
+
 /**
  * Returns a valid WordPress.com API HTTP Request action object
  *
  * @param {string} [apiVersion] specific API version for request
+ * @param {string} [apiNamespace] specific API namespace for request
  * @param {Object} [body] JSON-serializable body for POST requests
  * @param {string} method name of HTTP method to use
  * @param {string} path WordPress.com API path with %s and %d placeholders, e.g. /sites/%s
@@ -17,28 +82,57 @@ import { WPCOM_HTTP_REQUEST } from 'state/action-types';
  * @param {Object} [onProgress] Redux action to call on progress events from an upload
  * @param {Object} [options] extra options to send to the middleware, e.g. retry policy or offline policy
  * @param {Object} [action] default action to call on HTTP events
- * @returns {Object} Redux action describing WordPress.com API HTTP request
+ * @return {Object} Redux action describing WordPress.com API HTTP request
  */
-export const http = ( {
-	apiVersion = 'v1',
-	body = {},
-	method,
-	path,
-	query = {},
-	formData,
-	onSuccess,
-	onFailure,
-	onProgress,
-	...options,
-}, action = null ) => ( {
-	type: WPCOM_HTTP_REQUEST,
-	body,
-	method,
-	path,
-	query: { ...query, apiVersion },
-	formData,
-	onSuccess: onSuccess || action,
-	onFailure: onFailure || action,
-	onProgress: onProgress || action,
-	options,
-} );
+export const http = ( request, action = null ) => {
+	const {
+		apiVersion,
+		apiNamespace,
+		body = {},
+		method,
+		formData,
+		path,
+		query = {},
+		onSuccess,
+		onFailure,
+		onProgress,
+		...options
+	} = request;
+
+	// validate request and throw on error
+	validators.forEach( validator => validator( request ) );
+
+	const actionProperties = {
+		body,
+		onSuccess: onSuccess || action,
+		onFailure: onFailure || action,
+		onProgress: onProgress || action,
+		query: { ...query },
+		options,
+	};
+
+	if ( apiVersion ) {
+		actionProperties.query.apiVersion = apiVersion;
+	}
+
+	if ( apiNamespace ) {
+		actionProperties.query.apiNamespace = apiNamespace;
+	}
+
+	// formData is optional
+	if ( formData ) {
+		actionProperties.formData = FormData;
+	}
+
+	// optional parameters
+	if ( typeof formData !== 'undefined' ) {
+		actionProperties.formData = [];
+	}
+
+	return {
+		...actionProperties,
+		type: WPCOM_HTTP_REQUEST,
+		path,
+		method,
+	};
+};

--- a/client/state/data-layer/wpcom-http/actions.js
+++ b/client/state/data-layer/wpcom-http/actions.js
@@ -82,7 +82,7 @@ const validators = [
  * @param {Object} [onProgress] Redux action to call on progress events from an upload
  * @param {Object} [options] extra options to send to the middleware, e.g. retry policy or offline policy
  * @param {Object} [action] default action to call on HTTP events
- * @return {Object} Redux action describing WordPress.com API HTTP request
+ * @returns {Object} Redux action describing WordPress.com API HTTP request
  */
 export const http = ( request, action = null ) => {
 	const {

--- a/client/state/data-layer/wpcom-http/test/http.js
+++ b/client/state/data-layer/wpcom-http/test/http.js
@@ -1,0 +1,213 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { WPCOM_HTTP_REQUEST } from 'state/action-types';
+
+/**
+ * Internal dependencies
+ */
+import {
+	apiVersionPattern,
+	apiNamespacePattern,
+	http
+} from '../actions';
+
+describe( 'http', () => {
+	describe( 'apiVersion shape', () => {
+		it( 'should not accept `1` as a valid version', () => {
+			expect( apiVersionPattern.test( '1' ) ).to.be.false;
+		} );
+
+		it( 'should accept `v1` as a valid version', () => {
+			expect( apiVersionPattern.test( 'v1' ) ).to.be.true;
+		} );
+
+		it( 'should not accept `v1.` as a valid version', () => {
+			expect( apiVersionPattern.test( 'v1.' ) ).to.be.false;
+		} );
+
+		it( 'should accept `v1.3` as a valid version', () => {
+			expect( apiVersionPattern.test( 'v1.3' ) ).to.be.true;
+		} );
+	} );
+
+	describe( 'apiNamespace shape', () => {
+		it( 'should not accept `wpcom` as a valid namespace', () => {
+			expect( apiNamespacePattern.test( 'wpcom' ) ).to.be.false;
+		} );
+
+		it( 'should accept `wpcom/v1` as a valid namespace', () => {
+			expect( apiNamespacePattern.test( 'wpcom/v1' ) ).to.be.true;
+		} );
+
+		it( 'should not accept `wpcom/` as a valid namespace', () => {
+			expect( apiNamespacePattern.test( 'wpcom/' ) ).to.be.false;
+		} );
+
+		it( 'should not accept `wpcom/1` as a valid namespace', () => {
+			expect( apiNamespacePattern.test( 'wpcom/1' ) ).to.be.false;
+		} );
+	} );
+
+	describe( 'request action', () => {
+		it( 'should return a valid redux action defining apiVersion', () => {
+			const action = http( {
+				apiVersion: 'v2',
+				method: 'GET',
+				path: '/path/to/endpoint',
+			} );
+
+			expect( action ).to.eql( {
+				type: WPCOM_HTTP_REQUEST,
+				body: {},
+				method: 'GET',
+				path: '/path/to/endpoint',
+				query: {
+					apiVersion: 'v2'
+				},
+				options: {},
+				onSuccess: null,
+				onFailure: null,
+				onProgress: null,
+			} );
+		} );
+
+		it( 'should return a valid redux action defining apiNamespace', () => {
+			const action = http( {
+				apiNamespace: 'wpcom/v2',
+				method: 'GET',
+				path: '/path/to/endpoint',
+			} );
+
+			expect( action ).to.eql( {
+				type: WPCOM_HTTP_REQUEST,
+				body: {},
+				method: 'GET',
+				path: '/path/to/endpoint',
+				query: {
+					apiNamespace: 'wpcom/v2'
+				},
+				options: {},
+				onSuccess: null,
+				onFailure: null,
+				onProgress: null,
+			} );
+		} );
+
+		it( 'should return a valid redux action passing random parameters into the query', () => {
+			const action = http( {
+				apiVersion: 'v2',
+				method: 'GET',
+				path: '/path/to/endpoint',
+				query: {
+					number: 10,
+					context: 'display',
+					fields: [ 'foo', 'bar' ],
+				}
+			} );
+
+			expect( action ).to.eql( {
+				type: WPCOM_HTTP_REQUEST,
+				body: {},
+				method: 'GET',
+				path: '/path/to/endpoint',
+				query: {
+					apiVersion: 'v2',
+					number: 10,
+					context: 'display',
+					fields: [ 'foo', 'bar' ],
+				},
+				options: {},
+				onSuccess: null,
+				onFailure: null,
+				onProgress: null,
+			} );
+		} );
+	} );
+
+	describe( 'bad request action', () => {
+		it( 'should throw Error when `apiVersion` and `apiNamespace` are not defined.', () => {
+			const boundRequest = http.bind( http, {
+				path: '/path/to/endpoint',
+				method: 'GET',
+			} );
+
+			expect( boundRequest ).to.throw( 'One of `apiNamespace` and `apiVersion` must be defined (see wpcom.js/README.md)' );
+		} );
+
+		it( 'should throw Error when `path` is not defined', () => {
+			const boundRequest = http.bind( http, {
+				apiVersion: 'v1',
+				method: 'GET',
+			} );
+
+			expect( boundRequest ).to.throw( '{ path: undefined } param is invalid.' );
+		} );
+
+		it( 'should throw Error when `path` is invalid', () => {
+			const boundRequest = http.bind( http, {
+				apiVersion: 'v1',
+				method: 'GET',
+				path: true,
+			} );
+
+			expect( boundRequest ).to.throw( '{ path: true } param is invalid.' );
+		} );
+
+		it( 'should throw Error when method is not defined', () => {
+			const boundRequest = http.bind( http, {
+				apiVersion: 'v1',
+				path: '/path/to/endpoint',
+			} );
+
+			expect( boundRequest ).to.throw( '{ method: undefined } param is invalid.' );
+		} );
+
+		it( 'should throw Error when method is unknown', () => {
+			const boundRequest = http.bind( http, {
+				apiVersion: 'v1',
+				method: 'PUT',
+				path: '/path/to/endpoint',
+			} );
+
+			expect( boundRequest ).to.throw( '{ method: PUT } param is invalid.' );
+		} );
+
+		it( 'should throw Error when apiVersion is invalid', () => {
+			const boundRequest = http.bind( http, {
+				apiVersion: 'version1',
+				method: 'GET',
+				path: '/path/to/endpoint',
+			} );
+
+			expect( boundRequest ).to.throw( 'Given \'apiVersion\' of \'version1\' doesn\'t match pattern: v1, v1.1, v2, etc…' );
+		} );
+
+		it( 'should throw Error when apiNamespace is invalid', () => {
+			const boundRequest = http.bind( http, {
+				apiNamespace: 'v1',
+				method: 'GET',
+				path: '/path/to/endpoint',
+
+			} );
+
+			expect( boundRequest ).to.throw( 'Given \'apiNamespace\' of \'v1\' doesn\'t match pattern: wp/v1, wp/v2, wpcom/v2, etc…' );
+		} );
+
+		it( 'should throw Error when both apiVersion and apiNamespace are simultaneously defined', () => {
+			const boundRequest = http.bind( http, {
+				apiVersion: 'v1',
+				apiNamespace: 'wpcom/v2',
+				method: 'GET',
+				path: '/path/to/endpoint',
+			} );
+
+			expect( boundRequest ).to.throw( 'Cannot simultaneously define `apiNamespace` and `apiVersion` (see wpcom.js/README.md)' );
+		} );
+	} );
+} );


### PR DESCRIPTION
This patch attempts to improve the process which describes the HTTP request built by the `http()` function. The idea is checking the request parameters controlling when they are needed, type of value, etc.
For instance, `path` and `method` parameters must be defined, `path` should be a string, `method` just could take either `GET` or `POST` values, and so on.

The most important checking is detecting if both `apiVersion` and `apiNamespace` parameters are simultaneously defined. It will avoid reintroducing a bug: More info in the revert PR: https://github.com/Automattic/wp-calypso/pull/11267#issuecomment-278438016

If the request parameteres are ok the `http()` function will return a `WPCOM_HTTP_REQUEST` action type. If not the Redux action returned will be `WPCOM_HTTP_BAD_REQUEST`.

### Testing

```cli
> npm run test-client client/state/data-layer/wpcom-http/test/http.js
```

```
  state
    data-layer
      wpcom-http
        http
          request action
            ✓ should return a valid redux action
            ✓ should return a valid redux action defining apiVersion
            ✓ should return a valid redux action defining apiNamespace
          bad request action
            ✓ should return a bad action when `path` is not defined
            ✓ should return a bad action when `path` is invalid
            ✓ should return a bad action when method is not defined
            ✓ should return a bad action when method is unknown
            ✓ should return a bad action when apiVersion is invalid
            ✓ should return a bad action when apiNamespace is invalid
            ✓ should return a bad action when both apiVersion and apiNamespace are simultaneously defined

  10 passing (760ms)
```