### PR TITLE
Reader: move excerpt component to its own block

### DIFF
--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -8,7 +8,7 @@ import React from 'react';
  */
 import AutoDirection from 'components/auto-direction';
 
-const ReaderPostCardExcerpt = ( { post, isDiscover } )=> {
+const ReaderExcerpt = ( { post, isDiscover } ) => {
 	let excerpt = post.better_excerpt || post.excerpt;
 
 	// Force post.excerpt for Discover only
@@ -25,9 +25,9 @@ const ReaderPostCardExcerpt = ( { post, isDiscover } )=> {
 	);
 };
 
-ReaderPostCardExcerpt.propTypes = {
+ReaderExcerpt.propTypes = {
 	post: React.PropTypes.object.isRequired,
 	isDiscover: React.PropTypes.bool,
 };
 
-export default ReaderPostCardExcerpt;
+export default ReaderExcerpt;

--- a/client/blocks/reader-post-card/gallery.jsx
+++ b/client/blocks/reader-post-card/gallery.jsx
@@ -12,7 +12,7 @@ import { imageIsBigEnoughForGallery } from 'state/reader/posts/normalization-rul
 import resizeImageUrl from 'lib/resize-image-url';
 import cssSafeUrl from 'lib/css-safe-url';
 import { isFeaturedImageInContent } from 'lib/post-normalizer/utils';
-import ReaderPostCardExcerpt from './excerpt';
+import ReaderExcerpt from 'blocks/reader-excerpt';
 import { READER_CONTENT_WIDTH } from 'state/reader/posts/normalization-rules';
 
 function getGalleryWorthyImages( post ) {
@@ -55,7 +55,7 @@ const PostGallery = ( { post, children, isDiscover } ) => {
 						<a className="reader-post-card__title-link" href={ post.URL }>{ post.title }</a>
 					</h1>
 				</AutoDirection>
-				<ReaderPostCardExcerpt post={ post } isDiscover={ isDiscover } />
+				<ReaderExcerpt post={ post } isDiscover={ isDiscover } />
 				{ children }
 				</div>
 		</div> );

--- a/client/blocks/reader-post-card/standard.jsx
+++ b/client/blocks/reader-post-card/standard.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import AutoDirection from 'components/auto-direction';
 import FeaturedVideo from './featured-video';
 import FeaturedImage from './featured-image';
-import ReaderPostCardExcerpt from './excerpt';
+import ReaderExcerpt from 'blocks/reader-excerpt';
 
 const StandardPost = ( { post, children, isDiscover } )=> {
 	const canonicalMedia = post.canonical_media;
@@ -31,7 +31,7 @@ const StandardPost = ( { post, children, isDiscover } )=> {
 						<a className="reader-post-card__title-link" href={ post.URL }>{ post.title }</a>
 					</h1>
 				</AutoDirection>
-				<ReaderPostCardExcerpt post={ post } isDiscover={ isDiscover } />
+				<ReaderExcerpt post={ post } isDiscover={ isDiscover } />
 				{ children }
 			</div>
 		</div> );


### PR DESCRIPTION
The excerpt component currently lives inside `reader-post-card`, but in https://github.com/Automattic/wp-calypso/pull/11407 we'll be using it in `reader-combined-card` too. This PR moves the excerpt component out to a separate block so it can be reused.

I've not included a docs page because it doesn't do anything exciting :)