### PR TITLE
Domains: Show the fax field if it's in the WHOIS record

### DIFF
--- a/client/my-sites/upgrades/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/upgrades/domain-management/edit-contact-info/form-card.jsx
@@ -367,7 +367,7 @@ class EditContactInfoFormCard extends React.Component {
 	hasFaxField() {
 		const NETHERLANDS_TLD = '.nl';
 
-		return endsWith( this.props.selectedDomain.name, NETHERLANDS_TLD );
+		return endsWith( this.props.selectedDomain.name, NETHERLANDS_TLD ) || this.props.contactInformation.fax;
 	}
 
 	onChange = ( event ) => {


### PR DESCRIPTION
The fax field is only required for .nl domains, but in case it's already present in the WHOIS record, we should show it, as it can cause validation errors and thus prevent the user from successfully submitting the form.

### Testing
Go to the Edit Contact Info section for a domain (recommend an OpenHRS domain, as you don't need to disable privacy to edit the WHOIS). Either find a case that has a fax field or hack the frontend or backend to have the fax field prepopulated (bonus points for prepopulating it with invalid data).

Before:
<img width="688" alt="screen shot 2017-03-08 at 17 13 46" src="https://cloud.githubusercontent.com/assets/3392497/23712245/9e113322-0422-11e7-95b9-9a39ec5a51ae.png">

After (notice that the `Fax` field is now visible):
<img width="683" alt="screen shot 2017-03-08 at 17 14 43" src="https://cloud.githubusercontent.com/assets/3392497/23712295/c110d328-0422-11e7-88db-5fb975ca3892.png">

Make sure that the `Fax` field is not visible unless:
 * it's a `.nl` domain
 * or it already has a value.

Reported in `p2MSmN-5Qp-p2`
cc @ehti 