### PR TITLE
Fix choosing a domain mapping on signup

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -115,7 +115,7 @@ var DomainSearchResults = React.createClass( {
 
 	handleAddMapping: function( event ) {
 		event.preventDefault();
-		this.props.onAddMapping( { domain_name: this.props.lastDomainSearched } );
+		this.props.onAddMapping( this.props.lastDomainSearched );
 	},
 
 	renderPlaceholders: function() {

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -172,7 +172,7 @@ const MapDomainStep = React.createClass( {
 			switch ( status ) {
 				case domainAvailability.MAPPABLE:
 				case domainAvailability.UNKNOWN:
-					this.props.onMapDomain( { domain_name: domain } );
+					this.props.onMapDomain( domain );
 					return;
 
 				case domainAvailability.AVAILABLE:

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -172,7 +172,7 @@ const MapDomainStep = React.createClass( {
 			switch ( status ) {
 				case domainAvailability.MAPPABLE:
 				case domainAvailability.UNKNOWN:
-					this.props.onMapDomain( domain );
+					this.props.onMapDomain( { domain_name: domain } );
 					return;
 
 				case domainAvailability.AVAILABLE:

--- a/client/my-sites/upgrades/domain-search/domain-search.jsx
+++ b/client/my-sites/upgrades/domain-search/domain-search.jsx
@@ -77,8 +77,8 @@ var DomainSearch = React.createClass( {
 		}
 	},
 
-	handleAddMapping( suggestion ) {
-		upgradesActions.addItem( cartItems.domainMapping( { domain: suggestion.domain_name } ) );
+	handleAddMapping( domain ) {
+		upgradesActions.addItem( cartItems.domainMapping( { domain } ) );
 		page( '/checkout/' + this.props.sites.getSelectedSite().slug );
 	},
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -146,7 +146,7 @@ const DomainsStep = React.createClass( {
 	},
 
 	handleAddMapping: function( sectionName, domain, state ) {
-		const domainItem = cartItems.domainMapping( { domain: domain.domain_name } );
+		const domainItem = cartItems.domainMapping( { domain } );
 		const isPurchasingItem = true;
 
 		mapDomainAnalytics.recordEvent( 'addDomainButtonClick', domain.domain_name, 'signup' );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -149,7 +149,7 @@ const DomainsStep = React.createClass( {
 		const domainItem = cartItems.domainMapping( { domain } );
 		const isPurchasingItem = true;
 
-		mapDomainAnalytics.recordEvent( 'addDomainButtonClick', domain.domain_name, 'signup' );
+		mapDomainAnalytics.recordEvent( 'addDomainButtonClick', domain, 'signup' );
 
 		SignupActions.submitSignupStep( Object.assign( {
 			processingMessage: this.translate( 'Adding your domain mapping' ),
@@ -157,7 +157,7 @@ const DomainsStep = React.createClass( {
 			[ sectionName ]: state,
 			domainItem,
 			isPurchasingItem,
-			siteUrl: domain.domain_name,
+			siteUrl: domain,
 			stepSectionName: this.props.stepSectionName
 		}, this.getThemeArgs() ) );
 


### PR DESCRIPTION
Fixes #11937 

This fixes the domain mapping step on signup

### Testing Instructions
- Load this branch locally (or use the calypso.live link in matticbot comment)
- (either logged or logged out) Go to `/start/website` and at the domain step choose "Already own a domain". Enter a domain name and verify that you can finish the flow
- On an existing site, go to `http://calypso.localhost:3000/domains/add/:site_slug` and assert that the "Already own a domain" link works. Enter an existing domain name and assert that the "Map it" link works

### Reviews
- [x] Code
- [x] Product
