### PR TITLE
Components: remove noticons from FormRange

### DIFF
--- a/client/components/forms/range/README.md
+++ b/client/components/forms/range/README.md
@@ -11,8 +11,8 @@ Refer to the following code snippet for a typical usage example:
 
 ```jsx
 <Range
-	minContent={ <span className="noticon noticon-minus" /> }
-	maxContent={ <span className="noticon noticon-plus" /> }
+	minContent={ <Gridicon icon="minus-small" /> }
+	maxContent={ <Gridicon icon="plus-small" /> }
 	max="100"
 	value={ this.state.rangeValue }
 	onChange={ this.onChange }

--- a/client/components/forms/range/docs/example.jsx
+++ b/client/components/forms/range/docs/example.jsx
@@ -8,6 +8,7 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var FormRange = require( 'components/forms/range' );
+var Gridicon = require( 'gridicons' );
 
 module.exports = React.createClass( {
 	displayName: 'Ranges',
@@ -29,8 +30,8 @@ module.exports = React.createClass( {
 	render: function() {
 		return (
 			<FormRange
-				minContent={ <span className="noticon noticon-minus" /> }
-				maxContent={ <span className="noticon noticon-plus" /> }
+				minContent={ <Gridicon icon="minus-small" /> }
+				maxContent={ <Gridicon icon="plus-small" /> }
 				max="100"
 				value={ this.state.rangeValue }
 				onChange={ this.onChange }

--- a/client/components/forms/range/test/index.jsx
+++ b/client/components/forms/range/test/index.jsx
@@ -10,6 +10,7 @@ var expect = require( 'chai' ).expect,
  * Internal dependencies
  */
 var FormRange = require( '../' );
+var Gridicon = require( 'gridicons' );
 
 describe( 'index', function() {
 	require( 'test/helpers/use-fake-dom' )();
@@ -18,12 +19,12 @@ describe( 'index', function() {
 	} );
 
 	it( 'should render beginning content if passed a `minContent` prop', function() {
-		var range = TestUtils.renderIntoDocument( <FormRange minContent={ <span className="noticon noticon-minus" /> } /> );
-		TestUtils.findRenderedDOMComponentWithClass( range, 'noticon-minus' );
+		var range = TestUtils.renderIntoDocument( <FormRange minContent={ <Gridicon icon="minus-small" /> } /> );
+		TestUtils.findRenderedDOMComponentWithClass( range, 'gridicons-minus-small' );
 	} );
 
 	it( 'should not render ending content if not passed a `maxContent` prop', function() {
-		var range = TestUtils.renderIntoDocument( <FormRange minContent={ <span className="noticon noticon-minus" /> } /> ),
+		var range = TestUtils.renderIntoDocument( <FormRange minContent={ <Gridicon icon="minus-small" /> } /> ),
 			content = TestUtils.scryRenderedDOMComponentsWithClass( range, 'range__content' );
 
 		expect( content ).to.have.length( 1 );
@@ -31,12 +32,12 @@ describe( 'index', function() {
 	} );
 
 	it( 'should render ending content if passed a `maxContent` prop', function() {
-		var range = TestUtils.renderIntoDocument( <FormRange maxContent={ <span className="noticon noticon-plus" /> } /> );
-		TestUtils.findRenderedDOMComponentWithClass( range, 'noticon-plus' );
+		var range = TestUtils.renderIntoDocument( <FormRange maxContent={ <Gridicon icon="plus-small" /> } /> );
+		TestUtils.findRenderedDOMComponentWithClass( range, 'gridicons-plus-small' );
 	} );
 
 	it( 'should not render beginning content if not passed a `minContent` prop', function() {
-		var range = TestUtils.renderIntoDocument( <FormRange maxContent={ <span className="noticon noticon-plus" /> } /> ),
+		var range = TestUtils.renderIntoDocument( <FormRange maxContent={ <Gridicon icon="plus-small" /> } /> ),
 			content = TestUtils.scryRenderedDOMComponentsWithClass( range, 'range__content' );
 
 		expect( content ).to.have.length( 1 );


### PR DESCRIPTION
Updates the FormRange component to use Gridicons.

The only place where FormRange is used is the media library, and this PR has no affect.

To test, check out devdocs and make sure everything is working correctly.

https://wpcalypso.wordpress.com/devdocs/design/ranges

Before:

![screen shot 2017-03-07 at 11 51 20 am](https://cloud.githubusercontent.com/assets/618551/23670285/d94209c2-032c-11e7-891b-fe6d3d481ea8.png)


After:

![screen shot 2017-03-07 at 11 50 37 am](https://cloud.githubusercontent.com/assets/618551/23670294/df231124-032c-11e7-9469-9e2fbb7c3491.png)