### PR TITLE
Components: Fix missing bracket in code example for DropZone

### DIFF
--- a/client/components/drop-zone/README.md
+++ b/client/components/drop-zone/README.md
@@ -17,7 +17,7 @@ class MyComponent extends Component {
 	onFilesDrop( files ) {
 		console.log( 'You dropped some files: %s', files.map( function( file ) {
 			return file.name;
-		}.join( ', ' ) );
+		}.join( ', ' ) ) );
 	}
 
 	render() {


### PR DESCRIPTION
This PR fixes a missing bracket in the `DropZone` component documentation. 