### PR TITLE
Signup: Fix Themes step horizontal scroll

### DIFF
--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -15,11 +15,11 @@ export default React.createClass( {
 	displayName: 'StepWrapper',
 
 	propTypes: {
-		hideNavButtons: React.PropTypes.bool
+		shouldHideNavButtons: React.PropTypes.bool
 	},
 
 	renderBack: function() {
-		if ( this.props.hideNavButtons ) {
+		if ( this.props.shouldHideNavButtons ) {
 			return null;
 		}
 		return (
@@ -35,7 +35,7 @@ export default React.createClass( {
 	},
 
 	renderSkip: function() {
-		if ( !this.props.hideNavButtons && this.props.goToNextStep ) {
+		if ( ! this.props.shouldHideNavButtons && this.props.goToNextStep ) {
 			return (
 				<NavigationLink
 					direction="forward"

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -14,7 +14,14 @@ import config from 'config';
 export default React.createClass( {
 	displayName: 'StepWrapper',
 
+	propTypes: {
+		hideNavButtons: React.PropTypes.bool
+	},
+
 	renderBack: function() {
+		if ( this.props.hideNavButtons ) {
+			return null;
+		}
 		return (
 			<NavigationLink
 				direction="back"
@@ -28,7 +35,7 @@ export default React.createClass( {
 	},
 
 	renderSkip: function() {
-		if ( this.props.goToNextStep ) {
+		if ( !this.props.hideNavButtons && this.props.goToNextStep ) {
 			return (
 				<NavigationLink
 					direction="forward"
@@ -78,7 +85,7 @@ export default React.createClass( {
 					headerText={ this.headerText() }
 					subHeaderText={ this.subHeaderText() }>
 					{ config.isEnabled( 'jetpack/connect' )
-						? ( headerButton )
+						? headerButton
 						: null }
 				</StepHeader>
 				<div className="step-wrapper__content is-animated-content">

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -66,13 +66,35 @@ class ThemeSelectionStep extends Component {
 	};
 
 	renderThemesList() {
+
+		const pressableWrapperClassName = classNames( {
+			'theme-selection__pressable-wrapper': true,
+			'is-hidden': ! this.state.showPressable,
+		} );
+
+		const themesWrapperClassName = classNames( {
+			'theme-selection__themes-wrapper': true,
+			'is-hidden': this.state.showPressable,
+		} );
+
 		return (
-			<SignupThemesList
-				surveyQuestion={ this.props.chosenSurveyVertical }
-				designType={ this.props.designType || this.props.signupDependencies.designType }
-				handleScreenshotClick={ this.pickTheme }
-				handleThemeUpload={ this.handleThemeUpload }
-			/>
+			<div className="theme-selection__pressable-substep-wrapper">
+				<div className={ pressableWrapperClassName }>
+					<PressableThemeStep
+						{ ... this.props }
+						onBackClick={ this.handleStoreBackClick }
+					/>
+				</div>
+				<div className={ themesWrapperClassName }>
+					<SignupThemesList
+						className={ themesWrapperClassName }
+						surveyQuestion={ this.props.chosenSurveyVertical }
+						designType={ this.props.designType || this.props.signupDependencies.designType }
+						handleScreenshotClick={ this.pickTheme }
+						handleThemeUpload={ this.handleThemeUpload }
+					/>
+				</div>
+			</div>
 		);
 	}
 
@@ -101,42 +123,27 @@ class ThemeSelectionStep extends Component {
 
 	render = () => {
 		const defaultDependencies = this.props.useHeadstart ? { themeSlugWithRepo: 'pub/twentysixteen' } : undefined;
-
-		const pressableWrapperClassName = classNames( {
-			'theme-selection__pressable-wrapper': true,
-			'is-hidden': ! this.state.showPressable,
-		} );
-
-		const themesWrapperClassName = classNames( {
-			'theme-selection__themes-wrapper': true,
-			'is-hidden': this.state.showPressable,
-		} );
-
 		const { translate } = this.props;
 
+		let headerText = translate( 'Choose a theme.' );
+		let subHeaderText = translate( 'No need to overthink it. You can always switch to a different theme later.' );
+
+		if ( this.state.showPressable ) {
+			headerText = translate( 'Upload your WordPress Theme' );
+			subHeaderText = translate( 'Our partner Pressable is here to help you' );
+		}
+
 		return (
-			<div>
-				<div className={ pressableWrapperClassName } >
-					<PressableThemeStep
-						{ ... this.props }
-						onBackClick={ this.handleStoreBackClick }
-					/>
-				</div>
-				<div className={ themesWrapperClassName } >
-					<StepWrapper
-						fallbackHeaderText={ translate( 'Choose a theme.' ) }
-						fallbackSubHeaderText={
-							translate( 'No need to overthink it. You can always switch to a different theme later.' )
-						}
-						subHeaderText={
-							translate( 'Choose a theme. You can always switch to a different theme later.' )
-						}
-						stepContent={ this.renderThemesList() }
-						defaultDependencies={ defaultDependencies }
-						headerButton={ this.renderJetpackButton() }
-						{ ...this.props } />
-					</div>
-			</div>
+			<StepWrapper
+				fallbackHeaderText={ headerText }
+				fallbackSubHeaderText={ subHeaderText }
+				subHeaderText={ subHeaderText }
+				stepContent={ this.renderThemesList() }
+				defaultDependencies={ defaultDependencies }
+				headerButton={ this.renderJetpackButton() }
+				hideNavButtons={ this.state.showPressable }
+				{ ...this.props }
+			/>
 		);
 	}
 }

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -66,21 +66,21 @@ class ThemeSelectionStep extends Component {
 	};
 
 	renderThemesList() {
-		const pressableWrapperClassName = classNames( {
-			'theme-selection__pressable-wrapper': true,
-			'is-hidden': ! this.state.showPressable,
-		} );
+		const pressableWrapperClassName = classNames(
+			'theme-selection__pressable-wrapper',
+			{ 'is-hidden': ! this.state.showPressable }
+		);
 
-		const themesWrapperClassName = classNames( {
-			'theme-selection__themes-wrapper': true,
-			'is-hidden': this.state.showPressable,
-		} );
+		const themesWrapperClassName = classNames(
+			'theme-selection__themes-wrapper',
+			{ 'is-hidden': this.state.showPressable }
+		);
 
 		return (
 			<div className="theme-selection__pressable-substep-wrapper">
 				<div className={ pressableWrapperClassName }>
 					<PressableThemeStep
-						{ ... this.props }
+						{ ...this.props }
 						onBackClick={ this.handleStoreBackClick }
 					/>
 				</div>
@@ -129,8 +129,12 @@ class ThemeSelectionStep extends Component {
 			: translate( 'Choose a theme.' );
 
 		const subHeaderText = this.state.showPressable
-			? translate( 'Our partner Pressable is here to help you' )
-			: translate( 'No need to overthink it. You can always switch to a different theme later.' );
+			? translate( 'Our partner Pressable is here to help you', {
+				context: 'Subheader text in Signup, when a user chooses the Upload theme in the Themes step'
+			} )
+			: translate( 'No need to overthink it. You can always switch to a different theme later.', {
+				context: 'Themes step subheader in Signup'
+			} );
 
 		return (
 			<StepWrapper
@@ -140,7 +144,7 @@ class ThemeSelectionStep extends Component {
 				stepContent={ this.renderThemesList() }
 				defaultDependencies={ defaultDependencies }
 				headerButton={ this.renderJetpackButton() }
-				hideNavButtons={ this.state.showPressable }
+				shouldHideNavButtons={ this.state.showPressable }
 				{ ...this.props }
 			/>
 		);

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -66,7 +66,6 @@ class ThemeSelectionStep extends Component {
 	};
 
 	renderThemesList() {
-
 		const pressableWrapperClassName = classNames( {
 			'theme-selection__pressable-wrapper': true,
 			'is-hidden': ! this.state.showPressable,
@@ -125,13 +124,13 @@ class ThemeSelectionStep extends Component {
 		const defaultDependencies = this.props.useHeadstart ? { themeSlugWithRepo: 'pub/twentysixteen' } : undefined;
 		const { translate } = this.props;
 
-		let headerText = translate( 'Choose a theme.' );
-		let subHeaderText = translate( 'No need to overthink it. You can always switch to a different theme later.' );
+		const headerText = this.state.showPressable
+			? translate( 'Upload your WordPress Theme' )
+			: translate( 'Choose a theme.' );
 
-		if ( this.state.showPressable ) {
-			headerText = translate( 'Upload your WordPress Theme' );
-			subHeaderText = translate( 'Our partner Pressable is here to help you' );
-		}
+		const subHeaderText = this.state.showPressable
+			? translate( 'Our partner Pressable is here to help you' )
+			: translate( 'No need to overthink it. You can always switch to a different theme later.' );
 
 		return (
 			<StepWrapper

--- a/client/signup/steps/theme-selection/pressable-theme/index.jsx
+++ b/client/signup/steps/theme-selection/pressable-theme/index.jsx
@@ -18,7 +18,6 @@ import FormInputValidation from 'components/forms/form-input-validation';
 import FormButton from 'components/forms/form-button';
 import FormLabel from 'components/forms/form-label';
 import FormSectionHeading from 'components/forms/form-section-heading';
-import StepHeader from 'signup/step-header';
 import Button from 'components/button';
 import analytics from 'lib/analytics';
 
@@ -111,10 +110,6 @@ export default React.createClass( {
 	render() {
 		return (
 			<div className="pressable-theme">
-				<StepHeader
-					headerText={ this.translate( 'Upload your WordPress Theme' ) }
-					subHeaderText={ this.translate( 'Our partner Pressable is here to help you' ) }
-				/>
 				{ this.renderThemeForm() }
 				<div className="pressable-theme__back-button-wrapper">
 					<Button compact borderless onClick={ this.props.onBackClick }>

--- a/client/signup/steps/theme-selection/style.scss
+++ b/client/signup/steps/theme-selection/style.scss
@@ -27,3 +27,9 @@
 	}
 }
 
+/**
+ * Fixes Pressable sub-step width
+ */
+.theme-selection__pressable-substep-wrapper {
+	position: relative;
+}

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -13,6 +13,7 @@
 	position: absolute;
 		left: 0;
 		right: 0;
+	overflow: hidden;
 
 	@include breakpoint( "<480px" ) {
 		margin: 0;


### PR DESCRIPTION
This PR is a fix for #8745.

The Pressable "substeps" in Signup break the design a bit by being shifted to the side. Even though they are hidden, they still expand the bounding box and cause the scroll.

I'm trying to make the substeps play nice with the main steps and not cause such problems.

To test:
* Start Signup
* Reach Themes step
* Check if there is horizontal scroll - there shouldn't be
* Check if the `Upload theme` option is working correctly
* Check the Themes step submits properly
* Finish Signup and verify that the resulting site has the chosen theme
* Verify no JS errors appear in the console

Note:
After starting signup, you need to get yourself in the Theme Upload AB test, as @lsinger mentioned below:
> FWIW, to activate the Upload Theme option:
>
> `localStorage.setItem('ABTests', '{"signupThemeUpload_20160928": "showThemeUpload"}')`