### PR TITLE
Theme: on activation use new frontend trampoline

### DIFF
--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -23,6 +23,7 @@ import {
 	isWpcomTheme
 } from 'state/themes/selectors';
 import { clearActivated } from 'state/themes/actions';
+import { isJetpackSite } from 'state/sites/selectors';
 
 const ThanksModal = React.createClass( {
 	trackClick: trackClick.bind( null, 'current theme' ),
@@ -47,7 +48,7 @@ const ThanksModal = React.createClass( {
 
 	visitSite() {
 		this.trackClick( 'visit site' );
-		page( this.props.site.URL );
+		page( this.props.visitSiteUrl );
 	},
 
 	goBack() {
@@ -175,6 +176,7 @@ export default connect(
 			detailsUrl: site && getThemeDetailsUrl( state, currentThemeId, site.ID ),
 			customizeUrl: site && getThemeCustomizeUrl( state, currentThemeId, site.ID ),
 			forumUrl: site && getThemeForumUrl( state, currentThemeId, site.ID ),
+			visitSiteUrl: site.URL + ( isJetpackSite( state, site.ID ) ? '' : '?next=customize' ),
 			isActivating: !! ( site && isActivatingTheme( state, site.ID ) ),
 			hasActivated: !! ( site && hasActivatedTheme( state, site.ID ) ),
 			isThemeWpcom: isWpcomTheme( state, currentThemeId )

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -176,7 +176,7 @@ export default connect(
 			detailsUrl: site && getThemeDetailsUrl( state, currentThemeId, site.ID ),
 			customizeUrl: site && getThemeCustomizeUrl( state, currentThemeId, site.ID ),
 			forumUrl: site && getThemeForumUrl( state, currentThemeId, site.ID ),
-			visitSiteUrl: site.URL + ( isJetpackSite( state, site.ID ) ? '' : '?next=customize' ),
+			visitSiteUrl: site && site.URL + ( isJetpackSite( state, site.ID ) ? '' : '?next=customize' ),
 			isActivating: !! ( site && isActivatingTheme( state, site.ID ) ),
 			hasActivated: !! ( site && hasActivatedTheme( state, site.ID ) ),
 			isThemeWpcom: isWpcomTheme( state, currentThemeId )


### PR DESCRIPTION
This PR adds the ability to use our "Frontend Trampoline" when clicking on "View Site" from the theme activation modal. 

Why? The trampoline provides an intuitive "next step" for someone that has just activated a theme.

After clicking on "Visit Site" from the welcome modal:

![screen shot 2017-03-13 at 17 35 54](https://cloud.githubusercontent.com/assets/4389/23867394/ab57094a-0813-11e7-8a8c-b3a7aa5d4966.png)

### To test

1. Load this branch and open `/design`
2. Try on a .com site: activate a theme and you should see the trampoline UI above
3. Try on a Jetpack site: activate a theme, but trampoline UI won't show (it's a PHP plugin)
4. Try on all sites: activate a theme on a .com site, you should see the trampoline UI above
5. Verify the `?next=customize` doesn't show in the URL
6. Verify the three buttons on the trampoline work