### PR TITLE
General: Replace Merriweather with Noto Serif

### DIFF
--- a/assets/stylesheets/shared/_typography.scss
+++ b/assets/stylesheets/shared/_typography.scss
@@ -4,7 +4,7 @@ $monospace: "Courier 10 Pitch", Courier, monospace;
 $code: Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", $monospace;
 
 $serif-fallback: Georgia, "Times New Roman", Times, serif;
-$serif: Merriweather, $serif-fallback;
+$serif: "Noto Serif", $serif-fallback;
 
 $sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
 $sans-rtl: Tahoma, $sans;

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -148,7 +148,7 @@ const CONTENT_CSS = [
 	window.app.tinymceWpSkin,
 	'//s1.wp.com/wp-includes/css/dashicons.css',
 	window.app.tinymceEditorCss,
-	'//s1.wp.com/i/fonts/notoserif/notoserif.css',
+	'//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese',
 ];
 
 module.exports = React.createClass( {

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -148,7 +148,7 @@ const CONTENT_CSS = [
 	window.app.tinymceWpSkin,
 	'//s1.wp.com/wp-includes/css/dashicons.css',
 	window.app.tinymceEditorCss,
-	'//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese',
+	'//s1.wp.com/i/fonts/notoserif/notoserif.css',
 ];
 
 module.exports = React.createClass( {

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -148,7 +148,7 @@ const CONTENT_CSS = [
 	window.app.tinymceWpSkin,
 	'//s1.wp.com/wp-includes/css/dashicons.css',
 	window.app.tinymceEditorCss,
-	'//s1.wp.com/i/fonts/merriweather/merriweather.css',
+	'//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese',
 ];
 
 module.exports = React.createClass( {

--- a/client/devdocs/design/typography.jsx
+++ b/client/devdocs/design/typography.jsx
@@ -48,21 +48,21 @@ export default React.createClass( {
 		};
 
 		const contentTitle = {
-			fontFamily: 'Merriweather',
+			fontFamily: 'Noto Serif',
 			fontSize: '32px',
 			fontWeight: '700',
 			lineHeight: '40px'
 		};
 
 		const contentSubtitle = {
-			fontFamily: 'Merriweather',
+			fontFamily: 'Noto Serif',
 			fontSize: '24px',
 			fontWeight: '700',
 			lineHeight: '32px'
 		};
 
 		const contentBodyCopy = {
-			fontFamily: 'Merriweather',
+			fontFamily: 'Noto Serif',
 			fontSize: '16px',
 			fontWeight: '400',
 			lineHeight: '1.5'

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -64,7 +64,7 @@
 
 .devdocs__doc {
 	h1, h2, h3, h4, h5, h6 {
-		font-family: Merriweather, Georgia, "Times New Roman", Times, serif;
+		font-family: $serif;
 		font-weight: 700;
 		line-height: 1.5em;
 		margin-bottom: 0.6em;

--- a/client/my-sites/draft/style.scss
+++ b/client/my-sites/draft/style.scss
@@ -51,7 +51,7 @@
 	padding: 12px 16px 0;
 	background: $white;
 	z-index: 20;
-	border-bottom: 10px solid $white;
+	border-bottom: 8px solid $white;
 
 	a {
 		color: $gray-text;

--- a/client/reader/site-stream/style.scss
+++ b/client/reader/site-stream/style.scss
@@ -66,7 +66,7 @@
 
 .reader__featured-post-title {
 	position: relative;
-	font-family: Merriweather, Georgia, "Times New Roman", Times, serif;
+	font-family: $serif;
 	font-weight: 700;
 	font-size: 18px;
 	color: $white;

--- a/server/pages/404.jade
+++ b/server/pages/404.jade
@@ -10,7 +10,7 @@ html(lang='en')
 		link(rel='shortcut icon', type='image/x-icon', href='//s1.wp.com/i/favicon.ico', sizes='16x16')
 		link(rel='icon', type='image/x-icon', href='//s1.wp.com/i/favicon.ico', sizes='16x16')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
-		link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
+		link(rel='stylesheet', href='//s1.wp.com/i/fonts/notoserif/notoserif.css?v=20170320')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css')
 		link(rel='stylesheet', href=urls['style.css'])
 	body

--- a/server/pages/404.jade
+++ b/server/pages/404.jade
@@ -10,7 +10,7 @@ html(lang='en')
 		link(rel='shortcut icon', type='image/x-icon', href='//s1.wp.com/i/favicon.ico', sizes='16x16')
 		link(rel='icon', type='image/x-icon', href='//s1.wp.com/i/favicon.ico', sizes='16x16')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
-		link(rel='stylesheet', href='//s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210')
+		link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css')
 		link(rel='stylesheet', href=urls['style.css'])
 	body

--- a/server/pages/404.jade
+++ b/server/pages/404.jade
@@ -10,7 +10,7 @@ html(lang='en')
 		link(rel='shortcut icon', type='image/x-icon', href='//s1.wp.com/i/favicon.ico', sizes='16x16')
 		link(rel='icon', type='image/x-icon', href='//s1.wp.com/i/favicon.ico', sizes='16x16')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
-		link(rel='stylesheet', href='//s1.wp.com/i/fonts/notoserif/notoserif.css?v=20170320')
+		link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css')
 		link(rel='stylesheet', href=urls['style.css'])
 	body

--- a/server/pages/500.jade
+++ b/server/pages/500.jade
@@ -10,7 +10,7 @@ html(lang='en')
 		link(rel='shortcut icon', type='image/x-icon', href='//s1.wp.com/i/favicon.ico', sizes='16x16')
 		link(rel='icon', type='image/x-icon', href='//s1.wp.com/i/favicon.ico', sizes='16x16')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
-		link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
+		link(rel='stylesheet', href='//s1.wp.com/i/fonts/notoserif/notoserif.css?v=20170320')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css')
 		link(rel='stylesheet', href=urls['style.css'])
 	body

--- a/server/pages/500.jade
+++ b/server/pages/500.jade
@@ -10,7 +10,7 @@ html(lang='en')
 		link(rel='shortcut icon', type='image/x-icon', href='//s1.wp.com/i/favicon.ico', sizes='16x16')
 		link(rel='icon', type='image/x-icon', href='//s1.wp.com/i/favicon.ico', sizes='16x16')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
-		link(rel='stylesheet', href='//s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210')
+		link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css')
 		link(rel='stylesheet', href=urls['style.css'])
 	body

--- a/server/pages/500.jade
+++ b/server/pages/500.jade
@@ -10,7 +10,7 @@ html(lang='en')
 		link(rel='shortcut icon', type='image/x-icon', href='//s1.wp.com/i/favicon.ico', sizes='16x16')
 		link(rel='icon', type='image/x-icon', href='//s1.wp.com/i/favicon.ico', sizes='16x16')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
-		link(rel='stylesheet', href='//s1.wp.com/i/fonts/notoserif/notoserif.css?v=20170320')
+		link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css')
 		link(rel='stylesheet', href=urls['style.css'])
 	body

--- a/server/pages/browsehappy.jade
+++ b/server/pages/browsehappy.jade
@@ -37,7 +37,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		link(rel='apple-touch-icon', sizes='180x180', href='//s1.wp.com/i/favicons/apple-touch-icon-180x180.png')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
 		link(rel='manifest', href='/calypso/manifest.json')
-		link(rel='stylesheet', href='//s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210')
+		link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
 		link(rel='stylesheet', href='//s1.wp.com/wp-includes/css/dashicons.css?v=20150727')
 		if isRTL
@@ -58,11 +58,11 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 								img.empty-content__illustration(src="/calypso/images/drake/drake-browser.svg")
 								h2.empty-content__title Unsupported Browser
 								h3.empty-content__line
-									| Unfortunately this page cannot be used by your browser. You can either 
+									| Unfortunately this page cannot be used by your browser. You can either
 									a(
 										href=dashboardUrl
 									) use the classic WordPress dashboard
-									| , or 
+									| , or
 									a(
 										href="http://browsehappy.com"
 									) upgrade your browser

--- a/server/pages/browsehappy.jade
+++ b/server/pages/browsehappy.jade
@@ -37,7 +37,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		link(rel='apple-touch-icon', sizes='180x180', href='//s1.wp.com/i/favicons/apple-touch-icon-180x180.png')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
 		link(rel='manifest', href='/calypso/manifest.json')
-		link(rel='stylesheet', href='//s1.wp.com/i/fonts/notoserif/notoserif.css?v=20170320')
+		link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
 		link(rel='stylesheet', href='//s1.wp.com/wp-includes/css/dashicons.css?v=20150727')
 		if isRTL

--- a/server/pages/browsehappy.jade
+++ b/server/pages/browsehappy.jade
@@ -37,7 +37,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		link(rel='apple-touch-icon', sizes='180x180', href='//s1.wp.com/i/favicons/apple-touch-icon-180x180.png')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
 		link(rel='manifest', href='/calypso/manifest.json')
-		link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
+		link(rel='stylesheet', href='//s1.wp.com/i/fonts/notoserif/notoserif.css?v=20170320')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
 		link(rel='stylesheet', href='//s1.wp.com/wp-includes/css/dashicons.css?v=20150727')
 		if isRTL

--- a/server/pages/desktop.jade
+++ b/server/pages/desktop.jade
@@ -11,7 +11,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class='is-desktop' + ( isFluidWidth ?
 		link(rel='shortcut icon', type='image/x-icon', href=faviconURL, sizes='16x16')
 		link(rel='icon', type='image/x-icon', href=faviconURL, sizes='16x16')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
-		link(rel='stylesheet', href='https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
+		link(rel='stylesheet', href='https://s1.wp.com/i/fonts/notoserif/notoserif.css?v=20170320')
 		link(rel='stylesheet', href='https://s1.wp.com/i/noticons/noticons.css?v=20150727')
 		link(rel='stylesheet', href='https://s1.wp.com/wp-includes/css/dashicons.css?v=20150727')
 		if isRTL

--- a/server/pages/desktop.jade
+++ b/server/pages/desktop.jade
@@ -11,7 +11,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class='is-desktop' + ( isFluidWidth ?
 		link(rel='shortcut icon', type='image/x-icon', href=faviconURL, sizes='16x16')
 		link(rel='icon', type='image/x-icon', href=faviconURL, sizes='16x16')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
-		link(rel='stylesheet', href='https://s1.wp.com/i/fonts/notoserif/notoserif.css?v=20170320')
+		link(rel='stylesheet', href='https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
 		link(rel='stylesheet', href='https://s1.wp.com/i/noticons/noticons.css?v=20150727')
 		link(rel='stylesheet', href='https://s1.wp.com/wp-includes/css/dashicons.css?v=20150727')
 		if isRTL

--- a/server/pages/desktop.jade
+++ b/server/pages/desktop.jade
@@ -11,7 +11,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class='is-desktop' + ( isFluidWidth ?
 		link(rel='shortcut icon', type='image/x-icon', href=faviconURL, sizes='16x16')
 		link(rel='icon', type='image/x-icon', href=faviconURL, sizes='16x16')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
-		link(rel='stylesheet', href='https://s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210')
+		link(rel='stylesheet', href='https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
 		link(rel='stylesheet', href='https://s1.wp.com/i/noticons/noticons.css?v=20150727')
 		link(rel='stylesheet', href='https://s1.wp.com/wp-includes/css/dashicons.css?v=20150727')
 		if isRTL

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -44,7 +44,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		link(rel='apple-touch-icon', sizes='180x180', href='//s1.wp.com/i/favicons/apple-touch-icon-180x180.png')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
 		link(rel='manifest', href='/calypso/manifest.json')
-		link(rel='stylesheet', href='//s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210')
+		link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
 		link(rel='stylesheet', href='//s1.wp.com/wp-includes/css/dashicons.css?v=20150727')
 		if isRTL

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -44,7 +44,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		link(rel='apple-touch-icon', sizes='180x180', href='//s1.wp.com/i/favicons/apple-touch-icon-180x180.png')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
 		link(rel='manifest', href='/calypso/manifest.json')
-		link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
+		link(rel='stylesheet', href='//s1.wp.com/i/fonts/notoserif/notoserif.css?v=20170320')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
 		link(rel='stylesheet', href='//s1.wp.com/wp-includes/css/dashicons.css?v=20150727')
 		if isRTL

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -44,7 +44,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		link(rel='apple-touch-icon', sizes='180x180', href='//s1.wp.com/i/favicons/apple-touch-icon-180x180.png')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
 		link(rel='manifest', href='/calypso/manifest.json')
-		link(rel='stylesheet', href='//s1.wp.com/i/fonts/notoserif/notoserif.css?v=20170320')
+		link(rel='stylesheet', href='https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
 		link(rel='stylesheet', href='//s1.wp.com/wp-includes/css/dashicons.css?v=20150727')
 		if isRTL


### PR DESCRIPTION
## This is a redo of #11624

fixes #11614 

**Uses fonts from Google's CDN (Google Fonts)**

After I quick test I found that the Noto fonts we were serving with our CDN are **much** larger than the font files Google generates. 

Fonts that have a lot of subsets need some special font loading.

Some considerations:

- ~Is the google hosted version the best option vs hosting our own?~ **Google CDN appears to be faster**
- ~Is there a bandwidth difference using Noto Serif, because of all the additional glyphs? Does it make a difference?~ **The switch to Noto actually might be faster for some if not most users**
- ~There are some complex font switches that need to happen to get 100% language coverage (I think). Is it best to ship this now, and figure it out it another PR?~ **Yes**
- ~the WP desktop app uses https to load assets, and I don't know if Google Fonts can be loaded over https: https://github.com/Automattic/wp-calypso/pull/12326/files#diff-7a3d2e2c2f14b3738939aef8624eece3L14~ **It should be fine**

Before:
![screen shot 2017-02-27 at 4 27 39 pm](https://cloud.githubusercontent.com/assets/618551/23382915/b75b1750-fd09-11e6-868e-4f43e7cae2e7.png)


After:
![screen shot 2017-02-27 at 4 20 24 pm](https://cloud.githubusercontent.com/assets/618551/23382654/b2a1cbf6-fd08-11e6-87c1-061da6502683.png)

cc @mattmiklic 