### PR TITLE
Reader: Migrate imports and exports from CommonJS to ES2015

### DIFF
--- a/client/blocks/reader-share/helper.jsx
+++ b/client/blocks/reader-share/helper.jsx
@@ -1,5 +1,5 @@
 
-module.exports = {
+export default {
 	shouldShowShare: function( post ) {
 		return ! post.site_is_private;
 	}

--- a/client/blocks/reader-share/helper.jsx
+++ b/client/blocks/reader-share/helper.jsx
@@ -1,7 +1,12 @@
 
-export default {
+const exported = {
 	shouldShowShare: function( post ) {
 		return ! post.site_is_private;
 	}
 };
 
+export default exported;
+
+export const {
+    shouldShowShare
+} = exported;

--- a/client/reader/controller-helper.js
+++ b/client/reader/controller-helper.js
@@ -10,7 +10,7 @@
 import analytics from 'lib/analytics';
 import { recordTrack } from 'reader/stats';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import * as FeedStreamStoreActions from 'lib/feed-stream-store/actions';
+import { fetchNextPage } from 'lib/feed-stream-store/actions';
 import feedStreamFactory from 'lib/feed-stream-store';
 
 let storeId;
@@ -33,7 +33,7 @@ export function ensureStoreLoading( store, context ) {
 				store.startDate = startDate.format();
 			}
 		}
-		FeedStreamStoreActions.fetchNextPage( store.id );
+		fetchNextPage( store.id );
 	}
 	return store;
 }

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -299,8 +299,6 @@ const exported = {
 	}
 };
 
-export default exported;
-
 export const {
     initAbTests,
     prettyRedirects,

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -43,7 +43,7 @@ function renderFeedError( context ) {
 	);
 }
 
-export default {
+const exported = {
 	initAbTests( context, next ) {
 		// spin up the ab tests that are currently active for the reader
 		activeAbTests.forEach( test => abtest( test ) );
@@ -298,3 +298,22 @@ export default {
 		);
 	}
 };
+
+export default exported;
+
+export const {
+    initAbTests,
+    prettyRedirects,
+    legacyRedirects,
+    updateLastRoute,
+    incompleteUrlRedirects,
+    preloadReaderBundle,
+    loadSubscriptions,
+    sidebar,
+    unmountSidebar,
+    following,
+    feedDiscovery,
+    feedListing,
+    blogListing,
+    readA8C
+} = exported;

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -43,7 +43,7 @@ function renderFeedError( context ) {
 	);
 }
 
-module.exports = {
+export default {
 	initAbTests( context, next ) {
 		// spin up the ab tests that are currently active for the reader
 		activeAbTests.forEach( test => abtest( test ) );

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -11,10 +11,12 @@ import i18n from 'i18n-calypso';
  */
 import { abtest } from 'lib/abtest';
 import route from 'lib/route';
+import feedLookup from 'lib/feed-lookup';
 import feedStreamFactory from 'lib/feed-stream-store';
 import { ensureStoreLoading, trackPageLoad, trackUpdatesLoaded, trackScrollPage, setPageTitle } from './controller-helper';
 import FeedError from 'reader/feed-error';
 import FeedSubscriptionActions from 'lib/reader-feed-subscriptions/actions';
+import StreamComponent from 'reader/following/main';
 import {
 	getPrettyFeedUrl,
 	getPrettySiteUrl
@@ -23,6 +25,11 @@ import { recordTrack } from 'reader/stats';
 import { preload } from 'sections-preload';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import AsyncLoad from 'components/async-load';
+
+// these three are included to ensure that the stores required have been loaded and can accept actions
+import FeedSubscriptionStore from 'lib/reader-feed-subscriptions'; // eslint-disable-line no-unused-vars
+import PostEmailSubscriptionStore from 'lib/reader-post-email-subscriptions'; // eslint-disable-line no-unused-vars
+import CommentEmailSubscriptionStore from 'lib/reader-comment-email-subscriptions'; // eslint-disable-line no-unused-vars
 
 const analyticsPageTitle = 'Reader';
 
@@ -117,10 +124,6 @@ const exported = {
 	},
 
 	loadSubscriptions( context, next ) {
-		// these three are included to ensure that the stores required have been loaded and can accept actions
-		const FeedSubscriptionStore = require( 'lib/reader-feed-subscriptions' ), // eslint-disable-line no-unused-vars
-			PostEmailSubscriptionStore = require( 'lib/reader-post-email-subscriptions' ), // eslint-disable-line no-unused-vars
-			CommentEmailSubscriptionStore = require( 'lib/reader-comment-email-subscriptions' ); // eslint-disable-line no-unused-vars
 		FeedSubscriptionActions.fetchAll();
 		next();
 	},
@@ -141,8 +144,7 @@ const exported = {
 	},
 
 	following( context ) {
-		const StreamComponent = require( 'reader/following/main' ),
-			basePath = route.sectionify( context.path ),
+		const basePath = route.sectionify( context.path ),
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Following',
 			followingStore = feedStreamFactory( 'following' ),
 			mcKey = 'following';
@@ -180,8 +182,6 @@ const exported = {
 	},
 
 	feedDiscovery( context, next ) {
-		const feedLookup = require( 'lib/feed-lookup' );
-
 		if ( ! context.params.feed_id.match( /^\d+$/ ) ) {
 			feedLookup( context.params.feed_id )
 				.then( function( feedId ) {

--- a/client/reader/discover/controller.js
+++ b/client/reader/discover/controller.js
@@ -16,7 +16,7 @@ import AsyncLoad from 'components/async-load';
 
 const ANALYTICS_PAGE_TITLE = 'Reader';
 
-export default {
+const exported = {
 	discover( context ) {
 		const blogId = config( 'discover_blog_id' );
 		const basePath = route.sectionify( context.path );
@@ -60,3 +60,9 @@ export default {
 		);
 	}
 };
+
+export default exported;
+
+export const {
+    discover
+} = exported;

--- a/client/reader/discover/follow-button.jsx
+++ b/client/reader/discover/follow-button.jsx
@@ -8,7 +8,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import FollowButton from 'reader/follow-button';
-import * as discoverStats from './stats';
+import { recordFollowToggle } from './stats';
 
 class DiscoverFollowButton extends React.Component {
 
@@ -18,7 +18,7 @@ class DiscoverFollowButton extends React.Component {
 	}
 
 	recordFollowToggle = ( isFollowing ) => {
-		discoverStats.recordFollowToggle( isFollowing, this.props.siteUrl );
+		recordFollowToggle( isFollowing, this.props.siteUrl );
 	}
 
 	render() {

--- a/client/reader/discover/index.js
+++ b/client/reader/discover/index.js
@@ -6,16 +6,22 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import controller from './controller';
-import readerController from 'reader/controller';
+import { discover } from './controller';
+import {
+	initAbTests,
+	loadSubscriptions,
+	preloadReaderBundle,
+	sidebar,
+	updateLastRoute,
+} from 'reader/controller';
 
 export default function() {
 	page( '/discover',
-		readerController.preloadReaderBundle,
-		readerController.updateLastRoute,
-		readerController.loadSubscriptions,
-		readerController.initAbTests,
-		readerController.sidebar,
-		controller.discover
+		preloadReaderBundle,
+		updateLastRoute,
+		loadSubscriptions,
+		initAbTests,
+		sidebar,
+		discover
 	);
 }

--- a/client/reader/discover/post-attribution.jsx
+++ b/client/reader/discover/post-attribution.jsx
@@ -11,7 +11,11 @@ import Gridicon from 'gridicons';
 import { translate } from 'i18n-calypso';
 import FollowButton from 'reader/follow-button';
 import { getLinkProps } from './helper';
-import * as discoverStats from './stats';
+import {
+	recordAuthorClick,
+	recordFollowToggle,
+	recordSiteClick,
+} from './stats';
 
 class DiscoverPostAttribution extends React.Component {
 
@@ -36,15 +40,15 @@ class DiscoverPostAttribution extends React.Component {
 	}
 
 	recordAuthorClick( ) {
-		discoverStats.recordAuthorClick( this.props.attribution.author_url );
+		recordAuthorClick( this.props.attribution.author_url );
 	}
 
 	recordSiteClick( ) {
-		discoverStats.recordSiteClick( this.props.siteUrl );
+		recordSiteClick( this.props.siteUrl );
 	}
 
 	recordFollowToggle( isFollowing ) {
-		discoverStats.recordFollowToggle( isFollowing, this.props.siteUrl );
+		recordFollowToggle( isFollowing, this.props.siteUrl );
 	}
 
 	render() {

--- a/client/reader/discover/post-attribution.jsx
+++ b/client/reader/discover/post-attribution.jsx
@@ -76,4 +76,4 @@ class DiscoverPostAttribution extends React.Component {
 	}
 }
 
-module.exports = DiscoverPostAttribution;
+export default DiscoverPostAttribution;

--- a/client/reader/discover/site-attribution.jsx
+++ b/client/reader/discover/site-attribution.jsx
@@ -10,7 +10,10 @@ import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import FollowButton from 'reader/follow-button';
 import { getLinkProps } from './helper';
-import * as discoverStats from './stats';
+import {
+	recordFollowToggle,
+	recordSiteClick,
+} from './stats';
 
 class DiscoverSiteAttribution extends React.Component {
 
@@ -33,11 +36,11 @@ class DiscoverSiteAttribution extends React.Component {
 	}
 
 	recordSiteClick() {
-		discoverStats.recordSiteClick( this.props.siteUrl );
+		recordSiteClick( this.props.siteUrl );
 	}
 
 	recordFollowToggle( isFollowing ) {
-		discoverStats.recordFollowToggle( isFollowing, this.props.siteUrl );
+		recordFollowToggle( isFollowing, this.props.siteUrl );
 	}
 
 	render() {

--- a/client/reader/discover/site-attribution.jsx
+++ b/client/reader/discover/site-attribution.jsx
@@ -63,4 +63,4 @@ class DiscoverSiteAttribution extends React.Component {
 
 }
 
-module.exports = DiscoverSiteAttribution;
+export default DiscoverSiteAttribution;

--- a/client/reader/embed-helper.jsx
+++ b/client/reader/embed-helper.jsx
@@ -98,7 +98,7 @@ function resolveEmbedConfig( embed ) {
 	return embedsConfig.default;
 }
 
-module.exports = {
+export default {
 	getEmbedSizingFunction: function getEmbedSizingFunction( embed ) {
 		var embedConfig = resolveEmbedConfig( embed );
 

--- a/client/reader/embed-helper.jsx
+++ b/client/reader/embed-helper.jsx
@@ -98,10 +98,16 @@ function resolveEmbedConfig( embed ) {
 	return embedsConfig.default;
 }
 
-export default {
+const exported = {
 	getEmbedSizingFunction: function getEmbedSizingFunction( embed ) {
 		var embedConfig = resolveEmbedConfig( embed );
 
 		return embedConfig.sizingFunction.bind( embedConfig, embed );
 	}
 };
+
+export default exported;
+
+export const {
+    getEmbedSizingFunction
+} = exported;

--- a/client/reader/feed-stream/empty.jsx
+++ b/client/reader/feed-stream/empty.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 
 import EmptyContent from 'components/empty-content';
-import * as stats from 'reader/stats';
+import {
+	recordAction,
+	recordGaEvent,
+	recordTrack,
+} from 'reader/stats';
 
 const FeedEmptyContent = React.createClass( {
 	shouldComponentUpdate: function() {
@@ -9,15 +13,15 @@ const FeedEmptyContent = React.createClass( {
 	},
 
 	recordAction: function() {
-		stats.recordAction( 'clicked_search_on_empty' );
-		stats.recordGaEvent( 'Clicked Search on EmptyContent' );
-		stats.recordTrack( 'calypso_reader_search_on_empty_feed_clicked' );
+		recordAction( 'clicked_search_on_empty' );
+		recordGaEvent( 'Clicked Search on EmptyContent' );
+		recordTrack( 'calypso_reader_search_on_empty_feed_clicked' );
 	},
 
 	recordSecondaryAction: function() {
-		stats.recordAction( 'clicked_discover_on_empty' );
-		stats.recordGaEvent( 'Clicked Discover on EmptyContent' );
-		stats.recordTrack( 'calypso_reader_discover_on_empty_feed_clicked' );
+		recordAction( 'clicked_discover_on_empty' );
+		recordGaEvent( 'Clicked Discover on EmptyContent' );
+		recordTrack( 'calypso_reader_discover_on_empty_feed_clicked' );
 	},
 
 	render: function() {

--- a/client/reader/feed-stream/empty.jsx
+++ b/client/reader/feed-stream/empty.jsx
@@ -42,4 +42,4 @@ const FeedEmptyContent = React.createClass( {
 	}
 } );
 
-module.exports = FeedEmptyContent;
+export default FeedEmptyContent;

--- a/client/reader/feed-stream/empty.jsx
+++ b/client/reader/feed-stream/empty.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import EmptyContent from 'components/empty-content';
-import stats from 'reader/stats';
+import * as stats from 'reader/stats';
 
 const FeedEmptyContent = React.createClass( {
 	shouldComponentUpdate: function() {

--- a/client/reader/feed-stream/empty.jsx
+++ b/client/reader/feed-stream/empty.jsx
@@ -1,7 +1,7 @@
-const React = require( 'react' );
+import React from 'react';
 
-const EmptyContent = require( 'components/empty-content' ),
-	stats = require( 'reader/stats' );
+import EmptyContent from 'components/empty-content';
+import stats from 'reader/stats';
 
 const FeedEmptyContent = React.createClass( {
 	shouldComponentUpdate: function() {

--- a/client/reader/feed-stream/empty.jsx
+++ b/client/reader/feed-stream/empty.jsx
@@ -1,5 +1,12 @@
+/**
+ * External Dependencies
+ */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
+/**
+ * Internal Dependencies
+ */
 import EmptyContent from 'components/empty-content';
 import {
 	recordAction,
@@ -7,43 +14,41 @@ import {
 	recordTrack,
 } from 'reader/stats';
 
-const FeedEmptyContent = React.createClass( {
-	shouldComponentUpdate: function() {
-		return false;
-	},
+class FeedEmptyContent extends React.PureComponent {
 
-	recordAction: function() {
+	recordAction = () => {
 		recordAction( 'clicked_search_on_empty' );
 		recordGaEvent( 'Clicked Search on EmptyContent' );
 		recordTrack( 'calypso_reader_search_on_empty_feed_clicked' );
-	},
+	}
 
-	recordSecondaryAction: function() {
+	recordSecondaryAction = () => {
 		recordAction( 'clicked_discover_on_empty' );
 		recordGaEvent( 'Clicked Discover on EmptyContent' );
 		recordTrack( 'calypso_reader_discover_on_empty_feed_clicked' );
-	},
+	}
 
-	render: function() {
+	render() {
+		const translate = this.props.translate;
 		const action = <a
-				className="empty-content__action button is-primary"
+				className="empty-content__action button is-primary" //eslint-disable-line
 				onClick={ this.recordAction }
-				href="/read/search">{ this.translate( 'Find Sites to Follow' ) }</a>,
+				href="/read/search">{ translate( 'Find Sites to Follow' ) }</a>,
 			secondaryAction = (
 				<a
-					className="empty-content__action button"
+					className="empty-content__action button" //eslint-disable-line
 					onClick={ this.recordSecondaryAction }
-					href="/discover">{ this.translate( 'Explore Discover' ) }</a> );
+					href="/discover">{ translate( 'Explore Discover' ) }</a> );
 
 		return ( <EmptyContent
-			title={ this.translate( 'No recent posts' ) }
-			line={ this.translate( 'This site has not posted anything recently.' ) }
+			title={ translate( 'No recent posts' ) }
+			line={ translate( 'This site has not posted anything recently.' ) }
 			action={ action }
 			secondaryAction={ secondaryAction }
 			illustration={ '/calypso/images/drake/drake-empty-results.svg' }
 			illustrationWidth={ 500 }
 			/> );
 	}
-} );
+}
 
-export default FeedEmptyContent;
+export default localize( FeedEmptyContent );

--- a/client/reader/follow-button/follow-sources.jsx
+++ b/client/reader/follow-button/follow-sources.jsx
@@ -1,9 +1,20 @@
 /* Follow Source Constants */
-export default {
+const exported = {
 	IN_STREAM_RECOMMENDATION: 'in-stream-recommendation',
 	EMPTY_SEARCH_RECOMMENDATIONS: 'empty-search-rec',
 	SEARCH_RESULTS: 'search-results',
 	READER_SUBSCRIPTIONS: 'reader-subscriptions',
 	READER_FEED_SEARCH: 'reader-feed-search-result',
-	COMBINED_CARD: 'reader-combined-card',
+	COMBINED_CARD: 'reader-combined-card'
 };
+
+export default exported;
+
+export const {
+	IN_STREAM_RECOMMENDATION,
+	EMPTY_SEARCH_RECOMMENDATIONS,
+	SEARCH_RESULTS,
+	READER_SUBSCRIPTIONS,
+	READER_FEED_SEARCH,
+	COMBINED_CARD
+} = exported;

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -34,7 +34,12 @@ import FollowingImportButton from './import-button';
 import FeedDisplayHelper from 'reader/lib/feed-display-helper';
 import SectionHeader from 'components/section-header';
 import Button from 'components/button';
-import * as stats from 'reader/stats';
+import {
+	recordAction,
+	recordFollow,
+	recordGaEvent,
+	recordTrack,
+} from 'reader/stats';
 
 const initialLoadFeedCount = 20;
 
@@ -300,9 +305,9 @@ const FollowingEdit = React.createClass( {
 		// Call originating store and mark error as dismissed
 		FeedSubscriptionActions.dismissError( this.state.lastError );
 		this.setState( { isAttemptingFollow: false } );
-		stats.recordAction( 'dismiss_follow_error' );
-		stats.recordGaEvent( 'Clicked Dismiss Follow Error' );
-		stats.recordTrack( 'calypso_reader_follow_error_dismissed' );
+		recordAction( 'dismiss_follow_error' );
+		recordGaEvent( 'Clicked Dismiss Follow Error' );
+		recordTrack( 'calypso_reader_follow_error_dismissed' );
 	},
 
 	handleNewSubscriptionSearch: function( searchString ) {
@@ -359,7 +364,7 @@ const FollowingEdit = React.createClass( {
 	handleFollow: function( newUrl ) {
 		this.toggleAddSite();
 		this.setState( { isAttemptingFollow: true } );
-		stats.recordFollow( newUrl );
+		recordFollow( newUrl );
 	},
 
 	renderUnfollowError: function() {

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -34,7 +34,7 @@ import FollowingImportButton from './import-button';
 import FeedDisplayHelper from 'reader/lib/feed-display-helper';
 import SectionHeader from 'components/section-header';
 import Button from 'components/button';
-const stats = require( 'reader/stats' );
+import stats from 'reader/stats';
 
 const initialLoadFeedCount = 20;
 

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -34,7 +34,7 @@ import FollowingImportButton from './import-button';
 import FeedDisplayHelper from 'reader/lib/feed-display-helper';
 import SectionHeader from 'components/section-header';
 import Button from 'components/button';
-import stats from 'reader/stats';
+import * as stats from 'reader/stats';
 
 const initialLoadFeedCount = 20;
 

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -595,4 +595,4 @@ const FollowingEdit = React.createClass( {
 
 } );
 
-module.exports = FollowingEdit;
+export default FollowingEdit;

--- a/client/reader/following-edit/list-item.jsx
+++ b/client/reader/following-edit/list-item.jsx
@@ -1,27 +1,27 @@
 /**
  * External dependencies
  */
-const React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' ),
-	noop = require( 'lodash/noop' );
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
+import noop from 'lodash/noop';
 
 /**
  * Internal dependencies
  */
-const Icon = require( 'reader/list-item/icon' ),
-	Title = require( 'reader/list-item/title' ),
-	Description = require( 'reader/list-item/description' ),
-	Actions = require( 'reader/list-item/actions' ),
-	FeedDisplayHelper = require( 'reader/lib/feed-display-helper' ),
-	decodeEntities = require( 'lib/formatting' ).decodeEntities,
-	FeedSubscriptionActions = require( 'lib/reader-feed-subscriptions/actions' ),
-	ReaderFollowButton = require( 'reader/follow-button' ),
-	SubscriptionStates = require( 'lib/reader-feed-subscriptions/constants' ).state,
-	FollowingEditNotificationSettings = require( './notification-settings' ),
-	FoldableCard = require( 'components/foldable-card' ),
-	SiteStore = require( 'lib/reader-site-store' ),
-	FeedStore = require( 'lib/feed-store' ),
-	smartSetState = require( 'lib/react-smart-set-state' );
+import Icon from 'reader/list-item/icon';
+import Title from 'reader/list-item/title';
+import Description from 'reader/list-item/description';
+import Actions from 'reader/list-item/actions';
+import FeedDisplayHelper from 'reader/lib/feed-display-helper';
+import { decodeEntities } from 'lib/formatting';
+import FeedSubscriptionActions from 'lib/reader-feed-subscriptions/actions';
+import ReaderFollowButton from 'reader/follow-button';
+import { state as SubscriptionStates } from 'lib/reader-feed-subscriptions/constants';
+import FollowingEditNotificationSettings from './notification-settings';
+import FoldableCard from 'components/foldable-card';
+import SiteStore from 'lib/reader-site-store';
+import FeedStore from 'lib/feed-store';
+import smartSetState from 'lib/react-smart-set-state';
 
 import ExternalLink from 'components/external-link';
 

--- a/client/reader/following-edit/list-item.jsx
+++ b/client/reader/following-edit/list-item.jsx
@@ -135,4 +135,4 @@ const SubscriptionListItem = React.createClass( {
 
 } );
 
-module.exports = SubscriptionListItem;
+export default SubscriptionListItem;

--- a/client/reader/following-edit/navigation.jsx
+++ b/client/reader/following-edit/navigation.jsx
@@ -30,4 +30,4 @@ var FollowingEditNavigation = React.createClass( {
 	}
 } );
 
-module.exports = FollowingEditNavigation;
+export default FollowingEditNavigation;

--- a/client/reader/following-edit/navigation.jsx
+++ b/client/reader/following-edit/navigation.jsx
@@ -1,5 +1,5 @@
 // External dependencies
-var React = require( 'react' );
+import React from 'react';
 
 var FollowingEditNavigation = React.createClass( {
 

--- a/client/reader/following-edit/navigation.jsx
+++ b/client/reader/following-edit/navigation.jsx
@@ -1,4 +1,6 @@
-// External dependencies
+/**
+ * External dependencies
+ */
 import React from 'react';
 
 var FollowingEditNavigation = React.createClass( {

--- a/client/reader/following-edit/notification-settings.jsx
+++ b/client/reader/following-edit/notification-settings.jsx
@@ -1,20 +1,20 @@
 //const debug = require( 'debug' )( 'calypso:reader:following:edit' );
 
 // External dependencies
-const React = require( 'react' ),
-	classnames = require( 'classnames' );
+import React from 'react';
+import classnames from 'classnames';
 
 // Internal dependencies
-const Card = require( 'components/card' ),
-	FormToggle = require( 'components/forms/form-toggle' ),
-	SegmentedControl = require( 'components/segmented-control' ),
-	ControlItem = require( 'components/segmented-control/item' ),
-	PostEmailSubscriptionStore = require( 'lib/reader-post-email-subscriptions' ),
-	CommentEmailSubscriptionStore = require( 'lib/reader-comment-email-subscriptions' ),
-	PostEmailSubscriptionActions = require( 'lib/reader-post-email-subscriptions/actions' ),
-	CommentEmailSubscriptionActions = require( 'lib/reader-comment-email-subscriptions/actions' ),
-	FormInputValidation = require( 'components/forms/form-input-validation' ),
-	smartSetState = require( 'lib/react-smart-set-state' );
+import Card from 'components/card';
+import FormToggle from 'components/forms/form-toggle';
+import SegmentedControl from 'components/segmented-control';
+import ControlItem from 'components/segmented-control/item';
+import PostEmailSubscriptionStore from 'lib/reader-post-email-subscriptions';
+import CommentEmailSubscriptionStore from 'lib/reader-comment-email-subscriptions';
+import PostEmailSubscriptionActions from 'lib/reader-post-email-subscriptions/actions';
+import CommentEmailSubscriptionActions from 'lib/reader-comment-email-subscriptions/actions';
+import FormInputValidation from 'components/forms/form-input-validation';
+import smartSetState from 'lib/react-smart-set-state';
 
 const DELIVERY_FREQUENCY_INSTANTLY = 'instantly',
 	DELIVERY_FREQUENCY_DAILY = 'daily',

--- a/client/reader/following-edit/notification-settings.jsx
+++ b/client/reader/following-edit/notification-settings.jsx
@@ -191,4 +191,4 @@ var FollowingEditNotificationSettings = React.createClass( {
 
 } );
 
-module.exports = FollowingEditNotificationSettings;
+export default FollowingEditNotificationSettings;

--- a/client/reader/following-edit/notification-settings.jsx
+++ b/client/reader/following-edit/notification-settings.jsx
@@ -1,10 +1,12 @@
-//const debug = require( 'debug' )( 'calypso:reader:following:edit' );
-
-// External dependencies
+/**
+ * External dependencies
+ */
 import React from 'react';
 import classnames from 'classnames';
 
-// Internal dependencies
+/**
+ * Internal dependencies
+ */
 import Card from 'components/card';
 import FormToggle from 'components/forms/form-toggle';
 import SegmentedControl from 'components/segmented-control';

--- a/client/reader/following-edit/placeholder.jsx
+++ b/client/reader/following-edit/placeholder.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import Card from 'components/card';
 import SiteIcon from 'blocks/site-icon';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 
 	displayName: 'SubscriptionPlaceholder',
 

--- a/client/reader/following-edit/placeholder.jsx
+++ b/client/reader/following-edit/placeholder.jsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
-var Card = require( 'components/card' );
-var SiteIcon = require( 'blocks/site-icon' );
+import Card from 'components/card';
+import SiteIcon from 'blocks/site-icon';
 
 module.exports = React.createClass( {
 

--- a/client/reader/following-edit/placeholder.jsx
+++ b/client/reader/following-edit/placeholder.jsx
@@ -1,25 +1,29 @@
 /**
- * External dependencies
+ * External Dependencies
  */
 import React from 'react';
+
+/**
+ * Intenal Dependencies
+ */
 
 import Card from 'components/card';
 import SiteIcon from 'blocks/site-icon';
 
-export default React.createClass( {
+export default class SubscriptionPlaceholder extends React.PureComponent {
 
-	displayName: 'SubscriptionPlaceholder',
+	static displayName = 'SubscriptionPlaceholder'
 
-	render: function() {
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	render() {
 		return (
 			<Card className="is-compact reader-list-item__card is-placeholder">
 				<span className="reader-list-item__icon">
 					<SiteIcon size={ 48 } />
 				</span>
-
 				<h2 className="reader-list-item__title"><span className="placeholder-text">Title</span></h2>
 				<p className="reader-list-item__description"><span className="placeholder-text">URL</span></p>
 			</Card>
 			);
 	}
-} );
+}

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -1,12 +1,12 @@
 // External dependencies
-const React = require( 'react' ),
-	url = require( 'url' ),
-	noop = require( 'lodash/noop' );
+import React from 'react';
+import url from 'url';
+import noop from 'lodash/noop';
 
 // Internal dependencies
-const SearchCard = require( 'components/search-card' ),
-	FollowingEditSubscribeFormResult = require( './subscribe-form-result' ),
-	FeedSubscriptionActions = require( 'lib/reader-feed-subscriptions/actions' );
+import SearchCard from 'components/search-card';
+import FollowingEditSubscribeFormResult from './subscribe-form-result';
+import FeedSubscriptionActions from 'lib/reader-feed-subscriptions/actions';
 
 const minSearchLength = 8; // includes protocol
 

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -158,4 +158,4 @@ var FollowingEditSubscribeForm = React.createClass( {
 
 } );
 
-module.exports = FollowingEditSubscribeForm;
+export default FollowingEditSubscribeForm;

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -1,9 +1,13 @@
-// External dependencies
+/**
+ * External dependencies
+ */
 import React from 'react';
 import url from 'url';
 import noop from 'lodash/noop';
 
-// Internal dependencies
+/**
+ * Internal dependencies
+ */
 import SearchCard from 'components/search-card';
 import FollowingEditSubscribeFormResult from './subscribe-form-result';
 import FeedSubscriptionActions from 'lib/reader-feed-subscriptions/actions';

--- a/client/reader/following/controller.js
+++ b/client/reader/following/controller.js
@@ -15,7 +15,7 @@ import AsyncLoad from 'components/async-load';
 
 const analyticsPageTitle = 'Reader';
 
-export default {
+const exported = {
 	followingEdit( context ) {
 		const basePath = route.sectionify( context.path ),
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Manage Followed Sites',
@@ -64,3 +64,10 @@ export default {
 		);
 	}
 };
+
+export default exported;
+
+export const {
+    followingEdit,
+    followingManage
+} = exported;

--- a/client/reader/following/index.js
+++ b/client/reader/following/index.js
@@ -6,14 +6,22 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import controller from './controller';
-import readerController from 'reader/controller';
+import {
+	followingEdit,
+	followingManage,
+} from './controller';
+import {
+	loadSubscriptions,
+	initAbTests,
+	updateLastRoute,
+	sidebar,
+} from 'reader/controller';
 import config from 'config';
 
 export default function() {
-	page( '/following/*', readerController.loadSubscriptions, readerController.initAbTests );
-	page( '/following/edit', readerController.updateLastRoute, readerController.sidebar, controller.followingEdit );
+	page( '/following/*', loadSubscriptions, initAbTests );
+	page( '/following/edit', updateLastRoute, sidebar, followingEdit );
 	if ( config.isEnabled( 'reader/following-manage-refresh' ) ) {
-		page( '/following/manage', readerController.updateLastRoute, readerController.sidebar, controller.followingManage );
+		page( '/following/manage', updateLastRoute, sidebar, followingManage );
 	}
 }

--- a/client/reader/full-post/index.js
+++ b/client/reader/full-post/index.js
@@ -7,20 +7,24 @@ import page from 'page';
  * Internal dependencies
  */
 import { blogPost, feedPost } from './controller';
-import readerController from 'reader/controller';
+import {
+	legacyRedirects,
+	updateLastRoute,
+	unmountSidebar,
+} from 'reader/controller';
 
 export default function() {
 	// Feed full post
-	page( '/read/post/feed/:feed_id/:post_id', readerController.legacyRedirects );
+	page( '/read/post/feed/:feed_id/:post_id', legacyRedirects );
 	page( '/read/feeds/:feed/posts/:post',
-		readerController.updateLastRoute,
-		readerController.unmountSidebar,
+		updateLastRoute,
+		unmountSidebar,
 		feedPost );
 
 	// Blog full post
-	page( '/read/post/id/:blog_id/:post_id', readerController.legacyRedirects );
+	page( '/read/post/id/:blog_id/:post_id', legacyRedirects );
 	page( '/read/blogs/:blog/posts/:post',
-		readerController.updateLastRoute,
-		readerController.unmountSidebar,
+		updateLastRoute,
+		unmountSidebar,
 		blogPost );
 }

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -14,7 +14,7 @@ function forceTeamA8C( context, next ) {
 	next();
 }
 
-module.exports = function() {
+export default function() {
 	if ( config.isEnabled( 'reader' ) ) {
 		page( '/',
 			controller.preloadReaderBundle,

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -6,7 +6,21 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import controller from './controller';
+import {
+	blogListing,
+	feedDiscovery,
+	feedListing,
+	following,
+	incompleteUrlRedirects,
+	initAbTests,
+	legacyRedirects,
+	loadSubscriptions,
+	preloadReaderBundle,
+	prettyRedirects,
+	readA8C,
+	sidebar,
+	updateLastRoute,
+} from './controller';
 import config from 'config';
 
 function forceTeamA8C( context, next ) {
@@ -17,12 +31,12 @@ function forceTeamA8C( context, next ) {
 export default function() {
 	if ( config.isEnabled( 'reader' ) ) {
 		page( '/',
-			controller.preloadReaderBundle,
-			controller.loadSubscriptions,
-			controller.initAbTests,
-			controller.updateLastRoute,
-			controller.sidebar,
-			controller.following );
+			preloadReaderBundle,
+			loadSubscriptions,
+			initAbTests,
+			updateLastRoute,
+			sidebar,
+			following );
 
 		// Old and incomplete paths that should be redirected to /
 		page( '/read/following', '/' );
@@ -34,26 +48,26 @@ export default function() {
 		page( '/read/feed', '/' );
 
 		// Feed stream
-		page( '/read/*', controller.preloadReaderBundle, controller.loadSubscriptions, controller.initAbTests );
-		page( '/read/blog/feed/:feed_id', controller.legacyRedirects );
-		page( '/read/feeds/:feed_id/posts', controller.incompleteUrlRedirects );
+		page( '/read/*', preloadReaderBundle, loadSubscriptions, initAbTests );
+		page( '/read/blog/feed/:feed_id', legacyRedirects );
+		page( '/read/feeds/:feed_id/posts', incompleteUrlRedirects );
 		page( '/read/feeds/:feed_id',
-			controller.updateLastRoute,
-			controller.prettyRedirects,
-			controller.sidebar,
-			controller.feedDiscovery,
-			controller.feedListing );
+			updateLastRoute,
+			prettyRedirects,
+			sidebar,
+			feedDiscovery,
+			feedListing );
 
 		// Blog stream
-		page( '/read/blog/id/:blog_id', controller.legacyRedirects );
-		page( '/read/blogs/:blog_id/posts', controller.incompleteUrlRedirects );
+		page( '/read/blog/id/:blog_id', legacyRedirects );
+		page( '/read/blogs/:blog_id/posts', incompleteUrlRedirects );
 		page( '/read/blogs/:blog_id',
-			controller.updateLastRoute,
-			controller.prettyRedirects,
-			controller.sidebar,
-			controller.blogListing );
+			updateLastRoute,
+			prettyRedirects,
+			sidebar,
+			blogListing );
 	}
 
 	// Automattic Employee Posts
-	page( '/read/a8c', controller.updateLastRoute, controller.sidebar, forceTeamA8C, controller.readA8C );
+	page( '/read/a8c', updateLastRoute, sidebar, forceTeamA8C, readA8C );
 };

--- a/client/reader/lib/feed-display-helper/index.js
+++ b/client/reader/lib/feed-display-helper/index.js
@@ -1,7 +1,7 @@
 import { getSiteUrl, getFeedUrl } from 'reader/route';
 import { withoutHttp } from 'lib/url';
 
-module.exports = {
+export default {
 	formatUrlForDisplay: function( url ) {
 		if ( ! url ) {
 			return;

--- a/client/reader/lib/feed-display-helper/index.js
+++ b/client/reader/lib/feed-display-helper/index.js
@@ -1,7 +1,7 @@
-import { getSiteUrl, getFeedUrl } from 'reader/route';
+import { getSiteUrl as getSiteUrlFromRoute, getFeedUrl } from 'reader/route';
 import { withoutHttp } from 'lib/url';
 
-export default {
+const exported = {
 	formatUrlForDisplay: function( url ) {
 		if ( ! url ) {
 			return;
@@ -34,7 +34,7 @@ export default {
 			return getFeedUrl( feedData.feed_ID );
 		}
 
-		return getSiteUrl( siteData.get( 'ID' ) );
+		return getSiteUrlFromRoute( siteData.get( 'ID' ) );
 	},
 
 	getSiteUrl: function( siteData, feedData, subscription ) {
@@ -51,3 +51,12 @@ export default {
 		return siteUrl;
 	}
 };
+
+export default exported;
+
+export const {
+    formatUrlForDisplay,
+    getFeedTitle,
+    getFeedStreamUrl,
+    getSiteUrl
+} = exported;

--- a/client/reader/lib/feed-display-helper/index.js
+++ b/client/reader/lib/feed-display-helper/index.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { getSiteUrl as getSiteUrlFromRoute, getFeedUrl } from 'reader/route';
 import { withoutHttp } from 'lib/url';
 

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -32,4 +32,4 @@ const ReaderLikeButton = React.createClass( {
 
 } );
 
-module.exports = ReaderLikeButton;
+export default ReaderLikeButton;

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -1,9 +1,9 @@
-const React = require( 'react' );
+import React from 'react';
 
-const postStore = require( 'lib/feed-post-store' );
+import postStore from 'lib/feed-post-store';
 
-const LikeButtonContainer = require( 'blocks/like-button' );
-const { markSeen } = require( 'lib/feed-post-store/actions' );
+import LikeButtonContainer from 'blocks/like-button';
+import { markSeen } from 'lib/feed-post-store/actions';
 
 import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
 

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -1,10 +1,14 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
 
+/**
+ * Internal dependencies
+ */
 import postStore from 'lib/feed-post-store';
-
 import LikeButtonContainer from 'blocks/like-button';
 import { markSeen } from 'lib/feed-post-store/actions';
-
 import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
 
 const ReaderLikeButton = React.createClass( {

--- a/client/reader/like-helper.jsx
+++ b/client/reader/like-helper.jsx
@@ -1,7 +1,7 @@
 // Internal dependencies
 import { isDiscoverPost, isInternalDiscoverPost, isDiscoverSitePick } from 'reader/discover/helper';
 
-export default {
+const exported = {
 	shouldShowLikes( post ) {
 		let showLikes = false;
 		if ( isDiscoverPost( post ) ) {
@@ -15,3 +15,9 @@ export default {
 		return showLikes;
 	}
 };
+
+export default exported;
+
+export const {
+    shouldShowLikes
+} = exported;

--- a/client/reader/liked-stream/controller.js
+++ b/client/reader/liked-stream/controller.js
@@ -13,7 +13,7 @@ import { renderWithReduxStore } from 'lib/react-helpers';
 
 const analyticsPageTitle = 'Reader';
 
-export default {
+const exported = {
 	likes( context ) {
 		var LikedPostsStream = require( 'reader/liked-stream/main' ),
 			basePath = route.sectionify( context.path ),
@@ -43,3 +43,9 @@ export default {
 		);
 	}
 };
+
+export default exported;
+
+export const {
+    likes
+} = exported;

--- a/client/reader/liked-stream/controller.js
+++ b/client/reader/liked-stream/controller.js
@@ -9,14 +9,14 @@ import React from 'react';
 import route from 'lib/route';
 import feedStreamFactory from 'lib/feed-stream-store';
 import { ensureStoreLoading, trackPageLoad, trackUpdatesLoaded, trackScrollPage } from 'reader/controller-helper';
+import LikedPostsStream from 'reader/liked-stream/main';
 import { renderWithReduxStore } from 'lib/react-helpers';
 
 const analyticsPageTitle = 'Reader';
 
 const exported = {
 	likes( context ) {
-		var LikedPostsStream = require( 'reader/liked-stream/main' ),
-			basePath = route.sectionify( context.path ),
+		const basePath = route.sectionify( context.path ),
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > My Likes',
 			likedPostsStore = feedStreamFactory( 'likes' ),
 			mcKey = 'postlike';

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -7,8 +7,12 @@ import React from 'react';
  * Internal dependencies
  */
 import EmptyContent from 'components/empty-content';
-import * as stats from 'reader/stats';
-import * as discoverHelper from 'reader/discover/helper';
+import {
+	recordAction,
+	recordGaEvent,
+	recordTrack,
+} from 'reader/stats';
+import { isDiscoverEnabled } from 'reader/discover/helper';
 
 var TagEmptyContent = React.createClass( {
 	shouldComponentUpdate: function() {
@@ -16,15 +20,15 @@ var TagEmptyContent = React.createClass( {
 	},
 
 	recordAction: function() {
-		stats.recordAction( 'clicked_following_on_empty_likes' );
-		stats.recordGaEvent( 'Clicked Following on Empty Like Stream' );
-		stats.recordTrack( 'calypso_reader_following_on_empty_like_stream_clicked' );
+		recordAction( 'clicked_following_on_empty_likes' );
+		recordGaEvent( 'Clicked Following on Empty Like Stream' );
+		recordTrack( 'calypso_reader_following_on_empty_like_stream_clicked' );
 	},
 
 	recordSecondaryAction: function() {
-		stats.recordAction( 'clicked_discover_on_empty_likes' );
-		stats.recordGaEvent( 'Clicked Discover on Empty Like Stream' );
-		stats.recordTrack( 'calypso_reader_discover_on_empty_like_stream_clicked' );
+		recordAction( 'clicked_discover_on_empty_likes' );
+		recordGaEvent( 'Clicked Discover on Empty Like Stream' );
+		recordTrack( 'calypso_reader_discover_on_empty_like_stream_clicked' );
 	},
 
 	render: function() {
@@ -32,7 +36,7 @@ var TagEmptyContent = React.createClass( {
 			className="empty-content__action button is-primary"
 			onClick={ this.recordAction }
 			href="/">{ this.translate( 'Back to Following' ) }</a> ),
-			secondaryAction = discoverHelper.isDiscoverEnabled()
+			secondaryAction = isDiscoverEnabled()
 			? ( <a
 				className="empty-content__action button"
 				onClick={ this.recordSecondaryAction }

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -43,4 +43,4 @@ var TagEmptyContent = React.createClass( {
 	}
 } );
 
-module.exports = TagEmptyContent;
+export default TagEmptyContent;

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -1,8 +1,8 @@
-var React = require( 'react' );
+import React from 'react';
 
-var EmptyContent = require( 'components/empty-content' ),
-	stats = require( 'reader/stats' ),
-	discoverHelper = require( 'reader/discover/helper' );
+import EmptyContent from 'components/empty-content';
+import stats from 'reader/stats';
+import discoverHelper from 'reader/discover/helper';
 
 var TagEmptyContent = React.createClass( {
 	shouldComponentUpdate: function() {

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -1,8 +1,14 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
 
+/**
+ * Internal dependencies
+ */
 import EmptyContent from 'components/empty-content';
-import stats from 'reader/stats';
-import discoverHelper from 'reader/discover/helper';
+import * as stats from 'reader/stats';
+import * as discoverHelper from 'reader/discover/helper';
 
 var TagEmptyContent = React.createClass( {
 	shouldComponentUpdate: function() {

--- a/client/reader/liked-stream/index.js
+++ b/client/reader/liked-stream/index.js
@@ -6,16 +6,24 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import controller from './controller';
-import readerController from 'reader/controller';
+import {
+	likes
+} from './controller';
+import {
+	preloadReaderBundle,
+	loadSubscriptions,
+	initAbTests,
+	updateLastRoute,
+	sidebar,
+} from 'reader/controller';
 
 export default function() {
 	page( '/activities/likes',
-		readerController.preloadReaderBundle,
-		readerController.loadSubscriptions,
-		readerController.initAbTests,
-		readerController.updateLastRoute,
-		readerController.sidebar,
-		controller.likes
+		preloadReaderBundle,
+		loadSubscriptions,
+		initAbTests,
+		updateLastRoute,
+		sidebar,
+		likes
 	);
 }

--- a/client/reader/liked-stream/main.jsx
+++ b/client/reader/liked-stream/main.jsx
@@ -1,8 +1,8 @@
-var React = require( 'react' );
+import React from 'react';
 
-var Stream = require( 'reader/stream' ),
-	EmptyContent = require( './empty' ),
-	DocumentHead = require( 'components/data/document-head' );
+import Stream from 'reader/stream';
+import EmptyContent from './empty';
+import DocumentHead from 'components/data/document-head';
 
 var LikedStream = React.createClass( {
 

--- a/client/reader/liked-stream/main.jsx
+++ b/client/reader/liked-stream/main.jsx
@@ -19,4 +19,4 @@ var LikedStream = React.createClass( {
 
 } );
 
-module.exports = LikedStream;
+export default LikedStream;

--- a/client/reader/liked-stream/main.jsx
+++ b/client/reader/liked-stream/main.jsx
@@ -1,5 +1,11 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
 
+/**
+ * Internal dependencies
+ */
 import Stream from 'reader/stream';
 import EmptyContent from './empty';
 import DocumentHead from 'components/data/document-head';

--- a/client/reader/list-stream/empty.jsx
+++ b/client/reader/list-stream/empty.jsx
@@ -7,8 +7,12 @@ import React from 'react';
  * Internal dependencies
  */
 import EmptyContent from 'components/empty-content';
-import * as stats from 'reader/stats';
-import * as discoverHelper from 'reader/discover/helper';
+import {
+	recordAction,
+	recordGaEvent,
+	recordTrack,
+} from 'reader/stats';
+import { isDiscoverEnabled } from 'reader/discover/helper';
 
 var ListEmptyContent = React.createClass( {
 	shouldComponentUpdate: function() {
@@ -16,15 +20,15 @@ var ListEmptyContent = React.createClass( {
 	},
 
 	recordAction: function() {
-		stats.recordAction( 'clicked_following_on_empty' );
-		stats.recordGaEvent( 'Clicked Following on EmptyContent' );
-		stats.recordTrack( 'calypso_reader_following_on_empty_list_stream_clicked' );
+		recordAction( 'clicked_following_on_empty' );
+		recordGaEvent( 'Clicked Following on EmptyContent' );
+		recordTrack( 'calypso_reader_following_on_empty_list_stream_clicked' );
 	},
 
 	recordSecondaryAction: function() {
-		stats.recordAction( 'clicked_discover_on_empty' );
-		stats.recordGaEvent( 'Clicked Discover on EmptyContent' );
-		stats.recordTrack( 'calypso_reader_discover_on_empty_list_stream_clicked' );
+		recordAction( 'clicked_discover_on_empty' );
+		recordGaEvent( 'Clicked Discover on EmptyContent' );
+		recordTrack( 'calypso_reader_discover_on_empty_list_stream_clicked' );
 	},
 
 	render: function() {
@@ -32,7 +36,7 @@ var ListEmptyContent = React.createClass( {
 			className="empty-content__action button is-primary"
 			onClick={ this.recordAction }
 			href="/">{ this.translate( 'Back to Following' ) }</a> ),
-			secondaryAction = discoverHelper.isDiscoverEnabled()
+			secondaryAction = isDiscoverEnabled()
 			? ( <a
 				className="empty-content__action button"
 				onClick={ this.recordSecondaryAction }

--- a/client/reader/list-stream/empty.jsx
+++ b/client/reader/list-stream/empty.jsx
@@ -1,8 +1,14 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
 
+/**
+ * Internal dependencies
+ */
 import EmptyContent from 'components/empty-content';
-import stats from 'reader/stats';
-import discoverHelper from 'reader/discover/helper';
+import * as stats from 'reader/stats';
+import * as discoverHelper from 'reader/discover/helper';
 
 var ListEmptyContent = React.createClass( {
 	shouldComponentUpdate: function() {

--- a/client/reader/list-stream/empty.jsx
+++ b/client/reader/list-stream/empty.jsx
@@ -43,4 +43,4 @@ var ListEmptyContent = React.createClass( {
 	}
 } );
 
-module.exports = ListEmptyContent;
+export default ListEmptyContent;

--- a/client/reader/list-stream/empty.jsx
+++ b/client/reader/list-stream/empty.jsx
@@ -1,8 +1,8 @@
-var React = require( 'react' );
+import React from 'react';
 
-var EmptyContent = require( 'components/empty-content' ),
-	stats = require( 'reader/stats' ),
-	discoverHelper = require( 'reader/discover/helper' );
+import EmptyContent from 'components/empty-content';
+import stats from 'reader/stats';
+import discoverHelper from 'reader/discover/helper';
 
 var ListEmptyContent = React.createClass( {
 	shouldComponentUpdate: function() {

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -16,7 +16,11 @@ import ListStreamHeader from './header';
 import { followList, unfollowList } from 'state/reader/lists/actions';
 import { getListByOwnerAndSlug, isSubscribedByOwnerAndSlug, isMissingByOwnerAndSlug } from 'state/reader/lists/selectors';
 import QueryReaderList from 'components/data/query-reader-list';
-import * as stats from 'reader/stats';
+import {
+	recordAction,
+	recordGaEvent,
+	recordTrack,
+} from 'reader/stats';
 
 const ListStream = React.createClass( {
 
@@ -29,9 +33,9 @@ const ListStream = React.createClass( {
 			this.props.unfollowList( list.owner, list.slug );
 		}
 
-		stats.recordAction( isFollowRequested ? 'followed_list' : 'unfollowed_list' );
-		stats.recordGaEvent( isFollowRequested ? 'Clicked Follow List' : 'Clicked Unfollow List', list.owner + ':' + list.slug );
-		stats.recordTrack( isFollowRequested ? 'calypso_reader_reader_list_followed' : 'calypso_reader_reader_list_unfollowed', {
+		recordAction( isFollowRequested ? 'followed_list' : 'unfollowed_list' );
+		recordGaEvent( isFollowRequested ? 'Clicked Follow List' : 'Clicked Unfollow List', list.owner + ':' + list.slug );
+		recordTrack( isFollowRequested ? 'calypso_reader_reader_list_followed' : 'calypso_reader_reader_list_unfollowed', {
 			list_owner: list.owner,
 			list_slug: list.slug
 		} );

--- a/client/reader/list-stream/missing.jsx
+++ b/client/reader/list-stream/missing.jsx
@@ -10,7 +10,11 @@ import EmptyContent from 'components/empty-content';
 import { isDiscoverEnabled } from 'reader/discover/helper';
 import QueryReaderList from 'components/data/query-reader-list';
 
-import * as stats from 'reader/stats';
+import {
+	recordAction,
+	recordGaEvent,
+	recordTrack,
+} from 'reader/stats';
 
 const ListMissing = React.createClass( {
 
@@ -20,15 +24,15 @@ const ListMissing = React.createClass( {
 	},
 
 	recordAction() {
-		stats.recordAction( 'clicked_following_on_empty' );
-		stats.recordGaEvent( 'Clicked Following on EmptyContent' );
-		stats.recordTrack( 'calypso_reader_following_on_missing_list_clicked' );
+		recordAction( 'clicked_following_on_empty' );
+		recordGaEvent( 'Clicked Following on EmptyContent' );
+		recordTrack( 'calypso_reader_following_on_missing_list_clicked' );
 	},
 
 	recordSecondaryAction() {
-		stats.recordAction( 'clicked_discover_on_empty' );
-		stats.recordGaEvent( 'Clicked Discover on EmptyContent' );
-		stats.recordTrack( 'calypso_reader_discover_on_missing_list_clicked' );
+		recordAction( 'clicked_discover_on_empty' );
+		recordGaEvent( 'Clicked Discover on EmptyContent' );
+		recordTrack( 'calypso_reader_discover_on_missing_list_clicked' );
 	},
 
 	render() {

--- a/client/reader/list-stream/missing.jsx
+++ b/client/reader/list-stream/missing.jsx
@@ -10,7 +10,7 @@ import EmptyContent from 'components/empty-content';
 import { isDiscoverEnabled } from 'reader/discover/helper';
 import QueryReaderList from 'components/data/query-reader-list';
 
-import stats from 'reader/stats';
+import * as stats from 'reader/stats';
 
 const ListMissing = React.createClass( {
 

--- a/client/reader/list-stream/missing.jsx
+++ b/client/reader/list-stream/missing.jsx
@@ -10,7 +10,7 @@ import EmptyContent from 'components/empty-content';
 import { isDiscoverEnabled } from 'reader/discover/helper';
 import QueryReaderList from 'components/data/query-reader-list';
 
-const stats = require( 'reader/stats' );
+import stats from 'reader/stats';
 
 const ListMissing = React.createClass( {
 

--- a/client/reader/list/controller.js
+++ b/client/reader/list/controller.js
@@ -14,7 +14,7 @@ import AsyncLoad from 'components/async-load';
 
 const analyticsPageTitle = 'Reader';
 
-export default {
+const exported = {
 	listListing( context ) {
 		const basePath = '/read/list/:owner/:slug',
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > List > ' + context.params.user + ' - ' + context.params.list,
@@ -50,3 +50,9 @@ export default {
 		);
 	}
 };
+
+export default exported;
+
+export const {
+    listListing
+} = exported;

--- a/client/reader/list/index.js
+++ b/client/reader/list/index.js
@@ -6,9 +6,14 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import controller from './controller';
-import readerController from 'reader/controller';
+import {
+	listListing,
+} from './controller';
+import {
+	sidebar,
+	updateLastRoute,
+} from 'reader/controller';
 
 export default function() {
-	page( '/read/list/:user/:list', readerController.updateLastRoute, readerController.sidebar, controller.listListing );
+	page( '/read/list/:user/:list', updateLastRoute, sidebar, listListing );
 }

--- a/client/reader/reading-time/index.jsx
+++ b/client/reader/reading-time/index.jsx
@@ -36,4 +36,4 @@ var ReadingTime = React.createClass( {
 
 } );
 
-module.exports = ReadingTime;
+export default ReadingTime;

--- a/client/reader/reading-time/index.jsx
+++ b/client/reader/reading-time/index.jsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' );
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 var ReadingTime = React.createClass( {
 

--- a/client/reader/recommendations/controller.js
+++ b/client/reader/recommendations/controller.js
@@ -16,7 +16,7 @@ import { renderWithReduxStore } from 'lib/react-helpers';
 
 const ANALYTICS_PAGE_TITLE = 'Reader';
 
-export default {
+const exported = {
 	recommendedForYou( context ) {
 		const RecommendedForYou = require( 'reader/recommendations/for-you' ),
 			basePath = '/recommendations',
@@ -105,3 +105,10 @@ export default {
 		);
 	}
 };
+
+export default exported;
+
+export const {
+    recommendedForYou,
+    recommendedPosts
+} = exported;

--- a/client/reader/recommendations/controller.js
+++ b/client/reader/recommendations/controller.js
@@ -10,6 +10,8 @@ import i18n from 'i18n-calypso';
 import trackScrollPage from 'lib/track-scroll-page';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { ensureStoreLoading, trackPageLoad, trackUpdatesLoaded, userHasHistory } from 'reader/controller-helper';
+import RecommendedForYou from 'reader/recommendations/for-you';
+import RecommendedPostsStream from 'reader/recommendations/posts';
 import route from 'lib/route';
 import feedStreamFactory from 'lib/feed-stream-store';
 import { renderWithReduxStore } from 'lib/react-helpers';
@@ -18,8 +20,7 @@ const ANALYTICS_PAGE_TITLE = 'Reader';
 
 const exported = {
 	recommendedForYou( context ) {
-		const RecommendedForYou = require( 'reader/recommendations/for-you' ),
-			basePath = '/recommendations',
+		const basePath = '/recommendations',
 			fullAnalyticsPageTitle = ANALYTICS_PAGE_TITLE + ' > Recommended Sites For You',
 			mcKey = 'recommendations_for_you';
 
@@ -44,13 +45,12 @@ const exported = {
 
 	// Post Recommendations - Used by the Data team to test recommendation algorithms
 	recommendedPosts( context ) {
-		const RecommendedPostsStream = require( 'reader/recommendations/posts' ),
-			basePath = route.sectionify( context.path );
+		const basePath = route.sectionify( context.path );
 
 		let fullAnalyticsPageTitle = '';
 		let RecommendedPostsStore = null;
 		let mcKey = '';
-		switch( basePath ) {
+		switch ( basePath ) {
 			case '/recommendations/cold':
 				fullAnalyticsPageTitle = ANALYTICS_PAGE_TITLE + ' > Coldstart Posts';
 				RecommendedPostsStore = feedStreamFactory( 'cold_posts' );

--- a/client/reader/recommendations/index.js
+++ b/client/reader/recommendations/index.js
@@ -7,8 +7,17 @@ import { forEach } from 'lodash';
 /**
  * Internal dependencies
  */
-import controller from './controller';
-import readerController from 'reader/controller';
+import {
+	recommendedForYou,
+	recommendedPosts,
+} from './controller';
+import {
+	initAbTests,
+	loadSubscriptions,
+	preloadReaderBundle,
+	sidebar,
+	updateLastRoute,
+} from 'reader/controller';
 import config from 'config';
 
 export default function() {
@@ -17,12 +26,12 @@ export default function() {
 
 	// Blog Recommendations
 	page( '/recommendations',
-		readerController.preloadReaderBundle,
-		readerController.loadSubscriptions,
-		readerController.initAbTests,
-		readerController.updateLastRoute,
-		readerController.sidebar,
-		controller.recommendedForYou
+		preloadReaderBundle,
+		loadSubscriptions,
+		initAbTests,
+		updateLastRoute,
+		sidebar,
+		recommendedForYou
 	);
 
 	// Post Recommendations - Used by the Data team to test recommendation algorithms
@@ -31,11 +40,11 @@ export default function() {
 			( path ) => {
 				page.apply( page, [
 					path,
-					readerController.preloadReaderBundle,
-					readerController.loadSubscriptions,
-					readerController.updateLastRoute,
-					readerController.sidebar,
-					controller.recommendedPosts
+					preloadReaderBundle,
+					loadSubscriptions,
+					updateLastRoute,
+					sidebar,
+					recommendedPosts
 		] ) } )
 	}
 }

--- a/client/reader/recommendations/posts/empty.jsx
+++ b/client/reader/recommendations/posts/empty.jsx
@@ -7,8 +7,12 @@ import React from 'react';
  * Internal dependencies
  */
 import EmptyContent from 'components/empty-content';
-import * as stats from 'reader/stats';
-import * as discoverHelper from 'reader/discover/helper';
+import {
+	recordAction,
+	recordGaEvent,
+	recordTrack,
+} from 'reader/stats';
+import { isDiscoverEnabled } from 'reader/discover/helper';
 
 var RecommendedPostsEmptyContent = React.createClass( {
 	shouldComponentUpdate: function() {
@@ -16,15 +20,15 @@ var RecommendedPostsEmptyContent = React.createClass( {
 	},
 
 	recordAction: function() {
-		stats.recordAction( 'clicked_following_on_empty_recommended_posts' );
-		stats.recordGaEvent( 'Clicked Following on Empty Recommended Posts Stream' );
-		stats.recordTrack( 'calypso_reader_following_on_empty_Posts_stream_clicked' );
+		recordAction( 'clicked_following_on_empty_recommended_posts' );
+		recordGaEvent( 'Clicked Following on Empty Recommended Posts Stream' );
+		recordTrack( 'calypso_reader_following_on_empty_Posts_stream_clicked' );
 	},
 
 	recordSecondaryAction: function() {
-		stats.recordAction( 'clicked_discover_on_empty_recommended_posts' );
-		stats.recordGaEvent( 'Clicked Discover on Empty Recommended Posts Stream' );
-		stats.recordTrack( 'calypso_reader_discover_on_empty_Posts_stream_clicked' );
+		recordAction( 'clicked_discover_on_empty_recommended_posts' );
+		recordGaEvent( 'Clicked Discover on Empty Recommended Posts Stream' );
+		recordTrack( 'calypso_reader_discover_on_empty_Posts_stream_clicked' );
 	},
 
 	render: function() {
@@ -32,7 +36,7 @@ var RecommendedPostsEmptyContent = React.createClass( {
 			className="empty-content__action button is-primary"
 			onClick={ this.recordAction }
 			href="/">{ this.translate( 'Back to Following' ) }</a> ),
-			secondaryAction = discoverHelper.isDiscoverEnabled()
+			secondaryAction = isDiscoverEnabled()
 			? ( <a
 				className="empty-content__action button"
 				onClick={ this.recordSecondaryAction }

--- a/client/reader/recommendations/posts/empty.jsx
+++ b/client/reader/recommendations/posts/empty.jsx
@@ -1,8 +1,8 @@
-var React = require( 'react' );
+import React from 'react';
 
-var EmptyContent = require( 'components/empty-content' ),
-	stats = require( 'reader/stats' ),
-	discoverHelper = require( 'reader/discover/helper' );
+import EmptyContent from 'components/empty-content';
+import stats from 'reader/stats';
+import discoverHelper from 'reader/discover/helper';
 
 var RecommendedPostsEmptyContent = React.createClass( {
 	shouldComponentUpdate: function() {

--- a/client/reader/recommendations/posts/empty.jsx
+++ b/client/reader/recommendations/posts/empty.jsx
@@ -1,8 +1,14 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
 
+/**
+ * Internal dependencies
+ */
 import EmptyContent from 'components/empty-content';
-import stats from 'reader/stats';
-import discoverHelper from 'reader/discover/helper';
+import * as stats from 'reader/stats';
+import * as discoverHelper from 'reader/discover/helper';
 
 var RecommendedPostsEmptyContent = React.createClass( {
 	shouldComponentUpdate: function() {

--- a/client/reader/recommendations/posts/empty.jsx
+++ b/client/reader/recommendations/posts/empty.jsx
@@ -43,4 +43,4 @@ var RecommendedPostsEmptyContent = React.createClass( {
 	}
 } );
 
-module.exports = RecommendedPostsEmptyContent;
+export default RecommendedPostsEmptyContent;

--- a/client/reader/recommendations/posts/index.jsx
+++ b/client/reader/recommendations/posts/index.jsx
@@ -1,8 +1,8 @@
-var React = require( 'react' );
+import React from 'react';
 
-var Stream = require( 'reader/stream' ),
-	EmptyContent = require( './empty' ),
-	DocumentHead = require( 'components/data/document-head' );
+import Stream from 'reader/stream';
+import EmptyContent from './empty';
+import DocumentHead from 'components/data/document-head';
 
 var RecommendationPostsStream = React.createClass( {
 

--- a/client/reader/recommendations/posts/index.jsx
+++ b/client/reader/recommendations/posts/index.jsx
@@ -23,4 +23,4 @@ var RecommendationPostsStream = React.createClass( {
 
 } );
 
-module.exports = RecommendationPostsStream;
+export default RecommendationPostsStream;

--- a/client/reader/recommendations/posts/index.jsx
+++ b/client/reader/recommendations/posts/index.jsx
@@ -1,5 +1,11 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
 
+/**
+ * Internal dependencies
+ */
 import Stream from 'reader/stream';
 import EmptyContent from './empty';
 import DocumentHead from 'components/data/document-head';

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -7,8 +7,12 @@ import React from 'react';
  * Internal dependencies
  */
 import EmptyContent from 'components/empty-content';
-import * as stats from 'reader/stats';
-import * as discoverHelper from 'reader/discover/helper';
+import {
+	recordAction,
+	recordGaEvent,
+	recordTrack,
+} from 'reader/stats';
+import { isDiscoverEnabled } from 'reader/discover/helper';
 
 const SearchEmptyContent = React.createClass( {
 
@@ -21,15 +25,15 @@ const SearchEmptyContent = React.createClass( {
 	},
 
 	recordAction: function() {
-		stats.recordAction( 'clicked_following_on_empty' );
-		stats.recordGaEvent( 'Clicked Following on EmptyContent' );
-		stats.recordTrack( 'calypso_reader_following_on_empty_search_stream_clicked' );
+		recordAction( 'clicked_following_on_empty' );
+		recordGaEvent( 'Clicked Following on EmptyContent' );
+		recordTrack( 'calypso_reader_following_on_empty_search_stream_clicked' );
 	},
 
 	recordSecondaryAction: function() {
-		stats.recordAction( 'clicked_discover_on_empty' );
-		stats.recordGaEvent( 'Clicked Discover on EmptyContent' );
-		stats.recordTrack( 'calypso_reader_discover_on_empty_search_stream_clicked' );
+		recordAction( 'clicked_discover_on_empty' );
+		recordGaEvent( 'Clicked Discover on EmptyContent' );
+		recordTrack( 'calypso_reader_discover_on_empty_search_stream_clicked' );
 	},
 
 	render: function() {
@@ -38,7 +42,7 @@ const SearchEmptyContent = React.createClass( {
 			onClick={ this.recordAction }
 			href="/">{ this.translate( 'Back to Following' ) }</a> );
 
-		const secondaryAction = discoverHelper.isDiscoverEnabled()
+		const secondaryAction = isDiscoverEnabled()
 			? ( <a
 			className="empty-content__action button"
 			onClick={ this.recordSecondaryAction }

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -1,8 +1,8 @@
-const React = require( 'react' );
+import React from 'react';
 
-const EmptyContent = require( 'components/empty-content' ),
-	stats = require( 'reader/stats' ),
-	discoverHelper = require( 'reader/discover/helper' );
+import EmptyContent from 'components/empty-content';
+import stats from 'reader/stats';
+import discoverHelper from 'reader/discover/helper';
 
 const SearchEmptyContent = React.createClass( {
 

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -1,8 +1,14 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
 
+/**
+ * Internal dependencies
+ */
 import EmptyContent from 'components/empty-content';
-import stats from 'reader/stats';
-import discoverHelper from 'reader/discover/helper';
+import * as stats from 'reader/stats';
+import * as discoverHelper from 'reader/discover/helper';
 
 const SearchEmptyContent = React.createClass( {
 

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -54,4 +54,4 @@ const SearchEmptyContent = React.createClass( {
 	}
 } );
 
-module.exports = SearchEmptyContent;
+export default SearchEmptyContent;

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -29,7 +29,7 @@ function replaceSearchUrl( newValue, sort ) {
 	page.replace( searchUrl );
 }
 
-export default {
+const exported = {
 	search: function( context ) {
 		const basePath = '/read/search',
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Search',
@@ -91,3 +91,9 @@ export default {
 		);
 	}
 };
+
+export default exported;
+
+export const {
+    search
+} = exported;

--- a/client/reader/search/index.js
+++ b/client/reader/search/index.js
@@ -7,16 +7,20 @@ import page from 'page';
  * Internal dependencies
  */
 import config from 'config';
-import controller from './controller';
-import readerController from 'reader/controller';
+import { search } from './controller';
+import {
+	preloadReaderBundle,
+	sidebar,
+	updateLastRoute,
+} from 'reader/controller';
 
 export default function() {
 	if ( config.isEnabled( 'reader/search' ) ) {
 		page( '/read/search',
-			readerController.preloadReaderBundle,
-			readerController.updateLastRoute,
-			readerController.sidebar,
-			controller.search );
+			preloadReaderBundle,
+			updateLastRoute,
+			sidebar,
+			search );
 	} else {
 		// redirect search to the root
 		page.redirect( '/read/search', '/' );

--- a/client/reader/sidebar/helper.js
+++ b/client/reader/sidebar/helper.js
@@ -6,7 +6,7 @@ import some from 'lodash/some';
 import startsWith from 'lodash/startsWith';
 import assign from 'lodash/assign';
 
-module.exports = {
+export default {
 	itemLinkClass: function( path, currentPath, additionalClasses ) {
 		const basePathLowerCase = decodeURIComponent( currentPath ).split( '?' )[ 0 ].replace( /\/edit$/, '' ).toLowerCase(),
 			pathLowerCase = decodeURIComponent( path ).replace( /\/edit$/, '' ).toLowerCase();

--- a/client/reader/sidebar/helper.js
+++ b/client/reader/sidebar/helper.js
@@ -6,7 +6,7 @@ import some from 'lodash/some';
 import startsWith from 'lodash/startsWith';
 import assign from 'lodash/assign';
 
-export default {
+const exported = {
 	itemLinkClass: function( path, currentPath, additionalClasses ) {
 		const basePathLowerCase = decodeURIComponent( currentPath ).split( '?' )[ 0 ].replace( /\/edit$/, '' ).toLowerCase(),
 			pathLowerCase = decodeURIComponent( path ).replace( /\/edit$/, '' ).toLowerCase();
@@ -39,3 +39,11 @@ export default {
 		} );
 	}
 };
+
+export default exported;
+
+export const {
+    itemLinkClass,
+    itemLinkClassStartsWithOneOf,
+    pathStartsWithOneOf
+} = exported;

--- a/client/reader/sidebar/reader-sidebar-lists/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/index.jsx
@@ -11,7 +11,11 @@ import ExpandableSidebarMenu from '../expandable';
 import ReaderSidebarListsList from './list';
 import ReaderListsActions from 'lib/reader-lists/actions';
 
-import * as stats from 'reader/stats';
+import {
+	recordAction,
+	recordGaEvent,
+	recordTrack,
+} from 'reader/stats';
 
 export class ReaderSidebarLists extends Component {
 
@@ -30,16 +34,16 @@ export class ReaderSidebarLists extends Component {
 	}
 
 	createList = ( list ) => {
-		stats.recordAction( 'add_list' );
-		stats.recordGaEvent( 'Clicked Create List' );
-		stats.recordTrack( 'calypso_reader_create_list_clicked' );
+		recordAction( 'add_list' );
+		recordGaEvent( 'Clicked Create List' );
+		recordTrack( 'calypso_reader_create_list_clicked' );
 		ReaderListsActions.create( list );
 	}
 
 	handleAddClick = () => {
-		stats.recordAction( 'add_list_open_input' );
-		stats.recordGaEvent( 'Clicked Add List to Open Input' );
-		stats.recordTrack( 'calypso_reader_add_list_clicked' );
+		recordAction( 'add_list_open_input' );
+		recordGaEvent( 'Clicked Add List to Open Input' );
+		recordTrack( 'calypso_reader_add_list_clicked' );
 	}
 
 	render() {

--- a/client/reader/sidebar/reader-sidebar-lists/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/index.jsx
@@ -11,7 +11,7 @@ import ExpandableSidebarMenu from '../expandable';
 import ReaderSidebarListsList from './list';
 import ReaderListsActions from 'lib/reader-lists/actions';
 
-import stats from 'reader/stats';
+import * as stats from 'reader/stats';
 
 export class ReaderSidebarLists extends Component {
 

--- a/client/reader/sidebar/reader-sidebar-lists/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/index.jsx
@@ -11,7 +11,7 @@ import ExpandableSidebarMenu from '../expandable';
 import ReaderSidebarListsList from './list';
 import ReaderListsActions from 'lib/reader-lists/actions';
 
-const stats = require( 'reader/stats' );
+import stats from 'reader/stats';
 
 export class ReaderSidebarLists extends Component {
 

--- a/client/reader/sidebar/reader-sidebar-tags/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/index.jsx
@@ -16,7 +16,11 @@ import QueryReaderFollowedTags from 'components/data/query-reader-followed-tags'
 import { getReaderFollowedTags } from 'state/selectors';
 import { requestFollowTag, requestUnfollowTag } from 'state/reader/tags/items/actions';
 
-import * as stats from 'reader/stats';
+import {
+	recordAction,
+	recordGaEvent,
+	recordTrack,
+} from 'reader/stats';
 
 export class ReaderSidebarTags extends Component {
 
@@ -36,9 +40,9 @@ export class ReaderSidebarTags extends Component {
 
 	followTag = ( tag ) => {
 		this.props.followTag( decodeURIComponent( tag ) );
-		stats.recordAction( 'followed_topic' );
-		stats.recordGaEvent( 'Clicked Follow Topic', tag );
-		stats.recordTrack( 'calypso_reader_reader_tag_followed', {
+		recordAction( 'followed_topic' );
+		recordGaEvent( 'Clicked Follow Topic', tag );
+		recordTrack( 'calypso_reader_reader_tag_followed', {
 			tag: tag
 		} );
 		this.props.onFollowTag( tag );
@@ -49,9 +53,9 @@ export class ReaderSidebarTags extends Component {
 		event.preventDefault();
 		const slug = node && node.dataset && node.dataset.tagSlug;
 		if ( slug ) {
-			stats.recordAction( 'unfollowed_topic' );
-			stats.recordGaEvent( 'Clicked Unfollow Topic', slug );
-			stats.recordTrack( 'calypso_reader_reader_tag_unfollowed', {
+			recordAction( 'unfollowed_topic' );
+			recordGaEvent( 'Clicked Unfollow Topic', slug );
+			recordTrack( 'calypso_reader_reader_tag_unfollowed', {
 				tag: slug,
 			} );
 			this.props.unfollowTag( decodeURIComponent( slug ) );
@@ -59,9 +63,9 @@ export class ReaderSidebarTags extends Component {
 	}
 
 	handleAddClick = () => {
-		stats.recordAction( 'follow_topic_open_input' );
-		stats.recordGaEvent( 'Clicked Add Topic to Open Input' );
-		stats.recordTrack( 'calypso_reader_add_tag_clicked' );
+		recordAction( 'follow_topic_open_input' );
+		recordGaEvent( 'Clicked Add Topic to Open Input' );
+		recordTrack( 'calypso_reader_add_tag_clicked' );
 	}
 
 	render() {

--- a/client/reader/sidebar/reader-sidebar-tags/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/index.jsx
@@ -16,7 +16,7 @@ import QueryReaderFollowedTags from 'components/data/query-reader-followed-tags'
 import { getReaderFollowedTags } from 'state/selectors';
 import { requestFollowTag, requestUnfollowTag } from 'state/reader/tags/items/actions';
 
-import stats from 'reader/stats';
+import * as stats from 'reader/stats';
 
 export class ReaderSidebarTags extends Component {
 

--- a/client/reader/sidebar/reader-sidebar-tags/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/index.jsx
@@ -16,7 +16,7 @@ import QueryReaderFollowedTags from 'components/data/query-reader-followed-tags'
 import { getReaderFollowedTags } from 'state/selectors';
 import { requestFollowTag, requestUnfollowTag } from 'state/reader/tags/items/actions';
 
-const stats = require( 'reader/stats' );
+import stats from 'reader/stats';
 
 export class ReaderSidebarTags extends Component {
 

--- a/client/reader/site-stream/empty.jsx
+++ b/client/reader/site-stream/empty.jsx
@@ -8,25 +8,29 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import EmptyContent from 'components/empty-content';
-import * as stats from 'reader/stats';
-import * as DiscoverHelper from 'reader/discover/helper';
+import {
+	recordAction as statRecordAction,
+	recordGaEvent,
+	recordTrack,
+} from 'reader/stats';
+import { isDiscoverEnabled } from 'reader/discover/helper';
 
 const SiteEmptyContent = ( { translate } ) => {
 	const recordAction = () => {
-		stats.recordAction( 'clicked_discover_on_empty' );
-		stats.recordGaEvent( 'Clicked Discover on EmptyContent' );
-		stats.recordTrack( 'calypso_reader_discover_on_empty_site_stream_clicked' );
+		statRecordAction( 'clicked_discover_on_empty' );
+		recordGaEvent( 'Clicked Discover on EmptyContent' );
+		recordTrack( 'calypso_reader_discover_on_empty_site_stream_clicked' );
 	};
 
 	const recordSecondaryAction = () => {
-		stats.recordAction( 'clicked_search_on_empty' );
-		stats.recordGaEvent( 'Clicked Search on EmptyContent' );
-		stats.recordTrack( 'calypso_reader_search_on_empty_site_stream_clicked' );
+		statRecordAction( 'clicked_search_on_empty' );
+		recordGaEvent( 'Clicked Search on EmptyContent' );
+		recordTrack( 'calypso_reader_search_on_empty_site_stream_clicked' );
 	};
 
 	let action;
 
-	if ( DiscoverHelper.isDiscoverEnabled() ) {
+	if ( isDiscoverEnabled() ) {
 		action = (
 			<a className="empty-content__action button is-primary"
 				onClick={ recordAction }

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -12,7 +12,11 @@ import page from 'page';
 import FeedPostStore from 'lib/feed-post-store';
 import FeedPostStoreActions from 'lib/feed-post-store/actions';
 import { getSourceData as getDiscoverSourceData } from 'reader/discover/helper';
-import * as stats from 'reader/stats';
+import {
+	recordAction,
+	recordGaEvent,
+	recordTrackForPost,
+} from 'reader/stats';
 import cssSafeUrl from 'lib/css-safe-url';
 
 export default React.createClass( {
@@ -88,9 +92,9 @@ export default React.createClass( {
 
 	handleClick( postData ) {
 		const post = postData.post;
-		stats.recordTrackForPost( 'calypso_reader_clicked_featured_post', post );
-		stats.recordAction( 'clicked_featured_post' );
-		stats.recordGaEvent( 'Clicked Featured Post' );
+		recordTrackForPost( 'calypso_reader_clicked_featured_post', post );
+		recordAction( 'clicked_featured_post' );
+		recordGaEvent( 'Clicked Featured Post' );
 
 		page( postData.url );
 	},

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -57,6 +57,7 @@ class SiteStream extends React.Component {
 		if ( ( site && site.is_error ) || ( feed && feed.is_error ) ) {
 			return <FeedError sidebarTitle={ title } />;
 		}
+
 		const featuredContent = featuredStore && ( <FeedFeatured store={ featuredStore } /> );
 
 		return (

--- a/client/reader/stream/empty.jsx
+++ b/client/reader/stream/empty.jsx
@@ -7,8 +7,12 @@ import React from 'react';
  * Internal dependencies
  */
 import EmptyContent from 'components/empty-content';
-import * as stats from 'reader/stats';
-import * as discoverHelper from 'reader/discover/helper';
+import {
+	recordAction,
+	recordGaEvent,
+	recordTrack,
+} from 'reader/stats';
+import { isDiscoverEnabled } from 'reader/discover/helper';
 
 const FollowingEmptyContent = React.createClass( {
 	shouldComponentUpdate: function() {
@@ -16,13 +20,13 @@ const FollowingEmptyContent = React.createClass( {
 	},
 
 	recordAction: function() {
-		stats.recordAction( 'clicked_search_on_empty' );
-		stats.recordGaEvent( 'Clicked Search on EmptyContent' );
-		stats.recordTrack( 'calypso_reader_search_on_empty_stream_clicked' );
+		recordAction( 'clicked_search_on_empty' );
+		recordGaEvent( 'Clicked Search on EmptyContent' );
+		recordTrack( 'calypso_reader_search_on_empty_stream_clicked' );
 	},
 
 	render: function() {
-		const action = discoverHelper.isDiscoverEnabled()
+		const action = isDiscoverEnabled()
 		? (
 			<a
 				className="empty-content__action button is-primary"

--- a/client/reader/stream/empty.jsx
+++ b/client/reader/stream/empty.jsx
@@ -35,4 +35,4 @@ const FollowingEmptyContent = React.createClass( {
 	}
 } );
 
-module.exports = FollowingEmptyContent;
+export default FollowingEmptyContent;

--- a/client/reader/stream/empty.jsx
+++ b/client/reader/stream/empty.jsx
@@ -1,8 +1,14 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
 
+/**
+ * Internal dependencies
+ */
 import EmptyContent from 'components/empty-content';
-import stats from 'reader/stats';
-import discoverHelper from 'reader/discover/helper';
+import * as stats from 'reader/stats';
+import * as discoverHelper from 'reader/discover/helper';
 
 const FollowingEmptyContent = React.createClass( {
 	shouldComponentUpdate: function() {

--- a/client/reader/stream/empty.jsx
+++ b/client/reader/stream/empty.jsx
@@ -1,8 +1,8 @@
-const React = require( 'react' );
+import React from 'react';
 
-const EmptyContent = require( 'components/empty-content' ),
-	stats = require( 'reader/stats' ),
-	discoverHelper = require( 'reader/discover/helper' );
+import EmptyContent from 'components/empty-content';
+import stats from 'reader/stats';
+import discoverHelper from 'reader/discover/helper';
 
 const FollowingEmptyContent = React.createClass( {
 	shouldComponentUpdate: function() {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -12,7 +12,15 @@ import { connect } from 'react-redux';
  */
 import ReaderMain from 'components/reader-main';
 import EmptyContent from './empty';
-import * as FeedStreamStoreActions from 'lib/feed-stream-store/actions';
+import {
+	fetchNextPage,
+	selectFirstItem,
+	selectItem,
+	selectNextItem,
+	selectPrevItem,
+	showUpdates,
+	shufflePosts,
+} from 'lib/feed-stream-store/actions';
 import LikeStore from 'lib/like-store/like-store';
 import LikeStoreActions from 'lib/like-store/actions';
 import LikeHelper from 'reader/like-helper';
@@ -103,7 +111,7 @@ class ReaderStream extends React.Component {
 		if ( recommendationsStore ) {
 			if ( ! recs || recs.length < posts.length * ( RECS_PER_BLOCK / getDistanceBetweenRecs() ) ) {
 				if ( ! recommendationsStore.isFetchingNextPage() ) {
-					defer( () => FeedStreamStoreActions.fetchNextPage( recommendationsStore.id ) );
+					defer( () => fetchNextPage( recommendationsStore.id ) );
 				}
 			}
 		}
@@ -267,7 +275,7 @@ class ReaderStream extends React.Component {
 		if ( this.state.updateCount && this.state.updateCount > 0 ) {
 			this.showUpdates();
 		} else {
-			FeedStreamStoreActions.selectFirstItem( this.props.postsStore.id );
+			selectFirstItem( this.props.postsStore.id );
 		}
 	}
 
@@ -278,7 +286,7 @@ class ReaderStream extends React.Component {
 	selectNextItem = () => {
 		// do we have a selected item? if so, just move to the next one
 		if ( this.state.selectedPostKey ) {
-			FeedStreamStoreActions.selectNextItem( this.props.postsStore.id );
+			selectNextItem( this.props.postsStore.id );
 			return;
 		}
 
@@ -317,7 +325,7 @@ class ReaderStream extends React.Component {
 				} else {
 					postKey.blogId = candidateItem.blogId;
 				}
-				FeedStreamStoreActions.selectItem( this.props.postsStore.id, postKey );
+				selectItem( this.props.postsStore.id, postKey );
 			}
 
 			// find the index of the post / gap in the posts array.
@@ -326,9 +334,9 @@ class ReaderStream extends React.Component {
 			// Use lastIndexOf to walk the array from right to left
 			const selectedPostKey = findLast( posts, items[ index ], index );
 			if ( keysAreEqual( selectedPostKey, this.state.selectedPostKey ) ) {
-				FeedStreamStoreActions.selectNextItem( this.props.postsStore.id );
+				selectNextItem( this.props.postsStore.id );
 			} else {
-				FeedStreamStoreActions.selectItem( this.props.postsStore.id, selectedPostKey );
+				selectItem( this.props.postsStore.id, selectedPostKey );
 			}
 		}
 	}
@@ -338,7 +346,7 @@ class ReaderStream extends React.Component {
 		// currently has a selected item. Otherwise do nothing.
 		// We avoid the magic here because we expect users to enter the flow using next, not previous.
 		if ( this.state.selectedPostKey ) {
-			FeedStreamStoreActions.selectPrevItem( this.props.postsStore.id );
+			selectPrevItem( this.props.postsStore.id );
 		}
 	}
 
@@ -349,14 +357,14 @@ class ReaderStream extends React.Component {
 		if ( options.triggeredByScroll ) {
 			this.props.trackScrollPage( this.props.postsStore.getPage() + 1 );
 		}
-		FeedStreamStoreActions.fetchNextPage( this.props.postsStore.id );
+		fetchNextPage( this.props.postsStore.id );
 	}
 
 	showUpdates = () => {
 		this.props.onUpdatesShown();
-		FeedStreamStoreActions.showUpdates( this.props.postsStore.id );
+		showUpdates( this.props.postsStore.id );
 		if ( this.props.recommendationsStore ) {
-			FeedStreamStoreActions.shufflePosts( this.props.recommendationsStore.id );
+			shufflePosts( this.props.recommendationsStore.id );
 		}
 		if ( this._list ) {
 			this._list.scrollToTop();

--- a/client/reader/stream/post-unavailable.jsx
+++ b/client/reader/stream/post-unavailable.jsx
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' ),
-	config = require( 'config' );
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
+import config from 'config';
 
 /**
  * Internal dependencies
  */
-var Card = require( 'components/card' );
+import Card from 'components/card';
 
 var PostUnavailable = React.createClass( {
 

--- a/client/reader/stream/post-unavailable.jsx
+++ b/client/reader/stream/post-unavailable.jsx
@@ -45,4 +45,4 @@ var PostUnavailable = React.createClass( {
 
 } );
 
-module.exports = PostUnavailable;
+export default PostUnavailable;

--- a/client/reader/stream/recommended-posts.jsx
+++ b/client/reader/stream/recommended-posts.jsx
@@ -11,12 +11,15 @@ import Gridicon from 'gridicons';
  */
 import { RelatedPostCard } from 'blocks/reader-related-card-v2';
 import PostStore from 'lib/feed-post-store';
-import * as stats from 'reader/stats';
+import {
+	recordAction,
+	recordTrackForPost,
+} from 'reader/stats';
 import Button from 'components/button';
 import { dismissPost } from 'lib/feed-stream-store/actions';
 
 function dismissRecommendation( uiIndex, storeId, post ) {
-	stats.recordTrackForPost(
+	recordTrackForPost(
 		'calypso_reader_recommended_post_dismissed',
 		post,
 		{
@@ -24,12 +27,12 @@ function dismissRecommendation( uiIndex, storeId, post ) {
 			ui_position: uiIndex
 		}
 	);
-	stats.recordAction( 'in_stream_rec_dismiss' );
+	recordAction( 'in_stream_rec_dismiss' );
 	dismissPost( storeId, post );
 }
 
 function handleSiteClick( uiIndex, post ) {
-	stats.recordTrackForPost(
+	recordTrackForPost(
 		'calypso_reader_recommended_site_clicked',
 		post,
 		{
@@ -37,11 +40,11 @@ function handleSiteClick( uiIndex, post ) {
 			ui_position: uiIndex
 		}
 	);
-	stats.recordAction( 'in_stream_rec_site_click' );
+	recordAction( 'in_stream_rec_site_click' );
 }
 
 function handlePostClick( uiIndex, post ) {
-	stats.recordTrackForPost(
+	recordTrackForPost(
 		'calypso_reader_recommended_post_clicked',
 		post,
 		{
@@ -49,7 +52,7 @@ function handlePostClick( uiIndex, post ) {
 			ui_position: uiIndex
 		}
 	);
-	stats.recordAction( 'in_stream_rec_post_click' );
+	recordAction( 'in_stream_rec_post_click' );
 }
 
 export class RecommendedPosts extends React.PureComponent {

--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -15,7 +15,7 @@ import AsyncLoad from 'components/async-load';
 
 const analyticsPageTitle = 'Reader';
 
-export default {
+const exported = {
 	tagListing( context ) {
 		var basePath = '/tag/:slug',
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Tag > ' + context.params.tag,
@@ -56,3 +56,9 @@ export default {
 		);
 	}
 };
+
+export default exported;
+
+export const {
+    tagListing
+} = exported;

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -7,7 +7,11 @@ import React from 'react';
  * Internal dependencies
  */
 import EmptyContent from 'components/empty-content';
-import * as stats from 'reader/stats';
+import {
+	recordAction,
+	recordGaEvent,
+	recordTrack,
+} from 'reader/stats';
 import { isDiscoverEnabled } from 'reader/discover/helper';
 
 const TagEmptyContent = React.createClass( {
@@ -20,15 +24,15 @@ const TagEmptyContent = React.createClass( {
 	},
 
 	recordAction() {
-		stats.recordAction( 'clicked_following_on_empty' );
-		stats.recordGaEvent( 'Clicked Following on EmptyContent' );
-		stats.recordTrack( 'calypso_reader_following_on_empty_tag_stream_clicked' );
+		recordAction( 'clicked_following_on_empty' );
+		recordGaEvent( 'Clicked Following on EmptyContent' );
+		recordTrack( 'calypso_reader_following_on_empty_tag_stream_clicked' );
 	},
 
 	recordSecondaryAction() {
-		stats.recordAction( 'clicked_discover_on_empty' );
-		stats.recordGaEvent( 'Clicked Discover on EmptyContent' );
-		stats.recordTrack( 'calypso_reader_discover_on_empty_tag_stream_clicked' );
+		recordAction( 'clicked_discover_on_empty' );
+		recordGaEvent( 'Clicked Discover on EmptyContent' );
+		recordTrack( 'calypso_reader_discover_on_empty_tag_stream_clicked' );
 	},
 
 	render() {

--- a/client/reader/tag-stream/index.js
+++ b/client/reader/tag-stream/index.js
@@ -6,26 +6,35 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import controller from './controller';
-import readerController from 'reader/controller';
+import {
+	recommendedTags,
+	tagListing,
+} from './controller';
+import {
+	initAbTests,
+	loadSubscriptions,
+	preloadReaderBundle,
+	sidebar,
+	updateLastRoute,
+} from 'reader/controller';
 
 export default function() {
 	page( '/tag/*',
-		readerController.preloadReaderBundle,
-		readerController.loadSubscriptions,
-		readerController.initAbTests
+		preloadReaderBundle,
+		loadSubscriptions,
+		initAbTests
 	);
 	page( '/tag/:tag',
-		readerController.updateLastRoute,
-		readerController.sidebar,
-		controller.tagListing
+		updateLastRoute,
+		sidebar,
+		tagListing
 	);
 
 	page( '/tags',
-		readerController.loadSubscriptions,
-		readerController.initAbTests,
-		readerController.updateLastRoute,
-		readerController.sidebar,
-		controller.recommendedTags
+		loadSubscriptions,
+		initAbTests,
+		updateLastRoute,
+		sidebar,
+		recommendedTags
 	);
 }

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -11,7 +11,11 @@ import Stream from 'reader/stream';
 import DocumentHead from 'components/data/document-head';
 import EmptyContent from './empty';
 import TagStreamHeader from './header';
-import * as stats from 'reader/stats';
+import {
+	recordAction,
+	recordGaEvent,
+	recordTrack,
+} from 'reader/stats';
 import HeaderBack from 'reader/header-back';
 import { getReaderFollowedTags, getReaderTags } from 'state/selectors';
 import { requestFollowTag, requestUnfollowTag } from 'state/reader/tags/items/actions';
@@ -85,9 +89,9 @@ const TagStream = React.createClass( {
 		const isFollowing = this.isSubscribed(); // this is the current state, not the new state
 		const toggleAction = isFollowing ? unfollowTag : followTag;
 		toggleAction( decodedTag );
-		stats.recordAction( isFollowing ? 'unfollowed_topic' : 'followed_topic' );
-		stats.recordGaEvent( isFollowing ? 'Clicked Unfollow Topic' : 'Clicked Follow Topic', tag );
-		stats.recordTrack( isFollowing ? 'calypso_reader_reader_tag_unfollowed' : 'calypso_reader_reader_tag_followed', {
+		recordAction( isFollowing ? 'unfollowed_topic' : 'followed_topic' );
+		recordGaEvent( isFollowing ? 'Clicked Unfollow Topic' : 'Clicked Follow Topic', tag );
+		recordTrack( isFollowing ? 'calypso_reader_reader_tag_unfollowed' : 'calypso_reader_reader_tag_followed', {
 			tag
 		} );
 	},

--- a/client/reader/xpost-helper.js
+++ b/client/reader/xpost-helper.js
@@ -8,7 +8,7 @@ import url from 'url';
  */
 import { X_POST } from 'lib/feed-post-store/display-types';
 
-export default {
+const exported = {
 	/**
 	 * Examines the post metadata, and returns metadata related to cross posts.
 	 * @param {object} post - post object
@@ -44,6 +44,12 @@ export default {
 		return xPostMetadata;
 	}
 };
+
+export default exported;
+
+export const {
+    getXPostMetadata
+} = exported;
 
 export function isXPost( post ) {
 	return post && post.display_type & X_POST;


### PR DESCRIPTION
Part of #11688. 

This change will allow us to leverage [Webpack 2's tree shaking optimization for ES6 modules](https://gist.github.com/sokra/27b24881210b56bbaff7#es6-specific-optimizations) in the future. Please share your suggestions and comments!