### PR TITLE
Reader: tweak spacing on combined card featured image and visit gridicon

### DIFF
--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -36,7 +36,6 @@
 .reader-combined-card__post-details {
 	font-family: $serif;
 	width: 100%;
-
 }
 
 .reader-combined-card__post-title-link,
@@ -65,7 +64,7 @@
 
 .reader-combined-card__featured-image-wrapper {
 	min-width: 100px;
-	margin-right: 20px;
+	margin-right: 15px;
 }
 
 .reader-combined-card .reader-featured-image {
@@ -159,7 +158,7 @@
 	margin-right: 26px;
 
 	.reader-visit-link__label {
-		margin-left: 2px;
+		margin-left: 4px;
 	}
 }
 


### PR DESCRIPTION
As per @fraying's request in #12148, this PR slightly reduces the right margin on the combined card featured image, and slightly increases the right margin on the visit link gridicon.

Before:

<img width="281" alt="screen shot 2017-03-15 at 14 10 28" src="https://cloud.githubusercontent.com/assets/17325/23952497/8795dfa0-0989-11e7-898d-fb2d213dbe5d.png">

After:

<img width="251" alt="screen shot 2017-03-15 at 14 10 35" src="https://cloud.githubusercontent.com/assets/17325/23952496/878d9886-0989-11e7-8257-49c576283ab2.png">

Fixes #12148.