### PR TITLE
AT: disable Jetpack and VaultPress from bulk select

### DIFF
--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -4,7 +4,7 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { find, get, includes, isEmpty, isEqual, negate, range } from 'lodash';
+import { find, get, includes, isEmpty, isEqual, negate, range, reduce } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -115,9 +115,19 @@ export const PluginsList = React.createClass( {
 		this.props.recordGoogleEvent( 'Plugins', eventAction, 'Plugin Name', slug );
 	},
 
+	canBulkSelect( plugin ) {
+		const {
+			autoupdate: canAutoupdate,
+			activation: canActivate,
+		} = this.getAllowedPluginActions( plugin );
+		return ! this.hasNoSitesThatCanManage( plugin ) && ( canAutoupdate || canActivate );
+	},
+
 	setBulkSelectionState( plugins, selectionState ) {
-		const slugsToBeUpdated = {};
-		plugins.forEach( plugin => slugsToBeUpdated[ plugin.slug ] = this.hasNoSitesThatCanManage( plugin ) ? false : selectionState );
+		const slugsToBeUpdated = reduce( plugins, ( slugs, plugin ) => {
+			slugs[ plugin.slug ] = this.canBulkSelect( plugin ) && selectionState;
+			return slugs;
+		}, {} );
 
 		this.setState( { selectedPlugins: Object.assign( {}, this.state.selectedPlugins, slugsToBeUpdated ) } );
 	},
@@ -193,6 +203,7 @@ export const PluginsList = React.createClass( {
 
 	removePluginsNotices() {
 		const { notices: { completed, errors } = {} } = this.state;
+
 		if ( completed || errors ) {
 			PluginsActions.removePluginsNotices( [ ...completed, ...errors ] );
 		}
@@ -202,7 +213,6 @@ export const PluginsList = React.createClass( {
 		const isDeactivatingAndJetpackSelected = ( { slug } ) => 'deactivating' === actionName && 'jetpack' === slug;
 		const flattenArrays = ( full, partial ) => [ ...full, ...partial ];
 		this.removePluginsNotices();
-
 		this.props.plugins
 			.filter( this.isSelected ) // only use selected sites
 			.filter( negate( isDeactivatingAndJetpackSelected ) ) // ignore sites that are deactiving
@@ -445,6 +455,7 @@ export const PluginsList = React.createClass( {
 	renderPlugin( plugin ) {
 		const selectThisPlugin = this.togglePlugin.bind( this, plugin );
 		const allowedPluginActions = this.getAllowedPluginActions( plugin );
+		const isSelectable = this.state.bulkManagementActive && ( allowedPluginActions.autoupdate || allowedPluginActions.activation );
 		return (
 			<PluginItem
 				key={ plugin.slug }
@@ -455,7 +466,7 @@ export const PluginsList = React.createClass( {
 				errors={ this.state.notices.errors.filter( log => log.plugin && log.plugin.slug === plugin.slug ) }
 				notices={ this.state.notices }
 				isSelected={ this.isSelected( plugin ) }
-				isSelectable={ this.state.bulkManagementActive }
+				isSelectable={ isSelectable }
 				onClick={ selectThisPlugin }
 				selectedSite={ this.props.selectedSite }
 				pluginLink={ '/plugins/' + encodeURIComponent( plugin.slug ) + this.siteSuffix() }


### PR DESCRIPTION
This prevents users from adding Jetpack and Vaultpress to bulk select actions

<img width="740" alt="screen shot 2017-03-21 at 3 12 16 pm" src="https://cloud.githubusercontent.com/assets/744755/24173319/d5d20cc0-0e48-11e7-9a68-661b7df04354.png">

**Testing**
1. Visit plugins section for an AT site
2. Open bulk select
3. Jetpack and Vaultpress should not show a checkbox
4. Choice any action
5. Jetpack and Vaultpress should not perform the action
