### PR TITLE
Reader: Add TrainTracks to Search Suggestions

### DIFF
--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -118,12 +118,8 @@ function getStoreForSearch( storeId ) {
 	} );
 
 	function fetcher( query, callback ) {
-		switch ( storeId ) {
-			case 'suggested_search':
-				query.isSuggested = 'true';
-				break;
-			default:
-				query.isSuggested = 'false';
+		if ( stream.query_suggested ) {
+			query.suggested = true;
 		}
 		query.q = slug;
 		query.meta = 'site';

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -62,6 +62,9 @@ function trainTracksProxyForStream( stream, callback ) {
 		}
 		forEach( response && response.posts, ( post ) => {
 			if ( post.railcar ) {
+				if ( stream.isQuerySuggestion ) {
+					post.railcar.rec_result = 'suggestion';
+				}
 				analytics.tracks.recordEvent( eventName, post.railcar );
 			}
 		} );
@@ -118,9 +121,6 @@ function getStoreForSearch( storeId ) {
 	} );
 
 	function fetcher( query, callback ) {
-		if ( stream.isQuerySuggestion ) {
-			query.isSuggestion = true;
-		}
 		query.q = slug;
 		query.meta = 'site';
 		wpcomUndoc.readSearch( query, trainTracksProxyForStream( stream, callback ) );

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -118,6 +118,13 @@ function getStoreForSearch( storeId ) {
 	} );
 
 	function fetcher( query, callback ) {
+		switch ( storeId ) {
+			case 'suggested_search':
+				query.isSuggested = 'true';
+				break;
+			default:
+				query.isSuggested = 'false';
+		}
 		query.q = slug;
 		query.meta = 'site';
 		wpcomUndoc.readSearch( query, trainTracksProxyForStream( stream, callback ) );

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -118,8 +118,8 @@ function getStoreForSearch( storeId ) {
 	} );
 
 	function fetcher( query, callback ) {
-		if ( stream.query_suggested ) {
-			query.suggested = true;
+		if ( stream.isQuerySuggestion ) {
+			query.isSuggestion = true;
 		}
 		query.q = slug;
 		query.meta = 'site';

--- a/client/reader/search-stream/suggestion.jsx
+++ b/client/reader/search-stream/suggestion.jsx
@@ -14,7 +14,7 @@ export function Suggestion( { suggestion, source } ) {
 	};
 
 	return (
-		<a onClick={ handleSuggestionClick } href={ '/read/search?q=' + encodeURIComponent( suggestion ) } >
+		<a onClick={ handleSuggestionClick } href={ '/read/search?suggested=1&q=' + encodeURIComponent( suggestion ) } >
 			{ suggestion }
 		</a>
 	);

--- a/client/reader/search-stream/suggestion.jsx
+++ b/client/reader/search-stream/suggestion.jsx
@@ -14,7 +14,7 @@ export function Suggestion( { suggestion, source } ) {
 	};
 
 	return (
-		<a onClick={ handleSuggestionClick } href={ '/read/search?suggested=1&q=' + encodeURIComponent( suggestion ) } >
+		<a onClick={ handleSuggestionClick } href={ '/read/search?isSuggestion=1&q=' + encodeURIComponent( suggestion ) } >
 			{ suggestion }
 		</a>
 	);

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -34,7 +34,7 @@ export default {
 		let store;
 		if ( searchSlug ) {
 			store = feedStreamFactory( 'search:' + searchSlug );
-			store.query_suggested = context.query.suggested === '1';
+			store.isQuerySuggestion = context.query.isSuggestion === '1';
 			ensureStoreLoading( store, context );
 		} else {
 			store = feedStreamFactory( 'custom_recs_posts_with_images' );

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -34,6 +34,7 @@ export default {
 		let store;
 		if ( searchSlug ) {
 			store = feedStreamFactory( 'search:' + searchSlug );
+			store.query_suggested = context.query.suggested === '1';
 			ensureStoreLoading( store, context );
 		} else {
 			store = feedStreamFactory( 'custom_recs_posts_with_images' );


### PR DESCRIPTION
Whenever a user clicks on a Search suggestion, let's keep track of it in TrainTracks. To do so, we need to pass this information to the /read/search API.

~Backend diff: D4749~ No long need this. We are adding the tracking using the client side (not API).