### PR TITLE
Sharing: replace noticon with gridicon

### DIFF
--- a/client/my-sites/sharing/buttons/preview-action.jsx
+++ b/client/my-sites/sharing/buttons/preview-action.jsx
@@ -5,6 +5,11 @@ import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import { omit, startsWith, endsWith } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'gridicons';
+
 const SharingButtonsPreviewAction = ( props ) => {
 	const { active, position, icon, children } = props;
 	const classes = classNames( 'sharing-buttons-preview-action', {
@@ -17,7 +22,7 @@ const SharingButtonsPreviewAction = ( props ) => {
 
 	return (
 		<button type="button" className={ classes } { ...omit( props, [ 'active', 'position', 'icon' ] ) }>
-			{ icon && <span className={ 'noticon noticon-' + icon } /> }
+			{ icon && <Gridicon icon={ icon } size={ 18 } /> }
 			{ children }
 		</button>
 	);

--- a/client/my-sites/sharing/buttons/preview-placeholder.jsx
+++ b/client/my-sites/sharing/buttons/preview-placeholder.jsx
@@ -14,7 +14,7 @@ module.exports = React.createClass( {
 	render: function() {
 		return (
 			<div className="sharing-buttons-preview is-placeholder">
-				<ButtonsPreviewAction icon="edit" position="top-left" disabled={ true }>
+				<ButtonsPreviewAction icon="pencil" position="top-left" disabled={ true }>
 					{ this.translate( 'Edit label text', { context: 'Sharing: Buttons edit label' } ) }
 				</ButtonsPreviewAction>
 
@@ -38,10 +38,10 @@ module.exports = React.createClass( {
 				</div>
 
 				<div className="sharing-buttons-preview__button-tray-actions">
-					<ButtonsPreviewAction icon="edit" position="bottom-left" disabled={ true }>
+					<ButtonsPreviewAction icon="pencil" position="bottom-left" disabled={ true }>
 						{ this.translate( 'Edit visible buttons', { context: 'Sharing: Buttons edit label' } ) }
 					</ButtonsPreviewAction>
-					<ButtonsPreviewAction icon="edit" position="bottom-left" disabled={ true }>
+					<ButtonsPreviewAction icon="pencil" position="bottom-left" disabled={ true }>
 						{ this.translate( 'Edit “More” buttons', { context: 'Sharing: Buttons edit label' } ) }
 					</ButtonsPreviewAction>
 				</div>

--- a/client/my-sites/sharing/buttons/preview.jsx
+++ b/client/my-sites/sharing/buttons/preview.jsx
@@ -103,7 +103,7 @@ module.exports = React.createClass( {
 			<ButtonsPreviewAction
 				active={ null === this.state.buttonsTrayVisibility }
 				onClick={ this.showButtonsTray.bind( null, visibility ) }
-				icon={ enabledButtonsExist ? 'edit' : 'plus' }
+				icon={ enabledButtonsExist ? 'pencil' : 'plus' }
 				position="bottom-left">
 					{ this.getButtonsTrayToggleButtonLabel( visibility, enabledButtonsExist ) }
 			</ButtonsPreviewAction>
@@ -154,7 +154,7 @@ module.exports = React.createClass( {
 	render: function() {
 		return (
 			<div className="sharing-buttons-preview">
-				<ButtonsPreviewAction active={ ! this.state.isEditingLabel } onClick={ this.toggleEditLabel } icon="edit" position="top-left">
+				<ButtonsPreviewAction active={ ! this.state.isEditingLabel } onClick={ this.toggleEditLabel } icon="pencil" position="top-left">
 					{ this.translate( 'Edit label text', { context: 'Sharing: Buttons edit label' } ) }
 				</ButtonsPreviewAction>
 				<ButtonsLabelEditor

--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -697,14 +697,13 @@
 	position: relative;
 	overflow: visible;
 	display: none;
-	padding: 8px 8px 8px 26px;
+	align-items: center;
+	padding: 8px;
 	cursor: pointer;
 	border: 1px solid lighten( $gray, 20% );
 	border-radius: 4px;
 	box-shadow: 0 0 8px rgba( $gray-dark, 0.04 );
 	background-color: $white;
-	text-align: left;
-	line-height: 1;
 	color: $blue-wordpress;
 
 	@include breakpoint( "<480px") {
@@ -716,7 +715,7 @@
 	}
 
 	&.is-active {
-		display: inline-block;
+		display: inline-flex;
 	}
 
 	&.is-edit::before {
@@ -784,12 +783,8 @@
 	}
 }
 
-.sharing-buttons-preview-action .noticon {
-	position: absolute;
-	left: 6px;
-	top: 50%;
-	margin-top: -8px;
-	font-size: 16px;
+.sharing-buttons-preview-action .gridicon {
+	margin-right: 5px;
 }
 
 .sharing-buttons-preview__button-tray-actions {


### PR DESCRIPTION
Replaces noticons with gridicons

Uses `flex` to align icon and text.

To test, go to: wordpress.com/sharing/buttons/[siteurl]

Before:

![screen shot 2017-03-08 at 11 53 00 am](https://cloud.githubusercontent.com/assets/618551/23716509/20fe2c54-03f6-11e7-8ad6-42bc948c0510.png)

After:

![screen shot 2017-03-08 at 11 52 24 am](https://cloud.githubusercontent.com/assets/618551/23716514/237e7a42-03f6-11e7-8a45-7d0d5a281965.png)