### PR TITLE
Themes: Track Scrolling to Last Page

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -103,12 +103,16 @@ class ThemesSelection extends Component {
 	}
 
 	fetchNextPage = ( options ) => {
-		if ( this.props.isRequesting || this.props.isLastPage ) {
-			return;
+		if ( options.triggeredByScroll ) {
+			if ( this.props.isLastPage ) {
+				this.trackLastPage();
+			} else {
+				this.trackScrollPage();
+			}
 		}
 
-		if ( options.triggeredByScroll ) {
-			this.trackScrollPage();
+		if ( this.props.isRequesting || this.props.isLastPage ) {
+			return;
 		}
 
 		this.props.incrementPage();


### PR DESCRIPTION
Fixes #12462.

To test:
* http://calypso.localhost:3000/design
* Enable analytics debugging in the browser console (`localStorage.setItem( 'debug', 'calypso:analytics*' );`)
* Reload
* Enter a search term, e.g. `automattic`. Scroll and watch `calypso_themeshowcase_scroll` events being tracked in the console. When reaching the last page, a `calypso_themeshowcase_last_page_scroll` event should be tracked.