### PR TITLE
Site Settings: Move AMP to Traffic section

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -337,6 +337,7 @@
 @import 'my-sites/site-indicator/style';
 @import 'my-sites/site-settings/style';
 @import 'my-sites/site-settings/action-panel/style';
+@import 'my-sites/site-settings/amp/style';
 @import 'my-sites/site-settings/custom-content-types/style';
 @import 'my-sites/site-settings/comment-display-settings/style';
 @import 'my-sites/site-settings/date-time-format/style';

--- a/client/my-sites/site-settings/amp/style.scss
+++ b/client/my-sites/site-settings/amp/style.scss
@@ -1,0 +1,9 @@
+.amp__main {
+	.section-header__actions {
+		display: flex;
+
+		button {
+			margin-left: 15px;
+		}
+	}
+}

--- a/client/my-sites/site-settings/amp/wpcom.jsx
+++ b/client/my-sites/site-settings/amp/wpcom.jsx
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+import FormToggle from 'components/forms/form-toggle';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+
+class AmpWpcom extends Component {
+	static propTypes = {
+		submitForm: PropTypes.func.isRequired,
+		trackEvent: PropTypes.func.isRequired,
+		updateFields: PropTypes.func.isRequired,
+		isSavingSettings: PropTypes.bool,
+		isRequestingSettings: PropTypes.bool,
+		fields: PropTypes.object,
+	};
+
+	static defaultProps = {
+		isSavingSettings: false,
+		isRequestingSettings: true,
+		fields: {},
+	};
+
+	handleToggle = () => {
+		const { fields, submitForm, trackEvent, updateFields } = this.props;
+		updateFields( { amp_is_enabled: ! fields.amp_is_enabled }, () => {
+			submitForm();
+			trackEvent( 'Toggled AMP Toggle' );
+		} );
+	};
+
+	handleCustomize = () => {
+		this.props.trackEvent( 'Clicked AMP Customize button' );
+		page( '/customize/amp/' + this.props.siteSlug );
+	};
+
+	render() {
+		const {
+			fields: {
+				amp_is_supported: ampIsSupported,
+				amp_is_enabled: ampIsEnabled
+			},
+			isRequestingSettings,
+			isSavingSettings,
+			translate
+		} = this.props;
+
+		const isDisabled = isRequestingSettings || isSavingSettings;
+		const isCustomizeDisabled = isDisabled || ! ampIsEnabled;
+
+		if ( ! ampIsSupported ) {
+			return null;
+		}
+
+		return (
+			<div className="amp__main site-settings__amp">
+				<SectionHeader label={ translate( 'AMP' ) }>
+					<Button
+						compact
+						disabled={ isCustomizeDisabled }
+						onClick={ this.handleCustomize }>
+						{ translate( 'Edit Design' ) }
+					</Button>
+					<FormToggle
+						checked={ ampIsEnabled }
+						onChange={ this.handleToggle }
+						disabled={ isDisabled }
+					/>
+				</SectionHeader>
+				<Card className="amp__explanation site-settings__amp-explanation">
+					<p>
+						{ translate(
+							'Your WordPress.com site supports {{a}}Accelerated Mobile Pages (AMP){{/a}}, ' +
+							'a new Google-led initiative that dramatically improves loading speeds ' +
+							'on phones and tablets. {{a}}Learn More{{/a}}.',
+							{
+								components: {
+									a: <a
+										href="https://support.wordpress.com/google-amp-accelerated-mobile-pages/"
+										target="_blank" rel="noopener noreferrer" />
+								}
+							}
+						) }
+					</p>
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state ) => ( {
+		siteSlug: getSelectedSiteSlug( state ),
+	} )
+)( localize( AmpWpcom ) );

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import page from 'page';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import { get } from 'lodash';
@@ -24,7 +23,6 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLegend from 'components/forms/form-legend';
 import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
-import FormToggle from 'components/forms/form-toggle';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import Timezone from 'components/timezone';
@@ -227,75 +225,6 @@ class SiteSettingsFormGeneral extends Component {
 				}
 
 			</FormFieldset>
-		);
-	}
-
-	handleAmpToggle = () => {
-		const { fields, submitForm, trackEvent, updateFields } = this.props;
-		updateFields( { amp_is_enabled: ! fields.amp_is_enabled }, () => {
-			submitForm();
-			trackEvent( 'Toggled AMP Toggle' );
-		} );
-	};
-
-	handleAmpCustomize = () => {
-		this.props.trackEvent( 'Clicked AMP Customize button' );
-		page( '/customize/amp/' + this.props.site.slug );
-	};
-
-	renderAmpSection() {
-		if ( this.props.site.jetpack ) {
-			return;
-		}
-
-		const {
-			fields: {
-				amp_is_supported: ampIsSupported,
-				amp_is_enabled: ampIsEnabled
-			},
-			isRequestingSettings,
-			isSavingSettings,
-			translate
-		} = this.props;
-
-		const isDisabled = isRequestingSettings || isSavingSettings;
-		const isCustomizeDisabled = isDisabled || ! ampIsEnabled;
-
-		if ( ! ampIsSupported ) {
-			return null;
-		}
-
-		return (
-			<div className="site-settings__amp">
-				<SectionHeader label={ translate( 'AMP' ) }>
-					<Button
-						compact
-						disabled={ isCustomizeDisabled }
-						onClick={ this.handleAmpCustomize }>
-						{ translate( 'Edit Design' ) }
-					</Button>
-					<FormToggle
-						checked={ ampIsEnabled }
-						onChange={ this.handleAmpToggle }
-						disabled={ isDisabled } />
-				</SectionHeader>
-				<Card className="site-settings__amp-explanation">
-					<p>
-						{ translate(
-							'Your WordPress.com site supports {{a}}Accelerated Mobile Pages (AMP){{/a}}, ' +
-							'a new Google-led initiative that dramatically improves loading speeds ' +
-							'on phones and tablets. {{a}}Learn More{{/a}}.',
-							{
-								components: {
-									a: <a
-										href="https://support.wordpress.com/google-amp-accelerated-mobile-pages/"
-										target="_blank" rel="noopener noreferrer" />
-								}
-							}
-						) }
-					</p>
-				</Card>
-			</div>
 		);
 	}
 
@@ -577,8 +506,6 @@ class SiteSettingsFormGeneral extends Component {
 					</form>
 				</Card>
 
-				{ this.renderAmpSection() }
-
 				{
 					! site.jetpack && <div className="site-settings__footer-credit-container">
 						<SectionHeader label={ translate( 'Footer Credit' ) } />
@@ -667,8 +594,6 @@ export default wrapSettingsForm( settings => {
 		admin_url: '',
 		jetpack_sync_non_public_post_stati: false,
 		holidaysnow: false,
-		amp_is_supported: false,
-		amp_is_enabled: false,
 		api_cache: false,
 	};
 
@@ -687,9 +612,6 @@ export default wrapSettingsForm( settings => {
 		time_format: settings.time_format,
 		start_of_week: settings.start_of_week,
 		jetpack_sync_non_public_post_stati: settings.jetpack_sync_non_public_post_stati,
-
-		amp_is_supported: settings.amp_is_supported,
-		amp_is_enabled: settings.amp_is_enabled,
 
 		holidaysnow: !! settings.holidaysnow,
 

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -266,16 +266,6 @@
 	}
 }
 
-.site-settings__amp {
-	.section-header__actions {
-		display: flex;
-
-		button {
-			margin-left: 15px;
-		}
-	}
-}
-
 .site-settings__footer-credit-container {
 	margin-bottom: 16px;
 }

--- a/client/my-sites/site-settings/traffic/main.jsx
+++ b/client/my-sites/site-settings/traffic/main.jsx
@@ -18,6 +18,7 @@ import SeoSettingsHelpCard from 'my-sites/site-settings/seo-settings/help';
 import AnalyticsSettings from 'my-sites/site-settings/form-analytics';
 import JetpackSiteStats from 'my-sites/site-settings/jetpack-site-stats';
 import RelatedPosts from 'my-sites/site-settings/related-posts';
+import AmpWpcom from 'my-sites/site-settings/amp/wpcom';
 import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
@@ -27,12 +28,16 @@ const SiteSettingsTraffic = ( {
 	jetpackSettingsUiSupported,
 	handleAutosavingToggle,
 	handleSubmitForm,
+	isJetpack,
 	isRequestingSettings,
 	isSavingSettings,
 	setFieldValue,
 	site,
 	sites,
+	submitForm,
+	trackEvent,
 	translate,
+	updateFields,
 	upgradeToBusiness
 } ) => (
 	<Main className="traffic__main site-settings">
@@ -56,6 +61,17 @@ const SiteSettingsTraffic = ( {
 			isRequestingSettings={ isRequestingSettings }
 			fields={ fields }
 		/>
+		{
+			! isJetpack &&
+			<AmpWpcom
+				submitForm={ submitForm }
+				trackEvent={ trackEvent }
+				updateFields={ updateFields }
+				isSavingSettings={ isSavingSettings }
+				isRequestingSettings={ isRequestingSettings }
+				fields={ fields }
+			/>
+		}
 		<AnalyticsSettings />
 		<SeoSettingsHelpCard />
 		<SeoSettingsMain sites={ sites } upgradeToBusiness={ upgradeToBusiness } />
@@ -76,6 +92,7 @@ const connectComponent = connect(
 
 		return {
 			site,
+			isJetpack,
 			jetpackSettingsUiSupported,
 		};
 	}
@@ -91,6 +108,8 @@ const getFormSettings = partialRight( pick, [
 	'jetpack_relatedposts_enabled',
 	'jetpack_relatedposts_show_headline',
 	'jetpack_relatedposts_show_thumbnails',
+	'amp_is_supported',
+	'amp_is_enabled',
 ] );
 
 export default flowRight(


### PR DESCRIPTION
This PR moves .com AMP from the general form to a separate component, and embeds it into the Traffic section tab. Fixes #12273.

Placement of the AMP card before this PR:
![](https://cldup.com/ghhf7sFLNR.png)

Placement of the AMP card proposed in the PR:
![](https://cldup.com/xG0P9nwinr.png)

_Note: Related Posts has been moved to Traffic recently (in #12271). The "before" screenshot is taken after that move._

Also, for reference, we're tracking the implementation of the AMP card for Jetpack sites in #12367.

To test:
* Checkout this branch or get it going on calypso.live
* Go to `/settings/traffic/$site` where `$site` is one of your WordPress.com sites.
* Verify the AMP card is there, below the Related Posts card.
* Play with the AMP card toggle and button, verify it all works like it did before.
* Go to `/settings/traffic/$site` where `$site` is one of your connected Jetpack sites.
* Verify the AMP card is not displayed.