### PR TITLE
Signup: A/B test the headline for Domains step

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -40,6 +40,7 @@ import {
 	getDomainsSuggestions,
 	getDomainsSuggestionsError
 } from 'state/domains/suggestions/selectors';
+import { abtest } from 'lib/abtest';
 
 const domains = wpcom.domains();
 
@@ -220,7 +221,10 @@ const RegisterDomainStep = React.createClass( {
 	},
 
 	render: function() {
-		const queryObject = getQueryObject( this.props );
+		const queryObject = getQueryObject( this.props ),
+			placeholder = ( this.props.isSignupStep && abtest( 'signupDomainsHeadline' ) === 'updated' )
+				? this.props.translate( 'Enter a name or keyword' )
+				: this.props.translate( 'Enter a domain or keyword' );
 		return (
 			<div className="register-domain-step">
 					<div className="register-domain-step__search">
@@ -231,7 +235,7 @@ const RegisterDomainStep = React.createClass( {
 							onSearch={ this.onSearch }
 							onSearchChange={ this.onSearchChange }
 							onBlur={ this.save }
-							placeholder={ this.props.translate( 'Enter a domain or keyword', { textOnly: true } ) }
+							placeholder={ placeholder }
 							autoFocus={ true }
 							delaySearch={ true }
 							delayTimeout={ 1000 }

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -73,4 +73,12 @@ module.exports = {
 		defaultVariation: 'showMonthly',
 		allowExistingUsers: true
 	},
+	signupDomainsHeadline: {
+		datestamp: '20170313',
+		variations: {
+			original: 50,
+			updated: 50
+		},
+		defaultVariation: 'original'
+	},
 };

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -25,6 +25,7 @@ var StepWrapper = require( 'signup/step-wrapper' ),
 
 import { getCurrentUser, currentUserHasFlag } from 'state/current-user/selectors';
 import Notice from 'components/notice';
+import { abtest } from 'lib/abtest';
 
 const registerDomainAnalytics = analyticsMixin( 'registerDomain' ),
 	mapDomainAnalytics = analyticsMixin( 'mapDomain' );
@@ -243,6 +244,18 @@ const DomainsStep = React.createClass( {
 			);
 		}
 
+		let fallbackHeaderText,
+			fallbackSubHeaderText;
+		if ( abtest( 'signupDomainsHeadline' ) === 'updated' ) {
+			fallbackHeaderText = this.translate( 'Let\'s give your site an address.' ),
+			fallbackSubHeaderText = this.translate(
+				'Enter your site\'s name, or some key words that describe it ' +
+				'we\'ll use this to create your new site\'s address.' );
+		} else {
+			fallbackHeaderText = this.translate( 'Let\'s find a domain.' ),
+			fallbackSubHeaderText = this.translate( 'Choose a custom domain, or a free .wordpress.com address.' );
+		}
+
 		return (
 			<StepWrapper
 				flowName={ this.props.flowName }
@@ -251,8 +264,8 @@ const DomainsStep = React.createClass( {
 				positionInFlow={ this.props.positionInFlow }
 				signupProgress={ this.props.signupProgress }
 				subHeaderText={ this.translate( 'First up, let\'s find a domain.' ) }
-				fallbackHeaderText={ this.translate( 'Let\'s find a domain.' ) }
-				fallbackSubHeaderText={ this.translate( 'Choose a custom domain, or a free .wordpress.com address.' ) }
+				fallbackHeaderText={ fallbackHeaderText }
+				fallbackSubHeaderText={ fallbackSubHeaderText }
 				stepContent={ content } />
 		);
 	}


### PR DESCRIPTION
The hypothesis is that removing the word "Domain" from the headline on step 3 will increase signup rate by 1%.

P2 post TBD.
@Automattic/editorial - the updated version might be a bit rough, could you please have a look at it? The idea is to avoid using the word `domain` so that the user is not put off by it.

`original` variation:
<img width="1029" alt="screen shot 2017-03-07 at 20 42 51" src="https://cloud.githubusercontent.com/assets/3392497/23674772/57d72214-0377-11e7-9a1d-2387c313d9fc.png">

`updated` variation:
<img width="935" alt="screen shot 2017-03-09 at 22 55 58" src="https://cloud.githubusercontent.com/assets/3392497/23772544/9b4112ee-051b-11e7-9410-fa71ac6c3146.png">


### Testing
Try to create a new site, hit the Domains step and verify the correct copy is used.