### PR TITLE
Stats: Remove state list request persistence.

### DIFF
--- a/client/state/stats/lists/reducer.js
+++ b/client/state/stats/lists/reducer.js
@@ -10,7 +10,7 @@ import { merge, unset } from 'lodash';
 import { createReducer } from 'state/utils';
 import { isValidStateWithSchema } from 'state/utils';
 import { getSerializedStatsQuery } from './utils';
-import { itemSchema, requestsSchema } from './schema';
+import { itemSchema } from './schema';
 import {
 	DESERIALIZE,
 	SITE_STATS_RECEIVE,
@@ -58,7 +58,7 @@ export const requests = createReducer( {}, {
 			}
 		} );
 	}
-}, requestsSchema );
+} );
 
 /**
  * Returns the updated items state after an action has been dispatched. The

--- a/client/state/stats/lists/schema.js
+++ b/client/state/stats/lists/schema.js
@@ -18,29 +18,3 @@ export const itemSchema = {
 	},
 	additionalProperties: false
 };
-
-export const requestsSchema = {
-	type: 'object',
-	patternProperties: {
-		'^\\d+$': {
-			type: 'object',
-			patternProperties: {
-				'^[A-Za-z]+$': {
-					type: 'object',
-					patternProperties: {
-						'^\\{[^\\}]*\\}$': {
-							type: 'object',
-							properties: {
-								requesting: { type: 'boolean' },
-								status: { type: 'string' },
-								date: { type: 'string' }
-							}
-						}
-					}
-				}
-			},
-			additionalProperties: false
-		}
-	},
-	additionalProperties: false
-};

--- a/client/state/stats/lists/test/reducer.js
+++ b/client/state/stats/lists/test/reducer.js
@@ -140,7 +140,7 @@ describe( 'reducer', () => {
 			} );
 		} );
 
-		it( 'should persist state', () => {
+		it( 'should not persist state', () => {
 			const original = deepFreeze( {
 				2916284: {
 					statsStreak: {
@@ -151,10 +151,10 @@ describe( 'reducer', () => {
 
 			const state = requests( original, { type: SERIALIZE } );
 
-			expect( state ).to.eql( state );
+			expect( state ).to.eql( {} );
 		} );
 
-		it( 'should load persisted state', () => {
+		it( 'should not load persisted state', () => {
 			const original = deepFreeze( {
 				2916284: {
 					statsStreak: {
@@ -165,7 +165,7 @@ describe( 'reducer', () => {
 
 			const state = requests( original, { type: DESERIALIZE } );
 
-			expect( state ).to.eql( state );
+			expect( state ).to.eql( {} );
 		} );
 	} );
 


### PR DESCRIPTION
This branch fixes an issue introduced in #11035 that causes a stats page to become "stuck" on an old set of data.  The auto-refresh feature introduced in the branch currently persists the state of the `state.stats.lists.requests` subtree, which allows the status of various stats API requests to be permanently stuck in a `pending` state.

When a given query for a stats endpoint is set to `pending` in the state tree, the `<QuerySiteStats />` component will not issue any further API requests that match the endpoint/query that is set to `pending`.  As such the only way for a user to fix this problem currently is to delete `indexedDB` manually, or log out.

It is helpful to reproduce the issue for yourself to properly test out this branch:

__To Reproduce The Issue__
- Open a site stats page for today ( DAY )
- Wait for the next refresh to trigger in 3 minutes, by closely watching the network tab in your dev console. It helps to have a filter set to XHR and “top-posts”

<img width="1075" alt="stats_ _trout_bummin_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/23281485/58365e86-f9d2-11e6-845c-4983ddc4b015.png">

- Immediately close the browser tab while the requests are in-flight.  This will persist the pending state in redux.
- Reopen the same site stats page.  Note that the last updated timestamp is stuck, and if you wait 3 minutes, it will not update

There are other ways to get to this state, but I found the above to be the easiest way to reproduce the problem.

__To Test the Fix__
Run this branch locally, and follow the same steps.  Upon reloading the stats page in the last step, the last updated timestamp should be current, and it should update as expected in 3 minutes