### PR TITLE
Domains: Remove Change Primary and Add Domain Buttons for Jetpack Sites

### DIFF
--- a/client/my-sites/upgrades/domain-management/edit/card/header/index.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/card/header/index.jsx
@@ -32,10 +32,11 @@ const Header = React.createClass( {
 				<DomainPrimaryFlag
 					domain={ domain } />
 
+				{ this.props.selectedSite && ! this.props.selectedSite.jetpack &&
 				<PrimaryDomainButton
 					domain={ domain }
 					selectedSite={ this.props.selectedSite }
-					settingPrimaryDomain={ this.props.settingPrimaryDomain } />
+					settingPrimaryDomain={ this.props.settingPrimaryDomain } /> }
 			</SectionHeader>
 		);
 	}

--- a/client/my-sites/upgrades/domain-management/list/index.jsx
+++ b/client/my-sites/upgrades/domain-management/list/index.jsx
@@ -215,6 +215,10 @@ export const List = React.createClass( {
 	},
 
 	headerButtons() {
+		if ( this.props.selectedSite && this.props.selectedSite.jetpack ) {
+			return null;
+		}
+
 		if ( this.state.changePrimaryDomainModeEnabled ) {
 			return (
 				<Button


### PR DESCRIPTION
Fixes #11444
This PR hides three buttons:

- Add Domain
- Change Primary on Domain Management List
- Set Primary on Domain Management Edit

