### PR TITLE
Sharing: Simplify components in prep for #8991

### DIFF
--- a/client/my-sites/sharing/connections/account-dialog-account.jsx
+++ b/client/my-sites/sharing/connections/account-dialog-account.jsx
@@ -1,66 +1,49 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 
-export default class AccountDialogAccount extends Component {
-	static propTypes = {
-		account: PropTypes.shape( {
-			ID: PropTypes.oneOfType( [ React.PropTypes.number, React.PropTypes.string ] ),
-			name: PropTypes.string,
-			picture: PropTypes.string,
-			keyringConnectionId: PropTypes.number,
-			isConnected: PropTypes.bool,
-			isExternal: PropTypes.bool
-		} ).isRequired,
-		selected: PropTypes.bool,
-		conflicting: PropTypes.bool,
-		onChange: PropTypes.func,
-	};
+const AccountDialogAccount = ( { account, conflicting, onChange, selected } ) => {
+	const classes = classNames( 'account-dialog-account', {
+		'is-connected': account.isConnected,
+		'is-conflict': conflicting,
+	} );
 
-	static defaultProps = {
-		conflicting: false,
-		connected: false,
-		onChange: () => {},
-		selected: false,
-	};
+	return (
+		<li className={ classes }>
+			<label className="account-dialog-account__label">
+				{ conflicting && <Gridicon icon="notice" /> }
+				{ ! account.isConnected &&
+					<input type="radio" onChange={ onChange } checked={ selected } className="account-dialog-account__input" /> }
+				{ account.picture &&
+					<img src={ account.picture } alt={ account.name } className="account-dialog-account__picture" /> }
+				<span className="account-dialog-account__name">{ account.name }</span>
+			</label>
+		</li>
+	);
+};
 
-	getPictureElement() {
-		if ( this.props.account.picture ) {
-			return <img
-				src={ this.props.account.picture }
-				alt={ this.props.account.name }
-				className="account-dialog-account__picture" />;
-		}
-	}
+AccountDialogAccount.propTypes = {
+	account: PropTypes.shape( {
+		ID: PropTypes.oneOfType( [ React.PropTypes.number, React.PropTypes.string ] ),
+		name: PropTypes.string,
+		picture: PropTypes.string,
+		keyringConnectionId: PropTypes.number,
+		isConnected: PropTypes.bool,
+		isExternal: PropTypes.bool
+	} ).isRequired,
+	selected: PropTypes.bool,
+	conflicting: PropTypes.bool,
+	onChange: PropTypes.func,
+};
 
-	getRadioElement() {
-		if ( ! this.props.account.isConnected ) {
-			return <input
-				type="radio"
-				onChange={ this.props.onChange }
-				checked={ this.props.selected }
-				className="account-dialog-account__input" />;
-		}
-	}
+AccountDialogAccount.defaultProps = {
+	conflicting: false,
+	connected: false,
+	onChange: () => {},
+	selected: false,
+};
 
-	render() {
-		const classes = classNames( 'account-dialog-account', {
-			'is-connected': this.props.account.isConnected,
-			'is-conflict': this.props.conflicting,
-		} );
-
-		return (
-			<li className={ classes }>
-				<label className="account-dialog-account__label">
-					{ this.props.conflicting && <Gridicon icon="notice" /> }
-					{ this.getRadioElement() }
-					{ this.getPictureElement() }
-					<span className="account-dialog-account__name">{ this.props.account.name }</span>
-				</label>
-			</li>
-		);
-	}
-}
+export default AccountDialogAccount;

--- a/client/my-sites/sharing/connections/connections.jsx
+++ b/client/my-sites/sharing/connections/connections.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 
@@ -11,33 +11,28 @@ import { localize } from 'i18n-calypso';
 import QueryKeyringServices from 'components/data/query-keyring-services';
 import SharingServicesGroup from './services-group';
 
-class SharingConnections extends Component {
-	static propTypes = {
-		connections: PropTypes.object,
-		translate: PropTypes.func,
-	};
+const SharingConnections = ( { connections, translate } ) => (
+	<div className="sharing-settings sharing-connections">
+		<QueryKeyringServices />
+		<SharingServicesGroup
+			type="publicize"
+			title={ translate( 'Publicize Your Posts' ) }
+			connections={ connections } />
+		<SharingServicesGroup
+			type="other"
+			title={ translate( 'Other Connections' ) }
+			connections={ connections } />
+	</div>
+);
 
-	static defaultProps = {
-		connections: Object.freeze( {} ),
-		translate: identity,
-	};
+SharingConnections.propTypes = {
+	connections: PropTypes.object,
+	translate: PropTypes.func,
+};
 
-	render() {
-		return (
-			<div className="sharing-settings sharing-connections">
-				<QueryKeyringServices />
-				<SharingServicesGroup
-					type="publicize"
-					title={ this.props.translate( 'Publicize Your Posts' ) }
-					connections={ this.props.connections } />
-				<SharingServicesGroup
-					type="other"
-					title={ this.props.translate( 'Other Connections' ) }
-					description={ this.props.translate( 'Connect any of these additional services to further enhance your site.' ) }
-					connections={ this.props.connections } />
-			</div>
-		);
-	}
-}
+SharingConnections.defaultProps = {
+	connections: {},
+	translate: identity,
+};
 
 export default localize( SharingConnections );

--- a/client/my-sites/sharing/connections/service-example.jsx
+++ b/client/my-sites/sharing/connections/service-example.jsx
@@ -1,35 +1,29 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 
-export default class SharingServiceExample extends Component {
-	static propTypes = {
-		image: PropTypes.shape( {
-			src: PropTypes.string,
-			alt: PropTypes.string
-		} ),
-		label: PropTypes.node,
-		single: PropTypes.bool,
-	};
+const SharingServiceExample = ( { image, label, single } ) => (
+	<div className={ classNames( 'sharing-service-example', { 'is-single': single } ) }>
+		<div className="sharing-service-example-screenshot">
+			<img src={ image.src } alt={ image.alt } />
+		</div>
+		<div className="sharing-service-example-screenshot-label">{ label }</div>
+	</div>
+);
 
-	static defaultProps = {
-		single: false,
-	};
+SharingServiceExample.propTypes = {
+	image: PropTypes.shape( {
+		src: PropTypes.string,
+		alt: PropTypes.string
+	} ),
+	label: PropTypes.node,
+	single: PropTypes.bool,
+};
 
-	render() {
-		const classes = classNames( 'sharing-service-example', {
-			'is-single': this.props.single
-		} );
+SharingServiceExample.defaultProps = {
+	single: false,
+};
 
-		return (
-			<div className={ classes }>
-				<div className="sharing-service-example-screenshot">
-					<img src={ this.props.image.src } alt={ this.props.image.alt } />
-				</div>
-				<div className="sharing-service-example-screenshot-label">{ this.props.label }</div>
-			</div>
-		);
-	}
-}
+export default SharingServiceExample;

--- a/client/my-sites/sharing/connections/services-group.jsx
+++ b/client/my-sites/sharing/connections/services-group.jsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
-import classNames from 'classnames';
+import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { times } from 'lodash';
 
@@ -20,45 +19,33 @@ import ServicePlaceholder from './service-placeholder';
  */
 const NUMBER_OF_PLACEHOLDERS = 4;
 
-class SharingServicesGroup extends Component {
-	static propTypes = {
-		connections: PropTypes.object,
-		description: PropTypes.string,
-		services: PropTypes.array,
-		title: PropTypes.string.isRequired,
-		type: PropTypes.string.isRequired,
-	};
+const SharingServicesGroup = ( { connections, services, title } ) => (
+	<div className="sharing-services-group">
+		<SectionHeader label={ title } />
+		<ul className="sharing-services-group__services">
+			{ services.length
+				? services.map( ( service ) => (
+					<Service key={ service.ID } connections={ connections } service={ service } />
+				) )
+				: times( NUMBER_OF_PLACEHOLDERS, ( index ) => (
+					<ServicePlaceholder key={ 'service-placeholder-' + index } />
+				) )
+			}
+		</ul>
+	</div>
+);
 
-	static defaultProps = {
-		connections: Object.freeze( {} ),
-		description: '',
-		services: Object.freeze( [] ),
-	};
+SharingServicesGroup.propTypes = {
+	connections: PropTypes.object,
+	services: PropTypes.array,
+	title: PropTypes.string.isRequired,
+	type: PropTypes.string.isRequired,
+};
 
-	render() {
-		const classes = classNames( 'sharing-services-group', {
-			'is-empty': ! this.props.services.length
-		} );
-
-		return (
-			<div className={ classes }>
-				<SectionHeader label={ this.props.title } />
-				<ul className="sharing-services-group__services">
-					{ this.props.services.length
-						? this.props.services.map( ( service ) =>
-							<Service
-								key={ service.ID }
-								connections={ this.props.connections }
-								service={ service } /> )
-						: times( NUMBER_OF_PLACEHOLDERS, ( index ) =>
-							<ServicePlaceholder
-								key={ 'service-placeholder-' + index } /> )
-					}
-				</ul>
-			</div>
-		);
-	}
-}
+SharingServicesGroup.defaultProps = {
+	connections: Object.freeze( {} ),
+	services: Object.freeze( [] ),
+};
 
 export default connect(
 	( state, { type } ) => ( {


### PR DESCRIPTION
This is a janitorial PR, aiming to make reviewing and merging #8991 easier. It moves out a lot of the "noisy" optimization changes in that PR that are not directly related to removing `connections-list`.

To test:
Go to `/sharing/:site:/` and verify that creating and deleting single & multiple connections still work without errors.