### PR TITLE
Reader: add route for Manage Following refresh at /following/manage

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -429,6 +429,7 @@
 @import 'reader/discover/style';
 @import 'reader/following/style';
 @import 'reader/following-edit/style';
+@import 'reader/following-manage/style';
 @import 'reader/stream/style';
 @import 'reader/list-gap/style';
 @import 'reader/list-item/style';

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+class FollowingManage extends React.Component {
+
+	render() {
+		return (
+			<div className="reader-following-manage">
+				<h1 className="reader-following-manage__title">Manage Following</h1>
+				<p>This is the shiny new version of Manage Following.</p>
+			</div>
+		);
+	}
+}
+
+export default FollowingManage;

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -1,0 +1,3 @@
+.reader-following-manage__title {
+	font-size: 1.4em;
+}

--- a/client/reader/following/controller.js
+++ b/client/reader/following/controller.js
@@ -38,5 +38,29 @@ export default {
 			document.getElementById( 'primary' ),
 			context.store
 		);
+	},
+
+	followingManage( context ) {
+		const basePath = route.sectionify( context.path ),
+			fullAnalyticsPageTitle = analyticsPageTitle + ' > Manage Followed Sites',
+			mcKey = 'following_edit',
+			search = context.query.s;
+
+		setPageTitle( context, i18n.translate( 'Manage Followed Sites' ) );
+
+		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
+
+		renderWithReduxStore(
+			<AsyncLoad
+				require="reader/following-manage"
+				key="following-manage"
+				initialFollowUrl={ context.query.follow }
+				search={ search }
+				context={ context }
+				userSettings={ userSettings }
+			/>,
+			document.getElementById( 'primary' ),
+			context.store
+		);
 	}
 };

--- a/client/reader/following/index.js
+++ b/client/reader/following/index.js
@@ -8,8 +8,12 @@ import page from 'page';
  */
 import controller from './controller';
 import readerController from 'reader/controller';
+import config from 'config';
 
 export default function() {
 	page( '/following/*', readerController.loadSubscriptions, readerController.initAbTests );
 	page( '/following/edit', readerController.updateLastRoute, readerController.sidebar, controller.followingEdit );
+	if ( config.isEnabled( 'reader/following-manage-refresh' ) ) {
+		page( '/following/manage', readerController.updateLastRoute, readerController.sidebar, controller.followingManage );
+	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -122,6 +122,7 @@
 		"push-notifications": true,
 		"reader": true,
 		"reader/combined-cards": true,
+		"reader/following-manage-refresh": true,
 		"reader/full-errors": true,
 		"reader/list-management": false,
 		"reader/recommendations/posts": true,


### PR DESCRIPTION
This PR adds a new route `/following/manage` (available in development only). 

This will be used for developing the refreshed version of Manage Following whilst keeping the existing version accessible at the old URL (`/following/edit`).

### To test

Load http://calypso.localhost:3000/following/manage. You should see this:

<img width="902" alt="screen shot 2017-03-20 at 19 19 33" src="https://cloud.githubusercontent.com/assets/17325/24117450/3150f158-0da2-11e7-89fd-28f35ad1541d.png">