### PR TITLE
Components: fix text contrast issues in blocks and components

### DIFF
--- a/client/components/faq/style.scss
+++ b/client/components/faq/style.scss
@@ -14,7 +14,7 @@
 	margin-bottom: 32px;
 	font-size: 24px;
 	font-weight: 300;
-	color: $gray;
+	color: darken( $gray, 10% );
 }
 
 .faq__list {
@@ -59,11 +59,10 @@
 
 .faq__answer {
 	margin-bottom: 1em;
-	color: $gray;
+	color: darken( $gray, 20% );
 
 	a {
 		color: $blue-medium;
 		text-decoration: underline;
 	}
 }
-

--- a/client/components/foldable-card/style.scss
+++ b/client/components/foldable-card/style.scss
@@ -142,7 +142,7 @@ button.foldable-card__action {
 .foldable-card__summary,
 .foldable-card__summary_expanded {
 	margin-right: 40px;
-	color: $gray;
+	color: $gray-text-min;
 	font-size: 12px;
 	transition: opacity 0.2s linear;
 	display: inline-block;

--- a/client/components/happiness-support/style.scss
+++ b/client/components/happiness-support/style.scss
@@ -24,13 +24,13 @@
 }
 
 .happiness-support__heading {
-	color: darken( $gray, 20% );
+	color: darken( $gray, 10% );
 	clear: none;
 	font-size: 21px;
 }
 
 .happiness-support__text {
-	color: darken( $gray, 10% );
+	color: $gray-text-min;
 	margin-bottom: 16px;
 	margin-top: 16px;
 }

--- a/client/components/input-chrono/style.scss
+++ b/client/components/input-chrono/style.scss
@@ -22,7 +22,7 @@ input.input-chrono {
 	border: 1px solid lighten( $gray, 30% );
 	box-sizing: border-box;
 	background-color: $transparent;
-	color: $gray;
+	color: $gray-text-min;
 	font-size: 12px;
 	text-align: left;
 	position: relative;

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -63,8 +63,7 @@
 }
 
 .purchase-detail__description {
-	color: darken( $gray, 10% );
-	font-size: 16px;
+	color: $gray-text-min;
 	margin: 8px 0 16px 0;
 }
 
@@ -119,7 +118,7 @@
 
 .purchase-detail__title {
 	clear: none;
-	color: darken( $gray, 20% );
+	color: darken( $gray, 10% );
 	font-size: 21px;
 }
 


### PR DESCRIPTION
This updates a few components to use the $gray-text-min variable for text, which is the mimmim contrast needed to pass WCAG 2.0 AA tests on a white background.

In cases where the text was on a light gray background, the text color was darkened until it passed.

# **Before:**

![screen shot 2017-02-17 at 12 22 38 pm](https://cloud.githubusercontent.com/assets/618551/23077934/356bb042-f50c-11e6-8d6c-501f9e9a54ad.png)
![screen shot 2017-02-17 at 12 26 13 pm](https://cloud.githubusercontent.com/assets/618551/23077971/72bc75e4-f50c-11e6-993f-580a2ea3b9f7.png)
![screen shot 2017-02-17 at 12 27 48 pm](https://cloud.githubusercontent.com/assets/618551/23078047/b9e5a0d0-f50c-11e6-94c4-4e8346495025.png)
![screen shot 2017-02-17 at 12 27 35 pm](https://cloud.githubusercontent.com/assets/618551/23078046/b9e57c68-f50c-11e6-975b-927774efb38d.png)

---

# **After:**

![screen shot 2017-02-17 at 12 22 03 pm](https://cloud.githubusercontent.com/assets/618551/23078072/d0df011e-f50c-11e6-8f1b-681e8823df8a.png)
![screen shot 2017-02-17 at 12 31 27 pm](https://cloud.githubusercontent.com/assets/618551/23078125/0b102ae8-f50d-11e6-8a70-e6eaaafb58eb.png)
![screen shot 2017-02-17 at 12 33 04 pm](https://cloud.githubusercontent.com/assets/618551/23078198/4951ba7e-f50d-11e6-9f7e-711a362931da.png)
![screen shot 2017-02-17 at 12 32 46 pm](https://cloud.githubusercontent.com/assets/618551/23078199/495f31ae-f50d-11e6-8c92-3dd100b77c0d.png)

