### PR TITLE
Site: Avoid mutating options when normalizing post format

### DIFF
--- a/client/lib/site/computed-attributes.js
+++ b/client/lib/site/computed-attributes.js
@@ -38,7 +38,10 @@ export default function( site ) {
 
 	// The 'standard' post format is saved as an option of '0'
 	if ( ! attributes.options.default_post_format || attributes.options.default_post_format === '0' ) {
-		attributes.options.default_post_format = 'standard';
+		attributes.options = {
+			...attributes.options,
+			default_post_format: 'standard'
+		};
 	}
 
 	//TODO:(ehg) Pull out into selector when my-sites/sidebar is connected

--- a/client/lib/site/test/computed-attributes.js
+++ b/client/lib/site/test/computed-attributes.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import getComputedAttributes from '../computed-attributes';
+
+describe( 'getComputedAttributes()', () => {
+	it( 'should not mutate the original object', () => {
+		// This is enough for a test case because deepFreeze will throw an
+		// error if an attempt is made to mutate the object
+		getComputedAttributes( deepFreeze( {
+			ID: 2916284,
+			name: 'WordPress.com Example Blog',
+			description: 'Just another WordPress.com weblog',
+			URL: 'https://example.wordpress.com',
+			jetpack: false,
+			subscribers_count: 73,
+			lang: false,
+			logo: {
+				id: 0,
+				sizes: [],
+				url: ''
+			},
+			options: {
+				default_post_format: '0'
+			},
+			visible: null,
+			is_private: false,
+			is_following: false
+		} ) );
+	} );
+} );


### PR DESCRIPTION
This pull request seeks to resolve an issue where `getComputedAttributes` will inadvertently mutate the `site` argument when normalizing `attributes.options.default_post_format`. This was most obvious when used in combination with [the `getSite` selector](https://github.com/Automattic/wp-calypso/blob/d23c46fe64ad51e3615b603e6cf8a5d0c42131c0/client/state/sites/selectors.js#L47-L76), where the `sites.items` Redux state was mutated directly.

__Testing instructions:__

Verify that tests pass:

```
npm run test-client client/lib/site/computed-attributes.js
```