### PR TITLE
Fix issue with icon alignment in Banner component

### DIFF
--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -72,12 +72,20 @@
 		align-self: center;
 		color: $white;
 		display: block;
+
+		svg {
+			margin-top: 3px;
+		}
 	}
 
 	.banner__icon-circle {
 		color: white;
 		display: none;
 		padding: 3px 4px 4px 3px;
+
+		svg {
+			margin-top: 3px;
+		}
 	}
 
 	@include breakpoint( ">480px" ) {

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -12,6 +12,7 @@
 	border-left: 3px solid;
 	display: flex;
 	padding: 12px 6px 12px 12px;
+	line-height: 29px;
 
 	&.is-dismissible {
 		padding-right: 48px;
@@ -72,20 +73,12 @@
 		align-self: center;
 		color: $white;
 		display: block;
-
-		svg {
-			margin-top: 3px;
-		}
 	}
 
 	.banner__icon-circle {
 		color: white;
 		display: none;
 		padding: 3px 4px 4px 3px;
-
-		svg {
-			margin-top: 3px;
-		}
 	}
 
 	@include breakpoint( ">480px" ) {


### PR DESCRIPTION
When Banner component is used on a page with the an icons unrelated to plans (eg. star, info, etc.), the alignment of the icon within the circle (>480px breakpoint) is incorrect as is the alignment of the icon with text when < 480px breakpoint. 

<img alt="screen_shot" src="https://cldup.com/Vtx8ert8MF.png">

This solution just adds a margin-top of 3px which appears to solve the problem for these specific icons but may not be a comprehensive solution for all scenarios.