### PR TITLE
Components: DropZone accepts custom text label

### DIFF
--- a/client/components/drop-zone/index.jsx
+++ b/client/components/drop-zone/index.jsx
@@ -24,6 +24,7 @@ export const DropZone = React.createClass( {
 		onFilesDrop: PropTypes.func,
 		fullScreen: PropTypes.bool,
 		icon: PropTypes.string,
+		textLabel: PropTypes.string,
 		translate: PropTypes.func,
 	},
 
@@ -196,6 +197,10 @@ export const DropZone = React.createClass( {
 	renderContent() {
 		let content;
 
+		const textLabel = this.props.textLabel
+			? this.props.textLabel
+			: this.props.translate( 'Drop files to upload' );
+
 		if ( this.props.children ) {
 			content = this.props.children;
 		} else {
@@ -203,7 +208,7 @@ export const DropZone = React.createClass( {
 				icon: <Gridicon icon={ this.props.icon } size={ 48 } className="drop-zone__content-icon" />,
 				text: (
 					<span className="drop-zone__content-text">
-						{ this.props.translate( 'Drop files to upload' ) }
+						{ textLabel }
 					</span>
 				)
 			} );

--- a/client/components/drop-zone/test/index.jsx
+++ b/client/components/drop-zone/test/index.jsx
@@ -227,4 +227,22 @@ describe( 'index', function() {
 			expect( zone.state.isDraggingOverElement ).to.not.be.ok;
 		} );
 	} );
+
+	it( 'should accept a custom textLabel to override the default text', function() {
+		const tree = ReactDom.render( React.createElement( DropZone, {
+			textLabel: 'Custom Drop Zone Label'
+		} ), container );
+
+		const textContent = TestUtils.findRenderedDOMComponentWithClass( tree, 'drop-zone__content-text' );
+
+		expect( textContent.textContent ).to.equal( 'Custom Drop Zone Label' );
+	} );
+
+	it( 'should show the default text label if none specified', function() {
+		const tree = ReactDom.render( React.createElement( DropZone, {} ), container );
+
+		const textContent = TestUtils.findRenderedDOMComponentWithClass( tree, 'drop-zone__content-text' );
+
+		expect( textContent.textContent ).to.equal( 'Drop files to upload' );
+	} );
 } );


### PR DESCRIPTION
This PR is a preparation for #11839 . It allows the `DropZone` component to accept a custom label, which will be set according to specific need.

I've covered the PR with tests.

To test:

1. Open the Editor
2. Drag a file over the editor area 
3. Verify the text label is still the default one - `Drop files to upload` (localized)