### PR TITLE
Editor: Use Redux editPost Action to update th post's password

### DIFF
--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -26,7 +26,6 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPost } from 'state/posts/selectors';
 import EditorVisibility from 'post-editor/editor-visibility';
-import utils from 'lib/posts/utils';
 
 class EditPostStatus extends Component {
 
@@ -41,6 +40,7 @@ class EditPostStatus extends Component {
 		type: PropTypes.string,
 		postDate: PropTypes.string,
 		onPrivatePublish: PropTypes.func,
+		status: PropTypes.string,
 	};
 
 	constructor( props ) {
@@ -195,16 +195,15 @@ class EditPostStatus extends Component {
 			return;
 		}
 
-		const { status, password, type } = this.props.post || {};
+		const { password, type } = this.props.post || {};
 		const isPrivateSite = this.props.site && this.props.site.is_private;
 		const savedStatus = this.props.savedPost ? this.props.savedPost.status : null;
 		const savedPassword = this.props.savedPost ? this.props.savedPost.password : null;
 		const props = {
-			visibility: utils.getVisibility( this.props.post ),
+			status: this.props.status,
 			onPrivatePublish: this.props.onPrivatePublish,
 			isPrivateSite,
 			type,
-			status,
 			password,
 			savedStatus,
 			savedPassword

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -308,8 +308,11 @@ const EditorDrawer = React.createClass( {
 	renderStatus() {
 		// TODO: REDUX - remove this logic and prop for EditPostStatus when date is moved to redux
 		const postDate = this.props.post && this.props.post.date
-				? this.props.post.date
-				: null;
+			? this.props.post.date
+			: null;
+		const postStatus = this.props.post && this.props.post.status
+			? this.props.post.status
+			: null;
 
 		return (
 			<Accordion title={ this.translate( 'Status' ) }>
@@ -321,7 +324,9 @@ const EditorDrawer = React.createClass( {
 					onTrashingPost={ this.props.onTrashingPost }
 					onPrivatePublish={ this.props.onPrivatePublish }
 					setPostDate={ this.props.setPostDate }
-					site={ this.props.site }>
+					site={ this.props.site }
+					status={ postStatus }
+				>
 				</EditPostStatus>
 			</Accordion>
 		);

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import createFragment from 'react-addons-create-fragment';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -307,12 +308,8 @@ const EditorDrawer = React.createClass( {
 
 	renderStatus() {
 		// TODO: REDUX - remove this logic and prop for EditPostStatus when date is moved to redux
-		const postDate = this.props.post && this.props.post.date
-			? this.props.post.date
-			: null;
-		const postStatus = this.props.post && this.props.post.status
-			? this.props.post.status
-			: null;
+		const postDate = get( this.props.post, 'date', null );
+		const postStatus = get( this.props.post, 'status', null );
 
 		return (
 			<Accordion title={ this.translate( 'Status' ) }>
@@ -326,8 +323,7 @@ const EditorDrawer = React.createClass( {
 					setPostDate={ this.props.setPostDate }
 					site={ this.props.site }
 					status={ postStatus }
-				>
-				</EditPostStatus>
+				/>
 			</Accordion>
 		);
 	},

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -69,10 +69,23 @@ const EditorVisibility = React.createClass( {
 		}
 	},
 
+	getVisibility( props ) {
+		if ( props.password ) {
+			return 'password';
+		}
+
+		if ( 'private' === props.status ) {
+			return 'private';
+		}
+
+		return 'public';
+	},
+
 	setVisibility( props ) {
-		if ( props.visibility !== this.state.visibility ) {
+		const newVisibility = this.getVisibility( props );
+		if ( newVisibility !== this.state.visibility ) {
 			this.setState( {
-				visibility: props.visibility
+				visibility: newVisibility
 			} );
 		}
 	},
@@ -164,13 +177,9 @@ const EditorVisibility = React.createClass( {
 	updateVisibility( event ) {
 		const { siteId, postId } = this.props;
 		const defaultVisibility = 'draft' === this.props.status ? 'draft' : 'publish';
-		const postEdits = {
-			status: this.props.savedStatus && 'private' !== this.props.savedStatus
-				? this.props.savedStatus
-				: defaultVisibility
-		};
 		const newVisibility = event.target.value;
-		let reduxPostEdits = false;
+		const postEdits = { status: defaultVisibility };
+		let reduxPostEdits;
 
 		switch ( newVisibility ) {
 			case 'public':
@@ -202,11 +211,12 @@ const EditorVisibility = React.createClass( {
 	},
 
 	setPostToPrivate() {
+		const { siteId, postId } = this.props;
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		postActions.edit( {
-			password: '',
 			status: 'private'
 		} );
+		this.props.editPost( siteId, postId, { password: '' } );
 
 		this.setState( { visibility: 'private' } );
 

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -38,7 +38,6 @@ const EditorVisibility = React.createClass( {
 	},
 
 	propTypes: {
-		visibility: React.PropTypes.string,
 		onPrivatePublish: React.PropTypes.func,
 		isPrivateSite: React.PropTypes.bool,
 		type: React.PropTypes.string,
@@ -55,39 +54,19 @@ const EditorVisibility = React.createClass( {
 			showPopover: false,
 			passwordIsValid: true,
 			showVisibilityInfotips: false,
-			visibility: 'public',
 		};
 	},
 
-	componentWillMount() {
-		this.setVisibility( this.props );
-	},
-
-	componentWillReceiveProps( nextProps ) {
-		if ( this.state.passwordIsValid ) {
-			this.setVisibility( nextProps );
-		}
-	},
-
-	getVisibility( props ) {
-		if ( props.password ) {
+	getVisibility() {
+		if ( this.props.password ) {
 			return 'password';
 		}
 
-		if ( 'private' === props.status ) {
+		if ( 'private' === this.props.status ) {
 			return 'private';
 		}
 
 		return 'public';
-	},
-
-	setVisibility( props ) {
-		const newVisibility = this.getVisibility( props );
-		if ( newVisibility !== this.state.visibility ) {
-			this.setState( {
-				visibility: newVisibility
-			} );
-		}
 	},
 
 	togglePopover() {
@@ -130,7 +109,7 @@ const EditorVisibility = React.createClass( {
 	isPasswordValid() {
 		var password;
 
-		if ( 'password' !== this.state.visibility ) {
+		if ( 'password' !== this.getVisibility() ) {
 			return true;
 		}
 
@@ -192,8 +171,6 @@ const EditorVisibility = React.createClass( {
 				break;
 		}
 
-		this.setState( { visibility: newVisibility } );
-
 		recordStat( 'visibility-set-' + newVisibility );
 		recordEvent( 'Changed visibility', newVisibility );
 
@@ -217,8 +194,6 @@ const EditorVisibility = React.createClass( {
 			status: 'private'
 		} );
 		this.props.editPost( siteId, postId, { password: '' } );
-
-		this.setState( { visibility: 'private' } );
 
 		recordStat( 'visibility-set-private' );
 		recordEvent( 'Changed visibility', 'private' );
@@ -310,17 +285,13 @@ const EditorVisibility = React.createClass( {
 	},
 
 	render() {
-		var visibility, icons, classes;
-
-		icons = {
+		const visibility = this.getVisibility();
+		const icons = {
 			password: 'lock',
 			'private': 'not-visible',
 			'public': 'visible'
 		};
-
-		visibility = this.state.visibility;
-
-		classes = classNames( 'editor-visibility', {
+		const classes = classNames( 'editor-visibility', {
 			'is-dialog-open': this.state.showPopover,
 			'is-touch': touchDetect.hasTouch()
 		} );


### PR DESCRIPTION
This is an alternative to #12353 closes #12276 

Since the password prop is retrieved from the Redux Edited Post, we should use the redux action to dispatch any change to this value.

**Testing instructions**

 - Draft a new post
 - Set a password to this post
 - Publish
 - Edit the post's password
 - Save the edited post.

The password should update properly.