### PR TITLE
Framework: Upgrade to react-redux v5, take four

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -93,11 +93,8 @@ const ThemeSheet = React.createClass( {
 	},
 
 	getDefaultProps() {
-		// The defaultOption default prop is surprisingly important, see the long
-		// comment near the connect() function at the bottom of this file.
 		return {
-			section: '',
-			defaultOption: {}
+			section: ''
 		};
 	},
 
@@ -634,29 +631,6 @@ const ThemeSheetWithOptions = ( props ) => {
 };
 
 export default connect(
-	/*
-	 * A number of the props that this mapStateToProps function computes are used
-	 * by ThemeSheetWithOptions to compute defaultOption. After a state change
-	 * triggered by an async action, connect()ed child components are, quite
-	 * counter-intuitively, updated before their connect()ed parents (this is
-	 * https://github.com/reactjs/redux/issues/1415), and might be fixed by
-	 * react-redux 5.0.
-	 * For this reason, after e.g. activating a theme in single-site mode,
-	 * first the ThemeSheetWithOptions component's (child) connectOptions component
-	 * will update in response to the currently displayed theme being activated.
-	 * Doing so, it will filter and remove the activate option (adding customize
-	 * instead). However, since the parent connect()ed-ThemeSheetWithOptions will
-	 * only react to the state change afterwards, there is a brief moment when
-	 * connectOptions still receives "activate" as its defaultOption prop, when
-	 * activate is no longer part of its filtered options set, hence passing on
-	 * undefined as the defaultOption object prop for its child. For the theme
-	 * sheet, which eventually gets that defaultOption object prop, this means
-	 * we must be careful to not accidentally access any attribute of that
-	 * defaultOption prop. Otherwise, there will be an error that will prevent the
-	 * state update from finishing properly, hence not updating defaultOption at all.
-	 * The solution to this incredibly intricate issue is simple: Give ThemeSheet
-	 * a valid defaultProp for defaultOption.
-	 */
 	( state, { id } ) => {
 		const selectedSite = getSelectedSite( state );
 		const siteSlug = selectedSite ? getSiteSlug( state, selectedSite.ID ) : '';

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -34,7 +34,7 @@
       "version": "0.8.1"
     },
     "ajv": {
-      "version": "4.11.4"
+      "version": "4.11.5"
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -121,7 +121,7 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.9.5"
+      "version": "0.9.6"
     },
     "async": {
       "version": "0.9.0"
@@ -174,7 +174,7 @@
       "dev": true
     },
     "babel-generator": {
-      "version": "6.23.0",
+      "version": "6.24.0",
       "dependencies": {
         "source-map": {
           "version": "0.5.6"
@@ -299,7 +299,7 @@
       "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.23.0"
+      "version": "6.24.0"
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.22.0"
@@ -536,7 +536,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000632"
+      "version": "1.0.30000634"
     },
     "caseless": {
       "version": "0.12.0"
@@ -596,7 +596,7 @@
       "version": "1.0.1"
     },
     "chrono-node": {
-      "version": "1.2.5"
+      "version": "1.3.1"
     },
     "circular-json": {
       "version": "0.3.1",
@@ -1067,7 +1067,7 @@
       "version": "0.1.12"
     },
     "end-of-stream": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "once": {
           "version": "1.3.3"
@@ -1161,7 +1161,7 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.12",
+      "version": "0.10.13",
       "dev": true
     },
     "es6-iterator": {
@@ -1604,7 +1604,7 @@
       "version": "1.0.0"
     },
     "fstream": {
-      "version": "1.0.10"
+      "version": "1.0.11"
     },
     "function-bind": {
       "version": "1.1.0"
@@ -1940,7 +1940,7 @@
       "version": "1.0.1"
     },
     "is-buffer": {
-      "version": "1.1.4"
+      "version": "1.1.5"
     },
     "is-builtin-module": {
       "version": "1.0.0"
@@ -2332,6 +2332,9 @@
       "version": "1.5.3",
       "dev": true
     },
+    "lodash-es": {
+      "version": "4.17.4"
+    },
     "lodash._baseassign": {
       "version": "3.2.0",
       "dev": true
@@ -2653,7 +2656,7 @@
       "version": "3.0.6"
     },
     "normalize-package-data": {
-      "version": "2.3.5"
+      "version": "2.3.6"
     },
     "normalize-path": {
       "version": "2.0.1"
@@ -3108,7 +3111,7 @@
       "version": "1.0.2"
     },
     "react-redux": {
-      "version": "4.4.5"
+      "version": "5.0.2"
     },
     "react-test-env": {
       "version": "0.2.0",
@@ -3175,7 +3178,7 @@
       "dev": true
     },
     "recast": {
-      "version": "0.11.22",
+      "version": "0.11.23",
       "dependencies": {
         "source-map": {
           "version": "0.5.6"
@@ -3240,10 +3243,13 @@
       "version": "2.0.1"
     },
     "request": {
-      "version": "2.80.0",
+      "version": "2.81.0",
       "dependencies": {
         "qs": {
-          "version": "6.3.2"
+          "version": "6.4.0"
+        },
+        "tunnel-agent": {
+          "version": "0.6.0"
         },
         "uuid": {
           "version": "3.0.1"
@@ -3352,6 +3358,9 @@
     "rx-lite": {
       "version": "3.1.2",
       "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.0.1"
     },
     "samsam": {
       "version": "1.1.2",
@@ -4342,7 +4351,7 @@
       "dev": true
     },
     "webpack-sources": {
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "source-map": {
           "version": "0.5.6"
@@ -4479,7 +4488,7 @@
       "version": "3.2.1"
     },
     "yallist": {
-      "version": "2.0.0"
+      "version": "2.1.1"
     },
     "yargs": {
       "version": "3.10.0"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -435,7 +435,7 @@
       "version": "1.2.0",
       "dependencies": {
         "readable-stream": {
-          "version": "2.2.3"
+          "version": "2.2.5"
         }
       }
     },
@@ -536,7 +536,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000634"
+      "version": "1.0.30000635"
     },
     "caseless": {
       "version": "0.12.0"
@@ -963,7 +963,7 @@
       "version": "1.1.0"
     },
     "doiuse": {
-      "version": "2.5.0",
+      "version": "2.6.0",
       "dev": true,
       "dependencies": {
         "source-map": {
@@ -1028,7 +1028,7 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.3",
+          "version": "2.2.5",
           "dev": true
         }
       }
@@ -1067,12 +1067,7 @@
       "version": "0.1.12"
     },
     "end-of-stream": {
-      "version": "1.2.0",
-      "dependencies": {
-        "once": {
-          "version": "1.3.3"
-        }
-      }
+      "version": "1.4.0"
     },
     "engine.io": {
       "version": "1.6.8",
@@ -2229,7 +2224,12 @@
       "dev": true
     },
     "jsprim": {
-      "version": "1.3.1"
+      "version": "1.4.0",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0"
+        }
+      }
     },
     "jstimezonedetect": {
       "version": "1.0.5"
@@ -2441,7 +2441,7 @@
       "version": "0.3.0",
       "dependencies": {
         "readable-stream": {
-          "version": "2.2.3"
+          "version": "2.2.5"
         }
       }
     },
@@ -3136,7 +3136,7 @@
       "dev": true,
       "dependencies": {
         "readable-stream": {
-          "version": "2.2.3",
+          "version": "2.2.5",
           "dev": true
         }
       }
@@ -3165,7 +3165,7 @@
           "version": "3.0.3"
         },
         "readable-stream": {
-          "version": "2.2.3"
+          "version": "2.2.5"
         }
       }
     },
@@ -3723,7 +3723,7 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.3",
+          "version": "2.2.5",
           "dev": true
         },
         "resolve-from": {
@@ -3753,7 +3753,7 @@
           "version": "6.4.0"
         },
         "readable-stream": {
-          "version": "2.2.3"
+          "version": "2.2.5"
         }
       }
     },
@@ -3818,7 +3818,7 @@
       "version": "1.5.2",
       "dependencies": {
         "readable-stream": {
-          "version": "2.2.3"
+          "version": "2.2.5"
         }
       }
     },
@@ -4488,7 +4488,7 @@
       "version": "3.2.1"
     },
     "yallist": {
-      "version": "2.1.1"
+      "version": "2.1.2"
     },
     "yargs": {
       "version": "3.10.0"

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "react-dom": "15.4.0",
     "react-modal": "1.6.5",
     "react-pure-render": "1.0.2",
-    "react-redux": "4.4.5",
+    "react-redux": "5.0.2",
     "react-virtualized": "8.8.1",
     "redux": "3.0.4",
     "redux-thunk": "1.0.0",


### PR DESCRIPTION
Don't even think about merging this 😉  before ~#11437~ #11867 is in (see https://github.com/Automattic/wp-calypso/pull/11752#issuecomment-284027478).

(Furthermore, note that we can only 5.0.2 but not to 5.0.3 because of https://github.com/Automattic/wp-calypso/issues/11726. A fix is under development in https://github.com/Automattic/wp-calypso/pull/11739.)

cc @blowery 