### PR TITLE
Update i18n-calypso to improve Localize component naming

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1854,7 +1854,7 @@
       "version": "0.0.0"
     },
     "i18n-calypso": {
-      "version": "1.7.0",
+      "version": "1.7.1",
       "dependencies": {
         "async": {
           "version": "1.5.2"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "hard-source-webpack-plugin": "0.0.42",
     "he": "0.5.0",
     "html-loader": "0.4.0",
-    "i18n-calypso": "1.7.0",
+    "i18n-calypso": "1.7.1",
     "immutable": "3.7.6",
     "imports-loader": "0.6.5",
     "inherits": "2.0.1",


### PR DESCRIPTION
Localize HOC in i18n-calypso was not aligned with the way `react-redux` and other HOC naming is done. Until now localized component X go the name LocalizeX and from now it will be Localize(X).

This makes it easier to distinguish between the `Localize` HOC and the component it wraps when using tools such as `React DevTool` or `React Perf`.

React DevTools @ 1.7.0
![before](https://cloud.githubusercontent.com/assets/25921241/24325770/25c010ea-11b1-11e7-86e3-bdcd02098160.png)

React DevTool @ 1.7.1
![after](https://cloud.githubusercontent.com/assets/25921241/24325773/31556324-11b1-11e7-953e-a89ede4dfe49.png)

**To Test**
Open [Chrome React DevTools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi), inspect element such as MySitesSidebar or StatsModuleChartTabs (and select React tab again in the DevTools) to see the component tree.