### PR TITLE
Domain Warnings: Hide NS record warning for Jetpack (but not AT) sites

### DIFF
--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import _debug from 'debug';
 import moment from 'moment';
-import { intersection, map, every, find } from 'lodash';
+import { intersection, map, every, find, get } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -97,6 +97,10 @@ export default React.createClass( {
 
 	wrongNSMappedDomains() {
 		debug( 'Rendering wrongNSMappedDomains' );
+
+		if ( get( this.props, 'selectedSite.jetpack' ) && ! get( this.props, 'selectedSite.options.is_automated_transfer' ) ) {
+			return null;
+		}
 
 		const wrongMappedDomains = this.getDomains().filter( domain =>
 			domain.type === domainTypes.MAPPED && ! domain.pointsToWpcom );


### PR DESCRIPTION
Fixes #11450 

This changes hides the DNS record domains warnings for Jetpack sites, but keeps them active for AT sites.