### PR TITLE
Sharing: add a tour about sharing basics

### DIFF
--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -5,9 +5,11 @@ import { combineTours } from 'layout/guided-tours/config-elements';
 import { MainTour } from 'layout/guided-tours/tours/main-tour';
 import { TutorialSitePreviewTour } from 'layout/guided-tours/tours/tutorial-site-preview-tour';
 import { GDocsIntegrationTour } from 'layout/guided-tours/tours/gdocs-integration-tour';
+import { SharingBasicsTour } from 'layout/guided-tours/tours/sharing-basics-tour';
 
 export default combineTours( {
 	main: MainTour,
 	tutorialSitePreview: TutorialSitePreviewTour,
 	gdocsIntegrationTour: GDocsIntegrationTour,
+	sharingBasicsTour: SharingBasicsTour,
 } );

--- a/client/layout/guided-tours/tours/sharing-basics-tour.js
+++ b/client/layout/guided-tours/tours/sharing-basics-tour.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { translate } from 'i18n-calypso';
+import {
+	overEvery as and,
+} from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	makeTour,
+	Tour,
+	Step,
+	ButtonRow,
+	Next,
+	Quit,
+} from 'layout/guided-tours/config-elements';
+import {
+	isNewUser,
+} from 'state/ui/guided-tours/contexts';
+import { isDesktop } from 'lib/viewport';
+
+export const SharingBasicsTour = makeTour(
+	<Tour
+		name="sharingBasicsTour"
+		version="201703213"
+		path="/sharing"
+			when={ and(
+			isDesktop,
+			isNewUser,
+			) }
+		>
+		<Step
+			name="init"
+			placement="center"
+			style={ { animationDelay: '3s', } }
+			>
+			<p>
+				Welcome to Publicize, a tool you can use to share your site to social media.
+			</p>
+			<ButtonRow>
+				<Next step="connect-account">Continue</Next>
+				<Quit>Quit</Quit>
+			</ButtonRow>
+		</Step>
+
+		<Step
+			name="connect-account"
+			target=".sharing-services-group .sharing-service .button.is-primary"
+			placement="beside"
+			>
+			<p>
+			{
+					translate( 'Click {{strong}}Connect{{/strong}} to share your posts with a service.',
+						{
+							components: {
+								strong: <strong />,
+							}
+						} )
+				}
+			</p>
+			<ButtonRow>
+				<Quit primary>Got it, I'm ready to share!</Quit>
+			</ButtonRow>
+		</Step>
+
+	</Tour>
+);


### PR DESCRIPTION
A tour for `/sharing` that briefly explains what it is and what to do next. 

![sharingbasicstour](https://cloud.githubusercontent.com/assets/23619/24251758/37dc7a94-1016-11e7-98fc-16bffc55b589.gif)

Committing / opening a PR here for @mgalbritton who made the tour but can't commit because of an authentication issue that none of us was able to figure out. 