### PR TITLE
Show 404 for `/mailing-lists` base path

### DIFF
--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -192,7 +192,7 @@ const sections = [
 	},
 	{
 		name: 'mailing-lists',
-		paths: [ '/mailing-lists' ],
+		paths: [ '/mailing-lists/unsubscribe' ],
 		module: 'mailing-lists',
 		enableLoggedOut: true
 	}


### PR DESCRIPTION
Previously, if the base path `/mailing-lists` was visited by a logged out user, a blank page would be shown.

![screencapture at fri mar 3 14 13 32 est 2017](https://cloud.githubusercontent.com/assets/2098816/23565438/988884d8-001b-11e7-99e2-0401da00e5c1.png)

Instead, the proper 404 "Page not found" should be shown.

![screencapture at fri mar 3 14 14 04 est 2017](https://cloud.githubusercontent.com/assets/2098816/23565457/acaf85ba-001b-11e7-89fe-d49765982d72.png)

To test:
- Try to access `/mailing-lists` and verify "Page not found" is shown and 404 returned
- Try to access `/mailing-lists/unsubscribe` and verify the "You're subscribed" page is shown (note: because of https://github.com/Automattic/wp-calypso/issues/11756, a broken page appears instead of an error message, even though valid query parameters were not provided).