### PR TITLE
Improve editor on mobile, and remove hoz scrollbar when sidebar open

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -20,9 +20,9 @@
 	}
 
 	@include breakpoint( "<660px" ) {
-		left: -100vw;
-		width: 100vw;
-		max-height: calc(100vh - 47px );
+		left: -100%;
+		width: 100%;
+		max-height: calc( 100% - 47px );
 		pointer-events: none;
 		transform: translateX( 0 );
 		transition: all 0.15s cubic-bezier(0.770, 0.000, 0.175, 1.000);
@@ -30,11 +30,11 @@
 		.focus-sidebar & {
 			pointer-events: auto;
 			-webkit-overflow-scrolling: touch;
-			transform: translateX( 100vw );
+			transform: translateX( 100% );
 		}
 
 		.focus-sites & {
-			transform: translateX( 100vw );
+			transform: translateX( 100% );
 		}
 	}
 

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -98,7 +98,7 @@
 		pointer-events: auto;
 
 		@include breakpoint( "<660px" ) {
-			transform: translateX( 100vw );
+			transform: translateX( 100% );
 		}
 	}
 
@@ -146,8 +146,8 @@
 	}
 
 	@include breakpoint( "<660px" ) {
-		width: 100vw;
-		left: -100vw;
+		width: 100%;
+		left: -100%;
 		-webkit-overflow-scrolling: touch;
 	}
 

--- a/client/post-editor/editor-post-formats/index.jsx
+++ b/client/post-editor/editor-post-formats/index.jsx
@@ -93,9 +93,7 @@ const EditorPostFormats = React.createClass( {
 						/>
 						<span className="editor-post-formats__format-label">
 							<span className={ 'editor-post-formats__format-icon' } >
-								{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
-								<Gridicon icon={ this.getPostFormatIcon( postFormatSlug ) } size={ 20 } />
-								{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
+								<Gridicon icon={ this.getPostFormatIcon( postFormatSlug ) } size={ 18 } />
 							</span>
 							{ postFormatLabel }
 						</span>

--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -23,6 +23,7 @@
 		left: 0;
 		height: 0;
 		transition: none;
+		border-left: none;
 
 		.focus-sidebar & {
 			height: auto;

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -19,6 +19,11 @@
 	.is-group-editor.focus-sidebar::before {
 		background-color: lighten( $gray, 30% );
 	}
+
+	.is-group-editor .sidebar {
+		right: auto;
+	}
+
 }
 
 .is-group-editor .layout__content {

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -29,12 +29,6 @@
 .post-editor__inner {
 	position: relative;
 	top: 47px;
-
-	@include breakpoint( "<660px" ) {
-		overflow-x: hidden;
-		margin-bottom: 47px;
-		border-bottom: 1px solid lighten( $gray, 20 );
-	}
 }
 
 .post-editor__content {


### PR DESCRIPTION
This PR increases vertical space in the editor on mobile, by removing a bottom margin that didn't seem to do anything at all.

Additionally, it removes a horizontal scrollbar when looking at <660px breakpoint, which was hidden using `overflow-x: hidden;`. This came from the use of `vw` as a unit, instead of `%`. The former is the full viewport width, including the scrollbar, which makes it a virtually useless unit except for some edgecases.

Screenshots, before:

![screen shot 2017-03-22 at 11 53 57](https://cloud.githubusercontent.com/assets/1204802/24194909/14ee8280-0ef8-11e7-88f3-800af77aae70.png)

![screen shot 2017-03-22 at 11 54 07](https://cloud.githubusercontent.com/assets/1204802/24194912/17d8adcc-0ef8-11e7-822e-1e67868b1bdc.png)

After:

![screen shot 2017-03-22 at 11 59 48](https://cloud.githubusercontent.com/assets/1204802/24194955/3825ef72-0ef8-11e7-8f92-17c987ff2143.png)

![screen shot 2017-03-22 at 11 59 59](https://cloud.githubusercontent.com/assets/1204802/24194964/3cba28e6-0ef8-11e7-81f9-86f4b154e14d.png)

This was the offending code:

```
@include breakpoint( "<660px" ) {		
	overflow-x: hidden;		
	margin-bottom: 47px;		
	border-bottom: 1px solid lighten( $gray, 20 );		
}
```

Because I don't understand the history of why this CSS was added, ping @mtias, you may know some of the context here. The `vw` unit goes way back to the initial commit of the sidebar CSS code, so that's a BIG change. Before I ask for wide testing (in my minimal testing, nothing broke), I'd like to understand the context so I don't include this change just because it seems obvious. 