### PR TITLE
Add the ThemeSetupDialog component.

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -332,6 +332,7 @@
 @import 'my-sites/site-settings/site-icon-setting/style';
 @import 'my-sites/site-settings/taxonomies/style';
 @import 'my-sites/site-settings/theme-setup/style';
+@import 'my-sites/site-settings/theme-setup-dialog/style';
 @import 'my-sites/importer/style';
 @import 'blocks/site/style';
 @import 'my-sites/sites/style';

--- a/client/my-sites/site-settings/theme-setup-dialog/index.jsx
+++ b/client/my-sites/site-settings/theme-setup-dialog/index.jsx
@@ -1,0 +1,130 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+import PulsingDot from 'components/pulsing-dot';
+import { getSelectedSite } from 'state/ui/selectors';
+import { toggleDialog, runThemeSetup } from 'state/ui/theme-setup/actions';
+
+class ThemeSetupDialog extends React.Component {
+	renderButtons( { runThemeSetup, site, isActive, result, translate } ) {
+		const keepContent = {
+			action: 'keep-content',
+			label: translate( 'Set Up Your Theme' ),
+			isPrimary: true,
+			onClick: () => runThemeSetup( site.ID ),
+		};
+		const cancel = {
+			action: 'cancel',
+			label: translate( 'Cancel' ),
+		};
+		const backToSetup = {
+			action: 'back-to-setup',
+			label: translate( 'Back To Setup' ),
+			disabled: isActive,
+		};
+		const viewSite = {
+			action: 'view-site',
+			label: translate( 'View Site' ),
+			isPrimary: true,
+			disabled: isActive,
+			onClick: () => page( site.URL ),
+		};
+
+		if ( isActive || 'success' === result.result ) {
+			return [
+				backToSetup,
+				viewSite
+			];
+		}
+		return [
+			cancel,
+			keepContent,
+		];
+	}
+
+	renderContent( { isActive, result, site, translate } ) {
+		const keepContent = (
+			<div>
+				<h1>{ translate( 'Theme Setup' ) }</h1>
+				<p>
+					{ translate( 'Settings will be changed on {{strong}}%(site)s{{/strong}}, and these changes will be live immmediately. Do you want to proceed?', {
+						components: {
+							strong: <strong />,
+						},
+						args: {
+							site: site.domain,
+						}
+					} ) }
+				</p>
+			</div>
+		);
+		const loading = (
+			<div>
+				<h1>{ translate( 'Theme Setup' ) }</h1>
+				<p>{ translate( 'Running Theme Setup. This may take up to a minute.' ) }</p>
+				<PulsingDot active={ true } />
+			</div>
+		);
+		const success = (
+			<div>
+				<h1>{ translate( 'Theme Setup' ) }</h1>
+				<p>
+					{ translate( 'Success! Your theme is all set up like the demo.' ) }
+				</p>
+			</div>
+		);
+		const failure = (
+			<div>
+				<h1>{ translate( 'Theme Setup' ) }</h1>
+				<p>
+					{ translate( 'We encountered a problem – would you like to try again?' ) }
+				</p>
+			</div>
+		);
+		if ( isActive ) {
+			return loading;
+		}
+		if ( result ) {
+			return ( 'success' === result.result ) ? success : failure;
+		}
+		return keepContent;
+	}
+
+	render() {
+		return (
+			<Dialog className="theme-setup-dialog"
+				isVisible={ this.props.isDialogVisible }
+				buttons={ this.renderButtons( this.props ) }
+				onClose={ this.props.isActive ? null : this.props.toggleDialog }>
+				{ this.renderContent( this.props ) }
+			</Dialog>
+		);
+	}
+}
+
+ThemeSetupDialog = localize( ThemeSetupDialog );
+
+const mapStateToProps = ( state ) => {
+	const isDialogVisible = state.ui.themeSetup.isDialogVisible;
+	const isActive = state.ui.themeSetup.active;
+	const result = state.ui.themeSetup.result;
+	const site = getSelectedSite( state );
+	return {
+		isDialogVisible,
+		isActive,
+		result,
+		site,
+	};
+};
+
+export default connect( mapStateToProps, { toggleDialog, runThemeSetup } )( ThemeSetupDialog );
+

--- a/client/my-sites/site-settings/theme-setup-dialog/style.scss
+++ b/client/my-sites/site-settings/theme-setup-dialog/style.scss
@@ -1,0 +1,10 @@
+.theme-setup-dialog {
+	min-height: 170px;
+	width: 400px;
+
+	@include breakpoint( "<480px" ) {
+		box-sizing: border-box;
+		width: 100%;
+	}
+}
+

--- a/client/my-sites/site-settings/theme-setup/index.jsx
+++ b/client/my-sites/site-settings/theme-setup/index.jsx
@@ -16,8 +16,9 @@ import ThemeSetupCard from './theme-setup-card';
 import ThemeSetupPlaceholder from './theme-setup-placeholder';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getActiveTheme, getTheme } from 'state/themes/selectors';
+import { toggleDialog } from 'state/ui/theme-setup/actions';
 
-let ThemeSetup = ( { site, themeId, theme, translate, activeSiteDomain } ) => {
+let ThemeSetup = ( { site, themeId, theme, translate, activeSiteDomain, toggleDialog } ) => {
 	const onBack = () => {
 		page( '/settings/general/' + activeSiteDomain );
 	};
@@ -29,6 +30,7 @@ let ThemeSetup = ( { site, themeId, theme, translate, activeSiteDomain } ) => {
 			<HeaderCake onClick={ onBack }><h1>{ translate( 'Theme Setup' ) }</h1></HeaderCake>
 			{ site && theme
 				? <ThemeSetupCard
+					onClick={ toggleDialog }
 					theme={ theme } />
 				: <ThemeSetupPlaceholder /> }
 		</div>
@@ -48,5 +50,5 @@ const mapStateToProps = ( state ) => {
 	};
 };
 
-export default connect( mapStateToProps )( ThemeSetup );
+export default connect( mapStateToProps, { toggleDialog } )( ThemeSetup );
 

--- a/client/my-sites/site-settings/theme-setup/theme-setup-card.jsx
+++ b/client/my-sites/site-settings/theme-setup/theme-setup-card.jsx
@@ -15,8 +15,9 @@ import ActionPanelFigure from 'my-sites/site-settings/action-panel/figure';
 import Notice from 'components/notice';
 import Button from 'components/button';
 import ActiveThemeScreenshot from './active-theme-screenshot';
+import ThemeSetupDialog from 'my-sites/site-settings/theme-setup-dialog';
 
-const ThemeSetupCard = ( { theme, translate } ) => (
+const ThemeSetupCard = ( { theme, translate, onClick } ) => (
 	<ActionPanel>
 		<ActionPanelBody>
 			<ActionPanelTitle>{ translate( 'Theme Setup' ) }</ActionPanelTitle>
@@ -30,10 +31,11 @@ const ThemeSetupCard = ( { theme, translate } ) => (
 			<p>{ translate( 'You can apply Theme Setup to your current site while keeping all your posts, pages, and widgets. Some placeholder text may appear on your site – some themes need certain elements to look like the demo, so Theme Setup adds those for you. Please customize it!', { components: { strong: <strong /> } } ) }</p>
 		</ActionPanelBody>
 		<ActionPanelFooter>
-			<Button className="theme-setup__button" primary={ true }>
+			<Button className="theme-setup__button" primary={ true } onClick={ onClick }>
 				{ translate( 'Set Up Your Theme' ) }
 			</Button>
 		</ActionPanelFooter>
+		<ThemeSetupDialog />
 	</ActionPanel>
 );
 

--- a/client/state/ui/theme-setup/reducers.js
+++ b/client/state/ui/theme-setup/reducers.js
@@ -24,7 +24,7 @@ export const themeSetup = ( state = initialState, action ) => {
 		case THEME_SETUP_REQUEST:
 			return { ...state, active: true, result: false };
 		case THEME_SETUP_TOGGLE_DIALOG:
-			return { ...state, isDialogVisible: ! state.isDialogVisible };
+			return { ...state, isDialogVisible: ! state.isDialogVisible, result: false };
 	}
 
 	return state;


### PR DESCRIPTION
This PR adds the `ThemeSetupDialog` component for implementing #10542 . It will be used behind a feature flag for a8c-only testing in a later PR.

**Testing**

Replace the current Start Over component by swapping it out with this one. In `client/my-sites/site-settings/controller.js`:
* Add `import ThemeSetup from './theme-setup';`
* Replace L172 with `<ThemeSetup activeSiteDomain={ context.params.site_id } />`
* Load http://calypso.localhost:3000/settings/start-over/site.wordpress.com (**only use a site you don't mind getting Headstarted**)

Clicking "Set Up Your Theme" should get you this dialog:

![screen shot 2017-03-07 at 4 17 12 pm](https://cloud.githubusercontent.com/assets/349751/23684206/175d3e0a-0352-11e7-99b8-36dac7346301.png)

Clicking the primary action again will start running Headstart (for real) and should get you:

![screen shot 2017-03-07 at 4 17 37 pm](https://cloud.githubusercontent.com/assets/349751/23684201/0e49d2f6-0352-11e7-8a13-bfe813186d69.png)

On success, you'll have:

![screen shot 2017-03-07 at 4 18 33 pm](https://cloud.githubusercontent.com/assets/349751/23684197/03a1db5a-0352-11e7-8307-a8384dc11e49.png)

And on failure:

![screen shot 2017-03-07 at 4 19 04 pm](https://cloud.githubusercontent.com/assets/349751/23684190/f6683416-0351-11e7-85fb-f4370d69c487.png)


