### PR TITLE
MediaLibrary - set minimun limito to sticky the header panel

### DIFF
--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -14,11 +14,24 @@ var viewport = require( 'lib/viewport' );
 module.exports = React.createClass( {
 	displayName: 'StickyPanel',
 
+	propTypes: {
+		minLimit: React.PropTypes.oneOfType( [
+			React.PropTypes.bool,
+			React.PropTypes.number,
+		] ),
+	},
+
+	getDefaultProps: function() {
+		return {
+			minLimit: false,
+		};
+	},
+
 	getInitialState: function() {
 		return {
 			isSticky: false,
 			spacerHeight: 0,
-			blockWidth: 0
+			blockWidth: 0,
 		};
 	},
 
@@ -53,7 +66,10 @@ module.exports = React.createClass( {
 	updateIsSticky: function() {
 		var isSticky = window.pageYOffset > this.threshold;
 
-		if ( viewport.isMobile() ) {
+		if (
+			this.props.minLimit !== false && this.props.minLimit >= window.innerWidth ||
+			viewport.isMobile()
+		) {
 			return this.setState( { isSticky: false } );
 		}
 

--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -140,7 +140,7 @@ export default React.createClass( {
 
 		if ( this.props.sticky ) {
 			return (
-				<StickyPanel>
+				<StickyPanel minLimit ={ 660 }>
 					{ card }
 				</StickyPanel>
 			);


### PR DESCRIPTION
This PR fixes #12076 allowing define a minimum limit to force to do not stick the `<StickyPanel />` component beyond of the isMobile conditions.

### Testing
Open a media library sections with a lot of images trying to scroll up the section with a viewport width less or equal to 660px. The header shouldn't be sticked.

**before this patch**
<img src="https://cloud.githubusercontent.com/assets/1270189/23869658/034161d8-07e1-11e7-96bf-07db17ccd408.gif" width="500px" />

**after this patch**

<img src="https://cloud.githubusercontent.com/assets/77539/23907012/8882684c-08ae-11e7-9735-8a4b67ca66b3.gif" width="500px" />