### PR TITLE
My Sites: Fix performance issue in Blocks/Site

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -11,9 +11,12 @@ import Gridicon from 'gridicons';
  */
 import SiteIcon from 'blocks/site-icon';
 import SiteIndicator from 'my-sites/site-indicator';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 export default React.createClass( {
 	displayName: 'Site',
+
+	mixins: [ PureRenderMixin ],
 
 	getDefaultProps() {
 		return {

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -2,6 +2,10 @@
 require( 'lib/local-storage' )();
 if ( process.env.NODE_ENV === 'development' ) {
 	require( 'lib/wrap-es6-functions' )();
+
+	var Perf = require('react-addons-perf');
+	// Expose the React Performance Tools on the`window` object
+	window.Perf = Perf;
 }
 
 /**

--- a/client/lib/mixins/perf/why-did-you-update/README.md
+++ b/client/lib/mixins/perf/why-did-you-update/README.md
@@ -1,0 +1,18 @@
+Why did you update
+==================
+
+A React mixin that check if a component update was really required.
+
+Drop this mixin into a component that wastes time according to Perf.getWastedTime() to find
+out what state/props should be preserved. Once it says "Update avoidable!" for {state, props},
+you should be able to drop in React.addons.PureRenderMixin
+
+```js
+var WhyDidYouUpdateMixin = require( 'lib/mixins/perf/why-did-you-update' );
+
+var MyComponent = React.createClass({
+	mixins: [ WhyDidYouUpdateMixin ]
+});
+```
+
+([Read more about React Performance and the source of this mixin (Saif Hakim)](http://benchling.engineering/deep-dive-react-perf-debugging/).)

--- a/client/lib/mixins/perf/why-did-you-update/index.js
+++ b/client/lib/mixins/perf/why-did-you-update/index.js
@@ -1,0 +1,61 @@
+/* eslint-disable no-console */
+
+/**
+ * External dependencies
+ */
+import _ from 'underscore';
+
+/*
+Drop this mixin into a component that wastes time according to Perf.getWastedTime() to find
+out what state/props should be preserved. Once it says "Update avoidable!" for {state, props},
+you should be able to drop in React.addons.PureRenderMixin
+React.createClass {
+	mixins: [WhyDidYouUpdateMixin]
+}
+*/
+function isRequiredUpdateObject( o ) {
+	return Array.isArray( o ) || ( o && o.constructor === Object.prototype.constructor );
+}
+
+function deepDiff( o1, o2, p ) {
+	const notify = ( status ) => {
+		console.warn( 'Update %s', status );
+		console.log( '%cbefore', 'font-weight: bold', o1 );
+		console.log( '%cafter ', 'font-weight: bold', o2 );
+	};
+
+	if ( ! _.isEqual( o1, o2 ) ) {
+		console.group( p );
+		if ( [ o1, o2 ].every( _.isFunction ) ) {
+			notify( 'avoidable?' );
+		} else if ( ! [ o1, o2 ].every( isRequiredUpdateObject ) ) {
+			notify( 'required.' );
+		} else {
+			const keys = _.union( _.keys( o1 ), _.keys( o2 ) );
+			for ( const key of keys ) {
+				deepDiff( o1[ key ], o2[ key ], key );
+			}
+		}
+		console.groupEnd();
+	} else if ( o1 !== o2 ) {
+		console.group( p );
+		notify( 'avoidable!' );
+		if ( _.isObject( o1 ) && _.isObject( o2 ) ) {
+			const keys = _.union( _.keys( o1 ), _.keys( o2 ) );
+			for ( const key of keys ) {
+				deepDiff( o1[ key ], o2[ key ], key );
+			}
+		}
+		console.groupEnd();
+	}
+}
+
+const WhyDidYouUpdateMixin = {
+	componentDidUpdate( prevProps, prevState ) {
+		deepDiff( { props: prevProps, state: prevState },
+						{ props: this.props, state: this.state },
+						this.constructor.displayName );
+	},
+};
+
+export default WhyDidYouUpdateMixin;

--- a/package.json
+++ b/package.json
@@ -180,6 +180,7 @@
     "mockery": "1.7.0",
     "nock": "8.0.0",
     "nodemon": "1.4.1",
+    "react-addons-perf": "15.4.2",
     "react-addons-test-utils": "15.4.0",
     "react-hot-loader": "1.3.0",
     "react-test-env": "0.2.0",
@@ -189,6 +190,7 @@
     "socket.io": "1.4.5",
     "stylelint": "^6.5.1",
     "supertest": "2.0.0",
+    "underscore": "1.8.3",
     "webpack-bundle-analyzer": "2.2.1",
     "webpack-dashboard": "0.2.0",
     "webpack-dev-server": "1.11.0"


### PR DESCRIPTION
* Add React Perf addon which allows diagnosing React performance issues by recording an interaction with the app and get a report of components that waste time on avoidable renders.

* Add Mixin WhyDidYouUpdate to identify components that can be turned to PureRender.

* Using this technique I've identified that SiteIcon in Sites block is rendered thousands of times for simple interaction such as selecting Blogs and then Pages in My Sites sidebar. Adding PureRenderMixin to Site block solved the excessive render issue.