### PR TITLE
Signup: remove the Site Title A/B test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -37,15 +37,6 @@ module.exports = {
 		defaultVariation: 'hideThemeUpload',
 		allowExistingUsers: false,
 	},
-	siteTitleStep: {
-		datestamp: '20170102',
-		variations: {
-			showSiteTitleStep: 5,
-			hideSiteTitleStep: 95,
-		},
-		defaultVariation: 'hideSiteTitleStep',
-		allowExistingUsers: false
-	},
 	userFirstSignup: {
 		datestamp: '20160124',
 		variations: {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -7,7 +7,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { abtest, getABTestVariation } from 'lib/abtest';
+import { abtest } from 'lib/abtest';
 import config from 'config';
 import stepConfig from './steps';
 import userFactory from 'lib/user';
@@ -111,13 +111,6 @@ const flows = {
 
 	surveystep: {
 		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
-		destination: getSiteDestination,
-		description: 'The current best performing flow in AB tests',
-		lastModified: '2016-05-23'
-	},
-
-	sitetitle: {
-		steps: [ 'site-title', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'The current best performing flow in AB tests',
 		lastModified: '2016-05-23'
@@ -362,7 +355,7 @@ const Flows = {
 		 */
 		if ( 'main' === flowName ) {
 			if ( '' === stepName ) {
-				abtest( 'siteTitleStep' );
+				// e.g. abtest( 'siteTitleStep' );
 			}
 		}
 	},
@@ -382,9 +375,11 @@ const Flows = {
 	getABTestFilteredFlow( flowName, flow ) {
 		// Only do this on the main flow
 		if ( 'main' === flowName ) {
+			/* e.g.:
 			if ( getABTestVariation( 'siteTitleStep' ) === 'showSiteTitleStep' ) {
 				return Flows.insertStepIntoFlow( 'site-title', flow );
 			}
+			*/
 		}
 
 		return flow;

--- a/client/signup/test/flows.js
+++ b/client/signup/test/flows.js
@@ -89,7 +89,7 @@ describe( 'Signup Flows Configuration', () => {
 
 		it( 'should check AB variation in main flow', () => {
 			assert.equal( flows.getABTestFilteredFlow( 'main', 'testflow' ), 'testflow' );
-			assert.equal( getABTestVariationSpy.callCount, 1 );
+			assert.equal( getABTestVariationSpy.callCount, 0 );
 			assert.equal( flows.insertStepIntoFlow.callCount, 0 );
 		} );
 
@@ -100,7 +100,7 @@ describe( 'Signup Flows Configuration', () => {
 			};
 
 			assert.equal( flows.getABTestFilteredFlow( 'main', myFlow ), myFlow );
-			assert.equal( getABTestVariationSpy.callCount, 2 );
+			assert.equal( getABTestVariationSpy.callCount, 0 );
 			assert.equal( flows.insertStepIntoFlow.callCount, 0 );
 		} );
 	} );


### PR DESCRIPTION
This PR removes the `siteTitleStep` A/B test that had been running but that we don't have the resources to analyze and / or improve currently. 

/cc especially @bisko since he probably knows best. 