### PR TITLE
Makefile: add a few useful docker commands to the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,7 @@ docker-build:
 	docker build -t wp-calypso .
 
 docker-run:
+	@echo running wp-calypso docker image at localhost:3000
 	docker run -it --name wp-calypso --rm -p 80:3000 -e NODE_ENV='wpcalypso' -e CALYPSO_ENV='wpcalypso' wp-calypso
 
 

--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,13 @@ urn:
 	@printf "⚱\n\n";
 	@$(MAKE) run;
 
+docker-build:
+	docker build -t wp-calypso .
+
+docker-run:
+	docker run -it --name wp-calypso --rm -p 80:3000 -e NODE_ENV='wpcalypso' -e CALYPSO_ENV='wpcalypso' wp-calypso
+
+
 # rule that can be used as a prerequisite for other rules to force them to always run
 FORCE:
 


### PR DESCRIPTION
I recently ran into some issues where things broke on docker builds but not in regular devserver builds.

It would be nice (and help encourage more docker testing) if we had make targets for building/running wpcalypso in docker.  This PR seeks to add:
1. `make docker-build`
2. `make docker-run`