### PR TITLE
Themes: theme search suggestion welcome style alternative

### DIFF
--- a/client/components/suggestions/style.scss
+++ b/client/components/suggestions/style.scss
@@ -34,7 +34,6 @@
 	border-top: 0px;
 	font-size: 16px;
 	cursor: pointer;
-	transition: background 120ms ease-in, color 60ms ease-in;
 
 	.suggestions__value-emphasis,
 	.suggestions__value-normal {

--- a/client/components/suggestions/style.scss
+++ b/client/components/suggestions/style.scss
@@ -1,4 +1,21 @@
 
+/*
+ * Suggestions start out invisible, and they show up only when triggered.
+ */
+.suggestions {
+	display: none;
+}
+
+.has-suggestions {
+	.suggestions {
+		display: block;
+	}
+}
+
+
+/*
+ * Suggestions list
+ */
 .suggestions__suggestions {
 	display: flex;
 	flex-direction: column;

--- a/client/components/suggestions/style.scss
+++ b/client/components/suggestions/style.scss
@@ -48,7 +48,7 @@
 	}
 
 	&.has-highlight {
-		background-color: $blue-wordpress;
+		background-color: $blue-medium;
 		color: $white;
 	}
 }

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -1,3 +1,7 @@
+
+/*
+ * Search card and text input
+ */
 .themes-magic-search-card {
 	display: flex;
 	align-items: center;
@@ -12,6 +16,7 @@
 	.search {
 		flex: 0 1 auto;
 		margin: 0;
+
 		&.has-focus {
 			box-shadow: none;
 		}
@@ -45,11 +50,14 @@
 		flex: 0 1 auto;
 		padding: 8px 14px 8px;
 	}
-
 }
 
+
+/*
+ * Tokens
+ */
 .themes-magic-search-card__token {
-	/* These are required to make it work */
+	/* These are required to make token alignment work */
 	font: inherit;
 	pointer-events: none;
 	position: relative;
@@ -65,7 +73,7 @@
 	}
 
 	.themes-magic-search-card__token-taxonomy {
-		/* These are required to make it work */
+		/* These are required to make token alignment work */
 		pointer-events: none;
 		display: inline-block;
 
@@ -75,7 +83,7 @@
 	}
 
 	.themes-magic-search-card__token-separator {
-		/* These are required to make it work */
+		/* These are required to make token alignment work */
 		pointer-events: none;
 		display: inline-block;
 
@@ -85,6 +93,7 @@
 	}
 
 	.themes-magic-search-card__token-filter {
+		/* These are required to make token alignment work */
 		pointer-events: none;
 		display: inline-block;
 
@@ -94,17 +103,23 @@
 }
 
 .themes-magic-search-card__search-text {
+	/* These are required to make token alignment work */
 	font: inherit;
 	pointer-events: none;
 	color: transparent;
 }
 
 .themes-magic-search-card__search-white-space {
+	/* These are required to make token alignment work */
 	font: inherit;
 	pointer-events: none;
 	white-space: pre;
 }
 
+
+/*
+ * Suggestions
+ */
 .themes-magic-search {
 
 	.themes-magic-search-card__welcome,
@@ -121,9 +136,12 @@
 			margin-top: 5px;
 		}
 	}
-
 }
 
+
+/*
+ * Suggestions: Welcome Card
+ */
 .themes-magic-search-card__welcome {
 	color: $gray;
 	background-color: $white;
@@ -141,10 +159,6 @@
 
 	text-transform: uppercase;
 	color: $gray-dark;
-}
-
-.themes-magic-search-card__welcome-header {
-	font-size: 13px;
 }
 
 .themes-magic-search-card__welcome-taxonomies {

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -157,22 +157,29 @@
 	flex-direction: column;
 	text-align: center;
 	flex: 1 0 auto;
-	padding: 4px 8px;
+	padding: 10px 8px;
 	margin: 0;
 	font-size: 13px;
 	line-height: 16px;
 	text-transform: capitalize;
 	cursor: pointer;
-	border-bottom: 3px solid $blue-medium;
+	color: $gray-dark;
 	transition: all 200ms ease-in;
 
 	.gridicon {
+		fill: $gray-dark;
 		margin: 0 auto;
+		transition: fill 200ms ease-in;
 	}
 
 	&:hover {
+		color: $blue-medium;
 		background: lighten( $gray, 35% );
-		box-shadow: 0 2px 0 0 $blue-medium;
+		box-shadow: inset 0 -3px 0 0 $blue-medium;
+
+		.gridicon {
+			fill: $blue-medium;
+		}
 	}
 
 	&.themes-magic-search-card__welcome-taxonomy-highlight {
@@ -183,31 +190,3 @@
 .themes-magic-search-card__welcome-taxonomy-icon {
 	pointer-events: none;
 }
-
-// Colors
-@mixin themes-magic-search__token-colors( $name, $color ) {
-	.themes-magic-search-card__welcome-taxonomy-type-#{$name} {
-		color: $color;
-		border-color: $color;
-
-		&:hover {
-			box-shadow: 0 2px 0 0 $color;
-		}
-	}
-
-	.themes-magic-search-card__token-type-#{$name} {
-		.themes-magic-search-card__token-taxonomy,
-		.themes-magic-search-card__token-separator,
-		.themes-magic-search-card__token-filter {
-			border-color: $color;
-		}
-	}
-}
-
-@include themes-magic-search__token-colors( 'color', #005082 );
-@include themes-magic-search__token-colors( 'column', #d54e21 );
-@include themes-magic-search__token-colors( 'feature', #4ab866 );
-@include themes-magic-search__token-colors( 'layout', #f0821e );
-@include themes-magic-search__token-colors( 'subject', #855da6 );
-@include themes-magic-search__token-colors( 'style', #e12f67 );
-@include themes-magic-search__token-colors( 'picks', #0087be );

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -121,18 +121,9 @@
  * Suggestions
  */
 .themes-magic-search {
-
-	.themes-magic-search-card__welcome,
-	.suggestions {
-		display: none;
-	}
-
-
-
 	&.has-suggestions {
 		.themes-magic-search-card__welcome,
 		.suggestions {
-			display: block;
 			margin-top: 5px;
 		}
 	}

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -121,9 +121,15 @@
  * Suggestions
  */
 .themes-magic-search {
+
+	.themes-magic-search-card__welcome {
+		display: none;
+	}
+
 	&.has-suggestions {
 		.themes-magic-search-card__welcome,
 		.suggestions {
+			display: block;
 			margin-top: 5px;
 		}
 	}
@@ -187,6 +193,7 @@
 		transition: fill 200ms ease-in;
 	}
 
+	&.themes-magic-search-card__welcome-taxonomy-highlight,
 	&:hover {
 		color: $blue-medium;
 
@@ -198,10 +205,6 @@
 			background: lighten( $gray, 35% );
 			box-shadow: inset 0 -3px 0 0 $blue-medium;
 		}
-	}
-
-	&.themes-magic-search-card__welcome-taxonomy-highlight {
-		box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20% );
 	}
 }
 

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -130,39 +130,49 @@
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
 	display: flex;
 	flex-direction: column;
-	padding: 10px 18px 18px;
+}
 
-	.themes-magic-search-card__welcome-top-searches,
-	.themes-magic-search-card__welcome-taxonomies {
-		display: flex;
-		flex-direction: row;
-		flex-wrap: wrap;
-	}
+.themes-magic-search-card__welcome-header {
+	background-color: $gray-light;
+	border-bottom: 1px solid darken( $gray-light, 10% );
+	border-top: 0px;
+	padding: 4px 8px;
+	font-size: 13px;
 
-	.themes-magic-search-card__welcome-header {
-		font-size: 13px;
-	}
+	text-transform: uppercase;
+	color: $gray-dark;
+}
+
+.themes-magic-search-card__welcome-header {
+	font-size: 13px;
+}
+
+.themes-magic-search-card__welcome-taxonomies {
+	display: flex;
+	flex-direction: row;
 }
 
 .themes-magic-search-card__welcome-taxonomy {
 	display: flex;
-	align-items: center;
+	flex-direction: column;
+	text-align: center;
+	flex: 1 0 auto;
 	padding: 4px 8px;
-	margin: 10px 10px 0px 0px;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
-	border-radius: 3px;
+	margin: 0;
 	font-size: 13px;
 	line-height: 16px;
 	text-transform: capitalize;
 	cursor: pointer;
+	border-bottom: 3px solid $blue-medium;
 	transition: all 200ms ease-in;
 
 	.gridicon {
-		padding-right: 6px;
+		margin: 0 auto;
 	}
 
 	&:hover {
-		box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20% );
+		background: lighten( $gray, 35% );
+		box-shadow: 0 2px 0 0 $blue-medium;
 	}
 
 	&.themes-magic-search-card__welcome-taxonomy-highlight {
@@ -178,6 +188,11 @@
 @mixin themes-magic-search__token-colors( $name, $color ) {
 	.themes-magic-search-card__welcome-taxonomy-type-#{$name} {
 		color: $color;
+		border-color: $color;
+
+		&:hover {
+			box-shadow: 0 2px 0 0 $color;
+		}
 	}
 
 	.themes-magic-search-card__token-type-#{$name} {

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -149,7 +149,11 @@
 
 .themes-magic-search-card__welcome-taxonomies {
 	display: flex;
-	flex-direction: row;
+	flex-wrap: wrap;
+
+	@include breakpoint( ">660px" ) {
+		flex-wrap: nowrap;
+	}
 }
 
 .themes-magic-search-card__welcome-taxonomy {
@@ -157,7 +161,9 @@
 	flex-direction: column;
 	text-align: center;
 	flex: 1 0 auto;
-	padding: 10px 8px;
+	width: 28%;
+	overflow: hidden;
+	padding: 10px 6px;
 	margin: 0;
 	font-size: 13px;
 	line-height: 16px;
@@ -165,6 +171,10 @@
 	cursor: pointer;
 	color: $gray-dark;
 	transition: all 200ms ease-in;
+
+	@include breakpoint( ">660px" ) {
+		width: auto;
+	}
 
 	.gridicon {
 		fill: $gray-dark;
@@ -174,11 +184,14 @@
 
 	&:hover {
 		color: $blue-medium;
-		background: lighten( $gray, 35% );
-		box-shadow: inset 0 -3px 0 0 $blue-medium;
 
 		.gridicon {
 			fill: $blue-medium;
+		}
+
+		@include breakpoint( ">660px" ) {
+			background: lighten( $gray, 35% );
+			box-shadow: inset 0 -3px 0 0 $blue-medium;
 		}
 	}
 

--- a/client/my-sites/themes/themes-magic-search-card/welcome.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/welcome.jsx
@@ -84,7 +84,7 @@ class MagicSearchWelcome extends React.Component {
 	render() {
 		return (
 			<div className="themes-magic-search-card__welcome" >
-				<span className="themes-magic-search-card__welcome-header">{ i18n.translate( 'Search by' ) }</span>
+				<div className="themes-magic-search-card__welcome-header">{ i18n.translate( 'Search by' ) }</div>
 				<div className="themes-magic-search-card__welcome-taxonomies">
 					{ this.props.taxonomies.map( taxonomy => this.renderToken( taxonomy ) ) }
 				</div>


### PR DESCRIPTION
This is a try for an alternate styling for the suggestion box to make it more aligned to the Calypso patterns and the "underline" look.

Current: 

![screen shot 2017-03-15 at 19 14 49](https://cloud.githubusercontent.com/assets/4389/23966553/b213c6e6-09b3-11e7-8124-7692ad69e3fe.png)



Initial version of this PR (now changed, see comments below):

![screen shot 2017-03-15 at 19 10 03](https://cloud.githubusercontent.com/assets/4389/23966464/54b44278-09b3-11e7-900d-2498fbd03940.png)

Current version:

![screen shot 2017-03-16 at 12 57 46](https://cloud.githubusercontent.com/assets/4389/23997184/34e22ae2-0a48-11e7-8f50-079de958ed6b.png)



Here's an alternate idea for styling the welcome screen.

This approach doesn't wrap, so will need an adjustment (rows) on mobile (not yet in the PR).

### To test

1. Open `/design`.
2. Try searching free text, and using autocomplete.
3. Try clicking/tapping to see if you can add filters without using the keyboard.