### PR TITLE
Remove/disconnect from batch edit plugins

### DIFF
--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -233,25 +233,22 @@ export default React.createClass( {
 					{ this.translate( 'Activate' ) }
 				</Button>
 			);
-			const deactivateButton = isJetpackSelected
-				? (
-					<Button compact
-						key="plugin-list-header__buttons-deactivate"
-						disabled={ ! this.props.haveActiveSelected }
-						onClick={ this.props.deactiveAndDisconnectSelected }>
-						{ this.translate( 'Disconnect' ) }
-					</Button>
-				)
-				: (
-					<Button compact
-						key="plugin-list-header__buttons-disable"
-						disabled={ ! this.props.haveActiveSelected }
-						onClick={ this.props.deactivateSelected }>
-						{ this.translate( 'Deactivate' ) }
-					</Button>
-				);
-			activateButtons.push( deactivateButton );
-			leftSideButtons.push( <ButtonGroup key="plugin-list-header__buttons-activate-buttons">{ activateButtons }</ButtonGroup> );
+
+			activateButtons.push(
+				<Button compact
+					key="plugin-list-header__buttons-deactivate"
+					disabled={ ! this.props.haveActiveSelected }
+					onClick={ isJetpackSelected
+						? this.props.deactiveAndDisconnectSelected
+						: this.props.deactivateSelected
+						} >
+					{ this.translate( 'Deactivate' ) }
+				</Button>
+			);
+
+			if ( ! ( isJetpackSelected && this.props.selected.length === 1 ) ) {
+				leftSideButtons.push( <ButtonGroup key="plugin-list-header__buttons-activate-buttons">{ activateButtons }</ButtonGroup> );
+			}
 
 			autoupdateButtons.push(
 				<Button key="plugin-list-header__buttons-autoupdate-on"
@@ -302,9 +299,9 @@ export default React.createClass( {
 			return null;
 		}
 
-		const isJetpackSelected = this.props.selected.some( plugin => 'jetpack' === plugin.slug ),
-			needsRemoveButton = !! this.props.selected.length && this.canUpdatePlugins() && ! isJetpackSelected;
-
+		const isJetpackSelected = this.props.selected.some( plugin => 'jetpack' === plugin.slug );
+		const needsRemoveButton = !! this.props.selected.length && this.canUpdatePlugins() && ! isJetpackSelected;
+		const isJetpackOnlySelected = ! ( isJetpackSelected && this.props.selected.length === 1 );
 		return (
 			<SelectDropdown compact
 					className="plugin-list-header__actions_dropdown"
@@ -324,22 +321,19 @@ export default React.createClass( {
 				</DropdownItem>
 
 				<DropdownSeparator key="plugin__actions_separator_1" />
-
-				<DropdownItem key="plugin__actions_activate"
-						disabled={ ! this.props.haveInactiveSelected }
-						onClick={ this.props.activateSelected }>
-					{ this.translate( 'Activate' ) }
-				</DropdownItem>
-
-				{ isJetpackSelected
-					? <DropdownItem key="plugin__actions_disconnect"
-							disabled={ ! this.props.haveActiveSelected }
-							onClick={ this.props.deactiveAndDisconnectSelected }>
-						{ this.translate( 'Disconnect' ) }
+				{ isJetpackOnlySelected &&
+					<DropdownItem key="plugin__actions_activate"
+							disabled={ ! this.props.haveInactiveSelected }
+							onClick={ this.props.activateSelected }>
+						{ this.translate( 'Activate' ) }
 					</DropdownItem>
-					: <DropdownItem key="plugin__actions_deactivate"
+				}
+				{ isJetpackOnlySelected &&
+					<DropdownItem key="plugin__actions_disconnect"
 							disabled={ ! this.props.haveActiveSelected }
-							onClick={ this.props.deactivateSelected }>
+							onClick={ isJetpackSelected
+								? this.props.deactiveAndDisconnectSelected
+								: this.props.deactivateSelected }>
 						{ this.translate( 'Deactivate' ) }
 					</DropdownItem>
 				}

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -65,7 +65,8 @@ export default React.createClass( {
 	},
 
 	shouldComponentUpdate( nextProps, nextState ) {
-		const propsToCheck = [ 'label', 'isBulkManagementActive', 'haveUpdatesSelected', 'pluginUpdateCount', 'haveActiveSelected', 'haveInactiveSelected', 'bulkManagement' ];
+		const propsToCheck = [ 'label', 'isBulkManagementActive', 'haveUpdatesSelected',
+				'pluginUpdateCount', 'haveActiveSelected', 'haveInactiveSelected', 'bulkManagement' ];
 		if ( checkPropsChange.call( this, nextProps, propsToCheck ) ) {
 			return true;
 		}

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -255,11 +255,9 @@ export const PluginsList = React.createClass( {
 			PluginsActions.deactivatePlugin( site, plugin );
 		} );
 
-		if ( waitForDeactivate ) {
-			this.setState( { disconnectJetpackDialog: true } );
-		} else {
-			this.setState( { showJetpackDisconnectDialog: true } );
-			this.forceUpdate();
+		if ( waitForDeactivate && this.props.selectedSite ) {
+				this.setState( { disconnectJetpackDialog: true } );
+			}
 		}
 
 		this.recordEvent( 'Clicked Deactivate Plugin(s) and Disconnect Jetpack', true );

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -397,7 +397,7 @@ export const PluginsList = React.createClass( {
 			} );
 
 			this.props.warningNotice(
-				translate( 'Jetpack cannot be deactivated from WordPress.com. {{link}}Manage Connection{{/link}}', {
+				translate( 'Jetpack cannot be deactivated from WordPress.com. {{link}}Manage connection{{/link}}', {
 					components: {
 						link: <a href={ '/settings/general/' + this.props.selectedSiteSlug } />
 					}

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -12,7 +12,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import acceptDialog from 'lib/accept';
-import Dialog from 'components/dialog';
+import { infoNotice } from 'state/notices/actions';
 import PluginItem from 'my-sites/plugins/plugin-item/plugin-item';
 import PluginsActions from 'lib/plugins/actions';
 import PluginsListHeader from 'my-sites/plugins/plugin-list-header';
@@ -256,8 +256,7 @@ export const PluginsList = React.createClass( {
 		} );
 
 		if ( waitForDeactivate && this.props.selectedSite ) {
-				this.setState( { disconnectJetpackDialog: true } );
-			}
+			this.setState( { disconnectJetpackDialog: true } );
 		}
 
 		this.recordEvent( 'Clicked Deactivate Plugin(s) and Disconnect Jetpack', true );
@@ -390,9 +389,13 @@ export const PluginsList = React.createClass( {
 		if ( this.state.disconnectJetpackDialog && ! this.state.notices.inProgress.length ) {
 			this.setState( {
 				disconnectJetpackDialog: false,
-				showJetpackDisconnectDialog: true
 			} );
-			this.forceUpdate();
+
+			this.props.infoNotice( 'Disconnect Jetpack from WordPress.com', {
+				button: 'Manage Connection',
+				persistent: true,
+				href: '/settings/general/' + this.props.selectedSiteSlug
+			} );
 		}
 	},
 
@@ -430,18 +433,6 @@ export const PluginsList = React.createClass( {
 			return null;
 		}
 
-		const dialogButtons = [
-			{
-				action: 'cancel',
-				label: translate( 'Cancel' )
-			},
-			{
-				action: 'continue',
-				label: translate( 'Manage Connection' ),
-				isPrimary: true
-			}
-		];
-
 		return (
 			<div className="plugins-list" >
 				<PluginsListHeader label={ this.props.header }
@@ -464,15 +455,7 @@ export const PluginsList = React.createClass( {
 					haveInactiveSelected={ this.props.plugins.some( this.filterSelection.inactive.bind( this ) ) }
 					haveUpdatesSelected= { this.props.plugins.some( this.filterSelection.updates.bind( this ) ) } />
 				<div className={ itemListClasses }>{ this.props.plugins.map( this.renderPlugin ) }</div>
-				{ this.props.selectedSite &&
-					<Dialog
-						ref="dialog"
-						isVisible={ this.state.showJetpackDisconnectDialog }
-						buttons={ dialogButtons }
-						onClose={ this.closeDialog }>
-						<h1>{ translate( 'Disconnect Jetpack' ) }</h1>
-					</Dialog>
-				}
+
 			</div>
 		);
 	},
@@ -524,5 +507,8 @@ export default connect(
 			isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, get( selectedSite, 'ID' ) ),
 		};
 	},
-	{ recordGoogleEvent }
+	{
+		recordGoogleEvent,
+		infoNotice
+	}
 )( PluginsList );

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -397,7 +397,7 @@ export const PluginsList = React.createClass( {
 			} );
 
 			this.props.warningNotice(
-				translate( 'Jetpack cannot be deactivated from WordPress.com {{link}}Manage Connection{{/link}}', {
+				translate( 'Jetpack cannot be deactivated from WordPress.com. {{link}}Manage Connection{{/link}}', {
 					components: {
 						link: <a href={ '/settings/general/' + this.props.selectedSiteSlug } />
 					}

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -4,15 +4,15 @@
 import React, { PropTypes } from 'react';
 import page from 'page';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import { find, get, includes, isEmpty, isEqual, negate, range, reduce } from 'lodash';
-import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import acceptDialog from 'lib/accept';
-import { infoNotice } from 'state/notices/actions';
+import { warningNotice } from 'state/notices/actions';
 import PluginItem from 'my-sites/plugins/plugin-item/plugin-item';
 import PluginsActions from 'lib/plugins/actions';
 import PluginsListHeader from 'my-sites/plugins/plugin-list-header';
@@ -277,8 +277,9 @@ export const PluginsList = React.createClass( {
 			sitesList = {};
 		let pluginName,
 			siteName;
+		const { plugins, translate } = this.props;
 
-		this.props.plugins
+		plugins
 			.filter( this.isSelected )
 			.forEach( ( plugin ) => {
 				pluginsList[ plugin.slug ] = true;
@@ -364,6 +365,8 @@ export const PluginsList = React.createClass( {
 	},
 
 	removePluginDialog() {
+		const { translate } = this.props;
+
 		const message = (
 			<div>
 				<span>{ this.getConfirmationText() }</span>
@@ -386,16 +389,20 @@ export const PluginsList = React.createClass( {
 	},
 
 	showDisconnectDialog() {
+		const { translate } = this.props;
+
 		if ( this.state.disconnectJetpackDialog && ! this.state.notices.inProgress.length ) {
 			this.setState( {
 				disconnectJetpackDialog: false,
 			} );
 
-			this.props.infoNotice( 'Disconnect Jetpack from WordPress.com', {
-				button: 'Manage Connection',
-				persistent: true,
-				href: '/settings/general/' + this.props.selectedSiteSlug
-			} );
+			this.props.warningNotice(
+				translate( 'Jetpack cannot be deactivated from WordPress.com {{link}}Manage Connection{{/link}}', {
+					components: {
+						link: <a href={ '/settings/general/' + this.props.selectedSiteSlug } />
+					}
+				} )
+			);
 		}
 	},
 
@@ -509,6 +516,6 @@ export default connect(
 	},
 	{
 		recordGoogleEvent,
-		infoNotice
+		warningNotice
 	}
-)( PluginsList );
+)( localize( PluginsList ) );


### PR DESCRIPTION
This PR removes the ability to disconnect Jetpack when in plugin batch edit mode. 

Now we show a dialog with a button that takes the user to manage jetpack. 
The dialog box appears after the deactivation of all the other plugins is done. 

(updated)
<img width="899" alt="screen shot 2017-04-06 at 12 03 11" src="https://cloud.githubusercontent.com/assets/115071/24771071/157a2b62-1ac1-11e7-8574-fea7dbbbb45a.png">


If only Jetpack is selected then we do not show the activate and deactivate buttons at all. 
![screen shot 2017-03-24 at 12 36 55](https://cloud.githubusercontent.com/assets/115071/24310927/08f79ce4-108f-11e7-8f7f-88bd3ef4fef3.png)

Also we skip jetpack when we activate and deactivate plugins in batch mode. We don't show any indication that we are performing anything in Jetpack
