### PR TITLE
Plugins: Jetpack, replace disconnect to manage connection link

### DIFF
--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -64,7 +64,7 @@
 }
 .plugin-action__disabled-info.info-popover {
 	float: right;
-	margin: 0 3px;
+	margin: -2px 4px 0 2px;
 }
 
 .plugin-action__disabled-info-list {

--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -45,18 +45,6 @@
 	}
 }
 
-.plugin-action__children a {
-	font-size: 11px;
-	line-height: 16px;
-	margin-right: 8px;
-	vertical-align: top;
-	text-transform: uppercase;
-}
-
-.foldable-card__content .plugin-action__children a {
-	margin-left: 12px;
-}
-
 .plugin-action .form-toggle__label .form-toggle__switch {
 	float: right;
 }

--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -45,6 +45,18 @@
 	}
 }
 
+.plugin-action__children a {
+	font-size: 11px;
+	line-height: 16px;
+	margin-right: 8px;
+	vertical-align: top;
+	text-transform: uppercase;
+}
+
+.foldable-card__content .plugin-action__children a {
+	margin-left: 12px;
+}
+
 .plugin-action .form-toggle__label .form-toggle__switch {
 	float: right;
 }

--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -20,6 +20,12 @@
 	.disconnect-jetpack-button {
 		margin-right: 0;
 	}
+
+	.plugin-action__label {
+		@include breakpoint( '<480px' ) {
+			color: $gray-dark;
+		}
+	}
 }
 
 .plugin-action .toggle__switch {

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -73,10 +73,10 @@ export class PluginActivateToggle extends Component {
 						className="plugin-activate-toggle__link"
 						onClick={ this.trackManageConnectionLink }
 						href={ '/settings/general/' + site.slug }>
-						{ translate( 'Manage Connection', { context: 'manage Jetpack connnection settings link' } ) }
+						{ translate( 'Manage Connection', { comment: 'manage Jetpack connnection settings link' } ) }
 					</a> }
 					{ disabled && <span className="plugin-activate-toggle__disabled">
-						{ translate( 'Manage Connection', { context: 'manage Jetpack connnection settings link' } ) }
+						{ translate( 'Manage Connection', { comment: 'manage Jetpack connnection settings link' } ) }
 					</span> }
 				</PluginAction>
 			);

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -4,6 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -51,6 +52,32 @@ export class PluginActivateToggle extends Component {
 		recordGAEvent( 'Plugins', 'Clicked Manage Jetpack Connection Link', 'Plugin Name', 'jetpack' );
 	}
 
+	manageConnectionLink() {
+		const { disabled, translate, site } = this.props;
+		if ( disabled ) {
+			return (
+				<span className="plugin-activate-toggle__disabled">
+					{ translate( 'Manage Connection', { comment: 'manage Jetpack connnection settings link' } ) }
+					<span className="plugin-activate-toggle__icon"><Gridicon icon="cog" size={ 18 } /></span>
+				</span>
+			);
+		}
+
+		return (
+			<span className="plugin-activate-toggle__link">
+				<a onClick={ this.trackManageConnectionLink }
+					href={ '/settings/general/' + site.slug } >
+					{ translate( 'Manage Connection ', { comment: 'manage Jetpack connnection settings link' } ) }
+				</a>
+				<a className="plugin-activate-toggle__icon"
+					onClick={ this.trackManageConnectionLink }
+					href={ '/settings/general/' + site.slug } >
+					<Gridicon icon="cog" size={ 18 } />
+				</a>
+			</span>
+		);
+	}
+
 	render() {
 		const { site, plugin, disabled, translate } = this.props;
 
@@ -68,16 +95,7 @@ export class PluginActivateToggle extends Component {
 				<PluginAction
 					className="plugin-activate-toggle"
 					htmlFor={ 'disconnect-jetpack-' + site.ID }
-					>
-					{ ! disabled && <a
-						className="plugin-activate-toggle__link"
-						onClick={ this.trackManageConnectionLink }
-						href={ '/settings/general/' + site.slug }>
-						{ translate( 'Manage Connection', { comment: 'manage Jetpack connnection settings link' } ) }
-					</a> }
-					{ disabled && <span className="plugin-activate-toggle__disabled">
-						{ translate( 'Manage Connection', { comment: 'manage Jetpack connnection settings link' } ) }
-					</span> }
+					>{ this.manageConnectionLink() }
 				</PluginAction>
 			);
 		}

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -46,6 +46,11 @@ export class PluginActivateToggle extends Component {
 		}
 	};
 
+	trackManageConnectionLink = () => {
+		const { recordGoogleEvent: recordGAEvent } = this.props;
+		recordGAEvent( 'Plugins', 'Clicked Manage Jetpack Connection Link', 'Plugin Name', 'jetpack' );
+	}
+
 	render() {
 		const { site, plugin, disabled, translate } = this.props;
 
@@ -64,7 +69,9 @@ export class PluginActivateToggle extends Component {
 					className="plugin-activate-toggle"
 					htmlFor={ 'disconnect-jetpack-' + site.ID }
 					>
-					<a href={ '/settings/general/' + site.slug }>
+					<a
+						onClick={ this.trackManageConnectionLink }
+						href={ '/settings/general/' + site.slug }>
 						{ translate( 'Manage Connection', { context: 'manage Jetpack connnection settings link' } ) }
 					</a>
 				</PluginAction>

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -69,11 +69,15 @@ export class PluginActivateToggle extends Component {
 					className="plugin-activate-toggle"
 					htmlFor={ 'disconnect-jetpack-' + site.ID }
 					>
-					<a
+					{ ! disabled && <a
+						className="plugin-activate-toggle__link"
 						onClick={ this.trackManageConnectionLink }
 						href={ '/settings/general/' + site.slug }>
 						{ translate( 'Manage Connection', { context: 'manage Jetpack connnection settings link' } ) }
-					</a>
+					</a> }
+					{ disabled && <span className="plugin-activate-toggle__disabled">
+						{ translate( 'Manage Connection', { context: 'manage Jetpack connnection settings link' } ) }
+					</span> }
 				</PluginAction>
 			);
 		}

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -11,7 +11,6 @@ import { localize } from 'i18n-calypso';
 import PluginsActions from 'lib/plugins/actions';
 import PluginsLog from 'lib/plugins/log-store';
 import PluginAction from 'my-sites/plugins/plugin-action/plugin-action';
-import DisconnectJetpackButton from 'my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 
 export class PluginActivateToggle extends Component {
@@ -48,7 +47,7 @@ export class PluginActivateToggle extends Component {
 	};
 
 	render() {
-		const { site, plugin, isMock, disabled, translate } = this.props;
+		const { site, plugin, disabled, translate } = this.props;
 
 		if ( ! site ) {
 			return null;
@@ -65,12 +64,9 @@ export class PluginActivateToggle extends Component {
 					className="plugin-activate-toggle"
 					htmlFor={ 'disconnect-jetpack-' + site.ID }
 					>
-					<DisconnectJetpackButton
-						disabled={ disabled || ! plugin }
-						site={ site }
-						redirect="/plugins/jetpack"
-						isMock={ isMock }
-						/>
+					<a href={ '/settings/general/' + site.slug }>
+						{ translate( 'Manage Connection', { context: 'manage Jetpack connnection settings link' } ) }
+					</a>
 				</PluginAction>
 			);
 		}

--- a/client/my-sites/plugins/plugin-activate-toggle/style.scss
+++ b/client/my-sites/plugins/plugin-activate-toggle/style.scss
@@ -5,10 +5,43 @@
 .plugin-activate-toggle__link {
 	font-size: 11px;
 	line-height: 16px;
-	margin-right: 8px;
+	margin-right: 12px;
 	vertical-align: top;
 	text-transform: uppercase;
+	color: $gray;
+
+	@include breakpoint( '<480px' ) {
+		color: $gray-dark;
+	}
+}
+.plugin-activate-toggle__link:hover {
+	color: $link-highlight;
 }
 .plugin-activate-toggle__disabled {
-	color: 	lighten( $gray, 30% );
+	color: lighten( $gray, 30% );
+}
+.plugin-activate-toggle__link {
+	a {
+		color: currentcolor;
+		line-height: 18px;
+		vertical-align: top;
+		@include breakpoint( '<480px' ) {
+			color: $gray-dark;
+		}
+	}
+	.plugin-activate-toggle__icon {
+		@include breakpoint( '<480px' ) {
+			color: $gray;
+		}
+	}
+}
+
+.plugin-activate-toggle__icon {
+	display: inline-block;
+	vertical-align: inherit;
+	float: right;
+
+	.gridicons-cog {
+		transform: translate(.5px, .5px);
+	}
 }

--- a/client/my-sites/plugins/plugin-activate-toggle/style.scss
+++ b/client/my-sites/plugins/plugin-activate-toggle/style.scss
@@ -1,16 +1,14 @@
-.plugin-activate-toggle .disconnect-jetpack-button {
-	font-size: 11px;
-	font-weight: 400;
-	color: $alert-red;
-	text-transform: uppercase;
-
-	&:disabled,
-	&:disabled:hover {
-		color: lighten( $gray, 30% );
-		cursor: default;
-	}
-}
-
 .plugin-activate-toggle .plugin-action__children {
 	float: none;
+}
+.plugin-activate-toggle__disabled,
+.plugin-activate-toggle__link {
+	font-size: 11px;
+	line-height: 16px;
+	margin-right: 8px;
+	vertical-align: top;
+	text-transform: uppercase;
+}
+.plugin-activate-toggle__disabled {
+	color: 	lighten( $gray, 30% );
 }

--- a/client/my-sites/plugins/plugin-activate-toggle/style.scss
+++ b/client/my-sites/plugins/plugin-activate-toggle/style.scss
@@ -40,7 +40,7 @@
 	display: inline-block;
 	vertical-align: inherit;
 	float: right;
-	padding-right: 4px;
+	margin: -1px 3px 0 -1px;
 
 	.gridicons-cog {
 		transform: translate(.5px, .5px);

--- a/client/my-sites/plugins/plugin-activate-toggle/style.scss
+++ b/client/my-sites/plugins/plugin-activate-toggle/style.scss
@@ -40,6 +40,7 @@
 	display: inline-block;
 	vertical-align: inherit;
 	float: right;
+	padding-right: 4px;
 
 	.gridicons-cog {
 		transform: translate(.5px, .5px);

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -131,7 +131,6 @@
 	.plugin-action__label {
 		@include breakpoint( '<480px' ) {
 			flex-grow: 2;
-			color: $gray-dark;
 			font-size: 11px;
 		}
 	}

--- a/client/my-sites/plugins/plugin-remove-button/style.scss
+++ b/client/my-sites/plugins/plugin-remove-button/style.scss
@@ -7,7 +7,15 @@
 	text-transform: uppercase;
 	display: block;
 }
-.plugin-site__actions .plugin-remove-button__remove{
+
+.plugin-remove-button__remove-link {
+	margin-left:12px;
+}
+.plugin-meta__actions .plugin-remove-button__remove-link {
+	margin-left: 0;
+}
+
+.plugin-site__actions .plugin-remove-button__remove {
 	margin-top: 0;
 	padding: 16px;
 }

--- a/client/my-sites/plugins/plugin-remove-button/style.scss
+++ b/client/my-sites/plugins/plugin-remove-button/style.scss
@@ -21,7 +21,7 @@
 }
 .plugin-remove-button__remove-icon {
 	display: block;
-	margin-top: -1px;
+	margin: -2px 3px 0;
 
 	.gridicons-trash {
 		color: $gray;

--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -43,6 +43,11 @@
 	.site__content {
 		padding: 0;
 	}
+
+	.plugin-activate-toggle__disabled,
+	.plugin-activate-toggle__link {
+		margin-left: 12px;
+	}
 }
 
 .plugin-site-jetpack__embed-action {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/12238

Replace the disconnect link with Manage Connection link. 

This is what it looks like now 

## /plugins/site.com
![screen shot 2017-03-17 at 15 44 01](https://cloud.githubusercontent.com/assets/115071/24065640/f0621e58-0b29-11e7-8e62-c752f7121b56.png)
disabled (in bulk edit mode)
![screen shot 2017-03-17 at 15 44 08](https://cloud.githubusercontent.com/assets/115071/24065637/ed14f61c-0b29-11e7-9003-c95cd2e934c2.png)

## /plugins/jetpack/example.com
![screen shot 2017-03-17 at 15 44 17](https://cloud.githubusercontent.com/assets/115071/24065610/acb474e4-0b29-11e7-8fc1-40f8f45a2383.png)
![screen shot 2017-03-17 at 15 44 24](https://cloud.githubusercontent.com/assets/115071/24065681/3db79c3c-0b2a-11e7-9489-a3cb2f96196f.png)

## /plugins/jetpack
![screen_shot_2017-03-17_at_15_44_45](https://cloud.githubusercontent.com/assets/115071/24065622/c4158c5e-0b29-11e7-9453-06cdd3a90457.png)
mobile
![screen_shot_2017-03-17_at_15_44_51](https://cloud.githubusercontent.com/assets/115071/24065603/9f385f88-0b29-11e7-8284-176267b63856.png)


## Fix Remove styling
Updated remove styling to be aligned with the rest.
![screen_shot_2017-03-17_at_15_45_29](https://cloud.githubusercontent.com/assets/115071/24065554/38b6ee14-0b29-11e7-8d45-403aaaac7a84.png)
also on this view
![screen shot 2017-03-17 at 15 49 28](https://cloud.githubusercontent.com/assets/115071/24065577/5e8005b8-0b29-11e7-8609-a907f15abb7d.png)
https://guides.github.com/features/mastering-markdown/

currently it looks like this
![screen shot 2017-03-17 at 15 51 09](https://cloud.githubusercontent.com/assets/115071/24065600/959784e0-0b29-11e7-9dd5-49b87fb74f08.png)



@rickybanister can you take a look does the design look fine with you? 
