### PR TITLE
Extensions: Move WooCommerce URL to /store

### DIFF
--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -16,16 +16,16 @@ import SectionHeader from 'components/section-header';
 const render = ( context ) => {
 	renderWithReduxStore( (
 		<Main className="woocommerce__main">
-			<SectionHeader label="WooCommerce" />
+			<SectionHeader label="WooCommerce Store" />
 			<Card>
-				<p>This is the starting point of something great!</p>
-				<p>This will be the home for your WooCommerce integration with WordPress.com.</p>
+				<p>This is the start of something great!</p>
+				<p>This will be the home for your WooCommerce Store integration with WordPress.com.</p>
 			</Card>
 		</Main>
 	), document.getElementById( 'primary' ), context.store );
 };
 
 export default function() {
-	page( '/woocommerce/:site?', siteSelection, navigation, render );
+	page( '/store/:site?', siteSelection, navigation, render );
 }
 

--- a/client/extensions/woocommerce/package.json
+++ b/client/extensions/woocommerce/package.json
@@ -1,12 +1,12 @@
 {
 	"name": "woocommerce",
 	"author": "Automattic",
-	"description": "WooCommerce",
+	"description": "WooCommerce Store",
 	"version": "0.0.1",
 	"env_id": [ "development", "wpcalypso" ],
 	"section": {
 		"name": "woocommerce",
-		"paths": [ "/woocommerce" ],
+		"paths": [ "/store" ],
 		"module": "woocommerce",
 		"group": "sites",
 		"secondary": true


### PR DESCRIPTION
This changes the woocommerce page from `/woocommerce` to `/store`

This should have been done in the previous PR, but something went wrong,
perhaps due to an internet service issue.