### PR TITLE
Media: enable media section in all environments

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -29,6 +29,7 @@
 		"manage/edit-user": true,
 		"manage/import/medium": true,
 		"manage/jetpack": true,
+		"manage/media": true,
 		"manage/menus": true,
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -35,7 +35,7 @@
 		"manage/export/guided-transfer": true,
 		"manage/import/medium": true,
 		"manage/jetpack": true,
-		"manage/media": false,
+		"manage/media": true,
 		"manage/menus": true,
 		"manage/menus-jetpack": true,
 		"manage/pages": true,

--- a/config/production.json
+++ b/config/production.json
@@ -28,6 +28,7 @@
 		"manage/export": true,
 		"manage/import/medium": true,
 		"manage/jetpack": true,
+		"manage/media": true,
 		"manage/menus": true,
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -33,6 +33,7 @@
 		"manage/export": true,
 		"manage/import/medium": true,
 		"manage/jetpack": true,
+		"manage/media": true,
 		"manage/menus": true,
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": false,


### PR DESCRIPTION
This PR enables the media section in all prod environments. This is a follow up to #11822

h/t to @iamtakashi @artpi @retrofox

This adds a new section that allows users to see their media easily.

![add-new](https://cloud.githubusercontent.com/assets/1270189/23910727/e070aa4e-0897-11e7-94d8-1f397a640574.png)

Edit items with a consistent action bar:
![edit](https://cloud.githubusercontent.com/assets/1270189/23910760/fb386d8a-0897-11e7-9aec-d5181e1f060a.png)

View details
![details](https://cloud.githubusercontent.com/assets/1270189/23910790/1863ed44-0898-11e7-8800-12ae04fc9b5d.png)

And touch up content if needed, in the image editor:
![image editor](https://cloud.githubusercontent.com/assets/1270189/23910801/23ac2d60-0898-11e7-9850-b444a6b94661.png)


