### PR TITLE
Reader: fix class name in ReaderExcerpt block

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -34,6 +34,7 @@
 @import 'blocks/post-relative-time/style';
 @import 'blocks/post-status/style';
 @import 'blocks/reader-avatar/style';
+@import 'blocks/reader-excerpt/style';
 @import 'blocks/reader-feed-header/style';
 @import 'blocks/reader-featured-image/style';
 @import 'blocks/reader-full-post/style';

--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -18,7 +18,7 @@ const ReaderExcerpt = ( { post, isDiscover } ) => {
 
 	return (
 		<AutoDirection>
-			<div className="reader-post-card__excerpt"
+			<div className="reader-excerpt"
 				dangerouslySetInnerHTML={ { __html: excerpt } } // eslint-disable-line react/no-danger
 			/>
 		</AutoDirection>

--- a/client/blocks/reader-excerpt/style.scss
+++ b/client/blocks/reader-excerpt/style.scss
@@ -1,0 +1,15 @@
+.reader-excerpt {
+	sup, sub {
+		vertical-align: baseline;
+		position: relative;
+		font-size: 0.83em;
+	}
+
+	sup {
+		top: -0.4em;
+	}
+
+	sub {
+		bottom: -0.2em;
+	}
+}

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -81,7 +81,7 @@ export default class ReaderPostCard extends React.Component {
 		}
 
 		// ignore clicks on anchors inside inline content
-		if ( closest( event.target, 'a', true, rootNode ) && closest( event.target, '.reader-post-card__excerpt', true, rootNode ) ) {
+		if ( closest( event.target, 'a', true, rootNode ) && closest( event.target, '.reader-excerpt', true, rootNode ) ) {
 			return;
 		}
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -393,7 +393,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	}
 }
 
-.reader-post-card__excerpt {
+.reader-post-card .reader-excerpt {
 	font-size: 15px;
 	line-height: 1.6;
 	font-weight: 100;
@@ -404,26 +404,12 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	p {
 		margin: 0;
 	}
-
-	sup, sub {
-		vertical-align: baseline;
-		position: relative;
-		font-size: 0.83em;
-	}
-
-	sup {
-		top: -0.4em;
-	}
-
-	sub {
-		bottom: -0.2em;
-	}
 }
 
 // If it's not a discover card, clamp lines
 .reader-post-card.card:not(.is-discover) {
 
-	.reader-post-card__excerpt {
+	.reader-excerpt {
 		overflow: hidden;
 		max-height: 15px * 1.6 * 3;
 
@@ -440,7 +426,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		}
 	}
 
-	.reader-post-card__excerpt[direction=rtl] {
+	.reader-excerpt[direction=rtl] {
 		&::before {
 			@include long-content-fade( $direction: left, $size: 15px * 1.6 * 5 );
 			top: inherit;
@@ -448,7 +434,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		}
 	}
 
-	.reader-post-card__excerpt[direction=ltr] {
+	.reader-excerpt[direction=ltr] {
 		&::before {
 			@include long-content-fade( $direction: right, $size: 15px * 1.6 * 5 );
 			top: inherit;
@@ -460,7 +446,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 // 3 line excerpt for thumbnail cards
 .reader-post-card.card.has-thumbnail:not(.is-gallery):not(.is-discover) {
 
-	.reader-post-card__excerpt {
+	.reader-excerpt {
 		max-height: 15px * 1.6 * 3;
 		overflow: hidden;
 	}


### PR DESCRIPTION
The recently added ReaderExcerpt block still uses `.reader-post-card__excerpt` as its class name, and it should be `.reader-excerpt`.

This PR updates the class name in the component and all related styles.

### To test

Ensure that excerpts look as expected on Reader streams. Ensure that Discover (`/discover`) still has three line excerpts.