### PR TITLE
Reader: Teach the feed-stream-store about date_range, emit more consistently

### DIFF
--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -233,6 +233,9 @@ export default class FeedStream {
 	}
 
 	getLastItemWithDate() {
+		if ( this.oldestPostDate ) {
+			return this.oldestPostDate;
+		}
 		let i = this.postKeys.length - 1;
 		if ( i === -1 ) {
 			return;
@@ -423,6 +426,7 @@ export default class FeedStream {
 		debug( 'receiving page in %s', this.id );
 
 		this._isFetchingNextPage = false;
+		this.oldestPostDate = get( data, [ 'date_range', 'after' ] );
 
 		if ( error ) {
 			debug( 'Error fetching posts from API:', error );
@@ -435,6 +439,7 @@ export default class FeedStream {
 		const posts = data && data.posts;
 
 		if ( ! posts ) {
+			this.emitChange();
 			return;
 		}
 
@@ -452,9 +457,11 @@ export default class FeedStream {
 				postById.add( postKey.postId );
 			} );
 			this.postKeys = this.postKeys.concat( postKeys );
-			this.page++;
-			this.emitChange();
+
 		}
+
+		this.page++;
+		this.emitChange( );
 	}
 
 	receiveUpdates( id, error, data ) {


### PR DESCRIPTION
This teaches the feed-stream-store to look for a date_range property on the results from the API and use that value when determining how to fetch the next page of results.

Prior, we would look at the date on the last post currently in the stream, but that falls down when we remove x-posts from the stream. The last date then becomes the date of the first consolidated x-post, and our standard page size of 7 can easily get stuck when fetching heavily cross-posted posts.

By using the reported last date instead of the post-consolidation posts, we get a more consistent and proper point from which to fetch the next page.