### PR TITLE
Signup: remove online store AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -8,15 +8,6 @@ module.exports = {
 		},
 		defaultVariation: 'singlePurchaseFlow'
 	},
-	signupStore: {
-		datestamp: '20160927',
-		variations: {
-			designTypeWithoutStore: 0,
-			designTypeWithStore: 100,
-		},
-		defaultVariation: 'designTypeWithStore',
-		allowExistingUsers: false,
-	},
 	userFirstSignup: {
 		datestamp: '20160124',
 		variations: {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -249,7 +249,7 @@ function filterDesignTypeInFlow( flow ) {
 		return;
 	}
 
-	if ( ! includes( flow.steps, 'design-type' ) || 'designTypeWithStore' !== abtest( 'signupStore' ) ) {
+	if ( ! includes( flow.steps, 'design-type' ) ) {
 		return flow;
 	}
 
@@ -309,6 +309,7 @@ const Flows = {
 			flow = removeUserStepFromFlow( flow );
 		}
 
+		// Show design type with store option only to new users with EN locale.
 		if ( ! user.get() && 'en' === i18n.getLocaleSlug() ) {
 			flow = filterDesignTypeInFlow( flow );
 		}


### PR DESCRIPTION
Since one test variation of `signupStore` was increased to 100%, we no longer need to keep this test active. Refactored to continue showing online store variant to all new users with `EN` locale, without using the `abtest` logic.

# Testing instructions

1. While logged in as existing user, navigate to `/start`. 
2. Verify that online store option is not shown among design types. 
3. Verify there are no JS errors in the console.

New users flow:

1. In new incognito window navigate to `/start`. 
2. Users with `EN` locale should see online store option in design selection step.
3. Verify there are no JS errors in the console.