### PR TITLE
Signup: remove version numbers from theme names.

### DIFF
--- a/client/lib/signup/themes-data.js
+++ b/client/lib/signup/themes-data.js
@@ -18,7 +18,7 @@ export const themes = [
 		verticals: []
 	},
 	{
-		name: 'Baskerville 2',
+		name: 'Baskerville',
 		slug: 'baskerville-2',
 		repo: 'pub',
 		fallback: false,
@@ -144,7 +144,7 @@ export const themes = [
 		verticals: []
 	},
 	{
-		name: 'Libre 2',
+		name: 'Libre',
 		slug: 'libre-2',
 		repo: 'pub',
 		fallback: false,


### PR DESCRIPTION
As themes get "refreshed", we should shy away from using version numbers for the Signup themes to reduce any possible user confusion.

Ref: pNEWy-95y-p2

#### Instructions for testing:
- Go to calypso.local:3000/start/
- Choose a design type.
- Make sure there are no themes on the `/themes/` step with a versioned label (e.g. Baskerville 2).
- Go back a step and repeat for each design type.