### PR TITLE
Site Settings: Remove ending periods and change capitalization in Subscriptions settings labels

### DIFF
--- a/client/my-sites/site-settings/subscriptions/index.jsx
+++ b/client/my-sites/site-settings/subscriptions/index.jsx
@@ -42,7 +42,7 @@ const Subscriptions = ( {
 					<div className="subscriptions__info-link-container site-settings__info-link-container">
 						<InfoPopover position={ 'left' }>
 							<ExternalLink href={ 'https://jetpack.com/support/subscriptions' } target="_blank">
-								{ translate( 'Learn more about Subscriptions' ) }
+								{ translate( 'Learn more about Subscriptions.' ) }
 							</ExternalLink>
 						</InfoPopover>
 					</div>
@@ -50,7 +50,7 @@ const Subscriptions = ( {
 					<JetpackModuleToggle
 						siteId={ selectedSiteId }
 						moduleSlug="subscriptions"
-						label={ translate( 'Allow users to subscribe to your posts and comments and receive notifications via email.' ) }
+						label={ translate( 'Allow users to subscribe to your posts and comments and receive notifications via email' ) }
 						disabled={ isRequestingSettings || isSavingSettings || moduleUnavailable }
 						/>
 
@@ -68,14 +68,14 @@ const Subscriptions = ( {
 							disabled={ isRequestingSettings || isSavingSettings || ! subscriptionsModuleActive || moduleUnavailable }
 							onChange={ handleAutosavingToggle( 'stc_enabled' ) }
 						>
-							{ translate( 'Show a "follow comments" option in the comment form.' ) }
+							{ translate( 'Show a "follow comments" option in the comment form' ) }
 						</CompactFormToggle>
 					</div>
 				</FormFieldset>
 			</CompactCard>
 
 			<CompactCard href={ '/people/email-followers/' + selectedSiteSlug }>
-				{ translate( 'View your Email Followers' ) }
+				{ translate( 'View your email followers' ) }
 			</CompactCard>
 		</div>
 	);


### PR DESCRIPTION
This PRs introduces the following changes:

Removes periods from the end of each toggle label 
Changes capitalization from "View your Email Followers" to "View your email followers"

Fixes #12179.

#### After

![image](https://cloud.githubusercontent.com/assets/746152/23965496/e85d0464-0996-11e7-8e49-b8e6869006b0.png)


#### Testing instructions

1. Test the live branch going to [/settings/discussion](https://calypso.live/settings/discussion?branch=fix/subscriptions-settings-card-punctuation) for one of your Jetpack sites.
1. Verify that the changes here, introduce the appropriate case and punctuation.