### PR TITLE
[Remove SitesList] Remove Site#isUpgradeable()

### DIFF
--- a/client/lib/site/README.md
+++ b/client/lib/site/README.md
@@ -3,7 +3,7 @@ Site
 
 Instances of `site` are returned by [`sites-list`](/client/lib/sites-list) and represent a WordPress.com or Jetpack site. Properties on `site` mirror those of an individual site returned by the [`/me/sites`](https://developer.wordpress.com/docs/api/1.1/get/me/sites/) API endpoint.
 
-Also provides utility methods such as `isCustomizable()` and `isUpgradeable()`.
+Also provides utility methods such as `isCustomizable()`.
 
 #### jetpack.js
 Extends `site` for Jetpack sites.

--- a/client/lib/site/index.js
+++ b/client/lib/site/index.js
@@ -214,10 +214,6 @@ Site.prototype.fetchUsers = function() {
 	}.bind( this ) );
 };
 
-Site.prototype.isUpgradeable = function() {
-	return this.capabilities && this.capabilities.manage_options;
-};
-
 Site.prototype.isCustomizable = function() {
 	return !! ( this.capabilities && this.capabilities.edit_theme_options );
 };

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -478,12 +478,6 @@ SitesList.prototype.getVisible = function() {
 	}, this );
 };
 
-SitesList.prototype.getUpgradeable = function() {
-	return this.get().filter( function( site ) {
-		return site.isUpgradeable();
-	}, this );
-};
-
 SitesList.prototype.getSelectedOrAllJetpackCanManage = function() {
 	return this.getSelectedOrAll().filter( function( site ) {
 		return site.jetpack &&

--- a/client/my-sites/sites/sites.jsx
+++ b/client/my-sites/sites/sites.jsx
@@ -3,6 +3,8 @@
  */
 import React from 'react';
 import page from 'page';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -12,13 +14,13 @@ import Main from 'components/main';
 import observe from 'lib/mixins/data-observe';
 import SiteSelector from 'components/site-selector';
 import { addSiteFragment } from 'lib/route';
+import isSiteUpgradeable from 'state/selectors/is-site-upgradeable';
 
-export default React.createClass( {
-	displayName: 'Sites',
-
+const Sites = React.createClass( {
 	mixins: [ observe( 'sites', 'user' ) ],
 
 	propTypes: {
+		isSiteUpgradeable: React.PropTypes.func.isRequired,
 		path: React.PropTypes.string.isRequired
 	},
 
@@ -44,7 +46,7 @@ export default React.createClass( {
 
 		// Filter out sites with no upgrades on particular routes
 		if ( /^\/domains/.test( path ) || /^\/plans/.test( this.props.sourcePath ) ) {
-			return site.isUpgradeable();
+			return this.props.isSiteUpgradeable( site.ID );
 		}
 
 		return site;
@@ -65,7 +67,7 @@ export default React.createClass( {
 
 		const path = this.props.path.split( '?' )[ 0 ].replace( /\//g, ' ' );
 
-		return this.translate( 'Please select a site to open {{strong}}%(path)s{{/strong}}', {
+		return this.props.translate( 'Please select a site to open {{strong}}%(path)s{{/strong}}', {
 			args: {
 				path: path
 			},
@@ -94,3 +96,9 @@ export default React.createClass( {
 		);
 	}
 } );
+
+export default connect(
+	( state ) => ( {
+		isSiteUpgradeable: ( siteId ) => isSiteUpgradeable( state, siteId )
+	} )
+)( localize( Sites ) );

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -68,9 +68,7 @@ module.exports = {
 				<CartData>
 					<DomainSearch
 						basePath={ basePath }
-						context={ context }
-						sites={ sites }
-						productsList={ productsList } />
+						context={ context } />
 				</CartData>
 			),
 			document.getElementById( 'primary' ),
@@ -91,9 +89,7 @@ module.exports = {
 		renderWithReduxStore(
 			(
 				<CartData>
-					<SiteRedirect
-						productsList={ productsList }
-						sites={ sites } />
+					<SiteRedirect />
 				</CartData>
 			),
 			document.getElementById( 'primary' ),
@@ -115,10 +111,7 @@ module.exports = {
 				<Main>
 					<CartData>
 						<MapDomain
-							store={ context.store }
-							productsList={ productsList }
-							initialQuery={ context.query.initialQuery }
-							sites={ sites } />
+							initialQuery={ context.query.initialQuery } />
 					</CartData>
 				</Main>
 			),

--- a/client/my-sites/upgrades/domain-search/domain-search.jsx
+++ b/client/my-sites/upgrades/domain-search/domain-search.jsx
@@ -1,89 +1,82 @@
 /**
  * External dependencies
  */
-var connect = require( 'react-redux' ).connect,
-	page = require( 'page' ),
-	React = require( 'react' ),
-	classnames = require( 'classnames' );
+import { connect } from 'react-redux';
+import page from 'page';
+import React, { Component } from 'react';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import isEmpty from 'lodash/isEmpty';
 
 /**
  * Internal dependencies
  */
-var observe = require( 'lib/mixins/data-observe' ),
-	EmptyContent = require( 'components/empty-content' ),
-	{ DOMAINS_WITH_PLANS_ONLY } = require( 'state/current-user/constants' ),
-	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
-	RegisterDomainStep = require( 'components/domains/register-domain-step' ),
-	UpgradesNavigation = require( 'my-sites/upgrades/navigation' ),
-	Main = require( 'components/main' ),
-	upgradesActions = require( 'lib/upgrades/actions' ),
-	cartItems = require( 'lib/cart-values/cart-items' ),
-	analyticsMixin = require( 'lib/mixins/analytics' );
+import EmptyContent from 'components/empty-content';
+import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import RegisterDomainStep from 'components/domains/register-domain-step';
+import UpgradesNavigation from 'my-sites/upgrades/navigation';
+import Main from 'components/main';
+import upgradesActions from 'lib/upgrades/actions';
+import cartItems from 'lib/cart-values/cart-items';
+import analyticsMixin from 'lib/mixins/analytics';
 import { currentUserHasFlag } from 'state/current-user/selectors';
+import isSiteUpgradeable from 'state/selectors/is-site-upgradeable';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import QueryProductsList from 'components/data/query-products-list';
 
-var DomainSearch = React.createClass( {
-	mixins: [ observe( 'productsList', 'sites' ), analyticsMixin( 'registerDomain' ) ],
+const analytics = analyticsMixin( 'registerDomain' );
 
-	propTypes: {
-		sites: React.PropTypes.object.isRequired,
+class DomainSearch extends Component {
+	static propTypes = {
+		selectedSite: React.PropTypes.object.isRequired,
 		productsList: React.PropTypes.object.isRequired,
 		basePath: React.PropTypes.string.isRequired,
 		context: React.PropTypes.object.isRequired,
 		domainsWithPlansOnly: React.PropTypes.bool.isRequired
-	},
+	};
 
-	getInitialState: function() {
-		return { domainRegistrationAvailable: true };
-	},
+	constructor() {
+		super();
+		this.handleDomainsAvailabilityChange = this.handleDomainsAvailabilityChange.bind( this );
+		this.handleAddRemoveDomain = this.handleAddRemoveDomain.bind( this );
+		this.handleAddMapping = this.handleAddMapping.bind( this );
+		this.state = { domainRegistrationAvailable: true };
+	}
 
-	componentWillMount: function() {
+	componentDidMount() {
 		this.checkSiteIsUpgradeable();
-	},
+	}
 
-	componentDidMount: function() {
-		this.props.sites.on( 'change', this.checkSiteIsUpgradeable );
+	componentWillReceiveProps() {
+		this.checkSiteIsUpgradeable();
+	}
 
-		this.previousSelectedSite = this.props.sites.getSelectedSite();
-	},
-
-	componentWillReceiveProps: function() {
-		var selectedSite = this.props.sites.getSelectedSite();
-		if ( this.previousSelectedSite !== selectedSite ) {
-			this.previousSelectedSite = selectedSite;
-		}
-	},
-
-	componentWillUnmount: function() {
-		this.props.sites.off( 'change', this.checkSiteIsUpgradeable );
-	},
-
-	checkSiteIsUpgradeable: function() {
-		var selectedSite = this.props.sites.getSelectedSite();
-
-		if ( selectedSite && ! selectedSite.isUpgradeable() ) {
+	checkSiteIsUpgradeable() {
+		if ( this.props.selectedSite && ! this.props.isSiteUpgradeable ) {
 			page.redirect( '/domains/add' );
 		}
-	},
+	}
 
-	handleDomainsAvailabilityChange: function( isAvailable ) {
+	handleDomainsAvailabilityChange( isAvailable ) {
 		this.setState( { domainRegistrationAvailable: isAvailable } );
-	},
+	}
 
-	handleAddRemoveDomain: function( suggestion ) {
+	handleAddRemoveDomain( suggestion ) {
 		if ( ! cartItems.hasDomainInCart( this.props.cart, suggestion.domain_name ) ) {
 			this.addDomain( suggestion );
 		} else {
 			this.removeDomain( suggestion );
 		}
-	},
+	}
 
 	handleAddMapping( domain ) {
 		upgradesActions.addItem( cartItems.domainMapping( { domain } ) );
-		page( '/checkout/' + this.props.sites.getSelectedSite().slug );
-	},
+		page( '/checkout/' + this.props.selectedSite.slug );
+	}
 
 	addDomain( suggestion ) {
-		this.recordEvent( 'addDomainButtonClick', suggestion.domain_name, 'domains' );
+		analytics.recordEvent( 'addDomainButtonClick', suggestion.domain_name, 'domains' );
 		const items = [
 			cartItems.domainRegistration( { domain: suggestion.domain_name, productSlug: suggestion.product_slug } )
 		];
@@ -96,27 +89,27 @@ var DomainSearch = React.createClass( {
 
 		upgradesActions.addItems( items );
 		upgradesActions.goToDomainCheckout( suggestion );
-	},
+	}
 
 	removeDomain( suggestion ) {
-		this.recordEvent( 'removeDomainButtonClick', suggestion.domain_name );
+		analytics.recordEvent( 'removeDomainButtonClick', suggestion.domain_name );
 		upgradesActions.removeDomainFromCart( suggestion );
-	},
+	}
 
-	render: function() {
-		var selectedSite = this.props.sites.getSelectedSite(),
+	render() {
+		const { selectedSite, translate } = this.props,
 			classes = classnames( 'main-column', {
 				'domain-search-page-wrapper': this.state.domainRegistrationAvailable
-			} ),
-			content;
+			} );
+		let content;
 
-		if ( ! this.state.domainRegistrationAvailable ) {
+		if ( ! this.state.domainRegistrationAvailable || isEmpty( this.props.productsList ) ) {
 			content = (
 				<EmptyContent
 					illustration="/calypso/images/drake/drake-500.svg"
-					title={ this.translate( 'Domain registration is unavailable' ) }
-					line={ this.translate( "We're hard at work on the issue. Please check back shortly." ) }
-					action={ this.translate( 'Back to Plans' ) }
+					title={ translate( 'Domain registration is unavailable' ) }
+					line={ translate( "We're hard at work on the issue. Please check back shortly." ) }
+					action={ translate( 'Back to Plans' ) }
 					actionURL={ '/plans/' + selectedSite.slug } />
 			);
 		} else {
@@ -139,7 +132,7 @@ var DomainSearch = React.createClass( {
 							selectedSite={ selectedSite }
 							offerMappingOption
 							basePath={ this.props.basePath }
-							products={ this.props.productsList.get() } />
+							products={ this.props.productsList } />
 					</div>
 				</span>
 			);
@@ -149,13 +142,17 @@ var DomainSearch = React.createClass( {
 			<Main className={ classes }>
 				<SidebarNavigation />
 				{ content }
+				<QueryProductsList />
 			</Main>
 		);
 	}
-} );
+}
 
-module.exports = connect(
+export default connect(
 	( state ) => ( {
-		domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY )
+		selectedSite: getSelectedSite( state ),
+		domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
+		isSiteUpgradeable: isSiteUpgradeable( state, getSelectedSiteId( state ) ),
+		productsList: state.productsList.items,
 	} )
-)( DomainSearch );
+)( localize( DomainSearch ) );

--- a/client/my-sites/upgrades/domain-search/site-redirect.jsx
+++ b/client/my-sites/upgrades/domain-search/site-redirect.jsx
@@ -1,63 +1,84 @@
 /**
  * External dependencies
  */
-var page = require( 'page' ),
-	React = require( 'react' );
+import page from 'page';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var HeaderCake = require( 'components/header-cake' ),
-	Main = require( 'components/main' ),
-	SiteRedirectStep = require( './site-redirect-step' ),
-	observe = require( 'lib/mixins/data-observe' );
+import HeaderCake from 'components/header-cake';
+import Main from 'components/main';
+import SiteRedirectStep from './site-redirect-step';
+import isSiteUpgradeable from 'state/selectors/is-site-upgradeable';
+import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import QueryProductsList from 'components/data/query-products-list';
 
-var SiteRedirect = React.createClass( {
-	mixins: [ observe( 'productsList', 'sites' ) ],
-
-	propTypes: {
+class SiteRedirect extends Component {
+	static propTypes = {
+		cart: React.PropTypes.object.isRequired,
+		selectedSite: React.PropTypes.object,
+		selectedSiteSlug: React.PropTypes.string,
+		isSiteUpgradeable: React.PropTypes.bool,
 		productsList: React.PropTypes.object.isRequired,
-		sites: React.PropTypes.object.isRequired
-	},
+		translate: React.PropTypes.func.isRequired,
+	};
 
-	componentWillMount: function() {
+	constructor() {
+		super();
+		this.handleBackToDomainSearch = this.handleBackToDomainSearch.bind( this );
+	}
+
+	componentDidMount() {
 		this.checkSiteIsUpgradeable();
-	},
+	}
 
-	componentDidMount: function() {
-		this.props.sites.on( 'change', this.checkSiteIsUpgradeable );
-	},
+	componentWillReceiveProps() {
+		this.checkSiteIsUpgradeable();
+	}
 
-	componentWillUnmount: function() {
-		this.props.sites.off( 'change', this.checkSiteIsUpgradeable );
-	},
-
-	checkSiteIsUpgradeable: function( ) {
-		var selectedSite = this.props.sites.getSelectedSite();
-
-		if ( selectedSite && ! selectedSite.isUpgradeable() ) {
+	checkSiteIsUpgradeable() {
+		if ( this.props.selectedSite && ! this.props.isSiteUpgradeable ) {
 			page.redirect( '/domains/add' );
 		}
-	},
+	}
 
-	backToDomainSearch: function() {
-		page( '/domains/add/' + this.props.sites.getSelectedSite().slug );
-	},
+	handleBackToDomainSearch() {
+		page( '/domains/add/' + this.props.selectedSiteSlug );
+	}
 
-	render: function() {
+	render() {
+		const {
+			cart,
+			selectedSite,
+			productsList,
+			translate,
+		} = this.props;
+
 		return (
 			<Main>
-				<HeaderCake onClick={ this.backToDomainSearch }>
-					{ this.translate( 'Redirect a Site' ) }
+				<HeaderCake onClick={ this.handleBackToDomainSearch }>
+					{ translate( 'Redirect a Site' ) }
 				</HeaderCake>
 
 				<SiteRedirectStep
-					cart={ this.props.cart }
-					products={ this.props.productsList.get() }
-					selectedSite={ this.props.sites.getSelectedSite() } />
+					cart={ cart }
+					products={ productsList }
+					selectedSite={ selectedSite } />
+
+				<QueryProductsList />
 			</Main>
 		);
 	}
-} );
+}
 
-module.exports = SiteRedirect;
+export default connect(
+	( state ) => ( {
+		selectedSite: getSelectedSite( state ),
+		selectedSiteSlug: getSelectedSiteSlug( state ),
+		isSiteUpgradeable: isSiteUpgradeable( state, getSelectedSiteId( state ) ),
+		productsList: state.productsList.items,
+	} )
+)( localize( SiteRedirect ) );

--- a/client/my-sites/upgrades/map-domain/index.jsx
+++ b/client/my-sites/upgrades/map-domain/index.jsx
@@ -1,84 +1,88 @@
 /**
  * External dependencies
  */
-var page = require( 'page' ),
-	React = require( 'react' ),
-	omit = require( 'lodash/omit' ),
-	{ connect } = require( 'react-redux' );
+import page from 'page';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var HeaderCake = require( 'components/header-cake' ),
-	MapDomainStep = require( 'components/domains/map-domain-step' ),
-	{ DOMAINS_WITH_PLANS_ONLY } = require( 'state/current-user/constants' ),
-	cartItems = require( 'lib/cart-values' ).cartItems,
-	upgradesActions = require( 'lib/upgrades/actions' ),
-	observe = require( 'lib/mixins/data-observe' ),
-	wpcom = require( 'lib/wp' ).undocumented(),
-	paths = require( 'my-sites/upgrades/paths' );
-import { currentUserHasFlag } from 'state/current-user/selectors';
+import HeaderCake from 'components/header-cake';
+import MapDomainStep from 'components/domains/map-domain-step';
+import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
+import { cartItems } from 'lib/cart-values';
+import upgradesActions from 'lib/upgrades/actions';
+import wp from 'lib/wp';
+import paths from 'my-sites/upgrades/paths';
 import Notice from 'components/notice';
+import { currentUserHasFlag } from 'state/current-user/selectors';
+import isSiteUpgradeable from 'state/selectors/is-site-upgradeable';
+import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import QueryProductsList from 'components/data/query-products-list';
 
-var MapDomain = React.createClass( {
-	mixins: [ observe( 'productsList', 'sites' ) ],
+const wpcom = wp.undocumented();
 
-	propTypes: {
+class MapDomain extends Component {
+	static propTypes = {
+		initialQuery: React.PropTypes.string,
 		query: React.PropTypes.string,
+		cart: React.PropTypes.object.isRequired,
+		selectedSite: React.PropTypes.object,
+		getSelectedSiteSlug: React.PropTypes.string,
+		domainsWithPlansOnly: React.PropTypes.bool.isRequired,
+		isSiteUpgradeable: React.PropTypes.bool,
 		productsList: React.PropTypes.object.isRequired,
-		domainsWithPlansOnly: React.PropTypes.bool.isRequired
-	},
+		translate: React.PropTypes.func.isRequired,
+	};
 
-	getInitialState: function() {
-		return {
+	constructor() {
+		super();
+		this.handleRegisterDomain = this.handleRegisterDomain.bind( this );
+		this.handleMapDomain = this.handleMapDomain.bind( this );
+		this.goBack = this.goBack.bind( this );
+		this.state = {
 			errorMessage: null
 		};
-	},
+	}
 
-	componentWillMount: function() {
+	componentDidMount() {
 		this.checkSiteIsUpgradeable();
-	},
+	}
 
-	componentDidMount: function() {
-		if ( this.props.sites ) {
-			this.props.sites.on( 'change', this.checkSiteIsUpgradeable );
+	componentWillReceiveProps() {
+		this.checkSiteIsUpgradeable();
+	}
+
+	checkSiteIsUpgradeable() {
+		if ( this.props.selectedSite && ! this.props.isSiteUpgradeable ) {
+			page.redirect( '/domains/add' );
 		}
-	},
+	}
 
-	componentWillUnmount: function() {
-		if ( this.props.sites ) {
-			this.props.sites.off( 'change', this.checkSiteIsUpgradeable );
-		}
-	},
+	goBack() {
+		const {
+			selectedSite,
+			selectedSiteSlug,
+		} = this.props;
 
-	checkSiteIsUpgradeable: function( ) {
-		if ( ! this.props.sites ) {
-			return;
-		}
-
-		const selectedSite = this.props.sites.getSelectedSite();
-
-		if ( selectedSite && ! selectedSite.isUpgradeable() ) {
-			page.redirect( '/domains/add/mapping' );
-		}
-	},
-
-	goBack: function() {
-		const selectedSite = this.props.sites && this.props.sites.getSelectedSite();
 		if ( ! selectedSite ) {
-			page( this.props.path.replace( '/mapping', '' ) );
+			page( paths.domainManagementRoot() );
 			return;
 		}
 
 		if ( selectedSite.is_vip ) {
-			page( paths.domainManagementList( selectedSite.slug ) );
+			page( paths.domainManagementList( selectedSiteSlug ) );
 			return;
 		}
 
-		page( '/domains/add/' + selectedSite.slug );
-	},
+		page( '/domains/add/' + selectedSiteSlug );
+	}
 
 	handleRegisterDomain( suggestion ) {
+		const { selectedSiteSlug } = this.props;
+
 		upgradesActions.addItem(
 			cartItems.domainRegistration( {
 				productSlug: suggestion.product_slug,
@@ -86,13 +90,11 @@ var MapDomain = React.createClass( {
 			} )
 		);
 
-		if ( this.isMounted() ) {
-			page( '/checkout/' + this.props.sites.getSelectedSite().slug );
-		}
-	},
+		page( '/checkout/' + selectedSiteSlug );
+	}
 
 	handleMapDomain( domain ) {
-		const selectedSite = this.props.sites.getSelectedSite();
+		const { selectedSite, selectedSiteSlug } = this.props;
 
 		this.setState( { errorMessage: null } );
 
@@ -100,49 +102,64 @@ var MapDomain = React.createClass( {
 		// We don't go through the usual checkout process
 		// Instead, we add the mapping directly
 		if ( selectedSite.is_vip ) {
-			wpcom.addVipDomainMapping( selectedSite.ID, domain ).then( () => {
-				page( paths.domainManagementList( selectedSite.slug ) );
-			}, error => this.setState( { errorMessage: error.message } ) );
+			wpcom.addVipDomainMapping( selectedSite.ID, domain )
+				.then(
+					() => page( paths.domainManagementList( selectedSiteSlug ) ),
+					( error ) => this.setState( { errorMessage: error.message } )
+				);
 			return;
 		}
 
 		upgradesActions.addItem( cartItems.domainMapping( { domain } ) );
 
-		if ( this.isMounted() ) {
-			page( '/checkout/' + selectedSite.slug );
-		}
-	},
+		page( '/checkout/' + selectedSiteSlug );
+	}
 
-	render: function() {
-		let selectedSite;
+	render() {
+		const {
+			cart,
+			domainsWithPlansOnly,
+			initialQuery,
+			productsList,
+			selectedSite,
+			translate,
+		} = this.props;
 
-		if ( this.props.sites ) {
-			selectedSite = this.props.sites.getSelectedSite();
-		}
+		const {
+			errorMessage
+		} = this.state;
 
 		return (
 			<span>
 				<HeaderCake onClick={ this.goBack }>
-					{ this.translate( 'Map a Domain' ) }
+					{ translate( 'Map a Domain' ) }
 				</HeaderCake>
 
-				{ this.state.errorMessage && <Notice status="is-error" text={ this.state.errorMessage }/> }
+				{ errorMessage && <Notice status="is-error" text={ errorMessage } /> }
 
 				<MapDomainStep
-					{ ...omit( this.props, [ 'children', 'productsList', 'sites' ] ) }
-					products={ this.props.productsList.get() }
+					cart={ cart }
+					domainsWithPlansOnly={ domainsWithPlansOnly }
+					initialQuery={ initialQuery }
+					products={ productsList }
 					selectedSite={ selectedSite }
 					onRegisterDomain={ this.handleRegisterDomain }
 					onMapDomain={ this.handleMapDomain }
 					analyticsSection="domains"
 				/>
+
+				<QueryProductsList />
 			</span>
 		);
 	}
-} );
+}
 
-module.exports = connect( state => (
-	{
-		domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY )
-	}
-) )( MapDomain );
+export default connect(
+	( state ) => ( {
+		selectedSite: getSelectedSite( state ),
+		selectedSiteSlug: getSelectedSiteSlug( state ),
+		domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
+		isSiteUpgradeable: isSiteUpgradeable( state, getSelectedSiteId( state ) ),
+		productsList: state.productsList.items,
+	} )
+)( localize( MapDomain ) );

--- a/client/signup/jetpack-connect/plans-grid.jsx
+++ b/client/signup/jetpack-connect/plans-grid.jsx
@@ -38,7 +38,7 @@ export default React.createClass( {
 	},
 
 	render() {
-		const defaultJetpackSite = { jetpack: true, plan: {}, isUpgradeable: () => true };
+		const defaultJetpackSite = { jetpack: true, plan: {} };
 		return (
 			<Main wideLayout>
 				<div className="jetpack-connect__plans">


### PR DESCRIPTION
This PR goal is to remove `Site#isUpgradeable()`.

This will help toward making the `Site` instance almost identical to the site objects in the redux store so the transition from `SitesList` to `state/sites` is easier. Progressively removing methods from `Site` and `SitesList` is a good way to help with this transition.

### Testing Instructions
- Boot this branch locally (or using calypso.live)
- Go to http://calypso.localhost:3000/sites and assert that there is no error when using this page
- Go to http://calypso.localhost:3000/domains assert that there is no error when using this page
- Go to `http://calypso.localhost:3000/domains/add/:exisiting-site-slug` and assert that there is no error
- Go to `http://calypso.localhost:3000/domains/add/suggestion/hello+world/:exisiting-site-slug` and assert that there is no error
- Go to `http://calypso.localhost:3000/domains/add/site-redirect/:exisiting-site-slug` and assert that there is no error

### Reviews
- [ ] Code
- [ ] Product
