### PR TITLE
Reader: photo cards too large in search stream

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -184,7 +184,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	margin-right: 0;
 	margin-bottom: 0;
 	max-width: 100%;
-	width: 100%;
 
 	&:hover {
 		cursor: zoom-in;


### PR DESCRIPTION
Currently: 
<img width="895" alt="screen shot 2017-03-23 at 3 54 47 pm" src="https://cloud.githubusercontent.com/assets/4656974/24268021/a4f812de-0fe2-11e7-915a-e8e030fe8458.png">

Notice bleeding photo on the top right 