### PR TITLE
Site Settings: Underline inline links

### DIFF
--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -51,6 +51,8 @@
 }
 
 .importer__service-info {
+	margin-bottom: 1.5em;
+
 	@include breakpoint(">480px") {
 		margin-left: 60px;
 	}

--- a/client/my-sites/site-settings/seo-settings/help.jsx
+++ b/client/my-sites/site-settings/seo-settings/help.jsx
@@ -25,18 +25,20 @@ const SeoSettingsHelpCard = ( {
 		<div>
 			<SectionHeader label={ translate( 'Search Engine Optimization' ) } />
 			<Card>
-				{ translate(
-					'{{b}}WordPress.com has great SEO{{/b}} out of the box. All of our themes are optimized ' +
-					'for search engines, so you don\'t have to do anything extra. However, you can tweak ' +
-					'these settings if you\'d like more advanced control. Read more about what you can do ' +
-					'to {{a}}optimize your site\'s SEO{{/a}}.',
-					{
-						components: {
-							a: <a href={ seoHelpLink } />,
-							b: <strong />
+				<p>
+					{ translate(
+						'{{b}}WordPress.com has great SEO{{/b}} out of the box. All of our themes are optimized ' +
+						'for search engines, so you don\'t have to do anything extra. However, you can tweak ' +
+						'these settings if you\'d like more advanced control. Read more about what you can do ' +
+						'to {{a}}optimize your site\'s SEO{{/a}}.',
+						{
+							components: {
+								a: <a href={ seoHelpLink } />,
+								b: <strong />
+							}
 						}
-					}
-				) }
+					) }
+				</p>
 			</Card>
 		</div>
 	);

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -54,6 +54,11 @@
 		font-weight: normal;
 	}
 
+	label a,
+	p a {
+		text-decoration: underline;
+	}
+
 	.is-primary {
 		float: right;
 	}

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -59,6 +59,10 @@
 		text-decoration: underline;
 	}
 
+	p:last-child {
+		margin-bottom: 0;
+	}
+
 	.is-primary {
 		float: right;
 	}


### PR DESCRIPTION
This PR underlines all inline links that are in sentences or labels. Below are previews of all affected links:

**Custom content types** card in **Writing** section:
![](https://cldup.com/tTmZZ_UQhA.png)

**Theme Enhancements** card in **Writing** section:
![](https://cldup.com/ZZthgOPco8.png)

**Comments** card in **Discussion** section:
![](https://cldup.com/GqmdwWF5Tn.png)

**Analytics Settings** card in **Analytics** section:
![](https://cldup.com/JvEHqZzidH.png)

**SEO** card in **SEO** section:
![](https://cldup.com/6790x5khye.png)

**Site Verification Services** card in **SEO** section:
![](https://cldup.com/khFIfSH4Fp.png)

**Site Profile** card in **General** section for **WordPress.com sites**:
![](https://cldup.com/OvqUFj-QTA.png)

**AMP** card in **General** section for **WordPress.com sites**:
![](https://cldup.com/GmdyfSTWjR.png)

**Import** section for **WordPress.com** sites:
![](https://cldup.com/_pNC88WAEO.png)

Fixes #12175.