### PR TITLE
ThemesSearch: Disable tokens overlay for Edge.

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -137,6 +137,11 @@ class ThemesMagicSearchCard extends React.Component {
 	}
 
 	searchTokens = ( input ) => {
+		//We are not able to scroll overlay on Edge so just create empty div
+		if ( /(Edge)/.test( global.window.navigator.userAgent ) ) {
+			return <div />;
+		}
+
 		const tokens = input.split( /(\s+)/ );
 
 		return (


### PR DESCRIPTION
### Information

We are not able to scroll tokens overlay in ThemesMagicSearch when on MS Edge: so we disable it. No overlay layer is generated.

On Edge:
![image](https://cloud.githubusercontent.com/assets/17271089/23856060/676d1f96-07f8-11e7-8b0b-93ee3529c2a6.png)

Every where else: 
![image](https://cloud.githubusercontent.com/assets/17271089/23856147/c403deca-07f8-11e7-9025-3070ee742d04.png)
