### PR TITLE
Themes: Fix try&customize on Jetpack sites

### DIFF
--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -53,6 +53,7 @@ import {
 } from 'state/analytics/actions';
 import {
 	getTheme,
+	getCanonicalTheme,
 	getActiveTheme,
 	getLastThemeQuery,
 	getThemeCustomizeUrl,
@@ -574,7 +575,7 @@ export function installAndTryAndCustomizeTheme( themeId, siteId ) {
 export function tryAndCustomizeTheme( themeId, siteId ) {
 	return ( dispatch, getState ) => {
 		const siteIdOrWpcom = isJetpackSite( getState(), siteId ) ? siteId : 'wpcom';
-		const theme = getTheme( getState(), siteIdOrWpcom, themeId );
+		const theme = getCanonicalTheme( getState(), siteIdOrWpcom, themeId );
 		if ( ! theme ) {
 			return dispatch( {
 				type: THEME_TRY_AND_CUSTOMIZE_FAILURE,

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, includes, isEqual, omit, some, get, uniq } from 'lodash';
+import { includes, isEqual, omit, some, get, uniq } from 'lodash';
 import createSelector from 'lib/create-selector';
 
 /**
@@ -62,8 +62,19 @@ export const getTheme = createSelector(
  * @return {?Object}         Theme object
  */
 export function getCanonicalTheme( state, siteId, themeId ) {
-	const source = find( [ 'wpcom', 'wporg', siteId ], s => getTheme( state, s, themeId ) );
-	return getTheme( state, source, themeId );
+	if ( ! themeId ) {
+		return null;
+	}
+	// Assume that a call for a -wpcom suffixed theme wants
+	// details for the non-suffixed version.
+	let theme = getTheme( state, 'wpcom', themeId.replace( /-wpcom$/, '' ) );
+	if ( ! theme ) {
+		theme = getTheme( state, 'wporg', themeId.replace( /-wpcom$/, '' ) );
+	}
+	if ( ! theme ) {
+		theme = getTheme( state, siteId, themeId );
+	}
+	return theme;
 }
 
 /**


### PR DESCRIPTION
Now that we are properly filtering out any wpcom theme from the Jetpack theme state (#11787 ), the theme lookup required for a _try&customize_ is failing.

Fix by calling getCanonicalTheme() instead of getTheme() so that details can be fetched from the wpcom list.

Also, for convenience, strip any suffix passed to getCanonicalTheme() when hitting the wpcom/wporg lists.

**To Test**
Test the _Try & customize_ option for wpcom themes on a Jetpack site from the various places:
* ... button in themes list
* Live preview modal

There are various ways we could fix this so feel free to criticise heartily! And I'm fully aware that I've trashed `getCanonicalTheme` totally. 
