### PR TITLE
Editor: Fix ground control for long site names

### DIFF
--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -24,7 +24,7 @@
 
 .editor-ground-control .site {
 	flex: 0 0 auto;
-	max-width: $sidebar-width-max;
+	max-width: calc( 100vw - 50% );
 
 	@include breakpoint( "<660px" ) {
 		display: none;

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -24,7 +24,7 @@
 
 .editor-ground-control .site {
 	flex: 0 0 auto;
-	max-width: calc( 100vw - 50% );
+	max-width: $sidebar-width-max;
 
 	@include breakpoint( "<660px" ) {
 		display: none;

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -24,6 +24,7 @@
 
 .editor-ground-control .site {
 	flex: 0 0 auto;
+	max-width: $sidebar-width-max;
 
 	@include breakpoint( "<660px" ) {
 		display: none;


### PR DESCRIPTION
Here is a one-liner fix for the issue where long site names wreak havoc on the editor ground control bar ( fixes #12187 ):

__Before__
<img width="579" alt="new_post_ _testing_timmy_timmay_timmaay_timmaaay_timmaaaay_timmaaaaay_timmaaaaaay_timmaaaaaaay_timmaaaaaaaay_timmaaaaaaaaay_timmaaaaaaaaaay_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/23972979/4f7e36c8-0991-11e7-88ed-d4a27ff58ffa.png">

__After__
<img width="579" alt="new_post_ _testing_timmy_timmay_timmaay_timmaaay_timmaaaay_timmaaaaay_timmaaaaaay_timmaaaaaaay_timmaaaaaaaay_timmaaaaaaaaay_timmaaaaaaaaaay_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/23972937/1ecf264a-0991-11e7-84d7-7c76fee67aee.png">

I'm not thrilled with the right padding on the after image above.  I spent some time ( I don't want to disclose how much 😆  ) trying to find a way to fix this, but each time would kind of fail and end up with long-content-fade on site titles that aren't too long.  So putting this out there to see if there are any other ideas on fixes for this, or perhaps this is good enough for now, so @blowery can begin publishing awesome test posts again!