### PR TITLE
Signup: Alias anonUserId to WPCOM user id when user is created

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -412,16 +412,19 @@ const analytics = {
 		}
 	},
 
-	identifyUser: function() {
+	identifyUser: function( newUserId = '', newUserName = '' ) {
 		const anonymousUserId = this.tracks.anonymousUserId();
 
 		// Don't identify the user if we don't have one
-		if ( _user && _user.initialized ) {
+		if ( ( _user && _user.initialized ) || ( newUserId && newUserName ) ) {
 			if ( anonymousUserId ) {
 				recordAliasInFloodlight();
 			}
 
-			window._tkq.push( [ 'identifyUser', _user.get().ID, _user.get().username ] );
+			const userId = newUserId || _user.get().ID;
+			const userName = newUserName || _user.get().username;
+
+			window._tkq.push( [ 'identifyUser', userId, userName ] );
 		}
 	},
 

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -269,6 +269,30 @@ module.exports = {
 					// Fire after a new user registers.
 					analytics.tracks.recordEvent( 'calypso_user_registration_complete' );
 					analytics.ga.recordEvent( 'Signup', 'calypso_user_registration_complete' );
+
+					/**
+					 * Auto login the user when it has been created.
+					 */
+					user.clear();
+					user.fetching = false;
+
+					user.on( 'change', () => {
+						const newLoggedUser = user.get();
+
+						if ( newLoggedUser && newLoggedUser.ID ) {
+							analytics.identifyUser( newLoggedUser.ID, newLoggedUser.username );
+						} else {
+							/**
+							 * The user fetching is a bit fragile and sometimes it requires to do a double-fetch.
+							 */
+							user.clear();
+							user.fetching = false;
+							user.fetch();
+						}
+					} );
+
+					// Force fetch the user details
+					user.fetch();
 				}
 
 				callback( errors, assign( {}, { username: userData.username }, bearerToken ) );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -238,7 +238,15 @@ const Signup = React.createClass( {
 		if ( userIsLoggedIn ) {
 			// deferred in case the user is logged in and the redirect triggers a dispatch
 			defer( function() {
-				page( destination );
+				/**
+				 * The destination URL is not always inside Calypso.
+				 * For these cases make sure that a proper redirect is issued.
+				 */
+				if ( /^https?:\/\// ) {
+					window.location.href = destination;
+				} else {
+					page( destination );
+				}
 			}.bind( this ) );
 		}
 


### PR DESCRIPTION
This PR aims to properly connect the `anonUserId` and the WPCOM user id. 

Context: p3Ex-24k-p2

To test:

1. Checkout branch
2. Go through Signup without adding anything into Cart (domain or plan)
3. Reach User step
4. Fill the user step
5. Submit
6. Verify the `_aliasUser ` event has been properly sent to the analytics backend