### PR TITLE
AT: show wpcom plans instead of JP ones, 2nd try

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -341,7 +341,7 @@ class PlansFeaturesMain extends Component {
 	}
 }
 
-PlansFeaturesMain.PropTypes = {
+PlansFeaturesMain.propTypes = {
 	site: PropTypes.object,
 	isInSignup: PropTypes.bool,
 	isLandingPage: PropTypes.bool,
@@ -351,7 +351,7 @@ PlansFeaturesMain.PropTypes = {
 	hideFreePlan: PropTypes.bool,
 	showFAQ: PropTypes.bool,
 	selectedFeature: PropTypes.string,
-	displayJetpackPlans: PropTypes.bool
+	displayJetpackPlans: PropTypes.bool.isRequired
 };
 
 PlansFeaturesMain.defaultProps = {
@@ -359,8 +359,7 @@ PlansFeaturesMain.defaultProps = {
 	intervalType: 'yearly',
 	hideFreePlan: false,
 	site: {},
-	showFAQ: true,
-	displayJetpackPlans: false
+	showFAQ: true
 };
 
 export default localize( PlansFeaturesMain );

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -31,7 +31,7 @@ const Plans = React.createClass( {
 	getDefaultProps() {
 		return {
 			intervalType: 'yearly',
-			displayJetpackPlans: true
+			displayJetpackPlans: false
 		};
 	},
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -77,6 +77,7 @@ class PlansStep extends Component {
 					isInSignup={ true }
 					onUpgradeClick={ this.onSelectPlan }
 					showFAQ={ false }
+					displayJetpackPlans={ false }
 				/>
 			</div>
 		);


### PR DESCRIPTION
In #11255, we fixed showing the WP.com plans for AT sites on the `/plans` page. However, it caused a regression to Jetpack NUX in which users were presented with WP.com plans instead of Jetpack ones (thus blocking Jetpack plan purchases).

@johnHackworth fixed it shortly after. In this PR, I'm adding a few small things to make it complete.

## Testing instructions

As this affects all of WP.com and Jetpack NUX, we need to test all the flows carefully and properly:

- With an AT site, navigate to /plans/ and verify that you see WP.com plans;
- With a WPCOM site, navigate to /plans/ and verify that you see WP.com plans
- With a Jetpack site, navigate to /plans/ and verify that you see Jetpack plans
- With a WPCOM site, go through NUX and verify you see WPCOM plans
- With a Jetpack site, go through NUX and verify that you see Jetpack plans

Also, each time you navigate to `/plans`, click on My Plan afterwards and then back on Plans and make sure you see the correct plans.

Props @richardmuscat for the testing instructions ( p3fqKv-4ku-p2 ).