### PR TITLE
Site Settings: Show SEO card for Jetpack sites

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -434,6 +434,10 @@ export const SeoForm = React.createClass( {
 			</Button>
 		);
 
+		const seoHelpLink = jetpack
+			? 'https://jetpack.com/support/seo-tools/'
+			: 'https://en.blog.wordpress.com/2013/03/22/seo-on-wordpress-com/';
+
 		/* eslint-disable react/jsx-no-target-blank */
 		return (
 			<div>
@@ -494,25 +498,21 @@ export const SeoForm = React.createClass( {
 					/>
 				}
 
-				{ ! jetpack &&
-					<div>
-						<SectionHeader label={ this.translate( 'Search Engine Optimization' ) } />
-						<Card>
-							{ this.translate(
-								'{{b}}WordPress.com has great SEO{{/b}} out of the box. All of our themes are optimized ' +
-								'for search engines, so you don\'t have to do anything extra. However, you can tweak ' +
-								'these settings if you\'d like more advanced control. Read more about what you can do ' +
-								'to {{a}}optimize your site\'s SEO{{/a}}.',
-								{
-									components: {
-										a: <a href={ 'https://en.blog.wordpress.com/2013/03/22/seo-on-wordpress-com/' } />,
-										b: <strong />
-									}
-								}
-							) }
-						</Card>
-					</div>
-				}
+				<SectionHeader label={ this.translate( 'Search Engine Optimization' ) } />
+				<Card>
+					{ this.translate(
+						'{{b}}WordPress.com has great SEO{{/b}} out of the box. All of our themes are optimized ' +
+						'for search engines, so you don\'t have to do anything extra. However, you can tweak ' +
+						'these settings if you\'d like more advanced control. Read more about what you can do ' +
+						'to {{a}}optimize your site\'s SEO{{/a}}.',
+						{
+							components: {
+								a: <a href={ seoHelpLink } />,
+								b: <strong />
+							}
+						}
+					) }
+				</Card>
 
 				<form onChange={ this.props.markChanged } className="seo-settings__seo-form">
 					{ showAdvancedSeo &&


### PR DESCRIPTION
This PR introduces the **"Search Engine Optimization"** card for Jetpack sites. Previously, it was available only for WordPress.com sites. Also, the PR suggests that for Jetpack sites, we're linking the "Optimize your site's SEO" link to https://jetpack.com/support/seo-tools/, while for WordPress.com sites it will still link to https://en.blog.wordpress.com/2013/03/22/seo-on-wordpress-com/.

![](https://cldup.com/xDlszu01r8.png)

This is consistent with the latest design of the Traffic section in p6TEKc-HQ-p2. This PR introduces the card for Jetpack sites, and in a future PR we'll move it to the Traffic section along with the rest of the cards that are planned for that.

To test:
* Checkout this branch or get it going on calypso.live
* Go to `/settings/seo/$site` for a Jetpack site with a Professional plan.
* Verify the card appears as shown on the screenshot and links to https://jetpack.com/support/seo-tools/.
* Go to `/settings/seo/$site` for a WordPress.com site with a Business plan.
* Verify the card appears properly and links to https://en.blog.wordpress.com/2013/03/22/seo-on-wordpress-com/

/cc
@oskosk @ryelle @johnHackworth @roccotripaldi for code review
@rickybanister @MichaelArestad for design review
@richardmuscat for reviewing if the text and suggested links are good

