### PR TITLE
Revert 11729

### DIFF
--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import { get, set, omit, omitBy, isEqual, reduce, merge, findKey, mapValues, mapKeys } from 'lodash';
+import { get, set, omit, omitBy, isEqual, reduce, merge, findKey, mapValues } from 'lodash';
 
 /**
  * Internal dependencies
@@ -273,6 +273,7 @@ export function edits( state = {}, action ) {
 			} );
 
 		case EDITOR_STOP:
+		case POST_SAVE_SUCCESS:
 			if ( ! state.hasOwnProperty( action.siteId ) ) {
 				break;
 			}
@@ -280,20 +281,6 @@ export function edits( state = {}, action ) {
 			return Object.assign( {}, state, {
 				[ action.siteId ]: omit( state[ action.siteId ], action.postId || '' )
 			} );
-
-		case POST_SAVE_SUCCESS:
-			if ( ! state.hasOwnProperty( action.siteId ) || ! action.savedPost || action.postId ) {
-				break;
-			}
-			const { siteId, savedPost } = action;
-
-			// if postId is null, copy over any edits
-			return {
-				...state,
-				[ siteId ]: mapKeys( state[ siteId ], ( value, key ) => (
-					'' === key ? savedPost.ID : key
-				) )
-			};
 
 		case SERIALIZE:
 		case DESERIALIZE:

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -903,33 +903,26 @@ describe( 'reducer', () => {
 			expect( state ).to.equal( original );
 		} );
 
-		it( 'should copy edits when the post is saved and prior postId was null', () => {
+		it( 'should discard edits when the post is saved', () => {
 			const state = edits( deepFreeze( {
 				2916284: {
+					841: {
+						title: 'Hello World'
+					},
 					'': {
 						title: 'Ribs & Chicken'
-					},
-					842: {
-						title: 'I like turtles'
 					}
 				}
 			} ), {
 				type: POST_SAVE_SUCCESS,
 				siteId: 2916284,
-				postId: null,
-				savedPost: {
-					ID: 841,
-					title: 'Ribs'
-				}
+				postId: 841
 			} );
 
 			expect( state ).to.eql( {
 				2916284: {
-					841: {
+					'': {
 						title: 'Ribs & Chicken'
-					},
-					842: {
-						title: 'I like turtles'
 					}
 				}
 			} );


### PR DESCRIPTION
This branch is a manual revert of #11729 which is no longer properly clearing out edits to `terms` in the local state tree causing auto-save to appear it isn't working - although it is indeed working :)

__To Test__
- Open a new post in the editor
- Add a title, assign a tag and a category
- Click Save or wait for auto-save to kick in, note that the SAVE link should no longer appear after the save completes
- Attempt to navigate away, and confirm you aren't prompted that you have unsaved changes