### PR TITLE
Reader: Fix content in captions

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -162,7 +162,8 @@
 
 	.wp-caption-text,
 	figure figcaption,
-	figure .caption {
+	figure .caption,
+	.wp-caption .wp-media-credit {
 		padding: 12px;
 		margin: 0;
 		font-size: 13px;

--- a/client/lib/post-normalizer/rule-create-better-excerpt.js
+++ b/client/lib/post-normalizer/rule-create-better-excerpt.js
@@ -48,7 +48,7 @@ function buildStrippedDom( content ) {
 	const dom = domForHtml( content );
 
 	// Ditch any photo captions, styles, scripts
-	const stripSelectors = '.wp-caption-text, style, script, blockquote[class^="instagram-"], figure, .tiled-gallery';
+	const stripSelectors = '.wp-caption, style, script, blockquote[class^="instagram-"], figure, .tiled-gallery';
 	forEach( dom.querySelectorAll( stripSelectors ), removeElement );
 	return dom.innerHTML;
 }

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -942,7 +942,7 @@ describe( 'index', function() {
 		it( 'strips empty elements and leading brs', function( done ) {
 			assertExcerptBecomes( `<br>
 <p>&nbsp;</p>
-<p class="wp-caption-text">caption</p>
+<p class="wp-caption">caption</p>
 <p><img src="http://example.com/image.jpg"></p>
 <p><a href="http://wikipedia.org">Giraffes</a> are <br>great</p>
 <p></p>`, '<p>Giraffes are <br>great</p>', done );


### PR DESCRIPTION
Teach the full post styles about .wp-caption .wp-media-credit and teach the post-normalizer to remove the entirety of .wp-caption elements. Fixes sites like UPROXX. https://wordpress.com/read/feeds/19850964