### PR TITLE
AT: adds a util function to see if at is enabled for the current site and current user

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -89,4 +89,13 @@ module.exports = {
 		defaultVariation: 'showThree',
 		allowExistingUsers: true
 	},
+	automatedTransfer1: {
+		datestamp: '20170316',
+		variations: {
+			enabled: 40,
+			disabled: 60
+		},
+		defaultVariation: 'disabled',
+		allowExistingUsers: false
+	},
 };

--- a/client/lib/automated-transfer/index.js
+++ b/client/lib/automated-transfer/index.js
@@ -28,7 +28,7 @@ export function isATEnabledForCurrentSite() {
 
 	// Site has Business plan
 	const site = require( 'lib/sites-list' )().getSelectedSite();
-	const planSlug = get( site, 'product_slug' );
+	const planSlug = get( site, 'plan.product_slug' );
 	if ( planSlug !== PLAN_BUSINESS ) {
 		return false;
 	}

--- a/client/lib/automated-transfer/index.js
+++ b/client/lib/automated-transfer/index.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+/**
+ * Internal dependencies
+ */
+import { isEnabled } from 'config';
+import { PLAN_BUSINESS } from 'lib/plans/constants';
+import { userCan } from 'lib/site/utils';
+
+/**
+ * Returns true if Automated Transfer is enabled for the current site and current user.
+ * @returns {Boolean} true if enabled for the current site and current user
+ */
+export function isATEnabledForCurrentSite() {
+	// don't let this explode in SSR'd envs
+	if ( typeof window !== 'object' ) {
+		return false;
+	}
+
+	// Feature must be enabled on environment
+	if ( ! isEnabled( 'automated-transfer' ) ) {
+		return false;
+	}
+
+	const abtest = require( 'lib/abtest' ).abtest;
+
+	// Site has Business plan
+	const site = require( 'lib/sites-list' )().getSelectedSite();
+	const planSlug = get( site, 'product_slug' );
+	if ( planSlug !== PLAN_BUSINESS ) {
+		return false;
+	}
+
+	// Current User can manage site
+	const canManageSite = userCan( 'manage_options', site );
+	if ( ! canManageSite ) {
+		return false;
+	}
+
+	// Gate to 40% roll. If we modify this value, we need a new test name
+	// in active-tests.js
+	return abtest( 'automatedTransfer1' ) === 'enabled';
+}

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -24,6 +24,7 @@ import { isJetpackSite, getSiteSlug } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import ThemePreview from './theme-preview';
 import config from 'config';
+import { isATEnabledForCurrentSite } from 'lib/automated-transfer';
 
 const ThemesSearchCard = config.isEnabled( 'manage/themes/magic-search' )
 	? require( './themes-magic-search-card' )
@@ -126,7 +127,7 @@ const ThemeShowcase = React.createClass( {
 			config.isEnabled( 'manage/themes/upload' ) &&
 			isLoggedIn &&
 			! isMultisite &&
-			( isJetpack || config.isEnabled( 'automated-transfer' ) )
+			( isJetpack || isATEnabledForCurrentSite() )
 		);
 	},
 


### PR DESCRIPTION
This PR adds a new util that lets us know if we should let a user start AT for the current site and current user. I'll follow up with more PRs for swapping out the current plain config check usage.

### Testing Instructions
- Navigate to http://calypso.localhost:3000/design/:siteID: (where siteID is a site that is AT ready)
- Set `localStorage.debug = 'calypso:abtests'`
- Using the bug badge abtest helper set `automatedTransfer1` to disabled
- No Upload Themes button should be shown
- Using the bug badge abtest helper set `automatedTransfer1` to enabled
- Upload Themes button should be shown
