### PR TITLE
Editor: accordion hover style

### DIFF
--- a/client/components/accordion/style.scss
+++ b/client/components/accordion/style.scss
@@ -1,7 +1,7 @@
 $accordion-padding: 16px;
 $accordion-subtitle-height: 16px;
 $accordion-background-collapsed: $white; // same as body
-$accordion-background-hover: $white;
+$accordion-background-hover: lighten( $gray, 35% );
 $accordion-background-expanded: $white;
 
 .accordion {
@@ -25,9 +25,18 @@ $accordion-background-expanded: $white;
 	color: $gray-dark;
 	background-color: $accordion-background-collapsed;
 	text-align: left;
+	transition: all 150ms ease-in;
 
 	&:hover {
 		background-color: $accordion-background-hover;
+
+		.accordion__title {
+			color: $blue-medium;
+		}
+
+		.accordion__arrow {
+			color: $blue-medium;
+		}
 	}
 
 	.accordion__arrow {
@@ -84,6 +93,7 @@ $accordion-background-expanded: $white;
 	font-size: 13px;
 	font-weight: 500;
 	line-height: $accordion-subtitle-height;
+	transition: all 150ms ease-in;
 
 	.accordion.has-icon & {
 		padding-left: 28px;


### PR DESCRIPTION
![cap-](https://cloud.githubusercontent.com/assets/4389/23794579/b4b7fc02-0588-11e7-90d0-3dcf86754c38.gif)

A quick finishing touch on the just merged editor. This adds a visible effect on hover to the accordion, making it clearer when closed, but also more importantly when it's open.

### To test

* Open this branch
* Move the mouse over the accordions, both when open and closed
* They should highlight