### PR TITLE
Account Recovery: Rewrite the `accountRecovery.reset.*` reducers via `createReducer` utility.

### DIFF
--- a/client/state/account-recovery/reset/reducer.js
+++ b/client/state/account-recovery/reset/reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import { get, pick } from 'lodash';
+import { pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,26 +15,24 @@ import {
 	ACCOUNT_RECOVERY_RESET_UPDATE_USER_DATA,
 } from 'state/action-types';
 
-const isRequesting = ( state = false, action ) => get( {
-	[ ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST ]: true,
-	[ ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE ]: false,
-	[ ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR ]: false,
-}, action.type, state );
+const options = combineReducers( {
+	isRequesting: createReducer( false, {
+		[ ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST ]: () => true,
+		[ ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE ]: () => false,
+		[ ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR ]: () => false,
+	} ),
 
-const error = ( state = null, action ) => get( {
-	[ ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST ]: null,
-	[ ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE ]: null,
-	[ ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR ]: action.error,
-}, action.type, state );
+	error: createReducer( null, {
+		[ ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST ]: () => null,
+		[ ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE ]: () => null,
+		[ ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR ]: ( state, { error } ) => error,
+	} ),
 
-const items = ( state = [], action ) => get( {
-	[ ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE ]: action.items,
-}, action.type, state );
-
-const resetOptions = combineReducers( {
-	isRequesting,
-	error,
-	items,
+	items: createReducer( [], {
+		[ ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE ]: ( state, { items } ) => items,
+		[ ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST ]: () => [],
+		[ ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR ]: () => [],
+	} ),
 } );
 
 const validUserDataProps = [ 'user', 'firstName', 'lastName', 'url' ];
@@ -47,6 +45,6 @@ const userData = createReducer( {}, {
 } );
 
 export default combineReducers( {
-	options: resetOptions,
+	options,
 	userData,
 } );

--- a/client/state/account-recovery/reset/test/reducer.js
+++ b/client/state/account-recovery/reset/test/reducer.js
@@ -16,12 +16,46 @@ import {
 import reducer from '../reducer';
 
 describe( '#account-recovery/reset reducer', () => {
+	const fetchedOptions = [
+		{
+			email: 'primary@example.com',
+			sms: '123456789',
+		},
+		{
+			email: 'secondary@example.com',
+			sms: '123456789',
+		},
+	];
+
 	it( 'ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST action should set isRequesting flag.', () => {
 		const state = reducer( undefined, {
 			type: ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST
 		} );
 
 		assert.isTrue( state.options.isRequesting );
+	} );
+
+	const hasItemsState = {
+		options: {
+			items: fetchedOptions,
+		},
+	};
+
+	it( 'ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST action should wipe the previous items.', () => {
+		const state = reducer( hasItemsState, {
+			type: ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST,
+		} );
+
+		assert.deepEqual( state.options.items, [] );
+	} );
+
+	it( 'ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR action should wipe the previous items.', () => {
+		const state = reducer( hasItemsState, {
+			type: ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
+			error: {},
+		} );
+
+		assert.deepEqual( state.options.items, [] );
 	} );
 
 	const requestingState = {
@@ -33,6 +67,7 @@ describe( '#account-recovery/reset reducer', () => {
 	it( 'ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE action should unset isRequesting flag.', () => {
 		const state = reducer( requestingState, {
 			type: ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
+			items: [],
 		} );
 
 		assert.isFalse( state.options.isRequesting );
@@ -41,22 +76,13 @@ describe( '#account-recovery/reset reducer', () => {
 	it( 'ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR action should unset isRequesting flag.', () => {
 		const state = reducer( requestingState, {
 			type: ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
+			error: {},
 		} );
 
 		assert.isFalse( state.options.isRequesting );
 	} );
 
 	it( 'ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE action should populate the items field.', () => {
-		const fetchedOptions = [
-			{
-				email: 'primary@example.com',
-				sms: '123456789',
-			},
-			{
-				email: 'secondary@example.com',
-				sms: '123456789',
-			},
-		];
 		const state = reducer( undefined, {
 			type: ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
 			items: fetchedOptions,

--- a/client/state/account-recovery/reset/test/reducer.js
+++ b/client/state/account-recovery/reset/test/reducer.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { assert } from 'chai';
+import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
@@ -16,7 +17,7 @@ import {
 import reducer from '../reducer';
 
 describe( '#account-recovery/reset reducer', () => {
-	const fetchedOptions = [
+	const fetchedOptions = deepFreeze( [
 		{
 			email: 'primary@example.com',
 			sms: '123456789',
@@ -25,7 +26,7 @@ describe( '#account-recovery/reset reducer', () => {
 			email: 'secondary@example.com',
 			sms: '123456789',
 		},
-	];
+	] );
 
 	it( 'ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST action should set isRequesting flag.', () => {
 		const state = reducer( undefined, {
@@ -35,11 +36,11 @@ describe( '#account-recovery/reset reducer', () => {
 		assert.isTrue( state.options.isRequesting );
 	} );
 
-	const hasItemsState = {
+	const hasItemsState = deepFreeze( {
 		options: {
 			items: fetchedOptions,
 		},
-	};
+	} );
 
 	it( 'ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST action should delete the previous items.', () => {
 		const state = reducer( hasItemsState, {
@@ -58,11 +59,11 @@ describe( '#account-recovery/reset reducer', () => {
 		assert.deepEqual( state.options.items, [] );
 	} );
 
-	const requestingState = {
+	const requestingState = deepFreeze( {
 		options: {
 			isRequesting: true,
 		},
-	};
+	} );
 
 	it( 'ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE action should unset isRequesting flag.', () => {
 		const state = reducer( requestingState, {

--- a/client/state/account-recovery/reset/test/reducer.js
+++ b/client/state/account-recovery/reset/test/reducer.js
@@ -41,7 +41,7 @@ describe( '#account-recovery/reset reducer', () => {
 		},
 	};
 
-	it( 'ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST action should wipe the previous items.', () => {
+	it( 'ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST action should delete the previous items.', () => {
 		const state = reducer( hasItemsState, {
 			type: ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST,
 		} );
@@ -49,7 +49,7 @@ describe( '#account-recovery/reset reducer', () => {
 		assert.deepEqual( state.options.items, [] );
 	} );
 
-	it( 'ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR action should wipe the previous items.', () => {
+	it( 'ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR action should delete the previous items.', () => {
 		const state = reducer( hasItemsState, {
 			type: ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
 			error: {},


### PR DESCRIPTION
## Summary
This PR attempts to rewrite the `/account-recovery/reset/reducers` via `createReducer` utility function. The rational is that all substates under this state tree should be serialized as the initial value, instead of the last value. Thus, `createReducer` utility becomes a good candidate for this task.

Also, with this PR, the `items` field will be wiped out on receiving `ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST` and `ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR`. These are simply the cases I've missed.

## Test Plan
`npm run test-client client/state/account-recovery/reset/test/`

