### PR TITLE
Search: avoid url search loop

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -119,10 +119,6 @@ const Search = React.createClass( {
 		if ( nextProps.isOpen ) {
 			this.setState( { isOpen: nextProps.isOpen } );
 		}
-
-		if ( nextProps.initialValue !== this.props.initialValue ) {
-			this.setState( { keyword: nextProps.initialValue || '' } );
-		}
 	},
 
 	componentDidUpdate: function( prevProps, prevState ) {

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -41,6 +41,7 @@ const Search = React.createClass( {
 	propTypes: {
 		additionalClasses: PropTypes.string,
 		initialValue: PropTypes.string,
+		value: PropTypes.string,
 		placeholder: PropTypes.string,
 		pinned: PropTypes.bool,
 		delaySearch: PropTypes.bool,
@@ -118,6 +119,10 @@ const Search = React.createClass( {
 
 		if ( nextProps.isOpen ) {
 			this.setState( { isOpen: nextProps.isOpen } );
+		}
+
+		if ( nextProps.value && nextProps.value !== this.state.keyword ) {
+			this.setState( { keyword: nextProps.value } );
 		}
 	},
 

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -196,7 +196,7 @@ class ThemesMagicSearchCard extends React.Component {
 		const searchField = (
 			<Search
 				onSearch={ this.props.onSearch }
-				initialValue={ this.state.searchInput }
+				value={ this.state.searchInput }
 				ref="url-search"
 				placeholder={ translate( 'What kind of theme are you looking for?' ) }
 				analyticsGroup="Themes"

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -214,7 +214,7 @@ class SearchStream extends Component {
 				<div className="search-stream__fixed-area" ref={ this.handleSearchBoxMounted }>
 					<CompactCard className="search-stream__input-card">
 						<SearchInput
-							initialValue={ query }
+							value={ query }
 							onSearch={ this.updateQuery }
 							onSearchClose={ this.scrollToTop }
 							autoFocus={ this.props.autoFocusInput }


### PR DESCRIPTION
This fixes #11566 where search can get into an infinite loop.

This happens when search has a delay set, we use the urlSearch mixin, and the user types rapidly. It looks like `initialValue` prop for search is not only used on mount but any time it updates. Consequently the `?s=foo` search query parameter is triggering a search any time the user types in the search box.

cc @gibrown @samouri are there any use cases where we'd want to keep the original initialValue behavior? It seems a bit unintuitive otherwise.

![49872522-fa87-11e6-87ea-70a1d05dba42](https://cloud.githubusercontent.com/assets/1270189/23572234/834801d2-0022-11e7-85a0-66093259ff93.gif)

### Testing Instructions
- Navigate to http://calypso.localhost:3000/media
- Select a site
- Click on the search icon in the top right corner
- Type a search, the url should update with `?s=yoursearch`
- Type rapidly, delete text
- We should not be able to get into a loop like above

Since this is a component that's used widely let's also do a bit of smoke testing
- [x] blocks/author-selector
- [x] components/search-card
- [x] components/section-nav
- [x] components/site-selector
- [x] media library (editor)
- [x] media library section
- [x] my-sites/pages/main
- [x] my-sites/people/people-section-nav
- [x] my-sites/plugins/main
- [x] my-sites/plugins-wpcom/jetpack-plugins-panel
- [x] my-sites/plugins/plugin-browser
- [x] my-sites/post-type-filter
- [x] my-sites/posts/posts-navigation
- [x] my-sites/themes/themes-magic-search-card
- [x] my-sites/themes/themes-search-card
- [x] client/reader/following/main
- [x] client/reader/search-stream
- [ ] client/vip/vip-logs

cc @alisterscott or @hoverduck would it be possible to run the e2e tests against this branch?
