### PR TITLE
AT: Disable Jetpack and Vaultpress plugin actions

### DIFF
--- a/client/my-sites/plugins/plugin-item/README.md
+++ b/client/my-sites/plugins/plugin-item/README.md
@@ -26,7 +26,14 @@ render: function() {
 #### Props
 
 * `plugin`: a plugin object.
+* `sites`: an array of site objects
 * `isSelected`: a boolean indicating if the plugin is selected.
 * `isSelectable`: a boolean if the plugin is selectable. If true it will show a checkbox.
 * `onClick`: onClick handler.
 * `pluginLink`: the url of the plugin.
+* `allowedActions`: an object of allowed plugin actions: `activation`, `autoupdate`. Used to display/hide plugin actions.
+* `isAutoManaged`: a boolean if the plugin is auto managed. If true it will dispaly an auto managed message. Defaults to false.
+* `progress`: an array of progress steps.
+* `errors`: an array of update errors.
+* `notices`: an object of plugin notices: `completed`, `errors`, `inProgress`.
+* `hasAllNoManageSites`: a boolean to display an non managed plugin.

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -37,6 +37,38 @@ module.exports = React.createClass( {
 
 	displayName: 'PluginItem',
 
+	propTypes: {
+		plugin: React.PropTypes.object,
+		sites: React.PropTypes.array,
+		isSelected: React.PropTypes.bool,
+		isSelectable: React.PropTypes.bool,
+		onClick: React.PropTypes.func,
+		pluginLink: React.PropTypes.string,
+		allowedActions: React.PropTypes.shape( {
+			activation: React.PropTypes.bool,
+			autoupdate: React.PropTypes.bool,
+		} ),
+		isAutoManaged: React.PropTypes.bool,
+		progress: React.PropTypes.array,
+		errors: React.PropTypes.array,
+		notices: React.PropTypes.shape( {
+			completed: React.PropTypes.array,
+			errors: React.PropTypes.array,
+			inProgress: React.PropTypes.array,
+		} ),
+		hasAllNoManageSites: React.PropTypes.bool,
+	},
+
+	defaultProps() {
+		return  {
+			allowedActions: {
+				activation: true,
+				autoupdate: true,
+			},
+			isAutoManaged: false,
+		}
+	},
+
 	shouldComponentUpdate( nextProps, nextState ) {
 		const propsToCheck = [ 'plugin', 'sites', 'selectedSite', 'isMock', 'isSelectable', 'isSelected' ];
 		if ( checkPropsChange.call( this, nextProps, propsToCheck ) ) {

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -202,19 +202,19 @@ module.exports = React.createClass( {
 
 		return (
 			<div className="plugin-item__actions">
-			{ canToggleActivation && <PluginActivateToggle
-					isMock={ this.props.isMock }
-					plugin={ this.props.plugin }
-					disabled={ this.props.isSelectable }
-					site={ this.props.selectedSite }
-					notices={ this.props.notices } /> }
-			{ canToggleAutoupdate && <PluginAutoupdateToggle
-					isMock={ this.props.isMock }
-					plugin={ this.props.plugin }
-					disabled={ this.props.isSelectable }
-					site={ this.props.selectedSite }
-					notices={ this.props.notices }
-					wporg={ !! this.props.plugin.wporg } /> }
+				{ canToggleActivation && <PluginActivateToggle
+						isMock={ this.props.isMock }
+						plugin={ this.props.plugin }
+						disabled={ this.props.isSelectable }
+						site={ this.props.selectedSite }
+						notices={ this.props.notices } /> }
+				{ canToggleAutoupdate && <PluginAutoupdateToggle
+						isMock={ this.props.isMock }
+						plugin={ this.props.plugin }
+						disabled={ this.props.isSelectable }
+						site={ this.props.selectedSite }
+						notices={ this.props.notices }
+						wporg={ !! this.props.plugin.wporg } /> }
 			</div>
 		);
 	},

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -160,6 +160,15 @@ module.exports = React.createClass( {
 				);
 			}
 		}
+
+		if ( this.props.isAutoManaged ) {
+			return (
+				<div className="plugin-item__last_updated">
+					{ this.translate( '%(pluginName)s is automatically managed on this site', { args: { pluginName: pluginData.name } } ) }
+				</div>
+			);
+		}
+
 		if ( this.hasUpdate() ) {
 			return this.renderUpdateFlag();
 		}

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -186,21 +186,26 @@ module.exports = React.createClass( {
 	},
 
 	renderActions() {
+		const {
+			activation: canToggleActivation,
+			autoupdate: canToggleAutoupdate,
+		} = this.props.allowedActions;
+
 		return (
 			<div className="plugin-item__actions">
-				<PluginActivateToggle
+			{ canToggleActivation && <PluginActivateToggle
 					isMock={ this.props.isMock }
 					plugin={ this.props.plugin }
 					disabled={ this.props.isSelectable }
 					site={ this.props.selectedSite }
-					notices={ this.props.notices } />
-				<PluginAutoupdateToggle
+					notices={ this.props.notices } /> }
+			{ canToggleAutoupdate && <PluginAutoupdateToggle
 					isMock={ this.props.isMock }
 					plugin={ this.props.plugin }
 					disabled={ this.props.isSelectable }
 					site={ this.props.selectedSite }
 					notices={ this.props.notices }
-					wporg={ !! this.props.plugin.wporg } />
+					wporg={ !! this.props.plugin.wporg } /> }
 			</div>
 		);
 	},

--- a/client/my-sites/plugins/plugin-meta/README.md
+++ b/client/my-sites/plugins/plugin-meta/README.md
@@ -24,5 +24,6 @@ render: function() {
 * `siteURL` : (string) The URL of the selected site. Used to determine if this is a single or all sites view.
 * `sites` : (array) An array of the sites that current plugin is installed on.
 * `isPlaceholder`: (boolean) Whether the component is being rendered in placeholder mode
-* `isMock`: a boolean indicating if the toggle should not launch any real action when interacted
-* `isInstalledOnSite`: a boolean indicating if the plugin is installed on the site or not.
+* `isMock`: (boolean) indicating if the toggle should not launch any real action when interacted
+* `isInstalledOnSite`: (boolean) indicating if the plugin is installed on the site or not.
+* `allowedActions`: (object) Object of actions allowed on the plugin: `activation`, `autoupdate`, `remove`. Used to display/hide plugin actions.

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -52,6 +52,21 @@ export default React.createClass( {
 		isInstalledOnSite: React.PropTypes.bool,
 		isPlaceholder: React.PropTypes.bool,
 		isMock: React.PropTypes.bool,
+		allowedActions: React.PropTypes.shape( {
+			activation: React.PropTypes.bool,
+			autoupdate: React.PropTypes.bool,
+			remove: React.PropTypes.bool,
+		} ),
+	},
+
+	getDefaultProps() {
+		return {
+			allowedActions: {
+				activation: true,
+				autoupdate: true,
+				remove: true,
+			}
+		};
 	},
 
 	displayBanner() {
@@ -121,14 +136,19 @@ export default React.createClass( {
 			return ( <div className="plugin-meta__actions"> { this.getInstallButton() } </div> );
 		}
 
+		const {
+			autoupdate: canToggleAutoupdate,
+			activation: canToggleActivation,
+			remove: canRemove,
+		} = this.props.allowedActions;
 		return (
 			<div className="plugin-meta__actions">
-				<PluginActivateToggle plugin={ this.props.plugin } site={ this.props.selectedSite }
-					notices={ this.props.notices } isMock={ this.props.isMock } />
-				<PluginAutoupdateToggle plugin={ this.props.plugin } site={ this.props.selectedSite }
-					notices={ this.props.notices } wporg={ this.props.plugin.wporg } isMock={ this.props.isMock } />
-				<PluginRemoveButton plugin={ this.props.plugin } site={ this.props.selectedSite }
-					notices={ this.props.notices } isMock={ this.props.isMock } />
+				{ canToggleActivation && <PluginActivateToggle plugin={ this.props.plugin } site={ this.props.selectedSite }
+					notices={ this.props.notices } isMock={ this.props.isMock } /> }
+				{ canToggleAutoupdate && <PluginAutoupdateToggle plugin={ this.props.plugin } site={ this.props.selectedSite }
+					notices={ this.props.notices } wporg={ this.props.plugin.wporg } isMock={ this.props.isMock } /> }
+				{ canRemove && <PluginRemoveButton plugin={ this.props.plugin } site={ this.props.selectedSite }
+					notices={ this.props.notices } isMock={ this.props.isMock } /> }
 			</div>
 		);
 	},

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -143,12 +143,22 @@ export default React.createClass( {
 		} = this.props.allowedActions;
 		return (
 			<div className="plugin-meta__actions">
-				{ canToggleActivation && <PluginActivateToggle plugin={ this.props.plugin } site={ this.props.selectedSite }
-					notices={ this.props.notices } isMock={ this.props.isMock } /> }
-				{ canToggleAutoupdate && <PluginAutoupdateToggle plugin={ this.props.plugin } site={ this.props.selectedSite }
-					notices={ this.props.notices } wporg={ this.props.plugin.wporg } isMock={ this.props.isMock } /> }
-				{ canRemove && <PluginRemoveButton plugin={ this.props.plugin } site={ this.props.selectedSite }
-					notices={ this.props.notices } isMock={ this.props.isMock } /> }
+				{ canToggleActivation && <PluginActivateToggle
+						plugin={ this.props.plugin }
+						site={ this.props.selectedSite }
+						notices={ this.props.notices }
+						isMock={ this.props.isMock } /> }
+				{ canToggleAutoupdate && <PluginAutoupdateToggle
+						plugin={ this.props.plugin }
+						site={ this.props.selectedSite }
+						notices={ this.props.notices }
+						wporg={ this.props.plugin.wporg }
+						isMock={ this.props.isMock } /> }
+				{ canRemove && <PluginRemoveButton
+						plugin={ this.props.plugin }
+						site={ this.props.selectedSite }
+						notices={ this.props.notices }
+						isMock={ this.props.isMock } /> }
 			</div>
 		);
 	},

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import config from 'config';
 import { connect } from 'react-redux';
 import page from 'page';
-import { uniq, upperFirst } from 'lodash';
+import { get, uniq, upperFirst } from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,6 +31,7 @@ import DocumentHead from 'components/data/document-head';
 import WpcomPluginsList from 'my-sites/plugins-wpcom/plugins-list';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, canJetpackSiteManage, getRawSite } from 'state/sites/selectors';
+import { isSiteAutomatedTransfer } from 'state/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 const SinglePlugin = React.createClass( {
@@ -214,11 +215,21 @@ const SinglePlugin = React.createClass( {
 		);
 	},
 
-	getAllowedPluginActions() {
+	getAllowedPluginActions( plugin ) {
+		let autoupdate = true;
+		let activation = true;
+		let remove = true;
+
+		if ( this.props.isSiteAutomatedTransfer && ( plugin.slug === 'jetpack' || plugin.slug === 'vaultpress' ) ) {
+			autoupdate = false;
+			activation = false;
+			remove = false;
+		}
+
 		return {
-			autoupdate: true,
-			activation: true,
-			remove: true,
+			autoupdate,
+			activation,
+			remove,
 		};
 	},
 
@@ -423,6 +434,7 @@ export default connect(
 			selectedSite: selectedSite,
 			isJetpackSite: siteId => isJetpackSite( state, siteId ),
 			canJetpackSiteManage: siteId => canJetpackSiteManage( state, siteId ),
+			isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, get( selectedSite, 'ID' ) ),
 		};
 	},
 	{

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -216,20 +216,12 @@ const SinglePlugin = React.createClass( {
 	},
 
 	getAllowedPluginActions( plugin ) {
-		let autoupdate = true;
-		let activation = true;
-		let remove = true;
-
-		if ( this.props.isSiteAutomatedTransfer && includes( [ 'jetpack', 'vaultpress' ], plugin.slug ) ) {
-			autoupdate = false;
-			activation = false;
-			remove = false;
-		}
+		const hiddenForAutomatedTransfer = this.props.isSiteAutomatedTransfer && includes( [ 'jetpack', 'vaultpress' ], plugin.slug );
 
 		return {
-			autoupdate,
-			activation,
-			remove,
+			autoupdate: ! hiddenForAutomatedTransfer,
+			activation: ! hiddenForAutomatedTransfer,
+			remove: ! hiddenForAutomatedTransfer,
 		};
 	},
 

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import config from 'config';
 import { connect } from 'react-redux';
 import page from 'page';
-import { get, uniq, upperFirst } from 'lodash';
+import { get, includes, uniq, upperFirst } from 'lodash';
 
 /**
  * Internal dependencies
@@ -220,7 +220,7 @@ const SinglePlugin = React.createClass( {
 		let activation = true;
 		let remove = true;
 
-		if ( this.props.isSiteAutomatedTransfer && ( plugin.slug === 'jetpack' || plugin.slug === 'vaultpress' ) ) {
+		if ( this.props.isSiteAutomatedTransfer && includes( [ 'jetpack', 'vaultpress' ], plugin.slug ) ) {
 			autoupdate = false;
 			activation = false;
 			remove = false;

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -214,6 +214,14 @@ const SinglePlugin = React.createClass( {
 		);
 	},
 
+	getAllowedPluginActions() {
+		return {
+			autoupdate: true,
+			activation: true,
+			remove: true,
+		};
+	},
+
 	renderDocumentHead() {
 		return <DocumentHead title={ this.state.pageTitle } />;
 	},
@@ -243,7 +251,6 @@ const SinglePlugin = React.createClass( {
 
 	renderPluginPlaceholder() {
 		const { selectedSite } = this.props;
-
 		return (
 			<MainComponent>
 				<SidebarNavigation />
@@ -337,6 +344,7 @@ const SinglePlugin = React.createClass( {
 
 		const plugin = this.getPlugin();
 		const pluginExists = this.pluginExists( plugin );
+		const allowedPluginActions = this.getAllowedPluginActions( plugin );
 
 		if ( pluginExists === 'unknown' ) {
 			return this.renderPluginPlaceholder();
@@ -389,7 +397,8 @@ const SinglePlugin = React.createClass( {
 								? null
 								: !! PluginsStore.getSitePlugin( selectedSite, this.state.plugin.slug )
 						}
-						isInstalling={ installing } />
+						isInstalling={ installing }
+						allowedActions={ allowedPluginActions } />
 					{ plugin.wporg && <PluginSections plugin={ plugin } isWpcom={ isWpcom } /> }
 					{ this.renderSitesList( plugin ) }
 				</div>

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -432,6 +432,13 @@ export const PluginsList = React.createClass( {
 		);
 	},
 
+	getAllowedPluginActions( ) {
+		return {
+			autoupdate: true,
+			activation: true
+		}
+	},
+
 	renderPlugin( plugin ) {
 		const selectThisPlugin = this.togglePlugin.bind( this, plugin );
 		return (
@@ -447,7 +454,8 @@ export const PluginsList = React.createClass( {
 				isSelectable={ this.state.bulkManagementActive }
 				onClick={ selectThisPlugin }
 				selectedSite={ this.props.selectedSite }
-				pluginLink={ '/plugins/' + encodeURIComponent( plugin.slug ) + this.siteSuffix() } />
+				pluginLink={ '/plugins/' + encodeURIComponent( plugin.slug ) + this.siteSuffix() }
+				allowedActions = { this.getAllowedPluginActions() } />
 		);
 	},
 

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -434,17 +434,11 @@ export const PluginsList = React.createClass( {
 	},
 
 	getAllowedPluginActions( plugin ) {
-		let autoupdate = true;
-		let activation = true;
-
-		if ( this.props.isSiteAutomatedTransfer && includes( [ 'jetpack', 'vaultpress' ], plugin.slug ) ) {
-			autoupdate = false;
-			activation = false;
-		}
+		const hiddenForAutomatedTransfer = this.props.isSiteAutomatedTransfer && includes( [ 'jetpack', 'vaultpress' ], plugin.slug );
 
 		return {
-			autoupdate,
-			activation,
+			autoupdate: ! hiddenForAutomatedTransfer,
+			activation: ! hiddenForAutomatedTransfer,
 		};
 	},
 

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -476,7 +476,7 @@ export default connect(
 		return {
 			selectedSite,
 			selectedSiteSlug: getSelectedSiteSlug( state ),
-			isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, get( selectedSite, 'ID' ) )
+			isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, get( selectedSite, 'ID' ) ),
 		};
 	},
 	{ recordGoogleEvent }


### PR DESCRIPTION
This hides the plugin actions for Jetpack and Vaultpress on automated transfer sites for the following routes:
http://calypso.localhost:3000/plugins/:site
http://calypso.localhost:3000/plugins/:plugin/:site

### `plugins/:site`

The targeted plugins no longer display the activation or auto update toggles. There is also added messaging: `{plugin} is automatically managed on this site`

![screen shot 2017-03-06 at 5 28 22 pm](https://cloud.githubusercontent.com/assets/744755/23638210/fffb78fc-0294-11e7-8b13-0f4d80fd0445.png)

### `plugins/:plugin/:site`

Users can still click through the plugin in the list to access details page. Here the actions again are not displayed but there is no additional messaging.

![screen shot 2017-03-06 at 5 28 35 pm](https://cloud.githubusercontent.com/assets/744755/23638225/233c7226-0295-11e7-966d-2023ed23d4cb.png)

The PR does not address bulk changes or non site selected pages ( `/plugins` or `/plugins/:plugin`). 

The changes here were guided from the feedback in #11541. In particular:

1. Take a more generalized approach to disabling plugin actions.
2. Do not grey out or disable clicking through to the detail page.
3. Consider using server side logic for filtering plugin actions

On the last point this PR _does_ use existing logic in calypso to check for automated transfer sites but the check is done further up the component hierarchy. It should be simple to refactor `getAllowedPluginActions` and remove the AT site selector after the new attributes are available from the plugins api. 

Related PR : #11541 
Fixes 84-gh-automated-transfer

@Automattic/stark 
cc @johnHackworth @enejb 