### PR TITLE
Reader: Allow brightcove out of the sandbox

### DIFF
--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -140,6 +140,7 @@ export function iframeIsWhitelisted( iframe ) {
 		'nyt.com',
 		'google.com',
 		'mixcloud.com',
+		'players.brightcove.net',
 	];
 	const hostName = iframe.src && url.parse( iframe.src ).hostname;
 	const iframeSrc = hostName && hostName.toLowerCase();


### PR DESCRIPTION
Allow brightcove videos out of the iframe sandbox.

To test, compare https://calypso.live/read/feeds/23559910/posts/1387625103?branch=fix/reader/brightcove to https://wordpress.com/read/feeds/23559910/posts/1387625103