### PR TITLE
Framework: Move `client/my-sites` from boot to section

### DIFF
--- a/client/boot/project/wordpress-com.js
+++ b/client/boot/project/wordpress-com.js
@@ -200,8 +200,6 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 		} );
 	}
 
-	require( 'my-sites' )();
-
 	if ( config.isEnabled( 'olark' ) ) {
 		asyncRequire( 'lib/olark', olark => olark.initialize( reduxStore.dispatch ) );
 	}

--- a/client/components/async-load/README.md
+++ b/client/components/async-load/README.md
@@ -36,3 +36,12 @@ In general usage, this should be passed as a string of the module to be imported
 </table>
 
 A placeholder to be shown while the module is being asynchronously required. If omitted, a default placeholder will be shown.
+
+### `noPlaceholder`
+
+<table>
+	<tr><td>Type</td><td>PropTypes.bool</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+A flag indicating if a placeholder should be hidden while the module is being asynchronously required. If omitted, the placeholder will be shown.

--- a/client/components/async-load/index.jsx
+++ b/client/components/async-load/index.jsx
@@ -6,8 +6,13 @@ import { omit } from 'lodash';
 
 export default class AsyncLoad extends Component {
 	static propTypes = {
+		noPlaceholder: PropTypes.bool,
+		placeholder: PropTypes.node,
 		require: PropTypes.func.isRequired,
-		placeholder: PropTypes.node
+	};
+
+	static defaultProps = {
+		noPlaceholder: false,
 	};
 
 	constructor() {
@@ -48,8 +53,12 @@ export default class AsyncLoad extends Component {
 
 	render() {
 		if ( this.state.component ) {
-			const props = omit( this.props, [ 'require', 'placeholder' ] );
+			const props = omit( this.props, [ 'noPlaceholder', 'placeholder', 'require' ] );
 			return <this.state.component { ...props } />;
+		}
+
+		if ( this.props.noPlaceholder ) {
+			return null;
 		}
 
 		if ( this.props.placeholder ) {

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -10,6 +10,7 @@ import { uniq, some, startsWith } from 'lodash';
 /**
  * Internal Dependencies
  */
+import AsyncLoad from 'components/async-load';
 import { SITES_ONCE_CHANGED } from 'state/action-types';
 import userFactory from 'lib/user';
 import { receiveSite, requestSites } from 'state/sites/actions';
@@ -27,7 +28,6 @@ import {
 } from 'state/ui/actions';
 import { savePreference } from 'state/preferences/actions';
 import { hasReceivedRemotePreferences, getPreference } from 'state/preferences/selectors';
-import NavigationComponent from 'my-sites/navigation';
 import route from 'lib/route';
 import notices from 'notices';
 import config from 'config';
@@ -89,7 +89,8 @@ function createNavigation( context ) {
 	}
 
 	return (
-		<NavigationComponent path={ context.path }
+		<AsyncLoad require="my-sites/navigation"
+			path={ context.path }
 			allSitesPath={ basePath }
 			siteBasePath={ basePath }
 			user={ user } />

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -10,7 +10,6 @@ import { uniq, some, startsWith } from 'lodash';
 /**
  * Internal Dependencies
  */
-import AsyncLoad from 'components/async-load';
 import { SITES_ONCE_CHANGED } from 'state/action-types';
 import userFactory from 'lib/user';
 import { receiveSite, requestSites } from 'state/sites/actions';
@@ -28,6 +27,7 @@ import {
 } from 'state/ui/actions';
 import { savePreference } from 'state/preferences/actions';
 import { hasReceivedRemotePreferences, getPreference } from 'state/preferences/selectors';
+import NavigationComponent from 'my-sites/navigation';
 import route from 'lib/route';
 import notices from 'notices';
 import config from 'config';
@@ -89,8 +89,7 @@ function createNavigation( context ) {
 	}
 
 	return (
-		<AsyncLoad require="my-sites/navigation"
-			path={ context.path }
+		<NavigationComponent path={ context.path }
 			allSitesPath={ basePath }
 			siteBasePath={ basePath }
 			user={ user } />

--- a/client/my-sites/current-site/domain-warnings.jsx
+++ b/client/my-sites/current-site/domain-warnings.jsx
@@ -11,10 +11,15 @@ import DomainWarnings from 'my-sites/upgrades/components/domain-warnings';
 import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
+import QuerySiteDomains from 'components/data/query-site-domains';
 
 const CurrentSiteDomainWarnings = ( { domains, isJetpack, selectedSiteId, selectedSite } ) => {
 	if ( ! selectedSiteId || isJetpack ) {
 		return null;
+	}
+
+	if ( ! domains.length ) {
+		return <QuerySiteDomains siteId={ selectedSiteId } />;
 	}
 
 	return (
@@ -23,14 +28,14 @@ const CurrentSiteDomainWarnings = ( { domains, isJetpack, selectedSiteId, select
 			selectedSite={ selectedSite }
 			domains={ domains }
 			ruleWhiteList={ [
+				'unverifiedDomainsCanManage',
+				'unverifiedDomainsCannotManage',
 				'expiredDomainsCanManage',
 				'expiringDomainsCanManage',
 				'expiredDomainsCannotManage',
 				'expiringDomainsCannotManage',
-				'pendingGappsTosAcceptanceDomains',
-				'unverifiedDomainsCanManage',
-				'unverifiedDomainsCannotManage',
 				'wrongNSMappedDomains',
+				'pendingGappsTosAcceptanceDomains',
 			] }
 		/>
 	);

--- a/client/my-sites/current-site/domain-warnings.jsx
+++ b/client/my-sites/current-site/domain-warnings.jsx
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import DomainWarnings from 'my-sites/upgrades/components/domain-warnings';
+import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+
+const CurrentSiteDomainWarnings = ( { domains, isJetpack, selectedSiteId, selectedSite } ) => {
+	if ( ! selectedSiteId || isJetpack ) {
+		return null;
+	}
+
+	return (
+		<DomainWarnings
+			isCompact
+			selectedSite={ selectedSite }
+			domains={ domains }
+			ruleWhiteList={ [
+				'expiredDomainsCanManage',
+				'expiringDomainsCanManage',
+				'expiredDomainsCannotManage',
+				'expiringDomainsCannotManage',
+				'pendingGappsTosAcceptanceDomains',
+				'unverifiedDomainsCanManage',
+				'unverifiedDomainsCannotManage',
+				'wrongNSMappedDomains',
+			] }
+		/>
+	);
+};
+
+CurrentSiteDomainWarnings.propTypes = {
+	domains: PropTypes.array,
+	isJetpack: PropTypes.bool,
+	selectedSite: PropTypes.object,
+	selectedSiteId: PropTypes.number,
+};
+
+export default connect(
+	state => {
+		const selectedSiteId = getSelectedSiteId( state );
+
+		return {
+			domains: getDecoratedSiteDomains( state, selectedSiteId ),
+			isJetpack: isJetpackSite( state, selectedSiteId ),
+			selectedSite: getSelectedSite( state ),
+			selectedSiteId,
+		};
+	}
+)( CurrentSiteDomainWarnings );

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -22,8 +22,6 @@ import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import Site from 'blocks/site';
 import SiteNotice from './notice';
 
-const EmptyComponent = () => null;
-
 class CurrentSite extends Component {
 	static propTypes = {
 		isPreviewShowing: React.PropTypes.bool,
@@ -92,7 +90,7 @@ class CurrentSite extends Component {
 					: <AllSites />
 				}
 				<AsyncLoad require="my-sites/current-site/domain-warnings"
-					placeholder={ <EmptyComponent /> } />
+					noPlaceholder={ true } />
 				<SiteNotice site={ selectedSite } />
 			</Card>
 		);

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -16,9 +16,8 @@ import Button from 'components/button';
 import Card from 'components/card';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedOrAllSites } from 'state/selectors';
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 import Gridicon from 'gridicons';
-import QuerySiteDomains from 'components/data/query-site-domains';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import Site from 'blocks/site';
 import SiteNotice from './notice';
@@ -30,7 +29,6 @@ class CurrentSite extends Component {
 		isPreviewShowing: React.PropTypes.bool,
 		siteCount: React.PropTypes.number.isRequired,
 		setLayoutFocus: React.PropTypes.func.isRequired,
-		selectedSiteId: React.PropTypes.number,
 		selectedSite: React.PropTypes.object,
 		translate: React.PropTypes.func.isRequired,
 		anySiteSelected: React.PropTypes.array
@@ -47,7 +45,7 @@ class CurrentSite extends Component {
 	previewSite = ( event ) => this.props.onClick && this.props.onClick( event );
 
 	render() {
-		const { selectedSite, selectedSiteId, translate, anySiteSelected } = this.props;
+		const { selectedSite, translate, anySiteSelected } = this.props;
 
 		if ( ! anySiteSelected.length ) {
 			return (
@@ -79,7 +77,6 @@ class CurrentSite extends Component {
 				}
 				{ selectedSite
 					? <div>
-						<QuerySiteDomains siteId={ selectedSiteId } />
 						<Site site={ selectedSite } />
 						<a
 							href={ selectedSite.URL }
@@ -104,11 +101,9 @@ class CurrentSite extends Component {
 
 export default connect(
 	( state ) => {
-		const selectedSiteId = getSelectedSiteId( state );
 		const user = getCurrentUser( state );
 
 		return {
-			selectedSiteId,
 			selectedSite: getSelectedSite( state ),
 			anySiteSelected: getSelectedOrAllSites( state ),
 			siteCount: get( user, 'visible_site_count', 0 ),

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -7,7 +7,7 @@ const sections = [
 		paths: [ '/sites' ],
 		module: 'my-sites',
 		group: 'sites',
-		secondary: true
+		secondary: false
 	},
 	{
 		name: 'customize',

--- a/server/bundler/bin/bundler.js
+++ b/server/bundler/bin/bundler.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --max_old_space_size=4096
 
 /**
  * External dependencies


### PR DESCRIPTION
Implements #12314: Async load sites section.

When thinking about sites section we refer to the code that is imported with this line of code: https://github.com/Automattic/wp-calypso/blob/5ec23905ced23ba7502f26ba270fce9ac2bc8623/client/boot/index.js#L361.

### Testing
1. Open Calypso using calypso.live branch or http://calypso.localhost:3000/.
2. Click My Sites button in the masterbar.
3. Make sure it works as before.
4. Navigate to a few subpages and make sure they still work.
5. Open /sites page and make sure it still works.

This is how current site should look like with domain warnings enabled:

![screen shot 2017-05-16 at 14 20 53](https://cloud.githubusercontent.com/assets/699132/26105621/f4f93d8c-3a42-11e7-82ab-5fe265da9bf2.png)


### Review

* [x] Code
* [x] Product