### PR TITLE
AT: Add new eligibility selectors

### DIFF
--- a/client/state/selectors/get-automated-transfer-eligibility-holds.js
+++ b/client/state/selectors/get-automated-transfer-eligibility-holds.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getEligibility } from 'state/automated-transfer/selectors';
+
+/**
+ * Returns any blocking reasons why a site is not eligible
+ * for automated transfer.
+ *
+ * @param {Object} state global app state
+ * @param {number} siteId requested site for transfer info
+ * @returns {Array} Any holds that exist
+ */
+export default function getAutomatedTransferEligiblityHolds( state, siteId ) {
+	const eligibilityData = getEligibility( state, siteId );
+	return get( eligibilityData, 'eligibilityHolds', [] );
+}

--- a/client/state/selectors/get-automated-transfer-eligibility-warnings.js
+++ b/client/state/selectors/get-automated-transfer-eligibility-warnings.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getEligibility } from 'state/automated-transfer/selectors';
+
+/**
+ * Returns any warnings about functionality that would be
+ * lost after a site goes through the automated transfer
+ * process.
+ *
+ * @param {Object} state global app state
+ * @param {number} siteId requested site for transfer info
+ * @returns {Array} Any warnings that exist
+ */
+export default function getAutomatedTransferEligiblityWarnings( state, siteId ) {
+	const eligibilityData = getEligibility( state, siteId );
+	return get( eligibilityData, 'eligibilityWarnings', [] );
+}

--- a/client/state/selectors/has-automated-transfer-eligibility-messages.js
+++ b/client/state/selectors/has-automated-transfer-eligibility-messages.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import {
+	getAutomatedTransferEligibilityHolds as holds,
+	getAutomatedTransferEligibilityWarnings as warnings,
+} from 'state/selectors';
+
+/**
+ * Determines if there are any eligibility messages to be displayed
+ * for the automated transfer of a site.
+ *
+ * @param {Object} state global app state
+ * @param {number} siteId requested site for transfer info
+ * @returns {boolean} True if any warnings or holds exist
+ */
+export default function hasAutomatedTransferEligiblityMessages( state, siteId ) {
+	return !! (
+		holds( state, siteId ).length +
+		warnings( state, siteId ).length
+	);
+}

--- a/client/state/selectors/has-only-automated-transfer-eligibility-business-message.js
+++ b/client/state/selectors/has-only-automated-transfer-eligibility-business-message.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { isEqual } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getAutomatedTransferEligibilityHolds,
+	getAutomatedTransferEligibilityWarnings,
+} from 'state/selectors';
+
+/**
+ * Determines if the one and only eligibility message that exists for
+ * the automated transfer of a site is a hold due to a missing business
+ * plan.
+ *
+ * @param {Object} state global app state
+ * @param {number} siteId requested site for transfer info
+ * @returns {boolean} True if only message is missing business plan
+ */
+export default function hasOnlyAutomatedTransferEligiblityBusinessMessage( state, siteId ) {
+	const holds = getAutomatedTransferEligibilityHolds( state, siteId );
+	const warnings = getAutomatedTransferEligibilityWarnings( state, siteId );
+
+	return warnings.length === 0 && isEqual( holds, [ 'NO_BUSINESS_PLAN' ] );
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -51,6 +51,7 @@ export getTimezonesLabelsByContinent from './get-timezones-labels-by-continent';
 export getUpcomingBillingTransactions from './get-upcoming-billing-transactions';
 export hasAutomatedTransferEligibilityMessages from './has-automated-transfer-eligibility-messages';
 export hasBrokenSiteUserConnection from './has-broken-site-user-connection';
+export hasOnlyAutomatedTransferEligibilityBusinessMessage from './has-only-automated-transfer-eligibility-business-message';
 export isActivatingJetpackJumpstart from './is-activating-jetpack-jumpstart';
 export isActivatingJetpackModule from './is-activating-jetpack-module';
 export isAutomatedTransferActive from './is-automated-transfer-active';

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -49,6 +49,7 @@ export getTimezonesLabel from './get-timezones-label';
 export getTimezonesLabels from './get-timezones-labels';
 export getTimezonesLabelsByContinent from './get-timezones-labels-by-continent';
 export getUpcomingBillingTransactions from './get-upcoming-billing-transactions';
+export hasAutomatedTransferEligibilityMessages from './has-automated-transfer-eligibility-messages';
 export hasBrokenSiteUserConnection from './has-broken-site-user-connection';
 export isActivatingJetpackJumpstart from './is-activating-jetpack-jumpstart';
 export isActivatingJetpackModule from './is-activating-jetpack-module';

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -17,6 +17,8 @@ export areSitePermalinksEditable from './are-site-permalinks-editable';
 export canCurrentUser from './can-current-user';
 export countPostLikes from './count-post-likes';
 export editedPostHasContent from './edited-post-has-content';
+export getAutomatedTransferEligibilityHolds from './get-automated-transfer-eligibility-holds';
+export getAutomatedTransferEligibilityWarnings from './get-automated-transfer-eligibility-warnings';
 export getBlockedSites from './get-blocked-sites';
 export getBillingTransactions from './get-billing-transactions';
 export getFollowCount from './get-follow-count';

--- a/client/state/selectors/test/get-automated-transfer-eligibility-holds.js
+++ b/client/state/selectors/test/get-automated-transfer-eligibility-holds.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { getAutomatedTransferEligibilityHolds as getHolds } from '../';
+
+describe( 'getAutomatedTransferEligibilityHolds()', () => {
+	it( 'should return empty array if no data available', () => {
+		expect( getHolds( {}, 2916284 ) ).to.be.deep.equal( [] );
+	} );
+
+	it( 'should return holds from state', () => {
+		const eligibilityHolds = [
+			'NO_BUSINESS_PLAN',
+			'SITE_PRIVATE',
+		];
+
+		const result = getHolds(
+			deepFreeze( {
+				automatedTransfer: {
+					2916284: {
+						eligibility: {
+							eligibilityHolds,
+						},
+					},
+				},
+			} ),
+			2916284
+		);
+		expect( result ).to.deep.equal( eligibilityHolds );
+	} );
+} );

--- a/client/state/selectors/test/get-automated-transfer-eligibility-warnings.js
+++ b/client/state/selectors/test/get-automated-transfer-eligibility-warnings.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { getAutomatedTransferEligibilityWarnings as getWarnings } from '../';
+
+describe( 'getAutomatedTransferEligibilityWarnings()', () => {
+	it( 'should return empty array if no data available', () => {
+		expect( getWarnings( {}, 2916284 ) ).to.be.deep.equal( [] );
+	} );
+
+	it( 'should return warnings from state', () => {
+		const eligibilityWarnings = [
+			{ name: 'warning 1' },
+			{ name: 'warning 2' },
+		];
+
+		const result = getWarnings(
+			deepFreeze( {
+				automatedTransfer: {
+					2916284: {
+						eligibility: {
+							eligibilityWarnings,
+						},
+					},
+				},
+			} ),
+			2916284
+		);
+		expect( result ).to.deep.equal( eligibilityWarnings );
+	} );
+} );

--- a/client/state/selectors/test/has-automated-transfer-eligibility-messages.js
+++ b/client/state/selectors/test/has-automated-transfer-eligibility-messages.js
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { hasAutomatedTransferEligibilityMessages as hasMessages } from '../';
+
+describe( 'hasAutomatedTransferEligibilityMessages()', () => {
+	it( 'should return false if no data available', () => {
+		expect( hasMessages( {}, 2916284 ) ).to.be.false;
+	} );
+
+	it( 'should return false if no holds or warnings', () => {
+		const eligibility = {
+			eligibilityWarnings: [],
+			eligibilityHolds: [],
+		};
+
+		const result = hasMessages(
+			deepFreeze( {
+				automatedTransfer: {
+					2916284: {
+						eligibility,
+					},
+				},
+			} ),
+			2916284
+		);
+		expect( result ).to.be.false;
+	} );
+
+	it( 'should return true if warnings exist', () => {
+		const eligibility = {
+			eligibilityWarnings: [
+				{ name: 'warning 1' },
+				{ name: 'warning 2' },
+			],
+		};
+
+		const result = hasMessages(
+			deepFreeze( {
+				automatedTransfer: {
+					2916284: {
+						eligibility,
+					},
+				},
+			} ),
+			2916284
+		);
+		expect( result ).to.be.true;
+	} );
+
+	it( 'should return true if holds exist', () => {
+		const eligibility = {
+			eligibilityHolds: [
+				'NO_BUSINESS_PLAN',
+				'SITE_PRIVATE',
+			],
+		};
+
+		const result = hasMessages(
+			deepFreeze( {
+				automatedTransfer: {
+					2916284: {
+						eligibility,
+					},
+				},
+			} ),
+			2916284
+		);
+		expect( result ).to.be.true;
+	} );
+} );

--- a/client/state/selectors/test/has-only-automated-transfer-eligibility-business-message.js
+++ b/client/state/selectors/test/has-only-automated-transfer-eligibility-business-message.js
@@ -1,0 +1,100 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { hasOnlyAutomatedTransferEligibilityBusinessMessage as hasOnlyBusinessMessage } from '../';
+
+describe( 'hasAutomatedTransferEligibilityMessages()', () => {
+	it( 'should return false if no data available', () => {
+		expect( hasOnlyBusinessMessage( {}, 2916284 ) ).to.be.false;
+	} );
+
+	it( 'should return false if no holds or warnings', () => {
+		const eligibility = {
+			eligibilityWarnings: [],
+			eligibilityHolds: [],
+		};
+
+		const result = hasOnlyBusinessMessage(
+			deepFreeze( {
+				automatedTransfer: {
+					2916284: {
+						eligibility,
+					},
+				},
+			} ),
+			2916284
+		);
+		expect( result ).to.be.false;
+	} );
+
+	it( 'should return false if warnings exist', () => {
+		const eligibility = {
+			eligibilityWarnings: [
+				{ name: 'warning 1' },
+				{ name: 'warning 2' },
+			],
+			eligibilityHolds: [
+				'NO_BUSINESS_PLAN',
+			]
+		};
+
+		const result = hasOnlyBusinessMessage(
+			deepFreeze( {
+				automatedTransfer: {
+					2916284: {
+						eligibility,
+					},
+				},
+			} ),
+			2916284
+		);
+		expect( result ).to.be.false;
+	} );
+
+	it( 'should return false if other holds exist', () => {
+		const eligibility = {
+			eligibilityHolds: [
+				'NO_BUSINESS_PLAN',
+				'SITE_PRIVATE',
+			],
+		};
+
+		const result = hasOnlyBusinessMessage(
+			deepFreeze( {
+				automatedTransfer: {
+					2916284: {
+						eligibility,
+					},
+				},
+			} ),
+			2916284
+		);
+		expect( result ).to.be.false;
+	} );
+
+	it( 'should return true if only business hold exists', () => {
+		const eligibility = {
+			eligibilityHolds: [
+				'NO_BUSINESS_PLAN',
+			],
+		};
+
+		const result = hasOnlyBusinessMessage(
+			deepFreeze( {
+				automatedTransfer: {
+					2916284: {
+						eligibility,
+					},
+				},
+			} ),
+			2916284
+		);
+		expect( result ).to.be.true;
+	} );
+} );


### PR DESCRIPTION
Add selectors for determining whether to display eligibility card for theme uploads in #11295 

The very specific selector, `hasOnlyAutomatedTransferEligiblityBusinessMessage`, is necessary because for theme uploads, we want to hide the eligibility card completely and show a business upgrade nudge instead if lack of business plan is the only problem (#11295).

**Question:** Could we tidy the names of these selectors by dropping the `AutomatedTransfer` from the names, leaving for example `getEligibilityHolds`?

No visual changes. Includes unit tests.

