### PR TITLE
Save redux store to localstorage on page unload

### DIFF
--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -70,7 +70,8 @@ function loadInitialStateFailed( error ) {
 
 export function persistOnChange( reduxStore, serializeState = serialize ) {
 	let state;
-	reduxStore.subscribe( throttle( function() {
+
+	const throttledSaveState = throttle( function() {
 		const nextState = reduxStore.getState();
 		if ( state && nextState === state ) {
 			return;
@@ -82,7 +83,13 @@ export function persistOnChange( reduxStore, serializeState = serialize ) {
 			.catch( ( setError ) => {
 				debug( 'failed to set redux-store state', setError );
 			} );
-	}, SERIALIZE_THROTTLE, { leading: false, trailing: true } ) );
+	}, SERIALIZE_THROTTLE, { leading: false, trailing: true } );
+
+	if ( global.window ) {
+		global.window.addEventListener( 'beforeunload', throttledSaveState.flush );
+	}
+
+	reduxStore.subscribe( throttledSaveState );
 
 	return reduxStore;
 }


### PR DESCRIPTION
Sometimes we might perform crucial store mutation before redirect, if we do that, after refresh
we'll get a stale state that will lead to unexpected behavior.

Such scenario is described [here](https://github.com/Automattic/wp-calypso/pull/11224#issuecomment-278633091) and it's fixed by this PR.
 
#### Testing instructions
  
1. Run `git checkout fix/save-ste-on-unload` and start your server, or open a [live branch](https://calypso.live/?branch=fix/save-ste-on-unload)
2. Assert tests pass
   
#### Reviews
  
- [x] Code
- [ ] Product

