### PR TITLE
Plans: Color PlanThankYouCard based on plan

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -30,6 +30,7 @@
 @import 'blocks/image-editor/style';
 @import 'blocks/like-button/style';
 @import 'blocks/plan-storage/style';
+@import 'blocks/plan-thank-you-card/style';
 @import 'blocks/post-edit-button/style';
 @import 'blocks/post-item/style';
 @import 'blocks/post-likes/style';

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -73,6 +73,7 @@ $z-layers: (
 		'.accessible-focus .theme__more-button button:focus': 1,
 		'.domain-suggestion.is-clickable:hover': 1,
 		'.editor-html-toolbar': 1,
+		'.thank-you-card__header': 1,
 		'.is-installing .theme': 2,
 		'.reader-update-notice': 2,
 		'.people-list-item .card__link-indicator': 2,
@@ -222,6 +223,11 @@ $z-layers: (
 	),
 	'.stats-post-summary': (
 		'.section-nav': 1
+	),
+	'.thank-you-card__header' : (
+		'.thank-you-card__background-icons .gridicon': 1,
+		'.thank-you-card__main-icon': 2,
+		'.thank-you-card__header-detail': 2
 	),
 
 	// The following may be inserted into different areas.

--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -4,6 +4,7 @@
 import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -15,6 +16,8 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import { getPlan } from 'lib/plans';
 import formatCurrency from 'lib/format-currency';
 import ThankYouCard from 'components/thank-you-card';
+import PlanIcon from 'components/plans/plan-icon';
+import { getPlanClass } from 'lib/plans/constants';
 
 const PlanThankYouCard = ( {
 	plan,
@@ -26,9 +29,16 @@ const PlanThankYouCard = ( {
 		args: { planName: getPlan( plan.productSlug ).getTitle() }
 	} );
 	const price = plan && formatCurrency( plan.rawPrice, plan.currencyCode );
+	const productSlug = plan && plan.productSlug;
+	const planClass = productSlug
+		? getPlanClass( productSlug )
+		: '';
+	const planIcon = productSlug
+		? <PlanIcon plan={ productSlug } />
+		: null;
 
 	return (
-		<div>
+		<div className={ classnames( 'plan-thank-you-card', planClass ) }>
 			<QuerySites siteId={ siteId } />
 			<QuerySitePlans siteId={ siteId } />
 
@@ -39,6 +49,7 @@ const PlanThankYouCard = ( {
 				description={ translate( "Now that we've taken care of the plan, it's time to see your new site." ) }
 				buttonUrl={ siteUrl }
 				buttonText={ translate( 'Visit Your Site' ) }
+				icon={ planIcon }
 			/>
 		</div>
 	);

--- a/client/blocks/plan-thank-you-card/style.scss
+++ b/client/blocks/plan-thank-you-card/style.scss
@@ -1,106 +1,65 @@
+@mixin plan-thank-you-card-color( $color ) {
+	.thank-you-card{
+		background-color: darken( $color, 10 );
+	}
+
+	.thank-you-card .thank-you-card__header {
+		background-color: $color;
+	}
+
+	.thank-you-card__name {
+		&.is-placeholder {
+			background-color: lighten( $color, 40 );
+		}
+	}
+
+	.thank-you-card__price {
+		color: lighten( $color, 40 );
+
+		&.is-placeholder {
+			background-color: lighten( $color, 40 );
+		}
+	}
+
+	.thank-you-card__button,
+	.thank-you-card__button:visited {
+		color: darken( $color, 30 );
+		border-color: darken( $color, 20 );
+
+		&.is-placeholder {
+			background-color: lighten( $color, 40 );
+		}
+	}
+
+	.thank-you-card__button {
+		&:hover {
+			border-color: darken( $color, 30 );
+			color: darken( $color, 10 );
+		}
+
+		&:focus {
+			color: darken( $color, 10 );
+		}
+
+		&:active {
+			color: darken( $color, 30 );
+		}
+	}
+}
+
 .plan-thank-you-card .thank-you-card__main-icon {
 	margin-bottom: 8px;
 }
 
 .plan-thank-you-card.is-free-plan {
-	.thank-you-card{
-		background-color: darken( $blue-medium, 10 );
-	}
-
-	.thank-you-card .thank-you-card__header {
-		background-color: $blue-medium;
-	}
-
-	.thank-you-card__name {
-		&.is-placeholder {
-			background-color: lighten( $blue-medium, 40 );
-		}
-	}
-
-	.thank-you-card__price {
-		color: lighten( $blue-medium, 40 );
-
-		&.is-placeholder {
-			background-color: lighten( $blue-medium, 40 );
-		}
-	}
-
-	.thank-you-card__button,
-	.thank-you-card__button:visited {
-		color: darken( $blue-medium, 30 );
-		border-color: darken( $blue-medium, 20 );
-
-		&.is-placeholder {
-			background-color: lighten( $blue-medium, 40 );
-		}
-	}
-
-	.thank-you-card__button {
-		&:hover {
-			border-color: darken( $blue-medium, 30 );
-			color: darken( $blue-medium, 10 );
-		}
-
-		&:focus {
-			color: darken( $blue-medium, 10 );
-		}
-
-		&:active {
-			color: darken( $blue-medium, 30 );
-		}
-	}
+	@include plan-thank-you-card-color( $blue-medium );
 }
 
 .plan-thank-you-card.is-personal-plan {
-	.thank-you-card{
-		background-color: darken( $alert-yellow, 10 );
-	}
-
-	.thank-you-card .thank-you-card__header {
-		background-color: $alert-yellow;
-	}
+	@include plan-thank-you-card-color( $alert-yellow );
 
 	.thank-you-card__header .plan-icon .plan-icon__personal-0 {
 		fill: darken( $alert-yellow, 10 );
-	}
-
-	.thank-you-card__name {
-		&.is-placeholder {
-			background-color: lighten( $alert-yellow, 40 );
-		}
-	}
-
-	.thank-you-card__price {
-		color: lighten( $alert-yellow, 40 );
-
-		&.is-placeholder {
-			background-color: lighten( $alert-yellow, 40 );
-		}
-	}
-
-	.thank-you-card__button,
-	.thank-you-card__button:visited {
-		color: darken( $alert-yellow, 30 );
-		border-color: darken( $alert-yellow, 20 );
-
-		&.is-placeholder {
-			background-color: lighten( $alert-yellow, 40 );
-		}
-	}
-
-	.thank-you-card__button {
-		&:hover {
-			border-color: darken( $alert-yellow, 30 );
-			color: darken( $alert-yellow, 10 );
-		}
-
-		&:focus {
-			color: darken( $alert-yellow, 10 );
-		}
-
-		&:active {
-			color: darken( $alert-yellow, 30 );
-		}
 	}
 }
 
@@ -111,54 +70,9 @@
 }
 
 .plan-thank-you-card.is-business-plan {
-	.thank-you-card{
-		background-color: darken( $alert-purple, 10 );
-	}
-
-	.thank-you-card .thank-you-card__header {
-		background-color: $alert-purple;
-	}
+	@include plan-thank-you-card-color( $alert-purple );
 
 	.thank-you-card__header .plan-icon .plan-icon__business-0 {
 		fill: darken( $alert-purple, 10 );
-	}
-
-	.thank-you-card__name {
-		&.is-placeholder {
-			background-color: lighten( $alert-purple, 40 );
-		}
-	}
-
-	.thank-you-card__price  {
-		color: lighten( $alert-purple, 40 );
-
-		&.is-placeholder {
-			background-color: lighten( $alert-purple, 40 );
-		}
-	}
-
-	.thank-you-card__button,
-	.thank-you-card__button:visited {
-		color: darken( $alert-purple, 30 );
-		border-color: darken( $alert-purple, 20 );
-
-		&.is-placeholder {
-			background-color: lighten( $alert-purple, 40 );
-		}
-	}
-
-	.thank-you-card__button {
-		&:hover {
-			border-color: darken( $alert-purple, 30 );
-			color: darken( $alert-purple, 10 );
-		}
-
-		&:focus {
-			color: darken( $alert-purple, 10 );
-		}
-
-		&:active {
-			color: darken( $alert-purple, 30 );
-		}
 	}
 }

--- a/client/blocks/plan-thank-you-card/style.scss
+++ b/client/blocks/plan-thank-you-card/style.scss
@@ -1,0 +1,164 @@
+.plan-thank-you-card .thank-you-card__main-icon {
+	margin-bottom: 8px;
+}
+
+.plan-thank-you-card.is-free-plan {
+	.thank-you-card{
+		background-color: darken( $blue-medium, 10 );
+	}
+
+	.thank-you-card .thank-you-card__header {
+		background-color: $blue-medium;
+	}
+
+	.thank-you-card__name {
+		&.is-placeholder {
+			background-color: lighten( $blue-medium, 40 );
+		}
+	}
+
+	.thank-you-card__price {
+		color: lighten( $blue-medium, 40 );
+
+		&.is-placeholder {
+			background-color: lighten( $blue-medium, 40 );
+		}
+	}
+
+	.thank-you-card__button,
+	.thank-you-card__button:visited {
+		color: darken( $blue-medium, 30 );
+		border-color: darken( $blue-medium, 20 );
+
+		&.is-placeholder {
+			background-color: lighten( $blue-medium, 40 );
+		}
+	}
+
+	.thank-you-card__button {
+		&:hover {
+			border-color: darken( $blue-medium, 30 );
+			color: darken( $blue-medium, 10 );
+		}
+
+		&:focus {
+			color: darken( $blue-medium, 10 );
+		}
+
+		&:active {
+			color: darken( $blue-medium, 30 );
+		}
+	}
+}
+
+.plan-thank-you-card.is-personal-plan {
+	.thank-you-card{
+		background-color: darken( $alert-yellow, 10 );
+	}
+
+	.thank-you-card .thank-you-card__header {
+		background-color: $alert-yellow;
+	}
+
+	.thank-you-card__header .plan-icon .plan-icon__personal-0 {
+		fill: darken( $alert-yellow, 10 );
+	}
+
+	.thank-you-card__name {
+		&.is-placeholder {
+			background-color: lighten( $alert-yellow, 40 );
+		}
+	}
+
+	.thank-you-card__price {
+		color: lighten( $alert-yellow, 40 );
+
+		&.is-placeholder {
+			background-color: lighten( $alert-yellow, 40 );
+		}
+	}
+
+	.thank-you-card__button,
+	.thank-you-card__button:visited {
+		color: darken( $alert-yellow, 30 );
+		border-color: darken( $alert-yellow, 20 );
+
+		&.is-placeholder {
+			background-color: lighten( $alert-yellow, 40 );
+		}
+	}
+
+	.thank-you-card__button {
+		&:hover {
+			border-color: darken( $alert-yellow, 30 );
+			color: darken( $alert-yellow, 10 );
+		}
+
+		&:focus {
+			color: darken( $alert-yellow, 10 );
+		}
+
+		&:active {
+			color: darken( $alert-yellow, 30 );
+		}
+	}
+}
+
+.plan-thank-you-card.is-premium-plan {
+	.thank-you-card__header .plan-icon .plan-icon__premium-0 {
+		fill: darken( $alert-green, 10 );
+	}
+}
+
+.plan-thank-you-card.is-business-plan {
+	.thank-you-card{
+		background-color: darken( $alert-purple, 10 );
+	}
+
+	.thank-you-card .thank-you-card__header {
+		background-color: $alert-purple;
+	}
+
+	.thank-you-card__header .plan-icon .plan-icon__business-0 {
+		fill: darken( $alert-purple, 10 );
+	}
+
+	.thank-you-card__name {
+		&.is-placeholder {
+			background-color: lighten( $alert-purple, 40 );
+		}
+	}
+
+	.thank-you-card__price  {
+		color: lighten( $alert-purple, 40 );
+
+		&.is-placeholder {
+			background-color: lighten( $alert-purple, 40 );
+		}
+	}
+
+	.thank-you-card__button,
+	.thank-you-card__button:visited {
+		color: darken( $alert-purple, 30 );
+		border-color: darken( $alert-purple, 20 );
+
+		&.is-placeholder {
+			background-color: lighten( $alert-purple, 40 );
+		}
+	}
+
+	.thank-you-card__button {
+		&:hover {
+			border-color: darken( $alert-purple, 30 );
+			color: darken( $alert-purple, 10 );
+		}
+
+		&:focus {
+			color: darken( $alert-purple, 10 );
+		}
+
+		&:active {
+			color: darken( $alert-purple, 30 );
+		}
+	}
+}

--- a/client/components/thank-you-card/index.jsx
+++ b/client/components/thank-you-card/index.jsx
@@ -7,12 +7,16 @@ import React, { PropTypes } from 'react';
 
 // Non standard gridicon sizes are used here because we use them as background pattern with various sizes and rotation
 /* eslint-disable wpcalypso/jsx-gridicon-size */
-const ThankYouCard = ( { heading, description, buttonUrl, buttonText, price, name } ) => (
+const ThankYouCard = ( { heading, description, buttonUrl, buttonText, price, name, icon } ) => (
 	<div className="thank-you-card">
 		<div className="thank-you-card__header">
-			<Gridicon className="thank-you-card__main-icon" icon="checkmark-circle" size={ 140 } />
+			{
+				icon
+				? <div className="thank-you-card__main-icon">{ icon }</div>
+				: <Gridicon className="thank-you-card__main-icon" icon="checkmark-circle" size={ 140 } />
+			}
 
-			<div>
+			<div className="thank-you-card__header-detail">
 				<div className={ classnames( 'thank-you-card__name', { 'is-placeholder': ! name } ) }>
 					{ name }
 				</div>
@@ -60,6 +64,7 @@ ThankYouCard.propTypes = {
 	heading: PropTypes.string,
 	name: PropTypes.string,
 	price: PropTypes.string,
+	icon: PropTypes.node
 };
 
 export default ThankYouCard;

--- a/client/components/thank-you-card/style.scss
+++ b/client/components/thank-you-card/style.scss
@@ -22,10 +22,16 @@
 	line-height: 1.2;
 	border-radius: 6px 6px 0 0;
 	overflow: hidden;
+	z-index: z-index( 'root', '.thank-you-card__header' );
 
 	@include breakpoint( ">480px" ) {
 		padding: 32px 0 15px;
 	}
+}
+
+.thank-you-card__header-detail {
+	position: relative;
+	z-index: z-index( '.thank-you-card__header', '.thank-you-card__header-detail' );
 }
 
 .thank-you-card__body {
@@ -39,6 +45,9 @@
 .thank-you-card__main-icon {
 	width: 72px;
 	height: 72px;
+	margin: 0 auto;
+	position: relative;
+	z-index: z-index( '.thank-you-card__header', '.thank-you-card__main-icon' );
 
 	@include breakpoint( ">480px" ) {
 		width: 96px;


### PR DESCRIPTION
This PR is meant to colorize the plans thank you card, and use the `PlanIcon` component, based on the type of plan the user has purchased. It is an improvement that @rickybanister suggested.

You can view @rickybanister's mocks here: p6TEKc-105-p2

Here are some screenshots for how things currently look in this PR.

<strong>Note:</strong> In all  screenshots, you'll notice the name of the plan and pricing is off. This is because I manually changed the plan type to get the screenshots. Further, the auto-config list below the thank you card should only show for Jetpack sites in the development environment. Lastly, you'll notice that there the background for the icons doesn't stand out. We'll need to fix this before merging.

### Free Plan

![screen shot 2017-03-07 at 1 23 16 pm](https://cloud.githubusercontent.com/assets/1126811/23674143/7fd331a0-033a-11e7-97df-6a9259997228.png)

### Personal Plan

![screen shot 2017-03-07 at 1 05 02 pm](https://cloud.githubusercontent.com/assets/1126811/23674151/87a8d8f8-033a-11e7-8846-358a1a0dc389.png)

### Premium Plan

![screen shot 2017-03-07 at 1 24 38 pm](https://cloud.githubusercontent.com/assets/1126811/23674195/ab650b40-033a-11e7-8260-b7cb5d29b476.png)

### Business Plan

![screen shot 2017-03-07 at 1 27 46 pm](https://cloud.githubusercontent.com/assets/1126811/23674208/b7016dcc-033a-11e7-868c-6b5e57b81a6a.png)

To test:

- You can test the WPCOM plans flow by creating a new user and following the NUX flow
- For Jetpack, you can purchase a plan for your Jetpack site, and then you should land on the auto-config flow
- You can test previous purchases by going to: `http://calypso.localhost:3000/checkout/thank-you/:siteId:/:receiptId:`