### PR TITLE
Menus: remove Calypso menus and send to Customizer instead

### DIFF
--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -5,9 +5,11 @@ import { combineTours } from 'layout/guided-tours/config-elements';
 import { MainTour } from 'layout/guided-tours/tours/main-tour';
 import { TutorialSitePreviewTour } from 'layout/guided-tours/tours/tutorial-site-preview-tour';
 import { GDocsIntegrationTour } from 'layout/guided-tours/tours/gdocs-integration-tour';
+import { MenuRemovalTour } from 'layout/guided-tours/tours/menu-removal-tour';
 
 export default combineTours( {
 	main: MainTour,
 	tutorialSitePreview: TutorialSitePreviewTour,
 	gdocsIntegrationTour: GDocsIntegrationTour,
+	menuRemoval: MenuRemovalTour,
 } );

--- a/client/layout/guided-tours/tours/menu-removal-tour.js
+++ b/client/layout/guided-tours/tours/menu-removal-tour.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import {
+	makeTour,
+	Tour,
+	Step,
+	ButtonRow,
+	Quit,
+} from 'layout/guided-tours/config-elements';
+import { isSelectedSiteCustomizable } from 'state/ui/guided-tours/contexts';
+
+export const MenuRemovalTour = makeTour(
+	<Tour name="menuRemoval" version="20170308" path="/stats" when={ isSelectedSiteCustomizable }>
+		<Step name="init"
+			target="themes"
+			arrow="left-top"
+			placement="beside"
+			when={ isSelectedSiteCustomizable }
+			scrollContainer=".sidebar__region"
+			shouldScrollTo
+		>
+			<p>
+				{
+					translate( '{{strong}}New!{{/strong}} Create and edit navigation menus with live preview' +
+						' in the {{strong}}Customizer{{/strong}}',
+						{
+							components: {
+								strong: <strong />,
+							}
+						} )
+				}
+			</p>
+			<ButtonRow>
+				<Quit primary>{ translate( 'Affirmative!' ) }</Quit>
+			</ButtonRow>
+		</Step>
+	</Tour>
+);

--- a/client/my-sites/customize/panels.js
+++ b/client/my-sites/customize/panels.js
@@ -8,7 +8,8 @@ export const PANEL_MAPPINGS = {
 	fonts: [ 'section', 'jetpack_fonts' ],
 	identity: [ 'section', 'title_tagline' ],
 	'custom-css': [ 'section', 'jetpack_custom_css' ],
-	amp: [ 'section', 'amp_design' ]
+	amp: [ 'section', 'amp_design' ],
+	menus: [ 'panel', 'nav_menus' ],
 };
 
 /**

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -223,43 +223,6 @@ export class MySitesSidebar extends Component {
 		);
 	}
 
-	menus() {
-		var site = this.getSelectedSite(),
-			menusLink = '/menus' + this.siteSuffix(),
-			showClassicLink = ! config.isEnabled( 'manage/menus' );
-
-		if ( ! site ) {
-			return null;
-		}
-
-		if ( ! site.capabilities ) {
-			return null;
-		}
-
-		if ( site.capabilities && ! site.capabilities.edit_theme_options ) {
-			return null;
-		}
-
-		if ( ! this.isSingle() ) {
-			return null;
-		}
-
-		if ( showClassicLink ) {
-			menusLink = site.options.admin_url + 'nav-menus.php';
-		}
-
-		return (
-			<SidebarItem
-				tipTarget="menus"
-				label={ this.props.translate( 'Menus' ) }
-				className={ this.itemLinkClass( '/menus', 'menus' ) }
-				link={ menusLink }
-				onNavigate={ this.onNavigate }
-				icon="menus"
-				preloadSectionName="menus" />
-		);
-	}
-
 	plugins() {
 		var site = this.getSelectedSite(),
 			pluginsLink = '/plugins' + this.siteSuffix(),
@@ -591,7 +554,7 @@ export class MySitesSidebar extends Component {
 		}
 
 		const publish = !! this.publish(),
-			appearance = ( !! this.themes() || !! this.menus() ),
+			appearance = ( !! this.themes() ),
 			configuration = ( !! this.sharing() || !! this.users() || !! this.siteSettings() || !! this.plugins() || !! this.upgrades() );
 
 		return (
@@ -616,7 +579,6 @@ export class MySitesSidebar extends Component {
 						<SidebarHeading>{ this.props.translate( 'Personalize' ) }</SidebarHeading>
 						<ul>
 							{ this.themes() }
-							{ this.menus() }
 						</ul>
 					</SidebarMenu>
 					: null


### PR DESCRIPTION
This PR will completely remove menu management from Calypso and defer to the Customizer's menu functionality. Calypso menus are not being maintained, and the Customizer's live preview functionality makes for a better UX. 

A Guided Tour will be shown to all users to indicate that the Menu functionality is now in the Customizer.

Fixes #4610