### PR TITLE
A/B Test: Calypso signup step 1 mobile optimization

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -25,6 +25,14 @@ module.exports = {
 		},
 		defaultVariation: 'original',
 	},
+	signupStepOneMobileOptimize: {
+		datestamp: '20170322',
+		variations: {
+			original: 50,
+			modified: 50,
+		},
+		defaultVariation: 'original',
+	},
 	readerPostCardTagCount: {
 		datestamp: '20170315',
 		variations: {

--- a/client/signup/step-header/style.scss
+++ b/client/signup/step-header/style.scss
@@ -29,3 +29,12 @@
 		padding: 0 20px;
 	}
 }
+
+.step-wrapper--mobile-test {
+	@include breakpoint( "<480px" ) {
+		.step-header__title {
+		    line-height: 1.2em;
+		    padding: 0 10px;
+		}
+	}
+}

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -9,6 +9,7 @@ import classNames from 'classnames';
  */
 import StepHeader from 'signup/step-header';
 import NavigationLink from 'signup/navigation-link';
+import { abtest } from 'lib/abtest';
 
 export default React.createClass( {
 	displayName: 'StepWrapper',
@@ -75,7 +76,8 @@ export default React.createClass( {
 	render: function() {
 		const { stepContent, headerButton } = this.props;
 		const classes = classNames( 'step-wrapper', {
-			'is-wide-layout': this.props.isWideLayout
+			'is-wide-layout': this.props.isWideLayout,
+			'step-wrapper--mobile-test': abtest( 'signupStepOneMobileOptimize' ) === 'modified',
 		} );
 
 		return (

--- a/client/signup/steps/design-type-with-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/index.jsx
@@ -112,9 +112,13 @@ class DesignTypeWithStoreStep extends Component {
 
 		if ( abtest( 'signupStepOneCopyChanges' ) === 'modified' ) {
 			choiceLabel = null;
-			choiceCardClass = 'design-type-with-store__choice design-type-with-store__choice--test';
+			choiceCardClass += ' design-type-with-store__choice--test';
 			choiceDescription = <p className="design-type-with-store__choice-description">{ choice.description }</p>;
 			callToAction = <span className="button is-compact design-type-with-store__cta">Start with {choice.label}</span>;
+		}
+
+		if ( abtest( 'signupStepOneMobileOptimize' ) === 'modified' ) {
+			choiceCardClass += ' design-type-with-store__choice--mobile-test';
 		}
 
 		return (

--- a/client/signup/steps/design-type-with-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/index.jsx
@@ -39,19 +39,19 @@ class DesignTypeWithStoreStep extends Component {
 			// Note: Don't make this translatable because it's only visible to English-language users
 			return [
 				{ type: 'blog',
-					label: 'A blog',
+					label: 'a blog',
 					description: 'To share your ideas, stories, and photographs with your followers.',
 					image: <BlogImage /> },
 				{ type: 'page',
-					label: 'A website',
+					label: 'a website',
 					description: 'To promote your business, organization, or brand and connect with your audience.',
 					image: <PageImage /> },
 				{ type: 'grid',
-					label: 'A portfolio',
+					label: 'a portfolio',
 					description: 'To present your creative projects in a visual showcase.',
 					image: <GridImage /> },
 				{ type: 'store',
-					label: 'An online store',
+					label: 'an online store',
 					description: 'To sell your products or services and accept payments.',
 					image: <StoreImage /> },
 			];
@@ -126,7 +126,9 @@ class DesignTypeWithStoreStep extends Component {
 				<a className="design-type-with-store__choice-link"
 					href="#"
 					onClick={ this.handleChoiceClick( choice.type ) }>
-					{ choice.image }
+					<div className="design-type-with-store__image">
+						{ choice.image }
+					</div>
 					<div className="design-type-with-store__choice-copy">
 						{ choiceLabel }
 						{ callToAction }

--- a/client/signup/steps/design-type-with-store/style.scss
+++ b/client/signup/steps/design-type-with-store/style.scss
@@ -93,3 +93,97 @@
 	font-size: 0.875em;
 	width: 100%;
 }
+
+.design-type-with-store__choice--mobile-test {
+	@include breakpoint( "<480px" ) {
+		margin-bottom: 0;
+		text-align: left;
+		position: relative;
+		border: 1px solid lighten( $gray, 20% );
+		border-bottom: 0;
+		box-shadow: none;
+
+		&:first-child {
+			border-top-right-radius: 6px;
+			border-top-left-radius: 6px;
+		}
+		
+		&:last-of-type {
+			margin-bottom: 20px;
+			border: 1px solid lighten( $gray, 20% );
+			border-bottom-right-radius: 6px;
+			border-bottom-left-radius: 6px;
+		}
+
+		&:hover {
+			box-shadow: none;
+		}
+
+		&:active {
+			.design-type-with-store__cta {
+				color: $blue-dark;
+			}
+
+			.design-type-with-store__choice-link:after {
+				border-top-color: $blue-dark;
+				border-right-color: $blue-dark;
+			}
+		}
+
+		.design-type-with-store__choice-link {
+			padding-right: 40px;
+			display: block;
+			box-sizing: border-box;
+
+			&:after {
+				content: '';
+				display: block;
+				width: 8px; //Match the size of the cta copy
+				height: 8px; //Match the size of the cta copy
+				position: absolute;
+				top: 20px;
+				right: 15px;
+				border-top: 2px solid lighten( $gray, 20% );
+				border-right: 2px solid lighten( $gray, 20% );
+				transform: rotate(45deg);
+			}
+		}
+
+		.design-type-with-store__image {
+			display: none;
+		}
+
+		.design-type-with-store__choice-copy {
+			border-top: 0;
+		}
+
+		//Reset button for now. If this test passes, we should remove button class.
+		.design-type-with-store__cta {
+			background: none;
+			font-size: 1.1em;
+			border: 0;
+			padding: 0;
+			text-transform: none;
+			margin: 0;
+			line-height: 1.1em;
+		}
+
+		.design-type-with-store__choice-description {
+			margin-top: 0;
+		}
+	}
+
+	@include breakpoint( ">480px" ) {
+		.design-type-with-store__image {
+			display: block;
+		}
+	}
+}
+
+.step-wrapper--mobile-test {
+	@include breakpoint( "<480px" ) {
+		.design-type-with-store__disclaimer {
+			padding: 0 20px;
+		}
+	}
+}


### PR DESCRIPTION
This PR a new a/b test to see if we can convert more people on mobile devices. I've currently just setup the a/b test but will continue to push code and update this description. 

## Hypothesis
Optimizing the design for step 1 of our Calypso signup flow on small screens will increase the number of people completing that step on mobile devices.

## Why
We recently improved conversions for the first step of our Calypso signup funnel with some copy changes. The changes mostly effected desktop users while conversions remained relatively the same on mobile. Over the last 3 months, only 45% of visitors on mobile complete the first step of our signup compared to 59% on desktop.

## Test parameters
**TestName:** signupStepOneMobileOptimize
**Variations:** Original 50% — Modified 50%
**Traffic:** TBD.
**Baseline Conversion Rate (BCR):** 45%
**Minimum Detectable Effect (MDE):** TBD
**Sample size (MSS):** TBD
**Duration:** TBD
**Start:** 2017-03-27
**End:** 2017-04-03

## Screenshots
control: `original`
<img width="373" alt="current" src="https://cloud.githubusercontent.com/assets/6981253/24259901/9c8f7b74-0fc8-11e7-8143-f39874e0cae4.png">


test: `modified`
<img width="376" alt="screen shot 2017-03-23 at 11 35 09 am" src="https://cloud.githubusercontent.com/assets/6981253/24259896/9972c04a-0fc8-11e7-9bda-eaa0ac1103db.png">
