### PR TITLE
Editor: Fix featured image bug during copy post

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -28,6 +28,7 @@ import { getEditorPostId, getEditorPath } from 'state/ui/editor/selectors';
 import { editPost } from 'state/posts/actions';
 import wpcom from 'lib/wp';
 import Dispatcher from 'dispatcher';
+import { getFeaturedImageId } from 'lib/posts/utils';
 
 function getPostID( context ) {
 	if ( ! context.params.post || 'new' === context.params.post ) {
@@ -132,6 +133,7 @@ function startEditingPostCopy( siteId, postToCopyId, context ) {
 		);
 		postAttributes.tags = map( postToCopy.tags, 'name' );
 		postAttributes.title = decodeEntities( postAttributes.title );
+		postAttributes.featured_image = getFeaturedImageId( postToCopy );
 
 		actions.startEditingNew( siteId, {
 			content: postToCopy.content,

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -1,25 +1,25 @@
 /**
  * External dependencies
  */
-var ReactDom = require( 'react-dom' ),
-	ReactDomServer = require( 'react-dom/server' ),
-	React = require( 'react' ),
-	i18n = require( 'i18n-calypso' ),
-	page = require( 'page' ),
-	ReduxProvider = require( 'react-redux' ).Provider,
-	qs = require( 'querystring' ),
-	isValidUrl = require( 'valid-url' ).isWebUri;
+import ReactDom from 'react-dom';
+import ReactDomServer from 'react-dom/server';
+import React from 'react';
+import i18n from 'i18n-calypso';
+import page from 'page';
+import { Provider as ReduxProvider } from 'react-redux';
+import qs from 'querystring';
+import { isWebUri as isValidUrl } from 'valid-url';
 import { map, pick, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
  */
-var actions = require( 'lib/posts/actions' ),
-	route = require( 'lib/route' ),
-	sites = require( 'lib/sites-list' )(),
-	user = require( 'lib/user' )(),
-	userUtils = require( 'lib/user/utils' ),
-	analytics = require( 'lib/analytics' );
+import actions from 'lib/posts/actions';
+import route from 'lib/route';
+import SitesList from 'lib/sites-list';
+import User from 'lib/user';
+import userUtils from 'lib/user/utils';
+import analytics from 'lib/analytics';
 import { decodeEntities } from 'lib/formatting';
 import PostEditor from './post-editor';
 import { startEditingPost, stopEditingPost } from 'state/ui/editor/actions';
@@ -29,6 +29,9 @@ import { editPost } from 'state/posts/actions';
 import wpcom from 'lib/wp';
 import Dispatcher from 'dispatcher';
 import { getFeaturedImageId } from 'lib/posts/utils';
+
+const sites = SitesList();
+const user = User();
 
 function getPostID( context ) {
 	if ( ! context.params.post || 'new' === context.params.post ) {
@@ -183,7 +186,7 @@ module.exports = {
 				actions.startEditingExisting( siteId, postID );
 				analytics.pageView.record( '/' + postType + '/:blogid/:postid', gaTitle + ' > Edit' );
 			} else {
-				let postOptions = { type: postType };
+				const postOptions = { type: postType };
 
 				// handle press-this params if applicable
 				if ( context.query.url ) {


### PR DESCRIPTION
This PR fixes a bug that prevented the featured image to be reliably copied when copying a post.

The logic involved here is that when _retrieved_, `featured_image` is the image URL, but when _saved_ it's the image media ID.
So, previously the `featured_image` attribute was simply taken as-is from the copied post and saved into the new one; now instead it's replaced by the ID of the image.

Additionally: I've fixed all the ESLint errors in `post-editor/controller.js` with the sole exception of `no-restricted-modules` on the `sites-list` import as I'm not sure if we have a system in place to replace it.