### PR TITLE
Media: do not show gallery help in media section

### DIFF
--- a/client/post-editor/media-modal/gallery-help.jsx
+++ b/client/post-editor/media-modal/gallery-help.jsx
@@ -17,6 +17,7 @@ import Button from 'components/button';
 
 import { setPreference, savePreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
+import { getSectionName } from 'state/ui/selectors';
 import QueryPreferences from 'components/data/query-preferences';
 
 const EditorMediaModalGalleryHelp =  React.createClass( {
@@ -25,7 +26,8 @@ const EditorMediaModalGalleryHelp =  React.createClass( {
 	mixins: [ PureRenderMixin ],
 
 	propTypes: {
-		onDismiss: PropTypes.func
+		onDismiss: PropTypes.func,
+		sectionName: PropTypes.string,
 	},
 
 	getInitialState() {
@@ -107,6 +109,11 @@ const EditorMediaModalGalleryHelp =  React.createClass( {
 	},
 
 	render() {
+		// note that the post editor section is used for posts and pages
+		if ( this.props.sectionName !== 'post-editor' ) {
+			return null;
+		}
+
 		if ( this.props.isMediaModalGalleryInstructionsDismissed ) {
 			return null;
 		}
@@ -121,6 +128,7 @@ const EditorMediaModalGalleryHelp =  React.createClass( {
 
 export default connect(
 	state => ( {
+		sectionName: getSectionName( state ),
 		isMediaModalGalleryInstructionsDismissed: (
 			getPreference( state, 'mediaModalGalleryInstructionsDismissed' ) ||
 			getPreference( state, 'mediaModalGalleryInstructionsDismissedForSession' )


### PR DESCRIPTION
This PR prevents the gallery help tip from displaying in the Media Section

![pasted_image_at_2017_03_13_19_53](https://cloud.githubusercontent.com/assets/1270189/23880492/2fef8310-0811-11e7-95b4-89e922a84f58.png)

### Testing Instructions:
- Either create a new user, or unset the `mediaModalGalleryInstructionsDismissed` user preference
- Navigate to http://calypso.localhost:3000/media
- Select a site
- Click on one item
- The popover is not shown

- Navigate to http://calypso.localhost:3000/post
- Select a site
- Click on "Insert Content" to open the media modal
- Click on one item
- We should see the gallery help modal
- Dismissing it should behave normally
