### PR TITLE
Themes: Remove client-side mime-type whitelist for theme zip uploads

### DIFF
--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -128,13 +128,14 @@ class Upload extends React.Component {
 	failureMessage() {
 		const { translate, error } = this.props;
 
-		debug( 'Error', error );
+		debug( 'Error', { error } );
 
 		const errorCauses = {
 			exists: translate( 'Upload problem: Theme already installed on site.' ),
 			already_installed: translate( 'Upload problem: Theme already installed on site.' ),
 			'Too Large': translate( 'Upload problem: Zip file too large to upload.' ),
 			incompatible: translate( 'Upload problem: Incompatible theme.' ),
+			unsupported_mime_type: translate( 'Upload problem: Not a valid zip file' ),
 		};
 
 		const errorString = JSON.stringify( error );
@@ -150,8 +151,6 @@ class Upload extends React.Component {
 		const { translate, siteId } = this.props;
 		const errorMessage = translate( 'Please drop a single zip file' );
 
-		console.log( 'files:', files );
-
 		if ( files.length !== 1 ) {
 			notices.error( errorMessage );
 			return;
@@ -159,15 +158,6 @@ class Upload extends React.Component {
 
 		// DropZone supplies an array, FilePicker supplies a FileList
 		const file = files[ 0 ] || files.item( 0 );
-
-		const validFileType = file.type === 'application/zip' || file.type === 'application/x-zip-compressed';
-		debug( 'file mime: ', file.type );
-		console.log( 'mime type:', file.type );
-
-		if ( ! validFileType ) {
-			notices.error( errorMessage );
-			return;
-		}
 		debug( 'zip file:', file );
 
 		const action = this.props.isJetpack

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -160,6 +160,7 @@ class Upload extends React.Component {
 
 		const validFileType = file.type === 'application/zip' || file.type === 'application/x-zip-compressed';
 		debug( 'file mime: ', file.type );
+		console.log( 'mime type:', file.type );
 
 		if ( ! validFileType ) {
 			notices.error( errorMessage );

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -150,6 +150,8 @@ class Upload extends React.Component {
 		const { translate, siteId } = this.props;
 		const errorMessage = translate( 'Please drop a single zip file' );
 
+		console.log( 'files:', files );
+
 		if ( files.length !== 1 ) {
 			notices.error( errorMessage );
 			return;


### PR DESCRIPTION
Fixes #12226

Because it seems that browsers can be unreliable in mime-type reporting, so rely on our server check instead.

Note: the file picker launched by clicking the drop zone only allows .zip files to be chosen, but it is possible to drag any file type into the zone.

Show 'Not a valid zip file' notice on receipt of server unsupported_mime_type error:
<img width="889" alt="screen shot 2017-03-17 at 11 48 10" src="https://cloud.githubusercontent.com/assets/7767559/24041950/a940186c-0b07-11e7-91ab-4516b00800c9.png">

**To Test**
* Go to http://calypso.localhost:3000/design/upload
* Choose a Jetpack site
* Upload all kinds of junk

**Expected**
* Appropriate errors, or success for valid theme zips

