### PR TITLE
Directly: Fix askQuestion bug

### DIFF
--- a/client/lib/directly/index.js
+++ b/client/lib/directly/index.js
@@ -126,7 +126,8 @@ export function askQuestion( questionText, name, email ) {
 	//
 	// As of the time of this comment Directly is still investigating this issue, which
 	// appears to be on their end. Their suggested stopgap is to "nagivate" out of the
-	// active chat before the "askQuestion" fires, hence the solution here:
+	// active chat before the "askQuestion" fires, hence the solution here. Note that
+	// "navigate" is an undocumented API, so you won't see it in the config guide.
 	return execute( 'navigate', '/ask' )
 		.then( () => execute( 'askQuestion', { questionText, name, email } ) );
 }

--- a/client/lib/directly/index.js
+++ b/client/lib/directly/index.js
@@ -120,5 +120,13 @@ export function initialize() {
  * @returns {Promise} Promise that resolves after initialization completes
  */
 export function askQuestion( questionText, name, email ) {
-	return execute( 'askQuestion', { questionText, name, email } );
+	// There's a bug that happens when you "askQuestion" and the widget is showing the minimized
+	// bubble with an expert avatar in it (indicating an active chat session). In this case,
+	// the widget throws errors and becomes unusable.
+	//
+	// As of the time of this comment Directly is still investigating this issue, which
+	// appears to be on their end. Their suggested stopgap is to "nagivate" out of the
+	// active chat before the "askQuestion" fires, hence the solution here:
+	return execute( 'navigate', '/ask' )
+		.then( () => execute( 'askQuestion', { questionText, name, email } ) );
 }


### PR DESCRIPTION
Fixes a bug from Directly's widget code. This has been reproduced in a reduced test case completely outside Calypso to rule out the possibility that it's our own integration code. This PR implements the stopgap fix from Directly while their team investigates and fixes the core issue.

### To reproduce the bug

- Open `master` branch and sign in as a user with no paid upgrades
- Go to http://calypso.localhost:3000/help/contact and you should see the Directly contact form with the submit button "Ask an Expert"
- Ask a question in the form and submit it
- A Directly widget will open up with your question
- Leave the widget open and ask @mattwondra to provide a response through the Directly interface
- Once your question has a response, minimize the widget. You should see it as a circle with the answerer's avatar.
- Fill another question into the form and submit it.
- Instead of opening with your question, the widget will expand still showing a stretched avatar and there will be an error in the JS console.

Here's a GIF showing the bug being triggered: https://cloudup.com/i-isD8E9E5Z

### To test

- Open `fix/directly-ask-question-bug` branch
- Refresh the page at http://calypso.localhost:3000/help/contact
- The Directly widget should appear instantly. Using the widget's Hamburger Menu, find and select the conversation with an answer.
- Minimize the widget. You should see it as a circle with the answerer's avatar.
- Fill another question into the form and submit it.
- The widget should open up successfully and populate your new question.