### PR TITLE
MagicSearch: dont suggest when there is no valid suggestion.

### DIFF
--- a/client/components/suggestions/index.jsx
+++ b/client/components/suggestions/index.jsx
@@ -32,7 +32,8 @@ const Suggestions = React.createClass( {
 	getInitialState() {
 		return {
 			taxonomySuggestionsArray: [],
-			suggestionPosition: -1,
+			suggestionPosition: 0,
+			currentSuggestion: undefined,
 			suggestions: {},
 			filterTerm: ''
 		};
@@ -98,7 +99,7 @@ const Suggestions = React.createClass( {
 				event.preventDefault();
 				break;
 			case 'Enter' :
-				if ( this.state.suggestionPosition !== -1 ) {
+				if ( this.state.currentSuggestion !== undefined ) {
 					this.props.suggest( this.state.currentSuggestion + ' ' );
 				}
 				break;

--- a/client/components/suggestions/index.jsx
+++ b/client/components/suggestions/index.jsx
@@ -33,7 +33,7 @@ const Suggestions = React.createClass( {
 		return {
 			taxonomySuggestionsArray: [],
 			suggestionPosition: 0,
-			currentSuggestion: undefined,
+			currentSuggestion: null,
 			suggestions: {},
 			filterTerm: ''
 		};
@@ -99,7 +99,7 @@ const Suggestions = React.createClass( {
 				event.preventDefault();
 				break;
 			case 'Enter' :
-				if ( this.state.currentSuggestion !== undefined ) {
+				if ( !! this.state.currentSuggestion ) {
 					this.props.suggest( this.state.currentSuggestion + ' ' );
 				}
 				break;


### PR DESCRIPTION
### Info

When invalid taxonomy:term was typed for example `color:blabla` and cursor was inside that search term pushing `Enter` triggered substitution. Since it was not a match `undefined` was used and substituted for the invalid search term. With this PR int that case `Enter` does nothing. 

fixes #12275 

### Testing

Go to `/design` create invalid term:taxonomy search term and type `Enter`. Compare to wpcalypso current behavior 