### PR TITLE
Sites List: Emit change when `Site` is changed

### DIFF
--- a/client/lib/site/index.js
+++ b/client/lib/site/index.js
@@ -61,14 +61,17 @@ Site.prototype.attributes = function( attributes ) {
 };
 
 Site.prototype.set = function( attributes ) {
-	var changed = false;
+	let changed = false;
+	const computedAttributes = Object.assign( {}, attributes, getAttributes( attributes ) );
 
-	for ( var prop in attributes ) {
-		if ( attributes.hasOwnProperty( prop ) && ! isEqual( attributes[ prop ], this[ prop ] ) ) {
-			if ( undefined === attributes[ prop ] ) {
+	// `attributes` may only contain the attributes we're updating here, so we
+	// only check if the new computed properties match the existing ones.
+	for ( const prop in attributes ) {
+		if ( computedAttributes.hasOwnProperty( prop ) && ! isEqual( computedAttributes[ prop ], this[ prop ] ) ) {
+			if ( undefined === computedAttributes[ prop ] ) {
 				delete this[ prop ];
 			} else {
-				this[ prop ] = attributes[ prop ];
+				this[ prop ] = computedAttributes[ prop ];
 			}
 
 			changed = true;
@@ -82,7 +85,6 @@ Site.prototype.set = function( attributes ) {
 	}
 
 	return changed;
-
 };
 
 /**

--- a/client/lib/site/test/index.js
+++ b/client/lib/site/test/index.js
@@ -71,5 +71,17 @@ describe( 'Calypso Site', () => {
 			site.set( { arr: [ 1, 2, 3 ] } );
 			expect( changeCallback.called ).to.be.false;
 		} );
+
+		it( '`set` returns `true` when an attribute is updated', () => {
+			const site = Site( mockSiteData );
+
+			expect( site.set( { description: 'new description' } ) ).to.be.true;
+		} );
+
+		it( '`set` returns `false` when no attribute is updated', () => {
+			const site = Site( mockSiteData );
+
+			expect( site.set( { description: mockSiteData.description } ) ).to.be.false;
+		} );
 	} );
 } );

--- a/client/state/sites/enhancer.js
+++ b/client/state/sites/enhancer.js
@@ -38,7 +38,7 @@ export default ( createStore ) => ( ...args ) => {
 		// Preserve original behavior
 		const hasChanged = originalSet.apply( this, arguments );
 		if ( ! hasChanged ) {
-			return;
+			return false;
 		}
 
 		// If we're tracking the site in state, apply attributes atop what we
@@ -47,6 +47,8 @@ export default ( createStore ) => ( ...args ) => {
 		if ( storeSite ) {
 			store.dispatch( receiveSite( this ) );
 		}
+
+		return true;
 	};
 
 	return store;


### PR DESCRIPTION
This PR:

- Updates `state/sites/enhancer.js` to preserve the behavior of `Site#set`. Currently, it updates `Site#set` to return `undefined`, instead of returning whether the site object is updated.
- Updates `Site#set` to return `true` only if one of the given attributes is updated.
- Adds tests for `Site#set`.

**Testing**
Here are some some instructions on Slack for testing a bug this fixes when a primary domain is updated during checkout: slack-p1487723363005930