### PR TITLE
Components: Increasing text contrast of blocks

### DIFF
--- a/client/blocks/credit-card-form/style.scss
+++ b/client/blocks/credit-card-form/style.scss
@@ -3,7 +3,7 @@
 }
 
 .credit-card-form__card-terms {
-	color: darken( $gray, 10% );
+	color: $gray-text-min;
 	margin: 5px 0 0 0;
 	padding: 0;
 	text-align: center;
@@ -15,7 +15,6 @@
 
 	p {
 		font-size: 12px;
-		font-weight: 100;
 		margin: 0;
 
 		@include breakpoint( ">660px" ) {
@@ -39,7 +38,7 @@
 	justify-content: space-between;
 
 	em {
-		color: lighten( $gray, 10% );
+		color: $gray-text-min;
 	}
 
 	button {

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -47,7 +47,7 @@ a.post-item__title-link {
 
 .post-item__meta {
 	font-size: 12px;
-	color: lighten( $gray, 10% );
+	color: $gray-text-min;
 }
 
 .post-item__meta .post-relative-time,

--- a/client/blocks/post-likes/style.scss
+++ b/client/blocks/post-likes/style.scss
@@ -16,11 +16,10 @@
 		line-height: 14px;
 		border-radius: 12px;
 		display: inline-block;
-		border: solid 1px #87a6bc;
-		color: #87a6bc;
+		border: solid 1px $gray;
+		color: $gray-text-min;
 		padding: 1px 6px;
 		font-weight: 600;
 		font-size: 11px;
 	}
 }
-

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -77,7 +77,7 @@
 }
 
 .site__domain {
-	color: $gray;
+	color: $gray-text-min;
 	display: block;
 	max-width: 95%;
 	font-size: 11px;

--- a/client/my-sites/plan-compare-card/style.scss
+++ b/client/my-sites/plan-compare-card/style.scss
@@ -12,9 +12,8 @@
 
 .plan-compare-card__features {
 	padding: 16px 24px;
-	background-color: lighten($gray, 35%);
 	font-size: 14px;
-	color: $gray;
+	color: $gray-text-min;
 }
 
 .plan-compare-card__header {
@@ -35,7 +34,7 @@
 .plan-compare-card__line {
 	font-size: 12px;
 	font-weight: normal;
-	color: $gray;
+	color: $gray-text-min;
 	font-style: italic;
 }
 

--- a/client/my-sites/plan-storage/style.scss
+++ b/client/my-sites/plan-storage/style.scss
@@ -5,7 +5,7 @@
 
 .plan-storage__storage-label {
 	font-size: 11px;
-	color: $gray;
+	color: $gray-text-min;
 	margin-left: 20px;
 }
 

--- a/client/my-sites/upgrade-nudge/style.scss
+++ b/client/my-sites/upgrade-nudge/style.scss
@@ -49,7 +49,7 @@
 }
 
 .upgrade-nudge__message {
-	color: $gray;
+	color: $gray-text-min;
 	font-size: 12px;
 	display: block;
 }


### PR DESCRIPTION
This updates a few components to use the $gray-text-min variable for text, which is the mimmim contrast needed to pass WCAG 2.0 AA tests on a white background.

Biggest thing to test is the Site component. To test, please check every place you can think of that uses the Site component.

Blocks affected:

- CreditCardForm
- PlanStorage
- UpgradeNudge
- PlanCompareCard
- FeatureComparison
- PostItem
- PostLikes
- Site

Before:

![screen shot 2017-02-14 at 4 13 56 pm](https://cloud.githubusercontent.com/assets/618551/22951928/ac2aea1a-f2d0-11e6-8b03-51d6a19659db.png)
![screen shot 2017-02-14 at 4 13 49 pm](https://cloud.githubusercontent.com/assets/618551/22951927/ac2aaf50-f2d0-11e6-9e6a-40397a872178.png)
![screen shot 2017-02-14 at 4 13 42 pm](https://cloud.githubusercontent.com/assets/618551/22951926/ac2a5e60-f2d0-11e6-9556-5da8648c398c.png)
![screen shot 2017-02-14 at 4 13 35 pm](https://cloud.githubusercontent.com/assets/618551/22951924/ac273604-f2d0-11e6-9621-f3aa7f0d5db7.png)
![screen shot 2017-02-14 at 4 13 28 pm](https://cloud.githubusercontent.com/assets/618551/22951925/ac28fb10-f2d0-11e6-8289-d4b1b3fec39c.png)
![screen shot 2017-02-14 at 4 13 16 pm](https://cloud.githubusercontent.com/assets/618551/22951929/ac2b61d4-f2d0-11e6-8cd6-41b4a861ffb9.png)

After:

![screen shot 2017-02-14 at 4 15 56 pm](https://cloud.githubusercontent.com/assets/618551/22952004/f27ab194-f2d0-11e6-875d-fe0e6fcf72a6.png)
![screen shot 2017-02-14 at 4 15 49 pm](https://cloud.githubusercontent.com/assets/618551/22952005/f2840d2a-f2d0-11e6-8ad2-78c49ba7cb0d.png)
![screen shot 2017-02-14 at 4 15 43 pm](https://cloud.githubusercontent.com/assets/618551/22952006/f2882d42-f2d0-11e6-88fa-1e41aed0ed77.png)
![screen shot 2017-02-14 at 4 15 36 pm](https://cloud.githubusercontent.com/assets/618551/22952007/f28a95a0-f2d0-11e6-96d8-6ed8e3432fad.png)
![screen shot 2017-02-14 at 4 15 30 pm](https://cloud.githubusercontent.com/assets/618551/22952009/f28c3a2c-f2d0-11e6-88c2-9fd35ae2ee67.png)
![screen shot 2017-02-14 at 4 15 21 pm](https://cloud.githubusercontent.com/assets/618551/22952008/f28ab2b0-f2d0-11e6-9870-c83fda54ea0c.png)

