### PR TITLE
Editor: Hide SEO description for private/hidden sites

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -27,6 +27,7 @@ import { getEditedPostValue } from 'state/posts/selectors';
 import { getPostType } from 'state/post-types/selectors';
 import { isJetpackMinimumVersion } from 'state/sites/selectors';
 import config from 'config';
+import { isPrivateSite } from 'state/selectors';
 
 import EditorDrawerTaxonomies from './taxonomies';
 import EditorDrawerPageOptions from './page-options';
@@ -249,7 +250,9 @@ const EditorDrawer = React.createClass( {
 
 		const { plan } = this.props.site;
 		const hasBusinessPlan = isBusiness( plan ) || isEnterprise( plan );
-		if ( ! hasBusinessPlan ) {
+		const { isPrivate } = this.props;
+
+		if ( ! hasBusinessPlan || isPrivate ) {
 			return;
 		}
 
@@ -353,7 +356,8 @@ export default connect(
 		return {
 			canJetpackUseTaxonomies: isJetpackMinimumVersion( state, siteId, '4.1' ),
 			jetpackVersionSupportsSeo: isJetpackMinimumVersion( state, siteId, '4.4-beta1' ),
-			typeObject: getPostType( state, siteId, type )
+			typeObject: getPostType( state, siteId, type ),
+			isPrivate: isPrivateSite( state, siteId ),
 		};
 	},
 	null,

--- a/client/state/selectors/is-private-site.js
+++ b/client/state/selectors/is-private-site.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { getRawSite } from 'state/sites/selectors';
+import { getSiteSettings } from 'state/site-settings/selectors';
 
 /**
  * Returns true if the site is private
@@ -12,9 +13,17 @@ import { getRawSite } from 'state/sites/selectors';
  */
 export default function isPrivateSite( state, siteId ) {
 	const site = getRawSite( state, siteId );
-	if ( ! site ) {
-		return null;
+
+	if ( site ) {
+		return site.is_private;
 	}
 
-	return site.is_private;
+	const settings = getSiteSettings( state, siteId );
+
+	if ( settings ) {
+		// Site settings returns a numerical value for blog_public.
+		return parseInt( settings.blog_public, 10 ) === -1;
+	}
+
+	return null;
 }

--- a/client/state/selectors/test/is-private-site.js
+++ b/client/state/selectors/test/is-private-site.js
@@ -9,7 +9,7 @@ import { expect } from 'chai';
 import { isPrivateSite } from '../';
 
 describe( 'isPrivateSite()', () => {
-	it( 'should return null if the site is not known', () => {
+	it( 'should return null if neither the site nor settings are known', () => {
 		const isPrivate = isPrivateSite( {
 			sites: {
 				items: {
@@ -18,10 +18,52 @@ describe( 'isPrivateSite()', () => {
 						is_private: false
 					}
 				}
+			},
+			siteSettings: {
+				items: {}
 			}
 		}, 2916285 );
 
 		expect( isPrivate ).to.be.null;
+	} );
+
+	it( 'should prefer site state', () => {
+		const isPrivate = isPrivateSite( {
+			sites: {
+				items: {
+					2916284: {
+						ID: 2916284,
+						is_private: true
+					}
+				}
+			},
+			siteSettings: {
+				items: {
+					2916284: {
+						blog_public: 1
+					}
+				}
+			}
+		}, 2916284 );
+
+		expect( isPrivate ).to.be.true;
+	} );
+
+	it( 'should fall back to settings state', () => {
+		const isPrivate = isPrivateSite( {
+			sites: {
+				items: {}
+			},
+			siteSettings: {
+				items: {
+					2916284: {
+						blog_public: 1
+					}
+				}
+			}
+		}, 2916284 );
+
+		expect( isPrivate ).to.be.false;
 	} );
 
 	it( 'should return false for public sites', () => {
@@ -31,6 +73,13 @@ describe( 'isPrivateSite()', () => {
 					2916284: {
 						ID: 2916284,
 						is_private: false
+					}
+				}
+			},
+			siteSettings: {
+				items: {
+					2916284: {
+						blog_public: 1
 					}
 				}
 			}
@@ -46,6 +95,13 @@ describe( 'isPrivateSite()', () => {
 					2916284: {
 						ID: 2916284,
 						is_private: true
+					}
+				}
+			},
+			siteSettings: {
+				items: {
+					2916284: {
+						blog_public: -1
 					}
 				}
 			}

--- a/client/state/selectors/test/is-site-supporting-image-editor.js
+++ b/client/state/selectors/test/is-site-supporting-image-editor.js
@@ -13,7 +13,10 @@ describe( 'isSiteSupportingImageEditor()', () => {
 		const siteSupportsImageEditor = isSiteSupportingImageEditor( {
 			sites: {
 				items: {}
-			}
+			},
+			// isPrivateSite falls back on siteSettings.
+			// An empty siteSettings object allows getSiteSettings to pass
+			siteSettings: {}
 		}, 2916284 );
 
 		expect( siteSupportsImageEditor ).to.be.true;

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -135,43 +135,67 @@ export function items( state = {}, action ) {
 		case SITE_SETTINGS_UPDATE:
 		case SITE_SETTINGS_RECEIVE: {
 			const { siteId, settings } = action;
-
-			// A site settings update may or may not include the icon property.
-			// If not, we should simply return state unchanged.
-			if ( ! settings.hasOwnProperty( 'site_icon' ) ) {
-				return state;
-			}
-
-			const mediaId = settings.site_icon;
-
-			// Similarly, return unchanged if next icon matches current value,
-			// accounting for the fact that a non-existent icon property is
-			// equivalent to setting the media icon as null
 			const site = state[ siteId ];
-			if ( ! site || ( ! site.icon && null === mediaId ) ||
-					( site.icon && site.icon.media_id === mediaId ) ) {
+
+			if ( ! site ) {
 				return state;
 			}
 
-			let nextSite;
-			if ( null === mediaId ) {
-				// Unset icon
-				nextSite = omit( site, 'icon' );
-			} else {
-				// Update icon, intentionally removing reference to the URL,
-				// shifting burden of URL lookup to selector
-				nextSite = {
-					...site,
-					icon: {
-						media_id: mediaId
-					}
-				};
-			}
+			let nextSite = site;
 
-			return {
-				...state,
-				[ siteId ]: nextSite
-			};
+			return reduce( [ 'blog_public', 'site_icon' ], ( memo, key ) => {
+				// A site settings update may or may not include the icon or blog_public property.
+				// If not, we should simply return state unchanged.
+				if ( ! settings.hasOwnProperty( key ) ) {
+					return memo;
+				}
+
+				switch ( key ) {
+					case 'blog_public':
+						const isPrivate = parseInt( settings.blog_public, 10 ) === -1;
+
+						if ( site.is_private === isPrivate ) {
+							return memo;
+						}
+
+						nextSite = {
+							...nextSite,
+							is_private: isPrivate
+						};
+						break;
+					case 'site_icon':
+						const mediaId = settings.site_icon;
+						// Return unchanged if next icon matches current value,
+						// accounting for the fact that a non-existent icon property is
+						// equivalent to setting the media icon as null
+						if ( ( ! site.icon && null === mediaId ) ||
+								( site.icon && site.icon.media_id === mediaId ) ) {
+							return memo;
+						}
+
+						if ( null === mediaId ) {
+							// Unset icon
+							nextSite = omit( nextSite, 'icon' );
+						} else {
+							// Update icon, intentionally removing reference to the URL,
+							// shifting burden of URL lookup to selector
+							nextSite = {
+								...nextSite,
+								icon: {
+									media_id: mediaId
+								}
+							};
+						}
+						break;
+				}
+
+				if ( memo === state ) {
+					memo = { ...state };
+				}
+
+				memo[ siteId ] = nextSite;
+				return memo;
+			}, state );
 		}
 
 		case MEDIA_DELETE: {

--- a/client/state/sites/test/reducer.js
+++ b/client/state/sites/test/reducer.js
@@ -397,6 +397,25 @@ describe( 'reducer', () => {
 			expect( state ).to.equal( original );
 		} );
 
+		it( 'should return same state if received privacy setting and matches current value', () => {
+			const original = deepFreeze( {
+				2916284: {
+					ID: 2916284,
+					name: 'WordPress.com Example Blog',
+					is_private: true
+				}
+			} );
+			const state = items( original, {
+				type: SITE_SETTINGS_RECEIVE,
+				siteId: 2916284,
+				settings: {
+					blog_public: -1
+				}
+			} );
+
+			expect( state ).to.equal( original );
+		} );
+
 		it( 'should return same state if received null icon setting and already unset', () => {
 			const original = deepFreeze( {
 				2916284: {
@@ -487,6 +506,59 @@ describe( 'reducer', () => {
 				2916284: {
 					ID: 2916284,
 					name: 'WordPress.com Example Blog',
+					icon: {
+						media_id: 42
+					}
+				}
+			} );
+		} );
+
+		it( 'should return site with false privacy setting if received blog_public of 1', () => {
+			const original = deepFreeze( {
+				2916284: {
+					ID: 2916284,
+					name: 'WordPress.com Example Blog',
+					is_private: true
+				}
+			} );
+			const state = items( original, {
+				type: SITE_SETTINGS_RECEIVE,
+				siteId: 2916284,
+				settings: {
+					blog_public: 1
+				}
+			} );
+
+			expect( state ).to.eql( {
+				2916284: {
+					ID: 2916284,
+					name: 'WordPress.com Example Blog',
+					is_private: false
+				}
+			} );
+		} );
+
+		it( 'should update both privacy and icon if received both setting updates', () => {
+			const original = deepFreeze( {
+				2916284: {
+					ID: 2916284,
+					name: 'WordPress.com Example Blog'
+				}
+			} );
+			const state = items( original, {
+				type: SITE_SETTINGS_RECEIVE,
+				siteId: 2916284,
+				settings: {
+					blog_public: 1,
+					site_icon: 42
+				}
+			} );
+
+			expect( state ).to.eql( {
+				2916284: {
+					ID: 2916284,
+					name: 'WordPress.com Example Blog',
+					is_private: false,
 					icon: {
 						media_id: 42
 					}


### PR DESCRIPTION
We disable the SEO settings for any site that is private. This commit disables the SEO description drawer in the Editor when a site is private as well. This is the second attempt after #11476 broke production (see p4TIVU-5UZ-p2).

The previous attempt broke production because it assumed `this.props.siteSettings` would exist when someone tried to load the editor. With a clear cache, this isn't necessarily true. We fetch site settings in specific instances like when someone tries to [visit the settings page directly](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/site-settings/controller.js#L85). When users tried to load the editor with an empty initial state, they received an error because `blog_public` wasn't defined yet leading to a broken experience.

In the revised approach:
- We use the specific `getSiteSetting` selector under [`state/selectors/`](https://github.com/Automattic/wp-calypso/tree/master/client/state/selectors).
- There are two safety valves. First, we check the truthiness of `this.props.privacySetting`. Then, we set a default value of `1` as a fallback.

I did test this on a cleared cache in my regular browser and an incognito window. I didn't experience any of the errors from the previous attempt.

## To test
1. Open up your site settings for a site on the Business plan: http://calypso.localhost:3000/settings/general/
2. Change the site to public
3. Click "Add" next to posts to start a new post. Verify that you see the SEO description panel in the editor drawer.
4. Click "My Sites" and go back to your site settings. Set the site to either hidden or private.
5. Start a new post again and verify that you do not see the SEO description panel in the drawer.

Resolves: #11406