### PR TITLE
Editor: Fix Issue where Save Button is Enabled During MCE Initialization

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -228,7 +228,7 @@ export const PostEditor = React.createClass( {
 						setPostDate={ this.setPostDate }
 						hasContent={ this.state.hasContent }
 						isDirty={ this.state.isDirty || this.props.dirty }
-						isSaveBlocked={ this.state.isSaveBlocked }
+						isSaveBlocked={ this.isSaveBlocked() }
 						isPublishing={ this.state.isPublishing }
 						isSaving={ this.state.isSaving }
 						onPreview={ this.onPreview }
@@ -560,10 +560,7 @@ export const PostEditor = React.createClass( {
 			return;
 		}
 
-		// prevent deleting content when onSave is called prior to MCE being fully initialized
-		if ( this.state.isEditorInitialized ) {
-			edits.content = this.refs.editor.getContent();
-		}
+		edits.content = this.refs.editor.getContent();
 
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		actions.saveEdited( edits, function( error ) {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -560,7 +560,10 @@ export const PostEditor = React.createClass( {
 			return;
 		}
 
-		edits.content = this.refs.editor.getContent();
+		// prevent deleting content when onSave is called prior to MCE being fully initialized
+		if ( this.state.isEditorInitialized ) {
+			edits.content = this.refs.editor.getContent();
+		}
 
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		actions.saveEdited( edits, function( error ) {


### PR DESCRIPTION
Fixes #12246

By design, the save button ( UPDATE ) in the editor is supposed to be disabled while the post is loading and TinyMCE initializes ( #6058 for some more history ).  From the report in #12246 it appears there is a window of time when the UPDATE button is still enabled during this initialization time before TINY has fully awoken:

![save-enabled](https://cloud.githubusercontent.com/assets/22080/24018167/fb54bb8e-0a4f-11e7-8996-b45f45a34d23.gif)

If one quickly performs an edit, like in the original issue modifying a post's categories, and clicks UPDATE while MCE is still loading, a POST is sent with the edited terms, and an empty `content` attribute to the API, resulting in the post content being lost.

The proposed fix here is to add a quick check to the `onSave()` logic, that checks to see if `this.state.isEditorInitialized` is truthy prior to grabbing content from tiny mce.

__To Test__
Follow the steps in the original issue:
- Open up a published post in the editor
- QUICKLY change the category, and have your mouse hovered over the UPDATE button.  As soon as it is enabled, click it to trigger the save
- Wait for the save notice to be displayed
- Refresh the page, and note that the editor content is still shown
