### PR TITLE
Signup: Migrate imports and exports from CommonJS to ES2015

### DIFF
--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -16,7 +16,7 @@ import UserSignupComponent from 'signup/steps/user';
 import PlansStepWithoutFreePlan from 'signup/steps/plans-without-free';
 
 
-module.exports = {
+export default {
 	'design-type': DesignTypeComponent,
 	'design-type-with-store': DesignTypeWithStoreComponent,
 	domains: DomainsStepComponent,

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -1,17 +1,17 @@
 /**
  * Internal dependencies
  */
-var config = require( 'config' ),
-	DesignTypeComponent = require( 'signup/steps/design-type' ),
-	DesignTypeWithStoreComponent = require( 'signup/steps/design-type-with-store' ),
-	DomainsStepComponent = require( 'signup/steps/domains' ),
-	GetDotBlogPlansStepComponent = require( 'signup/steps/get-dot-blog-plans' ),
-	PlansStepComponent = require( 'signup/steps/plans' ),
-	SiteComponent = require( 'signup/steps/site' ),
-	SiteOrDomainComponent = require( 'signup/steps/site-or-domain' ),
-	SiteTitleComponent = require( 'signup/steps/site-title' ),
-	SurveyStepComponent = require( 'signup/steps/survey' ),
-	ThemeSelectionComponent = require( 'signup/steps/theme-selection' );
+import config from 'config';
+import DesignTypeComponent from 'signup/steps/design-type';
+import DesignTypeWithStoreComponent from 'signup/steps/design-type-with-store';
+import DomainsStepComponent from 'signup/steps/domains';
+import GetDotBlogPlansStepComponent from 'signup/steps/get-dot-blog-plans';
+import PlansStepComponent from 'signup/steps/plans';
+import SiteComponent from 'signup/steps/site';
+import SiteOrDomainComponent from 'signup/steps/site-or-domain';
+import SiteTitleComponent from 'signup/steps/site-title';
+import SurveyStepComponent from 'signup/steps/survey';
+import ThemeSelectionComponent from 'signup/steps/theme-selection';
 import UserSignupComponent from 'signup/steps/user';
 import PlansStepWithoutFreePlan from 'signup/steps/plans-without-free';
 

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -9,7 +9,7 @@ import i18n from 'i18n-calypso';
 */
 import stepActions from 'lib/signup/step-actions';
 
-module.exports = {
+export default {
 	survey: {
 		stepName: 'survey',
 		props: {

--- a/client/signup/config/test/lib/signup/step-actions.js
+++ b/client/signup/config/test/lib/signup/step-actions.js
@@ -1,2 +1,2 @@
 // step-actions stub
-module.exports = {};
+export default {};

--- a/client/signup/config/test/lib/user/index.js
+++ b/client/signup/config/test/lib/user/index.js
@@ -2,7 +2,7 @@
  * User stub
  */
 
-module.exports = () => {
+export default () => {
 	return {
 		get() {
 			return {};

--- a/client/signup/flow-progress-indicator/index.jsx
+++ b/client/signup/flow-progress-indicator/index.jsx
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var flows = require( 'signup/config/flows' );
+import flows from 'signup/config/flows';
 
 module.exports = React.createClass( {
 	displayName: 'FlowProgressIndicator',

--- a/client/signup/index.web.js
+++ b/client/signup/index.web.js
@@ -10,7 +10,7 @@ import controller from './controller';
 import jetpackConnectController from './jetpack-connect/controller';
 import sitesController from 'my-sites/controller';
 
-module.exports = function() {
+export default function() {
 	page(
 		'/start/:flowName?/:stepName?/:stepSectionName?/:lang?',
 		controller.saveRefParameter,

--- a/client/signup/locale-suggestions/index.jsx
+++ b/client/signup/locale-suggestions/index.jsx
@@ -1,16 +1,16 @@
 /**
  * External dependencies
  */
-var i18n = require( 'i18n-calypso'),
-	React = require( 'react' ),
-	assign = require( 'lodash/assign' );
+import i18n from 'i18n-calypso';
+import React from 'react';
+import assign from 'lodash/assign';
 
 /**
  * Internal dependencies
  */
-var i18nUtils = require( 'lib/i18n-utils' ),
-	switchLocale = require( 'lib/i18n-utils/switch-locale' ),
-	LocaleSuggestionStore = require( 'lib/locale-suggestions' );
+import i18nUtils from 'lib/i18n-utils';
+import switchLocale from 'lib/i18n-utils/switch-locale';
+import LocaleSuggestionStore from 'lib/locale-suggestions';
 
 import Notice from 'components/notice';
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1,27 +1,26 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	{ PropTypes } = React,
-	{ connect } = require( 'react-redux' ),
-	defer = require( 'lodash/defer' ),
-	page = require( 'page' ),
-	i18n = require( 'i18n-calypso' );
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import defer from 'lodash/defer';
+import page from 'page';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var StepWrapper = require( 'signup/step-wrapper' ),
-	productsList = require( 'lib/products-list' )(),
-	cartItems = require( 'lib/cart-values' ).cartItems,
-	SignupActions = require( 'lib/signup/actions' ),
-	MapDomainStep = require( 'components/domains/map-domain-step' ),
-	RegisterDomainStep = require( 'components/domains/register-domain-step' ),
-	{ DOMAINS_WITH_PLANS_ONLY } = require( 'state/current-user/constants' ),
-	{ getSurveyVertical } = require( 'state/signup/steps/survey/selectors.js' ),
-	analyticsMixin = require( 'lib/mixins/analytics' ),
-	signupUtils = require( 'signup/utils' ),
-	getUsernameSuggestion = require( 'lib/signup/step-actions' ).getUsernameSuggestion;
+import StepWrapper from 'signup/step-wrapper';
+const productsList = require( 'lib/products-list' )();
+import { cartItems } from 'lib/cart-values';
+import SignupActions from 'lib/signup/actions';
+import MapDomainStep from 'components/domains/map-domain-step';
+import RegisterDomainStep from 'components/domains/register-domain-step';
+import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
+import { getSurveyVertical } from 'state/signup/steps/survey/selectors.js';
+import analyticsMixin from 'lib/mixins/analytics';
+import signupUtils from 'signup/utils';
+import { getUsernameSuggestion } from 'lib/signup/step-actions';
 
 import { getCurrentUser, currentUserHasFlag } from 'state/current-user/selectors';
 import Notice from 'components/notice';

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -1,26 +1,26 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	isEmpty = require( 'lodash/isEmpty' ),
-	includes = require( 'lodash/includes' ),
-	map = require( 'lodash/map' ),
-	debug = require( 'debug' )( 'calypso:steps:site' ); // eslint-disable-line no-unused-vars
+import React from 'react';
+import isEmpty from 'lodash/isEmpty';
+import includes from 'lodash/includes';
+import map from 'lodash/map';
+const debug = require( 'debug' )( 'calypso:steps:site' ); // eslint-disable-line no-unused-vars
 /**
  * Internal dependencies
  */
-var wpcom = require( 'lib/wp' ),
-	config = require( 'config' ),
-	analytics = require( 'lib/analytics' ),
-	formState = require( 'lib/form-state' ),
-	SignupActions = require( 'lib/signup/actions' ),
-	ValidationFieldset = require( 'signup/validation-fieldset' ),
-	FormLabel = require( 'components/forms/form-label' ),
-	FormButton = require( 'components/forms/form-button' ),
-	FormTextInput = require( 'components/forms/form-text-input' ),
-	StepWrapper = require( 'signup/step-wrapper' ),
-	LoggedOutForm = require( 'components/logged-out-form' ),
-	LoggedOutFormFooter = require( 'components/logged-out-form/footer' );
+import wpcom from 'lib/wp';
+import config from 'config';
+import analytics from 'lib/analytics';
+import formState from 'lib/form-state';
+import SignupActions from 'lib/signup/actions';
+import ValidationFieldset from 'signup/validation-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormButton from 'components/forms/form-button';
+import FormTextInput from 'components/forms/form-text-input';
+import StepWrapper from 'signup/step-wrapper';
+import LoggedOutForm from 'components/logged-out-form';
+import LoggedOutFormFooter from 'components/logged-out-form/footer';
 
 /**
  * Constants

--- a/client/signup/steps/test-step/index.jsx
+++ b/client/signup/steps/test-step/index.jsx
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:steps:test' );
+import React from 'react';
+const debug = require( 'debug' )( 'calypso:steps:test' );
 
 /**
  * Internal dependencies
  */
-var StepWrapper = require( 'signup/step-wrapper' ),
-	SubmitStepButton = require( 'signup/submit-step-button' );
+import StepWrapper from 'signup/step-wrapper';
+import SubmitStepButton from 'signup/submit-step-button';
 
 module.exports = React.createClass( {
 	displayName: 'TestStep',

--- a/client/signup/submit-step-button/index.jsx
+++ b/client/signup/submit-step-button/index.jsx
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var SignupActions = require( 'lib/signup/actions' );
+import SignupActions from 'lib/signup/actions';
 
 module.exports = React.createClass( {
 	displayName: 'SubmitStepButton',

--- a/client/signup/test/lib/user/index.js
+++ b/client/signup/test/lib/user/index.js
@@ -4,7 +4,7 @@
 
 var isLoggedIn = false;
 
-module.exports = function() {
+export default function() {
 	return {
 		get: function() {
 			return isLoggedIn;

--- a/client/signup/test/signup/config/steps.js
+++ b/client/signup/test/signup/config/steps.js
@@ -1,5 +1,5 @@
 // steps.js stub
-module.exports = {
+export default {
 	'theme-selection': { stepName: 'theme-selection' },
 	user: { stepName: 'user' }
 };

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -1,21 +1,21 @@
 /**
  * Exernal dependencies
  */
-var isEmpty = require( 'lodash/isEmpty' ),
-	find = require( 'lodash/find' ),
-	indexOf = require( 'lodash/indexOf' ),
-	pick = require( 'lodash/pick' ),
-	merge = require( 'lodash/merge' );
+import isEmpty from 'lodash/isEmpty';
+import find from 'lodash/find';
+import indexOf from 'lodash/indexOf';
+import pick from 'lodash/pick';
+import merge from 'lodash/merge';
 
 /**
  * Internal dependencies
  */
-var i18nUtils = require( 'lib/i18n-utils' ),
-	steps = require( 'signup/config/steps' ),
-	flows = require( 'signup/config/flows' ),
-	defaultFlowName = require( 'signup/config/flows' ).defaultFlowName,
-	formState = require( 'lib/form-state' ),
-	user = require( 'lib/user' )();
+import i18nUtils from 'lib/i18n-utils';
+import steps from 'signup/config/steps';
+import flows from 'signup/config/flows';
+import { defaultFlowName } from 'signup/config/flows';
+import formState from 'lib/form-state';
+const user = require( 'lib/user' )();
 
 function getFlowName( parameters ) {
 	const flow = ( parameters.flowName && isFlowName( parameters.flowName ) ) ? parameters.flowName : defaultFlowName;

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -127,7 +127,7 @@ function getDestination( destination, dependencies, flowName ) {
 	return flows.filterDestination( destination, dependencies, flowName );
 }
 
-module.exports = {
+export default {
 	getFlowName: getFlowName,
 	getFlowSteps: getFlowSteps,
 	getStepName: getStepName,

--- a/client/signup/validation-fieldset/index.jsx
+++ b/client/signup/validation-fieldset/index.jsx
@@ -1,17 +1,17 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	head = require( 'lodash/head' ),
-	values = require( 'lodash/values' ),
-	debug = require( 'debug' )( 'calypso:validate-fieldset' ); // eslint-disable-line no-unused-vars
+import React from 'react';
+import classNames from 'classnames';
+import head from 'lodash/head';
+import values from 'lodash/values';
+const debug = require( 'debug' )( 'calypso:validate-fieldset' ); // eslint-disable-line no-unused-vars
 
 /**
  * Internal dependencies
  */
-var FormFieldset = require( 'components/forms/form-fieldset' ),
-	FormInputValidation = require( 'components/forms/form-input-validation' );
+import FormFieldset from 'components/forms/form-fieldset';
+import FormInputValidation from 'components/forms/form-input-validation';
 
 module.exports = React.createClass( {
 	displayName: 'ValidationFieldset',

--- a/client/signup/wpcom-login-form/index.jsx
+++ b/client/signup/wpcom-login-form/index.jsx
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:signup:wpcom-login' );
+import React from 'react';
+const debug = require( 'debug' )( 'calypso:signup:wpcom-login' );
 
 /**
  * Internal dependencies
  */
-var config = require( 'config' );
+import config from 'config';
 
 module.exports = React.createClass( {
 	displayName: 'WpcomLoginForm',


### PR DESCRIPTION
Part of #11688. 

This change will allow us to leverage [Webpack 2's tree shaking optimization for ES6 modules](https://gist.github.com/sokra/27b24881210b56bbaff7#es6-specific-optimizations) in the future. Please share your suggestions and comments!