### PR TITLE
Jetpack: Removes monthly plans test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -55,15 +55,6 @@ module.exports = {
 		defaultVariation: 'withoutMarketingCopy',
 		allowExistingUsers: true
 	},
-	jetpackPlansNoMonthly: {
-		datestamp: '20170302',
-		variations: {
-			showMonthly: 50,
-			hideMonthly: 50
-		},
-		defaultVariation: 'showMonthly',
-		allowExistingUsers: true
-	},
 	signupDomainsHeadline: {
 		datestamp: '20170313',
 		variations: {

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -26,7 +26,6 @@ import {
 	PLAN_PERSONAL
 } from 'lib/plans/constants';
 import SitesList from 'lib/sites-list';
-import { abtest } from 'lib/abtest';
 
 /**
  * Module vars
@@ -135,7 +134,7 @@ export function filterPlansBySiteAndProps( plans, site, hideFreePlan, intervalTy
 
 	return plans.filter( function( plan ) {
 		if ( site && site.jetpack ) {
-			if ( 'monthly' === intervalType && abtest( 'jetpackPlansNoMonthly' ) !== 'hideMonthly' ) {
+			if ( 'monthly' === intervalType ) {
 				if ( showJetpackFreePlan ) {
 					return isJetpackPlan( plan ) && isMonthly( plan );
 				}

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -73,14 +73,12 @@ class PlanFeaturesHeader extends Component {
 
 	getBillingTimeframe() {
 		const {
-			hideMonthly,
 			billingTimeFrame,
 			discountPrice,
 			isPlaceholder,
 			site,
 			translate,
-			isSiteAT,
-			currentSitePlan
+			isSiteAT
 		} = this.props;
 
 		const isDiscounted = !! discountPrice;
@@ -92,8 +90,7 @@ class PlanFeaturesHeader extends Component {
 		if (
 			isSiteAT ||
 			! site.jetpack ||
-			this.props.planType === PLAN_JETPACK_FREE ||
-			( hideMonthly && ( ! currentSitePlan || currentSitePlan.productSlug === PLAN_JETPACK_FREE ) )
+			this.props.planType === PLAN_JETPACK_FREE
 		) {
 			return (
 				<p className={ timeframeClasses }>
@@ -168,7 +165,6 @@ class PlanFeaturesHeader extends Component {
 
 	getPlanFeaturesPrices() {
 		const {
-			hideMonthly,
 			currencyCode,
 			discountPrice,
 			rawPrice,
@@ -197,7 +193,7 @@ class PlanFeaturesHeader extends Component {
 			);
 		}
 
-		if ( relatedMonthlyPlan && ! hideMonthly ) {
+		if ( relatedMonthlyPlan ) {
 			const originalPrice = relatedMonthlyPlan.raw_price * 12;
 			return (
 				<span className="plan-features__header-price-group">

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -137,7 +137,7 @@ class PlanFeatures extends Component {
 				primaryUpgrade,
 				isPlaceholder
 			} = properties;
-			let { rawPrice, discountPrice } = properties;
+			const { rawPrice, discountPrice } = properties;
 
 			return (
 				<div className="plan-features__mobile-plan" key={ planName }>
@@ -203,7 +203,7 @@ class PlanFeatures extends Component {
 				relatedMonthlyPlan,
 				isPlaceholder
 			} = properties;
-			let { rawPrice, discountPrice } = properties;
+			const { rawPrice, discountPrice } = properties;
 			const classes = classNames( 'plan-features__table-item', 'has-border-top' );
 
 			return (
@@ -517,7 +517,7 @@ export default connect(
 
 		return {
 			canPurchase,
-			planProperties: planProperties
+			planProperties
 		};
 	},
 	{

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -105,7 +105,7 @@ class PlanFeatures extends Component {
 
 	renderMobileView() {
 		const {
-			isCurrentPlanPaid, canPurchase, translate, planProperties, isInSignup, isLandingPage, intervalType, site, basePlansPath
+			canPurchase, translate, planProperties, isInSignup, isLandingPage, intervalType, site, basePlansPath
 		} = this.props;
 
 		// move any free plan to last place in mobile view
@@ -138,10 +138,7 @@ class PlanFeatures extends Component {
 				isPlaceholder
 			} = properties;
 			let { rawPrice, discountPrice } = properties;
-			if ( abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly' && ! isCurrentPlanPaid && relatedMonthlyPlan && relatedMonthlyPlan.raw_price ) {
-				discountPrice = rawPrice;
-				rawPrice = relatedMonthlyPlan.raw_price;
-			}
+
 			return (
 				<div className="plan-features__mobile-plan" key={ planName }>
 					<PlanFeaturesHeader
@@ -158,7 +155,6 @@ class PlanFeatures extends Component {
 						intervalType={ intervalType }
 						site={ site }
 						basePlansPath={ basePlansPath }
-						hideMonthly={ abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly' && ! isCurrentPlanPaid }
 						relatedMonthlyPlan={ relatedMonthlyPlan }
 					/>
 					<p className="plan-features__description">
@@ -194,7 +190,7 @@ class PlanFeatures extends Component {
 	}
 
 	renderPlanHeaders() {
-		const { isCurrentPlanPaid, planProperties, intervalType, site, basePlansPath } = this.props;
+		const { planProperties, intervalType, site, basePlansPath } = this.props;
 
 		return map( planProperties, ( properties ) => {
 			const {
@@ -209,10 +205,7 @@ class PlanFeatures extends Component {
 			} = properties;
 			let { rawPrice, discountPrice } = properties;
 			const classes = classNames( 'plan-features__table-item', 'has-border-top' );
-			if ( abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly' && ! isCurrentPlanPaid && relatedMonthlyPlan && relatedMonthlyPlan.raw_price ) {
-				discountPrice = rawPrice;
-				rawPrice = relatedMonthlyPlan.raw_price;
-			}
+
 			return (
 				<td key={ planName } className={ classes }>
 					<PlanFeaturesHeader
@@ -230,7 +223,6 @@ class PlanFeatures extends Component {
 						site={ site }
 						basePlansPath={ basePlansPath }
 						relatedMonthlyPlan={ relatedMonthlyPlan }
-						hideMonthly={ abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly' && ! isCurrentPlanPaid }
 					/>
 				</td>
 			);
@@ -473,9 +465,7 @@ export default connect(
 				const popular = isPopular( plan ) && ! isPaid;
 				const newPlan = isNew( plan ) && ! isPaid;
 				const currentPlan = sitePlan && sitePlan.product_slug;
-				const showMonthlyPrice = abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly' && ! isPaid
-					? showMonthly
-					: ! relatedMonthlyPlan && showMonthly;
+				const showMonthlyPrice = ! relatedMonthlyPlan && showMonthly;
 
 				if ( placeholder || ! planObject || isLoadingSitePlans ) {
 					isPlaceholder = true;
@@ -491,9 +481,7 @@ export default connect(
 						selectedSiteId,
 						plan,
 						{
-							isMonthly: abtest( 'jetpackPlansNoMonthly' ) === 'hideMonthly' && ! isPaid
-								? true
-								: showMonthly
+							isMonthly: showMonthly
 						} ),
 					features: getPlanFeaturesObject( planConstantObj.getFeatures( abtest ) ),
 					onUpgradeClick: onUpgradeClick
@@ -529,8 +517,7 @@ export default connect(
 
 		return {
 			canPurchase,
-			planProperties: planProperties,
-			isCurrentPlanPaid: isPaid
+			planProperties: planProperties
 		};
 	},
 	{


### PR DESCRIPTION
Removes https://github.com/Automattic/wp-calypso/pull/11704

After a week running the no-monthly plans test, we think that the results are not good enough to go forward. This PR removes the test and restores the previous status-quo. 

How to test:

0. First, go to http://calypso.localhost:3000/plans/ and select a jetpack site ... make sure everything looks right. Then connect that site and make sure everything works fine in the plans selection screen ( you will need a site without any purchased plan so you can see the plans step there)

1. Now let's make sure the test is not there anymore. Open the developer tools and run this in the console: localStorage.setItem( 'ABTests', '{"jetpackPlansNoMonthly_20170302":"hideMonthly"}' ); 
2. Reload the page. You still should see the regular plans page, with the monthly selector.

