### PR TITLE
Site Settings: Remove ending periods from labels in the Media settings card

### DIFF
--- a/client/my-sites/site-settings/media-settings/index.jsx
+++ b/client/my-sites/site-settings/media-settings/index.jsx
@@ -54,8 +54,8 @@ const MediaSettings = ( {
 				<JetpackModuleToggle
 					siteId={ siteId }
 					moduleSlug="photon"
-					label={ translate( 'Speed up your images and photos with Photon.' ) }
-					description="Enabling Photon is required to use Tiled Galleries."
+					label={ translate( 'Speed up your images and photos with Photon' ) }
+					description={ translate( 'Enabling Photon is required to use Tiled Galleries' ) }
 					disabled={ isRequestingSettings || isSavingSettings || photonModuleUnavailable }
 					/>
 			</FormFieldset>
@@ -70,7 +70,7 @@ const MediaSettings = ( {
 				<JetpackModuleToggle
 					siteId={ siteId }
 					moduleSlug="carousel"
-					label={ translate( 'Transform standard image galleries into full-screen slideshows.' ) }
+					label={ translate( 'Transform standard image galleries into full-screen slideshows' ) }
 					disabled={ isRequestingSettings || isSavingSettings }
 					/>
 				<div className="media-settings__module-settings site-settings__child-settings">
@@ -79,7 +79,7 @@ const MediaSettings = ( {
 						checked={ fields.carousel_display_exif || false }
 						disabled={ isRequestingSettings || isSavingSettings || ! carouselActive }
 						onChange={ handleAutosavingToggle( 'carousel_display_exif' ) } >
-						{ translate( 'Show photo metadata in carousel, when available.' ) }
+						{ translate( 'Show photo metadata in carousel, when available' ) }
 					</FormToggle>
 					<FormLabel className={ labelClassName } htmlFor="carousel_background_color">
 						{ translate( 'Background color' ) }


### PR DESCRIPTION
Part of #11676 

This PRs removes some ending periods in the Toggle labels and section descriptions from the Media Settings Card.

**Before**

![image](https://cloud.githubusercontent.com/assets/746152/23717306/13af6312-0412-11e7-8f2c-9d0898881c51.png)


**After** 

![image](https://cloud.githubusercontent.com/assets/746152/23717299/048c56ce-0412-11e7-8301-faff064185af.png)

#### Testing instructions

* Check the [Writing Settings in the live branch](https://calypso.live/settings/writing?branch=update/remove-ending-periods-in-media-settings) for one of your Jetpack sites
* Confirm that labels in the **Media Settings** card don't have an ending period.


#### Why

We decided to go with labels without ending periods, regardless of the recommendations made on the PRs by the i18nbot.