### PR TITLE
Reader: Async load the sidebar

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -23,7 +23,7 @@ import {
 import { recordTrack } from 'reader/stats';
 import { preload } from 'sections-preload';
 import { renderWithReduxStore } from 'lib/react-helpers';
-import ReaderSidebarComponent from 'reader/sidebar';
+import AsyncLoad from 'components/async-load';
 
 const analyticsPageTitle = 'Reader';
 
@@ -128,9 +128,9 @@ module.exports = {
 
 	sidebar( context, next ) {
 		renderWithReduxStore(
-			React.createElement( ReduxProvider, { store: context.store },
-				React.createElement( ReaderSidebarComponent, { path: context.path } )
-			),
+			<ReduxProvider store={ context.store }>
+				<AsyncLoad require="reader/sidebar" path={ context.path } />
+			</ReduxProvider>,
 			document.getElementById( 'secondary' ),
 			context.store
 		);

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -128,9 +128,7 @@ module.exports = {
 
 	sidebar( context, next ) {
 		renderWithReduxStore(
-			<ReduxProvider store={ context.store }>
-				<AsyncLoad require="reader/sidebar" path={ context.path } />
-			</ReduxProvider>,
+			<AsyncLoad require="reader/sidebar" path={ context.path } />,
 			document.getElementById( 'secondary' ),
 			context.store
 		);


### PR DESCRIPTION
Async load the sidebar, drops a bit of size from the Reader bundle.

To test, load the reader. Sidebar should appear after a brief delay. Test on a slow (3g) network for best effect.