### PR TITLE
Domain only: Add domain delay notice to default screen

### DIFF
--- a/client/my-sites/upgrades/domain-management/list/domain-only.jsx
+++ b/client/my-sites/upgrades/domain-management/list/domain-only.jsx
@@ -10,7 +10,7 @@ import React, { PropTypes } from 'react';
 import EmptyContent from 'components/empty-content';
 import { domainManagementEdit } from 'my-sites/upgrades/paths';
 
-const DomainOnly = ( { domainName, siteId, translate } ) => (
+const DomainOnly = ( { domainName, hasNotice, siteId, translate } ) => (
 	<div>
 		<EmptyContent
 			title={ translate( '%(domainName)s is ready when you are.', { args: { domainName } } ) }
@@ -20,14 +20,17 @@ const DomainOnly = ( { domainName, siteId, translate } ) => (
 			secondaryAction={ translate( 'Manage Domain' ) }
 			secondaryActionURL={ domainManagementEdit( domainName, domainName ) }
 			illustration={ '/calypso/images/drake/drake-browser.svg' } />
-		<div className="domain-only-site__settings-notice">
-			{ translate( 'New domains usually start working immediately, but may be unreliable for the first few hours.' ) }
-		</div>
+		{ hasNotice && (
+			<div className="domain-only-site__settings-notice">
+				{ translate( 'Your domain should start working immediately, but may be unreliable during the first 72 hours.' ) }
+			</div>
+		) }
 	</div>
 );
 
 DomainOnly.propTypes = {
 	domainName: PropTypes.string.isRequired,
+	hasNotice: PropTypes.bool.isRequired,
 	translate: PropTypes.func.isRequired,
 	siteId: PropTypes.number.isRequired,
 };

--- a/client/my-sites/upgrades/domain-management/list/domain-only.jsx
+++ b/client/my-sites/upgrades/domain-management/list/domain-only.jsx
@@ -11,14 +11,19 @@ import EmptyContent from 'components/empty-content';
 import { domainManagementEdit } from 'my-sites/upgrades/paths';
 
 const DomainOnly = ( { domainName, siteId, translate } ) => (
-	<EmptyContent
-		title={ translate( '%(domainName)s is ready when you are.', { args: { domainName } } ) }
-		line={ translate( 'Start a site now to unlock everything WordPress.com can offer. Or add email and manage your domain preferences.' ) }
-		action={ translate( 'Create Site' ) }
-		actionURL={ `/start/site-selected/?siteSlug=${ encodeURIComponent( domainName ) }&siteId=${ encodeURIComponent( siteId ) }` }
-		secondaryAction={ translate( 'Manage Domain' ) }
-		secondaryActionURL={ domainManagementEdit( domainName, domainName ) }
-		illustration={ '/calypso/images/drake/drake-browser.svg' } />
+	<div>
+		<EmptyContent
+			title={ translate( '%(domainName)s is ready when you are.', { args: { domainName } } ) }
+			line={ translate( 'Start a site now to unlock everything WordPress.com can offer. Or add email and manage your domain preferences.' ) }
+			action={ translate( 'Create Site' ) }
+			actionURL={ `/start/site-selected/?siteSlug=${ encodeURIComponent( domainName ) }&siteId=${ encodeURIComponent( siteId ) }` }
+			secondaryAction={ translate( 'Manage Domain' ) }
+			secondaryActionURL={ domainManagementEdit( domainName, domainName ) }
+			illustration={ '/calypso/images/drake/drake-browser.svg' } />
+		<div className="domain-only-site__settings-notice">
+			{ translate( 'New domains usually start working immediately, but may be unreliable for the first few hours.' ) }
+		</div>
+	</div>
 );
 
 DomainOnly.propTypes = {

--- a/client/my-sites/upgrades/domain-management/list/index.jsx
+++ b/client/my-sites/upgrades/domain-management/list/index.jsx
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
+import { connect } from 'react-redux';
+import { find, findIndex, times } from 'lodash';
+import Gridicon from 'gridicons';
+import moment from 'moment';
 import page from 'page';
 import React from 'react';
-import times from 'lodash/times';
-import findIndex from 'lodash/findIndex';
-import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -100,6 +100,7 @@ export const List = React.createClass( {
 					<SidebarNavigation />
 					<DomainOnly
 						domainName={ this.props.selectedSite.domain }
+						hasNotice={ this.isFreshDomainOnlyRegistration() }
 						siteId={ this.props.selectedSite.ID }
 					/>
 				</Main>
@@ -131,6 +132,15 @@ export const List = React.createClass( {
 				<DomainToPlanNudge />
 			</Main>
 		);
+	},
+
+	isFreshDomainOnlyRegistration() {
+		const domainName = this.props.selectedSite.domain;
+		const domain = this.props.domains.hasLoadedFromServer &&
+			find( this.props.domains.list, ( { name } ) => name === domainName );
+
+		return domain && domain.registrationMoment &&
+			moment().subtract( 1, 'day' ).isBefore( domain.registrationMoment );
 	},
 
 	hideNotice() {

--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -1035,3 +1035,18 @@ ul.email-forwarding__list {
 	float: right;
 	font-size: 13px;
 }
+
+.domain-only-site__settings-notice {
+	color: darken( $gray, 20% );
+	margin-top: 30px;
+	text-align: center;
+
+	&::before {
+		background: lighten( $gray, 20% );
+		content: '';
+		display: block;
+		height: 1px;
+		margin: 0 auto 30px;
+		width: 60px;
+	}
+}


### PR DESCRIPTION
This addresses part of #11441 by adding the new domain delay notice to the default screen in place of the yellow warning notice. This creates a more positive experience for users who just purchased a domain because we don't immediately show them a big yellow warning.

![image](https://cloud.githubusercontent.com/assets/448298/23723298/a232915a-0416-11e7-9777-c7251f98919a.png)


Todo:

- [x] Only show this notice for the first six hours

#### Testing instructions

1. Start the server and visit http://calypso.localhost:3000/start/domain-first?new=newdomain.live where `newdomain.live` is a unique domain.
2. Continue through the checkout flow selecting "Just buy the domain" option.
3. Assert you see the notice about new domains on the default screen.
4. If you have one, switch to a domain-only site that was registered more than 48 hours ago.
5. Assert you do not see the notice about new domains on the default screen.