### PR TITLE
Themes: magic search styling, simpler to avoid glitches

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -70,7 +70,8 @@
 		display: inline-block;
 
 		/* These are styling */
-		color: $gray;
+		border-bottom: 3px solid $blue-medium;
+		opacity: 0.6;
 	}
 
 	.themes-magic-search-card__token-separator {
@@ -79,8 +80,8 @@
 		display: inline-block;
 
 		/* These are styling */
-		color: $gray;
-		height: 24px;
+		border-bottom: 3px solid $blue-medium;
+		opacity: 0.6;
 	}
 
 	.themes-magic-search-card__token-filter {
@@ -88,15 +89,14 @@
 		display: inline-block;
 
 		/* These are styling */
-		color: $blue-dark;
-		border-bottom: 3px solid $blue-dark;
+		border-bottom: 3px solid $blue-medium;
 	}
 }
 
 .themes-magic-search-card__search-text {
 	font: inherit;
 	pointer-events: none;
-	color: rgba(1, 0, 0, 0.2);
+	color: transparent;
 }
 
 .themes-magic-search-card__search-white-space {
@@ -174,9 +174,10 @@
 	}
 
 	.themes-magic-search-card__token-type-#{$name} {
+		.themes-magic-search-card__token-taxonomy,
+		.themes-magic-search-card__token-separator,
 		.themes-magic-search-card__token-filter {
-			color: $color;
-			border-bottom: 3px solid $color;
+			border-color: $color;
 		}
 	}
 }


### PR DESCRIPTION
![screen shot 2017-03-15 at 14 56 21](https://cloud.githubusercontent.com/assets/4389/23954832/31dc8864-0990-11e7-9126-47a21fc4de19.png)


Update to the style to simplify it.

**Why?** The current approach to style sometimes glitches and loses slightly the alignment, resulting in blurry fonts. By using just underline we make sure the fuzzy fonts don't show up.


### To test

1. Open `/design`
2. Try searching mixing taxonomies and text on multiple browsers