### PR TITLE
try and customize needs to dispatch an action and not follow url

### DIFF
--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -216,6 +216,11 @@ class Upload extends React.Component {
 		activate.action( this.props.uploadedTheme );
 	};
 
+	onTryAndCustomizeClick = () => {
+		const { tryandcustomize } = this.props.options;
+		tryandcustomize.action( this.props.uploadedTheme );
+	}
+
 	renderTheme() {
 		const { uploadedTheme: theme, translate, options } = this.props;
 		const { tryandcustomize, activate } = options;
@@ -229,7 +234,7 @@ class Upload extends React.Component {
 				</span>
 				<img src={ theme.screenshot } />
 				<span className="theme-upload__description">{ theme.description }</span>
-				<Button href={ tryandcustomize.getUrl( theme ) }>
+				<Button onClick={ this.onTryAndCustomizeClick } >
 					{ tryandcustomize.label }
 				</Button>
 				<Button primary onClick={ this.onActivateClick }>


### PR DESCRIPTION
### Info

try&customize was changed to action and needs different handling.

Fixes #11322

### To test

1. Open My Sites → Themes → Upload theme
2. Try to upload a theme (i.e. download one from https://wordpress.org/themes/
3. See that the upload completes correctly