### PR TITLE
Media Modal: <DetailFields /> component janitorial

### DIFF
--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -1,145 +1,151 @@
 /**
  * External dependencies
  */
-var ReactDom = require( 'react-dom' ),
-	React = require( 'react' ),
-	debounce = require( 'lodash/debounce' ),
-	assign = require( 'lodash/assign' ),
-	debug = require( 'debug' )( 'calypso:editor-media-modal' );
+import ReactDom from 'react-dom';
+import React, { Component, PropTypes } from 'react';
+import debounce from 'lodash/debounce';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
-var analytics = require( 'lib/analytics' ),
-	MediaUtils = require( 'lib/media/utils' ),
-	MediaActions = require( 'lib/media/actions' ),
-	ClipboardButtonInput = require( 'components/clipboard-button-input' ),
-	FormTextarea = require( 'components/forms/form-textarea' ),
-	FormTextInput = require( 'components/forms/form-text-input' ),
-	TrackInputChanges = require( 'components/track-input-changes' ),
-	EditorMediaModalFieldset = require( '../fieldset' );
+import analytics from 'lib/analytics';
+import MediaUtils from 'lib/media/utils';
+import MediaActions from 'lib/media/actions';
+import ClipboardButtonInput from 'components/clipboard-button-input';
+import FormTextarea from 'components/forms/form-textarea';
+import FormTextInput from 'components/forms/form-text-input';
+import TrackInputChanges from 'components/track-input-changes';
+import EditorMediaModalFieldset from '../fieldset';
 
-module.exports = React.createClass( {
-	displayName: 'EditorMediaModalDetailFields',
+class EditorMediaModalDetailFields extends Component {
+	static propTypes = {
+		site: PropTypes.object,
+		item: PropTypes.object
+	};
 
-	propTypes: {
-		site: React.PropTypes.object,
-		item: React.PropTypes.object
-	},
-
-	getInitialState: function() {
-		return {};
-	},
-
-	componentWillMount: function() {
+	constructor() {
+		super( ...arguments );
 		this.persistChange = debounce( this.persistChange, 1000 );
-	},
+	}
 
-	componentWillReceiveProps: function( nextProps ) {
-		if ( this.props.item && nextProps.item && nextProps.item.ID !== this.props.item.ID ) {
-			this.setState( {
-				modifiedItem: null
-			} );
-
+	componentWillReceiveProps( nextProps ) {
+		if (
+			this.props.item &&
+			nextProps.item &&
+			nextProps.item.ID !== this.props.item.ID
+		) {
+			this.setState( { modifiedItem: null } );
 			this.persistChange.cancel();
 		}
-	},
+	}
 
-	bumpStat: function( stat ) {
-		switch ( stat ) {
-			case 'alt':
-				analytics.ga.recordEvent( 'Media', 'Changed Image Alt' );
-				break;
+	bumpAltStat = () => {
+		analytics.ga.recordEvent( 'Media', 'Changed Image Alt' );
+		analytics.mc.bumpStat( 'calypso_media_edit_details', 'alt' );
+	};
 
-			case 'caption':
-				analytics.ga.recordEvent( 'Media', 'Changed Item Caption' );
-				break;
+	bumpCaptionStat = () => {
+		analytics.ga.recordEvent( 'Media', 'Changed Item Caption' );
+		analytics.mc.bumpStat( 'calypso_media_edit_details', 'caption' );
+	};
 
-			case 'description':
-				analytics.ga.recordEvent( 'Media', 'Changed Item Description' );
-				break;
-		}
+	bumpDescriptionStat = () => {
+		analytics.ga.recordEvent( 'Media', 'Changed Item Description' );
+		analytics.mc.bumpStat( 'calypso_media_edit_details', 'description' );
+	};
 
-		analytics.mc.bumpStat( 'calypso_media_edit_details', stat );
-	},
-
-	isMimePrefix: function( prefix ) {
+	isMimePrefix( prefix ) {
 		return MediaUtils.getMimePrefix( this.props.item ) === prefix;
-	},
+	}
 
-	persistChange: function() {
+	persistChange() {
 		if ( ! this.props.site || ! this.state.modifiedItem ) {
 			return;
 		}
 
-		debug( 'Update media to %o', this.state.modifiedItem );
 		MediaActions.update( this.props.site.ID, this.state.modifiedItem );
-	},
+	}
 
-	onChange: function( event ) {
-		var modifiedItem = assign( {
-			ID: this.props.item.ID
-		}, this.state.modifiedItem, {
-			[ event.target.name ]: event.target.value
-		} );
+	setFieldValue = ( { target } ) => {
+		const modifiedItem = Object.assign(
+			{ ID: this.props.item.ID },
+			get( this.state, 'modifiedItem', {} ),
+			{ [ target.name ]: target.value }
+		);
 
-		this.setState( {
-			modifiedItem: modifiedItem
-		} );
-
+		this.setState( { modifiedItem } );
 		this.persistChange();
-	},
+	};
 
-	getItemValue: function( attribute ) {
-		if ( this.state.modifiedItem && attribute in this.state.modifiedItem ) {
-			return this.state.modifiedItem[ attribute ];
+	getItemValue( attribute ) {
+		const modifiedValue = get( this.state, [ 'modifiedItem', attribute ], null );
+		if ( modifiedValue !== null ) {
+			return modifiedValue;
 		}
 
 		if ( this.props.item ) {
 			return this.props.item[ attribute ];
 		}
-	},
+	}
 
-	scrollToShowVisibleDropdown: function( event ) {
+	scrollToShowVisibleDropdown = ( event ) => {
 		if ( ! event.open || ! ( 'scrollIntoView' in window.Element.prototype ) ) {
 			return;
 		}
 
 		ReactDom.findDOMNode( event.target ).scrollIntoView();
-	},
+	}
 
-	renderImageAltText: function() {
+	renderImageAltText() {
 		if ( ! this.isMimePrefix( 'image' ) ) {
-			return;
+			return null;
 		}
 
 		return (
-			<EditorMediaModalFieldset legend={ this.translate( 'Alt text' ) }>
-				<TrackInputChanges onNewValue={ this.bumpStat.bind( this, 'alt' ) }>
-					<FormTextInput name="alt" value={ this.getItemValue( 'alt' ) } onChange={ this.onChange } />
+			<EditorMediaModalFieldset legend={ this.props.translate( 'Alt text' ) }>
+				<TrackInputChanges onNewValue={ this.bumpAltStat }>
+					<FormTextInput
+						name="alt"
+						value={ this.getItemValue( 'alt' ) }
+						onChange={ this.setFieldValue } />
 				</TrackInputChanges>
 			</EditorMediaModalFieldset>
 		);
-	},
+	}
 
-	render: function() {
+	render() {
+		const { translate } = this.props;
 		return (
 			<div className="editor-media-modal-detail__fields">
-				<EditorMediaModalFieldset legend={ this.translate( 'Caption' ) }>
-					<TrackInputChanges onNewValue={ this.bumpStat.bind( this, 'caption' ) }>
-						<FormTextarea name="caption" value={ this.getItemValue( 'caption' ) } onChange={ this.onChange } />
+				<EditorMediaModalFieldset legend={ translate( 'Caption' ) }>
+					<TrackInputChanges onNewValue={ this.bumpCaptionStat }>
+						<FormTextarea
+							name="caption"
+							value={ this.getItemValue( 'caption' ) }
+							onChange={ this.setFieldValue } />
 					</TrackInputChanges>
 				</EditorMediaModalFieldset>
+
 				{ this.renderImageAltText() }
-				<EditorMediaModalFieldset legend={ this.translate( 'Description' ) }>
-					<TrackInputChanges onNewValue={ this.bumpStat.bind( this, 'description' ) }>
-						<FormTextarea name="description" value={ this.getItemValue( 'description' ) } onChange={ this.onChange } />
+
+				<EditorMediaModalFieldset legend={ translate( 'Description' ) }>
+					<TrackInputChanges onNewValue={ this.bumpDescriptionStat }>
+						<FormTextarea
+							name="description"
+							value={ this.getItemValue( 'description' ) }
+							onChange={ this.setFieldValue } />
 					</TrackInputChanges>
 				</EditorMediaModalFieldset>
-				<EditorMediaModalFieldset legend={ this.translate( 'URL' ) }>
+
+				<EditorMediaModalFieldset legend={ translate( 'URL' ) }>
 					<ClipboardButtonInput value={ MediaUtils.url( this.props.item ) } />
 				</EditorMediaModalFieldset>
 			</div>
 		);
 	}
-} );
+}
+
+export default localize( EditorMediaModalDetailFields );
+


### PR DESCRIPTION
### Janitorial PR

This PR is part of the #11093 issue.

---------

This PR implements janitorial process in the `<DetailField />` component.

<img src="https://cloud.githubusercontent.com/assets/77539/23814873/0fae0e22-05c4-11e7-8e96-a2e2b2bda8ed.png" width="300px" />

Primary improvements:

- re-write component using ES class
- use localize() helper
- avoid binding function into a property
- rename methods trying to be more verbose
- several ESLint warnings, etc

### Testing

Open an item detail dialog.
Test to edit one of item fields: `Caption`, `Alt text` and `Description`
- You could take a look at the network tab paying attention to the requests triggered. It shouldn't trigger a request if the value doesn't change for instance
- Resize the viewport and scroll trying to hide an input and type there. It should be focused.
- Edit close and open the dialog once the changes are done.

Everything should be ok.
