### PR TITLE
Reader: decode entities in author name for post card byline

### DIFF
--- a/client/blocks/reader-author-link/index.jsx
+++ b/client/blocks/reader-author-link/index.jsx
@@ -36,7 +36,7 @@ const ReaderAuthorLink = ( { author, post, siteUrl, children, className } ) => {
 
 	// If we have neither author.URL or siteUrl, just return children in a wrapper
 	if ( ! siteUrl ) {
-		return ( <span className={ classes }>{children}</span> );
+		return ( <span className={ classes }>{ children }</span> );
 	}
 
 	return (

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -21,6 +21,7 @@ import ReaderSiteStreamLink from 'blocks/reader-site-stream-link';
 import { getStreamUrl } from 'reader/route';
 import ReaderAuthorLink from 'blocks/reader-author-link';
 import { areEqualIgnoringWhitespaceAndCase } from 'lib/string';
+import { decodeEntities } from 'lib/formatting';
 
 class PostByline extends React.Component {
 
@@ -79,7 +80,7 @@ class PostByline extends React.Component {
 							author={ post.author }
 							siteUrl={ streamUrl }
 							post={ post }>
-							{ post.author.name }
+							{ decodeEntities( post.author.name ) }
 						</ReaderAuthorLink>
 						}
 						{ shouldDisplayAuthor && showSiteName && ', ' }

--- a/client/lib/formatting/index.js
+++ b/client/lib/formatting/index.js
@@ -3,11 +3,7 @@
  */
 import { keys, trim } from 'lodash';
 import stripTags from 'striptags';
-
-/**
- * Internal Dependencies
- */
-import decode from './decode-entities';
+import { decode } from 'he';
 
 function decodeEntities( text ) {
 	// Bypass decode if text doesn't include entities

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -34,7 +34,7 @@
       "version": "0.8.1"
     },
     "ajv": {
-      "version": "4.11.4"
+      "version": "4.11.5"
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -121,7 +121,7 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.9.5"
+      "version": "0.9.6"
     },
     "async": {
       "version": "0.9.0"
@@ -174,7 +174,7 @@
       "dev": true
     },
     "babel-generator": {
-      "version": "6.23.0",
+      "version": "6.24.0",
       "dependencies": {
         "source-map": {
           "version": "0.5.6"
@@ -299,7 +299,7 @@
       "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.23.0"
+      "version": "6.24.0"
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.22.0"
@@ -536,7 +536,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000632"
+      "version": "1.0.30000634"
     },
     "caseless": {
       "version": "0.12.0"
@@ -596,7 +596,7 @@
       "version": "1.0.1"
     },
     "chrono-node": {
-      "version": "1.2.5"
+      "version": "1.3.1"
     },
     "circular-json": {
       "version": "0.3.1",
@@ -1067,7 +1067,7 @@
       "version": "0.1.12"
     },
     "end-of-stream": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "once": {
           "version": "1.3.3"
@@ -1161,7 +1161,7 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.12",
+      "version": "0.10.13",
       "dev": true
     },
     "es6-iterator": {
@@ -1604,7 +1604,7 @@
       "version": "1.0.0"
     },
     "fstream": {
-      "version": "1.0.10"
+      "version": "1.0.11"
     },
     "function-bind": {
       "version": "1.1.0"
@@ -1768,7 +1768,7 @@
       "version": "3.1.3"
     },
     "he": {
-      "version": "0.5.0"
+      "version": "1.1.1"
     },
     "hoek": {
       "version": "2.16.3"
@@ -1940,7 +1940,7 @@
       "version": "1.0.1"
     },
     "is-buffer": {
-      "version": "1.1.4"
+      "version": "1.1.5"
     },
     "is-builtin-module": {
       "version": "1.0.0"
@@ -2653,7 +2653,7 @@
       "version": "3.0.6"
     },
     "normalize-package-data": {
-      "version": "2.3.5"
+      "version": "2.3.6"
     },
     "normalize-path": {
       "version": "2.0.1"
@@ -3175,7 +3175,7 @@
       "dev": true
     },
     "recast": {
-      "version": "0.11.22",
+      "version": "0.11.23",
       "dependencies": {
         "source-map": {
           "version": "0.5.6"
@@ -3240,10 +3240,13 @@
       "version": "2.0.1"
     },
     "request": {
-      "version": "2.80.0",
+      "version": "2.81.0",
       "dependencies": {
         "qs": {
-          "version": "6.3.2"
+          "version": "6.4.0"
+        },
+        "tunnel-agent": {
+          "version": "0.6.0"
         },
         "uuid": {
           "version": "3.0.1"
@@ -3352,6 +3355,9 @@
     "rx-lite": {
       "version": "3.1.2",
       "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.0.1"
     },
     "samsam": {
       "version": "1.1.2",
@@ -4342,7 +4348,7 @@
       "dev": true
     },
     "webpack-sources": {
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "source-map": {
           "version": "0.5.6"
@@ -4479,7 +4485,7 @@
       "version": "3.2.1"
     },
     "yallist": {
-      "version": "2.0.0"
+      "version": "2.1.1"
     },
     "yargs": {
       "version": "3.10.0"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "get-video-id": "2.1.0",
     "gridicons": "1.0.0",
     "hard-source-webpack-plugin": "0.0.42",
-    "he": "0.5.0",
+    "he": "1.1.1",
     "html-loader": "0.4.0",
     "i18n-calypso": "1.7.0",
     "immutable": "3.7.6",


### PR DESCRIPTION
In the Reader post card byline, @eurello reported that the author name for some feeds contained undecoded HTML entities:

<img width="347" alt="screen shot 2017-03-10 at 15 18 41" src="https://cloud.githubusercontent.com/assets/17325/23800587/e302717a-05a4-11e7-86ba-00eae74dca83.png">

This PR adds decoding of entities in the author name before display.

Fixes https://github.com/Automattic/wp-calypso/issues/10574.

### To test

Try http://calypso.localhost:3000/read/feeds/62384476 and verify that the author name appears as below:

<img width="546" alt="screen shot 2017-03-10 at 15 19 36" src="https://cloud.githubusercontent.com/assets/17325/23800613/fe6c2a14-05a4-11e7-80f4-a4a0c3cfffff.png">


