### PR TITLE
My Sites: Improve speed of switch from Reader to My Sites

### DIFF
--- a/client/lib/sites-list/README.md
+++ b/client/lib/sites-list/README.md
@@ -43,3 +43,19 @@ Flux store providing the site-related messages for `notices.js`. Works with the 
 #### notices.js
 
 A mixin that displays site information and error notices via the [notices](/client/notices) module.
+
+#### sites-observer.jsx
+
+A High-Order-Component that mimic the functionality of `data-observer` only specific to SitesList. It listens to `change` event of SitesList and creates a new object that uses the original `SitesList` as prototype thus both `PureComponent` and `react-redux` `connect` are able to detect the data was changed even though `SitesList` mutate in-place.
+
+This component is designed to wrap any React Component or `react-redux` `connect` High-Order-Components that expect to get `sites` prop.
+
+This component expects to get `sites` prop and it passes to the component it wraps `sites` prop that will behave correctly for PureComponent.
+
+```
+import sitesObserver from 'lib/sites-list/sites-observer';
+
+export default sitesObserver(
+    connect( mapStateToProps, { setNextLayoutFocus, setLayoutFocus } )( localize( MySitesSidebar ) )
+);
+```

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -375,7 +375,7 @@ SitesList.prototype.getSelectedSite = function() {
  * @api private
  */
 SitesList.prototype.setSelectedSite = function( siteID ) {
-	if ( ! siteID ) {
+	if ( ! siteID || this.selected === siteID ) {
 		return;
 	}
 

--- a/client/lib/sites-list/sites-observer.jsx
+++ b/client/lib/sites-list/sites-observer.jsx
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import omit from 'lodash/omit';
+
+/**
+ * Internal dependencies
+ */
+import Debug from 'debug';
+const debug = Debug( 'calypso:site-observe-hoc' );
+
+const sitesObserver = ( WrappedComponent ) => {
+	class SitesObserverComponent extends Component {
+
+		componentWillMount() {
+			this.cacheSites();
+		}
+
+		componentDidMount() {
+			// Using componentDidMount to register to events because
+			// this lifecycle method will not be called on SSR.
+			this.props.sites.on( 'change', () => this.cacheSites() );
+		}
+
+		componentWillUnmount() {
+			this.props.sites.off( 'change', () => this.cacheSites() );
+		}
+
+		cacheSites() {
+			debug( 'Re-rendering ' + this.constructor.displayName + ' due to sites change event.' );
+			if ( this.props.sites ) {
+				this.setState( { sites: Object.create( this.props.sites ) } );
+			}
+		}
+
+		render() {
+			return (
+				<WrappedComponent
+					sites={ this.state.sites }
+					{ ...omit( this.props, 'sites' ) }
+				/>
+			);
+		}
+	}
+
+	const wrappedComponentName = WrappedComponent.displayName || WrappedComponent.name || 'Component';
+	SitesObserverComponent.displayName = `SitesObserver(${ wrappedComponentName })`;
+	SitesObserverComponent.propTypes = {
+		sites: PropTypes.object.isRequired
+	};
+
+	return SitesObserverComponent;
+};
+
+export default sitesObserver;

--- a/client/lib/sites-list/test/sites-observer.js
+++ b/client/lib/sites-list/test/sites-observer.js
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { assert, expect } from 'chai';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import sitesObserver from '../sites-observer';
+
+class MockInnerComponent extends React.Component {
+	render() {
+		return ( <div>Fake Component</div> );
+	}
+}
+
+describe( 'SitesObserver', () => {
+	let wrapper, SitesObserverHOC, mockSites;
+
+	function mockEventEmitter( name ) {
+		const onCalls = [];
+		const offCalls = [];
+
+		return {
+			onCalls,
+			offCalls,
+			mock: {
+				on: function( event/*, callback*/ ) {
+					onCalls.push( name );
+					assert.deepEqual( 'change', event );
+				},
+				off: function( event/*, callback*/ ) {
+					offCalls.push( name );
+					assert.deepEqual( 'change', event );
+				}
+			}
+		};
+	}
+
+	beforeEach( () => {
+		SitesObserverHOC = sitesObserver( MockInnerComponent );
+		mockSites = mockEventEmitter( 'testSites' );
+
+		wrapper = shallow( <SitesObserverHOC
+			sites={ mockSites.mock }
+			someProp={ 42 } />,
+		{ lifecycleExperimental: true } );
+	} );
+
+	it( 'wrapped component is rendered', () => {
+		expect( wrapper.first().type() ).to.equal( MockInnerComponent );
+	} );
+
+	it( 'change event should create new instance in sites prop', () => {
+		// Store the current (last) sites prop the wrapped component has.
+		const lastSites = wrapper.find( MockInnerComponent ).props().sites;
+
+		// First call SitesObserverHOC.cacheSites() method to simulate `change` event.
+		wrapper.instance().cacheSites();
+
+		// Then call Enzyme update to re-render the component.
+		wrapper.update();
+
+		// Ensure the sites prop of the wrapped component is different object than
+		// the last sites instance so shallow compare will detect change.
+		expect( wrapper.find( MockInnerComponent ).props().sites ).to.not.equal( lastSites );
+	} );
+
+	it( 'component register to sites.on(change)', () => {
+		assert.deepEqual( [ 'testSites' ], mockSites.onCalls );
+	} );
+
+	it( 'after unmount sites.off(change) should be called', () => {
+		wrapper.unmount();
+		assert.deepEqual( [ 'testSites' ], mockSites.offCalls );
+	} );
+
+	it( 'other properties pass-through', () => {
+		expect( wrapper.find( MockInnerComponent ).props().someProp ).to.equal( 42 );
+	} );
+} );

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -4,7 +4,7 @@
 import classNames from 'classnames';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import Gridicon from 'gridicons';
@@ -36,13 +36,14 @@ import { getCustomizerUrl, isJetpackSite } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { getStatsPathForTab } from 'lib/route/path';
 import { isATEnabledForCurrentSite } from 'lib/automated-transfer';
+import sitesObserver from 'lib/sites-list/sites-observer';
 
 /**
  * Module variables
  */
 const debug = debugFactory( 'calypso:my-sites:sidebar' );
 
-export class MySitesSidebar extends Component {
+export class MySitesSidebar extends PureComponent {
 
 	static propTypes = {
 		setNextLayoutFocus: PropTypes.func.isRequired,
@@ -671,5 +672,6 @@ function mapStateToProps( state ) {
 	};
 }
 
-// TODO: make this pure when sites can be retrieved from the Redux state
-export default connect( mapStateToProps, { setNextLayoutFocus, setLayoutFocus }, null, { pure: false } )( localize( MySitesSidebar ) );
+export default sitesObserver(
+	connect( mapStateToProps, { setNextLayoutFocus, setLayoutFocus } )( localize( MySitesSidebar ) )
+);


### PR DESCRIPTION
When user switches between the Reader and My Sites there is a fairly long pause, this commit tries to get that pause bellow 250ms so it will perceive instant.

It achieves it by extending a component of My Sites to be pure and thus eliminates wasted render calls when the data those components rely on do no change.