### PR TITLE
Themes: Install AT themes without -wpcom suffix

### DIFF
--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -71,6 +71,7 @@ import {
 	hasJetpackSiteJetpackThemesExtendedFeatures,
 	isJetpackSite
 } from 'state/sites/selectors';
+import { isSiteAutomatedTransfer } from 'state/selectors';
 import i18n from 'i18n-calypso';
 import accept from 'lib/accept';
 import config from 'config';
@@ -345,9 +346,12 @@ export function requestActiveTheme( siteId ) {
 export function activate( themeId, siteId, source = 'unknown', purchased = false ) {
 	return ( dispatch, getState ) => {
 		if ( isJetpackSite( getState(), siteId ) && ! getTheme( getState(), siteId, themeId ) ) {
-			// Suffix themeId here with `-wpcom`. If the suffixed theme is already installed,
-			// installation will silently fail, and it will just be activated.
-			return dispatch( installAndActivateTheme( themeId + '-wpcom', siteId, source, purchased ) );
+			// AT sites do not use the -wpcom suffix
+			const siteIsAT = isSiteAutomatedTransfer( getState(), siteId );
+			const installId = siteIsAT ? themeId : themeId + '-wpcom';
+			// If theme is already installed, installation will silently fail,
+			// and it will just be activated.
+			return dispatch( installAndActivateTheme( installId, siteId, source, purchased ) );
 		}
 
 		return dispatch( activateTheme( themeId, siteId, source, purchased ) );


### PR DESCRIPTION
Fixes theme activation and customization for AT sites.

AT sites no longer use -wpcom suffixes for wpcom themes. The intended plan for Calypso was to still supply a suffix to the install endpoint for AT sites (to avoid an AT special case), but the Jetpack install endpoint has problems returning a different (non-suffixed) theme id to the one that was supplied.

This change would require a modification to the wpcomsh plugin to not expect suffixed theme IDs.

This is an alternative to the workaround in #11535

/cc @lamosty