### PR TITLE
Jetpack: Remove monthly plans test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -74,16 +74,6 @@ module.exports = {
 		allowExistingUsers: false
 	},
 
-	jetpackConnectPlansFirst: {
-		datestamp: '20161024',
-		variations: {
-			showPlansBeforeAuth: 50,
-			showPlansAfterAuth: 50
-		},
-		defaultVariation: 'showPlansAfterAuth',
-		allowExistingUsers: true
-	},
-
 	siteTitleTour: {
 		datestamp: '20161207',
 		variations: {
@@ -113,4 +103,15 @@ module.exports = {
 		defaultVariation: 'withoutMarketingCopy',
 		allowExistingUsers: true
 	},
+
+	jetpackPlansNoMonthly: {
+		datestamp: '20170302',
+		variations: {
+			showMonthy: 50,
+			hideMonthly: 50
+		},
+		defaultVariation: 'showMonthy',
+		allowExistingUsers: true
+	},
+
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -107,10 +107,10 @@ module.exports = {
 	jetpackPlansNoMonthly: {
 		datestamp: '20170302',
 		variations: {
-			showMonthy: 50,
+			showMonthly: 50,
 			hideMonthly: 50
 		},
-		defaultVariation: 'showMonthy',
+		defaultVariation: 'showMonthly',
 		allowExistingUsers: true
 	},
 

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -26,6 +26,7 @@ import {
 	PLAN_PERSONAL
 } from 'lib/plans/constants';
 import SitesList from 'lib/sites-list';
+import { abtest } from 'lib/abtest';
 
 /**
  * Module vars
@@ -134,7 +135,7 @@ export function filterPlansBySiteAndProps( plans, site, hideFreePlan, intervalTy
 
 	return plans.filter( function( plan ) {
 		if ( site && site.jetpack ) {
-			if ( 'monthly' === intervalType ) {
+			if ( 'monthly' === intervalType && abtest( 'jetpackPlansNoMonthly' ) !== 'hideMonthly' ) {
 				if ( showJetpackFreePlan ) {
 					return isJetpackPlan( plan ) && isMonthly( plan );
 				}

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -73,12 +73,14 @@ class PlanFeaturesHeader extends Component {
 
 	getBillingTimeframe() {
 		const {
+			hideMonthly,
 			billingTimeFrame,
 			discountPrice,
 			isPlaceholder,
 			site,
 			translate,
-			isSiteAT
+			isSiteAT,
+			currentSitePlan
 		} = this.props;
 
 		const isDiscounted = !! discountPrice;
@@ -90,7 +92,8 @@ class PlanFeaturesHeader extends Component {
 		if (
 			isSiteAT ||
 			! site.jetpack ||
-			this.props.planType === PLAN_JETPACK_FREE
+			this.props.planType === PLAN_JETPACK_FREE ||
+			( hideMonthly && ( ! currentSitePlan || currentSitePlan.productSlug === PLAN_JETPACK_FREE ) )
 		) {
 			return (
 				<p className={ timeframeClasses }>
@@ -165,6 +168,7 @@ class PlanFeaturesHeader extends Component {
 
 	getPlanFeaturesPrices() {
 		const {
+			hideMonthly,
 			currencyCode,
 			discountPrice,
 			rawPrice,
@@ -185,7 +189,7 @@ class PlanFeaturesHeader extends Component {
 			);
 		}
 
-		if ( discountPrice ) {
+		if ( discountPrice && ! hideMonthly ) {
 			return (
 				<span className="plan-features__header-price-group">
 					<PlanPrice currencyCode={ currencyCode } rawPrice={ rawPrice } original />
@@ -194,7 +198,7 @@ class PlanFeaturesHeader extends Component {
 			);
 		}
 
-		if ( relatedMonthlyPlan ) {
+		if ( relatedMonthlyPlan && ! hideMonthly ) {
 			const originalPrice = relatedMonthlyPlan.raw_price * 12;
 			return (
 				<span className="plan-features__header-price-group">
@@ -260,7 +264,6 @@ export default connect( ( state, ownProps ) => {
 	const { isInSignup } = ownProps;
 	const selectedSiteId = isInSignup ? null : getSelectedSiteId( state );
 	const currentSitePlan = getCurrentPlan( state, selectedSiteId );
-
 	return Object.assign( {},
 		ownProps,
 		{

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -188,8 +188,7 @@ class PlanFeaturesHeader extends Component {
 				<div className={ classes } ></div>
 			);
 		}
-
-		if ( discountPrice && ! hideMonthly ) {
+		if ( discountPrice ) {
 			return (
 				<span className="plan-features__header-price-group">
 					<PlanPrice currencyCode={ currencyCode } rawPrice={ rawPrice } original />

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -475,7 +475,7 @@ export default connect(
 				const newPlan = isNew( plan ) && ! isPaid;
 				const currentPlan = sitePlan && sitePlan.product_slug;
 				const showMonthlyPrice = abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly' && ! isPaid
-					? true
+					? showMonthly
 					: ! relatedMonthlyPlan && showMonthly;
 
 				if ( placeholder || ! planObject || isLoadingSitePlans ) {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -129,18 +129,20 @@ class PlanFeatures extends Component {
 				currencyCode,
 				current,
 				features,
-				discountPrice,
 				onUpgradeClick,
 				planConstantObj,
 				planName,
 				popular,
 				newPlan,
-				rawPrice,
 				relatedMonthlyPlan,
 				primaryUpgrade,
 				isPlaceholder
 			} = properties;
-
+			let { rawPrice, discountPrice } = properties;
+			if ( abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly' && relatedMonthlyPlan && relatedMonthlyPlan.raw_price ) {
+				discountPrice = rawPrice;
+				rawPrice = relatedMonthlyPlan.raw_price;
+			}
 			return (
 				<div className="plan-features__mobile-plan" key={ planName }>
 					<PlanFeaturesHeader
@@ -199,16 +201,19 @@ class PlanFeatures extends Component {
 			const {
 				currencyCode,
 				current,
-				discountPrice,
 				planConstantObj,
 				planName,
 				popular,
 				newPlan,
-				rawPrice,
 				relatedMonthlyPlan,
 				isPlaceholder
 			} = properties;
+			let { rawPrice, discountPrice } = properties;
 			const classes = classNames( 'plan-features__table-item', 'has-border-top' );
+			if ( abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly' && relatedMonthlyPlan && relatedMonthlyPlan.raw_price ) {
+				discountPrice = rawPrice;
+				rawPrice = relatedMonthlyPlan.raw_price;
+			}
 			return (
 				<td key={ planName } className={ classes }>
 					<PlanFeaturesHeader
@@ -483,7 +488,14 @@ export default connect(
 					available: available,
 					currencyCode: getCurrentUserCurrencyCode( state ),
 					current: isCurrentSitePlan( state, selectedSiteId, planProductId ),
-					discountPrice: getPlanDiscountedRawPrice( state, selectedSiteId, plan, { isMonthly: showMonthly } ),
+					discountPrice: getPlanDiscountedRawPrice( state,
+						selectedSiteId,
+						plan,
+						{
+							isMonthly: abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly'
+								? true
+								: showMonthly
+						} ),
 					features: getPlanFeaturesObject( planConstantObj.getFeatures( abtest ) ),
 					onUpgradeClick: onUpgradeClick
 						? () => {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -106,7 +106,7 @@ class PlanFeatures extends Component {
 
 	renderMobileView() {
 		const {
-			canPurchase, translate, planProperties, isInSignup, isLandingPage, intervalType, site, basePlansPath
+			isCurrentPlanPaid, canPurchase, translate, planProperties, isInSignup, isLandingPage, intervalType, site, basePlansPath
 		} = this.props;
 
 		// move any free plan to last place in mobile view
@@ -139,7 +139,7 @@ class PlanFeatures extends Component {
 				isPlaceholder
 			} = properties;
 			let { rawPrice, discountPrice } = properties;
-			if ( abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly' && relatedMonthlyPlan && relatedMonthlyPlan.raw_price ) {
+			if ( abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly' && ! isCurrentPlanPaid && relatedMonthlyPlan && relatedMonthlyPlan.raw_price ) {
 				discountPrice = rawPrice;
 				rawPrice = relatedMonthlyPlan.raw_price;
 			}
@@ -159,7 +159,7 @@ class PlanFeatures extends Component {
 						intervalType={ intervalType }
 						site={ site }
 						basePlansPath={ basePlansPath }
-						hideMonthly={ abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly' }
+						hideMonthly={ abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly' && ! isCurrentPlanPaid }
 						relatedMonthlyPlan={ relatedMonthlyPlan }
 					/>
 					<p className="plan-features__description">
@@ -195,7 +195,7 @@ class PlanFeatures extends Component {
 	}
 
 	renderPlanHeaders() {
-		const { planProperties, intervalType, site, basePlansPath } = this.props;
+		const { isCurrentPlanPaid, planProperties, intervalType, site, basePlansPath } = this.props;
 
 		return map( planProperties, ( properties ) => {
 			const {
@@ -210,7 +210,7 @@ class PlanFeatures extends Component {
 			} = properties;
 			let { rawPrice, discountPrice } = properties;
 			const classes = classNames( 'plan-features__table-item', 'has-border-top' );
-			if ( abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly' && relatedMonthlyPlan && relatedMonthlyPlan.raw_price ) {
+			if ( abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly' && ! isCurrentPlanPaid && relatedMonthlyPlan && relatedMonthlyPlan.raw_price ) {
 				discountPrice = rawPrice;
 				rawPrice = relatedMonthlyPlan.raw_price;
 			}
@@ -231,7 +231,7 @@ class PlanFeatures extends Component {
 						site={ site }
 						basePlansPath={ basePlansPath }
 						relatedMonthlyPlan={ relatedMonthlyPlan }
-						hideMonthly={ abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly' }
+						hideMonthly={ abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly' && ! isCurrentPlanPaid }
 					/>
 				</td>
 			);
@@ -474,7 +474,7 @@ export default connect(
 				const popular = isPopular( plan ) && ! isPaid;
 				const newPlan = isNew( plan ) && ! isPaid;
 				const currentPlan = sitePlan && sitePlan.product_slug;
-				const showMonthyPrice = abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly'
+				const showMonthyPrice = abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly' && ! isPaid
 					? true
 					: ! relatedMonthlyPlan && showMonthly;
 
@@ -492,7 +492,7 @@ export default connect(
 						selectedSiteId,
 						plan,
 						{
-							isMonthly: abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly'
+							isMonthly: abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly' && ! isPaid
 								? true
 								: showMonthly
 						} ),
@@ -530,7 +530,8 @@ export default connect(
 
 		return {
 			canPurchase,
-			planProperties: planProperties
+			planProperties: planProperties,
+			isCurrentPlanPaid: isPaid
 		};
 	},
 	{

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -157,6 +157,7 @@ class PlanFeatures extends Component {
 						intervalType={ intervalType }
 						site={ site }
 						basePlansPath={ basePlansPath }
+						hideMonthly={ abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly' }
 						relatedMonthlyPlan={ relatedMonthlyPlan }
 					/>
 					<p className="plan-features__description">
@@ -225,6 +226,7 @@ class PlanFeatures extends Component {
 						site={ site }
 						basePlansPath={ basePlansPath }
 						relatedMonthlyPlan={ relatedMonthlyPlan }
+						hideMonthly={ abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly' }
 					/>
 				</td>
 			);
@@ -467,6 +469,9 @@ export default connect(
 				const popular = isPopular( plan ) && ! isPaid;
 				const newPlan = isNew( plan ) && ! isPaid;
 				const currentPlan = sitePlan && sitePlan.product_slug;
+				const showMonthyPrice = abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly'
+					? true
+					: ! relatedMonthlyPlan && showMonthly;
 
 				if ( placeholder || ! planObject || isLoadingSitePlans ) {
 					isPlaceholder = true;
@@ -505,7 +510,7 @@ export default connect(
 						popular,
 						newPlan
 					),
-					rawPrice: getPlanRawPrice( state, planProductId, ! relatedMonthlyPlan && showMonthly ),
+					rawPrice: getPlanRawPrice( state, planProductId, showMonthyPrice ),
 					relatedMonthlyPlan: relatedMonthlyPlan
 				};
 			} )

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -474,7 +474,7 @@ export default connect(
 				const popular = isPopular( plan ) && ! isPaid;
 				const newPlan = isNew( plan ) && ! isPaid;
 				const currentPlan = sitePlan && sitePlan.product_slug;
-				const showMonthyPrice = abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly' && ! isPaid
+				const showMonthlyPrice = abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly' && ! isPaid
 					? true
 					: ! relatedMonthlyPlan && showMonthly;
 
@@ -522,7 +522,7 @@ export default connect(
 						popular,
 						newPlan
 					),
-					rawPrice: getPlanRawPrice( state, planProductId, showMonthyPrice ),
+					rawPrice: getPlanRawPrice( state, planProductId, showMonthlyPrice ),
 					relatedMonthlyPlan: relatedMonthlyPlan
 				};
 			} )

--- a/client/state/sites/plans/selectors.js
+++ b/client/state/sites/plans/selectors.js
@@ -111,7 +111,6 @@ export function getPlanDiscountedRawPrice(
 	if ( get( plan, 'rawPrice', -1 ) < 0 || ! isSitePlanDiscounted( state, siteId, productSlug ) ) {
 		return null;
 	}
-
 	const discountPrice = plan.rawPrice;
 
 	return isMonthly ? parseFloat( ( discountPrice / 12 ).toFixed( 2 ) ) : discountPrice;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/11607

TLDR: We are going to run an a/b test removing the jetpack monthly plans.

This PR implements it.

How to test:
0. First, go to http://calypso.localhost:3000/plans/ and select a jetpack site ... make sure everything looks right. Then connect that site and make sure everything works fine in the plans selection screen ( you will need a site without any purchased plan so you can see the plans step there)
1. Now let's start the test. Open the developer tools and run this in the console: `localStorage.setItem( 'ABTests', '{"jetpackPlansNoMonthly_20170302":"hideMonthly"}' );`
2. Go to http://calypso.localhost:3000/plans/ and select a jetpack site that doesn't have any paid plan. You should see something like this:
![image](https://cloud.githubusercontent.com/assets/1554855/23505736/4325188e-ff45-11e6-8e9b-b34e8a43670b.png)


3. Disconnect that site and connect it again. In the plans selection step you should see:
![image](https://cloud.githubusercontent.com/assets/1554855/23505792/7f230a9e-ff45-11e6-88de-f71fadb77011.png)

4. Now purchase a plan with that site (or select any site with an already purchased plan). Go back to  http://calypso.localhost:3000/plans/[site-slug]. This time, you should see the monthly plans selector: 
![image](https://cloud.githubusercontent.com/assets/1554855/23505846/ab0c3126-ff45-11e6-8b55-fe073ac867a7.png)
Make sure you can see the monthly version of the plans

5. Now choose a WordPress.com site and go to the plans page again. Make sure nothing in this PR interfers with dotcom plans
