### PR TITLE
NPS Survey: Use label/input directly instead of FormLabel/FormRadio

### DIFF
--- a/client/blocks/nps-survey/recommendation-option.jsx
+++ b/client/blocks/nps-survey/recommendation-option.jsx
@@ -3,12 +3,6 @@
  */
 import React, { Component, PropTypes } from 'react';
 
-/**
- * Internal dependencies
- */
-import FormRadio from 'components/forms/form-radio';
-import FormLabel from 'components/forms/form-label';
-
 class RecommendationOption extends Component {
 	constructor( props ) {
 		super( props );
@@ -27,9 +21,8 @@ class RecommendationOption extends Component {
 
 	render() {
 		return (
-			<FormLabel>
-				<FormRadio
-					className="nps-survey__recommendation-option"
+			<label className="nps-survey__recommendation-option">
+				<input type="radio"
 					name="nps-survey-recommendation-option"
 					value={ this.props.value }
 					checked={ this.props.selected }
@@ -37,7 +30,7 @@ class RecommendationOption extends Component {
 					onChange={ this.handleChange }
 				/>
 				<span>{ this.props.value }</span>
-			</FormLabel>
+			</label>
 		);
 	}
 }

--- a/client/blocks/nps-survey/recommendation-select.jsx
+++ b/client/blocks/nps-survey/recommendation-select.jsx
@@ -31,7 +31,11 @@ class RecommendationSelect extends PureComponent {
 		const options = values.map( ( value ) => this.renderOption( value ) );
 
 		return (
-			<div>
+			<div className="nps-survey__recommendation-select">
+				<div className="nps-survey__scale-labels">
+					<span>Unlikely</span>
+					<span className="nps-survey__very-likely-label">Very Likely</span>
+				</div>
 				{ options }
 			</div>
 		);

--- a/client/blocks/nps-survey/style.scss
+++ b/client/blocks/nps-survey/style.scss
@@ -25,3 +25,12 @@
 		display: inline-block;
 	}
 }
+
+.nps-survey__recommendation-option {
+	display: inline-block;
+}
+
+.nps-survey__recommendation-option input[type=radio] + span {
+	clear: both;
+	margin-left: 0;
+}

--- a/client/blocks/nps-survey/style.scss
+++ b/client/blocks/nps-survey/style.scss
@@ -28,9 +28,15 @@
 
 .nps-survey__recommendation-option {
 	display: inline-block;
+	padding: 0 6px;
+}
+
+.nps-survey__recommendation-option input[type=radio] {
+	margin: 0 2px;
 }
 
 .nps-survey__recommendation-option input[type=radio] + span {
 	clear: both;
 	margin-left: 0;
+	text-align: center;
 }

--- a/client/blocks/nps-survey/style.scss
+++ b/client/blocks/nps-survey/style.scss
@@ -26,6 +26,18 @@
 	}
 }
 
+.nps-survey__recommendation-select {
+	display: inline-block;
+}
+
+.nps-survey__scale-labels {
+	padding: 0 6px;
+}
+
+.nps-survey__very-likely-label {
+	float: right;
+}
+
 .nps-survey__recommendation-option {
 	display: inline-block;
 	padding: 0 6px;


### PR DESCRIPTION
This PR is the first step on working on the styling of the NPS survey. A future PR will implement the remaining styling. This one just focuses on making a structural change that will enable easier styling moving forward. Namely, I have used `label` and `input` directly instead of using the `FormLabel` and `FormRadio` components -- those components are really geared for use on a more traditional form. And since we want this to look quite different in our survey (the label being below the radio button, and all the radio buttons on the same line), it didn't really make sense to use those wrappers -- I'd be overriding practically everything they give us.

<img width="550" alt="screencapture at tue mar 28 09 01 40 edt 2017" src="https://cloud.githubusercontent.com/assets/2098816/24406095/2f53bce8-1395-11e7-8dce-deef26a3867b.png">

To test (just a basic regression test to make sure the `nps-survey` block still functions as expected):
- Go to `http://calypso.localhost:3000/devdocs/blocks/nps-survey`
- Try answering survey (select a score; click Finish; then Dismiss on the thank you screen)
- Try dismissing without answering survey (select a score, or not; Then click I'd rather not answer)