### PR TITLE
EditGravatar: Allow user to drag and drop images

### DIFF
--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -34,6 +34,7 @@ import ImageEditor from 'blocks/image-editor';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
 import VerifyEmailDialog from 'components/email-verification/email-verification-dialog';
+import DropZone from 'components/drop-zone';
 
 /**
  * Module dependencies
@@ -209,6 +210,12 @@ export class EditGravatar extends Component {
 								)
 							}
 						>
+							{ user.email_verified && (
+								<DropZone
+									textLabel={ translate( 'Drop to upload profile photo' ) }
+									onFilesDrop={ this.onReceiveFile }
+								/>
+							) }
 							<Gravatar
 								imgSize={ GRAVATAR_IMG_SIZE }
 								size={ 150 }

--- a/client/blocks/edit-gravatar/style.scss
+++ b/client/blocks/edit-gravatar/style.scss
@@ -114,3 +114,28 @@
 		opacity: 0.33;
 	}
 }
+
+.edit-gravatar .drop-zone {
+	border-radius: 50%;
+	width: 150px;
+	height: 150px;
+	border: 0;
+	margin: 0;
+}
+
+.edit-gravatar .drop-zone__content {
+	top: calc( 50% - 0.5em ); // align with button text
+}
+
+.edit-gravatar .drop-zone__content-text {
+	padding: 0 1em;
+}
+
+.edit-gravatar .drop-zone.is-active ~ .edit-gravatar__label-container {
+	visibility: hidden;
+}
+
+.edit-gravatar .drop-zone .gridicon {
+	height: 36px;
+	width: 36px;
+}

--- a/client/blocks/edit-gravatar/test/index.jsx
+++ b/client/blocks/edit-gravatar/test/index.jsx
@@ -20,6 +20,7 @@ describe( 'EditGravatar', function() {
 		Gravatar,
 		ImageEditor,
 		VerifyEmailDialog,
+		DropZone,
 		sandbox;
 	const user = {
 		email_verified: false
@@ -47,6 +48,7 @@ describe( 'EditGravatar', function() {
 		Gravatar = require( 'components/gravatar' ).default;
 		ImageEditor = require( 'blocks/image-editor' );
 		VerifyEmailDialog = require( 'components/email-verification/email-verification-dialog' );
+		DropZone = require( 'components/drop-zone' ).default;
 	} );
 
 	describe( 'component rendering', () => {
@@ -80,6 +82,32 @@ describe( 'EditGravatar', function() {
 				/>
 			);
 			expect( wrapper.find( ImageEditor ).length ).to.equal( 0 );
+		} );
+
+		describe( 'drag and drop', () => {
+			it( 'does not contain a drop zone for unverified users', () => {
+				const wrapper = shallow(
+					<EditGravatar
+						translate={ noop }
+						user={ {
+							email_verified: false
+						} }
+					/>
+				);
+				expect( wrapper.find( DropZone ) ).to.have.length( 0 );
+			} );
+
+			it( 'contains a drop zone for verified users', () => {
+				const wrapper = shallow(
+					<EditGravatar
+						translate={ noop }
+						user={ {
+							email_verified: true
+						} }
+					/>
+				);
+				expect( wrapper.find( DropZone ) ).to.have.length( 1 );
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
This is part 3 of ~~3~~ 4 related PRs.

1. ✅ EditGravatar general changes: https://github.com/Automattic/wp-calypso/pull/12595
2. Ask users to verify their email first: https://github.com/Automattic/wp-calypso/pull/12596
3. Allow users to drag and drop image: https://github.com/Automattic/wp-calypso/pull/12597
4. Analytics: https://github.com/Automattic/wp-calypso/pull/13134

## Changes in this PR
- Use the DropZone component in EditGravatar

## Testing Instructions
1. Turn on the feature flag using export `ENABLE_FEATURES=me/edit-gravatar && make run`
2. Go to calypso.localhost:3000/me
3. See that you can drag and drop an image to change your Gravatar
<img width="796" alt="drag-and-drop" src="https://cloud.githubusercontent.com/assets/11487924/24421723/28005ef8-13c5-11e7-84b2-a5a7ae0fe6b3.png">

_(You may get an error in the next step - that's because this feature currently requires some extra steps to be tested in the browser. If you'd like to do that, see the extra instructions below)_


4. Log in to wp.com as a user without a verified email address
5. Go to calypso.localhost:3000/me
6. See that you cannot drag and drop an image

### Extra instructions to get whole feature to work
_Easy Mode_
Ask me for info for a test username :)

_Hard Mode_
1. Find your WP.com bearer token for the user you are logged in as. You can do that using this script:
```
$ curl -# -X POST --data-urlencode "grant_type=password" --data-urlencode "client_id=appid" --data-urlencode "client_secret=appsecret" --data-urlencode "username=username" --data-urlencode "password=password" https://public-api.wordpress.com/oauth2/token
```
You can use Calypso's app ID & secret, found [here](https://github.com/Automattic/wp-calypso/blob/a1c610c300e040a2c101bb5af6a66f7cd72b52d6/config/production.json#L108-L109).
    If you have 2FA enabled, you can add this extra parameter to the call: `--data-urlencode     "wpcom_otp=one-time-password"`, or you can create a new application password to use instead.
2. Save the bearer token to localStorage using `localStorage.setItem('bearerToken', 'your_bearer_token');`
3. You can now use the feature in its entirety.