### PR TITLE
Framework: Upgrade ESLint comma-spacing to error

### DIFF
--- a/client/components/tinymce/plugins/wpcom-view/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-view/plugin.js
@@ -686,7 +686,7 @@ function wpview( editor ) {
 			} else if ( cursorAfter ) {
 				handleEnter( view );
 			} else if ( cursorBefore ) {
-				handleEnter( view , true, key );
+				handleEnter( view, true, key );
 			}
 
 			if ( key === VK.ENTER ) {

--- a/client/state/sharing/publicize/selectors.js
+++ b/client/state/sharing/publicize/selectors.js
@@ -124,13 +124,13 @@ export function isFetchingConnection( state, connectionId ) {
 }
 
 export function isRequestingSharePost( state, siteId, postId ) {
-	return get( state.sharing.publicize.sharePostStatus, [ siteId , postId, 'requesting' ], false );
+	return get( state.sharing.publicize.sharePostStatus, [ siteId, postId, 'requesting' ], false );
 }
 
 export function sharePostSuccessMessage( state, siteId, postId ) {
-	return get( state.sharing.publicize.sharePostStatus, [ siteId , postId, 'success' ], false );
+	return get( state.sharing.publicize.sharePostStatus, [ siteId, postId, 'success' ], false );
 }
 
 export function sharePostFailure( state, siteId, postId ) {
-	return ( get( state.sharing.publicize.sharePostStatus, [ siteId , postId, 'error' ], false ) === true );
+	return ( get( state.sharing.publicize.sharePostStatus, [ siteId, postId, 'error' ], false ) === true );
 }


### PR DESCRIPTION
Related: #8562

This pull request continues the crusade to upgrade all ESLint rules to errors by resolving remaining issues with [`comma-spacing` rule](http://eslint.org/docs/rules/comma-spacing).

**Testing Instructions:**

That CircleCI passes is indication that the changes included are working as intended.

Verify that no regressions have been introduced to affected sections.