### PR TITLE
Site Settings: Prevent page jumping in SEO settings

### DIFF
--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -140,7 +140,7 @@ export class TitleFormatEditor extends Component {
 		this.skipOverTokens = this.skipOverTokens.bind( this );
 
 		this.state = {
-			editorState: EditorState.moveFocusToEnd(
+			editorState: EditorState.moveSelectionToEnd(
 				this.editorStateFrom( props )
 			)
 		};
@@ -149,7 +149,7 @@ export class TitleFormatEditor extends Component {
 	componentWillReceiveProps( nextProps ) {
 		if ( this.props.disabled && ! nextProps.disabled ) {
 			this.setState( {
-				editorState: EditorState.moveFocusToEnd(
+				editorState: EditorState.moveSelectionToEnd(
 					this.editorStateFrom( nextProps )
 				)
 			} );


### PR DESCRIPTION
While working on #11670 I noticed that loading the SEO section unexpectedly scrolls the page to the "Page Title Structure" card:

![](https://cldup.com/PtesJu8gt0.png)

A further inspection showed that this is coming from the `TitleFormatEditor` component, which automatically focuses each editor field, so it will move the selection to the end (done by @dmsnell in #7956 to address #7885). 

However, we don't need to focus the editors - all we need is to move the selection to the end, and there is a separate method for that. So this PR essentially changes the `moveFocusToEnd` calls to `moveSelectionToEnd` calls, which will still move the selection to the end, but will not focus unnecessarily.

To test:
* Checkout this branch
* Go to `/settings/seo/$site`, where `$site` has a Business/Professional plan.
* Verify you're not automatically scrolled to the "Page Title Structure" card when loading the page.
* Go to another section from the section nav.
* Go back to the SEO tab from the section nav.
* Verify you're not automatically scrolled to the "Page Title Structure" card after switching the sections.