### PR TITLE
Plugins: use correct call for default props

### DIFF
--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -59,7 +59,7 @@ module.exports = React.createClass( {
 		hasAllNoManageSites: React.PropTypes.bool,
 	},
 
-	defaultProps() {
+	getDefaultProps() {
 		return  {
 			allowedActions: {
 				activation: true,


### PR DESCRIPTION
Fixes  default props for `PluginItem` component.