### PR TITLE
MagicSearch: add terms and filters to analytics on search.

### DIFF
--- a/client/my-sites/themes/theme-filters.js
+++ b/client/my-sites/themes/theme-filters.js
@@ -272,6 +272,20 @@ export function getFilter( term ) {
 }
 
 /**
+ * For array of terms recreate full search string in
+ * "taxonomy:term taxonomy:term" search-box format.
+ *
+ * @param {Array} terms - the terms slugs
+ * @return {string}     - complete taxonomy:term filter string, or empty string if term is not valid
+ */
+export function prependFilterKeys( terms ) {
+	if ( terms ) {
+		return terms.split( ',' ).map( getFilter ).join( ' ' ) + ' ';
+	}
+	return '';
+}
+
+/**
  * Checks that a taxonomy:term filter is valid, using the theme
  * taxonomy data.
  *

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -18,7 +18,7 @@ import StickyPanel from 'components/sticky-panel';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { addTracking, trackClick } from './helpers';
 import DocumentHead from 'components/data/document-head';
-import { getFilter, getSortedFilterTerms, stripFilters } from './theme-filters.js';
+import { prependFilterKeys, getSortedFilterTerms, stripFilters } from './theme-filters.js';
 import buildUrl from 'lib/mixins/url-search/build-url';
 import { isJetpackSite, getSiteSlug } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
@@ -85,14 +85,6 @@ const ThemeShowcase = React.createClass( {
 		};
 	},
 
-	prependFilterKeys() {
-		const { filter } = this.props;
-		if ( filter ) {
-			return filter.split( ',' ).map( getFilter ).join( ' ' ) + ' ';
-		}
-		return '';
-	},
-
 	doSearch( searchBoxContent ) {
 		const filter = getSortedFilterTerms( searchBoxContent );
 		const searchString = stripFilters( searchBoxContent );
@@ -157,7 +149,7 @@ const ThemeShowcase = React.createClass( {
 				<StickyPanel>
 					<ThemesSearchCard
 						onSearch={ this.doSearch }
-						search={ this.prependFilterKeys() + search }
+						search={ prependFilterKeys( filter ) + search }
 						tier={ tier }
 						select={ this.onTierSelect } />
 				</StickyPanel>

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -12,6 +12,7 @@ import { trackClick } from './helpers';
 import QueryThemes from 'components/data/query-themes';
 import ThemesList from 'components/themes-list';
 import ThemesSelectionHeader from './themes-selection-header';
+import { prependFilterKeys } from './theme-filters.js';
 import analytics from 'lib/analytics';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
@@ -69,8 +70,11 @@ const ThemesSelection = React.createClass( {
 
 	recordSearchResultsClick( theme, resultsRank, action ) {
 		const { query, themes } = this.props;
+		const search_taxonomies = prependFilterKeys( query.filter );
+		const search_term = search_taxonomies + ( query.search || '' );
 		analytics.tracks.recordEvent( 'calypso_themeshowcase_theme_click', {
-			search_term: query.search,
+			search_term: search_term || null,
+			search_taxonomies,
 			theme: theme.id,
 			results_rank: resultsRank + 1,
 			results: themes.map( property( 'id' ) ).join(),

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -408,7 +408,8 @@ export function themeActivated( themeStylesheet, siteId, source = 'unknown', pur
 		};
 		const previousThemeId = getActiveTheme( getState(), siteId );
 		const query = getLastThemeQuery( getState(), siteId );
-
+		const search_taxonomies = prependFilterKeys( query.filter );
+		const search_term = search_taxonomies + ( query.search || '' );
 		const trackThemeActivation = recordTracksEvent(
 			'calypso_themeshowcase_theme_activate',
 			{
@@ -416,7 +417,8 @@ export function themeActivated( themeStylesheet, siteId, source = 'unknown', pur
 				previous_theme: previousThemeId,
 				source: source,
 				purchased: purchased,
-				search_term: query.search || null
+				search_term: search_term || null,
+				search_taxonomies
 			}
 		);
 		dispatch( withAnalytics( trackThemeActivation, action ) );

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -10,6 +10,7 @@ import page from 'page';
  */
 import wpcom from 'lib/wp';
 import wporg from 'lib/wporg';
+import { prependFilterKeys } from 'my-sites/themes/theme-filters';
 import {
 	ACTIVE_THEME_REQUEST,
 	ACTIVE_THEME_REQUEST_SUCCESS,
@@ -181,12 +182,15 @@ export function requestThemes( siteId, query = {} ) {
 				themes = map( rawThemes, normalizeJetpackTheme );
 			}
 
-			if ( query.search && query.page === 1 ) {
+			if ( ( query.search || query.filter ) && query.page === 1 ) {
 				const responseTime = ( new Date().getTime() ) - startTime;
+				const search_taxonomies = prependFilterKeys( query.filter );
+				const search_term = search_taxonomies + ( query.search || '' );
 				const trackShowcaseSearch = recordTracksEvent(
 					'calypso_themeshowcase_search',
 					{
-						search_term: query.search || null,
+						search_term: search_term || null,
+						search_taxonomies,
 						tier: query.tier,
 						response_time_in_ms: responseTime,
 						result_count: found,

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -405,6 +405,7 @@ describe( 'actions', () => {
 								properties: {
 									previous_theme: 'twentyfifteen',
 									purchased: false,
+									search_taxonomies: '',
 									search_term: 'simple, white',
 									source: 'unknown',
 									theme: 'twentysixteen',


### PR DESCRIPTION
### Info
We want `calypso_themeshowcase_search` in MagicSearch to be backwards compatible and store new information. 
 - Backward compatibility requires that we store full entered search string in `search_term` field. We are doing a simplified version of that because we are recreating this from search and filter values. After recreating the string if functionally equivalent to the one from input ( only the order of elements may be different ). Befor this PR we have storred only the non taxonomy:filter part. 
 - The new implemented feature is the `search_taxonomies` field is a string with all taxonomy:filter values.

This is how it looks on tracks:
![image](https://cloud.githubusercontent.com/assets/17271089/24101389/7a4dfd1c-0d78-11e7-9cce-196aa338c913.png)

### Testing
Search using filters and text and observe tracks( you need to wait a couple of minutes )