### PR TITLE
Add/try and customize ui indication

### DIFF
--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -70,6 +70,11 @@
 	0 2px 4px lighten( $gray, 20% );
 }
 
+.pulsing-dot {
+	float: right;
+	top: 10px;
+}
+
 .themes__upload-button {
 	float: right;
 

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -71,8 +71,9 @@
 }
 
 .pulsing-dot {
-	float: right;
-	top: 10px;
+	right: 24px;
+	top: 22px;
+	left: initial;
 }
 
 .themes__upload-button {

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -17,7 +17,8 @@ import {
 	getCanonicalTheme,
 	themePreviewVisibility,
 	isThemeActive,
-	isInstallingTheme
+	isInstallingTheme,
+	isActivatingTheme
 } from 'state/themes/selectors';
 import { getPreviewUrl } from 'my-sites/themes/helpers';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -32,19 +33,35 @@ const ThemePreview = React.createClass( {
 		theme: React.PropTypes.object,
 		themeOptions: React.PropTypes.object,
 		isActive: React.PropTypes.bool,
+		isInstalling: React.PropTypes.bool,
 		onClose: React.PropTypes.func,
+	},
+
+	getInitialState() {
+		return {
+			isInstalling: false
+		};
+	},
+
+	componentWillReceiveProps( nextProps ) {
+		if ( ! this.props.isActivatingTheme && nextProps.isActivatingTheme ) {
+			this.props.hideThemePreview();
+		}
+		if ( ! this.props.isInstalling && nextProps.isInstalling ) {
+			this.setState( { isInstalling: true } );
+		}
 	},
 
 	onPrimaryButtonClick() {
 		const option = this.getPrimaryOption();
 		option.action && option.action( this.props.theme );
-		//this.props.hideThemePreview();
+		! this.props.isJetpack && this.props.hideThemePreview();
 	},
 
 	onSecondaryButtonClick() {
 		const secondary = this.getSecondaryOption();
 		secondary.action && secondary.action( this.props.theme );
-		//this.props.hideThemePreview();
+		! this.props.isJetpack && this.props.hideThemePreview();
 	},
 
 	getPrimaryOption() {
@@ -81,7 +98,8 @@ const ThemePreview = React.createClass( {
 	},
 
 	render() {
-		const { themeId, isInstalling } = this.props;
+		const { themeId } = this.props;
+		const { isInstalling } = this.state;
 		if ( ! themeId ) {
 			return null;
 		}
@@ -127,6 +145,7 @@ export default connect(
 			themeOptions,
 			isInstalling: isInstallingTheme( state, themeId, siteId ),
 			isActive: isThemeActive( state, themeId, siteId ),
+			isActivating: isActivatingTheme( state, siteId ),
 			previewUrl: theme && theme.demo_uri ? getPreviewUrl( theme ) : null,
 			options: [
 				'activate',

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -39,16 +39,17 @@ const ThemePreview = React.createClass( {
 
 	getInitialState() {
 		return {
-			isInstalling: false
+			showActionIndicator: false
 		};
 	},
 
 	componentWillReceiveProps( nextProps ) {
-		if ( ! this.props.isActivatingTheme && nextProps.isActivatingTheme ) {
+		if ( this.props.isActivating && ! nextProps.isActivating ) {
+			this.setState( { showActionIndicator: false } );
 			this.props.hideThemePreview();
 		}
 		if ( ! this.props.isInstalling && nextProps.isInstalling ) {
-			this.setState( { isInstalling: true } );
+			this.setState( { showActionIndicator: true } );
 		}
 	},
 
@@ -99,7 +100,7 @@ const ThemePreview = React.createClass( {
 
 	render() {
 		const { themeId } = this.props;
-		const { isInstalling } = this.state;
+		const { showActionIndicator } = this.state;
 		if ( ! themeId ) {
 			return null;
 		}
@@ -114,9 +115,9 @@ const ThemePreview = React.createClass( {
 					onClose={ this.props.hideThemePreview }
 					previewUrl={ this.props.previewUrl }
 					externalUrl={ this.props.theme.demo_uri } >
-					<PulsingDot active={ isInstalling } />
-					{ ! isInstalling && this.renderSecondaryButton() }
-					{ ! isInstalling && this.renderPrimaryButton() }
+					{ showActionIndicator && <PulsingDot active={ true } /> }
+					{ ! showActionIndicator && this.renderSecondaryButton() }
+					{ ! showActionIndicator && this.renderPrimaryButton() }
 				</WebPreview> }
 			</div>
 		);


### PR DESCRIPTION
### Info
This PR adds pulsing dot indicator to UI to indicate that the theme is being installed. This way user will know that somethings is happenings.

![try_and_customize_ui](https://cloud.githubusercontent.com/assets/17271089/23301387/fb755f9a-fa89-11e6-8328-b8a2a623dc31.gif)


### Testing
Open Live Demo for wpcom theme on Jetpack site:
Check that the indicator is present during `Activate` or `Try & Customize` actions. Verify that the Live Preview closes properly. Check that for other actions like Customzie or Pick this design flow works as usual. 

Closes #11052