### PR TITLE
Site Settings: Update texts in toggle descriptions and InfoPopover content in Media Settings card

### DIFF
--- a/client/my-sites/site-settings/media-settings/index.jsx
+++ b/client/my-sites/site-settings/media-settings/index.jsx
@@ -47,7 +47,7 @@ const MediaSettings = ( {
 				<div className="media-settings__info-link-container site-settings__info-link-container">
 					<InfoPopover position={ 'left' }>
 						<ExternalLink target="_blank" icon={ true } href={ 'https://jetpack.com/support/photon' } >
-							{ translate( 'Learn more about Photon' ) }
+							{ translate( 'Learn more about Photon.' ) }
 						</ExternalLink>
 					</InfoPopover>
 				</div>
@@ -55,7 +55,7 @@ const MediaSettings = ( {
 					siteId={ siteId }
 					moduleSlug="photon"
 					label={ translate( 'Speed up your images and photos with Photon' ) }
-					description={ translate( 'Enabling Photon is required to use Tiled Galleries' ) }
+					description={ translate( 'Enabling Photon is required to use Tiled Galleries.' ) }
 					disabled={ isRequestingSettings || isSavingSettings || photonModuleUnavailable }
 					/>
 			</FormFieldset>
@@ -63,7 +63,7 @@ const MediaSettings = ( {
 				<div className="media-settings__info-link-container site-settings__info-link-container">
 					<InfoPopover position={ 'left' }>
 						<ExternalLink target="_blank" icon={ true } href={ 'https://jetpack.com/support/carousel' } >
-							{ translate( 'Learn more about Carousel' ) }
+							{ translate( 'Learn more about Carousel.' ) }
 						</ExternalLink>
 					</InfoPopover>
 				</div>

--- a/client/my-sites/site-settings/media-settings/index.jsx
+++ b/client/my-sites/site-settings/media-settings/index.jsx
@@ -55,7 +55,7 @@ const MediaSettings = ( {
 					siteId={ siteId }
 					moduleSlug="photon"
 					label={ translate( 'Speed up your images and photos with Photon' ) }
-					description={ translate( 'Enabling Photon is required to use Tiled Galleries.' ) }
+					description={ translate( 'Must be enabled to use tiled galleries.' ) }
 					disabled={ isRequestingSettings || isSavingSettings || photonModuleUnavailable }
 					/>
 			</FormFieldset>


### PR DESCRIPTION
* This PR updates some texts in the Media Setting Card for Jetpack Sites.
* It also updates the description text for the Photon toggle from `Enabling Photon is required to use Tiled Galleries` to `Must be enabled to use tiled galleries.`

PR #11906 removed some periods from toggle labels and descriptions. The latter was not desired. 


#### Testing instructions

1. Check the [Writing Settings page in the live branch](https://calypso.live/settings/writing?branch=fix/media-settings-card-labels) for one of your Jetpack sites
1. Get to the Media Settings Card
1. Confirm that the usage of periods for the texts is the expected.

#### After this PR

![image](https://cloud.githubusercontent.com/assets/746152/23773851/cddf563c-04ff-11e7-8a3d-c03d0ad07f83.png)


#### Before this PR

![image](https://cloud.githubusercontent.com/assets/746152/23772755/eaf2489c-04fa-11e7-9dcb-e7761e526b77.png)


#### Why

During #11906's review, It was recommended that the labels action texts don't use ending periods. And that the descriptions and the InfoPopovers content, use punctuation appropriately. 

