### PR TITLE
Reader: Cut down image transfer significantly

### DIFF
--- a/client/blocks/reader-post-card/featured-image.jsx
+++ b/client/blocks/reader-post-card/featured-image.jsx
@@ -8,6 +8,7 @@ import { noop } from 'lodash';
  * Internal Dependencies
  */
 import cssSafeUrl from 'lib/css-safe-url';
+import resizeImageUrl from 'lib/resize-image-url';
 
 const FeaturedImage = ( { imageUri, href, children, onClick } ) => {
 	if ( imageUri === undefined ) {
@@ -15,7 +16,7 @@ const FeaturedImage = ( { imageUri, href, children, onClick } ) => {
 	}
 
 	const featuredImageStyle = {
-		backgroundImage: 'url(' + cssSafeUrl( imageUri ) + ')',
+		backgroundImage: 'url(' + cssSafeUrl( resizeImageUrl( imageUri, { w: 250 } ) ) + ')',
 		backgroundSize: 'cover',
 		backgroundRepeat: 'no-repeat',
 		backgroundPosition: 'center center'

--- a/client/blocks/reader-post-card/featured-image.jsx
+++ b/client/blocks/reader-post-card/featured-image.jsx
@@ -10,13 +10,15 @@ import { noop } from 'lodash';
 import cssSafeUrl from 'lib/css-safe-url';
 import resizeImageUrl from 'lib/resize-image-url';
 
+const FEATURED_IMAGE_WIDTH = 250; // typical width of a featured image in the refresh
+
 const FeaturedImage = ( { imageUri, href, children, onClick } ) => {
 	if ( imageUri === undefined ) {
 		return null;
 	}
 
 	const featuredImageStyle = {
-		backgroundImage: 'url(' + cssSafeUrl( resizeImageUrl( imageUri, { w: 250 } ) ) + ')',
+		backgroundImage: 'url(' + cssSafeUrl( resizeImageUrl( imageUri, { w: FEATURED_IMAGE_WIDTH } ) ) + ')',
 		backgroundSize: 'cover',
 		backgroundRepeat: 'no-repeat',
 		backgroundPosition: 'center center'

--- a/client/blocks/reader-post-card/gallery.jsx
+++ b/client/blocks/reader-post-card/gallery.jsx
@@ -14,7 +14,7 @@ import cssSafeUrl from 'lib/css-safe-url';
 import { isFeaturedImageInContent } from 'lib/post-normalizer/utils';
 import ReaderPostCardExcerpt from './excerpt';
 
-const GALLERY_ITEM_THUMBNAIL_WIDTH = 420;
+const READER_CONTENT_WIDTH = 800;
 
 function getGalleryWorthyImages( post ) {
 	const numberOfImagesToDisplay = 4;
@@ -31,7 +31,7 @@ function getGalleryWorthyImages( post ) {
 const PostGallery = ( { post, children, isDiscover } ) => {
 	const imagesToDisplay = getGalleryWorthyImages( post );
 	const listItems = map( imagesToDisplay, ( image, index ) => {
-		const imageUrl = resizeImageUrl( image.src, { w: GALLERY_ITEM_THUMBNAIL_WIDTH } );
+		const imageUrl = resizeImageUrl( image.src, { w: READER_CONTENT_WIDTH / imagesToDisplay.length } );
 		const safeCssUrl = cssSafeUrl( imageUrl );
 		const imageStyle = {
 			backgroundImage: 'url(' + safeCssUrl + ')',

--- a/client/blocks/reader-post-card/gallery.jsx
+++ b/client/blocks/reader-post-card/gallery.jsx
@@ -13,8 +13,7 @@ import resizeImageUrl from 'lib/resize-image-url';
 import cssSafeUrl from 'lib/css-safe-url';
 import { isFeaturedImageInContent } from 'lib/post-normalizer/utils';
 import ReaderPostCardExcerpt from './excerpt';
-
-const READER_CONTENT_WIDTH = 800;
+import { READER_CONTENT_WIDTH } from 'state/reader/posts/normalization-rules';
 
 function getGalleryWorthyImages( post ) {
 	const numberOfImagesToDisplay = 4;

--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -18,11 +18,14 @@ import Gravatar from 'components/gravatar';
 import FollowButton from 'reader/follow-button';
 import { getPostUrl, getStreamUrl } from 'reader/route';
 import { areEqualIgnoringWhitespaceAndCase } from 'lib/string';
+import safeImageUrl from 'lib/safe-image-url';
+import resizeImageUrl from 'lib/resize-image-url';
 
 function FeaturedImage( { image, href } ) {
+	const uri = resizeImageUrl( safeImageUrl( image.uri ), { w: 385 } )
 	return (
 		<div className="reader-related-card-v2__featured-image" href={ href } style={ {
-			backgroundImage: 'url(' + image.uri + ')',
+			backgroundImage: 'url(' + uri + ')',
 			backgroundSize: 'cover',
 			backgroundRepeat: 'no-repeat',
 			backgroundPosition: '50% 50%'

--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -21,8 +21,10 @@ import { areEqualIgnoringWhitespaceAndCase } from 'lib/string';
 import safeImageUrl from 'lib/safe-image-url';
 import resizeImageUrl from 'lib/resize-image-url';
 
+const RELATED_IMAGE_WIDTH = 385; // usual width of featured images in related post card
+
 function FeaturedImage( { image, href } ) {
-	const uri = resizeImageUrl( safeImageUrl( image.uri ), { w: 385 } )
+	const uri = resizeImageUrl( safeImageUrl( image.uri ), { w: RELATED_IMAGE_WIDTH } )
 	return (
 		<div className="reader-related-card-v2__featured-image" href={ href } style={ {
 			backgroundImage: 'url(' + uri + ')',

--- a/client/lib/post-normalizer/rule-content-detect-media.js
+++ b/client/lib/post-normalizer/rule-content-detect-media.js
@@ -7,7 +7,7 @@ import getEmbedMetadata from 'get-video-id';
 /**
  * Internal Dependencies
  */
-import { iframeIsWhitelisted, maxWidthPhotonishURL } from './utils';
+import { iframeIsWhitelisted, maxWidthPhotonishURL, deduceImageWidthAndHeight } from './utils';
 import { READER_CONTENT_WIDTH } from 'state/reader/posts/normalization-rules';
 
 /** Checks whether or not an image is a tracking pixel
@@ -46,39 +46,13 @@ function isCandidateForContentImage( image ) {
 	return ! ( isTrackingPixel( image ) || imageShouldBeExcludedFromCandidacy );
 }
 
-function deduceImageWidthAndHeight( image ) {
-	if ( image.height && image.width ) {
-		return {
-			height: image.height,
-			width: image.width
-		};
-	}
-	if ( image.naturalHeight && image.natualWidth ) {
-		return {
-			height: image.naturalHeight,
-			width: image.naturalWidth
-		};
-	}
-	if ( image.dataset && image.dataset.origSize ) {
-		const [ width, height ] = image.dataset.origSize.split( ',' ).map( Number );
-		return {
-			width,
-			height
-		};
-	}
-	return {
-		width: 0,
-		height: 0
-	};
-}
-
 /** Detects and returns metadata if it should be considered as a content image
 * @param {image} image - the image
 * @returns {object} metadata - regarding the image or null
 */
 const detectImage = ( image ) => {
 	if ( isCandidateForContentImage( image ) ) {
-		const { width, height } = deduceImageWidthAndHeight( image );
+		const { width, height } = deduceImageWidthAndHeight( image ) || { width: 0, height: 0 };
 		return {
 			src: maxWidthPhotonishURL( image.getAttribute( 'src' ), READER_CONTENT_WIDTH ),
 			width: width,

--- a/client/lib/post-normalizer/rule-wait-for-images-to-load.js
+++ b/client/lib/post-normalizer/rule-wait-for-images-to-load.js
@@ -4,6 +4,7 @@
 import {
 	filter,
 	find,
+	flow,
 	forEach,
 	map,
 	pull,
@@ -43,12 +44,7 @@ function promiseForImage( image ) {
 	} );
 }
 
-const promiseForURL = function( urlOrPromise ) {
-	if ( urlOrPromise instanceof Promise ) {
-		return urlOrPromise;
-	}
-	return promiseForImage( imageForURL( urlOrPromise ) );
-};
+const promiseForURL = flow( imageForURL, promiseForImage );
 
 export default function waitForImagesToLoad( post ) {
 	return new Promise( ( resolve ) => {

--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -181,3 +181,26 @@ export function isFeaturedImageInContent( post ) {
 
 	return false;
 }
+
+export function deduceImageWidthAndHeight( image ) {
+	if ( image.height && image.width ) {
+		return {
+			height: image.height,
+			width: image.width
+		};
+	}
+	if ( image.naturalHeight && image.natualWidth ) {
+		return {
+			height: image.naturalHeight,
+			width: image.naturalWidth
+		};
+	}
+	if ( image.dataset && image.dataset.origSize ) {
+		const [ width, height ] = image.dataset.origSize.split( ',' ).map( Number );
+		return {
+			width,
+			height
+		};
+	}
+	return null;
+}

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -36,7 +36,7 @@ import addDiscoverProperties from 'lib/post-normalizer/rule-add-discover-propert
  * Module vars
  */
 export const
-	READER_CONTENT_WIDTH = 720,
+	READER_CONTENT_WIDTH = 800,
 	PHOTO_ONLY_MIN_WIDTH = 440,
 	GALLERY_MIN_IMAGES = 4,
 	GALLERY_MIN_IMAGE_WIDTH = 350;


### PR DESCRIPTION
The primary thing here is teaching `waitForImagesToLoad` how to detect existing dimensions on images. This prevents the majority of preload requests for size for WordPress hosted sites. In addition, it now only tries to preload 5 images, max.

This PR also teaches the post card, gallery card, and recommended post card to load smaller images by default.

This cuts down on the number of images we need to transfer to load Reader pages and significantly speeds up how we choose what image to show.

To test, pull up the Following stream and scroll. Make sure the network tab is open. You should see significantly less network traffic, mostly for images.