### PR TITLE
Editor: autoScroll editor when typing near bottom

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -303,6 +303,7 @@ module.exports = React.createClass( {
 			// minus the surrounding editor chrome to avoid scrollbars. In the
 			// future, we should calculate from the rendered editor bounds.
 			autoresize_min_height: Math.max( document.documentElement.clientHeight - 300, 300 ),
+			autoresize_bottom_margin: 150,
 
 			toolbar1: config.isEnabled( 'post-editor/insert-menu' )
 				? 'wpcom_insert_menu,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,wpcom_advanced'

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -303,6 +303,7 @@ module.exports = React.createClass( {
 			// minus the surrounding editor chrome to avoid scrollbars. In the
 			// future, we should calculate from the rendered editor bounds.
 			autoresize_min_height: Math.max( document.documentElement.clientHeight - 300, 300 ),
+			autoresize_bottom_margin: viewport.isMobile() ? 10 : 50,
 
 			toolbar1: config.isEnabled( 'post-editor/insert-menu' )
 				? 'wpcom_insert_menu,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,wpcom_advanced'

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -233,6 +233,11 @@ module.exports = React.createClass( {
 
 		this.localize();
 
+		// Try to find a suitable minimum size based on the viewport height
+		// minus the surrounding editor chrome to avoid scrollbars. In the
+		// future, we should calculate from the rendered editor bounds.
+		const minHeight = Math.max( document.documentElement.clientHeight - 300, 300 );
+
 		tinymce.init( {
 			selector: '#' + this._id,
 			skin_url: '//s1.wp.com/wp-includes/js/tinymce/skins/lightgray',
@@ -299,11 +304,8 @@ module.exports = React.createClass( {
 			atd_rpc_id: 'https://wordpress.com',
 			atd_ignore_enable: true,
 
-			// Try to find a suitable minimum size based on the viewport height
-			// minus the surrounding editor chrome to avoid scrollbars. In the
-			// future, we should calculate from the rendered editor bounds.
-			autoresize_min_height: Math.max( document.documentElement.clientHeight - 300, 300 ),
-			autoresize_bottom_margin: 150,
+			autoresize_min_height: minHeight,
+			autoresize_bottom_margin: minHeight > 300 ? 100 : 50,
 
 			toolbar1: config.isEnabled( 'post-editor/insert-menu' )
 				? 'wpcom_insert_menu,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,wpcom_advanced'

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -233,11 +233,6 @@ module.exports = React.createClass( {
 
 		this.localize();
 
-		// Try to find a suitable minimum size based on the viewport height
-		// minus the surrounding editor chrome to avoid scrollbars. In the
-		// future, we should calculate from the rendered editor bounds.
-		const minHeight = Math.max( document.documentElement.clientHeight - 300, 300 );
-
 		tinymce.init( {
 			selector: '#' + this._id,
 			skin_url: '//s1.wp.com/wp-includes/js/tinymce/skins/lightgray',
@@ -304,8 +299,11 @@ module.exports = React.createClass( {
 			atd_rpc_id: 'https://wordpress.com',
 			atd_ignore_enable: true,
 
-			autoresize_min_height: minHeight,
-			autoresize_bottom_margin: minHeight > 300 ? 100 : 50,
+			// Try to find a suitable minimum size based on the viewport height
+			// minus the surrounding editor chrome to avoid scrollbars. In the
+			// future, we should calculate from the rendered editor bounds.
+			autoresize_min_height: Math.max( document.documentElement.clientHeight - 300, 300 ),
+			autoresize_bottom_margin: viewport.isMobile() ? 20 : 60,
 
 			toolbar1: config.isEnabled( 'post-editor/insert-menu' )
 				? 'wpcom_insert_menu,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,wpcom_advanced'

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -303,7 +303,6 @@ module.exports = React.createClass( {
 			// minus the surrounding editor chrome to avoid scrollbars. In the
 			// future, we should calculate from the rendered editor bounds.
 			autoresize_min_height: Math.max( document.documentElement.clientHeight - 300, 300 ),
-			autoresize_bottom_margin: viewport.isMobile() ? 20 : 60,
 
 			toolbar1: config.isEnabled( 'post-editor/insert-menu' )
 				? 'wpcom_insert_menu,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,wpcom_advanced'

--- a/client/components/tinymce/plugins/wpcom-autoresize/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-autoresize/plugin.js
@@ -51,9 +51,11 @@ function wcpomAutoResize( editor ) {
 		marginTop = editor.dom.getStyle( body, 'margin-top', true );
 		marginBottom = editor.dom.getStyle( body, 'margin-bottom', true );
 		paddingTop = editor.dom.getStyle( body, 'padding-top', true );
-		paddingBottom = editor.dom.getStyle( body, 'padding-bottom', true );
 		borderTop = editor.dom.getStyle( body, 'border-top-width', true );
 		borderBottom = editor.dom.getStyle( body, 'border-bottom-width', true );
+		// paddingBottom seems to get reset to 1 somewhere, so grab
+		// autoresize_bottom_margin directly here
+		paddingBottom = editor.getParam( 'autoresize_bottom_margin', 50 );
 
 		myHeight = body.offsetHeight + parseInt( marginTop, 10 ) + parseInt( marginBottom, 10 ) +
 			parseInt( paddingTop, 10 ) + parseInt( paddingBottom, 10 ) +

--- a/client/components/tinymce/plugins/wpcom-autoresize/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-autoresize/plugin.js
@@ -126,7 +126,7 @@ function wcpomAutoResize( editor ) {
 			if ( e && e.type === 'keyup' ||
 				( e && e.type === 'nodechange' && e.element && e.element.tagName === 'BR' ) ) {
 				if ( isEndOfEditor() ) {
-					window.scrollTo( 0, window.screen.availHeight );
+					window.scrollTo( 0, document.body.scrollHeight );
 				}
 			}
 		}

--- a/client/components/tinymce/plugins/wpcom-autoresize/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-autoresize/plugin.js
@@ -71,9 +71,12 @@ function wcpomAutoResize( editor ) {
 		marginTop = editor.dom.getStyle( body, 'margin-top', true );
 		marginBottom = editor.dom.getStyle( body, 'margin-bottom', true );
 		paddingTop = editor.dom.getStyle( body, 'padding-top', true );
-		paddingBottom = editor.dom.getStyle( body, 'padding-bottom', true );
 		borderTop = editor.dom.getStyle( body, 'border-top-width', true );
 		borderBottom = editor.dom.getStyle( body, 'border-bottom-width', true );
+		// paddingBottom seems to get reset to 1 somewhere, so grab
+		// autoresize_bottom_margin directly here
+		paddingBottom = editor.getParam( 'autoresize_bottom_margin', 50 );
+
 		myHeight = body.offsetHeight + parseInt( marginTop, 10 ) + parseInt( marginBottom, 10 ) +
 			parseInt( paddingTop, 10 ) + parseInt( paddingBottom, 10 ) +
 			parseInt( borderTop, 10 ) + parseInt( borderBottom, 10 );

--- a/client/components/tinymce/plugins/wpcom-autoresize/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-autoresize/plugin.js
@@ -24,6 +24,27 @@ function wcpomAutoResize( editor ) {
 		return;
 	}
 
+	function isEndOfEditor() {
+		var range, start, body, element, child;
+		range = editor.selection.getRng();
+
+		if ( ( range.startOffset === 0 && range.endOffset !== 0 ) || ! range.collapsed ) {
+			return false;
+		}
+
+		start = range.startContainer;
+		body = editor.getBody();
+		element = start;
+		do {
+			child = element;
+			element = element.parentNode;
+			if ( element.childNodes[ element.childNodes.length - 1 ] !== child ) {
+				return false;
+			}
+		} while ( element !== body );
+		return true;
+	}
+
 	function resize( e ) {
 		var deltaSize, doc, body, docElm, DOM = tinymce.DOM, resizeHeight, myHeight,
 			marginTop, marginBottom, paddingTop, paddingBottom, borderTop, borderBottom;
@@ -100,6 +121,13 @@ function wcpomAutoResize( editor ) {
 			// So we need to continue to resize the iframe down until the size gets fixed
 			if ( tinymce.isWebKit && deltaSize < 0 ) {
 				resize( e );
+			}
+
+			if ( e && e.type === 'keyup' ||
+				( e && e.type === 'nodechange' && e.element && e.element.tagName === 'BR' ) ) {
+				if ( isEndOfEditor() ) {
+					window.scrollTo( 0, window.screen.availHeight );
+				}
 			}
 		}
 	}

--- a/client/components/tinymce/plugins/wpcom-autoresize/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-autoresize/plugin.js
@@ -24,30 +24,10 @@ function wcpomAutoResize( editor ) {
 		return;
 	}
 
-	function isEndOfEditor() {
-		var range, start, body, element, child;
-		range = editor.selection.getRng();
-
-		if ( ( range.startOffset === 0 && range.endOffset !== 0 ) || ! range.collapsed ) {
-			return false;
-		}
-
-		start = range.startContainer;
-		body = editor.getBody();
-		element = start;
-		do {
-			child = element;
-			element = element.parentNode;
-			if ( element.childNodes[ element.childNodes.length - 1 ] !== child ) {
-				return false;
-			}
-		} while ( element !== body );
-		return true;
-	}
-
 	function resize( e ) {
 		var deltaSize, doc, body, docElm, DOM = tinymce.DOM, resizeHeight, myHeight,
-			marginTop, marginBottom, paddingTop, paddingBottom, borderTop, borderBottom;
+			marginTop, marginBottom, paddingTop, paddingBottom, borderTop, borderBottom,
+			beforeBottomOffset, afterY;
 
 		doc = editor.getDoc();
 		if ( !doc ) {
@@ -71,11 +51,9 @@ function wcpomAutoResize( editor ) {
 		marginTop = editor.dom.getStyle( body, 'margin-top', true );
 		marginBottom = editor.dom.getStyle( body, 'margin-bottom', true );
 		paddingTop = editor.dom.getStyle( body, 'padding-top', true );
+		paddingBottom = editor.dom.getStyle( body, 'padding-bottom', true );
 		borderTop = editor.dom.getStyle( body, 'border-top-width', true );
 		borderBottom = editor.dom.getStyle( body, 'border-bottom-width', true );
-		// paddingBottom seems to get reset to 1 somewhere, so grab
-		// autoresize_bottom_margin directly here
-		paddingBottom = editor.getParam( 'autoresize_bottom_margin', 50 );
 
 		myHeight = body.offsetHeight + parseInt( marginTop, 10 ) + parseInt( marginBottom, 10 ) +
 			parseInt( paddingTop, 10 ) + parseInt( paddingBottom, 10 ) +
@@ -117,20 +95,19 @@ function wcpomAutoResize( editor ) {
 		// Resize content element
 		if ( resizeHeight !== oldSize ) {
 			deltaSize = resizeHeight - oldSize;
+			beforeBottomOffset = document.body.scrollHeight - window.innerHeight - window.scrollY;
 			DOM.setStyle( editor.iframeElement, 'height', resizeHeight + 'px' );
 			oldSize = resizeHeight;
+
+			afterY = document.body.scrollHeight - window.innerHeight - beforeBottomOffset;
+			if ( afterY !== window.scrollY ) {
+				window.scrollTo( 0, afterY );
+			}
 
 			// WebKit doesn't decrease the size of the body element until the iframe gets resized
 			// So we need to continue to resize the iframe down until the size gets fixed
 			if ( tinymce.isWebKit && deltaSize < 0 ) {
 				resize( e );
-			}
-
-			if ( e && e.type === 'keyup' ||
-				( e && e.type === 'nodechange' && e.element && e.element.tagName === 'BR' ) ) {
-				if ( isEndOfEditor() ) {
-					window.scrollTo( 0, document.body.scrollHeight );
-				}
 			}
 		}
 	}


### PR DESCRIPTION
With the addition of a new transparent footer in the editor, we received some feedback around text being obscured behind this bar while writing longer-form posts.  This branch is an attempt to fix that issue, and introduce a slight "typewriter" effect to the editor ( cc @folletto ).

In lieu of creating a new MCE plugin, I opted to piggyback on `wpcom-autoresize` since it seemed to tie in well with what I was hoping to fix... when the editor is expanding vertically to accomodate more type, `wpcom-autoresize` is increasing the size of the frame - so we could also add logic to scroll here as well!  ( If anyone else has a different approach, do please share here 🥇 )

![auto-scroll](https://cloud.githubusercontent.com/assets/22080/24127385/61f49e60-0d91-11e7-91fa-e090e894bc12.gif)

The logic here will scroll to the bottom of the page when you are typing at the end of the post only, and the auto-resize has increased the size of the frame.  So for example, if you are in the middle of a post, and it happens to be scrolled near the bottom, this will not scroll at that juncture.  So it isn't a true typewriter affect - so curious to have others play around with the branch and let me know their thoughts.
