### PR TITLE
Happychat: Filter out forOperator messages from transcript load

### DIFF
--- a/client/state/happychat/reducer.js
+++ b/client/state/happychat/reducer.js
@@ -77,6 +77,12 @@ const timeline = ( state = [], action ) => {
 				if ( ! message.id ) {
 					return false;
 				}
+
+				// if meta.forOperator is set, skip so won't show to user
+				if ( get( message, 'meta.forOperator', false ) ) {
+					return false;
+				}
+
 				return ! find( state, { id: message.id } );
 			} );
 			return state.concat( map( messages, message => {


### PR DESCRIPTION
The HAPPYCHAT_RECEIVE_MESSAGE event needed to filter out
the meta.forOperator messages so they don't show to user.

Fixes 281-gh-happychat