### PR TITLE
Replace Button with Button 2 in signup

### DIFF
--- a/client/lib/signup/themes-data.js
+++ b/client/lib/signup/themes-data.js
@@ -28,11 +28,11 @@ export const themes = [
 	},
 	{
 		name: 'Button',
-		slug: 'button',
+		slug: 'button-2',
 		repo: 'pub',
 		fallback: false,
 		design: 'blog',
-		demo_uri: 'https://buttondemo.wordpress.com',
+		demo_uri: 'https://button2demo.wordpress.com',
 		verticals: []
 	},
 	{


### PR DESCRIPTION
For testing:

* Switch to this PR 
* Go to calypso.local:3000(?)/start/ 
* Click “A list of your latest posts“ 
* Make sure Button 2 shows up instead of Button
