### PR TITLE
Video Editor: Add VideoPress poster picker

### DIFF
--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -156,15 +156,15 @@ class Media extends Component {
 		const site = this.props.sites.getSelectedSite();
 
 		// Photon does not support URLs with a querystring component.
-		posterUrl = posterUrl && posterUrl.split( '?' )[ 0 ];
+		const urlBeforeQuery = ( posterUrl || '' ).split( '?' )[ 0 ];
 
 		if ( site ) {
 			MediaActions.edit( site.ID, {
 				ID,
 				thumbnails: {
-					fmt_hd: posterUrl,
-					fmt_dvd: posterUrl,
-					fmt_std: posterUrl,
+					fmt_hd: urlBeforeQuery,
+					fmt_dvd: urlBeforeQuery,
+					fmt_std: urlBeforeQuery,
 				}
 			} );
 		}

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -153,7 +153,7 @@ class Media extends Component {
 	};
 
 	onVideoEditorUpdatePoster = ( { ID, posterUrl } ) => {
-		const site = this.props.sites.getSelectedSite();
+		const site = this.props.selectedSite;
 
 		// Photon does not support URLs with a querystring component.
 		const urlBeforeQuery = ( posterUrl || '' ).split( '?' )[ 0 ];

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -13,6 +13,7 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import Dialog from 'components/dialog';
 import { EditorMediaModalDetail } from 'post-editor/media-modal/detail';
 import ImageEditor from 'blocks/image-editor';
+import VideoEditor from 'blocks/video-editor';
 import MediaActions from 'lib/media/actions';
 import MediaUtils from 'lib/media/utils';
 import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
@@ -28,9 +29,10 @@ class Media extends Component {
 	};
 
 	state = {
-		editedItem: null,
 		currentDetail: null,
-		selectedImages: [],
+		editedImageItem: null,
+		editedVideoItem: null,
+		selectedItems: [],
 	};
 
 	componentDidMount() {
@@ -56,7 +58,7 @@ class Media extends Component {
 	openDetailsModalForASingleImage = ( image ) => {
 		this.setState( {
 			currentDetail: 0,
-			selectedImages: [ image ],
+			selectedItems: [ image ],
 		} );
 	};
 
@@ -66,21 +68,25 @@ class Media extends Component {
 
 		this.setState( {
 			currentDetail: 0,
-			selectedImages: selected
+			selectedItems: selected
 		} );
 	};
 
 	closeDetailsModal = () => {
-		this.setState( { editedItem: null, currentDetail: null, selectedImages: [] } );
+		this.setState( { editedImageItem: null, editedVideoItem: null, currentDetail: null, selectedItems: [] } );
 	};
 
 	editImage = () => {
-		this.setState( { currentDetail: null, editedItem: this.state.currentDetail } );
+		this.setState( { currentDetail: null, editedImageItem: this.state.currentDetail } );
+	};
+
+	editVideo = () => {
+		this.setState( { currentDetail: null, editedVideoItem: this.state.currentDetail } );
 	};
 
 	onImageEditorCancel = ( imageEditorProps ) => {
 		const {	resetAllImageEditorState } = imageEditorProps;
-		this.setState( { currentDetail: this.state.editedItem, editedItem: null } );
+		this.setState( { currentDetail: this.state.editedImageItem, editedImageItem: null } );
 
 		resetAllImageEditorState();
 	};
@@ -112,12 +118,12 @@ class Media extends Component {
 
 		MediaActions.update( site.ID, item, true );
 		resetAllImageEditorState();
-		this.setState( { currentDetail: null, editedItem: null, selectedImages: [] } );
+		this.setState( { currentDetail: null, editedImageItem: null, selectedItems: [] } );
 	};
 
 	getModalButtons() {
-		// do not render buttons if the media image editor is opened
-		if ( this.state.editedItem !== null ) {
+		// do not render buttons if the media image or video editor is opened
+		if ( ( this.state.editedImageItem !== null ) || ( this.state.editedVideoItem !== null ) ) {
 			return null;
 		}
 
@@ -142,12 +148,36 @@ class Media extends Component {
 		];
 	}
 
+	onVideoEditorCancel = () => {
+		this.setState( { currentDetail: this.state.editedVideoItem, editedVideoItem: null } );
+	};
+
+	onVideoEditorUpdatePoster = ( { ID, posterUrl } ) => {
+		const site = this.props.sites.getSelectedSite();
+
+		// Photon does not support URLs with a querystring component.
+		posterUrl = posterUrl && posterUrl.split( '?' )[ 0 ];
+
+		if ( site ) {
+			MediaActions.edit( site.ID, {
+				ID,
+				thumbnails: {
+					fmt_hd: posterUrl,
+					fmt_dvd: posterUrl,
+					fmt_std: posterUrl,
+				}
+			} );
+		}
+
+		this.setState( { currentDetail: null, editedVideoItem: null, selectedItems: [] } );
+	};
+
 	restoreOriginalMedia = ( siteId, item ) => {
 		if ( ! siteId || ! item ) {
 			return;
 		}
 		MediaActions.update( siteId, { ID: item.ID, media_url: item.guid }, true );
-		this.setState( { currentDetail: null, editedItem: null, selectedImages: [] } );
+		this.setState( { currentDetail: null, editedImageItem: null, selectedItems: [] } );
 	};
 
 	setDetailSelectedIndex = ( index ) => {
@@ -198,8 +228,8 @@ class Media extends Component {
 			return;
 		}
 
-		const selected = this.state.selectedImages && this.state.selectedImages.length
-			? this.state.selectedImages
+		const selected = this.state.selectedItems && this.state.selectedItems.length
+			? this.state.selectedItems
 			: MediaLibrarySelectedStore.getAll( site.ID );
 
 		MediaActions.delete( site.ID, selected );
@@ -210,7 +240,7 @@ class Media extends Component {
 		return (
 			<div ref="container" className="main main-column media" role="main">
 				<SidebarNavigation />
-				{ ( this.state.editedItem !== null || this.state.currentDetail !== null ) &&
+				{ ( this.state.editedImageItem !== null || this.state.editedVideoItem !== null || this.state.currentDetail !== null ) &&
 					<Dialog
 						isVisible={ true }
 						additionalClassNames="editor-media-modal media__item-dialog"
@@ -220,20 +250,28 @@ class Media extends Component {
 					{ this.state.currentDetail !== null &&
 						<EditorMediaModalDetail
 							site={ site }
-							items={ this.state.selectedImages }
+							items={ this.state.selectedItems }
 							selectedIndex={ this.state.currentDetail }
 							onReturnToList={ this.closeDetailsModal }
-							onEditItem={ this.editImage }
+							onEditImageItem={ this.editImage }
+							onEditVideoItem={ this.editVideo }
 							onRestoreItem={ this.restoreOriginalMedia }
 							onSelectedIndexChange={ this.setDetailSelectedIndex }
 						/>
 					}
-					{ this.state.editedItem !== null &&
+					{ this.state.editedImageItem !== null &&
 						<ImageEditor
 							siteId={ site && site.ID }
-							media={ this.state.selectedImages[ this.state.editedItem ] }
+							media={ this.state.selectedItems[ this.state.editedImageItem ] }
 							onDone={ this.onImageEditorDone }
 							onCancel={ this.onImageEditorCancel }
+						/>
+					}
+					{ this.state.editedVideoItem !== null &&
+						<VideoEditor
+							media={ this.state.selectedItems[ this.state.editedVideoItem ] }
+							onCancel={ this.onVideoEditorCancel }
+							onUpdatePoster={ this.onVideoEditorUpdatePoster }
 						/>
 					}
 					</Dialog>

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -122,11 +122,9 @@ class EditorMediaModalDetailItem extends Component {
 			return null;
 		}
 
-		let editText = translate( 'Edit Image' );
-
-		if ( 'video' === mimePrefix ) {
-			editText = translate( 'Edit Thumbnail' );
-		}
+		const editText = 'video' === mimePrefix
+			? translate( 'Edit Thumbnail' )
+			: translate( 'Edit Image' );
 
 		return (
 			<Button

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -31,10 +31,16 @@ import { getSiteOption, isJetpackModuleActive, isJetpackSite } from 'state/sites
  * This function return true if the image editor can be
  * enabled/shown
  *
+ * @param  {object} item - media item
  * @param  {object} site - current site
  * @return {boolean} `true` if the image-editor can be enabled.
  */
-const enableImageEditing = ( site ) => {
+const enableImageEditing = ( item, site ) => {
+	// do not allow if, for some reason, there isn't a valid item yet
+	if ( ! item ) {
+		return false;
+	}
+
 	// do not show if the feature flag isn't set
 	if ( ! config.isEnabled( 'post-editor/image-editor' ) ) {
 		return false;

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -179,11 +179,9 @@ class EditorMediaModalDetailItem extends Component {
 		const mimePrefix = MediaUtils.getMimePrefix( item );
 		const classes = classNames( 'editor-media-modal-detail__edition-bar', classname );
 
-		if ( 'video' === mimePrefix ) {
-			return this.renderVideoEditorButtons( item, classes );
-		}
-
-		return this.renderImageEditorButtons( classes, classname );
+		return 'video' === mimePrefix
+			? this.renderVideoEditorButtons( item, classes )
+			: this.renderImageEditorButtons( classes, classname );
 	}
 
 	renderImageEditorButtons( classes, classname ) {

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -20,6 +20,7 @@ import EditorMediaModalDetailPreviewVideo from './detail-preview-video';
 import EditorMediaModalDetailPreviewAudio from './detail-preview-audio';
 import EditorMediaModalDetailPreviewDocument from './detail-preview-document';
 import Button from 'components/button';
+import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import { userCan } from 'lib/site/utils';
 import versionCompare from 'lib/version-compare';
 import MediaUtils, { isItemBeingUploaded } from 'lib/media/utils';
@@ -318,7 +319,7 @@ class EditorMediaModalDetailItem extends Component {
 	}
 
 	render() {
-		const { item } = this.props;
+		const { isJetpack, item, siteId } = this.props;
 
 		const classes = classNames( 'editor-media-modal-detail__item', {
 			'is-loading': ! item
@@ -336,6 +337,7 @@ class EditorMediaModalDetailItem extends Component {
 					</div>
 
 					<div className="editor-media-modal-detail__sidebar">
+						{ isJetpack && <QueryJetpackModules siteId={ siteId } /> /* Is the VideoPress module active? */ }
 						{ this.renderMediaEditorButtons( item, 'is-mobile' ) }
 						{ this.renderFields() }
 						<EditorMediaModalDetailFileInfo
@@ -356,6 +358,7 @@ const connectComponent = connect(
 			isJetpack: isJetpackSite( state, siteId ),
 			isVideoPressEnabled: getSiteOption( state, siteId, 'videopress_enabled' ),
 			isVideoPressModuleActive: isJetpackModuleActive( state, siteId, 'videopress' ),
+			siteId,
 		};
 	}
 );

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
-import { noop } from 'lodash';
+import { includes, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 import url from 'url';
 import Gridicon from 'gridicons';
@@ -94,8 +94,14 @@ class EditorMediaModalDetailItem extends Component {
 
 		const mimePrefix = MediaUtils.getMimePrefix( item );
 
-		if ( 'image' !== mimePrefix ) {
+		if ( ! includes( [ 'image', 'video' ], mimePrefix ) ) {
 			return null;
+		}
+
+		let editText = translate( 'Edit Image' );
+
+		if ( 'video' === mimePrefix ) {
+			editText = translate( 'Edit Thumbnail' );
 		}
 
 		return (
@@ -104,7 +110,7 @@ class EditorMediaModalDetailItem extends Component {
 				onClick={ onEdit }
 				disabled={ isItemBeingUploaded( item ) }
 			>
-				<Gridicon icon="pencil" size={ 36 } /> { translate( 'Edit Image' ) }
+				<Gridicon icon="pencil" size={ 36 } /> { editText }
 			</Button>
 		);
 	}

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -192,19 +192,20 @@ class EditorMediaModalDetailItem extends Component {
 		}
 
 		const mimePrefix = MediaUtils.getMimePrefix( item );
-		const classes = classNames( 'editor-media-modal-detail__edition-bar', classname );
 
 		return 'video' === mimePrefix
-			? this.renderVideoEditorButtons( item, classes )
-			: this.renderImageEditorButtons( classes, classname );
+			? this.renderVideoEditorButtons( item, classname )
+			: this.renderImageEditorButtons( classname );
 	}
 
-	renderImageEditorButtons( classes, classname ) {
+	renderImageEditorButtons( classname ) {
 		const { site } = this.props;
 
 		if ( ! enableImageEditing( site ) ) {
 			return null;
 		}
+
+		const classes = classNames( 'editor-media-modal-detail__edition-bar', classname );
 
 		return (
 			<div className={ classes }>
@@ -214,10 +215,12 @@ class EditorMediaModalDetailItem extends Component {
 		);
 	}
 
-	renderVideoEditorButtons( item, classes ) {
+	renderVideoEditorButtons( item, classname ) {
 		if ( ! this.enableVideoEditing( item ) ) {
 			return null;
 		}
+
+		const classes = classNames( 'editor-media-modal-detail__edition-bar', classname );
 
 		return (
 			<div className={ classes }>

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -25,7 +25,7 @@ import versionCompare from 'lib/version-compare';
 import MediaUtils, { isItemBeingUploaded } from 'lib/media/utils';
 import config from 'config';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite, getSiteOption } from 'state/sites/selectors';
+import { getSiteOption, isJetpackModuleActive, isJetpackSite } from 'state/sites/selectors';
 
 /**
  * This function return true if the image editor can be
@@ -84,20 +84,28 @@ class EditorMediaModalDetailItem extends Component {
 	 * @return {Boolean} Whether the video editor can be enabled
 	 */
 	enableVideoEditing( item ) {
-		// do not show if the feature flag isn't set
 		if ( ! config.isEnabled( 'post-editor/video-editor' ) ) {
 			return false;
 		}
 
-		const { isJetpack, isVideoPressDisabled } = this.props;
+		const {
+			isJetpack,
+			isVideoPressEnabled,
+			isVideoPressModuleActive,
+		} = this.props;
 
-		// do not allow for Jetpack site with VideoPress disabled
+		// Not a VideoPress video
+		if ( ! MediaUtils.isVideoPressItem( item ) ) {
+			return false;
+		}
+
+		// Jetpack and VideoPress disabled
 		if ( isJetpack ) {
-			if ( ! MediaUtils.isVideoPressItem( item ) ) {
+			if ( ! isVideoPressModuleActive ) {
 				return false;
 			}
-		// do not allow for wpcom site with VideoPress disabled
-		} else if ( isVideoPressDisabled ) {
+		// WP.com and VideoPress disabled
+		} else if ( ! isVideoPressEnabled ) {
 			return false;
 		}
 
@@ -337,7 +345,8 @@ const connectComponent = connect(
 
 		return {
 			isJetpack: isJetpackSite( state, siteId ),
-			isVideoPressDisabled: ! getSiteOption( state, siteId, 'videopress_enabled' ),
+			isVideoPressEnabled: getSiteOption( state, siteId, 'videopress_enabled' ),
+			isVideoPressModuleActive: isJetpackModuleActive( state, siteId, 'videopress' ),
 		};
 	}
 );

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -13,6 +13,7 @@ import debug from 'debug';
 import { loadScript, removeScriptCallback } from 'lib/load-script';
 import {
 	setVideoEditorHasScriptLoadError,
+	setVideoEditorVideoHasLoaded,
 } from 'state/ui/editor/video-editor/actions';
 
 /**
@@ -36,6 +37,7 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 
 	componentDidMount() {
 		this.loadInitializeScript();
+		window.addEventListener( 'message', this.receiveMessage, false );
 	}
 
 	componentWillUnmount() {
@@ -93,7 +95,27 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 		}
 	};
 
+	receiveMessage = ( event ) => {
+		if ( event.origin && event.origin !== location.origin ) {
+			return;
+		}
+
+		const data = 'string' === typeof event.data
+			? JSON.parse( event.data )
+			: event.data;
+
+		if ( ! data || 'videopress_loading_state' !== data.event || ! ( 'state' in data ) ) {
+			return;
+		}
+
+		if ( 'loaded' === data.state ) {
+			this.props.setVideoHasLoaded();
+		}
+	}
+
 	destroy() {
+		window.removeEventListener( 'message', this.receiveMessage );
+
 		if ( ! this.player ) {
 			return;
 		}
@@ -140,5 +162,6 @@ export default connect(
 	null,
 	{
 		setHasScriptLoadError: setVideoEditorHasScriptLoadError,
+		setVideoHasLoaded: setVideoEditorVideoHasLoaded,
 	}
 )( EditorMediaModalDetailPreviewVideoPress );

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -48,6 +48,8 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 	componentWillReceiveProps( nextProps ) {
 		if ( this.props.isPlaying && ! nextProps.isPlaying ) {
 			this.pause();
+		} else if ( ! this.props.isPlaying && nextProps.isPlaying ) {
+			this.play();
 		}
 	}
 
@@ -125,6 +127,16 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 		// Remove DOM created outside of React.
 		while ( this.video.firstChild ) {
 			this.video.removeChild( this.video.firstChild );
+		}
+	}
+
+	play() {
+		if ( ! this.player || ! this.player.state ) {
+			return;
+		}
+
+		if ( typeof this.player.state.play === 'function' ) {
+			this.player.state.play();
 		}
 	}
 

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -102,15 +102,13 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 			return;
 		}
 
-		const data = 'string' === typeof event.data
-			? JSON.parse( event.data )
-			: event.data;
+		const data = event.data;
 
-		if ( ! data || 'videopress_loading_state' !== data.event || ! ( 'state' in data ) ) {
+		if ( ! data || 'videopress_loading_state' !== data.event || ! ( 'state' in data ) || ! ( 'converting' in data ) ) {
 			return;
 		}
 
-		if ( 'loaded' === data.state ) {
+		if ( ( 'loaded' === data.state ) && ! data.converting ) {
 			this.props.onVideoLoaded();
 		}
 	}

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -98,11 +98,7 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 		}
 
 		if ( typeof window !== 'undefined' && window.videopress ) {
-			this.player = window.videopress( videopress_guid, this.video, {
-				autoPlay: isPlaying,
-				height: height,
-				width: width,
-			} );
+			this.player = window.videopress( videopress_guid, this.video, { autoPlay: isPlaying, height, width } );
 		}
 	};
 
@@ -111,7 +107,7 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 			return;
 		}
 
-		const data = event.data;
+		const { data } = event;
 
 		if ( ! data || 'videopress_loading_state' !== data.event || ! ( 'state' in data ) || ! ( 'converting' in data ) ) {
 			return;

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import { get, invoke, noop, pick } from 'lodash';
+import { get, invoke, noop } from 'lodash';
 import classNames from 'classnames';
 import debug from 'debug';
 
@@ -91,7 +91,7 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 			height = 480,
 			videopress_guid,
 			width = 854,
-		} = pick( item, [ 'videopress_guid', 'height', 'width' ] );
+		} = item;
 
 		if ( ! videopress_guid ) {
 			return;

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { noop } from 'lodash';
+import { invoke, noop } from 'lodash';
 import classNames from 'classnames';
 import debug from 'debug';
 
@@ -120,7 +120,7 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 			return;
 		}
 
-		this.player.destroy();
+		invoke( this, 'player.destroy' );
 
 		// Remove DOM created outside of React.
 		while ( this.video.firstChild ) {
@@ -133,9 +133,7 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 			return;
 		}
 
-		if ( typeof this.player.state.play === 'function' ) {
-			this.player.state.play();
-		}
+		invoke( this, 'player.state.play' );
 	}
 
 	pause() {
@@ -143,14 +141,12 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 			return;
 		}
 
-		if ( typeof this.player.state.pause === 'function' ) {
-			this.player.state.pause();
-		}
+		invoke( this, 'player.state.pause' );
 
-		let currentTime;
+		const currentTime = invoke( this, 'player.state.videoAt' );
 
-		if ( typeof this.player.state.videoAt === 'function' ) {
-			currentTime = this.player.state.videoAt();
+		if ( ! currentTime ) {
+			return;
 		}
 
 		this.props.onPause( currentTime );

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import { connect } from 'react-redux';
 import { get, invoke, noop, pick } from 'lodash';
 import classNames from 'classnames';
 import debug from 'debug';
@@ -174,6 +173,4 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 	}
 }
 
-export default connect(
-	null,
-)( EditorMediaModalDetailPreviewVideoPress );
+export default EditorMediaModalDetailPreviewVideoPress;

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { invoke, noop } from 'lodash';
+import { get, invoke, noop, pick } from 'lodash';
 import classNames from 'classnames';
 import debug from 'debug';
 
@@ -82,17 +82,27 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 		} = this.props;
 
 		if ( error ) {
-			log( `Script${ error.src } failed to load.` );
+			log( `Script${ get( error, 'src', '' ) } failed to load.` );
 			onScriptLoadError();
 
 			return;
 		}
 
+		const {
+			height = 480,
+			videopress_guid,
+			width = 854,
+		} = pick( item, [ 'videopress_guid', 'height', 'width' ] );
+
+		if ( ! videopress_guid ) {
+			return;
+		}
+
 		if ( typeof window !== 'undefined' && window.videopress ) {
-			this.player = window.videopress( item.videopress_guid, this.video, {
+			this.player = window.videopress( videopress_guid, this.video, {
 				autoPlay: isPlaying,
-				height: item.height,
-				width: item.width,
+				height: height,
+				width: width,
 			} );
 		}
 	};

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -2,19 +2,15 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { noop } from 'lodash';
+import classNames from 'classnames';
 import debug from 'debug';
 
 /**
  * Internal dependencies
  */
 import { loadScript, removeScriptCallback } from 'lib/load-script';
-import {
-	setVideoEditorHasScriptLoadError,
-	setVideoEditorVideoHasLoaded,
-} from 'state/ui/editor/video-editor/actions';
 
 /**
  * Module variables
@@ -28,11 +24,15 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 		isPlaying: PropTypes.bool,
 		item: PropTypes.object.isRequired,
 		onPause: PropTypes.func,
+		onScriptLoadError: PropTypes.func,
+		onVideoLoaded: PropTypes.func,
 	};
 
 	static defaultProps = {
 		isPlaying: false,
 		onPause: noop,
+		onScriptLoadError: noop,
+		onVideoLoaded: noop,
 	};
 
 	componentDidMount() {
@@ -78,12 +78,12 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 		const {
 			isPlaying,
 			item,
-			setHasScriptLoadError,
+			onScriptLoadError,
 		} = this.props;
 
 		if ( error ) {
 			log( `Script${ error.src } failed to load.` );
-			setHasScriptLoadError();
+			onScriptLoadError();
 
 			return;
 		}
@@ -111,7 +111,7 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 		}
 
 		if ( 'loaded' === data.state ) {
-			this.props.setVideoHasLoaded();
+			this.props.onVideoLoaded();
 		}
 	}
 
@@ -172,8 +172,4 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 
 export default connect(
 	null,
-	{
-		setHasScriptLoadError: setVideoEditorHasScriptLoadError,
-		setVideoHasLoaded: setVideoEditorVideoHasLoaded,
-	}
 )( EditorMediaModalDetailPreviewVideoPress );

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -3,12 +3,16 @@
  */
 import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
+import { connect } from 'react-redux';
 import debug from 'debug';
 
 /**
  * Internal dependencies
  */
 import { loadScript, removeScriptCallback } from 'lib/load-script';
+import {
+	setVideoEditorHasScriptLoadError,
+} from 'state/ui/editor/video-editor/actions';
 
 /**
  * Module variables
@@ -58,15 +62,18 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 	}
 
 	onScriptLoaded = ( error ) => {
-		if ( error ) {
-			log( `Script${ error.src } failed to load.` );
-			return;
-		}
-
 		const {
 			isPlaying,
 			item,
+			setHasScriptLoadError,
 		} = this.props;
+
+		if ( error ) {
+			log( `Script${ error.src } failed to load.` );
+			setHasScriptLoadError();
+
+			return;
+		}
 
 		if ( typeof window !== 'undefined' && window.videopress ) {
 			this.player = window.videopress( item.videopress_guid, this.video, {
@@ -102,4 +109,9 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 	}
 }
 
-export default EditorMediaModalDetailPreviewVideoPress;
+export default connect(
+	null,
+	{
+		setHasScriptLoadError: setVideoEditorHasScriptLoadError,
+	}
+)( EditorMediaModalDetailPreviewVideoPress );

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -4,6 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
+import { noop } from 'lodash';
 import debug from 'debug';
 
 /**
@@ -25,10 +26,12 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 		className: PropTypes.string,
 		isPlaying: PropTypes.bool,
 		item: PropTypes.object.isRequired,
+		onPause: PropTypes.func,
 	};
 
 	static defaultProps = {
 		isPlaying: false,
+		onPause: noop,
 	};
 
 	componentDidMount() {
@@ -38,6 +41,12 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 	componentWillUnmount() {
 		removeScriptCallback( videoPressUrl, this.onScriptLoaded );
 		this.destroy();
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.isPlaying && ! nextProps.isPlaying ) {
+			this.pause();
+		}
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -95,6 +104,24 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 		while ( this.video.firstChild ) {
 			this.video.removeChild( this.video.firstChild );
 		}
+	}
+
+	pause() {
+		if ( ! this.player || ! this.player.state ) {
+			return;
+		}
+
+		if ( typeof this.player.state.pause === 'function' ) {
+			this.player.state.pause();
+		}
+
+		let currentTime;
+
+		if ( typeof this.player.state.videoAt === 'function' ) {
+			currentTime = this.player.state.videoAt();
+		}
+
+		this.props.onPause( currentTime );
 	}
 
 	render() {

--- a/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-videopress.jsx
@@ -134,7 +134,9 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 	}
 
 	play() {
-		if ( ! this.player || ! this.player.state ) {
+		const playerState = get( this, 'player.state' );
+
+		if ( ! playerState ) {
 			return;
 		}
 
@@ -142,7 +144,9 @@ class EditorMediaModalDetailPreviewVideoPress extends Component {
 	}
 
 	pause() {
-		if ( ! this.player || ! this.player.state ) {
+		const playerState = get( this, 'player.state' );
+
+		if ( ! playerState ) {
 			return;
 		}
 

--- a/client/post-editor/media-modal/detail/index.jsx
+++ b/client/post-editor/media-modal/detail/index.jsx
@@ -61,12 +61,14 @@ export const EditorMediaModalDetail = React.createClass( {
 			selectedIndex,
 			site,
 
-			onEditItem,
+			onEditImageItem,
+			onEditVideoItem,
 			onRestoreItem,
 			onReturnToList,
 		} = this.props;
 
 		const item = items[ selectedIndex ];
+		const mimePrefix = MediaUtils.getMimePrefix( item );
 
 		return (
 			<div className="editor-media-modal-detail">
@@ -79,7 +81,7 @@ export const EditorMediaModalDetail = React.createClass( {
 					onShowPreviousItem={ this.incrementIndex.bind( this, -1 ) }
 					onShowNextItem={ this.incrementIndex.bind( this, 1 ) }
 					onRestore={ onRestoreItem }
-					onEdit={ onEditItem } />
+					onEdit={ 'video' === mimePrefix ? onEditVideoItem : onEditImageItem } />
 			</div>
 		);
 	}
@@ -87,5 +89,6 @@ export const EditorMediaModalDetail = React.createClass( {
 
 export default connect( null, {
 	onReturnToList: partial( setEditorMediaModalView, ModalViews.LIST ),
-	onEditItem: partial( setEditorMediaModalView, ModalViews.IMAGE_EDITOR )
+	onEditImageItem: partial( setEditorMediaModalView, ModalViews.IMAGE_EDITOR ),
+	onEditVideoItem: partial( setEditorMediaModalView, ModalViews.VIDEO_EDITOR ),
 } )( EditorMediaModalDetail );

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -251,7 +251,25 @@ export class EditorMediaModal extends Component {
 		this.props.setView( ModalViews.DETAIL );
 	};
 
-	handleUpdatePoster = () => this.props.setView( ModalViews.DETAIL );
+	handleUpdatePoster = ( { ID, posterUrl } ) => {
+		const { site } = this.props;
+
+		// Photon does not support URLs with a querystring component.
+		posterUrl = posterUrl && posterUrl.split( '?' )[ 0 ];
+
+		if ( site ) {
+			MediaActions.edit( site.ID, {
+				ID,
+				thumbnails: {
+					fmt_hd: posterUrl,
+					fmt_dvd: posterUrl,
+					fmt_std: posterUrl,
+				}
+			} );
+		}
+
+		this.props.setView( ModalViews.DETAIL );
+	}
 
 	handleCancel = () => {
 		const { mediaLibrarySelectedItems } = this.props;

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -251,6 +251,8 @@ export class EditorMediaModal extends Component {
 		this.props.setView( ModalViews.DETAIL );
 	};
 
+	handleUpdatePoster = () => this.props.setView( ModalViews.DETAIL );
+
 	handleCancel = () => {
 		const { mediaLibrarySelectedItems } = this.props;
 		const item = mediaLibrarySelectedItems[ this.getDetailSelectedIndex() ];
@@ -436,6 +438,7 @@ export class EditorMediaModal extends Component {
 						<VideoEditor
 							media={ media }
 							onCancel={ this.handleCancel }
+							onUpdatePoster={ this.handleUpdatePoster }
 						/>
 					);
 				}

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -255,15 +255,15 @@ export class EditorMediaModal extends Component {
 		const { site } = this.props;
 
 		// Photon does not support URLs with a querystring component.
-		posterUrl = posterUrl && posterUrl.split( '?' )[ 0 ];
+		const urlBeforeQuery = ( posterUrl || '' ).split( '?' )[ 0 ];
 
 		if ( site ) {
 			MediaActions.edit( site.ID, {
 				ID,
 				thumbnails: {
-					fmt_hd: posterUrl,
-					fmt_dvd: posterUrl,
-					fmt_std: posterUrl,
+					fmt_hd: urlBeforeQuery,
+					fmt_dvd: urlBeforeQuery,
+					fmt_std: urlBeforeQuery,
 				}
 			} );
 		}

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -251,9 +251,8 @@ export class EditorMediaModal extends Component {
 		this.props.setView( ModalViews.DETAIL );
 	};
 
-	onImageEditorCancel = imageEditorProps => {
+	handleCancel = () => {
 		const { mediaLibrarySelectedItems } = this.props;
-
 		const item = mediaLibrarySelectedItems[ this.getDetailSelectedIndex() ];
 
 		if ( ! item ) {
@@ -262,9 +261,12 @@ export class EditorMediaModal extends Component {
 		}
 
 		this.props.setView( ModalViews.DETAIL );
+	}
 
+	onImageEditorCancel = imageEditorProps => {
 		const {	resetAllImageEditorState } = imageEditorProps;
 
+		this.handleCancel();
 		resetAllImageEditorState();
 	};
 
@@ -433,6 +435,7 @@ export class EditorMediaModal extends Component {
 					content = (
 						<VideoEditor
 							media={ media }
+							onCancel={ this.handleCancel }
 						/>
 					);
 				}

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -15,7 +15,8 @@ import {
 	some,
 	values,
 	isEmpty,
-	identity
+	identity,
+	includes,
 } from 'lodash';
 
 /**
@@ -40,6 +41,7 @@ import { setEditorMediaModalView } from 'state/ui/editor/actions';
 import { ModalViews } from 'state/ui/media-modal/constants';
 import { deleteMedia } from 'state/media/actions';
 import ImageEditor from 'blocks/image-editor';
+import VideoEditor from 'blocks/video-editor';
 import MediaModalDetail from './detail';
 import { withAnalytics, bumpStat, recordGoogleEvent } from 'state/analytics/actions';
 
@@ -338,7 +340,7 @@ export class EditorMediaModal extends Component {
 	}
 
 	getModalButtons() {
-		if ( ModalViews.IMAGE_EDITOR === this.props.view ) {
+		if ( includes( [ ModalViews.IMAGE_EDITOR, ModalViews.VIDEO_EDITOR ], this.props.view ) ) {
 			return;
 		}
 
@@ -374,7 +376,7 @@ export class EditorMediaModal extends Component {
 	}
 
 	shouldClose() {
-		return ( ModalViews.IMAGE_EDITOR !== this.props.view );
+		return ! includes( [ ModalViews.IMAGE_EDITOR, ModalViews.VIDEO_EDITOR ], this.props.view );
 	}
 
 	updateSettings = ( gallerySettings ) => {
@@ -407,6 +409,7 @@ export class EditorMediaModal extends Component {
 				break;
 
 			case ModalViews.IMAGE_EDITOR:
+			case ModalViews.VIDEO_EDITOR:
 				const {
 					site,
 					imageEditorProps,
@@ -416,15 +419,24 @@ export class EditorMediaModal extends Component {
 				const selectedIndex = this.getDetailSelectedIndex();
 				const media = items ? items[ selectedIndex ] : null;
 
-				content = (
-					<ImageEditor
-						siteId={ site && site.ID }
-						media={ media }
-						onDone={ this.onImageEditorDone }
-						onCancel={ this.onImageEditorCancel }
-						{ ...imageEditorProps }
-					/>
-				);
+				if ( ModalViews.IMAGE_EDITOR === this.props.view ) {
+					content = (
+						<ImageEditor
+							siteId={ site && site.ID }
+							media={ media }
+							onDone={ this.onImageEditorDone }
+							onCancel={ this.onImageEditorCancel }
+							{ ...imageEditorProps }
+						/>
+					);
+				} else {
+					content = (
+						<VideoEditor
+							media={ media }
+						/>
+					);
+				}
+
 				break;
 
 			default:

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -34,7 +34,9 @@ describe( 'EditorMediaModal', function() {
 
 	translate = require( 'i18n-calypso' ).translate;
 
-	useMockery();
+	useMockery( () => {
+		mockery.registerSubstitute( 'event', 'component-event' );
+	} );
 	useFakeDom();
 	useSandbox( ( sandbox ) => {
 		spy = sandbox.spy();

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -62,6 +62,7 @@
 		"post-editor/author-selector": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
+		"post-editor/video-editor": false,
 		"press-this": false,
 		"preview-layout": true,
 		"reader": true,

--- a/config/development.json
+++ b/config/development.json
@@ -118,6 +118,7 @@
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
 		"post-editor/media-advanced": false,
+		"post-editor/video-editor": true,
 		"press-this": true,
 		"publicize-preview": true,
 		"publicize-scheduling": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -69,6 +69,7 @@
 		"plans/jetpack-config-v2": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
+		"post-editor/video-editor": true,
 		"press-this": true,
 		"preview-layout": true,
 		"reader": true,

--- a/config/production.json
+++ b/config/production.json
@@ -68,6 +68,7 @@
 		"post-editor/author-selector": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
+		"post-editor/video-editor": false,
 		"press-this": true,
 		"preview-layout": true,
 		"push-notifications": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -71,6 +71,7 @@
 		"plans/jetpack-config-v2": false,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
+		"post-editor/video-editor": false,
 		"press-this": true,
 		"preview-layout": true,
 		"push-notifications": true,

--- a/config/test.json
+++ b/config/test.json
@@ -81,6 +81,7 @@
 		"plans/personal-plan": true,
 		"post-editor-github-link": false,
 		"post-editor/media-advanced": true,
+		"post-editor/video-editor": false,
 		"press-this": true,
 		"reader": true,
 		"reader/following-intro": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -81,6 +81,7 @@
 		"plans/jetpack-config-v2": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
+		"post-editor/video-editor": true,
 		"press-this": true,
 		"preview-layout": true,
 		"publicize-scheduling": true,


### PR DESCRIPTION
This PR enables choosing a custom VideoPress poster by either selecting a particular frame of the video or by uploading a custom image.

### Testing
Test using a site that has VideoPress enabled (e.g. a WP.com site that has a Premium plan or a Jetpack site that has a Jetpack Premium plan and VideoPress enabled in Jetpack settings).

The Video Editor can be accessed in the post editor by selecting "Add Media" from the toolbar dropdown, selecting a video, clicking the "Edit" button, and then clicking the "Edit Thumbnail" button.

It can also be accessed by clicking "Media" in the sidebar, selecting a video, clicking the "Edit" button, and then clicking the "Edit Thumbnail" button:

![screen shot 2017-02-15 at 11 42 15 am](https://cloud.githubusercontent.com/assets/1190420/22984581/d572949c-f373-11e6-9b59-5ebbeef1eba0.jpg)

![screen shot 2017-02-15 at 11 37 29 am](https://cloud.githubusercontent.com/assets/1190420/22984464/6f90bcc6-f373-11e6-86d8-771388e0b061.jpg)

If the video cannot be loaded or an error occurs when updating the poster, the following message is shown:

![screen shot 2017-02-15 at 11 38 09 am](https://cloud.githubusercontent.com/assets/1190420/22984509/8bde3bce-f373-11e6-953c-bf9bc3f28d4f.jpg)