### PR TITLE
Reader: Update border/line grays

### DIFF
--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -15,12 +15,12 @@ $gray-text:              $gray-dark;
 $gray-text-min:          darken( $gray, 18% ); //#537994
 
 // $gray color functions:
-// lighten( $gray, 10% )
-// lighten( $gray, 20% )
-// lighten( $gray, 30% )
-// darken( $gray, 10% )
-// darken( $gray, 20% )
-// darken( $gray, 30% )
+// lighten( $gray, 10% ) //#a8bece
+// lighten( $gray, 20% ) //#c8d7e1
+// lighten( $gray, 30% ) //#e9eff3
+// darken( $gray, 10% ) //#668eaa
+// darken( $gray, 20% ) //#4f748e
+// darken( $gray, 30% ) //#3d596d
 //
 // See wordpress.com/design-handbook/colors/ for more info.
 
@@ -69,5 +69,3 @@ $color-print: #f8f8f8;
 $color-skype: #00AFF0;
 $color-telegram: #0088cc;
 $color-whatsapp: #43d854;
-
-

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -24,7 +24,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 .reader-post-card.card {
 
-	border-bottom: 1px solid lighten( $gray, 30% );
+	border-bottom: 1px solid lighten( $gray, 20% );
 	box-shadow: none;
 	margin: 0 15px;
 	padding: 18px 0 20px;

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -5,6 +5,6 @@
 .following__search.card.is-compact {
 	padding: 0;
 	margin-bottom: 16px;
-	box-shadow: 0 0 0 2px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 2px lighten( $gray, 20% ), 0 1px 2px lighten( $gray, 20% );
 	z-index: z-index( 'root', '.reader-following-search' );
 }

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -11,6 +11,7 @@
 .search-stream__fixed-area-separator {
 	margin-top: 31px;
 	margin-bottom: 0;
+	background: #c8d7e1;
 }
 
 .is-reader-page .search-stream .reader-post-card.card {
@@ -41,7 +42,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 }
 
 .is-reader-page .search-stream__input-card.card {
-	box-shadow: 0 0 0 2px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 2px lighten( $gray, 20% ), 0 1px 2px lighten( $gray, 20% );
  }
 
  .is-reader-page .search-stream__blank-suggestions {


### PR DESCRIPTION
This PR fixes #12291 by bringing consistency to all the Reader search input and line colorings, which are now lighten( $gray, 20% ); aka #c8d7e1. Specifically, the changes have been made to:

* On stream: the Search box, the line under Suggestions, and the separator line between posts.
* On search: the Search box, the line under Suggestions, and the separator line between posts.

Also added RGBA->Hex color mappings in `assets/stylesheets/shared/_colors.scss` for other Calypso SASS initiates.