### PR TITLE
Sharing: Use dark gray for active account names

### DIFF
--- a/client/my-sites/post-share/style.scss
+++ b/client/my-sites/post-share/style.scss
@@ -175,7 +175,7 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 	}
 
 	&.is-active {
-		color: black;
+		color: $gray-dark;
 	}
 }
 


### PR DESCRIPTION
It was an oversight. It should've been the dark gray.