### PR TITLE
People Management: Add a download data as CSV link for email followers

### DIFF
--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -193,7 +193,7 @@ const Followers = localize( class FollowersComponent extends Component {
 			followers = this.renderPlaceholders();
 		}
 
-		const downloadListLink = this.props.fetchOptions.type === 'email'
+		const downloadListLink = this.props.fetchOptions.type === 'email' && !! this.props.site
 			? 'https://dashboard.wordpress.com/wp-admin/index.php?page=stats&blog=' +
 				this.props.site.ID + '&blog_subscribers=csv&type=email'
 			: null;

--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -1,15 +1,14 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' ),
-	omit = require( 'lodash/omit' ),
-	debug = require( 'debug' )( 'calypso:my-sites:people:followers-list' );
+import React, { Component } from 'react';
+import { omit } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var PeopleListItem = require( 'my-sites/people/people-list-item' ),
+const PeopleListItem = require( 'my-sites/people/people-list-item' ),
 	Card = require( 'components/card' ),
 	PeopleListSectionHeader = require( 'my-sites/people/people-list-section-header' ),
 	FollowersActions = require( 'lib/followers/actions' ),
@@ -24,73 +23,67 @@ var PeopleListItem = require( 'my-sites/people/people-list-item' ),
 	deterministicStringify = require( 'lib/deterministic-stringify' ),
 	accept = require( 'lib/accept' ),
 	analytics = require( 'lib/analytics' );
+import Button from 'components/button';
 
 const maxFollowers = 1000;
 
-let Followers = React.createClass( {
-
-	displayName: 'Followers',
-
-	getInitialState: function() {
-		return {
-			bulkEditing: false
-		};
-	},
-
-	mixins: [ PureRenderMixin ],
+const Followers = localize( class FollowersComponent extends Component {
+	state = {
+		bulkEditing: false
+	};
 
 	renderPlaceholders() {
-		return <PeopleListItem key="people-list-item-placeholder"/>;
-	},
+		return <PeopleListItem key="people-list-item-placeholder" />;
+	}
 
-	fetchNextPage() {
-		let actions = 'email' === this.props.type ? EmailFollowersActions : FollowersActions,
+	fetchNextPage = () => {
+		const actions = 'email' === this.props.type ? EmailFollowersActions : FollowersActions,
 			store = 'email' === this.props.type ? EmailFollowersStore : FollowersStore,
-			page = this.props.currentPage + 1,
 			paginationData = store.getPaginationData( this.props.fetchOptions ),
 			analyticsAction = 'email' === this.props.type
 				? 'Fetched more email followers with infinite list'
 				: 'Fetched more followers with infinite list';
 
+		let page = this.props.currentPage + 1;
 		if ( paginationData && paginationData.followersCurrentPage ) {
 			page = paginationData.followersCurrentPage + 1;
 		}
 
 		actions.fetchFollowers( Object.assign( this.props.fetchOptions, { page } ) );
 		analytics.ga.recordEvent( 'People', analyticsAction, 'page', page );
-		debug( 'Fetching next page: ' + page );
-	},
+	};
 
-	removeFollower: function( follower ) {
-		let listType = 'email' === this.props.type ? 'Email Follower' : 'Follower';
+	removeFollower( follower ) {
+		const listType = 'email' === this.props.type ? 'Email Follower' : 'Follower';
 		analytics.ga.recordEvent( 'People', 'Clicked Remove Follower Button On' + listType + ' list' );
 		accept( (
 			<div>
 				<p>
 				{
-					this.translate(
+					this.props.translate(
 						'If removed, this follower will stop receiving notifications about this site, unless they re-follow.'
 					)
 				}
 				</p>
 				<p>
-					{ this.translate( 'Would you still like to remove this follower?' ) }
+					{ this.props.translate( 'Would you still like to remove this follower?' ) }
 				</p>
 			</div>
 			),
 			accepted => {
 				if ( accepted ) {
 					analytics.ga.recordEvent( 'People', 'Clicked Remove Button In Remove ' + listType + ' Confirmation' );
-					( 'email' === this.props.type ? EmailFollowersActions : FollowersActions ).removeFollower( this.props.site.ID, follower );
+					( 'email' === this.props.type ? EmailFollowersActions : FollowersActions )
+						.removeFollower( this.props.site.ID, follower );
 				} else {
 					analytics.ga.recordEvent( 'People', 'Clicked Cancel Button In Remove ' + listType + ' Confirmation' );
 				}
 			},
-			this.translate( 'Remove', { context: 'Confirm Remove follower button text.' } )
+			this.props.translate( 'Remove', { context: 'Confirm Remove follower button text.' } )
 		);
-	},
+	}
 
-	renderFollower( follower ) {
+	renderFollower = ( follower ) => {
 		const removeFollower = () => {
 			this.removeFollower( follower );
 		};
@@ -105,40 +98,37 @@ let Followers = React.createClass( {
 				onRemove={ removeFollower }
 			/>
 		);
-	},
+	};
 
-	getFollowerRef( follower ) {
+	getFollowerRef = ( follower ) => {
 		return 'follower-' + follower.ID;
-	},
+	};
 
 	noFollowerSearchResults() {
 		return this.props.fetchInitialized &&
 			this.props.fetchOptions.search &&
 			! this.props.followers.length &&
 			! this.props.fetching;
-	},
+	}
 
 	siteHasNoFollowers() {
 		return ! this.props.followers.length && ! this.props.fetching;
-	},
+	}
 
 	isLastPage() {
 		return this.props.totalFollowers <= this.props.followers.length || maxFollowers <= this.props.followers.length;
-	},
+	}
 
 	render() {
-		let key = deterministicStringify( omit( this.props.fetchOptions, [ 'max', 'page' ] ) ),
-			headerText = this.props.label,
-			listClass = ( this.state.bulkEditing ) ? 'bulk-editing' : null,
-			followers,
-			emptyTitle;
+		const key = deterministicStringify( omit( this.props.fetchOptions, [ 'max', 'page' ] ) ),
+			listClass = ( this.state.bulkEditing ) ? 'bulk-editing' : null;
 
 		if ( this.noFollowerSearchResults() ) {
 			return (
 				<NoResults
 					image="/calypso/images/people/mystery-person.svg"
 					text={
-						this.translate( 'No results found for {{em}}%(searchTerm)s{{/em}}',
+						this.props.translate( 'No results found for {{em}}%(searchTerm)s{{/em}}',
 							{
 								args: { searchTerm: this.props.fetchOptions.search },
 								components: { em: <em /> }
@@ -148,20 +138,23 @@ let Followers = React.createClass( {
 			);
 		}
 
+		let emptyTitle;
 		if ( this.siteHasNoFollowers() ) {
 			if ( this.props.fetchOptions && 'email' === this.props.fetchOptions.type ) {
-				emptyTitle = this.translate( "You don't have any email followers yet." )
+				emptyTitle = this.props.translate( "You don't have any email followers yet." );
 			} else {
-				emptyTitle = this.translate( "You don't have any followers yet." )
+				emptyTitle = this.props.translate( "You don't have any followers yet." );
 			}
 			return (
 				<EmptyContent title={ emptyTitle } />
 			);
 		}
 
+		let headerText = this.props.label;
+		let followers;
 		if ( this.props.followers.length ) {
 			if ( this.props.fetchOptions.search && this.props.totalFollowers ) {
-				headerText = this.translate(
+				headerText = this.props.translate(
 					'%(numberPeople)d Follower Matching {{em}}"%(searchTerm)s"{{/em}}',
 					'%(numberPeople)d Followers Matching {{em}}"%(searchTerm)s"{{/em}}',
 					{
@@ -177,12 +170,10 @@ let Followers = React.createClass( {
 				);
 			}
 
-			let infiniteListConditionals = {
+			const infiniteListConditionals = {
 				fetchingNextPage: this.props.fetching,
 				lastPage: this.isLastPage()
 			};
-
-			debug( 'Infinite list conditionals: ' + JSON.stringify( infiniteListConditionals ) );
 
 			followers = (
 				<InfiniteList
@@ -201,13 +192,23 @@ let Followers = React.createClass( {
 		} else {
 			followers = this.renderPlaceholders();
 		}
+
+		const downloadListLink = this.props.fetchOptions.type === 'email'
+			? 'https://dashboard.wordpress.com/wp-admin/index.php?page=stats&blog=' +
+				this.props.site.ID + '&blog_subscribers=csv&type=email'
+			: null;
+
 		return (
 			<div>
 				<PeopleListSectionHeader
 					isFollower
 					label={ headerText }
 					site={ this.props.site }
-					count={ this.props.fetching || this.props.fetchOptions.search ? null : this.props.totalFollowers } />
+					count={ this.props.fetching || this.props.fetchOptions.search ? null : this.props.totalFollowers }>
+					{ downloadListLink &&
+						<Button href={ downloadListLink } compact>{ this.props.translate( 'Download Data as CSV' ) }</Button>
+					}
+				</PeopleListSectionHeader>
 				<Card className={ listClass }>
 					{ followers }
 				</Card>
@@ -217,36 +218,32 @@ let Followers = React.createClass( {
 	}
 } );
 
-module.exports = React.createClass( {
-	displayName: 'FollowersList',
+const FollowersList = ( props ) => {
+	let DataComponent;
+	const fetchOptions = {
+		max: 100,
+		page: 1,
+		search: ( props.search ) && props.search,
+		siteId: props.site.ID
+	};
 
-	mixins: [ PureRenderMixin ],
-
-	render() {
-		let DataComponent;
-		let fetchOptions = {
-			max: 100,
-			page: 1,
-			search: ( this.props.search ) && this.props.search,
-			siteId: this.props.site.ID
-		};
-
-		if ( 'email' === this.props.type ) {
-			DataComponent = EmailFollowersData;
-			fetchOptions.type = 'email';
-		} else {
-			DataComponent = FollowersData;
-		}
-
-		return (
-			<DataComponent
-				fetchOptions={ fetchOptions }
-				site={ this.props.site }
-				label={ this.props.label }
-				type={ this.props.type }
-			>
-				<Followers />
-			</DataComponent>
-		);
+	if ( 'email' === props.type ) {
+		DataComponent = EmailFollowersData;
+		fetchOptions.type = 'email';
+	} else {
+		DataComponent = FollowersData;
 	}
-} );
+
+	return (
+		<DataComponent
+			fetchOptions={ fetchOptions }
+			site={ props.site }
+			label={ props.label }
+			type={ props.type }
+		>
+			<Followers />
+		</DataComponent>
+	);
+};
+
+export default FollowersList;

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -61,7 +61,7 @@ export default React.createClass( {
 	},
 
 	render() {
-		const { label, count, site } = this.props;
+		const { label, count, site, children } = this.props;
 		const siteLink = this.getAddLink();
 		const classes = classNames(
 			this.props.className,
@@ -73,7 +73,7 @@ export default React.createClass( {
 				className={ classes }
 				count={ count }
 				label={ label } >
-
+				{ children }
 				{ siteLink &&
 					<ButtonGroup>
 						<Button

--- a/client/my-sites/people/people-notices/index.jsx
+++ b/client/my-sites/people/people-notices/index.jsx
@@ -56,8 +56,8 @@ const PeopleNotices = React.createClass( {
 	},
 
 	getState() {
-		const siteId = this.props.site.ID,
-			userId = this.props.user && this.props.user.ID;
+		const siteId = this.props.site ? this.props.site.ID : null;
+		const userId = this.props.user ? this.props.user.ID : null;
 
 		return {
 			errors: PeopleLog.getErrors( filterBy.bind( this, siteId, userId ) ),


### PR DESCRIPTION
Closes #10989

This link is already used in stats, that way we could redirect stats to this page.
I refactored the component (not entirely) to get rid of some ESLint issues.

<img width="684" alt="screen shot 2017-02-10 at 16 46 42" src="https://cloud.githubusercontent.com/assets/272444/22847090/89e83bd8-efb0-11e6-81d4-4c2aa6b364fc.png">


**Testing instructions**

 * Open the email followers page: `/people/email-followers/`
 * You should a "Download Data as CSV link" to grab the emails as csv
 * This link is not shown in the followers page