### PR TITLE
Update/add at guard to themes showcase

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -20,7 +20,7 @@ import { addTracking, trackClick } from './helpers';
 import DocumentHead from 'components/data/document-head';
 import { getFilter, getSortedFilterTerms, stripFilters } from './theme-filters.js';
 import buildUrl from 'lib/mixins/url-search/build-url';
-import { getSiteSlug } from 'state/sites/selectors';
+import { isJetpackSite, getSiteSlug } from 'state/sites/selectors';
 import ThemePreview from './theme-preview';
 import config from 'config';
 
@@ -119,7 +119,18 @@ const ThemeShowcase = React.createClass( {
 	},
 
 	render() {
-		const { site, options, getScreenshotOption, search, filter, translate, siteSlug, isMultisite } = this.props;
+		const {
+			site,
+			options,
+			getScreenshotOption,
+			search,
+			filter,
+			translate,
+			siteSlug,
+			isMultisite,
+			isJetpack
+		} = this.props;
+
 		const tier = config.isEnabled( 'upgrades/premium-themes' ) ? this.props.tier : 'free';
 
 		const metas = [
@@ -142,13 +153,14 @@ const ThemeShowcase = React.createClass( {
 						select={ this.onTierSelect } />
 				</StickyPanel>
 				{ config.isEnabled( 'manage/themes/upload' ) && siteSlug && ! isMultisite &&
-					<Button className="themes__upload-button" compact icon
-						onClick={ this.onUploadClick }
-						href={ `/design/upload/${ this.props.siteSlug }` }
-					>
-						<Gridicon icon="cloud-upload" />
-						{ translate( 'Upload Theme' ) }
-					</Button>
+					( isJetpack || config.isEnabled( 'automated-transfer' ) ) &&
+						<Button className="themes__upload-button" compact icon
+							onClick={ this.onUploadClick }
+							href={ `/design/upload/${ this.props.siteSlug }` }
+						>
+							<Gridicon icon="cloud-upload" />
+							{ translate( 'Upload Theme' ) }
+						</Button>
 				}
 				<ThemesSelection
 					search={ search }
@@ -193,5 +205,6 @@ const ThemeShowcase = React.createClass( {
 export default connect(
 	( state, { siteId } ) => ( {
 		siteSlug: getSiteSlug( state, siteId ),
+		isJetpack: isJetpackSite( state, siteId ),
 	} )
 )( localize( ThemeShowcase ) );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -118,6 +118,17 @@ const ThemeShowcase = React.createClass( {
 		trackClick( 'upload theme' );
 	},
 
+	showUploadButton() {
+		const { siteSlug, isMultisite, isJetpack } = this.props;
+
+		return (
+			config.isEnabled( 'manage/themes/upload' ) &&
+			siteSlug &&
+			! isMultisite &&
+			( isJetpack || config.isEnabled( 'automated-transfer' ) )
+		);
+	},
+
 	render() {
 		const {
 			site,
@@ -125,10 +136,7 @@ const ThemeShowcase = React.createClass( {
 			getScreenshotOption,
 			search,
 			filter,
-			translate,
-			siteSlug,
-			isMultisite,
-			isJetpack
+			translate
 		} = this.props;
 
 		const tier = config.isEnabled( 'upgrades/premium-themes' ) ? this.props.tier : 'free';
@@ -152,15 +160,12 @@ const ThemeShowcase = React.createClass( {
 						tier={ tier }
 						select={ this.onTierSelect } />
 				</StickyPanel>
-				{ config.isEnabled( 'manage/themes/upload' ) && siteSlug && ! isMultisite &&
-					( isJetpack || config.isEnabled( 'automated-transfer' ) ) &&
-						<Button className="themes__upload-button" compact icon
-							onClick={ this.onUploadClick }
-							href={ `/design/upload/${ this.props.siteSlug }` }
-						>
-							<Gridicon icon="cloud-upload" />
-							{ translate( 'Upload Theme' ) }
-						</Button>
+				{ this.showUploadButton() && <Button className="themes__upload-button" compact icon
+					onClick={ this.onUploadClick }
+					href={ `/design/upload/${ this.props.siteSlug }` }>
+					<Gridicon icon="cloud-upload" />
+					{ translate( 'Upload Theme' ) }
+				</Button>
 				}
 				<ThemesSelection
 					search={ search }

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import { includes, find, isEmpty } from 'lodash';
 import Gridicon from 'gridicons';
 import classNames from 'classnames';
+import config from 'config';
 
 /**
  * Internal dependencies
@@ -268,7 +269,7 @@ class Upload extends React.Component {
 		);
 	}
 
-	renderNotAvailable() {
+	renderNotAvailableForMultisite() {
 		return (
 			<EmptyContent
 				title={ this.props.translate( 'Not available for multi site' ) }
@@ -279,6 +280,19 @@ class Upload extends React.Component {
 			/>
 			);
 	}
+
+	renderNotAvailable() {
+		return (
+			<EmptyContent
+				title={ this.props.translate( 'Upload not available for this site' ) }
+				line={ this.props.translate( 'Please select a different site' ) }
+				action={ this.props.translate( 'Backt to themes' ) }
+				actionURL={ this.props.backPath }
+				illustration={ '/calypso/images/drake/drake-whoops.svg' }
+			/>
+			);
+	}
+
 	render() {
 		const {
 			translate,
@@ -296,6 +310,10 @@ class Upload extends React.Component {
 		const { showEligibility } = this.state;
 
 		if ( isMultisite ) {
+			return this.renderNotAvailableForMultisite();
+		}
+
+		if ( ! isJetpack && ! config.isEnabled( 'automated-transfer' ) ) {
 			return this.renderNotAvailable();
 		}
 


### PR DESCRIPTION
### Info
We want to be able to make Jetpack upload live and at the same time block AT from happening until AT config flag is switched on for production. Right now our internal flag `manage/themes/upload` stops us from doing that. The solution is to use `automated-transfer` flag to block upload page and hide upload button for all scenarios except Jetpack. This way when `manage/themes/upload` will be switched on in production only Jetpack will have upload enabled. 

When upload is not available `design/upload` looks like this:
![image](https://cloud.githubusercontent.com/assets/17271089/23463653/a0aceaa8-fe92-11e6-8039-155202150cd7.png)

@folletto ^ ?

### Testing
When only `manage/themes/upload`  is enabled Upload button and upload page work only for Jetpack
When also `automated-transfer` flag is enabled Upload button and page work for all sites. 
