### PR TITLE
Happychat - filter out browser info messages

### DIFF
--- a/client/lib/happychat/connection.js
+++ b/client/lib/happychat/connection.js
@@ -64,6 +64,13 @@ class Connection extends EventEmitter {
 		);
 	}
 
+	info( message ) {
+		this.openSocket.then(
+			socket => socket.emit( 'message', { text: message.text, id: uuid(), meta: { suppress: true } } ),
+			e => debug( 'failed to send message', e )
+		);
+	}
+
 	transcript( timestamp ) {
 		return this.openSocket.then( socket => Promise.race( [
 			new Promise( ( resolve, reject ) => {

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -34,7 +34,7 @@ import { isTicketSupportEligible, isTicketSupportConfigurationReady, getTicketSu
 import QueryOlark from 'components/data/query-olark';
 import QueryTicketSupportConfiguration from 'components/data/query-ticket-support-configuration';
 import HelpUnverifiedWarning from '../help-unverified-warning';
-import { connectChat as connectHappychat, sendChatMessage as sendHappychatMessage } from 'state/happychat/actions';
+import { connectChat as connectHappychat, sendChatMessage as sendHappychatMessage, sendBrowserInfo } from 'state/happychat/actions';
 import { openChat as openHappychat } from 'state/ui/happychat/actions';
 import { getCurrentUserLocale } from 'state/current-user/selectors';
 
@@ -130,18 +130,8 @@ const HelpContact = React.createClass( {
 		const { message, siteId } = contactForm;
 		const site = sites.getSite( siteId );
 
-		const userAgent = `User Agent: ${ navigator.userAgent }`;
-		const screenRes = `Screen Resolution: ${ screen.width }x${ screen.height }\n`;
-		const browserSize = `Browser Size: ${ window.innerWidth }x${ window.innerHeight }\n`;
-		const browserInfoMsg = [ `Information to assist troubleshooting.\n ${ screenRes } ${ browserSize } ${ userAgent }` ];
-
-		let messages = browserInfoMsg.concat( message );
-
-		if ( site ) {
-			messages = [ `Site I need help with: ${ site.URL }` ].concat( messages );
-		}
-
-		messages.forEach( this.props.sendHappychatMessage );
+		this.props.sendBrowserInfo( site.URL );
+		this.props.sendHappychatMessage( message );
 
 		page( '/help' );
 	},
@@ -659,5 +649,5 @@ export default connect(
 			ticketSupportRequestError: getTicketSupportRequestError( state ),
 		};
 	},
-	{ connectHappychat, openHappychat, sendHappychatMessage }
+	{ connectHappychat, openHappychat, sendHappychatMessage, sendBrowserInfo }
 )( localize( HelpContact ) );

--- a/client/state/happychat/actions.js
+++ b/client/state/happychat/actions.js
@@ -80,6 +80,19 @@ export const requestTranscript = () => ( dispatch, getState ) => {
 	);
 };
 
+export const sendBrowserInfo = () => dispatch => {
+	const userAgent = `User Agent: ${ navigator.userAgent }`;
+	const screenRes = `Screen Resolution: ${ screen.width }x${ screen.height }\n`;
+	const browserSize = `Browser Size: ${ window.innerWidth }x${ window.innerHeight }\n`;
+	const msg = {
+		text: `Information to assist troubleshooting.\n ${ screenRes } ${ browserSize } ${ userAgent }`,
+	};
+
+	debug( 'sending info message', msg );
+	dispatch( clearChatMessage() );
+	connection.info( msg );
+};
+
 /**
  * Opens Happychat Socket.IO client connection.
  * @return {Thunk} Action thunk

--- a/client/state/happychat/reducer.js
+++ b/client/state/happychat/reducer.js
@@ -65,6 +65,10 @@ const timeline = ( state = [], action ) => {
 		case DESERIALIZE:
 			return state;
 		case HAPPYCHAT_RECEIVE_EVENT:
+			// if meta.suppress is set, skip so won't show to user
+			if ( get( action, 'event.meta.suppress', false ) ) {
+				return state;
+			}
 			const event = timeline_event( {}, action );
 			const existing = find( state, ( { id } ) => event.id === id );
 			return existing ? state : concat( state, [ event ] );


### PR DESCRIPTION
Suppress the browser info messages so the user does not see them cluttering up the support chat. The information is useful for the Operator providing support, but not necessary for the user to see.

Fixes #219-gh-happychat