### PR TITLE
Components: increasing contrast in SectionHeader

### DIFF
--- a/client/components/header-cake/style.scss
+++ b/client/components/header-cake/style.scss
@@ -45,7 +45,7 @@
 
 .header-cake__title {
 	flex: 1 1 auto;
-	color: $gray-text;
+	color: $gray-dark;
 	text-align: center;
 	word-break: break-word;
 	white-space: nowrap;

--- a/client/components/header-cake/style.scss
+++ b/client/components/header-cake/style.scss
@@ -45,7 +45,7 @@
 
 .header-cake__title {
 	flex: 1 1 auto;
-	color: darken( $gray, 20 );
+	color: $gray-text;
 	text-align: center;
 	word-break: break-word;
 	white-space: nowrap;

--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -35,7 +35,7 @@
 }
 
 .section-header__label {
-	color: $gray-text;
+	color: $gray-dark;
 	font-size: 14px;
 }
 

--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -35,7 +35,7 @@
 }
 
 .section-header__label {
-	color: $gray;
+	color: $gray-text;
 	font-size: 14px;
 }
 


### PR DESCRIPTION
This updates a few components to use the $gray-text variable for text, which is the mimmim contrast needed to pass WCAG 2.0 AA tests on a white background.

affects:
- section header 
- header cake

The buttons will be using $gray-text once #11327 is shipped. Then, all text in the header will be the same color.

You may notice that the header title is actually 2% lighter after this change. That's because it was using `darken($gray, 20%)` which is darker than `gray-text`. Updating all text to use `$gray-text` will make all the text colors in the header consistent.

Before:
![screen shot 2017-02-10 at 2 48 29 pm](https://cloud.githubusercontent.com/assets/618551/22843736/7a1fe350-efa0-11e6-9aa1-b5e6c00d2336.png)
![screen shot 2017-02-10 at 2 49 15 pm](https://cloud.githubusercontent.com/assets/618551/22843714/6990f0b0-efa0-11e6-9852-60dc77485d5e.png)

After:
![screen shot 2017-02-10 at 2 48 36 pm](https://cloud.githubusercontent.com/assets/618551/22843760/8f9ddc5a-efa0-11e6-8ed0-9e900e1e2070.png)
![screen shot 2017-02-10 at 2 49 00 pm](https://cloud.githubusercontent.com/assets/618551/22843748/86e704ba-efa0-11e6-9073-09b4fe959859.png)


