### PR TITLE
Remove a/b testing around free to paid upsell nudge.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -123,5 +123,5 @@ module.exports = {
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
 		allowAnyLocale: true
-	},
+	}
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -124,14 +124,4 @@ module.exports = {
 		allowExistingUsers: true,
 		allowAnyLocale: true
 	},
-
-	freeToPaidUpsell: {
-		datestamp: '20170222',
-		variations: {
-			sidebar: 50,
-			disabled: 50
-		},
-		defaultVariation: 'disabled',
-		allowExistingUsers: true
-	}
 };

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -21,7 +21,6 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { isFinished as isJetpackPluginsFinished } from 'state/plugins/premium/selectors';
 import TrackComponentView from 'lib/analytics/track-component-view';
-import { abtest } from 'lib/abtest';
 
 const SiteNotice = React.createClass( {
 	propTypes: {
@@ -80,7 +79,7 @@ const SiteNotice = React.createClass( {
 	},
 
 	freeToPaidPlanNotice() {
-		if ( ! this.props.eligibleForFreeToPaidUpsell || abtest( 'freeToPaidUpsell' ) !== 'sidebar' ) {
+		if ( ! this.props.eligibleForFreeToPaidUpsell ) {
 			return null;
 		}
 		const eventName = 'calypso_free_to_paid_plan_nudge_impression';


### PR DESCRIPTION
This change removes the a/b test criteria for the free to paid upsell nudge.

The following notice will appearing in the sidebar for all qualifying users:

<img alt="sidebar variant" src="https://cldup.com/DuLzQLaPsV.png">

To qualify, users must:

* have registered within with last 2 to 30 days
* be able to manage options for the current site
* have a free plan for the current site
* have no domain mapping for the current site

# Steps for testing

You will either need a user that meets the criteria (user registered between 2 and 30 days ago) or can temporarily alter the selector function in `client/state/selectors/eligible-for-free-to-paid-upsell.js` to always return true.

You should now see the upsell in the sidebar when managing your site.