### PR TITLE
Editor: Enable the HTML Toolbar to all environments

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -62,6 +62,7 @@
 		"persist-redux": true,
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,
+		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
 		"post-editor/mentions": false,
 		"press-this": false,

--- a/config/production.json
+++ b/config/production.json
@@ -70,6 +70,7 @@
 		"persist-redux": true,
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,
+		"post-editor/html-toolbar": true,
 		"post-editor/insert-menu": true,
 		"post-editor/image-editor": true,
 		"post-editor/mentions": false,


### PR DESCRIPTION
This PR enables the HTML Toolbar in `desktop` and `production` environments.

The toolbar has been tested extensively on all the major OS and browsers, both desktop and mobile, on Horizon, and on the desktop app.