### PR TITLE
Update/single sorry no themes

### DIFF
--- a/client/components/themes-list/README.md
+++ b/client/components/themes-list/README.md
@@ -10,4 +10,9 @@ information about those themes.
 
 Each item in the `themes` array prop must contain theme attributes that can be used by the `Theme` component.
 Other accepted props are two boolean flags and a callback, all of which are related to pagination.
+
+#### Props
+
+* `emptyContent`: element ( optional ), element that will be displayed when the list is empty, if null or not provided default EmptyContent will be used.
+
 For a complete list of props along with their types, please refer to the `ThemesList` component's `propTypes` member.

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -90,7 +90,7 @@ const ConnectedSingleSiteJetpack = connectOptions(
 					<ThanksModal
 						site={ site }
 						source={ 'list' } />
-					{ config.isEnabled( 'manage/themes/upload' ) && showWpcomThemesList &&
+					{ showWpcomThemesList &&
 						<div>
 							<ConnectedThemesSelection
 								options={ [
@@ -139,7 +139,8 @@ const ConnectedSingleSiteJetpack = connectOptions(
 
 export default connect(
 	( state, { siteId, tier } ) => {
-		const showWpcomThemesList = hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId );
+		const showWpcomThemesList = config.isEnabled( 'manage/themes/upload' ) &&
+			hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId );
 		let emptyContent = null;
 		if ( showWpcomThemesList ) {
 			const siteQuery = getLastThemeQuery( state, siteId );

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -150,11 +150,10 @@ export default connect(
 
 			if ( siteThemesCount && ! wpcomThemesCount ) {
 				showNoThemesFoundWpcom = false;
-			} else if ( ! siteThemesCount && wpcomThemesCount ) {
-				showNoThemesFoundJetpack = false;
-			} else if ( ! siteThemesCount && ! wpcomThemesCount ) {
+			} else if ( ! siteThemesCount ) {
 				showNoThemesFoundJetpack = false;
 			}
+
 		}
 		return {
 			wpcomTier: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ) ? tier : 'free',

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import { pickBy } from 'lodash';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -162,7 +161,6 @@ export default connect(
 			showWpcomThemesList,
 			showNoThemesFoundJetpack,
 			showNoThemesFoundWpcom,
-			showNoThemesFound: ! showWpcomThemesList
 		};
 	}
-)( localize( ConnectedSingleSiteJetpack ) );
+)( ConnectedSingleSiteJetpack );

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -45,14 +45,14 @@ const ConnectedSingleSiteJetpack = connectOptions(
 		const {
 			analyticsPath,
 			analyticsPageTitle,
+			emptyContent,
 			getScreenshotOption,
 			search,
 			site,
 			siteId,
 			wpcomTier,
 			filter,
-			vertical,
-			showNoThemesFound
+			vertical
 		} = props;
 		const jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' );
 
@@ -83,7 +83,7 @@ const ConnectedSingleSiteJetpack = connectOptions(
 				<CurrentTheme siteId={ siteId } />
 				<ThemeShowcase { ...props }
 					siteId={ siteId }
-					showNoThemesFound={ false } >
+					emptyContent={ <div /> } >
 					{ siteId && <QuerySitePlans siteId={ siteId } /> }
 					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 					<ThanksModal
@@ -126,7 +126,7 @@ const ConnectedSingleSiteJetpack = connectOptions(
 								} }
 								trackScrollPage={ props.trackScrollPage }
 								source="wpcom"
-								showNoThemesFound={ showNoThemesFound }
+								emptyContent={ emptyContent }
 							/>
 						</div>
 					}
@@ -139,18 +139,18 @@ const ConnectedSingleSiteJetpack = connectOptions(
 export default connect(
 	( state, { siteId, tier } ) => {
 		const showWpcomThemesList = hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId );
-		let showNoThemesFound = true;
+		let emptyContent = null;
 		if ( showWpcomThemesList ) {
 			const siteQuery = getLastThemeQuery( state, siteId );
 			const wpcomQuery = getLastThemeQuery( state, 'wpcom' );
 			const siteThemesCount = getThemesFoundForQuery( state, siteId, siteQuery );
 			const wpcomThemesCount = getThemesFoundForQuery( state, 'wpcom', wpcomQuery );
-			showNoThemesFound = ! siteThemesCount && ! wpcomThemesCount;
+			emptyContent = ( ! siteThemesCount && ! wpcomThemesCount ) ? null : <div />;
 		}
 		return {
 			wpcomTier: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ) ? tier : 'free',
 			showWpcomThemesList,
-			showNoThemesFound,
+			emptyContent
 		};
 	}
 )( ConnectedSingleSiteJetpack );

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -52,8 +52,7 @@ const ConnectedSingleSiteJetpack = connectOptions(
 			wpcomTier,
 			filter,
 			vertical,
-			showNoThemesFoundJetpack,
-			showNoThemesFoundWpcom,
+			showNoThemesFound
 		} = props;
 		const jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' );
 
@@ -84,7 +83,7 @@ const ConnectedSingleSiteJetpack = connectOptions(
 				<CurrentTheme siteId={ siteId } />
 				<ThemeShowcase { ...props }
 					siteId={ siteId }
-					showNoThemesFound={ showNoThemesFoundJetpack } >
+					showNoThemesFound={ false } >
 					{ siteId && <QuerySitePlans siteId={ siteId } /> }
 					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 					<ThanksModal
@@ -127,7 +126,7 @@ const ConnectedSingleSiteJetpack = connectOptions(
 								} }
 								trackScrollPage={ props.trackScrollPage }
 								source="wpcom"
-								showNoThemesFound={ showNoThemesFoundWpcom }
+								showNoThemesFound={ showNoThemesFound }
 							/>
 						</div>
 					}
@@ -140,26 +139,18 @@ const ConnectedSingleSiteJetpack = connectOptions(
 export default connect(
 	( state, { siteId, tier } ) => {
 		const showWpcomThemesList = hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId );
-		let showNoThemesFoundJetpack = true;
-		let showNoThemesFoundWpcom = true;
+		let showNoThemesFound = true;
 		if ( showWpcomThemesList ) {
 			const siteQuery = getLastThemeQuery( state, siteId );
 			const wpcomQuery = getLastThemeQuery( state, 'wpcom' );
 			const siteThemesCount = getThemesFoundForQuery( state, siteId, siteQuery );
 			const wpcomThemesCount = getThemesFoundForQuery( state, 'wpcom', wpcomQuery );
-
-			if ( siteThemesCount && ! wpcomThemesCount ) {
-				showNoThemesFoundWpcom = false;
-			} else if ( ! siteThemesCount ) {
-				showNoThemesFoundJetpack = false;
-			}
-
+			showNoThemesFound = ! siteThemesCount && ! wpcomThemesCount;
 		}
 		return {
 			wpcomTier: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ) ? tier : 'free',
 			showWpcomThemesList,
-			showNoThemesFoundJetpack,
-			showNoThemesFoundWpcom,
+			showNoThemesFound,
 		};
 	}
 )( ConnectedSingleSiteJetpack );

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -47,6 +47,7 @@ const ConnectedSingleSiteJetpack = connectOptions(
 			analyticsPageTitle,
 			emptyContent,
 			getScreenshotOption,
+			showWpcomThemesList,
 			search,
 			site,
 			siteId,
@@ -83,13 +84,13 @@ const ConnectedSingleSiteJetpack = connectOptions(
 				<CurrentTheme siteId={ siteId } />
 				<ThemeShowcase { ...props }
 					siteId={ siteId }
-					emptyContent={ <div /> } >
+					emptyContent={ showWpcomThemesList ? <div /> : null } >
 					{ siteId && <QuerySitePlans siteId={ siteId } /> }
 					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 					<ThanksModal
 						site={ site }
 						source={ 'list' } />
-					{ config.isEnabled( 'manage/themes/upload' ) && props.showWpcomThemesList &&
+					{ config.isEnabled( 'manage/themes/upload' ) && showWpcomThemesList &&
 						<div>
 							<ConnectedThemesSelection
 								options={ [

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -10,7 +10,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import CurrentTheme from 'my-sites/themes/current-theme';
-import EmptyContent from 'components/empty-content';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 import config from 'config';
@@ -54,9 +53,8 @@ const ConnectedSingleSiteJetpack = connectOptions(
 			wpcomTier,
 			filter,
 			vertical,
-			showNoThemesFound,
-			showNoThemesFoundBanner,
-			translate
+			showNoThemesFoundJetpack,
+			showNoThemesFoundWpcom,
 		} = props;
 		const jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' );
 
@@ -87,7 +85,7 @@ const ConnectedSingleSiteJetpack = connectOptions(
 				<CurrentTheme siteId={ siteId } />
 				<ThemeShowcase { ...props }
 					siteId={ siteId }
-					showNoThemesFoundBanner={ showNoThemesFoundBanner } >
+					showNoThemesFound={ showNoThemesFoundJetpack } >
 					{ siteId && <QuerySitePlans siteId={ siteId } /> }
 					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 					<ThanksModal
@@ -130,15 +128,11 @@ const ConnectedSingleSiteJetpack = connectOptions(
 								} }
 								trackScrollPage={ props.trackScrollPage }
 								source="wpcom"
-								showNoThemesFoundBanner={ showNoThemesFoundBanner }
+								showNoThemesFound={ showNoThemesFoundWpcom }
 							/>
 						</div>
 					}
 				</ThemeShowcase>
-				{	showNoThemesFound && <EmptyContent
-					title={ translate( 'Sorry, no themes found.' ) }
-					line={ translate( 'Try a different search or more filters?' ) } />
-				}
 			</div>
 		);
 	}
@@ -147,19 +141,28 @@ const ConnectedSingleSiteJetpack = connectOptions(
 export default connect(
 	( state, { siteId, tier } ) => {
 		const showWpcomThemesList = hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId );
-		let showNoThemesFound = false;
+		let showNoThemesFoundJetpack = true;
+		let showNoThemesFoundWpcom = true;
 		if ( showWpcomThemesList ) {
 			const siteQuery = getLastThemeQuery( state, siteId );
 			const wpcomQuery = getLastThemeQuery( state, 'wpcom' );
 			const siteThemesCount = getThemesFoundForQuery( state, siteId, siteQuery );
 			const wpcomThemesCount = getThemesFoundForQuery( state, 'wpcom', wpcomQuery );
-			showNoThemesFound = ! siteThemesCount && ! wpcomThemesCount;
+
+			if ( siteThemesCount && ! wpcomThemesCount ) {
+				showNoThemesFoundWpcom = false;
+			} else if ( ! siteThemesCount && wpcomThemesCount ) {
+				showNoThemesFoundJetpack = false;
+			} else if ( ! siteThemesCount && ! wpcomThemesCount ) {
+				showNoThemesFoundJetpack = false;
+			}
 		}
 		return {
 			wpcomTier: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ) ? tier : 'free',
 			showWpcomThemesList,
-			showNoThemesFound,
-			showNoThemesFoundBanner: ! showWpcomThemesList
+			showNoThemesFoundJetpack,
+			showNoThemesFoundWpcom,
+			showNoThemesFound: ! showWpcomThemesList
 		};
 	}
 )( localize( ConnectedSingleSiteJetpack ) );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -70,7 +70,8 @@ const ThemeShowcase = React.createClass( {
 		return {
 			tier: '',
 			search: '',
-			showUploadButton: true
+			showUploadButton: true,
+			showNoThemesFoundBanner: true
 		};
 	},
 
@@ -179,6 +180,7 @@ const ThemeShowcase = React.createClass( {
 							option => ! ( option.hideForTheme && option.hideForTheme( theme ) )
 						); } }
 					trackScrollPage={ this.props.trackScrollPage }
+					showNoThemesFoundBanner={ this.props.showNoThemesFoundBanner }
 				/>
 				<ThemePreview />
 				{ this.props.children }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -56,6 +56,7 @@ const optionShape = PropTypes.shape( {
 
 const ThemeShowcase = React.createClass( {
 	propTypes: {
+		emptyContent: PropTypes.element,
 		tier: PropTypes.oneOf( [ '', 'free', 'premium' ] ),
 		search: PropTypes.string,
 		// Connected props
@@ -70,8 +71,8 @@ const ThemeShowcase = React.createClass( {
 		return {
 			tier: '',
 			search: '',
-			showUploadButton: true,
-			showNoThemesFound: true
+			emptyContent: null,
+			showUploadButton: true
 		};
 	},
 
@@ -180,7 +181,7 @@ const ThemeShowcase = React.createClass( {
 							option => ! ( option.hideForTheme && option.hideForTheme( theme ) )
 						); } }
 					trackScrollPage={ this.props.trackScrollPage }
-					showNoThemesFound={ this.props.showNoThemesFound }
+					emptyContent={ this.props.emptyContent }
 				/>
 				<ThemePreview />
 				{ this.props.children }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -71,7 +71,7 @@ const ThemeShowcase = React.createClass( {
 			tier: '',
 			search: '',
 			showUploadButton: true,
-			showNoThemesFoundBanner: true
+			showNoThemesFound: true
 		};
 	},
 
@@ -180,7 +180,7 @@ const ThemeShowcase = React.createClass( {
 							option => ! ( option.hideForTheme && option.hideForTheme( theme ) )
 						); } }
 					trackScrollPage={ this.props.trackScrollPage }
-					showNoThemesFoundBanner={ this.props.showNoThemesFoundBanner }
+					showNoThemesFound={ this.props.showNoThemesFound }
 				/>
 				<ThemePreview />
 				{ this.props.children }

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -50,12 +50,14 @@ const ThemesSelection = React.createClass( {
 		isThemeActive: PropTypes.func,
 		isThemePurchased: PropTypes.func,
 		isInstallingTheme: PropTypes.func,
-		placeholderCount: PropTypes.number
+		placeholderCount: PropTypes.number,
+		showNoThemesFoundBanner: PropTypes.bool
 	},
 
 	getDefaultProps() {
 		return {
-			showUploadButton: true
+			showUploadButton: true,
+			showNoThemesFoundBanner: true
 		};
 	},
 
@@ -137,6 +139,10 @@ const ThemesSelection = React.createClass( {
 		return options;
 	},
 
+	showNoThemesFoundBanner( ) {
+		return this.props.showNoThemesFoundBanner ? null : <div />;
+	},
+
 	render() {
 		const { source, query, listLabel, themesCount } = this.props;
 
@@ -160,6 +166,7 @@ const ThemesSelection = React.createClass( {
 					isPurchased={ this.props.isThemePurchased }
 					isInstalling={ this.props.isInstallingTheme }
 					loading={ this.props.isRequesting }
+					emptyContent={ this.showNoThemesFoundBanner() }
 					placeholderCount={ this.props.placeholderCount } />
 			</div>
 		);

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -31,6 +31,7 @@ import { PAGINATION_QUERY_KEYS } from 'lib/query-manager/paginated/constants';
 
 const ThemesSelection = React.createClass( {
 	propTypes: {
+		emptyContent: PropTypes.element,
 		query: PropTypes.object.isRequired,
 		siteId: PropTypes.number,
 		onScreenshotClick: PropTypes.func,
@@ -50,14 +51,13 @@ const ThemesSelection = React.createClass( {
 		isThemeActive: PropTypes.func,
 		isThemePurchased: PropTypes.func,
 		isInstallingTheme: PropTypes.func,
-		placeholderCount: PropTypes.number,
-		showNoThemesFound: PropTypes.bool
+		placeholderCount: PropTypes.number
 	},
 
 	getDefaultProps() {
 		return {
-			showUploadButton: true,
-			showNoThemesFound: true
+			emptyContent: null,
+			showUploadButton: true
 		};
 	},
 
@@ -139,10 +139,6 @@ const ThemesSelection = React.createClass( {
 		return options;
 	},
 
-	showNoThemesFound( ) {
-		return this.props.showNoThemesFound ? null : <div />;
-	},
-
 	render() {
 		const { source, query, listLabel, themesCount } = this.props;
 
@@ -166,7 +162,7 @@ const ThemesSelection = React.createClass( {
 					isPurchased={ this.props.isThemePurchased }
 					isInstalling={ this.props.isInstallingTheme }
 					loading={ this.props.isRequesting }
-					emptyContent={ this.showNoThemesFound() }
+					emptyContent={ this.props.emptyContent }
 					placeholderCount={ this.props.placeholderCount } />
 			</div>
 		);

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -51,13 +51,13 @@ const ThemesSelection = React.createClass( {
 		isThemePurchased: PropTypes.func,
 		isInstallingTheme: PropTypes.func,
 		placeholderCount: PropTypes.number,
-		showNoThemesFoundBanner: PropTypes.bool
+		showNoThemesFound: PropTypes.bool
 	},
 
 	getDefaultProps() {
 		return {
 			showUploadButton: true,
-			showNoThemesFoundBanner: true
+			showNoThemesFound: true
 		};
 	},
 
@@ -139,8 +139,8 @@ const ThemesSelection = React.createClass( {
 		return options;
 	},
 
-	showNoThemesFoundBanner( ) {
-		return this.props.showNoThemesFoundBanner ? null : <div />;
+	showNoThemesFound( ) {
+		return this.props.showNoThemesFound ? null : <div />;
 	},
 
 	render() {
@@ -166,7 +166,7 @@ const ThemesSelection = React.createClass( {
 					isPurchased={ this.props.isThemePurchased }
 					isInstalling={ this.props.isInstallingTheme }
 					loading={ this.props.isRequesting }
-					emptyContent={ this.showNoThemesFoundBanner() }
+					emptyContent={ this.showNoThemesFound() }
 					placeholderCount={ this.props.placeholderCount } />
 			</div>
 		);


### PR DESCRIPTION
### Info 
This fixes problem described in #11045. This is important only for Jetpack sites that have two themes lists on their `/design` page. Because two lists are located at two different levels in components hierarchy it would be very hard ( messy code ) for them to communicate on amount of themes they have to display. For this reason a solution was put in hierarchy above both of the themes lists. Code check redux for queries for site and wpcom ( we know that because this is single site Jetpack situation ), then checks pulls out found themes count for that queries. Compares them and figures out which list should or should not render no themes sign. This has the benefit of not using additional `EmptyContent` component. For all the other cases default props for `ThemesShowcase` and `ThemesList` are sufficient for proper behavior.
When we do not want to use no themes found in `ThemesList` we push empty `div` into `emptyContent` prop and it gets rendered instead of the sign which visually equals to no sign at all. 

### Testing
1. Open `/design` in `All Sites` mode and type in Search field. When search count returns 0 it "Sorry not themes ..." should be visible
2. Open `/design` in single site mode on Jetpack site ( two lists ). When search count returns 0 for just one of the lists no  "Sorry no themes ..."  should be visible. When search count returns 0 for both lists only one "Sorry no themes ..." should be visible. 

### Before 
![image](https://cloud.githubusercontent.com/assets/17271089/23131311/cd4b546a-f789-11e6-94e5-9aa64c81542f.png)


### After
![image](https://cloud.githubusercontent.com/assets/17271089/23131378/0f75ee72-f78a-11e6-97a5-78f18b6cbbc9.png)


Fixes #11045 