### PR TITLE
Themes: Show theme details when a wpcom theme is uploaded

### DIFF
--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -20,7 +20,7 @@ import EmptyContent from 'components/empty-content';
 import ProgressBar from 'components/progress-bar';
 import Button from 'components/button';
 import ThanksModal from 'my-sites/themes/thanks-modal';
-import QueryTheme from 'components/data/query-theme';
+import QueryCanonicalTheme from 'components/data/query-canonical-theme';
 // Necessary for ThanksModal
 import QueryActiveTheme from 'components/data/query-active-theme';
 import { localize } from 'i18n-calypso';
@@ -43,7 +43,7 @@ import {
 	getUploadProgressLoaded,
 	isInstallInProgress,
 } from 'state/themes/upload-theme/selectors';
-import { getTheme } from 'state/themes/selectors';
+import { getCanonicalTheme } from 'state/themes/selectors';
 import { connectOptions } from 'my-sites/themes/theme-options';
 import EligibilityWarnings from 'blocks/eligibility-warnings';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
@@ -321,7 +321,7 @@ class Upload extends React.Component {
 			<Main>
 				<QueryEligibility siteId={ siteId } />
 				<QueryActiveTheme siteId={ siteId } />
-				{ themeId && complete && <QueryTheme siteId={ siteId } themeId={ themeId } /> }
+				{ themeId && complete && <QueryCanonicalTheme siteId={ siteId } themeId={ themeId } /> }
 				<ThanksModal
 					site={ selectedSite }
 					source="upload" />
@@ -380,7 +380,7 @@ export default connect(
 			failed: hasUploadFailed( state, siteId ),
 			themeId,
 			isMultisite: isJetpackSiteMultiSite( state, siteId ),
-			uploadedTheme: getTheme( state, siteId, themeId ),
+			uploadedTheme: getCanonicalTheme( state, siteId, themeId ),
 			error: getUploadError( state, siteId ),
 			progressTotal: getUploadProgressTotal( state, siteId ),
 			progressLoaded: getUploadProgressLoaded( state, siteId ),

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -279,7 +279,7 @@ class Upload extends React.Component {
 				actionURL={ this.props.selectedSite.options.admin_url }
 				illustration={ '/calypso/images/drake/drake-jetpack.svg' }
 			/>
-			);
+		);
 	}
 
 	renderNotAvailable() {
@@ -291,7 +291,7 @@ class Upload extends React.Component {
 				actionURL={ this.props.backPath }
 				illustration={ '/calypso/images/drake/drake-whoops.svg' }
 			/>
-			);
+		);
 	}
 
 	render() {

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -130,6 +130,7 @@ class Upload extends React.Component {
 
 		const errorCauses = {
 			exists: translate( 'Upload problem: Theme already installed on site.' ),
+			already_installed: translate( 'Upload problem: Theme already installed on site.' ),
 			'Too Large': translate( 'Upload problem: Zip file too large to upload.' ),
 			incompatible: translate( 'Upload problem: Incompatible theme.' ),
 		};

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -44,6 +44,7 @@ export const getTheme = createSelector(
 		if ( ! manager ) {
 			return null;
 		}
+
 		return manager.getItem( themeId );
 	},
 	( state ) => state.themes.queries

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -44,7 +44,6 @@ export const getTheme = createSelector(
 		if ( ! manager ) {
 			return null;
 		}
-
 		return manager.getItem( themeId );
 	},
 	( state ) => state.themes.queries

--- a/client/state/themes/upload-theme/selectors.js
+++ b/client/state/themes/upload-theme/selectors.js
@@ -47,7 +47,11 @@ export function hasUploadFailed( state, siteId ) {
  * @return {?Object} -- Uploaded theme ID
  */
 export function getUploadedThemeId( state, siteId ) {
-	return get( state.themes.uploadTheme.uploadedThemeId, siteId );
+	const themeId = get( state.themes.uploadTheme.uploadedThemeId, siteId );
+	if ( themeId ) {
+		return themeId.replace( /-wpcom$/, '' );
+	}
+	return null;
 }
 
 /**

--- a/client/state/themes/upload-theme/selectors.js
+++ b/client/state/themes/upload-theme/selectors.js
@@ -44,10 +44,13 @@ export function hasUploadFailed( state, siteId ) {
  *
  * @param {Object} state -- Global state tree
  * @param {Number} siteId -- Site ID
- * @return {?Object} -- Uploaded theme ID
+ * @return {?string} -- Uploaded theme ID
  */
 export function getUploadedThemeId( state, siteId ) {
 	const themeId = get( state.themes.uploadTheme.uploadedThemeId, siteId );
+	// When wpcom themes are uploaded, we will not be able to retrieve details
+	// from the site, since we filter out all wpcom themes. Remove the suffix
+	// so we can use details from wpcom.
 	if ( themeId ) {
 		return themeId.replace( /-wpcom$/, '' );
 	}


### PR DESCRIPTION
Fix a problem with showing the theme screenshot and details after the upload of a theme that has been downloaded from wpcom.

This is a strange use case but we should handle it properly.

**To Test**
* Download [a theme](https://public-api.wordpress.com/rest/v1/themes/download/lodestar.zip) from wpcom 
* Go to http://calypso.localhost:3000/design/upload and upload the theme

**Expected**
* Theme details with screenshot should show after upload is complete
* _try&customize_ and _activate_ buttons should work
