### PR TITLE
Import: Fix import completed message

### DIFF
--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -127,7 +127,10 @@ export const ImportingPane = React.createClass( {
 			postLink = <a href={ '/posts/' + slug } />,
 			postText = this.translate( 'Posts', { context: 'noun' } );
 
-		if ( page && post ) {
+		const pageCount = page.total;
+		const postCount = post.total;
+
+		if ( pageCount && postCount ) {
 			return this.translate(
 				'All done! Check out {{a}}Posts{{/a}} or ' +
 				'{{b}}Pages{{/b}} to see your imported content.', {
@@ -139,12 +142,12 @@ export const ImportingPane = React.createClass( {
 			);
 		}
 
-		if ( page || post ) {
+		if ( pageCount || postCount ) {
 			return this.translate(
 				'All done! Check out {{a}}%(articles)s{{/a}} ' +
 				'to see your imported content.', {
-					components: { a: page ? pageLink : postLink },
-					args: { articles: page ? pageText : postText }
+					components: { a: pageCount ? pageLink : postLink },
+					args: { articles: pageCount ? pageText : postText }
 				}
 			);
 		}


### PR DESCRIPTION
Resolves: https://github.com/Automattic/wp-calypso/issues/11290

Prevent showing links to Posts or Pages when no items from those categories were imported.

Previously, since `page` and `post` are objects, the first condition was always evaluating true.