### PR TITLE
Add accessibility labels to FormToggle

### DIFF
--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -42,6 +42,7 @@ var FormFields = React.createClass( {
 		return {
 			checkedRadio: 'first',
 			toggled: false,
+			toggledWithText: false,
 			compactToggled: false,
 			phoneInput: { countryCode: 'US', value: '' }
 		};
@@ -53,6 +54,10 @@ var FormFields = React.createClass( {
 
 	handleToggle: function() {
 		this.setState( { toggled: ! this.state.toggled } );
+	},
+
+	handleToggleWithText: function() {
+		this.setState( { toggledWithText: ! this.state.toggledWithText } );
 	},
 
 	handleCompactToggle: function() {
@@ -182,6 +187,13 @@ var FormFields = React.createClass( {
 					<FormToggle
 						checked={ this.state.toggled }
 						onChange={ this.handleToggle }
+					/>
+					<br />
+					<FormToggle
+						checked={ this.state.toggledWithText }
+						onChange={ this.handleToggleWithText }
+						textOn="On"
+						textOff="Off"
 					/>
 					<br />
 					<FormToggle

--- a/client/components/forms/form-toggle/README.md
+++ b/client/components/forms/form-toggle/README.md
@@ -16,6 +16,8 @@ export default function MyComponent() {
 				toggling={ this.props.toggling }
 				disabled={ this.props.disabled }
 				onChange={ this.props.onChange }
+				textOn={ this.props.textOn }
+				textOff={ this.props.textOff }
 				id="you-rock-uniquely"
 			/>
 		</div>
@@ -29,4 +31,6 @@ export default function MyComponent() {
 * `toggling`: (bool) whether the toggle is in the middle of being performed.
 * `disabled`: (bool) whether the toggle should be in the disabled state.
 * `onChange`: (callback) what should be executed once the user clicks the toggle.
+* `textOn`: (string) text to display when checked
+* `textOff`: (string) text to display when unchecked
 * `id`: (string) the id of the checkbox and the for attribute of the label, should be unique.

--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -12,6 +12,8 @@ export default class FormToggle extends PureComponent {
 		disabled: PropTypes.bool,
 		id: PropTypes.string,
 		className: PropTypes.string,
+		textOn: PropTypes.string,
+		textOff: PropTypes.string,
 		toggling: PropTypes.bool,
 		'aria-label': PropTypes.string,
 		children: PropTypes.node
@@ -96,7 +98,11 @@ export default class FormToggle extends PureComponent {
 						aria-checked={ this.props.checked }
 						aria-label={ this.props[ 'aria-label' ] }
 						tabIndex={ this.props.disabled ? -1 : 0 }
-						></span>
+						>
+							<span className="form-toggle__label-text">
+								{ this.props.checked ? this.props.textOn : this.props.textOff }
+							</span>
+					</span>
 					<span className="form-toggle__label-content" onClick={ this.onLabelClick }>
 						{ this.props.children }
 					</span>

--- a/client/components/forms/form-toggle/style.scss
+++ b/client/components/forms/form-toggle/style.scss
@@ -6,13 +6,17 @@
 	display: none;
 }
 
+.form-toggle__label-text {
+	font-size: 13px;
+}
+
 .form-toggle__switch {
 	position: relative;
 	display: inline-block;
 	border-radius: 12px;
 	box-sizing: border-box;
 	padding: 2px;
-	width: 40px;
+	min-width: 40px;
 	height: 24px;
 	vertical-align: middle;
 	align-self: flex-start;
@@ -69,6 +73,21 @@
 		background: lighten( $gray, 10% );
 	}
 
+	& + .form-toggle__label .form-toggle__switch .form-toggle__label-text {
+		float: right;
+		margin-left: 25px;
+		padding: 0;
+		padding-right: 5px;
+	}
+
+	&:checked + .form-toggle__label .form-toggle__switch .form-toggle__label-text {
+		float: left;
+		margin-left: 0;
+		margin-right: 5px;
+		padding: 0;
+		padding-left: 5px;
+	}
+
 	&:not( :disabled ) {
 		+ .form-toggle__label .form-toggle__switch:hover {
 			background: lighten( $gray, 20% );
@@ -80,7 +99,7 @@
 			background: $blue-medium;
 
 			&:after {
-				left: 16px;
+				float: right;
 			}
 		}
 	}
@@ -116,6 +135,7 @@
 		border-radius: 8px;
 		width: 24px;
 		height: 16px;
+		min-width: 24px;
 
 		&:before,
 		&:after {
@@ -126,8 +146,11 @@
 	&:checked {
 		+ .form-toggle__label .form-toggle__switch {
 			&:after{
-				left: 8px;
+				float: right;
 			}
 		}
+	}
+	& + .form-toggle__label .form-toggle__switch .form-toggle__label-text {
+		display: none;
 	}
 }

--- a/client/components/forms/form-toggle/style.scss
+++ b/client/components/forms/form-toggle/style.scss
@@ -86,6 +86,7 @@
 		margin-right: 5px;
 		padding: 0;
 		padding-left: 5px;
+		color: $white;
 	}
 
 	&:not( :disabled ) {

--- a/client/components/forms/form-toggle/test/index.jsx
+++ b/client/components/forms/form-toggle/test/index.jsx
@@ -111,5 +111,19 @@ describe( 'FormToggle', function() {
 
 			return ids.length === uniq( ids ).length;
 		} );
+
+		it( 'should use textOn when checked is true', function() {
+			var toggle = TestUtils.renderIntoDocument( <FormToggle checked={ true } textOn="On" textOff="Off" disabled={ false }/> ),
+				toggleText = TestUtils.findRenderedDOMComponentWithClass( toggle, 'form-toggle__label-text' )
+
+			assert( toggleText.textContent === 'On' );
+		} );
+
+		it( 'should use textOff when checked is false', function() {
+			var toggle = TestUtils.renderIntoDocument( <FormToggle checked={ false } textOn="On" textOff="Off" disabled={ false }/> ),
+				toggleText = TestUtils.findRenderedDOMComponentWithClass( toggle, 'form-toggle__label-text' )
+
+			assert( toggleText.textContent === 'Off' );
+		} );
 	} );
 } );


### PR DESCRIPTION
Our `<FormToggle>` component does not currently allow you to set labels for the on/off state. This PR adds two new props to the component to allow you to do that when using the full (not compact) toggle button. Also includes 2 tests for FormToggle.

Having these labels can make the toggles more accessible to those who might have a difficult time telling the state just based on colors or position. (I sometimes personally have trouble immediately recognizing the state of these kinds of buttons and have the iOS accessibility feature for this turned on for example). These labels can also help provide context, in general, for what the toggle will do (Enabled/Disabled, On/Off, etc).

When going through our mockups for WooCommerce, I noticed this was not currently possible and thought it would be a good exercise for one of my first contributions to Calypso.

The CSS might also need a little help cc @kellychoffman.

--

The buttons do not change if you do not include the label props, so this should not affect any existing buttons.

To Test:
* View the example at https://calypso.live/devdocs/design/form-fields?branch=add/formtoggle-labels