### PR TITLE
AT: enable options for all AT sites

### DIFF
--- a/client/lib/automated-transfer/index.js
+++ b/client/lib/automated-transfer/index.js
@@ -19,18 +19,17 @@ export function isATEnabledForCurrentSite() {
 		return false;
 	}
 
+	// Feature must be enabled on environment
+	if ( ! isEnabled( 'automated-transfer' ) ) {
+		return false;
+	}
+
 	const site = require( 'lib/sites-list' )().getSelectedSite();
 
 	// Site has already been transferred
 	if ( get( site, 'options.is_automated_transfer' ) ) {
 		return true;
 	}
-
-	// Feature must be enabled on environment
-	if ( ! isEnabled( 'automated-transfer' ) ) {
-		return false;
-	}
-
 	// If it's wpcalypso, this is open
 	if ( config( 'env_id' ) === 'wpcalypso' ) {
 		return true;

--- a/client/lib/automated-transfer/index.js
+++ b/client/lib/automated-transfer/index.js
@@ -19,6 +19,13 @@ export function isATEnabledForCurrentSite() {
 		return false;
 	}
 
+	const site = require( 'lib/sites-list' )().getSelectedSite();
+
+	// Site has already been transferred
+	if ( get( site, 'options.is_automated_transfer' ) ) {
+		return true;
+	}
+
 	// Feature must be enabled on environment
 	if ( ! isEnabled( 'automated-transfer' ) ) {
 		return false;
@@ -30,7 +37,6 @@ export function isATEnabledForCurrentSite() {
 	}
 
 	// Site has Business plan
-	const site = require( 'lib/sites-list' )().getSelectedSite();
 	const planSlug = get( site, 'plan.product_slug' );
 	if ( planSlug !== PLAN_BUSINESS ) {
 		return false;


### PR DESCRIPTION
`isATEnabledForCurrentSite()` is returning false for sites that were transferred before the gate was set up. 
This updates the gate to let any automated transfer through.

**Testing**
1. Visit any client side environment that is not wpcalypso
2. Load an AT site transferred before the gate was set up
3. All AT options should be enabled such as the domains in the configuration sidebar