### PR TITLE
Build: Move the vendor DLL to a commons chunk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,10 +160,6 @@ server/devdocs/components-usage-stats.json: $(COMPONENTS_USAGE_STATS_FILES) $(CO
 server/devdocs/proptypes-index.json: $(COMPONENTS_PROPTYPE_FILES) $(COMPONENTS_PROPTYPES_JS)
 	@$(COMPONENTS_PROPTYPES_JS) $(COMPONENTS_PROPTYPE_FILES)
 
-build-dll: node_modules
-	@mkdir -p build
-	@CALYPSO_ENV=$(CALYPSO_ENV) $(NODE_BIN)/webpack --display-error-details --config webpack-dll.config.js
-
 build-server: install
 	@mkdir -p build
 	@CALYPSO_ENV=$(CALYPSO_ENV) $(NODE_BIN)/webpack --display-error-details --config webpack.config.node.js
@@ -172,12 +168,12 @@ build: install build-$(CALYPSO_ENV)
 
 build-css: public/style.css public/style-rtl.css public/style-debug.css public/editor.css
 
-build-development: server/devdocs/proptypes-index.json server/devdocs/components-usage-stats.json build-server build-dll $(CLIENT_CONFIG_FILE) server/devdocs/search-index.js build-css
+build-development: server/devdocs/proptypes-index.json server/devdocs/components-usage-stats.json build-server $(CLIENT_CONFIG_FILE) server/devdocs/search-index.js build-css
 
-build-wpcalypso: server/devdocs/proptypes-index.json server/devdocs/components-usage-stats.json build-server build-dll $(CLIENT_CONFIG_FILE) server/devdocs/search-index.js build-css
+build-wpcalypso: server/devdocs/proptypes-index.json server/devdocs/components-usage-stats.json build-server $(CLIENT_CONFIG_FILE) server/devdocs/search-index.js build-css
 	@$(BUNDLER)
 
-build-horizon build-stage build-production: build-server build-dll $(CLIENT_CONFIG_FILE) build-css
+build-horizon build-stage build-production: build-server $(CLIENT_CONFIG_FILE) build-css
 	@$(BUNDLER)
 
 build-desktop: build-server $(CLIENT_CONFIG_FILE) build-css
@@ -237,6 +233,6 @@ docker-run:
 # rule that can be used as a prerequisite for other rules to force them to always run
 FORCE:
 
-.PHONY: build build-development build-server build-dll build-desktop build-horizon build-stage build-production build-wpcalypso
+.PHONY: build build-development build-server build-desktop build-horizon build-stage build-production build-wpcalypso
 .PHONY: run install test clean distclean translate route node-version
 .PHONY: githooks githooks-commit githooks-push analyze-bundles urn

--- a/server/bundler/bin/bundler.js
+++ b/server/bundler/bin/bundler.js
@@ -114,7 +114,6 @@ webpack( webpackConfig, function( error, stats ) {
 	} ).map( function( chunk ) {
 		return path.join( process.cwd(), 'public', chunk.file );
 	} );
-	files.unshift( path.join( process.cwd(), 'public', 'vendor.' + bundleEnv + '.js' ) );
 
 	minify( files );
 });

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -33,8 +33,7 @@ const staticFiles = [
 	{ path: 'editor.css' },
 	{ path: 'tinymce/skins/wordpress/wp-content.css' },
 	{ path: 'style-debug.css' },
-	{ path: 'style-rtl.css' },
-	{ path: 'vendor.' + config( 'env' ) + '.js' }
+	{ path: 'style-rtl.css' }
 ];
 
 let sections = sectionsModule.get();
@@ -81,10 +80,6 @@ function generateStaticUrls( request ) {
 		}
 		urls[ file.path ] = getUrl( file.path, file.hash );
 	} );
-
-	// vendor dll
-	urls.vendor = urls[ 'vendor.' + config( 'env' ) + '.js' ];
-	urls[ 'vendor-min' ] = urls.vendor.replace( '.js', '.m.js' );
 
 	const assets = request.app.get( 'assets' );
 

--- a/webpack-dll.config.js
+++ b/webpack-dll.config.js
@@ -15,17 +15,7 @@ const bundleEnv = config( 'env' );
 module.exports = {
 	entry: {
 		vendor: [
-			'classnames',
-			'i18n-calypso',
-			'moment',
-			'page',
-			'react',
-			'react-dom',
-			'react-redux',
-			'redux',
-			'redux-thunk',
-			'store',
-			'wpcom',
+
 		]
 	},
 	output: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -104,11 +104,27 @@ if ( CALYPSO_ENV === 'desktop' ) {
 	// no chunks or dll here, just one big file for the desktop app
 	webpackConfig.output.filename = '[name].js';
 } else {
+
+	// vendor chunk
+	webpackConfig.entry.vendor = [
+		'classnames',
+		'i18n-calypso',
+		'moment',
+		'page',
+		'react',
+		'react-dom',
+		'react-redux',
+		'redux',
+		'redux-thunk',
+		'store',
+		'wpcom',
+	];
+
 	webpackConfig.plugins.push(
-		new webpack.DllReferencePlugin( {
-			context: path.join( __dirname, 'client' ),
-			manifest: require( './build/dll/vendor.' + bundleEnv + '-manifest.json' )
-		} )
+		new webpack.optimize.CommonsChunkPlugin(
+			'vendor',
+			'vendor.[chunkhash].js'
+		)
 	);
 
 	// slight black magic here. 'manifest' is a secret webpack module that includes the webpack loader and
@@ -128,6 +144,8 @@ if ( CALYPSO_ENV === 'desktop' ) {
 			filename: 'manifest.[hash].js'
 		} )
 	);
+
+
 
 	// this walks all of the chunks and finds modules that exist in at least a quarter of them.
 	// It moves those modules into a new "common" chunk, since most of the app will need to load them.
@@ -165,6 +183,8 @@ const jsLoader = {
 		] ]
 	}
 };
+
+
 
 if ( CALYPSO_ENV === 'development' ) {
 	const DashboardPlugin = require( 'webpack-dashboard/plugin' );


### PR DESCRIPTION
This PR gives us baked in hashes for the vendor bundle and a much simpler configuration. It also ends up invoking webpack once instead of twice and seems reasonably speedy (34s build on my laptop).

_Note, this is currently stacked on top of #11437._

After all the effort to move to a DLL, you may be wondering why I'd pull it back out. 

There were two goals with the DLL work: 1) Speed up builds and rebuilds and 2) give us a more stable chunk to load.

1) turned out to be a red herring. Subsequent investigation has shown that rebuild times are mostly dictated by the number of chunks the edited module is part of. Switching to a DLL didn't really have much effect on rebuild speed.

2) It did help out, but since, I've learned a lot more about how to make stable chunks. A stable chunk is one whose hash only changes when the contents of the chunk change.

Before all this work, we had two major problems. The build chunk hash was changing on every commit, even if nothing appeared to have changed within it, and when the build chunk changed, the vendor chunk hash would change as well. 

We tried to fix this by moving vendor to a DLL, which isolated it and we started using a CommonsChunkPlugin to extract the `manifest` from the build chunk. Removing the manifest was the real key; once we started doing that, changes to child chunks no longer made the hash on the build chunk change.

However, this introduced a bug. We used the `OccurrenceOrderPlugin` to try to make module IDs more stable, but it also means that when we add new code, module IDs can shift a bit.  If you look at the contents of the manifest, you'll find that it mostly contains the webpack loader and the mapping from chunk ID to URL. It _does not_ contain a mapping of module IDs in any way. The bug is that the hash that webpack calculates for the chunk _no longer seems to change when the module IDs change_ after removing the manifest.

See webpack/webpack#1856 for more discussion on this apparent bug. 

#11437 seeks to work around the webpack bug by using a different strategy for calculating module IDs. Instead of calculating them based on occurrence order, which is unstable, it calculates them based on a hash of the require path, which _is_ stable, but may have collisions.

But that also means that our motivation for having a vendor dll is misguided. We can simplify things by pulling it back into the main webpack configuration. This gives us a hash baked into the filename and the ability to use tools like `webpack-bundle-analyzer` more easily with Calypso. It will also let us more easily tweak the contents of the vendor bundle as needed. 

