### PR TITLE
Pass down the event argument to onChange handlers in form-toggle component

### DIFF
--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -45,15 +45,15 @@ export default class FormToggle extends PureComponent {
 
 		if ( event.key === 'Enter' || event.key === ' ' ) {
 			event.preventDefault();
-			this.props.onChange();
+			this.props.onChange( event );
 		}
 
 		this.props.onKeyDown( event );
 	}
 
-	onClick() {
+	onClick( event ) {
 		if ( ! this.props.disabled ) {
-			this.props.onChange();
+			this.props.onChange( event );
 		}
 	}
 
@@ -65,7 +65,7 @@ export default class FormToggle extends PureComponent {
 		const nodeName = event.target.nodeName.toLowerCase();
 		if ( nodeName !== 'a' && nodeName !== 'input' && nodeName !== 'select' ) {
 			event.preventDefault();
-			this.props.onChange();
+			this.props.onChange( event );
 		}
 	}
 


### PR DESCRIPTION
This PR makes the FormToggle component call the function passed on its `handleToggle` property, with an `event` first argument.

#### Testing instructions

_incoming_

#### Why

Most `onChange` event handlers for form components are passed the event object by React, but we're not doing it in `FormToggle` as this component is emulating a form control and the passed `onChange` handler is not provided by React itself, but by us. 