### PR TITLE
Plans: Fixes logic issue for when we were showing the confirmation notice

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -125,7 +125,7 @@ const CheckoutThankYou = React.createClass( {
 	},
 
 	renderConfirmationNotice: function() {
-		if ( ! this.props.user || ! this.props.user.email || this.props.email_verified ) {
+		if ( ! this.props.user || ! this.props.user.email || this.props.user.email_verified ) {
 			return null;
 		}
 


### PR DESCRIPTION
Earlier this afternoon, I noticed an issue where I was improperly seeing this notice above the plans thank you card.

![output](https://cloud.githubusercontent.com/assets/1126811/23485206/0f79258e-fea0-11e6-9e8a-2c889d4cc511.png)

The issue seems to be that the code expected `email_verified` to be passed in as a prop, but it is really part of `this.props.user`. This PR fixes that.

To test:

Currently, the PlansThankYouCard only shows for new WP.com users, so this is not the easiest thing to test. But, you could checkout #11692 and then apply this fix on top of that PR to test.