### PR TITLE
Site Settings: Lowercase copy in JetpackDevModeNotice

### DIFF
--- a/client/my-sites/site-settings/jetpack-dev-mode-notice.jsx
+++ b/client/my-sites/site-settings/jetpack-dev-mode-notice.jsx
@@ -26,7 +26,7 @@ const JetpackDevModeNotice = ( {
 			{
 				isJetpackSiteInDevMode &&
 				<Notice
-					text={ translate( 'Some features are disabled because your site is in Development mode.' ) }
+					text={ translate( 'Some features are disabled because your site is in development mode.' ) }
 					showDismiss={ false }
 				>
 					<NoticeAction href={ 'https://jetpack.com/support/development-mode/' } external>


### PR DESCRIPTION
This PR lowercases `Development` in the notice that we display when Development mode is on, as suggested in https://github.com/Automattic/wp-calypso/pull/11386#issuecomment-285092588.

Preview:

![](https://cldup.com/oHiZ9LrSmT.png)
