### PR TITLE
Reader: Fix how we accept error or broken responses from tag images

### DIFF
--- a/client/state/reader/tags/images/actions.js
+++ b/client/state/reader/tags/images/actions.js
@@ -57,7 +57,7 @@ export function requestTagImages( tag, limit = 5 ) {
 
 		return wpcom.undocumented().readTagImages( query )
 		.then( ( data ) => {
-			dispatch( receiveTagImages( tag, data.images ) );
+			dispatch( receiveTagImages( tag, ( data && data.images ) || [] ) );
 
 			dispatch( {
 				type: READER_TAG_IMAGES_REQUEST_SUCCESS,
@@ -66,6 +66,9 @@ export function requestTagImages( tag, limit = 5 ) {
 			} );
 		},
 		( error ) => {
+			// dispatch an empty array so we stop requesting it
+			dispatch( receiveTagImages( tag, [] ) );
+
 			dispatch( {
 				type: READER_TAG_IMAGES_REQUEST_FAILURE,
 				tag,


### PR DESCRIPTION
Currently, if the server responds with an error or a bad result object, we end up re-requesting tag images because we don't currently have any. This ends up spamming the server and issuing a ton of ES requests.

This changes it to push in an empty result set instead of nothing, preventing the duplicate requests.

Testing is a pain. Fire up a sandbox, alter the tag images endpoint to always error, and verify that we don't spam the API with requests when it returns.