### PR TITLE
Media: Clear selected media when leaving library

### DIFF
--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -14,6 +14,7 @@ import {
 	partial,
 	some,
 	values,
+	isEmpty,
 	identity
 } from 'lodash';
 
@@ -106,6 +107,13 @@ export class EditorMediaModal extends Component {
 
 	componentDidMount() {
 		this.statsTracking = {};
+	}
+
+	componentWillMount() {
+		const { view, mediaLibrarySelectedItems, site } = this.props;
+		if ( ! isEmpty( mediaLibrarySelectedItems ) && view === ModalViews.LIST ) {
+			MediaActions.setLibrarySelectedItems( site.ID, [] );
+		}
 	}
 
 	componentWillUnmount() {

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -30,7 +30,7 @@ const EMPTY_COMPONENT = React.createClass( {
 } );
 
 describe( 'EditorMediaModal', function() {
-	let spy, translate, deleteMedia, accept, EditorMediaModal;
+	let spy, translate, deleteMedia, accept, EditorMediaModal, setLibrarySelectedItems;
 
 	translate = require( 'i18n-calypso' ).translate;
 
@@ -38,6 +38,7 @@ describe( 'EditorMediaModal', function() {
 	useFakeDom();
 	useSandbox( ( sandbox ) => {
 		spy = sandbox.spy();
+		setLibrarySelectedItems = sandbox.stub();
 		deleteMedia = sandbox.stub();
 		accept = sandbox.stub().callsArgWithAsync( 1, true );
 	} );
@@ -54,7 +55,7 @@ describe( 'EditorMediaModal', function() {
 		mockery.registerMock( 'lib/accept', accept );
 		mockery.registerMock( 'lib/analytics', { mc: { bumpStat: noop } } );
 		mockery.registerMock( 'component-closest', {} );
-		mockery.registerMock( 'lib/media/actions', { delete: deleteMedia } );
+		mockery.registerMock( 'lib/media/actions', { 'delete': deleteMedia, setLibrarySelectedItems: setLibrarySelectedItems } );
 		mockery.registerMock( 'lib/posts/actions', { blockSave: noop } );
 		mockery.registerMock( 'lib/posts/stats', {
 			recordEvent: noop,


### PR DESCRIPTION
As described in #12109, if you're currently in the Media Library with selected items, leave to open a new post, and then try to add media to that post, you'll see the same selected items. This PR adds `MediaActions.setLibrarySelectedItems( this.props.site.ID, [] );` when the Media Library component clearing the selected items so this no longer occurs. This is similar to how we handle it in the post editor ([#](https://github.com/Automattic/wp-calypso/blob/master/client/post-editor/media-modal/index.jsx#L113)).

This is also an attempt to resolve #12235. Currently, if you set a featured image for a post then open the featured image media modal, the current featured image is not selected. This can create confusion if you have a lot of media items or multiple versions of the same image. This first attempt does the following:

- Render `MediaListData` in the Editor Drawer to have access to the media items for the existing site.
- Search for the featured image for the post. If it exists, using `MediaActions.setLibrarySelectedItems` to set the featured image as selected when the modal opens.

## To test
#12109
1. Load this branch and start on http://calypso.localhost:3000/media/. 
2. Select some images in the media library.
3. Click "Add" next to Posts to start a new post.
4. Click the + icon to add an image to your new posts. Notice that the previously selected images are no longer selected.

#12235
1. Load this branch and then start a new post at http://calypso.localhost:3000/post/
2. Set a featured image for your post.
3. Once you set a featured image, click on the image again to open the media modal. The existing featured image should be selected currently.

## GIF
Clearing selected images
![selectedmedia](https://cloud.githubusercontent.com/assets/7240478/24075511/89e4513c-0be2-11e7-8c11-5621a3db2353.gif)

Featured image
![featured](https://cloud.githubusercontent.com/assets/7240478/24075512/900a9a44-0be2-11e7-9c8a-6e5b5d674d50.gif)
