### PR TITLE
Media: fix-plan storage for business plan

### DIFF
--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -15,6 +15,7 @@ import {
 	getSiteSlug,
 	isJetpackSite
 } from 'state/sites/selectors';
+import { PLAN_BUSINESS } from 'lib/plans/constants';
 
 import PlanStorageBar from './bar';
 
@@ -37,6 +38,10 @@ class PlanStorage extends Component {
 		} = this.props;
 
 		if ( jetpackSite || ! sitePlanSlug ) {
+			return null;
+		}
+
+		if ( sitePlanSlug === PLAN_BUSINESS ) {
 			return null;
 		}
 


### PR DESCRIPTION
This PR fixes a visual bug in the filter-bar component of the media library.
The `<PlanStorage />` shouldn't be shown when the site has a business plan. We were only hiding the `<PlanStorageBar />` component before to this patch.

<img src="https://cloud.githubusercontent.com/assets/1270189/23673865/b0e05dac-0328-11e7-8e65-59753aca5124.png" width="800px" />

<img src="https://cloud.githubusercontent.com/assets/1270189/23673858/abc8cdf4-0328-11e7-86c1-25afb15d0dcf.png" width="800px" />

### Testing

1) Select a plan with business plan
2) The `<PlanStorage />` component should be hidden and the empty square shouldn't be there either.
