### PR TITLE
Reader: make sizing and spacing adjustments for the serif font change from Merriweather with Noto Serif

### DIFF
--- a/assets/stylesheets/shared/_typography.scss
+++ b/assets/stylesheets/shared/_typography.scss
@@ -4,7 +4,7 @@ $monospace: "Courier 10 Pitch", Courier, monospace;
 $code: Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", $monospace;
 
 $serif-fallback: Georgia, "Times New Roman", Times, serif;
-$serif: Merriweather, $serif-fallback;
+$serif: "Noto Serif", $serif-fallback;
 
 $sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
 $sans-rtl: Tahoma, $sans;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -1,3 +1,4 @@
+
 // Custom breakpoints needed to match original design
 
 $reader-post-card-breakpoint-xxlarge: "( min-width: 1100px )";

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -148,7 +148,7 @@ const CONTENT_CSS = [
 	window.app.tinymceWpSkin,
 	'//s1.wp.com/wp-includes/css/dashicons.css',
 	window.app.tinymceEditorCss,
-	'//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese',
+	'//s1.wp.com/i/fonts/notoserif/notoserif.css',
 ];
 
 module.exports = React.createClass( {

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -148,7 +148,7 @@ const CONTENT_CSS = [
 	window.app.tinymceWpSkin,
 	'//s1.wp.com/wp-includes/css/dashicons.css',
 	window.app.tinymceEditorCss,
-	'//s1.wp.com/i/fonts/merriweather/merriweather.css',
+	'//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese',
 ];
 
 module.exports = React.createClass( {

--- a/client/devdocs/design/typography.jsx
+++ b/client/devdocs/design/typography.jsx
@@ -48,21 +48,21 @@ export default React.createClass( {
 		};
 
 		const contentTitle = {
-			fontFamily: 'Merriweather',
+			fontFamily: 'Noto Serif',
 			fontSize: '32px',
 			fontWeight: '700',
 			lineHeight: '40px'
 		};
 
 		const contentSubtitle = {
-			fontFamily: 'Merriweather',
+			fontFamily: 'Noto Serif',
 			fontSize: '24px',
 			fontWeight: '700',
 			lineHeight: '32px'
 		};
 
 		const contentBodyCopy = {
-			fontFamily: 'Merriweather',
+			fontFamily: 'Noto Serif',
 			fontSize: '16px',
 			fontWeight: '400',
 			lineHeight: '1.5'

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -64,7 +64,7 @@
 
 .devdocs__doc {
 	h1, h2, h3, h4, h5, h6 {
-		font-family: Merriweather, Georgia, "Times New Roman", Times, serif;
+		font-family: $serif;
 		font-weight: 700;
 		line-height: 1.5em;
 		margin-bottom: 0.6em;

--- a/client/reader/site-stream/style.scss
+++ b/client/reader/site-stream/style.scss
@@ -66,7 +66,7 @@
 
 .reader__featured-post-title {
 	position: relative;
-	font-family: Merriweather, Georgia, "Times New Roman", Times, serif;
+	font-family: $serif;
 	font-weight: 700;
 	font-size: 18px;
 	color: $white;

--- a/server/pages/404.jade
+++ b/server/pages/404.jade
@@ -10,7 +10,7 @@ html(lang='en')
 		link(rel='shortcut icon', type='image/x-icon', href='//s1.wp.com/i/favicon.ico', sizes='16x16')
 		link(rel='icon', type='image/x-icon', href='//s1.wp.com/i/favicon.ico', sizes='16x16')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
-		link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
+		link(rel='stylesheet', href='//s1.wp.com/i/fonts/notoserif/notoserif.css?v=20170320')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css')
 		link(rel='stylesheet', href=urls['style.css'])
 	body

--- a/server/pages/404.jade
+++ b/server/pages/404.jade
@@ -10,7 +10,7 @@ html(lang='en')
 		link(rel='shortcut icon', type='image/x-icon', href='//s1.wp.com/i/favicon.ico', sizes='16x16')
 		link(rel='icon', type='image/x-icon', href='//s1.wp.com/i/favicon.ico', sizes='16x16')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
-		link(rel='stylesheet', href='//s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210')
+		link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css')
 		link(rel='stylesheet', href=urls['style.css'])
 	body

--- a/server/pages/500.jade
+++ b/server/pages/500.jade
@@ -10,7 +10,7 @@ html(lang='en')
 		link(rel='shortcut icon', type='image/x-icon', href='//s1.wp.com/i/favicon.ico', sizes='16x16')
 		link(rel='icon', type='image/x-icon', href='//s1.wp.com/i/favicon.ico', sizes='16x16')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
-		link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
+		link(rel='stylesheet', href='//s1.wp.com/i/fonts/notoserif/notoserif.css?v=20170320')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css')
 		link(rel='stylesheet', href=urls['style.css'])
 	body

--- a/server/pages/500.jade
+++ b/server/pages/500.jade
@@ -10,7 +10,7 @@ html(lang='en')
 		link(rel='shortcut icon', type='image/x-icon', href='//s1.wp.com/i/favicon.ico', sizes='16x16')
 		link(rel='icon', type='image/x-icon', href='//s1.wp.com/i/favicon.ico', sizes='16x16')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
-		link(rel='stylesheet', href='//s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210')
+		link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css')
 		link(rel='stylesheet', href=urls['style.css'])
 	body

--- a/server/pages/browsehappy.jade
+++ b/server/pages/browsehappy.jade
@@ -37,7 +37,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		link(rel='apple-touch-icon', sizes='180x180', href='//s1.wp.com/i/favicons/apple-touch-icon-180x180.png')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
 		link(rel='manifest', href='/calypso/manifest.json')
-		link(rel='stylesheet', href='//s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210')
+		link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
 		link(rel='stylesheet', href='//s1.wp.com/wp-includes/css/dashicons.css?v=20150727')
 		if isRTL
@@ -58,11 +58,11 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 								img.empty-content__illustration(src="/calypso/images/drake/drake-browser.svg")
 								h2.empty-content__title Unsupported Browser
 								h3.empty-content__line
-									| Unfortunately this page cannot be used by your browser. You can either 
+									| Unfortunately this page cannot be used by your browser. You can either
 									a(
 										href=dashboardUrl
 									) use the classic WordPress dashboard
-									| , or 
+									| , or
 									a(
 										href="http://browsehappy.com"
 									) upgrade your browser

--- a/server/pages/browsehappy.jade
+++ b/server/pages/browsehappy.jade
@@ -37,7 +37,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		link(rel='apple-touch-icon', sizes='180x180', href='//s1.wp.com/i/favicons/apple-touch-icon-180x180.png')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
 		link(rel='manifest', href='/calypso/manifest.json')
-		link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
+		link(rel='stylesheet', href='//s1.wp.com/i/fonts/notoserif/notoserif.css?v=20170320')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
 		link(rel='stylesheet', href='//s1.wp.com/wp-includes/css/dashicons.css?v=20150727')
 		if isRTL

--- a/server/pages/desktop.jade
+++ b/server/pages/desktop.jade
@@ -11,7 +11,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class='is-desktop' + ( isFluidWidth ?
 		link(rel='shortcut icon', type='image/x-icon', href=faviconURL, sizes='16x16')
 		link(rel='icon', type='image/x-icon', href=faviconURL, sizes='16x16')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
-		link(rel='stylesheet', href='https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
+		link(rel='stylesheet', href='https://s1.wp.com/i/fonts/notoserif/notoserif.css?v=20170320')
 		link(rel='stylesheet', href='https://s1.wp.com/i/noticons/noticons.css?v=20150727')
 		link(rel='stylesheet', href='https://s1.wp.com/wp-includes/css/dashicons.css?v=20150727')
 		if isRTL

--- a/server/pages/desktop.jade
+++ b/server/pages/desktop.jade
@@ -11,7 +11,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class='is-desktop' + ( isFluidWidth ?
 		link(rel='shortcut icon', type='image/x-icon', href=faviconURL, sizes='16x16')
 		link(rel='icon', type='image/x-icon', href=faviconURL, sizes='16x16')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
-		link(rel='stylesheet', href='https://s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210')
+		link(rel='stylesheet', href='https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
 		link(rel='stylesheet', href='https://s1.wp.com/i/noticons/noticons.css?v=20150727')
 		link(rel='stylesheet', href='https://s1.wp.com/wp-includes/css/dashicons.css?v=20150727')
 		if isRTL

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -44,7 +44,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		link(rel='apple-touch-icon', sizes='180x180', href='//s1.wp.com/i/favicons/apple-touch-icon-180x180.png')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
 		link(rel='manifest', href='/calypso/manifest.json')
-		link(rel='stylesheet', href='//s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210')
+		link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
 		link(rel='stylesheet', href='//s1.wp.com/wp-includes/css/dashicons.css?v=20150727')
 		if isRTL

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -44,7 +44,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		link(rel='apple-touch-icon', sizes='180x180', href='//s1.wp.com/i/favicons/apple-touch-icon-180x180.png')
 		link(rel='profile', href='http://gmpg.org/xfn/11')
 		link(rel='manifest', href='/calypso/manifest.json')
-		link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese')
+		link(rel='stylesheet', href='//s1.wp.com/i/fonts/notoserif/notoserif.css?v=20170320')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
 		link(rel='stylesheet', href='//s1.wp.com/wp-includes/css/dashicons.css?v=20150727')
 		if isRTL


### PR DESCRIPTION
This PR is for changes to Reader due to Noto Serif replacing Merriweather. Branched from https://github.com/Automattic/wp-calypso/pull/12326.