### PR TITLE
Masterbar: add hover to a recent drafts toggle near "Write"

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -319,6 +319,7 @@ $autobar-height: 20px;
 	padding: 0 8px;
 	border-radius: 0 3px 3px 0;
 	position: relative;
+	transition: all 0.2s ease-out;
 
 	.count {
 		border: none;
@@ -328,6 +329,14 @@ $autobar-height: 20px;
 		color: $gray-dark;
 		padding: 0 4px;
 		line-height: 30px;
+	}
+
+	&:hover {
+		background: $white;
+
+		.count {
+			color: $blue-wordpress;
+		}
 	}
 }
 


### PR DESCRIPTION
![cap-](https://cloud.githubusercontent.com/assets/4389/23512415/6a44373e-ff58-11e6-90a4-a58c132d56be.gif)

Simple hover effect to the new draft counter design we introduced in #11593. 

This is a CSS only PR.

## To test

1. Open this branch
2. From anywhere just hover on the counter, it should animate in and out quickly to the same white of the button