### PR TITLE
Stats: Add additional bars to week and month charts.

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -261,16 +261,10 @@ const connectComponent = connect(
 		const momentSiteZone = moment().utcOffset( timezoneOffset );
 		let date = rangeOfPeriod( period, momentSiteZone.locale( 'en' ) ).endOf;
 
-		let quantity = 10;
+		let quantity = 30;
 		switch ( period ) {
-			case 'day':
-				quantity = 30;
-				break;
-			case 'month':
-				quantity = 12;
-				break;
-			case 'week':
-				quantity = 13;
+			case 'year':
+				quantity = 10;
 				break;
 		}
 		const periodDifference = moment( date ).diff( moment( queryDate ), period );


### PR DESCRIPTION
This branch seeks to close #11377 - by setting the number of bars in the stats chart to 30 for Days, Weeks, and Months.  By adding more periods to the weeks and months charts, users will be able to see fluctuations in traffic over time easier - something that has been requested.

__To Test__
- Visit a site stats page
- Navigate to the Week, and Months pages, note the chart now shows up to 30 entries, just like Days.