### PR TITLE
Account Recovery: Add actions for fetching reset options

### DIFF
--- a/client/state/account-recovery/reset/actions.js
+++ b/client/state/account-recovery/reset/actions.js
@@ -8,6 +8,16 @@ import {
 	ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST,
 } from 'state/action-types';
 
+export const fetchResetOptionsSuccess = ( options ) => ( {
+	type: ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
+	options,
+} );
+
+export const fetchResetOptionsError = ( error ) => ( {
+	type: ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
+	error,
+} );
+
 const fromApi = ( data ) => ( [
 	{
 		email: data.primary_email,
@@ -28,26 +38,10 @@ export const fetchResetOptions = ( userData ) => ( dispatch ) => {
 		body: userData,
 		apiNamespace: 'wpcom/v2',
 		path: '/account-recovery/lookup',
-	} ).then( data => dispatch( {
-		type: ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
-		options: fromApi( data ),
-	} ) )
-	.catch( error => dispatch( {
-		type: ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
-		error,
-	} ) );
+	} ).then( data => dispatch( fetchResetOptionsSuccess( fromApi( data ) ) ) )
+	.catch( error => dispatch( fetchResetOptionsError( error ) ) );
 };
 
 export const fetchResetOptionsByLogin = ( user ) => fetchResetOptions( { user } );
 
 export const fetchResetOptionsByNameAndUrl = ( firstname, lastname, url ) => fetchResetOptions( { firstname, lastname, url } );
-
-export const fetchResetOptionsSuccess = ( options ) => ( {
-	type: ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
-	options,
-} );
-
-export const fetchResetOptionsError = ( error ) => ( {
-	type: ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
-	error,
-} );

--- a/client/state/account-recovery/reset/actions.js
+++ b/client/state/account-recovery/reset/actions.js
@@ -8,9 +8,9 @@ import {
 	ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST,
 } from 'state/action-types';
 
-export const fetchResetOptionsSuccess = ( options ) => ( {
+export const fetchResetOptionsSuccess = ( items ) => ( {
 	type: ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
-	options,
+	items,
 } );
 
 export const fetchResetOptionsError = ( error ) => ( {

--- a/client/state/account-recovery/reset/actions.js
+++ b/client/state/account-recovery/reset/actions.js
@@ -8,12 +8,16 @@ import {
 	ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST,
 } from 'state/action-types';
 
-const fromApi = ( data ) => ( {
-	primaryEmail: data.primary_email,
-	primarySms: data.primary_sms,
-	secondaryEmail: data.secondary_email,
-	secondarySms: data.secondary_sms,
-} );
+const fromApi = ( data ) => ( [
+	{
+		email: data.primary_email,
+		sms: data.primary_sms,
+	},
+	{
+		email: data.secondary_email,
+		sms: data.secondary_sms,
+	},
+] );
 
 export const fetchResetOptions = ( userData ) => ( dispatch ) => {
 	dispatch( {

--- a/client/state/account-recovery/reset/actions.js
+++ b/client/state/account-recovery/reset/actions.js
@@ -8,20 +8,42 @@ import {
 	ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST,
 } from 'state/action-types';
 
-export function fetchResetOptions( userData ) {
-	return ( dispatch ) => {
-		dispatch( { type: ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST } );
+const fromApi = ( data ) => ( {
+	primaryEmail: data.primary_email,
+	primarySms: data.primary_sms,
+	secondaryEmail: data.secondary_email,
+	secondarySms: data.secondary_sms,
+} );
 
-		wpcom.undocumented().accountRecoveryReset( userData ).getResetOptions()
-			.then( items => dispatch( { type: ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE, items } ) )
-			.catch( error => dispatch( { type: ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR, error } ) );
-	};
-}
+export const fetchResetOptions = ( userData ) => ( dispatch ) => {
+	dispatch( {
+		type: ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST,
+	} );
 
-export function fetchResetOptionsByLogin( user ) {
-	return fetchResetOptions( { user } );
-}
+	return wpcom.req.get( {
+		body: userData,
+		apiNamespace: 'wpcom/v2',
+		path: '/account-recovery/lookup',
+	} ).then( data => dispatch( {
+		type: ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
+		options: fromApi( data ),
+	} ) )
+	.catch( error => dispatch( {
+		type: ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
+		error,
+	} ) );
+};
 
-export function fetchResetOptionsByName( firstname, lastname, url ) {
-	return fetchResetOptions( { firstname, lastname, url } );
-}
+export const fetchResetOptionsByLogin = ( user ) => fetchResetOptions( { user } );
+
+export const fetchResetOptionsByNameAndUrl = ( firstname, lastname, url ) => fetchResetOptions( { firstname, lastname, url } );
+
+export const fetchResetOptionsSuccess = ( options ) => ( {
+	type: ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
+	options,
+} );
+
+export const fetchResetOptionsError = ( error ) => ( {
+	type: ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
+	error,
+} );

--- a/client/state/account-recovery/reset/test/actions.js
+++ b/client/state/account-recovery/reset/test/actions.js
@@ -23,18 +23,18 @@ import {
 
 describe( '#fetchResetOptionsSuccess', () => {
 	it( 'should return ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE action with options field.', () => {
-		const options = {
+		const items = {
 			primaryEmail: 'primary@example.com',
 			primarySms: '12345678',
 			secondaryEmail: 'secondary@example.com',
 			secondarySms: '12345678',
 		};
 
-		const action = fetchResetOptionsSuccess( options );
+		const action = fetchResetOptionsSuccess( items );
 
 		assert.deepEqual( action, {
 			type: ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
-			options,
+			items,
 		} );
 	} );
 } );
@@ -91,7 +91,7 @@ describe( '#fetchResetOptions', () => {
 			return thunk.then( () =>
 				assert.isTrue( spy.calledWith( {
 					type: ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
-					options: [
+					items: [
 						{
 							email: response.primary_email,
 							sms: response.primary_sms,

--- a/client/state/account-recovery/reset/test/actions.js
+++ b/client/state/account-recovery/reset/test/actions.js
@@ -6,12 +6,17 @@ import { assert } from 'chai';
 /**
  * Internal dependencies
  */
+import useNock from 'test/helpers/use-nock';
+import { useSandbox } from 'test/helpers/use-sinon';
+
 import {
+	fetchResetOptions,
 	fetchResetOptionsSuccess,
 	fetchResetOptionsError,
 } from '../actions';
 
 import {
+	ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST,
 	ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
 	ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
 } from 'state/action-types';
@@ -46,6 +51,81 @@ describe( '#fetchResetOptionsError', () => {
 		assert.deepEqual( action, {
 			type: ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
 			error,
+		} );
+	} );
+} );
+
+describe( '#fetchResetOptions', () => {
+	let spy;
+
+	useSandbox( sandbox => ( spy = sandbox.spy() ) );
+
+	const apiBaseUrl = 'https://public-api.wordpress.com:443';
+	const endpoint = '/wpcom/v2/account-recovery/lookup';
+
+	const userData = {
+		user: 'foo',
+	};
+
+	describe( 'success', () => {
+		const response = {
+			primary_email: 'a****@example.com',
+			secondary_email: 'b*****@example.com',
+			primary_sms: '+1******456',
+			secondary_sms: '+8*******456',
+		};
+
+		useNock( nock => (
+			nock( apiBaseUrl )
+				.get( endpoint )
+				.reply( 200, response )
+		) );
+
+		it( 'should dispatch RECEIVE action on success', () => {
+			const thunk = fetchResetOptions( userData )( spy );
+
+			assert.isTrue( spy.calledWith( {
+				type: ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST,
+			} ) );
+
+			return thunk.then( () =>
+				assert.isTrue( spy.calledWith( {
+					type: ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
+					options: [
+						{
+							email: response.primary_email,
+							sms: response.primary_sms,
+						},
+						{
+							email: response.secondary_email,
+							sms: response.secondary_sms,
+						},
+					],
+				} ) )
+			);
+		} );
+	} );
+
+	describe( 'failure', () => {
+		const errorResponse = {
+			status: 400,
+			message: 'Something wrong!',
+		};
+
+		useNock( nock => (
+			nock( apiBaseUrl )
+				.get( endpoint )
+				.reply( errorResponse.status, errorResponse )
+		) );
+
+		it( 'should dispatch ERROR action on failure', () => {
+			return fetchResetOptions( userData )( spy )
+				.then( () =>
+					assert.isTrue( spy.calledWithMatch( {
+						type: ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
+						error: errorResponse,
+					} ) )
+				);
 		} );
 	} );
 } );

--- a/client/state/account-recovery/reset/test/actions.js
+++ b/client/state/account-recovery/reset/test/actions.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	fetchResetOptionsSuccess,
+	fetchResetOptionsError,
+} from '../actions';
+
+import {
+	ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
+	ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
+} from 'state/action-types';
+
+describe( '#fetchResetOptionsSuccess', () => {
+	it( 'should return ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE action with options field.', () => {
+		const options = {
+			primaryEmail: 'primary@example.com',
+			primarySms: '12345678',
+			secondaryEmail: 'secondary@example.com',
+			secondarySms: '12345678',
+		};
+
+		const action = fetchResetOptionsSuccess( options );
+
+		assert.deepEqual( action, {
+			type: ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
+			options,
+		} );
+	} );
+} );
+
+describe( '#fetchResetOptionsError', () => {
+	it( 'should return ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR action with error field.', () => {
+		const error = {
+			status: 400,
+			message: 'error!',
+		};
+
+		const action = fetchResetOptionsError( error );
+
+		assert.deepEqual( action, {
+			type: ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
+			error,
+		} );
+	} );
+} );


### PR DESCRIPTION
## Summary
This PR adds the `thunk` for interacting with the `account-recovery/lookup` endpoint, which returns the password reset options a user has. It accepts two alternative set of arguments:

* { user } : Query by a username
* { firstname, lastname, url } : Query by a user's first name, last name, and a site url under one's account.

## Test Plan
Run `npm run test-client client/state/account-recovery/reset/test`