### PR TITLE
Media: add `Done` and `Delete` buttons

### DIFF
--- a/client/my-sites/media/style.scss
+++ b/client/my-sites/media/style.scss
@@ -5,3 +5,26 @@
 		padding: 0;
 	}
 }
+
+.media__item-dialog .dialog__action-buttons {
+	display: flex;
+	justify-content: space-between;
+}
+
+.media__modal-delete-item-button {
+	border: 0;
+
+	.dialog__button-label {
+		color: $alert-red;
+	}
+
+	&:hover {
+		color: lighten( $alert-red, 10% );
+	}
+
+	&:disabled {
+		cursor: default;
+		cursor: not-allowed;
+		color: lighten( $alert-red, 25% );
+	}
+}


### PR DESCRIPTION
### IMPORTANT

This PR is targeting to `try/media-section-v2`.

---------

This PR adds the `Done` and `Delete` buttons to the media item details dialog when it's opened from the Media section.

-----

Issues: #11024

----
### Testing

1) Go to the media section of a site: `http://calypso.localhost:3000/media/<site>`
2) Open the media item details dialog clicking on the pencil icon
3) Test either click on the `Done` or `Delete` button.


Check that:

* The dialog is closed clicking on the `Done` button
* The media is removed when clicking on `Delete` button
* It updates the media list in the media primary page
* It doesn't affect the current selection of items (items with labeled with a blue circle)

![media-item-detail-buttons-02](https://cloud.githubusercontent.com/assets/77539/23721331/1e718736-0420-11e7-9c5b-c97c53c85774.gif)
