### PR TITLE
deep equal for shouldComponentUpdate of react-post-card

### DIFF
--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import React, { PropTypes } from 'react';
-import { noop, truncate, get, isEmpty } from 'lodash';
+import { noop, truncate, get, isEmpty, isEqual } from 'lodash';
 import classnames from 'classnames';
 import ReactDom from 'react-dom';
 import closest from 'component-closest';
@@ -95,6 +95,10 @@ export default class ReaderPostCard extends React.Component {
 			event.preventDefault();
 			this.propagateCardClick();
 		}
+	}
+
+	shouldComponentUpdate( nextProps ) {
+		return isEqual( this.props, nextProps );
 	}
 
 	render() {
@@ -191,4 +195,3 @@ export default class ReaderPostCard extends React.Component {
 		);
 	}
 }
-


### PR DESCRIPTION
Attempt at fixing an issue where video cards + photo cards close without a users consent https://github.com/Automattic/wp-calypso/issues/11856

The hypothesis here is that reader post cards rerender more often than they have a right to (causing a loss of state).