### PR TITLE
Checkout: Show Thank You page for failed domain-only purchases

### DIFF
--- a/client/lib/domains/utils.js
+++ b/client/lib/domains/utils.js
@@ -46,7 +46,7 @@ function getDomainNameFromReceiptOrCart( receipt, cart ) {
 		domainRegistration = cartItems.getDomainRegistrations( cart )[ 0 ];
 	}
 
-	if ( domainRegistration ) {
+	if ( domainRegistration && isEmpty( receipt.failed_purchases ) ) {
 		return domainRegistration.meta;
 	}
 

--- a/client/lib/domains/utils.js
+++ b/client/lib/domains/utils.js
@@ -46,7 +46,7 @@ function getDomainNameFromReceiptOrCart( receipt, cart ) {
 		domainRegistration = cartItems.getDomainRegistrations( cart )[ 0 ];
 	}
 
-	if ( domainRegistration && isEmpty( receipt.failed_purchases ) ) {
+	if ( domainRegistration && ( ! receipt || isEmpty( receipt.failed_purchases ) ) ) {
 		return domainRegistration.meta;
 	}
 

--- a/client/lib/domains/utils.js
+++ b/client/lib/domains/utils.js
@@ -46,7 +46,7 @@ function getDomainNameFromReceiptOrCart( receipt, cart ) {
 		domainRegistration = cartItems.getDomainRegistrations( cart )[ 0 ];
 	}
 
-	if ( domainRegistration && ( ! receipt || isEmpty( receipt.failed_purchases ) ) ) {
+	if ( domainRegistration ) {
 		return domainRegistration.meta;
 	}
 

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -109,7 +109,7 @@ const CheckoutThankYou = React.createClass( {
 			nextProps.receipt.hasLoadedFromServer &&
 			this.hasPlanOrDomainProduct( nextProps )
 		) {
-			this.props.refreshSitePlans( this.props.selectedSite.ID );
+			this.props.refreshSitePlans( this.props.selectedSite );
 		}
 	},
 
@@ -200,7 +200,7 @@ const CheckoutThankYou = React.createClass( {
 
 		const userCreatedMoment = moment( this.props.userDate ),
 			isNewUser = userCreatedMoment.isAfter( moment().subtract( 2, 'hours' ) ),
-			goBackText = this.props.selectedSite ? this.translate( 'Back to my site' ) : this.translate( 'Register domain' );
+			goBackText = this.props.selectedSite ? this.translate( 'Back to my site' ) : this.translate( 'Register Domain' );
 
 		// this placeholder is using just wp logo here because two possible states do not share a common layout
 		if ( ! purchases && ! failedPurchases && ! this.isGenericReceipt() ) {

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -86,14 +86,21 @@ const CheckoutThankYou = React.createClass( {
 	componentDidMount() {
 		this.redirectIfThemePurchased();
 
-		if ( this.props.receipt.hasLoadedFromServer && this.hasPlanOrDomainProduct() ) {
-			this.props.refreshSitePlans( this.props.selectedSite );
-		} else if ( shouldFetchSitePlans( this.props.sitePlans, this.props.selectedSite ) ) {
-			this.props.fetchSitePlans( this.props.selectedSite );
+		const {
+			receipt,
+			receiptId,
+			selectedSite,
+			sitePlans
+		} = this.props;
+
+		if ( selectedSite && receipt.hasLoadedFromServer && this.hasPlanOrDomainProduct() ) {
+			this.props.refreshSitePlans( selectedSite );
+		} else if ( shouldFetchSitePlans( sitePlans, selectedSite ) ) {
+			this.props.fetchSitePlans( selectedSite );
 		}
 
-		if ( this.props.receiptId && ! this.props.receipt.hasLoadedFromServer && ! this.props.receipt.isRequesting ) {
-			this.props.fetchReceipt( this.props.receiptId );
+		if ( receiptId && ! receipt.hasLoadedFromServer && ! receipt.isRequesting ) {
+			this.props.fetchReceipt( receiptId );
 		}
 
 		analytics.tracks.recordEvent( 'calypso_checkout_thank_you_view' );
@@ -287,7 +294,9 @@ const CheckoutThankYou = React.createClass( {
 			failedPurchases = getFailedPurchases( this.props ),
 			hasFailedPurchases = failedPurchases.length > 0,
 			[ ComponentClass, primaryPurchase, domain ] = this.getComponentAndPrimaryPurchaseAndDomain(),
-			registrarSupportUrl = ( ! ComponentClass || this.isGenericReceipt() || hasFailedPurchases ) ? null : primaryPurchase.registrarSupportUrl;
+			registrarSupportUrl = ( ! ComponentClass || this.isGenericReceipt() || hasFailedPurchases )
+				? null
+				: primaryPurchase.registrarSupportUrl;
 
 		if ( ! this.isDataLoaded() ) {
 			return (
@@ -359,14 +368,10 @@ export default connect(
 				dispatch( fetchReceipt( receiptId ) );
 			},
 			fetchSitePlans( site ) {
-				if ( site ) {
-					dispatch( fetchSitePlans( site.ID ) );
-				}
+				dispatch( fetchSitePlans( site.ID ) );
 			},
 			refreshSitePlans( site ) {
-				if ( site ) {
-					dispatch( refreshSitePlans( site.ID ) );
-				}
+				dispatch( refreshSitePlans( site.ID ) );
 			},
 		};
 	}

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -237,8 +237,7 @@ const Checkout = React.createClass( {
 				}
 			}
 		} = this.props;
-		const redirectPath = this.getCheckoutCompleteRedirectPath(),
-			{ receipt_id: receiptId } = receipt;
+		const redirectPath = this.getCheckoutCompleteRedirectPath();
 
 		this.props.clearPurchases();
 
@@ -288,7 +287,9 @@ const Checkout = React.createClass( {
 			this.props.clearSitePlans( selectedSiteId );
 		}
 
-		if ( receiptId ) {
+		if ( receipt && receipt.receipt_id ) {
+			const receiptId = receipt.receipt_id;
+
 			this.props.fetchReceiptCompleted( receiptId, {
 				receiptId,
 				purchases: this.flattenPurchases( this.props.transaction.step.data.purchases ),

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -207,7 +207,7 @@ const Checkout = React.createClass( {
 				: '/checkout/thank-you/plans';
 		} else if ( cart.create_new_blog ) {
 			const domainName = getDomainNameFromReceiptOrCart( receipt, cart );
-			if ( domainName ) {
+			if ( domainName && receipt && isEmpty( receipt.failed_purchases ) ) {
 				return domainManagementList( domainName );
 			}
 
@@ -297,7 +297,7 @@ const Checkout = React.createClass( {
 			} );
 		}
 
-		if ( cart.create_new_blog ) {
+		if ( cart.create_new_blog && receipt && isEmpty( receipt.failed_purchases ) ) {
 			notices.info(
 				this.translate( 'Almost done…' )
 			);

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -43,7 +43,7 @@ import {
 	getSelectedSiteSlug,
 } from 'state/ui/selectors';
 import { getDomainNameFromReceiptOrCart } from 'lib/domains/utils';
-import { domainManagementList, domainManagementRoot } from 'my-sites/upgrades/paths';
+import { domainManagementList } from 'my-sites/upgrades/paths';
 import { fetchSitesAndUser } from 'lib/signup/step-actions';
 
 const Checkout = React.createClass( {
@@ -211,8 +211,7 @@ const Checkout = React.createClass( {
 				return domainManagementList( domainName );
 			}
 
-			// TODO: Redirect to Thank You page, but no site slug atm, so we need a new route
-			return domainManagementRoot();
+			return `/checkout/no-site/${ receiptId }`;
 		}
 
 		if ( ! selectedSiteSlug ) {
@@ -288,6 +287,16 @@ const Checkout = React.createClass( {
 			this.props.clearSitePlans( selectedSiteId );
 		}
 
+		if ( receipt && receipt.receipt_id ) {
+			const receiptId = receipt.receipt_id;
+
+			this.props.fetchReceiptCompleted( receiptId, {
+				receiptId: receiptId,
+				purchases: this.flattenPurchases( this.props.transaction.step.data.purchases ),
+				failedPurchases: this.flattenPurchases( this.props.transaction.step.data.failed_purchases ),
+			} );
+		}
+
 		if ( cart.create_new_blog ) {
 			notices.info(
 				this.translate( 'Almost done…' )
@@ -302,16 +311,6 @@ const Checkout = React.createClass( {
 
 				return;
 			}
-		}
-
-		if ( receipt && receipt.receipt_id ) {
-			const receiptId = receipt.receipt_id;
-
-			this.props.fetchReceiptCompleted( receiptId, {
-				receiptId: receiptId,
-				purchases: this.flattenPurchases( this.props.transaction.step.data.purchases ),
-				failedPurchases: this.flattenPurchases( this.props.transaction.step.data.failed_purchases ),
-			} );
 		}
 
 		page( redirectPath );

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -211,7 +211,7 @@ const Checkout = React.createClass( {
 				return domainManagementList( domainName );
 			}
 
-			return `/checkout/no-site/${ receiptId }`;
+			return `/checkout/thank-you/no-site/${ receiptId }`;
 		}
 
 		if ( ! selectedSiteSlug ) {
@@ -237,7 +237,8 @@ const Checkout = React.createClass( {
 				}
 			}
 		} = this.props;
-		const redirectPath = this.getCheckoutCompleteRedirectPath();
+		const redirectPath = this.getCheckoutCompleteRedirectPath(),
+			{ receipt_id: receiptId } = receipt;
 
 		this.props.clearPurchases();
 
@@ -287,11 +288,9 @@ const Checkout = React.createClass( {
 			this.props.clearSitePlans( selectedSiteId );
 		}
 
-		if ( receipt && receipt.receipt_id ) {
-			const receiptId = receipt.receipt_id;
-
+		if ( receiptId ) {
 			this.props.fetchReceiptCompleted( receiptId, {
-				receiptId: receiptId,
+				receiptId,
 				purchases: this.flattenPurchases( this.props.transaction.step.data.purchases ),
 				failedPurchases: this.flattenPurchases( this.props.transaction.step.data.failed_purchases ),
 			} );

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -257,6 +257,11 @@ module.exports = function() {
 		);
 
 		page(
+			'/checkout/no-site/:receiptId',
+			upgradesController.checkoutThankYou
+		);
+
+		page(
 			'/checkout/:domain/:product?',
 			controller.siteSelection,
 			upgradesController.checkout

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -234,6 +234,11 @@ module.exports = function() {
 
 	if ( config.isEnabled( 'upgrades/checkout' ) ) {
 		page(
+			'/checkout/thank-you/no-site/:receiptId',
+			upgradesController.checkoutThankYou
+		);
+
+		page(
 			'/checkout/thank-you/:site/:receiptId?',
 			controller.siteSelection,
 			upgradesController.checkoutThankYou
@@ -254,11 +259,6 @@ module.exports = function() {
 		page(
 			'/checkout/no-site',
 			upgradesController.sitelessCheckout
-		);
-
-		page(
-			'/checkout/no-site/:receiptId',
-			upgradesController.checkoutThankYou
 		);
 
 		page(


### PR DESCRIPTION
When a domain-only purchase fails, reuse the Thank You page we show for regular failed purchases.

- Added new route to handle domain-only case
- Refactored `CheckoutThankYou` to work properly when no site is passed

Test:
1. Hack back-end to fail a domain registration
2. Make sure you are redirected to `no-site/:receiptId`
3. Make sure the page shown makes sense
4. Test `Register Domain` link that takes you back to start of flow

Test regular purchases and make sure they work. 