### PR TITLE
Revert #11437, stable module ids under webpack

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -34,8 +34,7 @@
       "version": "0.8.1"
     },
     "ajv": {
-      "version": "4.11.3",
-      "dev": true
+      "version": "4.11.4"
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -454,7 +453,7 @@
       "version": "2.11.0"
     },
     "body-parser": {
-      "version": "1.16.1",
+      "version": "1.17.1",
       "dependencies": {
         "debug": {
           "version": "2.6.1"
@@ -463,7 +462,7 @@
           "version": "0.7.2"
         },
         "qs": {
-          "version": "6.2.1"
+          "version": "6.4.0"
         }
       }
     },
@@ -537,10 +536,10 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000626"
+      "version": "1.0.30000632"
     },
     "caseless": {
-      "version": "0.11.0"
+      "version": "0.12.0"
     },
     "center-align": {
       "version": "0.1.3"
@@ -642,8 +641,7 @@
       "dev": true
     },
     "co": {
-      "version": "4.6.0",
-      "dev": true
+      "version": "4.6.0"
     },
     "code-point-at": {
       "version": "1.1.0"
@@ -936,7 +934,7 @@
       "version": "1.0.0"
     },
     "delegate": {
-      "version": "3.1.1"
+      "version": "3.1.2"
     },
     "delegates": {
       "version": "1.0.0"
@@ -1144,7 +1142,7 @@
       }
     },
     "error-ex": {
-      "version": "1.3.0"
+      "version": "1.3.1"
     },
     "es-abstract": {
       "version": "1.7.0",
@@ -1569,10 +1567,10 @@
       }
     },
     "for-in": {
-      "version": "0.1.6"
+      "version": "1.0.2"
     },
     "for-own": {
-      "version": "0.1.4"
+      "version": "0.1.5"
     },
     "foreach": {
       "version": "2.0.5"
@@ -1697,7 +1695,7 @@
       }
     },
     "good-listener": {
-      "version": "1.2.1"
+      "version": "1.2.2"
     },
     "got": {
       "version": "3.3.1",
@@ -1726,25 +1724,17 @@
       "version": "3.0.0",
       "dev": true
     },
+    "har-schema": {
+      "version": "1.0.5"
+    },
     "har-validator": {
-      "version": "2.0.6",
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3"
-        },
-        "commander": {
-          "version": "2.9.0"
-        },
-        "supports-color": {
-          "version": "2.0.0"
-        }
-      }
+      "version": "4.2.1"
     },
     "hard-source-webpack-plugin": {
       "version": "0.0.42",
       "dependencies": {
         "bluebird": {
-          "version": "3.4.7"
+          "version": "3.5.0"
         },
         "source-map": {
           "version": "0.5.6"
@@ -1835,7 +1825,7 @@
       "version": "1.7.0"
     },
     "http-errors": {
-      "version": "1.5.1",
+      "version": "1.6.1",
       "dependencies": {
         "inherits": {
           "version": "2.0.3"
@@ -2173,7 +2163,7 @@
       "version": "3.0.1"
     },
     "js-yaml": {
-      "version": "3.8.1",
+      "version": "3.8.2",
       "dev": true
     },
     "jsdom": {
@@ -2200,8 +2190,7 @@
       "version": "0.2.3"
     },
     "json-stable-stringify": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "json-stringify-safe": {
       "version": "5.0.1"
@@ -2226,8 +2215,7 @@
       }
     },
     "jsonify": {
-      "version": "0.0.0",
-      "dev": true
+      "version": "0.0.0"
     },
     "jsonparse": {
       "version": "0.0.5",
@@ -2314,7 +2302,7 @@
       }
     },
     "levelup": {
-      "version": "1.3.3"
+      "version": "1.3.5"
     },
     "levn": {
       "version": "0.3.0",
@@ -2411,7 +2399,7 @@
       "version": "1.6.0"
     },
     "lower-case": {
-      "version": "1.1.3"
+      "version": "1.1.4"
     },
     "lower-case-first": {
       "version": "1.0.2"
@@ -2600,13 +2588,13 @@
       "dev": true,
       "dependencies": {
         "qs": {
-          "version": "6.3.1",
+          "version": "6.4.0",
           "dev": true
         }
       }
     },
     "node-abi": {
-      "version": "1.3.3"
+      "version": "2.0.0"
     },
     "node-contains": {
       "version": "1.0.0"
@@ -2855,6 +2843,9 @@
       "version": "1.0.2",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.5"
+    },
     "path-to-regexp": {
       "version": "0.1.7"
     },
@@ -2866,6 +2857,9 @@
     },
     "percentage-regex": {
       "version": "3.0.0"
+    },
+    "performance-now": {
+      "version": "0.2.0"
     },
     "phone": {
       "version": "1.0.8",
@@ -2897,7 +2891,7 @@
       "dev": true
     },
     "postcss": {
-      "version": "5.2.15",
+      "version": "5.2.16",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
@@ -2939,7 +2933,7 @@
       "version": "3.3.0"
     },
     "prebuild-install": {
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "minimist": {
           "version": "1.2.0"
@@ -3246,10 +3240,10 @@
       "version": "2.0.1"
     },
     "request": {
-      "version": "2.79.0",
+      "version": "2.80.0",
       "dependencies": {
         "qs": {
-          "version": "6.3.1"
+          "version": "6.3.2"
         },
         "uuid": {
           "version": "3.0.1"
@@ -3279,7 +3273,7 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.2.0"
+      "version": "1.3.2"
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -3293,7 +3287,7 @@
       "version": "0.1.3"
     },
     "rimraf": {
-      "version": "2.6.0",
+      "version": "2.6.1",
       "dependencies": {
         "glob": {
           "version": "7.1.1"
@@ -3430,8 +3424,20 @@
           "version": "1.0.3",
           "dev": true
         },
+        "http-errors": {
+          "version": "1.5.1",
+          "dev": true
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "dev": true
+        },
         "negotiator": {
           "version": "0.6.1",
+          "dev": true
+        },
+        "setprototypeof": {
+          "version": "1.0.2",
           "dev": true
         }
       }
@@ -3466,7 +3472,7 @@
       "version": "1.0.5"
     },
     "setprototypeof": {
-      "version": "1.0.2"
+      "version": "1.0.3"
     },
     "sha.js": {
       "version": "2.2.6"
@@ -3601,7 +3607,7 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.10.2",
+      "version": "1.11.0",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0"
@@ -3735,7 +3741,7 @@
           "version": "1.0.0-rc4"
         },
         "qs": {
-          "version": "6.3.1"
+          "version": "6.4.0"
         },
         "readable-stream": {
           "version": "2.2.3"
@@ -4105,6 +4111,10 @@
           "version": "1.0.6",
           "dev": true
         },
+        "debug": {
+          "version": "2.6.1",
+          "dev": true
+        },
         "destroy": {
           "version": "1.0.4",
           "dev": true
@@ -4113,16 +4123,24 @@
           "version": "1.0.3",
           "dev": true
         },
+        "etag": {
+          "version": "1.8.0",
+          "dev": true
+        },
         "express": {
-          "version": "4.14.1",
+          "version": "4.15.2",
           "dev": true
         },
         "filesize": {
-          "version": "3.5.4",
+          "version": "3.5.6",
           "dev": true
         },
         "finalhandler": {
-          "version": "0.5.1",
+          "version": "1.0.0",
+          "dev": true
+        },
+        "fresh": {
+          "version": "0.5.0",
           "dev": true
         },
         "ipaddr.js": {
@@ -4150,7 +4168,7 @@
           "dev": true
         },
         "qs": {
-          "version": "6.2.0",
+          "version": "6.4.0",
           "dev": true
         },
         "range-parser": {
@@ -4158,11 +4176,11 @@
           "dev": true
         },
         "send": {
-          "version": "0.14.2",
+          "version": "0.15.1",
           "dev": true
         },
         "serve-static": {
-          "version": "1.11.2",
+          "version": "1.12.1",
           "dev": true
         },
         "supports-color": {
@@ -4238,7 +4256,7 @@
           "dev": true
         },
         "filesize": {
-          "version": "3.5.4",
+          "version": "3.5.6",
           "dev": true
         },
         "isarray": {
@@ -4335,7 +4353,7 @@
       "version": "0.1.9"
     },
     "whatwg-fetch": {
-      "version": "2.0.2"
+      "version": "2.0.3"
     },
     "whatwg-url": {
       "version": "3.1.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -454,7 +454,7 @@
       "version": "2.11.0"
     },
     "body-parser": {
-      "version": "1.17.0",
+      "version": "1.16.1",
       "dependencies": {
         "debug": {
           "version": "2.6.1"
@@ -463,7 +463,7 @@
           "version": "0.7.2"
         },
         "qs": {
-          "version": "6.3.1"
+          "version": "6.2.1"
         }
       }
     },
@@ -537,7 +537,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000631"
+      "version": "1.0.30000626"
     },
     "caseless": {
       "version": "0.11.0"
@@ -936,7 +936,7 @@
       "version": "1.0.0"
     },
     "delegate": {
-      "version": "3.1.2"
+      "version": "3.1.1"
     },
     "delegates": {
       "version": "1.0.0"
@@ -1569,10 +1569,10 @@
       }
     },
     "for-in": {
-      "version": "1.0.2"
+      "version": "0.1.6"
     },
     "for-own": {
-      "version": "0.1.5"
+      "version": "0.1.4"
     },
     "foreach": {
       "version": "2.0.5"
@@ -1697,7 +1697,7 @@
       }
     },
     "good-listener": {
-      "version": "1.2.2"
+      "version": "1.2.1"
     },
     "got": {
       "version": "3.3.1",
@@ -1835,7 +1835,7 @@
       "version": "1.7.0"
     },
     "http-errors": {
-      "version": "1.6.1",
+      "version": "1.5.1",
       "dependencies": {
         "inherits": {
           "version": "2.0.3"
@@ -2173,7 +2173,7 @@
       "version": "3.0.1"
     },
     "js-yaml": {
-      "version": "3.8.2",
+      "version": "3.8.1",
       "dev": true
     },
     "jsdom": {
@@ -2314,7 +2314,7 @@
       }
     },
     "levelup": {
-      "version": "1.3.5"
+      "version": "1.3.3"
     },
     "levn": {
       "version": "0.3.0",
@@ -2411,7 +2411,7 @@
       "version": "1.6.0"
     },
     "lower-case": {
-      "version": "1.1.4"
+      "version": "1.1.3"
     },
     "lower-case-first": {
       "version": "1.0.2"
@@ -2606,7 +2606,7 @@
       }
     },
     "node-abi": {
-      "version": "2.0.0"
+      "version": "1.3.3"
     },
     "node-contains": {
       "version": "1.0.0"
@@ -2855,9 +2855,6 @@
       "version": "1.0.2",
       "dev": true
     },
-    "path-parse": {
-      "version": "1.0.5"
-    },
     "path-to-regexp": {
       "version": "0.1.7"
     },
@@ -2942,7 +2939,7 @@
       "version": "3.3.0"
     },
     "prebuild-install": {
-      "version": "2.1.1",
+      "version": "2.1.0",
       "dependencies": {
         "minimist": {
           "version": "1.2.0"
@@ -3282,7 +3279,7 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.3.2"
+      "version": "1.2.0"
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -3296,7 +3293,7 @@
       "version": "0.1.3"
     },
     "rimraf": {
-      "version": "2.6.1",
+      "version": "2.6.0",
       "dependencies": {
         "glob": {
           "version": "7.1.1"
@@ -3433,20 +3430,8 @@
           "version": "1.0.3",
           "dev": true
         },
-        "http-errors": {
-          "version": "1.5.1",
-          "dev": true
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "dev": true
-        },
         "negotiator": {
           "version": "0.6.1",
-          "dev": true
-        },
-        "setprototypeof": {
-          "version": "1.0.2",
           "dev": true
         }
       }
@@ -3481,7 +3466,7 @@
       "version": "1.0.5"
     },
     "setprototypeof": {
-      "version": "1.0.3"
+      "version": "1.0.2"
     },
     "sha.js": {
       "version": "2.2.6"
@@ -3616,7 +3601,7 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.11.0",
+      "version": "1.10.2",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0"
@@ -4120,10 +4105,6 @@
           "version": "1.0.6",
           "dev": true
         },
-        "debug": {
-          "version": "2.6.1",
-          "dev": true
-        },
         "destroy": {
           "version": "1.0.4",
           "dev": true
@@ -4132,24 +4113,16 @@
           "version": "1.0.3",
           "dev": true
         },
-        "etag": {
-          "version": "1.8.0",
-          "dev": true
-        },
         "express": {
-          "version": "4.15.0",
+          "version": "4.14.1",
           "dev": true
         },
         "filesize": {
-          "version": "3.5.5",
+          "version": "3.5.4",
           "dev": true
         },
         "finalhandler": {
-          "version": "1.0.0",
-          "dev": true
-        },
-        "fresh": {
-          "version": "0.5.0",
+          "version": "0.5.1",
           "dev": true
         },
         "ipaddr.js": {
@@ -4177,7 +4150,7 @@
           "dev": true
         },
         "qs": {
-          "version": "6.3.1",
+          "version": "6.2.0",
           "dev": true
         },
         "range-parser": {
@@ -4185,11 +4158,11 @@
           "dev": true
         },
         "send": {
-          "version": "0.15.0",
+          "version": "0.14.2",
           "dev": true
         },
         "serve-static": {
-          "version": "1.12.0",
+          "version": "1.11.2",
           "dev": true
         },
         "supports-color": {
@@ -4265,7 +4238,7 @@
           "dev": true
         },
         "filesize": {
-          "version": "3.5.5",
+          "version": "3.5.4",
           "dev": true
         },
         "isarray": {
@@ -4358,14 +4331,11 @@
         }
       }
     },
-    "webpack-stable-module-id-and-hash": {
-      "version": "1.0.5"
-    },
     "wemoji": {
       "version": "0.1.9"
     },
     "whatwg-fetch": {
-      "version": "2.0.3"
+      "version": "2.0.2"
     },
     "whatwg-url": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,6 @@
     "walk": "2.3.4",
     "webpack": "1.13.1",
     "webpack-dev-middleware": "1.2.0",
-    "webpack-stable-module-id-and-hash": "1.0.5",
     "wpcom": "5.3.0",
     "wpcom-oauth": "0.3.3",
     "wpcom-proxy-request": "3.0.0",
@@ -193,6 +192,5 @@
     "webpack-bundle-analyzer": "2.2.1",
     "webpack-dashboard": "0.2.0",
     "webpack-dev-server": "1.11.0"
-
   }
 }

--- a/webpack-dll.config.js
+++ b/webpack-dll.config.js
@@ -3,7 +3,6 @@
  */
 const path = require( 'path' );
 const webpack = require( 'webpack' );
-const WebpackStableModuleIdAndHash = require( 'webpack-stable-module-id-and-hash' );
 
 /**
  * Internal Dependencies
@@ -46,7 +45,7 @@ module.exports = {
 				NODE_ENV: JSON.stringify( bundleEnv )
 			}
 		} ),
-		new WebpackStableModuleIdAndHash()
+		new webpack.optimize.OccurenceOrderPlugin()
 	],
 	module: {
 		loaders: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,8 +15,7 @@ const config = require( './server/config' ),
 	cacheIdentifier = require( './server/bundler/babel/babel-loader-cache-identifier' ),
 	ChunkFileNamePlugin = require( './server/bundler/plugin' ),
 	CopyWebpackPlugin = require( 'copy-webpack-plugin' ),
-	HardSourceWebpackPlugin = require( 'hard-source-webpack-plugin' ),
-	WebpackStableModuleIdAndHash = require( 'webpack-stable-module-id-and-hash' );
+	HardSourceWebpackPlugin = require( 'hard-source-webpack-plugin' );
 
 /**
  * Internal variables
@@ -93,7 +92,7 @@ const webpackConfig = {
 				NODE_ENV: JSON.stringify( bundleEnv )
 			}
 		} ),
-		new WebpackStableModuleIdAndHash(),
+		new webpack.optimize.OccurenceOrderPlugin( true ),
 		new webpack.IgnorePlugin( /^props$/ ),
 		new CopyWebpackPlugin( [ { from: 'node_modules/flag-icon-css/flags/4x3', to: 'images/flags' } ] )
 	],


### PR DESCRIPTION
While module IDs are now stable, there's a new bug when chunk ids change, but nothing else does. Reverting for now.