### PR TITLE
AT:Domains: Disable domain transfer to another user

### DIFF
--- a/client/my-sites/upgrades/domain-management/controller.jsx
+++ b/client/my-sites/upgrades/domain-management/controller.jsx
@@ -319,6 +319,11 @@ module.exports = {
 	},
 
 	domainManagementTransferToOtherUser( pageContext ) {
+		const selectedSite = sites.getSelectedSite();
+		if ( selectedSite && selectedSite.options.is_automated_transfer ) {
+			page.redirect( '/domains/manage' + ( selectedSite ? ( '/' + selectedSite.slug ) : '' ) );
+		}
+
 		setTitle(
 			i18n.translate( 'Transfer Domain' ),
 			pageContext

--- a/client/my-sites/upgrades/domain-management/controller.jsx
+++ b/client/my-sites/upgrades/domain-management/controller.jsx
@@ -20,6 +20,9 @@ import ProductsList from 'lib/products-list';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import SiteRedirectData from 'components/data/domain-management/site-redirect';
 import SitesList from 'lib/sites-list';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import TransferData from 'components/data/domain-management/transfer';
 import WhoisData from 'components/data/domain-management/whois';
 import { setDocumentHeadTitle } from 'state/document-head/actions';
@@ -319,9 +322,13 @@ module.exports = {
 	},
 
 	domainManagementTransferToOtherUser( pageContext ) {
-		const selectedSite = sites.getSelectedSite();
-		if ( selectedSite && selectedSite.options.is_automated_transfer ) {
-			page.redirect( '/domains/manage' + ( selectedSite ? ( '/' + selectedSite.slug ) : '' ) );
+		const state = pageContext.store.getState();
+		const siteId = getSelectedSiteId( state );
+		const isAutomatedTransfer = isSiteAutomatedTransfer( state, siteId );
+		if ( isAutomatedTransfer ) {
+			const siteSlug = getSiteSlug( state, siteId );
+			page.redirect( `/domains/manage/${ siteSlug }` );
+			return;
 		}
 
 		setTitle(

--- a/client/my-sites/upgrades/domain-management/transfer/index.jsx
+++ b/client/my-sites/upgrades/domain-management/transfer/index.jsx
@@ -14,33 +14,31 @@ import Header from 'my-sites/upgrades/domain-management/components/header';
 import Main from 'components/main';
 import { get } from 'lodash';
 
-class Transfer extends React.Component {
-	render() {
-		const slug = this.props.selectedSite.slug;
-		const domainName = this.props.selectedDomainName;
-		const canTransferDomain = ! get( this.props.selectedSite, 'options.is_automated_transfer', false );
+function Transfer( props ) {
+	const { selectedSite, selectedDomainName, translate } = props;
+	const slug = get( selectedSite, 'slug' );
+	const canTransferDomain = ! get( selectedSite, 'options.is_automated_transfer', false );
 
-		return (
+	return (
 		<Main className="domain-management-transfer">
 			<Header
-				selectedDomainName={ domainName }
-				backHref={ paths.domainManagementEdit( slug, domainName ) }>
-				{ this.props.translate( 'Transfer Domain' ) }
+				selectedDomainName={ selectedDomainName }
+				backHref={ paths.domainManagementEdit( slug, selectedDomainName ) }>
+				{ translate( 'Transfer Domain' ) }
 			</Header>
 			<VerticalNav>
 				<VerticalNavItem path={
-					paths.domainManagementTransferOut( slug, domainName )
+					paths.domainManagementTransferOut( slug, selectedDomainName )
 				}>
-					{ this.props.translate( 'Transfer to another registrar' ) }
+					{ translate( 'Transfer to another registrar' ) }
 				</VerticalNavItem>
 					{ canTransferDomain &&
-						<VerticalNavItem path={ paths.domainManagementTransferToAnotherUser( slug, domainName ) }>
-							{ this.props.translate( 'Transfer to another user' ) }
+						<VerticalNavItem path={ paths.domainManagementTransferToAnotherUser( slug, selectedDomainName ) }>
+							{ translate( 'Transfer to another user' ) }
 						</VerticalNavItem> }
 			</VerticalNav>
 		</Main>
-		);
-	}
+	);
 }
 
 export default localize( Transfer );

--- a/client/my-sites/upgrades/domain-management/transfer/index.jsx
+++ b/client/my-sites/upgrades/domain-management/transfer/index.jsx
@@ -12,19 +12,13 @@ import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
 import Header from 'my-sites/upgrades/domain-management/components/header';
 import Main from 'components/main';
+import { get } from 'lodash';
 
 class Transfer extends React.Component {
 	render() {
-		const slug = this.props.selectedSite.slug,
-			domainName = this.props.selectedDomainName;
-
-		let transferToAnotherUser = null;
-		if ( ! this.props.selectedSite.options.is_automated_transfer ) {
-			transferToAnotherUser =
-				<VerticalNavItem path={ paths.domainManagementTransferToAnotherUser( slug, domainName ) }>
-					{ this.props.translate( 'Transfer to another user' ) }
-				</VerticalNavItem>;
-		}
+		const slug = this.props.selectedSite.slug;
+		const domainName = this.props.selectedDomainName;
+		const canTransferDomain = ! get( this.props.selectedSite, 'options.is_automated_transfer', false );
 
 		return (
 		<Main className="domain-management-transfer">
@@ -39,7 +33,10 @@ class Transfer extends React.Component {
 				}>
 					{ this.props.translate( 'Transfer to another registrar' ) }
 				</VerticalNavItem>
-				{ transferToAnotherUser }
+					{ canTransferDomain &&
+						<VerticalNavItem path={ paths.domainManagementTransferToAnotherUser( slug, domainName ) }>
+							{ this.props.translate( 'Transfer to another user' ) }
+						</VerticalNavItem> }
 			</VerticalNav>
 		</Main>
 		);

--- a/client/my-sites/upgrades/domain-management/transfer/index.jsx
+++ b/client/my-sites/upgrades/domain-management/transfer/index.jsx
@@ -17,6 +17,15 @@ class Transfer extends React.Component {
 	render() {
 		const slug = this.props.selectedSite.slug,
 			domainName = this.props.selectedDomainName;
+
+		let transferToAnotherUser = null;
+		if ( ! this.props.selectedSite.options.is_automated_transfer ) {
+			transferToAnotherUser =
+				<VerticalNavItem path={ paths.domainManagementTransferToAnotherUser( slug, domainName ) }>
+					{ this.props.translate( 'Transfer to another user' ) }
+				</VerticalNavItem>;
+		}
+
 		return (
 		<Main className="domain-management-transfer">
 			<Header
@@ -30,11 +39,7 @@ class Transfer extends React.Component {
 				}>
 					{ this.props.translate( 'Transfer to another registrar' ) }
 				</VerticalNavItem>
-				<VerticalNavItem path={
-					paths.domainManagementTransferToAnotherUser( slug, domainName )
-				}>
-					{ this.props.translate( 'Transfer to another user' ) }
-				</VerticalNavItem>
+				{ transferToAnotherUser }
 			</VerticalNav>
 		</Main>
 		);


### PR DESCRIPTION
Fixes #11517 

This disables the ability for AT sites to perform domain transfers to another user. 

For AT sites it:

1. It hides the "Transfer to another user" menu item from https://wpcalypso.wordpress.com/domains/manage/:site/transfer/:domain. It does however leave the "Transfer to another registrar" option.

2. It redirects https://wpcalypso.wordpress.com/domains/manage/:site/transfer/other-user/:domain to https://wpcalypso.wordpress.com/domains/manage/:site

