### PR TITLE
AT: remove gate check for plugin controller

### DIFF
--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -10,7 +10,6 @@ import controller from 'my-sites/controller';
 import config from 'config';
 import pluginsController from './controller';
 import { getSelectedSite } from 'state/ui/selectors';
-import { isATEnabledForCurrentSite } from 'lib/automated-transfer';
 
 const nonJetpackRedirectTo = path => ( context, next ) => {
 	const site = getSelectedSite( context.store.getState() );
@@ -77,13 +76,11 @@ module.exports = function() {
 			pluginsController.plugin
 		);
 
-		if ( isATEnabledForCurrentSite() ) {
-			page( '/plugins/:plugin/eligibility/:site_id',
-				controller.siteSelection,
-				controller.navigation,
-				pluginsController.eligibility
-			);
-		}
+		page( '/plugins/:plugin/eligibility/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			pluginsController.eligibility
+		);
 
 		page.exit( '/plugins*',
 			pluginsController.resetHistory


### PR DESCRIPTION
we don't need it... we just don't link to that route if AT isn't enabled. And it seems to be causing problems for the route in staging. Going to test the removal of this gate to see if that fixes it.