### PR TITLE
Site Settings: Update label of Comments main toggle

### DIFF
--- a/client/my-sites/site-settings/comment-display-settings/index.jsx
+++ b/client/my-sites/site-settings/comment-display-settings/index.jsx
@@ -38,8 +38,7 @@ class CommentDisplaySettings extends Component {
 					siteId={ selectedSiteId }
 					moduleSlug="comments"
 					label={ translate(
-						'Use Jetpack Comments. Readers will be able to use their WordPress.com, Twitter, Facebook, or Google+ accounts ' +
-						'to leave comments.'
+						'Allow readers to leave comments using their WordPress.com, Twitter, Facebook, or Google+ accounts'
 					) }
 					disabled={ !! submittingForm }
 					/>


### PR DESCRIPTION
This PR updates the label of the main toggle of the Comments card in the Discussion section from

> Use Jetpack Comments. Readers will be able to use their WordPress.com, Twitter, Facebook, or Google+ accounts to leave comments.

to

> Allow readers to leave comments using their WordPress.com, Twitter, Facebook, or Google+ accounts

Before:
![](https://cldup.com/mutsGTOeCa.png)

After:
![](https://cldup.com/GLtwhabaRP.png)

Fixes #12177.