### PR TITLE
[Domain only] Retrieve the domain name from the current step object in signup

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -67,8 +67,8 @@ export default {
 	},
 
 	redirectToFlow( context, next ) {
-		if ( context.path !== utils.getValidPath( context.params ) ) {
-			return page.redirect( utils.getValidPath( context.params ) );
+		if ( context.pathname !== utils.getValidPath( context.params ) ) {
+			return page.redirect( utils.getValidPath( context.params ) + ( context.querystring ? '?' + context.querystring : '' ) );
 		}
 
 		next();

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -18,25 +18,34 @@ import { externalRedirect } from 'lib/route/path';
 
 export default class SiteOrDomain extends Component {
 	componentWillMount() {
-		const { queryObject } = this.props;
-		let isValidDomain = queryObject && queryObject.new;
-
-		if ( isValidDomain ) {
-			const domainParts = queryObject.new.split( '.' );
-
-			if ( domainParts.length > 1 ) {
-				const tld = domainParts.slice( 1 ).join( '.' );
-				isValidDomain = !! tlds[ tld ];
-			} else {
-				isValidDomain = false;
-			}
-		}
-
-		if ( ! isValidDomain ) {
+		if ( ! this.getDomainName() ) {
 			// /domains domain search is an external application to calypso,
 			// therefor a full redirect required:
 			externalRedirect( '/domains' );
 		}
+	}
+
+	getDomainName() {
+		const { queryObject, step } = this.props;
+
+		let domain, isValidDomain = false;
+
+		if ( queryObject && queryObject.new ) {
+			domain = queryObject.new;
+		} else if ( step && step.domainItem ) {
+			domain = step.domainItem.meta
+		}
+
+		if ( domain ) {
+			const domainParts = domain.split( '.' );
+
+			if ( domainParts.length > 1 ) {
+				const tld = domainParts.slice( 1 ).join( '.' );
+				isValidDomain = !! tlds[ tld ];
+			}
+		}
+
+		return isValidDomain && domain;
 	}
 
 	getChoices() {
@@ -76,10 +85,9 @@ export default class SiteOrDomain extends Component {
 			stepName,
 			goToStep,
 			goToNextStep,
-			queryObject,
 		} = this.props;
 
-		const domain = queryObject.new;
+		const domain = this.getDomainName();
 		const tld = domain.split( '.' ).slice( 1 ).join( '.' );
 		const domainItem = cartItems.domainRegistration( { productSlug: tlds[ tld ], domain } );
 

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -33,7 +33,7 @@ export default class SiteOrDomain extends Component {
 		if ( queryObject && queryObject.new ) {
 			domain = queryObject.new;
 		} else if ( step && step.domainItem ) {
-			domain = step.domainItem.meta
+			domain = step.domainItem.meta;
 		}
 
 		if ( domain ) {


### PR DESCRIPTION
Fixes #11900

This PR should fix going back as well as reloading the `/domain-first` flow when the first step (`site-or-domain`) has been completed (first commit).

It also fixes reloading the page on the first step by propagating query params from `/:flowName` to `/:flowName/:firstStep` (second commit).

We should double check that the modification on `signup/controller.js` did not impact other flow.

### Testing Instructions

- Load the branch locally or on calypso.live

#### Test 1
- From a new incognito tab (logged out user), go to `/start/domain-first?new=hello.com` select one of the options
- Reload the page then click "Go back", and select either of the option, go up to checkout and assert that it works as expected.

#### Test 2
- From a new incognito tab (logged out user), go to `/start/domain-first?new=hello.com` select one of the options
- From the same tab load `/start/domain-first` and assert that you are brought back to the last step you left and that going back and continuing the flow up until checkout works as expected. 

#### Test 3
- From a new incognito tab (logged out user), go to `/start/domain-first?new=hello.com` reload the page and continue the flow, it should work as expected

### Reviews
- [x] Code
- [x] Product
- [x] Regression testing on signup
