### PR TITLE
A11y: updated CSS color text variables

### DIFF
--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -9,7 +9,10 @@ $gray:                   #87a6bc;
 $gray-light:             lighten( $gray, 33% ); //#f3f6f8
 $gray-dark:              darken( $gray, 38% ); //#2e4453
 
-$gray-text:              darken( $gray, 18% ); //#537994
+// $gray-text: ideal for standard, non placeholder text
+// $gray-text-min: minimum contrast needed for WCAG 2.0 AA on white background
+$gray-text:              $gray-dark;
+$gray-text-min:          darken( $gray, 18% ); //#537994
 
 // $gray color functions:
 // lighten( $gray, 10% )

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -64,7 +64,7 @@ button {
 	}
 	&.is-compact {
 		padding: 7px;
-		color: $gray-text;
+		color: $gray-text-min;
 		font-size: 11px;
 		line-height: 1;
 		text-transform: uppercase;
@@ -164,7 +164,7 @@ button {
 .button.is-borderless {
 	border: none;
 	background: none;
-	color: $gray-text;
+	color: $gray-text-min;
 	padding-left: 0;
 	padding-right: 0;
 	border-radius: 0;

--- a/client/components/count/style.scss
+++ b/client/components/count/style.scss
@@ -6,6 +6,6 @@
 	font-size: 11px;
 	font-weight: 600;
 	line-height: 14px;
-	color: $gray-text;
+	color: $gray-text-min;
 	text-align: center;
 }

--- a/client/components/forms/form-setting-explanation/style.scss
+++ b/client/components/forms/form-setting-explanation/style.scss
@@ -1,5 +1,5 @@
 .form-setting-explanation {
-	color: $gray-text;
+	color: $gray-text-min;
 	display: block;
 	font-size: 13px;
 	font-style: italic;

--- a/client/components/segmented-control/style.scss
+++ b/client/components/segmented-control/style.scss
@@ -43,7 +43,7 @@
 	border-right: none;
 	font-size: 14px;
 	line-height: 18px;
-	color: $gray-text;
+	color: $gray-text-min;
 	text-align: center;
 
 	&:focus {

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -90,7 +90,7 @@ $compact-header-height: 35;
 	.is-compact & {
 		height: #{$compact-header-height }px;
 		line-height: #{$compact-header-height - 3 }px;
-		color: $gray-text;
+		color: $gray-text-min;
 		font-size: 11px;
 		text-transform: uppercase;
 

--- a/client/components/version/style.scss
+++ b/client/components/version/style.scss
@@ -1,7 +1,7 @@
 .version {
 	text-transform: uppercase;
 	font-size: 11px;
-	color: $gray-text;
+	color: $gray-text-min;
 	line-height: 18px;
 	@include clear-fix;
 

--- a/client/components/vertical-menu/style.scss
+++ b/client/components/vertical-menu/style.scss
@@ -11,7 +11,7 @@
 
 	border-top: 1px solid lighten( $gray, 20% );
 	border-left: 3px solid transparent;
-	color: $gray-text;
+	color: $gray-text-min;
 	font-size: 13px;
 	font-weight: 200;
 

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -68,7 +68,7 @@
 		font-size: 13px;
 		font-style: italic;
 		font-weight: 400;
-		color: $gray-text;
+		color: $gray-text-min;
 		&.is-indented {
 			margin-left: 24px;
 		}


### PR DESCRIPTION
![screen shot 2017-02-13 at 11 04 30](https://cloud.githubusercontent.com/assets/4389/22880961/378752a6-f1dc-11e6-8c02-9f738f1881fc.png)

This PR introduces a slight variation from #9342:

* `$gray-text` is a sematically accurate alias of `$gray-dark` to be used on main text wherever possible
* `$gray-text` is renamed `$gray-text-min`, as it's the minimum WCAG 2.0 AA accessible text on white background

This PR also renames the only previously used instance of the `$gray-text` var. Visually there's no change anywhere in the UI yet.