### PR TITLE
Themes: Obtain theme info from canonical source

### DIFF
--- a/client/components/data/query-canonical-theme/README.md
+++ b/client/components/data/query-canonical-theme/README.md
@@ -1,0 +1,56 @@
+Query Canonical Theme
+=====================
+
+Query Canonical Theme is a React component used in managing the fetching of individual theme objects from what is considered their 'canonical' source, i.e. the one with richest information. It checks WP.com (which has a long description and multiple screenshots, and a preview URL) first, then WP.org (which has a preview URL), then the given fallback JP site.
+
+## Usage
+
+Render the component, passing `siteId` and `themeId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+
+```jsx
+import React from 'react';
+import { connect } from 'react-redux';
+import QueryCanonicalTheme from 'components/data/query-canonical-theme';
+import Theme from 'components/theme';
+import { getCanonicalTheme } from 'state/themes/selectors';
+
+function MyTheme( { theme } ) {
+	return (
+		<div>
+			<QueryCanonicalTheme
+				siteId={ 3584907 }
+				themeId={ 'twentysixteen' } />
+				<Theme theme={ theme } />
+			} }
+		</div>
+	);
+}
+
+export default connect(
+	( state ) => ( {
+		theme: getCanonicalTheme( state, 3584907, 'twentysixteen' )
+	} )
+)( MyTheme );
+```
+
+## Props
+
+### `siteId`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+	<tr><th>Default</th><td><code>null</code></td></tr>
+</table>
+
+The site ID which should be used as a fallback if the theme cannot be found on WP.com or WP.org.
+
+### `themeId`
+
+<table>
+	<tr><th>Type</th><td>string</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+	<tr><th>Default</th><td><code>''</code></td></tr>
+</table>
+
+The theme Id of theme we wish to obtain.

--- a/client/components/data/query-canonical-theme/index.jsx
+++ b/client/components/data/query-canonical-theme/index.jsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import QueryTheme from 'components/data/query-theme';
+import { isWpcomTheme, isWporgTheme } from 'state/themes/selectors';
+
+const QueryCanonicalTheme = ( { siteId, themeId, isWpcom, isWporg } ) => (
+	<div>
+		<QueryTheme themeId={ themeId } siteId="wpcom" />
+    { ! isWpcom && <QueryTheme themeId={ themeId } siteId="wporg" /> }
+		{ ! isWpcom && ! isWporg && siteId && <QueryTheme themeId={ themeId } siteId={ siteId } /> }
+	</div>
+);
+
+QueryCanonicalTheme.propTypes = {
+	siteId: PropTypes.number,
+	themeId: PropTypes.string.isRequired,
+  // Connected propTypes
+	isWpcom: PropTypes.bool.isRequired,
+	isWporg: PropTypes.bool.isRequired
+};
+
+export default connect(
+	( state, { themeId } ) => ( {
+		isWpcom: isWpcomTheme( state, themeId ),
+		isWporg: isWporgTheme( state, themeId )
+	} )
+)( QueryCanonicalTheme );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -41,6 +41,7 @@ import {
 	isThemeActive,
 	isThemePremium,
 	isPremiumThemeAvailable,
+	isWpcomTheme as isThemeWpcom,
 	getThemeRequestErrors,
 	getThemeForumUrl,
 } from 'state/themes/selectors';
@@ -49,7 +50,7 @@ import EmptyContentComponent from 'components/empty-content';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import DocumentHead from 'components/data/document-head';
 import { decodeEntities } from 'lib/formatting';
-import { getTheme } from 'state/themes/selectors';
+import { getCanonicalTheme } from 'state/themes/selectors';
 import { isValidTerm } from 'my-sites/themes/theme-filters';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { setThemePreviewOptions } from 'state/themes/actions';
@@ -661,12 +662,12 @@ export default connect(
 	( state, { id } ) => {
 		const selectedSite = getSelectedSite( state );
 		const siteSlug = selectedSite ? getSiteSlug( state, selectedSite.ID ) : '';
-		const isWpcomTheme = !! getTheme( state, 'wpcom', id );
+		const isWpcomTheme = isThemeWpcom( state, id );
 		const siteIdOrWpcom = ( selectedSite && ! isWpcomTheme ) ? selectedSite.ID : 'wpcom';
 		const backPath = getBackPath( state );
 		const currentUserId = getCurrentUserId( state );
 		const isCurrentUserPaid = isUserPaid( state, currentUserId );
-		const theme = getTheme( state, siteIdOrWpcom, id );
+		const theme = getCanonicalTheme( state, selectedSite && selectedSite.ID, id );
 		const error = theme ? false : getThemeRequestErrors( state, id, siteIdOrWpcom );
 
 		return {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -14,7 +14,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import QueryTheme from 'components/data/query-theme';
+import QueryCanonicalTheme from 'components/data/query-canonical-theme';
 import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
 import SectionHeader from 'components/section-header';
@@ -508,7 +508,7 @@ const ThemeSheet = React.createClass( {
 		const analyticsPath = `/theme/:slug${ section ? '/' + section : '' }${ siteID ? '/:site_id' : '' }`;
 		const analyticsPageTitle = `Themes > Details Sheet${ section ? ' > ' + titlecase( section ) : '' }${ siteID ? ' > Site' : '' }`;
 
-		const { name: themeName, description, currentUserId, isWpcomTheme } = this.props;
+		const { name: themeName, description, currentUserId } = this.props;
 		const title = themeName && i18n.translate( '%(themeName)s Theme', {
 			args: { themeName }
 		} );
@@ -532,9 +532,7 @@ const ThemeSheet = React.createClass( {
 
 		return (
 			<Main className="theme__sheet">
-				<QueryTheme themeId={ this.props.id } siteId={ 'wpcom' } />
-				{ ! isWpcomTheme && siteID && <QueryTheme themeId={ this.props.id } siteId={ siteID } /> }
-				{ ! isWpcomTheme && <QueryTheme themeId={ this.props.id } siteId="wporg" /> }
+				<QueryCanonicalTheme themeId={ this.props.id } siteId={ siteID } />
 				{ currentUserId && <QueryUserPurchases userId={ currentUserId } /> }
 				{ siteID && <QuerySitePurchases siteId={ siteID } /> }
 				{ siteID && <QuerySitePlans siteId={ siteID } /> }
@@ -663,11 +661,11 @@ export default connect(
 		const selectedSite = getSelectedSite( state );
 		const siteSlug = selectedSite ? getSiteSlug( state, selectedSite.ID ) : '';
 		const isWpcomTheme = isThemeWpcom( state, id );
-		const siteIdOrWpcom = ( selectedSite && ! isWpcomTheme ) ? selectedSite.ID : 'wpcom';
 		const backPath = getBackPath( state );
 		const currentUserId = getCurrentUserId( state );
 		const isCurrentUserPaid = isUserPaid( state, currentUserId );
 		const theme = getCanonicalTheme( state, selectedSite && selectedSite.ID, id );
+		const siteIdOrWpcom = selectedSite ? selectedSite.ID : 'wpcom';
 		const error = theme ? false : getThemeRequestErrors( state, id, siteIdOrWpcom );
 
 		return {

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -14,8 +14,7 @@ import Card from 'components/card';
 import CurrentThemeButton from './button';
 import { connectOptions } from '../theme-options';
 import { trackClick } from '../helpers';
-import { isJetpackSite } from 'state/sites/selectors';
-import { getActiveTheme, getTheme } from 'state/themes/selectors';
+import { getActiveTheme, getCanonicalTheme } from 'state/themes/selectors';
 import QueryActiveTheme from 'components/data/query-active-theme';
 
 /**
@@ -91,9 +90,8 @@ const CurrentThemeWithOptions = ( { siteId, currentTheme } ) => (
 export default connect(
 	( state, { siteId } ) => {
 		const currentThemeId = getActiveTheme( state, siteId );
-		const siteIdOrWpcom = isJetpackSite( state, siteId ) ? siteId : 'wpcom';
 		return {
-			currentTheme: getTheme( state, siteIdOrWpcom, currentThemeId ),
+			currentTheme: getCanonicalTheme( state, siteId, currentThemeId ),
 		};
 	}
 )( CurrentThemeWithOptions );

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -16,6 +16,7 @@ import { connectOptions } from '../theme-options';
 import { trackClick } from '../helpers';
 import { getActiveTheme, getCanonicalTheme } from 'state/themes/selectors';
 import QueryActiveTheme from 'components/data/query-active-theme';
+import QueryCanonicalTheme from 'components/data/query-canonical-theme';
 
 /**
  * Show current active theme for a site, with
@@ -37,7 +38,7 @@ class CurrentTheme extends Component {
 	trackClick = ( event ) => trackClick( 'current theme', event )
 
 	render() {
-		const { currentTheme, siteId, translate } = this.props,
+		const { currentTheme, currentThemeId, siteId, translate } = this.props,
 			placeholderText = <span className="current-theme__placeholder">loading...</span>,
 			text = ( currentTheme && currentTheme.name ) ? currentTheme.name : placeholderText;
 
@@ -48,6 +49,7 @@ class CurrentTheme extends Component {
 		return (
 			<Card className="current-theme">
 				{ siteId && <QueryActiveTheme siteId={ siteId } /> }
+				{ currentThemeId && <QueryCanonicalTheme themeId={ currentThemeId } siteId={ siteId } /> }
 				<div className="current-theme__current">
 					<span className="current-theme__label">
 						{ translate( 'Current Theme' ) }
@@ -76,8 +78,9 @@ class CurrentTheme extends Component {
 
 const ConnectedCurrentTheme = connectOptions( localize( CurrentTheme ) );
 
-const CurrentThemeWithOptions = ( { siteId, currentTheme } ) => (
+const CurrentThemeWithOptions = ( { siteId, currentTheme, currentThemeId } ) => (
 	<ConnectedCurrentTheme currentTheme={ currentTheme }
+		currentThemeId={ currentThemeId }
 		siteId={ siteId }
 		options={ [
 			'customize',
@@ -91,6 +94,7 @@ export default connect(
 	( state, { siteId } ) => {
 		const currentThemeId = getActiveTheme( state, siteId );
 		return {
+			currentThemeId,
 			currentTheme: getCanonicalTheme( state, siteId, currentThemeId ),
 		};
 	}

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -12,10 +12,9 @@ import { translate } from 'i18n-calypso';
 import Dialog from 'components/dialog';
 import PulsingDot from 'components/pulsing-dot';
 import { trackClick } from './helpers';
-import { isJetpackSite } from 'state/sites/selectors';
 import {
 	getActiveTheme,
-	getTheme,
+	getCanonicalTheme,
 	getThemeDetailsUrl,
 	getThemeCustomizeUrl,
 	getThemeForumUrl,
@@ -202,9 +201,8 @@ const ThanksModal = React.createClass( {
 
 export default connect(
 	( state, { site } ) => {
-		const siteIdOrWpcom = ( site && isJetpackSite( state, site.ID ) ) ? site.ID : 'wpcom';
 		const currentThemeId = site && getActiveTheme( state, site.ID );
-		const currentTheme = currentThemeId && getTheme( state, siteIdOrWpcom, currentThemeId );
+		const currentTheme = currentThemeId && getCanonicalTheme( state, site.ID, currentThemeId );
 
 		return {
 			currentTheme,

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -13,7 +13,7 @@ import QueryTheme from 'components/data/query-theme';
 import { connectOptions } from './theme-options';
 import {
 	getThemePreviewThemeOptions,
-	getTheme,
+	getCanonicalTheme,
 	themePreviewVisibility,
 	isThemeActive
 } from 'state/themes/selectors';
@@ -108,12 +108,7 @@ export default connect(
 
 		const siteId = getSelectedSiteId( state );
 		const isJetpack = isJetpackSite( state, siteId );
-		let theme = getTheme( state, 'wpcom', themeId );
-
-		if ( ! theme && isJetpack ) {
-			// This is not wpcom theme so check jetpack and org list.
-			theme = getTheme( state, siteId, themeId );
-		}
+		const theme = getCanonicalTheme( state, siteId, themeId );
 
 		const themeOptions = getThemePreviewThemeOptions( state );
 		return {

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -150,7 +150,7 @@ export function requestThemes( siteId, query = {} ) {
 				// So we have to filter on the client side.
 				// Also if Jetpack plugin has Themes Extended Features,
 				// we filter out -wpcom suffixed themes because we will show them in
-				// second list that is specific to WorpPress.com themes.
+				// second list that is specific to WordPress.com themes.
 				const keepWpcom = ! config.isEnabled( 'manage/themes/upload' ) ||
 					! hasJetpackSiteJetpackThemesExtendedFeatures( getState(), siteId );
 
@@ -439,8 +439,11 @@ export function installTheme( themeId, siteId ) {
 		}
 
 		return wpcom.undocumented().installThemeOnJetpack( siteId, themeId )
-			.then( ( theme ) => {
-				dispatch( receiveTheme( theme, siteId ) );
+			.then( () => {
+				// We do not `dispatch( receiveTheme( theme, siteId ) )` here because
+				// in our UI, themes from WP.com (and WP.org) are already present in
+				// a separate list, and we do not want to duplicate them.
+
 				dispatch( {
 					type: THEME_INSTALL_SUCCESS,
 					siteId,

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -501,7 +501,11 @@ export function getThemeForumUrl( state, themeId, siteId ) {
  * @return {?String}         Theme ID
  */
 export function getActiveTheme( state, siteId ) {
-	return get( state.themes.activeThemes, siteId, null );
+	const activeTheme = get( state.themes.activeThemes, siteId, null );
+	// If the theme ID is suffixed with -wpcom, remove that string. This is because
+	// we want to treat WP.com themes identically, whether or not they're installed
+	// on a given Jetpack site (where the -wpcom suffix would be appended).
+	return activeTheme && activeTheme.replace( '-wpcom', '' );
 }
 
 /**
@@ -513,7 +517,7 @@ export function getActiveTheme( state, siteId ) {
  * @return {Boolean}         True if the theme is active on the site
  */
 export function isThemeActive( state, themeId, siteId ) {
-	return getActiveTheme( state, siteId ) === getSuffixedThemeId( state, themeId, siteId );
+	return getActiveTheme( state, siteId ) === themeId;
 }
 
 /**

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, includes, isEqual, omit, some, get, pick, uniq } from 'lodash';
+import { find, includes, isEqual, omit, some, get, uniq } from 'lodash';
 import createSelector from 'lib/create-selector';
 
 /**
@@ -44,25 +44,7 @@ export const getTheme = createSelector(
 			return null;
 		}
 
-		const theme = manager.getItem( themeId );
-		if ( siteId === 'wpcom' || siteId === 'wporg' ) {
-			return theme;
-		}
-
-		if ( ! theme ) {
-			return null;
-		}
-
-		// We're dealing with a Jetpack site. If we have theme info obtained from the
-		// WordPress.org API, merge it.
-		const wporgTheme = getTheme( state, 'wporg', themeId );
-		if ( ! wporgTheme ) {
-			return theme;
-		}
-		return {
-			...theme,
-			...pick( wporgTheme, [ 'demo_uri', 'download', 'taxonomies' ] )
-		};
+		return manager.getItem( themeId );
 	},
 	( state ) => state.themes.queries
 );

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -315,6 +315,17 @@ export function isRequestingActiveTheme( state, siteId ) {
 }
 
 /**
+ * Whether a theme is present in the WordPress.com Theme Directory
+ *
+ * @param  {Object}  state   Global state tree
+ * @param  {Number}  themeId Theme ID
+ * @return {Boolean}         Whether theme is in WP.com theme directory
+ */
+export function isWpcomTheme( state, themeId ) {
+	return !! getTheme( state, 'wpcom', themeId );
+}
+
+/**
  * Whether a theme is present in the WordPress.org Theme Directory
  *
  * @param  {Object}  state   Global state tree

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { includes, isEqual, omit, some, get, pick, uniq } from 'lodash';
+import { find, includes, isEqual, omit, some, get, pick, uniq } from 'lodash';
 import createSelector from 'lib/create-selector';
 
 /**
@@ -66,6 +66,22 @@ export const getTheme = createSelector(
 	},
 	( state ) => state.themes.queries
 );
+
+/**
+ * Returns a theme object from what is considered the 'canonical' source, i.e.
+ * the one with richest information. Checks WP.com (which has a long description
+ * and multiple screenshots, and a preview URL) first, then WP.org (which has a
+ * preview URL), then the given JP site.
+ *
+ * @param  {Object}  state   Global state tree
+ * @param  {Number}  siteId  Jetpack Site ID to fall back to
+ * @param  {String}  themeId Theme ID
+ * @return {?Object}         Theme object
+ */
+export function getCanonicalTheme( state, siteId, themeId ) {
+	const source = find( [ 'wpcom', 'wporg', siteId ], s => getTheme( state, s, themeId ) );
+	return getTheme( state, source, themeId );
+}
 
 /**
  * When wpcom themes are installed on Jetpack sites, the

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -8,6 +8,7 @@ import { expect } from 'chai';
  */
 import {
 	getTheme,
+	getCanonicalTheme,
 	getThemeRequestErrors,
 	isRequestingTheme,
 	getThemesForQuery,
@@ -133,61 +134,67 @@ describe( 'themes selectors', () => {
 
 			expect( theme ).to.equal( twentysixteen );
 		} );
+	} );
 
-		context( 'on a Jetpack site', () => {
-			it( 'with a theme not found on WP.org, should return the theme object', () => {
-				const jetpackTheme = {
-					id: 'twentyseventeen',
-					name: 'Twenty Seventeen',
-					author: 'the WordPress team',
-				};
-
-				const theme = getTheme( {
-					themes: {
-						queries: {
-							2916284: new ThemeQueryManager( {
-								items: { twentyseventeen: jetpackTheme }
-							} )
-						}
+	describe( '#getCanonicalTheme()', () => {
+		it( 'with a theme found on WP.com, should return the object fetched from there', () => {
+			const theme = getCanonicalTheme( {
+				themes: {
+					queries: {
+						wpcom: new ThemeQueryManager( {
+							items: { twentysixteen }
+						} ),
 					}
-				}, 2916284, 'twentyseventeen' );
+				}
+			}, 2916284, 'twentysixteen' );
 
-				expect( theme ).to.deep.equal( jetpackTheme );
-			} );
+			expect( theme ).to.deep.equal( twentysixteen );
+		} );
 
-			it( 'with a theme found on WP.org, should return an object with some attrs merged from WP.org', () => {
-				const jetpackTheme = {
-					id: 'twentyseventeen',
-					name: 'Twenty Seventeen',
-					author: 'the WordPress team',
-				};
-				const wporgTheme = {
-					demo_uri: 'https://wp-themes.com/twentyseventeen',
-					download: 'http://downloads.wordpress.org/theme/twentyseventeen.1.1.zip',
-					taxonomies: {
-						theme_feature: {
-							'custom-header': 'Custom Header'
-						}
+		it( 'with a theme found on WP.org but not on WP.com, should return the object fetched from there', () => {
+			const wporgTheme = {
+				id: 'twentyseventeen',
+				name: 'Twenty Seventeen',
+				author: 'the WordPress team',
+				demo_uri: 'https://wp-themes.com/twentyseventeen',
+				download: 'http://downloads.wordpress.org/theme/twentyseventeen.1.1.zip',
+				taxonomies: {
+					theme_feature: {
+						'custom-header': 'Custom Header'
 					}
-				};
-				const theme = getTheme( {
-					themes: {
-						queries: {
-							2916284: new ThemeQueryManager( {
-								items: { twentyseventeen: jetpackTheme }
-							} ),
-							wporg: new ThemeQueryManager( {
-								items: { twentyseventeen: wporgTheme }
-							} ),
-						}
+				}
+			};
+			const theme = getCanonicalTheme( {
+				themes: {
+					queries: {
+						wporg: new ThemeQueryManager( {
+							items: { twentyseventeen: wporgTheme }
+						} ),
 					}
-				}, 2916284, 'twentyseventeen' );
+				}
+			}, 2916284, 'twentyseventeen' );
 
-				expect( theme ).to.deep.equal( {
-					...jetpackTheme,
-					...wporgTheme
-				} );
-			} );
+			expect( theme ).to.deep.equal( wporgTheme );
+		} );
+
+		it( 'with a theme not found on WP.com nor on WP.org, should return the theme object from the given siteId', () => {
+			const jetpackTheme = {
+				id: 'twentyseventeen',
+				name: 'Twenty Seventeen',
+				author: 'the WordPress team',
+			};
+
+			const theme = getCanonicalTheme( {
+				themes: {
+					queries: {
+						2916284: new ThemeQueryManager( {
+							items: { twentyseventeen: jetpackTheme }
+						} )
+					}
+				}
+			}, 2916284, 'twentyseventeen' );
+
+			expect( theme ).to.deep.equal( jetpackTheme );
 		} );
 	} );
 

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -1545,6 +1545,21 @@ describe( 'themes selectors', () => {
 
 			expect( activeTheme ).to.equal( 'twentysixteen' );
 		} );
+
+		it( 'given a site, should return its currently active theme without -wpcom suffix', () => {
+			const activeTheme = getActiveTheme(
+				{
+					themes: {
+						activeThemes: {
+							2916284: 'twentysixteen-wpcom'
+						}
+					}
+				},
+				2916284
+			);
+
+			expect( activeTheme ).to.equal( 'twentysixteen' );
+		} );
 	} );
 
 	describe( '#isThemeActive', () => {

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -28,6 +28,7 @@ import {
 	getActiveTheme,
 	isRequestingActiveTheme,
 	isWporgTheme,
+	isWpcomTheme,
 	isThemeActive,
 	isActivatingTheme,
 	hasActivatedTheme,
@@ -1864,6 +1865,33 @@ describe( 'themes selectors', () => {
 			}, 'twentyseventeen' );
 
 			expect( isWporg ).to.be.true;
+		} );
+	} );
+
+	describe( '#isWpcomTheme()', () => {
+		it( 'should return false if theme is not found on WP.com', () => {
+			const isWpcom = isWporgTheme( {
+				themes: {
+					queries: {
+					}
+				}
+			}, 'twentysixteen' );
+
+			expect( isWpcom ).to.be.false;
+		} );
+
+		it( 'should return true if theme is found on WP.com', () => {
+			const isWpcom = isWpcomTheme( {
+				themes: {
+					queries: {
+						wpcom: new ThemeQueryManager( {
+							items: { twentysixteen }
+						} ),
+					}
+				}
+			}, 'twentysixteen' );
+
+			expect( isWpcom ).to.be.true;
 		} );
 	} );
 

--- a/client/state/themes/test/utils.js
+++ b/client/state/themes/test/utils.js
@@ -123,6 +123,7 @@ describe( 'utils', () => {
 			const normalizedTheme = normalizeWporgTheme();
 			expect( normalizedTheme ).to.deep.equal( {} );
 		} );
+
 		it( 'should rename some keys', () => {
 			const normalizedTheme = normalizeWporgTheme( {
 				slug: 'twentyfifteen',
@@ -131,6 +132,9 @@ describe( 'utils', () => {
 				screenshot_url: '//ts.w.org/wp-content/themes/twentyfifteen/screenshot.png?ver=1.7',
 				preview_url: 'https://wp-themes.com/twentyfifteen',
 				download_link: 'http://downloads.wordpress.org/theme/twentyfifteen.1.7.zip',
+				sections: {
+					description: 'Our 2015 default theme is clean, blog-focused, and designed for clarity. ...'
+				},
 				tags: {
 					'custom-header': 'Custom Header',
 					'two-columns': 'Two Columns'
@@ -143,6 +147,7 @@ describe( 'utils', () => {
 				screenshot: '//ts.w.org/wp-content/themes/twentyfifteen/screenshot.png?ver=1.7',
 				demo_uri: 'https://wp-themes.com/twentyfifteen',
 				download: 'http://downloads.wordpress.org/theme/twentyfifteen.1.7.zip',
+				description: 'Our 2015 default theme is clean, blog-focused, and designed for clarity. ...',
 				taxonomies: {
 					theme_feature: [
 						{ slug: 'custom-header', name: 'Custom Header' },

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -98,9 +98,14 @@ export function normalizeWporgTheme( theme ) {
 		download_link: 'download'
 	};
 
-	const normalizedTheme = mapKeys( theme, ( value, key ) => (
+	const normalizedTheme = mapKeys( omit( theme, 'sections' ), ( value, key ) => (
 		get( attributesMap, key, key )
 	) );
+
+	const description = get( theme, [ 'sections', 'description' ] );
+	if ( description ) {
+		normalizedTheme.description = description;
+	}
 
 	if ( ! normalizedTheme.tags ) {
 		return normalizedTheme;


### PR DESCRIPTION
Add a new `getCanonicalTheme` selector, which uses theme info from WP.com and WP.org before resorting to the (Jetpack) site the theme is found on. This allows us to remove the [merging of WP.org theme info into JP theme objects](https://github.com/Automattic/wp-calypso/blob/c983d62865b5a9ffe6bf7482d69316cd94a2b607/client/state/themes/selectors.js#L62-L65); the latter requires us to tune the `normalizeWporgTheme` a bit.

Leveraging the technique described in the previous paragraph, this PR then goes on to remove the `-wpcom` suffix in `getActiveTheme` (instead of `isActiveTheme`). Moving this logic one level deeper fixes the Current Theme Bar and Thanks Modal.

Also, this PR removes `receiveTheme` from the `installTheme` action to fix #11038.

Interestingly, we don't need to change error handling in the theme sheet: since `getCanonicalTheme` will try to fetch from WP.com, WP.org, and the given site in order, we will only end up with a `null` result if the theme isn't present on any. This means we only need to check if there was an error fetching from the given site. (What makes things slightly less intuitive, but doesn't rebut this argument, is that the given `siteId`, for a non Jetpack site, can be `wpcom`.)

To test:
* _This is a rather invasive change, so be sure to test the showcase thoroughly!_
* Check that the currently active theme is still handled and displayed correctly everywhere:
  * Themes List (blue highlight, options in '...' menu)
  * Current Theme Bar (theme name displayed? links point to the right destinations?)
  * Thanks Modal
  * Theme Sheet -- CTA button
  * Theme Preview
  * Be sure to cover activation of a previously not installed theme on a JP site.
* Verify that this PR fixes #10895 and #11038.