### PR TITLE
Reader: fix slugification. move away from lodash kebabCase

### DIFF
--- a/client/state/reader/tags/items/actions.js
+++ b/client/state/reader/tags/items/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { kebabCase } from 'lodash';
+import { trim } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,7 +20,12 @@ import {
  * @param  {String} tag  Tag name to parse into a slug
  * @return {String}      Tag slug
  */
-const slugify = ( tag ) => encodeURIComponent( kebabCase( tag ) );
+export const slugify = ( tag ) => encodeURIComponent(
+	trim( tag )
+		.toLowerCase()
+		.replace( /\s+/g, '-' )
+		.replace( /-{2,}/g, '-' )
+);
 
 export const requestTags = tag => {
 	const type = READER_TAGS_REQUEST;

--- a/client/state/reader/tags/items/test/actions.js
+++ b/client/state/reader/tags/items/test/actions.js
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { slugify } from '../actions';
+
+describe( 'actions', () => {
+	describe( '#slugify()', () => {
+		it( 'numbers dont get separated by hyphen', () => {
+			const tag = 'a8cday';
+			const slug = 'a8cday';
+
+			expect( slugify( tag ) ).to.eql( slug );
+		} );
+
+		it( 'unicode becomes encoded', () => {
+			const tag = '∑';
+			const slug = '%E2%88%91';
+
+			expect( slugify( tag ) ).to.eql( slug );
+		} );
+
+		it( 'Multi word becomes hyphenated', () => {
+			const tag = 'Chickens Love Poke';
+			const slug = 'chickens-love-poke';
+
+			expect( slugify( tag ) ).to.eql( slug );
+		} );
+
+		it( 'emoji becomes encoded', () => {
+			const tag = '🐬';
+			const slug = '%F0%9F%90%AC';
+
+			expect( slugify( tag ) ).to.eql( slug );
+		} );
+
+		it( 'single lowercase word remains unchanged', () => {
+			const tag = 'word';
+			const slug = 'word';
+
+			expect( slugify( tag ) ).to.eql( slug );
+		} );
+
+		it( 'camel cased word goes lowercase', () => {
+			const tag = 'wordWithCamels';
+			const slug = 'wordwithcamels';
+
+			expect( slugify( tag ) ).to.eql( slug );
+		} );
+	} );
+} );


### PR DESCRIPTION
Relying on lodash's `kebabCase` for slugification is a bad idea because it utilizes `words` for finding word separations.  By default that makes numbers new words which doesn't work for us.

Example: 'a8cday' --> 'a-8-cday' is not what we want.

This PR changes the slugification algo and adds unit tests.

Thanks @bluefuton for finding the issue!