### PR TITLE
Site Settings: Remove need for sanitizing and normalizing Mobile Theme settings values

### DIFF
--- a/client/state/jetpack/settings/test/fixture.js
+++ b/client/state/jetpack/settings/test/fixture.js
@@ -3,8 +3,8 @@ export const settings = {
 		setting_1: 4321,
 		setting_2: false,
 		setting_10: 'test',
-		wp_mobile_excerpt: 'disabled',
-		wp_mobile_featured_images: 'enabled',
+		wp_mobile_excerpt: false,
+		wp_mobile_featured_images: true,
 	},
 	87654321: {
 		setting_1: 1234,
@@ -18,9 +18,7 @@ export const settings = {
 export const normalizedSettings = {
 	...settings,
 	12345678: {
-		...settings[ 12345678 ],
-		wp_mobile_excerpt: false,
-		wp_mobile_featured_images: true,
+		...settings[ 12345678 ]
 	}
 };
 

--- a/client/state/jetpack/settings/test/reducer.js
+++ b/client/state/jetpack/settings/test/reducer.js
@@ -207,7 +207,7 @@ describe( 'reducer', () => {
 							active: true,
 							options: {
 								wp_mobile_excerpt: {
-									current_value: 'enabled',
+									current_value: true,
 								},
 								some_other_option: {
 									current_value: '123',

--- a/client/state/jetpack/settings/test/utils.js
+++ b/client/state/jetpack/settings/test/utils.js
@@ -20,46 +20,6 @@ describe( 'utils', () => {
 			} );
 		} );
 
-		it( 'should convert wp_mobile_excerpt to true if it is "enabled"', () => {
-			const settings = {
-				wp_mobile_excerpt: 'enabled'
-			};
-
-			expect( normalizeSettings( settings ) ).to.eql( {
-				wp_mobile_excerpt: true
-			} );
-		} );
-
-		it( 'should convert wp_mobile_excerpt to false if it is "disabled"', () => {
-			const settings = {
-				wp_mobile_excerpt: 'disabled'
-			};
-
-			expect( normalizeSettings( settings ) ).to.eql( {
-				wp_mobile_excerpt: false
-			} );
-		} );
-
-		it( 'should convert wp_mobile_featured_images to true if it is "enabled"', () => {
-			const settings = {
-				wp_mobile_featured_images: 'enabled'
-			};
-
-			expect( normalizeSettings( settings ) ).to.eql( {
-				wp_mobile_featured_images: true
-			} );
-		} );
-
-		it( 'should convert wp_mobile_featured_images to false if it is "disabled"', () => {
-			const settings = {
-				wp_mobile_featured_images: 'disabled'
-			};
-
-			expect( normalizeSettings( settings ) ).to.eql( {
-				wp_mobile_featured_images: false
-			} );
-		} );
-
 		it( 'should convert carousel_background_color to "black" if it is an empty string', () => {
 			const settings = {
 				carousel_background_color: ''
@@ -126,46 +86,6 @@ describe( 'utils', () => {
 
 			expect( sanitizeSettings( settings ) ).to.eql( {
 				some_random_setting: 'example'
-			} );
-		} );
-
-		it( 'should convert wp_mobile_excerpt to "enabled" if it is true', () => {
-			const settings = {
-				wp_mobile_excerpt: true
-			};
-
-			expect( sanitizeSettings( settings ) ).to.eql( {
-				wp_mobile_excerpt: 'enabled'
-			} );
-		} );
-
-		it( 'should convert wp_mobile_excerpt to "disabled" if it is false', () => {
-			const settings = {
-				wp_mobile_excerpt: false
-			};
-
-			expect( sanitizeSettings( settings ) ).to.eql( {
-				wp_mobile_excerpt: 'disabled'
-			} );
-		} );
-
-		it( 'should convert wp_mobile_featured_images to "enabled" if it is true', () => {
-			const settings = {
-				wp_mobile_featured_images: true
-			};
-
-			expect( sanitizeSettings( settings ) ).to.eql( {
-				wp_mobile_featured_images: 'enabled'
-			} );
-		} );
-
-		it( 'should convert wp_mobile_featured_images to "disabled" if it is false', () => {
-			const settings = {
-				wp_mobile_featured_images: false
-			};
-
-			expect( sanitizeSettings( settings ) ).to.eql( {
-				wp_mobile_featured_images: 'disabled'
 			} );
 		} );
 

--- a/client/state/jetpack/settings/utils.js
+++ b/client/state/jetpack/settings/utils.js
@@ -12,10 +12,6 @@ import { forEach, get, omit } from 'lodash';
 export const normalizeSettings = ( settings ) => {
 	return Object.keys( settings ).reduce( ( memo, key ) => {
 		switch ( key ) {
-			case 'wp_mobile_excerpt':
-			case 'wp_mobile_featured_images':
-				memo[ key ] = settings[ key ] === 'enabled';
-				break;
 			case 'carousel_background_color':
 				memo[ key ] = settings [ key ] === '' ? 'black' : settings[ key ];
 				break;
@@ -40,10 +36,6 @@ export const normalizeSettings = ( settings ) => {
 export const sanitizeSettings = ( settings ) => {
 	return Object.keys( settings ).reduce( ( memo, key ) => {
 		switch ( key ) {
-			case 'wp_mobile_excerpt':
-			case 'wp_mobile_featured_images':
-				memo[ key ] = !! settings [ key ] ? 'enabled' : 'disabled';
-				break;
 			case 'post_by_email_address':
 				break;
 			default:


### PR DESCRIPTION
This PR removes the mapping of `enabled`/`disabled` values to booleans that was done on save and on fetch of a site's settings. 

This PR will fix an issue for Jetpack 4.8+ sites but drops compatibility with Jetpack 4.7 and lower versions. This is addressed on #13241 that depends on the changes introduced here. 

#### Testing instructions

1. Visit `/settings/writing` for a Jetpack Site (With Jetpack 4.8.x)
1. On the **Theme Enhancements** card make sure the setting `Optimize your site with a mobile-friendly theme for tablets and phones` is on. 
1. Toggle `Hide all featured images` and confirm that it shows a success notice.
1. Refresh the page and check that the change persisted.

Also, verify the tests pass.

```sh
$ npm run test-client client/state/jetpack
```

FIxes Automattic/Jetpack#6737

#### Why

It looks better to create a small PR to fix this for the freshly released Jetpack 4.8 and handle the backwards compatibility in [another PR](13241).