### PR TITLE
Reader: make link colours consistent on combined card

### DIFF
--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -131,13 +131,16 @@
 	color: $gray;
 	cursor: pointer;
 
-	&:focus {
+	&:focus,
+	&:link,
+	&:visited {
 		color: $gray;
 	}
-}
 
-.reader-combined-card .reader-author-link:hover {
-	color: $blue-medium;
+	&:hover,
+	&:active {
+		color: $blue-medium;
+	}
 }
 
 .reader-combined-card__post .reader-excerpt {
@@ -154,8 +157,17 @@
 	}
 }
 
-.reader-combined-card__site-link a {
-	color: $blue-wordpress;
+.reader-combined-card__site-link {
+	&:focus,
+	&:link,
+	&:visited {
+		color: $blue-wordpress;
+	}
+
+	&:hover,
+	&:active {
+		color: $blue-medium;
+	}
 }
 
 // Override standard .card styles in stream


### PR DESCRIPTION
Ensure that visited, active and hover states are correctly set for combined card links.

Header site link - always `blue-wordpress` unless :hover or :active (`blue-medium`)

<img width="149" alt="screen shot 2017-03-14 at 18 39 48" src="https://cloud.githubusercontent.com/assets/17325/23916952/baa438e6-08e5-11e7-8cb6-23a6d5a15261.png">

Footer links - always `gray` unless :hover or :active (`blue-medium`)

<img width="282" alt="screen shot 2017-03-14 at 18 39 53" src="https://cloud.githubusercontent.com/assets/17325/23916964/c1182192-08e5-11e7-8a49-dc8385d4bc24.png">

Fixes #12089.
