### PR TITLE
[Remove SitesList] Move `lib/site/computed-attributes` to appropriate state folder

### DIFF
--- a/client/lib/people/log-store.js
+++ b/client/lib/people/log-store.js
@@ -110,7 +110,12 @@ PeopleLogStore.dispatchToken = Dispatcher.register( function( payload ) {
 			}
 			break;
 		case 'RECEIVE_USER_FAILED':
-			addLog( 'error', action.type, action.fetchOptions.siteId, action.login, action.error.error );
+			addLog( 'error',
+				action.type,
+				action.fetchOptions.siteId,
+				{ login: action.login, userId: action.userId },
+				action.error.error
+			);
 			PeopleLogStore.emitChange();
 			break;
 		case 'UPDATE_SITE_USER':

--- a/client/lib/site/README.md
+++ b/client/lib/site/README.md
@@ -3,8 +3,6 @@ Site
 
 Instances of `site` are returned by [`sites-list`](/client/lib/sites-list) and represent a WordPress.com or Jetpack site. Properties on `site` mirror those of an individual site returned by the [`/me/sites`](https://developer.wordpress.com/docs/api/1.1/get/me/sites/) API endpoint.
 
-Also provides utility methods such as `isCustomizable()` and `isUpgradeable()`.
-
 #### jetpack.js
 Extends `site` for Jetpack sites.
 

--- a/client/lib/site/computed-attributes.js
+++ b/client/lib/site/computed-attributes.js
@@ -49,11 +49,5 @@ export default function( site ) {
 		isHttps( attributes.options.unmapped_url )
 	);
 
-	//TODO:(ehg) Replace instances with canCurrentUser selector when my-sites/sidebar is connected
-	attributes.is_customizable = !! (
-		site.capabilities &&
-		site.capabilities.edit_theme_options
-	);
-
 	return attributes;
 }

--- a/client/lib/site/index.js
+++ b/client/lib/site/index.js
@@ -4,7 +4,6 @@
 var debug = require( 'debug' )( 'calypso:site' ),
 	i18n = require( 'i18n-calypso' ),
 	isEqual = require( 'lodash/isEqual' ),
-	find = require( 'lodash/find' ),
 	omit = require( 'lodash/omit' );
 
 /**
@@ -167,51 +166,6 @@ Site.prototype.saveSettings = function( newSettings, callback ) {
 		callback( error, data );
 	} );
 
-};
-
-/**
- * Returns a site user object by user ID
- *
- * @param  {int} userId The user ID to retrieve
- */
-Site.prototype.getUser = function( userId ) {
-	return find( this.getUsers(), { ID: userId } );
-};
-
-/**
- * Returns all of the site's users. Triggers a fetch if user data doesn't
- * already exist.
- */
-Site.prototype.getUsers = function() {
-	if ( ! this.users ) {
-		this.users = [];
-		this.fetchUsers();
-	}
-
-	return this.users;
-};
-
-/**
- * Triggers a network request to fetch all users for the current site. Emits a
- * "change" event when the users have been fetched.
- */
-Site.prototype.fetchUsers = function() {
-	if ( this.fetchingUsers ) {
-		return;
-	}
-
-	this.fetchingUsers = true;
-
-	wpcom.site( this.ID ).usersList( function( error, data ) {
-		if ( error || ! data.users ) {
-			debug( 'error fetching site users data from api', error );
-			return;
-		}
-
-		this.set( { users: data.users } );
-		this.fetchingUsers = false;
-		this.emit( 'usersFetched' );
-	}.bind( this ) );
 };
 
 Site.prototype.isUpgradeable = function() {

--- a/client/lib/site/index.js
+++ b/client/lib/site/index.js
@@ -218,8 +218,4 @@ Site.prototype.isUpgradeable = function() {
 	return this.capabilities && this.capabilities.manage_options;
 };
 
-Site.prototype.isCustomizable = function() {
-	return !! ( this.capabilities && this.capabilities.edit_theme_options );
-};
-
 module.exports = Site;

--- a/client/lib/users/actions.js
+++ b/client/lib/users/actions.js
@@ -113,22 +113,22 @@ const UsersActions = {
 		wpcom.undocumented().site( siteId ).updateUser( userId, attributes, ( error, data ) => {
 			if ( error ) {
 				debug( 'Update user error', error );
-				Dispatcher.handleServerAction( {
+				return Dispatcher.handleServerAction( {
 					type: 'RECEIVE_UPDATE_SITE_USER_FAILURE',
 					action: 'UPDATE_SITE_USER',
 					siteId: siteId,
 					user: user,
 					error: error
 				} );
-			} else {
-				Dispatcher.handleServerAction( {
-					type: 'RECEIVE_UPDATE_SITE_USER_SUCCESS',
-					action: 'UPDATE_SITE_USER',
-					siteId: siteId,
-					user: user,
-					data: data
-				} );
 			}
+
+			Dispatcher.handleServerAction( {
+				type: 'RECEIVE_UPDATE_SITE_USER_SUCCESS',
+				action: 'UPDATE_SITE_USER',
+				siteId: siteId,
+				user: user,
+				data: data
+			} );
 		} );
 	},
 
@@ -142,23 +142,49 @@ const UsersActions = {
 
 		wpcom.undocumented().site( fetchOptions.siteId ).getUser( userId, ( error, data ) => {
 			if ( error ) {
+				return Dispatcher.handleServerAction( {
+					type: 'RECEIVE_USER_FAILED',
+					siteId: fetchOptions.siteId,
+					fetchOptions,
+					userId,
+					error
+				} );
+			}
+
+			Dispatcher.handleServerAction( {
+				type: 'RECEIVE_SINGLE_USER',
+				fetchOptions: fetchOptions,
+				user: data
+			} );
+		} );
+	},
+
+	fetchUserByLogin: ( fetchOptions, login ) => {
+		debug( 'fetchUserByLogin', fetchOptions );
+
+		Dispatcher.handleViewAction( {
+			type: 'FETCHING_USERS',
+			fetchOptions: fetchOptions
+		} );
+
+		wpcom.undocumented().site( fetchOptions.siteId ).getUserByLogin( login, ( error, data ) => {
+			if ( error ) {
 				Dispatcher.handleServerAction( {
 					type: 'RECEIVE_USER_FAILED',
-					fetchOptions: fetchOptions,
 					siteId: fetchOptions.siteId,
-					userId: userId,
-					error: error
+					fetchOptions,
+					login,
+					error
 				} );
 			} else {
 				Dispatcher.handleServerAction( {
 					type: 'RECEIVE_SINGLE_USER',
-					fetchOptions: fetchOptions,
+					fetchOptions,
 					user: data
 				} );
 			}
 		} );
 	}
-
 };
 
 module.exports = UsersActions;

--- a/client/lib/users/actions.js
+++ b/client/lib/users/actions.js
@@ -132,7 +132,7 @@ const UsersActions = {
 		} );
 	},
 
-	fetchUser: ( fetchOptions, login ) => {
+	fetchUser: ( fetchOptions, userId ) => {
 		debug( 'fetchUser', fetchOptions );
 
 		Dispatcher.handleViewAction( {
@@ -140,13 +140,13 @@ const UsersActions = {
 			fetchOptions: fetchOptions
 		} );
 
-		wpcom.undocumented().site( fetchOptions.siteId ).getUser( login, ( error, data ) => {
+		wpcom.undocumented().site( fetchOptions.siteId ).getUser( userId, ( error, data ) => {
 			if ( error ) {
 				Dispatcher.handleServerAction( {
 					type: 'RECEIVE_USER_FAILED',
 					fetchOptions: fetchOptions,
 					siteId: fetchOptions.siteId,
-					login: login,
+					userId: userId,
 					error: error
 				} );
 			} else {

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -151,7 +151,11 @@ UndocumentedSite.prototype.updateUser = function( userId, attributes, callback )
 	}, callback );
 };
 
-UndocumentedSite.prototype.getUser = function( login, callback ) {
+UndocumentedSite.prototype.getUser = function( userId, callback ) {
+	return this.wpcom.req.get( '/sites/' + this._id + '/users/' + userId, callback );
+};
+
+UndocumentedSite.prototype.getUserByLogin = function( login, callback ) {
 	return this.wpcom.req.get( '/sites/' + this._id + '/users/login:' + login, callback );
 };
 

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -126,7 +126,7 @@ function renderSingleTeamMember( context ) {
 		user = UsersStore.getUserByLogin( siteId, userLogin );
 
 		if ( ! user ) {
-			UsersActions.fetchUser( { siteId: siteId }, userLogin );
+			UsersActions.fetchUserByLogin( { siteId }, userLogin );
 			PeopleLogStore.once( 'change', function() {
 				let fetchUserError = PeopleLogStore.getErrors(
 					log => siteId === log.siteId && 'RECEIVE_USER_FAILED' === log.action && userLogin === log.user

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -251,7 +251,7 @@ module.exports = protectForm( React.createClass( {
 		UsersStore.on( 'change', this.refreshUser );
 		PeopleLog.on( 'change', this.checkRemoveUser );
 		if ( ! this.state.user && this.props.siteId ) {
-			UsersActions.fetchUser( { siteId: this.props.siteId }, this.props.userLogin );
+			UsersActions.fetchUserByLogin( { siteId: this.props.siteId }, this.props.userLogin );
 		}
 	},
 

--- a/client/my-sites/sharing/connections/connection.jsx
+++ b/client/my-sites/sharing/connections/connection.jsx
@@ -14,7 +14,7 @@ import { getCurrentUserId } from 'state/current-user/selectors';
 import { canCurrentUser } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
-import site from 'lib/site';
+import UsersStore from 'lib/users/store';
 
 class SharingConnection extends Component {
 	static propTypes = {
@@ -126,8 +126,7 @@ class SharingConnection extends Component {
 	}
 
 	getConnectionKeyringUserLabel() {
-		const { connection, siteId, translate, userId } = this.props;
-		const keyringUser = site( { ID: siteId } ).getUser( connection.keyring_connection_user_ID );
+		const keyringUser = this.props.getUser( this.props.connection.keyring_connection_user_ID );
 
 		if ( keyringUser && userId !== keyringUser.ID ) {
 			return (
@@ -204,6 +203,7 @@ export default connect(
 			siteId,
 			userHasCaps: canCurrentUser( state, siteId, 'edit_others_posts' ),
 			userId: getCurrentUserId( state ),
+			getUser: userId => UsersStore.getUser( getSelectedSiteId( state ), userId ),
 		};
 	},
 	{ recordGoogleEvent },

--- a/client/my-sites/sharing/connections/connection.jsx
+++ b/client/my-sites/sharing/connections/connection.jsx
@@ -15,6 +15,7 @@ import { canCurrentUser } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import UsersStore from 'lib/users/store';
+import UsersActions from 'lib/users/actions';
 
 class SharingConnection extends Component {
 	static propTypes = {
@@ -126,7 +127,14 @@ class SharingConnection extends Component {
 	}
 
 	getConnectionKeyringUserLabel() {
-		const keyringUser = this.props.getUser( this.props.connection.keyring_connection_user_ID );
+		const { connection, siteId, translate, userId } = this.props;
+
+		const keyringUser = UsersStore.getUser( siteId, connection.keyring_connection_user_ID );
+
+		if ( ! keyringUser ) {
+			UsersActions.fetchUser( { siteId: this.props.siteId }, this.props.connection.keyring_connection_user_ID );
+			UsersStore.once( 'change', () => this.forceUpdate() );
+		}
 
 		if ( keyringUser && userId !== keyringUser.ID ) {
 			return (
@@ -203,7 +211,6 @@ export default connect(
 			siteId,
 			userHasCaps: canCurrentUser( state, siteId, 'edit_others_posts' ),
 			userId: getCurrentUserId( state ),
-			getUser: userId => UsersStore.getUser( getSelectedSiteId( state ), userId ),
 		};
 	},
 	{ recordGoogleEvent },

--- a/client/my-sites/sharing/connections/connection.jsx
+++ b/client/my-sites/sharing/connections/connection.jsx
@@ -79,9 +79,32 @@ class SharingConnection extends Component {
 		};
 	}
 
+	componentWillMount() {
+		this.fetchKeyringUser();
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.siteId !== this.props.siteId || nextProps.connection !== this.props.connection ) {
+			this.fetchKeyringUser();
+		}
+	}
+
 	componentDidUpdate( prevProps ) {
 		if ( this.state.isSavingSitewide && this.props.connection.shared !== prevProps.connection.shared ) {
 			this.setState( { isSavingSitewide: false } );
+		}
+	}
+
+	fetchKeyringUser() {
+		if ( ! this.props.siteId || ! this.props.connection.keyring_connection_user_ID ) {
+			return;
+		}
+
+		const keyringUser = UsersStore.getUser( this.props.siteId, this.props.connection.keyring_connection_user_ID );
+
+		if ( ! keyringUser ) {
+			UsersActions.fetchUser( { siteId: this.props.siteId }, this.props.connection.keyring_connection_user_ID );
+			UsersStore.once( 'change', () => this.forceUpdate() );
 		}
 	}
 
@@ -130,11 +153,6 @@ class SharingConnection extends Component {
 		const { connection, siteId, translate, userId } = this.props;
 
 		const keyringUser = UsersStore.getUser( siteId, connection.keyring_connection_user_ID );
-
-		if ( ! keyringUser ) {
-			UsersActions.fetchUser( { siteId: this.props.siteId }, this.props.connection.keyring_connection_user_ID );
-			UsersStore.once( 'change', () => this.forceUpdate() );
-		}
 
 		if ( keyringUser && userId !== keyringUser.ID ) {
 			return (

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -190,7 +190,7 @@ export class MySitesSidebar extends Component {
 			jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' ),
 			themesLink;
 
-		if ( site && ! site.isCustomizable() ) {
+		if ( site && ! site.is_customizable ) {
 			return null;
 		}
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -31,7 +31,7 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { setNextLayoutFocus, setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { userCan } from 'lib/site/utils';
-import { isDomainOnlySite } from 'state/selectors';
+import { isDomainOnlySite, isSiteCustomizable } from 'state/selectors';
 import { getCustomizerUrl, isJetpackSite } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { getStatsPathForTab } from 'lib/route/path';
@@ -190,7 +190,7 @@ export class MySitesSidebar extends Component {
 			jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' ),
 			themesLink;
 
-		if ( site && ! site.is_customizable ) {
+		if ( site && ! this.props.isSiteCustomizable ) {
 			return null;
 		}
 
@@ -666,6 +666,7 @@ function mapStateToProps( state ) {
 		isDomainOnly: isDomainOnlySite( state, selectedSiteId ),
 		isJetpack: isJetpackSite( state, selectedSiteId ),
 		isSiteAutomatedTransfer: !! isSiteAutomatedTransfer( state, selectedSiteId ),
+		isSiteCustomizable: !! isSiteCustomizable( state, selectedSiteId ),
 	};
 }
 

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -117,6 +117,7 @@ export isSendingBillingReceiptEmail from './is-sending-billing-receipt-email';
 export isSharingButtonsSaveSuccessful from './is-sharing-buttons-save-successful';
 export isSiteAutomatedTransfer from './is-site-automated-transfer';
 export isSiteBlocked from './is-site-blocked';
+export isSiteCustomizable from './is-site-customizable';
 export isSiteOnFreePlan from './is-site-on-free-plan';
 export isSiteSupportingImageEditor from './is-site-supporting-image-editor';
 export isSiteUpgradeable from './is-site-upgradeable';

--- a/client/state/selectors/is-site-customizable.js
+++ b/client/state/selectors/is-site-customizable.js
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies
+ */
+import { canCurrentUser } from 'state/selectors';
+import { getCurrentUserId } from 'state/current-user/selectors';
+import { getRawSite } from 'state/sites/selectors';
+
+/**
+ * Returns true if the site can be customized by the user, false if the
+ * site cannot be customized, or null if customizing ability cannot be
+ * determined.
+ *
+ * @param  {Object}   state  Global state tree
+ * @param  {Number}   siteId Site ID
+ * @return {?Boolean}        Whether site is customizable
+ */
+export default function( state, siteId ) {
+	// Cannot determine site customizing ability if there is no current user
+	if ( ! getCurrentUserId( state ) || ! getRawSite( state, siteId ) ) {
+		return null;
+	}
+
+	return canCurrentUser( state, siteId, 'edit_theme_options' );
+}

--- a/client/state/selectors/test/get-visible-sites.js
+++ b/client/state/selectors/test/get-visible-sites.js
@@ -55,7 +55,7 @@ describe( 'getVisibleSites()', () => {
 				domain: 'example.com',
 				slug: 'example.com',
 				hasConflict: false,
-				is_customizable: false,
+				is_customizable: null,
 				is_previewable: false,
 				options: {
 					default_post_format: 'standard',

--- a/client/state/selectors/test/get-visible-sites.js
+++ b/client/state/selectors/test/get-visible-sites.js
@@ -55,7 +55,6 @@ describe( 'getVisibleSites()', () => {
 				domain: 'example.com',
 				slug: 'example.com',
 				hasConflict: false,
-				is_customizable: null,
 				is_previewable: false,
 				options: {
 					default_post_format: 'standard',

--- a/client/state/selectors/test/is-site-customizable.js
+++ b/client/state/selectors/test/is-site-customizable.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isSiteCustomizable } from '../';
+
+describe( 'isSiteCustomizable()', () => {
+	it( 'should return null if the capability is not set for the current user', () => {
+		const isCustomizable = isSiteCustomizable( {
+			sites: {
+				items: {
+					77203199: {
+						ID: 77203199,
+						URL: 'https://example.com'
+					}
+				}
+			},
+			currentUser: {
+				id: 12345678,
+				capabilities: {
+					77203199: {}
+				}
+			}
+		}, 77203199 );
+
+		expect( isCustomizable ).to.be.null;
+	} );
+
+	it( 'should return true is the corresponding user capability is true for this site', () => {
+		const isCustomizable = isSiteCustomizable( {
+			sites: {
+				items: {
+					77203199: {
+						ID: 77203199,
+						URL: 'http://example.com',
+						options: {
+							unmapped_url: 'http://example.com'
+						}
+					}
+				}
+			},
+			currentUser: {
+				id: 12345678,
+				capabilities: {
+					77203199: {
+						edit_theme_options: true
+					}
+				}
+			}
+		}, 77203199 );
+
+		expect( isCustomizable ).to.be.true;
+	} );
+} );

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -70,7 +70,8 @@ export const getSite = createSelector(
 			title: getSiteTitle( state, siteId ),
 			slug: getSiteSlug( state, siteId ),
 			domain: getSiteDomain( state, siteId ),
-			is_previewable: isSitePreviewable( state, siteId )
+			is_previewable: isSitePreviewable( state, siteId ),
+			is_customizable: isSiteCustomizable( state, siteId )
 		};
 	},
 	( state ) => state.sites.items
@@ -86,7 +87,7 @@ export function getComputedAttributes( state, siteId ) {
 
 	// The 'standard' post format is saved as an option of '0'
 	let defaultPostFormat = getSiteOption( state, siteId, 'default_post_format' );
-	if ( defaultPostFormat === null || defaultPostFormat === '0' ) {
+	if ( defaultPostFormat == null || defaultPostFormat === '0' ) {
 		defaultPostFormat = 'standard';
 	}
 
@@ -94,12 +95,10 @@ export function getComputedAttributes( state, siteId ) {
 		title: trim( site.name ) || domain,
 		slug,
 		domain: isRedirectOrConflicting ? slug : domain,
-		options: Object.assign( site.options, {
+		options: Object.assign( site.options || {}, {
 			...isWpcomMappedDomain && { wpcom_url: wpcomUrl },
 			default_post_format: defaultPostFormat
-		} ),
-		is_previewable: isSitePreviewable( state, siteId ),
-		is_customizable: canCurrentUser( state, siteId, 'edit_theme_options' )
+		} )
 	};
 }
 
@@ -307,6 +306,19 @@ export function isSitePreviewable( state, siteId ) {
 
 	const unmappedUrl = getSiteOption( state, siteId, 'unmapped_url' );
 	return !! unmappedUrl && isHttps( unmappedUrl );
+}
+
+/**
+ * Returns true if the site can be customized by the user, false if the
+ * site cannot be customized, or null if customizing ability cannot be
+ * determined.
+ *
+ * @param  {Object}   state  Global state tree
+ * @param  {Number}   siteId Site ID
+ * @return {?Boolean}        Whether site is customizable
+ */
+export function isSiteCustomizable( state, siteId ) {
+	return state.currentUser ? canCurrentUser( state, siteId, 'edit_theme_options' ) : false;
 }
 
 /**

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -31,7 +31,7 @@ import createSelector from 'lib/create-selector';
 import { fromApi as seoTitleFromApi } from 'components/seo/meta-title-editor/mappings';
 import versionCompare from 'lib/version-compare';
 import { getCustomizerFocus } from 'my-sites/customize/panels';
-import canCurrentUser from 'state/selectors/can-current-user';
+import { isSiteCustomizable } from 'state/selectors';
 
 /**
  * Returns a raw site object by its ID.
@@ -302,24 +302,6 @@ export function isSitePreviewable( state, siteId ) {
 
 	const unmappedUrl = getSiteOption( state, siteId, 'unmapped_url' );
 	return !! unmappedUrl && isHttps( unmappedUrl );
-}
-
-/**
- * Returns true if the site can be customized by the user, false if the
- * site cannot be customized, or null if customizing ability cannot be
- * determined.
- *
- * @param  {Object}   state  Global state tree
- * @param  {Number}   siteId Site ID
- * @return {?Boolean}        Whether site is customizable
- */
-export function isSiteCustomizable( state, siteId ) {
-	// Cannot determine site customizing ability if there is no current user
-	if ( ! state.currentUser ) {
-		return null;
-	}
-
-	return canCurrentUser( state, siteId, 'edit_theme_options' );
 }
 
 /**

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -31,7 +31,6 @@ import createSelector from 'lib/create-selector';
 import { fromApi as seoTitleFromApi } from 'components/seo/meta-title-editor/mappings';
 import versionCompare from 'lib/version-compare';
 import { getCustomizerFocus } from 'my-sites/customize/panels';
-import { isSiteCustomizable } from 'state/selectors';
 
 /**
  * Returns a raw site object by its ID.
@@ -69,7 +68,6 @@ export const getSite = createSelector(
 			slug: getSiteSlug( state, siteId ),
 			domain: getSiteDomain( state, siteId ),
 			is_previewable: isSitePreviewable( state, siteId ),
-			is_customizable: isSiteCustomizable( state, siteId ),
 			options: getSiteOptions( state, siteId ),
 		};
 	},

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -23,7 +23,6 @@ import {
 	getSiteTitle,
 	getSiteThemeShowcasePath,
 	isSitePreviewable,
-	isSiteCustomizable,
 	isRequestingSites,
 	isRequestingSite,
 	getSiteBySlug,
@@ -752,53 +751,6 @@ describe( 'selectors', () => {
 
 				expect( isPreviewable ).to.be.true;
 			} );
-		} );
-	} );
-
-	describe( 'isSiteCustomizable()', () => {
-		it( 'should return null if the capability is not set for the current user', () => {
-			const isCustomizable = isSiteCustomizable( {
-				sites: {
-					items: {
-						77203199: {
-							ID: 77203199,
-							URL: 'https://example.com'
-						}
-					}
-				},
-				currentUser: {
-					capabilities: {
-						77203199: {}
-					}
-				}
-			}, 77203199 );
-
-			expect( isCustomizable ).to.be.null;
-		} );
-
-		it( 'should return true is the corresponding user capability is true for this site', () => {
-			const isCustomizable = isSiteCustomizable( {
-				sites: {
-					items: {
-						77203199: {
-							ID: 77203199,
-							URL: 'http://example.com',
-							options: {
-								unmapped_url: 'http://example.com'
-							}
-						}
-					}
-				},
-				currentUser: {
-					capabilities: {
-						77203199: {
-							edit_theme_options: true
-						}
-					}
-				}
-			}, 77203199 );
-
-			expect( isCustomizable ).to.be.true;
 		} );
 	} );
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -11,6 +11,7 @@ import config from 'config';
 import { useSandbox } from 'test/helpers/use-sinon';
 import {
 	getSite,
+	getSiteOptions,
 	getSiteCollisions,
 	isSiteConflicting,
 	isSingleUserSite,
@@ -111,6 +112,64 @@ describe( 'selectors', () => {
 					default_post_format: 'standard',
 					unmapped_url: 'https://example.wordpress.com'
 				}
+			} );
+		} );
+	} );
+
+	describe( '#getSiteOptions()', () => {
+		it( 'should return null if the site is not known', () => {
+			const siteOptions = getSiteOptions( {
+				sites: {
+					items: {}
+				}
+			}, 2916284 );
+
+			expect( siteOptions ).to.be.null;
+		} );
+
+		it( 'should return a the site options along with the computed option wpcom_url', () => {
+			const siteOptions = getSiteOptions( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.com',
+							options: {
+								unmapped_url: 'https://example.wordpress.com',
+								is_mapped_domain: true
+							}
+						}
+					}
+				}
+			}, 2916284 );
+
+			expect( siteOptions ).to.eql( {
+				default_post_format: 'standard',
+				unmapped_url: 'https://example.wordpress.com',
+				is_mapped_domain: true,
+				wpcom_url: 'example.wordpress.com'
+			} );
+		} );
+
+		it( 'should fix `default_post_format` if it is equal to \'0\'', () => {
+			const siteOptions = getSiteOptions( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.com',
+							options: {
+								default_post_format: '0',
+								unmapped_url: 'https://example.wordpress.com'
+							}
+						}
+					}
+				}
+			}, 2916284 );
+
+			expect( siteOptions ).to.eql( {
+				default_post_format: 'standard',
+				unmapped_url: 'https://example.wordpress.com'
 			} );
 		} );
 	} );

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -23,6 +23,7 @@ import {
 	getSiteTitle,
 	getSiteThemeShowcasePath,
 	isSitePreviewable,
+	isSiteCustomizable,
 	isRequestingSites,
 	isRequestingSite,
 	getSiteBySlug,
@@ -751,6 +752,53 @@ describe( 'selectors', () => {
 
 				expect( isPreviewable ).to.be.true;
 			} );
+		} );
+	} );
+
+	describe( 'isSiteCustomizable()', () => {
+		it( 'should return null if the capability is not set for the current user', () => {
+			const isCustomizable = isSiteCustomizable( {
+				sites: {
+					items: {
+						77203199: {
+							ID: 77203199,
+							URL: 'https://example.com'
+						}
+					}
+				},
+				currentUser: {
+					capabilities: {
+						77203199: {}
+					}
+				}
+			}, 77203199 );
+
+			expect( isCustomizable ).to.be.null;
+		} );
+
+		it( 'should return true is the corresponding user capability is true for this site', () => {
+			const isCustomizable = isSiteCustomizable( {
+				sites: {
+					items: {
+						77203199: {
+							ID: 77203199,
+							URL: 'http://example.com',
+							options: {
+								unmapped_url: 'http://example.com'
+							}
+						}
+					}
+				},
+				currentUser: {
+					capabilities: {
+						77203199: {
+							edit_theme_options: true
+						}
+					}
+				}
+			}, 77203199 );
+
+			expect( isCustomizable ).to.be.true;
 		} );
 	} );
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -106,7 +106,6 @@ describe( 'selectors', () => {
 				domain: 'example.com',
 				slug: 'example.com',
 				hasConflict: false,
-				is_customizable: null,
 				is_previewable: true,
 				options: {
 					default_post_format: 'standard',

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -105,7 +105,7 @@ describe( 'selectors', () => {
 				domain: 'example.com',
 				slug: 'example.com',
 				hasConflict: false,
-				is_customizable: false,
+				is_customizable: null,
 				is_previewable: true,
 				options: {
 					default_post_format: 'standard',

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -12,7 +12,7 @@ import {
 } from 'state/ui/selectors';
 import { getLastAction } from 'state/ui/action-log/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
-import { canCurrentUser } from 'state/selectors';
+import { canCurrentUser, isSiteCustomizable } from 'state/selectors';
 import {
 	hasDefaultSiteTitle,
 	isCurrentPlanPaid,
@@ -122,7 +122,7 @@ export const isSelectedSitePreviewable = state =>
  * @return {Boolean} True if user can run customizer, false otherwise.
  */
 export const isSelectedSiteCustomizable = state =>
-	getSelectedSite( state ) && getSelectedSite( state ).is_customizable;
+	isSiteCustomizable( state, getSelectedSiteId( state ) );
 
 /**
  * Returns a selector that tests whether an A/B test is in a given variant.

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -48,7 +48,7 @@ describe( 'selectors', () => {
 				URL: 'https://example.com',
 				domain: 'example.com',
 				hasConflict: false,
-				is_customizable: false,
+				is_customizable: null,
 				is_previewable: false,
 				options: {
 					default_post_format: 'standard',

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -48,7 +48,6 @@ describe( 'selectors', () => {
 				URL: 'https://example.com',
 				domain: 'example.com',
 				hasConflict: false,
-				is_customizable: null,
 				is_previewable: false,
 				options: {
 					default_post_format: 'standard',


### PR DESCRIPTION
This PR removes the reference of `lib/site/computed-attributes` from `sites/selectors` by adding the `getSiteOptions` and the `isSiteCustomizable` selectors. The original `getComputedAttributes` applied to `Site` instances is not removed yet since we still have a lot of code using SitesList and accessing those computed properties through those objects.

This PR has some additional changes:
- It updates any code calling the `Site#isCustomizable()` method and replaces it with the `isSiteCustomizable` selector.
- The bug fixed in #11301 was still calling `Site#getUser()`, I switched to using the `UsersStore` and added a new method to wpcom.js undocumented to fetch a single user from its `userId`.
- `Site#fetchUsers`, `Site#getUser()` and `Site#getUser()` are removed since they aren't used anywhere now in calypso.

## Testing Instructions
- `git checkout update/computed-attributes && make run`
- Navigate to http://calypso.localhost:3000

### Testing the bug fix
- Select a site, go to `Sharing > Connections` and open a connection set by another user than yourself
- assert that you can see `CONNECTED BY <login name of the user who set the connection>` next to the username connected

### Testing `isSiteCustomizable`
- Run the tests (`make test`)
- Check that you don't have access to `Themes` in the left sidebar when you don't have the permissions

### Testing the removal of getUsers methods in Site
- Go to `People` and check that you can see the users as usual
- Check that the app works for different kind of sites (jetpack, wpcom with mapped domain...)


## Reviews
- [ ] Product review
- [ ] Code review
