### PR TITLE
Themes Thanks Modal: Drop site prop, get siteId from state

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -540,9 +540,7 @@ const ThemeSheet = React.createClass( {
 				<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />
 				{ this.renderBar() }
 				{ siteID && <QueryActiveTheme siteId={ siteID } /> }
-				<ThanksModal
-					site={ this.props.selectedSite }
-					source={ 'details' } />
+				<ThanksModal source={ 'details' } />
 				<HeaderCake className="theme__sheet-action-bar"
 					backHref={ this.props.backPath }
 					backText={ i18n.translate( 'All Themes' ) }>

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -87,9 +87,7 @@ const ConnectedSingleSiteJetpack = connectOptions(
 					emptyContent={ showWpcomThemesList ? <div /> : null } >
 					{ siteId && <QuerySitePlans siteId={ siteId } /> }
 					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
-					<ThanksModal
-						site={ site }
-						source={ 'list' } />
+					<ThanksModal source={ 'list' } />
 					{ showWpcomThemesList &&
 						<div>
 							<ConnectedThemesSelection

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -18,7 +18,7 @@ import ThemeShowcase from './theme-showcase';
 
 export default connectOptions(
 	( props ) => {
-		const { site, siteId, translate } = props;
+		const { siteId, translate } = props;
 
 		return (
 			<div>
@@ -33,9 +33,7 @@ export default connectOptions(
 				<ThemeShowcase { ...props } siteId={ siteId }>
 					{ siteId && <QuerySitePlans siteId={ siteId } /> }
 					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
-					<ThanksModal
-						site={ site }
-						source={ 'list' } />
+					<ThanksModal source={ 'list' } />
 				</ThemeShowcase>
 			</div>
 		);

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import page from 'page';
 import { translate } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,7 +24,8 @@ import {
 	isWpcomTheme
 } from 'state/themes/selectors';
 import { clearActivated } from 'state/themes/actions';
-import { isJetpackSite } from 'state/sites/selectors';
+import { getSite, isJetpackSite } from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 const ThanksModal = React.createClass( {
 	trackClick: trackClick.bind( null, 'current theme' ),
@@ -42,7 +44,7 @@ const ThanksModal = React.createClass( {
 	},
 
 	onCloseModal() {
-		this.props.clearActivated( this.props.site.ID );
+		this.props.clearActivated( this.props.siteId );
 		this.setState( { show: false } );
 	},
 
@@ -167,18 +169,20 @@ const ThanksModal = React.createClass( {
 } );
 
 export default connect(
-	( state, { site } ) => {
-		const currentThemeId = site && getActiveTheme( state, site.ID );
-		const currentTheme = currentThemeId && getCanonicalTheme( state, site.ID, currentThemeId );
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const siteUrl = get( getSite( state, siteId ), 'URL' );
+		const currentThemeId = getActiveTheme( state, siteId );
+		const currentTheme = currentThemeId && getCanonicalTheme( state, siteId, currentThemeId );
 
 		return {
 			currentTheme,
-			detailsUrl: site && getThemeDetailsUrl( state, currentThemeId, site.ID ),
-			customizeUrl: site && getThemeCustomizeUrl( state, currentThemeId, site.ID ),
-			forumUrl: site && getThemeForumUrl( state, currentThemeId, site.ID ),
-			visitSiteUrl: site && site.URL + ( isJetpackSite( state, site.ID ) ? '' : '?next=customize' ),
-			isActivating: !! ( site && isActivatingTheme( state, site.ID ) ),
-			hasActivated: !! ( site && hasActivatedTheme( state, site.ID ) ),
+			detailsUrl: getThemeDetailsUrl( state, currentThemeId, siteId ),
+			customizeUrl: getThemeCustomizeUrl( state, currentThemeId, siteId ),
+			forumUrl: getThemeForumUrl( state, currentThemeId, siteId ),
+			visitSiteUrl: siteUrl + ( isJetpackSite( state, siteId ) ? '' : '?next=customize' ),
+			isActivating: !! ( isActivatingTheme( state, siteId ) ),
+			hasActivated: !! ( hasActivatedTheme( state, siteId ) ),
 			isThemeWpcom: isWpcomTheme( state, currentThemeId )
 		};
 	},

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -176,6 +176,7 @@ export default connect(
 		const currentTheme = currentThemeId && getCanonicalTheme( state, siteId, currentThemeId );
 
 		return {
+			siteId,
 			currentTheme,
 			detailsUrl: getThemeDetailsUrl( state, currentThemeId, siteId ),
 			customizeUrl: getThemeCustomizeUrl( state, currentThemeId, siteId ),

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import page from 'page';
 import { translate } from 'i18n-calypso';
@@ -32,15 +32,23 @@ const ThanksModal = React.createClass( {
 
 	propTypes: {
 		// Where is the modal being used?
-		source: React.PropTypes.oneOf( [ 'details', 'list', 'upload' ] ).isRequired,
+		source: PropTypes.oneOf( [ 'details', 'list', 'upload' ] ).isRequired,
 		// Connected props
-		isActivating: React.PropTypes.bool.isRequired,
-		hasActivated: React.PropTypes.bool.isRequired,
-		currentTheme: React.PropTypes.shape( {
-			name: React.PropTypes.string,
-			id: React.PropTypes.string
+		clearActivated: PropTypes.func.isRequired,
+		currentTheme: PropTypes.shape( {
+			author: PropTypes.string,
+			author_uri: PropTypes.string,
+			id: PropTypes.string,
+			name: PropTypes.string,
 		} ),
-		clearActivated: React.PropTypes.func.isRequired,
+		customizeUrl: PropTypes.string,
+		detailsUrl: PropTypes.string,
+		forumUrl: PropTypes.string,
+		hasActivated: PropTypes.bool.isRequired,
+		isActivating: PropTypes.bool.isRequired,
+		isThemeWpcom: PropTypes.bool.isRequired,
+		siteId: PropTypes.number,
+		visitSiteUrl: PropTypes.string
 	},
 
 	onCloseModal() {

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -303,7 +303,6 @@ class Upload extends React.Component {
 			translate,
 			complete,
 			siteId,
-			selectedSite,
 			themeId,
 			upgradeJetpack,
 			backPath,
@@ -326,9 +325,7 @@ class Upload extends React.Component {
 				<QueryEligibility siteId={ siteId } />
 				<QueryActiveTheme siteId={ siteId } />
 				{ themeId && complete && <QueryCanonicalTheme siteId={ siteId } themeId={ themeId } /> }
-				<ThanksModal
-					site={ selectedSite }
-					source="upload" />
+				<ThanksModal source="upload" />
 				<HeaderCake backHref={ backPath }>{ translate( 'Upload theme' ) }</HeaderCake>
 				{ upgradeJetpack && <JetpackManageErrorPage
 					template="updateJetpack"


### PR DESCRIPTION
To test: Check the Thanks Modal, from different modes (themes list, sheet; multisite, single WP.com site, JP site)
* Verify that it still works.
* Verify that all links, and the 'Visit Site' button, point to the correct URL (try also JP, ideally installed in a subdir).

(This is a preparatory PR for #12124.)