### PR TITLE
Happychat: Uses cross grid icon for close button

### DIFF
--- a/client/components/happychat/index.jsx
+++ b/client/components/happychat/index.jsx
@@ -65,7 +65,7 @@ const connectedTitle = ( { onCloseChat } ) => (
 	<div className="happychat__active-toolbar">
 	<h4>{ translate( 'Support Chat' ) }</h4>
 		<div onClick={ onCloseChat }>
-			<GridIcon icon="chevron-down" />
+			<GridIcon icon="cross" />
 		</div>
 	</div>
 );


### PR DESCRIPTION

![screen shot 2017-02-15 at 11 33 27 am](https://cloud.githubusercontent.com/assets/19795/22991862/a229a004-f372-11e6-913c-4cecd90e431b.png)


## How to test

0. Go to `https://happychat-io-staging.go-vip.co` and make yourself available for chatting
1. Go to `http://calypso.live/help/contact`
2. Start Happychat session
3. Observe that the icon in the title bar af the chat is an ╳