### PR TITLE
Automated Transfer: Fix a logic bug when receiving eligibility responses

### DIFF
--- a/client/state/automated-transfer/reducer.js
+++ b/client/state/automated-transfer/reducer.js
@@ -23,7 +23,7 @@ import {
 } from 'state/action-types';
 
 export const status = ( state = null, action ) => get( {
-	[ ELIGIBILITY_UPDATE ]: action.status,
+	[ ELIGIBILITY_UPDATE ]: state || transferStates.INQUIRING,
 	[ INITIATE ]: transferStates.START,
 	[ INITIATE_FAILURE ]: transferStates.INQUIRING,
 	[ SET_STATUS ]: action.status,

--- a/client/state/automated-transfer/test/reducer.js
+++ b/client/state/automated-transfer/test/reducer.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { status } from '../reducer';
+import { transferStates } from '../constants';
+
+import {
+	AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE as ELIGIBILITY_UPDATE,
+} from 'state/action-types';
+
+describe( 'state', () => {
+	describe( 'automated-transfer', () => {
+		describe( 'reducer', () => {
+			describe( 'eligibility', () => {
+				const update = { type: ELIGIBILITY_UPDATE };
+
+				it( 'should set inquiring status when first polling eligibility',
+					() => expect( status( null, update ) ).to.equal( transferStates.INQUIRING )
+				);
+
+				it( 'should not overwrite the status when a valid state already exists',
+					() => expect( status( transferStates.START, update ) ).to.equal( transferStates.START )
+				);
+			} );
+		} );
+	} );
+} );

--- a/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
@@ -13,7 +13,6 @@ import {
 
 import { updateEligibility } from 'state/automated-transfer/actions';
 import {
-	transferStates,
 	eligibilityHolds,
 } from 'state/automated-transfer/constants';
 
@@ -68,7 +67,6 @@ const eligibilityWarningsFromApi = ( { warnings = {} } ) =>
  */
 const fromApi = data => ( {
 	lastUpdate: Date.now(),
-	status: transferStates.INQUIRING,
 	eligibilityHolds: eligibilityHoldsFromApi( data ),
 	eligibilityWarnings: eligibilityWarningsFromApi( data ),
 } );


### PR DESCRIPTION
Resolves #11378

Previously when initiating an automated tranfser the progress bar would
momentarily appear before disappearing again. The reason for this was
that the reducer for the `status` data was resetting every time we
received a response from the eligibility endpoint.

It had been decided earlier to ignore the `status` value of the
eligibility response due to unclarity in what values could occupy it and
when. Unfortunately when we made that update we decided that any
eligibility response should indicate the `INQUIRING` status. This was
wrong however because the eligibility endpoint polls and would overwrite
a transfer once one began.

Now the reducer will only update on response to the eligibility endpoint
if indeed the `status` was previously unset, preferring the existing
value if one is there.

Tests have been added to confirm this behavior.

**Testing**
Compare against **master**:
 1. Prepare a site for automated transfer
 2. Visit a plugin page
 3. Click on the install button
 4. Observe the progress bar and message

In this branch the message should persist until the process finishes but
in **master** it should appear only for a moment.

**Before**
![plugininstall](https://cloud.githubusercontent.com/assets/5431237/22912904/1d391ab2-f225-11e6-8301-89f23879bd75.gif)

**After**
![properprogressbar](https://cloud.githubusercontent.com/assets/5431237/22912978/79ee411a-f225-11e6-97eb-d565d4ac87dd.gif)
