### PR TITLE
Remove all references to NODE_ENV and CALYPSO_ENV

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -1,6 +1,7 @@
 // Initialize localStorage polyfill before any dependencies are loaded
 require( 'lib/local-storage' )();
-if ( process.env.NODE_ENV === 'development' ) {
+const config = require( 'config' );
+if ( config( 'env' ) === 'development' ) {
 	require( 'lib/wrap-es6-functions' )();
 }
 
@@ -24,8 +25,7 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 // lib/local-storage must be run before lib/user
-var config = require( 'config' ),
-	abtestModule = require( 'lib/abtest' ),
+var abtestModule = require( 'lib/abtest' ),
 	getSavedVariations = abtestModule.getSavedVariations,
 	switchLocale = require( 'lib/i18n-utils/switch-locale' ),
 	analytics = require( 'lib/analytics' ),
@@ -120,7 +120,7 @@ function setUpContext( reduxStore ) {
 }
 
 function loadDevModulesAndBoot() {
-	if ( process.env.NODE_ENV === 'development' && config.isEnabled( 'render-visualizer' ) ) {
+	if ( config( 'env' ) === 'development' && config.isEnabled( 'render-visualizer' ) ) {
 		// Use Webpack's code splitting feature to put the render visualizer in a separate fragment.
 		// This way it won't get downloaded unless this feature is enabled.
 		// Since loading this fragment is asynchronous and we need to inject this mixin into all React classes,

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -148,7 +148,7 @@ const analytics = {
 
 			eventProperties = eventProperties || {};
 
-			if ( process.env.NODE_ENV !== 'production' ) {
+			if ( config( 'env' ) !== 'production' ) {
 				for ( const key in eventProperties ) {
 					if ( isObjectLike( eventProperties[ key ] ) && typeof console !== 'undefined' ) {
 						console.error( `Unable to record event "${ eventName }" because nested properties are not supported by Tracks. Check '${ key }' on`, eventProperties ); //eslint-disable-line no-console

--- a/client/lib/create-selector/index.js
+++ b/client/lib/create-selector/index.js
@@ -1,8 +1,14 @@
 /**
  * External dependencies
  */
-import memoize from 'lodash/memoize';
+import { memoize, includes } from 'lodash';
 import shallowEqual from 'react-pure-render/shallowEqual';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import warn from 'lib/warn';
 
 /**
  * Constants
@@ -36,14 +42,7 @@ const DEFAULT_GET_DEPENDANTS = ( state ) => state;
  * @type {Function} Function returning cache key for memoized selector
  */
 const DEFAULT_GET_CACHE_KEY = ( () => {
-	let warn, includes;
-	if ( 'production' !== process.env.NODE_ENV ) {
-		// Webpack can optimize bundles if it can detect that a block will
-		// never be reached. Since `NODE_ENV` is defined using DefinePlugin,
-		// these debugging modules will be excluded from the production build.
-		warn = require( 'lib/warn' );
-		includes = require( 'lodash/includes' );
-	} else {
+	if ( 'production' === config( 'env' ) ) {
 		return ( state, ...args ) => args.join();
 	}
 
@@ -104,4 +103,3 @@ export default function createSelector( selector, getDependants = DEFAULT_GET_DE
 		return memoizedSelector( state, ...args );
 	}, { memoizedSelector } );
 }
-

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -9,6 +9,7 @@ import debugFactory from 'debug';
  */
 import { mc, ga, tracks } from 'lib/analytics';
 import SubscriptionStore from 'lib/reader-feed-subscriptions';
+import config from 'config';
 
 const debug = debugFactory( 'calypso:reader:stats' );
 
@@ -96,7 +97,7 @@ export function recordTrack( eventName, eventProperties ) {
 		eventProperties = Object.assign( { subscription_count: subCount }, eventProperties );
 	}
 
-	if ( process.env.NODE_ENV !== 'production' ) {
+	if ( config( 'env' ) !== 'production' ) {
 		if ( 'blog_id' in eventProperties && 'post_id' in eventProperties && ! ( 'is_jetpack' in eventProperties ) ) {
 			console.warn( 'consider using recordTrackForPost...', eventName, eventProperties ); //eslint-disable-line no-console
 		}
@@ -143,7 +144,7 @@ export function recordTrackForPost( eventName, post = {}, additionalProps = {} )
 	if ( post.railcar && tracksRailcarEventWhitelist.has( eventName ) ) {
 		// check for overrides for the railcar
 		recordTracksRailcarInteract( eventName, post.railcar, pick( additionalProps, [ 'ui_position', 'ui_algo' ] ) );
-	} else if ( process.env.NODE_ENV !== 'production' && post.railcar ) {
+	} else if ( config( 'env' ) !== 'production' && post.railcar ) {
 		console.warn( 'Consider whitelisting reader track', eventName ); //eslint-disable-line no-console
 	}
 }

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -48,7 +48,7 @@ import { JPC_PLANS_PAGE } from './constants';
  *  Local variables;
  */
 const _fetching = {};
-const calypsoEnv = config( 'env_id' ) || process.env.NODE_ENV;
+const calypsoEnv = config( 'env_id' );
 const remoteAuthPath = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&calypso_env=' + calypsoEnv;
 const remoteInstallPath = '/wp-admin/plugin-install.php?tab=plugin-information&plugin=jetpack';
 const remoteActivatePath = '/wp-admin/plugins.php';

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -12,6 +12,7 @@ import {
 	SERIALIZE,
 } from './action-types';
 import warn from 'lib/warn';
+import config from 'config';
 
 export function isValidStateWithSchema( state, schema ) {
 	const validate = validator( schema );
@@ -214,7 +215,7 @@ export function createReducer( initialState = null, customHandlers = {}, schema 
 	return ( state = initialState, action ) => {
 		const { type } = action;
 
-		if ( 'production' !== process.env.NODE_ENV && 'type' in action && ! type ) {
+		if ( 'production' !== config( 'env' ) && 'type' in action && ! type ) {
 			throw new TypeError( 'Reducer called with undefined type.' +
 				' Verify that the action type is defined in state/action-types.js' );
 		}

--- a/server/api/test/index.js
+++ b/server/api/test/index.js
@@ -46,7 +46,7 @@ describe( 'api', function() {
 	} );
 
 	let maybeIt = it;
-	if ( process.env.NODE_ENV !== 'desktop' ) {
+	if ( config( 'env' ) !== 'desktop' ) {
 		maybeIt = maybeIt.skip;
 	}
 

--- a/server/api/test/index.js
+++ b/server/api/test/index.js
@@ -10,16 +10,16 @@ import supertest from 'supertest';
  */
 import { allowNetworkAccess } from 'test/helpers/nock-control';
 import { useSandbox } from 'test/helpers/use-sinon';
+import config from 'config';
 
 describe( 'api', function() {
-	let app, config, localRequest, sandbox;
+	let app, localRequest, sandbox;
 
 	allowNetworkAccess();
 	useSandbox( newSandbox => sandbox = newSandbox );
 
 	before( () => {
-		config = require( 'config' );
-		sandbox.stub( config, 'isEnabled' ).withArgs( 'oauth' ).returns( true );
+		config.isEnabled = arg => arg === 'oauth';
 		app = require( '../' )();
 		localRequest = supertest( app );
 	} );

--- a/server/api/test/index.js
+++ b/server/api/test/index.js
@@ -10,16 +10,17 @@ import supertest from 'supertest';
  */
 import { allowNetworkAccess } from 'test/helpers/nock-control';
 import { useSandbox } from 'test/helpers/use-sinon';
-import config from 'config';
+import unmodifiedConfig from 'config';
 
 describe( 'api', function() {
-	let app, localRequest, sandbox;
+	let app, config, localRequest, sandbox;
 
 	allowNetworkAccess();
 	useSandbox( newSandbox => sandbox = newSandbox );
 
 	before( () => {
-		config.isEnabled = arg => arg === 'oauth';
+		config = require( 'config' );
+		sandbox.stub( config, 'isEnabled' ).withArgs( 'oauth' ).returns( true );
 		app = require( '../' )();
 		localRequest = supertest( app );
 	} );
@@ -46,7 +47,7 @@ describe( 'api', function() {
 	} );
 
 	let maybeIt = it;
-	if ( config( 'env' ) !== 'desktop' ) {
+	if ( unmodifiedConfig( 'env_id' ) !== 'desktop' ) {
 		maybeIt = maybeIt.skip;
 	}
 

--- a/server/bundler/bin/bundler.js
+++ b/server/bundler/bin/bundler.js
@@ -21,7 +21,6 @@ var webpackConfig = require( process.cwd() + '/webpack.config' ),
  * Variables
  */
 var start = new Date().getTime(),
-	CALYPSO_ENV = process.env.CALYPSO_ENV || 'development',
 	bundleEnv = config( 'env' ),
 	outputOptions;
 

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -22,10 +22,10 @@ import { createReduxStore } from 'state';
 
 const debug = debugFactory( 'calypso:pages' );
 
-let HASH_LENGTH = 10,
-	URL_BASE_PATH = '/calypso',
-	SERVER_BASE_PATH = '/public',
-	CALYPSO_ENV = process.env.CALYPSO_ENV || process.env.NODE_ENV || 'development';
+const HASH_LENGTH = 10;
+const URL_BASE_PATH = '/calypso';
+const SERVER_BASE_PATH = '/public';
+const calypsoEnv = config( 'env' );
 
 const staticFiles = [
 	{ path: 'style.css' },
@@ -123,7 +123,7 @@ function getDefaultContext( request ) {
 		compileDebug: config( 'env' ) === 'development' ? true : false,
 		urls: generateStaticUrls( request ),
 		user: false,
-		env: CALYPSO_ENV,
+		env: calypsoEnv,
 		sanitize: sanitize,
 		isRTL: config( 'rtl' ),
 		isDebug: request.query.debug !== undefined ? true : false,
@@ -145,26 +145,26 @@ function getDefaultContext( request ) {
 		tinymceEditorCss: context.urls[ 'editor.css' ]
 	};
 
-	if ( CALYPSO_ENV === 'wpcalypso' ) {
-		context.badge = CALYPSO_ENV;
+	if ( calypsoEnv === 'wpcalypso' ) {
+		context.badge = calypsoEnv;
 		context.devDocs = true;
 		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/';
 		context.faviconURL = '/calypso/images/favicons/favicon-wpcalypso.ico';
 	}
 
-	if ( CALYPSO_ENV === 'horizon' ) {
+	if ( calypsoEnv === 'horizon' ) {
 		context.badge = 'feedback';
 		context.feedbackURL = 'https://horizonfeedback.wordpress.com/';
 		context.faviconURL = '/calypso/images/favicons/favicon-horizon.ico';
 	}
 
-	if ( CALYPSO_ENV === 'stage' ) {
+	if ( calypsoEnv === 'stage' ) {
 		context.badge = 'staging';
 		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/';
 		context.faviconURL = '/calypso/images/favicons/favicon-staging.ico';
 	}
 
-	if ( CALYPSO_ENV === 'development' ) {
+	if ( calypsoEnv === 'development' ) {
 		context.badge = 'dev';
 		context.devDocs = true;
 		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/';

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -25,7 +25,7 @@ const debug = debugFactory( 'calypso:pages' );
 const HASH_LENGTH = 10;
 const URL_BASE_PATH = '/calypso';
 const SERVER_BASE_PATH = '/public';
-const calypsoEnv = config( 'env' );
+const calypsoEnv = config( 'env_id' );
 
 const staticFiles = [
 	{ path: 'style.css' },

--- a/webpack-dll.config.js
+++ b/webpack-dll.config.js
@@ -4,13 +4,6 @@
 const path = require( 'path' );
 const webpack = require( 'webpack' );
 
-/**
- * Internal Dependencies
- */
-const config = require( './server/config' );
-
-const bundleEnv = config( 'env' );
-
 module.exports = {
 	entry: {
 		vendor: [
@@ -39,11 +32,6 @@ module.exports = {
 			path: path.join( __dirname, 'build', 'dll', '[name]-manifest.json' ),
 			name: '[name]',
 			context: path.resolve( __dirname, 'client' )
-		} ),
-		new webpack.DefinePlugin( {
-			'process.env': {
-				NODE_ENV: JSON.stringify( bundleEnv )
-			}
 		} ),
 		new webpack.optimize.OccurenceOrderPlugin()
 	],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,13 +20,10 @@ const config = require( './server/config' ),
 /**
  * Internal variables
  */
-const CALYPSO_ENV = process.env.CALYPSO_ENV || 'development';
-
-const bundleEnv = config( 'env' );
 const sectionCount = sections.length;
 
 const webpackConfig = {
-	bail: CALYPSO_ENV !== 'development',
+	bail: config( 'env' ) !== 'development',
 	cache: true,
 	entry: {},
 	devtool: '#eval',
@@ -87,11 +84,6 @@ const webpackConfig = {
 		fs: 'empty'
 	},
 	plugins: [
-		new webpack.DefinePlugin( {
-			'process.env': {
-				NODE_ENV: JSON.stringify( bundleEnv )
-			}
-		} ),
 		new webpack.optimize.OccurenceOrderPlugin( true ),
 		new webpack.IgnorePlugin( /^props$/ ),
 		new CopyWebpackPlugin( [ { from: 'node_modules/flag-icon-css/flags/4x3', to: 'images/flags' } ] )
@@ -99,7 +91,7 @@ const webpackConfig = {
 	externals: [ 'electron' ]
 };
 
-if ( CALYPSO_ENV === 'desktop' ) {
+if ( config( 'env' ) === 'desktop' ) {
 	// no chunks or dll here, just one big file for the desktop app
 	webpackConfig.output.filename = '[name].js';
 } else {
@@ -165,7 +157,7 @@ const jsLoader = {
 	}
 };
 
-if ( CALYPSO_ENV === 'development' ) {
+if ( config( 'env' ) === 'development' ) {
 	const DashboardPlugin = require( 'webpack-dashboard/plugin' );
 	webpackConfig.plugins.splice( 0, 0, new DashboardPlugin() );
 	webpackConfig.plugins.push( new webpack.HotModuleReplacementPlugin() );
@@ -194,7 +186,7 @@ if ( CALYPSO_ENV === 'development' ) {
 	webpackConfig.devtool = false;
 }
 
-if ( CALYPSO_ENV === 'production' ) {
+if ( config( 'env' ) === 'production' ) {
 	webpackConfig.plugins.push( new webpack.NormalModuleReplacementPlugin(
 		/^debug$/,
 		path.join( __dirname, 'client', 'lib', 'debug-noop' )

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,8 +22,10 @@ const config = require( './server/config' ),
  */
 const sectionCount = sections.length;
 
+const calypsoEnv = config( 'env_id' );
+
 const webpackConfig = {
-	bail: config( 'env' ) !== 'development',
+	bail: calypsoEnv !== 'development',
 	cache: true,
 	entry: {},
 	devtool: '#eval',
@@ -91,7 +93,7 @@ const webpackConfig = {
 	externals: [ 'electron' ]
 };
 
-if ( config( 'env' ) === 'desktop' ) {
+if ( calypsoEnv === 'desktop' ) {
 	// no chunks or dll here, just one big file for the desktop app
 	webpackConfig.output.filename = '[name].js';
 } else {
@@ -157,7 +159,7 @@ const jsLoader = {
 	}
 };
 
-if ( config( 'env' ) === 'development' ) {
+if ( calypsoEnv === 'development' ) {
 	const DashboardPlugin = require( 'webpack-dashboard/plugin' );
 	webpackConfig.plugins.splice( 0, 0, new DashboardPlugin() );
 	webpackConfig.plugins.push( new webpack.HotModuleReplacementPlugin() );
@@ -186,7 +188,7 @@ if ( config( 'env' ) === 'development' ) {
 	webpackConfig.devtool = false;
 }
 
-if ( config( 'env' ) === 'production' ) {
+if ( calypsoEnv === 'production' ) {
 	webpackConfig.plugins.push( new webpack.NormalModuleReplacementPlugin(
 		/^debug$/,
 		path.join( __dirname, 'client', 'lib', 'debug-noop' )

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -36,7 +36,6 @@ function getExternals() {
 	externals[ 'webpack.config' ] = 'commonjs webpack.config';
 	// Exclude hot-reloader, as webpack will try and resolve this in production builds,
 	// and error.
-	// TODO: use WebpackDefinePlugin for CALYPSO_ENV, so we can make conditional requires work
 	externals[ 'bundler/hot-reloader' ] = 'commonjs bundler/hot-reloader';
 	// Exclude the devdocs search-index, as it's huge.
 	externals[ 'devdocs/search-index' ] = 'commonjs devdocs/search-index';


### PR DESCRIPTION
This PR seeks to remove all references to `NODE_ENV` and `CALYPSO_ENV`, esp from the client.  It converts them to `config( 'env' )` or `config( 'env_id' )`.  This is favorable because NODE_ENV will only capture `development` and `production` whereas through config we can get wpcalypso/horizon/staging etc.

After this PR the only javascript files in wp-calypso that still reference those them directly are:
1. server/bundler/babel/babel-loader-cache-identifier/index.js:  
2. server/config/index.js: 
3. test/run-mocha.js:

Part of https://github.com/Automattic/wp-calypso/pull/11352


For the reviewer:
> Is it okay to remove the DefinePlugin for process.env in Webpack?

To Test:
 - test out docker build in multiple stages (`make docker-build && make docker-run`)
 - `make run`