### PR TITLE
Reader Featured Video: allow display of thumbnail only

### DIFF
--- a/client/blocks/reader-featured-image/style.scss
+++ b/client/blocks/reader-featured-image/style.scss
@@ -1,3 +1,16 @@
 .reader-featured-image {
 	border: 1px solid lighten( $gray, 20% );
+	box-sizing: border-box;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-basis: auto;
+	flex-grow: 1;
+	cursor: pointer;
 }
+
+.is-section-devdocs .reader-featured-image {
+	min-height: 100px;
+	margin-bottom: 16px;
+}
+

--- a/client/blocks/reader-featured-image/style.scss
+++ b/client/blocks/reader-featured-image/style.scss
@@ -4,8 +4,6 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	flex-basis: auto;
-	flex-grow: 1;
 	cursor: pointer;
 }
 

--- a/client/blocks/reader-featured-image/style.scss
+++ b/client/blocks/reader-featured-image/style.scss
@@ -1,6 +1,5 @@
 .reader-featured-image {
 	border: 1px solid lighten( $gray, 20% );
-	box-sizing: border-box;
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/client/blocks/reader-featured-video/README.md
+++ b/client/blocks/reader-featured-video/README.md
@@ -10,7 +10,9 @@ Displays a featured video for a Reader post card.
 
 ## Props
 
-- `thumbnailUrl`: Image URL for the video thumbnail
-- `autoplayIframe`
-- `iframe`
-- `videoEmbed`
+- `thumbnailUrl`: image URL for the video thumbnail
+- `autoplayIframe`: the iframe HTML element with a url such that it will autoplay when placed in a DOM
+- `iframe`: the iframe html element to place in the DOM when the play button has been clicked
+- `videoEmbed`: the associated metadata for the embed that the post-normalizer generated. Should contain height/width etc.
+- `allowPlaying`: should we show a play button and allow playing of the video in-place? If set to false, only the thumbnail will be displayed
+- `onThumbnailClick`: click handler to be executed when the thumbnail is clicked

--- a/client/blocks/reader-featured-video/docs/example.jsx
+++ b/client/blocks/reader-featured-video/docs/example.jsx
@@ -1,0 +1,46 @@
+/**
+* External dependencies
+*/
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import ReaderFeaturedVideoBlock from 'blocks/reader-featured-video';
+
+const exampleVideo = {
+	autoplayIframe: "<iframe data-wpcom-embed-url=\"https://www.youtube.com/watch?v=jtQ98OZrW5M\" class=\"youtube-player\" type=\"text/html\" width=\"640\" height=\"390\" src=\"https://www.youtube.com/embed/jtQ98OZrW5M?version=3&amp;rel=1&amp;fs=1&amp;autohide=2&amp;showsearch=0&amp;showinfo=1&amp;iv_load_policy=1&amp;wmode=transparent&amp;autoplay=1\" allowfullscreen=\"true\" sandbox=\"allow-same-origin allow-scripts allow-popups\"></iframe>",
+	aspectRatio: 1.641025641025641,
+	height: 390,
+	iframe: "<iframe data-wpcom-embed-url=\"https://www.youtube.com/watch?v=jtQ98OZrW5M\" class=\"youtube-player\" type=\"text/html\" width=\"640\" height=\"390\" src=\"https://www.youtube.com/embed/jtQ98OZrW5M?version=3&amp;rel=1&amp;fs=1&amp;autohide=2&amp;showsearch=0&amp;showinfo=1&amp;iv_load_policy=1&amp;wmode=transparent\" allowfullscreen=\"true\" sandbox=\"allow-same-origin allow-scripts allow-popups\"></iframe>",
+	mediaType: 'video',
+	src: "https://www.youtube.com/embed/jtQ98OZrW5M?version=3&rel=1&fs=1&autohide=2&showsearch=0&showinfo=1&iv_load_policy=1&wmode=transparent",
+	thumbnailUrl: "https://img.youtube.com/vi/jtQ98OZrW5M/mqdefault.jpg",
+	type: 'youtube',
+	width: 640,
+};
+
+const ReaderFeaturedVideo = () => (
+	<div className="design-assets__group">
+		<div>
+			<h3>With play button</h3>
+			<ReaderFeaturedVideoBlock
+				{ ...exampleVideo }
+				videoEmbed={ exampleVideo }
+			/>
+		</div>
+		<div>
+			<h3>Without play button</h3>
+			<ReaderFeaturedVideoBlock
+				{ ...exampleVideo }
+				videoEmbed={ exampleVideo }
+				allowPlaying={ false }
+			/>
+		</div>
+	</div>
+);
+
+ReaderFeaturedVideo.displayName = 'ReaderFeaturedVideo';
+
+export default ReaderFeaturedVideo;

--- a/client/blocks/reader-featured-video/index.jsx
+++ b/client/blocks/reader-featured-video/index.jsx
@@ -95,7 +95,7 @@ class ReaderFeaturedVideo extends React.Component {
 		if ( preferThumbnail && thumbnailUrl ) {
 			return (
 				<ReaderFeaturedImage imageUrl={ thumbnailUrl } onClick={ this.handleThumbnailClick }>
-					{ allowPlaying && <img className="reader-post-card__play-icon"
+					{ allowPlaying && <img className="reader-featured-video__play-icon"
 						src="/calypso/images/reader/play-icon.png"
 						title={ translate( 'Play Video' ) }
 					/> }

--- a/client/blocks/reader-featured-video/index.jsx
+++ b/client/blocks/reader-featured-video/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { throttle, constant } from 'lodash';
+import { throttle, constant, noop } from 'lodash';
 import ReactDom from 'react-dom';
 import { localize } from 'i18n-calypso';
 
@@ -22,12 +22,19 @@ class ReaderFeaturedVideo extends React.Component {
 		autoplayIframe: React.PropTypes.string,
 		iframe: React.PropTypes.string,
 		videoEmbed: React.PropTypes.object,
+		allowPlaying: React.PropTypes.bool,
+		onThumbnailClick: React.PropTypes.func,
+	}
+
+	static defaultProps = {
+		allowPlaying: true,
+		onThumbnailClick: noop,
 	}
 
 	constructor( props ) {
 		super( props );
 		this.state = {
-			preferThumbnail: true
+			preferThumbnail: true,
 		};
 	}
 
@@ -55,6 +62,12 @@ class ReaderFeaturedVideo extends React.Component {
 
 	handleThumbnailClick = ( e ) => {
 		e.preventDefault();
+		this.props.onThumbnailClick();
+
+		if ( ! this.props.allowPlaying ) {
+			return false;
+		}
+
 		this.setState( { preferThumbnail: false }, () => this.updateVideoSize() );
 	}
 
@@ -64,31 +77,35 @@ class ReaderFeaturedVideo extends React.Component {
 	}
 
 	componentDidMount() {
-		global.window && global.window.addEventListener( 'resize', this.throttledUpdateVideoSize );
+		if ( this.props.allowPlaying ) {
+			global.window && global.window.addEventListener( 'resize', this.throttledUpdateVideoSize );
+		}
 	}
 
 	componentWillUnmount() {
-		global.window && global.window.removeEventListener( 'resize', this.throttledUpdateVideoSize );
+		if ( this.props.allowPlaying ) {
+			global.window && global.window.removeEventListener( 'resize', this.throttledUpdateVideoSize );
+		}
 	}
 
 	render() {
-		const { thumbnailUrl, autoplayIframe, iframe, translate } = this.props;
+		const { thumbnailUrl, autoplayIframe, iframe, translate, allowPlaying } = this.props;
 		const preferThumbnail = this.state.preferThumbnail;
 
 		if ( preferThumbnail && thumbnailUrl ) {
 			return (
 				<ReaderFeaturedImage imageUrl={ thumbnailUrl } onClick={ this.handleThumbnailClick }>
-					<img className="reader-post-card__play-icon"
+					{ allowPlaying && <img className="reader-post-card__play-icon"
 						src="/calypso/images/reader/play-icon.png"
 						title={ translate( 'Play Video' ) }
-					/>
+					/> }
 				</ReaderFeaturedImage>
 			);
 		}
 
 		// if we can't retrieve a thumbnail that means there was an issue
 		// with the embed and we shouldn't display it
-		const showEmbed = !! this.props.thumbnailUrl;
+		const showEmbed = !! thumbnailUrl;
 
 		/* eslint-disable react/no-danger */
 		return (

--- a/client/blocks/reader-featured-video/style.scss
+++ b/client/blocks/reader-featured-video/style.scss
@@ -10,3 +10,7 @@
 .reader-featured-image:hover .reader-featured-video__play-icon {
 	opacity: 1;
 }
+
+.is-section-devdocs .reader-featured-video__video {
+	margin-bottom: 16px;
+}

--- a/client/blocks/reader-featured-video/style.scss
+++ b/client/blocks/reader-featured-video/style.scss
@@ -3,8 +3,8 @@
 }
 
 .reader-featured-video__play-icon {
-	opacity: .8;
-	transition: opacity .25s;
+	opacity: 0.8;
+	transition: opacity 0.25s;
 }
 
 .reader-featured-image:hover .reader-featured-video__play-icon {

--- a/client/blocks/reader-featured-video/style.scss
+++ b/client/blocks/reader-featured-video/style.scss
@@ -1,3 +1,12 @@
 .reader-featured-video__video iframe {
 	display: flex;
 }
+
+.reader-featured-video__play-icon {
+	opacity: .8;
+	transition: opacity .25s;
+}
+
+.reader-featured-image:hover .reader-featured-video__play-icon {
+	opacity: 1;
+}

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -53,15 +53,8 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	&.has-thumbnail {
 
 		.reader-featured-image {
-			box-sizing: border-box;
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			flex-basis: auto;
-			flex-grow: 1;
 			margin-right: 20px;
 			max-width: 190px;
-			cursor: pointer;
 
 			@include breakpoint( ">960px" ) {
 				max-width: 250px;
@@ -80,15 +73,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 				width: 100%;
 				margin-bottom: 10px;
 			}
-
-			&:hover .reader-post-card__play-icon {
-				opacity: 1;
-			}
-		}
-
-		.reader-post-card__play-icon {
-			opacity: .8;
-			transition: opacity .25s;
 		}
 
 		&.is-photo {
@@ -676,8 +660,4 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 // For these borderless cards to look more presentable on Devdocs
 .is-section-devdocs .reader-post-card.card {
 	padding: 16px;
-}
-
-.is-section-devdocs .reader-featured-image {
-	bottom: 16px;
 }

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -53,6 +53,8 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	&.has-thumbnail {
 
 		.reader-featured-image {
+			flex-basis: auto;
+			flex-grow: 1;
 			margin-right: 20px;
 			max-width: 190px;
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -57,6 +57,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			flex-grow: 1;
 			margin-right: 20px;
 			max-width: 190px;
+			box-sizing: border-box;
 
 			@include breakpoint( ">960px" ) {
 				max-width: 250px;

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -54,6 +54,7 @@ import ReaderPostCard from 'blocks/reader-post-card/docs/example';
 import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu/docs/example';
 import DailyPostButton from 'blocks/daily-post-button/docs/example';
 import PostLikes from 'blocks/post-likes/docs/example';
+import ReaderFeaturedVideo from 'blocks/reader-featured-video/docs/example';
 
 export default React.createClass( {
 
@@ -128,6 +129,7 @@ export default React.createClass( {
 					<ReaderPostOptionsMenu />
 					<DailyPostButton />
 					<PostLikes />
+					<ReaderFeaturedVideo />
 				</Collection>
 			</Main>
 		);


### PR DESCRIPTION
In some scenarios (notably the new combined card #11407), we want to display a video thumbnail but not allow playing of the video in-place.

This PR adds a new prop `allowPlaying` that defaults to true. Setting it to false shows just the thumbnail and disables the play button.

### To test

Check out the brand new devdocs page at:

http://calypso.localhost:3000/devdocs/blocks/reader-featured-video

Check for any regressions to the appearance of featured images and featured videos on post cards. Here's a selection of the different post types:

http://calypso.localhost:3000/read/blogs/122463145

<img width="685" alt="screen shot 2017-03-02 at 21 19 00" src="https://cloud.githubusercontent.com/assets/17325/23525196/e5798186-ff8d-11e6-8add-d7f256f6a3cf.png">
