### PR TITLE
PostSchedule: Add AM/PM selector

### DIFF
--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -46,17 +46,21 @@ class PostScheduleClock extends Component {
 			return null;
 		}
 
-		let value = this.maybeConvertHour( Number( event.target.value ) ) - operation;
-
-		// Snap back a day, when looping through date line.
-		if ( ( this.props.is12hour ? 23 : -1 ) === value && 1 === operation ) {
-			modifiers.date = this.props.date.get( 'date' ) - 1;
-		}
+		let value = Number( event.target.value );
 
 		if ( 'hour' === field ) {
+			value = this.maybeConvertHour( value ) - operation;
+
+			// Snap back a day, when looping through date line.
+			if ( ( this.props.is12hour ? 23 : -1 ) === value && 1 === operation ) {
+				modifiers.date = this.props.date.get( 'date' ) - 1;
+			}
+
 			value = value > 24 ? 1 : value;
 			value = value < 0 ? 23 : value;
 		} else {
+			value -= operation;
+
 			value = value > 59 ? 0 : value;
 			value = value < 0 ? 59 : value;
 		}

--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -48,6 +48,11 @@ class PostScheduleClock extends Component {
 
 		let value = this.maybeConvertHour( Number( event.target.value ) ) - operation;
 
+		// Snap back a day, when looping through date line.
+		if ( 0 === value && 1 === operation ) {
+			modifiers.date = this.props.date.get( 'date' ) - 1;
+		}
+
 		if ( 'hour' === field ) {
 			value = value > 24 ? 1 : value;
 			value = value < 0 ? 23 : value;

--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -49,7 +49,7 @@ class PostScheduleClock extends Component {
 		let value = this.maybeConvertHour( Number( event.target.value ) ) - operation;
 
 		// Snap back a day, when looping through date line.
-		if ( 0 === value && 1 === operation ) {
+		if ( ( this.props.is12hour ? 23 : -1 ) === value && 1 === operation ) {
 			modifiers.date = this.props.date.get( 'date' ) - 1;
 		}
 
@@ -114,7 +114,7 @@ class PostScheduleClock extends Component {
 	 * @return {Number}      The converted hour.
 	 */
 	maybeConvertHour( hour ) {
-		if ( this.refs.amPmReference && (
+		if ( this.props.is12hour && this.refs.amPmReference && (
 			( 'PM' === this.refs.amPmReference.value && hour < 12 ) ||
 			( 'AM' === this.refs.amPmReference.value && 12 === hour )
 		) ) {
@@ -189,8 +189,7 @@ class PostScheduleClock extends Component {
 	}
 
 	render() {
-		const { date, timeFormat, translate } = this.props;
-		const is12hour = is12hr( timeFormat );
+		const { date, is12hour, translate } = this.props;
 
 		return (
 			<div className="post-schedule__clock">
@@ -249,6 +248,6 @@ PostScheduleClock.defaultProps = {
 
 export default connect(
 	( state, { siteId } ) => ( {
-		timeFormat: getSiteSetting( state, siteId, 'time_format' ),
+		is12hour: is12hr( getSiteSetting( state, siteId, 'time_format' ) ),
 	} ),
-)( localize( PostScheduleClock )) ;
+)( localize( PostScheduleClock ) ) ;

--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -54,13 +54,7 @@ class PostScheduleClock extends Component {
 			}
 
 			value = value - operation;
-
-			// Snap back a day, when looping through date line.
-			if ( ( this.props.is12hour ? 23 : -1 ) === value && 1 === operation ) {
-				modifiers.date = this.props.date.get( 'date' ) - 1;
-			}
-
-			value = value > 24 ? 1 : value;
+			value = value > 23 ? 0 : value;
 			value = value < 0 ? 23 : value;
 		} else {
 			value -= operation;
@@ -125,11 +119,10 @@ class PostScheduleClock extends Component {
 	 * @return {Number}      The converted hour.
 	 */
 	convertTo24Hour( hour ) {
-		if (
-			( 'PM' === this.refs.amPmReference.value && hour < 12 ) ||
-			( 'AM' === this.refs.amPmReference.value && 12 === hour )
-		) {
+		if ( 'PM' === this.refs.amPmReference.value && hour < 12 ) {
 			hour += 12;
+		} else if ( 'AM' === this.refs.amPmReference.value && 12 === hour ) {
+			hour = 0;
 		}
 
 		return hour;

--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -49,7 +49,11 @@ class PostScheduleClock extends Component {
 		let value = Number( event.target.value );
 
 		if ( 'hour' === field ) {
-			value = this.maybeConvertHour( value ) - operation;
+			if ( this.props.is12hour && this.refs.amPmReference ) {
+				value = this.convertTo24Hour( value );
+			}
+
+			value = value - operation;
 
 			// Snap back a day, when looping through date line.
 			if ( ( this.props.is12hour ? 23 : -1 ) === value && 1 === operation ) {
@@ -85,14 +89,13 @@ class PostScheduleClock extends Component {
 			modifiers.hour = Number( hour );
 		}
 
-		if ( amPmReference && (
-			'undefined' === typeof modifiers.hour ||
-			( 'PM' === amPmReference.value && modifiers.hour > 12 )
-		) ) {
-			modifiers.hour = Number( hourReference.value.substr( -1 ) );
-		}
+		if ( this.props.is12hour && amPmReference ) {
+			if ( 'undefined' === typeof modifiers.hour || ( 'PM' === amPmReference.value && modifiers.hour > 12 ) ) {
+				modifiers.hour = Number( hourReference.value.substr( -1 ) );
+			}
 
-		modifiers.hour = this.maybeConvertHour( modifiers.hour );
+			modifiers.hour = this.convertTo24Hour( modifiers.hour );
+		}
 
 		if ( false !== minute ) {
 			if ( minute > 60 ) {
@@ -121,11 +124,11 @@ class PostScheduleClock extends Component {
 	 * @param {Number}  hour The hour to convert.
 	 * @return {Number}      The converted hour.
 	 */
-	maybeConvertHour( hour ) {
-		if ( this.props.is12hour && this.refs.amPmReference && (
+	convertTo24Hour( hour ) {
+		if (
 			( 'PM' === this.refs.amPmReference.value && hour < 12 ) ||
 			( 'AM' === this.refs.amPmReference.value && 12 === hour )
-		) ) {
+		) {
 			hour += 12;
 		}
 

--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -77,9 +77,9 @@ class PostScheduleClock extends Component {
 			minuteRef
 		} = this.refs;
 
-		const hour = parseAndValidateNumber( hourReference.value );
-		const minute = parseAndValidateNumber( minuteRef.value );
 		const modifiers = {};
+		const hour = parseAndValidateNumber( hourReference.value );
+		let minute = parseAndValidateNumber( minuteRef.value );
 
 		if ( false !== hour && hour < 24 ) {
 			modifiers.hour = Number( hour );
@@ -89,12 +89,16 @@ class PostScheduleClock extends Component {
 			'undefined' === typeof modifiers.hour ||
 			( 'PM' === amPmReference.value && modifiers.hour > 12 )
 		) ) {
-			modifiers.hour = Number( hourReference.value.toString().slice( -1 ) );
+			modifiers.hour = Number( hourReference.value.substr( -1 ) );
 		}
 
 		modifiers.hour = this.maybeConvertHour( modifiers.hour );
 
-		if ( false !== minute && minute <= 59 ) {
+		if ( false !== minute ) {
+			if ( minute > 60 ) {
+				minute = minuteRef.value.substr( -1 );
+			}
+
 			modifiers.minute = Number( minute );
 		}
 

--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize, moment } from 'i18n-calypso';
-import { endsWith, noop } from 'lodash';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,6 +19,7 @@ import viewport from 'lib/viewport';
  * Local dependencies
  */
 import {
+	is12hr,
 	isValidGMTOffset,
 	parseAndValidateNumber,
 	convertHoursToHHMM,
@@ -45,7 +46,7 @@ class PostScheduleClock extends Component {
 			return null;
 		}
 
-		const hour = endsWith( this.props.timeFormat, 'A' ) || endsWith( this.props.timeFormat, 'a' ) ? 11 : 23;
+		const hour = is12hr( this.props.timeFormat ) ? 11 : 23;
 		let value = Number( event.target.value ) - operation;
 
 		if ( 'hour' === field ) {
@@ -96,8 +97,8 @@ class PostScheduleClock extends Component {
 		this.props.onChange( date, modifiers );
 	};
 
-	setAmPm( event, amPm ) {
-		this.refs.amPmReference.value = amPm;
+	setAmPm( event, amOrPm ) {
+		this.refs.amPmReference.value = amOrPm;
 		this.setTime( event );
 	}
 
@@ -167,7 +168,7 @@ class PostScheduleClock extends Component {
 
 	render() {
 		const { date, timeFormat, translate } = this.props;
-		const hasAmPm = endsWith( timeFormat, 'A' ) || endsWith( timeFormat, 'a' );
+		const is12hour = is12hr( timeFormat );
 
 		return (
 			<div className="post-schedule__clock">
@@ -175,7 +176,7 @@ class PostScheduleClock extends Component {
 					className="post-schedule__clock-time"
 					name="post-schedule__clock_hour"
 					ref="hourReference"
-					value={ date.format( hasAmPm ? 'hh' : 'HH' ) }
+					value={ date.format( is12hour ? 'hh' : 'HH' ) }
 					onChange={ this.setTime }
 					onKeyDown={ this.adjustHour }
 					type="text" />
@@ -191,7 +192,7 @@ class PostScheduleClock extends Component {
 					onKeyDown={ this.adjustMinute }
 					type="text" />
 
-				{ hasAmPm && (
+				{ is12hour && (
 					<span>
 						<input type="hidden" ref="amPmReference" name="post-schedule__clock_am-pm" value={ date.format( 'A' ) } />
 						<SegmentedControl compact>

--- a/client/components/post-schedule/index.jsx
+++ b/client/components/post-schedule/index.jsx
@@ -9,6 +9,7 @@ import { moment } from 'i18n-calypso';
  */
 import InputChrono from 'components/input-chrono';
 import DatePicker from 'components/date-picker';
+import QuerySiteSettings from 'components/data/query-site-settings';
 import User from 'lib/user';
 
 /**
@@ -168,7 +169,11 @@ class PostSchedule extends Component {
 
 	render() {
 		return (
-			<div className="post-schedule" >
+			<div className="post-schedule">
+				{
+					// Used by Clock for now, likely others in the future.
+					this.props.site && <QuerySiteSettings siteId={ this.props.site.ID } />
+				}
 				<Header
 					date={ this.state.calendarViewDate }
 					onDateChange={ this.setViewDate }
@@ -208,7 +213,6 @@ PostSchedule.propTypes = {
 	timezone: PropTypes.string,
 	gmtOffset: PropTypes.number,
 	site: PropTypes.object,
-
 	onDateChange: PropTypes.func,
 	onMonthChange: PropTypes.func
 };

--- a/client/components/post-schedule/style.scss
+++ b/client/components/post-schedule/style.scss
@@ -89,18 +89,31 @@ hr.post-schedule__hr {
 }
 
 input.post-schedule__clock-time {
-	height: 26px;
-	line-height: 26px;
+	height: 28px;
 	display: inline-block;
 	border: 1px solid lighten( $gray, 30% );
 	width: 42px;
 	text-align: center;
 	padding: 0;
-	font-size: 12px;
+	font-size: 13px;
 }
 
 .post-schedule__clock-divisor {
 	margin: 0 6px;
+}
+
+.post-schedule__clock .segmented-control {
+	display: inline-flex;
+	margin: 0 6px;
+	vertical-align: bottom;
+}
+
+.post-schedule__clock .segmented-control__item {
+	display: inline-table;
+}
+
+.post-schedule__clock .segmented-control__link {
+	display: inline-block;
 }
 
 .info-popover__tooltip.post-schedule__timezone-info,

--- a/client/components/post-schedule/test/index.js
+++ b/client/components/post-schedule/test/index.js
@@ -7,6 +7,7 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
+	is12hr,
 	isValidGMTOffset,
 	getLocalizedDate,
 	convertHoursToHHMM,
@@ -14,12 +15,24 @@ import {
 	parseAndValidateNumber,
 } from '../utils';
 
+describe( 'is12hr', () => {
+	it( 'Should return true for a 12-hour time format', () => {
+		expect( is12hr( 'F j, Y, g:i a' ) ).to.be.true;
+		expect( is12hr( 'h:i' ) ).to.be.true;
+	} );
+
+	it( 'Should return false for a 24-hour time', () => {
+		expect( is12hr( 'H:i:s' ) ).to.be.false;
+		expect( is12hr( 'G:i' ) ).to.be.false;
+	} );
+} );
+
 describe( 'gmtOffset', () => {
 	it( 'Should return true for a valid gtm offset', () => {
 		expect( isValidGMTOffset( 2 ) ).to.be.true;
 	} );
 
-	it( 'Should return true for a valid gtm offset', () => {
+	it( 'Should return false for an invalid gtm offset', () => {
 		expect( isValidGMTOffset( '2' ) ).to.be.false;
 	} );
 } );

--- a/client/components/post-schedule/utils.js
+++ b/client/components/post-schedule/utils.js
@@ -1,30 +1,22 @@
 /**
  * External dependencies
  */
-import { endsWith, includes } from 'lodash';
 import { moment } from 'i18n-calypso';
 
 /**
  * Checks whether the passed time  format is of a 12-hour format.
+ *
+ * g - 12-hour format of an hour without leading zeros.
+ * h - 12-hour format of an hour with leading zeros.
+ * a - Lowercase Ante meridiem and Post meridiem.
+ * A - Uppercase Ante meridiem and Post meridiem.
  *
  * @see https://wikipedia.org/wiki/12-hour_clock
  *
  * @param  {String}  timeFormat Time format.
  * @return {Boolean}            Whether it's a 12-hour time format.
  */
-const is12hr = ( timeFormat ) => (
-	// 12-hour format of an hour without leading zeros.
-	includes( timeFormat, 'g' ) ||
-
-	// 12-hour format of an hour with leading zeros.
-	includes( timeFormat, 'h' ) ||
-
-	// Lowercase Ante meridiem and Post meridiem.
-	endsWith( timeFormat, 'a' ) ||
-
-	// Uppercase Ante meridiem and Post meridiem.
-	endsWith( timeFormat, 'A' )
-);
+const is12hr = ( timeFormat ) => timeFormat && /[gh]|[aA]$/.test( timeFormat );
 
 /**
  * Check whether is a valid gmtOffset value.

--- a/client/components/post-schedule/utils.js
+++ b/client/components/post-schedule/utils.js
@@ -1,7 +1,30 @@
 /**
  * External dependencies
  */
+import { endsWith, includes } from 'lodash';
 import { moment } from 'i18n-calypso';
+
+/**
+ * Checks whether the passed time  format is of a 12-hour format.
+ *
+ * @see https://wikipedia.org/wiki/12-hour_clock
+ *
+ * @param  {String}  timeFormat Time format.
+ * @return {Boolean}            Whether it's a 12-hour time format.
+ */
+const is12hr = ( timeFormat ) => (
+	// 12-hour format of an hour without leading zeros.
+	includes( timeFormat, 'g' ) ||
+
+	// 12-hour format of an hour with leading zeros.
+	includes( timeFormat, 'h' ) ||
+
+	// Lowercase Ante meridiem and Post meridiem.
+	endsWith( timeFormat, 'a' ) ||
+
+	// Uppercase Ante meridiem and Post meridiem.
+	endsWith( timeFormat, 'A' )
+);
 
 /**
  * Check whether is a valid gmtOffset value.
@@ -115,6 +138,7 @@ export default {
 	getDateInLocalUTC,
 	getLocalizedDate,
 	getTimeOffset,
+	is12hr,
 	isValidGMTOffset,
 	parseAndValidateNumber,
 };

--- a/client/state/selectors/get-site-setting.js
+++ b/client/state/selectors/get-site-setting.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteSettings } from 'state/site-settings/selectors';
+
+/**
+ * Returns a specific setting for the specified site ID
+ *
+ * @param  {Object} state   Global state tree
+ * @param  {Number} siteId  Site ID
+ * @param  {String} setting Setting name
+ * @return {Object}         Site setting
+ */
+export default function getSiteSetting( state, siteId, setting ) {
+	return get( getSiteSettings( state, siteId ), [ setting ], null );
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -43,6 +43,7 @@ export getSharingButtons from './get-sharing-buttons';
 export getSiteGmtOffset from './get-site-gmt-offset';
 export getSiteIconId from './get-site-icon-id';
 export getSiteIconUrl from './get-site-icon-url';
+export getSiteSetting from './get-site-setting';
 export getSiteStatsQueryDate from './get-site-stats-query-date';
 export getSiteStatsViewSummary from './get-site-stats-view-summary';
 export getTimezones from './get-timezones';

--- a/client/state/selectors/test/get-site-setting.js
+++ b/client/state/selectors/test/get-site-setting.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteSetting } from '../';
+
+describe( 'getSiteSettings()', () => {
+	const state = {
+		siteSettings: {
+			items: {
+				2916284: { default_category: 'chicken' }
+			}
+		}
+	};
+
+	it( 'should return null if the site is not tracked', () => {
+		const settings = getSiteSetting( state, 2916285 );
+
+		expect( settings ).to.be.null;
+	} );
+
+	it( 'should return the setting for a siteId', () => {
+		const settings = getSiteSetting( state, 2916284, 'default_category' );
+
+		expect( settings ).to.eql( 'chicken' );
+	} );
+} );


### PR DESCRIPTION
This PR adds an AM/PM selector to the scheduling component of the
editor.

Fixes #10762.

To test: Make sure your site’s time format is set to include AM/PM
(setting is still in wp-admin). Navigate to the editor and open the
calendar next to the Publish button. Time should adjust in the
background.