### PR TITLE
Editor: Prevent screen jumping on IE11

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -43,6 +43,7 @@ import toolbarPinPlugin from './plugins/toolbar-pin/plugin';
 import insertMenuPlugin from './plugins/insert-menu/plugin';
 import embedReversalPlugin from './plugins/embed-reversal/plugin';
 import EditorHtmlToolbar from 'post-editor/editor-html-toolbar';
+import isIE11Detected from 'lib/detect-ie11';
 
 [
 	wpcomPlugin,
@@ -380,7 +381,10 @@ module.exports = React.createClass( {
 
 			// Collapse selection to avoid scrolling to the bottom of the textarea
 			textNode.setSelectionRange( 0, 0 );
-			textNode.focus();
+
+			if ( ! isIE11Detected ) {
+				textNode.focus();
+			}
 		} else if ( this._editor ) {
 			this._editor.focus();
 		}

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -43,7 +43,7 @@ import toolbarPinPlugin from './plugins/toolbar-pin/plugin';
 import insertMenuPlugin from './plugins/insert-menu/plugin';
 import embedReversalPlugin from './plugins/embed-reversal/plugin';
 import EditorHtmlToolbar from 'post-editor/editor-html-toolbar';
-import isIE11Detected from 'lib/detect-ie11';
+import isIE11 from 'lib/detect-ie11';
 
 [
 	wpcomPlugin,
@@ -382,7 +382,7 @@ module.exports = React.createClass( {
 			// Collapse selection to avoid scrolling to the bottom of the textarea
 			textNode.setSelectionRange( 0, 0 );
 
-			if ( ! isIE11Detected ) {
+			if ( ! isIE11 ) {
 				textNode.focus();
 			}
 		} else if ( this._editor ) {

--- a/client/lib/detect-ie11/index.js
+++ b/client/lib/detect-ie11/index.js
@@ -1,0 +1,8 @@
+export const isIE11Detected = (
+	window &&
+	window.MSInputMethodContext &&
+	document &&
+	document.documentMode
+);
+
+export default isIE11Detected;

--- a/client/lib/detect-ie11/index.js
+++ b/client/lib/detect-ie11/index.js
@@ -1,8 +1,8 @@
-export const isIE11Detected = (
+export const isIE11 = (
 	window &&
 	window.MSInputMethodContext &&
 	document &&
 	document.documentMode
 );
 
-export default isIE11Detected;
+export default isIE11;

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -17,6 +17,7 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import { serialize } from 'components/tinymce/plugins/contact-form/shortcode-utils';
+import { isIE11Detected } from 'lib/detect-ie11';
 import MediaActions from 'lib/media/actions';
 import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
 import MediaUtils from 'lib/media/utils';
@@ -39,15 +40,9 @@ import EditorMediaModal from 'post-editor/editor-media-modal';
 import MediaLibraryDropZone from 'my-sites/media-library/drop-zone';
 
 /**
- * Module constants
+ * Module constant
  */
 const TOOLBAR_HEIGHT = 39;
-const isIE11Detected = (
-	window &&
-	window.MSInputMethodContext &&
-	document &&
-	document.documentMode
-);
 
 export class EditorHtmlToolbar extends Component {
 
@@ -194,7 +189,7 @@ export class EditorHtmlToolbar extends Component {
 		this.props.content.value = fullContent;
 		onToolbarChangeContent( fullContent );
 		this.setCursorPosition( selectionEnd, fullContent.length - value.length );
-		this.props.content.focus();
+		//this.props.content.focus();
 	}
 
 	attributesToString = ( attributes = {} ) => reduce(

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -189,7 +189,6 @@ export class EditorHtmlToolbar extends Component {
 		this.props.content.value = fullContent;
 		onToolbarChangeContent( fullContent );
 		this.setCursorPosition( selectionEnd, fullContent.length - value.length );
-		//this.props.content.focus();
 	}
 
 	attributesToString = ( attributes = {} ) => reduce(

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -17,7 +17,7 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import { serialize } from 'components/tinymce/plugins/contact-form/shortcode-utils';
-import { isIE11Detected } from 'lib/detect-ie11';
+import { isIE11 } from 'lib/detect-ie11';
 import MediaActions from 'lib/media/actions';
 import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
 import MediaUtils from 'lib/media/utils';
@@ -172,7 +172,7 @@ export class EditorHtmlToolbar extends Component {
 
 	// execCommand( 'insertText' ), needed to preserve the undo stack, does not exist in IE11.
 	// Using the previous version of replacing the entire content value instead.
-	updateEditorContent = isIE11Detected
+	updateEditorContent = isIE11
 		? this.updateEditorContentIE11
 		: this.insertEditorContent;
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/10991

On IE11, `focus()` has a side effect that scrolls the screen to the top of the focus target.
Unfortunately, this means that the editor top (the first couple of lines, and in particular the cursor position) gets hidden under the top bar.

To prevent this behaviour, I've externalized into its own library the IE11 detection already used for the HTML toolbar content insertion, and checked against it to decide if trigger `focus()` or not on:
- Editor mode switching from Visual to HTML.
- HTML tag insertion in HTML mode.

Surprisingly, IE11 automatically focuses the HTML editor even without explicitly calling `focus()`.

**Note**
The issue also report the same screen jump behaviour in Edge.
I was able to reproduce a slightly different behaviour, much less annoying: `focus()` scrolls to the top of the screen when switching from Visual to HTML mode.
This might be a little jarring, but considering that at the moment it's inevitable to be at (or near) the top of the screen to switch modes, and that without `focus()` the editor wouldn't be focused, I've decided to simply disregard the issue for Edge.