### PR TITLE
Optionally install fsevents module to prevent 100% CPU load on macOS (#12368)

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,5 +192,8 @@
     "webpack-bundle-analyzer": "2.2.1",
     "webpack-dashboard": "0.2.0",
     "webpack-dev-server": "1.11.0"
+  },
+  "optionalDependencies": {
+    "fsevents": "1.1.1"
   }
 }


### PR DESCRIPTION
Add fsevents module as an optional (macOS) dependency. When this module is installed,
webpack-dev-server watches the project files without polling and doesn't consume CPU.