### PR TITLE
Fix double slashes path not returning 404 on the server.

### DIFF
--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -114,14 +114,10 @@ function splitTemplate( path, section ) {
 }
 
 function getPathRegex( pathString ) {
-	var regex;
-
 	if ( pathString === '/' ) {
 		return JSON.stringify( pathString );
 	}
-
-	regex = utils.pathToRegExp( pathString );
-
+	const regex = utils.pathToRegExp( pathString );
 	return '/' + regex.toString().slice( 1, -1 ) + '/';
 }
 

--- a/server/bundler/utils.js
+++ b/server/bundler/utils.js
@@ -13,7 +13,10 @@ function getAssets( stats ) {
 	} );
 }
 
+// Adapts route paths to also include wildcard
+// subroutes under the root level section.
 function pathToRegExp( path ) {
+	// Prevents root level double dash urls from being validated.
 	if ( path === '/' ) {
 		return path;
 	}

--- a/server/bundler/utils.js
+++ b/server/bundler/utils.js
@@ -14,6 +14,9 @@ function getAssets( stats ) {
 }
 
 function pathToRegExp( path ) {
+	if ( path === '/' ) {
+		return path;
+	}
 	return new RegExp( '^' + path + '(/.*)?$' );
 }
 


### PR DESCRIPTION
Fixes `//foo/blah.js` returning a valid logged in session.