### PR TITLE
Site Settings: Move SEO box in a separate component

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -34,6 +34,7 @@ import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import CountedTextarea from 'components/forms/counted-textarea';
 import Banner from 'components/banner';
+import SeoSettingsHelpCard from './help';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import {
 	getSiteOption,
@@ -450,10 +451,6 @@ export const SeoForm = React.createClass( {
 			</Button>
 		);
 
-		const seoHelpLink = siteIsJetpack
-			? 'https://jetpack.com/support/seo-tools/'
-			: 'https://en.blog.wordpress.com/2013/03/22/seo-on-wordpress-com/';
-
 		/* eslint-disable react/jsx-no-target-blank */
 		return (
 			<div>
@@ -518,21 +515,7 @@ export const SeoForm = React.createClass( {
 					/>
 				}
 
-				<SectionHeader label={ translate( 'Search Engine Optimization' ) } />
-				<Card>
-					{ translate(
-						'{{b}}WordPress.com has great SEO{{/b}} out of the box. All of our themes are optimized ' +
-						'for search engines, so you don\'t have to do anything extra. However, you can tweak ' +
-						'these settings if you\'d like more advanced control. Read more about what you can do ' +
-						'to {{a}}optimize your site\'s SEO{{/a}}.',
-						{
-							components: {
-								a: <a href={ seoHelpLink } />,
-								b: <strong />
-							}
-						}
-					) }
-				</Card>
+				<SeoSettingsHelpCard />
 
 				<form onChange={ this.props.markChanged } className="seo-settings__seo-form">
 					{ showAdvancedSeo &&

--- a/client/my-sites/site-settings/seo-settings/help.jsx
+++ b/client/my-sites/site-settings/seo-settings/help.jsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+import { isJetpackSite } from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+const SeoSettingsHelpCard = ( {
+	siteIsJetpack,
+	translate
+} ) => {
+	const seoHelpLink = siteIsJetpack
+		? 'https://jetpack.com/support/seo-tools/'
+		: 'https://en.blog.wordpress.com/2013/03/22/seo-on-wordpress-com/';
+
+	return (
+		<div>
+			<SectionHeader label={ translate( 'Search Engine Optimization' ) } />
+			<Card>
+				{ translate(
+					'{{b}}WordPress.com has great SEO{{/b}} out of the box. All of our themes are optimized ' +
+					'for search engines, so you don\'t have to do anything extra. However, you can tweak ' +
+					'these settings if you\'d like more advanced control. Read more about what you can do ' +
+					'to {{a}}optimize your site\'s SEO{{/a}}.',
+					{
+						components: {
+							a: <a href={ seoHelpLink } />,
+							b: <strong />
+						}
+					}
+				) }
+			</Card>
+		</div>
+	);
+};
+
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const siteIsJetpack = isJetpackSite( state, siteId );
+
+		return {
+			siteIsJetpack,
+		};
+	}
+)( localize( SeoSettingsHelpCard ) );


### PR DESCRIPTION
This PR moves the SEO help box away from the SEO settings form in a separate component.

Why this is useful: #11615 requires us to put the SEO help box on the top, but place the rest of the SEO cards at the bottom of the new Traffic tab. To simplify this, we have to move it in a separate component.

![](https://cldup.com/j87Ul8nL0s.png)

To test:

* Checkout this branch
* Go to `/settings/seo/$site` for a Jetpack site.
* Verify the SEO box appears properly and the links leads to the Jetpack SEO help article.
* Go to `/settings/seo/$site` for a WordPress.com site.
* Verify the SEO box appears properly and the links leads to the WordPress.com SEO help article.

