### PR TITLE
Components: Add SubMasterbarNav component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -169,6 +169,7 @@
 @import 'components/spinner-line/style';
 @import 'components/stat-update-indicator/style';
 @import 'components/sticky-panel/style';
+@import 'components/sub-masterbar-nav/style';
 @import 'components/suggestions/style';
 @import 'components/textarea-autosize/style';
 @import 'components/thank-you-card/style';

--- a/client/components/sub-masterbar-nav/README.md
+++ b/client/components/sub-masterbar-nav/README.md
@@ -5,12 +5,12 @@ This component displays a navigation header under the masterbar.
 
 ### How to use:
 
-The component should be inserted into a ```Main``` component.  
-Options should contain a ```label``` and an ```uri```. If the latter matches the ```uri``` property of the component, it will be marked as selected.  
-In case no option is selected, the ```fallback``` value will be shown in the dropdown.
+The component should be inserted into a `Main` component.  
+Options should contain a `label` and an `uri`. If the latter matches the `uri` property of the component, it will be marked as selected.  
+In case no option is selected, the `fallback` value will be shown in the dropdown.
 
-```icon``` should be a valid gridicon name. The icon will be displayed next to/on top of the label.  
-If no ```icon``` is provided, ```star``` will be used by default.
+`icon` should be a valid gridicon name. The icon will be displayed next to/on top of the label.  
+If no `icon` is provided, `star` will be used by default.
 
 ```js
 const SubMasterbarNav = require( 'components/sub-masterbar-nav' );

--- a/client/components/sub-masterbar-nav/README.md
+++ b/client/components/sub-masterbar-nav/README.md
@@ -15,14 +15,14 @@ If no `icon` is provided, `star` will be used by default.
 ```js
 const SubMasterbarNav = require( 'components/sub-masterbar-nav' );
 
-const options = {
+const options = [
     {
         label: 'Home',
         uri: '/',
         icon: 'house'
     },
     ...
-};
+];
 
 render: function() {
     return {

--- a/client/components/sub-masterbar-nav/README.md
+++ b/client/components/sub-masterbar-nav/README.md
@@ -1,0 +1,37 @@
+Sub Masterbar Nav
+=================
+
+This component displays a navigation header under the masterbar.
+
+### How to use:
+
+The component should be inserted into a ```Main``` component.  
+Options should contain a ```label``` and an ```uri```. If the latter matches the ```uri``` property of the component, it will be marked as selected.  
+In case no option is selected, the ```fallback``` value will be shown in the dropdown.
+
+```icon``` should be a valid gridicon name. The icon will be displayed next to/on top of the label.  
+If no ```icon``` is provided, ```star``` will be used by default.
+
+```js
+const SubMasterbarNav = require( 'components/sub-masterbar-nav' );
+
+const options = {
+    {
+        label: 'Home',
+        uri: '/',
+        icon: 'house'
+    },
+    ...
+};
+
+render: function() {
+    return {
+        <Main>
+            <SubMasterbarNav
+                options={ options }
+                fallback={ options[ 0 ] }
+                uri={ '/foo/bar' } />
+        </Main>
+    };
+}
+```

--- a/client/components/sub-masterbar-nav/dropdown.jsx
+++ b/client/components/sub-masterbar-nav/dropdown.jsx
@@ -10,14 +10,17 @@ import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import Item from './item';
 
+const OptionShape = PropTypes.shape( {
+	label: PropTypes.string.isRequired,
+	uri: PropTypes.string.isRequired,
+	icon: PropTypes.string
+} );
+
 export default class Dropdown extends Component {
 
 	static propTypes = {
-		children: PropTypes.func.isRequired,
-		selected: PropTypes.shape( {
-			label: PropTypes.string.isRequired,
-			icon: PropTypes.string.isRequired
-		} )
+		selected: OptionShape,
+		options: PropTypes.arrayOf( OptionShape )
 	};
 
 	state = {
@@ -50,10 +53,22 @@ export default class Dropdown extends Component {
 				</div>
 				<div className="sub-masterbar-nav__wrapper">
 					<div className="sub-masterbar-nav__items">
-						{ this.props.children( { onSelect: this.collapse } ) }
+						{ this.props.options.map( this.renderItem ) }
 					</div>
 				</div>
 			</div>
+		);
+	}
+
+	renderItem = ( item, index ) => {
+		return (
+			<Item
+				key={ index }
+				onClick={ this.collapse }
+				label={ item.label }
+				icon={ item.icon }
+				href={ item.uri }
+			/>
 		);
 	}
 

--- a/client/components/sub-masterbar-nav/dropdown.jsx
+++ b/client/components/sub-masterbar-nav/dropdown.jsx
@@ -34,7 +34,7 @@ export default class Dropdown extends Component {
 
 	render() {
 		const className = classNames(
-			'sub-masterbar-nav',
+			'sub-masterbar-nav__dropdown',
 			{ 'is-collapsed': this.state.collapsed }
 		);
 

--- a/client/components/sub-masterbar-nav/dropdown.jsx
+++ b/client/components/sub-masterbar-nav/dropdown.jsx
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'gridicons';
+import Item from './item';
+
+export default class Dropdown extends Component {
+
+	static propTypes = {
+		children: PropTypes.func.isRequired,
+		selected: PropTypes.shape( {
+			label: PropTypes.string.isRequired,
+			icon: PropTypes.string.isRequired
+		} )
+	};
+
+	state = {
+		collapsed: true
+	};
+
+	componentDidMount() {
+		window.addEventListener( 'scroll', this.collapse );
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'scroll', this.collapse );
+	}
+
+	render() {
+		const className = classNames(
+			'sub-masterbar-nav',
+			{ 'is-collapsed': this.state.collapsed }
+		);
+
+		return (
+			<div className={ className }>
+				<div className="sub-masterbar-nav__select" onClick={ this.toggle }>
+					<Item
+						isSelected={ true }
+						label={ this.props.selected.label }
+						icon={ this.props.selected.icon }
+					/>
+					<Gridicon icon="chevron-down" className="sub-masterbar-nav__select-icon" />
+				</div>
+				<div className="sub-masterbar-nav__wrapper">
+					<div className="sub-masterbar-nav__items">
+						{ this.props.children( { onSelect: this.collapse } ) }
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	toggle = () => {
+		this.setState( ( state ) => ( {
+			collapsed: ! state.collapsed
+		} ) );
+	}
+
+	collapse = () => {
+		this.setState( () => ( {
+			collapsed: true
+		} ) );
+	}
+}

--- a/client/components/sub-masterbar-nav/index.jsx
+++ b/client/components/sub-masterbar-nav/index.jsx
@@ -42,13 +42,13 @@ export default class SubMasterbarNav extends Component {
 	componentDidMount() {
 		this.onResize();
 
-		window.addEventListener( 'resize', this.onResize.bind( this ) );
-		window.addEventListener( 'scroll', this.onScroll.bind( this ) );
+		window.addEventListener( 'resize', this.onResize );
+		window.addEventListener( 'scroll', this.onScroll );
 	}
 
 	componentWillUnmount() {
-		window.removeEventListener( 'resize', this.onResize.bind( this ) );
-		window.removeEventListener( 'scroll', this.onScroll.bind( this ) );
+		window.removeEventListener( 'resize', this.onResize );
+		window.removeEventListener( 'scroll', this.onScroll );
 	}
 
 	render() {
@@ -65,7 +65,7 @@ export default class SubMasterbarNav extends Component {
 		return (
 			<div className={ className }>
 				{ this.isDroppable( this.state.width ) &&
-					<div className="sub-masterbar-nav__select" onClick={ this.toggleList.bind( this ) }>
+					<div className="sub-masterbar-nav__select" onClick={ this.toggleList }>
 						<Item
 							isSelected={ true }
 							label={ this.getSelected().label }
@@ -81,7 +81,7 @@ export default class SubMasterbarNav extends Component {
 				</div>
 				{ this.isFoldable( this.state.width, this.props.options ) && (
 					<div className="sub-masterbar-nav__switch">
-						<Gridicon icon="ellipsis" className={ ellipsisClass } onClick={ this.toggleList.bind( this ) } />
+						<Gridicon icon="ellipsis" className={ ellipsisClass } onClick={ this.toggleList } />
 					</div>
 				)}
 			</div>
@@ -93,7 +93,7 @@ export default class SubMasterbarNav extends Component {
 			<Item
 				key={ index }
 				isSelected={ this.isSelected( item ) }
-				onClick={ this.selectItem.bind( this, item ) }
+				onClick={ this.onSelect }
 				label={ item.label }
 				icon={ item.icon }
 				href={ item.uri }
@@ -101,29 +101,25 @@ export default class SubMasterbarNav extends Component {
 		);
 	}
 
-	selectItem( option ) {
-		if ( ! option ) {
-			return;
-		}
-
-		this.setState( ( state ) => ( {
-			collapsed: this.isDroppable( state.width ) || state.collapsed
-		} ) );
-	}
-
-	toggleList() {
+	toggleList = () => {
 		this.setState( ( state ) => ( {
 			collapsed: ! state.collapsed
 		} ) );
 	}
 
-	onScroll() {
+	onSelect = () => {
+		this.setState( ( state ) => ( {
+			collapsed: this.isDroppable( state.width ) || state.collapsed
+		} ) );
+	}
+
+	onScroll = () => {
 		this.setState( ( state ) => ( {
 			collapsed: state.collapsed || this.isDroppable( state.width )
 		} ) );
 	}
 
-	onResize() {
+	onResize = () => {
 		const currentWidth = findDOMNode( this ).offsetWidth;
 
 		this.setState( ( state, props ) => ( {

--- a/client/components/sub-masterbar-nav/index.jsx
+++ b/client/components/sub-masterbar-nav/index.jsx
@@ -4,6 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { findDOMNode } from 'react-dom';
 import classNames from 'classnames';
+import { find } from 'lodash';
 
 import Gridicon from 'gridicons';
 import Item from './item';
@@ -149,9 +150,6 @@ export default class SubMasterbarNav extends Component {
 	}
 
 	getSelected() {
-		return this.props.options.reduce(
-			( selected, current ) => this.isSelected( current ) ? current : selected,
-			this.props.fallback
-		);
+		return find( this.props.options, ( option ) => this.isSelected( option ) ) || this.props.fallback;
 	}
 }

--- a/client/components/sub-masterbar-nav/index.jsx
+++ b/client/components/sub-masterbar-nav/index.jsx
@@ -12,22 +12,16 @@ import Navbar from './navbar';
 import Dropdown from './dropdown';
 import Item from './item';
 
+const OptionShape = PropTypes.shape( {
+	label: PropTypes.string.isRequired,
+	uri: PropTypes.string.isRequired,
+	icon: PropTypes.string
+} );
+
 export default class SubMasterbarNav extends Component {
 	static propTypes = {
-		fallback: PropTypes.shape(
-			{
-				label: PropTypes.string.isRequired,
-				uri: PropTypes.string.isRequired,
-				icon: PropTypes.string
-			}
-		),
-		options: PropTypes.arrayOf(
-			PropTypes.shape( {
-				label: PropTypes.string.isRequired,
-				uri: PropTypes.string.isRequired,
-				icon: PropTypes.string
-			} )
-		),
+		fallback: OptionShape,
+		options: PropTypes.arrayOf( OptionShape ),
 		uri: PropTypes.string.isRequired
 	};
 

--- a/client/components/sub-masterbar-nav/index.jsx
+++ b/client/components/sub-masterbar-nav/index.jsx
@@ -2,16 +2,15 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import { findDOMNode } from 'react-dom';
-import classNames from 'classnames';
-import { find } from 'lodash';
+import { find, noop } from 'lodash';
 
-import Gridicon from 'gridicons';
+/**
+ * Internal dependencies
+ */
+import { isWithinBreakpoint } from 'lib/viewport';
+import Navbar from './navbar';
+import Dropdown from './dropdown';
 import Item from './item';
-
-const VIEW_BREAKPOINT = 660;
-const VIEW_PADDING = 50;
-const ITEM_WIDTH = 110;
 
 export default class SubMasterbarNav extends Component {
 	static propTypes = {
@@ -44,57 +43,44 @@ export default class SubMasterbarNav extends Component {
 		this.onResize();
 
 		window.addEventListener( 'resize', this.onResize );
-		window.addEventListener( 'scroll', this.onScroll );
 	}
 
 	componentWillUnmount() {
 		window.removeEventListener( 'resize', this.onResize );
-		window.removeEventListener( 'scroll', this.onScroll );
 	}
 
 	render() {
-		const className = classNames(
-			'sub-masterbar-nav',
-			{ 'is-collapsed': this.state.collapsed }
-		);
+		if ( this.state.isDropdown ) {
+			return this.renderDropdown();
+		}
 
-		const ellipsisClass = classNames(
-			'sub-masterbar-nav__ellipsis',
-			{ 'is-open': ! this.state.collapsed }
-		);
+		return this.renderNavbar();
+	}
 
+	renderDropdown() {
 		return (
-			<div className={ className }>
-				{ this.isDroppable( this.state.width ) &&
-					<div className="sub-masterbar-nav__select" onClick={ this.toggleList }>
-						<Item
-							isSelected={ true }
-							label={ this.getSelected().label }
-							icon={ this.getSelected().icon }
-						/>
-						<Gridicon icon="chevron-down" className="sub-masterbar-nav__select-icon" />
-					</div>
-				}
-				<div className="sub-masterbar-nav__wrapper">
-					<div className="sub-masterbar-nav__items">
-						{ this.renderItems() }
-					</div>
-				</div>
-				{ this.isFoldable( this.state.width, this.props.options ) && (
-					<div className="sub-masterbar-nav__switch">
-						<Gridicon icon="ellipsis" className={ ellipsisClass } onClick={ this.toggleList } />
-					</div>
-				)}
-			</div>
+			<Dropdown selected={ this.getSelected() }>
+				{ ( { onSelect } ) => (
+					this.renderItems( onSelect )
+				) }
+			</Dropdown>
 		);
 	}
 
-	renderItems() {
+	renderNavbar() {
+		return (
+			<Navbar>
+				{ this.renderItems( noop ) }
+			</Navbar>
+		);
+	}
+
+	renderItems( onSelect ) {
 		return this.props.options.map( ( item, index ) =>
 			<Item
 				key={ index }
 				isSelected={ this.isSelected( item ) }
-				onClick={ this.onSelect }
+				onClick={ onSelect }
 				label={ item.label }
 				icon={ item.icon }
 				href={ item.uri }
@@ -102,47 +88,10 @@ export default class SubMasterbarNav extends Component {
 		);
 	}
 
-	toggleList = () => {
-		this.setState( ( state ) => ( {
-			collapsed: ! state.collapsed
-		} ) );
-	}
-
-	onSelect = () => {
-		this.setState( ( state ) => ( {
-			collapsed: this.isDroppable( state.width ) || state.collapsed
-		} ) );
-	}
-
-	onScroll = () => {
-		this.setState( ( state ) => ( {
-			collapsed: state.collapsed || this.isDroppable( state.width )
-		} ) );
-	}
-
 	onResize = () => {
-		const currentWidth = findDOMNode( this ).offsetWidth;
-
-		this.setState( ( state, props ) => ( {
-			width: currentWidth,
-			collapsed: state.collapsed || this.hasChangedView( state.width, currentWidth, props.options )
+		this.setState( () => ( {
+			isDropdown: isWithinBreakpoint( '<660px' )
 		} ) );
-	}
-
-	hasChangedView( oldWidth, newWidth, options ) {
-		const min = Math.min( oldWidth, newWidth );
-		const max = Math.max( oldWidth, newWidth );
-
-		return ( this.isDroppable( min ) && ! this.isDroppable( max ) ) ||
-			( this.isFoldable( min, options ) && ! this.isFoldable( max, options ) );
-	}
-
-	isFoldable( width, options ) {
-		return VIEW_BREAKPOINT < width && width < options.length * ITEM_WIDTH + VIEW_PADDING;
-	}
-
-	isDroppable( width ) {
-		return width <= VIEW_BREAKPOINT;
 	}
 
 	isSelected( option ) {

--- a/client/components/sub-masterbar-nav/index.jsx
+++ b/client/components/sub-masterbar-nav/index.jsx
@@ -1,0 +1,161 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { findDOMNode } from 'react-dom';
+import classNames from 'classnames';
+
+import Gridicon from 'gridicons';
+import Item from './item';
+
+const VIEW_BREAKPOINT = 660;
+const VIEW_PADDING = 50;
+const ITEM_WIDTH = 110;
+
+export default class SubMasterbarNav extends Component {
+	static propTypes = {
+		fallback: PropTypes.shape(
+			{
+				label: PropTypes.string.isRequired,
+				uri: PropTypes.string.isRequired,
+				icon: PropTypes.string
+			}
+		),
+		options: PropTypes.arrayOf(
+			PropTypes.shape( {
+				label: PropTypes.string.isRequired,
+				uri: PropTypes.string.isRequired,
+				icon: PropTypes.string
+			} )
+		),
+		uri: PropTypes.string.isRequired
+	};
+
+	static defaultProps = {
+		options: []
+	}
+
+	state = {
+		collapsed: true
+	};
+
+	componentDidMount() {
+		this.onResize();
+
+		window.addEventListener( 'resize', this.onResize.bind( this ) );
+		window.addEventListener( 'scroll', this.onScroll.bind( this ) );
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'resize', this.onResize.bind( this ) );
+		window.removeEventListener( 'scroll', this.onScroll.bind( this ) );
+	}
+
+	render() {
+		const className = classNames(
+			'sub-masterbar-nav',
+			{ 'is-collapsed': this.state.collapsed }
+		);
+
+		const ellipsisClass = classNames(
+			'sub-masterbar-nav__ellipsis',
+			{ 'is-open': ! this.state.collapsed }
+		);
+
+		return (
+			<div className={ className }>
+				{ this.isDroppable( this.state.width ) &&
+					<div className="sub-masterbar-nav__select" onClick={ this.toggleList.bind( this ) }>
+						<Item
+							isSelected={ true }
+							label={ this.getSelected().label }
+							icon={ this.getSelected().icon }
+						/>
+						<Gridicon icon="chevron-down" className="sub-masterbar-nav__select-icon" />
+					</div>
+				}
+				<div className="sub-masterbar-nav__wrapper">
+					<div className="sub-masterbar-nav__items">
+						{ this.renderItems() }
+					</div>
+				</div>
+				{ this.isFoldable( this.state.width, this.props.options ) && (
+					<div className="sub-masterbar-nav__switch">
+						<Gridicon icon="ellipsis" className={ ellipsisClass } onClick={ this.toggleList.bind( this ) } />
+					</div>
+				)}
+			</div>
+		);
+	}
+
+	renderItems() {
+		return this.props.options.map( ( item, index ) =>
+			<Item
+				key={ index }
+				isSelected={ this.isSelected( item ) }
+				onClick={ this.selectItem.bind( this, item ) }
+				label={ item.label }
+				icon={ item.icon }
+				href={ item.uri }
+			/>
+		);
+	}
+
+	selectItem( option ) {
+		if ( ! option ) {
+			return;
+		}
+
+		this.setState( ( state ) => ( {
+			collapsed: this.isDroppable( state.width ) || state.collapsed
+		} ) );
+	}
+
+	toggleList() {
+		this.setState( ( state ) => ( {
+			collapsed: ! state.collapsed
+		} ) );
+	}
+
+	onScroll() {
+		this.setState( ( state ) => ( {
+			collapsed: state.collapsed || this.isDroppable( state.width )
+		} ) );
+	}
+
+	onResize() {
+		const currentWidth = findDOMNode( this ).offsetWidth;
+
+		this.setState( ( state, props ) => ( {
+			width: currentWidth,
+			collapsed: state.collapsed || this.hasChangedView( state.width, currentWidth, props.options )
+		} ) );
+	}
+
+	hasChangedView( oldWidth, newWidth, options ) {
+		const min = Math.min( oldWidth, newWidth );
+		const max = Math.max( oldWidth, newWidth );
+
+		return ( this.isDroppable( min ) && ! this.isDroppable( max ) ) ||
+			( this.isFoldable( min, options ) && ! this.isFoldable( max, options ) );
+	}
+
+	isFoldable( width, options ) {
+		return VIEW_BREAKPOINT < width && width < options.length * ITEM_WIDTH + VIEW_PADDING;
+	}
+
+	isDroppable( width ) {
+		return width <= VIEW_BREAKPOINT;
+	}
+
+	isSelected( option ) {
+		return option.uri === this.props.uri;
+	}
+
+	getSelected() {
+		return this.props.options.reduce(
+			( selected, current ) => this.isSelected( current ) ? current : selected,
+			this.props.fallback
+		);
+	}
+}

--- a/client/components/sub-masterbar-nav/index.jsx
+++ b/client/components/sub-masterbar-nav/index.jsx
@@ -7,7 +7,6 @@ import { find, noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isWithinBreakpoint } from 'lib/viewport';
 import Navbar from './navbar';
 import Dropdown from './dropdown';
 import Item from './item';
@@ -29,43 +28,18 @@ export default class SubMasterbarNav extends Component {
 		options: []
 	}
 
-	state = {
-		collapsed: true
-	};
-
-	componentDidMount() {
-		this.onResize();
-
-		window.addEventListener( 'resize', this.onResize );
-	}
-
-	componentWillUnmount() {
-		window.removeEventListener( 'resize', this.onResize );
-	}
-
 	render() {
-		if ( this.state.isDropdown ) {
-			return this.renderDropdown();
-		}
-
-		return this.renderNavbar();
-	}
-
-	renderDropdown() {
 		return (
-			<Dropdown selected={ this.getSelected() }>
-				{ ( { onSelect } ) => (
-					this.renderItems( onSelect )
-				) }
-			</Dropdown>
-		);
-	}
-
-	renderNavbar() {
-		return (
-			<Navbar>
-				{ this.renderItems( noop ) }
-			</Navbar>
+			<div className="sub-masterbar-nav">
+				<Dropdown selected={ this.getSelected() }>
+					{ ( { onSelect } ) => (
+						this.renderItems( onSelect )
+					) }
+				</Dropdown>
+				<Navbar>
+					{ this.renderItems( noop ) }
+				</Navbar>
+			</div>
 		);
 	}
 
@@ -80,12 +54,6 @@ export default class SubMasterbarNav extends Component {
 				href={ item.uri }
 			/>
 		);
-	}
-
-	onResize = () => {
-		this.setState( () => ( {
-			isDropdown: isWithinBreakpoint( '<660px' )
-		} ) );
 	}
 
 	isSelected( option ) {

--- a/client/components/sub-masterbar-nav/index.jsx
+++ b/client/components/sub-masterbar-nav/index.jsx
@@ -2,14 +2,13 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import { find, noop } from 'lodash';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Navbar from './navbar';
 import Dropdown from './dropdown';
-import Item from './item';
 
 const OptionShape = PropTypes.shape( {
 	label: PropTypes.string.isRequired,
@@ -31,36 +30,13 @@ export default class SubMasterbarNav extends Component {
 	render() {
 		return (
 			<div className="sub-masterbar-nav">
-				<Dropdown selected={ this.getSelected() }>
-					{ ( { onSelect } ) => (
-						this.renderItems( onSelect )
-					) }
-				</Dropdown>
-				<Navbar>
-					{ this.renderItems( noop ) }
-				</Navbar>
+				<Dropdown selected={ this.getSelected() || this.props.fallback } options={ this.props.options } />
+				<Navbar selected={ this.getSelected() } options={ this.props.options } />
 			</div>
 		);
 	}
 
-	renderItems( onSelect ) {
-		return this.props.options.map( ( item, index ) =>
-			<Item
-				key={ index }
-				isSelected={ this.isSelected( item ) }
-				onClick={ onSelect }
-				label={ item.label }
-				icon={ item.icon }
-				href={ item.uri }
-			/>
-		);
-	}
-
-	isSelected( option ) {
-		return option.uri === this.props.uri;
-	}
-
 	getSelected() {
-		return find( this.props.options, ( option ) => this.isSelected( option ) ) || this.props.fallback;
+		return find( this.props.options, ( option ) => option.uri === this.props.uri );
 	}
 }

--- a/client/components/sub-masterbar-nav/item.jsx
+++ b/client/components/sub-masterbar-nav/item.jsx
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+import { noop } from 'lodash';
+
+import Gridicon from 'gridicons';
+
+export const Item = props => {
+	const {
+		isSelected,
+		onClick,
+		label,
+		icon,
+		href
+	} = props;
+
+	const classes = classNames(
+		'sub-masterbar-nav__item',
+		{ 'is-selected': isSelected }
+	);
+
+	return (
+		<a
+			href={ href }
+			className={ classes }
+			onClick={ onClick }
+			aria-selected={ isSelected }
+			role="menuitem">
+			<Gridicon className="sub-masterbar-nav__icon" icon={ icon } size={ 24 } />
+			<div className={ 'sub-masterbar-nav__label' }>
+				{ label }
+			</div>
+		</a>
+	);
+};
+
+Item.propTypes = {
+	isSelected: PropTypes.bool,
+	onClick: PropTypes.func,
+	label: PropTypes.string.isRequired,
+	icon: PropTypes.string,
+	href: PropTypes.string
+};
+
+Item.defaultProps = {
+	isSelected: false,
+	onClick: noop,
+	icon: 'star'
+};
+
+export default Item;

--- a/client/components/sub-masterbar-nav/item.jsx
+++ b/client/components/sub-masterbar-nav/item.jsx
@@ -5,6 +5,9 @@ import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import { noop } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
 import Gridicon from 'gridicons';
 
 export const Item = props => {

--- a/client/components/sub-masterbar-nav/navbar.jsx
+++ b/client/components/sub-masterbar-nav/navbar.jsx
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { findDOMNode } from 'react-dom';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'gridicons';
+
+const SIDE_PADDING = 50;
+const ITEM_WIDTH = 110;
+
+export default class Navbar extends Component {
+
+	static propTypes = {
+		children: PropTypes.array.isRequired
+	};
+
+	state = {
+		collapsed: true,
+		foldable: false
+	};
+
+	componentDidMount() {
+		this.onResize();
+
+		window.addEventListener( 'resize', this.onResize );
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'resize', this.onResize );
+	}
+
+	render() {
+		const className = classNames(
+			'sub-masterbar-nav',
+			{ 'is-collapsed': this.state.collapsed }
+		);
+
+		const ellipsisClass = classNames(
+			'sub-masterbar-nav__ellipsis',
+			{ 'is-open': ! this.state.collapsed }
+		);
+
+		return (
+			<div className={ className }>
+				<div className="sub-masterbar-nav__wrapper">
+					<div className="sub-masterbar-nav__items">
+						{ this.props.children }
+					</div>
+				</div>
+				{ this.state.foldable && (
+					<div className="sub-masterbar-nav__switch">
+						<Gridicon icon="ellipsis" className={ ellipsisClass } onClick={ this.toggleList } />
+					</div>
+				)}
+			</div>
+		);
+	}
+
+	toggleList = () => {
+		this.setState( ( state ) => ( {
+			collapsed: ! state.collapsed
+		} ) );
+	}
+
+	onResize = () => {
+		const width = findDOMNode( this ).offsetWidth;
+
+		this.setState( ( state, props ) => ( {
+			foldable: width < props.children.length * ITEM_WIDTH + SIDE_PADDING
+		} ) );
+	}
+}

--- a/client/components/sub-masterbar-nav/navbar.jsx
+++ b/client/components/sub-masterbar-nav/navbar.jsx
@@ -36,7 +36,7 @@ export default class Navbar extends Component {
 
 	render() {
 		const className = classNames(
-			'sub-masterbar-nav',
+			'sub-masterbar-nav__navbar',
 			{ 'is-collapsed': this.state.collapsed }
 		);
 

--- a/client/components/sub-masterbar-nav/navbar.jsx
+++ b/client/components/sub-masterbar-nav/navbar.jsx
@@ -9,14 +9,22 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import Gridicon from 'gridicons';
+import Item from './item';
 
 const SIDE_PADDING = 50;
 const ITEM_WIDTH = 110;
 
+const OptionShape = PropTypes.shape( {
+	label: PropTypes.string.isRequired,
+	uri: PropTypes.string.isRequired,
+	icon: PropTypes.string
+} );
+
 export default class Navbar extends Component {
 
 	static propTypes = {
-		children: PropTypes.array.isRequired
+		selected: OptionShape,
+		options: PropTypes.arrayOf( OptionShape )
 	};
 
 	state = {
@@ -49,7 +57,7 @@ export default class Navbar extends Component {
 			<div className={ className }>
 				<div className="sub-masterbar-nav__wrapper">
 					<div className="sub-masterbar-nav__items">
-						{ this.props.children }
+						{ this.props.options.map( this.renderItem ) }
 					</div>
 				</div>
 				{ this.state.foldable && (
@@ -58,6 +66,18 @@ export default class Navbar extends Component {
 					</div>
 				)}
 			</div>
+		);
+	}
+
+	renderItem = ( item, index ) => {
+		return (
+			<Item
+				key={ index }
+				isSelected={ item === this.props.selected }
+				label={ item.label }
+				icon={ item.icon }
+				href={ item.uri }
+			/>
 		);
 	}
 
@@ -71,7 +91,7 @@ export default class Navbar extends Component {
 		const width = findDOMNode( this ).offsetWidth;
 
 		this.setState( ( state, props ) => ( {
-			foldable: width < props.children.length * ITEM_WIDTH + SIDE_PADDING
+			foldable: width < props.options.length * ITEM_WIDTH + SIDE_PADDING
 		} ) );
 	}
 }

--- a/client/components/sub-masterbar-nav/style.scss
+++ b/client/components/sub-masterbar-nav/style.scss
@@ -1,4 +1,5 @@
-.sub-masterbar-nav {
+.sub-masterbar-nav__dropdown,
+.sub-masterbar-nav__navbar {
 	display: flex;
 	flex-direction: column;
 	padding: 56px 20px 28px;
@@ -22,6 +23,19 @@
 	}
 }
 
+.sub-masterbar-nav__dropdown {
+	@include breakpoint( ">660px" ) {
+		display: none;
+	}
+}
+
+.sub-masterbar-nav__navbar {
+	@include breakpoint( "<660px" ) {
+		display: none;
+	}
+}
+
+
 .sub-masterbar-nav__wrapper {
 	flex: 1;
 	position: relative;
@@ -42,7 +56,8 @@
 		border-bottom-left-radius: 5px;
 		border-bottom-right-radius: 5px;
 
-		.sub-masterbar-nav.is-collapsed & {
+		.sub-masterbar-nav__dropdown.is-collapsed &,
+		.sub-masterbar-nav__navbar.is-collapsed & {
 			display: none;
 		}
 	}

--- a/client/components/sub-masterbar-nav/style.scss
+++ b/client/components/sub-masterbar-nav/style.scss
@@ -1,0 +1,146 @@
+.sub-masterbar-nav {
+	display: flex;
+	flex-direction: column;
+	padding: 56px 20px 28px;
+	background-color: $masterbar-color;
+
+	&:not(.is-collapsed) .sub-masterbar-nav__select {
+		background-color: $blue-dark;
+		border-top-left-radius: 5px;
+		border-top-right-radius: 5px;
+	}
+
+	@include breakpoint( ">660px" ) {
+		flex-direction: row;
+		padding: 56px 20px 0 30px;
+
+		&.is-collapsed {
+			height: 128px;
+			overflow: hidden;
+			box-sizing: border-box;
+		}
+	}
+}
+
+.sub-masterbar-nav__wrapper {
+	flex: 1;
+	position: relative;
+	width: 100%;
+}
+
+.sub-masterbar-nav__items {
+	display: flex;
+	flex-direction: column;
+
+	@include breakpoint( "<660px" ) {
+		position: absolute;
+			top: 0;
+			left: 0;
+		z-index: 30;
+		width: 100%;
+		background-color: $blue-dark;
+		border-bottom-left-radius: 5px;
+		border-bottom-right-radius: 5px;
+
+		.sub-masterbar-nav.is-collapsed & {
+			display: none;
+		}
+	}
+
+	@include breakpoint( ">660px" ) {
+		flex-direction: row;
+		flex-wrap: wrap;
+	}
+}
+
+.sub-masterbar-nav__item {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	width: 100%;
+	height: 44px;
+	box-sizing: border-box;
+	background-color: transparent;
+	border: 0;
+	border-radius: 5px;
+	outline: 0;
+	color: $blue-light;
+	font-size: 14px;
+	cursor: pointer;
+
+	&:hover {
+		background-color: $blue-medium;
+		color: lighten( $gray, 30% );
+	}
+
+	&.is-selected {
+			background-color: $blue-dark;
+			color: $gray-light;
+	}
+
+	@include breakpoint( "<660px" ) {
+		padding: 0 15px;
+
+		.sub-masterbar-nav__items &.is-selected {
+			color: $blue-light;
+		}
+	}
+
+	@include breakpoint( ">660px" ) {
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		width: 100px;
+		height: 62px;
+		margin: 0 10px 10px 0;
+		font-size: 11px;
+		text-align: center;
+	}
+}
+
+.sub-masterbar-nav__icon {
+	display: inline-block;
+
+	@include breakpoint( "<660px" ) {
+		margin: 0 10px 0 0;
+	}
+}
+
+.sub-masterbar-nav__label {
+	text-transform: uppercase;
+}
+
+.sub-masterbar-nav__switch {
+	@include breakpoint( ">660px" ) {
+		display: flex;
+		flex-direction: column;
+		align-content: center;
+		justify-content: center;
+		height: 62px;
+		color: lighten( $gray, 30% );
+	}
+}
+
+.sub-masterbar-nav__ellipsis {
+	display: block;
+	outline: 0;
+	cursor: pointer;
+	transition: transform 0.2s;
+
+	&.is-open {
+		transform: rotate(90deg);
+	}
+}
+
+.sub-masterbar-nav__select {
+	position: relative;
+	width: 100%;
+}
+
+.sub-masterbar-nav__select-icon {
+	position: absolute;
+		top: 10px;
+		right: 15px;
+	color: lighten( $gray, 30% );
+	cursor: pointer;
+}

--- a/client/components/sub-masterbar-nav/test/dropdown.jsx
+++ b/client/components/sub-masterbar-nav/test/dropdown.jsx
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import React from 'react';
+import { shallow } from 'enzyme';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Dropdown from '../dropdown';
+import Item from '../item';
+
+describe( 'Dropdown', () => {
+	const options = [
+		{ label: 'sites', uri: '/sites', icon: 'star' },
+		{ label: 'more', uri: '/more', icon: 'star' }
+	];
+
+	const renderItems = ( onSelect ) => {
+		return options.map( ( item, index ) => (
+			<Item
+				key={ index }
+				onClick={ onSelect || noop }
+				label={ item.label }
+				icon={ item.icon }
+				href={ item.uri }
+			/>
+		) );
+	};
+
+	it( 'should render a dropdown given a child rendering function and the current selection', () => {
+		const wrapper = shallow(
+			<Dropdown selected={ { label: 'Select option', icon: 'home' } }>
+				{ () => renderItems() }
+			</Dropdown>
+		);
+
+		const select = wrapper.find( '.sub-masterbar-nav__select' );
+		const selected = select.find( Item );
+
+		expect( selected ).prop( 'label' ).to.equal( 'Select option' );
+		expect( selected ).prop( 'icon' ).to.equal( 'home' );
+
+		const list = wrapper.find( '.sub-masterbar-nav__items' );
+		const items = list.find( Item );
+
+		expect( items.length ).to.equal( 2 );
+		expect( items.at( 0 ).prop( 'label' ) ).to.equal( 'sites' );
+		expect( items.at( 1 ).prop( 'label' ) ).to.equal( 'more' );
+		expect( items.at( 0 ).prop( 'icon' ) ).to.equal( 'star' );
+		expect( items.at( 1 ).prop( 'icon' ) ).to.equal( 'star' );
+	} );
+
+	it( 'should be toggled by clicking the selected item', () => {
+		const wrapper = shallow(
+			<Dropdown selected={ { label: 'Select option', icon: 'home' } }>
+				{ () => renderItems() }
+			</Dropdown>
+		);
+
+		expect( wrapper.hasClass( 'is-collapsed' ) ).to.equal( true );
+
+		wrapper.find( '.sub-masterbar-nav__select' ).simulate( 'click' );
+
+		expect( wrapper.hasClass( 'is-collapsed' ) ).to.equal( false );
+
+		wrapper.find( '.sub-masterbar-nav__select' ).simulate( 'click' );
+
+		expect( wrapper.hasClass( 'is-collapsed' ) ).to.equal( true );
+	} );
+
+	it( 'should close after invoking onSelect from its children', () => {
+		const wrapper = shallow(
+			<Dropdown selected={ { label: 'Select option', icon: 'home' } }>
+				{ ( { onSelect } ) => renderItems( onSelect ) }
+			</Dropdown>
+		);
+
+		wrapper.find( '.sub-masterbar-nav__select' ).simulate( 'click' );
+
+		expect( wrapper.hasClass( 'is-collapsed' ) ).to.equal( false );
+
+		wrapper.find( '.sub-masterbar-nav__items' ).find( Item ).at( 1 ).simulate( 'click' );
+
+		expect( wrapper.hasClass( 'is-collapsed' ) ).to.equal( true );
+	} );
+} );

--- a/client/components/sub-masterbar-nav/test/dropdown.jsx
+++ b/client/components/sub-masterbar-nav/test/dropdown.jsx
@@ -4,7 +4,6 @@
 import { expect } from 'chai';
 import React from 'react';
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,23 +17,9 @@ describe( 'Dropdown', () => {
 		{ label: 'more', uri: '/more', icon: 'star' }
 	];
 
-	const renderItems = ( onSelect ) => {
-		return options.map( ( item, index ) => (
-			<Item
-				key={ index }
-				onClick={ onSelect || noop }
-				label={ item.label }
-				icon={ item.icon }
-				href={ item.uri }
-			/>
-		) );
-	};
-
-	it( 'should render a dropdown given a child rendering function and the current selection', () => {
+	it( 'should render a dropdown given a list of options and the current selection', () => {
 		const wrapper = shallow(
-			<Dropdown selected={ { label: 'Select option', icon: 'home' } }>
-				{ () => renderItems() }
-			</Dropdown>
+			<Dropdown selected={ { label: 'Select option', icon: 'home' } } options={ options } />
 		);
 
 		const select = wrapper.find( '.sub-masterbar-nav__select' );
@@ -55,9 +40,7 @@ describe( 'Dropdown', () => {
 
 	it( 'should be toggled by clicking the selected item', () => {
 		const wrapper = shallow(
-			<Dropdown selected={ { label: 'Select option', icon: 'home' } }>
-				{ () => renderItems() }
-			</Dropdown>
+			<Dropdown selected={ { label: 'Select option', icon: 'home' } } options={ options } />
 		);
 
 		expect( wrapper.hasClass( 'is-collapsed' ) ).to.equal( true );
@@ -73,9 +56,7 @@ describe( 'Dropdown', () => {
 
 	it( 'should close after invoking onSelect from its children', () => {
 		const wrapper = shallow(
-			<Dropdown selected={ { label: 'Select option', icon: 'home' } }>
-				{ ( { onSelect } ) => renderItems( onSelect ) }
-			</Dropdown>
+			<Dropdown selected={ { label: 'Select option', icon: 'home' } } options={ options } />
 		);
 
 		wrapper.find( '.sub-masterbar-nav__select' ).simulate( 'click' );

--- a/client/components/sub-masterbar-nav/test/index.jsx
+++ b/client/components/sub-masterbar-nav/test/index.jsx
@@ -13,12 +13,12 @@ import Item from '../item';
 
 describe( 'SubMasterbarNav', () => {
 	const options = [
-		{ label: 'sites', uri: '/sites' },
-		{ label: 'more' }
+		{ label: 'sites', uri: '/sites', icon: 'star' },
+		{ label: 'more', uri: '/more', icon: 'star' }
 	];
 
 	it( 'should render a navigation bar given a list of options', () => {
-		const wrapper = shallow( <SubMasterbarNav options={ options } uri="" /> );
+		const wrapper = shallow( <SubMasterbarNav options={ options } uri="/" /> );
 		const items = wrapper.find( Item );
 
 		expect( items.length ).to.equal( 2 );

--- a/client/components/sub-masterbar-nav/test/index.jsx
+++ b/client/components/sub-masterbar-nav/test/index.jsx
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import React from 'react';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import SubMasterbarNav from '../';
+import Item from '../item';
+
+describe( 'SubMasterbarNav', () => {
+	const options = [
+		{ label: 'sites', uri: '/sites' },
+		{ label: 'more' }
+	];
+
+	it( 'should render a navigation bar given a list of options', () => {
+		const wrapper = shallow( <SubMasterbarNav options={ options } uri="" /> );
+		const items = wrapper.find( Item );
+
+		expect( items.length ).to.equal( 2 );
+		expect( items.everyWhere( item => item.prop( 'isSelected' ) ) ).to.equal( false );
+		expect( items.at( 0 ).prop( 'label' ) ).to.equal( 'sites' );
+		expect( items.at( 1 ).prop( 'label' ) ).to.equal( 'more' );
+	} );
+
+	it( 'should mark an option with a matching URI as selected', () => {
+		const wrapper = shallow( <SubMasterbarNav options={ options } uri="/sites" /> );
+		const items = wrapper.find( Item );
+
+		expect( items.length ).to.equal( 2 );
+		expect( items.at( 0 ).prop( 'label' ) ).to.equal( 'sites' );
+		expect( items.at( 1 ).prop( 'label' ) ).to.equal( 'more' );
+		expect( items.at( 0 ).prop( 'isSelected' ) ).to.equal( true );
+		expect( items.at( 1 ).prop( 'isSelected' ) ).to.equal( false );
+	} );
+} );

--- a/client/components/sub-masterbar-nav/test/index.jsx
+++ b/client/components/sub-masterbar-nav/test/index.jsx
@@ -9,7 +9,8 @@ import { shallow } from 'enzyme';
  * Internal dependencies
  */
 import SubMasterbarNav from '../';
-import Item from '../item';
+import Dropdown from '../dropdown';
+import Navbar from '../navbar';
 
 describe( 'SubMasterbarNav', () => {
 	const options = [
@@ -17,24 +18,48 @@ describe( 'SubMasterbarNav', () => {
 		{ label: 'more', uri: '/more', icon: 'star' }
 	];
 
-	it( 'should render a navigation bar given a list of options', () => {
+	it( 'should render a navbar and a dropdown with the given options', () => {
 		const wrapper = shallow( <SubMasterbarNav options={ options } uri="/" /> );
-		const items = wrapper.find( Item );
+		const dropdown = wrapper.find( Dropdown );
+		const navbar = wrapper.find( Navbar );
 
-		expect( items.length ).to.equal( 2 );
-		expect( items.everyWhere( item => item.prop( 'isSelected' ) ) ).to.equal( false );
-		expect( items.at( 0 ).prop( 'label' ) ).to.equal( 'sites' );
-		expect( items.at( 1 ).prop( 'label' ) ).to.equal( 'more' );
+		expect( dropdown.prop( 'options' ) ).to.equal( options );
+		expect( navbar.prop( 'options' ) ).to.equal( options );
 	} );
 
-	it( 'should mark an option with a matching URI as selected', () => {
-		const wrapper = shallow( <SubMasterbarNav options={ options } uri="/sites" /> );
-		const items = wrapper.find( Item );
+	it( 'should pass the selected option to the dropdown', () => {
+		const wrapper = shallow( <SubMasterbarNav options={ options } uri="/more" /> );
+		const dropdown = wrapper.find( Dropdown );
 
-		expect( items.length ).to.equal( 2 );
-		expect( items.at( 0 ).prop( 'label' ) ).to.equal( 'sites' );
-		expect( items.at( 1 ).prop( 'label' ) ).to.equal( 'more' );
-		expect( items.at( 0 ).prop( 'isSelected' ) ).to.equal( true );
-		expect( items.at( 1 ).prop( 'isSelected' ) ).to.equal( false );
+		expect( dropdown.prop( 'options' ) ).to.equal( options );
+		expect( dropdown.prop( 'selected' ) ).to.equal( options[ 1 ] );
+	} );
+
+	it( 'should pass the fallback as selected to the dropdown if none of the options is selected', () => {
+		const fallback = { label: 'Select...', uri: '#' };
+
+		const wrapper = shallow( <SubMasterbarNav options={ options } uri="/foo" fallback={ fallback } /> );
+		const dropdown = wrapper.find( Dropdown );
+
+		expect( dropdown.prop( 'options' ) ).to.equal( options );
+		expect( dropdown.prop( 'selected' ) ).to.equal( fallback );
+	} );
+
+	it( 'should pass the selected option to the navbar', () => {
+		const wrapper = shallow( <SubMasterbarNav options={ options } uri="/sites" /> );
+		const navbar = wrapper.find( Navbar );
+
+		expect( navbar.prop( 'options' ) ).to.equal( options );
+		expect( navbar.prop( 'selected' ) ).to.equal( options[ 0 ] );
+	} );
+
+	it( 'should not pass the fallback as selected to the navbar when nothing is selected', () => {
+		const fallback = { label: 'Select...', uri: '#' };
+
+		const wrapper = shallow( <SubMasterbarNav options={ options } uri="/foo" fallback={ fallback } /> );
+		const navbar = wrapper.find( Navbar );
+
+		expect( navbar.prop( 'options' ) ).to.equal( options );
+		expect( navbar.prop( 'selected' ) ).to.equal( undefined );
 	} );
 } );

--- a/client/components/sub-masterbar-nav/test/item.jsx
+++ b/client/components/sub-masterbar-nav/test/item.jsx
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import React from 'react';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import Item from '../item';
+import Gridicon from 'gridicons';
+
+describe( 'Item', () => {
+	it( 'should render a link containing the given label', () => {
+		const item = shallow( <Item label={ 'test item' } /> );
+		const label = item.find( '.sub-masterbar-nav__label' );
+
+		expect( label.length ).to.equal( 1 );
+		expect( label.text() ).to.equal( 'test item' );
+	} );
+
+	it( 'should link to the passed url', () => {
+		const item = shallow( <Item label={ 'home' } href={ 'https://wordpress.com' } /> );
+
+		expect( item.prop( 'href' ) ).to.equal( 'https://wordpress.com' );
+	} );
+
+	it( 'should be selectable', () => {
+		const item = shallow( <Item label={ 'test item' } isSelected={ true } /> );
+
+		expect( item.hasClass( 'is-selected' ) ).to.equal( true );
+	} );
+
+	it( 'should not be selected by default', () => {
+		const item = shallow( <Item label={ 'test item' } /> );
+
+		expect( item.hasClass( 'is-selected' ) ).to.equal( false );
+	} );
+
+	it( 'should display a given gridicon', () => {
+		const item = shallow( <Item label={ 'test item' } icon={ 'globe' } /> );
+
+		expect(
+			item.contains(
+				<Gridicon className="sub-masterbar-nav__icon" icon={ 'globe' } size={ 24 } />
+			)
+		).to.equal( true );
+	} );
+
+	it( 'should display a \'star\' gridicon by default', () => {
+		const item = shallow( <Item label={ 'test item' } /> );
+
+		expect(
+			item.contains(
+				<Gridicon className="sub-masterbar-nav__icon" icon={ 'star' } size={ 24 } />
+			)
+		).to.equal( true );
+	} );
+} );

--- a/client/components/sub-masterbar-nav/test/item.jsx
+++ b/client/components/sub-masterbar-nav/test/item.jsx
@@ -40,21 +40,15 @@ describe( 'Item', () => {
 
 	it( 'should display a given gridicon', () => {
 		const item = shallow( <Item label={ 'test item' } icon={ 'globe' } /> );
+		const icon = item.find( Gridicon );
 
-		expect(
-			item.contains(
-				<Gridicon className="sub-masterbar-nav__icon" icon={ 'globe' } size={ 24 } />
-			)
-		).to.equal( true );
+		expect( icon.prop( 'icon' ) ).to.equal( 'globe' );
 	} );
 
 	it( 'should display a \'star\' gridicon by default', () => {
 		const item = shallow( <Item label={ 'test item' } /> );
+		const icon = item.find( Gridicon );
 
-		expect(
-			item.contains(
-				<Gridicon className="sub-masterbar-nav__icon" icon={ 'star' } size={ 24 } />
-			)
-		).to.equal( true );
+		expect( icon.prop( 'icon' ) ).to.equal( 'star' );
 	} );
 } );

--- a/client/components/sub-masterbar-nav/test/navbar.jsx
+++ b/client/components/sub-masterbar-nav/test/navbar.jsx
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import React from 'react';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import Navbar from '../navbar';
+import Item from '../item';
+
+describe( 'Navbar', () => {
+	const options = [
+		{ label: 'sites', uri: '/sites', icon: 'star' },
+		{ label: 'more', uri: '/more', icon: 'star' }
+	];
+
+	const renderItems = () => {
+		return options.map( ( item, index ) => (
+			<Item
+				key={ index }
+				label={ item.label }
+				icon={ item.icon }
+				href={ item.uri }
+			/>
+		) );
+	};
+
+	it( 'should render a navbar containing the children', () => {
+		const wrapper = shallow(
+			<Navbar>
+				{ renderItems() }
+			</Navbar>
+		);
+
+		const items = wrapper.find( Item );
+
+		expect( items.length ).to.equal( 2 );
+		expect( items.at( 0 ).prop( 'label' ) ).to.equal( 'sites' );
+		expect( items.at( 1 ).prop( 'label' ) ).to.equal( 'more' );
+		expect( items.at( 0 ).prop( 'icon' ) ).to.equal( 'star' );
+		expect( items.at( 1 ).prop( 'icon' ) ).to.equal( 'star' );
+	} );
+} );

--- a/client/components/sub-masterbar-nav/test/navbar.jsx
+++ b/client/components/sub-masterbar-nav/test/navbar.jsx
@@ -17,30 +17,38 @@ describe( 'Navbar', () => {
 		{ label: 'more', uri: '/more', icon: 'star' }
 	];
 
-	const renderItems = () => {
-		return options.map( ( item, index ) => (
-			<Item
-				key={ index }
-				label={ item.label }
-				icon={ item.icon }
-				href={ item.uri }
-			/>
-		) );
-	};
-
-	it( 'should render a navbar containing the children', () => {
+	it( 'should render a navbar given a list of options', () => {
 		const wrapper = shallow(
-			<Navbar>
-				{ renderItems() }
-			</Navbar>
+			<Navbar options={ options } />
 		);
 
 		const items = wrapper.find( Item );
 
 		expect( items.length ).to.equal( 2 );
+
 		expect( items.at( 0 ).prop( 'label' ) ).to.equal( 'sites' );
 		expect( items.at( 1 ).prop( 'label' ) ).to.equal( 'more' );
+
 		expect( items.at( 0 ).prop( 'icon' ) ).to.equal( 'star' );
 		expect( items.at( 1 ).prop( 'icon' ) ).to.equal( 'star' );
+
+		expect( items.at( 0 ).prop( 'isSelected' ) ).to.equal( false );
+		expect( items.at( 1 ).prop( 'isSelected' ) ).to.equal( false );
+	} );
+
+	it( 'should higlight currently selected option', () => {
+		const wrapper = shallow(
+			<Navbar selected={ options[ 1 ] } options={ options } />
+		);
+
+		const items = wrapper.find( Item );
+
+		expect( items.length ).to.equal( 2 );
+
+		expect( items.at( 0 ).prop( 'label' ) ).to.equal( 'sites' );
+		expect( items.at( 1 ).prop( 'label' ) ).to.equal( 'more' );
+
+		expect( items.at( 0 ).prop( 'isSelected' ) ).to.equal( false );
+		expect( items.at( 1 ).prop( 'isSelected' ) ).to.equal( true );
 	} );
 } );


### PR DESCRIPTION
Add a component to display a header navigation bar.

This navigation bar will be used on the themes page to filter between different categories. The navigation bar will be responsive and will either show all buttons (desktop), fold the buttons which don't fit (tablet) or display a dropdown.

![header-nav](https://cloud.githubusercontent.com/assets/750733/23716357/45a28a02-0430-11e7-8bde-d6487b70a095.png)
