### PR TITLE
Site Settings: Bring back missing discussion fields

### DIFF
--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -565,6 +565,7 @@ const getFormSettings = settings => {
 		'comment_order',
 		'comments_notify',
 		'moderation_notify',
+		'likes',
 		'social_notifications_like',
 		'social_notifications_reblog',
 		'social_notifications_subscribe',
@@ -578,6 +579,9 @@ const getFormSettings = settings => {
 		'markdown_supported',
 		'highlander_comment_form_prompt',
 		'jetpack_comment_form_color_scheme',
+		'subscriptions',
+		'stb_enabled',
+		'stc_enabled',
 	] );
 };
 


### PR DESCRIPTION
It appears that in https://github.com/Automattic/wp-calypso/commit/85afdd55c757231fa40a3460e1f59acb82ff5c85 some of the necessary fields have been removed from the Discussion form (probably by accident). These are necessary for the Likes and Subscriptions settings to work properly. Without them, the fields within the Subscriptions card will not be able to obtain their current value, and the Likes settings will not be saved. This PR brings the missing fields back. 

To test:
* Checkout this branch
* Go to `/settings/discussion/$site` where `$site` is a Jetpack site.
* Enable the Subscriptions module in wp-admin and enable its sub-settings.
* Verify the Subscriptions card loads all values properly.

/cc @ryelle as she worked on this one.