### PR TITLE
Media modal: do not apply custom styles to uploading-by-URL box

### DIFF
--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -25,6 +25,7 @@ module.exports = React.createClass( {
 	mixins: [ urlSearch ],
 
 	propTypes: {
+		className: React.PropTypes.string,
 		site: React.PropTypes.object,
 		filter: React.PropTypes.string,
 		enabledFilters: React.PropTypes.arrayOf( React.PropTypes.string ),
@@ -143,9 +144,11 @@ module.exports = React.createClass( {
 			);
 		}
 
-		classes = classNames( 'media-library', {
-			'is-single': this.props.single
-		} );
+		classes = classNames(
+			'media-library',
+			{ 'is-single': this.props.single },
+			this.props.className,
+		);
 
 		return (
 			<div className={ classes }>

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -94,14 +94,6 @@
 	}
 }
 
-.media-library__header.media-library__upload-url {
-	padding: 6px 12px;
-	background-color: $white;
-	box-sizing: border-box;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
-}
-
 .media-library__upload-buttons {
 	display: inline;
 }

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -238,6 +238,7 @@ export default React.createClass( {
 					<MediaLibrarySelectedData siteId={ site.ID }>
 						<MediaLibrary
 							{ ...this.props }
+							className="media__main-section"
 							onFilterChange={ this.onFilterChange }
 							site={ site }
 							single={ false }

--- a/client/my-sites/media/style.scss
+++ b/client/my-sites/media/style.scss
@@ -28,3 +28,11 @@
 		color: lighten( $alert-red, 25% );
 	}
 }
+
+.media__main-section .media-library__header.media-library__upload-url {
+	padding: 6px 12px;
+	background-color: $white;
+	box-sizing: border-box;
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		0 1px 2px lighten( $gray, 30% );
+}


### PR DESCRIPTION
This PR removes custom styles to the uploading-by-URL section in the media-modal. Now, these styles are only applied to the main media section.

### Testing

#### Media modal

1) Start to write/edit a post
2) Open the media modal adding a new media
3) switch to upload by URL

You *shouldn't* see a weird border shadow like the following:

<img width="930" alt="screen shot 2017-03-08 at 4 06 23 pm" src="https://cloud.githubusercontent.com/assets/1270189/23729889/480c0668-0419-11e7-92ee-288a290d7cf6.png">

It should look like this:

<img width="500" src="https://cloud.githubusercontent.com/assets/77539/23730191/fd3bcd40-0444-11e7-9a2b-a02f6dddb84a.png" />


#### Media

1) Go to the media main section: `http://calypso.localhost:3000/media/<site>`
3) switch to upload by URL

You should see the custom style in the uploading-by-URL

<img width="500" src="https://cloud.githubusercontent.com/assets/77539/23730240/317ea41a-0445-11e7-8e53-e9bea3325172.png" />
