### PR TITLE
Add a recent drafts popover with count to the masterbar

### DIFF
--- a/client/layout/masterbar/drafts.jsx
+++ b/client/layout/masterbar/drafts.jsx
@@ -1,0 +1,136 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSite } from 'state/ui/selectors';
+import Popover from 'components/popover';
+import Count from 'components/count';
+import { getMyPostCounts } from 'state/posts/counts/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import {
+	getSitePostsForQueryIgnoringPage,
+	isRequestingSitePostsForQuery
+} from 'state/posts/selectors';
+import Draft from 'my-sites/draft';
+import QueryPosts from 'components/data/query-posts';
+import QueryPostCounts from 'components/data/query-post-counts';
+import Button from 'components/button';
+import Site from 'blocks/site';
+import { getCurrentUserId } from 'state/current-user/selectors';
+import sitesList from 'lib/sites-list';
+
+const sites = sitesList();
+
+const MasterbarDrafts = React.createClass( {
+	propTypes: {
+		user: React.PropTypes.object,
+		sites: React.PropTypes.object,
+		isActive: React.PropTypes.bool,
+		className: React.PropTypes.string,
+		tooltip: React.PropTypes.string,
+		// connected props
+		selectedSite: React.PropTypes.object,
+	},
+
+	getInitialState() {
+		return {
+			showDrafts: false
+		};
+	},
+
+	toggleDrafts( event ) {
+		event.stopPropagation();
+		event.preventDefault();
+		this.setState( {
+			showDrafts: ! this.state.showDrafts
+		} );
+	},
+
+	closeDrafts() {
+		this.setState( { showDrafts: false } );
+	},
+
+	render() {
+		const site = this.props.selectedSite;
+		const isLoading = this.props.draftCount !== 0 && this.props.loadingDrafts;
+
+		if ( ! site ) {
+			return null;
+		}
+
+		return (
+			<div>
+				<QueryPostCounts siteId={ site.ID } type="post" />
+				{ this.props.draftCount ?
+					<Button compact borderless className="masterbar__toggle-drafts" onClick={ this.toggleDrafts } ref="drafts">
+						<Count count={ this.props.draftCount } />
+					</Button>
+				: null }
+				<Popover
+					isVisible={ this.state.showDrafts }
+					onClose={ this.closeDrafts }
+					position="bottom left"
+					context={ this.refs && this.refs.drafts }
+					className="masterbar__recent-drafts"
+				>
+					<QueryPosts
+						siteId={ site.ID }
+						query={ this.props.draftsQuery } />
+					<Site site={ site } />
+					{ this.props.drafts && this.props.drafts.map( this.renderDraft, this ) }
+					{ isLoading && <Draft isPlaceholder /> }
+					{ this.props.draftCount > 6 &&
+						<Button compact borderless className="masterbar__see-all-drafts" href={ `/posts/drafts/${ site.slug }` } onClick={ this.closeDrafts }>
+							{ this.translate( 'See all drafts' ) }
+							{ this.props.draftCount ? <Count count={ this.props.draftCount } /> : null }
+						</Button>
+					}
+				</Popover>
+			</div>
+		);
+	},
+
+	renderDraft( draft ) {
+		if ( ! draft ) {
+			return null;
+		}
+
+		const site = this.props.selectedSite;
+
+		return <Draft
+			key={ draft.global_ID }
+			post={ draft }
+			sites={ sites }
+			showAuthor={ site && ! site.single_user_site && ! this.props.userId }
+			onTitleClick={ this.closeDrafts }
+		/>;
+	}
+} );
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	const userId = getCurrentUserId( state );
+	const site = getSelectedSite( state );
+	const draftsQuery = {
+		type: 'post',
+		status: 'draft',
+		number: 10,
+		order_by: 'modified',
+		author: ( site && ! site.single_user_site ) ? userId : null
+	};
+
+	const myPostCounts = getMyPostCounts( state, siteId, 'post' );
+
+	return {
+		drafts: getSitePostsForQueryIgnoringPage( state, siteId, draftsQuery ),
+		loadingDrafts: isRequestingSitePostsForQuery( state, siteId, draftsQuery ),
+		draftsQuery: draftsQuery,
+		draftCount: myPostCounts && myPostCounts.draft,
+		selectedSite: site,
+	};
+} )( MasterbarDrafts );

--- a/client/layout/masterbar/drafts.jsx
+++ b/client/layout/masterbar/drafts.jsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -26,51 +27,47 @@ import sitesList from 'lib/sites-list';
 
 const sites = sitesList();
 
-const MasterbarDrafts = React.createClass( {
-	propTypes: {
-		user: React.PropTypes.object,
-		sites: React.PropTypes.object,
-		isActive: React.PropTypes.bool,
-		className: React.PropTypes.string,
-		tooltip: React.PropTypes.string,
-		// connected props
-		selectedSite: React.PropTypes.object,
-	},
+class MasterbarDrafts extends Component {
+	static propTypes = {
+		user: PropTypes.object,
+		sites: PropTypes.object,
+		isActive: PropTypes.bool,
+		className: PropTypes.string,
+		tooltip: PropTypes.string,
+		selectedSite: PropTypes.object,
+	};
 
-	getInitialState() {
-		return {
-			showDrafts: false
-		};
-	},
+	state = {
+		showDrafts: false
+	};
 
-	toggleDrafts( event ) {
-		event.stopPropagation();
-		event.preventDefault();
+	toggleDrafts = () => {
+		const { showDrafts } = this.state;
 		this.setState( {
-			showDrafts: ! this.state.showDrafts
+			showDrafts: ! showDrafts
 		} );
-	},
+	};
 
-	closeDrafts() {
+	closeDrafts = () => {
 		this.setState( { showDrafts: false } );
-	},
+	};
 
 	render() {
-		const site = this.props.selectedSite;
-		const isLoading = this.props.draftCount !== 0 && this.props.loadingDrafts;
+		const { selectedSite, draftCount, loadingDrafts, translate } = this.props;
+		const isLoading = draftCount !== 0 && loadingDrafts;
 
-		if ( ! site ) {
+		if ( ! selectedSite ) {
 			return null;
 		}
 
 		return (
 			<div>
-				<QueryPostCounts siteId={ site.ID } type="post" />
-				{ this.props.draftCount ?
+				<QueryPostCounts siteId={ selectedSite.ID } type="post" />
+				{ this.props.draftCount > 0 &&
 					<Button compact borderless className="masterbar__toggle-drafts" onClick={ this.toggleDrafts } ref="drafts">
 						<Count count={ this.props.draftCount } />
 					</Button>
-				: null }
+				}
 				<Popover
 					isVisible={ this.state.showDrafts }
 					onClose={ this.closeDrafts }
@@ -79,21 +76,21 @@ const MasterbarDrafts = React.createClass( {
 					className="masterbar__recent-drafts"
 				>
 					<QueryPosts
-						siteId={ site.ID }
+						siteId={ selectedSite.ID }
 						query={ this.props.draftsQuery } />
-					<Site site={ site } />
+					<Site site={ selectedSite } />
 					{ this.props.drafts && this.props.drafts.map( this.renderDraft, this ) }
 					{ isLoading && <Draft isPlaceholder /> }
 					{ this.props.draftCount > 6 &&
-						<Button compact borderless className="masterbar__see-all-drafts" href={ `/posts/drafts/${ site.slug }` } onClick={ this.closeDrafts }>
-							{ this.translate( 'See all drafts' ) }
+						<Button compact borderless className="masterbar__see-all-drafts" href={ `/posts/drafts/${ selectedSite.slug }` } onClick={ this.closeDrafts }>
+							{ translate( 'See all drafts' ) }
 							{ this.props.draftCount ? <Count count={ this.props.draftCount } /> : null }
 						</Button>
 					}
 				</Popover>
 			</div>
 		);
-	},
+	}
 
 	renderDraft( draft ) {
 		if ( ! draft ) {
@@ -110,7 +107,7 @@ const MasterbarDrafts = React.createClass( {
 			onTitleClick={ this.closeDrafts }
 		/>;
 	}
-} );
+}
 
 export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
@@ -133,4 +130,4 @@ export default connect( ( state ) => {
 		draftCount: myPostCounts && myPostCounts.draft,
 		selectedSite: site,
 	};
-} )( MasterbarDrafts );
+} )( localize( MasterbarDrafts ) );

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -14,6 +14,7 @@ import paths from 'lib/paths';
 import viewport from 'lib/viewport';
 import { preload } from 'sections-preload';
 import { getSelectedSite } from 'state/ui/selectors';
+import AsyncLoad from 'components/async-load';
 
 const MasterbarItemNew = React.createClass( {
 	propTypes: {
@@ -71,26 +72,29 @@ const MasterbarItemNew = React.createClass( {
 		const newPostPath = paths.newPost( currentSite );
 
 		return (
-			<MasterbarItem
-				ref={ this.setPostButtonContext }
-				url={ newPostPath }
-				icon="create"
-				onClick={ this.onClick }
-				isActive={ this.props.isActive }
-				tooltip={ this.props.tooltip }
-				className={ classes }
-				preloadSection={ () => preload( 'post-editor' ) }
-			>
-				{ this.props.children }
-				<SitesPopover
-					id="popover__sites-popover-masterbar"
-					sites={ this.props.sites }
-					visible={ this.state.isShowingPopover }
-					context={ this.state.postButtonContext }
-					onClose={ this.toggleSitesPopover.bind( this, false ) }
-					groups={ true }
-					position={ this.getPopoverPosition() } />
-			</MasterbarItem>
+			<div className="masterbar__publish">
+				<MasterbarItem
+					ref={ this.setPostButtonContext }
+					url={ newPostPath }
+					icon="create"
+					onClick={ this.onClick }
+					isActive={ this.props.isActive }
+					tooltip={ this.props.tooltip }
+					className={ classes }
+					preloadSection={ () => preload( 'post-editor' ) }
+				>
+					{ this.props.children }
+					<SitesPopover
+						id="popover__sites-popover-masterbar"
+						sites={ this.props.sites }
+						visible={ this.state.isShowingPopover }
+						context={ this.state.postButtonContext }
+						onClose={ this.toggleSitesPopover.bind( this, false ) }
+						groups={ true }
+						position={ this.getPopoverPosition() } />
+				</MasterbarItem>
+				<AsyncLoad require="layout/masterbar/drafts" />
+			</div>
 		);
 	}
 } );

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -286,3 +286,57 @@ $autobar-height: 20px;
 		margin-right: auto;
 	}
 }
+
+.masterbar__recent-drafts.popover {
+	width: 280px;
+
+	.popover__inner {
+		overflow-y: auto;
+		text-align: left;
+		max-height: 70vh;
+
+		.async-load {
+			margin: 16px;
+			width: auto;
+		}
+	}
+}
+
+.masterbar__publish {
+	display: flex;
+
+	.async-load {
+		display: none;
+	}
+}
+
+.masterbar__toggle-drafts.button.is-borderless {
+	background: lighten( $gray, 26% );
+	border-left: 1px solid lighten( $gray, 10% );
+	color: $gray-text-min;
+	height: 36px;
+	margin: 5px 8px 5px -10px;
+	padding: 0 8px;
+	border-radius: 0 3px 3px 0;
+	position: relative;
+
+	.count {
+		border: none;
+		margin: 0;
+		font-size: 13px;
+		font-weight: 400;
+		color: $gray-dark;
+		padding: 0 4px;
+		line-height: 30px;
+	}
+}
+
+.masterbar__see-all-drafts {
+	display: block;
+	text-align: center;
+	margin: 4px 0;
+
+	.count {
+		margin-left: 8px;
+	}
+}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -340,3 +340,10 @@ $autobar-height: 20px;
 		margin-left: 8px;
 	}
 }
+
+.masterbar__recent-drafts {
+	// Trashing seems busted
+	.draft__actions {
+		display: none;
+	}
+}

--- a/client/my-sites/draft/index.jsx
+++ b/client/my-sites/draft/index.jsx
@@ -182,7 +182,7 @@ module.exports = React.createClass( {
 		];
 
 		title = post.title || <span className="draft__untitled">{ this.translate( 'Untitled' ) }</span>;
-		excerpt = post.excerpt ? <span className="draft__excerpt"><Gridicon icon="aside" size={ 18 } />{ post.excerpt }</span> : title;
+		excerpt = post.excerpt && <span className="draft__excerpt">{ post.excerpt }</span>;
 
 		// Render each Post
 		return (
@@ -196,6 +196,11 @@ module.exports = React.createClass( {
 						{ post.format === 'aside' ? excerpt : title }
 					</a>
 				</h3>
+				{ post.excerpt &&
+					<span className="draft__excerpt">
+						<a href={ editPostURL } onClick={ this.props.onTitleClick }>{ post.excerpt }</a>
+					</span>
+				}
 				{ this.props.sites.selected ? this.draftActions() : <SiteIcon site={ site } size={ 32 } /> }
 				{ image ? this.renderImage( imageUrl ) : null }
 				{ this.props.post.status === 'trash' ? this.restoreButton() : null }

--- a/client/my-sites/draft/index.jsx
+++ b/client/my-sites/draft/index.jsx
@@ -140,7 +140,7 @@ module.exports = React.createClass( {
 	render: function() {
 		var post = this.props.post,
 			image = null,
-			site, classes, imageUrl, editPostURL, title, excerpt;
+			site, classes, imageUrl, editPostURL, title;
 
 		if ( this.props.isPlaceholder ) {
 			return this.postPlaceholder();
@@ -167,33 +167,29 @@ module.exports = React.createClass( {
 			}
 		}
 
-		classes = [
-			'draft',
-			{
-				'has-all-actions': this.props.showAllActions,
-				'has-image': !! image,
-				'is-image-expanded': this.state.fullImage,
-				'is-trashed': this.props.post.status === 'trash' || this.state.isTrashing,
-				'is-placeholder': this.props.isPlaceholder,
-				'is-restoring': this.state.isRestoring,
-				'is-touch': hasTouch(),
-				'is-selected': this.props.selected
-			}
-		];
+		classes = classnames( 'draft', `is-${ post.format }`, {
+			'has-all-actions': this.props.showAllActions,
+			'has-image': !! image,
+			'is-image-expanded': this.state.fullImage,
+			'is-trashed': this.props.post.status === 'trash' || this.state.isTrashing,
+			'is-placeholder': this.props.isPlaceholder,
+			'is-restoring': this.state.isRestoring,
+			'is-touch': hasTouch(),
+			'is-selected': this.props.selected,
+		} );
 
 		title = post.title || <span className="draft__untitled">{ this.translate( 'Untitled' ) }</span>;
-		excerpt = post.excerpt && <span className="draft__excerpt">{ post.excerpt }</span>;
 
 		// Render each Post
 		return (
-			<CompactCard className={ classnames.apply( null, classes ) } key={ 'draft-' + post.ID }>
+			<CompactCard className={ classes } key={ 'draft-' + post.ID }>
 				{ this.showStatusChange() }
 				<h3 className="draft__title">
 					{ post.status === 'pending' &&
 						<span className="draft__pending-label">{ this.translate( 'Pending' ) }</span> }
 					{ this.props.showAuthor && <Gravatar user={ post.author } size={ 22 } /> }
 					<a href={ editPostURL } onClick={ this.props.onTitleClick }>
-						{ post.format === 'aside' ? excerpt : title }
+						{ title }
 					</a>
 				</h3>
 				{ post.excerpt &&

--- a/client/my-sites/draft/style.scss
+++ b/client/my-sites/draft/style.scss
@@ -1,6 +1,12 @@
 .draft.card.is-compact {
 	padding: 16px;
 	text-align: left;
+
+	&:hover {
+		.draft__excerpt {
+			display: block;
+		}
+	}
 }
 
 .draft__title {
@@ -29,14 +35,28 @@
 }
 
 .draft__excerpt {
-	color: darken( $gray, 20% );
 	font-size: 12px;
 	font-weight: 300;
+	display: none;
+	overflow: hidden;
+	line-height: 1.2;
+	position: absolute;
+	left: 0;
+	right: 24px;
+	top: 0;
+	bottom: 0;
+	padding: 12px 16px 0;
+	background: $white;
+	z-index: 20;
+	border-bottom: 10px solid $white;
 
-	.gridicon {
-		color: $gray;
-		vertical-align: text-bottom;
-		margin-right: 8px;
+	a {
+		color: $gray-text;
+		text-decoration: none;
+	}
+
+	&::after {
+		@include long-content-fade( $size: 20% );
 	}
 }
 

--- a/client/my-sites/draft/style.scss
+++ b/client/my-sites/draft/style.scss
@@ -2,9 +2,11 @@
 	padding: 16px;
 	text-align: left;
 
-	&:hover {
-		.draft__excerpt {
-			display: block;
+	@include breakpoint( ">660px" ) {
+		&:hover {
+			.draft__excerpt {
+				display: block;
+			}
 		}
 	}
 }
@@ -35,14 +37,15 @@
 }
 
 .draft__excerpt {
+	font-family: $serif;
 	font-size: 12px;
-	font-weight: 300;
+	font-weight: 400;
 	display: none;
 	overflow: hidden;
-	line-height: 1.2;
+	line-height: 1.3;
 	position: absolute;
 	left: 0;
-	right: 24px;
+	right: 28px;
 	top: 0;
 	bottom: 0;
 	padding: 12px 16px 0;
@@ -101,6 +104,10 @@
 		max-width: 65%;
 	}
 
+	.draft__excerpt {
+		left: 76px;
+	}
+
 	&.has-all-actions {
 		.draft__title {
 			max-width: 56%
@@ -123,6 +130,11 @@
 			margin-left: 0;
 			max-width: 85%;
 		}
+
+		&:hover .draft__excerpt {
+			display: none;
+		}
+
 		.draft__featured-image {
 			cursor: zoom-out;
 			border-top: 1px solid lighten( $gray, 30% );

--- a/client/my-sites/draft/style.scss
+++ b/client/my-sites/draft/style.scss
@@ -1,12 +1,13 @@
 .draft.card.is-compact {
 	padding: 16px;
+	text-align: left;
 }
 
 .draft__title {
 	display: inline-block;
 	font-family: $serif;
 	font-weight: 400;
-	font-size: 14px;
+	font-size: 13px;
 	white-space: nowrap;
 	overflow: hidden;
 	width: 95%;
@@ -19,6 +20,7 @@
 
 	a {
 		color: $gray-dark;
+		text-decoration: none;
 	}
 
 	&::after {

--- a/client/post-editor/drafts-button/index.jsx
+++ b/client/post-editor/drafts-button/index.jsx
@@ -27,7 +27,7 @@ function EditorDraftsButton( { count, onClick, jetpack, siteId, hideText } ) {
 			{ siteId && (
 				<QueryPostCounts siteId={ siteId } type="post" />
 			) }
-			{ ! hideText && <span className="drafts-button__label">{ translate( 'Drafts' ) }</span> }
+			{ ! hideText && <span>{ translate( 'Drafts' ) }</span> }
 			{ count && ! jetpack ? <Count count={ count } /> : null }
 		</Button>
 	);

--- a/client/post-editor/drafts-button/index.jsx
+++ b/client/post-editor/drafts-button/index.jsx
@@ -27,7 +27,7 @@ function EditorDraftsButton( { count, onClick, jetpack, siteId, hideText } ) {
 			{ siteId && (
 				<QueryPostCounts siteId={ siteId } type="post" />
 			) }
-			{ ! hideText && <span>{ translate( 'Drafts' ) }</span> }
+			{ ! hideText && <span className="drafts-button__label">{ translate( 'Drafts' ) }</span> }
 			{ count && ! jetpack ? <Count count={ count } /> : null }
 		</Button>
 	);


### PR DESCRIPTION
This seeks to consolidate all the recent drafts approaches in a consistent placement that works across sections and is fast to access.

![image](https://cloud.githubusercontent.com/assets/548849/23312565/87a43664-faba-11e6-8102-243bdd9b22f7.png)

