### PR TITLE
Themes: Fix install of themes not hosted on wpcom

### DIFF
--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -840,8 +840,8 @@ export function hideThemePreview() {
  * installed via downloaded zip.
  *
  * @param {Object} state Global state tree
- * @param {number} siteId the Site ID
- * @param {string} themeId Child theme ID
+ * @param {number} siteId Site ID
+ * @param {string} themeId Theme ID
  * @return {string} the theme id to use when installing the theme
  */
 function suffixThemeIdForInstall( state, siteId, themeId ) {

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -57,6 +57,7 @@ import {
 	getThemeCustomizeUrl,
 	getWpcomParentThemeId,
 	shouldFilterWpcomThemes,
+	isDownloadableFromWpcom,
 } from './selectors';
 import {
 	getThemeIdFromStylesheet,
@@ -833,9 +834,22 @@ export function hideThemePreview() {
 	};
 }
 
+/**
+ * Install of any theme hosted as a zip on wpcom must
+ * be suffixed with -wpcom. Themes on AT sites are not
+ * installed via downloaded zip.
+ *
+ * @param {Object} state Global state tree
+ * @param {number} siteId the Site ID
+ * @param {string} themeId Child theme ID
+ * @return {string} the theme id to use when installing the theme
+ */
 function suffixThemeIdForInstall( state, siteId, themeId ) {
 	// AT sites do not use the -wpcom suffix
 	if ( isSiteAutomatedTransfer( state, siteId ) ) {
+		return themeId;
+	}
+	if ( ! isDownloadableFromWpcom( state, themeId ) ) {
 		return themeId;
 	}
 	return themeId + '-wpcom';

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -674,7 +674,7 @@ export function themePreviewVisibility( state ) {
  * @return {?string} Parent theme id if it exists
  */
 export function getWpcomParentThemeId( state, themeId ) {
-	return get( getTheme( state, 'wpcom', themeId ), [ 'template' ], null );
+	return get( getTheme( state, 'wpcom', themeId ), 'template', null );
 }
 
 /**
@@ -682,11 +682,11 @@ export function getWpcomParentThemeId( state, themeId ) {
  * wpcom for download.
  *
  * @param {Object} state Global state tree
- * @param {string} themeId Child theme ID
+ * @param {string} themeId Theme ID
  * @return {boolean} true if zip is available on wpcom
  */
 export function isDownloadableFromWpcom( state, themeId ) {
-	const downloadUri = get( getTheme( state, 'wpcom', themeId ), [ 'download' ], '' );
+	const downloadUri = get( getTheme( state, 'wpcom', themeId ), 'download', '' );
 	return !! includes( downloadUri, 'wordpress.com' );
 }
 

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -678,6 +678,19 @@ export function getWpcomParentThemeId( state, themeId ) {
 }
 
 /**
+ * Determine whether a zip of a given theme is hosted on
+ * wpcom for download.
+ *
+ * @param {Object} state Global state tree
+ * @param {string} themeId Child theme ID
+ * @return {boolean} true if zip is available on wpcom
+ */
+export function isDownloadableFromWpcom( state, themeId ) {
+	const downloadUri = get( getTheme( state, 'wpcom', themeId ), [ 'download' ], '' );
+	return !! includes( downloadUri, 'wordpress.com' );
+}
+
+/**
  * Determine whether wpcom themes should be removed from
  * a queried list of themes. For jetpack sites with the
  * required capabilities, we hide wpcom themes from the


### PR DESCRIPTION
Some default themes, for example Twenty Sixteen, are not hosted as downloadable zips on wpcom. Change the call to the Jetpack theme install endpoint to not use the -wpcom suffix for these themes, meaning they will be successfully installed from .org.

Requires D4735-code

**To Test**
* `arc patch D4735` on sandbox and sandbox public-api.wordpress.com
* Go to http://calypso.localhost:3000/design/ and choose a jetpack site
* Ensure theme _Twenty Sixteen_ is not already installed on that site
* Search for twenty sixteen and _Activate_ or _Try and Customize_

**Expected**
* Above operations should succeed
