### PR TITLE
Convert Sharing to use es6

### DIFF
--- a/client/layout/nux-welcome/welcome-message.jsx
+++ b/client/layout/nux-welcome/welcome-message.jsx
@@ -47,7 +47,7 @@ module.exports = React.createClass( {
 		if ( welcomeSite ) {
 			postLink = '/post/' + welcomeSite.slug;
 			customizeLink = config.isEnabled( 'manage/customize' ) ? '/customize/' + welcomeSite.slug : adminURL + 'customize.php?return=' + encodeURIComponent( window.location.href );
-			sharingLink = config.isEnabled( 'manage/sharing' ) ? '/sharing/' + welcomeSite.slug : adminURL + 'options-general.php?page=sharing';
+			sharingLink = '/sharing/' + welcomeSite.slug;
 		}
 
 		if ( window.innerWidth <= 400 ) {

--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -28,7 +28,7 @@ export const layout = ( { contentComponent, path, store } ) => {
 	}
 
 	renderWithReduxStore(
-		createElement( Sharing, { contentComponent, path, site } ),
+		createElement( Sharing, { contentComponent, path } ),
 		document.getElementById( 'primary' ),
 		store
 	);

--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -75,9 +75,3 @@ export const buttons = ( context, next ) => {
 
 	next();
 };
-
-export default {
-	buttons,
-	connections,
-	layout,
-};

--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -1,97 +1,83 @@
 /**
  * External Dependencies
  */
-var page = require( 'page' ),
-	React = require( 'react' ),
-	i18n = require( 'i18n-calypso' );
+import { createElement } from 'react';
+import page from 'page';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
  */
-var sites = require( 'lib/sites-list' )(),
-	utils = require( 'lib/site/utils' ),
-	notices = require( 'notices' ),
-	route = require( 'lib/route' ),
-	analytics = require( 'lib/analytics' ),
-	setTitle = require( 'state/document-head/actions' ).setDocumentHeadTitle,
-	analyticsPageTitle = 'Sharing';
-
+import notices from 'notices';
+import { pageView } from 'lib/analytics';
 import { renderWithReduxStore } from 'lib/react-helpers';
+import { sectionify } from 'lib/route';
+import Sharing from 'my-sites/sharing/main';
+import SharingButtons from 'my-sites/sharing/buttons/buttons';
+import SharingConnections from 'my-sites/sharing/connections/connections';
+import sites from 'lib/sites-list';
+import utils from 'lib/site/utils';
 
-module.exports = {
-	layout: function( context ) {
-		var Sharing = require( 'my-sites/sharing/main' ),
-			site = sites.getSelectedSite();
+const analyticsPageTitle = 'Sharing';
 
-		context.store.dispatch( setTitle( i18n.translate( 'Sharing', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+export const layout = ( { contentComponent, path, store } ) => {
+	const site = sites().getSelectedSite();
 
-		if ( site && ! site.settings && utils.userCan( 'manage_options', site ) ) {
-			site.fetchSettings();
-		}
-
-		renderWithReduxStore(
-			React.createElement( Sharing, {
-				path: context.path,
-				contentComponent: context.contentComponent
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
-	},
-
-	connections: function( context, next ) {
-		var SharingConnections = require( 'my-sites/sharing/connections/connections' ),
-			site = sites.getSelectedSite(),
-			basePath = route.sectionify( context.path ),
-			baseAnalyticsPath;
-
-		if ( site ) {
-			baseAnalyticsPath = basePath + '/:site';
-		} else {
-			baseAnalyticsPath = basePath;
-		}
-
-		if ( site && ! utils.userCan( 'publish_posts', site ) ) {
-			notices.error( i18n.translate( 'You are not authorized to manage sharing settings for this site.' ) );
-		}
-
-		if ( site && site.jetpack && ! site.isModuleActive( 'publicize' ) ) {
-			// Redirect to sharing buttons if Jetpack Publicize module is not
-			// active, but ShareDaddy is active
-			page.redirect( site.isModuleActive( 'sharedaddy' ) ? '/sharing/buttons/' + sites.selected : '/stats' );
-		} else {
-			analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle + ' > Connections' );
-
-			context.contentComponent = React.createElement( SharingConnections );
-		}
-
-		next();
-	},
-
-	buttons: function( context, next ) {
-		var SharingButtons = require( 'my-sites/sharing/buttons/buttons' ),
-			site = sites.getSelectedSite(),
-			basePath = route.sectionify( context.path ),
-			baseAnalyticsPath;
-
-		if ( site ) {
-			baseAnalyticsPath = basePath + '/:site';
-		} else {
-			baseAnalyticsPath = basePath;
-		}
-
-		analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle + ' > Sharing Buttons' );
-
-		if ( site && ! utils.userCan( 'manage_options', site ) ) {
-			notices.error( i18n.translate( 'You are not authorized to manage sharing settings for this site.' ) );
-		}
-
-		if ( site && site.jetpack && ( ! site.isModuleActive( 'sharedaddy' ) || site.versionCompare( '3.4-dev', '<' ) ) ) {
-			notices.error( i18n.translate( 'This page is only available to Jetpack sites running version 3.4 or higher with the Sharing module activated.' ) );
-		}
-
-		context.contentComponent = React.createElement( SharingButtons );
-
-		next();
+	if ( site && ! site.settings && utils.userCan( 'manage_options', site ) ) {
+		site.fetchSettings();
 	}
+
+	renderWithReduxStore(
+		createElement( Sharing, { contentComponent, path, site } ),
+		document.getElementById( 'primary' ),
+		store
+	);
+};
+
+export const connections = ( context, next ) => {
+	const site = sites().getSelectedSite();
+	const basePath = sectionify( context.path );
+	const baseAnalyticsPath = site ? basePath + '/:site' : basePath;
+
+	if ( site && ! utils.userCan( 'publish_posts', site ) ) {
+		notices.error( translate( 'You are not authorized to manage sharing settings for this site.' ) );
+	}
+
+	if ( site && site.jetpack && ! site.isModuleActive( 'publicize' ) ) {
+		// Redirect to sharing buttons if Jetpack Publicize module is not
+		// active, but ShareDaddy is active
+		page.redirect( site.isModuleActive( 'sharedaddy' ) ? '/sharing/buttons/' + sites.selected : '/stats' );
+	} else {
+		pageView.record( baseAnalyticsPath, analyticsPageTitle + ' > Connections' );
+
+		context.contentComponent = createElement( SharingConnections );
+	}
+
+	next();
+};
+
+export const buttons = ( context, next ) => {
+	const site = sites().getSelectedSite();
+	const basePath = sectionify( context.path );
+	const baseAnalyticsPath = site ? basePath + '/:site' : basePath;
+
+	pageView.record( baseAnalyticsPath, analyticsPageTitle + ' > Sharing Buttons' );
+
+	if ( site && ! utils.userCan( 'manage_options', site ) ) {
+		notices.error( translate( 'You are not authorized to manage sharing settings for this site.' ) );
+	}
+
+	if ( site && site.jetpack && ( ! site.isModuleActive( 'sharedaddy' ) || site.versionCompare( '3.4-dev', '<' ) ) ) {
+		notices.error( translate( 'This page is only available to Jetpack sites running version 3.4 or higher with the Sharing module activated.' ) );
+	}
+
+	context.contentComponent = createElement( SharingButtons );
+
+	next();
+};
+
+export default {
+	buttons,
+	connections,
+	layout,
 };

--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -12,9 +12,9 @@ import notices from 'notices';
 import { pageView } from 'lib/analytics';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import { sectionify } from 'lib/route';
-import Sharing from 'my-sites/sharing/main';
-import SharingButtons from 'my-sites/sharing/buttons/buttons';
-import SharingConnections from 'my-sites/sharing/connections/connections';
+import Sharing from './main';
+import SharingButtons from './buttons/buttons';
+import SharingConnections from './connections/connections';
 import sites from 'lib/sites-list';
 import utils from 'lib/site/utils';
 

--- a/client/my-sites/sharing/index.js
+++ b/client/my-sites/sharing/index.js
@@ -1,20 +1,16 @@
 /**
  * External dependencies
  */
-var page = require( 'page' );
+import page from 'page';
 
 /**
  * Internal dependencies
  */
-var sharingController = require( './controller' ),
-	controller = require( 'my-sites/controller' ),
-	config = require( 'config' );
+import { awaitSiteLoaded, jetpackModuleActive, navigation, sites, siteSelection } from 'my-sites/controller';
+import { buttons, connections, layout } from './controller';
 
-
-module.exports = function() {
-	if ( config.isEnabled( 'manage/sharing' ) ) {
-		page( /^\/sharing(\/buttons)?$/, controller.siteSelection, controller.sites );
-		page( '/sharing/:domain', controller.siteSelection, controller.navigation, controller.awaitSiteLoaded, controller.jetpackModuleActive( 'publicize', false ), sharingController.connections, sharingController.layout );
-		page( '/sharing/buttons/:domain', controller.siteSelection, controller.navigation, controller.awaitSiteLoaded, controller.jetpackModuleActive( 'sharedaddy' ), sharingController.buttons, sharingController.layout );
-	}
-};
+export default function() {
+	page( /^\/sharing(\/buttons)?$/, siteSelection, sites );
+	page( '/sharing/:domain', siteSelection, navigation, awaitSiteLoaded, jetpackModuleActive( 'publicize', false ), connections, layout );
+	page( '/sharing/buttons/:domain', siteSelection, navigation, awaitSiteLoaded, jetpackModuleActive( 'sharedaddy' ), buttons, layout );
+}

--- a/client/my-sites/sharing/main.jsx
+++ b/client/my-sites/sharing/main.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { find, get } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -18,67 +18,57 @@ import SectionNav from 'components/section-nav';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
 
-class Sharing extends Component {
-	getFilters() {
-		const { canManageOptions, site, translate } = this.props;
-		const pathSuffix = site ? '/' + site.slug : '';
-		const filters = [];
+export const Sharing = ( { canManageOptions, contentComponent, path, site, translate } ) => {
+	const pathSuffix = site ? '/' + site.slug : '';
+	const filters = [];
 
-		// Include Connections link if all sites are selected. Otherwise,
-		// verify that the required Jetpack module is active
-		if ( ! site || ! site.jetpack || site.isModuleActive( 'publicize' ) ) {
-			filters.push( {
-				id: 'sharing-connections',
-				path: '/sharing' + pathSuffix,
-				title: translate( 'Connections' ),
-			} );
-		}
-
-		// Include Sharing Buttons link if a site is selected and the
-		// required Jetpack module is active
-		if ( site && canManageOptions &&
-			( ! site.jetpack ||
-				( site.isModuleActive( 'sharedaddy' ) && site.versionCompare( '3.4-dev', '>=' ) )
-			)
-		) {
-			filters.push( {
-				id: 'sharing-buttons',
-				path: '/sharing/buttons' + pathSuffix,
-				title: translate( 'Sharing Buttons' ),
-			} );
-		}
-
-		return filters;
+	// Include Connections link if all sites are selected. Otherwise,
+	// verify that the required Jetpack module is active
+	if ( ! site || ! site.jetpack || site.isModuleActive( 'publicize' ) ) {
+		filters.push( {
+			id: 'sharing-connections',
+			route: '/sharing' + pathSuffix,
+			title: translate( 'Connections' ),
+		} );
 	}
 
-	render() {
-		const filters = this.getFilters();
-		const selected = find( filters, { path: this.props.path } );
-
-		return (
-			<Main className="sharing">
-				<DocumentHead title={ this.props.translate( 'Sharing', { textOnly: true } ) } />
-				<SidebarNavigation />
-				<SectionNav selectedText={ get( selected, 'title', '' ) }>
-					<NavTabs>
-						{ filters.map( ( { id, path, title } ) => (
-							<NavItem key={ id } path={ path } selected={ path === this.props.path }>
-								{ title }
-							</NavItem>
-						) ) }
-					</NavTabs>
-				</SectionNav>
-				<UpgradeNudge
-					title={ this.props.translate( 'No Ads with WordPress.com Premium' ) }
-					message={ this.props.translate( 'Prevent ads from showing on your site.' ) }
-					feature="no-adverts"
-					event="sharing_no_ads"
-				/>
-				{ this.props.contentComponent }
-			</Main>
-		);
+	// Include Sharing Buttons link if a site is selected and the
+	// required Jetpack module is active
+	if ( site && canManageOptions &&
+		( ! site.jetpack || ( site.isModuleActive( 'sharedaddy' ) && site.versionCompare( '3.4-dev', '>=' ) ) )
+	) {
+		filters.push( {
+			id: 'sharing-buttons',
+			route: '/sharing/buttons' + pathSuffix,
+			title: translate( 'Sharing Buttons' ),
+		} );
 	}
-}
+
+	const selected = find( filters, { route: path } );
+
+	return (
+		<Main className="sharing">
+			<DocumentHead title={ translate( 'Sharing', { textOnly: true } ) } />
+			<SidebarNavigation />
+			<SectionNav selectedText={ get( selected, 'title', '' ) }>
+				<NavTabs>
+					{ filters.map( ( { id, route, title } ) => (
+						<NavItem key={ id } path={ route } selected={ path === route }>
+							{ title }
+						</NavItem>
+					) ) }
+				</NavTabs>
+			</SectionNav>
+			<UpgradeNudge
+				event="sharing_no_ads"
+				feature="no-adverts"
+				message={ translate( 'Prevent ads from showing on your site.' ) }
+				title={ translate( 'No Ads with WordPress.com Premium' ) }
+			/>
+			{ contentComponent }
+		</Main>
+	);
+};
 
 Sharing.propTypes = {
 	canManageOptions: PropTypes.bool,

--- a/client/my-sites/sharing/main.jsx
+++ b/client/my-sites/sharing/main.jsx
@@ -101,11 +101,11 @@ export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
 		const isJetpack = isJetpackSite( state, siteId );
+		const canManageOptions = canCurrentUser( state, siteId, 'manage_options' );
+		const hasSharedaddy = isJetpackModuleActive( state, siteId, 'sharedaddy' ) && isJetpackMinimumVersion( state, siteId, '3.4-dev' );
 
 		return {
-			showButtons: ( siteId && canCurrentUser( state, siteId, 'manage_options' ) && ( ! isJetpack || (
-				isJetpackModuleActive( state, siteId, 'sharedaddy' ) && isJetpackMinimumVersion( state, siteId, '3.4-dev' )
-			) ) ),
+			showButtons: siteId && canManageOptions && ( ! isJetpack || hasSharedaddy ),
 			showConnections: ! siteId || ! isJetpack || isJetpackModuleActive( state, siteId, 'publicize' ),
 			siteId,
 			siteSlug: getSiteSlug( state, siteId ),

--- a/client/my-sites/sharing/main.jsx
+++ b/client/my-sites/sharing/main.jsx
@@ -61,7 +61,7 @@ export const Sharing = ( {
 
 	return (
 		<Main className="sharing">
-			<DocumentHead title={ translate( 'Sharing', { textOnly: true } ) } />
+			<DocumentHead title={ translate( 'Sharing' ) } />
 			{ siteId && <QueryJetpackModules siteId={ siteId } /> }
 			<SidebarNavigation />
 			{ filters.length > 0 &&

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -428,10 +428,6 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		if ( ! config.isEnabled( 'manage/sharing' ) && site.options ) {
-			sharingLink = site.options.admin_url + 'options-general.php?page=sharing';
-		}
-
 		return (
 			<SidebarItem
 				label={ this.props.translate( 'Sharing' ) }

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -43,7 +43,6 @@
 		"manage/posts": true,
 		"manage/security": true,
 		"manage/seo": true,
-		"manage/sharing": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,

--- a/config/development.json
+++ b/config/development.json
@@ -80,7 +80,6 @@
 		"manage/posts": true,
 		"manage/security": true,
 		"manage/seo": true,
-		"manage/sharing": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -49,7 +49,6 @@
 		"manage/posts": true,
 		"manage/security": true,
 		"manage/seo": true,
-		"manage/sharing": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,

--- a/config/production.json
+++ b/config/production.json
@@ -45,7 +45,6 @@
 		"manage/posts": true,
 		"manage/security": true,
 		"manage/seo": true,
-		"manage/sharing": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -47,7 +47,6 @@
 		"manage/plugins/setup": true,
 		"manage/posts": true,
 		"manage/security": true,
-		"manage/sharing": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,

--- a/config/test.json
+++ b/config/test.json
@@ -61,7 +61,6 @@
 		"manage/posts": true,
 		"manage/security": true,
 		"manage/seo": true,
-		"manage/sharing": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -58,7 +58,6 @@
 		"manage/posts": true,
 		"manage/security": true,
 		"manage/seo": true,
-		"manage/sharing": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,


### PR DESCRIPTION
This PR modernizes Sharing's top-level components and removes the feature flag.

After #8991 these are the remaining pieces that can be cleaned up.

To test:
Verify that My Sites > Sharing is still accessible, both the Connections and the Sharing Buttons tab.