### PR TITLE
Site Settings: ES6ify the Security settings section

### DIFF
--- a/client/my-sites/site-settings/section-security.jsx
+++ b/client/my-sites/site-settings/section-security.jsx
@@ -1,64 +1,56 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:my-sites:site-settings' );
+import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var JetpackProtect = require( 'my-sites/site-settings/form-jetpack-protect' ),
-	JetpackMonitor = require( 'my-sites/site-settings/form-jetpack-monitor' ),
-	JetpackManageErrorPage = require( 'my-sites/jetpack-manage-error-page' );
+import JetpackProtect from 'my-sites/site-settings/form-jetpack-protect';
+import JetpackMonitor from 'my-sites/site-settings/form-jetpack-monitor';
+import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 
-module.exports = React.createClass( {
-	displayName: 'SiteSettingsSecurity',
-
-	componentWillMount: function() {
-		debug( 'Mounting SiteSettingsSecurity React component.' );
-	},
-
-	render: function() {
-		var site = this.props.site;
-
-		if ( ! site.jetpack ) {
-			return (
-				<JetpackManageErrorPage
-					action={ this.translate( 'Manage general settings for %(site)s', { args: { site: site.name } } ) }
-					actionURL={ '/settings/general/' + site.slug }
-					title={ this.translate( 'No security configuration is required.' ) }
-					line={ this.translate( 'Security management is automatic for WordPress.com sites.' ) }
-					illustration="/calypso/images/drake/drake-jetpack.svg"
-				/>
-			);
-		}
-
-		if ( ! site.canManage() ) {
-			return (
-				<JetpackManageErrorPage
-					template="optInManage"
-					title= { this.translate( 'Looking to manage this site\'s security settings?' ) }
-					section="security-settings"
-					siteId={ site.ID }
-				/>
-			);
-		}
-
-		if ( ! site.versionCompare( '3.4', '>=' ) ) {
-			return (
-				<JetpackManageErrorPage
-					template="updateJetpack"
-					siteId={ site.ID }
-					version="3.4"
-				/>
-			);
-		}
-
+const SiteSettingsSecurity = ( { site, translate } ) => {
+	if ( ! site.jetpack ) {
 		return (
-			<div>
-				<JetpackProtect site={ site } />
-				<JetpackMonitor site={ site } />
-			</div>
+			<JetpackManageErrorPage
+				action={ translate( 'Manage general settings for %(site)s', { args: { site: site.name } } ) }
+				actionURL={ '/settings/general/' + site.slug }
+				title={ translate( 'No security configuration is required.' ) }
+				line={ translate( 'Security management is automatic for WordPress.com sites.' ) }
+				illustration="/calypso/images/drake/drake-jetpack.svg"
+			/>
 		);
 	}
-} );
+
+	if ( ! site.canManage() ) {
+		return (
+			<JetpackManageErrorPage
+				template="optInManage"
+				title= { translate( 'Looking to manage this site\'s security settings?' ) }
+				section="security-settings"
+				siteId={ site.ID }
+			/>
+		);
+	}
+
+	if ( ! site.versionCompare( '3.4', '>=' ) ) {
+		return (
+			<JetpackManageErrorPage
+				template="updateJetpack"
+				siteId={ site.ID }
+				version="3.4"
+			/>
+		);
+	}
+
+	return (
+		<div>
+			<JetpackProtect site={ site } />
+			<JetpackMonitor site={ site } />
+		</div>
+	);
+};
+
+export default localize( SiteSettingsSecurity );


### PR DESCRIPTION
This PR ES6ifies the Security settings section. It also removes the unnecessary debug code.

To test:

* Checkout this branch
* Go to `/settings/security/$site` where `$site` is a Jetpack site
* Verify the section works correctly as before, and there are no warnings/errors.
* Test with a Jetpack site with disabled Manage and verify you see the expected error.
* Test the above with a WordPress.com site and verify that you see the "Security management is automatic for WordPress.com sites." message.