### PR TITLE
Editor: Fix timezone issue on scheduling clock

### DIFF
--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -147,7 +147,7 @@ class PostScheduleClock extends Component {
 		if ( timezone ) {
 			const tzDate = date.clone().tz( timezone );
 			tzDateOffset = tzDate.format( 'Z' );
-			diffInMinutes = tzDate.utcOffset() - moment().utcOffset();
+			diffInMinutes = tzDate.utcOffset() - moment( date ).utcOffset();
 		} else if ( isValidGMTOffset( gmtOffset ) ) {
 			const utcDate = date.clone().utcOffset( gmtOffset );
 			diffInMinutes = utcDate.utcOffset() - moment().utcOffset();


### PR DESCRIPTION
Currently, if you schedule a post for a time in the future that crosses the DST threshold, the clock may incorrectly tell you that the timezone in site settings doesn't match your local timezone, which is incorrect (see #11438 for an example). This updates the calculation we use for `moment()` by passing in the date input (`tzDate._i`). This way, `moment()` is using the same date input as `tzDate` for the calculation.

Note: This issue only applies if the user sets a specific timezone instead of a `gmtOffset`. `moment()` correctly interprets the time if you use the `gmtOffset`.

Here's an example just to clarify:
1. I have my time set to "Denver" in site settings. For Denver, DST starts at 2:00AM on March 12.
2. Start a new post. Open the schedule calendar and schedule the post for March 23.
3. On master, you'll incorrectly see that `This site timezone is +1h from your local timezone.`

*Original*
<img width="282" alt="screen shot 2017-02-22 at 7 24 42 am" src="https://cloud.githubusercontent.com/assets/7240478/23215538/001846fe-f8d0-11e6-86cd-3622c457c704.png">

*Branch (Same details)*
<img width="275" alt="screen shot 2017-02-22 at 7 25 51 am" src="https://cloud.githubusercontent.com/assets/7240478/23215693/8871af36-f8d0-11e6-8da6-940772d761e2.png">

## To test
1. Set the timezone in your site to your local timezone.
2. Open the post editor. Try setting a future date across a DST threshold. You shouldn't see any kind of notice since you'll be in the same timezone.
3. Go back and change your site settings to a different timezone +1 or -1 from your location.
4. Go back into the post editor. You should see a warning that your site is +1/-1 from your local timezone. Try selecting a date beyond the DST threshold. This should stay consistent.

Here's an edge case I did test:
- Phoenix doesn't observe DST meaning it's UTC-7 all year long. Right now, I'm in the same timezone as Phoenix. When I set Phoenix as my timezone in site settings and schedule a post before DST kicks in, it recognizes that I'm in that timezone, and I do not see a warning. When I schedule a post for after DST, it correctly recognizes that I'll be UTC-6, and Phoenix will still be UTC-7. I see the "This site timezone is -1h from your local timezone" as a result.
