### PR TITLE
Don't query themes when query was already done.

### DIFF
--- a/client/components/data/query-themes/index.jsx
+++ b/client/components/data/query-themes/index.jsx
@@ -9,7 +9,7 @@ import { isEqual } from 'lodash';
  * Internal dependencies
  */
 import { requestThemes } from 'state/themes/actions';
-import { isRequestingThemesForQuery, getThemesFoundForQuery } from 'state/themes/selectors';
+import { isRequestingThemesForQuery, wasQuerySuccesfullyRequested } from 'state/themes/selectors';
 
 class QueryThemes extends Component {
 	static propTypes = {
@@ -34,6 +34,7 @@ class QueryThemes extends Component {
 		// Connected props
 		isRequesting: PropTypes.bool.isRequired,
 		requestThemes: PropTypes.func.isRequired,
+		hasQuery: PropTypes.bool
 	}
 
 	componentDidMount() {
@@ -50,7 +51,7 @@ class QueryThemes extends Component {
 	}
 
 	request() {
-		if ( ! this.props.isRequesting && ( this.props.themesCount === null ) ) {
+		if ( ! this.props.isRequesting && ! this.props.hasQuery ) {
 			this.props.requestThemes( this.props.siteId, this.props.query );
 		}
 	}
@@ -62,7 +63,7 @@ class QueryThemes extends Component {
 
 export default connect(
 	( state, { query, siteId } ) => ( {
-		themesCount: getThemesFoundForQuery( state, siteId, query ),
+		hasQuery: wasQuerySuccesfullyRequested( state, siteId, query ),
 		isRequesting: isRequestingThemesForQuery( state, siteId, query ),
 	} ),
 	{ requestThemes }

--- a/client/components/data/query-themes/index.jsx
+++ b/client/components/data/query-themes/index.jsx
@@ -9,7 +9,7 @@ import { isEqual } from 'lodash';
  * Internal dependencies
  */
 import { requestThemes } from 'state/themes/actions';
-import { isRequestingThemesForQuery } from 'state/themes/selectors';
+import { isRequestingThemesForQuery, getThemesFoundForQuery } from 'state/themes/selectors';
 
 class QueryThemes extends Component {
 	static propTypes = {
@@ -50,7 +50,7 @@ class QueryThemes extends Component {
 	}
 
 	request() {
-		if ( ! this.props.isRequesting ) {
+		if ( ! this.props.isRequesting && ( this.props.themesCount === null ) ) {
 			this.props.requestThemes( this.props.siteId, this.props.query );
 		}
 	}
@@ -62,6 +62,7 @@ class QueryThemes extends Component {
 
 export default connect(
 	( state, { query, siteId } ) => ( {
+		themesCount: getThemesFoundForQuery( state, siteId, query ),
 		isRequesting: isRequestingThemesForQuery( state, siteId, query ),
 	} ),
 	{ requestThemes }

--- a/client/lib/query-manager/theme/constants.js
+++ b/client/lib/query-manager/theme/constants.js
@@ -6,3 +6,9 @@ export const DEFAULT_THEME_QUERY = {
 	offset: 0,
 	page: 1
 };
+
+export const PAGINATION_QUERY_KEYS = [
+	'number',
+	'offset',
+	'page'
+];

--- a/client/lib/query-manager/theme/index.js
+++ b/client/lib/query-manager/theme/index.js
@@ -1,14 +1,103 @@
+import { uniq, omit, reduce, isEqual, map, without } from 'lodash';
+
 /**
  * Internal dependencies
  */
 import PaginatedQueryManager from '../paginated';
 import ThemeQueryKey from './key';
-import { DEFAULT_THEME_QUERY } from './constants';
+import { DEFAULT_THEME_QUERY, PAGINATION_QUERY_KEYS } from './constants';
 
 /**
  * ThemeQueryManager manages themes which can be queried
  */
 export default class ThemeQueryManager extends PaginatedQueryManager {
+
+	/**
+	 * Signal that an item(s) has been received for tracking. Optionally
+	 * specify that items received are intended for patch application, or that
+	 * they are associated with a query. This function does not mutate the
+	 * instance state. Instead, it returns a new instance of QueryManager if
+	 * the tracked items have been modified, or the current instance otherwise.
+	 *
+	 * @param  {(Array|Object)} items              Item(s) to be received
+	 * @param  {Object}         options            Options for receive
+	 * @param  {Boolean}        options.patch      Apply changes as partial
+	 * @param  {Object}         options.query      Query set to set or replace
+	 * @param  {Boolean}        options.mergeQuery Add to existing query set
+	 * @param  {Number}         options.found      Total found items for query
+	 * @return {QueryManager}                      New instance if changed, or
+	 *                                             same instance otherwise
+	 */
+	receive( items, options = {} ) {
+		// Coerce received single item to array
+		if ( ! Array.isArray( items ) ) {
+			items = [ items ];
+		}
+
+		// When tracking queries, remove pagination query arguments. These are
+		// simulated in `PaginatedQueryManager.prototype.getItems`.
+		let modifiedOptions = options;
+		if ( options.query ) {
+			modifiedOptions = Object.assign( options, {
+				query: omit( options.query, PAGINATION_QUERY_KEYS )
+			} );
+		}
+
+		const nextItems = reduce( items, ( memo, receivedItem ) => {
+			const receivedItemKey = receivedItem[ this.options.itemKey ];
+			const item = this.getItem( receivedItemKey );
+
+			if ( isEqual( receivedItem, item ) ) {
+				return memo;
+			}
+
+			memo[ receivedItemKey ] = receivedItem;
+			return memo;
+		}, this.data.items );
+
+		const receivedQueryKey = this.constructor.QueryKey.stringify( modifiedOptions.query );
+		const isNewlyReceivedQueryKey = ! this.data.queries[ receivedQueryKey ];
+		const receivedItemKeys = map( items, this.options.itemKey );
+		let nextQueries = this.data.queries;
+		let nextQueryReceivedItemKeys;
+
+		if ( isNewlyReceivedQueryKey ) {
+			nextQueryReceivedItemKeys = receivedItemKeys;
+		} else {
+			const mergedItemkeys = uniq( this.data.queries[ receivedQueryKey ].itemKeys.concat( receivedItemKeys ) );
+			// get rid of null
+			nextQueryReceivedItemKeys = without( mergedItemkeys, null );
+		}
+
+		const nextReceivedQuery = {};
+		nextReceivedQuery.itemKey = nextQueryReceivedItemKeys;
+		nextReceivedQuery.found = options.found;
+
+		nextQueries = Object.assign( {}, nextQueries, {
+			[ receivedQueryKey ]: nextReceivedQuery
+		} );
+
+		return new this.constructor(
+			Object.assign( {}, this.data, {
+				items: nextItems,
+				queries: nextQueries
+			} ),
+			this.options
+		);
+	}
+
+	getItemsIgnoringPage( query, includeFiller = false ) {
+		if ( ! query ) {
+			return null;
+		}
+
+		const items = super.getItems( omit( query, PAGINATION_QUERY_KEYS ) );
+		if ( ! items || includeFiller ) {
+			return items;
+		}
+
+		return items.filter( ( item ) => undefined !== item );
+	}
 
 	/**
 	 * A sorting function that defines the sort order of items under

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -25,7 +25,7 @@ import { getCurrentUserId } from 'state/current-user/selectors';
 import ThemePreview from './theme-preview';
 import config from 'config';
 
-const ThemesSearchCard = config.isEnabled( 'manage/themes/magic-search' )
+const ThemesSearchCard = false /*config.isEnabled( 'manage/themes/magic-search' )*/
 	? require( './themes-magic-search-card' )
 	: require( './themes-search-card' );
 

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -20,6 +20,7 @@ import {
 	getThemesForQueryIgnoringPage,
 	getThemesFoundForQuery,
 	isRequestingThemesForQuery,
+	getLastQueriedPageNumberForQuery,
 	isThemesLastPageForQuery,
 	isPremiumThemeAvailable,
 	isThemeActive,
@@ -107,7 +108,7 @@ const ThemesSelection = React.createClass( {
 			this.trackScrollPage();
 		}
 
-		this.props.incrementPage();
+		this.props.incrementPage( this.props.lastQueriedPage + 1 );
 	},
 
 	//intercept preview and add primary and secondary
@@ -202,6 +203,7 @@ const ConnectedThemesSelection = connect(
 			isRequesting: isRequestingThemesForQuery( state, sourceSiteId, query ),
 			isLastPage: isThemesLastPageForQuery( state, sourceSiteId, query ),
 			isLoggedIn: !! getCurrentUserId( state ),
+			lastQueriedPage: getLastQueriedPageNumberForQuery( state, sourceSiteId, query ),
 			isThemeActive: themeId => isThemeActive( state, themeId, siteId ),
 			isInstallingTheme: themeId => isInstallingTheme( state, themeId, siteId ),
 			// Note: This component assumes that purchase and plans data is already present in the state tree
@@ -225,8 +227,8 @@ class ThemesSelectionWithPage extends React.Component {
 		page: 1,
 	};
 
-	incrementPage = () => {
-		this.setState( { page: this.state.page + 1 } );
+	incrementPage = ( newPage ) => {
+		this.setState( { page: newPage } );
 	}
 
 	resetPage = () => {

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -276,6 +276,28 @@ export const queryRequestErrors = createReducer( {}, {
 } );
 
 /**
+ * Returns the updated query request success state after an action has been
+ * dispatched. The state reflects a mapping of site ID, query ID pairing to an
+ * object containing the queriess that reutrned successfully.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export const queryRequestSuccess = createReducer( {}, {
+	[ THEMES_REQUEST_SUCCESS ]: ( state, { siteId, query } ) => {
+		const serializedQuery = JSON.stringify( omit( query, 'page' ) );
+		return {
+			...state,
+			[ siteId ]: {
+				...state[ siteId ],
+				[ serializedQuery ]: query.page
+			}
+		};
+	},
+} );
+
+/**
  * Returns the updated theme query state after an action has been dispatched.
  * The state reflects a mapping of serialized query key to an array of theme IDs
  * for the query, if a query response was successfully received.
@@ -379,6 +401,7 @@ export default combineReducers( {
 	queries,
 	queryRequests,
 	queryRequestErrors,
+	queryRequestSuccess,
 	lastQuery,
 	themeInstalls,
 	themeRequests,

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -178,6 +178,19 @@ export function getThemesFoundForQuery( state, siteId, query ) {
 	return state.themes.queries[ siteId ].getFound( query );
 }
 
+export function getLastQueriedPageNumberForQuery( state, siteId, query ) {
+	if ( ! state.themes.queryRequestSuccess[ siteId ] ) {
+		return 0;
+	}
+	const serializedQuery = JSON.stringify( omit( query, 'page' ) );
+	return get( state.themes.queryRequestSuccess[ siteId ], serializedQuery, 0 );
+}
+
+export function wasQuerySuccesfullyRequested( state, siteId, query ) {
+	const lastQueriedPage = getLastQueriedPageNumberForQuery( state, siteId, query );
+	return query.page <= lastQueriedPage;
+}
+
 /**
  * Returns the last queryable page of themes for the given query, or null if the
  * total number of queryable themes if unknown.


### PR DESCRIPTION
### Info
This fix aims to optimize Themes Showcase experience. It is achieve by reusing queries. Right now we often query multiple times for the same search string, With this PR we first check if we have result for this query already available if so then we do not query again.

Work in progress. 