### PR TITLE
Directly: Add API integration (take 2)

### DIFF
--- a/client/lib/directly/README.md
+++ b/client/lib/directly/README.md
@@ -1,0 +1,77 @@
+Directly
+========
+
+[Directly's](https://www.directly.com/) Real Time Messaging (RTM) is an on-demand
+customer support tool that we're using to provide live chat support to unpaid
+customers. This module wraps the Directly RTM library and API to provide a modular
+interface to its global functions.
+
+## Docs
+- [Directly's website](https://www.directly.com/)
+- [RTM configuration guide](https://cloudup.com/cySVQ9R_O6S)
+
+## Usage
+
+**Unless you have a very good reason, you should interact with the RTM widget through
+[its Redux interface](../../state/help/directly).**
+
+Not all of the RTM widget API has been wrapped with this library. Refer to the [API
+documentation](https://cloudup.com/cySVQ9R_O6S) to see other available methods, which
+should be wrapped here rather than called using the `window.DirectlyRTM()` function.
+
+The following functions are provided:
+
+#### `initialize()`
+
+Configures the RTM widget and loads all its third-party assets (about 200KB at the time of
+writing). If the user has recently interacted with the RTM widget, it will open up on
+initialization (an unavoidable part of the library's mount).
+
+#### `askQuestion( questionText, name, email )`
+
+Asks a question with the given params and opens the "Alerting experts" view. All parameters
+are required strings. This also initializes the RTM widget if it hasn't already been done.
+
+## Upgrading the RTM widget
+We're self-hosting the primary RTM embed script. Instead of pulling from Directly's servers at
+[https://www.directly.com/widgets/rtm/embed.js](https://www.directly.com/widgets/rtm/embed.js)
+the script is hosted at
+[http://widgets.wp.com/directly/embed.js](http://widgets.wp.com/directly/embed.js).
+So if the RTM widget ever needs to be upgraded, you'll need to paste the new upgraded
+script to our self-hosted file.
+
+## Environments & testing
+There are two Directly accounts so we can separate development / staging from production for testing.
+
+* __Sandbox (dev/staging)__  
+  Login: https://automattic-sandbox.directly.com  
+	Apply to be an Expert: https://automattic-sandbox.directly.com/apply  
+
+* __Production__  
+  Login: https://automattic.directly.com  
+	Apply to be an Expert: https://automattic.directly.com/apply
+
+To test user interactions with the RTM widget you'll want to apply for an Expert account
+(most likely on the Sandbox environment). Once you apply your account will be reviewed
+by an Expert Operations manager and approved. You most likely _don't_ want to be marked
+as an "Official Expert" because user questions are routed more slowly to these accounts.
+
+## Notes, quirks, and gotchas
+- Directly's out-of-the-box integration code assumes you'll load the RTM widget on
+every pageload, but we need finer control. So our initialization code doesn't look
+quite like the standard setup in the docs, but should be documented well enough
+to see how it all fits together.
+
+- The docs give many configuration options, however only one configuration can be
+applied per pageload. Since we may have multiple components interacting with Directly,
+we don't allow custom configuration. This avoids situations where components request
+separate configuration options (e.g. `questionCategory`) and it's not transparent
+which set of configs will be used.
+
+- If a user has recently interacted with the RTM widget, it will open immediately
+on `initialize()`. This is built-in to the system and we don't have much direct control
+over it. There may be mitigation strategies if this becomes undesirable.  
+
+- User questions are routed more slowly to "Official Experts", so if you don't see
+questions appearing immediately in your Expert account you likely need to have the
+"Official" designation dropped from your account.

--- a/client/lib/directly/index.js
+++ b/client/lib/directly/index.js
@@ -1,0 +1,124 @@
+/**
+ * @file Interface to the third-party Real Time Messaging (RTM) widget from Directly.
+ *
+ * @see ./README.md for a higher-level overview
+ * @see https://cloudup.com/cySVQ9R_O6S for Directly's configuration guide
+ */
+
+/**
+ * External dependencies
+ */
+import config from 'config';
+
+/**
+ * Internal dependencies
+ */
+import { loadScript } from 'lib/load-script';
+
+const DIRECTLY_RTM_SCRIPT_URL = 'https://widgets.wp.com/directly/embed.js';
+const DIRECTLY_ASSETS_BASE_URL = 'https://www.directly.com';
+let directlyPromise;
+
+/**
+ * Gets the default set of options to configure the Directly RTM widget.
+ * It's important to keep this config in a getter function, rather than a constant
+ * on the module scope, to prevent import-time errors errors that could crash Calypso.
+ *
+ * @see https://cloudup.com/cySVQ9R_O6S for all configuration options
+ *
+ * @returns {Object} The default configuration options
+ */
+function getDefaultOptions() {
+	const ids = config( 'directly_rtm_widget_ids' );
+	const env = config( 'directly_rtm_widget_environment' );
+
+	return {
+		id: ids[ env ],
+		displayAskQuestion: false
+	};
+}
+
+/**
+ * Set up global variables and configuration for the RTM widget
+ *
+ * @see https://cloudup.com/cySVQ9R_O6S for the standard setup instructions
+ */
+function configureGlobals() {
+	// Set up the global DirectlyRTM function, required for the RTM widget.
+	// This snippet is pasted from Directly's setup code.
+	window.DirectlyRTM = window.DirectlyRTM || function() {
+		( window.DirectlyRTM.cq = window.DirectlyRTM.cq || [] ).push( arguments );
+	};
+	// Since we can only configure once per pageload, this library only provides a
+	// single global configuration.
+	window.DirectlyRTM( 'config', getDefaultOptions() );
+}
+
+/**
+ * Inserts a dummy DOM element that the widget uses to calculate the base URL for its assets.
+ *
+ * Under standard setup, the RTM widget gathers its base URL by inspecting the src attribute of
+ * the <script> used to load the library. Since we've got a custom setup that doesn't include
+ * a <script> tag, we need to fake this by placing a DOM element with id="directlyRTMScript"
+ * and a src with the appropriate base URL.
+ *
+ * @see https://cloudup.com/cySVQ9R_O6S for the standard setup instructions we've modified
+ */
+function insertDOM() {
+	if ( null !== document.getElementById( 'directlyRTMScript' ) ) {
+		return;
+	}
+	const d = document.createElement( 'div' );
+	d.id = 'directlyRTMScript';
+	d.src = DIRECTLY_ASSETS_BASE_URL;
+	document.body.appendChild( d );
+}
+
+/**
+ * Initializes the RTM widget if it hasn't already been initialized, and then executes the
+ * command by passing the arguments to window.DirectlyRTM
+ *
+ * @returns {Promise} Promise that resolves after initialization and command execution
+ */
+function execute( ...args ) {
+	return initialize().then( () => window.DirectlyRTM( ...args ) );
+}
+
+/**
+ * Initializes the RTM widget if it hasn't already been initialized. This sets up global
+ * objects and DOM elements and requests the vendor script.
+ *
+ * @returns {Promise} Promise that resolves after initialization completes
+ */
+export function initialize() {
+	if ( directlyPromise instanceof Promise ) {
+		return directlyPromise;
+	}
+
+	directlyPromise = new Promise( ( resolve, reject ) => {
+		configureGlobals();
+		insertDOM();
+
+		loadScript( DIRECTLY_RTM_SCRIPT_URL, function( error ) {
+			if ( error ) {
+				reject( error );
+			} else {
+				resolve();
+			}
+		} );
+	} );
+
+	return directlyPromise;
+}
+
+/**
+ * Ask a question to the Directly RTM widget.
+ *
+ * @param {string} questionText - The question to submit
+ * @param {string} name - The question asker's name
+ * @param {string} email - The question asker's email address
+ * @returns {Promise} Promise that resolves after initialization completes
+ */
+export function askQuestion( questionText, name, email ) {
+	return execute( 'askQuestion', { questionText, name, email } );
+}

--- a/client/lib/directly/test/index.js
+++ b/client/lib/directly/test/index.js
@@ -1,0 +1,100 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+ /**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+// import * as loadScript from 'lib/load-script';
+
+let directly;
+let loadScript;
+
+describe( 'index', () => {
+	// Need to use `require` to correctly spy on loadScript
+	loadScript = require( 'lib/load-script' );
+	sinon.spy( loadScript, 'loadScript' );
+
+	useFakeDom();
+
+	beforeEach( () => {
+		directly = require( '..' );
+	} );
+
+	afterEach( () => {
+		loadScript.loadScript.reset();
+
+		// After each test, clean up the globals put in place by Directly
+		const script = document.querySelector( '#directlyRTMScript' );
+		if ( script ) {
+			script.remove();
+		}
+		delete window.DirectlyRTM;
+		delete require.cache[ require.resolve( '..' ) ];
+	} );
+
+	describe( '#initialize()', () => {
+		it( 'creates a window.DirectlyRTM function', () => {
+			directly.initialize();
+			expect( typeof window.DirectlyRTM ).to.equal( 'function' );
+		} );
+
+		it( 'attempts to load the remote script', () => {
+			directly.initialize();
+			expect( loadScript.loadScript ).to.have.been.calledOnce;
+		} );
+
+		it( 'does nothing after the first call', () => {
+			directly.initialize();
+			directly.initialize();
+			directly.initialize();
+
+			expect( window.DirectlyRTM.cq ).to.have.lengthOf( 1 );
+			expect( window.DirectlyRTM.cq[ 0 ][ 0 ] ).to.equal( 'config' );
+			expect( loadScript.loadScript ).to.have.been.calledOnce;
+		} );
+
+		it( 'resolves the returned promise if the library load succeeds', ( done ) => {
+			directly.initialize().then( () => done() );
+			loadScript.loadScript.firstCall.args[ 1 ]();
+		} );
+
+		it( 'rejects the returned promise if the library load fails', ( done ) => {
+			const error = { oh: 'no' };
+			directly.initialize().then(
+				() => {},
+				( e ) => {
+					expect( e ).to.equal( error );
+					done();
+				}
+			);
+			loadScript.loadScript.firstCall.args[ 1 ]( error );
+		} );
+	} );
+
+	describe( '#askQuestion()', () => {
+		const questionText = 'How can I give you all my money?';
+		const name = 'Richie Rich';
+		const email = 'richie@richenterprises.biz';
+
+		it( 'initializes Directly if it hasn\'t already been initialized', () => {
+			directly.askQuestion( questionText, name, email );
+			expect( typeof window.DirectlyRTM ).to.equal( 'function' );
+			expect( loadScript.loadScript ).to.have.been.calledOnce;
+		} );
+
+		it( 'invokes the Directly API with the given paramaters', ( done ) => {
+			window.DirectlyRTM = sinon.spy();
+			directly.askQuestion( questionText, name, email ).then( () => {
+				expect( window.DirectlyRTM ).to.have.been.calledWith( 'askQuestion', { questionText, name, email } );
+				done();
+			} );
+
+			// Fake the script loading to resolve the initialize() promise chain
+			loadScript.loadScript.firstCall.args[ 1 ]();
+		} );
+	} );
+} );

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -7,6 +7,11 @@
 	"discover_blog_id": 53424024,
 	"discover_feed_id": 41325786,
 	"daily_post_blog_id": 489937,
+	"directly_rtm_widget_environment": "production",
+	"directly_rtm_widget_ids": {
+		"sandbox": "8a2968fc57d1e2f40157f42bf2d43160",
+		"production": "8a12a3ca5a21a619015a47e492b02cfc"
+	},
 	"discover_logged_out_redirect_url": null,
 	"facebook_api_key": null,
 	"features": {},

--- a/config/client.json
+++ b/config/client.json
@@ -18,6 +18,8 @@
   "google_analytics_key",
   "google_adwords_conversion_id",
   "olark",
+  "directly_rtm_widget_environment",
+  "directly_rtm_widget_ids",
   "languages",
   "jetpack_min_version",
   "signup_url",

--- a/config/development.json
+++ b/config/development.json
@@ -2,6 +2,7 @@
 	"env": "development",
 	"env_id": "development",
 	"client_slug": "browser",
+	"directly_rtm_widget_environment": "sandbox",
 	"hostname": "calypso.localhost",
 	"port": 3000,
 	"i18n_default_locale_slug": "en",

--- a/config/stage.json
+++ b/config/stage.json
@@ -2,6 +2,7 @@
 	"env": "production",
 	"env_id": "stage",
 	"client_slug": "browser",
+	"directly_rtm_widget_environment": "sandbox",
 	"hostname": "wordpress.com",
 	"i18n_default_locale_slug": "en",
 	"wpcom_user_bootstrap": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -2,6 +2,7 @@
 	"env": "production",
 	"env_id": "wpcalypso",
 	"client_slug": "browser",
+	"directly_rtm_widget_environment": "sandbox",
 	"hostname": "wpcalypso.wordpress.com",
 	"i18n_default_locale_slug": "en",
 	"wpcom_user_bootstrap": true,


### PR DESCRIPTION
This is a re-try of #11489 (see that PR for context and code review history). That code was merged and became the source of a production bug when #11490 was also merged. The underlying problem is that config keys were added to `config/development.json` but not to other environments like `config/production.json`.

#11489 was removed in #11660, so this PR re-introduces that Directly Real Time Messaging code and fixes the underlying bug.

I already tested this fix locally. Since it wasn't discoverable in the `development` environment I used Docker to test it in the `wpcalypso` environment. The bug also is not found until `lib/directly` is integrated into app code, so I added the following to the top of [me/help/help-contact/index.jsx](https://github.com/Automattic/wp-calypso/blob/master/client/me/help/help-contact/index.jsx):

```
import { initialize } from 'lib/directly';
initialize();
```

On visiting the `/help/contact` page I saw Directly load in and I could interact with it from the browser console. If the bug hadn't been fixed, importing the library would have thrown an error.

Once the PR merges I'll also run thorough tests on `stage` before deploying to `production`.