### PR TITLE
ExternalLink: don't use iconClassName as a prop on the a element

### DIFF
--- a/client/components/external-link/index.jsx
+++ b/client/components/external-link/index.jsx
@@ -35,7 +35,7 @@ export default React.createClass( {
 		const classes = classnames( 'external-link', this.props.className, {
 			'has-icon': !! this.props.icon,
 		} );
-		const props = assign( {}, omit( this.props, 'icon', 'iconSize', 'showIconFirst' ), {
+		const props = assign( {}, omit( this.props, 'icon', 'iconSize', 'showIconFirst', 'iconClassName' ), {
 			className: classes,
 			rel: 'external'
 		} );


### PR DESCRIPTION
#11501 added an `iconClassName` prop to the `ExternalLink` component. 

I forgot to include the new prop in the list of props that are not applied to the `a` element. 

This PR fixes that :)