### PR TITLE
Media: add media section

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -39,6 +39,7 @@ $z-layers: (
 		'.site-icon.is-blank .gridicon': 0,
 		'.chart__bar-section.is-spacer': 0,
 		'.gear-dropdown:after': 0,
+		'.media-library .search.is-expanded-to-container': 1,
 		'.ribbon': 1,
 		'.reader__featured-post': 0,
 		'.reader__featured-post-title': 1,

--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
 import QueryMediaStorage from 'components/data/query-media-storage';
 import { getMediaStorage } from 'state/sites/media-storage/selectors';
 import {
-	getSitePlan,
+	getSitePlanSlug,
 	getSiteSlug,
 	isJetpackSite
 } from 'state/sites/selectors';
@@ -23,6 +23,8 @@ class PlanStorage extends Component {
 		className: PropTypes.string,
 		mediaStorage: PropTypes.object,
 		siteId: PropTypes.number,
+		sitePlanSlug: PropTypes.string,
+		siteSlug: PropTypes.string,
 	};
 
 	render() {
@@ -30,11 +32,11 @@ class PlanStorage extends Component {
 			className,
 			jetpackSite,
 			siteId,
-			sitePlan,
+			sitePlanSlug,
 			siteSlug,
 		} = this.props;
 
-		if ( jetpackSite || ! sitePlan ) {
+		if ( jetpackSite || ! sitePlanSlug ) {
 			return null;
 		}
 
@@ -43,7 +45,7 @@ class PlanStorage extends Component {
 				<QueryMediaStorage siteId={ siteId } />
 				<PlanStorageBar
 					siteSlug={ siteSlug }
-					sitePlanSlug={ sitePlan.product_slug }
+					sitePlanSlug={ sitePlanSlug }
 					mediaStorage={ this.props.mediaStorage }
 				>
 					{ this.props.children }
@@ -58,7 +60,7 @@ export default connect( ( state, ownProps ) => {
 	return {
 		mediaStorage: getMediaStorage( state, siteId ),
 		jetpackSite: isJetpackSite( state, siteId ),
-		sitePlan: getSitePlan( state, siteId ),
+		sitePlanSlug: getSitePlanSlug( state, siteId ),
 		siteSlug: getSiteSlug( state, siteId ),
 	};
 } )( PlanStorage );

--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -15,6 +15,7 @@ import {
 	getSiteSlug,
 	isJetpackSite
 } from 'state/sites/selectors';
+import { PLAN_BUSINESS } from 'lib/plans/constants';
 
 import PlanStorageBar from './bar';
 
@@ -37,6 +38,10 @@ class PlanStorage extends Component {
 		} = this.props;
 
 		if ( jetpackSite || ! sitePlanSlug ) {
+			return null;
+		}
+
+		if ( sitePlanSlug === PLAN_BUSINESS ) {
 			return null;
 		}
 

--- a/client/blocks/plan-storage/style.scss
+++ b/client/blocks/plan-storage/style.scss
@@ -1,14 +1,19 @@
+.plan-storage {
+	display: flex;
+}
 
 .plan-storage__bar {
+	align-self: center; // flex-item behavior (parent element: .plans-storage)
+	display: flex; // flex-container bahavior
+	flex-flow: row wrap;
+	justify-content: space-between;
 	line-height: 12px;
-	display: inline-block;
 	width: 100%;
 }
 
 .plan-storage__storage-label,
 .plan-storage__storage-link {
 	font-size: 11px;
-	display: inline-block;
 	height: 24px;
 	line-height: 24px;
 }
@@ -16,11 +21,9 @@
 .plan-storage__storage-label {
 	color: $gray-dark;
 	font-weight: 500;
-	margin-right: 10px;
 }
 
 .plan-storage__storage-link {
-	float: right;
 	text-decoration: none;
 }
 

--- a/client/blocks/plan-storage/style.scss
+++ b/client/blocks/plan-storage/style.scss
@@ -14,8 +14,8 @@
 .plan-storage__storage-label,
 .plan-storage__storage-link {
 	font-size: 11px;
-	height: 24px;
-	line-height: 24px;
+	line-height: 1;
+	margin-top: 6px;
 }
 
 .plan-storage__storage-label {
@@ -24,7 +24,7 @@
 }
 
 .plan-storage__storage-link {
-	margin-left: 3px;
+	margin-left: 12px;
 	text-decoration: none;
 }
 

--- a/client/blocks/plan-storage/style.scss
+++ b/client/blocks/plan-storage/style.scss
@@ -24,6 +24,7 @@
 }
 
 .plan-storage__storage-link {
+	margin-left: 3px;
 	text-decoration: none;
 }
 

--- a/client/components/popover/style.scss
+++ b/client/components/popover/style.scss
@@ -204,6 +204,12 @@
 		vertical-align: bottom;
 		margin-right: 8px;
 	}
+	&.is-compact {
+		padding: 6px 12px;
+		font-size: 11px;
+		line-height: 1;
+		text-transform: uppercase;
+	}
 }
 
 .popover__menu-separator,

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -194,7 +194,7 @@
 	}
 }
 
-a.sidebar__button {
+a.sidebar__button, form.sidebar__button {
 	display: flex;
 	position: relative;
 	box-sizing: border-box;
@@ -217,6 +217,9 @@ a.sidebar__button {
 		padding: 8px 16px;
 		margin: 10px 10px 0 0;
 	}
+}
+form.sidebar__button {
+	cursor: pointer;
 }
 
 // Selected Menu
@@ -308,7 +311,7 @@ a.sidebar__button {
 	}
 }
 
-.notouch .sidebar__menu li:not(.selected) a {
+.notouch .sidebar__menu li:not(.selected) a, form {
 	&.sidebar__button:hover {
 		color: $blue-medium;
 	}

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -197,6 +197,7 @@ const MediaLibraryContent = React.createClass( {
 						selectedItems={ this.props.selectedItems }
 						onViewDetails={ this.props.onViewDetails }
 						onDeleteItem={ this.props.onDeleteItem }
+						sticky={ ! this.props.scrollable }
 					/>
 				}
 				{ this.renderErrors() }

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -37,7 +37,7 @@ const MediaLibraryContent = React.createClass( {
 		scrollable: React.PropTypes.bool,
 		onAddMedia: React.PropTypes.func,
 		onMediaScaleChange: React.PropTypes.func,
-		onEditItem: React.PropTypes.func
+		onEditItem: React.PropTypes.func,
 	},
 
 	getDefaultProps: function() {
@@ -193,7 +193,11 @@ const MediaLibraryContent = React.createClass( {
 						filter={ this.props.filter }
 						onMediaScaleChange={ this.props.onMediaScaleChange }
 						onAddMedia={ this.props.onAddMedia }
-						onAddAndEditImage={ this.props.onAddAndEditImage } />
+						onAddAndEditImage={ this.props.onAddAndEditImage }
+						selectedItems={ this.props.selectedItems }
+						onViewDetails={ this.props.onViewDetails }
+						onDeleteItem={ this.props.onDeleteItem }
+					/>
 				}
 				{ this.renderErrors() }
 				{ this.renderMediaList() }

--- a/client/my-sites/media-library/content.scss
+++ b/client/my-sites/media-library/content.scss
@@ -8,8 +8,8 @@
 
 .media-library__scale-range.range {
 	position: absolute;
-	top: 11px;
-	right: 0;
+	top: 16px;
+	right: 12px;
 	width: 12%;
 	margin: 0 28px;
 

--- a/client/my-sites/media-library/content.scss
+++ b/client/my-sites/media-library/content.scss
@@ -9,7 +9,7 @@
 .media-library__scale-range.range {
 	position: absolute;
 	top: 16px;
-	right: 12px;
+	right: 24px;
 	width: 12%;
 	margin: 0 28px;
 

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -128,13 +128,15 @@ export class MediaLibraryFilterBar extends Component {
 
 	render() {
 		return (
-			<SectionNav selectedText={ this.getFilterLabel( this.props.filter ) } hasSearch={ true }>
-				<SectionNavTabs>
-					{ this.renderTabItems() }
-				</SectionNavTabs>
-				{ this.renderSearchSection() }
+			<div className="media-library__filter-bar">
+				<SectionNav selectedText={ this.getFilterLabel( this.props.filter ) } hasSearch={ true }>
+					<SectionNavTabs>
+						{ this.renderTabItems() }
+					</SectionNavTabs>
+					{ this.renderSearchSection() }
+				</SectionNav>
 				{ this.renderPlanStorage() }
-			</SectionNav>
+			</div>
 		);
 	}
 }

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -16,6 +16,8 @@ import {
 import SectionNav from 'components/section-nav';
 import SectionNavTabs from 'components/section-nav/tabs';
 import Search from 'components/search';
+import TrackComponentView from 'lib/analytics/track-component-view';
+import PlanStorage from 'blocks/plan-storage';
 import FilterItem from './filter-item';
 
 export class MediaLibraryFilterBar extends Component {
@@ -114,14 +116,24 @@ export class MediaLibraryFilterBar extends Component {
 		);
 	}
 
+	renderPlanStorage() {
+		const eventName = 'calypso_upgrade_nudge_impression';
+		const eventProperties = { cta_name: 'plan-media-storage' };
+		return (
+			<PlanStorage siteId={ this.props.site.ID }>
+				<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
+			</PlanStorage>
+		);
+	}
+
 	render() {
 		return (
 			<SectionNav selectedText={ this.getFilterLabel( this.props.filter ) } hasSearch={ true }>
 				<SectionNavTabs>
 					{ this.renderTabItems() }
 				</SectionNavTabs>
-
 				{ this.renderSearchSection() }
+				{ this.renderPlanStorage() }
 			</SectionNav>
 		);
 	}

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -97,22 +97,31 @@ export class MediaLibraryFilterBar extends Component {
 		);
 	}
 
+	renderSearchSection() {
+		if ( this.props.filterRequiresUpgrade ) {
+			return null;
+		}
+
+		return (
+			<Search
+				analyticsGroup="Media"
+				pinned
+				fitsContainer
+				onSearch={ this.props.onSearch }
+				initialValue={ this.props.search }
+				placeholder={ this.getSearchPlaceholderText() }
+				delaySearch={ true } />
+		);
+	}
+
 	render() {
 		return (
 			<SectionNav selectedText={ this.getFilterLabel( this.props.filter ) } hasSearch={ true }>
 				<SectionNavTabs>
 					{ this.renderTabItems() }
 				</SectionNavTabs>
-				{ ! this.props.filterRequiresUpgrade &&
-					<Search
-						analyticsGroup="Media"
-						pinned
-						fitsContainer
-						onSearch={ this.props.onSearch }
-						initialValue={ this.props.search }
-						placeholder={ this.getSearchPlaceholderText() }
-						delaySearch={ true } />
-				}
+
+				{ this.renderSearchSection() }
 			</SectionNav>
 		);
 	}

--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -130,7 +130,6 @@ export default React.createClass( {
 					selectedItems={ this.props.selectedItems }
 					onViewDetails={ this.props.onViewDetails }
 					onDelete={ this.props.onDeleteItem }
-					renderStorage={ false }
 					site={ this.props.site }
 					view={ 'LIST' }
 				/>

--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -100,8 +100,8 @@ export default React.createClass( {
 						isVisible={ this.state.isMoreOptionsVisible }
 						onClose={ this.toggleMoreOptions.bind( this, false ) }
 						position="bottom right"
-						className="popover is-dialog-visible">
-						<PopoverMenuItem onClick={ this.toggleAddViaUrl.bind( this, true ) } className="is-compact">
+						className="is-dialog-visible media-library__header-popover">
+						<PopoverMenuItem onClick={ this.toggleAddViaUrl.bind( this, true ) }>
 							{ this.translate( 'Add via URL', { context: 'Media upload' } ) }
 						</PopoverMenuItem>
 					</PopoverMenu>

--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -13,6 +13,7 @@ import MediaLibraryScale from './scale';
 import UploadButton from './upload-button';
 import MediaLibraryUploadUrl from './upload-url';
 import { userCan } from 'lib/site/utils';
+import MediaModalSecondaryActions from 'post-editor/media-modal/secondary-actions';
 
 export default React.createClass( {
 	displayName: 'MediaLibraryHeader',
@@ -123,6 +124,14 @@ export default React.createClass( {
 			<header className="media-library__header">
 				<h2 className="media-library__heading">{ this.translate( 'Media Library' ) }</h2>
 				{ this.renderUploadButtons() }
+				<MediaModalSecondaryActions
+					selectedItems={ this.props.selectedItems }
+					onViewDetails={ this.props.onViewDetails }
+					onDelete={ this.props.onDeleteItem }
+					renderStorage={ false }
+					site={ this.props.site }
+					view={ 'LIST' }
+				/>
 				<MediaLibraryScale
 					onChange={ this.props.onMediaScaleChange } />
 			</header>

--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -14,6 +14,10 @@ import UploadButton from './upload-button';
 import MediaLibraryUploadUrl from './upload-url';
 import { userCan } from 'lib/site/utils';
 import MediaModalSecondaryActions from 'post-editor/media-modal/secondary-actions';
+import Card from 'components/card';
+import ButtonGroup from 'components/button-group';
+import Button from 'components/button';
+import StickyPanel from 'components/sticky-panel';
 
 export default React.createClass( {
 	displayName: 'MediaLibraryHeader',
@@ -23,7 +27,8 @@ export default React.createClass( {
 		filter: PropTypes.string,
 		sliderPositionCount: PropTypes.number,
 		onMediaScaleChange: React.PropTypes.func,
-		onAddMedia: PropTypes.func
+		onAddMedia: PropTypes.func,
+		sticky: React.PropTypes.bool,
 	},
 
 	getInitialState() {
@@ -36,7 +41,8 @@ export default React.createClass( {
 	getDefaultProps() {
 		return {
 			onAddMedia: () => {},
-			sliderPositionCount: 100
+			sliderPositionCount: 100,
+			sticky: false,
 		};
 	},
 
@@ -71,23 +77,20 @@ export default React.createClass( {
 		}
 
 		return (
-			<div className="media-library__upload-buttons">
+			<ButtonGroup className="media-library__upload-buttons">
 				<UploadButton
 					site={ site }
 					filter={ filter }
 					onAddMedia={ onAddMedia }
-					className="button is-primary">
-					{ this.translate( 'Add New', { context: 'Media upload' } ) }
+					className="button is-compact">
+					<Gridicon icon="add-image" />
+					<span className="is-desktop">{ this.translate( 'Add New', { context: 'Media upload' } ) }</span>
 				</UploadButton>
-				<button
-					onClick={ this.toggleAddViaUrl.bind( this, true ) }
-					className="button is-desktop">
-					{ this.translate( 'Add via URL', { context: 'Media upload' } ) }
-				</button>
-				<button
+				<Button
+					compact
 					ref={ this.setMoreOptionsContext }
 					onClick={ this.toggleMoreOptions.bind( this, ! this.state.isMoreOptionsVisible ) }
-					className="button is-primary is-mobile">
+					className="button media-library__upload-more">
 					<span className="screen-reader-text">
 						{ this.translate( 'More Options' ) }
 					</span>
@@ -98,12 +101,12 @@ export default React.createClass( {
 						onClose={ this.toggleMoreOptions.bind( this, false ) }
 						position="bottom right"
 						className="popover is-dialog-visible">
-						<PopoverMenuItem onClick={ this.toggleAddViaUrl.bind( this, true ) }>
+						<PopoverMenuItem onClick={ this.toggleAddViaUrl.bind( this, true ) } className="is-compact">
 							{ this.translate( 'Add via URL', { context: 'Media upload' } ) }
 						</PopoverMenuItem>
 					</PopoverMenu>
-				</button>
-			</div>
+				</Button>
+			</ButtonGroup>
 		);
 	},
 
@@ -120,9 +123,8 @@ export default React.createClass( {
 			);
 		}
 
-		return (
-			<header className="media-library__header">
-				<h2 className="media-library__heading">{ this.translate( 'Media Library' ) }</h2>
+		const card = (
+			<Card className="media-library__header">
 				{ this.renderUploadButtons() }
 				<MediaModalSecondaryActions
 					selectedItems={ this.props.selectedItems }
@@ -134,7 +136,17 @@ export default React.createClass( {
 				/>
 				<MediaLibraryScale
 					onChange={ this.props.onMediaScaleChange } />
-			</header>
+			</Card>
 		);
+
+		if ( this.props.sticky ) {
+			return (
+				<StickyPanel>
+					{ card }
+				</StickyPanel>
+			);
+		} else {
+			return card;
+		}
 	}
 } );

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -128,7 +128,10 @@ module.exports = React.createClass( {
 				onAddMedia={ this.onAddMedia }
 				onAddAndEditImage={ this.props.onAddAndEditImage }
 				onMediaScaleChange={ this.props.onScaleChange }
-				onEditItem={ this.props.onEditItem } />
+				selectedItems={ this.props.mediaLibrarySelectedItems }
+				onDeleteItem={ this.props.onDeleteItem }
+				onEditItem={ this.props.onEditItem }
+				onViewDetails={ this.props.onViewDetails } />
 		);
 
 		if ( this.props.site ) {

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -44,7 +44,8 @@ module.exports = React.createClass( {
 		return {
 			fullScreenDropZone: true,
 			onAddMedia: () => {},
-			onScaleChange: () => {}
+			onScaleChange: () => {},
+			scrollable: false,
 		};
 	},
 

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -25,6 +25,7 @@ module.exports = React.createClass( {
 	mixins: [ urlSearch ],
 
 	propTypes: {
+		className: React.PropTypes.string,
 		site: React.PropTypes.object,
 		filter: React.PropTypes.string,
 		enabledFilters: React.PropTypes.arrayOf( React.PropTypes.string ),
@@ -143,9 +144,11 @@ module.exports = React.createClass( {
 			);
 		}
 
-		classes = classNames( 'media-library', {
-			'is-single': this.props.single
-		} );
+		classes = classNames(
+			'media-library',
+			{ 'is-single': this.props.single },
+			this.props.className,
+		);
 
 		return (
 			<div className={ classes }>

--- a/client/my-sites/media-library/scale.jsx
+++ b/client/my-sites/media-library/scale.jsx
@@ -125,7 +125,7 @@ class MediaLibraryScale extends Component {
 						<span className="media-library__scale-toggle-label">
 							{ translate( 'Grid' ) }
 						</span>
-						<Gridicon icon="grid" />
+						<Gridicon icon="grid" size={ 18 } />
 					</SegmentedControlItem>
 					<SegmentedControlItem
 						selected={ 1 === scale }
@@ -133,7 +133,7 @@ class MediaLibraryScale extends Component {
 						<span className="media-library__scale-toggle-label">
 							{ translate( 'List' ) }
 						</span>
-						<Gridicon icon="menu" />
+						<Gridicon icon="menu" size={ 18 } />
 					</SegmentedControlItem>
 				</SegmentedControl>
 				<FormRange

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -57,15 +57,13 @@
 
 	.plan-storage {
 		display: none;
-		min-width: 200px;
-		margin-left: 1px;
 		margin-bottom: 9px;
 		box-shadow:
 		  0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
 		  0 1px 2px lighten( $gray, 30% );
 		background-color: $white;
-		padding-left:20px;
-		padding-right: 20px;
+		padding-left: 24px;
+		padding-right: 24px;
 		box-sizing: border-box;
 		flex: 1 0 auto;
 

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -41,6 +41,14 @@
 	margin-left: 0;
 }
 
+.media-library__header.media-library__upload-url {
+	margin-bottom: 10px;
+
+	@include breakpoint( ">480px" ) {
+		margin-bottom: 16px;
+	}
+}
+
 .media-library__filter-bar {
 	display: flex;
 	flex-flow: row nowrap;
@@ -81,9 +89,6 @@
 .editor-media-modal .media-library__filter-bar {
 	.plan-storage {
 		@include breakpoint( ">480px" ) {
-			margin-bottom: 16px;
-		}
-		@include breakpoint( ">960px" ) {
 			margin-bottom: 16px;
 		}
 	}

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -49,6 +49,11 @@
 	}
 }
 
+.media-library__header-popover .popover__menu-item.is-compact {
+	text-transform: none;
+	font-size: 14px;
+}
+
 .media-library__filter-bar {
 	display: flex;
 	flex-flow: row nowrap;

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -94,6 +94,14 @@
 	}
 }
 
+.media-library__header.media-library__upload-url {
+	padding: 6px 12px;
+	background-color: $white;
+	box-sizing: border-box;
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		0 1px 2px lighten( $gray, 30% );
+}
+
 .media-library__upload-buttons {
 	display: inline;
 }

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -133,12 +133,15 @@
 .media-library__videopress-nudge-container {
 	display: block;
 	overflow-y: auto;
-	position: absolute;
-	top: 50px;
-	bottom: 72px;
 	right: 0;
 	left: 0;
 	margin: 0;
+}
+
+.editor-media-modal .media-library__videopress-nudge-container {
+	position: absolute;
+	top: 50px;
+	bottom: 72px;
 }
 
 .media-library__videopress-nudge-container .upgrade-nudge-expanded {

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -6,15 +6,15 @@
 @import 'upload-url';
 
 .media-library__header {
-	margin-bottom: 14px;
-	padding: 12px 24px;
+	padding-top: 11px;
+	padding-bottom: 11px;
 	display: flex;
 }
 
 .dialog__content .media-library__header.card {
 	box-shadow: none;
 	.media-library__scale-range.range {
-		top: 4px;
+		top: 7px;
 	}
 }
 
@@ -27,11 +27,7 @@
 }
 
 .media-library__header .button {
-	margin: 0 8px;
-
-	&:first-of-type {
-		margin-left: 0;
-	}
+	margin-right: 8px;
 }
 
 .media-library__header .button.media-library__upload-button {
@@ -100,8 +96,7 @@
 
 .media-library__scale-toggle {
 	position: absolute;
-	top: 10;
-	right: 24px;
+	right: 16px;
 	&.segmented-control.is-compact .segmented-control__link {
 		padding: 2px 4px;
 	}

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -57,6 +57,7 @@
 
 	.section-nav {
 		flex: 1 auto;
+		z-index: z-index( 'root', '.media-library .search.is-expanded-to-container' );
 	}
 
 	.plan-storage {

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -6,35 +6,28 @@
 @import 'upload-url';
 
 .media-library__header {
-	position: relative;
 	margin-bottom: 14px;
+	padding: 12px 24px;
+	display: flex;
+}
+
+.dialog__content .media-library__header.card {
+	box-shadow: none;
+	.media-library__scale-range.range {
+		top: 4px;
+	}
+}
+
+.media-library__header .is-desktop {
+	display: none;
+
+	@include breakpoint( ">660px" ) {
+		display: inline-block;
+	}
 }
 
 .media-library__header .button {
 	margin: 0 8px;
-
-	&.is-desktop {
-		display: none;
-
-		@include breakpoint( ">660px" ) {
-			display: inline-block;
-		}
-	}
-
-	&.is-mobile {
-		position: relative;
-		left: -1px;
-		height: 40px;
-		margin-left: 0;
-		padding-left: 8px;
-		padding-right: 8px;
-		border-top-left-radius: 0;
-		border-bottom-left-radius: 0;
-
-		@include breakpoint( ">660px" ) {
-			display: none;
-		}
-	}
 
 	&:first-of-type {
 		margin-left: 0;
@@ -42,13 +35,15 @@
 }
 
 .media-library__header .button.media-library__upload-button {
+	margin-right: 0;
 	@include breakpoint( "<660px" ) {
-		margin-right: 0;
 		border-top-right-radius: 0;
 		border-bottom-right-radius: 0;
 	}
 }
-
+.media-library__header .button.media-library__upload-more {
+	margin-left: 0;
+}
 .media-library__heading {
 	@include heading;
 	display: inline-block;
@@ -67,8 +62,11 @@
 
 .media-library__scale-toggle {
 	position: absolute;
-		top: 0;
-		right: 0;
+	top: 10;
+	right: 24px;
+	&.segmented-control.is-compact .segmented-control__link {
+		padding: 2px 4px;
+	}
 
 	@include breakpoint( ">480px" ) {
 		display: none;
@@ -88,7 +86,7 @@
 }
 
 .media-library__scale-toggle .gridicon {
-	margin: 2px 8px;
+	margin: 2px 4px;
 	vertical-align: middle;
 }
 

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -94,14 +94,6 @@
 	}
 }
 
-.media-library__header.media-library__upload-url {
-	padding: 6px 12px;
-	background-color: $white;
-	box-sizing: border-box;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
-}
-
 .media-library__upload-buttons {
 	display: inline;
 }

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -44,6 +44,46 @@
 .media-library__header .button.media-library__upload-more {
 	margin-left: 0;
 }
+
+.media-library__filter-bar {
+	display: flex;
+	flex-flow: row nowrap;
+	align-items: stretch;
+	position: relative;
+
+	.section-nav {
+		flex: 1 auto;
+	}
+
+	.plan-storage {
+		display: none;
+		min-width: 200px;
+		margin-left: 1px;
+		margin-bottom: 9px;
+		box-shadow:
+		  0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		  0 1px 2px lighten( $gray, 30% );
+		background-color: $white;
+		padding-left:20px;
+		padding-right: 20px;
+		box-sizing: border-box;
+		flex: 1 0 auto;
+
+		@include breakpoint( ">480px" ) {
+			display: flex;
+		}
+
+		@include breakpoint( ">660px" ) {
+			display: none;
+		}
+
+		@include breakpoint( ">960px" ) {
+			display: flex;
+			margin-bottom: 17px;
+		}
+	}
+}
+
 .media-library__heading {
 	@include heading;
 	display: inline-block;

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -65,7 +65,6 @@
 
 		@include breakpoint( ">480px" ) {
 			display: flex;
-
 		}
 
 		@include breakpoint( ">660px" ) {

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -6,15 +6,15 @@
 @import 'upload-url';
 
 .media-library__header {
-	padding-top: 11px;
-	padding-bottom: 11px;
+	padding-top: 12px;
+	padding-bottom: 12px;
 	display: flex;
 }
 
 .dialog__content .media-library__header.card {
 	box-shadow: none;
 	.media-library__scale-range.range {
-		top: 7px;
+		top: 11px;
 	}
 }
 
@@ -65,6 +65,7 @@
 
 		@include breakpoint( ">480px" ) {
 			display: flex;
+
 		}
 
 		@include breakpoint( ">660px" ) {
@@ -74,6 +75,17 @@
 		@include breakpoint( ">960px" ) {
 			display: flex;
 			margin-bottom: 17px;
+		}
+	}
+}
+
+.editor-media-modal .media-library__filter-bar {
+	.plan-storage {
+		@include breakpoint( ">480px" ) {
+			margin-bottom: 16px;
+		}
+		@include breakpoint( ">960px" ) {
+			margin-bottom: 16px;
 		}
 	}
 }

--- a/client/my-sites/media-library/upload-button.jsx
+++ b/client/my-sites/media-library/upload-button.jsx
@@ -5,6 +5,7 @@ import ReactDom from 'react-dom';
 import React from 'react';
 import noop from 'lodash/noop';
 import classNames from 'classnames';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -14,7 +15,6 @@ import MediaActions from 'lib/media/actions';
 import MediaUtils from 'lib/media/utils';
 import uniq from 'lodash/uniq';
 import { VideoPressFileTypes } from 'lib/media/constants';
-import Button from 'components/button';
 
 module.exports = React.createClass( {
 	displayName: 'MediaLibraryUploadButton',
@@ -22,14 +22,21 @@ module.exports = React.createClass( {
 	propTypes: {
 		site: React.PropTypes.object,
 		onAddMedia: React.PropTypes.func,
-		className: React.PropTypes.string
+		className: React.PropTypes.string,
 	},
 
 	getDefaultProps: function() {
 		return {
 			onAddMedia: noop,
 			type: 'button',
+			href: null,
 		};
+	},
+
+	onClick: function() {
+		if ( this.props.href ) {
+			page( this.props.href );
+		}
 	},
 
 	uploadFiles: function( event ) {
@@ -62,20 +69,19 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		var classes = classNames( 'media-library__upload-button', this.props.className );
+		var classes = classNames( 'media-library__upload-button', 'button', this.props.className );
 
 		return (
-			<Button icon className={ classes }>
-				<form ref="form">
-					{ this.props.children }
-					<input
-						type="file"
-						accept={ this.getInputAccept() }
-						multiple
-						onChange={ this.uploadFiles }
-						className="media-library__upload-button-input" />
-				</form>
-			</Button>
+			<form ref="form" className={ classes }>
+				{ this.props.children }
+				<input
+					type="file"
+					accept={ this.getInputAccept() }
+					multiple
+					onChange={ this.uploadFiles }
+					onClick={ this.onClick }
+					className="media-library__upload-button-input" />
+			</form>
 		);
 	}
 } );

--- a/client/my-sites/media-library/upload-button.jsx
+++ b/client/my-sites/media-library/upload-button.jsx
@@ -14,6 +14,7 @@ import MediaActions from 'lib/media/actions';
 import MediaUtils from 'lib/media/utils';
 import uniq from 'lodash/uniq';
 import { VideoPressFileTypes } from 'lib/media/constants';
+import Button from 'components/button';
 
 module.exports = React.createClass( {
 	displayName: 'MediaLibraryUploadButton',
@@ -26,7 +27,8 @@ module.exports = React.createClass( {
 
 	getDefaultProps: function() {
 		return {
-			onAddMedia: noop
+			onAddMedia: noop,
+			type: 'button',
 		};
 	},
 
@@ -63,15 +65,17 @@ module.exports = React.createClass( {
 		var classes = classNames( 'media-library__upload-button', this.props.className );
 
 		return (
-			<form ref="form" className={ classes }>
-				<span>{ this.props.children }</span>
-				<input
-					type="file"
-					accept={ this.getInputAccept() }
-					multiple
-					onChange={ this.uploadFiles }
-					className="media-library__upload-button-input" />
-			</form>
+			<Button icon className={ classes }>
+				<form ref="form">
+					{ this.props.children }
+					<input
+						type="file"
+						accept={ this.getInputAccept() }
+						multiple
+						onChange={ this.uploadFiles }
+						className="media-library__upload-button-input" />
+				</form>
+			</Button>
 		);
 	}
 } );

--- a/client/my-sites/media-library/upload-url.jsx
+++ b/client/my-sites/media-library/upload-url.jsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import noop from 'lodash/noop';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -13,68 +14,62 @@ import analytics from 'lib/analytics';
 import FormTextInput from 'components/forms/form-text-input';
 import MediaActions from 'lib/media/actions';
 
-export default React.createClass( {
-	displayName: 'MediaLibraryUploadUrl',
+class MediaLibraryUploadUrl extends Component {
+	static propTypes = {
+		className: PropTypes.string,
+		site: PropTypes.object,
+		onAddMedia: PropTypes.func,
+		onClose: PropTypes.func,
+	};
 
-	propTypes: {
-		site: React.PropTypes.object,
-		onAddMedia: React.PropTypes.func,
-		onClose: React.PropTypes.func,
-		className: React.PropTypes.string
-	},
+	static defaultProps = {
+		onAddMedia: noop,
+		onClose: noop,
+	};
 
-	getInitialState() {
-		return {
-			value: '',
-			isError: false
-		};
-	},
+	state = {
+		value: '',
+		isError: false,
+	};
 
-	getDefaultProps() {
-		return {
-			onAddMedia: noop,
-			onClose: noop
-		};
-	},
+	upload = event => {
+		const isError = ! event.target.checkValidity();
 
-	upload( event ) {
-		var isError = ! event.target.checkValidity();
-
-		this.setState( {
-			isError: isError
-		} );
+		this.setState( { isError } );
 
 		if ( isError || ! this.props.site ) {
 			return;
 		}
 
+		event.preventDefault();
+
 		MediaActions.clearValidationErrors( this.props.site.ID );
 		MediaActions.add( this.props.site.ID, this.state.value );
 
-		this.replaceState( this.getInitialState() );
+		this.setState( { value: '', isError: false } );
 		this.props.onAddMedia();
 		this.props.onClose();
 		analytics.mc.bumpStat( 'editor_upload_via', 'url' );
-		event.preventDefault();
-	},
+	};
 
-	onChange( event ) {
+	onChange = event => {
 		this.setState( {
+			isError: false,
 			value: event.target.value,
-			isError: false
 		} );
-	},
+	};
 
-	onKeyDown( event ) {
+	onKeyDown = event => {
 		if ( event.key !== 'Enter' ) {
 			return;
 		}
 
 		this.upload( event );
-	},
+	};
 
 	render() {
 		const classes = classNames( 'media-library__upload-url', this.props.className );
+		const { onClose, translate } = this.props;
 
 		return (
 			<form className={ classes } onSubmit={ this.upload }>
@@ -89,11 +84,12 @@ export default React.createClass( {
 					required />
 				<div className="media-library__upload-url-button-group">
 					<button type="submit" className="button is-primary">
-						{ this.translate( 'Upload', { context: 'verb' } ) }
+						{ translate( 'Upload', { context: 'verb' } ) }
 					</button>
-					<button type="button" className="media-library__upload-url-cancel" onClick={ this.props.onClose }>
+
+					<button type="button" className="media-library__upload-url-cancel" onClick={ onClose }>
 						<span className="screen-reader-text">
-							{ this.translate( 'Cancel' ) }
+							{ translate( 'Cancel' ) }
 						</span>
 						<Gridicon icon="cross" />
 					</button>
@@ -101,4 +97,7 @@ export default React.createClass( {
 			</form>
 		);
 	}
-} );
+}
+
+export default localize( MediaLibraryUploadUrl );
+

--- a/client/my-sites/media-library/upload-url.jsx
+++ b/client/my-sites/media-library/upload-url.jsx
@@ -33,15 +33,14 @@ class MediaLibraryUploadUrl extends Component {
 	};
 
 	upload = event => {
-		const isError = ! event.target.checkValidity();
+		event.preventDefault();
 
+		const isError = ! event.target.checkValidity();
 		this.setState( { isError } );
 
 		if ( isError || ! this.props.site ) {
 			return;
 		}
-
-		event.preventDefault();
 
 		MediaActions.clearValidationErrors( this.props.site.ID );
 		MediaActions.add( this.props.site.ID, this.state.value );
@@ -76,7 +75,7 @@ class MediaLibraryUploadUrl extends Component {
 		const { onClose, translate } = this.props;
 
 		return (
-			<form className={ classes } onSubmit={ this.upload }>
+			<form className={ classes } onSubmit={ this.upload } noValidate>
 				<FormTextInput
 					type="url"
 					value={ this.state.value }

--- a/client/my-sites/media-library/upload-url.jsx
+++ b/client/my-sites/media-library/upload-url.jsx
@@ -60,6 +60,10 @@ class MediaLibraryUploadUrl extends Component {
 	};
 
 	onKeyDown = event => {
+		if ( event.key === 'Escape' ) {
+			return this.props.onClose( event );
+		}
+
 		if ( event.key !== 'Enter' ) {
 			return;
 		}
@@ -82,6 +86,7 @@ class MediaLibraryUploadUrl extends Component {
 					isError={ this.state.isError }
 					autoFocus
 					required />
+
 				<div className="media-library__upload-url-button-group">
 					<button type="submit" className="button is-primary">
 						{ translate( 'Upload', { context: 'verb' } ) }

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -186,6 +186,7 @@ export default React.createClass( {
 							onFilterChange={ this.onFilterChange }
 							site={ site }
 							single={ false }
+							filter={ this.props.filter }
 							onEditItem={ this.openDetailsModalForASingleImage }
 							onViewDetails={ this.openDetailsModalForAllSelected }
 							onDeleteItem={ this.deleteMedia }

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -15,6 +15,9 @@ import { EditorMediaModalDetail } from 'post-editor/media-modal/detail';
 import ImageEditor from 'blocks/image-editor';
 import MediaActions from 'lib/media/actions';
 import MediaUtils from 'lib/media/utils';
+import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
+import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
+import accept from 'lib/accept';
 
 export default React.createClass( {
 	displayName: 'Media',
@@ -28,7 +31,8 @@ export default React.createClass( {
 	getInitialState: function() {
 		return {
 			editedItem: null,
-			openedDetails: null,
+			currentDetail: null,
+			selectedImages: [],
 		};
 	},
 
@@ -52,21 +56,34 @@ export default React.createClass( {
 		page( redirect );
 	},
 
-	openDetailsModal( item ) {
-		this.setState( { openedDetails: item } );
+	openDetailsModalForASingleImage( image ) {
+		this.setState( {
+			currentDetail: 0,
+			selectedImages: [ image ],
+		} );
+	},
+
+	openDetailsModalForAllSelected() {
+		const site = this.props.sites.getSelectedSite();
+		const selected = MediaLibrarySelectedStore.getAll( site.ID );
+
+		this.setState( {
+			currentDetail: 0,
+			selectedImages: selected
+		} );
 	},
 
 	closeDetailsModal() {
-		this.setState( { openedDetails: null, editedItem: null } );
+		this.setState( { editedItem: null, currentDetail: null, selectedImages: [] } );
 	},
 
 	editImage() {
-		this.setState( { openedDetails: null, editedItem: this.state.openedDetails } );
+		this.setState( { currentDetail: null, editedItem: this.state.currentDetail } );
 	},
 
 	onImageEditorCancel: function( imageEditorProps ) {
 		const {	resetAllImageEditorState } = imageEditorProps;
-		this.setState( { openedDetails: this.state.editedItem, editedItem: null } );
+		this.setState( { currentDetail: this.state.editedItem, editedItem: null } );
 
 		resetAllImageEditorState();
 	},
@@ -97,54 +114,82 @@ export default React.createClass( {
 
 		MediaActions.update( site.ID, item, true );
 		resetAllImageEditorState();
-		this.setState( { openedDetails: null, editedItem: null } );
+		this.setState( { currentDetail: null, editedItem: null, selectedImages: [] } );
 	},
 	restoreOriginalMedia: function( siteId, item ) {
 		if ( ! siteId || ! item ) {
 			return;
 		}
 		MediaActions.update( siteId, { ID: item.ID, media_url: item.guid }, true );
-		this.setState( { openedDetails: null, editedItem: null } );
+		this.setState( { currentDetail: null, editedItem: null, selectedImages: [] } );
+	},
+	setDetailSelectedIndex: function( index ) {
+		this.setState( { currentDetail: index } );
+	},
+	confirmDeleteMedia: function ( accepted ) {
+		const site = this.props.sites.getSelectedSite();
+		if ( ! site || ! accepted ) {
+			return;
+		}
+		const selected = MediaLibrarySelectedStore.getAll( site.ID );
+		MediaActions.delete( site.ID, selected );
 	},
 
+	deleteMedia: function() {
+		const site = this.props.sites.getSelectedSite();
+		const selected = MediaLibrarySelectedStore.getAll( site.ID );
+		const selectedCount = selected.length;
+		const confirmMessage = this.translate(
+			'Are you sure you want to permanently delete this item?',
+			'Are you sure you want to permanently delete these items?',
+			{ count: selectedCount }
+		);
+
+		accept( confirmMessage, this.confirmDeleteMedia );
+	},
 	render: function() {
 		const site = this.props.sites.getSelectedSite();
 		return (
 			<div ref="container" className="main main-column media" role="main">
 				<SidebarNavigation />
-				{ ( this.state.editedItem || this.state.openedDetails ) &&
+				{ ( this.state.editedItem !== null || this.state.currentDetail !== null) &&
 					<Dialog
 						isVisible={ true }
 						additionalClassNames="editor-media-modal"
 						onClose={ this.closeDetailsModal }
 					>
-					{ this.state.openedDetails &&
+					{ this.state.currentDetail !== null &&
 						<EditorMediaModalDetail
 							site={ site }
-							items={ [ this.state.openedDetails ] }
-							selectedIndex={ 0 }
+							items={ this.state.selectedImages }
+							selectedIndex={ this.state.currentDetail }
 							onReturnToList={ this.closeDetailsModal }
 							onEditItem={ this.editImage }
 							onRestoreItem={ this.restoreOriginalMedia }
+							onSelectedIndexChange={ this.setDetailSelectedIndex }
 						/>
 					}
-					{ this.state.editedItem &&
+					{ this.state.editedItem !== null &&
 						<ImageEditor
 							siteId={ site && site.ID }
-							media={ this.state.editedItem }
+							media={ this.state.selectedImages[ this.state.editedItem ] }
 							onDone={ this.onImageEditorDone }
 							onCancel={ this.onImageEditorCancel }
 						/>
 					}
 					</Dialog>
 				}
-				<MediaLibrary
-					{ ...this.props }
-					onFilterChange={ this.onFilterChange }
-					site={ site || false }
-					single={ true }
-					onEditItem={ this.openDetailsModal }
-					containerWidth={ this.state.containerWidth } />
+				<MediaLibrarySelectedData siteId={ site && site.ID }>
+					<MediaLibrary
+						{ ...this.props }
+						onFilterChange={ this.onFilterChange }
+						site={ site || false }
+						single={ false }
+						onEditItem={ this.openDetailsModalForASingleImage }
+						onViewDetails={ this.openDetailsModalForAllSelected }
+						onDeleteItem={ this.deleteMedia }
+						containerWidth={ this.state.containerWidth } />
+				</MediaLibrarySelectedData>
 			</div>
 		);
 	}

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -179,18 +179,20 @@ export default React.createClass( {
 					}
 					</Dialog>
 				}
-				<MediaLibrarySelectedData siteId={ site && site.ID }>
-					<MediaLibrary
-						{ ...this.props }
-						onFilterChange={ this.onFilterChange }
-						site={ site || false }
-						single={ false }
-						onEditItem={ this.openDetailsModalForASingleImage }
-						onViewDetails={ this.openDetailsModalForAllSelected }
-						onDeleteItem={ this.deleteMedia }
-						modal={ false }
-						containerWidth={ this.state.containerWidth } />
-				</MediaLibrarySelectedData>
+				{ site && site.ID && (
+					<MediaLibrarySelectedData siteId={ site.ID }>
+						<MediaLibrary
+							{ ...this.props }
+							onFilterChange={ this.onFilterChange }
+							site={ site }
+							single={ false }
+							onEditItem={ this.openDetailsModalForASingleImage }
+							onViewDetails={ this.openDetailsModalForAllSelected }
+							onDeleteItem={ this.deleteMedia }
+							modal={ false }
+							containerWidth={ this.state.containerWidth } />
+					</MediaLibrarySelectedData>
+				) }
 			</div>
 		);
 	}

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -238,6 +238,7 @@ export default React.createClass( {
 					<MediaLibrarySelectedData siteId={ site.ID }>
 						<MediaLibrary
 							{ ...this.props }
+							className="media__main-section"
 							onFilterChange={ this.onFilterChange }
 							site={ site }
 							single={ false }

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -87,6 +87,7 @@ export default React.createClass( {
 
 		resetAllImageEditorState();
 	},
+
 	onImageEditorDone( error, blob, imageEditorProps ) {
 		if ( error ) {
 			this.onEditImageCancel( imageEditorProps );
@@ -116,6 +117,27 @@ export default React.createClass( {
 		resetAllImageEditorState();
 		this.setState( { currentDetail: null, editedItem: null, selectedImages: [] } );
 	},
+
+	getModalButtons() {
+		return [
+			{
+				action: 'delete',
+				additionalClassNames: 'media__modal-delete-item-button is-link',
+				label: this.translate( 'Delete' ),
+				isPrimary: false,
+				disabled: false,
+				onClick: this.deleteMediaByItemDetail,
+			},
+			{
+				action: 'confirm',
+				label: this.translate( 'Done' ),
+				isPrimary: true,
+				disabled: false,
+				onClose: this.closeDetailsModal,
+			}
+		];
+	},
+
 	restoreOriginalMedia: function( siteId, item ) {
 		if ( ! siteId || ! item ) {
 			return;
@@ -123,19 +145,19 @@ export default React.createClass( {
 		MediaActions.update( siteId, { ID: item.ID, media_url: item.guid }, true );
 		this.setState( { currentDetail: null, editedItem: null, selectedImages: [] } );
 	},
+
 	setDetailSelectedIndex: function( index ) {
 		this.setState( { currentDetail: index } );
 	},
-	confirmDeleteMedia: function ( accepted ) {
-		const site = this.props.sites.getSelectedSite();
-		if ( ! site || ! accepted ) {
-			return;
-		}
-		const selected = MediaLibrarySelectedStore.getAll( site.ID );
-		MediaActions.delete( site.ID, selected );
-	},
 
-	deleteMedia: function() {
+	/**
+	 * Start the process to delete media items.
+	 * `callback` is an optional parameter which will execute once the confirm dialog is accepted.
+	 * It's used especially when the item is attempting to be removed using the item detail dialog.
+	 *
+	 * @param  {Function} [callback] - callback function
+	 */
+	deleteMedia: function( callback ) {
 		const site = this.props.sites.getSelectedSite();
 		const selected = MediaLibrarySelectedStore.getAll( site.ID );
 		const selectedCount = selected.length;
@@ -145,8 +167,40 @@ export default React.createClass( {
 			{ count: selectedCount }
 		);
 
-		accept( confirmMessage, this.confirmDeleteMedia );
+		accept( confirmMessage, accepted => {
+			if ( ! accepted ) {
+				return;
+			}
+
+			this.confirmDeleteMedia();
+			if ( callback ) {
+				callback();
+			}
+		} );
 	},
+
+	handleDeleteMediaEvent() {
+		this.deleteMedia();
+	},
+
+	deleteMediaByItemDetail() {
+		this.deleteMedia( () => this.closeDetailsModal() );
+	},
+
+	confirmDeleteMedia: function() {
+		const site = this.props.sites.getSelectedSite();
+
+		if ( ! site ) {
+			return;
+		}
+
+		const selected = this.state.selectedImages && this.state.selectedImages.length
+			? this.state.selectedImages
+			: MediaLibrarySelectedStore.getAll( site.ID );
+
+		MediaActions.delete( site.ID, selected );
+	},
+
 	render: function() {
 		const site = this.props.sites.getSelectedSite();
 		return (
@@ -155,7 +209,8 @@ export default React.createClass( {
 				{ ( this.state.editedItem !== null || this.state.currentDetail !== null) &&
 					<Dialog
 						isVisible={ true }
-						additionalClassNames="editor-media-modal"
+						additionalClassNames="editor-media-modal media__item-dialog"
+						buttons={ this.getModalButtons() }
 						onClose={ this.closeDetailsModal }
 					>
 					{ this.state.currentDetail !== null &&
@@ -189,7 +244,7 @@ export default React.createClass( {
 							filter={ this.props.filter }
 							onEditItem={ this.openDetailsModalForASingleImage }
 							onViewDetails={ this.openDetailsModalForAllSelected }
-							onDeleteItem={ this.deleteMedia }
+							onDeleteItem={ this.handleDeleteMediaEvent }
 							modal={ false }
 							containerWidth={ this.state.containerWidth } />
 					</MediaLibrarySelectedData>

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -188,6 +188,7 @@ export default React.createClass( {
 						onEditItem={ this.openDetailsModalForASingleImage }
 						onViewDetails={ this.openDetailsModalForAllSelected }
 						onDeleteItem={ this.deleteMedia }
+						modal={ false }
 						containerWidth={ this.state.containerWidth } />
 				</MediaLibrarySelectedData>
 			</div>

--- a/client/my-sites/media/style.scss
+++ b/client/my-sites/media/style.scss
@@ -5,3 +5,26 @@
 		padding: 0;
 	}
 }
+
+.media__item-dialog .dialog__action-buttons {
+	display: flex;
+	justify-content: space-between;
+}
+
+.media__modal-delete-item-button {
+	border: 0;
+
+	.dialog__button-label {
+		color: $alert-red;
+	}
+
+	&:hover {
+		color: lighten( $alert-red, 10% );
+	}
+
+	&:disabled {
+		cursor: default;
+		cursor: not-allowed;
+		color: lighten( $alert-red, 25% );
+	}
+}

--- a/client/my-sites/media/style.scss
+++ b/client/my-sites/media/style.scss
@@ -28,3 +28,11 @@
 		color: lighten( $alert-red, 25% );
 	}
 }
+
+.media__main-section .media-library__header.media-library__upload-url {
+	padding: 6px 12px;
+	background-color: $white;
+	box-sizing: border-box;
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		0 1px 2px lighten( $gray, 30% );
+}

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -17,6 +17,7 @@ import { getPostTypes } from 'state/post-types/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
 import analytics from 'lib/analytics';
 import { decodeEntities } from 'lib/formatting';
+import MediaLibraryUploadButton from 'my-sites/media-library/upload-button';
 
 const PublishMenu = React.createClass( {
 	propTypes: {
@@ -86,6 +87,7 @@ const PublishMenu = React.createClass( {
 				queryable: true,
 				config: 'manage/media',
 				link: '/media',
+				buttonLink: '/media/' + site.slug,
 				wpAdminLink: 'upload.php',
 				showOnAllMySites: false,
 			} );
@@ -158,9 +160,12 @@ const PublishMenu = React.createClass( {
 				icon={ icon }
 				preloadSectionName={ preload }
 			>
-				<SidebarButton href={ menuItem.buttonLink } preloadSectionName="post-editor">
-					{ this.translate( 'Add' ) }
-				</SidebarButton>
+				{ menuItem.name === 'media' && (
+					<MediaLibraryUploadButton className="sidebar__button" site={ site } href={ menuItem.buttonLink }>{ this.translate( 'Add' ) }</MediaLibraryUploadButton>
+				) }
+				{ menuItem.name !== 'media' && (
+					<SidebarButton href={ menuItem.buttonLink } preloadSectionName="post-editor">{ this.translate( 'Add' ) }</SidebarButton>
+				) }
 			</SidebarItem>
 		);
 	},

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -26,7 +26,6 @@ import {
 	recordEvent,
 	recordStat
 } from 'lib/posts/stats';
-import MediaModalSecondaryActions from './secondary-actions';
 import MediaModalGallery from './gallery';
 import MediaActions from 'lib/media/actions';
 import MediaUtils from 'lib/media/utils';
@@ -331,11 +330,6 @@ export class EditorMediaModal extends Component {
 		const isDisabled = this.isDisabled();
 		const selectedItems = this.props.mediaLibrarySelectedItems;
 		const buttons = [
-			<MediaModalSecondaryActions
-				site={ this.props.site }
-				selectedItems={ selectedItems }
-				disabled={ isDisabled }
-				onDelete={ this.deleteMedia } />,
 			{
 				action: 'cancel',
 				label: this.props.translate( 'Cancel' )

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -10,6 +10,7 @@ import {
 	head,
 	noop,
 	map,
+	flow,
 	partial,
 	some,
 	values,
@@ -40,6 +41,7 @@ import { ModalViews } from 'state/ui/media-modal/constants';
 import { deleteMedia } from 'state/media/actions';
 import ImageEditor from 'blocks/image-editor';
 import MediaModalDetail from './detail';
+import { withAnalytics, bumpStat, recordGoogleEvent } from 'state/analytics/actions';
 
 export class EditorMediaModal extends Component {
 	static propTypes = {
@@ -431,6 +433,9 @@ export class EditorMediaModal extends Component {
 						onEditItem={ this.editItem }
 						fullScreenDropZone={ false }
 						single={ this.props.single }
+						onDeleteItem={ this.deleteMedia }
+						onViewDetails={ this.props.onViewDetails }
+						mediaLibrarySelectedItems={ this.props.mediaLibrarySelectedItems }
 						scrollable />
 				);
 				break;
@@ -463,6 +468,11 @@ export default connect(
 	{
 		setView: setEditorMediaModalView,
 		resetView: resetMediaModalView,
-		deleteMedia
+		deleteMedia,
+		onViewDetails: flow(
+			withAnalytics( bumpStat( 'editor_media_actions', 'edit_button_dialog' ) ),
+			withAnalytics( recordGoogleEvent( 'Media', 'Clicked Dialog Edit Button' ) ),
+			partial( setEditorMediaModalView, ModalViews.DETAIL )
+		)
 	}
 )( localize( EditorMediaModal ) );

--- a/client/post-editor/media-modal/index.scss
+++ b/client/post-editor/media-modal/index.scss
@@ -33,10 +33,8 @@
 
 .editor-media-modal .section-nav {
 	z-index: z-index( '.dialog__backdrop', '.editor-media-modal .section-nav' );
-	padding: 0 16px;
-
-	@include breakpoint( ">660px" ) {
-		padding: 0;
+	@include breakpoint( ">480px" ) {
+		margin-bottom: 16px;
 	}
 }
 
@@ -66,11 +64,16 @@
 }
 
 .editor-media-modal .media-library__header {
-	padding: 2px 16px;
+	padding: 0 16px;
 
 	@include breakpoint( ">660px" ) {
 		padding: 0 24px;
 	}
+}
+
+.editor-media-modal .media-library__header:not(.media-library__upload-url) {
+	padding-top: 6px;
+	padding-bottom: 6px;
 }
 
 .editor-media-modal .media-library__scale-toggle,
@@ -114,24 +117,31 @@
 .editor-media-modal .media-library__list {
 	@extend .editor-media-modal__content;
 	display: block;
-	top: 95px;
+	top: 105px;
 	right: 0;
 	left: 0;
 	padding: 4px 16px;
 	transform: translateZ( 0 );
 	pointer-events: all;
 
+	@include breakpoint( ">480px" ) {
+		top: 131px;
+	}
+
 	@include breakpoint( ">660px" ) {
 		padding-left: 24px;
 		padding-right: 24px;
 		overflow-y: auto;
-		top: 108px;
+		top: 122px;
 	}
 }
 
 .editor-media-modal .notice {
 	z-index: z-index( '.dialog__backdrop', '.editor-media-modal .notice' );
-	margin-top: -4px;
+
+	@include breakpoint( ">660px" ) {
+		margin-top: 16px;
+	}
 }
 
 .editor-media-modal .media-library__upload-url-cancel {

--- a/client/post-editor/media-modal/index.scss
+++ b/client/post-editor/media-modal/index.scss
@@ -66,7 +66,7 @@
 }
 
 .editor-media-modal .media-library__header {
-	padding: 0 16px;
+	padding: 2px 16px;
 
 	@include breakpoint( ">660px" ) {
 		padding: 0 24px;
@@ -114,7 +114,7 @@
 .editor-media-modal .media-library__list {
 	@extend .editor-media-modal__content;
 	display: block;
-	top: 117px;
+	top: 95px;
 	right: 0;
 	left: 0;
 	padding: 4px 16px;
@@ -125,6 +125,7 @@
 		padding-left: 24px;
 		padding-right: 24px;
 		overflow-y: auto;
+		top: 108px;
 	}
 }
 

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { values, noop, some, every, flow, partial, pick } from 'lodash';
 import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -39,12 +40,15 @@ class MediaModalSecondaryActions extends Component {
 
 	getButtons() {
 		const {
-			user,
-			site,
-			selectedItems,
-			view,
 			disabled,
-			onDelete
+			selectedItems,
+			site,
+			translate,
+			user,
+			view,
+
+			onDelete,
+			onViewDetails,
 		} = this.props;
 
 		const buttons = [];
@@ -52,10 +56,10 @@ class MediaModalSecondaryActions extends Component {
 		if ( ModalViews.LIST === view && selectedItems.length ) {
 			buttons.push( {
 				key: 'edit',
-				text: this.translate( 'Edit' ),
+				text: translate( 'Edit' ),
 				disabled: disabled,
 				primary: true,
-				onClick: this.props.onViewDetails
+				onClick: onViewDetails
 			} );
 		}
 
@@ -109,4 +113,4 @@ export default connect(
 		//We want to overwrite connected props if 'onViewDetails', 'view' were provided
 		return Object.assign( {}, ownProps, stateProps, dispatchProps, pick( ownProps, [ 'onViewDetails', 'view' ] ) );
 	}
-)( MediaModalSecondaryActions );
+)( localize( MediaModalSecondaryActions ) );

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -29,13 +29,11 @@ class MediaModalSecondaryActions extends Component {
 		disabled: PropTypes.bool,
 		onDelete: PropTypes.func,
 		onViewDetails: PropTypes.func,
-		renderStorage: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		disabled: false,
 		onDelete: noop,
-		renderStorage: true,
 	};
 
 	getButtons() {

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { values, noop, some, every, flow, partial, pick } from 'lodash';
@@ -19,8 +19,8 @@ import { ModalViews } from 'state/ui/media-modal/constants';
 import { withAnalytics, bumpStat, recordGoogleEvent } from 'state/analytics/actions';
 import Button from 'components/button';
 
-const MediaModalSecondaryActions = React.createClass( {
-	propTypes: {
+class MediaModalSecondaryActions extends Component {
+	static propTypes = {
 		user: PropTypes.object,
 		site: PropTypes.object,
 		selectedItems: PropTypes.array,
@@ -29,15 +29,13 @@ const MediaModalSecondaryActions = React.createClass( {
 		onDelete: PropTypes.func,
 		onViewDetails: PropTypes.func,
 		renderStorage: PropTypes.bool,
-	},
+	};
 
-	getDefaultProps() {
-		return {
-			disabled: false,
-			onDelete: noop,
-			renderStorage: true,
-		};
-	},
+	static defaultProps = {
+		disabled: false,
+		onDelete: noop,
+		renderStorage: true,
+	};
 
 	getButtons() {
 		const {
@@ -49,7 +47,7 @@ const MediaModalSecondaryActions = React.createClass( {
 			onDelete
 		} = this.props;
 
-		let buttons = [];
+		const buttons = [];
 
 		if ( ModalViews.LIST === view && selectedItems.length ) {
 			buttons.push( {
@@ -76,7 +74,7 @@ const MediaModalSecondaryActions = React.createClass( {
 		}
 
 		return buttons;
-	},
+	}
 
 	render() {
 		return (
@@ -93,7 +91,7 @@ const MediaModalSecondaryActions = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
 export default connect(
 	( state, ownProps ) => ( {

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -10,17 +10,14 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import TrackComponentView from 'lib/analytics/track-component-view';
-import PopoverMenu from 'components/popover/menu';
-import PopoverMenuItem from 'components/popover/menu-item';
 import { canUserDeleteItem } from 'lib/media/utils';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
-import PlanStorage from 'blocks/plan-storage';
 import { getMediaModalView } from 'state/ui/media-modal/selectors';
 import { setEditorMediaModalView } from 'state/ui/editor/actions';
 import { ModalViews } from 'state/ui/media-modal/constants';
 import { withAnalytics, bumpStat, recordGoogleEvent } from 'state/analytics/actions';
+import Button from 'components/button';
 
 const MediaModalSecondaryActions = React.createClass( {
 	propTypes: {
@@ -42,22 +39,6 @@ const MediaModalSecondaryActions = React.createClass( {
 		};
 	},
 
-	getInitialState() {
-		return {
-			isMobilePopoverVisible: false
-		};
-	},
-
-	setMobilePopoverContext( component ) {
-		if ( ! component ) {
-			return;
-		}
-
-		this.setState( {
-			mobilePopoverContext: component
-		} );
-	},
-
 	getButtons() {
 		const {
 			user,
@@ -73,8 +54,9 @@ const MediaModalSecondaryActions = React.createClass( {
 		if ( ModalViews.LIST === view && selectedItems.length ) {
 			buttons.push( {
 				key: 'edit',
-				value: this.translate( 'Edit' ),
+				text: this.translate( 'Edit' ),
 				disabled: disabled,
+				primary: true,
 				onClick: this.props.onViewDetails
 			} );
 		}
@@ -86,8 +68,8 @@ const MediaModalSecondaryActions = React.createClass( {
 		if ( ModalViews.GALLERY !== view && canDeleteItems ) {
 			buttons.push( {
 				key: 'delete',
-				value: this.translate( 'Delete' ),
-				className: 'is-link editor-media-modal__delete',
+				icon: 'trash',
+				className: 'editor-media-modal__delete',
 				disabled: disabled || some( selectedItems, 'transient' ),
 				onClick: onDelete
 			} );
@@ -96,89 +78,18 @@ const MediaModalSecondaryActions = React.createClass( {
 		return buttons;
 	},
 
-	toggleMobilePopover() {
-		this.setState( {
-			isMobilePopoverVisible: ! this.state.isMobilePopoverVisible
-		} );
-	},
-
-	renderMobileButtons() {
-		const buttons = this.getButtons();
-
-		if ( ! buttons.length ) {
-			return;
-		}
-
-		const classes = classNames( 'editor-media-modal__secondary-action', 'button', 'is-mobile', 'is-link', {
-			'is-active': this.state.isMobilePopoverVisible
-		} );
-
-		const menuItems = buttons.map( ( button ) => {
-			const onClick = () => {
-				this.toggleMobilePopover();
-
-				if ( button.onClick ) {
-					button.onClick();
-				}
-			};
-
-			return React.createElement( PopoverMenuItem, {
-				key: button.key,
-				action: button.key,
-				onClick: onClick
-			}, button.value );
-		} );
-
-		return (
-			<button
-				ref={ this.setMobilePopoverContext }
-				onClick={ this.toggleMobilePopover }
-				className={ classes }>
-				<span className="screen-reader-text">{ this.translate( 'More Options' ) }</span>
-				<Gridicon icon="ellipsis" size={ 24 } />
-				<PopoverMenu
-					context={ this.state.mobilePopoverContext }
-					isVisible={ this.state.isMobilePopoverVisible }
-					onClose={ this.toggleMobilePopover }
-					position="top right"
-					className="popover is-dialog-visible">
-					{ menuItems }
-				</PopoverMenu>
-			</button>
-		);
-	},
-
-	renderDesktopButtons() {
-		return this.getButtons().map( ( button ) => {
-			return React.createElement( 'input', Object.assign( {
-				type: 'button'
-			}, button, {
-				className: classNames( 'editor-media-modal__secondary-action', 'button', 'is-desktop', button.className )
-			} ) );
-		} );
-	},
-
-	renderPlanStorage() {
-		if ( this.props.selectedItems.length === 0 ) {
-			const eventName = 'calypso_upgrade_nudge_impression';
-			const eventProperties = { cta_name: 'plan-media-storage' };
-			return (
-				<PlanStorage
-					className="editor-media-modal__plan-storage"
-					siteId={ this.props.site.ID } >
-					<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
-				</PlanStorage>
-			);
-		}
-		return null;
-	},
-
 	render() {
 		return (
-			<div className="editor-media-modal__secondary-actions">
-				{ this.renderMobileButtons() }
-				{ this.renderDesktopButtons() }
-				{ this.props.renderStorage && this.renderPlanStorage() }
+			<div>
+				{ this.getButtons().map( button => <Button
+					className={ classNames( 'editor-media-modal__secondary-action', button.className ) }
+					icon={ !! button.icon }
+					compact
+					{ ...pick( button, [ 'key', 'disabled', 'onClick', 'primary' ] ) }
+				>
+					{ button.icon && <Gridicon icon={ button.icon } /> }
+					{ button.text && button.text }
+				</Button> ) }
 			</div>
 		);
 	}

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -4,7 +4,7 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { values, noop, some, every, flow, partial } from 'lodash';
+import { values, noop, some, every, flow, partial, pick } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
@@ -30,13 +30,15 @@ const MediaModalSecondaryActions = React.createClass( {
 		view: React.PropTypes.oneOf( values( ModalViews ) ),
 		disabled: PropTypes.bool,
 		onDelete: PropTypes.func,
-		onViewDetails: PropTypes.func
+		onViewDetails: PropTypes.func,
+		renderStorage: PropTypes.bool,
 	},
 
 	getDefaultProps() {
 		return {
 			disabled: false,
-			onDelete: noop
+			onDelete: noop,
+			renderStorage: true,
 		};
 	},
 
@@ -176,7 +178,7 @@ const MediaModalSecondaryActions = React.createClass( {
 			<div className="editor-media-modal__secondary-actions">
 				{ this.renderMobileButtons() }
 				{ this.renderDesktopButtons() }
-				{ this.renderPlanStorage() }
+				{ this.props.renderStorage && this.renderPlanStorage() }
 			</div>
 		);
 	}
@@ -194,5 +196,8 @@ export default connect(
 			withAnalytics( recordGoogleEvent( 'Media', 'Clicked Dialog Edit Button' ) ),
 			partial( setEditorMediaModalView, ModalViews.DETAIL )
 		)
+	}, function mergeProps( stateProps, dispatchProps, ownProps ) {
+		//We want to overwrite connected props if 'onViewDetails', 'view' were provided
+		return Object.assign( {}, ownProps, stateProps, dispatchProps, pick( ownProps, [ 'onViewDetails', 'view' ] ) );
 	}
 )( MediaModalSecondaryActions );

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -503,6 +503,10 @@ export function getSitePlan( state, siteId ) {
 	return site.plan;
 }
 
+export function getSitePlanSlug( state, siteId ) {
+	return get( getSitePlan( state, siteId ), 'product_slug' );
+}
+
 /**
  * Returns true if the current site plan is a paid one
  *


### PR DESCRIPTION
This PR makes a number of improvements to the media section and updates the media modal to include an action bar at the top. The media section is controlled by the `manage/media` feature flag. This is currently enabled in dev, wpcalypso, horizon and test. The media section can be shown by clicking on the `Media` option into the sidebar.

Related Design Discussion: https://github.com/Automattic/wp-calypso/issues/10805

### The whole picture

![image](https://cloud.githubusercontent.com/assets/77539/23767493/7f3aae86-04e7-11e7-8014-c560a7640c57.png)

### Primary Changes
Beyond add the media library this PR implements many changes. Following, the most important ones:

#### Media -> Add item

It allows adding a new item quickly. 

<img src="https://cloud.githubusercontent.com/assets/77539/23767908/0c2c4588-04e9-11e7-903b-2399c2850b52.png" width="400px" />

#### Media -> Actions bar

<img src="https://cloud.githubusercontent.com/assets/77539/23767650/0d04cada-04e8-11e7-8dda-5a946631b60d.gif" width="800px" />


#### Media -> Plan storage nudge

A plan storage nudge is shown in the filter bar is the site doesn't have a business plan.

<img src="https://cloud.githubusercontent.com/assets/77539/23767750/82c42a90-04e8-11e7-843e-eb22fa68a86a.png" width="400px" />

#### Media -> Item detail dialog

* Added `DONE` and `DELETE` buttons

![image](https://cloud.githubusercontent.com/assets/77539/23767301/e8c8bd4e-04e6-11e7-8abc-9f3a5859db43.png)

#### Post editor -> add media -> Item detail dialog

* Actions buttons were removed from the bottom
* Added the actions bar above the media gallery 

<img src="https://cloud.githubusercontent.com/assets/77539/23767388/269be6dc-04e7-11e7-9f95-09d2e3c67bfa.png" width="600px" />

-----------------------
### Testing Instructions:

#### Media Modal
- Navigate to http://calypso.localhost:3000/post/
- Select a site when prompted
- Click on insert content: 
<img width="52" alt="screen shot 2017-03-09 at 12 18 11 pm" src="https://cloud.githubusercontent.com/assets/1270189/23768933/7c779ad0-04c2-11e7-8fdd-4cd12ea66453.png">

- The new action bar appears at the top. 
- The plan storage component in the top right corner can be seen for folks with a wpcom free/personal/premium plan.
<img width="869" alt="screen shot 2017-03-09 at 12 18 27 pm" src="https://cloud.githubusercontent.com/assets/1270189/23768944/89bc21a2-04c2-11e7-8b63-1b439a7a055d.png">

- Clicking "Add new" opens the file picker
<img width="141" alt="screen shot 2017-03-09 at 12 21 10 pm" src="https://cloud.githubusercontent.com/assets/1270189/23769054/e8974b84-04c2-11e7-950c-714b9fb56886.png">

- Click on the chevron next to "add new" gives you this option:
<img width="298" alt="screen shot 2017-03-09 at 12 21 43 pm" src="https://cloud.githubusercontent.com/assets/1270189/23769077/fb11e396-04c2-11e7-9b57-1f7db93b7003.png">

- Clicking on Add Via Url updates the interface:
<img width="298" alt="screen shot 2017-03-09 at 12 21 43 pm" src="https://cloud.githubusercontent.com/assets/1270189/23769094/0bab2eba-04c3-11e7-89b9-05575a7fb0d1.png">

- Selecting items adds an edit and delete button to the action bar
<img width="854" alt="screen shot 2017-03-09 at 12 22 33 pm" src="https://cloud.githubusercontent.com/assets/1270189/23769114/23612690-04c3-11e7-8740-93a118a1b20e.png">

- Search works as expected
- Other media modal flows work as expected

#### Media Section
- Click on the add button of the media section
<img width="264" alt="screen shot 2017-03-09 at 12 37 08 pm" src="https://cloud.githubusercontent.com/assets/1270189/23769719/22778f88-04c5-11e7-8fcb-3d72b90eb189.png">

- The media section should open with the file picker ready
- Clicking on the section link outside of "add" should just open the media section
- The media section visually looks ok
<img width="822" alt="screen shot 2017-03-09 at 12 38 15 pm" src="https://cloud.githubusercontent.com/assets/1270189/23769769/4f71ab18-04c5-11e7-954a-e25789a1cc5d.png">

- We can edit media like we can do in the media modal
- scrolling down, stickies the action bar:
<img width="831" alt="screen shot 2017-03-09 at 12 39 46 pm" src="https://cloud.githubusercontent.com/assets/1270189/23769827/85751664-04c5-11e7-81ab-753525900250.png">


#### Site Icon
- We can update a public site icon correctly
- Navigate to http://calypso.localhost:3000/settings/general/
- Select a public site
- Click on "Change" underneath the site icon
- Follow flow, site icon should update


### Known Visual Issues

There are a few known visual issues in the media section that should be addressed after this feature branch lands. It should be safe to land with these quirks since the media section is not enabled in prod yet. We're hoping to land the feature branch quickly to avoid drift and a larger diff.

- Image Editor in Media Section shows too many buttons:
![pasted_image_at_2017_03_09_05_46_pm_360](https://cloud.githubusercontent.com/assets/1270189/23770383/b2c6d574-04c7-11e7-827b-15cbfbbdacc4.png)
- Visual quirks at smaller sizes with the sticky bar
<img width="589" alt="screen shot 2017-03-09 at 11 42 10 am" src="https://cloud.githubusercontent.com/assets/1270189/23770419/cfed0e3e-04c7-11e7-8821-26783e5ac840.png">



### Pull Requests

This process was done working in different patches:

* Media Section: Move Action buttons to top, multiple selection #11589
* Media Section: Add Link #11672
* Media Section: Action bar buttons + card #11560
* Media Section: Move Action buttons to top, multiple selection #11589
* Media Section: tidying secondary actions #11770
* Component: reimplement plan-storage structure using flexbox  #11769
* Media: add plan-storage component #11749
* Plan Storage: Minor style adjustments #11858
* Media Library: fix elevation visual bug in search icon #11836
* Media: fix-plan storage for business plan #11870
* Media modal: do not apply custom styles to uploading-by-URL box #11932
* Media: add `Done` and `Delete` buttons https://github.com/Automattic/wp-calypso/pull/11910
* Media Library: upload-url janitorial #11828 
* Media Library: improve uploading by URL section #11830 
* Media Section: Style cleanup for action bar #11873 

h/t to @iamtakashi @artpi @retrofox @gwwar 