### PR TITLE
Revert "Media: Update/scarier media delete message"

### DIFF
--- a/client/lib/accept/README.md
+++ b/client/lib/accept/README.md
@@ -7,10 +7,10 @@ Accept is a stylized substitute to the browser `confirm` dialog.
 
 ## Arguments
 
-* `message` - A string that gets displayed to the user in the cofirm dialog.
+* `message` - A string that gets displayed to the user in the cofirm dialog. 
 * `callback` - A callback that gets called after confirms or cancels the dialog.
-* `confirmButtonText` - Optional confirm button text (defaults to 'OK') OR Button element.
-* `cancelButtonText` - Optional cancel button text (defaults to 'Cancel') OR Button element.
+* `confirmButtonText` - Optional confirm button text, defaults to 'OK'.
+* `cancelButtonText` - Optional cancel button text, defaults to 'Cancel'.
 
 ## Usage
 

--- a/client/lib/accept/dialog.jsx
+++ b/client/lib/accept/dialog.jsx
@@ -15,7 +15,7 @@ const AcceptDialog = React.createClass( {
 		message: PropTypes.node,
 		onClose: PropTypes.func.isRequired,
 		confirmButtonText: PropTypes.node,
-		cancelButtonText: PropTypes.node,
+		cancelButtonText: PropTypes.node
 	},
 
 	getInitialState: function() {
@@ -31,18 +31,16 @@ const AcceptDialog = React.createClass( {
 	},
 
 	getActionButtons: function() {
-		const cancelButton = React.isValidElement( this.props.cancelButtonText ) ? this.props.cancelButtonText : {
-			action: 'cancel',
-			label: this.props.cancelButtonText ? this.props.cancelButtonText : this.props.translate( 'Cancel' ),
-		};
-		const confirmButton = React.isValidElement( this.props.confirmButtonText ) ? this.props.confirmButtonText : {
-			action: 'accept',
-			label: this.props.confirmButtonText ? this.props.confirmButtonText : this.props.translate( 'OK' ),
-			isPrimary: true,
-		};
 		return [
-			cancelButton,
-			confirmButton,
+			{
+				action: 'cancel',
+				label: this.props.cancelButtonText ? this.props.cancelButtonText : this.props.translate( 'Cancel' ),
+			},
+			{
+				action: 'accept',
+				label: this.props.confirmButtonText ? this.props.confirmButtonText : this.props.translate( 'OK' ),
+				isPrimary: true
+			}
 		];
 	},
 

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -30,7 +30,6 @@ import MediaModalGallery from './gallery';
 import MediaActions from 'lib/media/actions';
 import MediaUtils from 'lib/media/utils';
 import Dialog from 'components/dialog';
-import Button from 'components/button';
 import accept from 'lib/accept';
 
 import { getMediaModalView } from 'state/ui/media-modal/selectors';
@@ -175,16 +174,12 @@ export class EditorMediaModal extends Component {
 		}
 
 		const confirmMessage = this.props.translate(
-			'Are you sure you want to permanently delete this item? It will be ' +
-			'permanently removed from all other locations where it currently appears.',
-			'Are you sure you want to permanently delete these items? They will be ' +
-			'permanently removed from all other locations where they appear.',
+			'Are you sure you want to permanently delete this item?',
+			'Are you sure you want to permanently delete these items?',
 			{ count: selectedCount }
 		);
 
-		const deleteButton = <Button primary scary>{ this.props.translate( 'Delete' ) }</Button>;
-
-		accept( confirmMessage, this.confirmDeleteMedia, deleteButton );
+		accept( confirmMessage, this.confirmDeleteMedia );
 	};
 
 	onAddMedia = () => {

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -73,10 +73,7 @@ describe( 'EditorMediaModal', function() {
 		).instance();
 		tree.deleteMedia();
 
-		expect( accept ).to.have.been.calledWith(
-			'Are you sure you want to permanently delete this item? It will be ' +
-			'permanently removed from all other locations where it currently appears.'
-		);
+		expect( accept ).to.have.been.calledWith( 'Are you sure you want to permanently delete this item?' );
 		process.nextTick( function() {
 			expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, media );
 			done();
@@ -89,10 +86,7 @@ describe( 'EditorMediaModal', function() {
 		).instance();
 		tree.deleteMedia();
 
-		expect( accept ).to.have.been.calledWith(
-			'Are you sure you want to permanently delete these items? They will be ' +
-			'permanently removed from all other locations where they appear.',
-		);
+		expect( accept ).to.have.been.calledWith( 'Are you sure you want to permanently delete these items?' );
 		process.nextTick( function() {
 			expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, DUMMY_MEDIA );
 			done();
@@ -108,10 +102,7 @@ describe( 'EditorMediaModal', function() {
 		).instance();
 		tree.deleteMedia();
 
-		expect( accept ).to.have.been.calledWith(
-			'Are you sure you want to permanently delete this item? It will be ' +
-			'permanently removed from all other locations where it currently appears.'
-		);
+		expect( accept ).to.have.been.calledWith( 'Are you sure you want to permanently delete this item?' );
 		process.nextTick( function() {
 			expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, media );
 			done();
@@ -124,10 +115,7 @@ describe( 'EditorMediaModal', function() {
 		).instance();
 		tree.deleteMedia();
 
-		expect( accept ).to.have.been.calledWith(
-			'Are you sure you want to permanently delete this item? It will be ' +
-			'permanently removed from all other locations where it currently appears.'
-		);
+		expect( accept ).to.have.been.calledWith( 'Are you sure you want to permanently delete this item?' );
 		process.nextTick( function() {
 			expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, DUMMY_MEDIA[ 0 ] );
 			done();


### PR DESCRIPTION
Reverts Automattic/wp-calypso#11629

Poor testing on my part. I thought I was just changing the design and wording for a simple button. But I didn't realize that using a component changes the functionality of the buttons, and so I hadn't actually tested to notice that "delete" stops working.