### PR TITLE
Extensions: Add WooCommerce base extension

### DIFF
--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { navigation, siteSelection } from 'my-sites/controller';
+import { renderWithReduxStore } from 'lib/react-helpers';
+import Main from 'components/main';
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+
+const render = ( context ) => {
+	renderWithReduxStore( (
+		<Main className="woocommerce__main">
+			<SectionHeader label="WooCommerce" />
+			<Card>
+				<p>This is the starting point of something great!</p>
+				<p>This will be the home for your WooCommerce integration with WordPress.com.</p>
+			</Card>
+		</Main>
+	), document.getElementById( 'primary' ), context.store );
+};
+
+export default function() {
+	page( '/woocommerce/:site?', siteSelection, navigation, render );
+}
+

--- a/client/extensions/woocommerce/package.json
+++ b/client/extensions/woocommerce/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "woocommerce",
+	"author": "Automattic",
+	"description": "WooCommerce",
+	"version": "0.0.1",
+	"env_id": [ "development", "wpcalypso" ],
+	"section": {
+		"name": "woocommerce",
+		"paths": [ "/woocommerce" ],
+		"module": "woocommerce",
+		"group": "sites",
+		"secondary": true
+	}
+}


### PR DESCRIPTION
This adds the base extension for WooCommerce.
It's only for dev builds and it's just a placeholder page for now.