### PR TITLE
rebase: post-share janitorial

### DIFF
--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -104,9 +104,9 @@ class PostShare extends Component {
 		);
 	}
 
-	dismiss() {
+	dismiss = () => {
 		this.props.dismissShareConfirmation( this.props.siteId, this.props.post.ID );
-	}
+	};
 
 	sharePost = () => {
 		this.props.sharePost( this.props.siteId, this.props.post.ID, this.state.skipped, this.state.message );


### PR DESCRIPTION
Before this patch

1) share a post
2) try to close the notice
you should get the following bug:

![image](https://cloud.githubusercontent.com/assets/77539/24085792/56fc47a4-0cd0-11e7-8c39-cf452fbf5b4b.png)

After this patch: The notice should be close when the user clicks on the cross button.