### PR TITLE
Components: Fixing color contrast on accordion

### DIFF
--- a/client/components/accordion/style.scss
+++ b/client/components/accordion/style.scss
@@ -1,6 +1,6 @@
 $accordion-padding: 16px;
 $accordion-subtitle-height: 16px;
-$accordion-background-collapsed: $gray-light; // same as body
+$accordion-background-collapsed: $white;
 $accordion-background-hover: lighten( $gray, 30% );
 $accordion-background-expanded: $white;
 
@@ -91,7 +91,7 @@ $accordion-background-expanded: $white;
 .accordion__subtitle {
 	font-size: 0.8em;
 	font-style: italic;
-	color: $gray;
+	color: $gray-text;
 	white-space: nowrap;
 	overflow-x: hidden;
 	position: relative;

--- a/client/components/accordion/style.scss
+++ b/client/components/accordion/style.scss
@@ -1,6 +1,6 @@
 $accordion-padding: 16px;
 $accordion-subtitle-height: 16px;
-$accordion-background-collapsed: $white;
+$accordion-background-collapsed: $gray-light; // same as body
 $accordion-background-hover: lighten( $gray, 30% );
 $accordion-background-expanded: $white;
 
@@ -91,7 +91,7 @@ $accordion-background-expanded: $white;
 .accordion__subtitle {
 	font-size: 0.8em;
 	font-style: italic;
-	color: $gray-text;
+	color: $gray-dark;
 	white-space: nowrap;
 	overflow-x: hidden;
 	position: relative;


### PR DESCRIPTION
This updates the accordion component to use the $gray-dark variable for text, which makes it pass WCAG 2.0 AA tests.

Affects only the editor.

Before:
<img width="328" alt="screen shot 2017-02-10 at 11 17 45 am" src="https://cloud.githubusercontent.com/assets/618551/22836615/c64538ca-ef82-11e6-8890-41ff1ce94e22.png">
After:
![screen shot 2017-02-10 at 4 12 41 pm](https://cloud.githubusercontent.com/assets/618551/22846163/cb48aedc-efab-11e6-98d2-4f414ce5be05.png)
