### PR TITLE
Update the NS check on the domains page

### DIFF
--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -98,7 +98,7 @@ export default React.createClass( {
 	wrongNSMappedDomains() {
 		debug( 'Rendering wrongNSMappedDomains' );
 
-		if ( get( this.props, 'selectedSite.jetpack' ) && ! get( this.props, 'selectedSite.options.is_automated_transfer' ) ) {
+		if ( get( this.props, 'selectedSite.jetpack' ) || get( this.props, 'selectedSite.options.is_automated_transfer' ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
Once a site has been migrated the name servers will no longer point to wpcom so we should
not be checking that they do.