### PR TITLE
Domains: Update section title on mobile navigation

### DIFF
--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -30,6 +30,7 @@ import QuerySiteDomains from 'components/data/query-site-domains';
 import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
 import DomainWarnings from 'my-sites/upgrades/components/domain-warnings';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 
 class CurrentPlan extends Component {
 	static propTypes = {
@@ -96,6 +97,7 @@ class CurrentPlan extends Component {
 
 		return (
 			<Main className="current-plan" wideLayout>
+				<SidebarNavigation />
 				<DocumentHead title={ translate( 'Plans', { textOnly: true } ) } />
 				<QuerySites siteId={ selectedSiteId } />
 				<QuerySitePlans siteId={ selectedSiteId } />

--- a/client/my-sites/upgrades/navigation.jsx
+++ b/client/my-sites/upgrades/navigation.jsx
@@ -49,11 +49,32 @@ const PlansNavigation = React.createClass( {
 		Dispatcher.unregister( this.dispatchToken );
 	},
 
+	getSectionTitle( path ) {
+		switch ( path ) {
+			case '/plans/my-plan':
+				return 'My Plan';
+
+			case '/plans':
+			case '/plans/monthly':
+				return 'Plans';
+
+			case '/domains/manage':
+			case '/domains/add':
+				return 'Domains';
+
+			case '/domains/manage/email':
+				return 'Email';
+
+			default:
+				return path.split( '?' )[ 0 ].replace( /\//g, ' ' );
+		}
+	},
+
 	render() {
 		const site = this.props.selectedSite;
 		const path = sectionify( this.props.path );
 		const hasPlan = site && site.plan && site.plan.product_slug !== 'free_plan';
-		const sectionTitle = path.split( '?' )[ 0 ].replace( /\//g, ' ' );
+		const sectionTitle = this.getSectionTitle( path );
 		const userCanManageOptions = get( site, 'capabilities.manage_options', false );
 		const canManageDomain = userCanManageOptions &&
 			( isATEnabledForCurrentSite() || ! site.jetpack );


### PR DESCRIPTION
Previously, we were splitting the path and using regex to come up with the section title for mobile navigation in Upgrades. This explicitly sets the section title depending on the path to address #12108. We use the previous regex method as a backup.

I also noticed that the mobile sidebar navigation was missing when visiting `/plans/my-plan/{ slug }`. That felt a bit weird as there wasn't a really simple way to get back to the sidebar after selecting `My Plan` in the navigation. I added it, but I can remove if this was intended.

## To test
1. Load up this branch and check it out on a mobile device.
2. Visit the following page: http://calypso.localhost:3000/domains/add/. The section title in the mobile navigation should read "Domains" (previously "domains add"). Continue to change the selection in the menu and notice that the section title adjusts accordingly.
3. Visit http://calypso.localhost:3000/plans/my-plan and verify that the mobile sidebar navigation does appear.

## Screenshots
(This captures the mobile nav + the updated section title)
<img width="749" alt="screen shot 2017-03-23 at 07 51 52" src="https://cloud.githubusercontent.com/assets/7240478/24250988/44cbdcea-0f9e-11e7-9294-b06d9c1e9217.png">
