### PR TITLE
Themes: search welcome taxonomies cfg refactoring

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/taxonomies-config.js
+++ b/client/my-sites/themes/themes-magic-search-card/taxonomies-config.js
@@ -4,10 +4,19 @@
 import { get } from 'lodash';
 
 /**
-	* This is a helper file that establishes designed visual connection between
-	* search taxonomy and its graphical representation.
-	*/
+ * Taxonomies allowed in the search welcome suggestion card.
+ */
+export const taxonomiesWelcomeWhitelist = [
+	'column',
+	'feature',
+	'layout',
+	'subject',
+	'style',
+];
 
+/**
+ * Associates an icon to each taxonomy.
+ */
 const taxonomyToGridiconMap = {
 	color: 'ink',
 	column: 'align-justify',

--- a/client/my-sites/themes/themes-magic-search-card/welcome.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/welcome.jsx
@@ -2,24 +2,15 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
-import { noop } from 'lodash';
+import { noop, intersection } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
-import intersection from 'lodash/intersection';
 
 /**
  * Internal dependencies
  */
 import i18n from 'i18n-calypso';
-import { taxonomyToGridicon } from './taxonomy-styling.js';
-
-const taxonomiesWhitelist = [
-	'column',
-	'feature',
-	'layout',
-	'subject',
-	'style',
-];
+import { taxonomiesWelcomeWhitelist, taxonomyToGridicon } from './taxonomies-config.js';
 
 class MagicSearchWelcome extends React.Component {
 
@@ -92,7 +83,7 @@ class MagicSearchWelcome extends React.Component {
 
 	renderTaxonomies = () => {
 		const { taxonomies } = this.props;
-		return intersection( taxonomies, taxonomiesWhitelist ).map( ( taxonomy ) => this.renderToken( taxonomy ) );
+		return intersection( taxonomies, taxonomiesWelcomeWhitelist ).map( ( taxonomy ) => this.renderToken( taxonomy ) );
 	}
 
 	render() {


### PR DESCRIPTION
Refactoring of the configuration bits of the Themes Magic Search Welcome Card:

1. Renamed `taxonomy-styling.js` to `taxonomies-config.js`.
2. Moved the welcome taxonomies whitelist to that file.
3. Cleanup: cleared `lodash` declaration.

Follow up from #12279. 

### To test

This is just code shuffling, so no UI change.

1. Open `/design`
2. Try searching with strings and taxonomies, typing only
3. Try searching by clicking on the Welcome card
4. Try auto-completing colors ("blue") or picks ("staff") and see it still works.