### PR TITLE
Reader: Combined Cards: Indented Imageless Posts

### DIFF
--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import React from 'react';
-import { get, size } from 'lodash';
+import { get, size, filter, isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -71,6 +71,7 @@ class ReaderCombinedCard extends React.Component {
 		const siteName = siteNameFromSiteAndPost( site, posts[ 0 ] );
 		const isSelectedPost = post => keysAreEqual( keyForPost( post ), selectedPostKey );
 		const followUrl = feed && feed.URL || site && site.URL;
+		const mediaCount = filter( posts, post => ! isEmpty( post.canonical_media ) ).length;
 
 		return (
 			<Card className="reader-combined-card">
@@ -113,6 +114,7 @@ class ReaderCombinedCard extends React.Component {
 							onClick={ onClick }
 							isDiscover={ isDiscover }
 							isSelected={ isSelectedPost( post ) }
+							showFeaturedAsset={ mediaCount > 0 }
 							/>
 					) ) }
 				</ul>

--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -90,7 +90,8 @@ class ReaderCombinedCardPost extends React.Component {
 
 		const classes = classnames( {
 			'reader-combined-card__post': true,
-			'is-selected': isSelected
+			'is-selected': isSelected,
+			'has-featured-asset': !! featuredAsset,
 		} );
 
 		return (

--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -27,7 +27,12 @@ class ReaderCombinedCardPost extends React.Component {
 		post: React.PropTypes.object.isRequired,
 		streamUrl: React.PropTypes.string,
 		onClick: React.PropTypes.func,
+		showFeaturedAsset: React.PropTypes.bool,
 	};
+
+	static defaultProps = {
+		showFeaturedAsset: true,
+	}
 
 	handleCardClick = ( event ) => {
 		const rootNode = ReactDom.findDOMNode( this ),
@@ -90,8 +95,8 @@ class ReaderCombinedCardPost extends React.Component {
 
 		return (
 			<li className={ classes } onClick={ this.handleCardClick }>
-				{ featuredAsset &&
-					<div className="reader-combined-card__featured-image-wrapper">
+				{ this.props.showFeaturedAsset &&
+					<div className="reader-combined-card__featured-asset-wrapper">
 						{ featuredAsset }
 					</div>
 				}

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -153,10 +153,6 @@
 			display: flex;
 		}
 	}
-
-	&.has-featured-asset {
-
-	}
 }
 
 .reader-combined-card__post-author-and-time {

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -69,6 +69,10 @@
 .reader-combined-card__featured-image-wrapper {
 	min-width: 100px;
 	margin-right: 15px;
+
+	@include breakpoint( '<660px' ) {
+		min-width: 64px;
+	}
 }
 
 .reader-combined-card .reader-featured-image {

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -66,7 +66,7 @@
 	}
 }
 
-.reader-combined-card__featured-image-wrapper {
+.reader-combined-card__featured-asset-wrapper {
 	min-width: 100px;
 	margin-right: 15px;
 
@@ -78,12 +78,6 @@
 .reader-combined-card .reader-featured-image {
 	display: block;
 	height: 64px;
-}
-
-@include breakpoint( '>660px' ) {
-	.reader-combined-card__post.indented .reader-combined-card__post-details {
-		margin-left: 115px;
-	}
 }
 
 .reader-combined-card__post-list {
@@ -114,7 +108,7 @@
 	}
 
 	&.is-placeholder {
-		.reader-combined-card__featured-image-wrapper,
+		.reader-combined-card__featured-asset-wrapper,
 		.reader-combined-card__post-title,
 		.reader-excerpt,
 		.reader-combined-card__visit-link-placeholder,

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -80,6 +80,12 @@
 	height: 64px;
 }
 
+@include breakpoint( '>660px' ) {
+	.reader-combined-card__post.indented .reader-combined-card__post-details {
+		margin-left: 115px;
+	}
+}
+
 .reader-combined-card__post-list {
 	margin-left: 0;
 }

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -66,12 +66,21 @@
 	}
 }
 
-.reader-combined-card__featured-asset-wrapper {
-	min-width: 100px;
+// Indent at all breakpoints but only if we have a featured asset
+.reader-combined-card__post.has-featured-asset .reader-combined-card__featured-asset-wrapper {
+	min-width: 64px;
 	margin-right: 15px;
 
-	@include breakpoint( '<660px' ) {
-		min-width: 64px;
+	@include breakpoint( '>660px' ) {
+		min-width: 100px;
+	}
+}
+
+// Always indent the wrapper at larger breakpoints, asset or no asset
+.reader-combined-card__featured-asset-wrapper {
+	@include breakpoint( '>660px' ) {
+		min-width: 100px;
+		margin-right: 15px;
 	}
 }
 
@@ -143,6 +152,10 @@
 		.reader-combined-card__post-author-and-time {
 			display: flex;
 		}
+	}
+
+	&.has-featured-asset {
+
 	}
 }
 


### PR DESCRIPTION
This PR implements the combined card indentation rules discussed in #12152.

*At smaller breakpoints <660px*
- Combined card posts with an image or video should be indented
- Text-only combined card posts should never be indented

Mixed card example:

<img width="498" alt="screen shot 2017-03-17 at 16 44 09" src="https://cloud.githubusercontent.com/assets/17325/24053711/d055e4f2-0b31-11e7-82f2-69749d0d1741.png">

*At larger breakpoints 660px+*
- Combined card posts with an image or video should be indented
- Text-only combined card posts should only be indented _only if_ there are other posts in the card with an image or video.

Mixed card example:

<img width="724" alt="screen shot 2017-03-17 at 16 43 55" src="https://cloud.githubusercontent.com/assets/17325/24053687/bfae2876-0b31-11e7-9d94-087215132e3d.png">

Fixes #12152.

