### PR TITLE
Site Settings: Update description text color contrast

### DIFF
--- a/client/my-sites/site-settings/delete-site-options/style.scss
+++ b/client/my-sites/site-settings/delete-site-options/style.scss
@@ -20,7 +20,7 @@
 .delete-site-options__section-footnote {
 	margin-bottom: 0;
 	font-size: 13px;
-	color: $gray;
+	color: $gray-text-min;
 	font-style: italic;
 }
 

--- a/client/my-sites/site-settings/delete-site/style.scss
+++ b/client/my-sites/site-settings/delete-site/style.scss
@@ -9,7 +9,7 @@
 	line-height: 16px;
 	text-transform: uppercase;
 	text-align: left;
-	color: $gray;
+	color: $gray-text-min;
 }
 
 .delete-site__content-list {
@@ -53,7 +53,7 @@ h1.delete-site__confirm-header {
 	margin-bottom: 8px;
 	font-size: 14px;
 	line-height: 24px;
-	color: $gray;
+	color: $gray-text-min;
 }
 
 .delete-site__target-domain {

--- a/client/my-sites/site-settings/jetpack-sync-panel/style.scss
+++ b/client/my-sites/site-settings/jetpack-sync-panel/style.scss
@@ -32,7 +32,7 @@
 
 .jetpack-sync-panel__status-notice {
 	background: none;
-	color: $gray;
+	color: $gray-text-min;
 }
 
 .jetpack-sync-panel .jetpack-sync-panel__status-notice .notice__text {

--- a/client/my-sites/site-settings/taxonomies/style.scss
+++ b/client/my-sites/site-settings/taxonomies/style.scss
@@ -12,7 +12,7 @@
 }
 
 .taxonomies__card-content {
-	color: $gray;
+	color: $gray-text-min;
 	font-size: 13px;
 	white-space: nowrap;
 	overflow: hidden;

--- a/client/my-sites/site-settings/theme-setup/style.scss
+++ b/client/my-sites/site-settings/theme-setup/style.scss
@@ -26,7 +26,7 @@
 .theme-setup .active-theme-screenshot__name {
 	font-size: 0.85em;
 	font-weight: 600;
-	color: $gray;
+	color: $gray-text-min;
 	text-transform: uppercase;
 }
 


### PR DESCRIPTION
This PR fixes the color contrast of the description texts throughout site settings - the minimum accessible light value is `$gray-text-min` and not `$gray`. 

**Taxonomies** card - before:
![](https://cldup.com/UaWOzGvE7J.png)

**Taxonomies** card - after:
![](https://cldup.com/Ae68hytgei.png)

**Jetpack Sync** card - before
![](https://cldup.com/wuuorq8lgl.png)

**Jetpack Sync** card - after
![](https://cldup.com/_xr76Vu1mX.png)

It's also updating these colors in the texts in the following site settings locations:

* Delete site box
* Delete site options
* Theme setup

Fixes #12173.