### PR TITLE
Update EditGravatar style

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -210,6 +210,7 @@
 @import 'me/notification-settings/push-notification-settings/style';
 @import 'me/notification-settings/settings-form/style';
 @import 'me/notification-settings/wpcom-settings/style';
+@import 'me/profile/style';
 @import 'me/profile-gravatar/style';
 @import 'me/profile-link/style';
 @import 'me/profile-links-add-other/style';

--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -7,23 +7,21 @@ import { connect } from 'react-redux';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import path from 'path';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
 import { ALLOWED_FILE_EXTENSIONS } from './constants';
 import { AspectRatios } from 'state/ui/editor/image-editor/constants';
-import Button from 'components/button';
 import Dialog from 'components/dialog';
 import FilePicker from 'components/file-picker';
-import FormLabel from 'components/forms/form-label';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getToken as getOauthToken } from 'lib/oauth-token';
 import Gravatar from 'components/gravatar';
 import {
 	isCurrentUserUploadingGravatar,
 } from 'state/current-user/gravatar-status/selectors';
-import { isOffline } from 'state/application/selectors';
 import {
 	resetAllImageEditorState
 } from 'state/ui/editor/image-editor/actions';
@@ -49,7 +47,6 @@ export class EditGravatar extends Component {
 	}
 
 	static propTypes = {
-		isOffline: PropTypes.bool,
 		isUploading: PropTypes.bool,
 		translate: PropTypes.func,
 		receiveGravatarImageFailed: PropTypes.func,
@@ -158,49 +155,41 @@ export class EditGravatar extends Component {
 		}
 	}
 
+	renderInstructionText() {
+		return (
+			<div className="edit-gravatar__label-container">
+				<Gridicon icon="cloud-upload" size={ 36 } />
+				<span className="edit-gravatar__label">
+					{ this.props.translate( 'Click to change photo' ) }
+				</span>
+			</div>
+		);
+	}
+
 	render() {
 		const {
-			isOffline: userIsOffline,
 			isUploading,
-			translate,
 			user
 		} = this.props;
 		return (
-			<div>
+			<div className="edit-gravatar">
 				{ this.renderImageEditor() }
-				<FormLabel>
-					{
-						translate( 'Avatar', {
-							comment: 'A section heading on the profile page.'
-						} )
-					}
-				</FormLabel>
-				<div
-					className={
-						classnames( 'edit-gravatar__image-container',
-							{ 'is-uploading': isUploading }
-						)
-					}
-				>
-					<Gravatar
-						imgSize={ 270 }
-						size={ 100 }
-						user={ user }
-					/>
-					{ isUploading && <Spinner className="edit-gravatar__spinner" /> }
-				</div>
-				<p>
-					{
-						translate( 'To change, select an image or ' +
-							'drag and drop a picture from your computer.' )
-					}
-				</p>
 				<FilePicker accept="image/*" onPick={ this.onReceiveFile }>
-					<Button
-						disabled={ userIsOffline || isUploading || ! user.email_verified }
+					<div
+						className={
+							classnames( 'edit-gravatar__image-container',
+								{ 'is-uploading': isUploading }
+							)
+						}
 					>
-						{ translate( 'Select Image' ) }
-					</Button>
+						<Gravatar
+							imgSize={ 400 }
+							size={ 150 }
+							user={ user }
+						/>
+						{ ! isUploading && this.renderInstructionText() }
+						{ isUploading && <Spinner className="edit-gravatar__spinner" /> }
+						</div>
 				</FilePicker>
 			</div>
 		);
@@ -210,7 +199,6 @@ export class EditGravatar extends Component {
 export default connect(
 	state => ( {
 		user: getCurrentUser( state ),
-		isOffline: isOffline( state ),
 		isUploading: isCurrentUserUploadingGravatar( state ),
 	} ),
 	{

--- a/client/blocks/edit-gravatar/style.scss
+++ b/client/blocks/edit-gravatar/style.scss
@@ -14,6 +14,12 @@
 	}
 }
 
+.edit-gravatar__image-container .gravatar.is-missing {
+	display: block;
+	width: 150px;
+	height: 150px;
+}
+
 .edit-gravatar__spinner {
 	position: absolute;
 		top: 50%;

--- a/client/blocks/edit-gravatar/style.scss
+++ b/client/blocks/edit-gravatar/style.scss
@@ -1,16 +1,16 @@
 .edit-gravatar__image-container {
 	display: inline-block;
 	position: relative;
-	line-height: 0;
 
 	&.is-uploading::before {
 		content: '';
 		position: absolute;
 			top: 0;
-			right: 0;
-			bottom: 0;
 			left: 0;
-		background-color: rgba( $white, 0.75 );
+		background-color: rgba( $gray-dark, 0.5 );
+		border-radius: 50%;
+		height: 150px;
+		width: 150px;
 	}
 }
 
@@ -47,4 +47,31 @@
 
 .edit-gravatar-modal .dialog__content {
 	height: 100%;
+}
+
+.edit-gravatar__label-container {
+	position: absolute;
+		left: 0;
+		top: 0;
+	width: 150px;
+	height: 150px;
+	border-radius: 50%;
+	background: rgba( $gray-dark, 0.5 );
+	color: #fff;
+	text-align: center;
+
+	.gridicon {
+		display: block;
+		margin: 2em auto 0;
+	}
+}
+
+.edit-gravatar__label {
+	display: inline-block;
+	line-height: 1.2em;
+	padding: 0 1em;
+}
+
+.edit-gravatar .spinner__border {
+	fill: rgba( $gray-dark, 0.5 );
 }

--- a/client/components/gravatar/index.jsx
+++ b/client/components/gravatar/index.jsx
@@ -77,7 +77,7 @@ export class Gravatar extends Component {
 			);
 		}
 
-		if ( this.state.failedToLoad ) {
+		if ( this.state.failedToLoad && ! tempImage ) {
 			return <span className="gravatar is-missing" />;
 		}
 

--- a/client/components/gravatar/test/index.jsx
+++ b/client/components/gravatar/test/index.jsx
@@ -1,96 +1,103 @@
 /**
  * External dependencies
  */
-import assert from 'assert';
-import ReactDomServer from 'react-dom/server';
+import { expect } from 'chai';
 import React from 'react';
+import { shallow } from 'enzyme';
 
 /**
  * Internal dependencies
  */
 import { Gravatar } from '../';
 
-/**
- * Pass in a react-generated html string to remove react-specific attributes
- * to make it easier to compare to expected html structure
- * @param {string} string react-generated html
- * @return {string} HTML without react attributes
- */
-function stripReactAttributes( string ) {
-	return string.replace( /\sdata\-(reactid|react\-checksum)\=\"[^\"]+\"/g, '' );
-}
-
-describe( 'Gravatar', function() {
-	const bobTester = {
-		avatar_URL: 'https://0.gravatar.com/avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&d=identicon',
+describe( 'Gravatar', () => {
+	const genericUser = {
+		avatar_URL: 'https://0.gravatar.com/' +
+			'avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&d=mm',
 		display_name: 'Bob The Tester'
 	};
 
 	describe( 'rendering', function() {
 		it( 'should render an image given a user with valid avatar_URL, with default width and height 32', function() {
-			const gravatar = <Gravatar user={ bobTester } />;
-			const expectedResultString = '<img alt="Bob The Tester" ' +
-				'class="gravatar" ' +
-				'src="https://0.gravatar.com/' +
-				'avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&amp;d=mm" ' +
-				'width="32" height="32"/>';
+			const gravatar = shallow( <Gravatar user={ genericUser } /> );
+			const img = gravatar.find( 'img' );
 
-			assert.equal( expectedResultString, stripReactAttributes( ReactDomServer.renderToStaticMarkup( gravatar ) ) );
+			expect( img.length ).to.equal( 1 );
+			expect( img.prop( 'src' ) ).to.equal( 'https://0.gravatar.com/' +
+				'avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&d=mm' );
+			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
+			expect( img.prop( 'width' ) ).to.equal( 32 );
+			expect( img.prop( 'height' ) ).to.equal( 32 );
 		} );
 
 		it( 'should update the width and height when given a size attribute', function() {
-			const gravatar = <Gravatar user={ bobTester } size={ 100 } />;
-			const expectedResultString = '<img alt="Bob The Tester" ' +
-				'class="gravatar" ' +
-				'src="https://0.gravatar.com/' +
-				'avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&amp;d=mm" ' +
-				'width="100" height="100"/>';
+			const gravatar = shallow(
+				<Gravatar user={ genericUser } size={ 100 } />
+			);
+			const img = gravatar.find( 'img' );
 
-			assert.equal( expectedResultString, stripReactAttributes( ReactDomServer.renderToStaticMarkup( gravatar ) ) );
+			expect( img.length ).to.equal( 1 );
+			expect( img.prop( 'src' ) ).to.equal( 'https://0.gravatar.com/' +
+				'avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&d=mm' );
+			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
+			expect( img.prop( 'width' ) ).to.equal( 100 );
+			expect( img.prop( 'height' ) ).to.equal( 100 );
 		} );
 
 		it( 'should update source image when given imgSize attribute', function() {
-			const gravatar = <Gravatar user={ bobTester } imgSize={ 200 } />;
-			const expectedResultString = '<img alt="Bob The Tester" ' +
-				'class="gravatar" ' +
-				'src="https://0.gravatar.com/' +
-				'avatar/cf55adb1a5146c0a11a808bce7842f7b?s=200&amp;d=mm" ' +
-				'width="32" height="32"/>';
+			const gravatar = shallow(
+				<Gravatar user={ genericUser } imgSize={ 200 } />
+			);
+			const img = gravatar.find( 'img' );
 
-			assert.equal( expectedResultString, stripReactAttributes( ReactDomServer.renderToStaticMarkup( gravatar ) ) );
+			expect( img.length ).to.equal( 1 );
+			expect( img.prop( 'src' ) ).to.equal( 'https://0.gravatar.com/' +
+				'avatar/cf55adb1a5146c0a11a808bce7842f7b?s=200&d=mm' );
+			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
+			expect( img.prop( 'width' ) ).to.equal( 32 );
+			expect( img.prop( 'height' ) ).to.equal( 32 );
 		} );
 
 		it( 'should serve a default image if no avatar_URL available', function() {
-			const noImageTester = { display_name: 'Bob The Tester' };
-			const gravatar = <Gravatar user={ noImageTester } />;
-			const expectedResultString = '<img alt="Bob The Tester" ' +
-				'class="gravatar" ' +
-				'src="https://www.gravatar.com/avatar/0?s=96&amp;d=mm" ' +
-				'width="32" height="32"/>';
+			const noImageUser = { display_name: 'Bob The Tester' };
+			const gravatar = shallow( <Gravatar user={ noImageUser } /> );
+			const img = gravatar.find( 'img' );
 
-			assert.equal( expectedResultString, stripReactAttributes( ReactDomServer.renderToStaticMarkup( gravatar ) ) );
+			expect( img.length ).to.equal( 1 );
+			expect( img.prop( 'src' ) )
+				.to.equal( 'https://www.gravatar.com/avatar/0?s=96&d=mm' );
+			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
+			expect( img.prop( 'width' ) ).to.equal( 32 );
+			expect( img.prop( 'height' ) ).to.equal( 32 );
 		} );
 
 		it( 'should allow overriding the alt attribute', function() {
-			const gravatar = <Gravatar user={ bobTester } alt="Alternate Alt" />;
-			const expectedResultString = '<img alt="Alternate Alt" ' +
-				'class="gravatar" ' +
-				'src="https://0.gravatar.com/' +
-				'avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&amp;d=mm" ' +
-				'width="32" height="32"/>';
+			const gravatar = shallow(
+				<Gravatar user={ genericUser } alt="Another Alt" />
+			);
+			const img = gravatar.find( 'img' );
 
-			assert.equal( expectedResultString, stripReactAttributes( ReactDomServer.renderToStaticMarkup( gravatar ) ) );
+			expect( img.length ).to.equal( 1 );
+			expect( img.prop( 'src' ) ).to.equal( 'https://0.gravatar.com/' +
+				'avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&d=mm' );
+			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
+			expect( img.prop( 'width' ) ).to.equal( 32 );
+			expect( img.prop( 'height' ) ).to.equal( 32 );
+			expect( img.prop( 'alt' ) ).to.equal( 'Another Alt' );
 		} );
 
 		// I believe jetpack sites could have custom avatars, so can't assume it's always a gravatar
 		it( 'should promote non-secure avatar urls to secure', function() {
-			const nonSecureTester = { avatar_URL: 'http://www.example.com/avatar' };
-			const gravatar = <Gravatar user={ nonSecureTester } />;
-			const expectedResultString = '<img class="gravatar" ' +
-				'src="https://i2.wp.com/www.example.com/avatar?resize=96%2C96" ' +
-				'width="32" height="32"/>';
+			const nonSecureUrlUser = { avatar_URL: 'http://www.example.com/avatar' };
+			const gravatar = shallow( <Gravatar user={ nonSecureUrlUser } /> );
+			const img = gravatar.find( 'img' );
 
-			assert.equal( expectedResultString, stripReactAttributes( ReactDomServer.renderToStaticMarkup( gravatar ) ) );
+			expect( img.length ).to.equal( 1 );
+			expect( img.prop( 'src' ) )
+				.to.equal( 'https://i2.wp.com/www.example.com/avatar?resize=96%2C96' );
+			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
+			expect( img.prop( 'width' ) ).to.equal( 32 );
+			expect( img.prop( 'height' ) ).to.equal( 32 );
 		} );
 	} );
 } );

--- a/client/components/gravatar/test/index.jsx
+++ b/client/components/gravatar/test/index.jsx
@@ -99,5 +99,40 @@ describe( 'Gravatar', () => {
 			expect( img.prop( 'width' ) ).to.equal( 32 );
 			expect( img.prop( 'height' ) ).to.equal( 32 );
 		} );
+
+		describe( 'when Gravatar fails to load',  function() {
+			it( 'should render a span element', function() {
+				const gravatar = shallow( <Gravatar user={ genericUser } /> );
+
+				// simulate the Gravatar not loading
+				gravatar.setState( { failedToLoad: true } );
+
+				const img = gravatar.find( 'img' );
+				const span = gravatar.find( 'span' );
+
+				expect( img.length ).to.equal( 0 );
+				expect( span.length ).to.equal( 1 );
+				expect( span.hasClass( 'is-missing' ) ).to.equal( true );
+			} );
+
+			it( 'should show temp image if it exists', function() {
+				const gravatar = shallow(
+					<Gravatar
+						tempImage={ 'tempImage' }
+						user={ genericUser } />
+				);
+
+				// simulate the Gravatar not loading
+				gravatar.setState( { failedToLoad: true } );
+
+				const img = gravatar.find( 'img' );
+				const span = gravatar.find( 'span' );
+
+				expect( img.length ).to.equal( 1 );
+				expect( span.length ).to.equal( 0 );
+				expect( img.prop( 'src' ) ).to.equal( 'tempImage' );
+				expect( img.hasClass( 'gravatar' ) ).to.equal( true );
+			} );
+		} );
 	} );
 } );

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -26,6 +26,7 @@ import observe from 'lib/mixins/data-observe';
 import eventRecorder from 'me/event-recorder';
 import Main from 'components/main';
 import { isEnabled } from 'config';
+import SectionHeader from 'components/section-header';
 
 const debug = debugFactory( 'calypso:me:profile' );
 
@@ -50,34 +51,8 @@ export default protectForm( React.createClass( {
 			<Main className="profile">
 				<MeSidebarNavigation />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+				<SectionHeader label={ this.translate( 'Profile' ) } />
 				<Card className="me-profile-settings">
-					<p>
-						{ this.translate(
-							'This information will be displayed publicly on {{profilelink}}your profile{{/profilelink}} and in ' +
-							'{{hovercardslink}}Gravatar Hovercards{{/hovercardslink}}.',
-							{
-								components: {
-									profilelink: (
-										<a
-											onClick={ this.recordClickEvent( 'My Profile Link' ) }
-											href={ gravatarProfileLink }
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									),
-									hovercardslink: (
-										<a
-											onClick={ this.recordClickEvent( 'Gravatar Hovercards Link' ) }
-											href="https://support.wordpress.com/gravatar-hovercards/"
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									)
-								}
-							}
-						) }
-					</p>
-
 					{ isEnabled( 'me/edit-gravatar' ) && <EditGravatar /> }
 
 					<form onSubmit={ this.submitForm } onChange={ this.props.markChanged }>
@@ -130,6 +105,32 @@ export default protectForm( React.createClass( {
 							</FormButton>
 						</p>
 					</form>
+					<p className="me-profile-settings__info-text">
+						{ this.translate(
+							'This information will be displayed publicly on {{profilelink}}your profile{{/profilelink}} and in ' +
+							'{{hovercardslink}}Gravatar Hovercards{{/hovercardslink}}.',
+							{
+								components: {
+									profilelink: (
+										<a
+											onClick={ this.recordClickEvent( 'My Profile Link' ) }
+											href={ gravatarProfileLink }
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+									hovercardslink: (
+										<a
+											onClick={ this.recordClickEvent( 'Gravatar Hovercards Link' ) }
+											href="https://support.wordpress.com/gravatar-hovercards/"
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									)
+								}
+							}
+						) }
+					</p>
 				</Card>
 
 				<ProfileLinks userProfileLinks={ userProfileLinks } />

--- a/client/me/profile/style.scss
+++ b/client/me/profile/style.scss
@@ -1,0 +1,16 @@
+.me-profile-settings .edit-gravatar {
+	text-align: center;
+
+	@include breakpoint( ">960px" ) {
+		float: left;
+		margin-right: 40px;
+		margin-bottom: 20px;
+	}
+}
+
+.me-profile-settings .form-fieldset:nth-child(1),
+.me-profile-settings .form-fieldset:nth-child(2) {
+	@include breakpoint( ">960px" ) {
+		clear: right;
+	}
+}


### PR DESCRIPTION
This PR updates the EditGravatar component in the me/profile section.

It used to look like:

<img width="450" alt="old" src="https://cloud.githubusercontent.com/assets/11487924/23150522/0523bd54-f7c2-11e6-8d8e-9648f5407d95.png">

And now it looks like:

<img width="450" alt="updated-desktop" src="https://cloud.githubusercontent.com/assets/11487924/23150440/7e2f6b04-f7c1-11e6-8ee4-98aee4fe9292.png">

And on smaller screens:

<img width="300" alt="updated-smaller-screen" src="https://cloud.githubusercontent.com/assets/11487924/23150444/824c97fc-f7c1-11e6-93db-65ea12074ad7.png">

If a Gravatar cannot load, it will look like this:

<img width="300" alt="missing-gravatar" src="https://cloud.githubusercontent.com/assets/11487924/23150446/87cda6d0-f7c1-11e6-93cf-2910969d09f0.png">

You can read the design discussion in p7W0co-1X-p2

**Testing instructions:**
1. Check out this branch
2. Go to http://calypso.localhost:3000/me and make sure you don't see the Gravatar editing component
3. Enable the feature flag:
`export ENABLE_FEATURES=me/edit-gravatar && make run`
3. Go to http://calypso.localhost:3000/me and you should be able to see the Gravatar editing section
5. To test the functionality, you can add your bearer token to browser storage using this code:
```
localStorage.setItem('bearerToken', 'your_bearer_token');
```
You can find your bearer token by running this script in 
```
curl -# -X POST --data-urlencode "grant_type=password" --data-urlencode "client_id=appid" --data-urlencode "client_secret=appsecret" --data-urlencode "username=username" --data-urlencode "password=password" https://public-api.wordpress.com/oauth2/token
```

You can use Calypso's app ID & secret, found [here](https://github.com/Automattic/wp-calypso/blob/a1c610c300e040a2c101bb5af6a66f7cd72b52d6/config/production.json#L108-L109).
If you have 2FA enabled, you can add this extra parameter to the call: --data-urlencode "wpcom_otp=one-time-password", or you can create a new application password to use instead

Todo:
- [ ] make sure there isn't a visual regression of the spinner in IE11