### PR TITLE
Themes: Improve error message for large theme upload

### DIFF
--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -133,13 +133,13 @@ class Upload extends React.Component {
 		const errorCauses = {
 			exists: translate( 'Upload problem: Theme already installed on site.' ),
 			already_installed: translate( 'Upload problem: Theme already installed on site.' ),
-			'Too Large': translate( 'Upload problem: Zip file too large to upload.' ),
+			'too large': translate( 'Upload problem: Zip file too large to upload.' ),
 			incompatible: translate( 'Upload problem: Incompatible theme.' ),
 			unsupported_mime_type: translate( 'Upload problem: Not a valid zip file' ),
 			initiate_failure: translate( 'Upload problem: Theme may not be valid' ),
 		};
 
-		const errorString = JSON.stringify( error );
+		const errorString = JSON.stringify( error ).toLowerCase();
 		const cause = find( errorCauses, ( v, key ) => {
 			return includes( errorString, key );
 		} );


### PR DESCRIPTION
Match error return from wpcom server when zip is too large to upload.
<img width="547" alt="screen shot 2017-03-24 at 15 53 50" src="https://cloud.githubusercontent.com/assets/7767559/24302337/2fccc388-10aa-11e7-966c-8997c89b2126.png">

**To Test**
* Go to http://calypso.localhost:3000/design/upload/{jetpack site]
* Upload a theme zip > 10MB

