### PR TITLE
Components: segmented control contrast

### DIFF
--- a/client/components/segmented-control/style.scss
+++ b/client/components/segmented-control/style.scss
@@ -43,7 +43,7 @@
 	border-right: none;
 	font-size: 14px;
 	line-height: 18px;
-	color: $gray;
+	color: $gray-text;
 	text-align: center;
 
 	&:focus {

--- a/client/components/version/style.scss
+++ b/client/components/version/style.scss
@@ -8,5 +8,6 @@
 	.gridicon {
 		float: left;
 		margin-right: 4px;
+		fill: $gray;
 	}
 }

--- a/client/components/version/style.scss
+++ b/client/components/version/style.scss
@@ -1,7 +1,7 @@
 .version {
 	text-transform: uppercase;
 	font-size: 11px;
-	color: $gray;
+	color: $gray-text;
 	line-height: 18px;
 	@include clear-fix;
 

--- a/client/components/vertical-menu/style.scss
+++ b/client/components/vertical-menu/style.scss
@@ -11,7 +11,7 @@
 
 	border-top: 1px solid lighten( $gray, 20% );
 	border-left: 3px solid transparent;
-	color: $gray;
+	color: $gray-text;
 	font-size: 13px;
 	font-weight: 200;
 
@@ -22,8 +22,12 @@
 
 	&.is-selected {
 		border-left: 3px solid $blue-wordpress;
-		color: darken( $gray, 30% );
+		color: $gray-dark;
 		font-weight: 400;
+
+		.social-logo {
+			fill: $gray-dark;
+		}
 	}
 
 	&:last-child {
@@ -32,6 +36,10 @@
 
 	&:not(.is-selected):hover {
 		color: $blue-medium;
+
+		.social-logo {
+			fill: $blue-medium;
+		}
 	}
 }
 
@@ -41,3 +49,6 @@
 	margin-bottom: -4px;
 }
 
+.vertical-menu__items__social-icon .social-logo {
+	fill: $gray;
+}


### PR DESCRIPTION
This updates a few components to use the $gray-text variable for text, which is the mimmim contrast needed to pass WCAG 2.0 AA tests on a white background.

affects:
- segmented control
- vertical menu
- version

I went ahead and included the vertical menu and version components since they are less frequently used components.

Before:

![screen shot 2017-02-10 at 3 14 49 pm](https://cloud.githubusercontent.com/assets/618551/22844431/da72d098-efa3-11e6-956a-4ca485b5554a.png)
![screen shot 2017-02-10 at 3 15 10 pm](https://cloud.githubusercontent.com/assets/618551/22844456/027033ce-efa4-11e6-8681-1273b7fca100.png)
![screen shot 2017-02-10 at 3 11 47 pm](https://cloud.githubusercontent.com/assets/618551/22844465/0ab36f4c-efa4-11e6-8543-9ec49f0be1fc.png)

after:

![screen shot 2017-02-10 at 3 15 02 pm](https://cloud.githubusercontent.com/assets/618551/22844479/168d93f6-efa4-11e6-9570-4675724bfe92.png)
![screen shot 2017-02-10 at 3 15 50 pm](https://cloud.githubusercontent.com/assets/618551/22844474/124fbdaa-efa4-11e6-8702-bd46c03d270f.png)
![screen shot 2017-02-10 at 3 11 32 pm](https://cloud.githubusercontent.com/assets/618551/22844482/1b982820-efa4-11e6-9e2c-422b38ba45c2.png)
