### PR TITLE
Stats: fix flag icons in IE11

### DIFF
--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -168,23 +168,27 @@ module.exports = React.createClass( {
 		label = labelData.map( function( labelItem, i ) {
 			var iconClassSetOptions = { avatar: true },
 				icon,
-				avatar,
 				gridiconSpan;
 
 			if ( labelItem.labelIcon ) {
 				gridiconSpan = ( <Gridicon icon={ labelItem.labelIcon } /> );
 			}
 
-			if ( 'icon' in labelItem ) {
+			if ( labelItem.icon ) {
 				if ( labelItem.iconClassName ) {
 					iconClassSetOptions[ labelItem.iconClassName ] = true;
 				}
 
-				if ( labelItem.icon ) {
-					avatar = ( <span className='icon'><img alt="" src={ labelItem.icon } className={ classNames( iconClassSetOptions ) } /></span> );
-				}
+				icon = (
+					<span className='icon'>
+						<img alt="" src={ labelItem.icon } className={ classNames( iconClassSetOptions ) } />
+					</span>
+				);
+			}
 
-				icon = avatar;
+			if ( labelItem.backgroundImage ) {
+				const style = { backgroundImage: `url( ${ labelItem.backgroundImage } )` };
+				icon = ( <span className="stats-list__flag-icon" style={ style } /> );
 			}
 
 			return ( <span className={ wrapperClassSet } key={ i } >{ gridiconSpan }{ icon }<Emojify>{ labelItem.label }</Emojify></span> );

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -201,6 +201,18 @@
 		margin-right: 8px;
 	}
 
+	.stats-list__flag-icon {
+		position: relative;
+		display: inline-block;
+		background-size: contain;
+		background-position: 50%;
+		background-repeat: no-repeat;
+		width: 24px;
+		height: 18px;
+		top: 3px;
+		margin-right: 8px;
+	}
+
 	.icon {
 		position: relative;
 		display: inline-block;
@@ -217,12 +229,6 @@
 			position: relative;
 			width: 20px;
 			height: 20px;
-
-			&.is-flag {
-				width: 24px;
-				height: 18px;
-				padding-top: 2px;
-			}
 		}
 
 		// Hide for user avatars

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -524,8 +524,7 @@ describe( 'utils', () => {
 						label: 'United States',
 						value: 1,
 						region: '021',
-						icon: '/calypso/images/flags/us.svg',
-						iconClassName: 'is-flag'
+						backgroundImage: '/calypso/images/flags/us.svg'
 					}
 				] );
 			} );
@@ -561,8 +560,7 @@ describe( 'utils', () => {
 						label: 'United States',
 						value: 10,
 						region: '021',
-						icon: '/calypso/images/flags/us.svg',
-						iconClassName: 'is-flag'
+						backgroundImage: '/calypso/images/flags/us.svg'
 					}
 				] );
 			} );
@@ -597,8 +595,7 @@ describe( 'utils', () => {
 						label: 'United States',
 						value: 100,
 						region: '021',
-						icon: '/calypso/images/flags/us.svg',
-						iconClassName: 'is-flag'
+						backgroundImage: '/calypso/images/flags/us.svg'
 					}
 				] );
 			} );
@@ -634,8 +631,7 @@ describe( 'utils', () => {
 						label: 'United States',
 						value: 100,
 						region: '021',
-						icon: '/calypso/images/flags/us.svg',
-						iconClassName: 'is-flag'
+						backgroundImage: '/calypso/images/flags/us.svg'
 					}
 				] );
 			} );
@@ -671,8 +667,7 @@ describe( 'utils', () => {
 						label: 'US\'A',
 						value: 100,
 						region: '021',
-						icon: '/calypso/images/flags/us.svg',
-						iconClassName: 'is-flag'
+						backgroundImage: '/calypso/images/flags/us.svg'
 					}
 				] );
 			} );
@@ -711,8 +706,7 @@ describe( 'utils', () => {
 						label: 'United States',
 						value: 100,
 						region: '021',
-						icon: '/calypso/images/flags/us.svg',
-						iconClassName: 'is-flag'
+						backgroundImage: '/calypso/images/flags/us.svg'
 					}
 				] );
 			} );

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -234,8 +234,7 @@ export const normalizers = {
 				label: country.country_full.replace( /’/, "'" ),
 				value: viewData.views,
 				region: country.map_region,
-				icon: icon,
-				iconClassName: 'is-flag'
+				backgroundImage: icon
 			};
 		} );
 	},


### PR DESCRIPTION
Fixes #11808 - With the move to using svgs for the country flags, we ( I ) created an issue for IE11 users, because IE 11 does not scale svg properly in all cases by the assigned `width` and `height` attributes.  TIL!

As such, I opted to utilize the styling approach that is taken in the source svg project [#](https://github.com/lipis/flag-icon-css/blob/master/css/flag-icon.css#L6-L14) by having a block element with a background image that is the svg for the country.

__To Test__
- Verify country flags show up just as they do in production in non IE11 browsers
- Boot up an IE11 VM and verify that the flag icons also show correctly there 