### PR TITLE
Signup: Create new social account when signing up with Google

### DIFF
--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -426,7 +426,6 @@ export default React.createClass( {
 	formFooter() {
 		return (
 			<LoggedOutFormFooter>
-				{ this.getNotice() }
 				{ this.termsOfServiceLink() }
 				<FormButton className="signup-form__submit" disabled={ this.state.submitting || this.props.disabled }>
 					{ this.props.submitButtonText }
@@ -477,6 +476,7 @@ export default React.createClass( {
 					{ this.props.isSocialSignupEnabled && <HrWithText>
 						{ i18n.translate( 'Or sign up with your email address:' ) }
 					</HrWithText> }
+					{ this.getNotice() }
 					{ this.formFields() }
 					{ this.props.formFooter || this.formFooter() }
 				</LoggedOutForm>

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -57,6 +57,7 @@ export default React.createClass( {
 		formHeader: PropTypes.node,
 		getRedirectToAfterLoginUrl: PropTypes.string.isRequired,
 		goToNextStep: PropTypes.func,
+		handleSocialResponse: PropTypes.func,
 		isSocialSignupEnabled: PropTypes.bool,
 		locale: PropTypes.string,
 		positionInFlow: PropTypes.number,
@@ -472,7 +473,7 @@ export default React.createClass( {
 							{ this.props.formHeader }
 						</header>
 					}
-					{ this.props.isSocialSignupEnabled && <SocialSignupForm /> }
+					{ this.props.isSocialSignupEnabled && <SocialSignupForm handleResponse={ this.props.handleSocialResponse } /> }
 					{ this.props.isSocialSignupEnabled && <HrWithText>
 						{ i18n.translate( 'Or sign up with your email address:' ) }
 					</HrWithText> }

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -48,8 +48,24 @@ export default React.createClass( {
 	displayName: 'SignupForm',
 
 	propTypes: {
+		className: PropTypes.string,
+		disableEmailExplanation: PropTypes.bool,
+		disableEmailInput: PropTypes.bool,
+		disabled: PropTypes.bool,
+		email: PropTypes.string,
+		footerLink: PropTypes.node,
+		formHeader: PropTypes.node,
+		getRedirectToAfterLoginUrl: PropTypes.string.isRequired,
+		goToNextStep: PropTypes.func,
 		isSocialSignupEnabled: PropTypes.bool,
-		suggestedUsername: PropTypes.string.isRequired
+		locale: PropTypes.string,
+		positionInFlow: PropTypes.number,
+		save: PropTypes.func,
+		signupDependencies: PropTypes.object,
+		step: PropTypes.object,
+		submitButtonText: PropTypes.string.isRequired,
+		submitting: PropTypes.bool,
+		suggestedUsername: PropTypes.string.isRequired,
 	},
 
 	getDefaultProps() {

--- a/client/components/signup-form/social.jsx
+++ b/client/components/signup-form/social.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import GoogleLoginButton from 'components/social-buttons/google';
 import FacebookLoginButton from 'components/social-buttons/facebook';
 
@@ -11,20 +11,25 @@ import FacebookLoginButton from 'components/social-buttons/facebook';
 import config from 'config';
 
 class SocialSignupForm extends Component {
-	constructor() {
-		super();
-		this.onGoogleResponse = this.onGoogleResponse.bind( this );
-		this.onFacebookResponse = this.onFacebookResponse.bind( this );
+	static propTypes = {
+		handleResponse: PropTypes.func.isRequired,
 	}
 
-	onGoogleResponse( response ) {
+	constructor() {
+		super();
+		this.handleGoogleResponse = this.handleGoogleResponse.bind( this );
+		this.handleFacebookResponse = this.handleFacebookResponse.bind( this );
+	}
+
+	handleGoogleResponse( response ) {
 		if ( ! response.Zi || ! response.Zi.id_token ) {
 			return;
 		}
-		// TODO: post response to the new wpcom endpoint to login
+
+		this.props.handleResponse( 'google', response.Zi.id_token );
 	}
 
-	onFacebookResponse( response ) {
+	handleFacebookResponse( response ) {
 		if ( ! response.email ) {
 			return;
 		}
@@ -36,10 +41,10 @@ class SocialSignupForm extends Component {
 			<div className="signup-form__social">
 				<GoogleLoginButton
 					clientId={ config( 'google_oauth_client_id' ) }
-					responseHandler={ this.onGoogleResponse } />
+					responseHandler={ this.handleGoogleResponse } />
 				<FacebookLoginButton
 					appId={ config( 'facebook_app_id' ) }
-					responseHandler={ this.onFacebookResponse } />
+					responseHandler={ this.handleFacebookResponse } />
 			</div>
 		);
 	}

--- a/client/components/signup-form/style.scss
+++ b/client/components/signup-form/style.scss
@@ -34,3 +34,7 @@
 		width: 100%;
 	}
 }
+
+.signup-form__notice.notice {
+	margin-bottom: 10px;
+}

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1446,6 +1446,29 @@ Undocumented.prototype.usersNew = function( query, fn ) {
 };
 
 /**
+ * Sign up for a new account with a social service (e.g. Google/Facebook).
+ *
+ * @param {string} service - Social service associated with token, e.g. google.
+ * @param {string} token - Token returned from service.
+ * @param {Function} fn - callback
+ *
+ * @return {Promise} A promise for the request
+ */
+Undocumented.prototype.usersSocialNew = function( service, token, fn ) {
+	const body = { service, token, locale: i18n.getLocaleSlug() };
+
+	// This API call is restricted to these OAuth keys
+	restrictByOauthKeys( body );
+
+	const args = {
+		path: '/users/social/new',
+		body
+	};
+
+	return this.wpcom.req.post( args, fn );
+};
+
+/**
  * Sign up for a new phone account
  *
  * @param {string} query - a key/value pair; key: 'phone_number', value: 'the users phone number'

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -354,18 +354,16 @@ const Signup = React.createClass( {
 		const firstInvalidStep = find( SignupProgressStore.get(), { status: 'invalid' } );
 
 		if ( firstInvalidStep ) {
-			if ( firstInvalidStep.stepName === this.props.stepName ) {
-				// reset the signup stores so we have a chance to start over the flow
-				// TODO: fix loading invalid steps from the store
-				SignupDependencyStore.reset();
-				SignupProgressStore.reset();
-				console.error( 'Current step is invalid, cannot redirect to it.', firstInvalidStep.errors ); //eslint-disable-line no-console
-				return;
-			}
 			analytics.tracks.recordEvent( 'calypso_signup_goto_invalid_step', {
 				step: firstInvalidStep.stepName,
 				flow: this.props.flowName
 			} );
+
+			if ( firstInvalidStep.stepName === this.props.stepName ) {
+				// No need to redirect
+				return;
+			}
+
 			page( utils.getStepUrl( this.props.flowName, firstInvalidStep.stepName, this.props.locale ) );
 		}
 	},

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -73,6 +73,17 @@ export class UserStep extends Component {
 		} );
 	};
 
+	submit = ( data ) => {
+		SignupActions.submitSignupStep( {
+			processingMessage: this.props.translate( 'Creating your account' ),
+			flowName: this.props.flowName,
+			stepName: this.props.stepName,
+			...data
+		} );
+
+		this.props.goToNextStep();
+	};
+
 	submitForm = ( form, userData, analyticsData ) => {
 		const queryArgs = {
 			jetpackRedirect: get( this.props, 'queryObject.jetpack_redirect' )
@@ -88,16 +99,15 @@ export class UserStep extends Component {
 
 		this.props.recordTracksEvent( 'calypso_signup_user_step_submit', analyticsData );
 
-		SignupActions.submitSignupStep( {
-			processingMessage: this.props.translate( 'Creating your account' ),
-			flowName: this.props.flowName,
+		this.submit( {
 			userData,
-			stepName: this.props.stepName,
 			form: formWithoutPassword,
 			queryArgs
 		} );
+	};
 
-		this.props.goToNextStep();
+	handleSocialResponse = ( service, token ) => {
+		this.submit( { service, token } );
 	};
 
 	userCreationComplete() {
@@ -151,6 +161,7 @@ export class UserStep extends Component {
 				submitForm={ this.submitForm }
 				submitButtonText={ this.submitButtonText() }
 				suggestedUsername={ this.props.suggestedUsername }
+				handleSocialResponse={ this.handleSocialResponse }
 				isSocialSignupEnabled={ this.props.isSocialSignupEnabled }
 			/>
 		);


### PR DESCRIPTION
Requires D4835-code.

This PR:

- Adds `propTypes` to `SignupForm`.
- Updates signup to create a new social account when the user signs up with Google.
- Moves the global notice from the user step closer to the social buttons. This is rarely ever displayed since we validate normal signups, but is also displayed in the case that the user attempts to sign up with a Google account that has the same email address as an existing non-social account.
- Removes the error that is thrown when the last step in signup has errors. This is not really an error with our application, so simply handling the redirect properly (i.e. not redirecting, because that error occurs on the last step) is adequate. It also removes the code to reset the stores if the last step contains an error, since the user might want to fix an issue with existing data.

**Testing**
*New social signup*
- Create a [new Google account](https://accounts.google.com/signup?hl=en).
- Visit [`/start/social`](http://calypso.localhost:3000/start/social).
- Click `Google` and authorize the application with the account you created.
- Assert that you are signed up properly and are logged in after clicking `Continue`.

*Attempting to sign up with an existing social account*
- Visit `/start/social`.
- Click `Google` and authorize the application with the account you created in the previous step.
- Assert that you are signed *in* properly after clicking `Continue`. We may want different copy here to let the user know that we're logging them into their existing account.

*Attempting to sign up with an existing non-social account*
- Visit `/start/social`.
- Click `Google` and authorize a Google account that has an email address for a non-social WordPress.com account. For me, this was my main Google account, as I have an existing WordPress.com account for `drew.blaisdell@gmail.com`.
- Assert that you are redirected to the user step with an error indicating that this account already exists. We may want to change the copy here or provide a link for the user to easily log in to this account.

- [x] Code
- [x] Product