### PR TITLE
Editor: Add ltr button for RTL users

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -13,6 +13,7 @@ require( 'tinymce/themes/modern/theme.js' );
 
 // TinyMCE plugins
 require( 'tinymce/plugins/colorpicker/plugin.js' );
+require( 'tinymce/plugins/directionality/plugin.js' );
 require( 'tinymce/plugins/hr/plugin.js' );
 require( 'tinymce/plugins/lists/plugin.js' );
 require( 'tinymce/plugins/media/plugin.js' );
@@ -117,6 +118,7 @@ const PLUGINS = [
 	'wpeditimage',
 	'wplink',
 	'AtD',
+	'directionality',
 	'wpcom/autoresize',
 	'wpcom/media',
 	'wpcom/advanced',
@@ -233,6 +235,11 @@ module.exports = React.createClass( {
 
 		this.localize();
 
+		const ltrButton = user.isRTL() ? 'ltr,' : null;
+		const toolbar1 = config.isEnabled( 'post-editor/insert-menu' )
+				? `wpcom_insert_menu,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,${ ltrButton }wpcom_advanced`
+				: `wpcom_add_media,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,wpcom_add_contact_form,${ ltrButton }wpcom_advanced`;
+
 		tinymce.init( {
 			selector: '#' + this._id,
 			skin_url: '//s1.wp.com/wp-includes/js/tinymce/skins/lightgray',
@@ -305,9 +312,7 @@ module.exports = React.createClass( {
 			autoresize_min_height: Math.max( document.documentElement.clientHeight - 300, 300 ),
 			autoresize_bottom_margin: viewport.isMobile() ? 10 : 50,
 
-			toolbar1: config.isEnabled( 'post-editor/insert-menu' )
-				? 'wpcom_insert_menu,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,wpcom_advanced'
-				: 'wpcom_add_media,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,wpcom_add_contact_form,wpcom_advanced',
+			toolbar1: toolbar1,
 			toolbar2: 'strikethrough,underline,hr,alignjustify,forecolor,pastetext,removeformat,wp_charmap,outdent,indent,undo,redo,wp_help',
 			toolbar3: '',
 			toolbar4: '',

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -235,7 +235,7 @@ module.exports = React.createClass( {
 
 		this.localize();
 
-		const ltrButton = user.isRTL() ? 'ltr,' : null;
+		const ltrButton = user.isRTL() ? 'ltr,' : '';
 		const toolbar1 = config.isEnabled( 'post-editor/insert-menu' )
 				? `wpcom_insert_menu,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,${ ltrButton }wpcom_advanced`
 				: `wpcom_add_media,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,wpcom_add_contact_form,${ ltrButton }wpcom_advanced`;


### PR DESCRIPTION
This fixes #12061 by adding in support for the `directionality` plugin and the corresponding `ltr` button for users with an RTL interface language.

__Before__
<img width="789" alt="_ _ _trout_bummin_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/24227602/75a6f6ce-0f2b-11e7-9a16-3106234ef5b8.png">

__After__
<img width="789" alt="_ _ _testing_timmy_timmay_timmaay_timmaaay_timmaaaay_timmaaaaay_timmaaaaaay_timmaaaaaaay_timmaaaaaaaay_timmaaaaaaaaay_timmaaaaaaaaaay_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/24227566/479dba60-0f2b-11e7-8e16-ad86cf5d0396.png">

__To Test__
- Set your interface language to Hebrew
- Open the editor, and verify the LTR button is shown on the upper toolbar
- Set your interface language to a non RTL language
- Open the editor and verify the button is not shown

While implementing this, I checked to see if we could possibly remove the config `post-editor/insert-menu` - but it appears that this is still disabled for desktop.  @jasmussen do you by chance know why this feature is disabled in desktop?  Without it - adding media to posts isn't nearly as full featured.