### PR TITLE
Update: republicize form parameters

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -963,15 +963,15 @@ Undocumented.prototype.createConnection = function( keyringConnectionId, siteId,
  *
  * @returns {Promise}
  */
-Undocumented.prototype.publicizePost = function( siteId, postId, message, skippedConnections, fn ) {
+Undocumented.prototype.publicizePost = function( siteId, postId, message, connections, fn ) {
 	const body = { skipped_connections: [] };
 
 	if ( message ) {
 		body.message = message;
 	}
 
-	if ( skippedConnections && skippedConnections.length > 0 ) {
-		body.skipped_connections = skippedConnections;
+	if ( connections ) {
+		body.connections = connections;
 	}
 
 	return this.wpcom.req.post( { path: `/sites/${ siteId }/post/${ postId }/publicize`, body, apiVersion: '1.1' }, fn );

--- a/client/my-sites/posts/post-share.jsx
+++ b/client/my-sites/posts/post-share.jsx
@@ -15,7 +15,7 @@ import Button from 'components/button';
 import { isPublicizeEnabled } from 'state/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
-import { getSiteUserConnections, hasFetchedConnections, getSiteUserActiveConnectionIds } from 'state/sharing/publicize/selectors';
+import { getSiteUserConnections, hasFetchedConnections, getSiteUserActiveConnections } from 'state/sharing/publicize/selectors';
 import { fetchConnections as requestConnections, sharePost, dismissShareConfirmation } from 'state/sharing/publicize/actions';
 import { isRequestingSharePost, sharePostFailure, sharePostSuccessMessage } from 'state/sharing/publicize/selectors';
 import PostMetadata from 'lib/post-metadata';
@@ -43,7 +43,7 @@ const PostSharing = React.createClass( {
 
 	getInitialState() {
 		return {
-			messageConnectionIds: this.props.messageConnectionIds,
+			messageConnectionIds: map( this.props.activeConnectionIds, 'keyring_connectino_ID' ),
 			skipped: PostMetadata.publicizeSkipped( this.props.post ) || [],
 			message: PostMetadata.publicizeMessage( this.props.post ) || this.props.post.title
 		}
@@ -60,10 +60,7 @@ const PostSharing = React.createClass( {
 	},
 
 	isConnectionActive: function( connection ) {
-		return (
-			connection.status !== 'broken' &&
-			includes( this.state.messageConnectionIds, connection.keyring_connection_ID )
-		);
+		return includes( this.state.messageConnections, connection.keyring_connection_ID );
 	},
 
 	renderServices: function() {
@@ -112,7 +109,7 @@ const PostSharing = React.createClass( {
 		this.props.dismissShareConfirmation( this.props.siteId, this.props.post.ID );
 	},
 	sharePost: function() {
-		this.props.sharePost( this.props.siteId, this.props.post.ID, this.state.message, this.state.messageConnectionIds );
+		this.props.sharePost( this.props.siteId, this.props.post.ID, this.state.messageConnectionIds, this.state.message );
 	},
 	isButtonDisabled() {
 		if ( this.props.requesting ) {
@@ -232,8 +229,8 @@ export default connect(
 			requesting: isRequestingSharePost( state, siteId, props.post.ID ),
 			failed: sharePostFailure( state, siteId, props.post.ID ),
 			success: sharePostSuccessMessage( state, siteId, props.post.ID ),
-			messageConnectionIds: getSiteUserActiveConnectionIds( state, siteId, userId ),
-		}
+			activeConnections: getSiteUserActiveConnections( state, siteId, userId ),
+		};
 	},
 	{ requestConnections, sharePost, dismissShareConfirmation }
 )( PostSharing );

--- a/client/my-sites/posts/post-share.jsx
+++ b/client/my-sites/posts/post-share.jsx
@@ -15,7 +15,7 @@ import Button from 'components/button';
 import { isPublicizeEnabled } from 'state/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
-import { getSiteUserConnections, hasFetchedConnections } from 'state/sharing/publicize/selectors';
+import { getSiteUserConnections, hasFetchedConnections, getSiteUserActiveConnectionIds } from 'state/sharing/publicize/selectors';
 import { fetchConnections as requestConnections, sharePost, dismissShareConfirmation } from 'state/sharing/publicize/actions';
 import { isRequestingSharePost, sharePostFailure, sharePostSuccessMessage } from 'state/sharing/publicize/selectors';
 import PostMetadata from 'lib/post-metadata';
@@ -37,11 +37,13 @@ const PostSharing = React.createClass( {
 		isPublicizeEnabled: PropTypes.bool,
 		connections: PropTypes.array,
 		hasFetchedConnections: PropTypes.bool,
-		requestConnections: PropTypes.func
+		requestConnections: PropTypes.func,
+		messageConnectionIds: PropTypes.array,
 	},
 
 	getInitialState() {
 		return {
+			messageConnectionIds: this.props.messageConnectionIds,
 			skipped: PostMetadata.publicizeSkipped( this.props.post ) || [],
 			message: PostMetadata.publicizeMessage( this.props.post ) || this.props.post.title
 		}
@@ -52,20 +54,15 @@ const PostSharing = React.createClass( {
 	},
 
 	toggleConnection: function ( id ) {
-		const skipped = this.state.skipped.slice();
-		const index = skipped.indexOf( id );
-		if ( index !== -1 ) {
-			skipped.splice( index, 1 );
-		} else {
-			skipped.push( id );
-		}
-		this.setState( { skipped } );
+		const messageConnectionIds = new Set( this.state.messageConnectionIds );
+		messageConnectionIds.delete( id ) || messageConnectionIds.add( id );
+		this.setState( { messageConnectionIds: Array.from( messageConnectionIds ) } );
 	},
 
 	isConnectionActive: function( connection ) {
 		return (
 			connection.status !== 'broken' &&
-			this.state.skipped.indexOf( connection.keyring_connection_ID ) === -1
+			includes( this.state.messageConnectionIds, connection.keyring_connection_ID )
 		);
 	},
 
@@ -115,7 +112,7 @@ const PostSharing = React.createClass( {
 		this.props.dismissShareConfirmation( this.props.siteId, this.props.post.ID );
 	},
 	sharePost: function() {
-		this.props.sharePost( this.props.siteId, this.props.post.ID, this.state.skipped, this.state.message );
+		this.props.sharePost( this.props.siteId, this.props.post.ID, this.state.message, this.state.messageConnectionIds );
 	},
 	isButtonDisabled() {
 		if ( this.props.requesting ) {
@@ -234,8 +231,9 @@ export default connect(
 			hasFetchedConnections: hasFetchedConnections( state, siteId ),
 			requesting: isRequestingSharePost( state, siteId, props.post.ID ),
 			failed: sharePostFailure( state, siteId, props.post.ID ),
-			success: sharePostSuccessMessage( state, siteId, props.post.ID )
-		};
+			success: sharePostSuccessMessage( state, siteId, props.post.ID ),
+			messageConnectionIds: getSiteUserActiveConnectionIds( state, siteId, userId ),
+		}
 	},
 	{ requestConnections, sharePost, dismissShareConfirmation }
 )( PostSharing );

--- a/client/state/sharing/publicize/actions.js
+++ b/client/state/sharing/publicize/actions.js
@@ -31,18 +31,18 @@ export function dismissShareConfirmation( siteId, postId ) {
 	};
 }
 
-export function sharePost( siteId, postId, skippedConnections, message ) {
+export function sharePost( siteId, postId, message, connections ) {
 	return ( dispatch ) => {
 		dispatch( {
 			type: PUBLICIZE_SHARE,
 			siteId,
 			postId,
-			skippedConnections,
-			message
+			message,
+			connections,
 		} );
 
 		return new Promise( ( resolve ) => {
-			wpcom.undocumented().publicizePost( siteId, postId, message, skippedConnections, ( error, data ) => {
+			wpcom.undocumented().publicizePost( siteId, postId, message, connections, ( error, data ) => {
 				if ( error || ! data.success ) {
 					dispatch( { type: PUBLICIZE_SHARE_FAILURE, siteId, postId, error } );
 				} else {

--- a/client/state/sharing/publicize/actions.js
+++ b/client/state/sharing/publicize/actions.js
@@ -31,18 +31,18 @@ export function dismissShareConfirmation( siteId, postId ) {
 	};
 }
 
-export function sharePost( siteId, postId, message, connections ) {
+export function sharePost( siteId, postId, message, connectionIds ) {
 	return ( dispatch ) => {
 		dispatch( {
 			type: PUBLICIZE_SHARE,
 			siteId,
 			postId,
 			message,
-			connections,
+			connectionIds,
 		} );
 
 		return new Promise( ( resolve ) => {
-			wpcom.undocumented().publicizePost( siteId, postId, message, connections, ( error, data ) => {
+			wpcom.undocumented().publicizePost( siteId, postId, message, connectionIds, ( error, data ) => {
 				if ( error || ! data.success ) {
 					dispatch( { type: PUBLICIZE_SHARE_FAILURE, siteId, postId, error } );
 				} else {

--- a/client/state/sharing/publicize/selectors.js
+++ b/client/state/sharing/publicize/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, get, map } from 'lodash';
+import { filter, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -38,7 +38,7 @@ export function getSiteUserConnections( state, siteId, userId ) {
 }
 
 /**
- * Returns an array of known active connection ids for the given site ID
+ * Returns an array of known active connection for the given site ID
  * that are available to the specified user ID.
  *
  * @param  {Object} state Global state tree
@@ -46,10 +46,9 @@ export function getSiteUserConnections( state, siteId, userId ) {
  * @param  {Number} userId User ID to filter
  * @return {Array}  User connections
  */
-export function getSiteUserActiveConnectionIds( state, siteId, userId ) {
+export function getSiteUserActiveConnections( state, siteId, userId ) {
 	const connections = getSiteUserConnections( state, siteId, userId );
-	const activeConnections = filter( connections, connection => connection.status !== 'broken' );
-	return map( activeConnections, 'keyring_connection_ID' );
+	return filter( connections, connection => connection.status !== 'broken' );
 }
 
 /**

--- a/client/state/sharing/publicize/selectors.js
+++ b/client/state/sharing/publicize/selectors.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import filter from 'lodash/filter';
-import get from 'lodash/get';
+import { filter, get, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,6 +35,12 @@ export function getSiteUserConnections( state, siteId, userId ) {
 		const { site_ID, shared, keyring_connection_user_ID } = connection;
 		return site_ID === siteId && ( shared || keyring_connection_user_ID === userId );
 	} );
+}
+
+export function getSiteUserActiveConnectionIds( state, siteId, userId ) {
+	const connections = getSiteUserConnections( state, siteId, userId );
+	const activeConnections = filter( connections, connection => connection.status !== 'broken' );
+	return map( activeConnections, 'keyring_connection_ID' );
 }
 
 /**

--- a/client/state/sharing/publicize/selectors.js
+++ b/client/state/sharing/publicize/selectors.js
@@ -37,6 +37,15 @@ export function getSiteUserConnections( state, siteId, userId ) {
 	} );
 }
 
+/**
+ * Returns an array of known active connection ids for the given site ID
+ * that are available to the specified user ID.
+ *
+ * @param  {Object} state Global state tree
+ * @param  {Number} siteId Site ID
+ * @param  {Number} userId User ID to filter
+ * @return {Array}  User connections
+ */
 export function getSiteUserActiveConnectionIds( state, siteId, userId ) {
 	const connections = getSiteUserConnections( state, siteId, userId );
 	const activeConnections = filter( connections, connection => connection.status !== 'broken' );

--- a/client/state/sharing/publicize/test/selectors.js
+++ b/client/state/sharing/publicize/test/selectors.js
@@ -14,7 +14,8 @@ import {
 	getRemovableConnections,
 	hasFetchedConnections,
 	isFetchingConnection,
-	isFetchingConnections
+	isFetchingConnections,
+	getSiteUserActiveConnections,
 } from '../selectors';
 
 describe( 'getBrokenSiteUserConnectionsForService()', () => {
@@ -123,6 +124,28 @@ describe( '#getSiteUserConnections()', () => {
 		expect( connections ).to.eql( [
 			{ ID: 1, site_ID: 2916284, shared: true },
 			{ ID: 2, site_ID: 2916284, keyring_connection_user_ID: 26957695 }
+		] );
+	} );
+} );
+
+describe( '#getSiteUserActiveConnections()', () => {
+	it( 'should return an array with only active connetions', () => {
+		const activeConnections = getSiteUserActiveConnections( {
+			sharing: {
+				publicize: {
+					connections: {
+						1: { ID: 1, site_ID: 2916284, keyring_connection_user_ID: 26957695, status: 'broken' },
+						2: { ID: 2, site_ID: 2916284, shared: true , status: 'ok' },
+						3: { ID: 3, site_ID: 2916284, keyring_connection_user_ID: 26957695,  status: 'ok' },
+						4: { ID: 4, site_ID: 2916284, shared: true, status: 'broken' },
+					}
+				}
+			}
+		}, 2916284, 26957695 );
+
+		expect( activeConnections ).to.eql( [
+			{ ID: 2, site_ID: 2916284, shared: true, status: 'ok' },
+			{ ID: 3, site_ID: 2916284, keyring_connection_user_ID: 26957695, status: 'ok' }
 		] );
 	} );
 } );


### PR DESCRIPTION
This replaces the blacklist `skip_connections` with a whitelist `connections` to work with the recent updates to the `/sites/:site/post/:post/publicize` endpoint.

**Testing** 

1. Open sharing form on a post
2. Deselect all but one sharing network connection
3. Verify that a `connections` parameter is sent with the request
4. Verify that `skip_connections` is not sent with the request
5. Verify that the message is posted to only the selection sharing network