### PR TITLE
Desktop: Improve Webpack resolve configuration

### DIFF
--- a/desktop/webpack.shared.js
+++ b/desktop/webpack.shared.js
@@ -47,14 +47,15 @@ module.exports = {
 		'devdocs/components-usage-stats.json'
 	],
 	resolve: {
-		extensions: [ '', '.js', '.jsx' ],
+		extensions: [ '', '.js', '.json', '.jsx' ],
 		modulesDirectories: [
 			'node_modules',
+		],
+		root: [
 			path.join( __dirname, '..', 'server' ),
 			path.join( __dirname, '..', 'client' ),
-			'desktop'
+			path.join( __dirname, 'desktop' ),
 		],
-
 	},
 	plugins: [
 		// new webpack.optimize.DedupePlugin(),


### PR DESCRIPTION
The aim of these changes is to improve the `resolve` configuration of desktops `webpack.config.js`.
Though `moduleDirectories` works for us, it's not quite the correct place to place our application code - instead, these should configured as `root` modules.
There's a better explanation in this thread https://github.com/webpack/webpack/issues/472, but here is the main take away:

> resolve.root is an absolute path to a directory containing modules.
resolve.moduleDirectories is an relative path to a tree of directories containing modules.

As a happy side effect, these changes actually give us a decent (~6-11%) reduction in bundle processing time due to the way Webpack attempts to resolve paths using paths within `modulesDirectories` (check out this comment https://github.com/webpack/webpack/issues/472#issuecomment-168351291 for some insight).
By running webpack builds with & without these changes a few times I got these timings:

| Before  | After | Speedup | % |
| ------- | ------- | --- | --- |
| 29906ms | 26372ms | 3534 ms | 11.8% |
| 26095ms | 23790ms | 2305 ms | 8.83% |
| 25796ms | 23594ms | 2202 ms | 8.54% |
| 25676ms | 23645ms | 2031 ms | 7.91% |
| 25644ms | 23990ms | 1654 ms | 6.45% |

For anybody interested in running the build themselves (run from `/desktop`), make sure to include the `NODE_PATH`:

```cli
NODE_PATH=../server:../client webpack --config webpack.config.js
```

```js
extensions: [ '', '.js', '.json', '.jsx' ],
```

Ideally we wouldn't need to add `.json` to the `resolve.extensions` array but there's an issue with resolving a json file in `node-wpcom-oauth` otherwise.
I have a PR open that should fix the reference (https://github.com/Automattic/node-wpcom-oauth/pull/12) and allow us to remove `.json` from the list of extensions.



