### PR TITLE
Implement new UI for switching languages

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -125,6 +125,7 @@
 @import 'components/info-popover/style';
 @import 'components/input-chrono/style';
 @import 'components/logged-out-form/style';
+@import 'components/language-picker/style';
 @import 'components/main/style';
 @import 'components/marketing-survey/cancel-purchase-form/style';
 @import 'components/mobile-back-to-sidebar/style';

--- a/client/components/language-picker/README.md
+++ b/client/components/language-picker/README.md
@@ -1,0 +1,69 @@
+LanguagePicker
+==============
+
+React component used to display a Language Picker.
+
+---
+
+## Example Usage
+
+```js
+import LanguagePicker from 'components/language-picker';
+
+const languages = [
+	{
+		value: 1,
+		langSlug: 'en',
+		name: 'English',
+		wpLocale: 'en_US',
+		popular: 1
+	},
+	{
+		value: 11,
+		langSlug: 'cs',
+		name: 'Čeština',
+		wpLocale: 'cs_CZ'
+	}
+];
+
+class LanguagePickerDemo {
+	onSelectLanguage = ( event ) => {
+		this.setState( { language: event.target.value } );
+	}
+
+	render() {
+		return (
+			<LanguagePicker
+				languages={ languages }
+				valueKey="langSlug"
+				value={ this.state.language }
+				onChange={ this.onSelectLanguage }
+			/>
+		);
+	}
+}
+```
+
+---
+
+## LanguagePicker
+
+The `LanguagePicker` is a form component with API similar to a HTML `input` or `select`
+element - its value is specified in a `value` prop, and it calls an `onChange` handler
+when its value changes.
+
+#### Props
+
+`languages` - **required** Array with information about languages, their names, language
+slugs, popularity etc. It's exported by `config` module under the `languages` key.
+
+`valueKey` - **optional** Which property of the `languages` objects should be used
+as the `value` of the component? The default is `value`, other options are `langSlug` and
+`wpLocale`. This determines what kind of value is expeced as the `value` property and
+what is the value passed as parameter in the `onChange` handler.
+
+`value` - **optional** The selected value of the language picker
+
+`onChange` - **optional** Handler called when the selected value is changed
+
+------------

--- a/client/components/language-picker/button.jsx
+++ b/client/components/language-picker/button.jsx
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import config from 'config';
+import { getOriginalUserSetting } from 'state/selectors';
+import { saveUserSettings } from 'state/user-settings/actions';
+import { successNotice, errorNotice } from 'state/notices/actions';
+import LanguagePickerModal from './modal';
+
+class LanguageButton extends Component {
+	state = {
+		open: false
+	}
+
+	toggleOpen = () => {
+		this.setState( { open: ! this.state.open } );
+	}
+
+	handleClose = () => {
+		this.setState( { open: false } );
+	}
+
+	selectLanguage = ( newLanguageSlug ) => {
+		if ( newLanguageSlug === this.props.languageSlug ) {
+			return;
+		}
+
+		this.props.saveUserSettings(
+			{ language: newLanguageSlug },
+			successNotice( this.props.translate( 'Your language was changed successfully!' ) ),
+			errorNotice( this.props.translate( 'There was a problem changing your language.' ) )
+			// TODO: window.location = window.location.pathname + '?updated=success';
+		);
+	}
+
+	// TODO: Reorganize the styles and get rid of the eslint errors
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	renderIcon( languageSlug ) {
+		if ( ! languageSlug ) {
+			return <div className="sidebar__footer-lang-icon is-loading" />;
+		}
+
+		const [ langCode, langSubcode ] = languageSlug.split( '-' );
+
+		return (
+			<div className="sidebar__footer-lang-icon">
+				<div>
+					{ langCode }
+					{ langSubcode && <br /> }
+					{ langSubcode }
+				</div>
+			</div>
+		);
+	}
+
+	render() {
+		const { languageSlug, translate } = this.props;
+
+		return (
+			<Button
+				className="sidebar__footer-lang"
+				borderless
+				title={ translate( 'Interface Language' ) }
+				onClick={ this.toggleOpen }
+			>
+				{ this.renderIcon( languageSlug ) }
+				<LanguagePickerModal
+					isVisible={ this.state.open }
+					languages={ config( 'languages' ) }
+					onClose={ this.handleClose }
+					onSelected={ this.selectLanguage }
+					selected={ languageSlug }
+				/>
+			</Button>
+		);
+	}
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
+}
+
+export default connect(
+	state => ( {
+		// Look at the original setting - there might be an unsaved /me/account
+		// form displayed on the page, and we don't want to display the unsaved
+		// change - only the committed one.
+		languageSlug: getOriginalUserSetting( state, 'language' )
+	} ),
+	{ saveUserSettings }
+)( localize( LanguageButton ) );

--- a/client/components/language-picker/docs/example.jsx
+++ b/client/components/language-picker/docs/example.jsx
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import LanguagePicker from 'components/language-picker';
+import Card from 'components/card';
+
+class LanguagePickerExample extends PureComponent {
+	state = {
+		disabled: false,
+		loading: false,
+		language: 'en'
+	}
+
+	selectLanguage = ( event ) => {
+		this.setState( { language: event.target.value } );
+	}
+
+	toggleDisabled = () => {
+		this.setState( { disabled: ! this.state.disabled } );
+	}
+
+	triggerLoading = () => {
+		if ( ! this.state.loading ) {
+			this.setState( { loading: true } );
+			setTimeout( () => this.setState( { loading: false } ), 2000 );
+		}
+	}
+
+	render() {
+		const { disabled, loading, language } = this.state;
+
+		const loadingCls = classNames( 'docs__design-toggle button', {
+			'is-busy': loading
+		} );
+
+		return (
+			<div>
+				<a className="docs__design-toggle button" onClick={ this.toggleDisabled }>
+					{ disabled ? 'Enabled State' : 'Disabled State' }
+				</a>
+				<a
+					className={ loadingCls }
+					style={ { marginRight: '8px' } }
+					onClick={ this.triggerLoading }
+				>Test Loading</a>
+				<Card>
+					<LanguagePicker
+						languages={ config( 'languages' ) }
+						valueKey="langSlug"
+						value={ loading ? null : language }
+						onChange={ this.selectLanguage }
+						disabled={ disabled }
+					/>
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default LanguagePickerExample;

--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -1,0 +1,134 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes, PureComponent } from 'react';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { find, noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import LanguagePickerModal from './modal';
+
+class LanguagePicker extends PureComponent {
+
+	static propTypes = {
+		languages: PropTypes.array.isRequired,
+		valueKey: PropTypes.string,
+		value: PropTypes.any,
+		onChange: PropTypes.func,
+	}
+
+	static defaultProps = {
+		languages: [],
+		valueKey: 'value',
+		onChange: noop,
+	}
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			selectedLanguage: this.findLanguage( props.valueKey, props.value )
+		};
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.value !== this.props.value || nextProps.valueKey !== this.props.valueKey ) {
+			this.setState( {
+				selectedLanguage: this.findLanguage( nextProps.valueKey, nextProps.value )
+			} );
+		}
+	}
+
+	findLanguage( valueKey, value ) {
+		return find( this.props.languages, lang => {
+			// The value passed is sometimes string instead of number - need to use ==
+			return lang[ valueKey ] == value; // eslint-disable-line eqeqeq
+		} );
+	}
+
+	selectLanguage = ( languageSlug ) => {
+		// Find the language by the slug
+		const language = this.findLanguage( 'langSlug', languageSlug );
+		if ( ! language ) {
+			return;
+		}
+
+		// onChange takes an object in shape of a DOM event as argument
+		const value = language[ this.props.valueKey ];
+		const event = { target: { value } };
+		this.props.onChange( event );
+		this.setState( {
+			selectedLanguage: language,
+		} );
+	}
+
+	toggleOpen = () => {
+		if ( ! this.props.disabled ) {
+			this.setState( { open: ! this.state.open } );
+		}
+	}
+
+	handleClose = () => {
+		this.setState( { open: false } );
+	}
+
+	renderPlaceholder() {
+		const classes = classNames( 'language-picker', 'is-loading' );
+
+		return (
+			<div className={ classes }>
+				<div className="language-picker__icon">
+					<div className="language-picker__icon-inner" />
+				</div>
+				<div className="language-picker__name">
+					<div className="language-picker__name-inner" />
+				</div>
+			</div>
+		);
+	}
+
+	render() {
+		const language = this.state.selectedLanguage;
+		if ( ! language ) {
+			return this.renderPlaceholder();
+		}
+
+		const [ langCode, langSubcode ] = language.langSlug.split( '-' );
+		const langName = language.name;
+		const { disabled, translate } = this.props;
+
+		return (
+			<div className="language-picker" onClick={ this.toggleOpen } disabled={ disabled }>
+				<div className="language-picker__icon">
+					<div className="language-picker__icon-inner">
+						{ langCode }
+						{ langSubcode && <br /> }
+						{ langSubcode }
+					</div>
+				</div>
+				<div className="language-picker__name">
+					<div className="language-picker__name-inner">
+						<div className="language-picker__name-label">
+							{ langName }
+						</div>
+						<div className="language-picker__name-change" >
+							{ translate( 'Change' ) }
+						</div>
+					</div>
+				</div>
+				<LanguagePickerModal
+					isVisible={ this.state.open }
+					languages={ this.props.languages }
+					onClose={ this.handleClose }
+					onSelected={ this.selectLanguage }
+					selected={ language.langSlug }
+				/>
+			</div>
+		);
+	}
+}
+
+export default localize( LanguagePicker );

--- a/client/components/language-picker/modal.jsx
+++ b/client/components/language-picker/modal.jsx
@@ -1,0 +1,189 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes, PureComponent } from 'react';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { includes, map, noop, partial } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+import SectionNav from 'components/section-nav';
+import SectionNavTabs from 'components/section-nav/tabs';
+import SectionNavTabItem from 'components/section-nav/item';
+import Search from 'components/search';
+
+class LanguagePickerModal extends PureComponent {
+	static propTypes = {
+		onSelected: PropTypes.func,
+		onClose: PropTypes.func,
+	}
+
+	static defaultProps = {
+		onSelected: noop,
+		onClose: noop,
+	}
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			filter: 'popular',
+			search: false,
+			selectedLanguageSlug: this.props.selected,
+		};
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.selected !== this.state.selectedLanguageSlug ) {
+			this.setState( {
+				selectedLanguageSlug: nextProps.selected
+			} );
+		}
+	}
+
+	getFilterLabel( filter ) {
+		const { translate } = this.props;
+
+		switch ( filter ) {
+			case 'popular':
+				return translate( 'Popular languages', { textOnly: true } );
+			default:
+				return translate( 'All languages', { textOnly: true } );
+		}
+	}
+
+	getDisplayedLanguages() {
+		const { languages } = this.props;
+		const { search, filter } = this.state;
+
+		if ( search ) {
+			const searchString = search.toLowerCase();
+			return languages.filter( language => {
+				return includes( language.name.toLowerCase(), searchString );
+			} );
+		}
+
+		switch ( filter ) {
+			case 'popular':
+				const popularLanguages = languages.filter( language => language.popular );
+				popularLanguages.sort( ( a, b ) => a.popular - b.popular );
+				return popularLanguages;
+			default:
+				return languages;
+		}
+	}
+
+	handleSearch = ( search ) => {
+		this.setState( { search } );
+	}
+
+	handleClick = ( selectedLanguageSlug ) => {
+		this.setState( { selectedLanguageSlug } );
+	}
+
+	handleSelectLanguage = () => {
+		const langSlug = this.state.selectedLanguageSlug;
+		this.props.onSelected( langSlug );
+		this.handleClose();
+	}
+
+	handleClose = () => {
+		this.props.onClose();
+	}
+
+	renderTabItems() {
+		const tabs = [ 'popular', '' ];
+
+		return map( tabs, filter => {
+			const selected = this.state.filter === filter;
+			const onClick = () => this.setState( { filter } );
+
+			return (
+				<SectionNavTabItem
+					key={ filter }
+					selected={ selected }
+					onClick={ onClick }
+				>
+					{ this.getFilterLabel( filter ) }
+				</SectionNavTabItem>
+			);
+		} );
+	}
+
+	renderLanguageList() {
+		const languages = this.getDisplayedLanguages();
+
+		return (
+			<div className="language-picker__modal-list">
+				{ map( languages, this.renderLanguageItem ) }
+			</div>
+		);
+	}
+
+	renderLanguageItem = ( language ) => {
+		const isSelected = language.langSlug === this.state.selectedLanguageSlug;
+		const classes = classNames( 'language-picker__modal-text', {
+			'is-selected': isSelected
+		} );
+
+		return (
+			<div
+				className="language-picker__modal-item"
+				key={ language.langSlug }
+				onClick={ partial( this.handleClick, language.langSlug ) }
+			>
+				<span className={ classes }>{ language.name }</span>
+			</div>
+		);
+	}
+
+	render() {
+		const { isVisible, translate } = this.props;
+
+		if ( ! isVisible ) {
+			// Render nothing at all if the modal is not visible
+			// <Dialog isVisible={ false }> still renders a lot of useless elements
+			return null;
+		}
+
+		const buttons = [
+			{
+				action: 'cancel',
+				label: translate( 'Cancel' )
+			},
+			{
+				action: 'confirm',
+				label: translate( 'Select Language' ),
+				isPrimary: true,
+				onClick: this.handleSelectLanguage
+			},
+		];
+
+		return (
+			<Dialog
+				isVisible
+				buttons={ buttons }
+				onClose={ this.handleClose }
+				additionalClassNames="language-picker__modal"
+			>
+				<SectionNav selectedText={ this.getFilterLabel( this.state.filter ) }>
+					<SectionNavTabs>
+						{ this.renderTabItems() }
+					</SectionNavTabs>
+					<Search
+						pinned
+						fitsContainer
+						onSearch={ this.handleSearch }
+						placeholder={ translate( 'Search languages…' ) }
+					/>
+				</SectionNav>
+				{ this.renderLanguageList() }
+			</Dialog>
+		);
+	}
+}
+
+export default localize( LanguagePickerModal );

--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -1,0 +1,177 @@
+.language-picker {
+	background: $white;
+	border: 1px solid lighten( $gray, 20% );
+	border-width: 1px 1px 2px;
+	border-radius: 4px;
+	width: 300px;
+	display: flex;
+	flex: 1 0 auto;
+	font-size: 14px;
+	height: 64px;
+	align-items: stretch;
+	cursor: pointer;
+	transition: border-color .15s ease-in-out;
+
+	@include breakpoint( "<660px" ) {
+		width: 100%;
+	}
+
+	&[disabled] {
+		cursor: default;
+
+		&,
+		.language-picker__icon {
+			border-color: lighten( $gray, 30% );
+		}
+
+		&,
+		.language-picker__name-change {
+			color: lighten( $gray, 30% );
+		}
+	}
+
+	&:not([disabled]):hover {
+		&,
+		.language-picker__icon {
+			border-color: lighten( $gray, 10% );
+		}
+	}
+
+	&.is-loading {
+		.language-picker__icon-inner {
+			width: 30px;
+			height: 30px;
+			animation: pulse-light 0.8s ease-in-out infinite;
+		}
+
+		.language-picker__name-inner {
+			width: 100%;
+			height: 30px;
+			background-color: lighten( $gray, 30% );
+		}
+	}
+}
+
+.language-picker__icon {
+	width: 64px;
+	margin: 4px 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex: none;
+	border-right: 1px solid lighten( $gray, 20% );
+	transition: border-color .15s ease-in-out;
+}
+
+.language-picker__icon-inner {
+	text-transform: uppercase;
+	font-weight: 700;
+	line-height: 1.0;
+}
+
+.language-picker__name {
+	flex: auto;
+	margin: 4px 16px;
+	display: flex;
+	align-items: center;
+}
+
+.language-picker__name-inner {
+	font-weight: 600;
+	overflow: hidden;
+}
+
+.language-picker__name-label {
+	white-space: nowrap;
+}
+
+.language-picker__name-change {
+	text-transform: uppercase;
+	color: $gray-text-min;
+}
+
+.language-picker__modal {
+	padding: 0;
+
+	&.dialog.card {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		max-width: none;
+		font-size: 14px;
+		display: flex;
+		flex-direction: column;
+
+		@include breakpoint( ">660px" ) {
+			top: 5%;
+			bottom: 5%;
+			left: 5%;
+			right: 5%;
+			width: 90%;
+		}
+
+		@include breakpoint( ">960px" ) {
+			left: 12.5%;
+			right: 12.5%;
+			width: 75%;
+		}
+	}
+
+	.dialog__content {
+		display: flex;
+		flex-direction: column;
+		flex: auto;
+	}
+
+	.dialog__action-buttons {
+		flex: none;
+		margin: 0;
+	}
+
+	.section-nav {
+		flex: none;
+		margin-bottom: 0;
+		z-index: 10;
+	}
+}
+
+.language-picker__modal-list {
+	box-sizing: border-box;
+	width: 100%;
+	overflow-y: auto;
+	padding: 8px 16px;
+	flex: auto;
+}
+
+.language-picker__modal-item {
+	display: inline-block;
+	width: 100%;
+	white-space: nowrap;
+	overflow: hidden;
+
+	@include breakpoint( ">480px") {
+		width: 50%;
+	}
+
+	@include breakpoint( ">660px" ) {
+		width: 33%;
+	}
+
+	@include breakpoint( ">960px" ) {
+		width: 25%;
+	}
+}
+
+.language-picker__modal-text {
+	display: inline-block;
+	padding: 4px 8px;
+	border-radius: 4px;
+	cursor: pointer;
+
+	&.is-selected {
+		background: $blue-medium;
+		color: $white;
+	}
+}

--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -175,3 +175,18 @@
 		color: $white;
 	}
 }
+
+.language-picker__modal-suggested {
+	flex: none;
+	width: 100%;
+	background: $gray-light;
+	border-top: 1px solid lighten( $gray, 30% );
+	display: flex;
+	align-items: center;
+	padding: 8px 16px;
+	box-sizing: border-box;
+
+	.language-picker__modal-text {
+		margin-left: 16px;
+	}
+}

--- a/client/components/language-picker/test/index.jsx
+++ b/client/components/language-picker/test/index.jsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { render } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import useMockery from 'test/helpers/use-mockery';
+
+const languages = [
+	{
+		value: 1,
+		langSlug: 'en',
+		name: 'English',
+		wpLocale: 'en_US',
+		popular: 1
+	},
+	{
+		value: 11,
+		langSlug: 'cs',
+		name: 'Čeština',
+		wpLocale: 'cs_CZ'
+	}
+];
+
+describe( 'LanguagePicker', () => {
+	let LanguagePicker;
+
+	useMockery( mockery => {
+		mockery.registerMock( 'lib/analytics', {} );
+	} );
+
+	before( () => {
+		LanguagePicker = require( '../' );
+	} );
+
+	it( 'should render the right icon and label', () => {
+		const wrapper = render(
+			<LanguagePicker
+				languages={ languages }
+				valueKey="langSlug"
+				value="en"
+			/>
+		);
+		expect( wrapper.find( '.language-picker__icon' ) ).to.have.text( 'en' );
+		expect( wrapper.find( '.language-picker__name-label' ) ).to.have.text( 'English' );
+	} );
+} );

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -70,6 +70,7 @@ import FAQ from 'components/faq/docs/example';
 import VerticalMenu from 'components/vertical-menu/docs/example';
 import Banner from 'components/banner/docs/example';
 import EmojifyExample from 'components/emojify/docs/example';
+import LanguagePicker from 'components/language-picker/docs/example';
 
 let DesignAssets = React.createClass( {
 	displayName: 'DesignAssets',
@@ -144,6 +145,7 @@ let DesignAssets = React.createClass( {
 					<InfoPopover />
 					<Tooltip />
 					<InputChrono />
+					<LanguagePicker />
 					<Notices />
 					<PaymentLogo />
 					<Popovers />

--- a/client/layout/sidebar/footer.jsx
+++ b/client/layout/sidebar/footer.jsx
@@ -12,11 +12,13 @@ import Gridicon from 'gridicons';
 import Button from 'components/button';
 import config from 'config';
 import HappychatButton from 'components/happychat/button';
+import LanguageButton from 'components/language-picker/button';
 import { isHappychatChatActive } from 'state/happychat/selectors';
 
 const SidebarFooter = ( { translate, children, isHappychatButtonVisible } ) => (
 	<div className="sidebar__footer">
 		{ children }
+		<LanguageButton />
 		<Button
 			className="sidebar__footer-help"
 			borderless

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -356,7 +356,8 @@ form.sidebar__button {
 	margin-right: auto;
 
 	&.sidebar__footer-help,
-	&.sidebar__footer-chat {
+	&.sidebar__footer-chat,
+	&.sidebar__footer-lang {
 		border-left: 1px solid darken( $sidebar-bg-color, 10% );
 		flex: 0 1 40px;
 		margin-right: 0;
@@ -369,7 +370,7 @@ form.sidebar__button {
 
 	}
 
-	&.sidebar__footer-help {
+	&.sidebar__footer-lang {
 		margin-left: auto;
 	}
 
@@ -419,6 +420,21 @@ form.sidebar__button {
 .layout.is-section-help .sidebar .sidebar__footer-help {
 	background-color: $sidebar-selected-color;
 	color: $white;
+}
+
+.sidebar__footer-lang-icon {
+	width: 24px;
+	height: 24px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	line-height: 1.0;
+	text-align: left;
+
+	&.is-loading {
+		animation: loading-dot-pulse 0.8s ease-in-out infinite;
+		background-color: lighten( $gray, 20% );
+	}
 }
 
 .sidebar__region {

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -18,7 +18,7 @@ import { bindActionCreators } from 'redux';
 /**
  * Internal dependencies
  */
-import LanguageSelector from 'components/forms/language-selector';
+import LanguagePicker from 'components/language-picker';
 import MeSidebarNavigation from 'me/sidebar-navigation';
 import { protectForm } from 'lib/protect-form';
 import formBase from 'me/form-base';
@@ -517,7 +517,7 @@ const Account = React.createClass( {
 
 				<FormFieldset>
 					<FormLabel htmlFor="language">{ translate( 'Interface Language' ) }</FormLabel>
-					<LanguageSelector
+					<LanguagePicker
 						disabled={ this.getDisabledState() }
 						id="language"
 						languages={ config( 'languages' ) }

--- a/client/my-sites/sidebar/test/sidebar.jsx
+++ b/client/my-sites/sidebar/test/sidebar.jsx
@@ -19,6 +19,7 @@ describe( 'MySitesSidebar', () => {
 		mockery.registerMock( './publish-menu', EmptyComponent );
 		mockery.registerMock( 'layout/sidebar', EmptyComponent );
 		mockery.registerMock( 'components/tooltip', EmptyComponent );
+		mockery.registerMock( 'components/language-picker/button', EmptyComponent );
 
 		MySitesSidebar = require( '../sidebar' ).MySitesSidebar;
 	} );

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -14,7 +14,7 @@ import wrapSettingsForm from './wrap-settings-form';
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import Button from 'components/button';
-import LanguageSelector from 'components/forms/language-selector';
+import LanguagePicker from 'components/language-picker';
 import DisconnectJetpackButton from 'my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button';
 import SectionHeader from 'components/section-header';
 import config from 'config';
@@ -158,7 +158,7 @@ class SiteSettingsFormGeneral extends Component {
 		return (
 			<FormFieldset>
 				<FormLabel htmlFor="lang_id">{ translate( 'Language' ) }</FormLabel>
-				<LanguageSelector
+				<LanguagePicker
 					name="lang_id"
 					id="lang_id"
 					languages={ config( 'languages' ) }

--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -56,7 +56,7 @@ export const storeFetchedUserSettings = ( { dispatch }, action, next, data ) => 
  * Post settings to WordPress.com API at /me/settings endpoint
  */
 export function saveUserSettings( { dispatch, getState }, action, next ) {
-	const { settingsOverride } = action;
+	const { settingsOverride, onSuccess, onFailure } = action;
 	const settings = settingsOverride || getUnsavedUserSettings( getState() );
 
 	if ( ! isEmpty( settings ) ) {
@@ -65,6 +65,8 @@ export function saveUserSettings( { dispatch, getState }, action, next ) {
 			method: 'POST',
 			path: '/me/settings',
 			body: settings,
+			onSuccess,
+			onFailure,
 		}, action ) );
 	}
 

--- a/client/state/user-settings/actions.js
+++ b/client/state/user-settings/actions.js
@@ -30,12 +30,14 @@ export const fetchUserSettings = () => ( {
 /**
  * Post settings to WordPress.com API at /me/settings endpoint
  *
- * @param {Object} settingsOverride - default settings object
+ * @param {Object} [settingsOverride] - default settings object
  * @return {Object} Action object
  */
-export const saveUserSettings = ( settingsOverride ) => ( {
+export const saveUserSettings = ( settingsOverride, onSuccess, onFailure ) => ( {
 	type: USER_SETTINGS_SAVE,
-	settingsOverride
+	settingsOverride,
+	onSuccess,
+	onFailure
 } );
 
 /**


### PR DESCRIPTION
This is a PR for my trial project described in my post on the i18n P2 blog (internal ref: pxLjZ-3EJ-p2).

The main part of the effort is implementing a new language picker component (internal ref: p4TIVU-5np-p2).

A big task with many subtasks:
- [x] Implement a `LanguageChooser` component intended to replace the existing `LanguageSelector`. Its design is based on the `SitesDropdown` component.
- [x] Implement a `LanguageChooserModal` dialog that opens after clicking the "Change" link in the `LanguageChooser`. The design is based on `EditorMediaModal`. A tab bar with language groups and search, filtered list of languages to choose from, and  a button bar with "Cancel" and "Select" buttons.
- [x] Use the new `LanguageChooser` on the `/me/account` page.
- [x] Use the `LanguageChooser` on the `my-sites/site-settings/form-general` page. This will need several improvements to the component:
  - [x] In addition to `valueLink` prop, support also a `value`/`onChange` variant. Or get rid of the `valueLink` in `me/account/main.jsx`. That might be more future-proof, as `valueLink` is deprecated. (`valueLink` is being removed in PR #12729)
  - [x] Support the `disabled` state
  - [x] Support hooking telemetry (`eventTracker`) into the component
- [x] Support a "placeholder" state in `LanguageChooser`. It's displayed when settings data is being loaded.
- [x] Highlight the currently selected language in `LanguageChooserModal`
- [x] Add a `README.md` for the new components
- [x] Learn how unit tests are written in Calypso and write a testing suite (are we testing actions and reducers, or also UI rendering? What about integration (e2e) tests?
- [x] ~~Display the explanation text side-by-side with the `LanguageChooser` (if the viewport is wide enough)~~ abandoned, displaying under the component for consistency.
- [x] Create a `LanguageSidebarChooser` component that will be displayed in sidebars
- [x] Add a "Suggested Languages" list to `LanguageChooserModal`. The suggestions will be based on the browser language settings.
  - [x] Get the language list from `navigator.languages`
  - [x] ~~For browsers that don't support `navigator.languages` (it's a new experimental API, supported only by Chrome and Firefox atm, according to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorLanguage/languages), find some fallback - probably some server REST API endpoint that reads the `Accept-Language` header.~~ Decided to support only `navigator.languages` now and maybe make `/locale-guesser` smarter sometime in future.
  - [x] As a last-resort fallback, use geolocation for suggestions. Investigate the `/locale-guesser` API endpoint. Result: using geolocation to select the default tab.
- [x] Group the language list into territories (Europe, Asia, Americas, ...), like the Facebook language picker does
  - [x] Use the CLDR data for that. Decide whether to hardcode the data into the `config/_shared.json` file, or whether to query it online (see below)
  - [x] Investigate the [wp-cldr](https://github.com/Automattic/wp-cldr) plugin. Does it have REST API? Can we detect if it's installed and query it? (It should be available on all WordPress.com sites). Result: hardcoding the data into JS code (it's not that big). Might load the data with `AsyncLoad` in future.
- [ ] Support searching for a language by multiple names (Czech, Čeština, Tschechisch, ...). CLDR has all the translations.
  - [ ] How big will the translation data be? Decide whether to support only popular languages, or all.
  - [ ] Use the same data to display a tooltip over the language name that translates the name into the current language. The language name in the list is always self-referential (English, Deutsch, Čeština). Facebook dialog does this.
- [x] Tune the CSS styling of the modal. Right now, the styles depend on precise pixel sizes. Vertical flex should make the styling simpler and more reliable. Do all supported browser have good-enough vertical flex support?
- [x] Fine-tune the responsivity of the modal dialog (size, column sizes and count)
- [x] ~~When a language name is too long and doesn't fit into the column, add a "fade-out" effect to make the clipping look good.~~ (turns out this is not needed when the column count is responsive -- there's always enough room for all existing language names)
- [x] Clean up the language list data in `config/_shared.json`. There are a few errors. (moved this task to an independent PR: #12714)
  - [x] Don't include the language slug in the language `name`. Convert `en - English` to `English`.

A related task that will probably be an independent PR: avoid reloading the whole page after a language is switched. Just trigger a React rerender with the new language. (Moved to #13712)
- [ ] Does the `localize` HOC from `i18n-calypso` support this? Will the value of the injected `translate` property change?
- [ ] Will all components properly rerender when `translate` props changes? Or will it be blocked by some `shouldComponentUpdate` implementation? Or a wrong/missing `componentWillReceiveProps`?
- [ ] Does something that's not managed by React need to change on language switch? Like CSS styles or other assets?
- [x] Decide what directory should the new components be in. Is it `client/components`, or `client/blocks` or `client/components/form`? **Result:** It should be `client/component` - it's a "dumb" component that only renders what it's passed in props. To be eligible to be a `block`, it would need to connect to the app state by itself.
- [x] Consider removing the current `LanguageSelector` component and replace it completely with the `LanguageChooser`, maybe even reusing the name.

The `LanguageChooser` uses the `lib/user-settings` module that uses a legacy, event-based approach to data. Converting this module to Redux would be great.
- [x] Create a Redux state slice for user settings and provide appropriate action creators and selectors as the new API (happens in a separate PR: #12819)
- [ ] Convert the existing `lib/user-settings` into a thin wrapper over the Redux API
- [ ] Migrate all usages of `lib/user-settings`
- [ ] Remove the legacy `lib/user-settings` module
