### PR TITLE
Ensure onClick is not fired by disabled buttons in Dialog

### DIFF
--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -64,7 +64,7 @@ class DialogBase extends Component {
 
 		return (
 			<button key={ button.action } className={ classes } onClick={ clickHandler } disabled={ !! button.disabled }>
-				<span className={ this.props.baseClassName + '__button-label' }>{ button.label }</span>
+				{ button.label }
 			</button>
 		);
 	}


### PR DESCRIPTION
It seems that on chrome and safari:

```
<button disabled onClick={handler}>
  <span>Click Me</span>
</button>
```

The button `handler` event will be fired despite the button being disabled.