### PR TITLE
Reader: Fix Follow Stream Recomended Posts Spacing and Text Alignment

### DIFF
--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -249,7 +249,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		.has-thumbnail {
 
 			.reader-related-card-v2__post {
-				max-height: 200px;
+				max-height: 210px;
 
 				@include breakpoint( "<960px" ) {
 					max-height: 240px;

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -414,7 +414,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 .reader-related-card-v2__featured-image {
 	border: 1px solid lighten( $gray, 20% );
 	display: block;
-	height: 80px;
+	height: 90px;
 
 	@media #{$reader-related-card-v2-breakpoint-small} {
 		flex: 1;

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -249,7 +249,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		.has-thumbnail {
 
 			.reader-related-card-v2__post {
-				max-height: 205px;
+				max-height: 211px;
 
 				@include breakpoint( "<960px" ) {
 					max-height: 240px;
@@ -299,7 +299,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 			}
 
 			.reader-related-card-v2__post {
-				max-height: 205px;
+				max-height: 211px;
 
 				@media #{$reader-related-card-v2-breakpoint-medium} {
 					max-height: 150px;

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -249,7 +249,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		.has-thumbnail {
 
 			.reader-related-card-v2__post {
-				max-height: 210px;
+				max-height: 205px;
 
 				@include breakpoint( "<960px" ) {
 					max-height: 240px;

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -316,7 +316,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		}
 
 		.reader-related-card-v2__featured-image {
-			margin: 4px 0 19px;
+			margin: 0 0 19px;
 		}
 	}
 

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -562,7 +562,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 			}
 
 			.reader-related-card-v2__post {
-				max-height: 200px;
+				max-height: 210px;
 
 				@media #{$reader-related-card-v2-breakpoint-small} {
 					max-height: 150px;

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -562,7 +562,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 			}
 
 			.reader-related-card-v2__post {
-				max-height: 210px;
+				max-height: 205px;
 
 				@media #{$reader-related-card-v2-breakpoint-small} {
 					max-height: 150px;

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -518,7 +518,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 	.card.reader-related-card-v2 {
 		margin: 0;
-		padding-top: 10px;
+		padding-top: 6px;
 
 		@media #{$reader-related-card-v2-breakpoint-medium} {
 			padding-top: 0;
@@ -531,7 +531,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		&.has-thumbnail {
 
 			.reader-related-card-v2__meta {
-				margin-bottom: 15px;
+				margin-bottom: 14px;
 
 				@media #{$reader-related-card-v2-breakpoint-medium} {
 					margin-top: -2px;
@@ -629,7 +629,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 	.reader-related-card-v2__featured-image {
 		border: 1px solid lighten( $gray, 30% );
-		margin: 4px 0 17px;
+		margin: 0 0 17px;
 
 		@media #{$reader-related-card-v2-breakpoint-medium} {
 			margin: 0 15px 0 0;


### PR DESCRIPTION
This PR address two bugs.

1. In #11356 the spacing above and below the `.reader-related-card-v2__meta` should be 20px, instead of 25px; and
2. In #11956, where there are two rec posts where one has no feature image, the top of the title of the post with no feature image should line up with it's neighbor with an image. Also the body text of both rec posts should line up and this achieved by increasing the image height by 10px.