### PR TITLE
Jetpack Connect

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -225,7 +225,6 @@ const LoggedInForm = React.createClass( {
 
 	componentWillReceiveProps( props ) {
 		const {
-			authorizationCode,
 			siteReceived,
 			isActivating,
 			queryObject,
@@ -267,10 +266,6 @@ const LoggedInForm = React.createClass( {
 			this.retryingAuth = true;
 			return this.props.retryAuth( queryObject.site, attempts + 1 );
 		}
-		if ( props.isAlreadyOnSitesList && ! queryObject.already_authorized && ! props.isFetchingSites && ! this.retryingAuth ) {
-			this.retryingAuth = true;
-			return this.props.goToXmlrpcErrorFallbackUrl( queryObject, authorizationCode );
-		}
 	},
 
 	renderFormHeader( isConnected ) {
@@ -300,6 +295,7 @@ const LoggedInForm = React.createClass( {
 		debug( 'Activating Manage module and calculating redirection', queryObject );
 		this.props.activateManage( queryObject.client_id, queryObject.state, activateManageSecret );
 		if ( 'jpo' === queryObject.from || this.props.isSSO ) {
+			debug( 'Going back to WP Admin.', 'Connection initiated via: ', queryObject.from, 'SSO found:', this.props.isSSO );
 			this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
 		} else {
 			page.redirect( this.getRedirectionTarget() );

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -196,6 +196,7 @@ export default {
 				url: url,
 				type: 'remote_auth'
 			} );
+			debug( 'goToRemoteAuth', url );
 			externalRedirect(
 				addQueryArgs( {
 					calypso_env: calypsoEnv
@@ -215,6 +216,7 @@ export default {
 				url: url,
 				attempt: attemptNumber
 			} );
+			debug( 'retryAuth', url );
 			externalRedirect(
 				addQueryArgs( {
 					jetpack_connect_url: url + remoteAuthPath,
@@ -265,6 +267,7 @@ export default {
 			dispatch( {
 				type: JETPACK_CONNECT_REDIRECT_WP_ADMIN
 			} );
+			debug( 'goBackToWpAdmin', url );
 			externalRedirect( url );
 		};
 	},
@@ -278,6 +281,7 @@ export default {
 				type: JETPACK_CONNECT_REDIRECT_XMLRPC_ERROR_FALLBACK_URL,
 				url
 			} );
+			debug( 'goToXmlrpcErrorFallbackUrl', queryObject, authorizationCode );
 			externalRedirect( url );
 		};
 	},


### PR DESCRIPTION
- adding more debug statements to Jetpack connect
- fixing logic that was causing the plans page to be bypassed

This fixes an issue in Jetpack Connect where when we try to connect a site that does not have a plan, we land on the plans page, then after a few seconds, we are directed back to wp-admin before we are able to select a plan.

The logic in #11261 was a little off, and I believe this PR fixes it.
