### PR TITLE
Domains:AT: show domain warnings for AT sites on plans page

### DIFF
--- a/client/my-sites/plans/current-plan/controller.jsx
+++ b/client/my-sites/plans/current-plan/controller.jsx
@@ -18,6 +18,12 @@ export default {
 
 		const selectedSite = getSelectedSite( state );
 
+		if ( ! selectedSite ) {
+			page.redirect( '/plans/' );
+
+			return null;
+		}
+
 		if ( isFreePlan( selectedSite.plan ) ) {
 			page.redirect( `/plans/${ selectedSite.slug }` );
 

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -29,6 +29,7 @@ import { getPlan } from 'lib/plans';
 import QuerySiteDomains from 'components/data/query-site-domains';
 import { getDecoratedSiteDomains, isRequestingSiteDomains } from 'state/sites/domains/selectors';
 import DomainWarnings from 'my-sites/upgrades/components/domain-warnings';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 
 class CurrentPlan extends Component {
 	static propTypes = {
@@ -67,39 +68,16 @@ class CurrentPlan extends Component {
 		};
 	}
 
-	renderDomainWarnings() {
-		const {
-			domains,
-			selectedSite,
-			hasDomainsLoaded
-		} = this.props;
-
-		if ( hasDomainsLoaded ) {
-			return (
-				<DomainWarnings
-					domains={ domains }
-					selectedSite={ selectedSite }
-					ruleWhiteList={ [
-						'newDomainsWithPrimary',
-						'newDomains',
-						'unverifiedDomainsCanManage',
-						'pendingGappsTosAcceptanceDomains',
-						'unverifiedDomainsCannotManage',
-						'wrongNSMappedDomains'
-					] }
-				/>
-			);
-		}
-	}
-
 	render() {
 		const {
 			selectedSite,
 			selectedSiteId,
+			domains,
 			context,
 			currentPlan,
 			isExpiring,
-			isJetpack,
+			shouldShowDomainWarnings,
+			hasDomainsLoaded,
 			translate,
 		} = this.props;
 
@@ -108,19 +86,33 @@ class CurrentPlan extends Component {
 
 		const { title, tagLine } = this.getHeaderWording( currentPlanSlug );
 
+		const shouldQuerySiteDomains = selectedSiteId && shouldShowDomainWarnings;
+		const showDomainWarnings = hasDomainsLoaded && shouldShowDomainWarnings;
+
 		return (
 			<Main className="current-plan" wideLayout>
 				<DocumentHead title={ translate( 'Plans', { textOnly: true } ) } />
 				<QuerySites siteId={ selectedSiteId } />
 				<QuerySitePlans siteId={ selectedSiteId } />
-				{ selectedSiteId && ! isJetpack && <QuerySiteDomains siteId={ selectedSiteId } /> }
+				{ shouldQuerySiteDomains && <QuerySiteDomains siteId={ selectedSiteId } /> }
 
 				<PlansNavigation
 					path={ context.path }
 					selectedSite={ selectedSite }
 				/>
 
-				{ ! isJetpack && this.renderDomainWarnings() }
+				{ showDomainWarnings && <DomainWarnings
+						domains={ domains }
+						selectedSite={ selectedSite }
+						ruleWhiteList={ [
+							'newDomainsWithPrimary',
+							'newDomains',
+							'unverifiedDomainsCanManage',
+							'pendingGappsTosAcceptanceDomains',
+							'unverifiedDomainsCannotManage',
+							'wrongNSMappedDomains'
+						] } />
+				}
 
 				<ProductPurchaseFeatures>
 					<CurrentPlanHeader
@@ -146,8 +138,11 @@ class CurrentPlan extends Component {
 
 export default connect(
 	( state, ownProps ) => {
-		const selectedSite = getSelectedSite( state ),
-			selectedSiteId = getSelectedSiteId( state );
+		const selectedSite = getSelectedSite( state );
+		const selectedSiteId = getSelectedSiteId( state );
+
+		const isJetpack = isJetpackSite( state, selectedSiteId );
+		const isAutomatedTransfer = isSiteAutomatedTransfer( state, selectedSiteId );
 
 		return {
 			selectedSite,
@@ -155,10 +150,10 @@ export default connect(
 			context: ownProps.context,
 			currentPlan: getCurrentPlan( state, selectedSiteId ),
 			isExpiring: isCurrentPlanExpiring( state, selectedSiteId ),
-			isJetpack: isJetpackSite( state, selectedSiteId ),
+			shouldShowDomainWarnings: ! isJetpack || isAutomatedTransfer,
+			hasDomainsLoaded: ! isRequestingSiteDomains( state, selectedSiteId ),
 			isRequestingSitePlans: isRequestingSitePlans( state, selectedSiteId ),
 			domains: getDecoratedSiteDomains( state, selectedSiteId ),
-			hasDomainsLoaded: ! isRequestingSiteDomains( state, selectedSiteId )
 		};
 	}
 )( localize( CurrentPlan ) );

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -36,7 +36,12 @@ class CurrentPlan extends Component {
 		selectedSiteId: PropTypes.number,
 		selectedSite: PropTypes.object,
 		isRequestingSitePlans: PropTypes.bool,
-		context: PropTypes.object
+		context: PropTypes.object,
+		domains: PropTypes.array,
+		currentPlan: PropTypes.object,
+		isExpiring: PropTypes.bool,
+		shouldShowDomainWarnings: PropTypes.bool,
+		hasDomainsLoaded: PropTypes.bool,
 	};
 
 	isLoading() {

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -27,7 +27,7 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import { PLAN_BUSINESS } from 'lib/plans/constants';
 import { getPlan } from 'lib/plans';
 import QuerySiteDomains from 'components/data/query-site-domains';
-import { getDecoratedSiteDomains, isRequestingSiteDomains } from 'state/sites/domains/selectors';
+import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
 import DomainWarnings from 'my-sites/upgrades/components/domain-warnings';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 
@@ -145,6 +145,7 @@ export default connect(
 	( state, ownProps ) => {
 		const selectedSite = getSelectedSite( state );
 		const selectedSiteId = getSelectedSiteId( state );
+		const domains = getDecoratedSiteDomains( state, selectedSiteId );
 
 		const isJetpack = isJetpackSite( state, selectedSiteId );
 		const isAutomatedTransfer = isSiteAutomatedTransfer( state, selectedSiteId );
@@ -152,13 +153,13 @@ export default connect(
 		return {
 			selectedSite,
 			selectedSiteId,
+			domains,
 			context: ownProps.context,
 			currentPlan: getCurrentPlan( state, selectedSiteId ),
 			isExpiring: isCurrentPlanExpiring( state, selectedSiteId ),
 			shouldShowDomainWarnings: ! isJetpack || isAutomatedTransfer,
-			hasDomainsLoaded: ! isRequestingSiteDomains( state, selectedSiteId ),
+			hasDomainsLoaded: !! domains,
 			isRequestingSitePlans: isRequestingSitePlans( state, selectedSiteId ),
-			domains: getDecoratedSiteDomains( state, selectedSiteId ),
 		};
 	}
 )( localize( CurrentPlan ) );

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -147,7 +147,7 @@ export default connect(
 		const selectedSiteId = getSelectedSiteId( state );
 		const domains = getDecoratedSiteDomains( state, selectedSiteId );
 
-		const isJetpack = isJetpackSite( state, selectedSiteId );
+		const isWpcom = ! isJetpackSite( state, selectedSiteId );
 		const isAutomatedTransfer = isSiteAutomatedTransfer( state, selectedSiteId );
 
 		return {
@@ -157,7 +157,7 @@ export default connect(
 			context: ownProps.context,
 			currentPlan: getCurrentPlan( state, selectedSiteId ),
 			isExpiring: isCurrentPlanExpiring( state, selectedSiteId ),
-			shouldShowDomainWarnings: ! isJetpack || isAutomatedTransfer,
+			shouldShowDomainWarnings: isWpcom || isAutomatedTransfer,
 			hasDomainsLoaded: !! domains,
 			isRequestingSitePlans: isRequestingSitePlans( state, selectedSiteId ),
 		};


### PR DESCRIPTION
Domains for automatic transfer sites are managed by wordpress.com so we should show domain warnings on the site plans page.

### testing

Enable logging for the domain warnings component: 
    
    localStorage.setItem( 'calypso:domain-warnings' );

For an automatic transfer site or a wordpress.com site with a custom domain
1. visit the plans page: http://calypso.localhost:3000/plans/my-plan/:site
2. A request to the domains endpoint should be made.
3. There should be multiple log statements in the browser console.
4. Any domain warning should be displayed .

For a Jetpack site
1. visit the plans page: http://calypso.localhost:3000/plans/my-plan/:site
2. No requests to the domains endpoint should be made.
3. There should be no log statements in the browser console.

cc @klimeryk @umurkontaci 
Partial Fix for #11493

