### PR TITLE
Suggestions: Up arrow wrap around should calculate position correctly.

### DIFF
--- a/client/components/suggestions/index.jsx
+++ b/client/components/suggestions/index.jsx
@@ -81,9 +81,9 @@ const Suggestions = React.createClass( {
 	},
 
 	decPosition() {
-		const position = ( this.state.suggestionPosition - 1 ) % this.countSuggestions();
+		const position = this.state.suggestionPosition - 1;
 		this.setState( {
-			suggestionPosition: position,
+			suggestionPosition: position < 0 ? this.countSuggestions() - 1 : position,
 			currentSuggestion: this.getSuggestionForPosition( position )
 		} );
 	},


### PR DESCRIPTION
### Info
When user is clicking up on keyboard in suggestions components internal counter was wrapping around not in a proper way. This PR fixes that and Up click in top position wraps to bottom.

### Testing
Open `/design` start typing in Search until Suggestions appear( not welcome banner) start using keyboard arrows and go to the top most position and click once more. Highlight should go to the bottom (wrap-around).