### PR TITLE
ReaderSubscriptionListItem displayName changed to static

### DIFF
--- a/client/blocks/reader-subscription-list-item/docs/example.jsx
+++ b/client/blocks/reader-subscription-list-item/docs/example.jsx
@@ -51,7 +51,7 @@ const items = [
 ]
 
 export default class ReaderSubscriptionListItemExample extends PureComponent {
-	displayName = 'ReaderSubscriptionListItem';
+	static displayName = 'ReaderSubscriptionListItem';
 
 	render() {
 		return (


### PR DESCRIPTION
super small, fix the title for the devdocs example.
It needed to be static.