### PR TITLE
Stats: Fix loading state on summarized views.

### DIFF
--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -58,6 +58,10 @@ class StatsModule extends Component {
 		if ( ! nextProps.requesting && this.props.requesting ) {
 			this.setState( { loaded: true } );
 		}
+
+		if ( nextProps.query !== this.props.query && this.state.loaded ) {
+			this.setState( { loaded: false } );
+		}
 	}
 
 	getModuleLabel() {


### PR DESCRIPTION
Currently when viewing a stats summary page that supports Summarized views, navigating between the different summary periods does not properly toggle the loading indicator.  This results in a message saying no data was found be displayed while the API request completes.

The fix here is to set `loaded` to `false` when the `query` prop changes on the component.

Thanks to @supernovia for the bug report

__Before__
![no-data](https://cloud.githubusercontent.com/assets/22080/23326294/069c74d6-fab1-11e6-97f5-dd0a517174ed.gif)

__After__
![no-data-after](https://cloud.githubusercontent.com/assets/22080/23326312/2467f3fa-fab1-11e6-94ba-b18bc5372485.gif)

__To Test__
- Open a site stats page
- Click on Posts & Pages to access the summary view
- Select the All Time view, note the loading indicator is shown while the data is being requested