### PR TITLE
Themes: Use installed theme id for theme activation

### DIFF
--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -457,8 +457,9 @@ export function installTheme( themeId, siteId ) {
 				dispatch( {
 					type: THEME_INSTALL_SUCCESS,
 					siteId,
-					themeId
+					themeId: theme.id, // id returned from AT sites will have no -wpcom suffix
 				} );
+				return theme.id;
 			} )
 			.catch( ( error ) => {
 				dispatch( {
@@ -467,6 +468,14 @@ export function installTheme( themeId, siteId ) {
 					themeId,
 					error
 				} );
+				// Workaround: Installing a theme on an AT site currently
+				// returns an install error even after successful install.
+				// In this case, return a suffixless theme id (mimicking
+				// id return in success case above).
+				if ( error.error === 'install_error' ) {
+					return themeId.replace( '-wpcom', '' );
+				}
+				return themeId;
 			} );
 	};
 }
@@ -518,8 +527,8 @@ export function tryAndCustomize( themeId, siteId ) {
 export function installAndTryAndCustomizeTheme( themeId, siteId ) {
 	return ( dispatch ) => {
 		return dispatch( installTheme( themeId, siteId ) )
-			.then( () => {
-				dispatch( tryAndCustomizeTheme( themeId, siteId ) );
+			.then( ( installedId ) => {
+				dispatch( tryAndCustomizeTheme( installedId, siteId ) );
 			} );
 	};
 }
@@ -563,10 +572,10 @@ export function tryAndCustomizeTheme( themeId, siteId ) {
 export function installAndActivateTheme( themeId, siteId, source = 'unknown', purchased = false ) {
 	return ( dispatch ) => {
 		return dispatch( installTheme( themeId, siteId ) )
-			.then( () => {
+			.then( ( installedId ) => {
 				// This will be called even if `installTheme` silently fails. We rely on
 				// `activateTheme`'s own error handling here.
-				dispatch( activateTheme( themeId, siteId, source, purchased ) );
+				dispatch( activateTheme( installedId, siteId, source, purchased ) );
 			} );
 	};
 }


### PR DESCRIPTION
Enables wpcom theme activation on AT sites.

Now that the -wpcom suffix is not used on AT sites, use the theme id returned from the install endpoint to activate the theme.

There is currently a problem with the installs on AT sites that means the endpoint returns an error after a successful install. In this case, attempt to activate the suffix-less theme id.

**Note** The _try & customize_ action, which needs the full theme object returned from the install endpoint, will not work until we fix the JP install endpoint properly.


**To Test**
* _Activate_ theme should work for wpcom themes for both AT and Jetpack sites

/cc @lamosty 

