### PR TITLE
Themes: Hide redundant upload eligibility

### DIFF
--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -45,6 +45,8 @@ import { getBackPath } from 'state/themes/themes-ui/selectors';
 import { hasFeature } from 'state/sites/plans/selectors';
 import Banner from 'components/banner';
 import { PLAN_BUSINESS, FEATURE_UNLIMITED_PREMIUM_THEMES, FEATURE_UPLOAD_THEMES } from 'lib/plans/constants';
+import QueryEligibility from 'components/data/query-atat-eligibility';
+import { hasEligibilityMessagesOtherThanBusiness } from 'state/automated-transfer/selectors';
 
 const debug = debugFactory( 'calypso:themes:theme-upload' );
 
@@ -64,10 +66,11 @@ class Upload extends React.Component {
 		isJetpack: React.PropTypes.bool,
 		upgradeJetpack: React.PropTypes.bool,
 		backPath: React.PropTypes.string,
+		showEligibility: React.PropTypes.bool,
 	};
 
 	state = {
-		showEligibility: ! this.props.isJetpack,
+		showEligibility: this.props.showEligibility,
 	}
 
 	componentDidMount() {
@@ -80,7 +83,7 @@ class Upload extends React.Component {
 			const { siteId, inProgress } = nextProps;
 			! inProgress && this.props.clearThemeUpload( siteId );
 
-			this.setState( { showEligibility: ! nextProps.isJetpack } );
+			this.setState( { showEligibility: nextProps.showEligibility } );
 		}
 	}
 
@@ -263,10 +266,11 @@ class Upload extends React.Component {
 			isJetpack
 		} = this.props;
 
-		const showEligibility = ! isJetpack && this.state.showEligibility;
+		const { showEligibility } = this.state;
 
 		return (
 			<Main>
+				<QueryEligibility siteId={ siteId } />
 				<QueryActiveTheme siteId={ siteId } />
 				{ themeId && complete && <QueryTheme siteId={ siteId } themeId={ themeId } /> }
 				<ThanksModal
@@ -325,6 +329,7 @@ export default connect(
 			installing: isInstallInProgress( state, siteId ),
 			upgradeJetpack: isJetpack && ! hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ),
 			backPath: getBackPath( state ),
+			showEligibility: ! isJetpack && hasEligibilityMessagesOtherThanBusiness( state, siteId ),
 		};
 	},
 	{ uploadTheme, clearThemeUpload, initiateThemeTransfer },

--- a/client/state/automated-transfer/selectors.js
+++ b/client/state/automated-transfer/selectors.js
@@ -4,6 +4,7 @@
 import {
 	flowRight as compose,
 	get,
+	includes,
 } from 'lodash';
 
 export const getAutomatedTransfer = ( state, siteId ) =>
@@ -68,3 +69,21 @@ export const isEligibleForAutomatedTransfer = compose(
 	getEligibilityStatus,
 	getEligibility
 );
+
+/**
+ * Determine if eligibility warnings or holds exist for
+ * a site other than a business plan hold.
+ *
+ * @param {Object} state global app state
+ * @param {number} siteId requested site for transfer info
+ * @returns {boolean} False if there is one and only one hold/warning referring to missing business plan
+ */
+export const hasEligibilityMessagesOtherThanBusiness = ( state, siteId ) => {
+	const data = getEligibility( state, siteId );
+	const holds = get( data, 'eligibilityHolds', [] );
+	const warnings = get( data, 'eligibilityWarnings', [] );
+
+	return warnings.length > 0 ||
+		holds.length > 1 ||
+		( holds.length > 0 && ! includes( holds, 'NO_BUSINESS_PLAN' ) );
+};


### PR DESCRIPTION
Only display eligibility card if there are messages to show other than missing business plan. Missing biz plan case is already handled by a plan nudge and a disabled upload zone. The idea here is not to bother the user with the eligibility card unless it adds any information.

**To Test**
Go to http://calypso.localhost:3000/design/upload and view for different sites.

**No errors/warnings before**
<img width="754" alt="screen shot 2017-02-09 at 13 58 57" src="https://cloud.githubusercontent.com/assets/7767559/22787717/22454682-eed5-11e6-91d6-e1d7f6b0bd82.png">

**No errors/warnings after**
<img width="774" alt="screen shot 2017-02-09 at 13 59 11" src="https://cloud.githubusercontent.com/assets/7767559/22787719/246ab960-eed5-11e6-8aaa-ac587f421835.png">

**Only missing business plan before**
<img width="782" alt="screen shot 2017-02-09 at 13 59 27" src="https://cloud.githubusercontent.com/assets/7767559/22787721/2781d976-eed5-11e6-8b8b-f8c437859bda.png">

**Only missing business plan after**
<img width="770" alt="screen shot 2017-02-09 at 13 59 45" src="https://cloud.githubusercontent.com/assets/7767559/22787722/299f5170-eed5-11e6-84d2-04dfdfd533be.png">
