### PR TITLE
Reader: add ReaderVisitLink block

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -34,13 +34,14 @@
 @import 'blocks/post-relative-time/style';
 @import 'blocks/post-status/style';
 @import 'blocks/reader-avatar/style';
+@import 'blocks/reader-feed-header/style';
 @import 'blocks/reader-full-post/style';
 @import 'blocks/reader-post-actions/style';
 @import 'blocks/reader-post-card/style';
 @import 'blocks/reader-post-options-menu/style';
 @import 'blocks/reader-related-card/style';
 @import 'blocks/reader-related-card-v2/style';
-@import 'blocks/reader-feed-header/style';
+@import 'blocks/reader-visit-link/style';
 @import 'blocks/taxonomy-manager/style';
 @import 'blocks/term-form-dialog/style';
 @import 'blocks/term-tree-selector/style';

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -18,7 +18,7 @@ import { shouldShowShare } from 'reader/share/helper';
 import { userCan } from 'lib/posts/utils';
 import * as stats from 'reader/stats';
 import { localize } from 'i18n-calypso';
-import ExternalLink from 'components/external-link';
+import ReaderVisitLink from 'blocks/reader-visit-link';
 
 const ReaderPostActions = ( props ) => {
 	const {
@@ -53,14 +53,12 @@ const ReaderPostActions = ( props ) => {
 		<ul className={ listClassnames }>
 			{ showVisit &&
 				<li className="reader-post-actions__item reader-post-actions__visit">
-					<ExternalLink href={ visitUrl || post.URL }
-						target="_blank"
-						icon={ true }
-						showIconFirst={ true }
+					<ReaderVisitLink
+						href={ visitUrl || post.URL }
 						iconSize={ iconSize }
 						onClick={ onPermalinkVisit }>
-						<span className="reader-post-actions__visit-label">{ translate( 'Visit' ) }</span>
-					</ExternalLink>
+							{ translate( 'Visit' ) }
+					</ReaderVisitLink>
 				</li>
 			}
 			{ showEdit && site && userCan( 'edit_post', post ) &&

--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -15,29 +15,12 @@
 	&.reader-post-actions__visit {
 		flex: 1;
 
-		.reader-post-actions__visit-label {
-			color: $gray;
-		}
-
-		.external-link {
+		.reader-visit-link {
 			align-items: center;
 			box-sizing: border-box;
 			display: inline-flex;
 			padding: 4px 4px 4px 0;
 			position: relative;
-		}
-
-		.external-link:hover,
-		.external-link:focus,
-		.external-link:active {
-
-			.gridicon {
-				fill: $blue-medium;
-			}
-
-			.reader-post-actions__visit-label {
-				color: $blue-medium;
-			}
 		}
 	}
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -476,7 +476,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		margin-left: -2px;
 
 		.gridicon {
-			fill: $gray;
 			position: relative;
 				left: -8px;
 				top: -1px;

--- a/client/blocks/reader-visit-link/README.md
+++ b/client/blocks/reader-visit-link/README.md
@@ -1,0 +1,25 @@
+# Reader Visit Link
+
+A link to an external site from Reader, labelled 'Visit'.
+
+## Example
+
+The component can be used in much the same way that you would use an `<a>` element. The link wraps whatever is placed between the ReaderVisitLink elements.
+
+```html
+<ReaderVisitLink url={ post.URL }>Visit this</ReaderVisitLink>
+```
+
+## Props
+
+### `href`
+
+The URL to link to.
+
+### `iconSize`
+
+Size of the visit icon. Defaults to 24px.
+
+### `onClick`
+
+Function to execute when the visit link is clicked.

--- a/client/blocks/reader-visit-link/README.md
+++ b/client/blocks/reader-visit-link/README.md
@@ -7,7 +7,7 @@ A link to an external site from Reader.
 The component can be used in much the same way that you would use an `<a>` element. The link wraps whatever is placed between the ReaderVisitLink elements.
 
 ```html
-<ReaderVisitLink url={ post.URL }>Visit this</ReaderVisitLink>
+<ReaderVisitLink href={ post.URL }>Visit this</ReaderVisitLink>
 ```
 
 ## Props

--- a/client/blocks/reader-visit-link/README.md
+++ b/client/blocks/reader-visit-link/README.md
@@ -1,6 +1,6 @@
 # Reader Visit Link
 
-A link to an external site from Reader, labelled 'Visit'.
+A link to an external site from Reader.
 
 ## Example
 

--- a/client/blocks/reader-visit-link/index.jsx
+++ b/client/blocks/reader-visit-link/index.jsx
@@ -31,6 +31,7 @@ class ReaderVisitLink extends React.Component {
 				icon={ true }
 				showIconFirst={ true }
 				iconSize={ this.props.iconSize }
+				iconClassName="reader-visit-link__icon"
 				onClick={ this.props.onClick }>
 				<span className="reader-visit-link__label">
 					{ this.props.children }

--- a/client/blocks/reader-visit-link/index.jsx
+++ b/client/blocks/reader-visit-link/index.jsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import ExternalLink from 'components/external-link';
+
+class ReaderVisitLink extends React.Component {
+
+	static propTypes = {
+		url: React.PropTypes.string,
+		iconSize: React.PropTypes.number,
+		onClick: React.PropTypes.func,
+	}
+
+	static defaultProps = {
+		iconSize: 24,
+		onClick: noop,
+	}
+
+	render() {
+		return (
+			<ExternalLink
+				className="reader-visit-link"
+				href={ this.props.href }
+				target="_blank"
+				icon={ true }
+				showIconFirst={ true }
+				iconSize={ this.props.iconSize }
+				onClick={ this.props.onClick }>
+				<span className="reader-visit-link__label">
+					{ this.props.children }
+				</span>
+			</ExternalLink>
+		);
+	}
+
+}
+
+export default ReaderVisitLink;

--- a/client/blocks/reader-visit-link/style.scss
+++ b/client/blocks/reader-visit-link/style.scss
@@ -1,0 +1,19 @@
+.reader-visit-link {
+	border: 1px solid red;
+}
+
+.reader-visit-link__label {
+	color: $gray;
+}
+
+.reader-visit-link:hover,
+.reader-visit-link:focus,
+.reader-visit-link:active {
+	.reader-visit-link__icon {
+		fill: $blue-medium !important;
+	}
+
+	.reader-visit-link__label {
+		color: $blue-medium;
+	}
+}

--- a/client/blocks/reader-visit-link/style.scss
+++ b/client/blocks/reader-visit-link/style.scss
@@ -1,5 +1,5 @@
-.reader-visit-link {
-	border: 1px solid red;
+.reader-visit-link__icon {
+	fill: $gray;
 }
 
 .reader-visit-link__label {
@@ -10,7 +10,7 @@
 .reader-visit-link:focus,
 .reader-visit-link:active {
 	.reader-visit-link__icon {
-		fill: $blue-medium !important;
+		fill: $blue-medium;
 	}
 
 	.reader-visit-link__label {

--- a/client/components/external-link/index.jsx
+++ b/client/components/external-link/index.jsx
@@ -34,6 +34,7 @@ export default React.createClass( {
 		const classes = classnames( 'external-link', this.props.className, {
 			'has-icon': !! this.props.icon,
 		} );
+		const iconClassName = this.props.className && `${ this.props.className }__icon`;
 
 		const props = assign( {}, omit( this.props, 'icon', 'iconSize', 'showIconFirst' ), {
 			className: classes,
@@ -44,7 +45,7 @@ export default React.createClass( {
 			props.rel = props.rel.concat( ' noopener noreferrer' );
 		}
 
-		const iconComponent = <Gridicon icon="external" size={ this.props.iconSize } />;
+		const iconComponent = <Gridicon className={ iconClassName } icon="external" size={ this.props.iconSize } />;
 
 		return (
 			<a { ...props }>

--- a/client/components/external-link/index.jsx
+++ b/client/components/external-link/index.jsx
@@ -20,7 +20,8 @@ export default React.createClass( {
 		icon: React.PropTypes.bool,
 		iconSize: React.PropTypes.number,
 		target: React.PropTypes.string,
-		showIconFirst: React.PropTypes.bool
+		showIconFirst: React.PropTypes.bool,
+		iconClassName: React.PropTypes.string,
 	},
 
 	getDefaultProps() {
@@ -34,8 +35,6 @@ export default React.createClass( {
 		const classes = classnames( 'external-link', this.props.className, {
 			'has-icon': !! this.props.icon,
 		} );
-		const iconClassName = this.props.className && `${ this.props.className }__icon`;
-
 		const props = assign( {}, omit( this.props, 'icon', 'iconSize', 'showIconFirst' ), {
 			className: classes,
 			rel: 'external'
@@ -45,7 +44,7 @@ export default React.createClass( {
 			props.rel = props.rel.concat( ' noopener noreferrer' );
 		}
 
-		const iconComponent = <Gridicon className={ iconClassName } icon="external" size={ this.props.iconSize } />;
+		const iconComponent = <Gridicon className={ this.props.iconClassName } icon="external" size={ this.props.iconSize } />;
 
 		return (
 			<a { ...props }>


### PR DESCRIPTION
This PR moves the visit link component out to a separate block so it can be reused.

It currently appears on the Reader post card, and will soon be used on the Reader combined card too (#11407).

### To test

Check that the visit link appears and behaves as expected on Reader post cards:

<img width="241" alt="screen shot 2017-02-21 at 12 01 43" src="https://cloud.githubusercontent.com/assets/17325/23164132/8b2f4c0e-f82d-11e6-9a3e-4876ebd5e7dc.png">
