### PR TITLE
Plugins: Fix banner icon alignment in AT eligibility

### DIFF
--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -29,6 +29,7 @@
 .eligibility-warnings .banner {
 	margin-bottom: 16px;
 	.banner__icon-circle {
+		line-height: 32px;
 		padding: 4px;
 	}
 }


### PR DESCRIPTION
Fix vertical positioning of the `Banner` icon.

| Before | After |
| --- | --- |
| ![gridiconissue_1024](https://cloud.githubusercontent.com/assets/2070010/23806449/a6d4729c-05b9-11e7-960a-f35ae4067448.png) | <img width="416" alt="screen shot 2017-03-10 at 17 42 03" src="https://cloud.githubusercontent.com/assets/2070010/23806310/1c25c326-05b9-11e7-9c12-6bb6cc4748b3.png"> |

cc @folletto 
Apparently this is not the first time the `Banner` icon misalignes.
This time I fixed it by setting the circle `line-height` = its `height` (`32px`). The other time it wasn't my fix, but it involved `line-height` as well.
I'd say it could be worth it applying `line-height: 32px` directly in the `Banner` component style.
Do you by any chance remember what was it the other time?