### PR TITLE
Add WP Admin link to plugin detail

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -369,7 +369,7 @@ const PluginMeta = React.createClass( {
 
 		const plugin = this.props.selectedSite && this.props.sites[ 0 ] ? this.props.sites[ 0 ].plugin : this.props.plugin;
 		let actionLinks = get( plugin, 'action_links' );
-		if ( isEmpty( actionLinks ) ) {
+		if ( get( plugin, 'active' ) && isEmpty( actionLinks ) ) {
 			actionLinks = this.getDefaultActionLinks();
 		}
 

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -238,7 +238,7 @@ const PluginMeta = React.createClass( {
 	getDefaultActionLinks() {
 		const adminUrl = get( this.props, 'selectedSite.options.admin_url' );
 		return adminUrl
-			? { 'wp-admin': adminUrl }
+			? { [ i18n.translate( 'WP Admin' ) ]: adminUrl }
 			: null;
 	},
 

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -235,6 +235,13 @@ const PluginMeta = React.createClass( {
 		}
 	},
 
+	getDefaultActionLinks() {
+		const adminUrl = get( this.props, 'selectedSite.options.admin_url' );
+		return adminUrl
+			? { 'wp-admin': adminUrl }
+			: null;
+	},
+
 	getUpdateWarning() {
 		const newVersions = this.getAvailableNewVersions();
 		if ( newVersions.length > 0 ) {
@@ -361,7 +368,10 @@ const PluginMeta = React.createClass( {
 		} );
 
 		const plugin = this.props.selectedSite && this.props.sites[ 0 ] ? this.props.sites[ 0 ].plugin : this.props.plugin;
-		const actionLinks = get( plugin, 'action_links' );
+		let actionLinks = get( plugin, 'action_links' );
+		if ( isEmpty( actionLinks ) ) {
+			actionLinks = this.getDefaultActionLinks();
+		}
 
 		return (
 			<div className="plugin-meta">


### PR DESCRIPTION
Adds a default `WP Admin` link button to a plugin if it didn't provide any action links.

Fixes #12141 

<img width="211" alt="screen shot 2017-03-15 at 9 39 40 am" src="https://cloud.githubusercontent.com/assets/789137/23961665/e092fafa-0968-11e7-90fd-639692240ea3.png">
