### PR TITLE
Reader: testing out a couple tweaks to combined cards

### DIFF
--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import React from 'react';
-import { get } from 'lodash';
+import { get, take } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -24,6 +24,8 @@ const ReaderCombinedCard = ( { posts, site, feed, selectedPostKey, onClick, isDi
 	const streamUrl = getStreamUrl( feedId, siteId );
 	const siteName = siteNameFromSiteAndPost( site, posts[ 0 ] );
 	const isSelectedPost = post => keysAreEqual( keyForPost( post ), selectedPostKey );
+	const firstFivePosts = take( posts, 5 );
+	const thereWereMorePosts = firstFivePosts.length !== posts.length;
 
 	return (
 		<Card className="reader-combined-card">
@@ -49,10 +51,13 @@ const ReaderCombinedCard = ( { posts, site, feed, selectedPostKey, onClick, isDi
 							}
 						} ) }
 					</p>
+					{ thereWereMorePosts &&
+						<p> { translate( "there were more than 5 posts, read more at the site" ) } </p>
+					}
 				</div>
 			</header>
 			<ul className="reader-combined-card__post-list">
-				{ posts.map( post => (
+				{ firstFivePosts.map( post => (
 					<ReaderCombinedCardPost
 						key={ `post-${ post.ID }` }
 						post={ post }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -118,19 +118,6 @@ function combine( postKey1, postKey2 ) {
 	};
 }
 
-// const combineCards = ( postKeys ) => postKeys.reduce(
-// 	( accumulator, postKey ) => {
-// 		const lastPostKey = last( accumulator );
-// 		if ( sameSite( lastPostKey, postKey ) ) {
-// 			accumulator[ accumulator.length - 1 ] = combine( last( accumulator ), postKey );
-// 		} else {
-// 			accumulator.push( postKey );
-// 		}
-// 		return accumulator;
-// 	},
-// 	[]
-// );
-
 const getMomentForPostKey = postKey =>  {
 	window.getMomentForPostKey = getMomentForPostKey;
 	let post = PostStore.get( postKey );
@@ -154,14 +141,14 @@ const getMomentForPostKey = postKey =>  {
 
 /* Combine all cards from the same site that are within the same 2 hour span
  */
-const CARDS_PER_DAY_PER_SITE = 4; // max combined card only counts as one card
-const HOURS_PER_CARD = 24 / CARDS_PER_DAY_PER_SITE;
+// const CARDS_PER_DAY_PER_SITE = 4; // max combined card only counts as one card
+const MINUTES_PER_CARD = 10;
 const combineCards = ( postKeys ) => {
 	window.moment = moment;
 	const timeSliced = groupBy( postKeys, postKey => {
 		const moment = getMomentForPostKey( postKey );
-		moment && moment.millisecond( 0 ).second( 0 ).minute( 0 ).hour(
-			Math.floor( moment.hour() / HOURS_PER_CARD ) * HOURS_PER_CARD
+		moment && moment.millisecond( 0 ).second( 0 ).minute(
+			Math.floor( moment.minute() / MINUTES_PER_CARD ) * MINUTES_PER_CARD
 		)
 		return moment;
 	} );


### PR DESCRIPTION
This PR aims to experiment with CombinedCards.  One of the goals of combined cards is to make it so that a noisy site cannot overwhelm your following stream. This PR takes that goal and runs with it wayy further

This PR changes the current behavior of CCs in two ways:
- lifts the requirement that combined posts must be consecutive.  Instead each site has a maximum number of `CARDS_PER_DAY` (combined cards counts as 1).  As of now its set to 4.  Real Example: Lets say you follow uproxx which posts a ton of times per day.  Now it will at-maximum be allowed to have 4 separate combined cards throughout the day
- combined cards will now group together as many posts that occurred during the allotted timeframe (6 hours currently because 4 cards per day and 24/4 = 6).
- even though combining will eat as many cards as occur, it will display a maximum of 5.

known brokeness:
- keyboard shortcuts.  they currently rely on the original postKey ordering whereas the entire point of this PR is to see how it feels if we break with reverse chronological

further ideas:
- click to expand and see all posts in card?

After making this PR it made me think of the following stream a bit differently.  Instead of being a "complete collection of everything I follow in reverse-chronological order", it become more like a jumping off point to explore the things that I follow.

@fraying @bluefuton @blowery: please take it for a spin! let me know how it feels. I'm okay with throwing it out but I wanted to test out this idea.


edit: the code is currently super messy, so feel free not to look at it 😟 