### PR TITLE
Editor: show warning when updating a published post date

### DIFF
--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -174,6 +174,7 @@ export default React.createClass( {
 				: null;
 
 			this.setPostDate( date );
+			this.props.warnPublishDateChange( { clearWarning: true } );
 		}
 
 		this.setState( { showSchedulePopover: false } );

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -126,7 +126,7 @@ export default React.createClass( {
 		const dateValue = date ? date.format() : null;
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		postActions.edit( { date: dateValue } );
-		this.showDateWarning( dateValue );
+		this.checkForDateChange( dateValue );
 	},
 
 	setCurrentMonth: function( date ) {
@@ -136,7 +136,7 @@ export default React.createClass( {
 		} );
 	},
 
-	showDateWarning( date ) {
+	checkForDateChange( date ) {
 		const { savedPost, warnPublishDateChange } = this.props;
 
 		if ( ! savedPost ) {

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -123,8 +123,10 @@ export default React.createClass( {
 	},
 
 	setPostDate: function( date ) {
+		const dateValue = date ? date.format() : null;
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		postActions.edit( { date: date ? date.format() : null } );
+		postActions.edit( { date: dateValue } );
+		this.showDateWarning( dateValue );
 	},
 
 	setCurrentMonth: function( date ) {
@@ -132,6 +134,13 @@ export default React.createClass( {
 			firstDayOfTheMonth: this.getFirstDayOfTheMonth( date ),
 			lastDayOfTheMonth: this.getLastDayOfTheMonth( date )
 		} );
+	},
+
+	showDateWarning( date ) {
+		const { savedPost, warnPublishDateChange } = this.props;
+		if ( savedPost.type !== 'page' && postUtils.isPublished( savedPost ) && date !== savedPost.date ) {
+			warnPublishDateChange();
+		}
 	},
 
 	getPreviewLabel: function() {

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -185,7 +185,6 @@ export default React.createClass( {
 				: null;
 
 			this.setPostDate( date );
-			// this.props.warnPublishDateChange( { clearWarning: true } ); -> not needed anymre
 		}
 
 		this.setState( { showSchedulePopover: false } );

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -147,7 +147,7 @@ export default React.createClass( {
 		const ModifiedDate = this.moment( savedPost.date );
 		const diff = !! currentDate.diff( ModifiedDate );
 
-		if ( savedPost.type !== 'page' && postUtils.isPublished( savedPost ) && diff ) {
+		if ( savedPost.type === 'post' && postUtils.isPublished( savedPost ) && diff ) {
 			warnPublishDateChange();
 		} else {
 			warnPublishDateChange( { clearWarning: true } );

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -138,8 +138,19 @@ export default React.createClass( {
 
 	showDateWarning( date ) {
 		const { savedPost, warnPublishDateChange } = this.props;
-		if ( savedPost.type !== 'page' && postUtils.isPublished( savedPost ) && date !== savedPost.date ) {
+
+		if ( ! savedPost ) {
+			return;
+		}
+
+		const currentDate = this.moment( date );
+		const ModifiedDate = this.moment( savedPost.date );
+		const diff = !! currentDate.diff( ModifiedDate );
+
+		if ( savedPost.type !== 'page' && postUtils.isPublished( savedPost ) && diff ) {
 			warnPublishDateChange();
+		} else {
+			warnPublishDateChange( { clearWarning: true } );
 		}
 	},
 
@@ -174,7 +185,7 @@ export default React.createClass( {
 				: null;
 
 			this.setPostDate( date );
-			this.props.warnPublishDateChange( { clearWarning: true } );
+			// this.props.warnPublishDateChange( { clearWarning: true } ); -> not needed anymre
 		}
 
 		this.setState( { showSchedulePopover: false } );

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -56,6 +56,8 @@ export class EditorNotice extends Component {
 		const { translate, type, typeObject, site } = this.props;
 
 		switch ( key ) {
+			case 'warnPublishDateChange':
+				return translate( 'Are you sure about that? If you change the date, existing links to your post will stop working.' );
 			case 'publishFailure':
 				if ( 'page' === type ) {
 					return translate( 'Publishing of page failed.' );

--- a/client/post-editor/editor-sidebar/index.jsx
+++ b/client/post-editor/editor-sidebar/index.jsx
@@ -35,7 +35,8 @@ export default class EditorSidebar extends Component {
 		userUtils: PropTypes.object,
 		type: PropTypes.string,
 		showDrafts: PropTypes.bool,
-		onMoreInfoAboutEmailVerify: PropTypes.func
+		onMoreInfoAboutEmailVerify: PropTypes.func,
+		warnPublishDateChange: PropTypes.func
 	}
 
 	renderDraftsList() {
@@ -64,6 +65,7 @@ export default class EditorSidebar extends Component {
 					type={ this.props.type }
 				/>
 				<EditorGroundControl
+					warnPublishDateChange={ this.props.warnPublishDateChange }
 					hasContent={ this.props.hasContent }
 					isDirty={ this.props.isDirty }
 					isSaveBlocked={ this.props.isSaveBlocked }

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -690,8 +690,11 @@ export const PostEditor = React.createClass( {
 	// when a post that is published, modifies its date, this updates the post url
 	// we should warn users of this case
 	warnPublishDateChange( { clearWarning = false } = {} )  {
-		if ( clearWarning && get( this.state, 'notice.message' ) === 'warnPublishDateChange' ) {
-			return this.hideNotice();
+		if ( clearWarning ) {
+			if ( get( this.state, 'notice.message' ) === 'warnPublishDateChange' ) {
+				this.hideNotice();
+			}
+			return;
 		}
 		this.setState( {
 			notice: {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -300,6 +300,7 @@ export const PostEditor = React.createClass( {
 						type={ this.props.type }
 						showDrafts={ this.props.showDrafts }
 						onMoreInfoAboutEmailVerify={ this.onMoreInfoAboutEmailVerify }
+						warnPublishDateChange={ this.warnPublishDateChange }
 						/>
 					{ this.iframePreviewEnabled() ?
 						<EditorPreview
@@ -684,6 +685,17 @@ export const PostEditor = React.createClass( {
 		} );
 
 		window.scrollTo( 0, 0 );
+	},
+
+	// when a post that is published, modifies its date, this updates the post url
+	// we should warn users of this case
+	warnPublishDateChange() {
+		this.setState( {
+			notice: {
+				status: 'is-warning',
+				message: 'warnPublishDateChange'
+			}
+		} );
 	},
 
 	onSaveSuccess: function( message, action, link ) {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -689,7 +689,10 @@ export const PostEditor = React.createClass( {
 
 	// when a post that is published, modifies its date, this updates the post url
 	// we should warn users of this case
-	warnPublishDateChange() {
+	warnPublishDateChange( { clearWarning = false } = {} )  {
+		if ( clearWarning && get( this.state, 'notice.message' ) === 'warnPublishDateChange' ) {
+			return this.hideNotice();
+		}
 		this.setState( {
 			notice: {
 				status: 'is-warning',


### PR DESCRIPTION
Fixes #10358, this adds a warning when a user attempts to update the date of an already published post. Updating this will create a new post url, and the url will not work.

<img width="1055" alt="screen shot 2017-02-10 at 11 23 57 am" src="https://cloud.githubusercontent.com/assets/1270189/22840707/711a96c8-ef83-11e6-94b7-d9a1a7bd0768.png">

### Testing Instructions
- Navigate to to http://calypso.localhost:3000/post
- Select a site
- Add some content
- Publish your post
- Click on the calendar button, and set a date in the past or future
- Warning should display