### PR TITLE
Directly: Add Analytics (take 3)

### DIFF
--- a/client/lib/directly/index.js
+++ b/client/lib/directly/index.js
@@ -9,6 +9,7 @@
  * External dependencies
  */
 import config from 'config';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -101,7 +102,9 @@ export function initialize() {
 
 		loadScript( DIRECTLY_RTM_SCRIPT_URL, function( error ) {
 			if ( error ) {
-				reject( error );
+				reject( new Error(
+					i18n.translate( 'Failed to load script "%(src)s".', { args: { src: error.src } } )
+				) );
 			} else {
 				resolve();
 			}

--- a/client/lib/directly/index.js
+++ b/client/lib/directly/index.js
@@ -9,7 +9,6 @@
  * External dependencies
  */
 import config from 'config';
-import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -102,12 +101,9 @@ export function initialize() {
 
 		loadScript( DIRECTLY_RTM_SCRIPT_URL, function( error ) {
 			if ( error ) {
-				reject( new Error(
-					i18n.translate( 'Failed to load script "%(src)s".', { args: { src: error.src } } )
-				) );
-			} else {
-				resolve();
+				return reject( new Error( `Failed to load script "${ error.src }".` ) );
 			}
+			resolve();
 		} );
 	} );
 

--- a/client/lib/directly/test/index.js
+++ b/client/lib/directly/test/index.js
@@ -63,14 +63,14 @@ describe( 'index', () => {
 		} );
 
 		it( 'rejects the returned promise if the library load fails', ( done ) => {
-			const error = { oh: 'no' };
-			directly.initialize().then(
-				() => {},
-				( e ) => {
-					expect( e ).to.equal( error );
-					done();
-				}
-			);
+			const error = { src: 'http://url.to/directly/embed.js' };
+			directly.initialize()
+				.catch( ( e ) => {
+					expect( e ).to.be.an.instanceof( Error );
+					expect( e.toString() ).to.contain( error.src );
+				} )
+				.then( () => done() );
+
 			loadScript.loadScript.firstCall.args[ 1 ]( error );
 		} );
 	} );

--- a/client/state/data-layer/third-party/directly/index.js
+++ b/client/state/data-layer/third-party/directly/index.js
@@ -2,6 +2,10 @@
  * Internal dependencies
  */
 import {
+	recordTracksEvent,
+	withAnalytics,
+} from 'state/analytics/actions';
+import {
 	DIRECTLY_ASK_QUESTION,
 	DIRECTLY_INITIALIZATION_START,
 } from 'state/action-types';
@@ -11,17 +15,28 @@ import {
 } from 'state/help/directly/actions';
 import * as directly from 'lib/directly';
 
-export function askQuestion( store, action, next ) {
+export function askQuestion( { dispatch }, action, next ) {
+	dispatch( recordTracksEvent( 'calypso_directly_ask_question' ) );
 	directly.askQuestion( action.questionText, action.name, action.email );
 	next( action );
 }
 
-export function initialize( { dispatch }, action, next ) {
+export function initialize( { dispatch, getState }, action, next ) {
 	next( action );
 
+	dispatch( recordTracksEvent( 'calypso_directly_initialization_start' ) );
+
 	return directly.initialize()
-		.then( () => dispatch( initializationCompleted() ) )
-		.catch( () => dispatch( initializationFailed() ) );
+		.then( () => dispatch( withAnalytics(
+			recordTracksEvent( 'calypso_directly_initialization_success' ),
+			initializationCompleted()
+		) ) )
+		.catch( ( error ) => dispatch( withAnalytics(
+			recordTracksEvent( 'calypso_directly_initialization_error', {
+				error: ( error ? error.toString() : 'Unknown error' )
+			} ),
+			initializationFailed()
+		) ) );
 }
 
 export default {

--- a/client/state/data-layer/third-party/directly/index.js
+++ b/client/state/data-layer/third-party/directly/index.js
@@ -16,9 +16,10 @@ import {
 import * as directly from 'lib/directly';
 
 export function askQuestion( { dispatch }, action, next ) {
-	dispatch( recordTracksEvent( 'calypso_directly_ask_question' ) );
-	directly.askQuestion( action.questionText, action.name, action.email );
 	next( action );
+
+	return directly.askQuestion( action.questionText, action.name, action.email )
+		.then( () => dispatch( recordTracksEvent( 'calypso_directly_ask_question' ) ) );
 }
 
 export function initialize( { dispatch, getState }, action, next ) {

--- a/client/state/data-layer/third-party/directly/test/index.js
+++ b/client/state/data-layer/third-party/directly/test/index.js
@@ -55,6 +55,10 @@ describe( 'Directly data layer', () => {
 		const email = 'hammie@royalfamily.dk';
 		const action = { type: DIRECTLY_ASK_QUESTION, questionText, name, email };
 
+		beforeEach( () => {
+			directly.askQuestion.returns( Promise.resolve() );
+		} );
+
 		it( 'should invoke the corresponding Directly function', () => {
 			askQuestion( store, action, next );
 			expect( directly.askQuestion ).to.have.been.calledWith( questionText, name, email );
@@ -65,10 +69,10 @@ describe( 'Directly data layer', () => {
 			expect( next ).to.have.been.calledWith( action );
 		} );
 
-		it( 'should dispatch an analytics event', () => {
-			askQuestion( store, action, next );
-			expect( analytics.recordTracksEvent ).to.have.been.calledWith( 'calypso_directly_ask_question' );
-		} );
+		it( 'should dispatch an analytics event', () => (
+			askQuestion( store, action, next )
+				.then( () => expect( analytics.recordTracksEvent ).to.have.been.calledWith( 'calypso_directly_ask_question' ) )
+		) );
 	} );
 
 	describe( '#initialize', () => {


### PR DESCRIPTION
This is the third take — previously analytics were in the `lib` layer (https://github.com/Automattic/wp-calypso/pull/11751) then the component layer (https://github.com/Automattic/wp-calypso/pull/11908) and now the `data-layer`.

This approach is likely the most future-proof. It tracks Directly at the source of our components-library connection.

### To test

Sign in as a user with no paid upgrades (these are the only users who interact with Directly). Open the browser console and enable Tracks debug messages with:

```
localStorage.setItem('debug', 'calypso:analytics:tracks');
```

Navigate to http://calypso.localhost:3000/help/contact and watch the console. You should see debug messages for `calypso_directly_initialization_start` and then `calypso_directly_initialization_success` come through.

Fill the form with a question and press "Ask an Expert". You should see debug messages for `calypso_directly_ask_question`.

Edit [the URL to the Directly library](https://github.com/Automattic/wp-calypso/blob/master/client/lib/directly/index.js#L18) to something bogus to trigger an error and refresh the page. You should see debug messages for `calypso_directly_initialization_start` and then `calypso_directly_initialization_error` come through. The error debug should also have an object with an `error` param explaining the error.
