### PR TITLE
Banner: Updated the broken title

### DIFF
--- a/client/components/banner/docs/example.jsx
+++ b/client/components/banner/docs/example.jsx
@@ -57,4 +57,6 @@ const BannerExample = () =>
 		/>
 	</div>;
 
+BannerExample.displayName = 'Banner';
+
 export default BannerExample;


### PR DESCRIPTION
The banner component title is “u” and this is to change it to “Banner.”

Before:
<img width="466" alt="screen shot 2017-02-13 at 12 49 08 pm" src="https://cloud.githubusercontent.com/assets/22752103/22882346/ec6dfbd0-f1ea-11e6-9836-9c2e6b29b5a4.png">

After:
<img width="479" alt="screen shot 2017-02-13 at 12 48 34 pm" src="https://cloud.githubusercontent.com/assets/22752103/22882351/f2563544-f1ea-11e6-8acf-be3e17e6de80.png">
