### PR TITLE
Components: add disableHref prop to prevent unwanted linked `Banner`s

### DIFF
--- a/client/components/banner/README.md
+++ b/client/components/banner/README.md
@@ -7,6 +7,7 @@ This component renders a customizable banner.
 - *callToAction* - shows a CTA text.
 - *className* - any additional CSS classes.
 - *description* - the banner description.
+- *disableHref* - when true, prevent the Banner to be linked either via the `href` props or as a side effect of the `siteSlug` connected prop.
 - *dismissPreferenceName*: the user preference name that we store a boolean against, prefixed with 'dismissible-card-' to avoid namespace collisions.
 - *dismissTemporary*: when true, clicking on the cross will dismiss the card for the current page load.
 - *event* - event to distinguish the nudge in tracks. Used as `cta_name` event property.
@@ -36,8 +37,9 @@ render() {
 		<Banner
 			callToAction="Upgrade now!"
 			description="Obtain more features."
+			disableHref
 			dismissPreferenceName="example-banner"
-			dismissTemporary={ true }
+			dismissTemporary
 			event="track_event"
 			feature={ FEATURE_ADVANCED_SEO }
 			href="https://wordpress.com/"

--- a/client/components/banner/docs/example.jsx
+++ b/client/components/banner/docs/example.jsx
@@ -16,9 +16,13 @@ import Banner from 'components/banner';
 
 const BannerExample = () =>
 	<div>
-		<Banner title="Banner unrelated to any plan"/>
+		<Banner
+			disableHref
+			title="Banner unrelated to any plan"
+		/>
 		<Banner
 			description="And with a description."
+			disableHref
 			icon="star"
 			title="Banner unrelated to any plan"
 		/>

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -34,6 +34,7 @@ class Banner extends Component {
 		callToAction: PropTypes.string,
 		className: PropTypes.string,
 		description: PropTypes.string,
+		disableHref: PropTypes.bool,
 		dismissPreferenceName: PropTypes.string,
 		dismissTemporary: PropTypes.bool,
 		event: PropTypes.string,
@@ -49,6 +50,7 @@ class Banner extends Component {
 	};
 
 	static defaultProps = {
+		disableHref: false,
 		dismissTemporary: false,
 		onClick: noop,
 	};
@@ -192,6 +194,7 @@ class Banner extends Component {
 		const {
 			callToAction,
 			className,
+			disableHref,
 			dismissPreferenceName,
 			dismissTemporary,
 			plan,
@@ -223,7 +226,7 @@ class Banner extends Component {
 		return (
 			<Card
 				className={ classes }
-				href={ callToAction ? null : this.getHref() }
+				href={ disableHref || callToAction ? null : this.getHref() }
 				onClick={ callToAction ? noop : this.handleClick }
 			>
 				{ this.getIcon() }
@@ -234,8 +237,8 @@ class Banner extends Component {
 
 }
 
-const mapStateToProps = state => ( {
-	siteSlug: getSelectedSiteSlug( state ),
+const mapStateToProps = ( state, ownProps ) => ( {
+	siteSlug: ownProps.disableHref ? null : getSelectedSiteSlug( state ),
 } );
 
 export default connect(


### PR DESCRIPTION
To keep a backward compatibility to all the deprecated banner-like components, `Banner` can appear as a linked card either by manually passing the `href` prop, or by receiving the `siteSlug` from the Redux state.

It was not clear in the docs, where `siteSlug` is always `null`, that in real life usage, it would be basically impossible to create a **non-linked** `Banner`, since it's to be expected that `siteSlug` won't be `null`.

To allow it, I've added a new `disableHref` prop, that overrides `href` and prevent the selection of `siteSlug` from the Redux state.

Any existing `Banner`s are not affected by this PR, since it requires to manually add the `disableHref` prop.