### PR TITLE
Editor: Reduxify EditorVisibility Component

### DIFF
--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -21,7 +21,6 @@ export default React.createClass( {
 
 	propTypes: {
 		isNew: React.PropTypes.bool,
-		onPrivatePublish: React.PropTypes.func,
 		post: React.PropTypes.object,
 		savedPost: React.PropTypes.object,
 		site: React.PropTypes.object,

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -389,6 +389,7 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const postId = getEditorPostId( state );
 
-		return { siteId, postId }
-;	},
-{ editPost } )( EditorVisibility );
+		return { siteId, postId };
+	},
+	{ editPost }
+)( EditorVisibility );

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -256,8 +256,7 @@ const EditorVisibility = React.createClass( {
 
 	renderPasswordInput() {
 		var value, isError, errorMessage;
-
-		value = this.props.password ? this.props.password.trim() : null;
+		value = this.props.password ? this.props.password.trim() : '';
 		isError = ! this.state.passwordIsValid;
 		errorMessage = this.translate( 'Password is empty.', { context: 'Editor: Error shown when password is empty.' } );
 

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -653,11 +653,6 @@ export const PostEditor = React.createClass( {
 			...this.props.edits
 		};
 
-		// determine if this is a future publish
-		if ( utils.isFutureDated( this.state.post ) ) {
-			edits.status = 'future';
-		}
-
 		// Update content on demand to avoid unnecessary lag and because it is expensive
 		// to serialize when TinyMCE is the active mode
 		edits.content = this.refs.editor.getContent();

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -252,7 +252,6 @@ export const PostEditor = React.createClass( {
 								onDismissClick={ this.hideNotice } />
 							<EditorActionBar
 								isNew={ this.state.isNew }
-								onPrivatePublish={ this.onPublish }
 								post={ this.state.post }
 								savedPost={ this.state.savedPost }
 								site={ site }
@@ -650,14 +649,12 @@ export const PostEditor = React.createClass( {
 
 	onPublish: function() {
 		const edits = {
-			...this.props.edits,
-			status: 'publish'
+			status: 'publish',
+			...this.props.edits
 		};
 
-		// determine if this is a private publish
-		if ( utils.isPrivate( this.state.post ) ) {
-			edits.status = 'private';
-		} else if ( utils.isFutureDated( this.state.post ) ) {
+		// determine if this is a future publish
+		if ( utils.isFutureDated( this.state.post ) ) {
 			edits.status = 'future';
 		}
 


### PR DESCRIPTION
closes #12276

This PR reduxifies the EditorVisibility Component on the Calypso's Editor. So from now on, all updates to the post status are performed through Redux. While this is a step forward in reduxifying the whole editor, this is also a risky change, that needs to be tested carefully.

I tried several workflows: Saving Drafts, switching to private published posts, switching to password protected posts, editing the password, switching to a "future" post. It seems to behave as expected but I'll definitely need a lot of eyes here.