### PR TITLE
VIP: Migrate imports and exports from CommonJS to ES2015

### DIFF
--- a/client/vip/controller.js
+++ b/client/vip/controller.js
@@ -1,15 +1,15 @@
 /**
  * External Dependencies
  */
-var React = require( 'react' ),
-	i18n = require( 'i18n-calypso' ),
-	page = require( 'page' );
+import React from 'react';
+import i18n from 'i18n-calypso';
+import page from 'page';
 
 /**
  * Internal Dependencies
  */
-var setTitle = require( 'state/document-head/actions' ).setDocumentHeadTitle,
-	sites = require( 'lib/sites-list' )();
+import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
+const sites = require( 'lib/sites-list' )();
 
 import { renderWithReduxStore } from 'lib/react-helpers';
 

--- a/client/vip/controller.js
+++ b/client/vip/controller.js
@@ -13,7 +13,7 @@ const sites = require( 'lib/sites-list' )();
 
 import { renderWithReduxStore } from 'lib/react-helpers';
 
-module.exports = {
+export default {
 
 	vip: function() {
 		page.redirect( '/vip/updates' );

--- a/client/vip/index.js
+++ b/client/vip/index.js
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-var page = require( 'page' );
+import page from 'page';
 
 /**
  * Internal dependencies
  */
-var vipController = require( './controller' ),
-	controller = require( 'my-sites/controller' ),
-	config = require( 'config' );
+import vipController from './controller';
+import controller from 'my-sites/controller';
+import config from 'config';
 
 module.exports = function() {
 	if ( config.isEnabled( 'vip/deploys' ) ) {

--- a/client/vip/index.js
+++ b/client/vip/index.js
@@ -10,7 +10,7 @@ import vipController from './controller';
 import controller from 'my-sites/controller';
 import config from 'config';
 
-module.exports = function() {
+export default function() {
 	if ( config.isEnabled( 'vip/deploys' ) ) {
 		page( '/vip/deploys/:site_id', controller.siteSelection, controller.navigation, vipController.deploys );
 

--- a/client/vip/vip-backups/index.jsx
+++ b/client/vip/vip-backups/index.jsx
@@ -1,15 +1,15 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:vip:backups' );
+import React from 'react';
+const debug = require( 'debug' )( 'calypso:vip:backups' );
 
 /**
  * Internal dependencies
  */
-var Card = require( 'components/card' ),
-	Main = require( 'components/main' ),
-	config = require( 'config' );
+import Card from 'components/card';
+import Main from 'components/main';
+import config from 'config';
 
 module.exports = React.createClass( {
 	displayName: 'vipBackups',

--- a/client/vip/vip-backups/index.jsx
+++ b/client/vip/vip-backups/index.jsx
@@ -11,7 +11,7 @@ import Card from 'components/card';
 import Main from 'components/main';
 import config from 'config';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'vipBackups',
 
 	componentWillMount: function() {

--- a/client/vip/vip-billing/index.jsx
+++ b/client/vip/vip-billing/index.jsx
@@ -11,7 +11,7 @@ import Card from 'components/card';
 import Main from 'components/main';
 import config from 'config';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'vipBilling',
 
 	componentWillMount: function() {

--- a/client/vip/vip-billing/index.jsx
+++ b/client/vip/vip-billing/index.jsx
@@ -1,15 +1,15 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:vip:billing' );
+import React from 'react';
+const debug = require( 'debug' )( 'calypso:vip:billing' );
 
 /**
  * Internal dependencies
  */
-var Card = require( 'components/card' ),
-	Main = require( 'components/main' ),
-	config = require( 'config' );
+import Card from 'components/card';
+import Main from 'components/main';
+import config from 'config';
 
 module.exports = React.createClass( {
 	displayName: 'vipBilling',

--- a/client/vip/vip-dashboard/index.jsx
+++ b/client/vip/vip-dashboard/index.jsx
@@ -11,7 +11,7 @@ import Card from 'components/card';
 import Main from 'components/main';
 import config from 'config';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'vipDashboard',
 
 	componentWillMount: function() {

--- a/client/vip/vip-dashboard/index.jsx
+++ b/client/vip/vip-dashboard/index.jsx
@@ -1,15 +1,15 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:vip:dashboard' );
+import React from 'react';
+const debug = require( 'debug' )( 'calypso:vip:dashboard' );
 
 /**
  * Internal dependencies
  */
-var Card = require( 'components/card' ),
-	Main = require( 'components/main' ),
-	config = require( 'config' );
+import Card from 'components/card';
+import Main from 'components/main';
+import config from 'config';
 
 module.exports = React.createClass( {
 	displayName: 'vipDashboard',

--- a/client/vip/vip-deploys/index.jsx
+++ b/client/vip/vip-deploys/index.jsx
@@ -11,7 +11,7 @@ import Card from 'components/card';
 import Main from 'components/main';
 import config from 'config';
 
-module.exports = React.createClass({
+export default React.createClass( {
 	displayName: 'vipDeploys',
 
 	componentWillMount: function() {

--- a/client/vip/vip-deploys/index.jsx
+++ b/client/vip/vip-deploys/index.jsx
@@ -1,15 +1,15 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:vip:deploys' );
+import React from 'react';
+const debug = require( 'debug' )( 'calypso:vip:deploys' );
 
 /**
  * Internal dependencies
  */
-var Card = require( 'components/card' ),
-	Main = require( 'components/main' ),
-	config = require( 'config' );
+import Card from 'components/card';
+import Main from 'components/main';
+import config from 'config';
 
 module.exports = React.createClass({
 	displayName: 'vipDeploys',

--- a/client/vip/vip-logs/index.jsx
+++ b/client/vip/vip-logs/index.jsx
@@ -17,7 +17,7 @@ import URLSearch from 'lib/mixins/url-search';
 import LogsTable from './logs-table';
 import config from 'config';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'vipLogs',
 	mixins: [ URLSearch ],
 

--- a/client/vip/vip-logs/index.jsx
+++ b/client/vip/vip-logs/index.jsx
@@ -1,21 +1,21 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:vip:logs' );
+import React from 'react';
+const debug = require( 'debug' )( 'calypso:vip:logs' );
 
 /**
  * Internal dependencies
  */
-var Main = require( 'components/main' ),
-	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
-	SectionNav = require( 'components/section-nav' ),
-	NavTabs = require( 'components/section-nav/tabs' ),
-	NavItem = require( 'components/section-nav/item' ),
-	Search = require( 'components/search' ),
-	URLSearch = require( 'lib/mixins/url-search' ),
-	LogsTable = require( './logs-table' ),
-	config = require( 'config' );
+import Main from 'components/main';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import SectionNav from 'components/section-nav';
+import NavTabs from 'components/section-nav/tabs';
+import NavItem from 'components/section-nav/item';
+import Search from 'components/search';
+import URLSearch from 'lib/mixins/url-search';
+import LogsTable from './logs-table';
+import config from 'config';
 
 module.exports = React.createClass( {
 	displayName: 'vipLogs',

--- a/client/vip/vip-logs/logs-table.jsx
+++ b/client/vip/vip-logs/logs-table.jsx
@@ -13,7 +13,7 @@ const debug = require( 'debug' )( 'calypso:vip:logs' );
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'viplogsTable',
 
 	componentWillMount: function() {

--- a/client/vip/vip-logs/logs-table.jsx
+++ b/client/vip/vip-logs/logs-table.jsx
@@ -1,17 +1,17 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	isEmpty = require( 'lodash/isEmpty' ),
-	classnames = require( 'classnames' ),
-	i18n = require( 'i18n-calypso' ),
-	debug = require( 'debug' )( 'calypso:vip:logs' );
+import React from 'react';
+import isEmpty from 'lodash/isEmpty';
+import classnames from 'classnames';
+import i18n from 'i18n-calypso';
+const debug = require( 'debug' )( 'calypso:vip:logs' );
 
 /**
  * Internal dependencies
  */
-var Card = require( 'components/card' ),
-	SectionHeader = require( 'components/section-header' );
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
 
 module.exports = React.createClass( {
 	displayName: 'viplogsTable',

--- a/client/vip/vip-support/index.jsx
+++ b/client/vip/vip-support/index.jsx
@@ -11,7 +11,7 @@ import Card from 'components/card';
 import Main from 'components/main';
 import config from 'config';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'vipSupport',
 
 	componentWillMount: function() {

--- a/client/vip/vip-support/index.jsx
+++ b/client/vip/vip-support/index.jsx
@@ -1,15 +1,15 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:vip:support' );
+import React from 'react';
+const debug = require( 'debug' )( 'calypso:vip:support' );
 
 /**
  * Internal dependencies
  */
-var Card = require( 'components/card' ),
-	Main = require( 'components/main' ),
-	config = require( 'config' );
+import Card from 'components/card';
+import Main from 'components/main';
+import config from 'config';
 
 module.exports = React.createClass( {
 	displayName: 'vipSupport',


### PR DESCRIPTION
Part of #11688. 

This change will allow us to leverage [Webpack 2's tree shaking optimization for ES6 modules](https://gist.github.com/sokra/27b24881210b56bbaff7#es6-specific-optimizations) in the future. Please share your suggestions and comments!