### PR TITLE
AT: Enable Domain Management Section

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -367,7 +367,7 @@ module.exports = {
 		const basePath = route.sectionify( context.path );
 		const selectedSite = sites.getSelectedSite();
 
-		if ( selectedSite && selectedSite.jetpack ) {
+		if ( selectedSite && selectedSite.jetpack && ! ( config.isEnabled( 'automated-transfer' ) ) ) {
 			renderWithReduxStore( (
 				<Main>
 					<JetpackManageErrorPage

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -324,7 +324,7 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		if ( site.jetpack ) {
+		if ( site.jetpack && ! ( config.isEnabled( 'automated-transfer' ) ) ) {
 			return null;
 		}
 

--- a/client/my-sites/upgrades/navigation.jsx
+++ b/client/my-sites/upgrades/navigation.jsx
@@ -50,11 +50,12 @@ const PlansNavigation = React.createClass( {
 
 	render() {
 		const site = this.props.selectedSite;
-		const isJetpack = site && site.jetpack;
 		const path = sectionify( this.props.path );
 		const hasPlan = site && site.plan && site.plan.product_slug !== 'free_plan';
 		const sectionTitle = path.split( '?' )[ 0 ].replace( /\//g, ' ' );
 		const userCanManageOptions = get( site, 'capabilities.manage_options', false );
+		const canManageDomain = userCanManageOptions &&
+			( config.isEnabled( 'automated-transfer' ) || ! site.jetpack );
 
 		return (
 			<SectionNav
@@ -70,13 +71,13 @@ const PlansNavigation = React.createClass( {
 					<NavItem path={ `/plans/${ site.slug }` } key="plans" selected={ path === '/plans' || path === '/plans/monthly' }>
 						{ this.translate( 'Plans' ) }
 					</NavItem>
-					{ ! isJetpack && userCanManageOptions &&
+					{ canManageDomain &&
 						<NavItem path={ `/domains/manage/${ site.slug }` } key="domains"
 							selected={ path === '/domains/manage' || path === '/domains/add' }>
 							{ this.translate( 'Domains' ) }
 						</NavItem>
 					}
-					{ ! isJetpack && userCanManageOptions &&
+					{ canManageDomain &&
 						<NavItem path={ `/domains/manage/email/${ site.slug }` } key="googleApps"
 							selected={ path === '/domains/manage/email' }>
 							{ this.translate( 'Email' ) }


### PR DESCRIPTION
This broadly enables domain management section for *all* Jetpack sites when `automated-transfer` flag is enabled.

There are plenty of things not working, we'll remove the interfaces for those in subsequent PRs.

