### PR TITLE
Component: add and use getSitePlanSlug selector

### DIFF
--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
 import QueryMediaStorage from 'components/data/query-media-storage';
 import { getMediaStorage } from 'state/sites/media-storage/selectors';
 import {
-	getSitePlan,
+	getSitePlanSlug,
 	getSiteSlug,
 	isJetpackSite
 } from 'state/sites/selectors';
@@ -23,6 +23,8 @@ class PlanStorage extends Component {
 		className: PropTypes.string,
 		mediaStorage: PropTypes.object,
 		siteId: PropTypes.number,
+		sitePlanSlug: PropTypes.string,
+		siteSlug: PropTypes.string,
 	};
 
 	render() {
@@ -30,11 +32,11 @@ class PlanStorage extends Component {
 			className,
 			jetpackSite,
 			siteId,
-			sitePlan,
+			sitePlanSlug,
 			siteSlug,
 		} = this.props;
 
-		if ( jetpackSite || ! sitePlan ) {
+		if ( jetpackSite || ! sitePlanSlug ) {
 			return null;
 		}
 
@@ -43,7 +45,7 @@ class PlanStorage extends Component {
 				<QueryMediaStorage siteId={ siteId } />
 				<PlanStorageBar
 					siteSlug={ siteSlug }
-					sitePlanSlug={ sitePlan.product_slug }
+					sitePlanSlug={ sitePlanSlug }
 					mediaStorage={ this.props.mediaStorage }
 				>
 					{ this.props.children }
@@ -58,7 +60,7 @@ export default connect( ( state, ownProps ) => {
 	return {
 		mediaStorage: getMediaStorage( state, siteId ),
 		jetpackSite: isJetpackSite( state, siteId ),
-		sitePlan: getSitePlan( state, siteId ),
+		sitePlanSlug: getSitePlanSlug( state, siteId ),
 		siteSlug: getSiteSlug( state, siteId ),
 	};
 } )( PlanStorage );

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -503,6 +503,10 @@ export function getSitePlan( state, siteId ) {
 	return site.plan;
 }
 
+export function getSitePlanSlug( state, siteId ) {
+	return get( getSitePlan( state, siteId ), 'product_slug' );
+}
+
 /**
  * Returns true if the current site plan is a paid one
  *


### PR DESCRIPTION
## IMPORTANT
This PR is part of a set of PRs. Take a look to https://github.com/Automattic/wp-calypso/issues/11667, Pull requests section, to know to right order to review.

This PR is targeting to `try/media-section-v2`.


---------

In order to attend [this comment](https://github.com/Automattic/wp-calypso/pull/11639#pullrequestreview-24287895) I've created this PR which:

* Add `addSitePlanSlug()` selector
* and use this in `plan-storage` component.