### PR TITLE
Add the main Theme Setup card to site settings.

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -331,6 +331,7 @@
 @import 'my-sites/site-settings/related-posts/style';
 @import 'my-sites/site-settings/site-icon-setting/style';
 @import 'my-sites/site-settings/taxonomies/style';
+@import 'my-sites/site-settings/theme-setup/style';
 @import 'my-sites/importer/style';
 @import 'blocks/site/style';
 @import 'my-sites/sites/style';

--- a/client/my-sites/site-settings/theme-setup/index.jsx
+++ b/client/my-sites/site-settings/theme-setup/index.jsx
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import HeaderCake from 'components/header-cake';
+import QueryActiveTheme from 'components/data/query-active-theme';
+import QueryTheme from 'components/data/query-theme';
+import ThemeSetupCard from './theme-setup-card';
+import ThemeSetupPlaceholder from './theme-setup-placeholder';
+import { getSelectedSite } from 'state/ui/selectors';
+import { getActiveTheme, getTheme } from 'state/themes/selectors';
+
+let ThemeSetup = ( { site, themeId, theme, translate, activeSiteDomain } ) => {
+	const onBack = () => {
+		page( '/settings/general/' + activeSiteDomain );
+	};
+
+	return (
+		<div className="main theme-setup" role="main">
+			{ site && <QueryActiveTheme siteId={ site.ID } /> }
+			{ themeId && <QueryTheme siteId={ 'wpcom' } themeId={ themeId } /> }
+			<HeaderCake onClick={ onBack }><h1>{ translate( 'Theme Setup' ) }</h1></HeaderCake>
+			{ site && theme
+				? <ThemeSetupCard
+					theme={ theme } />
+				: <ThemeSetupPlaceholder /> }
+		</div>
+	);
+};
+
+ThemeSetup = localize( ThemeSetup );
+
+const mapStateToProps = ( state ) => {
+	const site = getSelectedSite( state );
+	const themeId = site && getActiveTheme( state, site.ID );
+	const theme = themeId && getTheme( state, 'wpcom', themeId );
+	return {
+		site,
+		themeId,
+		theme,
+	};
+};
+
+export default connect( mapStateToProps )( ThemeSetup );
+

--- a/client/my-sites/site-settings/theme-setup/style.scss
+++ b/client/my-sites/site-settings/theme-setup/style.scss
@@ -1,0 +1,16 @@
+.theme-setup__button {
+	margin-bottom: 8px;
+	margin-right: 8px;
+
+	&.is-placeholder {
+		border: none;
+		border-radius: 0;
+	}
+}
+
+.theme-setup {
+	.is-placeholder {
+		@include placeholder;
+	}
+}
+

--- a/client/my-sites/site-settings/theme-setup/theme-setup-card.jsx
+++ b/client/my-sites/site-settings/theme-setup/theme-setup-card.jsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import ActionPanel from 'my-sites/site-settings/action-panel';
+import ActionPanelTitle from 'my-sites/site-settings/action-panel/title';
+import ActionPanelBody from 'my-sites/site-settings/action-panel/body';
+import ActionPanelFooter from 'my-sites/site-settings/action-panel/footer';
+import Notice from 'components/notice';
+import Button from 'components/button';
+
+const ThemeSetupCard = ( { translate } ) => (
+	<ActionPanel>
+		<ActionPanelBody>
+			<ActionPanelTitle>{ translate( 'Theme Setup' ) }</ActionPanelTitle>
+			<Notice status={ 'is-warning' } showDismiss={ false }>
+				{ translate( 'This action cannot be undone.' ) }
+			</Notice>
+			<p>{ translate( 'Want your site to look like the demo? Use Theme Setup to automatically apply the demo site\'s settings to your site.' ) }</p>
+			<p>{ translate( 'You can apply Theme Setup to your current site while keeping all your posts, pages, and widgets. Some placeholder text may appear on your site – some themes need certain elements to look like the demo, so Theme Setup adds those for you. Please customize it!', { components: { strong: <strong /> } } ) }</p>
+		</ActionPanelBody>
+		<ActionPanelFooter>
+			<Button className="theme-setup__button" primary={ true }>
+				{ translate( 'Set Up Your Theme' ) }
+			</Button>
+		</ActionPanelFooter>
+	</ActionPanel>
+);
+
+export default localize( ThemeSetupCard );
+

--- a/client/my-sites/site-settings/theme-setup/theme-setup-placeholder.jsx
+++ b/client/my-sites/site-settings/theme-setup/theme-setup-placeholder.jsx
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+
+const ThemeSetupPlaceholder = () => {
+	return (
+		<div className="card settings-action-panel">
+			<div className="settings-action-panel__body">
+				<h2 className="settings-action-panel__title">
+					<span className="is-placeholder">Theme Setup</span>
+				</h2>
+				<div className="notice is-placeholder">
+					<span className="notice__text">Notice</span>
+				</div>
+				<p className="is-placeholder">Want your site to look like the demo? Use Theme Setup to automatically apply the demo site's settings to your site.</p>
+				<p className="is-placeholder">You can apply Theme Setup to your current site while keeping all your posts, pages, and widgets. Some placeholder text may appear on your site – some themes need certain elements to look like the demo, so Theme Setup adds those for you. Please customize it!</p>
+			</div>
+			<div className="settings-action-panel__footer">
+				<button className="button theme-setup__button is-placeholder">Set Up And Keep Content</button>
+			</div>
+		</div>
+	);
+};
+
+export default ThemeSetupPlaceholder;
+


### PR DESCRIPTION
This PR adds the components needed for Theme Setup #10542 . Note that the button shouldn't do anything, the store and the dialog are not wired up to simplify testing.

**Testing**

Replace the current Start Over component by swapping it out with this one. In `client/my-sites/site-settings/controller.js`:
* Add `import ThemeSetup from './theme-setup';`
* Replace L172 with `<ThemeSetup activeSiteDomain={ context.params.site_id } />`
* Load http://calypso.localhost:3000/settings/start-over/site.wordpress.com

You should see a card similar to this:

![screen shot 2017-03-06 at 3 04 58 pm](https://cloud.githubusercontent.com/assets/349751/23634289/59ad0616-027e-11e7-89b7-87eb0c2e3544.png)

To test the placeholder component:
* Open `client/my-sites/site-settings/theme-setup/index.jsx`
* On L30, replace `site` with `false`

You should see a pulsing card like this:

![screen shot 2017-03-06 at 3 15 23 pm](https://cloud.githubusercontent.com/assets/349751/23634584/c706e9d8-027f-11e7-8df7-61988c3704b5.png)
