### PR TITLE
Reader: Allow mixcloud through the sandbox

### DIFF
--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -139,6 +139,7 @@ export function iframeIsWhitelisted( iframe ) {
 		'embed.itunes.apple.com',
 		'nyt.com',
 		'google.com',
+		'mixcloud.com',
 	];
 	const hostName = iframe.src && url.parse( iframe.src ).hostname;
 	const iframeSrc = hostName && hostName.toLowerCase();


### PR DESCRIPTION
Lets mixcloud embeds work in full post view. Used by Nerdist and others.