### PR TITLE
Themes: Enable showcase 'magic search' in Production

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -60,6 +60,7 @@
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,
 		"manage/themes/logged-out": true,
+		"manage/themes/magic-search": true,
 		"manage/themes/upload": true,
 		"me/account": true,
 		"me/find-friends": false,

--- a/config/production.json
+++ b/config/production.json
@@ -57,6 +57,7 @@
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,
 		"manage/themes/logged-out": true,
+		"manage/themes/magic-search": true,
 		"manage/themes/upload": true,
 		"me/account": true,
 		"me/find-friends": false,


### PR DESCRIPTION
<img width="942" alt="screen shot 2017-03-21 at 10 58 50" src="https://cloud.githubusercontent.com/assets/7767559/24144520/6d560bba-0e25-11e7-868d-943b315d6b82.png">

Also enable on Horizon.

Allows theme filtering from the search box with UI auto-suggest. Also allows saving/sharing filters via URL.
