### PR TITLE
Site Settings: Fix punctuation and icons in InfoPopover Links

### DIFF
--- a/client/my-sites/site-settings/composing/after-the-deadline.jsx
+++ b/client/my-sites/site-settings/composing/after-the-deadline.jsx
@@ -184,7 +184,7 @@ class AfterTheDeadline extends Component {
 
 				<div className="composing__info-link-container site-settings__info-link-container">
 					<InfoPopover position={ 'left' }>
-						<ExternalLink href={ 'https://jetpack.com/support/spelling-and-grammar/' } target="_blank">
+						<ExternalLink href={ 'https://jetpack.com/support/spelling-and-grammar/' } icon target="_blank">
 							{ translate( 'Learn more about After the Deadline.' ) }
 						</ExternalLink>
 					</InfoPopover>

--- a/client/my-sites/site-settings/composing/after-the-deadline.jsx
+++ b/client/my-sites/site-settings/composing/after-the-deadline.jsx
@@ -185,7 +185,7 @@ class AfterTheDeadline extends Component {
 				<div className="composing__info-link-container site-settings__info-link-container">
 					<InfoPopover position={ 'left' }>
 						<ExternalLink href={ 'https://jetpack.com/support/spelling-and-grammar/' } target="_blank">
-							{ translate( 'Learn more about After the Deadline' ) }
+							{ translate( 'Learn more about After the Deadline.' ) }
 						</ExternalLink>
 					</InfoPopover>
 				</div>

--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -105,7 +105,7 @@ class PublishingTools extends Component {
 				<div className="publishing-tools__info-link-container site-settings__info-link-container">
 					<InfoPopover position={ 'left' }>
 						<ExternalLink href={ 'https://jetpack.com/support/post-by-email/' } target="_blank">
-							{ translate( 'Learn more about Post by Email' ) }
+							{ translate( 'Learn more about Post by Email.' ) }
 						</ExternalLink>
 					</InfoPopover>
 				</div>

--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -104,7 +104,7 @@ class PublishingTools extends Component {
 			<FormFieldset>
 				<div className="publishing-tools__info-link-container site-settings__info-link-container">
 					<InfoPopover position={ 'left' }>
-						<ExternalLink href={ 'https://jetpack.com/support/post-by-email/' } target="_blank">
+						<ExternalLink href={ 'https://jetpack.com/support/post-by-email/' } icon target="_blank">
 							{ translate( 'Learn more about Post by Email.' ) }
 						</ExternalLink>
 					</InfoPopover>

--- a/client/my-sites/site-settings/sso.jsx
+++ b/client/my-sites/site-settings/sso.jsx
@@ -41,7 +41,7 @@ const Sso = ( {
 					<div className="sso__info-link-container site-settings__info-link-container">
 						<InfoPopover position={ 'left' }>
 							<ExternalLink href={ 'https://jetpack.com/support/sso' } target="_blank">
-								{ translate( 'Learn more about WordPress.com Secure Sign On' ) }
+								{ translate( 'Learn more about WordPress.com Secure Sign On.' ) }
 							</ExternalLink>
 						</InfoPopover>
 					</div>

--- a/client/my-sites/site-settings/sso.jsx
+++ b/client/my-sites/site-settings/sso.jsx
@@ -40,7 +40,7 @@ const Sso = ( {
 				<FormFieldset>
 					<div className="sso__info-link-container site-settings__info-link-container">
 						<InfoPopover position={ 'left' }>
-							<ExternalLink href={ 'https://jetpack.com/support/sso' } target="_blank">
+							<ExternalLink href={ 'https://jetpack.com/support/sso' } icon target="_blank">
 								{ translate( 'Learn more about WordPress.com Secure Sign On.' ) }
 							</ExternalLink>
 						</InfoPopover>

--- a/client/my-sites/site-settings/subscriptions.jsx
+++ b/client/my-sites/site-settings/subscriptions.jsx
@@ -41,7 +41,7 @@ const Subscriptions = ( {
 				<FormFieldset>
 					<div className="subscriptions__info-link-container site-settings__info-link-container">
 						<InfoPopover position={ 'left' }>
-							<ExternalLink href={ 'https://jetpack.com/support/subscriptions' } target="_blank">
+							<ExternalLink href={ 'https://jetpack.com/support/subscriptions' } icon target="_blank">
 								{ translate( 'Learn more about Subscriptions.' ) }
 							</ExternalLink>
 						</InfoPopover>

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -53,7 +53,7 @@ class ThemeEnhancements extends Component {
 			<FormFieldset>
 				<div className="theme-enhancements__info-link-container site-settings__info-link-container">
 					<InfoPopover position={ 'left' }>
-						<ExternalLink href={ 'https://jetpack.com/support/infinite-scroll' } target="_blank">
+						<ExternalLink href={ 'https://jetpack.com/support/infinite-scroll' } icon target="_blank">
 							{ translate( 'Learn more about Infinite Scroll.' ) }
 						</ExternalLink>
 					</InfoPopover>
@@ -94,7 +94,7 @@ class ThemeEnhancements extends Component {
 			<FormFieldset>
 				<div className="theme-enhancements__info-link-container site-settings__info-link-container">
 					<InfoPopover position={ 'left' }>
-						<ExternalLink href={ 'https://jetpack.com/support/mobile-theme' } target="_blank">
+						<ExternalLink href={ 'https://jetpack.com/support/mobile-theme' } icon target="_blank">
 							{ translate( 'Learn more about Mobile Theme.' ) }
 						</ExternalLink>
 					</InfoPopover>

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -54,7 +54,7 @@ class ThemeEnhancements extends Component {
 				<div className="theme-enhancements__info-link-container site-settings__info-link-container">
 					<InfoPopover position={ 'left' }>
 						<ExternalLink href={ 'https://jetpack.com/support/infinite-scroll' } target="_blank">
-							{ translate( 'Learn more about Infinite Scroll' ) }
+							{ translate( 'Learn more about Infinite Scroll.' ) }
 						</ExternalLink>
 					</InfoPopover>
 				</div>
@@ -95,7 +95,7 @@ class ThemeEnhancements extends Component {
 				<div className="theme-enhancements__info-link-container site-settings__info-link-container">
 					<InfoPopover position={ 'left' }>
 						<ExternalLink href={ 'https://jetpack.com/support/mobile-theme' } target="_blank">
-							{ translate( 'Learn more about Mobile Theme' ) }
+							{ translate( 'Learn more about Mobile Theme.' ) }
 						</ExternalLink>
 					</InfoPopover>
 				</div>


### PR DESCRIPTION
Part of #11676 

This PR introduces the following changes

1. Adds ending periods to sentences in InfoPopovers
1. Adds `icon` property to ExternalLinks usage.

#### Testing instructions

1. Check this branch
1. Get to `/settings/writing`, `/settings/discussion` and `/settings/sso` for one of your Jetpack sites, click on every InfoLink icon to check to PopOvers content have the right punctuation and icon.


