### PR TITLE
AT: use automated_transfer for the tracking namespace

### DIFF
--- a/client/my-sites/plugins-wpcom/plugin-install-button.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-install-button.jsx
@@ -48,7 +48,7 @@ export const WpcomPluginInstallButton = props => {
 			// No need to show eligibility warnings page, initiate transfer immediately
 			initiateTransfer( siteId, null, plugin.slug );
 		} else {
-			props.recordTracksEvent( 'calypso_automatic_transfer_plugin_install_ineligible',
+			props.recordTracksEvent( 'calypso_automated_transfer_plugin_install_ineligible',
 				{
 					eligibilityHolds: eligibilityHolds.join( ', ' ),
 					eligibilityWarnings: eligibilityWarnings.join( ', ' ),

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -655,7 +655,7 @@ export function initiateThemeTransfer( siteId, file, plugin ) {
 					transferId: transfer_id,
 				};
 				dispatch( withAnalytics(
-					recordTracksEvent( 'calypso_automatic_transfer_inititate_success', { plugin } ),
+					recordTracksEvent( 'calypso_automated_transfer_inititate_success', { plugin } ),
 					themeInitiateSuccessAction
 				) );
 				dispatch( pollThemeTransferStatus( siteId, transfer_id ) );
@@ -697,7 +697,7 @@ function transferInitiateFailure( siteId, error, plugin ) {
 			error,
 		};
 		dispatch( withAnalytics(
-			recordTracksEvent( 'calypso_automatic_transfer_inititate_failure', { plugin } ),
+			recordTracksEvent( 'calypso_automated_transfer_inititate_failure', { plugin } ),
 			themeInitiateFailureAction
 		) );
 	};
@@ -730,7 +730,7 @@ export function pollThemeTransferStatus( siteId, transferId, interval = 3000, ti
 					dispatch( transferStatus( siteId, transferId, status, message, uploaded_theme_slug ) );
 					if ( status === 'complete' ) {
 						// finished, stop polling
-						dispatch( recordTracksEvent( 'calypso_automatic_transfer_complete', { transfer_id: transferId } ) );
+						dispatch( recordTracksEvent( 'calypso_automated_transfer_complete', { transfer_id: transferId } ) );
 						return resolve();
 					}
 					// poll again


### PR DESCRIPTION
Replace `automatic_transfer` with `automated_transfer` for event tracking namespace