### PR TITLE
Media library: remove pencil-button from media library

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -190,7 +190,6 @@ $z-layers: (
 		'.media-library__list-item.is-transient .media-library__list-item-figure::after': 10,
 		'.media-library__list-item-selected-icon .gridicon': 20,
 		'.media-library__list-item-spinner': 20,
-		'.media-library__list-item-edit': 20
 	),
 	'.dialog__backdrop': (
 		'.editor-media-modal .section-nav': 10,

--- a/client/my-sites/media-library/list-item.jsx
+++ b/client/my-sites/media-library/list-item.jsx
@@ -13,7 +13,6 @@ var React = require( 'react' ),
  */
 var Spinner = require( 'components/spinner' ),
 	Gridicon = require( 'gridicons' ),
-	Button = require( 'components/button' ),
 	ListItemImage = require( './list-item-image' ),
 	ListItemVideo = require( './list-item-video' ),
 	ListItemAudio = require( './list-item-audio' ),
@@ -58,13 +57,6 @@ export default React.createClass( {
 
 	clickItem: function( event ) {
 		this.props.onToggle( this.props.media, event.shiftKey );
-	},
-
-	editItem: function( event ) {
-		this.props.onEditItem( this.props.media );
-
-		// Prevent default list item toggle behavior
-		event.stopPropagation();
 	},
 
 	renderItem: function() {
@@ -125,12 +117,6 @@ export default React.createClass( {
 					{ this.renderItem() }
 					{ this.renderSpinner() }
 					{ this.props.showGalleryHelp && <EditorMediaModalGalleryHelp /> }
-					<Button type="button" className="media-library__list-item-edit" onClick={ this.editItem }>
-						<span className="screen-reader-text">
-							{ this.translate( 'Edit', { context: 'verb' } ) }
-						</span>
-						<Gridicon icon="pencil" />
-					</Button>
 				</figure>
 			</div>
 		);

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -149,31 +149,8 @@
 	margin-bottom: 0;
 }
 
-.media-library__list-item-edit {
-	position: absolute;
-		top: 8px;
-		right: 8px;
-	z-index: z-index( '.media-library__list-item', '.media-library__list-item-edit' );
-	padding: 2px 6px 3px;
-	transition: 0.2s opacity;
-	opacity: 0;
-	color: darken( $gray, 10% );
-
-	&:hover {
-		color: darken( $gray, 20% );
-	}
-}
-
 .media-library__list {
 	padding: 0 16px;
-}
-
-.media-library__list-item:hover .media-library__list-item-edit {
-	opacity: 1;
-}
-
-.media-library__list-item.is-small .media-library__list-item-edit {
-	display: none;
 }
 
 .media-library__list-item.is-small .media-library__list-item-file-details .media-library__list-item-icon {


### PR DESCRIPTION
According to #11498, this PR removes the edit pencil-button from the media item.

### Testing.

Open the media library from no matter from where. The edit pencil button should disappear.

Open the media library from no matter from where. The edit pencil button should disappear.

<img src="https://cloud.githubusercontent.com/assets/77539/23730809/55c6339e-0448-11e7-86f0-2d7f73a64b49.png" width="300px" />
