### PR TITLE
Site Settings: add date/time formats tokens

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -84,6 +84,7 @@
 @import 'components/count/style';
 @import 'components/credit-card-form-fields/style';
 @import 'components/date-picker/style';
+@import 'components/date-time-format-editor/style';
 @import 'components/dialog/style';
 @import 'components/domains/domain-mapping-suggestion/style';
 @import 'components/domains/domain-product-price/style';

--- a/client/components/date-time-format-editor/README.md
+++ b/client/components/date-time-format-editor/README.md
@@ -1,0 +1,1 @@
+# Date Time Format Editor

--- a/client/components/date-time-format-editor/index.jsx
+++ b/client/components/date-time-format-editor/index.jsx
@@ -1,0 +1,406 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import {
+	head,
+	map,
+	max,
+	min,
+	noop,
+} from 'lodash';
+
+// The following polyfills exist for the draft-js editor, since
+// we are unable to change its codebase and yet we are waiting
+// on a solid solution for general IE polyfills
+//
+// They were borrowed and modified from MDN
+//
+// @TODO Remove these when we have a real Calypso polyfill solution
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith
+if ( ! String.prototype.endsWith ) {
+	String.prototype.endsWith = function( searchString, position ) {
+		const subjectString = this.toString();
+		if (
+			( typeof position !== 'number' ) ||
+			( ! isFinite( position ) ) ||
+			( Math.floor( position ) !== position ) ||
+			( position > subjectString.length )
+		) {
+			position = subjectString.length;
+		}
+		position -= searchString.length;
+		const lastIndex = subjectString.indexOf( searchString, position );
+		return lastIndex !== -1 && lastIndex === position;
+	};
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
+if ( ! String.prototype.startsWith ) {
+	String.prototype.startsWith = function( searchString, position ) {
+		position = position || 0;
+		return this.substr( position, searchString.length ) === searchString;
+	};
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fill
+if ( ! Array.prototype.fill ) {
+	Array.prototype.fill = function( value ) {
+		// Steps 1-2.
+		if ( this === null ) {
+			throw new TypeError( 'this is null or not defined' );
+		}
+
+		const O = Object( this );
+
+		// Steps 3-5.
+		const len = O.length >>> 0;
+
+		// Steps 6-7.
+		const start = arguments[ 1 ];
+		const relativeStart = start >> 0;
+
+		// Step 8.
+		let k = relativeStart < 0
+			? Math.max( len + relativeStart, 0 )
+			: Math.min( relativeStart, len );
+
+		// Steps 9-10.
+		const end = arguments[ 2 ];
+		const relativeEnd = end === undefined
+			? len
+			: end >> 0;
+
+		// Step 11.
+		const final = relativeEnd < 0
+			? Math.max( len + relativeEnd, 0 )
+			: Math.min( relativeEnd, len );
+
+		// Step 12.
+		while ( k < final ) {
+			O[ k ] = value;
+			k++;
+		}
+
+		// Step 13.
+		return O;
+	};
+}
+
+// The below is a `require()` statement becuase it needs to
+// be loaded in after the polyfills are created.
+const {
+	CompositeDecorator,
+	Editor,
+	EditorState,
+	Entity,
+	Modifier,
+	SelectionState,
+} = require( 'draft-js' );
+
+// Parser also requires draft-js. Lets load it after the polyfills are created too.
+const {
+	fromEditor,
+	mapTokenTitleForEditor,
+	toEditor,
+} = require( './parser' );
+
+import Token from './token';
+import { buildSeoTitle } from 'state/sites/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
+import { localize } from 'i18n-calypso';
+
+const Chip = onClick => props => <Token { ...props } onClick={ onClick } />;
+
+export class DateTimeFormatEditor extends Component {
+	static propTypes = {
+		disabled: PropTypes.bool,
+		placeholder: PropTypes.string,
+		type: PropTypes.object.isRequired,
+		tokens: PropTypes.object.isRequired,
+		onChange: PropTypes.func.isRequired,
+	};
+
+	static defaultProps = {
+		disabled: false,
+		placeholder: '',
+	};
+
+	constructor( props ) {
+		super( props );
+
+		this.storeEditorReference = r => ( this.editor = r );
+		this.focusEditor = () => this.editor.focus();
+
+		this.updateEditor = this.updateEditor.bind( this );
+		this.addToken = this.addToken.bind( this );
+		this.removeToken = this.removeToken.bind( this );
+		this.renderTokens = this.renderTokens.bind( this );
+		this.editorStateFrom = this.editorStateFrom.bind( this );
+		this.skipOverTokens = this.skipOverTokens.bind( this );
+
+		this.state = {
+			editorState: EditorState.moveSelectionToEnd(
+				this.editorStateFrom( props )
+			)
+		};
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.disabled && ! nextProps.disabled ) {
+			this.setState( {
+				editorState: EditorState.moveSelectionToEnd(
+					this.editorStateFrom( nextProps )
+				)
+			} );
+		}
+	}
+
+	editorStateFrom( props ) {
+		const { disabled } = props;
+
+		return EditorState.createWithContent(
+			toEditor( props.titleFormats, props.tokens ),
+			new CompositeDecorator( [ {
+				strategy: this.renderTokens,
+				component: Chip( disabled ? noop : this.removeToken )
+			} ] )
+		);
+	}
+
+	/**
+	 * Returns a new editorState that forces
+	 * selection to hop over tokens, preventing
+	 * navigating the cursor into a token
+	 *
+	 * @param {EditorState} editorState new state of editor after changes
+	 * @returns {EditorState} maybe filtered state for editor
+	 */
+	skipOverTokens( editorState ) {
+		const content = editorState.getCurrentContent();
+		const selection = editorState.getSelection();
+
+		// okay if we did not move the cursor
+		const before = this.state.editorState.getSelection();
+		const offset = selection.getFocusOffset();
+
+		if (
+			( before.getFocusKey() === selection.getFocusKey() ) &&
+			( before.getFocusOffset() === offset )
+		) {
+			return editorState;
+		}
+
+		const block = content.getBlockForKey( selection.getFocusKey() );
+		const direction = Math.sign( offset - before.getFocusOffset() );
+		const entityKey = block.getEntityAt( offset );
+
+		// okay if we are at the edges of the block
+		if ( 0 === offset || block.getLength() === offset ) {
+			return editorState;
+		}
+
+		// okay if we aren't in a token
+		if ( ! entityKey ) {
+			return editorState;
+		}
+
+		// get characters in entity
+		const indices = block
+			.getCharacterList()
+			.reduce( ( ids, value, key ) => {
+				return entityKey === value.entity
+					? [ ...ids, key ]
+					: ids;
+			}, [] );
+
+		// okay if cursor is at the spot
+		// right before the token
+		if ( offset === head( indices ) ) {
+			return editorState;
+		}
+
+		const outside = direction > 0
+			? Math.min( max( indices ) + 1, block.getLength() )
+			: Math.max( min( indices ), 0 );
+
+		return EditorState.forceSelection(
+			editorState,
+			selection
+				.set( 'anchorOffset', outside )
+				.set( 'focusOffset', outside )
+		);
+	}
+
+	updateEditor( rawEditorState, { doFocus = false } = {} ) {
+		const { onChange, type } = this.props;
+		const currentContent = rawEditorState.getCurrentContent();
+
+		// limit to one line
+		if ( currentContent.getBlockMap().size > 1 ) {
+			return;
+		}
+
+		const editorState = this.skipOverTokens( rawEditorState );
+
+		this.setState(
+			{ editorState },
+			() => {
+				doFocus && this.focusEditor();
+				onChange( type.value, fromEditor( currentContent ) );
+			}
+		);
+	}
+
+	addToken( title, name ) {
+		return () => {
+			const { editorState } = this.state;
+			const currentSelection = editorState.getSelection();
+
+			const tokenEntity = Entity.create( 'TOKEN', 'IMMUTABLE', { name } );
+
+			const contentState = Modifier.replaceText(
+				editorState.getCurrentContent(),
+				currentSelection,
+				mapTokenTitleForEditor( title ),
+				null,
+				tokenEntity
+			);
+
+			this.updateEditor( EditorState.push(
+				editorState,
+				contentState,
+				'add-token'
+			), { doFocus: true } );
+		};
+	}
+
+	removeToken( entityKey ) {
+		return () => {
+			const { editorState } = this.state;
+			const currentContent = editorState.getCurrentContent();
+			const currentSelection = editorState.getSelection();
+
+			const block = currentContent.getBlockForKey( currentSelection.focusKey );
+
+			// get characters in entity
+			const indices = block
+				.getCharacterList()
+				.reduce( ( ids, value, key ) => {
+					return entityKey === value.entity
+						? [ ...ids, key ]
+						: ids;
+				}, [] );
+
+			const range = SelectionState
+				.createEmpty( block.key )
+				.set( 'anchorOffset', min( indices ) )
+				.set( 'focusOffset', max( indices ) );
+
+			const withoutToken = EditorState.push(
+				editorState,
+				Modifier.removeRange(
+					currentContent,
+					range,
+					'forward'
+				),
+				'remove-range'
+			);
+
+			const selectionBeforeToken = EditorState.forceSelection(
+				withoutToken,
+				range
+					.set( 'anchorOffset', min( indices ) )
+					.set( 'focusOffset', min( indices ) )
+			);
+
+			this.updateEditor( selectionBeforeToken );
+		};
+	}
+
+	renderTokens( contentBlock, callback ) {
+		contentBlock.findEntityRanges(
+			character => {
+				const entity = character.getEntity();
+
+				if ( null === entity ) {
+					return false;
+				}
+
+				return 'TOKEN' === Entity.get( entity ).getType();
+			},
+			callback
+		);
+	}
+
+	render() {
+		const { editorState } = this.state;
+		const {
+			disabled,
+			placeholder,
+			titleData,
+			translate,
+			tokens,
+			type
+		} = this.props;
+
+		const previewText = type.value && editorState.getCurrentContent().hasText()
+			? buildSeoTitle( { [ type.value ]: fromEditor( editorState.getCurrentContent() ) }, type.value, titleData )
+			: '';
+
+		const formattedPreview = previewText
+			? `${ translate( 'Preview' ) }: ${ previewText }`
+			: '';
+
+		const editorClassNames = classNames( 'date-time-format-editor', {
+			disabled
+		} );
+
+		return (
+			<div className={ editorClassNames }>
+				<div className="date-time-format-editor__header">
+					<span className="date-time-format-editor__title">{ type.label }</span>
+					{ map( tokens, ( title, name ) => (
+						<span
+							key={ name }
+							className="date-time-format-editor__button"
+							onClick={ disabled ? noop : this.addToken( title, name ) }
+						>
+							{ title }
+						</span>
+					) ) }
+				</div>
+				<div className="date-time-format-editor__editor-wrapper">
+					<Editor
+						readOnly={ disabled }
+						editorState={ editorState }
+						onChange={ disabled ? noop : this.updateEditor }
+						placeholder={ placeholder }
+						ref={ this.storeEditorReference }
+					/>
+				</div>
+				<div className="date-time-format-editor__preview">{ formattedPreview }</div>
+			</div>
+		);
+	}
+}
+
+const mapStateToProps = ( state, ownProps ) => {
+	const site = getSelectedSite( state );
+	const { translate } = ownProps;
+
+	// Add example content for post/page title, tag name and archive dates
+	return ( {
+		titleData: {
+			site,
+			post: { title: translate( 'Example Title' ) },
+			tag: translate( 'Example Tag' ),
+			date: translate( 'August 2016' )
+		}
+	} );
+};
+
+export default localize( connect( mapStateToProps )( DateTimeFormatEditor ) );

--- a/client/components/date-time-format-editor/index.jsx
+++ b/client/components/date-time-format-editor/index.jsx
@@ -121,11 +121,12 @@ export class DateTimeFormatEditor extends Component {
 		placeholder: PropTypes.string,
 		type: PropTypes.object.isRequired,
 		tokens: PropTypes.object.isRequired,
-		onChange: PropTypes.func.isRequired,
+		onChange: PropTypes.func,
 	};
 
 	static defaultProps = {
 		disabled: false,
+		onChange: noop,
 		placeholder: '',
 	};
 
@@ -143,16 +144,19 @@ export class DateTimeFormatEditor extends Component {
 		this.skipOverTokens = this.skipOverTokens.bind( this );
 
 		this.state = {
-			editorState: EditorState.moveSelectionToEnd(
+			editorState: EditorState.moveFocusToEnd(
 				this.editorStateFrom( props )
 			)
 		};
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		if ( this.props.disabled && ! nextProps.disabled ) {
+		if (
+			this.props.disabled && ! nextProps.disabled ||
+			this.props.titleFormats !== nextProps.titleFormats
+		) {
 			this.setState( {
-				editorState: EditorState.moveSelectionToEnd(
+				editorState: EditorState.moveFocusToEnd(
 					this.editorStateFrom( nextProps )
 				)
 			} );

--- a/client/components/date-time-format-editor/parser.js
+++ b/client/components/date-time-format-editor/parser.js
@@ -7,13 +7,18 @@ import {
 	fromPairs,
 	get,
 	map,
-	matchesProperty,
+	//matchesProperty,
 	reduce,
 } from 'lodash';
 import {
 	convertFromRaw,
 	convertToRaw,
 } from 'draft-js';
+
+/**
+ * Internal dependencies
+ */
+import { phpToMomentMapping } from 'lib/formatting';
 
 /*
  * The functions in this file convert between the
@@ -113,7 +118,8 @@ export const fromEditor = content => {
 	] );
 };
 
-const isTextPiece = matchesProperty( 'type', 'string' );
+//const isTextPiece = matchesProperty( 'type', 'string' );
+const isTextPiece = piece => undefined === phpToMomentMapping[ piece ];
 
 const emptyBlockMap = {
 	text: '',
@@ -146,7 +152,8 @@ export const mapTokenTitleForEditor = title => `\u205f\u205f${ title }\u205f\u20
  * @param {object} tokens available tokens, e.g. { siteName: 'Site Name', tagline: 'Tagline' }
  * @returns {string} translated chip name
  */
-const tokenTitle = ( type, tokens ) => mapTokenTitleForEditor( get( tokens, type, '' ).trim() );
+//const tokenTitle = ( type, tokens ) => mapTokenTitleForEditor( get( tokens, type, '' ).trim() );
+const tokenTitle = title => mapTokenTitleForEditor( title.trim() );
 
 /**
  * Creates a new entity reference for a blockMap
@@ -191,13 +198,13 @@ const buildBlockMap = compose(
 			...block,
 			entityRanges: isTextPiece( piece )
 				? block.entityRanges // text pieces don't add entities
-				: [ ...block.entityRanges, newEntityAt( lastIndex, piece.type, tokens, entityGuide ) ],
-			text: block.text + ( isTextPiece( piece ) ? piece.value : tokenTitle( piece.type, tokens ) ),
+				: [ ...block.entityRanges, newEntityAt( lastIndex, piece, tokens, entityGuide ) ],
+			text: block.text + ( isTextPiece( piece ) ? piece : tokenTitle( piece, tokens ) ),
 		},
-		lastIndex + ( piece.value ? piece.value.length : tokenTitle( piece.type, tokens ).length ),
+		lastIndex + ( isTextPiece( piece ) ? piece.length : tokenTitle( piece, tokens ).length ),
 		isTextPiece( piece )
 			? entityGuide
-			: [ ...entityGuide, piece.type ]
+			: [ ...entityGuide, piece ]
 	], [ emptyBlockMap, 0, [] ] )
 );
 

--- a/client/components/date-time-format-editor/parser.js
+++ b/client/components/date-time-format-editor/parser.js
@@ -1,0 +1,225 @@
+/**
+ * External dependencies
+ */
+import {
+	compact,
+	flowRight as compose,
+	fromPairs,
+	get,
+	map,
+	matchesProperty,
+	reduce,
+} from 'lodash';
+import {
+	convertFromRaw,
+	convertToRaw,
+} from 'draft-js';
+
+/*
+ * The functions in this file convert between the
+ * Calypso-native representation of title formats
+ * and its translation into the structure for the
+ * draft-js editor.
+ *
+ * Custom block titles consist of a list of zero
+ * or more "pieces," each of which is either a
+ * predefined "token" or a sequence of arbitrary
+ * text.
+ *
+ * "Tokens" are placeholders for dynamic content
+ * replaced at runtime, such as a site's name or
+ * a post's title.
+ *
+ * <Calypso-native title format>
+ * [
+ *   { type: 'postTitle' },
+ *   { type: 'string', value: ' | ' },
+ *   { type: 'siteName' }
+ * ]
+ *
+ * The draft-js editor however operates on a list
+ * of blocks containing plain-text and associated
+ * meta information about the characters within
+ * each block. It is domain-specific to rich text
+ * and not to our problems at hand. We must map
+ * the title formats into something the editor can
+ * use to render and edit them. See the draft-js
+ * documentation for understanding its data model.
+ *
+ * draft-js translation of above example
+ * (some data omitted to clarify the example)
+ *
+ * <RawDraftContentState>
+ * {
+ *   blocks: [
+ *     0: {
+ *       text: 'Post Title | Site Name',
+ *       type: 'unstyled',
+ *       entityRanges: [
+ *         { key: 0, offset: 0, length: 10 },
+ *         { key: 1, offset: 13, length: 9 }
+ *       ]
+ *     }
+ *   ],
+ *   entityMap: {
+ *     0: { type: 'TOKEN', mutability: 'IMMUTABLE', data: { name: 'postTitle' } },
+ *     1: { type: 'TOKEN', mutability: 'IMMUTABLE', data: { name: 'siteName' } }
+ *   }
+ * }
+ *
+ * The challenge then is to provide an effective
+ * mapping between these formats. Notice that in
+ * the editor we are showing the translations of
+ * the token names since that is what it will
+ * render to the browser. However, the native name
+ * is stored as metadata for the range of characters
+ * that represent the token.
+ *
+ */
+
+/**
+ * Converts from ContentState to native Calypso format list
+ *
+ * Since the editor constrains us to a single block, we can
+ * safely assume that we only need to convert the first one
+ *
+ * @param {ContentState} content Content of editor
+ * @returns {Array} title format
+ */
+export const fromEditor = content => {
+	const rawContent = convertToRaw( content );
+	const text = get( rawContent, 'blocks[0].text', '' );
+	const ranges = get( rawContent, 'blocks[0].entityRanges', [] );
+	const entities = get( rawContent, 'entityMap' );
+
+	// [ output, index, text ]
+	const [ o, i, t ] = ranges.reduce( ( [ output, lastIndex, remainingText ], next ) => {
+		const tokenName = get( entities, [ next.key, 'data', 'name' ], null );
+		const textBlock = next.offset > lastIndex
+			? { type: 'string', value: remainingText.slice( lastIndex, next.offset ) }
+			: null;
+
+		return [ [
+			...output,
+			textBlock,
+			{ type: tokenName }
+		], next.offset + next.length, remainingText ];
+	}, [ [], 0, text ] );
+
+	// add final remaining text not captured by any entity ranges
+	return compact( [
+		...o,
+		i < t.length && { type: 'string', value: t.slice( i ) }
+	] );
+};
+
+const isTextPiece = matchesProperty( 'type', 'string' );
+
+const emptyBlockMap = {
+	text: '',
+	entityRanges: [],
+	type: 'unstyled'
+};
+
+/**
+ * Preprocesses token title for display in editor.
+ *
+ * Explicit spacing is required here in order to make
+ * the display of the tokens look right. Simply adding
+ * CSS to a trimmed title leads to cursor and spacing
+ * inconsistencies.
+ *
+ * \u205f is a mathematical medium space. A normal space
+ * was being trimmed implicitly somewhere in WebKit and
+ * raising exceptions and causing visual glitches.
+ * See #8047
+ *
+ * @param {string} title - Token's title
+ * @returns {string} - Processed title
+ */
+export const mapTokenTitleForEditor = title => `\u205f\u205f${ title }\u205f\u205f`;
+
+/**
+ * Returns the translated name for the chip
+ *
+ * @param {string} type chip name, e.g. 'siteName'
+ * @param {object} tokens available tokens, e.g. { siteName: 'Site Name', tagline: 'Tagline' }
+ * @returns {string} translated chip name
+ */
+const tokenTitle = ( type, tokens ) => mapTokenTitleForEditor( get( tokens, type, '' ).trim() );
+
+/**
+ * Creates a new entity reference for a blockMap
+ *
+ * @param {Number} offset start of entity inside of block text
+ * @param {String} type token name for entity reference
+ * @param {object} tokens mapping between token names and translated titles
+ * @param {object} entityGuide mapping between tokens and entity keys
+ * @returns {object} entityRange for use in blockMap in ContentState
+ */
+const newEntityAt = ( offset, type, tokens, entityGuide ) => ( {
+	key: entityGuide.length,
+	length: tokenTitle( type, tokens ).length,
+	offset
+} );
+
+/**
+ * Converts native format object to block map
+ *
+ * E.g.
+ *     From: [
+ *         { type: 'siteName' },
+ *         { type: 'string', value: ' | ' },
+ *         { type: 'tagline' }
+ *     ]
+ *     To: {
+ *         text: 'siteName | tagline',
+ *         entityRanges: [
+ *             { key: 0, offset: 0, length: 8 },
+ *             { key: 1, offset: 11, length: 7 }
+ *         ]
+ *     }
+ *
+ * @param {Array} format native Calypso title format object
+ * @param {object} tokens mapping between token names and translated titles
+ * @param {object} entityGuide mapping between tokens and entity keys
+ * @returns {object} blockMap for use in ContentState
+ */
+const buildBlockMap = compose(
+	( format, tokens ) => reduce( format, ( [ block, lastIndex, entityGuide ], piece ) => [
+		{
+			...block,
+			entityRanges: isTextPiece( piece )
+				? block.entityRanges // text pieces don't add entities
+				: [ ...block.entityRanges, newEntityAt( lastIndex, piece.type, tokens, entityGuide ) ],
+			text: block.text + ( isTextPiece( piece ) ? piece.value : tokenTitle( piece.type, tokens ) ),
+		},
+		lastIndex + ( piece.value ? piece.value.length : tokenTitle( piece.type, tokens ).length ),
+		isTextPiece( piece )
+			? entityGuide
+			: [ ...entityGuide, piece.type ]
+	], [ emptyBlockMap, 0, [] ] )
+);
+
+/**
+ * Converts Calypso-native title format into RawDraftContentState for Editor
+ *
+ * @param {Array} format pieces used to build title format
+ * @param {object} tokens mapping between token names and translated titles
+ * @returns {ContentState} content for editor
+ */
+export const toEditor = ( format, tokens ) => {
+	const [ blocks, /* lastIndex */, entityGuide ] = buildBlockMap( format, tokens );
+
+	return convertFromRaw( {
+		blocks: [ blocks ],
+		entityMap: fromPairs( map( entityGuide, ( name, key ) => ( [
+			key, // entity key is position in list
+			{
+				type: 'TOKEN',
+				mutability: 'IMMUTABLE',
+				data: { name }
+			}
+		] ) ) )
+	} );
+};

--- a/client/components/date-time-format-editor/style.scss
+++ b/client/components/date-time-format-editor/style.scss
@@ -1,0 +1,88 @@
+.date-time-format-editor {
+	margin-bottom: 20px;
+
+	&.disabled {
+		.date-time-format-editor__editor-wrapper {
+			border: 1px solid lighten( $gray, 20% );
+			background-color: $gray-light;
+		}
+
+		.date-time-format-editor__token, .date-time-format-editor__button {
+			pointer-events: none;
+		}
+
+		.date-time-format-editor__token {
+			background-color: $gray;
+		}
+	}
+}
+
+.date-time-format-editor__header {
+	display: flex;
+	align-items: baseline;
+	justify-content: flex-end;
+	flex-wrap: wrap-reverse;
+	margin-bottom: 6px;
+}
+
+.date-time-format-editor__title {
+	font-weight: 600;
+	font-size: 14px;
+	flex: 1;
+	margin-right: auto;
+}
+
+.date-time-format-editor__button {
+	border-radius: 3px;
+	background-color: $white;
+	color: darken( $gray, 30% );
+	border: 1px solid lighten( $gray, 20% );
+	padding: 3px 8px 3px 8px;
+	margin-left: 10px;
+	margin-top: 3px;
+	font-size: 12px;
+	font-weight: 600;
+	cursor: pointer;
+
+	&:before {
+		content: '+';
+		margin-right: 4px;
+		font-weight: 600;
+	}
+
+	&:hover {
+		color: $blue-medium;
+	}
+}
+
+.date-time-format-editor__editor-wrapper {
+	border: 1px solid lighten( $gray, 10% );
+	padding: 7px 14px;
+	line-height: 24px;
+}
+
+.date-time-format-editor__token {
+	display: inline-block;
+	background-color: darken( $gray, 20% );
+	color: $white;
+	border-radius: 4px;
+	cursor: pointer;
+	transition: all 0.3s ease;
+
+	&:hover {
+		background-color: $alert-red;
+	}
+}
+
+.date-time-format-editor__token-close {
+	margin-left: 10px;
+	color: lighten( $gray, 10% );
+	font-size: 10px;
+}
+
+.date-time-format-editor__preview {
+	color: $gray;
+	font-style: italic;
+	margin-top: 5px;
+	font-size: 13px;
+}

--- a/client/components/date-time-format-editor/token.jsx
+++ b/client/components/date-time-format-editor/token.jsx
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export const Token = props => {
+	const { onClick } = props;
+
+	// please ignore the formatting below
+	// if we allow spaces it will mess up
+	// the way the component renders in
+	// the draft-js editor
+	return (
+		<span
+			className="date-time-format-editor__token"
+			onClick={ onClick( props.entityKey ) }
+		>{ props.children }</span>
+	);
+};
+
+export default Token;

--- a/client/lib/formatting/index.js
+++ b/client/lib/formatting/index.js
@@ -53,8 +53,6 @@ function stripHTML( string ) {
  * @return {string}             the widow-prevented string
  */
 function preventWidows( text, wordsToKeep = 2 ) {
-	let words, endWords;
-
 	if ( typeof text !== 'string' ) {
 		return text;
 	}
@@ -64,7 +62,7 @@ function preventWidows( text, wordsToKeep = 2 ) {
 		return text;
 	}
 
-	words = text.match( /\S+/g );
+	const words = text.match( /\S+/g );
 	if ( ! words || 1 === words.length ) {
 		return text;
 	}
@@ -73,7 +71,7 @@ function preventWidows( text, wordsToKeep = 2 ) {
 		return words.join( '\xA0' );
 	}
 
-	endWords = words.splice( -wordsToKeep, wordsToKeep );
+	const endWords = words.splice( -wordsToKeep, wordsToKeep );
 
 	return words.join( ' ' ) + ' ' + endWords.join( '\xA0' );
 }

--- a/client/my-sites/site-settings/date-time-format/date-format-option.jsx
+++ b/client/my-sites/site-settings/date-time-format/date-format-option.jsx
@@ -15,6 +15,14 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import { defaultDateFormats } from './default-formats';
 import { phpToMomentDatetimeFormat } from './utils';
 
+import DateTimeFormatEditor from 'components/date-time-format-editor';
+
+const getValidTokens = translate => ( {
+	Y: translate( 'Year' ),
+	M: translate( 'Month' ),
+	D: translate( 'Day' ),
+} );
+
 export const DateFormatOption = ( {
 	dateFormat,
 	disabled,
@@ -67,6 +75,15 @@ export const DateFormatOption = ( {
 				</FormSettingExplanation>
 			</span>
 		</FormLabel>
+		<div>
+			<DateTimeFormatEditor
+				disabled={ disabled }
+				placeholder={ 'YYYY-MM-DD' }
+				titleFormats={ dateFormat || '' }
+				tokens={ getValidTokens( translate ) }
+				type={ { label: 'Date Format Custom', value: 'date_format_custom' } }
+			/>
+		</div>
 	</FormFieldset>
 );
 


### PR DESCRIPTION
Add Draft.js tokens to the custom date/time formats.

See: https://github.com/Automattic/wp-calypso/issues/10441#issuecomment-271835986