### PR TITLE
Reader: Suppress the default feed icon for dotcom sites

### DIFF
--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { startsWith } from 'lodash';
+import { startsWith, endsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,6 +14,10 @@ import classnames from 'classnames';
 
 const ReaderAvatar = ( { author, siteIcon, feedIcon, siteUrl, siteIconSize = 96, preferGravatar = false, showPlaceholder = false } ) => {
 	let fakeSite;
+	// don't show the default favicon for some sites
+	if ( endsWith( feedIcon, 'wp.com/i/buttonw-com.png' ) ) {
+		feedIcon = null;
+	}
 	if ( siteIcon ) {
 		fakeSite = {
 			icon: {


### PR DESCRIPTION
Suppress http://s2.wp.com/i/buttonw-com.png, the default feed icon for wpcom sites. It's currently appearing for sites who have no site icon picked.

Fixes #12136