### PR TITLE
Editor Site Icon: Fix sizing

### DIFF
--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -84,6 +84,7 @@
 	overflow: hidden;
 	align-self: center;
 	margin-right: 8px;
+	flex: 0 0 auto;
 }
 
 // The group of site title and domain


### PR DESCRIPTION
Previously the site icon in the editor would be small when the title was long. This PR fixes that by adding a flex rule for sizing. Props @folletto

Screenshot before:

<img width="405" alt="screen shot 2017-03-28 at 09 31 41" src="https://cloud.githubusercontent.com/assets/1204802/24393786/bb3d88de-1399-11e7-83cd-8cd50fda5e0d.png">

After:

<img width="388" alt="screen shot 2017-03-28 at 09 31 20" src="https://cloud.githubusercontent.com/assets/1204802/24393787/bdecb942-1399-11e7-9d68-d2980b1c255f.png">
