### PR TITLE
Chain install calls of parent and child theme.

### DIFF
--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -445,16 +445,6 @@ export function installTheme( themeId, siteId ) {
 			themeId
 		} );
 
-		if ( isThemeFromWpcom( themeId ) ) {
-			const parentThemeId = getWpcomParentThemeId(
-				getState(),
-				themeId.replace( '-wpcom', '' )
-			);
-			if ( parentThemeId ) {
-				dispatch( installTheme( parentThemeId + '-wpcom', siteId ) );
-			}
-		}
-
 		return wpcom.undocumented().installThemeOnJetpack( siteId, themeId )
 			.then( ( theme ) => {
 				dispatch( receiveTheme( theme, siteId ) );
@@ -463,6 +453,17 @@ export function installTheme( themeId, siteId ) {
 					siteId,
 					themeId
 				} );
+			} )
+			.then( () => {
+				if ( isThemeFromWpcom( themeId ) ) {
+					const parentThemeId = getWpcomParentThemeId(
+						getState(),
+						themeId.replace( '-wpcom', '' )
+					);
+					if ( parentThemeId ) {
+						dispatch( installTheme( parentThemeId + '-wpcom', siteId ) );
+					}
+				}
 			} )
 			.catch( ( error ) => {
 				dispatch( {


### PR DESCRIPTION
### Info
Wpcom theme activation on Jetpack site requires installation of that theme first.
If the theme has a parent theme Calypso calls the install endpoint both for parent and child theme.
Before this change the calls where executed basically simultaneously. This caused some issues on Jetpack side - one of the themes was not getting installed properly. This PR chains the two installs together so one is executed after another. 

### Testing
Open `design` for Jetpack site and activate a theme that requires parent theme like Goran(child) and Edin(parent). Activating Goran should also install Edin. Make sure that they are both not installed on Jetpack prior to test. 

### kudos
This solution was created by @seear 