### PR TITLE
Notifications: Bump version in cache buster

### DIFF
--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -28,7 +28,7 @@ import userLib from 'lib/user';
 /**
  * Module variables
  */
-const NOTIFICATIONS_CLIENT_VERSION = 'beta-r150343-wpcom-7-g7493844';
+const NOTIFICATIONS_CLIENT_VERSION = 'beta-r151017-wpcom-6-gaaf83b2';
 
 const user = userLib();
 const widgetDomain = 'https://widgets.wp.com';


### PR DESCRIPTION
This busts the cache on the notifications client after recent updates to
that app in Automattic/notifications-client#621