### PR TITLE
Change copy for plan cancellation question.

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -198,7 +198,7 @@ const CancelPurchaseForm = React.createClass( {
 					value="onlyNeedFree"
 					checked={ 'onlyNeedFree' === this.state.questionOneRadio }
 					onChange={ this.onRadioOneChange } />
-				<span>{ this.translate( 'All I need is the free plan.' ) }</span>
+				<span>{ this.translate( 'The plan was too expensive.' ) }</span>
 				{ 'onlyNeedFree' === this.state.questionOneRadio && onlyNeedFreeInput }
 			</FormLabel>
 		);


### PR DESCRIPTION
This changes the copy on a plan cancellation survey from 'All I need is the free plan.' to 'The plan was too expensive.

**To Test**

For a user with at least one paid plan.

* browse to /me/purchases
* click the plan
* click 'Remove WordPress.com plan'
* verify survey copy change