### PR TITLE
State: Introduce selectors for whether Jetpack modules require connection

### DIFF
--- a/client/state/selectors/get-jetpack-modules-requiring-connection.js
+++ b/client/state/selectors/get-jetpack-modules-requiring-connection.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+
+/**
+ * Returns an array of modules that require connection in order to work.
+ * Returns null if the site is not known.
+ *
+ * @param  {Object}  state       Global state tree
+ * @param  {Number}  siteId      The ID of the site we're querying
+ * @return {?Array}              Slugs of modules that require connection to work.
+ */
+const getJetpackModulesRequiringConnection = createSelector(
+	( state, siteId ) => {
+		const modules = get( state.jetpack.modules.items, [ siteId ], null );
+		if ( ! modules ) {
+			return null;
+		}
+
+		return Object.keys( modules ).filter( ( module_slug ) =>
+			modules[ module_slug ].requires_connection
+		);
+	},
+	( state ) => [ state.jetpack.modules.items ]
+);
+
+export default getJetpackModulesRequiringConnection;

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -25,6 +25,7 @@ export getJetpackConnectionStatus from './get-jetpack-connection-status';
 export getJetpackJumpstartStatus from './get-jetpack-jumpstart-status';
 export getJetpackModule from './get-jetpack-module';
 export getJetpackModules from './get-jetpack-modules';
+export getJetpackModulesRequiringConnection from './get-jetpack-modules-requiring-connection';
 export getJetpackSetting from './get-jetpack-setting';
 export getJetpackSettings from './get-jetpack-settings';
 export getJetpackSettingsSaveError from './get-jetpack-settings-save-error';

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -61,6 +61,7 @@ export isDeactivatingJetpackModule from './is-deactivating-jetpack-module';
 export isDomainOnlySite from './is-domain-only-site';
 export isFetchingJetpackModules from './is-fetching-jetpack-modules';
 export isJetpackModuleActive from './is-jetpack-module-active';
+export isJetpackModuleUnavailableInDevelopmentMode from './is-jetpack-module-unavailable-in-development-mode';
 export isJetpackSettingsSaveFailure from './is-jetpack-settings-save-failure';
 export isJetpackSiteInDevelopmentMode from './is-jetpack-site-in-development-mode';
 export isJetpackSiteInStagingMode from './is-jetpack-site-in-staging-mode';

--- a/client/state/selectors/is-jetpack-module-unavailable-in-development-mode.js
+++ b/client/state/selectors/is-jetpack-module-unavailable-in-development-mode.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import { getJetpackModulesRequiringConnection } from './';
+
+/**
+ * Returns true if the module is unavailable in development mode. False if not.
+ * Returns null if the site modules are not known yet.
+ *
+ * @param  {Object}  state       Global state tree
+ * @param  {Number}  siteId      The ID of the site we're querying
+ * @param  {String}  moduleSlug  Module slug
+ * @return {?Boolean}            Whether the module is unavailable in dev mode.
+ */
+const isJetpackModuleUnavailableInDevelopmentMode = createSelector(
+	( state, siteId, moduleSlug ) => {
+		const modulesRequiringConnection = getJetpackModulesRequiringConnection( state, siteId );
+		if ( ! modulesRequiringConnection ) {
+			return null;
+		}
+
+		return includes( modulesRequiringConnection, moduleSlug );
+	},
+	getJetpackModulesRequiringConnection
+);
+
+export default isJetpackModuleUnavailableInDevelopmentMode;

--- a/client/state/selectors/test/get-jetpack-modules-requiring-connection.js
+++ b/client/state/selectors/test/get-jetpack-modules-requiring-connection.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getJetpackModulesRequiringConnection } from '../';
+
+describe( 'getJetpackModulesRequiringConnection()', () => {
+	it( 'should return null if the site has never been fetched', () => {
+		const stateTree = {
+			jetpack: {
+				modules: {
+					items: {}
+				}
+			}
+		};
+
+		const modules = getJetpackModulesRequiringConnection( stateTree, 12345678 );
+		expect( modules ).to.be.null;
+	} );
+
+	it( 'should return the modules that require connection for a known site', () => {
+		const stateTree = {
+			jetpack: {
+				modules: {
+					items: {
+						12345678: {
+							'module-a': {
+								module: 'module-a',
+								requires_connection: true,
+							},
+							'module-b': {
+								module: 'module-b',
+								requires_connection: false,
+							},
+							'module-c': {
+								module: 'module-c',
+							}
+						}
+					}
+				}
+			}
+		};
+
+		const modules = getJetpackModulesRequiringConnection( stateTree, 12345678 );
+		expect( modules ).to.eql( [ 'module-a' ] );
+	} );
+} );

--- a/client/state/selectors/test/is-jetpack-module-unavailable-in-development-mode.js
+++ b/client/state/selectors/test/is-jetpack-module-unavailable-in-development-mode.js
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isJetpackModuleUnavailableInDevelopmentMode } from '../';
+
+describe( 'isJetpackModuleUnavailableInDevelopmentMode()', () => {
+	it( 'should return null if the site modules are not known', () => {
+		const stateTree = {
+			jetpack: {
+				modules: {
+					items: {}
+				}
+			}
+		};
+
+		const unavailable = isJetpackModuleUnavailableInDevelopmentMode( stateTree, 12345678, 'module-a' );
+		expect( unavailable ).to.be.null;
+	} );
+
+	it( 'should return true for a module that requires connection', () => {
+		const stateTree = {
+			jetpack: {
+				modules: {
+					items: {
+						12345678: {
+							'module-a': {
+								module: 'module-a',
+								requires_connection: true,
+							},
+						}
+					}
+				}
+			}
+		};
+
+		const unavailable = isJetpackModuleUnavailableInDevelopmentMode( stateTree, 12345678, 'module-a' );
+		expect( unavailable ).to.be.true;
+	} );
+
+	it( 'should return false for a module that does not require connection', () => {
+		const stateTree = {
+			jetpack: {
+				modules: {
+					items: {
+						12345678: {
+							'module-a': {
+								module: 'module-a',
+								requires_connection: false,
+							},
+						}
+					}
+				}
+			}
+		};
+
+		const unavailable = isJetpackModuleUnavailableInDevelopmentMode( stateTree, 12345678, 'module-a' );
+		expect( unavailable ).to.be.false;
+	} );
+
+	it( 'should return false for a module that does not specify whether it requires connection', () => {
+		const stateTree = {
+			jetpack: {
+				modules: {
+					items: {
+						12345678: {
+							'module-a': {
+								module: 'module-a',
+							},
+						}
+					}
+				}
+			}
+		};
+
+		const unavailable = isJetpackModuleUnavailableInDevelopmentMode( stateTree, 12345678, 'module-a' );
+		expect( unavailable ).to.be.false;
+	} );
+} );


### PR DESCRIPTION
This PR introduces 2 new selectors that we'll use to get all Jetpack modules that require connection, and whether a certain module requires connection. We'll need them in order to be able to disable certain functionality, like we do in the Jetpack settings page. see https://github.com/Automattic/jetpack/pull/6180 for the approach in Jetpack:

Those 2 selectors are similar to the ones in Jetpack:
* `getJetpackModulesRequiringConnection()` - retrieve all modules that require connection
* `isJetpackModuleUnavailableInDevelopmentMode()` - whether a certain module is unavailable in dev mode

Once we have these selectors in place, we'll be able to implement nudges and disable certain UI pieces in Jetpack Settings cards, following the example of https://github.com/Automattic/jetpack/pull/6180.

To test:
* Checkout this branch
* Verify all tests pass:

```
npm run test-client client/state/selectors/test/get-jetpack-modules-requiring-connection.js 
```

```
npm run test-client client/state/selectors/test/is-jetpack-module-unavailable-in-development-mode.js
```