### PR TITLE
Domains: Include WPCOM email in the messaging for WHOIS update on WWD domains

### DIFF
--- a/client/my-sites/upgrades/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/upgrades/domain-management/edit-contact-info/form-card.jsx
@@ -179,7 +179,7 @@ class EditContactInfoFormCard extends React.Component {
 			'If you don’t have access to {{strong}}%(currentEmail)s{{/strong}}, ' +
 			'we will also email you at {{strong}}%(wpcomEmail)s{{/strong}}, as backup.', {
 				args: { currentEmail, wpcomEmail },
-				components: { supportLink: <a href={ support.CALYPSO_CONTACT } />, strong }
+				components: { strong }
 			}
 		) }</p>;
 	}

--- a/client/my-sites/upgrades/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/upgrades/domain-management/edit-contact-info/form-card.jsx
@@ -222,7 +222,7 @@ class EditContactInfoFormCard extends React.Component {
 			<Dialog isVisible={ this.state.showNonDaConfirmationDialog } buttons={ buttons } onClose={ this.handleDialogClose }>
 				<h1>{ translate( 'Confirmation Needed' ) }</h1>
 				<p>{ text }</p>
-				<p>{ currentEmail !== wpcomEmail && this.renderBackupEmail() }</p>
+				{ currentEmail !== wpcomEmail && this.renderBackupEmail() }
 			</Dialog>
 		);
 	}

--- a/client/my-sites/upgrades/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/upgrades/domain-management/edit-contact-info/form-card.jsx
@@ -202,9 +202,9 @@ class EditContactInfoFormCard extends React.Component {
 			const newEmail = formState.getFieldValue( this.state.form, 'email' );
 
 			text = translate( 'To finish this process, this change will need to be confirmed by emails ' +
-				'sent to {{strong}}%(currentEmails)s{{/strong}} and {{strong}}%(newEmail)s{{/strong}}. Please make sure ' +
+				'sent to {{strong}}%(oldEmail)s{{/strong}} and {{strong}}%(newEmail)s{{/strong}}. Please make sure ' +
 				'you\'ll be able to do so.', {
-					args: { currentEmails, newEmail }, components: { strong }
+					args: { oldEmail: currentEmails, newEmail }, components: { strong }
 				}
 			);
 		}
@@ -459,10 +459,10 @@ class EditContactInfoFormCard extends React.Component {
 						const newEmail = formState.getFieldValue( this.state.form, 'email' );
 
 						message = this.props.translate(
-							'Emails have been sent to {{strong}}%(currentEmails)s{{/strong}} and {{strong}}%(newEmail)s{{/strong}}. ' +
+							'Emails have been sent to {{strong}}%(oldEmail)s{{/strong}} and {{strong}}%(newEmail)s{{/strong}}. ' +
 							'Please ensure they\'re both confirmed to finish this process.',
 							{
-								args: { currentEmails, newEmail },
+								args: { oldEmail: currentEmails, newEmail },
 								components: { strong }
 							}
 						);

--- a/client/my-sites/upgrades/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/upgrades/domain-management/edit-contact-info/form-card.jsx
@@ -231,8 +231,7 @@ class EditContactInfoFormCard extends React.Component {
 		const { translate } = this.props,
 			saveButtonLabel = translate( 'Save Contact Info' ),
 			{ OPENHRS, OPENSRS } = registrarNames,
-			canUseDesignatedAgent = includes( [ OPENHRS, OPENSRS ], this.props.selectedDomain.registrar ),
-			requiresConfirmation = this.requiresConfirmation();
+			canUseDesignatedAgent = includes( [ OPENHRS, OPENSRS ], this.props.selectedDomain.registrar );
 
 		return (
 			<Card>
@@ -333,7 +332,7 @@ class EditContactInfoFormCard extends React.Component {
 					<FormFooter>
 						<FormButton
 							disabled={ this.state.formSubmitting }
-							onClick={ requiresConfirmation ? this.showNonDaConfirmationDialog : this.saveContactInfo }>
+							onClick={ this.requiresConfirmation() ? this.showNonDaConfirmationDialog : this.saveContactInfo }>
 							{ saveButtonLabel }
 						</FormButton>
 

--- a/client/my-sites/upgrades/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/upgrades/domain-management/edit-contact-info/form-card.jsx
@@ -135,7 +135,7 @@ class EditContactInfoFormCard extends React.Component {
 		return this.props.translate( '%(currentEmail)s (additionally to %(wpcomEmail)s)',
 			{
 				args: { currentEmail, wpcomEmail },
-				context: 'List of emails the WHOIS confirmation email is sent to'
+				comment: 'List of emails the WHOIS confirmation email is sent to'
 			}
 		);
 	}

--- a/client/my-sites/upgrades/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/upgrades/domain-management/edit-contact-info/form-card.jsx
@@ -133,7 +133,7 @@ class EditContactInfoFormCard extends React.Component {
 	}
 
 	hasEmailChanged() {
-		return this.props.contactInformation.email === formState.getFieldValue( this.state.form, 'email' );
+		return this.props.contactInformation.email !== formState.getFieldValue( this.state.form, 'email' );
 	}
 
 	handleFormControllerError = ( error ) => {

--- a/client/my-sites/upgrades/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/upgrades/domain-management/edit-contact-info/form-card.jsx
@@ -194,7 +194,7 @@ class EditContactInfoFormCard extends React.Component {
 				},
 				{
 					action: 'confirm',
-					label: this.props.translate( 'Confirm' ),
+					label: this.props.translate( 'Request Confirmation' ),
 					onClick: this.saveContactInfo,
 					isPrimary: true
 				}

--- a/client/my-sites/upgrades/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/upgrades/domain-management/edit-contact-info/form-card.jsx
@@ -185,6 +185,23 @@ class EditContactInfoFormCard extends React.Component {
 		);
 	}
 
+	renderBackupEmail() {
+		const currentEmail = this.props.contactInformation.email,
+			wpcomEmail = this.props.currentUser.email,
+			strong = <strong />;
+
+		return <p>{ this.props.translate(
+			'If you don’t have access to {{strong}}%(currentEmail)s{{/strong}}, ' +
+			'we will also email you at {{strong}}%(wpcomEmail)s{{/strong}}, as backup.', {
+				args: { currentEmail, wpcomEmail },
+				components: {
+					supportLink: <a href={ support.CALYPSO_CONTACT } />,
+					strong
+				}
+			}
+		) }</p>;
+	}
+
 	renderDialog() {
 		const { translate } = this.props,
 			strong = <strong />,
@@ -200,32 +217,29 @@ class EditContactInfoFormCard extends React.Component {
 					isPrimary: true
 				}
 			],
-			currentEmails = this.getCurrentEmails();
+			currentEmail = this.props.contactInformation.email,
+			wpcomEmail = this.props.currentUser.email;
 
 		let text;
 		if ( this.hasEmailChanged() ) {
 			const newEmail = formState.getFieldValue( this.state.form, 'email' );
 
-			text = translate( 'We’ll email you at {{strong}}%(oldEmail)s{{/strong}} and {{strong}}%(newEmail)s{{/strong}} with a link to confirm the new details. ' +
-				'The change won’t go live until we receive confirmation from both emails.' +
-				'If you don’t have access to {{strong}}%(oldEmail)s{{/strong}}, we will also email you at {{strong}}%(newEmail)s{{/strong}}, as backup.', {
-					args: { oldEmail: currentEmails, newEmail }, components: { strong }
-				}
+			text = translate( 'We’ll email you at {{strong}}%(currentEmail)s{{/strong}} and {{strong}}%(newEmail)s{{/strong}} ' +
+				'with a link to confirm the new details. The change won’t go live until we receive confirmation from both emails.',
+				{ args: { oldEmail: currentEmail, newEmail }, components: { strong } }
 			);
 		} else {
-			text = translate( 'We’ll email you at {{strong}}%(currentEmails)s{{/strong}} with a link to confirm the new details. ' +
+			text = translate( 'We’ll email you at {{strong}}%(currentEmail)s{{/strong}} with a link to confirm the new details. ' +
 				'The change won\'t go live until we receive confirmation from one of these emails.', {
-					args: { currentEmails }, components: { strong }
+					args: { currentEmail }, components: { strong }
 				}
 			);
 		}
 		return (
 			<Dialog isVisible={ this.state.showNonDaConfirmationDialog } buttons={ buttons } onClose={ this.handleDialogClose }>
-				<h1>{ translate( 'Request Confirmation' ) }</h1>
+				<h1>{ translate( 'Confirmation Needed' ) }</h1>
 				<p>{ text }</p>
-				<p>{ translate( 'If that is not the case, please {{supportLink}}contact support{{/supportLink}} instead.', {
-					components: { supportLink: <a href={ support.CALYPSO_CONTACT } /> }
-				} ) }</p>
+				<p>{ currentEmail !== wpcomEmail && this.renderBackupEmail() }</p>
 			</Dialog>
 		);
 	}


### PR DESCRIPTION
There's been a change in how the user can confirm a WHOIS update for a WWD domain (backend changes merged, see `D4312-code`), we now send a third, backup email to their WPCOM account.

So, up to three emails will be sent:

1. If the email has not been changed, the confirmation email will be sent to the current email plus the WPCOM one.
   <img width="1106" alt="screen shot 2017-02-28 at 19 18 08" src="https://cloud.githubusercontent.com/assets/3392497/23480488/67260cd4-fec8-11e6-98ae-018c8982043c.png">


2. If the email has been changed, the confirmation email will be sent to the current email (with the WPCOM one acting as a backup) and the new email.
   <img width="1158" alt="screen shot 2017-02-28 at 19 18 53" src="https://cloud.githubusercontent.com/assets/3392497/23480501/6fc2c3d2-fec8-11e6-834d-4f37168a8e30.png">


I've updated the copy a bit to mention that we'll be sending this backup email to their WPCOM email address. If the current email and WPCOM one are the same, we don't mention them both, since only one email will be sent in that case.

_Added:_
I've also updated the logic to not show the above dialog if we did not change any of the main fields (first name, last name, organization, email) - because in that case, no confirmation is needed, even in WWD case ;)