### PR TITLE
Add space after entering suggestion from keyboard.

### DIFF
--- a/client/components/suggestions/index.jsx
+++ b/client/components/suggestions/index.jsx
@@ -100,7 +100,7 @@ const Suggestions = React.createClass( {
 				break;
 			case 'Enter' :
 				if ( this.state.suggestionPosition !== -1 ) {
-					this.props.suggest( this.state.currentSuggestion );
+					this.props.suggest( this.state.currentSuggestion + ' ' );
 				}
 				break;
 		}


### PR DESCRIPTION
### Info 
When user picks up suggestion from Suggestions component we want him to be able to pick next suggestion straight away if he wishes to. For this to happen function that inputs suggestion into search adds one single space char at the end of the suggestion so new suggestions can be added.

### Testing
Open the `/design` and pick category in search welcome banner and then using keyboard pick a term.
After `Enter` the suggestion should be added to the input with one additional space char at the end. Welcome banner should be opened again ready for new selection.
