### PR TITLE
ThemesSearch: fix ssr: skip user agent test on server.

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -138,7 +138,7 @@ class ThemesMagicSearchCard extends React.Component {
 
 	searchTokens = ( input ) => {
 		//We are not able to scroll overlay on Edge so just create empty div
-		if ( /(Edge)/.test( global.window.navigator.userAgent ) ) {
+		if ( global.window && /(Edge)/.test( global.window.navigator.userAgent ) ) {
 			return <div />;
 		}
 


### PR DESCRIPTION
### Info
Fix ssr rendering in MagicSearch by testing if window is present.

###Testing
Start branch, go to `/design` it should be SSR rendered.