### PR TITLE
Fix Jetpack theme install action.

### DIFF
--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -452,11 +452,8 @@ export function installTheme( themeId, siteId ) {
 		}
 
 		return wpcom.undocumented().installThemeOnJetpack( siteId, themeId )
-			.then( () => {
-				// We do not `dispatch( receiveTheme( theme, siteId ) )` here because
-				// in our UI, themes from WP.com (and WP.org) are already present in
-				// a separate list, and we do not want to duplicate them.
-
+			.then( ( theme ) => {
+				dispatch( receiveTheme( theme, siteId ) );
 				dispatch( {
 					type: THEME_INSTALL_SUCCESS,
 					siteId,


### PR DESCRIPTION
### Info
During install store installed theme in redux state for Jetpack themes. This theme then becomes available for other actions like Try & Customize action. 

### Testing 
Open `design` in single-site mode on Jetpack. Use Try & Customize action on theme that was not previously installed. It should work. 
