### PR TITLE
Editor: Avoid scrolling when selecting a gallery on TinyMCE

### DIFF
--- a/client/components/tinymce/plugins/wpcom-view/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-view/plugin.js
@@ -187,7 +187,9 @@ function wpview( editor ) {
 			// Make sure that the editor is focused.
 			// It is possible that the editor is not focused when the mouse event fires
 			// without focus, the selection will not work properly.
-			editor.getBody().focus();
+			if ( ! focus ) {
+				editor.getBody().focus();
+			}
 
 			deselect();
 			selected = viewNode;


### PR DESCRIPTION
We use to auto focus the editor on each click (mousedown and up), this was causing the editor to scroll up even if we were already focusing it.


**Testing instructions**
 - Navigate to the editor `/post`
 - Insert a gallery at the top of the post
 - Add content to make the post scrollable
 - Insert a second gallery
 - Select the first gallery
 - Try selecting the second gallery
 - The second gallery should be selected and the editor should not scroll up