### PR TITLE
Post: Update view link to open in-app versus a new window

### DIFF
--- a/client/my-sites/posts/post-controls.jsx
+++ b/client/my-sites/posts/post-controls.jsx
@@ -4,7 +4,6 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import url from 'url';
 import classNames from 'classnames';
 import { includes, noop } from 'lodash';
 import Gridicon from 'gridicons';
@@ -16,9 +15,8 @@ import { isEnabled } from 'config';
 import { ga } from 'lib/analytics';
 import { userCan } from 'lib/posts/utils';
 import { isPublicizeEnabled } from 'state/selectors';
+import { isSitePreviewable } from 'state/sites/selectors';
 
-const view = () => ga.recordEvent( 'Posts', 'Clicked View Post' );
-const preview = () => ga.recordEvent( 'Posts', 'Clicked Preiew Post' );
 const edit = () => ga.recordEvent( 'Posts', 'Clicked Edit Post' );
 const copy = () => ga.recordEvent( 'Posts', 'Clicked Copy Post' );
 const viewStats = () => ga.recordEvent( 'Posts', 'Clicked View Post Stats' );
@@ -37,6 +35,7 @@ const getAvailableControls = props => {
 		post,
 		site,
 		translate,
+		onViewPost,
 	} = props;
 	const controls = { main: [], more: [] };
 
@@ -58,9 +57,8 @@ const getAvailableControls = props => {
 		controls.main.push( {
 			className: 'view',
 			href: post.URL,
-			icon: 'external',
-			onClick: view,
-			target: '_blank',
+			icon: props.isPreviewable ? 'visible' : 'external',
+			onClick: onViewPost,
 			text: translate( 'View' ),
 		} );
 
@@ -82,17 +80,10 @@ const getAvailableControls = props => {
 			} );
 		}
 	} else if ( 'trash' !== post.status ) {
-		const parsedUrl = url.parse( post.URL, true );
-		parsedUrl.query.preview = true;
-		// NOTE: search needs to be cleared in order to rebuild query
-		// http://nodejs.org/api/url.html#url_url_format_urlobj
-		parsedUrl.search = '';
-
 		controls.main.push( {
 			className: 'view',
-			href: url.format( parsedUrl ),
-			icon: 'external',
-			onClick: preview,
+			icon: props.isPreviewable ? 'visible' : 'external',
+			onClick: onViewPost,
 			text: translate( 'Preview' ),
 		} );
 
@@ -214,6 +205,7 @@ PostControls.propTypes = {
 	editURL: PropTypes.string.isRequired,
 	fullWidth: PropTypes.bool,
 	isPublicizeEnabled: PropTypes.bool,
+	isPreviewable: PropTypes.bool,
 	onDelete: PropTypes.func,
 	onHideMore: PropTypes.func.isRequired,
 	onPublish: PropTypes.func,
@@ -221,11 +213,13 @@ PostControls.propTypes = {
 	onShowMore: PropTypes.func.isRequired,
 	onToggleShare: PropTypes.func,
 	onTrash: PropTypes.func,
+	onViewPost: PropTypes.func,
 	post: PropTypes.object.isRequired,
 	site: PropTypes.object,
 	translate: PropTypes.func,
 };
 
 export default connect( ( state, { site, post } ) => ( {
+	isPreviewable: false !== isSitePreviewable( state, site.ID ),
 	isPublicizeEnabled: isPublicizeEnabled( state, site.ID, post.type ),
 } ) )( localize( PostControls ) );


### PR DESCRIPTION
This addresses #11344 by opening up the "View" link for posts and pages in-app rather than a new tab/window. Since the link isn't opening anything in a new window/tab, the icon is also updated to `visible` from `external`. This matches the icon we currently have on other items that exhibit this same behavior like viewing a testimonial within WP.com ([screenshot](https://cloudup.com/cRNrLX7B02n)).

I moved the analytics calls for `view` and `preview` from `post-controls.jsx` since we can make the same calls in `post.jsx`.

## To test
1. Fire up this branch
2. Test out the view link under published posts here: http://calypso.localhost:3000/posts/. Test the preview link under scheduled posts here: http://calypso.localhost:3000/posts/scheduled/.
3. Test out the same functionality for pages here: http://calypso.localhost:3000/pages/. You'll want to test the view/preview link for published, drafted, and scheduled pages.

### Screenshots

**View published or preview scheduled post/page**

<img width="2207" alt="screen shot 2017-02-17 at 7 15 20 am" src="https://cloud.githubusercontent.com/assets/7240478/23068450/f7ba7a74-f4e0-11e6-90e8-416314c99395.png">

**Icon update on view/preview link for posts**

<img width="843" alt="screen shot 2017-02-17 at 7 15 50 am" src="https://cloud.githubusercontent.com/assets/7240478/23068467/07401ca6-f4e1-11e6-9c2f-f5f80208a524.png">

**Icon update on view/preview link for pages**

<img width="985" alt="screen shot 2017-02-17 at 7 15 44 am" src="https://cloud.githubusercontent.com/assets/7240478/23068482/17b7e28a-f4e1-11e6-9c44-6dea6dbf639c.png">
