### PR TITLE
Directly: Allow in stage and wpcalypso environments

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -24,6 +24,7 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
+		"help/directly": true,
 		"jetpack/google-analytics": true,
 		"jetpack/api-cache": true,
 		"jetpack_core_inline_update": true,

--- a/config/test.json
+++ b/config/test.json
@@ -37,6 +37,7 @@
 		"devdocs/redirect-loggedout-homepage": true,
 		"devdocs/components-usage-stats": false,
 		"help": true,
+		"help/directly": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
 		"manage/customize": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -30,6 +30,7 @@
 		"guided-tours/theme-sheet-welcome": true,
 		"help": true,
 		"help/courses": true,
+		"help/directly": true,
 		"jetpack/api-cache": true,
 		"jetpack_core_inline_update": true,
 		"jetpack/google-analytics": true,


### PR DESCRIPTION
Super simple PR that enables the Directly feature flag for `stage` and `wpcalypso`. (Also `test` for good measure).

Once this ships we will be able to have internal and external stakeholders to this project start testing the Directly RTM integration end-to-end.

### To test

Load up `stage` and/or `wpcalypso` in Docker locally. Sign in as a user with no paid upgrades and navigate to the `/help/contact` page. You should see the Directly version of the form with the button "Ask an Expert" and submitting the form should open the Directly widget.

(I already tested this in a Dockerized `wpcalypso` and will test in both real environments after merge before deploying out to production.)