### PR TITLE
WP Super Cache: Add Easy settings tab

### DIFF
--- a/client/extensions/wp-super-cache/components/easy.jsx
+++ b/client/extensions/wp-super-cache/components/easy.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -15,6 +15,11 @@ import FormRadio from 'components/forms/form-radio';
 import SectionHeader from 'components/section-header';
 
 class Easy extends Component {
+	static propTypes = {
+		site: PropTypes.object.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
 	state = {
 		checkedRadio: 'off',
 	};
@@ -22,7 +27,7 @@ class Easy extends Component {
 	handleRadioChange = event => this.setState( { checkedRadio: event.currentTarget.value } );
 
 	render() {
-		const { translate } = this.props;
+		const { site, translate } = this.props;
 		const { checkedRadio } = this.state;
 
 		return (
@@ -62,16 +67,24 @@ class Easy extends Component {
 				<Card>
 					<p>
 						{ translate(
-						'Cached pages are stored on your server as html and PHP files. ' +
-						'If you need to delete them, use the button below.'
+						'Cached pages are stored on your server as HTML and PHP files. ' +
+						'If you need to delete them, use the buttons below.'
 						) }
 					</p>
 					<div>
 						<Button
 							compact={ true }
+							style={ { marginRight: '8px' } }
 							type="submit">
 								{ translate( 'Delete Cache' ) }
 						</Button>
+						{ site.jetpack && site.is_multisite &&
+							<Button
+								compact={ true }
+								type="submit">
+									{ translate( 'Delete Cache On All Blogs' ) }
+							</Button>
+						}
 					</div>
 				</Card>
 			</div>

--- a/client/extensions/wp-super-cache/components/easy.jsx
+++ b/client/extensions/wp-super-cache/components/easy.jsx
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormRadio from 'components/forms/form-radio';
+import SectionHeader from 'components/section-header';
+
+class Easy extends Component {
+	state = {
+		checkedRadio: 'off',
+	};
+
+	handleRadioChange = event => this.setState( { checkedRadio: event.currentTarget.value } );
+
+	render() {
+		const { translate } = this.props;
+		const { checkedRadio } = this.state;
+
+		return (
+			<div>
+				<SectionHeader label={ translate( 'Caching' ) }>
+					<Button
+						compact={ true }
+						primary={ true }
+						type="submit">
+							{ translate( 'Update Status' ) }
+					</Button>
+				</SectionHeader>
+				<Card>
+					<form>
+						<FormFieldset>
+							<FormLabel>
+								<FormRadio value="on" checked={ 'on' === checkedRadio } onChange={ this.handleRadioChange } />
+								<span>
+									{ translate(
+										'Caching On {{em}}(Recommended){{/em}}',
+										{
+											components: { em: <em /> }
+										}
+									) }
+								</span>
+							</FormLabel>
+
+							<FormLabel>
+								<FormRadio value="off" checked={ 'off' === checkedRadio } onChange={ this.handleRadioChange } />
+								<span>{ translate( 'Caching Off' ) }</span>
+							</FormLabel>
+						</FormFieldset>
+					</form>
+				</Card>
+
+				<SectionHeader label={ translate( 'Delete Cached Pages' ) } />
+				<Card>
+					<p>
+						{ translate(
+						'Cached pages are stored on your server as html and PHP files. ' +
+						'If you need to delete them, use the button below.'
+						) }
+					</p>
+					<div>
+						<Button
+							compact={ true }
+							type="submit">
+								{ translate( 'Delete Cache' ) }
+						</Button>
+					</div>
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default localize( Easy );

--- a/client/extensions/wp-super-cache/components/easy.jsx
+++ b/client/extensions/wp-super-cache/components/easy.jsx
@@ -37,7 +37,7 @@ class Easy extends Component {
 						compact={ true }
 						primary={ true }
 						type="submit">
-							{ translate( 'Update Status' ) }
+							{ translate( 'Save Settings' ) }
 					</Button>
 				</SectionHeader>
 				<Card>

--- a/client/extensions/wp-super-cache/components/navigation.jsx
+++ b/client/extensions/wp-super-cache/components/navigation.jsx
@@ -10,37 +10,45 @@ import { localize } from 'i18n-calypso';
 import SectionNav from 'components/section-nav';
 import SectionNavTabs from 'components/section-nav/tabs';
 import SectionNavTabItem from 'components/section-nav/item';
-
-/**
- * Module Variables
- */
-const tabs = [ 'easy', 'advanced', 'cdn', 'contents', 'preload', 'plugins', 'debug' ];
+import { Tabs } from '../constants';
 
 const Navigation = ( { activeTab, translate } ) => {
 	const getLabel = tab => {
 		switch ( tab ) {
-			case 'easy':
+			case Tabs.EASY:
 				return translate( 'Easy' );
-			case 'advanced':
+			case Tabs.ADVANCED:
 				return translate( 'Advanced' );
-			case 'cdn':
+			case Tabs.CDN:
 				return translate( 'CDN' );
-			case 'contents':
+			case Tabs.CONTENTS:
 				return translate( 'Contents' );
-			case 'preload':
+			case Tabs.PRELOAD:
 				return translate( 'Preload' );
-			case 'plugins':
+			case Tabs.PLUGINS:
 				return translate( 'Plugins' );
-			case 'debug':
+			case Tabs.DEBUG:
 				return translate( 'Debug' );
 		}
 	};
 
-	const renderTabItems = () => {
+	const getTabs = () => {
+		const tabs = [];
+
+		for ( const key in Tabs ) {
+			if ( Tabs.hasOwnProperty( key ) ) {
+				tabs.push( Tabs[ key ] );
+			}
+		}
+
+		return tabs;
+	};
+
+	const renderTabItems = ( tabs ) => {
 		return tabs.map( tab => {
 			let path = '/extensions/wp-super-cache';
 
-			if ( tab !== tabs[ 0 ] ) {
+			if ( tab !== Tabs.EASY ) {
 				path = `${ path }/${ tab }`;
 			}
 
@@ -48,7 +56,7 @@ const Navigation = ( { activeTab, translate } ) => {
 				<SectionNavTabItem
 					key={ `wp-super-cache-${ tab }` }
 					path={ path }
-					selected={ ( activeTab || tabs[ 0 ] ) === tab }>
+					selected={ ( activeTab || Tabs.EASY ) === tab }>
 					{ getLabel( tab ) }
 				</SectionNavTabItem>
 			);
@@ -58,7 +66,7 @@ const Navigation = ( { activeTab, translate } ) => {
 	return (
 		<SectionNav selectedText="Settings">
 			<SectionNavTabs>
-				{ renderTabItems() }
+				{ renderTabItems( getTabs() ) }
 			</SectionNavTabs>
 		</SectionNav>
 	);

--- a/client/extensions/wp-super-cache/components/navigation.jsx
+++ b/client/extensions/wp-super-cache/components/navigation.jsx
@@ -12,7 +12,7 @@ import SectionNavTabs from 'components/section-nav/tabs';
 import SectionNavTabItem from 'components/section-nav/item';
 import { Tabs } from '../constants';
 
-const Navigation = ( { activeTab, translate } ) => {
+const Navigation = ( { activeTab, site, translate } ) => {
 	const getLabel = tab => {
 		switch ( tab ) {
 			case Tabs.EASY:
@@ -52,6 +52,8 @@ const Navigation = ( { activeTab, translate } ) => {
 				path = `${ path }/${ tab }`;
 			}
 
+			path += `/${ site.slug }`;
+
 			return (
 				<SectionNavTabItem
 					key={ `wp-super-cache-${ tab }` }
@@ -74,7 +76,8 @@ const Navigation = ( { activeTab, translate } ) => {
 
 Navigation.propTypes = {
 	activeTab: PropTypes.string,
-	translate: PropTypes.func.isRequired
+	site: React.PropTypes.object.isRequired,
+	translate: PropTypes.func.isRequired,
 };
 
 Navigation.defaultProps = {

--- a/client/extensions/wp-super-cache/constants.js
+++ b/client/extensions/wp-super-cache/constants.js
@@ -1,0 +1,9 @@
+export const Tabs = {
+	EASY: 'easy',
+	ADVANCED: 'advanced',
+	CDN: 'cdn',
+	CONTENTS: 'contents',
+	PRELOAD: 'preload',
+	PLUGINS: 'plugins',
+	DEBUG: 'debug',
+};

--- a/client/extensions/wp-super-cache/controller.js
+++ b/client/extensions/wp-super-cache/controller.js
@@ -11,22 +11,24 @@ import analytics from 'lib/analytics';
 import titlecase from 'to-title-case';
 import { getSiteFragment, sectionify } from 'lib/route';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
+import { getSelectedSite } from 'state/ui/selectors';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import WPSuperCache from './main';
 
 const controller = {
 
 	settings: function( context ) {
-		const siteID = getSiteFragment( context.path );
+		const siteId = getSiteFragment( context.path );
+		const site = getSelectedSite( context.store.getState() );
 		let tab = context.params.tab;
 
-		tab = ( ! tab || tab === siteID ) ? '' : tab;
+		tab = ( ! tab || tab === siteId ) ? '' : tab;
 		context.store.dispatch( setTitle( i18n.translate( 'WP Super Cache', { textOnly: true } ) ) );
 
 		const basePath = sectionify( context.path );
 		let baseAnalyticsPath;
 
-		if ( siteID ) {
+		if ( siteId ) {
 			baseAnalyticsPath = `${ basePath }/:site`;
 		} else {
 			baseAnalyticsPath = basePath;
@@ -44,8 +46,9 @@ const controller = {
 
 		renderWithReduxStore(
 			React.createElement( WPSuperCache, {
-				context: context,
-				tab: tab,
+				context,
+				site,
+				tab,
 			} ),
 			document.getElementById( 'primary' ),
 			context.store

--- a/client/extensions/wp-super-cache/index.js
+++ b/client/extensions/wp-super-cache/index.js
@@ -6,9 +6,10 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { navigation, siteSelection } from 'my-sites/controller';
+import { navigation, sites, siteSelection } from 'my-sites/controller';
 import controller from './controller';
 
 export default function() {
-	page( '/extensions/wp-super-cache/:tab?/:site?', siteSelection, navigation, controller.settings );
+	page( '/extensions/wp-super-cache', siteSelection, sites, navigation, controller.settings );
+	page( '/extensions/wp-super-cache/:tab?/:site', siteSelection, navigation, controller.settings );
 }

--- a/client/extensions/wp-super-cache/main.jsx
+++ b/client/extensions/wp-super-cache/main.jsx
@@ -8,12 +8,36 @@ import React from 'react';
  */
 import Main from 'components/main';
 import Navigation from './components/navigation';
+import Easy from './components/easy';
+import { Tabs } from './constants';
 
-const WPSuperCache = ( { tab } ) => (
-	<Main className="wp-super-cache__main">
-		<Navigation activeTab={ tab } />
-	</Main>
-);
+const WPSuperCache = ( { tab } ) => {
+	const renderTab = () => {
+		switch ( tab ) {
+			case Tabs.ADVANCED:
+				break;
+			case Tabs.CDN:
+				break;
+			case Tabs.CONTENTS:
+				break;
+			case Tabs.PRELOAD:
+				break;
+			case Tabs.PLUGINS:
+				break;
+			case Tabs.DEBUG:
+				break;
+			default:
+				return <Easy />;
+		}
+	};
+
+	return (
+		<Main className="wp-super-cache__main">
+			<Navigation activeTab={ tab } />
+			{ renderTab() }
+		</Main>
+	);
+};
 
 WPSuperCache.propTypes = {
 	tab: React.PropTypes.string

--- a/client/extensions/wp-super-cache/main.jsx
+++ b/client/extensions/wp-super-cache/main.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 
 /**
  * Internal dependencies
@@ -11,7 +11,7 @@ import Navigation from './components/navigation';
 import Easy from './components/easy';
 import { Tabs } from './constants';
 
-const WPSuperCache = ( { tab } ) => {
+const WPSuperCache = ( { site, tab } ) => {
 	const renderTab = () => {
 		switch ( tab ) {
 			case Tabs.ADVANCED:
@@ -27,20 +27,21 @@ const WPSuperCache = ( { tab } ) => {
 			case Tabs.DEBUG:
 				break;
 			default:
-				return <Easy />;
+				return <Easy site={ site } />;
 		}
 	};
 
 	return (
 		<Main className="wp-super-cache__main">
-			<Navigation activeTab={ tab } />
+			<Navigation activeTab={ tab } site={ site } />
 			{ renderTab() }
 		</Main>
 	);
 };
 
 WPSuperCache.propTypes = {
-	tab: React.PropTypes.string
+	site: React.PropTypes.object,
+	tab: PropTypes.string,
 };
 
 WPSuperCache.defaultProps = {


### PR DESCRIPTION
This PR adds the settings UI for the _Easy_ tab. The _Recommended Links and Plugins_ section was not ported from the original plugin.

### Single Site

![easy-single-site](https://cloud.githubusercontent.com/assets/1190420/23663543/d9bddb76-0320-11e7-89d9-14c03eb91a52.jpg)

### Multi-Site

![easy-multi-site](https://cloud.githubusercontent.com/assets/1190420/23663490/b54e8736-0320-11e7-983c-43070283cd16.jpg)