### PR TITLE
Reader: Pull feeds from sites and sites from feeds in FPA

### DIFF
--- a/client/lib/reader-post-flux-adapter/index.js
+++ b/client/lib/reader-post-flux-adapter/index.js
@@ -69,14 +69,20 @@ const fluxPostAdapter = Component => {
 	return connect(
 		( state, ownProps ) => {
 			const { feedId, blogId } = ownProps.postKey;
-			const feed = feedId && getFeed( state, feedId );
-			const site = blogId && getSite( state, blogId );
+			let feed, site;
+			if ( feedId ) {
+				feed = getFeed( state, feedId );
+				site = feed && feed.blog_ID ? getSite( state, feed.blog_ID ) : undefined;
+			} else {
+				site = getSite( state, blogId );
+				feed = site && site.feed_ID ? getFeed( state, site.feed_ID ) : undefined;
+			}
 			return {
 				feed,
 				site
 			};
 		}
 	)( ReaderPostFluxAdapter );
-}
+};
 
 export default fluxPostAdapter;


### PR DESCRIPTION
If the postKey is a site, pull the feed object from the site object. Opposite for postKeys that are feeds.