### PR TITLE
Reader: Combined Card styling fixes

### DIFF
--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -220,12 +220,12 @@
 	&:focus,
 	&:link,
 	&:visited {
-		color: $blue-wordpress;
+		color: $blue-medium;
 	}
 
 	&:hover,
 	&:active {
-		color: $blue-medium;
+		color: $blue-light;
 	}
 }
 

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -7,7 +7,7 @@
 }
 
 .reader-avatar.has-site-icon {
-	margin-right: 8px;
+	margin-right: 12px;
 }
 
 .reader-combined-card__header-details {

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -91,6 +91,7 @@
 
 .reader-combined-card__post-list {
 	margin-left: 0;
+	margin-bottom: 18px;
 }
 
 .reader-combined-card__post {
@@ -152,6 +153,10 @@
 		.reader-combined-card__post-author-and-time {
 			display: flex;
 		}
+	}
+
+	&:last-of-type {
+		margin-bottom: 18px;
 	}
 }
 


### PR DESCRIPTION
The PR resolves some styling issues for combined cards:

* Reduces the margin below each combined card #12427
* Increase the combined card avatars right margin #12426
* Adjusts some combined card link colors brining them in line with existing link colors #12464

This closes #12427, closes #12426 and closes #12464.