### PR TITLE
Themes: Fix try&customize for wpcom themes on Jetpack sites

### DIFF
--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -53,6 +53,7 @@ import {
 } from 'state/analytics/actions';
 import {
 	getTheme,
+	getCanonicalTheme,
 	getActiveTheme,
 	getLastThemeQuery,
 	getThemeCustomizeUrl,
@@ -574,7 +575,11 @@ export function installAndTryAndCustomizeTheme( themeId, siteId ) {
 export function tryAndCustomizeTheme( themeId, siteId ) {
 	return ( dispatch, getState ) => {
 		const siteIdOrWpcom = isJetpackSite( getState(), siteId ) ? siteId : 'wpcom';
-		const theme = getTheme( getState(), siteIdOrWpcom, themeId );
+		const theme = getCanonicalTheme(
+			getState(),
+			siteIdOrWpcom,
+			themeId.replace( /-wpcom$/, '' )
+		);
 		if ( ! theme ) {
 			return dispatch( {
 				type: THEME_TRY_AND_CUSTOMIZE_FAILURE,

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -967,8 +967,8 @@ describe( 'actions', () => {
 			}
 			return false;
 		};
-		const getThemeSpy = ( state, siteId, themeId ) => {
-			if ( themeId === 'karuna-wpcom' ) {
+		const getCanonicalThemeSpy = ( state, siteId, themeId ) => {
+			if ( themeId === 'karuna' ) {
 				return { theme: themeId };
 			}
 			return null;
@@ -984,7 +984,7 @@ describe( 'actions', () => {
 			} );
 			mockery.registerMock( './selectors', {
 				getThemeCustomizeUrl: () => 'customizer/url',
-				getTheme: getThemeSpy,
+				getCanonicalTheme: getCanonicalThemeSpy,
 			} );
 			_tryAndCustomize = require( '../actions' ).tryAndCustomizeTheme;
 		} );


### PR DESCRIPTION
Now that we filter out all wpcom themes from Jetpack theme requests, we need to fetch the theme object required for the try&customize action from a non-site store.

**To Test**
* Check that _try&customize_ action works for wpcom themes for on Jetpack sites
