### PR TITLE
Reader: combined cards must have been posted the same day relative to…

### DIFF
--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { forEach, startsWith, random } from 'lodash';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -19,14 +20,16 @@ const wpcomUndoc = wpcom.undocumented();
 function feedKeyMaker( post ) {
 	return {
 		feedId: post.feed_ID,
-		postId: post.ID
+		postId: post.ID,
+		localMoment: moment( post.date ).local(),
 	};
 }
 
 function siteKeyMaker( post ) {
 	return {
 		blogId: post.site_ID,
-		postId: post.ID
+		postId: post.ID,
+		localMoment: moment( post.date ).local(),
 	};
 }
 
@@ -34,7 +37,8 @@ function mixedKeyMaker( post ) {
 	if ( post.feed_ID && post.feed_item_ID ) {
 		return {
 			feedId: post.feed_ID,
-			postId: post.feed_item_ID
+			postId: post.feed_item_ID,
+			localMoment: moment( post.date ).local(),
 		};
 	}
 

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -21,7 +21,7 @@ function feedKeyMaker( post ) {
 	return {
 		feedId: post.feed_ID,
 		postId: post.ID,
-		localMoment: moment( post.date ).local(),
+		localMoment: moment( post.date ),
 	};
 }
 
@@ -29,7 +29,7 @@ function siteKeyMaker( post ) {
 	return {
 		blogId: post.site_ID,
 		postId: post.ID,
-		localMoment: moment( post.date ).local(),
+		localMoment: moment( post.date ),
 	};
 }
 
@@ -38,7 +38,7 @@ function mixedKeyMaker( post ) {
 		return {
 			feedId: post.feed_ID,
 			postId: post.feed_item_ID,
-			localMoment: moment( post.date ).local(),
+			localMoment: moment( post.date ),
 		};
 	}
 

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -97,7 +97,7 @@ function sameDay( postKey1, postKey2 ) {
 		b = postKey2.localMoment;
 	return a.year() === b.year() &&
 		a.month() === b.month() &&
-		a.date() === a.date(); // date === day of the month
+		a.date() === b.date(); // date === day of the month
 }
 
 /**

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -93,7 +93,11 @@ function sameSite( postKey1, postKey2 ) {
 }
 
 function sameDay( postKey1, postKey2 ) {
-	return postKey1.localMoment.date() === postKey2.localMoment.date(); // date === day of the month
+	const a = postKey1.localMoment,
+		b = postKey2.localMoment;
+	return a.year() === b.year() &&
+		a.month() === b.month() &&
+		a.date() === a.date(); // date === day of the month
 }
 
 /**

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -93,11 +93,7 @@ function sameSite( postKey1, postKey2 ) {
 }
 
 function sameDay( postKey1, postKey2 ) {
-	const a = postKey1.localMoment,
-		b = postKey2.localMoment;
-	return a.year() === b.year() &&
-		a.month() === b.month() &&
-		a.date() === b.date(); // date === day of the month
+	return postKey1.localMoment.isSame( postKey2.localMoment, 'day' );
 }
 
 /**

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -92,6 +92,10 @@ function sameSite( postKey1, postKey2 ) {
 		);
 }
 
+function sameDay( postKey1, postKey2 ) {
+	return postKey1.localMoment.date() === postKey2.localMoment.date(); // date === day of the month
+}
+
 /**
  * Takes two postKeys and combines them into a ReaderCombinedCard postKey.
  * Note: This only makes sense for postKeys from the same site
@@ -109,7 +113,9 @@ function combine( postKey1, postKey2 ) {
 		isCombination: true,
 		blogId: postKey1.blogId,
 		feedId: postKey1.feedId,
-		index: postKey1.index,
+		localMoment: postKey1.localMoment && postKey1.localMoment.isBefore( postKey2.localMoment ) // keep the earliest moment
+			? postKey1.localMoment
+			: postKey2.localMoment,
 		postIds: [
 			...( postKey1.postIds || [ postKey1.postId ] ),
 			...( postKey2.postIds || [ postKey2.postId ] ),
@@ -120,7 +126,7 @@ function combine( postKey1, postKey2 ) {
 const combineCards = ( postKeys ) => postKeys.reduce(
 	( accumulator, postKey ) => {
 		const lastPostKey = last( accumulator );
-		if ( sameSite( lastPostKey, postKey ) ) {
+		if ( sameSite( lastPostKey, postKey ) && sameDay( lastPostKey, postKey ) ) {
 			accumulator[ accumulator.length - 1 ] = combine( last( accumulator ), postKey );
 		} else {
 			accumulator.push( postKey );


### PR DESCRIPTION
… the user or else they won't getcombined

Implements: https://github.com/Automattic/wp-calypso/issues/12151

The strategy here was to attach a moment to each postKey as it is ingested in the keyMakers.  the flag `local()` says to use the users local time.