### PR TITLE
Media Library: improve uploading by URL section

### DIFF
--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -94,6 +94,14 @@
 	}
 }
 
+.media-library__header.media-library__upload-url {
+	padding: 6px 12px;
+	background-color: $white;
+	box-sizing: border-box;
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		0 1px 2px lighten( $gray, 30% );
+}
+
 .media-library__upload-buttons {
 	display: inline;
 }

--- a/client/my-sites/media-library/upload-url.jsx
+++ b/client/my-sites/media-library/upload-url.jsx
@@ -60,6 +60,10 @@ class MediaLibraryUploadUrl extends Component {
 	};
 
 	onKeyDown = event => {
+		if ( event.key === 'Escape' ) {
+			return this.props.onClose( event );
+		}
+
 		if ( event.key !== 'Enter' ) {
 			return;
 		}
@@ -82,6 +86,7 @@ class MediaLibraryUploadUrl extends Component {
 					isError={ this.state.isError }
 					autoFocus
 					required />
+
 				<div className="media-library__upload-url-button-group">
 					<button type="submit" className="button is-primary">
 						{ translate( 'Upload', { context: 'verb' } ) }

--- a/client/my-sites/media-library/upload-url.jsx
+++ b/client/my-sites/media-library/upload-url.jsx
@@ -38,6 +38,7 @@ class MediaLibraryUploadUrl extends Component {
 		this.setState( { isError } );
 
 		if ( isError || ! this.props.site ) {
+			event.preventDefault();
 			return;
 		}
 
@@ -76,7 +77,7 @@ class MediaLibraryUploadUrl extends Component {
 		const { onClose, translate } = this.props;
 
 		return (
-			<form className={ classes } onSubmit={ this.upload }>
+			<form className={ classes } onSubmit={ this.upload } noValidate>
 				<FormTextInput
 					type="url"
 					value={ this.state.value }


### PR DESCRIPTION
### IMPORTANT
This PR is part of a set of PRs. Take a look to https://github.com/Automattic/wp-calypso/issues/11804, Pull requests section, to know to right order to review.

This PR is targeting to `try/media-section-v2`.

---------

This PR implements some improvements in the uploading input field by URL of the media file:

* Tweak styles in the uploading files by URL field. It fixes #11804 
* Allows close/cancel the uploading field by pressing ESC key (5d1a2e22d29261ef8aa9a97987b120c5b4d7a97f)
* Disable native validation: TBD 665219c90f979780627ae1815ed8914810c17f55

![uploading-by-url](https://cloud.githubusercontent.com/assets/77539/23656476/a32c302e-0318-11e7-8e21-3101c04d1cd6.gif)

--------
### Testing

1) Go to the media library section: `http://calypso.localhost:3000/media/<site>`
2) Open the `Add by URL` option
<img src="https://cloud.githubusercontent.com/assets/77539/23656276/c6b452ca-0317-11e7-8429-de4c95696e2d.png" width="300px" />

3) Try to upload a valid file, an invalid one, passing an invalid URL (404), passing a value non-URL.