### PR TITLE
LikeButton: fix i18n context

### DIFF
--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -59,7 +59,7 @@ const LikeButton = React.createClass( {
 			'has-label': this.props.showLabel
 		};
 		let likeLabel = this.translate( 'Like', {
-			context: 'verb',
+			context: 'verb: imperative',
 			comment: 'Label for a button to "like" a post.'
 		} );
 

--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -58,7 +58,10 @@ const LikeButton = React.createClass( {
 			'has-count': showLikeCount,
 			'has-label': this.props.showLabel
 		};
-		let likeLabel = this.translate( 'Like', { comment: 'Label for a button to "like" a post.' } );
+		let likeLabel = this.translate( 'Like', {
+			context: 'verb',
+			comment: 'Label for a button to "like" a post.'
+		} );
 
 		if ( this.props.liked ) {
 			containerClasses[ 'is-liked' ] = true;
@@ -74,7 +77,8 @@ const LikeButton = React.createClass( {
 		if ( showLikeCount ) {
 			likeLabel = this.translate( 'Like', 'Likes', {
 				count: likeCount,
-				comment: 'Displayed when a person "likes" a post.'
+				context: 'noun',
+				comment: 'Number of likes.'
 			} );
 		}
 


### PR DESCRIPTION
The pt-pt translation of the Reader has been broken for a while, and I suspect this affects other locales:

### Before
<img width="256" alt="screen shot 2017-03-01 at 21 31 56" src="https://cloud.githubusercontent.com/assets/150562/23482328/8cec6622-fec6-11e6-84d8-e20f24df3b68.png">

The above reads: "1 comment" (correct) and "1 [the verb "to like", infinitive form]" (incorrect). This is because in English both forms are labeled `Like` while they are separate terms with very different function.

### After
<img width="232" alt="screen shot 2017-03-01 at 21 32 06" src="https://cloud.githubusercontent.com/assets/150562/23482332/95a99f28-fec6-11e6-9f48-fa2dcbed5909.png">

^ The above is a reflection of the lack of translated strings in local Calypso, but the string should now become translatable.

# Testing

- In either the Reader or in `/posts`'s comment view, look for posts with exactly one like.
- In English, everything should behave and look the same as without the patch.
- With other locales, YMMV, but make sure that the translation of "1 Like" is sane.