### PR TITLE
Add SubMasterbarNav to theme-showcase view for not logged users

### DIFF
--- a/client/components/sub-masterbar-nav/navbar.jsx
+++ b/client/components/sub-masterbar-nav/navbar.jsx
@@ -28,12 +28,13 @@ export default class Navbar extends Component {
 	};
 
 	state = {
-		collapsed: true,
+		collapsed: false,
 		foldable: false
 	};
 
 	componentDidMount() {
 		this.onResize();
+		this.setListCollapsed( true );
 
 		window.addEventListener( 'resize', this.onResize );
 	}
@@ -62,7 +63,9 @@ export default class Navbar extends Component {
 				</div>
 				{ this.state.foldable && (
 					<div className="sub-masterbar-nav__switch">
-						<Gridicon icon="ellipsis" className={ ellipsisClass } onClick={ this.toggleList } />
+						<Gridicon
+							icon="ellipsis"
+							className={ ellipsisClass } onClick={ this.toggleList } />
 					</div>
 				)}
 			</div>
@@ -82,8 +85,12 @@ export default class Navbar extends Component {
 	}
 
 	toggleList = () => {
-		this.setState( ( state ) => ( {
-			collapsed: ! state.collapsed
+		this.setListCollapsed( ! this.state.collapsed );
+	}
+
+	setListCollapsed( collapsed ) {
+		this.setState( () => ( {
+			collapsed: collapsed
 		} ) );
 	}
 
@@ -91,7 +98,7 @@ export default class Navbar extends Component {
 		const width = findDOMNode( this ).offsetWidth;
 
 		this.setState( ( state, props ) => ( {
-			foldable: width < props.options.length * ITEM_WIDTH + SIDE_PADDING
+			foldable: window !== undefined && width < props.options.length * ITEM_WIDTH + SIDE_PADDING
 		} ) );
 	}
 }

--- a/client/components/sub-masterbar-nav/navbar.jsx
+++ b/client/components/sub-masterbar-nav/navbar.jsx
@@ -65,7 +65,9 @@ export default class Navbar extends Component {
 					<div className="sub-masterbar-nav__switch">
 						<Gridicon
 							icon="ellipsis"
-							className={ ellipsisClass } onClick={ this.toggleList } />
+							className={ ellipsisClass }
+							onClick={ this.toggleList }
+						/>
 					</div>
 				)}
 			</div>
@@ -89,9 +91,9 @@ export default class Navbar extends Component {
 	}
 
 	setListCollapsed( collapsed ) {
-		this.setState( () => ( {
+		this.setState( {
 			collapsed: collapsed
-		} ) );
+		} );
 	}
 
 	onResize = () => {

--- a/client/components/sub-masterbar-nav/navbar.jsx
+++ b/client/components/sub-masterbar-nav/navbar.jsx
@@ -28,13 +28,12 @@ export default class Navbar extends Component {
 	};
 
 	state = {
-		collapsed: false,
+		collapsed: true,
 		foldable: false
 	};
 
 	componentDidMount() {
 		this.onResize();
-		this.setListCollapsed( true );
 
 		window.addEventListener( 'resize', this.onResize );
 	}
@@ -87,20 +86,16 @@ export default class Navbar extends Component {
 	}
 
 	toggleList = () => {
-		this.setListCollapsed( ! this.state.collapsed );
-	}
-
-	setListCollapsed( collapsed ) {
-		this.setState( {
-			collapsed: collapsed
-		} );
+		this.setState( ( state ) => ( {
+			collapsed: ! state.collapsed
+		} ) );
 	}
 
 	onResize = () => {
 		const width = findDOMNode( this ).offsetWidth;
 
 		this.setState( ( state, props ) => ( {
-			foldable: window !== undefined && width < props.options.length * ITEM_WIDTH + SIDE_PADDING
+			foldable: width < props.options.length * ITEM_WIDTH + SIDE_PADDING
 		} ) );
 	}
 }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -23,7 +23,8 @@ $autobar-height: 20px;
 		border-bottom: 1px solid darken( $orange-jazzy, 4% );
 	}
 
-	.is-section-theme & {
+	.is-section-theme &,
+	.is-section-themes.has-no-sidebar & {
 		border: none;
 	}
 

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -20,7 +20,8 @@
 		padding-left: 32px;
 	}
 
-	.is-section-theme & {
+	.is-section-theme &,
+	.is-section-themes.has-no-sidebar & {
 		padding: 0;
 		margin: 0;
 	}
@@ -39,7 +40,8 @@
 			padding-left: 24px;
 		}
 
-		.is-section-theme & {
+		.is-section-theme &,
+		.is-section-themes.has-no-sidebar & {
 			padding: 0;
 			margin: 0;
 		}

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -94,3 +94,7 @@
 		}
 	}
 }
+
+.is-section-themes.has-no-sidebar .themes__content {
+	padding: 32px;
+}

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -96,5 +96,9 @@
 }
 
 .is-section-themes.has-no-sidebar .themes__content {
-	padding: 32px;
+	padding: 0 0 32px;
+
+	@include breakpoint( ">480px" ) {
+		padding: 32px;
+	}
 }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -158,13 +158,13 @@ const ThemeShowcase = React.createClass( {
 
 		const headerIcons = [ {
 			label: 'new',
-			uri: '/design',
+			uri: '/themes',
 			icon: 'star'
 		} ].concat(
 			getSubjects()
 				.map( subject => subjectsMeta[ subject ] && {
 					label: subject,
-					uri: `/design/${ subject }`,
+					uri: `/themes/${ subject }`,
 					icon: subjectsMeta[ subject ].icon,
 					order: subjectsMeta[ subject ].order
 				} )
@@ -183,7 +183,7 @@ const ThemeShowcase = React.createClass( {
 					<SubMasterbarNav
 						options={ headerIcons }
 						fallback={ headerIcons[ 0 ] }
-						uri={ `/design${ verticalSection }` } />
+						uri={ `/themes${ verticalSection }` } />
 				)}
 				<div className="themes__content">
 					<ThemesSearchCard

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -14,10 +14,11 @@ import Gridicon from 'gridicons';
 import Main from 'components/main';
 import Button from 'components/button';
 import ThemesSelection from './themes-selection';
+import SubMasterbarNav from 'components/sub-masterbar-nav';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { addTracking, trackClick } from './helpers';
 import DocumentHead from 'components/data/document-head';
-import { prependFilterKeys, getSortedFilterTerms, stripFilters } from './theme-filters.js';
+import { prependFilterKeys, getSortedFilterTerms, stripFilters, getSubjects } from './theme-filters.js';
 import buildUrl from 'lib/mixins/url-search/build-url';
 import { isJetpackSite, getSiteSlug } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
@@ -46,6 +47,19 @@ const themesMeta = {
 		description: 'Discover Premium WordPress Themes on the WordPress.com Theme Showcase.',
 		canonicalUrl: 'https://wordpress.com/themes/premium',
 	}
+};
+
+const subjectsMeta = {
+	photo: { icon: 'camera', order: 1 },
+	portfolio: { icon: 'custom-post-type', order: 2 },
+	magazine: { icon: 'reader', order: 3 },
+	blog: { icon: 'posts', order: 4 },
+	business: { icon: 'cart', order: 5 },
+	wedding: { icon: 'heart', order: 6 },
+	minimal: { icon: 'minus-small', order: 7 },
+	travel: { icon: 'globe', order: 8 },
+	food: { icon: 'flip-horizontal', order: 9 },
+	music: { icon: 'audio', order: 10 }
 };
 
 const optionShape = PropTypes.shape( {
@@ -130,7 +144,9 @@ const ThemeShowcase = React.createClass( {
 			search,
 			filter,
 			translate,
-			siteSlug
+			siteSlug,
+			vertical,
+			isLoggedIn
 		} = this.props;
 		const tier = config.isEnabled( 'upgrades/premium-themes' ) ? this.props.tier : 'free';
 
@@ -140,58 +156,84 @@ const ThemeShowcase = React.createClass( {
 			{ property: 'og:type', content: 'website' }
 		];
 
+		const headerIcons = [ {
+			label: 'new',
+			uri: '/design',
+			icon: 'star'
+		} ].concat(
+			getSubjects()
+				.map( subject => subjectsMeta[ subject ] && {
+					label: subject,
+					uri: `/design/${ subject }`,
+					icon: subjectsMeta[ subject ].icon,
+					order: subjectsMeta[ subject ].order
+				} )
+				.filter( icon => !! icon )
+				.sort( ( a, b ) => a.order - b.order )
+		);
+
+		const verticalSection = vertical ? `/${ vertical }` : '';
+
 		// FIXME: Logged-in title should only be 'Themes'
 		return (
 			<Main className="themes">
 				<DocumentHead title={ themesMeta[ tier ].title } meta={ metas } />
 				<PageViewTracker path={ this.props.analyticsPath } title={ this.props.analyticsPageTitle } />
-				<ThemesSearchCard
-					onSearch={ this.doSearch }
-					search={ prependFilterKeys( filter ) + search }
-					tier={ tier }
-					select={ this.onTierSelect } />
-				{ this.showUploadButton() && <Button className="themes__upload-button" compact icon
-					onClick={ this.onUploadClick }
-					href={ siteSlug ? `/themes/upload/${ siteSlug }` : '/themes/upload' }>
-					<Gridicon icon="cloud-upload" />
-					{ translate( 'Upload Theme' ) }
-				</Button>
-				}
-				<ThemesSelection
-					search={ search }
-					tier={ this.props.tier }
-					filter={ filter }
-					vertical={ this.props.vertical }
-					siteId={ this.props.siteId }
-					listLabel={ this.props.listLabel }
-					defaultOption={ this.props.defaultOption }
-					secondaryOption={ this.props.secondaryOption }
-					placeholderCount={ this.props.placeholderCount }
-					getScreenshotUrl={ function( theme ) {
-						if ( ! getScreenshotOption( theme ).getUrl ) {
-							return null;
-						}
-						return getScreenshotOption( theme ).getUrl( theme );
-					} }
-					onScreenshotClick={ function( theme ) {
-						if ( ! getScreenshotOption( theme ).action ) {
-							return;
-						}
-						getScreenshotOption( theme ).action( theme );
-					} }
-					getActionLabel={ function( theme ) {
-						return getScreenshotOption( theme ).label;
-					} }
-					getOptions={ function( theme ) {
-						return pickBy(
-							addTracking( options ),
-							option => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
-						); } }
-					trackScrollPage={ this.props.trackScrollPage }
-					emptyContent={ this.props.emptyContent }
-				/>
-				<ThemePreview />
-				{ this.props.children }
+				{ ! isLoggedIn && (
+					<SubMasterbarNav
+						options={ headerIcons }
+						fallback={ headerIcons[ 0 ] }
+						uri={ `/design${ verticalSection }` } />
+				)}
+				<div className="themes__content">
+					<ThemesSearchCard
+						onSearch={ this.doSearch }
+						search={ prependFilterKeys( filter ) + search }
+						tier={ tier }
+						select={ this.onTierSelect } />
+					{ this.showUploadButton() && <Button className="themes__upload-button" compact icon
+						onClick={ this.onUploadClick }
+						href={ siteSlug ? `/themes/upload/${ siteSlug }` : '/themes/upload' }>
+						<Gridicon icon="cloud-upload" />
+						{ translate( 'Upload Theme' ) }
+					</Button>
+					}
+					<ThemesSelection
+						search={ search }
+						tier={ this.props.tier }
+						filter={ filter }
+						vertical={ this.props.vertical }
+						siteId={ this.props.siteId }
+						listLabel={ this.props.listLabel }
+						defaultOption={ this.props.defaultOption }
+						secondaryOption={ this.props.secondaryOption }
+						placeholderCount={ this.props.placeholderCount }
+						getScreenshotUrl={ function( theme ) {
+							if ( ! getScreenshotOption( theme ).getUrl ) {
+								return null;
+							}
+							return getScreenshotOption( theme ).getUrl( theme );
+						} }
+						onScreenshotClick={ function( theme ) {
+							if ( ! getScreenshotOption( theme ).action ) {
+								return;
+							}
+							getScreenshotOption( theme ).action( theme );
+						} }
+						getActionLabel={ function( theme ) {
+							return getScreenshotOption( theme ).label;
+						} }
+						getOptions={ function( theme ) {
+							return pickBy(
+								addTracking( options ),
+								option => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
+							); } }
+						trackScrollPage={ this.props.trackScrollPage }
+						emptyContent={ this.props.emptyContent }
+					/>
+					<ThemePreview />
+					{ this.props.children }
+				</div>
 			</Main>
 		);
 	}


### PR DESCRIPTION
This pull-request adds the ```SubMasterbarNav``` to ```theme-showcase``` section for not logged users.  
The links are a subset of `subject:` filter and should redirect to `/themes/{subject}`.

![themes_submasterbarnav](https://cloud.githubusercontent.com/assets/8056203/25044952/f72a460a-2129-11e7-9c38-6d02e12d4de6.png)

Testing:

- Go to `/themes` - `SubMasterbarNav` component should appear under the `Masterbar`
- Check if the links in `SubMasterbarNav` redirect to `/themes/{filter}`
- `SubMasterbarNav` isn't fixed and should move out of the viewport once your start scrolling
- Check if `SubMasterbarNav` doesn't interfere with the search bar on different viewport widths