### PR TITLE
Editor: Properly clear local state tree edits on POST_SAVE_SUCCESS

### DIFF
--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import { get, set, omit, omitBy, isEqual, reduce, merge, findKey, mapValues } from 'lodash';
+import { get, set, omit, omitBy, isEqual, reduce, merge, findKey, mapValues, mapKeys } from 'lodash';
 
 /**
  * Internal dependencies
@@ -277,7 +277,6 @@ export function edits( state = {}, action ) {
 			} );
 
 		case EDITOR_STOP:
-		case POST_SAVE_SUCCESS:
 			if ( ! state.hasOwnProperty( action.siteId ) ) {
 				break;
 			}
@@ -285,6 +284,20 @@ export function edits( state = {}, action ) {
 			return Object.assign( {}, state, {
 				[ action.siteId ]: omit( state[ action.siteId ], action.postId || '' )
 			} );
+
+		case POST_SAVE_SUCCESS:
+			if ( ! state.hasOwnProperty( action.siteId ) || ! action.savedPost || action.postId ) {
+				break;
+			}
+			const { siteId, savedPost } = action;
+
+			// if postId is null, copy over any edits
+			return {
+				...state,
+				[ siteId ]: mapKeys( state[ siteId ], ( value, key ) => (
+					'' === key ? savedPost.ID : key
+				) )
+			};
 
 		case SERIALIZE:
 		case DESERIALIZE:

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -33,6 +33,7 @@ import counts from './counts/reducer';
 import likes from './likes/reducer';
 import {
 	getSerializedPostsQuery,
+	hasTermEditDifferences,
 	mergeIgnoringArrays,
 	normalizePostForState
 } from './utils';
@@ -253,6 +254,9 @@ export function edits( state = {}, action ) {
 				}
 
 				return set( memoState, [ post.site_ID, post.ID ], omitBy( postEdits, ( value, key ) => {
+					if ( key === 'terms' ) {
+						return ! hasTermEditDifferences( value, post[ key ] );
+					}
 					return isEqual( post[ key ], value );
 				} ) );
 			}, state );

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -33,7 +33,7 @@ import counts from './counts/reducer';
 import likes from './likes/reducer';
 import {
 	getSerializedPostsQuery,
-	hasTermEditDifferences,
+	isTermsEqual,
 	mergeIgnoringArrays,
 	normalizePostForState
 } from './utils';
@@ -255,7 +255,7 @@ export function edits( state = {}, action ) {
 
 				return set( memoState, [ post.site_ID, post.ID ], omitBy( postEdits, ( value, key ) => {
 					if ( key === 'terms' ) {
-						return ! hasTermEditDifferences( value, post[ key ] );
+						return isTermsEqual( value, post[ key ] );
 					}
 					return isEqual( post[ key ], value );
 				} ) );

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -892,6 +892,124 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		it( 'should should handle term shape differences on posts received', () => {
+			const state = edits( deepFreeze( {
+				2916284: {
+					841: {
+						title: 'Hello World',
+						type: 'post',
+						terms: {
+							post_tag: [ 'chicken', 'ribs' ],
+							category: [ {
+								ID: 1,
+								name: 'uncategorized'
+							} ]
+						}
+					},
+					'': {
+						title: 'Unrelated'
+					}
+				}
+			} ), {
+				type: POSTS_RECEIVE,
+				posts: [ {
+					ID: 841,
+					site_ID: 2916284,
+					type: 'post',
+					title: 'Hello',
+					terms: {
+						post_tag: {
+							chicken: {
+								ID: 111,
+								name: 'chicken'
+							},
+							ribs: {
+								ID: 112,
+								name: 'ribs'
+							}
+						},
+						category: {
+							uncategorized: {
+								ID: 1,
+								name: 'uncategorized'
+							}
+						}
+					}
+				} ]
+			} );
+
+			expect( state ).to.eql( {
+				2916284: {
+					841: {
+						title: 'Hello World'
+					},
+					'': {
+						title: 'Unrelated'
+					}
+				}
+			} );
+		} );
+
+		it( 'should should preserve term edit differences on posts received', () => {
+			const state = edits( deepFreeze( {
+				2916284: {
+					841: {
+						title: 'Hello World',
+						type: 'post',
+						terms: {
+							post_tag: [ 'ribs' ],
+							category: [ {
+								ID: 1,
+								name: 'uncategorized'
+							} ]
+						}
+					},
+					'': {
+						title: 'Unrelated'
+					}
+				}
+			} ), {
+				type: POSTS_RECEIVE,
+				posts: [ {
+					ID: 841,
+					site_ID: 2916284,
+					type: 'post',
+					title: 'Hello World',
+					terms: {
+						post_tag: {
+							chicken: {
+								ID: 111,
+								name: 'chicken'
+							}
+						},
+						category: {
+							uncategorized: {
+								ID: 1,
+								name: 'uncategorized'
+							}
+						}
+					}
+				} ]
+			} );
+
+			expect( state ).to.eql( {
+				2916284: {
+					841: {
+						terms: {
+							post_tag: [ 'ribs' ],
+							category: [ {
+								ID: 1,
+								name: 'uncategorized'
+							} ]
+						}
+					},
+					'': {
+						title: 'Unrelated'
+					}
+				}
+			} );
+		} );
+
 		it( 'should ignore reset edits action when discarded site doesn\'t exist', () => {
 			const original = deepFreeze( {} );
 			const state = edits( original, {

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -892,7 +892,7 @@ describe( 'reducer', () => {
 			} );
 		} );
 
-		it( 'should should handle term shape differences on posts received', () => {
+		it( 'should handle term shape differences on posts received', () => {
 			const state = edits( deepFreeze( {
 				2916284: {
 					841: {
@@ -1021,26 +1021,33 @@ describe( 'reducer', () => {
 			expect( state ).to.equal( original );
 		} );
 
-		it( 'should discard edits when the post is saved', () => {
+		it( 'should copy edits when the post is saved and prior postId was null', () => {
 			const state = edits( deepFreeze( {
 				2916284: {
-					841: {
-						title: 'Hello World'
-					},
 					'': {
 						title: 'Ribs & Chicken'
+					},
+					842: {
+						title: 'I like turtles'
 					}
 				}
 			} ), {
 				type: POST_SAVE_SUCCESS,
 				siteId: 2916284,
-				postId: 841
+				postId: null,
+				savedPost: {
+					ID: 841,
+					title: 'Ribs'
+				}
 			} );
 
 			expect( state ).to.eql( {
 				2916284: {
-					'': {
+					841: {
 						title: 'Ribs & Chicken'
+					},
+					842: {
+						title: 'I like turtles'
 					}
 				}
 			} );

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -864,7 +864,7 @@ describe( 'reducer', () => {
 			} );
 		} );
 
-		it( 'should should eliminate redundant data on posts received', () => {
+		it( 'should eliminate redundant data on posts received', () => {
 			const state = edits( deepFreeze( {
 				2916284: {
 					841: {
@@ -950,7 +950,7 @@ describe( 'reducer', () => {
 			} );
 		} );
 
-		it( 'should should preserve term edit differences on posts received', () => {
+		it( 'should preserve term edit differences on posts received', () => {
 			const state = edits( deepFreeze( {
 				2916284: {
 					841: {

--- a/client/state/posts/test/utils.js
+++ b/client/state/posts/test/utils.js
@@ -16,10 +16,80 @@ import {
 	getDeserializedPostsQueryDetails,
 	getSerializedPostsQueryWithoutPage,
 	getTermIdsFromEdits,
+	hasTermEditDifferences,
 	mergeIgnoringArrays
 } from '../utils';
 
 describe( 'utils', () => {
+	describe( 'hasTermEditDifferences', () => {
+		it( 'should return false if no term edits passed', () => {
+			expect( hasTermEditDifferences() ).to.be.false;
+		} );
+
+		it( 'should return false if term edits are the same as saved terms', () => {
+			const hasDifferences = hasTermEditDifferences( {
+				post_tag: [ 'ribs', 'chicken' ],
+				category: [ {
+					ID: 777,
+					name: 'amazing food'
+				} ]
+			}, {
+				post_tag: {
+					ribs: {
+						ID: 11,
+						name: 'ribs'
+					},
+					chicken: {
+						ID: 12,
+						name: 'chicken'
+					}
+				},
+				category: {
+					'amazing-food': {
+						ID: 777,
+						name: 'amazing food'
+					}
+				}
+			} );
+			expect( hasDifferences ).to.be.false;
+		} );
+
+		it( 'should return true if term edits are not the same as saved terms', () => {
+			const hasDifferences = hasTermEditDifferences( {
+				post_tag: [ 'ribs' ],
+				category: [ {
+					ID: 777,
+					name: 'amazing food'
+				} ]
+			}, {
+				post_tag: {
+					ribs: {
+						ID: 11,
+						name: 'ribs'
+					},
+					chicken: {
+						ID: 12,
+						name: 'chicken'
+					}
+				},
+				category: {
+					'amazing-food': {
+						ID: 777,
+						name: 'amazing food'
+					}
+				}
+			} );
+			expect( hasDifferences ).to.be.true;
+		} );
+
+		it( 'should return true savedTerms is missing a taxonomy', () => {
+			const hasDifferences = hasTermEditDifferences( {
+				post_tag: [ 'ribs' ]
+			}, {} );
+			expect( hasDifferences ).to.be.true;
+		} );
+	} );
+
 	describe( 'normalizePostForApi()', () => {
 		it( 'should return null if post is falsey', () => {
 			const normalizedPost = normalizePostForApi();

--- a/client/state/posts/test/utils.js
+++ b/client/state/posts/test/utils.js
@@ -16,18 +16,14 @@ import {
 	getDeserializedPostsQueryDetails,
 	getSerializedPostsQueryWithoutPage,
 	getTermIdsFromEdits,
-	hasTermEditDifferences,
+	isTermsEqual,
 	mergeIgnoringArrays
 } from '../utils';
 
 describe( 'utils', () => {
-	describe( 'hasTermEditDifferences', () => {
-		it( 'should return false if no term edits passed', () => {
-			expect( hasTermEditDifferences() ).to.be.false;
-		} );
-
+	describe( 'isTermsEqual', () => {
 		it( 'should return false if term edits are the same as saved terms', () => {
-			const hasDifferences = hasTermEditDifferences( {
+			const isEqual = isTermsEqual( {
 				post_tag: [ 'ribs', 'chicken' ],
 				category: [ {
 					ID: 777,
@@ -51,11 +47,11 @@ describe( 'utils', () => {
 					}
 				}
 			} );
-			expect( hasDifferences ).to.be.false;
+			expect( isEqual ).to.be.true;
 		} );
 
-		it( 'should return true if term edits are not the same as saved terms', () => {
-			const hasDifferences = hasTermEditDifferences( {
+		it( 'should return false if term edits are not the same as saved terms', () => {
+			const isEqual = isTermsEqual( {
 				post_tag: [ 'ribs' ],
 				category: [ {
 					ID: 777,
@@ -79,14 +75,14 @@ describe( 'utils', () => {
 					}
 				}
 			} );
-			expect( hasDifferences ).to.be.true;
+			expect( isEqual ).to.be.false;
 		} );
 
-		it( 'should return true savedTerms is missing a taxonomy', () => {
-			const hasDifferences = hasTermEditDifferences( {
+		it( 'should return false savedTerms is missing a taxonomy', () => {
+			const isEqual = isTermsEqual( {
 				post_tag: [ 'ribs' ]
 			}, {} );
-			expect( hasDifferences ).to.be.true;
+			expect( isEqual ).to.be.false;
 		} );
 	} );
 


### PR DESCRIPTION
This is take 2 of #11729 which was reverted in #11878 due to breaking an e2e test.  Ultimately, this branch seeks to close #11567 - which is a nasty bug that results in local changes to things like the post title, and terms being lost when an auto-save is in-flight.

__Notes__
While the original fix definitely solved the issue of lost post titles, it also uncovered the issue of the shape of `terms` being different between what we set in the local `edits` and send to the API, and what the API ultimately returns.  Since the prior logic would clear out all local edits on `POST_SAVE_SUCCESS` the `terms` discrepancy was never an issue - though they too were exposed to data loss of edits made while API requests were in-flight.

The reason there are differences are quite numerous: API issues and CPT custom taxonomy support, but for those interested see #7617 and D2607-code for some history.  

Ultimately, here is how we track term edits in the local state tree:
```
{
    terms: {
        post_tag: [ 'tag one', 'tag two' ], // non-hierarchical terms are added as simple arrays
        category: [
          { ID: 1, name: 'uncategorized' ] // while hierarchical terms are added as full objects
        ]
    }
}
```

And here is what the API response looks like after saving those edits from above:
```
{
    terms: {
        post_tag: {
          'tag one': { ID: ... },
          'tag two': { ID: ... }
        }
        category:  {
          'uncategorized': { ID: ... }
        }
    }
}
```

Because of this difference in object shape, the simple [equality check](https://github.com/Automattic/wp-calypso/blob/master/client/state/posts/reducer.js#L256) in `POSTS_RECIEVE` would always be `false`y for `terms` and even though term saves were working, the local edits were never properly flushed out on a valid save.

__Proposed Solution__
To get around this issue without disrupting all the term persistence logic, I have opted here to introduce a new utility method `hasTermEditDifferences` that compares local term edits against those saved in the API to determine equality.

__To Test__
Two distinct flows need to be tested.  The first is to ensure the data-loss issue is still fixed:
- Open a new draft in the editor
- Add a title and some content, place your cursor in the title field
- Wait for an auto-save to trigger, then quickly edit the title 
- After the auto-save completes, your edited title should still be intact, and the autosave status link should show 'SAVE' as an option since local edits do exist

Test the flow covered by the e2e test:
- Open a new draft in the editor
- Select a category ( other than the default )
- Add a tag
- Edit the title and wait for an autosave to happen
- Note after the auto-save finishes, the 'SAVE' link does not show, because no local edits exist. Also navigating away from the editor **should not** trigger the unsaved changes dialog

/cc @alisterscott if we could run the e2e tests against this branch I'd really appreciate it ( or if this is something I can do myself, please let me know how )
