### PR TITLE
Purchases: Add tracks events for cancellation survey

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -455,7 +455,7 @@ export default connect(
 	null,
 	( dispatch ) => ( {
 		clickRadio: ( option, value ) => dispatch( recordTracksEvent(
-			'calypso_cancel_purchase_survey_select_radio_option', {
+			'calypso_purchases_cancel_form_select_radio_option', {
 				option: option,
 				value: value
 			}

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import shuffle from 'lodash/shuffle';
+import { connect } from 'react-redux';
 
 /**
  * Internal Dependencies
@@ -447,4 +448,7 @@ const CancelPurchaseForm = React.createClass( {
 	}
 } );
 
-export default CancelPurchaseForm;
+export default connect(
+	null,
+	null,
+)( CancelPurchaseForm );

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -14,6 +14,7 @@ import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
 import FormTextInput from 'components/forms/form-text-input';
 import FormTextarea from 'components/forms/form-textarea';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 const CancelPurchaseForm = React.createClass( {
 	propTypes: {
@@ -71,6 +72,7 @@ const CancelPurchaseForm = React.createClass( {
 	},
 
 	onRadioOneChange( event ) {
+		this.props.clickRadio( 'radio_1', event.currentTarget.value );
 		const newState = {
 			...this.state,
 			questionOneRadio: event.currentTarget.value,
@@ -90,6 +92,7 @@ const CancelPurchaseForm = React.createClass( {
 	},
 
 	onRadioTwoChange( event ) {
+		this.props.clickRadio( 'radio_2', event.currentTarget.value );
 		const newState = {
 			...this.state,
 			questionTwoRadio: event.currentTarget.value,
@@ -450,5 +453,12 @@ const CancelPurchaseForm = React.createClass( {
 
 export default connect(
 	null,
-	null,
+	( dispatch ) => ( {
+		clickRadio: ( option, value ) => dispatch( recordTracksEvent(
+			'calypso_cancel_purchase_survey_select_radio_option', {
+				option: option,
+				value: value
+			}
+		) ),
+	} )
 )( CancelPurchaseForm );

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -4,6 +4,7 @@
 import page from 'page';
 import React from 'react';
 import { moment } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -44,9 +45,11 @@ const CancelPurchaseButton = React.createClass( {
 	},
 
 	recordEvent( name, properties = {} ) {
+		const product_slug = get( this.props, 'purchase.productSlug' );
+		const refund = true;
 		this.props.recordTracksEvent(
 			name,
-			Object.assign( { refund: true, product_slug: this.props.purchase.productSlug }, properties )
+			Object.assign( { refund, product_slug }, properties )
 		);
 	},
 

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -9,7 +9,6 @@ import { moment } from 'i18n-calypso';
  * Internal Dependencies
  */
 import config from 'config';
-import analytics from 'lib/analytics';
 import Button from 'components/button';
 import { cancelAndRefundPurchase, cancelPurchase, submitSurvey } from 'lib/upgrades/actions';
 import { clearPurchases } from 'state/purchases/actions';
@@ -23,6 +22,7 @@ import notices from 'notices';
 import paths from 'me/purchases/paths';
 import { refreshSitePlans } from 'state/sites/plans/actions';
 import FormSectionHeading from 'components/forms/form-section-heading';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 const CancelPurchaseButton = React.createClass( {
 	propTypes: {
@@ -43,10 +43,19 @@ const CancelPurchaseButton = React.createClass( {
 		};
 	},
 
+	recordEvent( name, properties = {} ) {
+		this.props.recordTracksEvent(
+			name,
+			Object.assign( { refund: true, product_slug: this.props.purchase.productSlug }, properties )
+		);
+	},
+
 	handleCancelPurchaseClick() {
 		if ( isDomainRegistration( this.props.purchase ) ) {
 			return this.goToCancelConfirmation();
 		}
+
+		this.recordEvent( 'calypso_purchases_cancel_form_start' );
 
 		this.setState( {
 			showDialog: true
@@ -54,6 +63,8 @@ const CancelPurchaseButton = React.createClass( {
 	},
 
 	closeDialog() {
+		this.recordEvent( 'calypso_purchases_cancel_form_close' );
+
 		this.setState( {
 			showDialog: false,
 			surveyStep: 1,
@@ -65,9 +76,11 @@ const CancelPurchaseButton = React.createClass( {
 	},
 
 	changeSurveyStep() {
-		this.setState( {
-			surveyStep: this.state.surveyStep === 1 ? 2 : 1,
-		} );
+		const newStep = this.state.surveyStep === 1 ? 2 : 1;
+
+		this.recordEvent( 'calypso_purchases_cancel_survey_step', { new_step: newStep } );
+
+		this.setState( { surveyStep: newStep } );
 	},
 
 	onSurveyChange( update ) {
@@ -210,10 +223,7 @@ const CancelPurchaseButton = React.createClass( {
 
 		this.props.clearPurchases();
 
-		analytics.tracks.recordEvent(
-			'calypso_purchases_cancel_form_submit',
-			{ product_slug: this.props.purchase.productSlug }
-		);
+		this.recordEvent( 'calypso_purchases_cancel_form_submit' );
 
 		page.redirect( paths.purchasesRoot() );
 	},
@@ -361,6 +371,7 @@ export default connect(
 	null,
 	{
 		clearPurchases,
-		refreshSitePlans
+		recordTracksEvent,
+		refreshSitePlans,
 	}
 )( CancelPurchaseButton );

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -95,6 +95,7 @@ const RemovePurchase = React.createClass( {
 	},
 
 	closeDialog() {
+		analytics.tracks.recordEvent( 'calypso_cancel_purchase_survey_close' );
 		this.setState( {
 			isDialogVisible: false,
 			surveyStep: 1,
@@ -106,6 +107,7 @@ const RemovePurchase = React.createClass( {
 	},
 
 	openDialog( event ) {
+		analytics.tracks.recordEvent( 'calypso_cancel_purchase_survey_start' );
 		event.preventDefault();
 
 		this.setState( { isDialogVisible: true } );
@@ -119,9 +121,9 @@ const RemovePurchase = React.createClass( {
 	},
 
 	changeSurveyStep() {
-		this.setState( {
-			surveyStep: this.state.surveyStep === 1 ? 2 : 1,
-		} );
+		const newStep = this.state.surveyStep === 1 ? 2 : 1;
+		analytics.tracks.recordEvent( 'calypso_cancel_purchase_survey_step', { new_step: newStep } );
+		this.setState( { surveyStep: newStep } );
 	},
 
 	onSurveyChange( update ) {

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -6,6 +6,7 @@ import page from 'page';
 import React from 'react';
 import Gridicon from 'gridicons';
 import { moment } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -84,7 +85,7 @@ const RemovePurchase = React.createClass( {
 	},
 
 	recordChatEvent( eventAction ) {
-		const purchase = getPurchase( this.props );
+		const purchase = this.props.selectedPurchase;
 		this.props.recordTracksEvent( eventAction, {
 			survey_step: this.state.surveyStep,
 			purchase: purchase.productSlug,
@@ -95,9 +96,11 @@ const RemovePurchase = React.createClass( {
 	},
 
 	recordEvent( name, properties = {} ) {
+		const product_slug = get( this.props, 'selectedPurchase.productSlug' );
+		const refund = false;
 		this.props.recordTracksEvent(
 			name,
-			Object.assign( { refund: false, product_slug: this.props.purchase.productSlug }, properties )
+			Object.assign( { refund, product_slug }, properties )
 		);
 	},
 

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -126,7 +126,7 @@ const RemovePurchase = React.createClass( {
 	openChat() {
 		olarkActions.expandBox();
 		olarkActions.focusBox();
-		this.recordChatEvent( 'calypso_purchases_cancel_form_click' );
+		this.recordChatEvent( 'calypso_precancellation_chat_click' );
 		this.setState( { isDialogVisible: false } );
 	},
 


### PR DESCRIPTION
The cancellation survey does not currently fire any analytics events so it is not possible to see how this survey is being used unless it is completely filled in and submitted.

This change adds the following tracks events:

* `calypso_purchases_cancel_form_start` when the 'remove <product>' button is clicked
* `calypso_purchases_cancel_form_select_radio_option` when the radio button options are selected
* `calypso_purchases_cancel_form_step` when the 'next' and 'previous' buttons are clicked
* `calypso_purchases_cancel_form_close` when the survey is cancelled
* `calypso_purchases_cancel_form_submit` when the survey is submitted (and plan is cancelled)

# To test

There are two completely distinct sets of components for cancelling/removing a plan depending on whether a refund is due.

You will need a user with a site associated with a paid plan and another site with a paid plan due for a refund. In chrome, show the network tab in developer tools with a filter for `t.gif` requests.

* browse to `/me/purchases`
* click on the plan
* click on 'Remove <product>'
* fill in survey, click previous, next, cancel, etc. and you should see each of the above events firing.
