### PR TITLE
AT: remove jetpack disconnect button from AT sites

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -5,6 +5,7 @@ import React, { Component } from 'react';
 import page from 'page';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -344,8 +345,9 @@ class SiteSettingsFormGeneral extends Component {
 
 	jetpackDisconnectOption() {
 		const { site, translate } = this.props;
+		const isAutomatedTransfer = get( site, 'options.is_automated_transfer', false );
 
-		if ( ! site.jetpack ) {
+		if ( ! site.jetpack || isAutomatedTransfer ) {
 			return null;
 		}
 


### PR DESCRIPTION
We missed one spot where users can disconnect AT sites. Disconnecting Jetpack on an AT site will cause problems for the site.

## Testing instructions

### AT Site
Login to an AT site in Calypso, go to `http://calypso.localhost:3000/settings/general/:site`, scroll to the bottom and make sure in the Jetpack section that you _do not see_ a big red "disconnect site" button. It should look like this.
![no disconnect](https://cloudup.com/cjiB4PGwVv6+)

### Jetpack Site
Now login to a non-AT Jetpack site, go to `http://calypso.localhost:3000/settings/general/:site`, scroll to the bottom and make sure in the Jetpack section that you _do see_ a big red "disconnect site" button. It should look like this.
![disconnect site](https://cloudup.com/cEYn7xnxLEu+)
