### PR TITLE
Media: change primary classname

### DIFF
--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -18,6 +18,7 @@ import MediaUtils from 'lib/media/utils';
 import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
 import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
 import accept from 'lib/accept';
+import Main from 'components/main';
 
 export default React.createClass( {
 	displayName: 'Media',
@@ -209,53 +210,54 @@ export default React.createClass( {
 	render: function() {
 		const site = this.props.sites.getSelectedSite();
 		return (
-			<div ref="container" className="main main-column media" role="main">
-				<SidebarNavigation />
-				{ ( this.state.editedItem !== null || this.state.currentDetail !== null ) &&
-					<Dialog
-						isVisible={ true }
-						additionalClassNames="editor-media-modal media__item-dialog"
-						buttons={ this.getModalButtons() }
-						onClose={ this.closeDetailsModal }
-					>
-					{ this.state.currentDetail !== null &&
-						<EditorMediaModalDetail
-							site={ site }
-							items={ this.state.selectedImages }
-							selectedIndex={ this.state.currentDetail }
-							onReturnToList={ this.closeDetailsModal }
-							onEditItem={ this.editImage }
-							onRestoreItem={ this.restoreOriginalMedia }
-							onSelectedIndexChange={ this.setDetailSelectedIndex }
-						/>
+			<Main className="media main-column">
+				<div ref="container">
+					<SidebarNavigation />
+					{ ( this.state.editedItem !== null || this.state.currentDetail !== null ) &&
+						<Dialog
+							isVisible={ true }
+							additionalClassNames="editor-media-modal media__item-dialog"
+							buttons={ this.getModalButtons() }
+							onClose={ this.closeDetailsModal }
+						>
+						{ this.state.currentDetail !== null &&
+							<EditorMediaModalDetail
+								site={ site }
+								items={ this.state.selectedImages }
+								selectedIndex={ this.state.currentDetail }
+								onReturnToList={ this.closeDetailsModal }
+								onEditItem={ this.editImage }
+								onRestoreItem={ this.restoreOriginalMedia }
+								onSelectedIndexChange={ this.setDetailSelectedIndex }
+							/>
+						}
+						{ this.state.editedItem !== null &&
+							<ImageEditor
+								siteId={ site && site.ID }
+								media={ this.state.selectedImages[ this.state.editedItem ] }
+								onDone={ this.onImageEditorDone }
+								onCancel={ this.onImageEditorCancel }
+							/>
+						}
+						</Dialog>
 					}
-					{ this.state.editedItem !== null &&
-						<ImageEditor
-							siteId={ site && site.ID }
-							media={ this.state.selectedImages[ this.state.editedItem ] }
-							onDone={ this.onImageEditorDone }
-							onCancel={ this.onImageEditorCancel }
-						/>
-					}
-					</Dialog>
-				}
-				{ site && site.ID && (
-					<MediaLibrarySelectedData siteId={ site.ID }>
-						<MediaLibrary
-							{ ...this.props }
-							className="media__main-section"
-							onFilterChange={ this.onFilterChange }
-							site={ site }
-							single={ false }
-							filter={ this.props.filter }
-							onEditItem={ this.openDetailsModalForASingleImage }
-							onViewDetails={ this.openDetailsModalForAllSelected }
-							onDeleteItem={ this.handleDeleteMediaEvent }
-							modal={ false }
-							containerWidth={ this.state.containerWidth } />
-					</MediaLibrarySelectedData>
-				) }
-			</div>
+					{ site && site.ID && (
+						<MediaLibrarySelectedData siteId={ site.ID }>
+							<MediaLibrary
+								{ ...this.props }
+								onFilterChange={ this.onFilterChange }
+								site={ site }
+								single={ false }
+								filter={ this.props.filter }
+								onEditItem={ this.openDetailsModalForASingleImage }
+								onViewDetails={ this.openDetailsModalForAllSelected }
+								onDeleteItem={ this.handleDeleteMediaEvent }
+								modal={ false }
+								containerWidth={ this.state.containerWidth } />
+						</MediaLibrarySelectedData>
+					) }
+				</div>
+			</Main>
 		);
 	}
 } );

--- a/client/my-sites/media/style.scss
+++ b/client/my-sites/media/style.scss
@@ -29,7 +29,7 @@
 	}
 }
 
-.media__main-section .media-library__header.media-library__upload-url {
+.media .media-library__header.media-library__upload-url {
 	padding: 6px 12px;
 	background-color: $white;
 	box-sizing: border-box;


### PR DESCRIPTION
To be consistent with posts page, which its main className is `posts_primary, let's rename the main className to `media__primary`.

<img src="https://cloud.githubusercontent.com/assets/77539/23752480/38f31d60-04b4-11e7-8800-646f6c452993.png" width="400px" />

### Testing

Take a look to the main className of the media section. 

<img src="https://cloud.githubusercontent.com/assets/77539/23752575/acdbd6c2-04b4-11e7-98d8-3fc568b80937.png" width="400px" />

The only one style which uses this class, afaik, is the uploading-by-URL block.

<img src="https://cloud.githubusercontent.com/assets/77539/23752611/ca6e42ce-04b4-11e7-9e5c-d3174baef007.png" width="500px" />

<img src="https://cloud.githubusercontent.com/assets/77539/23752635/e8eb5750-04b4-11e7-85a7-c6f7b88ef245.png" width="500px" />


