### PR TITLE
Add publicize footer section scaffolding

### DIFF
--- a/client/components/section-nav/index.jsx
+++ b/client/components/section-nav/index.jsx
@@ -22,7 +22,8 @@ var SectionNav = React.createClass( {
 		selectedText: React.PropTypes.node,
 		selectedCount: React.PropTypes.number,
 		hasPinnedItems: React.PropTypes.bool,
-		onMobileNavPanelOpen: React.PropTypes.func
+		onMobileNavPanelOpen: React.PropTypes.func,
+		className: React.PropTypes.string
 	},
 
 	getInitialState: function() {
@@ -61,7 +62,7 @@ var SectionNav = React.createClass( {
 			className = classNames( {
 				'section-nav': true,
 				'is-empty': true
-			} );
+			}, this.props.className );
 
 			return (
 				<div className={ className }>
@@ -76,7 +77,7 @@ var SectionNav = React.createClass( {
 			'section-nav': true,
 			'is-open': this.state.mobileOpen,
 			'has-pinned-items': this.hasPinnedSearch || this.props.hasPinnedItems
-		} );
+		}, this.props.className );
 
 		return (
 			<div className={ className }>

--- a/client/components/section-nav/index.jsx
+++ b/client/components/section-nav/index.jsx
@@ -23,7 +23,7 @@ var SectionNav = React.createClass( {
 		selectedCount: React.PropTypes.number,
 		hasPinnedItems: React.PropTypes.bool,
 		onMobileNavPanelOpen: React.PropTypes.func,
-		className: React.PropTypes.string
+		className: React.PropTypes.string,
 	},
 
 	getInitialState: function() {

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -156,7 +156,22 @@ class PostShare extends Component {
 	}
 
 	renderScheduledList() {
-		return 'scheduled';
+		const { planSlug } = this.props;
+
+		if ( planSlug !== PLAN_BUSINESS ) {
+			return (
+				<Banner
+					className="post-share__footer-banner"
+					callToAction="Upgrade for $9.99"
+					description="Live chat support and no advertising."
+					dismissPreferenceName="devdocs-banner-example"
+					dismissTemporary
+					list={ [ 'Live chat support', 'No advertising' ] }
+					plan={ PLAN_BUSINESS }
+					title="Upgrade to a Business Plan!"
+				/>
+			);
+		}
 	}
 
 	renderPublishedList() {

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -201,13 +201,13 @@ class PostShare extends Component {
 				<div className="post-share__footer-item">
 					<div className="post-share__handle">
 						<SocialLogo icon={ service === 'google_plus' ? 'google-plus' : service } />
-						<span>
+						<span className="post-share__handle-value">
 							{ service === 'twitter' ? `@${ handle }` : handle }
 						</span>
 					</div>
 					<div className="post-share__timestamp">
 						<Gridicon icon="time" size={ 18 } />
-						<span>
+						<span className="post-share__timestamp-value">
 							{ timestamp }
 						</span>
 					</div>
@@ -252,7 +252,7 @@ class PostShare extends Component {
 					description={ translate( 'Live chat support and no advertising.' ) }
 					list={ [
 						translate( 'Live chat support' ),
-						translate( 'No advertising' )
+						translate( 'No Advertising' )
 					] }
 					plan={ PLAN_BUSINESS }
 					title={ translate( 'Upgrade to a Business Plan!' ) }

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { includes, map } from 'lodash';
+import { includes, map, partial } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -34,6 +34,9 @@ import {
 import Banner from 'components/banner';
 import Connection from './connection';
 import { isEnabled } from 'config';
+import SectionNav from 'components/section-nav';
+import NavTabs from 'components/section-nav/tabs';
+import NavItem from 'components/section-nav/item';
 
 class PostShare extends Component {
 	static propTypes = {
@@ -48,10 +51,26 @@ class PostShare extends Component {
 		requestConnections: PropTypes.func
 	};
 
+	static FOOTER_SECTION_SCHEDULED = 'footer-section-scheduled';
+	static FOOTER_SECTION_PUBLISHED = 'footer-section-published';
+
 	state = {
 		skipped: PostMetadata.publicizeSkipped( this.props.post ) || [],
-		message: PostMetadata.publicizeMessage( this.props.post ) || this.props.post.title
+		message: PostMetadata.publicizeMessage( this.props.post ) || this.props.post.title,
+		footerSection: PostShare.FOOTER_SECTION_SCHEDULED
 	};
+
+	constructor() {
+		super( ...arguments );
+
+		this.setFooterSection = this.setFooterSection.bind( this );
+	}
+
+	setFooterSection( section ) {
+		this.setState( {
+			footerSection: section
+		} );
+	}
 
 	hasConnections() {
 		return !! ( this.props.connections && this.props.connections.length );
@@ -136,6 +155,14 @@ class PostShare extends Component {
 		return this.props.connections.filter( this.isConnectionActive ).length < 1;
 	}
 
+	renderScheduledList() {
+		return 'scheduled';
+	}
+
+	renderPublishedList() {
+		return 'published';
+	}
+
 	render() {
 		if ( ! this.props.isPublicizeEnabled ) {
 			return null;
@@ -155,6 +182,8 @@ class PostShare extends Component {
 		const classes = classNames( 'post-share__wrapper', {
 			'has-connections': this.hasConnections()
 		} );
+
+		const { footerSection } = this.state;
 
 		return (
 			<div className="post-share">
@@ -244,6 +273,43 @@ class PostShare extends Component {
 									>
 										{ this.props.translate( 'Add account' ) }
 									</Button>
+								</div>
+							</div>
+
+							<div className="post-share__footer">
+								<SectionNav selectedText={ 'some text' }>
+									<NavTabs label="Status" selectedText="Published">
+										<NavItem
+											selected={ footerSection === PostShare.FOOTER_SECTION_SCHEDULED }
+											count={ 4 }
+											onClick={ partial(
+												this.setFooterSection,
+												PostShare.FOOTER_SECTION_SCHEDULED
+											) }
+										>
+											Scheduled
+										</NavItem>
+										<NavItem
+											selected={ footerSection === PostShare.FOOTER_SECTION_PUBLISHED }
+											count={ 2 }
+											onClick={ partial(
+												this.setFooterSection,
+												PostShare.FOOTER_SECTION_PUBLISHED
+											) }
+										>
+											Published
+										</NavItem>
+									</NavTabs>
+								</SectionNav>
+								<div className="post-share__scheduled-list">
+									{ footerSection === PostShare.FOOTER_SECTION_SCHEDULED &&
+										this.renderScheduledList()
+									}
+								</div>
+								<div className="post-share__published-list">
+									{ footerSection === PostShare.FOOTER_SECTION_PUBLISHED &&
+										this.renderPublishedList()
+									}
 								</div>
 							</div>
 						</div>

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -163,6 +163,49 @@ class PostShare extends Component {
 		return 'published';
 	}
 
+	renderFooter() {
+		const { footerSection } = this.state;
+
+		return (
+			<div className="post-share__footer">
+				<SectionNav selectedText={ 'some text' }>
+					<NavTabs label="Status" selectedText="Published">
+						<NavItem
+							selected={ footerSection === PostShare.FOOTER_SECTION_SCHEDULED }
+							count={ 4 }
+							onClick={ partial(
+								this.setFooterSection,
+								PostShare.FOOTER_SECTION_SCHEDULED
+							) }
+						>
+							Scheduled
+						</NavItem>
+						<NavItem
+							selected={ footerSection === PostShare.FOOTER_SECTION_PUBLISHED }
+							count={ 2 }
+							onClick={ partial(
+								this.setFooterSection,
+								PostShare.FOOTER_SECTION_PUBLISHED
+							) }
+						>
+							Published
+						</NavItem>
+					</NavTabs>
+				</SectionNav>
+				<div className="post-share__scheduled-list">
+					{ footerSection === PostShare.FOOTER_SECTION_SCHEDULED &&
+					this.renderScheduledList()
+					}
+				</div>
+				<div className="post-share__published-list">
+					{ footerSection === PostShare.FOOTER_SECTION_PUBLISHED &&
+					this.renderPublishedList()
+					}
+				</div>
+			</div>
+		);
+	}
+
 	render() {
 		if ( ! this.props.isPublicizeEnabled ) {
 			return null;
@@ -182,8 +225,6 @@ class PostShare extends Component {
 		const classes = classNames( 'post-share__wrapper', {
 			'has-connections': this.hasConnections()
 		} );
-
-		const { footerSection } = this.state;
 
 		return (
 			<div className="post-share">
@@ -276,42 +317,7 @@ class PostShare extends Component {
 								</div>
 							</div>
 
-							<div className="post-share__footer">
-								<SectionNav selectedText={ 'some text' }>
-									<NavTabs label="Status" selectedText="Published">
-										<NavItem
-											selected={ footerSection === PostShare.FOOTER_SECTION_SCHEDULED }
-											count={ 4 }
-											onClick={ partial(
-												this.setFooterSection,
-												PostShare.FOOTER_SECTION_SCHEDULED
-											) }
-										>
-											Scheduled
-										</NavItem>
-										<NavItem
-											selected={ footerSection === PostShare.FOOTER_SECTION_PUBLISHED }
-											count={ 2 }
-											onClick={ partial(
-												this.setFooterSection,
-												PostShare.FOOTER_SECTION_PUBLISHED
-											) }
-										>
-											Published
-										</NavItem>
-									</NavTabs>
-								</SectionNav>
-								<div className="post-share__scheduled-list">
-									{ footerSection === PostShare.FOOTER_SECTION_SCHEDULED &&
-										this.renderScheduledList()
-									}
-								</div>
-								<div className="post-share__published-list">
-									{ footerSection === PostShare.FOOTER_SECTION_PUBLISHED &&
-										this.renderPublishedList()
-									}
-								</div>
-							</div>
+							{ isEnabled( 'publicize-scheduling' ) && this.renderFooter() }
 						</div>
 					}
 

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -37,6 +37,7 @@ import { isEnabled } from 'config';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
+import CompactCard from 'components/card/compact';
 
 class PostShare extends Component {
 	static propTypes = {
@@ -155,6 +156,14 @@ class PostShare extends Component {
 		return this.props.connections.filter( this.isConnectionActive ).length < 1;
 	}
 
+	renderFooterSectionItem( item, index ) {
+		return (
+			<CompactCard key={ index }>
+				{ item.type }
+			</CompactCard>
+		);
+	}
+
 	renderScheduledList() {
 		const { planSlug } = this.props;
 
@@ -172,6 +181,32 @@ class PostShare extends Component {
 				/>
 			);
 		}
+
+		// TODO: get from Redux
+		const scheduledItems = [
+			{
+				type: 'twitter',
+				handle: 'styleandgear',
+				timestamp: 'Tue, Jan 29, 2017 at 5:00 PM',
+				message: 'Do you have a trip coming up? Bla some more text'
+			},
+			{
+				type: 'twitter',
+				handle: 'tasha',
+				timestamp: 'Tue, Jan 28, 2017 at 3:35 PM',
+				message: 'Do you have a trip coming up? Bla some more text'
+			},
+			{
+				type: 'facebook',
+				handle: 'Style and Gear',
+				timestamp: 'Tue, Jan 28, 2017 at 3:35 PM',
+				message: 'Do you have a trip coming up? Bla some more text'
+			}
+		];
+
+		return scheduledItems.map(
+			( item, index ) => this.renderFooterSectionItem( item, index )
+		);
 	}
 
 	renderPublishedList() {
@@ -183,7 +218,7 @@ class PostShare extends Component {
 
 		return (
 			<div className="post-share__footer">
-				<SectionNav selectedText={ 'some text' }>
+				<SectionNav className="post-share__footer-nav" selectedText={ 'some text' }>
 					<NavTabs label="Status" selectedText="Published">
 						<NavItem
 							selected={ footerSection === PostShare.FOOTER_SECTION_SCHEDULED }

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -202,18 +202,24 @@ class PostShare extends Component {
 		} = item;
 
 		return (
-			<CompactCard className="post-share__footer-item" key={ index }>
-				<SocialLogo icon={ service === 'google_plus' ? 'google-plus' : service } />
-				<span className="post-share__footer-item__handle">
-					{ service === 'twitter' ? `@${ handle }` : handle }
-				</span>
-				<Gridicon icon="time" size={ 18 } />
-				<span className="post-share__footer-item__timestamp">
-					{ timestamp }
-				</span>
-				<span className="post-share__footer-item__message">
-					{ message }
-				</span>
+			<CompactCard className="post-share__footer-items" key={ index }>
+				<div className="post-share__footer-item">
+					<div className="post-share__handle">
+						<SocialLogo icon={ service === 'google_plus' ? 'google-plus' : service } />
+						<span>
+							{ service === 'twitter' ? `@${ handle }` : handle }
+						</span>
+					</div>
+					<div className="post-share__timestamp">
+						<Gridicon icon="time" size={ 18 } />
+						<span>
+							{ timestamp }
+						</span>
+					</div>
+					<div className="post-share__message">
+						{ message }
+					</div>
+				</div>
 				<EllipsisMenu>
 					<PopoverMenuItem icon="visible">
 						Preview

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { includes, map, partial } from 'lodash';
 import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -38,6 +39,7 @@ import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 import CompactCard from 'components/card/compact';
+import SocialLogo from 'social-logos';
 
 class PostShare extends Component {
 	static propTypes = {
@@ -157,9 +159,26 @@ class PostShare extends Component {
 	}
 
 	renderFooterSectionItem( item, index ) {
+		const {
+			service,
+			handle,
+			timestamp,
+			message
+		} = item;
+
 		return (
-			<CompactCard key={ index }>
-				{ item.type }
+			<CompactCard className="post-share__footer-item" key={ index }>
+				<SocialLogo icon={ service === 'google_plus' ? 'google-plus' : service } />
+				<span className="post-share__footer-item__handle">
+					{ service === 'twitter' ? `@${ handle }` : handle }
+				</span>
+				<Gridicon icon="gridicons-time" size={ 18 } />
+				<span className="post-share__footer-item__timestamp">
+					{ timestamp }
+				</span>
+				<span className="post-share__footer-item__message">
+					{ message }
+				</span>
 			</CompactCard>
 		);
 	}
@@ -185,19 +204,19 @@ class PostShare extends Component {
 		// TODO: get from Redux
 		const scheduledItems = [
 			{
-				type: 'twitter',
+				service: 'twitter',
 				handle: 'styleandgear',
 				timestamp: 'Tue, Jan 29, 2017 at 5:00 PM',
 				message: 'Do you have a trip coming up? Bla some more text'
 			},
 			{
-				type: 'twitter',
+				service: 'tumblr',
 				handle: 'tasha',
 				timestamp: 'Tue, Jan 28, 2017 at 3:35 PM',
 				message: 'Do you have a trip coming up? Bla some more text'
 			},
 			{
-				type: 'facebook',
+				service: 'facebook',
 				handle: 'Style and Gear',
 				timestamp: 'Tue, Jan 28, 2017 at 3:35 PM',
 				message: 'Do you have a trip coming up? Bla some more text'

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -316,12 +316,12 @@ class PostShare extends Component {
 				</SectionNav>
 				<div className="post-share__scheduled-list">
 					{ footerSection === PostShare.FOOTER_SECTION_SCHEDULED &&
-					this.renderScheduledList()
+						this.renderScheduledList()
 					}
 				</div>
 				<div className="post-share__published-list">
 					{ footerSection === PostShare.FOOTER_SECTION_PUBLISHED &&
-					this.renderPublishedList()
+						this.renderPublishedList()
 					}
 				</div>
 			</div>

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { includes, map, partial } from 'lodash';
+import { includes, map } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
@@ -68,17 +68,7 @@ class PostShare extends Component {
 
 	};
 
-	constructor() {
-		super( ...arguments );
-
-		this.setFooterSection = this.setFooterSection.bind( this );
-	}
-
-	setFooterSection( section ) {
-		this.setState( {
-			footerSection: section
-		} );
-	}
+	setFooterSection = footerSection => () => this.setState( { footerSection } );
 
 	hasConnections() {
 		return !! ( this.props.connections && this.props.connections.length );
@@ -294,20 +284,14 @@ class PostShare extends Component {
 						<NavItem
 							selected={ footerSection === PostShare.FOOTER_SECTION_SCHEDULED }
 							count={ 4 }
-							onClick={ partial(
-								this.setFooterSection,
-								PostShare.FOOTER_SECTION_SCHEDULED
-							) }
+							onClick={ this.setFooterSection( PostShare.FOOTER_SECTION_SCHEDULED ) }
 						>
 							Scheduled
 						</NavItem>
 						<NavItem
 							selected={ footerSection === PostShare.FOOTER_SECTION_PUBLISHED }
 							count={ 2 }
-							onClick={ partial(
-								this.setFooterSection,
-								PostShare.FOOTER_SECTION_PUBLISHED
-							) }
+							onClick={ this.setFooterSection( PostShare.FOOTER_SECTION_PUBLISHED ) }
 						>
 							Published
 						</NavItem>

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -226,19 +226,20 @@ class PostShare extends Component {
 	}
 
 	renderScheduledList() {
-		const { planSlug } = this.props;
+		const { planSlug, translate } = this.props;
 
 		if ( planSlug !== PLAN_BUSINESS ) {
 			return (
 				<Banner
 					className="post-share__footer-banner"
-					callToAction="Upgrade for $9.99"
-					description="Live chat support and no advertising."
-					dismissPreferenceName="devdocs-banner-example"
-					dismissTemporary
-					list={ [ 'Live chat support', 'No advertising' ] }
+					callToAction={ translate( 'Upgrade for $9.99' ) }
+					description={ translate( 'Live chat support and no advertising.' ) }
+					list={ [
+						translate( 'Live chat support' ),
+						translate( 'No advertising' )
+					] }
 					plan={ PLAN_BUSINESS }
-					title="Upgrade to a Business Plan!"
+					title={ translate( 'Upgrade to a Business Plan!' ) }
 				/>
 			);
 		}

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -40,6 +40,8 @@ import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 import CompactCard from 'components/card/compact';
 import SocialLogo from 'social-logos';
+import EllipsisMenu from 'components/ellipsis-menu';
+import PopoverMenuItem from 'components/popover/menu-item';
 
 class PostShare extends Component {
 	static propTypes = {
@@ -172,13 +174,24 @@ class PostShare extends Component {
 				<span className="post-share__footer-item__handle">
 					{ service === 'twitter' ? `@${ handle }` : handle }
 				</span>
-				<Gridicon icon="gridicons-time" size={ 18 } />
+				<Gridicon icon="time" size={ 18 } />
 				<span className="post-share__footer-item__timestamp">
 					{ timestamp }
 				</span>
 				<span className="post-share__footer-item__message">
 					{ message }
 				</span>
+				<EllipsisMenu>
+					<PopoverMenuItem icon="visible">
+						Preview
+					</PopoverMenuItem>
+					<PopoverMenuItem icon="pencil">
+						Edit
+					</PopoverMenuItem>
+					<PopoverMenuItem icon="trash">
+						Trash
+					</PopoverMenuItem>
+				</EllipsisMenu>
 			</CompactCard>
 		);
 	}

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -188,7 +188,7 @@ class PostShare extends Component {
 			service,
 			handle,
 			timestamp,
-			message
+			message,
 		} = item;
 
 		return (

--- a/client/my-sites/post-share/style.scss
+++ b/client/my-sites/post-share/style.scss
@@ -183,3 +183,161 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 	margin: 25px;
 }
 
+.post-share__footer-items {
+	display: flex;
+	flex-wrap: nowrap;
+	justify-content: space-between;
+
+	&::after {
+		content: '';
+		display: none;
+	}
+
+	.ellipsis-menu {
+		display: flex;
+	}
+
+	.ellipsis-menu__toggle {
+		padding-top: 0;
+		padding-bottom: 0;
+
+		.gridicon {
+			top: 4px;
+		}
+	}
+}
+
+.post-share__footer-item {
+	display: flex;
+	flex: 1 1 auto;
+	flex-direction: column;
+	overflow: hidden;
+	position: relative;
+
+	.social-logo {
+		flex: 0 0 24px;
+
+		@include breakpoint( ">660px" ) {
+			position: relative;
+			top: 1px;
+		}
+	}
+
+	.gridicons-time {
+		flex: 0 0 18px;
+		padding: 3px;
+		position: relative;
+			top: -1px;
+			left: -1px;
+
+		@include breakpoint( ">660px" ) {
+			top: 0;
+		}
+	}
+
+	@include breakpoint( ">480px" ) {
+		align-items: center;
+		flex-direction: row;
+
+		&::after {
+			@include long-content-fade( $color: $white );
+		}
+	}
+
+	@include breakpoint( ">660px" ) {
+		align-items: flex-start;
+		flex-direction: column;
+	}
+
+	@include breakpoint( ">960px" ) {
+		align-items: center;
+		flex-direction: row;
+	}
+}
+
+.post-share__handle,
+.post-share__timestamp {
+	align-items: center;
+	display: flex;
+	flex: 0 0 auto;
+	margin-right: 12px;
+
+	span {
+		padding-left: 4px;
+	}
+}
+
+.post-share__handle {
+	.social-logo.twitter {
+		color: $color-twitter;
+	}
+
+	.social-logo.facebook {
+		color: $color-facebook;
+	}
+
+	.social-logo.tumblr {
+		color: $color-tumblr;
+	}
+
+	.social-logo.google_plus {
+		color: $color-gplus;
+	}
+
+	.social-logo.linkedin {
+		color: $color-linkedin;
+	}
+
+	.social-logo.path {
+		color: $color-path;
+	}
+
+	@include breakpoint( ">480px" ) {
+		margin-right: 7px;
+	}
+
+	@include breakpoint( ">660px" ) {
+		margin-right: 12px;
+	}
+
+	@include breakpoint( ">960px" ) {
+		margin-right: 7px;
+	}
+}
+
+.post-share__timestamp {
+	span {
+		@include breakpoint( ">480px" ) {
+			padding-left: 2px;
+		}
+
+		@include breakpoint( ">660px" ) {
+			padding-left: 4px;
+		}
+
+		@include breakpoint( ">960px" ) {
+			padding-left: 2px;
+		}
+	}
+}
+
+.post-share__message {
+	color: $gray-text-min;
+	display: none;
+	flex: 0 1 auto;
+	font-style: italic;
+	white-space: nowrap;
+
+	@include breakpoint( ">480px" ) {
+		display: block;
+	}
+
+	@include breakpoint( ">660px" ) {
+		display: none;
+	}
+
+	@include breakpoint( ">960px" ) {
+		display: block;
+	}
+}
+

--- a/client/my-sites/post-share/style.scss
+++ b/client/my-sites/post-share/style.scss
@@ -162,6 +162,11 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 	}
 }
 
+.post-share__footer-nav {
+	margin: 0;
+
+}
+
 .post-share__footer-banner {
 	margin: 25px;
 }

--- a/client/my-sites/post-share/style.scss
+++ b/client/my-sites/post-share/style.scss
@@ -176,7 +176,6 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 
 .post-share__footer-nav {
 	margin: 0;
-
 }
 
 .post-share__footer-banner {

--- a/client/my-sites/post-share/style.scss
+++ b/client/my-sites/post-share/style.scss
@@ -260,10 +260,11 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 	display: flex;
 	flex: 0 0 auto;
 	margin-right: 12px;
+}
 
-	span {
-		padding-left: 4px;
-	}
+.post-share__handle-value,
+.post-share__timestamp-value {
+	padding-left: 4px;
 }
 
 .post-share__handle {
@@ -304,19 +305,17 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 	}
 }
 
-.post-share__timestamp {
-	span {
-		@include breakpoint( ">480px" ) {
-			padding-left: 2px;
-		}
+.post-share__timestamp-value {
+	@include breakpoint( ">480px" ) {
+		padding-left: 2px;
+	}
 
-		@include breakpoint( ">660px" ) {
-			padding-left: 4px;
-		}
+	@include breakpoint( ">660px" ) {
+		padding-left: 4px;
+	}
 
-		@include breakpoint( ">960px" ) {
-			padding-left: 2px;
-		}
+	@include breakpoint( ">960px" ) {
+		padding-left: 2px;
 	}
 }
 

--- a/client/my-sites/post-share/style.scss
+++ b/client/my-sites/post-share/style.scss
@@ -162,3 +162,7 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 	}
 }
 
+.post-share__footer-banner {
+	margin: 25px;
+}
+

--- a/client/my-sites/post-share/style.scss
+++ b/client/my-sites/post-share/style.scss
@@ -38,6 +38,7 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 	.post-share__form {
 		flex: 3;
 		border-right: $section-border;
+		padding-bottom: 20px;
 	}
 
 	.post-share__services {
@@ -47,6 +48,7 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 		display: flex;
 		flex-wrap: wrap;
 		margin-top: 16px;
+		padding-bottom: 20px;
 
 		@include breakpoint( ">480px" ) {
 		}


### PR DESCRIPTION
Adding the Publicize scheduler footer section scaffold (ie scheduled/published):

![selection_008](https://cloud.githubusercontent.com/assets/4988512/24124235/c539ebca-0d90-11e7-9fca-1d23f7f3a0f2.png)

![selection_009](https://cloud.githubusercontent.com/assets/4988512/24124263/e2f4e3f4-0d90-11e7-8a60-a849fdd5ae62.png)


Do not merge as @iamtakashi is adding some styling.

## Testing instructions

1. With a wpcom Business site, use the Share feature and make sure you can see the footer section with items in Scheduled nav tab;
2. With a wpcom non-business site, use the Share feature and make sure you can see the footer section with upgrade to Business nudge in the Scheduled nav tab
