### PR TITLE
Posts: Fix detectImage post normalizer when there's an iframe with an empty src

### DIFF
--- a/client/lib/post-normalizer/rule-content-make-embeds-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-embeds-safe.js
@@ -19,7 +19,8 @@ function doesNotNeedSandbox( iframe ) {
 		'kickstarter.com'
 	];
 
-	const iframeHost = iframe.src && url.parse( iframe.src ).hostname.toLowerCase();
+	const hostName = iframe.src && url.parse( iframe.src ).hostname;
+	const iframeHost = hostName && hostName.toLowerCase();
 
 	return some( trustedHosts, trustedHost => endsWith( '.' + iframeHost, '.' + trustedHost ) );
 }

--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -138,8 +138,8 @@ export function iframeIsWhitelisted( iframe ) {
 		'facebook.com',
 		'embed.itunes.apple.com'
 	];
-
-	const iframeSrc = iframe.src && url.parse( iframe.src ).hostname.toLowerCase();
+	const hostName = iframe.src && url.parse( iframe.src ).hostname;
+	const iframeSrc = hostName && hostName.toLowerCase();
 	return some( iframeWhitelist, function( whitelistedSuffix ) {
 		return endsWith( '.' + iframeSrc, '.' + whitelistedSuffix );
 	} );


### PR DESCRIPTION
closes #11411

The rule was failing silently on Chrome and was stoping the posts loading on Safari. 

**Testing instructions**

 - Create a post containing a getty embed ( `[getty src="539147864" width="594" height="441"]` )
 - Navigate to `/posts` using Safari
 - The posts list should load properly