### PR TITLE
Account Recovery: Redux state plumbing for the route /account-recovery/forgot-username

### DIFF
--- a/client/account-recovery/forgot-username/forgot-username-form/index.jsx
+++ b/client/account-recovery/forgot-username/forgot-username-form/index.jsx
@@ -61,52 +61,50 @@ export class ForgotUsernameFormComponent extends Component {
 		const isPrimaryButtonEnabled = firstName && lastName && url && ! isRequesting;
 
 		return (
-			<div>
+			<Card>
 				<h2 className="forgot-username-form__title">
 					{ translate( 'Forgot your username?' ) }
 				</h2>
 				<p>{ translate( 'Enter your information to find your username' ) }</p>
-				<Card>
-					<FormLabel>
-						{ translate( 'First Name' ) }
-						<FormInput
-							className="forgot-username-form__first-name-input"
-							onChange={ this.firstNameUpdated }
-							value={ firstName ? firstName : '' }
-							disabled={ isRequesting } />
-					</FormLabel>
-					<FormLabel>
-						{ translate( 'Last Name' ) }
-						<FormInput
-							className="forgot-username-form__last-name-input"
-							onChange={ this.lastNameUpdated }
-							value={ lastName ? lastName : '' }
-							disabled={ isRequesting } />
-					</FormLabel>
-					<FormLabel>
-						{ translate( "Your site's URL" ) }
-						<FormInput
-							className="forgot-username-form__site-url-input"
-							onChange={ this.siteUrlUpdated }
-							value={ url ? url : '' }
-							disabled={ isRequesting } />
-					</FormLabel>
-					{
-						( null != requestError ) && (
-						<p className="forgot-username-form__error-message">
-							{ translate( 'We encountered some problems with that login information. ' +
-								'Please provide another one or try again later.' ) }
-						</p> )
-					}
-					<Button
-						className="forgot-username-form__submit-button"
-						onClick={ this.submitForm }
-						disabled={ ! isPrimaryButtonEnabled }
-						primary>
-						{ translate( 'Continue' ) }
-					</Button>
-				</Card>
-			</div>
+				<FormLabel>
+					{ translate( 'First Name' ) }
+					<FormInput
+						className="forgot-username-form__first-name-input"
+						onChange={ this.firstNameUpdated }
+						value={ firstName || '' }
+						disabled={ isRequesting } />
+				</FormLabel>
+				<FormLabel>
+					{ translate( 'Last Name' ) }
+					<FormInput
+						className="forgot-username-form__last-name-input"
+						onChange={ this.lastNameUpdated }
+						value={ lastName || '' }
+						disabled={ isRequesting } />
+				</FormLabel>
+				<FormLabel>
+					{ translate( "Your site's URL" ) }
+					<FormInput
+						className="forgot-username-form__site-url-input"
+						onChange={ this.siteUrlUpdated }
+						value={ url || '' }
+						disabled={ isRequesting } />
+				</FormLabel>
+				{
+					requestError && (
+					<p className="forgot-username-form__error-message">
+						{ translate( 'We encountered some problems with that login information. ' +
+							'Please provide another one or try again later.' ) }
+					</p> )
+				}
+				<Button
+					className="forgot-username-form__submit-button"
+					onClick={ this.submitForm }
+					disabled={ ! isPrimaryButtonEnabled }
+					primary>
+					{ translate( 'Continue' ) }
+				</Button>
+			</Card>
 		);
 	}
 }

--- a/client/account-recovery/forgot-username/forgot-username-form/index.jsx
+++ b/client/account-recovery/forgot-username/forgot-username-form/index.jsx
@@ -21,21 +21,15 @@ import {
 
 import {
 	isRequestingAccountRecoveryResetOptions,
-	getAccountRecoveryResetUserFirstName,
-	getAccountRecoveryResetUserLastName,
-	getAccountRecoveryResetUserSiteUrl,
+	getAccountRecoveryResetUserData,
 	getAccountRecoveryResetOptionsError,
 } from 'state/selectors';
 
 export class ForgotUsernameFormComponent extends Component {
 	submitForm = () => {
-		const {
-			firstName,
-			lastName,
-			url,
-		} = this.props;
+		const { userData } = this.props;
 
-		this.props.fetchResetOptionsByNameAndUrl( firstName, lastName, url );
+		this.props.fetchResetOptionsByNameAndUrl( userData.firstName, userData.lastName, userData.url );
 	};
 
 	firstNameUpdated = ( event ) => {
@@ -53,12 +47,16 @@ export class ForgotUsernameFormComponent extends Component {
 	render() {
 		const {
 			translate,
-			firstName,
-			lastName,
-			url,
+			userData,
 			isRequesting,
 			requestError,
 		} = this.props;
+
+		const {
+			firstName,
+			lastName,
+			url,
+		} = userData;
 
 		const isPrimaryButtonEnabled = firstName && lastName && url && ! isRequesting;
 
@@ -74,7 +72,7 @@ export class ForgotUsernameFormComponent extends Component {
 						<FormInput
 							className="forgot-username-form__first-name-input"
 							onChange={ this.firstNameUpdated }
-							value={ firstName }
+							value={ firstName ? firstName : '' }
 							disabled={ isRequesting } />
 					</FormLabel>
 					<FormLabel>
@@ -82,7 +80,7 @@ export class ForgotUsernameFormComponent extends Component {
 						<FormInput
 							className="forgot-username-form__last-name-input"
 							onChange={ this.lastNameUpdated }
-							value={ lastName }
+							value={ lastName ? lastName : '' }
 							disabled={ isRequesting } />
 					</FormLabel>
 					<FormLabel>
@@ -90,7 +88,7 @@ export class ForgotUsernameFormComponent extends Component {
 						<FormInput
 							className="forgot-username-form__site-url-input"
 							onChange={ this.siteUrlUpdated }
-							value={ url }
+							value={ url ? url : '' }
 							disabled={ isRequesting } />
 					</FormLabel>
 					{
@@ -115,9 +113,7 @@ export class ForgotUsernameFormComponent extends Component {
 
 ForgotUsernameFormComponent.defaultProps = {
 	isRequesting: false,
-	firstName: '',
-	lastName: '',
-	url: '',
+	userData: {},
 	requestError: null,
 	translate: identity,
 	fetchResetOptionsByNameAndUrl: noop,
@@ -127,9 +123,7 @@ ForgotUsernameFormComponent.defaultProps = {
 export default connect(
 	( state ) => ( {
 		isRequesting: isRequestingAccountRecoveryResetOptions( state ),
-		firstName: getAccountRecoveryResetUserFirstName( state ),
-		lastName: getAccountRecoveryResetUserLastName( state ),
-		url: getAccountRecoveryResetUserSiteUrl( state ),
+		userData: getAccountRecoveryResetUserData( state ),
 		requestError: getAccountRecoveryResetOptionsError( state ),
 	} ),
 	{

--- a/client/account-recovery/forgot-username/forgot-username-form/index.jsx
+++ b/client/account-recovery/forgot-username/forgot-username-form/index.jsx
@@ -35,11 +35,7 @@ export class ForgotUsernameFormComponent extends Component {
 			url,
 		} = this.props;
 
-		this.props.fetchResetOptionsByNameAndUrl( {
-			firstName,
-			lastName,
-			url,
-		} );
+		this.props.fetchResetOptionsByNameAndUrl( firstName, lastName, url );
 	};
 
 	firstNameUpdated = ( event ) => {

--- a/client/account-recovery/forgot-username/forgot-username-form/index.jsx
+++ b/client/account-recovery/forgot-username/forgot-username-form/index.jsx
@@ -116,7 +116,7 @@ export class ForgotUsernameFormComponent extends Component {
 					onClick={ this.submitForm }
 					disabled={ ! isPrimaryButtonEnabled }
 					primary>
-					{ translate( 'Continue' ) }
+					{ translate( 'Continue', { context: 'verb' } ) }
 				</Button>
 			</Card>
 		);

--- a/client/account-recovery/forgot-username/forgot-username-form/index.jsx
+++ b/client/account-recovery/forgot-username/forgot-username-form/index.jsx
@@ -116,7 +116,7 @@ export class ForgotUsernameFormComponent extends Component {
 					onClick={ this.submitForm }
 					disabled={ ! isPrimaryButtonEnabled }
 					primary>
-					{ translate( 'Continue', { context: 'verb' } ) }
+					{ translate( 'Continue' ) }
 				</Button>
 			</Card>
 		);

--- a/client/account-recovery/forgot-username/forgot-username-form/index.jsx
+++ b/client/account-recovery/forgot-username/forgot-username-form/index.jsx
@@ -44,6 +44,20 @@ export class ForgotUsernameFormComponent extends Component {
 		this.props.updatePasswordResetUserData( { url: event.target.value } );
 	};
 
+	getErrorMessage = ( requestError ) => {
+		const { translate } = this.props;
+
+		if ( ! requestError ) {
+			return '';
+		}
+
+		if ( requestError.statusCode === 404 ) {
+			return translate( "We weren't able to find a user with that login information. Please try another one." );
+		}
+
+		return translate( "We've encountered some technical issues. Please try again later." );
+	};
+
 	render() {
 		const {
 			translate,
@@ -65,7 +79,7 @@ export class ForgotUsernameFormComponent extends Component {
 				<h2 className="forgot-username-form__title">
 					{ translate( 'Forgot your username?' ) }
 				</h2>
-				<p>{ translate( 'Enter your information to find your username.' ) }</p>
+				<p>{ translate( 'Enter the following information instead.' ) }</p>
 				<FormLabel>
 					{ translate( 'First Name' ) }
 					<FormInput
@@ -93,8 +107,7 @@ export class ForgotUsernameFormComponent extends Component {
 				{
 					requestError && (
 					<p className="forgot-username-form__error-message">
-						{ translate( 'We encountered some problems with that login information. ' +
-							'Please provide another one or try again later.' ) }
+						{ this.getErrorMessage( requestError ) }
 					</p> )
 				}
 				<Button

--- a/client/account-recovery/forgot-username/forgot-username-form/index.jsx
+++ b/client/account-recovery/forgot-username/forgot-username-form/index.jsx
@@ -68,9 +68,9 @@ export class ForgotUsernameFormComponent extends Component {
 		} = this.props;
 
 		const {
-			firstName,
-			lastName,
-			url,
+			firstName = '',
+			lastName = '',
+			url = '',
 		} = userData;
 
 		const isPrimaryButtonEnabled = firstName && lastName && url && ! isRequesting;
@@ -86,7 +86,7 @@ export class ForgotUsernameFormComponent extends Component {
 					<FormInput
 						className="forgot-username-form__first-name-input"
 						onChange={ this.firstNameUpdated }
-						value={ firstName || '' }
+						value={ firstName }
 						disabled={ isRequesting } />
 				</FormLabel>
 				<FormLabel>
@@ -94,7 +94,7 @@ export class ForgotUsernameFormComponent extends Component {
 					<FormInput
 						className="forgot-username-form__last-name-input"
 						onChange={ this.lastNameUpdated }
-						value={ lastName || '' }
+						value={ lastName }
 						disabled={ isRequesting } />
 				</FormLabel>
 				<FormLabel>
@@ -102,7 +102,7 @@ export class ForgotUsernameFormComponent extends Component {
 					<FormInput
 						className="forgot-username-form__site-url-input"
 						onChange={ this.siteUrlUpdated }
-						value={ url || '' }
+						value={ url }
 						disabled={ isRequesting } />
 				</FormLabel>
 				{

--- a/client/account-recovery/forgot-username/forgot-username-form/index.jsx
+++ b/client/account-recovery/forgot-username/forgot-username-form/index.jsx
@@ -52,7 +52,8 @@ export class ForgotUsernameFormComponent extends Component {
 		}
 
 		if ( requestError.statusCode === 404 ) {
-			return translate( "We weren't able to find a user with that login information. Please try another one." );
+			return translate( "We're not able to find an account matching that information. " +
+				'Double-check your spelling, or try another name or URL.' );
 		}
 
 		return translate( "We've encountered some technical issues. Please try again later." );
@@ -79,7 +80,7 @@ export class ForgotUsernameFormComponent extends Component {
 				<h2 className="forgot-username-form__title">
 					{ translate( 'Forgot your username?' ) }
 				</h2>
-				<p>{ translate( 'Enter the following information instead.' ) }</p>
+				<p>{ translate( 'Enter your full name and URL instead.' ) }</p>
 				<FormLabel>
 					{ translate( 'First Name' ) }
 					<FormInput

--- a/client/account-recovery/forgot-username/forgot-username-form/index.jsx
+++ b/client/account-recovery/forgot-username/forgot-username-form/index.jsx
@@ -65,7 +65,7 @@ export class ForgotUsernameFormComponent extends Component {
 				<h2 className="forgot-username-form__title">
 					{ translate( 'Forgot your username?' ) }
 				</h2>
-				<p>{ translate( 'Enter your information to find your username' ) }</p>
+				<p>{ translate( 'Enter your information to find your username.' ) }</p>
 				<FormLabel>
 					{ translate( 'First Name' ) }
 					<FormInput

--- a/client/account-recovery/forgot-username/forgot-username-form/style.scss
+++ b/client/account-recovery/forgot-username/forgot-username-form/style.scss
@@ -15,3 +15,8 @@
 	margin-top: 16px;
 	width: 100%;
 }
+
+.forgot-username-form__error-message {
+	margin-bottom: 4px;
+	color: $alert-red;
+}

--- a/client/account-recovery/forgot-username/forgot-username-form/test/index.jsx
+++ b/client/account-recovery/forgot-username/forgot-username-form/test/index.jsx
@@ -51,7 +51,11 @@ describe( 'ForgotUsername', () => {
 		it( 'should be disabled if firstName is blank', function() {
 			const wrapper = mount(
 				<ForgotUsernameFormComponent className="test__test"
-					firstName={ '' }
+					userData={ {
+						firstName: '',
+						lastName: 'Bar',
+						url: 'test.example.com',
+					} }
 				/> );
 
 			// Expect the button to be disabled
@@ -61,7 +65,11 @@ describe( 'ForgotUsername', () => {
 		it( 'should be disabled if lastName is blank', function() {
 			const wrapper = mount(
 				<ForgotUsernameFormComponent className="test__test"
-					lastName={ '' }
+					userData={ {
+						firstName: 'Foo',
+						lastName: '',
+						url: 'test.example.com',
+					} }
 				/> );
 
 			// Expect the button to be disabled
@@ -71,7 +79,11 @@ describe( 'ForgotUsername', () => {
 		it( 'should be disabled if url is blank', function() {
 			const wrapper = mount(
 				<ForgotUsernameFormComponent className="test__test"
-					url={ '' }
+					userData={ {
+						firstName: 'Foo',
+						lastName: 'Bar',
+						url: '',
+					} }
 				/> );
 
 			// Expect the button to be disabled
@@ -81,9 +93,11 @@ describe( 'ForgotUsername', () => {
 		it( 'should be enabled when all fields are filled in', function() {
 			const wrapper = mount(
 				<ForgotUsernameFormComponent className="test__test"
-					firstName={ 'Foo' }
-					lastName={ 'Bar' }
-					url={ 'test.example.com' }
+					userData={ {
+						firstName: 'Foo',
+						lastName: 'Bar',
+						url: 'test.example.com',
+					} }
 				/> );
 
 			// Expect the button to be enabled

--- a/client/account-recovery/forgot-username/forgot-username-form/test/index.jsx
+++ b/client/account-recovery/forgot-username/forgot-username-form/test/index.jsx
@@ -21,8 +21,6 @@ describe( 'ForgotUsername', () => {
 	it( 'should render as expected', () => {
 		const wrapper = shallow( <ForgotUsernameFormComponent /> );
 
-		expect( wrapper ).to.have.state( 'isSubmitting' ).to.be.false;
-
 		// Expect the fields to be enabled
 		inputSelectors.forEach( selector => {
 			expect( wrapper.find( selector ).prop( 'disabled' ) ).to.not.be.ok;
@@ -34,18 +32,11 @@ describe( 'ForgotUsername', () => {
 	context( 'fields', () => {
 		useFakeDom();
 
-		it( 'should be disabled while submitting', function() {
-			const wrapper = mount( <ForgotUsernameFormComponent className="test__test" /> );
-
-			// Initialize all inputs with some dummy text
-			inputSelectors.forEach( selector => {
-				wrapper.find( selector ).node.value = 'dummy text';
-				wrapper.find( selector ).simulate( 'change' );
-			} );
-
-			wrapper.find( '.forgot-username-form__submit-button' ).simulate( 'click' );
-
-			expect( wrapper ).to.have.state( 'isSubmitting' ).to.be.true;
+		it( 'should be disabled when isRequesting is on', function() {
+			const wrapper = mount(
+				<ForgotUsernameFormComponent className="test__test"
+					isRequesting={ true }
+				/> );
 
 			// Expect the fields to be disabled
 			inputSelectors.forEach( selector => {
@@ -57,83 +48,46 @@ describe( 'ForgotUsername', () => {
 	context( 'submit button', () => {
 		useFakeDom();
 
-		it( 'should be disabled if first name field is blank', function() {
-			const wrapper = mount( <ForgotUsernameFormComponent className="test__test" /> );
-
-			// Initialize all inputs with some dummy text
-			inputSelectors.forEach( selector => {
-				wrapper.find( selector ).node.value = 'dummy text';
-				wrapper.find( selector ).simulate( 'change' );
-			} );
-
-			// Change the field to be empty
-			wrapper.find( '.forgot-username-form__first-name-input' ).node.value = '';
-			wrapper.find( '.forgot-username-form__first-name-input' ).simulate( 'change' );
+		it( 'should be disabled if firstName is blank', function() {
+			const wrapper = mount(
+				<ForgotUsernameFormComponent className="test__test"
+					firstName={ '' }
+				/> );
 
 			// Expect the button to be disabled
 			expect( wrapper.find( '.forgot-username-form__submit-button' ).prop( 'disabled' ) ).to.be.ok;
 		} );
 
-		it( 'should be disabled if last name field is blank', function() {
-			const wrapper = mount( <ForgotUsernameFormComponent className="test__test" /> );
-
-			// Initialize all inputs with some dummy text
-			inputSelectors.forEach( selector => {
-				wrapper.find( selector ).node.value = 'dummy text';
-				wrapper.find( selector ).simulate( 'change' );
-			} );
-
-			// Change the field to be empty
-			wrapper.find( '.forgot-username-form__last-name-input' ).node.value = '';
-			wrapper.find( '.forgot-username-form__last-name-input' ).simulate( 'change' );
+		it( 'should be disabled if lastName is blank', function() {
+			const wrapper = mount(
+				<ForgotUsernameFormComponent className="test__test"
+					lastName={ '' }
+				/> );
 
 			// Expect the button to be disabled
 			expect( wrapper.find( '.forgot-username-form__submit-button' ).prop( 'disabled' ) ).to.be.ok;
 		} );
 
-		it( 'should be disabled if site url field is blank', function() {
-			const wrapper = mount( <ForgotUsernameFormComponent className="test__test" /> );
-
-			// Initialize all inputs with some dummy text
-			inputSelectors.forEach( selector => {
-				wrapper.find( selector ).node.value = 'dummy text';
-				wrapper.find( selector ).simulate( 'change' );
-			} );
-
-			// Change the field to be empty
-			wrapper.find( '.forgot-username-form__site-url-input' ).node.value = '';
-			wrapper.find( '.forgot-username-form__site-url-input' ).simulate( 'change' );
+		it( 'should be disabled if url is blank', function() {
+			const wrapper = mount(
+				<ForgotUsernameFormComponent className="test__test"
+					url={ '' }
+				/> );
 
 			// Expect the button to be disabled
 			expect( wrapper.find( '.forgot-username-form__submit-button' ).prop( 'disabled' ) ).to.be.ok;
 		} );
 
 		it( 'should be enabled when all fields are filled in', function() {
-			const wrapper = mount( <ForgotUsernameFormComponent className="test__test" /> );
-
-			// Initialize all inputs with some dummy text
-			inputSelectors.forEach( selector => {
-				wrapper.find( selector ).node.value = 'dummy text';
-				wrapper.find( selector ).simulate( 'change' );
-			} );
+			const wrapper = mount(
+				<ForgotUsernameFormComponent className="test__test"
+					firstName={ 'Foo' }
+					lastName={ 'Bar' }
+					url={ 'test.example.com' }
+				/> );
 
 			// Expect the button to be enabled
 			expect( wrapper.find( '.forgot-username-form__submit-button' ).prop( 'disabled' ) ).to.not.be.ok;
-		} );
-
-		it( 'should be disabled when clicked', function() {
-			const wrapper = mount( <ForgotUsernameFormComponent className="test__test" /> );
-
-			// Initialize all inputs with some dummy text
-			inputSelectors.forEach( selector => {
-				wrapper.find( selector ).node.value = 'dummy text';
-				wrapper.find( selector ).simulate( 'change' );
-			} );
-
-			wrapper.find( '.forgot-username-form__submit-button' ).simulate( 'click' );
-
-			expect( wrapper ).to.have.state( 'isSubmitting' ).to.be.true;
-			expect( wrapper.find( '.forgot-username-form__submit-button' ).prop( 'disabled' ) ).to.be.ok;
 		} );
 	} );
 } );

--- a/client/account-recovery/forgot-username/forgot-username-form/test/index.jsx
+++ b/client/account-recovery/forgot-username/forgot-username-form/test/index.jsx
@@ -108,5 +108,24 @@ describe( 'ForgotUsername', () => {
 			// Expect the button to be enabled
 			expect( wrapper.find( '.forgot-username-form__submit-button' ).prop( 'disabled' ) ).to.not.be.ok;
 		} );
+
+		it( 'should be disabled when submitted', function() {
+			const wrapper = mount(
+				<ForgotUsernameFormComponent
+					className="test__test"
+					isRequesting={ true }
+					userData={ {
+						firstName: 'Foo',
+						lastName: 'Bar',
+						url: 'test.example.com',
+					} }
+				/> );
+
+			inputSelectors.forEach( selector => {
+				expect( wrapper.find( selector ).prop( 'disabled' ) ).to.be.ok;
+			} );
+
+			expect( wrapper.find( '.forgot-username-form__submit-button' ).prop( 'disabled' ) ).to.be.ok;
+		} );
 	} );
 } );

--- a/client/account-recovery/forgot-username/forgot-username-form/test/index.jsx
+++ b/client/account-recovery/forgot-username/forgot-username-form/test/index.jsx
@@ -34,7 +34,8 @@ describe( 'ForgotUsername', () => {
 
 		it( 'should be disabled when isRequesting is on', function() {
 			const wrapper = mount(
-				<ForgotUsernameFormComponent className="test__test"
+				<ForgotUsernameFormComponent
+					className="test__test"
 					isRequesting={ true }
 				/> );
 
@@ -50,7 +51,8 @@ describe( 'ForgotUsername', () => {
 
 		it( 'should be disabled if firstName is blank', function() {
 			const wrapper = mount(
-				<ForgotUsernameFormComponent className="test__test"
+				<ForgotUsernameFormComponent
+					className="test__test"
 					userData={ {
 						firstName: '',
 						lastName: 'Bar',
@@ -64,7 +66,8 @@ describe( 'ForgotUsername', () => {
 
 		it( 'should be disabled if lastName is blank', function() {
 			const wrapper = mount(
-				<ForgotUsernameFormComponent className="test__test"
+				<ForgotUsernameFormComponent
+					className="test__test"
 					userData={ {
 						firstName: 'Foo',
 						lastName: '',
@@ -78,7 +81,8 @@ describe( 'ForgotUsername', () => {
 
 		it( 'should be disabled if url is blank', function() {
 			const wrapper = mount(
-				<ForgotUsernameFormComponent className="test__test"
+				<ForgotUsernameFormComponent
+					className="test__test"
 					userData={ {
 						firstName: 'Foo',
 						lastName: 'Bar',
@@ -92,7 +96,8 @@ describe( 'ForgotUsername', () => {
 
 		it( 'should be enabled when all fields are filled in', function() {
 			const wrapper = mount(
-				<ForgotUsernameFormComponent className="test__test"
+				<ForgotUsernameFormComponent
+					className="test__test"
 					userData={ {
 						firstName: 'Foo',
 						lastName: 'Bar',


### PR DESCRIPTION
## Summary
This PR is based on #11558, #11562, and #11695, which aims to wire the UI components at the route `/account-recovery/forgot-username` with the underlying `accountRecovery.reset` state tree.

## Test Plan
* Open an incognito window, and visit http://calypso.localhost:3000/account-recovery/forgot-username
* Open the Network inspector
* Enter a valid first name / last name / site url combination, hit submit, and you should find a `GET /account-recovery/lookup` request is sent. The response should be successful and nothing happens.
* Enter an invalid one. This time the response should be failure and an error message occurs:
![image](https://cloud.githubusercontent.com/assets/1842898/23490961/82a947dc-ff36-11e6-80b3-bbf0969360f3.png)
