### PR TITLE
Sidebar: replace external noticon with gridicon

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -226,8 +226,7 @@ $z-layers: (
 	// The following may be inserted into different areas.
 	// The parent stacking context may be root, or something else depending on where it is inserted.
 	'icon-parent': (
-		'.sidebar__menu .gridicon.gridicons-external': 1,
-		'.sidebar__menu .noticon-external': 1
+		'.sidebar__menu .gridicon.gridicons-external': 1
 	),
 	'screen-reader-text-parent': (
 		'.screen-reader-text:focus': 100000

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -47,7 +47,7 @@ export default React.createClass( {
 				>
 					<Gridicon icon={ this.props.icon } size={ 24 } />
 					<span className="menu-link-text">{ this.props.label }</span>
-					{ isExternalLink ? <span className="noticon noticon-external" /> : null }
+					{ isExternalLink ? <Gridicon icon="external" size={ 24 } /> : null }
 				</a>
 				{ this.props.children }
 			</li>

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -192,20 +192,6 @@
 			}
 		}
 	}
-
-	.noticon-external {
-		position: absolute;
-			top: 15px;
-			right: 19px;
-		z-index: z-index( 'icon-parent', '.sidebar__menu .noticon-external' );
-		color: $gray;
-
-		@include breakpoint( "<660px" ) {
-			top: 9px;
-			right: 16px;
-			font-size: 32px;
-		}
-	}
 }
 
 a.sidebar__button {

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -535,7 +535,7 @@ export class MySitesSidebar extends Component {
 				<a onClick={ this.trackWpadminClick } href={ site.options.admin_url } target="_blank" rel="noopener noreferrer">
 					<Gridicon icon="my-sites" size={ 24 } />
 					<span className="menu-link-text">{ this.props.translate( 'WP Admin' ) }</span>
-					<span className="noticon noticon-external" />
+					<Gridicon icon="external" size={ 24 } />
 				</a>
 			</li>
 		);


### PR DESCRIPTION
This replaces the noticon used for the WP Admin link, at the bottom the sidebar. I removed the css that was related to the noticon as well.

I also replaced the external icon that was used for sidebar items that linked to wp-admin and were not yet in Calypso. I believe until very recently, this included CPTs in Jetpack. So, currently, there are no links to wp-admin in the sidebar, except for the Customizer (doesn't use external icon) and the WP Admin link.

Tested on latest:

- [x] - Safari
- [x] - Chrome
- [ ] - IE

**To test:**

Select a site that meets one of these:

- non jetpack site with user registration before `2015-09-07` ? (still not sure of cutoff)
- VIP site

Before/After

![screen shot 2017-02-23 at 2 01 23 pm](https://cloud.githubusercontent.com/assets/618551/23277936/609db530-f9d5-11e6-9ab9-bbd01391c0cd.png)