### PR TITLE
CalendarPopover: Fist approach

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -20,6 +20,7 @@
 @import 'blocks/app-promo/style';
 @import 'blocks/author-compact-profile/style';
 @import 'blocks/author-selector/style';
+@import 'blocks/calendar-popover/style';
 @import 'blocks/comment-button/style';
 @import 'blocks/comments/style';
 @import 'blocks/daily-post-button/style';

--- a/client/blocks/calendar-popover/README.md
+++ b/client/blocks/calendar-popover/README.md
@@ -1,0 +1,85 @@
+Calendar Popover
+================
+
+This component shows a Popover with a calendar inside.
+
+Beyond combining Popover and PostSchedule, this component connects with the state-tree, so in this way timezone data related to the site configuration is propagated automatically.
+
+
+## Usage
+
+```es6
+import Button from 'components/button';
+import CalendarPopover from 'blocks/calendar-popover';
+
+toggle = () => this.setState( { show: ! this.state.show } );
+
+render() {
+	return (
+		<div>
+			<Button
+				ref="button"
+				onClick={ this.toggle }
+			>
+				Show Popover
+			</Button>
+
+			<CalendarPopover
+				context={ this.refs && this.refs.button }
+				isVisible={ this.state.show }
+			/>
+		</div>
+	);
+}
+```
+
+## Props
+
+The following props can be passed to the CalendarPopover component:
+
+### `children`
+
+<table>
+	<tr><td>Type</td><td>Element</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+
+#### Connect Props
+
+### `gmtOffset`
+
+<table>
+	<tr><td>Type</td><td>Number</td></tr>
+</table>
+
+The site's UTC offset.
+
+### `timezoneValue`
+
+<table>
+	<tr><td>Type</td><td>String</td></tr>
+</table>
+
+The site's timezone value, in the format of 'America/Araguaina (see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+
+#### Props propagated to the `<Popover />`
+
+* `autoPosition`
+* `closeOnEsc`
+* `ignoreContext`
+* `isVisible`
+* `position`
+* `rootClassName`
+* `showDelay`
+* `onClose`
+* `onShow`
+
+#### Props propagated to the `<PostSchedule />`
+
+ * `events`
+ * `selectedDay`
+ * `siteId`
+ * `onDateChange`
+ * `onMonthChange`
+

--- a/client/blocks/calendar-popover/docs/example.jsx
+++ b/client/blocks/calendar-popover/docs/example.jsx
@@ -1,0 +1,45 @@
+
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import { moment } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import CalendarPopover from 'blocks/calendar-popover';
+
+const tomorrow = date => date.date( date.date() + 1 );
+
+class CalendarPopoverExample extends PureComponent {
+	state = { show: false, currentDate: tomorrow( moment() ) };
+
+	toggle = () => this.setState( { show: ! this.state.show } );
+
+	close = () => this.setState( { show: false } );
+
+	render() {
+		return (
+			<div>
+				<Button
+					primary
+					ref="button"
+					onClick={ this.toggle }
+				>
+					Show Popover
+				</Button>
+
+				<CalendarPopover
+					context={ this.refs && this.refs.button }
+					isVisible={ this.state.show }
+					selectedDay={ this.state.currentDate }
+					onClose={ this.close }
+				/>
+			</div>
+		);
+	}
+}
+
+export default CalendarPopoverExample;

--- a/client/blocks/calendar-popover/index.jsx
+++ b/client/blocks/calendar-popover/index.jsx
@@ -1,0 +1,116 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { noop, pick } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getSiteGmtOffset,
+	getSiteTimezoneValue,
+} from 'state/selectors';
+import Popover from 'components/popover';
+import PostSchedule from 'components/post-schedule';
+
+class CalendarPopover extends Component {
+	static propTypes = {
+		children: PropTypes.element,
+		
+		// connect props
+		gmtOffset: PropTypes.number,
+		timezoneValue: PropTypes.string,
+
+		// popover props
+		autoPosition: PropTypes.bool,
+		closeOnEsc: PropTypes.bool,
+		ignoreContext: PropTypes.shape( { getDOMNode: React.PropTypes.function } ),
+		isVisible: PropTypes.bool,
+		position: PropTypes.string,
+		rootClassName: PropTypes.string,
+		showDelay: PropTypes.number,
+		onClose: PropTypes.func,
+		onShow: PropTypes.func,
+
+		// calendar props
+		events: PropTypes.array,
+		selectedDay: PropTypes.object,
+		siteId: PropTypes.number,
+		onDateChange: PropTypes.func,
+		onMonthChange: PropTypes.func,
+	};
+
+	static defaultProps = {
+		timezoneValue: '',
+		onDateChange: noop,
+	};
+
+	state = { date: null };
+
+	componentWillMount() {
+		if ( this.props.selectedDay ) {
+			this.setState( { date: this.props.selectedDay } );
+		}
+	}
+
+	setDate = date => {
+		this.setState( { date } );
+		this.props.onDateChange( date );
+	};
+
+	renderScheduler() {
+		const schedulerProps = Object.assign( {}, pick( this.props, [
+			'events',
+			'posts',
+			'site',
+			'onDateChange',
+			'onMonthChange',
+		] ) );
+
+		return (
+			<PostSchedule
+				{ ...schedulerProps }
+				className="calendar-popover__scheduler"
+				selectedDay={ this.state.date }
+				gmtOffset={ this.props.gmtOffset }
+				timezone={ this.props.timezoneValue }
+				onDateChange={ this.setDate }
+			/>
+		);
+	}
+
+	render() {
+		const popoverProps = Object.assign( {}, pick( this.props, [
+			'autoPosition',
+			'closeOnEsc',
+			'context',
+			'ignoreContext',
+			'isVisible',
+			'position',
+			'rootClassName',
+			'showDelay',
+			'onClose',
+			'onShow',
+		] ) );
+
+		return (
+			<div className="calendar-popover">
+				<Popover
+					{ ...popoverProps }
+					className="calendar-popover__popover"
+				>
+					{ this.renderScheduler() }
+				</Popover>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state, { siteId } ) => ( {
+		gmtOffset: getSiteGmtOffset( state, siteId ),
+		timezoneValue: getSiteTimezoneValue( state, siteId ),
+	} )
+ )( CalendarPopover );

--- a/client/blocks/calendar-popover/style.scss
+++ b/client/blocks/calendar-popover/style.scss
@@ -1,0 +1,6 @@
+.calendar-popover__popover .popover__inner {
+	box-sizing: border-box;
+	display: block;
+	padding: 0 16px;
+	width: 237px;
+}

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -19,6 +19,7 @@ import { isEnabled } from 'config';
  * Docs examples
  */
 import CreditCardForm from 'blocks/credit-card-form/docs/example';
+import CalendarPopover from 'blocks/calendar-popover/docs/example';
 import AuthorSelector from 'blocks/author-selector/docs/example';
 import CommentButtons from 'blocks/comment-button/docs/example';
 import DisconnectJetpackDialog from 'blocks/disconnect-jetpack-dialog/docs/example';
@@ -99,6 +100,7 @@ export default React.createClass( {
 					section="blocks"
 				>
 					<AuthorSelector />
+					<CalendarPopover />
 					<CommentButtons />
 					<DisconnectJetpackDialog />
 					<CreditCardForm />


### PR DESCRIPTION
This PR adds a new component named `<CalendarComponent />` which shows a `<Popover />` with a calendar (`<postShedule />`) inside.

Beyond to combining the Popover and PostSchedule components in only one, this component connects with the state-tree, so in this way timezone data related to the site configuration is propagated automatically. It simplifies its usages and guarantees the connection with Redux.

We worked on this approach as part of the new Publicize section, however, it could/should used in other places. 

<img src="https://cloud.githubusercontent.com/assets/77539/24380200/d476be36-130f-11e7-8166-42865dd05b16.png" width="400px" />

For more information take a look to the [README.md](https://github.com/Automattic/wp-calypso/blob/a49a4291a338ad986fa43ff8592bba16f8e6d778/client/blocks/calendar-popover/README.md) file.

### Testing

Go to Devdocs/blocks testing page: http://calypso.localhost:3000/devdocs/blocks/calendar-popover and test the implementation. You should be able to change date, month, etc.