### PR TITLE
Editor: increase the HTML Toolbar z-index

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -72,6 +72,7 @@ $z-layers: (
 		'.signup-processing-screen__processing-step.is-processing:before': 1,
 		'.accessible-focus .theme__more-button button:focus': 1,
 		'.domain-suggestion.is-clickable:hover': 1,
+		'.editor-html-toolbar': 1,
 		'.is-installing .theme': 2,
 		'.reader-update-notice': 2,
 		'.people-list-item .card__link-indicator': 2,

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -1,6 +1,7 @@
 .editor-html-toolbar {
 	height: 39px;
 	position: relative;
+	z-index: z-index( 'root', '.editor-html-toolbar' );
 
 	.editor-html-toolbar__wrapper {
 		background-color: rgba( $white, 0.92 );


### PR DESCRIPTION
To prevent compatibility issues with browser extensions modifying the textarea (e.g. Grammarly), I've added a `z-index: 1` to the HTML Toolbar.

## Screenshots

**Before**

The extension-modified textarea covers the toolbar when it sticks to the top of the page and even the Insert Media dropdown (notice the chevron pointing up).

<img width="716" alt="screen shot 2017-03-03 at 16 25 48" src="https://cloud.githubusercontent.com/assets/2070010/23560241/a3f83ece-0031-11e7-97e9-e616291347dc.png">
<img width="201" alt="screen shot 2017-03-03 at 16 25 59" src="https://cloud.githubusercontent.com/assets/2070010/23560240/a3f736f0-0031-11e7-94dd-02bbfc9f0962.png">


**After**

<img width="677" alt="screen shot 2017-03-03 at 16 26 27" src="https://cloud.githubusercontent.com/assets/2070010/23560252/a8778932-0031-11e7-9137-7f82f5785ed5.png">
<img width="219" alt="screen shot 2017-03-03 at 16 26 07" src="https://cloud.githubusercontent.com/assets/2070010/23560251/a8760116-0031-11e7-8ec1-f7fc90982556.png">