### PR TITLE
Component: do not render plan-storage if sitePlan is not defined

### DIFF
--- a/client/blocks/plan-storage/docs/example.jsx
+++ b/client/blocks/plan-storage/docs/example.jsx
@@ -55,7 +55,7 @@ export default React.createClass( {
 						mediaStorage={ mediaStorage.green }
 					/>
 				</div>
-				<div style={ { marginBottom: 16, maxWidth: '400' } }>
+				<div style={ { marginBottom: 16, maxWidth: '400px' } }>
 					<PlanStorageBar
 						siteSlug={ primarySite.slug }
 						sitePlanSlug={ PLAN_PERSONAL }
@@ -63,7 +63,7 @@ export default React.createClass( {
 					/>
 				</div>
 
-				<div style={ { marginBottom: 16, maxWidth: '300' } }>
+				<div style={ { marginBottom: 16, maxWidth: '300px' } }>
 					<PlanStorageBar
 						siteSlug={ primarySite.slug }
 						sitePlanSlug={ PLAN_PREMIUM }

--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -34,7 +34,7 @@ class PlanStorage extends Component {
 			siteSlug,
 		} = this.props;
 
-		if ( jetpackSite ) {
+		if ( jetpackSite || ! sitePlan ) {
 			return null;
 		}
 


### PR DESCRIPTION
This PR fix the issue when the `sitePlan` var isn't defined. If it is the case do not render the component.

### Testing
1) Be sure to clean the browser cache
2) Go to the plan-storage testing page: `http://calypso.localhost:3000/devdocs/blocks/plan-storage`
3) Take a look the browser console. Everything should be ok.
The bug to fix is `Uncaught (in promise) TypeError: Cannot read property 'product_slug' of null`

![image](https://cloud.githubusercontent.com/assets/77539/23414447/caf9598c-fdba-11e6-9eb0-dbecf29ead68.png)
