### PR TITLE
People: Fixes fetching of followers when Jetpack stats module off

### DIFF
--- a/client/lib/email-followers/actions.js
+++ b/client/lib/email-followers/actions.js
@@ -24,7 +24,7 @@ var EmailFollowersActions = {
 				fetchOptions: fetchOptions
 			} );
 		}
-		wpcom.site( fetchOptions.siteId ).statsFollowers( fetchOptions, function( error, data ) {
+		wpcom.undocumented().site( fetchOptions.siteId ).fetchFollowers( fetchOptions, function( error, data ) {
 			Dispatcher.handleServerAction( {
 				type: 'RECEIVE_EMAIL_FOLLOWERS',
 				fetchOptions: fetchOptions,

--- a/client/lib/followers/actions.js
+++ b/client/lib/followers/actions.js
@@ -23,7 +23,7 @@ var FollowersActions = {
 				fetchOptions: fetchOptions
 			} );
 		}
-		wpcom.site( fetchOptions.siteId ).statsFollowers( fetchOptions, function( error, data ) {
+		wpcom.undocumented().site( fetchOptions.siteId ).fetchFollowers( fetchOptions, function( error, data ) {
 			Dispatcher.handleServerAction( {
 				type: 'RECEIVE_FOLLOWERS',
 				fetchOptions: fetchOptions,

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -161,6 +161,14 @@ UndocumentedSite.prototype.removeFollower = function( followerId, callback ) {
 	}, callback );
 };
 
+UndocumentedSite.prototype.fetchFollowers = function( fetchOptions, callback ) {
+	return this.wpcom.req.get(
+		'/sites/' + this._id + '/followers/',
+		fetchOptions,
+		callback
+	);
+};
+
 UndocumentedSite.prototype.removeEmailFollower = function( followerId, callback ) {
 	return this.wpcom.req.post( {
 		path: '/sites/' + this._id + '/email-followers/' + followerId + '/delete'


### PR DESCRIPTION
Fixes #11308

There was a change in the stats endpoint where followers would not be returned for Jetpack sites if the stats module was off. To address this, we extended that endpoint in the API and overrode the behavior that checked whether the stats module was enabled.

The new endpoint we created is at: `GET /sites/$site/followers`.

This PR updates the actions that the people section uses to point towards the new endpoint.

To test:

- Checkout patch D4339 on WPCOM
- Sandbox API
- Go to `/people/followers/$site` where `$site` is a Jetpack site
- Ensure that loads
- Turn off stats module in Jetpack site
- Wait a minute
- Reload followers page in Calypso

All should work

cc @lezama for review