### PR TITLE
Refactor to use existing helper function decodeEntities

### DIFF
--- a/client/me/help/help-results/item.jsx
+++ b/client/me/help/help-results/item.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
 import Gridicon from 'gridicons';
+import { decodeEntities } from 'lib/formatting';
 
 /**
  * Internal dependencies
@@ -41,19 +42,13 @@ module.exports = React.createClass( {
 		}
 	},
 
-	decodeEntities: function(text) {
-		let textarea = document.createElement('textarea');
-		textarea.innerHTML = text;
-		return textarea.value;
-	},
-
 	render: function() {
 		return (
 			<a className="help-result" href={ this.props.helpLink.link } target="__blank" onClick={ this.onClick }>
 				<CompactCard className="help-result__wrapper">
 					{ this.getResultIcon() }
-					<h2 className="help-result__title">{ this.decodeEntities(this.props.helpLink.title) }</h2>
-					<p className="help-result__description">{ this.decodeEntities(this.props.helpLink.description) }</p>
+					<h2 className="help-result__title">{ decodeEntities(this.props.helpLink.title) }</h2>
+					<p className="help-result__description">{ decodeEntities(this.props.helpLink.description) }</p>
 				</CompactCard>
 			</a>
 		);


### PR DESCRIPTION
Refactor Help-Results Item component to use decodeEntities Helper function

The previous fix wrote a duplicate decodeEntities method on the component.

cc @alisterscott 