### PR TITLE
Framework: button has now `is-busy` state.

### DIFF
--- a/client/components/button/docs/example.jsx
+++ b/client/components/button/docs/example.jsx
@@ -114,6 +114,12 @@ var Buttons = React.createClass( {
 							<Gridicon icon="cross" /> Remove
 						</Button>
 					</div>
+					<div className="docs__design-button-row">
+						<Button busy >Busy button</Button>
+						<Button primary busy icon ><Gridicon icon="camera" /> Primary icon button</Button>
+						<Button primary busy icon ><Gridicon icon="time" /></Button>
+						<Button primary busy >Primary busy button</Button>
+					</div>
 				</Card>
 			);
 		} else {
@@ -176,6 +182,12 @@ var Buttons = React.createClass( {
 						<Button compact borderless scary disabled>
 							<Gridicon icon="cross" /> Remove
 						</Button>
+					</div>
+					<div className="docs__design-button-row">
+						<Button compact busy >Busy button</Button>
+						<Button compact primary busy icon ><Gridicon icon="camera" /> Primary icon button</Button>
+						<Button compact primary busy icon ><Gridicon icon="time" /></Button>
+						<Button compact primary busy >Primary busy button</Button>
 					</div>
 				</Card>
 			);

--- a/client/components/button/index.jsx
+++ b/client/components/button/index.jsx
@@ -10,6 +10,7 @@ export default class Button extends PureComponent {
 		compact: PropTypes.bool,
 		primary: PropTypes.bool,
 		scary: PropTypes.bool,
+		busy: PropTypes.bool,
 		type: PropTypes.string,
 		href: PropTypes.string,
 		borderless: PropTypes.bool,
@@ -22,7 +23,7 @@ export default class Button extends PureComponent {
 	};
 
 	render() {
-		const omitProps = [ 'compact', 'primary', 'scary', 'borderless' ];
+		const omitProps = [ 'compact', 'primary', 'scary', 'busy', 'borderless' ];
 
 		let tag;
 		if ( this.props.href ) {
@@ -50,6 +51,7 @@ export default class Button extends PureComponent {
 				'is-compact': this.props.compact,
 				'is-primary': this.props.primary,
 				'is-scary': this.props.scary,
+				'is-busy': this.props.busy,
 				'is-borderless': this.props.borderless
 			} )
 		} );

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -89,6 +89,11 @@ button {
 			margin-left: -4px;
 		}
 	}
+	&.is-busy {
+		animation: button__busy-animation 3000ms infinite linear;
+		background-size: 120px 100%;
+		background-image: linear-gradient( -45deg, lighten( $gray, 30% ) 28%, $white 28%, $white 72%, lighten( $gray, 30% ) 72%);
+	}
 	&.hidden {
 		display: none;
 	}
@@ -120,6 +125,9 @@ button {
 	}
 	&.is-compact {
 		color: $white;
+	}
+	&.is-busy {
+		background-image: linear-gradient( -45deg, $blue-medium 28%, darken( $blue-medium, 5% ) 28%, darken( $blue-medium, 5% ) 72%, $blue-medium 72%);
 	}
 }
 
@@ -295,4 +303,9 @@ button {
 		font-style: normal;
 		font-weight: normal;
 	}
+}
+
+
+@keyframes button__busy-animation {
+  0%   { background-position: 240px 0; }
 }

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -127,6 +127,7 @@ button {
 		color: $white;
 	}
 	&.is-busy {
+		background-size: 120px 100%;
 		background-image: linear-gradient( -45deg, $blue-medium 28%, darken( $blue-medium, 5% ) 28%, darken( $blue-medium, 5% ) 72%, $blue-medium 72%);
 	}
 }


### PR DESCRIPTION
Introducing an `is-busy` state for buttons (`busy` prop).

This follows the Progress Bar pattern, and it's useful in instances like #12140. 

**Why?** We need this to emphasize when some operations have been taken.

**When to use?** If an operation is not instant this can be introduced — change instantly to the `is-busy` state to signal that the operation has been received.

![cap-](https://cloud.githubusercontent.com/assets/4389/23947263/e7db4f62-0975-11e7-9c32-44a6b6f220f3.gif)

![cap-](https://cloud.githubusercontent.com/assets/4389/23947405/8b98c698-0976-11e7-9312-8786efec07ee.gif)



### To test

1. Open `/devdocs/design/buttons`
2. Check both normal and compact version on multiple browsers
