### PR TITLE
Calypso Step 1 Signup copy test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -71,5 +71,13 @@ module.exports = {
 			updated: 50
 		},
 		defaultVariation: 'original'
+	}
+	signupCopy: {
+		datestamp: '20170307',
+		variations: {
+            oldSignupCopy: 50,
+            newSignupCopy: 50
+        },
+        defaultVariation: 'oldSignupCopy'
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -72,12 +72,12 @@ module.exports = {
 		},
 		defaultVariation: 'original'
 	}
-	signupCopy: {
+	signupStepOneCopyChanges: {
 		datestamp: '20170307',
 		variations: {
-            oldSignupCopy: 50,
-            newSignupCopy: 50
+            original: 50,
+            modified: 50
         },
-        defaultVariation: 'oldSignupCopy'
+        defaultVariation: 'original'
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -71,13 +71,13 @@ module.exports = {
 			updated: 50
 		},
 		defaultVariation: 'original'
-	}
+	},
 	signupStepOneCopyChanges: {
 		datestamp: '20170307',
 		variations: {
-            original: 50,
-            modified: 50
-        },
-        defaultVariation: 'original'
+			original: 50,
+			modified: 50,
+		},
+		defaultVariation: 'original',
 	},
 };

--- a/client/signup/steps/design-type-with-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/index.jsx
@@ -37,12 +37,22 @@ class DesignTypeWithStoreStep extends Component {
 	getChoices() {
 		const { translate } = this.props;
 
-		return [
-			{ type: 'blog', label: translate( 'A list of my latest posts' ), image: <BlogImage /> },
-			{ type: 'page', label: translate( 'A welcome page for my site' ), image: <PageImage /> },
-			{ type: 'grid', label: translate( 'A grid of my latest posts' ), image: <GridImage /> },
-			{ type: 'store', label: translate( 'An online store' ), image: <StoreImage /> },
-		];
+		switch ( abtest( 'signupCopy' ) ) {
+			case 'newSignupCopy':
+				return [
+						{ type: 'blog', label: 'Test copy for label', description: 'Test copy for description', image: <BlogImage /> },
+						{ type: 'page', label: 'Test copy for label', description: 'Test copy for description', image: <PageImage /> },
+						{ type: 'grid', label: 'Test copy for label', description: 'Test copy for description', image: <GridImage /> },
+						{ type: 'store', label: 'Test copy for label', description: 'Test copy for description', image: <StoreImage /> },
+				];
+			default:
+				return [
+						{ type: 'blog', label: translate( 'A list of my latest posts' ), image: <BlogImage /> },
+						{ type: 'page', label: translate( 'A welcome page for my site' ), image: <PageImage /> },
+						{ type: 'grid', label: translate( 'A grid of my latest posts' ), image: <GridImage /> },
+						{ type: 'store', label: translate( 'An online store' ), image: <StoreImage /> },
+				];
+		}
 	}
 
 	scrollUp() {
@@ -85,16 +95,35 @@ class DesignTypeWithStoreStep extends Component {
 	};
 
 	renderChoice = ( choice ) => {
-		return (
-			<Card className="design-type-with-store__choice" key={ choice.type }>
-				<a className="design-type-with-store__choice-link"
-					href="#"
-					onClick={ this.handleChoiceClick( choice.type ) }>
-					{ choice.image }
-					<h2>{ choice.label }</h2>
-				</a>
-			</Card>
-		);
+		switch ( abtest( 'signupCopy' ) ) {
+			case 'newSignupCopy':
+				return (
+					<Card className="design-type-with-store__choice" key={ choice.type }>
+						<a className="design-type-with-store__choice-link"
+							href="#"
+							onClick={ this.handleChoiceClick( choice.type ) }>
+							{ choice.image }
+							<div className="design-type-with-store__choice-copy">
+								<h2 className="design-type-with-store__choice-label">{ choice.label }</h2>
+								<p className="design-type-with-store__choice-description">{ choice.description }</p>
+							</div>
+						</a>
+					</Card>
+				);
+			default:
+				return (
+					<Card className="design-type-with-store__choice" key={ choice.type }>
+						<a className="design-type-with-store__choice-link"
+							href="#"
+							onClick={ this.handleChoiceClick( choice.type ) }>
+							{ choice.image }
+							<div className="design-type-with-store__choice-copy">
+								<h2 className="design-type-with-store__choice-label">{ choice.label }</h2>
+							</div>
+						</a>
+					</Card>
+				);
+		}
 	};
 
 	renderChoices() {
@@ -151,8 +180,25 @@ class DesignTypeWithStoreStep extends Component {
 		}
 	}
 
+	getHeaderText() {
+		const { translate } = this.props;
+		let headerText = translate( 'What would you like your homepage to look like?' );
+
+		if ( this.state.showStore ) {
+			headerText = translate( 'Create your WordPress Store' );
+		}
+
+		if ( abtest( 'signupCopy' ) === 'newSignupCopy' ) {
+			// Note: Don't make this translatable because it's only visible to English-language users
+			headerText = 'Test title for Header text';
+		}
+
+		return headerText;
+	}
+
 	getSubHeaderText() {
 		const { translate } = this.props;
+		let subHeaderText = translate( 'This will help us figure out what kinds of designs to show you.' );
 
 		if ( this.state.showStore ) {
 			switch ( abtest( 'signupStoreBenchmarking' ) ) {
@@ -167,16 +213,16 @@ class DesignTypeWithStoreStep extends Component {
 			}
 		}
 
-		return translate( 'This will help us figure out what kinds of designs to show you.' );
+		if ( abtest( 'signupCopy' ) === 'newSignupCopy' ) {
+			// Note: Don't make this translatable because it's only visible to English-language users
+			subHeaderText = 'Test title for subTitle';
+		}
+
+		return subHeaderText;
 	}
 
 	render() {
-		const { translate } = this.props;
-
-		const headerText = this.state.showStore
-			? translate( 'Create your WordPress Store' )
-			: translate( 'What would you like your homepage to look like?' );
-
+		const headerText = this.getHeaderText();
 		const subHeaderText = this.getSubHeaderText();
 
 		return (
@@ -186,11 +232,11 @@ class DesignTypeWithStoreStep extends Component {
 				positionInFlow={ this.props.positionInFlow }
 				fallbackHeaderText={ headerText }
 				fallbackSubHeaderText={ subHeaderText }
+				headerText={ headerText }
 				subHeaderText={ subHeaderText }
 				signupProgress={ this.props.signupProgress }
 				stepContent={ this.renderChoices() }
-				shouldHideNavButtons={ this.state.showStore }
-			/>
+				shouldHideNavButtons={ this.state.showStore } />
 		);
 	}
 }

--- a/client/signup/steps/design-type-with-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/index.jsx
@@ -40,10 +40,22 @@ class DesignTypeWithStoreStep extends Component {
 		if ( abtest( 'signupStepOneCopyChanges' ) === 'modified' ) {
 			// Note: Don't make this translatable because it's only visible to English-language users
 			return [
-				{ type: 'blog', label: 'Test copy for label', description: 'Test copy for description', image: <BlogImage /> },
-				{ type: 'page', label: 'Test copy for label', description: 'Test copy for description', image: <PageImage /> },
-				{ type: 'grid', label: 'Test copy for label', description: 'Test copy for description', image: <GridImage /> },
-				{ type: 'store', label: 'Test copy for label', description: 'Test copy for description', image: <StoreImage /> },
+				{ type: 'blog',
+					label: 'A blog',
+					description: 'To share your ideas, stories, and photographs with your followers.',
+					image: <BlogImage /> },
+				{ type: 'page',
+					label: 'A website',
+					description: 'To promote your business, organization, or brand and connect with your audience.',
+					image: <PageImage /> },
+				{ type: 'grid',
+					label: 'A portfolio',
+					description: 'To present your creative projects in a visual showcase.',
+					image: <GridImage /> },
+				{ type: 'store',
+					label: 'An online store',
+					description: 'To sell your products or services and accept payments.',
+					image: <StoreImage /> },
 			];
 		}
 
@@ -95,16 +107,22 @@ class DesignTypeWithStoreStep extends Component {
 	};
 
 	renderChoice = ( choice ) => {
-		let choiceDescription = <p className="design-type-with-store__choice-description">{ choice.description }</p>;
-		let choiceLabelClass = 'design-type-with-store__choice-label design-type-with-store__choice-label--with-arrow';
+		let choiceLabelClass = 'design-type-with-store__choice-label';
+		let choiceCardClass = 'design-type-with-store__choice';
+		let choiceDescription = null;
+		let callToAction = null;
 
-		if ( abtest( 'signupStepOneCopyChanges' ) === 'original' ) {
-			choiceDescription = null;
-			choiceLabelClass = 'design-type-with-store__choice-label';
+		if ( abtest( 'signupStepOneCopyChanges' ) === 'modified' ) {
+			choiceLabelClass = 'design-type-with-store__choice-label design-type-with-store__choice-label--test';
+			choiceCardClass = 'design-type-with-store__choice design-type-with-store__choice--test';
+			choiceDescription = <p className="design-type-with-store__choice-description">{ choice.description }</p>;
+			callToAction = <div className="design-type-with-store__choice-cta">
+								<span className="button is-compact">Create {choice.label}</span>
+							</div>;
 		}
 
 		return (
-			<Card className="design-type-with-store__choice" key={ choice.type }>
+			<Card className={ choiceCardClass } key={ choice.type }>
 				<a className="design-type-with-store__choice-link"
 					href="#"
 					onClick={ this.handleChoiceClick( choice.type ) }>
@@ -112,6 +130,7 @@ class DesignTypeWithStoreStep extends Component {
 					<div className="design-type-with-store__choice-copy">
 						<h2 className={ choiceLabelClass }>{ choice.label }</h2>
 						{ choiceDescription }
+						{ callToAction }
 					</div>
 				</a>
 			</Card>
@@ -119,6 +138,8 @@ class DesignTypeWithStoreStep extends Component {
 	};
 
 	renderChoices() {
+		let disclaimer = null;
+
 		const storeWrapperClassName = classNames(
 			'design-type-with-store__store-wrapper',
 			{ 'is-hidden': ! this.state.showStore }
@@ -129,6 +150,13 @@ class DesignTypeWithStoreStep extends Component {
 			{ 'is-hidden': this.state.showStore }
 		);
 
+		if ( abtest( 'signupStepOneCopyChanges' ) === 'modified' && ! this.state.showStore ) {
+			// Note: Don't make this translatable because it's only visible to English-language users
+			disclaimer = <p className="design-type-with-store__disclaimer">
+								Not sure? Pick the closest option. You can always change your settings later.
+							</p>;
+		}
+
 		return (
 			<div className="design-type-with-store__substep-wrapper">
 				<div className={ storeWrapperClassName }>
@@ -137,6 +165,7 @@ class DesignTypeWithStoreStep extends Component {
 				<div className={ designTypeListClassName }>
 					{ this.getChoices().map( this.renderChoice ) }
 				</div>
+				{ disclaimer }
 			</div>
 		);
 	}
@@ -174,18 +203,17 @@ class DesignTypeWithStoreStep extends Component {
 
 	getHeaderText() {
 		const { translate } = this.props;
-		let headerText = translate( 'What would you like your homepage to look like?' );
 
 		if ( this.state.showStore ) {
-			headerText = translate( 'Create your WordPress Store' );
+			return translate( 'Create your WordPress Store' );
 		}
 
 		if ( abtest( 'signupStepOneCopyChanges' ) === 'modified' ) {
 			// Note: Don't make this translatable because it's only visible to English-language users
-			headerText = 'Test title for Header text';
+			return 'Hello! Let’s create your new site.';
 		}
 
-		return headerText;
+		return translate( 'What would you like your homepage to look like?' );
 	}
 
 	getSubHeaderText() {
@@ -206,7 +234,7 @@ class DesignTypeWithStoreStep extends Component {
 
 		if ( abtest( 'signupStepOneCopyChanges' ) === 'modified' ) {
 			// Note: Don't make this translatable because it's only visible to English-language users
-			return 'Test title for subTitle';
+			return 'What kind of site do you need? Choose an option below:';
 		}
 
 		return translate( 'This will help us figure out what kinds of designs to show you.' );

--- a/client/signup/steps/design-type-with-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/index.jsx
@@ -37,22 +37,22 @@ class DesignTypeWithStoreStep extends Component {
 	getChoices() {
 		const { translate } = this.props;
 
-		switch ( abtest( 'signupStepOneCopyChanges' ) ) {
-			case 'modified':
-				return [
-					{ type: 'blog', label: 'Test copy for label', description: 'Test copy for description', image: <BlogImage /> },
-					{ type: 'page', label: 'Test copy for label', description: 'Test copy for description', image: <PageImage /> },
-					{ type: 'grid', label: 'Test copy for label', description: 'Test copy for description', image: <GridImage /> },
-					{ type: 'store', label: 'Test copy for label', description: 'Test copy for description', image: <StoreImage /> },
-				];
-			default:
-				return [
-					{ type: 'blog', label: translate( 'A list of my latest posts' ), image: <BlogImage /> },
-					{ type: 'page', label: translate( 'A welcome page for my site' ), image: <PageImage /> },
-					{ type: 'grid', label: translate( 'A grid of my latest posts' ), image: <GridImage /> },
-					{ type: 'store', label: translate( 'An online store' ), image: <StoreImage /> },
-				];
+		if ( abtest( 'signupStepOneCopyChanges' ) === 'modified' ) {
+			// Note: Don't make this translatable because it's only visible to English-language users
+			return [
+				{ type: 'blog', label: 'Test copy for label', description: 'Test copy for description', image: <BlogImage /> },
+				{ type: 'page', label: 'Test copy for label', description: 'Test copy for description', image: <PageImage /> },
+				{ type: 'grid', label: 'Test copy for label', description: 'Test copy for description', image: <GridImage /> },
+				{ type: 'store', label: 'Test copy for label', description: 'Test copy for description', image: <StoreImage /> },
+			];
 		}
+
+		return [
+			{ type: 'blog', label: translate( 'A list of my latest posts' ), image: <BlogImage /> },
+			{ type: 'page', label: translate( 'A welcome page for my site' ), image: <PageImage /> },
+			{ type: 'grid', label: translate( 'A grid of my latest posts' ), image: <GridImage /> },
+			{ type: 'store', label: translate( 'An online store' ), image: <StoreImage /> },
+		];
 	}
 
 	scrollUp() {
@@ -190,7 +190,6 @@ class DesignTypeWithStoreStep extends Component {
 
 	getSubHeaderText() {
 		const { translate } = this.props;
-		let subHeaderText = translate( 'This will help us figure out what kinds of designs to show you.' );
 
 		if ( this.state.showStore ) {
 			switch ( abtest( 'signupStoreBenchmarking' ) ) {
@@ -207,10 +206,10 @@ class DesignTypeWithStoreStep extends Component {
 
 		if ( abtest( 'signupStepOneCopyChanges' ) === 'modified' ) {
 			// Note: Don't make this translatable because it's only visible to English-language users
-			subHeaderText = 'Test title for subTitle';
+			return 'Test title for subTitle';
 		}
 
-		return subHeaderText;
+		return translate( 'This will help us figure out what kinds of designs to show you.' );
 	}
 
 	render() {

--- a/client/signup/steps/design-type-with-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/index.jsx
@@ -107,18 +107,16 @@ class DesignTypeWithStoreStep extends Component {
 	};
 
 	renderChoice = ( choice ) => {
-		let choiceLabelClass = 'design-type-with-store__choice-label';
 		let choiceCardClass = 'design-type-with-store__choice';
+		let choiceLabel = <h2 className="design-type-with-store__choice-label">{ choice.label }</h2>;
 		let choiceDescription = null;
 		let callToAction = null;
 
 		if ( abtest( 'signupStepOneCopyChanges' ) === 'modified' ) {
-			choiceLabelClass = 'design-type-with-store__choice-label design-type-with-store__choice-label--test';
+			choiceLabel = null;
 			choiceCardClass = 'design-type-with-store__choice design-type-with-store__choice--test';
 			choiceDescription = <p className="design-type-with-store__choice-description">{ choice.description }</p>;
-			callToAction = <div className="design-type-with-store__choice-cta">
-								<span className="button is-compact">Create {choice.label}</span>
-							</div>;
+			callToAction = <span className="button is-compact">Create {choice.label}</span>;
 		}
 
 		return (
@@ -128,9 +126,9 @@ class DesignTypeWithStoreStep extends Component {
 					onClick={ this.handleChoiceClick( choice.type ) }>
 					{ choice.image }
 					<div className="design-type-with-store__choice-copy">
-						<h2 className={ choiceLabelClass }>{ choice.label }</h2>
-						{ choiceDescription }
 						{ callToAction }
+						{ choiceLabel }
+						{ choiceDescription }
 					</div>
 				</a>
 			</Card>

--- a/client/signup/steps/design-type-with-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/index.jsx
@@ -116,7 +116,7 @@ class DesignTypeWithStoreStep extends Component {
 			choiceLabel = null;
 			choiceCardClass = 'design-type-with-store__choice design-type-with-store__choice--test';
 			choiceDescription = <p className="design-type-with-store__choice-description">{ choice.description }</p>;
-			callToAction = <span className="button is-compact">Create {choice.label}</span>;
+			callToAction = <span className="button is-compact design-type-with-store__cta">Start with {choice.label}</span>;
 		}
 
 		return (
@@ -126,8 +126,8 @@ class DesignTypeWithStoreStep extends Component {
 					onClick={ this.handleChoiceClick( choice.type ) }>
 					{ choice.image }
 					<div className="design-type-with-store__choice-copy">
-						{ callToAction }
 						{ choiceLabel }
+						{ callToAction }
 						{ choiceDescription }
 					</div>
 				</a>
@@ -148,7 +148,7 @@ class DesignTypeWithStoreStep extends Component {
 			{ 'is-hidden': this.state.showStore }
 		);
 
-		if ( abtest( 'signupStepOneCopyChanges' ) === 'modified' && ! this.state.showStore ) {
+		if ( abtest( 'signupStepOneCopyChanges' ) === 'modified' ) {
 			// Note: Don't make this translatable because it's only visible to English-language users
 			disclaimer = <p className="design-type-with-store__disclaimer">
 								Not sure? Pick the closest option. You can always change your settings later.
@@ -162,8 +162,8 @@ class DesignTypeWithStoreStep extends Component {
 				</div>
 				<div className={ designTypeListClassName }>
 					{ this.getChoices().map( this.renderChoice ) }
+					{ disclaimer }
 				</div>
-				{ disclaimer }
 			</div>
 		);
 	}
@@ -211,7 +211,7 @@ class DesignTypeWithStoreStep extends Component {
 			return 'Hello! Let’s create your new site.';
 		}
 
-		return translate( 'What would you like your homepage to look like?' );
+		return translate( 'Let\'s get started.' );
 	}
 
 	getSubHeaderText() {

--- a/client/signup/steps/design-type-with-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/index.jsx
@@ -37,20 +37,20 @@ class DesignTypeWithStoreStep extends Component {
 	getChoices() {
 		const { translate } = this.props;
 
-		switch ( abtest( 'signupCopy' ) ) {
-			case 'newSignupCopy':
+		switch ( abtest( 'signupStepOneCopyChanges' ) ) {
+			case 'modified':
 				return [
-						{ type: 'blog', label: 'Test copy for label', description: 'Test copy for description', image: <BlogImage /> },
-						{ type: 'page', label: 'Test copy for label', description: 'Test copy for description', image: <PageImage /> },
-						{ type: 'grid', label: 'Test copy for label', description: 'Test copy for description', image: <GridImage /> },
-						{ type: 'store', label: 'Test copy for label', description: 'Test copy for description', image: <StoreImage /> },
+					{ type: 'blog', label: 'Test copy for label', description: 'Test copy for description', image: <BlogImage /> },
+					{ type: 'page', label: 'Test copy for label', description: 'Test copy for description', image: <PageImage /> },
+					{ type: 'grid', label: 'Test copy for label', description: 'Test copy for description', image: <GridImage /> },
+					{ type: 'store', label: 'Test copy for label', description: 'Test copy for description', image: <StoreImage /> },
 				];
 			default:
 				return [
-						{ type: 'blog', label: translate( 'A list of my latest posts' ), image: <BlogImage /> },
-						{ type: 'page', label: translate( 'A welcome page for my site' ), image: <PageImage /> },
-						{ type: 'grid', label: translate( 'A grid of my latest posts' ), image: <GridImage /> },
-						{ type: 'store', label: translate( 'An online store' ), image: <StoreImage /> },
+					{ type: 'blog', label: translate( 'A list of my latest posts' ), image: <BlogImage /> },
+					{ type: 'page', label: translate( 'A welcome page for my site' ), image: <PageImage /> },
+					{ type: 'grid', label: translate( 'A grid of my latest posts' ), image: <GridImage /> },
+					{ type: 'store', label: translate( 'An online store' ), image: <StoreImage /> },
 				];
 		}
 	}
@@ -95,35 +95,27 @@ class DesignTypeWithStoreStep extends Component {
 	};
 
 	renderChoice = ( choice ) => {
-		switch ( abtest( 'signupCopy' ) ) {
-			case 'newSignupCopy':
-				return (
-					<Card className="design-type-with-store__choice" key={ choice.type }>
-						<a className="design-type-with-store__choice-link"
-							href="#"
-							onClick={ this.handleChoiceClick( choice.type ) }>
-							{ choice.image }
-							<div className="design-type-with-store__choice-copy">
-								<h2 className="design-type-with-store__choice-label">{ choice.label }</h2>
-								<p className="design-type-with-store__choice-description">{ choice.description }</p>
-							</div>
-						</a>
-					</Card>
-				);
-			default:
-				return (
-					<Card className="design-type-with-store__choice" key={ choice.type }>
-						<a className="design-type-with-store__choice-link"
-							href="#"
-							onClick={ this.handleChoiceClick( choice.type ) }>
-							{ choice.image }
-							<div className="design-type-with-store__choice-copy">
-								<h2 className="design-type-with-store__choice-label">{ choice.label }</h2>
-							</div>
-						</a>
-					</Card>
-				);
+		let choiceDescription = <p className="design-type-with-store__choice-description">{ choice.description }</p>;
+		let choiceLabelClass = 'design-type-with-store__choice-label design-type-with-store__choice-label--with-arrow';
+
+		if ( abtest( 'signupStepOneCopyChanges' ) === 'original' ) {
+			choiceDescription = null;
+			choiceLabelClass = 'design-type-with-store__choice-label';
 		}
+
+		return (
+			<Card className="design-type-with-store__choice" key={ choice.type }>
+				<a className="design-type-with-store__choice-link"
+					href="#"
+					onClick={ this.handleChoiceClick( choice.type ) }>
+					{ choice.image }
+					<div className="design-type-with-store__choice-copy">
+						<h2 className={ choiceLabelClass }>{ choice.label }</h2>
+						{ choiceDescription }
+					</div>
+				</a>
+			</Card>
+		);
 	};
 
 	renderChoices() {
@@ -188,7 +180,7 @@ class DesignTypeWithStoreStep extends Component {
 			headerText = translate( 'Create your WordPress Store' );
 		}
 
-		if ( abtest( 'signupCopy' ) === 'newSignupCopy' ) {
+		if ( abtest( 'signupStepOneCopyChanges' ) === 'modified' ) {
 			// Note: Don't make this translatable because it's only visible to English-language users
 			headerText = 'Test title for Header text';
 		}
@@ -213,7 +205,7 @@ class DesignTypeWithStoreStep extends Component {
 			}
 		}
 
-		if ( abtest( 'signupCopy' ) === 'newSignupCopy' ) {
+		if ( abtest( 'signupStepOneCopyChanges' ) === 'modified' ) {
 			// Note: Don't make this translatable because it's only visible to English-language users
 			subHeaderText = 'Test title for subTitle';
 		}

--- a/client/signup/steps/design-type-with-store/style.scss
+++ b/client/signup/steps/design-type-with-store/style.scss
@@ -53,16 +53,25 @@
 		width: 100%; // Safari fix
 	}
 
-	h2 {
-		color: darken( $gray, 20% );
-		padding-left: 15px;
-		border-top: 1px solid transparentize( lighten( $gray, 20% ), .5 );
-		line-height: 54px;
-	}
-
 	&:hover {
 		box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20 );
 	}
+}
+
+.design-type-with-store__choice-copy {
+	padding: 15px;
+	border-top: 1px solid transparentize( lighten( $gray, 20% ), .5 );
+}
+
+.design-type-with-store__choice-label {
+	color: darken( $gray, 20% );
+	padding: 0;
+}
+
+.design-type-with-store__choice-description {
+	margin: 0;
+	color: $gray;
+	font-size: 0.875em;
 }
 
 .design-type-with-store__flex-container {

--- a/client/signup/steps/design-type-with-store/style.scss
+++ b/client/signup/steps/design-type-with-store/style.scss
@@ -77,12 +77,8 @@
 	position: relative;
 }
 
-.design-type-with-store__choice-cta {
-	margin-top: 10px;
-}
-
 .design-type-with-store__choice-description {
-	margin: 0;
+	margin: 10px 0 0;
 	color: $gray;
 	font-size: 0.875em;
 }

--- a/client/signup/steps/design-type-with-store/style.scss
+++ b/client/signup/steps/design-type-with-store/style.scss
@@ -83,6 +83,10 @@
 	font-size: 0.875em;
 }
 
+.button.design-type-with-store__cta {
+	color: $blue-wordpress;
+}
+
 .design-type-with-store__flex-container {
 	display: inline-flex;
 	flex-flow: row wrap;
@@ -236,4 +240,5 @@
 	text-align: center;
 	color: darken( $gray, 20 );
 	font-size: 0.875em;
+	width: 100%;
 }

--- a/client/signup/steps/design-type-with-store/style.scss
+++ b/client/signup/steps/design-type-with-store/style.scss
@@ -28,7 +28,6 @@
 .design-type-with-store__store-wrapper {
 	position: absolute;
 	width: 100%;
-
 	opacity: 1;
 	filter: blur( 0 );
 	transform: translateZ( 0 ) translateX( 0 );
@@ -47,6 +46,7 @@
 	width: 230px;
 	flex-grow: 1;
 	transition: all 100ms ease-in-out;
+	position: relative;
 
 	a, svg {
 		display: block;
@@ -58,6 +58,10 @@
 	}
 }
 
+.design-type-with-store__choice--test {
+	text-align: center;
+}
+
 .design-type-with-store__choice-copy {
 	padding: 15px;
 	border-top: 1px solid transparentize( lighten( $gray, 20% ), .5 );
@@ -66,6 +70,15 @@
 .design-type-with-store__choice-label {
 	color: darken( $gray, 20% );
 	padding: 0;
+}
+
+.design-type-with-store__choice-label--test {
+	color: $blue-wordpress;
+	position: relative;
+}
+
+.design-type-with-store__choice-cta {
+	margin-top: 10px;
 }
 
 .design-type-with-store__choice-description {
@@ -221,4 +234,10 @@
 	height: 30px;
 	display: block;
 	margin-bottom: 18px;
+}
+
+.design-type-with-store__disclaimer {
+	text-align: center;
+	color: darken( $gray, 20 );
+	font-size: 0.875em;
 }


### PR DESCRIPTION
This PR implements the Calypso signup copy test (internal reference: p5XAZ9-1la-p2). Our launch date is Monday **13 March**. Here's a summary of actions taken:

- [x] Implement A/B test
- [x] Implement copy and design
- [x] Identify testing parameters
- [x] Launch test

## Screenshots
**Control:** `original` 
<img width="1678" alt="screen shot 2017-03-10 at 10 12 49 am" src="https://cloud.githubusercontent.com/assets/6981253/23797384/2a7d75f2-057a-11e7-91ce-7cd4678b7410.png">

**Variant:** `modified`
<img width="1680" alt="screen shot 2017-03-10 at 9 36 20 am" src="https://cloud.githubusercontent.com/assets/6981253/23797091/be0cd2b0-0578-11e7-92a9-1a6211e442f9.png">

## Test parameters
Name: `signupStepOneCopyChanges`. 
Variants: `original` and `modified`. 

## Notes
I noticed that the `headerText` wasn't being passed to the `StepWrapper` component. Instead of saying "What would you like your homepage to look like?" it said "Let's get started." I fixed it on the control as well. 

@MicBosi @travisw @markryall can you guys take a look?