### PR TITLE
AT: bumping the active AT variant to 100%

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -69,11 +69,11 @@ module.exports = {
 		defaultVariation: 'showThree',
 		allowExistingUsers: true
 	},
-	automatedTransfer1: {
+	automatedTransfer2: {
 		datestamp: '20170316',
 		variations: {
-			enabled: 40,
-			disabled: 60
+			enabled: 100,
+			disabled: 0
 		},
 		defaultVariation: 'disabled',
 		allowExistingUsers: false

--- a/client/lib/automated-transfer/index.js
+++ b/client/lib/automated-transfer/index.js
@@ -45,5 +45,5 @@ export function isATEnabledForCurrentSite() {
 	// Gate to 40% roll. If we modify this value, we need a new test name
 	// in active-tests.js
 	const abtest = require( 'lib/abtest' ).abtest;
-	return abtest( 'automatedTransfer1' ) === 'enabled';
+	return abtest( 'automatedTransfer2' ) === 'enabled';
 }


### PR DESCRIPTION
This PR creates a new abtest variant that bumps AT-enabled to 100%. This still targets only new users, and all of the other checks remain in place (business-plan-only).