### PR TITLE
JPC: Standardize disclaimer text

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -626,7 +626,6 @@ const LoggedInForm = React.createClass( {
 		}
 		return (
 			<LoggedOutFormFooter className="jetpack-connect__action-disclaimer">
-				{ this.getDisclaimerText() }
 				<Button
 					primary
 					disabled={ this.isAuthorizing() || this.props.requestHasXmlrpcError() }
@@ -634,6 +633,7 @@ const LoggedInForm = React.createClass( {
 				>
 					{ this.getButtonText() }
 				</Button>
+				{ this.getDisclaimerText() }
 			</LoggedOutFormFooter>
 
 		);

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -494,39 +494,41 @@ const LoggedInForm = React.createClass( {
 		}
 	},
 
-	onClickDisclaimerLink() {
-		this.props.recordTracksEvent( 'calypso_jpc_disclaimer_link_click' );
+	getTermsOfServiceUrl() {
+		return 'https://' + i18n.getLocaleSlug() + '.wordpress.com/tos/';
+	},
+
+	onClickShareDetailsLink() {
+		this.props.recordTracksEvent( 'calypso_jpc_share_details_link_click' );
 	},
 
 	getDisclaimerText() {
-		const { queryObject } = this.props.jetpackConnectAuthorize;
-		const { blogname } = queryObject;
-
-		const detailsLink = (
+		const shareDetailsLink = (
 			<a
 				target="_blank"
 				rel="noopener noreferrer"
-				onClick={ this.onClickDisclaimerLink }
+				onClick={ this.onClickShareDetailsLink }
 				href="https://jetpack.com/support/what-data-does-jetpack-sync/"
 				className="jetpack-connect__sso-actions-modal-link" />
 		);
 
-		const text = this.translate(
-			'By connecting your site, you agree to {{detailsLink}}share details{{/detailsLink}} between WordPress.com and %(siteName)s.',
-			{
-				components: {
-					detailsLink
-				},
-				args: {
-					siteName: decodeEntities( blogname )
-				}
-			}
-		);
-
 		return (
-			<p className="jetpack-connect__tos-link">
-				{ text }
-			</p>
+			<p className="jetpack-connect__tos-link">{
+				this.translate(
+					'By connecting your site you agree to our fascinating {{tosLink}}Terms of Service{{/tosLink}} and to {{shareDetailsLink}}share details{{/shareDetailsLink}} with WordPress.com',
+					{
+						components: {
+							shareDetailsLink,
+							tosLink: <a
+								className="jetpack-connect__tos-link-text"
+								href={ this.getTermsOfServiceUrl() }
+								onClick={ this.props.handleOnClickTos }
+								target="_blank"
+								rel="noopener noreferrer" />
+						}
+					}
+				)
+			}</p>
 		);
 	},
 

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -120,10 +120,10 @@ export default React.createClass( {
 						: null }
 				</div>
 				<Card className="jetpack-connect__connect-button-card">
+					{ this.renderDisclaimerText() }
 					<Button primary
 						disabled={ ( ! this.state.value || this.props.isFetching || hasError ) }
 						onClick={ this.props.onClick }>{ this.renderButtonLabel() }</Button>
-					{ this.renderDisclaimerText() }
 				</Card>
 			</div>
 		);

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -14,6 +14,7 @@ import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import Spinner from 'components/spinner';
 import untrailingslashit from 'lib/route/untrailingslashit';
+//import { recordTracksEvent } from 'state/analytics/actions';
 
 export default React.createClass( {
 	displayName: 'JetpackConnectSiteURLInput',
@@ -62,14 +63,28 @@ export default React.createClass( {
 		return 'https://' + i18n.getLocaleSlug() + '.wordpress.com/tos/';
 	},
 
-	renderTermsOfServiceLink() {
+	onClickShareDetailsLink() {
+		this.props.recordTracksEvent( 'calypso_jpc_share_details_link_click' );
+	},
+
+	renderDisclaimerText() {
+		const shareDetailsLink = (
+			<a
+				target="_blank"
+				rel="noopener noreferrer"
+				onClick={ this.onClickShareDetailsLink }
+				href="https://jetpack.com/support/what-data-does-jetpack-sync/"
+				className="jetpack-connect__sso-actions-modal-link" />
+		);
+
 		return (
 			<p className="jetpack-connect__tos-link">{
 				this.translate(
-					'By connecting your site you agree to our fascinating {{a}}Terms of Service{{/a}}.',
+					'By connecting your site you agree to our fascinating {{tosLink}}Terms of Service{{/tosLink}} and to {{shareDetailsLink}}share details{{/shareDetailsLink}} with WordPress.com',
 					{
 						components: {
-							a: <a
+							shareDetailsLink,
+							tosLink: <a
 								className="jetpack-connect__tos-link-text"
 								href={ this.getTermsOfServiceUrl() }
 								onClick={ this.props.handleOnClickTos }
@@ -105,10 +120,10 @@ export default React.createClass( {
 						: null }
 				</div>
 				<Card className="jetpack-connect__connect-button-card">
-					{ this.renderTermsOfServiceLink() }
 					<Button primary
 						disabled={ ( ! this.state.value || this.props.isFetching || hasError ) }
 						onClick={ this.props.onClick }>{ this.renderButtonLabel() }</Button>
+					{ this.renderDisclaimerText() }
 				</Card>
 			</div>
 		);

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -382,7 +382,7 @@
 
 .jetpack-connect__tos-link {
 	font-size: 11px;
-	margin: 0 0 16px 0;
+	margin: 16px 0 0;
 	text-align: center;
 }
 

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -382,7 +382,7 @@
 
 .jetpack-connect__tos-link {
 	font-size: 11px;
-	margin: 16px 0 0;
+	margin: 0 0 16px 0;
 	text-align: center;
 }
 


### PR DESCRIPTION
This PR standardizes disclaimer text (ToS and share details) when connecting a JP site.

**Before:**

`By connecting your site you agree to our fascinating {{a}}Terms of Service{{/a}}.`

And

`By connecting your site, you agree to {{detailsLink}}share details{{/detailsLink}} between WordPress.com and %(siteName)s.`

**After:**

`By connecting your site you agree to our fascinating {{tosLink}}Terms of Service{{/tosLink}} and to {{shareDetailsLink}}share details{{/shareDetailsLink}} with WordPress.com`

~~It also reorders the disclaimer paragraph, moving it under the button.~~ As per https://github.com/Automattic/wp-calypso/pull/11531#issuecomment-282001185 we are no longer reordering the disclaimer text and button.

## Screens

### Before

<img width="458" alt="screen-shot-2017-02-02-at-1-01-17-pm" src="https://cloud.githubusercontent.com/assets/390760/23219743/cb17de2c-f917-11e6-923c-e661ba95a9ea.png">

<img width="494" alt="screen-shot-2017-02-02-at-1-02-12-pm" src="https://cloud.githubusercontent.com/assets/390760/23219745/ce6a0ca8-f917-11e6-8676-3fa44586686c.png">


### After

<img width="458" alt="screen shot 2017-02-22 at 15 49 46" src="https://cloud.githubusercontent.com/assets/390760/23219764/db467f38-f917-11e6-946b-851cafd40a26.png">

<img width="466" alt="screen shot 2017-02-22 at 15 52 53" src="https://cloud.githubusercontent.com/assets/390760/23219780/e2dc75ae-f917-11e6-80b5-ec6008e6bde9.png">

---

There's still a few things left to do, so pinging @johnHackworth to handle them.

Related: https://github.com/Automattic/wp-calypso/pull/10658