### PR TITLE
Site Settings: Remove ending periods for labels in the Writing Settings tab.

### DIFF
--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -113,7 +113,7 @@ class PublishingTools extends Component {
 				<JetpackModuleToggle
 					siteId={ selectedSiteId }
 					moduleSlug="post-by-email"
-					label={ translate( 'Publish posts by sending an email.' ) }
+					label={ translate( 'Publish posts by sending an email' ) }
 					disabled={ formPending || moduleUnavailable }
 					/>
 

--- a/client/my-sites/site-settings/theme-enhancements/index.jsx
+++ b/client/my-sites/site-settings/theme-enhancements/index.jsx
@@ -62,7 +62,7 @@ class ThemeEnhancements extends Component {
 				<JetpackModuleToggle
 					siteId={ selectedSiteId }
 					moduleSlug="infinite-scroll"
-					label={ translate( 'Add support for infinite scroll to your theme.' ) }
+					label={ translate( 'Add support for infinite scroll to your theme' ) }
 					disabled={ formPending }
 					/>
 
@@ -103,7 +103,7 @@ class ThemeEnhancements extends Component {
 				<JetpackModuleToggle
 					siteId={ selectedSiteId }
 					moduleSlug="minileven"
-					label={ translate( 'Optimize your site with a mobile-friendly theme for tablets and phones.' ) }
+					label={ translate( 'Optimize your site with a mobile-friendly theme for tablets and phones' ) }
 					disabled={ formPending }
 					/>
 


### PR DESCRIPTION

This PRs introduces the following changes:

* Removes periods from the end of each of the toggle labels in the Theme Enhancements and Publishing Tools settings.

Fixes #12172.

#### After

![image](https://cloud.githubusercontent.com/assets/746152/23970832/18289010-09aa-11e7-9426-b507a10ece3f.png)


#### Testing instructions

1. Test the [live branch going to `/settings/writing`](https://calypso.live/settings/writing?branch=update/remove-periods-from-writing-settings-labels) for one of your Jetpack sites.
1. Verify that the changes here, introduce the appropriate punctuation in toggle labels.