### PR TITLE
Hide SEO button for domain only sites

### DIFF
--- a/client/blocks/url-preview/index.jsx
+++ b/client/blocks/url-preview/index.jsx
@@ -13,6 +13,7 @@ import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getPreviewUrl } from 'state/ui/preview/selectors';
 import { getSiteOption, getSiteSlug } from 'state/sites/selectors';
 import addQueryArgs from 'lib/route/add-query-args';
+import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 
 const debug = debugFactory( 'calypso:design-preview' );
 
@@ -77,6 +78,7 @@ export default function urlPreview( WebPreview ) {
 					showClose={ true }
 					showPreview={ this.props.showPreview }
 					onClose={ this.onClosePreview }
+					showSEO={ ! this.props.isDomainOnlySite }
 				/>
 			);
 		}
@@ -101,6 +103,7 @@ export default function urlPreview( WebPreview ) {
 			selectedSiteUrl: 'https://' + getSiteSlug( state, selectedSiteId ),
 			selectedSiteNonce: getSiteOption( state, selectedSiteId, 'frame_nonce' ) || '',
 			previewUrl: getPreviewUrl( state ),
+			isDomainOnlySite: isDomainOnlySite( state, selectedSiteId ),
 		};
 	}
 


### PR DESCRIPTION
When a user clicks the site from the sidebar:
![screen shot 2017-03-01 at 11 34 33](https://cloud.githubusercontent.com/assets/326402/23456356/c6599aec-fe7b-11e6-92e4-ec370a7a8b33.png)

a preview screen is opened, on this preview screen, if the user previewing a domain only site, we should hide the SEO button.

@stephanethomas suggested that might be related to #11579 , however I'm not sure it is, just in case pinging @jeremeylduvall for his opinion =)
![screen shot 2017-03-01 at 11 34 17](https://cloud.githubusercontent.com/assets/326402/23456477/4cbb5bd4-fe7c-11e6-8d1b-a36392dada9f.png)


#### Testing instructions
  
1. Run `git checkout add/hide-seo-for-domain-only` and start your server, or open a [live branch](https://calypso.live/?branch=add/hide-seo-for-domain-only)
2. Open the [`Domain only` flow](http://calypso.localhost:3000/start/domain-first)
3. Complete the flow for buying a domain only site
4. Click on it in the sidebar to open a preview
5. Assert the `SEO` button isn't visible 
  
#### Reviews
  
- [x] Code
- [x] Product