### PR TITLE
Reader: move featured video to its own block

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -38,6 +38,7 @@
 @import 'blocks/reader-excerpt/style';
 @import 'blocks/reader-feed-header/style';
 @import 'blocks/reader-featured-image/style';
+@import 'blocks/reader-featured-video/style';
 @import 'blocks/reader-full-post/style';
 @import 'blocks/reader-post-actions/style';
 @import 'blocks/reader-post-card/style';

--- a/client/blocks/reader-featured-video/README.md
+++ b/client/blocks/reader-featured-video/README.md
@@ -1,0 +1,16 @@
+# Reader Featured Video
+
+Displays a featured video for a Reader post card.
+
+## Example
+
+```html
+<ReaderFeaturedVideo thumbnailUrl={ thumbnail } videoEmbed={ post.canonical_media } />
+```
+
+## Props
+
+- `thumbnailUrl`: Image URL for the video thumbnail
+- `autoplayIframe`
+- `iframe`
+- `videoEmbed`

--- a/client/blocks/reader-featured-video/index.jsx
+++ b/client/blocks/reader-featured-video/index.jsx
@@ -15,7 +15,7 @@ import ReaderFeaturedImage from 'blocks/reader-featured-image';
 import { getThumbnailForIframe } from 'state/reader/thumbnails/selectors';
 import QueryReaderThumbnail from 'components/data/query-reader-thumbnails';
 
-class FeaturedVideo extends React.Component {
+class ReaderFeaturedVideo extends React.Component {
 
 	static propTypes = {
 		thumbnailUrl: React.PropTypes.string,
@@ -86,10 +86,10 @@ class FeaturedVideo extends React.Component {
 
 		/* eslint-disable react/no-danger */
 		return (
-			<div>
+			<div className="reader-featured-video">
 				<QueryReaderThumbnail embedUrl={ this.props.videoEmbed.src } />
 				{ showEmbed &&
-					<div ref={ this.setVideoEmbedRef } className="reader-post-card__video"
+					<div ref={ this.setVideoEmbedRef } className="reader-featured-video__video"
 						dangerouslySetInnerHTML={ { __html: thumbnailUrl ? autoplayIframe : iframe } }
 					/>
 				}
@@ -103,4 +103,4 @@ const mapStateToProps = ( state, ownProps ) => ( {
 	thumbnailUrl: getThumbnailForIframe( state, ownProps.videoEmbed.src ),
 } );
 
-export default connect( mapStateToProps )( localize( FeaturedVideo ) );
+export default connect( mapStateToProps )( localize( ReaderFeaturedVideo ) );

--- a/client/blocks/reader-featured-video/style.scss
+++ b/client/blocks/reader-featured-video/style.scss
@@ -1,0 +1,3 @@
+.reader-featured-video__video iframe {
+	display: flex;
+}

--- a/client/blocks/reader-post-card/standard.jsx
+++ b/client/blocks/reader-post-card/standard.jsx
@@ -7,7 +7,7 @@ import React from 'react';
  * Internal Dependencies
  */
 import AutoDirection from 'components/auto-direction';
-import FeaturedVideo from './featured-video';
+import ReaderFeaturedVideo from 'blocks/reader-featured-video';
 import ReaderFeaturedImage from 'blocks/reader-featured-image';
 import ReaderExcerpt from 'blocks/reader-excerpt';
 
@@ -17,7 +17,7 @@ const StandardPost = ( { post, children, isDiscover } )=> {
 	if ( ! canonicalMedia ) {
 		featuredAsset = null;
 	} else if ( canonicalMedia.mediaType === 'video' ) {
-		featuredAsset = <FeaturedVideo { ...canonicalMedia } videoEmbed={ canonicalMedia } />;
+		featuredAsset = <ReaderFeaturedVideo { ...canonicalMedia } videoEmbed={ canonicalMedia } />;
 	} else {
 		featuredAsset = <ReaderFeaturedImage imageUrl={ canonicalMedia.src } href={ post.URL } />;
 	}

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -639,7 +639,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	}
 }
 
-.reader-post-card__video {
+.reader-post-card .reader-featured-video__video {
 	padding-bottom: 17px;
 
 	@media #{$reader-post-card-breakpoint-medium} {
@@ -649,10 +649,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	@media #{$reader-post-card-breakpoint-small} {
 		padding-bottom: 10px;
 	}
-}
-
-.reader-post-card__video iframe {
-	display: flex;
 }
 
 .reader-post-card__gallery-image {


### PR DESCRIPTION
To allow reuse in the upcoming Reader combined card (#11407), this PR moves the featured video component out of `reader-post-card` and into its own block.

There should be no functional changes.

### To test

Make sure that videos in the Reader stream still function and appear as expected. This test blog has a Youtube and Vimeo video to try:

http://calypso.localhost:3000/read/blogs/122463145