### PR TITLE
Editor: Enable editor mentions for all environments

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -138,10 +138,8 @@ const PLUGINS = [
 	'wpcom/insertmenu',
 ];
 
-if ( config.isEnabled( 'post-editor/mentions' ) ) {
-	mentionsPlugin();
-	PLUGINS.push( 'wpcom/mentions' );
-}
+mentionsPlugin();
+PLUGINS.push( 'wpcom/mentions' );
 
 const CONTENT_CSS = [
 	window.app.tinymceWpSkin,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -64,7 +64,6 @@
 		"post-editor/author-selector": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
-		"post-editor/mentions": false,
 		"press-this": false,
 		"preview-layout": true,
 		"reader": true,

--- a/config/development.json
+++ b/config/development.json
@@ -114,7 +114,6 @@
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
 		"post-editor/media-advanced": false,
-		"post-editor/mentions": true,
 		"press-this": true,
 		"push-notifications": true,
 		"reader": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -74,7 +74,6 @@
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
-		"post-editor/mentions": true,
 		"press-this": true,
 		"preview-layout": true,
 		"reader": true,

--- a/config/production.json
+++ b/config/production.json
@@ -72,7 +72,6 @@
 		"post-editor/author-selector": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
-		"post-editor/mentions": false,
 		"press-this": true,
 		"preview-layout": true,
 		"push-notifications": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -74,7 +74,6 @@
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
-		"post-editor/mentions": false,
 		"press-this": true,
 		"preview-layout": true,
 		"push-notifications": true,

--- a/config/test.json
+++ b/config/test.json
@@ -84,7 +84,6 @@
 		"plans/personal-plan": true,
 		"post-editor-github-link": false,
 		"post-editor/media-advanced": true,
-		"post-editor/mentions": false,
 		"press-this": true,
 		"reader": true,
 		"reader/combined-cards": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -85,7 +85,6 @@
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
-		"post-editor/mentions": true,
 		"press-this": true,
 		"preview-layout": true,
 		"reader": true,


### PR DESCRIPTION
Enable editor mentions in all Calypso environments. To use, just select a site with multiple users, start a new post (or open an existing post) and type @ in the editor to see a list of users you can mention.

(One of) The original PR(s) can be found [here](https://github.com/Automattic/wp-calypso/pull/10321).