### PR TITLE
Framework: Remove atob dependency and build a new shrinkwrap

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -135,9 +135,6 @@
     "asynckit": {
       "version": "0.4.0"
     },
-    "atob": {
-      "version": "1.1.2"
-    },
     "autoprefixer": {
       "version": "6.3.5"
     },
@@ -2088,7 +2085,7 @@
       "version": "1.0.0"
     },
     "isexe": {
-      "version": "1.1.2"
+      "version": "2.0.0"
     },
     "isobject": {
       "version": "2.1.0"
@@ -4394,7 +4391,7 @@
       "dev": true
     },
     "which": {
-      "version": "1.2.12"
+      "version": "1.2.14"
     },
     "which-module": {
       "version": "1.0.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "main": "index.js",
   "dependencies": {
     "async": "0.9.0",
-    "atob": "1.1.2",
     "autoprefixer": "6.3.5",
     "autosize": "3.0.15",
     "babel-core": "6.9.1",


### PR DESCRIPTION
It seems that `atob` is no longer needed and can be removed from the list of dependencies. It appears that its last usage was in the legacy `server/list-routes` (see 2697-gh-calypso-pre-oss), which has been removed some time ago in 11984-gh-calypso-pre-oss.

So, this PR removes the `atob` dependency and builds a new `npm-shrinkwrap`.

To test:
* Verify Calypso builds correctly without `atob`.
* Perform a [smoke test](https://github.com/Automattic/wp-e2e-tests).