### PR TITLE
Unmount the Accept Dialog component on close

### DIFF
--- a/client/lib/accept/index.js
+++ b/client/lib/accept/index.js
@@ -15,6 +15,7 @@ module.exports = function( message, callback, confirmButtonText, cancelButtonTex
 
 	function onClose( result ) {
 		if ( wrapper ) {
+			ReactDom.unmountComponentAtNode( wrapper );
 			document.body.removeChild( wrapper );
 			wrapper = null;
 		}


### PR DESCRIPTION
This PR makes the `lib/accept` module, unmount the AcceptDialog  Component when it's closed.

As a result of this component not being unmounted you are left with multiple instances of the components  (one for each closed dialog), after they've been closed by the user, even when its container element has been removed from the DOM.


![image](https://cloud.githubusercontent.com/assets/746152/23876173/e5a309f8-081a-11e7-93d0-f3250727076c.png)

##### Testing instructions

The `accept()` module is used in several places, but this is one flow you can test to check the behavior introduced by this PR.

1. Get to edit one of your public posts from any of your sites
1. Open the React Dev Tools, and take a glance at the last Component shown as rendered.
2. On the sidebar, expand the **Status** Settings.
3. Try to change the visibility of the post to `Private`. A modal dialog will pop up.
4. Click **No** in the dialog (to close it) to reject the change.
5. Confirm that you see no `<LocalizedAcceptDialog />` instances being left rendered at the list of components shown in the Dev Tools View



#### After

You can see that the `LocalizedAcceptDialog` component is added when the Dialog is shown, and is removed when the dialog is closed.

![accept](https://cloud.githubusercontent.com/assets/746152/23874782/a31ca7ec-0815-11e7-9c78-b87bbbc3bc7d.gif)

#### Before

You can see that the `LocalizedAcceptDialog` components are still there after the dialog is closed.

![accept2](https://cloud.githubusercontent.com/assets/746152/23874816/c5f67fae-0815-11e7-89c1-731e0b9a3822.gif)


#### Why

Previously we were just removing the container element, but the component reference was still there. As mentioned in [ReactDOM.render and the Top Level React API](https://facebook.github.io/react/blog/2015/10/01/react-render-and-top-level-api.html), leaving the Component mounted, leaks. 