### PR TITLE
CalendarButton: first approach

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -20,6 +20,7 @@
 @import 'blocks/app-promo/style';
 @import 'blocks/author-compact-profile/style';
 @import 'blocks/author-selector/style';
+@import 'blocks/calendar-button/style';
 @import 'blocks/calendar-popover/style';
 @import 'blocks/comment-button/style';
 @import 'blocks/comments/style';

--- a/client/blocks/calendar-button/README.md
+++ b/client/blocks/calendar-button/README.md
@@ -1,0 +1,125 @@
+Calendar Button
+===============
+
+This component is used to display a calendar button. When it pressed, it shows a Popover with a calendar inside.
+
+## Usage
+
+```es6
+import CalendarButton from 'blocks/calendar-button';
+
+render() {
+	return (
+		<CalendarButton />
+	);
+}
+```
+
+## Props
+
+### `children`
+
+<table>
+	<tr><td>Type</td><td>Element</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+### `icon`
+
+<table>
+	<tr><td>Type</td><td>String</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td>calendar</td></tr>
+</table>
+
+If the component doesn't have children elements then an icon (Gridicon) will be rendered inside of this one.
+
+### `popoverPosition`
+
+<table>
+	<tr><td>Type</td><td>String</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td>bottom</td></tr>
+</table>
+
+It defines the position of the Popover once it shows. This value is propagated to the `<Popover />` instance through of the `position` property.
+
+
+### `type`
+
+
+<table>
+	<tr><td>Type</td><td>String</td></tr>
+	<tr><td>Required</td><td>Yes</td></tr>
+	<tr><td>Default</td><td>button</td></tr>
+</table>
+
+This property defines to this component as a `button`. You shouldn't change this it.
+
+### Props propagated to the `<Popover />`
+
+* `autoPosition`
+* `closeOnEsc`
+* `events`
+* `ignoreContext`
+* `isVisible`
+* `rootClassName`
+* `selectedDay`
+* `showDelay`
+* `siteId`
+
+* `onClose`
+* `onDateChange`
+* `onMonthChange`
+* `onShow`
+
+### Props propagated to the `<CalendarPopover />`
+
+* `selectedDay`: the date which will be shown initially
+* `siteId`: Passing siteId the calendar will try to get values related with time zone.
+* `onDateChange`: Function to be executed when the user selects a date.
+
+
+## Examples
+
+### As much simple as possible
+
+```es6
+import CalendarButton from 'blocks/calendar-button';
+
+render() {
+	const tomorrow = new Date( new Date().getTime() + 24 * 60 * 60 * 1000 );
+
+	return (
+		<CalendarButton
+			selectedDay={ tomorrow }
+			onDateChange={ this.setDate } />
+	);
+}
+```
+
+### Custom calendar icon
+
+```es6
+import CalendarButton from 'blocks/calendar-button';
+
+render() {
+	return (
+		<CalendarButton icon="thumbs-up" />
+	);
+}
+```
+
+### Render using children property
+
+```es6
+import CalendarButton from 'blocks/calendar-button';
+
+render() {
+	return (
+		<CalendarButton onDateChange={ this.setDate }>
+			<a class="custom-content" href="#">Open Me!</a>
+		</CalendarButton>
+	);
+}
+```

--- a/client/blocks/calendar-button/docs/example.jsx
+++ b/client/blocks/calendar-button/docs/example.jsx
@@ -1,0 +1,19 @@
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import CalendarButton from 'blocks/calendar-button';
+
+const CalendarButtonExample = () => {
+	const tomorrow = new Date( new Date().getTime() + 24 * 60 * 60 * 1000 );
+	return (
+		<CalendarButton primary selectedDay={ tomorrow } />
+	);
+};
+
+export default CalendarButtonExample;

--- a/client/blocks/calendar-button/index.jsx
+++ b/client/blocks/calendar-button/index.jsx
@@ -1,0 +1,124 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import Gridicon from 'gridicons';
+import classNames from 'classnames';
+import { noop, pick } from 'lodash';
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import AsyncLoad from 'components/async-load';
+
+class CalendarButton extends Component {
+	static propTypes = {
+		children: PropTypes.element,
+		icon: PropTypes.string,
+		popoverPosition: PropTypes.string,
+		type: PropTypes.string,
+
+		// calendar-popover properties
+		autoPosition: PropTypes.bool,
+		closeOnEsc: PropTypes.bool,
+		events: PropTypes.array,
+		ignoreContext: PropTypes.shape( { getDOMNode: React.PropTypes.function } ),
+		isVisible: PropTypes.bool,
+		rootClassName: PropTypes.string,
+		selectedDay: PropTypes.object,
+		showDelay: PropTypes.number,
+		siteId: PropTypes.number,
+
+		onClose: PropTypes.func,
+		onDateChange: PropTypes.func,
+		onMonthChange: PropTypes.func,
+		onShow: PropTypes.func,
+	};
+
+	static defaultProps = {
+		icon: 'calendar',
+		type: 'button',
+		popoverPosition: 'bottom',
+		onDateChange: noop,
+	};
+
+	state = { showPopover: false };
+
+	setDate = date => {
+		this.setState( { date } );
+		this.props.onDateChange( date );
+	};
+
+	closePopover = () => this.setState( { showPopover: false } );
+
+	togglePopover = () => this.setState( { showPopover: ! this.state.showPopover } );
+
+	setPopoverReference = calendarButtonRef => ( this.reference = calendarButtonRef );
+
+	renderCalendarPopover() {
+		const { showPopover } = this.state;
+
+		if ( ! showPopover ) {
+			return null;
+		}
+
+		const calendarProperties = Object.assign( {}, pick( this.props, [
+			'autoPosition',
+			'closeOnEsc',
+			'events',
+			'ignoreContext',
+			'isVisible',
+			'rootClassName',
+			'selectedDay',
+			'showDelay',
+			'siteId',
+			'onDateChange',
+			'onMonthChange',
+			'onShow',
+		] ) );
+
+		return (
+			<AsyncLoad
+				{ ...calendarProperties }
+				require="blocks/calendar-popover"
+				context={ this.reference }
+				isVisible={ showPopover }
+				position={ this.props.popoverPosition }
+				onClose={ this.closePopover }
+			/>
+		);
+	}
+
+	renderCalendarContent() {
+		return this.props.children
+			? this.props.children
+			: ( <Gridicon icon={ this.props.icon } /> );
+	}
+
+	render() {
+		const buttonsProperties = Object.assign( {}, pick( this.props, [
+			'compact',
+			'primary',
+			'scary',
+			'busy',
+			'href',
+			'borderless',
+			'target',
+			'rel',
+		] ) );
+
+		return (
+			<Button
+				{ ...buttonsProperties }
+				className={ classNames( 'calendar-button', this.props.className ) }
+				ref={ this.setPopoverReference }
+				onClick={ this.togglePopover }
+			>
+				{ this.renderCalendarContent() }
+				{ this.renderCalendarPopover() }
+			</Button>
+		);
+	}
+}
+
+export default CalendarButton;

--- a/client/blocks/calendar-button/style.scss
+++ b/client/blocks/calendar-button/style.scss
@@ -1,0 +1,3 @@
+.calendar-button .async-load {
+	display: none;
+}

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -19,6 +19,7 @@ import { isEnabled } from 'config';
  * Docs examples
  */
 import CreditCardForm from 'blocks/credit-card-form/docs/example';
+import CalendarButton from 'blocks/calendar-button/docs/example';
 import CalendarPopover from 'blocks/calendar-popover/docs/example';
 import AuthorSelector from 'blocks/author-selector/docs/example';
 import CommentButtons from 'blocks/comment-button/docs/example';
@@ -100,6 +101,7 @@ export default React.createClass( {
 					section="blocks"
 				>
 					<AuthorSelector />
+					<CalendarButton />
 					<CalendarPopover />
 					<CommentButtons />
 					<DisconnectJetpackDialog />


### PR DESCRIPTION
### This PR depends on https://github.com/Automattic/wp-calypso/pull/12572
---------
This PR adds the `<CalendarButton />` component. It renders a button and when it pressed, shows a popover with a calendar inside. It facilitates its usage, the popover (and the calendar) loads asynchronically, among other improvements.

More information in the [README.md](https://github.com/Automattic/wp-calypso/blob/6b11c083206d4ef3ab68929f2973250127b7d6b2/client/blocks/calendar-button/README.md) file.

<img src="https://cloud.githubusercontent.com/assets/77539/24381962/f3aca4f6-1318-11e7-9fa5-1f48ea0dc376.png" width="400px" />

### Testing

Go to the Devdocs blocks testing page http://calypso.localhost:3000/devdocs/blocks/calendar-button and test the component showing and hiding the popover, setting a date, changing the month, etc.