### PR TITLE
Site Settings: Remove site icon feature flag

### DIFF
--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -25,7 +25,6 @@ import { isJetpackSite, getCustomizerUrl, getSiteAdminUrl } from 'state/sites/se
 import { ModalViews } from 'state/ui/media-modal/constants';
 import { AspectRatios } from 'state/ui/editor/image-editor/constants';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isEnabled } from 'config';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import InfoPopover from 'components/info-popover';
@@ -219,10 +218,9 @@ class SiteIconSetting extends Component {
 	render() {
 		const { isJetpack, isPrivate, iconUrl, customizerUrl, generalOptionsUrl, siteSupportsImageEditor } = this.props;
 		const { isModalVisible, hasToggledModal, isEditingSiteIcon } = this.state;
-		const isIconManagementEnabled = isEnabled( 'manage/site-settings/site-icon' );
 
 		let buttonProps;
-		if ( isIconManagementEnabled && siteSupportsImageEditor ) {
+		if ( siteSupportsImageEditor ) {
 			buttonProps = {
 				type: 'button',
 				onClick: this.showModal,
@@ -235,7 +233,7 @@ class SiteIconSetting extends Component {
 			// send to wp-admin instead (Customizer field unsupported)
 			const hasBlavatar = includes( iconUrl, '.gravatar.com/blavatar/' );
 
-			if ( isJetpack || ( isIconManagementEnabled && isPrivate && ! hasBlavatar ) ) {
+			if ( isJetpack || ( isPrivate && ! hasBlavatar ) ) {
 				buttonProps.href = customizerUrl;
 			} else {
 				buttonProps.href = generalOptionsUrl;
@@ -274,7 +272,7 @@ class SiteIconSetting extends Component {
 					compact>
 					{ translate( 'Change', { context: 'verb' } ) }
 				</Button>
-				{ isIconManagementEnabled && hasIcon && (
+				{ hasIcon && (
 					<Button
 						compact
 						scary
@@ -284,7 +282,7 @@ class SiteIconSetting extends Component {
 						{ translate( 'Remove' ) }
 					</Button>
 				) }
-				{ isIconManagementEnabled && hasToggledModal && (
+				{ hasToggledModal && (
 					<MediaLibrarySelectedData siteId={ siteId }>
 						<AsyncLoad
 							require="post-editor/media-modal"

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -48,7 +48,6 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,
-		"manage/site-settings/site-icon": true,
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,

--- a/config/development.json
+++ b/config/development.json
@@ -86,7 +86,6 @@
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,
 		"manage/site-settings/date-time-format": true,
-		"manage/site-settings/site-icon": true,
 		"manage/stats": true,
 		"manage/stats/podcasts": true,
 		"manage/themes": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -54,7 +54,6 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,
-		"manage/site-settings/site-icon": true,
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,

--- a/config/production.json
+++ b/config/production.json
@@ -51,7 +51,6 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,
-		"manage/site-settings/site-icon": true,
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -52,7 +52,6 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,
-		"manage/site-settings/site-icon": true,
 		"manage/seo": true,
 		"manage/stats": true,
 		"manage/themes": true,

--- a/config/test.json
+++ b/config/test.json
@@ -67,7 +67,6 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,
-		"manage/site-settings/site-icon": true,
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -64,7 +64,6 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,
-		"manage/site-settings/site-icon": true,
 		"manage/stats": true,
 		"manage/stats/podcasts": true,
 		"manage/themes": true,


### PR DESCRIPTION
Related: #11203

Site icon management was enabled in all environments on February 6th. This pull request seeks to remove the feature flag that had been used in its development for falling back to legacy site icon flows.

__Testing instructions:__

Verify that site icon flows continue to work as expected* without errors.

_*_ Specifically:

- WordPress.com non-private sites and Jetpack sites with Photon module activated should show site icon modal flow
- WordPress.com private sites with Blavatar should direct to wp-admin Settings > General
- WordPress.com private sites without Blavatar should direct to Calypso Customizer
- Jetpack sites without Photon module activated should direct to wp-admin Customizer

Ensure that there are no remaining references to the `manage/site-settings/site-icon` feature flag.