### PR TITLE
Signup: Fix horizontal scroll on Design Type With Store Signup step

### DIFF
--- a/client/signup/steps/design-type-with-store/bluehost-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/bluehost-store/index.jsx
@@ -9,7 +9,6 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import StepHeader from 'signup/step-header';
 import Button from 'components/button';
 import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -28,7 +27,6 @@ export const BluehostStoreStep = props => {
 		'favorite WordPress eCommerce solution.'
 	);
 
-	let subHeaderText = translate( 'Our partners at BlueHost are here for you.'	);
 	let partnerUrl = 'https://www.bluehost.com/track/wp/dotcomsans2?page=/wordpress';
 	let price = '$2.95';
 
@@ -39,18 +37,12 @@ export const BluehostStoreStep = props => {
 			'to help you get started.'
 		);
 
-		subHeaderText = translate( 'Our partners at BlueHost and WooCommerce are here for you.' );
 		partnerUrl = 'https://www.bluehost.com/track/wp/dotcomwoo2?page=/wordpress-woocommerce';
 		price = '$11.95';
 	}
 
 	return (
 		<div className="design-type-with-store__partner-box">
-			<StepHeader
-				headerText={ translate( 'Create a WordPress Store' ) }
-				subHeaderText={ subHeaderText }
-			/>
-
 			<div className="design-type-with-store__flex-container">
 				<div className="design-type-with-store__copy">
 					<div className="design-type-with-store__vertical-center">

--- a/client/signup/steps/design-type-with-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/index.jsx
@@ -38,7 +38,7 @@ class DesignTypeWithStoreStep extends Component {
 		const { translate } = this.props;
 
 		return [
-			{ type: 'blog', label: translate( 'A list of my latest posts' ), image: <BlogImage />  },
+			{ type: 'blog', label: translate( 'A list of my latest posts' ), image: <BlogImage /> },
 			{ type: 'page', label: translate( 'A welcome page for my site' ), image: <PageImage /> },
 			{ type: 'grid', label: translate( 'A grid of my latest posts' ), image: <GridImage /> },
 			{ type: 'store', label: translate( 'An online store' ), image: <StoreImage /> },
@@ -87,7 +87,7 @@ class DesignTypeWithStoreStep extends Component {
 	renderChoice = ( choice ) => {
 		return (
 			<Card className="design-type-with-store__choice" key={ choice.type }>
-				<a className="design-type-with-store__choice__link"
+				<a className="design-type-with-store__choice-link"
 					href="#"
 					onClick={ this.handleChoiceClick( choice.type ) }>
 					{ choice.image }
@@ -98,9 +98,24 @@ class DesignTypeWithStoreStep extends Component {
 	};
 
 	renderChoices() {
+		const storeWrapperClassName = classNames(
+			'design-type-with-store__store-wrapper',
+			{ 'is-hidden': ! this.state.showStore }
+		);
+
+		const designTypeListClassName = classNames(
+			'design-type-with-store__list',
+			{ 'is-hidden': this.state.showStore }
+		);
+
 		return (
-			<div className="design-type-with-store__list">
-				{ this.getChoices().map( this.renderChoice ) }
+			<div className="design-type-with-store__substep-wrapper">
+				<div className={ storeWrapperClassName }>
+					{ this.renderStoreStep() }
+				</div>
+				<div className={ designTypeListClassName }>
+					{ this.getChoices().map( this.renderChoice ) }
+				</div>
 			</div>
 		);
 	}
@@ -136,34 +151,46 @@ class DesignTypeWithStoreStep extends Component {
 		}
 	}
 
-	render() {
-		const storeWrapperClassName = classNames( {
-			'design-type-with-store__store-wrapper': true,
-			'is-hidden': ! this.state.showStore,
-		} );
+	getSubHeaderText() {
+		const { translate } = this.props;
 
-		const sectionWrapperClassName = classNames( {
-			'design-type-with-store__section-wrapper': true,
-			'is-hidden': this.state.showStore,
-		} );
+		if ( this.state.showStore ) {
+			switch ( abtest( 'signupStoreBenchmarking' ) ) {
+				case 'bluehost':
+					return translate( 'Our partners at BlueHost are here for you.'	);
+				case 'bluehostWithWoo':
+					return translate( 'Our partners at BlueHost and WooCommerce are here for you.' );
+				case 'siteground':
+					return translate( 'Our partners at SiteGround and WooCommerce are here for you.' );
+				default:
+					return translate( 'Our partners at Pressable and WooCommerce are here for you.' );
+			}
+		}
+
+		return translate( 'This will help us figure out what kinds of designs to show you.' );
+	}
+
+	render() {
+		const { translate } = this.props;
+
+		const headerText = this.state.showStore
+			? translate( 'Create your WordPress Store' )
+			: translate( 'What would you like your homepage to look like?' );
+
+		const subHeaderText = this.getSubHeaderText();
 
 		return (
-			<div className="design-type-with-store">
-				<div className={ storeWrapperClassName } >
-					{ this.renderStoreStep() }
-				</div>
-				<div className={ sectionWrapperClassName }>
-					<StepWrapper
-						flowName={ this.props.flowName }
-						stepName={ this.props.stepName }
-						positionInFlow={ this.props.positionInFlow }
-						fallbackHeaderText={ this.props.translate( 'What would you like your homepage to look like?' ) }
-						fallbackSubHeaderText={ this.props.translate( 'This will help us figure out what kinds of designs to show you.' ) }
-						subHeaderText={ this.props.translate( 'First up, what would you like your homepage to look like?' ) }
-						signupProgress={ this.props.signupProgress }
-						stepContent={ this.renderChoices() } />
-				</div>
-			</div>
+			<StepWrapper
+				flowName={ this.props.flowName }
+				stepName={ this.props.stepName }
+				positionInFlow={ this.props.positionInFlow }
+				fallbackHeaderText={ headerText }
+				fallbackSubHeaderText={ subHeaderText }
+				subHeaderText={ subHeaderText }
+				signupProgress={ this.props.signupProgress }
+				stepContent={ this.renderChoices() }
+				shouldHideNavButtons={ this.state.showStore }
+			/>
 		);
 	}
 }

--- a/client/signup/steps/design-type-with-store/pressable-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/pressable-store/index.jsx
@@ -20,7 +20,6 @@ import FormInputValidation from 'components/forms/form-input-validation';
 import FormButton from 'components/forms/form-button';
 import FormLabel from 'components/forms/form-label';
 import FormSectionHeading from 'components/forms/form-section-heading';
-import StepHeader from 'signup/step-header';
 import Button from 'components/button';
 import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -141,10 +140,6 @@ class PressableStoreStep extends Component {
 
 		return (
 			<div className="pressable-store">
-				<StepHeader
-					headerText={ translate( 'Create your WordPress Store' ) }
-					subHeaderText={ translate( 'Our partners at Pressable and WooCommerce are here for you.' ) }
-				/>
 				{ this.renderStoreForm() }
 				<div className="pressable-store__back-button-wrapper">
 					<Button compact={ true } borderless={ true } onClick={ this.props.onBackClick }>

--- a/client/signup/steps/design-type-with-store/siteground-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/siteground-store/index.jsx
@@ -9,7 +9,6 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import StepHeader from 'signup/step-header';
 import Button from 'components/button';
 import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -18,11 +17,6 @@ import SitegroundLogo from './siteground-logo';
 
 export const SitegroundStoreStep = ( { onBackClick, translate, partnerClickRecorder, price } ) => (
 	<div className="design-type-with-store__partner-box">
-		<StepHeader
-			headerText={ translate( 'Create a WordPress Store' ) }
-			subHeaderText={ translate( 'Our partners at SiteGround and WooCommerce are here for you.' ) }
-		/>
-
 		<div className="design-type-with-store__flex-container">
 			<div className="design-type-with-store__copy">
 				<div className="design-type-with-store__vertical-center">

--- a/client/signup/steps/design-type-with-store/style.scss
+++ b/client/signup/steps/design-type-with-store/style.scss
@@ -3,7 +3,16 @@
 	text-align: center;
 }
 
-.design-type-with-store__section-wrapper {
+.design-type-with-store__substep-wrapper {
+	position: relative;
+}
+
+.design-type-with-store__list {
+	margin: 0 auto;
+	display: flex;
+	flex-flow: row wrap;
+	max-width: 640px;
+
 	opacity: 1;
 	filter: blur( 0 );
 	transform: translateZ( 0 ) translateX( 0 );
@@ -30,13 +39,6 @@
 		transform: translateZ( 0 ) translateX( 25% );
 		opacity: 0;
 	}
-}
-
-.design-type-with-store__list {
-	margin: 0 auto;
-	display: flex;
-	flex-flow: row wrap;
-	max-width: 640px;
 }
 
 .design-type-with-store__choice {
@@ -104,6 +106,10 @@
 	background-color: #f3f6f8;
 	box-sizing: border-box;
 	height: 195px;
+}
+
+.design-type-with-store__partner-box {
+	text-align: center;
 }
 
 @include breakpoint( "<480px" ) {
@@ -191,6 +197,7 @@
 
 .design-type-with-store__back-button-wrapper {
 	margin: 32px;
+	text-align: center;
 }
 
 .design-type-with-store__bluehost-logo {


### PR DESCRIPTION
This PR is a continuation of #11299 and fixes the Design Type With Store step in Signup. 

The Pressable "substeps" in Signup break the design a bit by being shifted to the side. Even though they are hidden, they still expand the bounding box and cause the scroll.

I'm trying to make the substeps play nice with the main steps and not cause such problems.

To test:

* Start Signup
* Reach Design Type With Store step. This will only show up for logged-out users!
* Check if there is horizontal scroll - there shouldn't be
* Check if the Store option is working correctly
* Verify no JS errors appear in the console
* Test different partners configurations, which are a part of a separate AB test. You need to adjust the AB test values for each partner. See below

There are several different partners store options. To access each one of them:
* BlueHost: `localStorage.setItem('ABTests', '{"signupStoreBenchmarking_20160927": "bluehost"}')`
* BlueHost+Woo: `localStorage.setItem('ABTests', '{"signupStoreBenchmarking_20160927": "bluehostWithWoo"}')`
* Pressable: `localStorage.setItem('ABTests', '{"signupStoreBenchmarking_20160927": "pressable"}')`
* SiteGround: `localStorage.setItem('ABTests', '{"signupStoreBenchmarking_20160927": "pressable"}')`