### PR TITLE
Domains: Properly handle TLDs we can't check availability for

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -16,6 +16,7 @@ import DomainMappingSuggestion from 'components/domains/domain-mapping-suggestio
 import DomainSuggestion from 'components/domains/domain-suggestion';
 import { isNextDomainFree } from 'lib/cart-values/cart-items';
 import Notice from 'components/notice';
+import { getTld } from 'lib/domains';
 
 var DomainSearchResults = React.createClass( {
 	propTypes: {
@@ -93,7 +94,7 @@ var DomainSearchResults = React.createClass( {
 			}
 
 			const domainUnavailableMessage = this.noAvailabilityInfoForDomain()
-				? this.translate( '%(domain)s might be taken.', { args: { domain } } )
+				? this.translate( '.%(tld)s domains are not offered on WordPress.com.', { args: { tld: getTld( domain ) } } )
 				: this.translate( '%(domain)s is taken.', { args: { domain } } );
 
 			if ( this.props.offerMappingOption ) {

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -1,19 +1,21 @@
 /**
  * External dependencies
  */
-const React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	times = require( 'lodash/times' );
-
-import Notice from 'components/notice';
+import React from 'react';
+import classNames from 'classnames';
+import {
+	includes,
+	times
+} from 'lodash';
 
 /**
  * Internal dependencies
  */
-const DomainRegistrationSuggestion = require( 'components/domains/domain-registration-suggestion' ),
-	DomainMappingSuggestion = require( 'components/domains/domain-mapping-suggestion' ),
-	DomainSuggestion = require( 'components/domains/domain-suggestion' ),
-	{ isNextDomainFree } = require( 'lib/cart-values/cart-items' );
+import DomainRegistrationSuggestion from 'components/domains/domain-registration-suggestion';
+import DomainMappingSuggestion from 'components/domains/domain-mapping-suggestion';
+import DomainSuggestion from 'components/domains/domain-suggestion';
+import { isNextDomainFree } from 'lib/cart-values/cart-items';
+import Notice from 'components/notice';
 
 var DomainSearchResults = React.createClass( {
 	propTypes: {
@@ -33,8 +35,14 @@ var DomainSearchResults = React.createClass( {
 		onAddMapping: React.PropTypes.func,
 		onClickMapping: React.PropTypes.func
 	},
+
 	isDomainMappable: function() {
-		return this.props.lastDomainError && this.props.lastDomainError.code === 'not_available_but_mappable';
+		return this.props.lastDomainError &&
+			includes( [ 'not_available_but_mappable', 'no_availability_but_mappable' ], this.props.lastDomainError.code );
+	},
+
+	noAvailabilityInfoForDomain() {
+		return this.props.lastDomainError && this.props.lastDomainError.code === 'no_availability_but_mappable';
 	},
 
 	domainAvailability: function() {
@@ -84,7 +92,9 @@ var DomainSearchResults = React.createClass( {
 					'%(cost)s.{{/small}}', { args: { domain, cost: this.props.products.domain_map.cost_display }, components } );
 			}
 
-			const domainUnavailableMessage = this.translate( '%(domain)s is taken.', { args: { domain } } );
+			const domainUnavailableMessage = this.noAvailabilityInfoForDomain()
+				? this.translate( '%(domain)s might be taken.', { args: { domain } } )
+				: this.translate( '%(domain)s is taken.', { args: { domain } } );
 
 			if ( this.props.offerMappingOption ) {
 				availabilityElement = (

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -4,6 +4,9 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import {
+	includes
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -166,7 +169,7 @@ const MapDomainStep = React.createClass( {
 
 		checkDomainAvailability( domain, ( error, result ) => {
 			if ( error ) {
-				if ( error.code === 'not_available_but_mappable' ) {
+				if ( includes( [ 'not_available_but_mappable', 'no_availability_but_mappable' ], error.code ) ) {
 					this.props.onMapDomain( domain );
 					return;
 				}

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -62,7 +62,7 @@ function checkDomainAvailability( domainName, onComplete ) {
 			errorCode = 'no_availability_but_mappable';
 		} else if ( isAvailable === false && isMappable ) {
 			errorCode = 'not_available_but_mappable';
-		} else if ( isAvailable === true && ! isRegistrable ) {
+		} else if ( isAvailable && ! isRegistrable ) {
 			errorCode = 'available_but_not_registrable';
 		}
 

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -58,9 +58,11 @@ function checkDomainAvailability( domainName, onComplete ) {
 			if ( unmappabilityReason ) {
 				errorCode += `_${ unmappabilityReason }`;
 			}
-		} else if ( ! isAvailable && isMappable ) {
+		} else if ( isAvailable === null && isMappable ) {
+			errorCode = 'no_availability_but_mappable';
+		} else if ( isAvailable === false && isMappable ) {
 			errorCode = 'not_available_but_mappable';
-		} else if ( isAvailable && ! isRegistrable ) {
+		} else if ( isAvailable === true && ! isRegistrable ) {
 			errorCode = 'available_but_not_registrable';
 		}
 

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -48,6 +48,7 @@ function getAvailabilityNotice( domain, error ) {
 			}
 			break;
 		case 'not_available_but_mappable':
+		case 'no_availability_but_mappable':
 		case 'domain_registration_unavailable':
 			// unavailable domains are displayed in the search results, not as a notice OR
 			// domain registrations are closed, in which case it is handled in parent


### PR DESCRIPTION
We can't be sure if they are available or not, but we shouldn't prevent users from mapping them (unless they are already mapped, etc.). In `D4461-code` I've proposed to return `is_available` flag equal to `null` for such cases, so that we can handle them on the frontend if needed. The additional benefit of using null is that it's a false-y value, so it should be backwards compatible with existing code.

### Testing
Try searching for an `.ie` domain:
* In domain search, you should see changed copy, suggesting that the domain _might_ be taken and the user can/should map it.
   Previously:
   <img width="745" alt="screen shot 2017-02-21 at 18 29 26" src="https://cloud.githubusercontent.com/assets/3392497/23176554/b9fef404-f863-11e6-93d6-ba88ff2bc665.png">
   Now:
   <img width="756" alt="screen shot 2017-02-21 at 18 29 09" src="https://cloud.githubusercontent.com/assets/3392497/23176553/b9d71bd2-f863-11e6-80f3-8fa88b81f7ab.png">
* In mapping step, one should be able to input any `.ie` domain (that is not already mapped to a WPCOM site, etc.) and be able to map it.

Other cases should remain the same.

Fixes #11051