### PR TITLE
Themes: Fix actions from uploaded theme confirmation

### DIFF
--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -227,12 +227,12 @@ class Upload extends React.Component {
 
 	onActivateClick = () => {
 		const { activate } = this.props.options;
-		activate.action( this.props.uploadedTheme );
+		activate.action( this.props.themeId );
 	};
 
 	onTryAndCustomizeClick = () => {
 		const { tryandcustomize } = this.props.options;
-		tryandcustomize.action( this.props.uploadedTheme );
+		tryandcustomize.action( this.props.themeId );
 	}
 
 	renderTheme() {


### PR DESCRIPTION
Activate and Try&Customize button were broken by #10434.

Fix by passing themeId instead of theme object.

**To Test**
* Upload a theme to a jetpack site from http://calypso.localhost:3000/design/upload/
* Check that _Activate_ and _Try&Cutomize_ buttons work after upload has completed
