### PR TITLE
Remove olark locale dependency

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -26,7 +26,6 @@ import wpcomLib from 'lib/wp';
 import notices from 'notices';
 import siteList from 'lib/sites-list';
 import analytics from 'lib/analytics';
-import i18n from 'lib/i18n-utils';
 import { isOlarkTimedOut } from 'state/ui/olark/selectors';
 import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import { isHappychatAvailable } from 'state/happychat/selectors';
@@ -578,7 +577,7 @@ const HelpContact = React.createClass( {
 		//    requests are sent to the language specific forums (for popular languages)
 		//    we don't tell the user that support is only offered in English.
 		const showHelpLanguagePrompt =
-			( currentUserLocale !== i18n.getLocaleSlug() ) &&
+			( config( 'support_locales' ).indexOf( currentUserLocale ) === -1 ) &&
 			SUPPORT_FORUM !== variationSlug;
 
 		return {

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -203,7 +203,7 @@ const HelpContact = React.createClass( {
 
 	submitKayakoTicket: function( contactForm ) {
 		const { subject, message, howCanWeHelp, howYouFeel, siteSlug } = contactForm;
-		const { locale } = this.state.olark;
+		const { currentUserLocale } = this.props;
 		const site = sites.getSite( siteSlug );
 
 		const ticketMeta = [
@@ -216,7 +216,7 @@ const HelpContact = React.createClass( {
 
 		this.setState( { isSubmitting: true } );
 
-		wpcom.submitKayakoTicket( subject, kayakoMessage, locale, this.props.clientSlug, ( error ) => {
+		wpcom.submitKayakoTicket( subject, kayakoMessage, currentUserLocale, this.props.clientSlug, ( error ) => {
 			if ( error ) {
 				// TODO: bump a stat here
 				notices.error( error.message );
@@ -247,11 +247,11 @@ const HelpContact = React.createClass( {
 
 	submitSupportForumsTopic: function( contactForm ) {
 		const { subject, message } = contactForm;
-		const locale = this.props.currentUserLocale;
+		const { currentUserLocale } = this.props;
 
 		this.setState( { isSubmitting: true } );
 
-		wpcom.submitSupportForumsTopic( subject, message, locale, this.props.clientSlug, ( error, data ) => {
+		wpcom.submitSupportForumsTopic( subject, message, currentUserLocale, this.props.clientSlug, ( error, data ) => {
 			if ( error ) {
 				// TODO: bump a stat here
 				notices.error( error.message );
@@ -568,7 +568,8 @@ const HelpContact = React.createClass( {
 	},
 
 	getContactFormCommonProps: function( variationSlug ) {
-		const { olark, isSubmitting } = this.state;
+		const { isSubmitting } = this.state;
+		const { currentUserLocale } = this.props;
 
 		// Let the user know we only offer support in English.
 		// We only need to show the message if:
@@ -577,7 +578,7 @@ const HelpContact = React.createClass( {
 		//    requests are sent to the language specific forums (for popular languages)
 		//    we don't tell the user that support is only offered in English.
 		const showHelpLanguagePrompt =
-			( olark.locale !== i18n.getLocaleSlug() ) &&
+			( currentUserLocale !== i18n.getLocaleSlug() ) &&
 			SUPPORT_FORUM !== variationSlug;
 
 		return {

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -31,6 +31,7 @@
 	"happychat_url": "https://happychat.io/customer",
 	"google_oauth_client_id": "543610697398-l287fumouns096o4os9l9fs1svh5esjc.apps.googleusercontent.com",
 	"facebook_app_id": "611241942420191",
+	"support_locales": [ "en", "es", "pt-br" ],
 	"languages": [
 		{ "value": 2, "langSlug": "af", "name": "Afrikaans", "wpLocale": "af" },
 		{ "value": 418, "langSlug": "als", "name": "Alemannisch", "wpLocale": "" },

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -10,6 +10,7 @@
 	"logout_url": "/logout",
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "/",
+	"support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": true,
 		"always_use_logout_url": true,

--- a/config/development.json
+++ b/config/development.json
@@ -29,6 +29,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",
+	"support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"account-recovery": true,
 		"ad-tracking": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -12,6 +12,7 @@
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
+	"support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,
 		"apple-pay": false,

--- a/config/production.json
+++ b/config/production.json
@@ -11,6 +11,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"facebook_app_id": "2373049596",
+	"support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": true,
 		"apple-pay": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -13,6 +13,7 @@
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
+	"support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,
 		"apple-pay": true,

--- a/config/test.json
+++ b/config/test.json
@@ -26,6 +26,7 @@
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
+	"support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,
 		"apple-pay": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -13,6 +13,7 @@
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
+	"support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"ad-tracking": false,
 		"automated-transfer": true,


### PR DESCRIPTION
This pull request removes the dependency on the locale that comes from the olark api endpoint. This is the first step in removing olark.

### How to test
This pull request touches the /help/contact form which has a few variations

#### HappyChat
1. Login to calypso as a paid user in the `en` locale.
2. Navigate to http://calypso.localhost:3000/help/contact
3. If HappyChat is staffed for the locale you've set then you should be able to start a chat.
4. Verify with the HE that you the correct locale has been applied.
5. Repeat steps 1-4 for the `es` and `pt-br` locales.

#### Email support
1. Login to calypso as a paid user while there is no staffing for your locale
2. Navigate to http://calypso.localhost:3000/help/contact
3. Make sure that chat is not staffed for your locale
4. Submit an email support ticket and verify that your locale has been set correctly in Kayako
5. Repeat steps 1-4 for the `es` and `pt-br` locales.

#### Directly support
1. Login to calypso as an unpaid user with the `en` locale set.
2. Navigate to http://calypso.localhost:3000/help/contact
3. Confirm that you get the "Ask Expert" support variation

#### Forums support
1. Login to calypso as an unpaid user with any locale other than `en` set.
2. Navigate to http://calypso.localhost:3000/help/contact
3. Confirm that you get the "Ask the forums" support variation
