### PR TITLE
Pages: Default discussion settings to closed

### DIFF
--- a/client/post-editor/editor-discussion/index.jsx
+++ b/client/post-editor/editor-discussion/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 const React = require( 'react' ),
+	get = require( 'lodash/get' ),
 	pick = require( 'lodash/pick' );
 
 /**
@@ -41,10 +42,15 @@ export default React.createClass( {
 			return this.props.post.discussion;
 		}
 
-		if ( this.props.site && this.props.isNew ) {
+		if ( this.props.site && this.props.isNew && this.props.post ) {
+			const { site } = this.props;
+			const isPage = this.props.post.type === 'page';
+			const defaultCommentStatus = get( site, 'options.default_comment_status', false );
+			const defaultPingStatus = get( site, 'options.default_ping_status', false );
+
 			return {
-				comment_status: booleanToStatus( this.props.site.options.default_comment_status ),
-				ping_status: booleanToStatus( this.props.site.options.default_ping_status )
+				comment_status: isPage ? 'closed' : booleanToStatus( defaultCommentStatus ),
+				ping_status: isPage ? 'closed' : booleanToStatus( defaultPingStatus )
 			};
 		}
 

--- a/client/post-editor/editor-discussion/test/index.jsx
+++ b/client/post-editor/editor-discussion/test/index.jsx
@@ -69,10 +69,12 @@ describe( 'EditorDiscussion', function() {
 					default_comment_status: true,
 					default_ping_status: false
 				}
+			}, post = {
+				type: 'post'
 			}, tree;
 
 			tree = TestUtils.renderIntoDocument(
-				<EditorDiscussion site={ site } isNew />
+				<EditorDiscussion site={ site } post={ post } isNew />
 			);
 
 			expect( tree.getDiscussionSetting() ).to.eql( {
@@ -87,15 +89,37 @@ describe( 'EditorDiscussion', function() {
 					default_comment_status: false,
 					default_ping_status: true
 				}
+			}, post = {
+				type: 'post'
 			}, tree;
 
 			tree = TestUtils.renderIntoDocument(
-				<EditorDiscussion site={ site } isNew />
+				<EditorDiscussion site={ site } post={ post } isNew />
 			);
 
 			expect( tree.getDiscussionSetting() ).to.eql( {
 				comment_status: 'closed',
 				ping_status: 'open'
+			} );
+		} );
+
+		it( 'should return comments closed if site exists, post is new, and post is type page', function() {
+			var site = {
+				options: {
+					default_comment_status: false,
+					default_ping_status: true
+				}
+			}, post = {
+				type: 'page'
+			}, tree;
+
+			tree = TestUtils.renderIntoDocument(
+				<EditorDiscussion site={ site } post={ post } isNew />
+			);
+
+			expect( tree.getDiscussionSetting() ).to.eql( {
+				comment_status: 'closed',
+				ping_status: 'closed'
 			} );
 		} );
 


### PR DESCRIPTION
This PR modifies the Discussion settings behavior for new pages across WordPress.com. Now, comments and pingbacks will be disabled by default to match the behavior in wp-admin and in Core. See related Core discussion here:

https://make.wordpress.org/core/2015/07/06/comments-are-now-turned-off-on-pages-by-default/

It also updates the test files in `editor-discussion` to include a `post` object. This is necessary for the tests to pass since the `post` object is now required to render the Discussion settings.

## To test
1. Load this branch and set the discussion settings for your site at http://calypso.localhost:3000/settings/discussion/. Set comments and pingbacks both to true.
2. Click "Add" to start a new post. Verify that both options are checked under More Options -> Discussion Settings.
3. Go back to your main dashboard. Start a new page. Verify that both options are unchecked under the Discussion Settings.
4. Check one of the options and either trigger and autosave or manually save the post.
5. Exit the editor. Then, go back in to edit the page you just saved. Verify that your Discussion settings are still correct (whatever you checked in Step 4).

Resolves: #6324