### PR TITLE
Reader combined cards: fetch missing site and feed objects, and use postKey for siteId/feedId

### DIFF
--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -15,10 +15,12 @@ import ReaderSiteStreamLink from 'blocks/reader-site-stream-link';
 import { siteNameFromSiteAndPost } from 'reader/utils';
 import ReaderCombinedCardPost from './post';
 import { keysAreEqual, keyForPost } from 'lib/feed-stream-store/post-key';
+import QueryReaderSite from 'components/data/query-reader-site';
+import QueryReaderFeed from 'components/data/query-reader-feed';
 
-const ReaderCombinedCard = ( { posts, site, feed, selectedPostKey, onClick, isDiscover, translate } ) => {
-	const feedId = get( feed, 'feed_ID' );
-	const siteId = get( site, 'ID' );
+const ReaderCombinedCard = ( { posts, site, feed, postKey, selectedPostKey, onClick, isDiscover, translate } ) => {
+	const feedId = postKey.feedId;
+	const siteId = postKey.blogId;
 	const siteIcon = get( site, 'icon.img' );
 	const feedIcon = get( feed, 'image' );
 	const streamUrl = getStreamUrl( feedId, siteId );
@@ -63,6 +65,8 @@ const ReaderCombinedCard = ( { posts, site, feed, selectedPostKey, onClick, isDi
 						/>
 				) ) }
 			</ul>
+			{ feedId && <QueryReaderFeed feedId={ +feedId } includeMeta={ false } /> }
+			{ siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }
 		</Card>
 	);
 };


### PR DESCRIPTION
Some combined cards were missing `feed` and `site` objects, leading to sparse-looking card headers (https://github.com/Automattic/wp-calypso/issues/12090).

We were also waiting for the `feed` and `site` to come in to pull the IDs off them, leading to undefined IDs in the author link (https://github.com/Automattic/wp-calypso/issues/12134).

This PR adds query components to fetch the feed and site where needed, and switches to use the post key to grab the feed ID and site ID (so they should be set immediately rather than waiting for other requests to complete).

Fixes #12090 and #12134.

cc @fraying @designsimply 