### PR TITLE
Connect the <ResetPasswordForm /> component with the underlying states.

### DIFF
--- a/client/account-recovery/reset-password/reset-password-form/index.jsx
+++ b/client/account-recovery/reset-password/reset-password-form/index.jsx
@@ -13,8 +13,7 @@ import Card from 'components/card';
 import Button from 'components/button';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLegend from 'components/forms/form-legend';
-import FormLabel from 'components/forms/form-label';
-import FormRadio from 'components/forms/form-radio';
+import ResetOptionSet from './reset-option-set';
 
 import { getAccountRecoveryResetOptions } from 'state/selectors';
 
@@ -44,7 +43,11 @@ export class ResetPasswordFormComponent extends Component {
 	};
 
 	render() {
-		const { translate } = this.props;
+		const {
+			resetOptions,
+			translate
+		} = this.props;
+
 		const { isSubmitting, selectedResetOption } = this.state;
 		const isPrimaryButtonEnabled = selectedResetOption && ! isSubmitting;
 
@@ -64,48 +67,15 @@ export class ResetPasswordFormComponent extends Component {
 						<FormLegend className="reset-password-form__legend">
 							{ translate( 'How would you like to reset your password?' ) }
 						</FormLegend>
-						<FormLabel>
-							<FormRadio
-								className="reset-password-form__primary-email-option"
-								value="primaryEmail"
-								checked={ 'primaryEmail' === selectedResetOption }
-								disabled={ isSubmitting }
-								onChange={ this.onResetOptionChanged } />
-							<span>
-								{ translate(
-									'Email a reset link to {{strong}}your main email address{{/strong}}',
-									{ components: { strong: <strong /> } }
-								) }
-							</span>
-						</FormLabel>
-						<FormLabel>
-							<FormRadio
-								className="reset-password-form__secondary-email-option"
-								value="secondaryEmail"
-								checked={ 'secondaryEmail' === selectedResetOption }
-								disabled={ isSubmitting }
-								onChange={ this.onResetOptionChanged } />
-							<span>
-								{ translate(
-									'Email a reset link to {{strong}}your recovery email address{{/strong}}',
-									{ components: { strong: <strong /> } }
-								) }
-							</span>
-						</FormLabel>
-						<FormLabel>
-							<FormRadio
-								className="reset-password-form__sms-option"
-								value="sms"
-								checked={ 'sms' === selectedResetOption }
-								disabled={ isSubmitting }
-								onChange={ this.onResetOptionChanged } />
-							<span>
-								{ translate(
-									'Send a reset code to {{strong}}your phone{{/strong}}',
-									{ components: { strong: <strong /> } }
-								) }
-							</span>
-						</FormLabel>
+						{ resetOptions.map( ( resetOption ) => (
+							<ResetOptionSet
+								email={ resetOption.email }
+								sms={ resetOption.sms }
+								name={ resetOption.name }
+								onOptionChanged={ this.onResetOptionChanged }
+								selectedResetOption={ selectedResetOption }
+							/>
+						) ) }
 					</FormFieldset>
 					<Button
 						className="reset-password-form__submit-button"

--- a/client/account-recovery/reset-password/reset-password-form/index.jsx
+++ b/client/account-recovery/reset-password/reset-password-form/index.jsx
@@ -67,11 +67,12 @@ export class ResetPasswordFormComponent extends Component {
 						<FormLegend className="reset-password-form__legend">
 							{ translate( 'How would you like to reset your password?' ) }
 						</FormLegend>
-						{ resetOptions.map( ( resetOption ) => (
+						{ resetOptions.map( ( resetOption, index ) => (
 							<ResetOptionSet
+								key={ index }
 								email={ resetOption.email }
 								sms={ resetOption.sms }
-								name={ resetOption.name }
+								name={ 'todo' }
 								onOptionChanged={ this.onResetOptionChanged }
 								selectedResetOption={ selectedResetOption }
 							/>
@@ -94,4 +95,4 @@ export default connect(
 	( state ) => ( {
 		resetOptions: getAccountRecoveryResetOptions( state ),
 	} )
-, localize( ResetPasswordFormComponent ) );
+)( localize( ResetPasswordFormComponent ) );

--- a/client/account-recovery/reset-password/reset-password-form/index.jsx
+++ b/client/account-recovery/reset-password/reset-password-form/index.jsx
@@ -42,6 +42,37 @@ export class ResetPasswordFormComponent extends Component {
 		this.setState( { selectedResetOption: event.currentTarget.value } );
 	};
 
+	getOptionDisplayStrings = ( optionName ) => {
+		const { translate } = this.props;
+
+		switch ( optionName ) {
+			case 'primary':
+				return {
+					email: translate(
+						'Email a reset link to {{strong}}your main email address{{/strong}}',
+						{ components: { strong: <strong /> } }
+					),
+					sms: translate(
+						'Send a reset code to {{strong}}your main phone{{/strong}}',
+						{ components: { strong: <strong /> } }
+					),
+				};
+			case 'secondary':
+				return {
+					email: translate(
+						'Email a reset link to {{strong}}your recovery email address{{/strong}}',
+						{ components: { strong: <strong /> } }
+					),
+					sms: translate(
+						'Send a reset code to {{strong}}your recovery phone{{/strong}}',
+						{ components: { strong: <strong /> } }
+					),
+				};
+			default:
+				return '';
+		}
+	};
+
 	render() {
 		const {
 			resetOptions,
@@ -73,6 +104,7 @@ export class ResetPasswordFormComponent extends Component {
 								email={ email }
 								sms={ sms }
 								name={ name }
+								displayStrings={ this.getOptionDisplayStrings( name ) }
 								disabled={ isSubmitting }
 								onOptionChanged={ this.onResetOptionChanged }
 								selectedResetOption={ selectedResetOption }

--- a/client/account-recovery/reset-password/reset-password-form/index.jsx
+++ b/client/account-recovery/reset-password/reset-password-form/index.jsx
@@ -67,12 +67,12 @@ export class ResetPasswordFormComponent extends Component {
 						<FormLegend className="reset-password-form__legend">
 							{ translate( 'How would you like to reset your password?' ) }
 						</FormLegend>
-						{ resetOptions.map( ( resetOption, index ) => (
+						{ resetOptions.map( ( { email, sms, name }, index ) => (
 							<ResetOptionSet
 								key={ index }
-								email={ resetOption.email }
-								sms={ resetOption.sms }
-								name={ 'todo' }
+								email={ email }
+								sms={ sms }
+								name={ name }
 								onOptionChanged={ this.onResetOptionChanged }
 								selectedResetOption={ selectedResetOption }
 							/>

--- a/client/account-recovery/reset-password/reset-password-form/index.jsx
+++ b/client/account-recovery/reset-password/reset-password-form/index.jsx
@@ -69,7 +69,7 @@ export class ResetPasswordFormComponent extends Component {
 					),
 				};
 			default:
-				return '';
+				return {};
 		}
 	};
 

--- a/client/account-recovery/reset-password/reset-password-form/index.jsx
+++ b/client/account-recovery/reset-password/reset-password-form/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { identity } from 'lodash';
 
@@ -15,6 +16,8 @@ import FormLegend from 'components/forms/form-legend';
 import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
 
+import { getAccountRecoveryResetOptions } from 'state/selectors';
+
 export class ResetPasswordFormComponent extends Component {
 	static defaultProps = {
 		translate: identity,
@@ -22,6 +25,7 @@ export class ResetPasswordFormComponent extends Component {
 
 	static propTypes = {
 		translate: PropTypes.func.isRequired,
+		resetOptions: PropTypes.array.isRequired,
 	};
 
 	state = {
@@ -30,6 +34,8 @@ export class ResetPasswordFormComponent extends Component {
 	};
 
 	submitForm = () => {
+		// TODO:
+		// This is going to be replaced by corresponding redux actions.
 		this.setState( { isSubmitting: true } );
 	};
 
@@ -114,4 +120,8 @@ export class ResetPasswordFormComponent extends Component {
 	}
 }
 
-export default localize( ResetPasswordFormComponent );
+export default connect(
+	( state ) => ( {
+		resetOptions: getAccountRecoveryResetOptions( state ),
+	} )
+, localize( ResetPasswordFormComponent ) );

--- a/client/account-recovery/reset-password/reset-password-form/index.jsx
+++ b/client/account-recovery/reset-password/reset-password-form/index.jsx
@@ -73,6 +73,7 @@ export class ResetPasswordFormComponent extends Component {
 								email={ email }
 								sms={ sms }
 								name={ name }
+								disabled={ isSubmitting }
 								onOptionChanged={ this.onResetOptionChanged }
 								selectedResetOption={ selectedResetOption }
 							/>

--- a/client/account-recovery/reset-password/reset-password-form/reset-option-set.jsx
+++ b/client/account-recovery/reset-password/reset-password-form/reset-option-set.jsx
@@ -46,7 +46,7 @@ const ResetOptionSet = ( props ) => {
 						className="reset-password-form__sms-option"
 						value={ smsFieldValue }
 						checked={ smsFieldValue === selectedResetOption }
-						onChange={ this.onResetOptionChanged } />
+						onChange={ onOptionChanged } />
 					<span>
 						{ translate(
 							'Send a reset code to {{strong}}your phone{{/strong}}',

--- a/client/account-recovery/reset-password/reset-password-form/reset-option-set.jsx
+++ b/client/account-recovery/reset-password/reset-password-form/reset-option-set.jsx
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import FormLabel from 'components/forms/form-label';
+import FormRadio from 'components/forms/form-radio';
+
+const ResetOptionSet = ( props ) => {
+	const {
+		email,
+		sms,
+		name,
+		translate,
+		onOptionChanged,
+		selectedResetOption,
+	} = props;
+
+	const emailFieldValue = name + '-email';
+	const smsFieldValue = name + '-sms';
+
+	return (
+		<div>
+			{ email && (
+				<FormLabel>
+					<FormRadio
+						className="reset-password-form__email-option"
+						value={ emailFieldValue }
+						checked={ emailFieldValue === selectedResetOption }
+						onChange={ onOptionChanged } />
+					<span>
+						{ translate(
+							'Email a reset link to {{strong}}your main email address{{/strong}}',
+							{ components: { strong: <strong /> } }
+						) }
+					</span>
+				</FormLabel> )
+			}
+			{ sms && (
+				<FormLabel>
+					<FormRadio
+						className="reset-password-form__sms-option"
+						value={ smsFieldValue }
+						checked={ smsFieldValue === selectedResetOption }
+						onChange={ this.onResetOptionChanged } />
+					<span>
+						{ translate(
+							'Send a reset code to {{strong}}your phone{{/strong}}',
+							{ components: { strong: <strong /> } }
+						) }
+					</span>
+				</FormLabel> )
+			}
+		</div>
+	);
+};
+
+export default localize( ResetOptionSet );

--- a/client/account-recovery/reset-password/reset-password-form/reset-option-set.jsx
+++ b/client/account-recovery/reset-password/reset-password-form/reset-option-set.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -30,6 +31,7 @@ const ResetOptionSet = ( props ) => {
 		email,
 		sms,
 		name,
+		disabled,
 		translate,
 		onOptionChanged,
 		selectedResetOption,
@@ -44,9 +46,10 @@ const ResetOptionSet = ( props ) => {
 			{ email && (
 				<FormLabel>
 					<FormRadio
-						className="reset-password-form__email-option"
+						className={ classnames( 'reset-password-form__email-option', name ) }
 						value={ emailFieldValue }
 						checked={ emailFieldValue === selectedResetOption }
+						disabled={ disabled }
 						onChange={ onOptionChanged } />
 					<span>
 						{ translate(
@@ -63,9 +66,10 @@ const ResetOptionSet = ( props ) => {
 			{ sms && (
 				<FormLabel>
 					<FormRadio
-						className="reset-password-form__sms-option"
+						className={ classnames( 'reset-password-form__sms-option', name ) }
 						value={ smsFieldValue }
 						checked={ smsFieldValue === selectedResetOption }
+						disabled={ disabled }
 						onChange={ onOptionChanged } />
 					<span>
 						{ translate(

--- a/client/account-recovery/reset-password/reset-password-form/reset-option-set.jsx
+++ b/client/account-recovery/reset-password/reset-password-form/reset-option-set.jsx
@@ -14,11 +14,11 @@ const getResetOptionDisplayString = ( optionName, translate ) => {
 	switch ( optionName ) {
 		case 'primary':
 			return translate( 'main', {
-				context: 'It is about which way a user wants to reset the password. e.g. main email, recovery email.',
+				comment: 'It is about which way a user wants to reset the password. e.g. main email, recovery email.',
 			} );
 		case 'secondary':
 			return translate( 'recovery', {
-				context: 'It is about which way a user wants to reset the password. e.g. main email, recovery email.',
+				comment: 'It is about which way a user wants to reset the password. e.g. main email, recovery email.',
 			} );
 		default:
 			return '';
@@ -54,7 +54,7 @@ const ResetOptionSet = ( props ) => {
 							{
 								components: { strong: <strong /> },
 								args: { optionName: optionDisplayName },
-								context: 'The %(optionName)s can be "main" or "recovery".',
+								comment: 'The %(optionName)s can be "main" or "recovery".',
 							}
 						) }
 					</span>
@@ -73,7 +73,7 @@ const ResetOptionSet = ( props ) => {
 							{
 								components: { strong: <strong /> },
 								args: { optionName: optionDisplayName },
-								context: 'The %(optionName)s can be "main" or "recovery".',
+								comment: 'The %(optionName)s can be "main" or "recovery".',
 							}
 						) }
 					</span>

--- a/client/account-recovery/reset-password/reset-password-form/reset-option-set.jsx
+++ b/client/account-recovery/reset-password/reset-password-form/reset-option-set.jsx
@@ -10,6 +10,17 @@ import { localize } from 'i18n-calypso';
 import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
 
+const getResetOptionDisplayString = ( optionName, translate ) => {
+	switch ( optionName ) {
+		case 'primary':
+			return translate( 'main' );
+		case 'secondary':
+			return translate( 'recovery' );
+		default:
+			return '';
+	}
+};
+
 const ResetOptionSet = ( props ) => {
 	const {
 		email,
@@ -20,8 +31,9 @@ const ResetOptionSet = ( props ) => {
 		selectedResetOption,
 	} = props;
 
-	const emailFieldValue = name + '-email';
-	const smsFieldValue = name + '-sms';
+	const emailFieldValue = name + '_email';
+	const smsFieldValue = name + '_sms';
+	const optionDisplayName = getResetOptionDisplayString( name, translate );
 
 	return (
 		<div>
@@ -34,8 +46,11 @@ const ResetOptionSet = ( props ) => {
 						onChange={ onOptionChanged } />
 					<span>
 						{ translate(
-							'Email a reset link to {{strong}}your main email address{{/strong}}',
-							{ components: { strong: <strong /> } }
+							'Email a reset link to {{strong}}your %(optionName)s email address{{/strong}}',
+							{
+								components: { strong: <strong /> },
+								args: { optionName: optionDisplayName },
+							}
 						) }
 					</span>
 				</FormLabel> )
@@ -49,8 +64,11 @@ const ResetOptionSet = ( props ) => {
 						onChange={ onOptionChanged } />
 					<span>
 						{ translate(
-							'Send a reset code to {{strong}}your phone{{/strong}}',
-							{ components: { strong: <strong /> } }
+							'Send a reset code to {{strong}}your %(optionName)s phone{{/strong}}',
+							{
+								components: { strong: <strong /> },
+								args: { optionName: optionDisplayName },
+							}
 						) }
 					</span>
 				</FormLabel> )

--- a/client/account-recovery/reset-password/reset-password-form/reset-option-set.jsx
+++ b/client/account-recovery/reset-password/reset-password-form/reset-option-set.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { localize } from 'i18n-calypso';
 import classnames from 'classnames';
 
 /**
@@ -11,35 +10,19 @@ import classnames from 'classnames';
 import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
 
-const getResetOptionDisplayString = ( optionName, translate ) => {
-	switch ( optionName ) {
-		case 'primary':
-			return translate( 'main', {
-				comment: 'It is about which way a user wants to reset the password. e.g. main email, recovery email.',
-			} );
-		case 'secondary':
-			return translate( 'recovery', {
-				comment: 'It is about which way a user wants to reset the password. e.g. main email, recovery email.',
-			} );
-		default:
-			return '';
-	}
-};
-
 const ResetOptionSet = ( props ) => {
 	const {
 		email,
 		sms,
 		name,
+		displayStrings,
 		disabled,
-		translate,
 		onOptionChanged,
 		selectedResetOption,
 	} = props;
 
 	const emailFieldValue = name + '_email';
 	const smsFieldValue = name + '_sms';
-	const optionDisplayName = getResetOptionDisplayString( name, translate );
 
 	return (
 		<div>
@@ -51,16 +34,7 @@ const ResetOptionSet = ( props ) => {
 						checked={ emailFieldValue === selectedResetOption }
 						disabled={ disabled }
 						onChange={ onOptionChanged } />
-					<span>
-						{ translate(
-							'Email a reset link to {{strong}}your %(optionName)s email address{{/strong}}',
-							{
-								components: { strong: <strong /> },
-								args: { optionName: optionDisplayName },
-								comment: 'The %(optionName)s can be "main" or "recovery".',
-							}
-						) }
-					</span>
+					<span>{ displayStrings.email }</span>
 				</FormLabel> )
 			}
 			{ sms && (
@@ -71,20 +45,11 @@ const ResetOptionSet = ( props ) => {
 						checked={ smsFieldValue === selectedResetOption }
 						disabled={ disabled }
 						onChange={ onOptionChanged } />
-					<span>
-						{ translate(
-							'Send a reset code to {{strong}}your %(optionName)s phone{{/strong}}',
-							{
-								components: { strong: <strong /> },
-								args: { optionName: optionDisplayName },
-								comment: 'The %(optionName)s can be "main" or "recovery".',
-							}
-						) }
-					</span>
+					<span>{ displayStrings.sms }</span>
 				</FormLabel> )
 			}
 		</div>
 	);
 };
 
-export default localize( ResetOptionSet );
+export default ResetOptionSet;

--- a/client/account-recovery/reset-password/reset-password-form/reset-option-set.jsx
+++ b/client/account-recovery/reset-password/reset-password-form/reset-option-set.jsx
@@ -13,9 +13,13 @@ import FormRadio from 'components/forms/form-radio';
 const getResetOptionDisplayString = ( optionName, translate ) => {
 	switch ( optionName ) {
 		case 'primary':
-			return translate( 'main' );
+			return translate( 'main', {
+				context: 'It is about which way a user wants to reset the password. e.g. main email, recovery email.',
+			} );
 		case 'secondary':
-			return translate( 'recovery' );
+			return translate( 'recovery', {
+				context: 'It is about which way a user wants to reset the password. e.g. main email, recovery email.',
+			} );
 		default:
 			return '';
 	}
@@ -50,6 +54,7 @@ const ResetOptionSet = ( props ) => {
 							{
 								components: { strong: <strong /> },
 								args: { optionName: optionDisplayName },
+								context: 'The %(optionName)s can be "main" or "recovery".',
 							}
 						) }
 					</span>
@@ -68,6 +73,7 @@ const ResetOptionSet = ( props ) => {
 							{
 								components: { strong: <strong /> },
 								args: { optionName: optionDisplayName },
+								context: 'The %(optionName)s can be "main" or "recovery".',
 							}
 						) }
 					</span>

--- a/client/account-recovery/reset-password/reset-password-form/test/index.jsx
+++ b/client/account-recovery/reset-password/reset-password-form/test/index.jsx
@@ -10,28 +10,38 @@ import { shallow, mount } from 'enzyme';
  */
 import useFakeDom from 'test/helpers/use-fake-dom';
 import { ResetPasswordFormComponent } from '..';
+import ResetOptionSet from '../reset-option-set';
 
 describe( 'ResetPasswordForm', () => {
+	const exampleResetOptions = [
+		{
+			email: 'test@example.com',
+			sms: '+15555555555',
+			name: 'primary',
+		},
+		{
+			email: 'test2@example.com',
+			sms: '+16666666666',
+			name: 'secondary',
+		},
+	];
+
 	const inputSelectors = [
-		'.reset-password-form__primary-email-option',
-		'.reset-password-form__secondary-email-option',
-		'.reset-password-form__sms-option',
+		'.reset-password-form__email-option.primary',
+		'.reset-password-form__email-option.secondary',
+		'.reset-password-form__sms-option.primary',
+		'.reset-password-form__sms-option.secondary',
 	];
 
 	it( 'should render as expected', () => {
 		const wrapper = shallow(
 			<ResetPasswordFormComponent
-				primaryEmail="test@gmail.com"
-				secondaryEmail="test@yahoo.com"
-				phoneNumber="+15555555555" />
+				resetOptions={ exampleResetOptions }
+			/>
 		);
 
 		expect( wrapper ).to.have.state( 'isSubmitting' ).to.be.false;
-
-		// Expect the radio buttons to be enabled
-		inputSelectors.forEach( selector => {
-			expect( wrapper.find( selector ).prop( 'disabled' ) ).to.not.be.ok;
-		} );
+		expect( wrapper.find( ResetOptionSet ) ).to.have.length( 2 );
 
 		expect( wrapper.find( '.reset-password-form__submit-button' ).prop( 'disabled' ) ).to.be.ok;
 	} );
@@ -42,11 +52,10 @@ describe( 'ResetPasswordForm', () => {
 		it( 'should be disabled while submitting', function() {
 			const wrapper = mount(
 				<ResetPasswordFormComponent
-					primaryEmail="test@gmail.com"
-					secondaryEmail="test@yahoo.com"
-					phoneNumber="+15555555555" />
+					resetOptions={ exampleResetOptions }
+				/>
 			);
-			wrapper.find( '.reset-password-form__primary-email-option' ).simulate( 'change' );
+			wrapper.find( '.reset-password-form__email-option.primary' ).simulate( 'change' );
 
 			// Expect the button to be enabled
 			expect( wrapper.find( '.reset-password-form__submit-button' ).prop( 'disabled' ) ).to.not.be.ok;
@@ -68,9 +77,8 @@ describe( 'ResetPasswordForm', () => {
 		it( 'should be disabled if no reset option is selected', function() {
 			const wrapper = mount(
 				<ResetPasswordFormComponent
-					primaryEmail="test@gmail.com"
-					secondaryEmail="test@yahoo.com"
-					phoneNumber="+15555555555" />
+					resetOptions={ exampleResetOptions }
+				/>
 			);
 
 			// Expect the button to be disabled
@@ -80,12 +88,11 @@ describe( 'ResetPasswordForm', () => {
 		it( 'should be disabled when clicked', function() {
 			const wrapper = mount(
 				<ResetPasswordFormComponent
-					primaryEmail="test@gmail.com"
-					secondaryEmail="test@yahoo.com"
-					phoneNumber="+15555555555" />
+					resetOptions={ exampleResetOptions }
+				/>
 			);
 
-			wrapper.find( '.reset-password-form__primary-email-option' ).simulate( 'click' );
+			wrapper.find( '.reset-password-form__email-option.primary' ).simulate( 'click' );
 			wrapper.find( '.reset-password-form__submit-button' ).simulate( 'click' );
 
 			expect( wrapper ).to.have.state( 'isSubmitting' ).to.be.true;


### PR DESCRIPTION
## Summary
This PR connects the `<ResetPasswordForm />` with the underlying redux states: `accountRecovery.reset.options.items`.

## Test Plan
* Open an incognito window and make sure you are logged out.
* Visit `/account-recovery/reset-password`. You should see an empty form card, which is expected: 
![image](https://cloud.githubusercontent.com/assets/1842898/23243527/982795d6-f9ba-11e6-8cf6-e73ef7906892.png)

* Open your browser console, and dispatch the receiving action there to fill the content:
```
dispatch( { type: actionTypes.ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE, items: [ { email: 'aaa@bbb.com', sms: '1234567', name: 'primary' }, { email: 'bbb@ccc.com', sms: '444555666', name: 'secondary' } ] } );
```
* Now you should see the following: 
![image](https://cloud.githubusercontent.com/assets/1842898/23288009/d2de74a8-fa7b-11e6-9184-18a4e8a16101.png)


* Try to opt-out some fields by filling empty strings, and they should not be displayed.