### PR TITLE
Site Settings: Use compact cards for Subscriptions

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -326,7 +326,6 @@
 @import 'my-sites/site-settings/publishing-tools/style';
 @import 'my-sites/site-settings/related-posts/style';
 @import 'my-sites/site-settings/site-icon-setting/style';
-@import 'my-sites/site-settings/subscriptions/style';
 @import 'my-sites/site-settings/taxonomies/style';
 @import 'my-sites/importer/style';
 @import 'blocks/site/style';

--- a/client/my-sites/site-settings/subscriptions/index.jsx
+++ b/client/my-sites/site-settings/subscriptions/index.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
+import CompactCard from 'components/card/compact';
 import JetpackModuleToggle from '../jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormToggle from 'components/forms/form-toggle';
@@ -28,50 +28,50 @@ const Subscriptions = ( {
 	translate
 } ) => {
 	return (
-		<Card className="subscriptions site-settings__discussion-settings">
-			<FormFieldset>
-				<div className="subscriptions__info-link-container site-settings__info-link-container">
-					<InfoPopover position={ 'left' }>
-						<ExternalLink href={ 'https://jetpack.com/support/subscriptions' } target="_blank">
-							{ translate( 'Learn more about Subscriptions' ) }
-						</ExternalLink>
-					</InfoPopover>
-				</div>
+		<div>
+			<CompactCard className="subscriptions__card site-settings__discussion-settings">
+				<FormFieldset>
+					<div className="subscriptions__info-link-container site-settings__info-link-container">
+						<InfoPopover position={ 'left' }>
+							<ExternalLink href={ 'https://jetpack.com/support/subscriptions' } target="_blank">
+								{ translate( 'Learn more about Subscriptions' ) }
+							</ExternalLink>
+						</InfoPopover>
+					</div>
 
-				<JetpackModuleToggle
-					siteId={ selectedSiteId }
-					moduleSlug="subscriptions"
-					label={ translate( 'Allow users to subscribe to your posts and comments and receive notifications via email.' ) }
-					disabled={ isRequestingSettings || isSavingSettings }
-					/>
+					<JetpackModuleToggle
+						siteId={ selectedSiteId }
+						moduleSlug="subscriptions"
+						label={ translate( 'Allow users to subscribe to your posts and comments and receive notifications via email.' ) }
+						disabled={ isRequestingSettings || isSavingSettings }
+						/>
 
-				<div className="subscriptions__module-settings site-settings__child-settings">
-					<FormToggle
-						className="subscriptions__module-settings-toggle is-compact"
-						checked={ !! fields.stb_enabled }
-						disabled={ isRequestingSettings || isSavingSettings || ! subscriptionsModuleActive }
-						onChange={ handleToggle( 'stb_enabled' ) }
-					>
-						{ translate( 'Show a "follow blog" option in the comment form' ) }
-					</FormToggle>
+					<div className="subscriptions__module-settings site-settings__child-settings">
+						<FormToggle
+							className="subscriptions__module-settings-toggle is-compact"
+							checked={ !! fields.stb_enabled }
+							disabled={ isRequestingSettings || isSavingSettings || ! subscriptionsModuleActive }
+							onChange={ handleToggle( 'stb_enabled' ) }
+						>
+							{ translate( 'Show a "follow blog" option in the comment form' ) }
+						</FormToggle>
 
-					<FormToggle
-						className="subscriptions__module-settings-toggle is-compact"
-						checked={ !! fields.stc_enabled }
-						disabled={ isRequestingSettings || isSavingSettings || ! subscriptionsModuleActive }
-						onChange={ handleToggle( 'stc_enabled' ) }
-					>
-						{ translate( 'Show a "follow comments" option in the comment form.' ) }
-					</FormToggle>
+						<FormToggle
+							className="subscriptions__module-settings-toggle is-compact"
+							checked={ !! fields.stc_enabled }
+							disabled={ isRequestingSettings || isSavingSettings || ! subscriptionsModuleActive }
+							onChange={ handleToggle( 'stc_enabled' ) }
+						>
+							{ translate( 'Show a "follow comments" option in the comment form.' ) }
+						</FormToggle>
+					</div>
+				</FormFieldset>
+			</CompactCard>
 
-					<p className="subscriptions__email-followers">
-						<a href={ '/people/email-followers/' + selectedSiteSlug }>
-							{ translate( 'View your Email Followers' ) }
-						</a>
-					</p>
-				</div>
-			</FormFieldset>
-		</Card>
+			<CompactCard href={ '/people/email-followers/' + selectedSiteSlug }>
+				{ translate( 'View your Email Followers' ) }
+			</CompactCard>
+		</div>
 	);
 };
 

--- a/client/my-sites/site-settings/subscriptions/style.scss
+++ b/client/my-sites/site-settings/subscriptions/style.scss
@@ -1,3 +1,0 @@
-.subscriptions__email-followers {
-	margin-top: 16px;
-}


### PR DESCRIPTION
As suggested by @MichaelArestad in https://github.com/Automattic/wp-calypso/pull/11631#issuecomment-283414286 (originally by @rickybanister), the Subscriptions card needs some love in terms of the awkward spacing below the link at the bottom. 

This PR changes the Subscriptions card to use `CompactCard` instead of `Card`, and moves the link within a separate `CompactCard`. It also fixes a ESLint warning with the class name that is applied to the first `Card`.

**Before:**
![](https://cldup.com/6v2fI-5Tdw.png)

**After:**
![](https://cldup.com/itv9lcn1yH.png)

To test:
* Checkout this branch or get it going on calypso.live
* Go to `/settings/discussion/$site` where `$site` is one of your Jetpack sites.
* Verify the Subscriptions card looks as shown on the "After" preview.