### PR TITLE
Editor: Hide toolbar borders dependent on sidebar presence

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -76,6 +76,7 @@ $z-layers: (
 		'.domain-suggestion.is-clickable:hover': 1,
 		'.editor-html-toolbar': 1,
 		'.thank-you-card__header': 1,
+		'.post-editor__sidebar': 2,
 		'.editor-action-bar .editor-status-label': 2,
 		'.is-installing .theme': 2,
 		'.reader-update-notice': 2,

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -30,6 +30,7 @@
 
 			@include breakpoint( "660px-960px" ) {
 				@include long-content-fade();
+				right: 1px;
 				height: 36px;
 			}
 		}
@@ -70,13 +71,22 @@
 		background-color: rgba( $white, 0.92 );
 		border-color: lighten( $gray, 25% );
 		border-style: solid;
+		border-left-width: 1px;
+		border-right-width: 1px;
 		padding: 0;
 		overflow-x: auto;
 		margin: 0 auto;
 
-		@media screen and ( min-width: ( 700px + $sidebar-width-min ) ) {
-			border-left-width: 1px;
-			border-right-width: 1px;
+		@media screen and ( max-width: 700px ) {
+			border-left-width: 0;
+			border-right-width: 0;
+		}
+
+		.focus-sidebar & {
+			@media screen and ( max-width: ( 700px + $sidebar-width-min ) ) {
+				border-left-width: 0;
+				border-right-width: 0;
+			}
 		}
 	}
 

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -7,6 +7,8 @@
 		background-color: rgba( $white, 0.92 );
 		border-color: lighten( $gray, 20% );
 		border-style: solid;
+		border-left-width: 1px;
+		border-right-width: 1px;
 		border-bottom-width: 1px;
 		box-sizing: border-box;
 		margin: 0 auto;
@@ -14,10 +16,17 @@
 		position: relative;
 		width: 100%;
 
-		@media ( min-width: 930px ) {
-			border-left-width: 1px;
-			border-right-width: 1px;
+		@media ( max-width: 700px ) {
+			border-left-width: 0;
+			border-right-width: 0;
 		}
+
+		.focus-sidebar & {
+			@media screen and ( max-width: ( 700px + $sidebar-width-min ) ) {
+				border-left-width: 0;
+				border-right-width: 0;
+			}
+  		}
 	}
 
 	&.is-pinned .editor-html-toolbar__wrapper {

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -48,6 +48,17 @@
 			width: calc( 100% - ( #{ ( $sidebar-width-max * 2 ) + 1 } ) );
 			left: 0;
 		}
+
+		@include breakpoint( "660px-960px" ) {
+			.focus-sidebar &,
+			.has-chat & {
+				width: calc( 100% - ( #{ $sidebar-width-min + 1 } ) );
+			}
+
+			.focus-sidebar.has-chat & {
+				width: calc( 100% - ( #{ ( $sidebar-width-min * 2 ) + 1 } ) );
+			}
+		}
 	}
 
 	.editor-html-toolbar__wrapper-buttons {

--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -1,5 +1,6 @@
 .post-editor__sidebar {
 	@extend .sidebar;
+	z-index: z-index( 'root', '.post-editor__sidebar' );
 	background: lighten( $gray, 30% );
 	left: auto;
 	right: -273px;

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -114,6 +114,7 @@
 
 .editor__header,
 .editor .mce-edit-area {
+	box-sizing: border-box;
 	padding: 0 16px;
 
 	@include breakpoint( ">1040px" ) {

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -101,12 +101,9 @@
 .editor__header,
 .editor .mce-container-body,
 .editor .tinymce {
-	max-width: 100%;
+	width: 100%;
+	max-width: 700px;
 	margin: 0 auto;
-
-	@include breakpoint( ">960px" ) {
-		width: 700px;
-	}
 }
 
 .focus-content .editor__header {


### PR DESCRIPTION
Related: #11536

This pull request seeks to resolve an issue where toolbar borders may be hidden in the editor if the settings panel is closed and between particular medium-size resolutions.

The changes now adjusts for `.focus-sidebar`, showing borders by default but hiding them if either the screen size is small enough that the editor hits the left and right bounds, accounting for when the settings panel is opened.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/23798200/7966ae9e-0571-11e7-908f-fd2c04a6361f.png)|![After](https://cloud.githubusercontent.com/assets/1779930/23798083/e5c997f0-0570-11e7-9bf4-e5c4241c1661.png)

__Testing instructions:__

Verify that toolbar borders are present on left and right when post editor settings panel is closed between medium resolution sizes, and present again at larger resolutions.