### PR TITLE
Components: Prevent default behavior when toggling FoldableCard

### DIFF
--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -92,6 +92,7 @@ var FoldableCard = React.createClass( {
 			return (
 				<button
 					disabled={ this.props.disabled }
+					type="button"
 					className="foldable-card__action foldable-card__expand"
 					onClick={ clickAction }>
 					<span className="screen-reader-text">{ screenReaderText }</span>


### PR DESCRIPTION
While working on #12105 I noticed that if we insert a `FoldableCard` into a form, it will trigger the form submission each time we expand or collapse the card. This is unexpected, and should not happen. 

This PR fixes this behavior, suggesting to call `event.preventDefault()`.

To test this one, you'll have to insert the `FoldableCard` component in a `<form />`, or you can refer to #12105 for testing it in a real case.