### PR TITLE
Reader: add tracks event for combined card render

### DIFF
--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import React from 'react';
-import { get } from 'lodash';
+import { get, size } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -17,71 +17,99 @@ import ReaderCombinedCardPost from './post';
 import { keysAreEqual, keyForPost } from 'lib/feed-stream-store/post-key';
 import QueryReaderSite from 'components/data/query-reader-site';
 import QueryReaderFeed from 'components/data/query-reader-feed';
+import { recordTrack } from 'reader/stats';
 
-const ReaderCombinedCard = ( { posts, site, feed, postKey, selectedPostKey, onClick, isDiscover, translate } ) => {
-	const feedId = postKey.feedId;
-	const siteId = postKey.blogId;
-	const siteIcon = get( site, 'icon.img' );
-	const feedIcon = get( feed, 'image' );
-	const streamUrl = getStreamUrl( feedId, siteId );
-	const siteName = siteNameFromSiteAndPost( site, posts[ 0 ] );
-	const isSelectedPost = post => keysAreEqual( keyForPost( post ), selectedPostKey );
+class ReaderCombinedCard extends React.Component {
 
-	return (
-		<Card className="reader-combined-card">
-			<header className="reader-combined-card__header">
-				<ReaderAvatar
-					siteIcon={ siteIcon }
-					feedIcon={ feedIcon }
-					author={ null }
-					preferGravatar={ true }
-					siteUrl={ streamUrl }
-					siteIconSize={ 32 } />
-				<div className="reader-combined-card__header-details">
-					<ReaderSiteStreamLink
-						className="reader-combined-card__site-link"
-						feedId={ feedId }
-						siteId={ siteId }>
-						{ siteName }
-					</ReaderSiteStreamLink>
-					<p className="reader-combined-card__header-post-count">
-						{ translate( '%(count)d posts', {
-							args: {
-								count: posts.length
-							}
-						} ) }
-					</p>
-				</div>
-			</header>
-			<ul className="reader-combined-card__post-list">
-				{ posts.map( post => (
-					<ReaderCombinedCardPost
-						key={ `post-${ post.ID }` }
-						post={ post }
-						streamUrl={ streamUrl }
-						onClick={ onClick }
-						isDiscover={ isDiscover }
-						isSelected={ isSelectedPost( post ) }
-						/>
-				) ) }
-			</ul>
-			{ feedId && <QueryReaderFeed feedId={ +feedId } includeMeta={ false } /> }
-			{ siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }
-		</Card>
-	);
-};
+	static propTypes = {
+		posts: React.PropTypes.array.isRequired,
+		site: React.PropTypes.object,
+		feed: React.PropTypes.object,
+		onClick: React.PropTypes.func,
+		isDiscover: React.PropTypes.bool,
+		postKey: React.PropTypes.object,
+		selectedPostKey: React.PropTypes.object
+	}
 
-ReaderCombinedCard.propTypes = {
-	posts: React.PropTypes.array.isRequired,
-	site: React.PropTypes.object,
-	feed: React.PropTypes.object,
-	onClick: React.PropTypes.func,
-	isDiscover: React.PropTypes.bool,
-	selectedPostKey: React.PropTypes.object
-};
+	static defaultProps = {
+		isDiscover: false,
+	}
 
-ReaderCombinedCard.defaultProps = {
-	isDiscover: false,
-};
+	componentDidMount() {
+		this.recordRenderTrack();
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.postKey.feedId !== nextProps.postKey.feedId ||
+			this.props.postKey.blogId !== nextProps.postKey.blogId ||
+			size( this.props.posts ) !== size( nextProps.posts ) ) {
+			this.recordRenderTrack( nextProps );
+		}
+	}
+
+	recordRenderTrack = ( props = this.props ) => {
+		const { postKey, posts } = props;
+
+		recordTrack( 'calypso_reader_combined_card_render', {
+			blog_id: postKey.blogId,
+			feed_id: postKey.feedId,
+			post_count: size( posts ),
+		} );
+	}
+
+	render() {
+		const { posts, site, feed, postKey, selectedPostKey, onClick, isDiscover, translate } = this.props;
+		const feedId = postKey.feedId;
+		const siteId = postKey.blogId;
+		const siteIcon = get( site, 'icon.img' );
+		const feedIcon = get( feed, 'image' );
+		const streamUrl = getStreamUrl( feedId, siteId );
+		const siteName = siteNameFromSiteAndPost( site, posts[ 0 ] );
+		const isSelectedPost = post => keysAreEqual( keyForPost( post ), selectedPostKey );
+
+		return (
+			<Card className="reader-combined-card">
+				<header className="reader-combined-card__header">
+					<ReaderAvatar
+						siteIcon={ siteIcon }
+						feedIcon={ feedIcon }
+						author={ null }
+						preferGravatar={ true }
+						siteUrl={ streamUrl }
+						siteIconSize={ 32 } />
+					<div className="reader-combined-card__header-details">
+						<ReaderSiteStreamLink
+							className="reader-combined-card__site-link"
+							feedId={ feedId }
+							siteId={ siteId }>
+							{ siteName }
+						</ReaderSiteStreamLink>
+						<p className="reader-combined-card__header-post-count">
+							{ translate( '%(count)d posts', {
+								args: {
+									count: posts.length
+								}
+							} ) }
+						</p>
+					</div>
+				</header>
+				<ul className="reader-combined-card__post-list">
+					{ posts.map( post => (
+						<ReaderCombinedCardPost
+							key={ `post-${ post.ID }` }
+							post={ post }
+							streamUrl={ streamUrl }
+							onClick={ onClick }
+							isDiscover={ isDiscover }
+							isSelected={ isSelectedPost( post ) }
+							/>
+					) ) }
+				</ul>
+				{ feedId && <QueryReaderFeed feedId={ +feedId } includeMeta={ false } /> }
+				{ siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }
+			</Card>
+		);
+	}
+}
 
 export default localize( ReaderCombinedCard );


### PR DESCRIPTION
Fire a Tracks event when a new Reader Combined Card is rendered, including:
- blog ID (where available)
- feed ID (where available) 
- number of posts in the combined card

Fixes #12014.

<img width="920" alt="screen shot 2017-03-13 at 15 28 54" src="https://cloud.githubusercontent.com/assets/17325/23861391/ce21762a-0801-11e7-8b2b-408fed41823a.png">
