### PR TITLE
Posts: Filter comments by Status

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -233,7 +233,7 @@ class PostCommentList extends React.Component {
 						}</span> : null }
 				</div> }
 				{ isEnabled( 'comments/filters-in-posts' ) &&
-					<SegmentedControl>
+					<SegmentedControl compact primary>
 						<SegmentedControlItem
 							selected={ commentsFilter === 'all' }
 							onClick={ this.handleFilterClick( 'all' ) }>{ translate( 'All' ) }

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -234,7 +234,7 @@ class PostCommentList extends React.Component {
 				<SegmentedControl>
 					<SegmentedControlItem
 						selected={ commentsFilter === 'all' }
-						onClick={ this.handleFilterClick( 'all' ) }>{ translate( 'All', { context: 'comment status'} ) }
+						onClick={ this.handleFilterClick( 'all' ) }>{ translate( 'All' ) }
 					</SegmentedControlItem>
 					<SegmentedControlItem
 						selected={ commentsFilter === 'approved' }

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -27,6 +27,8 @@ import {
 import PostComment from './post-comment';
 import PostCommentForm from './form';
 import CommentCount from './comment-count';
+import SegmentedControl from 'components/segmented-control';
+import SegmentedControlItem from 'components/segmented-control/item';
 
 class PostCommentList extends React.Component {
 	constructor( props ) {
@@ -210,6 +212,13 @@ class PostCommentList extends React.Component {
 							} )
 						}</span> : null }
 				</div> }
+				<SegmentedControl>
+					<SegmentedControlItem selected={ true }>{ translate( 'All' ) }</SegmentedControlItem>
+					<SegmentedControlItem>{ translate( 'Approved' ) }</SegmentedControlItem>
+					<SegmentedControlItem>{ translate( 'Pending' ) }</SegmentedControlItem>
+					<SegmentedControlItem>{ translate( 'Spam' ) }</SegmentedControlItem>
+					<SegmentedControlItem>{ translate( 'Trash' ) }</SegmentedControlItem>
+				</SegmentedControl>
 				{ this.renderCommentsList( displayedComments ) }
 				{ this.renderCommentForm() }
 			</div>

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -10,6 +10,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'config';
 import {
 	getPostCommentsTree,
 	getPostTotalCommentsCount,
@@ -231,28 +232,30 @@ class PostCommentList extends React.Component {
 							} )
 						}</span> : null }
 				</div> }
-				<SegmentedControl>
-					<SegmentedControlItem
-						selected={ commentsFilter === 'all' }
-						onClick={ this.handleFilterClick( 'all' ) }>{ translate( 'All' ) }
-					</SegmentedControlItem>
-					<SegmentedControlItem
-						selected={ commentsFilter === 'approved' }
-						onClick={ this.handleFilterClick( 'approved' ) }>{ translate( 'Approved', { context: 'comment status'} ) }
-					</SegmentedControlItem>
-					<SegmentedControlItem
-						selected={ commentsFilter === 'unapproved' }
-						onClick={ this.handleFilterClick( 'unapproved' ) }>{ translate( 'Pending', { context: 'comment status'} ) }
-					</SegmentedControlItem>
-					<SegmentedControlItem
-						selected={ commentsFilter === 'spam' }
-						onClick={ this.handleFilterClick( 'spam' ) }>{ translate( 'Spam', { context: 'comment status'} ) }
-					</SegmentedControlItem>
-					<SegmentedControlItem
-						selected={ commentsFilter === 'trash' }
-						onClick={ this.handleFilterClick( 'trash' ) }>{ translate( 'Trash', { context: 'comment status'} ) }
-					</SegmentedControlItem>
-				</SegmentedControl>
+				{ isEnabled( 'comments/filters-in-posts' ) &&
+					<SegmentedControl>
+						<SegmentedControlItem
+							selected={ commentsFilter === 'all' }
+							onClick={ this.handleFilterClick( 'all' ) }>{ translate( 'All' ) }
+						</SegmentedControlItem>
+						<SegmentedControlItem
+							selected={ commentsFilter === 'approved' }
+							onClick={ this.handleFilterClick( 'approved' ) }>{ translate( 'Approved', { context: 'comment status'} ) }
+						</SegmentedControlItem>
+						<SegmentedControlItem
+							selected={ commentsFilter === 'unapproved' }
+							onClick={ this.handleFilterClick( 'unapproved' ) }>{ translate( 'Pending', { context: 'comment status'} ) }
+						</SegmentedControlItem>
+						<SegmentedControlItem
+							selected={ commentsFilter === 'spam' }
+							onClick={ this.handleFilterClick( 'spam' ) }>{ translate( 'Spam', { context: 'comment status'} ) }
+						</SegmentedControlItem>
+						<SegmentedControlItem
+							selected={ commentsFilter === 'trash' }
+							onClick={ this.handleFilterClick( 'trash' ) }>{ translate( 'Trash', { context: 'comment status'} ) }
+						</SegmentedControlItem>
+					</SegmentedControl>
+				}
 				{ this.renderCommentsList( displayedComments ) }
 				{ this.renderCommentForm() }
 			</div>

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -234,23 +234,23 @@ class PostCommentList extends React.Component {
 				<SegmentedControl>
 					<SegmentedControlItem
 						selected={ commentsFilter === 'all' }
-						onClick={ this.handleFilterClick( 'all' ) }>{ translate( 'All' ) }
+						onClick={ this.handleFilterClick( 'all' ) }>{ translate( 'All', { context: 'comment status'} ) }
 					</SegmentedControlItem>
 					<SegmentedControlItem
 						selected={ commentsFilter === 'approved' }
-						onClick={ this.handleFilterClick( 'approved' ) }>{ translate( 'Approved' ) }
+						onClick={ this.handleFilterClick( 'approved' ) }>{ translate( 'Approved', { context: 'comment status'} ) }
 					</SegmentedControlItem>
 					<SegmentedControlItem
 						selected={ commentsFilter === 'unapproved' }
-						onClick={ this.handleFilterClick( 'unapproved' ) }>{ translate( 'Pending' ) }
+						onClick={ this.handleFilterClick( 'unapproved' ) }>{ translate( 'Pending', { context: 'comment status'} ) }
 					</SegmentedControlItem>
 					<SegmentedControlItem
 						selected={ commentsFilter === 'spam' }
-						onClick={ this.handleFilterClick( 'spam' ) }>{ translate( 'Spam' ) }
+						onClick={ this.handleFilterClick( 'spam' ) }>{ translate( 'Spam', { context: 'comment status'} ) }
 					</SegmentedControlItem>
 					<SegmentedControlItem
 						selected={ commentsFilter === 'trash' }
-						onClick={ this.handleFilterClick( 'trash' ) }>{ translate( 'Trash' ) }
+						onClick={ this.handleFilterClick( 'trash' ) }>{ translate( 'Trash', { context: 'comment status'} ) }
 					</SegmentedControlItem>
 				</SegmentedControl>
 				{ this.renderCommentsList( displayedComments ) }

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -4,8 +4,11 @@
 	clear: both;
 	margin: 36px 0 0;
 	padding-top: 11px;
-}
 
+	.segmented-control {
+		margin: 20px;
+	}
+}
 
 // Comment Counter
 .comments__count {

--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -431,7 +431,7 @@ const Post = React.createClass( {
 					<Comments
 						showCommentCount={ false }
 						post={ this.props.post }
-						commentsFilter={ this.state.commentsFilter }
+						commentsFilter={ config.isEnabled( 'comments/filters-in-posts' ) ? this.state.commentsFilter : 'approved' }
 						onFilterChange={ commentsFilter => this.setState( { commentsFilter } )}
 						onCommentsUpdate={ () => {} } />
 				}

--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -53,7 +53,8 @@ const Post = React.createClass( {
 		return {
 			showMoreOptions: false,
 			showComments: false,
-			showShare: false
+			showShare: false,
+			commentsFilter: 'all'
 		};
 	},
 
@@ -426,7 +427,14 @@ const Post = React.createClass( {
 					transitionLeaveTimeout={ 300 }>
 					{ this.buildUpdateTemplate() }
 				</ReactCSSTransitionGroup>
-				{ this.state.showComments && <Comments showCommentCount={ false } post={ this.props.post } onCommentsUpdate={ () => {} } /> }
+				{ this.state.showComments &&
+					<Comments
+						showCommentCount={ false }
+						post={ this.props.post }
+						commentsFilter={ this.state.commentsFilter }
+						onFilterChange={ commentsFilter => this.setState( { commentsFilter } )}
+						onCommentsUpdate={ () => {} } />
+				}
 				{ this.state.showShare && config.isEnabled( 'republicize' ) && <PostShare post={ this.props.post } site={ site } /> }
 			</Card>
 		);

--- a/client/state/comments/actions.js
+++ b/client/state/comments/actions.js
@@ -92,14 +92,15 @@ function commentsRequestFailure( dispatch, requestId, err ) {
  * @param {Number} postId post identifier
  * @returns {Function} thunk that requests comments for a given post
  */
-export function requestPostComments( siteId, postId ) {
+export function requestPostComments( siteId, postId, status = 'all' ) {
 	return ( dispatch, getState ) => {
 		const postCommentRequests = getPostCommentRequests( getState(), siteId, postId );
 		const oldestCommentDateForPost = getPostOldestCommentDate( getState(), siteId, postId );
 
 		const query = {
 			order: 'DESC',
-			number: NUMBER_OF_COMMENTS_PER_FETCH
+			number: NUMBER_OF_COMMENTS_PER_FETCH,
+			status
 		};
 
 		if ( oldestCommentDateForPost && oldestCommentDateForPost.toISOString ) {

--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -48,7 +48,7 @@ export const getPostTotalCommentsCount = ( state, siteId, postId ) => state.comm
 export const getPostMostRecentCommentDate = createSelector(
 	( state, siteId, postId ) => {
 		const items = getPostCommentItems( state, siteId, postId );
-		return items && items.first() ? new Date( items.first().get( 'date' ) ) : undefined
+		return items && items.first() ? new Date( items.first().get( 'date' ) ) : undefined;
 	},
 	getPostCommentItems
 );
@@ -63,7 +63,7 @@ export const getPostMostRecentCommentDate = createSelector(
 export const getPostOldestCommentDate = createSelector(
 	( state, siteId, postId ) => {
 		const items = getPostCommentItems( state, siteId, postId );
-		return items && items.last() ? new Date( items.last().get( 'date' ) ) : undefined
+		return items && items.last() ? new Date( items.last().get( 'date' ) ) : undefined;
 	},
 	getPostCommentItems
 );
@@ -76,9 +76,9 @@ export const getPostOldestCommentDate = createSelector(
  * @return {Immutable.Map<CommentId, CommentNode>} comments tree in the form of immutable map<CommentId, CommentNode>, and in addition a children array
  */
 export const getPostCommentsTree = createSelector(
-	( state, siteId, postId ) => {
+	( state, siteId, postId, status ) => {
 		const items = getPostCommentItems( state, siteId, postId );
-		return items ? buildCommentsTree( items ) : undefined;
+		return items ? buildCommentsTree( items, status ) : undefined;
 	},
 	getPostCommentItems
 );

--- a/client/state/comments/test/actions.js
+++ b/client/state/comments/test/actions.js
@@ -53,7 +53,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should not dispatch a thing if the request is already in flight', () => {
-			const requestId = createRequestId( MANY_COMMENTS_POST.siteId, MANY_COMMENTS_POST.postId, { order: 'DESC', number: NUMBER_OF_COMMENTS_PER_FETCH } );
+			const requestId = createRequestId( MANY_COMMENTS_POST.siteId, MANY_COMMENTS_POST.postId, { order: 'DESC', number: NUMBER_OF_COMMENTS_PER_FETCH, status: 'all' } );
 
 			const dispatchSpy = sinon.spy();
 			const getStateStub = sinon.stub().returns( {
@@ -83,20 +83,20 @@ describe( 'actions', () => {
 
 			nock( API_DOMAIN )
 				.get( `/rest/v1.1/sites/${ MANY_COMMENTS_POST.siteId }/posts/${ MANY_COMMENTS_POST.postId }/replies/` )
-				.query( { order: 'DESC', number: NUMBER_OF_COMMENTS_PER_FETCH } )
+				.query( { order: 'DESC', number: NUMBER_OF_COMMENTS_PER_FETCH, status: 'all' } )
 				.reply( 200, { found: 123, comments: [] } );
 
 			const reqPromise = requestPostComments( MANY_COMMENTS_POST.siteId, MANY_COMMENTS_POST.postId )( dispatchSpy, getStateStub );
 
 			expect( dispatchSpy ).to.have.been.calledWith( {
 				type: COMMENTS_REQUEST,
-				requestId: createRequestId( MANY_COMMENTS_POST.siteId, MANY_COMMENTS_POST.postId, { order: 'DESC', number: NUMBER_OF_COMMENTS_PER_FETCH } )
+				requestId: createRequestId( MANY_COMMENTS_POST.siteId, MANY_COMMENTS_POST.postId, { order: 'DESC', number: NUMBER_OF_COMMENTS_PER_FETCH, status: 'all' } )
 			} );
 
 			return reqPromise.then( () => {
 				expect( dispatchSpy ).to.have.been.calledWith( {
 					type: COMMENTS_REQUEST_SUCCESS,
-					requestId: createRequestId( MANY_COMMENTS_POST.siteId, MANY_COMMENTS_POST.postId, { order: 'DESC', number: NUMBER_OF_COMMENTS_PER_FETCH } )
+					requestId: createRequestId( MANY_COMMENTS_POST.siteId, MANY_COMMENTS_POST.postId, { order: 'DESC', number: NUMBER_OF_COMMENTS_PER_FETCH, status: 'all' } )
 				} );
 			} );
 		} );
@@ -122,20 +122,20 @@ describe( 'actions', () => {
 				.query( { order: 'DESC', number: NUMBER_OF_COMMENTS_PER_FETCH } )
 				.reply( 200, { found: 123, comments: [] } )
 				.get( `/rest/v1.1/sites/${ MANY_COMMENTS_POST.siteId }/posts/${ MANY_COMMENTS_POST.postId }/replies/` )
-				.query( { order: 'DESC', number: NUMBER_OF_COMMENTS_PER_FETCH, before: beforeDateString } )
+				.query( { order: 'DESC', number: NUMBER_OF_COMMENTS_PER_FETCH, before: beforeDateString, status: 'all' } )
 				.reply( 200, { found: 123, comments: [] } );
 
 			const reqPromise = requestPostComments( MANY_COMMENTS_POST.siteId, MANY_COMMENTS_POST.postId )( dispatchSpy, getStateSpy );
 
 			expect( dispatchSpy ).to.have.been.calledWith( {
 				type: COMMENTS_REQUEST,
-				requestId: createRequestId( MANY_COMMENTS_POST.siteId, MANY_COMMENTS_POST.postId, { order: 'DESC', number: NUMBER_OF_COMMENTS_PER_FETCH, before: new Date( beforeDateString ).toISOString() } )
+				requestId: createRequestId( MANY_COMMENTS_POST.siteId, MANY_COMMENTS_POST.postId, { order: 'DESC', number: NUMBER_OF_COMMENTS_PER_FETCH, before: new Date( beforeDateString ).toISOString(), status: 'all' } )
 			} );
 
 			return reqPromise.then( () => {
 				expect( dispatchSpy ).to.have.been.calledWith( {
 					type: COMMENTS_REQUEST_SUCCESS,
-					requestId: createRequestId( MANY_COMMENTS_POST.siteId, MANY_COMMENTS_POST.postId, { order: 'DESC', number: NUMBER_OF_COMMENTS_PER_FETCH, before: new Date( beforeDateString ).toISOString() } )
+					requestId: createRequestId( MANY_COMMENTS_POST.siteId, MANY_COMMENTS_POST.postId, { order: 'DESC', number: NUMBER_OF_COMMENTS_PER_FETCH, before: new Date( beforeDateString ).toISOString(), status: 'all' } )
 				} );
 			} );
 		} );

--- a/client/state/comments/utils.js
+++ b/client/state/comments/utils.js
@@ -33,13 +33,16 @@ export function createRequestId( siteId, postId, query ) {
  * 	children: List<id>, // Array of root level comments ids
  * }
  * @param {Immutable.List} comments list of comments (as built on state.comments.items) sorted by date in descending order
+ * @param {String} status String representing the comment status to show. Defaults to 'all'.
  * @returns {Immutable.Map} Immutable map comments tree instance of the shape Map<id, CommentNode>{ children: List<id> }
  */
-export function buildCommentsTree( comments ) {
+export function buildCommentsTree( comments, status = 'all' ) {
 	const tree = Immutable.fromJS( { children: [] } );
 
+	const filteredComments = status !== 'all' ? comments.filter( comment => comment.get( 'status' ) === status ) : comments;
+
 	return tree.withMutations( ( commentsTree ) => {
-		comments.forEach( ( comment ) => {
+		filteredComments.forEach( ( comment ) => {
 			// if the comment has a parent, but we haven't seen that parent yet, create a placeholder
 			if ( comment.get( 'parent' ) && ! commentsTree.has( comment.getIn( [ 'parent', 'ID' ] ) ) ) {
 				commentsTree.set( comment.getIn( [ 'parent', 'ID' ] ), Immutable.fromJS( {

--- a/config/development.json
+++ b/config/development.json
@@ -34,6 +34,7 @@
 		"automated-transfer": true,
 		"apple-pay": true,
 		"code-splitting": true,
+		"comments/filters-in-posts": true,
 		"community-translator": true,
 		"css-hot-reload": true,
 		"desktop-promo": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -19,6 +19,7 @@
 		"apple-pay": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
+		"comments/filters-in-posts": true,
 		"community-translator": true,
 		"desktop-promo": true,
 		"devdocs": true,


### PR DESCRIPTION
Adds filters to the comments view under a post. Works with https://github.com/Automattic/wp-calypso/pull/11964.

This is hidden under the `comments/filters-in-posts`

![fireshot capture 004 - blog posts free site wordpress co_ - http___calypso localhost_3000_post](https://cloud.githubusercontent.com/assets/233601/24111575/a3e6d408-0d75-11e7-81eb-0eef619523fc.png)

Part of #11209.