### PR TITLE
Plans: Add data attributes to the plans page to indicate Jetpack

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -48,7 +48,7 @@ class PlansFeaturesMain extends Component {
 				jetpackPlans.shift();
 			}
 			return (
-				<div className="plans-features-main__group">
+				<div className="plans-features-main__group plans-features-main__jetpack">
 					<PlanFeatures
 						plans={ jetpackPlans }
 						selectedFeature={ selectedFeature }
@@ -69,7 +69,7 @@ class PlansFeaturesMain extends Component {
 				jetpackPlans.shift();
 			}
 			return (
-				<div className="plans-features-main__group">
+				<div className="plans-features-main__group plans-features-main__jetpack">
 					<PlanFeatures
 						plans={ jetpackPlans }
 						selectedFeature={ selectedFeature }
@@ -95,7 +95,7 @@ class PlansFeaturesMain extends Component {
 		);
 
 		return (
-			<div className="plans-features-main__group">
+			<div className="plans-features-main__group plans-features-main__wpcom">
 				<PlanFeatures
 					plans={ plans }
 					onUpgradeClick={ onUpgradeClick }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -48,7 +48,7 @@ class PlansFeaturesMain extends Component {
 				jetpackPlans.shift();
 			}
 			return (
-				<div className="plans-features-main__group plans-features-main__jetpack">
+				<div className="plans-features-main__group" data-e2e-display-jetpack-plans={ displayJetpackPlans }>
 					<PlanFeatures
 						plans={ jetpackPlans }
 						selectedFeature={ selectedFeature }
@@ -69,7 +69,7 @@ class PlansFeaturesMain extends Component {
 				jetpackPlans.shift();
 			}
 			return (
-				<div className="plans-features-main__group plans-features-main__jetpack">
+				<div className="plans-features-main__group" data-e2e-display-jetpack-plans={ displayJetpackPlans }>
 					<PlanFeatures
 						plans={ jetpackPlans }
 						selectedFeature={ selectedFeature }
@@ -95,7 +95,7 @@ class PlansFeaturesMain extends Component {
 		);
 
 		return (
-			<div className="plans-features-main__group plans-features-main__wpcom">
+			<div className="plans-features-main__group" data-e2e-display-jetpack-plans={ displayJetpackPlans }>
 				<PlanFeatures
 					plans={ plans }
 					onUpgradeClick={ onUpgradeClick }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -48,7 +48,7 @@ class PlansFeaturesMain extends Component {
 				jetpackPlans.shift();
 			}
 			return (
-				<div className="plans-features-main__group" data-e2e-display-jetpack-plans={ displayJetpackPlans }>
+				<div className="plans-features-main__group" data-e2e-plans="jetpack">
 					<PlanFeatures
 						plans={ jetpackPlans }
 						selectedFeature={ selectedFeature }
@@ -69,7 +69,7 @@ class PlansFeaturesMain extends Component {
 				jetpackPlans.shift();
 			}
 			return (
-				<div className="plans-features-main__group" data-e2e-display-jetpack-plans={ displayJetpackPlans }>
+				<div className="plans-features-main__group" data-e2e-plans="jetpack">
 					<PlanFeatures
 						plans={ jetpackPlans }
 						selectedFeature={ selectedFeature }
@@ -95,7 +95,7 @@ class PlansFeaturesMain extends Component {
 		);
 
 		return (
-			<div className="plans-features-main__group" data-e2e-display-jetpack-plans={ displayJetpackPlans }>
+			<div className="plans-features-main__group" data-e2e-plans="wpcom">
 				<PlanFeatures
 					plans={ plans }
 					onUpgradeClick={ onUpgradeClick }


### PR DESCRIPTION
I am writing an e2e automated test to verify that Jetpack plans are shown on Jetpack sites (and WP.com plans on WP.com sites).

I can’t work out how to know I am seeing Jetpack plans (and vice-versa) currently since the classes are all the same (the content varies but I don’t want to use content for verification as it changes).

This PR adds a data attribute to the plans group that indicates it shows Jetpack or WP.com plans

**Testing Instructions**

1. Load plans page for Jetpack and WordPress.com sites and make sure there's no visual differences (than master)
2. Make sure that `[data-e2e-plans="jetpack"]` and `[data-e2e-plans="wpcom"]` selectors work on these pages