### PR TITLE
ThemesSelection: don't show loading state when fetching themes.

### DIFF
--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -95,6 +95,15 @@ describe( 'logged-out', () => {
 		} );
 
 		it( 'renders without error when no themes are present', () => {
+			this.store.dispatch( receiveThemes( [], 'wpcom' ) );
+			this.store.dispatch( {
+				type: THEMES_REQUEST_SUCCESS,
+				siteId: 'wpcom',
+				query: DEFAULT_THEME_QUERY,
+				found: 0,
+				themes: []
+			} );
+
 			let markup;
 			assert.doesNotThrow( () => {
 				markup = renderToString( this.layout );

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -95,14 +95,7 @@ describe( 'logged-out', () => {
 		} );
 
 		it( 'renders without error when no themes are present', () => {
-			this.store.dispatch( receiveThemes( [], 'wpcom' ) );
-			this.store.dispatch( {
-				type: THEMES_REQUEST_SUCCESS,
-				siteId: 'wpcom',
-				query: DEFAULT_THEME_QUERY,
-				found: 0,
-				themes: []
-			} );
+			this.store.dispatch( receiveThemes( [], 'wpcom', DEFAULT_THEME_QUERY, 0 ) );
 
 			let markup;
 			assert.doesNotThrow( () => {

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -54,7 +54,6 @@ class ThemesSelection extends Component {
 	static defaultProps = {
 		emptyContent: null,
 		showUploadButton: true,
-		showPlaceholders: true
 	}
 
 	state = {

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -56,16 +56,6 @@ class ThemesSelection extends Component {
 		showUploadButton: true,
 	}
 
-	state = {
-		showPlaceholders: ! this.themes
-	}
-
-	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.themesCount !== null && ! nextProps.isRequesting ) {
-			this.setState( { showPlaceholders: false } );
-		}
-	}
-
 	shouldComponentUpdate( nextProps ) {
 		return nextProps.themesCount !== null;
 	}
@@ -148,7 +138,7 @@ class ThemesSelection extends Component {
 	shouldShowPlaceholders() {
 		// 1 show placholders on initial load
 		// 2 show placeholders when we have themes to show and are fetching next pages
-		return this.state.showPlaceholders || ( this.props.isRequesting && ( this.props.themesCount !== null ) );
+		return this.props.isRequesting || this.props.themesCount === null;
 	}
 
 	render() {

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -32,8 +32,6 @@ import config from 'config';
 class ThemesSelection extends Component {
 	static propTypes = {
 		emptyContent: PropTypes.element,
-		query: PropTypes.object.isRequired,
-		siteId: PropTypes.number,
 		onScreenshotClick: PropTypes.func,
 		getOptions: PropTypes.func,
 		getActionLabel: PropTypes.func,
@@ -55,7 +53,22 @@ class ThemesSelection extends Component {
 
 	static defaultProps = {
 		emptyContent: null,
-		showUploadButton: true
+		showUploadButton: true,
+		showPlaceholders: true
+	}
+
+	state = {
+		showPlaceholders: ! this.themes
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.themesCount !== null && ! nextProps.isRequesting ) {
+			this.setState( { showPlaceholders: false } );
+		}
+	}
+
+	shouldComponentUpdate( nextProps ) {
+		return nextProps.themesCount !== null;
 	}
 
 	recordSearchResultsClick = ( theme, resultsRank, action ) => {
@@ -133,19 +146,22 @@ class ThemesSelection extends Component {
 		return options;
 	}
 
+	shouldShowPlaceholders() {
+		// 1 show placholders on initial load
+		// 2 show placeholders when we have themes to show and are fetching next pages
+		return this.state.showPlaceholders || ( this.props.isRequesting && ( this.props.themesCount !== null ) );
+	}
+
 	render() {
-		const { source, query, listLabel, themesCount } = this.props;
+		const { listLabel, themes, themesCount } = this.props;
 
 		return (
 			<div className="themes__selection">
-				<QueryThemes
-					query={ query }
-					siteId={ source } />
 				<ThemesSelectionHeader
 					label={ listLabel }
 					count={ themesCount }
 				/>
-				<ThemesList themes={ this.props.themes }
+				<ThemesList themes={ themes }
 					fetchNextPage={ this.fetchNextPage }
 					onMoreButtonClick={ this.recordSearchResultsClick }
 					getButtonOptions={ this.getOptions }
@@ -155,7 +171,7 @@ class ThemesSelection extends Component {
 					isActive={ this.props.isThemeActive }
 					isPurchased={ this.props.isThemePurchased }
 					isInstalling={ this.props.isInstallingTheme }
-					loading={ this.props.isRequesting }
+					loading={ this.shouldShowPlaceholders() }
 					emptyContent={ this.props.emptyContent }
 					placeholderCount={ this.props.placeholderCount } />
 			</div>
@@ -164,31 +180,8 @@ class ThemesSelection extends Component {
 }
 
 const ConnectedThemesSelection = connect(
-	( state, { filter, page, search, tier, vertical, siteId, source } ) => {
-		const isJetpack = isJetpackSite( state, siteId );
-		let sourceSiteId;
-		if ( source === 'wpcom' || source === 'wporg' ) {
-			sourceSiteId = source;
-		} else {
-			sourceSiteId = ( siteId && isJetpack ) ? siteId : 'wpcom';
-		}
-
-		// number calculation is just a hack for Jetpack sites. Jetpack themes endpoint does not paginate the
-		// results and sends all of the themes at once. QueryManager is not expecting such behaviour
-		// and we ended up loosing all of the themes above number 20. Real solution will be pagination on
-		// Jetpack themes endpoint.
-		const number = ! includes( [ 'wpcom', 'wporg' ], sourceSiteId ) ? 2000 : 20;
-		const query = {
-			search,
-			page,
-			tier: config.isEnabled( 'upgrades/premium-themes' ) ? tier : 'free',
-			filter: compact( [ filter, vertical ] ).join( ',' ),
-			number
-		};
-
+	( state, { siteId, sourceSiteId, query } ) => {
 		return {
-			query,
-			source: sourceSiteId,
 			siteSlug: getSiteSlug( state, siteId ),
 			themes: getThemesForQueryIgnoringPage( state, sourceSiteId, query ) || [],
 			themesCount: getThemesFoundForQuery( state, sourceSiteId, query ),
@@ -236,13 +229,50 @@ class ThemesSelectionWithPage extends React.Component {
 	}
 
 	render() {
+		const { filter, search, tier, vertical, sourceSiteId } = this.props;
+
+		// number calculation is just a hack for Jetpack sites. Jetpack themes endpoint does not paginate the
+		// results and sends all of the themes at once. QueryManager is not expecting such behaviour
+		// and we ended up loosing all of the themes above number 20. Real solution will be pagination on
+		// Jetpack themes endpoint.
+		const number = ! includes( [ 'wpcom', 'wporg' ], sourceSiteId ) ? 2000 : 20;
+		const query = {
+			search,
+			page: this.state.page,
+			tier: config.isEnabled( 'upgrades/premium-themes' ) ? tier : 'free',
+			filter: compact( [ filter, vertical ] ).join( ',' ),
+			number
+		};
+
 		return (
-			<ConnectedThemesSelection { ...this.props }
-				page={ this.state.page }
-				incrementPage={ this.incrementPage }
-			/>
+			<div>
+				<QueryThemes
+					query={ query }
+					siteId={ sourceSiteId } />
+				<ConnectedThemesSelection { ...this.props }
+					query={ query }
+					page={ this.state.page }
+					incrementPage={ this.incrementPage }
+				/>
+			</div>
 		);
 	}
 }
 
-export default ThemesSelectionWithPage;
+const ConnectedThemesSelectionWithPage = connect(
+	( state, { siteId, source } ) => {
+		const isJetpack = isJetpackSite( state, siteId );
+		let sourceSiteId;
+		if ( source === 'wpcom' || source === 'wporg' ) {
+			sourceSiteId = source;
+		} else {
+			sourceSiteId = ( siteId && isJetpack ) ? siteId : 'wpcom';
+		}
+
+		return {
+			sourceSiteId
+		};
+	}
+)( ThemesSelectionWithPage );
+
+export default ConnectedThemesSelectionWithPage;

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -20,6 +20,7 @@ import { getSiteSlug } from 'state/sites/selectors';
 import {
 	getThemesForQueryIgnoringPage,
 	getThemesFoundForQuery,
+	getQueryRequestError,
 	isRequestingThemesForQuery,
 	isThemesLastPageForQuery,
 	isPremiumThemeAvailable,
@@ -138,7 +139,7 @@ class ThemesSelection extends Component {
 	shouldShowPlaceholders() {
 		// 1 show placholders on initial load
 		// 2 show placeholders when we have themes to show and are fetching next pages
-		return this.props.isRequesting || this.props.themesCount === null;
+		return this.props.isRequesting || ( this.props.themesCount === null && this.props.queryError === null );
 	}
 
 	render() {
@@ -174,6 +175,7 @@ const ConnectedThemesSelection = connect(
 			siteSlug: getSiteSlug( state, siteId ),
 			themes: getThemesForQueryIgnoringPage( state, sourceSiteId, query ) || [],
 			themesCount: getThemesFoundForQuery( state, sourceSiteId, query ),
+			queryError: getQueryRequestError( state, sourceSiteId, query ),
 			isRequesting: isRequestingThemesForQuery( state, sourceSiteId, query ),
 			isLastPage: isThemesLastPageForQuery( state, sourceSiteId, query ),
 			isLoggedIn: !! getCurrentUserId( state ),

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -99,6 +99,19 @@ export function getThemeRequestErrors( state, themeId, siteId ) {
 }
 
 /**
+ * Returns theme query request error object or null if no error
+ *
+ * @param  {Object}  state   Global state tree
+ * @param  {Number}  siteId  Site ID
+ * @param  {Object}  query  Theme query object
+ * @return {Object}          error object if present or null otherwise
+ */
+export function getQueryRequestError( state, siteId, query ) {
+	const serializedQuery = getSerializedThemesQuery( query, siteId );
+	return get( state.themes.queryRequestErrors, [ siteId, serializedQuery ], null );
+}
+
+/**
  * Returns an array of normalized themes for the themes query, or null if no
  * themes have been received.
  *


### PR DESCRIPTION
### Info
By changing components hierarchy from:
```
<ThemesSelection> 
    <QueryThemes>
    <ThemesSelectionHeader>
    <ThemesList>
</ThemesSelection>
```
to:
```
<QueryThemes>
<ThemesSelection> 
    <ThemesSelectionHeader>
    <ThemesList>
</ThemesSelection>
```
We are able to implement `shouldComponentUpdate` for ThemesSelectio  in a way that rendered themes will only change when the new set of themes has arrived. No loading state is shown except for initial load - where we have nothing to show yet. Second case when we show loading placeholders is when we are loading more than initial pages  - in this case loading placeholders are added at end of the list.

### Testing
Go to `/design` start searching and observe Showacase behavior. Compare to master.  