### PR TITLE
Framework: Rework how we deal with failed chunk loads

### DIFF
--- a/server/bundler/plugin.js
+++ b/server/bundler/plugin.js
@@ -19,26 +19,45 @@ ChunkFileNames.prototype.apply = function( compiler ) {
 				this.indent( "installedChunks[ chunkId ].push( callback );" ),
 				" } else { ",
 				this.indent( [
+					"function __loadChunk( src ) {",
+					this.indent( [
+						"var head = document.getElementsByTagName( 'head' )[ 0 ];",
+						"var script = document.createElement( 'script' );",
+						"script.type = 'text/javascript';",
+						"script.charset = 'utf-8';",
+						"script.async = true;",
+						"script.onerror = function() {",
+
+						this.indent( [
+							// try to reload the script once
+							"if( src.indexOf( 'retry=1' ) === -1 ) {",
+							this.indent( [
+								"__loadChunk( src + '?retry=1' );",
+								"return;"
+							] ),
+							"}",
+							// attempt to reload the entire app if we hit a chunk loading error
+							// a chunk loading error typically means that the application has moved on since it was loaded and
+							// the hashes of dependent chunks have changed. We have to reload to pick up the new manifest
+							// and the new set of hashes
+							"if ( window.location.search.indexOf( 'retry=1' ) === -1 ) { ",
+							this.indent( [
+								"window.location.search += ( window.location.search ? '&retry=1' : 'retry=1' );",
+								"return;"
+							] ),
+							"}",
+							// what should we do here? It appears we can't actually load the app.
+							"console && console.error( 'Unable to load ' + chunkName + ' from ' + src );"
+						] ),
+						"};",
+						"script.src = src",
+						"head.appendChild( script );"
+					] ),
+					"}",
 					"// start chunk loading",
 					"installedChunks[ chunkId ] = [ callback ];",
-					"window.__chunkErrors = window.__chunkErrors || {};",
-					"window.__chunkErrors[ chunkName ]=null;",
-					"var head = document.getElementsByTagName( 'head' )[ 0 ];",
-					"var script = document.createElement( 'script' );",
-					"var isDebug = window.app.isDebug;",
-					"script.type = 'text/javascript';",
-					"script.charset = 'utf-8';",
-					"script.async = true;",
-					"script.onerror = function() {",
-					this.indent( [
-						"script.onerror = script.onload = script.onreadystatechange = null;",
-						"delete installedChunks[ chunkId ];",
-						"window.__chunkErrors[ chunkName ] = new Error( 'could not load ' + chunkName );",
-						"callback.call( null, " + this.requireFn + ")"
-					] ),
-					"};",
-					"script.src = " + this.requireFn + ".p + ( chunkName ) + '.' + ( chunkHash ) + ( isDebug ? '' : '.m' ) + '.js';",
-					"head.appendChild( script );"
+					"var src = " + this.requireFn + ".p + ( chunkName ) + '.' + ( chunkHash ) + ( window.app.isDebug ? '' : '.m' ) + '.js';",
+					"__loadChunk( src )"
 				] ),
 				"}"
 			] );

--- a/server/bundler/plugin.js
+++ b/server/bundler/plugin.js
@@ -6,6 +6,10 @@ ChunkFileNames.prototype.apply = function( compiler ) {
 		compilation.mainTemplate.plugin("require-ensure", function( _, chunk ) {
 			var chunkMaps = chunk.getChunkMaps();
 			return this.asString( [
+				"var chunkNames = " + JSON.stringify( chunkMaps.name, null, '  ' ) + ";",
+				"var chunkHashes = " + JSON.stringify( chunkMaps.hash, null, '  ' ) + ";",
+				"var chunkName = chunkNames[ chunkId ] || chunkId;",
+				"var chunkHash = chunkHashes[ chunkId ] || chunkId;",
 				"// \"0\" is the signal for \"already loaded\"",
 				"if ( installedChunks[ chunkId ] === 0 ) {",
 				this.indent("return callback.call( null, " + this.requireFn + " );"),
@@ -18,8 +22,8 @@ ChunkFileNames.prototype.apply = function( compiler ) {
 					"// start chunk loading",
 					"installedChunks[ chunkId ] = [ callback ];",
 					"window.__chunkErrors = window.__chunkErrors || {};",
-					"window.__chunkErrors[ " + JSON.stringify( chunkMaps.name ) + "[chunkId]||chunkId ]=null;",
-					"var head = document.getElementsByTagName('head')[0];",
+					"window.__chunkErrors[ chunkName ]=null;",
+					"var head = document.getElementsByTagName( 'head' )[ 0 ];",
 					"var script = document.createElement( 'script' );",
 					"var isDebug = window.app.isDebug;",
 					"script.type = 'text/javascript';",
@@ -29,11 +33,11 @@ ChunkFileNames.prototype.apply = function( compiler ) {
 					this.indent( [
 						"script.onerror = script.onload = script.onreadystatechange = null;",
 						"delete installedChunks[ chunkId ];",
-						"window.__chunkErrors[ " + JSON.stringify( chunkMaps.name ) + "[chunkId]||chunkId ]=new Error();",
+						"window.__chunkErrors[ chunkName ] = new Error( 'could not load ' + chunkName );",
 						"callback.call( null, " + this.requireFn + ")"
 					] ),
 					"};",
-					"script.src = " + this.requireFn + ".p + (" + JSON.stringify( chunkMaps.name ) + "[chunkId]||chunkId) + '.' + (" + JSON.stringify( chunkMaps.hash ) + "[chunkId]||chunkID) + ( isDebug ? '' : '.m' ) + '.js';",
+					"script.src = " + this.requireFn + ".p + ( chunkName ) + '.' + ( chunkHash ) + ( isDebug ? '' : '.m' ) + '.js';",
 					"head.appendChild( script );"
 				] ),
 				"}"


### PR DESCRIPTION
Today, when a chunk fails to load, especially a chunk loaded via `asyncRequire` set, the only indication is a console error, "Cannot read property 'call' of undefined" in the manifest. This happens more than one might think; any time we deploy code that changes a chunk hash, any clients that attempt to load the previous chunk hash will fail with a console error.

We used to have a mechanism to alert the user if a chunk load failed (see `client/layout/error.jsx`), but since we switched to requiring many chunks to load a given section, it stopped working. An attempt was made to fix it in e214f01f44121e5e0a01548f489fa362c007226e, but it appears that fix either never worked or has since stopped working.

We have a bit of a chicken-and-the-egg problem with that solution. It'll work if it has successfully loaded, but we can't really know if it's successfully loaded from here. 

An alternative, proposed here, is to try to reload the failed chunk once, and then reload the entire app if that fails, all contained within the loader itself. This has the advantage of being self-contained and not requiring any knowledge of what parts of the app are properly spun up and operating.

The downside is that it's a pretty heavy hammer.

Thoughts?