### PR TITLE
PluginMeta: fix broken mobile styles of toggles on plugin list and single plugin view

### DIFF
--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -16,6 +16,10 @@
 			color: $alert-red;
 		}
 	}
+
+	.disconnect-jetpack-button {
+		margin-right: 0;
+	}
 }
 
 .plugin-action .toggle__switch {

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -122,17 +122,18 @@
 		}
 	}
 
-}
-
-.plugin-meta__actions .plugin-action__label {
-	@include breakpoint( '<480px' ) {
-		flex-grow: 2;
-		color: $gray-dark;
-		font-size: 11px;
+	.form-toggle__label-content {
+		@include breakpoint( '<480px' ) {
+			margin-left: 0;
+		}
 	}
-	@include breakpoint( '<660px' ) {
-		display: block;
-		padding-right: 16px;
+
+	.plugin-action__label {
+		@include breakpoint( '<480px' ) {
+			flex-grow: 2;
+			color: $gray-dark;
+			font-size: 11px;
+		}
 	}
 }
 


### PR DESCRIPTION
It also happens to fix the spacing of the Jetpack `Disconnect` button.

#### To test
* switch to this branch
* go to a JP connected site on WordPress.com
* take a look at your plugins list
 * resize your browser a bunch while keeping an eye on the toggles and the `Disconnect` Jetpack button
* take a look at a single plugin or two (including JP)
 * resize your browser a bunch while keeping an eye on the toggles and the `Disconnect` Jetpack button


#### Before
![image](https://cloud.githubusercontent.com/assets/1123119/24021315/fe501e26-0a65-11e7-8546-4a5f38d85d40.png)
![image](https://cloud.githubusercontent.com/assets/1123119/24021353/270a8d06-0a66-11e7-9584-e950f1d5157c.png)
![image](https://cloud.githubusercontent.com/assets/1123119/24021452/ac1b5052-0a66-11e7-9b38-198c0875b3c5.png)

#### After
![image](https://cloud.githubusercontent.com/assets/1123119/24021339/15d878cc-0a66-11e7-8ddd-38c6848cafd0.png)
![image](https://cloud.githubusercontent.com/assets/1123119/24021373/36a87c0a-0a66-11e7-97c1-b6b0f48f673d.png)
![image](https://cloud.githubusercontent.com/assets/1123119/24021448/a31386a0-0a66-11e7-9991-4dc76a124bdc.png)

