### PR TITLE
Button: reset styles in dialog__content

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -228,7 +228,8 @@ button {
 // ==========================================================================
 
 // Turn Reset 'buttons' into regular text links
-.layout__content input {
+.layout__content input,
+.dialog__content input {
 	&[type=reset],
 	&[type=reset]:hover,
 	&[type=reset]:active,
@@ -242,7 +243,8 @@ button {
 }
 
 // Buttons within sentences sit on the text baseline.
-.layout__content p .button {
+.layout__content p .button,
+.dialog__content p .button {
 	vertical-align: baseline;
 }
 
@@ -250,7 +252,11 @@ button {
 .layout__content button::-moz-focus-inner,
 .layout__content input[type=reset]::-moz-focus-inner,
 .layout__content input[type=button]::-moz-focus-inner,
-.layout__content input[type=submit]::-moz-focus-inner {
+.layout__content input[type=submit]::-moz-focus-inner ,
+.dialog__content button::-moz-focus-inner,
+.dialog__content input[type=reset]::-moz-focus-inner,
+.dialog__content input[type=button]::-moz-focus-inner,
+.dialog__content input[type=submit]::-moz-focus-inner {
 	border: 0;
 	padding: 0;
 }


### PR DESCRIPTION
This PR fixes a visual bug in buttons rendered into a dialog (children of `.dialog__content` dom element).
We are cleaning some pseudo classes in FF which allow achieving cross-browsing but only of buttons [children of the `.layout__content` element.](https://github.com/Automattic/wp-calypso/blob/master/client/components/button/style.scss#L226).

In this PR we are resetting styles to support the compatibility also for the Dialog.

### Testing:

The visual bug was found in the new uploading media button.

1) Start to write/edit a post (always in FF): http://calypso.localhost:3000/post/<site>
2) Add a media item
3) take a look at the uploading media button. It should look ok.

**Before this patch**
<img src="https://cloud.githubusercontent.com/assets/77539/23879482/3e8aa3e4-082c-11e7-8e8f-44ae55b7f868.png" width="300px" />

**After this patch**
<img src="https://cloud.githubusercontent.com/assets/77539/23879479/2d4dd1dc-082c-11e7-9f37-67652d565d20.png" width="300px" />

You could take a look at the pseudo-classes defined in this patch as well:

<img src="https://cloud.githubusercontent.com/assets/77539/23879498/6874e9c6-082c-11e7-8f52-dbeeb11a14dc.png" width="500px" />

<img src="https://cloud.githubusercontent.com/assets/77539/23879490/545b1f64-082c-11e7-8563-4c663d9c7220.png" width="500px" />
