### PR TITLE
ATAT: disable AT in production temporarily

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -14,7 +14,7 @@
 	"features": {
 		"ad-tracking": true,
 		"apple-pay": true,
-		"automated-transfer": true,
+		"automated-transfer": false,
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,


### PR DESCRIPTION
We're seeing some intermittent issues where domains are not reliably routed to the new AT system. Turning off AT in production briefly until we sort this out.