### PR TITLE
Site Settings: Move SEO help card above the other SEO cards

### DIFF
--- a/client/my-sites/site-settings/traffic/main.jsx
+++ b/client/my-sites/site-settings/traffic/main.jsx
@@ -32,7 +32,6 @@ const SiteSettingsTraffic = ( {
 		<SidebarNavigation />
 		<SiteSettingsNavigation site={ site } section="traffic" />
 
-		<SeoSettingsHelpCard />
 		<RelatedPosts
 			onSubmitForm={ handleSubmitForm }
 			handleAutosavingToggle={ handleAutosavingToggle }
@@ -41,6 +40,7 @@ const SiteSettingsTraffic = ( {
 			fields={ fields }
 		/>
 		<AnalyticsSettings />
+		<SeoSettingsHelpCard />
 		<SeoSettingsMain sites={ sites } upgradeToBusiness={ upgradeToBusiness } />
 	</Main>
 );


### PR DESCRIPTION
This PR moves the SEO help card above the other SEO cards. When we introduced the Traffic tab, it was at the top of it, which was a little confusing. 

Fixes #12308.

Preview for a Jetpack site with a Pro plan:
![](https://cldup.com/o1oE8UuK4w.png)

Preview for a Jetpack site with a cheaper plan: 
![](https://cldup.com/-Msx81dViE.png)

Preview for a WordPress.com site with non-business plan:
![](https://cldup.com/o_OHXEKh7l.png)

Not sure if we should move the help card below the nudge though, so some design feedback is appreciated here.