### PR TITLE
Boot: Cleanup manage/seo config keys

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -43,7 +43,6 @@
 		"manage/plugins/setup": false,
 		"manage/posts": true,
 		"manage/security": true,
-		"manage/seo": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,

--- a/config/development.json
+++ b/config/development.json
@@ -79,7 +79,6 @@
 		"manage/plugins/setup": true,
 		"manage/posts": true,
 		"manage/security": true,
-		"manage/seo": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/date-time-format": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -50,7 +50,6 @@
 		"manage/plugins/setup": true,
 		"manage/posts": true,
 		"manage/security": true,
-		"manage/seo": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,

--- a/config/production.json
+++ b/config/production.json
@@ -48,7 +48,6 @@
 		"manage/plugins/setup": true,
 		"manage/posts": true,
 		"manage/security": true,
-		"manage/seo": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -53,7 +53,6 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,
-		"manage/seo": true,
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,

--- a/config/test.json
+++ b/config/test.json
@@ -61,7 +61,6 @@
 		"manage/plugins/setup": true,
 		"manage/posts": true,
 		"manage/security": true,
-		"manage/seo": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -59,7 +59,6 @@
 		"manage/plugins/setup": true,
 		"manage/posts": true,
 		"manage/security": true,
-		"manage/seo": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/site-settings/delete-site": true,


### PR DESCRIPTION
This PR removes the `manage/seo` config key definitions from all config files, as that config key is not used anymore. See #12262.

To test:
* Checkout this branch.
* Verify Calypso builds correctly and works as expected.