### PR TITLE
Reader Following: Use an appropriate icon in the search card

### DIFF
--- a/client/components/search-card/index.jsx
+++ b/client/components/search-card/index.jsx
@@ -22,7 +22,8 @@ const SearchCard = React.createClass( {
 		autoFocus: React.PropTypes.bool,
 		disabled: React.PropTypes.bool,
 		dir: React.PropTypes.string,
-		maxLength: React.PropTypes.number
+		maxLength: React.PropTypes.number,
+		openIcon: React.PropTypes.string,
 	},
 
 	render: function() {

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -63,7 +63,8 @@ const Search = React.createClass( {
 		dir: PropTypes.oneOf( [ 'ltr', 'rtl' ] ),
 		fitsContainer: PropTypes.bool,
 		maxLength: PropTypes.number,
-		hideClose: PropTypes.bool
+		hideClose: PropTypes.bool,
+		openIcon: PropTypes.string,
 	},
 
 	getInitialState: function() {
@@ -341,7 +342,7 @@ const Search = React.createClass( {
 					}
 					aria-controls={ 'search-component-' + this.state.instanceId }
 					aria-label={ i18n.translate( 'Open Search', { context: 'button label' } ) }>
-					<Gridicon icon="search" className="search__open-icon" />
+					<Gridicon icon={ this.props.openIcon ? this.props.openIcon : 'search' } className="search__open-icon" />
 				</div>
 				<div className={ fadeDivClass }>
 					<input

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -150,6 +150,7 @@ var FollowingEditSubscribeForm = React.createClass( {
 					onKeyDown={ this.handleKeyDown }
 					disableAutocorrect={ true }
 					initialValue={ this.props.initialSearchString }
+					openIcon="reader-follow"
 				/>
 				{ searchResult }
 			</div>


### PR DESCRIPTION
As shown in this screenshot:
<img width="1095" alt="reader-following-edit-double-search-icons" src="https://cloud.githubusercontent.com/assets/1587282/23726296/c27eddd2-0421-11e7-9d06-e40143d709d2.png">

Showing the "magnifying glass" / "search" gridicon in two fields so close to one another is confusing. When I want to search for a particular site in this list, I always attempt to do so in the top box because that's the first "search" icon I see when I scan the page.

Even though the `Enter a site URL to follow` control is search-backed, I expect the icon to indicate that I'm adding a site to the list of things that I'm following.

This proposed change passes `reader-follow` via an `openIcon` prop from the `FollowingEditSubscribeForm` component through the `SearchCard` component to the underlying `Search` component which uses the prop if present and falls back to `search`.

It looks like:
<img width="741" alt="screen shot 2017-03-08 at 5 19 05 pm" src="https://cloud.githubusercontent.com/assets/1587282/23726737/645e20f8-0423-11e7-86a6-84797094962d.png">
