### PR TITLE
Directly: Add user throttling

### DIFF
--- a/client/lib/directly/index.js
+++ b/client/lib/directly/index.js
@@ -14,6 +14,7 @@ import config from 'config';
  * Internal dependencies
  */
 import { loadScript } from 'lib/load-script';
+import wpcom from 'lib/wp';
 
 const DIRECTLY_RTM_SCRIPT_URL = 'https://widgets.wp.com/directly/embed.js';
 const DIRECTLY_ASSETS_BASE_URL = 'https://www.directly.com';
@@ -85,20 +86,12 @@ function execute( ...args ) {
 }
 
 /**
- * Initializes the RTM widget if it hasn't already been initialized. This sets up global
- * objects and DOM elements and requests the vendor script.
+ * Make the request for Directly's remote JavaScript.
  *
- * @returns {Promise} Promise that resolves after initialization completes
+ * @returns {Promise} Promise that resolves after the script loads or fails
  */
-export function initialize() {
-	if ( directlyPromise instanceof Promise ) {
-		return directlyPromise;
-	}
-
-	directlyPromise = new Promise( ( resolve, reject ) => {
-		configureGlobals();
-		insertDOM();
-
+function loadDirectlyScript() {
+	return new Promise( ( resolve, reject ) => {
 		loadScript( DIRECTLY_RTM_SCRIPT_URL, function( error ) {
 			if ( error ) {
 				return reject( new Error( `Failed to load script "${ error.src }".` ) );
@@ -106,6 +99,30 @@ export function initialize() {
 			resolve();
 		} );
 	} );
+}
+
+/**
+ * Initializes the RTM widget if it hasn't already been initialized. This sets up global
+ * objects and DOM elements and requests the vendor script.
+ *
+ * @returns {Promise} Promise that resolves after initialization completes or fails
+ */
+export function initialize() {
+	if ( directlyPromise instanceof Promise ) {
+		return directlyPromise;
+	}
+
+	directlyPromise = wpcom.undocumented().getDirectlyConfiguration().then(
+		( { isAvailable } ) => {
+			if ( ! isAvailable ) {
+				return Promise.reject( new Error( i18n.translate( 'Directly Real-Time Messaging is not available at this time.' ) ) );
+			}
+
+			configureGlobals();
+			insertDOM();
+			return loadDirectlyScript();
+		}
+	);
 
 	return directlyPromise;
 }

--- a/client/lib/directly/index.js
+++ b/client/lib/directly/index.js
@@ -115,7 +115,7 @@ export function initialize() {
 	directlyPromise = wpcom.undocumented().getDirectlyConfiguration().then(
 		( { isAvailable } ) => {
 			if ( ! isAvailable ) {
-				return Promise.reject( new Error( i18n.translate( 'Directly Real-Time Messaging is not available at this time.' ) ) );
+				return Promise.reject( new Error( 'Directly Real-Time Messaging is not available at this time.' ) );
 			}
 
 			configureGlobals();

--- a/client/lib/directly/test/index.js
+++ b/client/lib/directly/test/index.js
@@ -8,7 +8,7 @@ import sinon from 'sinon';
  * Internal dependencies
  */
 import useFakeDom from 'test/helpers/use-fake-dom';
-// import * as loadScript from 'lib/load-script';
+import useNock from 'test/helpers/use-nock';
 
 let directly;
 let loadScript;
@@ -16,17 +16,23 @@ let loadScript;
 describe( 'index', () => {
 	// Need to use `require` to correctly spy on loadScript
 	loadScript = require( 'lib/load-script' );
-	sinon.spy( loadScript, 'loadScript' );
+	sinon.stub( loadScript, 'loadScript' );
+
+	// Helpers to simulate whether the remote Directly script loads or fails
+	const simulateSuccessfulScriptLoad = () => loadScript.loadScript.callsArg( 1 );
+	const simulateFailedScriptLoad = ( error ) => loadScript.loadScript.callsArgWith( 1, error );
 
 	useFakeDom();
 
 	beforeEach( () => {
 		directly = require( '..' );
+
+		loadScript.loadScript.reset();
+		// Since most tests expect the script to load, make this the default
+		simulateSuccessfulScriptLoad();
 	} );
 
 	afterEach( () => {
-		loadScript.loadScript.reset();
-
 		// After each test, clean up the globals put in place by Directly
 		const script = document.querySelector( '#directlyRTMScript' );
 		if ( script ) {
@@ -36,65 +42,109 @@ describe( 'index', () => {
 		delete require.cache[ require.resolve( '..' ) ];
 	} );
 
-	describe( '#initialize()', () => {
-		it( 'creates a window.DirectlyRTM function', () => {
-			directly.initialize();
-			expect( typeof window.DirectlyRTM ).to.equal( 'function' );
+	describe( 'when the API says Directly is available', () => {
+		useNock( ( nock ) => {
+			nock( 'https://public-api.wordpress.com:443' )
+				.persist()
+				.get( '/rest/v1.1/help/directly/mine' )
+				.reply( 200, {
+					isAvailable: true
+				} );
 		} );
 
-		it( 'attempts to load the remote script', () => {
-			directly.initialize();
-			expect( loadScript.loadScript ).to.have.been.calledOnce;
+		describe( '#initialize()', () => {
+			it( 'creates a window.DirectlyRTM function', ( done ) => {
+				directly.initialize()
+					.then( () => expect( typeof window.DirectlyRTM ).to.equal( 'function' ) )
+					.then( () => done() );
+			} );
+
+			it( 'attempts to load the remote script', ( done ) => {
+				directly.initialize()
+					.then( () => expect( loadScript.loadScript ).to.have.been.calledOnce )
+					.then( () => done() );
+			} );
+
+			it( 'does nothing after the first call', ( done ) => {
+				Promise.all( [
+					directly.initialize(),
+					directly.initialize(),
+					directly.initialize()
+						.then( () => {
+							expect( window.DirectlyRTM.cq ).to.have.lengthOf( 1 );
+							expect( window.DirectlyRTM.cq[ 0 ][ 0 ] ).to.equal( 'config' );
+							expect( loadScript.loadScript ).to.have.been.calledOnce;
+						} )
+				] ).then( () => done() );
+			} );
+
+			it( 'resolves the returned promise if the library load succeeds', ( done ) => {
+				directly.initialize().then( () => done() );
+			} );
+
+			it( 'rejects the returned promise if the library load fails', ( done ) => {
+				const error = { src: 'http://url.to/directly/embed.js' };
+				simulateFailedScriptLoad( error );
+
+				directly.initialize()
+					.catch( ( e ) => {
+						expect( e ).to.be.an.instanceof( Error );
+						expect( e.message ).to.contain( error.src );
+					} )
+					.then( () => done() );
+			} );
 		} );
 
-		it( 'does nothing after the first call', () => {
-			directly.initialize();
-			directly.initialize();
-			directly.initialize();
+		describe( '#askQuestion()', () => {
+			const questionText = 'How can I give you all my money?';
+			const name = 'Richie Rich';
+			const email = 'richie@richenterprises.biz';
 
-			expect( window.DirectlyRTM.cq ).to.have.lengthOf( 1 );
-			expect( window.DirectlyRTM.cq[ 0 ][ 0 ] ).to.equal( 'config' );
-			expect( loadScript.loadScript ).to.have.been.calledOnce;
-		} );
+			it( 'initializes Directly if it hasn\'t already been initialized', ( done ) => {
+				directly.askQuestion( questionText, name, email )
+					.then( () => {
+						expect( typeof window.DirectlyRTM ).to.equal( 'function' );
+						expect( loadScript.loadScript ).to.have.been.calledOnce;
+					} )
+					.then( () => done() );
+			} );
 
-		it( 'resolves the returned promise if the library load succeeds', ( done ) => {
-			directly.initialize().then( () => done() );
-			loadScript.loadScript.firstCall.args[ 1 ]();
-		} );
-
-		it( 'rejects the returned promise if the library load fails', ( done ) => {
-			const error = { src: 'http://url.to/directly/embed.js' };
-			directly.initialize()
-				.catch( ( e ) => {
-					expect( e ).to.be.an.instanceof( Error );
-					expect( e.toString() ).to.contain( error.src );
-				} )
-				.then( () => done() );
-
-			loadScript.loadScript.firstCall.args[ 1 ]( error );
+			it( 'invokes the Directly API with the given paramaters', ( done ) => {
+				window.DirectlyRTM = sinon.spy();
+				directly.askQuestion( questionText, name, email )
+					.then( () => expect( window.DirectlyRTM ).to.have.been.calledWith( 'askQuestion', { questionText, name, email } ) )
+					.then( () => done() );
+			} );
 		} );
 	} );
 
-	describe( '#askQuestion()', () => {
-		const questionText = 'How can I give you all my money?';
-		const name = 'Richie Rich';
-		const email = 'richie@richenterprises.biz';
-
-		it( 'initializes Directly if it hasn\'t already been initialized', () => {
-			directly.askQuestion( questionText, name, email );
-			expect( typeof window.DirectlyRTM ).to.equal( 'function' );
-			expect( loadScript.loadScript ).to.have.been.calledOnce;
+	describe( 'when the public API says Directly is not available', () => {
+		useNock( ( nock ) => {
+			nock( 'https://public-api.wordpress.com:443' )
+				.persist()
+				.get( '/rest/v1.1/help/directly/mine' )
+				.reply( 200, {
+					isAvailable: false
+				} );
 		} );
 
-		it( 'invokes the Directly API with the given paramaters', ( done ) => {
-			window.DirectlyRTM = sinon.spy();
-			directly.askQuestion( questionText, name, email ).then( () => {
-				expect( window.DirectlyRTM ).to.have.been.calledWith( 'askQuestion', { questionText, name, email } );
-				done();
+		describe( '#initialize()', () => {
+			it( 'rejects intialization with an error', ( done ) => {
+				directly.initialize()
+					.catch( ( e ) => {
+						expect( e ).to.be.an.instanceof( Error );
+						expect( e.message ).to.equal( 'Directly Real-Time Messaging is not available at this time.' );
+					} )
+					.then( () => done() );
 			} );
 
-			// Fake the script loading to resolve the initialize() promise chain
-			loadScript.loadScript.firstCall.args[ 1 ]();
+			it( 'does not attempt to load the remote script', ( done ) => {
+				directly.initialize()
+					.catch( () => {
+						expect( loadScript.loadScript ).not.to.have.beenCalled;
+					} )
+					.then( () => done() );
+			} );
 		} );
 	} );
 } );

--- a/client/lib/directly/test/index.js
+++ b/client/lib/directly/test/index.js
@@ -70,12 +70,13 @@ describe( 'index', () => {
 					directly.initialize(),
 					directly.initialize(),
 					directly.initialize()
-						.then( () => {
-							expect( window.DirectlyRTM.cq ).to.have.lengthOf( 1 );
-							expect( window.DirectlyRTM.cq[ 0 ][ 0 ] ).to.equal( 'config' );
-							expect( loadScript.loadScript ).to.have.been.calledOnce;
-						} )
-				] ).then( () => done() );
+				] )
+				.then( () => {
+					expect( window.DirectlyRTM.cq ).to.have.lengthOf( 1 );
+					expect( window.DirectlyRTM.cq[ 0 ][ 0 ] ).to.equal( 'config' );
+					expect( loadScript.loadScript ).to.have.been.calledOnce;
+				} )
+				.then( () => done() );
 			} );
 
 			it( 'resolves the returned promise if the library load succeeds', ( done ) => {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2052,6 +2052,20 @@ Undocumented.prototype.cancelPlanTrial = function( planId, fn ) {
 	}, fn );
 };
 
+/**
+ * Get the Directly configuration for the current user
+ *
+ * @param {Function} fn The callback function
+ * @returns {Promise} A promise that resolves when the request completes
+ * @api public
+ */
+Undocumented.prototype.getDirectlyConfiguration = function( fn ) {
+	return this.wpcom.req.get( {
+		apiVersion: '1.1',
+		path: '/help/directly/mine'
+	}, fn );
+};
+
 Undocumented.prototype.submitKayakoTicket = function( subject, message, locale, client, fn ) {
 	debug( 'submitKayakoTicket' );
 


### PR DESCRIPTION
We created a control in the REST API that allows us to throttle Directly support to a percentage of our userbase. This allows us to slowly roll it out as we start adding Experts in this testing period. This PR fetches that API endpoint before the library is fetched to ensure that only certain users in the % grouping will receive Directly support.

### To test

You will need access to the Network Admin to adjust throttling percentages, under Happiness » Live Chat Options.

#### When Directly is available
- Set the Directly throttle to 100%
- Sign in as a user with no paid upgrades & go to http://calypso.localhost:3000/help/contact
- You should see the Directly form with the "Ask an Expert" submit button

#### When Directly is not available
- Set the Directly throttle to 0%
- Sign in as a user with no paid upgrades & go to http://calypso.localhost:3000/help/contact
- You should see the Forum form with the "Ask in the forums" submit button