### PR TITLE
ReaderPostCard: added missing title to devdocs example

### DIFF
--- a/client/blocks/reader-post-card/docs/example.jsx
+++ b/client/blocks/reader-post-card/docs/example.jsx
@@ -146,4 +146,6 @@ const ReaderPostCard = () => (
 	</div>
 );
 
+ReaderPostCard.displayName = 'ReaderPostCard';
+
 export default ReaderPostCard;


### PR DESCRIPTION
The title for ReaderPostCard in the examples was `c`. It seems to work locally before my changes, but the live version doesn't. I think this is caused by missing `displayName`.

Before:
![image](https://cloud.githubusercontent.com/assets/1123119/22882506/ae8950e8-f1eb-11e6-8338-2c0e78aa42e4.png)

After:
![image](https://cloud.githubusercontent.com/assets/1123119/22882639/63324888-f1ec-11e6-9b5a-d15ebc5a0108.png)
