### PR TITLE
Add back no-restricted-modules and no-restricted-imports ESLint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,9 @@ module.exports = {
 	},
 	rules: {
 		camelcase: 0, // REST API objects include underscores
-		'no-unused-expressions': 0, // Allows Chai `expect` expressions
 		'max-len': [ 2, { code: 140 } ],
+		'no-restricted-imports': [ 2, 'lib/sites-list', 'lib/mixins/data-observe' ],
+		'no-restricted-modules': [ 2, 'lib/sites-list', 'lib/mixins/data-observe' ],
+		'no-unused-expressions': 0, // Allows Chai `expect` expressions
 	}
 };


### PR DESCRIPTION
They were removed in #6945 inadvertently.