### PR TITLE
MagicSearch: add initial value to Search.

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -239,6 +239,7 @@ class ThemesMagicSearchCard extends React.Component {
 		const searchField = (
 			<Search
 				onSearch={ this.props.onSearch }
+				initialValue={ this.state.searchInput }
 				value={ this.state.searchInput }
 				ref="url-search"
 				placeholder={ translate( 'What kind of theme are you looking for?' ) }


### PR DESCRIPTION
### Info
MagicSearch does not load initial value properly. After some changes to Search component we need to use initial value prop to start Search in MagicSearch - probably we could do that always but for some reason this was not needed until now. 

### Testing
Go to `/design` start searching, add a token and then hit refresh. Search should have the values back in the search filed. Compare to the current wp.com where after refresh input is empty. All other functionalities of search should still work.
