### PR TITLE
Editor: show busy button state while saving or publishing.

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -58,9 +58,11 @@ button {
 			border-width: 1px 1px 2px;
 		}
 	}
-	&:focus {
-		border-color: $blue-medium;
-		box-shadow: 0 0 0 2px $blue-light;
+	.accessible-focus & {
+		&:focus {
+			border-color: $blue-medium;
+			box-shadow: 0 0 0 2px $blue-light;
+		}
 	}
 	&.is-compact {
 		padding: 7px;

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -361,6 +361,7 @@ export default React.createClass( {
 							isSaveBlocked={ this.props.isSaveBlocked }
 							hasContent={ this.props.hasContent }
 							needsVerification={ this.state.needsVerification }
+							busy={ this.props.isPublishing || this.props.isSaving }
 						/>
 						{ this.canPublishPost() &&
 							<Button

--- a/client/post-editor/editor-publish-button/index.jsx
+++ b/client/post-editor/editor-publish-button/index.jsx
@@ -52,7 +52,8 @@ export class EditorPublishButton extends Component {
 		isPublishing: PropTypes.bool,
 		isSaveBlocked: PropTypes.bool,
 		hasContent: PropTypes.bool,
-		needsVerification: PropTypes.bool
+		needsVerification: PropTypes.bool,
+		busy: PropTypes.bool
 	};
 
 	constructor( props ) {
@@ -123,6 +124,7 @@ export class EditorPublishButton extends Component {
 				className="editor-publish-button"
 				primary
 				compact
+				busy={ this.props.busy }
 				onClick={ this.onClick }
 				disabled={ ! this.isEnabled() }
 				tabIndex={ this.props.tabIndex }


### PR DESCRIPTION
Clarifies something is happening:

![image](https://cloud.githubusercontent.com/assets/548849/23948651/4022383a-0984-11e7-90cc-4a51480f5b38.png)

Fixes #12140.