### PR TITLE
Publicize: Add/post share add schedule button

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -52,6 +52,7 @@
 @import 'blocks/reader-related-card-v2/style';
 @import 'blocks/reader-subscription-list-item/style';
 @import 'blocks/reader-visit-link/style';
+@import 'blocks/scheduler-popover/style';
 @import 'blocks/taxonomy-manager/style';
 @import 'blocks/term-form-dialog/style';
 @import 'blocks/term-tree-selector/style';

--- a/client/blocks/scheduler-popover/index.jsx
+++ b/client/blocks/scheduler-popover/index.jsx
@@ -1,0 +1,113 @@
+/**
+ * External dependencies
+ */
+import React, { cloneElement, Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { noop, pick } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getSiteGmtOffset,
+	getSiteTimezoneValue,
+} from 'state/selectors';
+import Popover from 'components/popover';
+import PostSchedule from 'components/post-schedule';
+
+class SchedulerPopover extends Component {
+	static propTypes = {
+		children: PropTypes.element,
+		gmtOffset: PropTypes.number,
+		position: PropTypes.string,
+		timezoneValue: PropTypes.string,
+
+		onDateChange: PropTypes.func,
+	};
+
+	static defaultProps = {
+		position: 'bottom left',
+		timezoneValue: '',
+		onDateChange: noop,
+	};
+
+	state = {
+		date: null,
+		show: false,
+	};
+
+	setDate = date => {
+		this.setState( { date } );
+		this.props.onDateChange( date );
+	};
+
+	closePopover = () => this.setState( { show: false } );
+
+	toggleScheduler = () => this.setState( { show: ! this.state.show } );
+
+	getPopoverReference = scheduler => ( this.schedulerReference = scheduler );
+
+	renderScheduler() {
+		const schedulerProperties = Object.assign( {}, pick( this.props, [
+			'events',
+			'posts',
+			'site',
+			'onMonthChange',
+		] ) );
+
+		return (
+			<PostSchedule
+				{ ...schedulerProperties }
+				selectedDay={ this.state.date }
+				gmtOffset={ this.props.gmtOffset }
+				timezone={ this.props.timezoneValue }
+
+				onDateChange={ this.setDate }
+			/>
+		);
+	}
+
+	renderChildrenButton() {
+		const buttonsProperties = Object.assign( {}, pick( this.props, [
+			'onClick',
+			'primary',
+			'title',
+			'tabIndex',
+		] ), {
+			onClick: this.toggleScheduler,
+			ref: this.getPopoverReference
+		} );
+
+		return cloneElement(
+			this.props.children,
+			buttonsProperties,
+		);
+	}
+
+	render() {
+		return (
+			<div className="scheduler-popover">
+				{ this.renderChildrenButton() }
+
+				<Popover
+					context={ this.schedulerReference }
+					className="scheduler-popover__popover"
+					isVisible={ this.state.show }
+					onClose={ this.closePopover }
+					position={ this.props.position }
+				>
+					<span className="scheduler-popover__scheduler">
+						{ this.renderScheduler() }
+					</span>
+				</Popover>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state, { site } ) => ( {
+		gmtOffset: getSiteGmtOffset( state, site.ID ),
+		timezoneValue: getSiteTimezoneValue( state, site.ID ),
+	} )
+ )( SchedulerPopover );

--- a/client/blocks/scheduler-popover/style.scss
+++ b/client/blocks/scheduler-popover/style.scss
@@ -1,0 +1,6 @@
+.scheduler-popover__popover .popover__inner {
+	box-sizing: border-box;
+	display: block;
+	padding: 0 16px;
+	width: 237px;
+}

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import QueryPostTypes from 'components/data/query-post-types';
 import Button from 'components/button';
+import ButtonGroup from 'components/button-group';
 import { isPublicizeEnabled } from 'state/selectors';
 import {
 	getSiteSlug,
@@ -34,6 +35,8 @@ import {
 import Banner from 'components/banner';
 import Connection from './connection';
 import { isEnabled } from 'config';
+import Gridicon from 'gridicons';
+import AsyncLoad from 'components/async-load';
 
 class PostShare extends Component {
 	static propTypes = {
@@ -49,8 +52,8 @@ class PostShare extends Component {
 	};
 
 	state = {
+		message: PostMetadata.publicizeMessage( this.props.post ) || this.props.post.title,
 		skipped: PostMetadata.publicizeSkipped( this.props.post ) || [],
-		message: PostMetadata.publicizeMessage( this.props.post ) || this.props.post.title
 	};
 
 	hasConnections() {
@@ -81,8 +84,7 @@ class PostShare extends Component {
 		return this.state.skipped.indexOf( keyring_connection_ID ) === -1;
 	}
 
-	isConnectionActive = connection =>
-		connection.status !== 'broken' && this.skipConnection( connection );
+	isConnectionActive = connection => connection.status !== 'broken' && this.skipConnection( connection );
 
 	renderServices() {
 		if ( ! this.props.site || ! this.hasConnections() ) {
@@ -100,6 +102,22 @@ class PostShare extends Component {
 	}
 
 	setMessage = message => this.setState( { message } );
+
+	dismiss = () => {
+		this.props.dismissShareConfirmation( this.props.siteId, this.props.post.ID );
+	};
+
+	sharePost = () => {
+		this.props.sharePost( this.props.siteId, this.props.post.ID, this.state.skipped, this.state.message );
+	};
+
+	isButtonDisabled() {
+		if ( this.props.requesting ) {
+			return true;
+		}
+
+		return this.props.connections.filter( this.isConnectionActive ).length < 1;
+	}
 
 	renderMessage() {
 		if ( ! this.hasConnections() ) {
@@ -120,20 +138,35 @@ class PostShare extends Component {
 		);
 	}
 
-	dismiss = () => {
-		this.props.dismissShareConfirmation( this.props.siteId, this.props.post.ID );
-	};
+	renderShareButton() {
+		const { translate } = this.props;
+		return (
+			<ButtonGroup className="post-share__share-combo">
+				<Button
+					className="post-share__button"
+					primary
+					onClick={ this.sharePost }
+					disabled={ this.isButtonDisabled() }
+				>
+					{ translate( 'Share post' ) }
+				</Button>
 
-	sharePost = () => {
-		this.props.sharePost( this.props.siteId, this.props.post.ID, this.state.skipped, this.state.message );
-	};
-
-	isButtonDisabled() {
-		if ( this.props.requesting ) {
-			return true;
-		}
-
-		return this.props.connections.filter( this.isConnectionActive ).length < 1;
+				<AsyncLoad
+					require="blocks/scheduler-popover"
+					site={ this.props.site }
+					type="button" // ButtonGroup hopes that this element should be a button.
+				>
+					<Button
+						primary
+						className="post-share__schedule-button"
+						title={ translate( 'Set date and time' ) }
+						tabIndex={ 3 }
+					>
+						<Gridicon icon="calendar" />
+					</Button>
+				</AsyncLoad>
+			</ButtonGroup>
+		);
 	}
 
 	render() {
@@ -222,14 +255,7 @@ class PostShare extends Component {
 							<div className="post-share__main">
 								<div className="post-share__form">
 									{ this.renderMessage() }
-									<Button
-										className="post-share__button"
-										primary={ true }
-										onClick={ this.sharePost }
-										disabled={ this.isButtonDisabled() }
-									>
-										{ this.props.translate( 'Share post' ) }
-									</Button>
+									{ this.renderShareButton() }
 								</div>
 
 								<div className="post-share__services">

--- a/client/my-sites/post-share/style.scss
+++ b/client/my-sites/post-share/style.scss
@@ -151,11 +151,23 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 		margin: 0;
 	}
 
-	.post-share__button{
-		width: 100%;
+	.post-share__share-combo {
+		display: flex;
 
-		@include breakpoint( ">480px" ) {
-			width: auto;
+		.post-share__button {
+			border-radius: 4px 0 0 4px;
+			padding: 5px 14px 7px;
+
+			@include breakpoint( ">480px" ) {
+				width: auto;
+			}
+		}
+
+		.post-share__schedule-button {
+			border-radius: 0 4px 4px 0;
+			padding-left: 8px;
+			padding-right: 8px;
+			margin-left: -1px;
 		}
 	}
 }


### PR DESCRIPTION
This PR adds a new block component named `<SchedulerPopover />` which combine the `<Popover />` and `<PostSchedule />` components.



![giphy 1](https://cloud.githubusercontent.com/assets/77539/24112210/cf006e92-0d66-11e7-9a69-3235fa8f0a20.gif)


The best highlights of `<SchedulerPopover />` are:

* React/Redux connection: It means the component gets its owns properties (`gtmOffset`, `timezoneValue`, etc.) through of the state-tree, so you won't get worried about getting and passing these values.
* self-controlled: you won't need to set the current state of the component such as visibility, current date. No more `onClick` bound functions, `ref` value, etc. It takes over of these states into its `state` object. However, we still have the ability to connect with properties/events if it's needed.

### Example

```es6
import AsyncLoad from 'components/async-load';


const MyComponent = ( { setParentDate, site, translate } ) => {
  const setDate = date => setParentDate( date );

  return (
    <AsyncLoad
      require="blocks/scheduler-popover"
      site={ site }
      onDateChange={ setDate }
    >
      <Button
        primary
        className="scheduler-button"
        title={ translate( 'Set date and time' ) }
        tabIndex={ 3 }
      >
        <Gridicon icon="calendar" />
      </Button>
    </AsyncLoad>
  );
};
```

### Testing

This component is used in the publicize section, so:

1) Go to posts list page: `http://calypso.localhost:3000/post/><site>`

<img src="https://cloud.githubusercontent.com/assets/77539/24113078/949bb470-0d69-11e7-98cd-3f1be439d083.png" width="500px" />

2) Click in `share` tab of some post
3) Test the scheduler clicking into the calendar button (close to `SharePost` button)