### PR TITLE
Site Settings: Move migrate followers link to Subscriptions card

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -638,9 +638,6 @@ class SiteSettingsFormGeneral extends Component {
 						<CompactCard href={ '../security/' + site.slug }>
 							{ translate( 'View Jetpack Monitor Settings' ) }
 						</CompactCard>
-						<CompactCard href={ 'https://wordpress.com/manage/' + site.ID }>
-							{ translate( 'Migrate followers from another WordPress.com blog' ) }
-						</CompactCard>
 					</div>
 					: null }
 			</div>

--- a/client/my-sites/site-settings/subscriptions/index.jsx
+++ b/client/my-sites/site-settings/subscriptions/index.jsx
@@ -77,6 +77,10 @@ const Subscriptions = ( {
 			<CompactCard href={ '/people/email-followers/' + selectedSiteSlug }>
 				{ translate( 'View your Email Followers' ) }
 			</CompactCard>
+
+			<CompactCard href={ 'https://wordpress.com/manage/' + selectedSiteId }>
+				{ translate( 'Migrate followers from another WordPress.com blog' ) }
+			</CompactCard>
 		</div>
 	);
 };

--- a/client/my-sites/site-settings/subscriptions/index.jsx
+++ b/client/my-sites/site-settings/subscriptions/index.jsx
@@ -79,7 +79,7 @@ const Subscriptions = ( {
 			</CompactCard>
 
 			<CompactCard href={ 'https://wordpress.com/manage/' + selectedSiteId }>
-				{ translate( 'Migrate followers from another WordPress.com blog' ) }
+				{ translate( 'Migrate followers from another site' ) }
 			</CompactCard>
 		</div>
 	);


### PR DESCRIPTION
This PR moves the "Migrate followers" link from the General tab to the Subscriptions card where it belongs. Fixes #11892.

Preview:

![](https://cldup.com/lvyUAai77o.png)

To test:
* Checkout this branch
* Go to `/settings/discussion/$site` where `$site` is a Jetpack site.
* Verify the "Migrate followers from another WordPress.com blog" link is at the bottom of the Subscriptions card, as shown on the preview.
* Verify the links is no longer at the bottom of the "Jetpack" card in the "General" settings section.
* Verify the link works like it did before.

