### PR TITLE
Signup: Enable `domain-first` flow on `wpcalypso`

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -105,6 +105,7 @@
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,
 		"settings/security/scan": true,
+		"signup/domain-first-flow": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,


### PR DESCRIPTION
We need this to be publicly accessible somewhere for user testing.

**Testing**

This is already enabled in development, so the easiest way to test this is to assert that `/start/domain-first` does not redirect away to the main flow in development but does in production.