### PR TITLE
Hide *.wordpress.com domains when using Jetpack 

### DIFF
--- a/client/my-sites/upgrades/domain-management/list/index.jsx
+++ b/client/my-sites/upgrades/domain-management/list/index.jsx
@@ -39,6 +39,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { isDomainOnlySite } from 'state/selectors';
 import { isPlanFeaturesEnabled } from 'lib/plans';
 import DomainToPlanNudge from 'blocks/domain-to-plan-nudge';
+import { type } from 'lib/domains/constants';
 
 export const List = React.createClass( {
 	mixins: [ analyticsMixin( 'domainManagement', 'list' ) ],
@@ -329,7 +330,10 @@ export const List = React.createClass( {
 			return times( 3, n => <ListItemPlaceholder key={ `item-${ n }` } /> );
 		}
 
-		return this.props.domains.list.map( ( domain, index ) => {
+		const domains = this.props.selectedSite.jetpack
+			? this.props.domains.list.filter( domain => domain.type !== type.WPCOM )
+			: this.props.domains.list;
+		return domains.map( ( domain, index ) => {
 			return (
 				<ListItem
 					key={ domain.name }


### PR DESCRIPTION
(Fixes #11451)

Hides wordpress.com domains from Domain Management for Jetpack sites