### PR TITLE
Media: add plan-storage component

### DIFF
--- a/client/blocks/plan-storage/style.scss
+++ b/client/blocks/plan-storage/style.scss
@@ -24,6 +24,7 @@
 }
 
 .plan-storage__storage-link {
+	margin-left: 3px;
 	text-decoration: none;
 }
 

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -128,13 +128,15 @@ export class MediaLibraryFilterBar extends Component {
 
 	render() {
 		return (
-			<SectionNav selectedText={ this.getFilterLabel( this.props.filter ) } hasSearch={ true }>
-				<SectionNavTabs>
-					{ this.renderTabItems() }
-				</SectionNavTabs>
-				{ this.renderSearchSection() }
+			<div className="media-library__filter-bar">
+				<SectionNav selectedText={ this.getFilterLabel( this.props.filter ) } hasSearch={ true }>
+					<SectionNavTabs>
+						{ this.renderTabItems() }
+					</SectionNavTabs>
+					{ this.renderSearchSection() }
+				</SectionNav>
 				{ this.renderPlanStorage() }
-			</SectionNav>
+			</div>
 		);
 	}
 }

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -16,6 +16,8 @@ import {
 import SectionNav from 'components/section-nav';
 import SectionNavTabs from 'components/section-nav/tabs';
 import Search from 'components/search';
+import TrackComponentView from 'lib/analytics/track-component-view';
+import PlanStorage from 'blocks/plan-storage';
 import FilterItem from './filter-item';
 
 export class MediaLibraryFilterBar extends Component {
@@ -114,14 +116,24 @@ export class MediaLibraryFilterBar extends Component {
 		);
 	}
 
+	renderPlanStorage() {
+		const eventName = 'calypso_upgrade_nudge_impression';
+		const eventProperties = { cta_name: 'plan-media-storage' };
+		return (
+			<PlanStorage siteId={ this.props.site.ID }>
+				<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
+			</PlanStorage>
+		);
+	}
+
 	render() {
 		return (
 			<SectionNav selectedText={ this.getFilterLabel( this.props.filter ) } hasSearch={ true }>
 				<SectionNavTabs>
 					{ this.renderTabItems() }
 				</SectionNavTabs>
-
 				{ this.renderSearchSection() }
+				{ this.renderPlanStorage() }
 			</SectionNav>
 		);
 	}

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -97,22 +97,31 @@ export class MediaLibraryFilterBar extends Component {
 		);
 	}
 
+	renderSearchSection() {
+		if ( this.props.filterRequiresUpgrade ) {
+			return null;
+		}
+
+		return (
+			<Search
+				analyticsGroup="Media"
+				pinned
+				fitsContainer
+				onSearch={ this.props.onSearch }
+				initialValue={ this.props.search }
+				placeholder={ this.getSearchPlaceholderText() }
+				delaySearch={ true } />
+		);
+	}
+
 	render() {
 		return (
 			<SectionNav selectedText={ this.getFilterLabel( this.props.filter ) } hasSearch={ true }>
 				<SectionNavTabs>
 					{ this.renderTabItems() }
 				</SectionNavTabs>
-				{ ! this.props.filterRequiresUpgrade &&
-					<Search
-						analyticsGroup="Media"
-						pinned
-						fitsContainer
-						onSearch={ this.props.onSearch }
-						initialValue={ this.props.search }
-						placeholder={ this.getSearchPlaceholderText() }
-						delaySearch={ true } />
-				}
+
+				{ this.renderSearchSection() }
 			</SectionNav>
 		);
 	}

--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -130,7 +130,6 @@ export default React.createClass( {
 					selectedItems={ this.props.selectedItems }
 					onViewDetails={ this.props.onViewDetails }
 					onDelete={ this.props.onDeleteItem }
-					renderStorage={ false }
 					site={ this.props.site }
 					view={ 'LIST' }
 				/>

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -44,6 +44,46 @@
 .media-library__header .button.media-library__upload-more {
 	margin-left: 0;
 }
+
+.media-library__filter-bar {
+	display: flex;
+	flex-flow: row nowrap;
+	align-items: stretch;
+	position: relative;
+
+	.section-nav {
+		flex: 1 auto;
+	}
+
+	.plan-storage {
+		display: none;
+		min-width: 200px;
+		margin-left: 1px;
+		margin-bottom: 9px;
+		box-shadow:
+		  0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		  0 1px 2px lighten( $gray, 30% );
+		background-color: $white;
+		padding-left:20px;
+		padding-right: 20px;
+		box-sizing: border-box;
+		flex: 1 0 auto;
+
+		@include breakpoint( ">480px" ) {
+			display: flex;
+		}
+
+		@include breakpoint( ">660px" ) {
+			display: none;
+		}
+
+		@include breakpoint( ">960px" ) {
+			display: flex;
+			margin-bottom: 17px;
+		}
+	}
+}
+
 .media-library__heading {
 	@include heading;
 	display: inline-block;

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -29,13 +29,11 @@ class MediaModalSecondaryActions extends Component {
 		disabled: PropTypes.bool,
 		onDelete: PropTypes.func,
 		onViewDetails: PropTypes.func,
-		renderStorage: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		disabled: false,
 		onDelete: noop,
-		renderStorage: true,
 	};
 
 	getButtons() {


### PR DESCRIPTION
## IMPORTANT

This PR is targeting to `try/media-section-v2`.

---------

This PR restores the `plan-storage` component in a new location. It was removed from secondary actions, and now it's anchored in the filter bar.

**Media Gallery - `full screen`**
<img src="https://cloud.githubusercontent.com/assets/77539/23618614/9da04c8e-026f-11e7-9e02-d4d561fe028a.png" width="600px" />


**Media Gallery - `> 960px`**
<img src="https://cloud.githubusercontent.com/assets/77539/23618668/d2986a34-026f-11e7-8df1-79a19b7917f8.png" width="400px" />

**Media Gallery - `> 660px` and `< 960px`**
<img src="https://cloud.githubusercontent.com/assets/77539/23632218/bd4308da-029f-11e7-91eb-03618aeae9a1.png" width="330px" />
_width: 960px_

**Media Gallery - `< 660px`**
<img src="https://cloud.githubusercontent.com/assets/77539/23618778/373c2980-0270-11e7-9c92-450dbbf3dfdb.png" width="300px" />

<img src="https://cloud.githubusercontent.com/assets/77539/23618856/8630260e-0270-11e7-821c-a2a9630cc6f3.png" width="250px" />


**Media Gallery - `< 480px`**
<img src="https://cloud.githubusercontent.com/assets/77539/23632190/ad85653c-029f-11e7-9858-00e5e2acba4b.png" width="250px" />
_width: 480px_

----------

### Testing

1) Open media library either from `media` section, from `post-editor` or `icon` site settings:
    - Icon site setting: `http://calypso.localhost:3000/settings/general/<site>`
    - Post editor: `http://calypso.localhost:3000/post/<site>`
    - Media section: `http://calypso.localhost:3000/media/<site>`
2) The plan-storage should be shown/hidden according to the different sizes of the viewport. Take a look at the screenshots above.
3) Keep in mind that `plan-storage` is hidden for sites with a business plan.

-----------
_`updated: 2017-03-06` by @retrofox_