### PR TITLE
Site Settings: Make the toggles in Discussion Settings, autosave on toggle

### DIFF
--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -35,29 +35,37 @@ class SiteSettingsFormDiscussion extends Component {
 		this.props.trackEvent( 'Toggled Comment Order on Page' );
 		this.props.updateFields( {
 			comment_order: this.props.fields.comment_order === 'desc' ? 'asc' : 'desc'
+		}, () => {
+			this.props.submitForm();
 		} );
 	}
 
 	defaultArticleSettings() {
-		const { fields, handleToggle, isRequestingSettings, translate } = this.props;
+		const {
+			fields,
+			handleAutosavingToggle,
+			isRequestingSettings,
+			isSavingSettings,
+			translate
+		} = this.props;
 		return (
 			<FormFieldset>
 				<CompactFormToggle
 					checked={ !! fields.default_pingback_flag }
-					disabled={ isRequestingSettings }
-					onChange={ handleToggle( 'default_pingback_flag' ) }>
+					disabled={ isRequestingSettings || isSavingSettings }
+					onChange={ handleAutosavingToggle( 'default_pingback_flag' ) }>
 					<span>{ translate( 'Attempt to notify any blogs linked to from the article' ) }</span>
 				</CompactFormToggle>
 				<CompactFormToggle
 					checked={ !! fields.default_ping_status }
-					disabled={ isRequestingSettings }
-					onChange={ handleToggle( 'default_ping_status' ) }>
+					disabled={ isRequestingSettings || isSavingSettings }
+					onChange={ handleAutosavingToggle( 'default_ping_status' ) }>
 					<span>{ translate( 'Allow link notifications from other blogs (pingbacks and trackbacks)' ) }</span>
 				</CompactFormToggle>
 				<CompactFormToggle
 					checked={ !! fields.default_comment_status }
-					disabled={ isRequestingSettings }
-					onChange={ handleToggle( 'default_comment_status' ) }>
+					disabled={ isRequestingSettings || isSavingSettings }
+					onChange={ handleAutosavingToggle( 'default_comment_status' ) }>
 					<span>{ translate( 'Allow people to post comments on new articles' ) }</span>
 				</CompactFormToggle>
 				<FormSettingExplanation>
@@ -93,25 +101,31 @@ class SiteSettingsFormDiscussion extends Component {
 	}
 
 	otherCommentSettings() {
-		const { fields, handleToggle, isRequestingSettings, translate } = this.props;
+		const {
+			fields,
+			handleAutosavingToggle,
+			isRequestingSettings,
+			isSavingSettings,
+			translate
+		} = this.props;
 		return (
 			<FormFieldset className="site-settings__other-comment-settings">
 				<CompactFormToggle
 					checked={ !! fields.require_name_email }
-					disabled={ isRequestingSettings }
-					onChange={ handleToggle( 'require_name_email' ) }>
+					disabled={ isRequestingSettings || isSavingSettings }
+					onChange={ handleAutosavingToggle( 'require_name_email' ) }>
 					<span>{ translate( 'Comment author must fill out name and e-mail' ) }</span>
 				</CompactFormToggle>
 				<CompactFormToggle
 					checked={ !! fields.comment_registration }
-					disabled={ isRequestingSettings }
-					onChange={ handleToggle( 'comment_registration' ) }>
+					disabled={ isRequestingSettings || isSavingSettings }
+					onChange={ handleAutosavingToggle( 'comment_registration' ) }>
 					<span>{ translate( 'Users must be registered and logged in to comment' ) }</span>
 				</CompactFormToggle>
 				<CompactFormToggle
 					checked={ !! fields.close_comments_for_old_posts }
-					disabled={ isRequestingSettings }
-					onChange={ handleToggle( 'close_comments_for_old_posts' ) }>
+					disabled={ isRequestingSettings || isSavingSettings }
+					onChange={ handleAutosavingToggle( 'close_comments_for_old_posts' ) }>
 					<span>
 						{
 							translate(
@@ -128,8 +142,8 @@ class SiteSettingsFormDiscussion extends Component {
 				</CompactFormToggle>
 				<CompactFormToggle
 					checked={ !! fields.thread_comments }
-					disabled={ isRequestingSettings }
-					onChange={ handleToggle( 'thread_comments' ) }>
+					disabled={ isRequestingSettings || isSavingSettings }
+					onChange={ handleAutosavingToggle( 'thread_comments' ) }>
 					<span>
 						{
 							translate( 'Enable threaded (nested) comments up to {{number /}} levels deep', {
@@ -142,8 +156,8 @@ class SiteSettingsFormDiscussion extends Component {
 				</CompactFormToggle>
 				<CompactFormToggle
 					checked={ !! fields.page_comments }
-					disabled={ isRequestingSettings }
-					onChange={ handleToggle( 'page_comments' ) }>
+					disabled={ isRequestingSettings || isSavingSettings }
+					onChange={ handleAutosavingToggle( 'page_comments' ) }>
 					<span>
 						{
 							translate(
@@ -161,7 +175,7 @@ class SiteSettingsFormDiscussion extends Component {
 				</CompactFormToggle>
 				<CompactFormToggle
 					checked={ 'asc' === fields.comment_order }
-					disabled={ isRequestingSettings }
+					disabled={ isRequestingSettings || isSavingSettings }
 					onChange={ this.handleCommentOrder }>
 					<span>{ translate( 'Comments should be displayed with the older comments at the top of each page' ) }</span>
 				</CompactFormToggle>
@@ -170,7 +184,14 @@ class SiteSettingsFormDiscussion extends Component {
 	}
 
 	renderInputNumberDays() {
-		const { eventTracker, fields, isRequestingSettings, onChangeField, uniqueEventTracker } = this.props;
+		const {
+			eventTracker,
+			fields,
+			isRequestingSettings,
+			isSavingSettings,
+			onChangeField,
+			uniqueEventTracker
+		} = this.props;
 		return (
 			<FormTextInput
 				name="close_comments_days_old"
@@ -181,7 +202,7 @@ class SiteSettingsFormDiscussion extends Component {
 				className="small-text"
 				value={ 'undefined' === typeof fields.close_comments_days_old ? 14 : fields.close_comments_days_old }
 				onChange={ onChangeField( 'close_comments_days_old' ) }
-				disabled={ isRequestingSettings }
+				disabled={ isRequestingSettings || isSavingSettings }
 				onClick={ eventTracker( 'Clicked Automatically Close Days Field' ) }
 				onKeyPress={ uniqueEventTracker( 'Typed in Automatically Close Days Field' ) }
 			/>
@@ -189,14 +210,20 @@ class SiteSettingsFormDiscussion extends Component {
 	}
 
 	renderInputThreadDepth() {
-		const { eventTracker, fields, isRequestingSettings, onChangeField } = this.props;
+		const {
+			eventTracker,
+			fields,
+			isRequestingSettings,
+			isSavingSettings,
+			onChangeField
+		} = this.props;
 		return (
 			<FormSelect
 				className="is-compact"
 				name="thread_comments_depth"
 				value={ fields.thread_comments_depth }
 				onChange={ onChangeField( 'thread_comments_depth' ) }
-				disabled={ isRequestingSettings }
+				disabled={ isRequestingSettings || isSavingSettings }
 				onClick={ eventTracker( 'Selected Comment Nesting Level' ) }>
 					{ [ 2, 3, 4, 5, 6, 7, 8, 9, 10 ].map( level =>
 						<option value={ level } key={ 'comment-depth-' + level }>{ level }</option>
@@ -206,7 +233,14 @@ class SiteSettingsFormDiscussion extends Component {
 	}
 
 	renderInputNumComments() {
-		const { eventTracker, fields, isRequestingSettings, onChangeField, uniqueEventTracker } = this.props;
+		const {
+			eventTracker,
+			fields,
+			isRequestingSettings,
+			isSavingSettings,
+			onChangeField,
+			uniqueEventTracker
+		} = this.props;
 		return (
 			<FormTextInput
 				name="comments_per_page"
@@ -217,14 +251,21 @@ class SiteSettingsFormDiscussion extends Component {
 				value={ 'undefined' === typeof fields.comments_per_page ? 50 : fields.comments_per_page }
 				onChange={ onChangeField( 'comments_per_page' ) }
 				className="small-text"
-				disabled={ isRequestingSettings }
+				disabled={ isRequestingSettings || isSavingSettings }
 				onClick={ eventTracker( 'Clicked Comments Per Page Field' ) }
 				onKeyPress={ uniqueEventTracker( 'Typed in Comments Per Page Field' ) } />
 		);
 	}
 
 	renderInputDisplayDefault() {
-		const { eventTracker, fields, isRequestingSettings, onChangeField, translate } = this.props;
+		const {
+			eventTracker,
+			fields,
+			isRequestingSettings,
+			onChangeField,
+			translate,
+			isSavingSettings
+		} = this.props;
 		return (
 			<FormSelect
 				className="is-compact"
@@ -232,7 +273,7 @@ class SiteSettingsFormDiscussion extends Component {
 				style={ { marginTop: '4px' } }
 				value={ fields.default_comments_page }
 				onChange={ onChangeField( 'default_comments_page' ) }
-				disabled={ isRequestingSettings }
+				disabled={ isRequestingSettings || isSavingSettings }
 				onClick={ eventTracker( 'Selected Comment Page Display Default' ) }>
 					<option value="newest">{ translate( 'last' ) }</option>
 					<option value="oldest">{ translate( 'first' ) }</option>
@@ -241,20 +282,26 @@ class SiteSettingsFormDiscussion extends Component {
 	}
 
 	emailMeSettings() {
-		const { fields, handleToggle, isRequestingSettings, translate } = this.props;
+		const {
+			fields,
+			handleAutosavingToggle,
+			isRequestingSettings,
+			isSavingSettings,
+			translate
+		} = this.props;
 		return (
 			<FormFieldset>
 				<FormLegend>{ translate( 'E-mail me whenever' ) }</FormLegend>
 				<CompactFormToggle
 					checked={ !! fields.comments_notify }
-					disabled={ isRequestingSettings }
-					onChange={ handleToggle( 'comments_notify' ) }>
+					disabled={ isRequestingSettings || isSavingSettings }
+					onChange={ handleAutosavingToggle( 'comments_notify' ) }>
 					<span>{ translate( 'Anyone posts a comment' ) }</span>
 				</CompactFormToggle>
 				<CompactFormToggle
 					checked={ !! fields.moderation_notify }
-					disabled={ isRequestingSettings }
-					onChange={ handleToggle( 'moderation_notify' ) }>
+					disabled={ isRequestingSettings || isSavingSettings }
+					onChange={ handleAutosavingToggle( 'moderation_notify' ) }>
 					<span>{ translate( 'A comment is held for moderation' ) }</span>
 				</CompactFormToggle>
 				{ this.emailMeLikes() }
@@ -265,7 +312,15 @@ class SiteSettingsFormDiscussion extends Component {
 	}
 
 	emailMeLikes() {
-		const { fields, handleToggle, isJetpack, isLikesModuleActive, isRequestingSettings, translate } = this.props;
+		const {
+			fields,
+			handleAutosavingToggle,
+			isJetpack,
+			isLikesModuleActive,
+			isRequestingSettings,
+			isSavingSettings,
+			translate
+		} = this.props;
 		// likes are only supported on jetpack sites with the Likes module activated
 		if ( isJetpack && ! isLikesModuleActive ) {
 			return null;
@@ -274,15 +329,22 @@ class SiteSettingsFormDiscussion extends Component {
 		return (
 			<CompactFormToggle
 				checked={ !! fields.social_notifications_like }
-				disabled={ isRequestingSettings }
-				onChange={ handleToggle( 'social_notifications_like' ) }>
+				disabled={ isRequestingSettings || isSavingSettings }
+				onChange={ handleAutosavingToggle( 'social_notifications_like' ) }>
 				<span>{ translate( 'Someone likes one of my posts' ) }</span>
 			</CompactFormToggle>
 		);
 	}
 
 	emailMeReblogs() {
-		const { fields, handleToggle, isJetpack, isRequestingSettings, translate } = this.props;
+		const {
+			fields,
+			handleAutosavingToggle,
+			isJetpack,
+			isRequestingSettings,
+			isSavingSettings,
+			translate
+		} = this.props;
 		// reblogs are not supported on Jetpack sites
 		if ( isJetpack ) {
 			return null;
@@ -291,15 +353,22 @@ class SiteSettingsFormDiscussion extends Component {
 		return (
 			<CompactFormToggle
 				checked={ !! fields.social_notifications_reblog }
-				disabled={ isRequestingSettings }
-				onChange={ handleToggle( 'social_notifications_reblog' ) }>
+				disabled={ isRequestingSettings || isSavingSettings }
+				onChange={ handleAutosavingToggle( 'social_notifications_reblog' ) }>
 				<span>{ translate( 'Someone reblogs one of my posts' ) }</span>
 			</CompactFormToggle>
 		);
 	}
 
 	emailMeFollows() {
-		const { fields, handleToggle, isJetpack, isRequestingSettings, translate } = this.props;
+		const {
+			fields,
+			handleAutosavingToggle,
+			isJetpack,
+			isRequestingSettings,
+			isSavingSettings,
+			translate
+		} = this.props;
 		// follows are not supported on Jetpack sites
 		if ( isJetpack ) {
 			return null;
@@ -308,28 +377,34 @@ class SiteSettingsFormDiscussion extends Component {
 		return (
 			<CompactFormToggle
 				checked={ !! fields.social_notifications_subscribe }
-				disabled={ isRequestingSettings }
-				onChange={ handleToggle( 'social_notifications_subscribe' ) }>
+				disabled={ isRequestingSettings || isSavingSettings }
+				onChange={ handleAutosavingToggle( 'social_notifications_subscribe' ) }>
 				<span>{ translate( 'Someone follows my blog' ) }</span>
 			</CompactFormToggle>
 		);
 	}
 
 	beforeCommentSettings() {
-		const { fields, handleToggle, isRequestingSettings, translate } = this.props;
+		const {
+			fields,
+			handleAutosavingToggle,
+			isRequestingSettings,
+			isSavingSettings,
+			translate
+		} = this.props;
 		return (
 			<FormFieldset>
 				<FormLegend>{ translate( 'Before a comment appears' ) }</FormLegend>
 				<CompactFormToggle
 					checked={ !! fields.comment_moderation }
-					disabled={ isRequestingSettings }
-					onChange={ handleToggle( 'comment_moderation' ) }>
+					disabled={ isRequestingSettings || isSavingSettings }
+					onChange={ handleAutosavingToggle( 'comment_moderation' ) }>
 					<span>{ translate( 'Comment must be manually approved' ) }</span>
 				</CompactFormToggle>
 				<CompactFormToggle
 					checked={ !! fields.comment_whitelist }
-					disabled={ isRequestingSettings }
-					onChange={ handleToggle( 'comment_whitelist' ) }>
+					disabled={ isRequestingSettings || isSavingSettings }
+					onChange={ handleAutosavingToggle( 'comment_whitelist' ) }>
 					<span>{ translate( 'Comment author must have a previously approved comment' ) }</span>
 				</CompactFormToggle>
 			</FormFieldset>
@@ -337,7 +412,15 @@ class SiteSettingsFormDiscussion extends Component {
 	}
 
 	commentModerationSettings() {
-		const { eventTracker, fields, isRequestingSettings, onChangeField, translate, uniqueEventTracker } = this.props;
+		const {
+			eventTracker,
+			fields,
+			isRequestingSettings,
+			isSavingSettings,
+			onChangeField,
+			translate,
+			uniqueEventTracker
+		} = this.props;
 		return (
 			<FormFieldset className="site-settings__moderation-settings">
 				<FormLegend>{ translate( 'Comment Moderation' ) }</FormLegend>
@@ -372,7 +455,7 @@ class SiteSettingsFormDiscussion extends Component {
 					id="moderation_keys"
 					value={ fields.moderation_keys }
 					onChange={ onChangeField( 'moderation_keys' ) }
-					disabled={ isRequestingSettings }
+					disabled={ isRequestingSettings || isSavingSettings }
 					autoCapitalize="none"
 					onClick={ eventTracker( 'Clicked Moderation Queue Field' ) }
 					onKeyPress={ uniqueEventTracker( 'Typed in Moderation Queue Field' ) }>
@@ -382,7 +465,15 @@ class SiteSettingsFormDiscussion extends Component {
 	}
 
 	commentBlacklistSettings() {
-		const { eventTracker, fields, isRequestingSettings, onChangeField, translate, uniqueEventTracker } = this.props;
+		const {
+			eventTracker,
+			fields,
+			isRequestingSettings,
+			isSavingSettings,
+			onChangeField,
+			translate,
+			uniqueEventTracker
+		} = this.props;
 		return (
 			<FormFieldset>
 				<FormLegend>{ translate( 'Comment Blacklist' ) }</FormLegend>
@@ -395,7 +486,7 @@ class SiteSettingsFormDiscussion extends Component {
 					id="blacklist_keys"
 					value={ fields.blacklist_keys }
 					onChange={ onChangeField( 'blacklist_keys' ) }
-					disabled={ isRequestingSettings }
+					disabled={ isRequestingSettings || isSavingSettings }
 					autoCapitalize="none"
 					onClick={ eventTracker( 'Clicked Blacklist Field' ) }
 					onKeyPress={ uniqueEventTracker( 'Typed in Blacklist Field' ) }>
@@ -405,7 +496,14 @@ class SiteSettingsFormDiscussion extends Component {
 	}
 
 	renderInputNumLinks() {
-		const { eventTracker, fields, isRequestingSettings, onChangeField, uniqueEventTracker } = this.props;
+		const {
+			eventTracker,
+			fields,
+			isRequestingSettings,
+			isSavingSettings,
+			onChangeField,
+			uniqueEventTracker
+		} = this.props;
 		return (
 			<FormTextInput
 				name="comment_max_links"
@@ -415,7 +513,7 @@ class SiteSettingsFormDiscussion extends Component {
 				className="small-text"
 				value={ 'undefined' === typeof fields.comment_max_links ? 2 : fields.comment_max_links }
 				onChange={ onChangeField( 'comment_max_links' ) }
-				disabled={ isRequestingSettings }
+				disabled={ isRequestingSettings || isSavingSettings }
 				onClick={ eventTracker( 'Clicked Comment Queue Link Count Field' ) }
 				onKeyPress={ uniqueEventTracker( 'Typed in Comment Queue Link Count Field' ) } />
 		);
@@ -442,18 +540,17 @@ class SiteSettingsFormDiscussion extends Component {
 		const {
 			fields,
 			handleSubmitForm,
-			handleToggle,
+			handleAutosavingToggle,
 			siteId,
 			isRequestingSettings,
 			isSavingSettings,
 			isJetpack,
-			isSubscriptionsModuleActive,
 			jetpackSettingsUISupported,
 			translate
 		} = this.props;
 		return (
 			<form id="site-settings" onSubmit={ handleSubmitForm }>
-				{ this.renderSectionHeader( translate( 'Default Article Settings' ) ) }
+				{ this.renderSectionHeader( translate( 'Default Article Settings' ), false ) }
 				<Card className="site-settings__discussion-settings">
 					{ this.defaultArticleSettings() }
 				</Card>
@@ -477,11 +574,11 @@ class SiteSettingsFormDiscussion extends Component {
 						<div>
 							<QueryJetpackModules siteId={ siteId } />
 
-							{ this.renderSectionHeader( translate( 'Subscriptions' ), isSubscriptionsModuleActive !== false ) }
+							{ this.renderSectionHeader( translate( 'Subscriptions' ), false ) }
 
 							<Subscriptions
 								onSubmitForm={ handleSubmitForm }
-								handleToggle={ handleToggle }
+								handleAutosavingToggle={ handleAutosavingToggle }
 								isSavingSettings={ isSavingSettings }
 								isRequestingSettings={ isRequestingSettings }
 								fields={ fields }

--- a/client/my-sites/site-settings/subscriptions/index.jsx
+++ b/client/my-sites/site-settings/subscriptions/index.jsx
@@ -24,7 +24,7 @@ import ExternalLink from 'components/external-link';
 
 const Subscriptions = ( {
 	fields,
-	handleToggle,
+	handleAutosavingToggle,
 	isRequestingSettings,
 	isSavingSettings,
 	moduleUnavailable,
@@ -58,7 +58,7 @@ const Subscriptions = ( {
 						<CompactFormToggle
 							checked={ !! fields.stb_enabled }
 							disabled={ isRequestingSettings || isSavingSettings || ! subscriptionsModuleActive || moduleUnavailable }
-							onChange={ handleToggle( 'stb_enabled' ) }
+							onChange={ handleAutosavingToggle( 'stb_enabled' ) }
 						>
 							{ translate( 'Show a "follow blog" option in the comment form' ) }
 						</CompactFormToggle>
@@ -66,7 +66,7 @@ const Subscriptions = ( {
 						<CompactFormToggle
 							checked={ !! fields.stc_enabled }
 							disabled={ isRequestingSettings || isSavingSettings || ! subscriptionsModuleActive || moduleUnavailable }
-							onChange={ handleToggle( 'stc_enabled' ) }
+							onChange={ handleAutosavingToggle( 'stc_enabled' ) }
 						>
 							{ translate( 'Show a "follow comments" option in the comment form.' ) }
 						</CompactFormToggle>
@@ -89,7 +89,7 @@ Subscriptions.defaultProps = {
 
 Subscriptions.propTypes = {
 	onSubmitForm: PropTypes.func.isRequired,
-	handleToggle: PropTypes.func.isRequired,
+	handleAutosavingToggle: PropTypes.func.isRequired,
 	isSavingSettings: PropTypes.bool,
 	isRequestingSettings: PropTypes.bool,
 	fields: PropTypes.object,


### PR DESCRIPTION
Part of #11676 

 This PR does the following:
* Makes the toggles int the **Discussion** tab, autosave on toggle.
* Removes the Save Settings button on two cards as every setting on these is autosaving on change.

<img src="https://cloud.githubusercontent.com/assets/746152/23748688/72653bac-04a3-11e7-9c42-319b880c422f.gif" height="400px" />

#### Testing instructions

1. Get to `/settings/discussion/site-slug` where `site-slug` is one of your connected Jetpack sites.
1. Toggle any of the children toggles.
2. Wait for the success notice to pop up.
3. Refresh the page and check that the setting value remains set as you left it before refreshing.


#### Why

While implementing a few toggles as part of #9171, we left some of them as regular toggles instead of autosaving ones as specified by the designs.
