### PR TITLE
Jetpack Plans: Add product API key to purchase page

### DIFF
--- a/client/me/purchases/api-keys/index.jsx
+++ b/client/me/purchases/api-keys/index.jsx
@@ -9,6 +9,8 @@ import React, { Component } from 'react';
  */
 import Card from 'components/card';
 import ClipboardButtonInput from 'components/clipboard-button-input';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
 import QueryPluginKeys from 'components/data/query-plugin-keys';
 import { getPurchase, isDataLoading } from '../utils';
 import { isJetpackPlan, isFreeJetpackPlan } from 'lib/products-values';
@@ -41,11 +43,15 @@ class ManagePurchaseApiKeys extends Component {
 			<Card>
 				<QueryPluginKeys siteId={ selectedSite.ID } />
 				{ pluginList.map( ( plugin, i ) => {
+					if ( 'vaultpress' === plugin.slug )
+						plugin.key = '5bGeNE9vQceyS2VL2ZmIbL4bdaaa3vVR5Omu4kZ311';
+					else
+						plugin.key = '0078qyIuSZow';
 					return (
-						<p key={ i }>
-							{ this.renderPluginLabel( plugin.slug ) }
-							<ClipboardButtonInput value={ plugin.key } />
-						</p>
+						<FormFieldset key={ i }>
+							<FormLabel htmlFor={ `plugin-${ plugin.slug }` }>{ this.renderPluginLabel( plugin.slug ) }</FormLabel>
+							<ClipboardButtonInput id={ `plugin-${ plugin.slug }` } value={ plugin.key } />
+						</FormFieldset>
 					);
 				} ) }
 			</Card>

--- a/client/me/purchases/api-keys/index.jsx
+++ b/client/me/purchases/api-keys/index.jsx
@@ -1,0 +1,60 @@
+/**
+ * External Dependencies
+ */
+import { connect } from 'react-redux';
+import React, { Component } from 'react';
+
+/**
+ * Internal Dependencies
+ */
+import Card from 'components/card';
+import ClipboardButtonInput from 'components/clipboard-button-input';
+import QueryPluginKeys from 'components/data/query-plugin-keys';
+import { getPurchase, isDataLoading } from '../utils';
+import { isJetpackPlan, isFreeJetpackPlan } from 'lib/products-values';
+import { getPluginsForSite } from 'state/plugins/premium/selectors';
+
+class ManagePurchaseApiKeys extends Component {
+	renderPluginLabel( slug ) {
+		switch ( slug ) {
+			case 'vaultpress':
+				return 'VaultPress';
+			case 'akismet':
+				return 'Akismet';
+			case 'polldaddy':
+				return 'Polldaddy';
+		}
+	}
+
+	render() {
+		if ( isDataLoading( this.props ) || ! this.props.selectedSite ) {
+			return null;
+		}
+
+		const { selectedSite, pluginList } = this.props;
+		const purchase = getPurchase( this.props );
+		if ( ! isJetpackPlan( purchase ) || isFreeJetpackPlan( purchase ) ) {
+			return null;
+		}
+
+		return (
+			<Card>
+				<QueryPluginKeys siteId={ selectedSite.ID } />
+				{ pluginList.map( ( plugin, i ) => {
+					return (
+						<p key={ i }>
+							{ this.renderPluginLabel( plugin.slug ) }
+							<ClipboardButtonInput value={ plugin.key } />
+						</p>
+					);
+				} ) }
+			</Card>
+		);
+	}
+}
+
+export default connect(
+	( state, props ) => ( {
+		pluginList: getPluginsForSite( state, props.selectedSite.ID ),
+	} )
+)( ManagePurchaseApiKeys );

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -535,6 +535,19 @@ const ManagePurchase = React.createClass( {
 		}
 	},
 
+	renderPlanDetails() {
+		if ( ! config.isEnabled( 'me/purchases-v2' ) ) {
+			return null;
+		}
+
+		return (
+			<PurchasePlanDetails
+				selectedSite={ this.props.selectedSite }
+				purchaseId={ this.props.purchaseId }
+			/>
+		);
+	},
+
 	renderEditPaymentMethodNavItem() {
 		const purchase = getPurchase( this.props );
 		const { translate } = this.props;
@@ -700,10 +713,7 @@ const ManagePurchase = React.createClass( {
 					{ contactSupportToRenewMessage }
 				</Card>
 
-				<PurchasePlanDetails
-					selectedSite={ this.props.selectedSite }
-					purchaseId={ this.props.purchaseId }
-				/>
+				{ this.renderPlanDetails() }
 
 				{ expiredRenewNotice }
 				{ editPaymentMethodNavItem }

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -3,6 +3,7 @@
  */
 import classNames from 'classnames';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 import page from 'page';
 import React from 'react';
 
@@ -135,6 +136,7 @@ const ManagePurchase = React.createClass( {
 
 	renderContactSupportToRenewMessage() {
 		const purchase = getPurchase( this.props );
+		const { translate } = this.props;
 
 		if ( getSelectedSite( this.props ) ) {
 			return null;
@@ -142,7 +144,7 @@ const ManagePurchase = React.createClass( {
 
 		return (
 			<div className="manage-purchase__contact-support">
-				{ this.translate( 'You are the owner of %(purchaseName)s but because you are no longer a user on %(siteSlug)s, ' +
+				{ translate( 'You are the owner of %(purchaseName)s but because you are no longer a user on %(siteSlug)s, ' +
 				'renewing it will require staff assistance. Please {{contactSupportLink}}contact support{{/contactSupportLink}}, ' +
 				'and consider transferring this purchase to another active user on %(siteSlug)s to avoid this issue in the future.',
 					{
@@ -159,8 +161,9 @@ const ManagePurchase = React.createClass( {
 	},
 
 	getExpiringText( purchase ) {
+		const { translate } = this.props;
 		if ( purchase.expiryStatus === 'manualRenew' ) {
-			return this.translate( '%(purchaseName)s will expire and be removed from your site %(expiry)s. ' +
+			return translate( '%(purchaseName)s will expire and be removed from your site %(expiry)s. ' +
 				'Please, add a credit card if you want it to autorenew. ',
 				{
 					args: {
@@ -174,7 +177,7 @@ const ManagePurchase = React.createClass( {
 			const expiryMoment = this.moment( purchase.expiryMoment );
 			const daysToExpiry = this.moment( expiryMoment.diff( this.moment() ) ).format( 'D' );
 
-			return this.translate( '%(purchaseName)s will expire and be removed from your site %(expiry)s days. ',
+			return translate( '%(purchaseName)s will expire and be removed from your site %(expiry)s days. ',
 				{
 					args: {
 						purchaseName: getName( purchase ),
@@ -184,7 +187,7 @@ const ManagePurchase = React.createClass( {
 			);
 		}
 
-		return this.translate( '%(purchaseName)s will expire and be removed from your site %(expiry)s.',
+		return translate( '%(purchaseName)s will expire and be removed from your site %(expiry)s.',
 			{
 				args: {
 					purchaseName: getName( purchase ),
@@ -217,18 +220,20 @@ const ManagePurchase = React.createClass( {
 	},
 
 	renderRenewNoticeAction() {
+		const { translate } = this.props;
 		if ( ! config.isEnabled( 'upgrades/checkout' ) || ! getSelectedSite( this.props ) ) {
 			return null;
 		}
 
 		return (
 			<NoticeAction onClick={ this.handleRenew }>
-				{ this.translate( 'Renew Now' ) }
+				{ translate( 'Renew Now' ) }
 			</NoticeAction>
 		);
 	},
 
 	renderCreditCardExpiringNotice() {
+		const { translate, selectedSite } = this.props;
 		const purchase = getPurchase( this.props ),
 			{ payment: { creditCard } } = purchase;
 
@@ -243,8 +248,8 @@ const ManagePurchase = React.createClass( {
 					showDismiss={ false }
 					status={ showCreditCardExpiringWarning( purchase ) ? 'is-error' : 'is-info' }>
 					{
-						this.translate( 'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. ' +
-							'Please {{a}}update your payment information{{/a}}.', {
+						translate( 'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s ' +
+							'– before the next renewal. Please {{a}}update your payment information{{/a}}.', {
 								args: {
 									cardType: creditCard.type.toUpperCase(),
 									cardNumber: creditCard.number,
@@ -252,7 +257,7 @@ const ManagePurchase = React.createClass( {
 								},
 								components: {
 									a: canEditPaymentDetails( purchase )
-										? <a href={ getEditCardDetailsPath( this.props.selectedSite, purchase ) } />
+										? <a href={ getEditCardDetailsPath( selectedSite, purchase ) } />
 										: <span />
 								}
 							}
@@ -304,12 +309,13 @@ const ManagePurchase = React.createClass( {
 	},
 
 	renderPrice() {
+		const { translate } = this.props;
 		const purchase = getPurchase( this.props ),
 			{ amount, currencyCode, currencySymbol, productSlug } = purchase,
-			period = productSlug && isMonthly( productSlug ) ? this.translate( 'month' ) : this.translate( 'year' );
+			period = productSlug && isMonthly( productSlug ) ? translate( 'month' ) : translate( 'year' );
 
 		if ( isOneTimePurchase( purchase ) ) {
-			return this.translate( '%(currencySymbol)s%(amount)f %(currencyCode)s {{period}}(one-time){{/period}}', {
+			return translate( '%(currencySymbol)s%(amount)f %(currencyCode)s {{period}}(one-time){{/period}}', {
 				args: { amount, currencyCode, currencySymbol },
 				components: {
 					period: <span className="manage-purchase__time-period" />
@@ -318,10 +324,10 @@ const ManagePurchase = React.createClass( {
 		}
 
 		if ( isIncludedWithPlan( purchase ) ) {
-			return this.translate( 'Free with Plan' );
+			return translate( 'Free with Plan' );
 		}
 
-		return this.translate( '%(currencySymbol)s%(amount)f %(currencyCode)s {{period}}/ %(period)s{{/period}}', {
+		return translate( '%(currencySymbol)s%(amount)f %(currencyCode)s {{period}}/ %(period)s{{/period}}', {
 			args: {
 				amount,
 				currencyCode,
@@ -336,6 +342,7 @@ const ManagePurchase = React.createClass( {
 
 	renderPaymentInfo() {
 		const purchase = getPurchase( this.props );
+		const { translate } = this.props;
 
 		if ( isDataLoading( this.props ) ) {
 			return <span className="manage-purchase__content manage-purchase__detail" />;
@@ -344,7 +351,7 @@ const ManagePurchase = React.createClass( {
 		if ( isIncludedWithPlan( purchase ) ) {
 			return (
 				<span className="manage-purchase__content manage-purchase__detail">
-					{ this.translate( 'Included with plan' ) }
+					{ translate( 'Included with plan' ) }
 				</span>
 			);
 		}
@@ -355,7 +362,7 @@ const ManagePurchase = React.createClass( {
 			if ( isPaidWithCreditCard( purchase ) ) {
 				paymentInfo = purchase.payment.creditCard.number;
 			} else if ( isPaidWithPayPalDirect( purchase ) ) {
-				paymentInfo = this.translate( 'expiring %(cardExpiry)s', {
+				paymentInfo = translate( 'expiring %(cardExpiry)s', {
 					args: {
 						cardExpiry: purchase.payment.expiryMoment.format( 'MMMM YYYY' )
 					},
@@ -372,22 +379,23 @@ const ManagePurchase = React.createClass( {
 
 		return (
 			<span className="manage-purchase__content manage-purchase__detail">
-				{ this.translate( 'None' ) }
+				{ translate( 'None' ) }
 			</span>
 		);
 	},
 
 	renderPaymentDetails() {
 		const purchase = getPurchase( this.props );
+		const { translate } = this.props;
 
 		if ( ! isDataLoading( this.props ) && isOneTimePurchase( purchase ) ) {
 			return null;
 		}
 
-		let paymentDetails = (
+		const paymentDetails = (
 			<span>
 				<em className="manage-purchase__content manage-purchase__detail-label">
-					{ isDataLoading( this.props ) ? null : this.translate( 'Payment method' ) }
+					{ isDataLoading( this.props ) ? null : translate( 'Payment method' ) }
 				</em>
 				{ this.renderPaymentInfo() }
 			</span>
@@ -412,18 +420,22 @@ const ManagePurchase = React.createClass( {
 
 	renderRenewButton() {
 		const purchase = getPurchase( this.props );
+		const { translate } = this.props;
 
 		if ( ! config.isEnabled( 'upgrades/checkout' ) || ! isRenewable( purchase ) || isExpired( purchase ) || isExpiring( purchase ) || ! getSelectedSite( this.props ) ) {
 			return null;
 		}
 
 		return (
-			<Button className="manage-purchase__renew-button" onClick={ this.handleRenew } compact>{ this.translate( 'Renew Now' ) }</Button>
+			<Button className="manage-purchase__renew-button" onClick={ this.handleRenew } compact>
+				{ translate( 'Renew Now' ) }
+			</Button>
 		);
 	},
 
 	renderExpiredRenewNotice() {
 		const purchase = getPurchase( this.props );
+		const { translate } = this.props;
 
 		if ( ! isRenewable( purchase ) && ! isRedeemable( purchase ) ) {
 			return null;
@@ -437,7 +449,7 @@ const ManagePurchase = React.createClass( {
 			<Notice
 				showDismiss={ false }
 				status="is-error"
-				text={ this.translate( 'This purchase has expired and is no longer in use.' ) }>
+				text={ translate( 'This purchase has expired and is no longer in use.' ) }>
 				{ this.renderRenewNoticeAction() }
 			</Notice>
 		);
@@ -445,45 +457,46 @@ const ManagePurchase = React.createClass( {
 
 	renderRenewsOrExpiresOnLabel() {
 		const purchase = getPurchase( this.props );
+		const { translate } = this.props;
 
 		if ( isExpiring( purchase ) || creditCardExpiresBeforeSubscription( purchase ) ) {
 			if ( isDomainRegistration( purchase ) ) {
-				return this.translate( 'Domain expires on' );
+				return translate( 'Domain expires on' );
 			}
 
 			if ( isSubscription( purchase ) ) {
-				return this.translate( 'Subscription expires on' );
+				return translate( 'Subscription expires on' );
 			}
 
 			if ( isOneTimePurchase( purchase ) ) {
-				return this.translate( 'Expires on' );
+				return translate( 'Expires on' );
 			}
 		}
 
 		if ( isExpired( purchase ) ) {
 			if ( isDomainRegistration( purchase ) ) {
-				return this.translate( 'Domain expired on' );
+				return translate( 'Domain expired on' );
 			}
 
 			if ( isSubscription( purchase ) ) {
-				return this.translate( 'Subscription expired on' );
+				return translate( 'Subscription expired on' );
 			}
 
 			if ( isOneTimePurchase( purchase ) ) {
-				return this.translate( 'Expired on' );
+				return translate( 'Expired on' );
 			}
 		}
 
 		if ( isDomainRegistration( purchase ) ) {
-			return this.translate( 'Domain auto-renews on' );
+			return translate( 'Domain auto-renews on' );
 		}
 
 		if ( isSubscription( purchase ) ) {
-			return this.translate( 'Subscription auto-renews on' );
+			return translate( 'Subscription auto-renews on' );
 		}
 
 		if ( isOneTimePurchase( purchase ) ) {
-			return this.translate( 'Auto-renews on' );
+			return translate( 'Auto-renews on' );
 		}
 
 		return null;
@@ -491,6 +504,7 @@ const ManagePurchase = React.createClass( {
 
 	renderRenewsOrExpiresOn() {
 		const purchase = getPurchase( this.props );
+		const { translate } = this.props;
 
 		if ( isIncludedWithPlan( purchase ) ) {
 			const attachedPlanUrl = paths.managePurchase(
@@ -500,9 +514,9 @@ const ManagePurchase = React.createClass( {
 
 			return (
 				<span>
-					{ this.translate( 'Renews with Plan' ) }
+					{ translate( 'Renews with Plan' ) }
 					<a href={ attachedPlanUrl }>
-						{ this.translate( 'View Plan' ) }
+						{ translate( 'View Plan' ) }
 					</a>
 				</span>
 			);
@@ -517,23 +531,24 @@ const ManagePurchase = React.createClass( {
 		}
 
 		if ( isOneTimePurchase( purchase ) ) {
-			return this.translate( 'Never Expires' );
+			return translate( 'Never Expires' );
 		}
 	},
 
 	renderEditPaymentMethodNavItem() {
+		const purchase = getPurchase( this.props );
+		const { translate } = this.props;
+
 		if ( ! getSelectedSite( this.props ) ) {
 			return null;
 		}
-
-		const purchase = getPurchase( this.props );
 
 		if ( canEditPaymentDetails( purchase ) ) {
 			const path = getEditCardDetailsPath( this.props.selectedSite, purchase );
 
 			const text = isRenewing( purchase )
-				? this.translate( 'Edit Payment Method' )
-				: this.translate( 'Add Credit Card' );
+				? translate( 'Edit Payment Method' )
+				: translate( 'Add Credit Card' );
 
 			return (
 				<CompactCard href={ path }>{ text }</CompactCard>
@@ -546,6 +561,7 @@ const ManagePurchase = React.createClass( {
 	renderCancelPurchaseNavItem() {
 		const purchase = getPurchase( this.props ),
 			{ id } = purchase;
+		const { translate } = this.props;
 
 		if ( ! isCancelable( purchase ) || ! getSelectedSite( this.props ) ) {
 			return null;
@@ -556,27 +572,27 @@ const ManagePurchase = React.createClass( {
 		if ( isRefundable( purchase ) ) {
 			if ( isDomainRegistration( purchase ) ) {
 				if ( isRenewal( purchase ) ) {
-					text = this.translate( 'Contact Support to Cancel Domain and Refund' );
+					text = translate( 'Contact Support to Cancel Domain and Refund' );
 					link = support.CALYPSO_CONTACT;
 				} else {
-					text = this.translate( 'Cancel Domain and Refund' );
+					text = translate( 'Cancel Domain and Refund' );
 				}
 			}
 
 			if ( isSubscription( purchase ) ) {
-				text = this.translate( 'Cancel Subscription and Refund' );
+				text = translate( 'Cancel Subscription and Refund' );
 			}
 
 			if ( isOneTimePurchase( purchase ) ) {
-				text = this.translate( 'Cancel and Refund' );
+				text = translate( 'Cancel and Refund' );
 			}
 		} else {
 			if ( isDomainRegistration( purchase ) ) {
-				text = this.translate( 'Cancel Domain' );
+				text = translate( 'Cancel Domain' );
 			}
 
 			if ( isSubscription( purchase ) ) {
-				text = this.translate( 'Cancel Subscription' );
+				text = translate( 'Cancel Subscription' );
 			}
 		}
 
@@ -590,6 +606,7 @@ const ManagePurchase = React.createClass( {
 	renderCancelPrivacyProtection() {
 		const purchase = getPurchase( this.props ),
 			{ id } = purchase;
+		const { translate } = this.props;
 
 		if ( isExpired( purchase ) || ! hasPrivacyProtection( purchase ) || ! getSelectedSite( this.props ) ) {
 			return null;
@@ -597,12 +614,13 @@ const ManagePurchase = React.createClass( {
 
 		return (
 			<CompactCard href={ paths.cancelPrivacyProtection( this.props.selectedSite.slug, id ) }>
-				{ this.translate( 'Cancel Privacy Protection' ) }
+				{ translate( 'Cancel Privacy Protection' ) }
 			</CompactCard>
 		);
 	},
 
 	renderPurchaseDetail() {
+		const { translate } = this.props;
 		let classes,
 			purchase,
 			purchaseTypeSeparator,
@@ -665,7 +683,7 @@ const ManagePurchase = React.createClass( {
 					<ul className="manage-purchase__meta">
 						<li>
 							<em className="manage-purchase__content manage-purchase__detail-label">
-								{ isDataLoading( this.props ) ? null : this.translate( 'Price' ) }
+								{ isDataLoading( this.props ) ? null : translate( 'Price' ) }
 							</em>
 							<span className="manage-purchase__content manage-purchase__detail">{ price }</span>
 						</li>
@@ -731,4 +749,4 @@ export default connect(
 		selectedPurchase: getByPurchaseId( state, props.purchaseId ),
 		selectedSite: getSelectedSiteSelector( state )
 	} )
-)( ManagePurchase );
+)( localize( ManagePurchase ) );

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -701,10 +701,8 @@ const ManagePurchase = React.createClass( {
 				</Card>
 
 				<PurchasePlanDetails
-					hasLoadedSites={ this.props.hasLoadedSites }
-					hasLoadedUserPurchasesFromServer={ this.props.hasLoadedUserPurchasesFromServer }
 					selectedSite={ this.props.selectedSite }
-					selectedPurchase={ this.props.selectedPurchase }
+					purchaseId={ this.props.purchaseId }
 				/>
 
 				{ expiredRenewNotice }

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -44,6 +44,7 @@ import HeaderCake from 'components/header-cake';
 import { isDomainRegistration } from 'lib/products-values';
 import { isRequestingSites } from 'state/sites/selectors';
 import Main from 'components/main';
+import ManagePurchaseApiKeys from '../api-keys';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import PaymentLogo from 'components/payment-logo';
@@ -680,6 +681,13 @@ const ManagePurchase = React.createClass( {
 					{ renewButton }
 					{ contactSupportToRenewMessage }
 				</Card>
+
+				<ManagePurchaseApiKeys
+					hasLoadedSites={ this.props.hasLoadedSites }
+					hasLoadedUserPurchasesFromServer={ this.props.hasLoadedUserPurchasesFromServer }
+					selectedSite={ this.props.selectedSite }
+					selectedPurchase={ this.props.selectedPurchase }
+				/>
 
 				{ expiredRenewNotice }
 				{ editPaymentMethodNavItem }

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -44,7 +44,7 @@ import HeaderCake from 'components/header-cake';
 import { isDomainRegistration } from 'lib/products-values';
 import { isRequestingSites } from 'state/sites/selectors';
 import Main from 'components/main';
-import ManagePurchaseApiKeys from '../api-keys';
+import PurchasePlanDetails from './plan-details';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import PaymentLogo from 'components/payment-logo';
@@ -682,7 +682,7 @@ const ManagePurchase = React.createClass( {
 					{ contactSupportToRenewMessage }
 				</Card>
 
-				<ManagePurchaseApiKeys
+				<PurchasePlanDetails
 					hasLoadedSites={ this.props.hasLoadedSites }
 					hasLoadedUserPurchasesFromServer={ this.props.hasLoadedUserPurchasesFromServer }
 					selectedSite={ this.props.selectedSite }

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -13,7 +13,9 @@ import ClipboardButtonInput from 'components/clipboard-button-input';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import QueryPluginKeys from 'components/data/query-plugin-keys';
-import { getPurchase, isDataLoading } from '../../utils';
+import { isRequestingSites } from 'state/sites/selectors';
+import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
+import { getPurchase, isDataLoading } from 'me/purchases/utils';
 import { isJetpackPlan, isFreeJetpackPlan } from 'lib/products-values';
 import { getPluginsForSite } from 'state/plugins/premium/selectors';
 
@@ -28,12 +30,13 @@ class PurchasePlanDetails extends Component {
 	}
 
 	render() {
+		const { selectedSite, pluginList } = this.props;
+		const purchase = getPurchase( this.props );
+
 		if ( isDataLoading( this.props ) || ! this.props.selectedSite ) {
 			return null;
 		}
 
-		const { selectedSite, pluginList } = this.props;
-		const purchase = getPurchase( this.props );
 		if ( ! isJetpackPlan( purchase ) || isFreeJetpackPlan( purchase ) ) {
 			return null;
 		}
@@ -54,8 +57,13 @@ class PurchasePlanDetails extends Component {
 	}
 }
 
+// hasLoadedSites & hasLoadedUserPurchasesFromServer are used in isDataLoading,
+// selectedPurchase is used in getPurchase
 export default connect(
 	( state, props ) => ( {
+		hasLoadedSites: ! isRequestingSites( state ),
+		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
+		selectedPurchase: getByPurchaseId( state, props.purchaseId ),
 		pluginList: getPluginsForSite( state, props.selectedSite.ID ),
 	} )
 )( localize( PurchasePlanDetails ) );

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -3,6 +3,7 @@
  */
 import { connect } from 'react-redux';
 import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -12,19 +13,17 @@ import ClipboardButtonInput from 'components/clipboard-button-input';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import QueryPluginKeys from 'components/data/query-plugin-keys';
-import { getPurchase, isDataLoading } from '../utils';
+import { getPurchase, isDataLoading } from '../../utils';
 import { isJetpackPlan, isFreeJetpackPlan } from 'lib/products-values';
 import { getPluginsForSite } from 'state/plugins/premium/selectors';
 
-class ManagePurchaseApiKeys extends Component {
+class PurchasePlanDetails extends Component {
 	renderPluginLabel( slug ) {
 		switch ( slug ) {
 			case 'vaultpress':
-				return 'VaultPress';
+				return this.props.translate( 'Backups and security scanning API key' );
 			case 'akismet':
-				return 'Akismet';
-			case 'polldaddy':
-				return 'Polldaddy';
+				return this.props.translate( 'Anti-spam API key' );
 		}
 	}
 
@@ -43,10 +42,6 @@ class ManagePurchaseApiKeys extends Component {
 			<Card>
 				<QueryPluginKeys siteId={ selectedSite.ID } />
 				{ pluginList.map( ( plugin, i ) => {
-					if ( 'vaultpress' === plugin.slug )
-						plugin.key = '5bGeNE9vQceyS2VL2ZmIbL4bdaaa3vVR5Omu4kZ311';
-					else
-						plugin.key = '0078qyIuSZow';
 					return (
 						<FormFieldset key={ i }>
 							<FormLabel htmlFor={ `plugin-${ plugin.slug }` }>{ this.renderPluginLabel( plugin.slug ) }</FormLabel>
@@ -63,4 +58,4 @@ export default connect(
 	( state, props ) => ( {
 		pluginList: getPluginsForSite( state, props.selectedSite.ID ),
 	} )
-)( ManagePurchaseApiKeys );
+)( localize( PurchasePlanDetails ) );

--- a/config/development.json
+++ b/config/development.json
@@ -100,6 +100,7 @@
 		"me/my-profile": true,
 		"me/next-steps": true,
 		"me/notifications": true,
+		"me/purchases-v2": true,
 		"me/trophies": false,
 		"nps-survey/devdocs": true,
 		"nps-survey/dev-trigger": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -75,6 +75,7 @@
 		"me/my-profile": true,
 		"me/next-steps": true,
 		"me/notifications": true,
+		"me/purchases-v2": true,
 		"me/trophies": false,
 		"network-connection": true,
 		"notifications2beta": true,


### PR DESCRIPTION
Fixes #205, #10494

This PR starts the work to show product API keys in Calypso. It creates a new component card which is displayed on the Manage Purchase page (`/me/purchases`). This only shows up on paid Jetpack sites.

**To test**

1. On a Jetpack site with a Personal, Professional, or Premium plan, view your plan `/plans/my-plan/$site`
2. Click Manage Payment (this is the easiest way to get to the purchase screen)
3. Below your site info, there should be a second card with your API keys.

![screen shot 2017-03-16 at 4 31 31 pm](https://cloud.githubusercontent.com/assets/541093/24017362/16736e22-0a66-11e7-95da-a5ab8d17eb8f.png)
(those are not real keys for the screenshot, but it does show your actual keys 😄 )

cc @johnHackworth