### PR TITLE
AT: Disable Jetpack and VaultPress in list of plugins

### DIFF
--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
@@ -11,6 +11,7 @@ import { translate } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import DisconnectJetpackDialog from 'my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog';
+import { isSiteAutomatedTransfer } from 'state/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 class DisconnectJetpackButton extends Component {
@@ -28,9 +29,13 @@ class DisconnectJetpackButton extends Component {
 	};
 
 	render() {
+		if ( this.props.hideOnAutomatedTransfer ) {
+			return null;
+		}
+
 		const { site, redirect, linkDisplay } = this.props;
 
-		const omitProps = [ 'site', 'redirect', 'isMock', 'linkDisplay', 'text', 'recordGoogleEvent' ];
+		const omitProps = [ 'hideOnAutomatedTransfer', 'site', 'redirect', 'isMock', 'linkDisplay', 'text', 'recordGoogleEvent' ];
 		const buttonProps = {
 			...omit( this.props, omitProps ),
 			id: `disconnect-jetpack-${ site.ID }`,
@@ -58,6 +63,7 @@ class DisconnectJetpackButton extends Component {
 }
 
 DisconnectJetpackButton.propTypes = {
+	hideOnAutomatedTransfer: PropTypes.bool,
 	site: PropTypes.object.isRequired,
 	redirect: PropTypes.string.isRequired,
 	disabled: PropTypes.bool,
@@ -67,10 +73,13 @@ DisconnectJetpackButton.propTypes = {
 };
 
 DisconnectJetpackButton.defaultProps = {
+	hideOnAutomatedTransfer: false,
 	linkDisplay: true
 };
 
 export default connect(
-	null,
+	( state, { site } ) => ( {
+		hideOnAutomatedTransfer: isSiteAutomatedTransfer( state, site.ID ),
+	} ),
 	{ recordGoogleEvent }
 )( DisconnectJetpackButton );

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -14,6 +14,7 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import pluginsAccessControl from 'my-sites/plugins/access-control';
 import PluginItem from './plugin-item/plugin-item';
 import DocumentHead from 'components/data/document-head';
+import QuerySites from 'components/data/query-sites';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
@@ -386,6 +387,7 @@ const PluginsMain = React.createClass( {
 		return (
 			<Main className={ containerClass }>
 				{ this.renderDocumentHead() }
+				<QuerySites allSites />
 				<SidebarNavigation />
 				<SectionNav selectedText={ this.getSelectedText() }>
 					<NavTabs>

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -12,6 +13,7 @@ import PluginsActions from 'lib/plugins/actions';
 import PluginsLog from 'lib/plugins/log-store';
 import PluginAction from 'my-sites/plugins/plugin-action/plugin-action';
 import DisconnectJetpackButton from 'my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button';
+import { isSiteAutomatedTransfer } from 'state/selectors';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 
 export class PluginActivateToggle extends Component {
@@ -48,9 +50,9 @@ export class PluginActivateToggle extends Component {
 	};
 
 	render() {
-		const { site, plugin, isMock, disabled, translate } = this.props;
+		const { hideOnAutomatedTransfer, site, plugin, isMock, disabled, translate } = this.props;
 
-		if ( ! site ) {
+		if ( ! site || hideOnAutomatedTransfer ) {
 			return null;
 		}
 
@@ -89,6 +91,7 @@ export class PluginActivateToggle extends Component {
 }
 
 PluginActivateToggle.propTypes = {
+	hideOnAutomatedTransfer: PropTypes.bool,
 	site: PropTypes.object.isRequired,
 	plugin: PropTypes.object.isRequired,
 	notices: React.PropTypes.object,
@@ -97,12 +100,15 @@ PluginActivateToggle.propTypes = {
 };
 
 PluginActivateToggle.defaultProps = {
+	hideOnAutomatedTransfer: false,
 	isMock: false,
 	disabled: false,
 };
 
 export default connect(
-	null,
+	( state, { plugin, site } ) => ( {
+		hideOnAutomatedTransfer: isSiteAutomatedTransfer( state, site.ID ) && includes( [ 'jetpack', 'vaultpress' ], plugin.slug ),
+	} ),
 	{
 		recordGoogleEvent,
 		recordTracksEvent

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -12,6 +13,7 @@ import PluginsActions from 'lib/plugins/actions';
 import PluginsLog from 'lib/plugins/log-store';
 import PluginAction from 'my-sites/plugins/plugin-action/plugin-action';
 import ExternalLink from 'components/external-link';
+import { isSiteAutomatedTransfer } from 'state/selectors';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import utils from 'lib/site/utils';
 
@@ -113,8 +115,8 @@ export class PluginAutoUpdateToggle extends Component {
 	}
 
 	render() {
-		const { site, plugin, translate, disabled } = this.props;
-		if ( ! site.jetpack ) {
+		const { hideOnAutomatedTransfer, site, plugin, translate, disabled } = this.props;
+		if ( ! site.jetpack || hideOnAutomatedTransfer ) {
 			return null;
 		}
 
@@ -145,6 +147,7 @@ export class PluginAutoUpdateToggle extends Component {
 }
 
 PluginAutoUpdateToggle.propTypes = {
+	hideOnAutomatedTransfer: PropTypes.bool,
 	isMock: PropTypes.bool,
 	site: PropTypes.object.isRequired,
 	plugin: PropTypes.object.isRequired,
@@ -153,12 +156,15 @@ PluginAutoUpdateToggle.propTypes = {
 };
 
 PluginAutoUpdateToggle.defaultProps = {
+	hideOnAutomatedTransfer: false,
 	isMock: false,
 	disabled: false,
 };
 
 export default connect(
-	null,
+	( state, { plugin, site } ) => ( {
+		hideOnAutomatedTransfer: isSiteAutomatedTransfer( state, site.ID ) && includes( [ 'jetpack', 'vaultpress' ], plugin.slug ),
+	} ),
 	{
 		recordGoogleEvent,
 		recordTracksEvent

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { includes } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
@@ -9,16 +11,14 @@ import Gridicon from 'gridicons';
  */
 import analytics from 'lib/analytics';
 import accept from 'lib/accept';
+import { isSiteAutomatedTransfer } from 'state/selectors';
 import PluginsLog from 'lib/plugins/log-store';
 import PluginAction from 'my-sites/plugins/plugin-action/plugin-action';
 import PluginsActions from 'lib/plugins/actions';
 import ExternalLink from 'components/external-link';
 import utils from 'lib/site/utils';
 
-module.exports = React.createClass( {
-
-	displayName: 'PluginRemoveButton',
-
+const PluginRemoveButton = React.createClass( {
 	removeAction() {
 		accept( this.translate( 'Are you sure you want to remove {{strong}}%(pluginName)s{{/strong}} from %(siteName)s? {{br /}} {{em}}This will deactivate the plugin and delete all associated files and data.{{/em}}', {
 			components: {
@@ -150,7 +150,7 @@ module.exports = React.createClass( {
 	},
 
 	render() {
-		if ( ! this.props.site.jetpack ) {
+		if ( ! this.props.site.jetpack || this.props.hideOnAutomatedTransfer ) {
 			return null;
 		}
 
@@ -162,3 +162,22 @@ module.exports = React.createClass( {
 	}
 } );
 
+PluginRemoveButton.propTypes = {
+	hideOnAutomatedTransfer: PropTypes.bool,
+	isEmbed: PropTypes.bool,
+	notices: PropTypes.object,
+	plugin: PropTypes.object.isRequired,
+	site: PropTypes.object.isRequired,
+};
+
+PluginRemoveButton.defaultProps = {
+	hideOnAutomatedTransfer: false,
+	isEmbed: false,
+	notices: {},
+};
+
+export default connect(
+	( state, { plugin, site } ) => ( {
+		hideOnAutomatedTransfer: isSiteAutomatedTransfer( state, site.ID ) && includes( [ 'jetpack', 'vaultpress' ], plugin.slug ),
+	} ),
+)( PluginRemoveButton );

--- a/client/my-sites/plugins/plugin-site/plugin-site.jsx
+++ b/client/my-sites/plugins/plugin-site/plugin-site.jsx
@@ -2,15 +2,18 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import PluginSiteJetpack from 'my-sites/plugins/plugin-site-jetpack';
 import PluginSiteNetwork from 'my-sites/plugins/plugin-site-network';
+import { isSiteAutomatedTransfer } from 'state/selectors';
 
 const PluginSite = ( props ) => {
-	if ( ! props.site ) {
+	if ( ! props.site || props.hideOnAutomatedTransfer ) {
 		return null;
 	}
 
@@ -21,4 +24,8 @@ const PluginSite = ( props ) => {
 	return <PluginSiteJetpack { ...props } />;
 };
 
-export default PluginSite;
+export default connect(
+	( state, { plugin, site } ) => ( {
+		hideOnAutomatedTransfer: isSiteAutomatedTransfer( state, site.ID ) && includes( [ 'jetpack', 'vaultpress' ], plugin.slug ),
+	} ),
+)( PluginSite );

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import config from 'config';
 import { connect } from 'react-redux';
 import page from 'page';
-import { uniq, upperFirst } from 'lodash';
+import { get, includes, some, uniq, upperFirst } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,6 +28,7 @@ import pluginsAccessControl from 'my-sites/plugins/access-control';
 import EmptyContent from 'components/empty-content';
 import FeatureExample from 'components/feature-example';
 import DocumentHead from 'components/data/document-head';
+import QuerySites from 'components/data/query-sites';
 import WpcomPluginsList from 'my-sites/plugins-wpcom/plugins-list';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, canJetpackSiteManage, getRawSite } from 'state/sites/selectors';
@@ -219,7 +220,12 @@ const SinglePlugin = React.createClass( {
 	},
 
 	renderSitesList( plugin ) {
-		if ( this.props.siteUrl || this.isFetching() ) {
+		const hideOnAutomatedTransfer = (
+			includes( [ 'jetpack', 'vaultpress' ], plugin.slug ) &&
+			! some( plugin.sites, ( site ) => ! get( site, 'options.is_automated_transfer', false ) )
+		);
+
+		if ( this.props.siteUrl || this.isFetching() || hideOnAutomatedTransfer ) {
 			return;
 		}
 
@@ -375,6 +381,7 @@ const SinglePlugin = React.createClass( {
 		return (
 			<MainComponent>
 				{ this.renderDocumentHead() }
+				<QuerySites allSites />
 				<SidebarNavigation />
 				<div className="plugin__page">
 					{ this.displayHeader() }

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -4,7 +4,7 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { find, includes, isEmpty, isEqual, negate, range } from 'lodash';
+import { find, includes, isEmpty, isEqual, get, negate, range } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -153,7 +153,12 @@ export const PluginsList = React.createClass( {
 	},
 
 	hasNoSitesThatCanManage( plugin ) {
-		return ! plugin.sites.some( site => includes( site.modules || [], 'manage' ) );
+		return ( ! plugin.sites.some( ( site ) => includes( site.modules || [], 'manage' ) ) ||
+			(
+				includes( [ 'jetpack', 'vaultpress' ], plugin.slug ) &&
+				! plugin.sites.some( ( site ) => ! get( site, 'options.is_automated_transfer', false ) )
+			)
+		);
 	},
 
 	getSelected() {


### PR DESCRIPTION
This PR adds filters to disable Jetpack and VaultPress in the plugin list, when the current site was an Automated Transfer. They'll also be excluded from bulk management.

Both plugins are needed to ensure AT sites continue to work on Pressable and can communicate with wp.com.

Fixes 84-gh-automated-transfer