### PR TITLE
Plans: First pass at adding ProgressBar to PlanThankYouCard for Jetpack sites

### DIFF
--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -24,6 +24,7 @@ const PlanThankYouCard = ( {
 	translate,
 	siteId,
 	siteUrl,
+	action
 } ) => {
 	const name = plan && translate( '%(planName)s Plan', {
 		args: { planName: getPlan( plan.productSlug ).getTitle() }
@@ -36,6 +37,13 @@ const PlanThankYouCard = ( {
 	const planIcon = productSlug
 		? <PlanIcon plan={ productSlug } />
 		: null;
+	const renderAction = () => {
+		if ( action ) {
+			return action;
+		}
+
+		return null;
+	};
 
 	return (
 		<div className={ classnames( 'plan-thank-you-card', planClass ) }>
@@ -50,6 +58,7 @@ const PlanThankYouCard = ( {
 				buttonUrl={ siteUrl }
 				buttonText={ translate( 'Visit Your Site' ) }
 				icon={ planIcon }
+				action={ renderAction() }
 			/>
 		</div>
 	);
@@ -60,6 +69,7 @@ PlanThankYouCard.propTypes = {
 	siteId: PropTypes.number.isRequired,
 	siteUrl: PropTypes.string,
 	translate: PropTypes.func.isRequired,
+	action: PropTypes.node
 };
 
 export default connect( ( state, ownProps ) => {

--- a/client/components/progress-bar/style.scss
+++ b/client/components/progress-bar/style.scss
@@ -11,6 +11,20 @@
 	}
 }
 
+.plan-thank-you-card {
+	&.is-personal-plan .progress-bar  {
+		background-color: darken( $alert-yellow, 30% );
+	}
+
+	&.is-premium-plan .progress-bar  {
+		background-color: darken( $alert-green, 30% );
+	}
+
+	&.is-business-plan .progress-bar  {
+		background-color: darken( $alert-purple, 30% );
+	}
+}
+
 .progress-bar__progress {
 	display: inline-block;
 	position: absolute;
@@ -20,6 +34,20 @@
 	background-color: lighten( $blue-dark, 10% );
 	border-radius: 4.5px;
 	transition: width 200ms;
+}
+
+.plan-thank-you-card {
+	&.is-personal-plan .progress-bar__progress {
+		background-color: $alert-yellow;
+	}
+
+	&.is-premium-plan .progress-bar__progress {
+		background-color: $alert-green;
+	}
+
+	&.is-business-plan .progress-bar__progress {
+		background-color: $alert-purple;
+	}
 }
 
 .progress-bar.is-pulsing .progress-bar__progress {
@@ -33,6 +61,38 @@
 		lighten( $blue-wordpress, 5% ) 72%,
 		$blue-wordpress 72%
 	);
+}
+
+.plan-thank-you-card {
+	&.is-personal-plan .progress-bar.is-pulsing .progress-bar__progress {
+		background-image: linear-gradient(
+			-45deg,
+			$alert-yellow 28%,
+			lighten( $alert-yellow, 20% ) 28%,
+			lighten( $alert-yellow, 20% ) 72%,
+			$alert-yellow 72%
+		);
+	}
+
+	&.is-premium-plan .progress-bar.is-pulsing .progress-bar__progress {
+		background-image: linear-gradient(
+			-45deg,
+			$alert-green 28%,
+			lighten( $alert-green, 20% ) 28%,
+			lighten( $alert-green, 20% ) 72%,
+			$alert-green 72%
+		);
+	}
+
+	&.is-business-plan .progress-bar.is-pulsing .progress-bar__progress {
+		background-image: linear-gradient(
+			-45deg,
+			$alert-purple 28%,
+			lighten( $alert-purple, 20% ) 28%,
+			lighten( $alert-purple, 20% ) 72%,
+			$alert-purple 72%
+		);
+	}
 }
 
 @keyframes progress-bar-animation {

--- a/client/components/progress-bar/style.scss
+++ b/client/components/progress-bar/style.scss
@@ -10,10 +10,10 @@
 	.progress-bar.is-pulsing .progress-bar__progress {
 		background-image: linear-gradient(
 			-45deg,
-			darken( $color, 20% ) 28%,
-			lighten( $color, 20% ) 28%,
-			lighten( $color, 20% ) 72%,
-			darken( $color, 20% ) 72%
+			$color 28%,
+			lighten( $color, 5% ) 28%,
+			lighten( $color, 5% ) 72%,
+			$color 72%
 		);
 	}
 }

--- a/client/components/progress-bar/style.scss
+++ b/client/components/progress-bar/style.scss
@@ -1,3 +1,23 @@
+@mixin plan-progress-bar-color( $color ) {
+	.progress-bar {
+		background-color: darken( $color, 30% );
+	}
+
+	.progress-bar__progress {
+		background-color: $color;
+	}
+
+	.progress-bar.is-pulsing .progress-bar__progress {
+		background-image: linear-gradient(
+			-45deg,
+			darken( $color, 20% ) 28%,
+			lighten( $color, 20% ) 28%,
+			lighten( $color, 20% ) 72%,
+			darken( $color, 20% ) 72%
+		);
+	}
+}
+
 .progress-bar {
 	width: 100%;
 	display: inline-block;
@@ -11,20 +31,6 @@
 	}
 }
 
-.plan-thank-you-card {
-	&.is-personal-plan .progress-bar  {
-		background-color: darken( $alert-yellow, 30% );
-	}
-
-	&.is-premium-plan .progress-bar  {
-		background-color: darken( $alert-green, 30% );
-	}
-
-	&.is-business-plan .progress-bar  {
-		background-color: darken( $alert-purple, 30% );
-	}
-}
-
 .progress-bar__progress {
 	display: inline-block;
 	position: absolute;
@@ -34,20 +40,6 @@
 	background-color: lighten( $blue-dark, 10% );
 	border-radius: 4.5px;
 	transition: width 200ms;
-}
-
-.plan-thank-you-card {
-	&.is-personal-plan .progress-bar__progress {
-		background-color: $alert-yellow;
-	}
-
-	&.is-premium-plan .progress-bar__progress {
-		background-color: $alert-green;
-	}
-
-	&.is-business-plan .progress-bar__progress {
-		background-color: $alert-purple;
-	}
 }
 
 .progress-bar.is-pulsing .progress-bar__progress {
@@ -64,34 +56,16 @@
 }
 
 .plan-thank-you-card {
-	&.is-personal-plan .progress-bar.is-pulsing .progress-bar__progress {
-		background-image: linear-gradient(
-			-45deg,
-			$alert-yellow 28%,
-			lighten( $alert-yellow, 20% ) 28%,
-			lighten( $alert-yellow, 20% ) 72%,
-			$alert-yellow 72%
-		);
+	&.is-personal-plan {
+		@include plan-progress-bar-color( $alert-yellow );
 	}
 
-	&.is-premium-plan .progress-bar.is-pulsing .progress-bar__progress {
-		background-image: linear-gradient(
-			-45deg,
-			$alert-green 28%,
-			lighten( $alert-green, 20% ) 28%,
-			lighten( $alert-green, 20% ) 72%,
-			$alert-green 72%
-		);
+	&.is-premium-plan {
+		@include plan-progress-bar-color( $alert-green );
 	}
 
-	&.is-business-plan .progress-bar.is-pulsing .progress-bar__progress {
-		background-image: linear-gradient(
-			-45deg,
-			$alert-purple 28%,
-			lighten( $alert-purple, 20% ) 28%,
-			lighten( $alert-purple, 20% ) 72%,
-			$alert-purple 72%
-		);
+	&.is-business-plan {
+		@include plan-progress-bar-color( $alert-purple );
 	}
 }
 

--- a/client/components/thank-you-card/index.jsx
+++ b/client/components/thank-you-card/index.jsx
@@ -7,54 +7,70 @@ import React, { PropTypes } from 'react';
 
 // Non standard gridicon sizes are used here because we use them as background pattern with various sizes and rotation
 /* eslint-disable wpcalypso/jsx-gridicon-size */
-const ThankYouCard = ( { heading, description, buttonUrl, buttonText, price, name, icon } ) => (
-	<div className="thank-you-card">
-		<div className="thank-you-card__header">
-			{
-				icon
-				? <div className="thank-you-card__main-icon">{ icon }</div>
-				: <Gridicon className="thank-you-card__main-icon" icon="checkmark-circle" size={ 140 } />
-			}
 
-			<div className="thank-you-card__header-detail">
-				<div className={ classnames( 'thank-you-card__name', { 'is-placeholder': ! name } ) }>
-					{ name }
-				</div>
-				<div className={ classnames( 'thank-you-card__price', { 'is-placeholder': ! price } ) }>
-					{ price }
-				</div>
-			</div>
+const ThankYouCard = ( { heading, description, buttonUrl, buttonText, price, name, icon, action } ) => {
+	const renderAction = () => {
+		if ( action ) {
+			return action;
+		}
 
-			<div className="thank-you-card__background-icons">
-				<Gridicon icon="audio" size={ 52 } />
-				<Gridicon icon="audio" size={ 20 } />
-				<Gridicon icon="heart" size={ 52 } />
-				<Gridicon icon="heart" size={ 41 } />
-				<Gridicon icon="star" size={ 26 } />
-				<Gridicon icon="status" size={ 52 } />
-				<Gridicon icon="audio" size={ 38 } />
-				<Gridicon icon="status" size={ 28 } />
-				<Gridicon icon="status" size={ 65 } />
-				<Gridicon icon="star" size={ 57 } />
-				<Gridicon icon="star" size={ 33 } />
-				<Gridicon icon="star" size={ 45 } />
-			</div>
-		</div>
-		<div className="thank-you-card__body">
-			<div className="thank-you-card__heading">
-				{ heading }
-			</div>
-			<div className="thank-you-card__description">
-				{ description }
-			</div>
+		return (
 			<a
 				className={ classnames( 'thank-you-card__button', { 'is-placeholder': ! buttonUrl } ) }
 				href={ buttonUrl }>
 				{ buttonText }
 			</a>
+		);
+	};
+
+	return (
+		<div className="thank-you-card">
+			<div className="thank-you-card__header">
+				{
+					icon
+					? <div className="thank-you-card__main-icon">{ icon }</div>
+					: <Gridicon className="thank-you-card__main-icon" icon="checkmark-circle" size={ 140 } />
+				}
+
+				<div className="thank-you-card__header-detail">
+					<div className={ classnames( 'thank-you-card__name', { 'is-placeholder': ! name } ) }>
+						{ name }
+					</div>
+					<div className={ classnames( 'thank-you-card__price', { 'is-placeholder': ! price } ) }>
+						{ price }
+					</div>
+				</div>
+
+				<div className="thank-you-card__background-icons">
+					<Gridicon icon="audio" size={ 52 } />
+					<Gridicon icon="audio" size={ 20 } />
+					<Gridicon icon="heart" size={ 52 } />
+					<Gridicon icon="heart" size={ 41 } />
+					<Gridicon icon="star" size={ 26 } />
+					<Gridicon icon="status" size={ 52 } />
+					<Gridicon icon="audio" size={ 38 } />
+					<Gridicon icon="status" size={ 28 } />
+					<Gridicon icon="status" size={ 65 } />
+					<Gridicon icon="star" size={ 57 } />
+					<Gridicon icon="star" size={ 33 } />
+					<Gridicon icon="star" size={ 45 } />
+				</div>
+			</div>
+			<div className="thank-you-card__body">
+				<div className="thank-you-card__heading">
+					{ heading }
+				</div>
+				<div className="thank-you-card__description">
+					{ description }
+				</div>
+
+				<div className="thank-you-card__action">
+					{ renderAction() }
+				</div>
+			</div>
 		</div>
-	</div>
-);
+	);
+};
 /* eslint-enable wpcalypso/jsx-gridicon-size */
 
 ThankYouCard.propTypes = {
@@ -64,7 +80,8 @@ ThankYouCard.propTypes = {
 	heading: PropTypes.string,
 	name: PropTypes.string,
 	price: PropTypes.string,
-	icon: PropTypes.node
+	icon: PropTypes.node,
+	action: PropTypes.node
 };
 
 export default ThankYouCard;

--- a/client/my-sites/upgrades/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -44,6 +44,7 @@ import {
 } from 'state/plugins/premium/selectors';
 // Store for existing plugins
 import PluginsStore from 'lib/plugins/store';
+import ProgressBar from 'components/progress-bar';
 
 class JetpackThankYouCard extends Component {
 	trackConfigFinished( eventName, options = null ) {
@@ -304,6 +305,12 @@ class JetpackThankYouCard extends Component {
 		);
 	}
 
+	renderAction() {
+		return (
+			<ProgressBar value={ 40 } isPulsing />
+		);
+	}
+
 	render() {
 		const site = this.props.selectedSite;
 		const turnOnManage = site && ! site.canManage();
@@ -320,7 +327,7 @@ class JetpackThankYouCard extends Component {
 				<QueryPluginKeys siteId={ site.ID } />
 				{ this.renderErrorNotice() }
 				{ turnOnManage && this.renderManageNotice() }
-				<PlanThankYouCard siteId={ site.ID } />
+				<PlanThankYouCard siteId={ site.ID } action={ this.renderAction() } />
 				{ turnOnManage
 					? <FeatureExample>{ this.renderPlugins() }</FeatureExample>
 					: this.renderPlugins()

--- a/client/my-sites/upgrades/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -311,21 +311,17 @@ class JetpackThankYouCard extends Component {
 			return null;
 		}
 
-		const countSteps = plugins.length * 4;
+		const countSteps = plugins.length * 3;
 		const countCompletion = plugins.reduce( ( total, plugin ) => {
 			switch ( plugin.status ) {
 				case 'done':
-					total += 4;
+					total += 3;
 					break;
 				case 'activate':
 				case 'configure':
-					total += 3;
-					break;
-				case 'install':
 					total += 2;
 					break;
-				case 'wait':
-				default:
+				case 'install':
 					total += 1;
 					break;
 			}

--- a/client/my-sites/upgrades/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -306,8 +306,39 @@ class JetpackThankYouCard extends Component {
 	}
 
 	renderAction() {
+		const { plugins } = this.props;
+		if ( ! plugins || ! Array.isArray( plugins ) ) {
+			return null;
+		}
+
+		const countSteps = plugins.length * 4;
+		const countCompletion = plugins.reduce( ( total, plugin ) => {
+			switch ( plugin.status ) {
+				case 'done':
+					total += 4;
+					break;
+				case 'activate':
+				case 'configure':
+					total += 3;
+					break;
+				case 'install':
+					total += 2;
+					break;
+				case 'wait':
+				default:
+					total += 1;
+					break;
+			}
+
+			return total;
+		}, 0 );
+
+		if ( countSteps === countCompletion ) {
+			return null;
+		}
+
 		return (
-			<ProgressBar value={ 40 } isPulsing />
+			<ProgressBar value={ countCompletion } total={ countSteps } isPulsing />
 		);
 	}
 


### PR DESCRIPTION
This PR is meant to add a colorized `ProgressBar` to the `JetpackThankYouCard` component. It relies on #11865 being merged first.

You can view @rickybanister's mocks for colorized thank you pages here: p6TEKc-105-p2

~Screenshots will come after I merge the other PR.~ Screenshots below.

cc @lezama @enejb for code review.

To test:

- You can test the WPCOM plans flow by creating a new user and following the NUX flow
- For Jetpack, you can purchase a plan for your Jetpack site, and then you should land on the auto-config flow
- You can test previous purchases by going to: http://calypso.localhost:3000/checkout/thank-you/:siteId:/:receiptId: