### PR TITLE
Site Picker: Fix site picker when path is not exactly `/sites`

### DIFF
--- a/client/my-sites/sites/sites.jsx
+++ b/client/my-sites/sites/sites.jsx
@@ -52,7 +52,7 @@ export default React.createClass( {
 
 	onSiteSelect: function( slug ) {
 		let path = this.props.path;
-		if ( path === '/sites' ) {
+		if ( /^\/sites/.test( path ) ) {
 			path = '/stats/insights';
 		}
 		page( addSiteFragment( path, slug ) );


### PR DESCRIPTION
Fixes #11543

You should now be able to choose a site when the path is `http://wordpress.com/sites/yoursiteurl.com` 