### PR TITLE
Site Settings: Update body font size to 14px

### DIFF
--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -1,4 +1,6 @@
 .site-settings {
+	font-size: 14px;
+
 	fieldset {
 		clear: both;
 		margin-bottom: 24px;


### PR DESCRIPTION
This PR updates the body font size within site settings to 14px, so it'll be consistent with the size of the labels.

Before:
![](https://cldup.com/mIW4KsYTmD.png)

After:
![](https://cldup.com/pcfveHhcxb.png)

Fixes #12170.