### PR TITLE
Domain Only: Hide transfer to another user for domain-only sites

### DIFF
--- a/client/my-sites/upgrades/domain-management/transfer/index.jsx
+++ b/client/my-sites/upgrades/domain-management/transfer/index.jsx
@@ -1,23 +1,25 @@
 /**
  * External Dependencies
  */
+import { connect } from 'react-redux';
 import React from 'react';
 
 /**
  * Internal Dependencies
  */
+import { get } from 'lodash';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import Header from 'my-sites/upgrades/domain-management/components/header';
+import { isDomainOnlySite, isSiteAutomatedTransfer } from 'state/selectors';
 import { localize } from 'i18n-calypso';
+import Main from 'components/main';
 import paths from 'my-sites/upgrades/paths';
 import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
-import Header from 'my-sites/upgrades/domain-management/components/header';
-import Main from 'components/main';
-import { get } from 'lodash';
 
 function Transfer( props ) {
-	const { selectedSite, selectedDomainName, translate } = props;
+	const { isAutomatedTransfer, isDomainOnly, selectedSite, selectedDomainName, translate } = props;
 	const slug = get( selectedSite, 'slug' );
-	const canTransferDomain = ! get( selectedSite, 'options.is_automated_transfer', false );
 
 	return (
 		<Main className="domain-management-transfer">
@@ -32,7 +34,7 @@ function Transfer( props ) {
 				}>
 					{ translate( 'Transfer to another registrar' ) }
 				</VerticalNavItem>
-					{ canTransferDomain &&
+					{ ! isAutomatedTransfer && ! isDomainOnly &&
 						<VerticalNavItem path={ paths.domainManagementTransferToAnotherUser( slug, selectedDomainName ) }>
 							{ translate( 'Transfer to another user' ) }
 						</VerticalNavItem> }
@@ -41,4 +43,10 @@ function Transfer( props ) {
 	);
 }
 
-export default localize( Transfer );
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	return {
+		isAutomatedTransfer: isSiteAutomatedTransfer( state, siteId ),
+		isDomainOnly: isDomainOnlySite( state, siteId )
+	};
+} )( localize( Transfer ) );


### PR DESCRIPTION
Users shouldn't be able to transfer a domain associated with a domain only site to another user.

cc @umurkontaci moved the `isAutomattedTransfer` to `connect`, want to confirm if it's ok.

Steps:
1. Get a domain only site
2. Go to Manage Domain -> Transfer Domain
3. Shouldn't see option to transfer domain to another user

Before:
![bad](https://cloud.githubusercontent.com/assets/1103398/24375718/9c05ccd4-1339-11e7-9792-1781128ee30b.png)

After:
![good](https://cloud.githubusercontent.com/assets/1103398/24375724/9ef42c7e-1339-11e7-908d-811f73205697.png)

Fixes: https://github.com/Automattic/wp-calypso/issues/12102