### PR TITLE
Site Settings: Make the toggles in Writing Settings for Custom Content Types, autosave on toggle

### DIFF
--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -10,7 +10,6 @@ import { connect } from 'react-redux';
  */
 import SectionHeader from 'components/section-header';
 import Card from 'components/card';
-import Button from 'components/button';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormToggle from 'components/forms/form-toggle';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
@@ -54,14 +53,14 @@ class CustomContentTypes extends Component {
 		const {
 			activatingCustomContentTypesModule,
 			fields,
-			handleToggle
+			handleAutosavingToggle
 		} = this.props;
 		return (
 			<FormToggle
 				className="custom-content-types__module-settings-toggle is-compact"
 				checked={ !! fields[ name ] }
 				disabled={ this.isFormPending() || activatingCustomContentTypesModule }
-				onChange={ handleToggle( name ) }
+				onChange={ handleAutosavingToggle( name ) }
 			>
 				{ label }
 			</FormToggle>
@@ -70,26 +69,11 @@ class CustomContentTypes extends Component {
 
 	renderHeader() {
 		const {
-			onSubmitForm,
-			isSavingSettings,
 			translate
 		} = this.props;
-		const formPending = this.isFormPending();
 
 		return (
-			<SectionHeader label={ translate( 'Custom Content Types' ) }>
-				<Button
-					compact
-					primary
-					onClick={ onSubmitForm }
-					disabled={ formPending }
-				>
-					{ isSavingSettings
-						? translate( 'Saving…' )
-						: translate( 'Save Settings' )
-					}
-				</Button>
-			</SectionHeader>
+			<SectionHeader label={ translate( 'Custom Content Types' ) } />
 		);
 	}
 
@@ -186,7 +170,7 @@ CustomContentTypes.defaultProps = {
 
 CustomContentTypes.propTypes = {
 	onSubmitForm: PropTypes.func.isRequired,
-	handleToggle: PropTypes.func.isRequired,
+	handleAutosavingToggle: PropTypes.func.isRequired,
 	isSavingSettings: PropTypes.bool,
 	isRequestingSettings: PropTypes.bool,
 	fields: PropTypes.object,

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -67,16 +67,6 @@ class CustomContentTypes extends Component {
 		);
 	}
 
-	renderHeader() {
-		const {
-			translate
-		} = this.props;
-
-		return (
-			<SectionHeader label={ translate( 'Custom Content Types' ) } />
-		);
-	}
-
 	renderContentTypeSettings( fieldName, fieldLabel, fieldDescription ) {
 		return (
 			<div className="custom-content-types__module-settings">
@@ -147,9 +137,10 @@ class CustomContentTypes extends Component {
 	}
 
 	render() {
+		const { translate } = this.props;
 		return (
 			<div>
-				{ this.renderHeader() }
+				<SectionHeader label={ translate( 'Custom Content Types' ) } />
 
 				<Card className="custom-content-types__card site-settings">
 					<FormFieldset>

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -104,7 +104,7 @@ class SiteSettingsFormWriting extends Component {
 
 							<CustomContentTypes
 								onSubmitForm={ this.props.handleSubmitForm }
-								handleToggle={ handleToggle }
+								handleAutosavingToggle={ handleAutosavingToggle }
 								isSavingSettings={ isSavingSettings }
 								isRequestingSettings={ isRequestingSettings }
 								fields={ fields }


### PR DESCRIPTION
Part of #11676 

 This PR does the following:

* Makes the toggles under The **Custom Content Types** settings, autosave on toggle.
* Removes the Save Settings button as every setting in the card is autosaving on change.

<img src="https://cloud.githubusercontent.com/assets/746152/23716171/fee8ddfe-040d-11e7-9851-4fd99920623c.gif" height="400px" />


#### Testing instructions

1. Get to `/settings/writing/site-slug` where `site-slug` is one of your connected Jetpack sites.
1. Get to the **Custom Content Types** Card.
1. Toggle any of the settings.
2. Wait for the success notice to pop up.
3. Refresh the page and check that the setting value remains set as you left it before refreshing.


#### Why

While implementing a few toggles as part of #9171, we left some of them as regular toggles instead of autosaving ones as specified by the designs.
