### PR TITLE
Reader: switch x-posts to use ReaderAvatar

### DIFF
--- a/client/blocks/reader-avatar/README.md
+++ b/client/blocks/reader-avatar/README.md
@@ -1,0 +1,41 @@
+# Reader Avatar
+
+Display an avatar for a feed, site and/or author.
+
+If both a feed/site icon and author Gravatar are available, they will be overlaid on top of each other.
+
+## Example
+
+```html
+<ReaderAvatar author={ author } siteIcon={ siteIcon } isCompact={ true } />
+```
+
+## Props
+
+### `author` (required)
+
+An author object to pull the author info from.
+
+### `siteIcon`
+
+URL to the site icon image.
+
+### `feedIcon`
+
+URL to the feed icon image.
+
+### `siteUrl`
+
+If present, the avatar will be linked to this URL.
+
+### `preferGravatar`
+
+If we have an avatar and we prefer it, don't even consider the site icon.
+
+### `showPlaceholder`
+
+Show a loading placeholder if the icons/author are not yet available.
+
+### `isCompact`
+
+Show a small version of the avatar. Used in post cards and streams.

--- a/client/blocks/reader-avatar/README.md
+++ b/client/blocks/reader-avatar/README.md
@@ -39,3 +39,8 @@ Show a loading placeholder if the icons/author are not yet available.
 ### `isCompact`
 
 Show a small version of the avatar. Used in post cards and streams.
+
+### `onClick`
+
+Click handler to be executed when avatar is clicked.
+

--- a/client/blocks/reader-avatar/docs/example.jsx
+++ b/client/blocks/reader-avatar/docs/example.jsx
@@ -20,6 +20,8 @@ const ReaderAvatarExample = () => {
 	return (
 		<div className="design-assets__group">
 			<ReaderAvatar author={ author } siteIcon={ siteIcon } />
+			<h4>Compact</h4>
+			<ReaderAvatar author={ author } siteIcon={ siteIcon } isCompact={ true } />
 		</div>
 	);
 };

--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { startsWith, endsWith, noop } from 'lodash';
+import { startsWith, endsWith, noop, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -43,7 +43,7 @@ const ReaderAvatar = ( {
 		};
 	}
 
-	let hasSiteIcon = !! ( fakeSite && fakeSite.icon.img );
+	let hasSiteIcon = !! get( fakeSite, 'icon.img' );
 	let hasAvatar = !! ( author && author.has_avatar );
 
 	if ( hasSiteIcon && hasAvatar ) {

--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { startsWith, endsWith } from 'lodash';
+import { startsWith, endsWith, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,6 +20,7 @@ const ReaderAvatar = ( {
 		isCompact = false,
 		preferGravatar = false,
 		showPlaceholder = false,
+		onClick,
 	} ) => {
 	let fakeSite;
 
@@ -84,7 +85,7 @@ const ReaderAvatar = ( {
 	const iconElements = [ siteIconElement, avatarElement ];
 
 	return (
-		<div className={ classes }>
+		<div className={ classes } onClick={ onClick }>
 			{ siteUrl ? <a href={ siteUrl }>{ iconElements }</a> : iconElements }
 		</div>
 	);
@@ -98,6 +99,11 @@ ReaderAvatar.propTypes = {
 	preferGravatar: React.PropTypes.bool,
 	showPlaceholder: React.PropTypes.bool,
 	isCompact: React.PropTypes.bool,
+	onClick: React.PropTypes.func,
+};
+
+ReaderAvatar.defaultProps = {
+	onClick: noop,
 };
 
 export default localize( ReaderAvatar );

--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -17,16 +17,17 @@ const ReaderAvatar = ( {
 		siteIcon,
 		feedIcon,
 		siteUrl,
-		siteIconSize = 96,
-		gravatarSize,
+		isCompact = false,
 		preferGravatar = false,
 		showPlaceholder = false,
 	} ) => {
 	let fakeSite;
+
 	// don't show the default favicon for some sites
 	if ( endsWith( feedIcon, 'wp.com/i/buttonw-com.png' ) ) {
 		feedIcon = null;
 	}
+
 	if ( siteIcon ) {
 		fakeSite = {
 			icon: {
@@ -41,7 +42,7 @@ const ReaderAvatar = ( {
 		};
 	}
 
-	let hasSiteIcon = !! ( fakeSite && fakeSite.icon );
+	let hasSiteIcon = !! ( fakeSite && fakeSite.icon.img );
 	let hasAvatar = !! ( author && author.has_avatar );
 
 	if ( hasSiteIcon && hasAvatar ) {
@@ -59,13 +60,19 @@ const ReaderAvatar = ( {
 
 	const hasBothIcons = hasSiteIcon && hasAvatar;
 
-	if ( ! gravatarSize ) {
+	let siteIconSize, gravatarSize;
+	if ( isCompact ) {
+		siteIconSize = 32;
+		gravatarSize = hasBothIcons ? 24 : 32;
+	} else {
+		siteIconSize = 96;
 		gravatarSize = hasBothIcons ? 32 : 96;
 	}
 
 	const classes = classnames(
 		'reader-avatar',
 		{
+			'is-compact': isCompact,
 			'has-site-and-author-icon': hasBothIcons,
 			'has-site-icon': hasSiteIcon,
 			'has-gravatar': hasAvatar || showPlaceholder
@@ -89,7 +96,8 @@ ReaderAvatar.propTypes = {
 	feedIcon: React.PropTypes.string,
 	siteUrl: React.PropTypes.string,
 	preferGravatar: React.PropTypes.bool,
-	showPlaceholder: React.PropTypes.bool
+	showPlaceholder: React.PropTypes.bool,
+	isCompact: React.PropTypes.bool,
 };
 
 export default localize( ReaderAvatar );

--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -12,7 +12,16 @@ import SiteIcon from 'blocks/site-icon';
 import { localize } from 'i18n-calypso';
 import classnames from 'classnames';
 
-const ReaderAvatar = ( { author, siteIcon, feedIcon, siteUrl, siteIconSize = 96, preferGravatar = false, showPlaceholder = false } ) => {
+const ReaderAvatar = ( {
+		author,
+		siteIcon,
+		feedIcon,
+		siteUrl,
+		siteIconSize = 96,
+		gravatarSize,
+		preferGravatar = false,
+		showPlaceholder = false,
+	} ) => {
 	let fakeSite;
 	// don't show the default favicon for some sites
 	if ( endsWith( feedIcon, 'wp.com/i/buttonw-com.png' ) ) {
@@ -50,6 +59,10 @@ const ReaderAvatar = ( { author, siteIcon, feedIcon, siteUrl, siteIconSize = 96,
 
 	const hasBothIcons = hasSiteIcon && hasAvatar;
 
+	if ( ! gravatarSize ) {
+		gravatarSize = hasBothIcons ? 32 : 96;
+	}
+
 	const classes = classnames(
 		'reader-avatar',
 		{
@@ -60,7 +73,7 @@ const ReaderAvatar = ( { author, siteIcon, feedIcon, siteUrl, siteIconSize = 96,
 	);
 
 	const siteIconElement = hasSiteIcon && <SiteIcon key="site-icon" size={ siteIconSize } site={ fakeSite } />;
-	const avatarElement = ( hasAvatar || showPlaceholder ) && <Gravatar key="author-avatar" user={ author } size={ hasBothIcons ? 32 : 96 } />;
+	const avatarElement = ( hasAvatar || showPlaceholder ) && <Gravatar key="author-avatar" user={ author } size={ gravatarSize } />;
 	const iconElements = [ siteIconElement, avatarElement ];
 
 	return (

--- a/client/blocks/reader-avatar/style.scss
+++ b/client/blocks/reader-avatar/style.scss
@@ -8,7 +8,6 @@
 }
 
 .reader-avatar {
-
 	&.has-site-and-author-icon {
 		.site-icon {
 			height: 96px;
@@ -32,10 +31,12 @@
 	}
 
 	&.is-compact {
-		&.has-site-and-author-icon {
+		&.has-gravatar {
 			min-width: 32px;
 			min-height: 32px;
+		}
 
+		&.has-site-and-author-icon {
 			.site-icon {
 				height: 32px;
 				width: 32px;

--- a/client/blocks/reader-avatar/style.scss
+++ b/client/blocks/reader-avatar/style.scss
@@ -32,6 +32,9 @@
 	}
 
 	&.is-compact {
+		min-width: 32px;
+		min-height: 32px;
+
 		&.has-site-and-author-icon {
 			.site-icon {
 				height: 32px;

--- a/client/blocks/reader-avatar/style.scss
+++ b/client/blocks/reader-avatar/style.scss
@@ -32,10 +32,10 @@
 	}
 
 	&.is-compact {
-		min-width: 32px;
-		min-height: 32px;
-
 		&.has-site-and-author-icon {
+			min-width: 32px;
+			min-height: 32px;
+
 			.site-icon {
 				height: 32px;
 				width: 32px;

--- a/client/blocks/reader-avatar/style.scss
+++ b/client/blocks/reader-avatar/style.scss
@@ -45,8 +45,8 @@
 
 			.gravatar {
 				height: 24px;
-					left: 12px;
-					top: -22px;
+				left: 12px;
+				top: -22px;
 				width: 24px;
 			}
 		}

--- a/client/blocks/reader-avatar/style.scss
+++ b/client/blocks/reader-avatar/style.scss
@@ -1,12 +1,15 @@
 .reader-avatar {
 	margin: 0 auto;
 	max-height: 105px;
+
+	&.is-compact {
+		max-height: 32px;
+	}
 }
 
 .reader-avatar {
 
 	&.has-site-and-author-icon {
-
 		.site-icon {
 			height: 96px;
 			width: 96px;
@@ -25,6 +28,27 @@
 				top: -75px;
 			width: 80px;
 			background-color: $white;
+		}
+	}
+
+	&.is-compact {
+		&.has-site-and-author-icon {
+			.site-icon {
+				height: 32px;
+				width: 32px;
+
+				.gridicon {
+					height: 32px;
+					width: 32px;
+				}
+			}
+
+			.gravatar {
+				height: 24px;
+					left: 12px;
+					top: -22px;
+				width: 24px;
+			}
 		}
 	}
 }

--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -82,7 +82,7 @@ class ReaderCombinedCard extends React.Component {
 						author={ null }
 						preferGravatar={ true }
 						siteUrl={ streamUrl }
-						siteIconSize={ 32 } />
+						isCompact={ true } />
 					<div className="reader-combined-card__header-details">
 						<ReaderSiteStreamLink
 							className="reader-combined-card__site-link"

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -93,7 +93,7 @@ class PostByline extends React.Component {
 					author={ post.author }
 					preferGravatar={ true }
 					siteUrl={ streamUrl }
-					siteIconSize={ 32 } />
+					isCompact={ true } />
 				<div className="reader-post-card__byline-details">
 					<div className="reader-post-card__byline-author-site">
 						{ shouldDisplayAuthor &&

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -234,8 +234,8 @@
 			color: $gray-dark;
 		}
 
-		.reader__site-and-author-icon {
-			margin-right: 12px;
+		.reader-avatar {
+			margin: 0 12px 0 0;
 			width: auto;
 
 			&:hover {

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -14,6 +14,9 @@ import PostUnavailable from './post-unavailable';
 import CrossPost from './x-post';
 import XPostHelper from 'reader/xpost-helper';
 import { shallowEquals } from 'reader/utils';
+//import fluxPostAdapter from 'lib/reader-post-flux-adapter';
+
+//const ConnectedCrossPost = fluxPostAdapter( CrossPost );
 
 export default class PostLifecycle extends React.PureComponent {
 	static propTypes = {
@@ -83,7 +86,8 @@ export default class PostLifecycle extends React.PureComponent {
 						isSelected={ this.props.isSelected }
 						xMetadata={ xMetadata }
 						xPostedTo={ this.props.store.getSitesCrossPostedTo( xMetadata.commentURL || xMetadata.postURL ) }
-						handleClick={ this.props.handleClick } />;
+						handleClick={ this.props.handleClick }
+						postKey={ this.props.postKey } />;
 				}
 
 				return <PostClass

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -14,9 +14,6 @@ import PostUnavailable from './post-unavailable';
 import CrossPost from './x-post';
 import XPostHelper from 'reader/xpost-helper';
 import { shallowEquals } from 'reader/utils';
-//import fluxPostAdapter from 'lib/reader-post-flux-adapter';
-
-//const ConnectedCrossPost = fluxPostAdapter( CrossPost );
 
 export default class PostLifecycle extends React.PureComponent {
 	static propTypes = {

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -7,6 +7,7 @@ import classnames from 'classnames';
 import url from 'url';
 import { localize } from 'i18n-calypso';
 import closest from 'component-closest';
+import { get } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -23,6 +24,8 @@ class CrossPost extends PureComponent {
 		xPostedTo: React.PropTypes.array,
 		handleClick: React.PropTypes.func.isRequired,
 		translate: React.PropTypes.func.isRequired,
+		postKey: React.PropTypes.object,
+		site: React.PropTypes.object,
 	}
 
 	handleTitleClick = ( event ) => {
@@ -127,8 +130,11 @@ class CrossPost extends PureComponent {
 	}
 
 	render() {
-		const post = this.props.post,
-			articleClasses = classnames( {
+		const post = this.props.post;
+		const siteId = this.props.postKey.blogId;
+		const siteIcon = get( this.props.site, 'icon.img' );
+
+		const articleClasses = classnames( {
 				reader__card: true,
 				'is-x-post': true,
 				'is-selected': this.props.isSelected
@@ -142,7 +148,7 @@ class CrossPost extends PureComponent {
 		return (
 			<Card tagName="article" onClick={ this.handleCardClick } className={ articleClasses }>
 				<ReaderAvatar
-					siteIcon={ null }
+					siteIcon={ siteIcon }
 					author={ post.author }
 					onClick={ this.handleTitleClick }
 					sizeIconSize={ 24 }
@@ -155,7 +161,9 @@ class CrossPost extends PureComponent {
 						}
 					{ this.getDescription( post.author.first_name ) }
 				</div>
-			</Card> );
+			{ siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }
+			</Card>
+		);
 	}
 }
 

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -12,7 +12,7 @@ import closest from 'component-closest';
  * Internal Dependencies
  */
 import Card from 'components/card';
-import SiteAndAuthorIcon from 'reader/site-and-author-icon';
+import ReaderAvatar from 'blocks/reader-avatar';
 
 class CrossPost extends PureComponent {
 
@@ -73,29 +73,35 @@ class CrossPost extends PureComponent {
 		const siteName = this.getSiteNameFromURL( this.props.xMetadata.siteURL );
 		const isCrossComment = !! this.props.xMetadata.commentURL;
 		if ( isCrossComment ) {
-			label = this.props.translate( '{{author}}%(authorFirstName)s{{/author}} {{label}}left a comment on %(siteName)s, cross-posted to{{/label}} {{blogNames/}}', {
-				args: {
-					siteName: siteName,
-					authorFirstName: authorFirstName
-				},
-				components: {
-					author: <span className="reader__x-post-author" />,
-					label: <span className="reader__x-post-label" />,
-					blogNames: this.getXPostedToContent()
+			label = this.props.translate(
+				'{{author}}%(authorFirstName)s{{/author}} {{label}}left a comment on %(siteName)s, cross-posted to{{/label}} {{blogNames/}}',
+				{
+					args: {
+						siteName: siteName,
+						authorFirstName: authorFirstName
+					},
+					components: {
+						author: <span className="reader__x-post-author" />,
+						label: <span className="reader__x-post-label" />,
+						blogNames: this.getXPostedToContent()
+					}
 				}
-			} );
+			);
 		} else {
-			label = this.props.translate( '{{author}}%(authorFirstName)s{{/author}} {{label}}cross-posted from %(siteName)s to{{/label}} {{blogNames/}}', {
-				args: {
-					siteName: siteName,
-					authorFirstName: authorFirstName
-				},
-				components: {
-					author: <span className="reader__x-post-author" />,
-					label: <span className="reader__x-post-label" />,
-					blogNames: this.getXPostedToContent()
+			label = this.props.translate(
+				'{{author}}%(authorFirstName)s{{/author}} {{label}}cross-posted from %(siteName)s to{{/label}} {{blogNames/}}',
+				{
+					args: {
+						siteName: siteName,
+						authorFirstName: authorFirstName
+					},
+					components: {
+						author: <span className="reader__x-post-author" />,
+						label: <span className="reader__x-post-label" />,
+						blogNames: this.getXPostedToContent()
+					}
 				}
-			} );
+			);
 		}
 		return label;
 	}
@@ -114,7 +120,7 @@ class CrossPost extends PureComponent {
 					{ xPostedTo.siteName }
 					{ index + 2 < array.length ? <span>, </span> : null }
 					{ index + 2 === array.length ?
-						<span> { this.props.translate( 'and', { comment: 'last conjuction in a list of blognames: (blog1, blog2,) blog3 _and_ blog4' } ) } </span> : null }
+						<span> { this.props.translate( 'and', { comment: 'last conjunction in a list of blognames: (blog1, blog2,) blog3 _and_ blog4' } ) } </span> : null }
 				</span>
 			);
 		} );
@@ -135,12 +141,12 @@ class CrossPost extends PureComponent {
 
 		return (
 			<Card tagName="article" onClick={ this.handleCardClick } className={ articleClasses }>
-				<SiteAndAuthorIcon
-					siteId={ this.props.post.site_ID }
-					isExternal={ this.props.post.is_external }
-					user={ post.author }
+				<ReaderAvatar
+					siteIcon={ null }
+					author={ post.author }
 					onClick={ this.handleTitleClick }
-					href={ post.URL } />
+					sizeIconSize={ 24 }
+					gravatarSize={ 24 } />
 				<div className="reader__x-post">
 					{ post.title &&
 						<h1 className="reader__post-title">

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -159,8 +159,7 @@ class CrossPost extends PureComponent {
 					feedIcon={ feedIcon }
 					author={ post.author }
 					onClick={ this.handleTitleClick }
-					sizeIconSize={ 24 }
-					gravatarSize={ 24 } />
+					isCompact={ true } />
 				<div className="reader__x-post">
 					{ post.title &&
 						<h1 className="reader__post-title">

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -17,6 +17,8 @@ import Card from 'components/card';
 import ReaderAvatar from 'blocks/reader-avatar';
 import { getSite } from 'state/reader/sites/selectors';
 import { getFeed } from 'state/reader/feeds/selectors';
+import QueryReaderSite from 'components/data/query-reader-site';
+import QueryReaderFeed from 'components/data/query-reader-feed';
 
 class CrossPost extends PureComponent {
 
@@ -125,9 +127,9 @@ class CrossPost extends PureComponent {
 			return (
 				<span className="reader__x-post-site" key={ xPostedTo.siteURL + '-' + index }>
 					{ xPostedTo.siteName }
-					{ index + 2 < array.length ? <span>, </span> : null }
-					{ index + 2 === array.length ?
-						<span> { this.props.translate( 'and', { comment: 'last conjunction in a list of blognames: (blog1, blog2,) blog3 _and_ blog4' } ) } </span> : null }
+					{ ( index + 2 < array.length ) && <span>, </span> }
+					{ ( index + 2 === array.length ) &&
+						<span> { this.props.translate( 'and', { comment: 'last conjunction in a list of blognames: (blog1, blog2,) blog3 _and_ blog4' } ) } </span> }
 				</span>
 			);
 		} );
@@ -135,15 +137,15 @@ class CrossPost extends PureComponent {
 
 	render() {
 		const { post, postKey, site, feed } = this.props;
-		const siteId = postKey.blogId;
+		const { blogId: siteId, feedId } = postKey;
 		const siteIcon = get( site, 'icon.img' );
 		const feedIcon = get( feed, 'image' );
 
 		const articleClasses = classnames( {
-				reader__card: true,
-				'is-x-post': true,
-				'is-selected': this.props.isSelected
-			} );
+			'reader__card': true,
+			'is-x-post': true,
+			'is-selected': this.props.isSelected
+		} );
 
 		// Remove the x-post text from the title.
 		// TODO: maybe add xpost metadata, so we can remove this regex
@@ -167,7 +169,8 @@ class CrossPost extends PureComponent {
 						}
 					{ this.getDescription( post.author.first_name ) }
 				</div>
-			{ siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }
+				{ feedId && <QueryReaderFeed feedId={ +feedId } includeMeta={ false } /> }
+				{ siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }
 			</Card>
 		);
 	}

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -8,12 +8,15 @@ import url from 'url';
 import { localize } from 'i18n-calypso';
 import closest from 'component-closest';
 import { get } from 'lodash';
+import { connect } from 'react-redux';
 
 /**
  * Internal Dependencies
  */
 import Card from 'components/card';
 import ReaderAvatar from 'blocks/reader-avatar';
+import { getSite } from 'state/reader/sites/selectors';
+import { getFeed } from 'state/reader/feeds/selectors';
 
 class CrossPost extends PureComponent {
 
@@ -26,6 +29,7 @@ class CrossPost extends PureComponent {
 		translate: React.PropTypes.func.isRequired,
 		postKey: React.PropTypes.object,
 		site: React.PropTypes.object,
+		feed: React.PropTypes.object,
 	}
 
 	handleTitleClick = ( event ) => {
@@ -130,9 +134,10 @@ class CrossPost extends PureComponent {
 	}
 
 	render() {
-		const post = this.props.post;
-		const siteId = this.props.postKey.blogId;
-		const siteIcon = get( this.props.site, 'icon.img' );
+		const { post, postKey, site, feed } = this.props;
+		const siteId = postKey.blogId;
+		const siteIcon = get( site, 'icon.img' );
+		const feedIcon = get( feed, 'image' );
 
 		const articleClasses = classnames( {
 				reader__card: true,
@@ -149,6 +154,7 @@ class CrossPost extends PureComponent {
 			<Card tagName="article" onClick={ this.handleCardClick } className={ articleClasses }>
 				<ReaderAvatar
 					siteIcon={ siteIcon }
+					feedIcon={ feedIcon }
 					author={ post.author }
 					onClick={ this.handleTitleClick }
 					sizeIconSize={ 24 }
@@ -167,4 +173,20 @@ class CrossPost extends PureComponent {
 	}
 }
 
-export default localize( CrossPost );
+export default connect(
+	( state, ownProps ) => {
+		const { feedId, blogId } = ownProps.postKey;
+		let feed, site;
+		if ( feedId ) {
+			feed = getFeed( state, feedId );
+			site = feed && feed.blog_ID ? getSite( state, feed.blog_ID ) : undefined;
+		} else {
+			site = getSite( state, blogId );
+			feed = site && site.feed_ID ? getFeed( state, site.feed_ID ) : undefined;
+		}
+		return {
+			feed,
+			site
+		};
+	}
+)( localize( CrossPost ) );


### PR DESCRIPTION
This PR switches x-posts to use ReaderAvatar, so we can retire the old SiteAndAuthorIcon component (as mentioned here https://github.com/Automattic/wp-calypso/pull/12441#issuecomment-288741629).

### To test

Check that there are no regressions with avatar display and functionality on post cards, combined cards or in devdocs:

http://calypso.localhost:3000/devdocs/blocks/reader-avatar

<img width="306" alt="screen shot 2017-03-24 at 19 59 39" src="https://cloud.githubusercontent.com/assets/17325/24311524/7113f678-10cc-11e7-90a5-6eff590d3529.png">

Compare team streams on development and wpcalypso. Make sure x-post avatars appear in the same way, and that clicking on the avatar opens full post view.

<img width="660" alt="screen shot 2017-03-23 at 15 35 09" src="https://cloud.githubusercontent.com/assets/17325/24255788/54528782-0fde-11e7-862a-5fe082dee1ee.png">


