### PR TITLE
ThemesShowcase: Make only search input sticky and not suggestions.

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -14,7 +14,6 @@ import Gridicon from 'gridicons';
 import Main from 'components/main';
 import Button from 'components/button';
 import ThemesSelection from './themes-selection';
-import StickyPanel from 'components/sticky-panel';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { addTracking, trackClick } from './helpers';
 import DocumentHead from 'components/data/document-head';
@@ -146,13 +145,11 @@ const ThemeShowcase = React.createClass( {
 			<Main className="themes">
 				<DocumentHead title={ themesMeta[ tier ].title } meta={ metas } />
 				<PageViewTracker path={ this.props.analyticsPath } title={ this.props.analyticsPageTitle } />
-				<StickyPanel>
-					<ThemesSearchCard
-						onSearch={ this.doSearch }
-						search={ prependFilterKeys( filter ) + search }
-						tier={ tier }
-						select={ this.onTierSelect } />
-				</StickyPanel>
+				<ThemesSearchCard
+					onSearch={ this.doSearch }
+					search={ prependFilterKeys( filter ) + search }
+					tier={ tier }
+					select={ this.onTierSelect } />
 				{ this.showUploadButton() && <Button className="themes__upload-button" compact icon
 					onClick={ this.onUploadClick }
 					href={ siteSlug ? `/design/upload/${ siteSlug }` : '/design/upload' }>

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -14,6 +14,7 @@ import Gridicon from 'gridicons';
 import Search from 'components/search';
 import SegmentedControl from 'components/segmented-control';
 import Suggestions from 'components/suggestions';
+import StickyPanel from 'components/sticky-panel';
 import config from 'config';
 import { isMobile } from 'lib/viewport';
 import { filterIsValid, getTaxonomies, } from '../theme-filters.js';
@@ -269,31 +270,33 @@ class ThemesMagicSearchCard extends React.Component {
 
 		return (
 			<div className={ magicSearchClass }>
-				<div
-					className={ themesSearchCardClass }
-					data-tip-target="themes-search-card"
-					onClick={ this.handleClickInside } >
-					{ searchField }
-					{ ! isMobile() && this.state.searchInput !== '' &&
-						<div className="themes-magic-search-card__icon" >
-							<Gridicon
-								icon="cross"
-								className="themes-magic-search-card__icon-close"
-								tabIndex="0"
-								onClick={ this.clearSearch }
-								aria-controls={ 'search-component-magic-search' }
-								aria-label={ translate( 'Clear Search' ) }
+				<StickyPanel>
+					<div
+						className={ themesSearchCardClass }
+						data-tip-target="themes-search-card"
+						onClick={ this.handleClickInside } >
+						{ searchField }
+						{ ! isMobile() && this.state.searchInput !== '' &&
+							<div className="themes-magic-search-card__icon" >
+								<Gridicon
+									icon="cross"
+									className="themes-magic-search-card__icon-close"
+									tabIndex="0"
+									onClick={ this.clearSearch }
+									aria-controls={ 'search-component-magic-search' }
+									aria-label={ translate( 'Clear Search' ) }
+								/>
+							</div>
+						}
+						{ isPremiumThemesEnabled && ! isJetpack &&
+							<SegmentedControl
+								initialSelected={ this.props.tier }
+								options={ tiers }
+								onSelect={ this.props.select }
 							/>
-						</div>
-					}
-					{ isPremiumThemesEnabled && ! isJetpack &&
-						<SegmentedControl
-							initialSelected={ this.props.tier }
-							options={ tiers }
-							onSelect={ this.props.select }
-						/>
-					}
-				</div>
+						}
+					</div>
+				</StickyPanel>
 				{ renderSuggestions &&
 					<Suggestions
 						ref="suggestions"


### PR DESCRIPTION
### Info
Search component is located inside the `StickyPanel` component. This made search input always visible even when scrolling to bottom. When suggestions where added in `MagicSearch` they also where located inside `StickyPanel`. When suggestions list is big it can happen that it goes down bellow the limit of the screen and since it is sticky it is not possible to scroll there. This PR implements a fix that puts only Search input inside `StickyPanel` and suggestions outside so they are part of the rest of the page and scrollable like everything else. 

Fixes #12243 

### Testing 
Go to `/design` enter single char into input - this way suggestions list will be very big.Scroll down. Search stays in place - suggestions scroll. Compare to master. 