### PR TITLE
Themes: Don't add received active themes to store

### DIFF
--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -340,7 +340,7 @@ export function requestTheme( themeId, siteId ) {
  * @return {Function}        Redux thunk with request action
  */
 export function requestActiveTheme( siteId ) {
-	return ( dispatch, getState ) => {
+	return ( dispatch ) => {
 		dispatch( {
 			type: ACTIVE_THEME_REQUEST,
 			siteId,
@@ -349,10 +349,6 @@ export function requestActiveTheme( siteId ) {
 		return wpcom.undocumented().activeTheme( siteId )
 			.then( theme => {
 				debug( 'Received current theme', theme );
-				// We want to store the theme object in the appropriate Redux subtree -- either 'wpcom'
-				// for WPCOM sites, or siteId for Jetpack sites.
-				const siteIdOrWpcom = isJetpackSite( getState(), siteId ) ? siteId : 'wpcom';
-				dispatch( receiveTheme( theme, siteIdOrWpcom ) );
 				dispatch( {
 					type: ACTIVE_THEME_REQUEST_SUCCESS,
 					siteId,

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -659,16 +659,6 @@ describe( 'actions', () => {
 			message: 'Unknown blog'
 		};
 
-		const fakeGetState = () => ( {
-			sites: {
-				items: {
-					77203074: {
-						jetpack: true
-					}
-				}
-			}
-		} );
-
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
@@ -691,7 +681,7 @@ describe( 'actions', () => {
 
 		context( 'when request completes successfully', () => {
 			it( 'should dispatch active theme request success action', () => {
-				return requestActiveTheme( 2211667 )( spy, fakeGetState ).then( () => {
+				return requestActiveTheme( 2211667 )( spy ).then( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: ACTIVE_THEME_REQUEST_SUCCESS,
 						siteId: 2211667,
@@ -702,7 +692,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should dispatch active theme request failure action when request completes', () => {
-			return requestActiveTheme( 666 )( spy, fakeGetState ).then( () => {
+			return requestActiveTheme( 666 )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: ACTIVE_THEME_REQUEST_FAILURE,
 					siteId: 666,


### PR DESCRIPTION
This prevents wpcom themes ending up in the uploaded themes list.

The /mine endpoint does not return enough details to properly determine if a theme is wpcom or not, so active themes received for jetpack sites end up in the uploaded themes list.

Since the only place an active theme is requested is the current-theme component, and that component will make a request for full theme details as soon as it knows the id of the active theme, we do not need to add the received active theme to the store at all, eliminating the filtering problem.

**To Test**
* Go to http://calypso.localhost:3000/design
* Check that the _CURRENT THEME_ bar works as before for both wpcom and Jetpack sites


