### PR TITLE
Site Settings: Introduce a Site Stats card to Traffic section

### DIFF
--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -26,7 +26,7 @@ import {
 	isJetpackSiteInDevelopmentMode
 } from 'state/selectors';
 
-class SiteStats extends Component {
+class JetpackSiteStats extends Component {
 	static defaultProps = {
 		isSavingSettings: false,
 		isRequestingSettings: true,
@@ -111,12 +111,12 @@ class SiteStats extends Component {
 				<SectionHeader label={ translate( 'Site stats' ) } />
 
 				<FoldableCard
-					className="stats__foldable-card site-settings__foldable-card is-top-level"
+					className="site-settings__foldable-card is-top-level"
 					header={ header }
 					clickableHeader
 				>
 					<FormFieldset>
-						<div className="stats__info-link-container site-settings__info-link-container">
+						<div className="site-settings__info-link-container">
 							<InfoPopover position={ 'left' }>
 								<ExternalLink href={ 'https://jetpack.com/support/wordpress-com-stats/' } target="_blank">
 									{ translate( 'Learn more about WordPress.com Stats' ) }
@@ -187,4 +187,4 @@ export default connect(
 			siteRoles: getSiteRoles( state, siteId ),
 		};
 	}
-)( localize( SiteStats ) );
+)( localize( JetpackSiteStats ) );

--- a/client/my-sites/site-settings/stats.jsx
+++ b/client/my-sites/site-settings/stats.jsx
@@ -1,0 +1,190 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import FoldableCard from 'components/foldable-card';
+import SectionHeader from 'components/section-header';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLegend from 'components/forms/form-legend';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import InfoPopover from 'components/info-popover';
+import ExternalLink from 'components/external-link';
+import QueryJetpackConnection from 'components/data/query-jetpack-connection';
+import QuerySiteRoles from 'components/data/query-site-roles';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteRoles } from 'state/site-roles/selectors';
+import {
+	isJetpackModuleActive,
+	isJetpackModuleUnavailableInDevelopmentMode,
+	isJetpackSiteInDevelopmentMode
+} from 'state/selectors';
+
+class SiteStats extends Component {
+	static defaultProps = {
+		isSavingSettings: false,
+		isRequestingSettings: true,
+		fields: {}
+	};
+
+	static propTypes = {
+		handleAutosavingToggle: PropTypes.func.isRequired,
+		setFieldValue: PropTypes.func.isRequired,
+		isSavingSettings: PropTypes.bool,
+		isRequestingSettings: PropTypes.bool,
+		fields: PropTypes.object,
+	};
+
+	onChangeToggleGroup = ( groupName, fieldName ) => {
+		return () => {
+			const { setFieldValue } = this.props;
+			let groupFields = this.getCurrentGroupFields( groupName );
+
+			if ( groupFields.includes( fieldName ) ) {
+				groupFields = groupFields.filter( field => field !== fieldName );
+			} else {
+				groupFields.push( fieldName );
+			}
+
+			setFieldValue( groupName, groupFields, true );
+		};
+	};
+
+	getCurrentGroupFields( groupName ) {
+		const { fields } = this.props;
+
+		if ( ! fields[ groupName ] ) {
+			return [];
+		}
+		return fields[ groupName ];
+	}
+
+	renderToggle( name, label, checked = null, onChange = null ) {
+		const {
+			fields,
+			handleAutosavingToggle,
+			isRequestingSettings,
+			isSavingSettings,
+			moduleUnavailable,
+			statsModuleActive
+		} = this.props;
+
+		if ( checked === null ) {
+			checked = !! fields[ name ];
+		}
+
+		if ( onChange === null ) {
+			onChange = handleAutosavingToggle( name );
+		}
+
+		return (
+			<CompactFormToggle
+				checked={ checked }
+				disabled={ isRequestingSettings || isSavingSettings || moduleUnavailable || ! statsModuleActive }
+				onChange={ onChange }
+				key={ name }
+			>
+				{ label }
+			</CompactFormToggle>
+		);
+	}
+
+	render() {
+		const {
+			siteId,
+			siteRoles,
+			translate
+		} = this.props;
+		const header = translate( 'Collecting valuable traffic stats and insights' );
+
+		return (
+			<div className="site-settings__traffic-settings">
+				<QueryJetpackConnection siteId={ siteId } />
+				<QuerySiteRoles siteId={ siteId } />
+
+				<SectionHeader label={ translate( 'Site stats' ) } />
+
+				<FoldableCard
+					className="stats__foldable-card site-settings__foldable-card is-top-level"
+					header={ header }
+					clickableHeader
+				>
+					<FormFieldset>
+						<div className="stats__info-link-container site-settings__info-link-container">
+							<InfoPopover position={ 'left' }>
+								<ExternalLink href={ 'https://jetpack.com/support/wordpress-com-stats/' } target="_blank">
+									{ translate( 'Learn more about WordPress.com Stats' ) }
+								</ExternalLink>
+							</InfoPopover>
+						</div>
+
+						{ this.renderToggle( 'admin_bar', translate( 'Put a chart showing 48 hours of views in the admin bar' ) ) }
+						{ this.renderToggle( 'hide_smile', (
+							<div>
+								{ translate( 'Hide the stats smiley face image' ) }
+								<FormSettingExplanation>
+									{ translate( 'The image helps collect stats, but should work when hidden.' ) }
+								</FormSettingExplanation>
+							</div>
+						) ) }
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLegend>
+							{ translate( 'Count logged in page views from' ) }
+						</FormLegend>
+						{
+							siteRoles &&
+							siteRoles.map(
+								role => this.renderToggle(
+									'count_roles_' + role.name,
+									role.display_name,
+									this.getCurrentGroupFields( 'count_roles' ).includes( role.name ),
+									this.onChangeToggleGroup( 'count_roles', role.name )
+								)
+							)
+						}
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLegend>
+							{ translate( 'Allow stats reports to be viewed by' ) }
+						</FormLegend>
+						{
+							siteRoles &&
+							siteRoles.map(
+								role => this.renderToggle(
+									'roles_' + role.name,
+									role.display_name,
+									this.getCurrentGroupFields( 'roles' ).includes( role.name ),
+									this.onChangeToggleGroup( 'roles', role.name )
+								)
+							)
+						}
+					</FormFieldset>
+				</FoldableCard>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const siteInDevMode = isJetpackSiteInDevelopmentMode( state, siteId );
+		const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode( state, siteId, 'stats' );
+
+		return {
+			siteId,
+			statsModuleActive: !! isJetpackModuleActive( state, siteId, 'stats' ),
+			moduleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
+			siteRoles: getSiteRoles( state, siteId ),
+		};
+	}
+)( localize( SiteStats ) );

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -364,6 +364,10 @@
 		padding: 8px 24px 24px;
 		border-top: 1px lighten( $gray, 20% ) solid;
 	}
+
+	&.is-expanded.is-top-level .foldable-card__content {
+		padding: 24px;
+	}
 }
 
 // Site settings group styles

--- a/client/my-sites/site-settings/traffic/main.jsx
+++ b/client/my-sites/site-settings/traffic/main.jsx
@@ -14,16 +14,20 @@ import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
 import SeoSettingsMain from 'my-sites/site-settings/seo-settings/main';
 import SeoSettingsHelpCard from 'my-sites/site-settings/seo-settings/help';
 import AnalyticsSettings from 'my-sites/site-settings/form-analytics';
+import JetpackSiteStats from 'my-sites/site-settings/jetpack-site-stats';
 import RelatedPosts from 'my-sites/site-settings/related-posts';
 import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
 
 const SiteSettingsTraffic = ( {
 	fields,
+	jetpackSettingsUiSupported,
 	handleAutosavingToggle,
 	handleSubmitForm,
 	isRequestingSettings,
 	isSavingSettings,
+	setFieldValue,
 	site,
 	sites,
 	upgradeToBusiness
@@ -32,6 +36,15 @@ const SiteSettingsTraffic = ( {
 		<SidebarNavigation />
 		<SiteSettingsNavigation site={ site } section="traffic" />
 
+		{ jetpackSettingsUiSupported &&
+			<JetpackSiteStats
+				handleAutosavingToggle={ handleAutosavingToggle }
+				setFieldValue={ setFieldValue }
+				isSavingSettings={ isSavingSettings }
+				isRequestingSettings={ isRequestingSettings }
+				fields={ fields }
+			/>
+		}
 		<RelatedPosts
 			onSubmitForm={ handleSubmitForm }
 			handleAutosavingToggle={ handleAutosavingToggle }
@@ -51,12 +64,25 @@ SiteSettingsTraffic.propTypes = {
 };
 
 const connectComponent = connect(
-	( state ) => ( {
-		site: getSelectedSite( state ),
-	} )
+	( state ) => {
+		const site = getSelectedSite( state );
+		const siteId = getSelectedSiteId( state );
+		const isJetpack = isJetpackSite( state, siteId );
+		const jetpackSettingsUiSupported = isJetpack && siteSupportsJetpackSettingsUi( state, siteId );
+
+		return {
+			site,
+			jetpackSettingsUiSupported,
+		};
+	}
 );
 
 const getFormSettings = partialRight( pick, [
+	'stats',
+	'admin_bar',
+	'hide_smile',
+	'count_roles',
+	'roles',
 	'jetpack_relatedposts_allowed',
 	'jetpack_relatedposts_enabled',
 	'jetpack_relatedposts_show_headline',

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -150,9 +150,11 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			} );
 		};
 
-		setFieldValue = ( field, value ) => {
+		setFieldValue = ( field, value, autosave = false ) => {
 			this.props.updateFields( {
 				[ field ]: value
+			}, () => {
+				autosave && this.submitForm();
 			} );
 		};
 

--- a/client/state/jetpack/settings/test/utils.js
+++ b/client/state/jetpack/settings/test/utils.js
@@ -229,7 +229,12 @@ describe( 'utils', () => {
 				jetpack_comment_form_color_scheme: 'light',
 				carousel: true,
 				carousel_background_color: 'black',
-				carousel_display_exif: true
+				carousel_display_exif: true,
+				stats: true,
+				admin_bar: true,
+				hide_smile: true,
+				count_roles: true,
+				roles: true,
 			};
 
 			expect( filterSettingsByActiveModules( settings ) ).to.eql( {
@@ -267,7 +272,11 @@ describe( 'utils', () => {
 				highlander_comment_form_prompt: 'Leave a Reply',
 				jetpack_comment_form_color_scheme: 'light',
 				carousel_background_color: 'black',
-				carousel_display_exif: true
+				carousel_display_exif: true,
+				admin_bar: true,
+				hide_smile: true,
+				count_roles: true,
+				roles: true,
 			} );
 		} );
 
@@ -318,7 +327,12 @@ describe( 'utils', () => {
 				jetpack_comment_form_color_scheme: 'light',
 				carousel: false,
 				carousel_background_color: 'black',
-				carousel_display_exif: true
+				carousel_display_exif: true,
+				stats: false,
+				admin_bar: true,
+				hide_smile: true,
+				count_roles: true,
+				roles: true,
 			};
 
 			expect( filterSettingsByActiveModules( settings ) ).to.eql( {
@@ -362,7 +376,11 @@ describe( 'utils', () => {
 				highlander_comment_form_prompt: 'Leave a Reply',
 				jetpack_comment_form_color_scheme: 'light',
 				carousel_background_color: 'black',
-				carousel_display_exif: true
+				carousel_display_exif: true,
+				admin_bar: true,
+				hide_smile: true,
+				count_roles: true,
+				roles: true,
 			};
 
 			expect( filterSettingsByActiveModules( settings ) ).to.eql( {

--- a/client/state/jetpack/settings/utils.js
+++ b/client/state/jetpack/settings/utils.js
@@ -117,6 +117,12 @@ export const filterSettingsByActiveModules = ( settings ) => {
 		carousel: [
 			'carousel_background_color',
 			'carousel_display_exif'
+		],
+		stats: [
+			'admin_bar',
+			'hide_smile',
+			'count_roles',
+			'roles',
 		]
 	};
 	let filteredSettings = { ...settings };


### PR DESCRIPTION
This PR introduces a Site Stats card as specified in p6TEKc-HQ-p2. It works and looks the same way that the corresponding Stats card does in Jetpack. 

Fixes #12272. Fixes #11615 too, as it's the last card in the list.

Preview (collapsed)
![](https://cldup.com/8i9tCYS8y5.png)

Preview (expanded)
![](https://cldup.com/2PZduUBSBU.png)

To test:
* Checkout this branch or get it going on calypso.live.
* Go to `/settings/traffic/$site`, where `$site` is one of your Jetpack sites.
* Play with all of the settings in the new Site Stats card and verify that they save correctly to your Jetpack site.
* Verify the card does not appear for WordPress.com sites. 