### PR TITLE
Purchases: Flatten nested properties for some checkout events

### DIFF
--- a/client/lib/cart/store/cart-analytics.js
+++ b/client/lib/cart/store/cart-analytics.js
@@ -1,29 +1,32 @@
 /**
+ * External dependencies
+ */
+import { difference, each, isObjectLike, omitBy } from 'lodash';
+
+/**
  * Internal dependencies
  */
-var analytics = require( 'lib/analytics' ),
-	cartItems = require( 'lib/cart-values' ).cartItems,
-	difference = require( 'lodash/difference' );
-
+import analytics from 'lib/analytics';
+import { cartItems } from 'lib/cart-values';
 import { recordAddToCart } from 'lib/analytics/ad-tracking';
 
 function recordEvents( previousCart, nextCart ) {
-	var previousItems = cartItems.getAll( previousCart ),
+	const previousItems = cartItems.getAll( previousCart ),
 		nextItems = cartItems.getAll( nextCart );
 
-	difference( nextItems, previousItems ).forEach( recordAddEvent );
-	difference( previousItems, nextItems ).forEach( recordRemoveEvent );
+	each( difference( nextItems, previousItems ), recordAddEvent );
+	each( difference( previousItems, nextItems ), recordRemoveEvent );
 }
 
 function recordAddEvent( cartItem ) {
-	analytics.tracks.recordEvent( 'calypso_cart_product_add', cartItem );
+	analytics.tracks.recordEvent( 'calypso_cart_product_add', omitBy( cartItem, isObjectLike ) );
 	recordAddToCart( cartItem );
 }
 
 function recordRemoveEvent( cartItem ) {
-	analytics.tracks.recordEvent( 'calypso_cart_product_remove', cartItem );
+	analytics.tracks.recordEvent( 'calypso_cart_product_remove', omitBy( cartItem, isObjectLike ) );
 }
 
-module.exports = {
+export default {
 	recordEvents: recordEvents
 };

--- a/client/lib/cart/store/cart-analytics.js
+++ b/client/lib/cart/store/cart-analytics.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { difference, each, isObjectLike, omitBy } from 'lodash';
+import { difference, each, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,17 +18,17 @@ function recordEvents( previousCart, nextCart ) {
 	each( difference( previousItems, nextItems ), recordRemoveEvent );
 }
 
-function flattenCartObject( cartItem ) {
-	return omitBy( cartItem, isObjectLike );
+function removeNestedProperties( cartItem ) {
+	return omit( cartItem, [ 'extra' ] );
 }
 
 function recordAddEvent( cartItem ) {
-	analytics.tracks.recordEvent( 'calypso_cart_product_add', flattenCartObject( cartItem ) );
+	analytics.tracks.recordEvent( 'calypso_cart_product_add', removeNestedProperties( cartItem ) );
 	recordAddToCart( cartItem );
 }
 
 function recordRemoveEvent( cartItem ) {
-	analytics.tracks.recordEvent( 'calypso_cart_product_remove', flattenCartObject( cartItem ) );
+	analytics.tracks.recordEvent( 'calypso_cart_product_remove', removeNestedProperties( cartItem ) );
 }
 
 export default {

--- a/client/lib/cart/store/cart-analytics.js
+++ b/client/lib/cart/store/cart-analytics.js
@@ -18,13 +18,17 @@ function recordEvents( previousCart, nextCart ) {
 	each( difference( previousItems, nextItems ), recordRemoveEvent );
 }
 
+function flattenCartObject( cartItem ) {
+	return omitBy( cartItem, isObjectLike );
+}
+
 function recordAddEvent( cartItem ) {
-	analytics.tracks.recordEvent( 'calypso_cart_product_add', omitBy( cartItem, isObjectLike ) );
+	analytics.tracks.recordEvent( 'calypso_cart_product_add', flattenCartObject( cartItem ) );
 	recordAddToCart( cartItem );
 }
 
 function recordRemoveEvent( cartItem ) {
-	analytics.tracks.recordEvent( 'calypso_cart_product_remove', omitBy( cartItem, isObjectLike ) );
+	analytics.tracks.recordEvent( 'calypso_cart_product_remove', flattenCartObject( cartItem ) );
 }
 
 export default {

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -372,7 +372,7 @@ export default React.createClass( {
 
 		tracksEventObject = reduce(
 			formState.getErrorMessages( this.state.form ),
-			function( result, value, key ) {
+			( result, value, key ) => {
 				result[ `error_${ key }` ] = value;
 				return result;
 			},

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -364,20 +364,18 @@ export default React.createClass( {
 	},
 
 	recordSubmit() {
-		const errors = formState.getErrorMessages( this.state.form );
-		let tracksEventObject = {
-			errors_count: errors && errors.length || 0,
-			submission_count: this.state.submissionCount + 1
-		};
-
-		tracksEventObject = reduce(
-			formState.getErrorMessages( this.state.form ),
-			( result, value, key ) => {
-				result[ `error_${ key }` ] = value;
-				return result;
-			},
-			tracksEventObject
-		);
+		const errors = formState.getErrorMessages( this.state.form ),
+			tracksEventObject = reduce(
+				formState.getErrorMessages( this.state.form ),
+				( result, value, key ) => {
+					result[ `error_${ key }` ] = value;
+					return result;
+				},
+				{
+					errors_count: errors && errors.length || 0,
+					submission_count: this.state.submissionCount + 1
+				}
+			);
 
 		analytics.tracks.recordEvent( 'calypso_contact_information_form_submit', tracksEventObject );
 		this.setState( { submissionCount: this.state.submissionCount + 1 } );

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import classNames from 'classnames';
-import { map, camelCase, kebabCase, head, omit } from 'lodash';
+import { camelCase, head, kebabCase, map, omit, reduce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -365,11 +365,21 @@ export default React.createClass( {
 
 	recordSubmit() {
 		const errors = formState.getErrorMessages( this.state.form );
-		analytics.tracks.recordEvent( 'calypso_contact_information_form_submit', {
-			errors,
+		let tracksEventObject = {
 			errors_count: errors && errors.length || 0,
 			submission_count: this.state.submissionCount + 1
-		} );
+		};
+
+		tracksEventObject = reduce(
+			formState.getErrorMessages( this.state.form ),
+			function( result, value, key ) {
+				result[ `error_${ key }` ] = value;
+				return result;
+			},
+			tracksEventObject
+		);
+
+		analytics.tracks.recordEvent( 'calypso_contact_information_form_submit', tracksEventObject );
 		this.setState( { submissionCount: this.state.submissionCount + 1 } );
 	},
 


### PR DESCRIPTION
We were passing nested properties for these events:
- calypso_contact_information_form_submit
- calypso_cart_product_add
- calypso_cart_product_remove

Preprocess the objects to either remove values or flatten them.

Test:
- Follow steps in https://github.com/Automattic/wp-calypso/issues/11474
- Shouldn't see any errors in the console

### Review
* [x] Code
* [x] Product