### PR TITLE
Reader: Let soundcloud out of the sandbox

### DIFF
--- a/client/lib/post-normalizer/rule-content-make-embeds-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-embeds-safe.js
@@ -16,7 +16,8 @@ import url from 'url';
 function doesNotNeedSandbox( iframe ) {
 	const trustedHosts = [
 		'spotify.com',
-		'kickstarter.com'
+		'kickstarter.com',
+		'soundcloud.com',
 	];
 
 	const hostName = iframe.src && url.parse( iframe.src ).hostname;


### PR DESCRIPTION
Soundcloud changed something in their embeded code recently and they are now throwing errors when sandboxed. This lets them escape the sandbox and quiets down the console.

To test, load https://wordpress.com/read/feeds/21867259/posts/1358551282 vs https://calypso.live/read/feeds/21867259/posts/1358551282?branch=update/reader/unsandbox-soundcloud

the later should not have a console error about loading a plugin. 