### PR TITLE
Editor: Fix over-riding of local title edits on auto-save.

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -713,6 +713,9 @@ export const PostEditor = React.createClass( {
 			this.props.resetEditorLastDraft();
 		}
 
+		// Remove this when the editor is completely reduxified ( When using Redux actions for all post saving requests )
+		this.props.savePostSuccess( post.site_ID, this.props.postId, post, {} );
+
 		// Receive updated post into state
 		this.props.receivePost( post );
 

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -713,9 +713,6 @@ export const PostEditor = React.createClass( {
 			this.props.resetEditorLastDraft();
 		}
 
-		// Remove this when the editor is completely reduxified ( When using Redux actions for all post saving requests )
-		this.props.savePostSuccess( post.site_ID, this.props.postId, post, {} );
-
 		// Receive updated post into state
 		this.props.receivePost( post );
 

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -21,7 +21,6 @@ import {
 	POST_RESTORE,
 	POST_RESTORE_FAILURE,
 	POST_SAVE,
-	POST_SAVE_SUCCESS,
 	POSTS_RECEIVE,
 	POSTS_REQUEST,
 	POSTS_REQUEST_SUCCESS,
@@ -273,7 +272,6 @@ export function edits( state = {}, action ) {
 			} );
 
 		case EDITOR_STOP:
-		case POST_SAVE_SUCCESS:
 			if ( ! state.hasOwnProperty( action.siteId ) ) {
 				break;
 			}

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -21,6 +21,7 @@ import {
 	POST_RESTORE,
 	POST_RESTORE_FAILURE,
 	POST_SAVE,
+	POST_SAVE_SUCCESS,
 	POSTS_RECEIVE,
 	POSTS_REQUEST,
 	POSTS_REQUEST_SUCCESS,
@@ -278,6 +279,23 @@ export function edits( state = {}, action ) {
 
 			return Object.assign( {}, state, {
 				[ action.siteId ]: omit( state[ action.siteId ], action.postId || '' )
+			} );
+
+		case POST_SAVE_SUCCESS:
+			if ( ! state.hasOwnProperty( action.siteId ) || ! action.savedPost ) {
+				break;
+			}
+			const { postId, siteId, savedPost } = action;
+
+			if ( postId ) {
+				return state;
+			}
+
+			// if postId is null, copy over any edits
+			return Object.assign( {}, state, {
+				[ siteId ]: {
+					[ savedPost.ID ]: state[ siteId ][ '' ]
+				}
 			} );
 
 		case SERIALIZE:

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import { get, set, omit, omitBy, isEqual, reduce, merge, findKey, mapValues } from 'lodash';
+import { get, set, omit, omitBy, isEqual, reduce, merge, findKey, mapValues, mapKeys } from 'lodash';
 
 /**
  * Internal dependencies
@@ -282,21 +282,18 @@ export function edits( state = {}, action ) {
 			} );
 
 		case POST_SAVE_SUCCESS:
-			if ( ! state.hasOwnProperty( action.siteId ) || ! action.savedPost ) {
+			if ( ! state.hasOwnProperty( action.siteId ) || ! action.savedPost || action.postId ) {
 				break;
 			}
-			const { postId, siteId, savedPost } = action;
-
-			if ( postId ) {
-				return state;
-			}
+			const { siteId, savedPost } = action;
 
 			// if postId is null, copy over any edits
-			return Object.assign( {}, state, {
-				[ siteId ]: {
-					[ savedPost.ID ]: state[ siteId ][ '' ]
-				}
-			} );
+			return {
+				...state,
+				[ siteId ]: mapKeys( state[ siteId ], ( value, key ) => (
+					'' === key ? savedPost.ID : key
+				) )
+			};
 
 		case SERIALIZE:
 		case DESERIALIZE:

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -908,6 +908,9 @@ describe( 'reducer', () => {
 				2916284: {
 					'': {
 						title: 'Ribs & Chicken'
+					},
+					842: {
+						title: 'I like turtles'
 					}
 				}
 			} ), {
@@ -924,6 +927,9 @@ describe( 'reducer', () => {
 				2916284: {
 					841: {
 						title: 'Ribs & Chicken'
+					},
+					842: {
+						title: 'I like turtles'
 					}
 				}
 			} );

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -21,6 +21,7 @@ import {
 	POST_RESTORE,
 	POST_RESTORE_FAILURE,
 	POST_SAVE,
+	POST_SAVE_SUCCESS,
 	POSTS_RECEIVE,
 	POSTS_REQUEST,
 	POSTS_REQUEST_FAILURE,
@@ -886,6 +887,43 @@ describe( 'reducer', () => {
 					},
 					'': {
 						title: 'Unrelated'
+					}
+				}
+			} );
+		} );
+
+		it( 'should ignore reset edits action when discarded site doesn\'t exist', () => {
+			const original = deepFreeze( {} );
+			const state = edits( original, {
+				type: POST_SAVE_SUCCESS,
+				siteId: 2916284,
+				postId: 841
+			} );
+
+			expect( state ).to.equal( original );
+		} );
+
+		it( 'should copy edits when the post is saved and prior postId was null', () => {
+			const state = edits( deepFreeze( {
+				2916284: {
+					'': {
+						title: 'Ribs & Chicken'
+					}
+				}
+			} ), {
+				type: POST_SAVE_SUCCESS,
+				siteId: 2916284,
+				postId: null,
+				savedPost: {
+					ID: 841,
+					title: 'Ribs'
+				}
+			} );
+
+			expect( state ).to.eql( {
+				2916284: {
+					841: {
+						title: 'Ribs & Chicken'
 					}
 				}
 			} );

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -21,7 +21,6 @@ import {
 	POST_RESTORE,
 	POST_RESTORE_FAILURE,
 	POST_SAVE,
-	POST_SAVE_SUCCESS,
 	POSTS_RECEIVE,
 	POSTS_REQUEST,
 	POSTS_REQUEST_FAILURE,
@@ -887,42 +886,6 @@ describe( 'reducer', () => {
 					},
 					'': {
 						title: 'Unrelated'
-					}
-				}
-			} );
-		} );
-
-		it( 'should ignore reset edits action when discarded site doesn\'t exist', () => {
-			const original = deepFreeze( {} );
-			const state = edits( original, {
-				type: POST_SAVE_SUCCESS,
-				siteId: 2916284,
-				postId: 841
-			} );
-
-			expect( state ).to.equal( original );
-		} );
-
-		it( 'should discard edits when the post is saved', () => {
-			const state = edits( deepFreeze( {
-				2916284: {
-					841: {
-						title: 'Hello World'
-					},
-					'': {
-						title: 'Ribs & Chicken'
-					}
-				}
-			} ), {
-				type: POST_SAVE_SUCCESS,
-				siteId: 2916284,
-				postId: 841
-			} );
-
-			expect( state ).to.eql( {
-				2916284: {
-					'': {
-						title: 'Ribs & Chicken'
 					}
 				}
 			} );


### PR DESCRIPTION
This branch fixes #11567 which is causing local edits of the title field to be lost when the changes are made while an auto-save is in flight.

There is a video of the bug in #11567 - but to see the bug in action, add some content to a post ( draft ) you are editing, then focus on the title field.  Watch the ground control area, and as soon as an auto save fires, start changing the title, and once the API returns, your local title changes will disappear 💥 

I traced the issue back to `onSaveSuccess` in `<PostEditor />` which was calling `savePostSuccess` which clears out any local edits in the state tree.  `onSaveSuccess` also calls `receivePost` which iterates over the local edits, and compares it against the saved post from the API, and only deletes edits that match - so it _seems_ like the call to `recievePost` should be enough here ( though /cc @aduth for your thoughts ).