### PR TITLE
JPC: Authorize-form refactor

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -438,6 +438,8 @@
 @import 'signup/style';
 @import 'signup/flow-progress-indicator/style';
 @import 'signup/jetpack-connect/style';
+@import 'signup/jetpack-connect/authorize-form/style';
+@import 'signup/jetpack-connect/jetpack-site-card/style';
 @import 'signup/jetpack-connect/plan-features-tab/style';
 @import 'signup/locale-suggestions/style';
 @import 'signup/navigation-link/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -440,6 +440,7 @@
 @import 'signup/jetpack-connect/style';
 @import 'signup/jetpack-connect/authorize-form/style';
 @import 'signup/jetpack-connect/jetpack-site-card/style';
+@import 'signup/jetpack-connect/logged-out-form/style';
 @import 'signup/jetpack-connect/plan-features-tab/style';
 @import 'signup/locale-suggestions/style';
 @import 'signup/navigation-link/style';

--- a/client/signup/jetpack-connect/authorize-form/index.jsx
+++ b/client/signup/jetpack-connect/authorize-form/index.jsx
@@ -1,0 +1,170 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import cookie from 'cookie';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import {
+	createAccount,
+	authorize,
+	goBackToWpAdmin,
+	activateManage,
+	retryAuth,
+	goToXmlrpcErrorFallbackUrl
+} from 'state/jetpack-connect/actions';
+import {
+	getAuthorizationData,
+	getAuthorizationRemoteSite,
+	getSSOSessions,
+	isCalypsoStartedConnection,
+	hasXmlrpcError,
+	hasExpiredSecretError,
+	getSiteSelectedPlan,
+	isRemoteSiteOnSitesList,
+	getGlobalSelectedPlan,
+	getAuthAttempts
+} from 'state/jetpack-connect/selectors';
+import LoggedOutFormLinks from 'components/logged-out-form/links';
+import { recordTracksEvent } from 'state/analytics/actions';
+import EmptyContent from 'components/empty-content';
+import observe from 'lib/mixins/data-observe';
+import { requestSites } from 'state/sites/actions';
+import { isRequestingSites } from 'state/sites/selectors';
+import MainWrapper from '../main-wrapper';
+import HelpButton from '../help-button';
+import { urlToSlug } from 'lib/url';
+import Plans from '../plans';
+import CheckoutData from 'components/data/checkout';
+import LoggedOutForm from '../logged-out-form';
+import LoggedInForm from '../logged-in-form';
+
+const JetpackConnectAuthorizeForm = React.createClass( {
+	displayName: 'JetpackConnectAuthorizeForm',
+	mixins: [ observe( 'userModule' ) ],
+
+	componentWillMount() {
+		this.props.recordTracksEvent( 'calypso_jpc_authorize_form_view' );
+	},
+
+	isSSO() {
+		const cookies = cookie.parse( document.cookie );
+		const query = this.props.jetpackConnectAuthorize.queryObject;
+		return (
+			query.from &&
+			'sso' === query.from &&
+			cookies.jetpack_sso_approved &&
+			query.client_id &&
+			query.client_id === cookies.jetpack_sso_approved
+		);
+	},
+
+	renderNoQueryArgsError() {
+		return (
+			<Main className="jetpack-connect__main-error">
+				<EmptyContent
+					illustration="/calypso/images/drake/drake-whoops.svg"
+					title={ this.translate(
+						'Oops, this URL should not be accessed directly'
+					) }
+					action={ this.translate( 'Get back to Jetpack Connect screen' ) }
+					actionURL="/jetpack/connect"
+				/>
+				<LoggedOutFormLinks>
+					<HelpButton onClick={ this.clickHelpButton } />
+				</LoggedOutFormLinks>
+			</Main>
+		);
+	},
+
+	renderPlansSelector() {
+		return (
+				<div>
+					<CheckoutData>
+						<Plans { ...this.props } showFirst={ true } />
+					</CheckoutData>
+				</div>
+		);
+	},
+
+	renderForm() {
+		const { userModule } = this.props;
+		const user = userModule.get();
+		const props = Object.assign( {}, this.props, {
+			user: user
+		} );
+
+		return (
+			( user )
+				? <LoggedInForm { ...props } isSSO={ this.isSSO() } />
+				: <LoggedOutForm { ...props } isSSO={ this.isSSO() } />
+		);
+	},
+
+	render() {
+		const { queryObject } = this.props.jetpackConnectAuthorize;
+
+		if ( typeof queryObject === 'undefined' ) {
+			return this.renderNoQueryArgsError();
+		}
+
+		if ( queryObject && queryObject.already_authorized && ! this.props.isAlreadyOnSitesList ) {
+			this.renderForm();
+		}
+
+		if ( this.props.plansFirst && ! this.props.selectedPlan ) {
+			return this.renderPlansSelector();
+		}
+
+		return (
+			<MainWrapper>
+				<div className="jetpack-connect-authorize-form">
+					{ this.renderForm() }
+				</div>
+			</MainWrapper>
+		);
+	}
+} );
+
+export default connect(
+	state => {
+		const remoteSiteUrl = getAuthorizationRemoteSite( state );
+		const siteSlug = urlToSlug( remoteSiteUrl );
+		const requestHasXmlrpcError = () => {
+			return hasXmlrpcError( state );
+		};
+		const requestHasExpiredSecretError = () => {
+			return hasExpiredSecretError( state );
+		};
+		const selectedPlan = getSiteSelectedPlan( state, siteSlug ) || getGlobalSelectedPlan( state );
+
+		return {
+			siteSlug,
+			selectedPlan,
+			jetpackConnectAuthorize: getAuthorizationData( state ),
+			plansFirst: false,
+			jetpackSSOSessions: getSSOSessions( state ),
+			isAlreadyOnSitesList: isRemoteSiteOnSitesList( state ),
+			isFetchingSites: isRequestingSites( state ),
+			requestHasXmlrpcError,
+			requestHasExpiredSecretError,
+			calypsoStartedConnection: isCalypsoStartedConnection( state, remoteSiteUrl ),
+			authAttempts: getAuthAttempts( state, siteSlug ),
+		};
+	},
+	dispatch => bindActionCreators( {
+		requestSites,
+		recordTracksEvent,
+		authorize,
+		createAccount,
+		activateManage,
+		goBackToWpAdmin,
+		retryAuth,
+		goToXmlrpcErrorFallbackUrl
+	}, dispatch )
+)( JetpackConnectAuthorizeForm );

--- a/client/signup/jetpack-connect/authorize-form/style.scss
+++ b/client/signup/jetpack-connect/authorize-form/style.scss
@@ -1,0 +1,38 @@
+.jetpack-connect__authorize-form {
+	.jetpack-connect__authorize-form-header {
+		text-align: center;
+	}
+}
+
+.jetpack-connect__logged-in-form {
+	.jetpack-connect__logged-in-form-user-text {
+		text-align: center;
+	}
+
+	.gravatar {
+		display: block;
+		margin: 0 auto 8px auto;
+	}
+
+	.button {
+		width: 100%;
+	}
+
+	.logged-out-form__links .gridicon {
+		top: 2px;
+	}
+}
+
+.jetpack-connect__logged-in-form-loading {
+	text-align: center;
+
+	span {
+		animation: loading-fade 1.6s ease-in-out infinite;
+		display: block;
+	}
+
+	.spinner {
+		display: inline-block;
+		margin-top: 8px;
+	}
+}

--- a/client/signup/jetpack-connect/jetpack-site-card/index.jsx
+++ b/client/signup/jetpack-connect/jetpack-site-card/index.jsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import urlModule from 'url';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+import safeImageUrl from 'lib/safe-image-url';
+import { decodeEntities } from 'lib/formatting';
+import QuerySites from 'components/data/query-sites';
+import Site from 'blocks/site';
+
+const JetpackSiteCard = ( { site_icon, blogname, home_url, site_url } ) => {
+	const safeIconUrl = site_icon ? safeImageUrl( site_icon ) : false;
+	const siteIcon = safeIconUrl ? { img: safeIconUrl } : false;
+	const url = decodeEntities( home_url );
+	const parsedUrl = urlModule.parse( url );
+	const path = ( parsedUrl.path === '/' ) ? '' : parsedUrl.path;
+	const site = {
+		ID: null,
+		url: url,
+		admin_url: decodeEntities( site_url + '/wp-admin' ),
+		domain: parsedUrl.host + path,
+		icon: siteIcon,
+		is_vip: false,
+		title: decodeEntities( blogname )
+	};
+
+	return (
+		<CompactCard className="jetpack-site-card">
+			<QuerySites allSites />
+			<Site site={ site } />
+		</CompactCard>
+	);
+};
+
+export default JetpackSiteCard;
+

--- a/client/signup/jetpack-connect/jetpack-site-card/style.scss
+++ b/client/signup/jetpack-connect/jetpack-site-card/style.scss
@@ -1,0 +1,3 @@
+.jetpack-connect__site.card {
+	padding: 0;
+}

--- a/client/signup/jetpack-connect/logged-in-form/index.jsx
+++ b/client/signup/jetpack-connect/logged-in-form/index.jsx
@@ -2,74 +2,34 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import page from 'page';
-import urlModule from 'url';
 import i18n from 'i18n-calypso';
 import Gridicon from 'gridicons';
 const debug = require( 'debug' )( 'calypso:jetpack-connect:authorize-form' );
-import cookie from 'cookie';
 
 /**
  * Internal dependencies
  */
 import addQueryArgs from 'lib/route/add-query-args';
-import Main from 'components/main';
-import StepHeader from '../step-header';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
-import SignupForm from 'components/signup-form';
-import WpcomLoginForm from 'signup/wpcom-login-form';
+import versionCompare from 'lib/version-compare';
+import SiteCard from '../jetpack-site-card';
+import StepHeader from '../../step-header';
 import config from 'config';
-import QuerySites from 'components/data/query-sites';
-import {
-	createAccount,
-	authorize,
-	goBackToWpAdmin,
-	activateManage,
-	retryAuth,
-	goToXmlrpcErrorFallbackUrl
-} from 'state/jetpack-connect/actions';
-import {
-	getAuthorizationData,
-	getAuthorizationRemoteSite,
-	getSSOSessions,
-	isCalypsoStartedConnection,
-	hasXmlrpcError,
-	hasExpiredSecretError,
-	getSiteSelectedPlan,
-	isRemoteSiteOnSitesList,
-	getGlobalSelectedPlan,
-	getAuthAttempts
-} from 'state/jetpack-connect/selectors';
-import JetpackConnectNotices from './jetpack-connect-notices';
-import observe from 'lib/mixins/data-observe';
+import HelpButton from '../help-button';
+import JetpackConnectNotices from '../jetpack-connect-notices';
 import userUtilities from 'lib/user/utils';
 import Card from 'components/card';
-import CompactCard from 'components/card/compact';
 import Gravatar from 'components/gravatar';
-import LocaleSuggestions from 'signup/locale-suggestions';
-import { recordTracksEvent } from 'state/analytics/actions';
 import Spinner from 'components/spinner';
-import Site from 'blocks/site';
 import { decodeEntities } from 'lib/formatting';
-import versionCompare from 'lib/version-compare';
-import EmptyContent from 'components/empty-content';
-import safeImageUrl from 'lib/safe-image-url';
 import Button from 'components/button';
-import { requestSites } from 'state/sites/actions';
-import { isRequestingSites } from 'state/sites/selectors';
-import MainWrapper from './main-wrapper';
-import HelpButton from './help-button';
-import { urlToSlug } from 'lib/url';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
-import Plans from './plans';
-import CheckoutData from 'components/data/checkout';
 import { externalRedirect } from 'lib/route/path';
 
 /**
@@ -77,124 +37,6 @@ import { externalRedirect } from 'lib/route/path';
  */
 const PLANS_PAGE = '/jetpack/connect/plans/';
 const MAX_AUTH_ATTEMPTS = 3;
-
-const SiteCard = React.createClass( {
-	render() {
-		const { site_icon, blogname, home_url, site_url } = this.props.queryObject;
-		const safeIconUrl = site_icon ? safeImageUrl( site_icon ) : false;
-		const siteIcon = safeIconUrl ? { img: safeIconUrl } : false;
-		const url = decodeEntities( home_url );
-		const parsedUrl = urlModule.parse( url );
-		const path = ( parsedUrl.path === '/' ) ? '' : parsedUrl.path;
-		const site = {
-			ID: null,
-			url: url,
-			admin_url: decodeEntities( site_url + '/wp-admin' ),
-			domain: parsedUrl.host + path,
-			icon: siteIcon,
-			is_vip: false,
-			title: decodeEntities( blogname )
-		};
-
-		return (
-			<CompactCard className="jetpack-connect__site">
-				<QuerySites allSites />
-				<Site site={ site } />
-			</CompactCard>
-		);
-	}
-} );
-
-const LoggedOutForm = React.createClass( {
-	displayName: 'LoggedOutForm',
-
-	componentDidMount() {
-		this.props.recordTracksEvent( 'calypso_jpc_signup_view' );
-	},
-
-	renderFormHeader() {
-		const headerText = i18n.translate( 'Create your account' );
-		const subHeaderText = i18n.translate( 'You are moments away from connecting your site.' );
-		const { queryObject } = this.props.jetpackConnectAuthorize;
-		const siteCard = versionCompare( queryObject.jp_version, '4.0.3', '>' )
-			? <SiteCard queryObject={ queryObject } />
-			: null;
-
-		return (
-			<div>
-				<StepHeader
-					headerText={ headerText }
-					subHeaderText={ subHeaderText } />
-				{ siteCard }
-			</div>
-		);
-	},
-
-	submitForm( form, userData ) {
-		debug( 'submiting new account', form, userData );
-		this.props.createAccount( userData );
-	},
-
-	isSubmitting() {
-		return this.props.jetpackConnectAuthorize && this.props.jetpackConnectAuthorize.isAuthorizing;
-	},
-
-	loginUser() {
-		const { queryObject, userData, bearerToken } = this.props.jetpackConnectAuthorize;
-		const redirectTo = addQueryArgs( queryObject, window.location.href );
-		return (
-			<WpcomLoginForm
-				log={ userData.username }
-				authorization={ 'Bearer ' + bearerToken }
-				redirectTo={ redirectTo } />
-		);
-	},
-
-	renderLocaleSuggestions() {
-		if ( ! this.props.locale ) {
-			return;
-		}
-
-		return (
-			<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
-		);
-	},
-
-	renderFooterLink() {
-		const { queryObject } = this.props.jetpackConnectAuthorize;
-		const redirectTo = addQueryArgs( queryObject, window.location.href );
-		const loginUrl = addQueryArgs( { redirect_to: redirectTo }, config( 'login_url' ) );
-		return (
-			<LoggedOutFormLinks>
-				<LoggedOutFormLinkItem href={ loginUrl }>
-					{ this.translate( 'Already have an account? Sign in' ) }
-				</LoggedOutFormLinkItem>
-				<HelpButton onClick={ this.clickHelpButton } />
-			</LoggedOutFormLinks>
-		);
-	},
-
-	render() {
-		const { userData } = this.props.jetpackConnectAuthorize;
-		return (
-			<div>
-				{ this.renderLocaleSuggestions() }
-				{ this.renderFormHeader() }
-				<SignupForm
-					getRedirectToAfterLoginUrl={ window.location.href }
-					disabled={ this.isSubmitting() }
-					submitting={ this.isSubmitting() }
-					save={ this.save }
-					submitForm={ this.submitForm }
-					submitButtonText={ this.translate( 'Sign Up and Connect Jetpack' ) }
-					footerLink={ this.renderFooterLink() }
-					suggestedUsername={ userData && userData.username ? userData.username : '' }
-				/>
-				{ userData && this.loginUser() }
-			</div>
-		);
-	}
-} );
 
 const LoggedInForm = React.createClass( {
 	displayName: 'LoggedInForm',
@@ -282,7 +124,7 @@ const LoggedInForm = React.createClass( {
 			? i18n.translate( 'Thank you for flying with Jetpack' )
 			: i18n.translate( 'Jetpack is finishing up the connection process' );
 		const siteCard = versionCompare( queryObject.jp_version, '4.0.3', '>' )
-			? <SiteCard queryObject={ queryObject } />
+			? <SiteCard { ...queryObject } />
 			: null;
 
 		return (
@@ -654,127 +496,4 @@ const LoggedInForm = React.createClass( {
 	}
 } );
 
-const JetpackConnectAuthorizeForm = React.createClass( {
-	displayName: 'JetpackConnectAuthorizeForm',
-	mixins: [ observe( 'userModule' ) ],
-
-	componentWillMount() {
-		this.props.recordTracksEvent( 'calypso_jpc_authorize_form_view' );
-	},
-
-	isSSO() {
-		const cookies = cookie.parse( document.cookie );
-		const query = this.props.jetpackConnectAuthorize.queryObject;
-		return (
-			query.from &&
-			'sso' === query.from &&
-			cookies.jetpack_sso_approved &&
-			query.client_id &&
-			query.client_id === cookies.jetpack_sso_approved
-		);
-	},
-
-	renderNoQueryArgsError() {
-		return (
-			<Main className="jetpack-connect__main-error">
-				<EmptyContent
-					illustration="/calypso/images/drake/drake-whoops.svg"
-					title={ this.translate(
-						'Oops, this URL should not be accessed directly'
-					) }
-					action={ this.translate( 'Get back to Jetpack Connect screen' ) }
-					actionURL="/jetpack/connect"
-				/>
-				<LoggedOutFormLinks>
-					<HelpButton onClick={ this.clickHelpButton } />
-				</LoggedOutFormLinks>
-			</Main>
-		);
-	},
-
-	renderPlansSelector() {
-		return (
-				<div>
-					<CheckoutData>
-						<Plans { ...this.props } showFirst={ true } />
-					</CheckoutData>
-				</div>
-		);
-	},
-
-	renderForm() {
-		const { userModule } = this.props;
-		const user = userModule.get();
-		const props = Object.assign( {}, this.props, {
-			user: user
-		} );
-
-		return (
-			( user )
-				? <LoggedInForm { ...props } isSSO={ this.isSSO() } />
-				: <LoggedOutForm { ...props } isSSO={ this.isSSO() } />
-		);
-	},
-
-	render() {
-		const { queryObject } = this.props.jetpackConnectAuthorize;
-
-		if ( typeof queryObject === 'undefined' ) {
-			return this.renderNoQueryArgsError();
-		}
-
-		if ( queryObject && queryObject.already_authorized && ! this.props.isAlreadyOnSitesList ) {
-			this.renderForm();
-		}
-
-		if ( this.props.plansFirst && ! this.props.selectedPlan ) {
-			return this.renderPlansSelector();
-		}
-
-		return (
-			<MainWrapper>
-				<div className="jetpack-connect__authorize-form">
-					{ this.renderForm() }
-				</div>
-			</MainWrapper>
-		);
-	}
-} );
-
-export default connect(
-	state => {
-		const remoteSiteUrl = getAuthorizationRemoteSite( state );
-		const siteSlug = urlToSlug( remoteSiteUrl );
-		const requestHasXmlrpcError = () => {
-			return hasXmlrpcError( state );
-		};
-		const requestHasExpiredSecretError = () => {
-			return hasExpiredSecretError( state );
-		};
-		const selectedPlan = getSiteSelectedPlan( state, siteSlug ) || getGlobalSelectedPlan( state );
-
-		return {
-			siteSlug,
-			selectedPlan,
-			jetpackConnectAuthorize: getAuthorizationData( state ),
-			plansFirst: false,
-			jetpackSSOSessions: getSSOSessions( state ),
-			isAlreadyOnSitesList: isRemoteSiteOnSitesList( state ),
-			isFetchingSites: isRequestingSites( state ),
-			requestHasXmlrpcError,
-			requestHasExpiredSecretError,
-			calypsoStartedConnection: isCalypsoStartedConnection( state, remoteSiteUrl ),
-			authAttempts: getAuthAttempts( state, siteSlug ),
-		};
-	},
-	dispatch => bindActionCreators( {
-		requestSites,
-		recordTracksEvent,
-		authorize,
-		createAccount,
-		activateManage,
-		goBackToWpAdmin,
-		retryAuth,
-		goToXmlrpcErrorFallbackUrl
-	}, dispatch )
-)( JetpackConnectAuthorizeForm );
+export default LoggedInForm;

--- a/client/signup/jetpack-connect/logged-out-form/index.jsx
+++ b/client/signup/jetpack-connect/logged-out-form/index.jsx
@@ -1,0 +1,114 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import i18n from 'i18n-calypso';
+const debug = require( 'debug' )( 'calypso:jetpack-connect:authorize-form' );
+
+/**
+ * Internal dependencies
+ */
+import addQueryArgs from 'lib/route/add-query-args';
+import LoggedOutFormLinks from 'components/logged-out-form/links';
+import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
+import SignupForm from 'components/signup-form';
+import WpcomLoginForm from 'signup/wpcom-login-form';
+import LocaleSuggestions from 'signup/locale-suggestions';
+import versionCompare from 'lib/version-compare';
+import SiteCard from '../jetpack-site-card';
+import StepHeader from '../../step-header';
+import config from 'config';
+import HelpButton from '../help-button';
+
+const LoggedOutForm = React.createClass( {
+	displayName: 'LoggedOutForm',
+
+	componentDidMount() {
+		this.props.recordTracksEvent( 'calypso_jpc_signup_view' );
+	},
+
+	renderFormHeader() {
+		const headerText = i18n.translate( 'Create your account' );
+		const subHeaderText = i18n.translate( 'You are moments away from connecting your site.' );
+		const { queryObject } = this.props.jetpackConnectAuthorize;
+		const siteCard = versionCompare( queryObject.jp_version, '4.0.3', '>' )
+			? <SiteCard { ...queryObject } />
+			: null;
+
+		return (
+			<div>
+				<StepHeader
+					headerText={ headerText }
+					subHeaderText={ subHeaderText } />
+				{ siteCard }
+			</div>
+		);
+	},
+
+	submitForm( form, userData ) {
+		debug( 'submiting new account', form, userData );
+		this.props.createAccount( userData );
+	},
+
+	isSubmitting() {
+		return this.props.jetpackConnectAuthorize && this.props.jetpackConnectAuthorize.isAuthorizing;
+	},
+
+	loginUser() {
+		const { queryObject, userData, bearerToken } = this.props.jetpackConnectAuthorize;
+		const redirectTo = addQueryArgs( queryObject, window.location.href );
+		return (
+			<WpcomLoginForm
+				log={ userData.username }
+				authorization={ 'Bearer ' + bearerToken }
+				redirectTo={ redirectTo } />
+		);
+	},
+
+	renderLocaleSuggestions() {
+		if ( ! this.props.locale ) {
+			return;
+		}
+
+		return (
+			<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
+		);
+	},
+
+	renderFooterLink() {
+		const { queryObject } = this.props.jetpackConnectAuthorize;
+		const redirectTo = addQueryArgs( queryObject, window.location.href );
+		const loginUrl = addQueryArgs( { redirect_to: redirectTo }, config( 'login_url' ) );
+		return (
+			<LoggedOutFormLinks>
+				<LoggedOutFormLinkItem href={ loginUrl }>
+					{ this.translate( 'Already have an account? Sign in' ) }
+				</LoggedOutFormLinkItem>
+				<HelpButton onClick={ this.clickHelpButton } />
+			</LoggedOutFormLinks>
+		);
+	},
+
+	render() {
+		const { userData } = this.props.jetpackConnectAuthorize;
+		return (
+			<div>
+				{ this.renderLocaleSuggestions() }
+				{ this.renderFormHeader() }
+				<SignupForm
+					getRedirectToAfterLoginUrl={ window.location.href }
+					disabled={ this.isSubmitting() }
+					submitting={ this.isSubmitting() }
+					save={ this.save }
+					submitForm={ this.submitForm }
+					submitButtonText={ this.translate( 'Sign Up and Connect Jetpack' ) }
+					footerLink={ this.renderFooterLink() }
+					suggestedUsername={ userData && userData.username ? userData.username : '' }
+				/>
+				{ userData && this.loginUser() }
+			</div>
+		);
+	}
+} );
+
+export default LoggedOutForm;

--- a/client/signup/jetpack-connect/logged-out-form/style.scss
+++ b/client/signup/jetpack-connect/logged-out-form/style.scss
@@ -1,0 +1,28 @@
+.jetpack-connect__main {
+	.logged-out-form__links {
+		max-width: 100%;
+
+		.logged-out-form__link-item {
+			.gridicon {
+				position: relative;
+				top: 4px;
+			}
+		}
+
+	}
+}
+
+.jetpack-connect__main-error {
+	.logged-out-form__links {
+		margin-top: 15px;
+		text-align: center;
+
+		.logged-out-form__link-item {
+			.gridicon {
+				position: relative;
+				top: 4px;
+			}
+		}
+	}
+}
+

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -87,31 +87,6 @@
 	}
 }
 
-.jetpack-connect__authorize-form {
-	.jetpack-connect__authorize-form-header {
-		text-align: center;
-	}
-}
-
-.jetpack-connect__logged-in-form {
-	.jetpack-connect__logged-in-form-user-text {
-		text-align: center;
-	}
-
-	.gravatar {
-		display: block;
-		margin: 0 auto 8px auto;
-	}
-
-	.button {
-		width: 100%;
-	}
-
-	.logged-out-form__links .gridicon {
-		top: 2px;
-	}
-}
-
 .jetpack-connect__back-button {
 	margin-top: 16px;
 }
@@ -364,20 +339,6 @@
 	display: block;
 	text-align: center;
 	width: 100%;
-}
-
-.jetpack-connect__logged-in-form-loading {
-	text-align: center;
-
-	span {
-		animation: loading-fade 1.6s ease-in-out infinite;
-		display: block;
-	}
-
-	.spinner {
-		display: inline-block;
-		margin-top: 8px;
-	}
 }
 
 .jetpack-connect__tos-link {

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -1,18 +1,6 @@
 .jetpack-connect__main {
 	max-width: 400px;
 
-	.logged-out-form__links {
-		max-width: 100%;
-
-		.logged-out-form__link-item {
-			.gridicon {
-				position: relative;
-				top: 4px;
-			}
-		}
-
-	}
-
 	.step-header {
 		margin-bottom: 16px;
 	}
@@ -25,20 +13,6 @@
 
 	.button.is-primary {
 		width: 320px;
-	}
-}
-
-.jetpack-connect__main-error {
-	.logged-out-form__links {
-		margin-top: 15px;
-		text-align: center;
-
-		.logged-out-form__link-item {
-			.gridicon {
-				position: relative;
-				top: 4px;
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
This PR splits authorize-form in several different files. We have several components being defined in /signup/jetpack-connec/authorize-form.jsx, which is very confusing and makes it hard to improve the general readability of our components.

This is the first step towards a more complete refactor.

How To Test
=========
0. There shouldn't be any functional change
1. Go to http://calypso.localhost:3000/jetpack/connect and connect a site. Make sure that you can connect a jetpack site
2. Repeat the process starting without a logged session in wordpress.com