### PR TITLE
Reader: Update the FPA less frequently

### DIFF
--- a/client/lib/reader-post-flux-adapter/index.js
+++ b/client/lib/reader-post-flux-adapter/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
-import { map } from 'lodash';
+import { every, map } from 'lodash';
 import { connect } from 'react-redux';
 
 /*
@@ -42,6 +42,16 @@ const fluxPostAdapter = Component => {
 		state = this.getStateFromStores( this.props );
 
 		updateState = ( newState = this.getStateFromStores() ) => {
+			// check to see if this new state is the same as the old state
+			if ( newState.posts.length === this.state.posts.length ) {
+				// same length, so they might be.
+				// check to see if the individual posts are equal
+				// since feed-post-store uses immutable posts, this is safe (and fast)
+				const current = this.state.posts;
+				if ( every( newState.posts, ( post, index ) => post === current[ index ] ) ) {
+					return;
+				}
+			}
 			this.setState( newState );
 		}
 


### PR DESCRIPTION
Prior to this PR, the Flux Post Adapter, which the new combined cards use, would update state every time the post store emitted a change event. This would then schedule a render reconciliation, which often did nothing.

This PR teaches the FPA to only setState and schedule a reconciliation when the state it's holding actually changes. Most updates that flow through the post store are for posts not contained within each FPA, so this saves a number of reconciliations for each FPA using component.