### PR TITLE
Domains: Fix the illustration for domain-only selection

### DIFF
--- a/client/signup/steps/design-type-with-store/domain-image.jsx
+++ b/client/signup/steps/design-type-with-store/domain-image.jsx
@@ -1,0 +1,11 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export default () => (
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 310 230">
+		<rect fill="#E8F0F5" width="310" height="230" />
+		<rect fill="#D2DEE6" x="80" y="110" width="150" height="13" />
+	</svg>
+);

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -10,7 +10,7 @@ import StepWrapper from 'signup/step-wrapper';
 import SignupActions from 'lib/signup/actions';
 import Card from 'components/card';
 // TODO: `design-type-with-store`, `design-type`, and this component could be refactored to reduce redundancy
-import BlogImage from 'signup/steps/design-type-with-store/blog-image';
+import DomainImage from 'signup/steps/design-type-with-store/domain-image';
 import PageImage from 'signup/steps/design-type-with-store/page-image';
 
 export default class SiteOrDomain extends Component {
@@ -19,12 +19,12 @@ export default class SiteOrDomain extends Component {
 			{
 				type: 'page',
 				label: 'Start a new site',
-				image: <BlogImage />
+				image: <PageImage />
 			},
 			{
 				type: 'domain',
 				label: 'Just buy a domain',
-				image: <PageImage />
+				image: <DomainImage />
 			},
 		];
 	}

--- a/client/signup/steps/site-or-domain/style.scss
+++ b/client/signup/steps/site-or-domain/style.scss
@@ -12,6 +12,10 @@
 	padding: 0;
 	transition: box-shadow 100ms ease-in-out;
 
+	svg {
+		display: block;
+	}
+
 	&:hover {
 		box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20 );
 	}

--- a/client/signup/steps/site-or-domain/style.scss
+++ b/client/signup/steps/site-or-domain/style.scss
@@ -10,6 +10,11 @@
 	max-width: 330px;
 	min-width: 230px;
 	padding: 0;
+	transition: box-shadow 100ms ease-in-out;
+
+	&:hover {
+		box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20 );
+	}
 }
 
 .site-or-domain__label {


### PR DESCRIPTION
Fixes #11439 by adding a new illustration for "Just buy the domain" choice in the domain-only flow.

Before | After
------------ | -------------
<img width="729" alt="screen shot 2017-02-24 at 13 15 07" src="https://cloud.githubusercontent.com/assets/448298/23315219/4aa51d40-fa93-11e6-8d69-a694d9ea548f.png"> | <img width="740" alt="screen shot 2017-02-24 at 13 12 18" src="https://cloud.githubusercontent.com/assets/448298/23315200/2d69c136-fa93-11e6-9283-f2cf69015b5a.png">


#### Testing

* Checkout Calypso locally and open http://calypso.localhost:3000/start/domain-first.
* Search and select a domain.
* Assert the illustration is correct and looks ok.

#### Review

- [x] Code
- [x] Product