### PR TITLE
Editor: Select current featured image when opening media library

### DIFF
--- a/client/post-editor/editor-featured-image/index.jsx
+++ b/client/post-editor/editor-featured-image/index.jsx
@@ -1,58 +1,65 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
 import MediaModal from 'post-editor/media-modal';
+import MediaActions from 'lib/media/actions';
 import PostActions from 'lib/posts/actions';
 import PostUtils from 'lib/posts/utils';
 import * as stats from 'lib/posts/stats';
 import EditorFeaturedImagePreviewContainer from './preview-container';
 import Button from 'components/button';
+import { getMediaItem } from 'state/selectors';
+import { getFeaturedImageId } from 'lib/posts/utils';
+import QueryMedia from 'components/data/query-media';
+import { localize } from 'i18n-calypso';
 
-export default React.createClass( {
-	displayName: 'EditorFeaturedImage',
-
-	propTypes: {
+class EditorFeaturedImage extends Component {
+	static propTypes = {
 		maxWidth: React.PropTypes.number,
 		site: React.PropTypes.object,
 		post: React.PropTypes.object,
 		selecting: React.PropTypes.bool,
-		onImageSelected: React.PropTypes.func
-	},
+		onImageSelected: React.PropTypes.func,
+		featuredImage: React.PropTypes.object,
+	};
 
-	getDefaultProps() {
-		return {
-			maxWidth: 450,
-			onImageSelected: () => {}
-		};
-	},
+	static defaultProps = {
+		maxWidth: 450,
+		onImageSelected: () => {}
+	};
 
-	getInitialState() {
-		return {
-			isSelecting: false
-		};
-	},
+	state = {
+		isSelecting: false
+	};
 
-	showMediaModal() {
+	showMediaModal = () => {
+		const { featuredImage, site } = this.props;
+
+		if ( featuredImage ) {
+			MediaActions.setLibrarySelectedItems( site.ID, [ featuredImage ] );
+		}
+
 		this.setState( {
 			isSelecting: true
 		} );
-	},
+	};
 
-	hideMediaModal() {
+	hideMediaModal = () => {
 		this.setState( {
 			isSelecting: false
 		} );
-	},
+	};
 
-	setImage( value ) {
+	setImage = ( value ) => {
 		this.hideMediaModal();
 		this.props.onImageSelected();
 
@@ -66,9 +73,9 @@ export default React.createClass( {
 
 		stats.recordStat( 'featured_image_set' );
 		stats.recordEvent( 'Featured image set' );
-	},
+	};
 
-	renderMediaModal() {
+	renderMediaModal = () => {
 		if ( ! this.props.site ) {
 			return;
 		}
@@ -79,14 +86,14 @@ export default React.createClass( {
 					visible={ this.props.selecting || this.state.isSelecting }
 					onClose={ this.setImage }
 					site={ this.props.site }
-					labels={ { confirm: this.translate( 'Set Featured Image' ) } }
+					labels={ { confirm: this.props.translate( 'Set Featured Image' ) } }
 					enabledFilters={ [ 'images' ] }
 					single />
 			</MediaLibrarySelectedData>
 		);
-	},
+	};
 
-	renderCurrentImage() {
+	renderCurrentImage = () => {
 		if ( ! this.props.site || ! this.props.post ) {
 			return;
 		}
@@ -102,15 +109,18 @@ export default React.createClass( {
 				itemId={ itemId }
 				maxWidth={ this.props.maxWidth } />
 		);
-	},
+	};
 
 	render() {
+		const { site, post } = this.props;
+		const featuredImageId = getFeaturedImageId( post );
 		const classes = classnames( 'editor-featured-image', {
 			'is-assigned': !! PostUtils.getFeaturedImageId( this.props.post )
 		} );
 
 		return (
 			<div className={ classes }>
+				{ site && featuredImageId && <QueryMedia siteId={ site.ID } mediaId={ featuredImageId } /> }
 				{ this.renderMediaModal() }
 				<Button
 						className="editor-featured-image__current-image"
@@ -125,4 +135,16 @@ export default React.createClass( {
 			</div>
 		);
 	}
-} );
+}
+
+export default connect(
+	( state, ownProps ) => {
+		const { post, site } = ownProps;
+		const siteId = site && site.ID;
+		const featuredImageId = getFeaturedImageId( post );
+
+		return {
+			featuredImage: getMediaItem( state, siteId, featuredImageId ),
+		};
+	},
+)( localize( EditorFeaturedImage ) );


### PR DESCRIPTION
Currently, if you set a featured image for a post then open the featured image media modal, the current featured image is not selected. This can create confusion if you have a lot of media items or multiple versions of the same image. This selects the featured image if it exists (fix for #12235). These changes were broken out of #12296. The new approach takes advantage of `<QueryMedia />` to make the featured image available.

ESLint was blocking this commit because it used createClass instead of ES6. I converted to ES6 as a result. I can revert back and circumvent ESLint if desired.

## To test
1. Load this branch and then start a new post at http://calypso.localhost:3000/post/
2. Set a featured image for your post.
3. Once you set a featured image, click on the image again to open the media modal. The existing featured image should be selected currently. This should work for both the featured image in the sidebar and above the post.
4. Try removing/deleting/re-adding the featured image. You shouldn't notice any regressions.

## GIF
![900a9a44-0be2-11e7-9c8a-6e5b5d674d50](https://cloud.githubusercontent.com/assets/7240478/24408206/44a2287e-138a-11e7-9877-56badee10482.gif)