### PR TITLE
Fix dot indicator position in themes list.

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -212,6 +212,12 @@
 		left: 50%;
 }
 
+.web-preview .pulsing-dot {
+	right: 24px;
+	top: 22px;
+	left: initial;
+}
+
 .web-preview__loading-message {
 	color: $gray;
 	font-size: 18px;

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -70,10 +70,12 @@
 	0 2px 4px lighten( $gray, 20% );
 }
 
-.pulsing-dot {
-	right: 24px;
-	top: 22px;
-	left: initial;
+.web-preview {
+	.pulsing-dot {
+		right: 24px;
+		top: 22px;
+		left: initial;
+	}
 }
 
 .themes__upload-button {

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -70,14 +70,6 @@
 	0 2px 4px lighten( $gray, 20% );
 }
 
-.web-preview {
-	.pulsing-dot {
-		right: 24px;
-		top: 22px;
-		left: initial;
-	}
-}
-
 .themes__upload-button {
 	float: right;
 


### PR DESCRIPTION
### Info

#11582 has added dot indicator for Activate and Try&Customize action for Live Demo. Unfortunately CSS for dot styling also has affected other places where dot is used in Themes. This PR fixes this situation.

### Testing
1 Got to `design` use Activate action from ellipsis menu. Dot should be in correct place. 
2 Go to Jetpack site Live Demo of a theme. Click Activate or T&C and verify that dot is visible and located on the menu right side where the buttons where located. 