### PR TITLE
My Sites: Fix several issues with domain-only sites

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -74,6 +74,7 @@
 @import 'components/email-verification/style';
 @import 'components/emojify/style';
 @import 'components/empty-content/style';
+@import 'components/empty-content/feature-unavailable/style';
 @import 'components/external-link/style';
 @import 'components/faq/style';
 @import 'components/feature-example/style';

--- a/client/components/empty-content/feature-unavailable/index.jsx
+++ b/client/components/empty-content/feature-unavailable/index.jsx
@@ -7,22 +7,30 @@ import React, { PropTypes } from 'react';
 /**
  * Internal dependencies
  */
+import DocumentHead from 'components/data/document-head';
 import { domainManagementEdit } from 'my-sites/upgrades/paths';
 import EmptyContent from 'components/empty-content';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 
 /**
  * Renders content to be displayed in response of any action not available in domain-only sites.
  */
 const FeatureUnavailable = ( { domainName, siteId, translate } ) => {
 	return (
-		<EmptyContent
-			className={ 'feature-unavailable' }
-			title={ translate( 'Add a site to start using this feature.' ) }
-			line={ translate( 'Your domain is only set up with a temporary page. Start a site now to unlock everything WordPress.com can offer.' ) }
-			action={ translate( 'Create Site' ) }
-			actionURL={ `/start/site-selected/?siteSlug=${ encodeURIComponent( domainName ) }&siteId=${ encodeURIComponent( siteId ) }` }
-			secondaryAction={ translate( 'Manage Domain' ) }
-			secondaryActionURL={ domainManagementEdit( domainName, domainName ) } />
+		<div>
+			<DocumentHead title={ translate( 'Domain Management' ) } />
+
+			<SidebarNavigation />
+
+			<EmptyContent
+				className={ 'feature-unavailable' }
+				title={ translate( 'Add a site to start using this feature.' ) }
+				line={ translate( 'Your domain is only set up with a temporary page. Start a site now to unlock everything WordPress.com can offer.' ) }
+				action={ translate( 'Create Site' ) }
+				actionURL={ `/start/site-selected/?siteSlug=${ encodeURIComponent( domainName ) }&siteId=${ encodeURIComponent( siteId ) }` }
+				secondaryAction={ translate( 'Manage Domain' ) }
+				secondaryActionURL={ domainManagementEdit( domainName, domainName ) } />
+		</div>
 	);
 };
 

--- a/client/components/empty-content/feature-unavailable/index.jsx
+++ b/client/components/empty-content/feature-unavailable/index.jsx
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { domainManagementEdit } from 'my-sites/upgrades/paths';
+import EmptyContent from 'components/empty-content';
+
+const FeatureUnavailable = ( { selectedSite, translate } ) => {
+	return (
+		<EmptyContent
+			className={ 'feature-unavailable' }
+			title={ translate( 'Add a site to start using this feature.' ) }
+			line={ translate( 'Your domain is only set up with a temporary page. Start a site now to unlock everything WordPress.com can offer.' ) }
+			action={ translate( 'Create Site' ) }
+			actionURL={ `/start/site-selected/?siteSlug=${ encodeURIComponent( selectedSite.slug ) }&siteId=${ encodeURIComponent( selectedSite.ID ) }` }
+			secondaryAction={ translate( 'Manage Domain' ) }
+			secondaryActionURL={ domainManagementEdit( selectedSite.slug ) } />
+	);
+};
+
+FeatureUnavailable.propTypes = {
+	selectedSite: PropTypes.object.isRequired,
+	translate: PropTypes.func.isRequired
+};
+
+export default localize( FeatureUnavailable );

--- a/client/components/empty-content/feature-unavailable/index.jsx
+++ b/client/components/empty-content/feature-unavailable/index.jsx
@@ -10,21 +10,25 @@ import React, { PropTypes } from 'react';
 import { domainManagementEdit } from 'my-sites/upgrades/paths';
 import EmptyContent from 'components/empty-content';
 
-const FeatureUnavailable = ( { selectedSite, translate } ) => {
+/**
+ * Renders content to be displayed in response of any action not available in domain-only sites.
+ */
+const FeatureUnavailable = ( { domainName, siteId, translate } ) => {
 	return (
 		<EmptyContent
 			className={ 'feature-unavailable' }
 			title={ translate( 'Add a site to start using this feature.' ) }
 			line={ translate( 'Your domain is only set up with a temporary page. Start a site now to unlock everything WordPress.com can offer.' ) }
 			action={ translate( 'Create Site' ) }
-			actionURL={ `/start/site-selected/?siteSlug=${ encodeURIComponent( selectedSite.slug ) }&siteId=${ encodeURIComponent( selectedSite.ID ) }` }
+			actionURL={ `/start/site-selected/?siteSlug=${ encodeURIComponent( domainName ) }&siteId=${ encodeURIComponent( siteId ) }` }
 			secondaryAction={ translate( 'Manage Domain' ) }
-			secondaryActionURL={ domainManagementEdit( selectedSite.slug ) } />
+			secondaryActionURL={ domainManagementEdit( domainName, domainName ) } />
 	);
 };
 
 FeatureUnavailable.propTypes = {
-	selectedSite: PropTypes.object.isRequired,
+	domainName: PropTypes.string.isRequired,
+	siteId: PropTypes.number.isRequired,
 	translate: PropTypes.func.isRequired
 };
 

--- a/client/components/empty-content/feature-unavailable/style.scss
+++ b/client/components/empty-content/feature-unavailable/style.scss
@@ -1,0 +1,11 @@
+// Repositions the content of the page whenever the editor is requested (this is just a hack to cope with the different
+// layout applied in the editor styles)
+.is-group-editor .layout__content .feature-unavailable {
+	@media ( min-width: 661px ) {
+		padding: 9px 24px 24px 252px;
+	}
+
+	@media ( min-width: 961px ) {
+		padding: 17px 32px 32px 296px;
+	}
+}

--- a/client/components/empty-content/feature-unavailable/style.scss
+++ b/client/components/empty-content/feature-unavailable/style.scss
@@ -1,6 +1,10 @@
 // Repositions the content of the page whenever the editor is requested (this is just a hack to cope with the different
 // layout applied in the editor styles)
 .is-group-editor .layout__content .feature-unavailable {
+	@media ( max-width: 660px ) {
+		margin-top: 0;
+	}
+
 	@media ( min-width: 661px ) {
 		padding: 9px 24px 24px 252px;
 	}

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -18,7 +18,7 @@ import { preload } from 'sections-preload';
 import ResumeEditing from 'my-sites/resume-editing';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteSlug, getSiteBySlug } from 'state/sites/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 import { getStatsPathForTab } from 'lib/route/path';
 import { getCurrentUser } from 'state/current-user/selectors';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
@@ -26,7 +26,7 @@ import { domainManagementList } from 'my-sites/upgrades/paths';
 
 const MasterbarLoggedIn = React.createClass( {
 	propTypes: {
-		isDomainOnlySite: React.PropTypes.bool,
+		domainOnlySite: React.PropTypes.bool,
 		user: React.PropTypes.object,
 		sites: React.PropTypes.object,
 		section: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.bool ] ),
@@ -69,8 +69,8 @@ const MasterbarLoggedIn = React.createClass( {
 	},
 
 	render() {
-		const { isDomainOnlySite, siteSlug } = this.props,
-			mySitesUrl = isDomainOnlySite
+		const { domainOnlySite, siteSlug } = this.props,
+			mySitesUrl = domainOnlySite
 				? domainManagementList( siteSlug )
 				: getStatsPathForTab( 'day', siteSlug );
 
@@ -83,7 +83,7 @@ const MasterbarLoggedIn = React.createClass( {
 					onClick={ this.clickMySites }
 					isActive={ this.isActive( 'sites' ) }
 					tooltip={ this.translate( 'View a list of your sites and access their dashboards', { textOnly: true } ) }
-					preloadSection={ () => preload( isDomainOnlySite ? 'upgrades' : 'stats' ) }
+					preloadSection={ () => preload( domainOnlySite ? 'upgrades' : 'stats' ) }
 				>
 					{ this.props.user.get().visible_site_count > 1
 						? this.translate( 'My Sites', { comment: 'Toolbar, must be shorter than ~12 chars' } )
@@ -143,30 +143,29 @@ const MasterbarLoggedIn = React.createClass( {
 // TODO: make this pure when sites can be retrieved from the Redux state
 export default connect( ( state, { sites } ) => {
 	let siteId = getSelectedSiteId( state );
-	let siteSlug = getSiteSlug( state, siteId );
 
-	// If siteId has not been set in redux, fall back to currentUser.primarySiteSlug
 	if ( ! siteId ) {
-		const currentUser = getCurrentUser( state );
-		siteSlug = get( currentUser, 'primarySiteSlug' );
+		// Falls back to using the user's primary site if no site has been selected by the user yet
+		siteId = get( getCurrentUser( state ), 'primary_blog' );
+	}
 
-		if ( ! sites.getSite( siteSlug ) ) {
-			// The user's `primarySiteSlug` property might be stale if a site
-			// was just deleted, so we need to make sure the site is still in
-			// `sites-list`.
-			siteSlug = null;
-		}
+	let siteSlug = getSiteSlug( state, siteId );
+	let domainOnlySite = false;
 
-		// Now we can look up the site ID from its slug
-		const site = getSiteBySlug( state, siteSlug );
+	if ( siteSlug ) {
+		domainOnlySite = isDomainOnlySite( state, siteId );
+	} else {
+		// Retrieves the site from the Sites store when the global state tree doesn't contain the list of sites yet
+		const site = sites.getSite( siteId );
 
 		if ( site ) {
-			siteId = site.ID;
+			siteSlug = site.slug;
+			domainOnlySite = get( site, 'options.is_domain_only', false );
 		}
 	}
 
 	return {
 		siteSlug,
-		isDomainOnlySite: isDomainOnlySite( state, siteId ),
+		domainOnlySite
 	};
 }, { setNextLayoutFocus }, null, { pure: false } )( MasterbarLoggedIn );

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -22,7 +22,7 @@ import { getSiteSlug, getSiteBySlug } from 'state/sites/selectors';
 import { getStatsPathForTab } from 'lib/route/path';
 import { getCurrentUser } from 'state/current-user/selectors';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
-import { domainManagementEdit } from 'my-sites/upgrades/paths';
+import { domainManagementList } from 'my-sites/upgrades/paths';
 
 const MasterbarLoggedIn = React.createClass( {
 	propTypes: {
@@ -71,9 +71,7 @@ const MasterbarLoggedIn = React.createClass( {
 	render() {
 		const { isDomainOnlySite, siteSlug } = this.props,
 			mySitesUrl = isDomainOnlySite
-				// The site slug for a domain-only site is equal to its only
-				// domain, so we can use it for the domain parameter here.
-				? domainManagementEdit( siteSlug, siteSlug )
+				? domainManagementList( siteSlug )
 				: getStatsPathForTab( 'day', siteSlug );
 
 		return (

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -113,18 +113,12 @@ function renderNoVisibleSites( context ) {
 }
 
 function renderSelectedSiteIsDomainOnly( reactContext, selectedSite ) {
-	const EmptyContentComponent = require( 'components/empty-content' );
+	const FeatureUnavailable = require( 'components/empty-content/feature-unavailable' );
 	const { store: reduxStore } = reactContext;
 
-	renderWithReduxStore(
-		React.createElement( EmptyContentComponent, {
-			title: i18n.translate( 'Add a site to start using this feature.' ),
-			line: i18n.translate( 'Your domain is only set up with a temporary page. Start a site now to unlock everything WordPress.com can offer.' ),
-			action: i18n.translate( 'Create Site' ),
-			actionURL: `/start/site-selected/?siteSlug=${ encodeURIComponent( selectedSite.slug ) }&siteId=${ encodeURIComponent( selectedSite.ID ) }`,
-			secondaryAction: i18n.translate( 'Manage Domain' ),
-			secondaryActionURL: domainManagementEdit( selectedSite.slug )
-		} ),
+	renderWithReduxStore( (
+			<FeatureUnavailable selectedSite={ selectedSite } />
+		),
 		document.getElementById( 'primary' ),
 		reduxStore
 	);

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -132,7 +132,7 @@ function renderSelectedSiteIsDomainOnly( reactContext, selectedSite ) {
 	const { store: reduxStore } = reactContext;
 
 	renderWithReduxStore( (
-			<FeatureUnavailable selectedSite={ selectedSite } />
+			<FeatureUnavailable domainName={ selectedSite.slug } siteId={ selectedSite.ID } />
 		),
 		document.getElementById( 'primary' ),
 		reduxStore
@@ -146,25 +146,28 @@ function renderSelectedSiteIsDomainOnly( reactContext, selectedSite ) {
 }
 
 function isPathAllowedForDomainOnlySite( path, domainName ) {
-	const urlWhiteListForDomainOnlySite = [
-		domainManagementAddGoogleApps( domainName, domainName ),
-		domainManagementContactsPrivacy( domainName, domainName ),
-		domainManagementDns( domainName, domainName ),
-		domainManagementEdit( domainName ),
-		domainManagementEditContactInfo( domainName, domainName ),
-		domainManagementEmail( domainName, domainName ),
-		domainManagementEmailForwarding( domainName, domainName ),
-		domainManagementList( domainName, domainName ),
-		domainManagementNameServers( domainName, domainName ),
-		domainManagementPrivacyProtection( domainName, domainName ),
-		domainManagementRedirectSettings( domainName, domainName ),
-		domainManagementTransfer( domainName, domainName ),
-		domainManagementTransferOut( domainName, domainName ),
-		domainManagementTransferToAnotherUser( domainName, domainName ),
-		`/checkout/${ domainName }`,
+	const domainManagementPaths = [
+		domainManagementAddGoogleApps,
+		domainManagementContactsPrivacy,
+		domainManagementDns,
+		domainManagementEdit,
+		domainManagementEditContactInfo,
+		domainManagementEmail,
+		domainManagementEmailForwarding,
+		domainManagementList,
+		domainManagementNameServers,
+		domainManagementPrivacyProtection,
+		domainManagementRedirectSettings,
+		domainManagementTransfer,
+		domainManagementTransferOut,
+		domainManagementTransferToAnotherUser
+	].map( pathFactory => pathFactory( domainName, domainName ) );
+
+	const otherPaths = [
+		`/checkout/${ domainName }`
 	];
 
-	return urlWhiteListForDomainOnlySite.indexOf( path ) > -1;
+	return [ ...domainManagementPaths, ...otherPaths ].indexOf( path ) > -1;
 }
 
 function onSelectedSiteAvailable( context ) {

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -30,7 +30,22 @@ import utils from 'lib/site/utils';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
-import { domainManagementList, domainManagementEdit, domainManagementDns } from 'my-sites/upgrades/paths';
+import {
+	domainManagementAddGoogleApps,
+	domainManagementContactsPrivacy,
+	domainManagementDns,
+	domainManagementEdit,
+	domainManagementEditContactInfo,
+	domainManagementEmail,
+	domainManagementEmailForwarding,
+	domainManagementList,
+	domainManagementNameServers,
+	domainManagementPrivacyProtection,
+	domainManagementRedirectSettings,
+	domainManagementTransfer,
+	domainManagementTransferOut,
+	domainManagementTransferToAnotherUser
+} from 'my-sites/upgrades/paths';
 import SitesComponent from 'my-sites/sites';
 
 /**
@@ -130,15 +145,26 @@ function renderSelectedSiteIsDomainOnly( reactContext, selectedSite ) {
 	);
 }
 
-function isPathAllowedForDomainOnlySite( pathname, domainName ) {
+function isPathAllowedForDomainOnlySite( path, domainName ) {
 	const urlWhiteListForDomainOnlySite = [
-		domainManagementList( domainName ),
+		domainManagementAddGoogleApps( domainName, domainName ),
+		domainManagementContactsPrivacy( domainName, domainName ),
+		domainManagementDns( domainName, domainName ),
 		domainManagementEdit( domainName ),
-		domainManagementDns( domainName ),
+		domainManagementEditContactInfo( domainName, domainName ),
+		domainManagementEmail( domainName, domainName ),
+		domainManagementEmailForwarding( domainName, domainName ),
+		domainManagementList( domainName, domainName ),
+		domainManagementNameServers( domainName, domainName ),
+		domainManagementPrivacyProtection( domainName, domainName ),
+		domainManagementRedirectSettings( domainName, domainName ),
+		domainManagementTransfer( domainName, domainName ),
+		domainManagementTransferOut( domainName, domainName ),
+		domainManagementTransferToAnotherUser( domainName, domainName ),
 		`/checkout/${ domainName }`,
 	];
 
-	return urlWhiteListForDomainOnlySite.indexOf( pathname ) > -1;
+	return urlWhiteListForDomainOnlySite.indexOf( path ) > -1;
 }
 
 function onSelectedSiteAvailable( context ) {

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -123,7 +123,7 @@ function renderSelectedSiteIsDomainOnly( reactContext, selectedSite ) {
 			action: i18n.translate( 'Create Site' ),
 			actionURL: `/start/site-selected/?siteSlug=${ encodeURIComponent( selectedSite.slug ) }&siteId=${ encodeURIComponent( selectedSite.ID ) }`,
 			secondaryAction: i18n.translate( 'Manage Domain' ),
-			secondaryActionURL: domainManagementList( selectedSite.slug )
+			secondaryActionURL: domainManagementEdit( selectedSite.slug )
 		} ),
 		document.getElementById( 'primary' ),
 		reduxStore

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -116,8 +116,6 @@ function renderSelectedSiteIsDomainOnly( reactContext, selectedSite ) {
 	const EmptyContentComponent = require( 'components/empty-content' );
 	const { store: reduxStore } = reactContext;
 
-	removeSidebar( reactContext );
-
 	renderWithReduxStore(
 		React.createElement( EmptyContentComponent, {
 			title: i18n.translate( 'Add a site to start using this feature.' ),
@@ -128,6 +126,12 @@ function renderSelectedSiteIsDomainOnly( reactContext, selectedSite ) {
 			secondaryActionURL: domainManagementList( selectedSite.slug )
 		} ),
 		document.getElementById( 'primary' ),
+		reduxStore
+	);
+
+	renderWithReduxStore(
+		createNavigation( reactContext ),
+		document.getElementById( 'secondary' ),
 		reduxStore
 	);
 }

--- a/client/my-sites/upgrades/domain-management/list/domain-only.jsx
+++ b/client/my-sites/upgrades/domain-management/list/domain-only.jsx
@@ -16,7 +16,7 @@ const DomainOnly = ( { domainName, siteId, translate } ) => (
 		action={ translate( 'Create Site' ) }
 		actionURL={ `/start/site-selected/?siteSlug=${ encodeURIComponent( domainName ) }&siteId=${ encodeURIComponent( siteId ) }` }
 		secondaryAction={ translate( 'Manage Domain' ) }
-		secondaryActionURL={ domainManagementEdit( domainName ) }
+		secondaryActionURL={ domainManagementEdit( domainName, domainName ) }
 		illustration={ '/calypso/images/drake/drake-browser.svg' } />
 );
 

--- a/client/my-sites/upgrades/domain-management/list/domain-only.jsx
+++ b/client/my-sites/upgrades/domain-management/list/domain-only.jsx
@@ -12,13 +12,11 @@ import { domainManagementEdit } from 'my-sites/upgrades/paths';
 
 const DomainOnly = ( { domainName, siteId, translate } ) => (
 	<EmptyContent
-		title={ translate( '%(domainName)s is not set up yet.', {
-			args: { domainName }
-		} ) }
+		title={ translate( '%(domainName)s is not set up yet.', { args: { domainName } } ) }
 		action={ translate( 'Create Site' ) }
 		actionURL={ `/start/site-selected/?siteSlug=${ encodeURIComponent( domainName ) }&siteId=${ encodeURIComponent( siteId ) }` }
 		secondaryAction={ translate( 'Manage Domain' ) }
-		secondaryActionURL={ domainManagementEdit( domainName, domainName ) }
+		secondaryActionURL={ domainManagementEdit( domainName ) }
 		illustration={ '/calypso/images/drake/drake-browser.svg' } />
 );
 

--- a/client/my-sites/upgrades/paths.js
+++ b/client/my-sites/upgrades/paths.js
@@ -13,9 +13,6 @@ function domainManagementList( siteName ) {
 }
 
 function domainManagementEdit( siteName, domainName, slug ) {
-	// the site slug and domain name are equivalent for domain-only sites,
-	// which can omit the latter in this case.
-	domainName = domainName || siteName;
 	slug = slug || 'edit';
 
 	// Encodes only real domain names and not parameter placeholders
@@ -113,12 +110,12 @@ module.exports = {
 	domainManagementEditContactInfo,
 	domainManagementEmail,
 	domainManagementEmailForwarding,
-	domainManagementNameServers,
 	domainManagementList,
-	domainManagementPrivacyProtection,
-	domainManagementRoot,
-	domainManagementRedirectSettings,
+	domainManagementNameServers,
 	domainManagementPrimaryDomain,
+	domainManagementPrivacyProtection,
+	domainManagementRedirectSettings,
+	domainManagementRoot,
 	domainManagementTransfer,
 	domainManagementTransferOut,
 	domainManagementTransferToAnotherUser,


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/wp-calypso/issues/11443 and addresses other issues - some of them mentioned in https://github.com/Automattic/wp-calypso/issues/11430. More specifically, this pull request:

* Updates the `My Site` link in the top bar to target the `Domains` page
* Fixes a bug that would make that link point to the `Stats` page in certain cases
* Brings back the sidebar in the `Add a site to start using this feature` page
* Updates the `Manage Domain` button on that page to target the `Domain Settings` page
* Grants access to subsections of the `Domain Settings` page

#### Testing instructions
 
1. Run `git checkout fix/my-sites-for-domain-only` and start your server, or open a [live branch](https://calypso.live/?branch=fix/my-sites-for-domain-only)
2. Open a tab in incognito mode
3. [Log into](https://wordpress.com/wp-login.php) WordPress.com using an account with a domain-only site
4. Open the [`Reader` page](http://calypso.localhost:3000)
5. Check that the `My Site` link in the top bar points to the [`Domains` page](http://calypso.localhost:3000/domains/manage/:domain)
6. Click it and check that you are presented with the `<domain> is not set up yet` page
7. Click the `Write` button in the top bar
8. Check that you are presented with the `Add a site to start using this feature` page now
9. Check that the sidebar is displayed, with only `Settings` in the list of options
10. Click the  `Manage Domain` button
11. Check that you are presented with the [`Domain Settings` page](http://calypso.localhost:3000/domains/manage/:domain/edit/:domain)
12. Check that you can navigate in any of the subpages (e.g. the [`Email Forwarding` page](http://calypso.localhost:3000/domains/manage/:domain/email-forwarding/:domain)

Check everything again with a small viewport to simulate a mobile device.

#### Additional notes
 
I wasn't able to restore the light gray background on the `Editor` pages because of the way this color is set for this section (it's overridden via a CSS rule that is too high in the HTML tree). However the white background isn't so different so this might be an acceptable solution for now.
 
#### Reviews
 
- [x] Code
- [x] Product
- [x] Tests