### PR TITLE
Include date/number formatting extra strings when generating the POT file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ distclean: clean
 
 # create list of translations, saved as `./calypso-strings.pot`
 translate: node_modules
-	$(I18N_CALYPSO) --format pot --output-file ./calypso-strings.pot $(JS_FILES)
+	$(I18N_CALYPSO) --format pot --output-file ./calypso-strings.pot $(JS_FILES) -e date
 
 # install all git hooks
 githooks: githooks-commit githooks-push


### PR DESCRIPTION
At some point we stopped including the strings required for `i18n.numberFormat` in the pot file generated by `make translate`, which in turns excludes those strings from the language files we generate with translations.

i18n-calypso already has a flag to add those strings, we just need to turn it on.

Fixes #10682 

**Testing:**
run `make translate` and make sure the `calypso-strings.pot` file includes strings from `extras/date.js`, specifically: `number_format_decimal_point` and `number_format_thousands_sep` 