### PR TITLE
Plugins: Disable install button during automated transfer

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -45,8 +45,6 @@ import QueryEligibility from 'components/data/query-atat-eligibility';
 const PluginMeta = React.createClass( {
 	OUT_OF_DATE_YEARS: 2,
 
-	displayName: 'PluginMeta',
-
 	propTypes: {
 		siteURL: React.PropTypes.string,
 		sites: React.PropTypes.array,

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import classNames from 'classnames';
 import i18n from 'i18n-calypso';
 import some from 'lodash/some';
@@ -37,9 +38,11 @@ import {
 	isBusiness,
 	isEnterprise
 } from 'lib/products-values';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isAutomatedTransferActive } from 'state/selectors';
 import QueryEligibility from 'components/data/query-atat-eligibility';
 
-export default React.createClass( {
+const PluginMeta = React.createClass( {
 	OUT_OF_DATE_YEARS: 2,
 
 	displayName: 'PluginMeta',
@@ -165,10 +168,12 @@ export default React.createClass( {
 			return <PluginInstallButton { ...this.props } />;
 		}
 
+		const { isTransferring } = this.props;
+
 		if ( this.props.selectedSite && ! this.props.selectedSite.jetpack ) {
 			return (
 				<WpcomPluginInstallButton
-					disabled={ ! this.hasBusinessPlan() }
+					disabled={ ! this.hasBusinessPlan() || isTransferring }
 					plugin={ this.props.plugin }
 				/>
 			);
@@ -382,3 +387,13 @@ export default React.createClass( {
 		);
 	}
 } );
+
+const mapStateToProps = state => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		isTransferring: isAutomatedTransferActive( state, siteId ),
+	};
+};
+
+export default connect( mapStateToProps )( PluginMeta );


### PR DESCRIPTION
We received a few reports that the Install button was still enabled during an automated transfer. This PR connects up to the `isTransferring` state and disables the button if a Transfer is occurring.

**To test**
* On a wp.com site with a business plan, visit `/plugins/browse` and select a plugin.
* Set the state in the browser console: `dispatch( { siteId: yoursiteid, type: 'AUTOMATED_TRANSFER_STATUS_SET', status: 'start' } )`
* You should see the transfer dialog, and the Install button disabled.
* Reset the transfer state with another console command: `dispatch( { siteId: yoursiteid, type: 'AUTOMATED_TRANSFER_STATUS_SET', status: '' } )`
* The install button should be enabled again.

Screenshot:
<img width="634" alt="screen shot 2017-03-07 at 11 11 42 am" src="https://cloud.githubusercontent.com/assets/789137/23673357/dfccc454-0326-11e7-9e98-cf09476fe879.png">
