### PR TITLE
Editor: update logic behind "busy" state of primary button

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -109,7 +109,7 @@ button {
 }
 
 // Primary buttons
-@mixin button-is-primary {
+.button.is-primary {
 	background: $blue-medium;
 	border-color: darken( $blue-medium, 8% );
 	color: $white;
@@ -119,23 +119,19 @@ button {
 		border-color: $blue-dark;
 		color: $white;
 	}
-	&[disabled],
-	&:disabled {
-		background: tint( $blue-light, 50% );
-		border-color: tint( $blue-wordpress, 55% );
-		color: $white;
-	}
 	&.is-compact {
 		color: $white;
+	}
+	&[disabled],
+	&:disabled {
+		color: lighten( $gray, 30% );
+		background: $white;
+		border-color: lighten( $gray, 30% );
 	}
 	&.is-busy {
 		background-size: 120px 100%;
 		background-image: linear-gradient( -45deg, $blue-medium 28%, darken( $blue-medium, 5% ) 28%, darken( $blue-medium, 5% ) 72%, $blue-medium 72%);
 	}
-}
-
-.button.is-primary {
-	@include button-is-primary;
 }
 
 // Scary buttons

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -361,7 +361,7 @@ export default React.createClass( {
 							isSaveBlocked={ this.props.isSaveBlocked }
 							hasContent={ this.props.hasContent }
 							needsVerification={ this.state.needsVerification }
-							busy={ this.props.isPublishing || this.props.isSaving }
+							busy={ this.props.isPublishing || ( postUtils.isPublished( this.props.savedPost ) && this.props.isSaving ) }
 						/>
 						{ this.canPublishPost() &&
 							<Button


### PR DESCRIPTION
Only show busy state on publishing and when clicking "update" on a published or scheduled to publish post, not on draft autosaves as it is confusing.