### PR TITLE
Reader fix bottom border color on combined-card

### DIFF
--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -226,7 +226,7 @@
 
 // Override standard .card styles in stream
 .reader-combined-card.card {
-	border-bottom: 1px solid lighten( $gray, 30% );
+	border-bottom: 1px solid lighten( $gray, 20% );
 	box-shadow: none;
 	margin: 0 15px;
 	padding: 18px 0 0;


### PR DESCRIPTION
This PR adds a change that was inadvertently left out of https://github.com/Automattic/wp-calypso/pull/12403.