### PR TITLE
Reader: fix blocking sites

### DIFF
--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -495,6 +495,7 @@ class ReaderStream extends React.Component {
 			showSiteName={ this.props.showSiteNameOnCards }
 			cardClassForPost={ this.cardClassForPost }
 			followSource={ this.props.followSource }
+			blockedSites={ this.props.blockedSites }
 		/>;
 	}
 


### PR DESCRIPTION
Currently when you attempt to block a site, the site will get blocked but the card does not rerender.
Bad UX.  It is caused by a faulty `shouldComponentUpdate` that assumes props would change when a card gets blocked.

This PR passes in blockedSites to post-lifecycle just so that it knows 'something changed' and will rerender.

Fixes https://github.com/Automattic/wp-calypso/issues/12501.