### PR TITLE
Account Recovery: Add the reset password sms form

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -11,6 +11,7 @@
 @import 'account-recovery/forgot-username/forgot-username-form/style';
 @import 'account-recovery/lost-password/lost-password-form/style';
 @import 'account-recovery/reset-password/reset-password-form/style';
+@import 'account-recovery/reset-password/reset-password-sms-form/style';
 @import 'account-recovery/reset-password/transaction-id-form/style';
 @import 'account-recovery/style';
 @import 'auth/style';

--- a/client/account-recovery/controller.js
+++ b/client/account-recovery/controller.js
@@ -11,6 +11,7 @@ import LostPasswordPage from 'account-recovery/lost-password';
 import ForgotUsernamePage from 'account-recovery/forgot-username';
 import ResetPasswordPage from 'account-recovery/reset-password';
 import ResetPasswordForm from 'account-recovery/reset-password/reset-password-form';
+import ResetPasswordSmsForm from 'account-recovery/reset-password/reset-password-sms-form';
 import TransactionIdForm from 'account-recovery/reset-password/transaction-id-form';
 import { getCurrentUser } from 'state/current-user/selectors';
 
@@ -28,6 +29,16 @@ export function resetPassword( context, next ) {
 	context.primary = (
 		<ResetPasswordPage basePath={ context.path }>
 			<ResetPasswordForm />
+		</ResetPasswordPage>
+	);
+
+	next();
+}
+
+export function resetPasswordSmsForm( context, next ) {
+	context.primary = (
+		<ResetPasswordPage basePath={ context.path }>
+			<ResetPasswordSmsForm />
 		</ResetPasswordPage>
 	);
 

--- a/client/account-recovery/index.js
+++ b/client/account-recovery/index.js
@@ -5,6 +5,7 @@ import {
 	lostPassword,
 	forgotUsername,
 	resetPassword,
+	resetPasswordSmsForm,
 	resetPasswordByTransactionId,
 	redirectLoggedIn
 } from './controller';
@@ -16,6 +17,7 @@ export default function( router ) {
 		router( '/account-recovery', redirectLoggedIn, lostPassword );
 		router( '/account-recovery/forgot-username', redirectLoggedIn, forgotUsername );
 		router( '/account-recovery/reset-password', redirectLoggedIn, resetPassword );
+		router( '/account-recovery/reset-password/sms-form', redirectLoggedIn, resetPasswordSmsForm );
 		router( '/account-recovery/reset-password/transaction-id', redirectLoggedIn, resetPasswordByTransactionId );
 	}
 }

--- a/client/account-recovery/reset-password/reset-password-sms-form/index.jsx
+++ b/client/account-recovery/reset-password/reset-password-sms-form/index.jsx
@@ -25,7 +25,7 @@ class ResetPasswordSmsForm extends Component {
 				<Card>
 					<p>
 						{ translate( 'Please enter the code you were sent by SMS. ' +
-								'It will look something like 63423423. You may need to wait a few moments before it arrives.' )
+							'It will look something like 63423423. You may need to wait a few moments before it arrives.' )
 						}
 					</p>
 					<FormTextInput className="reset-password-sms-form__validation-code-input" />

--- a/client/account-recovery/reset-password/reset-password-sms-form/index.jsx
+++ b/client/account-recovery/reset-password/reset-password-sms-form/index.jsx
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import FormTextInput from 'components/forms/form-text-input';
+import FormButton from 'components/forms/form-button';
+
+class ResetPasswordSmsForm extends Component {
+	render() {
+		const {
+			translate,
+		} = this.props;
+
+		return (
+			<div className="reset-password-sms-form">
+				<h2 className="reset-password-sms-form__title">
+					{ translate( 'Reset your password' ) }
+				</h2>
+				<Card>
+					<p>
+						{ translate( 'Please enter the code you were sent by SMS. ' +
+								'It will look something like 63423423. You may need to wait a few moments before it arrives.' )
+						}
+					</p>
+					<FormTextInput />
+					<a href="#">{ translate( 'No SMS?' ) }</a>
+					<FormButton />
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default localize( ResetPasswordSmsForm );

--- a/client/account-recovery/reset-password/reset-password-sms-form/index.jsx
+++ b/client/account-recovery/reset-password/reset-password-sms-form/index.jsx
@@ -28,9 +28,13 @@ class ResetPasswordSmsForm extends Component {
 								'It will look something like 63423423. You may need to wait a few moments before it arrives.' )
 						}
 					</p>
-					<FormTextInput />
-					<a href="#">{ translate( 'No SMS?' ) }</a>
-					<FormButton />
+					<FormTextInput className="reset-password-sms-form__validation-code-input" />
+					<a href="#" className="reset-password-sms-form__no-sms-link">
+						{ translate( 'No SMS?' ) }
+					</a>
+					<FormButton className="reset-password-sms-form__submit-button">
+						{ translate( 'Continue' ) }
+					</FormButton>
 				</Card>
 			</div>
 		);

--- a/client/account-recovery/reset-password/reset-password-sms-form/index.jsx
+++ b/client/account-recovery/reset-password/reset-password-sms-form/index.jsx
@@ -18,25 +18,23 @@ class ResetPasswordSmsForm extends Component {
 		} = this.props;
 
 		return (
-			<div className="reset-password-sms-form">
+			<Card>
 				<h2 className="reset-password-sms-form__title">
 					{ translate( 'Reset your password' ) }
 				</h2>
-				<Card>
-					<p>
-						{ translate( 'Please enter the code you were sent by SMS. ' +
-							'It will look something like 63423423. You may need to wait a few moments before it arrives.' )
-						}
-					</p>
-					<FormTextInput className="reset-password-sms-form__validation-code-input" />
-					<a href="#" className="reset-password-sms-form__no-sms-link">
-						{ translate( 'No SMS?' ) }
-					</a>
-					<FormButton className="reset-password-sms-form__submit-button">
-						{ translate( 'Continue' ) }
-					</FormButton>
-				</Card>
-			</div>
+				<p>
+					{ translate( 'Please enter the code you were sent by SMS. ' +
+						'It will look something like 63423423. You may need to wait a few moments before it arrives.' )
+					}
+				</p>
+				<FormTextInput className="reset-password-sms-form__validation-code-input" />
+				<FormButton className="reset-password-sms-form__submit-button">
+					{ translate( 'Continue' ) }
+				</FormButton>
+				<a href="#" className="reset-password-sms-form__no-sms-link">
+					{ translate( 'No SMS?' ) }
+				</a>
+			</Card>
 		);
 	}
 }

--- a/client/account-recovery/reset-password/reset-password-sms-form/index.jsx
+++ b/client/account-recovery/reset-password/reset-password-sms-form/index.jsx
@@ -24,7 +24,8 @@ class ResetPasswordSmsForm extends Component {
 				</h2>
 				<p>
 					{ translate( 'Please enter the code you were sent by SMS. ' +
-						'It will look something like 63423423. You may need to wait a few moments before it arrives.' )
+						'It will look something like {{code}}63423423{{/code}}. You may need to wait a few moments before it arrives.',
+						{ components: { code: <code /> } } )
 					}
 				</p>
 				<FormTextInput className="reset-password-sms-form__validation-code-input" />

--- a/client/account-recovery/reset-password/reset-password-sms-form/style.scss
+++ b/client/account-recovery/reset-password/reset-password-sms-form/style.scss
@@ -1,0 +1,18 @@
+.reset-password-sms-form__title {
+	font-size: 20px;
+	font-weight: 600;
+	margin-bottom: 8px;
+}
+
+.reset-password-sms-form__validation-code-input {
+	margin-top: 4px;
+}
+
+.reset-password-sms-form__no-sms-link {
+	padding: 8px 0px;
+	display: inline-block;
+}
+
+.reset-password-sms-form__submit-button {
+	width: 100%;
+}

--- a/client/account-recovery/reset-password/reset-password-sms-form/style.scss
+++ b/client/account-recovery/reset-password/reset-password-sms-form/style.scss
@@ -4,8 +4,8 @@
 	margin-bottom: 8px;
 }
 
-.reset-password-sms-form__validation-code-input {
-	margin-top: 4px;
+.form-text-input.reset-password-sms-form__validation-code-input {
+	margin-bottom: 16px;
 }
 
 .reset-password-sms-form__no-sms-link {


### PR DESCRIPTION
## Summary 
![image](https://cloud.githubusercontent.com/assets/1842898/23544266/45368d1e-0031-11e7-99f7-1f5eb832fda7.png)
This PR adds the form that users will see after choosing to reset passwords through sms numbers.

## Test Plan
* Open an incognito window, and make sure you are logged out.
* Visit http://calypso.localhost:3000/account-recovery/reset-password/sms-form and you should see the page.
* Note that the "No SMS" link and the "Continue" button don't do anything now as expected.