### PR TITLE
Docs: config / create-config

### DIFF
--- a/client/config/README.md
+++ b/client/config/README.md
@@ -1,7 +1,7 @@
 client/config
 =============
 
-The `index.js` file is generated on startup by `regenerate-client.js`. Based on the environment, data is read from the appropriate .json file in the root config directory, for example, `/config/development.json`. The data is then compared against a whitelist in `/config/client.json`, and whitelisted items are added to the data object in `/client/config/index.js`. You can read more about how to use `config` in the [config documentation](../config).
+The `index.js` utilized the config created from `lib/create-config/index.js`. Based on the environment, data is read from the appropriate .json file in the root config directory, for example, `/config/development.json`. The data is then compared against a whitelist in `/config/client.json`, and whitelisted items are added to the data object in `/client/config/index.js`. You can read more about how to use `config` in the [config documentation](../config).
 
 Feature Flags API
 -----------------


### PR DESCRIPTION
This PR aims to update all of the outdated documentation regarding how `config` gets created for client/server and anywhere that talks about building multiple bundles per env.

