### PR TITLE
Editor: Fix various issues

### DIFF
--- a/client/components/tinymce/iframe.scss
+++ b/client/components/tinymce/iframe.scss
@@ -41,6 +41,7 @@ pre {
 	background: $gray-light;
 	font-family: $code;
 	padding: 8px;
+	overflow-x: auto;
 
 	code {
 		background: none;

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -48,14 +48,12 @@
 			border-left-width: 0;
 			border-right-width: 0;
 
-			.focus-sidebar &,
-			.has-chat & {
+			.focus-sidebar & {
 				width: calc( 100% - ( #{ $sidebar-width-max + 1 } ) );
+				@include breakpoint( "660px-960px" ) {
+					width: calc( 100% - ( #{ $sidebar-width-min + 1 } ) );
+				}
 				margin: 0;
-			}
-
-			.focus-sidebar.has-chat & {
-				width: calc( 100% - ( #{ ( $sidebar-width-max * 2 ) + 1 } ) )
 			}
 		}
 

--- a/client/post-editor/editor-action-bar/style.scss
+++ b/client/post-editor/editor-action-bar/style.scss
@@ -33,6 +33,10 @@
 		.focus-sidebar & {
 			right: 228px;
 
+			@include breakpoint( "<660px" ) {
+				display: none;
+			}
+
 			@include breakpoint( ">960px" ) {
 				right: 273px;
 			}


### PR DESCRIPTION
This PR fixes 3 issues:

1. when a `pre` tag was present, you couldn't select all text in the visual editor
2. TinyMCE toolbar wasn't wide enough between 660 and 960 with post settings open
3. "Saved n minutes ago" overlapped post settings on the <660 breakpoint