### PR TITLE
Happychat: Add notices for abnormal events

### DIFF
--- a/client/components/happychat/index.jsx
+++ b/client/components/happychat/index.jsx
@@ -33,6 +33,7 @@ import {
 	timeline,
 	composer
 } from './helpers';
+import Notices from './notices';
 import { translate } from 'i18n-calypso';
 
 const isChatOpen = any( isConnected, isConnecting );
@@ -117,6 +118,7 @@ const Happychat = React.createClass( {
 						} ) }
 					</div>
 					{ timeline( { connectionStatus, isMinimizing } ) }
+					<Notices />
 					{ composer( { connectionStatus, isMinimizing } ) }
 				</div>
 			</div>

--- a/client/components/happychat/notices.jsx
+++ b/client/components/happychat/notices.jsx
@@ -31,7 +31,7 @@ class Notices extends Component {
 
 		const noticeText = {
 			[ HAPPYCHAT_CHAT_STATUS_ABANDONED ]: translate( "We're having some connection trouble on our end, please bear with us." ),
-			[ HAPPYCHAT_CHAT_STATUS_ASSIGNING ]: translate( "We're connecting you with a Happiness Engineer" ),
+			[ HAPPYCHAT_CHAT_STATUS_ASSIGNING ]: translate( 'Connecting you with a Happiness Engineer…' ),
 			[ HAPPYCHAT_CHAT_STATUS_PENDING ]:
 				translate( "Sorry, we couldn't connect you with a Happiness Engineer. Please check back later." ),
 			[ HAPPYCHAT_CHAT_STATUS_MISSED ]:

--- a/client/components/happychat/notices.jsx
+++ b/client/components/happychat/notices.jsx
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { localize } from 'i18n-calypso';
+import {
+	HAPPYCHAT_CHAT_STATUS_ASSIGNING,
+	HAPPYCHAT_CHAT_STATUS_PENDING,
+	HAPPYCHAT_CHAT_STATUS_MISSED,
+	HAPPYCHAT_CHAT_STATUS_ABANDONED,
+	getHappychatStatus,
+	getHappychatConnectionStatus,
+} from 'state/happychat/selectors';
+
+/*
+ * Renders any notices about the chat session to the user
+ */
+class Notices extends Component {
+	statusNotice() {
+		const { isConnected, statusNotice, translate } = this.props;
+
+		if ( ! isConnected ) {
+			return translate( "We're having trouble connecting to chat. Please check your internet connection and refresh the page." );
+		}
+
+		const noticeText = {
+			[ HAPPYCHAT_CHAT_STATUS_ABANDONED ]: translate( "We're having some connection trouble on our end, please bear with us." ),
+			[ HAPPYCHAT_CHAT_STATUS_ASSIGNING ]: translate( "We're connecting you with a Happiness Engineer" ),
+			[ HAPPYCHAT_CHAT_STATUS_PENDING ]:
+				translate( "Sorry, we couldn't connect you with a Happiness Engineer. Please check back later." ),
+			[ HAPPYCHAT_CHAT_STATUS_MISSED ]:
+				translate( 'Sorry, we missed you! All our Happiness Engineers are currently busy. Please check back later.' ),
+		};
+
+		return get( noticeText, statusNotice, null );
+	}
+
+	render() {
+		const noticeText = this.statusNotice();
+
+		if ( noticeText == null ) {
+			return null;
+		}
+
+		return (
+			<div className="happychat__notice">
+				{ noticeText }
+			</div>
+		);
+	}
+}
+
+const mapState = ( state ) => ( {
+	isConnected: getHappychatConnectionStatus( state ) === 'connected',
+	chatStatus: getHappychatStatus( state )
+} );
+
+export default localize( connect( mapState )( Notices ) );

--- a/client/components/happychat/notices.jsx
+++ b/client/components/happychat/notices.jsx
@@ -23,7 +23,7 @@ import {
  */
 class Notices extends Component {
 	statusNotice() {
-		const { isConnected, statusNotice, translate } = this.props;
+		const { isConnected, chatStatus, translate } = this.props;
 
 		if ( ! isConnected ) {
 			return translate( "We're having trouble connecting to chat. Please check your internet connection and refresh the page." );
@@ -38,7 +38,7 @@ class Notices extends Component {
 				translate( 'Sorry, we missed you! All our Happiness Engineers are currently busy. Please check back later.' ),
 		};
 
-		return get( noticeText, statusNotice, null );
+		return get( noticeText, chatStatus, null );
 	}
 
 	render() {

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -109,9 +109,9 @@
 
 .happychat__notice {
 	padding: 12px;
-	border-left: 1px solid lighten( $gray, 20% );
 	border-top: 1px solid lighten( $gray, 20% );
-	background-color: $white;
+	color: $white;
+	background-color: lighten( $gray-dark, 20% );
 	margin: 0;
 }
 

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -107,6 +107,14 @@
 
 }
 
+.happychat__notice {
+	padding: 12px;
+	border-left: 1px solid lighten( $gray, 20% );
+	border-top: 1px solid lighten( $gray, 20% );
+	background-color: $white;
+	margin: 0;
+}
+
 .happychat__welcome {
 	flex: 1 auto;
 	padding: 16px;

--- a/client/state/happychat/selectors.js
+++ b/client/state/happychat/selectors.js
@@ -37,6 +37,15 @@ export const isHappychatChatActive = createSelector(
 	state => state.happychat.chatStatus
 );
 
+/**
+ * Gets the current chat session status
+ * @param {Object} state - global redux state
+ * @return {String} status of the current chat session
+ */
+export const getHappychatStatus = createSelector(
+	state => state.happychat.chatStatus
+);
+
 export const isHappychatAcceptingChats = createSelector(
 	state => state.happychat.isAvailable
 );


### PR DESCRIPTION
Adds notices for when the operator disconnects or user's connection drops.

cc @beaucollins @mkaz 

and @jasmussen and @evilluendas for design thoughts

![screen shot 2017-03-07 at 6 22 51 pm](https://cloud.githubusercontent.com/assets/416133/23648379/30d2db1a-0366-11e7-9dc6-da35208f1c86.png)

I've just made a guess what the notice text should be, so these are open for discussion. ~~I'm especially unsure what the meaning behind the `pending` status is and what we should ask the user to do in that case.~~ @beaucollins confirmed the notice below works for `pending`

| Status | Meaning | Notice |
| ------ | --------  | ------ |
| `default` | no chat has been started | (No notice) |
| `pending` | chat has been started but no operator assigned | Sorry, we couldn't connect you with a Happiness Engineer. Please check back later. |
| `assigning` | system is assigning to an operator | Connecting you with a Happiness Engineer... |
| `assigned` | operator has been connected to the chat | (No notice) |
| `missed` | no operator could be assigned | Sorry, we missed you! All our Happiness Engineers are currently busy. Please check back later. |
| `abandoned` | operator was disconnected | We're having some connection trouble on our end, please bear with us. |
| (No connection) | No connection to Happychat at all | We're having trouble connecting to chat. Please check your internet connection and refresh the page. |

### How to test

Note that some of these notices will not appear until #11604 is merged - currently client disconnection events are not handled.

An easy way to show the notice is to make yourself available as an operator, start a chat from Calypso, then close the HUD tab. You should then see the `abandoned` message above. 