### PR TITLE
Replace Baskerville with Baskerville 2 in signup

### DIFF
--- a/client/lib/signup/themes-data.js
+++ b/client/lib/signup/themes-data.js
@@ -18,12 +18,12 @@ export const themes = [
 		verticals: []
 	},
 	{
-		name: 'Baskerville',
-		slug: 'baskerville',
+		name: 'Baskerville 2',
+		slug: 'baskerville-2',
 		repo: 'pub',
 		fallback: false,
 		design: 'grid',
-		demo_uri: 'https://baskervilledemo.wordpress.com',
+		demo_uri: 'https://baskerville2demo.wordpress.com',
 		verticals: []
 	},
 	{


### PR DESCRIPTION
Instructions for testing:
* Switch to this PR 
* Go to calypso.local:3000(?)/start/ 
* Click "A grid of my latest posts" 
* Make sure Baskerville 2 shows up instead of Baskerville

Pinging @michaeldcain when you have a chance, thank you!