### PR TITLE
Extensions: Add routing and tabbed navigation to WP Super Cache settings page

### DIFF
--- a/client/extensions/wp-super-cache/components/navigation.jsx
+++ b/client/extensions/wp-super-cache/components/navigation.jsx
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import SectionNav from 'components/section-nav';
+import SectionNavTabs from 'components/section-nav/tabs';
+import SectionNavTabItem from 'components/section-nav/item';
+
+/**
+ * Module Variables
+ */
+const tabs = [ 'easy', 'advanced', 'cdn', 'contents', 'preload', 'plugins', 'debug' ];
+
+const Navigation = ( { activeTab, translate } ) => {
+	const getLabel = tab => {
+		switch ( tab ) {
+			case 'easy':
+				return translate( 'Easy' );
+			case 'advanced':
+				return translate( 'Advanced' );
+			case 'cdn':
+				return translate( 'CDN' );
+			case 'contents':
+				return translate( 'Contents' );
+			case 'preload':
+				return translate( 'Preload' );
+			case 'plugins':
+				return translate( 'Plugins' );
+			case 'debug':
+				return translate( 'Debug' );
+		}
+	};
+
+	const renderTabItems = () => {
+		return tabs.map( tab => {
+			let path = '/wp-super-cache';
+
+			if ( tab !== tabs[ 0 ] ) {
+				path = `/wp-super-cache/${ tab }`;
+			}
+
+			return (
+				<SectionNavTabItem
+					key={ `wp-super-cache-${ tab }` }
+					path={ path }
+					selected={ ( activeTab || tabs[ 0 ] ) === tab }>
+					{ getLabel( tab ) }
+				</SectionNavTabItem>
+			);
+		} );
+	};
+
+	return (
+		<SectionNav selectedText="Settings">
+			<SectionNavTabs>
+				{ renderTabItems() }
+			</SectionNavTabs>
+		</SectionNav>
+	);
+};
+
+Navigation.propTypes = {
+	activeTab: PropTypes.string,
+	translate: PropTypes.func.isRequired
+};
+
+Navigation.defaultProps = {
+	activeTab: ''
+};
+
+export default localize( Navigation );

--- a/client/extensions/wp-super-cache/components/navigation.jsx
+++ b/client/extensions/wp-super-cache/components/navigation.jsx
@@ -38,10 +38,10 @@ const Navigation = ( { activeTab, translate } ) => {
 
 	const renderTabItems = () => {
 		return tabs.map( tab => {
-			let path = '/wp-super-cache';
+			let path = '/extensions/wp-super-cache';
 
 			if ( tab !== tabs[ 0 ] ) {
-				path = `/wp-super-cache/${ tab }`;
+				path = `/extensions/wp-super-cache/${ tab }`;
 			}
 
 			return (

--- a/client/extensions/wp-super-cache/components/navigation.jsx
+++ b/client/extensions/wp-super-cache/components/navigation.jsx
@@ -41,7 +41,7 @@ const Navigation = ( { activeTab, translate } ) => {
 			let path = '/extensions/wp-super-cache';
 
 			if ( tab !== tabs[ 0 ] ) {
-				path = `/extensions/wp-super-cache/${ tab }`;
+				path = `${ path }/${ tab }`;
 			}
 
 			return (

--- a/client/extensions/wp-super-cache/controller.js
+++ b/client/extensions/wp-super-cache/controller.js
@@ -1,0 +1,56 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import i18n from 'i18n-calypso';
+
+/**
+ * Internal Dependencies
+ */
+import analytics from 'lib/analytics';
+import titlecase from 'to-title-case';
+import { getSiteFragment, sectionify } from 'lib/route';
+import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
+import { renderWithReduxStore } from 'lib/react-helpers';
+import WPSuperCache from './main';
+
+const controller = {
+
+	settings: function( context ) {
+		const siteID = getSiteFragment( context.path );
+		let tab = context.params.tab;
+
+		tab = ( ! tab || tab === siteID ) ? '' : tab;
+		context.store.dispatch( setTitle( i18n.translate( 'WP Super Cache', { textOnly: true } ) ) );
+
+		const basePath = sectionify( context.path );
+		let baseAnalyticsPath;
+
+		if ( siteID ) {
+			baseAnalyticsPath = `${ basePath }/:site`;
+		} else {
+			baseAnalyticsPath = basePath;
+		}
+
+		let analyticsPageTitle = 'WP Super Cache';
+
+		if ( tab.length ) {
+			analyticsPageTitle += ` > ${ titlecase( tab ) }`;
+		} else {
+			analyticsPageTitle += ' > Easy';
+		}
+
+		analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
+
+		renderWithReduxStore(
+			React.createElement( WPSuperCache, {
+				context: context,
+				tab: tab,
+			} ),
+			document.getElementById( 'primary' ),
+			context.store
+		);
+	}
+};
+
+module.exports = controller;

--- a/client/extensions/wp-super-cache/index.js
+++ b/client/extensions/wp-super-cache/index.js
@@ -10,5 +10,5 @@ import { navigation, siteSelection } from 'my-sites/controller';
 import controller from './controller';
 
 export default function() {
-	page( '/wp-super-cache/:tab?/:site?', siteSelection, navigation, controller.settings );
+	page( '/extensions/wp-super-cache/:tab?/:site?', siteSelection, navigation, controller.settings );
 }

--- a/client/extensions/wp-super-cache/index.js
+++ b/client/extensions/wp-super-cache/index.js
@@ -2,28 +2,13 @@
  * External dependencies
  */
 import page from 'page';
-import React from 'react';
 
 /**
  * Internal dependencies
  */
 import { navigation, siteSelection } from 'my-sites/controller';
-import { renderWithReduxStore } from 'lib/react-helpers';
-import Main from 'components/main';
-import Card from 'components/card';
-import SectionHeader from 'components/section-header';
-
-const render = ( context ) => {
-	renderWithReduxStore( (
-		<Main className="wp-super-cache__main">
-			<SectionHeader label="WP Super Cache" />
-			<Card>
-				<p>This will be the home for your WP Super Cache integration with WordPress.com.</p>
-			</Card>
-		</Main>
-	), document.getElementById( 'primary' ), context.store );
-};
+import controller from './controller';
 
 export default function() {
-	page( '/wp-super-cache/:site?', siteSelection, navigation, render );
+	page( '/wp-super-cache/:tab?/:site?', siteSelection, navigation, controller.settings );
 }

--- a/client/extensions/wp-super-cache/main.jsx
+++ b/client/extensions/wp-super-cache/main.jsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import Navigation from './components/navigation';
+
+const WPSuperCache = ( { tab } ) => (
+	<Main className="wp-super-cache__main">
+		<Navigation activeTab={ tab } />
+	</Main>
+);
+
+WPSuperCache.propTypes = {
+	tab: React.PropTypes.string
+};
+
+WPSuperCache.defaultProps = {
+	tab: ''
+};
+
+export default WPSuperCache;

--- a/client/extensions/wp-super-cache/package.json
+++ b/client/extensions/wp-super-cache/package.json
@@ -6,7 +6,7 @@
 	"env_id": [ "development", "wpcalypso" ],
 	"section": {
 		"name": "wp-super-cache",
-		"paths": [ "/wp-super-cache" ],
+		"paths": [ "/extensions/wp-super-cache" ],
 		"module": "wp-super-cache",
 		"group": "sites",
 		"secondary": true


### PR DESCRIPTION
Adds tabbed navigation and routing to the WP Super Cache settings page.
Updates the URL to be _/extensions/wp-super-cache_.

#### Default Tab

![screen shot 2017-03-02 at 4 25 50 pm](https://cloud.githubusercontent.com/assets/1190420/23527732/18c0436e-ff65-11e6-85db-eacd48413249.jpg)

#### Selected Tab
![screen shot 2017-03-02 at 4 26 02 pm](https://cloud.githubusercontent.com/assets/1190420/23527741/21abccdc-ff65-11e6-865d-ace0bdf05eeb.jpg)

@dbtlr @pgk @donnchawp