### PR TITLE
Keep focus when clicking inside Magic Search.

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -2,9 +2,11 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import wrapWithClickOutside from 'react-click-outside';
 import { connect } from 'react-redux';
 import { debounce } from 'lodash';
 import classNames from 'classnames';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -156,11 +158,6 @@ class ThemesMagicSearchCard extends React.Component {
 		this.setState( { searchInput: input } );
 	}
 
-	onBlur = ( event ) => {
-		event.preventDefault();
-		this.setState( { searchIsOpen: false } );
-	}
-
 	searchTokens = ( input ) => {
 		//We are not able to scroll overlay on Edge so just create empty div
 		if ( global.window && /(Edge)/.test( global.window.navigator.userAgent ) ) {
@@ -208,6 +205,24 @@ class ThemesMagicSearchCard extends React.Component {
 		this.updateInput( updatedInput );
 	}
 
+	focusOnInput = () => {
+		this.refs[ 'url-search' ].focus();
+	}
+
+	clearSearch = () => {
+		this.updateInput( '' );
+		this.focusOnInput();
+	}
+
+	handleClickOutside() {
+		this.setState( { searchIsOpen: false } );
+	}
+
+	// TODO remember cursor position and put it back after focus
+	handleClickInside = () => {
+		this.focusOnInput();
+	}
+
 	render() {
 		const { isJetpack, translate } = this.props;
 		const isPremiumThemesEnabled = config.isEnabled( 'upgrades/premium-themes' );
@@ -235,9 +250,8 @@ class ThemesMagicSearchCard extends React.Component {
 				onKeyDown={ this.onKeyDown }
 				onClick={ this.onClick }
 				overlayStyling={ this.searchTokens }
-				onBlur={ this.onBlur }
 				fitsContainer={ this.state.isMobile && this.state.searchIsOpen }
-				hideClose={ isMobile() }
+				hideClose={ true }
 			/>
 		);
 
@@ -254,8 +268,23 @@ class ThemesMagicSearchCard extends React.Component {
 
 		return (
 			<div className={ magicSearchClass }>
-				<div className={ themesSearchCardClass } data-tip-target="themes-search-card">
+				<div
+					className={ themesSearchCardClass }
+					data-tip-target="themes-search-card"
+					onClick={ this.handleClickInside } >
 					{ searchField }
+					{ ! isMobile() && this.state.searchInput !== '' &&
+						<div className="themes-magic-search-card__icon" >
+							<Gridicon
+								icon="cross"
+								className="themes-magic-search-card__icon-close"
+								tabIndex="0"
+								onClick={ this.clearSearch }
+								aria-controls={ 'search-component-magic-search' }
+								aria-label={ translate( 'Clear Search', { context: 'button label' } ) }
+							/>
+						</div>
+					}
 					{ isPremiumThemesEnabled && ! isJetpack &&
 						<SegmentedControl
 							initialSelected={ this.props.tier }
@@ -303,4 +332,4 @@ export default connect(
 	( state ) => ( {
 		isJetpack: isJetpackSite( state, getSelectedSiteId( state ) )
 	} )
-)( localize( ThemesMagicSearchCard ) );
+)( localize( wrapWithClickOutside( ThemesMagicSearchCard ) ) );

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -218,7 +218,6 @@ class ThemesMagicSearchCard extends React.Component {
 		this.setState( { searchIsOpen: false } );
 	}
 
-	// TODO remember cursor position and put it back after focus
 	handleClickInside = () => {
 		this.focusOnInput();
 	}
@@ -281,7 +280,7 @@ class ThemesMagicSearchCard extends React.Component {
 								tabIndex="0"
 								onClick={ this.clearSearch }
 								aria-controls={ 'search-component-magic-search' }
-								aria-label={ translate( 'Clear Search', { context: 'button label' } ) }
+								aria-label={ translate( 'Clear Search' ) }
 							/>
 						</div>
 					}

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -75,6 +75,7 @@ class ThemesMagicSearchCard extends React.Component {
 
 		if ( event.key === 'Enter' && ! inputUpdated && this.isPreviousCharWhitespace() ) {
 			this.refs[ 'url-search' ].blur();
+			this.setState( { searchIsOpen: false } );
 		}
 	}
 

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -7,7 +7,7 @@
 	align-items: center;
 	background: white;
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
-	//transition: all 0.15s ease-in-out;
+	transition: all 0.15s ease-in-out;
 
 	&.has-highlight {
 		box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -7,7 +7,7 @@
 	align-items: center;
 	background: white;
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
-	transition: all 0.15s ease-in-out;
+	//transition: all 0.15s ease-in-out;
 
 	&.has-highlight {
 		box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;
@@ -32,6 +32,23 @@
 
 	.search .search-open__icon {
 		color: lighten( $gray, 10% );
+	}
+
+	.themes-magic-search-card__icon {
+		display: flex;
+		color: $blue-wordpress;
+		cursor: pointer;
+		z-index: z-index( '.search', '.search .search__open-icon' );
+
+		.accessible-focus &:focus {
+			outline: dotted 1px $blue-wordpress;
+		}
+
+		.themes-magic-search-card__icon-close {
+			flex: 0 0 auto;
+			color: darken( $gray, 30% );
+			align-items: center;
+		}
 	}
 
 	.segmented-control {


### PR DESCRIPTION
### Information 
This feature was requested in #12229. Additionally to the request from Issue this PR also extends requested behavior and now clicking on tier also preserves focus. 

Code in this PR may be seen as a bit controversial. the `X` in `Search` was disabled( standard prop no change required ) and MagicSearch implements it's own `X` functionality. The decision to go this was made because `X` functionality from search component was design and created as **close** and changing that would require deep modifications in `Search` 

fixes #12229 

### Testing
To verify that this works compare to the situation from #12229