### PR TITLE
Reader: fix proptype warning for object-->array

### DIFF
--- a/client/reader/stream/recommended-posts.jsx
+++ b/client/reader/stream/recommended-posts.jsx
@@ -114,7 +114,7 @@ export class RecommendedPosts extends React.PureComponent {
 RecommendedPosts.propTypes = {
 	index: PropTypes.number,
 	translate: PropTypes.func,
-	recommendations: PropTypes.object,
+	recommendations: PropTypes.array,
 };
 
 export default localize( RecommendedPosts );


### PR DESCRIPTION
Sometimes when you see a proptype warning you need to ask yourself: 'what would @bluefuton do'