### PR TITLE
Plugins: Don't show AT install button once transfer completes

### DIFF
--- a/client/my-sites/plugins-wpcom/plugin-install-button.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-install-button.jsx
@@ -30,7 +30,6 @@ export const WpcomPluginInstallButton = props => {
 		transferState
 	} = props;
 
-	// Don't show the button if the transfer has completed
 	if ( transferStates.COMPLETE === transferState ) {
 		return null;
 	}

--- a/client/my-sites/plugins-wpcom/plugin-install-button.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-install-button.jsx
@@ -11,9 +11,11 @@ import page from 'page';
  * Internal dependencies
  */
 import Button from 'components/button';
+import { getAutomatedTransferStatus } from 'state/automated-transfer/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getEligibility } from 'state/automated-transfer/selectors';
 import { initiateThemeTransfer } from 'state/themes/actions';
+import { transferStates } from 'state/automated-transfer/constants';
 
 export const WpcomPluginInstallButton = props => {
 	const {
@@ -24,8 +26,14 @@ export const WpcomPluginInstallButton = props => {
 		siteId,
 		eligibilityData,
 		navigateTo,
-		initiateTransfer
+		initiateTransfer,
+		transferState
 	} = props;
+
+	const { COMPLETE } = transferStates;
+	if ( COMPLETE === transferState ) {
+		return null;
+	}
 
 	function installButtonAction( event ) {
 		event.preventDefault();
@@ -59,7 +67,8 @@ const mapStateToProps = state => {
 	return {
 		siteId: site.ID,
 		siteSlug: site.slug,
-		eligibilityData: getEligibility( state, site.ID )
+		eligibilityData: getEligibility( state, site.ID ),
+		transferState: getAutomatedTransferStatus( state, site.ID ),
 	};
 };
 

--- a/client/my-sites/plugins-wpcom/plugin-install-button.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-install-button.jsx
@@ -30,8 +30,8 @@ export const WpcomPluginInstallButton = props => {
 		transferState
 	} = props;
 
-	const { COMPLETE } = transferStates;
-	if ( COMPLETE === transferState ) {
+	// Don't show the button if the transfer has completed
+	if ( transferStates.COMPLETE === transferState ) {
 		return null;
 	}
 


### PR DESCRIPTION
I noticed that the plugin install button was hanging around after a transfer completed. This PR removes the button once the `COMPLETE` status is reached for a transfer.

Video: https://cloudup.com/ccZLLn5dICE

**To test**
* Set up a site for Automated Transfer
* Start the transfer by installing a plugin
* At the end of the transfer, the Success message should display, and the Install button should disappear.

I was trying to think of ways this PR would cause the button to be gone when we don't want it to be. Maybe if a site needs to be transferred again for some reason? Feedback welcome on that.