### PR TITLE
Add canUpdateFiles as a site attribute

### DIFF
--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -82,6 +82,7 @@ export function getJetpackComputedAttributes( state, siteId ) {
 	return {
 		hasMinimumJetpackVersion: siteHasMinimumJetpackVersion( state, siteId ),
 		canAutoupdateFiles: canJetpackSiteAutoUpdateFiles( state, siteId ),
+		canUpdateFiles: canJetpackSiteUpdateFiles( state, siteId ),
 	};
 }
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -48,6 +48,7 @@ import {
 	isJetpackSiteMainNetworkSite,
 	getSiteAdminUrl,
 	getCustomizerUrl,
+	getJetpackComputedAttributes,
 	siteSupportsJetpackSettingsUi
 } from '../selectors';
 
@@ -2464,6 +2465,43 @@ describe( 'selectors', () => {
 			}, 77203074 );
 
 			expect( supportsJetpackSettingsUI ).to.be.true;
+		} );
+	} );
+
+	describe( 'getJetpackComputedAttributes()', () => {
+		it( 'should return undefined attributes if a site is not Jetpack', () => {
+			const state = {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							jetpack: false,
+						}
+					}
+				}
+			};
+
+			const noNewAttributes = getJetpackComputedAttributes( state, 77203074 );
+			expect( noNewAttributes.hasMinimumJetpackVersion ).to.equal( undefined );
+			expect( noNewAttributes.canAutoupdateFiles ).to.equal( undefined );
+			expect( noNewAttributes.canUpdateFiles ).to.equal( undefined );
+		} );
+
+		it( 'should return exists for attributes if a site is Jetpack', () => {
+			const state = {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							jetpack: true,
+						}
+					}
+				}
+			};
+			const noNewAttributes = getJetpackComputedAttributes( state, 77203074 );
+			expect( noNewAttributes.hasMinimumJetpackVersion ).to.have.property;
+			expect( noNewAttributes.canAutoupdateFiles ).to.have.property;
+			expect( noNewAttributes.canUpdateFiles ).to.have.property;
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes an in issue were a user that enabled autoupdates for a plugin didn't get the plugin auto updated. 

This fixes the issue because under some circumstances the site object passed to PluginAction.enableAutoupdates didn't have `site.canUpdateFiles` attribute. 

This PR fixes this by making sure that the all jetpack sites have that attribute. 
