### PR TITLE
Themes: Filter wpcom themes by theme_uri instead of ID

### DIFF
--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, map, property, delay } from 'lodash';
+import { filter, map, property, delay, endsWith } from 'lodash';
 import debugFactory from 'debug';
 import page from 'page';
 
@@ -167,7 +167,7 @@ function filterThemes( themes, siteId, filterWpcom, query, found ) {
 		themes,
 		theme => (
 			isThemeMatchingQuery( query, theme ) &&
-			! ( filterWpcom && isThemeFromWpcom( theme.id ) )
+			! ( filterWpcom && isThemeFromWpcom( theme ) )
 		)
 	);
 
@@ -487,7 +487,7 @@ export function installTheme( themeId, siteId ) {
 				} );
 			} )
 			.then( () => {
-				if ( isThemeFromWpcom( themeId ) ) {
+				if ( endsWith( themeId, '-wpcom' ) ) {
 					const parentThemeId = getWpcomParentThemeId(
 						getState(),
 						themeId.replace( '-wpcom', '' )

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -199,8 +199,14 @@ export function getSerializedThemesQueryWithoutPage( query, siteId ) {
 }
 
 /**
- * Check if theme is a wpcom theme
- * checking is done based on existance of -wpcom suffix
+ * Check if theme is a wpcom theme.
+ *
+ * For wpcom theme zips, the theme_uri field is
+ * set in style.css by the bundling script.
+ *
+ * For AT themes, the wpcomsh plugin sets the theme_uri
+ * field to contain 'wordpress.com' for Jetpack API
+ * requests.
  *
  * @param  {Object} theme Theme object
  * @return {Boolean}      Whether theme is a wpcom theme

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -4,7 +4,6 @@
 import startsWith from 'lodash/startsWith';
 import {
 	every,
-	endsWith,
 	get,
 	includes,
 	map,
@@ -203,11 +202,11 @@ export function getSerializedThemesQueryWithoutPage( query, siteId ) {
  * Check if theme is a wpcom theme
  * checking is done based on existance of -wpcom suffix
  *
- * @param  {string}  themeId Theme id
- * @return {Boolean}         Wheter theme is a wpcom theme
+ * @param  {Object} theme Theme object
+ * @return {Boolean}      Whether theme is a wpcom theme
  */
-export function isThemeFromWpcom( themeId ) {
-	return endsWith( themeId, '-wpcom' );
+export function isThemeFromWpcom( theme ) {
+	return includes( theme.theme_uri, 'wordpress.com' );
 }
 
 /**


### PR DESCRIPTION
Because Automated Transfer sites do not use _-wpcom_ suffixes on theme IDs. This technique will work for both regular Jetpack and Automated Transfer sites.

<img width="944" alt="screen shot 2017-03-07 at 11 51 07" src="https://cloud.githubusercontent.com/assets/7767559/23655433/de0b4dc4-032c-11e7-9ca0-2e8842204229.png">

**To Test**
* Go to http://calypso.localhost:3000/design
* Select a Jetpack or Automated Transfer site

**Expected**
* No wpcom themes should appear in the top (_Uploaded Themes_) list
* Activating a wpcom theme from the bottom list should not move it up to the top
* Installing a child theme, such as _Sidekick_ should still work correctly

**Note** Some premium themes will appear in the top list for AT sites until Jetpack 4.7 is released.
