### PR TITLE
Update Refund survey

### DIFF
--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -238,7 +238,11 @@ const CancelPurchaseButton = React.createClass( {
 				type: 'refund'
 			};
 
-			submitSurvey( 'calypso-remove-purchase', this.props.selectedSite.ID, enrichedSurveyData( surveyData, moment(), selectedSite, purchase ) );
+			submitSurvey(
+				'calypso-remove-purchase',
+				this.props.selectedSite.ID,
+				enrichedSurveyData( surveyData, moment(), selectedSite, purchase )
+			);
 		}
 
 		cancelAndRefundPurchase( this.props.purchase.id, { product_id: this.props.purchase.productId }, this.handleSubmit );

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -3,6 +3,7 @@
  */
 import page from 'page';
 import React from 'react';
+import { moment } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -16,6 +17,7 @@ import { connect } from 'react-redux';
 import Dialog from 'components/dialog';
 import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
 import { getName, getSubscriptionEndDate, isOneTimePurchase, isRefundable, isSubscription } from 'lib/purchases';
+import { enrichedSurveyData } from '../utils';
 import { isDomainRegistration, isTheme, isGoogleApps, isJetpackPlan } from 'lib/products-values';
 import notices from 'notices';
 import paths from 'me/purchases/paths';
@@ -222,22 +224,21 @@ const CancelPurchaseButton = React.createClass( {
 		} );
 
 		if ( config.isEnabled( 'upgrades/removal-survey' ) ) {
-			const { purchase } = this.props,
-				surveyData = {
-					'why-cancel': {
-						response: this.state.survey.questionOneRadio,
-						text: this.state.survey.questionOneText
-					},
-					'next-adventure': {
-						response: this.state.survey.questionTwoRadio,
-						text: this.state.survey.questionTwoText
-					},
-					'what-better': { text: this.state.survey.questionThreeText },
-					purchase: purchase.productSlug,
-					type: 'refund'
-				};
+			const { purchase, selectedSite } = this.props;
+			const surveyData = {
+				'why-cancel': {
+					response: this.state.survey.questionOneRadio,
+					text: this.state.survey.questionOneText
+				},
+				'next-adventure': {
+					response: this.state.survey.questionTwoRadio,
+					text: this.state.survey.questionTwoText
+				},
+				'what-better': { text: this.state.survey.questionThreeText },
+				type: 'refund'
+			};
 
-			submitSurvey( 'calypso-remove-purchase', this.props.selectedSite.ID, surveyData );
+			submitSurvey( 'calypso-remove-purchase', this.props.selectedSite.ID, enrichedSurveyData( surveyData, moment(), selectedSite, purchase ) );
 		}
 
 		cancelAndRefundPurchase( this.props.purchase.id, { product_id: this.props.purchase.productId }, this.handleSubmit );

--- a/client/me/purchases/test/utils.js
+++ b/client/me/purchases/test/utils.js
@@ -65,28 +65,4 @@ describe( 'enrichedSurveyData', function() {
 			enrichedSurveyData( {}, moment( '2017-01-19T03:00:00+00:00' ), site, purchase ).daysSinceSiteCreation
 		).to.equal( 10 );
 	} );
-
-	it( 'should calculate newOrRenewal as new purchase when purchase subscribed date is less than one year minus 30 days ago', function() {
-		const site = null;
-		const purchase = { subscribedDate: '2017-01-09T03:00:00+00:00' };
-		expect(
-			enrichedSurveyData( {}, moment( '2017-01-19T03:00:00+00:00' ), site, purchase ).newOrRenewal
-		).to.equal( 'new purchase' );
-	} );
-
-	it( 'should calculate newOrRenewal as new purchase when purchase subscribed date is exactly one year minus 30 days ago', function() {
-		const site = null;
-		const purchase = { subscribedDate: '2017-01-10T03:00:00+00:00' };
-		expect(
-			enrichedSurveyData( {}, moment( '2017-12-11T03:00:00+00:00' ), site, purchase ).newOrRenewal
-		).to.equal( 'new purchase' );
-	} );
-
-	it( 'should calculate newOrRenewal as renewal when purchase subscribed date is greater than one year minus 30 days ago', function() {
-		const site = null;
-		const purchase = { subscribedDate: '2017-01-09T03:00:00+00:00' };
-		expect(
-			enrichedSurveyData( {}, moment( '2017-12-11T03:00:00+00:00' ), site, purchase ).newOrRenewal
-		).to.equal( 'renewal' );
-	} );
 } );

--- a/client/me/purchases/test/utils.js
+++ b/client/me/purchases/test/utils.js
@@ -52,7 +52,7 @@ describe( 'enrichedSurveyData', function() {
 		const site = null;
 		const purchase = { subscribedDate: '2017-01-09T03:00:00+00:00' };
 		expect(
-			enrichedSurveyData( { key: 'value' }, moment( '2017-01-19T03:00:00+00:00' ), site, purchase ).daysSincePurchase
+			enrichedSurveyData( {}, moment( '2017-01-19T03:00:00+00:00' ), site, purchase ).daysSincePurchase
 		).to.equal( 10 );
 	} );
 
@@ -62,7 +62,31 @@ describe( 'enrichedSurveyData', function() {
 		};
 		const purchase = null;
 		expect(
-			enrichedSurveyData( { key: 'value' }, moment( '2017-01-19T03:00:00+00:00' ), site, purchase ).daysSinceSiteCreation
+			enrichedSurveyData( {}, moment( '2017-01-19T03:00:00+00:00' ), site, purchase ).daysSinceSiteCreation
 		).to.equal( 10 );
+	} );
+
+	it( 'should calculate newOrRenewal as new purchase when purchase subscribed date is less than one year minus 30 days ago', function() {
+		const site = null;
+		const purchase = { subscribedDate: '2017-01-09T03:00:00+00:00' };
+		expect(
+			enrichedSurveyData( {}, moment( '2017-01-19T03:00:00+00:00' ), site, purchase ).newOrRenewal
+		).to.equal( 'new purchase' );
+	} );
+
+	it( 'should calculate newOrRenewal as new purchase when purchase subscribed date is exactly one year minus 30 days ago', function() {
+		const site = null;
+		const purchase = { subscribedDate: '2017-01-10T03:00:00+00:00' };
+		expect(
+			enrichedSurveyData( {}, moment( '2017-12-11T03:00:00+00:00' ), site, purchase ).newOrRenewal
+		).to.equal( 'new purchase' );
+	} );
+
+	it( 'should calculate newOrRenewal as renewal when purchase subscribed date is greater than one year minus 30 days ago', function() {
+		const site = null;
+		const purchase = { subscribedDate: '2017-01-09T03:00:00+00:00' };
+		expect(
+			enrichedSurveyData( {}, moment( '2017-12-11T03:00:00+00:00' ), site, purchase ).newOrRenewal
+		).to.equal( 'renewal' );
 	} );
 } );

--- a/client/me/purchases/test/utils.js
+++ b/client/me/purchases/test/utils.js
@@ -47,4 +47,22 @@ describe( 'enrichedSurveyData', function() {
 			enrichedSurveyData( { key: 'value' }, moment(), site, purchase ).purchase
 		).to.equal( 'product slug' );
 	} );
+
+	it( 'should add daysSincePurchase to survey data when purchase.subscribedDate is provided', function() {
+		const site = null;
+		const purchase = { subscribedDate: '2017-01-09T03:00:00+00:00' };
+		expect(
+			enrichedSurveyData( { key: 'value' }, moment( '2017-01-19T03:00:00+00:00' ), site, purchase ).daysSincePurchase
+		).to.equal( 10 );
+	} );
+
+	it( 'should add daysSinceSiteCreation to survey data when site.options.created_at is provided', function() {
+		const site = {
+			options: { created_at: '2017-01-09T03:00:00+00:00' }
+		};
+		const purchase = null;
+		expect(
+			enrichedSurveyData( { key: 'value' }, moment( '2017-01-19T03:00:00+00:00' ), site, purchase ).daysSinceSiteCreation
+		).to.equal( 10 );
+	} );
 } );

--- a/client/me/purchases/test/utils.js
+++ b/client/me/purchases/test/utils.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { moment } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import useMockery from 'test/helpers/use-mockery';
+
+describe( 'enrichedSurveyData', function() {
+	let enrichedSurveyData;
+
+	useMockery( mockery => {
+		mockery.registerMock( 'lib/analytics', {} );
+	} );
+
+	before( function() {
+		enrichedSurveyData = require( '../utils' ).enrichedSurveyData;
+	} );
+
+	it( 'should duplicate survey data if no site or purchase are provided', function() {
+		expect(
+			enrichedSurveyData( { key: 'value' }, moment() )
+		).to.deep.equal(
+			{
+				key: 'value',
+				purchase: null,
+				purchaseId: null,
+			}
+		);
+	} );
+
+	it( 'should add purchase id and slug to survey data if purchase is provided', function() {
+		const site = null;
+		const purchase = { id: 'purchase id', productSlug: 'product slug' };
+		expect(
+			enrichedSurveyData( { key: 'value' }, moment(), site, purchase ).purchase
+		).to.equal( 'product slug' );
+	} );
+
+	it( 'should add purchase id and slug to survey data if purchase is provided', function() {
+		const site = null;
+		const purchase = { id: 'purchase id', productSlug: 'product slug' };
+		expect(
+			enrichedSurveyData( { key: 'value' }, moment(), site, purchase ).purchase
+		).to.equal( 'product slug' );
+	} );
+} );

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -80,7 +80,8 @@ function enrichedSurveyData( surveyData, moment, site, purchase ) {
 		},
 		siteStartDate && {
 			daysSinceSiteCreation: moment.diff( siteStartDate, 'days', true ),
-		}
+		},
+		surveyData,
 	);
 }
 

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -69,21 +69,19 @@ function enrichedSurveyData( surveyData, moment, site, purchase ) {
 	const purchaseId = get( purchase, 'id', null );
 	const productSlug = get( purchase, 'productSlug', null );
 
-	const enrichment = {
-		purchase: productSlug,
-		purchaseId
-	};
-
-	if ( purchaseStartDate ) {
-		enrichment.daysSincePurchase = moment.diff( purchaseStartDate, 'days', true );
-		enrichment.newOrRenewal = moment.diff( purchaseStartDate, 'years', true ) > 1.0 ? 'renewal' : 'new purchase';
-	}
-
-	if ( siteStartDate ) {
-		enrichment.daysSinceSiteCreation = moment.diff( siteStartDate, 'days', true );
-	}
-
-	return { ...surveyData, ...enrichment };
+	return Object.assign(
+		{
+			purchase: productSlug,
+			purchaseId,
+		},
+		purchaseStartDate && {
+			daysSincePurchase: moment.diff( purchaseStartDate, 'days', true ),
+			newOrRenewal: moment.diff( purchaseStartDate, 'years', true ) > 1.0 ? 'renewal' : 'new purchase',
+		},
+		siteStartDate && {
+			daysSinceSiteCreation: moment.diff( siteStartDate, 'days', true ),
+		}
+	);
 }
 
 export {

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -76,6 +76,7 @@ function enrichedSurveyData( surveyData, moment, site, purchase ) {
 
 	if ( purchaseStartDate ) {
 		enrichment.daysSincePurchase = moment.diff( purchaseStartDate, 'days', true );
+		enrichment.newOrRenewal = moment.diff( purchaseStartDate, 'years', true ) > 1.0 ? 'renewal' : 'new purchase';
 	}
 
 	if ( siteStartDate ) {

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -76,7 +76,7 @@ function enrichedSurveyData( surveyData, moment, site, purchase ) {
 		},
 		purchaseStartDate && {
 			daysSincePurchase: moment.diff( purchaseStartDate, 'days', true ),
-			newOrRenewal: moment.diff( purchaseStartDate, 'years', true ) > 1.0 ? 'renewal' : 'new purchase',
+			newOrRenewal: moment.add( 30, 'days' ).diff( purchaseStartDate, 'years', true ) > 1.0 ? 'renewal' : 'new purchase',
 		},
 		siteStartDate && {
 			daysSinceSiteCreation: moment.diff( siteStartDate, 'days', true ),

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -76,7 +76,6 @@ function enrichedSurveyData( surveyData, moment, site, purchase ) {
 		},
 		purchaseStartDate && {
 			daysSincePurchase: moment.diff( purchaseStartDate, 'days', true ),
-			newOrRenewal: moment.add( 30, 'days' ).diff( purchaseStartDate, 'years', true ) > 1.0 ? 'renewal' : 'new purchase',
 		},
 		siteStartDate && {
 			daysSinceSiteCreation: moment.diff( siteStartDate, 'days', true ),

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import page from 'page';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -62,6 +63,28 @@ function recordPageView( trackingSlug, props, nextProps = null ) {
 	analytics.tracks.recordEvent( `calypso_${ trackingSlug }_purchase_view`, { product_slug: productSlug } );
 }
 
+function enrichedSurveyData( surveyData, moment, site, purchase ) {
+	const purchaseStartDate = get( purchase, 'subscribedDate', null );
+	const siteStartDate = get( site, 'options.created_at', null );
+	const purchaseId = get( purchase, 'id', null );
+	const productSlug = get( purchase, 'productSlug', null );
+
+	const enrichment = {
+		purchase: productSlug,
+		purchaseId
+	};
+
+	if ( purchaseStartDate ) {
+		enrichment.daysSincePurchase = moment.diff( purchaseStartDate, 'days', true );
+	}
+
+	if ( siteStartDate ) {
+		enrichment.daysSinceSiteCreation = moment.diff( siteStartDate, 'days', true );
+	}
+
+	return { ...surveyData, ...enrichment };
+}
+
 export {
 	getPurchase,
 	getSelectedSite,
@@ -69,5 +92,6 @@ export {
 	goToList,
 	goToManagePurchase,
 	isDataLoading,
-	recordPageView
+	recordPageView,
+	enrichedSurveyData,
 };


### PR DESCRIPTION
This change adds some information to the `calypso-remove-purchase` survey payload:

* `daysSincePurchase` - the number of days since the purchase was made
* `daysSinceSiteCreation` - the number of days since the site was created

**To Test**

For a user with at least one paid plan.

* browse to `/me/purchases`
* click the plan
* click 'Remove WordPress.com _plan_'
* complete survey
* observe in network tab the payload of the calypso-remove-purchase survey