### PR TITLE
Revert "Boot: Load olark async"

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -373,7 +373,7 @@ function reduxStoreReady( reduxStore ) {
 	page( '*', require( 'notices' ).clearNoticesOnNavigation );
 
 	if ( config.isEnabled( 'olark' ) ) {
-		asyncRequire( 'lib/olark', olark => olark.initialize( reduxStore.dispatch ) );
+		require( 'lib/olark' ).initialize( reduxStore.dispatch );
 	}
 
 	if ( config.isEnabled( 'keyboard-shortcuts' ) ) {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#11110

This ended up pushing the olark flux store into two separate chunks, so we ended up with two instances of the olark store. 