### PR TITLE
Update Site Indicator Component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -322,7 +322,7 @@
 @import 'my-sites/sharing/connections/services-group';
 @import 'my-sites/sidebar/style';
 @import 'my-sites/sidebar-navigation/style';
-@import 'my-sites/site-indicator/style';
+@import 'blocks/site-indicator/style';
 @import 'my-sites/site-settings/style';
 @import 'my-sites/site-settings/action-panel/style';
 @import 'my-sites/site-settings/custom-content-types/style';

--- a/client/blocks/site-indicator/README.md
+++ b/client/blocks/site-indicator/README.md
@@ -1,0 +1,28 @@
+Site Indicator
+==============
+
+This component is used to display a round badge next to a site with information about updates available, connection issues with Jetpack, whether a site is Jetpack, upgrades expiring soon, etc. It takes `siteId` int as property.
+
+#### How to use
+
+```js
+var SiteIndicator = require( 'blocks/site-indicator' );
+
+render: function() {
+    return(
+        <SiteIndicator siteId={ 123 } />
+    );
+}
+```
+
+## Props
+
+### `siteId`
+
+<table>
+	<tr><th>Type</th><td>Int</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The siteId object. 
+

--- a/client/blocks/site-indicator/index.jsx
+++ b/client/blocks/site-indicator/index.jsx
@@ -121,8 +121,8 @@ export const renderSiteIndicatorHasUpdate = ( { translate, site }, expanded = fa
 export class SiteIndicator extends Component {
 	constructor( props ) {
 		super( props );
-		this.state = { expand: false }
-		this.toggleExpand = this.toggleExpand.bind(this);
+		this.state = { expand: false };
+		this.toggleExpand = this.toggleExpand.bind( this );
 	}
 
 	toggleExpand() {

--- a/client/blocks/site-indicator/index.jsx
+++ b/client/blocks/site-indicator/index.jsx
@@ -1,0 +1,173 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import config from 'config';
+import classNames from 'classnames';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import Animate from 'components/animate';
+import DisconnectJetpackButton from 'my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button';
+import analytics from 'lib/analytics';
+
+const renderSiteIndicatorCloseIcon = ( toggleExpand ) => {
+	return (
+		<button className="site-indicator__button" onClick={ toggleExpand }>
+			<Animate type="appear">
+				<Gridicon icon="cross" size={ 18 } />
+			</Animate>
+		</button>
+	);
+};
+
+const SiteIndicatorMessage = ( props ) => {
+	return (
+		<div className="site-indicator__message">
+			<div className="site-indicator__action">
+				<span>
+					{ props.children }
+				</span>
+			</div>
+			{ renderSiteIndicatorCloseIcon( props.onClose ) }
+		</div>
+	);
+};
+
+const renderSiteIndicatorIcon = ( toggleExpand, icon = 'notice' ) => {
+	return (
+		<Animate type="appear">
+			<button className="site-indicator__button" onClick={ toggleExpand }>
+				{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
+				<Gridicon icon={ icon } size={ 16 } />
+				{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
+			</button>
+		</Animate>
+	);
+};
+
+export const renderSiteIndicatorHasWarning = ( { translate, site }, expanded = false, toggleExpand ) => {
+	const indicatorClass = classNames( {
+		'is-expanded': expanded,
+		'is-warning': true,
+		'is-action': true,
+		'site-indicator': true
+	} );
+
+	return (
+		<div className={ indicatorClass }>
+			{ ! expanded && renderSiteIndicatorIcon( toggleExpand ) }
+			{ expanded &&
+				<SiteIndicatorMessage onClose={ toggleExpand } >
+					{ translate( 'Jetpack %(version)s is required', { args: { version: config( 'jetpack_min_version' ) } } ) }.
+					<a
+						href={ site.options.admin_url + 'plugins.php?plugin_status=upgrade' }
+						>{ translate( 'Update now' ) }
+					</a>.
+				</SiteIndicatorMessage>
+			}
+		</div>
+	);
+};
+
+export const renderSiteIndicatorHasError = ( { translate, site }, expanded = false, toggleExpand ) => {
+	const indicatorClass = classNames( {
+		'is-expanded': expanded,
+		'is-error': true,
+		'is-action': true,
+		'site-indicator': true
+	} );
+
+	return (
+		<div className={ indicatorClass }>
+			{ ! expanded && renderSiteIndicatorIcon( toggleExpand ) }
+			{ expanded &&
+				<SiteIndicatorMessage onClose={ toggleExpand }>
+					{ translate( 'This site cannot be accessed.' ) }
+					<DisconnectJetpackButton site={ site } text={ translate( 'Disconnect Site' ) } redirect="/sites" />
+				</SiteIndicatorMessage>
+			}
+		</div>
+	);
+};
+
+export const renderSiteIndicatorHasUpdate = ( { translate, site }, expanded = false, toggleExpand ) => {
+	const indicatorClass = classNames( {
+		'is-expanded': expanded,
+		'is-error': true,
+		'is-action': true,
+		'site-indicator': true
+	} );
+
+	return (
+		<div className={ indicatorClass }>
+			{ ! expanded && renderSiteIndicatorIcon( toggleExpand, 'sync' ) }
+			{ expanded &&
+				<SiteIndicatorMessage onClose={ toggleExpand }>
+					{ translate( 'Jetpack %(version)s is required', { args: { version: config( 'jetpack_min_version' ) } } ) }.
+					<a
+						href={ site.options.admin_url + 'plugins.php?plugin_status=upgrade' }
+						>{ translate( 'Update now' ) }
+					</a>.
+				</SiteIndicatorMessage>
+			}
+		</div>
+	);
+};
+
+export class SiteIndicator extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = { expand: false }
+		this.toggleExpand = this.toggleExpand.bind(this);
+	}
+
+	toggleExpand() {
+		this.setState( {
+			updateError: false,
+			updateSucceed: false,
+			expand: ! this.state.expand
+		} );
+		analytics.ga.recordEvent(
+			'Site-Indicator',
+			'Clicked to ' + ( ! this.state.expand ? 'Expand' : 'Collapse' ) + ' the Site Indicator'
+		);
+	}
+
+	hasError() {
+		return false;
+	}
+
+	hasWarning() {
+		return false;
+	}
+
+	hasUpdate() {
+		return false;
+	}
+
+	render() {
+		if ( this.hasError() ) {
+			return renderSiteIndicatorHasError( this.props, this.state.expand, this.toggleExpand );
+		}
+
+		if ( this.hasWarning() ) {
+			return renderSiteIndicatorHasWarning( this.props, this.state.expand, this.toggleExpand );
+		}
+
+		if ( this.hasUpdate() ) {
+			return renderSiteIndicatorHasWarning( this.props, this.state.expand, this.toggleExpand );
+		}
+		return null;
+	}
+}
+
+SiteIndicator.displayName = 'SiteIndicator';
+SiteIndicator.propTypes = {
+	site: PropTypes.object.isRequired
+};
+
+export default localize( SiteIndicator );

--- a/client/blocks/site-indicator/index.jsx
+++ b/client/blocks/site-indicator/index.jsx
@@ -2,17 +2,19 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 import config from 'config';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import Animate from 'components/animate';
 import DisconnectJetpackButton from 'my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button';
-import analytics from 'lib/analytics';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 const renderSiteIndicatorCloseIcon = ( toggleExpand ) => {
 	return (
@@ -49,7 +51,28 @@ const renderSiteIndicatorIcon = ( toggleExpand, icon = 'notice' ) => {
 	);
 };
 
-export const renderSiteIndicatorHasWarning = ( { translate, site }, expanded = false, toggleExpand ) => {
+export const renderSiteIndicatorHasError = ( { translate, site, recordGoogleEvent: recordGAEvent }, expanded = false, toggleExpand ) => {
+	const indicatorClass = classNames( {
+		'is-expanded': expanded,
+		'is-error': true,
+		'is-action': true,
+		'site-indicator': true
+	} );
+
+	return (
+		<div className={ indicatorClass }>
+			{ ! expanded && renderSiteIndicatorIcon( toggleExpand ) }
+			{ expanded &&
+				<SiteIndicatorMessage onClose={ toggleExpand }>
+					{ translate( 'This site cannot be accessed.' ) }
+					<DisconnectJetpackButton site={ site } text={ translate( 'Disconnect Site' ) } redirect="/sites" />
+				</SiteIndicatorMessage>
+			}
+		</div>
+	);
+};
+
+export const renderSiteIndicatorHasWarning = ( { translate, site, recordGoogleEvent: recordGAEvent }, expanded = false, toggleExpand ) => {
 	const indicatorClass = classNames( {
 		'is-expanded': expanded,
 		'is-warning': true,
@@ -73,45 +96,34 @@ export const renderSiteIndicatorHasWarning = ( { translate, site }, expanded = f
 	);
 };
 
-export const renderSiteIndicatorHasError = ( { translate, site }, expanded = false, toggleExpand ) => {
+export const renderSiteIndicatorHasUpdate = ( { translate, site, recordGoogleEvent: recordGAEvent }, expanded = false, toggleExpand ) => {
 	const indicatorClass = classNames( {
 		'is-expanded': expanded,
-		'is-error': true,
+		'is-update': true,
 		'is-action': true,
 		'site-indicator': true
 	} );
 
-	return (
-		<div className={ indicatorClass }>
-			{ ! expanded && renderSiteIndicatorIcon( toggleExpand ) }
-			{ expanded &&
-				<SiteIndicatorMessage onClose={ toggleExpand }>
-					{ translate( 'This site cannot be accessed.' ) }
-					<DisconnectJetpackButton site={ site } text={ translate( 'Disconnect Site' ) } redirect="/sites" />
-				</SiteIndicatorMessage>
-			}
-		</div>
-	);
-};
-
-export const renderSiteIndicatorHasUpdate = ( { translate, site }, expanded = false, toggleExpand ) => {
-	const indicatorClass = classNames( {
-		'is-expanded': expanded,
-		'is-error': true,
-		'is-action': true,
-		'site-indicator': true
-	} );
+	const onlyPlugins = site.updates.plugins === site.updates.total;
 
 	return (
 		<div className={ indicatorClass }>
 			{ ! expanded && renderSiteIndicatorIcon( toggleExpand, 'sync' ) }
 			{ expanded &&
 				<SiteIndicatorMessage onClose={ toggleExpand }>
-					{ translate( 'Jetpack %(version)s is required', { args: { version: config( 'jetpack_min_version' ) } } ) }.
-					<a
-						href={ site.options.admin_url + 'plugins.php?plugin_status=upgrade' }
-						>{ translate( 'Update now' ) }
-					</a>.
+				<a href={ onlyPlugins ? '/plugins/updates/' + site.slug : site.options.admin_url + 'update-core.php' } >
+					{ onlyPlugins
+						? translate(
+							'There is a plugin update available.',
+							'There are plugin updates available.',
+							{ count: site.updates.total }
+						) : translate(
+							'There is an update available.',
+							'There are updates available.',
+							{ count: this.props.site.updates.total }
+						)
+					}
+				</a>
 				</SiteIndicatorMessage>
 			}
 		</div>
@@ -131,25 +143,51 @@ export class SiteIndicator extends Component {
 			updateSucceed: false,
 			expand: ! this.state.expand
 		} );
-		analytics.ga.recordEvent(
+		this.props.recordGoogleEvent(
 			'Site-Indicator',
 			'Clicked to ' + ( ! this.state.expand ? 'Expand' : 'Collapse' ) + ' the Site Indicator'
 		);
 	}
 
+	hasUpdate() {
+		const { site } = this.props;
+		return !! get( site, 'updates.total' );
+	}
+
 	hasError() {
+		const { site } = this.props;
+		if ( site.unreachable ) {
+			return true;
+		}
 		return false;
 	}
 
 	hasWarning() {
-		return false;
-	}
+		const { site } = this.props;
 
-	hasUpdate() {
-		return false;
+		if ( site.hasMinimumJetpackVersion && site.unreachable === false ) {
+			return false;
+		}
+
+		if ( site.callingHome ) {
+			return false;
+		} else if ( typeof site.unreachable === 'undefined' ) {
+			if ( 'function' === typeof site.callHome ) {
+				site.callHome();
+			}
+			return false;
+		}
+
+		return true;
 	}
 
 	render() {
+		const { site } = this.props;
+
+		if ( ! site.jetpack ) {
+			return null;
+		}
+
 		if ( this.hasError() ) {
 			return renderSiteIndicatorHasError( this.props, this.state.expand, this.toggleExpand );
 		}
@@ -158,8 +196,8 @@ export class SiteIndicator extends Component {
 			return renderSiteIndicatorHasWarning( this.props, this.state.expand, this.toggleExpand );
 		}
 
-		if ( this.hasUpdate() ) {
-			return renderSiteIndicatorHasWarning( this.props, this.state.expand, this.toggleExpand );
+		if ( this.hasUpdate() && site.canUpdateFiles ) {
+			return renderSiteIndicatorHasUpdate( this.props, this.state.expand, this.toggleExpand );
 		}
 		return null;
 	}
@@ -170,4 +208,9 @@ SiteIndicator.propTypes = {
 	site: PropTypes.object.isRequired
 };
 
-export default localize( SiteIndicator );
+export default connect(
+	null,
+	{
+		recordGoogleEvent
+	}
+)( localize( SiteIndicator ) );

--- a/client/blocks/site-indicator/style.scss
+++ b/client/blocks/site-indicator/style.scss
@@ -1,0 +1,115 @@
+/**
+ * Site Indicator
+ */
+
+.site-indicator {
+	align-self: center;
+	margin-right: 16px;
+}
+
+.site-indicator__button {
+	align-self: center;
+	background: $gray-light;
+	border: none;
+	border-radius: 50%;
+	box-shadow: none;
+	color: $gray;
+	cursor: default;
+	display: block;
+	width: 26px;
+	height: 26px;
+	padding: 2px;
+	position: relative;
+	text-align: center;
+	text-transform: none;
+	z-index: z-index( 'root', '.site-indicator__button' );
+	overflow: initial;
+	line-height: 28px;
+
+	&:focus {
+		box-shadow: none;
+	}
+	.accessible-focus &:focus {
+		outline: 0;
+		border: 1px dotted $blue-wordpress;
+		&::before {
+			top: 4px;
+			left: 4px;
+		}
+	}
+
+	.is-action & {
+		cursor: pointer;
+	}
+
+	.is-update & {
+		background: $alert-yellow;
+		color: $white;
+	}
+
+	.is-warning & {
+		background: $alert-yellow;
+		color: $white;
+	}
+
+	.is-error & {
+		background: $alert-red;
+		color: $white;
+	}
+
+	.is-expanded & {
+		.accessible-focus &:focus {
+			border: 1px dotted $white;
+			&::before {
+				top: 6px;
+				left: 6px;
+			}
+		}
+		.site-indicator__button {
+			position: absolute;
+				right: 0;
+		}
+	}
+
+	.notouch & {
+		&:hover {
+			cursor: pointer;
+		}
+	}
+}
+
+// Displayed on top of a Site element once the user clicks on the button
+.site-indicator__message {
+	color: $white;
+	font-size: 12px;
+	line-height: 1.4;
+	padding: 5px 16px 5px 16px;
+	position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+	display: flex;
+	justify-content: space-between;
+
+	.is-warning &,
+	.is-update & {
+		background: $alert-yellow;
+	}
+	.is-error & {
+		background: $alert-red;
+	}
+}
+.site-indicator__action {
+	align-self: center;
+	display: inline-block;
+	vertical-align: middle;
+
+	// Links within the action message
+	a,
+	.button.is-link {
+		border-bottom: 1px solid rgba( 255, 255, 255, 0.6 );
+		color: $white;
+		text-decoration: none;
+	}
+}

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -10,7 +10,7 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import SiteIcon from 'blocks/site-icon';
-import SiteIndicator from 'my-sites/site-indicator';
+import SiteIndicator from 'blocks/site-indicator';
 
 export default React.createClass( {
 	displayName: 'Site',
@@ -132,10 +132,7 @@ export default React.createClass( {
 						</span>
 					}
 				</a>
-				{ this.props.indicator
-					? <SiteIndicator site={ site } />
-					: null
-				}
+				{ this.props.indicator && <SiteIndicator site={ site } />  }
 			</div>
 		);
 	}


### PR DESCRIPTION
Site Indicator could use a ES6 refresh 

This PR simplifies the  Site Indicator Component
removes the updating of WordPress core form the component ( it was under a feature flag ) but never really used. Design was needed.
moves it from client/my-sites => blocks

[ ] remove my-sites/site-indicator
[ ] Record events