### PR TITLE
VSCode jsconfig: exclude node_modules, build, and public from intellisense

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -7,5 +7,10 @@
 		"paths": {
 			"*": [ "test/*", "server/*", "client/*" ]
 		}
-	}
+	},
+	"exclude": [
+		"node_modules",
+		"public",
+		"build"
+	]
 }


### PR DESCRIPTION
Currently we get a warning at the bottom right of VS Code saying to configure excludes.

<img width="1440" alt="screen shot 2017-03-24 at 1 19 08 pm" src="https://cloud.githubusercontent.com/assets/4656974/24305754/7cd6f3da-1094-11e7-9b06-408629f93ec7.png">
