### PR TITLE
Site: fix empty default icon on non-compact version.

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -107,7 +107,7 @@ export default React.createClass( {
 						} )
 					}
 				>
-					<SiteIcon site={ site } size={ this.props.compact ? 24 : null } />
+					<SiteIcon site={ site } size={ this.props.compact ? 24 : 32 } />
 					<div className="site__info">
 						<div className="site__title">
 							{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }


### PR DESCRIPTION
When it was being set to null, it overwrote the default prop.