### PR TITLE
Reader: fix squashed emoji in IE11

### DIFF
--- a/assets/stylesheets/_main.scss
+++ b/assets/stylesheets/_main.scss
@@ -271,6 +271,7 @@ img.wp-smiley {
 	margin: 0;
 	padding: 0 0.2em;
 	vertical-align: -0.1em;
+	width: 1em;
 }
 
 /* =Media

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -321,11 +321,6 @@
 		bottom: 2px;
 		left: 2px;
 		right: 2px;
-
-	img.emoji {
-		width: 1em;
-		height: 1em;
-	}
 }
 
 .tiled-gallery .tiled-gallery-item-small .tiled-gallery-caption { /* Smaller captions */

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -321,6 +321,11 @@
 		bottom: 2px;
 		left: 2px;
 		right: 2px;
+
+	img.emoji {
+		width: 1em;
+		height: 1em;
+	}
 }
 
 .tiled-gallery .tiled-gallery-item-small .tiled-gallery-caption { /* Smaller captions */


### PR DESCRIPTION
This fixes one issue in #10028 where twemoji (when they appeared) appeared squashed. Fix works on all emoji not just in tiled galleries, but anywhere in a post.

Before:

<img width="301" alt="d805652a-c210-11e6-955c-49952b89b01c" src="https://cloud.githubusercontent.com/assets/2627210/23052589/9733043c-f526-11e6-8633-dc2375b43405.png">

After:

![twemoji fixed on ie11](https://cloud.githubusercontent.com/assets/2627210/23052578/80e815fa-f526-11e6-8106-b5ed7281978d.png)