### PR TITLE
Components: Increasing contrast in form component

### DIFF
--- a/assets/stylesheets/shared/_forms.scss
+++ b/assets/stylesheets/shared/_forms.scss
@@ -22,7 +22,7 @@
 	box-sizing: border-box;
 
 	&::placeholder {
-		color: $gray;
+		color: $gray-text;
 	}
 
 	&:hover {

--- a/assets/stylesheets/shared/_forms.scss
+++ b/assets/stylesheets/shared/_forms.scss
@@ -22,7 +22,7 @@
 	box-sizing: border-box;
 
 	&::placeholder {
-		color: $gray-text;
+		color: $gray;
 	}
 
 	&:hover {

--- a/client/components/forms/form-setting-explanation/style.scss
+++ b/client/components/forms/form-setting-explanation/style.scss
@@ -1,5 +1,5 @@
 .form-setting-explanation {
-	color: $gray;
+	color: $gray-text;
 	display: block;
 	font-size: 13px;
 	font-style: italic;


### PR DESCRIPTION
This updates forms to use the $gray-text variable for text, which is the mimmim contrast needed to pass WCAG 2.0 AA tests on a white background.

Affected:
- explanation text
- ~placeholder text~

Edit: removed the new placeholder color, reverted back to lighter gray

Before
![screen shot 2017-02-10 at 1 50 15 pm](https://cloud.githubusercontent.com/assets/618551/22841742/4b3ddc02-ef98-11e6-8611-bb588c3cbcf2.png)

After
![screen shot 2017-02-10 at 1 50 04 pm](https://cloud.githubusercontent.com/assets/618551/22841746/501d2750-ef98-11e6-85dd-c2e4fe00ddac.png)

Settings:

![screen shot 2017-02-10 at 1 56 15 pm](https://cloud.githubusercontent.com/assets/618551/22841845/b5ab9f02-ef98-11e6-9398-27aea1885e5e.png)


