### PR TITLE
Site Settings: Add a lighter controller to start splitting bundle

### DIFF
--- a/client/my-sites/site-settings/settings-controller.js
+++ b/client/my-sites/site-settings/settings-controller.js
@@ -1,0 +1,54 @@
+/**
+ * External Dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal Dependencies
+ */
+import analytics from 'lib/analytics';
+import route from 'lib/route';
+import { sectionify } from 'lib/route/path';
+import sitesFactory from 'lib/sites-list';
+import titlecase from 'to-title-case';
+import utils from 'lib/site/utils';
+
+/**
+ * Module vars
+ */
+const sites = sitesFactory();
+
+export default {
+	siteSettings( context, next ) {
+		let analyticsPageTitle = 'Site Settings';
+		const basePath = route.sectionify( context.path );
+		const fiveMinutes = 5 * 60 * 1000;
+		let site = sites.getSelectedSite();
+		const section = sectionify( context.path ).split( '/' )[ 2 ];
+
+		// if site loaded, but user cannot manage site, redirect
+		if ( site && ! utils.userCan( 'manage_options', site ) ) {
+			page.redirect( '/stats' );
+			return;
+		}
+
+		if ( ! site.latestSettings || new Date().getTime() - site.latestSettings > ( fiveMinutes ) ) {
+			if ( sites.initialized ) {
+				site.fetchSettings();
+			} else {
+				sites.once( 'change', function() {
+					site = sites.getSelectedSite();
+					site.fetchSettings();
+				} );
+			}
+		}
+
+		// analytics tracking
+		if ( 'undefined' !== typeof section ) {
+			analyticsPageTitle += ' > ' + titlecase( section );
+		}
+		analytics.pageView.record( basePath + '/:site', analyticsPageTitle );
+
+		next();
+	}
+};


### PR DESCRIPTION
With the recent work on [Jetpack Settings in Calypso](https://github.com/Automattic/wp-calypso/milestone/141) the settings bundle has grown very large (over 1MB now). This is too large, so we must consider splitting it into multiple sections, as discussed in p4TIVU-5Zs-p2.

This PR is the first step towards that - it introduces a new controller for the site settings. It's currently not used anywhere, but we'll be using it in several PRs that will use it. After several iterations, it will replace the default site settings container, however, for now we have to keep it separate in order to maintain the rest of the sections while refactoring a particular one.

The PR basically duplicates the existing `siteSettings` callback of the current site settings controller, but changes it to not render anything, but rather leave that to the next invoked callback. We could consider improving some of that code, but this is not the goal of this PR.

No special testing is really needed, because this file is not used anywhere right now. Just a sanity check should be enough. 

/cc @mtias @dmsnell as they participated actively in the discussion.