### PR TITLE
Add the `ActiveThemeScreenshot` component.

### DIFF
--- a/client/my-sites/site-settings/theme-setup/active-theme-screenshot.jsx
+++ b/client/my-sites/site-settings/theme-setup/active-theme-screenshot.jsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+
+const ActiveThemeScreenshot = ( { theme, translate } ) => {
+	return (
+		<div className="active-theme-screenshot">
+			{ theme &&
+				<a href={ theme.demo_uri }>
+					<img className="active-theme-screenshot__image" src={ theme.screenshot } />
+					<span className="active-theme-screenshot__name">
+						{ translate( 'Current theme: %(name)s', {
+							args: {
+								name: theme.name
+							}
+						} ) }
+					</span>
+				</a>
+			}
+		</div>
+	);
+};
+
+export default localize( ActiveThemeScreenshot );

--- a/client/my-sites/site-settings/theme-setup/style.scss
+++ b/client/my-sites/site-settings/theme-setup/style.scss
@@ -14,3 +14,19 @@
 	}
 }
 
+.theme-setup .active-theme-screenshot {
+	min-height: 200px;
+}
+
+.theme-setup .active-theme-screenshot__image {
+	border: 1px solid lighten( $gray, 30% );
+	box-sizing: border-box;
+}
+
+.theme-setup .active-theme-screenshot__name {
+	font-size: 0.85em;
+	font-weight: 600;
+	color: $gray;
+	text-transform: uppercase;
+}
+

--- a/client/my-sites/site-settings/theme-setup/theme-setup-card.jsx
+++ b/client/my-sites/site-settings/theme-setup/theme-setup-card.jsx
@@ -11,16 +11,21 @@ import ActionPanel from 'my-sites/site-settings/action-panel';
 import ActionPanelTitle from 'my-sites/site-settings/action-panel/title';
 import ActionPanelBody from 'my-sites/site-settings/action-panel/body';
 import ActionPanelFooter from 'my-sites/site-settings/action-panel/footer';
+import ActionPanelFigure from 'my-sites/site-settings/action-panel/figure';
 import Notice from 'components/notice';
 import Button from 'components/button';
+import ActiveThemeScreenshot from './active-theme-screenshot';
 
-const ThemeSetupCard = ( { translate } ) => (
+const ThemeSetupCard = ( { theme, translate } ) => (
 	<ActionPanel>
 		<ActionPanelBody>
 			<ActionPanelTitle>{ translate( 'Theme Setup' ) }</ActionPanelTitle>
 			<Notice status={ 'is-warning' } showDismiss={ false }>
 				{ translate( 'This action cannot be undone.' ) }
 			</Notice>
+			<ActionPanelFigure>
+				<ActiveThemeScreenshot theme={ theme } />
+			</ActionPanelFigure>
 			<p>{ translate( 'Want your site to look like the demo? Use Theme Setup to automatically apply the demo site\'s settings to your site.' ) }</p>
 			<p>{ translate( 'You can apply Theme Setup to your current site while keeping all your posts, pages, and widgets. Some placeholder text may appear on your site – some themes need certain elements to look like the demo, so Theme Setup adds those for you. Please customize it!', { components: { strong: <strong /> } } ) }</p>
 		</ActionPanelBody>


### PR DESCRIPTION
This PR adds the `ActiveThemeScreenshot ` component for implementing #10542 . It requires #11806 to be merged first, but can be tested since it includes ae1461cd6cb14280fbe73a3bb5e8175b297cc4d5 from #11806 .

**Testing**

Replace the current Start Over component by swapping it out with this one. In `client/my-sites/site-settings/controller.js`:
* Add `import ThemeSetup from './theme-setup';`
* Replace L172 with `<ThemeSetup activeSiteDomain={ context.params.site_id } />`
* Load http://calypso.localhost:3000/settings/start-over/site.wordpress.com

You should see a card similar to this:

![screen shot 2017-03-07 at 11 03 27 am](https://cloud.githubusercontent.com/assets/349751/23673109/e58e87f2-0325-11e7-88fe-83eee4747b46.png)

* Note that the theme name should be styled in uppercase, and the screenshot should link to the correct theme demo site.
