### PR TITLE
Change site_language to blog_lang for tracks.

### DIFF
--- a/client/lib/analytics/super-props.js
+++ b/client/lib/analytics/super-props.js
@@ -26,8 +26,11 @@ module.exports = {
 				// why we use it here instead of calling the property site_id
 				blog_id: selectedSite.ID,
 
+				// Tracks expects a blog_lang property to identify the blog language which is
+				// why we use it here instead of calling the property site_language
+				blog_lang: selectedSite.lang,
+
 				site_id_label: selectedSite.jetpack ? 'jetpack' : 'wpcom',
-				site_language: selectedSite.lang,
 				site_plan_id: selectedSite.plan ? selectedSite.plan.product_id : null,
 				site_post_count: selectedSite.post_count
 			};


### PR DESCRIPTION
Tracks expects language to be sent in as blog_lang, so change site_language to blog_lang.

To test: choose a specific site in calypso, click on plans, and verify that bloglang is set in the live view of tracks for calypso_plans_view.