### PR TITLE
Theme: update theme uploaded screen style

### DIFF
--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -242,19 +242,21 @@ class Upload extends React.Component {
 
 		return (
 			<div className="theme-upload__theme-sheet">
-				<span className="theme-upload__theme-name">{ theme.name }</span>
-				<span className="theme-upload__author">
+				<img className="theme-upload__screenshot" src={ theme.screenshot } />
+				<h2 className="theme-upload__theme-name">{ theme.name }</h2>
+				<div className="theme-upload__author">
 					{ translate( 'by ' ) }
 					<a href={ theme.author_uri }>{ theme.author }</a>
-				</span>
-				<img src={ theme.screenshot } />
-				<span className="theme-upload__description">{ theme.description }</span>
-				<Button onClick={ this.onTryAndCustomizeClick } >
-					{ tryandcustomize.label }
-				</Button>
-				<Button primary onClick={ this.onActivateClick }>
-					{ activate.label }
-				</Button>
+				</div>
+				<div className="theme-upload__description">{ theme.description }</div>
+				<div className="theme-upload__action-buttons">
+					<Button onClick={ this.onTryAndCustomizeClick } >
+						{ tryandcustomize.label }
+					</Button>
+					<Button primary onClick={ this.onActivateClick }>
+						{ activate.label }
+					</Button>
+				</div>
 			</div>
 		);
 	}

--- a/client/my-sites/themes/theme-upload/style.scss
+++ b/client/my-sites/themes/theme-upload/style.scss
@@ -1,3 +1,4 @@
+// View: theme upload
 .theme-upload__dropzone {
 	position: relative;
 	background-color: $gray-light;
@@ -39,30 +40,44 @@
 }
 
 
+.theme-upload {
+	&.is-disabled {
+		opacity: 0.2;
+		pointer-events: none;
+	}
+}
+
+
+// View : theme successfully uploaded
 .theme-upload__theme-sheet {
-	span {
-		display: block;
-	}
-
-	img {
-		width: 300px;
-		margin: 20px;
-		border: 1px solid $gray;
-	}
-
-	.button {
-		margin: 20px 20px 0 0;
-	}
+	font-size: 14px;
 }
 
 .theme-upload__theme-name {
 	font-size: 24px;
 	font-weight: 600;
+	clear: none;
 }
 
-.theme-upload {
-	&.is-disabled {
-		opacity: 0.2;
-		pointer-events: none;
+.theme-upload__screenshot {
+	float: right;
+	width: 300px;
+	border: 1px solid lighten( $gray, 30% );
+	margin-left: 24px;
+}
+
+.theme-upload__description {
+	margin: 24px 0;
+}
+
+.theme-upload__action-buttons {
+	clear: both;
+	overflow: hidden;
+	border-top: 1px solid lighten( $gray, 30% );
+	padding: 16px;
+	margin: 24px -24px -24px;
+
+	.button {
+		margin: 0 20px 0 0;
 	}
 }

--- a/client/my-sites/themes/theme-upload/style.scss
+++ b/client/my-sites/themes/theme-upload/style.scss
@@ -64,6 +64,12 @@
 	width: 300px;
 	border: 1px solid lighten( $gray, 30% );
 	margin-left: 24px;
+
+	@include breakpoint( "<960px" ) {
+		float: none;
+		margin-left: 0;
+		margin-bottom: 24px;
+	}
 }
 
 .theme-upload__description {


### PR DESCRIPTION
The current uploaded screen styling is a bit off. I did a pass to restructure the CSS a bit, and introduce better positioning (and a couple of changes in the DOM structure).

A direct user benefit is that the button would be higher, so easier to reach.


Before:
![screen shot 2017-03-13 at 16 47 10](https://cloud.githubusercontent.com/assets/4389/23865540/eddc7242-080d-11e7-86f0-a30abb9cecfa.png)



After:
![screen shot 2017-03-13 at 16 46 33](https://cloud.githubusercontent.com/assets/4389/23865543/efb73520-080d-11e7-905e-db9edd854e45.png)

