### PR TITLE
Masterbar: add title attribute to recent drafts button.

### DIFF
--- a/client/layout/masterbar/drafts.jsx
+++ b/client/layout/masterbar/drafts.jsx
@@ -64,7 +64,7 @@ class MasterbarDrafts extends Component {
 			<div>
 				<QueryPostCounts siteId={ selectedSite.ID } type="post" />
 				{ this.props.draftCount > 0 &&
-					<Button compact borderless className="masterbar__toggle-drafts" onClick={ this.toggleDrafts } ref="drafts">
+					<Button compact borderless className="masterbar__toggle-drafts" onClick={ this.toggleDrafts } ref="drafts" title={ translate( 'Latest Drafts' ) }>
 						<Count count={ this.props.draftCount } />
 					</Button>
 				}


### PR DESCRIPTION
Adds a title to the drafts number for context around what I'm about to click.

![draft-title](https://cloud.githubusercontent.com/assets/942359/23800850/e6c23986-057b-11e7-915e-9cb0f752517b.gif)
