### PR TITLE
Editor: Hide SEO description for hidden sites

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -21,6 +21,7 @@ import { recordStat, recordEvent } from 'lib/posts/stats';
 import siteUtils from 'lib/site/utils';
 import { isBusiness, isEnterprise } from 'lib/products-values';
 import QueryPostTypes from 'components/data/query-post-types';
+import QuerySiteSettings from 'components/data/query-site-settings';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
@@ -28,6 +29,7 @@ import { getPostType } from 'state/post-types/selectors';
 import { isJetpackMinimumVersion } from 'state/sites/selectors';
 import config from 'config';
 import { isPrivateSite } from 'state/selectors';
+import { isHiddenSite } from 'state/selectors';
 
 import EditorDrawerTaxonomies from './taxonomies';
 import EditorDrawerPageOptions from './page-options';
@@ -250,9 +252,9 @@ const EditorDrawer = React.createClass( {
 
 		const { plan } = this.props.site;
 		const hasBusinessPlan = isBusiness( plan ) || isEnterprise( plan );
-		const { isPrivate } = this.props;
+		const { isPrivate, isHidden } = this.props;
 
-		if ( ! hasBusinessPlan || isPrivate ) {
+		if ( ! hasBusinessPlan || isPrivate || isHidden ) {
 			return;
 		}
 
@@ -335,6 +337,9 @@ const EditorDrawer = React.createClass( {
 				{ site && (
 					<QueryPostTypes siteId={ site.ID } />
 				) }
+				{ site && (
+					<QuerySiteSettings siteId={ site.ID } />
+				) }
 				{ this.renderStatus() }
 				{ this.renderTaxonomies() }
 				{ this.renderFeaturedImage() }
@@ -358,6 +363,7 @@ export default connect(
 			jetpackVersionSupportsSeo: isJetpackMinimumVersion( state, siteId, '4.4-beta1' ),
 			typeObject: getPostType( state, siteId, type ),
 			isPrivate: isPrivateSite( state, siteId ),
+			isHidden: isHiddenSite( state, siteId ),
 		};
 	},
 	null,

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -73,6 +73,7 @@ export isDirectlyReady from './is-directly-ready';
 export isDirectlyUninitialized from './is-directly-uninitialized';
 export isDomainOnlySite from './is-domain-only-site';
 export isFetchingJetpackModules from './is-fetching-jetpack-modules';
+export isHiddenSite from './is-hidden-site';
 export isJetpackModuleActive from './is-jetpack-module-active';
 export isJetpackModuleUnavailableInDevelopmentMode from './is-jetpack-module-unavailable-in-development-mode';
 export isJetpackSettingsSaveFailure from './is-jetpack-settings-save-failure';

--- a/client/state/selectors/is-hidden-site.js
+++ b/client/state/selectors/is-hidden-site.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { getSiteSettings } from 'state/site-settings/selectors';
+
+/**
+ * Returns true if the site is hidden
+ *
+ * @param {Object} state Global state tree
+ * @param {Object} siteId Site ID
+ * @return {Boolean} True if site is hidden
+ */
+export default function isHiddenSite( state, siteId ) {
+	const settings = getSiteSettings( state, siteId );
+
+	if ( ! settings ) {
+		return null;
+	}
+
+	// Site settings returns a numerical value for blog_public.
+	return parseInt( settings.blog_public, 10 ) === 0;
+}

--- a/client/state/selectors/test/is-hidden-site.js
+++ b/client/state/selectors/test/is-hidden-site.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isHiddenSite } from '../';
+
+describe( 'isHiddenSite()', () => {
+	it( 'should return null if the site is not known', () => {
+		const isHidden = isHiddenSite( {
+			siteSettings: {
+				items: {
+					2916284: {
+						blog_public: 1
+					}
+				}
+			}
+		}, 2916285 );
+
+		expect( isHidden ).to.be.null;
+	} );
+
+	it( 'should return false for public sites', () => {
+		const isHidden = isHiddenSite( {
+			siteSettings: {
+				items: {
+					2916284: {
+						blog_public: 1
+					}
+				}
+			}
+		}, 2916284 );
+
+		expect( isHidden ).to.be.false;
+	} );
+
+	it( 'should return true for hidden sites', () => {
+		const isHidden = isHiddenSite( {
+			siteSettings: {
+				items: {
+					2916284: {
+						blog_public: 0
+					}
+				}
+			}
+		}, 2916284 );
+
+		expect( isHidden ).to.be.true;
+	} );
+} );


### PR DESCRIPTION
This PR is related to #11579. In that PR, we're hiding the SEO description setting in the editor for private sites. This introduces a new selector that checks whether a site is hidden and hides the SEO description as well.

We'll have some merge conflicts to address so let's not merge it yet, but I wanted to get the bulk of the code for the selector written.

## To test
1. Load up this branch. Visit settings for one of your sites at http://calypso.localhost:3000/settings/general/.
2. Set your site to hidden.
3. Click "Add" to start a new post. The SEO description in the sidebar should not be visible.
4. Go back to your site settings. Change the site to public.
5. Open the Editor again. The SEO description in the sidebar should be visible.