### PR TITLE
Settings: Redirect SEO and Analytics to Traffic

### DIFF
--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -15,7 +15,6 @@ module.exports = function() {
 	page( '/settings/general/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.siteSettings );
 	page( '/settings/writing/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.siteSettings );
 	page( '/settings/discussion/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.siteSettings );
-	page( '/settings/analytics/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.siteSettings );
 	page( '/settings/security/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.siteSettings );
 
 	page( '/settings/import/:site_id', controller.siteSelection, controller.navigation, settingsController.importSite );

--- a/client/my-sites/site-settings/traffic/index.js
+++ b/client/my-sites/site-settings/traffic/index.js
@@ -9,6 +9,14 @@ import page from 'page';
 import controller from './controller';
 import mySitesController from 'my-sites/controller';
 
+const redirectToTrafficSection = ( context ) => {
+	page.redirect( '/settings/traffic/' + ( context.params.site_id || '' ) );
+};
+
 export default function() {
 	page( '/settings/traffic/:site_id', mySitesController.siteSelection, mySitesController.navigation, controller.traffic );
+
+	// redirect legacy urls
+	page( '/settings/analytics/:site_id', redirectToTrafficSection );
+	page( '/settings/seo/:site_id', redirectToTrafficSection );
 }

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -109,7 +109,7 @@ const sections = [
 	},
 	{
 		name: 'settings-traffic',
-		paths: [ '/settings/traffic' ],
+		paths: [ '/settings/traffic', '/settings/seo', '/settings/analytics' ],
 		module: 'my-sites/site-settings/traffic',
 		secondary: true,
 		group: 'sites'


### PR DESCRIPTION
This PR redirects the legacy `/settings/seo/:site_id` and `/settings/analytics/:site_id` routes to the new `/settings/traffic/:site_id` route.

Fixes #12263.

To test:
* Checkout this branch.
* Perform a fresh build: `make run`.
* Go to `/settings/seo/$site`, where `$site` is one of your sites.
* Verify you're redirected to `/settings/traffic/$site` with no errors.
* Go to `/settings/analytics/$site`, where `$site` is one of your sites.
* Verify you're redirected to `/settings/traffic/$site` with no errors.
* Go to `/settings/seo/`.
* Verify you're presented with the site picker.
* Select a site `$site`.
* Verify you're redirected to `/settings/traffic/$site` with no errors.
* Go to `/settings/analytics/`
* Verify you're presented with the site picker.
* Select a site `$site`.
* Verify you're redirected to `/settings/traffic/$site` with no errors.
* Verify `/settings/traffic/` also presents the site picker and after selecting a site it works fine.
* Verify `/settings/traffic/$site` works fine.