### PR TITLE
Components: remove noticons from VerticalNav

### DIFF
--- a/client/components/vertical-nav/item/index.jsx
+++ b/client/components/vertical-nav/item/index.jsx
@@ -8,6 +8,7 @@ import noop from 'lodash/noop';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
+import Gridicon from 'gridicons';
 
 const VerticalNavItem = React.createClass( {
 	propTypes: {
@@ -54,10 +55,10 @@ const VerticalNavItem = React.createClass( {
 
 	getIcon() {
 		if ( this.props.external ) {
-			return <span className="noticon noticon-external"></span>;
+			return <Gridicon icon="external" />;
 		}
 
-		return <span className="noticon noticon-collapse"></span>;
+		return <Gridicon icon="chevron-right" />;
 	}
 } );
 

--- a/client/components/vertical-nav/item/style.scss
+++ b/client/components/vertical-nav/item/style.scss
@@ -1,19 +1,12 @@
 .vertical-nav-item {
-	.noticon {
+	.gridicon {
 		box-sizing: border-box;
-		color: $gray;
-		font-size: 20px;
+		color: lighten( $gray, 10% );
+		display: block;
 		height: 100%;
-		padding-left: 3px;
-		padding-top: 20px;
 		position: absolute;
 			top: 0;
-			right: 0;
-		width: 55px;
-	}
-
-	.noticon-collapse {
-		transform: rotate( 90deg );
+			right: 16px;
 	}
 }
 


### PR DESCRIPTION
Updates the VerticalNav component to use Gridicons. 

To test:

- go to https://wordpress.com/domains
- select a site with a custom domain
- click on both the custom domain and the free domain to see the screens in the screenshots below

I don't know every place VerticalNav is used, so please help test more areas if you know of any.

Before:

![screen shot 2017-03-07 at 11 29 29 am](https://cloud.githubusercontent.com/assets/618551/23669349/6c3baee4-0329-11e7-99c9-66689674cc05.png)
![screen shot 2017-03-07 at 11 29 08 am](https://cloud.githubusercontent.com/assets/618551/23669350/6c41c90a-0329-11e7-95d6-a018c1bb6f74.png)

After:

![screen shot 2017-03-07 at 11 28 44 am](https://cloud.githubusercontent.com/assets/618551/23669358/72a58318-0329-11e7-9d73-653fbad59d31.png)
![screen shot 2017-03-07 at 11 28 36 am](https://cloud.githubusercontent.com/assets/618551/23669357/72a30458-0329-11e7-9bfc-35484ea3d1c8.png)