### PR TITLE
Reader: add 'export button' block

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -43,6 +43,7 @@
 @import 'blocks/reader-avatar/style';
 @import 'blocks/reader-combined-card/style';
 @import 'blocks/reader-excerpt/style';
+@import 'blocks/reader-export-button/style';
 @import 'blocks/reader-feed-header/style';
 @import 'blocks/reader-featured-image/style';
 @import 'blocks/reader-featured-video/style';

--- a/client/blocks/reader-export-button/README.md
+++ b/client/blocks/reader-export-button/README.md
@@ -1,0 +1,3 @@
+# Reader Export Button
+
+Allows a Reader user to export their subscriptions in OPML format.

--- a/client/blocks/reader-export-button/docs/example.jsx
+++ b/client/blocks/reader-export-button/docs/example.jsx
@@ -1,0 +1,21 @@
+/**
+* External dependencies
+*/
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import ReaderExportButtonBlock from 'blocks/reader-export-button';
+
+const ReaderExportButton = () => (
+	<div className="design-assets__group">
+		<div>
+			<ReaderExportButtonBlock />
+		</div>
+	</div>
+);
+
+ReaderExportButton.displayName = 'ReaderExportButton';
+
+export default ReaderExportButton;

--- a/client/blocks/reader-export-button/index.jsx
+++ b/client/blocks/reader-export-button/index.jsx
@@ -1,0 +1,21 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal Dependencies
+ */
+
+class ReaderExportButton extends React.Component {
+	render() {
+		return (
+			<div className="reader-export-button">
+				{ this.props.translate( 'Export' ) }
+			</div>
+		);
+	}
+}
+
+export default localize( ReaderExportButton );

--- a/client/blocks/reader-export-button/index.jsx
+++ b/client/blocks/reader-export-button/index.jsx
@@ -1,19 +1,72 @@
 /**
- * External Dependencies
+ * External dependencies
  */
+import Blob from 'blob';
 import React from 'react';
+import { noop } from 'lodash';
+import { saveAs } from 'browser-filesaver';
 import { localize } from 'i18n-calypso';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
+import wpcom from 'lib/wp';
+import Button from 'components/button';
 
 class ReaderExportButton extends React.Component {
+	static propTypes = {
+		onError: React.PropTypes.func,
+		onExport: React.PropTypes.func,
+		saveAs: React.PropTypes.string
+	}
+
+	static defaultProps = {
+		onError: noop,
+		onExport: noop,
+		saveAs: 'wpcom-subscriptions.opml',
+	}
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			disabled: false
+		};
+	}
+
+	onClick = () => {
+		wpcom.undocumented().exportReaderFeed( this.onFeed );
+		this.setState( {
+			disabled: true
+		} );
+	}
+
+	onFeed = ( err, data ) => {
+		this.setState( {
+			disabled: false
+		} );
+
+		if ( ! err && ! data.success ) {
+			err = new Error( this.props.translate( 'Error exporting Reader feed' ) );
+		}
+
+		if ( err ) {
+			this.props.onError( err );
+		} else {
+			const blob = new Blob( [ data.opml ], { type: 'text/xml;charset=utf-8' } );
+			saveAs( blob, this.props.saveAs );
+			this.props.onExport( this.props.saveAs );
+		}
+	}
+
 	render() {
 		return (
-			<div className="reader-export-button">
+			<Button
+				className="reader-export-button"
+				compact
+				disabled={ this.state.disabled }
+				onClick={ this.onClick }>
 				{ this.props.translate( 'Export' ) }
-			</div>
+			</Button>
 		);
 	}
 }

--- a/client/blocks/reader-export-button/index.jsx
+++ b/client/blocks/reader-export-button/index.jsx
@@ -26,12 +26,7 @@ class ReaderExportButton extends React.Component {
 		saveAs: 'wpcom-subscriptions.opml',
 	}
 
-	constructor( props ) {
-		super( props );
-		this.state = {
-			disabled: false
-		};
-	}
+	state = { disabled: false }
 
 	onClick = () => {
 		// Don't kick off a new export request if there's one in progress

--- a/client/blocks/reader-export-button/index.jsx
+++ b/client/blocks/reader-export-button/index.jsx
@@ -1,17 +1,17 @@
 /**
  * External dependencies
  */
-import Blob from 'blob';
 import React from 'react';
+import Blob from 'blob';
 import { noop } from 'lodash';
 import { saveAs } from 'browser-filesaver';
 import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
 import wpcom from 'lib/wp';
-import Button from 'components/button';
 
 class ReaderExportButton extends React.Component {
 	static propTypes = {
@@ -34,13 +34,18 @@ class ReaderExportButton extends React.Component {
 	}
 
 	onClick = () => {
-		wpcom.undocumented().exportReaderFeed( this.onFeed );
+		// Don't kick off a new export request if there's one in progress
+		if ( this.state.disabled ) {
+			return;
+		}
+
+		wpcom.undocumented().exportReaderFeed( this.onApiResponse );
 		this.setState( {
 			disabled: true
 		} );
 	}
 
-	onFeed = ( err, data ) => {
+	onApiResponse = ( err, data ) => {
 		this.setState( {
 			disabled: false
 		} );
@@ -60,13 +65,12 @@ class ReaderExportButton extends React.Component {
 
 	render() {
 		return (
-			<Button
-				className="reader-export-button"
-				compact
-				disabled={ this.state.disabled }
-				onClick={ this.onClick }>
-				{ this.props.translate( 'Export' ) }
-			</Button>
+			<div className="reader-export-button" onClick={ this.onClick }>
+				<Gridicon icon="cloud-download" className="reader-export-button__icon" />
+				<span className="reader-export-button__label">
+					{ this.props.translate( 'Export' ) }
+				</span>
+			</div>
 		);
 	}
 }

--- a/client/blocks/reader-export-button/style.scss
+++ b/client/blocks/reader-export-button/style.scss
@@ -1,0 +1,24 @@
+.reader-export-button {
+	cursor: pointer;
+
+	&:hover {
+		.reader-export-button__icon {
+			fill: $blue-medium;
+		}
+
+		.reader-export-button__label {
+			color: $blue-medium;
+		}
+	}
+}
+
+.reader-export-button__icon {
+	fill: $gray;
+	vertical-align: middle;
+}
+
+.reader-export-button__label {
+	font-size: 14px;
+	color: $gray;
+	padding-left: 4px;
+}

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -60,6 +60,7 @@ import ReaderSubscriptionListItem from 'blocks/reader-subscription-list-item/doc
 import PostLikes from 'blocks/post-likes/docs/example';
 import ReaderFeaturedVideo from 'blocks/reader-featured-video/docs/example';
 import NpsSurvey from 'blocks/nps-survey/docs/example';
+import ReaderExportButton from 'blocks/reader-export-button/docs/example';
 
 export default React.createClass( {
 
@@ -141,6 +142,7 @@ export default React.createClass( {
 					{ isEnabled( 'nps-survey/devdocs' ) &&
 						<NpsSurvey />
 					}
+					<ReaderExportButton />
 				</Collection>
 			</Main>
 		);


### PR DESCRIPTION
This PR extracts the existing 'export feed' functionality to a separate block, ready for the new Manage Following.

http://calypso.localhost:3000/devdocs/blocks/reader-export-button

![45cee212-f91f-11e6-8cef-55fb056d1d4a](https://cloud.githubusercontent.com/assets/17325/24163179/bcaac908-0e61-11e7-9e1d-03dd3760d30e.jpg)
