### PR TITLE
Data Layer: Fix POSTing data in data layer

### DIFF
--- a/client/state/data-layer/wpcom-http/actions.js
+++ b/client/state/data-layer/wpcom-http/actions.js
@@ -21,7 +21,7 @@ import { WPCOM_HTTP_REQUEST } from 'state/action-types';
  */
 export const http = ( {
 	apiVersion = 'v1',
-	body = {},
+	body,
 	method,
 	path,
 	query = {},
@@ -35,7 +35,7 @@ export const http = ( {
 	body,
 	method,
 	path,
-	query: { ...query, apiVersion },
+	query: method === 'GET' && { ...query, apiVersion },
 	formData,
 	onSuccess: onSuccess || action,
 	onFailure: onFailure || action,

--- a/client/state/data-layer/wpcom-http/index.js
+++ b/client/state/data-layer/wpcom-http/index.js
@@ -29,7 +29,7 @@ export const progressMeta = ( { size: total, loaded } ) => ( { meta: { dataLayer
 
 const queueRequest = ( { dispatch }, action, next ) => {
 	const {
-		body = {},
+		body,
 		formData,
 		method: rawMethod,
 		onSuccess,

--- a/client/state/data-layer/wpcom-http/index.js
+++ b/client/state/data-layer/wpcom-http/index.js
@@ -25,7 +25,7 @@ const fetcherMap = method => get( {
 
 export const successMeta = data => ( { meta: { dataLayer: { data } } } );
 export const failureMeta = error => ( { meta: { dataLayer: { error } } } );
-export const progressMeta = ( { size: total, loaded } ) => ( { meta: { dataLayer: { progress: { total, loaded } } } } );
+export const progressMeta = ( { total, loaded } ) => ( { meta: { dataLayer: { progress: { total, loaded } } } } );
 
 const queueRequest = ( { dispatch }, action, next ) => {
 	const {


### PR DESCRIPTION
Passing empty objects for `body` and `query` causes form data to not be POSTed correctly, since wpcom runs explicit checks against `undefined`, or missing, parameters. Not passing these parameters to wpcom at all resolves the problem.