### PR TITLE
Themes: Add error message for theme activation

### DIFF
--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -46,6 +46,7 @@ import {
 	SITE_FRONT_PAGE_SET_FAILURE,
 	THEME_DELETE_FAILURE,
 	THEME_DELETE_SUCCESS,
+	THEME_ACTIVATE_REQUEST_FAILURE,
 } from 'state/action-types';
 
 import { dispatchSuccess, dispatchError } from './utils';
@@ -228,6 +229,7 @@ export const handlers = {
 	[ SITE_FRONT_PAGE_SET_FAILURE ]: dispatchError( translate( 'An error occurred while setting the homepage' ) ),
 	[ THEME_DELETE_FAILURE ]: onThemeDeleteFailure,
 	[ THEME_DELETE_SUCCESS ]: onThemeDeleteSuccess,
+	[ THEME_ACTIVATE_REQUEST_FAILURE ]: dispatchError( translate( 'Theme not yet available for this site' ) ),
 };
 
 /**

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { truncate } from 'lodash';
+import { truncate, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -184,6 +184,13 @@ const onThemeDeleteFailure = ( dispatch, { themeId } ) => dispatch(
 	} ) )
 );
 
+const onThemeActivateFailure = ( dispatch, { error } ) => {
+	if ( includes( error.error, 'theme_not_found' ) ) {
+		return dispatch( errorNotice( translate( 'Theme not yet available for this site' ) ) );
+	}
+	return dispatch( errorNotice( translate( 'Unable to activate theme. Contact support.' ) ) );
+};
+
 /**
  * Handler action type mapping
  */
@@ -229,7 +236,7 @@ export const handlers = {
 	[ SITE_FRONT_PAGE_SET_FAILURE ]: dispatchError( translate( 'An error occurred while setting the homepage' ) ),
 	[ THEME_DELETE_FAILURE ]: onThemeDeleteFailure,
 	[ THEME_DELETE_SUCCESS ]: onThemeDeleteSuccess,
-	[ THEME_ACTIVATE_REQUEST_FAILURE ]: dispatchError( translate( 'Theme not yet available for this site' ) ),
+	[ THEME_ACTIVATE_REQUEST_FAILURE ]: onThemeActivateFailure,
 };
 
 /**


### PR DESCRIPTION
<img width="963" alt="screen shot 2017-03-10 at 17 40 22" src="https://cloud.githubusercontent.com/assets/7767559/23806413/7bc5083c-05b9-11e7-977f-431b8785c9a1.png">

The only known case we have of activation failure is when a theme is not yet available for download from wpcom, therefore installation fails on Jetpack. Show a message to this effect.

**To Test**
* Go to http://calypso.localhost:3000/design
* Choose a Jetpack site
* Install _Twenty Sixteen_

**Expected**
* Error notice shows

**Note** Installation of default themes that have no wpcom download such as _Twenty Sixteen_ will be fixed in another PR. The use case of this PR is for brand new themes for which the zip is not yet available.


