### PR TITLE
Sites: Add a delay to the search for site selector

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -393,6 +393,7 @@ const SiteSelector = React.createClass( {
 				<Search
 					ref="siteSearch"
 					onSearch={ this.onSearch }
+					delaySearch={ true }
 					autoFocus={ this.props.autoFocus }
 					disabled={ ! this.props.sites.initialized }
 					onSearchClose={ this.props.onClose }


### PR DESCRIPTION
Right now we fire off a search instantly on every keypress. For users with a lot of sites (I have 300+), that first keypress is painful and feels really laggy.

This turns on the delaySearch feature of the search input, which debounces keypresses a bit and gives the user more time to type more than one character. This in turn makes the search feel much much faster.

To test, find a test user that has a lot of sites (I have 345 total, 25 showing, 320 hidden). Open any site selector (under Write, or the sidebar picker in My Sites) and search for something. 