### PR TITLE
Video: Switch from showing video in an iframe to loading VideoPress script directly

### DIFF
--- a/client/lib/load-script/index.js
+++ b/client/lib/load-script/index.js
@@ -67,8 +67,28 @@ var loadjQueryDependentScript = function( scriptURL, callback ) {
 	} );
 };
 
+const removeScriptCallback = function( url, callback ) {
+	if ( ! callbacksForURLsInProgress[ url ] ) {
+		return;
+	}
+
+	const index = callbacksForURLsInProgress[ url ].indexOf( callback );
+
+	if ( -1 === index ) {
+		return;
+	}
+
+	if ( 1 === callbacksForURLsInProgress[ url ].length ) {
+		delete callbacksForURLsInProgress[ url ];
+		return;
+	}
+
+	callbacksForURLsInProgress[ url ].splice( index, 1 );
+};
+
 module.exports = {
 	loadScript: loadScript,
 	loadjQueryDependentScript: loadjQueryDependentScript,
+	removeScriptCallback: removeScriptCallback,
 	JQUERY_URL: JQUERY_URL
 };

--- a/client/post-editor/media-modal/detail/_style.scss
+++ b/client/post-editor/media-modal/detail/_style.scss
@@ -68,6 +68,13 @@
 		transition: opacity 200ms ease-in-out;
 	}
 
+	&.is-video {
+		display: flex;
+		align-items: center;
+		height: 100%;
+		width: 100%;
+	}
+
 	&.is-uploading,
 	&.is-loading {
 		opacity: 0.5;

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -13,6 +13,7 @@ import loadScript from 'lib/load-script';
  * Module variables
  */
 const log = debug( 'calypso:post-editor:videopress' );
+const videoPressUrl = 'https://wordpress.com/wp-content/plugins/video/assets/js/next/videopress.js';
 
 class EditorMediaModalDetailPreviewVideoPress extends Component {
 	static propTypes = {
@@ -35,6 +36,7 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 	}
 
 	componentWillUnmount() {
+		loadScript.removeScriptCallback( videoPressUrl, this.onScriptLoaded );
 		this.destroy();
 	}
 
@@ -56,7 +58,7 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 	setVideoInstance = ref => this.video = ref;
 
 	loadInitializeScript() {
-		loadScript.loadScript( 'https://wordpress.com/wp-content/plugins/video/assets/js/next/videopress.js', this.onScriptLoaded );
+		loadScript.loadScript( videoPressUrl, this.onScriptLoaded );
 	}
 
 	onScriptLoaded( error ) {

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -25,12 +25,6 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 		isPlaying: false,
 	};
 
-	constructor() {
-		super();
-
-		this.onScriptLoaded = this.onScriptLoaded.bind( this );
-	}
-
 	componentDidMount() {
 		this.loadInitializeScript();
 	}
@@ -61,20 +55,25 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 		loadScript.loadScript( videoPressUrl, this.onScriptLoaded );
 	}
 
-	onScriptLoaded( error ) {
+	onScriptLoaded = ( error ) => {
 		if ( error ) {
 			log( `Script${ error.src } failed to load.` );
 			return;
 		}
 
-		/* eslint-disable no-undef */
-		this.player = videopress( this.props.item.videopress_guid, this.video, {
-		/* eslint-enable no-undef */
-			autoPlay: this.props.isPlaying,
-			height: this.props.item.height,
-			width: this.props.item.width,
-		} );
-	}
+		const {
+			isPlaying,
+			item,
+		} = this.props;
+
+		if ( typeof window !== 'undefined' && window.videopress ) {
+			this.player = window.videopress( item.videopress_guid, this.video, {
+				autoPlay: isPlaying,
+				height: item.height,
+				width: item.width,
+			} );
+		}
+	};
 
 	destroy() {
 		if ( ! this.player ) {

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -7,7 +7,7 @@ import debug from 'debug';
 /**
  * Internal dependencies
  */
-import loadScript from 'lib/load-script';
+import { loadScript, removeScriptCallback } from 'lib/load-script';
 
 /**
  * Module variables
@@ -30,7 +30,7 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 	}
 
 	componentWillUnmount() {
-		loadScript.removeScriptCallback( videoPressUrl, this.onScriptLoaded );
+		removeScriptCallback( videoPressUrl, this.onScriptLoaded );
 		this.destroy();
 	}
 
@@ -52,7 +52,7 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 	setVideoInstance = ref => this.video = ref;
 
 	loadInitializeScript() {
-		loadScript.loadScript( videoPressUrl, this.onScriptLoaded );
+		loadScript( videoPressUrl, this.onScriptLoaded );
 	}
 
 	onScriptLoaded = ( error ) => {


### PR DESCRIPTION
To facilitate upcoming functionality that allows for choosing a custom poster for a video, the `video` element needs to be accessible in order to be able to control its playback and read its properties. This is not currently possible with the `iframe` approach due to cross-domain restrictions.

This PR eliminates use of the `iframe` and loads the _videopress.js_ script directly. It also adds the ability to auto-play the video by setting the `isPlaying` prop to `true`.

### Testing
Test using a Jetpack site with VideoPress enabled. It should look similar to the following in the media modal:

![screen shot 2017-02-17 at 5 21 51 am](https://cloud.githubusercontent.com/assets/1190420/23061783/2ec3cb34-f4d1-11e6-90e9-c6e4e2bd9cde.jpg)