### PR TITLE
Themes: On Jetpack sites, include id field in query

### DIFF
--- a/client/state/themes/test/utils.js
+++ b/client/state/themes/test/utils.js
@@ -261,6 +261,7 @@ describe( 'utils', () => {
 
 	describe( '#matches()', () => {
 		const DEFAULT_THEME = {
+			id: 'twentysomething',
 			name: 'Twenty Something',
 			author: 'the WordPress team',
 			screenshot: 'https://i0.wp.com/theme.wordpress.com/wp-content/themes/pub/twentysomething/screenshot.png',
@@ -311,17 +312,25 @@ describe( 'utils', () => {
 				expect( isMatch ).to.be.false;
 			} );
 
-			it( 'should return true for a matching title search', () => {
+			it( 'should return true for a falsey search', () => {
 				const isMatch = isThemeMatchingQuery( {
-					search: 'Twenty'
+					search: null
 				}, DEFAULT_THEME );
 
 				expect( isMatch ).to.be.true;
 			} );
 
-			it( 'should return true for a falsey title search', () => {
+			it( 'should return true for a matching ID search', () => {
 				const isMatch = isThemeMatchingQuery( {
-					search: null
+					search: 'twentysomething'
+				}, DEFAULT_THEME );
+
+				expect( isMatch ).to.be.true;
+			} );
+
+			it( 'should return true for a matching title search', () => {
+				const isMatch = isThemeMatchingQuery( {
+					search: 'Twenty'
 				}, DEFAULT_THEME );
 
 				expect( isMatch ).to.be.true;

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -235,6 +235,7 @@ export function isThemeMatchingQuery( query, theme ) {
 				) );
 
 				return foundInTaxonomies || (
+					( theme.id && includes( theme.id.toLowerCase(), search ) ) ||
 					( theme.name && includes( theme.name.toLowerCase(), search ) ) ||
 					( theme.author && includes( theme.author.toLowerCase(), search ) ) ||
 					( theme.descriptionLong && includes( theme.descriptionLong.toLowerCase(), search ) )


### PR DESCRIPTION
To test: In single-site-jetpack mode, search for a theme ID (e.g. `twentyfourteen`) and verify that the corresponding locally installed theme is returned by search.

We're implementing the same thing for WP.com sites in D4442-code. As we're still not able to query Jetpack sites for themes via their endpoint, we rely on our own little client-side search method. Consequently, we need to add the same search capability here.