### PR TITLE
Update/disable upload for multisite

### DIFF
--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -23,7 +23,7 @@ import ThemesSelection from './themes-selection';
 import { addTracking } from './helpers';
 import { hasFeature } from 'state/sites/plans/selectors';
 import { getLastThemeQuery, getThemesFoundForQuery } from 'state/themes/selectors';
-import { hasJetpackSiteJetpackThemesExtendedFeatures } from 'state/sites/selectors';
+import { isJetpackSiteMultiSite, hasJetpackSiteJetpackThemesExtendedFeatures } from 'state/sites/selectors';
 import { FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
 
 const ConnectedThemesSelection = connectOptions(
@@ -152,7 +152,8 @@ export default connect(
 		return {
 			wpcomTier: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ) ? tier : 'free',
 			showWpcomThemesList,
-			emptyContent
+			emptyContent,
+			isMultisite: isJetpackSiteMultiSite( state, siteId ),
 		};
 	}
 )( ConnectedSingleSiteJetpack );

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -139,8 +139,9 @@ const ConnectedSingleSiteJetpack = connectOptions(
 
 export default connect(
 	( state, { siteId, tier } ) => {
+		const isMultisite = isJetpackSiteMultiSite( state, siteId );
 		const showWpcomThemesList = config.isEnabled( 'manage/themes/upload' ) &&
-			hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId );
+			hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ) && ! isMultisite;
 		let emptyContent = null;
 		if ( showWpcomThemesList ) {
 			const siteQuery = getLastThemeQuery( state, siteId );
@@ -153,7 +154,7 @@ export default connect(
 			wpcomTier: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ) ? tier : 'free',
 			showWpcomThemesList,
 			emptyContent,
-			isMultisite: isJetpackSiteMultiSite( state, siteId ),
+			isMultisite,
 		};
 	}
 )( ConnectedSingleSiteJetpack );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -119,7 +119,7 @@ const ThemeShowcase = React.createClass( {
 	},
 
 	render() {
-		const { site, options, getScreenshotOption, search, filter, translate } = this.props;
+		const { site, options, getScreenshotOption, search, filter, translate, siteSlug, isMultisite } = this.props;
 		const tier = config.isEnabled( 'upgrades/premium-themes' ) ? this.props.tier : 'free';
 
 		const metas = [
@@ -141,7 +141,7 @@ const ThemeShowcase = React.createClass( {
 						tier={ tier }
 						select={ this.onTierSelect } />
 				</StickyPanel>
-				{ config.isEnabled( 'manage/themes/upload' ) && this.props.siteSlug &&
+				{ config.isEnabled( 'manage/themes/upload' ) && siteSlug && ! isMultisite &&
 					<Button className="themes__upload-button" compact icon
 						onClick={ this.onUploadClick }
 						href={ `/design/upload/${ this.props.siteSlug }` }

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -15,6 +15,7 @@ import HeaderCake from 'components/header-cake';
 import Card from 'components/card';
 import FilePicker from 'components/file-picker';
 import DropZone from 'components/drop-zone';
+import EmptyContent from 'components/empty-content';
 import ProgressBar from 'components/progress-bar';
 import Button from 'components/button';
 import ThanksModal from 'my-sites/themes/thanks-modal';
@@ -26,7 +27,11 @@ import notices from 'notices';
 import debugFactory from 'debug';
 import { uploadTheme, clearThemeUpload, initiateThemeTransfer } from 'state/themes/actions';
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
-import { isJetpackSite, hasJetpackSiteJetpackThemesExtendedFeatures } from 'state/sites/selectors';
+import {
+	isJetpackSite,
+	isJetpackSiteMultiSite,
+	hasJetpackSiteJetpackThemesExtendedFeatures
+} from 'state/sites/selectors';
 import {
 	isUploadInProgress,
 	isUploadComplete,
@@ -263,6 +268,14 @@ class Upload extends React.Component {
 		);
 	}
 
+	renderNotAvailable() {
+		return (
+			<EmptyContent
+				title={ this.props.translate( 'Sorry, themes upload is not yet available for multi-site installations.' ) }
+			/>
+		);
+	}
+
 	render() {
 		const {
 			translate,
@@ -273,10 +286,15 @@ class Upload extends React.Component {
 			upgradeJetpack,
 			backPath,
 			isBusiness,
-			isJetpack
+			isJetpack,
+			isMultisite
 		} = this.props;
 
 		const { showEligibility } = this.state;
+
+		if ( isMultisite ) {
+			return this.renderNotAvailable();
+		}
 
 		return (
 			<Main>
@@ -340,6 +358,7 @@ export default connect(
 			complete: isUploadComplete( state, siteId ),
 			failed: hasUploadFailed( state, siteId ),
 			themeId,
+			isMultisite: isJetpackSiteMultiSite( state, siteId ),
 			uploadedTheme: getTheme( state, siteId, themeId ),
 			error: getUploadError( state, siteId ),
 			progressTotal: getUploadProgressTotal( state, siteId ),

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -272,8 +272,12 @@ class Upload extends React.Component {
 		return (
 			<EmptyContent
 				title={ this.props.translate( 'Sorry, themes upload is not yet available for multi-site installations.' ) }
+				line={ this.props.translate( 'Open your site:' ) }
+				action={ this.props.translate( '[WP Admin]' ) }
+				actionURL={ this.props.selectedSite.options.admin_url }
+				illustration={ '/calypso/images/drake/drake-jetpack.svg' }
 			/>
-		);
+			);
 	}
 
 	render() {

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -271,15 +271,14 @@ class Upload extends React.Component {
 	renderNotAvailable() {
 		return (
 			<EmptyContent
-				title={ this.props.translate( 'Sorry, themes upload is not yet available for multi-site installations.' ) }
-				line={ this.props.translate( 'Open your site:' ) }
-				action={ this.props.translate( '[WP Admin]' ) }
+				title={ this.props.translate( 'Not available for multi site' ) }
+				line={ this.props.translate( 'Use the WP Admin interface instead' ) }
+				action={ this.props.translate( 'Open WP Admin' ) }
 				actionURL={ this.props.selectedSite.options.admin_url }
 				illustration={ '/calypso/images/drake/drake-jetpack.svg' }
 			/>
 			);
 	}
-
 	render() {
 		const {
 			translate,

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -741,6 +741,24 @@ export function hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ) {
 }
 
 /**
+ * Determines if the Jetpack site is part of multi-site.
+ * Returns null if the site is not known or is not a Jetpack site.
+ *
+ * @param  {Object}   state  Global state tree
+ * @param  {Number}   siteId Site ID
+ * @return {?Boolean}        true if the site is multi-site
+ */
+export function isJetpackSiteMultiSite( state, siteId ) {
+	const site = getRawSite( state, siteId );
+
+	if ( ! site || ! isJetpackSite( state, siteId ) ) {
+		return null;
+	}
+
+	return site.is_multisite === true;
+}
+
+/**
  * Determines if a site is the main site in a Network
  * True if it is either in a non multi-site configuration
  * or if its url matches the `main_network_site` url option.

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -69,7 +69,8 @@ import {
 import {
 	getSiteTitle,
 	hasJetpackSiteJetpackThemesExtendedFeatures,
-	isJetpackSite
+	isJetpackSite,
+	isJetpackSiteMultiSite
 } from 'state/sites/selectors';
 import i18n from 'i18n-calypso';
 import accept from 'lib/accept';
@@ -167,8 +168,11 @@ export function requestThemes( siteId, query = {} ) {
 				// Also if Jetpack plugin has Themes Extended Features,
 				// we filter out -wpcom suffixed themes because we will show them in
 				// second list that is specific to WordPress.com themes.
+				// For multi-site installation we do not provide themes upload yet so
+				// we can only show one list and we should not filter wpcom themes.
 				const keepWpcom = ! config.isEnabled( 'manage/themes/upload' ) ||
-					! hasJetpackSiteJetpackThemesExtendedFeatures( getState(), siteId );
+					! hasJetpackSiteJetpackThemesExtendedFeatures( getState(), siteId ) ||
+					isJetpackSiteMultiSite( getState(), siteId );
 
 				filteredThemes = filter(
 					themes,


### PR DESCRIPTION
### Info

We need to disable upload functionality on multi-site jetpack installations. This has to be done while we are waiting for [ this PR to land ](https://github.com/Automattic/jetpack/pull/6201) that will manage multi-site themes installation from Jetpack side of things. 

This disables upload at two levels:
1. For Jetpack multi-sites upload button is not visible
2. `design/upload` shows feature not available:
![image](https://cloud.githubusercontent.com/assets/17271089/23162861/4f2666b8-f830-11e6-98b4-388c712e1af7.png)

### Testing
1. Open `design` in single site mode for Jetpack site:
 a) for single-site installation `Upload` button is visible
 b) for multi-site installation 'Upload' button is not visible
2. Open 'design/upload` in single site mode for Jetpack site:
 a) for single-site installation upload form is visible
 b) for multi-site installation upload form is not visible and `Sorry, themes upload is not yet available for multi-site installations.` is displayed.

This closes #11042 