### PR TITLE
Signup: Update themes/plans in post-domain-first flow

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -466,7 +466,7 @@ export default connect(
 				const planConstantObj = applyTestFiltersToPlansList( plan, abtest );
 				const planProductId = planConstantObj.getProductId();
 				const planObject = getPlan( state, planProductId );
-				const isLoadingSitePlans = ! isInSignup && ! sitePlans.hasLoadedFromServer;
+				const isLoadingSitePlans = selectedSiteId && ! sitePlans.hasLoadedFromServer;
 				const showMonthly = ! isMonthly( plan );
 				const available = isInSignup ? true : canUpgradeToPlan( plan ) && canPurchase;
 				const relatedMonthlyPlan = showMonthly ? getPlanBySlug( state, getMonthlyPlanByYearly( plan ) ) : null;

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -16,7 +16,6 @@ import PlanFeaturesItem from './item';
 import PlanFeaturesActions from './actions';
 import { isCurrentPlanPaid, isCurrentSitePlan, getSitePlan, getSiteSlug } from 'state/sites/selectors';
 import { isCurrentUserCurrentPlanOwner, getPlansBySiteId } from 'state/sites/plans/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getPlanDiscountedRawPrice } from 'state/sites/plans/selectors';
 import {
@@ -455,8 +454,8 @@ PlanFeatures.defaultProps = {
 
 export default connect(
 	( state, ownProps ) => {
-		const { isInSignup, placeholder, plans, onUpgradeClick, isLandingPage } = ownProps;
-		const selectedSiteId = isInSignup ? null : getSelectedSiteId( state );
+		const { isInSignup, placeholder, plans, onUpgradeClick, isLandingPage, site } = ownProps;
+		const selectedSiteId = site ? site.ID : null;
 		const sitePlan = getSitePlan( state, selectedSiteId );
 		const sitePlans = getPlansBySiteId( state, selectedSiteId );
 		const isPaid = isCurrentPlanPaid( state, selectedSiteId );

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -31,7 +31,10 @@ module.exports = {
 		stepName: 'themes-site-selected',
 		dependencies: [ 'siteSlug', 'themeSlugWithRepo' ],
 		providesDependencies: [ 'themeSlugWithRepo' ],
-		apiRequestFunction: stepActions.setThemeOnSite
+		apiRequestFunction: stepActions.setThemeOnSite,
+		props: {
+			headerText: i18n.translate( 'Choose a theme for your new site.' ),
+		}
 	},
 
 	'plans-site-selected': {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { connect } from 'react-redux';
 import React, { Component, PropTypes } from 'react';
 import { isEmpty } from 'lodash';
 import classNames from 'classnames';
@@ -11,6 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import analytics from 'lib/analytics';
 import { cartItems } from 'lib/cart-values';
+import { getSiteBySlug } from 'state/sites/selectors';
 import SignupActions from 'lib/signup/actions';
 import StepWrapper from 'signup/step-wrapper';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
@@ -66,13 +68,14 @@ class PlansStep extends Component {
 	}
 
 	plansFeaturesList() {
-		const {	hideFreePlan } = this.props;
+		const {	hideFreePlan, selectedSite } = this.props;
 
 		return (
 			<div>
 				<QueryPlans />
 
 				<PlansFeaturesMain
+					site={ selectedSite }
 					hideFreePlan={ hideFreePlan }
 					isInSignup={ true }
 					onUpgradeClick={ this.onSelectPlan }
@@ -123,9 +126,17 @@ PlansStep.propTypes = {
 	additionalStepData: PropTypes.object,
 	goToNextStep: PropTypes.func.isRequired,
 	hideFreePlan: PropTypes.bool,
+	selectedSite: PropTypes.object,
 	stepName: PropTypes.string.isRequired,
 	stepSectionName: PropTypes.string,
 	translate: PropTypes.func.isRequired,
 };
 
-export default localize( PlansStep );
+export default connect(
+	( state, { signupDependencies: { siteSlug } } ) => ( {
+		// This step could be used to set up an existing site, in which case
+		// some descendants of this component may display discounted prices if
+		// they apply to the given site.
+		selectedSite: siteSlug ? getSiteBySlug( state, siteSlug ) : null
+	} )
+)( localize( PlansStep ) );

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -75,7 +75,7 @@ class PlansStep extends Component {
 				<QueryPlans />
 
 				<PlansFeaturesMain
-					site={ selectedSite }
+					site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
 					hideFreePlan={ hideFreePlan }
 					isInSignup={ true }
 					onUpgradeClick={ this.onSelectPlan }

--- a/client/state/sites/plans/selectors.js
+++ b/client/state/sites/plans/selectors.js
@@ -61,7 +61,7 @@ export const getCurrentPlan = ( state, siteId ) => {
 export const getSitePlan = createSelector(
 	( state, siteId, productSlug ) => {
 		const plansBySiteId = getPlansBySiteId( state, siteId );
-		if ( ! plansBySiteId || plansBySiteId.isRequesting || ! plansBySiteId.data ) {
+		if ( ! plansBySiteId || ! plansBySiteId.data ) {
 			return null;
 		}
 		return plansBySiteId.data.filter( plan => plan.productSlug === productSlug ).shift();


### PR DESCRIPTION
Addresses parts of #11480.

This PR:

- Updates the themes step in signup to use a different header in the `site-selected` flow (`Choose a theme for your new site.`) per the issue above.
- Updates `PlanFeatures` to use the `site` prop it is provided instead of one from `connect`.
- Updates `PlansStep` to provide the selected site if it is present to `PlanFeaturesMain`. This ensures that discounts on the plans step are displayed if we're using `/start` to update an existing site.
- Updates the `getSitePlan` selector to return the desired site plan if it exists in state, regardless of whether or not it is being requested. This prevents an issue where the generic plan prices are displayed before the discounts are loaded.

**Testing**
*Site selected flow*
- Visit `/stats/day/:site_slug` for a domain-only site and click "Create Site".
- Assert that the header on the themes step reads "Choose a theme for your new site.".
- Continue to the plans step.
- Assert that you see discounted plan prices.

I also checked the following, and think it is important to do so:
- Asserted that `/plans/:site_slug` displays discounts for a non-DWPO site that has purchased a domain recently.
- Asserted that `/plans/:site_slug` does not display discounts for a free site.
- Asserted that it is possible to complete signup through `/start`, purchasing a domain/plan.
- Asserted that it is possible to complete signup through `/start` for a free site.
- Asserted that it is possible to complete signup through `/start/domain-first?new=DOMAIN` where `DOMAIN` is a valid, available domain name like `example-one-two-three.live`.

- [x] Code
- [x] Product