### PR TITLE
Editor: Update notice action to in app preview

### DIFF
--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -29,6 +29,7 @@ export class EditorNotice extends Component {
 		status: PropTypes.string,
 		action: PropTypes.string,
 		link: PropTypes.string,
+		onViewClick: PropTypes.func,
 		onDismissClick: PropTypes.func,
 		error: PropTypes.object
 	}
@@ -192,8 +193,27 @@ export class EditorNotice extends Component {
 		}
 	}
 
+	renderNoticeAction() {
+		const { onViewClick, action, link } = this.props;
+		if ( onViewClick && ! this.props.site.jetpack ) {
+			return (
+				<NoticeAction onClick={ onViewClick } icon={ 'visible' }>
+					{ this.getText( action ) }
+				</NoticeAction>
+			);
+		}
+
+		return (
+			link && (
+				<NoticeAction href={ link } external>
+					{ this.getText( action ) }
+				</NoticeAction>
+			)
+		);
+	}
+
 	render() {
-		const { siteId, message, status, action, link, onDismissClick } = this.props;
+		const { siteId, message, status, onDismissClick } = this.props;
 		const text = this.getErrorMessage() || this.getText( message );
 
 		return (
@@ -203,11 +223,7 @@ export class EditorNotice extends Component {
 					<Notice
 						{ ...{ status, text, onDismissClick } }
 						showDismiss={ true }>
-						{ link && (
-							<NoticeAction href={ link } external>
-								{ this.getText( action ) }
-							</NoticeAction>
-						) }
+						{ this.renderNoticeAction() }
 					</Notice>
 				) }
 			</div>
@@ -226,6 +242,6 @@ export default connect( ( state ) => {
 		siteId,
 		site: getSelectedSite( state ),
 		type: post.type,
-		typeObject: getPostType( state, siteId, post.type )
+		typeObject: getPostType( state, siteId, post.type ),
 	};
 }, { setLayoutFocus } )( localize( EditorNotice ) );

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -17,6 +17,7 @@ import { getPostType } from 'state/post-types/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { isMobile } from 'lib/viewport';
+import { isSitePreviewable } from 'state/sites/selectors';
 
 export class EditorNotice extends Component {
 	static propTypes = {
@@ -30,6 +31,7 @@ export class EditorNotice extends Component {
 		action: PropTypes.string,
 		link: PropTypes.string,
 		onViewClick: PropTypes.func,
+		isSitePreviewable: PropTypes.bool,
 		onDismissClick: PropTypes.func,
 		error: PropTypes.object
 	}
@@ -194,8 +196,8 @@ export class EditorNotice extends Component {
 	}
 
 	renderNoticeAction() {
-		const { onViewClick, action, link } = this.props;
-		if ( onViewClick && ! this.props.site.jetpack ) {
+		const { onViewClick, action, link, isSitePreviewable } = this.props;
+		if ( onViewClick && isSitePreviewable ) {
 			return (
 				<NoticeAction onClick={ onViewClick } icon={ 'visible' }>
 					{ this.getText( action ) }
@@ -243,5 +245,6 @@ export default connect( ( state ) => {
 		site: getSelectedSite( state ),
 		type: post.type,
 		typeObject: getPostType( state, siteId, post.type ),
+		isSitePreviewable: isSitePreviewable( state, siteId ),
 	};
 }, { setLayoutFocus } )( localize( EditorNotice ) );

--- a/client/post-editor/editor-notice/test/index.jsx
+++ b/client/post-editor/editor-notice/test/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import { translate } from 'i18n-calypso';
+import sinon from 'sinon';
 
 /**
  * Internal dependencies
@@ -107,5 +108,39 @@ describe( 'EditorNotice', () => {
 		expect( wrapper.find( Notice ) ).to.have.prop( 'status' ).equal( 'is-success' );
 		expect( wrapper.find( NoticeAction ) ).to.have.prop( 'href' ).equal( 'https://example.wordpress.com/published-project' );
 		expect( wrapper.find( NoticeAction ) ).to.have.prop( 'children' ).equal( 'View Project' );
+	} );
+
+	it( 'should use onViewClick function if provided on non-jetpack sites', () => {
+		const spy = sinon.spy();
+
+		const wrapper = shallow(
+			<EditorNotice
+				translate={ translate }
+				message="published"
+				status="is-success"
+				type="page"
+				link="https://example.wordpress.com/published-page"
+				action="view"
+				onViewClick={ spy }
+				site={ {
+					URL: 'https://example.wordpress.com',
+					title: 'Example Site',
+					jetpack: false
+				} } />
+		);
+
+		expect( wrapper.find( Notice ) ).to.have.prop( 'text' ).eql(
+			translate( 'Page published on {{siteLink/}}!', {
+				components: {
+					siteLink: <a href="https://example.wordpress.com" target="_blank" rel="noopener noreferrer">Example Site</a>
+				}
+			} )
+		);
+		expect( wrapper.find( Notice ) ).to.have.prop( 'status' ).equal( 'is-success' );
+		expect( wrapper.find( NoticeAction ) ).to.have.prop( 'icon' ).equal( 'visible' );
+		expect( wrapper.find( NoticeAction ) ).to.have.prop( 'children' ).equal( 'View Page' );
+		expect( wrapper.find( NoticeAction ) ).to.have.prop( 'onClick' ).equal( spy );
+		wrapper.find( NoticeAction ).simulate( 'click' );
+		expect( spy ).to.have.been.calledOnce;
 	} );
 } );

--- a/client/post-editor/editor-notice/test/index.jsx
+++ b/client/post-editor/editor-notice/test/index.jsx
@@ -110,7 +110,7 @@ describe( 'EditorNotice', () => {
 		expect( wrapper.find( NoticeAction ) ).to.have.prop( 'children' ).equal( 'View Project' );
 	} );
 
-	it( 'should use onViewClick function if provided on non-jetpack sites', () => {
+	it( 'should use onViewClick function if provided a previewable site', () => {
 		const spy = sinon.spy();
 
 		const wrapper = shallow(
@@ -121,11 +121,11 @@ describe( 'EditorNotice', () => {
 				type="page"
 				link="https://example.wordpress.com/published-page"
 				action="view"
+				isSitePreviewable={ true }
 				onViewClick={ spy }
 				site={ {
 					URL: 'https://example.wordpress.com',
 					title: 'Example Site',
-					jetpack: false
 				} } />
 		);
 

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -249,7 +249,8 @@ export const PostEditor = React.createClass( {
 						<div className="editor">
 							<EditorNotice
 								{ ...this.state.notice }
-								onDismissClick={ this.hideNotice } />
+								onDismissClick={ this.hideNotice }
+								onViewClick={ this.iframePreview } />
 							<EditorActionBar
 								isNew={ this.state.isNew }
 								onPrivatePublish={ this.onPublish }

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -56,6 +56,7 @@ import StatusLabel from 'post-editor/editor-status-label';
 import { editedPostHasContent } from 'state/selectors';
 import EditorGroundControl from 'post-editor/editor-ground-control';
 import { isMobile } from 'lib/viewport';
+import { isSitePreviewable } from 'state/sites/selectors';
 
 export const PostEditor = React.createClass( {
 	propTypes: {
@@ -331,7 +332,7 @@ export const PostEditor = React.createClass( {
 						setPostDate={ this.setPostDate }
 						onSave={ this.onSave }
 						/>
-					{ this.iframePreviewEnabled() ?
+					{ this.props.isSitePreviewable ?
 						<EditorPreview
 							showPreview={ this.state.showPreview }
 							onClose={ this.onPreviewClose }
@@ -583,7 +584,7 @@ export const PostEditor = React.createClass( {
 		var status = 'draft',
 			previewPost;
 
-		if ( this.iframePreviewEnabled() && ! event.metaKey && ! event.ctrlKey ) {
+		if ( this.props.isSitePreviewable && ! event.metaKey && ! event.ctrlKey ) {
 			return this.iframePreview();
 		}
 
@@ -611,11 +612,6 @@ export const PostEditor = React.createClass( {
 		} else {
 			this.onSave( null, previewPost );
 		}
-	},
-
-	iframePreviewEnabled: function() {
-		var site = this.props.sites.getSelectedSite();
-		return site && ! site.jetpack;
 	},
 
 	iframePreview: function() {
@@ -848,6 +844,7 @@ export default connect(
 			hasContent: editedPostHasContent( state, siteId, postId ),
 			layoutFocus: getCurrentLayoutFocus( state ),
 			hasBrokenPublicizeConnection: hasBrokenSiteUserConnection( state, siteId, userId ),
+			isSitePreviewable: isSitePreviewable( state, siteId ),
 		};
 	},
 	( dispatch ) => {


### PR DESCRIPTION
When a new page or post is published/scheduled/updated, we display a success
notice including a link to open the post/page. This updates the notice action in
that notice to use the in app preview if available instead of opening in another
tab. The commit also includes tests for the desired `NoticeAction` behavior.

## To test
1. Starting at http://calypso.localhost:3000/post, publish a new post. The "View Post" button should have a visible gridicon and open in app for WordPress.com and Jetpack sites.
2. Try updating and scheduling the same post. The view/preview link should continue to open in app.
3. Open the editor on a VIP post or page. Publish a new post/page or update an existing one. You should still see the external icon since [`isSitePreviewable`](https://github.com/Automattic/wp-calypso/blob/master/client/state/sites/selectors.js#L265) will return false.

## Screenshots

**Updated Notice Action**
<img width="1280" alt="screen shot 2017-03-14 at 7 57 25 am" src="https://cloud.githubusercontent.com/assets/7240478/23903997/0323b0ba-088c-11e7-9275-187c28755d17.png">

**Preview**
<img width="1282" alt="screen shot 2017-03-14 at 7 57 35 am" src="https://cloud.githubusercontent.com/assets/7240478/23903976/f6a40de4-088b-11e7-84cf-b3e700866401.png">

**Notice if preview not available**
_(Site title in notice removed on purpose)_
<img width="1008" alt="screen shot 2017-03-14 at 08 01 16" src="https://cloud.githubusercontent.com/assets/7240478/23904137/6e9bcee0-088c-11e7-911a-5eae0403253f.png">

Resolves: #11981