### PR TITLE
Reader: Whitelist google.com as an iframe provider

### DIFF
--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -138,6 +138,7 @@ export function iframeIsWhitelisted( iframe ) {
 		'facebook.com',
 		'embed.itunes.apple.com',
 		'nyt.com',
+		'google.com',
 	];
 	const hostName = iframe.src && url.parse( iframe.src ).hostname;
 	const iframeSrc = hostName && hostName.toLowerCase();


### PR DESCRIPTION
Fixes embeded google maps. See that ticket for a repro.

To test, visit https://calypso.live/read/blogs/100341607/posts/1408?branch=update/reader/whitelist-gmaps and verify that embedded maps appear.

Fixes #11703