### PR TITLE
JPC: Use state so the UI is updated on change

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -70,6 +70,7 @@ const JetpackConnectMain = React.createClass( {
 	getInitialState() {
 		return {
 			currentUrl: '',
+			waitingForSites: false
 		};
 	},
 
@@ -108,7 +109,7 @@ const JetpackConnectMain = React.createClass( {
 			jetpack_url: this.state.currentUrl
 		} );
 		if ( this.props.isRequestingSites ) {
-			this.waitingForSites = true;
+			this.setState( { waitingForSites: true } );
 		} else {
 			this.props.checkUrl(
 				this.state.currentUrl,
@@ -156,8 +157,8 @@ const JetpackConnectMain = React.createClass( {
 			return this.props.goToPlans( this.state.currentUrl );
 		}
 
-		if ( this.waitingForSites && ! this.props.isRequestingSites ) {
-			this.waitingForSites = false;
+		if ( this.state.waitingForSites && ! this.props.isRequestingSites ) {
+			this.setState( { waitingForSites: false } );
 			this.props.checkUrl(
 				this.state.currentUrl,
 				!! this.props.getJetpackSiteByUrl( this.state.currentUrl ),
@@ -323,7 +324,7 @@ const JetpackConnectMain = React.createClass( {
 					onClick={ this.onURLEnter }
 					onDismissClick={ this.onDismissClick }
 					isError={ this.getStatus() }
-					isFetching={ this.isCurrentUrlFetching() || this.isRedirecting() || this.waitingForSites }
+					isFetching={ this.isCurrentUrlFetching() || this.isRedirecting() || this.state.waitingForSites }
 					isInstall={ this.isInstall() } />
 			</Card>
 		);


### PR DESCRIPTION
The Symptom
========
When you go to the first step of jetpack connect ( https://wordpress.com/jetpack/connect ) and enter a url right away, it looks like nothing is happening

The Problem
====
The problem there is that when you go to that page, we force a sites-list refresh. Until we have fresh data of your sites, we can't proceed to the next step, so if you enter a url before the sites-list is refreshed, we are just queuing the request until the moment we have fresh data. This works well, but we are using an internal attribute to flag if we are waiting or not... so when we change it to true, the component doesn't get rendered again and looks like nothing is happening.

The Solution
=========
Just use react state instead of a regular object attr, so when we change it, the component gets rerendered.

How To Test
=========
0. Go to http://calypso.localhost:3000/jetpack/connect and enter anything on the url input (Quickly, so the sites-list is still refreshing)
1. The UI should change to reflect that we are querying that info for you (in contrast to "just froze and do nothing for a couple of seconds")