### PR TITLE
Components add query-timezones component

### DIFF
--- a/client/components/data/query-timezones/index.jsx
+++ b/client/components/data/query-timezones/index.jsx
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { requestTimezones } from 'state/timezones/actions';
+import { isRequestingTimezones } from 'state/selectors';
+
+export class QueryTimezones extends Component {
+	static propTypes = {
+		isRequesting: PropTypes.bool,
+		requestTimezones: PropTypes.func
+	};
+
+	componentDidMount() {
+		if ( this.props.requesting ) {
+			return;
+		}
+
+		this.props.requestTimezones();
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect(
+	( state ) => ( {
+		requesting: isRequestingTimezones( state )
+	} ),
+	{ requestTimezones }
+)( QueryTimezones );

--- a/client/state/data-layer/wpcom/timezones/index.js
+++ b/client/state/data-layer/wpcom/timezones/index.js
@@ -50,7 +50,7 @@ export const fromApi = ( { manual_utc_offsets, timezones, timezones_by_continent
 /*
  * Start a request to WordPress.com server to get the timezones data
  */
-export const fetchTimezones = ( { dispatch } ) => (
+export const fetchTimezones = ( { dispatch }, action, next ) => {
 	wpcom.req.get( '/timezones', { apiNamespace: 'wpcom/v2' } )
 		.then( data => {
 			dispatch( timezonesRequestSuccess() );
@@ -58,8 +58,10 @@ export const fetchTimezones = ( { dispatch } ) => (
 		} )
 		.catch( error => {
 			dispatch( timezonesRequestFailure( error ) );
-		} )
-);
+		} );
+
+	return next( action );
+};
 
 export default {
 	[ TIMEZONES_REQUEST ]: [ fetchTimezones ],

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -85,6 +85,7 @@ export isRequestingMediaItem from './is-requesting-media-item';
 export isRequestingPostLikes from './is-requesting-post-likes';
 export isRequestingReaderTeams from './is-requesting-reader-teams';
 export isRequestingSharingButtons from './is-requesting-sharing-buttons';
+export isRequestingTimezones from './is-requesting-timezones';
 export isSavingSharingButtons from './is-saving-sharing-buttons';
 export isSendingBillingReceiptEmail from './is-sending-billing-receipt-email';
 export isSharingButtonsSaveSuccessful from './is-sharing-buttons-save-successful';

--- a/client/state/selectors/is-requesting-timezones.js
+++ b/client/state/selectors/is-requesting-timezones.js
@@ -1,10 +1,14 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
 
 /**
  * Returns true if we are requesting the timezones
  *
- * @param  {Object}  state  Global state tree
+ * @param {Object} state - Global state tree
  * @return {Boolean} - Whether timezones is being requested
  */
 export default function isRequestingTimezones( state ) {
-	return state.timezones.requesting;
+	return get( state, 'timezones.isRequesting', false );
 }

--- a/client/state/selectors/is-requesting-timezones.js
+++ b/client/state/selectors/is-requesting-timezones.js
@@ -1,0 +1,10 @@
+
+/**
+ * Returns true if we are requesting the timezones
+ *
+ * @param  {Object}  state  Global state tree
+ * @return {Boolean} - Whether timezones is being requested
+ */
+export default function isRequestingTimezones( state ) {
+	return state.timezones.requesting;
+}

--- a/client/state/timezones/reducer.js
+++ b/client/state/timezones/reducer.js
@@ -7,7 +7,10 @@ import { combineReducers } from 'redux';
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
-import { TIMEZONES_RECEIVE } from 'state/action-types';
+import {
+	TIMEZONES_RECEIVE,
+	TIMEZONES_REQUEST,
+} from 'state/action-types';
 
 import {
 	rawOffsetsSchema,
@@ -27,8 +30,13 @@ export const byContinents = createReducer( {}, {
 	[ TIMEZONES_RECEIVE ]: ( state, actions ) => ( actions.byContinents )
 }, continentsSchema );
 
+export const isRequesting = ( state = false, { type } ) => (
+	type === TIMEZONES_REQUEST
+);
+
 export default combineReducers( {
 	rawOffsets,
 	labels,
 	byContinents,
+	isRequesting
 } );

--- a/client/state/timezones/test/reducer.js
+++ b/client/state/timezones/test/reducer.js
@@ -12,10 +12,16 @@ import { useSandbox } from 'test/helpers/use-sinon';
 import timezonesReducer, {
 	byContinents,
 	labels,
+	isRequesting,
 	rawOffsets,
 } from '../reducer';
 
-import { timezonesReceive } from '../actions';
+import {
+	requestTimezones,
+	timezonesRequestSuccess,
+	timezonesReceive,
+	timezonesRequestFailure,
+} from '../actions';
 
 describe( 'reducer', () => {
 	let sandbox;
@@ -30,11 +36,12 @@ describe( 'reducer', () => {
 			'byContinents',
 			'labels',
 			'rawOffsets',
+			'isRequesting'
 		] );
 	} );
 
 	describe( '#rawOffsets()', () => {
-		it( 'should default to an empty Object', () => {
+		it( 'should default to an empty action object', () => {
 			expect( rawOffsets( undefined, {} ) ).to.eql( {} );
 		} );
 
@@ -130,7 +137,7 @@ describe( 'reducer', () => {
 	} );
 
 	describe( '#labels()', () => {
-		it( 'should default to an empty Object', () => {
+		it( 'should default to an empty action object', () => {
 			expect( rawOffsets( undefined, {} ) ).to.eql( {} );
 		} );
 
@@ -220,7 +227,7 @@ describe( 'reducer', () => {
 	} );
 
 	describe( '#byContinents()', () => {
-		it( 'should default to an empty Object', () => {
+		it( 'should default to an empty action object', () => {
 			expect( rawOffsets( undefined, {} ) ).to.eql( {} );
 		} );
 
@@ -352,6 +359,54 @@ describe( 'reducer', () => {
 			deepFreeze( initialStateONE );
 			const newStateONE = byContinents( initialStateONE, { type: 'DESERIALIZE' } );
 			expect( newStateONE ).to.eql( {} );
+		} );
+	} );
+
+	describe( '#isRequesting()', () => {
+		it( 'should default `isRequesting` to an empty action object', () => {
+			expect( isRequesting( undefined, {} ) ).to.eql( false );
+		} );
+
+		describe( 'requestTimezones() action', () => {
+			it( 'should index `isRequesting` state', () => {
+				const action = requestTimezones();
+				const newState = isRequesting( undefined, action );
+				expect( newState ).to.eql( true );
+			} );
+
+			it( 'should override `isRequesting` state', () => {
+				const action = requestTimezones();
+				const newState = isRequesting( false, action );
+				expect( newState ).to.eql( true );
+			} );
+		} );
+
+		describe( 'timezonesRequestSuccess() action', () => {
+			it( 'should index `isRequesting` state', () => {
+				const action = timezonesRequestSuccess();
+				const newState = isRequesting( undefined, action );
+				expect( newState ).to.eql( false );
+			} );
+
+			it( 'should override `isRequesting` state', () => {
+				const action = timezonesRequestSuccess();
+				const newState = isRequesting( true, action );
+				expect( newState ).to.eql( false );
+			} );
+		} );
+
+		describe( 'timezonesRequestFailure() action', () => {
+			it( 'should index `isRequesting` state', () => {
+				const action = timezonesRequestFailure();
+				const newState = isRequesting( undefined, action );
+				expect( newState ).to.eql( false );
+			} );
+
+			it( 'should override `isRequesting` state', () => {
+				const action = timezonesRequestFailure();
+				const newState = isRequesting( true, action );
+				expect( newState ).to.eql( false );
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds the `query-timezones` component. For this purpose I've added the isRequeting selectors and also `requesting` into the reducer of timezones.

### Testing

#### test the query-timozone test

```
> npm run test-client client/components/data/query-timezones/test/
```

### Also test timezones redux tests since has been modified
```
> npm run test-client client/state/timezones/test/
```