### PR TITLE
Revert "Notifications: Bump version in cache buster"

### DIFF
--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -28,7 +28,7 @@ import userLib from 'lib/user';
 /**
  * Module variables
  */
-const NOTIFICATIONS_CLIENT_VERSION = 'beta-r151017-wpcom-6-gaaf83b2';
+const NOTIFICATIONS_CLIENT_VERSION = 'beta-r150343-wpcom-7-g7493844';
 
 const user = userLib();
 const widgetDomain = 'https://widgets.wp.com';


### PR DESCRIPTION
Reverts Automattic/wp-calypso#11775

Strange error with a broken RegExp - looks like an optimization bug

<img width="526" alt="screen shot 2017-03-06 at 3 21 51 am" src="https://cloud.githubusercontent.com/assets/5431237/23605988/0fa5f3a0-021c-11e7-8e8b-052138e3f295.png">

```js
// found in notes client `node_modules/page/index.js`
i.match(/^\/[a-zA-Z]:\
```