### PR TITLE
Reader: add post duration to combined card

### DIFF
--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -47,7 +47,7 @@ const ReaderCombinedCard = ( { posts, site, feed, onClick, isDiscover, translate
 						{ siteName }
 					</ReaderSiteStreamLink>
 					<p className="reader-combined-card__header-post-count">
-						{ translate( '%(count)d posts in %(duration)s', {
+						{ translate( '%(count)d posts over %(duration)s', {
 							args: {
 								count: posts.length,
 								duration,

--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -2,8 +2,9 @@
  * External Dependencies
  */
 import React from 'react';
-import { get } from 'lodash';
+import { get, isEmpty, first, last } from 'lodash';
 import { localize } from 'i18n-calypso';
+import moment from 'moment';
 
 /**
  * Internal Dependencies
@@ -16,12 +17,17 @@ import { siteNameFromSiteAndPost } from 'reader/utils';
 import ReaderCombinedCardPost from './post';
 
 const ReaderCombinedCard = ( { posts, site, feed, onClick, isDiscover, translate } ) => {
+	if ( isEmpty( posts ) ) {
+		return null;
+	}
+
 	const feedId = get( feed, 'feed_ID' );
 	const siteId = get( site, 'ID' );
 	const siteIcon = get( site, 'icon.img' );
 	const feedIcon = get( feed, 'image' );
 	const streamUrl = getStreamUrl( feedId, siteId );
 	const siteName = siteNameFromSiteAndPost( site, posts[ 0 ] );
+	const duration = getHumanizedDuration( first( posts ).date, last( posts ).date );
 
 	return (
 		<Card className="reader-combined-card">
@@ -41,9 +47,10 @@ const ReaderCombinedCard = ( { posts, site, feed, onClick, isDiscover, translate
 						{ siteName }
 					</ReaderSiteStreamLink>
 					<p className="reader-combined-card__header-post-count">
-						{ translate( '%(count)d posts', {
+						{ translate( '%(count)d posts in %(duration)s', {
 							args: {
-								count: posts.length
+								count: posts.length,
+								duration,
 							}
 						} ) }
 					</p>
@@ -63,6 +70,12 @@ const ReaderCombinedCard = ( { posts, site, feed, onClick, isDiscover, translate
 		</Card>
 	);
 };
+
+function getHumanizedDuration( startDate, endDate ) {
+	const start = moment( startDate );
+	const end = moment( endDate );
+	return moment.duration( start.diff( end ) ).humanize();
+}
 
 ReaderCombinedCard.propTypes = {
 	posts: React.PropTypes.array.isRequired,


### PR DESCRIPTION
As described in https://github.com/Automattic/wp-calypso/issues/11973, this PR adds post timespan/duration to the combined card:

<img width="337" alt="screen shot 2017-03-10 at 12 09 20" src="https://cloud.githubusercontent.com/assets/17325/23794870/6b6090f8-058a-11e7-94bb-a8137768a907.png">

It uses Moment's duration `humanize()`, so the unit should change depending upon the duration. In most cases it'll say "x posts in x minutes".

https://momentjs.com/docs/#/durations/humanize/

Fixes #11793.

### To test

Load your Reader following stream at http://calypso.localhost:3000/, look for a combined card and check that the duration shown looks reasonable.