### PR TITLE
Image Editor: enable on prod and desktop

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -64,6 +64,7 @@
 		"persist-redux": true,
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,
+		"post-editor/image-editor": true,
 		"press-this": false,
 		"preview-layout": true,
 		"reader": true,

--- a/config/production.json
+++ b/config/production.json
@@ -69,6 +69,7 @@
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,
 		"post-editor/insert-menu": true,
+		"post-editor/image-editor": true,
 		"press-this": true,
 		"preview-layout": true,
 		"push-notifications": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -74,6 +74,7 @@
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/insert-menu": true,
+		"post-editor/image-editor": true,
 		"press-this": true,
 		"preview-layout": true,
 		"push-notifications": true,


### PR DESCRIPTION
This PR finally enables the image editor in production and desktop. Props to @marcinbot @drw158 and Team Stark.

### Testing Instructions
No functional changes in any testing environment, but confirm that the config values look correct.