### PR TITLE
Replace Dyad with Dyad 2 in signup

### DIFF
--- a/client/lib/signup/themes-data.js
+++ b/client/lib/signup/themes-data.js
@@ -45,7 +45,7 @@ export const themes = [
 		verticals: []
 	},
 	{
-		name: 'Dyad 2',
+		name: 'Dyad',
 		slug: 'dyad-2',
 		repo: 'pub',
 		fallback: true,

--- a/client/lib/signup/themes-data.js
+++ b/client/lib/signup/themes-data.js
@@ -45,12 +45,12 @@ export const themes = [
 		verticals: []
 	},
 	{
-		name: 'Dyad',
-		slug: 'dyad',
+		name: 'Dyad 2',
+		slug: 'dyad-2',
 		repo: 'pub',
 		fallback: true,
 		design: 'grid',
-		demo_uri: 'https://dyaddemo.wordpress.com',
+		demo_uri: 'https://dyad2demo.wordpress.com',
 		verticals: []
 	},
 	{


### PR DESCRIPTION
Instructions for local testing:
Switch to this PR
Go to calypso.local:3000(?)/start/
Click "A grid of my latest posts"
Make sure Dyad 2 shows up instead of Dyad

Also, live testing can be done here: 
https://calypso.live/?branch=update-themes-in-signup-dyad-2

Following @sixhours lead and pinging @michaeldcain for when you get a free moment. 

Thanks!