### PR TITLE
Reader: Use a feed stream for searches ordered by date

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -78,7 +78,7 @@ $z-layers: (
 		'.thank-you-card__header': 1,
 		'.editor-action-bar .editor-status-label': 2,
 		'.is-installing .theme': 2,
-		'.reader-update-notice': 2,
+		'.reader-update-notice': 22,
 		'.people-list-item .card__link-indicator': 2,
 		'.updated-confirmation': 2,
 		'.auth__form .form-fieldset input:focus': 2,

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -63,7 +63,7 @@ export default class FeedStream {
 			perPage: 7,
 			selectedIndex: -1,
 			xPostedByURL: {},
-			maxUpdates: 40,
+			maxUpdates: spec.maxUpdates || 40,
 			gapFillCount: 21,
 			orderBy: 'date',
 			_isLastPage: false,
@@ -457,7 +457,6 @@ export default class FeedStream {
 				postById.add( postKey.postId );
 			} );
 			this.postKeys = this.postKeys.concat( postKeys );
-
 		}
 
 		this.page++;

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -133,8 +133,15 @@ function getStoreForSearch( storeId ) {
 	const slug = idParts.slice( 2 ).join( ':' );
 	// We can use a feed stream when it's a strict date sort.
 	// This lets us go deeper than 20 pages and let's the results auto-update
-	const StreamClass = sort === 'date' ? FeedStream : PagedStream;
-	const stream = new StreamClass( {
+	const stream = sort === 'date' ? new FeedStream( {
+		id: storeId,
+		fetcher: fetcher,
+		keyMaker: siteKeyMaker,
+		perPage: 5,
+		onGapFetch: limitSiteParams,
+		onUpdateFetch: limitSiteParams,
+		maxUpdates: 20,
+	} ) : new PagedStream( {
 		id: storeId,
 		fetcher: fetcher,
 		keyMaker: siteKeyMaker,

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -131,7 +131,10 @@ function getStoreForSearch( storeId ) {
 	const idParts = storeId.split( ':' );
 	const sort = validateSearchSort( idParts[ 1 ] );
 	const slug = idParts.slice( 2 ).join( ':' );
-	const stream = new PagedStream( {
+	// We can use a feed stream when it's a strict date sort.
+	// This lets us go deeper than 20 pages and let's the results auto-update
+	const StreamClass = sort === 'date' ? FeedStream : PagedStream;
+	const stream = new StreamClass( {
 		id: storeId,
 		fetcher: fetcher,
 		keyMaker: siteKeyMaker,


### PR DESCRIPTION
This allows the search stream to poll for new posts in the search and load more pages of results past the 200 post limit on paged streams.

To test, pull up a search for a popular term (say `photo`), change to the date-sorted search using the pill in the search box, then wait a minute for new results to be detected. You should see the `N New Posts` pill appear. Clicking it should load in the new posts.
