### PR TITLE
Jetpack Settings: Add Spam filtering settings card for Jetpack sites to Security tab

### DIFF
--- a/client/my-sites/site-settings/spam-filtering-settings.jsx
+++ b/client/my-sites/site-settings/spam-filtering-settings.jsx
@@ -1,0 +1,134 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { includes } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import FoldableCard from 'components/foldable-card';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
+import FormInputValidation from 'components/forms/form-input-validation';
+import Gridicon from 'gridicons';
+import InfoPopover from 'components/info-popover';
+import ExternalLink from 'components/external-link';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getJetpackSettingsSaveError, getJetpackSettingsSaveRequestStatus } from 'state/selectors';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+
+const SpamFilteringSettings = ( {
+	currentAkismetKey,
+	dirtyFields,
+	fields,
+	hasAkismetKeyError,
+	isRequestingSettings,
+	isSavingSettings,
+	onChangeField,
+	translate,
+} ) => {
+	const { akismet: akismetActive, wordpress_api_key } = fields;
+	const isStoredKey = wordpress_api_key === currentAkismetKey;
+	const isDirty = includes( dirtyFields, 'wordpress_api_key' );
+	const inTransition = isRequestingSettings || isSavingSettings;
+	const isValidKey =
+		( wordpress_api_key && isStoredKey ) ||
+		( wordpress_api_key && isDirty && isStoredKey && ! hasAkismetKeyError );
+	const isInvalidKey = isDirty && hasAkismetKeyError && ! isStoredKey;
+	let validationText, className, header = null;
+	if ( ! inTransition && isValidKey ) {
+		validationText = translate( 'Your Antispam key is valid.' );
+		className = 'is-valid';
+		header = (
+			<div>
+				<Gridicon icon="checkmark" />
+				{ translate( 'Your site is protected from spam.' ) }
+			</div>
+		);
+	}
+	if ( ! inTransition && isInvalidKey ) {
+		validationText = translate( "There's a problem with your Antispam API key." );
+		className = 'is-error';
+		header = (
+			<div>
+				<Gridicon icon="notice-outline" />
+				{ translate( 'Your site needs an Antispam key.' ) }
+			</div>
+		);
+	}
+	return (
+		<FoldableCard
+			header={ header }
+			className="spam-filtering__foldable-card site-settings__foldable-card"
+		>
+			<FormFieldset>
+				<div className="spam-filtering__settings site-settings__child-settings">
+					<div className="spam-filtering__info-link-container site-settings__info-link-container">
+						<InfoPopover>
+							<ExternalLink
+								target="_blank"
+								icon
+								href={ 'https://jetpack.com/features/security/spam-filtering/' }
+							>
+								{ translate( 'Learn more about spam filtering.' ) }
+							</ExternalLink>
+						</InfoPopover>
+					</div>
+					<FormLabel htmlFor="wordpress_api_key">{ translate( 'Your API Key' ) }</FormLabel>
+					<FormTextInput
+						name="wordpress_api_key"
+						className={ className }
+						value={ wordpress_api_key }
+						disabled={ inTransition || ! akismetActive }
+						onChange={ onChangeField( 'wordpress_api_key' ) }
+					/>
+					{ ( isValidKey || isInvalidKey ) &&
+						! inTransition &&
+						<FormInputValidation isError={ isInvalidKey } text={ validationText } /> }
+					{ ( ! wordpress_api_key || isInvalidKey || ! isValidKey ) &&
+						<FormSettingExplanation>
+							{ translate(
+								"If you don't already have an API key, then" +
+									' {{link}}get your API key here{{/link}},' +
+									" and you'll be guided through the process of getting one in a new window.",
+								{
+									components: {
+										link: (
+											<ExternalLink icon href="https://akismet.com/wordpress/" target="_blank" />
+										),
+									},
+								}
+							) }
+						</FormSettingExplanation> }
+				</div>
+			</FormFieldset>
+		</FoldableCard>
+	);
+};
+
+SpamFilteringSettings.propTypes = {
+	dirtyFields: PropTypes.array,
+	fields: PropTypes.object,
+	hasAkismetKeyError: PropTypes.bool,
+	isRequestingSettings: PropTypes.bool,
+	isSavingSettings: PropTypes.bool,
+	settings: PropTypes.object,
+};
+
+export default connect( state => {
+	const selectedSiteId = getSelectedSiteId( state );
+	const jetpackSettingsSaveError = getJetpackSettingsSaveError( state, selectedSiteId );
+	const jetpackSettingsSaveStatus = getJetpackSettingsSaveRequestStatus( state, selectedSiteId );
+	const hasAkismetKeyError =
+		jetpackSettingsSaveStatus &&
+		jetpackSettingsSaveStatus === 'error' &&
+		( includes( jetpackSettingsSaveError, 'wordpress_api_key' ) ||
+			includes( jetpackSettingsSaveError, 'wordpress_api_key' ) );
+	return {
+		hasAkismetKeyError,
+	};
+} )( localize( SpamFilteringSettings ) );

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -334,10 +334,17 @@
 	.foldable-card__header {
 		padding: 24px;
 
-		.gridicons-checkmark {
+		.gridicons-checkmark, .gridicons-notice-outline {
 			margin-right: 4px;
 			vertical-align: bottom;
+		}
+
+		.gridicons-checkmark {
 			color: $alert-green;
+		}
+
+		.gridicons-notice-outline {
+			color: $alert-red;
 		}
 	}
 
@@ -355,7 +362,8 @@
 	}
 
 	.composing__module-settings .site-settings__info-link-container,
-	.protect__module-settings .site-settings__info-link-container {
+	.protect__module-settings .site-settings__info-link-container,
+	.spam-filtering__settings .site-settings__info-link-container {
 		margin-right: -36px;
 		height: 0;
 	}

--- a/client/state/jetpack/settings/test/utils.js
+++ b/client/state/jetpack/settings/test/utils.js
@@ -160,6 +160,17 @@ describe( 'utils', () => {
 			} );
 		} );
 
+		it( 'should omit akismet from sanitized settings', () => {
+			const settings = {
+				some_other_setting: 123,
+				akismet: true
+			};
+
+			expect( sanitizeSettings( settings ) ).to.eql( {
+				some_other_setting: 123,
+			} );
+		} );
+
 		it( 'should skip infinite scroll settings if infinite_scroll is not defined', () => {
 			const settings = {
 				some_other_setting: 123,

--- a/client/state/jetpack/settings/utils.js
+++ b/client/state/jetpack/settings/utils.js
@@ -52,13 +52,13 @@ export const normalizeSettings = ( settings ) => {
 export const sanitizeSettings = ( settings ) => {
 	return Object.keys( settings ).reduce( ( memo, key ) => {
 		switch ( key ) {
-			case 'post_by_email_address':
-				break;
+			// Jetpack's settings endpoint in version 4.9 does not support receiving 'akismet' among the settings
+			case 'akismet':
 			case 'custom-content-types':
-			case 'jetpack_testimonial':
-			case 'jetpack_portfolio':
-				break;
 			case 'infinite-scroll':
+			case 'jetpack_portfolio':
+			case 'jetpack_testimonial':
+			case 'post_by_email_address':
 				break;
 			case 'infinite_scroll':
 				if ( settings[ key ] === 'default' ) {


### PR DESCRIPTION
This PR introduces a new card, under the Security tab for configuring Spam filtering (Akismet) API key.

Fixes #12195 

##### Collapsed

![image](https://cloud.githubusercontent.com/assets/746152/25857757/6468a204-34b0-11e7-8ef1-8b1533dd74e1.png)

![image](https://cloud.githubusercontent.com/assets/746152/25857784/743ec514-34b0-11e7-8313-e7181efa9804.png)


#### Expanded with an empty input

![image](https://cloud.githubusercontent.com/assets/746152/25856649/020bd818-34ad-11e7-929e-6d0e793a5490.png)



#### Expanded after saving empty input

![image](https://cloud.githubusercontent.com/assets/746152/25857733/52d45de4-34b0-11e7-94bc-c2d34f5249a9.png)



#### After trying to save wrong key

![image](https://cloud.githubusercontent.com/assets/746152/25856576/c34ce978-34ac-11e7-8ea0-1fe6337f13f4.png)


#### Expanded with a valid key

![image](https://cloud.githubusercontent.com/assets/746152/25856549/b4364254-34ac-11e7-9820-5e84015356b5.png)





