### PR TITLE
MagicSearch: animate initial suggestions/welcome opening.

### DIFF
--- a/client/components/suggestions/index.jsx
+++ b/client/components/suggestions/index.jsx
@@ -248,7 +248,18 @@ const Suggestions = React.createClass( {
 			noOfSuggestions += suggestions[ key ].length;
 		}
 
-		return <div className="suggestions__suggestions">{ rendered }</div>;
+		if ( rendered.length ) {
+			return <div className="suggestions__suggestions">{ rendered }</div>;
+		}
+
+		// inform that there are no suggestions at all for input
+		return (
+			<div className="suggestions__suggestions">
+				<div className="suggestions__category" key={ 'nothing' }>
+					{ this.translate( 'No suggestions found, try different phrase' ) }
+				</div>
+			</div>
+		);
 	},
 
 	render() {

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -264,22 +264,26 @@ class ThemesMagicSearchCard extends React.Component {
 						/>
 					}
 				</div>
-				{ renderSuggestions &&
-					<Suggestions
-						ref="suggestions"
-						terms={ taxonomies }
-						input={ this.state.editedSearchElement }
-						suggest={ this.suggest }
-					/>
-				}
-				{ ! renderSuggestions &&
-					<MagicSearchWelcome
-						ref="welcome"
-						taxonomies={ taxonomiesKeys }
-						topSearches={ [] }
-						suggestionsCallback={ this.insertTextInInput }
-					/>
-				}
+				<div className="themes-magic-search-card__overflowHidden">
+					{ this.state.searchIsOpen && <div className="themes-magic-search-card__slideDown" >
+						{ renderSuggestions &&
+							<Suggestions
+								ref="suggestions"
+								terms={ taxonomies }
+								input={ this.state.editedSearchElement }
+								suggest={ this.suggest }
+							/>
+						}
+						{ ! renderSuggestions &&
+							<MagicSearchWelcome
+								ref="welcome"
+								taxonomies={ taxonomiesKeys }
+								topSearches={ [] }
+								suggestionsCallback={ this.insertTextInInput }
+							/>
+						}
+					</div> }
+				</div>
 			</div>
 		);
 	}

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -38,6 +38,8 @@
 		flex: 0 0 auto;
 		min-width: 0;
 		padding: 11px 14px 11px;
+		// z-indes to match search - those elements are at the same level
+		z-index: z-index( 'root', '.search' );
 
 		.segmented-control__item,
 		.segmented-control__link,
@@ -210,4 +212,24 @@
 
 .themes-magic-search-card__welcome-taxonomy-icon {
 	pointer-events: none;
+}
+
+.themes-magic-search-card__overflowHidden {
+	overflow: hidden;
+}
+
+.themes-magic-search-card__slideDown {
+	animation-name: slideDown;
+	animation-duration: 0.3s;
+	animation-timing-function: ease-in-out;
+	visibility: visible !important;
+}
+
+@keyframes slideDown {
+	0% {
+		transform: translateY(-100%);
+	}
+	100% {
+		transform: translateY(0%);
+	}
 }


### PR DESCRIPTION
### Information
Add a bit of movement to the MagicSearch. Only animate initial opening of suggestions or welcome. When switching from welcome to suggestions and back no animations are applied ( looked awkward ). Basically it happens `onFocus` of the component.

Actual styling/tempo and animation needs designing - just wanted to check if this is possible to do within reason.

### How it looks
![animate-m5](https://cloud.githubusercontent.com/assets/17271089/24189966/5255dd64-0ee7-11e7-9b99-ce3468dbd8d6.gif)
