### PR TITLE
Signup: Domain-Only IE11 site-or-domain step fix

### DIFF
--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -70,7 +70,7 @@ export default class SiteOrDomain extends Component {
 					<Card className="site-or-domain__choice" key={ choice.type }>
 						<a href="#" onClick={ ( event ) => this.handleClickChoice( event, choice.type ) }>
 							{ choice.image }
-							<h2 className="site-or-domain__label">{ choice.label }</h2>
+							<h2>{ choice.label }</h2>
 						</a>
 					</Card>
 				) ) }

--- a/client/signup/steps/site-or-domain/style.scss
+++ b/client/signup/steps/site-or-domain/style.scss
@@ -5,23 +5,25 @@
 }
 
 .site-or-domain__choice {
-	flex-grow: 1;
-	margin: 10px;
-	max-width: 330px;
-	min-width: 230px;
 	padding: 0;
+	margin: 10px;
+	width: 230px;
+	max-width: 330px;
+	flex-grow: 1;
 	transition: box-shadow 100ms ease-in-out;
+	cursor: pointer;
 
-	svg {
+	a, svg {
 		display: block;
+		width: 100%;
 	}
 
 	&:hover {
 		box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20 );
 	}
-}
 
-.site-or-domain__label {
-	border-top: solid 1px $gray-light;
-	padding: 10px 15px;
+	h2 {
+		border-top: solid 1px $gray-light;
+		padding: 10px 15px;
+	}
 }

--- a/client/signup/steps/site-or-domain/style.scss
+++ b/client/signup/steps/site-or-domain/style.scss
@@ -7,7 +7,7 @@
 .site-or-domain__choice {
 	padding: 0;
 	margin: 10px;
-	width: 230px;
+	min-width: 230px;
 	max-width: 330px;
 	flex-grow: 1;
 	transition: box-shadow 100ms ease-in-out;


### PR DESCRIPTION
The choice labels were hidden in IE11.

Fixes https://github.com/Automattic/wp-calypso/issues/12125

Test:
Make sure the labels can be seen with IE11 http://calypso.localhost:3000/start/domain-first/site-or-domain?new=some-random-test-domain-who-knows-how-many-times.com