### PR TITLE
Enable domain-first signup flow for all environments

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -72,7 +72,7 @@
 		"republicize": false,
 		"rubberband-scroll-disable": true,
 		"settings/security/monitor": true,
-		"signup/domain-first-flow": false,
+		"signup/domain-first-flow": true,
 		"ui/first-view": false,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -85,7 +85,7 @@
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
-		"signup/domain-first-flow": false,
+		"signup/domain-first-flow": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,

--- a/config/production.json
+++ b/config/production.json
@@ -80,7 +80,7 @@
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
-		"signup/domain-first-flow": false,
+		"signup/domain-first-flow": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -90,7 +90,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,
-		"signup/domain-first-flow": false,
+		"signup/domain-first-flow": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,

--- a/config/test.json
+++ b/config/test.json
@@ -94,7 +94,7 @@
 		"republicize": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
-		"signup/domain-first-flow": false,
+		"signup/domain-first-flow": true,
 		"settings/security/monitor": true,
 		"support-user": true,
 		"sync-handler": true,


### PR DESCRIPTION
This pull request enables the `domain-first` signup flow for all environments.
 
![Screenshot](https://i02.hsncdn.com/is/image/HomeShoppingNetwork/prodfull/tortuga-golden-rum-cake-and-caribbean-key-lime-rum-cake-d-2015052012121358~431045_alt2.jpg)
  
#### Testing instructions
 
1. Run `git checkout update/enable-domain-first`
2. Start your server with `NODE_ENV=production make run`
3. Open the [`Signup` page](http://calypso.localhost:3000/start/domain-first?new=EXAMPLE.COM)
4. Check that you can create an account and purchase a domain

#### Reviews
 
- [x] Code
- [x] Product