### PR TITLE
Site Settings: Disable Photon when in Dev mode

### DIFF
--- a/client/my-sites/site-settings/media-settings/index.jsx
+++ b/client/my-sites/site-settings/media-settings/index.jsx
@@ -16,9 +16,14 @@ import FormLabel from 'components/forms/form-label';
 import FormToggle from 'components/forms/form-toggle';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
-import { isJetpackModuleActive } from 'state/selectors';
+import {
+	isJetpackModuleActive,
+	isJetpackModuleUnavailableInDevelopmentMode,
+	isJetpackSiteInDevelopmentMode
+} from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { updateSettings } from 'state/jetpack/settings/actions';
+import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 
 const MediaSettings = ( {
 	fields,
@@ -28,12 +33,16 @@ const MediaSettings = ( {
 	isSavingSettings,
 	siteId,
 	carouselActive,
+	photonModuleUnavailable,
+	selectedSiteId,
 	translate
 } ) => {
 	const labelClassName = isSavingSettings || ! carouselActive ? 'is-disabled' : null;
 
 	return (
 		<Card className="media-settings site-settings site-settings__module-settings">
+			<QueryJetpackConnection siteId={ selectedSiteId } />
+
 			<FormFieldset>
 				<div className="media-settings__info-link-container site-settings__info-link-container">
 					<InfoPopover position={ 'left' }>
@@ -47,7 +56,7 @@ const MediaSettings = ( {
 					moduleSlug="photon"
 					label={ translate( 'Speed up your images and photos with Photon.' ) }
 					description="Enabling Photon is required to use Tiled Galleries."
-					disabled={ isRequestingSettings || isSavingSettings }
+					disabled={ isRequestingSettings || isSavingSettings || photonModuleUnavailable }
 					/>
 			</FormFieldset>
 			<FormFieldset className="media-settings__formfieldset has-divider is-top-only">
@@ -107,8 +116,13 @@ MediaSettings.propTypes = {
 export default connect(
 	( state ) => {
 		const selectedSiteId = getSelectedSiteId( state );
+		const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
+		const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode( state, selectedSiteId, 'photon' );
+
 		return {
-			carouselActive: !! isJetpackModuleActive( state, selectedSiteId, 'carousel' )
+			selectedSiteId,
+			carouselActive: !! isJetpackModuleActive( state, selectedSiteId, 'carousel' ),
+			photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
 		};
 	},
 	{


### PR DESCRIPTION
This PR will disable the Photon if the current Jetpack site is in development mode. Related with #11386.

Preview when Photon is disabled because of Dev mode:
![](https://cldup.com/y0jmDFpiet.png)

To test:

* Checkout this branch
* Select one of your Jetpack sites and enable dev mode by adding this to your wp-config.php: `define( 'JETPACK_DEV_DEBUG', true );`
* Verify the Photon toggle in the Media card in the Writing tab is disabled.
* Disable the Dev mode by deleting the line we just added to wp-config.php.
* Verify the Photon toggle is now enabled and can be interacted with.

/cc @rickybanister @MichaelArestad because I have the feeling that we need do something more in addition to just disabling the toggle in that case (as also mentioned here: https://github.com/Automattic/wp-calypso/pull/11386#issuecomment-284359883).