### PR TITLE
Theme Options: Merge hideForSite criterion into hideForTheme

### DIFF
--- a/client/my-sites/themes/themes-site-selector-modal.jsx
+++ b/client/my-sites/themes/themes-site-selector-modal.jsx
@@ -104,10 +104,7 @@ const ThemesSiteSelectorModal = React.createClass( {
 				{ selectedOption && <SiteSelectorModal className="themes__site-selector-modal"
 					isVisible={ true }
 					filter={ function( site ) {
-						return ! (
-							( selectedOption.hideForSite && selectedOption.hideForSite( site.ID ) ) ||
-							( selectedOption.hideForTheme && selectedOption.hideForTheme( selectedThemeId, site.ID ) )
-						);
+						return ! ( selectedOption.hideForTheme && selectedOption.hideForTheme( selectedThemeId, site.ID ) );
 					} }
 					hide={ this.hideSiteSelectorModal }
 					mainAction={ this.trackAndCallAction }


### PR DESCRIPTION
This is in preparation of a future PR that will move theme options computation entirely inside `theme-options.js`, removing the need for an `options` prop and those ugly layers of `ConnectedSomething` components.

To test:
Compare this branch to production. Compare all different showcase modes (logged-out, multi-site, single-site WP.com, single-site Jetpack), different themes (free, premium, purchased premium, active), and different plans (free, premium, business). Make sure that the '...' contains the same entries on this branch as in production. In multi-site mode, also compare the contents of the site selector modal.