### PR TITLE
EditGravatar: Ensure user has verified email

### DIFF
--- a/client/blocks/edit-gravatar/style.scss
+++ b/client/blocks/edit-gravatar/style.scss
@@ -104,3 +104,13 @@
 .edit-gravatar__pop-over p:last-of-type {
 	margin-bottom: 0;
 }
+
+.edit-gravatar.is-unverified {
+	.file-picker {
+		pointer-events: none;
+	}
+
+	.gravatar {
+		opacity: 0.33;
+	}
+}

--- a/client/blocks/edit-gravatar/test/index.jsx
+++ b/client/blocks/edit-gravatar/test/index.jsx
@@ -19,6 +19,7 @@ describe( 'EditGravatar', function() {
 		FilePicker,
 		Gravatar,
 		ImageEditor,
+		VerifyEmailDialog,
 		sandbox;
 	const user = {
 		email_verified: false
@@ -45,6 +46,7 @@ describe( 'EditGravatar', function() {
 		FilePicker = require( 'components/file-picker' );
 		Gravatar = require( 'components/gravatar' ).default;
 		ImageEditor = require( 'blocks/image-editor' );
+		VerifyEmailDialog = require( 'components/email-verification/email-verification-dialog' );
 	} );
 
 	describe( 'component rendering', () => {
@@ -175,6 +177,23 @@ describe( 'EditGravatar', function() {
 			expect( wrapper.update().find( ImageEditor ).length ).to.equal( 0 );
 			expect( receiveGravatarImageFailedSpy ).to.have.been.calledOnce;
 			expect( uploadGravatarSpy.callCount ).to.equal( 0 );
+		} );
+	} );
+
+	describe( 'unverified user', () => {
+		it( 'shows email verification dialog when clicked', () => {
+			const wrapper = shallow(
+				<EditGravatar
+					translate={ noop }
+					user={ user }
+				/>
+			);
+			// Enzyme requires simulate() to be called directly on the element with the click handler
+			const clickableWrapper = wrapper.find( '.edit-gravatar > div' ).first();
+
+			clickableWrapper.simulate( 'click' );
+			wrapper.update(); // make sure the state has been updated
+			expect( wrapper.find( VerifyEmailDialog ) ).to.have.length( 1 );
 		} );
 	} );
 } );


### PR DESCRIPTION
This is part 2 of ~~3~~ 4 related PRs.

1. ✅  EditGravatar general changes: https://github.com/Automattic/wp-calypso/pull/12595
2. Ask users to verify their email first: https://github.com/Automattic/wp-calypso/pull/12596
3. Allow users to drag and drop image: https://github.com/Automattic/wp-calypso/pull/12597
4. Analytics: https://github.com/Automattic/wp-calypso/pull/13134

## Changes in this PR
- A different message is displayed for users who have not verified their email
- Clicking the Gravatar will not show the file uploader
- Instead, an email verification modal will be shown
- `VerifyEmailDialog` was moved to `/components` from `/post-editor`
- `VerifyEmailDialog` no longer relies on the user prop passed in to have the `sendVerificationEmail` function

The designs for these were discussed in p7W0co-1X-p2 and p3fqKv-3Z2-p2

## Testing instructions
1. Turn on the feature flag using `export ENABLE_FEATURES=me/edit-gravatar && make run`
2. Log in to wp.com as a user without a verified email address
3. Go to calypso.localhost:3000/me
4. You see a different message on the Gravatar, "Verify email first":
<img width="245" alt="verify-email-first" src="https://cloud.githubusercontent.com/assets/11487924/24421412/257265d8-13c4-11e7-94a8-3067c15e8e46.png">

5. After clicking on the Gravatar, you see this modal:
<img width="667" alt="screen shot 2017-03-28 at 2 39 19 pm" src="https://cloud.githubusercontent.com/assets/11487924/24421485/61982cd2-13c4-11e7-8e56-6e697ed09c80.png">
