### PR TITLE
Themes: Remove redundant download rendering code

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -266,7 +266,7 @@ const ThemeSheet = React.createClass( {
 					{ this.renderDescription() }
 				</Card>
 				{ this.renderFeaturesCard() }
-				{ download && <ThemeDownloadCard href={ this.props.download } /> }
+				{ download && <ThemeDownloadCard href={ download } /> }
 				{ isWpcomTheme && this.renderRelatedThemes() }
 			</div>
 		);

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -258,14 +258,16 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderOverviewTab() {
+		const { isWpcomTheme, download } = this.props;
+
 		return (
 			<div>
 				<Card className="theme__sheet-content">
 					{ this.renderDescription() }
 				</Card>
 				{ this.renderFeaturesCard() }
-				{ this.renderDownload() }
-				{ this.props.isWpcomTheme && this.renderRelatedThemes() }
+				{ download && <ThemeDownloadCard href={ this.props.download } /> }
+				{ isWpcomTheme && this.renderRelatedThemes() }
 			</div>
 		);
 	},
@@ -423,19 +425,6 @@ const ThemeSheet = React.createClass( {
 				</Card>
 			</div>
 		);
-	},
-
-	renderDownload() {
-		// Don't render download button:
-		// * If it's a premium theme
-		// * If it's a non-wpcom theme, and the theme object doesn't have a 'download' attr
-		//   Note that not having a 'download' attr would be permissible for a theme on WPCOM
-		//   since we don't provide any for some themes found on WordPress.org (notably the 'Twenties').
-		//   The <ThemeDownloadCard /> component can handle that case.
-		if ( this.props.isPremium || ( ! this.props.isWpcomTheme && ! this.props.download ) ) {
-			return null;
-		}
-		return <ThemeDownloadCard theme={ this.props.id } href={ this.props.download } />;
 	},
 
 	getDefaultOptionLabel() {

--- a/client/my-sites/theme/theme-download-card/index.jsx
+++ b/client/my-sites/theme/theme-download-card/index.jsx
@@ -11,16 +11,15 @@ import Gridicon from 'gridicons';
 import Button from 'components/button';
 import Card from 'components/card';
 
-const ThemeDownloadCard = React.createClass( {
+class ThemeDownloadCard extends React.Component {
 
-	propTypes: {
-		theme: React.PropTypes.string.isRequired,
+	static propTypes = {
 		href: React.PropTypes.string
-	},
+	}
 
 	render() {
-		// When we don't generate zips, it's because we have released the theme on .org.
-		const downloadURI = this.props.href || ( 'https://downloads.wordpress.org/theme/' + this.props.theme + '.zip' );
+		const { href } = this.props;
+
 		const downloadText =
 			i18n.translate( 'This theme is available for download to be used on your {{a}}WordPress self-hosted{{/a}} installation.', {
 				components: {
@@ -31,10 +30,10 @@ const ThemeDownloadCard = React.createClass( {
 			<Card className="theme-download-card">
 				<Gridicon icon="cloud-download" size={ 48 } />
 				<p>{ downloadText }</p>
-				<Button href={ downloadURI }>{ i18n.translate( 'Download' ) }</Button>
+				<Button href={ href }>{ i18n.translate( 'Download' ) }</Button>
 			</Card>
 		);
 	}
-} );
+}
 
 module.exports = ThemeDownloadCard;

--- a/client/my-sites/theme/theme-download-card/index.jsx
+++ b/client/my-sites/theme/theme-download-card/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import i18n from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
 /**
@@ -10,18 +9,19 @@ import Gridicon from 'gridicons';
  */
 import Button from 'components/button';
 import Card from 'components/card';
+import { localize } from 'i18n-calypso';
 
-class ThemeDownloadCard extends React.Component {
+class ThemeDownloadCard extends React.PureComponent {
 
 	static propTypes = {
 		href: React.PropTypes.string
 	}
 
 	render() {
-		const { href } = this.props;
+		const { href, translate } = this.props;
 
 		const downloadText =
-			i18n.translate( 'This theme is available for download to be used on your {{a}}WordPress self-hosted{{/a}} installation.', {
+			translate( 'This theme is available for download to be used on your {{a}}WordPress self-hosted{{/a}} installation.', {
 				components: {
 					a: <a href={ 'https://wordpress.org' } />
 				}
@@ -30,10 +30,10 @@ class ThemeDownloadCard extends React.Component {
 			<Card className="theme-download-card">
 				<Gridicon icon="cloud-download" size={ 48 } />
 				<p>{ downloadText }</p>
-				<Button href={ href }>{ i18n.translate( 'Download' ) }</Button>
+				<Button href={ href }>{ translate( 'Download' ) }</Button>
 			</Card>
 		);
 	}
 }
 
-module.exports = ThemeDownloadCard;
+export default localize( ThemeDownloadCard );


### PR DESCRIPTION
With D4735-code, we can now rely on the download uri from the APIs.

**To Test**
* `arc patch D4735` on sandbox and sandbox public-api.wordpress.com
* go to http://calypso.localhost:3000/design
* check the download links (at bottom of details sheet) for various themes on 'all sites' and jetpack sites

**Expected**
* Premium themes should have no download card
* Themes not hosted on wpcom (for example _Twenty Sixteen_) should have a .org link
* Free wpcom themes should have a wordpress.com link


