### PR TITLE
Themes: Hide upload eligibility card if no messages

### DIFF
--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { includes, find } from 'lodash';
+import { includes, find, isEmpty } from 'lodash';
 import Gridicon from 'gridicons';
 import classNames from 'classnames';
 
@@ -45,6 +45,8 @@ import { getBackPath } from 'state/themes/themes-ui/selectors';
 import { hasFeature } from 'state/sites/plans/selectors';
 import Banner from 'components/banner';
 import { PLAN_BUSINESS, FEATURE_UNLIMITED_PREMIUM_THEMES, FEATURE_UPLOAD_THEMES } from 'lib/plans/constants';
+import QueryEligibility from 'components/data/query-atat-eligibility';
+import { getEligibility } from 'state/automated-transfer/selectors';
 
 const debug = debugFactory( 'calypso:themes:theme-upload' );
 
@@ -64,10 +66,11 @@ class Upload extends React.Component {
 		isJetpack: React.PropTypes.bool,
 		upgradeJetpack: React.PropTypes.bool,
 		backPath: React.PropTypes.string,
+		showEligibility: React.PropTypes.bool,
 	};
 
 	state = {
-		showEligibility: ! this.props.isJetpack,
+		showEligibility: this.props.showEligibility,
 	}
 
 	componentDidMount() {
@@ -80,7 +83,7 @@ class Upload extends React.Component {
 			const { siteId, inProgress } = nextProps;
 			! inProgress && this.props.clearThemeUpload( siteId );
 
-			this.setState( { showEligibility: ! nextProps.isJetpack } );
+			this.setState( { showEligibility: nextProps.showEligibility } );
 		}
 	}
 
@@ -268,10 +271,11 @@ class Upload extends React.Component {
 			isJetpack
 		} = this.props;
 
-		const showEligibility = ! isJetpack && this.state.showEligibility;
+		const { showEligibility } = this.state;
 
 		return (
 			<Main>
+				<QueryEligibility siteId={ siteId } />
 				<QueryActiveTheme siteId={ siteId } />
 				{ themeId && complete && <QueryTheme siteId={ siteId } themeId={ themeId } /> }
 				<ThanksModal
@@ -314,6 +318,11 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const themeId = getUploadedThemeId( state, siteId );
 		const isJetpack = isJetpackSite( state, siteId );
+		const { eligibilityHolds, eligibilityWarnings } = getEligibility( state, siteId );
+		const hasEligibilityMessages = ! (
+			isEmpty( eligibilityHolds ) &&
+			isEmpty( eligibilityWarnings )
+		);
 		return {
 			siteId,
 			isBusiness: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
@@ -330,6 +339,7 @@ export default connect(
 			installing: isInstallInProgress( state, siteId ),
 			upgradeJetpack: isJetpack && ! hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ),
 			backPath: getBackPath( state ),
+			showEligibility: ! isJetpack && hasEligibilityMessages,
 		};
 	},
 	{ uploadTheme, clearThemeUpload, initiateThemeTransfer },

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -46,7 +46,10 @@ import { hasFeature } from 'state/sites/plans/selectors';
 import Banner from 'components/banner';
 import { PLAN_BUSINESS, FEATURE_UNLIMITED_PREMIUM_THEMES, FEATURE_UPLOAD_THEMES } from 'lib/plans/constants';
 import QueryEligibility from 'components/data/query-atat-eligibility';
-import { getEligibility } from 'state/automated-transfer/selectors';
+import {
+	getEligibility,
+	isEligibleForAutomatedTransfer
+} from 'state/automated-transfer/selectors';
 
 const debug = debugFactory( 'calypso:themes:theme-upload' );
 
@@ -82,7 +85,9 @@ class Upload extends React.Component {
 		if ( nextProps.siteId !== this.props.siteId ) {
 			const { siteId, inProgress } = nextProps;
 			! inProgress && this.props.clearThemeUpload( siteId );
+		}
 
+		if ( nextProps.showEligibility !== this.props.showEligibility ) {
 			this.setState( { showEligibility: nextProps.showEligibility } );
 		}
 	}
@@ -319,6 +324,9 @@ export default connect(
 		const themeId = getUploadedThemeId( state, siteId );
 		const isJetpack = isJetpackSite( state, siteId );
 		const { eligibilityHolds, eligibilityWarnings } = getEligibility( state, siteId );
+		// Use this selector to take advantage of eligibility card placeholders
+		// before data has loaded.
+		const isEligible = isEligibleForAutomatedTransfer( state, siteId );
 		const hasEligibilityMessages = ! (
 			isEmpty( eligibilityHolds ) &&
 			isEmpty( eligibilityWarnings )
@@ -339,7 +347,7 @@ export default connect(
 			installing: isInstallInProgress( state, siteId ),
 			upgradeJetpack: isJetpack && ! hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ),
 			backPath: getBackPath( state ),
-			showEligibility: ! isJetpack && hasEligibilityMessages,
+			showEligibility: ! isJetpack && ( hasEligibilityMessages || ! isEligible ),
 		};
 	},
 	{ uploadTheme, clearThemeUpload, initiateThemeTransfer },


### PR DESCRIPTION
If there are no holds or warnings to display, simply show the upload dropzone. This removes the need for the user to click the 'Proceed' button on an empty 'Conflicts' card.

**To Test**
Go to http://calypso.localhost:3000/design/upload and view for different sites.

**No errors/warnings before**
<img width="754" alt="screen shot 2017-02-09 at 13 58 57" src="https://cloud.githubusercontent.com/assets/7767559/22787717/22454682-eed5-11e6-91d6-e1d7f6b0bd82.png">

**No errors/warnings after**
<img width="774" alt="screen shot 2017-02-09 at 13 59 11" src="https://cloud.githubusercontent.com/assets/7767559/22787719/246ab960-eed5-11e6-8aaa-ac587f421835.png">

**Note** this PR should not interfere with the redesign to the eligibility component in #11394 