### PR TITLE
Jetpack Settings: Make the carousel_display_exif setting toggle for jetpack sites autosave on toggle

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -48,6 +48,7 @@ class SiteSettingsFormWriting extends Component {
 			eventTracker,
 			fields,
 			handleToggle,
+			handleAutosavingToggle,
 			isRequestingSettings,
 			isSavingSettings,
 			onChangeField,
@@ -88,7 +89,7 @@ class SiteSettingsFormWriting extends Component {
 							}
 							<MediaSettings
 								siteId={ this.props.siteId }
-								handleToggle={ handleToggle }
+								handleAutosavingToggle={ handleAutosavingToggle }
 								onChangeField={ onChangeField }
 								isSavingSettings={ isSavingSettings }
 								isRequestingSettings={ isRequestingSettings }

--- a/client/my-sites/site-settings/media-settings/index.jsx
+++ b/client/my-sites/site-settings/media-settings/index.jsx
@@ -22,7 +22,7 @@ import { updateSettings } from 'state/jetpack/settings/actions';
 
 const MediaSettings = ( {
 	fields,
-	handleToggle,
+	handleAutosavingToggle,
 	onChangeField,
 	isRequestingSettings,
 	isSavingSettings,
@@ -69,7 +69,7 @@ const MediaSettings = ( {
 						className="media-settings__carousel-module-settings-toggle is-compact"
 						checked={ fields.carousel_display_exif || false }
 						disabled={ isRequestingSettings || isSavingSettings || ! carouselActive }
-						onChange={ handleToggle( 'carousel_display_exif' ) } >
+						onChange={ handleAutosavingToggle( 'carousel_display_exif' ) } >
 						{ translate( 'Show photo metadata in carousel, when available.' ) }
 					</FormToggle>
 					<FormLabel className={ labelClassName } htmlFor="carousel_background_color">
@@ -99,7 +99,7 @@ MediaSettings.propTypes = {
 	isSavingSettings: PropTypes.bool,
 	isRequestingSettings: PropTypes.bool,
 	siteId: PropTypes.number.isRequired,
-	handleToggle: PropTypes.func.isRequired,
+	handleAutosavingToggle: PropTypes.func.isRequired,
 	onChangeField: PropTypes.func.isRequired,
 	fields: PropTypes.object
 };


### PR DESCRIPTION
Part of #11676 

This PR makes the toggle for `carousel_display_exif` settings autosave on toggle.

<img src="https://cloud.githubusercontent.com/assets/746152/23552381/4eabc616-fffa-11e6-99b1-c50a4378b074.gif" height="500px" />


#### Testing instructions

1. Get to `/settings/writing/site-slug` where `site-slug` is one of your connected Jetpack sites.
1. Toggle the `Show photo metadata in carousel, when available` toggle.
2. Wait for the success notice to pop up.
3. Refresh the page and check that the setting value remains set as you left it before refreshing.


#### Why

While implementing a few toggles as part of #9171, we left some of them as regular toggles instead of autosaving ones as specified by the designs.
