### PR TITLE
Happychat: Middleware refactor of HAPPYCHAT_SET_MESSAGE

### DIFF
--- a/client/components/happychat/composer.jsx
+++ b/client/components/happychat/composer.jsx
@@ -8,8 +8,8 @@ import isEmpty from 'lodash/isEmpty';
  * Internal dependencies
  */
 import {
-	updateChatMessage,
-	sendChatMessage
+	sendChatMessage,
+	setChatMessage,
 } from 'state/happychat/actions';
 import {
 	when,
@@ -67,7 +67,7 @@ const mapState = ( { happychat: { message } } ) => ( { message } );
 
 const mapDispatch = ( dispatch ) => ( {
 	onUpdateChatMessage( message ) {
-		dispatch( updateChatMessage( message ) );
+		dispatch( setChatMessage( message ) );
 	},
 	onSendChatMessage( message ) {
 		dispatch( sendChatMessage( message ) );

--- a/client/state/happychat/README.md
+++ b/client/state/happychat/README.md
@@ -12,7 +12,7 @@ Used in combination with the Redux store instance `dispatch` function, actions c
 
 Opens Happychat Socket.IO client connection
 
-### `updateChatMessage( message: String )`
+### `setChatMessage( message: String )`
 
 Updates the pending message that the user is composing in the Happychat client.
 

--- a/client/state/happychat/actions.js
+++ b/client/state/happychat/actions.js
@@ -6,22 +6,16 @@
  */
 
 /**
- * External dependencies
- */
-import isEmpty from 'lodash/isEmpty';
-import throttle from 'lodash/throttle';
-
-/**
  * Internal dependencies
  */
 import wpcom from 'lib/wp';
 import {
 	HAPPYCHAT_CONNECTING,
 	HAPPYCHAT_CONNECTED,
-	HAPPYCHAT_SET_MESSAGE,
 	HAPPYCHAT_RECEIVE_EVENT,
 	HAPPYCHAT_SET_AVAILABLE,
 	HAPPYCHAT_SET_CHAT_STATUS,
+	HAPPYCHAT_SET_MESSAGE,
 	HAPPYCHAT_TRANSCRIPT_RECEIVE,
 	HAPPYCHAT_TRANSCRIPT_REQUEST,
 } from 'state/action-types';
@@ -66,20 +60,13 @@ export const receiveChatTranscript = ( messages, timestamp ) => ( {
 
 const setChatConnecting = () => ( { type: HAPPYCHAT_CONNECTING } );
 const setChatConnected = () => ( { type: HAPPYCHAT_CONNECTED } );
-const setChatMessage = message => {
-	if ( isEmpty( message ) ) {
-		connection.notTyping();
-	}
-	return { type: HAPPYCHAT_SET_MESSAGE, message };
-};
+
 const setHappychatAvailable = isAvailable => ( { type: HAPPYCHAT_SET_AVAILABLE, isAvailable } );
 
-const clearChatMessage = () => setChatMessage( '' );
+export const setChatMessage = message => ( { type: HAPPYCHAT_SET_MESSAGE, message } );
+export const clearChatMessage = () => setChatMessage( '' );
 
 const receiveChatEvent = event => ( { type: HAPPYCHAT_RECEIVE_EVENT, event } );
-const sendTyping = throttle( message => {
-	connection.typing( message );
-}, 1000, { leading: true, trailing: false } );
 
 export const sendBrowserInfo = ( siteurl ) => dispatch => {
 	const siteHelp = `Site I need help with: ${ siteurl }\n`;
@@ -126,13 +113,6 @@ export const connectChat = () => ( dispatch, getState ) => {
 		},
 		e => debug( 'failed to start happychat session', e, e.stack )
 	);
-};
-
-export const updateChatMessage = message => dispatch => {
-	dispatch( setChatMessage( message ) );
-	if ( ! isEmpty( message ) ) {
-		sendTyping( message );
-	}
 };
 
 export const sendChatMessage = message => dispatch => {

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -1,13 +1,24 @@
 /**
+ * External dependencies
+ */
+import isEmpty from 'lodash/isEmpty';
+import throttle from 'lodash/throttle';
+
+/**
  * Internal dependencies
  */
 import {
+	HAPPYCHAT_SET_MESSAGE,
 	HAPPYCHAT_TRANSCRIPT_REQUEST,
 } from 'state/action-types';
 import { receiveChatTranscript } from './actions';
 import { getHappychatTranscriptTimestamp } from './selectors';
 
 const debug = require( 'debug' )( 'calypso:happychat:actions' );
+
+const sendTyping = throttle( ( connection, message ) => {
+	connection.typing( message );
+}, 1000, { leading: true, trailing: false } );
 
 export const requestTranscript = ( connection, { getState, dispatch } ) => {
 	const timestamp = getHappychatTranscriptTimestamp( getState() );
@@ -16,6 +27,14 @@ export const requestTranscript = ( connection, { getState, dispatch } ) => {
 		result => dispatch( receiveChatTranscript( result.messages, result.timestamp ) ),
 		e => debug( 'failed to get transcript', e )
 	);
+};
+
+const onMessageChange = ( connection, message ) => {
+	if ( isEmpty( message ) ) {
+		connection.notTyping();
+	} else {
+		sendTyping( connection, message );
+	}
 };
 
 export default function( connection = null ) {
@@ -27,6 +46,9 @@ export default function( connection = null ) {
 
 	return store => next => action => {
 		switch ( action.type ) {
+			case HAPPYCHAT_SET_MESSAGE:
+				onMessageChange( connection, action.message );
+				break;
 			case HAPPYCHAT_TRANSCRIPT_REQUEST:
 				requestTranscript( connection, store );
 				break;

--- a/client/state/happychat/test/middleware.js
+++ b/client/state/happychat/test/middleware.js
@@ -3,17 +3,33 @@
  */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-import { stub } from 'sinon';
+import { spy, stub } from 'sinon';
 
 /**
  * Internal dependencies
  */
 import {
+	HAPPYCHAT_SET_MESSAGE,
 	HAPPYCHAT_TRANSCRIPT_RECEIVE,
 } from 'state/action-types';
-import { requestTranscript } from '../middleware';
+import middleware, { requestTranscript } from '../middleware';
 
 describe( 'middleware', () => {
+	describe( 'HAPPYCHAT_SET_MESSAGE action', () => {
+		it( 'should send the connection a typing signal when a message is present', () => {
+			const action = { type: HAPPYCHAT_SET_MESSAGE, message: 'Hello world' };
+			const connection = { typing: spy() };
+			middleware( connection )()( spy() )( action );
+			expect( connection.typing ).to.have.been.calledWith( action.message );
+		} );
+		it( 'should send the connection a notTyping signal when the message is blank', () => {
+			const action = { type: HAPPYCHAT_SET_MESSAGE, message: '' };
+			const connection = { notTyping: spy() };
+			middleware( connection )()( spy() )( action );
+			expect( connection.notTyping ).to.have.been.calledOnce;
+		} );
+	} );
+
 	describe( 'HAPPYCHAT_TRANSCRIPT_REQUEST action', () => {
 		it( 'should fetch transcript from connection and dispatch receive action', () => {
 			const state = deepFreeze( {

--- a/client/state/happychat/test/middleware.js
+++ b/client/state/happychat/test/middleware.js
@@ -4,6 +4,7 @@
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 import { spy, stub } from 'sinon';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,13 +20,13 @@ describe( 'middleware', () => {
 		it( 'should send the connection a typing signal when a message is present', () => {
 			const action = { type: HAPPYCHAT_SET_MESSAGE, message: 'Hello world' };
 			const connection = { typing: spy() };
-			middleware( connection )()( spy() )( action );
+			middleware( connection )()( noop )( action );
 			expect( connection.typing ).to.have.been.calledWith( action.message );
 		} );
 		it( 'should send the connection a notTyping signal when the message is blank', () => {
 			const action = { type: HAPPYCHAT_SET_MESSAGE, message: '' };
 			const connection = { notTyping: spy() };
-			middleware( connection )()( spy() )( action );
+			middleware( connection )()( noop )( action );
 			expect( connection.notTyping ).to.have.been.calledOnce;
 		} );
 	} );


### PR DESCRIPTION
Moves side effects related to `HAPPYCHAT_SET_MESSAGE` actions into the middleware. Part of an ongoing refactor.

`HAPPYCHAT_SET_MESSAGE` updates the controlled form input state in the Happychat composer when a user types. The side effect is that the remote operator is informed when the user starts and stops typing.

### To test

- In side-by-side windows pull up the Happychat HUD, http://calypso.localhost:3000/me/chat, and Redux Dev Tools inspecting the Calypso instance
- In Redux Dev Tools, open the `happychat` subtree. The `message` key should initially have a value `''`
- Start typing in the message box in Calypso
  - Your characters should appear in the Calypso text box
  - Redux `happychat.message` should be syncing in real-time with your changes
  - The HUD should show the user typing as soon as you start
- Start typing and then delete everything you typed
  - The HUD should show the user as typing right up until the message box is blank, when the typing animation should disappear completely