### PR TITLE
Stats: use svg country flags instead of gravatar hosted flags.

### DIFF
--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -181,7 +181,7 @@ module.exports = React.createClass( {
 				}
 
 				if ( labelItem.icon ) {
-					avatar = ( <span className='icon'><img alt="" src={ labelItem.icon } width="20" height="20" className={ classNames( iconClassSetOptions ) } /></span> );
+					avatar = ( <span className='icon'><img alt="" src={ labelItem.icon } className={ classNames( iconClassSetOptions ) } /></span> );
 				}
 
 				icon = avatar;

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -190,12 +190,10 @@
 	}
 
 	.icon {
-		$icon-size: 24px;
-
 		position: relative;
 		display: inline-block;
-		width: $icon-size;
-		height: $icon-size;
+		width: 24px;
+		height: 24px;
 		overflow: hidden;
 		vertical-align: middle;
 		min-width: 24px;
@@ -205,6 +203,14 @@
 			display: block;
 			background: $white;
 			position: relative;
+			width: 20px;
+			height: 20px;
+
+			&.is-flag {
+				width: 24px;
+				height: 18px;
+				padding-top: 2px;
+			}
 		}
 
 		// Hide for user avatars

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -524,7 +524,8 @@ describe( 'utils', () => {
 						label: 'United States',
 						value: 1,
 						region: '021',
-						icon: 'https://secure.gravatar.com/blavatar/9f4faa5ad0c723474f7a6d810172447c?s=48'
+						icon: '/calypso/images/flags/us.svg',
+						iconClassName: 'is-flag'
 					}
 				] );
 			} );
@@ -560,7 +561,8 @@ describe( 'utils', () => {
 						label: 'United States',
 						value: 10,
 						region: '021',
-						icon: 'https://secure.gravatar.com/blavatar/9f4faa5ad0c723474f7a6d810172447c?s=48'
+						icon: '/calypso/images/flags/us.svg',
+						iconClassName: 'is-flag'
 					}
 				] );
 			} );
@@ -595,7 +597,8 @@ describe( 'utils', () => {
 						label: 'United States',
 						value: 100,
 						region: '021',
-						icon: 'https://secure.gravatar.com/blavatar/9f4faa5ad0c723474f7a6d810172447c?s=48'
+						icon: '/calypso/images/flags/us.svg',
+						iconClassName: 'is-flag'
 					}
 				] );
 			} );
@@ -631,43 +634,8 @@ describe( 'utils', () => {
 						label: 'United States',
 						value: 100,
 						region: '021',
-						icon: 'https://secure.gravatar.com/blavatar/9f4faa5ad0c723474f7a6d810172447c?s=48'
-					}
-				] );
-			} );
-
-			it( 'should ignore missing grey flag icons', () => {
-				const parsedData = normalizers.statsCountryViews( {
-					date: '2015-12-25',
-					days: {
-						'2015-12-01': {
-							views: [ {
-								country_code: 'US',
-								views: 100
-							} ],
-							other_views: 0,
-							total_views: 100
-						}
-					},
-					'country-info': {
-						US: {
-							flag_icon: 'https://secure.gravatar.com/blavatar/5a83891a81b057fed56930a6aaaf7b3c?s=48',
-							flat_flag_icon: 'https://s-ssl.wordpress.com/i/stats/square-grey.png',
-							country_full: 'United States',
-							map_region: '021'
-						}
-					}
-				}, {
-					period: 'month',
-					date: '2015-12-25'
-				} );
-
-				expect( parsedData ).to.eql( [
-					{
-						label: 'United States',
-						value: 100,
-						region: '021',
-						icon: null
+						icon: '/calypso/images/flags/us.svg',
+						iconClassName: 'is-flag'
 					}
 				] );
 			} );
@@ -703,7 +671,8 @@ describe( 'utils', () => {
 						label: 'US\'A',
 						value: 100,
 						region: '021',
-						icon: null
+						icon: '/calypso/images/flags/us.svg',
+						iconClassName: 'is-flag'
 					}
 				] );
 			} );
@@ -742,7 +711,8 @@ describe( 'utils', () => {
 						label: 'United States',
 						value: 100,
 						region: '021',
-						icon: 'https://secure.gravatar.com/blavatar/9f4faa5ad0c723474f7a6d810172447c?s=48'
+						icon: '/calypso/images/flags/us.svg',
+						iconClassName: 'is-flag'
 					}
 				] );
 			} );

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -227,14 +227,15 @@ export const normalizers = {
 
 		return map( countryData, ( viewData ) => {
 			const country = countryInfo[ viewData.country_code ];
-			const icon = country.flat_flag_icon.match( /grey\.png/ ) ? null : country.flat_flag_icon;
-
+			//const icon = country.flat_flag_icon.match( /grey\.png/ ) ? null : country.flat_flag_icon;
+			const icon = `/calypso/images/flags/${ viewData.country_code.toLowerCase() }.svg`
 			// ’ in country names causes google's geo viz to break
 			return {
 				label: country.country_full.replace( /’/, "'" ),
 				value: viewData.views,
 				region: country.map_region,
-				icon: icon
+				icon: icon,
+				iconClassName: 'is-flag'
 			};
 		} );
 	},

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -227,8 +227,8 @@ export const normalizers = {
 
 		return map( countryData, ( viewData ) => {
 			const country = countryInfo[ viewData.country_code ];
-			//const icon = country.flat_flag_icon.match( /grey\.png/ ) ? null : country.flat_flag_icon;
-			const icon = `/calypso/images/flags/${ viewData.country_code.toLowerCase() }.svg`
+			const icon = `/calypso/images/flags/${ viewData.country_code.toLowerCase() }.svg`;
+
 			// ’ in country names causes google's geo viz to break
 			return {
 				label: country.country_full.replace( /’/, "'" ),


### PR DESCRIPTION
Currently, the flag images for the Stats Countries module are hosted on Gravatar.  There was a bug in Gravatar which caused some of these flag images to be cached incorrectly, resulting in broken images showing in Calypso ( pMz3w-6xv-p2 ).  In lieu of tracking down a fix there, I have opted to create this branch which utilizes svg country flags that are already present in Calypso.

These flag svgs are already being used in the `<PhoneInput />` component, and since they are available, it makes sense to utilize them here as well.  For reference, the svg images are [copied via webpack](https://github.com/Automattic/wp-calypso/blob/master/webpack.config.js#L97) from the following project: https://github.com/lipis/flag-icon-css.  In my testing, the flag set is a bit more current than the gravatar images, and has a flag for the EU - which we do not have on Gravatar.

__Before ( Note broken gravatar images and misssing EU )__
![the_wordpress_com_blog_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/22996206/d481a2e4-f382-11e6-8175-8d78a134e69e.png)

__After__
![the_wordpress_com_blog_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/22996212/d8fca9c2-f382-11e6-9f8b-5d2738e0d458.png)
