### PR TITLE
Domains: minor copy updates for domain-only sites

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -120,8 +120,8 @@ function renderSelectedSiteIsDomainOnly( reactContext, selectedSite ) {
 
 	renderWithReduxStore(
 		React.createElement( EmptyContentComponent, {
-			title: i18n.translate( 'This feature is not available for domains' ),
-			line: i18n.translate( 'To use this feature you need to create a site' ),
+			title: i18n.translate( 'Add a site to start using this feature.' ),
+			line: i18n.translate( 'Your domain is only set up with a temporary page. Start a site now to use all of WordPress.com\'s features.' ),
 			action: i18n.translate( 'Create New Site' ),
 			actionURL: `/start/site-selected/?siteSlug=${ encodeURIComponent( selectedSite.slug ) }&siteId=${ encodeURIComponent( selectedSite.ID ) }`,
 			secondaryAction: i18n.translate( 'Manage Domain' ),

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -122,7 +122,7 @@ function renderSelectedSiteIsDomainOnly( reactContext, selectedSite ) {
 		React.createElement( EmptyContentComponent, {
 			title: i18n.translate( 'Add a site to start using this feature.' ),
 			line: i18n.translate( 'Your domain is only set up with a temporary page. Start a site now to use all of WordPress.com\'s features.' ),
-			action: i18n.translate( 'Create New Site' ),
+			action: i18n.translate( 'Create Site' ),
 			actionURL: `/start/site-selected/?siteSlug=${ encodeURIComponent( selectedSite.slug ) }&siteId=${ encodeURIComponent( selectedSite.ID ) }`,
 			secondaryAction: i18n.translate( 'Manage Domain' ),
 			secondaryActionURL: domainManagementList( selectedSite.slug )

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -121,7 +121,7 @@ function renderSelectedSiteIsDomainOnly( reactContext, selectedSite ) {
 	renderWithReduxStore(
 		React.createElement( EmptyContentComponent, {
 			title: i18n.translate( 'Add a site to start using this feature.' ),
-			line: i18n.translate( 'Your domain is only set up with a temporary page. Start a site now to use all of WordPress.com\'s features.' ),
+			line: i18n.translate( 'Your domain is only set up with a temporary page. Start a site now to unlock everything WordPress.com can offer.' ),
 			action: i18n.translate( 'Create Site' ),
 			actionURL: `/start/site-selected/?siteSlug=${ encodeURIComponent( selectedSite.slug ) }&siteId=${ encodeURIComponent( selectedSite.ID ) }`,
 			secondaryAction: i18n.translate( 'Manage Domain' ),

--- a/client/my-sites/upgrades/domain-management/list/domain-only.jsx
+++ b/client/my-sites/upgrades/domain-management/list/domain-only.jsx
@@ -17,7 +17,7 @@ const DomainOnly = ( { domainName, siteId, translate } ) => (
 		} ) }
 		action={ translate( 'Create New Site' ) }
 		actionURL={ `/start/site-selected/?siteSlug=${ encodeURIComponent( domainName ) }&siteId=${ encodeURIComponent( siteId ) }` }
-		secondaryAction={ translate( 'Advanced' ) }
+		secondaryAction={ translate( 'Manage Domain' ) }
 		secondaryActionURL={ domainManagementEdit( domainName, domainName ) }
 		illustration={ '/calypso/images/drake/drake-browser.svg' } />
 );

--- a/client/my-sites/upgrades/domain-management/list/domain-only.jsx
+++ b/client/my-sites/upgrades/domain-management/list/domain-only.jsx
@@ -15,7 +15,7 @@ const DomainOnly = ( { domainName, siteId, translate } ) => (
 		title={ translate( '%(domainName)s is not set up yet.', {
 			args: { domainName }
 		} ) }
-		action={ translate( 'Create New Site' ) }
+		action={ translate( 'Create Site' ) }
 		actionURL={ `/start/site-selected/?siteSlug=${ encodeURIComponent( domainName ) }&siteId=${ encodeURIComponent( siteId ) }` }
 		secondaryAction={ translate( 'Manage Domain' ) }
 		secondaryActionURL={ domainManagementEdit( domainName, domainName ) }


### PR DESCRIPTION
Following up on #11098, this updates the copy on the feature gate screen to the following:

> Add a site to start using this feature
>
> Your domain is only set up with a temporary page. Start a site now to use all of WordPress.com's features.

Also changes the button label "Create New Site" to "Create site", and the "Advanced" button label to "Manage Domain", in the default domain screen and on the feature gate screen.

#### Testing instructions
  
1. Run `git checkout update/domain-only-site-copy` and start your server, or open a [live branch](https://calypso.live/?branch=update/domain-only-site-copy)
2. Select a domain-only site.
2. Hit the 'Write' button in the masterbar.
3. Check that you see the notice mentioned above.
  
#### Reviews
  
- [x] Code
- [x] Product
