### PR TITLE
Directly: Open to Horizon environment

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -22,6 +22,7 @@
 		"happychat": false,
 		"help": true,
 		"help/courses": true,
+		"help/directly": true,
 		"jetpack/api-cache": true,
 		"jetpack/google-analytics": true,
 		"jetpack_core_inline_update": true,


### PR DESCRIPTION
This allows us to sanity check the Production Directly environment ahead of Monday's launch.