### PR TITLE
Settings: Add handleAutosavingToggle method to wrap-settings-form High-order component

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -135,6 +135,13 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			this.props.updateFields( { [ name ]: ! this.props.fields[ name ] } );
 		};
 
+		handleAutosavingToggle = name => () => {
+			this.props.trackEvent( `Toggled ${ name }` );
+			this.props.updateFields( { [ name ]: ! this.props.fields[ name ] }, () => {
+				this.submitForm();
+			} );
+		};
+
 		onChangeField = field => event => {
 			this.props.updateFields( {
 				[ field ]: event.target.value
@@ -165,6 +172,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				handleSelect: this.handleSelect,
 				handleSubmitForm: this.handleSubmitForm,
 				handleToggle: this.handleToggle,
+				handleAutosavingToggle: this.handleAutosavingToggle,
 				onChangeField: this.onChangeField,
 				setFieldValue: this.setFieldValue,
 				submitForm: this.submitForm,


### PR DESCRIPTION
This PR introduces a `handleAutosavingToggle` to `wrapSettingsForm()`.

<img src="https://cloud.githubusercontent.com/assets/746152/23552381/4eabc616-fffa-11e6-99b1-c50a4378b074.gif" height="500px" />

#### Testing instructions.

PR #11744 has this commit cherry-picked, so you can try the live branch for #11744 and the instructions there in order to test the behaviour of the change introduced here.

1. Go to https://calypso.live/settings/?branch=update/autosave-on-toggle-media-settings-card
1. Select one of your connected Jetpack sites.
1. Toggle the `Show photo metadata in carousel` toggle.
1. Wait for the success notice to pop up.
1. Refresh the page and check that the setting value remains set as you left it before refreshing

#### Why

This allows us to have auto-saving toggles instead of just toggles that need to be also saved after being upated