### PR TITLE
Site Settings: Make the toggles in Writing Settings for Theme Enhancements, autosave on toggle

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -112,7 +112,7 @@ class SiteSettingsFormWriting extends Component {
 
 							<ThemeEnhancements
 								onSubmitForm={ this.props.handleSubmitForm }
-								handleToggle={ handleToggle }
+								handleAutosavingToggle={ handleAutosavingToggle }
 								isSavingSettings={ isSavingSettings }
 								isRequestingSettings={ isRequestingSettings }
 								fields={ fields }

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -10,7 +10,6 @@ import { connect } from 'react-redux';
  */
 import SectionHeader from 'components/section-header';
 import Card from 'components/card';
-import Button from 'components/button';
 import JetpackModuleToggle from '../jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormToggle from 'components/forms/form-toggle';
@@ -30,13 +29,13 @@ class ThemeEnhancements extends Component {
 	}
 
 	renderToggle( name, isDisabled, label ) {
-		const { fields, handleToggle } = this.props;
+		const { fields, handleAutosavingToggle } = this.props;
 		return (
 			<FormToggle
 				className="theme-enhancements__module-settings-toggle is-compact"
 				checked={ !! fields[ name ] }
 				disabled={ this.isFormPending() || isDisabled }
-				onChange={ handleToggle( name ) }
+				onChange={ handleAutosavingToggle( name ) }
 			>
 				{ label }
 			</FormToggle>
@@ -45,26 +44,11 @@ class ThemeEnhancements extends Component {
 
 	renderHeader() {
 		const {
-			onSubmitForm,
-			isSavingSettings,
 			translate
 		} = this.props;
-		const formPending = this.isFormPending();
 
 		return (
-			<SectionHeader label={ translate( 'Theme Enhancements' ) }>
-				<Button
-					compact
-					primary
-					onClick={ onSubmitForm }
-					disabled={ formPending }
-				>
-					{ isSavingSettings
-						? translate( 'Saving…' )
-						: translate( 'Save Settings' )
-					}
-				</Button>
-			</SectionHeader>
+			<SectionHeader label={ translate( 'Theme Enhancements' ) } />
 		);
 	}
 
@@ -185,7 +169,7 @@ ThemeEnhancements.defaultProps = {
 
 ThemeEnhancements.propTypes = {
 	onSubmitForm: PropTypes.func.isRequired,
-	handleToggle: PropTypes.func.isRequired,
+	handleAutosavingToggle: PropTypes.func.isRequired,
 	isSavingSettings: PropTypes.bool,
 	isRequestingSettings: PropTypes.bool,
 	fields: PropTypes.object,

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -42,16 +42,6 @@ class ThemeEnhancements extends Component {
 		);
 	}
 
-	renderHeader() {
-		const {
-			translate
-		} = this.props;
-
-		return (
-			<SectionHeader label={ translate( 'Theme Enhancements' ) } />
-		);
-	}
-
 	renderInfiniteScrollSettings() {
 		const {
 			selectedSiteId,
@@ -145,9 +135,10 @@ class ThemeEnhancements extends Component {
 	}
 
 	render() {
+		const { translate } = this.props;
 		return (
 			<div>
-				{ this.renderHeader() }
+				<SectionHeader label={ translate( 'Theme Enhancements' ) } />
 
 				<Card className="theme-enhancements__card site-settings">
 					{ this.renderInfiniteScrollSettings() }


### PR DESCRIPTION
Part of #11676 

 This PR does the following:
* Makes the toggles under The **Theme Enhancements** settings, autosave on toggle.
* Removes the Save Settings button as every setting in the card is autosaving on change.

<img src="https://cloud.githubusercontent.com/assets/746152/23714340/8dfaec78-0407-11e7-9fc2-8eaae467ea78.gif" height="400px" />


#### Testing instructions

1. Get to `/settings/writing/site-slug` where `site-slug` is one of your connected Jetpack sites.
1. Get to the **Theme Enhancements** Card.
1. Toggle any of the children toggles.
2. Wait for the success notice to pop up.
3. Refresh the page and check that the setting value remains set as you left it before refreshing.


#### Why

While implementing a few toggles as part of #9171, we left some of them as regular toggles instead of autosaving ones as specified by the designs.
