### PR TITLE
Posts: Modify widths for Blog Post and Latest Draft lists

### DIFF
--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -12,6 +12,10 @@
 .posts__primary {
 	flex-grow: 1;
 	max-width: 720px;
+
+	@include breakpoint( ">1280px" ) {
+		min-width: 520px;
+	}
 }
 
 .posts__list {
@@ -622,9 +626,12 @@
 
 	@include breakpoint( ">1280px" ) {
 		display: block;
+		max-width: 400px;
 	}
 
 	@include breakpoint( ">1600px" ) {
+		max-width: 600px;
+
 		.post-item.is-mini.card.is-compact {
 			padding: 16px 24px;
 


### PR DESCRIPTION
As described in #12099, if you have a long title in the drafts container in the post list, the container can squish the main post list or push it out of view. This PR sets a max width on the draft container for >1280px screens so this doesn't happen. 

While testing this, I also noticed that on larger screens (>1280px), it's possible for the main post list to get pushed out of view as shown here (this is at 1281px view with the max-width set on the drafts container):

<img width="1292" alt="screen shot 2017-03-22 at 7 46 00 am" src="https://cloud.githubusercontent.com/assets/7240478/24200765/b5a9dadc-0ed3-11e7-91ba-493574183752.png">

To fix this, I set a min-width of 520px on `.posts__primary` on screens larger than 1280px. Background behind the specific sizes below :)

## Previous

**1281px**
<img width="1282" alt="screen shot 2017-03-22 at 7 51 41 am" src="https://cloud.githubusercontent.com/assets/7240478/24201005/6fef3b58-0ed4-11e7-89a7-a314a6b4f60b.png">

## Updated

**2556px**
<img width="2555" alt="2556px" src="https://cloud.githubusercontent.com/assets/7240478/24201055/97c65a8a-0ed4-11e7-8285-b5b949442c3b.png">

**1281px**
<img width="1277" alt="1281px" src="https://cloud.githubusercontent.com/assets/7240478/24201059/9ceadb62-0ed4-11e7-843b-818cf6dacc7a.png">

**1280px**
<img width="1283" alt="1280px" src="https://cloud.githubusercontent.com/assets/7240478/24201063/a206ee56-0ed4-11e7-8e9b-18fdf31faea2.png">


To determine the widths to set, I took into account the layout at 1281px. We [set a left padding of 304px](https://github.com/Automattic/wp-calypso/blob/0b5e25559e3a7cd6a5f858047da1f47b2661cb91/client/layout/style.scss#L14) on the main layout content. `.posts__recent-drafts` has a left margin of 24px. This left 952px of remaining space to use. I used 400px for the recent drafts and 520px for the main post list.