### PR TITLE
Theme Sheet: Prepend protocol and server to canonical URL

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -684,7 +684,7 @@ export default connect(
 			isPremium: isThemePremium( state, id ),
 			isPurchased: selectedSite && isPremiumThemeAvailable( state, id, selectedSite.ID ),
 			forumUrl: getThemeForumUrl( state, id, selectedSite && selectedSite.ID ),
-			canonicalUrl: getThemeDetailsUrl( state, id ) // No siteId specified since we want the *canonical* URL :-)
+			canonicalUrl: 'https://wordpress.com' + getThemeDetailsUrl( state, id ) // No siteId specified since we want the *canonical* URL :-)
 		};
 	},
 	{


### PR DESCRIPTION
I accidentally dropped them in #12018.

To test:
* Theme Sheet: Logged-out, check the page source for the `<meta property="og:url" ... />` and `<link rel="canonical" ... />` tags. (Need to restart Calypso first!)