### PR TITLE
Site Picker: Update background color on disabled search input

### DIFF
--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -109,6 +109,10 @@
 		-webkit-appearance: none;
 	}
 
+	&:disabled {
+		background: $white;
+	}
+
 	&:focus {
 		box-shadow: none;
 		border: none;


### PR DESCRIPTION
We have some shared form styling under [`assets/stylesheets/shared/_forms.scss`](https://github.com/Automattic/wp-calypso/blob/master/assets/stylesheets/shared/_forms.scss) that impacts how form fields appear when disabled giving them `background: $gray-light;`. This was giving a weird shading to search inputs on loading states. This updates the background to `$white`.

## To test
1. Clear your cache or load this branch in an incognito window.
2. Visit a page that requires the site selector to load giving you a loading state like http://calypso.localhost:3000/stats/insights/ or http://calypso.localhost:3000/post.

**Before**
<img width="509" alt="screen shot 2017-03-09 at 7 05 28 am" src="https://cloud.githubusercontent.com/assets/7240478/23753454/cca344fe-0496-11e7-92fb-f67561dd5e38.png">

**After**
<img width="505" alt="screen shot 2017-03-09 at 6 57 17 am" src="https://cloud.githubusercontent.com/assets/7240478/23753458/d17e6404-0496-11e7-847b-6dea09b74d73.png">


Resolves: #10197