### PR TITLE
Themes: magic search styling: height, color, SCSS

### DIFF
--- a/client/components/suggestions/style.scss
+++ b/client/components/suggestions/style.scss
@@ -16,19 +16,19 @@
 	font-size: 13px;
 
 	.suggestions__category-name {
-		float: left;
 		text-transform: uppercase;
-		color: darken( $gray, 20% );
+		color: $gray-dark;
 	}
 
 	.suggestions__category-counter {
-		float: right;
-		color: $gray;
+		margin-left: 6px;
+		text-transform: uppercase;
+		color: $gray-text-min;
 	}
 }
 
 .suggestions__value {
-	padding: 18px 10px;
+	padding: 10px 10px;
 	background: $white;
 	border: 1px solid darken( $gray-light, 10% );
 	border-top: 0px;

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -137,7 +137,6 @@
 
 	.themes-magic-search-card__welcome-header {
 		font-size: 13px;
-		text-transform: uppercase;
 	}
 }
 
@@ -150,7 +149,7 @@
 	border-radius: 3px;
 	font-size: 13px;
 	line-height: 16px;
-	text-transform: uppercase;
+	text-transform: capitalize;
 	cursor: pointer;
 	transition: all 200ms ease-in;
 

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -91,34 +91,6 @@
 		color: $blue-dark;
 		border-bottom: 3px solid $blue-dark;
 	}
-
-	&.themes-magic-search-card__token-type-feature {
-		.themes-magic-search-card__token-filter {
-			color: $alert-green;
-			border-bottom: 3px solid $alert-green;
-		}
-	}
-
-	&.themes-magic-search-card__token-type-color {
-		.themes-magic-search-card__token-filter {
-			color: $blue-medium;
-			border-bottom: 3px solid $blue-medium;
-		}
-	}
-
-	&.themes-magic-search-card__token-type-layout {
-		.themes-magic-search-card__token-filter {
-			color: $orange_fire;
-			border-bottom: 3px solid $orange_fire;
-		}
-	}
-
-	&.themes-magic-search-card__token-type-subject {
-		.themes-magic-search-card__token-filter {
-			color: $alert-purple;
-			border-bottom: 3px solid $alert-purple;
-		}
-	}
 }
 
 .themes-magic-search-card__search-text {
@@ -195,21 +167,25 @@
 	pointer-events: none;
 }
 
-.themes-magic-search-card__welcome-taxonomy-type-color {
-	color: rgb( 0, 170, 220 );
+
+// Colors
+@mixin themes-magic-search__token-colors( $name, $color ) {
+	.themes-magic-search-card__welcome-taxonomy-type-#{$name} {
+		color: $color;
+	}
+
+	.themes-magic-search-card__token-type-#{$name} {
+		.themes-magic-search-card__token-filter {
+			color: $color;
+			border-bottom: 3px solid $color;
+		}
+	}
 }
-.themes-magic-search-card__welcome-taxonomy-type-column {
-	color: rgb( 144, 19, 254 );
-}
-.themes-magic-search-card__welcome-taxonomy-type-feature {
-	color: rgb( 102, 195, 126 );
-}
-.themes-magic-search-card__welcome-taxonomy-type-layout {
-	color: rgb( 242, 134, 10 );
-}
-.themes-magic-search-card__welcome-taxonomy-type-subject {
-	color: $gray;
-}
-.themes-magic-search-card__welcome-taxonomy-type-style {
-	color: rgb( 241, 56, 59 );
-}
+
+@include themes-magic-search__token-colors( 'color', #005082 );
+@include themes-magic-search__token-colors( 'column', #d54e21 );
+@include themes-magic-search__token-colors( 'feature', #4ab866 );
+@include themes-magic-search__token-colors( 'layout', #f0821e );
+@include themes-magic-search__token-colors( 'subject', #855da6 );
+@include themes-magic-search__token-colors( 'style', #e12f67 );
+@include themes-magic-search__token-colors( 'picks', #0087be );


### PR DESCRIPTION
![screen shot 2017-03-15 at 08 59 41](https://cloud.githubusercontent.com/assets/4389/23940663/be4beba6-095d-11e7-9d08-1c3ce7f598ea.png)

![screen shot 2017-03-15 at 09 58 50](https://cloud.githubusercontent.com/assets/4389/23943015/061d81a8-0966-11e7-956f-b920f22434cf.png)

Some changes that came out in early testing:

1. Dropdown items shorter (but still tall enough to work on mobile)
2. Counter of number of item moved from right side to near the section title so it's more obvious how many items are showing
3. Added SCSS mixin to generate colors appropriately.
4. Capitalize taxonomies instead of uppercase

### To test

1. Open /design
2. Try doing some searches with and without keywords
3. Check there are no visual glitches