### PR TITLE
Site Settings: Fix PlanCompareCard warning in SeoPreviewNudge

### DIFF
--- a/client/components/seo/preview-upgrade-nudge/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/index.jsx
@@ -95,7 +95,7 @@ const SeoPreviewNudge = ( { translate, domain, plan = {}, businessPlan = {} } ) 
 			</div>
 			<FeatureComparison className="preview-upgrade-nudge__feature-comparison">
 				<PlanCompareCard
-					title={ plan.product_name_short }
+					title={ plan.product_name_short || '' }
 					line={ planPrice }
 					buttonName={ translate( 'Your Plan' ) }
 					currentPlan={ true } >
@@ -111,7 +111,7 @@ const SeoPreviewNudge = ( { translate, domain, plan = {}, businessPlan = {} } ) 
 					) ) }
 				</PlanCompareCard>
 				<PlanCompareCard
-					title={ businessPlan.product_name_short }
+					title={ businessPlan.product_name_short || '' }
 					line={ translate( '%(price)s per month, billed yearly', { args: { price: businessPlanPrice } } ) }
 					buttonName={ translate( 'Upgrade' ) }
 					onClick={ () => {


### PR DESCRIPTION
This PR fixes a warning that appears when you open the SEO settings tab for a WordPress.com site with a non-business plan:

![](https://cldup.com/NOtDHn2lv8.png)

It can occur initially before the plan is being loaded, which causes that prop to be `undefined`. So this PR makes sure that it'll never be `undefined`. Originally discovered by @Copons [here](https://github.com/Automattic/wp-calypso/pull/11663#issuecomment-283320841), who also gets the great honor to review it 😆 .

To test:

* Checkout this branch.
* Go to `/settings/seo/$site` where `$site` is a WordPress.com site with a non-business plan (for example Premium or Personal).
* Verify the warning from the screenshot no longer appears in the console.