### PR TITLE
Reader: connect new combined cards component to streams

### DIFF
--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -16,7 +16,7 @@ import { siteNameFromSiteAndPost } from 'reader/utils';
 import ReaderCombinedCardPost from './post';
 
 const ReaderCombinedCard = ( { posts, site, feed, onClick, isDiscover, translate } ) => {
-	const feedId = get( feed, 'ID' );
+	const feedId = get( feed, 'feed_ID' );
 	const siteId = get( site, 'ID' );
 	const siteIcon = get( site, 'icon.img' );
 	const feedIcon = get( feed, 'image' );

--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -15,7 +15,7 @@ import ReaderSiteStreamLink from 'blocks/reader-site-stream-link';
 import { siteNameFromSiteAndPost } from 'reader/utils';
 import ReaderCombinedCardPost from './post';
 
-const ReaderCombinedCard = ( { posts, site, feed, onClickPost, isDiscover, translate } ) => {
+const ReaderCombinedCard = ( { posts, site, feed, onClick, isDiscover, translate } ) => {
 	const feedId = get( feed, 'ID' );
 	const siteId = get( site, 'ID' );
 	const siteIcon = get( site, 'icon.img' );
@@ -55,7 +55,7 @@ const ReaderCombinedCard = ( { posts, site, feed, onClickPost, isDiscover, trans
 						key={ `post-${ post.ID }` }
 						post={ post }
 						streamUrl={ streamUrl }
-						onClick={ onClickPost }
+						onClick={ onClick }
 						isDiscover={ isDiscover }
 						/>
 				) ) }
@@ -68,7 +68,7 @@ ReaderCombinedCard.propTypes = {
 	posts: React.PropTypes.array.isRequired,
 	site: React.PropTypes.object,
 	feed: React.PropTypes.object,
-	onClickPost: React.PropTypes.func,
+	onClick: React.PropTypes.func,
 	isDiscover: React.PropTypes.bool,
 };
 

--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -85,9 +85,11 @@ class ReaderCombinedCardPost extends React.Component {
 
 		return (
 			<li className="reader-combined-card__post" onClick={ this.handleCardClick }>
-				<div className="reader-combined-card__featured-image-wrapper">
-					{ featuredAsset }
-				</div>
+				{ featuredAsset &&
+					<div className="reader-combined-card__featured-image-wrapper">
+						{ featuredAsset }
+					</div>
+				}
 				<div className="reader-combined-card__post-details">
 					<AutoDirection>
 						<h1 className="reader-combined-card__post-title">

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -22,12 +22,14 @@
 	line-height: 1em;
 	margin-bottom: 0;
 	top: 0;
+	color: $blue-medium;
 }
 
 .reader-combined-card__header-post-count {
 	color: $gray;
 	margin-bottom: 0;
 	line-height: 1em;
+	margin-top: 4px;
 }
 
 /* Posts */

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -134,3 +134,16 @@
 .reader-combined-card__site-link a {
 	color: $blue-wordpress;
 }
+
+// Override standard .card styles in stream
+.reader-combined-card.card {
+	border-bottom: 1px solid lighten( $gray, 30% );
+	box-shadow: none;
+	margin: 0 15px;
+	padding: 18px 0 0;
+	position: relative;
+
+	@include breakpoint( ">660px" ) {
+		margin: 0;
+	}
+}

--- a/client/lib/reader-post-flux-adapter/index.js
+++ b/client/lib/reader-post-flux-adapter/index.js
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { map } from 'lodash';
+
+/*
+ * Internal Dependencies
+ */
+import FeedPostStore from 'lib/feed-post-store';
+import { fetchPost } from 'lib/feed-post-store/actions';
+
+/**
+ * A HoC function that translates a postKey or postKeys into a post or posts for its child.
+ */
+const fluxPostAdapter = Component => class ReaderPostFluxAdapter extends React.Component {
+	static propTypes = {
+		postKey: PropTypes.object,
+	}
+
+	getStateFromStores = ( props = this.props ) => {
+		const { postKey } = props;
+		const posts = map(
+			postKey.postIds,
+			postId => {
+				const post = FeedPostStore.get( { ...postKey, postId } )
+				if ( ! post ) {
+					fetchPost( { ...postKey, postId } );
+				}
+				return post;
+			}
+		);
+		return { posts };
+	}
+
+	state = this.getStateFromStores( this.props );
+
+	updateState = ( newState = this.getStateFromStores() ) => {
+		this.setState( newState );
+	}
+
+	componentWillMount() {
+		FeedPostStore.on( 'change', this.updateState );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		this.updateState( this.getStateFromStores( nextProps ) );
+	}
+
+	componentWillUnmount() {
+		FeedPostStore.off( 'change', this.updateState );
+	}
+
+	render() {
+		const { post, posts } = this.state;
+		if ( ! post && ! posts ) {
+			return null;
+		}
+		return <Component { ...{ ...this.props, post, posts } } />;
+	}
+};
+
+export default fluxPostAdapter;

--- a/client/lib/reader-post-flux-adapter/index.js
+++ b/client/lib/reader-post-flux-adapter/index.js
@@ -3,61 +3,80 @@
  */
 import React, { PropTypes } from 'react';
 import { map } from 'lodash';
+import { connect } from 'react-redux';
 
 /*
  * Internal Dependencies
  */
 import FeedPostStore from 'lib/feed-post-store';
 import { fetchPost } from 'lib/feed-post-store/actions';
+import { getSite } from 'state/reader/sites/selectors';
+import { getFeed } from 'state/reader/feeds/selectors';
 
 /**
  * A HoC function that translates a postKey or postKeys into a post or posts for its child.
  */
-const fluxPostAdapter = Component => class ReaderPostFluxAdapter extends React.Component {
-	static propTypes = {
-		postKey: PropTypes.object,
-	}
+const fluxPostAdapter = Component => {
 
-	getStateFromStores = ( props = this.props ) => {
-		const { postKey } = props;
-		const posts = map(
-			postKey.postIds,
-			postId => {
-				const post = FeedPostStore.get( { ...postKey, postId } )
-				if ( ! post ) {
-					fetchPost( { ...postKey, postId } );
-				}
-				return post;
-			}
-		);
-		return { posts };
-	}
-
-	state = this.getStateFromStores( this.props );
-
-	updateState = ( newState = this.getStateFromStores() ) => {
-		this.setState( newState );
-	}
-
-	componentWillMount() {
-		FeedPostStore.on( 'change', this.updateState );
-	}
-
-	componentWillReceiveProps( nextProps ) {
-		this.updateState( this.getStateFromStores( nextProps ) );
-	}
-
-	componentWillUnmount() {
-		FeedPostStore.off( 'change', this.updateState );
-	}
-
-	render() {
-		const { post, posts } = this.state;
-		if ( ! post && ! posts ) {
-			return null;
+	class ReaderPostFluxAdapter extends React.Component {
+		static propTypes = {
+			postKey: PropTypes.object,
 		}
-		return <Component { ...{ ...this.props, post, posts } } />;
+
+		getStateFromStores = ( props = this.props ) => {
+			const { postKey } = props;
+			const posts = map(
+				postKey.postIds,
+				postId => {
+					const post = FeedPostStore.get( { ...postKey, postId } )
+					if ( ! post ) {
+						fetchPost( { ...postKey, postId } );
+					}
+					return post;
+				}
+			);
+
+			return { posts };
+		}
+
+		state = this.getStateFromStores( this.props );
+
+		updateState = ( newState = this.getStateFromStores() ) => {
+			this.setState( newState );
+		}
+
+		componentWillMount() {
+			FeedPostStore.on( 'change', this.updateState );
+		}
+
+		componentWillReceiveProps( nextProps ) {
+			this.updateState( this.getStateFromStores( nextProps ) );
+		}
+
+		componentWillUnmount() {
+			FeedPostStore.off( 'change', this.updateState );
+		}
+
+		render() {
+			const { post, posts } = this.state;
+			if ( ! post && ! posts ) {
+				return null;
+			}
+			return <Component { ...{ ...this.props, post, posts } } />;
+		}
 	}
-};
+
+	return connect(
+		( state, ownProps ) => {
+			const { feedId, blogId } = ownProps.postKey;
+			const feed = feedId && getFeed( state, feedId );
+			const site = blogId && getSite( state, blogId );
+			return {
+				feed,
+				site
+			};
+		}
+	)( ReaderPostFluxAdapter );
+}
 
 export default fluxPostAdapter;

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -25,16 +25,6 @@
 }
 
 .reader__content {
-	a {
-		color: $blue-medium;
-
-		&:hover {
-			color: $blue-light;
-		}
-	}
-}
-
-.reader__content {
 	sup, sub {
 		position: relative;
 		font-size: 0.83em;

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -165,7 +165,9 @@ class FeedStream extends React.Component {
 				listName={ this.state.title }
 				emptyContent={ emptyContent }
 				showPostHeader={ false }
-				showSiteNameOnCards={ false }>
+				showSiteNameOnCards={ false }
+				shouldCombineCards={ false }
+			>
 				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: this.state.title } ) } />
 				<RefreshFeedHeader feed={ feed } site={ this.state.site } showBack={ this.props.showBack } />
 			</Stream>

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -207,7 +207,9 @@ class SearchStream extends Component {
 				showFollowInHeader={ true }
 				cardFactory={ this.cardFactory }
 				placeholderFactory={ this.placeholderFactory }
-				className="search-stream" >
+				className="search-stream"
+				shouldCombinedCards={ false }
+			>
 				{ this.props.showBack && <HeaderBack /> }
 				<DocumentHead title={ documentTitle } />
 				<div ref={ this.handleStreamMounted } />

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -208,7 +208,7 @@ class SearchStream extends Component {
 				cardFactory={ this.cardFactory }
 				placeholderFactory={ this.placeholderFactory }
 				className="search-stream"
-				shouldCombinedCards={ false }
+				shouldCombineCards={ false }
 			>
 				{ this.props.showBack && <HeaderBack /> }
 				<DocumentHead title={ documentTitle } />

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -161,7 +161,9 @@ class SiteStream extends React.Component {
 				emptyContent={ emptyContent }
 				showPostHeader={ false }
 				showSiteNameOnCards={ false }
-				isDiscoverStream={ this.props.isDiscoverStream }>
+				isDiscoverStream={ this.props.isDiscoverStream }
+				shouldCombinedCards={ false }
+			>
 				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: title } ) } />
 				<RefreshFeedHeader site={ site } feed={ this.state.feed } showBack={ this.props.showBack } />
 				{ featuredContent }

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -162,7 +162,7 @@ class SiteStream extends React.Component {
 				showPostHeader={ false }
 				showSiteNameOnCards={ false }
 				isDiscoverStream={ this.props.isDiscoverStream }
-				shouldCombinedCards={ false }
+				shouldCombineCards={ false }
 			>
 				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: title } ) } />
 				<RefreshFeedHeader site={ site } feed={ this.state.feed } showBack={ this.props.showBack } />

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -468,6 +468,13 @@ class ReaderStream extends React.Component {
 		return 'feed-post-' + ( postKey.feedId || postKey.blogId ) + '-' + postKey.postId;
 	}
 
+	handleConnectedCardClick = post => showSelectedPost( {
+		postKey: {
+			postId: post.feed_item_ID,
+			feedId: post.feed_ID,
+		}
+	} );
+
 	renderPost = ( postKey, index ) => {
 		const selectedPostKey = this.props.postsStore.getSelectedPost();
 		const isSelected = !! ( selectedPostKey &&
@@ -504,18 +511,11 @@ class ReaderStream extends React.Component {
 		}
 
 		if ( postKey.isCombination ) {
-			const handleClick = post => showSelectedPost( {
-				postKey: {
-					postId: post.feed_item_ID,
-					feedId: post.feed_ID,
-				}
-			} );
-
 			return <ConnectedCombinedCard
 						postKey={ postKey }
 						index={ index }
 						key={ `combined-card-${ index }` }
-						onClick={ handleClick }
+						onClick={ this.handleConnectedCardClick }
 					/>;
 		}
 

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -37,6 +37,7 @@ import { showSelectedPost } from 'reader/utils';
 import getBlockedSites from 'state/selectors/get-blocked-sites';
 import CombinedCard from 'blocks/reader-combined-card';
 import fluxPostAdapter from 'lib/reader-post-flux-adapter';
+import config from 'config';
 
 const ConnectedCombinedCard = fluxPostAdapter( CombinedCard );
 
@@ -205,7 +206,10 @@ class ReaderStream extends React.Component {
 		if ( ! this.state || posts !== this.state.posts || recs !== this.state.recs ) {
 			items = injectRecommendations( posts, recs );
 		}
-		items = combineCards( items );
+
+		if ( config.isEnabled( 'reader/combined-cards' ) ) {
+			items = combineCards( items );
+		}
 
 		return {
 			items,

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -500,6 +500,12 @@ class ReaderStream extends React.Component {
 						postKey={ postKey }
 						index={ index }
 						key={ `combined-card-${ index }` }
+						onClick={ post => showSelectedPost( {
+							postKey: {
+								postId: post.feed_item_ID,
+								feedId: post.feed_ID,
+							}
+						} ) }
 					/>;
 		}
 

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -43,6 +43,7 @@ const ConnectedCombinedCard = fluxPostAdapter( CombinedCard );
 
 const GUESSED_POST_HEIGHT = 600;
 const HEADER_OFFSET_TOP = 46;
+const MAX_COMBINED_CARD_POSTS = 5;
 
 function cardFactory( post ) {
 	if ( post.display_type & DISPLAY_TYPES.X_POST ) {
@@ -119,7 +120,7 @@ function combine( postKey1, postKey2 ) {
 const combineCards = ( postKeys ) => postKeys.reduce(
 	( accumulator, postKey ) => {
 		const lastPostKey = last( accumulator );
-		if ( sameSite( lastPostKey, postKey ) && ( ! lastPostKey.postIds || lastPostKey.postIds.length < 5 ) ) {
+		if ( sameSite( lastPostKey, postKey ) && ( ! lastPostKey.postIds || lastPostKey.postIds.length < MAX_COMBINED_CARD_POSTS ) ) {
 			accumulator[ accumulator.length - 1 ] = combine( last( accumulator ), postKey );
 		} else {
 			accumulator.push( postKey );

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -77,10 +77,11 @@ function getDistanceBetweenRecs() {
 }
 
 /**
- * Returns true if two postKeys are for the same siteId or feedId.
+ * Check if two postKeys are for the same siteId or feedId
  *
- * @param {*} postKey1
- * @param {*} postKey2
+ * @param {Object} postKey1 First post key
+ * @param {Object} postKey2 Second post key
+ * @returns {Boolean} Returns true if two postKeys are for the same siteId or feedId
  */
 function sameSite( postKey1, postKey2 ) {
 	return postKey1 && postKey2 &&
@@ -94,8 +95,9 @@ function sameSite( postKey1, postKey2 ) {
  * Takes two postKeys and combines them into a ReaderCombinedCard postKey.
  * Note: This only makes sense for postKeys from the same site
  *
- * @param {*} postKey1 must be either a ReaderCombinedCard postKey or a regular postKey
- * @param {*} postKey2 can only be a regular postKey. may not be a combinedCard postKey or a recommendations postKey
+ * @param {Object} postKey1 must be either a ReaderCombinedCard postKey or a regular postKey
+ * @param {Object} postKey2 can only be a regular postKey. May not be a combinedCard postKey or a recommendations postKey
+ * @returns {Object} A ReaderCombinedCard postKey
  */
 function combine( postKey1, postKey2 ) {
 	if ( ! postKey1 || ! postKey2 ) {
@@ -111,7 +113,7 @@ function combine( postKey1, postKey2 ) {
 			...( postKey1.postIds || [ postKey1.postId ] ),
 			...( postKey2.postIds || [ postKey2.postId ] ),
 		],
-	}
+	};
 }
 
 const combineCards = ( postKeys ) => postKeys.reduce(

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -4,7 +4,7 @@
 import ReactDom from 'react-dom';
 import React, { PropTypes } from 'react';
 import classnames from 'classnames';
-import { defer, flatMap, lastIndexOf, noop, times, clamp, includes, last } from 'lodash';
+import { defer, flatMap, lastIndexOf, noop, times, clamp, includes, last, startsWith } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -211,7 +211,10 @@ class ReaderStream extends React.Component {
 		}
 
 		if ( config.isEnabled( 'reader/combined-cards' ) ) {
-			items = combineCards( items );
+			// Create combined cards unless we're on a site or feed stream
+			if ( ! startsWith( store.id, 'feed:' ) && ! startsWith( store.id, 'site:' ) ) {
+				items = combineCards( items );
+			}
 		}
 
 		return {

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -22,7 +22,7 @@ class CrossPost extends PureComponent {
 		xMetadata: React.PropTypes.object.isRequired,
 		xPostedTo: React.PropTypes.array,
 		handleClick: React.PropTypes.func.isRequired,
-		translate: React.PropTypes.func.isRequried,
+		translate: React.PropTypes.func.isRequired,
 	}
 
 	handleTitleClick = ( event ) => {

--- a/client/reader/team/main.jsx
+++ b/client/reader/team/main.jsx
@@ -10,7 +10,10 @@ import Stream from 'reader/stream';
 
 const TeamStream = ( props ) => {
 	return (
-		<Stream { ...props }></Stream>
+		<Stream
+			{ ...props }
+			shouldCombineCards={ false }
+		/>
 	);
 };
 

--- a/config/development.json
+++ b/config/development.json
@@ -121,6 +121,7 @@
 		"press-this": true,
 		"push-notifications": true,
 		"reader": true,
+		"reader/combined-cards": true,
 		"reader/full-errors": true,
 		"reader/list-management": false,
 		"reader/recommendations/posts": true,

--- a/config/development.json
+++ b/config/development.json
@@ -121,7 +121,7 @@
 		"press-this": true,
 		"push-notifications": true,
 		"reader": true,
-		"reader/combined-cards": false,
+		"reader/combined-cards": true,
 		"reader/full-errors": true,
 		"reader/list-management": false,
 		"reader/recommendations/posts": true,

--- a/config/development.json
+++ b/config/development.json
@@ -121,7 +121,7 @@
 		"press-this": true,
 		"push-notifications": true,
 		"reader": true,
-		"reader/combined-cards": true,
+		"reader/combined-cards": false,
 		"reader/full-errors": true,
 		"reader/list-management": false,
 		"reader/recommendations/posts": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -91,6 +91,7 @@
 		"press-this": true,
 		"preview-layout": true,
 		"reader": true,
+		"reader/combined-cards": true,
 		"reader/full-errors": true,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,


### PR DESCRIPTION
This PR adds the new ReaderCombinedCard component (#11407) to streams.

It will bundle up consecutive posts from the same feed or site into one combined card rather than many individual post cards.

![c3f31c9c-f390-11e6-9fc2-a7a9ba6bd9db](https://cloud.githubusercontent.com/assets/17325/23703108/341eb4b6-03f6-11e7-881f-a6ee4dddc56e.png)
