### PR TITLE
Themes: Filter all received themes

### DIFF
--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -122,7 +122,6 @@ export function receiveThemes( themes, siteId ) {
  * @param {Array}  themes Themes received
  * @param {number} siteId ID of site for which themes have been received
  * @param {Object} query Theme query used in the API request
- * @param {number} foundCount Number of themes returned by the query
  * @return {Object} Action object
  */
 export function receiveThemesQuery( themes, siteId, query ) {

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -118,9 +118,25 @@ export function receiveThemes( themes, siteId ) {
 	};
 }
 
+/**
+ * Returns an action object to be used in signalling that theme objects from
+ * a query have been received.
+ *
+ * @param {Array}  themes Themes received
+ * @param {number} siteId ID of site for which themes have been received
+ * @param {Object} query Theme query used in the API request
+ * @param {number} foundCount Number of themes returned by the query
+ * @return {Object} Action object
+ */
 function receiveThemesQuery( themes, siteId, query, foundCount ) {
 	return ( dispatch, getState ) => {
-		const { filteredThemes, found } = filterThemes( getState, themes, siteId, query, foundCount );
+		const { filteredThemes, found } = filterThemes(
+			getState,
+			themes,
+			siteId,
+			query,
+			foundCount
+		);
 		dispatch( {
 			type: THEMES_REQUEST_SUCCESS,
 			themes: filteredThemes,

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -105,7 +105,7 @@ export function receiveTheme( theme, siteId ) {
 export function receiveThemes( themes, siteId ) {
 	return ( dispatch, getState ) => {
 		const filterWpcom = shouldFilterWpcomThemes( getState(), siteId );
-		const { filteredThemes } = filterThemes( themes, siteId, filterWpcom );
+		const filteredThemes = filterThemes( themes, siteId, filterWpcom );
 
 		dispatch( {
 			type: THEMES_RECEIVE,
@@ -125,7 +125,7 @@ export function receiveThemes( themes, siteId ) {
  * @param {number} foundCount Number of themes returned by the query
  * @return {Object} Action object
  */
-function receiveThemesQuery( themes, siteId, query ) {
+export function receiveThemesQuery( themes, siteId, query ) {
 	return ( dispatch, getState ) => {
 		const filterWpcom = shouldFilterWpcomThemes( getState(), siteId );
 		const filteredThemes = filterThemes( themes, siteId, filterWpcom, query );
@@ -226,7 +226,6 @@ export function requestThemes( siteId, query = {} ) {
 				dispatch( trackShowcaseSearch );
 			}
 
-			dispatch( receiveThemes( themes, siteId ) );
 			dispatch( receiveThemesQuery( themes, siteId, query ) );
 		} ).catch( ( error ) => {
 			dispatch( {

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -13,7 +13,8 @@ import {
 	getSiteOption,
 	isJetpackSite,
 	canJetpackSiteManage,
-	hasJetpackSiteJetpackThemesExtendedFeatures
+	hasJetpackSiteJetpackThemesExtendedFeatures,
+	isJetpackSiteMultiSite,
 } from 'state/sites/selectors';
 import { getSitePurchases } from 'state/purchases/selectors';
 import { getCustomizerUrl } from 'state/sites/selectors';
@@ -640,4 +641,23 @@ export function themePreviewVisibility( state ) {
  */
 export function getWpcomParentThemeId( state, themeId ) {
 	return get( getTheme( state, 'wpcom', themeId ), [ 'template' ], null );
+}
+
+/**
+ * Determine whether wpcom themes should be removed from
+ * a queried list of themes. For jetpack sites with the
+ * required capabilities, we hide wpcom themes from the
+ * list of locally installed themes.
+ *
+ * @param {Object} state Global state tree
+ * @param {number} siteId The Site ID
+ * @returns {boolean} true if wpcom themes should be removed
+ */
+export function shouldFilterWpcomThemes( state, siteId ) {
+	return (
+		isJetpackSite( state, siteId ) &&
+		config.isEnabled( 'manage/themes/upload' ) &&
+		hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ) &&
+		! isJetpackSiteMultiSite( state, siteId )
+	);
 }

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -44,6 +44,7 @@ import {
 	requestActiveTheme,
 	receiveTheme,
 	receiveThemes,
+	receiveThemesQuery,
 	requestThemes,
 	requestTheme,
 	pollThemeTransferStatus,
@@ -76,36 +77,117 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#receiveTheme()', () => {
-		it( 'should return an action object', () => {
-			const theme = { id: 'twentysixteen', name: 'Twenty Sixteen' };
-			const action = receiveTheme( theme, 77203074 );
+		const getState = () => ( {
+			themes: {
+				queries: {
+					wpcom: new ThemeQueryManager(),
+				},
+			},
+			sites: {
+				items: {},
+			},
+		} );
 
-			expect( action ).to.eql( {
+		it( 'should dispatch THEMES_RECIEVE action', () => {
+			const theme = { id: 'twentysixteen', name: 'Twenty Sixteen' };
+			receiveTheme( theme, 'wpcom' )( spy, getState );
+
+			expect( spy ).to.have.been.calledWith( {
 				type: THEMES_RECEIVE,
-				themes: [ theme ],
-				siteId: 77203074
+				themes: [
+					{ id: 'twentysixteen', name: 'Twenty Sixteen' },
+				],
+				siteId: 'wpcom'
 			} );
 		} );
 	} );
 
 	describe( '#receiveThemes()', () => {
-		it( 'should return an action object', () => {
-			const themes = [ { id: 'twentysixteen', name: 'Twenty Sixteen' } ];
-			const action = receiveThemes( themes, 77203074 );
+		const getState = () => ( {
+			themes: {
+				queries: {
+					wpcom: new ThemeQueryManager(),
+				},
+			},
+			sites: {
+				items: {},
+			},
+		} );
 
-			expect( action ).to.eql( {
+		it( 'should dispach THEMES_RECEIVE action', () => {
+			const themes = [ { id: 'twentysixteen', name: 'Twenty Sixteen' } ];
+			receiveThemes( themes, 'wpcom' )( spy, getState );
+
+			expect( spy ).to.have.been.calledWith( {
 				type: THEMES_RECEIVE,
-				themes,
-				siteId: 77203074
+				themes: [
+					{ id: 'twentysixteen', name: 'Twenty Sixteen' },
+				],
+				siteId: 'wpcom'
+			} );
+		} );
+	} );
+
+	describe( '#receiveThemesQuery()', () => {
+		const getState = () => ( {
+			themes: {
+				queries: {
+					wpcom: new ThemeQueryManager(),
+				},
+			},
+			sites: {
+				items: {
+					77203074: {
+						jetpack: true,
+						options: { jetpack_version: '4.4.2' }
+					},
+				}
+			},
+		} );
+
+		context( 'with a wpcom site', () => {
+			const themes = [
+				{ id: 'twentysixteen', name: 'Twenty Sixteen' },
+				{ id: 'mood', name: 'Mood' }
+			];
+			const query = { search: 'Automattic' };
+
+			it( 'should dispatch themes request success action', () => {
+				receiveThemesQuery( themes, 'wpcom', query )( spy, getState );
+				expect( spy ).to.have.been.calledWith( {
+					type: THEMES_REQUEST_SUCCESS,
+					siteId: 'wpcom',
+					query,
+					found: 2,
+					themes,
+				} );
+			} );
+		} );
+
+		context( 'with a Jetpack site', () => {
+			const themes = [
+				{ id: 'twentysixteen', name: 'Twenty Sixteen' },
+				{ id: 'mood', name: 'Mood' }
+			];
+
+			it( 'should dispatch themes request success action', () => {
+				receiveThemesQuery( themes, 77203074, {} )( spy, getState );
+				expect( spy ).to.have.been.calledWith( {
+					type: THEMES_REQUEST_SUCCESS,
+					siteId: 77203074,
+					query: {},
+					found: 2,
+					themes,
+				} );
 			} );
 		} );
 	} );
 
 	describe( '#requestThemes()', () => {
 		context( 'with a wpcom site', () => {
+			let nockScope;
 			useNock( ( nock ) => {
-				nock( 'https://public-api.wordpress.com:443' )
-					.persist()
+				nockScope = nock( 'https://public-api.wordpress.com:443' )
 					.get( '/rest/v1.2/themes' )
 					.reply( 200, {
 						found: 2,
@@ -113,12 +195,6 @@ describe( 'actions', () => {
 							{ ID: 'twentysixteen', name: 'Twenty Sixteen' },
 							{ ID: 'mood', name: 'Mood' }
 						]
-					} )
-					.get( '/rest/v1.2/themes' )
-					.query( { search: 'Sixteen' } )
-					.reply( 200, {
-						found: 1,
-						themes: [ { ID: 'twentysixteen', name: 'Twenty Sixteen' } ]
 					} );
 			} );
 
@@ -130,55 +206,13 @@ describe( 'actions', () => {
 					siteId: 'wpcom',
 					query: {}
 				} );
-			} );
-
-			it( 'should dispatch themes receive action when request completes', () => {
-				return requestThemes( 'wpcom' )( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
-						type: THEMES_RECEIVE,
-						themes: [
-							{ ID: 'twentysixteen', name: 'Twenty Sixteen' },
-							{ ID: 'mood', name: 'Mood' }
-						],
-						siteId: 'wpcom'
-					} );
-				} );
-			} );
-
-			it( 'should dispatch themes request success action when request completes', () => {
-				return requestThemes( 'wpcom' )( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
-						type: THEMES_REQUEST_SUCCESS,
-						siteId: 'wpcom',
-						query: {},
-						found: 2,
-						themes: [
-							{ ID: 'twentysixteen', name: 'Twenty Sixteen' },
-							{ ID: 'mood', name: 'Mood' }
-						]
-					} );
-				} );
-			} );
-
-			it( 'should dispatch themes request success action with query results', () => {
-				return requestThemes( 'wpcom', { search: 'Sixteen' } )( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
-						type: THEMES_REQUEST_SUCCESS,
-						siteId: 'wpcom',
-						query: { search: 'Sixteen' },
-						found: 1,
-						themes: [
-							{ ID: 'twentysixteen', name: 'Twenty Sixteen' },
-						]
-					} );
-				} );
+				expect( nockScope.isDone() ).to.be.true;
 			} );
 		} );
 
 		context( 'with a Jetpack site', () => {
 			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
-					.persist()
 					.get( '/rest/v1/sites/77203074/themes' )
 					.reply( 200, {
 						// The endpoint doesn't return `found` for Jetpack sites
@@ -187,28 +221,11 @@ describe( 'actions', () => {
 							{ ID: 'twentysixteen', name: 'Twenty Sixteen' }
 						]
 					} )
-					.get( '/rest/v1/sites/77203074/themes' )
-					.query( { search: 'Sixteen' } )
-					.reply( 200, {
-						// The endpoint doesn't return `found` for Jetpack sites
-						themes: [ { ID: 'twentysixteen', name: 'Twenty Sixteen' } ]
-					} )
 					.get( '/rest/v1/sites/1916284/themes' )
 					.reply( 403, {
 						error: 'authorization_required',
 						message: 'User cannot access this private blog.'
 					} );
-			} );
-
-			const fakeGetState = () => ( {
-				sites: {
-					items: {
-						77203074: {
-							jetpack: true,
-							options: { jetpack_version: '4.4.2' }
-						}
-					}
-				}
 			} );
 
 			it( 'should dispatch fetch action when thunk triggered', () => {
@@ -221,47 +238,6 @@ describe( 'actions', () => {
 				} );
 			} );
 
-			it( 'should dispatch themes receive action when request completes', () => {
-				return requestThemes( 77203074 )( spy, fakeGetState ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
-						type: THEMES_RECEIVE,
-						themes: [
-							{ ID: 'twentyfifteen', name: 'Twenty Fifteen' },
-							{ ID: 'twentysixteen', name: 'Twenty Sixteen' },
-						],
-						siteId: 77203074
-					} );
-				} );
-			} );
-
-			it( 'should dispatch themes request success action when request completes', () => {
-				return requestThemes( 77203074 )( spy, fakeGetState ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
-						type: THEMES_REQUEST_SUCCESS,
-						siteId: 77203074,
-						query: {},
-						found: 2,
-						themes: [
-							{ ID: 'twentyfifteen', name: 'Twenty Fifteen' },
-							{ ID: 'twentysixteen', name: 'Twenty Sixteen' },
-						]
-					} );
-				} );
-			} );
-
-			it( 'should dispatch themes request success action with query results', () => {
-				return requestThemes( 77203074, { search: 'Sixteen' } )( spy, fakeGetState ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
-						type: THEMES_REQUEST_SUCCESS,
-						siteId: 77203074,
-						query: { search: 'Sixteen' },
-						found: 1,
-						themes: [
-							{ ID: 'twentysixteen', name: 'Twenty Sixteen' },
-						]
-					} );
-				} );
-			} );
 			it( 'should dispatch fail action when request fails', () => {
 				return requestThemes( 1916284 )( spy ).then( () => {
 					expect( spy ).to.have.been.calledWith( {
@@ -290,14 +266,6 @@ describe( 'actions', () => {
 							{ slug: 'cassions', name: 'Cassions' },
 							{ slug: 'intentionally-blank', name: 'Intentionally Blank' }
 						]
-					} )
-					.get( '/themes/info/1.1/?action=query_themes&request%5Bfields%5D%5Bextended_author%5D=true' +
-						'&request%5Bsearch%5D=Sixteen' )
-					.reply( 200, {
-						info: { page: 1, pages: 1, results: 1 },
-						themes: [
-							{ slug: 'twentysixteen', name: 'Twenty Sixteen' }
-						]
 					} );
 			} );
 
@@ -308,52 +276,6 @@ describe( 'actions', () => {
 					type: THEMES_REQUEST,
 					siteId: 'wporg',
 					query: {}
-				} );
-			} );
-
-			it( 'should dispatch themes receive action when request completes', () => {
-				return requestThemes( 'wporg' )( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
-						type: THEMES_RECEIVE,
-						themes: [
-							{ id: 'bizprime', name: 'bizprime' },
-							{ id: 'shapely', name: 'Shapely' },
-							{ id: 'cassions', name: 'Cassions' },
-							{ id: 'intentionally-blank', name: 'Intentionally Blank' }
-						],
-						siteId: 'wporg'
-					} );
-				} );
-			} );
-
-			it( 'should dispatch themes request success action when request completes', () => {
-				return requestThemes( 'wporg' )( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
-						type: THEMES_REQUEST_SUCCESS,
-						siteId: 'wporg',
-						query: {},
-						found: 2452,
-						themes: [
-							{ id: 'bizprime', name: 'bizprime' },
-							{ id: 'shapely', name: 'Shapely' },
-							{ id: 'cassions', name: 'Cassions' },
-							{ id: 'intentionally-blank', name: 'Intentionally Blank' }
-						]
-					} );
-				} );
-			} );
-
-			it( 'should dispatch themes request success action with query results', () => {
-				return requestThemes( 'wporg', { search: 'Sixteen' } )( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
-						type: THEMES_REQUEST_SUCCESS,
-						siteId: 'wporg',
-						query: { search: 'Sixteen' },
-						found: 1,
-						themes: [
-							{ id: 'twentysixteen', name: 'Twenty Sixteen' },
-						]
-					} );
 				} );
 			} );
 		} );
@@ -380,18 +302,6 @@ describe( 'actions', () => {
 					type: THEME_REQUEST,
 					siteId: 'wpcom',
 					themeId: 'twentysixteen'
-				} );
-			} );
-
-			it( 'should dispatch themes receive action when request completes', () => {
-				return requestTheme( 'twentysixteen', 'wpcom' )( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
-						type: THEMES_RECEIVE,
-						themes: [
-							sinon.match( { id: 'twentysixteen', name: 'Twenty Sixteen' } )
-						],
-						siteId: 'wpcom'
-					} );
 				} );
 			} );
 
@@ -441,18 +351,6 @@ describe( 'actions', () => {
 				} );
 			} );
 
-			it( 'should dispatch themes receive action when request completes', () => {
-				return requestTheme( 'twentyfifteen', 77203074 )( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
-						type: THEMES_RECEIVE,
-						themes: [
-							sinon.match( { id: 'twentyfifteen', name: 'Twenty Fifteen' } )
-						],
-						siteId: 77203074
-					} );
-				} );
-			} );
-
 			it( 'should dispatch themes request success action when request completes', () => {
 				return requestTheme( 'twentyfifteen', 77203074 )( spy ).then( () => {
 					expect( spy ).to.have.been.calledWith( {
@@ -497,18 +395,6 @@ describe( 'actions', () => {
 					type: THEME_REQUEST,
 					siteId: 'wporg',
 					themeId: 'twentyseventeen'
-				} );
-			} );
-
-			it( 'should dispatch themes receive action when request completes', () => {
-				return requestTheme( 'twentyseventeen', 'wporg' )( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
-						type: THEMES_RECEIVE,
-						themes: [
-							sinon.match( { id: 'twentyseventeen', name: 'Twenty Seventeen' } )
-						],
-						siteId: 'wporg'
-					} );
 				} );
 			} );
 
@@ -804,21 +690,6 @@ describe( 'actions', () => {
 		} );
 
 		context( 'when request completes successfully', () => {
-			context( 'for a WP.com site', () => {
-				it( 'should dispatch receiveTheme action', () => {
-					return requestActiveTheme( 2211667 )( spy, fakeGetState ).then( () => {
-						expect( spy ).to.have.been.calledWith( receiveTheme( successResponse, 'wpcom' ) );
-					} );
-				} );
-			} );
-			context( 'for a Jetpack site', () => {
-				it( 'should dispatch receiveTheme action', () => {
-					return requestActiveTheme( 77203074 )( spy, fakeGetState ).then( () => {
-						expect( spy ).to.have.been.calledWith( receiveTheme( successResponse, 77203074 ) );
-					} );
-				} );
-			} );
-
 			it( 'should dispatch active theme request success action', () => {
 				return requestActiveTheme( 2211667 )( spy, fakeGetState ).then( () => {
 					expect( spy ).to.have.been.calledWith( {


### PR DESCRIPTION
Make sure we never see wpcom themes in the 'Uploaded themes' list for Jetpack sites by filtering them out whenever we receive themes from API requests.

Previously we were only filtering out themes from the results of a theme query, which meant that when we received themes from the active theme request, or when activating a new theme, a wpcom theme would appear to 'jump' into the top list.

**To Test**
* Go to http://calypso.localhost:3000/design and select a Jetpack site
* Activate a wpcom theme that has not previously been activated
* Pick a wpcom site, then come back to the previous Jetpack site
**Expected**: At no point should any wpcom theme be shown in the top 'Uploaded themes' list

**Note** AT sites will see wpcom themes in the top list until we change filtering to use the `theme_uri` field.
