### PR TITLE
Reader: don't raise an error when following a tag you're already subscribed to

### DIFF
--- a/client/state/data-layer/wpcom/read/tags/mine/new/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/new/index.js
@@ -47,6 +47,11 @@ export function receiveFollowTag( store, action, next, apiResponse ) {
 }
 
 export function receiveError( store, action, next, error ) {
+	// exit early and do nothing if the error is that the user is already following the tag
+	if ( error && error.error === 'already_subscribed' ) {
+		return;
+	}
+
 	const errorText = translate( 'Could not follow tag: %(tag)s', {
 		args: { tag: action.payload.slug }
 	} );


### PR DESCRIPTION
Issue: when following a tag that you are already subscribed to, the only thing that we should do is move you to the tag page.  There is no need for an error notice.

This PR removes the error notice for that case.

Problem introduced here: https://github.com/Automattic/wp-calypso/pull/11733