### PR TITLE
Reader: Fix gap filling on tag streams

### DIFF
--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -54,6 +54,11 @@ function limitSiteParamsForLikes( params ) {
 	params.fields += ',date_liked';
 }
 
+function limitSiteParamsForTags( params ) {
+	limitSiteParams( params );
+	params.fields += ',tagged_on';
+}
+
 function trainTracksProxyForStream( stream, callback ) {
 	return function( err, response ) {
 		const eventName = 'calypso_traintracks_render';
@@ -102,8 +107,8 @@ function getStoreForTag( storeId ) {
 		id: storeId,
 		fetcher: fetcher,
 		keyMaker: mixedKeyMaker,
-		onGapFetch: limitSiteParams,
-		onUpdateFetch: limitSiteParams,
+		onGapFetch: limitSiteParamsForTags,
+		onUpdateFetch: limitSiteParamsForTags,
 		dateProperty: 'tagged_on'
 	} );
 }


### PR DESCRIPTION
Fixes filling gaps and getting updates to tag streams.

To test, load http://wordpress.com/tag/chickens?at=2017-01-01. Wait for the updates pill to appear. Click it to accept updates. Scroll down until you see the gap indicator (Load More Posts). Click on it. Notice nothing happens.

Now try it with this PR. Gaps should load successfullly. 