### PR TITLE
Media: simplify calling preventDefault() event method

### DIFF
--- a/client/my-sites/media-library/upload-url.jsx
+++ b/client/my-sites/media-library/upload-url.jsx
@@ -33,16 +33,14 @@ class MediaLibraryUploadUrl extends Component {
 	};
 
 	upload = event => {
-		const isError = ! event.target.checkValidity();
+		event.preventDefault();
 
+		const isError = ! event.target.checkValidity();
 		this.setState( { isError } );
 
 		if ( isError || ! this.props.site ) {
-			event.preventDefault();
 			return;
 		}
-
-		event.preventDefault();
 
 		MediaActions.clearValidationErrors( this.props.site.ID );
 		MediaActions.add( this.props.site.ID, this.state.value );


### PR DESCRIPTION
This PR simplify calling the event.preventDefault() method declaring the call once.

### Testing

The `upload()` method is called in different ways. Try to reproduce all of them:

* uploading an invalid file
* uploading a valid file
* passing a non-valid URL
* passing a valid URL but without a resource (invent https://invalid-site.com/no-image.png)
* passing a valid URL

Everything should be ok. It means that, for instance, when it's tested from the media-modal, the modal shouldn't be closed.