### PR TITLE
Sharing: can't connect a second account

### DIFF
--- a/client/my-sites/sharing/connections/service.jsx
+++ b/client/my-sites/sharing/connections/service.jsx
@@ -35,6 +35,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import PopupMonitor from 'lib/popup-monitor';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { requestKeyringConnections } from 'state/sharing/keyring/actions';
+import { isKeyringConnectionsFetching } from 'state/sharing/keyring/selectors';
 import ServiceAction from './service-action';
 import ServiceConnectedAccounts from './service-connected-accounts';
 import ServiceDescription from './service-description';
@@ -51,6 +52,7 @@ class SharingService extends Component {
 		failCreateConnection: PropTypes.func,
 		fetchConnection: PropTypes.func,
 		isFetching: PropTypes.bool,
+		isFetchingKeyringConnections: PropTypes.bool,
 		keyringConnections: PropTypes.arrayOf( PropTypes.object ),
 		recordGoogleEvent: PropTypes.func,
 		removableConnections: PropTypes.arrayOf( PropTypes.object ),
@@ -72,6 +74,7 @@ class SharingService extends Component {
 		failCreateConnection: () => {},
 		fetchConnection: () => {},
 		isFetching: false,
+		isFetchingKeyringConnections: false,
 		keyringConnections: [],
 		recordGoogleEvent: () => {},
 		requestKeyringConnections: () => {},
@@ -238,6 +241,8 @@ class SharingService extends Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
+		const { isFetchingKeyringConnections } = this.props;
+
 		if ( this.props.siteUserConnections.length !== nextProps.siteUserConnections.length ) {
 			this.setState( {
 				isConnecting: false,
@@ -250,8 +255,7 @@ class SharingService extends Component {
 			this.setState( { isRefreshing: false } );
 		}
 
-		if ( this.state.isAwaitingConnections ) {
-			this.setState( { isAwaitingConnections: false } );
+		if ( isFetchingKeyringConnections === true && nextProps === false ) {
 
 			if ( this.didKeyringConnectionSucceed( nextProps.availableExternalAccounts ) ) {
 				this.setState( { isSelectingAccount: true } );
@@ -402,6 +406,7 @@ export default connect(
 			availableExternalAccounts: getAvailableExternalAccounts( state, service.ID ),
 			brokenConnections: getBrokenSiteUserConnectionsForService( state, siteId, userId, service.ID ),
 			isFetching: isFetchingConnections( state, siteId ),
+			isFetchingKeyringConnections: isKeyringConnectionsFetching( state ),
 			keyringConnections: getKeyringConnectionsByName( state, service.ID ),
 			removableConnections: getRemovableConnections( state, service.ID ),
 			siteId,
@@ -414,6 +419,7 @@ export default connect(
 		errorNotice,
 		failCreateConnection,
 		fetchConnection,
+		isKeyringConnectionsFetching,
 		recordGoogleEvent,
 		requestKeyringConnections,
 		updateSiteConnection,

--- a/client/my-sites/sharing/connections/service.jsx
+++ b/client/my-sites/sharing/connections/service.jsx
@@ -103,6 +103,10 @@ class SharingService extends Component {
 		}
 	};
 
+	addAccontDialogConnection = ( args ) => {
+		this.addConnection.call( this, args);
+		this.setState( { isSelectingAccount: false } );
+	}
 	/**
 	 * Establishes a new connection.
 	 *
@@ -357,7 +361,7 @@ class SharingService extends Component {
 					isVisible={ this.state.isSelectingAccount }
 					service={ this.props.service }
 					accounts={ accounts }
-					onAccountSelected={ this.addConnection } />
+					onAccountSelected={ this.addAccountDialogConnection } />
 				<FoldableCard
 					className={ classNames }
 					header={ header }
@@ -367,7 +371,7 @@ class SharingService extends Component {
 					expandedSummary={ action } >
 					<div className={ classnames( 'sharing-service__content', { 'is-placeholder': this.props.isFetching } ) }>
 						<ServiceExamples service={ this.props.service } />
-						<ServiceConnectedAccounts connect={ this.connectAnother } service={ this.props.service }>
+						<ServiceConnectedAccounts connect={ this.connectAnother.bind( this ) } service={ this.props.service }>
 							{ this.props.siteUserConnections.map( ( connection ) =>
 								<Connection
 									key={ connection.keyring_connection_ID }

--- a/client/my-sites/sharing/connections/service.jsx
+++ b/client/my-sites/sharing/connections/service.jsx
@@ -375,7 +375,7 @@ class SharingService extends Component {
 					expandedSummary={ action } >
 					<div className={ classnames( 'sharing-service__content', { 'is-placeholder': this.props.isFetching } ) }>
 						<ServiceExamples service={ this.props.service } />
-						<ServiceConnectedAccounts connect={ this.connectAnother.bind( this ) } service={ this.props.service }>
+						<ServiceConnectedAccounts connect={ this.connectAnother } service={ this.props.service }>
 							{ this.props.siteUserConnections.map( ( connection ) =>
 								<Connection
 									key={ connection.keyring_connection_ID }

--- a/client/my-sites/sharing/connections/service.jsx
+++ b/client/my-sites/sharing/connections/service.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
-import { identity, find, replace, some } from 'lodash';
+import { identity, isEqual, find, replace, some } from 'lodash';
 import { localize } from 'i18n-calypso';
 import SocialLogo from 'social-logos';
 
@@ -243,7 +243,7 @@ class SharingService extends Component {
 	componentWillReceiveProps( nextProps ) {
 		const { isFetchingKeyringConnections } = this.props;
 
-		if ( this.props.siteUserConnections.length !== nextProps.siteUserConnections.length ) {
+		if ( ! isEqual( this.props.siteUserConnections, nextProps.siteUserConnections ) ) {
 			this.setState( {
 				isConnecting: false,
 				isDisconnecting: false,
@@ -251,7 +251,7 @@ class SharingService extends Component {
 			} );
 		}
 
-		if ( this.props.brokenConnections.length !== nextProps.brokenConnections.length ) {
+		if ( ! isEqual( this.props.brokenConnections, nextProps.brokenConnections ) ) {
 			this.setState( { isRefreshing: false } );
 		}
 

--- a/client/state/sharing/keyring/selectors.js
+++ b/client/state/sharing/keyring/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, values } from 'lodash';
+import { filter, values, get } from 'lodash';
 
 /**
  * Returns an array of keyring connection objects.
@@ -56,5 +56,5 @@ export function getUserConnections( state, userId ) {
  * @return {Boolean}       Whether a request is in progress
  */
 export function isKeyringConnectionsFetching( state ) {
-	return state.sharing.keyring.isFetching;
+	return get( state, 'sharing.keyring.isFetching' );
 }


### PR DESCRIPTION
This PR fixes an issue where clicking on "Add a different account" will crash the page when the account has a Facebook page. @obenland we fixed the crash, but do you mind 👀 this diff is still incomplete and breaks the add a different account flow.

## To Reproduce 
- Navigate to http://calypso.localhost:3000/sharing/:siteId:
- Connect an account that has a facebook page
- Attempt to connect another facebook account

Expected: Clicking proceeds through connection flow
Actual: Page will crash in prod with a setState loop