### PR TITLE
Editor: Remove underline, alignjustify from tinymce toolbar

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -307,7 +307,7 @@ module.exports = React.createClass( {
 			toolbar1: config.isEnabled( 'post-editor/insert-menu' )
 				? 'wpcom_insert_menu,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,wpcom_advanced'
 				: 'wpcom_add_media,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,wpcom_add_contact_form,wpcom_advanced',
-			toolbar2: 'strikethrough,underline,hr,alignjustify,forecolor,pastetext,removeformat,wp_charmap,outdent,indent,undo,redo,wp_help',
+			toolbar2: 'strikethrough,hr,alignjustify,forecolor,pastetext,removeformat,wp_charmap,outdent,indent,undo,redo,wp_help',
 			toolbar3: '',
 			toolbar4: '',
 

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -307,7 +307,7 @@ module.exports = React.createClass( {
 			toolbar1: config.isEnabled( 'post-editor/insert-menu' )
 				? 'wpcom_insert_menu,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,wpcom_advanced'
 				: 'wpcom_add_media,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,wpcom_add_contact_form,wpcom_advanced',
-			toolbar2: 'strikethrough,hr,alignjustify,forecolor,pastetext,removeformat,wp_charmap,outdent,indent,undo,redo,wp_help',
+			toolbar2: 'strikethrough,hr,forecolor,pastetext,removeformat,wp_charmap,outdent,indent,undo,redo,wp_help',
 			toolbar3: '',
 			toolbar4: '',
 


### PR DESCRIPTION
Matching changes from 4.7 [[#](https://core.trac.wordpress.org/ticket/27159)], this branch removes `underline` and `alignjustify` from the MCE toolbar in the calypso editor:

__Before__
![edit_post_ _trout_bummin_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/23917422/8140dad4-08ac-11e7-8fd7-f3d5a6240834.png)

__After__
![underline-justify-after](https://cloud.githubusercontent.com/assets/22080/23917427/85f060ae-08ac-11e7-9f2c-4caf48e2c17e.png)

