### PR TITLE
Site Settings: Introduce the Traffic tab

### DIFF
--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -19,7 +19,6 @@ import { isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/select
 import GeneralSettings from './section-general';
 import WritingSettings from './form-writing';
 import DiscussionSettings from './form-discussion';
-import AnalyticsSettings from './form-analytics';
 import TrafficSettings from './section-traffic';
 import ImportSettings from './section-import';
 import ExportSettings from './section-export';
@@ -66,7 +65,6 @@ export class SiteSettingsComponent extends Component {
 			general: i18n.translate( 'General', { context: 'settings screen' } ),
 			writing: i18n.translate( 'Writing', { context: 'settings screen' } ),
 			discussion: i18n.translate( 'Discussion', { context: 'settings screen' } ),
-			analytics: i18n.translate( 'Analytics', { context: 'settings screen' } ),
 			traffic: i18n.translate( 'Traffic', { context: 'settings screen' } ),
 			security: i18n.translate( 'Security', { context: 'settings screen' } ),
 			'import': i18n.translate( 'Import', { context: 'settings screen' } ),
@@ -89,8 +87,6 @@ export class SiteSettingsComponent extends Component {
 				return <DiscussionSettings />;
 			case 'security':
 				return <SiteSecurity site={ site } />;
-			case 'analytics':
-				return <AnalyticsSettings />;
 			case 'traffic':
 				return <TrafficSettings sites={ sites } upgradeToBusiness={ upgradeToBusiness } />;
 			case 'import':

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -19,7 +19,6 @@ import { isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/select
 import GeneralSettings from './section-general';
 import WritingSettings from './form-writing';
 import DiscussionSettings from './form-discussion';
-import TrafficSettings from './section-traffic';
 import ImportSettings from './section-import';
 import ExportSettings from './section-export';
 import GuidedTransfer from 'my-sites/guided-transfer';
@@ -65,7 +64,6 @@ export class SiteSettingsComponent extends Component {
 			general: i18n.translate( 'General', { context: 'settings screen' } ),
 			writing: i18n.translate( 'Writing', { context: 'settings screen' } ),
 			discussion: i18n.translate( 'Discussion', { context: 'settings screen' } ),
-			traffic: i18n.translate( 'Traffic', { context: 'settings screen' } ),
 			security: i18n.translate( 'Security', { context: 'settings screen' } ),
 			'import': i18n.translate( 'Import', { context: 'settings screen' } ),
 			'export': i18n.translate( 'Export', { context: 'settings screen' } ),
@@ -74,7 +72,7 @@ export class SiteSettingsComponent extends Component {
 
 	getSection() {
 		const { site } = this.state;
-		const { section, hostSlug, sites, upgradeToBusiness } = this.props;
+		const { section, hostSlug } = this.props;
 
 		switch ( section ) {
 			case 'general':
@@ -87,8 +85,6 @@ export class SiteSettingsComponent extends Component {
 				return <DiscussionSettings />;
 			case 'security':
 				return <SiteSecurity site={ site } />;
-			case 'traffic':
-				return <TrafficSettings sites={ sites } upgradeToBusiness={ upgradeToBusiness } />;
 			case 'import':
 				return <ImportSettings site={ site } />;
 			case 'export':

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -20,6 +20,7 @@ import GeneralSettings from './section-general';
 import WritingSettings from './form-writing';
 import DiscussionSettings from './form-discussion';
 import AnalyticsSettings from './form-analytics';
+import TrafficSettings from './section-traffic';
 import ImportSettings from './section-import';
 import ExportSettings from './section-export';
 import GuidedTransfer from 'my-sites/guided-transfer';
@@ -66,8 +67,8 @@ export class SiteSettingsComponent extends Component {
 			writing: i18n.translate( 'Writing', { context: 'settings screen' } ),
 			discussion: i18n.translate( 'Discussion', { context: 'settings screen' } ),
 			analytics: i18n.translate( 'Analytics', { context: 'settings screen' } ),
+			traffic: i18n.translate( 'Traffic', { context: 'settings screen' } ),
 			security: i18n.translate( 'Security', { context: 'settings screen' } ),
-			seo: i18n.translate( 'SEO', { context: 'settings screen' } ),
 			'import': i18n.translate( 'Import', { context: 'settings screen' } ),
 			'export': i18n.translate( 'Export', { context: 'settings screen' } ),
 		};
@@ -75,7 +76,7 @@ export class SiteSettingsComponent extends Component {
 
 	getSection() {
 		const { site } = this.state;
-		const { section, hostSlug } = this.props;
+		const { section, hostSlug, sites, upgradeToBusiness } = this.props;
 
 		switch ( section ) {
 			case 'general':
@@ -90,6 +91,8 @@ export class SiteSettingsComponent extends Component {
 				return <SiteSecurity site={ site } />;
 			case 'analytics':
 				return <AnalyticsSettings />;
+			case 'traffic':
+				return <TrafficSettings sites={ sites } upgradeToBusiness={ upgradeToBusiness } />;
 			case 'import':
 				return <ImportSettings site={ site } />;
 			case 'export':

--- a/client/my-sites/site-settings/navigation.jsx
+++ b/client/my-sites/site-settings/navigation.jsx
@@ -26,8 +26,8 @@ export default React.createClass( {
 			writing: i18n.translate( 'Writing', { context: 'settings screen' } ),
 			discussion: i18n.translate( 'Discussion', { context: 'settings screen' } ),
 			analytics: i18n.translate( 'Analytics', { context: 'settings screen' } ),
+			traffic: i18n.translate( 'Traffic', { context: 'settings screen' } ),
 			security: i18n.translate( 'Security', { context: 'settings screen' } ),
-			seo: i18n.translate( 'SEO', { context: 'settings screen' } ),
 			'import': i18n.translate( 'Import', { context: 'settings screen' } ),
 			'export': i18n.translate( 'Export', { context: 'settings screen' } ),
 		};
@@ -97,10 +97,10 @@ export default React.createClass( {
 					}
 
 					<NavItem
-						path={ `/settings/seo/${ site.slug }` }
-						selected={ section === 'seo' }
+						path={ `/settings/traffic/${ site.slug }` }
+						selected={ section === 'traffic' }
 					>
-						{ strings.seo }
+						{ strings.traffic }
 					</NavItem>
 
 					{

--- a/client/my-sites/site-settings/navigation.jsx
+++ b/client/my-sites/site-settings/navigation.jsx
@@ -25,7 +25,6 @@ export default React.createClass( {
 			general: i18n.translate( 'General', { context: 'settings screen' } ),
 			writing: i18n.translate( 'Writing', { context: 'settings screen' } ),
 			discussion: i18n.translate( 'Discussion', { context: 'settings screen' } ),
-			analytics: i18n.translate( 'Analytics', { context: 'settings screen' } ),
 			traffic: i18n.translate( 'Traffic', { context: 'settings screen' } ),
 			security: i18n.translate( 'Security', { context: 'settings screen' } ),
 			'import': i18n.translate( 'Import', { context: 'settings screen' } ),
@@ -85,16 +84,6 @@ export default React.createClass( {
 						selected={ section === 'discussion' } >
 							{ strings.discussion }
 					</NavItem>
-
-					{
-						( ( ! site.jetpack && config.isEnabled( 'manage/plans' ) ) ||
-							( site.jetpack && config.isEnabled( 'jetpack/google-analytics' ) ) ) &&
-							<NavItem
-								path={ `/settings/analytics/${ site.slug }` }
-								selected={ section === 'analytics' } >
-									{ strings.analytics }
-							</NavItem>
-					}
 
 					<NavItem
 						path={ `/settings/traffic/${ site.slug }` }

--- a/client/my-sites/site-settings/section-traffic.jsx
+++ b/client/my-sites/site-settings/section-traffic.jsx
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import SeoSettingsMain from 'my-sites/site-settings/seo-settings/main';
+
+class SiteSettingsTraffic extends Component {
+	render() {
+		const { sites, upgradeToBusiness } = this.props;
+		return (
+			<div>
+				<SeoSettingsMain sites={ sites } upgradeToBusiness={ upgradeToBusiness } />
+			</div>
+		);
+	}
+}
+
+export default SiteSettingsTraffic;

--- a/client/my-sites/site-settings/section-traffic.jsx
+++ b/client/my-sites/site-settings/section-traffic.jsx
@@ -7,6 +7,7 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import SeoSettingsMain from 'my-sites/site-settings/seo-settings/main';
+import AnalyticsSettings from 'my-sites/site-settings/form-analytics';
 
 class SiteSettingsTraffic extends Component {
 	render() {
@@ -14,6 +15,7 @@ class SiteSettingsTraffic extends Component {
 		return (
 			<div>
 				<SeoSettingsMain sites={ sites } upgradeToBusiness={ upgradeToBusiness } />
+				<AnalyticsSettings />
 			</div>
 		);
 	}

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -34,7 +34,6 @@ import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import CountedTextarea from 'components/forms/counted-textarea';
 import Banner from 'components/banner';
-import SeoSettingsHelpCard from './help';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import {
 	getSiteOption,
@@ -503,8 +502,6 @@ export const SeoForm = React.createClass( {
 						title={ nudgeTitle }
 					/>
 				}
-
-				<SeoSettingsHelpCard />
 
 				<form onChange={ this.props.markChanged } className="seo-settings__seo-form">
 					{ showAdvancedSeo &&

--- a/client/my-sites/site-settings/seo-settings/main.jsx
+++ b/client/my-sites/site-settings/seo-settings/main.jsx
@@ -10,6 +10,7 @@ import debugFactory from 'debug';
  */
 import notices from 'notices';
 import QuerySitePurchases from 'components/data/query-site-purchases';
+import QuerySiteSettings from 'components/data/query-site-settings';
 import { getSitePurchases, hasLoadedSitePurchasesFromServer, getPurchasesError } from 'state/purchases/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import SeoForm from './form';
@@ -52,6 +53,7 @@ export class SeoSettings extends Component {
 
 		return (
 			<div>
+				{ site && <QuerySiteSettings siteId={ site.ID } /> }
 				{ site && <QuerySitePurchases siteId={ site.ID } /> }
 				{ site && <SeoForm { ...{ site, upgradeToBusiness } } /> }
 			</div>

--- a/client/my-sites/site-settings/seo-settings/main.jsx
+++ b/client/my-sites/site-settings/seo-settings/main.jsx
@@ -8,14 +8,11 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import Main from 'components/main';
 import notices from 'notices';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import { getSitePurchases, hasLoadedSitePurchasesFromServer, getPurchasesError } from 'state/purchases/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import SeoForm from './form';
-import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
-import SidebarNavigation from 'my-sites/sidebar-navigation';
 
 /**
  * Module vars
@@ -54,12 +51,10 @@ export class SeoSettings extends Component {
 		const { upgradeToBusiness } = this.props;
 
 		return (
-			<Main className="site-settings">
-				<SidebarNavigation />
-				<SiteSettingsNavigation site={ site } section="seo" />
+			<div>
 				{ site && <QuerySitePurchases siteId={ site.ID } /> }
 				{ site && <SeoForm { ...{ site, upgradeToBusiness } } /> }
-			</Main>
+			</div>
 		);
 	}
 

--- a/client/my-sites/site-settings/traffic/controller.js
+++ b/client/my-sites/site-settings/traffic/controller.js
@@ -11,7 +11,7 @@ import React from 'react';
 import analytics from 'lib/analytics';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import route from 'lib/route';
-import SeoSettingsMain from 'my-sites/site-settings/seo-settings/main';
+import TrafficMain from 'my-sites/site-settings/traffic/main';
 import sitesFactory from 'lib/sites-list';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import utils from 'lib/site/utils';
@@ -19,7 +19,7 @@ import utils from 'lib/site/utils';
 const sites = sitesFactory();
 
 export default {
-	seo( context ) {
+	traffic( context ) {
 		const analyticsPageTitle = 'Site Settings > SEO';
 		const basePath = route.sectionify( context.path );
 		const fiveMinutes = 5 * 60 * 1000;
@@ -33,7 +33,7 @@ export default {
 			page.redirect( '/stats' );
 			return;
 		}
-		
+
 		if ( ! site.latestSettings || new Date().getTime() - site.latestSettings > ( fiveMinutes ) ) {
 			if ( sites.initialized ) {
 				site.fetchSettings();
@@ -48,7 +48,7 @@ export default {
 		const upgradeToBusiness = () => page( '/checkout/' + site.domain + '/business' );
 
 		renderWithReduxStore(
-			React.createElement( SeoSettingsMain, {
+			React.createElement( TrafficMain, {
 				...{ sites, upgradeToBusiness }
 			} ),
 			document.getElementById( 'primary' ),

--- a/client/my-sites/site-settings/traffic/index.js
+++ b/client/my-sites/site-settings/traffic/index.js
@@ -6,12 +6,9 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import controller from './controller';
 import mySitesController from 'my-sites/controller';
 
 export default function() {
-	if ( config.isEnabled( 'manage/seo' ) ) {
-		page( '/settings/seo/:site_id', mySitesController.siteSelection, mySitesController.navigation, controller.seo );
-	}
+	page( '/settings/traffic/:site_id', mySitesController.siteSelection, mySitesController.navigation, controller.traffic );
 }

--- a/client/my-sites/site-settings/traffic/main.jsx
+++ b/client/my-sites/site-settings/traffic/main.jsx
@@ -11,6 +11,7 @@ import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
 import SeoSettingsMain from 'my-sites/site-settings/seo-settings/main';
+import SeoSettingsHelpCard from 'my-sites/site-settings/seo-settings/help';
 import AnalyticsSettings from 'my-sites/site-settings/form-analytics';
 import { getSelectedSite } from 'state/ui/selectors';
 
@@ -24,8 +25,9 @@ const SiteSettingsTraffic = ( {
 			<SidebarNavigation />
 			<SiteSettingsNavigation site={ site } section="traffic" />
 
-			<SeoSettingsMain sites={ sites } upgradeToBusiness={ upgradeToBusiness } />
+			<SeoSettingsHelpCard />
 			<AnalyticsSettings />
+			<SeoSettingsMain sites={ sites } upgradeToBusiness={ upgradeToBusiness } />
 		</Main>
 	);
 };

--- a/client/my-sites/site-settings/traffic/main.jsx
+++ b/client/my-sites/site-settings/traffic/main.jsx
@@ -19,18 +19,16 @@ const SiteSettingsTraffic = ( {
 	site,
 	sites,
 	upgradeToBusiness
-} ) => {
-	return (
-		<Main className="traffic__main site-settings">
-			<SidebarNavigation />
-			<SiteSettingsNavigation site={ site } section="traffic" />
+} ) => (
+	<Main className="traffic__main site-settings">
+		<SidebarNavigation />
+		<SiteSettingsNavigation site={ site } section="traffic" />
 
-			<SeoSettingsHelpCard />
-			<AnalyticsSettings />
-			<SeoSettingsMain sites={ sites } upgradeToBusiness={ upgradeToBusiness } />
-		</Main>
-	);
-};
+		<SeoSettingsHelpCard />
+		<AnalyticsSettings />
+		<SeoSettingsMain sites={ sites } upgradeToBusiness={ upgradeToBusiness } />
+	</Main>
+);
 
 SiteSettingsTraffic.propTypes = {
 	sites: PropTypes.object.isRequired,

--- a/client/my-sites/site-settings/traffic/main.jsx
+++ b/client/my-sites/site-settings/traffic/main.jsx
@@ -1,30 +1,42 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import Main from 'components/main';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
 import SeoSettingsMain from 'my-sites/site-settings/seo-settings/main';
 import AnalyticsSettings from 'my-sites/site-settings/form-analytics';
+import { getSelectedSite } from 'state/ui/selectors';
 
-class SiteSettingsTraffic extends Component {
-	static propTypes = {
-		sites: PropTypes.object.isRequired,
-		upgradeToBusiness: PropTypes.func.isRequired,
-	};
+const SiteSettingsTraffic = ( {
+	site,
+	sites,
+	upgradeToBusiness
+} ) => {
+	return (
+		<Main className="site-settings">
+			<SidebarNavigation />
+			<SiteSettingsNavigation site={ site } section="traffic" />
 
-	render() {
-		const { sites, upgradeToBusiness } = this.props;
-		return (
-			<Main className="site-settings">
-				<SeoSettingsMain sites={ sites } upgradeToBusiness={ upgradeToBusiness } />
-				<AnalyticsSettings />
-			</Main>
-		);
-	}
-}
+			<SeoSettingsMain sites={ sites } upgradeToBusiness={ upgradeToBusiness } />
+			<AnalyticsSettings />
+		</Main>
+	);
+};
 
-export default SiteSettingsTraffic;
+SiteSettingsTraffic.propTypes = {
+	sites: PropTypes.object.isRequired,
+	upgradeToBusiness: PropTypes.func.isRequired,
+};
+
+export default connect(
+	( state ) => ( {
+		site: getSelectedSite( state ),
+	} )
+)( SiteSettingsTraffic );

--- a/client/my-sites/site-settings/traffic/main.jsx
+++ b/client/my-sites/site-settings/traffic/main.jsx
@@ -20,7 +20,7 @@ const SiteSettingsTraffic = ( {
 	upgradeToBusiness
 } ) => {
 	return (
-		<Main className="site-settings">
+		<Main className="traffic__main site-settings">
 			<SidebarNavigation />
 			<SiteSettingsNavigation site={ site } section="traffic" />
 

--- a/client/my-sites/site-settings/traffic/main.jsx
+++ b/client/my-sites/site-settings/traffic/main.jsx
@@ -1,22 +1,28 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 
 /**
  * Internal dependencies
  */
+import Main from 'components/main';
 import SeoSettingsMain from 'my-sites/site-settings/seo-settings/main';
 import AnalyticsSettings from 'my-sites/site-settings/form-analytics';
 
 class SiteSettingsTraffic extends Component {
+	static propTypes = {
+		sites: PropTypes.object.isRequired,
+		upgradeToBusiness: PropTypes.func.isRequired,
+	};
+
 	render() {
 		const { sites, upgradeToBusiness } = this.props;
 		return (
-			<div>
+			<Main className="site-settings">
 				<SeoSettingsMain sites={ sites } upgradeToBusiness={ upgradeToBusiness } />
 				<AnalyticsSettings />
-			</div>
+			</Main>
 		);
 	}
 }

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -108,9 +108,9 @@ const sections = [
 		group: 'sites'
 	},
 	{
-		name: 'settings-seo',
-		paths: [ '/settings/seo' ],
-		module: 'my-sites/site-settings/seo-settings',
+		name: 'settings-traffic',
+		paths: [ '/settings/traffic' ],
+		module: 'my-sites/site-settings/traffic',
 		secondary: true,
 		group: 'sites'
 	},


### PR DESCRIPTION
This PR addresses part of #11615 - introducing the Traffic settings section. In further detail it does the following:

* Creates a new Traffic settings section.
* Moves "Analytics" in the new Traffic tab.
* Moves "SEO" in the new Traffic tab.
* Moves the "SEO" card above "Analytics".
* Renames the "settings-seo" section to the more general "settings-traffic".

Once we have the Traffic section there, we can also take care of adding the rest of the cards in it. For background, you can see #11676 or p6TEKc-HQ-p2.

Note: we're keeping Traffic as a separate bundle because of performance implications, as noted in p4TIVU-5Zs-p2.

Partial preview:
![](https://cldup.com/7MDyZ58C66.png)

To test:
1. Checkout this branch
2. Go to `/settings/traffic/$site`, where `$site` is a Jetpack site with Professional plan.
3. Play with Analytics and SEO settings and verify there are no regressions with them.
4. Test steps 2-3 with a WordPress.com site with a Business plan.
5. Test steps 2-3 with a Jetpack site with a Free plan.
6. Test steps 2-3 with a WordPress.com site with a Free plan.

I'm pinging some more folks for review, because I feel this needs substantial testing and 👀 