### PR TITLE
Media Library: fix elevation visual bug in search icon

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -189,6 +189,9 @@ $z-layers: (
 		'.media-library__list-item-spinner': 20,
 		'.media-library__list-item-edit': 20
 	),
+	'.media-library .section-nav': (
+		'.search.is-expanded-to-container': 1,
+	),
 	'.dialog__backdrop': (
 		'.editor-media-modal .section-nav': 10,
 		'.editor-media-modal .notice': 10,

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -53,6 +53,9 @@
 
 	.section-nav {
 		flex: 1 auto;
+		.search {
+			z-index: z-index( '.media-library .section-nav', '.search.is-expanded-to-container' );
+		}
 	}
 
 	.plan-storage {


### PR DESCRIPTION
### IMPORTANT

* This PR is targeting to `try/media-section-v2`.
* This PR fixes #11804 bug. 

------------

<img src="https://cloud.githubusercontent.com/assets/77539/23663329/059d3e8e-0331-11e7-9183-fca2059b865d.gif" width="800px" />

### Testing:

1) Go to the Media Library: `http://calypso.localhost:3000/media/<site>`. You should have enough media files to be able to make scrolling up on the media page.
2) Pay attention to the overlapping of the `search-icon` and the `plan-storage` components with the filters bar of the media library.