### PR TITLE
MagicSearch: blur input on empty search term.

### DIFF
--- a/client/components/suggestions/index.jsx
+++ b/client/components/suggestions/index.jsx
@@ -100,9 +100,11 @@ const Suggestions = React.createClass( {
 			case 'Enter' :
 				if ( this.state.suggestionPosition !== -1 ) {
 					this.props.suggest( this.state.currentSuggestion + ' ' );
+					return true;
 				}
 				break;
 		}
+		return false;
 	},
 
 	onMouseDown( event ) {

--- a/client/components/suggestions/index.jsx
+++ b/client/components/suggestions/index.jsx
@@ -87,6 +87,13 @@ const Suggestions = React.createClass( {
 		} );
 	},
 
+	/**
+	 * Provides keybord support for suggestings component by managing items highlith position
+	 * and calling suggestion callback when user hits Enter
+	 *
+	 * @param  {Object} event  Keybord event
+	 * @return {Bool}          true indicates suggestion was chosen and send to parent with using suggest prop callback
+	 */
 	handleKeyEvent( event ) {
 		switch ( event.key ) {
 			case 'ArrowDown' :

--- a/client/components/suggestions/index.jsx
+++ b/client/components/suggestions/index.jsx
@@ -92,7 +92,7 @@ const Suggestions = React.createClass( {
 	 * and calling suggestion callback when user hits Enter
 	 *
 	 * @param  {Object} event  Keybord event
-	 * @return {Bool}          true indicates suggestion was chosen and send to parent with using suggest prop callback
+	 * @return {Bool}          true indicates suggestion was chosen and send to parent using suggest prop callback
 	 */
 	handleKeyEvent( event ) {
 		switch ( event.key ) {

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -66,7 +66,7 @@ class ThemesMagicSearchCard extends React.Component {
 		const target = this.state.editedSearchElement !== '' ? 'suggestions' : 'welcome';
 		if ( this.refs[ target ] ) {
 			// handleKeyEvent functions return bool that infroms if suggestion was picked
-			// We need that because we cannot relly on input state because it is updated
+			// We need that because we cannot rely on input state because it is updated
 			// asynchronously and we are not able to observe what was changed during handleKeyEvent
 			inputUpdated = this.refs[ target ].handleKeyEvent( event );
 		}

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -57,13 +57,25 @@ class ThemesMagicSearchCard extends React.Component {
 	}
 
 	onKeyDown = ( event ) => {
-		this.findTextForSuggestions( event.target.value );
+		const txt = event.target.value;
+		this.findTextForSuggestions( txt );
 
+		let inputUpdated = false;
 		//We need this logic because we are working togheter with different modules.
 		//that provide suggestions to the input depending on what is currently in input
 		const target = this.state.editedSearchElement !== '' ? 'suggestions' : 'welcome';
 		if ( this.refs[ target ] ) {
-			this.refs[ target ].handleKeyEvent( event );
+			// handleKeyEvent functions return bool that infroms if suggestion was picked
+			// We need that because we cannot relly on input state because it is updated
+			// asynchronously and we are not able to observe what was changed during handleKeyEvent
+			inputUpdated = this.refs[ target ].handleKeyEvent( event );
+		}
+
+		if ( event.key === 'Enter' && ! inputUpdated ) {
+			const cursorPosition = txt.slice( 0, this.refs[ 'url-search' ].refs.searchInput.selectionStart ).length;
+			if ( txt[ cursorPosition - 1 ] === ' ' ) {
+				this.refs[ 'url-search' ].blur();
+			}
 		}
 	}
 

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -71,16 +71,20 @@ class ThemesMagicSearchCard extends React.Component {
 			inputUpdated = this.refs[ target ].handleKeyEvent( event );
 		}
 
-		if ( event.key === 'Enter' && ! inputUpdated ) {
-			const cursorPosition = txt.slice( 0, this.refs[ 'url-search' ].refs.searchInput.selectionStart ).length;
-			if ( txt[ cursorPosition - 1 ] === ' ' ) {
-				this.refs[ 'url-search' ].blur();
-			}
+		if ( event.key === 'Enter' && ! inputUpdated && this.isPreviousCharWhitespace() ) {
+			this.refs[ 'url-search' ].blur();
 		}
 	}
 
 	onClick = ( event ) => {
 		this.findTextForSuggestions( event.target.value );
+	}
+
+	// Check if char before cursor in input is a space.
+	isPreviousCharWhitespace = () => {
+		const { value, selectionStart } = this.refs[ 'url-search' ].refs.searchInput;
+		const cursorPosition = value.slice( 0, selectionStart ).length;
+		return value[ cursorPosition - 1 ] === ' ';
 	}
 
 	findEditedTokenIndex = ( tokens, cursorPosition ) => {

--- a/client/my-sites/themes/themes-magic-search-card/welcome.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/welcome.jsx
@@ -56,9 +56,11 @@ class MagicSearchWelcome extends React.Component {
 					this.props.suggestionsCallback( this.props.taxonomies[ position ] + ':' );
 					event.stopPropagation();
 					event.preventDefault();
+					return true;
 				}
 				break;
 		}
+		return false;
 	}
 
 	renderToken = ( taxonomy ) => {

--- a/client/my-sites/themes/themes-magic-search-card/welcome.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/welcome.jsx
@@ -40,6 +40,13 @@ class MagicSearchWelcome extends React.Component {
 		} );
 	}
 
+	/**
+	 * Provides keybord support for suggestings component by managing items highlith position
+	 * and calling suggestion callback when user hits Enter
+	 *
+	 * @param  {Object} event  Keybord event
+	 * @return {Bool}          true indicates suggestion was chosen and send to parent with using suggestionsCallback prop callback
+	 */
 	handleKeyEvent = ( event ) => {
 		switch ( event.key ) {
 			case 'ArrowDown' :

--- a/client/my-sites/themes/themes-magic-search-card/welcome.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/welcome.jsx
@@ -41,11 +41,11 @@ class MagicSearchWelcome extends React.Component {
 	}
 
 	/**
-	 * Provides keybord support for suggestings component by managing items highlith position
+	 * Provides keybord support for component by managing items highlith position
 	 * and calling suggestion callback when user hits Enter
 	 *
 	 * @param  {Object} event  Keybord event
-	 * @return {Bool}          true indicates suggestion was chosen and send to parent with using suggestionsCallback prop callback
+	 * @return {Bool}          true indicates suggestion was chosen and send to parent using suggestionsCallback prop callback
 	 */
 	handleKeyEvent = ( event ) => {
 		switch ( event.key ) {


### PR DESCRIPTION
### Info 
This PR changes the `Enter` key behavior in `MagicSearch`. Now if previous char was space and user clicked `Enter` the `Search` will loose focus. 

This feature was requested in #12266 
@folletto I was wondering if maybe we should expand this to loos focus on `Enter` when nothing has changed?

### Testing
Open `/design` and start typing into Input. When suggestion picked with `Enter` focus is not lost. When `Enter` is used and the previous char is different than space focus is not lost. When previous char is space and `Enter` is used focus is lost. 