### PR TITLE
wp-prettier, a fork of prettier for formatting wp-calypso code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 .env
 .DS_Store
 .idea
-.vscode
 *.iml
 *.iws
 /tags

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "javascript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": true,
+    "javascript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets": true,
+    "editor.tabSize": 2
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,5 +10,6 @@
 			"${file}"
 		],
     "isShellCommand": true,
-    "showOutput": "never"
+    "showOutput": "never",
+		"suppressTaskName": true
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,14 @@
+{
+    // wp-prettier run on current file
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "0.1.0",
+    "command": "node",
+		"args": [
+			"${workspaceRoot}/node_modules/wp-prettier/bin/prettier.js",
+			"--write",
+			"${file}"
+		],
+    "isShellCommand": true,
+    "showOutput": "never"
+}

--- a/package.json
+++ b/package.json
@@ -192,6 +192,6 @@
     "webpack-bundle-analyzer": "2.2.1",
     "webpack-dashboard": "0.2.0",
     "webpack-dev-server": "1.11.0",
-    "wp-prettier": "0.22.0"
+    "wp-prettier": "0.22.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
     "supertest": "2.0.0",
     "webpack-bundle-analyzer": "2.2.1",
     "webpack-dashboard": "0.2.0",
-    "webpack-dev-server": "1.11.0"
+    "webpack-dev-server": "1.11.0",
+    "wp-prettier": "0.22.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -192,6 +192,6 @@
     "webpack-bundle-analyzer": "2.2.1",
     "webpack-dashboard": "0.2.0",
     "webpack-dev-server": "1.11.0",
-    "wp-prettier": "0.22.1"
+    "wp-prettier": "0.22.2"
   }
 }


### PR DESCRIPTION
0. pulls in wp-prettier to devDependencies
1. keybinding to ctrlp to format current file (vs code shortcut)

Links to wp-prettie
- GH: https://github.com/samouri/prettier
- NPM: https://www.npmjs.com/package/wp-prettier

Reason why this cannot be somehow included into the vscode prettier extension (yet): https://github.com/esbenp/prettier-vscode/issues/29