### PR TITLE
Guided Tours: Support for listening to analytics events

### DIFF
--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -5,9 +5,11 @@ import { combineTours } from 'layout/guided-tours/config-elements';
 import { MainTour } from 'layout/guided-tours/tours/main-tour';
 import { TutorialSitePreviewTour } from 'layout/guided-tours/tours/tutorial-site-preview-tour';
 import { GDocsIntegrationTour } from 'layout/guided-tours/tours/gdocs-integration-tour';
+import { DesignShowcaseWelcomeTour } from 'layout/guided-tours/tours/design-showcase-welcome-tour';
 
 export default combineTours( {
 	main: MainTour,
 	tutorialSitePreview: TutorialSitePreviewTour,
 	gdocsIntegrationTour: GDocsIntegrationTour,
+	designShowcaseWelcome: DesignShowcaseWelcomeTour,
 } );

--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -5,11 +5,9 @@ import { combineTours } from 'layout/guided-tours/config-elements';
 import { MainTour } from 'layout/guided-tours/tours/main-tour';
 import { TutorialSitePreviewTour } from 'layout/guided-tours/tours/tutorial-site-preview-tour';
 import { GDocsIntegrationTour } from 'layout/guided-tours/tours/gdocs-integration-tour';
-import { DesignShowcaseWelcomeTour } from 'layout/guided-tours/tours/design-showcase-welcome-tour';
 
 export default combineTours( {
 	main: MainTour,
 	tutorialSitePreview: TutorialSitePreviewTour,
 	gdocsIntegrationTour: GDocsIntegrationTour,
-	designShowcaseWelcome: DesignShowcaseWelcomeTour,
 } );

--- a/client/layout/guided-tours/tours/design-showcase-welcome-tour.js
+++ b/client/layout/guided-tours/tours/design-showcase-welcome-tour.js
@@ -22,16 +22,16 @@ import {
 	Continue,
 } from 'layout/guided-tours/config-elements';
 import {
+	hasAnalyticsEventFired,
 	isAbTestInVariant,
 	inSection,
 	isNewUser,
 	isEnabled,
 	selectedSiteIsCustomizable,
-	hasUserInteractedWithComponent,
 } from 'state/ui/guided-tours/contexts';
 import { isDesktop } from 'lib/viewport';
 
-const anyThemeMoreButtonClicked = hasUserInteractedWithComponent( 'ThemeMoreButton' );
+const anyThemeMoreButtonClicked = hasAnalyticsEventFired( 'calypso_themeshowcase_theme_click' );
 
 export const DesignShowcaseWelcomeTour = makeTour(
 	<Tour

--- a/client/state/ui/action-log/reducer.js
+++ b/client/state/ui/action-log/reducer.js
@@ -7,6 +7,7 @@ import { takeRight } from 'lodash';
  * Internal dependencies
  */
 import {
+	ANALYTICS_EVENT_RECORD,
 	EDITOR_PASTE_EVENT,
 	FIRST_VIEW_HIDE,
 	GUIDED_TOUR_UPDATE,
@@ -17,6 +18,7 @@ import {
 } from 'state/action-types';
 
 const relevantTypes = {
+	ANALYTICS_EVENT_RECORD,
 	EDITOR_PASTE_EVENT,
 	FIRST_VIEW_HIDE,
 	GUIDED_TOUR_UPDATE,

--- a/client/state/ui/action-log/reducer.js
+++ b/client/state/ui/action-log/reducer.js
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { takeRight } from 'lodash';
+import { get, has, includes, isFunction, takeRight } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import {
-	ANALYTICS_EVENT_RECORD,
 	EDITOR_PASTE_EVENT,
 	FIRST_VIEW_HIDE,
 	GUIDED_TOUR_UPDATE,
@@ -17,8 +16,12 @@ import {
 	SITE_SETTINGS_RECEIVE,
 } from 'state/action-types';
 
+const relevantAnalyticsEvents = [
+	'calypso_themeshowcase_theme_click',
+];
+
 const relevantTypes = {
-	ANALYTICS_EVENT_RECORD,
+	ANALYTICS_EVENT_RECORD: isRelevantAnalytics,
 	EDITOR_PASTE_EVENT,
 	FIRST_VIEW_HIDE,
 	GUIDED_TOUR_UPDATE,
@@ -29,9 +32,14 @@ const relevantTypes = {
 };
 
 const isRelevantAction = ( action ) =>
-	relevantTypes.hasOwnProperty( action.type ) &&
-	( typeof relevantTypes[ action.type ] !== 'function' ||
+	has( relevantTypes, action.type ) && (
+		! isFunction( relevantTypes[ action.type ] ) ||
 		relevantTypes[ action.type ]( action ) );
+
+function isRelevantAnalytics( action ) {
+	return get( action, 'meta.analytics', [] ).some( record =>
+		includes( relevantAnalyticsEvents, record.payload.name ) );
+}
 
 const newAction = ( action ) => ( {
 	...action, timestamp: Date.now()

--- a/client/state/ui/action-log/test/reducer.js
+++ b/client/state/ui/action-log/test/reducer.js
@@ -56,4 +56,73 @@ describe( 'reducer', () => {
 
 		expect( state ).to.eql( [] );
 	} );
+
+	it( 'should log actions with relevant analytics meta', () => {
+		const actions = [
+			{
+				type: ROUTE_SET,
+				path: '/design/77203074',
+				meta: { analytics: [ {
+					type: 'ANALYTICS_EVENT_RECORD',
+					payload: {
+						service: 'tracks',
+						name: 'calypso_themeshowcase_theme_click',
+						properties: {}
+					}
+				} ] }
+			},
+			{
+				type: COMMENTS_LIKE,
+				path: '/menus/foobar',
+				meta: { analytics: [ {
+					type: 'ANALYTICS_EVENT_RECORD',
+					payload: {
+						service: 'tracks',
+						name: 'calypso_themeshowcase_theme_click',
+						properties: {}
+					}
+				} ] }
+			},
+		];
+		const state = actions.reduce( reducer, undefined );
+
+		expect( state ).to.eql( [
+			{ ...actions[ 0 ], timestamp: 1337 },
+			{ ...actions[ 1 ], timestamp: 1337 },
+		] );
+	} );
+
+	it( 'should discard actions with irrelevant analytics meta', () => {
+		const actions = [
+			{
+				type: ROUTE_SET,
+				path: '/design/77203074',
+				meta: { analytics: [ {
+					type: 'ANALYTICS_EVENT_RECORD',
+					payload: {
+						service: 'tracks',
+						name: 'calypso_all_your_base_are_belong_to_us',
+						properties: {}
+					}
+				} ] }
+			},
+			{
+				type: COMMENTS_LIKE,
+				path: '/menus/foobar',
+				meta: { analytics: [ {
+					type: 'ANALYTICS_EVENT_RECORD',
+					payload: {
+						service: 'tracks',
+						name: 'calypso_all_your_base_are_belong_to_us',
+						properties: {}
+					}
+				} ] }
+			},
+		];
+		const state = actions.reduce( reducer, undefined );
+
+		expect( state ).to.eql( [
+			{ ...actions[ 0 ], timestamp: 1337 },
+		] );
+	} );
 } );

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { EDITOR_PASTE_EVENT } from 'state/action-types';
+import { ANALYTICS_EVENT_RECORD, EDITOR_PASTE_EVENT } from 'state/action-types';
 import { SOURCE_GOOGLE_DOCS } from 'components/tinymce/plugins/wpcom-track-paste/sources';
 import config from 'config';
 import { abtest } from 'lib/abtest';
@@ -89,6 +89,22 @@ export const hasUserRegisteredBefore = date => state => {
  * Deprecated.
  */
 export const hasUserInteractedWithComponent = () => () => false;
+
+/**
+ * Returns a selector that tests whether a certain analytics event has been
+ * fired.
+ *
+ * @see client/state/analytics
+ *
+ * @param {String} eventName Name of analytics event
+ * @return {Function} Selector function
+ */
+export const hasAnalyticsEventFired = eventName => state => {
+	const last = getLastAction( state );
+	return ( last.type === ANALYTICS_EVENT_RECORD ) &&
+		last.meta.analytics.some( record =>
+			record.payload.name === eventName );
+};
 
 /**
  * Returns true if the selected site can be previewed

--- a/client/state/ui/guided-tours/test/contexts.js
+++ b/client/state/ui/guided-tours/test/contexts.js
@@ -15,7 +15,10 @@ import {
 } from 'components/tinymce/plugins/wpcom-track-paste/sources';
 
 describe( 'selectors', () => {
-	let hasUserRegisteredBefore, hasUserPastedFromGoogleDocs;
+	let hasUserRegisteredBefore;
+	let hasUserPastedFromGoogleDocs;
+	let hasAnalyticsEventFired;
+	let hasUserClicked;
 
 	useFakeDom();
 
@@ -27,6 +30,8 @@ describe( 'selectors', () => {
 		const contexts = require( '../contexts' );
 		hasUserRegisteredBefore = contexts.hasUserRegisteredBefore;
 		hasUserPastedFromGoogleDocs = contexts.hasUserPastedFromGoogleDocs;
+		hasAnalyticsEventFired = contexts.hasAnalyticsEventFired;
+		hasUserClicked = hasAnalyticsEventFired( 'calypso_themeshowcase_theme_click' );
 	} );
 
 	describe( '#hasUserRegisteredBefore', () => {
@@ -107,6 +112,61 @@ describe( 'selectors', () => {
 				}
 			};
 			expect( hasUserPastedFromGoogleDocs( state ) ).to.be.false;
+		} );
+	} );
+
+	describe( '#hasAnalyticsEventFired', () => {
+		it( 'should return false when no actions', () => {
+			const state = {
+				ui: {
+					actionLog: []
+				}
+			};
+			expect( hasUserClicked( state ) ).to.be.false;
+		} );
+		it( 'should return true when matching action', () => {
+			const state = {
+				ui: {
+					actionLog: [ {
+						type: 'ANALYTICS_EVENT_RECORD',
+						meta: {
+							analytics: [
+								{
+									type: 'ANALYTICS_EVENT_RECORD',
+									payload: {
+										service: 'tracks',
+										name: 'calypso_themeshowcase_theme_click',
+										properties: {}
+									}
+								}
+							]
+						}
+					} ]
+				}
+			};
+			expect( hasUserClicked( state ) ).to.be.true;
+		} );
+		it( 'should return false when mis-matching event', () => {
+			const state = {
+				ui: {
+					actionLog: [ {
+						type: 'ANALYTICS_EVENT_RECORD',
+						meta: {
+							analytics: [
+								{
+									type: 'ANALYTICS_EVENT_RECORD',
+									payload: {
+										service: 'tracks',
+										name: 'wrong_name',
+										properties: {}
+									}
+								}
+							]
+						}
+					} ]
+				}
+			};
+			expect( hasUserClicked( state ) ).to.be.false;
 		} );
 	} );
 } );


### PR DESCRIPTION
~Conceptual. **Do not merge.**~

Exploration spawned off of #11739. In short: analytics are already used throughout Calypso to signal user interactions, so let's use that instead of adding a separate `COMPONENT_INTERACTION_TRACKED` action just for `action-log` / Guided Tours. Things like the Theme Showcase already fire analytics events for the kinds of actions that may interest us (e.g., clicking a theme's _More_ (ellipsis) button).

# ~Why this shouldn't be merged~

- ~This re-adds `DesignShowcaseWelcomeTour` to `layout/guided-tours/config` only for the purpose of testing.~ Solved by re-deleting tour after testing.
- ~It adds `ANALYTICS_EVENT_RECORD` to `action-log`'s `relevantTypes` whitelist, which as-is is likely to have a performance impact on Guided Tours / Calypso, since a lot of such actions are constantly fired in Calypso. This can easily be solved by adding a `relevantAnalyticsEvents` list to `action-log` and only subscribing to matching events.~ Solved by adding `relevantAnalyticsEvents` to `action-log`.

# The idea here

~… is likely to just close this PR, but leave this concept here for the future. It seems wise not to waste time on this until there is an actual need for it, a need which has been removed #12424.~ This is a useful framework improvement right now, as other teams are currently working on new tours.