### PR TITLE
Directly: Integrate RTM widget with Contact Us form

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -36,7 +36,8 @@ import QueryTicketSupportConfiguration from 'components/data/query-ticket-suppor
 import HelpUnverifiedWarning from '../help-unverified-warning';
 import { connectChat as connectHappychat, sendChatMessage as sendHappychatMessage } from 'state/happychat/actions';
 import { openChat as openHappychat } from 'state/ui/happychat/actions';
-import { getCurrentUserLocale } from 'state/current-user/selectors';
+import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selectors';
+import { askQuestion as askDirectlyQuestion, initialize as initializeDirectly } from 'state/help/directly/actions';
 
 /**
  * Module variables
@@ -62,6 +63,10 @@ const HelpContact = React.createClass( {
 	componentDidMount: function() {
 		if ( config.isEnabled( 'happychat' ) ) {
 			this.props.connectHappychat();
+		}
+
+		if ( config.isEnabled( 'help/directly' ) ) {
+			this.props.initializeDirectly();
 		}
 
 		olarkStore.on( 'change', this.updateOlarkState );
@@ -169,9 +174,15 @@ const HelpContact = React.createClass( {
 	},
 
 	submitDirectlyQuestion: function( contactForm ) {
-		// TODO: open Directly form here
+		const { display_name, email } = this.props.currentUser;
 
-		return contactForm; // TODO: Remove this line once functionality is implemented
+		this.props.askDirectlyQuestion(
+			contactForm.message,
+			display_name,
+			email
+		);
+
+		this.clearSavedContactForm();
 	},
 
 	submitKayakoTicket: function( contactForm ) {
@@ -511,7 +522,7 @@ const HelpContact = React.createClass( {
 					showSubjectField: false,
 					showHowCanWeHelpField: false,
 					showHowYouFeelField: false,
-					showSiteField: hasMoreThanOneSite,
+					showSiteField: false,
 				};
 
 			default:
@@ -651,6 +662,7 @@ export default connect(
 	( state ) => {
 		return {
 			currentUserLocale: getCurrentUserLocale( state ),
+			currentUser: getCurrentUser( state ),
 			olarkTimedOut: isOlarkTimedOut( state ),
 			isEmailVerified: isCurrentUserEmailVerified( state ),
 			isHappychatAvailable: isHappychatAvailable( state ),
@@ -659,5 +671,11 @@ export default connect(
 			ticketSupportRequestError: getTicketSupportRequestError( state ),
 		};
 	},
-	{ connectHappychat, openHappychat, sendHappychatMessage }
+	{
+		connectHappychat,
+		openHappychat,
+		sendHappychatMessage,
+		askDirectlyQuestion,
+		initializeDirectly,
+	}
 )( localize( HelpContact ) );


### PR DESCRIPTION
[Directly](https://www.directly.com/) is a third-party customer support tool/widget. This PR integrates the Directly widget into the UI building on API and Redux work done in https://github.com/Automattic/wp-calypso/pull/11489 and https://github.com/Automattic/wp-calypso/pull/11490.

## Manual testing

### Development mode, unpaid user
Sign in as a user without any paid upgrades. Go to http://calypso.localhost:3000/help/contact. You should get a prompt to "Chat with an __Expert User__ of WordPress.com."

Write a question in the box and press "Ask an Expert." You'll see the Directly widget pop out with your question asked.

<img width="774" alt="screen shot 2017-02-20 at 9 45 24 pm" src="https://cloud.githubusercontent.com/assets/518059/23150055/024c3bbc-f7b6-11e6-99e0-bf74b6aae6bc.png">

Navigating away from the Contact Us page should leave the widget open.

You shouldn't see assets for Directly in the Dev Tools Network tab until you land on the http://calypso.localhost:3000/help/contact page. For example if you open a new tab to http://calypso.localhost:3000/me you shouldn't see the assets until you navigate to (?) -> Contact Us. 

### Development mode, paid user
Sign in as a user with paid upgrades. Go to http://calypso.localhost:3000/help/contact. You should see the form starting with "How can we help?" that opens Happychat.

<img width="764" alt="screen shot 2017-02-20 at 9 51 10 pm" src="https://cloud.githubusercontent.com/assets/518059/23150142/d5ce8814-f7b6-11e6-9504-7eb31efd979d.png">

You'll still see assets for Directly in the Dev Tools Network tab even though the library isn't supposed to load for paid users. This is a known issue that we will correct in another PR.

### Staging, paid or unpaid user
This feature is locked behind a flag for development environment only. So the staging/production environments should be unchanged from their current state, and you shouldn't see Directly assets requested ever.

## Known bugs

- You'll see 404 errors for https://wpcalypso.wordpress.com/calypso/directly.css — this will be resolved when a PR with custom CSS ships.
- Directly assets are still being requested for paid users. This will also be fixed before shipping to production. 