### PR TITLE
Track LearnMore button click in gdocs tour

### DIFF
--- a/client/layout/guided-tours/tours/gdocs-integration-tour.js
+++ b/client/layout/guided-tours/tours/gdocs-integration-tour.js
@@ -16,6 +16,11 @@ import {
 	Quit,
 } from 'layout/guided-tours/config-elements';
 import { hasUserPastedFromGoogleDocs } from 'state/ui/guided-tours/contexts';
+import analytics from 'lib/analytics';
+
+const trackUserInterest = () => {
+	analytics.tracks.recordEvent( 'calypso_editor_gdocs_tour_success' );
+};
 
 export const GDocsIntegrationTour = makeTour(
 	<Tour
@@ -30,6 +35,7 @@ export const GDocsIntegrationTour = makeTour(
 				<LinkQuit
 					primary
 					target="_blank"
+					onClick={ trackUserInterest }
 					href="https://apps.wordpress.com/google-docs/">
 					{ translate( 'Learn more' ) }
 				</LinkQuit>


### PR DESCRIPTION
This PR adds the ability to identify whether the [Google Docs integration tour](https://github.com/Automattic/wp-calypso/blob/6ff1225280c0ecb081cfefdddea523871bdcb58c/client/layout/guided-tours/tours/gdocs-integration-tour.js) has been a success or not by analyzing if the user clicked the `Learn more` button.

![gdocs-tour](https://cloud.githubusercontent.com/assets/583546/23748615/ae687b5c-04c4-11e7-9b6b-ce034903283a.png)

### How to test

* Visit http://calypso.localhost:3000/?tour=gdocsIntegrationTour 
* Clicking the `Learn more` button shall fire the `calypso_editor_gdocs_tour_success` event and the tour shall be closed.
* Clicking the `No thanks` button shall not fire the `calypso_editor_gdocs_tour_success` event and the tour shall be closed.
