### PR TITLE
Linting: Add stage to validate config keys and values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ mixedindentlint: node_modules/mixedindentlint
 
 # Ensure that default config values exist in _shared.json
 config-defaults-lint: $(CONFIG_FILES)
-	@$(NODE) server/config/validate-config-keys.js || exit
+	@$(NODE) bin/validate-config-keys.js || exit
 
 # keep track of the current CALYPSO_ENV so that it can be used as a
 # prerequisite for other rules

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,11 @@ COMPONENTS_PROPTYPE_FILES = $(shell \
 		-or -name 'example.jsx' \
 		-and -not -path '*/test/*' \
 )
+CONFIG_FILES = $(shell \
+	find config \
+		-name '*.json' \
+)
+
 CLIENT_CONFIG_FILE := client/config/index.js
 
 # variables
@@ -115,7 +120,7 @@ node_modules: package.json | node-version
 test: build
 	@$(NPM) test
 
-lint: node_modules/eslint node_modules/eslint-plugin-react node_modules/babel-eslint mixedindentlint
+lint: node_modules/eslint node_modules/eslint-plugin-react node_modules/babel-eslint config-defaults-lint mixedindentlint
 	@$(NPM) run lint
 
 eslint: lint
@@ -126,6 +131,10 @@ eslint-branch: node_modules/eslint node_modules/eslint-plugin-react node_modules
 # Skip files that are auto-generated
 mixedindentlint: node_modules/mixedindentlint
 	@echo "$(JS_FILES)\n$(SASS_FILES)" | xargs $(NODE_BIN)/mixedindentlint --ignore-comments --exclude="client/config/index.js"
+
+# Ensure that default config values exist in _shared.json
+config-defaults-lint: $(CONFIG_FILES)
+	@if [[ ! -z "$$(FORCE_COLOR=1 node server/config/validate-config-keys.js)" ]]; then exit 1; fi;
 
 # keep track of the current CALYPSO_ENV so that it can be used as a
 # prerequisite for other rules

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ mixedindentlint: node_modules/mixedindentlint
 
 # Ensure that default config values exist in _shared.json
 config-defaults-lint: $(CONFIG_FILES)
-	@if [[ ! -z "$$(FORCE_COLOR=1 node server/config/validate-config-keys.js)" ]]; then exit 1; fi;
+	@$(NODE) server/config/validate-config-keys.js || exit
 
 # keep track of the current CALYPSO_ENV so that it can be used as a
 # prerequisite for other rules
@@ -249,3 +249,4 @@ FORCE:
 .PHONY: build build-development build-server build-dll build-desktop build-horizon build-stage build-production build-wpcalypso
 .PHONY: run install test clean distclean translate route node-version
 .PHONY: githooks githooks-commit githooks-push analyze-bundles urn
+.PHONY: config-defaults-lint

--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -4,6 +4,9 @@ PATH="$PATH:/usr/local/bin"
 
 printf "\nBy contributing to this project, you license the materials you contribute under the GNU General Public License v2 (or later). All materials must have GPLv2 compatible licenses — see .github/CONTRIBUTING.md for details.\n\n"
 
+# Make quick pass over config files on every change
+make config-defaults-lint || exit 1
+
 files=$(git diff --cached --name-only --diff-filter=ACM | grep ".jsx*$")
 if [ "$files" = "" ]; then
     exit 0

--- a/bin/validate-config-keys.js
+++ b/bin/validate-config-keys.js
@@ -1,0 +1,1 @@
+../server/config/validate-config-keys.js

--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,7 @@ test:
           fi
       : parallel: true
   override:
+    - make config-defaults-lint
     - bin/run-lint :
         parallel: true
         files:

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -1,8 +1,27 @@
 {
+	"env": "shared",
+	"env_id": "shared",
+	"boom_analytics_enabled": null,
+	"boom_analytics_key": null,
+	"client_slug": null,
 	"discover_blog_id": 53424024,
 	"discover_feed_id": 41325786,
 	"daily_post_blog_id": 489937,
+	"discover_logged_out_redirect_url": null,
+	"facebook_api_key": null,
+	"features": {},
+	"google_analytics_enabled": null,
+	"google_analytics_key": null,
+	"google_adwords_conversion_id": null,
+	"hostname": null,
+	"i18n_default_locale_slug": "en",
+	"jetpack_min_version": null,
+	"login_url": null,
+	"logout_url": null,
+	"mc_analytics_enabled": null,
 	"oauth_client_id": false,
+	"olark": {},
+	"port": null,
 	"happychat_url": "https://happychat.io/customer",
 	"languages": [
 		{ "value": 2, "langSlug": "af", "name": "af - Afrikaans", "wpLocale": "af" },
@@ -144,5 +163,11 @@
 		{ "value": 452, "langSlug": "zh-tw", "name": "zh-tw - 繁體中文", "wpLocale": "zh_TW", "popular": 14 }
 	],
 	"project": "wordpress-com",
-	"twemoji_cdn_url": "https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/"
+	"rtl": null,
+	"siftscience_key": null,
+	"signup_url": null,
+	"twemoji_cdn_url": "https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/",
+	"wpcom_signup_id": null,
+	"wpcom_signup_key": null,
+	"wpcom_user_bootstrap": false
 }

--- a/config/development.json
+++ b/config/development.json
@@ -5,6 +5,7 @@
 	"hostname": "calypso.localhost",
 	"port": 3000,
 	"i18n_default_locale_slug": "en",
+  "foo": "biz baz boo",
 	"wpcom_user_bootstrap": false,
 	"rtl": false,
 	"jetpack_min_version": "3.3",

--- a/config/development.json
+++ b/config/development.json
@@ -5,7 +5,6 @@
 	"hostname": "calypso.localhost",
 	"port": 3000,
 	"i18n_default_locale_slug": "en",
-  "foo": "biz baz boo",
 	"wpcom_user_bootstrap": false,
 	"rtl": false,
 	"jetpack_min_version": "3.3",

--- a/server/config/validate-config-keys.js
+++ b/server/config/validate-config-keys.js
@@ -9,14 +9,6 @@ const path = require( 'path' );
 const configRoot = path.resolve( __dirname, '../../', 'config' );
 
 /**
- * @type {RegExp} matches possible config files
- *
- *  - doesn't start with an underscore
- *  - ends in `.json`
- */
-const environmentConfigPattern = /^(?!_)[^.]+\.json$/;
-
-/**
  * Reads a config file given its basename
  *
  * @param {String} filename basename of config file to read, e.g. 'development.json'
@@ -37,9 +29,10 @@ const parseConfig = filename => JSON.parse( readConfigFile( filename ) );
 /** @type {Array} list of [ filename, config data keys ] configuration pairs */
 const environmentKeys = fs
 	.readdirSync( configRoot, { encoding: 'utf8' } )
-	.filter( filename => environmentConfigPattern.test( path.basename( filename ) ) )
-	.filter( filename => ! ( /secrets/g ).test( filename ) )
-	.filter( filename => ! ( /client/g ).test( filename ) )
+	.filter( filename => /\.json$/.test( path.basename( filename ) ) ) // only the JSON config files
+	.filter( filename => '_shared.json' !== filename ) // base config for all environments
+	.filter( filename => 'client.json' !== filename ) // whitelist of keys allowed in client
+	.filter( filename => ! ( /secrets/g ).test( filename ) ) // secret tokens not part of this system
 	.map( filename => [ filename, Object.keys( parseConfig( filename ) ) ] );
 
 /** @type {Object} config data in the shared config file (defaults) */

--- a/server/config/validate-config-keys.js
+++ b/server/config/validate-config-keys.js
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+const chalk = require( 'chalk' );
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+/** @type {String} path to configuration file directory */
+const configRoot = path.resolve( __dirname, '../../', 'config' );
+
+/**
+ * @type {RegExp} matches possible config files
+ *
+ *  - doesn't start with an underscore
+ *  - ends in `.json`
+ */
+const environmentConfigPattern = /^(?!_)[^.]+\.json$/;
+
+/**
+ * Attempts to parse JSON data
+ *
+ * If data doesn't parse it will return
+ * `null` instead of throwing an error
+ *
+ * @param {*} data
+ * @returns {*}
+ */
+const parseJSON = data => {
+	try {
+		return JSON.parse( data );
+	} catch (e) {
+		return null;
+	}
+};
+
+/** @type {String[]} list of configuration files */
+const environmentConfigFiles = fs
+	.readdirSync( configRoot, { encoding: 'utf8' } )
+	.filter( filename => environmentConfigPattern.test( path.basename( filename ) ) )
+	.filter( filename => ! ( /secrets/g ).test( filename ) )
+	.filter( filename => ! ( /client/g ).test( filename ) );
+
+/** @type {Array} list of [ filename, data ] pairs */
+const environmentConfigs = environmentConfigFiles
+	.map( filename => [ filename, fs.readFileSync( path.join( configRoot, filename ), { encoding: 'utf8' } ) ] )
+	.map( ( [ filename, data ] ) => [ filename, parseJSON( data ) ] );
+
+/** @type {Object} config data in the shared config file (defaults) */
+const sharedConfig = parseJSON( fs.readFileSync( path.join( configRoot, '_shared.json' ), { encoding: 'utf8' } ) );
+
+/** @type {Array} list of [ filename, list of keys ] pairs */
+const environmentKeys = environmentConfigs
+	.map( ( [ filename, data ] ) => [ filename, Object.keys( data ) ] );
+
+/**
+ * Iterate over all of the keys in each configuration file
+ * and check if that key is also present in the shared file.
+ * If a key is missing from the shared file (meaning that
+ * there is no default value) then we want to flag it as
+ * invalid. Such a missing value could and likely would
+ * cause runtime errors in Calypso
+ */
+environmentKeys.forEach( ( [ filename, keys ] ) => {
+	keys.forEach( key => {
+		if ( ! sharedConfig.hasOwnProperty( key ) ) {
+			console.error(
+				`${ chalk.red( 'Configuration Error' ) }\n` +
+				`Key ${ chalk.blue( key ) } defined in ${ chalk.blue( filename ) } ` +
+				`but not in ${ chalk.blue( '_shared.json' ) }\n` +
+				`Please add a default value in ${ chalk.blue( '_shared.json' ) } ` +
+				`before adding overrides in the environment-specific config files.`
+			);
+
+			process.exit( 1 );
+		}
+	} );
+} );


### PR DESCRIPTION
If a configuration value is defined in one of the environment-specific
configuration files but no corresponding value or default is added to
the shared config in `config/_shared.json` then it is very likely that
something in Calypso will break when attempting to access that key in a
different environment than was used to develop and test in.

This commit introduces a new stage in the linting process which verifies
that all of the keys present in the environment-specific configuration
files also exist in the shared file.

This constraint is new. It makes no assertion on _what kind of value_
needs to be present in the shared config - only _that_ the value has to
exist.

Likely we will want to develop a policy on what should be available as
default values (for example, an empty string, a `NaN` or `0`, `null`,
etc...) but this is not addressed in this change.

**Testing**

 - Add a key to one of the configuration files such as `development.json` but not to `_shared.json`
 - Run `make lint`

The linting stage should fail.