### PR TITLE
Build: Minify bundles in parallel

### DIFF
--- a/server/bundler/bin/bundler.js
+++ b/server/bundler/bin/bundler.js
@@ -6,7 +6,9 @@
 var webpack = require( 'webpack' ),
 	cp = require( 'child_process' ),
 	fs = require( 'fs' ),
-	path = require( 'path' );
+	path = require( 'path' ),
+	async = require( 'async' ),
+	os = require( 'os' );
 
 /**
  * Internal dependencies
@@ -33,7 +35,9 @@ outputOptions = {
 };
 
 function minify( files ) {
-	files.forEach( function( file ) {
+	const startMinify = Date.now();
+
+	function minifyFile( file, callback ) {
 		var child;
 
 		if ( /\.map$/.test( file ) ) {
@@ -42,24 +46,40 @@ function minify( files ) {
 
 		console.log( '  minifying ' + file );
 
-		child = cp.spawnSync(
+		const startFile = Date.now();
+
+		child = cp.spawn(
 			path.join( 'node_modules', '.bin', 'uglifyjs' ),
 			[
 				file,
 				'-m',
 				'-c',
 				'-o', file.replace( '.js', '.m.js' )
-			]
+			],
+			// have to pipe stderr to parent, otherwise large bundles will never finish
+			// see https://github.com/nodejs/node-v0.x-archive/issues/6764
+			{ stdio: ['ignore', 'pipe', 'ignore'] }
 		);
 
-		if ( child.status != 0 ) {
-			console.error( '  error minifying ' + file );
-			console.dir( child );
-		}
-	} );
+		child.on( 'exit', function( code ) {
+			if ( code ) {
+				console.error( '!!error minifying %s', file );
+			}
 
-	console.log( 'Minification of all bundles completed.' );
-	console.log( 'Total build time: ' + ( new Date().getTime() - start ) + 'ms' );
+			callback( code );
+		} );
+	}
+
+	function done( err ) {
+		if ( err ) {
+			console.error( 'Error minifying files', err );
+		}
+		console.log( 'Minification of all bundles completed. (%dms)', Date.now() - startMinify );
+		console.log( 'Total build time: ' + ( new Date().getTime() - start ) + 'ms' );
+	}
+
+	// run one minifier per cpu core
+	async.eachLimit( files, os.cpus().length, minifyFile, done )
 }
 
 Error.stackTrackLimit = 30;
@@ -91,10 +111,13 @@ webpack( webpackConfig, function( error, stats ) {
 
 	fs.writeFileSync( path.join( __dirname, '..', 'assets-' + CALYPSO_ENV + '.json' ), JSON.stringify( assets, null, '\t' ) );
 
-	files = assets.map( function( chunk ) {
+	// sort by size to make parallel minification go a bit quicker. don't get stuck doing the big stuff last.
+	files = assets.sort( function( a, b ) {
+		return b.size - a.size;
+	} ).map( function( chunk ) {
 		return path.join( process.cwd(), 'public', chunk.file );
 	} );
-	files.push( path.join( process.cwd(), 'public', 'vendor.' + bundleEnv + '.js' ) );
+	files.unshift( path.join( process.cwd(), 'public', 'vendor.' + bundleEnv + '.js' ) );
 
 	minify( files );
 });

--- a/server/bundler/bin/bundler.js
+++ b/server/bundler/bin/bundler.js
@@ -20,8 +20,7 @@ var webpackConfig = require( process.cwd() + '/webpack.config' ),
 /**
  * Variables
  */
-var _children = [],
-	start = new Date().getTime(),
+var start = new Date().getTime(),
 	CALYPSO_ENV = process.env.CALYPSO_ENV || 'development',
 	bundleEnv = config( 'env' ),
 	outputOptions;
@@ -45,8 +44,6 @@ function minify( files ) {
 		}
 
 		console.log( '  minifying ' + file );
-
-		const startFile = Date.now();
 
 		child = cp.spawn(
 			path.join( 'node_modules', '.bin', 'uglifyjs' ),

--- a/server/bundler/utils.js
+++ b/server/bundler/utils.js
@@ -8,6 +8,7 @@ function getAssets( stats ) {
 			hash: chunk.hash,
 			file: filename,
 			url: stats.publicPath + filename,
+			size: chunk.size
 		};
 	} );
 }


### PR DESCRIPTION
This adds back the ability to minify bundles in parallel. It was dropped a while back when mangling was turned on because the build would never complete with it on.

It turns out the hang was due to stderr filling up and preventing the process from exiting. This PR teaches spawn to pipe stderr to the parent, which lets it drain and close.

In addition, it uses async to limit the number of parallel processes to the number of cores available.

On an 8-way Macbook Pro, this dropped minification time by roughly half, from ~70s to ~30s.

To test, spin up the docker instance using `make docker-build && make docker-run` and verify that calypso works and bundles are minified.