### PR TITLE
Fire calypso_free_to_paid_plan_nudge_impression event correctly

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -92,7 +92,7 @@ const SiteNotice = React.createClass( {
 					href={ `/plans/my-plan/${ this.props.site.slug }` }
 				>
 					{ this.translate( 'Upgrade' ) }
-					<TrackComponentView event Name={ eventName } eventProperties={ eventProperties } />
+					<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
 				</NoticeAction>
 			</Notice>
 		);


### PR DESCRIPTION
A stray whitespace character resulted in `event` and `Name` props being passed to `TrackComponentView` instead of `eventName`.

To qualify for the upsell, users must:

* have registered within with last 2 to 30 days
* be able to manage options for the current site
* have a free plan for the current site
* have no domain mapping for the current site

# Steps for testing

You will either need a user that meets the criteria (user registered between 2 and 30 days ago) or can temporarily alter the selector function in client/state/selectors/eligible-for-free-to-paid-upsell.js to always return true.

You should now see the calypso_free_to_paid_plan_nudge_impression tracks event in network requests (filter requests for t.gif).
