### PR TITLE
Site Settings: Fix resetting the form fields when switching websites

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -47,9 +47,9 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 		componentDidUpdate( prevProps ) {
 			if ( prevProps.siteId !== this.props.siteId ) {
 				this.props.clearDirtyFields();
-			}
-
-			if (
+				const newSiteFields = getFormSettings( this.props.settings );
+				this.props.replaceFields( newSiteFields );
+			} else if (
 				! isEqual( prevProps.settings, this.props.settings ) ||
 				! isEqual( prevProps.fields, this.props.fields )
 			) {


### PR DESCRIPTION
closes #11317

This PR adds logic to reset form fields while switching sites.

**Testing instructions**

 - Navigate to the site settings page `/settings/general/$site`
 - Update the title of your website
 - Switch to another website
 - The title form field should update properly with the new site's title.