### PR TITLE
Use standard event names for calypso_upgrade_nudges.

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -82,8 +82,8 @@ const SiteNotice = React.createClass( {
 		if ( ! this.props.eligibleForFreeToPaidUpsell ) {
 			return null;
 		}
-		const eventName = 'calypso_free_to_paid_plan_nudge_impression';
-		const eventProperties = { cta_name: 'current_site_free_to_paid_plan_nudge_notice' };
+		const eventName = 'calypso_upgrade_nudge_impression';
+		const eventProperties = { cta_name: 'free-to-paid-sidebar' };
 		return (
 			<Notice isCompact status="is-success" icon="info-outline">
 				{ this.translate( 'Free domain with a plan' ) }
@@ -149,8 +149,8 @@ export default connect( ( state, ownProps ) => {
 			}
 		) ),
 		clickFreeToPaidPlanNotice: () => dispatch( recordTracksEvent(
-			'calypso_free_to_paid_plan_nudge_click', {
-				cta_name: 'current_site_free_to_paid_plan_nudge_notice'
+			'calypso_upgrade_nudge_cta_click', {
+				cta_name: 'free-to-paid-sidebar'
 			}
 		) ),
 	};


### PR DESCRIPTION
All existing upgrade nudges use `calypso_upgrade_nudge_impression` and `calypso_upgrade_nudge_cta_click` with a unique `cta_name`.

This change just brings this nudge into line.

To qualify for this particular nudge, users must:

* have registered within with last 2 to 30 days
* be able to manage options for the current site
* have a free plan for the current site
* have no domain mapping for the current site

# Steps for testing

You will either need a user that meets the criteria (user registered between 2 and 30 days ago) or can temporarily alter the selector function in client/state/selectors/eligible-for-free-to-paid-upsell.js to always return true.

When viewing the site, you should now see a `calypso_upgrade_nudge_impression` in network requests (filter requests for t.gif).  Clicking on the nudge will trigger the `calypso_upgrade_nudge_cta_click` tracks event.
