### PR TITLE
ReaderAvatar: show feed icon where available

### DIFF
--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -28,12 +28,12 @@ const ReaderAvatar = ( { author, siteIcon, feedIcon, siteUrl, siteIconSize = 96,
 		};
 	}
 
-	let hasSiteIcon = !! siteIcon;
+	let hasSiteIcon = !! ( fakeSite && fakeSite.icon );
 	let hasAvatar = !! ( author && author.has_avatar );
 
 	if ( hasSiteIcon && hasAvatar ) {
 		// Do these both reference the same image? Disregard query string params.
-		const [ withoutQuery, ] = siteIcon.split( '?' );
+		const [ withoutQuery, ] = fakeSite.icon.img.split( '?' );
 		if ( startsWith( author.avatar_URL, withoutQuery ) ) {
 			hasAvatar = false;
 		}
@@ -56,8 +56,8 @@ const ReaderAvatar = ( { author, siteIcon, feedIcon, siteUrl, siteIconSize = 96,
 	);
 
 	const siteIconElement = hasSiteIcon && <SiteIcon key="site-icon" size={ siteIconSize } site={ fakeSite } />;
-	const feedIconElement = ( hasAvatar || showPlaceholder ) && <Gravatar key="feed-icon" user={ author } size={ hasBothIcons ? 32 : 96 } />;
-	const iconElements = [ siteIconElement, feedIconElement ];
+	const avatarElement = ( hasAvatar || showPlaceholder ) && <Gravatar key="author-avatar" user={ author } size={ hasBothIcons ? 32 : 96 } />;
+	const iconElements = [ siteIconElement, avatarElement ];
 
 	return (
 		<div className={ classes }>

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -69,7 +69,8 @@ class PostByline extends React.Component {
 					feedIcon={ feedIcon }
 					author={ post.author }
 					preferGravatar={ true }
-					siteUrl={ streamUrl } />
+					siteUrl={ streamUrl }
+					siteIconSize={ 32 } />
 				<div className="reader-post-card__byline-details">
 					<div className="reader-post-card__byline-author-site">
 						{ shouldDisplayAuthor &&


### PR DESCRIPTION
The current logic in the `ReaderAvatar` block means that a feed icon is not displayed where provided.

This PR displays a feed icon the same way as a site icon.

Before:

<img width="214" alt="screen shot 2017-03-09 at 17 25 00" src="https://cloud.githubusercontent.com/assets/17325/23762349/9fa758d0-04ed-11e7-8f89-89431587b3b4.png">

After:

<img width="174" alt="screen shot 2017-03-09 at 17 26 45" src="https://cloud.githubusercontent.com/assets/17325/23762361/a4ee015e-04ed-11e7-834b-df6738a09886.png">

Component in devdocs: http://calypso.localhost:3000/devdocs/blocks/reader-avatar

