### PR TITLE
Editor: add undo/redo capabilities to the HTML toolbar

### DIFF
--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -4,7 +4,6 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import {
-	every,
 	get,
 	map,
 	reduce,
@@ -35,6 +34,12 @@ import EditorMediaModal from 'post-editor/editor-media-modal';
  * Module constants
  */
 const TOOLBAR_HEIGHT = 39;
+const isIE11Detected = (
+	window &&
+	window.MSInputMethodContext &&
+	document &&
+	document.documentMode
+);
 
 export class EditorHtmlToolbar extends Component {
 
@@ -75,13 +80,6 @@ export class EditorHtmlToolbar extends Component {
 		document.addEventListener( 'click', this.clickOutsideInsertContentMenu );
 
 		this.toggleToolbarScrollableOnResize();
-
-		this.isIE11Detected = every( [
-			window,
-			document,
-			window.MSInputMethodContext,
-			document.documentMode,
-		] );
 	}
 
 	componentWillUnmount() {
@@ -171,7 +169,7 @@ export class EditorHtmlToolbar extends Component {
 
 	// execCommand( 'insertText' ), needed to preserve the undo stack, does not exist in IE11.
 	// Using the previous version of replacing the entire content value instead.
-	updateEditorContent = this.isIE11Detected
+	updateEditorContent = isIE11Detected
 		? this.updateEditorContentIE11
 		: this.insertEditorContent;
 
@@ -246,9 +244,10 @@ export class EditorHtmlToolbar extends Component {
 
 	insertCustomContent( content, options = {} ) {
 		const { before, inner, after } = this.splitEditorContent();
+		const paragraph = options.paragraph ? '\n' : '';
 		this.updateEditorContent(
 			before,
-			inner + ( options.paragraph ? '\n' : '' ) + content + ( options.paragraph ? '\n\n' : '' ),
+			inner + paragraph + content + paragraph + paragraph,
 			after
 		);
 	}


### PR DESCRIPTION
Changed the HTML toolbar insert content logic in order to make use of the undo/redo stack of the browser.

Previously, adding a tag from the toolbar consisted in replacing the entire content with the new  one. Roughly like this:
`content.value = beforeSelection + '<tag>' + insideSelection + '</tag>' + afterSelection;`
Unfortunately this did not use the undo/redo stack.

I've replaced it with `document.execCommand( 'insertText', ... )`.
It makes full use of the undo/redo stack with the following quirks:

- A change made in HTML mode is _not_ undoable from Visual mode, and vice versa as the two modes use a different stack apparently.
Introducing a change in HTML mode and removing it in Visual mode could actually lead to a weird behaviour if then undoing in HTML mode. I'm not quite able to figure out what happens though. It looks like the undo removes the amount of characters that have been inserted, even if those characters are not there anymore.

- `document.execCommand( 'insertText', ... )` does not exist in IE11 (see: https://msdn.microsoft.com/en-us/library/hh801231(v=vs.85).aspx#InsertText).
I've opted to detecting IE11 and providing it the old method, while enabling undo/redo for any other browser (possibly: at this time I have not started any compatibility checks).

## Browser Compatibility

- [x] Chrome 56 / macOS 10.12
- [x] Safari 10 / macOS 10.12
- [x] Firefox 51 / macOS 10.12
- [x] Edge / Windows 10
- [x] Internet Explorer 11 / Windows 10 (as expected, no undo feature, but tag insertion still works)
- [x] Chrome 56 / Android 6 (no undo feature, but tag insertion still works)
- [x] Safari / iOS 10.2 / iPhone 7