### PR TITLE
Plugins: Replace AT success banner with activating banner

### DIFF
--- a/client/my-sites/plugins/plugin-automated-transfer/index.jsx
+++ b/client/my-sites/plugins/plugin-automated-transfer/index.jsx
@@ -80,7 +80,7 @@ class PluginAutomatedTransfer extends Component {
 			return translate( "Don't leave quite yet! Just a bit longer." );
 		}
 		if ( transferComplete ) {
-			return translate( 'Successfully installed %(plugin)s!', { args: { plugin: plugin.name } } );
+			return translate( 'Activating %(plugin)s...', { args: { plugin: plugin.name } } );
 		}
 		switch ( transferState ) {
 			case START: return translate( 'Installing %(plugin)s…', { args: { plugin: plugin.name } } );
@@ -91,13 +91,10 @@ class PluginAutomatedTransfer extends Component {
 	getStatus = () => {
 		const { CONFLICTS } = transferStates;
 		const { transferState } = this.props;
-		const { clickOutside, transferComplete } = this.state;
+		const { clickOutside } = this.state;
 
 		if ( clickOutside ) {
 			return 'is-info';
-		}
-		if ( transferComplete ) {
-			return 'is-success';
 		}
 		if ( CONFLICTS === transferState ) {
 			return 'is-error';
@@ -108,13 +105,10 @@ class PluginAutomatedTransfer extends Component {
 	getIcon = () => {
 		const { CONFLICTS } = transferStates;
 		const { transferState } = this.props;
-		const { clickOutside, transferComplete } = this.state;
+		const { clickOutside } = this.state;
 
 		if ( clickOutside ) {
 			return 'sync';
-		}
-		if ( transferComplete ) {
-			return 'checkmark';
 		}
 		if ( CONFLICTS === transferState ) {
 			return 'notice';


### PR DESCRIPTION
Removed the success message and replaced it with an activating message that keeps the blue bar and spinner icon.

<img width="728" alt="screen shot 2017-03-16 at 10 01 34 am" src="https://cloud.githubusercontent.com/assets/789137/24008751/c41257be-0a2f-11e7-9cb1-b9b91c477d74.png">

Video: https://cloudup.com/cb59DURDDMP

To test: 
Go through an Automated Transfer via Plugins, or set the state for the transfer manually to see the updated banner.

Fixes #12085