### PR TITLE
AT: launch AT to horizon

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -15,6 +15,7 @@
 	"features": {
 		"ad-tracking": false,
 		"apple-pay": false,
+		"automated-transfer": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,


### PR DESCRIPTION
We enabled in production already, we should launch this in horizon too.