### PR TITLE
Change the wording of the site deletion area

### DIFF
--- a/client/my-sites/site-settings/delete-site-options/index.jsx
+++ b/client/my-sites/site-settings/delete-site-options/index.jsx
@@ -90,11 +90,15 @@ module.exports = React.createClass( {
 					<div className="delete-site-options__content">
 						<h2 className="delete-site-options__section-title">{ strings.deleteSite }</h2>
 						<p className="delete-site-options__section-desc">
-							{ this.translate( 'All your posts, images, data, and this site\'s address ({{siteAddress /}}) will be gone forever.', {
-								components: {
-									siteAddress: <strong>{ selectedSite.slug }</strong>
+							{ this.translate(
+								'All your posts, images, and data will be deleted. ' +
+								'And this site’s address ({{siteAddress /}}) will be lost.',
+								{
+									components: {
+										siteAddress: <strong>{ selectedSite.wpcom_url || selectedSite.slug }</strong>
+									}
 								}
-							} ) }
+							) }
 						</p>
 						<p className="delete-site-options__section-footnote">
 							{


### PR DESCRIPTION
This pull request changes the wording of the site deletion warning

See p2UL9c-3hV-p2 for details

### How to test
1. Navigate to http://calypso.localhost:3000/ while logged in
2. Click "My Sites" in the upper left corner
3. Click "Settings" on the left navigation. You'll probably need to scroll down to see it.
4. Scroll to the bottom of the page and notice the updated wording under "Delete Site"

#### Before

![screen shot 2017-02-23 at 9 04 40 pm](https://cloud.githubusercontent.com/assets/1854440/23287484/bac655ea-fa0b-11e6-81e3-7d0dcd8c1080.png)

#### After

![screen shot 2017-02-23 at 8 46 12 pm](https://cloud.githubusercontent.com/assets/1854440/23287448/843dddb8-fa0b-11e6-832c-cf35ec526671.png)
