### PR TITLE
Help HTML Encoding (fix for issue #5035)

### DIFF
--- a/client/me/help/help-results/item.jsx
+++ b/client/me/help/help-results/item.jsx
@@ -41,15 +41,19 @@ module.exports = React.createClass( {
 		}
 	},
 
-	//create function here
+	decodeEntities: function(text) {
+		let textarea = document.createElement('textarea');
+		textarea.innerHTML = text;
+		return textarea.value;
+	},
 
 	render: function() {
 		return (
 			<a className="help-result" href={ this.props.helpLink.link } target="__blank" onClick={ this.onClick }>
 				<CompactCard className="help-result__wrapper">
 					{ this.getResultIcon() }
-					<h2 className="help-result__title">{ this.props.helpLink.title }</h2>
-					<p className="help-result__description">{ this.props.helpLink.description }</p>
+					<h2 className="help-result__title">{ this.decodeEntities(this.props.helpLink.title) }</h2>
+					<p className="help-result__description">{ this.decodeEntities(this.props.helpLink.description) }</p>
 				</CompactCard>
 			</a>
 		);

--- a/client/me/help/help-results/item.jsx
+++ b/client/me/help/help-results/item.jsx
@@ -41,6 +41,8 @@ module.exports = React.createClass( {
 		}
 	},
 
+	//create function here
+
 	render: function() {
 		return (
 			<a className="help-result" href={ this.props.helpLink.link } target="__blank" onClick={ this.onClick }>


### PR DESCRIPTION
This PR will fix the issue stated in #5035 regarding HTML entities remaining encoded in the search results on the Me Help page. I'll create a short decoding function which will create a <textarea> element (unappended), set the innerHTML on that element and return textarea.val. 

This will decode any HTML entities while protecting against XSS attacks. I'm guessing the data returned from the Help Search should be trusted... but you never can be too sure!

The function will go in me/help/item.jsx