### PR TITLE
Add back eslint max-len of 140 characters

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,5 +13,6 @@ module.exports = {
 	rules: {
 		camelcase: 0, // REST API objects include underscores
 		'no-unused-expressions': 0, // Allows Chai `expect` expressions
+		'max-len': [ 1, { code: 140 } ],
 	}
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,6 @@ module.exports = {
 	rules: {
 		camelcase: 0, // REST API objects include underscores
 		'no-unused-expressions': 0, // Allows Chai `expect` expressions
-		'max-len': [ 1, { code: 140 } ],
+		'max-len': [ 2, { code: 140 } ],
 	}
 };


### PR DESCRIPTION
#6945 was a great effort that cleaned up a lot and will allow us to push only clean and compatible code. However, it also removed the `max-len` ESLint rule, which was previously set to 140 characters. The default value is 100, which means that it'll blow up almost everywhere - we have a ton of code with lines between 101 and 140 characters. 

This PR adds back that rule, which I think is necessary. Unless there was a discussion about reducing the max length of lines to 100 characters, and I missed it?