### PR TITLE
Components: Use default cursor for disabled form toggle labels

### DIFF
--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -71,12 +71,15 @@ export default class FormToggle extends PureComponent {
 
 	render() {
 		const id = this.props.id || 'toggle-' + this.id;
+		const wrapperClasses = classNames( 'form-toggle__wrapper', {
+			'is-disabled': this.props.disabled,
+		} );
 		const toggleClasses = classNames( 'form-toggle', this.props.className, {
 			'is-toggling': this.props.toggling
 		} );
 
 		return (
-			<span>
+			<span className={ wrapperClasses }>
 				<input
 					className={ toggleClasses }
 					type="checkbox"
@@ -86,7 +89,6 @@ export default class FormToggle extends PureComponent {
 					/>
 				<label className="form-toggle__label" htmlFor={ id } >
 					<span className="form-toggle__switch"
-						disabled={ this.props.disabled }
 						id={ id }
 						onClick={ this.onClick }
 						onKeyDown={ this.onKeyDown }


### PR DESCRIPTION
This PR fixes the cursor of disabled form toggle labels. Previously, we were making it a `pointer`, but it doesn't make sense to have that cursor for disabled form toggles.

To test:

* Checkout this branch
* Go to `/settings/writing/$site` where `$site` is one of your Jetpack sites.
* Disable one of the modules within the Theme Enhancements card.
* Verify the cursor is the default one when hovering one of the disabled subsetting form toggle labels.
* Verify the rest of the cursors behave as expected.

Reported initially by @rickybanister.