### PR TITLE
Reader: Add support for NYT video player iframe

### DIFF
--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -136,7 +136,8 @@ export function iframeIsWhitelisted( iframe ) {
 		'bandcamp.com',
 		'kickstarter.com',
 		'facebook.com',
-		'embed.itunes.apple.com'
+		'embed.itunes.apple.com',
+		'nyt.com',
 	];
 	const hostName = iframe.src && url.parse( iframe.src ).hostname;
 	const iframeSrc = hostName && hostName.toLowerCase();


### PR DESCRIPTION
To test, compare http://calypso.localhost:3000/read/feeds/6438763/posts/1343451102 to https://wordpress.com/read/feeds/6438763/posts/1343451102