### PR TITLE
Signup: Fix `site` path through `domain-first` flow

### DIFF
--- a/client/lib/cart/store/index.js
+++ b/client/lib/cart/store/index.js
@@ -134,6 +134,9 @@ CartStore.dispatchToken = Dispatcher.register( ( payload ) => {
 } );
 
 sites.on( 'change', setSelectedSite );
-setSelectedSite();
+
+if ( sites.fetched ) {
+	setSelectedSite();
+}
 
 module.exports = CartStore;

--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -204,12 +204,12 @@ assign( SignupFlowController.prototype, {
 
 			SignupActions.processSignupStep( step );
 
-			const apiFunction = steps[ step.stepName ].apiRequestFunction.bind( this );
+			const apiFunction = steps[ step.stepName ].apiRequestFunction;
 
 			apiFunction( ( errors, providedDependencies ) => {
 				this._processingSteps[ step.stepName ] = false;
 				SignupActions.processedSignupStep( step, errors, providedDependencies );
-			}, dependenciesFound, step );
+			}, dependenciesFound, step, this._reduxStore );
 		}
 	},
 

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -11,14 +11,11 @@ import { startsWith } from 'lodash';
 /**
  * Internal dependencies
  */
-import { cartItems } from 'lib/cart-values';
 import wpcom from 'lib/wp' ;
 const sites = require( 'lib/sites-list' )();
 const user = require( 'lib/user' )();
 import { getSavedVariations } from 'lib/abtest';
 import SignupCart from 'lib/signup/cart';
-import { startFreeTrial } from 'lib/upgrades/actions';
-import { PLAN_PREMIUM } from 'lib/plans/constants';
 import analytics from 'lib/analytics';
 
 import {
@@ -114,25 +111,6 @@ function createSiteWithCart( callback, dependencies, {
 			fetchSitesAndUser( siteSlug, addToCartAndProceed );
 		} else {
 			addToCartAndProceed();
-		}
-	} );
-}
-
-/**
- * Adds a Premium with free trial to the shopping cart.
- *
- * @param {function} callback - function to execute when action completes
- * @param {object} dependencies - data provided to the current step
- * @param {object} data - additional data provided by the current step
- */
-function startFreePremiumTrial( callback, dependencies, data ) {
-	const { siteId } = dependencies;
-
-	startFreeTrial( siteId, cartItems.planItem( PLAN_PREMIUM ), ( error ) => {
-		if ( error ) {
-			callback( error, dependencies );
-		} else {
-			callback( error, dependencies, data );
 		}
 	} );
 }
@@ -242,16 +220,6 @@ module.exports = {
 	createCart,
 
 	createSiteWithCart,
-
-	createSiteWithCartAndStartFreeTrial( callback, dependencies, data ) {
-		createSiteWithCart( ( error, providedDependencies ) => {
-			if ( error ) {
-				callback( error, providedDependencies );
-			} else {
-				startFreePremiumTrial( callback, providedDependencies, data );
-			}
-		}, dependencies, data );
-	},
 
 	addPlanToCart( callback, { siteId }, { cartItem, privacyItem } ) {
 		if ( isEmpty( cartItem ) ) {

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -28,7 +28,7 @@ import {
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import { getSurveyVertical, getSurveySiteType } from 'state/signup/steps/survey/selectors';
 
-function createCart( callback, dependencies, data ) {
+function createCart( callback, dependencies, data, reduxStore ) {
 	const { designType } = dependencies;
 	const { domainItem, themeItem } = data;
 
@@ -43,7 +43,7 @@ function createCart( callback, dependencies, data ) {
 
 		SignupCart.addToCart( cartKey, [ domainItem ], error => callback( error, providedDependencies ) );
 	} else {
-		createSiteWithCart( callback, dependencies, data );
+		createSiteWithCart( callback, dependencies, data, reduxStore );
 	}
 }
 
@@ -55,9 +55,9 @@ function createSiteWithCart( callback, dependencies, {
 	siteUrl,
 	themeSlugWithRepo,
 	themeItem
-} ) {
-	const siteTitle = getSiteTitle( this._reduxStore.getState() ).trim();
-	const surveyVertical = getSurveyVertical( this._reduxStore.getState() ).trim();
+}, reduxStore ) {
+	const siteTitle = getSiteTitle( reduxStore.getState() ).trim();
+	const surveyVertical = getSurveyVertical( reduxStore.getState() ).trim();
 
 	wpcom.undocumented().sitesNew( {
 		blog_name: siteUrl,
@@ -109,7 +109,7 @@ function createSiteWithCart( callback, dependencies, {
 		if ( ! user.get() && isFreeThemePreselected ) {
 			setThemeOnSite( addToCartAndProceed, { siteSlug, themeSlugWithRepo } );
 		} else if ( user.get() && isFreeThemePreselected ) {
-			fetchSitesAndUser( siteSlug, setThemeOnSite.bind( this, addToCartAndProceed, { siteSlug, themeSlugWithRepo } ) );
+			fetchSitesAndUser( siteSlug, setThemeOnSite.bind( null, addToCartAndProceed, { siteSlug, themeSlugWithRepo } ) );
 		} else if ( user.get() ) {
 			fetchSitesAndUser( siteSlug, addToCartAndProceed );
 		} else {
@@ -266,9 +266,9 @@ module.exports = {
 		SignupCart.addToCart( siteId, newCartItems, callback );
 	},
 
-	createAccount( callback, dependencies, { userData, flowName, queryArgs } ) {
-		const surveyVertical = getSurveyVertical( this._reduxStore.getState() ).trim();
-		const surveySiteType = getSurveySiteType( this._reduxStore.getState() ).trim();
+	createAccount( callback, dependencies, { userData, flowName, queryArgs }, reduxStore ) {
+		const surveyVertical = getSurveyVertical( reduxStore.getState() ).trim();
+		const surveySiteType = getSurveySiteType( reduxStore.getState() ).trim();
 
 		wpcom.undocumented().usersNew( assign(
 			{}, userData, {

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -20,7 +20,6 @@ module.exports = {
 	'design-type': DesignTypeComponent,
 	'design-type-with-store': DesignTypeWithStoreComponent,
 	domains: DomainsStepComponent,
-	'domains-with-plan': DomainsStepComponent,
 	'domain-only': DomainsStepComponent,
 	'domains-theme-preselected': DomainsStepComponent,
 	'jetpack-user': UserSignupComponent,

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -91,17 +91,6 @@ module.exports = {
 		delayApiRequestUntilComplete: true
 	},
 
-	'domains-with-plan': {
-		stepName: 'domains-with-plan',
-		apiRequestFunction: stepActions.createSiteWithCartAndStartFreeTrial,
-		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
-		dependencies: [ 'themeSlugWithRepo' ],
-		props: {
-			isDomainOnly: false
-		},
-		delayApiRequestUntilComplete: true
-	},
-
 	'domains-theme-preselected': {
 		stepName: 'domains-theme-preselected',
 		apiRequestFunction: stepActions.createSiteWithCart,


### PR DESCRIPTION
aca294986a8e326a911ec976008a665520656ddf updated `flow-controller` such that the redux store can be accessed in a step's `apiRequestFunction` via `this._reduxStore`, as `apiRequestFunction` is bound to the context of `SignupFlowController` which has a `_reduxStore` property.

This is a little bit fragile, as:

- It isn't clear which functions depend on the special context.
- Any function in `StepActions` that calls another function will need to use `Function.prototype.call` to preserve the `this` value.

I didn't catch this behavior when reviewing https://github.com/Automattic/wp-calypso/pull/10936, which broke the `domain-first` flow (which isn't public yet) if you select to create a site, as it called a function in `StepActions` without using `.call` to preserve the `SignupFlowController` context.

As far as I can tell, there isn't any reason to access `reduxStore` from the context instead of through a parameter, and doing the latter doesn't have the issues listed above. This PR makes that change.

**Testing**
- Visit `/start/domain-first`.
- Select a domain.
- Select to create a site in the second step.
- Proceed through the flow and assert that you land in checkout with the domain/plan you selected.

- [x] Code
- [ ] Product