### PR TITLE
Reader: Add ability to sort search results by date

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -44,6 +44,7 @@ $z-layers: (
 		'.reader__featured-post': 0,
 		'.reader__featured-post-title': 1,
 		'.search-stream__input-card': 0,
+		'.search-stream__sort-picker': 23,
 		'.reader-search-card': 0,
 		'.reader-featured-image': 0,
 		'.reader-post-card__title': 0,

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -120,9 +120,16 @@ function getStoreForTag( storeId ) {
 	} );
 }
 
+function validateSearchSort( sort ) {
+	if ( sort !== 'relevance' && sort !== 'date' ) {
+		return 'relevance';
+	}
+	return sort;
+}
+
 function getStoreForSearch( storeId ) {
 	const idParts = storeId.split( ':' );
-	const sort = idParts[ 1 ];
+	const sort = validateSearchSort( idParts[ 1 ] );
 	const slug = idParts.slice( 2 ).join( ':' );
 	const stream = new PagedStream( {
 		id: storeId,

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -137,6 +137,7 @@ function getStoreForSearch( storeId ) {
 		keyMaker: siteKeyMaker,
 		perPage: 5
 	} );
+	stream.sortOrder = sort;
 
 	function fetcher( query, callback ) {
 		query.q = slug;

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -121,7 +121,9 @@ function getStoreForTag( storeId ) {
 }
 
 function getStoreForSearch( storeId ) {
-	const slug = storeId.substring( storeId.indexOf( ':' ) + 1 );
+	const idParts = storeId.split( ':' );
+	const sort = idParts[ 1 ];
+	const slug = idParts.slice( 2 ).join( ':' );
 	const stream = new PagedStream( {
 		id: storeId,
 		fetcher: fetcher,
@@ -132,6 +134,7 @@ function getStoreForSearch( storeId ) {
 	function fetcher( query, callback ) {
 		query.q = slug;
 		query.meta = 'site';
+		query.sort = sort;
 		wpcomUndoc.readSearch( query, trainTracksProxyForStream( stream, callback ) );
 	}
 

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -246,7 +246,7 @@ class SearchStream extends Component {
 							value={ query }>
 						</SearchInput>
 						{ query &&
-							<SegmentedControl compact primary
+							<SegmentedControl compact
 								className="search-stream__sort-picker">
 								<ControlItem
 									selected={ sortOrder !== 'date' }

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -215,7 +215,14 @@ class SearchStream extends Component {
 		}
 
 		const suggestionList = initial( flatMap( suggestions, suggestionKeyword =>
-			[ <Suggestion suggestion={ suggestionKeyword } source="search" />, ', ' ] ) );
+			[
+				<Suggestion
+					suggestion={ suggestionKeyword }
+					source="search"
+					sort={ sortOrder === 'date' ? sortOrder : undefined }
+				/>,
+				', '
+			] ) );
 
 		const documentTitle = this.props.translate(
 			'%s ‹ Reader', { args: this.state.title || this.props.translate( 'Search' ) }

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
+import config from 'config';
 import ControlItem from 'components/segmented-control/item';
 import SegmentedControl from 'components/segmented-control';
 import CompactCard from 'components/card/compact';
@@ -220,6 +221,14 @@ class SearchStream extends Component {
 			'%s ‹ Reader', { args: this.state.title || this.props.translate( 'Search' ) }
 		);
 
+		const TEXT_RELEVANCE_SORT = this.props.translate( 'Relevance', {
+			comment: 'A sort order, showing the most relevant posts first.'
+		} );
+
+		const TEXT_DATE_SORT = this.props.translate( 'Date', {
+			comment: 'A sort order, showing the most recent posts first.'
+		} );
+
 		return (
 			<Stream { ...this.props }
 				listName={ this.props.translate( 'Search' ) }
@@ -245,18 +254,18 @@ class SearchStream extends Component {
 							initialValue={ query }
 							value={ query }>
 						</SearchInput>
-						{ query &&
+						{ query && config.isEnabled( 'reader/search/sort-by-date' ) &&
 							<SegmentedControl compact
 								className="search-stream__sort-picker">
 								<ControlItem
 									selected={ sortOrder !== 'date' }
 									onClick={ this.useRelevanceSort }>
-									{ this.props.translate( 'Relevance' ) }
+									{ TEXT_RELEVANCE_SORT }
 								</ControlItem>
 								<ControlItem
 									selected={ sortOrder === 'date' }
 									onClick={ this.useDateSort }>
-									{ this.props.translate( 'Date' ) }
+									{ TEXT_DATE_SORT }
 								</ControlItem>
 							</SegmentedControl>
 						}

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -8,6 +8,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
+import ControlItem from 'components/segmented-control/item';
+import SegmentedControl from 'components/segmented-control';
 import CompactCard from 'components/card/compact';
 import DocumentHead from 'components/data/document-head';
 import Stream from 'reader/stream';
@@ -48,7 +50,9 @@ function RecommendedPosts( { post, site } ) {
 	return (
 		<div className="search-stream__recommendation-list-item" key={ post.global_ID }>
 			<RelatedPostCard post={ post } site={ site }
-				onSiteClick={ handleSiteClick } onPostClick={ handlePostClick } followSource={ EMPTY_SEARCH_RECOMMENDATIONS } />
+				onSiteClick={ handleSiteClick }
+				onPostClick={ handlePostClick }
+				followSource={ EMPTY_SEARCH_RECOMMENDATIONS } />
 		</div>
 	);
 }
@@ -167,7 +171,10 @@ class SearchStream extends Component {
 	}
 
 	componentDidMount() {
-		this.resizeListener = window.addEventListener( 'resize', debounce( this.resizeSearchBox, 50 ) );
+		this.resizeListener = window.addEventListener(
+			'resize',
+			debounce( this.resizeSearchBox, 50 )
+		);
 		this.resizeSearchBox();
 	}
 
@@ -186,13 +193,24 @@ class SearchStream extends Component {
 		return null;
 	}
 
+	useRelevanceSort = () => {
+		this.props.onSortChange( 'relevance' );
+	}
+
+	useDateSort = () => {
+		this.props.onSortChange( 'date' );
+	}
+
 	render() {
 		const { query, suggestions } = this.props;
 		const emptyContent = <EmptyContent query={ query } />;
+		const sortOrder = this.props.postsStore && this.props.postsStore.sortOrder;
 
 		let searchPlaceholderText = this.props.searchPlaceholderText;
 		if ( ! searchPlaceholderText ) {
-			searchPlaceholderText = this.props.translate( 'Search billions of WordPress.com posts…' );
+			searchPlaceholderText = this.props.translate(
+				'Search billions of WordPress.com posts…'
+			);
 		}
 
 		const suggestionList = initial( flatMap( suggestions, suggestionKeyword =>
@@ -225,8 +243,23 @@ class SearchStream extends Component {
 							delayTimeout={ 500 }
 							placeholder={ searchPlaceholderText }
 							initialValue={ query }
-							value={ query }
-						/>
+							value={ query }>
+						</SearchInput>
+						{ query &&
+							<SegmentedControl compact primary
+								className="search-stream__sort-picker">
+								<ControlItem
+									selected={ sortOrder !== 'date' }
+									onClick={ this.useRelevanceSort }>
+									{ this.props.translate( 'Relevance' ) }
+								</ControlItem>
+								<ControlItem
+									selected={ sortOrder === 'date' }
+									onClick={ this.useDateSort }>
+									{ this.props.translate( 'Date' ) }
+								</ControlItem>
+							</SegmentedControl>
+						}
 					</CompactCard>
 					<p className="search-stream__blank-suggestions">
 						{ suggestions &&

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -215,3 +215,10 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		}
 	}
 }
+
+.search-stream__sort-picker {
+	position: absolute;
+	right: 50px;
+	top: 11px;
+	z-index: z-index( 'root', '.search-stream__sort-picker' );
+}

--- a/client/reader/search-stream/suggestion.jsx
+++ b/client/reader/search-stream/suggestion.jsx
@@ -2,19 +2,29 @@
  * External Dependencies
  */
 import React, { PropTypes } from 'react';
+import { stringify } from 'qs';
 
 /**
  * Internal Dependencies
  */
 import { recordTrack } from 'reader/stats';
 
-export function Suggestion( { suggestion, source } ) {
+export function Suggestion( { suggestion, source, sort } ) {
 	const handleSuggestionClick = () => {
 		recordTrack( 'calypso_reader_search_suggestion_click', { suggestion, source } );
 	};
 
+	const args = {
+		isSuggestion: 1,
+		q: suggestion,
+		sort
+	};
+
+	const searchUrl = '/read/search?' + stringify( args );
+
 	return (
-		<a onClick={ handleSuggestionClick } href={ '/read/search?isSuggestion=1&q=' + encodeURIComponent( suggestion ) } >
+		<a onClick={ handleSuggestionClick }
+			href={ searchUrl } >
 			{ suggestion }
 		</a>
 	);

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -62,6 +62,10 @@ export default {
 			replaceSearchUrl( query, sort !== 'relevance' ? sort : undefined );
 		}
 
+		function reportSortChange( newSort ) {
+			replaceSearchUrl( searchSlug, newSort !== 'relevance' ? newSort : undefined );
+		}
+
 		renderWithReduxStore(
 			<AsyncLoad require="reader/search-stream"
 				key="search"
@@ -79,6 +83,7 @@ export default {
 				showPrimaryFollowButtonOnCards={ true }
 				autoFocusInput={ autoFocusInput }
 				onQueryChange={ reportQueryChange }
+				onSortChange={ reportSortChange }
 			/>,
 			document.getElementById( 'primary' ),
 			context.store

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -21,10 +21,10 @@ import AsyncLoad from 'components/async-load';
 
 const analyticsPageTitle = 'Reader';
 
-function replaceSearchUrl( newValue ) {
+function replaceSearchUrl( newValue, sort ) {
 	let searchUrl = '/read/search';
 	if ( newValue ) {
-		searchUrl += '?' + qs.stringify( { q: newValue } );
+		searchUrl += '?' + qs.stringify( { q: newValue, sort } );
 	}
 	page.replace( searchUrl );
 }
@@ -58,6 +58,10 @@ export default {
 
 		const autoFocusInput = ( ! searchSlug ) || context.query.focus === '1';
 
+		function reportQueryChange( query ) {
+			replaceSearchUrl( query, sort !== 'relevance' ? sort : undefined );
+		}
+
 		renderWithReduxStore(
 			<AsyncLoad require="reader/search-stream"
 				key="search"
@@ -74,7 +78,7 @@ export default {
 				showBack={ false }
 				showPrimaryFollowButtonOnCards={ true }
 				autoFocusInput={ autoFocusInput }
-				onQueryChange={ replaceSearchUrl }
+				onQueryChange={ reportQueryChange }
 			/>,
 			document.getElementById( 'primary' ),
 			context.store

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -10,7 +10,12 @@ import qs from 'qs';
  */
 import feedStreamFactory from 'lib/feed-stream-store';
 import { recordTrack } from 'reader/stats';
-import { ensureStoreLoading, trackPageLoad, trackUpdatesLoaded, trackScrollPage } from 'reader/controller-helper';
+import {
+	ensureStoreLoading,
+	trackPageLoad,
+	trackUpdatesLoaded,
+	trackScrollPage
+} from 'reader/controller-helper';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import AsyncLoad from 'components/async-load';
 
@@ -26,14 +31,15 @@ function replaceSearchUrl( newValue ) {
 
 export default {
 	search: function( context ) {
-		var basePath = '/read/search',
+		const basePath = '/read/search',
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Search',
 			searchSlug = context.query.q,
+			sort = context.query.sort || 'relevance',
 			mcKey = 'search';
 
 		let store;
 		if ( searchSlug ) {
-			store = feedStreamFactory( 'search:' + searchSlug );
+			store = feedStreamFactory( `search:${ sort }:${ searchSlug }` );
 			store.isQuerySuggestion = context.query.isSuggestion === '1';
 			ensureStoreLoading( store, context );
 		} else {

--- a/config/development.json
+++ b/config/development.json
@@ -128,6 +128,7 @@
 		"reader/related-posts": true,
 		"reader/search": true,
 		"reader/tags-with-elasticsearch": false,
+		"reader/search/sort-by-date": true,
 		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -96,6 +96,7 @@
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,
 		"reader/search": true,
+		"reader/search/sort-by-date": true,
 		"reader/tags-with-elasticsearch": false,
 		"resume-editing": true,
 		"republicize": true,


### PR DESCRIPTION
Allows a user to choose relevance- or date-based sorting for search results on Reader Search.

![2eae4c10-0f10-11e7-885b-3aa78cad65ea](https://cloud.githubusercontent.com/assets/17325/24247283/fb655f7a-0fc2-11e7-856f-bf1676c0fd36.png)
