### PR TITLE
Stats: add view summary selector.

### DIFF
--- a/client/state/selectors/get-site-stats-view-summary.js
+++ b/client/state/selectors/get-site-stats-view-summary.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { moment } from 'i18n-calypso';
+import { round } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteStatsForQuery } from 'state/stats/lists/selectors';
+
+/**
+ * Returns the date of the last site stats query
+ *
+ * @param  {Object}  state    Global state tree
+ * @param  {Number}  siteId   Site ID
+ * @return {Object}           Stats View Summary
+ */
+export default function getSiteStatsViewSummary( state, siteId ) {
+	const query = {
+		stat_fields: 'views',
+		num: -1
+	};
+	const viewData = getSiteStatsForQuery( state, siteId, 'statsVisits', query );
+
+	if ( ! viewData || ! viewData.data ) {
+		return null;
+	}
+
+	const viewSummary = {};
+
+	viewData.data.forEach( ( item ) => {
+		const [ date, value ] = item;
+		const momentDate = moment( date );
+		const { years, months } = momentDate.toObject();
+
+		if ( ! viewSummary[ years ] ) {
+			viewSummary[ years ] = {};
+		}
+
+		if ( ! viewSummary[ years ][ months ] ) {
+			viewSummary[ years ][ months ] = {
+				total: 0,
+				data: [],
+				average: 0.0,
+				daysInMonth: momentDate.daysInMonth()
+			};
+		}
+		viewSummary[ years ][ months ].total += value;
+		viewSummary[ years ][ months ].data.push( item );
+		const average = viewSummary[ years ][ months ].total / viewSummary[ years ][ months ].daysInMonth;
+		viewSummary[ years ][ months ].average = round( average, 2 );
+	} );
+
+	return viewSummary;
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -42,6 +42,7 @@ export getSharingButtons from './get-sharing-buttons';
 export getSiteIconId from './get-site-icon-id';
 export getSiteIconUrl from './get-site-icon-url';
 export getSiteStatsQueryDate from './get-site-stats-query-date';
+export getSiteStatsViewSummary from './get-site-stats-view-summary';
 export getTimezones from './get-timezones';
 export getTimezonesByContinent from './get-timezones-by-continent';
 export getTimezonesLabel from './get-timezones-label';

--- a/client/state/selectors/test/get-site-stats-view-summary.js
+++ b/client/state/selectors/test/get-site-stats-view-summary.js
@@ -1,0 +1,95 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteStatsViewSummary } from '../';
+
+describe( 'getSiteStatsViewSummary()', () => {
+	it( 'should return null if no data exists', () => {
+		const data = getSiteStatsViewSummary( {
+			stats: {
+				lists: {
+					items: {}
+				}
+			}
+		}, 2916284 );
+
+		expect( data ).to.be.null;
+	} );
+
+	it( 'should return an empty object if data is empty', () => {
+		const data = getSiteStatsViewSummary( {
+			stats: {
+				lists: {
+					items: {
+						2916284: {
+							statsVisits: {
+								'[["num",-1],["stat_fields","views"]]': {
+									data: [],
+									fields: [ 'period', 'views' ],
+									unit: 'day'
+								}
+							}
+						}
+					}
+				}
+			}
+		}, 2916284 );
+
+		expect( data ).to.eql( {} );
+	} );
+
+	it( 'should return an empty object if data is empty', () => {
+		const data = getSiteStatsViewSummary( {
+			stats: {
+				lists: {
+					items: {
+						2916284: {
+							statsVisits: {
+								'[["num",-1],["stat_fields","views"]]': {
+									data: [
+										[ '2014-01-01', 4 ],
+										[ '2014-01-02', 4 ],
+										[ '2014-01-03', 23 ],
+										[ '2015-01-01', 10 ]
+									],
+									fields: [ 'period', 'views' ],
+									unit: 'day'
+								}
+							}
+						}
+					}
+				}
+			}
+		}, 2916284 );
+
+		expect( data ).to.eql( {
+			2014: {
+				0: {
+					total: 31,
+					average: 1,
+					daysInMonth: 31,
+					data: [
+						[ '2014-01-01', 4 ],
+						[ '2014-01-02', 4 ],
+						[ '2014-01-03', 23 ]
+					]
+				}
+			},
+			2015: {
+				0: {
+					total: 10,
+					average: 0.32,
+					daysInMonth: 31,
+					data: [
+						[ '2015-01-01', 10 ]
+					]
+				}
+			}
+		} );
+	} );
+} );


### PR DESCRIPTION
For #1960

This branch adds in a new selector that will enable us to build an All-Time page for Views within stats.

__To Test__
Ensure tests pass, nothing visual to test