### PR TITLE
Site Settings: Redirect SEO and Analytics legacy routes early

### DIFF
--- a/client/my-sites/site-settings/traffic/index.js
+++ b/client/my-sites/site-settings/traffic/index.js
@@ -17,6 +17,6 @@ export default function() {
 	page( '/settings/traffic/:site_id', mySitesController.siteSelection, mySitesController.navigation, controller.traffic );
 
 	// redirect legacy urls
-	page( '/settings/analytics/:site_id', redirectToTrafficSection );
-	page( '/settings/seo/:site_id', redirectToTrafficSection );
+	page( '/settings/analytics/:site_id?', redirectToTrafficSection );
+	page( '/settings/seo/:site_id?', redirectToTrafficSection );
 }

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -94,13 +94,6 @@ const sections = [
 		group: 'sites'
 	},
 	{
-		name: 'settings',
-		paths: [ '/settings' ],
-		module: 'my-sites/site-settings',
-		secondary: true,
-		group: 'sites'
-	},
-	{
 		name: 'settings-writing',
 		paths: [ '/settings/writing', '/settings/taxonomies' ],
 		module: 'my-sites/site-settings/settings-writing',
@@ -118,6 +111,13 @@ const sections = [
 		name: 'settings-traffic',
 		paths: [ '/settings/traffic', '/settings/seo', '/settings/analytics' ],
 		module: 'my-sites/site-settings/traffic',
+		secondary: true,
+		group: 'sites'
+	},
+	{
+		name: 'settings',
+		paths: [ '/settings' ],
+		module: 'my-sites/site-settings',
 		secondary: true,
 		group: 'sites'
 	},


### PR DESCRIPTION
@oskosk today noticed that if we open `https://wordpress.com/settings/seo` the site selector will be shown before the redirect. As he suggested, it would be nice if we could redirect first, and then show the site selector. 

This PR takes care of that by:
* Making the `site_id` context parameter optional.
* Moving the Traffic section above the general Settings section

To test:
* Checkout this branch, or get it going on calypso.live
* Go to `/settings/seo` (without a site slug in the URL) and verify you're redirected to `/settings/traffic` before the site selector is presented.
* Go to `/settings/analytics` (without a site slug in the URL) and verify you're redirected to `/settings/traffic` before the site selector is presented.
* Verify the other Settings routes work like before.