### PR TITLE
Themes Site Selector Modal: Drop Jetpack filter, use hideFor[Theme|Site] instead

### DIFF
--- a/client/components/site-selector-modal/index.jsx
+++ b/client/components/site-selector-modal/index.jsx
@@ -98,7 +98,7 @@ class SiteSelectorModal extends Component {
 				</div>
 				<SitesDropdown
 					onSiteSelect={ this.setSite }
-					selectedSiteId={ this.state.site.ID }
+					selectedSiteId={ this.state.site && this.state.site.ID }
 					filter={ this.props.filter } />
 			</Dialog>
 		);

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -43,7 +43,7 @@ class CurrentTheme extends Component {
 			text = ( currentTheme && currentTheme.name ) ? currentTheme.name : placeholderText;
 
 		const options = pickBy( this.props.options, option =>
-			currentTheme && ! ( option.hideForTheme && option.hideForTheme( currentTheme ) )
+			currentTheme && ! ( option.hideForTheme && option.hideForTheme( currentTheme, siteId ) )
 		);
 
 		return (

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -33,7 +33,7 @@ const ConnectedThemesSelection = connectOptions(
 				getOptions={ function( theme ) {
 					return pickBy(
 						addTracking( props.options ),
-						option => ! ( option.hideForTheme && option.hideForTheme( theme ) )
+						option => ! ( option.hideForTheme && option.hideForTheme( theme, props.siteId ) )
 					); } }
 			/>
 		);

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -17,7 +17,6 @@ import {
 	showThemePreview as themePreview,
 } from 'state/themes/actions';
 import {
-	getTheme,
 	getThemeSignupUrl,
 	getThemePurchaseUrl,
 	getThemeCustomizeUrl,
@@ -27,10 +26,9 @@ import {
 	isThemeActive,
 	isThemePremium,
 	isPremiumThemeAvailable,
-	isWpcomTheme
+	isThemeAvailableOnJetpackSite
 } from 'state/themes/selectors';
 import {
-	hasJetpackSiteJetpackThemesExtendedFeatures,
 	isJetpackSite,
 	isJetpackSiteMultiSite
 } from 'state/sites/selectors';
@@ -70,9 +68,7 @@ const activate = {
 	hideForTheme: ( state, theme, siteId ) => (
 		isThemeActive( state, theme.id, siteId ) ||
 		( isThemePremium( state, theme.id ) && ! isPremiumThemeAvailable( state, theme.id, siteId ) ) ||
-		// Are we trying to install and activate a (previously not-installed) WP.com theme on a Jetpack site?
-		isJetpackSite( state, siteId ) && isWpcomTheme( state, theme.id ) && ! getTheme( state, siteId, theme.id ) &&
-			! ( config.isEnabled( 'manage/themes/upload' ) && hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ) )
+		( isJetpackSite( state, siteId ) && ! isThemeAvailableOnJetpackSite( state, theme.id, siteId ) )
 	)
 };
 
@@ -112,9 +108,7 @@ const tryandcustomize = {
 			// is less readily available since it needs to be fetched using the `QuerySitePlans` component.
 			( isJetpackSite( state, siteId ) && ! isPremiumThemeAvailable( state, theme.id, siteId ) )
 		) ||
-		// Are we trying to install and try a (previously not-installed) WP.com theme on a Jetpack site?
-		isJetpackSite( state, siteId ) && isWpcomTheme( state, theme.id ) && ! getTheme( state, siteId, theme.id ) &&
-			! ( config.isEnabled( 'manage/themes/upload' ) && hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ) )
+		( isJetpackSite( state, siteId ) && ! isThemeAvailableOnJetpackSite( state, theme.id, siteId ) )
 		);
 	}
 };

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -149,21 +149,18 @@ const ALL_THEME_OPTIONS = {
 export const connectOptions = connect(
 	( state, { options: optionNames, siteId } ) => {
 		let options = pick( ALL_THEME_OPTIONS, optionNames );
-		let mapGetUrl = identity, mapHideForSite = identity;
-
-		// We bind hideForTheme to siteId even if it is null since the selectors
-		// that are used by it are expected to recognize that case as "no site selected"
-		// and work accordingly.
-		const mapHideForTheme = hideForTheme => ( t ) => hideForTheme( state, t, siteId );
+		let mapGetUrl = identity, mapHideForSite = identity, mapHideForTheme = identity;
 
 		if ( siteId ) {
 			mapGetUrl = getUrl => ( t ) => getUrl( state, t, siteId );
 			options = pickBy( options, option =>
 				! ( option.hideForSite && option.hideForSite( state, siteId ) )
 			);
+			mapHideForTheme = hideForTheme => ( t ) => hideForTheme( state, t, siteId );
 		} else {
 			mapGetUrl = getUrl => ( t, s ) => getUrl( state, t, s );
 			mapHideForSite = hideForSite => ( s ) => hideForSite( state, s );
+			mapHideForTheme = hideForTheme => ( t, s ) => hideForTheme( state, t, s );
 		}
 
 		return mapValues( options, option => Object.assign(

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -98,6 +98,7 @@ const tryandcustomize = {
 	hideForSite: ( state, siteId ) => ! canCurrentUser( state, siteId, 'edit_theme_options' ),
 	hideForTheme: ( state, theme, siteId ) => (
 		isThemeActive( state, theme.id, siteId ) ||
+		( isJetpackSite( state, siteId ) && isThemePremium( state, theme.id ) ) ||
 		// Are we trying to install and try a (previously not-installed) WP.com theme on a Jetpack site?
 		isJetpackSite( state, siteId ) && isWpcomTheme( state, theme.id ) && ! getTheme( state, siteId, theme.id ) &&
 			! ( config.isEnabled( 'manage/themes/upload' ) && hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ) )

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -45,7 +45,10 @@ const purchase = config.isEnabled( 'upgrades/checkout' )
 			comment: 'label for selecting a site for which to purchase a theme'
 		} ),
 		getUrl: getThemePurchaseUrl,
-		hideForSite: ( state, siteId ) => hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
+		hideForSite: ( state, siteId ) => (
+			hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ) ||
+			isJetpackSite( state, siteId )
+		),
 		hideForTheme: ( state, theme, siteId ) => (
 			! isThemePremium( state, theme.id ) ||
 			isThemeActive( state, theme.id, siteId ) ||

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -104,13 +104,19 @@ const tryandcustomize = {
 		! canCurrentUser( state, siteId, 'edit_theme_options' ) ||
 		( isJetpackSite( state, siteId ) && isJetpackSiteMultiSite( state, siteId ) )
 	),
-	hideForTheme: ( state, theme, siteId ) => (
-		isThemeActive( state, theme.id, siteId ) ||
-		( isJetpackSite( state, siteId ) && isThemePremium( state, theme.id ) ) ||
+	hideForTheme: ( state, theme, siteId ) => {
+		return (
+		isThemeActive( state, theme.id, siteId ) || (
+			isThemePremium( state, theme.id ) &&
+			// In theory, we shouldn't need the isJetpackSite() check. In practice, Redux state required for isPremiumThemeAvailable
+			// is less readily available since it needs to be fetched using the `QuerySitePlans` component.
+			( isJetpackSite( state, siteId ) && ! isPremiumThemeAvailable( state, theme.id, siteId ) )
+		) ||
 		// Are we trying to install and try a (previously not-installed) WP.com theme on a Jetpack site?
 		isJetpackSite( state, siteId ) && isWpcomTheme( state, theme.id ) && ! getTheme( state, siteId, theme.id ) &&
 			! ( config.isEnabled( 'manage/themes/upload' ) && hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ) )
-	)
+		);
+	}
 };
 
 const preview = {

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -96,7 +96,12 @@ const tryandcustomize = {
 	} ),
 	action: tryAndCustomizeAction,
 	hideForSite: ( state, siteId ) => ! canCurrentUser( state, siteId, 'edit_theme_options' ),
-	hideForTheme: ( state, theme, siteId ) => isThemeActive( state, theme.id, siteId )
+	hideForTheme: ( state, theme, siteId ) => (
+		isThemeActive( state, theme.id, siteId ) ||
+		// Are we trying to install and try a (previously not-installed) WP.com theme on a Jetpack site?
+		isJetpackSite( state, siteId ) && isWpcomTheme( state, theme.id ) && ! getTheme( state, siteId, theme.id ) &&
+			! ( config.isEnabled( 'manage/themes/upload' ) && hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ) )
+	)
 };
 
 const preview = {

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -17,6 +17,7 @@ import {
 	showThemePreview as themePreview,
 } from 'state/themes/actions';
 import {
+	getTheme,
 	getThemeSignupUrl,
 	getThemePurchaseUrl,
 	getThemeCustomizeUrl,
@@ -26,8 +27,9 @@ import {
 	isThemeActive,
 	isThemePremium,
 	isPremiumThemeAvailable,
+	isWpcomTheme
 } from 'state/themes/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
+import { hasJetpackSiteJetpackThemesExtendedFeatures, isJetpackSite } from 'state/sites/selectors';
 import { hasFeature } from 'state/sites/plans/selectors';
 import { canCurrentUser } from 'state/selectors';
 import { FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
@@ -59,7 +61,10 @@ const activate = {
 	action: activateAction,
 	hideForTheme: ( state, theme, siteId ) => (
 		isThemeActive( state, theme.id, siteId ) ||
-		( isThemePremium( state, theme.id ) && ! isPremiumThemeAvailable( state, theme.id, siteId ) )
+		( isThemePremium( state, theme.id ) && ! isPremiumThemeAvailable( state, theme.id, siteId ) ) ||
+		// Are we trying to install and activate a (previously not-installed) WP.com theme on a Jetpack site?
+		isJetpackSite( state, siteId ) && isWpcomTheme( state, theme.id ) && ! getTheme( state, siteId, theme.id ) &&
+			! ( config.isEnabled( 'manage/themes/upload' ) && hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ) )
 	)
 };
 

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -29,7 +29,11 @@ import {
 	isPremiumThemeAvailable,
 	isWpcomTheme
 } from 'state/themes/selectors';
-import { hasJetpackSiteJetpackThemesExtendedFeatures, isJetpackSite } from 'state/sites/selectors';
+import {
+	hasJetpackSiteJetpackThemesExtendedFeatures,
+	isJetpackSite,
+	isJetpackSiteMultiSite
+} from 'state/sites/selectors';
 import { hasFeature } from 'state/sites/plans/selectors';
 import { canCurrentUser } from 'state/selectors';
 import { FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
@@ -62,6 +66,7 @@ const activate = {
 	extendedLabel: i18n.translate( 'Activate this design' ),
 	header: i18n.translate( 'Activate on:', { comment: 'label for selecting a site on which to activate a theme' } ),
 	action: activateAction,
+	hideForSite: ( state, siteId ) => ( isJetpackSite( state, siteId ) && isJetpackSiteMultiSite( state, siteId ) ),
 	hideForTheme: ( state, theme, siteId ) => (
 		isThemeActive( state, theme.id, siteId ) ||
 		( isThemePremium( state, theme.id ) && ! isPremiumThemeAvailable( state, theme.id, siteId ) ) ||
@@ -95,7 +100,10 @@ const tryandcustomize = {
 		comment: 'label in the dialog for opening the Customizer with the theme in preview'
 	} ),
 	action: tryAndCustomizeAction,
-	hideForSite: ( state, siteId ) => ! canCurrentUser( state, siteId, 'edit_theme_options' ),
+	hideForSite: ( state, siteId ) => (
+		! canCurrentUser( state, siteId, 'edit_theme_options' ) ||
+		( isJetpackSite( state, siteId ) && isJetpackSiteMultiSite( state, siteId ) )
+	),
 	hideForTheme: ( state, theme, siteId ) => (
 		isThemeActive( state, theme.id, siteId ) ||
 		( isJetpackSite( state, siteId ) && isThemePremium( state, theme.id ) ) ||

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -132,13 +132,13 @@ const ThemeShowcase = React.createClass( {
 	render() {
 		const {
 			site,
+			siteId,
 			options,
 			getScreenshotOption,
 			search,
 			filter,
 			translate
 		} = this.props;
-
 		const tier = config.isEnabled( 'upgrades/premium-themes' ) ? this.props.tier : 'free';
 
 		const metas = [
@@ -195,7 +195,7 @@ const ThemeShowcase = React.createClass( {
 					getOptions={ function( theme ) {
 						return pickBy(
 							addTracking( options ),
-							option => ! ( option.hideForTheme && option.hideForTheme( theme ) )
+							option => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
 						); } }
 					trackScrollPage={ this.props.trackScrollPage }
 					emptyContent={ this.props.emptyContent }

--- a/client/my-sites/themes/themes-site-selector-modal.jsx
+++ b/client/my-sites/themes/themes-site-selector-modal.jsx
@@ -101,8 +101,11 @@ const ThemesSiteSelectorModal = React.createClass( {
 				{ selectedOption && <SiteSelectorModal className="themes__site-selector-modal"
 					isVisible={ true }
 					filter={ function( site ) {
-						return ! site.jetpack;
-					} /* No Jetpack sites for now. */ }
+						return ! (
+							( selectedOption.hideForSite && selectedOption.hideForSite( site.ID ) ) ||
+							( selectedOption.hideForTheme && selectedOption.hideForTheme( selectedTheme, site.ID ) )
+						);
+					} }
 					hide={ this.hideSiteSelectorModal }
 					mainAction={ this.trackAndCallAction }
 					mainActionLabel={ selectedOption.label }

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -602,6 +602,23 @@ export function isPremiumThemeAvailable( state, themeId, siteId ) {
 }
 
 /**
+ * Whether a given theme is installed or can be installed on a Jetpack site.
+ *
+ * @param  {Object}  state   Global state tree
+ * @param  {String}  themeId Theme ID for which we check availability
+ * @param  {Number}  siteId  Site ID
+ * @return {Boolean}         True if siteId is a Jetpack site on which theme is installed or can be installed.
+ */
+export function isThemeAvailableOnJetpackSite( state, themeId, siteId ) {
+	return !! getTheme( state, siteId, themeId ) || ( // The theme is already available or...
+		isWpcomTheme( state, themeId ) && (  // ...it's a WP.com theme and...
+			config.isEnabled( 'manage/themes/upload' ) &&
+			hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ) // ...the site supports theme installation from WP.com.
+		)
+	);
+}
+
+/**
  * Returns whether the theme has been purchased for the given site.
  *
  * Use this selector alongside with the <QuerySitePurchases /> component.

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -38,6 +38,7 @@ import {
 	isThemePurchased,
 	isPremiumSquaredTheme,
 	isPremiumThemeAvailable,
+	isThemeAvailableOnJetpackSite,
 	getWpcomParentThemeId,
 } from '../selectors';
 import ThemeQueryManager from 'lib/query-manager/theme';
@@ -2306,6 +2307,92 @@ describe( 'themes selectors', () => {
 				}, 'mood', 2916284
 			);
 
+			expect( isAvailable ).to.be.true;
+		} );
+	} );
+
+	describe( '#isThemeAvailableOnJetpackSite', () => {
+		it( 'should return true if theme is already installed on Jetpack site', () => {
+			const isAvailable = isThemeAvailableOnJetpackSite(
+				{
+					sites: {
+						items: {
+							77203074: {
+								ID: 77203074,
+								URL: 'https://example.net',
+								jetpack: true
+							}
+						}
+					},
+					themes: {
+						queries: {
+							77203074: new ThemeQueryManager( {
+								items: { twentyfifteen }
+							} )
+						}
+					}
+				},
+				'twentyfifteen',
+				77203074
+			);
+			expect( isAvailable ).to.be.true;
+		} );
+
+		it( 'should return false if theme is a WP.com theme but Jetpack site doesn\'t support WP.com theme installation', () => {
+			const isAvailable = isThemeAvailableOnJetpackSite(
+				{
+					sites: {
+						items: {
+							77203074: {
+								ID: 77203074,
+								URL: 'https://example.net',
+								jetpack: true,
+								options: {
+									jetpack_version: '4.0'
+								}
+							}
+						}
+					},
+					themes: {
+						queries: {
+							wpcom: new ThemeQueryManager( {
+								items: { twentyfifteen }
+							} )
+						}
+					}
+				},
+				'twentyfifteen',
+				77203074
+			);
+			expect( isAvailable ).to.be.false;
+		} );
+
+		it( 'should return true if theme is a WP.com theme and Jetpack site supports WP.com theme installation', () => {
+			const isAvailable = isThemeAvailableOnJetpackSite(
+				{
+					sites: {
+						items: {
+							77203074: {
+								ID: 77203074,
+								URL: 'https://example.net',
+								jetpack: true,
+								options: {
+									jetpack_version: '4.8'
+								}
+							}
+						}
+					},
+					themes: {
+						queries: {
+							wpcom: new ThemeQueryManager( {
+								items: { twentyfifteen }
+							} )
+						}
+					}
+				},
+				'twentyfifteen',
+				77203074
+			);
 			expect( isAvailable ).to.be.true;
 		} );
 	} );

--- a/config/test.json
+++ b/config/test.json
@@ -71,6 +71,7 @@
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,
 		"manage/themes/logged-out": true,
+		"manage/themes/upload": true,
 		"me/account": true,
 		"me/find-friends": false,
 		"me/my-profile": true,


### PR DESCRIPTION
Enables Jetpack sites in the `ThemesSiteSelectorModal` ("TSSM").

This PR changes `ThemeOptions` to no longer bind `hideForTheme()` to `siteId` early (but defers that to theme options consumers). This allows us then to use `hideForTheme` in `ThemeSiteSelectorModal`'s `filter` (instead of the previous `site.jetpack` check).

To test:
* Activate:
  * In multi-site mode, choose any theme's 'Activate' option. Verify that the TSSM's dropdown contains your Jetpack sites.
  * Verify that choosing a Jetpack site, and activating the theme there works.
  * Try an outdated JP version that doesn't have extended themes features, i.e. [< 4.4.2](https://github.com/Automattic/wp-calypso/blob/62476a8b92acdb7cf88af19736c5c46c738efedc/client/state/sites/selectors.js#L740)). Verify that the corresponding JP site is not displayed in the TSSM.
* Try and Customize: same as Activate
* Purchase:
  * Verify that for the 'Purchase' option, the TSSM filters out Jetpack sites.
* Verify that other parts affected by this PR still work (Current Theme bar -- correct options displayed?, single-site-wpcom), and that in no theme options have gone missing.

Fixes #2128