### PR TITLE
Theme Helpers: Remove obsolete getDetailsUrl() helper

### DIFF
--- a/client/me/purchases/product-link/index.jsx
+++ b/client/me/purchases/product-link/index.jsx
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import i18n from 'i18n-calypso';
 
 /**
@@ -9,11 +10,11 @@ import i18n from 'i18n-calypso';
  */
 import config from 'config';
 import { domainManagementEdit } from 'my-sites/upgrades/paths';
-import { getDetailsUrl as getThemeDetailsUrl } from 'my-sites/themes/helpers';
+import { getThemeDetailsUrl } from 'state/themes/selectors';
 import { googleAppsSettingsUrl } from 'lib/google-apps';
 import { isDomainProduct, isGoogleApps, isPlan, isSiteRedirect, isTheme } from 'lib/products-values';
 
-const ProductLink = ( { selectedPurchase, selectedSite } ) => {
+const ProductLink = ( { selectedPurchase, selectedSite, productUrl } ) => {
 	let props = {},
 		url,
 		text;
@@ -38,7 +39,7 @@ const ProductLink = ( { selectedPurchase, selectedSite } ) => {
 	}
 
 	if ( isTheme( selectedPurchase ) ) {
-		url = getThemeDetailsUrl( { id: selectedPurchase.meta }, { slug: selectedPurchase.domain } );
+		url = productUrl;
 		text = i18n.translate( 'Theme Details' );
 
 		if ( ! config.isEnabled( 'manage/themes/details' ) ) {
@@ -65,4 +66,13 @@ ProductLink.propTypes = {
 	] )
 };
 
-export default ProductLink;
+export default connect(
+	( state, { selectedPurchase } ) => {
+		if ( isTheme( selectedPurchase ) ) {
+			return {
+				// No <QueryTheme /> component needed, since getThemeDetailsUrl() only needs the themeId which we pass here.
+				productUrl: getThemeDetailsUrl( state, selectedPurchase.meta, selectedPurchase.siteId )
+			};
+		}
+	}
+)( ProductLink );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -42,6 +42,7 @@ import {
 	isThemePremium,
 	isPremiumThemeAvailable,
 	isWpcomTheme as isThemeWpcom,
+	getThemeDetailsUrl,
 	getThemeRequestErrors,
 	getThemeForumUrl,
 } from 'state/themes/selectors';
@@ -508,11 +509,10 @@ const ThemeSheet = React.createClass( {
 		const analyticsPath = `/theme/:slug${ section ? '/' + section : '' }${ siteID ? '/:site_id' : '' }`;
 		const analyticsPageTitle = `Themes > Details Sheet${ section ? ' > ' + titlecase( section ) : '' }${ siteID ? ' > Site' : '' }`;
 
-		const { name: themeName, description, currentUserId } = this.props;
+		const { canonicalUrl, currentUserId, description, name: themeName } = this.props;
 		const title = themeName && i18n.translate( '%(themeName)s Theme', {
 			args: { themeName }
 		} );
-		const canonicalUrl = `https://wordpress.com/theme/${ this.props.id }`; // TODO: use getDetailsUrl() When it becomes availavle
 
 		const metas = [
 			{ property: 'og:url', content: canonicalUrl },
@@ -684,6 +684,7 @@ export default connect(
 			isPremium: isThemePremium( state, id ),
 			isPurchased: selectedSite && isPremiumThemeAvailable( state, id, selectedSite.ID ),
 			forumUrl: getThemeForumUrl( state, id, selectedSite && selectedSite.ID ),
+			canonicalUrl: getThemeDetailsUrl( state, id ) // No siteId specified since we want the *canonical* URL :-)
 		};
 	},
 	{

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -12,25 +12,11 @@ import mapValues from 'lodash/mapValues';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import { sectionify } from 'lib/route/path';
 import { oldShowcaseUrl } from 'state/themes/utils';
 
 export function getPreviewUrl( theme ) {
 	return `${ theme.demo_uri }?demo=true&iframe=true&theme_preview=true`;
-}
-
-export function getDetailsUrl( theme, site ) {
-	if ( site && site.jetpack ) {
-		return site.options.admin_url + 'themes.php?theme=' + theme.id;
-	}
-
-	let baseUrl = oldShowcaseUrl + theme.id;
-	if ( config.isEnabled( 'manage/themes/details' ) ) {
-		baseUrl = `/theme/${ theme.id }`;
-	}
-
-	return baseUrl + ( site ? `/${ site.slug }` : '' );
 }
 
 export function getExternalThemesUrl( site ) {


### PR DESCRIPTION
Affects almost only the `ProductLink` component; and the theme sheet, which now uses the `getThemeDetailsUrl()` selector (and was computing `canonicalUrl` itself before).

To test:
* Theme Sheet: Logged-out, check the page source for the `<meta property="og:url" ... />` tag
* Product Link:
  * Go to http://calypso.localhost:3000/me/purchases
  * Select any theme purchase
  * Check the "Theme Details" link -- it should point to the theme sheet for the given site.

![image](https://cloud.githubusercontent.com/assets/96308/23806790/6704dee0-05c3-11e7-9574-11c6b4212409.png)
