### PR TITLE
Jetpack plans: new descriptions test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -43,4 +43,14 @@ module.exports = {
 		defaultVariation: 'disabled',
 		allowExistingUsers: false
 	},
+
+	jetpackNewDescriptions: {
+		datestamp: '20170327',
+		variations: {
+			showNew: 50,
+			showOld: 50
+		},
+		defaultVariation: 'showOld',
+		allowExistingUsers: true
+	},
 };

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -82,6 +82,16 @@ export const FEATURE_MALWARE_SCANNING_DAILY = 'malware-scanning-daily';
 export const FEATURE_MALWARE_SCANNING_DAILY_AND_ON_DEMAND = 'malware-scanning-daily-and-on-demand';
 export const FEATURE_ONE_CLICK_THREAT_RESOLUTION = 'one-click-threat-resolution';
 export const FEATURE_POLLS_PRO = 'polls-pro';
+export const FEATURE_CORE_JETPACK = 'core-jetpack';
+export const FEATURE_BASIC_SUPPORT_JETPACK = 'basic-support-jetpack';
+export const FEATURE_BASIC_SECURITY_JETPACK = 'basic-security-jetpack';
+export const FEATURE_SITE_BACKUPS_JETPACK = 'site-backups-jetpack';
+export const FEATURE_SECURITY_SCANNING_JETPACK = 'security-scanning-jetpack';
+export const FEATURE_REVENUE_GENERATION_JETPACK = 'revenue-generation-jetpack';
+export const FEATURE_VIDEO_HOSTING_JETPACK = 'vidoe-hosting-jetpack';
+export const FEATURE_SECURITY_ESSENTIALS_JETPACK = 'security-essentials-jetpack';
+export const FEATURE_PRIORITY_SUPPORT_JETPACK = 'priority-support-jetpack';
+export const FEATURE_SEO_TOOLS_JETPACK = 'seo-tools-jetpack';
 
 // DO NOT import. Use `getPlan` from `lib/plans` instead.
 export const PLANS_LIST = {
@@ -212,11 +222,19 @@ export const PLANS_LIST = {
 		getTitle: () => i18n.translate( 'Free' ),
 		getProductId: () => 2002,
 		getStoreSlug: () => PLAN_JETPACK_FREE,
-		getDescription: () => i18n.translate(
-			'The features most needed by WordPress sites' +
-			' — perfectly packaged and optimized for everyone.'
+
+		getDescription: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
+			? i18n.translate( 'Everything you need to get started.' )
+			: i18n.translate(
+				'The features most needed by WordPress sites' +
+				' — perfectly packaged and optimized for everyone.'
 		),
-		getFeatures: () => [
+		getFeatures: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
+		? [
+			FEATURE_CORE_JETPACK,
+			FEATURE_BASIC_SECURITY_JETPACK,
+			FEATURE_BASIC_SUPPORT_JETPACK ]
+		: [
 			FEATURE_STANDARD_SECURITY_TOOLS,
 			FEATURE_SITE_STATS,
 			FEATURE_TRAFFIC_TOOLS,
@@ -226,15 +244,29 @@ export const PLANS_LIST = {
 	},
 	[ PLAN_JETPACK_PREMIUM ]: {
 		getTitle: () => i18n.translate( 'Premium' ),
+		getSubtitle: () => i18n.translate( 'Protection, speed, and revenue.' ),
 		getProductId: () => 2000,
 		getStoreSlug: () => PLAN_JETPACK_PREMIUM,
 		availableFor: ( plan ) => includes( [ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL_MONTHLY ], plan ),
 		getPathSlug: () => 'premium',
-		getDescription: () => i18n.translate(
-			'Generate income and save on video hosting costs. ' +
-			'Improve security with daily backups, malware scanning, and spam defense.'
+		getDescription: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) !== 'showNew'
+			? i18n.translate(
+				'Generate income and save on video hosting costs. ' +
+				'Improve security with daily backups, malware scanning, and spam defense.'
+			)
+			: i18n.translate(
+				'Generate income and save on hosting costs.'
 		),
-		getFeatures: () => compact( [
+		getFeatures: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
+		? [
+			FEATURE_CORE_JETPACK,
+			FEATURE_SITE_BACKUPS_JETPACK,
+			FEATURE_SECURITY_SCANNING_JETPACK,
+			FEATURE_REVENUE_GENERATION_JETPACK,
+			FEATURE_VIDEO_HOSTING_JETPACK,
+			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
+		]
+		: [
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
 			FEATURE_BACKUP_ARCHIVE_30,
 			FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
@@ -246,7 +278,7 @@ export const PLANS_LIST = {
 			FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM,
 			FEATURE_MALWARE_SCANNING_DAILY,
 			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
-		] ),
+		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
 	},
 
@@ -256,11 +288,23 @@ export const PLANS_LIST = {
 		getStoreSlug: () => PLAN_JETPACK_PREMIUM_MONTHLY,
 		getPathSlug: () => 'premium-monthly',
 		availableFor: ( plan ) => includes( [ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL_MONTHLY ], plan ),
-		getDescription: () => i18n.translate(
-			'Generate income and save on video hosting costs. ' +
-			'Improve security with daily backups, malware scanning, and spam defense.'
+		getDescription: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) !== 'showNew'
+			? i18n.translate(
+				'Generate income and save on video hosting costs. ' +
+				'Improve security with daily backups, malware scanning, and spam defense.'
+			)
+			: i18n.translate(
+				'Generate income and save on hosting costs.'
 		),
-		getFeatures: () => compact( [
+		getFeatures: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
+		? [
+			FEATURE_CORE_JETPACK,
+			FEATURE_SITE_BACKUPS_JETPACK,
+			FEATURE_SECURITY_SCANNING_JETPACK,
+			FEATURE_REVENUE_GENERATION_JETPACK,
+			FEATURE_VIDEO_HOSTING_JETPACK,
+			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
+		] : [
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
 			FEATURE_BACKUP_ARCHIVE_30,
 			FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
@@ -272,7 +316,7 @@ export const PLANS_LIST = {
 			FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM,
 			FEATURE_MALWARE_SCANNING_DAILY,
 			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
-		] ),
+		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' )
 	},
 
@@ -282,19 +326,27 @@ export const PLANS_LIST = {
 		getStoreSlug: () => PLAN_JETPACK_PERSONAL,
 		availableFor: ( plan ) => includes( [ PLAN_JETPACK_FREE ], plan ),
 		getPathSlug: () => 'jetpack-personal',
-		getDescription: () => i18n.translate(
-			'Essentials for every site. The most affordable solution to keep your' +
-			' personal or small business site backed up and spam-free.'
+		getDescription: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
+			? i18n.translate( 'Security essentials for every site.' )
+			: i18n.translate(
+				'Essentials for every site. The most affordable solution to keep your' +
+				' personal or small business site backed up and spam-free.'
 		),
-		getFeatures: () => [
-			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
-			FEATURE_BACKUP_ARCHIVE_30,
-			FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
-			FEATURE_AUTOMATED_RESTORES,
-			FEATURE_SPAM_AKISMET_PLUS,
-			FEATURE_EASY_SITE_MIGRATION,
-			FEATURE_PREMIUM_SUPPORT
-		],
+		getFeatures: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
+			? [
+				FEATURE_CORE_JETPACK,
+				FEATURE_SECURITY_ESSENTIALS_JETPACK,
+				FEATURE_PRIORITY_SUPPORT_JETPACK
+			]
+			: [
+				FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
+				FEATURE_BACKUP_ARCHIVE_30,
+				FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
+				FEATURE_AUTOMATED_RESTORES,
+				FEATURE_SPAM_AKISMET_PLUS,
+				FEATURE_EASY_SITE_MIGRATION,
+				FEATURE_PREMIUM_SUPPORT
+			],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
 	},
 
@@ -304,19 +356,27 @@ export const PLANS_LIST = {
 		getProductId: () => 2006,
 		getPathSlug: () => 'jetpack-personal-monthly',
 		availableFor: ( plan ) => includes( [ PLAN_JETPACK_FREE ], plan ),
-		getDescription: () => i18n.translate(
-			'Essentials for every site. The most affordable solution to keep your' +
-			' personal or small business site backed up and spam-free.'
+		getDescription: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
+			? i18n.translate( 'Security essentials for every site.' )
+			: i18n.translate(
+				'Essentials for every site. The most affordable solution to keep your' +
+				' personal or small business site backed up and spam-free.'
 		),
-		getFeatures: () => [
-			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
-			FEATURE_BACKUP_ARCHIVE_30,
-			FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
-			FEATURE_AUTOMATED_RESTORES,
-			FEATURE_SPAM_AKISMET_PLUS,
-			FEATURE_EASY_SITE_MIGRATION,
-			FEATURE_PREMIUM_SUPPORT
-		],
+		getFeatures: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
+			? [
+				FEATURE_CORE_JETPACK,
+				FEATURE_SECURITY_ESSENTIALS_JETPACK,
+				FEATURE_PRIORITY_SUPPORT_JETPACK
+			]
+			: [
+				FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
+				FEATURE_BACKUP_ARCHIVE_30,
+				FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
+				FEATURE_AUTOMATED_RESTORES,
+				FEATURE_SPAM_AKISMET_PLUS,
+				FEATURE_EASY_SITE_MIGRATION,
+				FEATURE_PREMIUM_SUPPORT
+			],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' )
 	},
 
@@ -331,30 +391,42 @@ export const PLANS_LIST = {
 			PLAN_JETPACK_PERSONAL_MONTHLY
 		], plan ),
 		getPathSlug: () => 'professional',
-		getDescription: () => i18n.translate(
-			'Real-time backups, unlimited archives, and one-click threat ' +
-			'resolution. Also includes SEO tools, and unlimited video hosting.'
+		getDescription: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
+			? i18n.translate( 'Ultimate security and traffic tools.' )
+			: i18n.translate(
+				'Real-time backups, unlimited archives, and one-click threat ' +
+				'resolution. Also includes SEO tools, and unlimited video hosting.'
 		),
-		getFeatures: () => compact( [
-			FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
-			FEATURE_BACKUP_ARCHIVE_UNLIMITED,
-			FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
-			FEATURE_AUTOMATED_RESTORES,
-			FEATURE_SPAM_AKISMET_PLUS,
-			FEATURE_EASY_SITE_MIGRATION,
-			FEATURE_PREMIUM_SUPPORT,
-			FEATURE_WORDADS_INSTANT,
-			FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
-			FEATURE_MALWARE_SCANNING_DAILY_AND_ON_DEMAND,
-			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
-			FEATURE_ONE_CLICK_THREAT_RESOLUTION,
-			FEATURE_ADVANCED_SEO,
-			FEATURE_GOOGLE_ANALYTICS
-		] ),
+		getFeatures: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
+			? [
+				FEATURE_CORE_JETPACK,
+				FEATURE_SITE_BACKUPS_JETPACK,
+				FEATURE_SECURITY_SCANNING_JETPACK,
+				FEATURE_REVENUE_GENERATION_JETPACK,
+				FEATURE_VIDEO_HOSTING_JETPACK,
+				FEATURE_SEO_TOOLS_JETPACK
+			]
+			: compact( [
+				FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
+				FEATURE_BACKUP_ARCHIVE_UNLIMITED,
+				FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
+				FEATURE_AUTOMATED_RESTORES,
+				FEATURE_SPAM_AKISMET_PLUS,
+				FEATURE_EASY_SITE_MIGRATION,
+				FEATURE_PREMIUM_SUPPORT,
+				FEATURE_WORDADS_INSTANT,
+				FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
+				FEATURE_MALWARE_SCANNING_DAILY_AND_ON_DEMAND,
+				FEATURE_ONE_CLICK_THREAT_RESOLUTION,
+				FEATURE_ADVANCED_SEO,
+				isEnabled( 'jetpack/google-analytics' ) && FEATURE_GOOGLE_ANALYTICS
+			]
+		),
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
 	},
 	[ PLAN_JETPACK_BUSINESS_MONTHLY ]: {
 		getTitle: () => i18n.translate( 'Professional' ),
+		getSubtitle: () => i18n.translate( 'Ultimate security and traffic tools.' ),
 		getProductId: () => 2004,
 		getPathSlug: () => 'professional-monthly',
 		availableFor: ( plan ) => includes( [
@@ -364,26 +436,37 @@ export const PLANS_LIST = {
 			PLAN_JETPACK_PERSONAL,
 			PLAN_JETPACK_PERSONAL_MONTHLY
 		], plan ),
-		getDescription: () =>i18n.translate(
-			'Real-time backups, unlimited archives, and one-click threat ' +
-			'resolution. Also includes SEO tools, and unlimited video hosting.'
+		getDescription: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
+			? i18n.translate( 'Ultimate security and traffic tools.' )
+			: i18n.translate(
+				'Real-time backups, unlimited archives, and one-click threat ' +
+				'resolution. Also includes SEO tools, and unlimited video hosting.'
 		),
-		getFeatures: () => compact( [
-			FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
-			FEATURE_BACKUP_ARCHIVE_UNLIMITED,
-			FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
-			FEATURE_AUTOMATED_RESTORES,
-			FEATURE_SPAM_AKISMET_PLUS,
-			FEATURE_EASY_SITE_MIGRATION,
-			FEATURE_PREMIUM_SUPPORT,
-			FEATURE_WORDADS_INSTANT,
-			FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
-			FEATURE_MALWARE_SCANNING_DAILY_AND_ON_DEMAND,
-			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
-			FEATURE_ONE_CLICK_THREAT_RESOLUTION,
-			FEATURE_ADVANCED_SEO,
-			FEATURE_GOOGLE_ANALYTICS
-		] ),
+		getFeatures: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
+			? [
+				FEATURE_CORE_JETPACK,
+				FEATURE_SITE_BACKUPS_JETPACK,
+				FEATURE_SECURITY_SCANNING_JETPACK,
+				FEATURE_REVENUE_GENERATION_JETPACK,
+				FEATURE_VIDEO_HOSTING_JETPACK,
+				FEATURE_SEO_TOOLS_JETPACK
+			]
+			: compact( [
+				FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
+				FEATURE_BACKUP_ARCHIVE_UNLIMITED,
+				FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
+				FEATURE_AUTOMATED_RESTORES,
+				FEATURE_SPAM_AKISMET_PLUS,
+				FEATURE_EASY_SITE_MIGRATION,
+				FEATURE_PREMIUM_SUPPORT,
+				FEATURE_WORDADS_INSTANT,
+				FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
+				FEATURE_MALWARE_SCANNING_DAILY_AND_ON_DEMAND,
+				FEATURE_ONE_CLICK_THREAT_RESOLUTION,
+				FEATURE_ADVANCED_SEO,
+				isEnabled( 'jetpack/google-analytics' ) && FEATURE_GOOGLE_ANALYTICS
+			]
+		),
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
 	}
 };
@@ -751,6 +834,88 @@ export const FEATURES_LIST = {
 		getDescription: () => i18n.translate(
 			'Custom polls, surveys, ratings, and quizzes for the ultimate in customer and reader engagement.'
 		)
+	},
+
+	[ FEATURE_CORE_JETPACK ]: {
+		getSlug: () => FEATURE_CORE_JETPACK,
+		getTitle: () => i18n.translate( 'Core Jetpack Services' ),
+		getDescription: () => i18n.translate(
+			'Stats, customization, and promotion tools'
+		),
+		hideInfoPopover: true
+	},
+	[ FEATURE_BASIC_SECURITY_JETPACK ]: {
+		getSlug: () => FEATURE_BASIC_SECURITY_JETPACK,
+		getTitle: () => i18n.translate( 'Basic Security' ),
+		getDescription: () => i18n.translate(
+			'Brute force protection, monitoring, secure logins, updates.'
+		),
+		hideInfoPopover: true
+	},
+	[ FEATURE_BASIC_SUPPORT_JETPACK ]: {
+		getSlug: () => FEATURE_BASIC_SUPPORT_JETPACK,
+		getTitle: () => i18n.translate( 'Basic Support' ),
+		getDescription: () => i18n.translate(
+			'Standard support for all Jetpack free features.'
+		),
+		hideInfoPopover: true
+	},
+
+	[ FEATURE_SITE_BACKUPS_JETPACK ]: {
+		getSlug: () => FEATURE_SITE_BACKUPS_JETPACK,
+		getTitle: () => i18n.translate( 'Site Backups' ),
+		getDescription: () => i18n.translate(
+			'Automated daily backups (unlimited storage), one-click restores, and 30-day archive.'
+		),
+		hideInfoPopover: true
+	},
+	[ FEATURE_SECURITY_SCANNING_JETPACK ]: {
+		getSlug: () => FEATURE_SECURITY_SCANNING_JETPACK,
+		getTitle: () => i18n.translate( 'Security Scanning' ),
+		getDescription: () => i18n.translate(
+			'Daily scans for malware and threats with manual resolution.'
+		),
+		hideInfoPopover: true
+	},
+	[ FEATURE_REVENUE_GENERATION_JETPACK ]: {
+		getSlug: () => FEATURE_REVENUE_GENERATION_JETPACK,
+		getTitle: () => i18n.translate( 'Revenue Generation' ),
+		getDescription: () => i18n.translate(
+			'Display high-quality ads to generate income directly from your site.'
+		),
+		hideInfoPopover: true
+	},
+	[ FEATURE_VIDEO_HOSTING_JETPACK ]: {
+		getSlug: () => FEATURE_VIDEO_HOSTING_JETPACK,
+		getTitle: () => i18n.translate( 'Video Hosting' ),
+		getDescription: () => i18n.translate(
+			'13Gb of high-speed, HD, and ad-free video hosting.'
+		),
+		hideInfoPopover: true
+	},
+	[ FEATURE_SECURITY_ESSENTIALS_JETPACK ]: {
+		getSlug: () => FEATURE_SECURITY_ESSENTIALS_JETPACK,
+		getTitle: () => i18n.translate( 'Security Essentials' ),
+		getDescription: () => i18n.translate(
+			'Daily backups, unlimited storage, one-click restores, and spam filtering.'
+		),
+		hideInfoPopover: true
+	},
+	[ FEATURE_PRIORITY_SUPPORT_JETPACK ]: {
+		getSlug: () => FEATURE_PRIORITY_SUPPORT_JETPACK,
+		getTitle: () => i18n.translate( 'Priority Support' ),
+		getDescription: () => i18n.translate(
+			'Fast, dedicated support from our WordPress security experts.'
+		),
+		hideInfoPopover: true
+	},
+	[ FEATURE_SEO_TOOLS_JETPACK ]: {
+		getSlug: () => FEATURE_SEO_TOOLS_JETPACK,
+		getTitle: () => i18n.translate( 'SEO Tools' ),
+		getDescription: () => i18n.translate(
+			'Preview and optimize site content for better search engine results.'
+		),
+		hideInfoPopover: true
 	},
 };
 

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -84,6 +84,9 @@ export const FEATURE_ONE_CLICK_THREAT_RESOLUTION = 'one-click-threat-resolution'
 export const FEATURE_POLLS_PRO = 'polls-pro';
 export const FEATURE_CORE_JETPACK = 'core-jetpack';
 export const FEATURE_BASIC_SUPPORT_JETPACK = 'basic-support-jetpack';
+export const FEATURE_SPEED_JETPACK = 'speed-jetpack';
+export const FEATURE_SPEED_ADVANCED_JETPACK = 'speed-advanced-jetpack';
+export const FEATURE_SPEED_UNLIMITED_JETPACK = 'speed-unlimited_jetpack';
 export const FEATURE_BASIC_SECURITY_JETPACK = 'basic-security-jetpack';
 export const FEATURE_SITE_BACKUPS_JETPACK = 'site-backups-jetpack';
 export const FEATURE_SECURITY_SCANNING_JETPACK = 'security-scanning-jetpack';
@@ -91,7 +94,8 @@ export const FEATURE_REVENUE_GENERATION_JETPACK = 'revenue-generation-jetpack';
 export const FEATURE_VIDEO_HOSTING_JETPACK = 'vidoe-hosting-jetpack';
 export const FEATURE_SECURITY_ESSENTIALS_JETPACK = 'security-essentials-jetpack';
 export const FEATURE_PRIORITY_SUPPORT_JETPACK = 'priority-support-jetpack';
-export const FEATURE_SEO_TOOLS_JETPACK = 'seo-tools-jetpack';
+export const FEATURE_TRAFFIC_TOOLS_JETPACK = 'seo-tools-jetpack';
+export const FEATURE_ADVANCED_TRAFFIC_TOOLS_JETPACK = 'seo-tools-jetpack';
 
 // DO NOT import. Use `getPlan` from `lib/plans` instead.
 export const PLANS_LIST = {
@@ -233,7 +237,8 @@ export const PLANS_LIST = {
 		? [
 			FEATURE_CORE_JETPACK,
 			FEATURE_BASIC_SECURITY_JETPACK,
-			FEATURE_BASIC_SUPPORT_JETPACK ]
+			FEATURE_BASIC_SUPPORT_JETPACK,
+			FEATURE_SPEED_JETPACK ]
 		: [
 			FEATURE_STANDARD_SECURITY_TOOLS,
 			FEATURE_SITE_STATS,
@@ -255,16 +260,16 @@ export const PLANS_LIST = {
 				'Improve security with daily backups, malware scanning, and spam defense.'
 			)
 			: i18n.translate(
-				'Generate income and save on hosting costs.'
+				'Earn income and reduce costs.'
 		),
 		getFeatures: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
 		? [
 			FEATURE_CORE_JETPACK,
-			FEATURE_SITE_BACKUPS_JETPACK,
 			FEATURE_SECURITY_SCANNING_JETPACK,
+			FEATURE_PRIORITY_SUPPORT_JETPACK,
+			FEATURE_SPEED_ADVANCED_JETPACK,
 			FEATURE_REVENUE_GENERATION_JETPACK,
-			FEATURE_VIDEO_HOSTING_JETPACK,
-			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
+			FEATURE_TRAFFIC_TOOLS_JETPACK
 		]
 		: [
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
@@ -294,16 +299,16 @@ export const PLANS_LIST = {
 				'Improve security with daily backups, malware scanning, and spam defense.'
 			)
 			: i18n.translate(
-				'Generate income and save on hosting costs.'
+				'Earn income and reduce costs.'
 		),
 		getFeatures: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
 		? [
 			FEATURE_CORE_JETPACK,
-			FEATURE_SITE_BACKUPS_JETPACK,
 			FEATURE_SECURITY_SCANNING_JETPACK,
+			FEATURE_PRIORITY_SUPPORT_JETPACK,
+			FEATURE_SPEED_ADVANCED_JETPACK,
 			FEATURE_REVENUE_GENERATION_JETPACK,
-			FEATURE_VIDEO_HOSTING_JETPACK,
-			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
+			FEATURE_TRAFFIC_TOOLS_JETPACK
 		] : [
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
 			FEATURE_BACKUP_ARCHIVE_30,
@@ -336,7 +341,8 @@ export const PLANS_LIST = {
 			? [
 				FEATURE_CORE_JETPACK,
 				FEATURE_SECURITY_ESSENTIALS_JETPACK,
-				FEATURE_PRIORITY_SUPPORT_JETPACK
+				FEATURE_PRIORITY_SUPPORT_JETPACK,
+				FEATURE_SPEED_JETPACK
 			]
 			: [
 				FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
@@ -366,7 +372,8 @@ export const PLANS_LIST = {
 			? [
 				FEATURE_CORE_JETPACK,
 				FEATURE_SECURITY_ESSENTIALS_JETPACK,
-				FEATURE_PRIORITY_SUPPORT_JETPACK
+				FEATURE_PRIORITY_SUPPORT_JETPACK,
+				FEATURE_SPEED_JETPACK
 			]
 			: [
 				FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
@@ -400,11 +407,11 @@ export const PLANS_LIST = {
 		getFeatures: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
 			? [
 				FEATURE_CORE_JETPACK,
-				FEATURE_SITE_BACKUPS_JETPACK,
 				FEATURE_SECURITY_SCANNING_JETPACK,
+				FEATURE_PRIORITY_SUPPORT_JETPACK,
+				FEATURE_SPEED_UNLIMITED_JETPACK,
 				FEATURE_REVENUE_GENERATION_JETPACK,
-				FEATURE_VIDEO_HOSTING_JETPACK,
-				FEATURE_SEO_TOOLS_JETPACK
+				FEATURE_ADVANCED_TRAFFIC_TOOLS_JETPACK
 			]
 			: compact( [
 				FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
@@ -445,11 +452,11 @@ export const PLANS_LIST = {
 		getFeatures: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
 			? [
 				FEATURE_CORE_JETPACK,
-				FEATURE_SITE_BACKUPS_JETPACK,
 				FEATURE_SECURITY_SCANNING_JETPACK,
+				FEATURE_PRIORITY_SUPPORT_JETPACK,
+				FEATURE_SPEED_UNLIMITED_JETPACK,
 				FEATURE_REVENUE_GENERATION_JETPACK,
-				FEATURE_VIDEO_HOSTING_JETPACK,
-				FEATURE_SEO_TOOLS_JETPACK
+				FEATURE_ADVANCED_TRAFFIC_TOOLS_JETPACK
 			]
 			: compact( [
 				FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
@@ -840,7 +847,7 @@ export const FEATURES_LIST = {
 		getSlug: () => FEATURE_CORE_JETPACK,
 		getTitle: () => i18n.translate( 'Core Jetpack Services' ),
 		getDescription: () => i18n.translate(
-			'Stats, customization, and promotion tools'
+			'Stats, themes, and promotion tools.'
 		),
 		hideInfoPopover: true
 	},
@@ -852,11 +859,39 @@ export const FEATURES_LIST = {
 		),
 		hideInfoPopover: true
 	},
+
 	[ FEATURE_BASIC_SUPPORT_JETPACK ]: {
 		getSlug: () => FEATURE_BASIC_SUPPORT_JETPACK,
 		getTitle: () => i18n.translate( 'Basic Support' ),
 		getDescription: () => i18n.translate(
-			'Standard support for all Jetpack free features.'
+			'Free support to help you make the most of Jetpack.'
+		),
+		hideInfoPopover: true
+	},
+
+	[ FEATURE_SPEED_JETPACK ]: {
+		getSlug: () => FEATURE_SPEED_JETPACK,
+		getTitle: () => i18n.translate( 'Speed and Storage' ),
+		getDescription: () => i18n.translate(
+			'Unlimited use of our high speed image content delivery network.'
+		),
+		hideInfoPopover: true
+	},
+
+	[ FEATURE_SPEED_ADVANCED_JETPACK ]: {
+		getSlug: () => FEATURE_SPEED_ADVANCED_JETPACK,
+		getTitle: () => i18n.translate( 'Speed and Storage' ),
+		getDescription: () => i18n.translate(
+			'Also includes 13Gb of high-speed, ad-free video hosting.'
+		),
+		hideInfoPopover: true
+	},
+
+	[ FEATURE_SPEED_UNLIMITED_JETPACK ]: {
+		getSlug: () => FEATURE_SPEED_UNLIMITED_JETPACK,
+		getTitle: () => i18n.translate( 'Speed and Storage' ),
+		getDescription: () => i18n.translate(
+			'Also includes unlimited, high-speed, ad-free video hosting.'
 		),
 		hideInfoPopover: true
 	},
@@ -869,22 +904,25 @@ export const FEATURES_LIST = {
 		),
 		hideInfoPopover: true
 	},
+
 	[ FEATURE_SECURITY_SCANNING_JETPACK ]: {
 		getSlug: () => FEATURE_SECURITY_SCANNING_JETPACK,
-		getTitle: () => i18n.translate( 'Security Scanning' ),
+		getTitle: () => i18n.translate( 'Advanced Security' ),
 		getDescription: () => i18n.translate(
-			'Daily scans for malware and threats with manual resolution.'
+			'Also includes daily scans for malware and security threats.'
 		),
 		hideInfoPopover: true
 	},
+
 	[ FEATURE_REVENUE_GENERATION_JETPACK ]: {
 		getSlug: () => FEATURE_REVENUE_GENERATION_JETPACK,
 		getTitle: () => i18n.translate( 'Revenue Generation' ),
 		getDescription: () => i18n.translate(
-			'Display high-quality ads to generate income directly from your site.'
+			'High quality ads to generate income from your site.'
 		),
 		hideInfoPopover: true
 	},
+
 	[ FEATURE_VIDEO_HOSTING_JETPACK ]: {
 		getSlug: () => FEATURE_VIDEO_HOSTING_JETPACK,
 		getTitle: () => i18n.translate( 'Video Hosting' ),
@@ -893,30 +931,41 @@ export const FEATURES_LIST = {
 		),
 		hideInfoPopover: true
 	},
+
 	[ FEATURE_SECURITY_ESSENTIALS_JETPACK ]: {
 		getSlug: () => FEATURE_SECURITY_ESSENTIALS_JETPACK,
-		getTitle: () => i18n.translate( 'Security Essentials' ),
+		getTitle: () => i18n.translate( 'Essential Security' ),
 		getDescription: () => i18n.translate(
-			'Daily backups, unlimited storage, one-click restores, and spam filtering.'
+			'Daily backups, unlimited storage, one-click restores, spam filtering.'
 		),
 		hideInfoPopover: true
 	},
+
 	[ FEATURE_PRIORITY_SUPPORT_JETPACK ]: {
 		getSlug: () => FEATURE_PRIORITY_SUPPORT_JETPACK,
 		getTitle: () => i18n.translate( 'Priority Support' ),
 		getDescription: () => i18n.translate(
-			'Fast, dedicated support from our WordPress security experts.'
+			'Faster response times from our security experts.'
 		),
 		hideInfoPopover: true
 	},
-	[ FEATURE_SEO_TOOLS_JETPACK ]: {
-		getSlug: () => FEATURE_SEO_TOOLS_JETPACK,
-		getTitle: () => i18n.translate( 'SEO Tools' ),
+	[ FEATURE_TRAFFIC_TOOLS_JETPACK ]: {
+		getSlug: () => FEATURE_TRAFFIC_TOOLS_JETPACK,
+		getTitle: () => i18n.translate( 'Advanced Traffic Tools' ),
 		getDescription: () => i18n.translate(
-			'Preview and optimize site content for better search engine results.'
+			'Automatically re-promote existing content to social media.'
 		),
 		hideInfoPopover: true
 	},
+
+	[ FEATURE_ADVANCED_TRAFFIC_TOOLS_JETPACK ]: {
+		getSlug: () => FEATURE_ADVANCED_TRAFFIC_TOOLS_JETPACK,
+		getTitle: () => i18n.translate( 'Advanced Traffic Tools' ),
+		getDescription: () => i18n.translate(
+			'Also includes SEO previews and Google Analytics.'
+		),
+		hideInfoPopover: true
+	}
 };
 
 export const getPlanObject = planName => {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -321,28 +321,28 @@ class PlanFeatures extends Component {
 	}
 
 	renderFeatureItem( feature, index ) {
+		const description = feature.getDescription
+					? feature.getDescription( abtest )
+					: null;
+		const itemClasses = classNames(
+			'plan-features__item-title',
+			abtest( 'jetpackNewDescriptions' ) === 'showNew'
+			? 'plan-features__item-title-outlined'
+			: null
+		);
+
 		return (
 			<PlanFeaturesItem
 				key={ index }
-				description={ feature.getDescription
-					? feature.getDescription( abtest )
-					: null
-				}
-				hideInfoPopover={ feature.hideInfoPopover }
+				description={ description }
+				hideInfoPopover={ abtest( 'jetpackNewDescriptions' ) === 'showNew' }
 			>
 				<span className="plan_features__item-info">
-					<span className={ classNames(
-						'plan-features__item-title',
-						feature.hideInfoPopover && feature.getDescription
-							? 'plan-features__item-title-tabs'
-							: null
-						) } >
-						{ feature.getTitle() }
-					</span>
-				{ feature.hideInfoPopover && feature.getDescription
-					? <span className="plan-features__item-description">{ feature.getDescription( abtest ) }</span>
-					: null
-				}
+					<span className={ itemClasses }>{ feature.getTitle() }</span>
+					{ abtest( 'jetpackNewDescriptions' ) === 'showNew'
+						? <span className="plan-features__item-description">{ description }</span>
+						: null
+					}
 				</span>
 			</PlanFeaturesItem>
 		);

--- a/client/my-sites/plan-features/item.jsx
+++ b/client/my-sites/plan-features/item.jsx
@@ -12,7 +12,8 @@ import viewport from 'lib/viewport';
 
 export default function PlanFeaturesItem( {
 	children,
-	description
+	description,
+	hideInfoPopover
 } ) {
 	return (
 		<div className="plan-features__item">
@@ -20,11 +21,14 @@ export default function PlanFeaturesItem( {
 				className="plan-features__item-checkmark"
 				size={ 18 } icon="checkmark" />
 			{ children }
-			<InfoPopover
-				className="plan-features__item-tip-info"
-				position={ viewport.isMobile() ? 'top' : 'right' }>
-				{ description }
-			</InfoPopover>
+			{ hideInfoPopover
+				? null
+				: <InfoPopover
+					className="plan-features__item-tip-info"
+					position={ viewport.isMobile() ? 'top' : 'right' }>
+					{ description }
+				</InfoPopover>
+			}
 		</div>
 	);
 }

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -443,11 +443,12 @@ $plan-features-sidebar-width: 272px;
 	width: 100%;
 }
 
-.plan-features__item-title-tabs {
+.plan-features__item-title-outlined {
 	font-weight: bold;
 	display: block;
 }
 
 .plan-features__item-description {
+	display: inline-block;
 	margin-left: 10px;
-}
+ }

--- a/client/signup/jetpack-connect/plan-features-tab/style.scss
+++ b/client/signup/jetpack-connect/plan-features-tab/style.scss
@@ -1,0 +1,11 @@
+.plan-features-tab__selector {
+	max-width: 320px;
+	margin: 0px auto 16px;
+}
+
+.plans-features-main {
+	.plan-features__table.has-1-cols {
+		max-width: 640px;
+		margin: auto;
+	}
+}

--- a/public/directly.css
+++ b/public/directly.css
@@ -1,0 +1,686 @@
+form ul {
+  margin: 0;
+  padding: 0;
+  list-style: none; }
+
+input[type="text"],
+input[type="search"],
+input[type="email"],
+input[type="number"],
+input[type="password"],
+input[type=checkbox],
+input[type=radio],
+input[type="tel"],
+input[type="url"],
+textarea {
+  margin: 0;
+  padding: 7px 14px;
+  width: 100%;
+  color: #2e4453;
+  font-size: 16px;
+  line-height: 1.5;
+  border: 1px solid #c8d7e1;
+  background-color: white;
+  -webkit-transition: all .15s ease-in-out;
+  transition: all .15s ease-in-out;
+  box-sizing: border-box; }
+  input[type="text"]::-webkit-input-placeholder,
+  input[type="search"]::-webkit-input-placeholder,
+  input[type="email"]::-webkit-input-placeholder,
+  input[type="number"]::-webkit-input-placeholder,
+  input[type="password"]::-webkit-input-placeholder,
+  input[type=checkbox]::-webkit-input-placeholder,
+  input[type=radio]::-webkit-input-placeholder,
+  input[type="tel"]::-webkit-input-placeholder,
+  input[type="url"]::-webkit-input-placeholder,
+  textarea::-webkit-input-placeholder {
+    color: #87a6bc; }
+  input[type="text"]::-moz-placeholder,
+  input[type="search"]::-moz-placeholder,
+  input[type="email"]::-moz-placeholder,
+  input[type="number"]::-moz-placeholder,
+  input[type="password"]::-moz-placeholder,
+  input[type=checkbox]::-moz-placeholder,
+  input[type=radio]::-moz-placeholder,
+  input[type="tel"]::-moz-placeholder,
+  input[type="url"]::-moz-placeholder,
+  textarea::-moz-placeholder {
+    color: #87a6bc; }
+  input[type="text"]:-ms-input-placeholder,
+  input[type="search"]:-ms-input-placeholder,
+  input[type="email"]:-ms-input-placeholder,
+  input[type="number"]:-ms-input-placeholder,
+  input[type="password"]:-ms-input-placeholder,
+  input[type=checkbox]:-ms-input-placeholder,
+  input[type=radio]:-ms-input-placeholder,
+  input[type="tel"]:-ms-input-placeholder,
+  input[type="url"]:-ms-input-placeholder,
+  textarea:-ms-input-placeholder {
+    color: #87a6bc; }
+  input[type="text"]::placeholder,
+  input[type="search"]::placeholder,
+  input[type="email"]::placeholder,
+  input[type="number"]::placeholder,
+  input[type="password"]::placeholder,
+  input[type=checkbox]::placeholder,
+  input[type=radio]::placeholder,
+  input[type="tel"]::placeholder,
+  input[type="url"]::placeholder,
+  textarea::placeholder {
+    color: #87a6bc; }
+  input[type="text"]:hover,
+  input[type="search"]:hover,
+  input[type="email"]:hover,
+  input[type="number"]:hover,
+  input[type="password"]:hover,
+  input[type=checkbox]:hover,
+  input[type=radio]:hover,
+  input[type="tel"]:hover,
+  input[type="url"]:hover,
+  textarea:hover {
+    border-color: #a8bece; }
+  input[type="text"]:focus,
+  input[type="search"]:focus,
+  input[type="email"]:focus,
+  input[type="number"]:focus,
+  input[type="password"]:focus,
+  input[type=checkbox]:focus,
+  input[type=radio]:focus,
+  input[type="tel"]:focus,
+  input[type="url"]:focus,
+  textarea:focus {
+    border-color: #0087be;
+    outline: none;
+    box-shadow: 0 0 0 2px #78dcfa; }
+    input[type="text"]:focus::-ms-clear,
+    input[type="search"]:focus::-ms-clear,
+    input[type="email"]:focus::-ms-clear,
+    input[type="number"]:focus::-ms-clear,
+    input[type="password"]:focus::-ms-clear,
+    input[type=checkbox]:focus::-ms-clear,
+    input[type=radio]:focus::-ms-clear,
+    input[type="tel"]:focus::-ms-clear,
+    input[type="url"]:focus::-ms-clear,
+    textarea:focus::-ms-clear {
+      display: none; }
+  input[type="text"]:disabled,
+  input[type="search"]:disabled,
+  input[type="email"]:disabled,
+  input[type="number"]:disabled,
+  input[type="password"]:disabled,
+  input[type=checkbox]:disabled,
+  input[type=radio]:disabled,
+  input[type="tel"]:disabled,
+  input[type="url"]:disabled,
+  textarea:disabled {
+    background: #f3f6f8;
+    border-color: #e9eff3;
+    color: #a8bece;
+    opacity: 1;
+    -webkit-text-fill-color: #a8bece; }
+    input[type="text"]:disabled:hover,
+    input[type="search"]:disabled:hover,
+    input[type="email"]:disabled:hover,
+    input[type="number"]:disabled:hover,
+    input[type="password"]:disabled:hover,
+    input[type=checkbox]:disabled:hover,
+    input[type=radio]:disabled:hover,
+    input[type="tel"]:disabled:hover,
+    input[type="url"]:disabled:hover,
+    textarea:disabled:hover {
+      cursor: default; }
+    input[type="text"]:disabled::-webkit-input-placeholder,
+    input[type="search"]:disabled::-webkit-input-placeholder,
+    input[type="email"]:disabled::-webkit-input-placeholder,
+    input[type="number"]:disabled::-webkit-input-placeholder,
+    input[type="password"]:disabled::-webkit-input-placeholder,
+    input[type=checkbox]:disabled::-webkit-input-placeholder,
+    input[type=radio]:disabled::-webkit-input-placeholder,
+    input[type="tel"]:disabled::-webkit-input-placeholder,
+    input[type="url"]:disabled::-webkit-input-placeholder,
+    textarea:disabled::-webkit-input-placeholder {
+      color: #a8bece; }
+    input[type="text"]:disabled::-moz-placeholder,
+    input[type="search"]:disabled::-moz-placeholder,
+    input[type="email"]:disabled::-moz-placeholder,
+    input[type="number"]:disabled::-moz-placeholder,
+    input[type="password"]:disabled::-moz-placeholder,
+    input[type=checkbox]:disabled::-moz-placeholder,
+    input[type=radio]:disabled::-moz-placeholder,
+    input[type="tel"]:disabled::-moz-placeholder,
+    input[type="url"]:disabled::-moz-placeholder,
+    textarea:disabled::-moz-placeholder {
+      color: #a8bece; }
+    input[type="text"]:disabled:-ms-input-placeholder,
+    input[type="search"]:disabled:-ms-input-placeholder,
+    input[type="email"]:disabled:-ms-input-placeholder,
+    input[type="number"]:disabled:-ms-input-placeholder,
+    input[type="password"]:disabled:-ms-input-placeholder,
+    input[type=checkbox]:disabled:-ms-input-placeholder,
+    input[type=radio]:disabled:-ms-input-placeholder,
+    input[type="tel"]:disabled:-ms-input-placeholder,
+    input[type="url"]:disabled:-ms-input-placeholder,
+    textarea:disabled:-ms-input-placeholder {
+      color: #a8bece; }
+    input[type="text"]:disabled::placeholder,
+    input[type="search"]:disabled::placeholder,
+    input[type="email"]:disabled::placeholder,
+    input[type="number"]:disabled::placeholder,
+    input[type="password"]:disabled::placeholder,
+    input[type=checkbox]:disabled::placeholder,
+    input[type=radio]:disabled::placeholder,
+    input[type="tel"]:disabled::placeholder,
+    input[type="url"]:disabled::placeholder,
+    textarea:disabled::placeholder {
+      color: #a8bece; }
+
+textarea {
+  min-height: 92px; }
+
+fieldset,
+input[type="text"],
+input[type="search"],
+input[type="email"],
+input[type="number"],
+input[type="password"],
+input[type="tel"],
+input[type="url"],
+textarea,
+select,
+label {
+  box-sizing: border-box; }
+
+/*Checkbooms*/
+input[type=checkbox],
+input[type=radio] {
+  clear: none;
+  cursor: pointer;
+  display: inline-block;
+  line-height: 0;
+  height: 16px;
+  margin: 2px 0 0;
+  float: left;
+  outline: 0;
+  padding: 0;
+  text-align: center;
+  vertical-align: middle;
+  width: 16px;
+  min-width: 16px;
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none; }
+
+input[type=checkbox] + span,
+input[type=radio] + span {
+  display: block;
+  margin-left: 24px; }
+
+input[type=checkbox]:checked:before {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  content: '\f418';
+  margin: -4px 0 0 -5px;
+  float: left;
+  display: inline-block;
+  vertical-align: middle;
+  width: 16px;
+  font: 400 23px/1 Noticons;
+  speak: none;
+  color: #00aadc; }
+
+input[type=checkbox]:disabled:checked:before {
+  color: #a8bece; }
+
+input[type=radio] {
+  border-radius: 50%;
+  margin-right: 4px;
+  line-height: 10px; }
+  input[type=radio]:checked:before {
+    float: left;
+    display: inline-block;
+    content: '\2022';
+    margin: 3px;
+    width: 8px;
+    height: 8px;
+    text-indent: -9999px;
+    background: #00aadc;
+    vertical-align: middle;
+    border-radius: 50%;
+    -webkit-animation: grow .2s ease-in-out;
+            animation: grow .2s ease-in-out; }
+  input[type=radio]:disabled:checked:before {
+    background: #e9eff3; }
+
+@-webkit-keyframes grow {
+  0% {
+    -webkit-transform: scale(0.3);
+            transform: scale(0.3); }
+  60% {
+    -webkit-transform: scale(1.15);
+            transform: scale(1.15); }
+  100% {
+    -webkit-transform: scale(1);
+            transform: scale(1); } }
+
+@keyframes grow {
+  0% {
+    -webkit-transform: scale(0.3);
+            transform: scale(0.3); }
+  60% {
+    -webkit-transform: scale(1.15);
+            transform: scale(1.15); }
+  100% {
+    -webkit-transform: scale(1);
+            transform: scale(1); } }
+
+@keyframes grow {
+  0% {
+    -webkit-transform: scale(0.3);
+            transform: scale(0.3); }
+  60% {
+    -webkit-transform: scale(1.15);
+            transform: scale(1.15); }
+  100% {
+    -webkit-transform: scale(1);
+            transform: scale(1); } }
+
+/* end checkbooms */
+select {
+  background: white url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjQzhEN0UxIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==) no-repeat right 10px center;
+  border-color: #c8d7e1;
+  border-style: solid;
+  border-radius: 4px;
+  border-width: 1px 1px 2px;
+  color: #2e4453;
+  cursor: pointer;
+  display: inline-block;
+  margin: 0;
+  outline: 0;
+  overflow: hidden;
+  font-size: 14px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  text-decoration: none;
+  vertical-align: top;
+  white-space: nowrap;
+  box-sizing: border-box;
+  padding: 7px 32px 9px 14px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none; }
+  select:hover {
+    background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjYThiZWNlIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==); }
+  select:focus {
+    background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiA8dGl0bGU+YXJyb3ctZG93bjwvdGl0bGU+IDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPiA8ZGVmcz48L2RlZnM+IDxnIGlkPSJQYWdlLTEiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHNrZXRjaDp0eXBlPSJNU1BhZ2UiPiA8ZyBpZD0iYXJyb3ctZG93biIgc2tldGNoOnR5cGU9Ik1TQXJ0Ym9hcmRHcm91cCIgZmlsbD0iIzJlNDQ1MyI+IDxwYXRoIGQ9Ik0xNS41LDYgTDE3LDcuNSBMMTAuMjUsMTQuMjUgTDMuNSw3LjUgTDUsNiBMMTAuMjUsMTEuMjUgTDE1LjUsNiBaIiBpZD0iRG93bi1BcnJvdyIgc2tldGNoOnR5cGU9Ik1TU2hhcGVHcm91cCI+PC9wYXRoPiA8L2c+IDwvZz48L3N2Zz4=);
+    border-color: #00aadc;
+    box-shadow: 0 0 0 2px #78dcfa;
+    outline: 0;
+    -moz-outline: none;
+    -moz-user-focus: ignore; }
+  select:disabled, select:hover:disabled {
+    background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjZTllZmYzIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==) no-repeat right 10px center; }
+  select.is-compact {
+    min-width: 0;
+    padding: 0 20px 2px 6px;
+    margin: 0 4px;
+    background-position: right 5px center;
+    background-size: 12px 12px; }
+  label select,
+  label + select {
+    display: block;
+    min-width: 200px; }
+    label select.is-compact,
+    label + select.is-compact {
+      display: inline-block;
+      min-width: 0; }
+  select::-ms-expand {
+    display: none; }
+  select::-ms-value {
+    background: none;
+    color: #2e4453; }
+  select:-moz-focusring {
+    color: transparent;
+    text-shadow: 0 0 0 #2e4453; }
+
+/*Search Inputs*/
+input[type="search"]::-webkit-search-decoration {
+  display: none; }
+
+* {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif; }
+
+body {
+  color: #2e4453;
+  -webkit-font-smoothing: subpixel-antialiased; }
+
+html,
+input,
+select,
+textarea {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif; }
+
+.btn {
+  background: #00aadc;
+  border: 1px solid #008ab3;
+  color: white;
+  border-width: 1px 1px 2px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  vertical-align: top;
+  box-sizing: border-box;
+  line-height: 21px;
+  border-radius: 4px;
+  padding: 7px 14px 9px;
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
+  width: auto; }
+  .btn:hover {
+    border-color: #005082; }
+  .btn:active, .btn:active:enabled {
+    outline: 0;
+    border-width: 2px 1px 1px;
+    padding: 7px 14px 9px;
+    color: white; }
+  .btn:focus {
+    border-color: #005082;
+    box-shadow: 0 0 0 2px #78dcfa; }
+
+input[type="text"],
+input[type="password"],
+input[type="email"],
+input[type="tel"],
+input[type="number"],
+input[type="url"],
+textarea {
+  -webkit-font-smoothing: subpixel-antialiased; }
+  input[type="text"]::-webkit-input-placeholder,
+  input[type="password"]::-webkit-input-placeholder,
+  input[type="email"]::-webkit-input-placeholder,
+  input[type="tel"]::-webkit-input-placeholder,
+  input[type="number"]::-webkit-input-placeholder,
+  input[type="url"]::-webkit-input-placeholder,
+  textarea::-webkit-input-placeholder {
+    color: #87a6bc; }
+
+textarea {
+  vertical-align: inherit; }
+
+.minimized-view,
+.maximized-view {
+  background: #F2F6F8; }
+
+.minimized-view {
+  background: white;
+  box-shadow: 0 1px 10px rgba(46, 68, 83, 0.1);
+  border: 1px solid #d9e3ea; }
+
+.maximized-view.is-ask-view {
+  top: 0; }
+
+.message-list-transition-wrapper {
+  background: #F2F6F8; }
+
+/* HEADER */
+.header-container {
+  border-bottom: 1px solid #e9eff3;
+  box-shadow: none;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 32px;
+      -ms-flex: 0 0 32px;
+          flex: 0 0 32px;
+  height: 32px; }
+  .header-container .header-title {
+    text-transform: uppercase;
+    font-size: 11px;
+    font-weight: 700;
+    color: #87a6bc; }
+  .header-container .menu {
+    border-right: none;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 40px;
+        -ms-flex: 0 0 40px;
+            flex: 0 0 40px; }
+    .header-container .menu .svg-icon {
+      color: #87a6bc; }
+    .header-container .menu.disabled {
+      background: transparent; }
+      .header-container .menu.disabled .svg-icon {
+        color: #d9e3ea; }
+  .header-container .minimize-container {
+    border-left: none;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 40px;
+        -ms-flex: 0 0 40px;
+            flex: 0 0 40px; }
+    .header-container .minimize-container .svg-icon {
+      color: #87a6bc; }
+  .header-container .thread-view-title-container.has-notification {
+    border-bottom-color: #14abdd; }
+
+/* CHAT LIST (opens with the hamburguer button on header) */
+.chat-list-view-container .chat-list-container {
+  top: 32px; }
+  .chat-list-view-container .chat-list-container .question-bar,
+  .chat-list-view-container .chat-list-container .question-bar.closed {
+    background: #87a6bc;
+    padding: 10px 14px; }
+
+.chat-list-view-item-container {
+  background: #e9eff3;
+  border-bottom: 1px solid #d9e3ea;
+  color: #2e4453;
+  padding: 18px 10px 18px 24px; }
+  .chat-list-view-item-container .chat-list-item-title {
+    margin-bottom: 2px;
+    font-size: 16px; }
+  .chat-list-view-item-container .chat-list-item-meta {
+    color: #87a6bc; }
+  .chat-list-view-item-container .unread-message-dot {
+    background: #4ab866;
+    left: 10px;
+    top: 25px; }
+
+.chat-list-view-minimized .chat-list-status {
+  margin-top: 2px; }
+
+.chat-list-view-minimized .svg-icon {
+  color: #00aadc; }
+
+/* ASK QUESTION (opens from chat list) */
+.ask-question-form-container .input-group {
+  padding-bottom: 12px;
+  margin-top: 0; }
+  .ask-question-form-container .input-group label {
+    text-transform: none;
+    font-size: 14px;
+    font-weight: 600;
+    margin-bottom: 5px; }
+    .ask-question-form-container .input-group label strong {
+      font-weight: inherit; }
+
+.ask-question-form-container .submit {
+  width: 100%;
+  padding-bottom: 9px; }
+  .ask-question-form-container .submit .svg-icon {
+    display: none; }
+  .ask-question-form-container .submit strong {
+    margin-top: 0;
+    font-weight: 500; }
+
+/* THREAD */
+.thread-view-container .expert-response-time {
+  color: #87a6bc; }
+
+.message-container {
+  font-size: 14px;
+  border-radius: 8px; }
+  .message-container.is-poster {
+    background: #14abdd;
+    margin-left: inherit;
+    margin-right: 20px;
+    border-top-right-radius: 0px;
+    position: relative; }
+    .message-container.is-poster:after {
+      position: absolute;
+      top: 0;
+      right: -10px;
+      content: "";
+      display: block;
+      width: 0;
+      height: 0;
+      border-style: solid;
+      border-width: 10px 10px 0 0;
+      border-color: #14abdd transparent transparent transparent; }
+  .message-container.is-expert {
+    border: none;
+    border-radius: 8px;
+    border-top-left-radius: 0;
+    margin-right: inherit;
+    margin-left: 20px;
+    position: relative; }
+    .message-container.is-expert:after {
+      position: absolute;
+      top: 0;
+      left: -10px;
+      content: "";
+      display: block;
+      width: 0;
+      height: 0;
+      border-style: solid;
+      border-width: 0 10px 10px 0;
+      border-color: transparent white transparent transparent; }
+    .message-container.is-expert .author img {
+      width: 32px !important;
+      height: 32px !important; }
+
+.author .name-wrapper {
+  font-size: 12px;
+  font-weight: 500; }
+
+.author .profile .reputation {
+  color: #a8bece; }
+
+.avatar {
+  background: #d9e3ea; }
+
+.system-message {
+  border: 1px solid #d9e3ea;
+  background: #e9eff3;
+  font-size: 14px;
+  margin-right: 0;
+  border-radius: 8px; }
+  .system-message.has-sibling + .system-message {
+    border-top: 1px solid #d9e3ea; }
+  .system-message.success {
+    border-color: #4ab866;
+    background: #DCEEE5; }
+  .system-message.success.inverted {
+    border-color: transparent;
+    background: #4ab866;
+    color: white; }
+    .system-message.success.inverted a {
+      color: white; }
+  .system-message.warning {
+    background: #f0b849;
+    border-color: transparent;
+    color: white; }
+    .system-message.warning a {
+      color: white; }
+  .system-message.alerting-experts .expert-name:empty {
+    background: #d9e3ea; }
+  .system-message.alerting-experts .expert-last-active-date {
+    color: #87a6bc; }
+    .system-message.alerting-experts .expert-last-active-date:empty {
+      background: #d9e3ea; }
+  .system-message .icon-avatar {
+    background: #d9e3ea; }
+  .system-message .icon {
+    margin-top: 0; }
+    .system-message .icon.icon-primary {
+      background-color: #14abdd; }
+    .system-message .icon.icon-success {
+      background-color: white;
+      color: #4ab866; }
+    .system-message .icon.icon-warning {
+      background-color: white;
+      color: #f0b849; }
+  .system-message.inverted .icon.icon-success {
+    background-color: white;
+    color: #4ab866; }
+
+.expert-carousel {
+  box-shadow: none; }
+
+.thread-view-footer {
+  border-top: 1px solid #e9eff3;
+  box-shadow: none;
+  background: white; }
+
+.chat-view-minimized .alerting {
+  color: #87a6bc; }
+  .chat-view-minimized .alerting .beacon {
+    background: #0087be;
+    margin: 5px auto; }
+    .chat-view-minimized .alerting .beacon:after {
+      background: #0087be; }
+
+.chat-view-minimized .chatting img {
+  height: 64px;
+  width: 64px; }
+
+.chat-view-minimized .notification {
+  background: #00aadc;
+  font-size: 12px;
+  font-weight: 500;
+  min-width: 24px;
+  line-height: 24px;
+  margin-top: -3px;
+  margin-left: -3px; }
+
+.message-form-container .message-input {
+  padding-right: 10px;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center; }
+
+.message-form-container textarea:focus {
+  box-shadow: none; }
+
+.message-form-container .submit-btn[disabled] {
+  background-color: #d9e3ea;
+  border: none; }
+
+.toolbar-accepted-container,
+.toolbar-default-container,
+.toolbar-rate-container {
+  border-top: 1px solid #e9eff3; }
+
+.toolbar-container .tooltip-wrapper {
+  border-left: 1px solid #e9eff3; }
+
+.toolbar-container .toolbar-btn {
+  color: #87a6bc;
+  border-left: 1px solid #e9eff3; }
+  .toolbar-container .toolbar-btn .svg-icon {
+    color: #4ab866; }
+
+.toolbar-container .rate-icon .dot.dot-green {
+  background: #4ab866; }
+
+.toolbar-container .rate-icon .dot.dot-yellow {
+  background: #f0b849; }
+
+.toolbar-container .rate-icon .dot.dot-red {
+  background: #d94f4f; }
+
+.ActionBar {
+  background: white; }
+
+.ActionBar__button {
+  box-shadow: none; }
+  .ActionBar__button:hover {
+    box-shadow: none;
+    -webkit-transform: none;
+            transform: none; }


### PR DESCRIPTION
As proposed in`p7kMJG-1pI-p2`, we are going to run a test that changes the descriptions of the features on the jetpack plans pages.

This is how the test looks like:
![image](https://cloud.githubusercontent.com/assets/1554855/24258063/ececa4ec-0fec-11e7-972a-439d162aa739.png)

![image](https://cloud.githubusercontent.com/assets/1554855/24257891/58212860-0fec-11e7-9c9a-55d20b6cfdf9.png)


How to test
====

1. Go to http://calypso.localhost:3000/jetpack/connect/store and check the old plans page style and make sure is still three
2. Open the developer console and run `localStorage.setItem( 'ABTests', '{"jetpackNewDescriptions_20170327":"showNew"}' );`
3. Reload the page
4. The new descriptions & look should be there
5. Go to http://calypso.localhost:3000/ and select a jetpack site. Go to the plans page. You should see the new Style & descriptions there too
