### PR TITLE
Happychat: Persist transcripts between reloads

### DIFF
--- a/client/state/happychat/constants.js
+++ b/client/state/happychat/constants.js
@@ -1,0 +1,2 @@
+// Max number of messages to save between refreshes
+export const HAPPYCHAT_MAX_STORED_MESSAGES = 30;

--- a/client/state/happychat/reducer.js
+++ b/client/state/happychat/reducer.js
@@ -8,6 +8,7 @@ import {
 	find,
 	map,
 	get,
+	sortBy,
 	takeRight,
 } from 'lodash';
 import validator from 'is-my-json-valid';
@@ -57,6 +58,8 @@ const timeline_event = ( state = {}, action ) => {
 };
 
 const validateTimeline = validator( timelineSchema );
+const sortTimeline = timeline => sortBy( timeline, event => parseInt( event.timestamp, 10 ) );
+
 /**
  * Adds timeline events for happychat
  *
@@ -96,7 +99,7 @@ const timeline = ( state = [], action ) => {
 
 				return ! find( state, { id: message.id } );
 			} );
-			return state.concat( map( messages, message => {
+			return sortTimeline( state.concat( map( messages, message => {
 				return Object.assign( {
 					id: message.id,
 					source: message.source,
@@ -108,7 +111,7 @@ const timeline = ( state = [], action ) => {
 					type: get( message, 'type', 'message' ),
 					links: get( message, 'meta.links' )
 				} );
-			} ) );
+			} ) ) );
 	}
 	return state;
 };

--- a/client/state/happychat/reducer.js
+++ b/client/state/happychat/reducer.js
@@ -2,11 +2,14 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import get from 'lodash/get';
-import find from 'lodash/find';
-import concat from 'lodash/concat';
-import filter from 'lodash/filter';
-import map from 'lodash/map';
+import {
+	concat,
+	filter,
+	find,
+	map,
+	get,
+	takeRight,
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,6 +26,9 @@ import {
 	HAPPYCHAT_TRANSCRIPT_RECEIVE,
 } from 'state/action-types';
 
+import {
+	HAPPYCHAT_MAX_STORED_MESSAGES,
+} from './constants';
 /**
  * Returns a timeline event from the redux action
  *
@@ -61,7 +67,7 @@ const timeline_event = ( state = {}, action ) => {
 const timeline = ( state = [], action ) => {
 	switch ( action.type ) {
 		case SERIALIZE:
-			return [];
+			return takeRight( state, HAPPYCHAT_MAX_STORED_MESSAGES );
 		case DESERIALIZE:
 			return state;
 		case HAPPYCHAT_RECEIVE_EVENT:

--- a/client/state/happychat/reducer.js
+++ b/client/state/happychat/reducer.js
@@ -10,6 +10,7 @@ import {
 	get,
 	takeRight,
 } from 'lodash';
+import validator from 'is-my-json-valid';
 
 /**
  * Internal dependencies
@@ -25,10 +26,9 @@ import {
 	HAPPYCHAT_SET_CHAT_STATUS,
 	HAPPYCHAT_TRANSCRIPT_RECEIVE,
 } from 'state/action-types';
+import { HAPPYCHAT_MAX_STORED_MESSAGES } from './constants';
+import { timelineSchema } from './schema';
 
-import {
-	HAPPYCHAT_MAX_STORED_MESSAGES,
-} from './constants';
 /**
  * Returns a timeline event from the redux action
  *
@@ -56,6 +56,7 @@ const timeline_event = ( state = {}, action ) => {
 	return state;
 };
 
+const validateTimeline = validator( timelineSchema );
 /**
  * Adds timeline events for happychat
  *
@@ -69,7 +70,11 @@ const timeline = ( state = [], action ) => {
 		case SERIALIZE:
 			return takeRight( state, HAPPYCHAT_MAX_STORED_MESSAGES );
 		case DESERIALIZE:
-			return state;
+			const valid = validateTimeline( state );
+			if ( valid ) {
+				return state;
+			}
+			return [];
 		case HAPPYCHAT_RECEIVE_EVENT:
 			// if meta.forOperator is set, skip so won't show to user
 			if ( get( action, 'event.meta.forOperator', false ) ) {

--- a/client/state/happychat/schema.js
+++ b/client/state/happychat/schema.js
@@ -15,7 +15,7 @@ export const eventSchema = {
 		message: { type: 'string' },
 		name: { type: 'string' },
 		image: { type: 'string' },
-		timestamp: { type: 'number' },
+		timestamp: { type: [ 'number', 'string' ] },
 		user_id: { type: [ 'number', 'string' ] },
 		type: { type: 'string' },
 		links: { type: 'array' },

--- a/client/state/happychat/schema.js
+++ b/client/state/happychat/schema.js
@@ -1,0 +1,29 @@
+
+export const eventSchema = {
+	type: 'object',
+	additionalProperties: false,
+	required: [
+		'id',
+		'source',
+		'message',
+		'timestamp',
+		'user_id',
+		'type' ],
+	properties: {
+		id: { type: 'string' },
+		source: { type: 'string' },
+		message: { type: 'string' },
+		name: { type: 'string' },
+		image: { type: 'string' },
+		timestamp: { type: 'number' },
+		user_id: { type: [ 'number', 'string' ] },
+		type: { type: 'string' },
+		links: { type: 'array' },
+	}
+};
+
+export const timelineSchema = {
+	type: 'array',
+	additionalProperties: false,
+	items: eventSchema,
+};


### PR DESCRIPTION
This stores the last 30 messages between refreshes, showing the recent message history before the transcript arrives from the server. It will also persist between sessions, so the user can see the most recent messages from any previous session.

### How to test

1. Go to http://calyso.localhost:3000/me/chat
1. Send > 30 messages
1. Open the Redux devtools
1. Refresh the page
1. At first, the 30 most recent messages should be shown. Soon after, you should see the older messages appear in the timeline once they're fetched from the server. Ensure messages are in the correct order.
1. Check the Redux state history to confirm. At bootup, there should have been 30 messages in the state. Once the `HAPPYCHAT_TRANSCRIPT_RECEIVE` action fired, the `happychat.timeline` should show the full transcript of the recent session.
