### PR TITLE
Components: Increase contrast for button text

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -64,7 +64,7 @@ button {
 	}
 	&.is-compact {
 		padding: 7px;
-		color: darken( $gray, 10% );
+		color: $gray-text;
 		font-size: 11px;
 		line-height: 1;
 		text-transform: uppercase;
@@ -164,7 +164,7 @@ button {
 .button.is-borderless {
 	border: none;
 	background: none;
-	color: darken( $gray, 10% );
+	color: $gray-text;
 	padding-left: 0;
 	padding-right: 0;
 	border-radius: 0;

--- a/client/components/count/style.scss
+++ b/client/components/count/style.scss
@@ -6,6 +6,6 @@
 	font-size: 11px;
 	font-weight: 600;
 	line-height: 14px;
-	color: $gray;
+	color: $gray-text;
 	text-align: center;
 }

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -90,7 +90,7 @@ $compact-header-height: 35;
 	.is-compact & {
 		height: #{$compact-header-height }px;
 		line-height: #{$compact-header-height - 3 }px;
-		color: darken( $gray, 10% );
+		color: $gray-text;
 		font-size: 11px;
 		text-transform: uppercase;
 


### PR DESCRIPTION
This updates a few components to use the `$gray-text` variable for text, which is the mimmim contrast needed to pass WCAG 2.0 AA tests on a white background.

Components affected:

- compact button
- compact dropdown
- count

Before:
<img width="388" alt="screen shot 2017-02-10 at 11 02 07 am" src="https://cloud.githubusercontent.com/assets/618551/22836037/8feb45be-ef80-11e6-9f0c-ffb2048bb21b.png">
<img width="357" alt="screen shot 2017-02-10 at 11 01 23 am" src="https://cloud.githubusercontent.com/assets/618551/22836078/a8d64718-ef80-11e6-9d35-edfb8c2a0662.png">
<img width="388" alt="screen shot 2017-02-10 at 11 08 26 am" src="https://cloud.githubusercontent.com/assets/618551/22836275/51d1330a-ef81-11e6-98e8-e68553402592.png">


After:
<img width="383" alt="screen shot 2017-02-10 at 11 01 51 am" src="https://cloud.githubusercontent.com/assets/618551/22836051/99c57bae-ef80-11e6-9075-bcfd4692c540.png">
<img width="365" alt="screen shot 2017-02-10 at 11 00 49 am" src="https://cloud.githubusercontent.com/assets/618551/22836067/a1cb1674-ef80-11e6-90f4-7ee3650cbef7.png">
<img width="373" alt="screen shot 2017-02-10 at 11 08 38 am" src="https://cloud.githubusercontent.com/assets/618551/22836283/59699634-ef81-11e6-92fb-db7ca565aa78.png">
