### PR TITLE
Update/shrinkwrap 

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -435,7 +435,7 @@
       "version": "1.2.0",
       "dependencies": {
         "readable-stream": {
-          "version": "2.2.5"
+          "version": "2.2.6"
         }
       }
     },
@@ -536,7 +536,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000635"
+      "version": "1.0.30000640"
     },
     "caseless": {
       "version": "0.12.0"
@@ -858,7 +858,7 @@
       "version": "0.4.1"
     },
     "d": {
-      "version": "0.1.1",
+      "version": "1.0.0",
       "dev": true
     },
     "dashdash": {
@@ -1028,7 +1028,7 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.5",
+          "version": "2.2.6",
           "dev": true
         }
       }
@@ -1156,30 +1156,30 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.13",
+      "version": "0.10.15",
       "dev": true
     },
     "es6-iterator": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dev": true
     },
     "es6-map": {
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dev": true
     },
     "es6-set": {
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dev": true
     },
     "es6-symbol": {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "dev": true
     },
     "es6-templates": {
       "version": "0.2.3"
     },
     "es6-weak-map": {
-      "version": "2.0.1",
+      "version": "2.0.2",
       "dev": true
     },
     "escape-html": {
@@ -1382,7 +1382,7 @@
       "version": "1.7.0"
     },
     "event-emitter": {
-      "version": "0.3.4",
+      "version": "0.3.5",
       "dev": true
     },
     "event-stream": {
@@ -1479,7 +1479,7 @@
       "version": "2.1.1"
     },
     "fbjs": {
-      "version": "0.8.9",
+      "version": "0.8.11",
       "dependencies": {
         "core-js": {
           "version": "1.2.7"
@@ -1775,7 +1775,7 @@
       "version": "1.0.0"
     },
     "hosted-git-info": {
-      "version": "2.2.0"
+      "version": "2.4.1"
     },
     "html": {
       "version": "1.0.0",
@@ -1861,7 +1861,7 @@
       "version": "1.1.8"
     },
     "ignore": {
-      "version": "3.2.4",
+      "version": "3.2.6",
       "dev": true
     },
     "immediate": {
@@ -2441,7 +2441,7 @@
       "version": "0.3.0",
       "dependencies": {
         "readable-stream": {
-          "version": "2.2.5"
+          "version": "2.2.6"
         }
       }
     },
@@ -2614,10 +2614,13 @@
       "version": "1.6.3"
     },
     "node-gyp": {
-      "version": "3.5.0",
+      "version": "3.6.0",
       "dependencies": {
         "minimatch": {
           "version": "3.0.3"
+        },
+        "semver": {
+          "version": "5.3.0"
         }
       }
     },
@@ -3136,7 +3139,7 @@
       "dev": true,
       "dependencies": {
         "readable-stream": {
-          "version": "2.2.5",
+          "version": "2.2.6",
           "dev": true
         }
       }
@@ -3165,7 +3168,7 @@
           "version": "3.0.3"
         },
         "readable-stream": {
-          "version": "2.2.5"
+          "version": "2.2.6"
         }
       }
     },
@@ -3723,7 +3726,7 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.5",
+          "version": "2.2.6",
           "dev": true
         },
         "resolve-from": {
@@ -3753,7 +3756,7 @@
           "version": "6.4.0"
         },
         "readable-stream": {
-          "version": "2.2.5"
+          "version": "2.2.6"
         }
       }
     },
@@ -3812,13 +3815,13 @@
       "version": "2.2.1"
     },
     "tar-fs": {
-      "version": "1.15.1"
+      "version": "1.15.2"
     },
     "tar-stream": {
       "version": "1.5.2",
       "dependencies": {
         "readable-stream": {
-          "version": "2.2.5"
+          "version": "2.2.6"
         }
       }
     },
@@ -4145,8 +4148,14 @@
           "dev": true
         },
         "finalhandler": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.1",
+          "dev": true,
+          "dependencies": {
+            "debug": {
+              "version": "2.6.3",
+              "dev": true
+            }
+          }
         },
         "fresh": {
           "version": "0.5.0",
@@ -4197,7 +4206,7 @@
           "dev": true
         },
         "vary": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "dev": true
         }
       }


### PR DESCRIPTION
While rebasing and shrinkwrapping an unrelated PR https://github.com/Automattic/wp-calypso/pull/6945 I found that two tests were failing. It seems that the cause is that `npm-shrinkwrap.json` is outdated in `master`, so I prefer separate concerns and merge the other PR after this is solved.