### PR TITLE
Editor: Update editor publish button test

### DIFF
--- a/client/post-editor/editor-publish-button/test/index.jsx
+++ b/client/post-editor/editor-publish-button/test/index.jsx
@@ -47,6 +47,7 @@ describe( 'EditorPublishButton', function() {
 					site={ MOCK_SITE }
 				/>
 			).instance();
+
 			expect( tree.getButtonLabel() ).to.equal( 'Update' );
 		} );
 
@@ -81,7 +82,7 @@ describe( 'EditorPublishButton', function() {
 				nextMonth = now.month( now.month() + 1 ).format(),
 				tree = shallow(
 					<EditorPublishButton translate={ identity }
-						savedPost={ { status: 'draft' } }
+						savedPost={ { status: 'publish' } }
 						post={ { date: nextMonth } }
 						site={ MOCK_SITE }
 					/>


### PR DESCRIPTION
Quick fix for #11137. The test for `should return Schedule if the post is dated in the future and published` should check if `savedPost` status is set to `publish` (not `draft`) and the post date is set to `nextMonth`.

### To test
Confirm that all tests still pass by running `npm run test-client client/post-editor/editor-publish-button`