### PR TITLE
Directly: Wait to initialize widget until we know we need it

### DIFF
--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -67,6 +67,7 @@ export isDeactivatingJetpackJumpstart from './is-deactivating-jetpack-jumpstart'
 export isDeactivatingJetpackModule from './is-deactivating-jetpack-module';
 export isDirectlyFailed from './is-directly-failed';
 export isDirectlyReady from './is-directly-ready';
+export isDirectlyUninitialized from './is-directly-uninitialized';
 export isDomainOnlySite from './is-domain-only-site';
 export isFetchingJetpackModules from './is-fetching-jetpack-modules';
 export isJetpackModuleActive from './is-jetpack-module-active';

--- a/client/state/selectors/is-directly-uninitialized.js
+++ b/client/state/selectors/is-directly-uninitialized.js
@@ -1,0 +1,17 @@
+/**
+ * Tells whether the Directly RTM widget has started initialization
+ *
+ * @see lib/directly for more about Directly
+ *
+ * @param  {Object}  state  Global state tree
+ * @return {Boolean}        Whether the widget is waiting to be initialized
+ */
+
+/**
+ * Internal dependencies
+ */
+import { STATUS_UNINITIALIZED } from 'state/help/directly/constants';
+
+export default function isDirectlyUninitialized( state ) {
+	return state.help.directly.status === STATUS_UNINITIALIZED;
+}

--- a/client/state/selectors/test/is-directly-uninitialized.js
+++ b/client/state/selectors/test/is-directly-uninitialized.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	STATUS_ERROR,
+	STATUS_INITIALIZING,
+	STATUS_READY,
+	STATUS_UNINITIALIZED,
+} from 'state/help/directly/constants';
+
+import { isDirectlyUninitialized } from '../';
+
+describe( 'isDirectlyUninitialized()', () => {
+	it( 'should be true when uninitialized', () => {
+		const state = { help: { directly: { status: STATUS_UNINITIALIZED } } };
+		expect( isDirectlyUninitialized( state ) ).to.be.true;
+	} );
+
+	it( 'should be false when initializing', () => {
+		const state = { help: { directly: { status: STATUS_INITIALIZING } } };
+		expect( isDirectlyUninitialized( state ) ).to.be.false;
+	} );
+
+	it( 'should be false when ready', () => {
+		const state = { help: { directly: { status: STATUS_READY } } };
+		expect( isDirectlyUninitialized( state ) ).to.be.false;
+	} );
+
+	it( 'should be false when failed', () => {
+		const state = { help: { directly: { status: STATUS_ERROR } } };
+		expect( isDirectlyUninitialized( state ) ).to.be.false;
+	} );
+} );


### PR DESCRIPTION
This is another take at https://github.com/Automattic/wp-calypso/pull/11722. I realized that it had logic conflicts with another open PR.

This PR ensures that we don't initialize Directly's library until we need it, while doing as minimal logic changing in the component. Ultimately the `HelpContact` component needs to be refactored, but I was leary of doing that in the midst of Directly deadlines since it's the anchor for all our user support and has no automated tests.

One of the biggest issues is that `getSupportVariation()` returns a value even before sufficient data is loaded to know for sure which variation should be used. For example, for paid users on `componentDidMount()` the support variation is `SUPPORT_DIRECTLY` even though eventually once Olark/Ticket-dependent requests land, the variation will be something like `SUPPORT_TICKET`. So we need to wait to load Directly until we know for sure that we have the correct variation.

To accommodate this, I extracted existing logic from `shouldShowPreloadForm()` into `hasDataToDetermineVariation()`. The logic should all have parity with the previous iteration, but this allows us to only initialize Directly when we know 100% that we _should_ show it.

Let me know if I can clarify this any more. Again I'd love to do a bigger refactor, but let's save it for when we tear out Olark.

### To test

Check for initialization by opening Network dev tools and filtering on the term `directly`. If you see any assets come through, initialization has occurred.

#### 1. Paid users should not see initialization
Sign in as a user with paid upgrades. Visit http://calypso.localhost:3000/help/contact. You should not see initialization happen. You _should_ see the appropriate Happychat / Ticket support form.

#### 2. Unpaid English-speaking users should see initialization
Sign in as a user with no paid upgrades and account language set to English. Visit http://calypso.localhost:3000/help/contact. You should see initialization assets come across the network.

#### 3. Unpaid non-English speakers should not see initialization
On your unpaid account, set your language to something other than `en`. Visit http://calypso.localhost:3000/help/contact. You should not see initialization happen.

#### 4. Unpaid non-English speakers whose language switches to English should see initialization
On your unpaid account, set your language to something other than `en`. Visit http://calypso.localhost:3000/help/contact. You should not see initialization happen.

Now we'll send an action through Redux Dev Tools to change the language settings on the fly.

- Open Redux Dev Tools
- Find the `USER_RECEIVE` action and click it (should be one of the first dispatched)
- Open the "Raw" tab and copy the entire action
- Click the "keyboard" icon to dispatch a new action
- Paste in the copied action
- Find the `localeSlug` property and change the value to `'en'`
- Click the Dispatch button

You should now see the form change and Directly initialization assets come through the network.
