### PR TITLE
Reader: connect the SiteStream and FeedStream

### DIFF
--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -50,11 +50,11 @@ class FeedHeader extends Component {
 	}
 
 	render() {
-		const site = this.props.site,
-			feed = this.props.feed,
-			followerCount = this.getFollowerCount( feed, site ),
-			ownerDisplayName = site && site.owner && site.owner.name;
+		const { site, feed } = this.props;
+		const followerCount = this.getFollowerCount( feed, site );
+		const ownerDisplayName = site && site.owner && site.owner.name;
 		const siteish = this.buildSiteish( site, feed );
+		const description = site && site.description;
 
 		const classes = classnames( {
 			'reader-feed-header': true,
@@ -88,7 +88,7 @@ class FeedHeader extends Component {
 							indicator={ false } />
 					}
 					<div className="reader-feed-header__details">
-						<span className="reader-feed-header__description">{ ( site && site.description ) }</span>
+						<span className="reader-feed-header__description">{ description }</span>
 						{ ownerDisplayName && <span className="reader-feed-header__byline">
 							{ this.props.translate(
 								'by %(author)s',

--- a/client/reader/discover/controller.js
+++ b/client/reader/discover/controller.js
@@ -18,13 +18,16 @@ const ANALYTICS_PAGE_TITLE = 'Reader';
 
 export default {
 	discover( context ) {
-		const blogId = config( 'discover_blog_id' ),
-			basePath = route.sectionify( context.path ),
-			fullAnalyticsPageTitle = ANALYTICS_PAGE_TITLE + ' > Site > ' + blogId,
-			feedStore = feedStreamFactory( 'site:' + blogId ),
-			mcKey = 'discover';
+		const blogId = config( 'discover_blog_id' );
+		const basePath = route.sectionify( context.path );
+		const fullAnalyticsPageTitle = ANALYTICS_PAGE_TITLE + ' > Site > ' + blogId;
+		const feedStore = feedStreamFactory( 'site:' + blogId );
+		const featuredStore = feedStreamFactory( `featured:${ blogId }` );
+
+		const mcKey = 'discover';
 
 		ensureStoreLoading( feedStore, context );
+		ensureStoreLoading( featuredStore, context );
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 		recordTrack( 'calypso_reader_discover_viewed' );
@@ -50,6 +53,7 @@ export default {
 				isDiscoverStream={ true }
 				showBack={ false }
 				className="is-discover-stream is-site-stream"
+				featuredStore={ featuredStore }
 			/>,
 			document.getElementById( 'primary' ),
 			context.store

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import url from 'url';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -11,13 +12,12 @@ import { localize } from 'i18n-calypso';
 import EmptyContent from './empty';
 import DocumentHead from 'components/data/document-head';
 import Stream from 'reader/stream';
-import FeedStore from 'lib/feed-store';
-import FeedStoreActions from 'lib/feed-store/actions';
-import { state as FeedStoreState } from 'lib/feed-store/constants';
 import FeedError from 'reader/feed-error';
-import SiteStore from 'lib/reader-site-store';
-import { state as SiteState } from 'lib/reader-site-store/constants';
 import RefreshFeedHeader from 'blocks/reader-feed-header';
+import QueryReaderSite from 'components/data/query-reader-site';
+import QueryReaderFeed from 'components/data/query-reader-feed';
+import { getSite } from 'state/reader/sites/selectors';
+import { getFeed } from 'state/reader/feeds/selectors';
 
 class FeedStream extends React.Component {
 
@@ -32,39 +32,6 @@ class FeedStream extends React.Component {
 		className: 'is-site-stream',
 	};
 
-	constructor( props ) {
-		super( props );
-		this.state = this.getState( props );
-	}
-
-	componentDidMount() {
-		FeedStore.on( 'change', this.updateState );
-		SiteStore.on( 'change', this.updateState );
-	}
-
-	componentWillUnmount() {
-		FeedStore.off( 'change', this.updateState );
-		SiteStore.off( 'change', this.updateState );
-	}
-
-	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.feedId !== this.props.feedId ) {
-			this.updateState( nextProps );
-		}
-	}
-
-	getState = ( props = this.props ) => {
-		const feed = this.getFeed( props ),
-			site = this.getSite( props ),
-			title = this.getTitle( feed, site );
-
-		return {
-			title,
-			feed,
-			site
-		};
-	}
-
 	getTitle = ( feed, site ) => {
 		let title;
 
@@ -72,9 +39,9 @@ class FeedStream extends React.Component {
 			return this.props.translate( 'Loading Feed' );
 		}
 
-		if ( feed.state === FeedStoreState.ERROR ) {
+		if ( feed.is_error ) {
 			title = this.props.translate( 'Error fetching feed' );
-		} else if ( feed.state === FeedStoreState.COMPLETE ) {
+		} else if ( feed ) {
 			title = feed.name;
 		}
 
@@ -103,76 +70,40 @@ class FeedStream extends React.Component {
 		return title;
 	}
 
-	getFeed = ( props = this.props ) => {
-		const feed = FeedStore.get( props.feedId );
-
-		if ( ! feed ) {
-			FeedStoreActions.fetch( props.feedId );
-		}
-
-		return feed;
-	}
-
-	getSite = ( props = this.props ) => {
-		const feed = FeedStore.get( props.feedId );
-		let site;
-
-		if ( feed && feed.blog_ID ) {
-			// this comes in via a meta request, so don't bother querying it
-			site = SiteStore.get( feed.blog_ID );
-			if ( site && site.get( 'state' ) !== SiteState.COMPLETE ) {
-				site = null; // don't accept an incomplete or error site
-			}
-		}
-
-		return site;
-	}
-
-	updateState = ( props = this.props ) => {
-		const feed = this.getFeed( props ),
-			site = this.getSite( props ),
-			title = this.getTitle( feed, site ),
-			newState = {};
-
-		if ( feed !== this.state.feed ) {
-			newState.feed = feed;
-		}
-
-		if ( title !== this.state.title ) {
-			newState.title = title;
-		}
-
-		if ( site && site !== this.state.site ) {
-			newState.site = site;
-		}
-
-		if ( Object.keys( newState ).length > 0 ) {
-			this.setState( newState );
-		}
-	}
-
 	render() {
-		const feed = FeedStore.get( this.props.feedId ),
-			emptyContent = ( <EmptyContent /> );
+		const { feed, site } = this.props;
+		const emptyContent = ( <EmptyContent /> );
+		const title = this.getTitle( feed, site );
 
-		if ( feed && feed.state === FeedStoreState.ERROR ) {
-			return <FeedError sidebarTitle={ this.state.title } />;
+		if ( feed && feed.is_error ) {
+			return <FeedError sidebarTitle={ title } />;
 		}
 
 		return (
 			<Stream
 				{ ...this.props }
-				listName={ this.state.title }
+				listName={ title }
 				emptyContent={ emptyContent }
 				showPostHeader={ false }
 				showSiteNameOnCards={ false }
 				shouldCombineCards={ false }
 			>
-				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: this.state.title } ) } />
-				<RefreshFeedHeader feed={ feed } site={ this.state.site } showBack={ this.props.showBack } />
+				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: title } ) } />
+				<RefreshFeedHeader feed={ feed } site={ site } showBack={ this.props.showBack } />
+				{ ! feed && <QueryReaderFeed feedId={ this.props.feedId } /> }
+				{ ! site && feed.blog_ID && <QueryReaderSite siteId={ feed.blog_ID } /> }
 			</Stream>
 		);
 	}
 }
 
-export default localize( FeedStream );
+export default connect(
+	( state, ownProps ) => {
+		const feed = getFeed( state, ownProps.feedId );
+		return {
+			feed,
+			site: feed && feed.blog_ID && getSite( state, feed.blog_ID ),
+		};
+	}
+)( localize( FeedStream ) );
+

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -19,6 +19,11 @@ import QueryReaderFeed from 'components/data/query-reader-feed';
 import { getSite } from 'state/reader/sites/selectors';
 import { getFeed } from 'state/reader/feeds/selectors';
 
+// If the blog_ID of a reader feed is 0, that means no site exists for it.
+const getReaderSiteId = feed => feed && feed.blog_ID === 0
+		? null
+		: feed && feed.blog_ID;
+
 class FeedStream extends React.Component {
 
 	static propTypes = {
@@ -46,7 +51,7 @@ class FeedStream extends React.Component {
 		}
 
 		if ( ! title && site ) {
-			title = site.get( 'name' );
+			title = site.name;
 		}
 
 		if ( ! title && feed ) {
@@ -57,7 +62,7 @@ class FeedStream extends React.Component {
 		}
 
 		if ( ! title && site ) {
-			title = site.get( 'URL' );
+			title = site.URL;
 			if ( title ) {
 				title = url.parse( title ).hostname;
 			}
@@ -71,7 +76,7 @@ class FeedStream extends React.Component {
 	}
 
 	render() {
-		const { feed, site } = this.props;
+		const { feed, site, siteId } = this.props;
 		const emptyContent = ( <EmptyContent /> );
 		const title = this.getTitle( feed, site );
 
@@ -91,7 +96,7 @@ class FeedStream extends React.Component {
 				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: title } ) } />
 				<RefreshFeedHeader feed={ feed } site={ site } showBack={ this.props.showBack } />
 				{ ! feed && <QueryReaderFeed feedId={ this.props.feedId } /> }
-				{ ! site && feed && feed.blog_ID && <QueryReaderSite siteId={ feed.blog_ID } /> }
+				{ siteId && <QueryReaderSite siteId={ siteId } /> }
 			</Stream>
 		);
 	}
@@ -100,9 +105,12 @@ class FeedStream extends React.Component {
 export default connect(
 	( state, ownProps ) => {
 		const feed = getFeed( state, ownProps.feedId );
+		const siteId = getReaderSiteId( feed );
+
 		return {
 			feed,
-			site: feed && feed.blog_ID && getSite( state, feed.blog_ID ),
+			siteId,
+			site: siteId && getSite( state, siteId ),
 		};
 	}
 )( localize( FeedStream ) );

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -91,7 +91,7 @@ class FeedStream extends React.Component {
 				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: title } ) } />
 				<RefreshFeedHeader feed={ feed } site={ site } showBack={ this.props.showBack } />
 				{ ! feed && <QueryReaderFeed feedId={ this.props.feedId } /> }
-				{ ! site && feed.blog_ID && <QueryReaderSite siteId={ feed.blog_ID } /> }
+				{ ! site && feed && feed.blog_ID && <QueryReaderSite siteId={ feed.blog_ID } /> }
 			</Stream>
 		);
 	}

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -2,36 +2,23 @@
  * External dependencies
  */
 import React from 'react';
-import page from 'page';
-import { includes } from 'lodash';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import page from 'page';
 
 /**
  * Internal dependencies
  */
 import DocumentHead from 'components/data/document-head';
 import RefreshFeedHeader from 'blocks/reader-feed-header';
-import FeedFeatured from './featured';
 import EmptyContent from './empty';
 import Stream from 'reader/stream';
-import SiteStore from 'lib/reader-site-store';
-import SiteStoreActions from 'lib/reader-site-store/actions';
-import { state as SiteState } from 'lib/reader-site-store/constants';
 import FeedError from 'reader/feed-error';
-import FeedStore from 'lib/feed-store';
-import FeedStoreActions from 'lib/feed-store/actions';
-import { state as FeedState } from 'lib/feed-store/constants';
-import * as FeedStreamStoreActions from 'lib/feed-stream-store/actions';
-import feedStreamFactory from 'lib/feed-stream-store';
-import smartSetState from 'lib/react-smart-set-state';
-
-function checkForRedirect( site ) {
-	if ( site && site.get( 'prefer_feed' ) && site.get( 'feed_ID' ) ) {
-		setTimeout( function() {
-			page.replace( '/read/feeds/' + site.get( 'feed_ID' ) );
-		}, 0 );
-	}
-}
+import { getSite } from 'state/reader/sites/selectors';
+import { getFeed } from 'state/reader/feeds/selectors';
+import QueryReaderSite from 'components/data/query-reader-site';
+import QueryReaderFeed from 'components/data/query-reader-feed';
+import FeedFeatured from './featured';
 
 class SiteStream extends React.Component {
 
@@ -40,6 +27,7 @@ class SiteStream extends React.Component {
 		className: React.PropTypes.string,
 		showBack: React.PropTypes.bool,
 		isDiscoverStream: React.PropTypes.bool,
+		featuredStore: React.PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -48,85 +36,6 @@ class SiteStream extends React.Component {
 		isDiscoverStream: false,
 	};
 
-	constructor( props ) {
-		super( props );
-		this.state = this.getState( props );
-		this.smartSetState = smartSetState;
-	}
-
-	componentDidMount() {
-		SiteStore.on( 'change', this.updateState );
-		FeedStore.on( 'change', this.updateState );
-	}
-
-	componentWillUnmount() {
-		SiteStore.off( 'change', this.updateState );
-		FeedStore.off( 'change', this.updateState );
-	}
-
-	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.siteId !== this.props.siteId ) {
-			this.updateState( nextProps );
-		}
-	}
-
-	getState = ( props = this.props ) => {
-		const { site, feed } = this.getSiteAndFeed( props.siteId );
-		checkForRedirect( site );
-
-		const state = {
-			feed,
-			site,
-			title: props.title || this.getTitle( site )
-		};
-
-		return state;
-	}
-
-	updateState = ( props = this.props ) => {
-		const state = this.getState( props );
-		checkForRedirect( state.site );
-		this.smartSetState( state );
-	}
-
-	getSiteAndFeed = ( siteId ) => {
-		let site = SiteStore.get( siteId ),
-			feed;
-
-		if ( ! site ) {
-			SiteStoreActions.fetch( siteId );
-		}
-
-		if ( site && ! includes( [ SiteState.COMPLETE, SiteState.ERROR ], site.get( 'state' ) ) ) {
-			site = null; // don't accept an incomplete site
-		}
-
-		if ( site && site.get( 'state' ) === SiteState.COMPLETE && site.get( 'feed_ID' ) ) {
-			feed = FeedStore.get( site.get( 'feed_ID' ) );
-			if ( ! feed ) {
-				setTimeout( () => {
-					FeedStoreActions.fetch( site.get( 'feed_ID' ) );
-				}, 0 );
-			} else if ( feed.state !== FeedState.COMPLETE ) {
-				feed = null;
-			}
-		}
-
-		return { site, feed };
-	}
-
-	getTitle = ( site ) => {
-		if ( ! site ) {
-			return;
-		}
-
-		if ( site.get( 'state' ) === SiteState.COMPLETE ) {
-			return site.get( 'title' ) || site.get( 'domain' );
-		} else if ( site.get( 'state' ) === SiteState.ERROR ) {
-			return this.props.translate( 'Error fetching site' );
-		}
-	}
-
 	goBack = () => {
 		if ( typeof window !== 'undefined' ) {
 			window.history.back();
@@ -134,25 +43,21 @@ class SiteStream extends React.Component {
 	}
 
 	render() {
-		const site = this.state.site,
-			emptyContent = ( <EmptyContent /> );
-		let title = this.state.title,
-			featuredStore = null,
-			featuredContent = null;
-
-		if ( ! title ) {
-			title = this.props.translate( 'Loading Site' );
+		const { site, feed, featuredStore } = this.props;
+		// check for redirect
+		if ( site && site.prefer_feed && site.feed_ID ) {
+			page.replace( '/read/feeds/' + site.feed_ID );
 		}
 
-		if ( site && site.get( 'state' ) === SiteState.ERROR ) {
+		const emptyContent = ( <EmptyContent /> );
+		const title = site
+			? site.name
+			: this.props.translate( 'Loading Site' );
+
+		if ( ( site && site.is_error ) || ( feed && feed.is_error ) ) {
 			return <FeedError sidebarTitle={ title } />;
 		}
-
-		if ( site && site.get( 'has_featured' ) ) {
-			featuredStore = feedStreamFactory( 'featured:' + site.get( 'ID' ) );
-			setTimeout( () => FeedStreamStoreActions.fetchNextPage( featuredStore.id ), 0 ); // timeout to prevent invariant violations
-			featuredContent = ( <FeedFeatured store={ featuredStore } /> );
-		}
+		const featuredContent = featuredStore && ( <FeedFeatured store={ featuredStore } /> );
 
 		return (
 			<Stream
@@ -165,12 +70,22 @@ class SiteStream extends React.Component {
 				shouldCombineCards={ false }
 			>
 				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: title } ) } />
-				<RefreshFeedHeader site={ site } feed={ this.state.feed } showBack={ this.props.showBack } />
+				<RefreshFeedHeader site={ site } feed={ feed } showBack={ this.props.showBack } />
 				{ featuredContent }
+				{ ! site && <QueryReaderSite siteId={ this.props.siteId } /> }
+				{ ! feed && site && site.feed_ID && <QueryReaderFeed feedId={ site.feed_ID } /> }
 			</Stream>
 
 		);
 	}
 }
 
-export default localize( SiteStream );
+export default connect(
+	( state, ownProps ) => {
+		const site = getSite( state, ownProps.siteId );
+		return {
+			site: site,
+			feed: site && site.feed_ID && getFeed( state, site.feed_ID ),
+		};
+	}
+)( localize( SiteStream ) );


### PR DESCRIPTION
Connect the site stream and feed stream to Redux.

### Questions

#### Was it okay to remove checkForRedirect?
answer: No.  We need `checkForRedirect`.  Sometimes if someone somehow gets to a route like /blogs/blogid/post/postId and we _know_ that the feed is more reliable than the site, we will want to redirect them.  This is especially true for some vip jetpack sites.  

There is a field called `prefer_feed` that sites have.  It only exists as a property when it is true.

#### What is has_featured for?  I deleted a whole bit about featured feeds but probably need to put those back in

has_featured was a property we were using to say that it had a "featured posts" section at the top like Discover.  Since this is only true for Discover I special cased the whole thing anyway.  No need to generalize there.

### To test

Play with the site-stream- specifically going to /blog/ and /feed/ addresses, e.g.:

http://calypso.localhost:3000/read/blogs/122463145

http://calypso.localhost:3000/read/feeds/15197253