### PR TITLE
Themes: Enable SSR API Caching for tier, filters, verticals

### DIFF
--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -16,7 +16,7 @@ import Upload from 'my-sites/themes/theme-upload';
 import trackScrollPage from 'lib/track-scroll-page';
 import { DEFAULT_THEME_QUERY } from 'state/themes/constants';
 import { requestThemes, receiveThemes, setBackPath } from 'state/themes/actions';
-import { getThemesForQuery } from 'state/themes/selectors';
+import { getThemesForQuery, getThemesFoundForQuery } from 'state/themes/selectors';
 import { getAnalyticsData } from './helpers';
 
 const debug = debugFactory( 'calypso:themes' );
@@ -113,7 +113,7 @@ export function fetchThemeData( context, next, shouldUseCache = false ) {
 		const cachedData = themesQueryCache.get( cacheKey );
 		if ( cachedData ) {
 			debug( `found theme data in cache key=${ cacheKey }` );
-			context.store.dispatch( receiveThemes( cachedData.themes, siteId ) );
+			context.store.dispatch( receiveThemes( cachedData.themes, siteId, query, cachedData.found ) );
 			context.renderCacheKey = context.path + cachedData.timestamp;
 			return next();
 		}
@@ -123,8 +123,9 @@ export function fetchThemeData( context, next, shouldUseCache = false ) {
 		.then( () => {
 			if ( shouldUseCache ) {
 				const themes = getThemesForQuery( context.store.getState(), siteId, query );
+				const found = getThemesFoundForQuery( context.store.getState(), siteId, query );
 				const timestamp = Date.now();
-				themesQueryCache.set( cacheKey, { themes, timestamp } );
+				themesQueryCache.set( cacheKey, { themes, found, timestamp } );
 				context.renderCacheKey = context.path + timestamp;
 				debug( `caching theme data key=${ cacheKey }` );
 			}

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -107,14 +107,17 @@ export function fetchThemeData( context, next, shouldUseCache = false ) {
 		page: 1,
 		number: DEFAULT_THEME_QUERY.number,
 	};
-	const cacheKey = context.path;
+	// context.pathname includes tier, filter, and verticals, but not the query string, so it's a suitable cacheKey
+	// However, we can't guarantee it's normalized -- filters can be in any order, resulting in multiple possible cacheKeys for
+	// the same sets of results.
+	const cacheKey = context.pathname;
 
 	if ( shouldUseCache ) {
 		const cachedData = themesQueryCache.get( cacheKey );
 		if ( cachedData ) {
 			debug( `found theme data in cache key=${ cacheKey }` );
 			context.store.dispatch( receiveThemes( cachedData.themes, siteId, query, cachedData.found ) );
-			context.renderCacheKey = context.path + cachedData.timestamp;
+			context.renderCacheKey = cacheKey + cachedData.timestamp;
 			return next();
 		}
 	}
@@ -126,7 +129,7 @@ export function fetchThemeData( context, next, shouldUseCache = false ) {
 				const found = getThemesFoundForQuery( context.store.getState(), siteId, query );
 				const timestamp = Date.now();
 				themesQueryCache.set( cacheKey, { themes, found, timestamp } );
-				context.renderCacheKey = context.path + timestamp;
+				context.renderCacheKey = cacheKey + timestamp;
 				debug( `caching theme data key=${ cacheKey }` );
 			}
 			next();

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { compact, startsWith } from 'lodash';
+import { compact, isEmpty, startsWith } from 'lodash';
 import debugFactory from 'debug';
 import Lru from 'lru';
 import React from 'react';
@@ -138,8 +138,8 @@ export function fetchThemeData( context, next, shouldUseCache = false ) {
 }
 
 export function fetchThemeDataWithCaching( context, next ) {
-	if ( Object.keys( context.query ).length > 0 ) {
-		// Don't cache URLs with query params for now
+	if ( ! isEmpty( context.query ) ) {
+		// Don't cache URLs with query params
 		return fetchThemeData( context, next, false );
 	}
 

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -23,12 +23,14 @@ export default function( router ) {
 				makeLayout
 			);
 			router( '/design/upload/*', makeLayout );
-			router( '/design/*', fetchThemeDataWithCaching, loggedOut, makeLayout ); // Needed so direct hits don't result in a 404.
+			// The following route definition is needed so direct hits on `/design/<mysite>` don't result in a 404.
+			router( '/design/*', fetchThemeDataWithCaching, loggedOut, makeLayout );
 		} else {
 			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, makeLayout );
 			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`, makeLayout );
 			router( '/design/upload/*', makeLayout );
-			router( '/design/*', makeLayout ); // Needed so direct hits don't result in a 404.
+			// The following route definition is needed so direct hits on `/design/<mysite>` don't result in a 404.
+			router( '/design/*', makeLayout );
 		}
 	}
 }

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -4,7 +4,7 @@
 import config from 'config';
 import { makeLayout } from 'controller';
 import { getSubjects } from './theme-filters.js';
-import { fetchThemeDataWithCaching, fetchThemeData, loggedOut } from './controller';
+import { fetchThemeDataWithCaching, loggedOut } from './controller';
 
 // `logged-out` middleware isn't SSR-compliant yet, but we can at least render
 // the layout.
@@ -23,7 +23,7 @@ export default function( router ) {
 				makeLayout
 			);
 			router( '/design/upload/*', makeLayout );
-			router( '/design/*', fetchThemeData, loggedOut, makeLayout ); // Needed so direct hits don't result in a 404.
+			router( '/design/*', fetchThemeDataWithCaching, loggedOut, makeLayout ); // Needed so direct hits don't result in a 404.
 		} else {
 			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, makeLayout );
 			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`, makeLayout );

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -15,9 +15,13 @@ export default function( router ) {
 
 	if ( config.isEnabled( 'manage/themes' ) ) {
 		if ( config.isEnabled( 'manage/themes-ssr' ) ) {
-			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?$`, fetchThemeDataWithCaching, loggedOut, makeLayout );
-			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, fetchThemeData, loggedOut, makeLayout );
-			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`, fetchThemeData, loggedOut, makeLayout );
+			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, fetchThemeDataWithCaching, loggedOut, makeLayout );
+			router(
+				`/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`,
+				fetchThemeDataWithCaching,
+				loggedOut,
+				makeLayout
+			);
 			router( '/design/upload/*', makeLayout );
 			router( '/design/*', fetchThemeData, loggedOut, makeLayout ); // Needed so direct hits don't result in a 404.
 		} else {

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -17,7 +17,7 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { createReduxStore } from 'state';
 import EmptyComponent from 'test/helpers/react/empty-component';
 import useMockery from 'test/helpers/use-mockery';
-import { THEMES_REQUEST_SUCCESS, THEMES_REQUEST_FAILURE } from 'state/action-types';
+import { THEMES_REQUEST_FAILURE } from 'state/action-types';
 import { receiveThemes } from 'state/themes/actions';
 import { DEFAULT_THEME_QUERY } from 'state/themes/constants';
 
@@ -104,14 +104,12 @@ describe( 'logged-out', () => {
 		} );
 
 		it( 'renders without error when themes are present', () => {
-			this.store.dispatch( receiveThemes( this.themes, 'wpcom' ) );
-			this.store.dispatch( {
-				type: THEMES_REQUEST_SUCCESS,
-				siteId: 'wpcom',
-				query: DEFAULT_THEME_QUERY,
-				found: this.themes.length,
-				themes: this.themes
-			} );
+			this.store.dispatch( receiveThemes(
+				this.themes,
+				'wpcom',
+				DEFAULT_THEME_QUERY,
+				this.themes.length )
+			);
 
 			let markup;
 			assert.doesNotThrow( () => {


### PR DESCRIPTION
So far, we haven't been caching API data for `/design` routes that included tier, filters, or verticals.

This PR:

* Drops an obsolete route
* Uses the `fetchThemeDataWithCaching` (instead of un-cached `fetchThemeData`) middleware for `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`
* Uses `context.pathname` instead of `context.path` (which includes the query string) as cache key
* Makes sure we pass `query` and `found` args to `receiveThemes` so the results list is associated with the correct query (if any).
* Uses `isEmpty` instead of `Object.keys(...).lenth > 0` for better legibility
* De-duplicates the `logged-out` SSR test (only very tangentially related to the rest 😄)

To test:
* Re-start Calypso with debugging enabled, i.e. `DEBUG="calypso:server-render" make run`
* In an incognito window, hit several routes that include tier, filters, and verticals. Be sure to always hit 'Enter' in the browser's URL bar so actual HTTP requests for the given URL are fired and not intercepted by client-side routing! Try those routes with JS turned off and verify that you're seeing the same results. (Unfortunately, you can't try it all while JS is turned off, since apparently our `Search` component doesn't work without 😕.)
* Observe your node console: 
  * The first time you hit a given route, you should see `caching theme data key=${ cacheKey }` (`cacheKey` being the `pathname` of the URL you entered into your browser)
  * On second hit, you should see `found theme data in cache key=${ cacheKey }`
* Finally, try the showcase while logged-in and make sure it still works as before.