### PR TITLE
Media: hide item action buttons when image editor is opened

### DIFF
--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -119,6 +119,11 @@ export default React.createClass( {
 	},
 
 	getModalButtons() {
+		// do not render buttons if the media image editor is opened
+		if ( this.state.editedItem !== null ) {
+			return null;
+		}
+
 		return [
 			{
 				action: 'delete',
@@ -206,7 +211,7 @@ export default React.createClass( {
 		return (
 			<div ref="container" className="main main-column media" role="main">
 				<SidebarNavigation />
-				{ ( this.state.editedItem !== null || this.state.currentDetail !== null) &&
+				{ ( this.state.editedItem !== null || this.state.currentDetail !== null ) &&
 					<Dialog
 						isVisible={ true }
 						additionalClassNames="editor-media-modal media__item-dialog"


### PR DESCRIPTION
This PR fixes #11976 

### Testing

1) Go to the Media section: `http://calypso.localhost:3000/media/<site>`
2) Select an image media item
3) Start to edit
4) Start to edit the image

You shouldn't see the `DONE` and `DELETE` buttons

![image](https://cloud.githubusercontent.com/assets/77539/23773305/6298b21c-04fd-11e7-878c-bcf76e162d50.png)
