### PR TITLE
Themes: Install parent theme if required

### DIFF
--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -452,7 +452,7 @@ export function installTheme( themeId, siteId ) {
  * @param {number} siteId site ID
  * @return {function} Action thunk
  */
-function installWpcomParentTheme( themeId, siteId ) {
+export function installWpcomParentTheme( themeId, siteId ) {
 	return ( dispatch, getState ) => {
 		const theme = getTheme( getState(), 'wpcom', themeId.replace( '-wpcom', '' ) );
 		const parentThemeId = theme && theme.template;

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -420,6 +420,10 @@ export function installTheme( themeId, siteId ) {
 			themeId
 		} );
 
+		if ( isThemeFromWpcom( themeId ) ) {
+			dispatch( installWpcomParentTheme( themeId, siteId ) );
+		}
+
 		return wpcom.undocumented().installThemeOnJetpack( siteId, themeId )
 			.then( ( theme ) => {
 				dispatch( receiveTheme( theme, siteId ) );
@@ -437,6 +441,25 @@ export function installTheme( themeId, siteId ) {
 					error
 				} );
 			} );
+	};
+}
+
+/**
+ * Returns an action thunk that will install a wpcom
+ * parent theme if the supplied theme requires one.
+ *
+ * @param {string} themeId child theme ID
+ * @param {number} siteId site ID
+ * @return {function} Action thunk
+ */
+function installWpcomParentTheme( themeId, siteId ) {
+	return ( dispatch, getState ) => {
+		const theme = getTheme( getState(), 'wpcom', themeId.replace( '-wpcom', '' ) );
+		const parentThemeId = theme && theme.template;
+
+		if ( parentThemeId ) {
+			dispatch( installTheme( parentThemeId + '-wpcom', siteId ) );
+		}
 	};
 }
 

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -53,6 +53,7 @@ import {
 	tryAndCustomizeTheme,
 	tryAndCustomize,
 	deleteTheme,
+	installWpcomParentTheme,
 } from '../actions';
 import useNock from 'test/helpers/use-nock';
 import ThemeQueryManager from 'lib/query-manager/theme';
@@ -954,6 +955,38 @@ describe( 'actions', () => {
 					error: sinon.match( { message: 'The theme is already installed' } ),
 				} );
 			} );
+		} );
+	} );
+
+	describe( 'installWpcomParentTheme', () => {
+		const state = {
+			themes: {
+				queries: {
+					wpcom: new ThemeQueryManager( {
+						items: {
+							karuna: {
+								id: 'karuna',
+							},
+							sidekick: {
+								id: 'sidekick',
+								template: 'superhero',
+							},
+						}
+					} )
+				}
+			}
+		};
+
+		it( 'should do nothing for theme with no parent', () => {
+			installWpcomParentTheme( 'karuna-wpcom', 2211667 )( spy, () => state );
+			expect( spy ).to.not.have.been.called;
+		} );
+
+		it( 'should install parent', () => {
+			installWpcomParentTheme( 'sidekick-wpcom', 2211667 )( spy, () => state );
+			expect( spy ).to.have.been.calledWith( matchFunction(
+				installTheme( 'superhero-wpcom', 2211667 )
+			) );
 		} );
 	} );
 


### PR DESCRIPTION
Fixes #11104

Requires D4372-code.

When installing a wpcom theme to a jetpack site, check if the theme requires a parent, and install parent if so.

**To Test**
* Install D4372-code on sandbox and sandbox `public-api.wordpress.com`
* Go to http://calypso.localhost:3000/design/{jetpack site}
* Search for theme 'sidekick'
* Click ... _Activate_
**Expected**
* Theme should activate as normal
* Go to {jetpack site}/wp-admin and check that the parent theme, _Superhero_, was also installed


