### PR TITLE
Themes: Install parent theme if required (alternate PR)

### DIFF
--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -422,6 +422,10 @@ export function installTheme( themeId, siteId ) {
 			themeId
 		} );
 
+		if ( isThemeFromWpcom( themeId ) ) {
+			dispatch( installWpcomParentTheme( themeId, siteId ) );
+		}
+
 		return wpcom.undocumented().installThemeOnJetpack( siteId, themeId )
 			.then( ( theme ) => {
 				dispatch( receiveTheme( theme, siteId ) );
@@ -439,6 +443,25 @@ export function installTheme( themeId, siteId ) {
 					error
 				} );
 			} );
+	};
+}
+
+/**
+ * Returns an action thunk that will install a wpcom
+ * parent theme if the supplied theme requires one.
+ *
+ * @param {string} themeId child theme ID
+ * @param {number} siteId site ID
+ * @return {function} Action thunk
+ */
+function installWpcomParentTheme( themeId, siteId ) {
+	return ( dispatch, getState ) => {
+		const theme = getTheme( getState(), 'wpcom', themeId.replace( '-wpcom', '' ) );
+		const parentThemeId = theme && theme.template;
+
+		if ( parentThemeId ) {
+			dispatch( installTheme( parentThemeId + '-wpcom', siteId ) );
+		}
 	};
 }
 

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -617,3 +617,15 @@ export function getThemePreviewThemeOptions( state ) {
 export function themePreviewVisibility( state ) {
 	return get( state.themes, 'themePreviewVisibility', null );
 }
+
+/**
+ * Returns id of the parent theme, if any, for a wpcom theme.
+ *
+ * @param {Object} state Global state tree
+ * @param {string} themeId Child theme ID
+ *
+ * @return {?string} Parent theme id if it exists
+ */
+export function getWpcomParentThemeId( state, themeId ) {
+	return get( getTheme( state, 'wpcom', themeId ), [ 'template' ], null );
+}

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -870,6 +870,14 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#installTheme', () => {
+		const getState = () => ( {
+			themes: {
+				queries: {
+					wpcom: new ThemeQueryManager()
+				}
+			}
+		} );
+
 		const successResponse = {
 			id: 'karuna-wpcom',
 			screenshot: '//i0.wp.com/budzanowski.wpsandbox.me/wp-content/themes/karuna-wpcom/screenshot.png',
@@ -915,7 +923,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch install theme request action when triggered', () => {
-			installTheme( 'karuna-wpcom', 2211667 )( spy );
+			installTheme( 'karuna-wpcom', 2211667 )( spy, getState );
 
 			expect( spy ).to.have.been.calledWith( {
 				type: THEME_INSTALL,
@@ -925,7 +933,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch wpcom theme install request success action when request completes', () => {
-			return installTheme( 'karuna-wpcom', 2211667 )( spy ).then( () => {
+			return installTheme( 'karuna-wpcom', 2211667 )( spy, getState ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: THEME_INSTALL_SUCCESS,
 					siteId: 2211667,
@@ -935,7 +943,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch wpcom theme install request failure action when theme was not found', () => {
-			return installTheme( 'typist-wpcom', 2211667 )( spy ).then( () => {
+			return installTheme( 'typist-wpcom', 2211667 )( spy, getState ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: THEME_INSTALL_FAILURE,
 					siteId: 2211667,
@@ -946,7 +954,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch wpcom theme install request failure action when theme is already installed', () => {
-			return installTheme( 'pinboard-wpcom', 2211667 )( spy ).then( () => {
+			return installTheme( 'pinboard-wpcom', 2211667 )( spy, getState ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: THEME_INSTALL_FAILURE,
 					siteId: 2211667,

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -36,6 +36,7 @@ import {
 	isThemePurchased,
 	isPremiumSquaredTheme,
 	isPremiumThemeAvailable,
+	getWpcomParentThemeId,
 } from '../selectors';
 import ThemeQueryManager from 'lib/query-manager/theme';
 
@@ -92,6 +93,11 @@ const zuki = {
 	stylesheet: 'premium/zuki',
 	demo_uri: 'https:/zukidemo.wordpress.com/',
 	author_uri: 'https://wordpress.com/themes/'
+};
+
+const sidekick = {
+	id: 'sidekick',
+	template: 'superhero',
 };
 
 describe( 'themes selectors', () => {
@@ -2228,6 +2234,49 @@ describe( 'themes selectors', () => {
 			);
 
 			expect( isAvailable ).to.be.true;
+		} );
+	} );
+
+	describe( 'getWpcomParentThemeId', () => {
+		it( 'should return null for non-existent theme', () => {
+			const parentId = getWpcomParentThemeId(
+				{
+					themes: {
+						queries: {}
+					}
+				}, 'blah'
+			);
+			expect( parentId ).to.be.null;
+		} );
+
+		it( 'should return null for theme with no parent', () => {
+			const parentId = getWpcomParentThemeId(
+				{
+					themes: {
+						queries: {
+							wpcom: new ThemeQueryManager( {
+								items: { mood }
+							} )
+						}
+					}
+				}, 'mood'
+			);
+			expect( parentId ).to.be.null;
+		} );
+
+		it( 'should return parent id', () => {
+			const parentId = getWpcomParentThemeId(
+				{
+					themes: {
+						queries: {
+							wpcom: new ThemeQueryManager( {
+								items: { sidekick }
+							} )
+						}
+					}
+				}, 'sidekick'
+			);
+			expect( parentId ).to.equal( 'superhero' );
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #11104

Alternative to #11384. This PR uses a selector instead of the dedicated action.

When installing a wpcom theme to a jetpack site, check if the theme requires a parent, and install parent if so.

For testing see #11384 
