### PR TITLE
Server: Fix overwritten `sections` module variable

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -307,10 +307,10 @@ module.exports = function() {
 
 	// redirects to handle old newdash formats
 	app.use( '/sites/:site/:section', function( req, res, next ) {
+		const redirectedSections = [ 'posts', 'pages', 'sharing', 'upgrade', 'checkout', 'change-theme' ];
 		let redirectUrl;
-		sections = [ 'posts', 'pages', 'sharing', 'upgrade', 'checkout', 'change-theme' ];
 
-		if ( -1 === sections.indexOf( req.params.section ) ) {
+		if ( -1 === redirectedSections.indexOf( req.params.section ) ) {
 			next();
 			return;
 		}


### PR DESCRIPTION
An older piece of Express.js middleware in Calypso was erroneously reassigning the `sections` variable for the whole module.

## Why this wasn't an issue so far

`sections` is only read in a handful of places in the module, but, most importantly, it is seemingly only read during server init — consider the longer `sections.forEach` block, where `sections` is read during iteration but luckily inside the Express.js handlers.

## Testing?

Everything should behave properly, just as before patch application: client-side Calypso, server-rendered pages (e.g. logged-out themes).

/cc @scruffian @drewblaisdell b/c pre-oss-cb5e90bc89