### PR TITLE
Themes: sheet Support logic changes to include Jetpack

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -130,10 +130,11 @@ const ThemeSheet = React.createClass( {
 	},
 
 	getValidSections() {
+		const { isCurrentUserPaid, isJetpack, forumUrl, isWpcomTheme, isLoggedIn } = this.props;
 		const validSections = [];
 		validSections.push( '' ); // Default section
 		this.props.supportDocumentation && validSections.push( 'setup' );
-		validSections.push( 'support' );
+		( ! isLoggedIn || ( isCurrentUserPaid && ! isJetpack ) || forumUrl || isWpcomTheme ) && validSections.push( 'support' );
 		return validSections;
 	},
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -347,17 +347,16 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderSupportTab() {
+		const { isCurrentUserPaid, isJetpack, forumUrl, isWpcomTheme } = this.props;
 		let buttonCount = 1;
 
 		return (
 			<div>
-				{ this.props.isCurrentUserPaid && ! this.props.isJetpack &&
+				{ isCurrentUserPaid && ! isJetpack &&
 					this.renderSupportContactUsCard( buttonCount++ ) }
-				{ this.props.forumUrl && this.props.isPremium &&
+				{ forumUrl && isWpcomTheme &&
 					this.renderSupportThemeForumCard( buttonCount++ ) }
-				{ this.props.forumUrl && ( ! this.props.isPremium || ! this.props.isWpcomTheme ) &&
-					this.renderSupportThemeForumCard( buttonCount++ ) }
-				{ this.props.isWpcomTheme &&
+				{ isWpcomTheme &&
 					this.renderSupportCssCard( buttonCount++ ) }
 			</div>
 		);
@@ -643,7 +642,6 @@ export default connect(
 	( state, { id } ) => {
 		const selectedSite = getSelectedSite( state );
 		const siteSlug = selectedSite ? getSiteSlug( state, selectedSite.ID ) : '';
-		const isJetpack = selectedSite && isJetpackSite( state, selectedSite.ID );
 		const isWpcomTheme = !! getTheme( state, 'wpcom', id );
 		const siteIdOrWpcom = ( selectedSite && ! isWpcomTheme ) ? selectedSite.ID : 'wpcom';
 		const backPath = getBackPath( state );
@@ -658,13 +656,13 @@ export default connect(
 			error,
 			selectedSite,
 			siteSlug,
-			isJetpack,
 			backPath,
 			currentUserId,
 			isCurrentUserPaid,
 			isWpcomTheme,
 			isLoggedIn: !! currentUserId,
 			isActive: selectedSite && isThemeActive( state, id, selectedSite.ID ),
+			isJetpack: selectedSite && isJetpackSite( state, selectedSite.ID ),
 			isPremium: isThemePremium( state, id ),
 			isPurchased: selectedSite && isPremiumThemeAvailable( state, id, selectedSite.ID ),
 			forumUrl: getThemeForumUrl( state, id, selectedSite && selectedSite.ID ),

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -355,7 +355,7 @@ const ThemeSheet = React.createClass( {
 				<div>
 					{ isCurrentUserPaid && ! isJetpack &&
 						this.renderSupportContactUsCard( buttonCount++ ) }
-					{ forumUrl && isWpcomTheme &&
+					{ forumUrl &&
 						this.renderSupportThemeForumCard( buttonCount++ ) }
 					{ isWpcomTheme &&
 						this.renderSupportCssCard( buttonCount++ ) }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -130,11 +130,10 @@ const ThemeSheet = React.createClass( {
 	},
 
 	getValidSections() {
-		const { isCurrentUserPaid, isJetpack, forumUrl, isWpcomTheme, isLoggedIn } = this.props;
 		const validSections = [];
 		validSections.push( '' ); // Default section
 		this.props.supportDocumentation && validSections.push( 'setup' );
-		( ! isLoggedIn || ( isCurrentUserPaid && ! isJetpack ) || forumUrl || isWpcomTheme ) && validSections.push( 'support' );
+		validSections.push( 'support' );
 		return validSections;
 	},
 
@@ -350,9 +349,10 @@ const ThemeSheet = React.createClass( {
 	renderSupportTab() {
 		const { isCurrentUserPaid, isJetpack, forumUrl, isWpcomTheme, isLoggedIn } = this.props;
 		let buttonCount = 1;
+		let renderedTab = null;
 
 		if ( isLoggedIn ) {
-			return (
+			renderedTab = (
 				<div>
 					{ isCurrentUserPaid && ! isJetpack &&
 						this.renderSupportContactUsCard( buttonCount++ ) }
@@ -362,22 +362,41 @@ const ThemeSheet = React.createClass( {
 						this.renderSupportCssCard( buttonCount++ ) }
 				</div>
 			);
+
+			// No card has been rendered
+			if ( buttonCount === 1 ) {
+				renderedTab = (
+					<Card className="theme__sheet-card-support">
+						<Gridicon icon="notice-outline" size={ 48 } />
+						<div className="theme__sheet-card-support-details">
+							{ i18n.translate( 'This theme is unsupported' ) }
+							<small>
+								{ i18n.translate( 'Maybe it\'s a custom theme? Sorry about that.',
+									{ context: 'Support message when we no support links are available' } )
+								}
+							</small>
+						</div>
+					</Card>
+				);
+			}
+		} else {
+			// Logged out
+			renderedTab = (
+				<Card className="theme__sheet-card-support">
+					<Gridicon icon="help" size={ 48 } />
+					<div className="theme__sheet-card-support-details">
+						{ i18n.translate( 'Have a question about this theme?' ) }
+						<small>
+							{ i18n.translate( 'Pick this design and start a site with us, we can help!',
+								{ context: 'Logged out theme support message' } )
+							}
+						</small>
+					</div>
+				</Card>
+			);
 		}
 
-		// Logged out
-		return (
-			<Card className="theme__sheet-card-support">
-				<Gridicon icon="help" size={ 48 } />
-				<div className="theme__sheet-card-support-details">
-					{ i18n.translate( 'Have a question about this theme?' ) }
-					<small>
-						{ i18n.translate( 'Pick this design and start a site with us, we can help!',
-							{ context: 'Logged out theme support message' } )
-						}
-					</small>
-				</div>
-			</Card>
-		);
+		return renderedTab;
 	},
 
 	renderFeaturesCard() {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -347,18 +347,35 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderSupportTab() {
-		const { isCurrentUserPaid, isJetpack, forumUrl, isWpcomTheme } = this.props;
+		const { isCurrentUserPaid, isJetpack, forumUrl, isWpcomTheme, isLoggedIn } = this.props;
 		let buttonCount = 1;
 
+		if ( isLoggedIn ) {
+			return (
+				<div>
+					{ isCurrentUserPaid && ! isJetpack &&
+						this.renderSupportContactUsCard( buttonCount++ ) }
+					{ forumUrl && isWpcomTheme &&
+						this.renderSupportThemeForumCard( buttonCount++ ) }
+					{ isWpcomTheme &&
+						this.renderSupportCssCard( buttonCount++ ) }
+				</div>
+			);
+		}
+
+		// Logged out
 		return (
-			<div>
-				{ isCurrentUserPaid && ! isJetpack &&
-					this.renderSupportContactUsCard( buttonCount++ ) }
-				{ forumUrl && isWpcomTheme &&
-					this.renderSupportThemeForumCard( buttonCount++ ) }
-				{ isWpcomTheme &&
-					this.renderSupportCssCard( buttonCount++ ) }
-			</div>
+			<Card className="theme__sheet-card-support">
+				<Gridicon icon="help" size={ 48 } />
+				<div className="theme__sheet-card-support-details">
+					{ i18n.translate( 'Have a question about this theme?' ) }
+					<small>
+						{ i18n.translate( 'Pick this design and start a site with us, we can help!',
+							{ context: 'Logged out theme support message' } )
+						}
+					</small>
+				</div>
+			</Card>
 		);
 	},
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -284,7 +284,7 @@ const ThemeSheet = React.createClass( {
 		);
 	},
 
-	renderSupportContactUsCard( isPrimary = false ) {
+	renderSupportContactUsCard( buttonCount ) {
 		return (
 			<Card className="theme__sheet-card-support">
 				<Gridicon icon="help-outline" size={ 48 } />
@@ -293,7 +293,7 @@ const ThemeSheet = React.createClass( {
 					<small>{ i18n.translate( 'Get in touch with our support team' ) }</small>
 				</div>
 				<Button
-					primary={ isPrimary }
+					primary={ buttonCount === 1 }
 					href={ '/help/contact/' }
 					onClick={ this.trackContactUsClick }>
 					{ i18n.translate( 'Contact us' ) }
@@ -302,7 +302,7 @@ const ThemeSheet = React.createClass( {
 		);
 	},
 
-	renderSupportThemeForumCard( isPrimary = false ) {
+	renderSupportThemeForumCard( buttonCount ) {
 		if ( ! this.props.forumUrl ) {
 			return null;
 		}
@@ -319,7 +319,7 @@ const ThemeSheet = React.createClass( {
 					<small>{ description }</small>
 				</div>
 				<Button
-					primary={ isPrimary }
+					primary={ buttonCount === 1 }
 					href={ this.props.forumUrl }
 					onClick={ this.trackThemeForumClick }>
 					{ i18n.translate( 'Visit forum' ) }
@@ -328,7 +328,7 @@ const ThemeSheet = React.createClass( {
 		);
 	},
 
-	renderSupportCssCard( isPrimary = false ) {
+	renderSupportCssCard( buttonCount ) {
 		return (
 			<Card className="theme__sheet-card-support">
 				<Gridicon icon="briefcase" size={ 48 } />
@@ -337,7 +337,7 @@ const ThemeSheet = React.createClass( {
 					<small>{ i18n.translate( 'Get help from the experts in our CSS forum' ) }</small>
 				</div>
 				<Button
-					primary={ isPrimary }
+					primary={ buttonCount === 1 }
 					href="//en.forums.wordpress.com/forum/css-customization"
 					onClick={ this.trackCssClick }>
 					{ i18n.translate( 'Visit forum' ) }
@@ -347,20 +347,18 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderSupportTab() {
-		function hasPrimaryButtonOnce() {
-			return hasPrimaryButtonOnce.isAlreadyDone ? false : hasPrimaryButtonOnce.isAlreadyDone = true;
-		}
+		let buttonCount = 1;
 
 		return (
 			<div>
 				{ this.props.isCurrentUserPaid && ! this.props.isJetpack &&
-					this.renderSupportContactUsCard( hasPrimaryButtonOnce() ) }
+					this.renderSupportContactUsCard( buttonCount++ ) }
 				{ this.props.forumUrl && this.props.isPremium &&
-					this.renderSupportThemeForumCard( hasPrimaryButtonOnce() ) }
+					this.renderSupportThemeForumCard( buttonCount++ ) }
 				{ this.props.forumUrl && ( ! this.props.isPremium || ! this.props.isWpcomTheme ) &&
-					this.renderSupportThemeForumCard( hasPrimaryButtonOnce() ) }
+					this.renderSupportThemeForumCard( buttonCount++ ) }
 				{ this.props.isWpcomTheme &&
-					this.renderSupportCssCard( hasPrimaryButtonOnce() ) }
+					this.renderSupportCssCard( buttonCount++ ) }
 			</div>
 		);
 	},


### PR DESCRIPTION
This PR reviews the logic behind the "Support" tab in theme sheets, following the logic from #11263:

1. Contact us — shown only if “Paid” and “Not Jetpack”
2. Theme forum (Premium) — shown only if “Premium theme”
3. Theme forum (general) — shown only if “.com theme” and “not Premium theme”
4. CSS Support — shown only if “.com theme”

### To test:

Please note there's a bug 🐞  currently that won't show the "Theme Forums" if the theme sheet isn't for a URL with a site (single site). Check everything else (update: fix in #11296).

Check one of each of the kinds above:

1. Open `/theme/textbook/support/$site` (Free theme, Paid user) → should show "Need extra help?" + "Have a question (volounteers)?" + "Need CSS help?"
2. Open `/theme/shoreditch/support` (Free theme, Free user) → should show "Need CSS help?" only
3. Open `/theme/shoreditch/support` (Free theme, Paid user) → should show "Need extra help?" + "Need CSS help?"
4. Open `/theme/shoreditch/support/$jetpack` (Free theme, JP site) → should show "Need CSS help?" only.
5. Open `/theme/$customtheme/support/$jetpack` (Custom theme, JP site) → should show only the forum link for the custom theme

This list is probably not exhaustive, but should cover all the major cases.
