### PR TITLE
Plugins: update AT eligibility holds wording

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.jsx
+++ b/client/blocks/eligibility-warnings/hold-list.jsx
@@ -24,63 +24,64 @@ function getHoldMessages( translate ) {
 		},
 		TRANSFER_ALREADY_EXISTS: {
 			title: translate( 'Installation in progress' ),
-			description: translate( 'Another installation is already in progress.' ),
-			supportUrl: 'https://wordpress.com/help'
+			description: translate( 'Please wait for the other installation to complete, then try again.' ),
+			supportUrl: 'https://wordpress.com/help',
 		},
+		// Handled as a banner
 		NO_BUSINESS_PLAN: {
 			title: translate( 'Business plan required' ),
 			description: translate( 'This feature is only allowed on sites with a business plan.' ),
-			supportUrl: 'https://support.wordpress.com/'
+			supportUrl: 'https://support.wordpress.com/',
 		},
 		NO_JETPACK_SITES: {
-			title: translate( 'Jetpack site' ),
-			description: translate( 'This feature is not supported on Jetpack sites.' ),
-			supportUrl: 'https://wordpress.com/help'
+			title: translate( 'Jetpack not supported' ),
+			description: translate( 'Try using a different site.' ),
 		},
 		NO_VIP_SITES: {
-			title: translate( 'VIP site' ),
-			description: translate( 'This feature is not supported on VIP sites.' ),
-			supportUrl: 'https://wordpress.com/help'
+			title: translate( 'VIP site not supported' ),
+			description: translate( 'Try using a different site.' ),
 		},
 		SITE_PRIVATE: {
-			title: translate( 'Private site' ),
-			description: translate( 'This feature is not supported on private sites.' ),
-			supportUrl: 'https://support.wordpress.com/'
+			title: translate( 'Private site not supported' ),
+			description: translate( 'Make your site public to resolve.' ),
+			supportUrl: 'https://support.wordpress.com/settings/privacy-settings/',
 		},
 		SITE_GRAYLISTED: {
-			title: translate( 'Flagged site' ),
-			description: translate( 'This feature is not supported on sites that are not in good standing.' ),
-			supportUrl: 'https://wordpress.com/help'
+			title: translate( 'Flagged site not supported' ),
+			description: translate( "Contact us to review your site's standing to resolve." ),
+			supportUrl: 'https://support.wordpress.com/suspended-blogs/',
 		},
 		NON_ADMIN_USER: {
 			title: translate( 'Admin access required' ),
 			description: translate( 'Only site administrators are allowed to use this feature.' ),
-			supportUrl: 'https://support.wordpress.com/user-roles/'
+			supportUrl: 'https://support.wordpress.com/user-roles/',
 		},
+		// Handled as a banner
 		NOT_USING_CUSTOM_DOMAIN: {
 			title: translate( 'No custom domain' ),
 			description: translate( 'Your site must use a custom domain to use this feature.' ),
-			supportUrl: 'https://support.wordpress.com/register-domain/'
+			supportUrl: 'https://support.wordpress.com/register-domain/',
 		},
 		NOT_DOMAIN_OWNER: {
 			title: translate( 'Not a custom domain owner' ),
 			description: translate( 'You must be the owner of the primary domain subscription to use this feature.' ),
-			supportUrl: 'https://support.wordpress.com/domains/'
+			supportUrl: 'https://support.wordpress.com/domains/',
 		},
 		NO_WPCOM_NAMESERVERS: {
 			title: translate( 'No WordPress.com name servers' ),
-			description: translate( 'Your custom domain must point to WordPress.com name servers.' ),
-			supportUrl: 'https://support.wordpress.com/domain-helper/'
+			description: translate( 'Use WordPress.com name servers on your custom domain to resolve.' ),
+			supportUrl: 'https://support.wordpress.com/domain-helper/',
 		},
 		NOT_RESOLVING_TO_WPCOM: {
 			title: translate( 'Primary domain not pointing to WordPress.com servers' ),
-			description: translate( 'Your primary domain must point to WordPress.com servers.' ),
-			supportUrl: 'https://support.wordpress.com/domain-helper/'
+			description: translate( 'Point your primary domain to WordPress.com servers to resolve.' ),
+			supportUrl: 'https://support.wordpress.com/domain-helper/',
 		},
 		NO_SSL_CERTIFICATE: {
-			title: translate( 'Primary domain does not have a valid SSL certificate' ),
-			description: translate( 'You will be able to proceed once we finish setting up some security settings for the site.' ),
-			supportUrl: 'https://wordpress.com/help'
+			title: translate( "Primary domain doesn't have a valid SSL certificate" ),
+			description: translate(
+				'Please try again in a few minutes: you will be able to proceed once we finish setting up your security settings.'
+			),
 		}
 	};
 }
@@ -110,15 +111,17 @@ export const HoldList = ( {
 								{ holdMessages[ hold ].description }
 							</span>
 						</div>
-						<div className="eligibility-warnings__action">
-							<Button
-								compact
-								href={ holdMessages[ hold ].supportUrl }
-								rel="noopener noreferrer"
-							>
-								{ translate( 'Resolve' ) }
-							</Button>
-						</div>
+						{ holdMessages[ hold ].supportUrl &&
+							<div className="eligibility-warnings__action">
+								<Button
+									compact
+									href={ holdMessages[ hold ].supportUrl }
+									rel="noopener noreferrer"
+								>
+									{ translate( 'Resolve' ) }
+								</Button>
+							</div>
+						}
 					</div>
 				) }
 			</Card>

--- a/client/blocks/eligibility-warnings/hold-list.jsx
+++ b/client/blocks/eligibility-warnings/hold-list.jsx
@@ -22,12 +22,6 @@ function getHoldMessages( translate ) {
 			description: translate( 'Please wait for the other installation to complete, then try again.' ),
 			supportUrl: 'https://wordpress.com/help',
 		},
-		// Handled as a banner
-		NO_BUSINESS_PLAN: {
-			title: translate( 'Business plan required' ),
-			description: translate( 'This feature is only allowed on sites with a business plan.' ),
-			supportUrl: 'https://support.wordpress.com/',
-		},
 		NO_JETPACK_SITES: {
 			title: translate( 'Jetpack not supported' ),
 			description: translate( 'Try using a different site.' ),
@@ -50,12 +44,6 @@ function getHoldMessages( translate ) {
 			title: translate( 'Admin access required' ),
 			description: translate( 'Only site administrators are allowed to use this feature.' ),
 			supportUrl: 'https://support.wordpress.com/user-roles/',
-		},
-		// Handled as a banner
-		NOT_USING_CUSTOM_DOMAIN: {
-			title: translate( 'No custom domain' ),
-			description: translate( 'Your site must use a custom domain to use this feature.' ),
-			supportUrl: 'https://support.wordpress.com/register-domain/',
 		},
 		NOT_DOMAIN_OWNER: {
 			title: translate( 'Not a custom domain owner' ),

--- a/client/blocks/eligibility-warnings/hold-list.jsx
+++ b/client/blocks/eligibility-warnings/hold-list.jsx
@@ -17,11 +17,6 @@ import SectionHeader from 'components/section-header';
 // TODO: update supportUrls and maybe create similar mapping for warnings
 function getHoldMessages( translate ) {
 	return {
-		PLACEHOLDER: {
-			title: '',
-			description: '',
-			supportUrl: '',
-		},
 		TRANSFER_ALREADY_EXISTS: {
 			title: translate( 'Installation in progress' ),
 			description: translate( 'Please wait for the other installation to complete, then try again.' ),
@@ -88,6 +83,7 @@ function getHoldMessages( translate ) {
 
 export const HoldList = ( {
 	holds,
+	isPlaceholder,
 	translate,
 } ) => {
 	const holdMessages = getHoldMessages( translate );
@@ -100,7 +96,19 @@ export const HoldList = ( {
 				{ count: holds.length }
 			) } />
 			<Card className="eligibility-warnings__hold-list">
-				{ map( holds, hold =>
+				{ isPlaceholder &&
+					<div>
+						<div className="eligibility-warnings__hold">
+							<Gridicon icon="notice-outline" size={ 24 } />
+							<div className="eligibility-warnings__message"></div>
+						</div>
+						<div className="eligibility-warnings__hold">
+							<Gridicon icon="notice-outline" size={ 24 } />
+							<div className="eligibility-warnings__message"></div>
+						</div>
+					</div>
+				}
+				{ ! isPlaceholder && map( holds, hold =>
 					<div className="eligibility-warnings__hold" key={ hold }>
 						<Gridicon icon="notice-outline" size={ 24 } />
 						<div className="eligibility-warnings__message">

--- a/client/blocks/eligibility-warnings/hold-list.jsx
+++ b/client/blocks/eligibility-warnings/hold-list.jsx
@@ -23,7 +23,7 @@ function getHoldMessages( siteSlug, translate ) {
 			supportUrl: 'https://wordpress.com/help',
 		},
 		NO_JETPACK_SITES: {
-			title: translate( 'Jetpack not supported' ),
+			title: translate( 'Jetpack site not supported' ),
 			description: translate( 'Try using a different site.' ),
 		},
 		NO_VIP_SITES: {

--- a/client/blocks/eligibility-warnings/hold-list.jsx
+++ b/client/blocks/eligibility-warnings/hold-list.jsx
@@ -15,7 +15,7 @@ import SectionHeader from 'components/section-header';
 
 // Mapping eligibility holds to messages that will be shown to the user
 // TODO: update supportUrls and maybe create similar mapping for warnings
-function getHoldMessages( translate ) {
+function getHoldMessages( siteSlug, translate ) {
 	return {
 		TRANSFER_ALREADY_EXISTS: {
 			title: translate( 'Installation in progress' ),
@@ -33,7 +33,7 @@ function getHoldMessages( translate ) {
 		SITE_PRIVATE: {
 			title: translate( 'Private site not supported' ),
 			description: translate( 'Make your site public to resolve.' ),
-			supportUrl: 'https://support.wordpress.com/settings/privacy-settings/',
+			supportUrl: `/settings/general/${ siteSlug }`,
 		},
 		SITE_GRAYLISTED: {
 			title: translate( 'Flagged site not supported' ),
@@ -72,9 +72,10 @@ function getHoldMessages( translate ) {
 export const HoldList = ( {
 	holds,
 	isPlaceholder,
+	siteSlug,
 	translate,
 } ) => {
-	const holdMessages = getHoldMessages( translate );
+	const holdMessages = getHoldMessages( siteSlug, translate );
 
 	return (
 		<div>

--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -40,7 +40,7 @@ export const EligibilityWarnings = ( {
 	const warnings = get( eligibilityData, 'eligibilityWarnings', [] );
 
 	const [ bannerHolds, listHolds ] = partition(
-		get( eligibilityData, 'eligibilityHolds', [ 'PLACEHOLDER', 'PLACEHOLDER' ] ),
+		get( eligibilityData, 'eligibilityHolds', [] ),
 		hold => includes( [ 'NO_BUSINESS_PLAN', 'NOT_USING_CUSTOM_DOMAIN' ], hold ),
 	);
 
@@ -77,8 +77,12 @@ export const EligibilityWarnings = ( {
 				/>
 			}
 
-			{ listHolds.length > 0 && <HoldList holds={ listHolds } /> }
-			{ warnings.length > 0 && <WarningList warnings={ warnings } /> }
+			{ ( isPlaceholder || listHolds.length > 0 ) &&
+				<HoldList holds={ listHolds } isPlaceholder={ isPlaceholder } />
+			}
+			{ warnings.length > 0 &&
+				<WarningList warnings={ warnings } />
+			}
 
 			{ isEligible && 0 === listHolds.length && 0 === warnings.length &&
 				<Card className="eligibility-warnings__no-conflicts">

--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -78,7 +78,11 @@ export const EligibilityWarnings = ( {
 			}
 
 			{ ( isPlaceholder || listHolds.length > 0 ) &&
-				<HoldList holds={ listHolds } isPlaceholder={ isPlaceholder } />
+				<HoldList
+					holds={ listHolds }
+					isPlaceholder={ isPlaceholder }
+					siteSlug={ siteSlug }
+				/>
 			}
 			{ warnings.length > 0 &&
 				<WarningList warnings={ warnings } />

--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -55,7 +55,7 @@ export const EligibilityWarnings = ( {
 
 			{ ! hasBusinessPlan && ! isJetpack &&
 				<Banner
-					description={ translate( 'Also get unlimited themes, advanced customization, no ads, live chat support, and more!' ) }
+					description={ translate( 'Also get unlimited themes, advanced customization, no ads, live chat support, and more.' ) }
 					feature={ 'plugins' === context
 						? FEATURE_UPLOAD_PLUGINS
 						: FEATURE_UPLOAD_THEMES
@@ -71,7 +71,7 @@ export const EligibilityWarnings = ( {
 						? translate( 'To install this plugin, add a free custom domain.' )
 						: translate( 'To upload themes, add a free custom domain.' )
 					}
-					href={ `/domains/add/${ siteSlug }` }
+					href={ `/domains/manage/${ siteSlug }` }
 					icon="domains"
 					title={ translate( 'Custom domain required' ) }
 				/>

--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -53,26 +53,24 @@ export const EligibilityWarnings = ( {
 		<div className={ classes }>
 			<QueryEligibility siteId={ siteId } />
 
-			{ 'plugins' === context && ! hasBusinessPlan && ! isJetpack &&
+			{ ! hasBusinessPlan && ! isJetpack &&
 				<Banner
-					description={ translate( 'Please upgrade to install this plugin.' ) }
-					feature={ FEATURE_UPLOAD_PLUGINS }
+					description={ translate( 'Also get unlimited themes, advanced customization, no ads, live chat support, and more!' ) }
+					feature={ 'plugins' === context
+						? FEATURE_UPLOAD_PLUGINS
+						: FEATURE_UPLOAD_THEMES
+					}
 					plan={ PLAN_BUSINESS }
 					title={ translate( 'Business plan required' ) }
-				/>
-			}
-			{ 'themes' === context && ! hasBusinessPlan && ! isJetpack &&
-				<Banner
-					description={ translate( 'Unlimited themes, advanced customization, no ads, live chat support, and more!' ) }
-					feature={ FEATURE_UPLOAD_THEMES }
-					plan={ PLAN_BUSINESS }
-					title={ translate( 'To upload themes, upgrade to Business Plan' ) }
 				/>
 			}
 			{ hasBusinessPlan && ! isJetpack && includes( bannerHolds, 'NOT_USING_CUSTOM_DOMAIN' ) &&
 				<Banner
 					className="eligibility-warnings__banner"
-					description={ translate( 'Add a free custom domain to install this plugin.' ) }
+					description={ 'plugins' === context
+						? translate( 'To install this plugin, add a free custom domain.' )
+						: translate( 'To upload themes, add a free custom domain.' )
+					}
 					href={ `/domains/add/${ siteSlug }` }
 					icon="domains"
 					title={ translate( 'Custom domain required' ) }

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -11,8 +11,11 @@
 		color: $gray-light;
 		background-color: $gray-light;
 	}
+	.eligibility-warnings__message {
+		height: 24px;
+	}
 
-	.gridicon {
+	.eligibility-warnings__hold .gridicon {
 		color: $gray-light;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/11946

Update the wording used for the **hold list** of the AT eligibility screen.
The warning list will be discussed and tackled elsewhere, since it's not handled in Calypso.

This PR also fixes:

- Placeholder icons were red instead of grey.
- Placeholder list had a same key bug, therefore I've changed the logic behind it, removing the placeholder object from the hold list and manually rendering an empty element when the data is still loading.