### PR TITLE
Domains: fix the order of notices for mapping in plans

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -76,16 +76,16 @@ var DomainSearchResults = React.createClass( {
 		} else if ( suggestions.length !== 0 && includes( [ MAPPABLE, UNKNOWN ], lastDomainStatus ) && this.props.products.domain_map ) {
 			const components = { a: <a href="#" onClick={ this.handleAddMapping } />, small: <small /> };
 
-			if ( this.props.domainsWithPlansOnly ) {
+			if ( isNextDomainFree( this.props.cart ) ) {
+				mappingOffer = this.translate( '{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for ' +
+					'free.{{/small}}', { args: { domain }, components } );
+			} else if ( ! this.props.domainsWithPlansOnly ) {
+				mappingOffer = this.translate( '{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for ' +
+					'%(cost)s.{{/small}}', { args: { domain, cost: this.props.products.domain_map.cost_display }, components } );
+			} else {
 				mappingOffer = this.translate( '{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}}' +
 					' with WordPress.com Premium.{{/small}}', { args: { domain }, components }
 				);
-			} else if ( isNextDomainFree( this.props.cart ) ) {
-				mappingOffer = this.translate( '{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for ' +
-					'free.{{/small}}', { args: { domain }, components } );
-			} else {
-				mappingOffer = this.translate( '{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for ' +
-					'%(cost)s.{{/small}}', { args: { domain, cost: this.props.products.domain_map.cost_display }, components } );
 			}
 
 			const domainUnavailableMessage = lastDomainStatus === UNKNOWN


### PR DESCRIPTION
If the user already has a plan, we should not tell them that they have the domain free with Premium. That message is a DWPO upsell, should not be visible by users who have other plans.

To test:
1. Add a Personal or Business plan to a test blog
2. Search for a domain that's not available. Without this change, you'll see that you can get the domain as part of Premium. With this change, you should see that it's free.