### PR TITLE
Add theme setup info to thanks modal.

### DIFF
--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -1,7 +1,7 @@
 .themes-thanks-modal  {
 	width: 300px;
 	padding: 1.5em;
-	min-height: 245px;
+	min-height: 265px;
 
 	@include breakpoint( "<480px" ) {
 		box-sizing: border-box;

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -10,6 +10,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import Dialog from 'components/dialog';
 import PulsingDot from 'components/pulsing-dot';
 import { trackClick } from './helpers';
@@ -18,6 +19,7 @@ import {
 	getCanonicalTheme,
 	getThemeDetailsUrl,
 	getThemeCustomizeUrl,
+	getThemeSetupUrl,
 	getThemeForumUrl,
 	isActivatingTheme,
 	hasActivatedTheme,
@@ -48,7 +50,9 @@ const ThanksModal = React.createClass( {
 		isActivating: PropTypes.bool.isRequired,
 		isThemeWpcom: PropTypes.bool.isRequired,
 		siteId: PropTypes.number,
-		visitSiteUrl: PropTypes.string
+		visitSiteUrl: PropTypes.string,
+		isJetpackSite: PropTypes.bool.isRequired,
+		themeSetupUrl: PropTypes.string
 	},
 
 	onCloseModal() {
@@ -76,14 +80,28 @@ const ThanksModal = React.createClass( {
 	renderBody() {
 		return (
 			<ul>
+				{ config.isEnabled( 'settings/theme-setup' ) && ! this.props.isJetpackSite &&
+					<li>
+						{ this.renderThemeSetupInfo() }
+					</li>
+				}
 				<li>
 					{ this.props.source === 'list' ? this.renderThemeInfo() : this.renderCustomizeInfo() }
 				</li>
-			<li>
-				{ this.renderSupportInfo() }
-			</li>
+				<li>
+					{ this.renderSupportInfo() }
+				</li>
 			</ul>
 		);
+	},
+
+	renderThemeSetupInfo() {
+		return translate( 'Make your site look like the demo with {{a}}Theme Setup{{/a}}.', {
+			components: {
+				a: <a href={ this.props.themeSetupUrl }
+					onClick={ this.onLinkClick( 'setup' ) } />
+			}
+		} );
 	},
 
 	renderThemeInfo() {
@@ -192,7 +210,9 @@ export default connect(
 			visitSiteUrl: siteUrl + ( isJetpackSite( state, siteId ) ? '' : '?next=customize' ),
 			isActivating: !! ( isActivatingTheme( state, siteId ) ),
 			hasActivated: !! ( hasActivatedTheme( state, siteId ) ),
-			isThemeWpcom: isWpcomTheme( state, currentThemeId )
+			isThemeWpcom: isWpcomTheme( state, currentThemeId ),
+			isJetpackSite: isJetpackSite( state, siteId ),
+			themeSetupUrl: getThemeSetupUrl( state, siteId )
 		};
 	},
 	{ clearActivated }

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -456,6 +456,21 @@ export function getThemeCustomizeUrl( state, themeId, siteId ) {
 }
 
 /**
+ * Returns the URL for running Theme Setup on the current site (Headstart on demand).
+ *
+ * @param  {Object}  state   Global state tree
+ * @param  {Object}  siteId  Site ID
+ * @return {String}          Theme Setup URL
+ */
+export function getThemeSetupUrl( state, siteId ) {
+	if ( ! siteId ) {
+		return '/settings/theme-setup/';
+	}
+	const siteSlug = getSiteSlug( state, siteId );
+	return '/settings/theme-setup/' + siteSlug;
+}
+
+/**
  * Returns the URL for signing up for a new WordPress.com account with the given theme pre-selected.
  *
  * @param  {Object}  state   Global state tree


### PR DESCRIPTION
This PR adds a theme setup link to the thanks modal, seen by users after a theme switch (originally part of #10542 ). This should only be merged after #11914 .

![screen shot 2017-03-20 at 2 02 44 pm](https://cloud.githubusercontent.com/assets/349751/24121581/03ffb4b8-0d76-11e7-86c0-334b6e3bacd0.png)

**Testing**

* Load this PR.
* Switch themes on any dotcom site, and follow the link, which should take you to `https://wordpress.com/settings/theme-setup/<site>.wordpress.com`.
* Switch themes on a Jetpack site – no link should be seen.