### PR TITLE
Sharing: Display error response for more detailed feedback

### DIFF
--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -122,6 +122,12 @@ export const onPublicizeConnectionCreate = ( dispatch, { connection } ) => dispa
 	} ) )
 );
 
+export const onPublicizeConnectionCreateFailure = ( dispatch, { error } ) => dispatch(
+	errorNotice( error.message || translate( 'An error occurred while connecting the account.', {
+		context: 'Sharing: Publicize connection confirmation'
+	} ) )
+);
+
 export const onPublicizeConnectionDelete = ( dispatch, { connection } ) => dispatch(
 	successNotice( translate( 'The %(service)s account was successfully disconnected.', {
 		args: { service: connection.label },
@@ -212,7 +218,7 @@ export const handlers = {
 	[ POST_RESTORE_SUCCESS ]: dispatchSuccess( translate( 'Post successfully restored' ) ),
 	[ POST_SAVE_SUCCESS ]: onPostSaveSuccess,
 	[ PUBLICIZE_CONNECTION_CREATE ]: onPublicizeConnectionCreate,
-	[ PUBLICIZE_CONNECTION_CREATE_FAILURE ]: dispatchError( translate( 'An error occurred while connecting the account.' ) ),
+	[ PUBLICIZE_CONNECTION_CREATE_FAILURE ]: onPublicizeConnectionCreateFailure,
 	[ PUBLICIZE_CONNECTION_DELETE ]: onPublicizeConnectionDelete,
 	[ PUBLICIZE_CONNECTION_DELETE_FAILURE ]: onPublicizeConnectionDeleteFailure,
 	[ PUBLICIZE_CONNECTION_REFRESH ]: onPublicizeConnectionRefresh,


### PR DESCRIPTION
With the  merge of #10833, publicize creation errors are now human readable and provide a lot more context than the generic error message we're currently displaying.

#10833 allows us to query for the selected site when displaying publicize connections, meaning the client now knows about all connections and we won't run into a situation where we'd try to make a connection that already exists,  resulting in: 
> A publicize connection for this blog ID and Keyring connection ID already exists. You should be able to find it via the `/sites/$site/publicize-connections` endpoint.

See #8991 

To test: Modify the `/me/publicize-connections/new` endpoint to return an error and watch it be displayed.