### PR TITLE
Site Settings: ES6ify the General settings section

### DIFF
--- a/client/my-sites/site-settings/section-general.jsx
+++ b/client/my-sites/site-settings/section-general.jsx
@@ -1,36 +1,33 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:my-sites:site-settings' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var GeneralForm = require( 'my-sites/site-settings/form-general' ),
-	DeleteSiteOptions = require( './delete-site-options' ),
-	config = require( 'config' );
+import GeneralForm from 'my-sites/site-settings/form-general';
+import DeleteSiteOptions from './delete-site-options';
+import config from 'config';
 
-module.exports = React.createClass({
-	displayName: 'SiteSettingsGeneral',
+const SiteSettingsGeneral = ( {
+	hasLoadedSitePurchasesFromServer,
+	site,
+	sitePurchases
+} ) => {
+	return (
+		<div className="site-settings__main general-settings">
+			<GeneralForm site={ site } />
 
-	componentWillMount: function() {
-		debug( 'Mounting SiteSettingsGeneral React component.' );
-	},
-
-	render: function() {
-		var site = this.props.site;
-		return (
-			<div className="general-settings">
-				<GeneralForm site={ site } />
-				{ ( config.isEnabled( 'manage/site-settings/delete-site' ) && ! site.jetpack && ! site.is_vip ) ?
+			{ config.isEnabled( 'manage/site-settings/delete-site' ) && ! site.jetpack && ! site.is_vip &&
 				<DeleteSiteOptions
-					site={ this.props.site }
-					sitePurchases={ this.props.sitePurchases }
-					hasLoadedSitePurchasesFromServer={ this.props.hasLoadedSitePurchasesFromServer } />
-				: null }
-			</div>
-		);
+					site={ site }
+					sitePurchases={ sitePurchases }
+					hasLoadedSitePurchasesFromServer={ hasLoadedSitePurchasesFromServer }
+				/>
+			}
+		</div>
+	);
+};
 
-	}
-});
+export default SiteSettingsGeneral;


### PR DESCRIPTION
This PR ES6ifies the General settings section. It also removes the unnecessary debug code.

To test:

* Checkout this branch
* Go to `/settings/general/$site` where `$site` is a WordPress.com site
* Verify the form works properly, retrieves and stores data as expected, and throws no warnings or errors.
* Test the above with a Jetpack site.