### PR TITLE
Signup: Check all Signup flows for a valid configuration

### DIFF
--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -15,9 +15,7 @@ var debug = require( 'debug' )( 'calypso:signup:flow-controller' ), // eslint-di
 	filter = require( 'lodash/filter' ),
 	find = require( 'lodash/find' ),
 	pick = require( 'lodash/pick' ),
-	keys = require( 'lodash/keys' ),
-	page = require( 'page' );
-
+	keys = require( 'lodash/keys' );
 /**
  * Internal dependencies
  */
@@ -27,8 +25,7 @@ var SignupActions = require( './actions' ),
 	flows = require( 'signup/config/flows' ),
 	steps = require( 'signup/config/steps' ),
 	wpcom = require( 'lib/wp' ),
-	user = require( 'lib/user' )(),
-	utils = require( 'signup/utils' );
+	user = require( 'lib/user' )();
 
 /**
  * Constants
@@ -101,12 +98,6 @@ assign( SignupFlowController.prototype, {
 			const dependenciesFound = pick( SignupDependencyStore.get(), step.dependencies );
 			const dependenciesNotProvided = difference( step.dependencies, keys( dependenciesFound ), this._getFlowProvidesDependencies() );
 			if ( ! isEmpty( dependenciesNotProvided ) ) {
-
-				if ( this._flowName !== flows.defaultFlowName ) {
-					// redirect to the default signup flow, hopefully it will be valid
-					page( utils.getStepUrl() );
-				}
-
 				throw new Error( 'The ' + step.stepName + ' step requires dependencies [' + dependenciesNotProvided + '] which ' +
 				'are not provided in the ' + this._flowName + ' flow and are not already present in the store.' );
 			}

--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -22,10 +22,11 @@ var debug = require( 'debug' )( 'calypso:signup:flow-controller' ), // eslint-di
 var SignupActions = require( './actions' ),
 	SignupProgressStore = require( './progress-store' ),
 	SignupDependencyStore = require( './dependency-store' ),
-	flows = require( 'signup/config/flows' ),
 	steps = require( 'signup/config/steps' ),
 	wpcom = require( 'lib/wp' ),
 	user = require( 'lib/user' )();
+
+import flows from 'signup/config/flows';
 
 /**
  * Constants

--- a/client/signup/README.md
+++ b/client/signup/README.md
@@ -8,7 +8,7 @@ A Step is a React component that collects data for flows.
 
 ## Creating a new flow
 
-You can define a new flow from `/client/signup/config/flows.js`, by adding a new property to the `flows` object.
+You can define a new flow from `/client/signup/config/flows-configuration.js`, by adding a new property to the `flows` object.
 
 A flow is defined by two properties, `steps` and `destination`:
 
@@ -24,7 +24,7 @@ Example:
 account: { steps: [ 'site', 'user' ], destination: '/me/next?welcome' }
 ```
 
-Once you've added the flow to `flows.js`, it'll be available for users at `/start/flow-name` where `flow-name` is the key of your flow in `flows`.
+Once you've added the flow to `flows-configuration.js`, it'll be available for users at `/start/flow-name` where `flow-name` is the key of your flow in `flows`.
 
 *Note:* flows must include at least one step that creates a user and is able to provide a bearer token. See the `providesToken` property in "Creating a new step".
 
@@ -34,7 +34,7 @@ Anyone can create steps that flow designers can use in their flows.
 
 You can add a new step to Modular Signup from `/client/signup/config/steps.js`. A step is defined by three properties:
 
-- `stepName` is the identifier used to reference a step in `/client/signup/config/flows.js`.
+- `stepName` is the identifier used to reference a step in `/client/signup/config/flows-configuration.js`.
 - (optional) `dependencies`, which specifiy which properties this step needs from other steps in the flow in order to be processed.
 - (optional) `providesDependencies` is an array that lets the signup framework know what dependencies the step is expected to provide. If the step does not provide all of these, or if it provides more than it says, an error will be thrown.
 - (optional) `delayApiRequestUntilComplete` is a boolean that, when true, causes the step's `apiRequestFunction` to be called only after the user has submitted every step in the signup flow. This is useful for steps that the user should be able to go back and change at any point in signup.

--- a/client/signup/config/flows-configuration.js
+++ b/client/signup/config/flows-configuration.js
@@ -230,13 +230,4 @@ if ( config.isEnabled( 'signup/social' ) ) {
 	};
 }
 
-if ( config( 'env' ) === 'development' ) {
-	flows[ 'test-plans' ] = {
-		steps: [ 'site', 'plans', 'user' ],
-		destination: getSiteDestination,
-		description: 'This flow is used to test plans choice in signup',
-		lastModified: '2016-06-30'
-	};
-}
-
 export default flows;

--- a/client/signup/config/flows-configuration.js
+++ b/client/signup/config/flows-configuration.js
@@ -11,14 +11,6 @@ const dependenciesContainCartItem = ( dependencies ) => {
 	return dependencies.cartItem || dependencies.domainItem || dependencies.themeItem;
 };
 
-const getPostsDestination = ( dependencies ) => {
-	if ( dependenciesContainCartItem( dependencies ) ) {
-		return getCheckoutUrl( dependencies );
-	}
-
-	return '/posts/' + dependencies.siteSlug;
-};
-
 const getSiteDestination = ( dependencies ) => {
 	if ( dependenciesContainCartItem( dependencies ) ) {
 		return getCheckoutUrl( dependencies );
@@ -36,6 +28,14 @@ const getSiteDestination = ( dependencies ) => {
 	}
 
 	return protocol + '://' + dependencies.siteSlug;
+};
+
+const getPostsDestination = ( dependencies ) => {
+	if ( dependenciesContainCartItem( dependencies ) ) {
+		return getCheckoutUrl( dependencies );
+	}
+
+	return '/posts/' + dependencies.siteSlug;
 };
 
 const flows = {
@@ -108,14 +108,18 @@ const flows = {
 	website: {
 		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
-		description: 'This flow was originally used for the users who clicked "Create Website" on the two-button homepage. It is now linked to from the default homepage CTA as the main flow was slightly behind given translations.',
+		description: 'This flow was originally used for the users who clicked "Create Website" ' +
+		'on the two-button homepage. It is now linked to from the default homepage CTA as ' +
+		'the main flow was slightly behind given translations.',
 		lastModified: '2016-05-23'
 	},
 
 	blog: {
 		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
-		description: 'This flow was originally used for the users who clicked "Create Blog" on the two-button homepage. It is now used from blog-specific landing pages so that verbiage in survey steps refers to "blog" instead of "website".',
+		description: 'This flow was originally used for the users who clicked "Create Blog" on ' +
+		'the two-button homepage. It is now used from blog-specific landing pages so that ' +
+		'verbiage in survey steps refers to "blog" instead of "website".',
 		lastModified: '2016-05-23'
 	},
 
@@ -138,21 +142,24 @@ const flows = {
 	'delta-discover': {
 		steps: [ 'user' ],
 		destination: '/',
-		description: 'A copy of the `account` flow for the Delta email campaigns. Half of users who go through this flow receive a reader-specific drip email series.',
+		description: 'A copy of the `account` flow for the Delta email campaigns. Half of users who ' +
+		'go through this flow receive a reader-specific drip email series.',
 		lastModified: '2016-05-03'
 	},
 
 	'delta-blog': {
 		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
-		description: 'A copy of the `blog` flow for the Delta email campaigns. Half of users who go through this flow receive a blogging-specific drip email series.',
+		description: 'A copy of the `blog` flow for the Delta email campaigns. Half of users who go ' +
+		'through this flow receive a blogging-specific drip email series.',
 		lastModified: '2016-03-09'
 	},
 
 	'delta-site': {
 		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
-		description: 'A copy of the `website` flow for the Delta email campaigns. Half of users who go through this flow receive a website-specific drip email series.',
+		description: 'A copy of the `website` flow for the Delta email campaigns. Half of users who go ' +
+		'through this flow receive a website-specific drip email series.',
 		lastModified: '2016-03-09'
 	},
 
@@ -199,7 +206,7 @@ const flows = {
 
 if ( config.isEnabled( 'signup/domain-first-flow' ) ) {
 	flows[ 'domain-first' ] = {
-		steps: [ 'domain-only', 'site-or-domain', 'themes', 'plans', 'user' ],
+		steps: [ 'site-or-domain', 'themes', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'An experimental approach for WordPress.com/domains',
 		lastModified: '2017-01-16'
@@ -211,6 +218,24 @@ if ( config.isEnabled( 'signup/domain-first-flow' ) ) {
 		providesDependenciesInQuery: [ 'siteSlug', 'siteId' ],
 		description: 'A flow to test updating an existing site with `Signup`',
 		lastModified: '2017-01-19'
+	};
+}
+
+if ( config.isEnabled( 'signup/social' ) ) {
+	flows.social = {
+		steps: [ 'user-social' ],
+		destination: '/',
+		description: 'Create an account without a blog with social signup enabled.',
+		lastModified: '2017-03-16'
+	};
+}
+
+if ( config( 'env' ) === 'development' ) {
+	flows[ 'test-plans' ] = {
+		steps: [ 'site', 'plans', 'user' ],
+		destination: getSiteDestination,
+		description: 'This flow is used to test plans choice in signup',
+		lastModified: '2016-06-30'
 	};
 }
 

--- a/client/signup/config/flows-configuration.js
+++ b/client/signup/config/flows-configuration.js
@@ -214,13 +214,4 @@ if ( config.isEnabled( 'signup/domain-first-flow' ) ) {
 	};
 }
 
-if ( config( 'env' ) === 'development' ) {
-	flows[ 'test-plans' ] = {
-		steps: [ 'site', 'plans', 'user' ],
-		destination: getSiteDestination,
-		description: 'This flow is used to test plans choice in signup',
-		lastModified: '2016-06-30'
-	};
-}
-
 export default flows;

--- a/client/signup/config/flows-configuration.js
+++ b/client/signup/config/flows-configuration.js
@@ -1,0 +1,226 @@
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+
+const getCheckoutUrl = ( dependencies ) => {
+	return '/checkout/' + dependencies.siteSlug;
+};
+
+const dependenciesContainCartItem = ( dependencies ) => {
+	return dependencies.cartItem || dependencies.domainItem || dependencies.themeItem;
+};
+
+const getPostsDestination = ( dependencies ) => {
+	if ( dependenciesContainCartItem( dependencies ) ) {
+		return getCheckoutUrl( dependencies );
+	}
+
+	return '/posts/' + dependencies.siteSlug;
+};
+
+const getSiteDestination = ( dependencies ) => {
+	if ( dependenciesContainCartItem( dependencies ) ) {
+		return getCheckoutUrl( dependencies );
+	}
+
+	let protocol = 'https';
+
+	/**
+	 * It is possible that non-wordpress.com sites are not HTTPS ready.
+	 *
+	 * Redirect them
+	 */
+	if ( ! dependencies.siteSlug.match( /wordpress\.[a-z]+$/i ) ) {
+		protocol = 'http';
+	}
+
+	return protocol + '://' + dependencies.siteSlug;
+};
+
+const flows = {
+	account: {
+		steps: [ 'user' ],
+		destination: '/',
+		description: 'Create an account without a blog.',
+		lastModified: '2015-07-07'
+	},
+
+	business: {
+		steps: [ 'design-type', 'themes', 'domains', 'user' ],
+		destination: function( dependencies ) {
+			return '/plans/select/business/' + dependencies.siteSlug;
+		},
+		description: 'Create an account and a blog and then add the business plan to the users cart.',
+		lastModified: '2016-06-02',
+		meta: {
+			skipBundlingPlan: true
+		}
+	},
+
+	premium: {
+		steps: [ 'design-type', 'themes', 'domains', 'user' ],
+		destination: function( dependencies ) {
+			return '/plans/select/premium/' + dependencies.siteSlug;
+		},
+		description: 'Create an account and a blog and then add the premium plan to the users cart.',
+		lastModified: '2016-06-02',
+		meta: {
+			skipBundlingPlan: true
+		}
+	},
+
+	free: {
+		steps: [ 'design-type', 'themes', 'domains', 'user' ],
+		destination: getSiteDestination,
+		description: 'Create an account and a blog and default to the free plan.',
+		lastModified: '2016-06-02'
+	},
+
+	'with-theme': {
+		steps: [ 'domains-theme-preselected', 'plans', 'user' ],
+		destination: getSiteDestination,
+		description: 'Preselect a theme to activate/buy from an external source',
+		lastModified: '2016-01-27'
+	},
+
+	subdomain: {
+		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		destination: getSiteDestination,
+		description: 'Provide a vertical for subdomains',
+		lastModified: '2016-10-31'
+	},
+
+	main: {
+		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		destination: getSiteDestination,
+		description: 'The current best performing flow in AB tests',
+		lastModified: '2016-05-23'
+	},
+
+	surveystep: {
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		destination: getSiteDestination,
+		description: 'The current best performing flow in AB tests',
+		lastModified: '2016-05-23'
+	},
+
+	website: {
+		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		destination: getSiteDestination,
+		description: 'This flow was originally used for the users who clicked "Create Website" on the two-button homepage. It is now linked to from the default homepage CTA as the main flow was slightly behind given translations.',
+		lastModified: '2016-05-23'
+	},
+
+	blog: {
+		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		destination: getSiteDestination,
+		description: 'This flow was originally used for the users who clicked "Create Blog" on the two-button homepage. It is now used from blog-specific landing pages so that verbiage in survey steps refers to "blog" instead of "website".',
+		lastModified: '2016-05-23'
+	},
+
+	personal: {
+		steps: [ 'design-type', 'themes', 'domains', 'user' ],
+		destination: function( dependencies ) {
+			return '/plans/select/personal/' + dependencies.siteSlug;
+		},
+		description: 'Create an account and a blog and then add the personal plan to the users cart.',
+		lastModified: '2016-01-21'
+	},
+
+	'test-site': {
+		steps: config( 'env' ) === 'development' ? [ 'site', 'user' ] : [ 'user' ],
+		destination: '/',
+		description: 'This flow is used to test the site step.',
+		lastModified: '2015-09-22'
+	},
+
+	'delta-discover': {
+		steps: [ 'user' ],
+		destination: '/',
+		description: 'A copy of the `account` flow for the Delta email campaigns. Half of users who go through this flow receive a reader-specific drip email series.',
+		lastModified: '2016-05-03'
+	},
+
+	'delta-blog': {
+		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		destination: getSiteDestination,
+		description: 'A copy of the `blog` flow for the Delta email campaigns. Half of users who go through this flow receive a blogging-specific drip email series.',
+		lastModified: '2016-03-09'
+	},
+
+	'delta-site': {
+		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		destination: getSiteDestination,
+		description: 'A copy of the `website` flow for the Delta email campaigns. Half of users who go through this flow receive a website-specific drip email series.',
+		lastModified: '2016-03-09'
+	},
+
+	desktop: {
+		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		destination: getPostsDestination,
+		description: 'Signup flow for desktop app',
+		lastModified: '2016-05-30'
+	},
+
+	developer: {
+		steps: [ 'themes', 'site', 'user' ],
+		destination: '/devdocs/welcome',
+		description: 'Signup flow for developers in developer environment',
+		lastModified: '2015-11-23'
+	},
+
+	pressable: {
+		steps: [ 'design-type-with-store', 'themes', 'domains', 'plans', 'user' ],
+		destination: getSiteDestination,
+		description: 'Signup flow for testing the pressable-store step',
+		lastModified: '2016-06-27'
+	},
+
+	jetpack: {
+		steps: [ 'jetpack-user' ],
+		destination: '/'
+	},
+
+	'get-dot-blog': {
+		steps: [ 'get-dot-blog-themes', 'get-dot-blog-plans' ],
+		destination: getSiteDestination,
+		description: 'Used by `get.blog` users that connect their site to WordPress.com',
+		lastModified: '2016-11-14'
+	},
+
+	'user-first': {
+		steps: [ 'user', 'design-type', 'themes', 'domains', 'plans' ],
+		destination: getSiteDestination,
+		description: 'User-first signup flow',
+		lastModified: '2016-01-18',
+	},
+};
+
+if ( config.isEnabled( 'signup/domain-first-flow' ) ) {
+	flows[ 'domain-first' ] = {
+		steps: [ 'domain-only', 'site-or-domain', 'themes', 'plans', 'user' ],
+		destination: getSiteDestination,
+		description: 'An experimental approach for WordPress.com/domains',
+		lastModified: '2017-01-16'
+	};
+
+	flows[ 'site-selected' ] = {
+		steps: [ 'themes-site-selected', 'plans-site-selected' ],
+		destination: getSiteDestination,
+		providesDependenciesInQuery: [ 'siteSlug', 'siteId' ],
+		description: 'A flow to test updating an existing site with `Signup`',
+		lastModified: '2017-01-19'
+	};
+}
+
+if ( config( 'env' ) === 'development' ) {
+	flows[ 'test-plans' ] = {
+		steps: [ 'site', 'plans', 'user' ],
+		destination: getSiteDestination,
+		description: 'This flow is used to test plans choice in signup',
+		lastModified: '2016-06-30'
+	};
+}
+
+export default flows;

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -44,7 +44,7 @@ class Flows {
 			return;
 		}
 
-		if ( ! includes( flow.steps, 'design-type' ) || 'designTypeWithStore' !== abtest( 'signupStore' ) ) {
+		if ( ! includes( flow.steps, 'design-type' ) ) {
 			return flow;
 		}
 
@@ -63,7 +63,7 @@ class Flows {
 	 * @param {String} flowName The name of the flow
 	 * @returns {String} The flow where the user will be redirected to.
 	 */
-	filterDestination( destination, dependencies, flowName ) {
+	filterDestination( destination /*, dependencies, flowName */ ) {
 		return destination;
 	}
 
@@ -149,7 +149,7 @@ class Flows {
 		 */
 		if ( 'main' === flowName ) {
 			if ( '' === stepName ) {
-				abtest( 'siteTitleStep' );
+				abtest( 'signupSurveyStep' );
 			}
 		}
 	};

--- a/client/signup/config/test/index.js
+++ b/client/signup/config/test/index.js
@@ -1,15 +1,18 @@
 /**
  * External dependencies
  */
+import assert from 'assert';
 import keys from 'lodash/keys';
-import intersection from 'lodash/intersection';
-import isEmpty from 'lodash/isEmpty';
+import { intersection, isEmpty, identity } from 'lodash';
+import { createStore } from 'redux';
 
 /**
  * Internal dependencies
  */
+import useFakeDom from 'test/helpers/use-fake-dom';
 import useFilesystemMocks from 'test/helpers/use-filesystem-mocks';
 import useMockery from 'test/helpers/use-mockery';
+import { reducer } from 'state';
 
 describe( 'index', () => {
 	let flows, steps;
@@ -30,5 +33,68 @@ describe( 'index', () => {
 			throw new Error( 'Step and flow names must be unique. The following names are used as both step and flow names: [' +
 				overlappingNames + '].' );
 		}
+	} );
+} );
+
+describe( 'Signup flows configuration validation', () => {
+	let FlowController, ProgressStore, DependencyStore, Flows, flowControllerInstance;
+
+	useFakeDom();
+
+	useMockery( ( mockery ) => {
+		mockery.registerMock( 'lib/abtest', {
+			abtest: identity,
+			getABTestVariation: identity,
+		} );
+		mockery.registerMock( 'lib/signup/step-actions', {} );
+	} );
+
+	before( () => {
+		ProgressStore = require( 'lib/signup/progress-store' );
+		DependencyStore = require( 'lib/signup/dependency-store' );
+		FlowController = require( 'lib/signup/flow-controller' );
+		Flows = require( 'signup/config/flows' );
+		ProgressStore.reset();
+		const store = createStore( reducer );
+		DependencyStore.setReduxStore( store );
+
+
+		// temporarily instantiate the FlowController with a valid flow
+		flowControllerInstance = FlowController( {
+			flowName: 'account'
+		} );
+	} );
+
+	describe( 'Signup flows configuration validation', () => {
+		it( 'Verifying flows', () => {
+			Object.keys( Flows.getFlows() ).forEach( ( flowName ) => {
+				describe( `Verifying flow "${ flowName }"`, () => {
+					afterEach( function() {
+						flowControllerInstance.reset();
+						DependencyStore.reset();
+						ProgressStore.reset();
+					} );
+
+					it( 'Valid configuration', () => {
+						try {
+							flowControllerInstance = FlowController( {
+								flowName: flowName,
+								onComplete: () => {
+									console.log('Complete flow');
+								}
+							} );
+						} catch ( Exception ) {
+							/**
+							 * We have some steps that require parameters from the HTTP query.
+							 * Since at the moment we can't reliably test those, we silently skip them :)
+							 */
+							if ( ! Exception.message.match( /did not provide the query dependencies/ ) ) {
+								throw Exception;
+							}
+						}
+					} );
+				} );
+			} );
+		} );
 	} );
 } );

--- a/client/signup/config/test/index.js
+++ b/client/signup/config/test/index.js
@@ -13,6 +13,7 @@ import useFakeDom from 'test/helpers/use-fake-dom';
 import useFilesystemMocks from 'test/helpers/use-filesystem-mocks';
 import useMockery from 'test/helpers/use-mockery';
 import { reducer } from 'state';
+import flowsData from 'signup/config/flows-configuration';
 
 describe( 'index', () => {
 	let flows, steps;
@@ -66,33 +67,31 @@ describe( 'Signup flows configuration validation', () => {
 	} );
 
 	describe( 'Signup flows configuration validation', () => {
-		it( 'Verifying flows', () => {
-			Object.keys( Flows.getFlows() ).forEach( ( flowName ) => {
-				describe( `Verifying flow "${ flowName }"`, () => {
-					afterEach( function() {
-						flowControllerInstance.reset();
-						DependencyStore.reset();
-						ProgressStore.reset();
-					} );
+		Object.keys( flowsData ).forEach( ( flowName ) => {
+			describe( `Verifying flow "${ flowName }"`, () => {
+				afterEach( function() {
+					flowControllerInstance.reset();
+					DependencyStore.reset();
+					ProgressStore.reset();
+				} );
 
-					it( 'Valid configuration', () => {
-						try {
-							flowControllerInstance = FlowController( {
-								flowName: flowName,
-								onComplete: () => {
-									console.log('Complete flow');
-								}
-							} );
-						} catch ( Exception ) {
-							/**
-							 * We have some steps that require parameters from the HTTP query.
-							 * Since at the moment we can't reliably test those, we silently skip them :)
-							 */
-							if ( ! Exception.message.match( /did not provide the query dependencies/ ) ) {
-								throw Exception;
+				it( 'Valid configuration', () => {
+					try {
+						flowControllerInstance = FlowController( {
+							flowName: flowName,
+							onComplete: () => {
+								console.log( 'Complete flow' );
 							}
+						} );
+					} catch ( Exception ) {
+						/**
+						 * We have some steps that require parameters from the HTTP query.
+						 * Since at the moment we can't reliably test those, we silently skip them :)
+						 */
+						if ( ! Exception.message.match( /did not provide the query dependencies/ ) ) {
+							throw Exception;
 						}
-					} );
+					}
 				} );
 			} );
 		} );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -139,25 +139,35 @@ const Signup = React.createClass( {
 			providedDependencies = pick( this.props.queryObject, flow.providesDependenciesInQuery );
 		}
 
-		this.signupFlowController = new SignupFlowController( {
-			flowName: this.props.flowName,
-			providedDependencies,
-			reduxStore: this.context.store,
-			onComplete: function( dependencies, destination ) {
-				const timeSinceLoading = this.state.loadingScreenStartTime
-					? Date.now() - this.state.loadingScreenStartTime
-					: undefined;
-				const filteredDestination = utils.getDestination( destination, dependencies, this.props.flowName );
+		try {
+			this.signupFlowController = new SignupFlowController( {
+				flowName: this.props.flowName,
+				providedDependencies,
+				reduxStore: this.context.store,
+				onComplete: function( dependencies, destination ) {
+					const timeSinceLoading = this.state.loadingScreenStartTime
+						? Date.now() - this.state.loadingScreenStartTime
+						: undefined;
+					const filteredDestination = utils.getDestination( destination, dependencies, this.props.flowName );
 
-				if ( timeSinceLoading && timeSinceLoading < MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED ) {
-					return delay(
-						this.handleFlowComplete.bind( this, dependencies, filteredDestination ),
-						MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED - timeSinceLoading
-					);
-				}
-				return this.handleFlowComplete( dependencies, filteredDestination );
-			}.bind( this )
-		} );
+					if ( timeSinceLoading && timeSinceLoading < MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED ) {
+						return delay(
+							this.handleFlowComplete.bind( this, dependencies, filteredDestination ),
+							MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED - timeSinceLoading
+						);
+					}
+					return this.handleFlowComplete( dependencies, filteredDestination );
+				}.bind( this )
+			} );
+		} catch ( Exception ) {
+
+			// TODO fixme!
+
+			if ( this._flowName !== flows.defaultFlowName ) {
+				// redirect to the default signup flow, hopefully it will be valid
+				page( utils.getStepUrl() );
+			}
+		}
 
 		this.loadProgressFromStore();
 

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -12,8 +12,7 @@ import merge from 'lodash/merge';
  */
 import i18nUtils from 'lib/i18n-utils';
 import steps from 'signup/config/steps';
-import flows from 'signup/config/flows';
-import { defaultFlowName } from 'signup/config/flows';
+import flows, { defaultFlowName } from 'signup/config/flows';
 import formState from 'lib/form-state';
 const user = require( 'lib/user' )();
 


### PR DESCRIPTION
This PR introduces basic unit testing for the Signup flows. 

This will help reveal errors in the Signup flows configuration that may appear from time to time and can be a bit obscure if a specific flow isn't covered by the E2E tests.

The PR doesn't cover all possible flow configuration tests and only verifies that the step dependencies, specified in the config, are met. 

There are other tests that can be implemented, to properly test each flow from start to finish, to verify they are working correctly, but it requires improving the Signup framework to allow for proper unit-testing and is out of scope for the moment. 

Since the PR introduces some reorganization in the configuration files it would require testing.

To test:

1. Checkout branch or use Calypso.live link
2. Go through several flows in Signup, e.g. `main`, `premium`, the Jetpack flows, `get.blog` flows
3. Verify Signup is working correctly
4. Verify no errors in JS console