### PR TITLE
Show more than 20 first themes on Jetpack.

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -180,7 +180,7 @@ const ConnectedThemesSelection = connect(
 			page,
 			tier: config.isEnabled( 'upgrades/premium-themes' ) ? tier : 'free',
 			filter: compact( [ filter, vertical ] ).join( ',' ),
-			number: 20
+			number: isJetpack && ! ( queryWpcom === true ) ? 2000 : 20
 		};
 
 		return {

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -175,12 +175,18 @@ const ConnectedThemesSelection = connect(
 	( state, { filter, page, search, tier, vertical, siteId, queryWpcom } ) => {
 		const isJetpack = isJetpackSite( state, siteId );
 		const siteIdOrWpcom = ( siteId && isJetpack && ! ( queryWpcom === true ) ) ? siteId : 'wpcom';
+
+		// number calculation is just a hack for Jetpack sites. Jetpack themes endpoint does not paginate the
+		// results and sends all of the themes at once. QueryManager is not expecting such behaviour
+		// and we ended up loosing all of the themes above number 20. Real solution will be pagination on
+		// Jetpack themes endpoint.
+		const number = isJetpack && ! ( queryWpcom === true ) ? 2000 : 20;
 		const query = {
 			search,
 			page,
 			tier: config.isEnabled( 'upgrades/premium-themes' ) ? tier : 'free',
 			filter: compact( [ filter, vertical ] ).join( ',' ),
-			number: isJetpack && ! ( queryWpcom === true ) ? 2000 : 20
+			number
 		};
 
 		return {


### PR DESCRIPTION
### Info
`QueryManager` internals work based on pagination. This works bad with Jetpack themes endpoint that sends all the themes in one batch and does not care about query number.
Because of that we can increase the number in query for Jetpack sites high enough that `QueryManager` will store all the themes.

### Testing
Jetpack site with more than 20 themes installed is needed. Go to `/design` of that Jetpack site and count themes. 

Fixes #10896