### PR TITLE
Reader: Async load twemoji

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -7,7 +7,6 @@ import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
 import classNames from 'classnames';
 import config from 'config';
-import twemoji from 'twemoji';
 import { get } from 'lodash';
 
 /**
@@ -66,6 +65,13 @@ export class FullPostView extends React.Component {
 	}
 
 	hasScrolledToCommentAnchor = false;
+
+	componentWillMount() {
+		const self = this;
+		asyncRequire( 'twemoji', ( twemoji ) => {
+			self.setState( { twemoji }, self.parseEmoji.bind( self ) );
+		} );
+	}
 
 	componentDidMount() {
 		KeyboardShortcuts.on( 'close-full-post', this.handleBack );
@@ -217,7 +223,7 @@ export class FullPostView extends React.Component {
 			return;
 		}
 
-		twemoji.parse( this.refs.article, {
+		this.state && this.state.twemoji && this.state.twemoji.parse( this.refs.article, {
 			base: config( 'twemoji_cdn_url' )
 		} );
 	}

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { has } from 'lodash';
-import twemoji from 'twemoji';
 
 /**
  * Internal Dependencies
@@ -35,17 +34,26 @@ const TagStream = React.createClass( {
 			title,
 			subscribed: this.isSubscribed(),
 			canFollow: has( ReaderTags.get( this.props.tag ), 'ID' ),
-			isEmojiTitle: title && twemoji.test( title )
+			isEmojiTitle: false
 		};
 	},
 
 	componentWillMount() {
-		var self = this;
+		const self = this;
 		this._isMounted = true;
 		// can't use arrows with asyncRequire
 		asyncRequire( 'emoji-text', function( emojiText ) {
 			if ( self._isMounted ) {
 				self.setState( { emojiText } );
+			}
+		} );
+		asyncRequire( 'twemoji', function( twemoji ) {
+			if ( self._isMounted ) {
+				const title = self.state && self.state.title;
+				self.setState( {
+					twemoji,
+					isEmojiTitle: title && twemoji.test( title )
+				} );
 			}
 		} );
 	},
@@ -73,7 +81,7 @@ const TagStream = React.createClass( {
 			title,
 			subscribed: this.isSubscribed( props ),
 			canFollow: has( ReaderTags.get( props.tag ), 'ID' ),
-			isEmojiTitle: title && twemoji.test( title )
+			isEmojiTitle: title && this.state.twemoji && this.state.twemoji.test( title )
 		};
 		this.smartSetState( newState );
 	},


### PR DESCRIPTION
Async load twemoji in full post and tag streams. Improves reader bundle size by roughly 4k.

To test, pull up a post in full post that has emoji in the title or body.

Also pull up a tag stream that has an emoji as the title.