### PR TITLE
Replace Penscratch with Penscratch 2 in signup

### DIFF
--- a/client/lib/signup/themes-data.js
+++ b/client/lib/signup/themes-data.js
@@ -162,12 +162,12 @@ export const themes = [
 		verticals: []
 	},
 	{
-		name: 'Penscratch',
-		slug: 'penscratch',
+		name: 'Penscratch 2',
+		slug: 'penscratch-2',
 		repo: 'pub',
 		fallback: true,
 		design: 'blog',
-		demo_uri: 'https://penscratchdemo.wordpress.com',
+		demo_uri: 'https://penscratch2demo.wordpress.com',
 		verticals: []
 	},
 	{

--- a/client/lib/signup/themes-data.js
+++ b/client/lib/signup/themes-data.js
@@ -162,7 +162,7 @@ export const themes = [
 		verticals: []
 	},
 	{
-		name: 'Penscratch 2',
+		name: 'Penscratch',
 		slug: 'penscratch-2',
 		repo: 'pub',
 		fallback: true,


### PR DESCRIPTION
* Switch to this PR 
* Go to calypso.local:3000(?)/start/ 
* Click "A list of my latest posts" 
* Make sure Penscratch 2 shows up instead of Penscratch

