### PR TITLE
Add stats to automated transfer process, new analytics middleware

### DIFF
--- a/client/state/analytics/action-handlers/index.js
+++ b/client/state/analytics/action-handlers/index.js
@@ -1,0 +1,7 @@
+import { mergeHandlers } from 'state/data-layer/utils';
+
+import wpcom from './wpcom';
+
+export default mergeHandlers( {
+	wpcom,
+});

--- a/client/state/analytics/action-handlers/wpcom/automated-transfer/index.js
+++ b/client/state/analytics/action-handlers/wpcom/automated-transfer/index.js
@@ -1,0 +1,56 @@
+import { mergeHandlers } from 'state/data-layer/utils';
+
+import {
+	THEME_TRANSFER_INITIATE_FAILURE as FAILURE,
+	THEME_TRANSFER_INITIATE_REQUEST as REQUEST,
+	THEME_TRANSFER_INITIATE_SUCCESS as SUCCESS,
+} from 'state/action-types';
+
+import { getEligibility } from 'state/automated-transfer/selectors';
+
+import { recordTracksEvent } from 'state/analytics/actions';
+
+export const trackFailure = ( store, { plugin } ) => {
+	return recordTracksEvent(
+		'calypso_automated_transfer_inititate_failure',
+		{ plugin },
+	);
+};
+
+export const trackRequest = ( { getState }, { siteId, plugin } ) => {
+	const {
+		eligibilityHolds: holds,
+		eligibilityWarnings: warnings,
+	} = getEligibility( getState(), siteId );
+
+	if ( ! ( holds.length || warnings.length ) ) {
+		return recordTracksEvent(
+			'calypso_automatic_transfer_plugin_install_no_issues',
+			Object.assign( {},
+				plugin && { plugin_slug: plugin.slug },
+			),
+		);
+	}
+
+	return recordTracksEvent(
+		'calypso_automatic_transfer_plugin_install_ineligible',
+		Object.assign( {},
+			holds.length && { eligibilityHolds: holds.join( ', ' ) },
+			warnings.length && { eligibilityWarnings: warnings.join( ', ' ) },
+			plugin && { plugin_slug: plugin.slug },
+		),
+	);
+};
+
+export const trackSuccess = ( store, { plugin } ) => {
+	return recordTracksEvent(
+		'calypso_automated_transfer_inititate_success',
+		{ plugin },
+	);
+};
+
+export default mergeHandlers( {
+	[ FAILURE ]: [ trackFailure ],
+	[ REQUEST ]: [ trackRequest ],
+	[ SUCCESS ]: [ trackSuccess ],
+} );

--- a/client/state/analytics/action-handlers/wpcom/index.js
+++ b/client/state/analytics/action-handlers/wpcom/index.js
@@ -1,0 +1,7 @@
+import { mergeHandlers } from 'state/data-layer/utils';
+
+import automatedTransfer from './automated-transfer';
+
+export default mergeHandlers( {
+	automatedTransfer,
+} );

--- a/client/state/analytics/actions.js
+++ b/client/state/analytics/actions.js
@@ -22,7 +22,7 @@ const mergedMetaData = ( a, b ) => [
 	...get( b, 'meta.analytics', [] )
 ];
 
-const joinAnalytics = ( analytics, action ) =>
+export const joinAnalytics = ( analytics, action ) =>
 	isFunction( action )
 		? dispatch => {
 			dispatch( analytics );

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -628,6 +628,8 @@ export function initiateThemeTransfer( siteId, file, plugin ) {
 		dispatch( {
 			type: THEME_TRANSFER_INITIATE_REQUEST,
 			siteId,
+			file,
+			plugin,
 		} );
 		return wpcom.undocumented().initiateTransfer( siteId, plugin, file, ( event ) => {
 			dispatch( {
@@ -642,6 +644,7 @@ export function initiateThemeTransfer( siteId, file, plugin ) {
 					type: THEME_TRANSFER_INITIATE_SUCCESS,
 					siteId,
 					transferId: transfer_id,
+					plugin,
 				} );
 				dispatch( pollThemeTransferStatus( siteId, transfer_id ) );
 			} )
@@ -650,6 +653,7 @@ export function initiateThemeTransfer( siteId, file, plugin ) {
 					type: THEME_TRANSFER_INITIATE_FAILURE,
 					siteId,
 					error,
+					plugin,
 				} );
 			} );
 	};


### PR DESCRIPTION
This is already obsolute because someone else solved the problem at hand
in another PR, but I am proposing here a similar tree as exists in the
data-layer to attach metrics to dispatched Redux actions.

The key points of this are the fact that we can keep all analytics in
their own spot and they should be relatively discoverable by directory
and filename. Additionally we keep all of the analytics concerns
separated from the actual updates and logic happening. For example, we
don't have to sprinkle in analytics Redux actions into existing
components and data handlers

*Repeat* this is essentially a garbage unmergable PR but I would enjoy feedback on the idea it captures.