### PR TITLE
Importer: Update number format showing loading resource count

### DIFF
--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -4,8 +4,8 @@
 import React, { PropTypes } from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
 import classNames from 'classnames';
-import has from 'lodash/has';
-import omit from 'lodash/omit';
+import { numberFormat, translate } from 'i18n-calypso';
+import { has, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -107,14 +107,14 @@ export const ImportingPane = React.createClass( {
 
 	getErrorMessage( { description } ) {
 		if ( ! description ) {
-			return this.translate( 'An unspecified error occured during the import.' );
+			return translate( 'An unspecified error occured during the import.' );
 		}
 
 		return description;
 	},
 
 	getHeadingText: function() {
-		return this.translate(
+		return translate(
 			'Importing takes 15 minutes or a while longer if your site has a lot of media. ' +
 			'You can safely navigate away from this page if you need to: we\'ll send you a notification when it\'s done.'
 		);
@@ -123,9 +123,9 @@ export const ImportingPane = React.createClass( {
 	getSuccessText: function() {
 		const { site: { slug }, progress: { page, post } } = this.props.importerStatus,
 			pageLink = <a href={ '/pages/' + slug } />,
-			pageText = this.translate( 'Pages', { context: 'noun' } ),
+			pageText = translate( 'Pages', { context: 'noun' } ),
 			postLink = <a href={ '/posts/' + slug } />,
-			postText = this.translate( 'Posts', { context: 'noun' } );
+			postText = translate( 'Posts', { context: 'noun' } );
 
 		const pageCount = page.total;
 		const postCount = post.total;
@@ -152,20 +152,20 @@ export const ImportingPane = React.createClass( {
 			);
 		}
 
-		return this.translate( 'Import complete!' );
+		return translate( 'Import complete!' );
 	},
 
 	getImportMessage( numResources ) {
 		if ( 0 === numResources ) {
-			return this.translate( 'Finishing up the import' );
+			return translate( 'Finishing up the import' );
 		}
 
-		return this.translate(
-			'Waiting on %(numResources)d resource to import',
-			'Waiting on %(numResources)d resources to import',
+		return translate(
+			'Waiting on %(numResources)s resource to import',
+			'Waiting on %(numResources)s resources to import',
 			{
 				count: numResources,
-				args: { numResources }
+				args: { numResources: numberFormat( numResources ) }
 			}
 		);
 	},
@@ -235,7 +235,7 @@ export const ImportingPane = React.createClass( {
 						onStartImport={ () => startImporting( this.props.importerStatus ) }
 						{ ...{ siteId } }
 						sourceAuthors={ customData.sourceAuthors }
-						sourceTitle={ customData.siteTitle || this.translate( 'Original Site' ) }
+						sourceTitle={ customData.siteTitle || translate( 'Original Site' ) }
 						targetTitle={ siteName }
 					/>
 				}


### PR DESCRIPTION
Previously the number of importing resources was printed without any
formatting such as commas or decimal points.

Now we're using `i18n.numberFormat` to provide that formatting.

**Testing**

Import something and see what the numbers look like when it says, "Waiting on X resources…"
Test in another language.

@vindl this might introduce some simple merge conflicts with your work. If so, please feel free to manually incorporate this PR into yours or handle it however you best see fit.