### PR TITLE
Plans: increase text contrast

### DIFF
--- a/client/components/foldable-card/style.scss
+++ b/client/components/foldable-card/style.scss
@@ -142,7 +142,7 @@ button.foldable-card__action {
 .foldable-card__summary,
 .foldable-card__summary_expanded {
 	margin-right: 40px;
-	color: $gray;
+	color: $gray-text-min;
 	font-size: 12px;
 	transition: opacity 0.2s linear;
 	display: inline-block;

--- a/client/components/info-popover/style.scss
+++ b/client/components/info-popover/style.scss
@@ -1,6 +1,6 @@
 .info-popover .gridicon {
 	cursor: pointer;
-	color: lighten( $gray, 15% );
+	color: lighten( $gray, 10% );
 
 	&:hover {
 		color: $gray-dark;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -25,7 +25,7 @@ $plan-features-sidebar-width: 272px;
 }
 
 .plan-features__mobile {
-	color: $gray;
+	color: $gray-text-min;
 	margin: 0 16px;
 	display: block;
 
@@ -70,7 +70,7 @@ $plan-features-sidebar-width: 272px;
 .plan-features__mobile-plan {
 	font-size: 14px;
 	border: solid 1px lighten( $gray, 27% );
-	background-color: lighten( $gray, 35% );
+	background-color: $white;
 	margin-bottom: 24px;
 }
 
@@ -83,7 +83,7 @@ $plan-features-sidebar-width: 272px;
 
 .plan-features__table {
 	font-size: 14px;
-	color: $gray;
+	color: $gray-text-min;
 	border-spacing: 16px 0;
 	margin-top: -16px;
 	display: none;
@@ -107,7 +107,7 @@ $plan-features-sidebar-width: 272px;
 .plan-features__table-item {
 	border-right: solid 1px lighten( $gray, 27% );
 	border-left: solid 1px lighten( $gray, 27% );
-	background-color: lighten( $gray, 35% );
+	background-color: $white;
 	position: relative;
 
 	&.is-highlighted {
@@ -261,7 +261,7 @@ $plan-features-sidebar-width: 272px;
 	font-size: 12px;
 	font-style: italic;
 	font-weight: 400;
-	color: $gray;
+	color: $gray-text-min;
 	line-height: .6;
 	white-space: nowrap;
 

--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -111,5 +111,5 @@
 }
 
 .current-plan__header-expires-in {
-	color: $gray;
+	color: $gray-text-min;
 }


### PR DESCRIPTION
 This updates Plans to use the $gray-text-min variable for text, which is the mimmim contrast needed to pass WCAG 2.0 AA tests on a white background.

I also altered the info popover component so that the icon color is an acceptable contrast.

Before:

![screen shot 2017-02-17 at 2 47 46 pm](https://cloud.githubusercontent.com/assets/618551/23082688/13ef091e-f520-11e6-8b1e-1b223b8d1ca9.png)

After:

![screen shot 2017-02-17 at 2 47 31 pm](https://cloud.githubusercontent.com/assets/618551/23082695/18c03288-f520-11e6-8d51-131a4798becc.png)

Also darkened the expiration text on My Plan:

![screen shot 2017-02-17 at 2 53 42 pm](https://cloud.githubusercontent.com/assets/618551/23082903/00e26df6-f521-11e6-85bb-4343dd9b22dd.png)
