### PR TITLE
Themes: Disable manage/themes/magic-search in development and wp-calypso

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -93,7 +93,6 @@
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,
 		"manage/themes/logged-out": true,
-		"manage/themes/magic-search": true,
 		"manage/themes/upload": true,
 		"me/account": true,
 		"me/edit-gravatar": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -70,7 +70,6 @@
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,
 		"manage/themes/logged-out": true,
-		"manage/themes/magic-search": true,
 		"manage/themes/upload": true,
 		"me/account": true,
 		"me/find-friends": false,


### PR DESCRIPTION
Themes "magic" search in calypso hasn't been touched for a few months.

It was enabled in development and wpcalypso but no other environment, and since it's enabled in development it makes testing in development hard because it behaves differently to production.

This PR removes the activation in development and wpcalypso. If magic search is going to be launched soon we can add it back in, or otherwise we could delete the feature if it has been decided to not go ahead.

cc @folletto, @budzanowski, @ockham 

Before in development, wpcalypso.wordpress.com

<img width="1099" alt="magic" src="https://cloud.githubusercontent.com/assets/128826/23293861/5bc5cdb0-fab4-11e6-9f3f-82b315bbdeff.png">

After in development, wpcalypso.wordpress.com

<img width="1109" alt="non magic" src="https://cloud.githubusercontent.com/assets/128826/23293870/6468904c-fab4-11e6-85c6-e021c7d9f0a7.png">

**Testing Instructions**

Ensure magic search not shown in development and wpcalypso