### PR TITLE
Reinstate signup survey

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -69,4 +69,12 @@ module.exports = {
 		defaultVariation: 'showOld',
 		allowExistingUsers: true
 	},
+	signupSurveyStep: {
+		datestamp: '20170327',
+		variations: {
+			showSurveyStep: 20,
+			hideSurveyStep: 80,
+		},
+		defaultVariation: 'hideSurveyStep',
+	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -70,7 +70,7 @@ module.exports = {
 		allowExistingUsers: true
 	},
 	signupSurveyStep: {
-		datestamp: '20170327',
+		datestamp: '20170329',
 		variations: {
 			showSurveyStep: 20,
 			hideSurveyStep: 80,

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -119,14 +119,18 @@ const flows = {
 	website: {
 		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
-		description: 'This flow was originally used for the users who clicked "Create Website" on the two-button homepage. It is now linked to from the default homepage CTA as the main flow was slightly behind given translations.',
+		description: 'This flow was originally used for the users who clicked "Create Website" ' +
+			'on the two-button homepage. It is now linked to from the default homepage CTA as ' +
+			'the main flow was slightly behind given translations.',
 		lastModified: '2016-05-23'
 	},
 
 	blog: {
 		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
-		description: 'This flow was originally used for the users who clicked "Create Blog" on the two-button homepage. It is now used from blog-specific landing pages so that verbiage in survey steps refers to "blog" instead of "website".',
+		description: 'This flow was originally used for the users who clicked "Create Blog" on ' +
+			'the two-button homepage. It is now used from blog-specific landing pages so that ' +
+			'verbiage in survey steps refers to "blog" instead of "website".',
 		lastModified: '2016-05-23'
 	},
 
@@ -149,21 +153,24 @@ const flows = {
 	'delta-discover': {
 		steps: [ 'user' ],
 		destination: '/',
-		description: 'A copy of the `account` flow for the Delta email campaigns. Half of users who go through this flow receive a reader-specific drip email series.',
+		description: 'A copy of the `account` flow for the Delta email campaigns. Half of users who ' +
+			'go through this flow receive a reader-specific drip email series.',
 		lastModified: '2016-05-03'
 	},
 
 	'delta-blog': {
 		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
-		description: 'A copy of the `blog` flow for the Delta email campaigns. Half of users who go through this flow receive a blogging-specific drip email series.',
+		description: 'A copy of the `blog` flow for the Delta email campaigns. Half of users who go ' +
+			'through this flow receive a blogging-specific drip email series.',
 		lastModified: '2016-03-09'
 	},
 
 	'delta-site': {
 		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
-		description: 'A copy of the `website` flow for the Delta email campaigns. Half of users who go through this flow receive a website-specific drip email series.',
+		description: 'A copy of the `website` flow for the Delta email campaigns. Half of users who go ' +
+			'through this flow receive a website-specific drip email series.',
 		lastModified: '2016-03-09'
 	},
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -58,7 +58,7 @@ const flows = {
 	},
 
 	business: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'user' ],
+		steps: [ 'design-type', 'themes', 'domains', 'user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/business/' + dependencies.siteSlug;
 		},
@@ -70,7 +70,7 @@ const flows = {
 	},
 
 	premium: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'user' ],
+		steps: [ 'design-type', 'themes', 'domains', 'user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/premium/' + dependencies.siteSlug;
 		},
@@ -82,7 +82,7 @@ const flows = {
 	},
 
 	free: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'user' ],
+		steps: [ 'design-type', 'themes', 'domains', 'user' ],
 		destination: getSiteDestination,
 		description: 'Create an account and a blog and default to the free plan.',
 		lastModified: '2016-06-02'
@@ -103,7 +103,7 @@ const flows = {
 	},
 
 	main: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'The current best performing flow in AB tests',
 		lastModified: '2016-05-23'
@@ -117,7 +117,7 @@ const flows = {
 	},
 
 	website: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'This flow was originally used for the users who clicked "Create Website" ' +
 			'on the two-button homepage. It is now linked to from the default homepage CTA as ' +
@@ -126,7 +126,7 @@ const flows = {
 	},
 
 	blog: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'This flow was originally used for the users who clicked "Create Blog" on ' +
 			'the two-button homepage. It is now used from blog-specific landing pages so that ' +
@@ -135,7 +135,7 @@ const flows = {
 	},
 
 	personal: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'user' ],
+		steps: [ 'design-type', 'themes', 'domains', 'user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/personal/' + dependencies.siteSlug;
 		},
@@ -159,7 +159,7 @@ const flows = {
 	},
 
 	'delta-blog': {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'A copy of the `blog` flow for the Delta email campaigns. Half of users who go ' +
 			'through this flow receive a blogging-specific drip email series.',
@@ -167,7 +167,7 @@ const flows = {
 	},
 
 	'delta-site': {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'A copy of the `website` flow for the Delta email campaigns. Half of users who go ' +
 			'through this flow receive a website-specific drip email series.',
@@ -175,7 +175,7 @@ const flows = {
 	},
 
 	desktop: {
-		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getPostsDestination,
 		description: 'Signup flow for desktop app',
 		lastModified: '2016-05-30'
@@ -189,7 +189,7 @@ const flows = {
 	},
 
 	pressable: {
-		steps: [ 'survey', 'design-type-with-store', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'design-type-with-store', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'Signup flow for testing the pressable-store step',
 		lastModified: '2016-06-27'
@@ -372,7 +372,7 @@ const Flows = {
 		 */
 		if ( 'main' === flowName ) {
 			if ( '' === stepName ) {
-				// e.g. abtest( 'siteTitleStep' );
+				abtest( 'signupSurveyStep' );
 			}
 		}
 	},
@@ -392,16 +392,9 @@ const Flows = {
 	getABTestFilteredFlow( flowName, flow ) {
 		// Only do this on the main flow
 		if ( 'main' === flowName ) {
-			/* e.g.:
-			if ( getABTestVariation( 'siteTitleStep' ) === 'showSiteTitleStep' ) {
-				return Flows.insertStepIntoFlow( 'site-title', flow );
+			if ( abtest( 'signupSurveyStep' ) === 'showSurveyStep' ) {
+				return Flows.insertStepIntoFlow( 'survey', flow );
 			}
-			*/
-		}
-
-		// no matter the flow
-		if ( abtest( 'signupSurveyStep' ) === 'hideSurveyStep' ) {
-			return Flows.removeStepFromFlow( 'survey', flow );
 		}
 
 		return flow;

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -58,7 +58,7 @@ const flows = {
 	},
 
 	business: {
-		steps: [ 'design-type', 'themes', 'domains', 'user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/business/' + dependencies.siteSlug;
 		},
@@ -70,7 +70,7 @@ const flows = {
 	},
 
 	premium: {
-		steps: [ 'design-type', 'themes', 'domains', 'user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/premium/' + dependencies.siteSlug;
 		},
@@ -82,7 +82,7 @@ const flows = {
 	},
 
 	free: {
-		steps: [ 'design-type', 'themes', 'domains', 'user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'user' ],
 		destination: getSiteDestination,
 		description: 'Create an account and a blog and default to the free plan.',
 		lastModified: '2016-06-02'
@@ -103,7 +103,7 @@ const flows = {
 	},
 
 	main: {
-		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'The current best performing flow in AB tests',
 		lastModified: '2016-05-23'
@@ -117,21 +117,21 @@ const flows = {
 	},
 
 	website: {
-		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'This flow was originally used for the users who clicked "Create Website" on the two-button homepage. It is now linked to from the default homepage CTA as the main flow was slightly behind given translations.',
 		lastModified: '2016-05-23'
 	},
 
 	blog: {
-		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'This flow was originally used for the users who clicked "Create Blog" on the two-button homepage. It is now used from blog-specific landing pages so that verbiage in survey steps refers to "blog" instead of "website".',
 		lastModified: '2016-05-23'
 	},
 
 	personal: {
-		steps: [ 'design-type', 'themes', 'domains', 'user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/personal/' + dependencies.siteSlug;
 		},
@@ -154,21 +154,21 @@ const flows = {
 	},
 
 	'delta-blog': {
-		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'A copy of the `blog` flow for the Delta email campaigns. Half of users who go through this flow receive a blogging-specific drip email series.',
 		lastModified: '2016-03-09'
 	},
 
 	'delta-site': {
-		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'A copy of the `website` flow for the Delta email campaigns. Half of users who go through this flow receive a website-specific drip email series.',
 		lastModified: '2016-03-09'
 	},
 
 	desktop: {
-		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'survey', 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getPostsDestination,
 		description: 'Signup flow for desktop app',
 		lastModified: '2016-05-30'
@@ -182,7 +182,7 @@ const flows = {
 	},
 
 	pressable: {
-		steps: [ 'design-type-with-store', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'survey', 'design-type-with-store', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'Signup flow for testing the pressable-store step',
 		lastModified: '2016-06-27'
@@ -390,6 +390,11 @@ const Flows = {
 				return Flows.insertStepIntoFlow( 'site-title', flow );
 			}
 			*/
+		}
+
+		// no matter the flow
+		if ( abtest( 'signupSurveyStep' ) === 'hideSurveyStep' ) {
+			return Flows.removeStepFromFlow( 'survey', flow );
 		}
 
 		return flow;

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -34,7 +34,7 @@ function getSiteDestination( dependencies ) {
 	 *
 	 * Redirect them
 	 */
-	if ( ! dependencies.siteSlug.match(/wordpress\.[a-z]+$/i) ) {
+	if ( ! dependencies.siteSlug.match( /wordpress\.[a-z]+$/i ) ) {
 		protocol = 'http';
 	}
 


### PR DESCRIPTION
This is an a/b test to reinstate the signup survey step at the beginning of signup flows for 20% of users.

The a/b test is called `signupSurveyStep` (date `20170329`) and has variants `showSurveyStep` (20 % of users) and `hideSurveyStep` (80 of users).

To test, set the `signupSurveyStep` test to `showSurveyStep` and you should see the following on signup (http://calypso.localhost:3000/start):

![screen shot 2017-03-27 at 12 57 15 pm](https://cloud.githubusercontent.com/assets/1926/24339080/fc08c534-12ec-11e7-9206-b5aa5eb9d3d9.png)

Otherwise, you should see the design-type-with-store step:

![screen shot 2017-03-27 at 12 58 53 pm](https://cloud.githubusercontent.com/assets/1926/24339118/297c3f3c-12ed-11e7-9327-e302899ae9dc.png)
