### PR TITLE
AT: update eligibility screen design

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.jsx
+++ b/client/blocks/eligibility-warnings/hold-list.jsx
@@ -115,7 +115,6 @@ export const HoldList = ( {
 								compact
 								href={ holdMessages[ hold ].supportUrl }
 								rel="noopener noreferrer"
-								target="_blank"
 							>
 								{ translate( 'Resolve' ) }
 							</Button>

--- a/client/blocks/eligibility-warnings/hold-list.jsx
+++ b/client/blocks/eligibility-warnings/hold-list.jsx
@@ -1,0 +1,130 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import { map } from 'lodash';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+
+// Mapping eligibility holds to messages that will be shown to the user
+// TODO: update supportUrls and maybe create similar mapping for warnings
+function getHoldMessages( translate ) {
+	return {
+		PLACEHOLDER: {
+			title: '',
+			description: '',
+			supportUrl: '',
+		},
+		TRANSFER_ALREADY_EXISTS: {
+			title: translate( 'Installation in progress' ),
+			description: translate( 'Another installation is already in progress.' ),
+			supportUrl: 'https://wordpress.com/help'
+		},
+		NO_BUSINESS_PLAN: {
+			title: translate( 'Business plan required' ),
+			description: translate( 'This feature is only allowed on sites with a business plan.' ),
+			supportUrl: 'https://support.wordpress.com/'
+		},
+		NO_JETPACK_SITES: {
+			title: translate( 'Jetpack site' ),
+			description: translate( 'This feature is not supported on Jetpack sites.' ),
+			supportUrl: 'https://wordpress.com/help'
+		},
+		NO_VIP_SITES: {
+			title: translate( 'VIP site' ),
+			description: translate( 'This feature is not supported on VIP sites.' ),
+			supportUrl: 'https://wordpress.com/help'
+		},
+		SITE_PRIVATE: {
+			title: translate( 'Private site' ),
+			description: translate( 'This feature is not supported on private sites.' ),
+			supportUrl: 'https://support.wordpress.com/'
+		},
+		SITE_GRAYLISTED: {
+			title: translate( 'Flagged site' ),
+			description: translate( 'This feature is not supported on sites that are not in good standing.' ),
+			supportUrl: 'https://wordpress.com/help'
+		},
+		NON_ADMIN_USER: {
+			title: translate( 'Admin access required' ),
+			description: translate( 'Only site administrators are allowed to use this feature.' ),
+			supportUrl: 'https://support.wordpress.com/user-roles/'
+		},
+		NOT_USING_CUSTOM_DOMAIN: {
+			title: translate( 'No custom domain' ),
+			description: translate( 'Your site must use a custom domain to use this feature.' ),
+			supportUrl: 'https://support.wordpress.com/register-domain/'
+		},
+		NOT_DOMAIN_OWNER: {
+			title: translate( 'Not a custom domain owner' ),
+			description: translate( 'You must be the owner of the primary domain subscription to use this feature.' ),
+			supportUrl: 'https://support.wordpress.com/domains/'
+		},
+		NO_WPCOM_NAMESERVERS: {
+			title: translate( 'No WordPress.com name servers' ),
+			description: translate( 'Your custom domain must point to WordPress.com name servers.' ),
+			supportUrl: 'https://support.wordpress.com/domain-helper/'
+		},
+		NOT_RESOLVING_TO_WPCOM: {
+			title: translate( 'Primary domain not pointing to WordPress.com servers' ),
+			description: translate( 'Your primary domain must point to WordPress.com servers.' ),
+			supportUrl: 'https://support.wordpress.com/domain-helper/'
+		},
+		NO_SSL_CERTIFICATE: {
+			title: translate( 'Primary domain does not have a valid SSL certificate' ),
+			description: translate( 'You will be able to proceed once we finish setting up some security settings for the site.' ),
+			supportUrl: 'https://wordpress.com/help'
+		}
+	};
+}
+
+export const HoldList = ( {
+	holds,
+	translate,
+} ) => {
+	const holdMessages = getHoldMessages( translate );
+
+	return (
+		<div>
+			<SectionHeader label={ translate(
+				'Please resolve this issue:',
+				'Please resolve these issues:',
+				{ count: holds.length }
+			) } />
+			<Card className="eligibility-warnings__hold-list">
+				{ map( holds, ( hold, index ) =>
+					<div className="eligibility-warnings__hold" key={ index }>
+						<Gridicon icon="notice-outline" size={ 24 } />
+						<div className="eligibility-warnings__message">
+							<span className="eligibility-warnings__message-title">
+								{ holdMessages[ hold ].title }
+							</span>:&nbsp;
+							<span className="eligibility-warnings__message-description">
+								{ holdMessages[ hold ].description }
+							</span>
+						</div>
+						<div className="eligibility-warnings__action">
+							<Button
+								compact
+								href={ holdMessages[ hold ].supportUrl }
+								rel="noopener noreferrer"
+								target="_blank"
+							>
+								{ translate( 'Resolve' ) }
+							</Button>
+						</div>
+					</div>
+				) }
+			</Card>
+		</div>
+	);
+};
+
+export default localize( HoldList );

--- a/client/blocks/eligibility-warnings/hold-list.jsx
+++ b/client/blocks/eligibility-warnings/hold-list.jsx
@@ -99,8 +99,8 @@ export const HoldList = ( {
 				{ count: holds.length }
 			) } />
 			<Card className="eligibility-warnings__hold-list">
-				{ map( holds, ( hold, index ) =>
-					<div className="eligibility-warnings__hold" key={ index }>
+				{ map( holds, hold =>
+					<div className="eligibility-warnings__hold" key={ hold }>
 						<Gridicon icon="notice-outline" size={ 24 } />
 						<div className="eligibility-warnings__message">
 							<span className="eligibility-warnings__message-title">

--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -19,6 +19,7 @@ import Banner from 'components/banner';
 import Button from 'components/button';
 import Card from 'components/card';
 import HoldList from './hold-list';
+import Notice from 'components/notice';
 import QueryEligibility from 'components/data/query-atat-eligibility';
 import WarningList from './warning-list';
 
@@ -80,12 +81,20 @@ export const EligibilityWarnings = ( {
 			{ holds.length > 0 && <HoldList holds={ holds } /> }
 			{ warnings.length > 0 && <WarningList warnings={ warnings } /> }
 
+			{ isEligible && 0 === holds.length && 0 === warnings.length &&
+				<Notice
+					showDismiss={ false }
+					status="is-success"
+					text={ translate( 'No conflicts detected.' ) }
+				/>
+			}
+
 			<Card className="eligibility-warnings__confirm-box">
 				<div className="eligibility-warnings__confirm-text">
 					{ ! isEligible && translate(
 						'You must resolve the errors above before proceeding. '
 					) }
-					{ isEligible && translate(
+					{ isEligible && warnings.length > 0 && translate(
 						'If you proceed you will no longer be able to use these features. '
 					) }
 					{ translate( 'Have questions? Please {{a}}contact support{{/a}}.',

--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -10,8 +10,12 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import { PLAN_BUSINESS, FEATURE_UPLOAD_PLUGINS, FEATURE_UPLOAD_THEMES } from 'lib/plans/constants';
+import { isBusiness, isEnterprise } from 'lib/products-values';
 import { getEligibility, isEligibleForAutomatedTransfer } from 'state/automated-transfer/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
+import Banner from 'components/banner';
 import Button from 'components/button';
 import Card from 'components/card';
 import HoldList from './hold-list';
@@ -21,12 +25,15 @@ import WarningList from './warning-list';
 export const EligibilityWarnings = ( {
 	backUrl,
 	eligibilityData,
+	hasBusinessPlan,
 	isEligible,
+	isJetpack,
 	isPlaceholder,
 	onProceed,
 	siteId,
 	translate,
 } ) => {
+	const context = -1 !== backUrl.indexOf( 'plugins' ) ? 'plugins' : 'themes';
 	const holds = get( eligibilityData, 'eligibilityHolds', [ 'PLACEHOLDER', 'PLACEHOLDER' ] );
 	const warnings = get( eligibilityData, 'eligibilityWarnings', [] );
 
@@ -38,6 +45,23 @@ export const EligibilityWarnings = ( {
 	return (
 		<div className={ classes }>
 			<QueryEligibility siteId={ siteId } />
+
+			{ 'plugins' === context && ! hasBusinessPlan && ! isJetpack &&
+				<Banner
+					description={ translate( 'Please upgrade to install this plugin.' ) }
+					feature={ FEATURE_UPLOAD_PLUGINS }
+					plan={ PLAN_BUSINESS }
+					title={ translate( 'Business plan required' ) }
+				/>
+			}
+			{ 'themes' === context && ! hasBusinessPlan && ! isJetpack &&
+				<Banner
+					description={ translate( 'Unlimited themes, advanced customization, no ads, live chat support, and more!' ) }
+					feature={ FEATURE_UPLOAD_THEMES }
+					plan={ PLAN_BUSINESS }
+					title={ translate( 'To upload themes, upgrade to Business Plan' ) }
+				/>
+			}
 
 			{ holds.length > 0 && <HoldList holds={ holds } /> }
 			{ warnings.length > 0 && <WarningList warnings={ warnings } /> }
@@ -83,14 +107,18 @@ EligibilityWarnings.defaultProps = {
 };
 
 const mapStateToProps = state => {
-	const siteId = getSelectedSiteId( state );
+	const { ID: siteId, plan } = getSelectedSite( state );
 	const eligibilityData = getEligibility( state, siteId );
 	const isEligible = isEligibleForAutomatedTransfer( state, siteId );
+	const hasBusinessPlan = isBusiness( plan ) || isEnterprise( plan );
+	const isJetpack = isJetpackSite( state, siteId );
 	const dataLoaded = !! eligibilityData.lastUpdate;
 
 	return {
 		eligibilityData,
+		hasBusinessPlan,
 		isEligible,
+		isJetpack,
 		isPlaceholder: ! dataLoaded,
 		siteId,
 	};

--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { difference, filter, get, includes, noop } from 'lodash';
 import classNames from 'classnames';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -19,7 +20,6 @@ import Banner from 'components/banner';
 import Button from 'components/button';
 import Card from 'components/card';
 import HoldList from './hold-list';
-import Notice from 'components/notice';
 import QueryEligibility from 'components/data/query-atat-eligibility';
 import WarningList from './warning-list';
 
@@ -82,11 +82,12 @@ export const EligibilityWarnings = ( {
 			{ warnings.length > 0 && <WarningList warnings={ warnings } /> }
 
 			{ isEligible && 0 === holds.length && 0 === warnings.length &&
-				<Notice
-					showDismiss={ false }
-					status="is-success"
-					text={ translate( 'No conflicts detected.' ) }
-				/>
+				<Card className="eligibility-warnings__no-conflicts">
+					<Gridicon icon="thumbs-up" size={ 24 } />
+					<span>
+						{ translate( 'This site is eligible to install plugins and upload themes.' ) }
+					</span>
+				</Card>
 			}
 
 			<Card className="eligibility-warnings__confirm-box">

--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -2,159 +2,47 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
-import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, map, noop } from 'lodash';
-import Gridicon from 'gridicons';
+import { get, noop } from 'lodash';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
-import Card from 'components/card';
 import { getEligibility, isEligibleForAutomatedTransfer } from 'state/automated-transfer/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import SectionHeader from 'components/section-header';
+import Button from 'components/button';
+import Card from 'components/card';
+import HoldList from './hold-list';
 import QueryEligibility from 'components/data/query-atat-eligibility';
+import WarningList from './warning-list';
 
-// Mapping eligibility holds to messages that will be shown to the user
-// TODO: update supportUrls and maybe create similar mapping for warnings
-function getHoldMessages( translate ) {
-	return {
-		PLACEHOLDER: {
-			title: '',
-			description: '',
-			supportUrl: '',
-		},
-		TRANSFER_ALREADY_EXISTS: {
-			title: translate( 'Installation in progress' ),
-			description: translate( 'Another installation is already in progress.' ),
-			supportUrl: 'https://wordpress.com/help'
-		},
-		NO_BUSINESS_PLAN: {
-			title: translate( 'Business plan required' ),
-			description: translate( 'This feature is only allowed on sites with a business plan.' ),
-			supportUrl: 'https://support.wordpress.com/'
-		},
-		NO_JETPACK_SITES: {
-			title: translate( 'Jetpack site' ),
-			description: translate( 'This feature is not supported on Jetpack sites.' ),
-			supportUrl: 'https://wordpress.com/help'
-		},
-		NO_VIP_SITES: {
-			title: translate( 'VIP site' ),
-			description: translate( 'This feature is not supported on VIP sites.' ),
-			supportUrl: 'https://wordpress.com/help'
-		},
-		SITE_PRIVATE: {
-			title: translate( 'Private site' ),
-			description: translate( 'This feature is not supported on private sites.' ),
-			supportUrl: 'https://support.wordpress.com/'
-		},
-		SITE_GRAYLISTED: {
-			title: translate( 'Flagged site' ),
-			description: translate( 'This feature is not supported on sites that are not in good standing.' ),
-			supportUrl: 'https://wordpress.com/help'
-		},
-		NON_ADMIN_USER: {
-			title: translate( 'Admin access required' ),
-			description: translate( 'Only site administrators are allowed to use this feature.' ),
-			supportUrl: 'https://support.wordpress.com/user-roles/'
-		},
-		NOT_USING_CUSTOM_DOMAIN: {
-			title: translate( 'No custom domain' ),
-			description: translate( 'Your site must use a custom domain to use this feature.' ),
-			supportUrl: 'https://support.wordpress.com/register-domain/'
-		},
-		NOT_DOMAIN_OWNER: {
-			title: translate( 'Not a custom domain owner' ),
-			description: translate( 'You must be the owner of the primary domain subscription to use this feature.' ),
-			supportUrl: 'https://support.wordpress.com/domains/'
-		},
-		NO_WPCOM_NAMESERVERS: {
-			title: translate( 'No WordPress.com name servers' ),
-			description: translate( 'Your custom domain must point to WordPress.com name servers.' ),
-			supportUrl: 'https://support.wordpress.com/domain-helper/'
-		},
-		NOT_RESOLVING_TO_WPCOM: {
-			title: translate( 'Primary domain not pointing to WordPress.com servers' ),
-			description: translate( 'Your primary domain must point to WordPress.com servers.' ),
-			supportUrl: 'https://support.wordpress.com/domain-helper/'
-		},
-		NO_SSL_CERTIFICATE: {
-			title: translate( 'Primary domain does not have a valid SSL certificate' ),
-			description: translate( 'You will be able to proceed once we finish setting up some security settings for the site.' ),
-			supportUrl: 'https://wordpress.com/help'
-		}
-	};
-}
-
-const EligibilityWarnings = props => {
-	const {
-		translate,
-		backUrl,
-		onProceed,
-		siteId,
-		isEligible,
-		eligibilityData,
-		isPlaceholder,
-	} = props;
-
-	const holdMessages = getHoldMessages( translate );
+export const EligibilityWarnings = ( {
+	backUrl,
+	eligibilityData,
+	isEligible,
+	isPlaceholder,
+	onProceed,
+	siteId,
+	translate,
+} ) => {
 	const holds = get( eligibilityData, 'eligibilityHolds', [ 'PLACEHOLDER', 'PLACEHOLDER' ] );
 	const warnings = get( eligibilityData, 'eligibilityWarnings', [] );
 
-	const classes = classNames( {
-		'eligibility-warnings__message': true,
-		'eligibility-warnings__placeholder': isPlaceholder,
-	} );
+	const classes = classNames(
+		'eligibility-warnings',
+		{ 'eligibility-warnings__placeholder': isPlaceholder }
+	);
 
 	return (
-		<div className="eligibility-warnings">
+		<div className={ classes }>
 			<QueryEligibility siteId={ siteId } />
-			<SectionHeader label={ translate( 'Conflicts' ) } />
 
-			{ map( holds, ( error, index ) =>
-				<Card key={ index } className={ classes }>
-					<Gridicon icon="notice" className="eligibility-warnings__error-icon" />
-					<div className="eligibility-warnings__message-content">
-						<div className="eligibility-warnings__message-title">
-							{ translate( 'Error: %(title)s', { args: { title: holdMessages[ error ].title } } ) }
-						</div>
-						<div className="eligibility-warnings__message-description">
-							{ holdMessages[ error ].description }
-						</div>
-					</div>
-					<div className="eligibility-warnings__message-action">
-						<Button href={ holdMessages[ error ].supportUrl } target="_blank" rel="noopener noreferrer">
-							{ translate( 'Resolve' ) }
-						</Button>
-					</div>
-				</Card>
-			) }
-
-			{ map( warnings, ( { name, description, supportUrl }, index ) =>
-				<Card key={ index } className={ classes }>
-					<Gridicon icon="notice" className="eligibility-warnings__warning-icon" />
-					<div className="eligibility-warnings__message-content">
-						<div className="eligibility-warnings__message-title">
-							{ translate( 'Unsupported feature: %(name)s', { args: { name } } ) }
-						</div>
-						<div className="eligibility-warnings__message-description">
-							{ description }
-						</div>
-					</div>
-					<div className="eligibility-warnings__message-action">
-						<a href={ supportUrl } target="_blank" rel="noopener noreferrer">
-							<Gridicon icon="help-outline" className="eligibility-warnings__warning-action" />
-						</a>
-					</div>
-				</Card>
-			) }
+			{ holds.length > 0 && <HoldList holds={ holds } /> }
+			{ warnings.length > 0 && <WarningList warnings={ warnings } /> }
 
 			<Card className="eligibility-warnings__confirm-box">
-				<Gridicon icon="info-outline" className="eligibility-warnings__confirm-icon" />
 				<div className="eligibility-warnings__confirm-text">
 					{ ! isEligible && translate(
 						'You must resolve the errors above before proceeding. '
@@ -170,7 +58,7 @@ const EligibilityWarnings = props => {
 						}
 					) }
 				</div>
-				<div className="eligibility-warnings__buttons">
+				<div className="eligibility-warnings__confirm-buttons">
 					<Button href={ backUrl }>
 						{ translate( 'Cancel' ) }
 					</Button>
@@ -197,13 +85,14 @@ EligibilityWarnings.defaultProps = {
 const mapStateToProps = state => {
 	const siteId = getSelectedSiteId( state );
 	const eligibilityData = getEligibility( state, siteId );
+	const isEligible = isEligibleForAutomatedTransfer( state, siteId );
 	const dataLoaded = !! eligibilityData.lastUpdate;
 
 	return {
-		siteId,
 		eligibilityData,
-		isEligible: isEligibleForAutomatedTransfer( state, siteId ),
+		isEligible,
 		isPlaceholder: ! dataLoaded,
+		siteId,
 	};
 };
 

--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -4,7 +4,7 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { difference, filter, get, includes, noop } from 'lodash';
+import { get, includes, noop, partition } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 
@@ -35,13 +35,14 @@ export const EligibilityWarnings = ( {
 	siteSlug,
 	translate,
 } ) => {
-	const context = -1 !== backUrl.indexOf( 'plugins' ) ? 'plugins' : 'themes';
+	const context = includes( backUrl, 'plugins' ) ? 'plugins' : 'themes';
 
 	const warnings = get( eligibilityData, 'eligibilityWarnings', [] );
 
-	let holds = get( eligibilityData, 'eligibilityHolds', [ 'PLACEHOLDER', 'PLACEHOLDER' ] );
-	const bannerHolds = filter( holds, hold => -1 !== [ 'NO_BUSINESS_PLAN', 'NOT_USING_CUSTOM_DOMAIN' ].indexOf( hold ) );
-	holds = difference( holds, bannerHolds );
+	const [ bannerHolds, listHolds ] = partition(
+		get( eligibilityData, 'eligibilityHolds', [ 'PLACEHOLDER', 'PLACEHOLDER' ] ),
+		hold => includes( [ 'NO_BUSINESS_PLAN', 'NOT_USING_CUSTOM_DOMAIN' ], hold ),
+	);
 
 	const classes = classNames(
 		'eligibility-warnings',
@@ -78,10 +79,10 @@ export const EligibilityWarnings = ( {
 				/>
 			}
 
-			{ holds.length > 0 && <HoldList holds={ holds } /> }
+			{ listHolds.length > 0 && <HoldList holds={ listHolds } /> }
 			{ warnings.length > 0 && <WarningList warnings={ warnings } /> }
 
-			{ isEligible && 0 === holds.length && 0 === warnings.length &&
+			{ isEligible && 0 === listHolds.length && 0 === warnings.length &&
 				<Card className="eligibility-warnings__no-conflicts">
 					<Gridicon icon="thumbs-up" size={ 24 } />
 					<span>

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -25,12 +25,16 @@
 .eligibility-warnings .card {
 	margin: 0;
 }
+
 .eligibility-warnings .banner {
 	margin-bottom: 16px;
 	.banner__icon-circle {
 		padding: 4px;
 	}
+}
 
+.eligibility-warnings .notice {
+	margin-bottom: 16px;
 }
 
 .eligibility-warnings__hold,
@@ -82,7 +86,7 @@
 
 .eligibility-warnings__confirm-box {
 	flex-wrap: wrap;
-	justify-content: center;
+	justify-content: flex-end;
 
 	.eligibility-warnings__confirm-text {
 		color: $gray-text-min;

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -27,6 +27,10 @@
 }
 .eligibility-warnings .banner {
 	margin-bottom: 16px;
+	.banner__icon-circle {
+		padding: 4px;
+	}
+
 }
 
 .eligibility-warnings__hold,
@@ -46,7 +50,8 @@
 	}
 }
 
-.eligibility-warnings .gridicon {
+.eligibility-warnings__hold .gridicon,
+.eligibility-warnings__warning > .gridicon {
 	color: $alert-red;
 	flex-shrink: 0;
 }

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -1,76 +1,88 @@
 .eligibility-warnings {
-    margin-top: 32px;
-    font-size: 14px;
-    font-weight: 400;
-    line-height: 1.5;
+	margin-top: 32px;
+	font-size: 14px;
 }
 
 .eligibility-warnings__placeholder {
-    @include placeholder();
-}
+	@include placeholder();
 
-.eligibility-warnings__placeholder .eligibility-warnings__message-content {
-    color: $gray-light;
-    background-color: $gray-light;
-}
+	.section-header__label-text,
+	.eligibility-warnings__message {
+		color: $gray-light;
+		background-color: $gray-light;
+	}
 
-.eligibility-warnings__placeholder .eligibility-warnings__error-icon{
-    color: $gray-light;
-}
+	.gridicon {
+		color: $gray-light;
+	}
 
-.eligibility-warnings__placeholder .eligibility-warnings__message-action .button {
-    display: none;
+	.button,
+	.eligibility-warnings__confirm-box {
+		display: none;
+	}
 }
 
 .eligibility-warnings .card {
-    margin: 0;
-    display: flex;
+	margin: 0;
+}
+
+.eligibility-warnings__hold,
+.eligibility-warnings__warning,
+.eligibility-warnings__confirm-box.card {
+	align-items: center;
+	display: flex;
+	flex-direction: row;
+}
+
+.eligibility-warnings__hold,
+.eligibility-warnings__warning {
+	margin-bottom: 16px;
+
+	&:last-child {
+		margin-bottom: 0;
+	}
+}
+
+.eligibility-warnings .gridicon {
+	color: $alert-red;
+	flex-shrink: 0;
 }
 
 .eligibility-warnings__message {
-    display: flex;
-    align-items: center;
-    flex-direction: row;
-    min-height: 80px;
+	flex-grow: 1;
+	padding: 0 16px;
+
+	.eligibility-warnings__message-title {
+		font-weight: 600;
+	}
+
+	.eligibility-warnings__message-description {
+		color: $gray-text-min;
+	}
 }
 
-.eligibility-warnings__message-content {
-    flex-grow: 1;
-    margin: 0 16px;
-}
-
-.eligibility-warnings__message-description,
-.eligibility-warnings__warning-action,
-.eligibility-warnings__confirm-icon {
-    color: $gray;
-}
-
-.eligibility-warnings__error-icon {
-    color: $alert-red;
-    flex-shrink: 0;
-}
-
-.eligibility-warnings__warning-icon {
-    color: $alert-yellow;
-    flex-shrink: 0;
+.eligibility-warnings__action a {
+	.gridicons-help-outline {
+		color: $gray;
+	}
+	&:hover .gridicons-help-outline {
+		color: $blue-wordpress;
+	}
 }
 
 .eligibility-warnings__confirm-box {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: center;
-}
+	flex-wrap: wrap;
+	justify-content: center;
 
-.eligibility-warnings__confirm-text {
-    flex-grow: 1;
-    color: $gray;
-    font-style: italic;
-    flex-basis: 60%;
-    margin: 8px 16px;
-}
+	.eligibility-warnings__confirm-text {
+		color: $gray-text-min;
+		flex-basis: 60%;
+		flex-grow: 1;
+		font-style: italic;
+		padding: 8px 0;
+	}
 
-.eligibility-warnings__confirm-box .button {
-    margin-left: 16px;
+	.button {
+		margin-left: 16px;
+	}
 }

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -43,6 +43,7 @@
 
 .eligibility-warnings__hold,
 .eligibility-warnings__warning {
+	align-items: flex-start;
 	margin-bottom: 16px;
 
 	&:last-child {
@@ -58,6 +59,7 @@
 
 .eligibility-warnings__message {
 	flex-grow: 1;
+	line-height: 24px;
 	padding: 0 16px;
 
 	.eligibility-warnings__message-title {

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -1,5 +1,5 @@
 .eligibility-warnings {
-	margin-top: 32px;
+	margin-top: 16px;
 	font-size: 14px;
 }
 
@@ -24,6 +24,9 @@
 
 .eligibility-warnings .card {
 	margin: 0;
+}
+.eligibility-warnings .banner {
+	margin-bottom: 16px;
 }
 
 .eligibility-warnings__hold,

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -33,10 +33,6 @@
 	}
 }
 
-.eligibility-warnings .notice {
-	margin-bottom: 16px;
-}
-
 .eligibility-warnings__hold,
 .eligibility-warnings__warning,
 .eligibility-warnings__confirm-box.card {
@@ -81,6 +77,21 @@
 	}
 	&:hover .gridicons-help-outline {
 		color: $blue-wordpress;
+	}
+}
+
+.eligibility-warnings__no-conflicts.card {
+	align-items: center;
+	display: flex;
+
+	.gridicon {
+		color: $gray-text-min;
+		flex-shrink: 0;
+	}
+	span {
+		display: block;
+		flex-grow: 1;
+		padding-left: 16px;
 	}
 }
 

--- a/client/blocks/eligibility-warnings/warning-list.jsx
+++ b/client/blocks/eligibility-warnings/warning-list.jsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import { map } from 'lodash';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import ExternalLink from 'components/external-link';
+import SectionHeader from 'components/section-header';
+
+export const WarningList = ( {
+	translate,
+	warnings,
+} ) => {
+	return (
+		<div>
+			<SectionHeader label={ translate(
+				"By proceeding you'll lose %d feature:",
+				"By proceeding you'll lose these %d features:",
+				{
+					count: warnings.length,
+					args: warnings.length,
+				}
+			) } />
+			<Card className="eligibility-warnings__warning-list">
+				{ map( warnings, ( { name, description, supportUrl }, index ) =>
+					<div className="eligibility-warnings__warning" key={ index }>
+						<Gridicon icon="cross" size={ 24 } />
+						<div className="eligibility-warnings__message">
+							<span className="eligibility-warnings__message-title">
+								{ name }
+							</span>:&nbsp;
+							<span className="eligibility-warnings__message-description">
+								{ description }
+							</span>
+						</div>
+						<div className="eligibility-warnings__action">
+							<ExternalLink href={ supportUrl } target="_blank" rel="noopener noreferrer">
+								<Gridicon icon="help-outline" size={ 24 } />
+							</ExternalLink>
+						</div>
+					</div>
+				) }
+			</Card>
+		</div>
+	);
+};
+
+export default localize( WarningList );

--- a/client/blocks/eligibility-warnings/warning-list.jsx
+++ b/client/blocks/eligibility-warnings/warning-list.jsx
@@ -30,7 +30,7 @@ export const WarningList = ( {
 			<Card className="eligibility-warnings__warning-list">
 				{ map( warnings, ( { name, description, supportUrl }, index ) =>
 					<div className="eligibility-warnings__warning" key={ index }>
-						<Gridicon icon="cross" size={ 24 } />
+						<Gridicon icon="cross-small" size={ 24 } />
 						<div className="eligibility-warnings__message">
 							<span className="eligibility-warnings__message-title">
 								{ name }

--- a/client/blocks/eligibility-warnings/warning-list.jsx
+++ b/client/blocks/eligibility-warnings/warning-list.jsx
@@ -16,39 +16,36 @@ import SectionHeader from 'components/section-header';
 export const WarningList = ( {
 	translate,
 	warnings,
-} ) => {
-	return (
-		<div>
-			<SectionHeader label={ translate(
-				"By proceeding you'll lose %d feature:",
-				"By proceeding you'll lose these %d features:",
-				{
-					count: warnings.length,
-					args: warnings.length,
-				}
-			) } />
-			<Card className="eligibility-warnings__warning-list">
-				{ map( warnings, ( { name, description, supportUrl }, index ) =>
-					<div className="eligibility-warnings__warning" key={ index }>
-						<Gridicon icon="cross-small" size={ 24 } />
-						<div className="eligibility-warnings__message">
-							<span className="eligibility-warnings__message-title">
-								{ name }
-							</span>:&nbsp;
-							<span className="eligibility-warnings__message-description">
-								{ description }
-							</span>
-						</div>
-						<div className="eligibility-warnings__action">
-							<ExternalLink href={ supportUrl } target="_blank" rel="noopener noreferrer">
-								<Gridicon icon="help-outline" size={ 24 } />
-							</ExternalLink>
-						</div>
+} ) =>
+	<div>
+		<SectionHeader label={ translate(
+			"By proceeding you'll lose %d feature:",
+			"By proceeding you'll lose these %d features:",
+			{
+				count: warnings.length,
+				args: warnings.length,
+			}
+		) } />
+		<Card className="eligibility-warnings__warning-list">
+			{ map( warnings, ( { name, description, supportUrl }, index ) =>
+				<div className="eligibility-warnings__warning" key={ index }>
+					<Gridicon icon="cross-small" size={ 24 } />
+					<div className="eligibility-warnings__message">
+						<span className="eligibility-warnings__message-title">
+							{ name }
+						</span>:&nbsp;
+						<span className="eligibility-warnings__message-description">
+							{ description }
+						</span>
 					</div>
-				) }
-			</Card>
-		</div>
-	);
-};
+					<div className="eligibility-warnings__action">
+						<ExternalLink href={ supportUrl } target="_blank" rel="noopener noreferrer">
+							<Gridicon icon="help-outline" size={ 24 } />
+						</ExternalLink>
+					</div>
+				</div>
+			) }
+		</Card>
+	</div>;
 
 export default localize( WarningList );

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -48,6 +48,8 @@ import { connectOptions } from 'my-sites/themes/theme-options';
 import EligibilityWarnings from 'blocks/eligibility-warnings';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import { getBackPath } from 'state/themes/themes-ui/selectors';
+import { hasFeature } from 'state/sites/plans/selectors';
+import { FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
 import QueryEligibility from 'components/data/query-atat-eligibility';
 import {
 	getEligibility,
@@ -362,7 +364,9 @@ export default connect(
 		);
 		return {
 			siteId,
+			isBusiness: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
 			selectedSite: getSelectedSite( state ),
+			isJetpack,
 			inProgress: isUploadInProgress( state, siteId ),
 			complete: isUploadComplete( state, siteId ),
 			failed: hasUploadFailed( state, siteId ),

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -301,6 +301,7 @@ class Upload extends React.Component {
 			themeId,
 			upgradeJetpack,
 			backPath,
+			isJetpack,
 			isMultisite
 		} = this.props;
 

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -48,9 +48,6 @@ import { connectOptions } from 'my-sites/themes/theme-options';
 import EligibilityWarnings from 'blocks/eligibility-warnings';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import { getBackPath } from 'state/themes/themes-ui/selectors';
-import { hasFeature } from 'state/sites/plans/selectors';
-import Banner from 'components/banner';
-import { PLAN_BUSINESS, FEATURE_UNLIMITED_PREMIUM_THEMES, FEATURE_UPLOAD_THEMES } from 'lib/plans/constants';
 import QueryEligibility from 'components/data/query-atat-eligibility';
 import {
 	getEligibility,
@@ -302,8 +299,6 @@ class Upload extends React.Component {
 			themeId,
 			upgradeJetpack,
 			backPath,
-			isBusiness,
-			isJetpack,
 			isMultisite
 		} = this.props;
 
@@ -326,11 +321,6 @@ class Upload extends React.Component {
 					site={ selectedSite }
 					source="upload" />
 				<HeaderCake backHref={ backPath }>{ translate( 'Upload theme' ) }</HeaderCake>
-				{ ! isBusiness && ! isJetpack && <Banner
-					feature={ FEATURE_UPLOAD_THEMES }
-					plan={ PLAN_BUSINESS }
-					title={ translate( 'To upload themes, upgrade to Business Plan' ) }
-					description={ translate( 'Unlimited themes, advanced customization, no ads, live chat support, and more!' ) } /> }
 				{ upgradeJetpack && <JetpackManageErrorPage
 					template="updateJetpack"
 					siteId={ siteId }
@@ -372,9 +362,7 @@ export default connect(
 		);
 		return {
 			siteId,
-			isBusiness: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
 			selectedSite: getSelectedSite( state ),
-			isJetpack,
 			inProgress: isUploadInProgress( state, siteId ),
 			complete: isUploadComplete( state, siteId ),
 			failed: hasUploadFailed( state, siteId ),


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/11394, https://github.com/Automattic/wp-calypso/issues/11486, and https://github.com/Automattic/wp-calypso/issues/11514

This PR aims at updating the eligibility screen design - for both plugins and themes flows - to be more clear and less scary.

The current logic for showing the upgrade banners follows this cascading checks:

- Has no Business Plan? Show an "Upgrade to Business Plan" banner.
- Has Business Plan but no custom domain? Show an "Add a free custom domain" banner.

Each banner is expected to come in two copy-flavours, for plugins and themes.
E.g. "Upgrade to Business Plan to install this plugin", or "Upgrade to Business Plan to upload this theme".

Of all the holds currently covered (see: https://github.com/Automattic/wp-calypso/blob/master/client/blocks/eligibility-warnings/index.jsx#L23-L71), only `NO_BUSINESS_PLAN` and `NOT_USING_CUSTOM_DOMAIN` are replaced with a banner.

## Future updates

Not currently included in this PR (possibly in a future one):

- Decide if more holds need their own banner.
- Update copy for banners, holds and warnings.
- Update holds' `supportUrl` (possibly using the same logic used for warnings?).

## Screenshots

### Before
<img width="811" alt="screen shot 2017-02-14 at 12 45 17 pm" src="https://cloud.githubusercontent.com/assets/1464705/22949959/d14a042e-f2b8-11e6-8cae-a6602012b2a0.png">

### After

**Non-Business, private**
<img width="686" alt="non-biz-private" src="https://cloud.githubusercontent.com/assets/2070010/23412524/b4747f9e-fdcd-11e6-98e2-513a4d4077a5.png">

**Non-Business, no warnings**
<img width="685" alt="non-biz-no-warnings" src="https://cloud.githubusercontent.com/assets/2070010/23412525/b475450a-fdcd-11e6-9ff9-71c600b567eb.png">

**Business, no domain**
<img width="685" alt="biz-no-domain" src="https://cloud.githubusercontent.com/assets/2070010/23412523/b4745046-fdcd-11e6-943f-91c266e5e7ef.png">

**No conflicts**
<img width="650" alt="screen shot 2017-03-06 at 12 17 05" src="https://cloud.githubusercontent.com/assets/2070010/23609752/768268f6-0267-11e7-82f4-4f22683eab80.png">
*(please don't mind the "upload plugins" typo!)*
