### PR TITLE
Themes: Add functionality to query from WP.org

### DIFF
--- a/client/components/data/query-themes/index.jsx
+++ b/client/components/data/query-themes/index.jsx
@@ -15,7 +15,7 @@ class QueryThemes extends Component {
 	static propTypes = {
 		siteId: PropTypes.oneOfType( [
 			PropTypes.number,
-			PropTypes.oneOf( [ 'wpcom' ] )
+			PropTypes.oneOf( [ 'wpcom', 'wporg' ] )
 		] ).isRequired,
 		// A theme query. Note that on Jetpack sites, only the `search` argument is supported.
 		query: PropTypes.shape( {

--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -104,46 +104,26 @@ module.exports = {
 	 * Otherwise, will return a promise.
 	 *
 	 * @param {string}     themeId  The theme identifier.
-	 * @param {function}   callback Callback that gets executed after the XHR returns the results.
-	 * @returns {?Promise} Promise  that is returned if no callback parameter is passed
+	 * @returns {Promise.<Object>}  A promise that returns a `theme` object
 	 */
-	fetchThemeInformation: function( themeId, callback ) {
+	fetchThemeInformation: function( themeId ) {
 		const query = { action: 'theme_information', 'request[slug]': themeId };
-		// if callback is provided, behave traditionally
-		if ( 'function' === typeof callback ) {
-			return superagent
-				.get( _WPORG_THEMES_ENDPOINT )
-				.set( 'Accept', 'application/json' )
-				.query( query )
-				.end( ( err, { body } ) => {
-					callback( err, body );
-				} );
-		}
-
-		// otherwise, return a Promise
-		return new Promise( ( resolve, reject ) => {
-			return superagent
-				.get( _WPORG_THEMES_ENDPOINT )
-				.set( 'Accept', 'application/json' )
-				.query( query )
-				.end( ( err, { body } ) => {
-					err ? reject( err ) : resolve( body );
-				} );
-		} );
+		return superagent
+			.get( _WPORG_THEMES_ENDPOINT )
+			.set( 'Accept', 'application/json' )
+			.query( query )
+			.then( ( { body } ) => ( body ) );
 	},
 	/**
 	 * Get information about a given theme from the WordPress.org API.
-	 * If provided with a callback, will call that on succes with an object with theme details.
-	 * Otherwise, will return a promise.
 	 *
 	 * @param  {Object}        options         Theme query
 	 * @param  {String}        options.search  Search string
 	 * @param  {Number}        options.number  How many themes to return per page
 	 * @param  {Number}        options.page    Which page of matching themes to return
-	 * @param  {function}      callback        Callback that gets executed after the XHR returns the results.
-	 * @returns {?Promise}                     Promise that is returned if no callback parameter is passed
+	 * @returns {Promise.<Object>}             A promise that returns an object containing a `themes` array and an `info` object
 	 */
-	fetchThemesList: function( options = {}, callback ) {
+	fetchThemesList: function( options = {} ) {
 		const { search, page, number } = options;
 		const query = {
 			action: 'query_themes',
@@ -151,26 +131,11 @@ module.exports = {
 			'request[page]': page,
 			'request[per_page]:': number
 		};
-		// if callback is provided, behave traditionally
-		if ( 'function' === typeof callback ) {
-			return superagent
-				.get( _WPORG_THEMES_ENDPOINT )
-				.set( 'Accept', 'application/json' )
-				.query( query )
-				.end( ( err, { body } ) => {
-					callback( err, body );
-				} );
-		}
 
-		// otherwise, return a Promise
-		return new Promise( ( resolve, reject ) => {
-			return superagent
-				.get( _WPORG_THEMES_ENDPOINT )
-				.set( 'Accept', 'application/json' )
-				.query( query )
-				.end( ( err, { body } ) => {
-					err ? reject( err ) : resolve( body );
-				} );
-		} );
+		return superagent
+			.get( _WPORG_THEMES_ENDPOINT )
+			.set( 'Accept', 'application/json' )
+			.query( query )
+			.then( ( { body } ) => ( body ) );
 	},
 };

--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -22,6 +22,8 @@ var _WPORG_PLUGINS_LIST = 'https://api.wordpress.org/plugins/info/1.1/?action=qu
 	_DEFAULT_CATEGORY = 'all',
 	_DEFAULT_FIRST_PAGE = 1;
 
+const _WPORG_THEMES_ENDPOINT = 'https://api.wordpress.org/themes/info/1.1/';
+
 function getWporgLocaleCode( ) {
 	var currentLocaleCode,
 		wpOrgLocaleCode;
@@ -106,12 +108,11 @@ module.exports = {
 	 * @returns {?Promise} Promise  that is returned if no callback parameter is passed
 	 */
 	fetchThemeInformation: function( themeId, callback ) {
-		const url = 'https://api.wordpress.org/themes/info/1.1/';
 		const query = { action: 'theme_information', 'request[slug]': themeId };
 		// if callback is provided, behave traditionally
 		if ( 'function' === typeof callback ) {
 			return superagent
-				.get( url )
+				.get( _WPORG_THEMES_ENDPOINT )
 				.set( 'Accept', 'application/json' )
 				.query( query )
 				.end( ( err, { body } ) => {
@@ -122,7 +123,49 @@ module.exports = {
 		// otherwise, return a Promise
 		return new Promise( ( resolve, reject ) => {
 			return superagent
-				.get( url )
+				.get( _WPORG_THEMES_ENDPOINT )
+				.set( 'Accept', 'application/json' )
+				.query( query )
+				.end( ( err, { body } ) => {
+					err ? reject( err ) : resolve( body );
+				} );
+		} );
+	},
+	/**
+	 * Get information about a given theme from the WordPress.org API.
+	 * If provided with a callback, will call that on succes with an object with theme details.
+	 * Otherwise, will return a promise.
+	 *
+	 * @param  {Object}        options         Theme query
+	 * @param  {String}        options.search  Search string
+	 * @param  {Number}        options.number  How many themes to return per page
+	 * @param  {Number}        options.page    Which page of matching themes to return
+	 * @param  {function}      callback        Callback that gets executed after the XHR returns the results.
+	 * @returns {?Promise}                     Promise that is returned if no callback parameter is passed
+	 */
+	fetchThemesList: function( options = {}, callback ) {
+		const { search, page, number } = options;
+		const query = {
+			action: 'query_themes',
+			'request[search]': search,
+			'request[page]': page,
+			'request[per_page]:': number
+		};
+		// if callback is provided, behave traditionally
+		if ( 'function' === typeof callback ) {
+			return superagent
+				.get( _WPORG_THEMES_ENDPOINT )
+				.set( 'Accept', 'application/json' )
+				.query( query )
+				.end( ( err, { body } ) => {
+					callback( err, body );
+				} );
+		}
+
+		// otherwise, return a Promise
+		return new Promise( ( resolve, reject ) => {
+			return superagent
+				.get( _WPORG_THEMES_ENDPOINT )
 				.set( 'Accept', 'application/json' )
 				.query( query )
 				.end( ( err, { body } ) => {

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -121,7 +121,7 @@ const ConnectedSingleSiteJetpack = connectOptions(
 									return getScreenshotOption( theme ).label;
 								} }
 								trackScrollPage={ props.trackScrollPage }
-								queryWpcom={ true }
+								source="wpcom"
 							/>
 						</div>
 					}

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -181,7 +181,7 @@ const ConnectedThemesSelection = connect(
 		// results and sends all of the themes at once. QueryManager is not expecting such behaviour
 		// and we ended up loosing all of the themes above number 20. Real solution will be pagination on
 		// Jetpack themes endpoint.
-		const number = isJetpack && ! includes( [ 'wpcom', 'wporg' ], source ) ? 2000 : 20;
+		const number = ! includes( [ 'wpcom', 'wporg' ], source ) ? 2000 : 20;
 		const query = {
 			search,
 			page,

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -3,7 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { compact, isEqual, omit, property, snakeCase } from 'lodash';
+import { compact, includes, isEqual, omit, property, snakeCase } from 'lodash';
 
 /**
  * Internal dependencies
@@ -168,15 +168,20 @@ const ThemesSelection = React.createClass( {
 } );
 
 const ConnectedThemesSelection = connect(
-	( state, { filter, page, search, tier, vertical, siteId, queryWpcom } ) => {
+	( state, { filter, page, search, tier, vertical, siteId, source } ) => {
 		const isJetpack = isJetpackSite( state, siteId );
-		const siteIdOrWpcom = ( siteId && isJetpack && ! ( queryWpcom === true ) ) ? siteId : 'wpcom';
+		let siteIdOrWpcom;
+		if ( source === 'wpcom' || source === 'wporg' ) {
+			siteIdOrWpcom = source;
+		} else {
+			siteIdOrWpcom = ( siteId && isJetpack ) ? siteId : 'wpcom';
+		}
 
 		// number calculation is just a hack for Jetpack sites. Jetpack themes endpoint does not paginate the
 		// results and sends all of the themes at once. QueryManager is not expecting such behaviour
 		// and we ended up loosing all of the themes above number 20. Real solution will be pagination on
 		// Jetpack themes endpoint.
-		const number = isJetpack && ! ( queryWpcom === true ) ? 2000 : 20;
+		const number = isJetpack && ! includes( [ 'wpcom', 'wporg' ], source ) ? 2000 : 20;
 		const query = {
 			search,
 			page,

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -39,9 +39,9 @@ const ThemesSelection = React.createClass( {
 		incrementPage: PropTypes.func,
 		resetPage: PropTypes.func,
 		// connected props
-		siteIdOrWpcom: PropTypes.oneOfType( [
+		source: PropTypes.oneOfType( [
 			PropTypes.number,
-			PropTypes.oneOf( [ 'wpcom' ] )
+			PropTypes.oneOf( [ 'wpcom', 'wporg' ] )
 		] ),
 		themes: PropTypes.array,
 		themesCount: PropTypes.number,
@@ -138,13 +138,13 @@ const ThemesSelection = React.createClass( {
 	},
 
 	render() {
-		const { siteIdOrWpcom, query, listLabel, themesCount } = this.props;
+		const { source, query, listLabel, themesCount } = this.props;
 
 		return (
 			<div className="themes__selection">
 				<QueryThemes
 					query={ query }
-					siteId={ siteIdOrWpcom } />
+					siteId={ source } />
 				<ThemesSelectionHeader
 					label={ listLabel }
 					count={ themesCount }
@@ -170,11 +170,11 @@ const ThemesSelection = React.createClass( {
 const ConnectedThemesSelection = connect(
 	( state, { filter, page, search, tier, vertical, siteId, source } ) => {
 		const isJetpack = isJetpackSite( state, siteId );
-		let siteIdOrWpcom;
+		let sourceSiteId;
 		if ( source === 'wpcom' || source === 'wporg' ) {
-			siteIdOrWpcom = source;
+			sourceSiteId = source;
 		} else {
-			siteIdOrWpcom = ( siteId && isJetpack ) ? siteId : 'wpcom';
+			sourceSiteId = ( siteId && isJetpack ) ? siteId : 'wpcom';
 		}
 
 		// number calculation is just a hack for Jetpack sites. Jetpack themes endpoint does not paginate the
@@ -192,12 +192,12 @@ const ConnectedThemesSelection = connect(
 
 		return {
 			query,
-			siteIdOrWpcom,
+			source: sourceSiteId,
 			siteSlug: getSiteSlug( state, siteId ),
-			themes: getThemesForQueryIgnoringPage( state, siteIdOrWpcom, query ) || [],
-			themesCount: getThemesFoundForQuery( state, siteIdOrWpcom, query ),
-			isRequesting: isRequestingThemesForQuery( state, siteIdOrWpcom, query ),
-			isLastPage: isThemesLastPageForQuery( state, siteIdOrWpcom, query ),
+			themes: getThemesForQueryIgnoringPage( state, sourceSiteId, query ) || [],
+			themesCount: getThemesFoundForQuery( state, sourceSiteId, query ),
+			isRequesting: isRequestingThemesForQuery( state, sourceSiteId, query ),
+			isLastPage: isThemesLastPageForQuery( state, sourceSiteId, query ),
 			isLoggedIn: !! getCurrentUserId( state ),
 			isThemeActive: themeId => isThemeActive( state, themeId, siteId ),
 			isInstallingTheme: themeId => isInstallingTheme( state, themeId, siteId ),

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -116,9 +116,15 @@ export function receiveThemes( themes, siteId ) {
 /**
  * Triggers a network request to fetch themes for the specified site and query.
  *
- * @param  {Number|String} siteId Jetpack site ID or 'wpcom' for any WPCOM site
- * @param  {String}        query  Theme query
- * @return {Function}             Action thunk
+ * @param  {Number|String} siteId        Jetpack site ID or 'wpcom' for any WPCOM site
+ * @param  {Object}        query         Theme query
+ * @param  {String}        query.search  Search string
+ * @param  {String}        query.tier    Theme tier: 'free', 'premium', or '' (either)
+ * @param  {String}        query.filter  Filter
+ * @param  {Number}        query.number  How many themes to return per page
+ * @param  {Number}        query.offset  At which item to start the set of returned themes
+ * @param  {Number}        query.page    Which page of matching themes to return
+ * @return {Function}                    Action thunk
  */
 export function requestThemes( siteId, query = {} ) {
 	return ( dispatch, getState ) => {

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -102,45 +102,26 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestThemes()', () => {
-		useNock( ( nock ) => {
-			nock( 'https://public-api.wordpress.com:443' )
-				.persist()
-				.get( '/rest/v1.2/themes' )
-				.reply( 200, {
-					found: 2,
-					themes: [
-						{ ID: 'twentysixteen', name: 'Twenty Sixteen' },
-						{ ID: 'mood', name: 'Mood' }
-					]
-				} )
-				.get( '/rest/v1.2/themes' )
-				.query( { search: 'Sixteen' } )
-				.reply( 200, {
-					found: 1,
-					themes: [ { ID: 'twentysixteen', name: 'Twenty Sixteen' } ]
-				} )
-				.get( '/rest/v1/sites/77203074/themes' )
-				.reply( 200, {
-					// The endpoint doesn't return `found` for Jetpack sites
-					themes: [
-						{ ID: 'twentyfifteen', name: 'Twenty Fifteen' },
-						{ ID: 'twentysixteen', name: 'Twenty Sixteen' }
-					]
-				} )
-				.get( '/rest/v1/sites/77203074/themes' )
-				.query( { search: 'Sixteen' } )
-				.reply( 200, {
-					// The endpoint doesn't return `found` for Jetpack sites
-					themes: [ { ID: 'twentysixteen', name: 'Twenty Sixteen' } ]
-				} )
-				.get( '/rest/v1/sites/1916284/themes' )
-				.reply( 403, {
-					error: 'authorization_required',
-					message: 'User cannot access this private blog.'
-				} );
-		} );
-
 		context( 'with a wpcom site', () => {
+			useNock( ( nock ) => {
+				nock( 'https://public-api.wordpress.com:443' )
+					.persist()
+					.get( '/rest/v1.2/themes' )
+					.reply( 200, {
+						found: 2,
+						themes: [
+							{ ID: 'twentysixteen', name: 'Twenty Sixteen' },
+							{ ID: 'mood', name: 'Mood' }
+						]
+					} )
+					.get( '/rest/v1.2/themes' )
+					.query( { search: 'Sixteen' } )
+					.reply( 200, {
+						found: 1,
+						themes: [ { ID: 'twentysixteen', name: 'Twenty Sixteen' } ]
+					} );
+			} );
+
 			it( 'should dispatch fetch action when thunk triggered', () => {
 				requestThemes( 'wpcom' )( spy );
 
@@ -195,6 +176,30 @@ describe( 'actions', () => {
 		} );
 
 		context( 'with a Jetpack site', () => {
+			useNock( ( nock ) => {
+				nock( 'https://public-api.wordpress.com:443' )
+					.persist()
+					.get( '/rest/v1/sites/77203074/themes' )
+					.reply( 200, {
+						// The endpoint doesn't return `found` for Jetpack sites
+						themes: [
+							{ ID: 'twentyfifteen', name: 'Twenty Fifteen' },
+							{ ID: 'twentysixteen', name: 'Twenty Sixteen' }
+						]
+					} )
+					.get( '/rest/v1/sites/77203074/themes' )
+					.query( { search: 'Sixteen' } )
+					.reply( 200, {
+						// The endpoint doesn't return `found` for Jetpack sites
+						themes: [ { ID: 'twentysixteen', name: 'Twenty Sixteen' } ]
+					} )
+					.get( '/rest/v1/sites/1916284/themes' )
+					.reply( 403, {
+						error: 'authorization_required',
+						message: 'User cannot access this private blog.'
+					} );
+			} );
+
 			const fakeGetState = () => ( {
 				sites: {
 					items: {
@@ -264,6 +269,89 @@ describe( 'actions', () => {
 						siteId: 1916284,
 						query: {},
 						error: sinon.match( { message: 'User cannot access this private blog.' } )
+					} );
+				} );
+			} );
+		} );
+
+		context( 'with the WP.org API', () => {
+			useNock( ( nock ) => {
+				nock( 'https://api.wordpress.org' )
+					.persist()
+					.defaultReplyHeaders( {
+						'Content-Type': 'application/json'
+					} )
+					.get( '/themes/info/1.1/?action=query_themes' )
+					.reply( 200, {
+						info: { page: 1, pages: 123, results: 2452 },
+						themes: [
+							{ slug: 'bizprime', name: 'bizprime' },
+							{ slug: 'shapely', name: 'Shapely' },
+							{ slug: 'cassions', name: 'Cassions' },
+							{ slug: 'intentionally-blank', name: 'Intentionally Blank' }
+						]
+					} )
+					.get( '/themes/info/1.1/?action=query_themes&request%5Bsearch%5D=Sixteen' )
+					.reply( 200, {
+						info: { page: 1, pages: 1, results: 1 },
+						themes: [
+							{ slug: 'twentysixteen', name: 'Twenty Sixteen' }
+						]
+					} );
+			} );
+
+			it( 'should dispatch fetch action when thunk triggered', () => {
+				requestThemes( 'wporg' )( spy );
+
+				expect( spy ).to.have.been.calledWith( {
+					type: THEMES_REQUEST,
+					siteId: 'wporg',
+					query: {}
+				} );
+			} );
+
+			it( 'should dispatch themes receive action when request completes', () => {
+				return requestThemes( 'wporg' )( spy ).then( () => {
+					expect( spy ).to.have.been.calledWith( {
+						type: THEMES_RECEIVE,
+						themes: [
+							{ id: 'bizprime', name: 'bizprime' },
+							{ id: 'shapely', name: 'Shapely' },
+							{ id: 'cassions', name: 'Cassions' },
+							{ id: 'intentionally-blank', name: 'Intentionally Blank' }
+						],
+						siteId: 'wporg'
+					} );
+				} );
+			} );
+
+			it( 'should dispatch themes request success action when request completes', () => {
+				return requestThemes( 'wporg' )( spy ).then( () => {
+					expect( spy ).to.have.been.calledWith( {
+						type: THEMES_REQUEST_SUCCESS,
+						siteId: 'wporg',
+						query: {},
+						found: 2452,
+						themes: [
+							{ id: 'bizprime', name: 'bizprime' },
+							{ id: 'shapely', name: 'Shapely' },
+							{ id: 'cassions', name: 'Cassions' },
+							{ id: 'intentionally-blank', name: 'Intentionally Blank' }
+						]
+					} );
+				} );
+			} );
+
+			it( 'should dispatch themes request success action with query results', () => {
+				return requestThemes( 'wporg', { search: 'Sixteen' } )( spy ).then( () => {
+					expect( spy ).to.have.been.calledWith( {
+						type: THEMES_REQUEST_SUCCESS,
+						siteId: 'wporg',
+						query: { search: 'Sixteen' },
+						found: 1,
+						themes: [
+							{ id: 'twentysixteen', name: 'Twenty Sixteen' },
+						]
 					} );
 				} );
 			} );


### PR DESCRIPTION
This is a PoC to demonstrate that with the new Redux arch, we can relatively simply add functionality to fetch themes from WP.org.

This PR:
* Adds a new `fetchThemesList` function to `lib/wporg`
* Adds a conditional branch for fetching from WP.org to `requestThemes`
* Changes `ThemesSelection`'s `queryWpcom` flag to a more generic `source` one.

The PR's scope isn't feature-completeness for WP.org themes, but adding those new functions and covering them with unit tests for later use.

To test:
* Check that the theme showcase still works as before (try different modes and some random actions).
* Apply the following patch. Then, check the theme showcase's Jetpack single-site mode. The bottom list should now contain themes fetched from WP.org instead of WP.com. Querying for search strings should work, other stuff (theme activation) maybe not.

```diff
diff --git a/client/my-sites/themes/single-site-jetpack.jsx b/client/my-sites/themes/single-site-jetpack.jsx
index 18818ed..6b1a63b 100644
--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -119,7 +119,7 @@ const ConnectedSingleSiteJetpack = connectOptions(
                                                                        return getScreenshotOption( theme ).label;
                                                                } }
                                                                trackScrollPage={ props.trackScrollPage }
-                                                               source="wpcom"
+                                                               source="wporg"
                                                        />
                                                </div>
                                        }
``` 

One quick fix to make this available in the UI would be to add a WP.com/WP.org dropdown (or `ButtonGroup`) to the JP single-site mode's search field (much like we have for All/Premium/Free elsewhere) cc @folletto 
