### PR TITLE
In Reader empty sidebar sections, use max-width rather than \xa0

### DIFF
--- a/client/reader/sidebar/_style.scss
+++ b/client/reader/sidebar/_style.scss
@@ -174,6 +174,7 @@
 
 	.sidebar__menu-empty,
 	.sidebar__menu-empty:hover {
+		max-width: 60%;
 		padding-right: 32px;
 		padding-left: 55px;
 		font-size: 13px;

--- a/client/reader/sidebar/reader-sidebar-lists/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list.jsx
@@ -43,7 +43,7 @@ export class ReaderSidebarListsList extends React.Component {
 		const { translate, lists } = this.props;
 		if ( ! lists || lists.length === 0 ) {
 			return (
-				<li key="empty" className="sidebar__menu-empty">{ translate( 'Collect sites together by adding a\xa0list.' ) }</li>
+				<li key="empty" className="sidebar__menu-empty">{ translate( 'Collect sites together by adding a list.' ) }</li>
 			);
 		}
 

--- a/client/reader/sidebar/reader-sidebar-tags/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list.jsx
@@ -43,7 +43,7 @@ export class ReaderSidebarTagsList extends Component {
 		const { tags, translate } = this.props;
 		if ( ! tags || tags.length === 0 ) {
 			return (
-				<li key="empty" className="sidebar__menu-empty">{ translate( 'Find relevant posts by adding a\xa0tag.' ) }</li>
+				<li key="empty" className="sidebar__menu-empty">{ translate( 'Find relevant posts by adding a tag.' ) }</li>
 			);
 		}
 


### PR DESCRIPTION
@nellofn discovered that the string "Find relevant posts by adding a tag" in the Reader sidebar menu is not translated. @akirk found that this was caused by a rogue `\xa0` character, which had been inserted to prevent the word "tag" being orphaned on the second line.

This PR removes the `\xa0` character and instead uses max-width to constrain the string:

<img width="286" alt="screen shot 2017-03-10 at 10 14 52" src="https://cloud.githubusercontent.com/assets/17325/23791981/0f31e316-057d-11e7-9b37-8e493a5c4c62.png">

Fixes #11522.

### To test

Open the Reader at http://calypso.localhost:3000 and expand the 'Tags' section in the sidebar. If you're not following any tags, you should see the message.

cc @blowery 