### PR TITLE
Refactor to use renderWithReduxStore helper

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -54,6 +54,7 @@ var config = require( 'config' ),
 
 import { getSelectedSiteId, getSectionName } from 'state/ui/selectors';
 import { setNextLayoutFocus, activateNextLayoutFocus } from 'state/ui/layout-focus/actions';
+import { renderWithReduxStore } from 'lib/react-helpers';
 
 function init() {
 	var i18nLocaleStringsObject = null;
@@ -165,14 +166,7 @@ function boot() {
 function renderLayout( reduxStore ) {
 	const Layout = require( 'controller' ).ReduxWrappedLayout;
 
-	const layoutElement = React.createElement( Layout, {
-		store: reduxStore
-	} );
-
-	ReactDom.render(
-		layoutElement,
-		document.getElementById( 'wpcom' )
-	);
+	renderWithReduxStore( React.createElement( Layout, { store: reduxStore } ), 'wpcom', reduxStore );
 
 	debug( 'Main layout rendered.' );
 }

--- a/client/components/tinymce/plugins/contact-form/plugin.jsx
+++ b/client/components/tinymce/plugins/contact-form/plugin.jsx
@@ -4,9 +4,8 @@
 import tinymce from 'tinymce/tinymce';
 import i18n from 'i18n-calypso';
 import React, { createElement } from 'react';
-import { render, unmountComponentAtNode } from 'react-dom';
+import { unmountComponentAtNode } from 'react-dom';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { Provider } from 'react-redux';
 import Gridicon from 'gridicons';
 
 /**
@@ -22,6 +21,7 @@ import {
 	settingsUpdate
 } from 'state/ui/editor/contact-form/actions';
 import { serialize, deserialize } from './shortcode-utils';
+import { renderWithReduxStore } from 'lib/react-helpers';
 
 const wpcomContactForm = editor => {
 	let node;
@@ -49,40 +49,43 @@ const wpcomContactForm = editor => {
 		}
 
 		function renderModal( visibility = 'show', activeTab = 'fields' ) {
-			render(
-				createElement( Provider, { store },
-					createElement( ContactFormDialog, {
-						showDialog: visibility === 'show',
-						activeTab,
-						isEdit,
-						onInsert() {
-							const state = store.getState();
-							editor.execCommand( 'mceInsertContent', false, serialize( state.ui.editor.contactForm ) );
-							renderModal( 'hide' );
-						},
-						onChangeTabs( tab ) {
-							renderModal( 'show', tab );
-						},
-						onClose() {
-							store.dispatch( formClear() );
-							editor.focus();
-							renderModal( 'hide' );
-						},
-						onFieldAdd() {
-							store.dispatch( fieldAdd() );
-						},
-						onFieldRemove( index ) {
-							store.dispatch( fieldRemove( index ) );
-						},
-						onFieldUpdate( index, field ) {
-							store.dispatch( fieldUpdate( index, field ) );
-						},
-						onSettingsUpdate( settings ) {
-							store.dispatch( settingsUpdate( settings ) );
-						}
-					} )
-				),
-				node
+			renderWithReduxStore(
+				createElement( ContactFormDialog, {
+					showDialog: visibility === 'show',
+					activeTab,
+					isEdit,
+					onInsert() {
+						const state = store.getState();
+						editor.execCommand(
+							'mceInsertContent',
+							false,
+							serialize( state.ui.editor.contactForm )
+						);
+						renderModal( 'hide' );
+					},
+					onChangeTabs( tab ) {
+						renderModal( 'show', tab );
+					},
+					onClose() {
+						store.dispatch( formClear() );
+						editor.focus();
+						renderModal( 'hide' );
+					},
+					onFieldAdd() {
+						store.dispatch( fieldAdd() );
+					},
+					onFieldRemove( index ) {
+						store.dispatch( fieldRemove( index ) );
+					},
+					onFieldUpdate( index, field ) {
+						store.dispatch( fieldUpdate( index, field ) );
+					},
+					onSettingsUpdate( settings ) {
+						store.dispatch( settingsUpdate( settings ) );
+					}
+				} ),
+				node,
+				store
 			);
 		}
 

--- a/client/components/tinymce/plugins/media/advanced/index.jsx
+++ b/client/components/tinymce/plugins/media/advanced/index.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import ReactDom from 'react-dom';
 import ReactDomServer from 'react-dom/server';
-import { Provider as ReduxProvider } from 'react-redux';
 import i18n from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
@@ -14,6 +13,7 @@ import Gridicon from 'gridicons';
 import * as MediaSerialization from 'lib/media-serialization';
 import config from 'config';
 import EditorMediaAdvanced from 'post-editor/editor-media-advanced';
+import { renderWithReduxStore } from 'lib/react-helpers';
 
 export default function( editor ) {
 	const store = editor.getParam( 'redux_store' );
@@ -33,14 +33,13 @@ export default function( editor ) {
 			return unmount();
 		}
 
-		ReactDom.render(
-			<ReduxProvider store={ store }>
-				<EditorMediaAdvanced
-					{ ...{ visible, item } }
-					onClose={ hideModal }
-					insertMedia={ insertMedia } />
-			</ReduxProvider>,
-			container
+		renderWithReduxStore(
+			<EditorMediaAdvanced
+				{ ...{ visible, item } }
+				onClose={ hideModal }
+				insertMedia={ insertMedia } />,
+			container,
+			store
 		);
 	}
 

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -3,7 +3,6 @@
  */
 import ReactDom from 'react-dom';
 import ReactDomServer from 'react-dom/server';
-import { Provider as ReduxProvider } from 'react-redux';
 import React from 'react';
 import tinymce from 'tinymce/tinymce';
 import { assign, debounce, find, findLast, pick, values } from 'lodash';
@@ -33,6 +32,7 @@ import config from 'config';
 import { getSelectedSite } from 'state/ui/selectors';
 import { setEditorMediaModalView } from 'state/ui/editor/actions';
 import { ModalViews } from 'state/ui/media-modal/constants';
+import { renderWithReduxStore } from 'lib/react-helpers';
 
 /**
  * Module variables
@@ -89,17 +89,18 @@ function mediaButton( editor ) {
 			store.dispatch( setEditorMediaModalView( view ) );
 		}
 
-		ReactDom.render(
-			<ReduxProvider store={ store }>
-				<EditorMediaModal
-					{ ...props }
-					onClose={ renderModal.bind( null, { visible: false } ) }
-					onInsertMedia={ ( markup ) => {
-						insertMedia( markup );
-						renderModal( { visible: false } );
-					} } />
-			</ReduxProvider>,
-			nodes.modal
+		renderWithReduxStore(
+			<EditorMediaModal
+				{ ...props }
+				/* eslint-disable react/jsx-no-bind */
+				onClose={ renderModal.bind( null, { visible: false } ) }
+				/* eslint-disable react/jsx-no-bind */
+				onInsertMedia={ ( markup ) => {
+					insertMedia( markup );
+					renderModal( { visible: false } );
+				} } />,
+			nodes.modal,
+			store
 		);
 	}
 

--- a/client/components/tinymce/plugins/mentions/plugin.jsx
+++ b/client/components/tinymce/plugins/mentions/plugin.jsx
@@ -4,13 +4,13 @@
 import tinymce from 'tinymce/tinymce';
 import ReactDom from 'react-dom';
 import React from 'react';
-import { Provider as ReduxProvider } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import Mentions from './mentions';
 import { getSelectedSite } from 'state/ui/selectors';
+import { renderWithReduxStore } from 'lib/react-helpers';
 
 /**
  * Module variables
@@ -29,11 +29,10 @@ function mentions( editor ) {
 			node.setAttribute( 'class', 'mentions__container' );
 			editor.getContainer().appendChild( node );
 
-			ReactDom.render(
-				<ReduxProvider store={ store }>
-					<Mentions editor={ editor } node={ node } />
-				</ReduxProvider>,
-				node
+			renderWithReduxStore(
+				<Mentions editor={ editor } node={ node } />,
+				node,
+				store
 			);
 
 			isRendered = true;

--- a/client/components/tinymce/plugins/wpcom-view/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-view/plugin.js
@@ -15,13 +15,14 @@ var tinymce = require( 'tinymce/tinymce' ),
 	ReactDom = require( 'react-dom' ),
 	React = require( 'react'),
 	i18n = require( 'i18n-calypso' );
-import { Provider as ReduxProvider } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 var views = require( './views' ),
 	sites = require( 'lib/sites-list' )();
+
+import { renderWithReduxStore } from 'lib/react-helpers';
 
 /**
  * WordPress View plugin.
@@ -90,15 +91,14 @@ function wpview( editor ) {
 
 			type = $view.attr( 'data-wpview-type' );
 
-			ReactDom.render(
-				React.createElement( ReduxProvider, { store: editor.getParam( 'redux_store' ) },
-					React.createElement( views.components[ type ], {
-						content: getText( view ),
-						siteId: sites.getSelectedSite() ? sites.getSelectedSite().ID : null,
-						onResize: debounce( triggerNodeChanged, 500 )
-					} )
-				),
-				$view.find( '.wpview-body' )[ 0 ]
+			renderWithReduxStore(
+				React.createElement( views.components[ type ], {
+					content: getText( view ),
+					siteId: sites.getSelectedSite() ? sites.getSelectedSite().ID : null,
+					onResize: debounce( triggerNodeChanged, 500 )
+				} ),
+				$view.find( '.wpview-body' )[0],
+				editor.getParam( 'redux_store' )
 			);
 
 			$view.attr( 'data-wpview-rendered', '' );
@@ -656,7 +656,7 @@ function wpview( editor ) {
 					}
 				}
 				event.preventDefault();
-			} else if ( cursorBefore && ( key === VK.UP || key ===  VK.LEFT ) ) {
+			} else if ( cursorBefore && ( key === VK.UP || key === VK.LEFT ) ) {
 				if ( view.previousSibling ) {
 					if ( getView( view.previousSibling ) ) {
 						setViewCursor( key === VK.UP, view.previousSibling );

--- a/client/components/tinymce/plugins/wplink/plugin.js
+++ b/client/components/tinymce/plugins/wplink/plugin.js
@@ -13,26 +13,24 @@ var ReactDom = require( 'react-dom' ),
 	tinymce = require( 'tinymce/tinymce' ),
 	translate = require( 'i18n-calypso' ).translate;
 
-import { Provider as ReduxProvider } from 'react-redux';
-
 /**
  * Internal dependencies
  */
 var LinkDialog = require( './dialog' );
+import { renderWithReduxStore } from 'lib/react-helpers';
 
 function wpLink( editor ) {
 	var node, toolbar;
 
 	function render( visible = true ) {
-		ReactDom.render(
-			React.createElement( ReduxProvider, { store: editor.getParam( 'redux_store' ) },
-				React.createElement( LinkDialog, {
-					visible: visible,
-					editor: editor,
-					onClose: () => render( false )
-				} )
-			),
-			node
+		renderWithReduxStore(
+			React.createElement( LinkDialog, {
+				visible: visible,
+				editor: editor,
+				onClose: () => render( false )
+			} ),
+			node,
+			editor.getParam( 'redux_store' )
 		);
 
 		if ( ! visible ) {

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -18,6 +18,7 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import userFactory from 'lib/user';
 import sitesFactory from 'lib/sites-list';
 import debugFactory from 'debug';
+import { renderWithReduxStore } from 'lib/react-helpers';
 
 /**
  * Re-export
@@ -89,12 +90,7 @@ function renderPrimary( context ) {
 
 	if ( primary ) {
 		debug( 'Rendering primary', primary );
-		ReactDom.render(
-			<ReduxProvider store={ store }>
-				{ primary }
-			</ReduxProvider>,
-			document.getElementById( 'primary' )
-		);
+		renderWithReduxStore( primary, 'primary', store );
 	}
 }
 
@@ -106,11 +102,6 @@ function renderSecondary( context ) {
 		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 	} else if ( secondary !== undefined ) {
 		debug( 'Rendering secondary' );
-		ReactDom.render(
-			<ReduxProvider store={ store }>
-				{ secondary }
-			</ReduxProvider>,
-			document.getElementById( 'secondary' )
-		);
+		renderWithReduxStore( secondary, 'secondary', store );
 	}
 }

--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -6,7 +6,6 @@ import React from 'react';
 import qs from 'qs';
 import debounce from 'lodash/debounce';
 import page from 'page';
-import { Provider as ReduxProvider } from 'react-redux';
 import url from 'url';
 
 /**
@@ -22,6 +21,7 @@ import DevWelcome from './welcome';
 import Sidebar from './sidebar';
 import FormStateExamplesComponent from './form-state-examples';
 import EmptyContent from 'components/empty-content';
+import { renderWithReduxStore } from 'lib/react-helpers';
 
 const devdocs = {
 
@@ -93,37 +93,34 @@ const devdocs = {
 
 	// UI components
 	design: function( context ) {
-		ReactDom.render(
-			React.createElement( ReduxProvider, { store: context.store },
-				React.createElement( DesignAssetsComponent, {
-					component: context.params.component
-				} )
-			),
-			document.getElementById( 'primary' )
+		renderWithReduxStore(
+			React.createElement( DesignAssetsComponent, {
+				component: context.params.component
+			} ),
+			'primary',
+			context.store
 		);
 	},
 
 	// App Blocks
 	blocks: function( context ) {
-		ReactDom.render(
-			React.createElement( ReduxProvider, { store: context.store },
-				React.createElement( Blocks, {
-					component: context.params.component
-				} )
-			),
-			document.getElementById( 'primary' )
+		renderWithReduxStore(
+			React.createElement( Blocks, {
+				component: context.params.component
+			} ),
+			'primary',
+			context.store
 		);
 	},
 
 	selectors: function( context ) {
-		ReactDom.render(
-			React.createElement( ReduxProvider, { store: context.store },
-				React.createElement( DocsSelectors, {
-					selector: context.params.selector,
-					search: context.query.search
-				} )
-			),
-			document.getElementById( 'primary' )
+		renderWithReduxStore(
+			React.createElement( DocsSelectors, {
+				selector: context.params.selector,
+				search: context.query.search
+			} ),
+			'primary',
+			context.store
 		);
 	},
 

--- a/client/me/help/controller.js
+++ b/client/me/help/controller.js
@@ -1,9 +1,7 @@
 /**
  * External dependencies
  */
-import ReactDom from 'react-dom';
 import React from 'react';
-import { Provider as ReduxProvider } from 'react-redux';
 import i18n from 'i18n-calypso';
 
 /**
@@ -54,11 +52,10 @@ export default {
 
 		analytics.pageView.record( basePath, 'Help > Courses' );
 
-		ReactDom.render(
-			<ReduxProvider store={ context.store } >
-				<CoursesComponent />
-			</ReduxProvider>,
-			document.getElementById( 'primary' )
+		renderWithReduxStore(
+			<CoursesComponent />,
+			'primary',
+			context.store
 		);
 	},
 
@@ -72,11 +69,10 @@ export default {
 			window.scrollTo( 0, 0 );
 		}
 
-		ReactDom.render(
-			<ReduxProvider store={ context.store } >
-				<ContactComponent clientSlug={ config( 'client_slug' ) } />
-			</ReduxProvider>,
-			document.getElementById( 'primary' )
+		renderWithReduxStore(
+			<ContactComponent clientSlug={ config( 'client_slug' ) } />,
+			'primary',
+			context.store
 		);
 	}
 };

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -3,7 +3,6 @@
  */
 import ReactDom from 'react-dom';
 import React from 'react';
-import { Provider as ReduxProvider } from 'react-redux';
 import page from 'page';
 import some from 'lodash/some';
 import capitalize from 'lodash/capitalize';
@@ -88,18 +87,17 @@ function renderPluginList( context, basePath ) {
 	lastPluginsListVisited = getPathWithoutSiteSlug( context, site );
 	lastPluginsQuerystring = context.querystring;
 
-	ReactDom.render(
-		React.createElement( ReduxProvider, { store: context.store },
-			React.createElement( PluginListComponent, {
-				path: basePath,
-				context,
-				filter: context.params.pluginFilter,
-				category: context.params.category,
-				sites,
-				search
-			} )
-		),
-		document.getElementById( 'primary' )
+	renderWithReduxStore(
+		React.createElement( PluginListComponent, {
+			path: basePath,
+			context,
+			filter: context.params.pluginFilter,
+			category: context.params.category,
+			sites,
+			search
+		} ),
+		'primary',
+		context.store
 	);
 
 	if ( search ) {

--- a/client/my-sites/posts/controller.js
+++ b/client/my-sites/posts/controller.js
@@ -2,12 +2,9 @@
  * External Dependencies
  */
 var page = require( 'page' ),
-	ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:my-sites:posts' ),
 	i18n = require( 'i18n-calypso' );
-
-import { Provider } from 'react-redux';
 
 /**
  * Internal Dependencies
@@ -19,6 +16,8 @@ var user = require( 'lib/user' )(),
 	titlecase = require( 'to-title-case' ),
 	trackScrollPage = require( 'lib/track-scroll-page' ),
 	setTitle = require( 'state/document-head/actions' ).setDocumentHeadTitle;
+
+import { renderWithReduxStore } from 'lib/react-helpers';
 
 module.exports = {
 
@@ -77,24 +76,23 @@ module.exports = {
 
 		analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
 
-		ReactDom.render(
-			React.createElement( Provider, { store: context.store },
-				React.createElement( Posts, {
-					context: context,
-					siteID: siteID,
-					author: author,
-					statusSlug: statusSlug,
-					sites: sites,
-					search: search,
-					trackScrollPage: trackScrollPage.bind(
-						null,
-						baseAnalyticsPath,
-						analyticsPageTitle,
-						'Posts'
-					)
-				} )
-			),
-			document.getElementById( 'primary' )
+		renderWithReduxStore(
+			React.createElement( Posts, {
+				context: context,
+				siteID: siteID,
+				author: author,
+				statusSlug: statusSlug,
+				sites: sites,
+				search: search,
+				trackScrollPage: trackScrollPage.bind(
+					null,
+					baseAnalyticsPath,
+					analyticsPageTitle,
+					'Posts'
+				)
+			} ),
+			'primary',
+			context.store
 		);
 	}
 };

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -4,7 +4,6 @@
 import ReactDom from 'react-dom';
 import React from 'react';
 import page from 'page';
-import { Provider as ReduxProvider } from 'react-redux';
 import i18n from 'i18n-calypso';
 
 /**
@@ -159,25 +158,24 @@ module.exports = {
 		setPageTitle( context, i18n.translate( 'Following' ) );
 
 		// warn: don't async load this only. we need it to keep feed-post-store in the reader bundle
-		ReactDom.render(
-			React.createElement( ReduxProvider, { store: context.store },
-				React.createElement( StreamComponent, {
-					key: 'following',
-					listName: i18n.translate( 'Followed Sites' ),
-					postsStore: followingStore,
-					recommendationsStore,
-					showPrimaryFollowButtonOnCards: false,
-					trackScrollPage: trackScrollPage.bind(
-						null,
-						basePath,
-						fullAnalyticsPageTitle,
-						analyticsPageTitle,
-						mcKey
-					),
-					onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey )
-				} )
-			),
-			document.getElementById( 'primary' )
+		renderWithReduxStore(
+			React.createElement( StreamComponent, {
+				key: 'following',
+				listName: i18n.translate( 'Followed Sites' ),
+				postsStore: followingStore,
+				recommendationsStore,
+				showPrimaryFollowButtonOnCards: false,
+				trackScrollPage: trackScrollPage.bind(
+					null,
+					basePath,
+					fullAnalyticsPageTitle,
+					analyticsPageTitle,
+					mcKey
+				),
+				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey )
+			} ),
+			'primary',
+			context.store
 		);
 	},
 

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -3,7 +3,6 @@
  */
 import ReactDom from 'react-dom';
 import React from 'react';
-import { Provider as ReduxProvider } from 'react-redux';
 import page from 'page';
 import qs from 'qs';
 import isEmpty from 'lodash/isEmpty';
@@ -18,6 +17,7 @@ import SignupComponent from './main';
 import utils from './utils';
 import userModule from 'lib/user';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
+import { renderWithReduxStore } from 'lib/react-helpers';
 
 const user = userModule();
 
@@ -85,19 +85,18 @@ export default {
 		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 		context.store.dispatch( setLayoutFocus( 'content' ) );
 
-		ReactDom.render(
-			React.createElement( ReduxProvider, { store: context.store },
-				React.createElement( SignupComponent, {
-					path: context.path,
-					refParameter,
-					queryObject,
-					locale: utils.getLocale( context.params ),
-					flowName: flowName,
-					stepName: stepName,
-					stepSectionName: stepSectionName
-				} )
-			),
-			document.getElementById( 'primary' )
+		renderWithReduxStore(
+			React.createElement( SignupComponent, {
+				path: context.path,
+				refParameter,
+				queryObject,
+				locale: utils.getLocale( context.params ),
+				flowName: flowName,
+				stepName: stepName,
+				stepSectionName: stepSectionName
+			} ),
+			'primary',
+			context.store
 		);
 	}
 };


### PR DESCRIPTION
Use `renderWithReduxStore` helper, results in shorter code and a single point where we can introduce a HOC, for example, for[ inserting / removing JS bundled CSS](https://github.com/Automattic/wp-calypso/pull/12210/files#diff-f0c3b9fbf283478607f5112967244528R42).

Related: #11959 #12210 

#### Affected components:
```
boot/index.js
components/tinymce/plugins/contact-form/plugin.jsx
components/tinymce/plugins/media/advanced/index.jsx
components/tinymce/plugins/media/plugin.jsx
components/tinymce/plugins/mentions/plugin.jsx
components/tinymce/plugins/wpcom-view/plugin.js
components/tinymce/plugins/wplink/plugin.js
controller/index.web.js
devdocs/controller.js
me/help/controller.js
my-sites/plugins/controller.js
my-sites/posts/controller.js
reader/controller.js
signup/controller.js
```

#### Testing instructions
  
1. Run `git checkout update/unify-root-render-with-redux` and start your server, or open a [live branch](https://calypso.live/?branch=update/unify-root-render-with-redux)
2. Open the [`Home` page](http://calypso.localhost:3000/)
3. Check that affected components work as expected
  
#### Reviews
  
- [x] Code
- [x] Product
