### PR TITLE
Revert "Themes: Prevent active theme appearing in uploaded list"

### DIFF
--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -172,13 +172,12 @@ describe( 'actions', () => {
 
 			it( 'should dispatch themes request success action', () => {
 				receiveThemesQuery( themes, 77203074, {} )( spy, getState );
-				// Themes will be assumed to be wpcom themes and filtered out
 				expect( spy ).to.have.been.calledWith( {
 					type: THEMES_REQUEST_SUCCESS,
 					siteId: 77203074,
 					query: {},
-					found: 0,
-					themes: [ ]
+					found: 2,
+					themes,
 				} );
 			} );
 		} );

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -5,7 +5,6 @@ import startsWith from 'lodash/startsWith';
 import {
 	every,
 	get,
-	has,
 	includes,
 	map,
 	mapKeys,
@@ -213,13 +212,6 @@ export function getSerializedThemesQueryWithoutPage( query, siteId ) {
  * @return {Boolean}      Whether theme is a wpcom theme
  */
 export function isThemeFromWpcom( theme ) {
-	if ( ! has( theme, 'theme_uri' ) ) {
-		// If not enough information to determine, assume
-		// theme is wpcom to prevent it appearing in
-		// the uploaded themes list.
-		return true;
-	}
-
 	return includes( theme.theme_uri, 'wordpress.com' );
 }
 


### PR DESCRIPTION
This reverts commit f9a2523cb9c6fe734407c0089016f56dde882d69, i.e. #11869.

As of r152422-wpcom, the active theme endpoint includes the `theme_uri` field in its response, so this workaround is no longer needed.

To test: Make sure that in single-site Jetpack mode, the active theme still doesn't jump to the upper list on activation.