### PR TITLE
Stats: Use a masonry layout on the stats period pages

### DIFF
--- a/assets/stylesheets/shared/mixins/_breakpoints.scss
+++ b/assets/stylesheets/shared/mixins/_breakpoints.scss
@@ -3,7 +3,7 @@
 // See https://wpcalypso.wordpress.com/devdocs/docs/coding-guidelines/css.md#media-queries
 // ==========================================================================
 
-$breakpoints: 480px, 660px, 960px, 1040px, 1280px; // Think very carefully before adding a new breakpoint
+$breakpoints: 480px, 660px, 960px, 1040px, 1280px, 1380px; // Think very carefully before adding a new breakpoint
 
 @mixin breakpoint( $sizes... ){
 	@each $size in $sizes {

--- a/client/components/main/index.jsx
+++ b/client/components/main/index.jsx
@@ -7,10 +7,12 @@ import classNames from 'classnames';
 export default function Main( {
 	className,
 	children,
-	wideLayout = false
+	wideLayout = false,
+	maxWidthLayout = false
 } ) {
 	const classes = classNames( className, 'main', {
-		'is-wide-layout': wideLayout
+		'is-wide-layout': wideLayout,
+		'max-width-layout': maxWidthLayout
 	} );
 
 	return (

--- a/client/components/main/style.scss
+++ b/client/components/main/style.scss
@@ -21,6 +21,10 @@
 		max-width: 1040px;
 	}
 
+	&.max-width-layout {
+		max-width: none;
+	}
+
 	@include breakpoint( "<660px" ) {
 		backface-visibility: hidden;
 		perspective: 1000;

--- a/client/my-sites/stats/geochart/style.scss
+++ b/client/my-sites/stats/geochart/style.scss
@@ -3,7 +3,6 @@
 
 .stats-geochart {
 	@extend %mobile-interface-element;
-	margin: 0 24px;
 
 	&.is-loading,
 	&.has-no-data {

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -108,41 +108,39 @@ class StatsSite extends Component {
 
 		return (
 			<Main maxWidthLayout>
-				<div className="stats__center">
-					<StatsFirstView />
-					<SidebarNavigation />
-					<StatsNavigation section={ period } />
-				</div>
+				<StatsFirstView />
+				<SidebarNavigation />
+				<StatsNavigation section={ period } />
 				<div id="my-stats-content">
-					<div className="stats__center">
-						<ChartTabs
-							barClick={ this.barClick }
-							switchTab={ this.switchChart }
-							charts={ charts }
-							queryDate={ queryDate }
-							period={ this.props.period }
-							chartTab={ this.state.chartTab } />
-						<StickyPanel className="stats__sticky-navigation">
-							<StatsPeriodNavigation
-								date={ date }
+					<StickyPanel className="stats__sticky-navigation">
+						<StatsPeriodNavigation
+							date={ date }
+							period={ period }
+							url={ `/stats/${ period }/${ slug }` }
+						>
+							<DatePicker
 								period={ period }
-								url={ `/stats/${ period }/${ slug }` }
-							>
-								<DatePicker
-									period={ period }
-									date={ date }
-									query={ query }
-									statsType="statsTopPosts"
-									showQueryDate
-								/>
-							</StatsPeriodNavigation>
-						</StickyPanel>
-					</div>
+								date={ date }
+								query={ query }
+								statsType="statsTopPosts"
+								showQueryDate
+							/>
+						</StatsPeriodNavigation>
+					</StickyPanel>
 					<div className="stats__module-list is-events">
 						<MasonryLayout
 							className="stats__masonry-items"
 							options={ { columnWidth: 330, fitWidth: true, gutter: 20 } }
 						>
+							<div className="stats__masonry-two-columns">
+								<ChartTabs
+									barClick={ this.barClick }
+									switchTab={ this.switchChart }
+									charts={ charts }
+									queryDate={ queryDate }
+									period={ this.props.period }
+									chartTab={ this.state.chartTab } />
+							</div>
 							<StatsModule
 								path="posts"
 								moduleStrings={ moduleStrings.posts }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -83,26 +83,30 @@ class StatsSite extends Component {
 		// Video plays, and tags and categories are not supported in JetPack Stats
 		if ( ! isJetpack ) {
 			videoList = (
-				<StatsModule
-					path="videoplays"
-					moduleStrings={ moduleStrings.videoplays }
-					period={ this.props.period }
-					query={ query }
-					statType="statsVideoPlays"
-					showSummaryLink
-				/>
+				<div className="stats__grid-item">
+					<StatsModule
+						path="videoplays"
+						moduleStrings={ moduleStrings.videoplays }
+						period={ this.props.period }
+						query={ query }
+						statType="statsVideoPlays"
+						showSummaryLink
+					/>
+				</div>
 			);
 		}
 		if ( config.isEnabled( 'manage/stats/podcasts' ) && hasPodcasts ) {
 			podcastList = (
-				<StatsModule
-					path="podcastdownloads"
-					moduleStrings={ moduleStrings.podcastdownloads }
-					period={ this.props.period }
-					query={ query }
-					statType="statsPodcastDownloads"
-					showSummaryLink
-				/>
+				<div className="stats__grid-item">
+					<StatsModule
+						path="podcastdownloads"
+						moduleStrings={ moduleStrings.podcastdownloads }
+						period={ this.props.period }
+						query={ query }
+						statType="statsPodcastDownloads"
+						showSummaryLink
+					/>
+				</div>
 			);
 		}
 
@@ -130,9 +134,16 @@ class StatsSite extends Component {
 					<div className="stats__module-list is-events">
 						<MasonryLayout
 							className="stats__masonry-items"
-							options={ { columnWidth: 330, fitWidth: true, gutter: 20 } }
+							options={ {
+								columnWidth: '.stats__grid-sizer',
+								itemSelector: '.stats__grid-item',
+								gutter: '.stats__gutter-sizer',
+								percentPosition: true
+							} }
 						>
-							<div className="stats__masonry-two-columns">
+							<div className="stats__grid-sizer"></div>
+							<div className="stats__gutter-sizer"></div>
+							<div className="stats__grid-item stats__grid-large-item">
 								<ChartTabs
 									barClick={ this.barClick }
 									switchTab={ this.switchChart }
@@ -141,47 +152,59 @@ class StatsSite extends Component {
 									period={ this.props.period }
 									chartTab={ this.state.chartTab } />
 							</div>
-							<StatsModule
-								path="posts"
-								moduleStrings={ moduleStrings.posts }
-								period={ this.props.period }
-								query={ query }
-								statType="statsTopPosts"
-								showSummaryLink />
-							<Countries
-								path="countries"
-								period={ this.props.period }
-								query={ query }
-								summary={ false } />
-							<StatsModule
-								path="referrers"
-								moduleStrings={ moduleStrings.referrers }
-								period={ this.props.period }
-								query={ query }
-								statType="statsReferrers"
-								showSummaryLink />
-							<StatsModule
-								path="clicks"
-								moduleStrings={ moduleStrings.clicks }
-								period={ this.props.period }
-								query={ query }
-								statType="statsClicks"
-								showSummaryLink />
-							<StatsModule
-								path="authors"
-								moduleStrings={ moduleStrings.authors }
-								period={ this.props.period }
-								query={ query }
-								statType="statsTopAuthors"
-								className="stats__author-views"
-								showSummaryLink />
-							<StatsModule
-								path="searchterms"
-								moduleStrings={ moduleStrings.search }
-								period={ this.props.period }
-								query={ query }
-								statType="statsSearchTerms"
-								showSummaryLink />
+							<div className="stats__grid-item">
+								<StatsModule
+									path="posts"
+									moduleStrings={ moduleStrings.posts }
+									period={ this.props.period }
+									query={ query }
+									statType="statsTopPosts"
+									showSummaryLink />
+							</div>
+							<div className="stats__grid-item">
+								<Countries
+									path="countries"
+									period={ this.props.period }
+									query={ query }
+									summary={ false } />
+							</div>
+							<div className="stats__grid-item">
+								<StatsModule
+									path="referrers"
+									moduleStrings={ moduleStrings.referrers }
+									period={ this.props.period }
+									query={ query }
+									statType="statsReferrers"
+									showSummaryLink />
+							</div>
+							<div className="stats__grid-item">
+								<StatsModule
+									path="clicks"
+									moduleStrings={ moduleStrings.clicks }
+									period={ this.props.period }
+									query={ query }
+									statType="statsClicks"
+									showSummaryLink />
+							</div>
+							<div className="stats__grid-item">
+								<StatsModule
+									path="authors"
+									moduleStrings={ moduleStrings.authors }
+									period={ this.props.period }
+									query={ query }
+									statType="statsTopAuthors"
+									className="stats__author-views"
+									showSummaryLink />
+							</div>
+							<div className="stats__grid-item">
+								<StatsModule
+									path="searchterms"
+									moduleStrings={ moduleStrings.search }
+									period={ this.props.period }
+									query={ query }
+									statType="statsSearchTerms"
+									showSummaryLink />
+							</div>
 							{ videoList }
 							{ podcastList }
 						</MasonryLayout>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -5,6 +5,7 @@ import page from 'page';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import MasonryLayout from 'react-masonry-component';
 
 /**
  * Internal dependencies
@@ -106,35 +107,42 @@ class StatsSite extends Component {
 		}
 
 		return (
-			<Main wideLayout={ true }>
-				<StatsFirstView />
-				<SidebarNavigation />
-				<StatsNavigation section={ period } />
+			<Main maxWidthLayout>
+				<div className="stats__center">
+					<StatsFirstView />
+					<SidebarNavigation />
+					<StatsNavigation section={ period } />
+				</div>
 				<div id="my-stats-content">
-					<ChartTabs
-						barClick={ this.barClick }
-						switchTab={ this.switchChart }
-						charts={ charts }
-						queryDate={ queryDate }
-						period={ this.props.period }
-						chartTab={ this.state.chartTab } />
-					<StickyPanel className="stats__sticky-navigation">
-						<StatsPeriodNavigation
-							date={ date }
-							period={ period }
-							url={ `/stats/${ period }/${ slug }` }
-						>
-							<DatePicker
-								period={ period }
+					<div className="stats__center">
+						<ChartTabs
+							barClick={ this.barClick }
+							switchTab={ this.switchChart }
+							charts={ charts }
+							queryDate={ queryDate }
+							period={ this.props.period }
+							chartTab={ this.state.chartTab } />
+						<StickyPanel className="stats__sticky-navigation">
+							<StatsPeriodNavigation
 								date={ date }
-								query={ query }
-								statsType="statsTopPosts"
-								showQueryDate
-							/>
-						</StatsPeriodNavigation>
-					</StickyPanel>
+								period={ period }
+								url={ `/stats/${ period }/${ slug }` }
+							>
+								<DatePicker
+									period={ period }
+									date={ date }
+									query={ query }
+									statsType="statsTopPosts"
+									showQueryDate
+								/>
+							</StatsPeriodNavigation>
+						</StickyPanel>
+					</div>
 					<div className="stats__module-list is-events">
-						<div className="stats__module-column">
+						<MasonryLayout
+							className="stats__masonry-items"
+							options={ { columnWidth: 330, fitWidth: true, gutter: 20 } }
+						>
 							<StatsModule
 								path="posts"
 								moduleStrings={ moduleStrings.posts }
@@ -142,6 +150,11 @@ class StatsSite extends Component {
 								query={ query }
 								statType="statsTopPosts"
 								showSummaryLink />
+							<Countries
+								path="countries"
+								period={ this.props.period }
+								query={ query }
+								summary={ false } />
 							<StatsModule
 								path="referrers"
 								moduleStrings={ moduleStrings.referrers }
@@ -164,13 +177,6 @@ class StatsSite extends Component {
 								statType="statsTopAuthors"
 								className="stats__author-views"
 								showSummaryLink />
-						</div>
-						<div className="stats__module-column">
-							<Countries
-								path="countries"
-								period={ this.props.period }
-								query={ query }
-								summary={ false } />
 							<StatsModule
 								path="searchterms"
 								moduleStrings={ moduleStrings.search }
@@ -180,7 +186,7 @@ class StatsSite extends Component {
 								showSummaryLink />
 							{ videoList }
 							{ podcastList }
-						</div>
+						</MasonryLayout>
 					</div>
 				</div>
 			</Main>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -6,6 +6,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import MasonryLayout from 'react-masonry-component';
+import { throttle } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,6 +27,8 @@ import config from 'config';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getSiteOption, isJetpackSite } from 'state/sites/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
+
+const MASONRY_REFRESH_TIMEOUT = 200;
 
 class StatsSite extends Component {
 	constructor( props ) {
@@ -60,6 +63,14 @@ class StatsSite extends Component {
 		}
 	};
 
+	bindMasonry = ( ref ) => {
+		this.masonry = ref.masonry;
+	};
+
+	reloadMasonry = throttle( () => {
+		this.masonry && this.masonry.layout();
+	}, MASONRY_REFRESH_TIMEOUT );
+
 	render() {
 		const { date, isJetpack, hasPodcasts, slug, translate } = this.props;
 		const charts = [
@@ -91,6 +102,7 @@ class StatsSite extends Component {
 						query={ query }
 						statType="statsVideoPlays"
 						showSummaryLink
+						onRefresh={ this.reloadMasonry }
 					/>
 				</div>
 			);
@@ -105,6 +117,7 @@ class StatsSite extends Component {
 						query={ query }
 						statType="statsPodcastDownloads"
 						showSummaryLink
+						onRefresh={ this.reloadMasonry }
 					/>
 				</div>
 			);
@@ -140,6 +153,7 @@ class StatsSite extends Component {
 								gutter: '.stats__gutter-sizer',
 								percentPosition: true
 							} }
+							ref={ this.bindMasonry }
 						>
 							<div className="stats__grid-sizer"></div>
 							<div className="stats__gutter-sizer"></div>
@@ -159,14 +173,16 @@ class StatsSite extends Component {
 									period={ this.props.period }
 									query={ query }
 									statType="statsTopPosts"
-									showSummaryLink />
+									showSummaryLink
+									onRefresh={ this.reloadMasonry } />
 							</div>
 							<div className="stats__grid-item">
 								<Countries
 									path="countries"
 									period={ this.props.period }
 									query={ query }
-									summary={ false } />
+									summary={ false }
+									onRefresh={ this.reloadMasonry } />
 							</div>
 							<div className="stats__grid-item">
 								<StatsModule
@@ -175,7 +191,8 @@ class StatsSite extends Component {
 									period={ this.props.period }
 									query={ query }
 									statType="statsReferrers"
-									showSummaryLink />
+									showSummaryLink
+									onRefresh={ this.reloadMasonry } />
 							</div>
 							<div className="stats__grid-item">
 								<StatsModule
@@ -184,7 +201,8 @@ class StatsSite extends Component {
 									period={ this.props.period }
 									query={ query }
 									statType="statsClicks"
-									showSummaryLink />
+									showSummaryLink
+									onRefresh={ this.reloadMasonry } />
 							</div>
 							<div className="stats__grid-item">
 								<StatsModule
@@ -194,7 +212,8 @@ class StatsSite extends Component {
 									query={ query }
 									statType="statsTopAuthors"
 									className="stats__author-views"
-									showSummaryLink />
+									showSummaryLink
+									onRefresh={ this.reloadMasonry } />
 							</div>
 							<div className="stats__grid-item">
 								<StatsModule
@@ -203,7 +222,8 @@ class StatsSite extends Component {
 									period={ this.props.period }
 									query={ query }
 									statType="statsSearchTerms"
-									showSummaryLink />
+									showSummaryLink
+									onRefresh={ this.reloadMasonry } />
 							</div>
 							{ videoList }
 							{ podcastList }

--- a/client/my-sites/stats/stats-countries/index.jsx
+++ b/client/my-sites/stats/stats-countries/index.jsx
@@ -17,10 +17,11 @@ class StatCountries extends Component {
 		path: PropTypes.string,
 		period: PropTypes.object,
 		date: PropTypes.string,
+		onRefresh: PropTypes.func,
 	};
 
 	render() {
-		const { summary, query, period } = this.props;
+		const { summary, query, onRefresh, period } = this.props;
 		const moduleStrings = statsStrings();
 
 		return (
@@ -32,6 +33,7 @@ class StatCountries extends Component {
 				summary={ summary }
 				moduleStrings={ moduleStrings.countries }
 				statType="statsCountryViews"
+				onRefresh={ onRefresh }
 			>
 				<Geochart query={ query } />
 			</StatsModule>

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -5,7 +5,7 @@ import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
+import { includes, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -43,11 +43,13 @@ class StatsModule extends Component {
 		showSummaryLink: PropTypes.bool,
 		translate: PropTypes.func,
 		moment: PropTypes.func,
+		onRefresh: PropTypes.func,
 	};
 
 	static defaultProps = {
 		showSummaryLink: false,
-		query: {}
+		query: {},
+		onRefresh: noop
 	};
 
 	state = {
@@ -58,6 +60,14 @@ class StatsModule extends Component {
 		if ( ! nextProps.requesting && this.props.requesting ) {
 			this.setState( { loaded: true } );
 		}
+
+		if ( nextProps.query !== this.props.query ) {
+			this.setState( { loaded: false } );
+		}
+	}
+
+	componentDidUpdate() {
+		this.props.onRefresh();
 	}
 
 	getModuleLabel() {

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -56,22 +56,32 @@
 
 .stats__masonry-items {
 	margin: auto;
-	> div {
-		width: 330px;
-		box-sizing: border-box;
+
+	@include breakpoint( ">1380px" ) {
+		.stats__grid-sizer,
+		.stats__grid-item { width: 330px }
+		.stats__grid-large-item { width: 1030px; }
+		.stats__gutter-sizer { width: 20px; }
 	}
 
-	.stats__masonry-two-columns {
-		@include breakpoint( ">1380px" ) {
-			width: 1030px;
-		}
+	@include breakpoint( "<1380px" ) {
+		.stats__grid-sizer,
+		.stats__grid-item { width: 32%; }
+		.stats__grid-large-item { width: 100%; }
+		.stats__gutter-sizer { width: 1.5%; }
+	}
 
-		@include breakpoint( "<1380px" ) {
-			width: 680px;
-		}
+	@include breakpoint( "<1040px" ) {
+		.stats__grid-sizer,
+		.stats__grid-item { width: 49%; }
+		.stats__grid-large-item { width: 100%; }
+		.stats__gutter-sizer { width: 2%; }
+	}
 
-		@include breakpoint( "<1040px" ) {
-			width: 330px;
-		}
+	@include breakpoint( "<660px" ) {
+		.stats__grid-sizer,
+		.stats__grid-item,
+		.stats__grid-large-item { width: 100%; }
+		.stats__gutter-sizer { width: 0; }
 	}
 }

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -54,15 +54,24 @@
 	}
 }
 
-.stats__center {
-	max-width: 1040px;
-	margin: auto;
-}
-
 .stats__masonry-items {
 	margin: auto;
-	div {
+	> div {
 		width: 330px;
 		box-sizing: border-box;
+	}
+
+	.stats__masonry-two-columns {
+		@include breakpoint( ">1380px" ) {
+			width: 1030px;
+		}
+
+		@include breakpoint( "<1380px" ) {
+			width: 680px;
+		}
+
+		@include breakpoint( "<1040px" ) {
+			width: 330px;
+		}
 	}
 }

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -53,3 +53,16 @@
 		display: none;
 	}
 }
+
+.stats__center {
+	max-width: 1040px;
+	margin: auto;
+}
+
+.stats__masonry-items {
+	margin: auto;
+	div {
+		width: 330px;
+		box-sizing: border-box;
+	}
+}


### PR DESCRIPTION
This branch is an alternative solution to #11124 
Closes #11094 

In this PR I'm using a masonry layout for the period pages. Here are some screenshots

<img width="1440" alt="screen shot 2017-02-10 at 12 47 07" src="https://cloud.githubusercontent.com/assets/272444/22839468/247bbcaa-ef8f-11e6-9383-93253db3d5db.png">

<img width="1081" alt="screen shot 2017-02-10 at 12 47 32" src="https://cloud.githubusercontent.com/assets/272444/22839472/2a0f18ba-ef8f-11e6-8c35-3613821fffad.png">

Tested in Chrome only for now.

**Testing instructions**

 - Open the stats period pages : `/stats/day/$site`
 - Change the window size
 - The stats modules should fit wherever size you have, keeping their width equal to 330
