### PR TITLE
Domains: Remove references to primary domain for domain-only sites

### DIFF
--- a/client/my-sites/upgrades/domain-management/components/domain/primary-flag.jsx
+++ b/client/my-sites/upgrades/domain-management/components/domain/primary-flag.jsx
@@ -1,27 +1,39 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import { connect } from 'react-redux';
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies
  */
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isDomainOnlySite } from 'state/selectors';
+import { localize } from 'i18n-calypso';
 import Notice from 'components/notice';
 
-const DomainPrimaryFlag = React.createClass( {
-	propTypes: {
-		domain: React.PropTypes.object.isRequired
-	},
-
+class DomainPrimaryFlag extends Component {
 	render() {
-		if ( this.props.domain.isPrimary ) {
+		const { isDomainOnly, domain, translate } = this.props;
+
+		if ( domain.isPrimary && ! isDomainOnly ) {
 			return (
-				<Notice isCompact status="is-success">{ this.translate( 'Primary Domain' ) }</Notice>
+				<Notice isCompact status="is-success">{ translate( 'Primary Domain' ) }</Notice>
 			);
 		}
 
 		return null;
 	}
-} );
+}
 
-module.exports = DomainPrimaryFlag;
+DomainPrimaryFlag.propTypes = {
+	domain: React.PropTypes.object.isRequired,
+	isDomainOnly: React.PropTypes.bool,
+	translate: React.PropTypes.func.isRequired,
+};
+
+export default connect( ( state ) => {
+	return {
+		isDomainOnly: isDomainOnlySite( state, getSelectedSiteId( state ) )
+	};
+} )( localize( DomainPrimaryFlag ) );

--- a/client/my-sites/upgrades/domain-management/edit/card/header/index.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/card/header/index.jsx
@@ -2,17 +2,20 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import DomainPrimaryFlag from 'my-sites/upgrades/domain-management/components/domain/primary-flag';
+import { isDomainOnlySite } from 'state/selectors';
 import PrimaryDomainButton from './primary-domain-button';
 import SectionHeader from 'components/section-header';
 
 const Header = React.createClass( {
 	propTypes: {
 		domain: React.PropTypes.object.isRequired,
+		isDomainOnly: React.PropTypes.bool,
 		selectedSite: React.PropTypes.oneOfType( [
 			React.PropTypes.object,
 			React.PropTypes.bool
@@ -21,16 +24,15 @@ const Header = React.createClass( {
 	},
 
 	render() {
-		const domain = this.props.domain;
+		const { domain, isDomainOnly } = this.props;
 
-		if ( ! domain ) {
+		if ( ! domain || isDomainOnly ) {
 			return null;
 		}
 
 		return (
 			<SectionHeader label={ domain.name }>
-				<DomainPrimaryFlag
-					domain={ domain } />
+				<DomainPrimaryFlag domain={ domain } />
 
 				{ this.props.selectedSite && ! this.props.selectedSite.jetpack &&
 				<PrimaryDomainButton
@@ -42,4 +44,8 @@ const Header = React.createClass( {
 	}
 } );
 
-export default Header;
+export default connect( ( state, ownProps ) => {
+	return {
+		isDomainOnly: isDomainOnlySite( state, ownProps.selectedSite.ID )
+	};
+} )( Header );

--- a/client/my-sites/upgrades/domain-management/edit/card/header/index.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/card/header/index.jsx
@@ -2,20 +2,17 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import DomainPrimaryFlag from 'my-sites/upgrades/domain-management/components/domain/primary-flag';
-import { isDomainOnlySite } from 'state/selectors';
 import PrimaryDomainButton from './primary-domain-button';
 import SectionHeader from 'components/section-header';
 
 const Header = React.createClass( {
 	propTypes: {
 		domain: React.PropTypes.object.isRequired,
-		isDomainOnly: React.PropTypes.bool,
 		selectedSite: React.PropTypes.oneOfType( [
 			React.PropTypes.object,
 			React.PropTypes.bool
@@ -24,9 +21,9 @@ const Header = React.createClass( {
 	},
 
 	render() {
-		const { domain, isDomainOnly } = this.props;
+		const { domain } = this.props;
 
-		if ( ! domain || isDomainOnly ) {
+		if ( ! domain ) {
 			return null;
 		}
 
@@ -44,8 +41,4 @@ const Header = React.createClass( {
 	}
 } );
 
-export default connect( ( state, ownProps ) => {
-	return {
-		isDomainOnly: isDomainOnlySite( state, ownProps.selectedSite.ID )
-	};
-} )( Header );
+export default Header;

--- a/client/my-sites/upgrades/domain-management/list/test/index.js
+++ b/client/my-sites/upgrades/domain-management/list/test/index.js
@@ -4,10 +4,12 @@
 import deepFreeze from 'deep-freeze';
 import assert from 'assert';
 import { noop } from 'lodash';
+import { Provider as ReduxProvider } from 'react-redux';
 
 /**
  * Internal dependencies
  */
+import { createReduxStore } from 'state';
 import EmptyComponent from 'test/helpers/react/empty-component';
 import useFakeDom from 'test/helpers/use-fake-dom';
 import useMockery from 'test/helpers/use-mockery';
@@ -87,12 +89,17 @@ describe( 'index', function() {
 	} );
 
 	function renderWithProps( props = defaultProps ) {
-		return ReactDom.render(
-			<DomainList
-				{ ...props }
-			/>,
+		const store = createReduxStore(),
+			dom = ReactDom.render(
+			<ReduxProvider store={ store }>
+				<DomainList
+					{ ...props }
+				/>
+			</ReduxProvider>,
 			useFakeDom.getContainer()
 		);
+
+		return TestUtils.scryRenderedComponentsWithType( dom, DomainList )[ 0 ];
 	}
 
 	describe( 'regular cases', function() {


### PR DESCRIPTION
Remove `Primary Domain` header in domain management for domain only sites.

Fixes: https://github.com/Automattic/wp-calypso/issues/11813

Before:
![before](https://cloud.githubusercontent.com/assets/1103398/23664166/1b0f64d0-0355-11e7-8d1d-8be6938788ea.png)

After:
![after](https://cloud.githubusercontent.com/assets/1103398/23702888/8b631666-03fd-11e7-8ac1-3b3ce20763e1.png)

* [x] Code
* [x] Product
