### PR TITLE
Editor: Reduxify the EditorVisibility component 2nd attempt

### DIFF
--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -21,7 +21,6 @@ export default React.createClass( {
 
 	propTypes: {
 		isNew: React.PropTypes.bool,
-		onPrivatePublish: React.PropTypes.func,
 		post: React.PropTypes.object,
 		savedPost: React.PropTypes.object,
 		site: React.PropTypes.object,

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import includes from 'lodash/includes';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -20,13 +21,13 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import Button from 'components/button';
 import Popover from 'components/popover';
 import touchDetect from 'lib/touch-detect';
-import postActions from 'lib/posts/actions';
 import { recordEvent, recordStat } from 'lib/posts/stats';
 import accept from 'lib/accept';
+import { editPost } from 'state/posts/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
 
-export default React.createClass( {
-	displayName: 'EditorVisibility',
-
+const EditorVisibility = React.createClass( {
 	showingAcceptDialog: false,
 
 	getDefaultProps() {
@@ -44,6 +45,9 @@ export default React.createClass( {
 		password: React.PropTypes.string,
 		savedStatus: React.PropTypes.string,
 		savedPassword: React.PropTypes.string,
+		siteId: React.PropTypes.number,
+		postId: React.PropTypes.number,
+		editPost: React.PropTypes.func,
 	},
 
 	getInitialState() {
@@ -158,6 +162,7 @@ export default React.createClass( {
 	},
 
 	updateVisibility( event ) {
+		const { siteId, postId } = this.props;
 		var defaultVisibility, newVisibility, postEdits;
 
 		defaultVisibility = 'draft' === this.props.status ? 'draft' : 'publish';
@@ -182,8 +187,7 @@ export default React.createClass( {
 		recordStat( 'visibility-set-' + newVisibility );
 		recordEvent( 'Changed visibility', newVisibility );
 
-		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		postActions.edit( postEdits );
+		this.props.editPost( siteId, postId, postEdits );
 	},
 
 	onKey( event ) {
@@ -193,8 +197,8 @@ export default React.createClass( {
 	},
 
 	setPostToPrivate() {
-		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		postActions.edit( {
+		const { siteId, postId } = this.props;
+		this.props.editPost( siteId, postId, {
 			password: '',
 			status: 'private'
 		} );
@@ -238,6 +242,7 @@ export default React.createClass( {
 	},
 
 	onPasswordChange( event ) {
+		const { siteId, postId } = this.props;
 		let newPassword = event.target.value.trim();
 		const passwordIsValid = newPassword.length > 0;
 
@@ -246,15 +251,12 @@ export default React.createClass( {
 		if ( ! passwordIsValid ) {
 			newPassword = ' ';
 		}
-
-		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		postActions.edit( { password: newPassword } );
+		this.props.editPost( siteId, postId, { password: newPassword } );
 	},
 
 	renderPasswordInput() {
 		var value, isError, errorMessage;
-
-		value = this.props.password ? this.props.password.trim() : null;
+		value = this.props.password ? this.props.password.trim() : '';
 		isError = ! this.state.passwordIsValid;
 		errorMessage = this.translate( 'Password is empty.', { context: 'Editor: Error shown when password is empty.' } );
 
@@ -380,3 +382,13 @@ export default React.createClass( {
 	}
 
 } );
+
+export default connect(
+	state => {
+		const siteId = getSelectedSiteId( state );
+		const postId = getEditorPostId( state );
+
+		return { siteId, postId };
+	},
+	{ editPost }
+)( EditorVisibility );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -252,7 +252,6 @@ export const PostEditor = React.createClass( {
 								onDismissClick={ this.hideNotice } />
 							<EditorActionBar
 								isNew={ this.state.isNew }
-								onPrivatePublish={ this.onPublish }
 								post={ this.state.post }
 								savedPost={ this.state.savedPost }
 								site={ site }
@@ -651,15 +650,10 @@ export const PostEditor = React.createClass( {
 	onPublish: function() {
 		const edits = {
 			...this.props.edits,
-			status: 'publish'
+			status: [ 'private', 'future' ].indexOf( this.props.edits.status ) === -1
+				? 'publish'
+				: this.props.edits.status
 		};
-
-		// determine if this is a private publish
-		if ( utils.isPrivate( this.state.post ) ) {
-			edits.status = 'private';
-		} else if ( utils.isFutureDated( this.state.post ) ) {
-			edits.status = 'future';
-		}
 
 		// Update content on demand to avoid unnecessary lag and because it is expensive
 		// to serialize when TinyMCE is the active mode


### PR DESCRIPTION
This is the second attempt to close #12276

The first PR #12320 has been reverted because of the following use-case:

- Create a new post
- Fill quickly the title, content and set a password
- Hit publish before the first auto-save 
- The post remains as a draft and is not published

To fix this I switched the "status" priority on the `onPublish` method. The logic now is clearer.

- When publishing the status is set to "publish" unless the current edits contains a "publishable" status (private or future).

**Testing instructions**

- Try to publish privately
- Try to publish a future post
- Try to set/edit a password
- Try to revert to draft and republish
