### PR TITLE
Themes: Prevent active theme appearing in uploaded list

### DIFF
--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -172,12 +172,13 @@ describe( 'actions', () => {
 
 			it( 'should dispatch themes request success action', () => {
 				receiveThemesQuery( themes, 77203074, {} )( spy, getState );
+				// Themes will be assumed to be wpcom themes and filtered out
 				expect( spy ).to.have.been.calledWith( {
 					type: THEMES_REQUEST_SUCCESS,
 					siteId: 77203074,
 					query: {},
-					found: 2,
-					themes,
+					found: 0,
+					themes: [ ]
 				} );
 			} );
 		} );

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -5,6 +5,7 @@ import startsWith from 'lodash/startsWith';
 import {
 	every,
 	get,
+	hasIn,
 	includes,
 	map,
 	mapKeys,
@@ -212,7 +213,7 @@ export function getSerializedThemesQueryWithoutPage( query, siteId ) {
  * @return {Boolean}      Whether theme is a wpcom theme
  */
 export function isThemeFromWpcom( theme ) {
-	if ( ! theme.hasOwnProperty( 'theme_uri' ) ) {
+	if ( ! hasIn( theme, 'theme_uri' ) ) {
 		// If not enough information to determine, assume
 		// theme is wpcom to prevent it appearing in
 		// the uploaded themes list.

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -212,6 +212,13 @@ export function getSerializedThemesQueryWithoutPage( query, siteId ) {
  * @return {Boolean}      Whether theme is a wpcom theme
  */
 export function isThemeFromWpcom( theme ) {
+	if ( ! theme.hasOwnProperty( 'theme_uri' ) ) {
+		// if not enough information to determine, assume
+		// theme is wpcom to prevent it appearing in
+		// the uploaded themes list
+		return true;
+	}
+
 	return includes( theme.theme_uri, 'wordpress.com' );
 }
 

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -5,7 +5,7 @@ import startsWith from 'lodash/startsWith';
 import {
 	every,
 	get,
-	hasIn,
+	has,
 	includes,
 	map,
 	mapKeys,
@@ -213,7 +213,7 @@ export function getSerializedThemesQueryWithoutPage( query, siteId ) {
  * @return {Boolean}      Whether theme is a wpcom theme
  */
 export function isThemeFromWpcom( theme ) {
-	if ( ! hasIn( theme, 'theme_uri' ) ) {
+	if ( ! has( theme, 'theme_uri' ) ) {
 		// If not enough information to determine, assume
 		// theme is wpcom to prevent it appearing in
 		// the uploaded themes list.

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -213,9 +213,9 @@ export function getSerializedThemesQueryWithoutPage( query, siteId ) {
  */
 export function isThemeFromWpcom( theme ) {
 	if ( ! theme.hasOwnProperty( 'theme_uri' ) ) {
-		// if not enough information to determine, assume
+		// If not enough information to determine, assume
 		// theme is wpcom to prevent it appearing in
-		// the uploaded themes list
+		// the uploaded themes list.
 		return true;
 	}
 


### PR DESCRIPTION
The theme returned from the /mine endpoint does not have enough info to determine if it is a wpcom theme or not.

In this case, assume it is wpcom theme to prevent it appearing in the 'Uploaded themes' list.

**To Test**
* Go to http://calypso.localhost:3000/design, choose a Jetpack 4.7 site
* No wpcom themes should appear in the top list (Uploaded themes)
