### PR TITLE
Sharing: Don't display services when there are none.

### DIFF
--- a/client/my-sites/sharing/connections/services-group.jsx
+++ b/client/my-sites/sharing/connections/services-group.jsx
@@ -8,7 +8,7 @@ import { times } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getEligibleKeyringServices } from 'state/sharing/services/selectors';
+import { getEligibleKeyringServices, isKeyringServicesFetching } from 'state/sharing/services/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import SectionHeader from 'components/section-header';
 import Service from './service';
@@ -19,36 +19,45 @@ import ServicePlaceholder from './service-placeholder';
  */
 const NUMBER_OF_PLACEHOLDERS = 4;
 
-const SharingServicesGroup = ( { connections, services, title } ) => (
-	<div className="sharing-services-group">
-		<SectionHeader label={ title } />
-		<ul className="sharing-services-group__services">
-			{ services.length
-				? services.map( ( service ) => (
-					<Service key={ service.ID } connections={ connections } service={ service } />
-				) )
-				: times( NUMBER_OF_PLACEHOLDERS, ( index ) => (
-					<ServicePlaceholder key={ 'service-placeholder-' + index } />
-				) )
-			}
-		</ul>
-	</div>
-);
+const SharingServicesGroup = ( { connections, isFetching, services, title } ) => {
+	if ( ! services.length && ! isFetching ) {
+		return null;
+	}
+
+	return (
+		<div className="sharing-services-group">
+			<SectionHeader label={ title } />
+			<ul className="sharing-services-group__services">
+				{ services.length
+					? services.map( ( service ) => (
+						<Service key={ service.ID } connections={ connections } service={ service } />
+					) )
+					: times( NUMBER_OF_PLACEHOLDERS, ( index ) => (
+						<ServicePlaceholder key={ 'service-placeholder-' + index } />
+					) )
+				}
+			</ul>
+		</div>
+	);
+};
 
 SharingServicesGroup.propTypes = {
 	connections: PropTypes.object,
+	isFetching: PropTypes.bool,
 	services: PropTypes.array,
 	title: PropTypes.string.isRequired,
 	type: PropTypes.string.isRequired,
 };
 
 SharingServicesGroup.defaultProps = {
-	connections: Object.freeze( {} ),
-	services: Object.freeze( [] ),
+	connections: {},
+	isFetching: false,
+	services: [],
 };
 
 export default connect(
 	( state, { type } ) => ( {
+		isFetching: isKeyringServicesFetching( state ),
 		services: getEligibleKeyringServices( state, getSelectedSiteId( state ), type )
 	} ),
 )( SharingServicesGroup );


### PR DESCRIPTION
Only displays services placeholders when Services are being fetched.

Fixes a bug where "Other Connections" were shown as loading forever because `ServiceGroup` would just fall back to the loading indicator when there are no services.

Fixes #11542.