### PR TITLE
Signup: set the `userFirstSignup` test to 50/50

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -97,8 +97,8 @@ module.exports = {
 	userFirstSignup: {
 		datestamp: '20160124',
 		variations: {
-			userLast: 80,
-			userFirst: 20,
+			userLast: 50,
+			userFirst: 50,
 		},
 		defaultVariation: 'userLast',
 		allowExistingUsers: false,


### PR DESCRIPTION
This PR changes the ratio of the `userFirstSignup` A/B test to 50/50. 

To test: manually inspect the change. 