### PR TITLE
Themes: Update filtering of wpcom themes as data loads

### DIFF
--- a/client/lib/query-manager/theme/index.js
+++ b/client/lib/query-manager/theme/index.js
@@ -4,6 +4,7 @@
 import PaginatedQueryManager from '../paginated';
 import ThemeQueryKey from './key';
 import { DEFAULT_THEME_QUERY } from './constants';
+import { isThemeFromWpcom } from 'state/themes/utils';
 
 /**
  * ThemeQueryManager manages themes which can be queried
@@ -21,6 +22,20 @@ export default class ThemeQueryManager extends PaginatedQueryManager {
 	 */
 	sort() {
 		return; // Leave the keys argument unchanged.
+	}
+
+	/**
+	 * Returns true if the item matches the given query, or false otherwise.
+	 *
+	 * @param  {Object}  query Query object
+	 * @param  {Object}  item  Item to consider
+	 * @return {Boolean}       Whether item matches query
+	 */
+	matches( query, item ) {
+		if ( query.filterWpcomThemes ) {
+			return ! isThemeFromWpcom( item.id );
+		}
+		return super.matches( query, item );
 	}
 }
 

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -13,9 +13,13 @@ import QueryThemes from 'components/data/query-themes';
 import ThemesList from 'components/themes-list';
 import ThemesSelectionHeader from './themes-selection-header';
 import analytics from 'lib/analytics';
-import { isJetpackSite } from 'state/sites/selectors';
+import {
+	isJetpackSite,
+	getSiteSlug,
+	hasJetpackSiteJetpackThemesExtendedFeatures,
+	isJetpackSiteMultiSite,
+} from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
-import { getSiteSlug } from 'state/sites/selectors';
 import {
 	getThemesForQueryIgnoringPage,
 	getThemesFoundForQuery,
@@ -180,6 +184,15 @@ const ConnectedThemesSelection = connect(
 			sourceSiteId = ( siteId && isJetpack ) ? siteId : 'wpcom';
 		}
 
+		// Don't show wpcom themes in the 'Uploaded themes' list
+		const filterWpcomThemes = (
+			siteId &&
+			isJetpack &&
+			config.isEnabled( 'manage/themes/upload' ) &&
+			hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ) &&
+			! isJetpackSiteMultiSite( state, siteId )
+		);
+
 		// number calculation is just a hack for Jetpack sites. Jetpack themes endpoint does not paginate the
 		// results and sends all of the themes at once. QueryManager is not expecting such behaviour
 		// and we ended up loosing all of the themes above number 20. Real solution will be pagination on
@@ -190,7 +203,8 @@ const ConnectedThemesSelection = connect(
 			page,
 			tier: config.isEnabled( 'upgrades/premium-themes' ) ? tier : 'free',
 			filter: compact( [ filter, vertical ] ).join( ',' ),
-			number
+			number,
+			filterWpcomThemes,
 		};
 
 		return {

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -68,14 +68,11 @@ import {
 } from './utils';
 import {
 	getSiteTitle,
-	hasJetpackSiteJetpackThemesExtendedFeatures,
 	isJetpackSite,
-	isJetpackSiteMultiSite
 } from 'state/sites/selectors';
 import { isSiteAutomatedTransfer } from 'state/selectors';
 import i18n from 'i18n-calypso';
 import accept from 'lib/accept';
-import config from 'config';
 
 const debug = debugFactory( 'calypso:themes:actions' ); //eslint-disable-line no-unused-vars
 
@@ -129,7 +126,7 @@ export function receiveThemes( themes, siteId ) {
  * @return {Function}                    Action thunk
  */
 export function requestThemes( siteId, query = {} ) {
-	return ( dispatch, getState ) => {
+	return ( dispatch ) => {
 		const startTime = new Date().getTime();
 
 		dispatch( {
@@ -166,18 +163,9 @@ export function requestThemes( siteId, query = {} ) {
 				// A Jetpack site's themes endpoint ignores the query,
 				// returning an unfiltered list of all installed themes instead.
 				// So we have to filter on the client side.
-				// Also if Jetpack plugin has Themes Extended Features,
-				// we filter out -wpcom suffixed themes because we will show them in
-				// second list that is specific to WordPress.com themes.
-				// For multi-site installation we do not provide themes upload yet so
-				// we can only show one list and we should not filter wpcom themes.
-				const keepWpcom = ! config.isEnabled( 'manage/themes/upload' ) ||
-					! hasJetpackSiteJetpackThemesExtendedFeatures( getState(), siteId ) ||
-					isJetpackSiteMultiSite( getState(), siteId );
-
 				filteredThemes = filter(
 					themes,
-					theme => isThemeMatchingQuery( query, theme ) && ( keepWpcom || ! isThemeFromWpcom( theme.id ) )
+					theme => isThemeMatchingQuery( query, theme )
 				);
 				// The Jetpack specific endpoint doesn't return the number of `found` themes, so we calculate it ourselves.
 				found = filteredThemes.length;

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -254,6 +254,12 @@ export function isThemeMatchingQuery( query, theme ) {
 						some( terms, { slug: f } )
 					) )
 				) );
+
+			case 'filterWpcomThemes':
+				if ( ! value ) {
+					return true;
+				}
+				return ! isThemeFromWpcom( theme.id );
 		}
 
 		return true;


### PR DESCRIPTION
Work-in-progress

* Add a `filterWpcomThemes` property to the Query object
* This allows filtering to be updated as data loads, preventing wpcom themes showing in the 'Uploaded themes' list
* wpcom theme filtering can be moved into the existing jetpack filter function