### PR TITLE
Add path info for GUI apps such as Tower

### DIFF
--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+PATH="$PATH:/usr/local/bin"
+
 printf "\nBy contributing to this project, you license the materials you contribute under the GNU General Public License v2 (or later). All materials must have GPLv2 compatible licenses — see .github/CONTRIBUTING.md for details.\n\n"
 
 # Make quick pass over config files on every change


### PR DESCRIPTION
Certain apps such as Tower need the path info for the git hook to work. More info: https://www.git-tower.com/help/mac/faq-and-tips/faq#faq-hook-scripts