### PR TITLE
Directly: Enable in the Desktop environment

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -453,7 +453,6 @@ const HelpContact = React.createClass( {
 	shouldUseDirectly: function() {
 		const isEn = this.props.currentUserLocale === 'en';
 		return (
-			config.isEnabled( 'help/directly' ) &&
 			isEn &&
 			! this.props.isDirectlyFailed
 		);

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -22,7 +22,6 @@
 		"fluid-width": true,
 		"help": true,
 		"help/courses": true,
-		"help/directly": true,
 		"jetpack/personalPlan": true,
 		"manage/custom-post-types": true,
 		"manage/customize": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -22,6 +22,7 @@
 		"fluid-width": true,
 		"help": true,
 		"help/courses": true,
+		"help/directly": true,
 		"jetpack/personalPlan": true,
 		"manage/custom-post-types": true,
 		"manage/customize": true,

--- a/config/development.json
+++ b/config/development.json
@@ -46,7 +46,6 @@
 		"guided-tours/theme-sheet-welcome": true,
 		"help": true,
 		"help/courses": true,
-		"help/directly": true,
 		"jetpack/invites": true,
 		"jetpack_core_inline_update": true,
 		"jetpack/api-cache": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -23,7 +23,6 @@
 		"happychat": false,
 		"help": true,
 		"help/courses": true,
-		"help/directly": true,
 		"jetpack/api-cache": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,

--- a/config/production.json
+++ b/config/production.json
@@ -22,7 +22,6 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
-		"help/directly": true,
 		"jetpack/api-cache": false,
 		"manage/custom-post-types": true,
 		"manage/customize": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -24,7 +24,6 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
-		"help/directly": true,
 		"jetpack/api-cache": true,
 		"jetpack_core_inline_update": true,
 		"manage/custom-post-types": true,

--- a/config/test.json
+++ b/config/test.json
@@ -37,7 +37,6 @@
 		"devdocs/redirect-loggedout-homepage": true,
 		"devdocs/components-usage-stats": false,
 		"help": true,
-		"help/directly": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
 		"manage/customize": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -30,7 +30,6 @@
 		"guided-tours/theme-sheet-welcome": true,
 		"help": true,
 		"help/courses": true,
-		"help/directly": true,
 		"jetpack/api-cache": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,


### PR DESCRIPTION
Turns on Directly support in the Desktop environment.

### To test

Test this by enabling this branch of `wp-calypso` in `wp-desktop`:

```
cd path/to/wp-desktop
cd calypso
git fetch origin add/directly-in-desktop
git checkout add/directly-in-desktop
cd ..
make distclean
make run
```

When the desktop app opens, sign in as a user with no paid upgrades. Navigate to the Help / Contact Us page. You should see the form with button "Ask an Expert".

_Note:_ We are still throttling Directly so only 20% of users have access. If your account sees the "Ask in the forums" button, you'll either need to keep creating dummy accounts until you luck into one that has Directly access, or [comment out these 3 lines](https://github.com/Automattic/wp-calypso/blob/master/client/lib/directly/index.js#L117-L119) in `wp-desktop/calypso/client/lib/directly/index.js`. If you alter the code you'll need to `make distclean; make run` the project again to pick up the change.

Once you see the "Ask an Expert" button, fill in the form. **Please make this test message professional and clearly a test, as the Desktop app is hooked up to our production Directly instance, and our expert users will be notified of your message.** When you submit the form the Directly widget should open.

Sign into Directly here: https://automattic.directly.com. Use the shared Expert Account credentials found in the FG Directly page. Find the question you just asked and send a response.

Back in the Desktop app you should see the response appear in the widget. Mark the answer as accepted to close out the issue.
