### PR TITLE
Framework: Try Single-Tree Rendering

### DIFF
--- a/client/auth/index.js
+++ b/client/auth/index.js
@@ -9,10 +9,12 @@ import page from 'page';
 import config from 'config';
 import controller from './controller';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 module.exports = function() {
 	if ( config.isEnabled( 'oauth' ) ) {
-		page( '/login', controller.login );
-		page( '/authorize', controller.authorize );
-		page( '/api/oauth/token', controller.getToken );
+		page('/login', controller.login, makeLayout, clientRender);
+		page('/authorize', controller.authorize, makeLayout, clientRender);
+		page('/api/oauth/token', controller.getToken, makeLayout, clientRender);
 	}
 };

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -17,8 +17,7 @@ var React = require( 'react' ),
 	page = require( 'page' ),
 	url = require( 'url' ),
 	qs = require( 'querystring' ),
-	i18n = require( 'i18n-calypso' ),
-	includes = require( 'lodash/includes' );
+	i18n = require( 'i18n-calypso' );
 
 /**
  * Internal dependencies
@@ -395,34 +394,6 @@ function reduxStoreReady( reduxStore ) {
 			testHelper( document.querySelector( '.environment.is-tests' ) );
 		} );
 	}
-
-	/*
-	 * Layouts with differing React mount-points will not reconcile correctly,
-	 * so remove an existing single-tree layout by re-rendering if necessary.
-	 *
-	 * TODO (@seear): Converting all of Calypso to single-tree layout will
-	 * make this unnecessary.
-	 */
-	page( '*', function( context, next ) {
-		const previousLayoutIsSingleTree = !! (
-			document.getElementsByClassName( 'wp-singletree-layout' ).length
-		);
-
-		const singleTreeSections = [ 'theme', 'themes' ];
-		const sectionName = getSectionName( context.store.getState() );
-		const isMultiTreeLayout = ! includes( singleTreeSections, sectionName );
-
-		if ( isMultiTreeLayout && previousLayoutIsSingleTree ) {
-			debug( 'Re-rendering multi-tree layout' );
-			ReactDom.unmountComponentAtNode( document.getElementById( 'wpcom' ) );
-			renderLayout( context.store );
-		} else if ( ! isMultiTreeLayout && ! previousLayoutIsSingleTree ) {
-			debug( 'Unmounting multi-tree layout' );
-			ReactDom.unmountComponentAtNode( document.getElementById( 'primary' ) );
-			ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
-		}
-		next();
-	} );
 
 	detectHistoryNavigation.start();
 	page.start();

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -18,7 +18,7 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import userFactory from 'lib/user';
 import sitesFactory from 'lib/sites-list';
 import debugFactory from 'debug';
-import { renderWithReduxStore } from 'lib/react-helpers';
+import { makeLayout, render as clientRender } from 'controller';
 
 /**
  * Re-export
@@ -64,7 +64,7 @@ export const makeLayout = makeLayoutMiddleware( ReduxWrappedLayout );
  * divs.
  */
 export function clientRouter( route, ...middlewares ) {
-	page( route, ...middlewares, render );
+	page(route, ...middlewares, render, makeLayout, clientRender);
 }
 
 export function render( context ) {
@@ -85,23 +85,25 @@ function renderSeparateTrees( context ) {
 	renderSecondary( context );
 }
 
-function renderPrimary( context ) {
-	const { primary, store } = context;
+function renderPrimary(context, next) {
+    const { primary, store } = context;
 
 	if ( primary ) {
 		debug( 'Rendering primary', primary );
-		renderWithReduxStore( primary, 'primary', store );
+		context.primary = primary;
 	}
+	next();
 }
 
-function renderSecondary( context ) {
-	const { secondary, store } = context;
+function renderSecondary(context, next) {
+    const { secondary, store } = context;
 
 	if ( secondary === null ) {
 		debug( 'Unmounting secondary' );
 		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 	} else if ( secondary !== undefined ) {
 		debug( 'Rendering secondary' );
-		renderWithReduxStore( secondary, 'secondary', store );
+		context.secondary = secondary;
 	}
+	next();
 }

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -67,7 +67,7 @@ export function clientRouter( route, ...middlewares ) {
 	page( route, ...middlewares, render );
 }
 
-function render( context ) {
+export function render( context ) {
 	context.layout
 		? renderSingleTree( context )
 		: renderSeparateTrees( context );

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -18,7 +18,6 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import userFactory from 'lib/user';
 import sitesFactory from 'lib/sites-list';
 import debugFactory from 'debug';
-import { makeLayout, render as clientRender } from 'controller';
 
 /**
  * Re-export
@@ -64,7 +63,7 @@ export const makeLayout = makeLayoutMiddleware( ReduxWrappedLayout );
  * divs.
  */
 export function clientRouter( route, ...middlewares ) {
-	page(route, ...middlewares, render, makeLayout, clientRender);
+	page( route, ...middlewares, render );
 }
 
 export function render( context ) {
@@ -85,17 +84,16 @@ function renderSeparateTrees( context ) {
 	renderSecondary( context );
 }
 
-function renderPrimary(context, next) {
+function renderPrimary( context ) {
     const { primary, store } = context;
 
 	if ( primary ) {
 		debug( 'Rendering primary', primary );
 		context.primary = primary;
 	}
-	next();
 }
 
-function renderSecondary(context, next) {
+function renderSecondary( context ) {
     const { secondary, store } = context;
 
 	if ( secondary === null ) {
@@ -105,5 +103,4 @@ function renderSecondary(context, next) {
 		debug( 'Rendering secondary' );
 		context.secondary = secondary;
 	}
-	next();
 }

--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -21,7 +21,6 @@ import DevWelcome from './welcome';
 import Sidebar from './sidebar';
 import FormStateExamplesComponent from './form-state-examples';
 import EmptyContent from 'components/empty-content';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 const devdocs = {
 
@@ -92,36 +91,27 @@ const devdocs = {
 	},
 
 	// UI components
-	design: function( context ) {
-		renderWithReduxStore(
-			React.createElement( DesignAssetsComponent, {
-				component: context.params.component
-			} ),
-			'primary',
-			context.store
-		);
+	design: function(context, next) {
+	    context.primary = React.createElement( DesignAssetsComponent, {
+			component: context.params.component
+		} );
+		next();
 	},
 
 	// App Blocks
-	blocks: function( context ) {
-		renderWithReduxStore(
-			React.createElement( Blocks, {
-				component: context.params.component
-			} ),
-			'primary',
-			context.store
-		);
+	blocks: function(context, next) {
+	    context.primary = React.createElement( Blocks, {
+			component: context.params.component
+		} );
+		next();
 	},
 
-	selectors: function( context ) {
-		renderWithReduxStore(
-			React.createElement( DocsSelectors, {
-				selector: context.params.selector,
-				search: context.query.search
-			} ),
-			'primary',
-			context.store
-		);
+	selectors: function(context, next) {
+	    context.primary = React.createElement( DocsSelectors, {
+			selector: context.params.selector,
+			search: context.query.search
+		} );
+		next();
 	},
 
 	typography: function( context ) {

--- a/client/devdocs/index.js
+++ b/client/devdocs/index.js
@@ -9,19 +9,73 @@ import config from 'config';
  */
 import controller from './controller';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 export default function() {
 	if ( config.isEnabled( 'devdocs' ) ) {
-		page( '/devdocs', controller.sidebar, controller.devdocs );
-		page( '/devdocs/form-state-examples/:component?', controller.sidebar, controller.formStateExamples );
-		page( '/devdocs/design/typography', controller.sidebar, controller.typography );
-		page( '/devdocs/design/:component?', controller.sidebar, controller.design );
-		page( '/devdocs/app-components/:component?',
-			( context ) => page.redirect( '/devdocs/blocks/' + ( context.params.component || '' ) ) );
-		page( '/devdocs/app-components', '/devdocs/blocks' );
-		page( '/devdocs/blocks/:component?', controller.sidebar, controller.blocks );
-		page( '/devdocs/selectors/:selector?', controller.sidebar, controller.selectors );
-		page( '/devdocs/start', controller.pleaseLogIn );
-		page( '/devdocs/welcome', controller.sidebar, controller.welcome );
-		page( '/devdocs/:path*', controller.sidebar, controller.singleDoc );
+		page(
+		    '/devdocs',
+			controller.sidebar,
+			controller.devdocs,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/devdocs/form-state-examples/:component?',
+			controller.sidebar,
+			controller.formStateExamples,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/devdocs/design/typography',
+			controller.sidebar,
+			controller.typography,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/devdocs/design/:component?',
+			controller.sidebar,
+			controller.design,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/devdocs/app-components/:component?',
+			( context ) => page.redirect( '/devdocs/blocks/' + ( context.params.component || '' ) ),
+			makeLayout,
+			clientRender
+		);
+		page('/devdocs/app-components', '/devdocs/blocks', makeLayout, clientRender);
+		page(
+		    '/devdocs/blocks/:component?',
+			controller.sidebar,
+			controller.blocks,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/devdocs/selectors/:selector?',
+			controller.sidebar,
+			controller.selectors,
+			makeLayout,
+			clientRender
+		);
+		page('/devdocs/start', controller.pleaseLogIn, makeLayout, clientRender);
+		page(
+		    '/devdocs/welcome',
+			controller.sidebar,
+			controller.welcome,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/devdocs/:path*',
+			controller.sidebar,
+			controller.singleDoc,
+			makeLayout,
+			clientRender
+		);
 	}
 }

--- a/client/extensions/hello-dolly/index.js
+++ b/client/extensions/hello-dolly/index.js
@@ -11,10 +11,19 @@ import HelloDollyPage from './hello-dolly-page';
 import { renderPage } from 'lib/react-helpers';
 import { navigation, siteSelection } from 'my-sites/controller';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 const render = ( context ) => {
 	renderPage( context, <HelloDollyPage /> );
 };
 
 export default function() {
-	page( '/hello-dolly/:site?', siteSelection, navigation, render );
+	page(
+	 '/hello-dolly/:site?',
+	 siteSelection,
+	 navigation,
+	 render,
+	 makeLayout,
+	 clientRender
+	);
 }

--- a/client/extensions/sensei/index.js
+++ b/client/extensions/sensei/index.js
@@ -8,23 +8,30 @@ import React from 'react';
  * Internal dependencies
  */
 import { navigation, siteSelection } from 'my-sites/controller';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import Main from 'components/main';
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 
-const render = ( context ) => {
-	renderWithReduxStore( (
-		<Main className="sensei__main">
-			<SectionHeader label="Sensei LMS" />
-			<Card>
-				<p>This is the start of something great!</p>
-				<p>This will be the home for your Sensei integration with WordPress.com.</p>
-			</Card>
-		</Main>
-	), document.getElementById( 'primary' ), context.store );
+import { makeLayout, render as clientRender } from 'controller';
+
+const render = (context, next) => {
+    context.primary = <Main className="sensei__main">
+		<SectionHeader label="Sensei LMS" />
+		<Card>
+			<p>This is the start of something great!</p>
+			<p>This will be the home for your Sensei integration with WordPress.com.</p>
+		</Card>
+	</Main>;
+	next();
 };
 
 export default function() {
-	page( '/extensions/sensei/:site?', siteSelection, navigation, render );
+	page(
+	    '/extensions/sensei/:site?',
+		siteSelection,
+		navigation,
+		render,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -8,29 +8,38 @@ import page from 'page';
  * Internal dependencies
  */
 import { navigation, siteSelection } from 'my-sites/controller';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import ProductForm from './products/product-form';
 import Dashboard from './dashboard';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 const Controller = {
-	dashboard: function( context ) {
-		renderWithReduxStore(
-			React.createElement( Dashboard, { } ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+	dashboard: function(context, next) {
+	    context.primary = React.createElement( Dashboard, { } );
+		next();
 	},
 
-	addProduct: function( context ) {
-		renderWithReduxStore(
-			React.createElement( ProductForm, { } ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+	addProduct: function(context, next) {
+	    context.primary = React.createElement( ProductForm, { } );
+		next();
 	}
 };
 
 export default function() {
-	page( '/store/:site?', siteSelection, navigation, Controller.dashboard );
-	page( '/store/:site?/products/add', siteSelection, navigation, Controller.addProduct );
+	page(
+	    '/store/:site?',
+		siteSelection,
+		navigation,
+		Controller.dashboard,
+		makeLayout,
+		clientRender
+	);
+	page(
+	    '/store/:site?/products/add',
+		siteSelection,
+		navigation,
+		Controller.addProduct,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/extensions/wp-job-manager/index.js
+++ b/client/extensions/wp-job-manager/index.js
@@ -8,23 +8,30 @@ import React from 'react';
  * Internal dependencies
  */
 import { navigation, siteSelection } from 'my-sites/controller';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import Main from 'components/main';
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 
-const render = ( context ) => {
-	renderWithReduxStore( (
-		<Main className="wp-job-manager__main">
-			<SectionHeader label="WP Job Manager" />
-			<Card>
-				<p>This is the start of something great!</p>
-				<p>This will be the home for your WP Job Manager integration with WordPress.com.</p>
-			</Card>
-		</Main>
-	), document.getElementById( 'primary' ), context.store );
+import { makeLayout, render as clientRender } from 'controller';
+
+const render = (context, next) => {
+    context.primary = <Main className="wp-job-manager__main">
+		<SectionHeader label="WP Job Manager" />
+		<Card>
+			<p>This is the start of something great!</p>
+			<p>This will be the home for your WP Job Manager integration with WordPress.com.</p>
+		</Card>
+	</Main>;
+	next();
 };
 
 export default function() {
-	page( '/extensions/wp-job-manager/:site?', siteSelection, navigation, render );
+	page(
+	    '/extensions/wp-job-manager/:site?',
+		siteSelection,
+		navigation,
+		render,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/extensions/wp-super-cache/controller.js
+++ b/client/extensions/wp-super-cache/controller.js
@@ -12,13 +12,12 @@ import titlecase from 'to-title-case';
 import { getSiteFragment, sectionify } from 'lib/route';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { getSelectedSite } from 'state/ui/selectors';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import WPSuperCache from './main';
 
 const controller = {
 
-	settings: function( context ) {
-		const siteId = getSiteFragment( context.path );
+	settings: function(context, next) {
+	    const siteId = getSiteFragment( context.path );
 		const site = getSelectedSite( context.store.getState() );
 		let tab = context.params.tab;
 
@@ -44,15 +43,12 @@ const controller = {
 
 		analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
 
-		renderWithReduxStore(
-			React.createElement( WPSuperCache, {
-				context,
-				site,
-				tab,
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( WPSuperCache, {
+			context,
+			site,
+			tab,
+		} );
+		next();
 	}
 };
 

--- a/client/extensions/wp-super-cache/index.js
+++ b/client/extensions/wp-super-cache/index.js
@@ -9,7 +9,24 @@ import page from 'page';
 import { navigation, sites, siteSelection } from 'my-sites/controller';
 import controller from './controller';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 export default function() {
-	page( '/extensions/wp-super-cache', siteSelection, sites, navigation, controller.settings );
-	page( '/extensions/wp-super-cache/:tab?/:site', siteSelection, navigation, controller.settings );
+	page(
+	 '/extensions/wp-super-cache',
+	 siteSelection,
+	 sites,
+	 navigation,
+	 controller.settings,
+	 makeLayout,
+	 clientRender
+	);
+	page(
+	 '/extensions/wp-super-cache/:tab?/:site',
+	 siteSelection,
+	 navigation,
+	 controller.settings,
+	 makeLayout,
+	 clientRender
+	);
 }

--- a/client/lib/posts/post-list-store.js
+++ b/client/lib/posts/post-list-store.js
@@ -261,7 +261,7 @@ export default function( id ) {
 		}
 	}
 
-	return new class extends EventEmitter {
+	return new (class extends EventEmitter {
 		constructor() {
 			super();
 			this.id = id;
@@ -444,5 +444,5 @@ export default function( id ) {
 					break;
 			}
 		}
-	}();
+	})();
 };

--- a/client/lib/react-helpers/index.js
+++ b/client/lib/react-helpers/index.js
@@ -15,11 +15,7 @@ export function concatTitle( ...parts ) {
 }
 
 export function renderPage( context, component ) {
-	renderWithReduxStore(
-		component,
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = component;
 }
 
 export function recordPageView( path, ...title ) {

--- a/client/mailing-lists/controller.js
+++ b/client/mailing-lists/controller.js
@@ -9,24 +9,20 @@ import { setSection } from 'state/ui/actions';
  * Internal Dependencies
  */
 import MainComponent from './main';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 export default {
-	unsubscribe( context ) {
-		// We don't need the sidebar here.
+	unsubscribe(context, next) {
+	    // We don't need the sidebar here.
 		context.store.dispatch( setSection( { name: 'me' }, {
 			hasSidebar: false
 		} ) );
 
-		renderWithReduxStore(
-			React.createElement( MainComponent, {
-				email: context.query.email,
-				category: context.query.category,
-				hmac: context.query.hmac,
-				context: omit( context.query, [ 'email', 'category', 'hmac' ] )
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( MainComponent, {
+			email: context.query.email,
+			category: context.query.category,
+			hmac: context.query.hmac,
+			context: omit( context.query, [ 'email', 'category', 'hmac' ] )
+		} );
+		next();
 	}
 };

--- a/client/mailing-lists/index.js
+++ b/client/mailing-lists/index.js
@@ -8,9 +8,16 @@ import page from 'page';
  */
 import controller from './controller';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 export default function() {
 	// not putting category or email address in params, since `page`
 	// currently double-decodes the URI before doing route matching
 	// https://github.com/visionmedia/page.js/issues/306
-	page( '/mailing-lists/unsubscribe', controller.unsubscribe );
+	page(
+	 '/mailing-lists/unsubscribe',
+	 controller.unsubscribe,
+	 makeLayout,
+	 clientRender
+	);
 }

--- a/client/me/account/controller.js
+++ b/client/me/account/controller.js
@@ -11,13 +11,12 @@ import i18n from 'i18n-calypso';
 import analytics from 'lib/analytics';
 import userSettings from 'lib/user-settings';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 const ANALYTICS_PAGE_TITLE = 'Me';
 
 export default {
-	account( context ) {
-		const AccountComponent = require( 'me/account/main' );
+	account(context, next) {
+	    const AccountComponent = require( 'me/account/main' );
 		const username = require( 'lib/username' );
 		const basePath = context.path;
 		let showNoticeInitially = false;
@@ -35,17 +34,14 @@ export default {
 			analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Account Settings' );
 		}
 
-		renderWithReduxStore(
-			React.createElement( AccountComponent,
-				{
-					userSettings: userSettings,
-					path: context.path,
-					username: username,
-					showNoticeInitially: showNoticeInitially
-				}
-			),
-			document.getElementById( 'primary' ),
-			context.store
+		context.primary = React.createElement( AccountComponent,
+			{
+				userSettings: userSettings,
+				path: context.path,
+				username: username,
+				showNoticeInitially: showNoticeInitially
+			}
 		);
+		next();
 	}
 };

--- a/client/me/account/index.js
+++ b/client/me/account/index.js
@@ -9,6 +9,14 @@ import page from 'page';
 import meController from 'me/controller';
 import controller from './controller';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 export default function() {
-	page( '/me/account', meController.sidebar, controller.account );
-};
+	page(
+	 '/me/account',
+	 meController.sidebar,
+	 controller.account,
+	 makeLayout,
+	 clientRender
+	);
+}

--- a/client/me/billing-history/controller.js
+++ b/client/me/billing-history/controller.js
@@ -3,35 +3,25 @@
  */
 import React from 'react';
 
-/**
- * Internal dependencies
- */
-import { renderWithReduxStore } from 'lib/react-helpers';
 import sitesFactory from 'lib/sites-list';
 
 const sites = sitesFactory();
 
 export default {
-	billingHistory( context ) {
-		const BillingHistoryComponent = require( './main' );
+	billingHistory(context, next) {
+	    const BillingHistoryComponent = require( './main' );
 
-		renderWithReduxStore(
-			React.createElement( BillingHistoryComponent, { sites: sites } ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( BillingHistoryComponent, { sites: sites } );
+		next();
 	},
 
-	transaction( context ) {
-		const Receipt = require( './receipt' );
+	transaction(context, next) {
+	    const Receipt = require( './receipt' );
 		const receiptId = context.params.receiptId;
 
 		if ( receiptId ) {
-			renderWithReduxStore(
-				React.createElement( Receipt, { transactionId: receiptId } ),
-				document.getElementById( 'primary' ),
-				context.store
-			);
+			context.primary = React.createElement( Receipt, { transactionId: receiptId } );
 		}
+		next();
 	}
 };

--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -14,7 +14,6 @@ import analytics from 'lib/analytics';
 import route from 'lib/route';
 import userSettings from 'lib/user-settings';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 const ANALYTICS_PAGE_TITLE = 'Me';
 
@@ -22,59 +21,49 @@ export default {
 	sidebar( context, next ) {
 		const SidebarComponent = require( 'me/sidebar' );
 
-		renderWithReduxStore(
-			React.createElement( SidebarComponent, {
-				context: context
-			} ),
-			document.getElementById( 'secondary' ),
-			context.store
-		);
+		context.secondary = React.createElement( SidebarComponent, {
+			context: context
+		} );
 
 		next();
 	},
 
-	profile( context ) {
-		const ProfileComponent = require( 'me/profile' ),
+	profile(context, next) {
+	    const ProfileComponent = require( 'me/profile' ),
 			basePath = context.path;
 
 		context.store.dispatch( setTitle( i18n.translate( 'My Profile', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > My Profile' );
 
-		renderWithReduxStore(
-			React.createElement( ProfileComponent,
-				{
-					userSettings: userSettings,
-					path: context.path
-				}
-			),
-			document.getElementById( 'primary' ),
-			context.store
+		context.primary = React.createElement( ProfileComponent,
+			{
+				userSettings: userSettings,
+				path: context.path
+			}
 		);
+		next();
 	},
 
-	apps( context ) {
-		const AppsComponent = require( 'me/get-apps' ),
+	apps(context, next) {
+	    const AppsComponent = require( 'me/get-apps' ),
 			basePath = context.path;
 
 		context.store.dispatch( setTitle( i18n.translate( 'Get Apps', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Get Apps' );
 
-		renderWithReduxStore(
-			React.createElement( AppsComponent,
-				{
-					userSettings: userSettings,
-					path: context.path
-				}
-			),
-			document.getElementById( 'primary' ),
-			context.store
+		context.primary = React.createElement( AppsComponent,
+			{
+				userSettings: userSettings,
+				path: context.path
+			}
 		);
+		next();
 	},
 
-	nextSteps( context ) {
-		const analyticsBasePath = route.sectionify( context.path ),
+	nextSteps(context, next) {
+	    const analyticsBasePath = route.sectionify( context.path ),
 			NextSteps = require( './next-steps' ),
 			trophiesData = require( 'lib/trophies-data' ),
 			isWelcome = 'welcome' === context.params.welcome;
@@ -88,15 +77,12 @@ export default {
 		analytics.tracks.recordEvent( 'calypso_me_next_view', { is_welcome: isWelcome } );
 		analytics.pageView.record( analyticsBasePath, ANALYTICS_PAGE_TITLE + ' > Next' );
 
-		renderWithReduxStore(
-			React.createElement( NextSteps, {
-				path: context.path,
-				isWelcome: isWelcome,
-				trophiesData: trophiesData
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( NextSteps, {
+			path: context.path,
+			isWelcome: isWelcome,
+			trophiesData: trophiesData
+		} );
+		next();
 	},
 
 	// Users that are redirected to `/me/next?welcome` after signup should visit

--- a/client/me/help/controller.js
+++ b/client/me/help/controller.js
@@ -11,7 +11,6 @@ import analytics from 'lib/analytics';
 import route from 'lib/route';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import config from 'config';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import HelpComponent from './main';
 import CoursesComponent from './help-courses';
 import ContactComponent from './help-contact';
@@ -32,35 +31,29 @@ export default {
 		window.location.href = url;
 	},
 
-	help( context ) {
-		const basePath = route.sectionify( context.path );
+	help(context, next) {
+	    const basePath = route.sectionify( context.path );
 
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 		context.store.dispatch( setTitle( i18n.translate( 'Help', { textOnly: true } ) ) );
 
 		analytics.pageView.record( basePath, 'Help' );
 
-		renderWithReduxStore(
-			<HelpComponent isCoursesEnabled={ config.isEnabled( 'help/courses' ) } />,
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = <HelpComponent isCoursesEnabled={ config.isEnabled( 'help/courses' ) } />;
+		next();
 	},
 
-	courses( context ) {
-		const basePath = route.sectionify( context.path );
+	courses(context, next) {
+	    const basePath = route.sectionify( context.path );
 
 		analytics.pageView.record( basePath, 'Help > Courses' );
 
-		renderWithReduxStore(
-			<CoursesComponent />,
-			'primary',
-			context.store
-		);
+		context.primary = <CoursesComponent />;
+		next();
 	},
 
-	contact( context ) {
-		const basePath = route.sectionify( context.path );
+	contact(context, next) {
+	    const basePath = route.sectionify( context.path );
 
 		analytics.pageView.record( basePath, 'Help > Contact' );
 
@@ -69,10 +62,7 @@ export default {
 			window.scrollTo( 0, 0 );
 		}
 
-		renderWithReduxStore(
-			<ContactComponent clientSlug={ config( 'client_slug' ) } />,
-			'primary',
-			context.store
-		);
+		context.primary = <ContactComponent clientSlug={ config( 'client_slug' ) } />;
+		next();
 	}
 };

--- a/client/me/help/index.js
+++ b/client/me/help/index.js
@@ -5,11 +5,32 @@ var page = require( 'page' ),
 
 module.exports = function() {
 	if ( config.isEnabled( 'help' ) ) {
-		page( '/help', helpController.loggedOut, meController.sidebar, helpController.help );
-		page( '/help/contact', helpController.loggedOut, meController.sidebar, helpController.contact );
+		page(
+		    '/help',
+			helpController.loggedOut,
+			meController.sidebar,
+			helpController.help,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/help/contact',
+			helpController.loggedOut,
+			meController.sidebar,
+			helpController.contact,
+			makeLayout,
+			clientRender
+		);
 	}
 
 	if ( config.isEnabled( 'help/courses' ) ) {
-		page( '/help/courses', helpController.loggedOut, meController.sidebar, helpController.courses );
+		page(
+		    '/help/courses',
+			helpController.loggedOut,
+			meController.sidebar,
+			helpController.courses,
+			makeLayout,
+			clientRender
+		);
 	}
 };

--- a/client/me/index.js
+++ b/client/me/index.js
@@ -9,29 +9,49 @@ import page from 'page';
  */
 import controller from './controller';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 export default function() {
 	if ( config.isEnabled( 'me/my-profile' ) ) {
-		page( '/me', controller.sidebar, controller.profile );
+		page('/me', controller.sidebar, controller.profile, makeLayout, clientRender);
 
 		// Redirect previous URLs
-		page( '/me/profile', controller.profileRedirect );
-		page( '/me/public-profile', controller.profileRedirect );
+		page('/me/profile', controller.profileRedirect, makeLayout, clientRender);
+		page('/me/public-profile', controller.profileRedirect, makeLayout, clientRender);
 	}
 
 	if ( config.isEnabled( 'me/next-steps' ) ) {
-		page( '/me/next/:welcome?', controller.sidebar, controller.nextStepsWelcomeRedirect, controller.nextSteps );
+		page(
+		    '/me/next/:welcome?',
+			controller.sidebar,
+			controller.nextStepsWelcomeRedirect,
+			controller.nextSteps,
+			makeLayout,
+			clientRender
+		);
 	}
 
 	// Trophies and Find-Friends only exist in Atlas
 	// Using a reverse config flag here to try to reflect that
 	// If they're "not enabled", then the router should not redirect them, so they will be handled in Atlas
 	if ( ! config.isEnabled( 'me/trophies' ) ) {
-		page( '/me/trophies', controller.trophiesRedirect );
+		page('/me/trophies', controller.trophiesRedirect, makeLayout, clientRender);
 	}
 
 	if ( ! config.isEnabled( 'me/find-friends' ) ) {
-		page( '/me/find-friends', controller.findFriendsRedirect );
+		page(
+		    '/me/find-friends',
+			controller.findFriendsRedirect,
+			makeLayout,
+			clientRender
+		);
 	}
 
-	page( '/me/get-apps', controller.sidebar, controller.apps );
-};
+	page(
+	    '/me/get-apps',
+		controller.sidebar,
+		controller.apps,
+		makeLayout,
+		clientRender
+	);
+}

--- a/client/me/notification-settings/controller.js
+++ b/client/me/notification-settings/controller.js
@@ -10,7 +10,6 @@ import i18n from 'i18n-calypso';
 import analytics from 'lib/analytics';
 import userSettings from 'lib/user-settings';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import devicesFactory from 'lib/devices';
 import sitesFactory from 'lib/sites-list';
 import userFactory from 'lib/user';
@@ -21,86 +20,74 @@ const sites = sitesFactory();
 const user = userFactory();
 
 export default {
-	notifications( context ) {
-		const NotificationsComponent = require( 'me/notification-settings/main' ),
+	notifications(context, next) {
+	    const NotificationsComponent = require( 'me/notification-settings/main' ),
 			basePath = context.path;
 
 		context.store.dispatch( setTitle( i18n.translate( 'Notifications', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Notifications' );
 
-		renderWithReduxStore(
-			React.createElement( NotificationsComponent, {
-				user: user,
-				userSettings: userSettings,
-				blogs: sites,
-				devices: devices,
-				path: context.path
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( NotificationsComponent, {
+			user: user,
+			userSettings: userSettings,
+			blogs: sites,
+			devices: devices,
+			path: context.path
+		} );
+		next();
 	},
 
-	comments( context ) {
-		const CommentSettingsComponent = require( 'me/notification-settings/comment-settings' ),
+	comments(context, next) {
+	    const CommentSettingsComponent = require( 'me/notification-settings/comment-settings' ),
 			basePath = context.path;
 
 		context.store.dispatch( setTitle( i18n.translate( 'Comments on other sites', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Notifications > Comments on other sites' );
 
-		renderWithReduxStore(
-			React.createElement( CommentSettingsComponent,
-				{
-					user: user,
-					devices: devices,
-					path: context.path
-				}
-			),
-			document.getElementById( 'primary' ),
-			context.store
+		context.primary = React.createElement( CommentSettingsComponent,
+			{
+				user: user,
+				devices: devices,
+				path: context.path
+			}
 		);
+		next();
 	},
 
-	updates( context ) {
-		const WPcomSettingsComponent = require( 'me/notification-settings/wpcom-settings' ),
+	updates(context, next) {
+	    const WPcomSettingsComponent = require( 'me/notification-settings/wpcom-settings' ),
 			basePath = context.path;
 
 		context.store.dispatch( setTitle( i18n.translate( 'Updates from WordPress.com', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Notifications > Updates from WordPress.com' );
 
-		renderWithReduxStore(
-			React.createElement( WPcomSettingsComponent,
-				{
-					user: user,
-					devices: devices,
-					path: context.path
-				}
-			),
-			document.getElementById( 'primary' ),
-			context.store
+		context.primary = React.createElement( WPcomSettingsComponent,
+			{
+				user: user,
+				devices: devices,
+				path: context.path
+			}
 		);
+		next();
 	},
 
-	notificationSubscriptions( context ) {
-		const NotificationSubscriptions = require( 'me/notification-settings/reader-subscriptions' ),
+	notificationSubscriptions(context, next) {
+	    const NotificationSubscriptions = require( 'me/notification-settings/reader-subscriptions' ),
 			basePath = context.path;
 
 		context.store.dispatch( setTitle( i18n.translate( 'Notifications', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
 		analytics.ga.recordPageView( basePath, ANALYTICS_PAGE_TITLE + ' > Notifications > Comments on other sites' );
 
-		renderWithReduxStore(
-			React.createElement( NotificationSubscriptions,
-				{
-					userSettings: userSettings,
-					path: context.path
-				}
-			),
-			document.getElementById( 'primary' ),
-			context.store
+		context.primary = React.createElement( NotificationSubscriptions,
+			{
+				userSettings: userSettings,
+				path: context.path
+			}
 		);
+		next();
 	}
 };

--- a/client/me/notification-settings/index.js
+++ b/client/me/notification-settings/index.js
@@ -9,9 +9,35 @@ import page from 'page';
 import meController from 'me/controller';
 import controller from './controller';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 export default function() {
-	page( '/me/notifications', meController.sidebar, controller.notifications );
-	page( '/me/notifications/comments', meController.sidebar, controller.comments );
-	page( '/me/notifications/updates', meController.sidebar, controller.updates );
-	page( '/me/notifications/subscriptions', meController.sidebar, controller.notificationSubscriptions );
-};
+	page(
+	 '/me/notifications',
+	 meController.sidebar,
+	 controller.notifications,
+	 makeLayout,
+	 clientRender
+	);
+	page(
+	 '/me/notifications/comments',
+	 meController.sidebar,
+	 controller.comments,
+	 makeLayout,
+	 clientRender
+	);
+	page(
+	 '/me/notifications/updates',
+	 meController.sidebar,
+	 controller.updates,
+	 makeLayout,
+	 clientRender
+	);
+	page(
+	 '/me/notifications/subscriptions',
+	 meController.sidebar,
+	 controller.notificationSubscriptions,
+	 makeLayout,
+	 clientRender
+	);
+}

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -12,117 +12,159 @@ import meController from 'me/controller';
 import controller from './controller';
 import paths from './paths';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 export default function() {
 	if ( config.isEnabled( 'manage/payment-methods' ) ) {
 		page(
-			paths.addCreditCard(),
+		    paths.addCreditCard(),
 			meController.sidebar,
-			controller.addCreditCard
+			controller.addCreditCard,
+			makeLayout,
+			clientRender
 		);
 
 		// redirect legacy urls
 		page(
-			'/payment-methods/add-credit-card',
-			() => page.redirect( paths.addCreditCard() )
+		    '/payment-methods/add-credit-card',
+			() => page.redirect( paths.addCreditCard() ),
+			makeLayout,
+			clientRender
 		);
 	}
 
 	page(
-		paths.billingHistory(),
+	    paths.billingHistory(),
 		meController.sidebar,
-		billingController.billingHistory
+		billingController.billingHistory,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		paths.billingHistoryReceipt(),
+	    paths.billingHistoryReceipt(),
 		meController.sidebar,
-		billingController.transaction
+		billingController.transaction,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		paths.purchasesRoot(),
+	    paths.purchasesRoot(),
 		meController.sidebar,
 		controller.noSitesMessage,
-		controller.list
+		controller.list,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		paths.managePurchase(),
+	    paths.managePurchase(),
 		meController.sidebar,
 		controller.noSitesMessage,
-		controller.managePurchase
+		controller.managePurchase,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		paths.cancelPurchase(),
+	    paths.cancelPurchase(),
 		meController.sidebar,
 		controller.noSitesMessage,
-		controller.cancelPurchase
+		controller.cancelPurchase,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		paths.cancelPrivacyProtection(),
+	    paths.cancelPrivacyProtection(),
 		meController.sidebar,
 		controller.noSitesMessage,
-		controller.cancelPrivacyProtection
+		controller.cancelPrivacyProtection,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		paths.confirmCancelDomain(),
+	    paths.confirmCancelDomain(),
 		meController.sidebar,
 		controller.noSitesMessage,
-		controller.confirmCancelDomain
+		controller.confirmCancelDomain,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		paths.addCardDetails(),
+	    paths.addCardDetails(),
 		meController.sidebar,
 		controller.noSitesMessage,
-		controller.addCardDetails
+		controller.addCardDetails,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		paths.editCardDetails(),
+	    paths.editCardDetails(),
 		meController.sidebar,
 		controller.noSitesMessage,
-		controller.editCardDetails
+		controller.editCardDetails,
+		makeLayout,
+		clientRender
 	);
 
 	// redirect legacy urls
 	page(
-		'/purchases',
-		() => page.redirect( paths.purchasesRoot() )
+	    '/purchases',
+		() => page.redirect( paths.purchasesRoot() ),
+		makeLayout,
+		clientRender
 	);
 	page(
-		'/purchases/:siteName/:purchaseId',
-		( { params: { siteName, purchaseId } } ) => page.redirect( paths.managePurchase( siteName, purchaseId ) )
+	    '/purchases/:siteName/:purchaseId',
+		( { params: { siteName, purchaseId } } ) => page.redirect( paths.managePurchase( siteName, purchaseId ) ),
+		makeLayout,
+		clientRender
 	);
 	page(
-		'/purchases/:siteName/:purchaseId/cancel',
-		( { params: { siteName, purchaseId } } ) => page.redirect( paths.cancelPurchase( siteName, purchaseId ) )
+	    '/purchases/:siteName/:purchaseId/cancel',
+		( { params: { siteName, purchaseId } } ) => page.redirect( paths.cancelPurchase( siteName, purchaseId ) ),
+		makeLayout,
+		clientRender
 	);
 	page(
-		'/purchases/:siteName/:purchaseId/cancel-private-registration',
-		( { params: { siteName, purchaseId } } ) => page.redirect( paths.cancelPrivacyProtection( siteName, purchaseId ) )
+	    '/purchases/:siteName/:purchaseId/cancel-private-registration',
+		( { params: { siteName, purchaseId } } ) => page.redirect( paths.cancelPrivacyProtection( siteName, purchaseId ) ),
+		makeLayout,
+		clientRender
 	);
 	page(
-		'/purchases/:siteName/:purchaseId/confirm-cancel-domain',
-		( { params: { siteName, purchaseId } } ) => page.redirect( paths.confirmCancelDomain( siteName, purchaseId ) )
+	    '/purchases/:siteName/:purchaseId/confirm-cancel-domain',
+		( { params: { siteName, purchaseId } } ) => page.redirect( paths.confirmCancelDomain( siteName, purchaseId ) ),
+		makeLayout,
+		clientRender
 	);
 	page(
-		'/purchases/:siteName/:purchaseId/payment/add',
-		( { params: { siteName, purchaseId } } ) => page.redirect( paths.addCardDetails( siteName, purchaseId ) )
+	    '/purchases/:siteName/:purchaseId/payment/add',
+		( { params: { siteName, purchaseId } } ) => page.redirect( paths.addCardDetails( siteName, purchaseId ) ),
+		makeLayout,
+		clientRender
 	);
 	page(
-		'/purchases/:siteName/:purchaseId/payment/edit/:cardId',
-		( { params: { siteName, purchaseId, cardId } } ) => page.redirect( paths.editCardDetails( siteName, purchaseId, cardId ) )
+	    '/purchases/:siteName/:purchaseId/payment/edit/:cardId',
+		( { params: { siteName, purchaseId, cardId } } ) => page.redirect( paths.editCardDetails( siteName, purchaseId, cardId ) ),
+		makeLayout,
+		clientRender
 	);
 	page(
-		'/me/billing',
-		() => page.redirect( paths.billingHistory() )
+	    '/me/billing',
+		() => page.redirect( paths.billingHistory() ),
+		makeLayout,
+		clientRender
 	);
 	page(
-		'/me/billing/:receiptId',
-		( { params: { receiptId } } ) => page.redirect( paths.billingHistoryReceipt( receiptId ) )
+	    '/me/billing/:receiptId',
+		( { params: { receiptId } } ) => page.redirect( paths.billingHistoryReceipt( receiptId ) ),
+		makeLayout,
+		clientRender
 	);
 }

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -12,13 +12,12 @@ import analytics from 'lib/analytics';
 import notices from 'notices';
 import userSettings from 'lib/user-settings';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 const ANALYTICS_PAGE_TITLE = 'Me';
 
 export default {
-	password( context ) {
-		const PasswordComponent = require( 'me/security/main' );
+	password(context, next) {
+	    const PasswordComponent = require( 'me/security/main' );
 		const basePath = context.path;
 		const accountPasswordData = require( 'lib/account-password-data' );
 
@@ -32,21 +31,18 @@ export default {
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Password' );
 
-		renderWithReduxStore(
-			React.createElement( PasswordComponent,
-				{
-					userSettings: userSettings,
-					path: context.path,
-					accountPasswordData: accountPasswordData
-				}
-			),
-			document.getElementById( 'primary' ),
-			context.store
+		context.primary = React.createElement( PasswordComponent,
+			{
+				userSettings: userSettings,
+				path: context.path,
+				accountPasswordData: accountPasswordData
+			}
 		);
+		next();
 	},
 
-	twoStep( context ) {
-		const TwoStepComponent = require( 'me/two-step' ),
+	twoStep(context, next) {
+	    const TwoStepComponent = require( 'me/two-step' ),
 			basePath = context.path,
 			appPasswordsData = require( 'lib/application-passwords-data' );
 
@@ -54,21 +50,18 @@ export default {
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Two-Step Authentication' );
 
-		renderWithReduxStore(
-			React.createElement( TwoStepComponent,
-				{
-					userSettings: userSettings,
-					path: context.path,
-					appPasswordsData: appPasswordsData
-				}
-			),
-			document.getElementById( 'primary' ),
-			context.store
+		context.primary = React.createElement( TwoStepComponent,
+			{
+				userSettings: userSettings,
+				path: context.path,
+				appPasswordsData: appPasswordsData
+			}
 		);
+		next();
 	},
 
-	connectedApplications( context ) {
-		const ConnectedAppsComponent = require( 'me/connected-applications' ),
+	connectedApplications(context, next) {
+	    const ConnectedAppsComponent = require( 'me/connected-applications' ),
 			basePath = context.path,
 			connectedAppsData = require( 'lib/connected-applications-data' );
 
@@ -76,36 +69,30 @@ export default {
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Connected Applications' );
 
-		renderWithReduxStore(
-			React.createElement( ConnectedAppsComponent,
-				{
-					userSettings: userSettings,
-					path: context.path,
-					connectedAppsData: connectedAppsData
-				}
-			),
-			document.getElementById( 'primary' ),
-			context.store
+		context.primary = React.createElement( ConnectedAppsComponent,
+			{
+				userSettings: userSettings,
+				path: context.path,
+				connectedAppsData: connectedAppsData
+			}
 		);
+		next();
 	},
 
-	accountRecovery( context ) {
-		const AccountRecoveryComponent = require( 'me/security-account-recovery' ),
+	accountRecovery(context, next) {
+	    const AccountRecoveryComponent = require( 'me/security-account-recovery' ),
 			basePath = context.path;
 
 		context.store.dispatch( setTitle( i18n.translate( 'Account Recovery', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Account Recovery' );
 
-		renderWithReduxStore(
-			React.createElement( AccountRecoveryComponent,
-				{
-					userSettings: userSettings,
-					path: context.path
-				}
-			),
-			document.getElementById( 'primary' ),
-			context.store
+		context.primary = React.createElement( AccountRecoveryComponent,
+			{
+				userSettings: userSettings,
+				path: context.path
+			}
 		);
+		next();
 	}
 };

--- a/client/me/security/index.js
+++ b/client/me/security/index.js
@@ -9,10 +9,42 @@ import page from 'page';
 import meController from 'me/controller';
 import controller from './controller';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 export default function() {
-	page( '/me/security', meController.sidebar, controller.password );
-	page( '/me/security/two-step', meController.sidebar, controller.twoStep );
-	page( '/me/security/connected-applications', meController.sidebar, controller.connectedApplications );
-	page( '/me/security/connected-applications/:application_id', meController.sidebar, controller.connectedApplication );
-	page( '/me/security/account-recovery', meController.sidebar, controller.accountRecovery );
+	page(
+	 '/me/security',
+	 meController.sidebar,
+	 controller.password,
+	 makeLayout,
+	 clientRender
+	);
+	page(
+	 '/me/security/two-step',
+	 meController.sidebar,
+	 controller.twoStep,
+	 makeLayout,
+	 clientRender
+	);
+	page(
+	 '/me/security/connected-applications',
+	 meController.sidebar,
+	 controller.connectedApplications,
+	 makeLayout,
+	 clientRender
+	);
+	page(
+	 '/me/security/connected-applications/:application_id',
+	 meController.sidebar,
+	 controller.connectedApplication,
+	 makeLayout,
+	 clientRender
+	);
+	page(
+	 '/me/security/account-recovery',
+	 meController.sidebar,
+	 controller.accountRecovery,
+	 makeLayout,
+	 clientRender
+	);
 }

--- a/client/my-sites/ads/controller.js
+++ b/client/my-sites/ads/controller.js
@@ -15,7 +15,6 @@ var sites = require( 'lib/sites-list' )(),
 	AdsUtils = require( 'lib/ads/utils' ),
 	setTitle = require( 'state/document-head/actions' ).setDocumentHeadTitle,
 	utils = require( 'lib/site/utils' );
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 function _recordPageView( context, analyticsPageTitle ) {
 	var basePath = route.sectionify( context.path );
@@ -43,8 +42,8 @@ module.exports = {
 		return;
 	},
 
-	layout: function( context ) {
-		var Ads = require( 'my-sites/ads/main' ),
+	layout: function(context, next) {
+	    var Ads = require( 'my-sites/ads/main' ),
 			pathSuffix = sites.selected ? '/' + sites.selected : '',
 			layoutTitle = _getLayoutTitle( context ),
 			site = sites.getSelectedSite();
@@ -68,14 +67,11 @@ module.exports = {
 			window.scrollTo( 0, 0 );
 		}
 
-		renderWithReduxStore(
-			React.createElement( Ads, {
-				site: site,
-				section: context.params.section,
-				path: context.path,
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( Ads, {
+			site: site,
+			section: context.params.section,
+			path: context.path,
+		} );
+		next();
 	}
 };

--- a/client/my-sites/ads/index.js
+++ b/client/my-sites/ads/index.js
@@ -10,7 +10,20 @@ var controller = require( 'my-sites/controller' ),
 	adsController = require( './controller' );
 
 module.exports = function() {
-	page( '/ads', controller.siteSelection, controller.sites );
-	page( '/ads/:site_id', adsController.redirect );
-	page( '/ads/:section/:site_id', controller.siteSelection, controller.navigation, adsController.layout );
+	page(
+	 '/ads',
+	 controller.siteSelection,
+	 controller.sites,
+	 makeLayout,
+	 clientRender
+	);
+	page('/ads/:site_id', adsController.redirect, makeLayout, clientRender);
+	page(
+	 '/ads/:section/:site_id',
+	 controller.siteSelection,
+	 controller.navigation,
+	 adsController.layout,
+	 makeLayout,
+	 clientRender
+	);
 };

--- a/client/my-sites/customize/index.js
+++ b/client/my-sites/customize/index.js
@@ -12,7 +12,20 @@ var controller = require( 'my-sites/controller' ),
 
 module.exports = function() {
 	if ( config.isEnabled( 'manage/customize' ) ) {
-		page( '/customize/:panel([^\.]+)?', controller.siteSelection, controller.sites );
-		page( '/customize/:panel?/:domain', controller.siteSelection, controller.navigation, customizeController.customize );
+		page(
+		    '/customize/:panel([^\.]+)?',
+			controller.siteSelection,
+			controller.sites,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/customize/:panel?/:domain',
+			controller.siteSelection,
+			controller.navigation,
+			customizeController.customize,
+			makeLayout,
+			clientRender
+		);
 	}
 };

--- a/client/my-sites/drafts/controller.js
+++ b/client/my-sites/drafts/controller.js
@@ -10,28 +10,24 @@ import i18n from 'i18n-calypso';
 import sitesFactory from 'lib/sites-list';
 import route from 'lib/route';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 const sites = sitesFactory();
 
 module.exports = {
 
-	drafts: function( context ) {
-		var Drafts = require( 'my-sites/drafts/main' ),
+	drafts: function(context, next) {
+	    var Drafts = require( 'my-sites/drafts/main' ),
 			siteID = route.getSiteFragment( context.path );
 
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 		context.store.dispatch( setTitle( i18n.translate( 'Drafts', { textOnly: true } ) ) );
 
-		renderWithReduxStore(
-			React.createElement( Drafts, {
-				siteID: siteID,
-				sites: sites,
-				trackScrollPage: function() {}
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( Drafts, {
+			siteID: siteID,
+			sites: sites,
+			trackScrollPage: function() {}
+		} );
+		next();
 	}
 
 };

--- a/client/my-sites/drafts/index.js
+++ b/client/my-sites/drafts/index.js
@@ -13,7 +13,14 @@ var controller = require( 'my-sites/controller' ),
 module.exports = function() {
 
 	if ( config.isEnabled( 'manage/drafts' ) ) {
-		page( '/drafts/:domain?', controller.siteSelection, controller.navigation, draftsController.drafts );
+		page(
+		    '/drafts/:domain?',
+			controller.siteSelection,
+			controller.navigation,
+			draftsController.drafts,
+			makeLayout,
+			clientRender
+		);
 	}
 
 };

--- a/client/my-sites/index.js
+++ b/client/my-sites/index.js
@@ -8,6 +8,14 @@ import page from 'page';
  */
 import controller from './controller';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 export default function() {
-	page( '/sites/:sitesFilter?', controller.siteSelection, controller.sites );
-};
+	page(
+	 '/sites/:sitesFilter?',
+	 controller.siteSelection,
+	 controller.sites,
+	 makeLayout,
+	 clientRender
+	);
+}

--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -15,7 +15,6 @@ import i18n from 'i18n-calypso';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import InviteAccept from 'my-sites/invites/invite-accept';
 import { setSection } from 'state/ui/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import { getRedirectAfterAccept } from 'my-sites/invites/utils';
 import { acceptInvite as acceptInviteAction } from 'lib/invites/actions';
 import _user from 'lib/user';
@@ -48,8 +47,8 @@ export function redirectWithoutLocaleifLoggedIn( context, next ) {
 	next();
 }
 
-export function acceptInvite( context ) {
-	context.store.dispatch( setTitle( i18n.translate( 'Accept Invite', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+export function acceptInvite(context, next) {
+    context.store.dispatch( setTitle( i18n.translate( 'Accept Invite', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
 	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 	context.store.dispatch( setSection( null, { hasSidebar: false } ) );
@@ -80,19 +79,16 @@ export function acceptInvite( context ) {
 		return;
 	}
 
-	renderWithReduxStore(
-		React.createElement(
-			InviteAccept,
-			{
-				siteId: context.params.site_id,
-				inviteKey: context.params.invitation_key,
-				activationKey: context.params.activation_key,
-				authKey: context.params.auth_key,
-				locale: getLocale( context.params ),
-				path: context.path
-			}
-		),
-		document.getElementById( 'primary' ),
-		context.store
+	context.primary = React.createElement(
+		InviteAccept,
+		{
+			siteId: context.params.site_id,
+			inviteKey: context.params.invitation_key,
+			activationKey: context.params.activation_key,
+			authKey: context.params.auth_key,
+			locale: getLocale( context.params ),
+			path: context.path
+		}
 	);
+	next();
 }

--- a/client/my-sites/invites/index.js
+++ b/client/my-sites/invites/index.js
@@ -8,10 +8,14 @@ import page from 'page';
  */
 import { acceptInvite, redirectWithoutLocaleifLoggedIn } from './controller';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 export default () => {
 	page(
-		'/accept-invite/:site_id?/:invitation_key?/:activation_key?/:auth_key?/:locale?',
-		redirectWithoutLocaleifLoggedIn,
-		acceptInvite
+	 '/accept-invite/:site_id?/:invitation_key?/:activation_key?/:auth_key?/:locale?',
+	 redirectWithoutLocaleifLoggedIn,
+	 acceptInvite,
+	 makeLayout,
+	 clientRender
 	);
 };

--- a/client/my-sites/media/controller.js
+++ b/client/my-sites/media/controller.js
@@ -11,14 +11,13 @@ import sitesFactory from 'lib/sites-list';
 import route from 'lib/route';
 import analytics from 'lib/analytics';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 const sites = sitesFactory();
 
 module.exports = {
 
-	media: function( context ) {
-		var MediaComponent = require( 'my-sites/media/main' ),
+	media: function(context, next) {
+	    var MediaComponent = require( 'my-sites/media/main' ),
 			filter = context.params.filter,
 			search = context.query.s,
 			baseAnalyticsPath = route.sectionify( context.path );
@@ -34,15 +33,12 @@ module.exports = {
 		context.store.dispatch( setTitle( i18n.translate( 'Media', { textOnly: true } ) ) );
 
 		// Render
-		renderWithReduxStore(
-			React.createElement( MediaComponent, {
-				sites: sites,
-				filter: filter,
-				search: search
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( MediaComponent, {
+			sites: sites,
+			filter: filter,
+			search: search
+		} );
+		next();
 	}
 
 };

--- a/client/my-sites/media/index.js
+++ b/client/my-sites/media/index.js
@@ -13,8 +13,21 @@ var controller = require( 'my-sites/controller' ),
 module.exports = function() {
 
 	if ( config.isEnabled( 'manage/media' ) ) {
-		page( '/media', controller.siteSelection, controller.sites );
-		page( '/media/:filter?/:domain', controller.siteSelection, controller.navigation, mediaController.media );
+		page(
+		    '/media',
+			controller.siteSelection,
+			controller.sites,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/media/:filter?/:domain',
+			controller.siteSelection,
+			controller.navigation,
+			mediaController.media,
+			makeLayout,
+			clientRender
+		);
 	}
 
 };

--- a/client/my-sites/menus/controller.js
+++ b/client/my-sites/menus/controller.js
@@ -16,12 +16,11 @@ import MenusComponent from 'my-sites/menus/main';
 import notices from 'notices';
 import siteMenus from 'lib/menu-data';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 const sites = sitesFactory();
 
-export default function menus( context ) {
-	const analyticsPageTitle = 'Menus',
+export default function menus(context, next) {
+    const analyticsPageTitle = 'Menus',
 		basePath = route.sectionify( context.path ),
 		site = sites.getSelectedSite();
 	let baseAnalyticsPath;
@@ -35,20 +34,16 @@ export default function menus( context ) {
 	context.store.dispatch( setTitle( i18n.translate( 'Menus', { textOnly: true } ) ) );
 
 	function renderJetpackUpgradeMessage() {
-		renderWithReduxStore(
-			React.createElement( MainComponent, null,
-				React.createElement( JetpackManageErrorPage, {
-					template: 'updateJetpack',
-					site: site,
-					version: '3.5',
-					illustration: '/calypso/images/drake/drake-nomenus.svg',
-					secondaryAction: i18n.translate( 'Open Classic Menu Editor' ),
-					secondaryActionURL: site.options.admin_url + 'nav-menus.php',
-					secondaryActionTarget: '_blank'
-				} )
-			),
-			document.getElementById( 'primary' ),
-			context.store
+		context.primary = React.createElement( MainComponent, null,
+			React.createElement( JetpackManageErrorPage, {
+				template: 'updateJetpack',
+				site: site,
+				version: '3.5',
+				illustration: '/calypso/images/drake/drake-nomenus.svg',
+				secondaryAction: i18n.translate( 'Open Classic Menu Editor' ),
+				secondaryActionURL: site.options.admin_url + 'nav-menus.php',
+				secondaryActionTarget: '_blank'
+			} )
 		);
 	}
 
@@ -65,13 +60,10 @@ export default function menus( context ) {
 
 	analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
 
-	renderWithReduxStore(
-		React.createElement( MenusComponent, {
-			siteMenus: siteMenus,
-			key: siteMenus.siteID,
-			site: site
-		} ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = React.createElement( MenusComponent, {
+		siteMenus: siteMenus,
+		key: siteMenus.siteID,
+		site: site
+	} );
+	next();
 }

--- a/client/my-sites/menus/index.js
+++ b/client/my-sites/menus/index.js
@@ -10,9 +10,18 @@ import config from 'config';
 import { siteSelection, navigation, sites } from 'my-sites/controller';
 import menus from './controller';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 export default function() {
 	if ( config.isEnabled( 'manage/menus' ) ) {
-		page( '/menus/:site_id', siteSelection, navigation, menus );
-		page( '/menus', sites );
+		page(
+		 '/menus/:site_id',
+		 siteSelection,
+		 navigation,
+		 menus,
+		 makeLayout,
+		 clientRender
+		);
+		page('/menus', sites, makeLayout, clientRender);
 	}
 }

--- a/client/my-sites/pages/controller.js
+++ b/client/my-sites/pages/controller.js
@@ -14,12 +14,10 @@ var sites = require( 'lib/sites-list' )(),
 	trackScrollPage = require( 'lib/track-scroll-page' ),
 	setTitle = require( 'state/document-head/actions' ).setDocumentHeadTitle;
 
-import { renderWithReduxStore } from 'lib/react-helpers';
-
 var controller = {
 
-	pages: function( context ) {
-		var Pages = require( 'my-sites/pages/main' ),
+	pages: function(context, next) {
+	    var Pages = require( 'my-sites/pages/main' ),
 			siteID = route.getSiteFragment( context.path ),
 			status = context.params.status,
 			search = context.query.s,
@@ -44,23 +42,20 @@ var controller = {
 
 		analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
 
-		renderWithReduxStore(
-			React.createElement( Pages, {
-				context: context,
-				siteID: siteID,
-				status: status,
-				sites: sites,
-				search: search,
-				trackScrollPage: trackScrollPage.bind(
-					null,
-					baseAnalyticsPath,
-					analyticsPageTitle,
-					'Pages'
-				)
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( Pages, {
+			context: context,
+			siteID: siteID,
+			status: status,
+			sites: sites,
+			search: search,
+			trackScrollPage: trackScrollPage.bind(
+				null,
+				baseAnalyticsPath,
+				analyticsPageTitle,
+				'Pages'
+			)
+		} );
+		next();
 	}
 };
 

--- a/client/my-sites/pages/index.js
+++ b/client/my-sites/pages/index.js
@@ -12,6 +12,13 @@ var controller = require( 'my-sites/controller' ),
 
 module.exports = function() {
 	if ( config.isEnabled( 'manage/pages' ) ) {
-		page( '/pages/:status?/:domain?', controller.siteSelection, controller.navigation, pagesController.pages );
+		page(
+		    '/pages/:status?/:domain?',
+			controller.siteSelection,
+			controller.navigation,
+			pagesController.pages,
+			makeLayout,
+			clientRender
+		);
 	}
 };

--- a/client/my-sites/pages/index.js
+++ b/client/my-sites/pages/index.js
@@ -10,6 +10,8 @@ var controller = require( 'my-sites/controller' ),
 	pagesController = require( './controller' ),
 	config = require( 'config' );
 
+import { makeLayout, render as clientRender } from 'controller';
+
 module.exports = function() {
 	if ( config.isEnabled( 'manage/pages' ) ) {
 		page(

--- a/client/my-sites/paladin/controller.js
+++ b/client/my-sites/paladin/controller.js
@@ -3,19 +3,12 @@
  */
 import React from 'react';
 
-/**
- * Internal Dependencies
- */
-import { renderWithReduxStore } from 'lib/react-helpers';
 import PaladinComponent from './main';
 
 module.exports = {
-	activate: function( context ) {
-		renderWithReduxStore(
-			React.createElement( PaladinComponent ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+	activate: function(context, next) {
+	    context.primary = React.createElement( PaladinComponent );
+		next();
 	}
 };
 

--- a/client/my-sites/paladin/index.js
+++ b/client/my-sites/paladin/index.js
@@ -10,10 +10,25 @@ import controller from 'my-sites/controller';
 import paladinController from './controller';
 import config from 'config';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 module.exports = function() {
 	if ( config.isEnabled( 'paladin' ) ) {
-		page( '/paladin', controller.siteSelection, controller.sites );
-		page( '/paladin/:domain', controller.siteSelection, controller.navigation, paladinController.activate );
+		page(
+		 '/paladin',
+		 controller.siteSelection,
+		 controller.sites,
+		 makeLayout,
+		 clientRender
+		);
+		page(
+		 '/paladin/:domain',
+		 controller.siteSelection,
+		 controller.navigation,
+		 paladinController.activate,
+		 makeLayout,
+		 clientRender
+		);
 	}
 };
 

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -20,7 +20,6 @@ import UsersActions from 'lib/users/actions';
 import PeopleLogStore from 'lib/people/log-store';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import InvitePeople from './invite-people';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import config from 'config';
@@ -68,21 +67,17 @@ function redirectToTeam( context ) {
 function renderPeopleList( filter, context ) {
 	context.store.dispatch( setTitle( i18n.translate( 'People', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
-	renderWithReduxStore(
-		React.createElement( PeopleList, {
-			sites: sites,
-			peopleLog: PeopleLogStore,
-			filter: filter,
-			search: context.query.s
-		} ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	filter.primary = React.createElement( PeopleList, {
+		sites: sites,
+		peopleLog: PeopleLogStore,
+		filter: filter,
+		search: context.query.s
+	} );
 	analytics.pageView.record( 'people/' + filter + '/:site', 'People > ' + titlecase( filter ) );
 }
 
-function renderInvitePeople( context ) {
-	const site = sites.getSelectedSite();
+function renderInvitePeople(context, next) {
+    const site = sites.getSelectedSite();
 	const isJetpack = get( site, 'jetpack' );
 
 	if ( ! sites.initialized ) {
@@ -98,17 +93,14 @@ function renderInvitePeople( context ) {
 
 	context.store.dispatch( setTitle( i18n.translate( 'Invite People', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
-	renderWithReduxStore(
-		React.createElement( InvitePeople, {
-			site: site
-		} ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = React.createElement( InvitePeople, {
+		site: site
+	} );
+	next();
 }
 
-function renderSingleTeamMember( context ) {
-	let site,
+function renderSingleTeamMember(context, next) {
+    let site,
 		siteId,
 		user,
 		userLogin = context.params.user_login;
@@ -142,16 +134,13 @@ function renderSingleTeamMember( context ) {
 		}
 	}
 
-	renderWithReduxStore(
-		React.createElement( EditTeamMember, {
-			siteSlug: site && site.slug ? site.slug : undefined,
-			siteId: site && site.ID ? site.ID : undefined,
-			isJetpack: site && site.jetpack,
-			isMultisite: site && site.is_multisite,
-			userLogin: userLogin,
-			prevPath: context.prevPath
-		} ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = React.createElement( EditTeamMember, {
+		siteSlug: site && site.slug ? site.slug : undefined,
+		siteId: site && site.ID ? site.ID : undefined,
+		isJetpack: site && site.jetpack,
+		isMultisite: site && site.is_multisite,
+		userLogin: userLogin,
+		prevPath: context.prevPath
+	} );
+	next();
 }

--- a/client/my-sites/people/index.js
+++ b/client/my-sites/people/index.js
@@ -13,33 +13,51 @@ var controller = require( 'my-sites/controller' ),
 module.exports = function() {
 	if ( config.isEnabled( 'manage/people' ) ) {
 		[ 'team', 'followers', 'email-followers', 'viewers' ].forEach( function( filter ) {
-			page( '/people/' + filter, controller.siteSelection, controller.sites );
 			page(
-				'/people/' + filter + '/:site_id',
+			    '/people/' + filter,
+				controller.siteSelection,
+				controller.sites,
+				makeLayout,
+				clientRender
+			);
+			page(
+			    '/people/' + filter + '/:site_id',
 				peopleController.enforceSiteEnding,
 				controller.siteSelection,
 				controller.navigation,
-				peopleController.people.bind( null, filter )
+				peopleController.people.bind( null, filter ),
+				makeLayout,
+				clientRender
 			);
 		} );
 
 		page(
-			'/people/new/:site_id',
+		    '/people/new/:site_id',
 			peopleController.enforceSiteEnding,
 			controller.siteSelection,
 			controller.navigation,
-			peopleController.invitePeople
+			peopleController.invitePeople,
+			makeLayout,
+			clientRender
 		);
 
 		page(
-			'/people/edit/:site_id/:user_login',
+		    '/people/edit/:site_id/:user_login',
 			peopleController.enforceSiteEnding,
 			controller.siteSelection,
 			controller.navigation,
-			peopleController.person
+			peopleController.person,
+			makeLayout,
+			clientRender
 		);
 
 		// Anything else is unexpected and should be redirected to the default people management URL: /people/team
-		page( '/people/(.*)?', controller.siteSelection, peopleController.redirectToTeam );
+		page(
+		    '/people/(.*)?',
+			controller.siteSelection,
+			peopleController.redirectToTeam,
+			makeLayout,
+			clientRender
+		);
 	}
 };

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -10,72 +10,94 @@ import controller from 'my-sites/controller';
 import plansController from './controller';
 import currentPlanController from './current-plan/controller';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 export default function() {
 	page(
-		'/plans',
+	    '/plans',
 		controller.siteSelection,
-		controller.sites
+		controller.sites,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		'/plans/compare',
-		controller.siteSelection,
-		controller.navigation,
-		plansController.redirectToPlans
-	);
-
-	page(
-		'/plans/compare/:domain',
+	    '/plans/compare',
 		controller.siteSelection,
 		controller.navigation,
-		plansController.redirectToPlans
+		plansController.redirectToPlans,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		'/plans/features',
+	    '/plans/compare/:domain',
 		controller.siteSelection,
 		controller.navigation,
-		plansController.redirectToPlans
+		plansController.redirectToPlans,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		'/plans/features/:domain',
+	    '/plans/features',
 		controller.siteSelection,
 		controller.navigation,
-		plansController.redirectToPlans
+		plansController.redirectToPlans,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		'/plans/features/:feature/:domain',
-		plansController.features
+	    '/plans/features/:domain',
+		controller.siteSelection,
+		controller.navigation,
+		plansController.redirectToPlans,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		'/plans/my-plan',
+	    '/plans/features/:feature/:domain',
+		plansController.features,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+	    '/plans/my-plan',
 		controller.siteSelection,
 		controller.sites,
 		controller.navigation,
-		currentPlanController.currentPlan
+		currentPlanController.currentPlan,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		'/plans/my-plan/:site',
+	    '/plans/my-plan/:site',
 		controller.siteSelection,
 		controller.navigation,
-		currentPlanController.currentPlan
+		currentPlanController.currentPlan,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		'/plans/select/:plan/:domain',
+	    '/plans/select/:plan/:domain',
 		controller.siteSelection,
-		plansController.redirectToCheckout
+		plansController.redirectToCheckout,
+		makeLayout,
+		clientRender
 	);
 
 	// This route renders the plans page for both WPcom and Jetpack sites.
 	page(
-		'/plans/:intervalType?/:site',
+	    '/plans/:intervalType?/:site',
 		controller.siteSelection,
 		controller.navigation,
-		plansController.plans
+		plansController.plans,
+		makeLayout,
+		clientRender
 	);
 }

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -19,7 +19,6 @@ import PluginEligibility from './plugin-eligibility';
 import PluginListComponent from './main';
 import PluginComponent from './plugin';
 import PluginBrowser from './plugins-browser';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import { setSection } from 'state/ui/actions';
 import { getSelectedSite, getSection } from 'state/ui/selectors';
 
@@ -58,18 +57,14 @@ function renderSinglePlugin( context, siteUrl ) {
 	}
 
 	// Render single plugin component
-	renderWithReduxStore(
-		React.createElement( PluginComponent, {
-			path: context.path,
-			prevQuerystring: lastPluginsQuerystring,
-			prevPath,
-			sites,
-			pluginSlug,
-			siteUrl,
-		} ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = React.createElement( PluginComponent, {
+		path: context.path,
+		prevQuerystring: lastPluginsQuerystring,
+		prevPath,
+		sites,
+		pluginSlug,
+		siteUrl,
+	} );
 }
 
 function getPathWithoutSiteSlug( context, site ) {
@@ -87,18 +82,14 @@ function renderPluginList( context, basePath ) {
 	lastPluginsListVisited = getPathWithoutSiteSlug( context, site );
 	lastPluginsQuerystring = context.querystring;
 
-	renderWithReduxStore(
-		React.createElement( PluginListComponent, {
-			path: basePath,
-			context,
-			filter: context.params.pluginFilter,
-			category: context.params.category,
-			sites,
-			search
-		} ),
-		'primary',
-		context.store
-	);
+	context.primary = React.createElement( PluginListComponent, {
+		path: basePath,
+		context,
+		filter: context.params.pluginFilter,
+		category: context.params.category,
+		sites,
+		search
+	} );
 
 	if ( search ) {
 		analytics.ga.recordEvent( 'Plugins', 'Search', 'Search term', search );
@@ -119,8 +110,8 @@ function renderPluginList( context, basePath ) {
 		.record( baseAnalyticsPath, analyticsPageTitle );
 }
 
-function renderPluginsBrowser( context ) {
-	const searchTerm = context.query.s;
+function renderPluginsBrowser(context, next) {
+    const searchTerm = context.query.s;
 	const site = getSelectedSite( context.store.getState() );
 	let { category } = context.params;
 
@@ -144,36 +135,30 @@ function renderPluginsBrowser( context ) {
 	.pageView
 	.record( baseAnalyticsPath, analyticsPageTitle );
 
-	renderWithReduxStore(
-		React.createElement( PluginBrowser, {
-			site: site ? site.slug : null,
-			path: context.path,
-			category,
-			sites,
-			search: searchTerm
-		} ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = React.createElement( PluginBrowser, {
+		site: site ? site.slug : null,
+		path: context.path,
+		category,
+		sites,
+		search: searchTerm
+	} );
+	next();
 }
 
-function renderPluginWarnings( context ) {
-	const state = context.store.getState();
+function renderPluginWarnings(context, next) {
+    const state = context.store.getState();
 	const site = getSelectedSite( state );
 	const pluginSlug = decodeURIComponent( context.params.plugin );
 
-	renderWithReduxStore(
-		React.createElement( PluginEligibility, {
-			siteSlug: site.slug,
-			pluginSlug
-		} ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = React.createElement( PluginEligibility, {
+		siteSlug: site.slug,
+		pluginSlug
+	} );
+	next();
 }
 
-function renderProvisionPlugins( context ) {
-	const state = context.store.getState();
+function renderProvisionPlugins(context, next) {
+    const state = context.store.getState();
 	const section = getSection( state );
 	const site = getSelectedSite( state );
 	context.store.dispatch( setSection( Object.assign( {}, section, { secondary: false } ) ) );
@@ -185,13 +170,10 @@ function renderProvisionPlugins( context ) {
 
 	analytics.pageView.record( baseAnalyticsPath, 'Jetpack Plugins Setup' );
 
-	renderWithReduxStore(
-		React.createElement( PlanSetup, {
-			whitelist: context.query.only || false
-		} ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = React.createElement( PlanSetup, {
+		whitelist: context.query.only || false
+	} );
+	next();
 }
 
 const controller = {

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -11,6 +11,8 @@ import config from 'config';
 import pluginsController from './controller';
 import { getSelectedSite } from 'state/ui/selectors';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 const nonJetpackRedirectTo = path => ( context, next ) => {
 	const site = getSelectedSite( context.store.getState() );
 
@@ -23,63 +25,90 @@ const nonJetpackRedirectTo = path => ( context, next ) => {
 
 module.exports = function() {
 	if ( config.isEnabled( 'manage/plugins/setup' ) ) {
-		page( '/plugins/setup',
+		page(
+		    '/plugins/setup',
 			controller.siteSelection,
-			pluginsController.setupPlugins
+			pluginsController.setupPlugins,
+			makeLayout,
+			clientRender
 		);
 
-		page( '/plugins/setup/:site',
+		page(
+		    '/plugins/setup/:site',
 			controller.siteSelection,
-			pluginsController.setupPlugins
+			pluginsController.setupPlugins,
+			makeLayout,
+			clientRender
 		);
 	}
 
 	if ( config.isEnabled( 'manage/plugins' ) ) {
-		page( '/plugins/browse/:category/:site',
+		page(
+		    '/plugins/browse/:category/:site',
 			controller.siteSelection,
 			controller.navigation,
-			pluginsController.browsePlugins
+			pluginsController.browsePlugins,
+			makeLayout,
+			clientRender
 		);
 
-		page( '/plugins/browse/:siteOrCategory?',
+		page(
+		    '/plugins/browse/:siteOrCategory?',
 			controller.siteSelection,
 			controller.navigation,
-			pluginsController.browsePlugins
+			pluginsController.browsePlugins,
+			makeLayout,
+			clientRender
 		);
 
-		page( '/plugins/category/:category/:site_id',
+		page(
+		    '/plugins/category/:category/:site_id',
 			controller.siteSelection,
 			controller.navigation,
 			nonJetpackRedirectTo( '/plugins' ),
 			pluginsController.plugins.bind( null, 'all' ),
+			makeLayout,
+			clientRender
 		);
 
-		page( '/plugins',
+		page(
+		    '/plugins',
 			controller.siteSelection,
 			controller.navigation,
 			pluginsController.plugins.bind( null, 'all' ),
-			controller.sites
+			controller.sites,
+			makeLayout,
+			clientRender
 		);
 
 		[ 'active', 'inactive', 'updates' ].forEach( filter => (
-			page( `/plugins/${ filter }/:site_id?`,
+			page(
+			    `/plugins/${ filter }/:site_id?`,
 				controller.siteSelection,
 				controller.navigation,
 				pluginsController.jetpackCanUpdate.bind( null, filter ),
-				pluginsController.plugins.bind( null, filter )
+				pluginsController.plugins.bind( null, filter ),
+				makeLayout,
+				clientRender
 			)
 		) );
 
-		page( '/plugins/:plugin/:site_id?',
+		page(
+		    '/plugins/:plugin/:site_id?',
 			controller.siteSelection,
 			controller.navigation,
-			pluginsController.plugin
+			pluginsController.plugin,
+			makeLayout,
+			clientRender
 		);
 
-		page( '/plugins/:plugin/eligibility/:site_id',
+		page(
+		    '/plugins/:plugin/eligibility/:site_id',
 			controller.siteSelection,
 			controller.navigation,
-			pluginsController.eligibility
+			pluginsController.eligibility,
+			makeLayout,
+			clientRender
 		);
 
 		page.exit( '/plugins*',

--- a/client/my-sites/posts/controller.js
+++ b/client/my-sites/posts/controller.js
@@ -17,12 +17,10 @@ var user = require( 'lib/user' )(),
 	trackScrollPage = require( 'lib/track-scroll-page' ),
 	setTitle = require( 'state/document-head/actions' ).setDocumentHeadTitle;
 
-import { renderWithReduxStore } from 'lib/react-helpers';
-
 module.exports = {
 
-	posts: function( context ) {
-		var Posts = require( 'my-sites/posts/main' ),
+	posts: function(context, next) {
+	    var Posts = require( 'my-sites/posts/main' ),
 			siteID = route.getSiteFragment( context.path ),
 			author = ( context.params.author === 'my' ) ? user.get().ID : null,
 			statusSlug = ( author ) ? context.params.status : context.params.author,
@@ -76,23 +74,20 @@ module.exports = {
 
 		analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
 
-		renderWithReduxStore(
-			React.createElement( Posts, {
-				context: context,
-				siteID: siteID,
-				author: author,
-				statusSlug: statusSlug,
-				sites: sites,
-				search: search,
-				trackScrollPage: trackScrollPage.bind(
-					null,
-					baseAnalyticsPath,
-					analyticsPageTitle,
-					'Posts'
-				)
-			} ),
-			'primary',
-			context.store
-		);
+		context.primary = React.createElement( Posts, {
+			context: context,
+			siteID: siteID,
+			author: author,
+			statusSlug: statusSlug,
+			sites: sites,
+			search: search,
+			trackScrollPage: trackScrollPage.bind(
+				null,
+				baseAnalyticsPath,
+				analyticsPageTitle,
+				'Posts'
+			)
+		} );
+		next();
 	}
 };

--- a/client/my-sites/posts/index.js
+++ b/client/my-sites/posts/index.js
@@ -9,10 +9,15 @@ import page from 'page';
 import controller from 'my-sites/controller';
 import postsController from './controller';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 export default function() {
-	page( '/posts/:author?/:status?/:domain?',
-		controller.siteSelection,
-		controller.navigation,
-		postsController.posts
+	page(
+	 '/posts/:author?/:status?/:domain?',
+	 controller.siteSelection,
+	 controller.navigation,
+	 postsController.posts,
+	 makeLayout,
+	 clientRender
 	);
-};
+}

--- a/client/my-sites/sharing/index.js
+++ b/client/my-sites/sharing/index.js
@@ -9,8 +9,30 @@ import page from 'page';
 import { awaitSiteLoaded, jetpackModuleActive, navigation, sites, siteSelection } from 'my-sites/controller';
 import { buttons, connections, layout } from './controller';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 export default function() {
-	page( /^\/sharing(\/buttons)?$/, siteSelection, sites );
-	page( '/sharing/:domain', siteSelection, navigation, awaitSiteLoaded, jetpackModuleActive( 'publicize', false ), connections, layout );
-	page( '/sharing/buttons/:domain', siteSelection, navigation, awaitSiteLoaded, jetpackModuleActive( 'sharedaddy' ), buttons, layout );
+	page(/^\/sharing(\/buttons)?$/, siteSelection, sites, makeLayout, clientRender);
+	page(
+	 '/sharing/:domain',
+	 siteSelection,
+	 navigation,
+	 awaitSiteLoaded,
+	 jetpackModuleActive( 'publicize', false ),
+	 connections,
+	 layout,
+	 makeLayout,
+	 clientRender
+	);
+	page(
+	 '/sharing/buttons/:domain',
+	 siteSelection,
+	 navigation,
+	 awaitSiteLoaded,
+	 jetpackModuleActive( 'sharedaddy' ),
+	 buttons,
+	 layout,
+	 makeLayout,
+	 clientRender
+	);
 }

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -12,7 +12,6 @@ import analytics from 'lib/analytics';
 import config from 'config';
 import DeleteSite from './delete-site';
 import purchasesPaths from 'me/purchases/paths';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import route from 'lib/route';
 import { sectionify } from 'lib/route/path';
 import SiteSettingsComponent from 'my-sites/site-settings/main';
@@ -50,11 +49,7 @@ function canDeleteSite( site ) {
 }
 
 function renderPage( context, component ) {
-	renderWithReduxStore(
-		component,
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = component;
 }
 
 module.exports = {

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -11,35 +11,141 @@ var config = require( 'config' ),
 	settingsController = require( './controller' );
 
 module.exports = function() {
-	page( '/settings', controller.siteSelection, settingsController.redirectToGeneral );
-	page( '/settings/general/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.siteSettings );
-	page( '/settings/writing/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.siteSettings );
-	page( '/settings/discussion/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.siteSettings );
-	page( '/settings/security/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.siteSettings );
+	page(
+	    '/settings',
+		controller.siteSelection,
+		settingsController.redirectToGeneral,
+		makeLayout,
+		clientRender
+	);
+	page(
+	    '/settings/general/:site_id',
+		controller.siteSelection,
+		controller.navigation,
+		settingsController.setScroll,
+		settingsController.siteSettings,
+		makeLayout,
+		clientRender
+	);
+	page(
+	    '/settings/writing/:site_id',
+		controller.siteSelection,
+		controller.navigation,
+		settingsController.setScroll,
+		settingsController.siteSettings,
+		makeLayout,
+		clientRender
+	);
+	page(
+	    '/settings/discussion/:site_id',
+		controller.siteSelection,
+		controller.navigation,
+		settingsController.setScroll,
+		settingsController.siteSettings,
+		makeLayout,
+		clientRender
+	);
+	page(
+	    '/settings/security/:site_id',
+		controller.siteSelection,
+		controller.navigation,
+		settingsController.setScroll,
+		settingsController.siteSettings,
+		makeLayout,
+		clientRender
+	);
 
-	page( '/settings/import/:site_id', controller.siteSelection, controller.navigation, settingsController.importSite );
+	page(
+	    '/settings/import/:site_id',
+		controller.siteSelection,
+		controller.navigation,
+		settingsController.importSite,
+		makeLayout,
+		clientRender
+	);
 
 	if ( config.isEnabled( 'manage/export/guided-transfer' ) ) {
-		page( '/settings/export/guided/:host_slug?/:site_id', controller.siteSelection, controller.navigation, settingsController.guidedTransfer );
+		page(
+		    '/settings/export/guided/:host_slug?/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			settingsController.guidedTransfer,
+			makeLayout,
+			clientRender
+		);
 	}
 
 	if ( config.isEnabled( 'manage/export' ) ) {
-		page( '/settings/export/:site_id', controller.siteSelection, controller.navigation, settingsController.exportSite );
+		page(
+		    '/settings/export/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			settingsController.exportSite,
+			makeLayout,
+			clientRender
+		);
 	}
 
 	if ( config.isEnabled( 'manage/site-settings/delete-site' ) ) {
-		page( '/settings/delete-site/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.deleteSite );
-		page( '/settings/start-over/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.startOver );
-		page( '/settings/theme-setup/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.themeSetup );
+		page(
+		    '/settings/delete-site/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			settingsController.setScroll,
+			settingsController.deleteSite,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/settings/start-over/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			settingsController.setScroll,
+			settingsController.startOver,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/settings/theme-setup/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			settingsController.setScroll,
+			settingsController.themeSetup,
+			makeLayout,
+			clientRender
+		);
 	}
 
 	if ( config.isEnabled( 'manage/site-settings/categories' ) ) {
-		page( '/settings/taxonomies/:taxonomy/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.taxonomies );
+		page(
+		    '/settings/taxonomies/:taxonomy/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			settingsController.setScroll,
+			settingsController.taxonomies,
+			makeLayout,
+			clientRender
+		);
 	}
 
 	if ( config.isEnabled( 'manage/site-settings/date-time-format' ) ) {
-		page( '/settings/date-time-format/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.dateTimeFormat );
+		page(
+		    '/settings/date-time-format/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			settingsController.setScroll,
+			settingsController.dateTimeFormat,
+			makeLayout,
+			clientRender
+		);
 	}
 
-	page( '/settings/:section', settingsController.legacyRedirects, controller.siteSelection, controller.sites );
+	page(
+	    '/settings/:section',
+		settingsController.legacyRedirects,
+		controller.siteSelection,
+		controller.sites,
+		makeLayout,
+		clientRender
+	);
 };

--- a/client/my-sites/site-settings/traffic/controller.js
+++ b/client/my-sites/site-settings/traffic/controller.js
@@ -8,7 +8,6 @@ import React from 'react';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import route from 'lib/route';
 import TrafficMain from 'my-sites/site-settings/traffic/main';
 import sitesFactory from 'lib/sites-list';
@@ -17,8 +16,8 @@ import utils from 'lib/site/utils';
 const sites = sitesFactory();
 
 export default {
-	traffic( context ) {
-		const analyticsPageTitle = 'Site Settings > Traffic';
+	traffic(context, next) {
+	    const analyticsPageTitle = 'Site Settings > Traffic';
 		const basePath = route.sectionify( context.path );
 		const fiveMinutes = 5 * 60 * 1000;
 		let site = sites.getSelectedSite();
@@ -42,15 +41,12 @@ export default {
 
 		const upgradeToBusiness = () => page( '/checkout/' + site.domain + '/business' );
 
-		renderWithReduxStore(
-			React.createElement( TrafficMain, {
-				...{ sites, upgradeToBusiness }
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( TrafficMain, {
+			...{ sites, upgradeToBusiness }
+		} );
 
 		// analytics tracking
 		analytics.pageView.record( basePath + '/:site', analyticsPageTitle );
+		next();
 	}
 };

--- a/client/my-sites/site-settings/traffic/index.js
+++ b/client/my-sites/site-settings/traffic/index.js
@@ -9,14 +9,33 @@ import page from 'page';
 import controller from './controller';
 import mySitesController from 'my-sites/controller';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 const redirectToTrafficSection = ( context ) => {
 	page.redirect( '/settings/traffic/' + ( context.params.site_id || '' ) );
 };
 
 export default function() {
-	page( '/settings/traffic/:site_id', mySitesController.siteSelection, mySitesController.navigation, controller.traffic );
+	page(
+	 '/settings/traffic/:site_id',
+	 mySitesController.siteSelection,
+	 mySitesController.navigation,
+	 controller.traffic,
+	 makeLayout,
+	 clientRender
+	);
 
 	// redirect legacy urls
-	page( '/settings/analytics/:site_id', redirectToTrafficSection );
-	page( '/settings/seo/:site_id', redirectToTrafficSection );
+	page(
+	 '/settings/analytics/:site_id',
+	 redirectToTrafficSection,
+	 makeLayout,
+	 clientRender
+	);
+	page(
+	 '/settings/seo/:site_id',
+	 redirectToTrafficSection,
+	 makeLayout,
+	 clientRender
+	);
 }

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -14,7 +14,6 @@ import route from 'lib/route';
 import analytics from 'lib/analytics';
 import titlecase from 'to-title-case';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import { savePreference } from 'state/preferences/actions';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
@@ -127,11 +126,8 @@ module.exports = {
 		analytics.pageView.record( basePath, analyticsPageTitle + ' > Insights' );
 
 		const props = { followList };
-		renderWithReduxStore(
-			<AsyncLoad require="my-sites/stats/stats-insights" placeholder={ <StatsPagePlaceholder /> } { ...props } />,
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = <AsyncLoad require="my-sites/stats/stats-insights" placeholder={ <StatsPagePlaceholder /> } { ...props } />;
+		next();
 	},
 
 	overview: function( context, next ) {
@@ -165,11 +161,8 @@ module.exports = {
 				period: activeFilter.period,
 				path: context.pathname,
 			};
-			renderWithReduxStore(
-				<AsyncLoad placeholder={ <StatsPagePlaceholder /> } require="my-sites/stats/overview" { ...props } />,
-				document.getElementById( 'primary' ),
-				context.store
-			);
+			context.primary = <AsyncLoad placeholder={ <StatsPagePlaceholder /> } require="my-sites/stats/overview" { ...props } />;
+			next();
 		}
 	},
 
@@ -254,11 +247,8 @@ module.exports = {
 				period,
 			};
 
-			renderWithReduxStore(
-				<AsyncLoad placeholder={ <StatsPagePlaceholder /> } require="my-sites/stats/site" { ...siteComponentChildren } />,
-				document.getElementById( 'primary' ),
-				context.store
-			);
+			context.primary = <AsyncLoad placeholder={ <StatsPagePlaceholder /> } require="my-sites/stats/site" { ...siteComponentChildren } />;
+			next();
 		}
 	},
 
@@ -340,16 +330,13 @@ module.exports = {
 				period,
 				...extraProps
 			};
-			renderWithReduxStore(
-				<AsyncLoad placeholder={ <StatsPagePlaceholder /> } require="my-sites/stats/summary" { ...props } />,
-				document.getElementById( 'primary' ),
-				context.store
-			);
+			context.primary = <AsyncLoad placeholder={ <StatsPagePlaceholder /> } require="my-sites/stats/summary" { ...props } />;
+			next();
 		}
 	},
 
-	post: function( context ) {
-		let siteId = context.params.site_id;
+	post: function(context, next) {
+	    let siteId = context.params.site_id;
 		const postId = parseInt( context.params.post_id, 10 );
 		const pathParts = context.path.split( '/' );
 		const postOrPage = pathParts[ 2 ] === 'post' ? 'post' : 'page';
@@ -378,16 +365,13 @@ module.exports = {
 				postId,
 				context,
 			};
-			renderWithReduxStore(
-				<AsyncLoad placeholder={ <StatsPagePlaceholder /> } require="my-sites/stats/stats-post-detail" { ...props } />,
-				document.getElementById( 'primary' ),
-				context.store
-			);
+			context.primary = <AsyncLoad placeholder={ <StatsPagePlaceholder /> } require="my-sites/stats/stats-post-detail" { ...props } />;
 		}
+		next();
 	},
 
-	follows: function( context ) {
-		let siteId = context.params.site_id;
+	follows: function(context, next) {
+	    let siteId = context.params.site_id;
 		const FollowList = require( 'lib/follow-list' );
 		let pageNum = context.params.page_num;
 		const followList = new FollowList();
@@ -433,11 +417,8 @@ module.exports = {
 				siteId,
 				followList,
 			};
-			renderWithReduxStore(
-				<AsyncLoad placeholder={ <StatsPagePlaceholder /> } require="my-sites/stats/comment-follows" { ...props } />,
-				document.getElementById( 'primary' ),
-				context.store
-			);
+			context.primary = <AsyncLoad placeholder={ <StatsPagePlaceholder /> } require="my-sites/stats/comment-follows" { ...props } />;
 		}
+		next();
 	}
 };

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -13,42 +13,188 @@ var controller = require( 'my-sites/controller' ),
 module.exports = function() {
 	if ( config.isEnabled( 'manage/stats' ) ) {
 		// Stat Overview Page
-		page( '/stats', controller.siteSelection, controller.navigation, statsController.overview );
-		page( '/stats/day', controller.siteSelection, controller.navigation, statsController.overview );
-		page( '/stats/week', controller.siteSelection, controller.navigation, statsController.overview );
-		page( '/stats/month', controller.siteSelection, controller.navigation, statsController.overview );
-		page( '/stats/year', controller.siteSelection, controller.navigation, statsController.overview );
+		page(
+		    '/stats',
+			controller.siteSelection,
+			controller.navigation,
+			statsController.overview,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/stats/day',
+			controller.siteSelection,
+			controller.navigation,
+			statsController.overview,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/stats/week',
+			controller.siteSelection,
+			controller.navigation,
+			statsController.overview,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/stats/month',
+			controller.siteSelection,
+			controller.navigation,
+			statsController.overview,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/stats/year',
+			controller.siteSelection,
+			controller.navigation,
+			statsController.overview,
+			makeLayout,
+			clientRender
+		);
 
 		// Stat Insights Page
-		page( '/stats/insights/:site_id', controller.siteSelection, controller.navigation, statsController.insights );
+		page(
+		    '/stats/insights/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			statsController.insights,
+			makeLayout,
+			clientRender
+		);
 
 		// Stat Site Pages
-		page( '/stats/day/:site_id', controller.siteSelection, controller.navigation, statsController.site );
-		page( '/stats/week/:site_id', controller.siteSelection, controller.navigation, statsController.site );
-		page( '/stats/month/:site_id', controller.siteSelection, controller.navigation, statsController.site );
-		page( '/stats/year/:site_id', controller.siteSelection, controller.navigation, statsController.site );
+		page(
+		    '/stats/day/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			statsController.site,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/stats/week/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			statsController.site,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/stats/month/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			statsController.site,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/stats/year/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			statsController.site,
+			makeLayout,
+			clientRender
+		);
 
 		// Stat Summary Pages
-		page( '/stats/:module/:site_id', controller.siteSelection, controller.navigation, statsController.summary );
-		page( '/stats/day/:module/:site_id', controller.siteSelection, controller.navigation, statsController.summary );
-		page( '/stats/week/:module/:site_id', controller.siteSelection, controller.navigation, statsController.summary );
-		page( '/stats/month/:module/:site_id', controller.siteSelection, controller.navigation, statsController.summary );
-		page( '/stats/year/:module/:site_id', controller.siteSelection, controller.navigation, statsController.summary );
+		page(
+		    '/stats/:module/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			statsController.summary,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/stats/day/:module/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			statsController.summary,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/stats/week/:module/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			statsController.summary,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/stats/month/:module/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			statsController.summary,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/stats/year/:module/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			statsController.summary,
+			makeLayout,
+			clientRender
+		);
 
 		// Stat Single Post Page
-		page( '/stats/post/:post_id/:site_id', controller.siteSelection, controller.navigation, statsController.post );
-		page( '/stats/page/:post_id/:site_id', controller.siteSelection, controller.navigation, statsController.post );
+		page(
+		    '/stats/post/:post_id/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			statsController.post,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/stats/page/:post_id/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			statsController.post,
+			makeLayout,
+			clientRender
+		);
 
 		// Stat Follows Page
-		page( '/stats/follows/comment/:site_id', controller.siteSelection, controller.navigation, statsController.follows );
-		page( '/stats/follows/comment/:page_num/:site_id', controller.siteSelection, controller.navigation, statsController.follows );
+		page(
+		    '/stats/follows/comment/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			statsController.follows,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/stats/follows/comment/:page_num/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			statsController.follows,
+			makeLayout,
+			clientRender
+		);
 
 		// Reset first view
 		if ( config.isEnabled( 'ui/first-view/reset-route' ) ) {
-			page( '/stats/reset-first-view', statsController.resetFirstView );
+			page(
+			    '/stats/reset-first-view',
+				statsController.resetFirstView,
+				makeLayout,
+				clientRender
+			);
 		}
 
 		// Anything else should require site-selection
-		page( '/stats/(.*)', controller.siteSelection, controller.navigation, statsController.redirectToDefaultSitePage, controller.sites );
+		page(
+		    '/stats/(.*)',
+			controller.siteSelection,
+			controller.navigation,
+			statsController.redirectToDefaultSitePage,
+			controller.sites,
+			makeLayout,
+			clientRender
+		);
 	}
 };

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -10,6 +10,8 @@ var controller = require( 'my-sites/controller' ),
 	statsController = require( './controller' ),
 	config = require( 'config' );
 
+import { makeLayout, render as clientRender } from 'controller';
+
 module.exports = function() {
 	if ( config.isEnabled( 'manage/stats' ) ) {
 		// Stat Overview Page

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -14,7 +14,7 @@ const controller = require( 'my-sites/controller' ),
 	paths = require( './paths' );
 
 function registerMultiPage( { paths, handlers } ) {
-	paths.forEach( path => page( path, ...handlers ) );
+	paths.forEach( path => page(path, ...handlers, makeLayout, clientRender) );
 }
 
 function getCommonHandlers( { noSitePath = paths.domainManagementRoot(), warnIfJetpack = true } = {} ) {
@@ -38,9 +38,11 @@ module.exports = function() {
 	SiftScience.recordUser();
 
 	page(
-		paths.domainManagementEmail(),
+	    paths.domainManagementEmail(),
 		controller.siteSelection,
-		controller.sites
+		controller.sites,
+		makeLayout,
+		clientRender
 	);
 
 	registerMultiPage( {
@@ -66,208 +68,273 @@ module.exports = function() {
 	} );
 
 	page(
-		paths.domainManagementEmailForwarding( ':site', ':domain' ),
+	    paths.domainManagementEmailForwarding( ':site', ':domain' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementEmailForwarding
+		domainManagementController.domainManagementEmailForwarding,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		paths.domainManagementRedirectSettings( ':site', ':domain' ),
+	    paths.domainManagementRedirectSettings( ':site', ':domain' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementRedirectSettings
+		domainManagementController.domainManagementRedirectSettings,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		paths.domainManagementContactsPrivacy( ':site', ':domain' ),
+	    paths.domainManagementContactsPrivacy( ':site', ':domain' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementContactsPrivacy
+		domainManagementController.domainManagementContactsPrivacy,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		paths.domainManagementEditContactInfo( ':site', ':domain' ),
+	    paths.domainManagementEditContactInfo( ':site', ':domain' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementEditContactInfo
+		domainManagementController.domainManagementEditContactInfo,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		paths.domainManagementDns( ':site', ':domain' ),
+	    paths.domainManagementDns( ':site', ':domain' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementDns
+		domainManagementController.domainManagementDns,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		paths.domainManagementNameServers( ':site', ':domain' ),
+	    paths.domainManagementNameServers( ':site', ':domain' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementNameServers
+		domainManagementController.domainManagementNameServers,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		paths.domainManagementTransfer( ':site', ':domain' ),
+	    paths.domainManagementTransfer( ':site', ':domain' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementTransfer
+		domainManagementController.domainManagementTransfer,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		paths.domainManagementTransferOut( ':site', ':domain' ),
+	    paths.domainManagementTransferOut( ':site', ':domain' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementTransferOut
+		domainManagementController.domainManagementTransferOut,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		paths.domainManagementTransferToAnotherUser( ':site', ':domain' ),
+	    paths.domainManagementTransferToAnotherUser( ':site', ':domain' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementTransferToOtherUser
+		domainManagementController.domainManagementTransferToOtherUser,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		paths.domainManagementRoot(),
+	    paths.domainManagementRoot(),
 		controller.siteSelection,
-		controller.sites
+		controller.sites,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		paths.domainManagementList( ':site' ),
+	    paths.domainManagementList( ':site' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementList
+		domainManagementController.domainManagementList,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		paths.domainManagementEdit( ':site', ':domain' ),
+	    paths.domainManagementEdit( ':site', ':domain' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementEdit
+		domainManagementController.domainManagementEdit,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		paths.domainManagementPrivacyProtection( ':site', ':domain' ),
+	    paths.domainManagementPrivacyProtection( ':site', ':domain' ),
 		...getCommonHandlers( { warnIfJetpack: false } ),
-		domainManagementController.domainManagementPrivacyProtection
+		domainManagementController.domainManagementPrivacyProtection,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		paths.domainManagementPrimaryDomain( ':site', ':domain' ),
+	    paths.domainManagementPrimaryDomain( ':site', ':domain' ),
 		...getCommonHandlers(),
-		domainManagementController.domainManagementPrimaryDomain
+		domainManagementController.domainManagementPrimaryDomain,
+		makeLayout,
+		clientRender
 	);
 
 	if ( config.isEnabled( 'upgrades/domain-search' ) ) {
 		page(
-			'/domains/add',
+		    '/domains/add',
 			controller.siteSelection,
 			upgradesController.domainsAddHeader,
 			upgradesController.redirectToAddMappingIfVipSite(),
 			controller.jetPackWarning,
-			controller.sites
+			controller.sites,
+			makeLayout,
+			clientRender
 		);
 
 		page(
-			'/domains/add/mapping',
+		    '/domains/add/mapping',
 			controller.siteSelection,
 			upgradesController.domainsAddHeader,
 			controller.jetPackWarning,
-			controller.sites
+			controller.sites,
+			makeLayout,
+			clientRender
 		);
 
 		page(
-			'/domains/add/site-redirect',
+		    '/domains/add/site-redirect',
 			controller.siteSelection,
 			upgradesController.domainsAddRedirectHeader,
 			controller.jetPackWarning,
-			controller.sites
+			controller.sites,
+			makeLayout,
+			clientRender
 		);
 
-		page( '/domains/add/:domain',
+		page(
+		    '/domains/add/:domain',
 			controller.siteSelection,
 			controller.navigation,
 			upgradesController.redirectIfNoSite( '/domains/add' ),
 			upgradesController.redirectToAddMappingIfVipSite(),
 			controller.jetPackWarning,
-			upgradesController.domainSearch
+			upgradesController.domainSearch,
+			makeLayout,
+			clientRender
 		);
 
-		page( '/domains/add/suggestion/:suggestion/:domain',
+		page(
+		    '/domains/add/suggestion/:suggestion/:domain',
 			controller.siteSelection,
 			controller.navigation,
 			upgradesController.redirectIfNoSite( '/domains/add' ),
 			upgradesController.redirectToAddMappingIfVipSite(),
 			controller.jetPackWarning,
-			upgradesController.domainSearch
+			upgradesController.domainSearch,
+			makeLayout,
+			clientRender
 		);
 
-		page( '/domains/add/:registerDomain/google-apps/:domain',
+		page(
+		    '/domains/add/:registerDomain/google-apps/:domain',
 			controller.siteSelection,
 			controller.navigation,
 			upgradesController.redirectIfNoSite( '/domains/add' ),
 			controller.jetPackWarning,
-			upgradesController.googleAppsWithRegistration
+			upgradesController.googleAppsWithRegistration,
+			makeLayout,
+			clientRender
 		);
 
-		page( '/domains/add/mapping/:domain',
+		page(
+		    '/domains/add/mapping/:domain',
 			controller.siteSelection,
 			controller.navigation,
 			upgradesController.redirectIfNoSite( '/domains/add/mapping' ),
 			controller.jetPackWarning,
-			upgradesController.mapDomain
+			upgradesController.mapDomain,
+			makeLayout,
+			clientRender
 		);
 
-		page( '/domains/add/site-redirect/:domain',
+		page(
+		    '/domains/add/site-redirect/:domain',
 			controller.siteSelection,
 			controller.navigation,
 			upgradesController.redirectIfNoSite( '/domains/add/site-redirect' ),
 			controller.jetPackWarning,
-			upgradesController.siteRedirect
+			upgradesController.siteRedirect,
+			makeLayout,
+			clientRender
 		);
 	}
 
 	page(
-		'/domains',
+	    '/domains',
 		controller.siteSelection,
-		controller.sites
+		controller.sites,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		'/domains/:site',
+	    '/domains/:site',
 		controller.siteSelection,
 		controller.navigation,
 		controller.jetPackWarning,
-		domainManagementController.domainManagementIndex
+		domainManagementController.domainManagementIndex,
+		makeLayout,
+		clientRender
 	);
 
 	if ( config.isEnabled( 'upgrades/checkout' ) ) {
 		page(
-			'/checkout/thank-you/no-site/:receiptId?',
-			upgradesController.checkoutThankYou
+		    '/checkout/thank-you/no-site/:receiptId?',
+			upgradesController.checkoutThankYou,
+			makeLayout,
+			clientRender
 		);
 
 		page(
-			'/checkout/thank-you/:site/:receiptId?',
+		    '/checkout/thank-you/:site/:receiptId?',
 			controller.siteSelection,
-			upgradesController.checkoutThankYou
+			upgradesController.checkoutThankYou,
+			makeLayout,
+			clientRender
 		);
 
 		page(
-			'/checkout/features/:feature/:domain/:plan_name?',
+		    '/checkout/features/:feature/:domain/:plan_name?',
 			controller.siteSelection,
-			upgradesController.checkout
+			upgradesController.checkout,
+			makeLayout,
+			clientRender
 		);
 
 		page(
-			'/checkout/thank-you/features/:feature/:site/:receiptId?',
+		    '/checkout/thank-you/features/:feature/:site/:receiptId?',
 			controller.siteSelection,
-			upgradesController.checkoutThankYou
+			upgradesController.checkoutThankYou,
+			makeLayout,
+			clientRender
 		);
 
 		page(
-			'/checkout/no-site',
-			upgradesController.sitelessCheckout
+		    '/checkout/no-site',
+			upgradesController.sitelessCheckout,
+			makeLayout,
+			clientRender
 		);
 
 		page(
-			'/checkout/:domain/:product?',
+		    '/checkout/:domain/:product?',
 			controller.siteSelection,
-			upgradesController.checkout
+			upgradesController.checkout,
+			makeLayout,
+			clientRender
 		);
 
 		// Visting /checkout without a plan or product should be redirected to /plans
-		page( '/checkout', '/plans' );
+		page('/checkout', '/plans', makeLayout, clientRender);
 	}
 };

--- a/client/post-editor/index.js
+++ b/client/post-editor/index.js
@@ -10,21 +10,68 @@ var sitesController = require( 'my-sites/controller' ),
 	controller = require( './controller' );
 import config from 'config';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 module.exports = function() {
-	page( '/post', controller.pressThis, sitesController.siteSelection, sitesController.sites );
-	page( '/post/new', () => page.redirect( '/post' ) ); // redirect from beep-beep-boop
-	page( '/post/:site?/:post?', sitesController.siteSelection, sitesController.fetchJetpackSettings, controller.post );
+	page(
+	    '/post',
+		controller.pressThis,
+		sitesController.siteSelection,
+		sitesController.sites,
+		makeLayout,
+		clientRender
+	);
+	page('/post/new', () => page.redirect( '/post' ), makeLayout, clientRender); // redirect from beep-beep-boop
+	page(
+	    '/post/:site?/:post?',
+		sitesController.siteSelection,
+		sitesController.fetchJetpackSettings,
+		controller.post,
+		makeLayout,
+		clientRender
+	);
 	page.exit( '/post/:site?/:post?', controller.exitPost );
 
-	page( '/page', sitesController.siteSelection, sitesController.sites );
-	page( '/page/new', () => page.redirect( '/page' ) ); // redirect from beep-beep-boop
-	page( '/page/:site?/:post?', sitesController.siteSelection, sitesController.fetchJetpackSettings, controller.post );
+	page(
+	    '/page',
+		sitesController.siteSelection,
+		sitesController.sites,
+		makeLayout,
+		clientRender
+	);
+	page('/page/new', () => page.redirect( '/page' ), makeLayout, clientRender); // redirect from beep-beep-boop
+	page(
+	    '/page/:site?/:post?',
+		sitesController.siteSelection,
+		sitesController.fetchJetpackSettings,
+		controller.post,
+		makeLayout,
+		clientRender
+	);
 	page.exit( '/page/:site?/:post?', controller.exitPost );
 
 	if ( config.isEnabled( 'manage/custom-post-types' ) ) {
-		page( '/edit/:type', sitesController.siteSelection, sitesController.sites );
-		page( '/edit/:type/new', ( context ) => page.redirect( `/edit/${ context.params.type }` ) );
-		page( '/edit/:type/:site?/:post?', sitesController.siteSelection, sitesController.fetchJetpackSettings, controller.post );
+		page(
+		    '/edit/:type',
+			sitesController.siteSelection,
+			sitesController.sites,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/edit/:type/new',
+			( context ) => page.redirect( `/edit/${ context.params.type }` ),
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/edit/:type/:site?/:post?',
+			sitesController.siteSelection,
+			sitesController.fetchJetpackSettings,
+			controller.post,
+			makeLayout,
+			clientRender
+		);
 		page.exit( '/edit/:type/:site?/:post?', controller.exitPost );
 	}
 };

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -21,7 +21,6 @@ import {
 } from 'reader/route';
 import { recordTrack } from 'reader/stats';
 import { preload } from 'sections-preload';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import AsyncLoad from 'components/async-load';
 
 const analyticsPageTitle = 'Reader';
@@ -35,12 +34,9 @@ function userHasHistory( context ) {
 	return !! context.lastRoute;
 }
 
-function renderFeedError( context ) {
-	renderWithReduxStore(
-		React.createElement( FeedError ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
+function renderFeedError(context, next) {
+    context.primary = React.createElement( FeedError );
+	next();
 }
 
 module.exports = {
@@ -126,11 +122,7 @@ module.exports = {
 	},
 
 	sidebar( context, next ) {
-		renderWithReduxStore(
-			<AsyncLoad require="reader/sidebar" path={ context.path } />,
-			document.getElementById( 'secondary' ),
-			context.store
-		);
+		context.secondary = <AsyncLoad require="reader/sidebar" path={ context.path } />;
 
 		next();
 	},
@@ -140,8 +132,8 @@ module.exports = {
 		next();
 	},
 
-	following( context ) {
-		const StreamComponent = require( 'reader/following/main' ),
+	following(context, next) {
+	    const StreamComponent = require( 'reader/following/main' ),
 			basePath = route.sectionify( context.path ),
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Following',
 			followingStore = feedStreamFactory( 'following' ),
@@ -158,25 +150,22 @@ module.exports = {
 		setPageTitle( context, i18n.translate( 'Following' ) );
 
 		// warn: don't async load this only. we need it to keep feed-post-store in the reader bundle
-		renderWithReduxStore(
-			React.createElement( StreamComponent, {
-				key: 'following',
-				listName: i18n.translate( 'Followed Sites' ),
-				postsStore: followingStore,
-				recommendationsStore,
-				showPrimaryFollowButtonOnCards: false,
-				trackScrollPage: trackScrollPage.bind(
-					null,
-					basePath,
-					fullAnalyticsPageTitle,
-					analyticsPageTitle,
-					mcKey
-				),
-				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey )
-			} ),
-			'primary',
-			context.store
-		);
+		context.primary = React.createElement( StreamComponent, {
+			key: 'following',
+			listName: i18n.translate( 'Followed Sites' ),
+			postsStore: followingStore,
+			recommendationsStore,
+			showPrimaryFollowButtonOnCards: false,
+			trackScrollPage: trackScrollPage.bind(
+				null,
+				basePath,
+				fullAnalyticsPageTitle,
+				analyticsPageTitle,
+				mcKey
+			),
+			onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey )
+		} );
+		next();
 	},
 
 	feedDiscovery( context, next ) {
@@ -195,8 +184,8 @@ module.exports = {
 		}
 	},
 
-	feedListing( context ) {
-		const basePath = '/read/feeds/:feed_id',
+	feedListing(context, next) {
+	    const basePath = '/read/feeds/:feed_id',
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Feed > ' + context.params.feed_id,
 			feedStore = feedStreamFactory( 'feed:' + context.params.feed_id ),
 			mcKey = 'blog';
@@ -208,30 +197,27 @@ module.exports = {
 			feed_id: context.params.feed_id
 		} );
 
-		renderWithReduxStore(
-			<AsyncLoad require="reader/feed-stream"
-				key={ 'feed-' + context.params.feed_id }
-				postsStore={ feedStore }
-				feedId={ +context.params.feed_id }
-				trackScrollPage={ trackScrollPage.bind(
-					null,
-					basePath,
-					fullAnalyticsPageTitle,
-					analyticsPageTitle,
-					mcKey
-				) }
-				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
-				showPrimaryFollowButtonOnCards={ false }
-				suppressSiteNameLink={ true }
-				showBack={ userHasHistory( context ) }
-			/>,
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = <AsyncLoad require="reader/feed-stream"
+			key={ 'feed-' + context.params.feed_id }
+			postsStore={ feedStore }
+			feedId={ +context.params.feed_id }
+			trackScrollPage={ trackScrollPage.bind(
+				null,
+				basePath,
+				fullAnalyticsPageTitle,
+				analyticsPageTitle,
+				mcKey
+			) }
+			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
+			showPrimaryFollowButtonOnCards={ false }
+			suppressSiteNameLink={ true }
+			showBack={ userHasHistory( context ) }
+		/>;
+		next();
 	},
 
-	blogListing( context ) {
-		const basePath = '/read/blogs/:blog_id',
+	blogListing(context, next) {
+	    const basePath = '/read/blogs/:blog_id',
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Site > ' + context.params.blog_id,
 			feedStore = feedStreamFactory( 'site:' + context.params.blog_id ),
 			mcKey = 'blog';
@@ -243,30 +229,27 @@ module.exports = {
 			blog_id: context.params.blog_id
 		} );
 
-		renderWithReduxStore(
-			<AsyncLoad require="reader/site-stream"
-				key={ 'site-' + context.params.blog_id }
-				postsStore={ feedStore }
-				siteId={ +context.params.blog_id }
-				trackScrollPage={ trackScrollPage.bind(
-					null,
-					basePath,
-					fullAnalyticsPageTitle,
-					analyticsPageTitle,
-					mcKey
-				) }
-				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
-				showPrimaryFollowButtonOnCards={ false }
-				suppressSiteNameLink={ true }
-				showBack={ userHasHistory( context ) }
-			/>,
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = <AsyncLoad require="reader/site-stream"
+			key={ 'site-' + context.params.blog_id }
+			postsStore={ feedStore }
+			siteId={ +context.params.blog_id }
+			trackScrollPage={ trackScrollPage.bind(
+				null,
+				basePath,
+				fullAnalyticsPageTitle,
+				analyticsPageTitle,
+				mcKey
+			) }
+			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
+			showPrimaryFollowButtonOnCards={ false }
+			suppressSiteNameLink={ true }
+			showBack={ userHasHistory( context ) }
+		/>;
+		next();
 	},
 
-	readA8C( context ) {
-		const basePath = route.sectionify( context.path ),
+	readA8C(context, next) {
+	    const basePath = route.sectionify( context.path ),
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > A8C',
 			feedStore = feedStreamFactory( 'a8c' ),
 			mcKey = 'a8c';
@@ -277,24 +260,21 @@ module.exports = {
 
 		setPageTitle( context, 'Automattic' );
 
-		renderWithReduxStore(
-			<AsyncLoad require="reader/team/main"
-				key='read-a8c'
-				className='is-a8c'
-				listName='Automattic'
-				postsStore={ feedStore }
-				trackScrollPage={ trackScrollPage.bind(
-					null,
-					basePath,
-					fullAnalyticsPageTitle,
-					analyticsPageTitle,
-					mcKey
-				) }
-				showPrimaryFollowButtonOnCards={ false }
-				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
-			/>,
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = <AsyncLoad require="reader/team/main"
+			key='read-a8c'
+			className='is-a8c'
+			listName='Automattic'
+			postsStore={ feedStore }
+			trackScrollPage={ trackScrollPage.bind(
+				null,
+				basePath,
+				fullAnalyticsPageTitle,
+				analyticsPageTitle,
+				mcKey
+			) }
+			showPrimaryFollowButtonOnCards={ false }
+			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
+		/>;
+		next();
 	}
 };

--- a/client/reader/discover/controller.js
+++ b/client/reader/discover/controller.js
@@ -11,14 +11,13 @@ import route from 'lib/route';
 import feedStreamFactory from 'lib/feed-stream-store';
 import { recordTrack } from 'reader/stats';
 import { ensureStoreLoading, trackPageLoad, trackUpdatesLoaded, trackScrollPage } from 'reader/controller-helper';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import AsyncLoad from 'components/async-load';
 
 const ANALYTICS_PAGE_TITLE = 'Reader';
 
 export default {
-	discover( context ) {
-		const blogId = config( 'discover_blog_id' ),
+	discover(context, next) {
+	    const blogId = config( 'discover_blog_id' ),
 			basePath = route.sectionify( context.path ),
 			fullAnalyticsPageTitle = ANALYTICS_PAGE_TITLE + ' > Site > ' + blogId,
 			feedStore = feedStreamFactory( 'site:' + blogId ),
@@ -29,30 +28,27 @@ export default {
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 		recordTrack( 'calypso_reader_discover_viewed' );
 
-		renderWithReduxStore(
-			<AsyncLoad
-				require="reader/site-stream"
-				key={ 'site-' + blogId }
-				postsStore={ feedStore }
-				siteId={ +blogId }
-				title="Discover"
-				trackScrollPage={ trackScrollPage.bind(
-						null,
-						basePath,
-						fullAnalyticsPageTitle,
-						ANALYTICS_PAGE_TITLE,
-						mcKey
-					)
-				}
-				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
-				suppressSiteNameLink={ true }
-				showPrimaryFollowButtonOnCards={ false }
-				isDiscoverStream={ true }
-				showBack={ false }
-				className="is-discover-stream is-site-stream"
-			/>,
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = <AsyncLoad
+			require="reader/site-stream"
+			key={ 'site-' + blogId }
+			postsStore={ feedStore }
+			siteId={ +blogId }
+			title="Discover"
+			trackScrollPage={ trackScrollPage.bind(
+					null,
+					basePath,
+					fullAnalyticsPageTitle,
+					ANALYTICS_PAGE_TITLE,
+					mcKey
+				)
+			}
+			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
+			suppressSiteNameLink={ true }
+			showPrimaryFollowButtonOnCards={ false }
+			isDiscoverStream={ true }
+			showBack={ false }
+			className="is-discover-stream is-site-stream"
+		/>;
+		next();
 	}
 };

--- a/client/reader/discover/index.js
+++ b/client/reader/discover/index.js
@@ -9,13 +9,18 @@ import page from 'page';
 import controller from './controller';
 import readerController from 'reader/controller';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 export default function() {
-	page( '/discover',
-		readerController.preloadReaderBundle,
-		readerController.updateLastRoute,
-		readerController.loadSubscriptions,
-		readerController.initAbTests,
-		readerController.sidebar,
-		controller.discover
+	page(
+	 '/discover',
+	 readerController.preloadReaderBundle,
+	 readerController.updateLastRoute,
+	 readerController.loadSubscriptions,
+	 readerController.initAbTests,
+	 readerController.sidebar,
+	 controller.discover,
+	 makeLayout,
+	 clientRender
 	);
 }

--- a/client/reader/following/controller.js
+++ b/client/reader/following/controller.js
@@ -10,14 +10,13 @@ import i18n from 'i18n-calypso';
 import route from 'lib/route';
 import userSettings from 'lib/user-settings';
 import { trackPageLoad, setPageTitle } from 'reader/controller-helper';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import AsyncLoad from 'components/async-load';
 
 const analyticsPageTitle = 'Reader';
 
 export default {
-	followingEdit( context ) {
-		const basePath = route.sectionify( context.path ),
+	followingEdit(context, next) {
+	    const basePath = route.sectionify( context.path ),
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Manage Followed Sites',
 			mcKey = 'following_edit',
 			search = context.query.s;
@@ -26,22 +25,19 @@ export default {
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
-		renderWithReduxStore(
-			<AsyncLoad
-				require="reader/following-edit"
-				key="following-edit"
-				initialFollowUrl={ context.query.follow }
-				search={ search }
-				context={ context }
-				userSettings={ userSettings }
-			/>,
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = <AsyncLoad
+			require="reader/following-edit"
+			key="following-edit"
+			initialFollowUrl={ context.query.follow }
+			search={ search }
+			context={ context }
+			userSettings={ userSettings }
+		/>;
+		next();
 	},
 
-	followingManage( context ) {
-		const basePath = route.sectionify( context.path ),
+	followingManage(context, next) {
+	    const basePath = route.sectionify( context.path ),
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Manage Followed Sites',
 			mcKey = 'following_edit',
 			search = context.query.s;
@@ -50,17 +46,14 @@ export default {
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
-		renderWithReduxStore(
-			<AsyncLoad
-				require="reader/following-manage"
-				key="following-manage"
-				initialFollowUrl={ context.query.follow }
-				search={ search }
-				context={ context }
-				userSettings={ userSettings }
-			/>,
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = <AsyncLoad
+			require="reader/following-manage"
+			key="following-manage"
+			initialFollowUrl={ context.query.follow }
+			search={ search }
+			context={ context }
+			userSettings={ userSettings }
+		/>;
+		next();
 	}
 };

--- a/client/reader/following/index.js
+++ b/client/reader/following/index.js
@@ -10,10 +10,32 @@ import controller from './controller';
 import readerController from 'reader/controller';
 import config from 'config';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 export default function() {
-	page( '/following/*', readerController.loadSubscriptions, readerController.initAbTests );
-	page( '/following/edit', readerController.updateLastRoute, readerController.sidebar, controller.followingEdit );
+	page(
+	 '/following/*',
+	 readerController.loadSubscriptions,
+	 readerController.initAbTests,
+	 makeLayout,
+	 clientRender
+	);
+	page(
+	 '/following/edit',
+	 readerController.updateLastRoute,
+	 readerController.sidebar,
+	 controller.followingEdit,
+	 makeLayout,
+	 clientRender
+	);
 	if ( config.isEnabled( 'reader/following-manage-refresh' ) ) {
-		page( '/following/manage', readerController.updateLastRoute, readerController.sidebar, controller.followingManage );
+		page(
+		 '/following/manage',
+		 readerController.updateLastRoute,
+		 readerController.sidebar,
+		 controller.followingManage,
+		 makeLayout,
+		 clientRender
+		);
 	}
 }

--- a/client/reader/full-post/controller.js
+++ b/client/reader/full-post/controller.js
@@ -15,7 +15,6 @@ import {
 	trackPageLoad
 } from 'reader/controller-helper';
 import AsyncLoad from 'components/async-load';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 const analyticsPageTitle = 'Reader';
 
@@ -31,8 +30,8 @@ function renderPostNotFound() {
 	);
 }
 
-export function blogPost( context ) {
-	const blogId = context.params.blog,
+export function blogPost(context, next) {
+    const blogId = context.params.blog,
 		postId = context.params.post,
 		basePath = '/read/blogs/:blog_id/posts/:post_id',
 		fullPageTitle = analyticsPageTitle + ' > Blog Post > ' + blogId + ' > ' + postId;
@@ -43,29 +42,26 @@ export function blogPost( context ) {
 	}
 	trackPageLoad( basePath, fullPageTitle, 'full_post' );
 
-	renderWithReduxStore(
-		<AsyncLoad
-			require="blocks/reader-full-post"
-			blogId={ blogId }
-			postId={ postId }
-			referral={ referral }
-			onClose={ function() {
-				page.back( context.lastRoute || '/' );
-			} }
-			onPostNotFound={ renderPostNotFound }
-		/>,
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = <AsyncLoad
+		require="blocks/reader-full-post"
+		blogId={ blogId }
+		postId={ postId }
+		referral={ referral }
+		onClose={ function() {
+			page.back( context.lastRoute || '/' );
+		} }
+		onPostNotFound={ renderPostNotFound }
+	/>;
 	defer( function() {
 		if ( typeof window !== 'undefined' ) {
 			window.scrollTo( 0, 0 );
 		}
 	} );
+	next();
 }
 
-export function feedPost( context ) {
-	const feedId = context.params.feed,
+export function feedPost(context, next) {
+    const feedId = context.params.feed,
 		postId = context.params.post,
 		basePath = '/read/feeds/:feed_id/posts/:feed_item_id',
 		fullPageTitle = analyticsPageTitle + ' > Feed Post > ' + feedId + ' > ' + postId;
@@ -76,19 +72,16 @@ export function feedPost( context ) {
 		page.back( context.lastRoute || '/' );
 	}
 
-	renderWithReduxStore(
-		<AsyncLoad
-			require="blocks/reader-full-post"
-			feedId={ feedId }
-			postId={ postId }
-			onClose={ closer }
-			onPostNotFound={ renderPostNotFound } />,
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = <AsyncLoad
+		require="blocks/reader-full-post"
+		feedId={ feedId }
+		postId={ postId }
+		onClose={ closer }
+		onPostNotFound={ renderPostNotFound } />;
 	defer( function() {
 		if ( typeof window !== 'undefined' ) {
 			window.scrollTo( 0, 0 );
 		}
 	} );
+	next();
 }

--- a/client/reader/full-post/index.js
+++ b/client/reader/full-post/index.js
@@ -9,18 +9,38 @@ import page from 'page';
 import { blogPost, feedPost } from './controller';
 import readerController from 'reader/controller';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 export default function() {
 	// Feed full post
-	page( '/read/post/feed/:feed_id/:post_id', readerController.legacyRedirects );
-	page( '/read/feeds/:feed/posts/:post',
-		readerController.updateLastRoute,
-		readerController.unmountSidebar,
-		feedPost );
+	page(
+	 '/read/post/feed/:feed_id/:post_id',
+	 readerController.legacyRedirects,
+	 makeLayout,
+	 clientRender
+	);
+	page(
+	 '/read/feeds/:feed/posts/:post',
+	 readerController.updateLastRoute,
+	 readerController.unmountSidebar,
+	 feedPost,
+	 makeLayout,
+	 clientRender
+	);
 
 	// Blog full post
-	page( '/read/post/id/:blog_id/:post_id', readerController.legacyRedirects );
-	page( '/read/blogs/:blog/posts/:post',
-		readerController.updateLastRoute,
-		readerController.unmountSidebar,
-		blogPost );
+	page(
+	 '/read/post/id/:blog_id/:post_id',
+	 readerController.legacyRedirects,
+	 makeLayout,
+	 clientRender
+	);
+	page(
+	 '/read/blogs/:blog/posts/:post',
+	 readerController.updateLastRoute,
+	 readerController.unmountSidebar,
+	 blogPost,
+	 makeLayout,
+	 clientRender
+	);
 }

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -9,6 +9,8 @@ import page from 'page';
 import controller from './controller';
 import config from 'config';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 function forceTeamA8C( context, next ) {
 	context.params.team = 'a8c';
 	next();
@@ -16,44 +18,91 @@ function forceTeamA8C( context, next ) {
 
 module.exports = function() {
 	if ( config.isEnabled( 'reader' ) ) {
-		page( '/',
+		page(
+		    '/',
 			controller.preloadReaderBundle,
 			controller.loadSubscriptions,
 			controller.initAbTests,
 			controller.updateLastRoute,
 			controller.sidebar,
-			controller.following );
+			controller.following,
+			makeLayout,
+			clientRender
+		);
 
 		// Old and incomplete paths that should be redirected to /
-		page( '/read/following', '/' );
-		page( '/read', '/' );
-		page( '/read/blogs', '/' );
-		page( '/read/feeds', '/' );
-		page( '/read/blog', '/' );
-		page( '/read/post', '/' );
-		page( '/read/feed', '/' );
+		page('/read/following', '/', makeLayout, clientRender);
+		page('/read', '/', makeLayout, clientRender);
+		page('/read/blogs', '/', makeLayout, clientRender);
+		page('/read/feeds', '/', makeLayout, clientRender);
+		page('/read/blog', '/', makeLayout, clientRender);
+		page('/read/post', '/', makeLayout, clientRender);
+		page('/read/feed', '/', makeLayout, clientRender);
 
 		// Feed stream
-		page( '/read/*', controller.preloadReaderBundle, controller.loadSubscriptions, controller.initAbTests );
-		page( '/read/blog/feed/:feed_id', controller.legacyRedirects );
-		page( '/read/feeds/:feed_id/posts', controller.incompleteUrlRedirects );
-		page( '/read/feeds/:feed_id',
+		page(
+		    '/read/*',
+			controller.preloadReaderBundle,
+			controller.loadSubscriptions,
+			controller.initAbTests,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/read/blog/feed/:feed_id',
+			controller.legacyRedirects,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/read/feeds/:feed_id/posts',
+			controller.incompleteUrlRedirects,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/read/feeds/:feed_id',
 			controller.updateLastRoute,
 			controller.prettyRedirects,
 			controller.sidebar,
 			controller.feedDiscovery,
-			controller.feedListing );
+			controller.feedListing,
+			makeLayout,
+			clientRender
+		);
 
 		// Blog stream
-		page( '/read/blog/id/:blog_id', controller.legacyRedirects );
-		page( '/read/blogs/:blog_id/posts', controller.incompleteUrlRedirects );
-		page( '/read/blogs/:blog_id',
+		page(
+		    '/read/blog/id/:blog_id',
+			controller.legacyRedirects,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/read/blogs/:blog_id/posts',
+			controller.incompleteUrlRedirects,
+			makeLayout,
+			clientRender
+		);
+		page(
+		    '/read/blogs/:blog_id',
 			controller.updateLastRoute,
 			controller.prettyRedirects,
 			controller.sidebar,
-			controller.blogListing );
+			controller.blogListing,
+			makeLayout,
+			clientRender
+		);
 	}
 
 	// Automattic Employee Posts
-	page( '/read/a8c', controller.updateLastRoute, controller.sidebar, forceTeamA8C, controller.readA8C );
+	page(
+	    '/read/a8c',
+		controller.updateLastRoute,
+		controller.sidebar,
+		forceTeamA8C,
+		controller.readA8C,
+		makeLayout,
+		clientRender
+	);
 };

--- a/client/reader/liked-stream/controller.js
+++ b/client/reader/liked-stream/controller.js
@@ -9,13 +9,12 @@ import React from 'react';
 import route from 'lib/route';
 import feedStreamFactory from 'lib/feed-stream-store';
 import { ensureStoreLoading, trackPageLoad, trackUpdatesLoaded, trackScrollPage } from 'reader/controller-helper';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 const analyticsPageTitle = 'Reader';
 
 export default {
-	likes( context ) {
-		var LikedPostsStream = require( 'reader/liked-stream/main' ),
+	likes(context, next) {
+	    var LikedPostsStream = require( 'reader/liked-stream/main' ),
 			basePath = route.sectionify( context.path ),
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > My Likes',
 			likedPostsStore = feedStreamFactory( 'likes' ),
@@ -25,21 +24,18 @@ export default {
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
-		renderWithReduxStore(
-			React.createElement( LikedPostsStream, {
-				key: 'liked',
-				postsStore: likedPostsStore,
-				trackScrollPage: trackScrollPage.bind(
-					null,
-					basePath,
-					fullAnalyticsPageTitle,
-					analyticsPageTitle,
-					mcKey
-				),
-				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey )
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( LikedPostsStream, {
+			key: 'liked',
+			postsStore: likedPostsStore,
+			trackScrollPage: trackScrollPage.bind(
+				null,
+				basePath,
+				fullAnalyticsPageTitle,
+				analyticsPageTitle,
+				mcKey
+			),
+			onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey )
+		} );
+		next();
 	}
 };

--- a/client/reader/liked-stream/index.js
+++ b/client/reader/liked-stream/index.js
@@ -9,13 +9,18 @@ import page from 'page';
 import controller from './controller';
 import readerController from 'reader/controller';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 export default function() {
-	page( '/activities/likes',
-		readerController.preloadReaderBundle,
-		readerController.loadSubscriptions,
-		readerController.initAbTests,
-		readerController.updateLastRoute,
-		readerController.sidebar,
-		controller.likes
+	page(
+	 '/activities/likes',
+	 readerController.preloadReaderBundle,
+	 readerController.loadSubscriptions,
+	 readerController.initAbTests,
+	 readerController.updateLastRoute,
+	 readerController.sidebar,
+	 controller.likes,
+	 makeLayout,
+	 clientRender
 	);
 }

--- a/client/reader/list/controller.js
+++ b/client/reader/list/controller.js
@@ -9,14 +9,13 @@ import React from 'react';
 import feedStreamFactory from 'lib/feed-stream-store';
 import { recordTrack } from 'reader/stats';
 import { ensureStoreLoading, trackPageLoad, trackUpdatesLoaded, trackScrollPage } from 'reader/controller-helper';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import AsyncLoad from 'components/async-load';
 
 const analyticsPageTitle = 'Reader';
 
 export default {
-	listListing( context ) {
-		const basePath = '/read/list/:owner/:slug',
+	listListing(context, next) {
+	    const basePath = '/read/list/:owner/:slug',
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > List > ' + context.params.user + ' - ' + context.params.list,
 			listStore = feedStreamFactory( 'list:' + context.params.user + '-' + context.params.list ),
 			mcKey = 'list';
@@ -29,24 +28,21 @@ export default {
 			list_slug: context.params.list
 		} );
 
-		renderWithReduxStore(
-			<AsyncLoad require="reader/list-stream"
-				key={ 'tag-' + context.params.user + '-' + context.params.list }
-				postsStore={ listStore }
-				owner={ encodeURIComponent( context.params.user ) }
-				slug={ encodeURIComponent( context.params.list ) }
-				showPrimaryFollowButtonOnCards={ false }
-				trackScrollPage={ trackScrollPage.bind(
-					null,
-					basePath,
-					fullAnalyticsPageTitle,
-					analyticsPageTitle,
-					mcKey
-				) }
-				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
-			/>,
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = <AsyncLoad require="reader/list-stream"
+			key={ 'tag-' + context.params.user + '-' + context.params.list }
+			postsStore={ listStore }
+			owner={ encodeURIComponent( context.params.user ) }
+			slug={ encodeURIComponent( context.params.list ) }
+			showPrimaryFollowButtonOnCards={ false }
+			trackScrollPage={ trackScrollPage.bind(
+				null,
+				basePath,
+				fullAnalyticsPageTitle,
+				analyticsPageTitle,
+				mcKey
+			) }
+			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
+		/>;
+		next();
 	}
 };

--- a/client/reader/list/index.js
+++ b/client/reader/list/index.js
@@ -9,6 +9,15 @@ import page from 'page';
 import controller from './controller';
 import readerController from 'reader/controller';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 export default function() {
-	page( '/read/list/:user/:list', readerController.updateLastRoute, readerController.sidebar, controller.listListing );
+	page(
+	 '/read/list/:user/:list',
+	 readerController.updateLastRoute,
+	 readerController.sidebar,
+	 controller.listListing,
+	 makeLayout,
+	 clientRender
+	);
 }

--- a/client/reader/recommendations/controller.js
+++ b/client/reader/recommendations/controller.js
@@ -12,39 +12,35 @@ import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { ensureStoreLoading, trackPageLoad, trackUpdatesLoaded, userHasHistory } from 'reader/controller-helper';
 import route from 'lib/route';
 import feedStreamFactory from 'lib/feed-stream-store';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 const ANALYTICS_PAGE_TITLE = 'Reader';
 
 export default {
-	recommendedForYou( context ) {
-		const RecommendedForYou = require( 'reader/recommendations/for-you' ),
+	recommendedForYou(context, next) {
+	    const RecommendedForYou = require( 'reader/recommendations/for-you' ),
 			basePath = '/recommendations',
 			fullAnalyticsPageTitle = ANALYTICS_PAGE_TITLE + ' > Recommended Sites For You',
 			mcKey = 'recommendations_for_you';
 
-		renderWithReduxStore(
-			React.createElement( RecommendedForYou, {
-				trackScrollPage: trackScrollPage.bind(
-					null,
-					basePath,
-					fullAnalyticsPageTitle,
-					ANALYTICS_PAGE_TITLE,
-					mcKey
-				)
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( RecommendedForYou, {
+			trackScrollPage: trackScrollPage.bind(
+				null,
+				basePath,
+				fullAnalyticsPageTitle,
+				ANALYTICS_PAGE_TITLE,
+				mcKey
+			)
+		} );
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 		context.store.dispatch( setTitle( i18n.translate( 'Recommended Sites For You ‹ Reader' ) ) );
+		next();
 	},
 
 	// Post Recommendations - Used by the Data team to test recommendation algorithms
-	recommendedPosts( context ) {
-		const RecommendedPostsStream = require( 'reader/recommendations/posts' ),
+	recommendedPosts(context, next) {
+	    const RecommendedPostsStream = require( 'reader/recommendations/posts' ),
 			basePath = route.sectionify( context.path );
 
 		let fullAnalyticsPageTitle = '';
@@ -86,22 +82,19 @@ export default {
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
-		renderWithReduxStore(
-			React.createElement( RecommendedPostsStream, {
-				key: 'recommendations_posts',
-				postsStore: RecommendedPostsStore,
-				trackScrollPage: trackScrollPage.bind(
-					null,
-					basePath,
-					fullAnalyticsPageTitle,
-					ANALYTICS_PAGE_TITLE,
-					mcKey
-				),
-				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
-				showBack: userHasHistory( context )
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( RecommendedPostsStream, {
+			key: 'recommendations_posts',
+			postsStore: RecommendedPostsStore,
+			trackScrollPage: trackScrollPage.bind(
+				null,
+				basePath,
+				fullAnalyticsPageTitle,
+				ANALYTICS_PAGE_TITLE,
+				mcKey
+			),
+			onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
+			showBack: userHasHistory( context )
+		} );
+		next();
 	}
 };

--- a/client/reader/recommendations/index.js
+++ b/client/reader/recommendations/index.js
@@ -11,18 +11,23 @@ import controller from './controller';
 import readerController from 'reader/controller';
 import config from 'config';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 export default function() {
 	// Cold Start no longer exists - redirect to /
-	page( '/recommendations/start', '/' );
+	page('/recommendations/start', '/', makeLayout, clientRender);
 
 	// Blog Recommendations
-	page( '/recommendations',
+	page(
+	    '/recommendations',
 		readerController.preloadReaderBundle,
 		readerController.loadSubscriptions,
 		readerController.initAbTests,
 		readerController.updateLastRoute,
 		readerController.sidebar,
-		controller.recommendedForYou
+		controller.recommendedForYou,
+		makeLayout,
+		clientRender
 	);
 
 	// Post Recommendations - Used by the Data team to test recommendation algorithms

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -16,7 +16,6 @@ import {
 	trackUpdatesLoaded,
 	trackScrollPage
 } from 'reader/controller-helper';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import AsyncLoad from 'components/async-load';
 
 const analyticsPageTitle = 'Reader';
@@ -30,8 +29,8 @@ function replaceSearchUrl( newValue, sort ) {
 }
 
 export default {
-	search: function( context ) {
-		const basePath = '/read/search',
+	search: function(context, next) {
+	    const basePath = '/read/search',
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Search',
 			searchSlug = context.query.q,
 			sort = context.query.sort || 'relevance',
@@ -67,27 +66,24 @@ export default {
 			replaceSearchUrl( searchSlug, newSort !== 'relevance' ? newSort : undefined );
 		}
 
-		renderWithReduxStore(
-			<AsyncLoad require="reader/search-stream"
-				key="search"
-				postsStore={ store }
-				query={ searchSlug }
-				trackScrollPage={ trackScrollPage.bind(
-					null,
-					basePath,
-					fullAnalyticsPageTitle,
-					analyticsPageTitle,
-					mcKey
-				) }
-				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
-				showBack={ false }
-				showPrimaryFollowButtonOnCards={ true }
-				autoFocusInput={ autoFocusInput }
-				onQueryChange={ reportQueryChange }
-				onSortChange={ reportSortChange }
-			/>,
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = <AsyncLoad require="reader/search-stream"
+			key="search"
+			postsStore={ store }
+			query={ searchSlug }
+			trackScrollPage={ trackScrollPage.bind(
+				null,
+				basePath,
+				fullAnalyticsPageTitle,
+				analyticsPageTitle,
+				mcKey
+			) }
+			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
+			showBack={ false }
+			showPrimaryFollowButtonOnCards={ true }
+			autoFocusInput={ autoFocusInput }
+			onQueryChange={ reportQueryChange }
+			onSortChange={ reportSortChange }
+		/>;
+		next();
 	}
 };

--- a/client/reader/search/index.js
+++ b/client/reader/search/index.js
@@ -10,13 +10,19 @@ import config from 'config';
 import controller from './controller';
 import readerController from 'reader/controller';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 export default function() {
 	if ( config.isEnabled( 'reader/search' ) ) {
-		page( '/read/search',
+		page(
+		    '/read/search',
 			readerController.preloadReaderBundle,
 			readerController.updateLastRoute,
 			readerController.sidebar,
-			controller.search );
+			controller.search,
+			makeLayout,
+			clientRender
+		);
 	} else {
 		// redirect search to the root
 		page.redirect( '/read/search', '/' );

--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -10,14 +10,13 @@ import trim from 'lodash/trim';
 import feedStreamFactory from 'lib/feed-stream-store';
 import { recordTrack } from 'reader/stats';
 import { ensureStoreLoading, trackPageLoad, trackUpdatesLoaded, trackScrollPage } from 'reader/controller-helper';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import AsyncLoad from 'components/async-load';
 
 const analyticsPageTitle = 'Reader';
 
 export default {
-	tagListing( context ) {
-		var basePath = '/tag/:slug',
+	tagListing(context, next) {
+	    var basePath = '/tag/:slug',
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Tag > ' + context.params.tag,
 			tagSlug = trim( context.params.tag )
 				.toLowerCase()
@@ -34,25 +33,22 @@ export default {
 			tag: tagSlug
 		} );
 
-		renderWithReduxStore(
-			<AsyncLoad require="reader/tag-stream/main"
-				key={ 'tag-' + encodedTag }
-				postsStore={ tagStore }
-				tag={ encodedTag }
-				decodedTag={ tagSlug }
-				trackScrollPage={ trackScrollPage.bind(
-					null,
-					basePath,
-					fullAnalyticsPageTitle,
-					analyticsPageTitle,
-					mcKey
-				) }
-				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
-				showBack={ !! context.lastRoute }
-				showPrimaryFollowButtonOnCards={ true }
-			/>,
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = <AsyncLoad require="reader/tag-stream/main"
+			key={ 'tag-' + encodedTag }
+			postsStore={ tagStore }
+			tag={ encodedTag }
+			decodedTag={ tagSlug }
+			trackScrollPage={ trackScrollPage.bind(
+				null,
+				basePath,
+				fullAnalyticsPageTitle,
+				analyticsPageTitle,
+				mcKey
+			) }
+			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
+			showBack={ !! context.lastRoute }
+			showPrimaryFollowButtonOnCards={ true }
+		/>;
+		next();
 	}
 };

--- a/client/reader/tag-stream/index.js
+++ b/client/reader/tag-stream/index.js
@@ -9,23 +9,34 @@ import page from 'page';
 import controller from './controller';
 import readerController from 'reader/controller';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 export default function() {
-	page( '/tag/*',
+	page(
+	    '/tag/*',
 		readerController.preloadReaderBundle,
 		readerController.loadSubscriptions,
-		readerController.initAbTests
+		readerController.initAbTests,
+		makeLayout,
+		clientRender
 	);
-	page( '/tag/:tag',
+	page(
+	    '/tag/:tag',
 		readerController.updateLastRoute,
 		readerController.sidebar,
-		controller.tagListing
+		controller.tagListing,
+		makeLayout,
+		clientRender
 	);
 
-	page( '/tags',
+	page(
+	    '/tags',
 		readerController.loadSubscriptions,
 		readerController.initAbTests,
 		readerController.updateLastRoute,
 		readerController.sidebar,
-		controller.recommendedTags
+		controller.recommendedTags,
+		makeLayout,
+		clientRender
 	);
 }

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -17,7 +17,6 @@ import SignupComponent from './main';
 import utils from './utils';
 import userModule from 'lib/user';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 const user = userModule();
 
@@ -74,8 +73,8 @@ export default {
 		next();
 	},
 
-	start( context ) {
-		var basePath = route.sectionify( context.path ),
+	start(context, next) {
+	    var basePath = route.sectionify( context.path ),
 			flowName = utils.getFlowName( context.params ),
 			stepName = utils.getStepName( context.params ),
 			stepSectionName = utils.getStepSectionName( context.params );
@@ -85,18 +84,15 @@ export default {
 		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 		context.store.dispatch( setLayoutFocus( 'content' ) );
 
-		renderWithReduxStore(
-			React.createElement( SignupComponent, {
-				path: context.path,
-				refParameter,
-				queryObject,
-				locale: utils.getLocale( context.params ),
-				flowName: flowName,
-				stepName: stepName,
-				stepSectionName: stepSectionName
-			} ),
-			'primary',
-			context.store
-		);
+		context.primary = React.createElement( SignupComponent, {
+			path: context.path,
+			refParameter,
+			queryObject,
+			locale: utils.getLocale( context.params ),
+			flowName: flowName,
+			stepName: stepName,
+			stepSectionName: stepSectionName
+		} );
+		next();
 	}
 };

--- a/client/signup/index.web.js
+++ b/client/signup/index.web.js
@@ -10,78 +10,174 @@ import controller from './controller';
 import jetpackConnectController from './jetpack-connect/controller';
 import sitesController from 'my-sites/controller';
 
+import { makeLayout, render as clientRender } from 'controller';
+
 export default function() {
 	page(
-		'/start/:flowName?/:stepName?/:stepSectionName?/:lang?',
+	    '/start/:flowName?/:stepName?/:stepSectionName?/:lang?',
 		controller.saveRefParameter,
 		controller.saveQueryObject,
 		controller.redirectWithoutLocaleIfLoggedIn,
 		controller.redirectToFlow,
-		controller.start
+		controller.start,
+		makeLayout,
+		clientRender
 	);
 
-	page( '/jetpack/connect/install', jetpackConnectController.install );
-
-	page( '/jetpack/connect/personal', jetpackConnectController.personal );
-	page( '/jetpack/connect/personal/:intervalType', jetpackConnectController.personal );
-
-	page( '/jetpack/connect/premium', jetpackConnectController.premium );
-	page( '/jetpack/connect/premium/:intervalType', jetpackConnectController.premium );
-
-	page( '/jetpack/connect/pro', jetpackConnectController.pro );
-	page( '/jetpack/connect/pro/:intervalType', jetpackConnectController.pro );
-
-	page( '/jetpack/connect', jetpackConnectController.connect );
-
-	page( '/jetpack/connect/choose/:site', jetpackConnectController.plansPreSelection );
+	page(
+	    '/jetpack/connect/install',
+		jetpackConnectController.install,
+		makeLayout,
+		clientRender
+	);
 
 	page(
-		'/jetpack/connect/authorize/:localeOrInterval?',
+	    '/jetpack/connect/personal',
+		jetpackConnectController.personal,
+		makeLayout,
+		clientRender
+	);
+	page(
+	    '/jetpack/connect/personal/:intervalType',
+		jetpackConnectController.personal,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+	    '/jetpack/connect/premium',
+		jetpackConnectController.premium,
+		makeLayout,
+		clientRender
+	);
+	page(
+	    '/jetpack/connect/premium/:intervalType',
+		jetpackConnectController.premium,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+	    '/jetpack/connect/pro',
+		jetpackConnectController.pro,
+		makeLayout,
+		clientRender
+	);
+	page(
+	    '/jetpack/connect/pro/:intervalType',
+		jetpackConnectController.pro,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+	    '/jetpack/connect',
+		jetpackConnectController.connect,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+	    '/jetpack/connect/choose/:site',
+		jetpackConnectController.plansPreSelection,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+	    '/jetpack/connect/authorize/:localeOrInterval?',
 		jetpackConnectController.redirectWithoutLocaleifLoggedIn,
 		jetpackConnectController.saveQueryObject,
-		jetpackConnectController.authorizeForm
+		jetpackConnectController.authorizeForm,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		'/jetpack/connect/authorize/:intervalType/:locale',
+	    '/jetpack/connect/authorize/:intervalType/:locale',
 		jetpackConnectController.redirectWithoutLocaleifLoggedIn,
 		jetpackConnectController.saveQueryObject,
-		jetpackConnectController.authorizeForm
+		jetpackConnectController.authorizeForm,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		'/jetpack/connect/install/:locale?',
+	    '/jetpack/connect/install/:locale?',
 		jetpackConnectController.redirectWithoutLocaleifLoggedIn,
-		jetpackConnectController.install
+		jetpackConnectController.install,
+		makeLayout,
+		clientRender
 	);
 
-	page( '/jetpack/connect/store', jetpackConnectController.plansLanding );
-	page( '/jetpack/connect/store/:intervalType', jetpackConnectController.plansLanding );
-
-	page( '/jetpack/connect/vaultpress', jetpackConnectController.vaultpressLanding );
-	page( '/jetpack/connect/vaultpress/:intervalType', jetpackConnectController.vaultpressLanding );
-
-	page( '/jetpack/connect/akismet', jetpackConnectController.akismetLanding );
-	page( '/jetpack/connect/akismet/:intervalType', jetpackConnectController.akismetLanding );
+	page(
+	    '/jetpack/connect/store',
+		jetpackConnectController.plansLanding,
+		makeLayout,
+		clientRender
+	);
+	page(
+	    '/jetpack/connect/store/:intervalType',
+		jetpackConnectController.plansLanding,
+		makeLayout,
+		clientRender
+	);
 
 	page(
-		'/jetpack/connect/:locale?',
+	    '/jetpack/connect/vaultpress',
+		jetpackConnectController.vaultpressLanding,
+		makeLayout,
+		clientRender
+	);
+	page(
+	    '/jetpack/connect/vaultpress/:intervalType',
+		jetpackConnectController.vaultpressLanding,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+	    '/jetpack/connect/akismet',
+		jetpackConnectController.akismetLanding,
+		makeLayout,
+		clientRender
+	);
+	page(
+	    '/jetpack/connect/akismet/:intervalType',
+		jetpackConnectController.akismetLanding,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+	    '/jetpack/connect/:locale?',
 		jetpackConnectController.redirectWithoutLocaleifLoggedIn,
-		jetpackConnectController.connect
+		jetpackConnectController.connect,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		'/jetpack/connect/plans/:site',
+	    '/jetpack/connect/plans/:site',
 		sitesController.siteSelection,
-		jetpackConnectController.plansSelection
+		jetpackConnectController.plansSelection,
+		makeLayout,
+		clientRender
 	);
 
 	page(
-		'/jetpack/connect/plans/:intervalType/:site',
+	    '/jetpack/connect/plans/:intervalType/:site',
 		sitesController.siteSelection,
-		jetpackConnectController.plansSelection
+		jetpackConnectController.plansSelection,
+		makeLayout,
+		clientRender
 	);
 
-	page( '/jetpack/sso/:siteId?/:ssoNonce?', jetpackConnectController.sso );
-	page( '/jetpack/sso/*', jetpackConnectController.sso );
-};
+	page(
+	    '/jetpack/sso/:siteId?/:ssoNonce?',
+		jetpackConnectController.sso,
+		makeLayout,
+		clientRender
+	);
+	page('/jetpack/sso/*', jetpackConnectController.sso, makeLayout, clientRender);
+}

--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -14,7 +14,6 @@ import i18n from 'i18n-calypso';
 import JetpackConnect from './index';
 import JetpackConnectAuthorizeForm from './authorize-form';
 import { setSection } from 'state/ui/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 import { JETPACK_CONNECT_QUERY_SET } from 'state/action-types';
 import userFactory from 'lib/user';
 import jetpackSSOForm from './sso';
@@ -44,17 +43,13 @@ const jetpackConnectFirstStep = ( context, type ) => {
 
 	userModule.fetch();
 
-	renderWithReduxStore(
-		React.createElement( JetpackConnect, {
-			path: context.path,
-			context: context,
-			type: type,
-			userModule: userModule,
-			locale: context.params.locale
-		} ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
+	context.primary = React.createElement( JetpackConnect, {
+		path: context.path,
+		context: context,
+		type: type,
+		userModule: userModule,
+		locale: context.params.locale
+	} );
 };
 
 const getPlansLandingPage = ( context, hideFreePlan, path, landingType ) => {
@@ -152,8 +147,8 @@ export default {
 		jetpackConnectFirstStep( context, false );
 	},
 
-	authorizeForm( context ) {
-		const analyticsBasePath = 'jetpack/connect/authorize',
+	authorizeForm(context, next) {
+	    const analyticsBasePath = 'jetpack/connect/authorize',
 			analyticsPageTitle = 'Jetpack Authorize';
 
 		removeSidebar( context );
@@ -171,19 +166,16 @@ export default {
 		}
 
 		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
-		renderWithReduxStore(
-			<JetpackConnectAuthorizeForm
-				path={ context.path }
-				intervalType={ intervalType }
-				locale={ locale }
-				userModule={ userModule } />,
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = <JetpackConnectAuthorizeForm
+			path={ context.path }
+			intervalType={ intervalType }
+			locale={ locale }
+			userModule={ userModule } />;
+		next();
 	},
 
-	sso( context ) {
-		const analyticsBasePath = '/jetpack/sso',
+	sso(context, next) {
+	    const analyticsBasePath = '/jetpack/sso',
 			analyticsPageTitle = 'Jetpack SSO';
 
 		removeSidebar( context );
@@ -192,17 +184,14 @@ export default {
 
 		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
 
-		renderWithReduxStore(
-			React.createElement( jetpackSSOForm, {
-				path: context.path,
-				locale: context.params.locale,
-				userModule: userModule,
-				siteId: context.params.siteId,
-				ssoNonce: context.params.ssoNonce
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( jetpackSSOForm, {
+			path: context.path,
+			locale: context.params.locale,
+			userModule: userModule,
+			siteId: context.params.siteId,
+			ssoNonce: context.params.ssoNonce
+		} );
+		next();
 	},
 
 	vaultpressLanding( context ) {
@@ -217,8 +206,8 @@ export default {
 		getPlansLandingPage( context, false, '/jetpack/connect/store', 'jetpack' );
 	},
 
-	plansSelection( context ) {
-		const Plans = require( './plans' ),
+	plansSelection(context, next) {
+	    const Plans = require( './plans' ),
 			CheckoutData = require( 'components/data/checkout' ),
 			state = context.store.getState(),
 			siteId = getSelectedSiteId( state ),
@@ -239,21 +228,18 @@ export default {
 		analytics.tracks.recordEvent( 'calypso_plans_view' );
 		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
 
-		renderWithReduxStore(
-			<CheckoutData>
-				<Plans
-					context={ context }
-					destinationType={ context.params.destinationType }
-					basePlansPath={ '/jetpack/connect/plans' }
-					intervalType={ context.params.intervalType } />
-			</CheckoutData>,
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = <CheckoutData>
+			<Plans
+				context={ context }
+				destinationType={ context.params.destinationType }
+				basePlansPath={ '/jetpack/connect/plans' }
+				intervalType={ context.params.intervalType } />
+		</CheckoutData>;
+		next();
 	},
 
-	plansPreSelection( context ) {
-		const Plans = require( './plans' ),
+	plansPreSelection(context, next) {
+	    const Plans = require( './plans' ),
 			analyticsPageTitle = 'Plans',
 			basePath = route.sectionify( context.path ),
 			analyticsBasePath = basePath + '/:site';
@@ -261,13 +247,10 @@ export default {
 		analytics.tracks.recordEvent( 'calypso_plans_view' );
 		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
 
-		renderWithReduxStore(
-			<Plans
-				context={ context }
-				showFirst={ true }
-				destinationType={ context.params.destinationType } />,
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = <Plans
+			context={ context }
+			showFirst={ true }
+			destinationType={ context.params.destinationType } />;
+		next();
 	},
 };

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -617,8 +617,7 @@ export function isPremiumThemeAvailable( state, themeId, siteId ) {
 export function isThemeAvailableOnJetpackSite( state, themeId, siteId ) {
 	return !! getTheme( state, siteId, themeId ) || ( // The theme is already available or...
 		isWpcomTheme( state, themeId ) && (  // ...it's a WP.com theme and...
-			config.isEnabled( 'manage/themes/upload' ) &&
-			hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId ) // ...the site supports theme installation from WP.com.
+			(config.isEnabled( 'manage/themes/upload' ) && hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId )) // ...the site supports theme installation from WP.com.
 		)
 	);
 }


### PR DESCRIPTION
This is a Proof-of-Concept PR for trying out single-tree rendering. It is mostly the result of running the codemod found at #18231 ~https://gist.github.com/ockham/54159b8072ffb57da012b5bea3ac564d — or later revisions: I will try to keep this PR up-to-date with the latest state of that codemod~.

TODO:

- [x] Append [makeLayout](https://github.com/Automattic/wp-calypso/blob/0ada6677e27a9f233576250a5340ad594662bb93/client/controller/index.web.js#L49) and [render](https://github.com/Automattic/wp-calypso/blob/0ada6677e27a9f233576250a5340ad594662bb93/client/controller/index.web.js#L69-L73) middlewares to `page` route definitions so this actually renders anything 😄 
- [x] Drop `renderWithReduxStore` 
- [ ] Maybe also transform `ReactDom.render` calls, unless they all end up transformed to `renderWithReduxStore`
- [x] Fix whitespace: `prettier` can do that for us.

Rough roadmap:
I think we'll do the actual migration of our codebase to STR in slices, because it'll be a nightmare to test otherwise. This means we'll have to add each STR'd section [here](https://github.com/Automattic/wp-calypso/blob/c88d20a077df3b2ee0676a39e211a1ec57f9d3b4/client/boot/index.js#L405) as we go along.
However, to make an informed decision (and to be able to get some perf measurements), we need this PR to migrate at least a number of sections so we can switch back and forth between them.

* Use `commonjs-imports` codemod to change `var = require(...)`s to `import`s since the STR codemod can't handle the former gracefully.
* When we're all done, drop this (776ce1f0c4bf31e4a120705f4272eef69d12f93d does this): https://github.com/Automattic/wp-calypso/blob/c88d20a077df3b2ee0676a39e211a1ec57f9d3b4/client/boot/index.js#L393-L419

cc @ehg @gziolo @jsnmoon since you might be interested in this (or codemods in general)