### PR TITLE
Fix Reader Combined Card title in devdocs

### DIFF
--- a/client/blocks/reader-combined-card/docs/example.jsx
+++ b/client/blocks/reader-combined-card/docs/example.jsx
@@ -17,4 +17,6 @@ const ReaderCombinedCard = () => (
 	</div>
 );
 
+ReaderCombinedCard.displayName = 'ReaderCombinedCard';
+
 export default ReaderCombinedCard;


### PR DESCRIPTION
#11407 added the Reader Combined Card block, but the name is incorrect in Devdocs:

<img width="710" alt="screen shot 2017-03-07 at 17 57 51" src="https://cloud.githubusercontent.com/assets/17325/23671835/96a21188-0364-11e7-955f-e80187ff022d.png">

This PR fixes the display name.

### To test

Head to http://calypso.localhost:3000/devdocs/blocks and check the combined card is named correctly.

<img width="726" alt="screen shot 2017-03-07 at 18 32 09" src="https://cloud.githubusercontent.com/assets/17325/23671832/912a8df2-0364-11e7-96f8-050e707309a6.png">
