### PR TITLE
Themes: Obtain proper author name from WP.org API

### DIFF
--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -107,7 +107,13 @@ module.exports = {
 	 * @returns {Promise.<Object>}  A promise that returns a `theme` object
 	 */
 	fetchThemeInformation: function( themeId ) {
-		const query = { action: 'theme_information', 'request[slug]': themeId };
+		const query = {
+			action: 'theme_information',
+			// Return an `author` object containing `user_nicename` and `display_name` attrs.
+			// This is for consistency with WP.com, which always returns the display name as `author`.
+			'request[fields][extended_author]': true,
+			'request[slug]': themeId
+		};
 		return superagent
 			.get( _WPORG_THEMES_ENDPOINT )
 			.set( 'Accept', 'application/json' )
@@ -127,6 +133,9 @@ module.exports = {
 		const { search, page, number } = options;
 		const query = {
 			action: 'query_themes',
+			// Return an `author` object containing `user_nicename` and `display_name` attrs.
+			// This is for consistency with WP.com, which always returns the display name as `author`.
+			'request[fields][extended_author]': true,
 			'request[search]': search,
 			'request[page]': page,
 			'request[per_page]:': number

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -281,7 +281,7 @@ describe( 'actions', () => {
 					.defaultReplyHeaders( {
 						'Content-Type': 'application/json'
 					} )
-					.get( '/themes/info/1.1/?action=query_themes' )
+					.get( '/themes/info/1.1/?action=query_themes&request%5Bfields%5D%5Bextended_author%5D=true' )
 					.reply( 200, {
 						info: { page: 1, pages: 123, results: 2452 },
 						themes: [
@@ -291,7 +291,8 @@ describe( 'actions', () => {
 							{ slug: 'intentionally-blank', name: 'Intentionally Blank' }
 						]
 					} )
-					.get( '/themes/info/1.1/?action=query_themes&request%5Bsearch%5D=Sixteen' )
+					.get( '/themes/info/1.1/?action=query_themes&request%5Bfields%5D%5Bextended_author%5D=true' +
+						'&request%5Bsearch%5D=Sixteen' )
 					.reply( 200, {
 						info: { page: 1, pages: 1, results: 1 },
 						themes: [
@@ -481,9 +482,11 @@ describe( 'actions', () => {
 					.defaultReplyHeaders( {
 						'Content-Type': 'application/json'
 					} )
-					.get( '/themes/info/1.1/?action=theme_information&request%5Bslug%5D=twentyseventeen' )
+					.get( '/themes/info/1.1/?action=theme_information&request%5Bfields%5D%5Bextended_author%5D=true' +
+						'&request%5Bslug%5D=twentyseventeen' )
 					.reply( 200, { slug: 'twentyseventeen', name: 'Twenty Seventeen' } )
-					.get( '/themes/info/1.1/?action=theme_information&request%5Bslug%5D=twentyumpteen' )
+					.get( '/themes/info/1.1/?action=theme_information&request%5Bfields%5D%5Bextended_author%5D=true' +
+						'&request%5Bslug%5D=twentyumpteen' )
 					.reply( 200, false );
 			} );
 

--- a/client/state/themes/test/utils.js
+++ b/client/state/themes/test/utils.js
@@ -128,7 +128,10 @@ describe( 'utils', () => {
 			const normalizedTheme = normalizeWporgTheme( {
 				slug: 'twentyfifteen',
 				name: 'Twenty Fifteen',
-				author: 'wordpressdotorg',
+				author: {
+					user_nicename: 'wordpressdotorg',
+					display_name: 'WordPress.org'
+				},
 				screenshot_url: '//ts.w.org/wp-content/themes/twentyfifteen/screenshot.png?ver=1.7',
 				preview_url: 'https://wp-themes.com/twentyfifteen',
 				download_link: 'http://downloads.wordpress.org/theme/twentyfifteen.1.7.zip',
@@ -143,7 +146,7 @@ describe( 'utils', () => {
 			expect( normalizedTheme ).to.deep.equal( {
 				id: 'twentyfifteen',
 				name: 'Twenty Fifteen',
-				author: 'wordpressdotorg',
+				author: 'WordPress.org',
 				screenshot: '//ts.w.org/wp-content/themes/twentyfifteen/screenshot.png?ver=1.7',
 				demo_uri: 'https://wp-themes.com/twentyfifteen',
 				download: 'http://downloads.wordpress.org/theme/twentyfifteen.1.7.zip',

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -98,13 +98,18 @@ export function normalizeWporgTheme( theme ) {
 		download_link: 'download'
 	};
 
-	const normalizedTheme = mapKeys( omit( theme, 'sections' ), ( value, key ) => (
+	const normalizedTheme = mapKeys( omit( theme, [ 'sections', 'author' ] ), ( value, key ) => (
 		get( attributesMap, key, key )
 	) );
 
 	const description = get( theme, [ 'sections', 'description' ] );
 	if ( description ) {
 		normalizedTheme.description = description;
+	}
+
+	const author = get( theme, [ 'author', 'display_name' ] );
+	if ( author ) {
+		normalizedTheme.author = author;
 	}
 
 	if ( ! normalizedTheme.tags ) {


### PR DESCRIPTION
Pass `&request[fields][extended_author]=1` to the WP.org API in order for it to return an `author` object containing `user_nicename` and `display_name` attrs, and modify `normalizeWporgTheme` accordingly.
This is for consistency with WP.com, which always returns the display name as `author`.

Before:
![image](https://cloud.githubusercontent.com/assets/96308/23180547/0f149986-f872-11e6-832d-2a96eff7b53f.png)

After:
![image](https://cloud.githubusercontent.com/assets/96308/23180512/f3bbc970-f871-11e6-9973-180938de5347.png)

To test:
For a theme that's present in the WP.org but not in the WP.com showcase, open its theme sheet (on a Jetpack site) and observe that the author name is, uh, pretty printed. (Compare that to the WP.org showcase's theme sheet).