### PR TITLE
Reader: Set width on combined-card.

### DIFF
--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -231,6 +231,7 @@
 	margin: 0 15px;
 	padding: 18px 0 0;
 	position: relative;
+	width: 100%;
 
 	@include breakpoint( ">660px" ) {
 		margin: 0;


### PR DESCRIPTION
This PR fixes the issue in #12480 where combined-card cards with no excerpt are not displaying at 100% width.

**After** 

![screen shot 2017-03-27 at 1 01 30 pm](https://cloud.githubusercontent.com/assets/2627210/24337991/8b2c184c-12ed-11e7-9984-6a034feb9e14.png)
