### PR TITLE
AT: font and colors code is safe now, relaunching AT

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -14,7 +14,7 @@
 	"features": {
 		"ad-tracking": true,
 		"apple-pay": true,
-		"automated-transfer": false,
+		"automated-transfer": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -16,7 +16,7 @@
 	"features": {
 		"ad-tracking": false,
 		"apple-pay": true,
-		"automated-transfer": false,
+		"automated-transfer": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"community-translator": true,


### PR DESCRIPTION
Fonts still need options copied over, but we're no longer getting fatals, so we're safe to start transfers again.