### PR TITLE
Themes (Search Cards): Drop site obj prop, compute siteId from state

### DIFF
--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -9,17 +9,6 @@ import mapValues from 'lodash/mapValues';
  * Internal dependencies
  */
 import { sectionify } from 'lib/route/path';
-import { oldShowcaseUrl } from 'state/themes/utils';
-
-export function getExternalThemesUrl( site ) {
-	if ( ! site ) {
-		return oldShowcaseUrl;
-	}
-	if ( site.jetpack ) {
-		return site.options.admin_url + 'theme-install.php';
-	}
-	return oldShowcaseUrl + site.slug;
-}
 
 export function trackClick( componentName, eventName, verb = 'click' ) {
 	const stat = `${ componentName } ${ eventName } ${ verb }`;

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -132,7 +132,6 @@ const ThemeShowcase = React.createClass( {
 
 	render() {
 		const {
-			site,
 			siteId,
 			options,
 			getScreenshotOption,
@@ -156,7 +155,6 @@ const ThemeShowcase = React.createClass( {
 				<PageViewTracker path={ this.props.analyticsPath } title={ this.props.analyticsPageTitle } />
 				<StickyPanel>
 					<ThemesSearchCard
-						site={ site }
 						onSearch={ this.doSearch }
 						search={ this.prependFilterKeys() + search }
 						tier={ tier }

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
-import debounce from 'lodash/debounce';
+import { connect } from 'react-redux';
+import { debounce } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -16,6 +17,8 @@ import { isMobile } from 'lib/viewport';
 import { filterIsValid, getTaxonomies, } from '../theme-filters.js';
 import { localize } from 'i18n-calypso';
 import MagicSearchWelcome from './welcome';
+import { isJetpackSite } from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 class ThemesMagicSearchCard extends React.Component {
 	constructor( props ) {
@@ -184,7 +187,7 @@ class ThemesMagicSearchCard extends React.Component {
 	}
 
 	render() {
-		const isJetpack = this.props.site && this.props.site.jetpack;
+		const { isJetpack } = this.props;
 		const isPremiumThemesEnabled = config.isEnabled( 'upgrades/premium-themes' );
 		const { translate } = this.props;
 
@@ -259,14 +262,19 @@ class ThemesMagicSearchCard extends React.Component {
 ThemesMagicSearchCard.propTypes = {
 	tier: PropTypes.string,
 	select: PropTypes.func.isRequired,
-	site: PropTypes.object,
+	siteId: PropTypes.number,
 	onSearch: PropTypes.func.isRequired,
 	search: PropTypes.string,
 	translate: PropTypes.func.isRequired,
+	isJetpack: PropTypes.bool
 };
 
 ThemesMagicSearchCard.defaultProps = {
 	tier: 'all',
 };
 
-export default localize( ThemesMagicSearchCard );
+export default connect(
+	( state ) => ( {
+		isJetpack: isJetpackSite( state, getSelectedSiteId( state ) )
+	} )
+)( localize( ThemesMagicSearchCard ) );

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -187,9 +187,8 @@ class ThemesMagicSearchCard extends React.Component {
 	}
 
 	render() {
-		const { isJetpack } = this.props;
+		const { isJetpack, translate } = this.props;
 		const isPremiumThemesEnabled = config.isEnabled( 'upgrades/premium-themes' );
-		const { translate } = this.props;
 
 		const tiers = [
 			{ value: 'all', label: translate( 'All' ) },

--- a/client/my-sites/themes/themes-search-card/index.jsx
+++ b/client/my-sites/themes/themes-search-card/index.jsx
@@ -18,7 +18,7 @@ import NavItem from 'components/section-nav/item';
 import { trackClick } from '../helpers';
 import config from 'config';
 import { isMobile } from 'lib/viewport';
-import { getSiteAdminUrl, getSiteSlug, isJetpackSite } from 'state/sites/selectors';
+import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 import { oldShowcaseUrl } from 'state/themes/utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
@@ -163,17 +163,11 @@ const ThemesSearchCard = React.createClass( {
 export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
-		const isJetpack = isJetpackSite( state, siteId );
+		const siteSlug = getSiteSlug( state, siteId ) || '';
 
-		let externalUrl;
-		if ( ! siteId ) {
-			externalUrl = oldShowcaseUrl;
-		} else if ( isJetpack ) {
-			externalUrl = getSiteAdminUrl( state, siteId, 'theme-install.php' );
-		} else {
-			externalUrl = oldShowcaseUrl + getSiteSlug( state, siteId );
-		}
-
-		return { externalUrl, isJetpack };
+		return {
+			externalUrl: oldShowcaseUrl + siteSlug,
+			isJetpack: isJetpackSite( state, siteId )
+		};
 	}
 )( localize( ThemesSearchCard ) );


### PR DESCRIPTION
This also inlines a helper function that will be dropped alongside ThemesSearchCard once it's removed in favor of ThemesMagicSearchCard.

To test: Verify that search cards still work. Be sure to also test with a Jetpack site (All/Free/Premium themes switch!)
Be sure to test both search cards, i.e. also set `manage/themes/magic-search` to `false`, restart Calypso, and test the "old" search card.

(This is a preparatory PR for #12124.)