### PR TITLE
Set test to 100% of English visitors

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -37,8 +37,8 @@ module.exports = {
 	signupStepOneCopyChanges: {
 		datestamp: '20170307',
 		variations: {
-			original: 50,
-			modified: 50,
+			original: 0,
+			modified: 100, //Test completed. Sending copy for translation.
 		},
 		defaultVariation: 'original',
 	},


### PR DESCRIPTION
Our signup test was successful so we're going to enable it for 100% of English visitors until we get our translated copy in for everyone else. This PR updates the test so that all traffic is diverted to our modified code. 

@markryall 
cc @klimeryk 