### PR TITLE
Reader: Release sort order on search results

### DIFF
--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -8,7 +8,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import config from 'config';
 import ControlItem from 'components/segmented-control/item';
 import SegmentedControl from 'components/segmented-control';
 import CompactCard from 'components/card/compact';
@@ -261,7 +260,7 @@ class SearchStream extends Component {
 							initialValue={ query }
 							value={ query }>
 						</SearchInput>
-						{ query && config.isEnabled( 'reader/search/sort-by-date' ) &&
+						{ query &&
 							<SegmentedControl compact
 								className="search-stream__sort-picker">
 								<ControlItem

--- a/config/development.json
+++ b/config/development.json
@@ -127,7 +127,6 @@
 		"reader/related-posts": true,
 		"reader/search": true,
 		"reader/tags-with-elasticsearch": false,
-		"reader/search/sort-by-date": true,
 		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -95,7 +95,6 @@
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,
 		"reader/search": true,
-		"reader/search/sort-by-date": true,
 		"reader/tags-with-elasticsearch": false,
 		"resume-editing": true,
 		"republicize": true,


### PR DESCRIPTION
Removes the feature flag and it's associated check, allowing folks to sort search results.