### PR TITLE
Purchases: Add credit card form will use card for existing purchases

### DIFF
--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -34,7 +34,8 @@ const CreditCardForm = React.createClass( {
 		initialValues: PropTypes.object,
 		recordFormSubmitEvent: PropTypes.func.isRequired,
 		saveStoredCard: PropTypes.func,
-		successCallback: PropTypes.func.isRequired
+		successCallback: PropTypes.func.isRequired,
+		showUsedForExistingPurchasesInfo: PropTypes.bool,
 	},
 
 	getInitialState() {
@@ -273,6 +274,7 @@ const CreditCardForm = React.createClass( {
 							) }
 						</p>
 					</div>
+					{ this.renderUsedForExistingPurchases() }
 				</Card>
 
 				<CompactCard className="credit-card-form__footer">
@@ -288,6 +290,18 @@ const CreditCardForm = React.createClass( {
 				</CompactCard>
 			</form>
 		);
+	},
+	renderUsedForExistingPurchases() {
+		if ( this.props.showUsedForExistingPurchasesInfo ) {
+			return (
+				<div className="credit-card-form__card-terms">
+					<Gridicon icon="info-outline" size={ 18 } />
+					<p>
+						{ this.translate( 'This card will be also used for renewal of existing purchases, if any.' ) }
+					</p>
+				</div>
+			);
+		}
 	}
 } );
 

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -297,7 +297,7 @@ const CreditCardForm = React.createClass( {
 				<div className="credit-card-form__card-terms">
 					<Gridicon icon="info-outline" size={ 18 } />
 					<p>
-						{ this.translate( 'This card will be also used for renewal of existing purchases, if any.' ) }
+						{ this.translate( 'This card will be used for future renewals of existing purchases.' ) }
 					</p>
 				</div>
 			);

--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -183,7 +183,8 @@ UndocumentedMe.prototype.storedCardAdd = function( paygateToken, callback ) {
 	return this.wpcom.req.post( {
 		path: '/me/stored-cards'
 	}, {
-		payment_key: paygateToken
+		payment_key: paygateToken,
+		use_as_default: true
 	}, callback );
 };
 

--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -184,7 +184,7 @@ UndocumentedMe.prototype.storedCardAdd = function( paygateToken, callback ) {
 		path: '/me/stored-cards'
 	}, {
 		payment_key: paygateToken,
-		use_as_default: true
+		use_for_existing: true
 	}, callback );
 };
 

--- a/client/me/purchases/add-credit-card/index.jsx
+++ b/client/me/purchases/add-credit-card/index.jsx
@@ -49,7 +49,9 @@ class AddCreditCard extends Component {
 					createPaygateToken={ this.createPaygateToken }
 					recordFormSubmitEvent={ this.recordFormSubmitEvent }
 					saveStoredCard={ this.props.addStoredCard }
-					successCallback={ this.goToBillingHistory } />
+					successCallback={ this.goToBillingHistory }
+					showUsedForExistingPurchasesInfo={ true }
+				/>
 			</Main>
 		);
 	}


### PR DESCRIPTION
It is quite confusing that when the Add credit card form is used, the card is not used for renewal of existing subscriptions.

This adds explaining hint to that page, and sets parameter for the API call (so that we can prepare backend before deploying this). Backend part pending.

The message is only shown on Add credit card page, not on other places that use the credit card form.

Info text:
"This card will be also used for renewal of existing purchases, if any."
copy suggestions welcome!

![image](https://cloud.githubusercontent.com/assets/203105/23379825/b583b908-fd38-11e6-8c0a-223d623c3038.png)