### PR TITLE
Cart not displayed correctly when site is not selected

### DIFF
--- a/client/my-sites/upgrades/cart/cart-item.jsx
+++ b/client/my-sites/upgrades/cart/cart-item.jsx
@@ -104,7 +104,7 @@ const CartItem = React.createClass( {
 	},
 
 	getProductInfo() {
-		var domain = this.props.cartItem.meta || this.props.selectedSite.domain,
+		var domain = this.props.cartItem.meta || ( this.props.selectedSite && this.props.selectedSite.domain ),
 			info = null;
 		if ( isGoogleApps( this.props.cartItem ) && this.props.cartItem.extra.google_apps_users ) {
 			info = this.props.cartItem.extra.google_apps_users.map( user => <div>{ user.email }</div> );
@@ -113,7 +113,7 @@ const CartItem = React.createClass( {
 		} else if ( getIncludedDomain( this.props.cartItem ) ) {
 			info = getIncludedDomain( this.props.cartItem );
 		} else if ( isTheme( this.props.cartItem ) ) {
-			info = this.props.selectedSite.domain;
+			info = this.props.selectedSite && this.props.selectedSite.domain;
 		} else {
 			info = domain;
 		}


### PR DESCRIPTION
This pull request fixes the "stuck" cart on checkout when there is a credit item

![screen shot 2017-03-07 at 12 40 41](https://cloud.githubusercontent.com/assets/326402/23652952/64683692-0333-11e7-91b6-7330fe8de024.png)
![screen shot 2017-03-07 at 12 40 58](https://cloud.githubusercontent.com/assets/326402/23652960/67b30296-0333-11e7-9ced-04ba1fcc0659.png)

This should be tested together with D4625

#### Testing instructions
0. Add yourself some credits  (but less than the cost of the domain)
1. Run `git checkout fix/cart-item` and start your server, or open a [live branch](https://calypso.live/?branch=fix/cart-item)
2. Start the domain only flow by visiting the url: http://calypso.localhost:3000/start/domain-first?new=testing123.live
3. Assert you are seeing the correct cart at checkout.


#### Reviews
  
- [ ] Code
- [ ] Product

