### PR TITLE
Directly: Go to the /help page after submitting a questions

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -197,6 +197,8 @@ const HelpContact = React.createClass( {
 		);
 
 		this.clearSavedContactForm();
+
+		page( '/help' );
 	},
 
 	submitKayakoTicket: function( contactForm ) {


### PR DESCRIPTION
Does what it says on the tin! This mimics Happychat's behavior.

Before this PR, once you ask a question the Directly widget pops up but the question form remains unchanged. This can be confusing. We investigated changing the form to a confirmation message, but the Directly widget overlaps the message on most screen sizes. So we'll handle this the way Happychat does by redirecting the user to /help (with the open Directly widget) after a question is asked in the form.

### To test

- Open http://calypso.localhost:3000/help/contact as a user with no paid upgrades.
- Ask a question in the form and submit by pressing "Ask an Expert"
- The Directly widget should appear
- You should also be redirected to the /help page