### PR TITLE
AT: launches automated transfer to production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -13,6 +13,7 @@
 	"features": {
 		"ad-tracking": true,
 		"apple-pay": true,
+		"automated-transfer": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -16,6 +16,7 @@
 	"features": {
 		"ad-tracking": false,
 		"apple-pay": true,
+		"automated-transfer": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,


### PR DESCRIPTION
The gate-checks were merged in https://github.com/Automattic/wp-calypso/pull/12254. This PR opens AT to new users at 40%.