### PR TITLE
Editor: Media modal: Disable Insert when loading image via URL

### DIFF
--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -529,7 +529,8 @@ const MediaUtils = {
 				file: file,
 				title: path.basename( file ),
 				extension: MediaUtils.getFileExtension( file ),
-				mime_type: MediaUtils.getMimeType( file )
+				mime_type: MediaUtils.getMimeType( file ),
+				is_uploading_via_url: true
 			} );
 		} else {
 			// Handle the case where a an object has been passed that wraps a

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -510,6 +510,10 @@ const MediaUtils = {
 		return !! item.transient;
 	},
 
+	isTransientPreviewable( item ) {
+		return !! ( item && item.URL );
+	},
+
 	/**
 	 * Returns an object describing a transient media item which can be used in
 	 * optimistic rendering prior to media persistence to server.
@@ -529,8 +533,7 @@ const MediaUtils = {
 				file: file,
 				title: path.basename( file ),
 				extension: MediaUtils.getFileExtension( file ),
-				mime_type: MediaUtils.getMimeType( file ),
-				is_uploading_via_url: true
+				mime_type: MediaUtils.getMimeType( file )
 			} );
 		} else {
 			// Handle the case where a an object has been passed that wraps a

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -112,7 +112,13 @@ export class EditorMediaModal extends Component {
 	isDisabled() {
 		return some( this.props.mediaLibrarySelectedItems, function( item ) {
 			const mimePrefix = MediaUtils.getMimePrefix( item );
-			return item.transient && ( mimePrefix !== 'image' || ModalViews.GALLERY === this.props.view );
+			return item.transient && (
+				// Transients can't be handled by the editor if they are being
+				// uploaded via an external URL
+				item.is_uploading_via_url ||
+				mimePrefix !== 'image' ||
+				ModalViews.GALLERY === this.props.view
+			);
 		}.bind( this ) );
 	}
 

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -42,6 +42,18 @@ import ImageEditor from 'blocks/image-editor';
 import MediaModalDetail from './detail';
 import { withAnalytics, bumpStat, recordGoogleEvent } from 'state/analytics/actions';
 
+function areMediaActionsDisabled( modalView, mediaItems ) {
+	return some( mediaItems, item =>
+		MediaUtils.isItemBeingUploaded( item ) && (
+			// Transients can't be handled by the editor if they are being
+			// uploaded via an external URL
+			! MediaUtils.isTransientPreviewable( item ) ||
+			MediaUtils.getMimePrefix( item ) !== 'image' ||
+			ModalViews.GALLERY === modalView
+		)
+	);
+}
+
 export class EditorMediaModal extends Component {
 	static propTypes = {
 		visible: React.PropTypes.bool,
@@ -107,19 +119,6 @@ export class EditorMediaModal extends Component {
 			detailSelectedIndex: 0,
 			gallerySettings: props.initialGallerySettings
 		};
-	}
-
-	isDisabled() {
-		return some( this.props.mediaLibrarySelectedItems, function( item ) {
-			const mimePrefix = MediaUtils.getMimePrefix( item );
-			return item.transient && (
-				// Transients can't be handled by the editor if they are being
-				// uploaded via an external URL
-				item.is_uploading_via_url ||
-				mimePrefix !== 'image' ||
-				ModalViews.GALLERY === this.props.view
-			);
-		}.bind( this ) );
 	}
 
 	confirmSelection = () => {
@@ -333,8 +332,8 @@ export class EditorMediaModal extends Component {
 			return;
 		}
 
-		const isDisabled = this.isDisabled();
 		const selectedItems = this.props.mediaLibrarySelectedItems;
+		const isDisabled = areMediaActionsDisabled( this.props.view, selectedItems );
 		const buttons = [
 			{
 				action: 'cancel',

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -124,14 +124,16 @@ export class EditorMediaModal extends Component {
 	confirmSelection = () => {
 		const { view, mediaLibrarySelectedItems } = this.props;
 
-		let value;
-		if ( mediaLibrarySelectedItems.length ) {
-			value = {
+		if ( areMediaActionsDisabled( view, mediaLibrarySelectedItems ) ) {
+			return;
+		}
+
+		const value = mediaLibrarySelectedItems.length
+			? {
 				type: ModalViews.GALLERY === view ? 'gallery' : 'media',
 				items: mediaLibrarySelectedItems,
 				settings: this.state.gallerySettings
-			};
-		}
+			} : undefined;
 
 		this.props.onClose( value );
 	};


### PR DESCRIPTION
Fixes #11831 

# To test

See parent issue

# Visuals

<img width="850" alt="media-modal-disable-insert" src="https://cloud.githubusercontent.com/assets/150562/23797560/598c9ec2-0598-11e7-84a4-e3fdbbe53fff.png">