### PR TITLE
Gravatar: Update tests to use Enzyme

### DIFF
--- a/client/components/gravatar/test/index.jsx
+++ b/client/components/gravatar/test/index.jsx
@@ -1,96 +1,108 @@
 /**
  * External dependencies
  */
-import assert from 'assert';
-import ReactDomServer from 'react-dom/server';
+import { expect } from 'chai';
 import React from 'react';
+import { shallow } from 'enzyme';
 
 /**
  * Internal dependencies
  */
 import { Gravatar } from '../';
 
-/**
- * Pass in a react-generated html string to remove react-specific attributes
- * to make it easier to compare to expected html structure
- * @param {string} string react-generated html
- * @return {string} HTML without react attributes
- */
-function stripReactAttributes( string ) {
-	return string.replace( /\sdata\-(reactid|react\-checksum)\=\"[^\"]+\"/g, '' );
-}
+describe( 'Gravatar', () => {
+	/**
+	 * Gravatar URLs use email hashes
+	 * Here we're hashing MyEmailAddress@example.com
+	 * @see https://en.gravatar.com/site/implement/hash/
+	 */
+	const gravatarHash = 'f9879d71855b5ff21e4963273a886bfc';
 
-describe( 'Gravatar', function() {
-	const bobTester = {
-		avatar_URL: 'https://0.gravatar.com/avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&d=identicon',
+	const avatarUrl = `https://0.gravatar.com/avatar/${ gravatarHash }?s=96&d=mm`;
+
+	const genericUser = {
+		avatar_URL: avatarUrl,
 		display_name: 'Bob The Tester'
 	};
 
 	describe( 'rendering', function() {
 		it( 'should render an image given a user with valid avatar_URL, with default width and height 32', function() {
-			const gravatar = <Gravatar user={ bobTester } />;
-			const expectedResultString = '<img alt="Bob The Tester" ' +
-				'class="gravatar" ' +
-				'src="https://0.gravatar.com/' +
-				'avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&amp;d=mm" ' +
-				'width="32" height="32"/>';
+			const gravatar = shallow( <Gravatar user={ genericUser } /> );
+			const img = gravatar.find( 'img' );
 
-			assert.equal( expectedResultString, stripReactAttributes( ReactDomServer.renderToStaticMarkup( gravatar ) ) );
+			expect( img.length ).to.equal( 1 );
+			expect( img.prop( 'src' ) ).to.equal( avatarUrl );
+			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
+			expect( img.prop( 'width' ) ).to.equal( 32 );
+			expect( img.prop( 'height' ) ).to.equal( 32 );
 		} );
 
 		it( 'should update the width and height when given a size attribute', function() {
-			const gravatar = <Gravatar user={ bobTester } size={ 100 } />;
-			const expectedResultString = '<img alt="Bob The Tester" ' +
-				'class="gravatar" ' +
-				'src="https://0.gravatar.com/' +
-				'avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&amp;d=mm" ' +
-				'width="100" height="100"/>';
+			const gravatar = shallow(
+				<Gravatar user={ genericUser } size={ 100 } />
+			);
+			const img = gravatar.find( 'img' );
 
-			assert.equal( expectedResultString, stripReactAttributes( ReactDomServer.renderToStaticMarkup( gravatar ) ) );
+			expect( img.length ).to.equal( 1 );
+			expect( img.prop( 'src' ) ).to.equal( avatarUrl );
+			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
+			expect( img.prop( 'width' ) ).to.equal( 100 );
+			expect( img.prop( 'height' ) ).to.equal( 100 );
 		} );
 
 		it( 'should update source image when given imgSize attribute', function() {
-			const gravatar = <Gravatar user={ bobTester } imgSize={ 200 } />;
-			const expectedResultString = '<img alt="Bob The Tester" ' +
-				'class="gravatar" ' +
-				'src="https://0.gravatar.com/' +
-				'avatar/cf55adb1a5146c0a11a808bce7842f7b?s=200&amp;d=mm" ' +
-				'width="32" height="32"/>';
+			const gravatar = shallow(
+				<Gravatar user={ genericUser } imgSize={ 200 } />
+			);
+			const img = gravatar.find( 'img' );
 
-			assert.equal( expectedResultString, stripReactAttributes( ReactDomServer.renderToStaticMarkup( gravatar ) ) );
+			expect( img.length ).to.equal( 1 );
+			expect( img.prop( 'src' ) ).to
+				.equal( `https://0.gravatar.com/avatar/${ gravatarHash }?s=200&d=mm` );
+			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
+			expect( img.prop( 'width' ) ).to.equal( 32 );
+			expect( img.prop( 'height' ) ).to.equal( 32 );
 		} );
 
 		it( 'should serve a default image if no avatar_URL available', function() {
-			const noImageTester = { display_name: 'Bob The Tester' };
-			const gravatar = <Gravatar user={ noImageTester } />;
-			const expectedResultString = '<img alt="Bob The Tester" ' +
-				'class="gravatar" ' +
-				'src="https://www.gravatar.com/avatar/0?s=96&amp;d=mm" ' +
-				'width="32" height="32"/>';
+			const noImageUser = { display_name: 'Bob The Tester' };
+			const gravatar = shallow( <Gravatar user={ noImageUser } /> );
+			const img = gravatar.find( 'img' );
 
-			assert.equal( expectedResultString, stripReactAttributes( ReactDomServer.renderToStaticMarkup( gravatar ) ) );
+			expect( img.length ).to.equal( 1 );
+			expect( img.prop( 'src' ) )
+				.to.equal( 'https://www.gravatar.com/avatar/0?s=96&d=mm' );
+			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
+			expect( img.prop( 'width' ) ).to.equal( 32 );
+			expect( img.prop( 'height' ) ).to.equal( 32 );
 		} );
 
 		it( 'should allow overriding the alt attribute', function() {
-			const gravatar = <Gravatar user={ bobTester } alt="Alternate Alt" />;
-			const expectedResultString = '<img alt="Alternate Alt" ' +
-				'class="gravatar" ' +
-				'src="https://0.gravatar.com/' +
-				'avatar/cf55adb1a5146c0a11a808bce7842f7b?s=96&amp;d=mm" ' +
-				'width="32" height="32"/>';
+			const gravatar = shallow(
+				<Gravatar user={ genericUser } alt="Another Alt" />
+			);
+			const img = gravatar.find( 'img' );
 
-			assert.equal( expectedResultString, stripReactAttributes( ReactDomServer.renderToStaticMarkup( gravatar ) ) );
+			expect( img.length ).to.equal( 1 );
+			expect( img.prop( 'src' ) ).to.equal( avatarUrl );
+			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
+			expect( img.prop( 'width' ) ).to.equal( 32 );
+			expect( img.prop( 'height' ) ).to.equal( 32 );
+			expect( img.prop( 'alt' ) ).to.equal( 'Another Alt' );
 		} );
 
 		// I believe jetpack sites could have custom avatars, so can't assume it's always a gravatar
 		it( 'should promote non-secure avatar urls to secure', function() {
-			const nonSecureTester = { avatar_URL: 'http://www.example.com/avatar' };
-			const gravatar = <Gravatar user={ nonSecureTester } />;
-			const expectedResultString = '<img class="gravatar" ' +
-				'src="https://i2.wp.com/www.example.com/avatar?resize=96%2C96" ' +
-				'width="32" height="32"/>';
+			const nonSecureUrlUser = { avatar_URL: 'http://www.example.com/avatar' };
+			const gravatar = shallow( <Gravatar user={ nonSecureUrlUser } /> );
+			const img = gravatar.find( 'img' );
 
-			assert.equal( expectedResultString, stripReactAttributes( ReactDomServer.renderToStaticMarkup( gravatar ) ) );
+			expect( img.length ).to.equal( 1 );
+			expect( img.prop( 'src' ) )
+				.to.equal( 'https://i2.wp.com/www.example.com/avatar?resize=96%2C96' );
+			expect( img.hasClass( 'gravatar' ) ).to.equal( true );
+			expect( img.prop( 'width' ) ).to.equal( 32 );
+			expect( img.prop( 'height' ) ).to.equal( 32 );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR changes the unit tests for `<Gravatar />` to use Enzyme. This is needed in order to write some new tests in #11554

To test: checkout this branch, and run the tests