### PR TITLE
Site Settings: Apply non-strict comparison when determining dirty fields

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -80,7 +80,9 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 
 			// Compute the dirty fields by comparing the persisted and the current fields
 			const previousDirtyFields = this.props.dirtyFields;
-			const nextDirtyFields = previousDirtyFields.filter( field => ! isEqual( currentFields[ field ], persistedFields[ field ] ) );
+			/*eslint-disable eqeqeq*/
+			const nextDirtyFields = previousDirtyFields.filter( field => ! currentFields[ field ] == persistedFields[ field ] );
+			/*eslint-enable eqeqeq*/
 
 			// Update the dirty fields state without updating their values
 			if ( nextDirtyFields.length === 0 ) {

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -81,7 +81,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			// Compute the dirty fields by comparing the persisted and the current fields
 			const previousDirtyFields = this.props.dirtyFields;
 			/*eslint-disable eqeqeq*/
-			const nextDirtyFields = previousDirtyFields.filter( field => ! currentFields[ field ] == persistedFields[ field ] );
+			const nextDirtyFields = previousDirtyFields.filter( field => ! ( currentFields[ field ] == persistedFields[ field ] ) );
 			/*eslint-enable eqeqeq*/
 
 			// Update the dirty fields state without updating their values


### PR DESCRIPTION
This PR fixes #11682, where the "Unsaved changes" alert is being wrongly displayed on various occasions. 

The issue is caused by the fact that:
* Toggles expect and use boolean values - `true` and `false`. They can, of course, work with other values that evaluate as truthy/falsy - `0` and `1` for example.
* Settings APIs can return `""` instead of `false` on multiple fields, because this is the default behavior of theme options in WordPress. 
* If the previous state of a toggle was `false`, but now the API returns `""`, they are considered as different values, because we compare them strictly. This causes the dirty fields computation to fail, triggering an Unsaved Changes alert on `unload`.

The solution that is proposed in this PR is a little hacky (non-strict equality checks are not recommended anymore), but will work for the time being, and will handle all of the cases I described above.

A better solution we can consider in the future is to normalize all fields when they arrive from the APIs - this would require substantial testing to make sure we're not introducing any regressions. As this would require more time to pull off, I suggest we go with the solution that's proposed with this PR, because the alert can be really uncomfortable for the users.

To test:
* Checkout this branch
* Go to `/settings/general/$site`
* Update your Related Post settings, and click Save.
* Try to navigate away from the page.
* Verify that no alert is being displayed.
* Test this with more toggles on all other settings sections.