### PR TITLE
Directly: Only initialize widget for users who will use it

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -65,9 +65,7 @@ const HelpContact = React.createClass( {
 			this.props.connectHappychat();
 		}
 
-		if ( config.isEnabled( 'help/directly' ) ) {
-			this.props.initializeDirectly();
-		}
+		this.prepareDirectlyWidget();
 
 		olarkStore.on( 'change', this.updateOlarkState );
 		olarkEvents.on( 'api.chat.onOperatorsAway', this.onOperatorsAway );
@@ -85,6 +83,13 @@ const HelpContact = React.createClass( {
 		olarkActions.expandBox();
 		olarkActions.shrinkBox();
 		olarkActions.hideBox();
+	},
+
+	componentDidUpdate: function() {
+		// Directly initialization is a noop if it's already happened. This catches
+		// instances where a state/prop change moves a user to Directly support from
+		// some other variation.
+		this.prepareDirectlyWidget();
 	},
 
 	componentWillUnmount: function() {
@@ -171,6 +176,12 @@ const HelpContact = React.createClass( {
 		this.sendMessageToOperator( message );
 
 		this.clearSavedContactForm();
+	},
+
+	prepareDirectlyWidget: function() {
+		if ( this.getSupportVariation() === SUPPORT_DIRECTLY && ! this.shouldShowPreloadForm() ) {
+			this.props.initializeDirectly();
+		}
 	},
 
 	submitDirectlyQuestion: function( contactForm ) {


### PR DESCRIPTION
Currently the Directly RTM widget initializes for all users who visit `/help/contact`. This PR ensures that only users who are meant to see the widget will have the third-party code initialized.

### To test

Check for initialization by opening Network dev tools and filtering on the term `directly`. If you see any assets come through, initialization has occurred.

#### 1. Paid users should not see initialization
Sign in as a user with paid upgrades. Visit http://calypso.localhost:3000/help/contact. You should not see initialization happen.

#### 2. Unpaid English-speaking users should see initialization
Sign in as a user with no paid upgrades and account language set to English. Visit http://calypso.localhost:3000/help/contact. You should see initialization assets come across the network.

#### 3. Unpaid non-English speakers should not see initialization
On your unpaid account, set your language to something other than `en`. Visit http://calypso.localhost:3000/help/contact. You should not see initialization happen.

#### 4. Unpaid non-English speakers whose language switches to English should see initialization
On your unpaid account, set your language to something other than `en`. Visit http://calypso.localhost:3000/help/contact. You should not see initialization happen.

Now we'll send an action through Redux Dev Tools to change the language settings on the fly.

- Open Redux Dev Tools
- Find the `USER_RECEIVE` action and click it (should be one of the first dispatched)
- Open the "Raw" tab and copy the entire action
- Click the "keyboard" icon to dispatch a new action
- Paste in the copied action
- Find the `localeSlug` property and change the value to `'en'`
- Click the Dispatch button

You should now see the form change and Directly initialization assets come through the network.
