### PR TITLE
Site Settings: Update language option copy

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -171,7 +171,7 @@ class SiteSettingsFormGeneral extends Component {
 				<FormSettingExplanation>
 					{ translate( 'Language this blog is primarily written in.' ) }&nbsp;
 					<a href={ config.isEnabled( 'me/account' ) ? '/me/account' : '/settings/account/' }>
-						{ translate( 'You can also modify the interface language in your profile.' ) }
+						{ translate( "You can also modify your interface's language in your profile." ) }
 					</a>
 				</FormSettingExplanation>
 			</FormFieldset>


### PR DESCRIPTION
Changed the copy from "You can also modify the interface language in your profile." to "You can also modify your interface's language in your profile." as suggested in https://github.com/Automattic/wp-calypso/pull/11259#issuecomment-279784641.