### PR TITLE
Add Publicize scheduling share previews scaffolding

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -145,7 +145,8 @@
 @import 'components/segmented-control/style';
 @import 'components/select-dropdown/style';
 @import 'components/seo/style';
-@import 'components/share/style';
+@import 'components/share/facebook-share-preview/style';
+@import 'components/share/twitter-share-preview/style';
 @import 'blocks/upgrade-nudge-expanded/style';
 @import 'components/seo/preview-upgrade-nudge/style';
 @import 'components/signup-form/style';

--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -52,7 +52,6 @@ class SharingPreviewPane extends PureComponent {
 				return <FacebookSharePreview
 					title={ seoTitle }
 					url={ get( post, 'URL', '' ) }
-					type="article"
 					description={ getExcerptForPost( post ) }
 					image={ getPostImage( post ) }
 					author={ get( post, 'author.name', '' ) }

--- a/client/blocks/sharing-preview-pane/style.scss
+++ b/client/blocks/sharing-preview-pane/style.scss
@@ -10,10 +10,10 @@
 }
 
 .sharing-preview-pane__sidebar {
-	display: flex;
-	flex-direction: column;
-
 	background-color: $white;
+	display: flex;
+	flex: 0 0 auto;
+	flex-direction: column;
 
 	.vertical-menu {
 		flex-direction: row;
@@ -57,9 +57,8 @@
 	}
 
 	@include breakpoint( ">660px" ) {
-		width: 250px;
-		min-width: 250px;
 		border-right: 1px solid lighten( $gray, 20% );
+		flex: 0 0 250px;
 	}
 }
 
@@ -86,16 +85,9 @@
 }
 
 .sharing-preview-pane__preview-area {
-	margin: 10px auto;
-}
-
-.sharing-preview-pane__preview {
-	min-width: 400px;
-	height: auto;
-	margin: 0 10px;
-
-	background-color: $white;
-	border: 1px solid lighten( $gray, 25% );
+	background-color: #f2f6f8;
+	flex: 1 1 auto;
+	padding: 10px;
 }
 
 .sharing-preview-pane__message {

--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -25,7 +25,7 @@ export class FacebookSharePreview extends PureComponent {
 						</div>
 						<div className="facebook-share-preview__profile-line-part">
 							<div className="facebook-share-preview__profile-line">
-								<a href={ externalProfileUrl }>
+								<a className="facebook-share-preview__profile-name" href={ externalProfileUrl }>
 									{ externalName }
 								</a>
 								published an article on
@@ -33,8 +33,10 @@ export class FacebookSharePreview extends PureComponent {
 									WordPress.
 								</a>
 							</div>
-							<div className="facebook-share-preview__wp-line">
-								WordPress
+							<div className="facebook-share-preview__meta-line">
+								<a href="https://wordpress.com">
+									WordPress
+								</a>
 							</div>
 						</div>
 					</div>
@@ -42,8 +44,11 @@ export class FacebookSharePreview extends PureComponent {
 						<div className="facebook-share-preview__message">
 							{ message }
 						</div>
-						<div className="facebook-share-preview__article-url">
-							{ articleUrl }
+						<div className="facebook-share-preview__article-url-line">
+							<a className="facebook-share-preview__article-url"
+								href={ articleUrl }>
+								{ articleUrl }
+							</a>
 						</div>
 						{ imageUrl &&
 							<div className="facebook-share-preview__image-wrapper">

--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -1,78 +1,63 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, PureComponent } from 'react';
-import compact from 'lodash/compact';
-
-import {
-	firstValid,
-	hardTruncation,
-	shortEnough
-} from '../helpers';
-
-//Mostly copied from Seo Preview
-
-const TITLE_LENGTH = 80;
-const DESCRIPTION_LENGTH = 270;
-
-const baseDomain = url =>
-	url
-		.replace( /^[^/]+[/]*/, '' ) // strip leading protocol
-		.replace( /\/.*$/, '' ); // strip everything after the domain
-
-const facebookTitle = firstValid(
-	shortEnough( TITLE_LENGTH ),
-	hardTruncation( TITLE_LENGTH )
-);
-
-const facebookDescription = firstValid(
-	shortEnough( DESCRIPTION_LENGTH ),
-	hardTruncation( DESCRIPTION_LENGTH )
-);
+import React, { PureComponent } from 'react';
 
 export class FacebookSharePreview extends PureComponent {
 	render() {
-		const {
-			url,
-			type,
-			title,
-			description,
-			image,
-			author
-		} = this.props;
+		// TODO: use real data
+		const externalProfilePicture = 'https://3.bp.blogspot.com/-W__wiaHUjwI/Vt3Grd8df0I/AAAAAAAAA78/7xqUNj8ujtY/s1600/image02.png';
+		const externalProfileUrl = 'https://example.com';
+		const externalName = 'Style and Gear';
+		const message = 'Do you have a trip coming up? Check out this winter travel gear roundup!';
+		const articleUrl = 'https://styleandgear.com/2016/01/03/how-to-dress-like-a-proper-we-need-some-long-url';
+		const imageUrl = 'https://www.w3schools.com/css/trolltunga.jpg';
 
 		return (
-			<div className={ `facebook-share-preview facebook-share-preview__${ type }` }>
+			<div className="facebook-share-preview">
 				<div className="facebook-share-preview__content">
-					{ image &&
-					<div className="facebook-share-preview__image">
-						<img src={ image } />
+					<div className="facebook-share-preview__header">
+						<div className="facebook-share-preview__profile-picture-part">
+							<img
+								className="facebook-share-preview__profile-picture"
+								src={ externalProfilePicture }
+							/>
+						</div>
+						<div className="facebook-share-preview__profile-line-part">
+							<div className="facebook-share-preview__profile-line">
+								<a href={ externalProfileUrl }>
+									{ externalName }
+								</a>
+								published an article on
+								<a href="https://wordpress.com">
+									WordPress.
+								</a>
+							</div>
+							<div className="facebook-share-preview__wp-line">
+								WordPress
+							</div>
+						</div>
 					</div>
-					}
 					<div className="facebook-share-preview__body">
-						<div className="facebook-share-preview__title">
-							{ facebookTitle( title || '' ) }
+						<div className="facebook-share-preview__message">
+							{ message }
 						</div>
-						<div className="facebook-share-preview__description">
-							{ facebookDescription( description || '' ) }
+						<div className="facebook-share-preview__article-url">
+							{ articleUrl }
 						</div>
-						<div className="facebook-share-preview__url">
-							{ compact( [ baseDomain( url ), author ] ).join( ' | ' ) }
-						</div>
+						{ imageUrl &&
+							<div className="facebook-share-preview__image-wrapper">
+								<img
+									className="facebook-share-preview__image"
+									src={ imageUrl }
+								/>
+							</div>
+						}
 					</div>
 				</div>
 			</div>
 		);
 	}
 }
-
-FacebookSharePreview.propTypes = {
-	url: PropTypes.string,
-	type: PropTypes.string,
-	title: PropTypes.string,
-	description: PropTypes.string,
-	image: PropTypes.string,
-	author: PropTypes.string
-};
 
 export default FacebookSharePreview;

--- a/client/components/share/facebook-share-preview/style.scss
+++ b/client/components/share/facebook-share-preview/style.scss
@@ -1,0 +1,73 @@
+.facebook-share-preview {
+	background-color: $white;
+	border: 1px solid;
+	border-color: #e5e6e9 #dfe0e4 #d0d1d5;
+	border-radius: 3px;
+	color: #1d2129;
+	margin: 0 auto;
+	max-width: 486px;
+	padding: 12px;
+	-webkit-overflow-scrolling: touch;
+}
+
+.facebook-share-preview a {
+	color: #365899;
+}
+
+.facebook-share-preview__header {
+	display: flex;
+	margin-bottom: 6px;
+}
+
+.facebook-share-preview__profile-picture-part {
+	flex: 0 0 40px;
+	margin-right: 8px;
+	width: 40px;
+}
+
+.facebook-share-preview__profile-picture,
+.facebook-share-preview__image {
+	display: block;
+}
+
+.facebook-share-preview__profile-line,
+.facebook-share-preview__body {
+	font-size: 14px;
+	line-height: 1.38;
+}
+
+.facebook-share-preview__profile-line {
+	color: #90949c;
+	margin-bottom: 2px;
+}
+
+.facebook-share-preview__profile-name {
+	font-weight: bold;
+}
+
+.facebook-share-preview__meta-line {
+	color: #90949c;
+	font-size: 12px;
+	line-height: 1.34;
+}
+
+.facebook-share-preview .facebook-share-preview__meta-line a {
+	color: #90949c;
+}
+
+.facebook-share-preview__message p {
+	margin-bottom: 6px;
+}
+
+.facebook-share-preview__message p:last-child {
+	margin-bottom: 0;
+}
+
+.facebook-share-preview__article-url-line {
+	margin-top: 6px;
+	word-break: break-word;
+}
+
+.facebook-share-preview__image-wrapper {
+	margin-top: 10px;
+}

--- a/client/components/share/twitter-share-preview/index.jsx
+++ b/client/components/share/twitter-share-preview/index.jsx
@@ -41,8 +41,11 @@ export class TwitterSharePreview extends PureComponent {
 						<div className="twitter-share-preview__message">
 							{ message }
 						</div>
-						<div className="twitter-share-preview__article-url">
-							{ articleUrl }
+						<div className="twitter-share-preview__article-url-line">
+							<a className="twitter-share-preview__article-url"
+								href={ articleUrl }>
+								{ articleUrl }
+							</a>
 						</div>
 						{ imageUrl &&
 							<div className="twitter-share-preview__image-wrapper">

--- a/client/components/share/twitter-share-preview/index.jsx
+++ b/client/components/share/twitter-share-preview/index.jsx
@@ -1,58 +1,62 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, PureComponent } from 'react';
-
-const baseDomain = url =>
-	url
-		.replace( /^[^/]+[/]*/, '' ) // strip leading protocol
-		.replace( /\/.*$/, '' ); // strip everything after the domain
-
-//Mostly copied from Seo Preview
+import React, { PureComponent } from 'react';
 
 export class TwitterSharePreview extends PureComponent {
 	render() {
-		const {
-			url,
-			title,
-			type,
-			description,
-			image
-		} = this.props;
-
-		const previewImageStyle = {
-			backgroundImage: 'url(' + image + ')'
-		};
+		// TODO: use real data
+		const externalProfilePicture = 'https://3.bp.blogspot.com/-W__wiaHUjwI/Vt3Grd8df0I/AAAAAAAAA78/7xqUNj8ujtY/s1600/image02.png';
+		const externalProfileUrl = 'https://example.com';
+		const externalDisplay = 'Style and Gear';
+		const externalName = 'styleandgear';
+		const message = 'Do you have a trip coming up? Check out this winter travel gear roundup!';
+		const articleUrl = 'https://styleandgear.com/2016/01/03/how-to-dress-like-a-proper-we-need-some-long-url';
+		const imageUrl = 'https://www.w3schools.com/css/trolltunga.jpg';
 
 		return (
 			<div className="twitter-share-preview">
-				<div className={ `twitter-share-preview__${ type }` }>
-					{ image &&
-					<div className="twitter-share-preview__image" style={ previewImageStyle } />
-					}
-					<div className="twitter-share-preview__body">
-						<div className="twitter-share-preview__title">
-							{ title }
+				<div className="twitter-share-preview__content">
+					<div className="twitter-share-preview__profile-picture-part">
+						<img
+							className="twitter-share-preview__profile-picture"
+							src={ externalProfilePicture }
+						/>
+					</div>
+					<div className="twitter-share-preview__content-part">
+						<div className="twitter-share-preview__profile-line">
+							<a
+								className="twitter-share-preview__profile-name"
+								href={ externalProfileUrl }
+							>
+								{ externalDisplay }
+							</a>
+							<a
+								className="twitter-share-preview__profile-handle"
+								href={ externalProfileUrl }
+							>
+								@{ externalName }
+							</a>
 						</div>
-						<div className="twitter-share-preview__description">
-							{ description }
+						<div className="twitter-share-preview__message">
+							{ message }
 						</div>
-						<div className="twitter-share-preview__url">
-							{ baseDomain( url ) }
+						<div className="twitter-share-preview__article-url">
+							{ articleUrl }
 						</div>
+						{ imageUrl &&
+							<div className="twitter-share-preview__image-wrapper">
+								<img
+									className="twitter-share-preview__image"
+									src={ imageUrl }
+								/>
+							</div>
+						}
 					</div>
 				</div>
 			</div>
 		);
 	}
 }
-
-TwitterSharePreview.propTypes = {
-	url: PropTypes.string,
-	title: PropTypes.string,
-	type: PropTypes.string,
-	description: PropTypes.string,
-	image: PropTypes.string
-};
 
 export default TwitterSharePreview;

--- a/client/components/share/twitter-share-preview/style.scss
+++ b/client/components/share/twitter-share-preview/style.scss
@@ -1,0 +1,67 @@
+.twitter-share-preview {
+	background-color: $white;
+	border: 1px solid #e6ecf0;
+	color: #14171a;
+	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-size: 14px;
+	line-height: 1.375;
+	margin: 0 auto;
+	max-width: 565px;
+	padding: 12px;
+}
+
+.twitter-share-preview__content {
+	display: flex;
+}
+
+.twitter-share-preview__profile-picture-part {
+	flex: 0 0 48px;
+	margin: 3px 10px 0 0;
+	width: 48px;
+}
+
+.twitter-share-preview__profile-picture {
+	border-radius: 5px;
+	display: block;
+}
+
+.twitter-share-preview__profile-name {
+	color: #14171a;
+	font-weight: bold;
+	margin-right: 5px;
+
+	&:hover {
+		color: #0084B4;
+		text-decoration: underline;
+	}
+}
+
+.twitter-share-preview__profile-handle {
+	color: #657786;
+	font-size: 13px;
+}
+
+.twitter-share-preview__message,
+.twitter-share-preview__article-url {
+	font-size: 16px;
+	line-height: 22px;
+}
+
+.twitter-share-preview__message a,
+.twitter-share-preview__article-url {
+	color: #0084B4;
+}
+
+.twitter-share-preview__article-url-line {
+	word-break: break-word;
+}
+
+.twitter-share-preview__image-wrapper {
+	margin-top: 10px;
+}
+
+.twitter-share-preview__image {
+	border: 1px solid rgba(0,0,0,0.1);
+	border-radius: 5px;
+	display: block;
+}


### PR DESCRIPTION
Part of the Publicize Scheduling project (internal ref: p3fqKv-4qj-p2).

After clicking on the "Preview" button in the Share section under a post, we open a dialog in which the user can preview how the share will look like on the connected services.

In this PR, we add Facebook and Twitter share previews scaffolding with design.

<img width="642" alt="preview-linkedin" src="https://cloud.githubusercontent.com/assets/1119271/24208179/8dd9b832-0ee8-11e7-8f10-1e65622c836a.png">
<img width="689" alt="preview-path" src="https://cloud.githubusercontent.com/assets/1119271/24208184/8de39096-0ee8-11e7-9e62-27e42fcd6169.png">
<img width="705" alt="preview-tumblr" src="https://cloud.githubusercontent.com/assets/1119271/24208181/8ddebefe-0ee8-11e7-949c-95ce2bf33c66.png">
<img width="618" alt="preview-gplus" src="https://cloud.githubusercontent.com/assets/1119271/24208180/8dde7a02-0ee8-11e7-9c0c-25f0eadcf340.png">
<img width="679" alt="preview-twitter" src="https://cloud.githubusercontent.com/assets/1119271/24208182/8ddeef96-0ee8-11e7-86e5-3b2a02be81ee.png">
<img width="628" alt="preview-facebook" src="https://cloud.githubusercontent.com/assets/1119271/24208183/8ddfc038-0ee8-11e7-9796-7368a3c5f194.png">


## Testing

Go to http://calypso.localhost:3000/devdocs/blocks/sharing-preview-pane and look how the Facebook and Twitter share previews look like. Is it the same as in @iamtakashi's designs? (internal ref: p3fqKv-4qj)

Do not merge until @iamtakashi doesn't add the styling.