### PR TITLE
Bump eslines version

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1292,7 +1292,7 @@
       "dev": true
     },
     "eslines": {
-      "version": "0.0.11",
+      "version": "0.0.12",
       "dev": true
     },
     "eslint": {
@@ -2479,10 +2479,10 @@
       "version": "1.3.4"
     },
     "mime-db": {
-      "version": "1.26.0"
+      "version": "1.27.0"
     },
     "mime-types": {
-      "version": "2.1.14"
+      "version": "2.1.15"
     },
     "minimatch": {
       "version": "2.0.10"

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "esformatter-quotes": "1.0.3",
     "esformatter-semicolons": "1.1.1",
     "esformatter-special-bangs": "1.0.1",
-    "eslines": "0.0.11",
+    "eslines": "0.0.12",
     "eslint": "3.8.1",
     "eslint-config-wpcalypso": "0.6.0",
     "eslint-plugin-react": "6.4.1",


### PR DESCRIPTION
It forces strict-mode in some file, so we can use block-scoped constructs such as `let`.