### PR TITLE
Boot: Cleanup jetpack/google-analytics config keys

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -353,7 +353,7 @@ export const PLANS_LIST = {
 			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
 			FEATURE_ONE_CLICK_THREAT_RESOLUTION,
 			FEATURE_ADVANCED_SEO,
-			isEnabled( 'jetpack/google-analytics' ) && FEATURE_GOOGLE_ANALYTICS
+			FEATURE_GOOGLE_ANALYTICS
 		] ),
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
 	},
@@ -386,7 +386,7 @@ export const PLANS_LIST = {
 			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
 			FEATURE_ONE_CLICK_THREAT_RESOLUTION,
 			FEATURE_ADVANCED_SEO,
-			isEnabled( 'jetpack/google-analytics' ) && FEATURE_GOOGLE_ANALYTICS
+			FEATURE_GOOGLE_ANALYTICS
 		] ),
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
 	}

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -25,7 +25,6 @@ import { removeNotice, errorNotice } from 'state/notices/actions';
 import { getSiteOption, isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { isJetpackModuleActive } from 'state/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { isEnabled } from 'config';
 import { FEATURE_GOOGLE_ANALYTICS } from 'lib/plans/constants';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 
@@ -80,7 +79,7 @@ class GoogleAnalyticsForm extends Component {
 		} = this.props;
 
 		const placeholderText = isRequestingSettings ? translate( 'Loading' ) : '';
-		const isJetpackUnsupported = siteIsJetpack && ! jetpackVersionSupportsModule && isEnabled( 'jetpack/google-analytics' );
+		const isJetpackUnsupported = siteIsJetpack && ! jetpackVersionSupportsModule;
 
 		return (
 			<form id="site-settings" onSubmit={ handleSubmitForm }>
@@ -210,7 +209,7 @@ const mapStateToProps = ( state ) => {
 	const siteIsJetpack = isJetpackSite( state, siteId );
 	const googleAnalyticsEnabled = site && (
 		! siteIsJetpack ||
-		( siteIsJetpack && jetpackModuleActive && jetpackVersionSupportsModule && isEnabled( 'jetpack/google-analytics' ) )
+		( siteIsJetpack && jetpackModuleActive && jetpackVersionSupportsModule )
 	);
 
 	return {

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -22,7 +22,6 @@
 		"fluid-width": true,
 		"help": true,
 		"help/courses": true,
-		"jetpack/google-analytics": true,
 		"jetpack/personalPlan": true,
 		"manage/custom-post-types": true,
 		"manage/customize": true,

--- a/config/development.json
+++ b/config/development.json
@@ -49,7 +49,6 @@
 		"help/directly": true,
 		"jetpack/invites": true,
 		"jetpack_core_inline_update": true,
-		"jetpack/google-analytics": true,
 		"jetpack/api-cache": true,
 		"keyboard-shortcuts": true,
 		"happychat": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -25,7 +25,6 @@
 		"help/courses": true,
 		"help/directly": true,
 		"jetpack/api-cache": true,
-		"jetpack/google-analytics": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
 		"manage/custom-post-types": true,

--- a/config/production.json
+++ b/config/production.json
@@ -23,7 +23,6 @@
 		"help": true,
 		"help/courses": true,
 		"help/directly": true,
-		"jetpack/google-analytics": true,
 		"jetpack/api-cache": false,
 		"manage/custom-post-types": true,
 		"manage/customize": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -25,7 +25,6 @@
 		"help": true,
 		"help/courses": true,
 		"help/directly": true,
-		"jetpack/google-analytics": true,
 		"jetpack/api-cache": true,
 		"jetpack_core_inline_update": true,
 		"manage/custom-post-types": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -33,7 +33,6 @@
 		"help/directly": true,
 		"jetpack/api-cache": true,
 		"jetpack_core_inline_update": true,
-		"jetpack/google-analytics": true,
 		"keyboard-shortcuts": true,
 		"manage/customize": true,
 		"manage/custom-post-types": true,


### PR DESCRIPTION
This PR removes the `jetpack/google-analytics` config key definitions from all config files, and removes the current usage of that key, as it's been enabled in all environments for a while. See #12262.

To test:
* Checkout this branch.
* Verify Calypso builds correctly and works as expected.
* Go to `/settings/traffic/$site` where `$site` has a Business/Professional plan.
* Verify Analytics works as expected (saves/retrieves the tracking ID properly).