### PR TITLE
Signup: Add a param to hide progress indicator in flows

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -228,7 +228,7 @@ if ( config.isEnabled( 'signup/domain-first-flow' ) ) {
 		destination: getSiteDestination,
 		providesDependenciesInQuery: [ 'siteSlug', 'siteId' ],
 		description: 'A flow to test updating an existing site with `Signup`',
-		lastModified: '2017-01-19',
+		lastModified: '2017-03-08',
 		hideProgressIndicator: true
 	};
 }

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -228,7 +228,8 @@ if ( config.isEnabled( 'signup/domain-first-flow' ) ) {
 		destination: getSiteDestination,
 		providesDependenciesInQuery: [ 'siteSlug', 'siteId' ],
 		description: 'A flow to test updating an existing site with `Signup`',
-		lastModified: '2017-01-19'
+		lastModified: '2017-01-19',
+		hideProgressIndicator: true
 	};
 }
 

--- a/client/signup/flow-progress-indicator/index.jsx
+++ b/client/signup/flow-progress-indicator/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React from 'react';
 
 /**
  * Internal dependencies
@@ -9,28 +9,25 @@ import React, { Component } from 'react';
 import flows from 'signup/config/flows';
 import { localize } from 'i18n-calypso';
 
-class FlowProgressIndicator extends Component {
-	render() {
-		const { flowName, positionInFlow, translate } = this.props,
-			flow = flows.getFlow( flowName ),
-			flowStepsLength = flow.steps.length,
-			hideProgressIndicator = flow.hideProgressIndicator;
+const FlowProgressIndicator = ( { flowName, positionInFlow, translate } ) => {
+	const flow = flows.getFlow( flowName ),
+		flowStepsLength = flow.steps.length,
+		hideProgressIndicator = flow.hideProgressIndicator;
 
-		if ( ! hideProgressIndicator && flowStepsLength > 1 ) {
-			return (
-				<div className="flow-progress-indicator">{
-					translate( 'Step %(stepNumber)d of %(stepTotal)d', {
-						args: {
-							stepNumber: positionInFlow + 1,
-							stepTotal: flowStepsLength
-						}
-					} )
-				}</div>
-			);
-		}
-
+	if ( hideProgressIndicator || flowStepsLength < 2 ) {
 		return null;
 	}
-}
+
+	return (
+		<div className="flow-progress-indicator">{
+			translate( 'Step %(stepNumber)d of %(stepTotal)d', {
+				args: {
+					stepNumber: positionInFlow + 1,
+					stepTotal: flowStepsLength
+				}
+			} )
+		}</div>
+	);
+};
 
 export default localize( FlowProgressIndicator );

--- a/client/signup/flow-progress-indicator/index.jsx
+++ b/client/signup/flow-progress-indicator/index.jsx
@@ -1,30 +1,28 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies
  */
-var flows = require( 'signup/config/flows' );
+import flows from 'signup/config/flows';
+import { localize } from 'i18n-calypso';
 
-module.exports = React.createClass( {
-	displayName: 'FlowProgressIndicator',
+class FlowProgressIndicator extends Component {
+	render() {
+		const { flowName, positionInFlow, translate } = this.props,
+			flow = flows.getFlow( flowName ),
+			flowStepsLength = flow.steps.length,
+			hideProgressIndicator = flow.hideProgressIndicator;
 
-	getFlowLength: function() {
-		var flow = flows.getFlow( this.props.flowName );
-
-		return flow.steps.length;
-	},
-
-	render: function() {
-		if ( this.getFlowLength() > 1 ) {
+		if ( ! hideProgressIndicator && flowStepsLength > 1 ) {
 			return (
 				<div className="flow-progress-indicator">{
-					this.translate( 'Step %(stepNumber)d of %(stepTotal)d', {
+					translate( 'Step %(stepNumber)d of %(stepTotal)d', {
 						args: {
-							stepNumber: this.props.positionInFlow + 1,
-							stepTotal: this.getFlowLength()
+							stepNumber: positionInFlow + 1,
+							stepTotal: flowStepsLength
 						}
 					} )
 				}</div>
@@ -33,4 +31,6 @@ module.exports = React.createClass( {
 
 		return null;
 	}
-} );
+}
+
+export default localize( FlowProgressIndicator );


### PR DESCRIPTION
Added a param `hideProgressIndicator` to allow us to hide the progress indicator in certain flows.

Addresses parts of #11480.

Test:
1. Purchase domain using domain only site flow.
2. Go to My Sites.
3. Click `Create Site` button.
4. Shouldn't see the `Step # of #`.

### Review

* [ ] Code
* [ ] Product