### PR TITLE
Boot: Cleanup manage/plans config keys

### DIFF
--- a/client/lib/route/legacy-routes.js
+++ b/client/lib/route/legacy-routes.js
@@ -15,7 +15,7 @@ const legacyRoutes = [
 	{ match: /^\/?$/, predicate: notEnabled( 'reader' ) },
 	{ match: /^\/themes/ },
 	{ match: /^\/manage/ },
-	{ match: /^\/plans/, predicate: notEnabled( 'manage/plans' ) },
+	{ match: /^\/plans/ },
 	{
 		match: /^\/me/,
 		noMatch: /^\/me\/(billing|next)/,

--- a/client/lib/route/test/legacy-routes.js
+++ b/client/lib/route/test/legacy-routes.js
@@ -50,18 +50,6 @@ describe( 'legacy-routes', function() {
 			expect( isLegacyRoute( '/some/nested/page.php' ) ).to.be.true;
 		} );
 
-		it( 'should return true for /plans when `manage/plans` feature flag disabled', () => {
-			// config.isEnabled( 'manage/plans' ) === false
-			features = [];
-			expect( isLegacyRoute( '/plans' ) ).to.be.true;
-		} );
-
-		it( 'should return false for /plans when `manage/plans` feature flag enabled', () => {
-			// config.isEnabled( 'manage/plans' ) === true
-			features = [ 'manage/plans' ];
-			expect( isLegacyRoute( '/plans' ) ).to.be.false;
-		} );
-
 		describe( 'when `me/my-profile` feature flag is enabled', () => {
 			// config.isEnabled( 'me/my-profile' ) === true
 			beforeEach( () => {

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -6,79 +6,76 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import controller from 'my-sites/controller';
 import plansController from './controller';
 import currentPlanController from './current-plan/controller';
 
 export default function() {
-	if ( config.isEnabled( 'manage/plans' ) ) {
-		page(
-			'/plans',
-			controller.siteSelection,
-			controller.sites
-		);
+	page(
+		'/plans',
+		controller.siteSelection,
+		controller.sites
+	);
 
-		page(
-			'/plans/compare',
-			controller.siteSelection,
-			controller.navigation,
-			plansController.redirectToPlans
-		);
+	page(
+		'/plans/compare',
+		controller.siteSelection,
+		controller.navigation,
+		plansController.redirectToPlans
+	);
 
-		page(
-			'/plans/compare/:domain',
-			controller.siteSelection,
-			controller.navigation,
-			plansController.redirectToPlans
-		);
+	page(
+		'/plans/compare/:domain',
+		controller.siteSelection,
+		controller.navigation,
+		plansController.redirectToPlans
+	);
 
-		page(
-			'/plans/features',
-			controller.siteSelection,
-			controller.navigation,
-			plansController.redirectToPlans
-		);
+	page(
+		'/plans/features',
+		controller.siteSelection,
+		controller.navigation,
+		plansController.redirectToPlans
+	);
 
-		page(
-			'/plans/features/:domain',
-			controller.siteSelection,
-			controller.navigation,
-			plansController.redirectToPlans
-		);
+	page(
+		'/plans/features/:domain',
+		controller.siteSelection,
+		controller.navigation,
+		plansController.redirectToPlans
+	);
 
-		page(
-			'/plans/features/:feature/:domain',
-			plansController.features
-		);
+	page(
+		'/plans/features/:feature/:domain',
+		plansController.features
+	);
 
-		page(
-			'/plans/my-plan',
-			controller.siteSelection,
-			controller.sites,
-			controller.navigation,
-			currentPlanController.currentPlan
-		);
+	page(
+		'/plans/my-plan',
+		controller.siteSelection,
+		controller.sites,
+		controller.navigation,
+		currentPlanController.currentPlan
+	);
 
-		page(
-			'/plans/my-plan/:site',
-			controller.siteSelection,
-			controller.navigation,
-			currentPlanController.currentPlan
-		);
+	page(
+		'/plans/my-plan/:site',
+		controller.siteSelection,
+		controller.navigation,
+		currentPlanController.currentPlan
+	);
 
-		page(
-			'/plans/select/:plan/:domain',
-			controller.siteSelection,
-			plansController.redirectToCheckout
-		);
+	page(
+		'/plans/select/:plan/:domain',
+		controller.siteSelection,
+		plansController.redirectToCheckout
+	);
 
-		// This route renders the plans page for both WPcom and Jetpack sites.
-		page(
-			'/plans/:intervalType?/:site',
-			controller.siteSelection,
-			controller.navigation,
-			plansController.plans
-		);
-	}
+	// This route renders the plans page for both WPcom and Jetpack sites.
+	page(
+		'/plans/:intervalType?/:site',
+		controller.siteSelection,
+		controller.navigation,
+		plansController.plans
+	);
 }

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -308,10 +308,6 @@ export class MySitesSidebar extends Component {
 			domainsLink = '/domains/manage' + this.siteSuffix(),
 			addDomainLink = '/domains/add' + this.siteSuffix();
 
-		if ( ! config.isEnabled( 'manage/plans' ) ) {
-			return null;
-		}
-
 		if ( ! this.isSingle() ) {
 			return null;
 		}
@@ -345,10 +341,6 @@ export class MySitesSidebar extends Component {
 	}
 
 	plan() {
-		if ( ! config.isEnabled( 'manage/plans' ) ) {
-			return null;
-		}
-
 		if ( ! this.isSingle() ) {
 			return null;
 		}

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -35,7 +35,6 @@
 		"manage/pages": true,
 		"manage/people": true,
 		"manage/people/readers": true,
-		"manage/plans": true,
 		"manage/plan-features": false,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,

--- a/config/development.json
+++ b/config/development.json
@@ -70,7 +70,6 @@
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/people/role-filtering": true,
-		"manage/plans": true,
 		"manage/plan-features": true,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -42,7 +42,6 @@
 		"manage/payment-methods": true,
 		"manage/people": true,
 		"manage/people/readers": true,
-		"manage/plans": true,
 		"manage/plan-features": true,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,

--- a/config/production.json
+++ b/config/production.json
@@ -39,7 +39,6 @@
 		"manage/payment-methods": true,
 		"manage/people": true,
 		"manage/people/readers": true,
-		"manage/plans": true,
 		"manage/plan-features": true,
 		"manage/plugins": true,
 		"manage/plugins/browser": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -42,7 +42,6 @@
 		"manage/payment-methods": true,
 		"manage/people": true,
 		"manage/people/readers": true,
-		"manage/plans": true,
 		"manage/plan-features": true,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,

--- a/config/test.json
+++ b/config/test.json
@@ -53,7 +53,6 @@
 		"manage/pages": true,
 		"manage/people": true,
 		"manage/people/readers": true,
-		"manage/plans": true,
 		"manage/plan-features": true,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -51,7 +51,6 @@
 		"manage/payment-methods": true,
 		"manage/people": true,
 		"manage/people/readers": true,
-		"manage/plans": true,
 		"manage/plan-features": true,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,


### PR DESCRIPTION
This PR removes the `manage/plans` config key definitions from all config files, and removes the current usage of that key, as it's been enabled in all environments for a while. See #12262.

To test:
* Checkout this branch.
* Verify Calypso builds correctly and works as expected.
* Test various Plans pages and verify they work like they did before:
 * `/plans/`
 * `/plans/$site`
 * `/plans/my-plan`
 * `/plans/my-plan/$site`
* Try upgrading to a plan and verify it works correctly.
* Verify all tests still pass.

Fixes #12262.