### PR TITLE
Editor: Fix long labels in Insert Media menu are pushed outside of the dropdown

### DIFF
--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -144,7 +144,7 @@
 	left: 0;
 	position: absolute;
 	top: 38px;
-	width: 185px;
+	min-width: 185px;
 
 	&.is-visible {
 		display: block;


### PR DESCRIPTION
Languages with longer labels push the Insert Media labels outside of the dropdown.
Just converting from `width` to `min-width` is enough to fix this issue.

| Before | After |
| --- | --- |
| <img width="360" alt="screen_shot_2017-03-10_at_8 22 00_am_720" src="https://cloud.githubusercontent.com/assets/1204802/23797006/1105d3ac-059e-11e7-846d-5cf4186bb44c.png"> | <img width="291" alt="screen shot 2017-03-10 at 13 50 27" src="https://cloud.githubusercontent.com/assets/2070010/23797593/8e2dca34-0598-11e7-9d81-1e608ab488af.png"> |
