### PR TITLE
Bump Required Jetpack version to 4.7 for Themes Showcase and AT.

### DIFF
--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -335,7 +335,7 @@ class Upload extends React.Component {
 					template="updateJetpack"
 					siteId={ siteId }
 					featureExample={ this.renderUploadCard() }
-					version="4.4.2" /> }
+					version="4.7" /> }
 				{ showEligibility && <EligibilityWarnings
 					backUrl={ backPath }
 					onProceed={ this.onProceedClick } /> }

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -737,7 +737,7 @@ export function hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ) {
 	}
 
 	const siteJetpackVersion = getSiteOption( state, siteId, 'jetpack_version' );
-	return versionCompare( siteJetpackVersion, '4.4.2' ) >= 0;
+	return versionCompare( siteJetpackVersion, '4.7' ) >= 0;
 }
 
 /**

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -1735,7 +1735,7 @@ describe( 'selectors', () => {
 			expect( hasThemesExtendedFeatures ).to.be.null;
 		} );
 
-		it( 'it should return `false` if jetpack version is smaller than 4.4.2', () => {
+		it( 'it should return `false` if jetpack version is smaller than 4.7', () => {
 			const state = createStateWithItems( {
 				[ siteId ]: {
 					ID: siteId,
@@ -1751,14 +1751,14 @@ describe( 'selectors', () => {
 			expect( hasThemesExtendedFeatures ).to.be.false;
 		} );
 
-		it( 'it should return `true` if jetpack version is greater or equal to 4.4.2', () => {
+		it( 'it should return `true` if jetpack version is greater or equal to 4.7', () => {
 			const state = createStateWithItems( {
 				[ siteId ]: {
 					ID: siteId,
 					URL: 'https://jetpacksite.me',
 					jetpack: true,
 					options: {
-						jetpack_version: '4.4.2'
+						jetpack_version: '4.7'
 					}
 				}
 			} );

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -139,7 +139,7 @@ describe( 'actions', () => {
 				items: {
 					77203074: {
 						jetpack: true,
-						options: { jetpack_version: '4.4.2' }
+						options: { jetpack_version: '4.7' }
 					},
 				}
 			},

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -856,7 +856,7 @@ describe( 'themes selectors', () => {
 		} );
 
 		context( 'given a theme and a Jetpack site ID', () => {
-			context( 'with JP version < 4.4.2', () => {
+			context( 'with JP version < 4.7', () => {
 				it( 'should return the site\'s wp-admin theme details URL', () => {
 					const detailsUrl = getThemeDetailsUrl(
 						{
@@ -884,7 +884,7 @@ describe( 'themes selectors', () => {
 				} );
 			} );
 
-			context( 'with JP version >= 4.4.2', () => {
+			context( 'with JP version >= 4.7', () => {
 				context( 'with Jetpack Manage turned off', () => {
 					it( 'should return the site\'s wp-admin theme details URL', () => {
 						const detailsUrl = getThemeDetailsUrl(
@@ -897,7 +897,7 @@ describe( 'themes selectors', () => {
 											jetpack: true,
 											options: {
 												admin_url: 'https://example.net/wp-admin/',
-												jetpack_version: '4.4.2',
+												jetpack_version: '4.7',
 												active_modules: []
 											}
 										}
@@ -926,7 +926,7 @@ describe( 'themes selectors', () => {
 											jetpack: true,
 											options: {
 												admin_url: 'https://example.net/wp-admin/',
-												jetpack_version: '4.4.2'
+												jetpack_version: '4.7'
 											}
 										}
 									}


### PR DESCRIPTION
### Info
Proper AT work requires a filter added in Jetpack 4.7 (https://github.com/Automattic/jetpack/pull/6446)

This waits to land when 4.7 will be available as for now people need to be able to test stuff and this would block testing.

### Tesgin
Without Jetpack 4.7 AT is not possible.
With 4.7 it is posible. 
