### PR TITLE
Reader: exclude Discover from combined cards

### DIFF
--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import React from 'react';
-import { has, get } from 'lodash';
+import { has } from 'lodash';
 import ReactDom from 'react-dom';
 import closest from 'component-closest';
 import { localize } from 'i18n-calypso';
@@ -27,14 +27,7 @@ class ReaderCombinedCardPost extends React.Component {
 		post: React.PropTypes.object.isRequired,
 		streamUrl: React.PropTypes.string,
 		onClick: React.PropTypes.func,
-		isDiscover: React.PropTypes.bool,
 	};
-
-	propagateCardClick = () => {
-		// If we have an discover pick post available, send the discover pick to the full post view
-		const postToOpen = get( this.props, 'discoverPick.post' ) || this.props.post;
-		this.props.onClick( postToOpen );
-	}
 
 	handleCardClick = ( event ) => {
 		const rootNode = ReactDom.findDOMNode( this ),
@@ -66,7 +59,7 @@ class ReaderCombinedCardPost extends React.Component {
 		// programattic ignore
 		if ( ! event.defaultPrevented ) { // some child handled it
 			event.preventDefault();
-			this.propagateCardClick();
+			this.props.onClick( this.props.post );
 		}
 	}
 

--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -20,6 +20,14 @@ function hasDiscoverSlug( post, searchSlug ) {
 
 export const discoverBlogId = config( 'discover_blog_id' );
 
+export function isDiscoverBlog( blogId ) {
+	return +blogId === config( 'discover_blog_id' );
+}
+
+export function isDiscoverFeed( feedId ) {
+	return +feedId === config( 'discover_feed_id' );
+}
+
 export function isDiscoverEnabled() {
 	return userUtils.getLocaleSlug() === 'en';
 }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -39,6 +39,7 @@ import CombinedCard from 'blocks/reader-combined-card';
 import fluxPostAdapter from 'lib/reader-post-flux-adapter';
 import config from 'config';
 import { keysAreEqual } from 'lib/feed-stream-store/post-key';
+import { isDiscoverBlog, isDiscoverFeed } from 'reader/discover/helper';
 
 const ConnectedCombinedCard = fluxPostAdapter( CombinedCard );
 
@@ -96,6 +97,10 @@ function sameDay( postKey1, postKey2 ) {
 	return postKey1.localMoment.isSame( postKey2.localMoment, 'day' );
 }
 
+function isDiscoverPostKey( postKey ) {
+	return isDiscoverBlog( postKey.blogId ) || isDiscoverFeed( postKey.feedId );
+}
+
 /**
  * Takes two postKeys and combines them into a ReaderCombinedCard postKey.
  * Note: This only makes sense for postKeys from the same site
@@ -126,7 +131,9 @@ function combine( postKey1, postKey2 ) {
 const combineCards = ( postKeys ) => postKeys.reduce(
 	( accumulator, postKey ) => {
 		const lastPostKey = last( accumulator );
-		if ( sameSite( lastPostKey, postKey ) && sameDay( lastPostKey, postKey ) ) {
+		if ( sameSite( lastPostKey, postKey ) &&
+			sameDay( lastPostKey, postKey ) &&
+			! isDiscoverPostKey( postKey ) ) {
 			accumulator[ accumulator.length - 1 ] = combine( last( accumulator ), postKey );
 		} else {
 			accumulator.push( postKey );
@@ -393,7 +400,6 @@ class ReaderStream extends React.Component {
 	}
 
 	selectNextItem = () => {
-
 		// do we have a selected item? if so, just move to the next one
 		if ( this.state.selectedPostKey ) {
 			FeedStreamStoreActions.selectNextItem( this.props.postsStore.id );


### PR DESCRIPTION
As noted in #12159, we want to exclude Discover (http://wordpress.com/discover) posts from being included in combined cards.

This PR adds the exclusion for Discover and removes Discover-specific trickery from the combined card component.

### To test

Set up an empty test account and just follow Discover. None of the posts should appear in combined cards.

Check that other combined cards still function as expected.