### PR TITLE
AT: Reintroduce middleware and freeze site polling

### DIFF
--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -101,9 +101,6 @@ SitesList.prototype.fetch = function() {
 SitesList.prototype.pauseFetching = function() {
 	this.ignoreUpdates = true;
 };
-SitesList.prototype.resumeFetching = function() {
-	this.ignoreUpdates = false;
-};
 
 SitesList.prototype.sync = function( data ) {
 	debug( 'SitesList fetched from api:', data.sites );
@@ -225,7 +222,7 @@ SitesList.prototype.update = function( sites ) {
 			//Assign old URL because new url is broken because the site response caches domains
 			//and we have trouble getting over it.
 			if ( site.options.is_automated_transfer && site.URL.match( '.wordpress.com' ) ) {
-				return siteObj;
+				site.URL = siteObj.URL;
 			}
 
 			if ( site.options.is_automated_transfer && ! siteObj.jetpack && site.jetpack ) {

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -106,7 +106,10 @@ SitesList.prototype.resumeFetching = function() {
 };
 
 SitesList.prototype.sync = function( data ) {
-	debug( 'SitesList fetched from api:', data.sites );
+	if ( this.ignoreUpdates ) {
+		return;
+	}
+	debug( 'SitesList fetched from api:', data.sites, this.ignoreUpdates );
 
 	let sites = this.parse( data );
 	if ( ! this.initialized ) {

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -106,10 +106,7 @@ SitesList.prototype.resumeFetching = function() {
 };
 
 SitesList.prototype.sync = function( data ) {
-	if ( this.ignoreUpdates ) {
-		return;
-	}
-	debug( 'SitesList fetched from api:', data.sites, this.ignoreUpdates );
+	debug( 'SitesList fetched from api:', data.sites );
 
 	let sites = this.parse( data );
 	if ( ! this.initialized ) {

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -101,6 +101,9 @@ SitesList.prototype.fetch = function() {
 SitesList.prototype.pauseFetching = function() {
 	this.ignoreUpdates = true;
 };
+SitesList.prototype.resumeFetching = function() {
+	this.ignoreUpdates = false;
+};
 
 SitesList.prototype.sync = function( data ) {
 	debug( 'SitesList fetched from api:', data.sites );
@@ -222,7 +225,7 @@ SitesList.prototype.update = function( sites ) {
 			//Assign old URL because new url is broken because the site response caches domains
 			//and we have trouble getting over it.
 			if ( site.options.is_automated_transfer && site.URL.match( '.wordpress.com' ) ) {
-				site.URL = siteObj.URL;
+				return siteObj;
 			}
 
 			if ( site.options.is_automated_transfer && ! siteObj.jetpack && site.jetpack ) {

--- a/client/my-sites/plugins/access-control.js
+++ b/client/my-sites/plugins/access-control.js
@@ -31,6 +31,10 @@ const getWpcomPluginPageError = () => {
 const hasRestrictedAccess = ( site ) => {
 	site = site || sites.getSelectedSite();
 
+	if ( site.options && site.options.is_automated_transfer ) {
+		return;
+	}
+
 	// Display a 404 to users that don't have the rights to manage plugins
 	if ( hasErrorCondition( site, 'notRightsToManagePlugins' ) ) {
 		return {

--- a/client/my-sites/plugins/access-control.js
+++ b/client/my-sites/plugins/access-control.js
@@ -31,10 +31,6 @@ const getWpcomPluginPageError = () => {
 const hasRestrictedAccess = ( site ) => {
 	site = site || sites.getSelectedSite();
 
-	if ( site.options && site.options.is_automated_transfer ) {
-		return;
-	}
-
 	// Display a 404 to users that don't have the rights to manage plugins
 	if ( hasErrorCondition( site, 'notRightsToManagePlugins' ) ) {
 		return {

--- a/client/state/automated-transfer/middleware.js
+++ b/client/state/automated-transfer/middleware.js
@@ -6,24 +6,12 @@ import {
 	THEME_TRANSFER_INITIATE_REQUEST,
 	THEME_TRANSFER_INITIATE_SUCCESS,
 } from 'state/action-types';
-import { pauseAll, resumePaused } from 'lib/data-poller'; 
-
-const pauseFetching = () => {
-	pauseAll();
-	const sites = require( 'lib/sites-list' )();
-	sites.pauseFetching();
-};
-
-const resumeFetching = () => {
-	resumePaused();
-	const sites = require( 'lib/sites-list' )();
-	sites.resumeFetching();
-};
+import { pauseAll, resumePaused } from 'lib/data-poller';
 
 export const handlers = {
-	[ THEME_TRANSFER_INITIATE_REQUEST ]: pauseFetching,
-	[ THEME_TRANSFER_INITIATE_FAILURE ]: resumeFetching,
-	[ THEME_TRANSFER_INITIATE_SUCCESS ]: resumeFetching
+	[ THEME_TRANSFER_INITIATE_REQUEST ]: pauseAll,
+	[ THEME_TRANSFER_INITIATE_FAILURE ]: resumePaused,
+	[ THEME_TRANSFER_INITIATE_SUCCESS ]: resumePaused
 };
 
 /**

--- a/client/state/automated-transfer/middleware.js
+++ b/client/state/automated-transfer/middleware.js
@@ -6,12 +6,24 @@ import {
 	THEME_TRANSFER_INITIATE_REQUEST,
 	THEME_TRANSFER_INITIATE_SUCCESS,
 } from 'state/action-types';
-import { pauseAll, resumePaused } from 'lib/data-poller';
+import { pauseAll, resumePaused } from 'lib/data-poller'; 
+
+const pauseFetching = () => {
+	pauseAll();
+	const sites = require( 'lib/sites-list' )();
+	sites.pauseFetching();
+};
+
+const resumeFetching = () => {
+	resumePaused();
+	const sites = require( 'lib/sites-list' )();
+	sites.resumeFetching();
+};
 
 export const handlers = {
-	[ THEME_TRANSFER_INITIATE_REQUEST ]: pauseAll,
-	[ THEME_TRANSFER_INITIATE_FAILURE ]: resumePaused,
-	[ THEME_TRANSFER_INITIATE_SUCCESS ]: resumePaused
+	[ THEME_TRANSFER_INITIATE_REQUEST ]: pauseFetching,
+	[ THEME_TRANSFER_INITIATE_FAILURE ]: resumeFetching,
+	[ THEME_TRANSFER_INITIATE_SUCCESS ]: resumeFetching
 };
 
 /**

--- a/client/state/automated-transfer/middleware.js
+++ b/client/state/automated-transfer/middleware.js
@@ -1,29 +1,26 @@
 /**
  * Internal dependencies
  */
-import localforage from 'lib/localforage';
 import {
-	THEME_TRANSFER_STATUS_RECEIVE,
-	AUTOMATED_TRANSFER_STATUS_SET,
-	AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE
+	THEME_TRANSFER_INITIATE_FAILURE,
+	THEME_TRANSFER_INITIATE_REQUEST,
+	THEME_TRANSFER_INITIATE_SUCCESS,
 } from 'state/action-types';
 
-const clearBrowserStorageAndRefresh = ( dispatch, { status } ) => {
-	if ( typeof window !== 'undefined' && status === 'complete' ) {
-		localStorage.clear();
-		const isThemeUpload = window.location.pathname.indexOf( '/design/upload' ) === 0;
-		const destination = isThemeUpload
-			? window.location.pathname.split( '/upload' ).join( '' )
-			: window.location.pathname;
-		const goToDestination = () => window.location.href = destination;
-		localforage.clear().then( goToDestination, goToDestination );
-	}
+const pauseFetching = ( dispatch, { status } ) => {
+	const sites = require( 'lib/sites-list' )();
+	sites.pauseFetching();
+};
+
+const resumeFetching = ( dispatch, { status } ) => {
+	const sites = require( 'lib/sites-list' )();
+	sites.resumeFetching();
 };
 
 export const handlers = {
-	[ THEME_TRANSFER_STATUS_RECEIVE ]: clearBrowserStorageAndRefresh,
-	[ AUTOMATED_TRANSFER_STATUS_SET ]: clearBrowserStorageAndRefresh,
-	[ AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE ]: clearBrowserStorageAndRefresh
+	[ THEME_TRANSFER_INITIATE_REQUEST ]: pauseFetching,
+	[ THEME_TRANSFER_INITIATE_FAILURE ]: resumeFetching,
+	[ THEME_TRANSFER_INITIATE_SUCCESS ]: resumeFetching
 };
 
 /**

--- a/client/state/automated-transfer/middleware.js
+++ b/client/state/automated-transfer/middleware.js
@@ -6,13 +6,16 @@ import {
 	THEME_TRANSFER_INITIATE_REQUEST,
 	THEME_TRANSFER_INITIATE_SUCCESS,
 } from 'state/action-types';
+import { pauseAll, resumePaused } from 'lib/data-poller'; 
 
 const pauseFetching = () => {
+	pauseAll();
 	const sites = require( 'lib/sites-list' )();
 	sites.pauseFetching();
 };
 
 const resumeFetching = () => {
+	resumePaused();
 	const sites = require( 'lib/sites-list' )();
 	sites.resumeFetching();
 };

--- a/client/state/automated-transfer/middleware.js
+++ b/client/state/automated-transfer/middleware.js
@@ -2,11 +2,12 @@
  * Internal dependencies
  */
 import {
+	AUTOMATED_TRANSFER_STATUS_SET,
 	THEME_TRANSFER_INITIATE_FAILURE,
 	THEME_TRANSFER_INITIATE_REQUEST,
 	THEME_TRANSFER_INITIATE_SUCCESS,
 } from 'state/action-types';
-import { pauseAll, resumePaused } from 'lib/data-poller'; 
+import { pauseAll, resumePaused } from 'lib/data-poller';
 
 const pauseFetching = () => {
 	pauseAll();
@@ -23,7 +24,14 @@ const resumeFetching = () => {
 export const handlers = {
 	[ THEME_TRANSFER_INITIATE_REQUEST ]: pauseFetching,
 	[ THEME_TRANSFER_INITIATE_FAILURE ]: resumeFetching,
-	[ THEME_TRANSFER_INITIATE_SUCCESS ]: resumeFetching
+	[ THEME_TRANSFER_INITIATE_SUCCESS ]: resumeFetching,
+	[ AUTOMATED_TRANSFER_STATUS_SET ]: ( dispatch, { status } ) => {
+		if ( 'complete' === status ) {
+			resumeFetching();
+		} else if ( 'start' === status ) {
+			pauseFetching();
+		}
+	}
 };
 
 /**

--- a/client/state/automated-transfer/middleware.js
+++ b/client/state/automated-transfer/middleware.js
@@ -7,12 +7,12 @@ import {
 	THEME_TRANSFER_INITIATE_SUCCESS,
 } from 'state/action-types';
 
-const pauseFetching = ( dispatch, { status } ) => {
+const pauseFetching = () => {
 	const sites = require( 'lib/sites-list' )();
 	sites.pauseFetching();
 };
 
-const resumeFetching = ( dispatch, { status } ) => {
+const resumeFetching = () => {
 	const sites = require( 'lib/sites-list' )();
 	sites.resumeFetching();
 };

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -58,6 +58,7 @@ import themes from './themes/reducer';
 import ui from './ui/reducer';
 import users from './users/reducer';
 import wordads from './wordads/reducer';
+import config from 'config';
 
 /**
  * Module variables
@@ -124,6 +125,7 @@ export function createReduxStore( initialState = {} ) {
 		isBrowser && require( './analytics/middleware.js' ).analyticsMiddleware,
 		isBrowser && require( './data-layer/wpcom-api-middleware.js' ).default,
 		isAudioSupported && require( './audio/middleware.js' ).default,
+		isBrowser && config.isEnabled( 'automated-transfer' ) && require( './automated-transfer/middleware.js' ).default,
 	].filter( Boolean );
 
 	const enhancers = [


### PR DESCRIPTION
This reintroduces middleware created in https://github.com/Automattic/wp-calypso/pull/10986 and freezes site polling for the brief interim state where site returns corrupted data.

Attempts to solve this error: https://cloudup.com/ijxOOVNVydJ

## Testing
- Get a huge site with 1040 + posts
- Transfer it
- You shoould not see the error in the movie

### Allternative testing
- Build with debug `DEBUG=calypso:sites-list make run` OR change debug->console.log in line 109 of sites-list/list.js
- Whenever `me/sites` request in network tab completes, you should see `SitesList fetched from api` in the console
- Make dispatch a global somewhere in the code (redux devtool does not play nice for some reason)
- 
- dispatch action `THEME_TRANSFER_INITIATE_REQUEST` ( `window.d({type: 'THEME_TRANSFER_INITIATE_REQUEST'})`)in redux console
- now polling should stop and you should not get `SitesList fetched from api` in the console
- After a longer time, `window.d({type: 'THEME_TRANSFER_INITIATE_SUCCESS'})` and polling and logs should return

CC @gwwar 