### PR TITLE
Checkout: Fixes an issue where we were showing annual wording for monthly plans

### DIFF
--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -155,7 +155,7 @@ function isMonthly( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return product.bill_period === PLAN_MONTHLY_PERIOD;
+	return parseInt( product.bill_period, 10 ) === PLAN_MONTHLY_PERIOD;
 }
 
 function isJpphpBundle( product ) {


### PR DESCRIPTION
When I attempted to buy a monthly plan earlier, I saw something like this:

![screen shot 2017-02-08 at 7 53 28 pm](https://cloud.githubusercontent.com/assets/1126811/22766369/b79036d4-ee3a-11e6-97ea-feafcc0d61cc.png)

Note how it says the plan is $9 and it's $0.75 over 12 months. 😱 That's a steal 😉 

After debugging, it seems that the issue was because we were always failing the `isMonthly` check since the 

To test:

- Go to `/plans/$site` where `$site` is a Jetpack site
- Select a monthly plan and click "Upgrade"
- Make sure you see monthly wording