### PR TITLE
Editor: Resolve style conflict in editor sidebar on mobile

### DIFF
--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -20,7 +20,6 @@
 	@include breakpoint( "<660px" ) {
 		position: relative;
 		top: 0;
-		left: 0;
 		height: 0;
 		transition: none;
 

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -13,6 +13,10 @@
 .is-group-editor .sidebar {
 	left: auto;
 	right: -273px;
+
+	@include breakpoint( "<660px" ) {
+		left: 0;
+	}
 }
 
 @include breakpoint( "<660px" ) {


### PR DESCRIPTION
This is a quick fix for #12529. The settings sidebar is not currently visible on small mobile devices. We set a breakpoint for <660px and `left: 0;` for the sidebar [here](https://github.com/Automattic/wp-calypso/blob/master/client/post-editor/editor-sidebar/style.scss#L23), but this is getting overruled by a more specific selector and `left: auto;` [here](https://github.com/Automattic/wp-calypso/blob/master/client/post-editor/style.scss#L14). I moved the breakpoint to `post-editor/style.css` instead to fix the conflict.

## To test
Load up this branch and load the editor. On screen sizes below 660px, expand the editor sidebar. It should be fully visible instead of offset to the right.

## Screenshots

**Previous**
<img width="377" alt="screen shot 2017-03-27 at 6 25 55 am" src="https://cloud.githubusercontent.com/assets/7240478/24356226/510dbfa8-12b6-11e7-804c-eb7044fdff4b.png">

**Updated**
<img width="376" alt="smallscreen" src="https://cloud.githubusercontent.com/assets/7240478/24356213/4b58c3aa-12b6-11e7-8663-5d48dfd979b4.png">