### PR TITLE
Directly: Add Analytics (take 2)

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -184,6 +184,7 @@ const HelpContact = React.createClass( {
 			this.props.isDirectlyUninitialized
 		) {
 			this.props.initializeDirectly();
+			analytics.tracks.recordEvent( 'calypso_help_contact_directly_initialize' );
 		}
 	},
 
@@ -195,6 +196,8 @@ const HelpContact = React.createClass( {
 			display_name,
 			email
 		);
+
+		analytics.tracks.recordEvent( 'calypso_help_contact_directly_ask_question' );
 
 		this.clearSavedContactForm();
 	},

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -90,11 +90,15 @@ const HelpContact = React.createClass( {
 		olarkActions.hideBox();
 	},
 
-	componentDidUpdate: function() {
+	componentDidUpdate: function( prevProps ) {
 		// Directly initialization is a noop if it's already happened. This catches
 		// instances where a state/prop change moves a user to Directly support from
 		// some other variation.
 		this.prepareDirectlyWidget();
+
+		if ( ! prevProps.isDirectlyReady && this.props.isDirectlyReady ) {
+			analytics.tracks.recordEvent( 'calypso_help_contact_directly_initialize_success' );
+		}
 	},
 
 	componentWillUnmount: function() {


### PR DESCRIPTION
This is a re-try of https://github.com/Automattic/wp-calypso/pull/11751. That PR attempted to attach analytics events to Directly at a library level. The code got a little convoluted because `lib/analytics` throws on import in test environments.

This version places the tracking calls in the `HelpContact` component. This is probably a better approach because it keeps the library layer as minimal as possible and other /help/contact tracking calls are made in the component — so the `tracks` data for Directly will live side-by-side with Olark/Tickets/etc.

### To test

Sign in as a user with no paid upgrades (these are the only users who interact with Directly). Open the browser console and enable Tracks debug messages with:

```
localStorage.setItem('debug', 'calypso:analytics:tracks');
```

Navigate to http://calypso.localhost:3000/help/contact and watch the console. You should see debug messages for `calypso_help_contact_directly_initialize` and then `calypso_help_contact_directly_initialize_success` come through.

Fill the form with a question and press "Ask an Expert". You should see debug messages for `calypso_help_contact_directly_ask_question`.
