### PR TITLE
Add social buttons to sign up

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -111,6 +111,7 @@
 @import 'components/gravatar/style';
 @import 'components/happiness-support/style';
 @import 'components/header-cake/style';
+@import 'components/hr-with-text/style';
 @import 'components/infinite-list/style';
 @import 'components/info-popover/style';
 @import 'components/input-chrono/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -153,6 +153,7 @@
 @import 'components/site-title-example/style';
 @import 'components/sites-dropdown/style';
 @import 'components/sites-popover/style';
+@import 'components/social-buttons/style';
 @import 'components/spinner/style';
 @import 'components/spinner-button/style';
 @import 'components/spinner-line/style';
@@ -170,7 +171,6 @@
 @import 'components/phone-input/style';
 @import 'components/section-header/style';
 @import 'components/seo-preview-pane/style';
-@import 'components/signup-form/style';
 @import 'components/tooltip/style';
 @import 'components/upgrades/credit-card-number-input/style';
 @import 'components/user/style';

--- a/client/components/hr-with-text/README.md
+++ b/client/components/hr-with-text/README.md
@@ -1,0 +1,14 @@
+HR element with text over it
+============================
+
+
+An hr-like line with text on top:
+`------------------ text ---------------------`
+
+## Usage
+
+```js
+import HrWithText from 'components/hr-with-text';
+
+<HrWithText>This is some text</HrWithText>
+```

--- a/client/components/hr-with-text/README.md
+++ b/client/components/hr-with-text/README.md
@@ -2,7 +2,8 @@ HR element with text over it
 ============================
 
 
-An hr-like line with text on top:
+An [hr-like](https://developer.mozilla.org/en/docs/Web/HTML/Element/hr) line with text on top:
+
 `------------------ text ---------------------`
 
 ## Usage

--- a/client/components/hr-with-text/index.jsx
+++ b/client/components/hr-with-text/index.jsx
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+
+const HrWithText = ( { children } ) => (
+	<div className="hr-with-text">
+		<div>
+			{ children }
+		</div>
+	</div>
+);
+
+HrWithText.propTypes = {
+	children: PropTypes.node,
+};
+
+export default HrWithText;

--- a/client/components/hr-with-text/style.scss
+++ b/client/components/hr-with-text/style.scss
@@ -1,0 +1,36 @@
+.hr-with-text {
+	width: 100%;
+	display: block;
+	text-align: center;
+	overflow: hidden;
+	margin: 20px 0;
+
+	> div {
+		position: relative;
+		display: inline-block;
+		font-size: 14px;
+		line-height: 14px;
+		color: #c8d7e1;
+		max-width: 80%;
+
+		&:before, &:after {
+			content: "";
+			position: absolute;
+			top: 50%;
+			width: 9999px;
+			height: 1px;
+			background-color: #c8d7e1;
+		}
+
+		&:before {
+			right: 100%;
+			margin-right: 5px;
+		}
+
+		&::after {
+			left: 100%;
+			margin-left: 5px;
+		}
+	}
+}
+

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -28,6 +28,7 @@ import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import { mergeFormWithValue } from 'signup/utils';
 import SocialSignupForm from './social';
+import HrWithText from 'components/hr-with-text';
 
 const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 1500,
 	debug = debugModule( 'calypso:signup-form:form' );
@@ -456,7 +457,9 @@ export default React.createClass( {
 						</header>
 					}
 					{ this.props.isSocialSignupEnabled && <SocialSignupForm /> }
-					{ this.props.isSocialSignupEnabled && <hr /> }
+					{ this.props.isSocialSignupEnabled && <HrWithText>
+						{ i18n.translate( 'Or sign up with your email address:' ) }
+					</HrWithText> }
 					{ this.formFields() }
 					{ this.props.formFooter || this.formFooter() }
 				</LoggedOutForm>

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -27,6 +27,7 @@ import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import { mergeFormWithValue } from 'signup/utils';
+import SocialSignupForm from './social';
 
 const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 1500,
 	debug = debugModule( 'calypso:signup-form:form' );
@@ -46,7 +47,14 @@ export default React.createClass( {
 	displayName: 'SignupForm',
 
 	propTypes: {
+		isSocialSignupEnabled: PropTypes.bool,
 		suggestedUsername: PropTypes.string.isRequired
+	},
+
+	getDefaultProps() {
+		return {
+			isSocialSignupEnabled: false,
+		};
 	},
 
 	getInitialState() {
@@ -447,6 +455,8 @@ export default React.createClass( {
 							{ this.props.formHeader }
 						</header>
 					}
+					{ this.props.isSocialSignupEnabled && <SocialSignupForm /> }
+					{ this.props.isSocialSignupEnabled && <hr /> }
 					{ this.formFields() }
 					{ this.props.formFooter || this.formFooter() }
 				</LoggedOutForm>

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -303,7 +303,7 @@ export default React.createClass( {
 				<ValidationFieldset errorMessages={ this.getErrorMessagesWithLogin( 'email' ) }>
 					<FormLabel htmlFor="email">{ this.translate( 'Your email address' ) }</FormLabel>
 					<FormTextInput
-						autoFocus={ isEmpty( this.props.email ) }
+						autoFocus={ isEmpty( this.props.email ) && ! this.props.isSocialSignupEnabled }
 						autoCapitalize="off"
 						autoCorrect="off"
 						className="signup-form__input"

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
-import { map, forEach, head, includes, keys } from 'lodash';
+import { map, forEach, head, includes, isEmpty, keys } from 'lodash';
 import debugModule from 'debug';
 import classNames from 'classnames';
 import i18n from 'i18n-calypso';
@@ -70,9 +70,9 @@ export default React.createClass( {
 
 	getInitialFields() {
 		return {
-			email: this.props.email || null,
-			username: null,
-			password: null
+			email: this.props.email || '',
+			username: '',
+			password: ''
 		};
 	},
 
@@ -303,7 +303,7 @@ export default React.createClass( {
 				<ValidationFieldset errorMessages={ this.getErrorMessagesWithLogin( 'email' ) }>
 					<FormLabel htmlFor="email">{ this.translate( 'Your email address' ) }</FormLabel>
 					<FormTextInput
-						autoFocus={ ! this.props.email }
+						autoFocus={ isEmpty( this.props.email ) }
 						autoCapitalize="off"
 						autoCorrect="off"
 						className="signup-form__input"
@@ -322,7 +322,7 @@ export default React.createClass( {
 				<ValidationFieldset errorMessages={ this.getErrorMessagesWithLogin( 'username' ) }>
 					<FormLabel htmlFor="username">{ this.translate( 'Choose a username' ) }</FormLabel>
 					<FormTextInput
-						autoFocus={ ! ! this.props.email }
+						autoFocus={ ! isEmpty( this.props.email ) }
 						autoCapitalize="off"
 						autoCorrect="off"
 						className="signup-form__input"

--- a/client/components/signup-form/social.jsx
+++ b/client/components/signup-form/social.jsx
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import GoogleLoginButton from 'components/social-buttons/google';
+import FacebookLoginButton from 'components/social-buttons/facebook';
+
+/**
+ * External dependencies
+ */
+import config from 'config';
+
+class SocialSignupForm extends Component {
+	constructor() {
+		super();
+		this.onGoogleResponse = this.onGoogleResponse.bind( this );
+		this.onFacebookResponse = this.onFacebookResponse.bind( this );
+	}
+
+	onGoogleResponse( response ) {
+		if ( ! response.Zi || ! response.Zi.id_token ) {
+			return;
+		}
+		// TODO: post response to the new wpcom endpoint to login
+	}
+
+	onFacebookResponse( response ) {
+		if ( ! response.email ) {
+			return;
+		}
+		// TODO: post response to the new wpcom endpoint to login
+	}
+
+	render() {
+		return (
+			<div className="signup-form__social">
+				<GoogleLoginButton
+					clientId={ config( 'google_oauth_client_id' ) }
+					responseHandler={ this.onGoogleResponse } />
+				<FacebookLoginButton
+					appId={ config( 'facebook_app_id' ) }
+					responseHandler={ this.onFacebookResponse } />
+			</div>
+		);
+	}
+}
+
+export default SocialSignupForm;

--- a/client/components/signup-form/style.scss
+++ b/client/components/signup-form/style.scss
@@ -18,3 +18,19 @@
 		}
 	}
 }
+
+.signup-form__social {
+	display: flex;
+	align-items: center;
+	margin: 0 -5px;
+
+	> button {
+		flex: 1;
+		box-sizing: border-box;
+		margin: 0 5px;
+	}
+
+	button {
+		width: 100%;
+	}
+}

--- a/client/components/social-buttons/facebook.js
+++ b/client/components/social-buttons/facebook.js
@@ -1,0 +1,92 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import SocialLogo from 'social-logos';
+import { loadScript } from 'lib/load-script';
+
+export default class FacebookLoginButton extends Component {
+
+	// See: https://developers.facebook.com/docs/javascript/reference/FB.init/v2.8
+	static propTypes = {
+		appId: PropTypes.string.isRequired,
+		version: PropTypes.string,
+		cookie: PropTypes.bool,
+		status: PropTypes.bool,
+		xfbml: PropTypes.bool,
+		responseHandler: PropTypes.func.isRequired,
+		scope: PropTypes.string,
+	};
+
+	static defaultProps = {
+		version: 'v2.8',
+		cookie: false,
+		status: false,
+		xfbml: true,
+		scope: 'public_profile,email',
+	};
+
+	constructor( props ) {
+		super( props );
+		this.FB = null;
+		this.handleClick = this.handleClick.bind( this );
+	}
+
+	componentWillMount() {
+		this.loadFacebookAuth();
+	}
+
+	loadDependency() {
+		if ( window.FB ) {
+			return Promise.resolve( window.FB );
+		}
+
+		return new Promise( resolve => {
+			loadScript( '//connect.facebook.net/en_US/sdk.js', () => resolve( window.FB ) );
+		} );
+	}
+
+	loadFacebookAuth() {
+		if ( this.FB ) {
+			return Promise.resolve();
+		}
+
+		return new Promise( resolve => {
+			this.loadDependency().then( FB => {
+				FB.init( {
+					appId: this.props.appId,
+					version: this.props.version,
+					cookie: this.props.cookie,
+					xfbml: this.props.xfbml,
+				} );
+				this.FB = FB;
+				resolve();
+			} );
+		} );
+	}
+
+	handleClick() {
+		const { responseHandler, scope } = this.props;
+
+		// Handle click async if the library is not loaded yet
+		// the popup might be blocked by the browser in that case
+		this.loadFacebookAuth().then( () => {
+			this.FB.login( response => {
+				responseHandler( response );
+			}, { scope } );
+		} );
+	}
+
+	render() {
+		return (
+			<button className="button" onClick={ this.handleClick }>
+				<span>
+					<SocialLogo className="social-buttons__logo" icon="facebook" size={ 24 } />
+					<span className="social-buttons__service-name">
+						Facebook
+					</span>
+				</span>
+			</button>
+		);
+	}
+}

--- a/client/components/social-buttons/facebook.js
+++ b/client/components/social-buttons/facebook.js
@@ -28,12 +28,13 @@ export default class FacebookLoginButton extends Component {
 
 	constructor( props ) {
 		super( props );
-		this.initFacebookP = null;
+
+		this.initialized = null;
 		this.handleClick = this.handleClick.bind( this );
 	}
 
 	componentWillMount() {
-		this.loadFacebookAuth();
+		this.initialize();
 	}
 
 	loadDependency() {
@@ -46,12 +47,12 @@ export default class FacebookLoginButton extends Component {
 		} );
 	}
 
-	loadFacebookAuth() {
-		if ( this.initFacebookP ) {
-			return this.initFacebookP;
+	initialize() {
+		if ( this.initialized ) {
+			return this.initialized;
 		}
 
-		this.initFacebookP = this.loadDependency().then( FB => {
+		this.initialized = this.loadDependency().then( FB => {
 			FB.init( {
 				appId: this.props.appId,
 				version: this.props.version,
@@ -61,11 +62,12 @@ export default class FacebookLoginButton extends Component {
 
 			return FB;
 		} ).catch( error => {
-			this.initFacebookP = null;
+			this.initialized = null;
+
 			return Promise.reject( error );
 		} );
 
-		return this.initFacebookP;
+		return this.initialized;
 	}
 
 	handleClick( event ) {
@@ -75,7 +77,7 @@ export default class FacebookLoginButton extends Component {
 
 		// Handle click async if the library is not loaded yet
 		// the popup might be blocked by the browser in that case
-		this.loadFacebookAuth().then( FB => {
+		this.initialize().then( FB => {
 			FB.login( response => {
 				responseHandler( response );
 			}, { scope } );
@@ -87,6 +89,7 @@ export default class FacebookLoginButton extends Component {
 			<button className="button" onClick={ this.handleClick }>
 				<span>
 					<SocialLogo className="social-buttons__logo" icon="facebook" size={ 24 } />
+
 					<span className="social-buttons__service-name">
 						Facebook
 					</span>

--- a/client/components/social-buttons/facebook.js
+++ b/client/components/social-buttons/facebook.js
@@ -28,7 +28,7 @@ export default class FacebookLoginButton extends Component {
 
 	constructor( props ) {
 		super( props );
-		this.FB = null;
+		this.initFacebookP = null;
 		this.handleClick = this.handleClick.bind( this );
 	}
 
@@ -47,22 +47,25 @@ export default class FacebookLoginButton extends Component {
 	}
 
 	loadFacebookAuth() {
-		if ( this.FB ) {
-			return Promise.resolve();
+		if ( this.initFacebookP ) {
+			return this.initFacebookP;
 		}
 
-		return new Promise( resolve => {
-			this.loadDependency().then( FB => {
-				FB.init( {
-					appId: this.props.appId,
-					version: this.props.version,
-					cookie: this.props.cookie,
-					xfbml: this.props.xfbml,
-				} );
-				this.FB = FB;
-				resolve();
+		this.initFacebookP = this.loadDependency().then( FB => {
+			FB.init( {
+				appId: this.props.appId,
+				version: this.props.version,
+				cookie: this.props.cookie,
+				xfbml: this.props.xfbml,
 			} );
+
+			return FB;
+		} ).catch( error => {
+			this.initFacebookP = null;
+			return Promise.reject( error );
 		} );
+
+		return this.initFacebookP;
 	}
 
 	handleClick() {
@@ -70,8 +73,8 @@ export default class FacebookLoginButton extends Component {
 
 		// Handle click async if the library is not loaded yet
 		// the popup might be blocked by the browser in that case
-		this.loadFacebookAuth().then( () => {
-			this.FB.login( response => {
+		this.loadFacebookAuth().then( FB => {
+			FB.login( response => {
 				responseHandler( response );
 			}, { scope } );
 		} );

--- a/client/components/social-buttons/facebook.js
+++ b/client/components/social-buttons/facebook.js
@@ -68,7 +68,9 @@ export default class FacebookLoginButton extends Component {
 		return this.initFacebookP;
 	}
 
-	handleClick() {
+	handleClick( event ) {
+		event.preventDefault();
+
 		const { responseHandler, scope } = this.props;
 
 		// Handle click async if the library is not loaded yet

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import SocialLogo from 'social-logos';
+import { loadScript } from 'lib/load-script';
+
+export default class GoogleLoginButton extends Component {
+	static propTypes = {
+		clientId: PropTypes.string.isRequired,
+		scope: PropTypes.string,
+		fetchBasicProfile: PropTypes.bool,
+		responseHandler: PropTypes.func.isRequired,
+	};
+
+	static defaultProps = {
+		scope: 'profile',
+		fetchBasicProfile: true,
+	};
+
+	constructor( props ) {
+		super( props );
+		this.googleAuth = null;
+		this.handleClick = this.handleClick.bind( this );
+	}
+
+	componentWillMount() {
+		this.loadGoogleAuth();
+	}
+
+	loadDependency() {
+		if ( window.gapi ) {
+			return Promise.resolve( window.gapi );
+		}
+
+		return new Promise( resolve => {
+			loadScript( 'https://apis.google.com/js/platform.js', () => resolve( window.gapi ) );
+		} );
+	}
+
+	loadGoogleAuth() {
+		return new Promise( resolve => {
+			if ( this.googleAuth ) {
+				return resolve(); // we cannot pass `this.googleAuth` as argument is because it's a thenable
+			}
+
+			this.loadDependency().then( gapi => {
+				gapi.load( 'auth2', () => {
+					this.googleAuth = gapi.auth2.init( {
+						client_id: this.props.clientId,
+						scope: this.props.scope,
+						fetch_basic_profile: this.props.fetchBasicProfile,
+					} );
+					resolve();
+				} );
+			} );
+		} );
+	}
+
+	handleClick() {
+		const { responseHandler } = this.props;
+
+		// Handle click async if the library is not loaded yet
+		// the popup might be blocked by the browser in that case
+		this.loadGoogleAuth().then( () => {
+			this.googleAuth.signIn().then( googleUser => {
+				responseHandler( googleUser );
+			} );
+		} );
+	}
+
+	render() {
+		return (
+			<button className="button" onClick={ this.handleClick }>
+				<span>
+					<SocialLogo className="social-buttons__logo" icon="google" size={ 24 } />
+					<span className="social-buttons__service-name">
+						Google
+					</span>
+				</span>
+			</button>
+		);
+	}
+}

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -20,12 +20,13 @@ export default class GoogleLoginButton extends Component {
 
 	constructor( props ) {
 		super( props );
-		this.initGoogleP = null;
+
+		this.initialized = null;
 		this.handleClick = this.handleClick.bind( this );
 	}
 
 	componentWillMount() {
-		this.loadGoogleAuth();
+		this.initialize();
 	}
 
 	loadDependency() {
@@ -38,12 +39,12 @@ export default class GoogleLoginButton extends Component {
 		} );
 	}
 
-	loadGoogleAuth() {
-		if ( this.initGoogleP ) {
-			return this.initGoogleP;
+	initialize() {
+		if ( this.initialized ) {
+			return this.initialized;
 		}
 
-		this.initGoogleP = this.loadDependency()
+		this.initialized = this.loadDependency()
 			.then( gapi => new Promise( resolve => gapi.load( 'client:auth2', resolve ) ).then( () => gapi ) )
 			.then( gapi => gapi.client.init( {
 					client_id: this.props.clientId,
@@ -52,11 +53,12 @@ export default class GoogleLoginButton extends Component {
 				} )
 				.then( () => gapi ) // don't try to return gapi.auth2.getAuthInstance() here, it has a `then` method
 			).catch( error => {
-				this.initGoogleP = null;
+				this.initialized = null;
+
 				return Promise.reject( error );
 			} );
 
-		return this.initGoogleP;
+		return this.initialized;
 	}
 
 	handleClick( event ) {
@@ -66,7 +68,7 @@ export default class GoogleLoginButton extends Component {
 
 		// Handle click async if the library is not loaded yet
 		// the popup might be blocked by the browser in that case
-		this.loadGoogleAuth().then( gapi => gapi.auth2.getAuthInstance().signIn().then( responseHandler ) );
+		this.initialize().then( gapi => gapi.auth2.getAuthInstance().signIn().then( responseHandler ) );
 	}
 
 	render() {
@@ -74,6 +76,7 @@ export default class GoogleLoginButton extends Component {
 			<button className="button" onClick={ this.handleClick }>
 				<span>
 					<SocialLogo className="social-buttons__logo" icon="google" size={ 24 } />
+
 					<span className="social-buttons__service-name">
 						Google
 					</span>

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -59,7 +59,9 @@ export default class GoogleLoginButton extends Component {
 		return this.initGoogleP;
 	}
 
-	handleClick() {
+	handleClick( event ) {
+		event.preventDefault();
+
 		const { responseHandler } = this.props;
 
 		// Handle click async if the library is not loaded yet

--- a/client/components/social-buttons/style.scss
+++ b/client/components/social-buttons/style.scss
@@ -1,0 +1,12 @@
+/*rtl:ignore*/
+
+.social-buttons__logo {
+	vertical-align: top;
+	position: relative;
+	top: 1px;
+}
+
+.social-buttons__service-name {
+	margin-left: 8px;
+	line-height: 23px;
+}

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -225,6 +225,15 @@ if ( config.isEnabled( 'signup/domain-first-flow' ) ) {
 	};
 }
 
+if ( config.isEnabled( 'signup/social' ) ) {
+	flows.social = {
+		steps: [ 'user-social' ],
+		destination: '/',
+		description: 'Create an account without a blog with social signup enabled.',
+		lastModified: '2017-03-16'
+	};
+}
+
 if ( config( 'env' ) === 'development' ) {
 	flows[ 'test-plans' ] = {
 		steps: [ 'site', 'plans', 'user' ],

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -36,4 +36,5 @@ export default {
 	themes: ThemeSelectionComponent,
 	'themes-site-selected': ThemeSelectionComponent,
 	user: UserSignupComponent,
+	'user-social': UserSignupComponent,
 };

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -35,5 +35,5 @@ export default {
 	test: config( 'env' ) === 'development' ? require( 'signup/steps/test-step' ) : undefined,
 	themes: ThemeSelectionComponent,
 	'themes-site-selected': ThemeSelectionComponent,
-	user: UserSignupComponent
+	user: UserSignupComponent,
 };

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -67,6 +67,16 @@ export default {
 		providesDependencies: [ 'bearer_token', 'username' ]
 	},
 
+	'user-social': {
+		stepName: 'user-social',
+		apiRequestFunction: stepActions.createAccount,
+		providesToken: true,
+		providesDependencies: [ 'bearer_token', 'username' ],
+		props: {
+			isSocialSignupEnabled: true
+		},
+	},
+
 	'site-title': {
 		stepName: 'site-title',
 		providesDependencies: [ 'siteTitle' ]

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -22,11 +22,13 @@ export class UserStep extends Component {
 		flowName: PropTypes.string,
 		translate: PropTypes.func,
 		subHeaderText: PropTypes.string,
+		isSocialSignupEnabled: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		translate: identity,
-		suggestedUsername: identity
+		suggestedUsername: identity,
+		isSocialSignupEnabled: false,
 	};
 
 	state = {
@@ -149,7 +151,7 @@ export class UserStep extends Component {
 				submitForm={ this.submitForm }
 				submitButtonText={ this.submitButtonText() }
 				suggestedUsername={ this.props.suggestedUsername }
-				isSocialSignupEnabled={ isEnabled( 'signup/social' ) }
+				isSocialSignupEnabled={ this.props.isSocialSignupEnabled }
 			/>
 		);
 	}

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -149,7 +149,7 @@ export class UserStep extends Component {
 				submitForm={ this.submitForm }
 				submitButtonText={ this.submitButtonText() }
 				suggestedUsername={ this.props.suggestedUsername }
-				isSocialSignupEnabled={ true }
+				isSocialSignupEnabled={ isEnabled( 'signup/social' ) }
 			/>
 		);
 	}

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -149,6 +149,7 @@ export class UserStep extends Component {
 				submitForm={ this.submitForm }
 				submitButtonText={ this.submitButtonText() }
 				suggestedUsername={ this.props.suggestedUsername }
+				isSocialSignupEnabled={ true }
 			/>
 		);
 	}

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -28,6 +28,8 @@
 	"olark": {},
 	"port": null,
 	"happychat_url": "https://happychat.io/customer",
+	"google_oauth_client_id": "543610697398-l287fumouns096o4os9l9fs1svh5esjc.apps.googleusercontent.com",
+	"facebook_app_id": "611241942420191",
 	"languages": [
 		{ "value": 2, "langSlug": "af", "name": "af - Afrikaans", "wpLocale": "af" },
 		{ "value": 418, "langSlug": "als", "name": "als - Alemannisch", "wpLocale": "" },

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -79,6 +79,7 @@
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,
+		"signup/social": false,
 		"ui/first-view": false,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,

--- a/config/development.json
+++ b/config/development.json
@@ -137,6 +137,7 @@
 		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": true,
 		"signup/domain-first-flow": true,
+		"signup/social": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -91,6 +91,7 @@
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,
+		"signup/social": false,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,

--- a/config/production.json
+++ b/config/production.json
@@ -10,6 +10,7 @@
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
+	"facebook_app_id": "2373049596",
 	"features": {
 		"ad-tracking": true,
 		"apple-pay": true,

--- a/config/production.json
+++ b/config/production.json
@@ -90,6 +90,7 @@
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,
+		"signup/social": false,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -96,6 +96,7 @@
 		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,
+		"signup/social": false,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,

--- a/config/test.json
+++ b/config/test.json
@@ -98,6 +98,7 @@
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,
+		"signup/social": false,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -106,6 +106,7 @@
 		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": true,
 		"signup/domain-first-flow": true,
+		"signup/social": false,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,


### PR DESCRIPTION
This PR adds 2 buttons for social sign up on WordPress.com in the `user` step of signup (enabled on the new `social` flow only for now).
We still need to implement the login endpoints on wpcom for them to be operational.

![image](https://cloud.githubusercontent.com/assets/230230/23966144/9e7a5cb0-09ba-11e7-98ce-fcb3cb3f1008.png)

**(Outdated)**: 
> This reuses 2 components: [react-facebook-login-component](https://github.com/kennetpostigo/react-facebook-login-component) and [react-google-login-component](https://github.com/kennetpostigo/react-google-login-component) both of which are not really suited for our needs, so we will need to reimplement them (or make a contribution).
> 
> - In the case of `react-google-login-component` it seems the popup is blocked by the browser the first time, this is probably due to [this call](https://github.com/kennetpostigo/react-google-login-component/blob/master/src/GoogleLogin.js#L33) being asynchronous (so we should preload the library).
> - In the case of `react-facebook-login-component`, we don't want to call facebook's endpoint `/me` from the client, we just need to receive the access_token to do it from the server.

### Testing Instructions
- Run this locally and go to http://calypso.localhost:3000/start/social or open https://calypso.live/start/social?branch=add/social-signup-flow (need to be logged out)
- Check that the styles match the prototype
- Click on each social button and verify that a popup opens and display the oauth authorization page.
- Look at the console and check that we receive a response with an `access_token` each time

### Reviews
- [x] Code
- [x] Product
