### PR TITLE
Reader: add combined card post placeholder

### DIFF
--- a/client/blocks/reader-combined-card/placeholders/post.jsx
+++ b/client/blocks/reader-combined-card/placeholders/post.jsx
@@ -9,10 +9,10 @@ const ReaderCombinedCardPostPlaceholder = () => {
 			<div className="reader-combined-card__featured-image-wrapper"></div>
 			<div className="reader-combined-card__post-details">
 				<h1 className="reader-combined-card__post-title"></h1>
-				<div className="reader-excerpt"></div>
+				<div className="reader-excerpt is-placeholder"></div>
 				<div className="reader-combined-card__post-author-and-time is-placeholder">
-					<div className="reader-visit-link"></div>
-					<span className="reader-combined-card__timestamp"></span>
+					<div className="reader-combined-card__visit-link-placeholder"></div>
+					<div className="reader-combined-card__timestamp"></div>
 				</div>
 			</div>
 		</li>

--- a/client/blocks/reader-combined-card/placeholders/post.jsx
+++ b/client/blocks/reader-combined-card/placeholders/post.jsx
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+const ReaderCombinedCardPostPlaceholder = () => {
+	return (
+		<li className="reader-combined-card__post is-placeholder">
+			<div className="reader-combined-card__featured-image-wrapper"></div>
+			<div className="reader-combined-card__post-details">
+				<h1 className="reader-combined-card__post-title"></h1>
+				<div className="reader-excerpt"></div>
+				<div className="reader-combined-card__post-author-and-time is-placeholder">
+					<div className="reader-visit-link"></div>
+					<span className="reader-combined-card__timestamp"></span>
+				</div>
+			</div>
+		</li>
+	);
+};
+
+export default ReaderCombinedCardPostPlaceholder;

--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -72,7 +72,7 @@ class ReaderCombinedCardPost extends React.Component {
 
 	render() {
 		const { post, streamUrl, isDiscover, isSelected } = this.props;
-		const isLoading = ! post || post._state === 'pending';
+		const isLoading = ! post || post._state === 'pending' || post._state === 'minimal';
 
 		if ( isLoading ) {
 			return <ReaderCombinedCardPostPlaceholder />;

--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -20,6 +20,7 @@ import PostTime from 'reader/post-time';
 import ReaderFeaturedImage from 'blocks/reader-featured-image';
 import ReaderFeaturedVideo from 'blocks/reader-featured-video';
 import * as stats from 'reader/stats';
+import ReaderCombinedCardPostPlaceholder from 'blocks/reader-combined-card/placeholders/post';
 
 class ReaderCombinedCardPost extends React.Component {
 	static propTypes = {
@@ -71,8 +72,13 @@ class ReaderCombinedCardPost extends React.Component {
 
 	render() {
 		const { post, streamUrl, isDiscover, isSelected } = this.props;
-		const hasAuthorName = has( post, 'author.name' );
+		const isLoading = true; //! post || post._state === 'pending';
 
+		if ( isLoading ) {
+			return <ReaderCombinedCardPostPlaceholder />;
+		}
+
+		const hasAuthorName = has( post, 'author.name' );
 		let featuredAsset = null;
 		if ( post.canonical_media && post.canonical_media.mediaType === 'video' ) {
 			featuredAsset = <ReaderFeaturedVideo { ...post.canonical_media } videoEmbed={ post.canonical_media } allowPlaying={ false } />;

--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -72,7 +72,7 @@ class ReaderCombinedCardPost extends React.Component {
 
 	render() {
 		const { post, streamUrl, isDiscover, isSelected } = this.props;
-		const isLoading = true; //! post || post._state === 'pending';
+		const isLoading = ! post || post._state === 'pending';
 
 		if ( isLoading ) {
 			return <ReaderCombinedCardPostPlaceholder />;

--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -91,8 +91,8 @@ class ReaderCombinedCardPost extends React.Component {
 		};
 
 		const classes = classnames( {
-			"reader-combined-card__post": true,
-			"is-selected": isSelected
+			'reader-combined-card__post': true,
+			'is-selected': isSelected
 		} );
 
 		return (

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -99,6 +99,16 @@
 			}
 		}
 	}
+
+	&.is-placeholder {
+		.reader-combined-card__featured-image-wrapper,
+		.reader-combined-card__post-title,
+		.reader-excerpt,
+		.reader-visit-link,
+		.reader-combined-card__timestamp {
+			@include placeholder();
+		}
+	}
 }
 
 .reader-combined-card__post-author-and-time {
@@ -111,7 +121,7 @@
 	position: relative;
 	margin-top: 2px;
 
-	&::after {
+	&:not( .is-placeholder )::after {
 		@include long-content-fade( $size: 20% );
 	}
 }

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -115,6 +115,7 @@
 
 		.reader-excerpt {
 			height: 1em;
+			margin-top: 0.5em;
 		}
 
 		.reader-combined-card__visit-link-placeholder,

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -104,9 +104,36 @@
 		.reader-combined-card__featured-image-wrapper,
 		.reader-combined-card__post-title,
 		.reader-excerpt,
-		.reader-visit-link,
+		.reader-combined-card__visit-link-placeholder,
 		.reader-combined-card__timestamp {
 			@include placeholder();
+		}
+
+		.reader-combined-card__post-title {
+			height: 1.1em;
+		}
+
+		.reader-excerpt {
+			height: 1em;
+		}
+
+		.reader-combined-card__visit-link-placeholder,
+		.reader-combined-card__timestamp {
+			height: 1em;
+			margin-top: 0.4em;
+		}
+
+		.reader-combined-card__visit-link-placeholder {
+			width: 50px;
+			margin-right: 30px;
+		}
+
+		.reader-combined-card__timestamp {
+			width: 130px;
+		}
+
+		.reader-combined-card__post-author-and-time {
+			display: flex;
 		}
 	}
 }
@@ -159,7 +186,7 @@
 	position: relative;
 	margin-top: 4px;
 
-	&::after {
+	&:not( .is-placeholder )::after {
 		@include long-content-fade( $size: 20% );
 	}
 }

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -294,7 +294,7 @@ export class FullPostView extends React.Component {
 		}
 
 		const externalHref = isDiscoverPost( referralPost ) ? referralPost.URL : post.URL;
-		const isLoading = ! post || post._state === 'pending';
+		const isLoading = ! post || post._state === 'pending' || post._state === 'minimal';
 
 		/*eslint-disable react/no-danger */
 		/*eslint-disable react/jsx-no-target-blank */

--- a/client/blocks/reader-post-card/docs/fixtures.js
+++ b/client/blocks/reader-post-card/docs/fixtures.js
@@ -129,8 +129,8 @@ export const posts = [
 ];
 
 export const feed = {
-	blog_ID: "53424024",
-	feed_ID: "41325786",
+	blog_ID: 53424024,
+	feed_ID: 41325786,
 	name: "Discover",
 	URL: "https://discover.wordpress.com/",
 	feed_URL: "http://discover.wordpress.com",

--- a/client/reader/stream/post-placeholder.jsx
+++ b/client/reader/stream/post-placeholder.jsx
@@ -16,7 +16,6 @@ const PostPlaceholder = React.createClass( {
 	render() {
 		return (
 			<Card tagName="article" className="reader__card is-placeholder">
-
 				<div className="reader__post-header">
 					<h1 className="reader__post-title"><a className="reader__post-title-link" target="_blank" rel="noopener noreferrer"><span className="reader__placeholder-text">Loading interesting posts…</span></a></h1>
 					<div className="reader__post-byline">


### PR DESCRIPTION
This PR adds a loading placeholder for posts in a Reader combined card.

Loading extra posts currently looks a bit odd when clicking the new post pill (e.g. "2 new posts") - the visit link is shown and then the remaining post content arrives a moment later. The placeholder should fix that.

Fixes #12072.

<img width="851" alt="screen shot 2017-03-14 at 17 43 22" src="https://cloud.githubusercontent.com/assets/17325/23914405/c2587474-08dd-11e7-855e-15c42148082b.png">

### To test

If you want to manually set the loading state, you can set `isLoading` to `true` in reader-combined-card/placeholders/post.jsx.

The combined card devdocs page is http://calypso.localhost:3000/devdocs/blocks/reader-combined-card.