### PR TITLE
Plans: Always use included domain on plan features

### DIFF
--- a/client/blocks/product-purchase-features/product-purchase-features-list/custom-domain.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/custom-domain.jsx
@@ -12,7 +12,7 @@ import CustomDomainPurchaseDetail from 'my-sites/upgrades/checkout-thank-you/cus
 export default ( props ) => {
 	return (
 		<div className="product-purchase-features-list__item">
-			<CustomDomainPurchaseDetail { ...pick( props, [ 'selectedSite', 'hasDomainCredit' ] ) } />
+			<CustomDomainPurchaseDetail { ...pick( props, [ 'selectedSite', 'hasDomainCredit', 'includedDomainPurchase' ] ) } />
 		</div>
 	);
 };

--- a/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
@@ -66,12 +66,14 @@ class ProductPurchaseFeaturesList extends Component {
 		const {
 			selectedSite,
 			planHasDomainCredit,
+			includedDomainPurchase,
 		} = this.props;
 
 		return [
 			<CustomDomain
 				selectedSite={ selectedSite }
 				hasDomainCredit={ planHasDomainCredit }
+				includedDomainPurchase={ includedDomainPurchase }
 				key="customDomainFeature"
 			/>,
 			<AdvertisingRemoved

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -4,6 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import find from 'lodash/find';
 
 /**
  * Internal Dependencies
@@ -24,6 +25,7 @@ import ProductPurchaseFeaturesList from 'blocks/product-purchase-features/produc
 import CurrentPlanHeader from './header';
 import QuerySites from 'components/data/query-sites';
 import QuerySitePlans from 'components/data/query-site-plans';
+import QuerySitePurchases from 'components/data/query-site-purchases';
 import { PLAN_BUSINESS } from 'lib/plans/constants';
 import { getPlan } from 'lib/plans';
 import QuerySiteDomains from 'components/data/query-site-domains';
@@ -31,6 +33,8 @@ import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
 import DomainWarnings from 'my-sites/upgrades/components/domain-warnings';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import { getSitePurchases, getIncludedDomainPurchase } from 'state/purchases/selectors';
+import { isPlan } from 'lib/products-values';
 
 class CurrentPlan extends Component {
 	static propTypes = {
@@ -41,6 +45,7 @@ class CurrentPlan extends Component {
 		domains: PropTypes.array,
 		currentPlan: PropTypes.object,
 		isExpiring: PropTypes.bool,
+		includedDomainPurchase: PropTypes.object,
 		shouldShowDomainWarnings: PropTypes.bool,
 		hasDomainsLoaded: PropTypes.bool,
 		isAutomatedTransfer: PropTypes.bool,
@@ -83,6 +88,7 @@ class CurrentPlan extends Component {
 			context,
 			currentPlan,
 			isExpiring,
+			includedDomainPurchase = null,
 			shouldShowDomainWarnings,
 			hasDomainsLoaded,
 			translate,
@@ -103,6 +109,7 @@ class CurrentPlan extends Component {
 				<DocumentHead title={ translate( 'Plans', { textOnly: true } ) } />
 				<QuerySites siteId={ selectedSiteId } />
 				<QuerySitePlans siteId={ selectedSiteId } />
+				<QuerySitePurchases siteId={ selectedSiteId } />
 				{ shouldQuerySiteDomains && <QuerySiteDomains siteId={ selectedSiteId } /> }
 
 				<PlansNavigation
@@ -137,6 +144,7 @@ class CurrentPlan extends Component {
 					<ProductPurchaseFeaturesList
 						plan={ currentPlanSlug }
 						isPlaceholder={ isLoading }
+						includedDomainPurchase={ includedDomainPurchase }
 					/>
 				</ProductPurchaseFeatures>
 
@@ -154,12 +162,16 @@ export default connect(
 
 		const isWpcom = ! isJetpackSite( state, selectedSiteId );
 		const isAutomatedTransfer = isSiteAutomatedTransfer( state, selectedSiteId );
+		const sitePurchases = getSitePurchases( state, selectedSiteId );
+		const sitePlanPurchase = find( sitePurchases, purchase => ( isPlan( purchase ) ) );
+		const includedDomainPurchase = getIncludedDomainPurchase( state, sitePlanPurchase );
 
 		return {
 			selectedSite,
 			selectedSiteId,
 			domains,
 			isAutomatedTransfer,
+			includedDomainPurchase,
 			context: ownProps.context,
 			currentPlan: getCurrentPlan( state, selectedSiteId ),
 			isExpiring: isCurrentPlanExpiring( state, selectedSiteId ),

--- a/client/my-sites/upgrades/checkout-thank-you/custom-domain-purchase-detail.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/custom-domain-purchase-detail.jsx
@@ -8,9 +8,8 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import PurchaseDetail from 'components/purchase-detail';
-import { hasCustomDomain } from 'lib/site/utils';
 
-const CustomDomainPurchaseDetail = ( { selectedSite, hasDomainCredit, translate } ) => {
+const CustomDomainPurchaseDetail = ( { selectedSite, hasDomainCredit, includedDomainPurchase, translate } ) => {
 	if ( hasDomainCredit && selectedSite.plan.user_is_owner ) {
 		return ( <PurchaseDetail
 				icon="globe"
@@ -29,7 +28,7 @@ const CustomDomainPurchaseDetail = ( { selectedSite, hasDomainCredit, translate 
 				href={ `/domains/add/${ selectedSite.slug }` }
 			/>
 		);
-	} else if ( ! hasDomainCredit && hasCustomDomain( selectedSite ) ) {
+	} else if ( ! hasDomainCredit && includedDomainPurchase ) {
 		const actionButton = {};
 		actionButton.buttonText = translate( 'Manage my domains' );
 		actionButton.href = `/domains/manage/${ selectedSite.slug }`;
@@ -38,7 +37,7 @@ const CustomDomainPurchaseDetail = ( { selectedSite, hasDomainCredit, translate 
 			title={ translate( 'Custom Domain' ) }
 			description={ translate(
 				'Your plan includes the custom domain {{em}}%(siteDomain)s{{/em}}, your own personal corner of the web.', {
-					args: { siteDomain: selectedSite.domain },
+					args: { siteDomain: includedDomainPurchase.meta },
 					components: { em: <em /> }
 				}
 			) }
@@ -54,7 +53,8 @@ CustomDomainPurchaseDetail.propTypes = {
 		React.PropTypes.bool,
 		React.PropTypes.object
 	] ).isRequired,
-	hasDomainCredit: React.PropTypes.bool
+	hasDomainCredit: React.PropTypes.bool,
+	includedDomainPurchase: React.PropTypes.object,
 };
 
 export default localize( CustomDomainPurchaseDetail );


### PR DESCRIPTION
This branch is meant to address #9990. If you have registered or mapped a domain as part of a plan on your site, we should always display that domain on the plan features page even if you have another domain or a default .wordpress.com domain set as the primary domain.

The tricky piece to this is that from what I can tell we need to use the [purchase object](https://github.com/Automattic/wp-calypso/blob/master/client/lib/purchases/assembler.js#L27) to get the included domain on a given plan. The current approach does a few things:

- Queries the site purchases (Is this too expensive for this simple fix?)
- Fetches the site purchases with `getSitePurchases`
- Searches through `sitePurchases` to find the plan purchase
- Find the included domain using `getIncludedDomainPurchase` and the site plan purchase

## To test
This is meant to impact http://calypso.localhost:3000/plans/my-plan/{ site }. Load up this branch, and then check the following scenarios:

- Site with plan and included domain but primary domain set to default .wordpress.com address. 
- Site with plan and included domain but primary domain set to other custom domain. 
- Site with plan and included domain set as primary. 

In all cases, the included domain should appear in the "Custom Domain" feature box.

If you have a domain credit, you should still see the "Select your custom domain" option to replace your default domain.

## Screenshots
This is a site I have setup with the Business plan. I had another domain set as the primary domain at the time. It still showed the domain included with my plan.

<img width="555" alt="screen shot 2017-03-24 at 10 06 52 am" src="https://cloud.githubusercontent.com/assets/7240478/24304771/37be72be-1080-11e7-8469-945d9b4e2fa7.png">