### PR TITLE
Jetpack: Integrate the new disconnect dialog block

### DIFF
--- a/client/blocks/disconnect-jetpack-dialog/index.jsx
+++ b/client/blocks/disconnect-jetpack-dialog/index.jsx
@@ -26,7 +26,7 @@ class DisconnectJetpackDialog extends PureComponent {
 		const { plan, translate } = this.props;
 		const features = [];
 		switch ( plan ) {
-			case 'free':
+			case 'is-free-plan':
 				features.push(
 					translate(
 						'{{icon/}} Site stats, related content, and sharing tools',
@@ -40,20 +40,20 @@ class DisconnectJetpackDialog extends PureComponent {
 				features.push( translate( '{{icon/}} Unlimited, high-speed image hosting', this.getIcon( 'image' ) ) );
 				break;
 
-			case 'personal':
+			case 'is-personal-plan':
 				features.push( translate( '{{icon/}} Daily, automated backups (unlimited storage)', this.getIcon( 'history' ) ) );
 				features.push( translate( '{{icon/}} Priority WordPress and security support', this.getIcon( 'chat' ) ) );
 				features.push( translate( '{{icon/}} Spam filtering', this.getIcon( 'spam' ) ) );
 				break;
 
-			case 'premium':
+			case 'is-premium-plan':
 				features.push( translate( '{{icon/}} Daily, automated backups (unlimited storage)', this.getIcon( 'history' ) ) );
 				features.push( translate( '{{icon/}} Daily, automated malware scanning', this.getIcon( 'spam' ) ) );
 				features.push( translate( '{{icon/}} Priority WordPress and security support', this.getIcon( 'chat' ) ) );
 				features.push( translate( '{{icon/}} 13Gb of high-speed video hosting', this.getIcon( 'video' ) ) );
 				break;
 
-			case 'professional':
+			case 'is-business-plan':
 				features.push( translate( '{{icon/}} Daily, automated backups (unlimited storage)', this.getIcon( 'history' ) ) );
 				features.push(
 					translate( '{{icon/}} Daily, automated malware scanning with automated resolution',

--- a/client/lib/sites-list/actions.js
+++ b/client/lib/sites-list/actions.js
@@ -17,34 +17,12 @@ const SitesListActions = {
 			logs
 		} );
 	},
-
-	disconnect( site ) {
-		debug( 'disconnect site', site );
-
-		if ( site.capabilities && site.capabilities.manage_options ) {
-			Dispatcher.handleViewAction( {
-				type: 'DISCONNECT_SITE',
-				action: 'DISCONNECT_SITE',
-				site
-			} );
-
-			wpcom.undocumented().disconnectJetpack( site.ID, function( error, data ) {
-				Dispatcher.handleViewAction( {
-					type: 'RECEIVE_DISCONNECTED_SITE',
-					action: 'DISCONNECT_SITE',
-					site,
-					error,
-					data
-				} );
-			} );
-		} else {
-			Dispatcher.handleViewAction( {
-				type: 'DISCONNECTING_SITE_ERROR',
-				action: 'DISCONNECT_SITE',
-				site,
-				error: { error: 'unauthorized_access' }
-			} );
-		}
+	// A way to remove a Disconnected Site from the old list store
+	disconnectedSite( site ) {
+		Dispatcher.handleViewAction( {
+			type: 'DISCONNECT_SITE',
+			site
+		} );
 	},
 
 	deleteSite( site, onComplete ) {

--- a/client/lib/sites-list/index.js
+++ b/client/lib/sites-list/index.js
@@ -4,10 +4,10 @@
 import { action as InvitesActionTypes } from 'lib/invites/constants';
 import { JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST } from 'state/action-types';
 
-var SitesList = require( './list' ),
-	PollerPool = require( 'lib/data-poller' ),
-	Dispatcher = require( 'dispatcher' ),
-	_sites;
+import SitesList from './list';
+import PollerPool from 'lib/data-poller';
+import Dispatcher from 'dispatcher';
+let	_sites;
 
 module.exports = function() {
 	if ( ! _sites ) {
@@ -15,7 +15,7 @@ module.exports = function() {
 		PollerPool.add( _sites, 'fetch' );
 
 		_sites.dispatchToken = Dispatcher.register( function( payload ) {
-			var action = payload.action;
+			const action = payload.action;
 			switch ( action.type ) {
 				case 'DISCONNECT_SITE':
 				case 'RECEIVE_DELETED_SITE':
@@ -29,7 +29,6 @@ module.exports = function() {
 				case JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST:
 					_sites.sync( action.data );
 					break;
-				case 'RECEIVE_DISCONNECTED_SITE':
 				case 'FETCH_SITES':
 					_sites.fetch(); // refetch the sites from .com
 					break;

--- a/client/lib/sites-list/log-store.js
+++ b/client/lib/sites-list/log-store.js
@@ -1,23 +1,26 @@
 /**
  * External dependencies
  */
-var reject = require( 'lodash/reject' ),
-	filter = require( 'lodash/filter' ),
-	clone = require( 'lodash/clone' ),
-	debug = require( 'debug' )( 'calypso:sites-list:log-store' );
+import { reject, filter, clone } from 'lodash';
+import debugModule from 'debug';
 
 /**
  * Internal dependencies
  */
-var Dispatcher = require( 'dispatcher' ),
-	Emitter = require( 'lib/mixins/emitter' );
+import Dispatcher from 'dispatcher';
+import Emitter from 'lib/mixins/emitter';
 
-var _errors = [],
+/**
+ * Module variables
+ */
+const debug = debugModule( 'calypso:sites-list:log-store' );
+
+let _errors = [],
 	_inProgress = [],
 	_completed = [];
 
 function addLog( status, action, site, error ) {
-	var log = {
+	const log = {
 		status: status,
 		action: action,
 		site: site
@@ -62,7 +65,7 @@ function removeLog( log ) {
 	}
 }
 
-var LogStore = {
+const LogStore = {
 
 	getErrors: function( filterBy ) {
 		if ( filterBy ) {
@@ -91,34 +94,12 @@ var LogStore = {
 };
 
 LogStore.dispatchToken = Dispatcher.register( function( payload ) {
-	var action = payload.action;
+	const action = payload.action;
 
 	debug( 'register event Type', action.type, payload );
 	switch ( action.type ) {
 		case 'REMOVE_SITES_NOTICES':
 			action.logs.forEach( removeLog );
-			LogStore.emitChange();
-			break;
-		case 'DISCONNECTING_SITE_ERROR':
-			addLog( 'error', action.action, action.site, action.error );
-			LogStore.emitChange();
-			break;
-		case 'DISCONNECT_SITE':
-			addLog( 'inProgress', action.action, action.site );
-			LogStore.emitChange();
-			break;
-		case 'RECEIVE_DISCONNECTED_SITE':
-			removeLog( {
-				status: 'inProgress',
-				action: action.action,
-				site: action.site
-			} );
-
-			if ( action.error ) {
-				addLog( 'error', action.action, action.site, action.error );
-			} else {
-				addLog( 'completed', action.action, action.site );
-			}
 			LogStore.emitChange();
 			break;
 		case 'RECEIVE_PLUGINS':
@@ -128,7 +109,6 @@ LogStore.dispatchToken = Dispatcher.register( function( payload ) {
 			}
 			break;
 	}
-
 } );
 
 // Add the Store to the emitter so we can emit change events.

--- a/client/lib/sites-list/test/log-store.js
+++ b/client/lib/sites-list/test/log-store.js
@@ -16,11 +16,6 @@ describe( 'Sites Log Store', () => {
 		assert.lengthOf( LogStore.getErrors(), 0 );
 	} );
 
-	it( 'logs an update error', () => {
-		Dispatcher.handleServerAction( actions.disconnectedSiteError );
-		assert.lengthOf( LogStore.getErrors(), 1 );
-	} );
-
 	it( 'removing an error notice deletes an error', () => {
 		Dispatcher.handleServerAction( actions.removeNotices );
 		assert.lengthOf( LogStore.getErrors(), 0 );

--- a/client/lib/sites-list/test/mocks/lib/actions.js
+++ b/client/lib/sites-list/test/mocks/lib/actions.js
@@ -1,20 +1,6 @@
-var site = require( '../../fixtures/site' );
+const site = require( '../../fixtures/site' );
 
-var Actions = {
-
-	disconnectSite: {
-		type: 'DISCONNECT_SITE',
-		action: 'DISCONNECT_SITE',
-		site: site
-	},
-
-	disconnectedSiteError: {
-		type: 'RECEIVE_DISCONNECTED_SITE',
-		action: 'DISCONNECT_SITE',
-		site: site,
-		data: {},
-		error: { error: 'unauthorized_access' }
-	},
+const Actions = {
 
 	removeNotices: {
 		type: 'REMOVE_SITES_NOTICES',

--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
@@ -62,7 +62,7 @@ class DisconnectJetpackButton extends Component {
 		recordGAEvent( 'Jetpack', 'Clicked To Confirm Disconnect Jetpack Dialog' );
 
 		const { notice } = showInfoNotice(
-			translate( 'Disconnecting %(siteName)s', { args: { siteName: site.title } } )
+			translate( 'Disconnecting %(siteName)s.', { args: { siteName: site.title } } )
 			, { isPersistent: true, showDismiss: false }
 		);
 
@@ -74,7 +74,7 @@ class DisconnectJetpackButton extends Component {
 			disconnectedSiteDeprecated( site );
 			this.props.setAllSitesSelected();
 			removeInfoNotice( notice.noticeId );
-			showSuccessNotice( translate( '%(siteName)s has been successfully disconnected', { args: { siteName: site.title } } ) );
+			showSuccessNotice( translate( 'Successfully disconnected %(siteName)s.', { args: { siteName: site.title } } ) );
 			recordGAEvent( 'Jetpack', 'Successfully Disconnected' );
 		}, () => {
 			removeInfoNotice( notice.noticeId );

--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
@@ -62,7 +62,7 @@ class DisconnectJetpackButton extends Component {
 		recordGAEvent( 'Jetpack', 'Clicked To Confirm Disconnect Jetpack Dialog' );
 
 		const { notice } = showInfoNotice(
-			translate( 'Disconecting %(siteName)s', { args: { siteName: site.title } } )
+			translate( 'Disconnecting %(siteName)s', { args: { siteName: site.title } } )
 			, { isPersistent: true, showDismiss: false }
 		);
 
@@ -74,11 +74,11 @@ class DisconnectJetpackButton extends Component {
 			disconnectedSiteDeprecated( site );
 			this.props.setAllSitesSelected();
 			removeInfoNotice( notice.noticeId );
-			showSuccessNotice( translate( 'Disconnected %(siteName)s', { args: { siteName: site.title } } ) );
+			showSuccessNotice( translate( '%(siteName)s has been successfully disconnected', { args: { siteName: site.title } } ) );
 			recordGAEvent( 'Jetpack', 'Successfully Disconnected' );
 		}, () => {
 			removeInfoNotice( notice.noticeId );
-			showErrorNotice( translate( 'Error Disconnecting %(siteName)s', { args: { siteName: site.title } } ) );
+			showErrorNotice( translate( '%(siteName)s failed to disconnect', { args: { siteName: site.title } } ) );
 			recordGAEvent( 'Jetpack', 'Failed Disconnected Site' );
 		}, );
 

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -97,7 +97,7 @@ export class SiteSettingsComponent extends Component {
 						<JetpackDevModeNotice />
 					}
 					<SidebarNavigation />
-					{ site && <SiteSettingsNavigation site={ site } section={ section } /> |
+					{ site && <SiteSettingsNavigation site={ site } section={ section } /> }
 					<QueryProductsList />
 					{ site && <QuerySitePurchases siteId={ site.ID } /> }
 					{ site && this.getSection() }

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -97,7 +97,7 @@ export class SiteSettingsComponent extends Component {
 						<JetpackDevModeNotice />
 					}
 					<SidebarNavigation />
-					<SiteSettingsNavigation site={ site } section={ section } />
+					{ site && <SiteSettingsNavigation site={ site } section={ section } /> |
 					<QueryProductsList />
 					{ site && <QuerySitePurchases siteId={ site.ID } /> }
 					{ site && this.getSection() }


### PR DESCRIPTION
Lets Integrate the new Jetpack Disconnect Dialog into the Jetpack Disconnect Button

To test:
Go to Settings General and click the disconnect button. 
Do you see any error in console when disconnecting the site? 
