### PR TITLE
Themes: Enable SSR of /design in wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -67,6 +67,7 @@
 		"manage/stats/podcasts": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,
+		"manage/themes-ssr": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,
 		"manage/themes/logged-out": true,


### PR DESCRIPTION
This seems to be working nicely in the `development` environment, so let's enable it in `wpcalypso`.

To test in `development`:
* Restart Calypso
* Check the page source for logged-out `/design`. There should be `meta` tags with `property` attrs set to `og:description`, `og:url`, and `og:type`, respectively, and corresponding `content` attrs that make sense.
* Check that `/design` doesn't give an (all-too) bad content flash.