### PR TITLE
Desktop: Add convenience make commands to root Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,13 @@ docker-run:
 	@echo running wp-calypso docker image at localhost:3000
 	docker run -it --name wp-calypso --rm -p 80:3000 -e NODE_ENV='wpcalypso' -e CALYPSO_ENV='wpcalypso' wp-calypso
 
+# Desktop specific tasks
+# These are just convenience commands that run tasks from desktop/Makefile
+desktop-run:
+	@cd desktop; make run
+
+desktop-test:
+	@cd desktop; make test
 
 # rule that can be used as a prerequisite for other rules to force them to always run
 FORCE:


### PR DESCRIPTION
*Note that this is based on a branch that is still open as PR @ #12430*

This PR aims to add 'convenience' commands to the projects main Makefile that essentially just run commands from within `/desktop`.

Personally, I feel it makes sense for the desktop Makefile kept separate instead of merging the two - just for the sake of keeping the main Makefile smaller and cleaner. These commands would allow for this while avoiding a developer having to manually `cd` in to `/desktop` each time they wish to build or test.