### PR TITLE
Fix DevDocs display/search collection when a component is conditionally rendered

### DIFF
--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -35,7 +35,7 @@ const Collection = ( { children, filter, section = 'design', component } ) => {
 	const summary = [];
 
 	const examples = React.Children.map( children, ( example ) => {
-		if ( ! shouldShowInstance( example, filter, component ) ) {
+		if ( ! example || ! shouldShowInstance( example, filter, component ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
This PR fixes DevDocs display/search when a component is conditionally rendered (such as NpsSurvey).

To test:

Run with nps-survey disabled and make sure `http://calypso.localhost:3000/devdocs/blocks` loads correctly:

```
DISABLE_FEATURES=nps-survey/devdocs make run
```