### PR TITLE
NPS Survey: add new undocumented endpoints

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2365,6 +2365,27 @@ Undocumented.prototype.transferStatus = function( siteId, transferId ) {
 };
 
 /**
+ * Submit a response to the NPS Survey.
+ * @param {string}     surveyName     The name of the NPS survey being submitted
+ * @param {int}        score          The value for the survey response
+ * @param {Function}   fn             The callback function
+ * @returns {Promise}
+ */
+Undocumented.prototype.submitNPSSurvey = function( surveyName, score, fn ) {
+	return this.wpcom.req.post( { path: `/nps/${ surveyName }` }, { apiVersion: '1.2' }, { score }, fn );
+};
+
+/**
+ * Dismiss the NPS Survey.
+ * @param {string}     surveyName     The name of the NPS survey being submitted
+ * @param {Function}   fn             The callback function
+ * @returns {Promise}
+ */
+Undocumented.prototype.dismissNPSSurvey = function( surveyName, fn ) {
+	return this.wpcom.req.post( { path: `/nps/${ surveyName }` }, { apiVersion: '1.2' }, { dismissed: true }, fn );
+};
+
+/**
  * Expose `Undocumented` module
  */
 module.exports = Undocumented;


### PR DESCRIPTION
This PR adds two new undocumented endpoints to be used by the NPS Survey.

To test, checkout this branch and run it locally. Then from the console in your browser:

`wpcom.undocumented().dismissNPSSurvey( 'xyzxyz', response=>{ console.log( response ) } )`
`wpcom.undocumented().submitNPSSurvey( 'xyzxyz', 6, response=>{ console.log( response ) } )`

Each of the above should log an error about an invalid survey name. Using a valid survey name should error if the score isn't in the range of 0-10 or if you've recently completed a survey, otherwise your score should be recorded successfully.