### PR TITLE
Media section: proper icon

### DIFF
--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -139,6 +139,7 @@ const PublishMenu = React.createClass( {
 			case 'page': icon = 'pages'; break;
 			case 'jetpack-portfolio': icon = 'folder'; break;
 			case 'jetpack-testimonial': icon = 'quote'; break;
+			case 'media': icon = 'image'; break;
 			default: icon = 'custom-post-type';
 		}
 


### PR DESCRIPTION
Resolves #10747 

Puts a proper icon here:

<img width="348" alt="zrzut ekranu 2017-02-16 o 12 35 59" src="https://cloud.githubusercontent.com/assets/3775068/23019889/b90cad66-f444-11e6-8b27-4f06a939cf71.png">

CC @iamtakashi @gwwar @rralian 