### PR TITLE
Themes: Remove excess whitespace from SEO description

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -32,8 +32,8 @@ const ThemesSearchCard = config.isEnabled( 'manage/themes/magic-search' )
 const themesMeta = {
 	'': {
 		title: 'WordPress Themes',
-		description: 'Beautiful, responsive, free and premium WordPress themes \
-			for your photography site, portfolio, magazine, business website, or blog.',
+		description: 'Beautiful, responsive, free and premium WordPress themes ' +
+			'for your photography site, portfolio, magazine, business website, or blog.',
 		canonicalUrl: 'https://wordpress.com/design',
 	},
 	free: {


### PR DESCRIPTION
To test:
* First, check out `master`. In logged-out mode, check `http://calypso.localhost:3000/design`'s page source. You'll find

```html

<meta name="description" property="og:description" content="Beautiful, responsive, free and premium WordPress themes 				for your photography site, portfolio, magazine, business website, or blog.">
```

* Check out this PR, and re-start Calypso. Check logged-out `http://calypso.localhost:3000/design`'s page source again -- the excess whitespace between '...WordPress themes' and 'for your photography site, ...' should be gone.