### PR TITLE
TrackInteractions: Fix react-redux private API import

### DIFF
--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -30,6 +30,9 @@ class ThemeMoreButton extends React.Component {
 	togglePopover() {
 		this.setState( { showPopover: ! this.state.showPopover } );
 		! this.state.showPopover && this.props.onMoreButtonClick( this.props.theme, this.props.index, 'popup_open' );
+		if ( this.props.onClick ) {
+			this.props.onClick();
+		}
 	}
 
 	closePopover( action ) {

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -2,21 +2,13 @@
  * External dependencies
  */
 import sinon from 'sinon';
-import { Provider } from 'react-redux';
 import { assert } from 'chai';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import useFakeDom from 'test/helpers/use-fake-dom';
 import useMockery from 'test/helpers/use-mockery';
-
-const fakeStore = {
-	dispatch: noop,
-	getState: noop,
-	subscribe: noop,
-};
 
 describe( 'Theme', function() {
 	let ReactDom, React, TestUtils, Theme, togglePopoverStub;
@@ -61,9 +53,7 @@ describe( 'Theme', function() {
 			beforeEach( function() {
 				this.props.onScreenshotClick = sinon.spy();
 				const themeElement = TestUtils.renderIntoDocument(
-					React.createElement( Provider, { store: fakeStore },
-						React.createElement( Theme, this.props )
-					)
+					React.createElement( Theme, this.props )
 				);
 				this.themeNode = ReactDom.findDOMNode( themeElement );
 			} );
@@ -134,9 +124,7 @@ describe( 'Theme', function() {
 		beforeEach( function() {
 			this.props.theme.price = '$50';
 			const themeElement = TestUtils.renderIntoDocument(
-				React.createElement( Provider, { store: fakeStore },
-					React.createElement( Theme, this.props )
-				)
+				React.createElement( Theme, this.props )
 			);
 			this.themeNode = ReactDom.findDOMNode( themeElement );
 		} );

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -1,14 +1,22 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import sinon from 'sinon';
+import { Provider } from 'react-redux';
+import { assert } from 'chai';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import useFakeDom from 'test/helpers/use-fake-dom';
 import useMockery from 'test/helpers/use-mockery';
+
+const fakeStore = {
+	dispatch: noop,
+	getState: noop,
+	subscribe: noop,
+};
 
 describe( 'Theme', function() {
 	let ReactDom, React, TestUtils, Theme, togglePopoverStub;
@@ -52,7 +60,11 @@ describe( 'Theme', function() {
 		context( 'with default display buttonContents', function() {
 			beforeEach( function() {
 				this.props.onScreenshotClick = sinon.spy();
-				let themeElement = TestUtils.renderIntoDocument( React.createElement( Theme, this.props ) );
+				const themeElement = TestUtils.renderIntoDocument(
+					React.createElement( Provider, { store: fakeStore },
+						React.createElement( Theme, this.props )
+					)
+				);
 				this.themeNode = ReactDom.findDOMNode( themeElement );
 			} );
 
@@ -121,8 +133,10 @@ describe( 'Theme', function() {
 	context( 'when the theme has a price', function() {
 		beforeEach( function() {
 			this.props.theme.price = '$50';
-			let themeElement = TestUtils.renderIntoDocument(
-				React.createElement( Theme, this.props )
+			const themeElement = TestUtils.renderIntoDocument(
+				React.createElement( Provider, { store: fakeStore },
+					React.createElement( Theme, this.props )
+				)
 			);
 			this.themeNode = ReactDom.findDOMNode( themeElement );
 		} );

--- a/client/components/track-interactions/index.js
+++ b/client/components/track-interactions/index.js
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import storeShape from 'react-redux/lib/utils/storeShape';
 import { cloneElement, Children, Component, PropTypes } from 'react';
-import { constant, isFunction, noop } from 'lodash';
+import { connect } from 'react-redux';
+import { constant, isFunction } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,29 +16,23 @@ const stringShape = PropTypes.oneOfType( [
 	PropTypes.arrayOf( PropTypes.string )
 ] );
 
-export default class TrackInteractions extends Component {
+class TrackInteractions extends Component {
 	static propTypes = {
 		children: PropTypes.element.isRequired,
 		mapPropsToAction: PropTypes.func,
 		fields: stringShape,
+
+		dispatch: PropTypes.func.isRequired,
 	}
 
 	static defaultProps = {
 		mapPropsToAction: constant( {} ),
 	}
 
-	static contextTypes = { store: storeShape };
-
-	constructor( props, context ) {
-		super( props, context );
-		const store = ( props.store || context.store );
-		this.dispatch = store ? store.dispatch : noop;
-	}
-
 	track = ( child ) => {
 		const action = this.mapPropsToAction( child.props );
 
-		this.dispatch( {
+		this.props.dispatch( {
 			type: COMPONENT_INTERACTION_TRACKED,
 			eventType: 'click',
 			component: child.type.name,
@@ -68,3 +62,5 @@ export default class TrackInteractions extends Component {
 		return cloneElement( child, props );
 	}
 }
+
+export default connect( null, null )( TrackInteractions );

--- a/client/components/track-interactions/index.js
+++ b/client/components/track-interactions/index.js
@@ -21,8 +21,8 @@ class TrackInteractions extends Component {
 		children: PropTypes.element.isRequired,
 		mapPropsToAction: PropTypes.func,
 		fields: stringShape,
-
-		dispatch: PropTypes.func.isRequired,
+		// connected
+		trackInteraction: PropTypes.func.isRequired,
 	}
 
 	static defaultProps = {
@@ -30,14 +30,10 @@ class TrackInteractions extends Component {
 	}
 
 	track = ( child ) => {
-		const action = this.mapPropsToAction( child.props );
-
-		this.props.dispatch( {
-			type: COMPONENT_INTERACTION_TRACKED,
-			eventType: 'click',
-			component: child.type.name,
-			...action,
-		} );
+		this.props.trackInteraction(
+			child.type.name,
+			this.mapPropsToAction( child.props )
+		);
 	}
 
 	mapPropsToAction( props ) {
@@ -63,4 +59,16 @@ class TrackInteractions extends Component {
 	}
 }
 
-export default connect( null, null )( TrackInteractions );
+function trackInteraction( componentName, data ) {
+	return {
+		type: COMPONENT_INTERACTION_TRACKED,
+		eventType: 'click',
+		component: componentName,
+		...data,
+	};
+}
+
+export default connect(
+	null,
+	{ trackInteraction }
+)( TrackInteractions );

--- a/client/components/track-interactions/index.js
+++ b/client/components/track-interactions/index.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { cloneElement, Children, Component, PropTypes } from 'react';
-import { connect } from 'react-redux';
 import { constant, isFunction } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import connectOptional from 'lib/connect-optional';
 import deepPick from 'lib/deep-pick';
 import { COMPONENT_INTERACTION_TRACKED } from 'state/action-types';
 
@@ -68,7 +68,7 @@ function trackInteraction( componentName, data ) {
 	};
 }
 
-export default connect(
+export default connectOptional(
 	null,
 	{ trackInteraction }
 )( TrackInteractions );

--- a/client/lib/connect-optional/index.js
+++ b/client/lib/connect-optional/index.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { constant, noop } from 'lodash';
+
+const fakeStore = {
+	dispatch: noop,
+	getState: constant( {} ),
+	subscribe: noop,
+};
+
+const connectOptional = ( ...connectArgs ) => WrappedComponent =>
+	wrapWithOptionalConnect( connect( ...connectArgs )( WrappedComponent ) );
+
+function wrapWithOptionalConnect( WrappedComponent ) {
+	return class extends Component {
+		static contextTypes = {
+			store: PropTypes.object
+		};
+
+		constructor( props, context ) {
+			super( props, context );
+			this.store = props.store ||
+				context.store ||
+				fakeStore;
+		}
+
+		render() {
+			return <WrappedComponent { ...this.props } store={ this.store } />;
+		}
+	};
+}
+
+export default connectOptional;


### PR DESCRIPTION
Fixes #11726 

Adding @budzanowski to the reviewers because of 94178c3.

# Testing

Make sure that clicking the ellipsis icons on each theme in `/design` (`ThemeMoreButton`) yields a `COMPONENT_INTERACTION_TRACKED` action in the Redux debugging tool and that the action's data is sane. Make sure that `ThemeMoreButton` itself doesn't break.