### PR TITLE
Jetpack Settings: Fix toggle spacing in Subscriptions card

### DIFF
--- a/client/my-sites/site-settings/subscriptions/index.jsx
+++ b/client/my-sites/site-settings/subscriptions/index.jsx
@@ -28,7 +28,7 @@ const Subscriptions = ( {
 	translate
 } ) => {
 	return (
-		<Card className="subscriptions site-settings">
+		<Card className="subscriptions site-settings__discussion-settings">
 			<FormFieldset>
 				<div className="subscriptions__info-link-container site-settings__info-link-container">
 					<InfoPopover position={ 'left' }>


### PR DESCRIPTION
This PR fixes the weird spacing of toggles within the Subscriptions card in the Discussion settings tab. The spacing was incorrect due to an incorrect class being specified to the card.

**Before:**
![](https://cldup.com/WCBldEx3mH.png)

**After:**
![](https://cldup.com/WZ_Ag8gmiE.png)

To test:
* Checkout this branch or load it in calypso.live
* Go to `/settings/discussion/$site`, where `$site` is one of your Jetpack sites.
* Verify the spacing looks as shown in the "After" screenshot.