### PR TITLE
Account Recovery: Add the new password form

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -13,6 +13,7 @@
 @import 'account-recovery/reset-password/reset-password-form/style';
 @import 'account-recovery/reset-password/reset-password-sms-form/style';
 @import 'account-recovery/reset-password/reset-password-email-form/style';
+@import 'account-recovery/reset-password/reset-password-confirm-form/style';
 @import 'account-recovery/reset-password/transaction-id-form/style';
 @import 'account-recovery/style';
 @import 'auth/style';

--- a/client/account-recovery/controller.js
+++ b/client/account-recovery/controller.js
@@ -14,6 +14,7 @@ import ResetPasswordForm from 'account-recovery/reset-password/reset-password-fo
 import ResetPasswordSmsForm from 'account-recovery/reset-password/reset-password-sms-form';
 import ResetPasswordEmailForm from 'account-recovery/reset-password/reset-password-email-form';
 import TransactionIdForm from 'account-recovery/reset-password/transaction-id-form';
+import ResetPasswordConfirmForm from 'account-recovery/reset-password/reset-password-confirm-form';
 import { getCurrentUser } from 'state/current-user/selectors';
 
 export function lostPassword( context, next ) {
@@ -60,6 +61,16 @@ export function resetPasswordByTransactionId( context, next ) {
 	context.primary = (
 		<ResetPasswordPage basePath={ context.path }>
 			<TransactionIdForm />
+		</ResetPasswordPage>
+	);
+
+	next();
+}
+
+export function resetPasswordConfirmForm( context, next ) {
+	context.primary = (
+		<ResetPasswordPage basePath={ context.path }>
+			<ResetPasswordConfirmForm />
 		</ResetPasswordPage>
 	);
 

--- a/client/account-recovery/index.js
+++ b/client/account-recovery/index.js
@@ -8,6 +8,7 @@ import {
 	resetPasswordSmsForm,
 	resetPasswordEmailForm,
 	resetPasswordByTransactionId,
+	resetPasswordConfirmForm,
 	redirectLoggedIn
 } from './controller';
 import config from 'config';
@@ -21,5 +22,6 @@ export default function( router ) {
 		router( '/account-recovery/reset-password/sms-form', redirectLoggedIn, resetPasswordSmsForm );
 		router( '/account-recovery/reset-password/email-form', redirectLoggedIn, resetPasswordEmailForm );
 		router( '/account-recovery/reset-password/transaction-id', redirectLoggedIn, resetPasswordByTransactionId );
+		router( '/account-recovery/reset-password/confirm', redirectLoggedIn, resetPasswordConfirmForm );
 	}
 }

--- a/client/account-recovery/reset-password/reset-password-confirm-form/index.jsx
+++ b/client/account-recovery/reset-password/reset-password-confirm-form/index.jsx
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import FormTextInput from 'components/forms/form-text-input';
+import FormLegend from 'components/forms/form-legend';
+import FormButton from 'components/forms/form-button';
+
+class ResetPasswordConfirmForm extends Component {
+	render() {
+		const {
+			translate,
+		} = this.props;
+
+		return (
+			<div className="reset-password-confirm-form">
+				<h2>{ translate( 'Reset your password' ) }</h2>
+				<Card>
+					<FormLegend>{ translate( 'New password' ) }</FormLegend>
+					<FormTextInput />
+					<FormButton>{ translate( 'Generate strong password' ) }</FormButton>
+					<p>{ translate( '{{a}}Great passwords{{/a}} use upper and lower case characters' +
+							', numbers, and symbols like !/"$%&', { components: { a: <a href="#" /> }
+						} ) }</p>
+					<FormButton>{ translate( 'Reset Password' ) }</FormButton>
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default localize( ResetPasswordConfirmForm );

--- a/client/account-recovery/reset-password/reset-password-confirm-form/index.jsx
+++ b/client/account-recovery/reset-password/reset-password-confirm-form/index.jsx
@@ -1,49 +1,59 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React from 'react';
 import { localize } from 'i18n-calypso';
+import classNames from 'classnames';
+import { identity } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card';
 import FormTextInput from 'components/forms/form-text-input';
-import FormLegend from 'components/forms/form-legend';
+import FormLabel from 'components/forms/form-label';
 import FormButton from 'components/forms/form-button';
 import { STRONG_PASSWORD } from 'lib/url/support';
 
-class ResetPasswordConfirmForm extends Component {
-	render() {
-		const {
-			translate,
-		} = this.props;
+const ResetPasswordConfirmForm = ( props ) => {
+	const {
+		translate,
+		showPassword,
+	} = props;
 
-		return (
-			<Card>
-				<h2 className="reset-password-confirm-form__title">{ translate( 'Reset your password' ) }</h2>
-				<FormLegend>{ translate( 'New password' ) }</FormLegend>
-				<a href="#">{ translate( 'Hide' ) }</a>
-				<FormTextInput />
-				<FormButton className="reset-password-confirm-form__button generate-password-button" isPrimary={ false }>
-					{ translate( 'Generate strong password' ) }
-				</FormButton>
-				<p className="reset-password-confirm-form__description">
-					{ translate(
-						'{{a}}Great passwords{{/a}} use upper and lower case characters, numbers, and symbols like !/"$%&',
-						{
-							components: {
-								a: <a href={ STRONG_PASSWORD } target="_blank" rel="noopener noreferrer" />
-							}
+	return (
+		<Card>
+			<h2 className="reset-password-confirm-form__title">{ translate( 'Reset your password' ) }</h2>
+			<FormLabel className="reset-password-confirm-form__text-input-label" htmlFor="password">
+				{ translate( 'New password' ) }
+			</FormLabel>
+			<a className={ classNames( 'reset-password-confirm-form__show-hide-toggle', { show: showPassword } ) } href="#">
+				{ showPassword ? translate( 'Show' ) : translate( 'Hide' ) }
+			</a>
+			<FormTextInput className="reset-password-confirm-form__password-input-field" id="password" />
+			<FormButton className="reset-password-confirm-form__button generate-password-button" isPrimary={ false }>
+				{ translate( 'Generate strong password' ) }
+			</FormButton>
+			<p className="reset-password-confirm-form__description">
+				{ translate(
+					'{{a}}Great passwords{{/a}} use upper and lower case characters, numbers, and symbols like !/"$%&',
+					{
+						components: {
+							a: <a href={ STRONG_PASSWORD } target="_blank" rel="noopener noreferrer" />
 						}
-					) }
-				</p>
-				<FormButton className="reset-password-confirm-form__button submit">
-					{ translate( 'Reset Password' ) }
-				</FormButton>
-			</Card>
-		);
-	}
-}
+					}
+				) }
+			</p>
+			<FormButton className="reset-password-confirm-form__button submit">
+				{ translate( 'Reset Password' ) }
+			</FormButton>
+		</Card>
+	);
+};
+
+ResetPasswordConfirmForm.defaultProps = {
+	translate: identity,
+	showPassword: false,
+};
 
 export default localize( ResetPasswordConfirmForm );

--- a/client/account-recovery/reset-password/reset-password-confirm-form/index.jsx
+++ b/client/account-recovery/reset-password/reset-password-confirm-form/index.jsx
@@ -20,18 +20,28 @@ class ResetPasswordConfirmForm extends Component {
 		} = this.props;
 
 		return (
-			<div className="reset-password-confirm-form">
-				<h2>{ translate( 'Reset your password' ) }</h2>
-				<Card>
-					<FormLegend>{ translate( 'New password' ) }</FormLegend>
-					<FormTextInput />
-					<FormButton>{ translate( 'Generate strong password' ) }</FormButton>
-					<p>{ translate( '{{a}}Great passwords{{/a}} use upper and lower case characters' +
-							', numbers, and symbols like !/"$%&', { components: { a: <a href="#" /> }
-						} ) }</p>
-					<FormButton>{ translate( 'Reset Password' ) }</FormButton>
-				</Card>
-			</div>
+			<Card>
+				<h2 className="reset-password-confirm-form__title">{ translate( 'Reset your password' ) }</h2>
+				<FormLegend>{ translate( 'New password' ) }</FormLegend>
+				<a href="#">{ translate( 'Hide' ) }</a>
+				<FormTextInput />
+				<FormButton className="reset-password-confirm-form__button generate-password-button" isPrimary={ false }>
+					{ translate( 'Generate strong password' ) }
+				</FormButton>
+				<p className="reset-password-confirm-form__description">
+					{ translate(
+						'{{a}}Great passwords{{/a}} use upper and lower case characters, numbers, and symbols like !/"$%&',
+						{
+							components: {
+								a: <a href={ STRONG_PASSWORD } target="_blank" rel="noopener noreferrer" />
+							}
+						}
+					) }
+				</p>
+				<FormButton className="reset-password-confirm-form__button submit">
+					{ translate( 'Reset Password' ) }
+				</FormButton>
+			</Card>
 		);
 	}
 }

--- a/client/account-recovery/reset-password/reset-password-confirm-form/index.jsx
+++ b/client/account-recovery/reset-password/reset-password-confirm-form/index.jsx
@@ -11,6 +11,7 @@ import Card from 'components/card';
 import FormTextInput from 'components/forms/form-text-input';
 import FormLegend from 'components/forms/form-legend';
 import FormButton from 'components/forms/form-button';
+import { STRONG_PASSWORD } from 'lib/url/support';
 
 class ResetPasswordConfirmForm extends Component {
 	render() {

--- a/client/account-recovery/reset-password/reset-password-confirm-form/index.jsx
+++ b/client/account-recovery/reset-password/reset-password-confirm-form/index.jsx
@@ -29,10 +29,14 @@ const ResetPasswordConfirmForm = ( props ) => {
 			</FormButton>
 			<p className="reset-password-confirm-form__description">
 				{ translate(
-					'{{a}}Great passwords{{/a}} use upper and lower case characters, numbers, and symbols like !/"$%&',
+					'{{a}}Great passwords{{/a}} use upper and lower case characters, numbers, and symbols like {{em}}%(symbols)s{{/em}}.',
 					{
+						args: {
+							symbols: '!/"$%&',
+						},
 						components: {
-							a: <a href={ STRONG_PASSWORD } target="_blank" rel="noopener noreferrer" />
+							a: <a href={ STRONG_PASSWORD } target="_blank" rel="noopener noreferrer" />,
+							em: <em />,
 						}
 					}
 				) }

--- a/client/account-recovery/reset-password/reset-password-confirm-form/index.jsx
+++ b/client/account-recovery/reset-password/reset-password-confirm-form/index.jsx
@@ -3,23 +3,19 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import classNames from 'classnames';
 import { identity } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card';
-import FormTextInput from 'components/forms/form-text-input';
+import FormPasswordInput from 'components/forms/form-password-input';
 import FormLabel from 'components/forms/form-label';
 import FormButton from 'components/forms/form-button';
 import { STRONG_PASSWORD } from 'lib/url/support';
 
 const ResetPasswordConfirmForm = ( props ) => {
-	const {
-		translate,
-		showPassword,
-	} = props;
+	const { translate } = props;
 
 	return (
 		<Card>
@@ -27,10 +23,7 @@ const ResetPasswordConfirmForm = ( props ) => {
 			<FormLabel className="reset-password-confirm-form__text-input-label" htmlFor="password">
 				{ translate( 'New password' ) }
 			</FormLabel>
-			<a className={ classNames( 'reset-password-confirm-form__show-hide-toggle', { show: showPassword } ) } href="#">
-				{ showPassword ? translate( 'Show' ) : translate( 'Hide' ) }
-			</a>
-			<FormTextInput className="reset-password-confirm-form__password-input-field" id="password" />
+			<FormPasswordInput className="reset-password-confirm-form__password-input-field" id="password" />
 			<FormButton className="reset-password-confirm-form__button generate-password-button" isPrimary={ false }>
 				{ translate( 'Generate strong password' ) }
 			</FormButton>
@@ -53,7 +46,6 @@ const ResetPasswordConfirmForm = ( props ) => {
 
 ResetPasswordConfirmForm.defaultProps = {
 	translate: identity,
-	showPassword: false,
 };
 
 export default localize( ResetPasswordConfirmForm );

--- a/client/account-recovery/reset-password/reset-password-confirm-form/style.scss
+++ b/client/account-recovery/reset-password/reset-password-confirm-form/style.scss
@@ -13,38 +13,6 @@
 	margin: 4px 0;
 }
 
-.form-label.reset-password-confirm-form__text-input-label {
-	display: inline;
-	float: left;
-}
-
-.reset-password-confirm-form__show-hide-toggle {
-	display: inline;
-	float: right;
-	line-height: 16px;
-}
-
 .form-button.reset-password-confirm-form__button.generate-password-button {
 	line-height: 16px;
-}
-
-.form-button.reset-password-confirm-form__button.generate-password-button:before {
-	content: '\f427';
-	font: normal 16px/1 'Noticons';
-	margin-right: 5px;
-	vertical-align: top;
-}
-
-.reset-password-confirm-form__show-hide-toggle.show:before {
-	content: '\f403';
-	font: normal 16px/1 'Noticons';
-	margin-right: 5px;
-	vertical-align: top;
-}
-
-.reset-password-confirm-form__show-hide-toggle:before {
-	content: '\f404';
-	font: normal 16px/1 'Noticons';
-	margin-right: 5px;
-	vertical-align: top;
 }

--- a/client/account-recovery/reset-password/reset-password-confirm-form/style.scss
+++ b/client/account-recovery/reset-password/reset-password-confirm-form/style.scss
@@ -1,0 +1,50 @@
+.reset-password-confirm-form__title {
+	font-size: 20px;
+	font-weight: 600;
+	margin-bottom: 16px;
+}
+
+.form-button.reset-password-confirm-form__button {
+	width: 100%;
+	margin: 8px 0;
+}
+
+.reset-password-confirm-form__description {
+	margin: 4px 0;
+}
+
+.form-label.reset-password-confirm-form__text-input-label {
+	display: inline;
+	float: left;
+}
+
+.reset-password-confirm-form__show-hide-toggle {
+	display: inline;
+	float: right;
+	line-height: 16px;
+}
+
+.form-button.reset-password-confirm-form__button.generate-password-button {
+	line-height: 16px;
+}
+
+.form-button.reset-password-confirm-form__button.generate-password-button:before {
+	content: '\f427';
+	font: normal 16px/1 'Noticons';
+	margin-right: 5px;
+	vertical-align: top;
+}
+
+.reset-password-confirm-form__show-hide-toggle.show:before {
+	content: '\f403';
+	font: normal 16px/1 'Noticons';
+	margin-right: 5px;
+	vertical-align: top;
+}
+
+.reset-password-confirm-form__show-hide-toggle:before {
+	content: '\f404';
+	font: normal 16px/1 'Noticons';
+	margin-right: 5px;
+	vertical-align: top;
+}

--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -58,6 +58,7 @@ export default {
 	SEO_TAGS: `${ root }/getting-more-views-and-traffic/#use-appropriate-tags`,
 	SETTING_PRIMARY_DOMAIN: `${ root }/domains/#setting-the-primary-domain`,
 	SETTING_UP_PREMIUM_SERVICES: `${ root }/setting-up-premium-services`,
+	STRONG_PASSWORD: `${ root }/selecting-a-strong-password/`,
 	SHARING: `${ root }/sharing`,
 	START: `${ root }/start`,
 	STATS_CLICKS: `${ root }/stats/#clicks`,


### PR DESCRIPTION
## Summary
This PR adds the new password form of the whole account recovery flow:
![image](https://cloud.githubusercontent.com/assets/1842898/23701019/f29d0198-042f-11e7-9061-17598fbf42e8.png)
Note that all the buttons and toggles are not working in this PR. Those will be wired in the up-coming PR. 

One thing I'd really love to have feedbacks is the CSS code. My CSS skill is not even closed to an intermediate level, so I'm worrying that my code might have some responsiveness / cross-browser / backward compatible issues 😅

## Test Plan
* Open an incognito window, and make sure you are logged out.
* Visit http://calypso.localhost:3000/account-recovery/reset-password/confirm, and you should see the page.
* All the buttons and toggles can be clicked, but nothing should happen.
* The responsiveness should be intact.
