### PR TITLE
Themes: fix forum URL to show even without site selected

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -666,7 +666,7 @@ export default connect(
 			isActive: selectedSite && isThemeActive( state, id, selectedSite.ID ),
 			isPremium: isThemePremium( state, id ),
 			isPurchased: selectedSite && isPremiumThemeAvailable( state, id, selectedSite.ID ),
-			forumUrl: selectedSite && getThemeForumUrl( state, id, selectedSite.ID ),
+			forumUrl: getThemeForumUrl( state, id, selectedSite && selectedSite.ID ),
 		};
 	},
 	{


### PR DESCRIPTION
There's a bug where Theme Sheet support Forum URLs don't show up unless a site is selected. This PR fixes it.

Props: @ockham

Before:
  
![screen shot 2017-02-09 at 15 11 05](https://cloud.githubusercontent.com/assets/4389/22789137/0527fe82-eeda-11e6-85ea-f5c36bd3647a.png)

This PR:

![screen shot 2017-02-09 at 15 11 08](https://cloud.githubusercontent.com/assets/4389/22789145/0b909504-eeda-11e6-92fb-239f080aa7fb.png)


### To test:

* Open My Sites → Themes
* Check the Support pages for a Free Theme + Single Site
* Check the Support pages for a Free Theme + All Sites (no site in URL)
* Check the Support pages for a Premium Theme + Single Site
* Check the Support pages for a Premium Theme + All Sites (no site in URL)

The forum URL should show up every time, and change from generic volunteer one to the specific one for Premium themes.
