### PR TITLE
Directly: Enable in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -20,6 +20,7 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
+		"help/directly": true,
 		"jetpack/google-analytics": true,
 		"jetpack/api-cache": false,
 		"manage/custom-post-types": true,


### PR DESCRIPTION
Turns on the flag for Directly in production.

**BEFORE MERGING MAKE SURE THE DIRECTLY THROTTLE IN NETWORK ADMIN IS SET TO 0%**

### To test

I'm not entirely sure... I can't seem to get a production environment working with Docker. But Horizon has the same directly config as production and this has been thoroughly tested in all other environments, so I'm not anticipating any issues.