### PR TITLE
Jetpack plugins: make installed label more visible

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -12,6 +12,7 @@ import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
 import PluginsStore from 'lib/plugins/store';
 import Rating from 'components/rating/';
 import analytics from 'lib/analytics';
+import Gridicon from 'gridicons';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 
@@ -60,6 +61,7 @@ const PluginsBrowserListElement = React.createClass( {
 		if ( sites && sites.length > 0 || this.isWpcomPreinstalled() ) {
 			return (
 				<div className="plugins-browser-item__installed">
+						<Gridicon icon='checkmark' size={ 18 } />
 						{ this.translate( 'Installed' ) }
 				</div>
 			);

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -116,11 +116,18 @@
 }
 
 .plugins-browser-item__installed {
+	display: flex;
+	align-items: center;
 	position: absolute;
 		bottom: 8px;
 		right: 16px;
-	color: $gray;
+	color: $alert-green;
 	font-size: 10px;
+	font-weight: 600;
 	text-transform: uppercase;
 	animation: appear .15s ease-in;
+
+	.gridicon {
+		margin-right: 3px;
+	}
 }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -332,7 +332,7 @@ const PluginsBrowser = React.createClass( {
 		}
 
 		return (
-			<MainComponent>
+			<MainComponent className="is-wide-layout">
 				{ this.renderDocumentHead() }
 				<SidebarNavigation />
 				{ this.getPageHeaderView() }


### PR DESCRIPTION
fixes #11392 

- Adopt wide layout
- Makes text green and semibold
- Added gridicon

I plan on making the grid items bigger in another PR, to accommodate the wide layout.

Before:
![screen shot 2017-02-15 at 4 48 18 pm](https://cloud.githubusercontent.com/assets/618551/22998927/af0f2b50-f39e-11e6-9fcf-daa22f114d6a.png)

After:
![screen shot 2017-02-15 at 4 48 44 pm](https://cloud.githubusercontent.com/assets/618551/22998919/a78fcac4-f39e-11e6-9cb5-3437bd485d1a.png)
