### PR TITLE
Editor: add a Guided Tour for editor basics

### DIFF
--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -5,9 +5,11 @@ import { combineTours } from 'layout/guided-tours/config-elements';
 import { MainTour } from 'layout/guided-tours/tours/main-tour';
 import { TutorialSitePreviewTour } from 'layout/guided-tours/tours/tutorial-site-preview-tour';
 import { GDocsIntegrationTour } from 'layout/guided-tours/tours/gdocs-integration-tour';
+import { EditorBasicsTour } from 'layout/guided-tours/tours/editor-basics-tour';
 
 export default combineTours( {
 	main: MainTour,
+	editorBasicsTour: EditorBasicsTour,
 	tutorialSitePreview: TutorialSitePreviewTour,
 	gdocsIntegrationTour: GDocsIntegrationTour,
 } );

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -1,6 +1,7 @@
 .guided-tours__step {
 	position: fixed;
 	max-width: 410px;
+	width: 410px;
 	z-index: z-index( 'root', '.guided-tours__step' );
 	background: darken( $gray, 52 );
 	box-shadow: 0 2px 24px 0 rgba( darken( $gray, 52 ), 0.5 );

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -1,7 +1,7 @@
 .guided-tours__step {
 	position: fixed;
+	width: calc( 100% - 10px );
 	max-width: 410px;
-	width: 410px;
 	z-index: z-index( 'root', '.guided-tours__step' );
 	background: darken( $gray, 52 );
 	box-shadow: 0 2px 24px 0 rgba( darken( $gray, 52 ), 0.5 );
@@ -49,7 +49,6 @@
 	animation-timing-function: ease-out;
 	animation-delay: 2s;
 	animation-fill-mode: both;
-	width: calc( 100% - 10px );
 }
 
 .guided-tours__step-finish {

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -122,7 +122,15 @@ export const EditorBasicsTour = makeTour(
 			style={ { marginTop: '-17px' } }
 			>
 			<p>
-				Your changes are saved automatically. Click here when you're ready to publish!
+				{
+					translate( 'Your changes are saved automatically. ' +
+									'Click {{strong}}Publish{{/strong}} to share your work with the world!',
+						{
+							components: {
+								strong: <strong />,
+							}
+						} )
+				}
 			</p>
 			<ButtonRow>
 				<Quit primary>Got it, I'm ready to write!</Quit>

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -49,12 +49,14 @@ export const EditorBasicsTour = makeTour(
 			isNewSite,
 			isDesktop
 			) }
+
 		>
 		<Step
 			name="init"
 			arrow="top-left"
 			target=".editor-title"
 			placement="below"
+			style={ { animationDelay: '10s',} }
 			>
 			<p>
 				Welcome to the editor! Add a title here.

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -85,7 +85,7 @@ export const EditorBasicsTour = makeTour(
 			arrow="top-left"
 			target=".mce-wpcom-insert-menu button"
 			placement="below"
-			style={ { marginLeft: '-10px' } }
+			style={ { marginLeft: '-10px', minWidth: '240px' } }
 			>
 			<p>
 				{

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -74,7 +74,7 @@ export const EditorBasicsTour = makeTour(
 			<p>
 				Write your post in the content area.
 			</p>
-			<img style={ { marginTop: '40px' } } src="https://en-support.files.wordpress.com/2017/03/editor-content-area_360.gif" />
+			<img src="https://en-support.files.wordpress.com/2017/03/editor-content-area_360.gif" style={ { marginBottom: '10px', border: '4px solid #00AADC' } } />
 			<ButtonRow>
 				<Next step="add-image">Continue</Next>
 				<Quit>Quit</Quit>

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -78,7 +78,7 @@ export const EditorBasicsTour = makeTour(
 			</p>
 			<img
 				src="https://en-support.files.wordpress.com/2017/03/editor-content-area_360.gif"
-				style={ { marginBottom: '10px', border: '4px solid #00AADC' } }
+				style={ { marginBottom: '10px', border: '3px solid #00AADC', borderRadius: '4px' } }
 				/>
 			<ButtonRow>
 				<Next step="add-image">Continue</Next>

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -108,7 +108,7 @@ export const EditorBasicsTour = makeTour(
 			placement="beside"
 			>
 			<p>
-				Find additional settings in the sidebar, such as featured image, tags, categories.
+				Find additional settings in the sidebar, such as tags, categories, and the featured image.
 			</p>
 			<ButtonRow>
 				<Next step="publish">Continue</Next>

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -71,7 +71,7 @@ export const EditorBasicsTour = makeTour(
 			arrow="top-left"
 			target=".mce-wpcom-insert-menu button"
 			placement="below"
-			style={ { marginLeft: '-10px' } }
+			style={ { marginLeft: '-10px', zIndex: 'auto' } }
 		>
 			<p>
 				{

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -56,7 +56,7 @@ export const EditorBasicsTour = makeTour(
 			arrow="top-left"
 			target=".editor-title"
 			placement="below"
-			style={ { animationDelay: '5s',} }
+			style={ { animationDelay: '5s', } }
 			>
 			<p>
 				Welcome to the editor! Add a title here.

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -29,24 +29,21 @@ export const EditorBasicsTour = makeTour(
 		name="editorBasicsTour"
 		version="20170321"
 		path="/post/"
-		when={ and(
-			isDesktop,
-			isNewUser,
-			) }
-		>
+		when={ and( isDesktop, isNewUser ) }
+	>
 		<Step
 			name="init"
 			arrow="top-left"
 			target=".editor-title"
 			placement="below"
 			style={ { animationDelay: '5s', } }
-			>
+		>
 			<p>
 				Welcome to the editor! Add a title here.
 			</p>
 			<ButtonRow>
 				<Next step="write">Continue</Next>
-				<Quit>Quit</Quit>
+				<Quit />
 			</ButtonRow>
 		</Step>
 		<Step
@@ -55,7 +52,7 @@ export const EditorBasicsTour = makeTour(
 			target=".mce-toolbar-grp.mce-container"
 			placement="below"
 			style={ { marginTop: '40px' } }
-			>
+		>
 			<p>
 				Write your post in the content area.
 			</p>
@@ -65,7 +62,7 @@ export const EditorBasicsTour = makeTour(
 				/>
 			<ButtonRow>
 				<Next step="add-image">Continue</Next>
-				<Quit>Quit</Quit>
+				<Quit />
 			</ButtonRow>
 		</Step>
 		<Step
@@ -73,8 +70,8 @@ export const EditorBasicsTour = makeTour(
 			arrow="top-left"
 			target=".mce-wpcom-insert-menu button"
 			placement="below"
-			style={ { marginLeft: '-10px', minWidth: '240px' } }
-			>
+			style={ { marginLeft: '-10px' } }
+		>
 			<p>
 				{
 					translate( 'Click the {{icon/}} to add images.', {
@@ -95,7 +92,7 @@ export const EditorBasicsTour = makeTour(
 			target=".editor-ground-control__toggle-sidebar"
 			placement="beside"
 			style={ { marginTop: '-9px' } }
-			>
+		>
 			<p>
 				Find additional settings in the sidebar — such as tags, categories, and the featured image.
 			</p>
@@ -110,8 +107,8 @@ export const EditorBasicsTour = makeTour(
 
 			</p>
 			<ButtonRow>
-				<Next step="publish">Continue</Next>
-				<Quit>Quit</Quit>
+				<Next step="publish" />
+				<Quit />
 			</ButtonRow>
 		</Step>
 		<Step
@@ -120,11 +117,11 @@ export const EditorBasicsTour = makeTour(
 			target=".editor-ground-control__publish-combo"
 			placement="beside"
 			style={ { marginTop: '-17px' } }
-			>
+		>
 			<p>
 				{
 					translate( 'Your changes are saved automatically. ' +
-									'Click {{strong}}Publish{{/strong}} to share your work with the world!',
+							'Click {{strong}}Publish{{/strong}} to share your work with the world!',
 						{
 							components: {
 								strong: <strong />,

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -76,7 +76,10 @@ export const EditorBasicsTour = makeTour(
 			<p>
 				Write your post in the content area.
 			</p>
-			<img src="https://en-support.files.wordpress.com/2017/03/editor-content-area_360.gif" style={ { marginBottom: '10px', border: '4px solid #00AADC' } } />
+			<img
+				src="https://en-support.files.wordpress.com/2017/03/editor-content-area_360.gif"
+				style={ { marginBottom: '10px', border: '4px solid #00AADC' } }
+				/>
 			<ButtonRow>
 				<Next step="add-image">Continue</Next>
 				<Quit>Quit</Quit>

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -40,10 +40,10 @@ export const EditorBasicsTour = makeTour(
 			style={ { animationDelay: '5s', } }
 		>
 			<p>
-				Welcome to the editor! Add a title here.
+				{ translate( 'Welcome to the editor! Add a title here.' ) }
 			</p>
 			<ButtonRow>
-				<Next step="write">Continue</Next>
+				<Next step="write" />
 				<Quit />
 			</ButtonRow>
 		</Step>
@@ -55,14 +55,14 @@ export const EditorBasicsTour = makeTour(
 			style={ { marginTop: '40px' } }
 		>
 			<p>
-				Write your post in the content area.
+				{ translate( 'Write your post in the content area.' ) }
 			</p>
 			<img
 				src="https://en-support.files.wordpress.com/2017/03/editor-content-area_360.gif"
 				style={ { marginBottom: '10px', border: '3px solid #00AADC', borderRadius: '4px' } }
 				/>
 			<ButtonRow>
-				<Next step="add-image">Continue</Next>
+				<Next step="add-image" />
 				<Quit />
 			</ButtonRow>
 		</Step>
@@ -83,8 +83,8 @@ export const EditorBasicsTour = makeTour(
 				}
 			</p>
 			<ButtonRow>
-				<Next step="sidebar-options">Continue</Next>
-				<Quit>Quit</Quit>
+				<Next step="sidebar-options" />
+				<Quit />
 			</ButtonRow>
 		</Step>
 		<Step
@@ -95,7 +95,7 @@ export const EditorBasicsTour = makeTour(
 			style={ { marginTop: '-9px' } }
 		>
 			<p>
-				Add tags, categories, and a featured image from the sidebar.
+				{ translate( 'Add tags, categories, and a featured image from the sidebar.' ) }
 			</p>
 			<p>
 				{
@@ -131,7 +131,9 @@ export const EditorBasicsTour = makeTour(
 				}
 			</p>
 			<ButtonRow>
-				<Quit primary>Got it, I'm ready to write!</Quit>
+				<Quit primary>
+					{ translate( "Got it, I'm ready to write!" ) }
+				</Quit>
 			</ButtonRow>
 			<Link href="https://learn.wordpress.com/get-published/">
 				{ translate( 'Learn more about publishing content.' ) }

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -18,27 +18,11 @@ import {
 	ButtonRow,
 	Next,
 	Quit,
-	// Link,
-	// Continue,
 } from 'layout/guided-tours/config-elements';
 import {
-	isNewSite,
-	// isNewUser,
-	// isEnabled,
-	// isSelectedSitePreviewable,
+	isNewUser,
 } from 'state/ui/guided-tours/contexts';
-// import { isPreviewShowing } from 'state/ui/selectors';
 import { isDesktop } from 'lib/viewport';
-
-// const yes = () => {
-// 	return true;
-// };
-
-/*
-TODO:
-- proper path: /post/URL -- maybe /post/ is good enough?
-- make proper when
-*/
 
 export const EditorBasicsTour = makeTour(
 	<Tour
@@ -46,10 +30,9 @@ export const EditorBasicsTour = makeTour(
 		version="20170321"
 		path="/post/"
 		when={ and(
-			isNewSite,
-			isDesktop
+			isDesktop,
+			isNewUser,
 			) }
-
 		>
 		<Step
 			name="init"

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -1,0 +1,133 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { translate } from 'i18n-calypso';
+import {
+	overEvery as and,
+} from 'lodash';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import {
+	makeTour,
+	Tour,
+	Step,
+	ButtonRow,
+	Next,
+	Quit,
+	// Link,
+	// Continue,
+} from 'layout/guided-tours/config-elements';
+import {
+	isNewSite,
+	// isNewUser,
+	// isEnabled,
+	// isSelectedSitePreviewable,
+} from 'state/ui/guided-tours/contexts';
+// import { isPreviewShowing } from 'state/ui/selectors';
+import { isDesktop } from 'lib/viewport';
+
+// const yes = () => {
+// 	return true;
+// };
+
+/*
+TODO:
+- proper path: /post/URL -- maybe /post/ is good enough?
+- make proper when
+*/
+
+export const EditorBasicsTour = makeTour(
+	<Tour
+		name="editorBasicsTour"
+		version="20170321"
+		path="/post/"
+		when={ and(
+			isNewSite,
+			isDesktop
+			) }
+		>
+		<Step
+			name="init"
+			arrow="top-left"
+			target=".editor-title"
+			placement="below"
+			>
+			<p>
+				Welcome to the editor! Add a title here.
+			</p>
+			<ButtonRow>
+				<Next step="write">Continue</Next>
+				<Quit>Quit</Quit>
+			</ButtonRow>
+		</Step>
+		<Step
+			name="write"
+			arrow="top-left"
+			target=".mce-toolbar"
+			placement="below"
+			style={ { marginTop: '40px' } }
+			>
+			<p>
+				Write your post in the content area.
+			</p>
+			<img style={ { marginTop: '40px' } } src="https://en-support.files.wordpress.com/2017/03/editor-content-area_360.gif" />
+			<ButtonRow>
+				<Next step="add-image">Continue</Next>
+				<Quit>Quit</Quit>
+			</ButtonRow>
+		</Step>
+		<Step
+			name="add-image"
+			arrow="top-left"
+			target=".mce-wpcom-insert-menu button"
+			placement="below"
+			style={ { marginLeft: '-10px' } }
+			>
+			<p>
+				{
+					translate( 'Click the {{icon/}} to add images.', {
+						components: {
+							icon: <Gridicon icon="add-outline" />,
+						}
+					} )
+				}
+			</p>
+			<ButtonRow>
+				<Next step="sidebar-options">Continue</Next>
+				<Quit>Quit</Quit>
+			</ButtonRow>
+		</Step>
+		<Step
+			name="sidebar-options"
+			arrow="right-top"
+			target=".editor-categories-tags__accordion"
+			placement="beside"
+			>
+			<p>
+				Find additional settings in the sidebar, such as featured image, tags, categories.
+			</p>
+			<ButtonRow>
+				<Next step="publish">Continue</Next>
+				<Quit>Quit</Quit>
+			</ButtonRow>
+		</Step>
+		<Step
+			name="publish"
+			arrow="right-top"
+			target=".editor-ground-control__publish-combo"
+			placement="beside"
+			style={ { marginTop: '-17px' } }
+			>
+			<p>
+				Your changes are saved automatically. Click here when you're ready to publish!
+			</p>
+			<ButtonRow>
+				<Quit primary>Got it, I'm ready to write!</Quit>
+			</ButtonRow>
+		</Step>
+	</Tour>
+);

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -106,8 +106,9 @@ export const EditorBasicsTour = makeTour(
 		<Step
 			name="sidebar-options"
 			arrow="right-top"
-			target=".editor-categories-tags__accordion"
+			target=".editor-ground-control__toggle-sidebar"
 			placement="beside"
+			style={ { marginTop: '-9px' } }
 			>
 			<p>
 				Find additional settings in the sidebar, such as tags, categories, and the featured image.

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -56,7 +56,7 @@ export const EditorBasicsTour = makeTour(
 			arrow="top-left"
 			target=".editor-title"
 			placement="below"
-			style={ { animationDelay: '10s',} }
+			style={ { animationDelay: '5s',} }
 			>
 			<p>
 				Welcome to the editor! Add a title here.

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -18,6 +18,7 @@ import {
 	ButtonRow,
 	Next,
 	Quit,
+	Link,
 } from 'layout/guided-tours/config-elements';
 import {
 	isNewUser,
@@ -94,7 +95,7 @@ export const EditorBasicsTour = makeTour(
 			style={ { marginTop: '-9px' } }
 		>
 			<p>
-				Find additional settings in the sidebar — such as tags, categories, and the featured image.
+				Add tags, categories, and a featured image from the sidebar.
 			</p>
 			<p>
 				{
@@ -132,6 +133,9 @@ export const EditorBasicsTour = makeTour(
 			<ButtonRow>
 				<Quit primary>Got it, I'm ready to write!</Quit>
 			</ButtonRow>
+			<Link href="https://learn.wordpress.com/get-published/">
+				{ translate( 'Learn more about publishing content.' ) }
+			</Link>
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -114,7 +114,17 @@ export const EditorBasicsTour = makeTour(
 			style={ { marginTop: '-9px' } }
 			>
 			<p>
-				Find additional settings in the sidebar, such as tags, categories, and the featured image.
+				Find additional settings in the sidebar — such as tags, categories, and the featured image.
+			</p>
+			<p>
+				{
+					translate( 'Click the {{icon/}} to show or hide these settings.', {
+						components: {
+							icon: <Gridicon icon="cog" />,
+						}
+					} )
+				}
+
 			</p>
 			<ButtonRow>
 				<Next step="publish">Continue</Next>

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -28,7 +28,7 @@ import { isDesktop } from 'lib/viewport';
 export const EditorBasicsTour = makeTour(
 	<Tour
 		name="editorBasicsTour"
-		version="20170321"
+		version="20170503"
 		path="/post/"
 		when={ and( isDesktop, isNewUser ) }
 	>

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -69,7 +69,7 @@ export const EditorBasicsTour = makeTour(
 		<Step
 			name="write"
 			arrow="top-left"
-			target=".mce-toolbar"
+			target=".mce-toolbar-grp.mce-container"
 			placement="below"
 			style={ { marginTop: '40px' } }
 			>

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -14,11 +14,26 @@ import { getLastAction } from 'state/ui/action-log/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { canCurrentUser, isSiteCustomizable } from 'state/selectors';
 import {
+	getSiteOption,
 	hasDefaultSiteTitle,
 	isCurrentPlanPaid,
 } from 'state/sites/selectors';
 
 const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
+
+export const timeSinceSelectedSiteCreation = state => {
+	const site = getSelectedSite( state );
+	const siteId = site.id;
+	const creationDate = siteId && Date.parse( getSiteOption( state, siteId, 'created_at' ) );
+	const res = creationDate ? ( Date.now() - creationDate ) : false;
+	// console.log( site, siteId, creationDate, res );
+	return res;
+};
+
+export const isNewSite = state => {
+	const siteAge = timeSinceSelectedSiteCreation( state );
+	return siteAge !== false ? siteAge <= WEEK_IN_MILLISECONDS : false;
+};
 
 /**
  * Returns a selector that tests if the current user is in a given section

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -14,26 +14,11 @@ import { getLastAction } from 'state/ui/action-log/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { canCurrentUser, isSiteCustomizable } from 'state/selectors';
 import {
-	getSiteOption,
 	hasDefaultSiteTitle,
 	isCurrentPlanPaid,
 } from 'state/sites/selectors';
 
 const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
-
-export const timeSinceSelectedSiteCreation = state => {
-	const site = getSelectedSite( state );
-	const siteId = site.id;
-	const creationDate = siteId && Date.parse( getSiteOption( state, siteId, 'created_at' ) );
-	const res = creationDate ? ( Date.now() - creationDate ) : false;
-	// console.log( site, siteId, creationDate, res );
-	return res;
-};
-
-export const isNewSite = state => {
-	const siteAge = timeSinceSelectedSiteCreation( state );
-	return siteAge !== false ? siteAge <= WEEK_IN_MILLISECONDS : false;
-};
 
 /**
  * Returns a selector that tests if the current user is in a given section


### PR DESCRIPTION
This PR adds a tour that gets triggered when a new user (i.e., account age is 7 days or less) enters the post editor (i.e., path starts with `/post/`). 

This is what it looks like:

![editorbasicstour-v2](https://cloud.githubusercontent.com/assets/23619/25620574/2b38b91c-2f4f-11e7-93d4-60724c7bf65a.gif)

To test:
- Create a new user account, then head for the post editor a few times. Confirm that the tour gets triggered once and only once. 
- Go to `http://calypso.localhost:3000/post/SITE_URL?tour=editorBasicsTour` and confirm that the tour gets triggered. 
- Confirm that the tour's steps are worded appropriately. 

TODO:
- [x] add `translate` calls for the copy when the copy is final

This tour was made at the Cerberus meet-up. Props to @jerrysarcastic @dcoleonline @eurello @vparkhere @formosattic @mgalbritton. 🙌