### PR TITLE
Themes: Add getThemeDemoUrl selector, drop getPreviewUrl helper 

### DIFF
--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -1,8 +1,4 @@
 /**
- * DEPRECATED. Use client/state/themes/selectors instead.
- */
-
-/**
  * External dependencies
  */
 import analytics from 'lib/analytics';

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -15,10 +15,6 @@ import mapValues from 'lodash/mapValues';
 import { sectionify } from 'lib/route/path';
 import { oldShowcaseUrl } from 'state/themes/utils';
 
-export function getPreviewUrl( theme ) {
-	return `${ theme.demo_uri }?demo=true&iframe=true&theme_preview=true`;
-}
-
 export function getExternalThemesUrl( site ) {
 	if ( ! site ) {
 		return oldShowcaseUrl;

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -29,10 +29,14 @@ const ThemePreview = React.createClass( {
 	displayName: 'ThemePreview',
 
 	propTypes: {
-		themeOptions: React.PropTypes.object,
-		isActive: React.PropTypes.bool,
-		isInstalling: React.PropTypes.bool,
-		onClose: React.PropTypes.func,
+		// connected props
+		demoUrl: PropTypes.string,
+		isActivating: PropTypes.bool,
+		isActive: PropTypes.bool,
+		isInstalling: PropTypes.bool,
+		isJetpack: PropTypes.bool,
+		themeId: PropTypes.string,
+		themeOptions: PropTypes.object,
 	},
 
 	getInitialState() {

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -13,6 +13,7 @@ import PulsingDot from 'components/pulsing-dot';
 import QueryTheme from 'components/data/query-theme';
 import { connectOptions } from './theme-options';
 import {
+	getThemeDemoUrl,
 	getThemePreviewThemeOptions,
 	getCanonicalTheme,
 	themePreviewVisibility,
@@ -20,7 +21,6 @@ import {
 	isInstallingTheme,
 	isActivatingTheme
 } from 'state/themes/selectors';
-import { getPreviewUrl } from 'my-sites/themes/helpers';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { hideThemePreview } from 'state/themes/actions';
@@ -108,13 +108,13 @@ const ThemePreview = React.createClass( {
 		return (
 			<div>
 				{ this.props.isJetpack && <QueryTheme themeId={ themeId } siteId="wporg" /> }
-				{ this.props.previewUrl && <WebPreview
+				{ this.props.demoUrl && <WebPreview
 					showPreview={ true }
 					showExternal={ true }
 					showSEO={ false }
 					onClose={ this.props.hideThemePreview }
-					previewUrl={ this.props.previewUrl }
-					externalUrl={ this.props.theme.demo_uri } >
+					previewUrl={ this.props.demoUrl + '?demo=true&iframe=true&theme_preview=true' }
+					externalUrl={ this.props.demoUrl } >
 					{ showActionIndicator && <PulsingDot active={ true } /> }
 					{ ! showActionIndicator && this.renderSecondaryButton() }
 					{ ! showActionIndicator && this.renderPrimaryButton() }
@@ -147,7 +147,7 @@ export default connect(
 			isInstalling: isInstallingTheme( state, themeId, siteId ),
 			isActive: isThemeActive( state, themeId, siteId ),
 			isActivating: isActivatingTheme( state, siteId ),
-			previewUrl: theme && theme.demo_uri ? getPreviewUrl( theme ) : null,
+			demoUrl: getThemeDemoUrl( state, themeId, siteId ),
 			options: [
 				'activate',
 				'preview',

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -15,7 +15,6 @@ import { connectOptions } from './theme-options';
 import {
 	getThemeDemoUrl,
 	getThemePreviewThemeOptions,
-	getCanonicalTheme,
 	themePreviewVisibility,
 	isThemeActive,
 	isInstallingTheme,
@@ -30,7 +29,6 @@ const ThemePreview = React.createClass( {
 	displayName: 'ThemePreview',
 
 	propTypes: {
-		theme: React.PropTypes.object,
 		themeOptions: React.PropTypes.object,
 		isActive: React.PropTypes.bool,
 		isInstalling: React.PropTypes.bool,
@@ -55,13 +53,13 @@ const ThemePreview = React.createClass( {
 
 	onPrimaryButtonClick() {
 		const option = this.getPrimaryOption();
-		option.action && option.action( this.props.theme.id );
+		option.action && option.action( this.props.themeId );
 		! this.props.isJetpack && this.props.hideThemePreview();
 	},
 
 	onSecondaryButtonClick() {
 		const secondary = this.getSecondaryOption();
-		secondary.action && secondary.action( this.props.theme.id );
+		secondary.action && secondary.action( this.props.themeId );
 		! this.props.isJetpack && this.props.hideThemePreview();
 	},
 
@@ -76,7 +74,7 @@ const ThemePreview = React.createClass( {
 
 	renderPrimaryButton() {
 		const primaryOption = this.getPrimaryOption();
-		const buttonHref = primaryOption.getUrl ? primaryOption.getUrl( this.props.theme.id ) : null;
+		const buttonHref = primaryOption.getUrl ? primaryOption.getUrl( this.props.themeId ) : null;
 
 		return (
 			<Button primary onClick={ this.onPrimaryButtonClick } href={ buttonHref } >
@@ -90,7 +88,7 @@ const ThemePreview = React.createClass( {
 		if ( ! secondaryButton ) {
 			return;
 		}
-		const buttonHref = secondaryButton.getUrl ? secondaryButton.getUrl( this.props.theme.id ) : null;
+		const buttonHref = secondaryButton.getUrl ? secondaryButton.getUrl( this.props.themeId ) : null;
 		return (
 			<Button onClick={ this.onSecondaryButtonClick } href={ buttonHref } >
 				{ secondaryButton.extendedLabel }
@@ -136,12 +134,9 @@ export default connect(
 
 		const siteId = getSelectedSiteId( state );
 		const isJetpack = isJetpackSite( state, siteId );
-		const theme = getCanonicalTheme( state, siteId, themeId );
 		const themeOptions = getThemePreviewThemeOptions( state );
 		return {
 			themeId,
-			theme,
-			siteId,
 			isJetpack,
 			themeOptions,
 			isInstalling: isInstallingTheme( state, themeId, siteId ),

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -477,6 +477,19 @@ export function getThemeSignupUrl( state, themeId ) {
 }
 
 /**
+ * Returns the URL for a theme's demo.
+ *
+ * @param  {Object}  state   Global state tree
+ * @param  {String}  themeId Theme ID
+ * @param  {String}  siteId  Site ID
+ * @return {?String}         Theme forum URL
+ */
+export function getThemeDemoUrl( state, themeId, siteId ) {
+	const theme = getCanonicalTheme( state, siteId, themeId );
+	return get( theme, 'demo_uri' );
+}
+
+/**
  * Returns the URL for a premium theme's dedicated forum, or for the general themes
  * forum for a free theme.
  *

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -25,6 +25,7 @@ import {
 	getThemePurchaseUrl,
 	getThemeCustomizeUrl,
 	getThemeSignupUrl,
+	getThemeDemoUrl,
 	getThemeForumUrl,
 	getActiveTheme,
 	isRequestingActiveTheme,
@@ -1396,6 +1397,58 @@ describe( 'themes selectors', () => {
 			);
 
 			expect( signupUrl ).to.equal( '/start/with-theme?ref=calypshowcase&theme=mood&premium=true' );
+		} );
+	} );
+
+	describe( '#getThemeDemoUrl', () => {
+		it( 'with a theme not found on WP.com nor on WP.org, should return null', () => {
+			const demoUrl = getThemeDemoUrl( {
+				themes: {
+					queries: {}
+				}
+			}, 'twentysixteen', 2916284 );
+
+			expect( demoUrl ).to.be.undefined;
+		} );
+
+		it( 'with a theme found on WP.com, should return that object\'s demo_uri field', () => {
+			const demoUrl = getThemeDemoUrl( {
+				themes: {
+					queries: {
+						wpcom: new ThemeQueryManager( {
+							items: { twentysixteen }
+						} ),
+					}
+				}
+			}, 'twentysixteen', 2916284 );
+
+			expect( demoUrl ).to.deep.equal( 'https://twentysixteendemo.wordpress.com/' );
+		} );
+
+		it( 'with a theme found on WP.org but not on WP.com, should return that object\'s demo_uri field', () => {
+			const wporgTheme = {
+				id: 'twentyseventeen',
+				name: 'Twenty Seventeen',
+				author: 'the WordPress team',
+				demo_uri: 'https://wp-themes.com/twentyseventeen',
+				download: 'http://downloads.wordpress.org/theme/twentyseventeen.1.1.zip',
+				taxonomies: {
+					theme_feature: {
+						'custom-header': 'Custom Header'
+					}
+				}
+			};
+			const demoUrl = getThemeDemoUrl( {
+				themes: {
+					queries: {
+						wporg: new ThemeQueryManager( {
+							items: { twentyseventeen: wporgTheme }
+						} ),
+					}
+				}
+			}, 'twentyseventeen', 2916284 );
+
+			expect( demoUrl ).to.deep.equal( 'https://wp-themes.com/twentyseventeen' );
 		} );
 	} );
 


### PR DESCRIPTION
This removes the last `get...Url` helper from `my-sites/themes/helpers` (after #12018) in favor of a selector.

To test: Live Demo -- from both list and sheet, in different modes, and for WP.com and WP.org themes (on a JP site).

Also, ignore that matticbot says that this is a size L PR -- it's clearly lying 😄 