### PR TITLE
Jetpack plugins: tweak browser design

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -14,7 +14,7 @@
 	}
 
 	.plugins-browser-item__link {
-		padding: 16px 16px 48px 16px;
+		padding: 16px 16px 48px;
 		display: block;
 	}
 

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -4,7 +4,6 @@
 	cursor: pointer;
 	display: block;
 	float: left;
-	height: 96px;
 	margin: 0;
 	position: relative;
 	overflow: hidden;
@@ -15,7 +14,7 @@
 	}
 
 	.plugins-browser-item__link {
-		padding: 16px;
+		padding: 16px 16px 48px 16px;
 		display: block;
 	}
 
@@ -58,8 +57,8 @@
 
 .plugins-browser-item {
 	.plugin-icon {
-		width: 40px;
-		height: 40px;
+		width: 48px;
+		height: 48px;
 
 		&.is-placeholder {
 			animation: loading-fade 1.6s ease-in-out infinite;
@@ -74,10 +73,7 @@
 
 .plugins-browser-item__title,
 .plugins-browser-item__author {
-	margin-left: 52px;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	overflow: hidden;
+	margin-left: 60px;
 
 	.is-placeholder & {
 		color: transparent;
@@ -87,15 +83,15 @@
 }
 
 .plugins-browser-item__title {
-	color: darken( $gray, 20% );
+	color: $gray-dark;
 	font-weight: 600;
-	font-size: 14px;
+	font-size: 15px;
+	margin-top: 3px;
 }
 
 .plugins-browser-item__author {
 	color: $gray;
-	font-size: 10px;
-	text-transform: uppercase;
+	font-size: 13px;
 }
 
 .plugins-browser-item .plugin-icon.is-placeholder,
@@ -113,16 +109,19 @@
 
 .plugins-browser-item  .rating {
 	padding-top: 10px;
+	position: absolute;
+		bottom: 16px;
+		left: 16px;
 }
 
 .plugins-browser-item__installed {
 	display: flex;
 	align-items: center;
 	position: absolute;
-		bottom: 8px;
+		bottom: 16px;
 		right: 16px;
 	color: $alert-green;
-	font-size: 10px;
+	font-size: 11px;
 	font-weight: 600;
 	text-transform: uppercase;
 	animation: appear .15s ease-in;

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -73,6 +73,9 @@
 
 .plugins-browser-item__title,
 .plugins-browser-item__author {
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	overflow: hidden;
 	margin-left: 60px;
 
 	.is-placeholder & {

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -31,18 +31,6 @@
 	}
 
 	@include breakpoint( "<960px" ) {
-		width: 50%;
-
-		&:nth-child( 2n + 1 )  {
-			border-left: 0;
-		}
-
-		&:nth-child( n + 3 ) {
-			border-top: 1px solid lighten( $gray, 30% );
-		}
-	}
-
-	@include breakpoint( "<480px" ) {
 		width: 100%;
 
 		&:nth-child( n + 2 ) {

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -68,7 +68,6 @@
 
 .plugins-browser-item__info {
 	overflow: hidden; // lazy clearfix
-	margin-bottom: 5px;
 }
 
 .plugins-browser-item__title,

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -58,7 +58,7 @@ export default React.createClass( {
 		if ( this.props.expandedListLink ) {
 			return <a className="button is-link plugins-browser-list__select-all" href={ this.props.expandedListLink + ( this.props.site || '' ) }>
 				{ this.translate( 'See All' ) }
-				<Gridicon icon="chevron-right" size={ 12 } />
+				<Gridicon icon="chevron-right" size={ 18 } />
 			</a>;
 		}
 	},

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -39,7 +39,7 @@
 }
 
 .plugins-browser-list__elements {
-	min-height: 50px;
-	overflow: hidden; // lazy clearfix
+	display: flex;
+	flex-wrap: wrap;
 	padding: 0;
 }

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -29,10 +29,8 @@
 	}
 	.gridicon {
 		float: right;
-		top: 5px;
+		top: 2px;
 		margin-left: 3px;
-		width: 12px;
-		height: 12px;
 	}
 }
 


### PR DESCRIPTION
fixes #11393 

Biggest change is that now the plugin titles do not truncate.

![screen shot 2017-02-16 at 12 18 11 pm](https://cloud.githubusercontent.com/assets/618551/23034610/02e493e8-f442-11e6-8fb8-9b8111fd374c.png)


Changes:

- flex layout so that grids items can expand vertically
- bigger text and plugin icons
- increase text contrast
- remove text truncation
- `See All` button now uses standard 18px gridicon

cc @MichaelArestad 

Before:

![8bivpqqqxafngaaaaasuvork5cyii](https://cloud.githubusercontent.com/assets/618551/23034387/4a194296-f441-11e6-881a-2671a8b33461.png)
![wgsma4vqpvivqaaaabjru5erkjggg](https://cloud.githubusercontent.com/assets/618551/23034388/4a280f7e-f441-11e6-99fa-412184723281.png)

After:

![wnbvh fwqocljletlxaaaaaelftksuqmcc](https://cloud.githubusercontent.com/assets/618551/23034415/6079f396-f441-11e6-8025-7fae38f5816d.png)
![wkyx6kasm5 sqaaaabjru5erkjggg](https://cloud.githubusercontent.com/assets/618551/23034416/608998fa-f441-11e6-90ce-4a20b4207fd7.png)

[Here's the design before the wide layout](https://cloud.githubusercontent.com/assets/618551/23034453/7c90cd34-f441-11e6-8915-1c4afa73a791.png)