### PR TITLE
Press This: replacing noticon with Gridicon

### DIFF
--- a/client/my-sites/site-settings/press-this/index.jsx
+++ b/client/my-sites/site-settings/press-this/index.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Card from 'components/card';
+import Gridicon from 'gridicons';
 import PressThisLink from './link';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { getSelectedSite } from 'state/ui/selectors';
@@ -53,7 +54,7 @@ class PressThis extends Component {
 							site={ site }
 							onClick={ this.recordEvent( 'Clicked Press This Button' ) }
 							onDragStart={ this.recordEvent( 'Dragged Press This Button' ) }>
-							<span className="noticon noticon-pinned"></span>
+							<Gridicon icon="create" />
 							<span>{ translate( 'Press This', { context: 'name of browser bookmarklet tool' } ) }</span>
 						</PressThisLink>
 					</p>

--- a/client/my-sites/site-settings/press-this/style.scss
+++ b/client/my-sites/site-settings/press-this/style.scss
@@ -11,18 +11,20 @@
 		a:hover,
 		a:focus,
 		a:active {
+			display: inline-flex;
+			align-items: center;
 			cursor: move;
 			padding: 10px;
 			font-style: normal;
-			line-height: 16px;
 			font-size: 14px;
 			text-decoration: none;
+			color: $gray-dark;
 			background: lighten( $gray, 30% );
 			border-radius: 3px;
 			border: 1px solid lighten( $gray, 20% );
 		}
 
-			display: inline-block;
+		a .gridicon {
 			margin: 0 10px 0 0;
 		}
 	}

--- a/client/my-sites/site-settings/press-this/style.scss
+++ b/client/my-sites/site-settings/press-this/style.scss
@@ -11,29 +11,19 @@
 		a:hover,
 		a:focus,
 		a:active {
-			display: inline-block;
-			position: relative;
 			cursor: move;
 			padding: 10px;
 			font-style: normal;
 			line-height: 16px;
 			font-size: 14px;
 			text-decoration: none;
-			color: #333;
 			background: lighten( $gray, 30% );
 			border-radius: 3px;
 			border: 1px solid lighten( $gray, 20% );
 		}
 
-		a span {
 			display: inline-block;
 			margin: 0 10px 0 0;
-			font-family: $sans;
-
-			&:before {
-				color: #777;
-				font-family: Noticons;
-			}
 		}
 	}
 }


### PR DESCRIPTION
This replaces the noticon with a Gridicon. I used flex box to get everything centered. I also replaced a hex value with a variable.

Before:

![screen shot 2017-03-07 at 10 16 35 am](https://cloud.githubusercontent.com/assets/618551/23666431/9f323fa6-0320-11e7-9753-d7b495b9493f.png)

After:

![screen shot 2017-03-07 at 10 16 21 am](https://cloud.githubusercontent.com/assets/618551/23666441/a79915fc-0320-11e7-9489-7d04364c9757.png)