### PR TITLE
Stats: Link to People (Followers) pages instead of custom stats followers pages

### DIFF
--- a/client/my-sites/stats/comment-follows/index.jsx
+++ b/client/my-sites/stats/comment-follows/index.jsx
@@ -10,7 +10,7 @@ import { flowRight } from 'lodash';
 /**
  * Internal dependencies
  */
-import Followers from '../stats-followers-page';
+import Followers from '../stats-comment-followers-page';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import StatsFirstView from '../stats-first-view';
@@ -18,9 +18,8 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
-class StatsFollows extends Component {
+class StatsCommentFollows extends Component {
 	static propTypes = {
-		followType: PropTypes.string,
 		followList: PropTypes.object,
 		page: PropTypes.number,
 		perPage: PropTypes.number,
@@ -37,7 +36,7 @@ class StatsFollows extends Component {
 	}
 
 	paginationHandler = ( pageNum ) => {
-		let path = '/stats/follows/' + this.props.followType + '/';
+		let path = '/stats/follows/comment/';
 		if ( pageNum > 1 ) {
 			path += pageNum + '/';
 		}
@@ -46,31 +45,24 @@ class StatsFollows extends Component {
 		page( path );
 	};
 
-	changeFilter = ( selection ) => {
-		const filter = selection.value;
-
-		page( '/stats/follows/' + filter + '/' + this.props.slug );
-	};
-
 	render() {
-		const { followType, followList, perPage, translate } = this.props;
+		const { followList, perPage, translate } = this.props;
 
 		return (
 			<Main wideLayout={ true }>
 				<StatsFirstView />
 
-				<div id="my-stats-content" className={ 'follows-detail follows-detail-' + followType }>
+				<div id="my-stats-content" className="follows-detail follows-detail-comment">
 					<HeaderCake onClick={ this.goBack }>
-						{ translate( 'Followers' ) }
+						{ translate( 'Comments Followers' ) }
 					</HeaderCake>
 					<Followers
-						path={ followType + '-follow-summary' }
-						followType={ followType }
+						path="comment-follow-summary"
 						followList={ followList }
 						page={ this.props.page }
 						perPage={ perPage }
 						pageClick={ this.paginationHandler }
-						changeFilter={ this.changeFilter } />
+					/>
 				</div>
 			</Main>
 		);
@@ -91,4 +83,4 @@ const connectComponent = connect(
 export default flowRight(
 	connectComponent,
 	localize
-)( StatsFollows );
+)( StatsCommentFollows );

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -390,11 +390,9 @@ module.exports = {
 		}
 	},
 
-	follows: function( context, next ) {
+	follows: function( context ) {
 		let siteId = context.params.site_id;
 		const FollowList = require( 'lib/follow-list' );
-		const validFollowTypes = [ 'wpcom', 'email', 'comment' ];
-		const followType = context.params.follow_type;
 		let pageNum = context.params.page_num;
 		const followList = new FollowList();
 		const basePath = route.sectionify( context.path );
@@ -408,9 +406,7 @@ module.exports = {
 		const siteDomain = ( site && ( typeof site.slug !== 'undefined' ) )
 			? site.slug : route.getSiteFragment( context.path );
 
-		if ( -1 === validFollowTypes.indexOf( followType ) ) {
-			next();
-		} else if ( 0 === siteId ) {
+		if ( 0 === siteId ) {
 			if ( 0 === sites.data.length ) {
 				sites.once( 'change', function() {
 					page( context.path );
@@ -428,7 +424,7 @@ module.exports = {
 
 			analytics.pageView.record(
 				basePath.replace( '/' + pageNum, '' ),
-				analyticsPageTitle + ' > Followers > ' + titlecase( followType )
+				analyticsPageTitle + ' > Followers > Comment'
 			);
 
 			const props = {
@@ -439,11 +435,10 @@ module.exports = {
 				domain: siteDomain,
 				sites,
 				siteId,
-				followType,
 				followList,
 			};
 			renderWithReduxStore(
-				<AsyncLoad placeholder={ <StatsPagePlaceholder /> } require="my-sites/stats/follows" { ...props } />,
+				<AsyncLoad placeholder={ <StatsPagePlaceholder /> } require="my-sites/stats/comment-follows" { ...props } />,
 				document.getElementById( 'primary' ),
 				context.store
 			);

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -40,8 +40,8 @@ module.exports = function() {
 		page( '/stats/page/:post_id/:site_id', controller.siteSelection, controller.navigation, statsController.post );
 
 		// Stat Follows Page
-		page( '/stats/follows/:follow_type/:site_id', controller.siteSelection, controller.navigation, statsController.follows );
-		page( '/stats/follows/:follow_type/:page_num/:site_id', controller.siteSelection, controller.navigation, statsController.follows );
+		page( '/stats/follows/comment/:site_id', controller.siteSelection, controller.navigation, statsController.follows );
+		page( '/stats/follows/comment/:page_num/:site_id', controller.siteSelection, controller.navigation, statsController.follows );
 
 		// Reset first view
 		if ( config.isEnabled( 'ui/first-view/reset-route' ) ) {

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -111,8 +111,8 @@ class StatModuleFollowers extends Component {
 
 		const summaryPageSlug = siteSlug || '';
 		const summaryPageLink = 'email-followers' === activeFilter
-			? '/stats/follows/email/' + summaryPageSlug
-			: '/stats/follows/wpcom/' + summaryPageSlug;
+			? '/people/email-followers/' + summaryPageSlug
+			: '/people/followers/' + summaryPageSlug;
 
 		return (
 			<div>


### PR DESCRIPTION
closes #10990

This PR updates the insights followers links to the people/followers pages instead of the stats followers page. I also update the stats followers components to make them specific to comment followers.

**Testing instructions**

 - Navigate to the stats insights page : `/stats/insights/$site`
 - Click on the title of the followers' panel
 - You should be redirected to the people's followers page
 - Try switching to Email followers before clicking the link
 - Try clicking on the link to see the comment followers page, it should behave like master.