### PR TITLE
Reader: add video cards expanded state to redux

### DIFF
--- a/client/blocks/reader-featured-video/index.jsx
+++ b/client/blocks/reader-featured-video/index.jsx
@@ -27,19 +27,14 @@ class ReaderFeaturedVideo extends React.Component {
 		onThumbnailClick: React.PropTypes.func,
 		className: React.PropTypes.string,
 		href: React.PropTypes.string,
+		isExpanded: React.PropTypes.bool,
+		expandCard: React.PropTypes.func,
 	}
 
 	static defaultProps = {
 		allowPlaying: true,
 		onThumbnailClick: noop,
 		className: '',
-	}
-
-	constructor( props ) {
-		super( props );
-		this.state = {
-			preferThumbnail: true,
-		};
 	}
 
 	setVideoSizingStrategy = ( videoEmbed ) => {
@@ -68,7 +63,6 @@ class ReaderFeaturedVideo extends React.Component {
 		if ( this.props.allowPlaying ) {
 			e.preventDefault();
 			this.props.onThumbnailClick();
-			this.setState( { preferThumbnail: false }, () => this.updateVideoSize() );
 		}
 	}
 
@@ -90,10 +84,9 @@ class ReaderFeaturedVideo extends React.Component {
 	}
 
 	render() {
-		const { thumbnailUrl, autoplayIframe, iframe, translate, allowPlaying, className, href } = this.props;
-		const preferThumbnail = this.state.preferThumbnail;
+		const { thumbnailUrl, autoplayIframe, iframe, translate, allowPlaying, className, href, isExpanded } = this.props;
 
-		if ( preferThumbnail && thumbnailUrl ) {
+		if ( ! isExpanded && thumbnailUrl ) {
 			return (
 				<ReaderFeaturedImage
 					imageUrl={ thumbnailUrl }

--- a/client/blocks/reader-featured-video/index.jsx
+++ b/client/blocks/reader-featured-video/index.jsx
@@ -83,6 +83,10 @@ class ReaderFeaturedVideo extends React.Component {
 		}
 	}
 
+	componentWillReceiveProps() {
+		this.throttledUpdateVideoSize();
+	}
+
 	render() {
 		const { thumbnailUrl, autoplayIframe, iframe, translate, allowPlaying, className, href, isExpanded } = this.props;
 

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -120,7 +120,7 @@ class ReaderPostCard extends React.Component {
 
 		const isPhotoPost = !! ( post.display_type & DisplayTypes.PHOTO_ONLY );
 		const isGalleryPost = !! ( post.display_type & DisplayTypes.GALLERY );
-		const isExpandedVideo = !! ( post.display_type & DisplayTypes.FEATURED_VIDEO );
+		const isVideo = !! ( post.display_type & DisplayTypes.FEATURED_VIDEO );
 		const isDiscover = post.is_discover;
 		const title = truncate( post.title, { length: 140, separator: /,? +/ } );
 		const classes = classnames( 'reader-post-card', {
@@ -129,7 +129,7 @@ class ReaderPostCard extends React.Component {
 			'is-gallery': isGalleryPost,
 			'is-selected': isSelected,
 			'is-discover': isDiscover,
-			'is-expanded-video': isExpandedVideo,
+			'is-expanded-video': isVideo && isExpanded,
 		} );
 
 		let discoverFollowButton;

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -120,6 +120,7 @@ class ReaderPostCard extends React.Component {
 
 		const isPhotoPost = !! ( post.display_type & DisplayTypes.PHOTO_ONLY );
 		const isGalleryPost = !! ( post.display_type & DisplayTypes.GALLERY );
+		const isExpandedVideo = !! ( post.display_type & DisplayTypes.FEATURED_VIDEO );
 		const isDiscover = post.is_discover;
 		const title = truncate( post.title, { length: 140, separator: /,? +/ } );
 		const classes = classnames( 'reader-post-card', {
@@ -127,7 +128,8 @@ class ReaderPostCard extends React.Component {
 			'is-photo': isPhotoPost,
 			'is-gallery': isGalleryPost,
 			'is-selected': isSelected,
-			'is-discover': isDiscover
+			'is-discover': isDiscover,
+			'is-expanded-video': isExpandedVideo,
 		} );
 
 		let discoverFollowButton;
@@ -172,11 +174,21 @@ class ReaderPostCard extends React.Component {
 					{ readerPostActions }
 				</GalleryPost>;
 		} else {
-			readerPostCard = <StandardPost post={ post } title={ title } isDiscover={ isDiscover }>
+			readerPostCard = (
+				<StandardPost
+					post={ post }
+					title={ title }
+					isDiscover={ isDiscover }
+					isExpanded={ isExpanded }
+					expandCard={ expandCard }
+					site={ site }
+					postKey={ postKey }
+				>
 					{ isDailyPostChallengeOrPrompt( post ) && site && <DailyPostButton post={ post } site={ site } tagName="span" /> }
 					{ discoverFollowButton }
 					{ readerPostActions }
-				</StandardPost>;
+				</StandardPost>
+			);
 		}
 
 		// set up post byline

--- a/client/blocks/reader-post-card/standard.jsx
+++ b/client/blocks/reader-post-card/standard.jsx
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import React from 'react';
+import { partial } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -11,13 +12,20 @@ import ReaderFeaturedVideo from 'blocks/reader-featured-video';
 import ReaderFeaturedImage from 'blocks/reader-featured-image';
 import ReaderExcerpt from 'blocks/reader-excerpt';
 
-const StandardPost = ( { post, children, isDiscover } )=> {
+const StandardPost = ( { post, children, isDiscover, expandCard, postKey, isExpanded, site } )=> {
 	const canonicalMedia = post.canonical_media;
 	let featuredAsset;
 	if ( ! canonicalMedia ) {
 		featuredAsset = null;
 	} else if ( canonicalMedia.mediaType === 'video' ) {
-		featuredAsset = <ReaderFeaturedVideo { ...canonicalMedia } videoEmbed={ canonicalMedia } />;
+		featuredAsset = (
+			<ReaderFeaturedVideo
+				{ ...canonicalMedia }
+				videoEmbed={ canonicalMedia }
+				onThumbnailClick={ partial( expandCard, { postKey, post, site } ) }
+				isExpanded={ isExpanded }
+			/>
+		);
 	} else {
 		featuredAsset = <ReaderFeaturedImage imageUrl={ canonicalMedia.src } href={ post.URL } />;
 	}

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -78,10 +78,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			}
 		}
 
-		&.is-expanded-video .reader-post-card__post {
-			flex-direction: column;
-		}
-
 		&.is-photo {
 
 			.reader-post-card__post {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -78,7 +78,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			}
 		}
 
-		&.is-video-expanded {
+		&.is-expanded-video .reader-post-card__post {
 			flex-direction: column;
 		}
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -78,6 +78,10 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			}
 		}
 
+		&.is-video-expanded {
+			flex-direction: column;
+		}
+
 		&.is-photo {
 
 			.reader-post-card__post {

--- a/client/state/ui/reader/card-expansions/actions.js
+++ b/client/state/ui/reader/card-expansions/actions.js
@@ -6,17 +6,22 @@ import {
 	READER_RESET_CARD_EXPANSIONS,
 } from 'state/action-types';
 import PostStoreActions from 'lib/feed-post-store/actions';
+import DISPLAY_TYPES from 'state/reader/posts/display-types';
 import * as stats from 'reader/stats';
 
 export const expandCard = ( { postKey, post, site } ) => {
-	stats.recordTrackForPost( 'calypso_reader_photo_expanded', post );
+	if ( post.display_type & DISPLAY_TYPES.PHOTO_ONLY ) {
+		stats.recordTrackForPost( 'calypso_reader_photo_expanded', post );
+	} else if ( post.display_type & DISPLAY_TYPES.FEATURED_VIDEO ) {
+		stats.recordTrackForPost( 'calypso_reader_video_expanded', post );
+	}
 	stats.recordTrackForPost( 'calypso_reader_article_opened', post );
 
 	// Record page view
 	PostStoreActions.markSeen( post, site );
 	return {
 		type: READER_EXPAND_CARD,
-		payload: { postKey, post, site },
+		payload: { postKey },
 	};
 };
 


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/12339.

This PR aims to add video card's expanded state to redux at `ui.reader.cardExpansions`.
 - [x] Make work with videos cards (`showEmbed` --> `isExpanded`)
 - [x] verify all the stats are working as expected. Add `calypso_reader_video_expanded


To test:
1. make sure that photo cards still emit a metric when expanded
2. make sure video cards will still expand/unexpand as expected
3. make sure that video cards emit a new metric `calypso_reader_video_expanded`