### PR TITLE
Site Settings: Use real-time activation state of Jetpack analytics module

### DIFF
--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -22,11 +22,12 @@ import {
 	isJetpackBusiness
 } from 'lib/products-values';
 import { removeNotice, errorNotice } from 'state/notices/actions';
-import { getSiteOption, isJetpackModuleActive, isJetpackMinimumVersion } from 'state/sites/selectors';
+import { getSiteOption, isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
+import { isJetpackModuleActive } from 'state/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
 import { isEnabled } from 'config';
 import { FEATURE_GOOGLE_ANALYTICS } from 'lib/plans/constants';
+import QueryJetpackModules from 'components/data/query-jetpack-modules';
 
 const validateGoogleAnalyticsCode = code => ! code || code.match( /^UA-\d+-\d+$/i );
 const hasBusinessPlan = overSome( isBusiness, isEnterprise, isJetpackBusiness );
@@ -71,6 +72,7 @@ class GoogleAnalyticsForm extends Component {
 			jetpackVersionSupportsModule,
 			showUpgradeNudge,
 			site,
+			siteId,
 			siteIsJetpack,
 			siteSlug,
 			translate,
@@ -82,6 +84,10 @@ class GoogleAnalyticsForm extends Component {
 
 		return (
 			<form id="site-settings" onSubmit={ handleSubmitForm }>
+				{
+					siteIsJetpack &&
+					<QueryJetpackModules siteId={ siteId } />
+				}
 
 				{ showUpgradeNudge &&
 					<UpgradeNudge
@@ -108,7 +114,7 @@ class GoogleAnalyticsForm extends Component {
 					</Notice>
 				}
 
-				{ siteIsJetpack && ! jetpackModuleActive && ! isJetpackUnsupported && ! showUpgradeNudge &&
+				{ siteIsJetpack && jetpackModuleActive === false && ! isJetpackUnsupported && ! showUpgradeNudge &&
 					<Notice
 						status="is-warning"
 						showDismiss={ false }
@@ -209,6 +215,7 @@ const mapStateToProps = ( state ) => {
 
 	return {
 		site,
+		siteId,
 		siteSlug,
 		siteIsJetpack,
 		showUpgradeNudge: ! isGoogleAnalyticsEligible,


### PR DESCRIPTION
This PR updates the Jetpack Analytics module activation state to be pulled real-time from the site. This fixes a bug with Jetpack sites where the Analytics module can appear as disabled in Calypso if the module has been activated recently, and the sync hasn't completed yet.

To reproduce the bug:
* Disable the Analytics module for a Jetpack site with a Professional plan.
* Make sure it appears as disabled as shown on the bottom screenshot in `/settings/analytics/$site`
* Quickly enable the Analytics module in wp-admin
* Quickly go to `/settings/analytics/$site` and see that the module still appears to be inactive.

![](https://cldup.com/H2PawYLigr.png)

This PR basically changes the Analytics module activation state to be pulled in real time using the Jetpack site REST API that we use for the rest of the Jetpack Settings in Calypso.

To test:

* Checkout this branch
* Go to `/settings/analytics/$site`, where `$site` is a Jetpack site with a Professional plan.
* Disable the Analytics module from your wp-admin
* Verify the notice from the screenshot above is displayed in Calypso.
* Enable the Analytics module from your wp-admin
* Verify the notice from the screenshot above is NOT displayed anymore, and the tracking code form is enabled.
* Verify the changes haven't affected WordPress.com sites with a Business plan.

