### PR TITLE
Themes: Add screenshot to current theme bar

### DIFF
--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -46,12 +46,18 @@ class CurrentTheme extends Component {
 			currentTheme && ! ( option.hideForTheme && option.hideForTheme( currentTheme, siteId ) )
 		);
 
+		const showScreenshot = currentTheme && currentTheme.screenshot;
+		const screenshotPlaceholder = ! currentTheme;
+
 		return (
 			<Card className="current-theme">
 				{ siteId && <QueryActiveTheme siteId={ siteId } /> }
 				{ currentThemeId && <QueryCanonicalTheme themeId={ currentThemeId } siteId={ siteId } /> }
 				<div className="current-theme__current">
-					{ currentTheme && <img src={ currentTheme.screenshot } className="current-theme__img" /> }
+					{ screenshotPlaceholder && <div className="current-theme__img-placeholder" /> }
+					{ showScreenshot && <img
+						src={ currentTheme.screenshot + '?w=100' }
+						className="current-theme__img" /> }
 					<span className="current-theme__label">
 						{ translate( 'Current Theme' ) }
 					</span>

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -51,6 +51,7 @@ class CurrentTheme extends Component {
 				{ siteId && <QueryActiveTheme siteId={ siteId } /> }
 				{ currentThemeId && <QueryCanonicalTheme themeId={ currentThemeId } siteId={ siteId } /> }
 				<div className="current-theme__current">
+					{ currentTheme && <img src={ currentTheme.screenshot } className="current-theme__img" /> }
 					<span className="current-theme__label">
 						{ translate( 'Current Theme' ) }
 					</span>

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -47,6 +47,7 @@ class CurrentTheme extends Component {
 		);
 
 		const showScreenshot = currentTheme && currentTheme.screenshot;
+		// Show nothing for themes with no screenshot
 		const screenshotPlaceholder = ! currentTheme;
 
 		return (

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -18,7 +18,7 @@ import { getActiveTheme, getCanonicalTheme } from 'state/themes/selectors';
 import QueryActiveTheme from 'components/data/query-active-theme';
 import QueryCanonicalTheme from 'components/data/query-canonical-theme';
 
-/**
+/*
  * Show current active theme for a site, with
  * related actions.
  */

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -57,7 +57,7 @@ class CurrentTheme extends Component {
 				<div className="current-theme__current">
 					{ screenshotPlaceholder && <div className="current-theme__img-placeholder" /> }
 					{ showScreenshot && <img
-						src={ currentTheme.screenshot + '?w=100' }
+						src={ currentTheme.screenshot + '?w=150' }
 						className="current-theme__img" /> }
 					<span className="current-theme__label">
 						{ translate( 'Current Theme' ) }

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -47,15 +47,15 @@ class CurrentTheme extends Component {
 		);
 
 		const showScreenshot = currentTheme && currentTheme.screenshot;
-		// Show nothing for themes with no screenshot
-		const screenshotPlaceholder = ! currentTheme;
+		// Some themes have no screenshot, so only show placeholder until details loaded
+		const showScreenshotPlaceholder = ! currentTheme;
 
 		return (
 			<Card className="current-theme">
 				{ siteId && <QueryActiveTheme siteId={ siteId } /> }
 				{ currentThemeId && <QueryCanonicalTheme themeId={ currentThemeId } siteId={ siteId } /> }
 				<div className="current-theme__current">
-					{ screenshotPlaceholder && <div className="current-theme__img-placeholder" /> }
+					{ showScreenshotPlaceholder && <div className="current-theme__img-placeholder" /> }
 					{ showScreenshot && <img
 						src={ currentTheme.screenshot + '?w=150' }
 						className="current-theme__img" /> }

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -1,6 +1,6 @@
 
 $current-theme-height: 56px;
-$current-theme-border: 1px solid lighten( $gray, 20% );
+$current-theme-border: 1px solid transparentize( lighten( $gray, 20% ), .25 );
 
 .current-theme {
 	font-weight: 600;
@@ -17,6 +17,7 @@ $current-theme-border: 1px solid lighten( $gray, 20% );
 }
 
 .current-theme__img {
+	border-right: $current-theme-border;
 	float: left;
 	height: 100%;
 }

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -18,19 +18,27 @@ $current-theme-border: 1px solid transparentize( lighten( $gray, 20% ), .25 );
 
 .current-theme__img {
 	@include breakpoint( "<480px" ) {
-		display: none;
+		border-left: $current-theme-border;
+		float: right;
 	}
-	border-right: $current-theme-border;
-	float: left;
+	@include breakpoint( ">480px" ) {
+		border-right: $current-theme-border;
+		float: left;
+	}
 	height: 100%;
 }
 
 .current-theme__img-placeholder {
+	@include breakpoint( "<480px" ) {
+		float: right;
+	}
+	@include breakpoint( ">480px" ) {
+		float: left;
+	}
 	width: 75px;
 	color: transparent;
 	background-color: lighten( $gray, 30% );
 	animation: loading-fade 1.6s ease-in-out infinite;
-	float: left;
 	height: 100%;
 }
 

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -17,6 +17,9 @@ $current-theme-border: 1px solid transparentize( lighten( $gray, 20% ), .25 );
 }
 
 .current-theme__img {
+	@include breakpoint( "<480px" ) {
+		display: none;
+	}
 	border-right: $current-theme-border;
 	float: left;
 	height: 100%;

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -16,6 +16,11 @@ $current-theme-border: 1px solid lighten( $gray, 20% );
 	height: $current-theme-height;
 }
 
+.current-theme__img {
+	float: left;
+	height: 100%;
+}
+
 .current-theme__label {
 	font-size: 0.8em;
 	color: $gray;
@@ -23,7 +28,7 @@ $current-theme-border: 1px solid lighten( $gray, 20% );
 	padding-left: 15px;
 	padding-top: 10px;
 	margin-bottom: -2px;
-	float: left;
+	display: inline-block;
 }
 
 .current-theme__name {
@@ -33,8 +38,7 @@ $current-theme-border: 1px solid lighten( $gray, 20% );
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	max-width: 100%;
-	float: left;
-	clear: both;
+	display: block;
 }
 
 .current-theme__placeholder {

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -25,6 +25,15 @@ $current-theme-border: 1px solid transparentize( lighten( $gray, 20% ), .25 );
 	height: 100%;
 }
 
+.current-theme__img-placeholder {
+	width: 75px;
+	color: transparent;
+	background-color: lighten( $gray, 30% );
+	animation: loading-fade 1.6s ease-in-out infinite;
+	float: left;
+	height: 100%;
+}
+
 .current-theme__label {
 	font-size: 0.8em;
 	color: $gray;


### PR DESCRIPTION
**Before**
<img width="946" alt="screen shot 2017-03-08 at 19 41 15" src="https://cloud.githubusercontent.com/assets/7767559/23720686/41132710-0437-11e7-83bb-b38e862c43ca.png">

**After**
<img width="946" alt="screen shot 2017-03-08 at 19 37 37" src="https://cloud.githubusercontent.com/assets/7767559/23720550/e9a8e87a-0436-11e7-8c06-17f4d6e13465.png">

**After Mobile**
<img width="355" alt="screen shot 2017-03-09 at 14 37 05" src="https://cloud.githubusercontent.com/assets/7767559/23754728/f1928c9a-04d5-11e7-9d80-f4562d91198e.png">


Adds a small screenshot to the _Current Theme_ bar at wordpress.com/design/{site} to emphasise that it is displaying theme information.

**To Test**
Go to http://calypso.localhost:3000/design and select a site

