### PR TITLE
Reader: Fix how search accepts the value of a textbox

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -123,7 +123,7 @@ const Search = React.createClass( {
 			this.setState( { isOpen: nextProps.isOpen } );
 		}
 
-		if ( nextProps.value && nextProps.value !== this.state.keyword ) {
+		if ( this.props.value !== nextProps.value && nextProps.value && nextProps.value !== this.state.keyword ) {
 			this.setState( { keyword: nextProps.value } );
 		}
 	},

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -224,6 +224,7 @@ class SearchStream extends Component {
 							delaySearch={ true }
 							delayTimeout={ 500 }
 							placeholder={ searchPlaceholderText }
+							initialValue={ query }
 							value={ query }
 						/>
 					</CompactCard>

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -201,23 +201,24 @@ class SearchStream extends Component {
 		const documentTitle = this.props.translate(
 			'%s ‹ Reader', { args: this.state.title || this.props.translate( 'Search' ) }
 		);
-
+		debugger;
 		const searchInputProps = {
 			onSearch: this.updateQuery,
 			onSearchClose: this.scrollToTop,
 			autoFocus: this.props.autoFocusInput,
 			delaySearch: true,
 			delayTimeout: 500,
-			placeholder: searchPlaceholderText
+			placeholder: searchPlaceholderText,
+			value: query
 		};
 
-		if ( postsStore && postsStore.isQuerySuggestion ) {
-			// we need to set the value prop on the search input
-			searchInputProps.value = query;
-			searchInputProps.initialValue = query;
-		} else {
-			searchInputProps.initialValue = query;
-		}
+		// if ( postsStore && postsStore.isQuerySuggestion ) {
+		// 	// we need to set the value prop on the search input
+		// 	searchInputProps.value = query;
+		// 	searchInputProps.initialValue = query;
+		// } else {
+		// 	searchInputProps.initialValue = query;
+		// }
 
 		return (
 			<Stream { ...this.props }

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -187,7 +187,7 @@ class SearchStream extends Component {
 	}
 
 	render() {
-		const { postsStore, query, suggestions } = this.props;
+		const { query, suggestions } = this.props;
 		const emptyContent = <EmptyContent query={ query } />;
 
 		let searchPlaceholderText = this.props.searchPlaceholderText;
@@ -201,24 +201,6 @@ class SearchStream extends Component {
 		const documentTitle = this.props.translate(
 			'%s ‹ Reader', { args: this.state.title || this.props.translate( 'Search' ) }
 		);
-		debugger;
-		const searchInputProps = {
-			onSearch: this.updateQuery,
-			onSearchClose: this.scrollToTop,
-			autoFocus: this.props.autoFocusInput,
-			delaySearch: true,
-			delayTimeout: 500,
-			placeholder: searchPlaceholderText,
-			value: query
-		};
-
-		// if ( postsStore && postsStore.isQuerySuggestion ) {
-		// 	// we need to set the value prop on the search input
-		// 	searchInputProps.value = query;
-		// 	searchInputProps.initialValue = query;
-		// } else {
-		// 	searchInputProps.initialValue = query;
-		// }
 
 		return (
 			<Stream { ...this.props }
@@ -235,7 +217,15 @@ class SearchStream extends Component {
 				<div ref={ this.handleStreamMounted } />
 				<div className="search-stream__fixed-area" ref={ this.handleSearchBoxMounted }>
 					<CompactCard className="search-stream__input-card">
-						<SearchInput { ...searchInputProps } />
+						<SearchInput
+							onSearch={ this.updateQuery }
+							onSearchClose={ this.scrollToTop }
+							autoFocus={ this.props.autoFocusInput }
+							delaySearch={ true }
+							delayTimeout={ 500 }
+							placeholder={ searchPlaceholderText }
+							value={ query }
+						/>
 					</CompactCard>
 					<p className="search-stream__blank-suggestions">
 						{ suggestions &&

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -187,7 +187,7 @@ class SearchStream extends Component {
 	}
 
 	render() {
-		const { store, query, suggestions } = this.props;
+		const { postsStore, query, suggestions } = this.props;
 		const emptyContent = <EmptyContent query={ query } />;
 
 		let searchPlaceholderText = this.props.searchPlaceholderText;
@@ -201,8 +201,26 @@ class SearchStream extends Component {
 		const documentTitle = this.props.translate(
 			'%s ‹ Reader', { args: this.state.title || this.props.translate( 'Search' ) }
 		);
+
+		const searchInputProps = {
+			onSearch: this.updateQuery,
+			onSearchClose: this.scrollToTop,
+			autoFocus: this.props.autoFocusInput,
+			delaySearch: true,
+			delayTimeout: 500,
+			placeholder: searchPlaceholderText
+		};
+
+		if ( postsStore && postsStore.isQuerySuggestion ) {
+			// we need to set the value prop on the search input
+			searchInputProps.value = query;
+			searchInputProps.initialValue = query;
+		} else {
+			searchInputProps.initialValue = query;
+		}
+
 		return (
-			<Stream { ...this.props } store={ store }
+			<Stream { ...this.props }
 				listName={ this.props.translate( 'Search' ) }
 				emptyContent={ emptyContent }
 				showFollowInHeader={ true }
@@ -216,14 +234,7 @@ class SearchStream extends Component {
 				<div ref={ this.handleStreamMounted } />
 				<div className="search-stream__fixed-area" ref={ this.handleSearchBoxMounted }>
 					<CompactCard className="search-stream__input-card">
-						<SearchInput
-							initialValue={ query }
-							onSearch={ this.updateQuery }
-							onSearchClose={ this.scrollToTop }
-							autoFocus={ this.props.autoFocusInput }
-							delaySearch={ true }
-							delayTimeout={ 500 }
-							placeholder={ searchPlaceholderText } />
+						<SearchInput { ...searchInputProps } />
 					</CompactCard>
 					<p className="search-stream__blank-suggestions">
 						{ suggestions &&

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -217,7 +217,7 @@ class SearchStream extends Component {
 				<div className="search-stream__fixed-area" ref={ this.handleSearchBoxMounted }>
 					<CompactCard className="search-stream__input-card">
 						<SearchInput
-							value={ query }
+							initialValue={ query }
 							onSearch={ this.updateQuery }
 							onSearchClose={ this.scrollToTop }
 							autoFocus={ this.props.autoFocusInput }


### PR DESCRIPTION
~~Use initialValue instead of value to prevent a race while typing. If we use value, the query that comes in via the controller can override what the user is typing. By using initialValue, the current value is retained.~~

Teach the Search component to only reset the keyword state when the value prop changes and is truthy.

To test:

1. try typing `one two three` fairly slowly into the search input on both this branch and production. 2. make sure reloading a search works as expected, 
3. make sure clearing out a search works
4. make sure clicking on a suggestion works
5. make sure adding text to a suggestion by typing works
6. make sure removing text from a suggestion works
7. make sure the search input works on the site picker, both from the write button and the my sites sidebar

