### PR TITLE
Signup: set `userFirst` test to `0`

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -97,8 +97,8 @@ module.exports = {
 	userFirstSignup: {
 		datestamp: '20160124',
 		variations: {
-			userLast: 50,
-			userFirst: 50,
+			userLast: 100,
+			userFirst: 0,
 		},
 		defaultVariation: 'userLast',
 		allowExistingUsers: false,


### PR DESCRIPTION
This PR sets the `userFirstSignup` test's `userFirst` variation to `0` since the default behavior (`userLast`) performs better. 

To test: manually inspect the change. 