### PR TITLE
Docs: add missing npm install step

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,8 +22,9 @@ If you’d like to contribute code, first, you will need to run Calypso locally.
 1.	Make sure you have `git`, `node`, and `npm` installed.
 2.	Clone this repository locally.
 3.	Add `127.0.0.1 calypso.localhost` to your local hosts file.
-4.	Execute `make run` from the root directory of the repository.
-5.	Open `http://calypso.localhost:3000` in your browser.
+4.	Run `npm install`
+5.	Execute `make run` from the root directory of the repository.
+6.	Open `http://calypso.localhost:3000` in your browser.
 
 For more detailed instructions, see [Installing Calypso](../docs/install.md).
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ You can try out the user-side of Calypso on [WordPress.com](https://wordpress.co
 1.	Make sure you have `git`, `node`, and `npm` installed.
 2.	Clone this repository locally.
 3.	Add `127.0.0.1 calypso.localhost` to your local `hosts` file.
-4.	Execute `make run` or `make dashboard` (for a more visually-oriented interface) from the root directory of the repository.
-5.	Open [`calypso.localhost:3000`](http://calypso.localhost:3000/) in your browser.
+4.	Run `npm install`
+5.	Execute `make run` or `make dashboard` (for a more visually-oriented interface) from the root directory of the repository.
+6.	Open [`calypso.localhost:3000`](http://calypso.localhost:3000/) in your browser.
 
 Need more detailed installation instructions? [We have them](docs/install.md).
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,8 +7,9 @@ You can install Calypso directly on your machine by following the next steps, or
 1.	Check that you have all prerequisites (Git, Node, NPM). See [below](install.md#prerequisites) for more details.
 2.	Clone this repository locally.
 3.	Add `127.0.0.1 calypso.localhost` to your local `hosts` file.
-4.	Execute `make run` or `make dashboard` (for a more visually-oriented interface) from the root directory of the repository.
-5.	Open [`calypso.localhost:3000`](http://calypso.localhost:3000/) in your browser.
+4.	Run `npm install`
+5.	Execute `make run` or `make dashboard` (for a more visually-oriented interface) from the root directory of the repository.
+6.	Open [`calypso.localhost:3000`](http://calypso.localhost:3000/) in your browser.
 
 ## Prerequisites
 


### PR DESCRIPTION
Following precisely each step results in an error after executing make run. In order to reduce possible failure, npm install was added in every step by step instruction.