### PR TITLE
Jetpack Plans: Add a new selector to check if plugins have started installing

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -19,7 +19,10 @@ import {
 } from 'state/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import QuerySitePlans from 'components/data/query-site-plans';
-import { isFinished as isJetpackPluginsFinished } from 'state/plugins/premium/selectors';
+import {
+	isStarted as isJetpackPluginsStarted,
+	isFinished as isJetpackPluginsFinished
+} from 'state/plugins/premium/selectors';
 import TrackComponentView from 'lib/analytics/track-component-view';
 
 const SiteNotice = React.createClass( {
@@ -139,7 +142,7 @@ export default connect( ( state, ownProps ) => {
 		eligibleForFreeToPaidUpsell: eligibleForFreeToPaidUpsell( state, siteId, i18n.moment() ),
 		hasDomainCredit: hasDomainCredit( state, siteId ),
 		canManageOptions: canCurrentUser( state, siteId, 'manage_options' ),
-		pausedJetpackPluginsSetup: ! isJetpackPluginsFinished( state, siteId )
+		pausedJetpackPluginsSetup: isJetpackPluginsStarted( state, siteId ) && ! isJetpackPluginsFinished( state, siteId )
 	};
 }, ( dispatch ) => {
 	return {

--- a/client/state/plugins/premium/selectors.js
+++ b/client/state/plugins/premium/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, filter, some } from 'lodash';
+import { find, filter, some, every } from 'lodash';
 
 const isRequesting = function( state, siteId ) {
 	// if the `isRequesting` attribute doesn't exist yet,
@@ -35,6 +35,13 @@ const getPluginsForSite = function( state, siteId, whitelist = false ) {
 			return ( whitelist === plugin.slug );
 		}
 		return true;
+	} );
+};
+
+const isStarted = function( state, siteId, whitelist = false ) {
+	const pluginList = getPluginsForSite( state, siteId, whitelist );
+	return ! every( pluginList, ( item ) => {
+		return ( 'wait' === item.status );
 	} );
 };
 
@@ -83,4 +90,4 @@ const getNextPlugin = function( state, siteId, whitelist = false ) {
 	return plugin;
 };
 
-export default { isRequesting, hasRequested, isFinished, isInstalling, getPluginsForSite, getActivePlugin, getNextPlugin };
+export default { isRequesting, hasRequested, isStarted, isFinished, isInstalling, getPluginsForSite, getActivePlugin, getNextPlugin };

--- a/client/state/plugins/premium/test/selectors.js
+++ b/client/state/plugins/premium/test/selectors.js
@@ -33,6 +33,10 @@ describe( 'Premium Plugin Selectors', function() {
 		assert.equal( typeof selectors.isRequesting, 'function' );
 	} );
 
+	it( 'should contain isStarted method', function() {
+		assert.equal( typeof selectors.isStarted, 'function' );
+	} );
+
 	it( 'should contain isFinished method', function() {
 		assert.equal( typeof selectors.isFinished, 'function' );
 	} );
@@ -60,6 +64,24 @@ describe( 'Premium Plugin Selectors', function() {
 
 		it( 'Should get `true` if the requested site is being fetched', function() {
 			assert.equal( selectors.isRequesting( state, 'wait.site' ), true );
+		} );
+	} );
+
+	describe( 'isStarted', function() {
+		it( 'Should get `false` if the requested site is not in the current state', function() {
+			assert.equal( selectors.isStarted( state, 'no.site' ), false );
+		} );
+
+		it( 'Should get `false` if there are no plugins installing on the requested site', function() {
+			assert.equal( selectors.isStarted( state, 'start.site' ), false );
+		} );
+
+		it( 'Should get `true` if there is a plugin installing on the requested site', function() {
+			assert.equal( selectors.isStarted( state, 'installing.site' ), true );
+		} );
+
+		it( 'Should get `true` if all plugins on the requested site are either done or have errors', function() {
+			assert.equal( selectors.isStarted( state, 'finished.site' ), true );
 		} );
 	} );
 


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/pull/12247#issuecomment-287184213

Currently the "Your plan needs setting up" notice is triggered by any "not finished" premium plugin state, including when we've just requested the keys. To fix this, I've added a new selector for `isStarted`, which will check if any plugins are not in the `wait` status. This is now used with `isFinished` to display the notice.

We can't just check for wait in `isFinished`, because isFinished is used to show a success message on the plugins setup screen, and was showing it before the install started.

**To Test**

1. You can test the selector directly with `npm run test-client client/state/plugins/premium/test/selectors.js`
2. Visit the autoconfig flow `/plugins/setup/$site`, and leave the page during install
3. You should see a blue banner under your current site asking you to finish setup

You could also test by combining both this PR and #12247, and visiting the purchases page to fetch the keys - that _shouldn't_ trigger the blue banner in the sidebar.