### PR TITLE
Reader: Increase gray text contrast

### DIFF
--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -41,7 +41,7 @@
 			}
 
 			.follow-button__label {
-				color: $gray-text;
+				color: $gray-text-min;
 			}
 		}
 
@@ -77,7 +77,7 @@
 	justify-content: center;
 
 	&:hover {
-		color: $gray-text;
+		color: $gray-text-min;
 	}
 }
 
@@ -97,7 +97,7 @@
 }
 
 .author-compact-profile__follow-count {
-	color: $gray-text;
+	color: $gray-text-min;
 	padding: 5px;
 }
 

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -41,7 +41,7 @@
 			}
 
 			.follow-button__label {
-				color: lighten( $gray, 10% );
+				color: $gray-text;
 			}
 		}
 
@@ -77,7 +77,7 @@
 	justify-content: center;
 
 	&:hover {
-		color: lighten( $gray, 10% );
+		color: $gray-text;
 	}
 }
 
@@ -97,7 +97,7 @@
 }
 
 .author-compact-profile__follow-count {
-	color: lighten( $gray, 10% );
+	color: $gray-text;
 	padding: 5px;
 }
 

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -97,7 +97,7 @@
 }
 
 .author-compact-profile__follow-count {
-	color: $gray-text-min;
+	color: $gray;
 	padding: 5px;
 }
 

--- a/client/blocks/comment-button/style.scss
+++ b/client/blocks/comment-button/style.scss
@@ -1,7 +1,7 @@
 .comment-button {
 	align-items: center;
 	box-sizing: border-box;
-	color: $gray-text-min;
+	color: $gray;
 	cursor: pointer;
 	display: inline-flex;
 	list-style-type: none;
@@ -11,7 +11,11 @@
 	&:hover,
 	&:focus,
 	&:active {
-		color: $blue-light;
+		color: $blue-medium;
+
+		.gridicon {
+			fill: $blue-medium;
+		}
 	}
 
 	.comment-button__label-count {

--- a/client/blocks/comment-button/style.scss
+++ b/client/blocks/comment-button/style.scss
@@ -1,7 +1,7 @@
 .comment-button {
 	align-items: center;
 	box-sizing: border-box;
-	color: lighten( $gray, 10% );
+	color: $gray-text;
 	cursor: pointer;
 	display: inline-flex;
 	list-style-type: none;

--- a/client/blocks/comment-button/style.scss
+++ b/client/blocks/comment-button/style.scss
@@ -12,10 +12,6 @@
 	&:focus,
 	&:active {
 		color: $blue-medium;
-
-		.gridicon {
-			fill: $blue-medium;
-		}
 	}
 
 	.comment-button__label-count {
@@ -36,10 +32,6 @@
 }
 
 .comment-button__icon {
-	fill: lighten( $gray, 10% );
 	position: relative;
 		top: 1px;
-	&:hover {
-		fill: $blue-light;
-	}
 }

--- a/client/blocks/comment-button/style.scss
+++ b/client/blocks/comment-button/style.scss
@@ -1,7 +1,7 @@
 .comment-button {
 	align-items: center;
 	box-sizing: border-box;
-	color: $gray-text;
+	color: $gray-text-min;
 	cursor: pointer;
 	display: inline-flex;
 	list-style-type: none;

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -366,7 +366,7 @@ a.comments__comment-username {
 }
 
 .comments__comment-count {
-	color: lighten( $gray, 10% );
+	color: $gray;
 	font-size: 14px;
 	font-weight: 600;
 	line-height: 1;

--- a/client/blocks/like-button/style.scss
+++ b/client/blocks/like-button/style.scss
@@ -2,7 +2,7 @@
 	align-items: center;
 	display: inline-flex;
 	padding: 4px;
-	color: $gray-text-min;
+	color: $gray;
 	position: relative;
 	box-sizing: border-box;
 
@@ -32,10 +32,10 @@
 
 	&:hover {
 		cursor: pointer;
-		color: $blue-light;
+		color: $blue-medium;
 
 		.gridicons-star-outline {
-			fill: $blue-light;
+			fill: $blue-medium;
 		}
 	}
 

--- a/client/blocks/like-button/style.scss
+++ b/client/blocks/like-button/style.scss
@@ -22,10 +22,6 @@
 		transition: all 0.3s cubic-bezier(0.175, 0.885, 0.320, 1.275);
 	}
 
-	.gridicons-star-outline {
-		fill: lighten( $gray, 10 );
-	}
-
 	&.is-animated .gridicons-star-outline {
 		transition: all 0.2s cubic-bezier(0.175, 0.885, 0.320, 1.275);
 	}
@@ -33,10 +29,6 @@
 	&:hover {
 		cursor: pointer;
 		color: $blue-medium;
-
-		.gridicons-star-outline {
-			fill: $blue-medium;
-		}
 	}
 
 	&.is-liked {

--- a/client/blocks/like-button/style.scss
+++ b/client/blocks/like-button/style.scss
@@ -2,7 +2,7 @@
 	align-items: center;
 	display: inline-flex;
 	padding: 4px;
-	color: $gray-text;
+	color: $gray-text-min;
 	position: relative;
 	box-sizing: border-box;
 
@@ -40,7 +40,7 @@
 	}
 
 	&.is-liked {
-		color: $gray-text;
+		color: $gray-text-min;
 
 		.gridicons-star {
 			opacity: 1;

--- a/client/blocks/like-button/style.scss
+++ b/client/blocks/like-button/style.scss
@@ -2,7 +2,7 @@
 	align-items: center;
 	display: inline-flex;
 	padding: 4px;
-	color: lighten( $gray, 10 );
+	color: $gray-text;
 	position: relative;
 	box-sizing: border-box;
 
@@ -23,7 +23,7 @@
 	}
 
 	.gridicons-star-outline {
-		fill: lighten( $gray, 20 );
+		fill: lighten( $gray, 10 );
 	}
 
 	&.is-animated .gridicons-star-outline {
@@ -40,7 +40,7 @@
 	}
 
 	&.is-liked {
-		color: lighten( $gray, 10 );;
+		color: $gray-text;
 
 		.gridicons-star {
 			opacity: 1;

--- a/client/blocks/post-edit-button/style.scss
+++ b/client/blocks/post-edit-button/style.scss
@@ -12,10 +12,6 @@
 	&:focus,
 	&:active {
 		color: $blue-medium;
-
-		.gridicon {
-			fill: $blue-medium;
-		}
 	}
 
 	.post-edit-button__label {
@@ -36,7 +32,6 @@
 }
 
 .post-edit-button__icon {
-	fill: lighten( $gray, 10% );
 	position: relative;
 		top: 1px;
 }

--- a/client/blocks/post-edit-button/style.scss
+++ b/client/blocks/post-edit-button/style.scss
@@ -1,7 +1,7 @@
 .post-edit-button {
 	align-items: center;
 	box-sizing: border-box;
-	color: $gray-text;
+	color: $gray-text-min;
 	cursor: pointer;
 	display: inline-flex;
 	list-style-type: none;

--- a/client/blocks/post-edit-button/style.scss
+++ b/client/blocks/post-edit-button/style.scss
@@ -1,7 +1,7 @@
 .post-edit-button {
 	align-items: center;
 	box-sizing: border-box;
-	color: lighten( $gray, 10% );
+	color: $gray-text;
 	cursor: pointer;
 	display: inline-flex;
 	list-style-type: none;

--- a/client/blocks/post-edit-button/style.scss
+++ b/client/blocks/post-edit-button/style.scss
@@ -1,7 +1,7 @@
 .post-edit-button {
 	align-items: center;
 	box-sizing: border-box;
-	color: $gray-text-min;
+	color: $gray;
 	cursor: pointer;
 	display: inline-flex;
 	list-style-type: none;
@@ -11,7 +11,11 @@
 	&:hover,
 	&:focus,
 	&:active {
-		color: $blue-light;
+		color: $blue-medium;
+
+		.gridicon {
+			fill: $blue-medium;
+		}
 	}
 
 	.post-edit-button__label {

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -120,7 +120,7 @@
 	}
 
 	.reader-feed-header__follow-count {
-		color: $gray-text;
+		color: $gray-text-min;
 		font-size: 14px;
 	}
 

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -120,7 +120,7 @@
 	}
 
 	.reader-feed-header__follow-count {
-		color: lighten( $gray, 10% );
+		color: $gray-text;
 		font-size: 14px;
 	}
 

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -448,7 +448,7 @@
 
 .reader-full-post__header-date-link,
 .reader-full-post__header-date-link:visited {
-	color: $gray-text-min;
+	color: $gray;
 
 	&:hover {
 		color: $blue-light;
@@ -473,7 +473,7 @@
 }
 
 .reader-full-post__header-tag-list {
-	color: $gray-text-min;
+	color: $gray;
 	list-style: none;
 	margin: 0;
 	padding: 0;
@@ -489,7 +489,7 @@
 }
 
 .reader-full-post__header-tag-list-item {
-	color: $gray-text-min;
+	color: $gray;
 	display: inline;
 	margin-right: 5px;
 
@@ -508,7 +508,7 @@
 
 .reader-full-post__header-tag-list-item-link,
 .reader-full-post__header-tag-list-item-link:visited {
-	color: $gray-text-min;
+	color: $gray;
 
 	&:hover {
 		color: $blue-light;

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -295,7 +295,7 @@
 }
 
 .reader-full-post .reader-full-post__sidebar {
-	color: $gray-text;
+	color: $gray-text-min;
 
 	a.reader-author-link,
 	a.author-compact-profile__site-link {
@@ -448,7 +448,7 @@
 
 .reader-full-post__header-date-link,
 .reader-full-post__header-date-link:visited {
-	color: $gray-text;
+	color: $gray-text-min;
 
 	&:hover {
 		color: $blue-light;
@@ -473,7 +473,7 @@
 }
 
 .reader-full-post__header-tag-list {
-	color: $gray-text;
+	color: $gray-text-min;
 	list-style: none;
 	margin: 0;
 	padding: 0;
@@ -489,7 +489,7 @@
 }
 
 .reader-full-post__header-tag-list-item {
-	color: $gray-text;
+	color: $gray-text-min;
 	display: inline;
 	margin-right: 5px;
 
@@ -508,7 +508,7 @@
 
 .reader-full-post__header-tag-list-item-link,
 .reader-full-post__header-tag-list-item-link:visited {
-	color: $gray-text;
+	color: $gray-text-min;
 
 	&:hover {
 		color: $blue-light;

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -295,7 +295,7 @@
 }
 
 .reader-full-post .reader-full-post__sidebar {
-	color: lighten( $gray, 10% );
+	color: $gray-text;
 
 	a.reader-author-link,
 	a.author-compact-profile__site-link {
@@ -448,7 +448,7 @@
 
 .reader-full-post__header-date-link,
 .reader-full-post__header-date-link:visited {
-	color: $gray;
+	color: $gray-text;
 
 	&:hover {
 		color: $blue-light;
@@ -473,7 +473,7 @@
 }
 
 .reader-full-post__header-tag-list {
-	color: $gray;
+	color: $gray-text;
 	list-style: none;
 	margin: 0;
 	padding: 0;
@@ -489,7 +489,7 @@
 }
 
 .reader-full-post__header-tag-list-item {
-	color: $gray;
+	color: $gray-text;
 	display: inline;
 	margin-right: 5px;
 
@@ -508,7 +508,7 @@
 
 .reader-full-post__header-tag-list-item-link,
 .reader-full-post__header-tag-list-item-link:visited {
-	color: $gray;
+	color: $gray-text;
 
 	&:hover {
 		color: $blue-light;

--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -16,7 +16,7 @@
 		flex: 1;
 
 		.reader-post-actions__visit-label {
-			color: lighten( $gray, 10% );
+			color: $gray-text;
 		}
 
 		.external-link {

--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -16,7 +16,7 @@
 		flex: 1;
 
 		.reader-post-actions__visit-label {
-			color: $gray-text;
+			color: $gray-text-min;
 		}
 
 		.external-link {

--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -16,7 +16,7 @@
 		flex: 1;
 
 		.reader-post-actions__visit-label {
-			color: $gray-text-min;
+			color: $gray;
 		}
 
 		.external-link {
@@ -32,11 +32,11 @@
 		.external-link:active {
 
 			.gridicon {
-				fill: $blue-light;
+				fill: $blue-medium;
 			}
 
 			.reader-post-actions__visit-label {
-				color: $blue-light;
+				color: $blue-medium;
 			}
 		}
 	}

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -240,7 +240,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 .reader__content .reader-post-card__timestamp-link,
 .reader__content .reader-post-card__tag-link
 {
-	color: lighten( $gray, 10% );
+	color: $gray-text;
 	margin-top: 2px;
 	cursor: pointer;
 }
@@ -701,4 +701,3 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 .is-section-devdocs .reader-post-card__featured-image {
 	bottom: 16px;
 }
-

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -240,7 +240,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 .reader__content .reader-post-card__timestamp-link,
 .reader__content .reader-post-card__tag-link
 {
-	color: $gray-text;
+	color: $gray-text-min;
 	margin-top: 2px;
 	cursor: pointer;
 }

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -240,7 +240,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 .reader__content .reader-post-card__timestamp-link,
 .reader__content .reader-post-card__tag-link
 {
-	color: $gray-text-min;
+	color: $gray;
 	margin-top: 2px;
 	cursor: pointer;
 }
@@ -302,7 +302,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	position: relative;
 		top: 5px;
 	width: 15px;
-	fill: lighten( $gray, 10% );
+	fill: $gray;
 }
 
 .reader-post-card__byline .reader-avatar {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -476,7 +476,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		margin-left: -2px;
 
 		.gridicon {
-			fill: lighten( $gray, 10% );
+			fill: $gray;
 			position: relative;
 				left: -8px;
 				top: -1px;

--- a/client/blocks/reader-post-options-menu/style.scss
+++ b/client/blocks/reader-post-options-menu/style.scss
@@ -2,7 +2,7 @@
 .reader-post-options-menu .ellipsis-menu {
 
 	.button.is-borderless {
-		color: lighten( $gray, 10% );
+		color: $gray;
 
 		&:hover,
 		&:focus,

--- a/client/blocks/reader-post-options-menu/style.scss
+++ b/client/blocks/reader-post-options-menu/style.scss
@@ -7,7 +7,7 @@
 		&:hover,
 		&:focus,
 		&:active {
-			color: $blue-light;
+			color: $blue-medium;
 		}
 	}
 

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -19,7 +19,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 }
 
 .reader-related-card-v2__heading {
-	color: $gray-text;
+	color: $gray-text-min;
 	font-size: 14px;
 	font-weight: 600;
 	margin-bottom: 20px;

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -19,7 +19,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 }
 
 .reader-related-card-v2__heading {
-	color: lighten( $gray, 10% );
+	color: $gray-text;
 	font-size: 14px;
 	font-weight: 600;
 	margin-bottom: 20px;

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -19,7 +19,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 }
 
 .reader-related-card-v2__heading {
-	color: $gray-text-min;
+	color: $gray;
 	font-size: 14px;
 	font-weight: 600;
 	margin-bottom: 20px;

--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -1,6 +1,6 @@
 
 .reader-related-card__site-info-title {
-	color: $gray;
+	color: $gray-text;
 	float: left;
 	width: 100%;
 }
@@ -10,7 +10,7 @@
 }
 
 .reader-related-card__site-info {
-	color: $gray;
+	color: $gray-text;
 	display: block;
 	font-size: 13px;
 	margin-right: 120px;
@@ -20,7 +20,7 @@
 	width: 100%;
 
 	a {
-		color: $gray;
+		color: $gray-text;
 		text-decoration: none;
 
 		&:visited {
@@ -72,12 +72,12 @@
 }
 
 .reader-related-card__byline-author-and-site {
-	color: lighten( $gray, 10% );
+	color: $gray-text;
 	margin-right: 6px;
 }
 
 .reader-related-card__author-and-site {
-	color: lighten( $gray, 10% );
+	color: $gray-text;
 	margin-right: 10px;
 }
 
@@ -87,7 +87,7 @@
 
 	.reader-related-card__byline-link,
 	.reader-related-card__byline-link:visited {
-		color: lighten( $gray, 10% );
+		color: $gray-text;
 
 		&:hover {
 			color: $blue-wordpress;

--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -1,6 +1,6 @@
 
 .reader-related-card__site-info-title {
-	color: $gray-text;
+	color: $gray-text-min;
 	float: left;
 	width: 100%;
 }
@@ -10,7 +10,7 @@
 }
 
 .reader-related-card__site-info {
-	color: $gray-text;
+	color: $gray-text-min;
 	display: block;
 	font-size: 13px;
 	margin-right: 120px;
@@ -20,7 +20,7 @@
 	width: 100%;
 
 	a {
-		color: $gray-text;
+		color: $gray-text-min;
 		text-decoration: none;
 
 		&:visited {
@@ -72,12 +72,12 @@
 }
 
 .reader-related-card__byline-author-and-site {
-	color: $gray-text;
+	color: $gray-text-min;
 	margin-right: 6px;
 }
 
 .reader-related-card__author-and-site {
-	color: $gray-text;
+	color: $gray-text-min;
 	margin-right: 10px;
 }
 
@@ -87,7 +87,7 @@
 
 	.reader-related-card__byline-link,
 	.reader-related-card__byline-link:visited {
-		color: $gray-text;
+		color: $gray-text-min;
 
 		&:hover {
 			color: $blue-wordpress;

--- a/client/reader/share/style.scss
+++ b/client/reader/share/style.scss
@@ -1,7 +1,7 @@
 .reader-share_button {
 	align-items: center;
 	box-sizing: border-box;
-	color: $gray-text-min;
+	color: $gray;
 	display: inline-flex;
 	padding: 4px;
 	position: relative;
@@ -10,7 +10,11 @@
 	&:focus,
 	&:active {
 		cursor: pointer;
-		color: $blue-light;
+		color: $blue-medium;
+
+		.gridicon {
+			fill: $blue-medium;
+		}
 	}
 
 	.gridicon {

--- a/client/reader/share/style.scss
+++ b/client/reader/share/style.scss
@@ -11,14 +11,9 @@
 	&:active {
 		cursor: pointer;
 		color: $blue-medium;
-
-		.gridicon {
-			fill: $blue-medium;
-		}
 	}
 
 	.gridicon {
-		fill: lighten( $gray, 10 );
 		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 	}
 

--- a/client/reader/share/style.scss
+++ b/client/reader/share/style.scss
@@ -1,7 +1,7 @@
 .reader-share_button {
 	align-items: center;
 	box-sizing: border-box;
-	color: $gray-text;
+	color: $gray-text-min;
 	display: inline-flex;
 	padding: 4px;
 	position: relative;

--- a/client/reader/share/style.scss
+++ b/client/reader/share/style.scss
@@ -1,7 +1,7 @@
 .reader-share_button {
 	align-items: center;
 	box-sizing: border-box;
-	color: lighten( $gray, 10% );
+	color: $gray-text;
 	display: inline-flex;
 	padding: 4px;
 	position: relative;
@@ -14,6 +14,7 @@
 	}
 
 	.gridicon {
+		fill: lighten( $gray, 10 );
 		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 	}
 


### PR DESCRIPTION
This updates a few blocks to use the $gray-text-min variable for text, which is the mimmim contrast needed to pass WCAG 2.0 AA tests on a white background.

I went through all [blocks](https://wpcalypso.wordpress.com/devdocs/blocks) that are related to the Reader, and update all gray text that did not pass AA.

To test:

- go to Reader
- make sure all text looks consistent
- try hover states

cc @fraying 

Before:
![screen shot 2017-02-14 at 12 01 37 pm](https://cloud.githubusercontent.com/assets/618551/22942133/e56d26c6-f2ad-11e6-917d-db2c52e90936.png)
![screen shot 2017-02-14 at 12 01 18 pm](https://cloud.githubusercontent.com/assets/618551/22942140/ea164f40-f2ad-11e6-8097-de28efba9447.png)

After:

https://github.com/Automattic/wp-calypso/pull/11387#issuecomment-280079328