### PR TITLE
Account Recovery: Deprecate the thunk for `account-recovery/lookup` endpoint and reimplement it in the data layer

### DIFF
--- a/client/state/account-recovery/reset/actions.js
+++ b/client/state/account-recovery/reset/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import wpcom from 'lib/wp';
 import {
 	ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST,
 	ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
@@ -28,29 +27,10 @@ export const fetchResetOptionsError = ( error ) => ( {
 	error,
 } );
 
-const fromApi = ( data ) => ( [
-	{
-		email: data.primary_email,
-		sms: data.primary_sms,
-	},
-	{
-		email: data.secondary_email,
-		sms: data.secondary_sms,
-	},
-] );
-
-export const fetchResetOptions = ( userData ) => ( dispatch ) => {
-	dispatch( {
-		type: ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST,
-	} );
-
-	return wpcom.req.get( {
-		body: userData,
-		apiNamespace: 'wpcom/v2',
-		path: '/account-recovery/lookup',
-	} ).then( data => dispatch( fetchResetOptionsSuccess( fromApi( data ) ) ) )
-	.catch( error => dispatch( fetchResetOptionsError( error ) ) );
-};
+export const fetchResetOptions = ( userData ) => ( {
+	type: ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST,
+	userData,
+} );
 
 export const fetchResetOptionsByLogin = ( user ) => fetchResetOptions( { user } );
 

--- a/client/state/account-recovery/reset/test/actions.js
+++ b/client/state/account-recovery/reset/test/actions.js
@@ -6,13 +6,7 @@ import { assert } from 'chai';
 /**
  * Internal dependencies
  */
-import useNock from 'test/helpers/use-nock';
-import { useSandbox } from 'test/helpers/use-sinon';
-
 import {
-	fetchResetOptions,
-	fetchResetOptionsSuccess,
-	fetchResetOptionsError,
 	requestReset,
 	requestResetSuccess,
 	requestResetError,
@@ -20,123 +14,11 @@ import {
 } from '../actions';
 
 import {
-	ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST,
-	ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
-	ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
 	ACCOUNT_RECOVERY_RESET_REQUEST,
 	ACCOUNT_RECOVERY_RESET_REQUEST_SUCCESS,
 	ACCOUNT_RECOVERY_RESET_REQUEST_ERROR,
 	ACCOUNT_RECOVERY_RESET_UPDATE_USER_DATA,
 } from 'state/action-types';
-
-describe( '#fetchResetOptionsSuccess', () => {
-	it( 'should return ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE action with options field.', () => {
-		const items = {
-			primaryEmail: 'primary@example.com',
-			primarySms: '12345678',
-			secondaryEmail: 'secondary@example.com',
-			secondarySms: '12345678',
-		};
-
-		const action = fetchResetOptionsSuccess( items );
-
-		assert.deepEqual( action, {
-			type: ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
-			items,
-		} );
-	} );
-} );
-
-describe( '#fetchResetOptionsError', () => {
-	it( 'should return ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR action with error field.', () => {
-		const error = {
-			status: 400,
-			message: 'error!',
-		};
-
-		const action = fetchResetOptionsError( error );
-
-		assert.deepEqual( action, {
-			type: ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
-			error,
-		} );
-	} );
-} );
-
-describe( '#fetchResetOptions', () => {
-	let spy;
-
-	useSandbox( sandbox => ( spy = sandbox.spy() ) );
-
-	const apiBaseUrl = 'https://public-api.wordpress.com:443';
-	const endpoint = '/wpcom/v2/account-recovery/lookup';
-
-	const userData = {
-		user: 'foo',
-	};
-
-	describe( 'success', () => {
-		const response = {
-			primary_email: 'a****@example.com',
-			secondary_email: 'b*****@example.com',
-			primary_sms: '+1******456',
-			secondary_sms: '+8*******456',
-		};
-
-		useNock( nock => (
-			nock( apiBaseUrl )
-				.get( endpoint )
-				.reply( 200, response )
-		) );
-
-		it( 'should dispatch RECEIVE action on success', () => {
-			const thunk = fetchResetOptions( userData )( spy );
-
-			assert.isTrue( spy.calledWith( {
-				type: ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST,
-			} ) );
-
-			return thunk.then( () =>
-				assert.isTrue( spy.calledWith( {
-					type: ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
-					items: [
-						{
-							email: response.primary_email,
-							sms: response.primary_sms,
-						},
-						{
-							email: response.secondary_email,
-							sms: response.secondary_sms,
-						},
-					],
-				} ) )
-			);
-		} );
-	} );
-
-	describe( 'failure', () => {
-		const errorResponse = {
-			status: 400,
-			message: 'Something wrong!',
-		};
-
-		useNock( nock => (
-			nock( apiBaseUrl )
-				.get( endpoint )
-				.reply( errorResponse.status, errorResponse )
-		) );
-
-		it( 'should dispatch ERROR action on failure', () => {
-			return fetchResetOptions( userData )( spy )
-				.then( () =>
-					assert.isTrue( spy.calledWithMatch( {
-						type: ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
-						error: errorResponse,
-					} ) )
-				);
-		} );
-	} );
-} );
 
 describe( '#updatePasswordResetUserData', () => {
 	it( 'should return ACCOUNT_RECOVERY_RESET_UPDATE_USER_DATA action', () => {

--- a/client/state/data-layer/wpcom/account-recovery/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/index.js
@@ -2,11 +2,13 @@
  * Internal dependencies
  */
 import { mergeHandlers } from 'state/data-layer/utils';
+import lookup from './lookup';
 import requestReset from './request-reset';
 import reset from './reset';
 import validate from './validate';
 
 export default mergeHandlers(
+	lookup,
 	requestReset,
 	reset,
 	validate,

--- a/client/state/data-layer/wpcom/account-recovery/lookup/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/lookup/index.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { isString, tap } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import wpcom from 'lib/wp';
+import { ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST } from 'state/action-types';
+import {
+	fetchResetOptionsSuccess,
+	fetchResetOptionsError,
+} from 'state/account-recovery/reset/actions';
+
+export const fromApi = data => ( [
+	{
+		email: data.primary_email,
+		sms: data.primary_sms,
+		name: 'primary',
+	},
+	{
+		email: data.secondary_email,
+		sms: data.secondary_sms,
+		name: 'secondary',
+	},
+] );
+
+export const validate = ( { primary_email, primary_sms, secondary_email, secondary_sms } ) => {
+	if ( ! [ primary_email, primary_sms, secondary_email, secondary_sms ].every( isString ) ) {
+		throw Error( 'Unexpected response format from /account-recovery/lookup' );
+	}
+};
+
+export const handleRequestResetOptions = ( { dispatch }, { userData } ) => (
+	wpcom.req.get( {
+		body: userData,
+		apiNamespace: 'wpcom/v2',
+		path: '/account-recovery/lookup',
+	} ).then( data => dispatch( fetchResetOptionsSuccess( fromApi( tap( data, validate ) ) ) ) )
+	.catch( error => dispatch( fetchResetOptionsError( error ) ) )
+);
+
+export default {
+	[ ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST ]: [ handleRequestResetOptions ],
+};

--- a/client/state/data-layer/wpcom/account-recovery/lookup/test/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/lookup/test/index.js
@@ -1,0 +1,99 @@
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+import sinon from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import useNock from 'test/helpers/use-nock';
+
+import {
+	fromApi,
+	validate,
+	handleRequestResetOptions,
+} from '../';
+
+import {
+	ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
+	ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
+} from 'state/action-types';
+
+const validResponse = {
+	primary_email: 'a****@example.com',
+	secondary_email: 'b*****@example.com',
+	primary_sms: '+1******456',
+	secondary_sms: '+8*******456',
+};
+
+describe( 'validate()', () => {
+	it( 'should validate successfully and throw nothing.', () => {
+		assert.doesNotThrow( () => validate( validResponse ) );
+	} );
+
+	it( 'should invalidate missing keys and throw an error.', () => {
+		assert.throws( () => validate( {
+			primary_email: 'foo@example.com',
+		} ), Error );
+	} );
+
+	it( 'should invalidate unexpected value type and throw an error', () => {
+		assert.throws( () => validate( {
+			primary_email: 'foo@example.com',
+			primary_sms: '123456',
+			secondary_email: 'bar@example.com',
+			secondary_sms: 123456,
+		} ), Error );
+	} );
+} );
+
+describe( 'handleRequestResetOptions()', () => {
+	const dispatch = sinon.spy();
+
+	const apiBaseUrl = 'https://public-api.wordpress.com:443';
+	const endpoint = '/wpcom/v2/account-recovery/lookup';
+
+	const userData = {
+		user: 'foo',
+	};
+
+	describe( 'success', () => {
+		useNock( nock => (
+			nock( apiBaseUrl )
+				.get( endpoint )
+				.reply( 200, validResponse )
+		) );
+
+		it( 'should dispatch RECEIVE action on success', () => {
+			return handleRequestResetOptions( { dispatch }, { userData } ).then( () =>
+				assert.isTrue( dispatch.calledWith( {
+					type: ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
+					items: fromApi( validResponse ),
+				} ) )
+			);
+		} );
+	} );
+
+	describe( 'failure', () => {
+		const errorResponse = {
+			status: 400,
+			message: 'Something wrong!',
+		};
+
+		useNock( nock => (
+			nock( apiBaseUrl )
+				.get( endpoint )
+				.reply( errorResponse.status, errorResponse )
+		) );
+
+		it( 'should dispatch ERROR action on failure', () => {
+			return handleRequestResetOptions( { dispatch }, { userData } ).then( () =>
+				assert.isTrue( dispatch.calledWithMatch( {
+					type: ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
+					error: errorResponse,
+				} ) )
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
## Summary
This PR deprecates the thunk for interacting with `/account-recovery/lookup` endpoint and reimplement the code in the data layer. The previous attempt can be found in #10878, but there is an unresolved `wpcom-http` issue there and it is at the point that rebasing would take more effort than recreate a new PR.

## Test Plan
* `npm run test-client client/state/data-layer/wpcom/account-recovery/lookup/test`
* `npm run test-client client/state/account-recovery/reset/test/`