### PR TITLE
Editor: Update `ref` syntax and hopefully fix a bug

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -142,7 +142,7 @@ export const PostEditor = React.createClass( {
 	componentDidMount: function() {
 		// if content is passed in, e.g., through url param
 		if ( this.state.post && this.state.post.content ) {
-			this.refs.editor.setEditorContent( this.state.post.content, { initial: true } );
+			this.editor.setEditorContent( this.state.post.content, { initial: true } );
 		}
 	},
 
@@ -170,6 +170,10 @@ export const PostEditor = React.createClass( {
 			( nextProps.siteId === siteId && nextProps.postId !== postId ) ) {
 			this.useDefaultSidebarFocus( nextProps );
 		}
+	},
+
+	storeEditor( ref ) {
+		this.editor = ref;
 	},
 
 	useDefaultSidebarFocus( nextProps ) {
@@ -307,7 +311,7 @@ export const PostEditor = React.createClass( {
 							</div>
 							<hr className="editor__header-divider" />
 							<TinyMCE
-								ref="editor"
+								ref={ this.storeEditor }
 								mode={ mode }
 								tabIndex={ 2 }
 								isNew={ this.state.isNew }
@@ -405,16 +409,12 @@ export const PostEditor = React.createClass( {
 			this.setState( { loadingError } );
 		} else if ( ( PostEditStore.isNew() && ! this.state.isNew ) || PostEditStore.isLoading() ) {
 			// is new or loading
-			this.setState( this.getInitialState(), function() {
-				this.refs.editor.setEditorContent( '' );
-			} );
+			this.setState( this.getInitialState(), () => this.editor && this.editor.setEditorContent( '' ) );
 		} else if ( this.state.isNew && this.state.hasContent && ! this.state.isDirty ) {
 			// Is a copy of an existing post.
 			// When copying a post, the created draft is new and the editor is not yet dirty, but it already has content.
 			// Once the content is set, the editor becomes dirty and the following setState won't trigger anymore.
-			this.setState( this.getInitialState(), function() {
-				this.refs.editor.setEditorContent( this.state.post.content );
-			} );
+			this.setState( this.getInitialState(), () => this.editor && this.editor.setEditorContent( this.state.post.content ) );
 		} else {
 			postEditState = this.getPostEditState();
 			post = postEditState.post;
@@ -424,8 +424,8 @@ export const PostEditor = React.createClass( {
 				page.redirect( utils.getEditURL( post, site ) );
 			}
 			this.setState( postEditState, function() {
-				if ( didLoad || this.state.isLoadingAutosave ) {
-					this.refs.editor.setEditorContent( this.state.post.content, { initial: true } );
+				if ( this.editor && ( didLoad || this.state.isLoadingAutosave ) ) {
+					this.editor.setEditorContent( this.state.post.content, { initial: true } );
 				}
 
 				if ( this.state.isLoadingAutosave ) {
@@ -451,12 +451,12 @@ export const PostEditor = React.createClass( {
 	onEditorFocus: function() {
 		// Fire a click when the editor is focused so that any global handlers have an opportunity to do their thing.
 		// In particular, this ensures that open popovers are closed when a user clicks into the editor.
-		ReactDom.findDOMNode( this.refs.editor ).click();
+		ReactDom.findDOMNode( this.editor ).click();
 	},
 
 	saveRawContent: function() {
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		actions.editRawContent( this.refs.editor.getContent( { format: 'raw' } ) );
+		actions.editRawContent( this.editor.getContent( { format: 'raw' } ) );
 	},
 
 	autosave: function() {
@@ -470,7 +470,7 @@ export const PostEditor = React.createClass( {
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		const edits = {
 			...this.props.edits,
-			content: this.refs.editor.getContent()
+			content: this.editor.getContent()
 		};
 		actions.edit( edits );
 
@@ -562,7 +562,7 @@ export const PostEditor = React.createClass( {
 			return;
 		}
 
-		edits.content = this.refs.editor.getContent();
+		edits.content = this.editor.getContent();
 
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		actions.saveEdited( edits, function( error ) {
@@ -607,7 +607,7 @@ export const PostEditor = React.createClass( {
 
 		if ( status === 'publish' ) {
 			// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-			actions.edit( { content: this.refs.editor.getContent() } );
+			actions.edit( { content: this.editor.getContent() } );
 			actions.autosave( previewPost );
 		} else {
 			this.onSave( null, previewPost );
@@ -660,7 +660,7 @@ export const PostEditor = React.createClass( {
 
 		// Update content on demand to avoid unnecessary lag and because it is expensive
 		// to serialize when TinyMCE is the active mode
-		edits.content = this.refs.editor.getContent();
+		edits.content = this.editor.getContent();
 
 		actions.saveEdited( edits, function( error ) {
 			if ( error && 'NO_CHANGE' !== error.message ) {
@@ -801,10 +801,10 @@ export const PostEditor = React.createClass( {
 	},
 
 	switchEditorMode: function( mode ) {
-		var content = this.refs.editor.getContent();
+		var content = this.editor.getContent();
 
 		if ( mode === 'html' ) {
-			this.refs.editor.setEditorContent( content );
+			this.editor.setEditorContent( content );
 		}
 
 		this.props.setEditorModePreference( mode );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -801,7 +801,7 @@ export const PostEditor = React.createClass( {
 	},
 
 	switchEditorMode: function( mode ) {
-		var content = this.editor.getContent();
+		const content = this.editor.getContent();
 
 		if ( mode === 'html' ) {
 			this.editor.setEditorContent( content );

--- a/client/post-editor/test/post-editor.jsx
+++ b/client/post-editor/test/post-editor.jsx
@@ -96,9 +96,9 @@ describe( 'PostEditor', function() {
 			const stub = sandbox.stub( PostEditStore, 'isNew' );
 			stub.returns( true );
 
-			tree.refs.editor.setEditorContent = sandbox.spy();
+			tree.editor.setEditorContent = sandbox.spy();
 			tree.onEditedPostChange();
-			expect( tree.refs.editor.setEditorContent ).to.have.been.calledWith( '' );
+			expect( tree.editor.setEditorContent ).to.have.been.calledWith( '' );
 		} );
 
 		it( 'should not clear content when store state already isNew()', function() {
@@ -112,10 +112,10 @@ describe( 'PostEditor', function() {
 
 			const stub = sandbox.stub( PostEditStore, 'isNew' );
 			stub.returns( true );
-			tree.refs.editor.setEditorContent = sandbox.spy();
+			tree.editor.setEditorContent = sandbox.spy();
 			tree.setState( { isNew: true } );
 			tree.onEditedPostChange();
-			expect( tree.refs.editor.setEditorContent ).to.not.have.been.called;
+			expect( tree.editor.setEditorContent ).to.not.have.been.called;
 		} );
 
 		it( 'should clear content when loading', function() {
@@ -129,9 +129,9 @@ describe( 'PostEditor', function() {
 
 			const stub = sandbox.stub( PostEditStore, 'isLoading' );
 			stub.returns( true );
-			tree.refs.editor.setEditorContent = sandbox.spy();
+			tree.editor.setEditorContent = sandbox.spy();
 			tree.onEditedPostChange();
-			expect( tree.refs.editor.setEditorContent ).to.have.been.calledWith( '' );
+			expect( tree.editor.setEditorContent ).to.have.been.calledWith( '' );
 		} );
 
 		it( 'should set content after load', function() {
@@ -148,10 +148,10 @@ describe( 'PostEditor', function() {
 			stub.returns( {
 				content: content
 			} );
-			tree.refs.editor.setEditorContent = sandbox.spy();
+			tree.editor.setEditorContent = sandbox.spy();
 			tree.setState( { isLoading: true } );
 			tree.onEditedPostChange();
-			expect( tree.refs.editor.setEditorContent ).to.have.been.calledWith( content );
+			expect( tree.editor.setEditorContent ).to.have.been.calledWith( content );
 		} );
 
 		it( 'a normal content change should not clear content', function() {
@@ -168,11 +168,11 @@ describe( 'PostEditor', function() {
 			stub.returns( {
 				content: content
 			} );
-			tree.refs.editor.setEditorContent = sandbox.spy();
+			tree.editor.setEditorContent = sandbox.spy();
 			tree.setState( { post: { content: 'old content' } } );
 			tree.onEditedPostChange();
 
-			expect( tree.refs.editor.setEditorContent ).to.not.have.been.called;
+			expect( tree.editor.setEditorContent ).to.not.have.been.called;
 		} );
 
 		it( 'is a copy and it should set the copied content', function() {
@@ -193,10 +193,10 @@ describe( 'PostEditor', function() {
 
 			sandbox.stub( PostEditStore, 'get' ).returns( { content: content } );
 
-			tree.refs.editor.setEditorContent = sandbox.spy();
+			tree.editor.setEditorContent = sandbox.spy();
 			tree.onEditedPostChange();
 
-			expect( tree.refs.editor.setEditorContent ).to.have.been.calledWith( content );
+			expect( tree.editor.setEditorContent ).to.have.been.calledWith( content );
 		} );
 
 		it( 'should not set the copied content more than once', function() {
@@ -217,10 +217,10 @@ describe( 'PostEditor', function() {
 
 			sandbox.stub( PostEditStore, 'get' ).returns( { content: content } );
 
-			tree.refs.editor.setEditorContent = sandbox.spy();
+			tree.editor.setEditorContent = sandbox.spy();
 			tree.onEditedPostChange();
 
-			expect( tree.refs.editor.setEditorContent ).to.not.have.been.called;
+			expect( tree.editor.setEditorContent ).to.not.have.been.called;
 		} );
 	} );
 } );


### PR DESCRIPTION
Previously the post editor was using the React syntax for assigning a
reference to a component with a string name and lookup via
`this.refs.[name]`.

The use of a `ref` callback function is preferred to this older syntax
and the callback receives either a DOM object itself or the mounted
React component backing instance as the parameter, allowing us to use
`this.[name]` directly instead if we store it that way.

There have been bugs appearing in calypso with the following message:

```
Uncaught exception: TypeError: Cannot convert 'this.refs.editor' to
object
```

There were two or three places that I found which were referencing
`this.refs.editor` in the callback to `setState()` and I suspect that
these errors originated here. The reason is that since `setState()` is
an asynchronous operation it's possible that by the time the state is
updated and the callback gets called that the editor is no longer
mounted, meaning the ref is invalid.

To try and fix these I put a simple guard in the callback to only
attempt to update the editor content if the editor was still available
and mounted: `this.editor && this.editor.blahBlah( ... )`