### PR TITLE
Add access to the dotcom `theme-setup` endpoint.

### DIFF
--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -253,6 +253,18 @@ UndocumentedSite.prototype.getConnection = function( connectionId ) {
 };
 
 /**
+ * Runs Theme Setup (Headstart).
+ *
+ * @return {Promise} A Promise to resolve when complete.
+ */
+UndocumentedSite.prototype.runThemeSetup = function() {
+	return this.wpcom.req.post( {
+		path: `/sites/${ this._id }/theme-setup`,
+		apiNamespace: 'wpcom/v2',
+	} );
+};
+
+/**
  * Expose `UndocumentedSite` module
  */
 module.exports = UndocumentedSite;

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -259,7 +259,7 @@ UndocumentedSite.prototype.getConnection = function( connectionId ) {
  */
 UndocumentedSite.prototype.runThemeSetup = function() {
 	return this.wpcom.req.post( {
-		path: `/sites/${ this._id }/theme-setup`,
+		path: '/sites/' + this._id + '/theme-setup',
 		apiNamespace: 'wpcom/v2',
 	} );
 };


### PR DESCRIPTION
This will be used by Headstart on demand (being worked on in #10542 ).