### PR TITLE
Media: fix videopress nudge

### DIFF
--- a/client/lib/media/validation-store.js
+++ b/client/lib/media/validation-store.js
@@ -5,7 +5,7 @@ import mapValues from 'lodash/mapValues';
 import without from 'lodash/without';
 import isEmpty from 'lodash/isEmpty';
 import pickBy from 'lodash/pickBy';
-import get from 'lodash/get';
+
 /**
  * Internal dependencies
  */
@@ -14,7 +14,6 @@ import emitter from 'lib/mixins/emitter';
 import Sites from 'lib/sites-list';
 import MediaUtils from './utils';
 import { ValidationErrors as MediaValidationErrors } from './constants';
-import { PLAN_FREE } from 'lib/plans/constants';
 
 /**
  * Module variables
@@ -61,7 +60,7 @@ MediaValidationStore.validateItem = function( siteId, item ) {
 	}
 
 	if ( ! MediaUtils.isSupportedFileTypeForSite( item, site ) ) {
-		if ( get( site, 'plan.product_slug' ) === PLAN_FREE && MediaUtils.isSupportedFileTypeInPremium( item, site ) ) {
+		if ( MediaUtils.isSupportedFileTypeInPremium( item, site ) ) {
 			itemErrors.push( MediaValidationErrors.FILE_TYPE_NOT_IN_PLAN );
 		} else {
 			itemErrors.push( MediaValidationErrors.FILE_TYPE_UNSUPPORTED );


### PR DESCRIPTION
Fixes #11623, where we'd see an unhelpful file type unsupported error when trying to upload videos to a site on a Personal Plan. This PR updates this to display a warning, explaining that if this is available if the site is upgraded to a premium plan.

Before:
![585b018c-fd38-11e6-9fb6-f800271d66fb](https://cloud.githubusercontent.com/assets/1270189/23531223/4e222708-ff5a-11e6-99d3-6f005d526b76.png)

After:
![5857ac62-fd38-11e6-9087-f89ce3bc616b](https://cloud.githubusercontent.com/assets/1270189/23531153/e31d49ec-ff59-11e6-9273-434eb2c9ca1f.png)

### Testing Instructions
- Navigate to http://calypso.localhost:3000/post
- Select a site with a personal plan
- Click on 
<img width="94" alt="screen shot 2017-03-02 at 3 09 09 pm" src="https://cloud.githubusercontent.com/assets/1270189/23531205/355b9330-ff5a-11e6-9592-24b41985b884.png"> to open the media modal
- Drag a support video type like .mov into the modal
- Above warning should display instead of unsupported file type error
- Repeat steps above with connect Jetpack site with a free or personal plan
- We should see the warning
- Invalid file types should still show the red unsupported file type error
