### PR TITLE
Reader bugfix: Don't always mark posts as selected after going into f…

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -35,6 +35,7 @@ import Comments from 'blocks/comments';
 import scrollTo from 'lib/scroll-to';
 import PostExcerptLink from 'reader/post-excerpt-link';
 import { siteNameFromSiteAndPost } from 'reader/utils';
+import { keyForPost } from 'lib/feed-stream-store/post-key';
 import KeyboardShortcuts from 'lib/keyboard-shortcuts';
 import ReaderPostActions from 'blocks/reader-post-actions';
 import PostStoreActions from 'lib/feed-post-store/actions';
@@ -247,16 +248,22 @@ export class FullPostView extends React.Component {
 	goToNextPost = () => {
 		const store = getLastStore();
 		if ( store ) {
+			if ( ! store.getSelectedPostKey() ) {
+				store.selectItem( keyForPost( this.props.post ), store.id );
+			}
 			FeedStreamStoreActions.selectNextItem( store.getID() );
-			showSelectedPost( { store, postKey: store.getSelectedPost() } );
+			showSelectedPost( { store, postKey: store.getSelectedPostKey() } );
 		}
 	}
 
 	goToPreviousPost = () => {
 		const store = getLastStore();
 		if ( store ) {
+			if ( ! store.getSelectedPostKey() ) {
+				store.selectItem( keyForPost( this.props.post ), store.id );
+			}
 			FeedStreamStoreActions.selectPrevItem( store.getID() );
-			showSelectedPost( { store, postKey: store.getSelectedPost() } );
+			showSelectedPost( { store, postKey: store.getSelectedPostKey() } );
 		}
 	}
 

--- a/client/reader/utils.js
+++ b/client/reader/utils.js
@@ -11,7 +11,6 @@ import i18n from 'i18n-calypso';
 import { state as SiteState } from 'lib/reader-site-store/constants';
 import FeedDisplayHelper from 'reader/lib/feed-display-helper';
 import PostStore from 'lib/feed-post-store';
-import { selectItem } from 'lib/feed-stream-store/actions';
 import XPostHelper, { isXPost } from 'reader/xpost-helper';
 import { setLastStoreId } from 'reader/controller-helper';
 
@@ -80,11 +79,7 @@ export function showSelectedPost( { store, replaceHistory, selectedGap, postKey,
 		return;
 	}
 
-	if ( store && postKey ) {
-		selectItem( store.getID(), postKey );
-	} else if ( ! store ) {
-		setLastStoreId( undefined );
-	}
+	setLastStoreId( store && store.id );
 
 	if ( postKey.isGap === true ) {
 		return selectedGap.handleClick();


### PR DESCRIPTION
Recently we (I) made changes to support j/k keyboard shortcuts. Because of an implementation mistake, it made it so that even if a user never hit a keyboard shortcut, just entering a fullpost would activate the selected post view. This commit fixes the issue by creating a new shouldSelectPost flag