### PR TITLE
Publicize Scheduling:  update form params

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -963,15 +963,15 @@ Undocumented.prototype.createConnection = function( keyringConnectionId, siteId,
  *
  * @returns {Promise}
  */
-Undocumented.prototype.publicizePost = function( siteId, postId, message, skippedConnections, fn ) {
+Undocumented.prototype.publicizePost = function( siteId, postId, message, connections, fn ) {
 	const body = { skipped_connections: [] };
 
 	if ( message ) {
 		body.message = message;
 	}
 
-	if ( skippedConnections && skippedConnections.length > 0 ) {
-		body.skipped_connections = skippedConnections;
+	if ( connections ) {
+		body.connections = connections;
 	}
 
 	return this.wpcom.req.post( { path: `/sites/${ siteId }/post/${ postId }/publicize`, body, apiVersion: '1.1' }, fn );

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -959,20 +959,20 @@ Undocumented.prototype.createConnection = function( keyringConnectionId, siteId,
  * @param {int}       siteId            The site ID
  * @param {int}       postId            The post ID
  * @param {String}    message           Message for social media
- * @param {Array(int)}skippedconnetions        CKeyring connection ids to skip publicize
+ * @param {Array(int)}skippedConnetions        CKeyring connection ids to skip publicize
  * @param {Array(int)}connetions        CKeyring connection ids to publicize
  *
  * @returns {Promise}
  */
 Undocumented.prototype.publicizePost = function( siteId, postId, message, skippedConnections, connections, fn ) {
-	const body = { skip_connections: [] };
+	const body = { skipped_connections: [] };
 
 	if ( message ) {
 		body.message = message;
 	}
 
 	if ( skippedConnections && skippedConnections.length > 0) {
-		body.skip_connections = skippedConnections;
+		body.skipped_connections = skippedConnections;
 	}
 
 	if ( connections ) {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -959,15 +959,20 @@ Undocumented.prototype.createConnection = function( keyringConnectionId, siteId,
  * @param {int}       siteId            The site ID
  * @param {int}       postId            The post ID
  * @param {String}    message           Message for social media
- * @param {Array(int)}skipped           CKeyring connection ids to skip publicizing
+ * @param {Array(int)}skippedconnetions        CKeyring connection ids to skip publicize
+ * @param {Array(int)}connetions        CKeyring connection ids to publicize
  *
  * @returns {Promise}
  */
-Undocumented.prototype.publicizePost = function( siteId, postId, message, connections, fn ) {
-	const body = { skipped_connections: [] };
+Undocumented.prototype.publicizePost = function( siteId, postId, message, skippedConnections, connections, fn ) {
+	const body = { skip_connections: [] };
 
 	if ( message ) {
 		body.message = message;
+	}
+
+	if ( skippedConnections && skippedConnections.length > 0) {
+		body.skip_connections = skippedConnections;
 	}
 
 	if ( connections ) {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -959,7 +959,7 @@ Undocumented.prototype.createConnection = function( keyringConnectionId, siteId,
  * @param {int}       siteId            The site ID
  * @param {int}       postId            The post ID
  * @param {String}    message           Message for social media
- * @param {Array(int)}skippedConnetions        CKeyring connection ids to skip publicize
+ * @param {Array(int)}skippedConnetions CKeyring connection ids to skip publicize
  * @param {Array(int)}connetions        CKeyring connection ids to publicize
  *
  * @returns {Promise}

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -971,7 +971,7 @@ Undocumented.prototype.publicizePost = function( siteId, postId, message, skippe
 		body.message = message;
 	}
 
-	if ( skippedConnections && skippedConnections.length > 0) {
+	if ( skippedConnections && skippedConnections.length > 0 ) {
 		body.skipped_connections = skippedConnections;
 	}
 

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -14,13 +14,16 @@ import Gridicon from 'gridicons';
 import QueryPostTypes from 'components/data/query-post-types';
 import Button from 'components/button';
 import ButtonGroup from 'components/button-group';
-import { isPublicizeEnabled } from 'state/selectors';
+import {
+	isPublicizeEnabled,
+	getPublicizeSiteUserActiveConnections,
+} from 'state/selectors';
 import {
 	getSiteSlug,
 	getSitePlanSlug,
 } from 'state/sites/selectors';
 import { getCurrentUserId, getCurrentUserCurrencyCode } from 'state/current-user/selectors';
-import { getSiteUserConnections, hasFetchedConnections, getSiteUserActiveConnections } from 'state/sharing/publicize/selectors';
+import { getSiteUserConnections, hasFetchedConnections } from 'state/sharing/publicize/selectors';
 import { fetchConnections as requestConnections, sharePost, dismissShareConfirmation } from 'state/sharing/publicize/actions';
 import { isRequestingSharePost, sharePostFailure, sharePostSuccessMessage } from 'state/sharing/publicize/selectors';
 import PostMetadata from 'lib/post-metadata';
@@ -433,7 +436,7 @@ export default connect(
 			userCurrency: getCurrentUserCurrencyCode( state ), //populated by either plans endpoint
 			scheduledSharingActions: getPostShareScheduledActions( state, siteId, postId ),
 			publishedSharingActions: getPostSharePublishedActions( state, siteId, postId ),
-			activeConnections: getSiteUserActiveConnections( state, siteId, userId ),
+			activeConnections: getPublicizeSiteUserActiveConnections( state, siteId, userId ),
 		};
 	},
 	{ requestConnections, sharePost, dismissShareConfirmation }

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { get, includes, map } from 'lodash';
+import { get, includes, map, difference } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
@@ -117,7 +117,16 @@ class PostShare extends Component {
 	};
 
 	sharePost = () => {
-		this.props.sharePost( this.props.siteId, this.props.post.ID, this.state.message, this.state.enabledConnectionIds );
+		//TODO remove skippedConnections after api fully supports connection ids
+		const activeConnectionIds = map( this.props.activeConnections, 'keyring_connection_ID' );
+		const skippedConnections = difference( activeConnectionIds, this.state.enabledConnectionIds );
+		this.props.sharePost(
+			this.props.siteId,
+			this.props.post.ID,
+			skippedConnections,
+			this.state.message,
+			this.state.enabledConnectionIds
+		);
 	};
 
 	isButtonDisabled() {

--- a/client/state/selectors/get-publicize-site-user-active-connections.js
+++ b/client/state/selectors/get-publicize-site-user-active-connections.js
@@ -1,0 +1,20 @@
+/* External dependcies */
+import { filter } from 'lodash';
+
+/*
+ * returns an array of known active connection for the given site ID
+ * that are available to the specified user ID.
+ *
+ * @param  {Object} state Global state tree
+ * @param  {Number} siteId Site ID
+ * @param  {Number} userId User ID to filter
+ * @return {Array}  User connections
+ */
+export default function getPublicizeSiteUserActiveConnections( state, siteId, userId ) {
+	return filter( state.sharing.publicize.connections, ( connection ) => {
+		const { site_ID, shared, keyring_connection_user_ID } = connection;
+		return site_ID === siteId &&
+			( shared || keyring_connection_user_ID === userId ) &&
+			connection.status !== 'broken';
+	} );
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -41,6 +41,7 @@ export getMenuItemTypes from './get-menu-item-types';
 export getPastBillingTransaction from './get-past-billing-transaction';
 export getPastBillingTransactions from './get-past-billing-transactions';
 export getPublicizeConnection from './get-publicize-connection';
+export getPublicizeSiteUserActiveConnections from './get-publicize-site-user-active-connections';
 export getPostLikes from './get-post-likes';
 export getRawOffsets from './get-raw-offsets';
 export getReaderTeams from './get-reader-teams';

--- a/client/state/selectors/test/get-publicize-site-user-active-connections.js
+++ b/client/state/selectors/test/get-publicize-site-user-active-connections.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+
+import { getPublicizeSiteUserActiveConnections } from '../selectors';
+
+describe( '#getSiteUserActiveConnections()', () => {
+	it( 'should return an array with only active connetions', () => {
+		const activeConnections = getPublicizeSiteUserActiveConnections( {
+			sharing: {
+				publicize: {
+					connections: {
+						1: { ID: 1, site_ID: 2916284, keyring_connection_user_ID: 26957695, status: 'broken' },
+						2: { ID: 2, site_ID: 2916284, shared: true, status: 'ok' },
+						3: { ID: 3, site_ID: 2916284, keyring_connection_user_ID: 26957695, status: 'ok' },
+						4: { ID: 4, site_ID: 2916284, shared: true, status: 'broken' },
+					}
+				}
+			}
+		}, 2916284, 26957695 );
+
+		expect( activeConnections ).to.eql( [
+			{ ID: 2, site_ID: 2916284, shared: true, status: 'ok' },
+			{ ID: 3, site_ID: 2916284, keyring_connection_user_ID: 26957695, status: 'ok' }
+		] );
+	} );
+} );

--- a/client/state/selectors/test/get-publicize-site-user-active-connections.js
+++ b/client/state/selectors/test/get-publicize-site-user-active-connections.js
@@ -7,9 +7,9 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 
-import { getPublicizeSiteUserActiveConnections } from '../selectors';
+import { getPublicizeSiteUserActiveConnections } from '../';
 
-describe( '#getSiteUserActiveConnections()', () => {
+describe.only( '#getSiteUserActiveConnections()', () => {
 	it( 'should return an array with only active connetions', () => {
 		const activeConnections = getPublicizeSiteUserActiveConnections( {
 			sharing: {

--- a/client/state/sharing/publicize/actions.js
+++ b/client/state/sharing/publicize/actions.js
@@ -31,18 +31,18 @@ export function dismissShareConfirmation( siteId, postId ) {
 	};
 }
 
-export function sharePost( siteId, postId, skippedConnections, message ) {
+export function sharePost( siteId, postId, message, connections ) {
 	return ( dispatch ) => {
 		dispatch( {
 			type: PUBLICIZE_SHARE,
 			siteId,
 			postId,
-			skippedConnections,
-			message
+			message,
+			connections,
 		} );
 
 		return new Promise( ( resolve ) => {
-			wpcom.undocumented().publicizePost( siteId, postId, message, skippedConnections, ( error, data ) => {
+			wpcom.undocumented().publicizePost( siteId, postId, message, connections, ( error, data ) => {
 				if ( error || ! data.success ) {
 					dispatch( { type: PUBLICIZE_SHARE_FAILURE, siteId, postId, error } );
 				} else {

--- a/client/state/sharing/publicize/actions.js
+++ b/client/state/sharing/publicize/actions.js
@@ -31,18 +31,18 @@ export function dismissShareConfirmation( siteId, postId ) {
 	};
 }
 
-export function sharePost( siteId, postId, message, connections ) {
+export function sharePost( siteId, postId, message, connectionIds ) {
 	return ( dispatch ) => {
 		dispatch( {
 			type: PUBLICIZE_SHARE,
 			siteId,
 			postId,
 			message,
-			connections,
+			connectionIds,
 		} );
 
 		return new Promise( ( resolve ) => {
-			wpcom.undocumented().publicizePost( siteId, postId, message, connections, ( error, data ) => {
+			wpcom.undocumented().publicizePost( siteId, postId, message, connectionIds, ( error, data ) => {
 				if ( error || ! data.success ) {
 					dispatch( { type: PUBLICIZE_SHARE_FAILURE, siteId, postId, error } );
 				} else {

--- a/client/state/sharing/publicize/actions.js
+++ b/client/state/sharing/publicize/actions.js
@@ -31,18 +31,19 @@ export function dismissShareConfirmation( siteId, postId ) {
 	};
 }
 
-export function sharePost( siteId, postId, message, connectionIds ) {
+export function sharePost( siteId, postId, skippedConnections, message, connectionIds ) {
 	return ( dispatch ) => {
 		dispatch( {
 			type: PUBLICIZE_SHARE,
 			siteId,
 			postId,
+			skippedConnections,
 			message,
 			connectionIds,
 		} );
 
 		return new Promise( ( resolve ) => {
-			wpcom.undocumented().publicizePost( siteId, postId, message, connectionIds, ( error, data ) => {
+			wpcom.undocumented().publicizePost( siteId, postId, message, skippedConnections, connectionIds, ( error, data ) => {
 				if ( error || ! data.success ) {
 					dispatch( { type: PUBLICIZE_SHARE_FAILURE, siteId, postId, error } );
 				} else {

--- a/client/state/sharing/publicize/selectors.js
+++ b/client/state/sharing/publicize/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, get, map } from 'lodash';
+import { filter, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -38,7 +38,7 @@ export function getSiteUserConnections( state, siteId, userId ) {
 }
 
 /**
- * Returns an array of known active connection ids for the given site ID
+ * Returns an array of known active connection for the given site ID
  * that are available to the specified user ID.
  *
  * @param  {Object} state Global state tree
@@ -46,10 +46,9 @@ export function getSiteUserConnections( state, siteId, userId ) {
  * @param  {Number} userId User ID to filter
  * @return {Array}  User connections
  */
-export function getSiteUserActiveConnectionIds( state, siteId, userId ) {
+export function getSiteUserActiveConnections( state, siteId, userId ) {
 	const connections = getSiteUserConnections( state, siteId, userId );
-	const activeConnections = filter( connections, connection => connection.status !== 'broken' );
-	return map( activeConnections, 'keyring_connection_ID' );
+	return filter( connections, connection => connection.status !== 'broken' );
 }
 
 /**

--- a/client/state/sharing/publicize/selectors.js
+++ b/client/state/sharing/publicize/selectors.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import filter from 'lodash/filter';
-import get from 'lodash/get';
+import { filter, get, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,6 +35,12 @@ export function getSiteUserConnections( state, siteId, userId ) {
 		const { site_ID, shared, keyring_connection_user_ID } = connection;
 		return site_ID === siteId && ( shared || keyring_connection_user_ID === userId );
 	} );
+}
+
+export function getSiteUserActiveConnectionIds( state, siteId, userId ) {
+	const connections = getSiteUserConnections( state, siteId, userId );
+	const activeConnections = filter( connections, connection => connection.status !== 'broken' );
+	return map( activeConnections, 'keyring_connection_ID' );
 }
 
 /**

--- a/client/state/sharing/publicize/selectors.js
+++ b/client/state/sharing/publicize/selectors.js
@@ -37,6 +37,15 @@ export function getSiteUserConnections( state, siteId, userId ) {
 	} );
 }
 
+/**
+ * Returns an array of known active connection ids for the given site ID
+ * that are available to the specified user ID.
+ *
+ * @param  {Object} state Global state tree
+ * @param  {Number} siteId Site ID
+ * @param  {Number} userId User ID to filter
+ * @return {Array}  User connections
+ */
 export function getSiteUserActiveConnectionIds( state, siteId, userId ) {
 	const connections = getSiteUserConnections( state, siteId, userId );
 	const activeConnections = filter( connections, connection => connection.status !== 'broken' );

--- a/client/state/sharing/publicize/selectors.js
+++ b/client/state/sharing/publicize/selectors.js
@@ -38,20 +38,6 @@ export function getSiteUserConnections( state, siteId, userId ) {
 }
 
 /**
- * Returns an array of known active connection for the given site ID
- * that are available to the specified user ID.
- *
- * @param  {Object} state Global state tree
- * @param  {Number} siteId Site ID
- * @param  {Number} userId User ID to filter
- * @return {Array}  User connections
- */
-export function getSiteUserActiveConnections( state, siteId, userId ) {
-	const connections = getSiteUserConnections( state, siteId, userId );
-	return filter( connections, connection => connection.status !== 'broken' );
-}
-
-/**
  * Returns an array of known connections for the given site ID
  * that are available to the specified user ID.
  *

--- a/client/state/sharing/publicize/test/selectors.js
+++ b/client/state/sharing/publicize/test/selectors.js
@@ -14,7 +14,8 @@ import {
 	getRemovableConnections,
 	hasFetchedConnections,
 	isFetchingConnection,
-	isFetchingConnections
+	isFetchingConnections,
+	getSiteUserActiveConnections,
 } from '../selectors';
 
 describe( 'getBrokenSiteUserConnectionsForService()', () => {
@@ -123,6 +124,28 @@ describe( '#getSiteUserConnections()', () => {
 		expect( connections ).to.eql( [
 			{ ID: 1, site_ID: 2916284, shared: true },
 			{ ID: 2, site_ID: 2916284, keyring_connection_user_ID: 26957695 }
+		] );
+	} );
+} );
+
+describe( '#getSiteUserActiveConnections()', () => {
+	it( 'should return an array with only active connetions', () => {
+		const activeConnections = getSiteUserActiveConnections( {
+			sharing: {
+				publicize: {
+					connections: {
+						1: { ID: 1, site_ID: 2916284, keyring_connection_user_ID: 26957695, status: 'broken' },
+						2: { ID: 2, site_ID: 2916284, shared: true , status: 'ok' },
+						3: { ID: 3, site_ID: 2916284, keyring_connection_user_ID: 26957695,  status: 'ok' },
+						4: { ID: 4, site_ID: 2916284, shared: true, status: 'broken' },
+					}
+				}
+			}
+		}, 2916284, 26957695 );
+
+		expect( activeConnections ).to.eql( [
+			{ ID: 2, site_ID: 2916284, shared: true, status: 'ok' },
+			{ ID: 3, site_ID: 2916284, keyring_connection_user_ID: 26957695, status: 'ok' }
 		] );
 	} );
 } );

--- a/client/state/sharing/publicize/test/selectors.js
+++ b/client/state/sharing/publicize/test/selectors.js
@@ -15,7 +15,6 @@ import {
 	hasFetchedConnections,
 	isFetchingConnection,
 	isFetchingConnections,
-	getSiteUserActiveConnections,
 } from '../selectors';
 
 describe( 'getBrokenSiteUserConnectionsForService()', () => {
@@ -124,28 +123,6 @@ describe( '#getSiteUserConnections()', () => {
 		expect( connections ).to.eql( [
 			{ ID: 1, site_ID: 2916284, shared: true },
 			{ ID: 2, site_ID: 2916284, keyring_connection_user_ID: 26957695 }
-		] );
-	} );
-} );
-
-describe( '#getSiteUserActiveConnections()', () => {
-	it( 'should return an array with only active connetions', () => {
-		const activeConnections = getSiteUserActiveConnections( {
-			sharing: {
-				publicize: {
-					connections: {
-						1: { ID: 1, site_ID: 2916284, keyring_connection_user_ID: 26957695, status: 'broken' },
-						2: { ID: 2, site_ID: 2916284, shared: true , status: 'ok' },
-						3: { ID: 3, site_ID: 2916284, keyring_connection_user_ID: 26957695,  status: 'ok' },
-						4: { ID: 4, site_ID: 2916284, shared: true, status: 'broken' },
-					}
-				}
-			}
-		}, 2916284, 26957695 );
-
-		expect( activeConnections ).to.eql( [
-			{ ID: 2, site_ID: 2916284, shared: true, status: 'ok' },
-			{ ID: 3, site_ID: 2916284, keyring_connection_user_ID: 26957695, status: 'ok' }
 		] );
 	} );
 } );


### PR DESCRIPTION
This replaces the blacklist `skip_connections` with a whitelist `connections` to work with the recent updates to the /sites/:site/post/:post/publicize endpoint.

**Testing**

1. Open sharing form on a post
1. Deselect all but one sharing network connection
1. Verify that a connections parameter is sent with the request
1. Verify that skip_connections is not sent with the request
1. ~Verify that the message is posted to only the selection sharing network~

**Update**
We are waiting on a change to the api endpoint for this change to correctly send out the share