### PR TITLE
NPS Survey: Initial skeleton of NPS Survey block

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -30,6 +30,7 @@
 @import 'blocks/eligibility-warnings/style';
 @import 'blocks/image-editor/style';
 @import 'blocks/like-button/style';
+@import 'blocks/nps-survey/style';
 @import 'blocks/plan-storage/style';
 @import 'blocks/plan-thank-you-card/style';
 @import 'blocks/post-edit-button/style';

--- a/client/blocks/nps-survey/README.md
+++ b/client/blocks/nps-survey/README.md
@@ -1,0 +1,35 @@
+NPS Survey
+==========
+
+This block is used to display a Net Promoter Score (NPS) survey to the user.
+
+*Note: Currently still in development and not used in production yet.
+The following is still outstanding:*
+
+* Styling (the current implementation focused on getting the code structure
+	in place, not concerning ourselves with the styling or wording yet)
+* Wrapping strings for translation (since design and styling isn't finalized yet,
+	no need to translate likely-to-change wording)
+* Redux actions and state usage (this will likely remove the need for the
+	`onDismissed` handler prop)
+
+### Usage
+
+```javascript
+	<NpsSurvey
+		name="some_screen_v1"
+		onDismissed={ this.handleSurveyDismissed }
+	/>
+```
+
+### Props
+
+* `name`: The name of the survey, used in reporting to segment by location survey
+	was shown and version of survey. Each distinct location and version combo should
+	have a unique name.
+* `onDismissed`: A handler that is fired when the survey has been dismissed. An
+	event object with the following properties will be passed to the handler:
+	* `wasSubmitted`: `true` if the survey was submitted, `false` if the user dismissed
+		the survey without submitting it.
+	* `surveyName`: The name of the survey.
+	* `recommendationValue`: the value the user selected in the survey (0-10)

--- a/client/blocks/nps-survey/docs/example.jsx
+++ b/client/blocks/nps-survey/docs/example.jsx
@@ -1,61 +1,70 @@
 /**
  * External dependencies
  */
- import React, { PureComponent } from 'react';
+import React, { PureComponent } from 'react';
 
- /**
-  *
-	*/
-	import NpsSurvey from '../';
+/**
+ * Internal dependencies
+ */
+import NpsSurvey from '../';
+import { isEnabled } from 'config';
 
-	class NpsSurveyExample extends PureComponent {
-		constructor( props ) {
-			super( props );
-			this.state = {
-				wasDismissed: false,
-				wasSubmitted: false,
-				surveyName: null,
-				recommendationValue: null,
-			};
-			this.handleDismissed = this.handleDismissed.bind( this );
-		}
+class NpsSurveyExample extends PureComponent {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			wasDismissed: false,
+			wasSubmitted: false,
+			surveyName: null,
+			recommendationValue: null,
+		};
+		this.handleDismissed = this.handleDismissed.bind( this );
+	}
 
-		handleDismissed( event ) {
-			this.setState( {
-				wasDismissed: true,
-				wasSubmitted: event.wasSubmitted,
-				surveyName: event.surveyName,
-				recommendationValue: event.recommendationValue
-			} );
-		}
+	handleDismissed( event ) {
+		this.setState( {
+			wasDismissed: true,
+			wasSubmitted: event.wasSubmitted,
+			surveyName: event.surveyName,
+			recommendationValue: event.recommendationValue
+		} );
+	}
 
-		render() {
+	render() {
+		// Since this component is still in-progress and unstyled, we will hide it from
+		// the display in DevDocs unless in the development environment.
+		if ( ! isEnabled( 'nps-survey/devdocs' ) ) {
 			return (
-				<div>
-					{ ! this.state.wasDismissed &&
-						<NpsSurvey
-							name="devdocs"
-							onDismissed={ this.handleDismissed }
-						/>
-					}
-					{ this.state.wasDismissed && this.state.wasSubmitted &&
-						<div>
-							User dismissed survey after submitting:
-							<ul>
-								<li>Survey name: { this.state.surveyName }</li>
-								<li>Recommendation value: { this.state.recommendationValue }</li>
-							</ul>
-						</div>
-					}
-					{ this.state.wasDismissed && ! this.state.wasSubmitted &&
-						<div>
-							User dismissed survey without submitting.
-						</div>
-					}
-				</div>
+				<div>NPS Survey component is currently only available in the development environment.</div>
 			);
 		}
+
+		return (
+			<div>
+				{ ! this.state.wasDismissed &&
+					<NpsSurvey
+						name="devdocs"
+						onDismissed={ this.handleDismissed }
+					/>
+				}
+				{ this.state.wasDismissed && this.state.wasSubmitted &&
+					<div>
+						User dismissed survey after submitting:
+						<ul>
+							<li>Survey name: { this.state.surveyName }</li>
+							<li>Recommendation value: { this.state.recommendationValue }</li>
+						</ul>
+					</div>
+				}
+				{ this.state.wasDismissed && ! this.state.wasSubmitted &&
+					<div>
+						User dismissed survey without submitting.
+					</div>
+				}
+			</div>
+		);
 	}
+}
 
 NpsSurveyExample.displayName = 'NpsSurvey';
 

--- a/client/blocks/nps-survey/docs/example.jsx
+++ b/client/blocks/nps-survey/docs/example.jsx
@@ -7,7 +7,6 @@ import React, { PureComponent } from 'react';
  * Internal dependencies
  */
 import NpsSurvey from '../';
-import { isEnabled } from 'config';
 
 class NpsSurveyExample extends PureComponent {
 	constructor( props ) {
@@ -31,14 +30,6 @@ class NpsSurveyExample extends PureComponent {
 	}
 
 	render() {
-		// Since this component is still in-progress and unstyled, we will hide it from
-		// the display in DevDocs unless in the development environment.
-		if ( ! isEnabled( 'nps-survey/devdocs' ) ) {
-			return (
-				<div>NPS Survey component is currently only available in the development environment.</div>
-			);
-		}
-
 		return (
 			<div>
 				{ ! this.state.wasDismissed &&

--- a/client/blocks/nps-survey/docs/example.jsx
+++ b/client/blocks/nps-survey/docs/example.jsx
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+ import React, { PureComponent } from 'react';
+
+ /**
+  *
+	*/
+	import NpsSurvey from '../';
+
+	class NpsSurveyExample extends PureComponent {
+		constructor( props ) {
+			super( props );
+			this.state = {
+				wasDismissed: false,
+				wasSubmitted: false,
+				surveyName: null,
+				recommendationValue: null,
+			};
+			this.handleDismissed = this.handleDismissed.bind( this );
+		}
+
+		handleDismissed( event ) {
+			this.setState( {
+				wasDismissed: true,
+				wasSubmitted: event.wasSubmitted,
+				surveyName: event.surveyName,
+				recommendationValue: event.recommendationValue
+			} );
+		}
+
+		render() {
+			return (
+				<div>
+					{ ! this.state.wasDismissed &&
+						<NpsSurvey
+							name="devdocs"
+							onDismissed={ this.handleDismissed }
+						/>
+					}
+					{ this.state.wasDismissed && this.state.wasSubmitted &&
+						<div>
+							User dismissed survey after submitting:
+							<ul>
+								<li>Survey name: { this.state.surveyName }</li>
+								<li>Recommendation value: { this.state.recommendationValue }</li>
+							</ul>
+						</div>
+					}
+					{ this.state.wasDismissed && ! this.state.wasSubmitted &&
+						<div>
+							User dismissed survey without submitting.
+						</div>
+					}
+				</div>
+			);
+		}
+	}
+
+NpsSurveyExample.displayName = 'NpsSurvey';
+
+export default NpsSurveyExample;

--- a/client/blocks/nps-survey/index.jsx
+++ b/client/blocks/nps-survey/index.jsx
@@ -1,0 +1,112 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import RecommendationSelect from './recommendation-select';
+
+class NpsSurvey extends Component {
+	static propTypes = {
+		onDismissed: PropTypes.func,
+		name: PropTypes.string
+	}
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			recommendationValue: null,
+			isSubmitting: false,
+			isSubmitted: false
+		};
+		this.handleRecommendationSelectChange = this.handleRecommendationSelectChange.bind( this );
+		this.handleFinishClick = this.handleFinishClick.bind( this );
+		this.handleDismissClick = this.handleDismissClick.bind( this );
+	}
+
+	handleRecommendationSelectChange( newRecommendationValue ) {
+		this.setState( {
+			recommendationValue: newRecommendationValue
+		} );
+	}
+
+	handleFinishClick() {
+		// TODO: fire Redux action and use Redux state tree to determine when
+		// survey has been submitted
+		this.setState( {
+			isSubmitting: true
+		} );
+
+		// simulate requestresponse time
+		setTimeout( () => {
+			this.setState( {
+				isSubmitted: true
+			} );
+		}, 500 );
+	}
+
+	handleDismissClick() {
+		// TODO: fire Redux action and use Redux state tree to determine
+		// if survey has been dismissed
+
+		this.props.onDismissed( {
+			wasSubmitted: this.state.isSubmitted,
+			surveyName: this.props.name,
+			recommendationValue: this.state.recommendationValue
+		} );
+	}
+
+	render() {
+		const className = classNames( 'nps-survey', {
+			'is-recommendation-selected': Number.isInteger( this.state.recommendationValue ),
+			'is-submitting': this.state.isSubmitting,
+			'is-submitted': this.state.isSubmitted
+		} );
+
+		return (
+			<div className={ className }>
+				<div className="nps-survey__question-screen">
+					<div>How likely is it that you would recommend WordPress.com to your friends, family, or colleagues?</div>
+					<div>
+						<RecommendationSelect
+							value={ this.state.recommendationValue }
+							disabled={ this.state.isSubmitting }
+							onChange={ this.handleRecommendationSelectChange }
+						/>
+					</div>
+					<div>
+						<Button primary
+							className="nps-survey__finish-button"
+							disabled={ this.state.isSubmitting }
+							onClick={ this.handleFinishClick }
+						>
+							Finish
+						</Button>
+						<Button borderless
+							disabled={ this.state.isSubmitting }
+							onClick={ this.handleDismissClick }
+						>
+							I'd rather not answer
+						</Button>
+					</div>
+				</div>
+				<div className="nps-survey__thank-you-screen">
+					Thanks for providing your feedback!
+					<div>
+						<Button primary
+							onClick={ this.handleDismissClick }
+						>
+							Dismiss
+						</Button>
+					</div>
+				</div>
+		</div>
+		);
+	}
+}
+
+export default NpsSurvey;

--- a/client/blocks/nps-survey/index.jsx
+++ b/client/blocks/nps-survey/index.jsx
@@ -44,6 +44,7 @@ class NpsSurvey extends Component {
 		// simulate requestresponse time
 		setTimeout( () => {
 			this.setState( {
+				isSubmitting: false,
 				isSubmitted: true
 			} );
 		}, 500 );
@@ -67,6 +68,8 @@ class NpsSurvey extends Component {
 			'is-submitted': this.state.isSubmitted
 		} );
 
+		const shouldDisableControls = this.state.isSubmitting || this.state.isSubmitted;
+
 		return (
 			<div className={ className }>
 				<div className="nps-survey__question-screen">
@@ -74,20 +77,20 @@ class NpsSurvey extends Component {
 					<div>
 						<RecommendationSelect
 							value={ this.state.recommendationValue }
-							disabled={ this.state.isSubmitting }
+							disabled={ shouldDisableControls }
 							onChange={ this.handleRecommendationSelectChange }
 						/>
 					</div>
 					<div>
 						<Button primary
 							className="nps-survey__finish-button"
-							disabled={ this.state.isSubmitting }
+							disabled={ shouldDisableControls }
 							onClick={ this.handleFinishClick }
 						>
 							Finish
 						</Button>
 						<Button borderless
-							disabled={ this.state.isSubmitting }
+							disabled={ shouldDisableControls }
 							onClick={ this.handleDismissClick }
 						>
 							I'd rather not answer

--- a/client/blocks/nps-survey/recommendation-option.jsx
+++ b/client/blocks/nps-survey/recommendation-option.jsx
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import FormRadio from 'components/forms/form-radio';
+import FormLabel from 'components/forms/form-label';
+
+class RecommendationOption extends Component {
+	constructor( props ) {
+		super( props );
+		this.handleChange = this.handleChange.bind( this );
+	}
+
+	static propTypes = {
+		disabled: PropTypes.bool,
+		selected: PropTypes.bool,
+		value: PropTypes.number,
+	}
+
+	handleChange( event ) {
+		this.props.onChange( parseInt( event.target.value, 10 ) );
+	}
+
+	render() {
+		return (
+			<FormLabel>
+				<FormRadio
+					className="nps-survey__recommendation-option"
+					name="nps-survey-recommendation-option"
+					value={ this.props.value }
+					checked={ this.props.selected }
+					disabled={ this.props.disabled }
+					onChange={ this.handleChange }
+				/>
+				<span>{ this.props.value }</span>
+			</FormLabel>
+		);
+	}
+}
+
+export default RecommendationOption;

--- a/client/blocks/nps-survey/recommendation-select.jsx
+++ b/client/blocks/nps-survey/recommendation-select.jsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes, PureComponent } from 'react';
+import { range } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import RecommendationOption from './recommendation-option';
+
+class RecommendationSelect extends PureComponent {
+	static propTypes = {
+		disabled: PropTypes.bool
+	}
+
+	renderOption( value ) {
+		return (
+			<RecommendationOption
+				key={ value }
+				value={ value }
+				selected={ this.props.value === value }
+				disabled={ this.props.disabled }
+				onChange={ this.props.onChange }
+			/>
+		);
+	}
+
+	render() {
+		const values = range( 0, 11 );
+		const options = values.map( ( value ) => this.renderOption( value ) );
+
+		return (
+			<div>
+				{ options }
+			</div>
+		);
+	}
+}
+
+export default RecommendationSelect;

--- a/client/blocks/nps-survey/style.scss
+++ b/client/blocks/nps-survey/style.scss
@@ -1,0 +1,27 @@
+.nps-survey {
+	border: 1px solid $gray-dark;
+}
+
+.nps-survey__thank-you-screen {
+	display: none;
+}
+
+.button.nps-survey__finish-button {
+	display: none;
+}
+
+.nps-survey.is-submitted {
+	.nps-survey__question-screen {
+		display: none;
+	}
+
+	.nps-survey__thank-you-screen {
+		display: block;
+	}
+}
+
+.nps-survey.is-recommendation-selected {
+	.button.nps-survey__finish-button {
+		display: inline-block;
+	}
+}

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -57,6 +57,7 @@ import DailyPostButton from 'blocks/daily-post-button/docs/example';
 import ReaderSubscriptionListItem from 'blocks/reader-subscription-list-item/docs/example';
 import PostLikes from 'blocks/post-likes/docs/example';
 import ReaderFeaturedVideo from 'blocks/reader-featured-video/docs/example';
+import NpsSurvey from 'blocks/nps-survey/docs/example';
 
 export default React.createClass( {
 
@@ -134,6 +135,7 @@ export default React.createClass( {
 					<DailyPostButton />
 					<PostLikes />
 					<ReaderFeaturedVideo />
+					<NpsSurvey />
 				</Collection>
 			</Main>
 		);

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -13,6 +13,7 @@ import Collection from 'devdocs/design/search-collection';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import SearchCard from 'components/search-card';
+import { isEnabled } from 'config';
 
 /**
  * Docs examples
@@ -135,7 +136,9 @@ export default React.createClass( {
 					<DailyPostButton />
 					<PostLikes />
 					<ReaderFeaturedVideo />
-					<NpsSurvey />
+					{ isEnabled( 'nps-survey/devdocs' ) &&
+						<NpsSurvey />
+					}
 				</Collection>
 			</Main>
 		);

--- a/config/development.json
+++ b/config/development.json
@@ -102,6 +102,7 @@
 		"me/next-steps": true,
 		"me/notifications": true,
 		"me/trophies": false,
+		"nps-survey/devdocs": true,
 		"preview-layout": true,
 		"paladin": true,
 		"network-connection": true,

--- a/config/production.json
+++ b/config/production.json
@@ -61,6 +61,7 @@
 		"me/next-steps": true,
 		"me/notifications": true,
 		"me/trophies": false,
+		"nps-survey/devdocs": false,
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -66,6 +66,7 @@
 		"me/notifications": true,
 		"me/trophies": false,
 		"notifications2beta": true,
+		"nps-survey/devdocs": false,
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -80,6 +80,7 @@
 		"me/trophies": false,
 		"network-connection": true,
 		"notifications2beta": true,
+		"nps-survey/devdocs": false,
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,


### PR DESCRIPTION
This block is used to display a Net Promoter Score (NPS) survey to the user. This block will be used as part of a flow to collect feedback from the user on how likely they are to recommend WordPress.com to a friend/family/colleague.

*Note: NPS survey is currently still in development and not used in production yet. The following is still outstanding and will be added in future PRs:*

* Styling/UX (the current PR focuses on getting the code structure
	in place, not concerning ourselves with the styling or wording yet)
* Wrapping strings for translation (since design and styling isn't finalized yet,
	no need to translate likely-to-change wording)
* Redux actions and state usage (this will likely remove the need for the
	`onDismissed` handler prop)

To test:
- Go to `http://calypso.localhost:3000/devdocs/blocks/nps-survey`
- Try answering survey (select a score; click Finish; then Dismiss on the thank you screen)
- Try dismissing without answering survey (select a score, or not; Then click I'd rather not answer)

