### PR TITLE
Refactor theme install action.

### DIFF
--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -492,7 +492,7 @@ export function installTheme( themeId, siteId ) {
 						themeId.replace( '-wpcom', '' )
 					);
 					if ( parentThemeId ) {
-						dispatch( installTheme( parentThemeId + '-wpcom', siteId ) );
+						return dispatch( installTheme( parentThemeId + '-wpcom', siteId ) );
 					}
 				}
 			} )

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -484,8 +484,8 @@ export function installTheme( themeId, siteId ) {
 					siteId,
 					themeId
 				} );
-			} )
-			.then( () => {
+
+				// Install parent theme if theme requires one
 				if ( endsWith( themeId, '-wpcom' ) ) {
 					const parentThemeId = getWpcomParentThemeId(
 						getState(),


### PR DESCRIPTION
### Info

Installing a theme that had a parent theme required also installation of that parent theme.
Code for that was working but was using promises in non optimal way.

### Testing
Verify that on Jetpack site themes that have parent themes still install successfully.
Example themes with parents Goran( Edin ) or Sidekick( Superhero ) 