### PR TITLE
Domains: Switch to v1.2 of is_available endpoint

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
  */
 import { cartItems } from 'lib/cart-values';
 import { getFixedDomainSearch, checkDomainAvailability } from 'lib/domains';
+import { domainAvailability } from 'lib/domains/constants';
 import { getAvailabilityNotice } from 'lib/domains/registration/availability-messages';
 import DomainRegistrationSuggestion from 'components/domains/domain-registration-suggestion';
 import DomainProductPrice from 'components/domains/domain-product-price';
@@ -58,9 +59,10 @@ const MapDomainStep = React.createClass( {
 	},
 
 	render: function() {
-		const suggestion = { cost: this.props.products.domain_map.cost_display, product_slug: this.props.products.domain_map.product_slug },
-			price = this.props.products.domain_map ? this.props.products.domain_map.cost_display : null,
-			translate = this.props.translate;
+		const suggestion = this.props.products.domain_map
+				? { cost: this.props.products.domain_map.cost_display, product_slug: this.props.products.domain_map.product_slug }
+				: { cost: null, product_slug: '' },
+			{ translate } = this.props;
 
 		return (
 			<div className="map-domain-step">
@@ -80,16 +82,17 @@ const MapDomainStep = React.createClass( {
 						rule={ cartItems.getDomainPriceRule(
 							this.props.domainsWithPlansOnly,
 							this.props.selectedSite,
-							this.props.cart, suggestion
+							this.props.cart,
+							suggestion
 						) }
-						price={ price } />
+						price={ suggestion.cost } />
 
 					<div className="map-domain-step__add-domain" role="group">
 						<input
 							className="map-domain-step__external-domain"
 							type="text"
 							value={ this.state.searchQuery }
-							placeholder={ translate( 'Enter a domain', { textOnly: true } ) }
+							placeholder={ translate( 'Enter a domain' ) }
 							onBlur={ this.save }
 							onChange={ this.setSearchQuery }
 							onClick={ this.recordInputFocus }
@@ -109,7 +112,7 @@ const MapDomainStep = React.createClass( {
 	},
 
 	domainRegistrationUpsell: function() {
-		const suggestion = this.state.suggestion;
+		const { suggestion } = this.state;
 		if ( ! suggestion ) {
 			return;
 		}
@@ -158,25 +161,29 @@ const MapDomainStep = React.createClass( {
 	},
 
 	handleFormSubmit: function( event ) {
-		const domain = getFixedDomainSearch( this.state.searchQuery );
-
 		event.preventDefault();
+
+		const domain = getFixedDomainSearch( this.state.searchQuery );
 		this.recordEvent( 'formSubmit', this.state.searchQuery );
 		this.setState( { suggestion: null, notice: null } );
 
 		checkDomainAvailability( domain, ( error, result ) => {
-			if ( error ) {
-				if ( error.code === 'not_available_but_mappable' ) {
+			const status = result && result.status ? result.status : error;
+			switch ( status ) {
+				case domainAvailability.MAPPABLE:
+				case domainAvailability.UNKNOWN:
 					this.props.onMapDomain( domain );
 					return;
-				}
-				const { message, severity } = getAvailabilityNotice( domain, error );
-				this.setState( { notice: message, noticeSeverity: severity } );
-				return;
-			}
 
-			result.domain_name = domain;
-			this.setState( { suggestion: result } );
+				case domainAvailability.AVAILABLE:
+					this.setState( { suggestion: result } );
+					return;
+
+				default:
+					const { message, severity } = getAvailabilityNotice( domain, status );
+					this.setState( { notice: message, noticeSeverity: severity } );
+					return;
+			}
 		} );
 	},
 } );

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -3,14 +3,17 @@
  */
 import React from 'react';
 import async from 'async';
-import flatten from 'lodash/flatten';
-import reject from 'lodash/reject';
-import find from 'lodash/find';
-import uniqBy from 'lodash/uniqBy';
-import times from 'lodash/times';
-import compact from 'lodash/compact';
-import noop from 'lodash/noop';
-import startsWith from 'lodash/startsWith';
+import {
+	compact,
+	find,
+	flatten,
+	includes,
+	noop,
+	reject,
+	startsWith,
+	times,
+	uniqBy
+} from 'lodash';
 import page from 'page';
 import qs from 'qs';
 import { connect } from 'react-redux';
@@ -22,6 +25,7 @@ import { localize } from 'i18n-calypso';
 import wpcom from 'lib/wp';
 import Notice from 'components/notice';
 import { getFixedDomainSearch, checkDomainAvailability } from 'lib/domains';
+import { domainAvailability } from 'lib/domains/constants';
 import { getAvailabilityNotice } from 'lib/domains/registration/availability-messages';
 import SearchCard from 'components/search-card';
 import DomainRegistrationSuggestion from 'components/domains/domain-registration-suggestion';
@@ -137,7 +141,7 @@ const RegisterDomainStep = React.createClass( {
 			clickedExampleSuggestion: false,
 			lastQuery: suggestion,
 			lastDomainSearched: null,
-			lastDomainError: null,
+			lastDomainStatus: null,
 			loadingResults: Boolean( suggestion ),
 			notice: null,
 			searchResults: null
@@ -298,8 +302,7 @@ const RegisterDomainStep = React.createClass( {
 
 		this.setState( {
 			lastDomainSearched: domain,
-			searchResults: [],
-			lastDomainError: null
+			searchResults: []
 		} );
 
 		async.parallel(
@@ -314,22 +317,22 @@ const RegisterDomainStep = React.createClass( {
 					}
 
 					checkDomainAvailability( domain, ( error, result ) => {
-						const timeDiff = Date.now() - timestamp;
-						if ( error ) {
-							this.showValidationErrorMessage( domain, error );
-							this.setState( { lastDomainError: error } );
-						} else {
+						const timeDiff = Date.now() - timestamp,
+							status = result && result.status ? result.status : error,
+							{ AVAILABLE, UNKNOWN } = domainAvailability,
+							isDomainAvailable = includes( [ AVAILABLE, UNKNOWN ], status );
+
+						this.setState( { lastDomainStatus: status } );
+						if ( isDomainAvailable ) {
 							this.setState( { notice: null } );
-							if ( result ) {
-								result.domain_name = domain;
-							}
+						} else {
+							this.showValidationErrorMessage( domain, status );
 						}
 
-						const analyticsResult = ( error && error.code ) || 'available';
-						this.recordEvent( 'domainAvailabilityReceive', domain, analyticsResult, timeDiff, this.props.analyticsSection );
+						this.recordEvent( 'domainAvailabilityReceive', domain, status, timeDiff, this.props.analyticsSection );
 
 						this.props.onDomainsAvailabilityChange( true );
-						callback( null, result );
+						callback( null, isDomainAvailable ? result : null );
 					} );
 				},
 				callback => {
@@ -431,9 +434,9 @@ const RegisterDomainStep = React.createClass( {
 	},
 
 	allSearchResults: function() {
-		const lastDomainSearched = this.state.lastDomainSearched,
+		const { lastDomainSearched, lastDomainStatus } = this.state,
 			matchesSearchedDomain = ( suggestion ) => ( suggestion.domain_name === lastDomainSearched ),
-			availableDomain = this.state.lastDomainError ? undefined : find( this.state.searchResults, matchesSearchedDomain ),
+			availableDomain = lastDomainStatus === domainAvailability.AVAILABLE && find( this.state.searchResults, matchesSearchedDomain ),
 			onAddMapping = ( domain ) => this.props.onAddMapping( domain, this.state );
 
 		let suggestions = reject( this.state.searchResults, matchesSearchedDomain );
@@ -460,7 +463,7 @@ const RegisterDomainStep = React.createClass( {
 				availableDomain={ availableDomain }
 				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 				lastDomainSearched={ lastDomainSearched }
-				lastDomainError = { this.state.lastDomainError }
+				lastDomainStatus = { lastDomainStatus }
 				onAddMapping={ onAddMapping }
 				onClickResult={ this.props.onAddDomain }
 				onClickMapping={ this.goToMapDomainStep }

--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -49,8 +49,27 @@ const tlds = {
 	vip: 'dotvip_domain',
 };
 
+const domainAvailability = {
+	AVAILABLE: 'available',
+	MAPPABLE: 'mappable',
+	UNKNOWN: 'unknown',
+	NOT_REGISTRABLE: 'available_but_not_registrable',
+	MAINTENANCE: 'tld_in_maintenance',
+	PURCHASES_DISABLED: 'domain_registration_unavailable',
+	FORBIDDEN: 'forbidden_domain',
+	FORBIDDEN_SUBDOMAIN: 'forbidden_subdomain',
+	EMPTY_QUERY: 'empty_query',
+	INVALID: 'invalid_domain',
+	INVALID_TLD: 'invalid_tld',
+	RESTRICTED: 'restricted_domain',
+	BLACKLISTED: 'blacklisted_domain',
+	MAPPED: 'mapped_domain',
+	RECENTLY_UNMAPPED: 'recently_mapped',
+};
+
 export default {
 	type,
 	registrar,
-	tlds
+	tlds,
+	domainAvailability,
 };

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -12,7 +12,7 @@ import {
  * Internal dependencies
  */
 import wpcom from 'lib/wp';
-import { type as domainTypes } from './constants';
+import { type as domainTypes, domainAvailability } from './constants';
 
 const GOOGLE_APPS_INVALID_TLDS = [ 'in' ],
 	GOOGLE_APPS_BANNED_PHRASES = [ 'google' ];
@@ -35,40 +35,17 @@ function canAddGoogleApps( domainName ) {
 
 function checkDomainAvailability( domainName, onComplete ) {
 	if ( ! domainName ) {
-		onComplete( new ValidationError( 'empty_query' ) );
+		onComplete( null, { status: domainAvailability.EMPTY_QUERY } );
 		return;
 	}
 
-	wpcom.undocumented().isDomainAvailable( domainName, function( serverError, data ) {
+	wpcom.undocumented().isDomainAvailable( domainName, function( serverError, result ) {
 		if ( serverError ) {
-			onComplete( new ValidationError( serverError.error ) );
+			onComplete( serverError.error );
 			return;
 		}
 
-		const {
-			is_available: isAvailable,
-			is_mappable: isMappable,
-			is_registrable: isRegistrable,
-			unmappability_reason: unmappabilityReason
-		} = data;
-
-		let errorCode;
-		if ( ! isMappable ) {
-			errorCode = 'not_mappable';
-			if ( unmappabilityReason ) {
-				errorCode += `_${ unmappabilityReason }`;
-			}
-		} else if ( ! isAvailable && isMappable ) {
-			errorCode = 'not_available_but_mappable';
-		} else if ( isAvailable && ! isRegistrable ) {
-			errorCode = 'available_but_not_registrable';
-		}
-
-		if ( errorCode ) {
-			onComplete( new ValidationError( errorCode ) );
-		} else {
-			onComplete( null, data );
-		}
+		onComplete( null, result );
 	} );
 }
 

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -442,29 +442,17 @@ Undocumented.prototype._sendRequestWithLocale = function( originalParams, fn ) {
 };
 
 /**
- * Determine whether a domain name can be mapped
- *
- * @param {string} domain - The domain name to check.
- * @param {Function} fn The callback function
- * @api public
- */
-Undocumented.prototype.isDomainMappable = function( domain, fn ) {
-	domain = encodeURIComponent( domain );
-
-	return this.wpcom.req.get( { path: '/domains/' + domain + '/is-mappable' }, fn );
-};
-
-/**
  * Determine whether a domain name is available for registration
  *
  * @param {string} domain - The domain name to check.
  * @param {Function} fn The callback function
+ * @returns {Promise} A promise that resolves when the request completes
  * @api public
  */
 Undocumented.prototype.isDomainAvailable = function( domain, fn ) {
-	domain = encodeURIComponent( domain );
-
-	return this.wpcom.req.get( { path: '/domains/' + domain + '/is-available' }, fn );
+	return this.wpcom.req.get( `/domains/${ encodeURIComponent( domain ) }/is-available`, {
+		apiVersion: '1.2'
+	}, fn );
 };
 
 /**


### PR DESCRIPTION
Every month we run into problems caused by the constrains of the v1 of our `is_available` endpoint and the way it returns the availability/mappability/registrability of a domain. On the frontend, we tried to figure out how these flags work with each other, etc. Which led to bugs, whenever we touched one of them. These boolean flags also did not allow for a more finegrained returns status, like when we _don't_ know if a domain is available or not.
Since patching this approach obviously was not working, I've decided to step back, look at our requirements for that endpoint and try to write a v1.2 that satisfies them all.

The backend patch required for this PR is `D4542-code`.

The core of the change is that instead of individual flags, we have one `status` (string) field. If a domain is available for registration, it's `available`, if it's mappable, it's `mappable`. Other cases are treated as errors, with the exception of `unknown`, which gets a special treatment, since we have to allow mapping of such domains.

### Testing
Patch your sandbox with `D4542-code`.

Be sure to thoroughly test both the NUX and Domain Management flows for adding/registering a new domain or mapping an existing one.
Verify that `.ie` domains _and_ subdomains can be mapped (but not registered, of course).

<img width="751" alt="screen shot 2017-03-01 at 22 58 54" src="https://cloud.githubusercontent.com/assets/3392497/23483844/d37609a0-fed4-11e6-9d2b-7a8bcded75b9.png">


Fixes #11051