### PR TITLE
Accept comments argument in showSelectedPost

### DIFF
--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -70,11 +70,11 @@ const SearchCardAdapter = ( isRecommendations ) => class extends Component {
 
 	onCardClick = ( post ) => {
 		recordTrackForPost( 'calypso_reader_searchcard_clicked', post );
-		this.props.handleClick( { post } );
+		this.props.handleClick();
 	}
 
 	onCommentClick = () => {
-		this.props.handleClick( this.props.post, { comments: true } );
+		this.props.handleClick( { comments: true } );
 	}
 
 	render() {

--- a/client/reader/test/utils.js
+++ b/client/reader/test/utils.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import sinon from 'sinon';
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+import useMockery from 'test/helpers/use-mockery';
+
+describe( 'reader utils', () => {
+	const pageSpy = sinon.spy();
+
+	beforeEach( () => {
+		pageSpy.reset();
+	} );
+
+	describe( '#showSelectedPost', () => {
+		let showSelectedPost;
+		useFakeDom();
+		useMockery( ( mockery ) => {
+			mockery.registerMock( 'page', {
+				show: pageSpy,
+			} );
+			mockery.registerMock( 'lib/feed-stream-store/actions', {
+				selectItem: sinon.stub(),
+			} );
+			mockery.registerMock( 'reader/controller-helper', {
+				setLastStoreId: sinon.stub(),
+			} );
+			showSelectedPost = require( '../utils' ).showSelectedPost;
+		} );
+
+		it( 'does not do anything if postKey argument is missing', () => {
+			showSelectedPost( {} );
+			expect( pageSpy ).to.have.not.been.called;
+		} );
+
+		it( 'redirects if passed a post key', () => {
+			showSelectedPost( { postKey: { feedId: 1, postId: 5 } } );
+			expect( pageSpy ).to.have.been.calledOnce;
+		} );
+
+		it( 'redirects to a #comments URL if we passed comments argument', () => {
+			showSelectedPost( { postKey: { feedId: 1, postId: 5 }, comments: true } );
+			expect( pageSpy ).to.have.been.calledWithMatch('#comments');
+		} );
+	} );
+} );

--- a/client/reader/utils.js
+++ b/client/reader/utils.js
@@ -76,7 +76,7 @@ export function isPostNotFound( post ) {
 	return post.statusCode === 404;
 }
 
-export function showSelectedPost( { store, replaceHistory, selectedGap, postKey, index } ) {
+export function showSelectedPost( { store, replaceHistory, selectedGap, postKey, index, comments } ) {
 	if ( ! postKey ) {
 		return;
 	}
@@ -119,6 +119,7 @@ export function showSelectedPost( { store, replaceHistory, selectedGap, postKey,
 	showFullPost( {
 		post: mappedPost,
 		replaceHistory,
+		comments
 	} );
 }
 


### PR DESCRIPTION
Fixes #10951 – when clicking the Comments link on a card in the reader it doesn’t take us to the comments section of a post.

Implementation details are in the commit message.

A couple of design notes:

* Tracking passing callbacks and other arguments (the click handler and the comments argument) through several layers was not fun. As a reader it would’ve been easier if it was clearer where those values were coming from.
* I had to mock a lot of stuff to test the function. I don’t mind testing with some side effects, but calling `page` this deep the call chain was unexpected for me. It would’ve felt a lot more natural if `page` calls were limited to actions/controllers, or at least to components, not library functions.