### PR TITLE
Reader Search: if we don't have any search suggestions, hide the suggestions section

### DIFF
--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -235,9 +235,11 @@ class SearchStream extends Component {
 							delayTimeout={ 500 }
 							placeholder={ searchPlaceholderText } />
 					</CompactCard>
-					<p className="search-stream__blank-suggestions">
-						{ this.props.translate( 'Suggestions: {{suggestions /}}.', { components: { suggestions: sugList } } ) }
-					</p>
+					{ this.state.suggestions &&
+						<p className="search-stream__blank-suggestions">
+							{ this.props.translate( 'Suggestions: {{suggestions /}}.', { components: { suggestions: sugList } } ) }
+						</p>
+					}
 					<hr className="search-stream__fixed-area-separator" />
 				</div>
 			</Stream>


### PR DESCRIPTION
I recently discovered in #11547 that the search suggestions section is shown as:

<img width="862" alt="ff6b79fe-f944-11e6-87eb-af6eb6b653ae" src="https://cloud.githubusercontent.com/assets/17325/23272817/9e9673b2-f9f4-11e6-939c-99a56baa29a0.png">

...for locales other than `en`.

This PR hides the suggestions section entirely if there are no suggestions available.

### To test

Set your interface language to anything other than `en` (French will do nicely):

http://calypso.localhost:3000/me/account

Head to Reader Search and make sure the search suggestions section under the search input is not shown at all.

Fixes #11547.
