### PR TITLE
Theme Setup: Fix the broken demo site link for the ActiveThemeScreenshot component.

### DIFF
--- a/client/my-sites/site-settings/theme-setup/index.jsx
+++ b/client/my-sites/site-settings/theme-setup/index.jsx
@@ -15,7 +15,7 @@ import QueryTheme from 'components/data/query-theme';
 import ThemeSetupCard from './theme-setup-card';
 import ThemeSetupPlaceholder from './theme-setup-placeholder';
 import { getSelectedSite } from 'state/ui/selectors';
-import { getActiveTheme, getTheme } from 'state/themes/selectors';
+import { getActiveTheme, getCanonicalTheme } from 'state/themes/selectors';
 import { toggleDialog } from 'state/ui/theme-setup/actions';
 
 let ThemeSetup = ( { site, themeId, theme, translate, activeSiteDomain, toggleDialog } ) => {
@@ -42,7 +42,7 @@ ThemeSetup = localize( ThemeSetup );
 const mapStateToProps = ( state ) => {
 	const site = getSelectedSite( state );
 	const themeId = site && getActiveTheme( state, site.ID );
-	const theme = themeId && getTheme( state, 'wpcom', themeId );
+	const theme = themeId && getCanonicalTheme( state, 'wpcom', themeId );
 	return {
 		site,
 		themeId,


### PR DESCRIPTION
Currently, `ActiveThemeScreenshot` does not link to the theme's demo since it uses `theme.demo_uri`, which was removed from basic `theme` objects in recent refactoring. This PR swaps `getTheme` for the `getCanonicalTheme` selector, which includes `demo_uri` (Theme Setup is only active for dotcom sites, whose themes include this property).

**Testing**

Load the PR, and go to `/settings/theme-setup/` for a dotcom blog. Make sure the screenshot links to that theme's demo site.