### PR TITLE
Fix wpcom-track-paste

### DIFF
--- a/client/components/tinymce/plugins/wpcom-track-paste/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-track-paste/plugin.js
@@ -44,8 +44,8 @@ function trackPaste( editor ) {
 		} ) );
 	};
 
-	const onPasteFromTinyMCEEditor = event => recordPasteEvent( 'visual-editor', event.clipboardData.types );
-	const onPasteFromHTMLEditor = event => recordPasteEvent( 'html-editor', event.clipboardData.types );
+	const onPasteFromTinyMCEEditor = event => event.clipboardData && recordPasteEvent( 'visual-editor', event.clipboardData.types );
+	const onPasteFromHTMLEditor = event => event.clipboardData && recordPasteEvent( 'html-editor', event.clipboardData.types );
 
 	editor.on( 'paste', onPasteFromTinyMCEEditor );
 	const textarea = editor.getParam( 'textarea' );


### PR DESCRIPTION
Some browser are reporting `_Unable to get property 'types'_:_Unable to get property 'types'_:` errors. May be related to the clipboardData. Couldn't reproduce but checking for safety does not hurt.