### PR TITLE
Fix/commit from guis

### DIFF
--- a/server/config/validate-config-keys.js
+++ b/server/config/validate-config-keys.js
@@ -46,7 +46,9 @@ const sharedConfig = parseConfig( '_shared.json' );
  * invalid. Such a missing value could and likely would
  * cause runtime errors in Calypso
  */
-environmentKeys.forEach( ( [ filename, keys ] ) => {
+environmentKeys.forEach( ( envKey ) => {
+	const filename = envKey[ 0 ];
+	const keys = envKey[ 1 ];
 	keys.forEach( key => {
 		if ( ! sharedConfig.hasOwnProperty( key ) ) {
 			console.error(


### PR DESCRIPTION
This PR addresses an issue with `validate-config-keys.js` script invoked by git during the commit process if the developer uses a GUI for that purpose.

Problem: unless the git GUI application is started from the Calypso path in the console (so it uses `nvm` to determine the node version), we can't be sure that the GUI node version is the same as Calypso.

By not using array destructuring in scripts run by `git` we are being friendlier to more setups and developers.

## How to test

I'm using Atom and git-plus for this testing, but I believe any git GUI that runs into this problem will suffice.

- Modify any source and add it to the git index.
- Try to commit from a git GUI.

Without the patch, I've got:

![git-gui-fail](https://cloud.githubusercontent.com/assets/583546/26819024/4f67756c-4a9d-11e7-8116-4107715109b6.png)

With the patch, I've got:

![git-gui-success](https://cloud.githubusercontent.com/assets/583546/26819028/579a1186-4a9d-11e7-9c3e-a3aa6f7e1172.png)
