### PR TITLE
Remove border from follow-button

### DIFF
--- a/client/blocks/follow-button/style.scss
+++ b/client/blocks/follow-button/style.scss
@@ -3,6 +3,10 @@ $follow-button-gray-disabled: lighten( $gray, 20% );
 .follow-button,
 button.follow-button {
 
+	&:focus {
+		box-shadow: none;
+	}
+
 	.gridicon__follow {
 		opacity: 1;
 		pointer-events: auto;


### PR DESCRIPTION
When focused, the Follow/Unfollow button has an unintended blue border in Chrome, Firefox, IE and Edge.

![screen shot 2017-03-15 at 10 40 09 am](https://cloud.githubusercontent.com/assets/2627210/23927060/cde1219a-096b-11e7-8d2d-1d067aee28da.png)

This fix removes the border from the Reader Follow/Unfollow buttons.

