### PR TITLE
Domain Only: Update copy on settings page

### DIFF
--- a/client/my-sites/upgrades/domain-management/list/domain-only.jsx
+++ b/client/my-sites/upgrades/domain-management/list/domain-only.jsx
@@ -12,7 +12,8 @@ import { domainManagementEdit } from 'my-sites/upgrades/paths';
 
 const DomainOnly = ( { domainName, siteId, translate } ) => (
 	<EmptyContent
-		title={ translate( '%(domainName)s is not set up yet.', { args: { domainName } } ) }
+		title={ translate( '%(domainName)s is ready when you are.', { args: { domainName } } ) }
+		line={ translate( 'Start a site now to unlock everything WordPress.com can offer. Or add email and manage your domain preferences.' ) }
 		action={ translate( 'Create Site' ) }
 		actionURL={ `/start/site-selected/?siteSlug=${ encodeURIComponent( domainName ) }&siteId=${ encodeURIComponent( siteId ) }` }
 		secondaryAction={ translate( 'Manage Domain' ) }


### PR DESCRIPTION
Fixes #11741. Attempting to clarify the default state on the settings screen for a domain-only site.

Before | After
------------ | -------------
![image](https://cloud.githubusercontent.com/assets/448298/23721061/9d778fa6-040e-11e7-8b2a-555d4d0f3401.png) | ![image](https://cloud.githubusercontent.com/assets/448298/23721017/7b4a0210-040e-11e7-8d6c-cf11a97959ba.png)


#### Testing Instructions

* Log in with an account that has a domain-only site
* Select a domain-only site (or just visit `/domains/manage/:domain`)
* Assert the screen shows the new copy

#### Review

- [x] Code
- [x] Product