### PR TITLE
Happychat - add user agent info when starting chat

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -131,11 +131,11 @@ const HelpContact = React.createClass( {
 		const site = sites.getSite( siteId );
 
 		const userAgent = `User Agent: ${ navigator.userAgent }`;
-		const browserInfoMsg = [ `Information to assist trouble shooting.\nScreen Resolution: ${ screen.width }x${ screen.height }\nBrowser Size: ${ window.innerWidth }x${ window.innerHeight }\n ${ userAgent }` ];
+		const screenRes = `Screen Resolution: ${ screen.width }x${ screen.height }\n`;
+		const browserSize = `Browser Size: ${ window.innerWidth }x${ window.innerHeight }\n`;
+		const browserInfoMsg = [ `Information to assist trouble shooting.\n ${ screenRes } ${ browserSize } ${ userAgent }` ];
 
-		let messages = [
-			browserInfoMsg, message
-		];
+		let messages = browserInfoMsg.concat( message );
 
 		if ( site ) {
 			messages = [ `Site I need help with: ${ site.URL }` ].concat( messages );

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import page from 'page';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import electron from 'electron';
 
 /**
  * Internal dependencies
@@ -131,13 +130,8 @@ const HelpContact = React.createClass( {
 		const { message, siteId } = contactForm;
 		const site = sites.getSite( siteId );
 
-		let userAgent = `User Agent: ${ navigator.userAgent }`;
-		if ( config.client_slug === 'desktop' ) {
-			const version = electron.remote.getGlobal( 'desktop' ).config.version;
-			const build = electron.remote.getGlobal( 'desktop' ).config.build;
-			userAgent = `Desktop app ${ version } ${ build }`;
-		}
-		const browserInfoMsg = [ `Information to assist trouble shooting.\nScreen Resolution: ${ screen.width }x${ screen.height }\nBrowser Size: ${ window.innerWidth }x${ window.innerHeight }\n ${userAgent}` ];
+		const userAgent = `User Agent: ${ navigator.userAgent }`;
+		const browserInfoMsg = [ `Information to assist trouble shooting.\nScreen Resolution: ${ screen.width }x${ screen.height }\nBrowser Size: ${ window.innerWidth }x${ window.innerHeight }\n ${ userAgent }` ];
 
 		let messages = [
 			browserInfoMsg, message

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -130,7 +130,7 @@ const HelpContact = React.createClass( {
 		const { message, siteId } = contactForm;
 		const site = sites.getSite( siteId );
 
-		const browserInfoMsg = [ `User Agent: ${navigator.userAgent}` ];
+		const browserInfoMsg = [ `Information to assist trouble shooting.\nScreen Resolution: ${ screen.width }x${ screen.height }\nBrowser Size: ${ window.innerWidth }x${ window.innerHeight }\nUser Agent: ${navigator.userAgent}` ];
 
 		let messages = [
 			browserInfoMsg, message

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -130,8 +130,10 @@ const HelpContact = React.createClass( {
 		const { message, siteId } = contactForm;
 		const site = sites.getSite( siteId );
 
+		const browserInfoMsg = [ `User Agent: ${navigator.userAgent}` ];
+
 		let messages = [
-			message
+			browserInfoMsg, message
 		];
 
 		if ( site ) {

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import page from 'page';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import electron from 'electron';
 
 /**
  * Internal dependencies
@@ -130,7 +131,13 @@ const HelpContact = React.createClass( {
 		const { message, siteId } = contactForm;
 		const site = sites.getSite( siteId );
 
-		const browserInfoMsg = [ `Information to assist trouble shooting.\nScreen Resolution: ${ screen.width }x${ screen.height }\nBrowser Size: ${ window.innerWidth }x${ window.innerHeight }\nUser Agent: ${navigator.userAgent}` ];
+		let userAgent = `User Agent: ${ navigator.userAgent }`;
+		if ( config.client_slug === 'desktop' ) {
+			const version = electron.remote.getGlobal( 'desktop' ).config.version;
+			const build = electron.remote.getGlobal( 'desktop' ).config.build;
+			userAgent = `Desktop app ${ version } ${ build }`;
+		}
+		const browserInfoMsg = [ `Information to assist trouble shooting.\nScreen Resolution: ${ screen.width }x${ screen.height }\nBrowser Size: ${ window.innerWidth }x${ window.innerHeight }\n ${userAgent}` ];
 
 		let messages = [
 			browserInfoMsg, message

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -133,7 +133,7 @@ const HelpContact = React.createClass( {
 		const userAgent = `User Agent: ${ navigator.userAgent }`;
 		const screenRes = `Screen Resolution: ${ screen.width }x${ screen.height }\n`;
 		const browserSize = `Browser Size: ${ window.innerWidth }x${ window.innerHeight }\n`;
-		const browserInfoMsg = [ `Information to assist trouble shooting.\n ${ screenRes } ${ browserSize } ${ userAgent }` ];
+		const browserInfoMsg = [ `Information to assist troubleshooting.\n ${ screenRes } ${ browserSize } ${ userAgent }` ];
 
 		let messages = browserInfoMsg.concat( message );
 


### PR DESCRIPTION
Adds additional user agent info to starting chat so operator has browser and OS information.
Includes as an additional message.

Example:

<img width="662" alt="screen shot 2017-02-17 at 11 03 09 am" src="https://cloud.githubusercontent.com/assets/45363/23079206/baf30bd6-f500-11e6-8c5e-8e12d125ccb6.png">

