### PR TITLE
Themes: Reduce unnecessary searches

### DIFF
--- a/client/my-sites/themes/test/theme-filters.js
+++ b/client/my-sites/themes/test/theme-filters.js
@@ -57,7 +57,7 @@ describe( 'theme-filters', () => {
 
 	describe( 'getSortedFilterTerms', () => {
 		it( 'should return terms from a mixed input string', () => {
-			const terms = getSortedFilterTerms( 'blah rah color:blue yah feature: post-slider blah' );
+			const terms = getSortedFilterTerms( 'blah rah color:blue yah feature:post-slider blah' );
 			assert.equal( terms, 'blue,post-slider' );
 		} );
 

--- a/client/my-sites/themes/theme-filters.js
+++ b/client/my-sites/themes/theme-filters.js
@@ -1,7 +1,6 @@
 /**
 * Functions for working with theme search filters. The filter syntax is
 * {taxonomy}:{term}
-* allowing whitespace after the :
 *
 * Valid values for {taxonomy} and {term} are contained in the
 * `taxonomies` object.
@@ -15,7 +14,7 @@ import omitBy from 'lodash/omitBy';
 import includes from 'lodash/includes';
 
 // Regular expressions for matching "taxonomy:term" search-box syntax
-const FILTER_REGEX_STRING = '(\\w+)\\:\\s*([\\w-]+)';
+const FILTER_REGEX_STRING = '(\\w+)\\:([\\w-]*)';
 const FILTER_REGEX_GLOBAL = new RegExp( FILTER_REGEX_STRING, 'g' );
 const FILTER_REGEX_SINGLE = new RegExp( '^' + FILTER_REGEX_STRING + '$' );
 const FILTER_TAXONOMY_GROUP = 1;


### PR DESCRIPTION
Treat the string "tax:" as an invalid filter rather than a valid search string. This means that clicking on a taxonomy in the themes magic search box will not cause a jarring, pointless search, instead waiting for a valid term to be entered/clicked.

**Note** This means, for example, `color: red` is no longer valid. Instead use `color:red` without a space.