### PR TITLE
ThemesSearch: add keyboard support to welcome banner.

### DIFF
--- a/client/components/suggestions/index.jsx
+++ b/client/components/suggestions/index.jsx
@@ -23,7 +23,6 @@ const Suggestions = React.createClass( {
 
 	getDefaultProps() {
 		return {
-			welcomeSign: noop,
 			suggest: noop,
 			terms: {},
 			input: '',
@@ -243,15 +242,8 @@ const Suggestions = React.createClass( {
 	},
 
 	render() {
-		let suggestion;
-		if ( this.props.input === '' ) {
-			suggestion = this.props.welcomeSign;
-		} else {
-			suggestion = this.createSuggestions( this.state.suggestions );
-		}
-
 		return (
-			<div className="suggestions">{ suggestion }</div>
+			<div className="suggestions">{ this.createSuggestions( this.state.suggestions ) }</div>
 		);
 	}
 

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -58,7 +58,13 @@ class ThemesMagicSearchCard extends React.Component {
 
 	onKeyDown = ( event ) => {
 		this.findTextForSuggestions( event.target.value );
-		this.refs.suggestions.handleKeyEvent( event );
+
+		//We need this logic because we are working togheter with different modules.
+		//that provide suggestions to the input depending on what is currently in input
+		const target = this.state.editedSearchElement !== '' ? 'suggestions' : 'welcome';
+		if ( this.refs[ target ] ) {
+			this.refs[ target ].handleKeyEvent( event );
+		}
 	}
 
 	onClick = ( event ) => {
@@ -198,11 +204,6 @@ class ThemesMagicSearchCard extends React.Component {
 
 		const taxonomies = getTaxonomies();
 		const taxonomiesKeys = Object.keys( taxonomies );
-		const welcomeSignProps = {
-			taxonomies: taxonomiesKeys,
-			topSearches: [],
-			suggestionsCallback: this.insertTextInInput
-		};
 
 		const searchField = (
 			<Search
@@ -232,7 +233,8 @@ class ThemesMagicSearchCard extends React.Component {
 			'has-highlight': this.state.searchIsOpen
 		} );
 
-		const welcome = ( <MagicSearchWelcome { ...welcomeSignProps } /> );
+		// Check if we want to render suggestions or welcome banner
+		const renderSuggestions = this.state.editedSearchElement !== '';
 
 		return (
 			<div className={ magicSearchClass }>
@@ -246,13 +248,22 @@ class ThemesMagicSearchCard extends React.Component {
 						/>
 					}
 				</div>
-				<Suggestions
-					ref="suggestions"
-					terms={ taxonomies }
-					input={ this.state.editedSearchElement }
-					suggest={ this.suggest }
-					welcomeSign={ welcome }
-				/>
+				{ renderSuggestions &&
+					<Suggestions
+						ref="suggestions"
+						terms={ taxonomies }
+						input={ this.state.editedSearchElement }
+						suggest={ this.suggest }
+					/>
+				}
+				{ ! renderSuggestions &&
+					<MagicSearchWelcome
+						ref="welcome"
+						taxonomies={ taxonomiesKeys }
+						topSearches={ [] }
+						suggestionsCallback={ this.insertTextInInput }
+					/>
+				}
 			</div>
 		);
 	}

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -107,11 +107,15 @@
 
 .themes-magic-search {
 
+	.themes-magic-search-card__welcome,
 	.suggestions {
 		display: none;
 	}
 
+
+
 	&.has-suggestions {
+		.themes-magic-search-card__welcome,
 		.suggestions {
 			display: block;
 			margin-top: 5px;
@@ -160,12 +164,15 @@
 	&:hover {
 		box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20% );
 	}
+
+	&.themes-magic-search-card__welcome-taxonomy-highlight {
+		box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20% );
+	}
 }
 
 .themes-magic-search-card__welcome-taxonomy-icon {
 	pointer-events: none;
 }
-
 
 // Colors
 @mixin themes-magic-search__token-colors( $name, $color ) {

--- a/client/my-sites/themes/themes-magic-search-card/welcome.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/welcome.jsx
@@ -9,7 +9,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import { localize } from 'i18n-calypso';
+import i18n from 'i18n-calypso';
 import { taxonomyToGridicon } from './taxonomy-styling.js';
 
 class MagicSearchWelcome extends React.Component {
@@ -18,16 +18,55 @@ class MagicSearchWelcome extends React.Component {
 		super( props );
 	}
 
+	state = { suggestionPosition: -1 }
+
 	onMouseDown = ( event ) => {
 		this.props.suggestionsCallback( event.target.textContent + ':' );
 		event.stopPropagation();
 		event.preventDefault();
 	}
 
+	incPosition = () => {
+		const position = ( this.state.suggestionPosition + 1 ) % this.props.taxonomies.length;
+		this.setState( {
+			suggestionPosition: position,
+		} );
+	}
+
+	decPosition = () => {
+		const position = ( this.state.suggestionPosition - 1 );
+		this.setState( {
+			suggestionPosition: position < 0 ? this.props.taxonomies.length - 1 : position
+		} );
+	}
+
+	handleKeyEvent = ( event ) => {
+		switch ( event.key ) {
+			case 'ArrowDown' :
+				this.incPosition();
+				event.preventDefault();
+				break;
+			case 'ArrowUp' :
+				this.decPosition();
+				event.preventDefault();
+				break;
+			case 'Enter' :
+				const position = this.state.suggestionPosition;
+				if ( position !== -1 ) {
+					this.props.suggestionsCallback( this.props.taxonomies[ position ] + ':' );
+					event.stopPropagation();
+					event.preventDefault();
+				}
+				break;
+		}
+	}
+
 	renderToken = ( taxonomy ) => {
 		const themesTokenTypeClass = classNames(
 			'themes-magic-search-card__welcome-taxonomy',
-			'themes-magic-search-card__welcome-taxonomy-type-' + taxonomy
+			'themes-magic-search-card__welcome-taxonomy-type-' + taxonomy,
+			{ 'themes-magic-search-card__welcome-taxonomy-highlight':
+				this.props.taxonomies[ this.state.suggestionPosition ] === taxonomy }
 		);
 
 		return (
@@ -45,7 +84,7 @@ class MagicSearchWelcome extends React.Component {
 	render() {
 		return (
 			<div className="themes-magic-search-card__welcome" >
-				<span className="themes-magic-search-card__welcome-header">{ this.props.translate( 'Search by' ) }</span>
+				<span className="themes-magic-search-card__welcome-header">{ i18n.translate( 'Search by' ) }</span>
 				<div className="themes-magic-search-card__welcome-taxonomies">
 					{ this.props.taxonomies.map( taxonomy => this.renderToken( taxonomy ) ) }
 				</div>
@@ -58,7 +97,6 @@ MagicSearchWelcome.propTypes = {
 	taxonomies: PropTypes.array,
 	topSearches: PropTypes.array,
 	suggestionsCallback: PropTypes.func,
-	translate: React.PropTypes.func.isRequired,
 };
 
 MagicSearchWelcome.defaultProps = {
@@ -67,4 +105,4 @@ MagicSearchWelcome.defaultProps = {
 	suggestionsCallback: noop
 };
 
-export default localize( MagicSearchWelcome );
+export default MagicSearchWelcome;


### PR DESCRIPTION
### Info
M5 suggestions did not have keyboard support when welcome banner was displayed. Now when input has focus it is possible to operate only with keyboard.
Up/Down/Enter keys are usable.

### Note
WelcomBanner was previously passed as prop to Suggestions. This turned out to be very poor design. Now does are two separate components.

### Testing
Open `/design` and start using keyboard.
