### PR TITLE
Fix Safari-specific sidebar height issue on mobile.

### DIFF
--- a/client/post-editor/editor-action-bar/style.scss
+++ b/client/post-editor/editor-action-bar/style.scss
@@ -2,6 +2,7 @@
 	display: flex;
 	flex-direction: row;
 	flex-wrap: nowrap;
+	flex-shrink: 0;	// Safari fix for min-height
 	align-items: center;
 	margin-bottom: 24px;
 	padding: 12px 16px 8px;


### PR DESCRIPTION
Safari has a flex-box bug detailed here: https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored

This bug affected the Post Settings sidebar when opened on mobile breakpoints. This commit fixes it, and fixes #12212.