### PR TITLE
Themes: Show better error notice for failed transfer initiation

### DIFF
--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -136,7 +136,7 @@ class Upload extends React.Component {
 			'Too Large': translate( 'Upload problem: Zip file too large to upload.' ),
 			incompatible: translate( 'Upload problem: Incompatible theme.' ),
 			unsupported_mime_type: translate( 'Upload problem: Not a valid zip file' ),
-			not_found: translate( 'Upload problem: Not a valid theme' ),
+			initiate_failure: translate( 'Upload problem: Theme may not be valid' ),
 		};
 
 		const errorString = JSON.stringify( error );

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -136,6 +136,7 @@ class Upload extends React.Component {
 			'Too Large': translate( 'Upload problem: Zip file too large to upload.' ),
 			incompatible: translate( 'Upload problem: Incompatible theme.' ),
 			unsupported_mime_type: translate( 'Upload problem: Not a valid zip file' ),
+			not_found: translate( 'Upload problem: Not a valid theme' ),
 		};
 
 		const errorString = JSON.stringify( error );

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -644,6 +644,11 @@ export function initiateThemeTransfer( siteId, file, plugin ) {
 			} );
 		} )
 			.then( ( { transfer_id } ) => {
+				if ( ! transfer_id ) {
+					return dispatch(
+						transferInitiateFailure( siteId, { error: 'initiate_failure' }, plugin )
+					);
+				}
 				const themeInitiateSuccessAction = {
 					type: THEME_TRANSFER_INITIATE_SUCCESS,
 					siteId,
@@ -656,15 +661,7 @@ export function initiateThemeTransfer( siteId, file, plugin ) {
 				dispatch( pollThemeTransferStatus( siteId, transfer_id ) );
 			} )
 			.catch( error => {
-				const themeInitiateFailureAction = {
-					type: THEME_TRANSFER_INITIATE_FAILURE,
-					siteId,
-					error,
-				};
-				dispatch( withAnalytics(
-					recordTracksEvent( 'calypso_automatic_transfer_inititate_failure', { plugin } ),
-					themeInitiateFailureAction
-				) );
+				dispatch( transferInitiateFailure( siteId, error, plugin ) );
 			} );
 	};
 }
@@ -691,6 +688,20 @@ function transferStatusFailure( siteId, transferId, error ) {
 	};
 }
 
+// receive a transfer initiation failure
+function transferInitiateFailure( siteId, error, plugin ) {
+	return dispatch => {
+		const themeInitiateFailureAction = {
+			type: THEME_TRANSFER_INITIATE_FAILURE,
+			siteId,
+			error,
+		};
+		dispatch( withAnalytics(
+			recordTracksEvent( 'calypso_automatic_transfer_inititate_failure', { plugin } ),
+			themeInitiateFailureAction
+		) );
+	};
+}
 /**
  * Make API calls to the transfer status endpoint until a status complete is received,
  * or an error is received, or the timeout is reached.


### PR DESCRIPTION
Updates after https://github.com/Automattic/automated-transfer/issues/109

<img width="974" alt="screen shot 2017-03-20 at 17 20 57" src="https://cloud.githubusercontent.com/assets/7767559/24112498/a097d4a2-0d91-11e7-9d74-7b06d2caad6a.png">

If transfer initiation request returns transfer id of 0, dispatch an error instead of polling status of the 0 transfer. Display notice in theme page of likely cause.

**To Test**
* Initiate automated transfer process with a zip that is not actually a theme
* Or, go to http://calypso.localhost:3000/design/upload and pick a Jetpack site, then dispatch an error in the console:
`dispatch( { type: 'THEME_TRANSFER_INITIATE_FAILURE', siteId: 83720453, error: { error: 'initiate_failure' } } )`

