### PR TITLE
Editor: Remove post-editor/insert-menu config

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -135,11 +135,8 @@ const PLUGINS = [
 	'wpcom/sourcecode',
 	'wpcom/embedreversal',
 	'wpcom/trackpaste',
+	'wpcom/insertmenu',
 ];
-
-if ( config.isEnabled( 'post-editor/insert-menu' ) ) {
-	PLUGINS.push( 'wpcom/insertmenu' );
-}
 
 if ( config.isEnabled( 'post-editor/mentions' ) ) {
 	mentionsPlugin();
@@ -236,9 +233,6 @@ module.exports = React.createClass( {
 		this.localize();
 
 		const ltrButton = user.isRTL() ? 'ltr,' : '';
-		const toolbar1 = config.isEnabled( 'post-editor/insert-menu' )
-				? `wpcom_insert_menu,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,${ ltrButton }wpcom_advanced`
-				: `wpcom_add_media,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,wpcom_add_contact_form,${ ltrButton }wpcom_advanced`;
 
 		tinymce.init( {
 			selector: '#' + this._id,
@@ -312,7 +306,7 @@ module.exports = React.createClass( {
 			autoresize_min_height: Math.max( document.documentElement.clientHeight - 300, 300 ),
 			autoresize_bottom_margin: viewport.isMobile() ? 10 : 50,
 
-			toolbar1: toolbar1,
+			toolbar1: `wpcom_insert_menu,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,${ ltrButton }wpcom_advanced`,
 			toolbar2: 'strikethrough,underline,hr,alignjustify,forecolor,pastetext,removeformat,wp_charmap,outdent,indent,undo,redo,wp_help',
 			toolbar3: '',
 			toolbar4: '',

--- a/client/components/tinymce/plugins/insert-menu/plugin.jsx
+++ b/client/components/tinymce/plugins/insert-menu/plugin.jsx
@@ -5,7 +5,6 @@ import { renderToString } from 'react-dom/server';
 import i18n from 'i18n-calypso';
 
 import Gridicon from 'gridicons';
-import config from 'config';
 
 import menuItems from './menu-items';
 
@@ -36,9 +35,5 @@ const initialize = editor => {
 };
 
 export default () => {
-	if ( ! config.isEnabled( 'post-editor/insert-menu' ) ) {
-		return;
-	}
-
 	tinymce.PluginManager.add( 'wpcom/insertmenu', initialize );
 };

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -592,12 +592,6 @@ div.mce-path {
 	}
 }
 
-// [TODO]: Selector `:not( .mce-wpcom-insert-menu )` unnecessary when
-// `post-editor/insert-menu` feature enabled in all environments
-.mce-toolbar-grp:not( .mce-inline-toolbar-grp ) .mce-btn-group .mce-btn.mce-first:not( .mce-wpcom-insert-menu ) {
-	margin-left: 4px;
-}
-
 #wp-fullscreen-buttons .mce-btn:hover,
 .mce-toolbar .mce-btn-group .mce-btn:hover,
 #wp-fullscreen-buttons .mce-btn:focus,

--- a/client/layout/guided-tours/tours/editor-insert-menu-tour.js
+++ b/client/layout/guided-tours/tours/editor-insert-menu-tour.js
@@ -17,7 +17,6 @@ import {
 	Quit,
 } from 'layout/guided-tours/config-elements';
 import {
-	isEnabled,
 	hasUserRegisteredBefore,
 } from 'state/ui/guided-tours/contexts';
 import { isDesktop } from 'lib/viewport';
@@ -44,7 +43,6 @@ export const EditorInsertMenuTour = makeTour(
 		path={ [ '/post/', '/page/' ] }
 		version="20161215"
 		when={ and(
-			isEnabled( 'post-editor/insert-menu' ),
 			hasUserRegisteredBefore( new Date( '2016-12-15' ) ),
 			isDesktop,
 		) }

--- a/config/development.json
+++ b/config/development.json
@@ -115,7 +115,6 @@
 		"post-editor-github-link": false,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
-		"post-editor/insert-menu": true,
 		"post-editor/media-advanced": false,
 		"post-editor/mentions": true,
 		"press-this": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -74,7 +74,6 @@
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
-		"post-editor/insert-menu": true,
 		"post-editor/mentions": true,
 		"press-this": true,
 		"preview-layout": true,

--- a/config/production.json
+++ b/config/production.json
@@ -71,7 +71,6 @@
 		"plans/personal-plan": true,
 		"post-editor/author-selector": true,
 		"post-editor/html-toolbar": true,
-		"post-editor/insert-menu": true,
 		"post-editor/image-editor": true,
 		"post-editor/mentions": false,
 		"press-this": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -73,7 +73,6 @@
 		"persist-redux": true,
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,
-		"post-editor/insert-menu": true,
 		"post-editor/image-editor": true,
 		"post-editor/mentions": false,
 		"press-this": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -87,7 +87,6 @@
 		"plans/personal-plan": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
-		"post-editor/insert-menu": true,
 		"post-editor/mentions": true,
 		"press-this": true,
 		"preview-layout": true,


### PR DESCRIPTION
This is a follow-up PR from #12440 - the `post-editor/insert-menu` config is currently enabled in all environments, except desktop - but it _should_ be enabled there too 😲 !  So this PR removes the old config values, and all usage of the config values since it should be live in all the EVNs.

/cc @Copons 

__To Test__
Open the editor and note the insert menu is still there.  