### PR TITLE
Skip domain selection step if domain is given as a query parameter

### DIFF
--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -17,7 +17,40 @@ const registrar = {
 	MAINTENANCE: 'Registrar TLD Maintenance'
 };
 
+const tlds = {
+	com: 'domain_reg',
+	net: 'domain_reg',
+	org: 'domain_reg',
+	me: 'dotme_domain',
+	co: 'dotco_domain',
+	'com.br': 'dotcomdotbr_domain',
+	info: 'dotinfo_domain',
+	'net.br': 'dotnetdotbr_domain',
+	biz: 'dotbiz_domain',
+	mobi: 'dotmobi_domain',
+	mx: 'dotmx_domain',
+	es: 'dotes_domain',
+	nl: 'dotnl_domain',
+	be: 'dotbe_domain',
+	fm: 'dotfm_domain',
+	tv: 'dottv_domain',
+	us: 'dotus_domain',
+	'in': 'dotin_domain',
+	wtf: 'dotwtf_domain',
+	coffee: 'dotcoffee_domain',
+	live: 'dotlive_domain',
+	wales: 'dotwales_domain',
+	blog: 'dotblog_domain',
+	rocks: 'dotrocks_domain',
+	site: 'dotsite_domain',
+	cloud: 'dotcloud_domain',
+	club: 'dotclub_domain',
+	today: 'dottoday_domain',
+	vip: 'dotvip_domain',
+};
+
 export default {
 	type,
-	registrar
+	registrar,
+	tlds
 };

--- a/client/lib/signup/cart.js
+++ b/client/lib/signup/cart.js
@@ -11,7 +11,33 @@ var wpcom = require( 'lib/wp' ),
 	cartValues = require( 'lib/cart-values' ),
 	cartItems = cartValues.cartItems;
 
+function addProductsToCart( cart, newCartItems ) {
+	forEach( newCartItems, function( cartItem ) {
+		cartItem.extra = Object.assign( cartItem.extra || {}, {
+			context: 'signup'
+		} );
+		const addFunction = cartItems.add( cartItem );
+
+		cart = cartValues.fillInAllCartItemAttributes( addFunction( cart ), productsList.get() );
+	} );
+
+	return cart;
+}
+
 module.exports = {
+	createCart: function( cartKey, newCartItems, callback ) {
+		let newCart = {
+			cart_key: cartKey,
+			products: [],
+			temporary: false,
+		};
+
+		newCart = addProductsToCart( newCart, newCartItems );
+
+		wpcom.undocumented().cart( cartKey, 'POST', newCart, function( postError ) {
+			callback( postError );
+		} );
+	},
 	addToCart: function( cartKey, newCartItems, callback ) {
 		wpcom.undocumented().cart( cartKey, function( error, data ) {
 			if ( error ) {
@@ -24,14 +50,7 @@ module.exports = {
 
 			let newCart = data;
 
-			forEach( newCartItems, function( cartItem ) {
-				cartItem.extra = Object.assign( cartItem.extra || {}, {
-					context: 'signup'
-				} );
-				const addFunction = cartItems.add( cartItem );
-
-				newCart = cartValues.fillInAllCartItemAttributes( addFunction( newCart ), productsList.get() );
-			} );
+			addProductsToCart( newCart, newCartItems );
 
 			wpcom.undocumented().cart( cartKey, 'POST', newCart, function( postError ) {
 				callback( postError );

--- a/client/lib/signup/cart.js
+++ b/client/lib/signup/cart.js
@@ -48,13 +48,9 @@ module.exports = {
 				newCartItems = [ newCartItems ];
 			}
 
-			let newCart = data;
+			const newCart = addProductsToCart( data, newCartItems );
 
-			addProductsToCart( newCart, newCartItems );
-
-			wpcom.undocumented().cart( cartKey, 'POST', newCart, function( postError ) {
-				callback( postError );
-			} );
+			wpcom.undocumented().cart( cartKey, 'POST', newCart, callback );
 		} );
 	}
 };

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -26,8 +26,7 @@ import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import { getSurveyVertical, getSurveySiteType } from 'state/signup/steps/survey/selectors';
 
 function createCart( callback, dependencies, data, reduxStore ) {
-	const { designType } = dependencies;
-	const { domainItem, themeItem } = data;
+	const { domainItem, designType } = dependencies;
 
 	if ( designType === 'domain' ) {
 		const cartKey = 'no-site';
@@ -35,7 +34,6 @@ function createCart( callback, dependencies, data, reduxStore ) {
 			siteId: null,
 			siteSlug: cartKey,
 			domainItem,
-			themeItem
 		};
 
 		SignupCart.createCart( cartKey, [ domainItem ], error => callback( error, providedDependencies ) );

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -26,13 +26,15 @@ import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import { getSurveyVertical, getSurveySiteType } from 'state/signup/steps/survey/selectors';
 
 function createCart( callback, dependencies, data, reduxStore ) {
-	const { domainItem, designType } = dependencies;
+	const { domainItem } = data;
+	const { designType } = dependencies;
 
 	if ( designType === 'domain' ) {
 		const cartKey = 'no-site';
 		const providedDependencies = {
 			siteId: null,
-			siteSlug: cartKey,
+			siteSlug: null,
+			themeItem: null,
 			domainItem,
 		};
 

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -33,15 +33,15 @@ function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
 		const cartKey = 'no-site';
 		const providedDependencies = {
 			siteId: null,
-			siteSlug: null,
+			siteSlug: cartKey,
 			themeSlugWithRepo: null,
 			domainItem,
 		};
 
 		SignupCart.createCart( cartKey, [ domainItem ], error => callback( error, providedDependencies ) );
 	} else {
-		createSiteWithCart( function( errors, providedDependencies ) {
-			callback( errors, pick( providedDependencies, [ 'siteId', 'siteSlug', 'themeSlugWithRepo', 'domainItem' ] ) )
+		createSiteWithCart( ( errors, providedDependencies ) => {
+			callback( errors, pick( providedDependencies, [ 'siteId', 'siteSlug', 'themeSlugWithRepo', 'domainItem' ] ) );
 		}, dependencies, data, reduxStore );
 	}
 }

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -38,7 +38,7 @@ function createCart( callback, dependencies, data, reduxStore ) {
 			themeItem
 		};
 
-		SignupCart.addToCart( cartKey, [ domainItem ], error => callback( error, providedDependencies ) );
+		SignupCart.createCart( cartKey, [ domainItem ], error => callback( error, providedDependencies ) );
 	} else {
 		createSiteWithCart( callback, dependencies, data, reduxStore );
 	}

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -4,6 +4,7 @@
 import assign from 'lodash/assign';
 import defer from 'lodash/defer';
 import isEmpty from 'lodash/isEmpty';
+import pick from 'lodash/pick';
 import async from 'async';
 import { parse as parseURL } from 'url';
 import { startsWith } from 'lodash';
@@ -25,22 +26,23 @@ import {
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import { getSurveyVertical, getSurveySiteType } from 'state/signup/steps/survey/selectors';
 
-function createCart( callback, dependencies, data, reduxStore ) {
-	const { domainItem } = data;
-	const { designType } = dependencies;
+function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
+	const { designType, domainItem } = data;
 
 	if ( designType === 'domain' ) {
 		const cartKey = 'no-site';
 		const providedDependencies = {
 			siteId: null,
 			siteSlug: null,
-			themeItem: null,
+			themeSlugWithRepo: null,
 			domainItem,
 		};
 
 		SignupCart.createCart( cartKey, [ domainItem ], error => callback( error, providedDependencies ) );
 	} else {
-		createSiteWithCart( callback, dependencies, data, reduxStore );
+		createSiteWithCart( function( errors, providedDependencies ) {
+			callback( errors, pick( providedDependencies, [ 'siteId', 'siteSlug', 'themeSlugWithRepo', 'domainItem' ] ) )
+		}, dependencies, data, reduxStore );
 	}
 }
 
@@ -217,7 +219,7 @@ function getUsernameSuggestion( username, reduxState ) {
 }
 
 module.exports = {
-	createCart,
+	createSiteOrDomain,
 
 	createSiteWithCart,
 

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -233,7 +233,7 @@ module.exports = {
 
 		const newCartItems = [ cartItem, privacyItem ].filter( item => item );
 
-		SignupCart.addToCart( siteId, newCartItems, callback );
+		SignupCart.addToCart( siteId, newCartItems, error => callback( error, { cartItem, privacyItem } ) );
 	},
 
 	createAccount( callback, dependencies, { userData, flowName, queryArgs }, reduxStore ) {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -217,7 +217,7 @@ const flows = {
 
 if ( config.isEnabled( 'signup/domain-first-flow' ) ) {
 	flows[ 'domain-first' ] = {
-		steps: [ 'domain-only', 'site-or-domain', 'themes', 'plans', 'user' ],
+		steps: [ 'site-or-domain', 'themes', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'An experimental approach for WordPress.com/domains',
 		lastModified: '2017-01-16'

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -137,6 +137,7 @@ module.exports = {
 			headerText: i18n.translate( 'Do you want to use this domain yet?' ),
 			subHeaderText: i18n.translate( "Don't worry you can easily add a site later if you're not ready" )
 		},
+		dependencies: [ 'domainItem', 'designType' ],
 		providesDependencies: [ 'domainItem', 'siteId', 'siteSlug', 'designType' ]
 	},
 };

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -132,11 +132,12 @@ module.exports = {
 	// should not be used outside of the `domain-first` flow.
 	'site-or-domain': {
 		stepName: 'site-or-domain',
-		apiRequestFunction: stepActions.createCart,
+		apiRequestFunction: stepActions.createSiteOrDomain,
 		props: {
 			headerText: i18n.translate( 'Do you want to use this domain yet?' ),
 			subHeaderText: i18n.translate( "Don't worry you can easily add a site later if you're not ready" )
 		},
-		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'designType', 'themeItem' ]
+		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeSlugWithRepo', 'designType' ],
+		delayApiRequestUntilComplete: true
 	},
 };

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -137,7 +137,6 @@ module.exports = {
 			headerText: i18n.translate( 'Do you want to use this domain yet?' ),
 			subHeaderText: i18n.translate( "Don't worry you can easily add a site later if you're not ready" )
 		},
-		dependencies: [ 'domainItem', 'designType' ],
-		providesDependencies: [ 'domainItem', 'siteId', 'siteSlug', 'designType' ]
+		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'designType', 'themeItem' ]
 	},
 };

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -101,17 +101,6 @@ module.exports = {
 		delayApiRequestUntilComplete: true
 	},
 
-	'domain-only': {
-		stepName: 'domain-only',
-		apiRequestFunction: stepActions.createCart,
-		props: {
-			isDomainOnly: true
-		},
-		dependencies: [ 'themeSlugWithRepo', 'designType' ],
-		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
-		delayApiRequestUntilComplete: true
-	},
-
 	'jetpack-user': {
 		stepName: 'jetpack-user',
 		apiRequestFunction: stepActions.createAccount,
@@ -143,10 +132,11 @@ module.exports = {
 	// should not be used outside of the `domain-first` flow.
 	'site-or-domain': {
 		stepName: 'site-or-domain',
+		apiRequestFunction: stepActions.createCart,
 		props: {
 			headerText: i18n.translate( 'Do you want to use this domain yet?' ),
 			subHeaderText: i18n.translate( "Don't worry you can easily add a site later if you're not ready" )
 		},
-		providesDependencies: [ 'designType' ]
+		providesDependencies: [ 'domainItem', 'siteId', 'siteSlug', 'designType' ]
 	},
 };

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -137,7 +137,7 @@ module.exports = {
 			headerText: i18n.translate( 'Do you want to use this domain yet?' ),
 			subHeaderText: i18n.translate( "Don't worry you can easily add a site later if you're not ready" )
 		},
-		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeSlugWithRepo', 'designType' ],
+		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeSlugWithRepo' ],
 		delayApiRequestUntilComplete: true
 	},
 };

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -351,9 +351,17 @@ const Signup = React.createClass( {
 	},
 
 	goToFirstInvalidStep() {
-		var firstInvalidStep = find( SignupProgressStore.get(), { status: 'invalid' } );
+		const firstInvalidStep = find( SignupProgressStore.get(), { status: 'invalid' } );
 
 		if ( firstInvalidStep ) {
+			if ( firstInvalidStep.stepName === this.props.stepName ) {
+				// reset the signup stores so we have a chance to start over the flow
+				// TODO: fix loading invalid steps from the store
+				SignupDependencyStore.reset();
+				SignupProgressStore.reset();
+				console.error( 'Current step is invalid, cannot redirect to it.', firstInvalidStep.errors ); //eslint-disable-line no-console
+				return;
+			}
 			analytics.tracks.recordEvent( 'calypso_signup_goto_invalid_step', {
 				step: firstInvalidStep.stepName,
 				flow: this.props.flowName

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -70,7 +70,7 @@ export default class SiteOrDomain extends Component {
 		const tld = domain.split( '.' ).slice( 1 ).join( '.' );
 		const domainItem = cartItems.domainRegistration( { productSlug: tlds[ tld ], domain } );
 
-		SignupActions.submitSignupStep( { stepName }, [], { designType, domainItem } );
+		SignupActions.submitSignupStep( { stepName, domainItem, siteSlug: domain }, [], { designType } );
 
 		if ( designType === 'domain' ) {
 			// we can skip the next two steps in the `domain-first` flow if the

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -70,7 +70,14 @@ export default class SiteOrDomain extends Component {
 		const tld = domain.split( '.' ).slice( 1 ).join( '.' );
 		const domainItem = cartItems.domainRegistration( { productSlug: tlds[ tld ], domain } );
 
-		SignupActions.submitSignupStep( { stepName, domainItem, siteSlug: domain }, [], { designType } );
+		SignupActions.submitSignupStep( {
+			stepName,
+			domainItem,
+			designType,
+			siteSlug: domain,
+			siteUrl: domain,
+			isPurchasingItem: true,
+		}, [], { designType } );
 
 		if ( designType === 'domain' ) {
 			// we can skip the next two steps in the `domain-first` flow if the

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -12,7 +12,7 @@ import StepWrapper from 'signup/step-wrapper';
 import SignupActions from 'lib/signup/actions';
 import Card from 'components/card';
 // TODO: `design-type-with-store`, `design-type`, and this component could be refactored to reduce redundancy
-import BlogImage from 'signup/steps/design-type-with-store/blog-image';
+import DomainImage from 'signup/steps/design-type-with-store/domain-image';
 import PageImage from 'signup/steps/design-type-with-store/page-image';
 
 export default class SiteOrDomain extends Component {
@@ -21,12 +21,12 @@ export default class SiteOrDomain extends Component {
 			{
 				type: 'page',
 				label: 'Start a new site',
-				image: <BlogImage />
+				image: <PageImage />
 			},
 			{
 				type: 'domain',
 				label: 'Just buy a domain',
-				image: <PageImage />
+				image: <DomainImage />
 			},
 		];
 	}
@@ -59,9 +59,10 @@ export default class SiteOrDomain extends Component {
 		let domainItem;
 
 		if ( queryObject && queryObject.new ) {
-			const [ domain, ...tld ] = queryObject.new.split( '.' );
+			const domain = queryObject.new;
+			const tld = domain.split( '.' ).slice( 1 ).join( '.' );
 
-			domainItem = cartItems.domainRegistration( { productSlug: tlds[ tld.join( '.' ) ], domain } );
+			domainItem = cartItems.domainRegistration( { productSlug: tlds[ tld ], domain } );
 		}
 
 		SignupActions.submitSignupStep( { stepName }, [], { designType, domainItem } );

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -6,11 +6,13 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
+import { cartItems } from 'lib/cart-values';
+import { tlds } from 'lib/domains/constants';
 import StepWrapper from 'signup/step-wrapper';
 import SignupActions from 'lib/signup/actions';
 import Card from 'components/card';
 // TODO: `design-type-with-store`, `design-type`, and this component could be refactored to reduce redundancy
-import DomainImage from 'signup/steps/design-type-with-store/domain-image';
+import BlogImage from 'signup/steps/design-type-with-store/blog-image';
 import PageImage from 'signup/steps/design-type-with-store/page-image';
 
 export default class SiteOrDomain extends Component {
@@ -19,12 +21,12 @@ export default class SiteOrDomain extends Component {
 			{
 				type: 'page',
 				label: 'Start a new site',
-				image: <PageImage />
+				image: <BlogImage />
 			},
 			{
 				type: 'domain',
 				label: 'Just buy a domain',
-				image: <DomainImage />
+				image: <PageImage />
 			},
 		];
 	}
@@ -47,9 +49,22 @@ export default class SiteOrDomain extends Component {
 	handleClickChoice( event, designType ) {
 		event.preventDefault();
 
-		const { stepName, goToStep, goToNextStep } = this.props;
+		const {
+			stepName,
+			goToStep,
+			goToNextStep,
+			queryObject,
+		} = this.props;
 
-		SignupActions.submitSignupStep( { stepName }, [], { designType } );
+		let domainItem;
+
+		if ( queryObject && queryObject.new ) {
+			const [ domain, ...tld ] = queryObject.new.split( '.' );
+
+			domainItem = cartItems.domainRegistration( { productSlug: tlds[ tld.join( '.' ) ], domain } );
+		}
+
+		SignupActions.submitSignupStep( { stepName }, [], { designType, domainItem } );
 
 		if ( designType === 'domain' ) {
 			// we can skip the next two steps in the `domain-first` flow if the

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import page from 'page';
 import React, { Component } from 'react';
 
 /**
@@ -14,8 +15,17 @@ import Card from 'components/card';
 // TODO: `design-type-with-store`, `design-type`, and this component could be refactored to reduce redundancy
 import DomainImage from 'signup/steps/design-type-with-store/domain-image';
 import PageImage from 'signup/steps/design-type-with-store/page-image';
+import { getStepUrl } from 'signup/utils';
 
 export default class SiteOrDomain extends Component {
+	componentWillMount() {
+		const { queryObject } = this.props;
+
+		if ( ! queryObject || ! queryObject.new ) {
+			page( getStepUrl( 'main' ) );
+		}
+	}
+
 	getChoices() {
 		return [
 			{
@@ -56,14 +66,9 @@ export default class SiteOrDomain extends Component {
 			queryObject,
 		} = this.props;
 
-		let domainItem;
-
-		if ( queryObject && queryObject.new ) {
-			const domain = queryObject.new;
-			const tld = domain.split( '.' ).slice( 1 ).join( '.' );
-
-			domainItem = cartItems.domainRegistration( { productSlug: tlds[ tld ], domain } );
-		}
+		const domain = queryObject.new;
+		const tld = domain.split( '.' ).slice( 1 ).join( '.' );
+		const domainItem = cartItems.domainRegistration( { productSlug: tlds[ tld ], domain } );
 
 		SignupActions.submitSignupStep( { stepName }, [], { designType, domainItem } );
 

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -77,7 +77,7 @@ export default class SiteOrDomain extends Component {
 			siteSlug: domain,
 			siteUrl: domain,
 			isPurchasingItem: true,
-		}, [], { designType } );
+		}, [], { domainItem } );
 
 		if ( designType === 'domain' ) {
 			// we can skip the next two steps in the `domain-first` flow if the


### PR DESCRIPTION
This PR updates the `domain-first` flow to:

- Remove the first step in the flow. `/domains` will be where domain search is mounted.
- Add a domain to the user's cart based on the presence of a `new` query string parameter.

This PR also fixes the case where a user restarts the `domain-first` flow without purchasing. Since a domain only cart only allows one domain registration per cart, the new selected domain is never added. The fix is to simply replace the cart with the new domain registration product.

### Testing Instructions
- Load this branch locally and go to http://calypso.localhost:3000/start/domain-first?new=hello.com
- Assert that the first step is skipped
- Continue and buy the domain
- Restart the flow http://calypso.localhost:3000/start/domain-first?new=hello2.com and select add a site and check that this path still works
- Restart the flow http://calypso.localhost:3000/start/domain-first?new=hello3.com, go to checkout but don't buy the domain, then restart the flow http://calypso.localhost:3000/start/domain-first?new=hello4.com select domain only and assert that `hello3.com` has been replaced with `hello4.com`

### Reviews
- [x] Code
- [ ] Product