### PR TITLE
Media section: Move Action buttons to top, multiple selection

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -37,7 +37,7 @@ const MediaLibraryContent = React.createClass( {
 		scrollable: React.PropTypes.bool,
 		onAddMedia: React.PropTypes.func,
 		onMediaScaleChange: React.PropTypes.func,
-		onEditItem: React.PropTypes.func
+		onEditItem: React.PropTypes.func,
 	},
 
 	getDefaultProps: function() {
@@ -193,7 +193,11 @@ const MediaLibraryContent = React.createClass( {
 						filter={ this.props.filter }
 						onMediaScaleChange={ this.props.onMediaScaleChange }
 						onAddMedia={ this.props.onAddMedia }
-						onAddAndEditImage={ this.props.onAddAndEditImage } />
+						onAddAndEditImage={ this.props.onAddAndEditImage }
+						selectedItems={ this.props.selectedItems }
+						onViewDetails={ this.props.onViewDetails }
+						onDeleteItem={ this.props.onDeleteItem }
+					/>
 				}
 				{ this.renderErrors() }
 				{ this.renderMediaList() }

--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -13,7 +13,7 @@ import MediaLibraryScale from './scale';
 import UploadButton from './upload-button';
 import MediaLibraryUploadUrl from './upload-url';
 import { userCan } from 'lib/site/utils';
-import Button from 'components/button';
+import MediaModalSecondaryActions from 'post-editor/media-modal/secondary-actions';
 
 export default React.createClass( {
 	displayName: 'MediaLibraryHeader',
@@ -61,22 +61,6 @@ export default React.createClass( {
 		this.setState( {
 			isMoreOptionsVisible: state
 		} );
-	},
-
-	renderSecondaryActionButtons() {
-		const buttons = [];
-		if ( this.props.selectedItems && this.props.selectedItems.length > 0 ) {
-			buttons.push( <Button
-				compact
-				primary
-				onClick={ this.props.onViewDetails }
-			>{ "Edit" }</Button> );
-			buttons.push( <Button
-				compact
-				onClick={ this.props.onDeleteItem }
-			>{ "Delete" }</Button> );
-		}
-		return buttons;
 	},
 
 	renderUploadButtons() {
@@ -140,7 +124,14 @@ export default React.createClass( {
 			<header className="media-library__header">
 				<h2 className="media-library__heading">{ this.translate( 'Media Library' ) }</h2>
 				{ this.renderUploadButtons() }
-				{ this.renderSecondaryActionButtons() }
+				<MediaModalSecondaryActions
+					selectedItems={ this.props.selectedItems }
+					onViewDetails={ this.props.onViewDetails }
+					onDelete={ this.props.onDeleteItem }
+					renderStorage={ false }
+					site={ this.props.site }
+					view={ 'LIST' }
+				/>
 				<MediaLibraryScale
 					onChange={ this.props.onMediaScaleChange } />
 			</header>

--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -73,7 +73,7 @@ export default React.createClass( {
 			>{ "Edit" }</Button> );
 			buttons.push( <Button
 				compact
-				onClick={ this.onDeleteItem }
+				onClick={ this.props.onDeleteItem }
 			>{ "Delete" }</Button> );
 		}
 		return buttons;

--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -13,6 +13,7 @@ import MediaLibraryScale from './scale';
 import UploadButton from './upload-button';
 import MediaLibraryUploadUrl from './upload-url';
 import { userCan } from 'lib/site/utils';
+import Button from 'components/button';
 
 export default React.createClass( {
 	displayName: 'MediaLibraryHeader',
@@ -60,6 +61,22 @@ export default React.createClass( {
 		this.setState( {
 			isMoreOptionsVisible: state
 		} );
+	},
+
+	renderSecondaryActionButtons() {
+		const buttons = [];
+		if ( this.props.selectedItems && this.props.selectedItems.length > 0 ) {
+			buttons.push( <Button
+				compact
+				primary
+				onClick={ this.props.onViewDetails }
+			>{ "Edit" }</Button> );
+			buttons.push( <Button
+				compact
+				onClick={ this.onDeleteItem }
+			>{ "Delete" }</Button> );
+		}
+		return buttons;
 	},
 
 	renderUploadButtons() {
@@ -123,6 +140,7 @@ export default React.createClass( {
 			<header className="media-library__header">
 				<h2 className="media-library__heading">{ this.translate( 'Media Library' ) }</h2>
 				{ this.renderUploadButtons() }
+				{ this.renderSecondaryActionButtons() }
 				<MediaLibraryScale
 					onChange={ this.props.onMediaScaleChange } />
 			</header>

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -128,7 +128,9 @@ module.exports = React.createClass( {
 				onAddMedia={ this.onAddMedia }
 				onAddAndEditImage={ this.props.onAddAndEditImage }
 				onMediaScaleChange={ this.props.onScaleChange }
-				onEditItem={ this.props.onEditItem } />
+				selectedItems={ this.props.mediaLibrarySelectedItems }
+				onDeleteItem={ this.props.onDeleteItem }
+				onViewDetails={ this.props.onViewDetails } />
 		);
 
 		if ( this.props.site ) {

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -130,6 +130,7 @@ module.exports = React.createClass( {
 				onMediaScaleChange={ this.props.onScaleChange }
 				selectedItems={ this.props.mediaLibrarySelectedItems }
 				onDeleteItem={ this.props.onDeleteItem }
+				onEditItem={ this.props.onEditItem }
 				onViewDetails={ this.props.onViewDetails } />
 		);
 

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -32,7 +32,7 @@ export default React.createClass( {
 		return {
 			editedItem: null,
 			currentDetail: null,
-			selectedImages: []
+			selectedImages: [],
 		};
 	},
 
@@ -57,11 +57,9 @@ export default React.createClass( {
 	},
 
 	openDetailsModalForASingleImage( image ) {
-		const selected = [ image ];
-
 		this.setState( {
 			currentDetail: 0,
-			selectedImages: selected
+			selectedImages: [ image ],
 		} );
 	},
 

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -17,6 +17,7 @@ import MediaActions from 'lib/media/actions';
 import MediaUtils from 'lib/media/utils';
 import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
 import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
+import accept from 'lib/accept';
 
 export default React.createClass( {
 	displayName: 'Media',
@@ -127,7 +128,27 @@ export default React.createClass( {
 	setDetailSelectedIndex: function( index ) {
 		this.setState( { currentDetail: index } );
 	},
+	confirmDeleteMedia: function ( accepted ) {
+		const site = this.props.sites.getSelectedSite();
+		if ( ! site || ! accepted ) {
+			return;
+		}
+		const selected = MediaLibrarySelectedStore.getAll( site.ID );
+		MediaActions.delete( site.ID, selected );
+	},
 
+	deleteMedia: function() {
+		const site = this.props.sites.getSelectedSite();
+		const selected = MediaLibrarySelectedStore.getAll( site.ID );
+		const selectedCount = selected.length;
+		const confirmMessage = this.translate(
+			'Are you sure you want to permanently delete this item?',
+			'Are you sure you want to permanently delete these items?',
+			{ count: selectedCount }
+		);
+
+		accept( confirmMessage, this.confirmDeleteMedia );
+	},
 	render: function() {
 		const site = this.props.sites.getSelectedSite();
 		return (
@@ -168,7 +189,7 @@ export default React.createClass( {
 						single={ false }
 						onEditItem={ this.openDetailsModalForASingleImage }
 						onViewDetails={ this.openDetailsModalForAllSelected }
-						onDeleteItem={ () => {} }
+						onDeleteItem={ this.deleteMedia }
 						containerWidth={ this.state.containerWidth } />
 				</MediaLibrarySelectedData>
 			</div>

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -31,6 +31,7 @@ export default React.createClass( {
 		return {
 			editedItem: null,
 			currentDetail: null,
+			selectedImages: []
 		};
 	},
 
@@ -54,12 +55,27 @@ export default React.createClass( {
 		page( redirect );
 	},
 
-	openDetailsModal() {
-		this.setState( { currentDetail: 0 } );
+	openDetailsModalForASingleImage( image ) {
+		const selected = [ image ];
+
+		this.setState( {
+			currentDetail: 0,
+			selectedImages: selected
+		} );
+	},
+
+	openDetailsModalForAllSelected() {
+		const site = this.props.sites.getSelectedSite();
+		const selected = MediaLibrarySelectedStore.getAll( site.ID );
+
+		this.setState( {
+			currentDetail: 0,
+			selectedImages: selected
+		} );
 	},
 
 	closeDetailsModal() {
-		this.setState( { editedItem: null, currentDetail: null } );
+		this.setState( { editedItem: null, currentDetail: null, selectedImages: [] } );
 	},
 
 	editImage() {
@@ -99,14 +115,14 @@ export default React.createClass( {
 
 		MediaActions.update( site.ID, item, true );
 		resetAllImageEditorState();
-		this.setState( { currentDetail: null, editedItem: null } );
+		this.setState( { currentDetail: null, editedItem: null, selectedImages: [] } );
 	},
 	restoreOriginalMedia: function( siteId, item ) {
 		if ( ! siteId || ! item ) {
 			return;
 		}
 		MediaActions.update( siteId, { ID: item.ID, media_url: item.guid }, true );
-		this.setState( { currentDetail: null, editedItem: null } );
+		this.setState( { currentDetail: null, editedItem: null, selectedImages: [] } );
 	},
 	setDetailSelectedIndex: function( index ) {
 		this.setState( { currentDetail: index } );
@@ -126,7 +142,7 @@ export default React.createClass( {
 					{ this.state.currentDetail !== null &&
 						<EditorMediaModalDetail
 							site={ site }
-							items={ MediaLibrarySelectedStore.getAll( site.ID ) }
+							items={ this.state.selectedImages }
 							selectedIndex={ this.state.currentDetail }
 							onReturnToList={ this.closeDetailsModal }
 							onEditItem={ this.editImage }
@@ -137,7 +153,7 @@ export default React.createClass( {
 					{ this.state.editedItem !== null &&
 						<ImageEditor
 							siteId={ site && site.ID }
-							media={ MediaLibrarySelectedStore.getAll( site.ID )[ this.state.editedItem ] }
+							media={ this.state.selectedImages[ this.state.editedItem ] }
 							onDone={ this.onImageEditorDone }
 							onCancel={ this.onImageEditorCancel }
 						/>
@@ -150,8 +166,8 @@ export default React.createClass( {
 						onFilterChange={ this.onFilterChange }
 						site={ site || false }
 						single={ false }
-						onEditItem={ this.openDetailsModal }
-						onViewDetails={ this.openDetailsModal }
+						onEditItem={ this.openDetailsModalForASingleImage }
+						onViewDetails={ this.openDetailsModalForAllSelected }
 						onDeleteItem={ () => {} }
 						containerWidth={ this.state.containerWidth } />
 				</MediaLibrarySelectedData>

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -10,6 +10,7 @@ import {
 	head,
 	noop,
 	map,
+	flow,
 	partial,
 	some,
 	values,
@@ -40,6 +41,7 @@ import { ModalViews } from 'state/ui/media-modal/constants';
 import { deleteMedia } from 'state/media/actions';
 import ImageEditor from 'blocks/image-editor';
 import MediaModalDetail from './detail';
+import { withAnalytics, bumpStat, recordGoogleEvent } from 'state/analytics/actions';
 
 export class EditorMediaModal extends Component {
 	static propTypes = {
@@ -431,6 +433,9 @@ export class EditorMediaModal extends Component {
 						onEditItem={ this.editItem }
 						fullScreenDropZone={ false }
 						single={ this.props.single }
+						onDeleteItem={ this.deleteMedia }
+						onViewDetails={ this.props.onViewDetails }
+						mediaLibrarySelectedItems={ this.props.mediaLibrarySelectedItems }
 						scrollable />
 				);
 				break;
@@ -463,6 +468,11 @@ export default connect(
 	{
 		setView: setEditorMediaModalView,
 		resetView: resetMediaModalView,
-		deleteMedia
+		deleteMedia,
+		onViewDetails: flow(
+			withAnalytics( bumpStat( 'editor_media_actions', 'edit_button_dialog' ) ),
+			withAnalytics( recordGoogleEvent( 'Media', 'Clicked Dialog Edit Button' ) ),
+			partial( setEditorMediaModalView, ModalViews.DETAIL )
+		)
 	}
 )( localize( EditorMediaModal ) );

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -4,7 +4,7 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { values, noop, some, every, flow, partial } from 'lodash';
+import { values, noop, some, every, flow, partial, pick } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
@@ -30,13 +30,15 @@ const MediaModalSecondaryActions = React.createClass( {
 		view: React.PropTypes.oneOf( values( ModalViews ) ),
 		disabled: PropTypes.bool,
 		onDelete: PropTypes.func,
-		onViewDetails: PropTypes.func
+		onViewDetails: PropTypes.func,
+		renderStorage: PropTypes.bool,
 	},
 
 	getDefaultProps() {
 		return {
 			disabled: false,
-			onDelete: noop
+			onDelete: noop,
+			renderStorage: true,
 		};
 	},
 
@@ -176,7 +178,7 @@ const MediaModalSecondaryActions = React.createClass( {
 			<div className="editor-media-modal__secondary-actions">
 				{ this.renderMobileButtons() }
 				{ this.renderDesktopButtons() }
-				{ this.renderPlanStorage() }
+				{ this.props.renderStorage && this.renderPlanStorage() }
 			</div>
 		);
 	}
@@ -194,5 +196,8 @@ export default connect(
 			withAnalytics( recordGoogleEvent( 'Media', 'Clicked Dialog Edit Button' ) ),
 			partial( setEditorMediaModalView, ModalViews.DETAIL )
 		)
+	}, function mergeProps( stateProps, dispatchProps, ownProps ) {
+		//We want to overwrite connected props if 'onViewDetails', 'view' were provided
+		return Object.assign( {}, ownProps, stateProps, dispatchProps, pick( ownProps, [ 'onViewDetails', 'view' ] ) );
 	}
 )( MediaModalSecondaryActions );


### PR DESCRIPTION
This PR resolves #11512, #10851 and puts some work towards #10805
- Enables selecting of multiple media items
- Moves secondary action buttons to top action bar where they can be redesigned
- Splits off following tasks:

The bar does not look how it should, continue in #10805 to make it look proper

## Show me

![zrzut ekranu 2017-02-24 o 12 16 11](https://cloud.githubusercontent.com/assets/3775068/23301611/0dbbaa8c-fa8b-11e6-95eb-2f1f21c5a41c.png)
![zrzut ekranu 2017-02-24 o 12 15 45](https://cloud.githubusercontent.com/assets/3775068/23301612/0f35d1e4-fa8b-11e6-8d0b-00f2d3576519.png)

CC @iamtakashi @rralian @retrofox @gwwar @lamosty 
