### PR TITLE
Redirect /help/contact to support.wordpress.com/contact when logged out

### DIFF
--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -14,6 +14,7 @@ export default {
 	COMMUNITY_TRANSLATOR: `${ root }/community-translator`,
 	COMPLETING_GOOGLE_APPS_SIGNUP: `${ root }/adding-g-suite-to-your-site/#completing-sign-up`,
 	CONNECT: `${ root }/connect`,
+	CONTACT: `${ root }/contact`,
 	CALYPSO_CONTACT: '/help/contact',
 	CALYPSO_COURSES: '/help/courses',
 	CREATE: `${ root }/create`,

--- a/client/me/help/controller.js
+++ b/client/me/help/controller.js
@@ -24,9 +24,17 @@ export default {
 			return next();
 		}
 
-		const url = ( context.path === '/help' )
-			? support.SUPPORT_ROOT
-			: userUtils.getLoginUrl( window.location.href );
+		let url;
+		switch ( context.path ) {
+			case '/help':
+				url = support.SUPPORT_ROOT;
+				break;
+			case '/help/contact':
+				url = support.CONTACT;
+				break;
+			default:
+				url = userUtils.getLoginUrl( window.location.href );
+		}
 
 		// Not using the page library here since this is an external URL
 		window.location.href = url;


### PR DESCRIPTION
This pull request adds changes that will redirect logged out users that hit http://wordpress.com/help/contact to https://support.wordpress.com/contact.

## How to test
### As a logged out user
1. Navigate directly to http://calypso.localhost:3000/help/contact
2. Notice that you've been redirected to https://en.support.wordpress.com/contact
### As a logged in user
1. Navigate directly to http://calypso.localhost:3000/help/contact
2. Notice that you are taken to the calypso contact form.
### Regression

This pull request also touches code that handles the routes for /help and /help/courses so lets test to make sure thats working correctly
#### As a logged out user
1. Navigate directly to http://calypso.localhost:3000/help/courses
2. Confirm you are taken to the login screen
3. log in
4. Confirm you are redirected back to /help/courses where you can see the course list
#### As a logged in user
1. Navigate directly to http://calypso.localhost:3000/help
2. Confirm that you see the calypso help page
3. Navigate directly to http://calypso.localhost:3000/help/courses
4. Confirm that you see the help courses page
