### PR TITLE
Reader: Adjusted Comment, Like and Follow spacing for small screens

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -323,7 +323,7 @@
 
 	@include breakpoint( "<660px" ) {
 		position: fixed;
-			right: 138px;
+			right: 160px;
 			top: 10px;
 		z-index: z-index( '.masterbar', '.reader-profile' );
 	}
@@ -344,7 +344,7 @@
 	@include breakpoint( "<660px" ) {
 		position: fixed;
 			top: 10px;
-			right: 208px;
+			right: 232px;
 		z-index: z-index( '.masterbar', '.reader-profile' );
 		margin-right: 0;
 	}


### PR DESCRIPTION
This PR addresses issues in #11355 and is a quick fix (pending the [refactor](https://github.com/Automattic/wp-calypso/issues/11355#issuecomment-283808581)) to stop the Comment, Like and Follow-button bumping each other.
- Adjusted spacing between Comment, Like and Follow-button for <660px.

**After:**

<img width="386" alt="screen shot 2017-03-21 at 12 39 53 pm" src="https://cloud.githubusercontent.com/assets/2627210/24129055/1bb11fb6-0e34-11e7-8eb8-902ddf08b10a.png">

<img width="393" alt="screen shot 2017-03-21 at 12 39 45 pm" src="https://cloud.githubusercontent.com/assets/2627210/24129060/2282d41a-0e34-11e7-8906-5d8fc8b0cc61.png">