### PR TITLE
Editor: Performance Improvements for wplink

### DIFF
--- a/client/components/tinymce/plugins/wplink/dialog.jsx
+++ b/client/components/tinymce/plugins/wplink/dialog.jsx
@@ -48,7 +48,8 @@ var LinkDialog = React.createClass( {
 
 	getDefaultProps() {
 		return {
-			onClose: () => {}
+			onClose: () => {},
+			firstLoad: false,
 		};
 	},
 

--- a/client/components/tinymce/plugins/wplink/dialog.jsx
+++ b/client/components/tinymce/plugins/wplink/dialog.jsx
@@ -38,7 +38,8 @@ var LinkDialog = React.createClass( {
 		editor: PropTypes.object,
 		onClose: PropTypes.func,
 		site: PropTypes.object,
-		sitePosts: PropTypes.array
+		sitePosts: PropTypes.array,
+		firstLoad: PropTypes.bool,
 	},
 
 	getInitialState: function() {
@@ -351,6 +352,7 @@ var LinkDialog = React.createClass( {
 								order="DESC"
 								selected={ this.getSelectedPostId() }
 								onChange={ this.setExistingContent }
+								surpressFirstPageLoad={ ! this.props.firstLoad }
 								emptyMessage={ this.translate( 'No posts found' ) } />
 						) }
 					</FormLabel>

--- a/client/components/tinymce/plugins/wplink/dialog.jsx
+++ b/client/components/tinymce/plugins/wplink/dialog.jsx
@@ -353,7 +353,7 @@ var LinkDialog = React.createClass( {
 								order="DESC"
 								selected={ this.getSelectedPostId() }
 								onChange={ this.setExistingContent }
-								surpressFirstPageLoad={ ! this.props.firstLoad }
+								suppressFirstPageLoad={ ! this.props.firstLoad }
 								emptyMessage={ this.translate( 'No posts found' ) } />
 						) }
 					</FormLabel>

--- a/client/components/tinymce/plugins/wplink/plugin.js
+++ b/client/components/tinymce/plugins/wplink/plugin.js
@@ -8,19 +8,19 @@
 /**
  * External dependencies
  */
-var ReactDom = require( 'react-dom' ),
-	React = require( 'react' ),
-	tinymce = require( 'tinymce/tinymce' ),
-	translate = require( 'i18n-calypso' ).translate;
+import ReactDom from 'react-dom';
+import React from 'react';
+import tinymce from 'tinymce/tinymce';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var LinkDialog = require( './dialog' );
+import LinkDialog from './dialog';
 import { renderWithReduxStore } from 'lib/react-helpers';
 
 function wpLink( editor ) {
-	var node, toolbar, firstLoadComplete;
+	let node, toolbar, firstLoadComplete;
 
 	function render( visible = true ) {
 		renderWithReduxStore(
@@ -86,7 +86,7 @@ function wpLink( editor ) {
 	} );
 
 	editor.on( 'pastepreprocess', function( event ) {
-		var pastedStr = event.content;
+		let pastedStr = event.content;
 
 		if ( ! editor.selection.isCollapsed() ) {
 			pastedStr = pastedStr.replace( /<[^>]+>/g, '' );
@@ -116,7 +116,7 @@ function wpLink( editor ) {
 			);
 		},
 		setURL: function( url ) {
-			var index, lastIndex;
+			let index, lastIndex;
 
 			if ( this.url !== url ) {
 				this.url = url;
@@ -140,7 +140,10 @@ function wpLink( editor ) {
 				}
 
 				// If the URL is longer that 40 chars, concatenate the beginning (after the domain) and ending with ...
-				if ( url.length > 40 && ( index = url.indexOf( '/' ) ) !== -1 && ( lastIndex = url.lastIndexOf( '/' ) ) !== -1 && lastIndex !== index ) {
+				if ( url.length > 40 &&
+					( index = url.indexOf( '/' ) ) !== -1 &&
+					( lastIndex = url.lastIndexOf( '/' ) ) !== -1 &&
+					lastIndex !== index ) {
 					// If the beginning + ending are shorter that 40 chars, show more of the ending
 					if ( index + url.length - lastIndex < 40 ) {
 						lastIndex = -( 40 - ( index + 1 ) );
@@ -157,12 +160,12 @@ function wpLink( editor ) {
 	editor.addButton( 'wp_link_preview', {
 		type: 'WPLinkPreview',
 		onPostRender: function() {
-			var self = this;
+			const self = this;
 
 			editor.on( 'wptoolbar', function( event ) {
-				var anchor = editor.dom.getParent( event.element, 'a' ),
-					$anchor,
-					href;
+				const anchor = editor.dom.getParent( event.element, 'a' );
+				let $anchor;
+				let href;
 
 				if ( anchor ) {
 					$anchor = editor.$( anchor );

--- a/client/components/tinymce/plugins/wplink/plugin.js
+++ b/client/components/tinymce/plugins/wplink/plugin.js
@@ -20,18 +20,22 @@ var LinkDialog = require( './dialog' );
 import { renderWithReduxStore } from 'lib/react-helpers';
 
 function wpLink( editor ) {
-	var node, toolbar;
+	var node, toolbar, firstLoadComplete;
 
 	function render( visible = true ) {
 		renderWithReduxStore(
 			React.createElement( LinkDialog, {
 				visible: visible,
 				editor: editor,
+				firstLoad: ! firstLoadComplete,
 				onClose: () => render( false )
 			} ),
 			node,
 			editor.getParam( 'redux_store' )
 		);
+		if ( visible ) {
+			firstLoadComplete = true;
+		}
 
 		if ( ! visible ) {
 			editor.focus();

--- a/client/my-sites/post-selector/index.jsx
+++ b/client/my-sites/post-selector/index.jsx
@@ -28,7 +28,8 @@ export default React.createClass( {
 		createLink: PropTypes.string,
 		orderBy: PropTypes.oneOf( [ 'title', 'date', 'modified', 'comment_count', 'ID' ] ),
 		order: PropTypes.oneOf( [ 'ASC', 'DESC' ] ),
-		showTypeLabels: PropTypes.bool
+		showTypeLabels: PropTypes.bool,
+		surpressFirstPageLoad: PropTypes.bool,
 	},
 
 	getDefaultProps() {
@@ -37,7 +38,8 @@ export default React.createClass( {
 			status: 'publish,private',
 			multiple: false,
 			orderBy: 'title',
-			order: 'ASC'
+			order: 'ASC',
+			surpressFirstPageLoad: false,
 		};
 	},
 
@@ -64,13 +66,22 @@ export default React.createClass( {
 				return memo;
 			}
 
+			// if we don't have a search term, default to ordering by date
+			if ( key === 'orderBy' && search !== '' ) {
+				value = 'date';
+			}
+
+			if ( key === 'order' && search !== '' ) {
+				value = 'DESC';
+			}
+
 			memo[ snakeCase( key ) ] = value;
 			return memo;
 		}, {} );
 	},
 
 	render() {
-		const { siteId, multiple, onChange, emptyMessage, createLink, selected, showTypeLabels } = this.props;
+		const { siteId, multiple, onChange, emptyMessage, createLink, selected, showTypeLabels, surpressFirstPageLoad } = this.props;
 
 		return (
 			<PostSelectorPosts
@@ -83,6 +94,7 @@ export default React.createClass( {
 				createLink={ createLink }
 				selected={ selected }
 				showTypeLabels={ showTypeLabels }
+				surpressFirstPageLoad={ surpressFirstPageLoad }
 			/>
 		);
 	}

--- a/client/my-sites/post-selector/index.jsx
+++ b/client/my-sites/post-selector/index.jsx
@@ -29,7 +29,7 @@ export default React.createClass( {
 		orderBy: PropTypes.oneOf( [ 'title', 'date', 'modified', 'comment_count', 'ID' ] ),
 		order: PropTypes.oneOf( [ 'ASC', 'DESC' ] ),
 		showTypeLabels: PropTypes.bool,
-		surpressFirstPageLoad: PropTypes.bool,
+		suppressFirstPageLoad: PropTypes.bool,
 	},
 
 	getDefaultProps() {
@@ -39,7 +39,7 @@ export default React.createClass( {
 			multiple: false,
 			orderBy: 'title',
 			order: 'ASC',
-			surpressFirstPageLoad: false,
+			suppressFirstPageLoad: false,
 		};
 	},
 
@@ -81,7 +81,7 @@ export default React.createClass( {
 	},
 
 	render() {
-		const { siteId, multiple, onChange, emptyMessage, createLink, selected, showTypeLabels, surpressFirstPageLoad } = this.props;
+		const { siteId, multiple, onChange, emptyMessage, createLink, selected, showTypeLabels, suppressFirstPageLoad } = this.props;
 
 		return (
 			<PostSelectorPosts
@@ -94,7 +94,7 @@ export default React.createClass( {
 				createLink={ createLink }
 				selected={ selected }
 				showTypeLabels={ showTypeLabels }
-				surpressFirstPageLoad={ surpressFirstPageLoad }
+				suppressFirstPageLoad={ suppressFirstPageLoad }
 			/>
 		);
 	}

--- a/client/my-sites/post-selector/selector.jsx
+++ b/client/my-sites/post-selector/selector.jsx
@@ -41,7 +41,7 @@ import QueryPosts from 'components/data/query-posts';
 /**
  * Constants
  */
-const SEARCH_DEBOUNCE_TIME_MS = 500;
+const SEARCH_DEBOUNCE_TIME_MS = 800;
 const ITEM_HEIGHT = 25;
 const DEFAULT_POSTS_PER_PAGE = 20;
 const LOAD_OFFSET = 10;
@@ -395,7 +395,7 @@ const PostSelectorPosts = React.createClass( {
 	},
 
 	render() {
-		const { className, siteId, queryWithVersion } = this.props;
+		const { className, siteId, queryWithVersion, suppressFirstPageLoad, posts, postTypes } = this.props;
 		const { requestedPages, searchTerm } = this.state;
 		const isCompact = this.isCompact();
 		const isTypeLabelsVisible = this.isTypeLabelsVisible();
@@ -405,15 +405,22 @@ const PostSelectorPosts = React.createClass( {
 			'is-type-labels-visible': isTypeLabelsVisible
 		} );
 
+		const pagesToRequest = filter( requestedPages, ( page ) => {
+			if ( page !== 1 || ! suppressFirstPageLoad ) {
+				return true;
+			}
+			return ! posts;
+		} );
+
 		return (
 			<div className={ classes }>
-				{ requestedPages.map( ( page ) => (
+				{ pagesToRequest.map( ( page ) => (
 					<QueryPosts
 						key={ `page-${ page }` }
 						siteId={ siteId }
 						query={ { ...queryWithVersion, page } } />
 				) ) }
-				{ isTypeLabelsVisible && siteId && (
+				{ isTypeLabelsVisible && siteId && ! postTypes && (
 					<QueryPostTypes siteId={ siteId } />
 				) }
 				{ showSearch && (


### PR DESCRIPTION
This branch seeks to close #12481 by implementing a few performance enhancements to the `wplink` TinyMCE plugin.  The original issue was reported around 3 months ago in the forums by a user who has a site with over 1600 posts.

The user supplied a video showing the issue in action, which involves opening the link dialog multiple times in the same post, and how over time, the action continually gets slower.  While digging in to the problem I noticed that each time the link dialog is opened, we request the first page of posts for the site to populate the recent posts list.  This request can be quite slow on sites with a large number of posts.

Additionally, we do a request for `postTypes` each time the dialog is opened.

__To Reproduce__
It is best to play around on a site with a large number of posts to experience the sluggish behavior.  I used en.blog myself, and sandboxing the API really shows the slow behavior further.  Just open up the editor, and click the link button in the MCE toolbar multiple times.  Note that you can't really even cancel out of the dialog by clicking on the "Cancel" button immediately after it opens.

__Proposed Solution__
In this branch I've added logic to track if the wplink dialog has been shown once already, and as such the first page of posts have been fetched once already.  On subsequent displays of the dialog, a prop is passed to `<PostSelector />` to `surpressFirstPageLoad` if the API request has already taken place, and `posts` have been returned from the state tree for the first page of posts.

Also, the `QueryPostTypes` call is only done if no `postTypes` are passed in as a prop.  Even though the `postTypes` API call is a fast one, I figure it is worth preventing un-needed calls.

I also added logic to `getQuery` in the `PostSelector` to order search queries by `date` in an effort to mimic the search results seen in wp-admin.  I haven't been able to get the results to fully match what happens in wp-admin, but I think that is due to the API passing in more arguments to `WP_Query` - but I didn't fully go down that 🐰 🕳 

The last change I am proposing here is increasing the debounce time on the search field in the `<PostSelector />` by 300ms.  Just to _filter_ out potential API requests if someone types in the search field slower.

__To Test__
- Open the editor for a site with a large number of posts
- Have your network tab open in your browser's console
- Open the `wplink` dialog, note an API request is sent to get a list of posts for the site
- clear out your network tab, close the dialog, and open it again.  Note that no API requests should be sent for posts or postTypes
- Perform some searches in the dialog and verify that still works as expected