### PR TITLE
Build: Make webpack module IDs more stable

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -454,7 +454,7 @@
       "version": "2.11.0"
     },
     "body-parser": {
-      "version": "1.16.1",
+      "version": "1.17.0",
       "dependencies": {
         "debug": {
           "version": "2.6.1"
@@ -463,7 +463,7 @@
           "version": "0.7.2"
         },
         "qs": {
-          "version": "6.2.1"
+          "version": "6.3.1"
         }
       }
     },
@@ -537,7 +537,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000626"
+      "version": "1.0.30000631"
     },
     "caseless": {
       "version": "0.11.0"
@@ -936,7 +936,7 @@
       "version": "1.0.0"
     },
     "delegate": {
-      "version": "3.1.1"
+      "version": "3.1.2"
     },
     "delegates": {
       "version": "1.0.0"
@@ -1569,10 +1569,10 @@
       }
     },
     "for-in": {
-      "version": "0.1.6"
+      "version": "1.0.2"
     },
     "for-own": {
-      "version": "0.1.4"
+      "version": "0.1.5"
     },
     "foreach": {
       "version": "2.0.5"
@@ -1697,7 +1697,7 @@
       }
     },
     "good-listener": {
-      "version": "1.2.1"
+      "version": "1.2.2"
     },
     "got": {
       "version": "3.3.1",
@@ -1835,7 +1835,7 @@
       "version": "1.7.0"
     },
     "http-errors": {
-      "version": "1.5.1",
+      "version": "1.6.1",
       "dependencies": {
         "inherits": {
           "version": "2.0.3"
@@ -2173,7 +2173,7 @@
       "version": "3.0.1"
     },
     "js-yaml": {
-      "version": "3.8.1",
+      "version": "3.8.2",
       "dev": true
     },
     "jsdom": {
@@ -2314,7 +2314,7 @@
       }
     },
     "levelup": {
-      "version": "1.3.3"
+      "version": "1.3.5"
     },
     "levn": {
       "version": "0.3.0",
@@ -2411,7 +2411,7 @@
       "version": "1.6.0"
     },
     "lower-case": {
-      "version": "1.1.3"
+      "version": "1.1.4"
     },
     "lower-case-first": {
       "version": "1.0.2"
@@ -2606,7 +2606,7 @@
       }
     },
     "node-abi": {
-      "version": "1.3.3"
+      "version": "2.0.0"
     },
     "node-contains": {
       "version": "1.0.0"
@@ -2855,6 +2855,9 @@
       "version": "1.0.2",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.5"
+    },
     "path-to-regexp": {
       "version": "0.1.7"
     },
@@ -2939,7 +2942,7 @@
       "version": "3.3.0"
     },
     "prebuild-install": {
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "minimist": {
           "version": "1.2.0"
@@ -3279,7 +3282,7 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.2.0"
+      "version": "1.3.2"
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -3293,7 +3296,7 @@
       "version": "0.1.3"
     },
     "rimraf": {
-      "version": "2.6.0",
+      "version": "2.6.1",
       "dependencies": {
         "glob": {
           "version": "7.1.1"
@@ -3430,8 +3433,20 @@
           "version": "1.0.3",
           "dev": true
         },
+        "http-errors": {
+          "version": "1.5.1",
+          "dev": true
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "dev": true
+        },
         "negotiator": {
           "version": "0.6.1",
+          "dev": true
+        },
+        "setprototypeof": {
+          "version": "1.0.2",
           "dev": true
         }
       }
@@ -3466,7 +3481,7 @@
       "version": "1.0.5"
     },
     "setprototypeof": {
-      "version": "1.0.2"
+      "version": "1.0.3"
     },
     "sha.js": {
       "version": "2.2.6"
@@ -3601,7 +3616,7 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.10.2",
+      "version": "1.11.0",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0"
@@ -4105,6 +4120,10 @@
           "version": "1.0.6",
           "dev": true
         },
+        "debug": {
+          "version": "2.6.1",
+          "dev": true
+        },
         "destroy": {
           "version": "1.0.4",
           "dev": true
@@ -4113,16 +4132,24 @@
           "version": "1.0.3",
           "dev": true
         },
+        "etag": {
+          "version": "1.8.0",
+          "dev": true
+        },
         "express": {
-          "version": "4.14.1",
+          "version": "4.15.0",
           "dev": true
         },
         "filesize": {
-          "version": "3.5.4",
+          "version": "3.5.5",
           "dev": true
         },
         "finalhandler": {
-          "version": "0.5.1",
+          "version": "1.0.0",
+          "dev": true
+        },
+        "fresh": {
+          "version": "0.5.0",
           "dev": true
         },
         "ipaddr.js": {
@@ -4150,7 +4177,7 @@
           "dev": true
         },
         "qs": {
-          "version": "6.2.0",
+          "version": "6.3.1",
           "dev": true
         },
         "range-parser": {
@@ -4158,11 +4185,11 @@
           "dev": true
         },
         "send": {
-          "version": "0.14.2",
+          "version": "0.15.0",
           "dev": true
         },
         "serve-static": {
-          "version": "1.11.2",
+          "version": "1.12.0",
           "dev": true
         },
         "supports-color": {
@@ -4238,7 +4265,7 @@
           "dev": true
         },
         "filesize": {
-          "version": "3.5.4",
+          "version": "3.5.5",
           "dev": true
         },
         "isarray": {
@@ -4331,11 +4358,14 @@
         }
       }
     },
+    "webpack-stable-module-id-and-hash": {
+      "version": "1.0.5"
+    },
     "wemoji": {
       "version": "0.1.9"
     },
     "whatwg-fetch": {
-      "version": "2.0.2"
+      "version": "2.0.3"
     },
     "whatwg-url": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "walk": "2.3.4",
     "webpack": "1.13.1",
     "webpack-dev-middleware": "1.2.0",
+    "webpack-stable-module-id-and-hash": "1.0.5",
     "wpcom": "5.3.0",
     "wpcom-oauth": "0.3.3",
     "wpcom-proxy-request": "3.0.0",
@@ -192,5 +193,6 @@
     "webpack-bundle-analyzer": "2.2.1",
     "webpack-dashboard": "0.2.0",
     "webpack-dev-server": "1.11.0"
+
   }
 }

--- a/webpack-dll.config.js
+++ b/webpack-dll.config.js
@@ -3,6 +3,7 @@
  */
 const path = require( 'path' );
 const webpack = require( 'webpack' );
+const WebpackStableModuleIdAndHash = require( 'webpack-stable-module-id-and-hash' );
 
 /**
  * Internal Dependencies
@@ -45,7 +46,7 @@ module.exports = {
 				NODE_ENV: JSON.stringify( bundleEnv )
 			}
 		} ),
-		new webpack.optimize.OccurenceOrderPlugin()
+		new WebpackStableModuleIdAndHash()
 	],
 	module: {
 		loaders: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,8 @@ const config = require( './server/config' ),
 	cacheIdentifier = require( './server/bundler/babel/babel-loader-cache-identifier' ),
 	ChunkFileNamePlugin = require( './server/bundler/plugin' ),
 	CopyWebpackPlugin = require( 'copy-webpack-plugin' ),
-	HardSourceWebpackPlugin = require( 'hard-source-webpack-plugin' );
+	HardSourceWebpackPlugin = require( 'hard-source-webpack-plugin' ),
+	WebpackStableModuleIdAndHash = require( 'webpack-stable-module-id-and-hash' );
 
 /**
  * Internal variables
@@ -92,7 +93,7 @@ const webpackConfig = {
 				NODE_ENV: JSON.stringify( bundleEnv )
 			}
 		} ),
-		new webpack.optimize.OccurenceOrderPlugin( true ),
+		new WebpackStableModuleIdAndHash(),
 		new webpack.IgnorePlugin( /^props$/ ),
 		new CopyWebpackPlugin( [ { from: 'node_modules/flag-icon-css/flags/4x3', to: 'images/flags' } ] )
 	],


### PR DESCRIPTION
Use the `webpack-stable-module-id-and-hash` plugin to help webpack generate stable module IDs and better chunk hashes.

Prior, we were using the `OccurenceOrderPlugin`, which assigns module IDs by frequency of occurrence. This kept module ids mostly stable, but there was a catch. Webpack generates the hash for a chunk based on the contents of the chunk, but sometimes does not update the hash of the chunk when only module IDs change.  ( https://github.com/webpack/webpack/issues/1856 )


This means that if the module IDs generated by `OccurenceOrderPlugin` change because we use a module slightly more often, or introduce a new module that's used > 1 place, the hashes of the chunks that reference the module will not change and our CDN won't get the new file.

Refs:
https://github.com/webpack/webpack/issues/1856
https://github.com/webpack/webpack/issues/1315
https://github.com/zhenyong/webpack-stable-module-id-and-hash