### PR TITLE
Site Settings: Disable Post by Email when in Dev mode

### DIFF
--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -17,22 +17,32 @@ import FormLegend from 'components/forms/form-legend';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackModuleActive } from 'state/selectors';
 import { regeneratePostByEmail } from 'state/jetpack/settings/actions';
-import { isRegeneratingJetpackPostByEmail } from 'state/selectors';
+import {
+	isJetpackModuleActive,
+	isJetpackModuleUnavailableInDevelopmentMode,
+	isJetpackSiteInDevelopmentMode,
+	isRegeneratingJetpackPostByEmail
+} from 'state/selectors';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
 import ClipboardButtonInput from 'components/clipboard-button-input';
 import PressThis from '../press-this';
+import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 
 class PublishingTools extends Component {
 	componentDidUpdate() {
 		const {
 			fields,
+			moduleUnavailable,
 			postByEmailAddressModuleActive,
 			regeneratingPostByEmail,
 			selectedSiteId
 		} = this.props;
+
+		if ( ! moduleUnavailable ) {
+			return;
+		}
 
 		if ( postByEmailAddressModuleActive && regeneratingPostByEmail === null && ! fields.post_by_email_address ) {
 			this.props.regeneratePostByEmail( selectedSiteId );
@@ -53,10 +63,10 @@ class PublishingTools extends Component {
 	}
 
 	renderPostByEmailSettings() {
-		const { fields, translate, postByEmailAddressModuleActive, regeneratingPostByEmail } = this.props;
+		const { fields, moduleUnavailable, translate, postByEmailAddressModuleActive, regeneratingPostByEmail } = this.props;
 		const isFormPending = this.isFormPending();
 		const email = fields.post_by_email_address && fields.post_by_email_address !== 'regenerate' ? fields.post_by_email_address : '';
-		const labelClassName = regeneratingPostByEmail || ! postByEmailAddressModuleActive ? 'is-disabled' : null;
+		const labelClassName = moduleUnavailable || regeneratingPostByEmail || ! postByEmailAddressModuleActive ? 'is-disabled' : null;
 
 		return (
 			<div className="publishing-tools__module-settings site-settings__child-settings">
@@ -65,13 +75,13 @@ class PublishingTools extends Component {
 				</FormLabel>
 				<ClipboardButtonInput
 					className="publishing-tools__email-address"
-					disabled={ regeneratingPostByEmail || ! postByEmailAddressModuleActive }
+					disabled={ regeneratingPostByEmail || ! postByEmailAddressModuleActive || moduleUnavailable }
 					value={ email }
 				/>
 				<Button
 					compact
 					onClick={ this.onRegenerateButtonClick }
-					disabled={ isFormPending || regeneratingPostByEmail || ! postByEmailAddressModuleActive }
+					disabled={ isFormPending || regeneratingPostByEmail || ! postByEmailAddressModuleActive || moduleUnavailable }
 				>
 					{ regeneratingPostByEmail
 						? translate( 'Regenerating…' )
@@ -84,6 +94,7 @@ class PublishingTools extends Component {
 
 	renderPostByEmailModule() {
 		const {
+			moduleUnavailable,
 			selectedSiteId,
 			translate
 		} = this.props;
@@ -103,7 +114,7 @@ class PublishingTools extends Component {
 					siteId={ selectedSiteId }
 					moduleSlug="post-by-email"
 					label={ translate( 'Publish posts by sending an email.' ) }
-					disabled={ formPending }
+					disabled={ formPending || moduleUnavailable }
 					/>
 
 				{ this.renderPostByEmailSettings() }
@@ -126,13 +137,15 @@ class PublishingTools extends Component {
 	}
 
 	render() {
-		const { translate } = this.props;
+		const { selectedSiteId, translate } = this.props;
 
 		return (
 			<div>
+				<QueryJetpackConnection siteId={ selectedSiteId } />
+
 				<SectionHeader label={ translate( 'Publishing Tools' ) } />
 
-				<Card className="publishing-tools__card site-settings">
+				<Card className="publishing-tools__card site-settings__module-settings">
 					{ this.renderPostByEmailModule() }
 					<hr />
 					{ this.renderPressThis() }
@@ -159,11 +172,14 @@ export default connect(
 	( state ) => {
 		const selectedSiteId = getSelectedSiteId( state );
 		const regeneratingPostByEmail = isRegeneratingJetpackPostByEmail( state, selectedSiteId );
+		const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
+		const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode( state, selectedSiteId, 'post-by-email' );
 
 		return {
 			selectedSiteId,
 			regeneratingPostByEmail,
 			postByEmailAddressModuleActive: !! isJetpackModuleActive( state, selectedSiteId, 'post-by-email' ),
+			moduleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
 		};
 	},
 	{


### PR DESCRIPTION
This PR will disable the "Post by Email" settings if the current Jetpack site is in development mode. Related with #11386.

Preview when disabled:
![](https://cldup.com/WLt2Zh-i-x.png)

To test:

* Checkout this branch
* Select one of your Jetpack sites and enable dev mode by adding this to your wp-config.php: `define( 'JETPACK_DEV_DEBUG', true );`
* Verify the "Post by Email" settings in the Publishing Tools card in the Writing tab are disabled and can't be interacted with.
* Disable the Dev mode by deleting the line we just added to wp-config.php.
* Verify the "Post by Email" settings are now enabled and can be interacted with.

/cc @rickybanister @MichaelArestad because I have the feeling that we need do something more in addition to just disabling the fields in that case (as also mentioned here: https://github.com/Automattic/wp-calypso/pull/11386#issuecomment-284359883).