### PR TITLE
Reader: Overwrite subscribed lists with API response

### DIFF
--- a/client/state/reader/lists/reducer.js
+++ b/client/state/reader/lists/reducer.js
@@ -49,14 +49,14 @@ export function items( state = {}, action ) {
 		case READER_LIST_UPDATE_SUCCESS:
 			return Object.assign( {}, state, keyBy( [ action.data.list ], 'ID' ) );
 		case READER_LIST_UPDATE_TITLE:
-			let listForTitleChange = Object.assign( {}, state[ action.listId ] );
+			const listForTitleChange = Object.assign( {}, state[ action.listId ] );
 			if ( ! listForTitleChange ) {
 				return state;
 			}
 			listForTitleChange.title = action.title;
 			return Object.assign( {}, state, keyBy( [ listForTitleChange ], 'ID' ) );
 		case READER_LIST_UPDATE_DESCRIPTION:
-			let listForDescriptionChange = Object.assign( {}, state[ action.listId ] );
+			const listForDescriptionChange = Object.assign( {}, state[ action.listId ] );
 			if ( ! listForDescriptionChange ) {
 				return state;
 			}

--- a/client/state/reader/lists/reducer.js
+++ b/client/state/reader/lists/reducer.js
@@ -83,7 +83,7 @@ export function items( state = {}, action ) {
 export function subscribedLists( state = [], action ) {
 	switch ( action.type ) {
 		case READER_LISTS_RECEIVE:
-			return union( state, map( action.lists, 'ID' ) );
+			return map( action.lists, 'ID' );
 		case READER_LISTS_UNFOLLOW_SUCCESS:
 			// Remove the unfollowed list ID from subscribedLists
 			return filter( state, ( listId ) => {

--- a/client/state/reader/lists/test/reducer.js
+++ b/client/state/reader/lists/test/reducer.js
@@ -9,6 +9,7 @@ import deepFreeze from 'deep-freeze';
  */
 import {
 	READER_LISTS_RECEIVE,
+	READER_LISTS_UNFOLLOW_SUCCESS,
 	READER_LIST_UPDATE_SUCCESS,
 	READER_LIST_DISMISS_NOTICE,
 	READER_LIST_UPDATE_TITLE,
@@ -20,7 +21,8 @@ import {
 import {
 	items,
 	updatedLists,
-	missingLists
+	missingLists,
+	subscribedLists,
 } from '../reducer';
 
 describe( 'reducer', () => {
@@ -215,6 +217,43 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( [] );
+		} );
+	} );
+
+	describe( '#subscribedLists', () => {
+		it( 'should default to empty', () => {
+			expect( subscribedLists( undefined, { type: '@@BAD' } ) ).to.eql( [] );
+		} );
+
+		it( 'should pick up the ids of the subscribed lists', () => {
+			expect( subscribedLists( deepFreeze( [] ), {
+				type: READER_LISTS_RECEIVE,
+				lists: [
+					{ ID: 1 },
+					{ ID: 2 }
+				]
+			} ) ).to.eql( [ 1, 2 ] );
+		} );
+
+		it( 'should overwrite existing subs', () => {
+			const initial = deepFreeze( [ 1, 2 ] );
+			expect( subscribedLists( initial, {
+				type: READER_LISTS_RECEIVE,
+				lists: [
+					{ ID: 3 },
+					{ ID: 1 }
+				]
+			} ) ).to.eql( [ 3, 1 ] );
+		} );
+
+		it( 'should remove an item on unfollow', () => {
+			const initial = deepFreeze( [ 1, 2 ] );
+			expect( subscribedLists( initial, {
+				type: READER_LISTS_UNFOLLOW_SUCCESS,
+				data: {
+					list: { ID: 1 }
+				}
+			} ) ).to.eql( [ 2 ] );
 		} );
 	} );
 } );

--- a/client/state/reader/lists/test/reducer.js
+++ b/client/state/reader/lists/test/reducer.js
@@ -153,7 +153,7 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( [
-				{ owner: 'lister', slug: 'banana'}
+				{ owner: 'lister', slug: 'banana' }
 			] );
 		} );
 
@@ -181,7 +181,7 @@ describe( 'reducer', () => {
 			} );
 
 			expect( initialState ).to.eql( [
-				{ owner: 'lister', slug: 'banana'}
+				{ owner: 'lister', slug: 'banana' }
 			] );
 
 			const state = missingLists( initialState, {
@@ -206,7 +206,7 @@ describe( 'reducer', () => {
 			} );
 
 			expect( initialState ).to.eql( [
-				{ owner: 'lister', slug: 'banana'}
+				{ owner: 'lister', slug: 'banana' }
 			] );
 
 			const state = missingLists( initialState, {


### PR DESCRIPTION
Problem: When accepting a set of subscribed lists, we currently merge that
list with the current state. If you're subscribed to a list that was
deleted, that list will never be removed from your client-side serialized
state.

Solution: Overwrite the set of subscribed lists instead of merging them.
This removes the deleted lists from the client side state.

To test:
* Create a new list
* Go back to Calypso
* Refresh
* Open the list in Calypso, click on the Cog icon
* Delete the list
* Go back to Calypso and refresh
* On production, the list still appears. On this branch, the list should appear, then be removed from the list once the API request completes.