### PR TITLE
Add codemods: CommonJS -> ES2015 module

### DIFF
--- a/bin/codemods/commonjs-exports
+++ b/bin/codemods/commonjs-exports
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+/*
+	This codemod converts `module.exports` to `export` and `export default`.
+
+	How to use:
+	./bin/codemods/commonjs-exports path-to-transform/
+*/
+
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+const child_process = require( 'child_process' );
+
+/**
+ * Internal dependencies
+ */
+const config = require( './config' );
+const helpers = require( './helpers' );
+
+const args = process.argv.slice( 2 );
+if ( args.length === 0 ) {
+	process.stdout.write( 'No files to transform\n' );
+	process.exit( 0 );
+}
+
+const binArgs = [
+	// jscodeshift options
+	'--transform=node_modules/5to6-codemod/transforms/exports.js',
+	...config.jscodeshiftArgs,
+
+	// Recast options via 5to6
+	...config.recastArgs,
+
+	// Transform target
+	args[ 0 ],
+];
+const binPath = path.join( '.', 'node_modules', '.bin', 'jscodeshift' );
+const jscodeshift = child_process.spawn( binPath, binArgs );
+helpers.bindEvents( jscodeshift );

--- a/bin/codemods/commonjs-imports
+++ b/bin/codemods/commonjs-imports
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+/*
+	This codemod converts occurrences of `require( '...' )` to `import ... from '...'`
+	only if they occurr on the top level scope. CommonJS imports inside block statements,
+	like conditionals or function definitions, will not be converted.
+
+	How to use:
+	./bin/codemods/commonjs-imports path-to-transform/
+*/
+
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+const child_process = require( 'child_process' );
+
+/**
+ * Internal dependencies
+ */
+const config = require( './config' );
+const helpers = require( './helpers' );
+
+const args = process.argv.slice( 2 );
+if ( args.length === 0 ) {
+	process.stdout.write( 'No files to transform\n' );
+	process.exit( 0 );
+}
+
+const binArgs = [
+	// jscodeshift options
+	'--transform=node_modules/5to6-codemod/transforms/cjs.js',
+	...config.jscodeshiftArgs,
+
+	// Recast options via 5to6
+	...config.recastArgs,
+
+	// Transform target
+	args[ 0 ],
+];
+const binPath = path.join( '.', 'node_modules', '.bin', 'jscodeshift' );
+const jscodeshift = child_process.spawn( binPath, binArgs );
+helpers.bindEvents( jscodeshift );

--- a/bin/codemods/commonjs-imports-hoist
+++ b/bin/codemods/commonjs-imports-hoist
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+/*
+	This codemod hoists all occurrences of `require( '...' )` inside if, loop, and
+	function blocks. This can cause breakage! Use with caution.
+
+	How to use:
+	./bin/codemods/commonjs-imports path-to-transform/
+*/
+
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+const child_process = require( 'child_process' );
+
+/**
+ * Internal dependencies
+ */
+const config = require( './config' );
+const helpers = require( './helpers' );
+
+const args = process.argv.slice( 2 );
+if ( args.length === 0 ) {
+	process.stdout.write( 'No files to transform\n' );
+	process.exit( 0 );
+}
+
+const binArgs = [
+	// jscodeshift options
+	'--transform=node_modules/5to6-codemod/transforms/cjs.js',
+	...config.jscodeshiftArgs,
+
+	// Recast options via 5to6
+	...config.recastArgs,
+
+	// 5to6 transform options
+	'--hoist=true',
+
+	// Transform target
+	args[ 0 ],
+];
+const binPath = path.join( '.', 'node_modules', '.bin', 'jscodeshift' );
+const jscodeshift = child_process.spawn( binPath, binArgs );
+helpers.bindEvents( jscodeshift );

--- a/bin/codemods/config.js
+++ b/bin/codemods/config.js
@@ -1,0 +1,14 @@
+const jscodeshiftArgs = [
+	'--extensions=js,jsx',
+];
+
+// Used primarily by 5to6-codemod transformations
+const recastArgs = [
+	'--useTabs=true',
+	'--arrayBracketSpacing=true',
+];
+
+module.exports = {
+	jscodeshiftArgs,
+	recastArgs,
+};

--- a/bin/codemods/helpers.js
+++ b/bin/codemods/helpers.js
@@ -1,0 +1,13 @@
+function bindEvents( jscodeshiftProcess ) {
+	jscodeshiftProcess.stdout.on( 'data', ( data ) => {
+		process.stdout.write( data );
+	} );
+
+	jscodeshiftProcess.stderr.on( 'data', ( data ) => {
+		process.stderr.write( data );
+	} );
+}
+
+module.exports = {
+	bindEvents,
+};

--- a/bin/codemods/named-exports-from-default
+++ b/bin/codemods/named-exports-from-default
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+/*
+	This codemod generates named exports given a `default export { ... }`.
+	This can be useful in transitioning away from namespace imports
+	(`import * as blah from 'blah'`) to named imports (`import named from 'blah'`).
+
+	How to use:
+	./bin/codemods/named-export-from-default path-to-transform/
+*/
+
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+const child_process = require( 'child_process' );
+
+/**
+ * Internal dependencies
+ */
+const config = require( './config' );
+const helpers = require( './helpers' );
+
+const args = process.argv.slice( 2 );
+if ( args.length === 0 ) {
+	process.stdout.write( 'No files to transform\n' );
+	process.exit( 0 );
+}
+
+const binArgs = [
+	// jscodeshift options
+	'--transform=node_modules/5to6-codemod/transforms/named-export-generation.js',
+	...config.jscodeshiftArgs,
+
+	// Recast options via 5to6
+	...config.recastArgs,
+
+	// Transform target
+	args[ 0 ],
+];
+const binPath = path.join( '.', 'node_modules', '.bin', 'jscodeshift' );
+const jscodeshift = child_process.spawn( binPath, binArgs );
+helpers.bindEvents( jscodeshift );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,6 +2,30 @@
   "name": "wp-calypso",
   "version": "0.17.0",
   "dependencies": {
+    "5to6-codemod": {
+      "version": "1.8.0",
+      "from": "git://github.com/jsnmoon/5to6-codemod.git#34b2248a93cd491f4a7cd70249c8d5b56304d2c8",
+      "resolved": "git://github.com/jsnmoon/5to6-codemod.git#34b2248a93cd491f4a7cd70249c8d5b56304d2c8",
+      "dev": true,
+      "dependencies": {
+        "ast-types": {
+          "version": "0.9.11",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "dev": true
+        },
+        "recast": {
+          "version": "0.12.3",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "dev": true
+        }
+      }
+    },
     "abab": {
       "version": "1.0.3",
       "dev": true
@@ -34,7 +58,7 @@
       "version": "0.8.1"
     },
     "ajv": {
-      "version": "4.11.5"
+      "version": "4.11.7"
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -42,6 +66,10 @@
     },
     "align-text": {
       "version": "0.1.4"
+    },
+    "alter": {
+      "version": "0.2.0",
+      "dev": true
     },
     "amdefine": {
       "version": "1.0.1"
@@ -73,7 +101,7 @@
       "version": "2.0.0"
     },
     "arr-flatten": {
-      "version": "1.0.1"
+      "version": "1.0.3"
     },
     "array-differ": {
       "version": "1.0.0",
@@ -118,6 +146,10 @@
     },
     "assertion-error": {
       "version": "1.0.2",
+      "dev": true
+    },
+    "ast-traverse": {
+      "version": "0.1.1",
       "dev": true
     },
     "ast-types": {
@@ -171,51 +203,59 @@
       "dev": true
     },
     "babel-generator": {
-      "version": "6.24.0",
+      "version": "6.24.1",
       "dependencies": {
         "source-map": {
           "version": "0.5.6"
         }
       }
     },
+    "babel-helper-bindify-decorators": {
+      "version": "6.24.1",
+      "dev": true
+    },
     "babel-helper-builder-binary-assignment-operator-visitor": {
-      "version": "6.22.0"
+      "version": "6.24.1"
     },
     "babel-helper-builder-react-jsx": {
-      "version": "6.23.0"
+      "version": "6.24.1"
     },
     "babel-helper-call-delegate": {
-      "version": "6.22.0"
+      "version": "6.24.1"
     },
     "babel-helper-define-map": {
-      "version": "6.23.0"
+      "version": "6.24.1"
     },
     "babel-helper-explode-assignable-expression": {
-      "version": "6.22.0"
+      "version": "6.24.1"
+    },
+    "babel-helper-explode-class": {
+      "version": "6.24.1",
+      "dev": true
     },
     "babel-helper-function-name": {
-      "version": "6.23.0"
+      "version": "6.24.1"
     },
     "babel-helper-get-function-arity": {
-      "version": "6.22.0"
+      "version": "6.24.1"
     },
     "babel-helper-hoist-variables": {
-      "version": "6.22.0"
+      "version": "6.24.1"
     },
     "babel-helper-optimise-call-expression": {
-      "version": "6.23.0"
+      "version": "6.24.1"
     },
     "babel-helper-regex": {
-      "version": "6.22.0"
+      "version": "6.24.1"
     },
     "babel-helper-remap-async-to-generator": {
-      "version": "6.22.0"
+      "version": "6.24.1"
     },
     "babel-helper-replace-supers": {
-      "version": "6.23.0"
+      "version": "6.24.1"
     },
     "babel-helpers": {
-      "version": "6.23.0"
+      "version": "6.24.1"
     },
     "babel-loader": {
       "version": "6.2.4"
@@ -229,8 +269,66 @@
     "babel-plugin-check-es2015-constants": {
       "version": "6.22.0"
     },
+    "babel-plugin-constant-folding": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "babel-plugin-dead-code-elimination": {
+      "version": "1.0.2",
+      "dev": true
+    },
+    "babel-plugin-eval": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "babel-plugin-inline-environment-variables": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "babel-plugin-jscript": {
+      "version": "1.0.4",
+      "dev": true
+    },
     "babel-plugin-lodash": {
       "version": "3.2.0"
+    },
+    "babel-plugin-member-expression-literals": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "babel-plugin-property-literals": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "babel-plugin-proto-to-assign": {
+      "version": "1.0.4",
+      "dev": true,
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "dev": true
+        }
+      }
+    },
+    "babel-plugin-react-constant-elements": {
+      "version": "1.0.3",
+      "dev": true
+    },
+    "babel-plugin-react-display-name": {
+      "version": "1.0.3",
+      "dev": true
+    },
+    "babel-plugin-remove-console": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "babel-plugin-remove-debugger": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "babel-plugin-runtime": {
+      "version": "1.0.7",
+      "dev": true
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0"
@@ -238,14 +336,30 @@
     "babel-plugin-syntax-async-generators": {
       "version": "6.13.0"
     },
+    "babel-plugin-syntax-class-constructor-call": {
+      "version": "6.18.0",
+      "dev": true
+    },
     "babel-plugin-syntax-class-properties": {
       "version": "6.13.0"
+    },
+    "babel-plugin-syntax-decorators": {
+      "version": "6.13.0",
+      "dev": true
+    },
+    "babel-plugin-syntax-dynamic-import": {
+      "version": "6.18.0",
+      "dev": true
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0"
     },
     "babel-plugin-syntax-export-extensions": {
       "version": "6.13.0"
+    },
+    "babel-plugin-syntax-flow": {
+      "version": "6.18.0",
+      "dev": true
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.8.0"
@@ -257,13 +371,21 @@
       "version": "6.22.0"
     },
     "babel-plugin-transform-async-generator-functions": {
-      "version": "6.22.0"
+      "version": "6.24.1"
     },
     "babel-plugin-transform-async-to-generator": {
-      "version": "6.22.0"
+      "version": "6.24.1"
+    },
+    "babel-plugin-transform-class-constructor-call": {
+      "version": "6.24.1",
+      "dev": true
     },
     "babel-plugin-transform-class-properties": {
       "version": "6.9.1"
+    },
+    "babel-plugin-transform-decorators": {
+      "version": "6.24.1",
+      "dev": true
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0"
@@ -272,46 +394,46 @@
       "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.23.0"
+      "version": "6.24.1"
     },
     "babel-plugin-transform-es2015-classes": {
-      "version": "6.23.0"
+      "version": "6.24.1"
     },
     "babel-plugin-transform-es2015-computed-properties": {
-      "version": "6.22.0"
+      "version": "6.24.1"
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "6.23.0"
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
-      "version": "6.22.0"
+      "version": "6.24.1"
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.23.0"
     },
     "babel-plugin-transform-es2015-function-name": {
-      "version": "6.22.0"
+      "version": "6.24.1"
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.24.0"
+      "version": "6.24.1"
     },
     "babel-plugin-transform-es2015-object-super": {
-      "version": "6.22.0"
+      "version": "6.24.1"
     },
     "babel-plugin-transform-es2015-parameters": {
-      "version": "6.23.0"
+      "version": "6.24.1"
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
-      "version": "6.22.0"
+      "version": "6.24.1"
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-sticky-regex": {
-      "version": "6.22.0"
+      "version": "6.24.1"
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "6.22.0"
@@ -320,13 +442,17 @@
       "version": "6.23.0"
     },
     "babel-plugin-transform-es2015-unicode-regex": {
-      "version": "6.22.0"
+      "version": "6.24.1"
     },
     "babel-plugin-transform-exponentiation-operator": {
-      "version": "6.22.0"
+      "version": "6.24.1"
     },
     "babel-plugin-transform-export-extensions": {
       "version": "6.8.0"
+    },
+    "babel-plugin-transform-flow-strip-types": {
+      "version": "6.22.0",
+      "dev": true
     },
     "babel-plugin-transform-imports": {
       "version": "1.1.0"
@@ -341,22 +467,48 @@
       "version": "6.8.0"
     },
     "babel-plugin-transform-regenerator": {
-      "version": "6.22.0"
+      "version": "6.24.1"
     },
     "babel-plugin-transform-runtime": {
       "version": "6.9.0"
     },
     "babel-plugin-transform-strict-mode": {
-      "version": "6.22.0"
+      "version": "6.24.1"
+    },
+    "babel-plugin-undeclared-variables-check": {
+      "version": "1.0.2",
+      "dev": true
+    },
+    "babel-plugin-undefined-to-void": {
+      "version": "1.1.6",
+      "dev": true
     },
     "babel-preset-es2015": {
       "version": "6.9.0"
+    },
+    "babel-preset-stage-1": {
+      "version": "6.24.1",
+      "dev": true,
+      "dependencies": {
+        "babel-plugin-transform-class-properties": {
+          "version": "6.24.1",
+          "dev": true
+        },
+        "babel-plugin-transform-export-extensions": {
+          "version": "6.22.0",
+          "dev": true
+        },
+        "babel-preset-stage-2": {
+          "version": "6.24.1",
+          "dev": true
+        }
+      }
     },
     "babel-preset-stage-2": {
       "version": "6.5.0"
     },
     "babel-preset-stage-3": {
-      "version": "6.22.0"
+      "version": "6.24.1"
     },
     "babel-register": {
       "version": "6.9.0",
@@ -373,13 +525,13 @@
       "version": "6.23.0"
     },
     "babel-template": {
-      "version": "6.23.0"
+      "version": "6.24.1"
     },
     "babel-traverse": {
-      "version": "6.23.1"
+      "version": "6.24.1"
     },
     "babel-types": {
-      "version": "6.23.0"
+      "version": "6.24.1"
     },
     "babylon": {
       "version": "6.16.1"
@@ -432,7 +584,10 @@
       "version": "1.2.0",
       "dependencies": {
         "readable-stream": {
-          "version": "2.2.6"
+          "version": "2.2.9"
+        },
+        "string_decoder": {
+          "version": "1.0.0"
         }
       }
     },
@@ -474,10 +629,14 @@
       "version": "1.0.5"
     },
     "brace-expansion": {
-      "version": "1.1.6"
+      "version": "1.1.7"
     },
     "braces": {
       "version": "1.8.5"
+    },
+    "breakable": {
+      "version": "1.0.0",
+      "dev": true
     },
     "browser-filesaver": {
       "version": "1.1.0"
@@ -533,7 +692,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000649"
+      "version": "1.0.30000655"
     },
     "caseless": {
       "version": "0.12.0"
@@ -677,6 +836,24 @@
     },
     "commander": {
       "version": "2.3.0"
+    },
+    "commoner": {
+      "version": "0.10.8",
+      "dev": true,
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "dev": true
+        },
+        "glob": {
+          "version": "5.0.15",
+          "dev": true
+        },
+        "q": {
+          "version": "1.5.0",
+          "dev": true
+        }
+      }
     },
     "component-bind": {
       "version": "1.0.0"
@@ -917,6 +1094,28 @@
       "version": "1.1.2",
       "dev": true
     },
+    "defined": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "defs": {
+      "version": "1.1.1",
+      "dev": true,
+      "dependencies": {
+        "esprima-fb": {
+          "version": "15001.1001.0-dev-harmony-fb",
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.1.4",
+          "dev": true
+        },
+        "yargs": {
+          "version": "3.27.0",
+          "dev": true
+        }
+      }
+    },
     "del": {
       "version": "2.2.2",
       "dev": true,
@@ -944,6 +1143,16 @@
     },
     "detect-indent": {
       "version": "4.0.0"
+    },
+    "detective": {
+      "version": "4.5.0",
+      "dev": true,
+      "dependencies": {
+        "acorn": {
+          "version": "4.0.11",
+          "dev": true
+        }
+      }
     },
     "diff": {
       "version": "1.4.0",
@@ -1025,7 +1234,11 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.6",
+          "version": "2.2.9",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.0",
           "dev": true
         }
       }
@@ -1162,6 +1375,10 @@
     },
     "es6-map": {
       "version": "0.1.5",
+      "dev": true
+    },
+    "es6-promise": {
+      "version": "3.3.1",
       "dev": true
     },
     "es6-set": {
@@ -1560,6 +1777,10 @@
       "version": "1.0.2",
       "dev": true
     },
+    "flow-parser": {
+      "version": "0.44.0",
+      "dev": true
+    },
     "flux": {
       "version": "2.1.1",
       "dependencies": {
@@ -1590,7 +1811,7 @@
       "version": "0.6.1"
     },
     "form-data": {
-      "version": "2.1.2"
+      "version": "2.1.4"
     },
     "formatio": {
       "version": "1.1.1",
@@ -1607,6 +1828,10 @@
     },
     "fs-extra": {
       "version": "0.26.7"
+    },
+    "fs-readdir-recursive": {
+      "version": "0.1.2",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0"
@@ -1766,6 +1991,10 @@
         }
       }
     },
+    "has-color": {
+      "version": "0.1.7",
+      "dev": true
+    },
     "has-cors": {
       "version": "1.1.0"
     },
@@ -1791,7 +2020,7 @@
       "version": "1.0.0"
     },
     "hosted-git-info": {
-      "version": "2.4.1"
+      "version": "2.4.2"
     },
     "html": {
       "version": "1.0.0",
@@ -1877,7 +2106,7 @@
       "version": "1.1.8"
     },
     "ignore": {
-      "version": "3.2.6",
+      "version": "3.2.7",
       "dev": true
     },
     "immediate": {
@@ -2177,6 +2406,76 @@
       "version": "3.8.3",
       "dev": true
     },
+    "jscodeshift": {
+      "version": "0.3.30",
+      "dev": true,
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "dev": true
+        },
+        "babel-core": {
+          "version": "5.8.38",
+          "dev": true,
+          "dependencies": {
+            "babylon": {
+              "version": "5.8.38",
+              "dev": true
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "dev": true
+            }
+          }
+        },
+        "colors": {
+          "version": "1.1.2",
+          "dev": true
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "dev": true
+        },
+        "detect-indent": {
+          "version": "3.0.1",
+          "dev": true
+        },
+        "globals": {
+          "version": "6.4.1",
+          "dev": true
+        },
+        "js-tokens": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "dev": true
+        },
+        "node-dir": {
+          "version": "0.1.8",
+          "dev": true
+        },
+        "repeating": {
+          "version": "1.1.3",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.2.10",
+          "dev": true,
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.32",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
     "jsdom": {
       "version": "9.4.1",
       "dev": true,
@@ -2320,6 +2619,10 @@
     "levelup": {
       "version": "1.3.5"
     },
+    "leven": {
+      "version": "1.0.2",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "dev": true
@@ -2457,7 +2760,10 @@
       "version": "0.3.0",
       "dependencies": {
         "readable-stream": {
-          "version": "2.2.6"
+          "version": "2.2.9"
+        },
+        "string_decoder": {
+          "version": "1.0.0"
         }
       }
     },
@@ -2668,6 +2974,24 @@
         }
       }
     },
+    "nomnom": {
+      "version": "1.8.1",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "chalk": {
+          "version": "0.4.0",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "0.1.1",
+          "dev": true
+        }
+      }
+    },
     "noop-logger": {
       "version": "0.1.1"
     },
@@ -2797,6 +3121,10 @@
     "osenv": {
       "version": "0.1.4"
     },
+    "output-file-sync": {
+      "version": "1.1.2",
+      "dev": true
+    },
     "package-json": {
       "version": "1.2.0",
       "dev": true
@@ -2913,7 +3241,7 @@
       "dev": true
     },
     "postcss": {
-      "version": "5.2.16",
+      "version": "5.2.17",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
@@ -2955,7 +3283,7 @@
       "version": "3.3.0"
     },
     "prebuild-install": {
-      "version": "2.1.1",
+      "version": "2.1.2",
       "dependencies": {
         "minimist": {
           "version": "1.2.0"
@@ -3155,7 +3483,11 @@
       "dev": true,
       "dependencies": {
         "readable-stream": {
-          "version": "2.2.6",
+          "version": "2.2.9",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.0",
           "dev": true
         }
       }
@@ -3184,7 +3516,10 @@
           "version": "3.0.3"
         },
         "readable-stream": {
-          "version": "2.2.6"
+          "version": "2.2.9"
+        },
+        "string_decoder": {
+          "version": "1.0.0"
         }
       }
     },
@@ -3219,17 +3554,67 @@
     "regenerate": {
       "version": "1.3.2"
     },
+    "regenerator": {
+      "version": "0.8.40",
+      "dev": true,
+      "dependencies": {
+        "ast-types": {
+          "version": "0.8.12",
+          "dev": true
+        },
+        "esprima-fb": {
+          "version": "15001.1001.0-dev-harmony-fb",
+          "dev": true
+        },
+        "recast": {
+          "version": "0.10.33",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "dev": true
+        }
+      }
+    },
     "regenerator-runtime": {
       "version": "0.10.3"
     },
     "regenerator-transform": {
-      "version": "0.9.8"
+      "version": "0.9.11"
     },
     "regex-cache": {
       "version": "0.4.3"
     },
     "regexp-quote": {
       "version": "0.0.0"
+    },
+    "regexpu": {
+      "version": "1.3.0",
+      "dev": true,
+      "dependencies": {
+        "ast-types": {
+          "version": "0.8.15",
+          "dev": true
+        },
+        "esprima": {
+          "version": "2.7.3",
+          "dev": true
+        },
+        "recast": {
+          "version": "0.10.43",
+          "dev": true,
+          "dependencies": {
+            "esprima-fb": {
+              "version": "15001.1001.0-dev-harmony-fb",
+              "dev": true
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "dev": true
+        }
+      }
     },
     "regexpu-core": {
       "version": "2.0.0"
@@ -3522,8 +3907,16 @@
     "signal-exit": {
       "version": "3.0.2"
     },
+    "simple-fmt": {
+      "version": "0.1.0",
+      "dev": true
+    },
     "simple-get": {
       "version": "1.4.3"
+    },
+    "simple-is": {
+      "version": "0.2.0",
+      "dev": true
     },
     "sinon": {
       "version": "1.17.6",
@@ -3538,6 +3931,10 @@
     },
     "slice-ansi": {
       "version": "0.0.4",
+      "dev": true
+    },
+    "slide": {
+      "version": "1.1.6",
       "dev": true
     },
     "snake-case": {
@@ -3638,12 +4035,16 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.11.0",
+      "version": "1.13.0",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0"
         }
       }
+    },
+    "stable": {
+      "version": "0.1.6",
+      "dev": true
     },
     "statuses": {
       "version": "1.3.1"
@@ -3682,6 +4083,14 @@
     },
     "stringify-object": {
       "version": "2.4.0",
+      "dev": true
+    },
+    "stringmap": {
+      "version": "0.2.2",
+      "dev": true
+    },
+    "stringset": {
+      "version": "0.2.1",
       "dev": true
     },
     "stringstream": {
@@ -3745,11 +4154,15 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.6",
+          "version": "2.2.9",
           "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.0",
           "dev": true
         },
         "supports-color": {
@@ -3775,7 +4188,10 @@
           "version": "6.4.0"
         },
         "readable-stream": {
-          "version": "2.2.6"
+          "version": "2.2.9"
+        },
+        "string_decoder": {
+          "version": "1.0.0"
         }
       }
     },
@@ -3840,7 +4256,20 @@
       "version": "1.5.2",
       "dependencies": {
         "readable-stream": {
-          "version": "2.2.6"
+          "version": "2.2.9"
+        },
+        "string_decoder": {
+          "version": "1.0.0"
+        }
+      }
+    },
+    "temp": {
+      "version": "0.8.3",
+      "dev": true,
+      "dependencies": {
+        "rimraf": {
+          "version": "2.2.8",
+          "dev": true
         }
       }
     },
@@ -3940,8 +4369,16 @@
     "trim-right": {
       "version": "1.0.1"
     },
+    "try-resolve": {
+      "version": "1.0.1",
+      "dev": true
+    },
     "tryit": {
       "version": "1.0.3",
+      "dev": true
+    },
+    "tryor": {
+      "version": "0.1.2",
       "dev": true
     },
     "tty-browserify": {
@@ -3992,6 +4429,10 @@
     },
     "ultron": {
       "version": "1.0.2"
+    },
+    "underscore": {
+      "version": "1.6.0",
+      "dev": true
     },
     "uniq": {
       "version": "1.0.1",
@@ -4470,6 +4911,10 @@
     },
     "write": {
       "version": "0.2.1",
+      "dev": true
+    },
+    "write-file-atomic": {
+      "version": "1.3.1",
       "dev": true
     },
     "write-file-stdout": {

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "css-lint": "stylelint 'client/**/*.scss' --syntax scss"
   },
   "devDependencies": {
+    "5to6-codemod": "git://github.com/jsnmoon/5to6-codemod#v1.8.0",
     "babel-eslint": "6.1.2",
     "chai": "3.5.0",
     "chai-enzyme": "0.5.2",
@@ -172,6 +173,7 @@
     "eslint-plugin-react": "6.4.1",
     "eslint-plugin-wpcalypso": "3.0.2",
     "glob": "7.0.3",
+    "jscodeshift": "0.3.30",
     "lodash-deep": "1.5.3",
     "md5-file": "3.1.0",
     "mixedindentlint": "1.1.1",


### PR DESCRIPTION
Part of #11688.

This change adds executable codemod scripts to `bin/` and `bin/codemods`. The intent is to have these executables be available for Calypso contributors who are working on migrating CJS modules to ES modules. Each script in `bin/codemods/` are individually executable. 



Todo: 
- [x] ~~Await merge & publish of 5to6/5to6-codemod#40 (1).~~
- [x] Fork 5to6-codemod for internal use
- [x] Add import hoisting script
- [x] Fix errors for name export generation codemod
- [x] Fix errors for import codemod
- [x] Enable `useTabs` and `arrayBracketSpacing` Recast option flags
- [x] Thoroughly test codemods on all `*.js` and `*.jsx` files in `client/`

Caveats:
- recast improperly handles tabs (recast [#185](https://github.com/benjamn/recast/issues/185) and [#315](https://github.com/benjamn/recast/issues/315))
- recast adds unnecessary newline between first and second import statements (recast [#371](https://github.com/benjamn/recast/issues/371))