### PR TITLE
Redux state plumbing for the route /account-recovery

### DIFF
--- a/client/account-recovery/lost-password/lost-password-form/index.jsx
+++ b/client/account-recovery/lost-password/lost-password-form/index.jsx
@@ -49,34 +49,36 @@ export class LostPasswordFormComponent extends Component {
 
 		return (
 			<div>
-				<h2 className="lost-password-form__title">
-					{ translate( 'Lost your password' ) }
-				</h2>
-				<p>{ translate( 'Follow these simple steps to reset your account:' ) }</p>
-				<ol className="lost-password-form__instruction-list">
-					<li>
+				<Card compact>
+					<h2 className="lost-password-form__title">
+						{ translate( 'Lost your password?' ) }
+					</h2>
+					<p>{ translate( 'Follow these simple steps to reset your account:' ) }</p>
+					<ol className="lost-password-form__instruction-list">
+						<li>
+							{ translate(
+								'Enter your {{strong}}WordPress.com{{/strong}} username or email address',
+								{ components: { strong: <strong /> } }
+							) }
+						</li>
+						<li>
+							{ translate( 'Choose a password reset method' ) }
+						</li>
+						<li>
+							{ translate(
+								'Follow instructions and be re-united with your {{strong}}WordPress.com{{/strong}} account',
+								{ components: { strong: <strong /> } }
+							) }
+						</li>
+					</ol>
+					<p>
 						{ translate(
-							'Enter your {{strong}}WordPress.com{{/strong}} username or email address',
-							{ components: { strong: <strong /> } }
+							'Want more help? We have a full {{link}}guide to resetting your password{{/link}}.',
+							{ components: { link: <a href={ support.ACCOUNT_RECOVERY } /> } }
 						) }
-					</li>
-					<li>
-						{ translate( 'Choose a password reset method' ) }
-					</li>
-					<li>
-						{ translate(
-							'Follow instructions and be re-united with your {{strong}}WordPress.com{{/strong}} account',
-							{ components: { strong: <strong /> } }
-						) }
-					</li>
-				</ol>
-				<p>
-					{ translate(
-						'Want more help? We have a full {{link}}guide to resetting your password{{/link}}.',
-						{ components: { link: <a href={ support.ACCOUNT_RECOVERY } /> } }
-					) }
-				</p>
-				<Card>
+					</p>
+				</Card>
+				<Card compact>
 					<FormLabel>
 						{ translate( 'Username or Email' ) }
 
@@ -93,9 +95,6 @@ export class LostPasswordFormComponent extends Component {
 								'Please provide another one or try again later.' ) }
 						</p> )
 					}
-					<a href="/account-recovery/forgot-username" className="lost-password-form__forgot-username-link">
-						{ translate( 'Forgot your username?' ) }
-					</a>
 					<Button
 						className="lost-password-form__submit-button"
 						onClick={ this.submitForm }
@@ -104,6 +103,9 @@ export class LostPasswordFormComponent extends Component {
 					>
 						{ translate( 'Get New Password' ) }
 					</Button>
+					<a href="/account-recovery/forgot-username" className="lost-password-form__forgot-username-link">
+						{ translate( 'Forgot your username?' ) }
+					</a>
 				</Card>
 			</div>
 		);

--- a/client/account-recovery/lost-password/lost-password-form/index.jsx
+++ b/client/account-recovery/lost-password/lost-password-form/index.jsx
@@ -66,7 +66,7 @@ export class LostPasswordFormComponent extends Component {
 						</li>
 						<li>
 							{ translate(
-								'Follow instructions and be re-united with your {{strong}}WordPress.com{{/strong}} account',
+								'Follow instructions and be reunited with your {{strong}}WordPress.com{{/strong}} account',
 								{ components: { strong: <strong /> } }
 							) }
 						</li>

--- a/client/account-recovery/lost-password/lost-password-form/index.jsx
+++ b/client/account-recovery/lost-password/lost-password-form/index.jsx
@@ -111,8 +111,12 @@ export class LostPasswordFormComponent extends Component {
 }
 
 LostPasswordFormComponent.defaultProps = {
+	isRequesting: false,
+	userLogin: '',
+	requestError: null,
 	translate: identity,
 	fetchResetOptionsByLogin: noop,
+	updatePasswordResetUserData: noop,
 };
 
 export default connect(

--- a/client/account-recovery/lost-password/lost-password-form/index.jsx
+++ b/client/account-recovery/lost-password/lost-password-form/index.jsx
@@ -14,40 +14,36 @@ import Card from 'components/card';
 import Button from 'components/button';
 import FormLabel from 'components/forms/form-label';
 import FormInput from 'components/forms/form-text-input';
-import { fetchResetOptionsByLogin } from 'state/account-recovery/reset/actions';
-import { getAccountRecoveryResetOptions } from 'state/selectors';
+
+import {
+	fetchResetOptionsByLogin,
+	updatePasswordResetUserData,
+} from 'state/account-recovery/reset/actions';
+
+import {
+	isRequestingAccountRecoveryResetOptions,
+	getAccountRecoveryResetUserLogin,
+} from 'state/selectors';
 
 export class LostPasswordFormComponent extends Component {
-	constructor() {
-		super( ...arguments );
-
-		this.state = {
-			isSubmitting: false,
-			userLogin: '',
-		};
-	}
-
 	submitForm = () => {
-		this.setState( { isSubmitting: true } );
-
-		//This is only here to test the redux action and will be replaced in a future PR
-		this.props.fetchResetOptionsByLogin( this.state.userLogin );
+		this.props.fetchResetOptionsByLogin( this.props.userLogin );
 	};
 
 	onUserLoginChanged = ( event ) => {
-		this.setState( { userLogin: event.target.value } );
+		this.props.updatePasswordResetUserData( {
+			user: event.target.value
+		} );
 	};
 
-	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.resetOptions ) {
-			this.setState( { isSubmitting: false } );
-		}
-	}
-
 	render() {
-		const { translate } = this.props;
-		const { isSubmitting, userLogin } = this.state;
-		const isPrimaryButtonDisabled = ! userLogin || isSubmitting;
+		const {
+			translate,
+			userLogin,
+			isRequesting,
+		} = this.props;
+
+		const isPrimaryButtonDisabled = ! userLogin || isRequesting;
 
 		return (
 			<div>
@@ -86,7 +82,7 @@ export class LostPasswordFormComponent extends Component {
 							className="lost-password-form__user-login-input"
 							onChange={ this.onUserLoginChanged }
 							value={ userLogin }
-							disabled={ isSubmitting } />
+							disabled={ isRequesting } />
 					</FormLabel>
 					<a href="/account-recovery/forgot-username" className="lost-password-form__forgot-username-link">
 						{ translate( 'Forgot your username?' ) }
@@ -112,7 +108,11 @@ LostPasswordFormComponent.defaultProps = {
 
 export default connect(
 	( state ) => ( {
-		resetOptions: getAccountRecoveryResetOptions( state ),
+		isRequesting: isRequestingAccountRecoveryResetOptions( state ),
+		userLogin: getAccountRecoveryResetUserLogin( state ),
 	} ),
-	{ fetchResetOptionsByLogin }
+	{
+		fetchResetOptionsByLogin,
+		updatePasswordResetUserData,
+	}
 )( localize( LostPasswordFormComponent ) );

--- a/client/account-recovery/lost-password/lost-password-form/index.jsx
+++ b/client/account-recovery/lost-password/lost-password-form/index.jsx
@@ -22,7 +22,7 @@ import {
 
 import {
 	isRequestingAccountRecoveryResetOptions,
-	getAccountRecoveryResetUserLogin,
+	getAccountRecoveryResetUserData,
 	getAccountRecoveryResetOptionsError,
 } from 'state/selectors';
 
@@ -83,7 +83,7 @@ export class LostPasswordFormComponent extends Component {
 						<FormInput
 							className="lost-password-form__user-login-input"
 							onChange={ this.onUserLoginChanged }
-							value={ userLogin }
+							value={ userLogin ? userLogin : '' }
 							disabled={ isRequesting } />
 					</FormLabel>
 					{
@@ -112,7 +112,7 @@ export class LostPasswordFormComponent extends Component {
 
 LostPasswordFormComponent.defaultProps = {
 	isRequesting: false,
-	userLogin: '',
+	userLogin: null,
 	requestError: null,
 	translate: identity,
 	fetchResetOptionsByLogin: noop,
@@ -122,7 +122,7 @@ LostPasswordFormComponent.defaultProps = {
 export default connect(
 	( state ) => ( {
 		isRequesting: isRequestingAccountRecoveryResetOptions( state ),
-		userLogin: getAccountRecoveryResetUserLogin( state ),
+		userLogin: getAccountRecoveryResetUserData( state ).user,
 		requestError: getAccountRecoveryResetOptionsError( state ),
 	} ),
 	{

--- a/client/account-recovery/lost-password/lost-password-form/index.jsx
+++ b/client/account-recovery/lost-password/lost-password-form/index.jsx
@@ -23,6 +23,7 @@ import {
 import {
 	isRequestingAccountRecoveryResetOptions,
 	getAccountRecoveryResetUserLogin,
+	getAccountRecoveryResetOptionsError,
 } from 'state/selectors';
 
 export class LostPasswordFormComponent extends Component {
@@ -41,6 +42,7 @@ export class LostPasswordFormComponent extends Component {
 			translate,
 			userLogin,
 			isRequesting,
+			requestError,
 		} = this.props;
 
 		const isPrimaryButtonDisabled = ! userLogin || isRequesting;
@@ -84,6 +86,13 @@ export class LostPasswordFormComponent extends Component {
 							value={ userLogin }
 							disabled={ isRequesting } />
 					</FormLabel>
+					{
+						( null != requestError ) && (
+						<p className="lost-password-form__error-message">
+							{ translate( 'We encountered some problems with that login information. ' +
+								'Please provide another one or try again later.' ) }
+						</p> )
+					}
 					<a href="/account-recovery/forgot-username" className="lost-password-form__forgot-username-link">
 						{ translate( 'Forgot your username?' ) }
 					</a>
@@ -110,6 +119,7 @@ export default connect(
 	( state ) => ( {
 		isRequesting: isRequestingAccountRecoveryResetOptions( state ),
 		userLogin: getAccountRecoveryResetUserLogin( state ),
+		requestError: getAccountRecoveryResetOptionsError( state ),
 	} ),
 	{
 		fetchResetOptionsByLogin,

--- a/client/account-recovery/lost-password/lost-password-form/index.jsx
+++ b/client/account-recovery/lost-password/lost-password-form/index.jsx
@@ -85,11 +85,11 @@ export class LostPasswordFormComponent extends Component {
 						<FormInput
 							className="lost-password-form__user-login-input"
 							onChange={ this.onUserLoginChanged }
-							value={ userLogin ? userLogin : '' }
+							value={ userLogin || '' }
 							disabled={ isRequesting } />
 					</FormLabel>
 					{
-						( null != requestError ) && (
+						requestError && (
 						<p className="lost-password-form__error-message">
 							{ translate( 'We encountered some problems with that login information. ' +
 								'Please provide another one or try again later.' ) }

--- a/client/account-recovery/lost-password/lost-password-form/style.scss
+++ b/client/account-recovery/lost-password/lost-password-form/style.scss
@@ -20,3 +20,8 @@
 .lost-password-form__submit-button {
 	width: 100%;
 }
+
+.lost-password-form__error-message {
+	color: $alert-red;
+	margin-bottom: 4px;
+}

--- a/client/account-recovery/lost-password/lost-password-form/test/index.jsx
+++ b/client/account-recovery/lost-password/lost-password-form/test/index.jsx
@@ -15,7 +15,6 @@ describe( 'LostPassword', () => {
 	it( 'should render as expected', () => {
 		const wrapper = shallow( <LostPasswordFormComponent /> );
 
-		expect( wrapper ).to.have.state( 'isSubmitting' ).to.be.false;
 		expect( wrapper.find( '.lost-password-form__user-login-input' ).prop( 'disabled' ) ).to.not.be.ok;
 		expect( wrapper.find( '.lost-password-form__submit-button' ).prop( 'disabled' ) ).to.be.ok;
 	} );
@@ -24,22 +23,22 @@ describe( 'LostPassword', () => {
 		useFakeDom();
 
 		it( 'submit button shuold be disabled if user login is blank', function() {
-			const wrapper = mount( <LostPasswordFormComponent className="test__test" /> );
+			const wrapper = mount(
+				<LostPasswordFormComponent className="test__test"
+					userLogin={ '' }
+				/> );
 
 			wrapper.find( '.lost-password-form__user-login-input' ).node.value = '';
-			wrapper.find( '.lost-password-form__user-login-input' ).simulate( 'change' );
 			expect( wrapper.find( '.lost-password-form__user-login-input' ).prop( 'disabled' ) ).to.not.be.ok;
 			expect( wrapper.find( '.lost-password-form__submit-button' ).prop( 'disabled' ) ).to.be.ok;
 		} );
 
-		it( 'should be disabled when submit button clicked', function() {
-			const wrapper = mount( <LostPasswordFormComponent className="test__test" /> );
+		it( 'should be disabled when isRequesting is on', function() {
+			const wrapper = mount(
+				<LostPasswordFormComponent className="test__test"
+					isRequesting={ true }
+				/> );
 
-			wrapper.find( '.lost-password-form__user-login-input' ).node.value = 'test';
-			wrapper.find( '.lost-password-form__user-login-input' ).simulate( 'change' );
-			wrapper.find( '.lost-password-form__submit-button' ).simulate( 'click' );
-
-			expect( wrapper ).to.have.state( 'isSubmitting' ).to.be.true;
 			expect( wrapper.find( '.lost-password-form__user-login-input' ).prop( 'disabled' ) ).to.be.ok;
 			expect( wrapper.find( '.lost-password-form__submit-button' ).prop( 'disabled' ) ).to.be.ok;
 		} );

--- a/client/account-recovery/lost-password/lost-password-form/test/index.jsx
+++ b/client/account-recovery/lost-password/lost-password-form/test/index.jsx
@@ -22,22 +22,16 @@ describe( 'LostPassword', () => {
 	context( 'events', () => {
 		useFakeDom();
 
-		it( 'submit button shuold be disabled if user login is blank', function() {
-			const wrapper = mount(
-				<LostPasswordFormComponent className="test__test"
-					userLogin={ '' }
-				/> );
+		it( 'submit button should be disabled if user login is blank', function() {
+			const wrapper = mount( <LostPasswordFormComponent className="test__test" userLogin="" /> );
 
 			wrapper.find( '.lost-password-form__user-login-input' ).node.value = '';
 			expect( wrapper.find( '.lost-password-form__user-login-input' ).prop( 'disabled' ) ).to.not.be.ok;
 			expect( wrapper.find( '.lost-password-form__submit-button' ).prop( 'disabled' ) ).to.be.ok;
 		} );
 
-		it( 'should be disabled when isRequesting is on', function() {
-			const wrapper = mount(
-				<LostPasswordFormComponent className="test__test"
-					isRequesting={ true }
-				/> );
+		it( 'should be disabled when isRequesting is true', function() {
+			const wrapper = mount( <LostPasswordFormComponent className="test__test" isRequesting={ true } /> );
 
 			expect( wrapper.find( '.lost-password-form__user-login-input' ).prop( 'disabled' ) ).to.be.ok;
 			expect( wrapper.find( '.lost-password-form__submit-button' ).prop( 'disabled' ) ).to.be.ok;

--- a/client/state/selectors/get-account-recovery-reset-options-error.js
+++ b/client/state/selectors/get-account-recovery-reset-options-error.js
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * @param {Object} state Global app state
+ * @return {Object} An object encapsulates the error from requesting for the password reset options.
+ */
+export default ( state ) => {
+	return get( state, 'accountRecovery.reset.options.error', null );
+};

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -20,6 +20,7 @@ export editedPostHasContent from './edited-post-has-content';
 export eligibleForFreeToPaidUpsell from './eligible-for-free-to-paid-upsell';
 export getAccountRecoveryResetOptions from './get-account-recovery-reset-options';
 export getAccountRecoveryResetUserData from './get-account-recovery-reset-user-data';
+export getAccountRecoveryResetOptionsError from './get-account-recovery-reset-options-error';
 export getBlockedSites from './get-blocked-sites';
 export getBillingTransactions from './get-billing-transactions';
 export getFollowCount from './get-follow-count';

--- a/client/state/selectors/test/get-account-recovery-reset-options-error.js
+++ b/client/state/selectors/test/get-account-recovery-reset-options-error.js
@@ -26,4 +26,16 @@ describe( 'getAccountRecoveryResetOptionsError()', () => {
 
 		assert.deepEqual( getAccountRecoveryResetOptionsError( state ), expectedError );
 	} );
+
+	it( 'should return null if no error exists.', () => {
+		const state = {
+			accountRecovery: {
+				reset: {
+					options: {}
+				},
+			},
+		};
+
+		assert.isNull( getAccountRecoveryResetOptionsError( state ) );
+	} );
 } );

--- a/client/state/selectors/test/get-account-recovery-reset-options-error.js
+++ b/client/state/selectors/test/get-account-recovery-reset-options-error.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getAccountRecoveryResetOptionsError } from '../';
+
+describe( 'getAccountRecoveryResetOptionsError()', () => {
+	it( 'should return the error under account recovery state tree.', () => {
+		const expectedError = {
+			status: 404,
+			message: 'Something wrong!',
+		};
+		const state = {
+			accountRecovery: {
+				reset: {
+					options: {
+						error: expectedError,
+					},
+				},
+			},
+		};
+
+		assert.deepEqual( getAccountRecoveryResetOptionsError( state ), expectedError );
+	} );
+} );


### PR DESCRIPTION
## Summary
This PR is based on #11558 and #11562, which aims to wire the redux state with the page at route `/account-recovery`

## Test Plan
* Open an incognito window, and visit http://calypso.localhost:3000/account-recovery
* Open the Network inspector
* Enter a valid user name, hit submit, and you should find a `GET /account-recovery/lookup` request is sent. The response should be successful and nothing happens.
* Enter an invalid user name and hit submit. This time the response should be failure and an error message occurs:
![image](https://cloud.githubusercontent.com/assets/1842898/23489409/2f6f24a0-ff2d-11e6-827a-1b8b0d97c2cd.png)

