### PR TITLE
Site Settings: Use DocumentHead in Traffic section

### DIFF
--- a/client/my-sites/site-settings/traffic/controller.js
+++ b/client/my-sites/site-settings/traffic/controller.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import i18n from 'i18n-calypso';
 import page from 'page';
 import React from 'react';
 
@@ -13,20 +12,16 @@ import { renderWithReduxStore } from 'lib/react-helpers';
 import route from 'lib/route';
 import TrafficMain from 'my-sites/site-settings/traffic/main';
 import sitesFactory from 'lib/sites-list';
-import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import utils from 'lib/site/utils';
 
 const sites = sitesFactory();
 
 export default {
 	traffic( context ) {
-		const analyticsPageTitle = 'Site Settings > SEO';
+		const analyticsPageTitle = 'Site Settings > Traffic';
 		const basePath = route.sectionify( context.path );
 		const fiveMinutes = 5 * 60 * 1000;
 		let site = sites.getSelectedSite();
-
-		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-		context.store.dispatch( setTitle( i18n.translate( 'Site Settings', { textOnly: true } ) ) );
 
 		// if site loaded, but user cannot manage site, redirect
 		if ( site && ! utils.userCan( 'manage_options', site ) ) {

--- a/client/my-sites/site-settings/traffic/main.jsx
+++ b/client/my-sites/site-settings/traffic/main.jsx
@@ -3,12 +3,14 @@
  */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 import { flowRight, partialRight, pick } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Main from 'components/main';
+import DocumentHead from 'components/data/document-head';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
 import SeoSettingsMain from 'my-sites/site-settings/seo-settings/main';
@@ -30,9 +32,11 @@ const SiteSettingsTraffic = ( {
 	setFieldValue,
 	site,
 	sites,
+	translate,
 	upgradeToBusiness
 } ) => (
 	<Main className="traffic__main site-settings">
+		<DocumentHead title={ translate( 'Site Settings' ) } />
 		<SidebarNavigation />
 		<SiteSettingsNavigation site={ site } section="traffic" />
 
@@ -91,5 +95,6 @@ const getFormSettings = partialRight( pick, [
 
 export default flowRight(
 	connectComponent,
+	localize,
 	wrapSettingsForm( getFormSettings )
 )( SiteSettingsTraffic );


### PR DESCRIPTION
This PR removes the usage of `setDocumentHeadTitle` in the Traffic controller and replaces it with using the recommended `<DocumentHead />` component.

To test:
* Checkout this branch or get it going on calypso.live
* Go to `/settings/traffic/$site` where `$site` is one of your sites.
* Verify site title is set properly.