### PR TITLE
Editor: Hide SEO description for private/hidden sites

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -28,6 +28,7 @@ import { getEditedPostValue } from 'state/posts/selectors';
 import { getPostType } from 'state/post-types/selectors';
 import { isJetpackMinimumVersion } from 'state/sites/selectors';
 import config from 'config';
+import { getSiteSettings } from 'state/site-settings/selectors';
 
 import EditorDrawerTaxonomies from './taxonomies';
 import EditorDrawerPageOptions from './page-options';
@@ -245,8 +246,11 @@ const EditorDrawer = React.createClass( {
 		}
 
 		const { plan } = this.props.site;
+		const { blog_public } = this.props.siteSettings;
+		const isSitePrivate = parseInt( blog_public, 10 ) !== 1;
 		const hasBusinessPlan = isBusiness( plan ) || isEnterprise( plan );
-		if ( ! hasBusinessPlan ) {
+
+		if ( ! hasBusinessPlan || isSitePrivate ) {
 			return;
 		}
 
@@ -328,7 +332,8 @@ export default connect(
 		return {
 			canJetpackUseTaxonomies: isJetpackMinimumVersion( state, siteId, '4.1' ),
 			jetpackVersionSupportsSeo: isJetpackMinimumVersion( state, siteId, '4.4-beta1' ),
-			typeObject: getPostType( state, siteId, type )
+			typeObject: getPostType( state, siteId, type ),
+			siteSettings: getSiteSettings( state, siteId )
 		};
 	},
 	null,


### PR DESCRIPTION
We disable the SEO settings for any site that is private. This commit disables
the SEO description drawer in the Editor when a site is private as well.

I used `getSiteSettings` within `mapStateToProps` so that the `blog_public` const would be updated whenever the site settings changed for the given site. Otherwise, there were some instances where I would update my site settings then open the editor and see the incorrect result with the SEO panel.

## To test
1. Open up your site settings for a site on the Business plan: http://calypso.localhost:3000/settings/general/
2. Change the site to public
3. Click "Add" next to posts to start a new post. Verify that you see the SEO description panel in the editor drawer.
4. Click "My Sites" and go back to your site settings. Set the site to either hidden or private.
5. Start a new post again and verify that you do not see the SEO description panel in the drawer.

## Screenshots

**Public site**

<img width="411" alt="screen shot 2017-02-18 at 6 38 34 pm" src="https://cloud.githubusercontent.com/assets/7240478/23098403/9a443914-f609-11e6-8eef-fc0c8befa56e.png">

**Private/Hidden site**

<img width="509" alt="screen shot 2017-02-18 at 6 38 15 pm" src="https://cloud.githubusercontent.com/assets/7240478/23098399/955f622a-f609-11e6-83e5-fa81f83dd71f.png">

Resolves: #11406