### PR TITLE
Sharing: Fix link colors in social previews

### DIFF
--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -29,12 +29,14 @@ export class FacebookSharePreview extends PureComponent {
 									{ externalName }
 								</a>
 								published an article on
-								<a href="https://wordpress.com">
+								<a className="facebook-share-preview__profile-wp-link"
+									href="https://wordpress.com">
 									WordPress.
 								</a>
 							</div>
 							<div className="facebook-share-preview__meta-line">
-								<a href="https://wordpress.com">
+								<a className="facebook-share-preview__meta-link"
+									href="https://wordpress.com">
 									WordPress
 								</a>
 							</div>

--- a/client/components/share/facebook-share-preview/style.scss
+++ b/client/components/share/facebook-share-preview/style.scss
@@ -8,10 +8,17 @@
 	max-width: 486px;
 	padding: 12px;
 	-webkit-overflow-scrolling: touch;
-}
 
-.facebook-share-preview a {
-	color: #365899;
+	// Nesting to win main.scss
+	.facebook-share-preview__profile-name,
+	.facebook-share-preview__profile-wp-link,
+	.facebook-share-preview__article-url {
+		color: #365899;
+	}
+
+	.facebook-share-preview__meta-link {
+		color: #90949c;
+	}
 }
 
 .facebook-share-preview__header {
@@ -49,10 +56,6 @@
 	color: #90949c;
 	font-size: 12px;
 	line-height: 1.34;
-}
-
-.facebook-share-preview .facebook-share-preview__meta-line a {
-	color: #90949c;
 }
 
 .facebook-share-preview__message p {

--- a/client/components/share/twitter-share-preview/style.scss
+++ b/client/components/share/twitter-share-preview/style.scss
@@ -9,18 +9,18 @@
 	max-width: 565px;
 	padding: 12px;
 
-   // Nesting to win main.scss
-   .twitter-share-preview__profile-handle {
-           color: #657786;
-   }
+	// Nesting to win main.scss
+	.twitter-share-preview__profile-handle {
+		color: #657786;
+	}
 
-   .twitter-share-preview__profile-name {
-           color: #14171a;
-   }
+	.twitter-share-preview__profile-name {
+		color: #14171a;
+	}
 
-   .twitter-share-preview__article-url {
-           color: #0084b4;
-   }
+	.twitter-share-preview__article-url {
+		color: #0084b4;
+	}
 }
 
 .twitter-share-preview__content {

--- a/client/components/share/twitter-share-preview/style.scss
+++ b/client/components/share/twitter-share-preview/style.scss
@@ -8,6 +8,19 @@
 	margin: 0 auto;
 	max-width: 565px;
 	padding: 12px;
+
+   // Nesting to win main.scss
+   .twitter-share-preview__profile-handle {
+           color: #657786;
+   }
+
+   .twitter-share-preview__profile-name {
+           color: #14171a;
+   }
+
+   .twitter-share-preview__article-url {
+           color: #0084b4;
+   }
 }
 
 .twitter-share-preview__content {
@@ -26,18 +39,16 @@
 }
 
 .twitter-share-preview__profile-name {
-	color: #14171a;
 	font-weight: bold;
 	margin-right: 5px;
 
 	&:hover {
-		color: #0084B4;
+		color: #0084b4;
 		text-decoration: underline;
 	}
 }
 
 .twitter-share-preview__profile-handle {
-	color: #657786;
 	font-size: 13px;
 }
 
@@ -45,11 +56,6 @@
 .twitter-share-preview__article-url {
 	font-size: 16px;
 	line-height: 22px;
-}
-
-.twitter-share-preview__message a,
-.twitter-share-preview__article-url {
-	color: #0084B4;
 }
 
 .twitter-share-preview__article-url-line {


### PR DESCRIPTION
It's been raised in #12418. But it turns out we need to add specificities to win `main.scss` for now and this is a cleaner interim solution.