### PR TITLE
Add isSiteUpgradeable selector

### DIFF
--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -98,6 +98,7 @@ export isSiteAutomatedTransfer from './is-site-automated-transfer';
 export isSiteBlocked from './is-site-blocked';
 export isSiteOnFreePlan from './is-site-on-free-plan';
 export isSiteSupportingImageEditor from './is-site-supporting-image-editor';
+export isSiteUpgradeable from './is-site-upgradeable';
 export isTransientMedia from './is-transient-media';
 export isUpdatingJetpackSettings from './is-updating-jetpack-settings';
 export isUserRegistrationDaysWithinRange from './is-user-registration-days-within-range';

--- a/client/state/selectors/is-site-upgradeable.js
+++ b/client/state/selectors/is-site-upgradeable.js
@@ -1,0 +1,25 @@
+
+/**
+ * Internal dependencies
+ */
+import { canCurrentUser } from 'state/selectors';
+import { getCurrentUserId } from 'state/current-user/selectors';
+import { getRawSite } from 'state/sites/selectors';
+
+/**
+ * Returns true if the site can be upgraded by the user, false if the
+ * site cannot be upgraded, or null if upgrade ability cannot be
+ * determined.
+ *
+ * @param  {Object}   state  Global state tree
+ * @param  {Number}   siteId Site ID
+ * @return {?Boolean}        Whether site is upgradeable
+ */
+export default function( state, siteId ) {
+	// Cannot determine site upgradeability if there is no current user
+	if ( ! getCurrentUserId( state ) || ! getRawSite( state, siteId ) ) {
+		return null;
+	}
+
+	return canCurrentUser( state, siteId, 'manage_options' );
+}

--- a/client/state/selectors/test/is-site-upgradeable.js
+++ b/client/state/selectors/test/is-site-upgradeable.js
@@ -1,0 +1,122 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isSiteUpgradeable } from '../';
+
+describe( 'isSiteUpgradeable()', () => {
+	it( 'should return null if no siteId is given', () => {
+		const isUpgradeable = isSiteUpgradeable( {
+			sites: {
+				items: {
+					77203199: {
+						ID: 77203199,
+						URL: 'https://example.com',
+						options: {
+							unmapped_url: 'https://example.wordpress.com'
+						}
+					}
+				}
+			},
+			currentUser: {
+				id: 123456
+			}
+		}, null );
+
+		expect( isUpgradeable ).to.be.null;
+	} );
+
+	it( 'should return null if there is no site with that siteId', () => {
+		const isUpgradeable = isSiteUpgradeable( {
+			sites: {
+				items: {
+					77203199: {
+						ID: 77203199,
+						URL: 'https://example.com',
+						options: {
+							unmapped_url: 'https://example.wordpress.com'
+						}
+					}
+				}
+			},
+			currentUser: {}
+		}, 42 );
+
+		expect( isUpgradeable ).to.be.null;
+	} );
+
+	it( 'should return null if there is no current user', () => {
+		const isUpgradeable = isSiteUpgradeable( {
+			sites: {
+				items: {
+					77203199: {
+						ID: 77203199,
+						URL: 'https://example.com',
+						options: {
+							unmapped_url: 'https://example.wordpress.com'
+						}
+					}
+				}
+			},
+			currentUser: {}
+		}, 77203199 );
+
+		expect( isUpgradeable ).to.be.null;
+	} );
+
+	it( 'should return false if the user cannot manage the site ', () => {
+		const isUpgradeable = isSiteUpgradeable( {
+			sites: {
+				items: {
+					77203199: {
+						ID: 77203199,
+						URL: 'https://example.com',
+						options: {
+							unmapped_url: 'https://example.wordpress.com'
+						}
+					}
+				}
+			},
+			currentUser: {
+				id: 123456,
+				capabilities: {
+					77203199: {
+						manage_options: false
+					}
+				}
+			}
+		}, 77203199 );
+
+		expect( isUpgradeable ).to.be.false;
+	} );
+
+	it( 'should return true if the user can manage the site ', () => {
+		const isUpgradeable = isSiteUpgradeable( {
+			sites: {
+				items: {
+					77203199: {
+						ID: 77203199,
+						URL: 'https://example.com',
+						options: {
+							unmapped_url: 'https://example.wordpress.com'
+						}
+					}
+				}
+			},
+			currentUser: {
+				id: 123456,
+				capabilities: {
+					77203199: {
+						manage_options: true
+					}
+				}
+			}
+		}, 77203199 );
+
+		expect( isUpgradeable ).to.be.true;
+	} );
+} );


### PR DESCRIPTION
This is part of a larger refactor started in #11328

The goal is to remove any use of `site.isUpgradeable()`, replacing them by a redux selector.

This PR simply adds the new selector `isSiteUpgradeable` and adds tests for it.

### Testing Instructions
- Run `npm run test-client -- client/state/sites/test/selectors.js` and check that all the tests pass
