### PR TITLE
Hide non-public post types from post selector in editor

### DIFF
--- a/client/components/tinymce/plugins/wplink/dialog.jsx
+++ b/client/components/tinymce/plugins/wplink/dialog.jsx
@@ -344,7 +344,8 @@ var LinkDialog = React.createClass( {
 						{ this.props.site && (
 							<PostSelector
 								siteId={ this.props.site.ID }
-								type="public"
+								type="any"
+								excludePrivateTypes={ true }
 								status="publish"
 								orderBy="date"
 								order="DESC"

--- a/client/components/tinymce/plugins/wplink/dialog.jsx
+++ b/client/components/tinymce/plugins/wplink/dialog.jsx
@@ -344,7 +344,7 @@ var LinkDialog = React.createClass( {
 						{ this.props.site && (
 							<PostSelector
 								siteId={ this.props.site.ID }
-								type="any"
+								type="public"
 								status="publish"
 								orderBy="date"
 								order="DESC"

--- a/client/my-sites/post-selector/index.jsx
+++ b/client/my-sites/post-selector/index.jsx
@@ -66,7 +66,7 @@ export default React.createClass( {
 
 			memo[ snakeCase( key ) ] = value;
 			return memo;
-		}, { apiVersion: '1.2' } );
+		}, {} );
 	},
 
 	render() {

--- a/client/my-sites/post-selector/index.jsx
+++ b/client/my-sites/post-selector/index.jsx
@@ -65,7 +65,7 @@ export default React.createClass( {
 
 			memo[ snakeCase( key ) ] = value;
 			return memo;
-		}, {} );
+		}, { apiVersion: '1.2' } );
 	},
 
 	render() {

--- a/client/my-sites/post-selector/index.jsx
+++ b/client/my-sites/post-selector/index.jsx
@@ -17,6 +17,7 @@ export default React.createClass( {
 
 	propTypes: {
 		type: PropTypes.string,
+		excludePrivateTypes: PropTypes.bool,
 		siteId: PropTypes.number.isRequired,
 		status: PropTypes.string,
 		multiple: PropTypes.bool,
@@ -55,10 +56,10 @@ export default React.createClass( {
 	},
 
 	getQuery() {
-		const { type, status, excludeTree, orderBy, order } = this.props;
+		const { type, status, excludeTree, orderBy, order, excludePrivateTypes } = this.props;
 		const { search } = this.state;
 
-		return reduce( { type, status, excludeTree, orderBy, order, search }, ( memo, value, key ) => {
+		return reduce( { type, status, excludeTree, orderBy, order, excludePrivateTypes, search }, ( memo, value, key ) => {
 			if ( null === value || undefined === value ) {
 				return memo;
 			}

--- a/client/my-sites/post-selector/selector.jsx
+++ b/client/my-sites/post-selector/selector.jsx
@@ -191,7 +191,7 @@ const PostSelectorPosts = React.createClass( {
 			return this.props.showTypeLabels;
 		}
 
-		return 'any' === this.props.query.type || 'public' === this.props.query.type;
+		return 'any' === this.props.query.type;
 	},
 
 	isLastPage() {

--- a/client/my-sites/post-selector/selector.jsx
+++ b/client/my-sites/post-selector/selector.jsx
@@ -34,6 +34,7 @@ import {
 	getSitePostsLastPageForQuery
 } from 'state/posts/selectors';
 import { getPostTypes } from 'state/post-types/selectors';
+import { isJetpackSite, isJetpackMinimumVersion } from 'state/sites/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
 import QueryPosts from 'components/data/query-posts';
 
@@ -51,6 +52,7 @@ const PostSelectorPosts = React.createClass( {
 	propTypes: {
 		siteId: PropTypes.number.isRequired,
 		query: PropTypes.object,
+		queryWithVersion: PropTypes.object,
 		posts: PropTypes.array,
 		lastPage: PropTypes.number,
 		loading: PropTypes.bool,
@@ -95,7 +97,7 @@ const PostSelectorPosts = React.createClass( {
 	},
 
 	componentWillReceiveProps( nextProps ) {
-		if ( ! isEqual( this.props.query, nextProps.query ) ||
+		if ( ! isEqual( this.props.queryWithVersion, nextProps.queryWithVersion ) ||
 				this.props.siteId !== nextProps.siteId ) {
 			this.setState( {
 				requestedPages: [ 1 ]
@@ -191,7 +193,7 @@ const PostSelectorPosts = React.createClass( {
 			return this.props.showTypeLabels;
 		}
 
-		return 'any' === this.props.query.type;
+		return 'any' === this.props.queryWithVersion.type;
 	},
 
 	isLastPage() {
@@ -234,8 +236,8 @@ const PostSelectorPosts = React.createClass( {
 	},
 
 	getPageForIndex( index ) {
-		const { query, lastPage } = this.props;
-		const perPage = query.number || DEFAULT_POSTS_PER_PAGE;
+		const { queryWithVersion, lastPage } = this.props;
+		const perPage = queryWithVersion.number || DEFAULT_POSTS_PER_PAGE;
 		const page = Math.ceil( index / perPage );
 
 		return Math.max( Math.min( page, lastPage || Infinity ), 1 );
@@ -393,7 +395,7 @@ const PostSelectorPosts = React.createClass( {
 	},
 
 	render() {
-		const { className, siteId, query } = this.props;
+		const { className, siteId, queryWithVersion } = this.props;
 		const { requestedPages, searchTerm } = this.state;
 		const isCompact = this.isCompact();
 		const isTypeLabelsVisible = this.isTypeLabelsVisible();
@@ -409,7 +411,7 @@ const PostSelectorPosts = React.createClass( {
 					<QueryPosts
 						key={ `page-${ page }` }
 						siteId={ siteId }
-						query={ { ...query, page } } />
+						query={ { ...queryWithVersion, page } } />
 				) ) }
 				{ isTypeLabelsVisible && siteId && (
 					<QueryPostTypes siteId={ siteId } />
@@ -421,7 +423,7 @@ const PostSelectorPosts = React.createClass( {
 				) }
 				<div className="post-selector__results">
 					<AutoSizer
-						key={ JSON.stringify( query ) }
+						key={ JSON.stringify( queryWithVersion ) }
 						disableHeight={ isCompact }>
 						{ ( { height, width } ) => (
 							<List
@@ -444,11 +446,18 @@ const PostSelectorPosts = React.createClass( {
 
 export default connect( ( state, ownProps ) => {
 	const { siteId, query } = ownProps;
+
+	const queryWithVersion = { ...query };
+	if ( ! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '99' ) ) {
+		queryWithVersion.apiVersion = '1.2';
+	}
+
 	return {
-		posts: getSitePostsForQueryIgnoringPage( state, siteId, query ),
-		found: getSitePostsFoundForQuery( state, siteId, query ),
-		lastPage: getSitePostsLastPageForQuery( state, siteId, query ),
-		loading: isRequestingSitePostsForQueryIgnoringPage( state, siteId, query ),
-		postTypes: getPostTypes( state, siteId )
+		posts: getSitePostsForQueryIgnoringPage( state, siteId, queryWithVersion ),
+		found: getSitePostsFoundForQuery( state, siteId, queryWithVersion ),
+		lastPage: getSitePostsLastPageForQuery( state, siteId, queryWithVersion ),
+		loading: isRequestingSitePostsForQueryIgnoringPage( state, siteId, queryWithVersion ),
+		postTypes: getPostTypes( state, siteId ),
+		queryWithVersion: queryWithVersion
 	};
 } )( PostSelectorPosts );

--- a/client/my-sites/post-selector/selector.jsx
+++ b/client/my-sites/post-selector/selector.jsx
@@ -447,10 +447,10 @@ const PostSelectorPosts = React.createClass( {
 export default connect( ( state, ownProps ) => {
 	const { siteId, query } = ownProps;
 
-	const queryWithVersion = { ...query };
-	if ( ! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '99' ) ) {
-		queryWithVersion.apiVersion = '1.2';
-	}
+	const apiVersion = ! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '99' )
+		? '1.2'
+		: undefined;
+	const queryWithVersion = { ...query, apiVersion };
 
 	return {
 		posts: getSitePostsForQueryIgnoringPage( state, siteId, queryWithVersion ),

--- a/client/my-sites/post-selector/selector.jsx
+++ b/client/my-sites/post-selector/selector.jsx
@@ -191,7 +191,7 @@ const PostSelectorPosts = React.createClass( {
 			return this.props.showTypeLabels;
 		}
 
-		return 'any' === this.props.query.type;
+		return 'any' === this.props.query.type || 'public' === this.props.query.type;
 	},
 
 	isLastPage() {

--- a/client/post-editor/editor-html-toolbar/add-link-dialog.jsx
+++ b/client/post-editor/editor-html-toolbar/add-link-dialog.jsx
@@ -192,7 +192,8 @@ export class AddLinkDialog extends Component {
 						selected={ selectedPost.id }
 						showTypeLabels
 						siteId={ siteId }
-						type="public"
+						type="any"
+						excludePrivateTypes={ true }
 					/>
 				</FormFieldset>
 			</Dialog>

--- a/client/post-editor/editor-html-toolbar/add-link-dialog.jsx
+++ b/client/post-editor/editor-html-toolbar/add-link-dialog.jsx
@@ -192,7 +192,7 @@ export class AddLinkDialog extends Component {
 						selected={ selectedPost.id }
 						showTypeLabels
 						siteId={ siteId }
-						type="any"
+						type="public"
 					/>
 				</FormFieldset>
 			</Dialog>

--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -80,7 +80,7 @@ export function requestSitePosts( siteId, query = {} ) {
 			source = source.me();
 		}
 
-		return source.postsList( query ).then( ( { found, posts } ) => {
+		return source.postsList( { ...query } ).then( ( { found, posts } ) => {
 			dispatch( receivePosts( posts ) );
 			dispatch( {
 				type: POSTS_REQUEST_SUCCESS,


### PR DESCRIPTION
This will fix #4940

**To test:**

1. Apply D4766-code to your sandbox and make sure you are sandboxing the API in browser
2. Select a site that has some private post types with at least one post there (Feedback for example)
3. Create a new post (doesn't matter which type)
4. Write some content and create a link using the link modal

<img width="210" alt="screen shot 2017-05-11 at 16 54 56" src="https://cloud.githubusercontent.com/assets/156676/25971529/9a762464-366a-11e7-9ce3-424af58fb033.png">

5. Make sure the list of suggested links contains only posts of public post types (post, page, portfolio project… and NOT feedback)
6. Search is not broken and the modal generally behaves as expected

**How it looks like:**

| Before | After |
| --- | --- |
| <img width="365" alt="screen shot 2017-05-11 at 16 57 59" src="https://cloud.githubusercontent.com/assets/156676/25971786/896dc478-366b-11e7-89b1-488aafb2f348.png"> | <img width="369" alt="screen shot 2017-05-11 at 16 59 12" src="https://cloud.githubusercontent.com/assets/156676/25971797/90c051dc-366b-11e7-81cd-9cd43673b039.png"> |