### PR TITLE
Icons: adding comments to inform of noticons deprecation

### DIFF
--- a/assets/stylesheets/shared/_extends.scss
+++ b/assets/stylesheets/shared/_extends.scss
@@ -1,3 +1,5 @@
+// DO NOT USE: noticons are DEPRECATED
+// see http://calypso.localhost:3000/devdocs/docs/icons.md
 %noticon {
 	@include clear-text;
 	display: inline-block;

--- a/assets/stylesheets/shared/mixins/_mixins.scss
+++ b/assets/stylesheets/shared/mixins/_mixins.scss
@@ -14,6 +14,9 @@
 //======================================================
 // Copied _extends rules that are used in @media
 //======================================================
+
+// DO NOT USE: noticons are DEPRECATED
+// see http://calypso.localhost:3000/devdocs/docs/icons.md
 @mixin noticon-style { //copy of %noticon
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;

--- a/assets/stylesheets/shared/mixins/_noticon.scss
+++ b/assets/stylesheets/shared/mixins/_noticon.scss
@@ -1,6 +1,6 @@
 // ==========================================================================
-// Noticon mixin (clearfix)
-// See http://calypso.localhost:3000/devdocs/docs/coding-guidelines/css.md
+// DO NOT USE: noticons are DEPRECATED
+// see http://calypso.localhost:3000/devdocs/docs/icons.md
 // ==========================================================================
 
 @mixin noticon($char, $size: null) {

--- a/docs/icons.md
+++ b/docs/icons.md
@@ -4,7 +4,7 @@ This document will cover how to use icons in Calypso, as well as how to create i
 
 ## Gridicons
 
-Gridicons is the brand new icon set designed from the bottom up for Calypso. It features a consistent style.
+[Gridicons](https://github.com/Automattic/gridicons) is the icon set designed from the bottom up for Calypso. It features a consistent style.
 
 Gridicons are born with a 24px base grid. Strokes are 2px thick and icons are solid. If an icon is hollow, it generally means the "inactive" version of that icon. For example an outline bookmark icon becomes solid once clicked.
 
@@ -66,4 +66,3 @@ Finally, build the favicon. Only include 16 and 32px sizes directly in the .ico 
 
 - [Favicon Cheat Sheet](https://github.com/audreyr/favicon-cheat-sheet)
 - [Favicon Quiz](https://css-tricks.com/favicon-quiz/)
-


### PR DESCRIPTION
In order to prevent noticons from being used, this adds `DO NOT USE` comments to the shared css files with noticons.

Also tweaking the icon readme.

