### PR TITLE
Media: Pass className as prop in media modal preview components

### DIFF
--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -211,6 +211,7 @@ class EditorMediaModalDetailItem extends Component {
 		}
 
 		return React.createElement( Item, {
+			className: 'editor-media-modal-detail__preview',
 			site: site,
 			item: item
 		} );

--- a/client/post-editor/media-modal/detail/detail-preview-audio.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-audio.jsx
@@ -1,26 +1,30 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-var MediaUtils = require( 'lib/media/utils' );
+import MediaUtils from 'lib/media/utils';
 
 module.exports = React.createClass( {
 	displayName: 'EditorMediaModalDetailPreviewAudio',
 
 	propTypes: {
+		className: React.PropTypes.string,
 		item: React.PropTypes.object.isRequired
 	},
 
 	render: function() {
+		const classes = classNames( this.props.className, 'is-audio' );
+
 		return (
 			<audio
 				src={ MediaUtils.url( this.props.item ) }
 				controls
-				className="editor-media-modal-detail__preview is-audio" />
+				className={ classes } />
 		);
 	}
 } );

--- a/client/post-editor/media-modal/detail/detail-preview-document.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-document.jsx
@@ -3,13 +3,20 @@
  */
 import React from 'react';
 import Gridicon from 'gridicons';
+import classNames from 'classnames';
 
 export default React.createClass( {
 	displayName: 'EditorMediaModalDetailPreviewDocument',
 
+	propTypes: {
+		className: React.PropTypes.string,
+	},
+
 	render() {
+		const classes = classNames( this.props.className, 'is-document' );
+
 		return (
-			<div className="editor-media-modal-detail__preview is-document">
+			<div className={ classes }>
 				<Gridicon icon="pages" size={ 120 } />
 			</div>
 		);

--- a/client/post-editor/media-modal/detail/detail-preview-image.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-image.jsx
@@ -14,8 +14,9 @@ import { url, isItemBeingUploaded } from 'lib/media/utils';
 
 export default class EditorMediaModalDetailPreviewImage extends Component {
 	static propTypes = {
-		site: PropTypes.object,
+		className: PropTypes.string,
 		item: PropTypes.object.isRequired,
+		site: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -60,7 +61,7 @@ export default class EditorMediaModalDetailPreviewImage extends Component {
 		// - `is-blob` when the image is shown using local `blob` data.
 
 		const classes = classNames(
-			'editor-media-modal-detail__preview',
+			this.props.className,
 			'is-image',
 			{ 'is-uploading': uploading },
 			{ 'is-loading': loading },
@@ -71,7 +72,7 @@ export default class EditorMediaModalDetailPreviewImage extends Component {
 		// in order to improve the UX between the states that an image could have,
 		// for instance when the image is restored.
 		const fakeClasses = classNames(
-			'editor-media-modal-detail__preview',
+			this.props.className,
 			'is-image',
 			'is-fake',
 			{ 'is-uploading': uploading },

--- a/client/post-editor/media-modal/detail/detail-preview-video.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-video.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-const React = require( 'react' );
+import React from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -13,6 +14,7 @@ module.exports = React.createClass( {
 	displayName: 'EditorMediaModalDetailPreviewVideo',
 
 	propTypes: {
+		className: React.PropTypes.string,
 		item: React.PropTypes.object.isRequired
 	},
 
@@ -21,11 +23,13 @@ module.exports = React.createClass( {
 			return <EditorMediaModalDetailItemVideoPress { ...this.props } />;
 		}
 
+		const classes = classNames( this.props.className, 'is-video' );
+
 		return (
 			<video
 				src={ MediaUtils.url( this.props.item ) }
 				controls
-				className="editor-media-modal-detail__preview is-video" />
+				className={ classes } />
 		);
 	}
 } );

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
 import debug from 'debug';
 
 /**
@@ -17,6 +18,7 @@ const videoPressUrl = 'https://wordpress.com/wp-content/plugins/video/assets/js/
 
 class EditorMediaModalDetailPreviewVideoPress extends Component {
 	static propTypes = {
+		className: PropTypes.string,
 		isPlaying: PropTypes.bool,
 		item: PropTypes.object.isRequired,
 	};
@@ -89,9 +91,11 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 	}
 
 	render() {
+		const classes = classNames( this.props.className, 'is-video' );
+
 		return (
 			<div
-				className="editor-media-modal-detail__preview is-video"
+				className={ classes }
 				ref={ this.setVideoInstance }>
 			</div>
 		);


### PR DESCRIPTION
While working on PR #11389 to add support for custom video posters, it became apparent that the CSS class for the `EditorMediaModalDetailPreviewVideoPress` component should not be hard-coded to be `editor-media-modal-detail__preview`. Since the new video editor block will also use this same VideoPress preview component, the `editor-media-modal-detail__preview` class is a bit of a misnomer and should be changed to be configurable.

As the initialization of the other media modal preview components are tightly coupled, it also made sense to pass their class in via props as well.

### Testing
1. In the editor, select "Add Media" from the toolbar dropdown.
2. Upload a video and select it, or select an already uploaded video.
3. Click the Edit button.
4. Ensure the video preview is styled correctly. In particular, ensure that it is vertically and/or horizontally centred as per the following screenshot.
5. Repeat steps 2 - 4 for an audio, document and image file.

#### VideoPress Video
![video](https://cloud.githubusercontent.com/assets/1190420/23409673/6c73342a-fd9a-11e6-9f01-785ab0f4472c.jpg)

#### Non-VideoPress Video
![video](https://cloud.githubusercontent.com/assets/1190420/23749264/5cc27f48-0495-11e7-9505-542c5df46970.jpg)

#### Audio
![audio](https://cloud.githubusercontent.com/assets/1190420/23409699/7ed727a2-fd9a-11e6-9a9b-a430416101e9.jpg)

#### Document
![document](https://cloud.githubusercontent.com/assets/1190420/23409695/7909e094-fd9a-11e6-9416-07eec4de2364.jpg)

#### Image
![image](https://cloud.githubusercontent.com/assets/1190420/23409685/730deffa-fd9a-11e6-8268-c20b044876dc.jpg)