### PR TITLE
Plugins: Add Action Links to Plugin Detail View

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -59,6 +59,7 @@ function filterNoticesBy( site, pluginSlug, log ) {
 PluginUtils = {
 	whiteListPluginData: function( plugin ) {
 		return pick( plugin,
+			'action_links',
 			'active',
 			'author',
 			'author_url',

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -347,8 +347,11 @@ export default React.createClass( {
 							{ ! isEmpty( actionLinks ) &&
 								<div className="plugin-meta__action-links">
 									{ Object.keys( actionLinks ).map( linkTitle => (
-										<Button compact icon href={ actionLinks[ linkTitle ] } target="_blank">
-											{ linkTitle } <Gridicon icon="external" />
+										<Button compact icon
+											href={ actionLinks[ linkTitle ] }
+											target="_blank"
+											rel="noopener noreferrer">
+												{ linkTitle } <Gridicon icon="external" />
 										</Button>
 									) ) }
 								</div>

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -7,6 +7,7 @@ import i18n from 'i18n-calypso';
 import some from 'lodash/some';
 import get from 'lodash/get';
 import { includes } from 'lodash';
+import { isEmpty } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
@@ -327,6 +328,7 @@ export default React.createClass( {
 		} );
 
 		const plugin = this.props.selectedSite && this.props.sites[ 0 ] ? this.props.sites[ 0 ].plugin : this.props.plugin;
+		const actionLinks = get( plugin, 'action_links' );
 
 		return (
 			<div className="plugin-meta">
@@ -342,6 +344,15 @@ export default React.createClass( {
 							<div className="plugin-meta__meta">
 								{ this.renderAuthorUrl() }
 							</div>
+							{ ! isEmpty( actionLinks ) &&
+								<div className="plugin-meta__action-links">
+									{ Object.keys( actionLinks ).map( linkTitle => (
+										<Button compact icon href={ actionLinks[ linkTitle ] } target="_blank">
+											{ linkTitle } <Gridicon icon="external" />
+										</Button>
+									) ) }
+								</div>
+							}
 						</div>
 						{ this.renderActions() }
 					</div>

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -103,12 +103,13 @@
 	}
 
 	@include breakpoint( '>480px' ) {
+		min-width: 22%;
 		border: none;
 		margin: 0;
 		padding: 0;
 		text-align: right;
 		justify-content: flex-end;
-		align-self: center;
+		align-self: flex-start;
 
 		.plugin-action {
 			margin-top: 16px;
@@ -147,6 +148,19 @@
 
 .plugin-meta__actions .plugin-meta__active {
 	color: $alert-green;
+}
+
+.plugin-meta__action-links {
+	display: flex;
+	flex-wrap: wrap;
+	clear: both;
+	padding-top: 12px;
+
+	.button {
+		margin-top: 12px;
+		flex-shrink: 0;
+		margin-right: 10px;
+	}
 }
 
 a.plugin-meta__settings-link {


### PR DESCRIPTION
Adds plugin `action links` buttons to the plugin detail view. The plugin developer adds these using the [action link filter](https://codex.wordpress.org/Plugin_API/Filter_Reference/plugin_action_links_(plugin_file_name)).

**To test**
* Ensure your Jetpack site is running 4.7.
* Install some plugins via calypso that use action links (and some that don't). Jetpack and WooCommerce are good examples.
* After installing the plugin, you should see the action links appear as buttons underneath the plugin icon.
* Test the buttons to make sure they link properly to the content.
* Remove the plugin. The buttons should disappear.

Screenshot:
<img width="689" alt="screen shot 2017-02-28 at 3 27 23 pm" src="https://cloud.githubusercontent.com/assets/789137/23520892/905994c2-ff31-11e6-88df-fce2136c499e.png">

Fixes #82