### PR TITLE
Account Recovery: Tweak the format of the `accountRecovery/reset` state tree and add its related tests.

### DIFF
--- a/client/state/account-recovery/reset/actions.js
+++ b/client/state/account-recovery/reset/actions.js
@@ -13,7 +13,7 @@ export function fetchResetOptions( userData ) {
 		dispatch( { type: ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST } );
 
 		wpcom.undocumented().accountRecoveryReset( userData ).getResetOptions()
-			.then( options => dispatch( { type: ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE, options } ) )
+			.then( items => dispatch( { type: ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE, items } ) )
 			.catch( error => dispatch( { type: ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR, error } ) );
 	};
 }

--- a/client/state/account-recovery/reset/reducer.js
+++ b/client/state/account-recovery/reset/reducer.js
@@ -25,7 +25,7 @@ const error = ( state = null, action ) => get( {
 	[ ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR ]: action.error,
 }, action.type, state );
 
-const items = ( state = {}, action ) => get( {
+const items = ( state = [], action ) => get( {
 	[ ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE ]: action.options,
 	[ SERIALIZE ]: {},
 }, action.type, state );

--- a/client/state/account-recovery/reset/reducer.js
+++ b/client/state/account-recovery/reset/reducer.js
@@ -26,7 +26,7 @@ const error = ( state = null, action ) => get( {
 }, action.type, state );
 
 const items = ( state = [], action ) => get( {
-	[ ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE ]: action.options,
+	[ ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE ]: action.items,
 	[ SERIALIZE ]: [],
 }, action.type, state );
 

--- a/client/state/account-recovery/reset/reducer.js
+++ b/client/state/account-recovery/reset/reducer.js
@@ -27,7 +27,7 @@ const error = ( state = null, action ) => get( {
 
 const items = ( state = [], action ) => get( {
 	[ ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE ]: action.options,
-	[ SERIALIZE ]: {},
+	[ SERIALIZE ]: [],
 }, action.type, state );
 
 const resetOptions = combineReducers( {

--- a/client/state/account-recovery/reset/reducer.js
+++ b/client/state/account-recovery/reset/reducer.js
@@ -11,7 +11,6 @@ import {
 	ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
 	ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
 	ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST,
-	SERIALIZE,
 } from 'state/action-types';
 
 const isRequesting = ( state = false, action ) => get( {
@@ -21,13 +20,13 @@ const isRequesting = ( state = false, action ) => get( {
 }, action.type, state );
 
 const error = ( state = null, action ) => get( {
+	[ ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST ]: null,
 	[ ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE ]: null,
 	[ ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR ]: action.error,
 }, action.type, state );
 
 const items = ( state = [], action ) => get( {
 	[ ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE ]: action.items,
-	[ SERIALIZE ]: [],
 }, action.type, state );
 
 const resetOptions = combineReducers( {

--- a/client/state/account-recovery/reset/reducer.js
+++ b/client/state/account-recovery/reset/reducer.js
@@ -17,7 +17,7 @@ import {
 const isRequesting = ( state = false, action ) => get( {
 	[ ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST ]: true,
 	[ ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE ]: false,
-	[ ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR ]: true,
+	[ ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR ]: false,
 }, action.type, state );
 
 const error = ( state = null, action ) => get( {
@@ -25,7 +25,7 @@ const error = ( state = null, action ) => get( {
 	[ ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR ]: action.error,
 }, action.type, state );
 
-const options = ( state = {}, action ) => get( {
+const items = ( state = {}, action ) => get( {
 	[ ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE ]: action.options,
 	[ SERIALIZE ]: {},
 }, action.type, state );
@@ -33,7 +33,7 @@ const options = ( state = {}, action ) => get( {
 const resetOptions = combineReducers( {
 	isRequesting,
 	error,
-	options,
+	items,
 } );
 
 export default combineReducers( {

--- a/client/state/account-recovery/reset/selectors.js
+++ b/client/state/account-recovery/reset/selectors.js
@@ -1,1 +1,1 @@
-export const getResetOptions = ( state ) => state.accountRecovery.reset.options;
+export const getResetOptions = ( state ) => state.accountRecovery.reset.options.items;

--- a/client/state/account-recovery/reset/test/reducer.js
+++ b/client/state/account-recovery/reset/test/reducer.js
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
+	ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
+	ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST,
+} from 'state/action-types';
+
+import reducer from '../reducer';
+
+describe( '#account-recovery/reset reducer', () => {
+	it( 'ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST action should set isRequesting flag.', () => {
+		const state = reducer( undefined, {
+			type: ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST
+		} );
+
+		assert.isTrue( state.options.isRequesting );
+	} );
+
+	const requestingState = {
+		options: {
+			isRequesting: true,
+		},
+	};
+
+	it( 'ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE action should unset isRequesting flag.', () => {
+		const state = reducer( requestingState, {
+			type: ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
+		} );
+
+		assert.isFalse( state.options.isRequesting );
+	} );
+
+	it( 'ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR action should unset isRequesting flag.', () => {
+		const state = reducer( requestingState, {
+			type: ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
+		} );
+
+		assert.isFalse( state.options.isRequesting );
+	} );
+
+	it( 'ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE action should populate the items field.', () => {
+		const fetchedOptions = [
+			{
+				email: 'primary@example.com',
+				sms: '123456789',
+			},
+			{
+				email: 'secondary@example.com',
+				sms: '123456789',
+			},
+		];
+		const state = reducer( undefined, {
+			type: ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
+			options: fetchedOptions,
+		} );
+
+		assert.deepEqual( state.options.items, fetchedOptions );
+	} );
+
+	it( 'ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR action should populate the error field.', () => {
+		const fetchError = {
+			status: 400,
+			message: 'Something wrong!',
+		};
+
+		const state = reducer( undefined, {
+			type: ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
+			error: fetchError,
+		} );
+
+		assert.deepEqual( state.options.error, fetchError );
+	} );
+} );

--- a/client/state/account-recovery/reset/test/reducer.js
+++ b/client/state/account-recovery/reset/test/reducer.js
@@ -58,7 +58,7 @@ describe( '#account-recovery/reset reducer', () => {
 		];
 		const state = reducer( undefined, {
 			type: ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
-			options: fetchedOptions,
+			items: fetchedOptions,
 		} );
 
 		assert.deepEqual( state.options.items, fetchedOptions );


### PR DESCRIPTION
## Summary
This PR tweaks the `accountRecovery/reset` state tree as the following:

* Set `isRequesting` as `false` upon receiving `ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR`.
* Change `options` to `items`, since otherwise it would be `accountRecovery.reset.options.options` to access. I personally think  `accountRecovery.reset.options.items` is easier to understand, since we are using `items` as an array containing multiple instances of data elsewhere.

Also, the related test suite is added.

## Test Plan
`npm run test-client client/state/account-recovery/reset`