### PR TITLE
Reader: fix combined card block devdocs example

### DIFF
--- a/client/blocks/reader-combined-card/docs/example.jsx
+++ b/client/blocks/reader-combined-card/docs/example.jsx
@@ -9,10 +9,12 @@ import React from 'react';
 import ReaderCombinedCardBlock from 'blocks/reader-combined-card';
 import { posts, feed, site } from 'blocks/reader-post-card/docs/fixtures';
 
+const postKey = { blogId: site.ID };
+
 const ReaderCombinedCard = () => (
 	<div className="design-assets__group">
 		<div>
-			<ReaderCombinedCardBlock posts={ posts } feed={ feed } site={ site } />
+			<ReaderCombinedCardBlock postKey={ postKey } posts={ posts } feed={ feed } site={ site } />
 		</div>
 	</div>
 );

--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -28,7 +28,7 @@ class ReaderCombinedCard extends React.Component {
 		feed: React.PropTypes.object,
 		onClick: React.PropTypes.func,
 		isDiscover: React.PropTypes.bool,
-		postKey: React.PropTypes.object,
+		postKey: React.PropTypes.object.isRequired,
 		selectedPostKey: React.PropTypes.object,
 		showFollowButton: React.PropTypes.bool,
 		followSource: React.PropTypes.string,


### PR DESCRIPTION
@hoverduck reported that the blocks devdocs page was failing to load with the following error:

`Uncaught (in promise) TypeError: Cannot read property 'feedId' of undefined`

The devdocs example for combined card was missing a `postKey`. This PR adds a post key and marks the prop as required in the component.

### To test

Ensure that

http://calypso.localhost:3000/devdocs/blocks

and 

http://calypso.localhost:3000/devdocs/blocks/reader-combined-card

load correctly.