### PR TITLE
Site Settings: Fix some warnings in SEO settings

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -520,7 +520,7 @@ export const SeoForm = React.createClass( {
 							<SectionHeader label={ this.translate( 'Page Title Structure' ) }>
 								{ submitButton }
 							</SectionHeader>
-							<Card compact="true" className="seo-settings__page-title__header">
+							<Card compact className="seo-settings__page-title__header">
 								<img className="seo-settings__page-title__header-image" src="/calypso/images/seo/page-title.svg" />
 								<p className="seo-settings__page-title__header-text">
 								{ this.translate(
@@ -553,24 +553,23 @@ export const SeoForm = React.createClass( {
 										'on social media sites.'
 									) }
 								</p>
-								<p>
-									<FormLabel htmlFor="advanced_seo_front_page_description">
-										{ this.translate( 'Front Page Meta Description' ) }
-									</FormLabel>
-									<CountedTextarea
-										name="advanced_seo_front_page_description"
-										type="text"
-										id="advanced_seo_front_page_description"
-										value={ frontPageMetaDescription || '' }
-										disabled={ isDisabled }
-										maxLength="300"
-										acceptableLength={ 159 }
-										onChange={ this.handleMetaChange }
-									/>
-									{ hasHtmlTagError &&
-										<FormInputValidation isError={ true } text={ this.translate( 'HTML tags are not allowed.' ) } />
-									}
-								</p>
+								<FormLabel htmlFor="advanced_seo_front_page_description">
+									{ this.translate( 'Front Page Meta Description' ) }
+								</FormLabel>
+								<CountedTextarea
+									name="advanced_seo_front_page_description"
+									type="text"
+									id="advanced_seo_front_page_description"
+									value={ frontPageMetaDescription || '' }
+									disabled={ isDisabled }
+									maxLength="300"
+									acceptableLength={ 159 }
+									onChange={ this.handleMetaChange }
+									className="seo-settings__front-page-description"
+								/>
+								{ hasHtmlTagError &&
+									<FormInputValidation isError={ true } text={ this.translate( 'HTML tags are not allowed.' ) } />
+								}
 								<FormSettingExplanation>
 									<Button
 										className="seo-settings__preview-button"

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -147,6 +147,10 @@
 		line-height: 40px;
 	}
 
+	.seo-settings__front-page-description {
+		margin-bottom: 1.5em;
+	}
+
 	fieldset.site-icon-setting {
 		@include breakpoint( ">660px" ) {
 			flex: 0 0 122px;


### PR DESCRIPTION
This PR fixes a couple of console warnings that were appearing in the SEO Settings section:

**Incorrectly wrapping a `div` with a `p`:**
![](https://cldup.com/XzfqPNGuH1.png)

**Incorrectly specifying a boolean prop:**
![](https://cldup.com/LJOKq1IQVF.png)

To test:
* Go to `/settings/seo/$site` where `$site` is one of your Jetpack sites with Professional plan and SEO module enabled.
* Verify these 2 warnings are no longer appearing (note that there will still be some other warnings that are coming from `draft.js`).
* Verify we don't introduce any change with the spacing below the page description field.