### PR TITLE
Enable accessibility rules for eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
 	},
 	rules: {
 		camelcase: 0, // REST API objects include underscores
+		'jsx-a11y/label-has-for': 0, // Allow nested labels, which don't use `for`
 		'max-len': [ 2, { code: 140 } ],
 		'no-restricted-imports': [ 2, 'lib/sites-list', 'lib/mixins/data-observe' ],
 		'no-restricted-modules': [ 2, 'lib/sites-list', 'lib/mixins/data-observe' ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
 	root: true,
-	'extends': 'wpcalypso/react',
+	'extends': 'wpcalypso/react-a11y',
 	parser: 'babel-eslint',
 	env: {
 		browser: true,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -69,6 +69,10 @@
       "version": "1.0.9",
       "dev": true
     },
+    "aria-query": {
+      "version": "0.3.0",
+      "dev": true
+    },
     "arr-diff": {
       "version": "2.0.0"
     },
@@ -122,6 +126,10 @@
     },
     "ast-types": {
       "version": "0.9.6"
+    },
+    "ast-types-flow": {
+      "version": "0.0.7",
+      "dev": true
     },
     "async": {
       "version": "0.9.0"
@@ -858,6 +866,10 @@
       "version": "1.0.0",
       "dev": true
     },
+    "damerau-levenshtein": {
+      "version": "1.0.3",
+      "dev": true
+    },
     "dashdash": {
       "version": "1.14.1",
       "dependencies": {
@@ -1049,6 +1061,10 @@
     },
     "emitter-component": {
       "version": "1.0.0"
+    },
+    "emoji-regex": {
+      "version": "6.4.1",
+      "dev": true
     },
     "emoji-text": {
       "version": "0.2.6"
@@ -1338,7 +1354,11 @@
       }
     },
     "eslint-config-wpcalypso": {
-      "version": "0.6.0",
+      "version": "0.7.1",
+      "dev": true
+    },
+    "eslint-plugin-jsx-a11y": {
+      "version": "4.0.0",
       "dev": true
     },
     "eslint-plugin-react": {

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "esformatter-special-bangs": "1.0.1",
     "eslines": "0.0.11",
     "eslint": "3.8.1",
-    "eslint-config-wpcalypso": "0.6.0",
+    "eslint-config-wpcalypso": "0.7.1",
     "eslint-plugin-jsx-a11y": "4.0.0",
     "eslint-plugin-react": "6.4.1",
     "eslint-plugin-wpcalypso": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
     "eslines": "0.0.11",
     "eslint": "3.8.1",
     "eslint-config-wpcalypso": "0.6.0",
+    "eslint-plugin-jsx-a11y": "4.0.0",
     "eslint-plugin-react": "6.4.1",
     "eslint-plugin-wpcalypso": "3.0.2",
     "glob": "7.0.3",


### PR DESCRIPTION
This PR adds the accessibility configuration added to eslint-config-calypso in https://github.com/Automattic/eslint-config-wpcalypso/pull/4. Currently implemented as warnings, the following issues are detected (count of issues in parens):

- [onclick-has-role](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/onclick-has-role) (113)
- [click-events-have-key-events](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/click-events-have-key-events) (112)
- [img-has-alt](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-has-alt) (46)
- [href-no-hash](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/href-no-hash) (40)
- [label-has-for](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for) (37)
- [heading-has-content](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/heading-has-content) (10)
- [tabindex-no-positive](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/tabindex-no-positive) (7)
- [no-onchange](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-onchange) (6)
- [mouse-events-have-key-events](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/mouse-events-have-key-events) (5)
- [iframe-has-title](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/iframe-has-title) (4)
- [role-supports-aria-props](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/role-supports-aria-props) (3)
- [onclick-has-focus](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/onclick-has-focus) (2)
- [role-has-required-aria-props](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/role-has-required-aria-props) (1)
- [accessible-emoji](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/accessible-emoji) (1)
- [html-has-lang](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/html-has-lang) (1)

From https://github.com/Automattic/eslint-config-wpcalypso/pull/4:

> This PR enables the [jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y) rules for ESLint. This will let us quickly check for a handful of accessibility issues common in javascript apps. It won't get us to 100% accessible, but it's a good step for awareness of these issues.

**To test**

1. Check out branch
2. `make install` to update modules
3. Run `npm run lint` to run only eslint, should see no errors
4. Run `npm run lint -- --quiet=false` to allow warnings, should see jsx-a11y warnings (you'll want to run this only on a subdirectory, `npm run lint client/my-sites/importer -- --quiet=false` triggers some accessibility warnings)

BTW @aduth — if I should ping someone else on this & the eslint PR, let me know :)