### PR TITLE
Reader: use index for combined card key

### DIFF
--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -106,9 +106,9 @@ class ReaderCombinedCard extends React.Component {
 					}
 				</header>
 				<ul className="reader-combined-card__post-list">
-					{ posts.map( post => (
+					{ posts.map( ( post, index ) => (
 						<ReaderCombinedCardPost
-							key={ `post-${ post.ID }` }
+							key={ `post-${ index }` }
 							post={ post }
 							streamUrl={ streamUrl }
 							onClick={ onClick }


### PR DESCRIPTION
Very occasionally I've been seeing posts duplicated in combined cards. In one such instance, I noticed that one post was from a feed, which was followed by the same post from a site:

<img width="730" alt="screen shot 2017-03-21 at 12 55 17" src="https://cloud.githubusercontent.com/assets/17325/24148847/6a8174b6-0e38-11e7-9c1c-c829c3e38ff4.png">
<img width="842" alt="screen shot 2017-03-21 at 12 55 24" src="https://cloud.githubusercontent.com/assets/17325/24148854/711972e2-0e38-11e7-9e0e-d2423fae6372.png">

The post ID is different, but the post we're dealing with is the same.

The [React docs](https://facebook.github.io/react/docs/lists-and-keys.html) advise using the index instead if the object ID is not stable, so that's exactly what I've done in this PR.

### To test

If you're an Automattician - switch to the `futonbleu` account and verify that there are no duplicate posts in combined cards on Following.