### PR TITLE
Editor: Disable animation effect for post content

### DIFF
--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -51,82 +51,22 @@
 }
 
 .post-editor__content {
-	margin: 0 auto;					// born centered, so when width collapses for sidebar anim it doesn't move
+	margin: 0 auto; // born centered, so when width collapses for sidebar anim it doesn't move
 	left: 0;
-	@include breakpoint( ">960px" ) {
-		animation: closedsidebar 0.15s cubic-bezier(0.075, 0.82, 0.165, 1) normal 1 forwards;
-	}
-	@include breakpoint( "<960px" ) {
-		animation: closedsidebar-min 0.15s cubic-bezier(0.075, 0.82, 0.165, 1) normal 1 forwards;
-	}
+	width: 100%;
 
 	.focus-sidebar & {
 		@include breakpoint( ">960px" ) {
-			animation: opensidebar 0.15s cubic-bezier(0.075, 0.82, 0.165, 1) normal 1 forwards;
-			width: calc( 100% - ( #{ $sidebar-width-max } ) );		// subtract sidebar width
+			left: ( $sidebar-width-max / -2 );
+			width: calc( 100% - ( #{ $sidebar-width-max } ) ); // subtract sidebar width
 		}
 
 		@include breakpoint( "<960px" ) {
-			animation: opensidebar-min 0.15s cubic-bezier(0.075, 0.82, 0.165, 1) normal 1 forwards;
-			width: calc( 100% - ( #{ $sidebar-width-min } ) );		// subtract sidebar width
+			left: ( $sidebar-width-min / -2 );
+			width: calc( 100% - ( #{ $sidebar-width-min } ) ); // subtract sidebar width
 		}
 	}
 }
-
-@keyframes opensidebar {
-	0% {
-		transform: translateX( 0 );
-	}
-	99.9% {
-		left: 0;
-		transform: translateX( -#{ $sidebar-width-max / 2 } );
-	}
-	100% {
-		left: -#{ $sidebar-width-max / 2 };
-		transform: none;
-	}
-}
-
-@keyframes closedsidebar {
-	0% {
-		transform: translateX( -#{ $sidebar-width-max / 2 } );
-	}
-	99.9% {
-		transform: translateX( 0 );
-	}
-	100% {
-		left: 0;
-		transform: none;
-	}
-}
-
-@keyframes opensidebar-min {
-	0% {
-		transform: translateX( 0 );
-	}
-	99.9% {
-		left: 0;
-		transform: translateX( -#{ $sidebar-width-min / 2 } );
-	}
-	100% {
-		left: -#{ $sidebar-width-min / 2 };
-		transform: none;
-	}
-}
-
-@keyframes closedsidebar-min {
-	0% {
-		transform: translateX( -#{ $sidebar-width-min / 2 } );
-	}
-	99.9% {
-		transform: translateX( 0 );
-	}
-	100% {
-		left: 0;
-		transform: none;
-	}
-}
-
 
 .post-editor__site {
 	display:  flex;

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -53,7 +53,6 @@
 .post-editor__content {
 	margin: 0 auto; // born centered, so when width collapses for sidebar anim it doesn't move
 	left: 0;
-	width: 100%;
 
 	.focus-sidebar & {
 		@include breakpoint( ">960px" ) {


### PR DESCRIPTION
This pull request seeks to resolve an issue where in Firefox the toolbar no longer pins to the top of the screen when scrolling beyond the top of the page. The cause for this issue is due to the behavior of the pinned toolbar applying `position: fixed`. However, Firefox is more spec-compliant in its treatment of translated elements, which create a new fixed positioning context. 

See also: http://stackoverflow.com/a/37953806

__Testing Instructions:__

1. Navigate to the [post editor](http://calypso.localhost:3000/post) in Firefox and in your preferred browser
2. Select a site, if prompted
3. Ensure the editor content is the correct width, with and without post settings sidebar toggled
4. Add enough text that the page scrolls ([courtesy lorem ipsum](http://lipsum.com/feed/html))
5. Scroll the page
6. Observe the toolbar pins to the top of the screen when beyond the top of viewport