### PR TITLE
Editor: Fix firefox scroll issue.

### DIFF
--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -144,9 +144,11 @@
 	// typography for HTML view
 	font-family: $monospace;
 	font-size: 14px;
+	margin-bottom: 64px;
 
 	@include breakpoint( "<480px" ) {
 		padding: 24px 27px; /* 27px = 16px + the 11px padding on Visual mode */
+		margin-bottom: 0;
 	}
 
 	&:focus {


### PR DESCRIPTION
This PR seeks to fix an issue where on long posts, in HTML mode, in Firefox, you can not scroll to the bottom of the post.

/cc @jasmussen 

__To Test__
- Open the editor in Firefox and add enough content to where the page whill scroll
- Switch to the HTML tab and and ensure you can scroll to the bottom