### PR TITLE
Site Settings: Use CompactFormToggle instead of FormToggle with classname

### DIFF
--- a/client/my-sites/site-settings/composing/after-the-deadline.jsx
+++ b/client/my-sites/site-settings/composing/after-the-deadline.jsx
@@ -13,7 +13,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLegend from 'components/forms/form-legend';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import TokenField from 'components/token-field';
-import FormToggle from 'components/forms/form-toggle';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -64,14 +64,13 @@ class AfterTheDeadline extends Component {
 			moduleUnavailable
 		} = this.props;
 		return (
-			<FormToggle
-				className="composing__module-settings-toggle is-compact"
+			<CompactFormToggle
 				checked={ !! fields[ name ] }
 				disabled={ isRequestingSettings || isSavingSettings || isDisabled || moduleUnavailable }
 				onChange={ handleToggle( name ) }
 			>
 				{ label }
-			</FormToggle>
+			</CompactFormToggle>
 		);
 	}
 

--- a/client/my-sites/site-settings/composing/markdown.jsx
+++ b/client/my-sites/site-settings/composing/markdown.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
  */
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
-import FormToggle from 'components/forms/form-toggle';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
 
 const Markdown = ( {
 	fields,
@@ -24,8 +24,7 @@ const Markdown = ( {
 				{ translate( 'Markdown' ) }
 			</FormLabel>
 			<FormLabel>
-				<FormToggle
-					className="is-compact"
+				<CompactFormToggle
 					name="wpcom_publish_posts_with_markdown"
 					checked={ !! fields.wpcom_publish_posts_with_markdown }
 					onChange={ handleToggle( 'wpcom_publish_posts_with_markdown' ) }
@@ -44,7 +43,7 @@ const Markdown = ( {
 							}
 						} )
 					}
-				</FormToggle>
+				</CompactFormToggle>
 			</FormLabel>
 		</FormFieldset>
 	);

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -12,7 +12,7 @@ import SectionHeader from 'components/section-header';
 import Card from 'components/card';
 import Button from 'components/button';
 import FormFieldset from 'components/forms/form-fieldset';
-import FormToggle from 'components/forms/form-toggle';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackModuleActive, isActivatingJetpackModule } from 'state/selectors';
 import { activateModule } from 'state/jetpack/modules/actions';
@@ -57,14 +57,13 @@ class CustomContentTypes extends Component {
 			handleToggle
 		} = this.props;
 		return (
-			<FormToggle
-				className="custom-content-types__module-settings-toggle is-compact"
+			<CompactFormToggle
 				checked={ !! fields[ name ] }
 				disabled={ this.isFormPending() || activatingCustomContentTypesModule }
 				onChange={ handleToggle( name ) }
 			>
 				{ label }
-			</FormToggle>
+			</CompactFormToggle>
 		);
 	}
 

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -18,7 +18,7 @@ import FormSelect from 'components/forms/form-select';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
-import FormToggle from 'components/forms/form-toggle';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import SectionHeader from 'components/section-header';
 import Subscriptions from './subscriptions';
@@ -42,27 +42,24 @@ class SiteSettingsFormDiscussion extends Component {
 		const { fields, handleToggle, isRequestingSettings, translate } = this.props;
 		return (
 			<FormFieldset>
-				<FormToggle
-					className="is-compact"
+				<CompactFormToggle
 					checked={ !! fields.default_pingback_flag }
 					disabled={ isRequestingSettings }
 					onChange={ handleToggle( 'default_pingback_flag' ) }>
 					<span>{ translate( 'Attempt to notify any blogs linked to from the article' ) }</span>
-				</FormToggle>
-				<FormToggle
-					className="is-compact"
+				</CompactFormToggle>
+				<CompactFormToggle
 					checked={ !! fields.default_ping_status }
 					disabled={ isRequestingSettings }
 					onChange={ handleToggle( 'default_ping_status' ) }>
 					<span>{ translate( 'Allow link notifications from other blogs (pingbacks and trackbacks)' ) }</span>
-				</FormToggle>
-				<FormToggle
-					className="is-compact"
+				</CompactFormToggle>
+				<CompactFormToggle
 					checked={ !! fields.default_comment_status }
 					disabled={ isRequestingSettings }
 					onChange={ handleToggle( 'default_comment_status' ) }>
 					<span>{ translate( 'Allow people to post comments on new articles' ) }</span>
-				</FormToggle>
+				</CompactFormToggle>
 				<FormSettingExplanation>
 					{ translate( 'These settings may be overridden for individual articles.' ) }
 				</FormSettingExplanation>
@@ -100,22 +97,19 @@ class SiteSettingsFormDiscussion extends Component {
 		const markdownSupported = fields.markdown_supported;
 		return (
 			<FormFieldset className="site-settings__other-comment-settings">
-				<FormToggle
-					className="is-compact"
+				<CompactFormToggle
 					checked={ !! fields.require_name_email }
 					disabled={ isRequestingSettings }
 					onChange={ handleToggle( 'require_name_email' ) }>
 					<span>{ translate( 'Comment author must fill out name and e-mail' ) }</span>
-				</FormToggle>
-				<FormToggle
-					className="is-compact"
+				</CompactFormToggle>
+				<CompactFormToggle
 					checked={ !! fields.comment_registration }
 					disabled={ isRequestingSettings }
 					onChange={ handleToggle( 'comment_registration' ) }>
 					<span>{ translate( 'Users must be registered and logged in to comment' ) }</span>
-				</FormToggle>
-				<FormToggle
-					className="is-compact"
+				</CompactFormToggle>
+				<CompactFormToggle
 					checked={ !! fields.close_comments_for_old_posts }
 					disabled={ isRequestingSettings }
 					onChange={ handleToggle( 'close_comments_for_old_posts' ) }>
@@ -132,9 +126,8 @@ class SiteSettingsFormDiscussion extends Component {
 							)
 						}
 					</span>
-				</FormToggle>
-				<FormToggle
-					className="is-compact"
+				</CompactFormToggle>
+				<CompactFormToggle
 					checked={ !! fields.thread_comments }
 					disabled={ isRequestingSettings }
 					onChange={ handleToggle( 'thread_comments' ) }>
@@ -147,9 +140,8 @@ class SiteSettingsFormDiscussion extends Component {
 							} )
 						}
 					</span>
-				</FormToggle>
-				<FormToggle
-					className="is-compact"
+				</CompactFormToggle>
+				<CompactFormToggle
 					checked={ !! fields.page_comments }
 					disabled={ isRequestingSettings }
 					onChange={ handleToggle( 'page_comments' ) }>
@@ -167,10 +159,9 @@ class SiteSettingsFormDiscussion extends Component {
 							)
 						}
 					</span>
-				</FormToggle>
+				</CompactFormToggle>
 				{ markdownSupported &&
-					<FormToggle
-						className="is-compact"
+					<CompactFormToggle
 						checked={ !! fields.wpcom_publish_comments_with_markdown }
 						disabled={ isRequestingSettings }
 						onChange={ handleToggle( 'wpcom_publish_comments_with_markdown' ) }>
@@ -186,15 +177,14 @@ class SiteSettingsFormDiscussion extends Component {
 								} )
 							}
 						</span>
-					</FormToggle>
+					</CompactFormToggle>
 				}
-				<FormToggle
-					className="is-compact"
+				<CompactFormToggle
 					checked={ 'asc' === fields.comment_order }
 					disabled={ isRequestingSettings }
 					onChange={ this.handleCommentOrder }>
 					<span>{ translate( 'Comments should be displayed with the older comments at the top of each page' ) }</span>
-				</FormToggle>
+				</CompactFormToggle>
 			</FormFieldset>
 		);
 	}
@@ -275,20 +265,18 @@ class SiteSettingsFormDiscussion extends Component {
 		return (
 			<FormFieldset>
 				<FormLegend>{ translate( 'E-mail me whenever' ) }</FormLegend>
-				<FormToggle
-					className="is-compact"
+				<CompactFormToggle
 					checked={ !! fields.comments_notify }
 					disabled={ isRequestingSettings }
 					onChange={ handleToggle( 'comments_notify' ) }>
 					<span>{ translate( 'Anyone posts a comment' ) }</span>
-				</FormToggle>
-				<FormToggle
-					className="is-compact"
+				</CompactFormToggle>
+				<CompactFormToggle
 					checked={ !! fields.moderation_notify }
 					disabled={ isRequestingSettings }
 					onChange={ handleToggle( 'moderation_notify' ) }>
 					<span>{ translate( 'A comment is held for moderation' ) }</span>
-				</FormToggle>
+				</CompactFormToggle>
 				{ this.emailMeLikes() }
 				{ this.emailMeReblogs() }
 				{ this.emailMeFollows() }
@@ -304,13 +292,12 @@ class SiteSettingsFormDiscussion extends Component {
 		}
 
 		return (
-			<FormToggle
-				className="is-compact"
+			<CompactFormToggle
 				checked={ !! fields.social_notifications_like }
 				disabled={ isRequestingSettings }
 				onChange={ handleToggle( 'social_notifications_like' ) }>
 				<span>{ translate( 'Someone likes one of my posts' ) }</span>
-			</FormToggle>
+			</CompactFormToggle>
 		);
 	}
 
@@ -322,13 +309,12 @@ class SiteSettingsFormDiscussion extends Component {
 		}
 
 		return (
-			<FormToggle
-				className="is-compact"
+			<CompactFormToggle
 				checked={ !! fields.social_notifications_reblog }
 				disabled={ isRequestingSettings }
 				onChange={ handleToggle( 'social_notifications_reblog' ) }>
 				<span>{ translate( 'Someone reblogs one of my posts' ) }</span>
-			</FormToggle>
+			</CompactFormToggle>
 		);
 	}
 
@@ -340,13 +326,12 @@ class SiteSettingsFormDiscussion extends Component {
 		}
 
 		return (
-			<FormToggle
-				className="is-compact"
+			<CompactFormToggle
 				checked={ !! fields.social_notifications_subscribe }
 				disabled={ isRequestingSettings }
 				onChange={ handleToggle( 'social_notifications_subscribe' ) }>
 				<span>{ translate( 'Someone follows my blog' ) }</span>
-			</FormToggle>
+			</CompactFormToggle>
 		);
 	}
 
@@ -355,20 +340,18 @@ class SiteSettingsFormDiscussion extends Component {
 		return (
 			<FormFieldset>
 				<FormLegend>{ translate( 'Before a comment appears' ) }</FormLegend>
-				<FormToggle
-					className="is-compact"
+				<CompactFormToggle
 					checked={ !! fields.comment_moderation }
 					disabled={ isRequestingSettings }
 					onChange={ handleToggle( 'comment_moderation' ) }>
 					<span>{ translate( 'Comment must be manually approved' ) }</span>
-				</FormToggle>
-				<FormToggle
-					className="is-compact"
+				</CompactFormToggle>
+				<CompactFormToggle
 					checked={ !! fields.comment_whitelist }
 					disabled={ isRequestingSettings }
 					onChange={ handleToggle( 'comment_whitelist' ) }>
 					<span>{ translate( 'Comment author must have a previously approved comment' ) }</span>
-				</FormToggle>
+				</CompactFormToggle>
 			</FormFieldset>
 		);
 	}

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -26,6 +26,7 @@ import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
 import FormSelect from 'components/forms/form-select';
 import FormToggle from 'components/forms/form-toggle';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import Timezone from 'components/timezone';
 import JetpackSyncPanel from './jetpack-sync-panel';
@@ -324,8 +325,7 @@ class SiteSettingsFormGeneral extends Component {
 				<form>
 					<ul id="settings-jetpack">
 						<li>
-							<FormToggle
-								className="is-compact"
+							<CompactFormToggle
 								checked={ !! fields.jetpack_sync_non_public_post_stati }
 								disabled={ isRequestingSettings }
 								onChange={ handleToggle( 'jetpack_sync_non_public_post_stati' ) }
@@ -333,7 +333,7 @@ class SiteSettingsFormGeneral extends Component {
 								{ translate(
 									'Allow synchronization of Posts and Pages with non-public post statuses'
 								) }
-							</FormToggle>
+							</CompactFormToggle>
 							<FormSettingExplanation>
 								{ translate( '(e.g. drafts, scheduled, private, etc\u2026)' ) }
 							</FormSettingExplanation>
@@ -382,8 +382,7 @@ class SiteSettingsFormGeneral extends Component {
 				<FormLegend>{ translate( 'Holiday Snow' ) }</FormLegend>
 				<ul>
 					<li>
-						<FormToggle
-							className="is-compact"
+						<CompactFormToggle
 							checked={ !! fields.holidaysnow }
 							disabled={ isRequestingSettings }
 							onChange={ handleToggle( 'holidaysnow' ) }
@@ -391,7 +390,7 @@ class SiteSettingsFormGeneral extends Component {
 							{ translate(
 								'Show falling snow on my blog until January 4th.'
 							) }
-						</FormToggle>
+						</CompactFormToggle>
 					</li>
 				</ul>
 			</FormFieldset>
@@ -633,8 +632,7 @@ class SiteSettingsFormGeneral extends Component {
 
 		return (
 			<CompactCard>
-				<FormToggle
-					className="is-compact"
+				<CompactFormToggle
 					checked={ !! fields.api_cache }
 					disabled={ isRequestingSettings }
 					onChange={ handleToggle( 'api_cache' ) }
@@ -642,7 +640,7 @@ class SiteSettingsFormGeneral extends Component {
 					{ translate(
 						'Use synchronized data to boost performance'
 					) }
-				</FormToggle>
+				</CompactFormToggle>
 			</CompactCard>
 		);
 	}

--- a/client/my-sites/site-settings/media-settings/index.jsx
+++ b/client/my-sites/site-settings/media-settings/index.jsx
@@ -13,7 +13,7 @@ import JetpackModuleToggle from '../jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormSelect from 'components/forms/form-select';
 import FormLabel from 'components/forms/form-label';
-import FormToggle from 'components/forms/form-toggle';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
 import {
@@ -74,13 +74,12 @@ const MediaSettings = ( {
 					disabled={ isRequestingSettings || isSavingSettings }
 					/>
 				<div className="media-settings__module-settings site-settings__child-settings">
-					<FormToggle
-						className="media-settings__carousel-module-settings-toggle is-compact"
+					<CompactFormToggle
 						checked={ fields.carousel_display_exif || false }
 						disabled={ isRequestingSettings || isSavingSettings || ! carouselActive }
 						onChange={ handleAutosavingToggle( 'carousel_display_exif' ) } >
 						{ translate( 'Show photo metadata in carousel, when available' ) }
-					</FormToggle>
+					</CompactFormToggle>
 					<FormLabel className={ labelClassName } htmlFor="carousel_background_color">
 						{ translate( 'Background color' ) }
 					</FormLabel>

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
 import Card from 'components/card';
 import Button from 'components/button';
 import FormFieldset from 'components/forms/form-fieldset';
-import FormToggle from 'components/forms/form-toggle';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
 import SectionHeader from 'components/section-header';
 import RelatedContentPreview from './related-content-preview';
 
@@ -40,18 +40,16 @@ const RelatedPosts = ( {
 
 			<Card className="related-posts__card site-settings">
 				<FormFieldset>
-					<FormToggle
-						className="related-posts__settings-toggle is-compact"
+					<CompactFormToggle
 						checked={ !! fields.jetpack_relatedposts_enabled }
 						disabled={ isRequestingSettings }
 						onChange={ handleToggle( 'jetpack_relatedposts_enabled' ) }
 					>
 						{ translate( 'Show related content after posts' ) }
-					</FormToggle>
+					</CompactFormToggle>
 
 					<div className="related-posts__module-settings site-settings__child-settings">
-						<FormToggle
-							className="related-posts__settings-toggle is-compact"
+						<CompactFormToggle
 							checked={ !! fields.jetpack_relatedposts_show_headline }
 							disabled={ isRequestingSettings || ! fields.jetpack_relatedposts_enabled }
 							onChange={ handleToggle( 'jetpack_relatedposts_show_headline' ) }
@@ -59,10 +57,9 @@ const RelatedPosts = ( {
 							{ translate(
 								'Show a "Related" header to more clearly separate the related section from posts'
 							) }
-						</FormToggle>
+						</CompactFormToggle>
 
-						<FormToggle
-							className="related-posts__settings-toggle is-compact"
+						<CompactFormToggle
 							checked={ !! fields.jetpack_relatedposts_show_thumbnails }
 							disabled={ isRequestingSettings || ! fields.jetpack_relatedposts_enabled }
 							onChange={ handleToggle( 'jetpack_relatedposts_show_thumbnails' ) }
@@ -70,7 +67,7 @@ const RelatedPosts = ( {
 							{ translate(
 								'Use a large and visually striking layout'
 							) }
-						</FormToggle>
+						</CompactFormToggle>
 					</div>
 
 					<RelatedContentPreview

--- a/client/my-sites/site-settings/subscriptions/index.jsx
+++ b/client/my-sites/site-settings/subscriptions/index.jsx
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
 import CompactCard from 'components/card/compact';
 import JetpackModuleToggle from '../jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
-import FormToggle from 'components/forms/form-toggle';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import {
 	isJetpackModuleActive,
@@ -55,23 +55,21 @@ const Subscriptions = ( {
 						/>
 
 					<div className="subscriptions__module-settings site-settings__child-settings">
-						<FormToggle
-							className="subscriptions__module-settings-toggle is-compact"
+						<CompactFormToggle
 							checked={ !! fields.stb_enabled }
 							disabled={ isRequestingSettings || isSavingSettings || ! subscriptionsModuleActive || moduleUnavailable }
 							onChange={ handleToggle( 'stb_enabled' ) }
 						>
 							{ translate( 'Show a "follow blog" option in the comment form' ) }
-						</FormToggle>
+						</CompactFormToggle>
 
-						<FormToggle
-							className="subscriptions__module-settings-toggle is-compact"
+						<CompactFormToggle
 							checked={ !! fields.stc_enabled }
 							disabled={ isRequestingSettings || isSavingSettings || ! subscriptionsModuleActive || moduleUnavailable }
 							onChange={ handleToggle( 'stc_enabled' ) }
 						>
 							{ translate( 'Show a "follow comments" option in the comment form.' ) }
-						</FormToggle>
+						</CompactFormToggle>
 					</div>
 				</FormFieldset>
 			</CompactCard>

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -13,7 +13,7 @@ import Card from 'components/card';
 import Button from 'components/button';
 import JetpackModuleToggle from '../jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
-import FormToggle from 'components/forms/form-toggle';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackModuleActive } from 'state/selectors';
 import InfoPopover from 'components/info-popover';
@@ -32,14 +32,13 @@ class ThemeEnhancements extends Component {
 	renderToggle( name, isDisabled, label ) {
 		const { fields, handleToggle } = this.props;
 		return (
-			<FormToggle
-				className="theme-enhancements__module-settings-toggle is-compact"
+			<CompactFormToggle
 				checked={ !! fields[ name ] }
 				disabled={ this.isFormPending() || isDisabled }
 				onChange={ handleToggle( name ) }
 			>
 				{ label }
-			</FormToggle>
+			</CompactFormToggle>
 		);
 	}
 


### PR DESCRIPTION
This PR cleans up all `<FormToggle/>` usages that specify `classname="is-compact"` to actually use the component that's intended for that purpose - `CompactFormToggle`. This allows us to clean up some unnecessary `className` calls here and there within Site Settings.

To test:

* Checkout this branch
* Have a good look around all settings sections for a Jetpack site, verify there are no visual changes in any of them (compare with production).
* Have a good look around all settings sections for a WordPress.com site, verify there are no visual changes in any of them (compare with production).