### PR TITLE
Automated Transfer: Prevent installation of unsupported plugins

### DIFF
--- a/client/my-sites/plugins-wpcom/plugin-install-button.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-install-button.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
+import { get, includes } from 'lodash';
 import page from 'page';
 
 /**
@@ -49,11 +49,25 @@ export const WpcomPluginInstallButton = props => {
 		}
 	}
 
+	function isDisabled() {
+		// Pressable prevents installation of some plugins, so we need to disable AT for them.
+		// More info here: https://kb.pressable.com/faq/does-pressable-restrict-any-plugins/
+		const unsupportedPlugins = [
+			'nginx-helper',
+			'w3-total-cache',
+			'wp-rocket',
+			'wp-super-cache',
+			'bwp-minify',
+		];
+
+		return disabled || includes( unsupportedPlugins, plugin.slug );
+	}
+
 	return (
 		<Button
 			onClick={ installButtonAction }
 			primary={ true }
-			disabled={ disabled }
+			disabled={ isDisabled() }
 		>
 			{ translate( 'Install' ) }
 		</Button>

--- a/client/my-sites/plugins-wpcom/plugin-install-button.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-install-button.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { get, includes } from 'lodash';
+import { get } from 'lodash';
 import page from 'page';
 
 /**
@@ -49,25 +49,11 @@ export const WpcomPluginInstallButton = props => {
 		}
 	}
 
-	function isDisabled() {
-		// Pressable prevents installation of some plugins, so we need to disable AT for them.
-		// More info here: https://kb.pressable.com/faq/does-pressable-restrict-any-plugins/
-		const unsupportedPlugins = [
-			'nginx-helper',
-			'w3-total-cache',
-			'wp-rocket',
-			'wp-super-cache',
-			'bwp-minify',
-		];
-
-		return disabled || includes( unsupportedPlugins, plugin.slug );
-	}
-
 	return (
 		<Button
 			onClick={ installButtonAction }
 			primary={ true }
-			disabled={ isDisabled() }
+			disabled={ disabled }
 		>
 			{ translate( 'Install' ) }
 		</Button>

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -202,7 +202,7 @@ export class PluginInstallButton extends Component {
 	}
 
 	renderButton() {
-		const { translate, isInstalling, isEmbed } = this.props;
+		const { translate, isInstalling, isEmbed, disabled } = this.props;
 		const label = isInstalling ? translate( 'Installing…' ) : translate( 'Install' );
 
 		if ( isEmbed ) {
@@ -210,7 +210,7 @@ export class PluginInstallButton extends Component {
 				<span className="plugin-install-button__install embed">
 					{ isInstalling
 						? <span className="plugin-install-button__installing">{ label }</span>
-						: <Button compact={ true } onClick={ this.installAction } >
+						: <Button compact={ true } onClick={ this.installAction } disabled={ disabled }>
 							<Gridicon key="plus-icon" icon="plus-small" size={ 18 } />
 							<Gridicon icon="plugins" size={ 18 } />
 							{ translate( 'Install' ) }
@@ -222,7 +222,11 @@ export class PluginInstallButton extends Component {
 
 		return (
 			<span className="plugin-install-button__install">
-				<Button onClick={ this.installAction } primary={ true } disabled={ isInstalling } >
+				<Button
+					onClick={ this.installAction }
+					primary={ true }
+					disabled={ isInstalling || disabled }
+				>
 					{ label }
 				</Button>
 			</span>

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -209,7 +209,7 @@ const PluginMeta = React.createClass( {
 		}
 	},
 
-	maybeDisplayAtUnsupportedNotice() {
+	maybeDisplayUnsupportedNotice() {
 		const { selectedSite, plugin } = this.props;
 
 		// Pressable prevents installation of some plugins, so we need to disable AT for them.
@@ -435,7 +435,7 @@ const PluginMeta = React.createClass( {
 				</Card>
 
 				{ config.isEnabled( 'automated-transfer' ) &&
-					this.maybeDisplayAtUnsupportedNotice()
+					this.maybeDisplayUnsupportedNotice()
 				}
 
 				{ config.isEnabled( 'automated-transfer' ) && this.hasBusinessPlan() && ! get( this.props.selectedSite, 'jetpack' ) &&

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -88,7 +88,7 @@ const PluginMeta = React.createClass( {
 	},
 
 	isWpcomPreinstalled: function() {
-		const installedPlugins = [ 'Jetpack by WordPress.com', 'Akismet' ];
+		const installedPlugins = [ 'Jetpack by WordPress.com', 'Akismet', 'VaultPress' ];
 
 		if ( ! this.props.selectedSite ) {
 			return false;
@@ -204,6 +204,36 @@ const PluginMeta = React.createClass( {
 				<WpcomPluginInstallButton
 					disabled={ ! this.hasBusinessPlan() || isTransferring }
 					plugin={ this.props.plugin }
+				/>
+			);
+		}
+	},
+
+	maybeDisplayAtUnsupportedNotice() {
+		const { selectedSite, plugin } = this.props;
+
+		// Pressable prevents installation of some plugins, so we need to disable AT for them.
+		// More info here: https://kb.pressable.com/faq/does-pressable-restrict-any-plugins/
+		const unsupportedPlugins = [
+			'nginx-helper',
+			'w3-total-cache',
+			'wp-rocket',
+			'wp-super-cache',
+			'bwp-minify',
+		];
+
+		if ( selectedSite && ! selectedSite.jetpack && includes( unsupportedPlugins, plugin.slug ) ) {
+			return (
+				<Notice
+					text={ this.translate( 'This plugin is {{a}}not supported{{/a}} on WordPress.com.',
+						{
+							components: {
+								a: <a href="https://support.wordpress.com/incompatible-plugins/" />
+							}
+						}
+					) }
+					status="is-warning"
+					showDismiss={ false }
 				/>
 			);
 		}
@@ -403,6 +433,10 @@ const PluginMeta = React.createClass( {
 						/>
 					}
 				</Card>
+
+				{ config.isEnabled( 'automated-transfer' ) &&
+					this.maybeDisplayAtUnsupportedNotice()
+				}
 
 				{ config.isEnabled( 'automated-transfer' ) && this.hasBusinessPlan() && ! get( this.props.selectedSite, 'jetpack' ) &&
 					<PluginAutomatedTransfer plugin={ this.props.plugin } />

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -244,20 +244,18 @@ const PluginMeta = React.createClass( {
 
 	maybeDisplayUnsupportedNotice() {
 		const { selectedSite, automatedTransferSite } = this.props;
-		
+
 		if ( selectedSite && this.isUnsupportedPlugin() && ( ! selectedSite.jetpack || automatedTransferSite ) ) {
 			return (
 				<Notice
-					text={ this.translate( 'This plugin is {{a}}not supported{{/a}} on WordPress.com.',
-						{
-							components: {
-								a: <a href="https://support.wordpress.com/incompatible-plugins/" />
-							}
-						}
-					) }
+					text={ this.translate( 'Incompatible plugin: WordPress.com already provides this feature.' ) }
 					status="is-warning"
 					showDismiss={ false }
-				/>
+				>
+					<NoticeAction href="https://support.wordpress.com/incompatible-plugins/">
+						{ this.translate( 'More info' ) }
+					</NoticeAction>
+				</Notice>
 			);
 		}
 	},

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -47,7 +47,7 @@ const PluginsBrowserListElement = React.createClass( {
 	},
 
 	isWpcomPreinstalled: function() {
-		const installedPlugins = [ 'Jetpack by WordPress.com', 'Akismet' ];
+		const installedPlugins = [ 'Jetpack by WordPress.com', 'Akismet', 'VaultPress' ];
 
 		if ( ! this.props.site ) {
 			return false;


### PR DESCRIPTION
Resolves: https://github.com/Automattic/wp-calypso/issues/12131

Visual changes: 

![incompplugin](https://cloud.githubusercontent.com/assets/1182160/23958682/2e515cf2-09a3-11e7-8a5f-503f11ccbdc4.png)


# Testing instructions

1. On test dotcom site with a business plan navigate to `plugins/browse`.
2. Search for one of unsupported plugins (nginx-helper, w3-total-cache, wp-rocket, wp-super-cache, bwp-minify) and open plugin detail view.
3. Verify that plugin button is disabled and that appropriate notice is shown.
4. Verify that other plugins are working as expected.
5. Repeat steps 1-4 for AT site and verify that installation of unsupported plugins is disabled.
6. Verify that non-AT Jetpack sites haven't been affected by these changes.
