### PR TITLE
Site Settings: Update copy for Comment Blacklist in Discussion Settings

### DIFF
--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -478,7 +478,7 @@ class SiteSettingsFormDiscussion extends Component {
 			<FormFieldset>
 				<FormLegend>{ translate( 'Comment Blacklist' ) }</FormLegend>
 				<FormLabel htmlFor="blacklist_keys">{ translate(
-					'When a comment contains any of these words in its content, name, URL, e-mail, or IP, it will be marked as spam. ' +
+					'When a comment contains any of these words in its content, name, URL, e-mail, or IP, it will be put in the trash. ' +
 					'One word or IP per line. It will match inside words, so "press" will match "WordPress".'
 				) }</FormLabel>
 				<FormTextarea


### PR DESCRIPTION
In https://wordpress.com/settings/discussion/ copy for the Comment Blacklist section currently reads:

“When a comment contains any of these words in its content, name, URL, e-mail, or IP, it will be marked as spam.” 

![site_settings_ _kokkiestrialtestsite_ _wordpress_com](https://cloud.githubusercontent.com/assets/11873759/24254277/2097d7aa-0feb-11e7-9d12-95fc318f9425.png)

The actual behaviour for blacklisted terms is that they are sent to Trash instead, not to Spam. This is the behaviour on WordPress.com and Core, and is also what the copy indicates in {sitename}/wp-admin/options-discussion.php

With this change the copy will match that which appears in WP-Admin: “When a comment contains any of these words in its content, name, URL, email, or IP, it will be put in the trash.”

![site_settings_ _for_the_birds__mostly__ _wordpress_com](https://cloud.githubusercontent.com/assets/11873759/24254392/78fda988-0feb-11e7-8ee2-c7f9c8ebdc40.png)

Fixes #12445