### PR TITLE
Checkout: Add loading state

### DIFF
--- a/client/lib/upgrades/notices.jsx
+++ b/client/lib/upgrades/notices.jsx
@@ -39,7 +39,7 @@ export function displayError( error ) {
 	if ( typeof error.message === 'object' ) {
 		notices.error( <ValidationErrorList messages={ flatten( values( error.message ) ) } /> );
 	} else {
-		notices.error( getErrorFromApi( error.message ) )
+		notices.error( getErrorFromApi( error.message ) );
 	}
 }
 

--- a/client/lib/upgrades/notices.jsx
+++ b/client/lib/upgrades/notices.jsx
@@ -9,7 +9,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import notices from 'notices'
+import notices from 'notices';
 import ValidationErrorList from 'notices/validation-error-list';
 
 function getErrorFromApi( errorMessage ) {
@@ -41,10 +41,6 @@ export function displayError( error ) {
 	} else {
 		notices.error( getErrorFromApi( error.message ) )
 	}
-}
-
-export function displaySubmitting( { isFreeCart } ) {
-	notices.info( isFreeCart ? i18n.translate( 'Submitting' ) : i18n.translate( 'Submitting payment' ) );
 }
 
 export function clear() {

--- a/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import classnames from 'classnames';
+import { some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,17 +13,73 @@ var PayButton = require( './pay-button' ),
 	TermsOfService = require( './terms-of-service' ),
 	PaymentBox = require( './payment-box' ),
 	analytics = require( 'lib/analytics' ),
-	cartValues = require( 'lib/cart-values' );
+	cartValues = require( 'lib/cart-values' ),
+	transactionStepTypes = require( 'lib/store-transactions/step-types' );
 
 import CartCoupon from 'my-sites/upgrades/cart/cart-coupon';
 import PaymentChatButton from './payment-chat-button';
 import config from 'config';
 import { PLAN_BUSINESS } from 'lib/plans/constants';
-import { some } from 'lodash';
+import ProgressBar from 'components/progress-bar';
 
 var CreditCardPaymentBox = React.createClass( {
 	getInitialState: function() {
-		return { previousCart: null };
+		return {
+			elapsed: 0,
+			previousCart: null
+		};
+	},
+
+	componentWillReceiveProps: function( nextProps ) {
+		if ( nextProps.transactionStep && this.submitting( nextProps.transactionStep ) ) {
+			this.timer = setInterval( this.tick, 100 );
+		}
+	},
+
+	componentWillUnmount: function() {
+		clearInterval( this.timer );
+	},
+
+	tick: function() {
+		const elasped = this.state.elapsed + 1 / 100 * ( 100 - this.state.elapsed );
+		this.setState( {
+			elapsed: elasped
+		} );
+	},
+
+	submitting: function( transactionStep ) {
+		switch ( transactionStep.name ) {
+			case transactionStepTypes.BEFORE_SUBMIT:
+				return false;
+
+			case transactionStepTypes.INPUT_VALIDATION:
+				if ( this.props.transactionStep.error ) {
+					return false;
+				}
+				return true;
+
+			case transactionStepTypes.SUBMITTING_PAYMENT_KEY_REQUEST:
+				return true;
+
+			case transactionStepTypes.RECEIVED_PAYMENT_KEY_RESPONSE:
+				return true;
+
+			case transactionStepTypes.SUBMITTING_WPCOM_REQUEST:
+				return true;
+
+			case transactionStepTypes.RECEIVED_WPCOM_RESPONSE:
+				if ( this.props.transactionStep.error || ! this.props.transactionStep.data.success ) {
+					return false;
+				}
+				return true;
+
+			default:
+				return false;
+		}
+	},
+
+	progress: function() {
+		return Math.round( this.state.elapsed );
 	},
 
 	handleToggle: function( event ) {
@@ -33,17 +90,60 @@ var CreditCardPaymentBox = React.createClass( {
 		this.props.onToggle( 'paypal' );
 	},
 
+	progressBar: function() {
+		return (
+			<div className="credit-card-payment-box__progress-bar">
+				{ this.translate( 'Processing payment…' ) }
+				<ProgressBar value={ this.progress() } isPulsing />
+			</div>
+		);
+	},
+
+	paymentButtons: function() {
+		const cart = this.props.cart,
+			hasBusinessPlanInCart = some( cart.products, { product_slug: PLAN_BUSINESS } ),
+			showPaymentChatButton = config.isEnabled( 'upgrades/presale-chat' ) && hasBusinessPlanInCart,
+			paypalButtonClasses = classnames( 'credit-card-payment-box__switch-link', {
+				'credit-card-payment-box__switch-link-left': showPaymentChatButton
+			} );
+
+		return (
+			<div className="payment-box__payment-buttons">
+				<PayButton
+					cart={ this.props.cart }
+					transactionStep={ this.props.transactionStep } />
+
+				{ cartValues.isPayPalExpressEnabled( cart )
+					? <a className={ paypalButtonClasses } href="" onClick={ this.handleToggle }>{ this.translate( 'or use PayPal' ) }</a>
+					: null
+				}
+
+				{
+					showPaymentChatButton &&
+					<PaymentChatButton
+						paymentType="credits"
+						cart={ this.props.cart }
+						transactionStep={ this.props.transactionStep } />
+				}
+			</div>
+		);
+	},
+
+	paymentBoxActions: function() {
+		let content = this.paymentButtons();
+		if ( this.props.transactionStep && this.submitting( this.props.transactionStep ) ) {
+			content = this.progressBar();
+		}
+
+		return (
+			<div className="payment-box-actions">
+				{ content }
+			</div>
+		);
+	},
+
 	content: function() {
 		var cart = this.props.cart;
-
-		const hasBusinessPlanInCart = some( cart.products, { product_slug: PLAN_BUSINESS } );
-		const showPaymentChatButton =
-			config.isEnabled( 'upgrades/presale-chat' ) &&
-			hasBusinessPlanInCart;
-
-		const paypalButtonClasses = classnames( 'credit-card-payment-box__switch-link', {
-			'credit-card-payment-box__switch-link-left': showPaymentChatButton
-		} );
 
 		return (
 			<form autoComplete="off" onSubmit={ this.props.onSubmit }>
@@ -58,24 +158,7 @@ var CreditCardPaymentBox = React.createClass( {
 
 				<CartCoupon cart={ cart } />
 
-				<div className="payment-box-actions">
-					<PayButton
-						cart={ this.props.cart }
-						transactionStep={ this.props.transactionStep } />
-
-					{ cartValues.isPayPalExpressEnabled( cart )
-						? <a className={ paypalButtonClasses } href="" onClick={ this.handleToggle }>{ this.translate( 'or use PayPal' ) }</a>
-						: null
-					}
-
-					{
-						showPaymentChatButton &&
-						<PaymentChatButton
-							paymentType="credits"
-							cart={ this.props.cart }
-							transactionStep={ this.props.transactionStep } />
-					}
-				</div>
+				{ this.paymentBoxActions() }
 			</form>
 		);
 	},

--- a/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
@@ -25,7 +25,7 @@ import ProgressBar from 'components/progress-bar';
 var CreditCardPaymentBox = React.createClass( {
 	getInitialState: function() {
 		return {
-			elapsed: 0,
+			progress: 0,
 			previousCart: null
 		};
 	},
@@ -41,10 +41,10 @@ var CreditCardPaymentBox = React.createClass( {
 	},
 
 	tick: function() {
-		const elasped = this.state.elapsed + 1 / 200 * ( 100 - this.state.elapsed );
-		this.setState( {
-			elapsed: elasped
-		} );
+		// increase the progress of the progress bar by 0.5% of the remaining progress each tick
+		const progress = this.state.progress + 1 / 200 * ( 100 - this.state.progress );
+
+		this.setState( { progress } );
 	},
 
 	submitting: function( transactionStep ) {
@@ -74,10 +74,6 @@ var CreditCardPaymentBox = React.createClass( {
 		}
 	},
 
-	progress: function() {
-		return Math.round( this.state.elapsed );
-	},
-
 	handleToggle: function( event ) {
 		event.preventDefault();
 
@@ -90,7 +86,7 @@ var CreditCardPaymentBox = React.createClass( {
 		return (
 			<div className="credit-card-payment-box__progress-bar">
 				{ this.translate( 'Processing payment…' ) }
-				<ProgressBar value={ this.progress() } isPulsing />
+				<ProgressBar value={ Math.round( this.state.progress ) } isPulsing />
 			</div>
 		);
 	},
@@ -141,7 +137,7 @@ var CreditCardPaymentBox = React.createClass( {
 	submit: function( event ) {
 		event.preventDefault();
 		this.setState( {
-			elapsed: 0
+			progress: 0
 		} );
 		this.props.onSubmit( event );
 	},

--- a/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
@@ -31,7 +31,7 @@ var CreditCardPaymentBox = React.createClass( {
 	},
 
 	componentWillReceiveProps: function( nextProps ) {
-		if ( nextProps.transactionStep && this.submitting( nextProps.transactionStep ) ) {
+		if ( ! this.submitting( this.props.transactionStep ) && this.submitting( nextProps.transactionStep ) ) {
 			this.timer = setInterval( this.tick, 100 );
 		}
 	},

--- a/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
@@ -41,7 +41,7 @@ var CreditCardPaymentBox = React.createClass( {
 	},
 
 	tick: function() {
-		const elasped = this.state.elapsed + 1 / 100 * ( 100 - this.state.elapsed );
+		const elasped = this.state.elapsed + 1 / 200 * ( 100 - this.state.elapsed );
 		this.setState( {
 			elapsed: elasped
 		} );
@@ -59,16 +59,12 @@ var CreditCardPaymentBox = React.createClass( {
 				return true;
 
 			case transactionStepTypes.SUBMITTING_PAYMENT_KEY_REQUEST:
-				return true;
-
 			case transactionStepTypes.RECEIVED_PAYMENT_KEY_RESPONSE:
-				return true;
-
 			case transactionStepTypes.SUBMITTING_WPCOM_REQUEST:
 				return true;
 
 			case transactionStepTypes.RECEIVED_WPCOM_RESPONSE:
-				if ( this.props.transactionStep.error || ! this.props.transactionStep.data.success ) {
+				if ( transactionStep.error || ! transactionStep.data.success ) {
 					return false;
 				}
 				return true;
@@ -142,11 +138,19 @@ var CreditCardPaymentBox = React.createClass( {
 		);
 	},
 
+	submit: function( event ) {
+		event.preventDefault();
+		this.setState( {
+			elapsed: 0
+		} );
+		this.props.onSubmit( event );
+	},
+
 	content: function() {
 		var cart = this.props.cart;
 
 		return (
-			<form autoComplete="off" onSubmit={ this.props.onSubmit }>
+			<form autoComplete="off" onSubmit={ this.submit }>
 				<CreditCardSelector
 					cards={ this.props.cards }
 					countriesList={ this.props.countriesList }

--- a/client/my-sites/upgrades/checkout/style.scss
+++ b/client/my-sites/upgrades/checkout/style.scss
@@ -926,3 +926,10 @@
 		transform: translateZ(0) scale(1);
 	}
 }
+
+.credit-card-payment-box__progress-bar {
+	color: grey;
+	font-size: 12px;
+	padding-bottom: 1em;
+	text-align: center;
+}

--- a/client/my-sites/upgrades/checkout/style.scss
+++ b/client/my-sites/upgrades/checkout/style.scss
@@ -928,7 +928,7 @@
 }
 
 .credit-card-payment-box__progress-bar {
-	color: grey;
+	color: $grey;
 	font-size: 12px;
 	padding-bottom: 1em;
 	text-align: center;

--- a/client/my-sites/upgrades/checkout/style.scss
+++ b/client/my-sites/upgrades/checkout/style.scss
@@ -18,7 +18,6 @@
 
 		&:not(.domain-details) {
 			@include breakpoint( "<660px" ) {
-				background-color: transparent;
 				box-shadow: none;
 			}
 		}
@@ -261,12 +260,10 @@
 	}
 
 	.payment-box-actions {
-		@include breakpoint( ">660px" ) {
-			margin: 20px -30px 0px -30px;
-			padding: 20px 30px 0 30px;
-			border-top: 1px solid lighten( $gray, 30% );
-			@include clear-fix;
-		}
+		margin: 20px -30px 0px -30px;
+		padding: 20px 30px 0 30px;
+		border-top: 1px solid lighten( $gray, 30% );
+		@include clear-fix;
 	}
 
 	.credit-card-payment-box {
@@ -928,7 +925,7 @@
 }
 
 .credit-card-payment-box__progress-bar {
-	color: $grey;
+	color: $gray;
 	font-size: 12px;
 	padding-bottom: 1em;
 	text-align: center;

--- a/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
+++ b/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
@@ -12,8 +12,8 @@ const debug = debugFactory( 'calypso:my-sites:upgrades:checkout:transaction-step
  */
 import analytics from 'lib/analytics';
 import adTracking from 'lib/analytics/ad-tracking';
-import { cartItems, isFree } from 'lib/cart-values';
-import { displayError, displaySubmitting, clear } from 'lib/upgrades/notices';
+import { cartItems } from 'lib/cart-values';
+import { displayError, clear } from 'lib/upgrades/notices';
 import upgradesActions from 'lib/upgrades/actions';
 import { removeNestedProperties } from 'lib/cart/store/cart-analytics';
 
@@ -53,12 +53,6 @@ const TransactionStepsMixin = {
 		}
 
 		switch ( step.name ) {
-			case 'input-validation':
-				if ( ! cartItems.hasFreeTrial( cart ) ) {
-					displaySubmitting( { isFreeCart: isFree( cart ) } );
-				}
-				break;
-
 			case 'received-wpcom-response':
 				clear();
 				break;


### PR DESCRIPTION
This pull request fixes #2353 by adding a progress bar to the checkout form. This was an issue that was brought up in several usability tests for /domains.
 
![checkout](https://cloud.githubusercontent.com/assets/275961/24364534/f39a611e-130a-11e7-8606-beb147b65f93.gif)

The state of the progress bar is entirely artificial, which is not an ideal solution, but the perception of the users should be that their transaction is progressing.

#### Testing instructions
  
1. Run `git checkout add/checkout-loading-state` and start your server, or open a [live branch](https://delphin.live/?branch=add/checkout-loading-state)
2. Open the Calypso and add a plan to the cart
3. Make a payment and check that instead of the "Submitting payment" notice you see a progress bar
  
#### Reviews
  
- [x] Code
- [x] Product

@Automattic/sdev-feed