### PR TITLE
Fix IE11 & MS Edge components design glitches

### DIFF
--- a/client/components/accordion/style.scss
+++ b/client/components/accordion/style.scss
@@ -93,7 +93,7 @@ $accordion-background-expanded: $white;
 	font-style: italic;
 	color: $gray-dark;
 	white-space: nowrap;
-	overflow-x: hidden;
+	overflow: hidden;
 	position: relative;
 	height: $accordion-subtitle-height;
 }

--- a/client/components/spinner-button/style.scss
+++ b/client/components/spinner-button/style.scss
@@ -1,4 +1,4 @@
 .spinner-button__spinner {
 	float: right;
-	padding: 8px;
+	margin: 8px;
 }

--- a/client/components/spinner/index.jsx
+++ b/client/components/spinner/index.jsx
@@ -10,10 +10,8 @@ import classNames from 'classnames';
 
 /**
  * Defines whether the current browser supports CSS animations for SVG
- * elements. Specifically, this returns false for Internet Explorer versions
- * 11 and below.
+ * elements. Specifically, this returns false for Internet Explorer and Edge.
  *
- * @see http://dev.modern.ie/platform/status/csstransitionsanimationsforsvgelements/
  * @type {Boolean} True if the browser supports CSS animations for SVG
  *                 elements, or false otherwise.
  */
@@ -22,7 +20,7 @@ const isSVGCSSAnimationSupported = ( () => {
 		return false;
 	}
 
-	return ! /(MSIE |Trident\/)/.test( global.window.navigator.userAgent );
+	return ! /(MSIE |Trident\/|Edge\/)/.test( global.window.navigator.userAgent );
 } )();
 
 export default class Spinner extends PureComponent {

--- a/client/lib/wrap-es6-functions/index.js
+++ b/client/lib/wrap-es6-functions/index.js
@@ -27,7 +27,4 @@ export default function() {
 
 	[ 'codePointAt', 'normalize', 'repeat', 'startsWith', 'endsWith', 'includes' ]
 		.map( partial( wrapObjectFn, String.prototype, 'String#' ) );
-
-	[ 'flags' ].map( partial( wrapObjectFn, RegExp.prototype, 'RegExp#' ) );
-
 }

--- a/client/lib/wrap-es6-functions/test/index.js
+++ b/client/lib/wrap-es6-functions/test/index.js
@@ -25,7 +25,6 @@ describe( 'wrap-es6-functions', () => {
 		fromPairs( [
 			[ Array, [ 'keys', 'entries', 'values', 'findIndex', 'fill', 'find' ] ],
 			[ String, [ 'codePointAt', 'normalize', 'repeat', 'startsWith', 'endsWith', 'includes' ] ],
-			[ RegExp, [ 'flags' ] ]
 		], ( object, keys ) => {
 			keys.forEach( ( key ) => {
 				if ( isFunction( object.prototype[ key ] ) ) {
@@ -47,9 +46,5 @@ describe( 'wrap-es6-functions', () => {
 		[ 'codePointAt', 'repeat' ].forEach( partial( assertCall, 'hello', [ 1 ] ) );
 		[ 'startsWith', 'endsWith', 'includes' ].forEach( partial( assertCall, 'hello', [ 'a' ] ) );
 		[ 'normalize' ].forEach( partial( assertCall, 'hello', [] ) );
-	} );
-
-	describe( 'RegExp', () => {
-		[ 'flags' ].forEach( partial( assertCall, /a/, [ 'g' ] ) );
 	} );
 } );


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-services/issues/907

I was set to fix the `<Spinner>` component not animating on MS Edge, and when opening the Devdocs on Edge (and IE) I've found a few more problems, so I fixed them too.

Spinner in MS Edge doesn't spin:
![](https://cloud.githubusercontent.com/assets/1715800/23330446/bfe98994-fb45-11e6-883f-e44912ddfb2a.png)

Broken Spinner style on the `<SpinnerButton>` component:
![](https://cldup.com/JGNmEMs7NB.png)

Tiny scrollbars on the Accordion (IE11 only):
![](https://cldup.com/0J3Isz0wSd.png)

The individual commit messages have more detailed information.

cc/ @nabsul @v18 @marcinbot if you want to take a look