### PR TITLE
Update EditGravatar

### DIFF
--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -164,6 +164,9 @@ export class EditGravatar extends Component {
 			user
 		} = this.props;
 		const gravatarLink = `https://gravatar.com/${ user.username || '' }`;
+		// use imgSize = 400 for caching
+		// it's the popular value for large Gravatars in Calypso
+		const GRAVATAR_IMG_SIZE = 400;
 		return (
 			<div className="edit-gravatar">
 				{ this.renderImageEditor() }
@@ -176,7 +179,7 @@ export class EditGravatar extends Component {
 						}
 					>
 						<Gravatar
-							imgSize={ 400 }
+							imgSize={ GRAVATAR_IMG_SIZE }
 							size={ 150 }
 							user={ user }
 						/>

--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -162,7 +162,7 @@ export class EditGravatar extends Component {
 			translate,
 			user
 		} = this.props;
-		const gravatarLink = `//gravatar.com/${ user.username || '' }`;
+		const gravatarLink = `https://gravatar.com/${ user.username || '' }`;
 		return (
 			<div className="edit-gravatar">
 				{ this.renderImageEditor() }

--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -31,6 +31,7 @@ import {
 	uploadGravatar
 } from 'state/current-user/gravatar-status/actions';
 import ImageEditor from 'blocks/image-editor';
+import InfoPopover from 'components/info-popover';
 
 /**
  * Module dependencies
@@ -158,8 +159,10 @@ export class EditGravatar extends Component {
 	render() {
 		const {
 			isUploading,
+			translate,
 			user
 		} = this.props;
+		const gravatarLink = `//gravatar.com/${ user.username || '' }`;
 		return (
 			<div className="edit-gravatar">
 				{ this.renderImageEditor() }
@@ -187,6 +190,30 @@ export class EditGravatar extends Component {
 						{ isUploading && <Spinner className="edit-gravatar__spinner" /> }
 						</div>
 				</FilePicker>
+				<div>
+					<p className="edit-gravatar__explanation">Your profile photo is public.</p>
+					<InfoPopover
+						className="edit-gravatar__pop-over"
+						position="left" >
+						{ translate( '{{p}}The avatar you use on WordPress.com comes ' +
+							'from {{a}}Gravatar{{/a}} - a universal avatar service.{{/p}}' +
+							'{{p}}Your photo may be displayed on other sites where ' +
+							'you use your email address %(email)s.{{/p}}',
+							{
+								components: {
+									a: <a
+										href={ gravatarLink }
+										target="_blank"
+										rel="noopener noreferrer" />,
+									p: <p />
+								},
+								args: {
+									email: user.email
+								}
+							}
+						) }
+					</InfoPopover>
+				</div>
 			</div>
 		);
 	}

--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -226,7 +226,7 @@ export class EditGravatar extends Component {
 
 export default connect(
 	state => ( {
-		user: getCurrentUser( state ),
+		user: getCurrentUser( state ) || {},
 		isUploading: isCurrentUserUploadingGravatar( state ),
 	} ),
 	{

--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -32,6 +32,7 @@ import {
 } from 'state/current-user/gravatar-status/actions';
 import ImageEditor from 'blocks/image-editor';
 import InfoPopover from 'components/info-popover';
+import ExternalLink from 'components/external-link';
 
 /**
  * Module dependencies
@@ -196,15 +197,16 @@ export class EditGravatar extends Component {
 						className="edit-gravatar__pop-over"
 						position="left" >
 						{ translate( '{{p}}The avatar you use on WordPress.com comes ' +
-							'from {{a}}Gravatar{{/a}} - a universal avatar service.{{/p}}' +
+							'from {{ExternalLink}}Gravatar{{/ExternalLink}} - a universal avatar service.{{/p}}' +
 							'{{p}}Your photo may be displayed on other sites where ' +
 							'you use your email address %(email)s.{{/p}}',
 							{
 								components: {
-									a: <a
+									ExternalLink: <ExternalLink
 										href={ gravatarLink }
 										target="_blank"
-										rel="noopener noreferrer" />,
+										rel="noopener noreferrer"
+										icon={ true } />,
 									p: <p />
 								},
 								args: {

--- a/client/blocks/edit-gravatar/style.scss
+++ b/client/blocks/edit-gravatar/style.scss
@@ -82,3 +82,24 @@
 .edit-gravatar .spinner__border {
 	fill: rgba( $gray-dark, 0.5 );
 }
+
+.edit-gravatar__explanation {
+	color: $gray-text-min;
+	font-size: 13px;
+	font-style: italic;
+	font-weight: 400;
+	display: inline-block;
+	margin-top: 0.5em;
+}
+
+.edit-gravatar .info-popover {
+	vertical-align: middle;
+}
+
+.edit-gravatar__pop-over .external-link .gridicons-external { // specificity used to override margin
+	margin-left: 1px;
+}
+
+.edit-gravatar__pop-over p:last-of-type {
+	margin-bottom: 0;
+}

--- a/client/blocks/edit-gravatar/style.scss
+++ b/client/blocks/edit-gravatar/style.scss
@@ -1,4 +1,5 @@
 .edit-gravatar__image-container {
+	cursor: pointer;
 	display: inline-block;
 	position: relative;
 

--- a/client/me/profile-gravatar/index.jsx
+++ b/client/me/profile-gravatar/index.jsx
@@ -13,6 +13,7 @@ import Animate from 'components/animate';
 import Gravatar from 'components/gravatar';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { isEnabled } from 'config';
+import ExternalLink from 'components/external-link';
 
 const debug = debugFactory( 'calypso:me:sidebar-gravatar' );
 
@@ -44,7 +45,12 @@ class ProfileGravatar extends Component {
 					</div>
 					<h2 className="profile-gravatar__user-display-name">{ this.props.user.display_name }</h2>
 					<div className="profile-gravatar__user-secondary-info">
-						<a href={ profileURL } target="_blank" rel="noopener noreferrer">@{ this.props.user.username }</a>
+						<ExternalLink
+							href={ profileURL }
+							target="_blank"
+							rel="noopener noreferrer" >
+							@{ this.props.user.username }
+						</ExternalLink>
 					</div>
 				</div>
 			);
@@ -53,7 +59,7 @@ class ProfileGravatar extends Component {
 		return (
 			<div className="profile-gravatar">
 				<Animate type="appear">
-					<a
+					<ExternalLink
 						href="https://secure.gravatar.com/site/wpcom?wpcc-no-close"
 						target="_blank"
 						rel="noopener noreferrer"
@@ -67,11 +73,16 @@ class ProfileGravatar extends Component {
 								{ this.props.translate( 'Update Profile Photo' ) }
 							</span>
 						</span>
-					</a>
+					</ExternalLink>
 				</Animate>
 				<h2 className="profile-gravatar__user-display-name">{ this.props.user.display_name }</h2>
 				<div className="profile-gravatar__user-secondary-info">
-					<a href={ profileURL } target="_blank" rel="noopener noreferrer">@{ this.props.user.username }</a>
+					<ExternalLink
+						href={ profileURL }
+						target="_blank"
+						rel="noopener noreferrer" >
+						@{ this.props.user.username }
+					</ExternalLink>
 				</div>
 			</div>
 		);

--- a/client/me/profile-gravatar/index.jsx
+++ b/client/me/profile-gravatar/index.jsx
@@ -36,12 +36,15 @@ class ProfileGravatar extends Component {
 
 	render() {
 		const profileURL = `https://gravatar.com/${ this.props.user.username }`;
+		// use imgSize = 400 for caching
+		// it's the popular value for large Gravatars in Calypso
+		const GRAVATAR_IMG_SIZE = 400;
 
 		if ( isEnabled( 'me/edit-gravatar' ) ) {
 			return (
 				<div className="profile-gravatar">
 					<div className="profile-gravatar__gravatar-container" onClick={ this.handleImageClick }>
-						<Gravatar user={ this.props.user } size={ 150 } imgSize={ 400 } />
+						<Gravatar user={ this.props.user } size={ 150 } imgSize={ GRAVATAR_IMG_SIZE } />
 					</div>
 					<h2 className="profile-gravatar__user-display-name">{ this.props.user.display_name }</h2>
 					<div className="profile-gravatar__user-secondary-info">
@@ -66,7 +69,7 @@ class ProfileGravatar extends Component {
 						className="profile-gravatar__edit"
 						onClick={ this.handleExternalLinkClick } >
 
-						<Gravatar user={ this.props.user } size={ 150 } imgSize={ 400 } />
+						<Gravatar user={ this.props.user } size={ 150 } imgSize={ GRAVATAR_IMG_SIZE } />
 
 						<span className="profile-gravatar__edit-label-wrap">
 							<span className="profile-gravatar__edit-label">

--- a/client/me/profile-gravatar/index.jsx
+++ b/client/me/profile-gravatar/index.jsx
@@ -1,29 +1,54 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import debugFactory from 'debug';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import Animate from 'components/animate';
 import Gravatar from 'components/gravatar';
-import eventRecorder from 'me/event-recorder';
+import { recordGoogleEvent } from 'state/analytics/actions';
+import { isEnabled } from 'config';
 
 const debug = debugFactory( 'calypso:me:sidebar-gravatar' );
 
-export default React.createClass( {
-	displayName: 'ProfileGravatar',
-
-	mixins: [ eventRecorder ],
-
+class ProfileGravatar extends Component {
 	componentDidMount() {
 		debug( 'The ProfileGravatar component is mounted.' );
-	},
+	}
+
+	handleImageClick = () => {
+		this.props.recordGoogleEvent( 'Me',
+			'Clicked on Unclickable Gravatar Image in Sidebar'
+		);
+	};
+
+	handleExternalLinkClick = () => {
+		this.props.recordGoogleEvent( 'Me',
+			'Clicked on Gravatar Update Profile Photo in Sidebar'
+		);
+	};
 
 	render() {
 		const profileURL = `//gravatar.com/${ this.props.user.username }`;
+
+		if ( isEnabled( 'me/edit-gravatar' ) ) {
+			return (
+				<div className="profile-gravatar">
+					<div className="profile-gravatar__gravatar-container" onClick={ this.handleImageClick }>
+						<Gravatar user={ this.props.user } size={ 150 } imgSize={ 400 } />
+					</div>
+					<h2 className="profile-gravatar__user-display-name">{ this.props.user.display_name }</h2>
+					<div className="profile-gravatar__user-secondary-info">
+						<a href={ profileURL } target="_blank" rel="noopener noreferrer">@{ this.props.user.username }</a>
+					</div>
+				</div>
+			);
+		}
 
 		return (
 			<div className="profile-gravatar">
@@ -33,13 +58,13 @@ export default React.createClass( {
 						target="_blank"
 						rel="noopener noreferrer"
 						className="profile-gravatar__edit"
-						onClick={ this.recordClickEvent( 'Gravatar Update Profile Photo in Sidebar' ) } >
+						onClick={ this.handleExternalLinkClick } >
 
 						<Gravatar user={ this.props.user } size={ 150 } imgSize={ 400 } />
 
 						<span className="profile-gravatar__edit-label-wrap">
 							<span className="profile-gravatar__edit-label">
-								{ this.translate( 'Update Profile Photo' ) }
+								{ this.props.translate( 'Update Profile Photo' ) }
 							</span>
 						</span>
 					</a>
@@ -51,4 +76,8 @@ export default React.createClass( {
 			</div>
 		);
 	}
-} );
+}
+
+export default connect( null, {
+	recordGoogleEvent
+} )( localize( ProfileGravatar ) );

--- a/client/me/profile-gravatar/index.jsx
+++ b/client/me/profile-gravatar/index.jsx
@@ -34,7 +34,7 @@ class ProfileGravatar extends Component {
 	};
 
 	render() {
-		const profileURL = `//gravatar.com/${ this.props.user.username }`;
+		const profileURL = `https://gravatar.com/${ this.props.user.username }`;
 
 		if ( isEnabled( 'me/edit-gravatar' ) ) {
 			return (


### PR DESCRIPTION
This is part 1 of ~~3~~ 4 related PRs.

1. EditGravatar general changes: https://github.com/Automattic/wp-calypso/pull/12595
2. Ask users to verify their email first: https://github.com/Automattic/wp-calypso/pull/12596
3. Allow users to drag and drop image: https://github.com/Automattic/wp-calypso/pull/12597
4. Analytics: https://github.com/Automattic/wp-calypso/pull/13134

## There are 2 changes included in this PR:
1. Adding a note that Gravatars are public
2. Removing the Gravatar link from the /me sidebar when the `me/edit-gravatar` feature flag is enabled

Here's the behaviour of the note:

![info-pop-over](https://cloud.githubusercontent.com/assets/11487924/24420158/e1519972-13bf-11e7-9fa6-2b5938b4f226.gif)

## Testing instructions:
1. Check out this branch and `make run` as usual
2. Go to calypso.localhost:3000/me
3. See that clicking the Gravatar in the sidebar takes you to https://secure.gravatar.com/site/wpcom?wpcc-no-close
4. See that there is no EditGravatar component shown:
<img width="1048" alt="screen shot 2017-03-28 at 12 58 19 pm" src="https://cloud.githubusercontent.com/assets/11487924/24417417/4c09fb88-13b6-11e7-86dd-43fea63f511a.png">

5. Turn on the feature flag using `export ENABLE_FEATURES=me/edit-gravatar && make run`
6. Go to calypso.localhost:3000/me
7. See that clicking the Gravatar in the sidebar does not do anything
8. See the EditGravatar component:
![edit-gravatar-component](https://cloud.githubusercontent.com/assets/11487924/24436632/9b06aac0-140a-11e7-92fc-0afc70c9c3a5.gif)

9. See the extra info about Gravatars, and can click the popover

## The wording

The info popover wording could use a lookover, so I added the Needs Copy Review tag :) Here's what it says:

> The avatar you use on WordPress.com comes from Gravatar - a universal avatar service.
Your photo may be displayed on other sites where you use your email address rockstar@email.com.