### PR TITLE
Reader: tweak to combined card

### DIFF
--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -50,10 +50,10 @@ const ReaderCombinedCard = ( { posts, site, feed, selectedPostKey, onClick, isDi
 								count: posts.length
 							}
 						} ) }
-					{ thereWereMorePosts &&
-						<p> { translate( "only displaying 5 posts, read more at the site!" ) } </p>
-					}
 					</p>
+					{ thereWereMorePosts &&
+						<p> { translate( "there were more than 5 posts, read more at the site" ) } </p>
+					}
 				</div>
 			</header>
 			<ul className="reader-combined-card__post-list">

--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import React from 'react';
-import { get } from 'lodash';
+import { get, take } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -24,6 +24,8 @@ const ReaderCombinedCard = ( { posts, site, feed, selectedPostKey, onClick, isDi
 	const streamUrl = getStreamUrl( feedId, siteId );
 	const siteName = siteNameFromSiteAndPost( site, posts[ 0 ] );
 	const isSelectedPost = post => keysAreEqual( keyForPost( post ), selectedPostKey );
+	const firstFivePosts = take( posts, 5 );
+	const thereWereMorePosts = firstFivePosts.length !== posts.length;
 
 	return (
 		<Card className="reader-combined-card">
@@ -48,11 +50,14 @@ const ReaderCombinedCard = ( { posts, site, feed, selectedPostKey, onClick, isDi
 								count: posts.length
 							}
 						} ) }
+					{ thereWereMorePosts &&
+						<p> { translate( "only displaying 5 posts, read more at the site!" ) } </p>
+					}
 					</p>
 				</div>
 			</header>
 			<ul className="reader-combined-card__post-list">
-				{ posts.map( post => (
+				{ firstFivePosts.map( post => (
 					<ReaderCombinedCardPost
 						key={ `post-${ post.ID }` }
 						post={ post }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -4,8 +4,9 @@
 import ReactDom from 'react-dom';
 import React, { PropTypes } from 'react';
 import classnames from 'classnames';
-import { defer, findLast, flatMap, noop, times, clamp, includes, last } from 'lodash';
+import { defer, findLast, flatMap, noop, times, clamp, includes, last, groupBy, map, flattenDeep, values, sortBy, reverse, compact } from 'lodash';
 import { connect } from 'react-redux';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -117,18 +118,75 @@ function combine( postKey1, postKey2 ) {
 	};
 }
 
-const combineCards = ( postKeys ) => postKeys.reduce(
-	( accumulator, postKey ) => {
-		const lastPostKey = last( accumulator );
-		if ( sameSite( lastPostKey, postKey ) ) {
-			accumulator[ accumulator.length - 1 ] = combine( last( accumulator ), postKey );
+// const combineCards = ( postKeys ) => postKeys.reduce(
+// 	( accumulator, postKey ) => {
+// 		const lastPostKey = last( accumulator );
+// 		if ( sameSite( lastPostKey, postKey ) ) {
+// 			accumulator[ accumulator.length - 1 ] = combine( last( accumulator ), postKey );
+// 		} else {
+// 			accumulator.push( postKey );
+// 		}
+// 		return accumulator;
+// 	},
+// 	[]
+// );
+
+const getMomentForPostKey = postKey =>  {
+	window.getMomentForPostKey = getMomentForPostKey;
+	let post = PostStore.get( postKey );
+	if ( postKey.isCombination ) {
+		const postKeyForPost = { postId: postKey.postIds[ 0 ] };
+		if ( postKey.feedId ) {
+			postKeyForPost.feedId = postKey.feedId;
 		} else {
-			accumulator.push( postKey );
+			postKeyForPost.blogId = postKey.blogId;
 		}
-		return accumulator;
-	},
-	[]
-);
+
+		post = PostStore.get( postKeyForPost );
+	} else if ( postKey.isRecommendationBlock ){
+		post = null;
+	} else {
+		post = PostStore.get( postKey );
+	}
+
+	return post && moment( post.date );
+}
+
+/* Combine all cards from the same site that are within the same 2 hour span
+ */
+const CARDS_PER_DAY_PER_SITE = 4; // max combined card only counts as one card
+const HOURS_PER_CARD = 24 / CARDS_PER_DAY_PER_SITE;
+const combineCards = ( postKeys ) => {
+	window.moment = moment;
+	const timeSliced = groupBy( postKeys, postKey => {
+		const moment = getMomentForPostKey( postKey );
+		moment && moment.millisecond( 0 ).second( 0 ).minute( 0 ).hour(
+			Math.floor( moment.hour() / HOURS_PER_CARD ) * HOURS_PER_CARD
+		)
+		return moment;
+	} );
+
+	const groupedBySiteInTimeWindow = map( timeSliced,
+		keys => values( groupBy( keys, key => key.feedId || key.blogId ) )
+	);
+
+	const groupedBySiteInOrder = flattenDeep( groupedBySiteInTimeWindow );
+
+	const combined = groupedBySiteInOrder.reduce(
+		( accumulator, postKey ) => {
+			const lastPostKey = last( accumulator );
+			if ( sameSite( lastPostKey, postKey ) ) {
+				accumulator[ accumulator.length - 1 ] = combine( last( accumulator ), postKey );
+			} else {
+				accumulator.push( postKey );
+			}
+			return accumulator;
+		},
+		[]
+	);
+	const sorted = reverse( sortBy( combined, getMomentForPostKey ) );
+	return sorted;
+}
 
 function injectRecommendations( posts, recs = [] ) {
 	if ( ! recs || recs.length === 0 ) {
@@ -213,7 +271,7 @@ class ReaderStream extends React.Component {
 		}
 
 		if ( this.props.shouldCombineCards ) {
-			items = combineCards( items );
+			items = combineCards( items, this.props.postsStore );
 		}
 
 		return {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -186,7 +186,7 @@ const combineCards = ( postKeys ) => {
 	);
 	const sorted = reverse( sortBy( combined, getMomentForPostKey ) );
 	return sorted;
-}
+};
 
 function injectRecommendations( posts, recs = [] ) {
 	if ( ! recs || recs.length === 0 ) {
@@ -200,15 +200,16 @@ function injectRecommendations( posts, recs = [] ) {
 	}
 
 	let recIndex = 0;
-
+	let postsIndex = 0;
 	return flatMap( posts, ( post, index ) => {
-		if ( index && index % itemsBetweenRecs === 0 && recIndex < recs.length ) {
+		if ( index && postsIndex % itemsBetweenRecs === 0 && recIndex < recs.length ) {
 			const recBlock = {
 				isRecommendationBlock: true,
 				recommendations: recs.slice( recIndex, recIndex + RECS_PER_BLOCK ),
 				index: recIndex
 			};
 			recIndex += RECS_PER_BLOCK;
+			postsIndex += post.isCombination ? clamp( post.postIds.length, 5 ) : 1;
 			return [
 				recBlock,
 				post
@@ -265,13 +266,12 @@ class ReaderStream extends React.Component {
 			}
 		}
 
-		let items = this.state && this.state.items;
-		if ( ! this.state || posts !== this.state.posts || recs !== this.state.recs ) {
-			items = injectRecommendations( posts, recs );
-		}
-
+		let items;
 		if ( this.props.shouldCombineCards ) {
-			items = combineCards( items, this.props.postsStore );
+			items = combineCards( posts );
+		}
+		if ( ! this.state || posts !== this.state.posts || recs !== this.state.recs ) {
+			items = injectRecommendations( items, recs );
 		}
 
 		return {


### PR DESCRIPTION
This PR aims to experiment with CombinedCards.  One of the goals of combined cards is to make it so that a noisy site cannot overwhelm your following stream. This PR takes that goal and runs with it wayy further

This PR changes the current behavior of CCs in two ways:
- lifts the requirement that combined posts must be consecutive.  Instead each site has a maximum number of `CARDS_PER_DAY` (combined cards counts as 1).  As of now its set to 4.  Real Example: Lets say you follow uproxx which posts a ton of times per day.  Now it will at-maximum be allowed to have 4 separate combined cards throughout the day
- combined cards will group together as many posts that occurred during the allotted timeframe (6 hours currently because 4 cards per day and 24/4 = 6).  It will max out at displaying 5.

known brokeness:
- keyboard shortcuts.  they currently rely on the original postKey ordering whereas the entire point of this PR is to see how it feels if we break with reverse chronological


After making this PR it made me think of the following stream a bit differently.  Instead of being a "complete collection of everything I follow in reverse-chronological order", it become more like a jumping off point to explore the things that I follow.

cc @fraying 

edit: the code is currently super messy, so feel free not to look at it 😟 