### PR TITLE
Stats: Localize date in StatsDatePicker

### DIFF
--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -12,6 +12,7 @@ import { connect } from 'react-redux';
 import Tooltip from 'components/tooltip';
 import { getSiteStatsQueryDate } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { getCurrentUserLocale } from 'state/current-user/selectors';
 import { isRequestingSiteStatsForQuery } from 'state/stats/lists/selectors';
 import { isAutoRefreshAllowedForQuery } from 'state/stats/lists/utils';
 
@@ -26,6 +27,7 @@ class StatsDatePicker extends Component {
 		query: PropTypes.object,
 		statType: PropTypes.string,
 		showQueryDate: PropTypes.bool,
+		userLocale: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -45,8 +47,8 @@ class StatsDatePicker extends Component {
 	};
 
 	dateForSummarize() {
-		const { query, moment, translate } = this.props;
-		const localizedDate = moment();
+		const { query, moment, translate, userLocale } = this.props;
+		const localizedDate = moment().locale( userLocale );
 
 		switch ( query.num ) {
 			case '-1':
@@ -68,8 +70,8 @@ class StatsDatePicker extends Component {
 	}
 
 	dateForDisplay() {
-		const { date, moment, period, translate } = this.props;
-		const localizedDate = moment( date );
+		const { date, moment, period, translate, userLocale } = this.props;
+		const localizedDate = moment( date ).locale( userLocale );
 		let formattedDate;
 
 		switch ( period ) {
@@ -176,6 +178,7 @@ const connectComponent = connect(
 	( state, { query, statsType, showQueryDate } ) => {
 		const siteId = getSelectedSiteId( state );
 		return {
+			userLocale: getCurrentUserLocale( state ),
 			queryDate: showQueryDate ? getSiteStatsQueryDate( state, siteId, statsType, query ) : null,
 			requesting: showQueryDate ? isRequestingSiteStatsForQuery( state, siteId, statsType, query ) : false,
 		};


### PR DESCRIPTION
This branch fixes #12194.  Currently, the dates shown in the `<StatsDatePicker />` are not being displayed in a localized format.  It appears that the `moment` instance that is being passed in as a prop via `i18n-calypso#localize()` does not have the proper locale baked in.  Here we are grabbing the current user's locale, and using it in the `moment()` calls in the component.

__To Test__
- Set your interface language to something other than English.
- Open a site stats page
- Verify the date in the "Stats for XXXXX" text is localized

__Before__
<img width="936" alt="statistik_ _trout_bummin_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/24222280/ccbb3e4c-0f0e-11e7-95a1-7231e0148207.png">

__After__
<img width="939" alt="statistik_ _trout_bummin_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/24222349/f624906c-0f0e-11e7-85d1-2e4f8050ac22.png">

