### PR TITLE
Domains: Do not show domain needs configuration notice for AT

### DIFF
--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -102,8 +102,16 @@ export default React.createClass( {
 			return null;
 		}
 
-		const wrongMappedDomains = this.getDomains().filter( domain =>
-			domain.type === domainTypes.MAPPED && ! domain.pointsToWpcom );
+		const wrongMappedDomains = this.getDomains().filter( ( domain ) => {
+			if (
+				get( this.props, 'selectedSite.options.is_automated_transfer' ) &&
+				get( this.props, 'selectedSite.domain' ) === domain.domain
+			) {
+				return false;
+			}
+
+			return domain.type === domainTypes.MAPPED && ! domain.pointsToWpcom;
+		} );
 
 		debug( 'NS error domains:', wrongMappedDomains );
 		let learnMoreUrl,


### PR DESCRIPTION
If a mapped domain is used for an AT site, that results in users seeing a notice like this:

![screen shot 2017-03-23 at 7 23 51 pm](https://cloud.githubusercontent.com/assets/1126811/24275568/4f9e422e-0ffe-11e7-8234-c4eb0d9ea851.png)

I'm not sure if this is the correct solution, but it does seem to clear the issue on a user's site. Pinging @matthusby for a review. Here is some backstory: p6qnuF-4s3-p2.

cc @rralian 