### PR TITLE
Site Settings: Add markdown module toggle for Jetpack sites to composing writing settings

### DIFF
--- a/client/my-sites/site-settings/composing/after-the-deadline.jsx
+++ b/client/my-sites/site-settings/composing/after-the-deadline.jsx
@@ -179,7 +179,7 @@ class AfterTheDeadline extends Component {
 		} = this.props;
 
 		return (
-			<FormFieldset>
+			<FormFieldset className="site-settings__has-divider is-top-only">
 				<QueryJetpackConnection siteId={ selectedSiteId } />
 
 				<div className="composing__info-link-container site-settings__info-link-container">

--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
  */
 import Card from 'components/card';
 import DefaultPostFormat from './default-post-format';
+import JetpackMarkdown from './jetpack-markdown';
 import AfterTheDeadline from './after-the-deadline';
 import { isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -36,7 +37,7 @@ const Composing = ( {
 			{
 				siteIsJetpack && jetpackSettingsUISupported && (
 					<div>
-						<hr />
+						<JetpackMarkdown />
 						<AfterTheDeadline
 							handleToggle={ handleToggle }
 							setFieldValue={ setFieldValue }

--- a/client/my-sites/site-settings/composing/jetpack-markdown.jsx
+++ b/client/my-sites/site-settings/composing/jetpack-markdown.jsx
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import ExternalLink from 'components/external-link';
+import FormFieldset from 'components/forms/form-fieldset';
+import InfoPopover from 'components/info-popover';
+import JetpackModuleToggle from '../jetpack-module-toggle';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+const JetpackMarkdown = ( {
+	selectedSiteId,
+	translate
+} ) => {
+	return (
+		<FormFieldset className="composing__form-fieldset site-settings__has-divider is-top-only">
+			<div className="composing__info-link-container site-settings__info-link-container">
+				<InfoPopover position={ 'left' }>
+					<ExternalLink href={ 'https://jetpack.com/support/markdown/' } target="_blank">
+						{ translate( 'Learn more about Markdown.' ) }
+					</ExternalLink>
+				</InfoPopover>
+			</div>
+			<JetpackModuleToggle
+				siteId={ selectedSiteId }
+				moduleSlug="markdown"
+				label={ translate( 'Write posts or pages in plain text Markdown syntax' ) }
+				/>
+		</FormFieldset>
+	);
+};
+
+export default connect(
+	( state ) => {
+		return {
+			selectedSiteId: getSelectedSiteId( state )
+		};
+	}
+)( localize( JetpackMarkdown ) );


### PR DESCRIPTION
Part of #11676 

Adds a toggle for activating/deactivating the **Markdown** module on a Jetpack site to the Writing tab in Site Settings.

#### Testing instructions

1. Clone this branch or test the [live branch](https://calypso.live/settings/writing?branch=add/markdown-to-composing-writing-settings).
1. Visit `/settings/writing/site-slug` were `site-slug` is one of your connected Jetpack sites
1. Confirm that you see the Markdown Toggle and toggle it.
1. Refresh the browser and check that the update is kept.

#### Screenshot

![image](https://cloud.githubusercontent.com/assets/746152/23669523/3c7e6aba-0343-11e7-8142-79ebcc5a5c77.png)


**Gif**

![markdown-toggle](https://cloud.githubusercontent.com/assets/746152/23668855/1f42aeb8-0341-11e7-87ff-513b5b709168.gif)


