### PR TITLE
Show cancellation survey when no refund is due.

### DIFF
--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -232,12 +232,13 @@ const CancelPurchaseButton = React.createClass( {
 	},
 
 	submitCancelAndRefundPurchase() {
+		const { purchase, selectedSite } = this.props;
+
 		this.setState( {
 			submitting: true
 		} );
 
 		if ( config.isEnabled( 'upgrades/removal-survey' ) ) {
-			const { purchase, selectedSite } = this.props;
 			const surveyData = {
 				'why-cancel': {
 					response: this.state.survey.questionOneRadio,
@@ -258,7 +259,11 @@ const CancelPurchaseButton = React.createClass( {
 			);
 		}
 
-		cancelAndRefundPurchase( this.props.purchase.id, { product_id: this.props.purchase.productId }, this.handleSubmit );
+		if ( isRefundable( purchase ) ) {
+			cancelAndRefundPurchase( purchase.id, { product_id: purchase.productId }, this.handleSubmit );
+		} else {
+			this.cancelPurchase();
+		}
 	},
 
 	renderCancellationEffect() {
@@ -350,6 +355,7 @@ const CancelPurchaseButton = React.createClass( {
 			}
 
 			if ( isSubscription( purchase ) ) {
+				onClick = this.handleCancelPurchaseClick;
 				text = this.translate( 'Cancel Subscription' );
 			}
 		}

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -18,12 +18,13 @@ import Dialog from 'components/dialog';
 import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
 import { getName, getSubscriptionEndDate, isOneTimePurchase, isRefundable, isSubscription } from 'lib/purchases';
 import { enrichedSurveyData } from '../utils';
-import { isDomainRegistration, isTheme, isGoogleApps, isJetpackPlan } from 'lib/products-values';
+import { isDomainRegistration } from 'lib/products-values';
 import notices from 'notices';
 import paths from 'me/purchases/paths';
 import { refreshSitePlans } from 'state/sites/plans/actions';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { cancellationEffectDetail, cancellationEffectHeadline } from './cancellation-effect';
 
 const CancelPurchaseButton = React.createClass( {
 	propTypes: {
@@ -268,63 +269,13 @@ const CancelPurchaseButton = React.createClass( {
 	},
 
 	renderCancellationEffect() {
-		const { domain, refundText } = this.props.purchase,
-			purchaseName = getName( this.props.purchase );
-
-		let cancelationEffectText = this.translate(
-			'All plan features and custom changes will be removed from your site and you will be refunded %(cost)s.', {
-				args: {
-					cost: refundText
-				}
-			}
-		);
-
-		if ( isTheme( this.props.purchase ) ) {
-			cancelationEffectText = this.translate(
-				'Your site\'s appearance will revert to its previously selected theme and you will be refunded %(cost)s.', {
-					args: {
-						cost: refundText
-					}
-				}
-			);
-		}
-
-		if ( isGoogleApps( this.props.purchase ) ) {
-			cancelationEffectText = this.translate(
-				'You will be refunded %(cost)s, but your G Suite account will continue working without interruption. ' +
-				'You will be able to manage your G Suite billing directly through Google.', {
-					args: {
-						cost: refundText
-					}
-				}
-			);
-		}
-
-		if ( isJetpackPlan( this.props.purchase ) ) {
-			cancelationEffectText = this.translate(
-				'All plan features - spam filtering, backups, and security screening - will be removed from your site ' +
-				'and you will be refunded %(cost)s.', {
-					args: {
-						cost: refundText
-					}
-				}
-			);
-		}
+		const { props, translate } = this;
+		const { purchase } = props;
 
 		return (
 			<p>
-				{ this.translate(
-					'Are you sure you want to cancel and remove %(purchaseName)s from {{em}}%(domain)s{{/em}}? ', {
-						args: {
-							purchaseName,
-							domain
-						},
-						components: {
-							em: <em />
-						}
-					}
-				) }
-				{ cancelationEffectText }
+				{ cancellationEffectHeadline( purchase, translate ) }
+				{ cancellationEffectDetail( purchase, translate ) }
 			</p>
 		);
 	},

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -233,6 +233,7 @@ const CancelPurchaseButton = React.createClass( {
 
 	submitCancelAndRefundPurchase() {
 		const { purchase, selectedSite } = this.props;
+		const refundable = isRefundable( purchase );
 
 		this.setState( {
 			submitting: true
@@ -249,7 +250,7 @@ const CancelPurchaseButton = React.createClass( {
 					text: this.state.survey.questionTwoText
 				},
 				'what-better': { text: this.state.survey.questionThreeText },
-				type: 'refund'
+				type: refundable ? 'refund' : 'cancel-without-refund'
 			};
 
 			submitSurvey(
@@ -259,7 +260,7 @@ const CancelPurchaseButton = React.createClass( {
 			);
 		}
 
-		if ( isRefundable( purchase ) ) {
+		if ( refundable ) {
 			cancelAndRefundPurchase( purchase.id, { product_id: purchase.productId }, this.handleSubmit );
 		} else {
 			this.cancelPurchase();

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -102,26 +102,27 @@ const CancelPurchaseButton = React.createClass( {
 	},
 
 	renderCancelConfirmationDialog() {
+		const { translate } = this.props;
 		const buttons = {
 				close: {
 					action: 'close',
-					label: this.props.translate( "No, I'll Keep It" )
+					label: translate( "No, I'll Keep It" )
 				},
 				next: {
 					action: 'next',
 					disabled: this.state.isRemoving || this.isSurveyIncomplete(),
-					label: this.props.translate( 'Next' ),
+					label: translate( 'Next' ),
 					onClick: this.changeSurveyStep
 				},
 				prev: {
 					action: 'prev',
 					disabled: this.state.isRemoving,
-					label: this.props.translate( 'Previous Step' ),
+					label: translate( 'Previous Step' ),
 					onClick: this.changeSurveyStep
 				},
 				cancel: {
 					action: 'cancel',
-					label: this.props.translate( 'Yes, Cancel Now' ),
+					label: translate( 'Yes, Cancel Now' ),
 					isPrimary: true,
 					disabled: this.state.submitting,
 					onClick: this.submitCancelAndRefundPurchase
@@ -143,7 +144,7 @@ const CancelPurchaseButton = React.createClass( {
 				buttons={ buttonsArr }
 				onClose={ this.closeDialog }
 				className="cancel-purchase__button-warning-dialog">
-				<FormSectionHeading>{ this.props.translate( 'Cancel %(purchaseName)s', { args: { purchaseName } } ) }</FormSectionHeading>
+				<FormSectionHeading>{ translate( 'Cancel %(purchaseName)s', { args: { purchaseName } } ) }</FormSectionHeading>
 				<CancelPurchaseForm
 					surveyStep={ this.state.surveyStep }
 					showSurvey={ config.isEnabled( 'upgrades/removal-survey' ) }
@@ -162,7 +163,7 @@ const CancelPurchaseButton = React.createClass( {
 	},
 
 	cancelPurchase() {
-		const { purchase } = this.props;
+		const { purchase, translate } = this.props;
 
 		this.toggleDisabled();
 
@@ -175,7 +176,7 @@ const CancelPurchaseButton = React.createClass( {
 			this.props.clearPurchases();
 
 			if ( success ) {
-				notices.success( this.props.translate(
+				notices.success( translate(
 					'%(purchaseName)s was successfully cancelled. It will be available ' +
 					'for use until it expires on %(subscriptionEndDate)s.',
 					{
@@ -188,7 +189,7 @@ const CancelPurchaseButton = React.createClass( {
 
 				page( paths.purchasesRoot() );
 			} else {
-				notices.error( this.props.translate(
+				notices.error( translate(
 					'There was a problem canceling %(purchaseName)s. ' +
 					'Please try again later or contact support.',
 					{
@@ -282,7 +283,7 @@ const CancelPurchaseButton = React.createClass( {
 	},
 
 	render() {
-		const { purchase } = this.props;
+		const { purchase, translate } = this.props;
 
 		let text, onClick;
 
@@ -290,26 +291,26 @@ const CancelPurchaseButton = React.createClass( {
 			onClick = this.handleCancelPurchaseClick;
 
 			if ( isDomainRegistration( purchase ) ) {
-				text = this.props.translate( 'Cancel Domain and Refund' );
+				text = translate( 'Cancel Domain and Refund' );
 			}
 
 			if ( isSubscription( purchase ) ) {
-				text = this.props.translate( 'Cancel Subscription and Refund' );
+				text = translate( 'Cancel Subscription and Refund' );
 			}
 
 			if ( isOneTimePurchase( purchase ) ) {
-				text = this.props.translate( 'Cancel and Refund' );
+				text = translate( 'Cancel and Refund' );
 			}
 		} else {
 			onClick = this.cancelPurchase;
 
 			if ( isDomainRegistration( purchase ) ) {
-				text = this.props.translate( 'Cancel Domain' );
+				text = translate( 'Cancel Domain' );
 			}
 
 			if ( isSubscription( purchase ) ) {
 				onClick = this.handleCancelPurchaseClick;
-				text = this.props.translate( 'Cancel Subscription' );
+				text = translate( 'Cancel Subscription' );
 			}
 		}
 

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -252,7 +252,7 @@ const CancelPurchaseButton = React.createClass( {
 					text: this.state.survey.questionTwoText
 				},
 				'what-better': { text: this.state.survey.questionThreeText },
-				type: refundable ? 'refund' : 'cancel-without-refund'
+				type: refundable ? 'refund' : 'cancel-autorenew'
 			};
 
 			submitSurvey(

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -46,11 +46,12 @@ const CancelPurchaseButton = React.createClass( {
 	},
 
 	recordEvent( name, properties = {} ) {
-		const product_slug = get( this.props, 'purchase.productSlug' );
-		const refund = true;
+		const { purchase } = this.props;
+		const product_slug = get( purchase, 'productSlug' );
+		const cancellation_flow = isRefundable( purchase ) ? 'cancel_with_refund' : 'cancel_autorenew';
 		this.props.recordTracksEvent(
 			name,
-			Object.assign( { refund, product_slug }, properties )
+			Object.assign( { cancellation_flow, product_slug }, properties )
 		);
 	},
 

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import page from 'page';
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import { moment } from 'i18n-calypso';
 import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -27,26 +27,24 @@ import FormSectionHeading from 'components/forms/form-section-heading';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { cancellationEffectDetail, cancellationEffectHeadline } from './cancellation-effect';
 
-const CancelPurchaseButton = React.createClass( {
-	propTypes: {
-		purchase: React.PropTypes.object.isRequired,
-		selectedSite: React.PropTypes.object.isRequired
-	},
+class CancelPurchaseButton extends Component {
+	static propTypes = {
+		purchase: PropTypes.object.isRequired,
+		selectedSite: PropTypes.object.isRequired
+	}
 
-	getInitialState() {
-		return {
-			disabled: false,
-			showDialog: false,
-			isRemoving: false,
-			surveyStep: 1,
-			survey: {
-				questionOneRadio: null,
-				questionTwoRadio: null
-			}
-		};
-	},
+	state = {
+		disabled: false,
+		showDialog: false,
+		isRemoving: false,
+		surveyStep: 1,
+		survey: {
+			questionOneRadio: null,
+			questionTwoRadio: null
+		}
+	}
 
-	recordEvent( name, properties = {} ) {
+	recordEvent = ( name, properties = {} ) => {
 		const { purchase } = this.props;
 		const product_slug = get( purchase, 'productSlug' );
 		const cancellation_flow = isRefundable( purchase ) ? 'cancel_with_refund' : 'cancel_autorenew';
@@ -54,9 +52,9 @@ const CancelPurchaseButton = React.createClass( {
 			name,
 			Object.assign( { cancellation_flow, product_slug }, properties )
 		);
-	},
+	}
 
-	handleCancelPurchaseClick() {
+	handleCancelPurchaseClick = () => {
 		if ( isDomainRegistration( this.props.purchase ) ) {
 			return this.goToCancelConfirmation();
 		}
@@ -66,9 +64,9 @@ const CancelPurchaseButton = React.createClass( {
 		this.setState( {
 			showDialog: true
 		} );
-	},
+	}
 
-	closeDialog() {
+	closeDialog = () => {
 		this.recordEvent( 'calypso_purchases_cancel_form_close' );
 
 		this.setState( {
@@ -79,29 +77,29 @@ const CancelPurchaseButton = React.createClass( {
 				questionTwoRadio: null
 			}
 		} );
-	},
+	}
 
-	changeSurveyStep() {
+	changeSurveyStep = () => {
 		const newStep = this.state.surveyStep === 1 ? 2 : 1;
 
 		this.recordEvent( 'calypso_purchases_cancel_survey_step', { new_step: newStep } );
 
 		this.setState( { surveyStep: newStep } );
-	},
+	}
 
-	onSurveyChange( update ) {
+	onSurveyChange = ( update ) => {
 		this.setState( {
 			survey: update,
 		} );
-	},
+	}
 
-	isSurveyIncomplete() {
+	isSurveyIncomplete = () => {
 		return this.state.survey.questionOneRadio === null || this.state.survey.questionTwoRadio === null ||
 			( this.state.survey.questionOneRadio === 'anotherReasonOne' && this.state.survey.questionOneText === '' ) ||
 			( this.state.survey.questionTwoRadio === 'anotherReasonTwo' && this.state.survey.questionTwoText === '' );
-	},
+	}
 
-	renderCancelConfirmationDialog() {
+	renderCancelConfirmationDialog = () => {
 		const { translate } = this.props;
 		const buttons = {
 				close: {
@@ -153,16 +151,16 @@ const CancelPurchaseButton = React.createClass( {
 				/>
 			</Dialog>
 		);
-	},
+	}
 
-	goToCancelConfirmation() {
+	goToCancelConfirmation = () => {
 		const { id } = this.props.purchase,
 			{ slug } = this.props.selectedSite;
 
 		page( paths.confirmCancelDomain( slug, id ) );
-	},
+	}
 
-	cancelPurchase() {
+	cancelPurchase = () => {
 		const { purchase, translate } = this.props;
 
 		this.toggleDisabled();
@@ -199,23 +197,23 @@ const CancelPurchaseButton = React.createClass( {
 				this.cancellationFailed();
 			}
 		} );
-	},
+	}
 
-	cancellationFailed() {
+	cancellationFailed = () => {
 		this.closeDialog();
 
 		this.setState( {
 			submitting: false
 		} );
-	},
+	}
 
-	toggleDisabled() {
+	toggleDisabled = () => {
 		this.setState( {
 			disabled: ! this.state.disabled
 		} );
-	},
+	}
 
-	handleSubmit( error, response ) {
+	handleSubmit = ( error, response ) => {
 		if ( error ) {
 			notices.error( error.message );
 
@@ -233,9 +231,9 @@ const CancelPurchaseButton = React.createClass( {
 		this.recordEvent( 'calypso_purchases_cancel_form_submit' );
 
 		page.redirect( paths.purchasesRoot() );
-	},
+	}
 
-	submitCancelAndRefundPurchase() {
+	submitCancelAndRefundPurchase = () => {
 		const { purchase, selectedSite } = this.props;
 		const refundable = isRefundable( purchase );
 
@@ -269,9 +267,9 @@ const CancelPurchaseButton = React.createClass( {
 		} else {
 			this.cancelPurchase();
 		}
-	},
+	}
 
-	renderCancellationEffect() {
+	renderCancellationEffect = () => {
 		const { purchase, translate } = this.props;
 
 		return (
@@ -280,7 +278,7 @@ const CancelPurchaseButton = React.createClass( {
 				{ cancellationEffectDetail( purchase, translate ) }
 			</p>
 		);
-	},
+	}
 
 	render() {
 		const { purchase, translate } = this.props;
@@ -328,7 +326,7 @@ const CancelPurchaseButton = React.createClass( {
 
 		);
 	}
-} );
+}
 
 export default connect(
 	null,

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -19,7 +19,7 @@ import Dialog from 'components/dialog';
 import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
 import { getName, getSubscriptionEndDate, isOneTimePurchase, isRefundable, isSubscription } from 'lib/purchases';
 import { enrichedSurveyData } from '../utils';
-import { isDomainRegistration } from 'lib/products-values';
+import { isDomainRegistration, isJetpackPlan } from 'lib/products-values';
 import notices from 'notices';
 import paths from 'me/purchases/paths';
 import { refreshSitePlans } from 'state/sites/plans/actions';
@@ -100,34 +100,34 @@ class CancelPurchaseButton extends Component {
 	}
 
 	renderCancelConfirmationDialog = () => {
-		const { translate } = this.props;
+		const { purchase, translate } = this.props;
 		const buttons = {
-				close: {
-					action: 'close',
-					label: translate( "No, I'll Keep It" )
-				},
-				next: {
-					action: 'next',
-					disabled: this.state.isRemoving || this.isSurveyIncomplete(),
-					label: translate( 'Next' ),
-					onClick: this.changeSurveyStep
-				},
-				prev: {
-					action: 'prev',
-					disabled: this.state.isRemoving,
-					label: translate( 'Previous Step' ),
-					onClick: this.changeSurveyStep
-				},
-				cancel: {
-					action: 'cancel',
-					label: translate( 'Yes, Cancel Now' ),
-					isPrimary: true,
-					disabled: this.state.submitting,
-					onClick: this.submitCancelAndRefundPurchase
-				}
+			close: {
+				action: 'close',
+				label: translate( "No, I'll Keep It" )
 			},
-			purchaseName = getName( this.props.purchase ),
-			inStepOne = this.state.surveyStep === 1;
+			next: {
+				action: 'next',
+				disabled: this.state.isRemoving || this.isSurveyIncomplete(),
+				label: translate( 'Next' ),
+				onClick: this.changeSurveyStep
+			},
+			prev: {
+				action: 'prev',
+				disabled: this.state.isRemoving,
+				label: translate( 'Previous Step' ),
+				onClick: this.changeSurveyStep
+			},
+			cancel: {
+				action: 'cancel',
+				label: translate( 'Yes, Cancel Now' ),
+				isPrimary: true,
+				disabled: this.state.submitting,
+				onClick: this.submitCancelAndRefundPurchase
+			}
+		};
+		const purchaseName = getName( purchase );
+		const inStepOne = this.state.surveyStep === 1;
 
 		let buttonsArr;
 		if ( ! config.isEnabled( 'upgrades/removal-survey' ) ) {
@@ -148,6 +148,7 @@ class CancelPurchaseButton extends Component {
 					showSurvey={ config.isEnabled( 'upgrades/removal-survey' ) }
 					defaultContent={ this.renderCancellationEffect() }
 					onInputChange={ this.onSurveyChange }
+					isJetpack={ isJetpackPlan( purchase ) }
 				/>
 			</Dialog>
 		);

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -5,6 +5,7 @@ import page from 'page';
 import React from 'react';
 import { moment } from 'i18n-calypso';
 import { get } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -104,23 +105,23 @@ const CancelPurchaseButton = React.createClass( {
 		const buttons = {
 				close: {
 					action: 'close',
-					label: this.translate( "No, I'll Keep It" )
+					label: this.props.translate( "No, I'll Keep It" )
 				},
 				next: {
 					action: 'next',
 					disabled: this.state.isRemoving || this.isSurveyIncomplete(),
-					label: this.translate( 'Next' ),
+					label: this.props.translate( 'Next' ),
 					onClick: this.changeSurveyStep
 				},
 				prev: {
 					action: 'prev',
 					disabled: this.state.isRemoving,
-					label: this.translate( 'Previous Step' ),
+					label: this.props.translate( 'Previous Step' ),
 					onClick: this.changeSurveyStep
 				},
 				cancel: {
 					action: 'cancel',
-					label: this.translate( 'Yes, Cancel Now' ),
+					label: this.props.translate( 'Yes, Cancel Now' ),
 					isPrimary: true,
 					disabled: this.state.submitting,
 					onClick: this.submitCancelAndRefundPurchase
@@ -142,7 +143,7 @@ const CancelPurchaseButton = React.createClass( {
 				buttons={ buttonsArr }
 				onClose={ this.closeDialog }
 				className="cancel-purchase__button-warning-dialog">
-				<FormSectionHeading>{ this.translate( 'Cancel %(purchaseName)s', { args: { purchaseName } } ) }</FormSectionHeading>
+				<FormSectionHeading>{ this.props.translate( 'Cancel %(purchaseName)s', { args: { purchaseName } } ) }</FormSectionHeading>
 				<CancelPurchaseForm
 					surveyStep={ this.state.surveyStep }
 					showSurvey={ config.isEnabled( 'upgrades/removal-survey' ) }
@@ -174,7 +175,7 @@ const CancelPurchaseButton = React.createClass( {
 			this.props.clearPurchases();
 
 			if ( success ) {
-				notices.success( this.translate(
+				notices.success( this.props.translate(
 					'%(purchaseName)s was successfully cancelled. It will be available ' +
 					'for use until it expires on %(subscriptionEndDate)s.',
 					{
@@ -187,7 +188,7 @@ const CancelPurchaseButton = React.createClass( {
 
 				page( paths.purchasesRoot() );
 			} else {
-				notices.error( this.translate(
+				notices.error( this.props.translate(
 					'There was a problem canceling %(purchaseName)s. ' +
 					'Please try again later or contact support.',
 					{
@@ -270,8 +271,7 @@ const CancelPurchaseButton = React.createClass( {
 	},
 
 	renderCancellationEffect() {
-		const { props, translate } = this;
-		const { purchase } = props;
+		const { purchase, translate } = this.props;
 
 		return (
 			<p>
@@ -290,26 +290,26 @@ const CancelPurchaseButton = React.createClass( {
 			onClick = this.handleCancelPurchaseClick;
 
 			if ( isDomainRegistration( purchase ) ) {
-				text = this.translate( 'Cancel Domain and Refund' );
+				text = this.props.translate( 'Cancel Domain and Refund' );
 			}
 
 			if ( isSubscription( purchase ) ) {
-				text = this.translate( 'Cancel Subscription and Refund' );
+				text = this.props.translate( 'Cancel Subscription and Refund' );
 			}
 
 			if ( isOneTimePurchase( purchase ) ) {
-				text = this.translate( 'Cancel and Refund' );
+				text = this.props.translate( 'Cancel and Refund' );
 			}
 		} else {
 			onClick = this.cancelPurchase;
 
 			if ( isDomainRegistration( purchase ) ) {
-				text = this.translate( 'Cancel Domain' );
+				text = this.props.translate( 'Cancel Domain' );
 			}
 
 			if ( isSubscription( purchase ) ) {
 				onClick = this.handleCancelPurchaseClick;
-				text = this.translate( 'Cancel Subscription' );
+				text = this.props.translate( 'Cancel Subscription' );
 			}
 		}
 
@@ -336,4 +336,4 @@ export default connect(
 		recordTracksEvent,
 		refreshSitePlans,
 	}
-)( CancelPurchaseButton );
+)( localize( CancelPurchaseButton ) );

--- a/client/me/purchases/cancel-purchase/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/cancellation-effect.jsx
@@ -6,15 +6,29 @@ import React from 'react';
 /**
  * Internal Dependencies
  */
-import { getName } from 'lib/purchases';
-import { isTheme, isGoogleApps, isJetpackPlan } from 'lib/products-values';
+import { getName, getSubscriptionEndDate, isRefundable } from 'lib/purchases';
+import { isDomainMapping, isGoogleApps, isJetpackPlan, isTheme } from 'lib/products-values';
 
 function cancellationEffectHeadline( purchase, translate ) {
 	const { domain } = purchase;
 	const	purchaseName = getName( purchase );
 
+	if ( isRefundable( purchase ) ) {
+		return translate(
+			'Are you sure you want to cancel and remove %(purchaseName)s from {{em}}%(domain)s{{/em}}? ', {
+				args: {
+					purchaseName,
+					domain
+				},
+				components: {
+					em: <em />
+				}
+			}
+		);
+	}
+
 	return translate(
-		'Are you sure you want to cancel and remove %(purchaseName)s from {{em}}%(domain)s{{/em}}? ', {
+		'Are you sure you want to cancel %(purchaseName)s from {{em}}%(domain)s{{/em}}? ', {
 			args: {
 				purchaseName,
 				domain
@@ -26,7 +40,7 @@ function cancellationEffectHeadline( purchase, translate ) {
 	);
 }
 
-function cancellationEffectDetail( purchase, translate ) {
+function refundableCancellationEffectDetail( purchase, translate ) {
 	const { refundText } = purchase;
 
 	if ( isTheme( purchase ) ) {
@@ -68,6 +82,45 @@ function cancellationEffectDetail( purchase, translate ) {
 			}
 		}
 	);
+}
+
+function nonrefundableCancellationEffectDetail( purchase, translate ) {
+	const subscriptionEndDate = getSubscriptionEndDate( purchase );
+
+	if ( isGoogleApps( purchase ) ) {
+		return translate(
+			'Your G Suite account will continue working until it expires on %(subscriptionEndDate)s.', {
+				args: {
+					subscriptionEndDate
+				}
+			}
+		);
+	}
+
+	if ( isDomainMapping( purchase ) ) {
+		return translate(
+			'Your domain mapping will continue working until it expires on %(subscriptionEndDate)s.', {
+				args: {
+					subscriptionEndDate
+				}
+			}
+		);
+	}
+
+	return translate(
+		'All plan features will continue working until your subscription expires on %(subscriptionEndDate)s.', {
+			args: {
+				subscriptionEndDate
+			}
+		}
+	);
+}
+
+function cancellationEffectDetail( purchase, translate ) {
+	if ( isRefundable( purchase ) ) {
+		return refundableCancellationEffectDetail( purchase, translate );
+	}
+	return nonrefundableCancellationEffectDetail( purchase, translate );
 }
 
 export {

--- a/client/me/purchases/cancel-purchase/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/cancellation-effect.jsx
@@ -1,0 +1,76 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal Dependencies
+ */
+import { getName } from 'lib/purchases';
+import { isTheme, isGoogleApps, isJetpackPlan } from 'lib/products-values';
+
+function cancellationEffectHeadline( purchase, translate ) {
+	const { domain } = purchase;
+	const	purchaseName = getName( purchase );
+
+	return translate(
+		'Are you sure you want to cancel and remove %(purchaseName)s from {{em}}%(domain)s{{/em}}? ', {
+			args: {
+				purchaseName,
+				domain
+			},
+			components: {
+				em: <em />
+			}
+		}
+	);
+}
+
+function cancellationEffectDetail( purchase, translate ) {
+	const { refundText } = purchase;
+
+	if ( isTheme( purchase ) ) {
+		return translate(
+			'Your site\'s appearance will revert to its previously selected theme and you will be refunded %(cost)s.', {
+				args: {
+					cost: refundText
+				}
+			}
+		);
+	}
+
+	if ( isGoogleApps( purchase ) ) {
+		return translate(
+			'You will be refunded %(cost)s, but your G Suite account will continue working without interruption. ' +
+			'You will be able to manage your G Suite billing directly through Google.', {
+				args: {
+					cost: refundText
+				}
+			}
+		);
+	}
+
+	if ( isJetpackPlan( purchase ) ) {
+		return translate(
+			'All plan features - spam filtering, backups, and security screening - will be removed from your site ' +
+			'and you will be refunded %(cost)s.', {
+				args: {
+					cost: refundText
+				}
+			}
+		);
+	}
+
+	return translate(
+		'All plan features and custom changes will be removed from your site and you will be refunded %(cost)s.', {
+			args: {
+				cost: refundText
+			}
+		}
+	);
+}
+
+export {
+	cancellationEffectDetail,
+	cancellationEffectHeadline,
+};

--- a/client/me/purchases/cancel-purchase/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/cancellation-effect.jsx
@@ -89,7 +89,7 @@ function nonrefundableCancellationEffectDetail( purchase, translate ) {
 
 	if ( isGoogleApps( purchase ) ) {
 		return translate(
-			'Your G Suite account will continue working until it expires on %(subscriptionEndDate)s.', {
+			'Your G Suite account remains active until it expires on %(subscriptionEndDate)s.', {
 				args: {
 					subscriptionEndDate
 				}
@@ -99,7 +99,7 @@ function nonrefundableCancellationEffectDetail( purchase, translate ) {
 
 	if ( isDomainMapping( purchase ) ) {
 		return translate(
-			'Your domain mapping will continue working until it expires on %(subscriptionEndDate)s.', {
+			'Your domain mapping remains active until it expires on %(subscriptionEndDate)s.', {
 				args: {
 					subscriptionEndDate
 				}
@@ -108,7 +108,7 @@ function nonrefundableCancellationEffectDetail( purchase, translate ) {
 	}
 
 	return translate(
-		'All plan features will continue working until your subscription expires on %(subscriptionEndDate)s.', {
+		"Your plan's features remain active until your subscription expires on %(subscriptionEndDate)s.", {
 			args: {
 				subscriptionEndDate
 			}

--- a/client/me/purchases/cancel-purchase/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/cancellation-effect.jsx
@@ -28,7 +28,7 @@ function cancellationEffectHeadline( purchase, translate ) {
 	}
 
 	return translate(
-		'Are you sure you want to cancel %(purchaseName)s from {{em}}%(domain)s{{/em}}? ', {
+		'Are you sure you want to cancel %(purchaseName)s for {{em}}%(domain)s{{/em}}? ', {
 			args: {
 				purchaseName,
 				domain

--- a/client/me/purchases/cancel-purchase/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/cancellation-effect.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { getName, getSubscriptionEndDate, isRefundable } from 'lib/purchases';
 import { isDomainMapping, isGoogleApps, isJetpackPlan, isTheme } from 'lib/products-values';
 
-function cancellationEffectHeadline( purchase, translate ) {
+export function cancellationEffectHeadline( purchase, translate ) {
 	const { domain } = purchase;
 	const	purchaseName = getName( purchase );
 
@@ -116,14 +116,9 @@ function nonrefundableCancellationEffectDetail( purchase, translate ) {
 	);
 }
 
-function cancellationEffectDetail( purchase, translate ) {
+export function cancellationEffectDetail( purchase, translate ) {
 	if ( isRefundable( purchase ) ) {
 		return refundableCancellationEffectDetail( purchase, translate );
 	}
 	return nonrefundableCancellationEffectDetail( purchase, translate );
 }
-
-export {
-	cancellationEffectDetail,
-	cancellationEffectHeadline,
-};

--- a/client/me/purchases/cancel-purchase/test/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/test/cancellation-effect.jsx
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import useMockery from 'test/helpers/use-mockery';
+
+describe( 'cancellation-effect', function() {
+	const purchase = { domain: 'example.com' };
+	const purchases = {};
+	const productsValues = {};
+	let cancellationEffect;
+	let translate;
+
+	useMockery( mockery => {
+		mockery.registerMock( 'lib/purchases', purchases );
+		mockery.registerMock( 'lib/products-values', productsValues );
+	} );
+
+	beforeEach( function() {
+		purchases.getName = () => 'purchase name';
+		translate = ( text, args ) => ( { args, text } );
+		cancellationEffect = require( '../cancellation-effect' );
+	} );
+
+	describe( 'cancellationEffectHeadline', function() {
+		describe( 'when refundable', function() {
+			beforeEach( function() {
+				purchases.isRefundable = () => true;
+			} );
+
+			it( 'should return translation of cancel and return', function() {
+				const headline = cancellationEffect.cancellationEffectHeadline( purchase, translate );
+				expect( headline.text ).to.equal(
+					'Are you sure you want to cancel and remove %(purchaseName)s from {{em}}%(domain)s{{/em}}? ',
+				);
+			} );
+		} );
+
+		describe( 'when not refundable', function() {
+			beforeEach( function() {
+				purchases.isRefundable = () => false;
+			} );
+
+			it( 'should return translation of cancel', function() {
+				const headline = cancellationEffect.cancellationEffectHeadline( purchase, translate );
+				expect( headline.text ).to.equal(
+					'Are you sure you want to cancel %(purchaseName)s for {{em}}%(domain)s{{/em}}? ',
+				);
+			} );
+		} );
+	} );
+
+	describe( 'cancellationEffectDetail', function() {
+		describe( 'when refundable', function() {
+			beforeEach( function() {
+				purchases.isRefundable = () => true;
+			} );
+
+			it( 'should return translation of theme message when product is a theme', function() {
+				productsValues.isTheme = () => true;
+				const headline = cancellationEffect.cancellationEffectDetail( purchase, translate );
+				expect( headline.text ).to.equal(
+					"Your site's appearance will revert to its previously selected theme and you will be refunded %(cost)s."
+				);
+			} );
+		} );
+
+		describe( 'when not refundable', function() {
+			beforeEach( function() {
+				purchases.isRefundable = () => false;
+				purchases.getSubscriptionEndDate = () => '15/12/2093';
+			} );
+
+			it( 'should return translation of g suite message when product is g suite', function() {
+				productsValues.isGoogleApps = () => true;
+				const headline = cancellationEffect.cancellationEffectDetail( purchase, translate );
+				expect( headline.text ).to.equal(
+					'Your G Suite account remains active until it expires on %(subscriptionEndDate)s.'
+				);
+			} );
+		} );
+	} );
+} );

--- a/client/me/purchases/cancel-purchase/test/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/test/cancellation-effect.jsx
@@ -67,6 +67,37 @@ describe( 'cancellation-effect', function() {
 					"Your site's appearance will revert to its previously selected theme and you will be refunded %(cost)s."
 				);
 			} );
+
+			it( 'should return translation of g suite message when product is g suite', function() {
+				productsValues.isTheme = () => false;
+				productsValues.isGoogleApps = () => true;
+				const headline = cancellationEffect.cancellationEffectDetail( purchase, translate );
+				expect( headline.text ).to.equal(
+					'You will be refunded %(cost)s, but your G Suite account will continue working without interruption. ' +
+					'You will be able to manage your G Suite billing directly through Google.'
+				);
+			} );
+
+			it( 'should return translation of jetpack plan message when product is a jetpack plan', function() {
+				productsValues.isTheme = () => false;
+				productsValues.isGoogleApps = () => false;
+				productsValues.isJetpackPlan = () => true;
+				const headline = cancellationEffect.cancellationEffectDetail( purchase, translate );
+				expect( headline.text ).to.equal(
+					'All plan features - spam filtering, backups, and security screening ' +
+					'- will be removed from your site and you will be refunded %(cost)s.'
+				);
+			} );
+
+			it( 'should return translation of plan message when product is not a theme, g suite or a jetpack plan', function() {
+				productsValues.isTheme = () => false;
+				productsValues.isGoogleApps = () => false;
+				productsValues.isJetpackPlan = () => false;
+				const headline = cancellationEffect.cancellationEffectDetail( purchase, translate );
+				expect( headline.text ).to.equal(
+					'All plan features and custom changes will be removed from your site and you will be refunded %(cost)s.'
+				);
+			} );
 		} );
 
 		describe( 'when not refundable', function() {
@@ -80,6 +111,24 @@ describe( 'cancellation-effect', function() {
 				const headline = cancellationEffect.cancellationEffectDetail( purchase, translate );
 				expect( headline.text ).to.equal(
 					'Your G Suite account remains active until it expires on %(subscriptionEndDate)s.'
+				);
+			} );
+
+			it( 'should return translation of domain mapping message when product is a domain mapping', function() {
+				productsValues.isGoogleApps = () => false;
+				productsValues.isDomainMapping = () => true;
+				const headline = cancellationEffect.cancellationEffectDetail( purchase, translate );
+				expect( headline.text ).to.equal(
+					'Your domain mapping remains active until it expires on %(subscriptionEndDate)s.'
+				);
+			} );
+
+			it( 'should return translation of plan message when product is not g suite or a domain mapping', function() {
+				productsValues.isGoogleApps = () => false;
+				productsValues.isDomainMapping = () => false;
+				const headline = cancellationEffect.cancellationEffectDetail( purchase, translate );
+				expect( headline.text ).to.equal(
+					"Your plan's features remain active until your subscription expires on %(subscriptionEndDate)s."
 				);
 			} );
 		} );

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -97,10 +97,10 @@ const RemovePurchase = React.createClass( {
 
 	recordEvent( name, properties = {} ) {
 		const product_slug = get( this.props, 'selectedPurchase.productSlug' );
-		const refund = false;
+		const cancellation_flow = 'remove';
 		this.props.recordTracksEvent(
 			name,
-			Object.assign( { refund, product_slug }, properties )
+			Object.assign( { cancellation_flow, product_slug }, properties )
 		);
 	},
 

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -162,7 +162,7 @@ const RemovePurchase = React.createClass( {
 					text: this.state.survey.questionTwoText
 				},
 				'what-better': { text: this.state.survey.questionThreeText },
-				type: 'cancel'
+				type: 'remove'
 			};
 
 			survey.addResponses( enrichedSurveyData( surveyData, moment(), selectedSite, purchase ) );


### PR DESCRIPTION
There are three different flows for cancelling a paid subscription in calypso:

* a 'cancel and refund' flow when eligible for refund (which issues a refund and makes the plan inactive)
* a 'cancel' flow when no longer eligible for refund and autorenew is enabled (which disables autorenew)
* a 'remove' flow when no longer eligible for refund and autorenew is disabled (which makes the plan inactive)

Only flows 1 and 3 currently display the cancellation survey.  This means that if a user decides to discontinue a plan after the refund period, no feedback is requested unless they also choose to remove the subscription.

This PR ensures the survey questions are displayed in flow 2.

The following new copy will be displayed when cancelling autorenew on the second page of the survey:

* "Are you sure you want to cancel %(purchaseName) for %(domain). Your plan's features remain active until your subscription expires on %(subscriptionEndDate)." for a plan

* "Are you sure you want to cancel %(purchaseName) for %(domain). Your domain mapping remains active until it expires on %(subscriptionEndDate)." for a domain mapping

* "Are you sure you want to cancel %(purchaseName) for %(domain). Your G Suite account remains active until it expires on %(subscriptionEndDate)." for G Suite

The tracks events during cancellation flows will include a `cancellation_flow` attribute which will have one of the following values: `cancel_with_refund` (flow 1), `cancel_autorenew` (flow 2) and `remove` (flow 3). 

The cancellation survey now has an additional value for `type`: `refund` (flow 1), `cancel-autorenew` (flow 2) and `remove` (flow 3).

# To Test

Create a site with plan that is out of refund period and cancel.

Follow the cancellation process from `/me/purchases` for the plan.