### PR TITLE
Site Settings: Disable Subscriptions when in Dev mode

### DIFF
--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -484,6 +484,7 @@ class SiteSettingsFormDiscussion extends Component {
 			isRequestingSettings,
 			isSavingSettings,
 			isJetpack,
+			isSubscriptionsModuleActive,
 			jetpackSettingsUISupported,
 			translate
 		} = this.props;
@@ -513,7 +514,7 @@ class SiteSettingsFormDiscussion extends Component {
 						<div>
 							<QueryJetpackModules siteId={ siteId } />
 
-							{ this.renderSectionHeader( translate( 'Subscriptions' ) ) }
+							{ this.renderSectionHeader( translate( 'Subscriptions' ), isSubscriptionsModuleActive !== false ) }
 
 							<Subscriptions
 								onSubmitForm={ handleSubmitForm }
@@ -537,12 +538,14 @@ const connectComponent = connect(
 		const isJetpack = isJetpackSite( state, siteId );
 		const jetpackSettingsUISupported = siteSupportsJetpackSettingsUi( state, siteId );
 		const isLikesModuleActive = isJetpackModuleActive( state, siteId, 'likes' );
+		const isSubscriptionsModuleActive = isJetpackModuleActive( state, siteId, 'subscriptions' );
 
 		return {
 			siteId,
 			isJetpack,
 			jetpackSettingsUISupported,
 			isLikesModuleActive,
+			isSubscriptionsModuleActive,
 		};
 	}
 );

--- a/client/my-sites/site-settings/subscriptions/index.jsx
+++ b/client/my-sites/site-settings/subscriptions/index.jsx
@@ -13,7 +13,12 @@ import JetpackModuleToggle from '../jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormToggle from 'components/forms/form-toggle';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { isJetpackModuleActive } from 'state/selectors';
+import {
+	isJetpackModuleActive,
+	isJetpackModuleUnavailableInDevelopmentMode,
+	isJetpackSiteInDevelopmentMode
+} from 'state/selectors';
+import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
 
@@ -22,6 +27,7 @@ const Subscriptions = ( {
 	handleToggle,
 	isRequestingSettings,
 	isSavingSettings,
+	moduleUnavailable,
 	selectedSiteId,
 	selectedSiteSlug,
 	subscriptionsModuleActive,
@@ -29,6 +35,8 @@ const Subscriptions = ( {
 } ) => {
 	return (
 		<div>
+			<QueryJetpackConnection siteId={ selectedSiteId } />
+
 			<CompactCard className="subscriptions__card site-settings__discussion-settings">
 				<FormFieldset>
 					<div className="subscriptions__info-link-container site-settings__info-link-container">
@@ -43,14 +51,14 @@ const Subscriptions = ( {
 						siteId={ selectedSiteId }
 						moduleSlug="subscriptions"
 						label={ translate( 'Allow users to subscribe to your posts and comments and receive notifications via email.' ) }
-						disabled={ isRequestingSettings || isSavingSettings }
+						disabled={ isRequestingSettings || isSavingSettings || moduleUnavailable }
 						/>
 
 					<div className="subscriptions__module-settings site-settings__child-settings">
 						<FormToggle
 							className="subscriptions__module-settings-toggle is-compact"
 							checked={ !! fields.stb_enabled }
-							disabled={ isRequestingSettings || isSavingSettings || ! subscriptionsModuleActive }
+							disabled={ isRequestingSettings || isSavingSettings || ! subscriptionsModuleActive || moduleUnavailable }
 							onChange={ handleToggle( 'stb_enabled' ) }
 						>
 							{ translate( 'Show a "follow blog" option in the comment form' ) }
@@ -59,7 +67,7 @@ const Subscriptions = ( {
 						<FormToggle
 							className="subscriptions__module-settings-toggle is-compact"
 							checked={ !! fields.stc_enabled }
-							disabled={ isRequestingSettings || isSavingSettings || ! subscriptionsModuleActive }
+							disabled={ isRequestingSettings || isSavingSettings || ! subscriptionsModuleActive || moduleUnavailable }
 							onChange={ handleToggle( 'stc_enabled' ) }
 						>
 							{ translate( 'Show a "follow comments" option in the comment form.' ) }
@@ -93,11 +101,14 @@ export default connect(
 	( state ) => {
 		const selectedSiteId = getSelectedSiteId( state );
 		const selectedSiteSlug = getSelectedSiteSlug( state );
+		const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
+		const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode( state, selectedSiteId, 'subscriptions' );
 
 		return {
 			selectedSiteId,
 			selectedSiteSlug,
 			subscriptionsModuleActive: !! isJetpackModuleActive( state, selectedSiteId, 'subscriptions' ),
+			moduleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
 		};
 	}
 )( localize( Subscriptions ) );


### PR DESCRIPTION
This PR will disable the "Subscriptions" settings if the current Jetpack site is in development mode. Related with #11386.

Preview when disabled:
![](https://cldup.com/0ukbDj4v1h.png)

To test:

* Checkout this branch
* Select one of your Jetpack sites and enable dev mode by adding this to your wp-config.php: `define( 'JETPACK_DEV_DEBUG', true );`
* Verify the "Subscriptions" settings in the Publishing Tools card in the Discussion tab are disabled and can't be interacted with.
* Disable the Dev mode by deleting the line we just added to wp-config.php.
* Verify the "Subscriptions" settings are now enabled and can be interacted with.

/cc @rickybanister @MichaelArestad because I have the feeling that we need do something more in addition to just disabling the fields in that case (as also mentioned here: https://github.com/Automattic/wp-calypso/pull/11386#issuecomment-284359883).