### PR TITLE
Refactor help courses

### DIFF
--- a/client/me/help/help-courses/course-video.jsx
+++ b/client/me/help/help-courses/course-video.jsx
@@ -7,12 +7,9 @@ import React from 'react';
  * Internal dependencies
  */
 import { localize } from 'i18n-calypso';
-import Card from 'components/card';
 
 export default localize( ( props ) => {
 	const {
-		title,
-		description,
 		youtubeId
 	} = props;
 
@@ -24,10 +21,6 @@ export default localize( ( props ) => {
 					src={ `https://www.youtube.com/embed/${ youtubeId }?rel=0&showinfo=0` }
 					allowFullScreen />
 			</div>
-			<Card compact>
-				<h1 className="help-courses__course-video-title">{ title }</h1>
-				<p className="help-courses__course-video-description">{ description }</p>
-			</Card>
 		</div>
 	);
 } );

--- a/client/me/help/help-courses/course.jsx
+++ b/client/me/help/help-courses/course.jsx
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
 import Card from 'components/card';
 import CourseScheduleItem from './course-schedule-item';
 import HelpTeaserButton from '../help-teaser-button';
-import CourseVideos from './course-videos';
+import CourseVideo from './course-video';
 import sitesList from 'lib/sites-list';
 import analytics from 'lib/analytics';
 
@@ -36,7 +36,7 @@ class Course extends Component {
 			description,
 			schedule,
 			isBusinessPlanUser,
-			videos,
+			video,
 			translate
 		} = this.props;
 
@@ -44,7 +44,7 @@ class Course extends Component {
 
 		return (
 			<div className="help-courses__course">
-				<Card compact className="help-courses__course-label">{ translate( 'Next course' ) }</Card>
+				{ isBusinessPlanUser && video && <CourseVideo { ...video } /> }
 				<Card compact>
 					<h1 className="help-courses__course-title">{ title }</h1>
 					<p className="help-courses__course-description">{ description }</p>
@@ -58,10 +58,9 @@ class Course extends Component {
 						/>
 					}
 				</Card>
-				{ schedule.map( ( item, key ) => {
+				{ schedule && schedule.map( ( item, key ) => {
 					return ( <CourseScheduleItem { ...item } key={ key } isBusinessPlanUser={ isBusinessPlanUser } /> );
 				} ) }
-				{ isBusinessPlanUser && <CourseVideos videos={ videos } /> }
 			</div>
 		);
 	}

--- a/client/me/help/help-courses/index.jsx
+++ b/client/me/help/help-courses/index.jsx
@@ -29,12 +29,9 @@ function getCourses() {
 				'foundation for making sure that your site meets current SEO standards. We\'ll also discuss how to ' +
 				'maximize tools like Google Analytics and Webmaster Tools.'
 			),
-			schedule: [
-				{
-					date: i18n.moment( new Date( 'Thur, 2 Feb 2017 17:00:00 +0000' ) ),
-					registrationUrl: 'https://zoom.us/webinar/register/f358613ccf2137f934538d7d4481ef37'
-				},
-			],
+			video: {
+				youtubeId: 'FU7uxbngrq4'
+			}
 		},
 		{
 			title: i18n.translate( 'How to Make a Business Site on WordPress.com' ),
@@ -44,7 +41,6 @@ function getCourses() {
 				'plan, provide a basic setup overview to help you get started with your site, and show you ' +
 				'where to find additional resources and help in the future.'
 			),
-			schedule: [],
 			video: {
 				youtubeId: 'S2h_mV0OAcU'
 			}

--- a/client/me/help/help-courses/index.jsx
+++ b/client/me/help/help-courses/index.jsx
@@ -37,7 +37,7 @@ function getCourses() {
 			title: i18n.translate( 'How to Make a Business Site on WordPress.com' ),
 			description: i18n.translate(
 				'A 60-minute overview course with two of our Happiness Engineers. In this live group session, ' +
-				'we will provide an overview of WordPress.com, discuss features of the WordPress.com Business ' +
+				'we provide an overview of WordPress.com, discuss features of the WordPress.com Business ' +
 				'plan, provide a basic setup overview to help you get started with your site, and show you ' +
 				'where to find additional resources and help in the future.'
 			),

--- a/client/me/help/help-courses/index.jsx
+++ b/client/me/help/help-courses/index.jsx
@@ -35,19 +35,19 @@ function getCourses() {
 					registrationUrl: 'https://zoom.us/webinar/register/f358613ccf2137f934538d7d4481ef37'
 				},
 			],
-			videos: [
-				{
-					date: i18n.moment( new Date( 'Fri, 2 Sep 2016 01:00:00 +0000' ) ),
-					title: i18n.translate( 'How to Make a Business Site on WordPress.com' ),
-					description: i18n.translate(
-						'A 60-minute overview course with two of our Happiness Engineers. In this live group session, ' +
-						'we will provide an overview of WordPress.com, discuss features of the WordPress.com Business ' +
-						'plan, provide a basic setup overview to help you get started with your site, and show you ' +
-						'where to find additional resources and help in the future.'
-					),
-					youtubeId: 'S2h_mV0OAcU'
-				}
-			]
+		},
+		{
+			title: i18n.translate( 'How to Make a Business Site on WordPress.com' ),
+			description: i18n.translate(
+				'A 60-minute overview course with two of our Happiness Engineers. In this live group session, ' +
+				'we will provide an overview of WordPress.com, discuss features of the WordPress.com Business ' +
+				'plan, provide a basic setup overview to help you get started with your site, and show you ' +
+				'where to find additional resources and help in the future.'
+			),
+			schedule: [],
+			video: {
+				youtubeId: 'S2h_mV0OAcU'
+			}
 		}
 	];
 }

--- a/client/me/help/help-courses/style.scss
+++ b/client/me/help/help-courses/style.scss
@@ -6,6 +6,8 @@
 }
 
 .help-courses__course{
+	margin-top: 16px;
+
 	&.is-placeholder {
 		@include placeholder( 23% );
 	}


### PR DESCRIPTION
This pull request refactors the data for help courses so that we can show a video for a course without having any scheduled sessions.
### Whats changed
* I added an extra course video and I removed the "Next course" and "Latest course" headings because it splits the page in a way thats not representative of the data we're actually displaying.

### How to test
1. Navigate to http://calypso.localhost:3000/help/courses
2. Notice that the "Next course" and "Latest course" headers are gone and the course schedule is no longer showing for the course that already passed.

### Before
<img width="849" alt="screen shot 2017-02-14 at 8 46 22 pm" src="https://cloud.githubusercontent.com/assets/1854440/22957512/b478c46e-f2f6-11e6-9e35-f9014bc2d665.png">


### After
#### Business plan user
![screen shot 2017-02-14 at 9 24 52 pm](https://cloud.githubusercontent.com/assets/1854440/22958257/28bd5952-f2fc-11e6-96a9-62fc4e49ceb0.png)

#### Non-business plan user
![screen shot 2017-02-14 at 9 27 03 pm](https://cloud.githubusercontent.com/assets/1854440/22958294/6788b302-f2fc-11e6-9cf6-e5c2fa87189e.png)


This pull request replaces #11278