### PR TITLE
DropZone: Accept full nodes as icon, instead of text.

### DIFF
--- a/client/components/drop-zone/README.md
+++ b/client/components/drop-zone/README.md
@@ -52,4 +52,4 @@ Pass true to have the droppable area occupy the entire screen, regardless of whe
 
 ### `icon`
 
-Pass a React Node to set a custom icon. 
+Pass a React Node to set a custom icon. Defaults to `<Gridicon icon="cloud-upload" size={ 48 } />`.

--- a/client/components/drop-zone/README.md
+++ b/client/components/drop-zone/README.md
@@ -49,3 +49,7 @@ A function to be invoked when a user drops a file into the rendered Drop Zone el
 ### `fullScreen`
 
 Pass true to have the droppable area occupy the entire screen, regardless of whether the component is rendered in the context of a `relative` positioned element. Defaults to `false`.
+
+### `icon`
+
+Pass a React Node to set a custom icon. 

--- a/client/components/drop-zone/index.jsx
+++ b/client/components/drop-zone/index.jsx
@@ -3,7 +3,6 @@
  */
 import ReactDom from 'react-dom';
 import React, { PropTypes } from 'react';
-import createFragment from 'react-addons-create-fragment';
 import without from 'lodash/without';
 import includes from 'lodash/includes';
 import classNames from 'classnames';
@@ -23,7 +22,7 @@ export const DropZone = React.createClass( {
 		onVerifyValidTransfer: PropTypes.func,
 		onFilesDrop: PropTypes.func,
 		fullScreen: PropTypes.bool,
-		icon: PropTypes.string,
+		icon: PropTypes.node,
 		textLabel: PropTypes.string,
 		translate: PropTypes.func,
 	},
@@ -41,7 +40,7 @@ export const DropZone = React.createClass( {
 			onVerifyValidTransfer: () => true,
 			onFilesDrop: noop,
 			fullScreen: false,
-			icon: 'cloud-upload',
+			icon: <Gridicon icon="cloud-upload" size={ 48 } />,
 			translate: identity,
 		};
 	},
@@ -195,26 +194,28 @@ export const DropZone = React.createClass( {
 	},
 
 	renderContent() {
-		let content;
-
 		const textLabel = this.props.textLabel
 			? this.props.textLabel
 			: this.props.translate( 'Drop files to upload' );
 
-		if ( this.props.children ) {
-			content = this.props.children;
-		} else {
-			content = createFragment( {
-				icon: <Gridicon icon={ this.props.icon } size={ 48 } className="drop-zone__content-icon" />,
-				text: (
-					<span className="drop-zone__content-text">
-						{ textLabel }
-					</span>
-				)
-			} );
-		}
-
-		return <div className="drop-zone__content">{ content }</div>;
+		return (
+			<div className="drop-zone__content">
+				{
+					this.props.children
+						? this.props.children
+						: (
+							<div>
+								<span className="drop-zone__content-icon">
+									{ this.props.icon }
+								</span>
+								<span className="drop-zone__content-text">
+									{ textLabel }
+								</span>
+							</div>
+						)
+				}
+			</div>
+		);
 	},
 
 	render() {

--- a/client/components/drop-zone/style.scss
+++ b/client/components/drop-zone/style.scss
@@ -51,6 +51,7 @@
 
 .drop-zone__content-icon {
 	margin: 0 auto;
+	line-height: 0;
 }
 
 .drop-zone.is-full-screen .drop-zone__content {

--- a/client/components/drop-zone/test/index.jsx
+++ b/client/components/drop-zone/test/index.jsx
@@ -70,13 +70,13 @@ describe( 'index', function() {
 	} );
 
 	it( 'should accept an icon to override the default icon', function() {
-		var tree = ReactDom.render( React.createElement( DropZone, {
-				icon: 'house'
-			} ), container ), icon;
+		const tree = ReactDom.render( React.createElement( DropZone, {
+			icon: <div className="customIconClassName" />
+		} ), container );
 
-		icon = TestUtils.findRenderedDOMComponentWithClass( tree, 'drop-zone__content-icon' );
+		const icon = TestUtils.findRenderedDOMComponentWithClass( tree, 'customIconClassName' );
 
-		expect( icon.className ).to.contain( 'gridicons-house' );
+		expect( TestUtils.isDOMComponent( icon ) ).to.equal( true );
 	} );
 
 	it( 'should highlight the drop zone when dragging over the body', function() {


### PR DESCRIPTION
This PR is part of an ongoing series of improvements around #11839. 

It changes the type of the `icon` prop from `string` to `node` to accommodate more advanced customization of the DropZone. 

To test: 
1. Checkout branch or use Calypso.live 
2. Open the editor
3. Start dragging a file over the editor
4. Verify that everything looks the same
5. Verify there are no JS errors
6. Verify the file upload works correctly when dropping the file
7. Verify the post is saved/published properly