### PR TITLE
Reader: Fix up links to jetpack galleries

### DIFF
--- a/client/lib/post-normalizer/rule-content-link-jetpack-carousels.js
+++ b/client/lib/post-normalizer/rule-content-link-jetpack-carousels.js
@@ -27,6 +27,7 @@ export default function linkJetpackCarousels( post, dom ) {
 				const attachmentId = img.getAttribute( 'data-attachment-id' );
 				if ( attachmentId ) {
 					link.href = permalink + '#jp-carousel-' + attachmentId;
+					link.setAttribute( 'target', '_blank' );
 				}
 			}
 		} );

--- a/client/lib/post-normalizer/rule-content-link-jetpack-carousels.js
+++ b/client/lib/post-normalizer/rule-content-link-jetpack-carousels.js
@@ -1,0 +1,35 @@
+/**
+ * External Dependencies
+ */
+import { forEach, get } from 'lodash';
+
+export default function linkJetpackCarousels( post, dom ) {
+	const galleries = dom.querySelectorAll( '.tiled-gallery' );
+
+	forEach( galleries, gallery => {
+		let extra = get( gallery, [ 'dataset', 'carouselExtra' ], false );
+		if ( ! extra ) {
+			extra = gallery.getAttribute( 'data-carousel-extra' );
+			if ( ! extra ) {
+				return post;
+			}
+		}
+		let permalink;
+		try {
+			permalink = JSON.parse( extra ).permalink;
+		} catch ( e ) {
+			return post;
+		}
+		const links = gallery.querySelectorAll( '.tiled-gallery-item > a' );
+		forEach( links, link => {
+			const img = link.querySelector( 'img' );
+			if ( img ) {
+				const attachmentId = img.getAttribute( 'data-attachment-id' );
+				if ( attachmentId ) {
+					link.href = permalink + '#jp-carousel-' + attachmentId;
+				}
+			}
+		} );
+	} );
+	return post;
+}

--- a/client/lib/post-normalizer/rule-content-link-jetpack-carousels.js
+++ b/client/lib/post-normalizer/rule-content-link-jetpack-carousels.js
@@ -3,14 +3,28 @@
  */
 import { forEach, get } from 'lodash';
 
+/**
+ * The linkJetpackCarousels rule modifies all of the WordPress galleries in the content
+ * to link you to their host website's carousel instead of the permalink for that specific image.
+ * Based on the DOM layout for Jetpack Galleries, which are used by Jetpack sites and WordPress.com sites
+ * For example,
+ * Before: https://example.com/2017/03/25/my-family/img_1/
+ * After: https://example.com/2017/03/25/my-family/#jp-carousel-1234
+ * @param  {Object} post The post
+ * @param  {Object} dom  The DOM for the post's content
+ * @return {Object}      The post, with any additions
+ */
 export default function linkJetpackCarousels( post, dom ) {
 	const galleries = dom.querySelectorAll( '.tiled-gallery' );
 
 	forEach( galleries, gallery => {
 		let extra = get( gallery, [ 'dataset', 'carouselExtra' ], false );
 		if ( ! extra ) {
+			// this only really exists for jsdom. See https://github.com/tmpvar/jsdom/issues/961
 			extra = gallery.getAttribute( 'data-carousel-extra' );
 			if ( ! extra ) {
+				// We couldn't find the extra for this gallery. While we could pull it from the post, this makes it
+				// suspect that we really found a jetpack gallery. Just bail.
 				return post;
 			}
 		}
@@ -18,17 +32,17 @@ export default function linkJetpackCarousels( post, dom ) {
 		try {
 			permalink = JSON.parse( extra ).permalink;
 		} catch ( e ) {
+			// doesn't look like the extra was valid JSON. Maybe this isn't really a gallery? Bail.
 			return post;
 		}
+		// find all the links and rewrite them to point to the carousel instead of the permalink
 		const links = gallery.querySelectorAll( '.tiled-gallery-item > a' );
 		forEach( links, link => {
 			const img = link.querySelector( 'img' );
-			if ( img ) {
-				const attachmentId = img.getAttribute( 'data-attachment-id' );
-				if ( attachmentId ) {
-					link.href = permalink + '#jp-carousel-' + attachmentId;
-					link.setAttribute( 'target', '_blank' );
-				}
+			const attachmentId = img && img.getAttribute( 'data-attachment-id' );
+			if ( attachmentId ) {
+				link.href = permalink + '#jp-carousel-' + attachmentId;
+				link.setAttribute( 'target', '_blank' );
 			}
 		} );
 	} );

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -378,10 +378,10 @@ describe( 'index', function() {
 		it( 'leaves galleries intact', function( done ) {
 			normalizer(
 				{
-					content: '<style>.gallery{}</style><div class="gallery" style="width: 100000px"><div style="width:100px">some content</div></div>'
+					content: '<style>.gallery{}</style><div class="gallery" style="width: 100000px"><div style="width:100px">some content</div></div>' //eslint-disable-line max-len
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.removeStyles ] ) ], function( err, normalized ) {
-					assert.equal( normalized.content, '<style>.gallery{}</style><div class="gallery" style="width: 100000px"><div style="width:100px">some content</div></div>' );
+					assert.equal( normalized.content, '<style>.gallery{}</style><div class="gallery" style="width: 100000px"><div style="width:100px">some content</div></div>' ); //eslint-disable-line max-len
 					done( err );
 				}
 			);
@@ -395,7 +395,7 @@ describe( 'index', function() {
 					content: '<img src="http://example.com/example.jpg"><img src="http://example.com/example2.jpg">'
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe() ] ) ], function( err, normalized ) {
-					assert.equal( normalized.content, '<img src="http://example.com/example.jpg-SAFE"><img src="http://example.com/example2.jpg-SAFE">' );
+					assert.equal( normalized.content, '<img src="http://example.com/example.jpg-SAFE"><img src="http://example.com/example2.jpg-SAFE">' ); //eslint-disable-line max-len
 					done( err );
 				}
 			);
@@ -408,7 +408,9 @@ describe( 'index', function() {
 					content: '<img src="/example.jpg"><img src="example2.jpg">'
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe() ] ) ], function( err, normalized ) {
-					assert.equal( normalized.content, '<img src="http://example.wordpress.com/example.jpg-SAFE"><img src="http://example.wordpress.com/example2.jpg-SAFE">' );
+					assert.equal(
+						normalized.content,
+						'<img src="http://example.wordpress.com/example.jpg-SAFE"><img src="http://example.wordpress.com/example2.jpg-SAFE">' ); //eslint-disable-line max-len
 					done( err );
 				}
 			);
@@ -433,7 +435,9 @@ describe( 'index', function() {
 					content: '<img src="http://example.com/example.jpg"><img src="http://example.com/example2.jpg">'
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe( 400 ) ] ) ], function( err, normalized ) {
-					assert.equal( normalized.content, '<img src="http://example.com/example.jpg-SAFE?quality=80&amp;strip=info&amp;w=400"><img src="http://example.com/example2.jpg-SAFE?quality=80&amp;strip=info&amp;w=400">' );
+					assert.equal(
+						normalized.content,
+						'<img src="http://example.com/example.jpg-SAFE?quality=80&amp;strip=info&amp;w=400"><img src="http://example.com/example2.jpg-SAFE?quality=80&amp;strip=info&amp;w=400">' ); //eslint-disable-line max-len
 					done( err );
 				}
 			);
@@ -468,7 +472,7 @@ describe( 'index', function() {
 		it( 'removes srcsets', function( done ) {
 			normalizer(
 				{
-					content: '<img src="http://example.com/example.jpg" srcset="http://example.com/example-100.jpg 100w, http://example.com/example-600.jpg 600w">'
+					content: '<img src="http://example.com/example.jpg" srcset="http://example.com/example-100.jpg 100w, http://example.com/example-600.jpg 600w">' //eslint-disable-line max-len
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe() ] ) ], function( err, normalized ) {
 					assert.equal( normalized.content, '<img src="http://example.com/example.jpg-SAFE">' );
@@ -480,7 +484,7 @@ describe( 'index', function() {
 		it( 'removes invalid srcsets', function( done ) {
 			normalizer(
 				{
-					content: '<img src="http://example.com/example.jpg" srcset="http://example.com/example-100-and-a-half.jpg 100.5w, http://example.com/example-600.jpg 600w">'
+					content: '<img src="http://example.com/example.jpg" srcset="http://example.com/example-100-and-a-half.jpg 100.5w, http://example.com/example-600.jpg 600w">' //eslint-disable-line max-len
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe() ] ) ], function( err, normalized ) {
 					assert.equal( normalized.content, '<img src="http://example.com/example.jpg-SAFE">' );
@@ -493,7 +497,7 @@ describe( 'index', function() {
 	describe( 'waitForImagesToLoad', function() {
 		it.skip( 'should fire when all images have loaded or errored', function( done ) {
 			// these need to be objects that mimic the Image object
-			let completeImage = {
+			const completeImage = {
 					complete: true,
 					src: 'http://example.com/one'
 				},
@@ -510,13 +514,12 @@ describe( 'index', function() {
 					error: function() {
 						this.onerror();
 					}
-				},
-				post;
+				};
 
 			loadingImage.load = loadingImage.load.bind( loadingImage );
 			erroringImage.error = erroringImage.error.bind( erroringImage );
 
-			post = {
+			const post = {
 				content_images: [
 					completeImage, loadingImage, erroringImage
 				]
@@ -529,7 +532,7 @@ describe( 'index', function() {
 		} );
 
 		it.skip( 'should dedupe the images to check', function( done ) {
-			let first = {
+			const first = {
 					complete: true,
 					src: 'http://example.com/one'
 				},
@@ -637,7 +640,7 @@ describe( 'index', function() {
 					height: height
 				};
 			}
-			let post = {
+			const post = {
 					images: [
 						fakeImage( 5, 201 ),
 						fakeImage( 101, 5 ),
@@ -692,7 +695,10 @@ describe( 'index', function() {
 					content: '<iframe src="http://youtube.com"></iframe>'
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.makeEmbedsSafe ] ) ], function( err, normalized ) {
-					assert.strictEqual( normalized.content, '<iframe src="https://youtube.com/" sandbox="allow-same-origin allow-scripts allow-popups"></iframe>' );
+					assert.strictEqual(
+						normalized.content,
+						'<iframe src="https://youtube.com/" sandbox="allow-same-origin allow-scripts allow-popups"></iframe>'
+					);
 					done( err );
 				}
 			);
@@ -744,10 +750,9 @@ describe( 'index', function() {
 					content: '<iframe width="100" height="50" src="https://youtube.com"></iframe>'
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.detectMedia ] ) ], function( err, normalized ) {
-					let embed;
 					assert.lengthOf( normalized.content_embeds, 1 );
 
-					embed = normalized.content_embeds[ 0 ];
+					const embed = normalized.content_embeds[ 0 ];
 					assert.strictEqual( embed.iframe, '<iframe width="100" height="50" src="https://youtube.com"></iframe>' );
 					assert.strictEqual( embed.height, 50 );
 					assert.strictEqual( embed.width, 100 );
@@ -779,7 +784,9 @@ describe( 'index', function() {
 		it( 'detects images', function( done ) {
 			normalizer(
 				{
-					content: '<img src="example1.png" /> <img src="/relativeurl.png" /> <img src="https://google.com/images/absoluteurl.jpg"> text in the middle</img>'
+					content: `<img src="example1.png" />
+					<img src="/relativeurl.png" />
+					<img src="https://google.com/images/absoluteurl.jpg"> text in the middle</img>`
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.detectMedia ] ) ], function( err, normalized ) {
 					assert.lengthOf( normalized.content_media, 3 );
@@ -797,10 +804,9 @@ describe( 'index', function() {
 					content: '<iframe width="100" height="50" src="https://embed.spotify.com"></iframe>'
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.detectMedia ] ) ], function( err, normalized ) {
-					let embed;
 					assert.lengthOf( normalized.content_embeds, 1 );
 
-					embed = normalized.content_embeds[ 0 ];
+					const embed = normalized.content_embeds[ 0 ];
 					assert.strictEqual( embed.iframe, '<iframe width="100" height="50" src="https://embed.spotify.com"></iframe>' );
 					done( err );
 				}
@@ -896,7 +902,10 @@ describe( 'index', function() {
 				[
 					normalizer.withContentDOM( [ normalizer.content.detectPolls ] )
 				], function( err, normalized ) {
-					assert.include( normalized.content, '<p><a target="_blank" rel="external noopener noreferrer" href="https://polldaddy.com/poll/8980420">Take our poll</a></p>' );
+					assert.include(
+						normalized.content,
+						'<p><a target="_blank" rel="external noopener noreferrer" href="https://polldaddy.com/poll/8980420">Take our poll</a></p>' //eslint-disable-line max-len
+					);
 					done( err );
 				}
 			);

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -1031,7 +1031,7 @@ describe( 'index', function() {
 					<div class="gallery-row">
 						<div class="gallery-group">
 							<div class="tiled-gallery-item">
-								<a href="https://example.com/foo/#jp-carousel-500">
+								<a href="https://example.com/foo/#jp-carousel-500" target="_blank">
 									<img src="https://example.com/foo/bar/img/" data-attachment-id="500">
 								</a>
 							</div>

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -31,6 +31,7 @@ import waitForImagesToLoad from 'lib/post-normalizer/rule-wait-for-images-to-loa
 import pickCanonicalMedia from 'lib/post-normalizer/rule-pick-canonical-media';
 import removeElementsBySelector from 'lib/post-normalizer/rule-content-remove-elements-by-selector';
 import addDiscoverProperties from 'lib/post-normalizer/rule-add-discover-properties';
+import linkJetpackCarousels from 'lib/post-normalizer/rule-content-link-jetpack-carousels';
 
 /**
  * Module vars
@@ -123,6 +124,7 @@ const fastPostNormalizationRules = flow( [
 		disableAutoPlayOnMedia,
 		detectMedia,
 		detectPolls,
+		linkJetpackCarousels,
 	] ),
 	createBetterExcerpt,
 	pickCanonicalImage,


### PR DESCRIPTION
Turn them into links to the carousel instead of leaving them plain.

Fixes #12558 