### PR TITLE
Jetpack Settings: Make the carousel background color select input in Writing settings default to 'black' instead of an empty string

### DIFF
--- a/client/my-sites/site-settings/media-settings/index.jsx
+++ b/client/my-sites/site-settings/media-settings/index.jsx
@@ -78,7 +78,7 @@ const MediaSettings = ( {
 					<FormSelect
 						name="carousel_background_color"
 						id="carousel_background_color"
-						value={ fields.carousel_background_color || '' }
+						value={ fields.carousel_background_color || 'black' }
 						onChange={ onChangeField( 'carousel_background_color' ) }
 						disabled={ isRequestingSettings || isSavingSettings || ! carouselActive } >
 						<option value="black" key="carousel_background_color_black">

--- a/client/state/jetpack/settings/test/utils.js
+++ b/client/state/jetpack/settings/test/utils.js
@@ -59,6 +59,16 @@ describe( 'utils', () => {
 				wp_mobile_featured_images: false
 			} );
 		} );
+
+		it( 'should convert carousel_background_color to "black" if it is an empty string', () => {
+			const settings = {
+				carousel_background_color: ''
+			};
+
+			expect( normalizeSettings( settings ) ).to.eql( {
+				carousel_background_color: 'black'
+			} );
+		} );
 	} );
 
 	describe( 'sanitizeSettings()', () => {

--- a/client/state/jetpack/settings/utils.js
+++ b/client/state/jetpack/settings/utils.js
@@ -16,6 +16,9 @@ export const normalizeSettings = ( settings ) => {
 			case 'wp_mobile_featured_images':
 				memo[ key ] = settings[ key ] === 'enabled';
 				break;
+			case 'carousel_background_color':
+				memo[ key ] = settings [ key ] === '' ? 'black' : settings[ key ];
+				break;
 			default:
 				memo[ key ] = settings[ key ];
 		}


### PR DESCRIPTION
Part of #9171 

This PR fixes a bug that occurs when a Jetpack site's carousel background color settings was never configured on a Jetpack site.

#### Testing instructions.

1. Visit /settings/writing/$slug ( slug being one of your Jetpack sites on which you've never configured carousel)
2. Click any of the **SAVE SETTINGS**  buttons without altering any setting.
3. Confirm that you don't get an error notice

#### Why

The Site's REST API returns `""` as the value for this setting if you've never ever configured it, but this is not one of the allowed values for `carousel_background_color` on the writeable settings endpoint (`POST jetpack/v4/settings`)