### PR TITLE
Themes: Enable showcase 'magic search' in desktop app

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -52,6 +52,7 @@
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,
+		"manage/themes/magic-search": true,
 		"manage/themes/upload": true,
 		"me/account": true,
 		"me/find-friends": false,


### PR DESCRIPTION
<img width="1162" alt="screen shot 2017-03-21 at 17 27 23" src="https://cloud.githubusercontent.com/assets/7767559/24161217/ba4115e2-0e5b-11e7-84e1-46a64d9bdcae.png">

Allows theme filtering from the search box with UI auto-suggest. Also allows saving/sharing filters via URL.

Tested using https://github.com/Automattic/wp-desktop/pull/275
