### PR TITLE
Enable themes upload on Jetpack in Production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -52,6 +52,7 @@
 		"manage/themes": true,
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
+		"manage/themes/details/jetpack": true,
 		"manage/themes/logged-out": true,
 		"manage/themes/upload": true,
 		"me/account": true,

--- a/config/production.json
+++ b/config/production.json
@@ -53,6 +53,7 @@
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/logged-out": true,
+		"manage/themes/upload": true,
 		"me/account": true,
 		"me/find-friends": false,
 		"me/my-profile": true,


### PR DESCRIPTION
### Info 
This PR enables theme upload for Jetpack sites and allows activation of WP.com themes on Jetpack site directly from Calypso.
Jetpack >= 4.4.2 is required.

This changes the `/design` page for Jetpack sites. There are now two themes list: one with Uploaded Themes and 
