### PR TITLE
Build: Async Load Happy Chat, CSS Reload, Network detection (take 2)

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -203,11 +203,11 @@ function reduxStoreReady( reduxStore ) {
 	}
 
 	if ( config.isEnabled( 'network-connection' ) ) {
-		require( 'lib/network-connection' ).init( reduxStore );
+		asyncRequire( 'lib/network-connection', netConn => netConn.init( reduxStore ) );
 	}
 
 	if ( config.isEnabled( 'css-hot-reload' ) ) {
-		require( 'lib/css-hot-reload' )();
+		asyncRequire( 'lib/css-hot-reload', cssHotReload => cssHotReload() );
 	}
 
 	// Render Layout only for non-isomorphic sections.

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -10,7 +10,8 @@ var React = require( 'react' ),
 /**
  * Internal dependencies
  */
-var MasterbarLoggedIn = require( 'layout/masterbar/logged-in' ),
+var AsyncLoad = require( 'components/async-load' ),
+	MasterbarLoggedIn = require( 'layout/masterbar/logged-in' ),
 	MasterbarLoggedOut = require( 'layout/masterbar/logged-out' ),
 	observe = require( 'lib/mixins/data-observe' ),
 	GlobalNotices = require( 'components/global-notices' ),
@@ -29,8 +30,7 @@ var MasterbarLoggedIn = require( 'layout/masterbar/logged-in' ),
 	QueryPreferences = require( 'components/data/query-preferences' ),
 	KeyboardShortcutsMenu,
 	Layout,
-	SupportUser,
-	Happychat = require( 'components/happychat' );
+	SupportUser;
 
 import { isOffline } from 'state/application/selectors';
 import { hasSidebar } from 'state/ui/selectors';
@@ -171,7 +171,7 @@ Layout = React.createClass( {
 					isEnabled={ translator.isEnabled() }
 					isActive={ translator.isActivated() }/>
 				{ this.renderPreview() }
-				{ config.isEnabled( 'happychat' ) && this.props.chatIsOpen && <Happychat /> }
+				{ config.isEnabled( 'happychat' ) && this.props.chatIsOpen && <AsyncLoad require="components/happychat" /> }
 			</div>
 		);
 	}


### PR DESCRIPTION
This reverts commit 10088690b64fe17c1f65f4e29f10ab833c79482a.

A retry of #11714

Shaves 25kb off the gzip'd build bundle (424kb ➡️ 399kb). Needs more testing to verify it 1) works as expected and 2) uses a reasonable placeholder for the chat box while loading.

Most of the reason for the size diff here is that happy-chat is the only thing in boot using socket.io, which is a pretty big package itself, even after gzip. Necessary, but large.