### PR TITLE
Purchases: Remove connect warning on ProductLink for mapStateToProps.

### DIFF
--- a/client/me/purchases/product-link/index.jsx
+++ b/client/me/purchases/product-link/index.jsx
@@ -74,5 +74,6 @@ export default connect(
 				productUrl: getThemeDetailsUrl( state, selectedPurchase.meta, selectedPurchase.siteId )
 			};
 		}
+		return {};
 	}
 )( ProductLink );


### PR DESCRIPTION
Looking at `/me/purchases` then selecting a purchase on master right now, you will see the following console warning:

```
mapStateToProps() in Connect(ProductLink) must return a plain object. Instead received undefined.
```

This PR ensures an empty object is returned when the current product is not a theme.