### PR TITLE
Themes: add whitelist for search welcome card  taxonomies

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/welcome.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/welcome.jsx
@@ -5,7 +5,7 @@ import React, { PropTypes } from 'react';
 import { noop } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
-import includes from 'lodash/includes' ;
+import intersection from 'lodash/intersection';
 
 /**
  * Internal dependencies
@@ -92,10 +92,7 @@ class MagicSearchWelcome extends React.Component {
 
 	renderTaxonomies = () => {
 		const { taxonomies } = this.props;
-
-		return taxonomies
-			.filter( ( taxonomy ) => includes( taxonomiesWhitelist, taxonomy ) )
-			.map( ( taxonomy ) => this.renderToken( taxonomy ) );
+		return intersection( taxonomies, taxonomiesWhitelist ).map( ( taxonomy ) => this.renderToken( taxonomy ) );
 	}
 
 	render() {

--- a/client/my-sites/themes/themes-magic-search-card/welcome.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/welcome.jsx
@@ -12,6 +12,14 @@ import Gridicon from 'gridicons';
 import i18n from 'i18n-calypso';
 import { taxonomyToGridicon } from './taxonomy-styling.js';
 
+const taxonomiesWhitelist = [
+	'column',
+	'feature',
+	'layout',
+	'subject',
+	'style',
+];
+
 class MagicSearchWelcome extends React.Component {
 
 	constructor( props ) {
@@ -81,12 +89,22 @@ class MagicSearchWelcome extends React.Component {
 		);
 	}
 
+	renderTaxonomies = () => {
+		return this.props.taxonomies.map(
+			( taxonomy ) => {
+				if ( taxonomiesWhitelist.indexOf( taxonomy ) !== -1 ) {
+					return this.renderToken( taxonomy );
+				}
+			}
+		);
+	}
+
 	render() {
 		return (
 			<div className="themes-magic-search-card__welcome" >
 				<div className="themes-magic-search-card__welcome-header">{ i18n.translate( 'Search by' ) }</div>
 				<div className="themes-magic-search-card__welcome-taxonomies">
-					{ this.props.taxonomies.map( taxonomy => this.renderToken( taxonomy ) ) }
+					{ this.renderTaxonomies() }
 				</div>
 			</div>
 		);

--- a/client/my-sites/themes/themes-magic-search-card/welcome.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/welcome.jsx
@@ -5,6 +5,7 @@ import React, { PropTypes } from 'react';
 import { noop } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
+import includes from 'lodash/includes' ;
 
 /**
  * Internal dependencies
@@ -90,13 +91,11 @@ class MagicSearchWelcome extends React.Component {
 	}
 
 	renderTaxonomies = () => {
-		return this.props.taxonomies.map(
-			( taxonomy ) => {
-				if ( taxonomiesWhitelist.indexOf( taxonomy ) !== -1 ) {
-					return this.renderToken( taxonomy );
-				}
-			}
-		);
+		const { taxonomies } = this.props;
+
+		return taxonomies
+			.filter( ( taxonomy ) => includes( taxonomiesWhitelist, taxonomy ) )
+			.map( ( taxonomy ) => this.renderToken( taxonomy ) );
 	}
 
 	render() {


### PR DESCRIPTION
![screen shot 2017-03-17 at 16 25 53](https://cloud.githubusercontent.com/assets/4389/24052733/684f8fd2-0b2e-11e7-906b-36986377b0a4.png)

This PR adds a whitelist for theme taxonomies shown inside the Welcome Suggestions card, while keeping them available for pure auto-complete searches.

### The Whitelist

Currently this is the currently whitelist, matching the taxonomy slugs from admin:

```
const taxonomiesWhitelist = [
	'column',
	'feature',
	'layout',
	'subject',
	'style',
];
```

### To test

1. Open `/design`
2. Try searching with strings and taxonomies, typing only
3. Try searching by clicking on the Welcome card
4. Try auto-completing colors ("blue") or picks ("staff") and see it still works.