### PR TITLE
Plugins:AT: disable plugin actions on jetpack and vaultpress

### DIFF
--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -17,9 +17,6 @@ import PluginSiteDisabledManage from 'my-sites/plugins/plugin-site-disabled-mana
 import Site from 'blocks/site';
 
 const PluginSiteJetpack = React.createClass( {
-
-	displayName: 'PluginSiteJetpack',
-
 	propTypes: {
 		site: React.PropTypes.object,
 		plugin: React.PropTypes.object,
@@ -42,6 +39,7 @@ const PluginSiteJetpack = React.createClass( {
 			isAutoManaged: false,
 		};
 	},
+
 	renderInstallButton: function() {
 		var installInProgress = PluginsLog.isInProgressAction( this.props.site.ID, this.props.plugin.slug, 'INSTALL_PLUGIN' );
 

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -24,8 +24,24 @@ export default React.createClass( {
 		site: React.PropTypes.object,
 		plugin: React.PropTypes.object,
 		notices: React.PropTypes.object,
+		allowedActions: React.PropTypes.shape( {
+			activation: React.PropTypes.bool,
+			autoupdate: React.PropTypes.bool,
+			remove: React.PropTypes.bool
+		} ),
+		isAutoManaged: React.PropTypes.bool,
 	},
 
+	getDefaultProps: function() {
+		return {
+			allowedActions: {
+				activation: true,
+				autoupdate: true,
+				remove: true,
+			},
+			isAutoManaged: false,
+		};
+	},
 	renderInstallButton: function() {
 		var installInProgress = PluginsLog.isInProgressAction( this.props.site.ID, this.props.plugin.slug, 'INSTALL_PLUGIN' );
 
@@ -49,6 +65,12 @@ export default React.createClass( {
 	},
 
 	renderPluginSite: function() {
+		const {
+			activation: canToggleActivation,
+			autoupdate: canToggleAutoupdate,
+			remove: canToggleRemove,
+		} = this.props.allowedActions;
+
 		return (
 			<FoldableCard compact
 				clickableHeader
@@ -58,9 +80,21 @@ export default React.createClass( {
 				expandedSummary={ <PluginUpdateIndicator site={ this.props.site } plugin={ this.props.plugin } notices={ this.props.notices } expanded={ true } /> }
 				>
 				<div>
-					<PluginActivateToggle site={ this.props.site } plugin={ this.props.site.plugin } notices={ this.props.notices } />
-					<PluginAutoupdateToggle site={ this.props.site } plugin={ this.props.site.plugin } notices={ this.props.notices } wporg={ true } />
-					<PluginRemoveButton plugin={ this.props.site.plugin } site={ this.props.site } notices={ this.props.notices } />
+					{ canToggleActivation && <PluginActivateToggle
+						site={ this.props.site }
+						plugin={ this.props.site.plugin }
+						notices={ this.props.notices } /> }
+					{ canToggleAutoupdate && <PluginAutoupdateToggle
+						site={ this.props.site }
+						plugin={ this.props.site.plugin }
+						notices={ this.props.notices }
+						wporg={ true } /> }
+					{ canToggleRemove && <PluginRemoveButton
+						plugin={ this.props.site.plugin }
+						site={ this.props.site }
+						notices={ this.props.notices } /> }
+
+
 				</div>
 			</FoldableCard>
 		);

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-
+import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
@@ -16,7 +16,7 @@ import PluginRemoveButton from 'my-sites/plugins/plugin-remove-button';
 import PluginSiteDisabledManage from 'my-sites/plugins/plugin-site-disabled-manage';
 import Site from 'blocks/site';
 
-export default React.createClass( {
+const PluginSiteJetpack = React.createClass( {
 
 	displayName: 'PluginSiteJetpack',
 
@@ -71,6 +71,8 @@ export default React.createClass( {
 			remove: canToggleRemove,
 		} = this.props.allowedActions;
 
+		const showAutoManagedMessage = this.props.isAutoManaged;
+
 		return (
 			<FoldableCard compact
 				clickableHeader
@@ -94,6 +96,13 @@ export default React.createClass( {
 						site={ this.props.site }
 						notices={ this.props.notices } /> }
 
+					{ showAutoManagedMessage &&
+						<div className="plugin-site-jetpack__automanage-notice">
+						{ this.props.translate( '%(pluginName)s is automatically managed on this site',
+							{ args: { pluginName: this.props.plugin.name } } )
+						}
+						</div>
+					}
 
 				</div>
 			</FoldableCard>
@@ -126,3 +135,5 @@ export default React.createClass( {
 		return this.renderPluginSite();
 	}
 } );
+
+export default localize( PluginSiteJetpack );

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
+
 /**
  * Internal dependencies
  */
@@ -24,7 +25,7 @@ const PluginSiteJetpack = React.createClass( {
 		allowedActions: React.PropTypes.shape( {
 			activation: React.PropTypes.bool,
 			autoupdate: React.PropTypes.bool,
-			remove: React.PropTypes.bool
+			remove: React.PropTypes.bool,
 		} ),
 		isAutoManaged: React.PropTypes.bool,
 	},

--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -53,3 +53,10 @@
 	display: flex;
 	align-items: center;
 }
+
+.plugin-site-jetpack__automanage-notice {
+	color: $gray;
+	font-size: 12px;
+	line-height: 1;
+	padding: 6px 0;
+}

--- a/client/my-sites/plugins/plugin-site/plugin-site.jsx
+++ b/client/my-sites/plugins/plugin-site/plugin-site.jsx
@@ -24,24 +24,28 @@ const PluginSite = ( props ) => {
 	return <PluginSiteJetpack { ...props } />;
 };
 
-export default connect(
-	( state, ownProps ) => {
-		const pluginSlug = get( ownProps, 'plugin.slug' );
-		const siteId = get( ownProps, 'site.ID' );
+function mapStateToProps( state, ownProps ) {
+	const siteId = get( ownProps, 'site.ID' );
+	return {
+		isAutomatedTransfer: isSiteAutomatedTransfer( state, siteId ),
+	};
+}
 
-		if ( includes( [ 'jetpack', 'vaultpress' ], pluginSlug ) && isSiteAutomatedTransfer( state, siteId ) ) {
-			return {
-				...ownProps,
-				...{
-					allowedActions: {
-						activation: false,
-						autoupdate: false,
-						remove: false,
-					}
-				},
-				isAutoManaged: true,
-			};
-		}
-		return ownProps;
+function mergeProps( stateProps, dispatchProps, ownProps ) {
+	const pluginSlug = get( ownProps, 'plugin.slug' );
+	let overrides = {};
+
+	if ( includes( [ 'jetpack', 'vaultpress' ], pluginSlug ) && stateProps.isAutomatedTransfer ) {
+		overrides = {
+			allowedActions: {
+				activation: false,
+				autoupdate: false,
+				remove: false,
+			},
+			isAutoManaged: true,
+		};
 	}
-)( PluginSite );
+	return Object.assign( {}, ownProps, stateProps, dispatchProps, overrides );
+}
+
+export default connect( mapStateToProps, null, mergeProps )( PluginSite );

--- a/client/my-sites/plugins/plugin-site/plugin-site.jsx
+++ b/client/my-sites/plugins/plugin-site/plugin-site.jsx
@@ -2,12 +2,15 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
+import { get, includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import PluginSiteJetpack from 'my-sites/plugins/plugin-site-jetpack';
 import PluginSiteNetwork from 'my-sites/plugins/plugin-site-network';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 
 const PluginSite = ( props ) => {
 	if ( ! props.site ) {
@@ -21,4 +24,23 @@ const PluginSite = ( props ) => {
 	return <PluginSiteJetpack { ...props } />;
 };
 
-export default PluginSite;
+export default connect(
+	( state, ownProps ) => {
+		const pluginSlug = get( ownProps, 'plugin.slug' );
+		const siteId = get( ownProps, 'site.ID' );
+
+		if ( includes( [ 'jetpack', 'vaultpress' ], pluginSlug ) && isSiteAutomatedTransfer( state, siteId ) ) {
+			return {
+				...ownProps,
+				...{
+					allowedActions: {
+						activation: false,
+						autoupdate: false,
+						remove: false,
+					}
+				},
+			};
+		}
+		return ownProps;
+	}
+)( PluginSite );

--- a/client/my-sites/plugins/plugin-site/plugin-site.jsx
+++ b/client/my-sites/plugins/plugin-site/plugin-site.jsx
@@ -39,6 +39,7 @@ export default connect(
 						remove: false,
 					}
 				},
+				isAutoManaged: true,
 			};
 		}
 		return ownProps;

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -33,6 +33,7 @@ import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, canJetpackSiteManage, getRawSite } from 'state/sites/selectors';
 import { isSiteAutomatedTransfer } from 'state/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
+import QuerySites from 'components/data/query-sites';
 
 const SinglePlugin = React.createClass( {
 	_DEFAULT_PLUGINS_BASE_PATH: 'http://wordpress.org/plugins/',
@@ -385,6 +386,7 @@ const SinglePlugin = React.createClass( {
 
 		return (
 			<MainComponent>
+				<QuerySites allSites />
 				{ this.renderDocumentHead() }
 				<SidebarNavigation />
 				<div className="plugin__page">


### PR DESCRIPTION
This replaces the plugin actions for Jetpack and Vaultpress with an _auto managed_ message in plugin sites list for automated transfer sites:

![screen shot 2017-03-15 at 3 34 23 pm](https://cloud.githubusercontent.com/assets/744755/23975145/51a9de2e-099c-11e7-9dd8-69482ff286a1.png)

## Testing

1. visit http://calypso.localhost:3000/plugins/jetpack
2. Click on an automatic transfer site card
3. The plugin actions should not be displayed 
4. There should be an auto managed message
5. Repeat with 2-4 at  http://calypso.localhost:3000/plugins/vaultpress

Partial Fix for #11493
Related PR: #11986 
