### PR TITLE
Site Settings: Make the toggles in Related Posts Settings, autosave on toggle

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -515,7 +515,7 @@ class SiteSettingsFormGeneral extends Component {
 		const {
 			fields,
 			handleSubmitForm,
-			handleToggle,
+			handleAutosavingToggle,
 			isRequestingSettings,
 			isSavingSettings,
 			site,
@@ -605,7 +605,7 @@ class SiteSettingsFormGeneral extends Component {
 
 				<RelatedPosts
 					onSubmitForm={ handleSubmitForm }
-					handleToggle={ handleToggle }
+					handleAutosavingToggle={ handleAutosavingToggle }
 					isSavingSettings={ isSavingSettings }
 					isRequestingSettings={ isRequestingSettings }
 					fields={ fields }

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -8,7 +8,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Card from 'components/card';
-import Button from 'components/button';
 import FormFieldset from 'components/forms/form-fieldset';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import SectionHeader from 'components/section-header';
@@ -16,34 +15,20 @@ import RelatedContentPreview from './related-content-preview';
 
 const RelatedPosts = ( {
 	fields,
-	handleToggle,
+	handleAutosavingToggle,
 	isRequestingSettings,
-	isSavingSettings,
-	onSubmitForm,
 	translate
 } ) => {
 	return (
 		<div>
-			<SectionHeader label={ translate( 'Related Posts' ) }>
-				<Button
-					compact={ true }
-					onClick={ onSubmitForm }
-					primary={ true }
-					type="submit"
-					disabled={ isRequestingSettings || isSavingSettings }>
-						{ isSavingSettings
-							? translate( 'Saving…' )
-							: translate( 'Save Settings' )
-						}
-				</Button>
-			</SectionHeader>
+			<SectionHeader label={ translate( 'Related Posts' ) } />
 
 			<Card className="related-posts__card site-settings">
 				<FormFieldset>
 					<CompactFormToggle
 						checked={ !! fields.jetpack_relatedposts_enabled }
 						disabled={ isRequestingSettings }
-						onChange={ handleToggle( 'jetpack_relatedposts_enabled' ) }
+						onChange={ handleAutosavingToggle( 'jetpack_relatedposts_enabled' ) }
 					>
 						{ translate( 'Show related content after posts' ) }
 					</CompactFormToggle>
@@ -52,7 +37,7 @@ const RelatedPosts = ( {
 						<CompactFormToggle
 							checked={ !! fields.jetpack_relatedposts_show_headline }
 							disabled={ isRequestingSettings || ! fields.jetpack_relatedposts_enabled }
-							onChange={ handleToggle( 'jetpack_relatedposts_show_headline' ) }
+							onChange={ handleAutosavingToggle( 'jetpack_relatedposts_show_headline' ) }
 						>
 							{ translate(
 								'Show a "Related" header to more clearly separate the related section from posts'
@@ -62,7 +47,7 @@ const RelatedPosts = ( {
 						<CompactFormToggle
 							checked={ !! fields.jetpack_relatedposts_show_thumbnails }
 							disabled={ isRequestingSettings || ! fields.jetpack_relatedposts_enabled }
-							onChange={ handleToggle( 'jetpack_relatedposts_show_thumbnails' ) }
+							onChange={ handleAutosavingToggle( 'jetpack_relatedposts_show_thumbnails' ) }
 						>
 							{ translate(
 								'Use a large and visually striking layout'
@@ -88,7 +73,7 @@ RelatedPosts.defaultProps = {
 
 RelatedPosts.propTypes = {
 	onSubmitForm: PropTypes.func.isRequired,
-	handleToggle: PropTypes.func.isRequired,
+	handleAutosavingToggle: PropTypes.func.isRequired,
 	isSavingSettings: PropTypes.bool,
 	isRequestingSettings: PropTypes.bool,
 	fields: PropTypes.object,

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -17,6 +17,7 @@ const RelatedPosts = ( {
 	fields,
 	handleAutosavingToggle,
 	isRequestingSettings,
+	isSavingSettings,
 	translate
 } ) => {
 	return (
@@ -27,7 +28,7 @@ const RelatedPosts = ( {
 				<FormFieldset>
 					<CompactFormToggle
 						checked={ !! fields.jetpack_relatedposts_enabled }
-						disabled={ isRequestingSettings }
+						disabled={ isRequestingSettings || isSavingSettings }
 						onChange={ handleAutosavingToggle( 'jetpack_relatedposts_enabled' ) }
 					>
 						{ translate( 'Show related content after posts' ) }
@@ -36,7 +37,7 @@ const RelatedPosts = ( {
 					<div className="related-posts__module-settings site-settings__child-settings">
 						<CompactFormToggle
 							checked={ !! fields.jetpack_relatedposts_show_headline }
-							disabled={ isRequestingSettings || ! fields.jetpack_relatedposts_enabled }
+							disabled={ isRequestingSettings || isSavingSettings || ! fields.jetpack_relatedposts_enabled }
 							onChange={ handleAutosavingToggle( 'jetpack_relatedposts_show_headline' ) }
 						>
 							{ translate(
@@ -46,7 +47,7 @@ const RelatedPosts = ( {
 
 						<CompactFormToggle
 							checked={ !! fields.jetpack_relatedposts_show_thumbnails }
-							disabled={ isRequestingSettings || ! fields.jetpack_relatedposts_enabled }
+							disabled={ isRequestingSettings || isSavingSettings || ! fields.jetpack_relatedposts_enabled }
 							onChange={ handleAutosavingToggle( 'jetpack_relatedposts_show_thumbnails' ) }
 						>
 							{ translate(


### PR DESCRIPTION
Part of #11676 

 This PR does the following:
* Makes the toggles in the **Related Posts** tab, autosave on toggle.
* Removes the Save Settings button as every setting on the card is autosaving on change.

<img src="https://cloud.githubusercontent.com/assets/746152/23959450/fe98cf96-0983-11e7-8964-14d8e7f7e970.gif" height="400px" />


#### Testing instructions

1. Get to `/settings/general/site-slug` where `site-slug` is one of your connected Jetpack sites.
1. Get to the **Related Posts** card
1. Toggle any of the children toggles.
2. Wait for the success notice to pop up.
3. Refresh the page and check that the setting value remains set as you left it before refreshing.


#### Why

While implementing a few toggles as part of #9171, we left some of them as regular toggles instead of autosaving ones as specified by the designs.
