### PR TITLE
Site Settings: Move Related Posts to the Traffic section

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -30,7 +30,6 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import Timezone from 'components/timezone';
 import JetpackSyncPanel from './jetpack-sync-panel';
 import SiteIconSetting from './site-icon-setting';
-import RelatedPosts from './related-posts';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
 import { isBusiness } from 'lib/products-values';
 import { FEATURE_NO_BRANDING } from 'lib/plans/constants';
@@ -515,9 +514,7 @@ class SiteSettingsFormGeneral extends Component {
 
 	render() {
 		const {
-			fields,
 			handleSubmitForm,
-			handleAutosavingToggle,
 			isRequestingSettings,
 			isSavingSettings,
 			site,
@@ -605,14 +602,6 @@ class SiteSettingsFormGeneral extends Component {
 					</div>
 				}
 
-				<RelatedPosts
-					onSubmitForm={ handleSubmitForm }
-					handleAutosavingToggle={ handleAutosavingToggle }
-					isSavingSettings={ isSavingSettings }
-					isRequestingSettings={ isRequestingSettings }
-					fields={ fields }
-				/>
-
 				{ this.props.site.jetpack
 					? <div>
 						<SectionHeader label={ translate( 'Jetpack' ) }>
@@ -676,10 +665,6 @@ export default wrapSettingsForm( settings => {
 		start_of_week: 0,
 		blog_public: '',
 		admin_url: '',
-		jetpack_relatedposts_allowed: false,
-		jetpack_relatedposts_enabled: false,
-		jetpack_relatedposts_show_headline: false,
-		jetpack_relatedposts_show_thumbnails: false,
 		jetpack_sync_non_public_post_stati: false,
 		holidaysnow: false,
 		amp_is_supported: false,
@@ -701,7 +686,6 @@ export default wrapSettingsForm( settings => {
 		date_format: settings.date_format,
 		time_format: settings.time_format,
 		start_of_week: settings.start_of_week,
-		jetpack_relatedposts_allowed: settings.jetpack_relatedposts_allowed,
 		jetpack_sync_non_public_post_stati: settings.jetpack_sync_non_public_post_stati,
 
 		amp_is_supported: settings.amp_is_supported,
@@ -711,14 +695,6 @@ export default wrapSettingsForm( settings => {
 
 		api_cache: settings.api_cache,
 	};
-
-	if ( settings.jetpack_relatedposts_allowed ) {
-		Object.assign( formSettings, {
-			jetpack_relatedposts_enabled: ( settings.jetpack_relatedposts_enabled ) ? 1 : 0,
-			jetpack_relatedposts_show_headline: settings.jetpack_relatedposts_show_headline,
-			jetpack_relatedposts_show_thumbnails: settings.jetpack_relatedposts_show_thumbnails
-		} );
-	}
 
 	// handling `gmt_offset` and `timezone_string` values
 	const gmt_offset = settings.gmt_offset;

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -24,7 +24,7 @@ const RelatedPosts = ( {
 		<div>
 			<SectionHeader label={ translate( 'Related Posts' ) } />
 
-			<Card className="related-posts__card site-settings">
+			<Card className="related-posts__card site-settings__traffic-settings">
 				<FormFieldset>
 					<CompactFormToggle
 						checked={ !! fields.jetpack_relatedposts_enabled }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -191,6 +191,7 @@
 
 .site-settings__general-settings,
 .site-settings__writing-settings,
+.site-settings__traffic-settings,
 .site-settings__security-settings {
 	.form-toggle__label {
 		display: flex;

--- a/client/my-sites/site-settings/traffic/main.jsx
+++ b/client/my-sites/site-settings/traffic/main.jsx
@@ -3,6 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { flowRight, partialRight, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,9 +14,16 @@ import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
 import SeoSettingsMain from 'my-sites/site-settings/seo-settings/main';
 import SeoSettingsHelpCard from 'my-sites/site-settings/seo-settings/help';
 import AnalyticsSettings from 'my-sites/site-settings/form-analytics';
+import RelatedPosts from 'my-sites/site-settings/related-posts';
+import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
 import { getSelectedSite } from 'state/ui/selectors';
 
 const SiteSettingsTraffic = ( {
+	fields,
+	handleAutosavingToggle,
+	handleSubmitForm,
+	isRequestingSettings,
+	isSavingSettings,
 	site,
 	sites,
 	upgradeToBusiness
@@ -25,6 +33,13 @@ const SiteSettingsTraffic = ( {
 		<SiteSettingsNavigation site={ site } section="traffic" />
 
 		<SeoSettingsHelpCard />
+		<RelatedPosts
+			onSubmitForm={ handleSubmitForm }
+			handleAutosavingToggle={ handleAutosavingToggle }
+			isSavingSettings={ isSavingSettings }
+			isRequestingSettings={ isRequestingSettings }
+			fields={ fields }
+		/>
 		<AnalyticsSettings />
 		<SeoSettingsMain sites={ sites } upgradeToBusiness={ upgradeToBusiness } />
 	</Main>
@@ -35,8 +50,20 @@ SiteSettingsTraffic.propTypes = {
 	upgradeToBusiness: PropTypes.func.isRequired,
 };
 
-export default connect(
+const connectComponent = connect(
 	( state ) => ( {
 		site: getSelectedSite( state ),
 	} )
+);
+
+const getFormSettings = partialRight( pick, [
+	'jetpack_relatedposts_allowed',
+	'jetpack_relatedposts_enabled',
+	'jetpack_relatedposts_show_headline',
+	'jetpack_relatedposts_show_thumbnails',
+] );
+
+export default flowRight(
+	connectComponent,
+	wrapSettingsForm( getFormSettings )
 )( SiteSettingsTraffic );


### PR DESCRIPTION
This PR moves the Related Posts card from the General section to the Traffic section. The PR is part of #11615 and fixes #12178.

Placement of **Related Posts** before:
![](https://cldup.com/HOd-VbSkjg.png)

Placement of **Related Posts** after:
![](https://cldup.com/aidK4LcnPd.png)

To test:
* Checkout this branch
* Verify the Related Posts no longer appear in `/settings/general/$site`
* Go to `/settings/traffic/$site`.
* Note: Ignore the unexpected alert you'll receive when leaving the section/page - it is already reported in #11682 and an approach to fix it has been proposed in #12006.
* Play with the Related Posts settings of a WordPress.com site and verify they save and retrieve properly.
* Play with the Related Posts settings of a Jetpack site and verify they save and retrieve properly.
* Verify there are no visual or functional regressions within the moved Related Posts card.