### PR TITLE
Publicize: Add preview components

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -149,7 +149,8 @@
 @import 'components/segmented-control/style';
 @import 'components/select-dropdown/style';
 @import 'components/seo/style';
-@import 'components/share/style';
+@import 'components/share/facebook-share-preview/style';
+@import 'components/share/twitter-share-preview/style';
 @import 'blocks/upgrade-nudge-expanded/style';
 @import 'components/seo/preview-upgrade-nudge/style';
 @import 'components/signup-form/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -56,6 +56,7 @@
 @import 'blocks/reader-related-card-v2/style';
 @import 'blocks/reader-subscription-list-item/style';
 @import 'blocks/reader-visit-link/style';
+@import 'blocks/sharing-preview-pane/style';
 @import 'blocks/taxonomy-manager/style';
 @import 'blocks/term-form-dialog/style';
 @import 'blocks/term-tree-selector/style';
@@ -148,6 +149,7 @@
 @import 'components/segmented-control/style';
 @import 'components/select-dropdown/style';
 @import 'components/seo/style';
+@import 'components/share/style';
 @import 'blocks/upgrade-nudge-expanded/style';
 @import 'components/seo/preview-upgrade-nudge/style';
 @import 'components/signup-form/style';

--- a/client/blocks/sharing-preview-pane/docs/example.jsx
+++ b/client/blocks/sharing-preview-pane/docs/example.jsx
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { get } from 'lodash';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import SharingPreviewPane from 'blocks/sharing-preview-pane';
+import { getCurrentUser } from 'state/current-user/selectors';
+import QueryPosts from 'components/data/query-posts';
+import { getSitePosts } from 'state/posts/selectors';
+import Card from 'components/card';
+import QuerySites from 'components/data/query-sites';
+
+//Mostly copied from Seo Preview Pane
+const SharingPreviewPaneExample = ( { siteId, postId } ) => (
+	<Card>
+		<QuerySites siteId={ siteId } />
+		{ siteId && (
+			<QueryPosts
+				siteId={ siteId }
+				query={ { number: 1, type: 'post' } } />
+		) }
+		<SharingPreviewPane
+			postId={ postId }
+			siteId={ siteId } />
+	</Card>
+);
+
+const ConnectedSharingPreviewPaneExample = connect( ( state ) => {
+	const user = getCurrentUser( state );
+	const siteId = get( user, 'primary_blog' );
+	const posts = getSitePosts( state, siteId );
+	const post = posts && posts[ posts.length - 1 ];
+	const postId = get( post, 'ID' );
+
+	return {
+		siteId,
+		postId
+	};
+} )( SharingPreviewPaneExample );
+
+ConnectedSharingPreviewPaneExample.displayName = 'SharingPreviewPane';
+
+export default ConnectedSharingPreviewPaneExample;

--- a/client/blocks/sharing-preview-pane/docs/example.jsx
+++ b/client/blocks/sharing-preview-pane/docs/example.jsx
@@ -39,7 +39,7 @@ const ConnectedSharingPreviewPaneExample = connect( ( state ) => {
 
 	return {
 		siteId,
-		postId
+		postId,
 	};
 } )( SharingPreviewPaneExample );
 

--- a/client/blocks/sharing-preview-pane/docs/example.jsx
+++ b/client/blocks/sharing-preview-pane/docs/example.jsx
@@ -15,7 +15,6 @@ import { getSitePosts } from 'state/posts/selectors';
 import Card from 'components/card';
 import QuerySites from 'components/data/query-sites';
 
-//Mostly copied from Seo Preview Pane
 const SharingPreviewPaneExample = ( { siteId, postId } ) => (
 	<Card>
 		<QuerySites siteId={ siteId } />
@@ -25,6 +24,7 @@ const SharingPreviewPaneExample = ( { siteId, postId } ) => (
 				query={ { number: 1, type: 'post' } } />
 		) }
 		<SharingPreviewPane
+			message="Do you have a trip coming up?"
 			postId={ postId }
 			siteId={ siteId } />
 	</Card>

--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -52,7 +52,6 @@ class SharingPreviewPane extends PureComponent {
 				return <FacebookSharePreview
 					title={ seoTitle }
 					url={ get( post, 'URL', '' ) }
-					type="article"
 					description={ getExcerptForPost( post ) }
 					image={ getPostImage( post ) }
 					author={ get( post, 'author.name', '' ) }

--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -1,0 +1,117 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getPostImage, getExcerptForPost } from './utils';
+import FacebookSharePreview from 'components/share/facebook-share-preview';
+import TwitterSharePreview from 'components/share/twitter-share-preview';
+import VerticalMenu from 'components/vertical-menu';
+import { SocialItem } from 'components/vertical-menu/items';
+import { getSitePost } from 'state/posts/selectors';
+import { getSeoTitle } from 'state/sites/selectors';
+import { getSite } from 'state/sites/selectors';
+
+//Mostly copied from Seo Preview Pane
+
+class SharingPreviewPane extends PureComponent {
+
+	static propTypes = {
+		siteId: PropTypes.number,
+		postId: PropTypes.number,
+		services: PropTypes.array,
+		// connected properties
+		site: PropTypes.object,
+		post: PropTypes.object,
+		seoTitle: PropTypes.string,
+	};
+
+	static defaultProps = {
+		services: [ 'facebook', 'twitter' ]
+	};
+
+	state = {
+		selectedService: 'facebook'
+	};
+
+	selectPreview = ( selectedService ) => {
+		this.setState( { selectedService } );
+	};
+
+	renderPreview() {
+		const { post, seoTitle } = this.props;
+		const { selectedService } = this.state;
+		switch ( selectedService ) {
+			case 'facebook':
+				return <FacebookSharePreview
+					title={ seoTitle }
+					url={ get( post, 'URL', '' ) }
+					type="article"
+					description={ getExcerptForPost( post ) }
+					image={ getPostImage( post ) }
+					author={ get( post, 'author.name', '' ) }
+				/>;
+			case 'twitter':
+				return <TwitterSharePreview
+					title={ seoTitle }
+					url={ get( post, 'URL', '' ) }
+					type="large_image_summary"
+					description={ getExcerptForPost( post ) }
+					image={ getPostImage( post ) }
+				/>;
+			default:
+				return null;
+		}
+	}
+
+	render() {
+		const { translate, services } = this.props;
+
+		return (
+			<div className="sharing-preview-pane">
+				<div className="sharing-preview-pane__sidebar">
+					<div className="sharing-preview-pane__explanation">
+						<h1 className="sharing-preview-pane__title">
+							{ translate( 'Social Previews' ) }
+						</h1>
+						<p className="sharing-preview-pane__description">
+							{ translate(
+								'This is how your post will appear ' +
+								'when people view or share it on any of ' +
+								'the networks below' ) }
+						</p>
+					</div>
+					<VerticalMenu onClick={ this.selectPreview }>
+						{ services.map( service => <SocialItem { ...{ key: service, service } } /> ) }
+					</VerticalMenu>
+				</div>
+				<div className="sharing-preview-pane__preview-area">
+					<div className="sharing-preview-pane__preview">
+						{ this.renderPreview() }
+					</div>
+				</div>
+			</div>
+		);
+	}
+}
+
+const mapStateToProps = ( state, ownProps ) => {
+	const { siteId, postId } = ownProps;
+	const site = getSite( state, siteId );
+	const post = getSitePost( state, siteId, postId );
+	const seoTitle = getSeoTitle( state, 'posts', { site, post } );
+
+	return {
+		site,
+		post,
+		seoTitle
+	};
+};
+
+export default connect( mapStateToProps )( localize( SharingPreviewPane ) );

--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -9,7 +9,7 @@ import { get, find } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getPostImage, getExcerptForPost } from './utils';
+import { getPostImage } from './utils';
 import FacebookSharePreview from 'components/share/facebook-share-preview';
 import TwitterSharePreview from 'components/share/twitter-share-preview';
 import VerticalMenu from 'components/vertical-menu';
@@ -46,35 +46,38 @@ class SharingPreviewPane extends PureComponent {
 	};
 
 	renderPreview() {
-		const { post, seoTitle, message, connections } = this.props;
+		const { post, message, connections } = this.props;
 		const { selectedService } = this.state;
 		const connection = find( connections, { service: selectedService } );
 		if ( ! connection ) {
 			return null;
 		}
 
-		const externalName = get( connection, 'external_name' );
-		const externalProfileURL = get( connection, 'external_profile_URL' );
-		const externalProfilePicture = get( connection, 'external_profile_picture' );
+		const articleUrl = get( post, 'URL', '' );
+		const imageUrl = getPostImage( post );
+		const {
+			external_name: externalName,
+			external_profile_url: externalProfileURL,
+			external_profile_picture: externalProfilePicture,
+			external_display: externalDisplay,
+		} = connection || {};
+
+		const previewProps = {
+			articleUrl,
+			externalName,
+			externalProfileURL,
+			externalProfilePicture,
+			message,
+			imageUrl,
+		};
 
 		switch ( selectedService ) {
 			case 'facebook':
-				return <FacebookSharePreview
-					articleUrl={ get( post, 'URL', '' ) }
-					externalName={ externalName }
-					externalProfileURL={ externalProfileURL }
-					externalProfilePicture={ externalProfilePicture }
-					message={ message }
-					imageUrl={ getPostImage( post ) }
-				/>;
+				return <FacebookSharePreview { ...previewProps } />;
 			case 'twitter':
 				return <TwitterSharePreview
-					title={ seoTitle }
-					url={ get( post, 'URL', '' ) }
-					type="large_image_summary"
-					description={ getExcerptForPost( post ) }
-					image={ getPostImage( post ) }
-				/>;
+					{ ...previewProps }
+					externalDisplay={ externalDisplay } />;
 			default:
 				return null;
 		}

--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -60,7 +60,7 @@ class SharingPreviewPane extends PureComponent {
 			external_profile_url: externalProfileURL,
 			external_profile_picture: externalProfilePicture,
 			external_display: externalDisplay,
-		} = connection || {};
+		} = connection;
 
 		const previewProps = {
 			articleUrl,
@@ -126,7 +126,7 @@ const mapStateToProps = ( state, ownProps ) => {
 		site,
 		post,
 		seoTitle,
-		connections
+		connections,
 	};
 };
 

--- a/client/blocks/sharing-preview-pane/style.scss
+++ b/client/blocks/sharing-preview-pane/style.scss
@@ -10,10 +10,10 @@
 }
 
 .sharing-preview-pane__sidebar {
-	display: flex;
-	flex-direction: column;
-
 	background-color: $white;
+	display: flex;
+	flex: 0 0 auto;
+	flex-direction: column;
 
 	.vertical-menu {
 		flex-direction: row;
@@ -57,9 +57,8 @@
 	}
 
 	@include breakpoint( ">660px" ) {
-		width: 250px;
-		min-width: 250px;
 		border-right: 1px solid lighten( $gray, 20% );
+		flex: 0 0 250px;
 	}
 }
 
@@ -86,16 +85,9 @@
 }
 
 .sharing-preview-pane__preview-area {
-	margin: 10px auto;
-}
-
-.sharing-preview-pane__preview {
-	min-width: 400px;
-	height: auto;
-	margin: 0 10px;
-
-	background-color: $white;
-	border: 1px solid lighten( $gray, 25% );
+	background-color: #f2f6f8;
+	flex: 1 1 auto;
+	padding: 10px;
 }
 
 .sharing-preview-pane__message {

--- a/client/blocks/sharing-preview-pane/style.scss
+++ b/client/blocks/sharing-preview-pane/style.scss
@@ -1,0 +1,104 @@
+//Mostly copied from Seo Preview Pane
+.sharing-preview-pane {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+
+	@include breakpoint( ">660px" ) {
+		flex-direction: row;
+	}
+}
+
+.sharing-preview-pane__sidebar {
+	display: flex;
+	flex-direction: column;
+
+	background-color: $white;
+
+	.vertical-menu {
+		flex-direction: row;
+		justify-content: center;
+		max-width: none;
+
+		.vertical-menu__social-item {
+			border: 0;
+			padding: 8px;
+		}
+
+		.vertical-menu__items.is-selected {
+			border-left: 0;
+			border-bottom: 3px solid #0087be;
+		}
+
+		.vertical-menu__items__social-label {
+			display: none;
+		}
+
+		@include breakpoint( ">660px" ) {
+			flex-direction: column;
+			justify-content: flex-start;
+			border-bottom: 1px solid #c8d7e1;
+
+
+			.vertical-menu__social-item {
+				border-top: 1px solid #c8d7e1;
+				padding: 0;
+			}
+
+			.vertical-menu__items.is-selected {
+				border-left: 3px solid #0087be;
+				border-bottom: 0;
+			}
+
+			.vertical-menu__items__social-label {
+				display: block;
+			}
+		}
+	}
+
+	@include breakpoint( ">660px" ) {
+		width: 250px;
+		min-width: 250px;
+		border-right: 1px solid lighten( $gray, 20% );
+	}
+}
+
+.sharing-preview-pane__explanation {
+	display: flex;
+	flex-direction: column;
+	margin: 20px 20px 0;
+
+	font-family: $sans;
+
+	.sharing-preview-pane__title {
+		font-size: 16px;
+	}
+
+	.sharing-preview-pane__description {
+		font-size: 12px;
+		color: $gray;
+	}
+
+	@include breakpoint( ">660px" ) {
+		margin: 40px 0 40px 20px;
+		max-width: 200px;
+	}
+}
+
+.sharing-preview-pane__preview-area {
+	margin: 10px auto;
+}
+
+.sharing-preview-pane__preview {
+	min-width: 400px;
+	height: auto;
+	margin: 0 10px;
+
+	background-color: $white;
+	border: 1px solid lighten( $gray, 25% );
+}
+
+.sharing-preview-pane__message {
+	padding: 10px;
+	text-align: center;
+}

--- a/client/blocks/sharing-preview-pane/utils.js
+++ b/client/blocks/sharing-preview-pane/utils.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import {
+	get,
+	find,
+	identity,
+	trim
+} from 'lodash';
+import striptags from 'striptags';
+
+/**
+ * Internal dependencies
+ */
+import { formatExcerpt } from 'lib/post-normalizer/rule-create-better-excerpt';
+import PostMetadata from 'lib/post-metadata';
+import { parseHtml } from 'lib/formatting';
+
+const PREVIEW_IMAGE_WIDTH = 512;
+
+//Mostly copied from Seo Preview Pane
+
+export const getPostImage = ( post ) => {
+	if ( ! post ) {
+		return null;
+	}
+
+	// Use the featured image if one was set
+	if ( post.featured_image ) {
+		return post.featured_image;
+	}
+
+	// Otherwise we'll look for a large enough image in the post
+	const content = post.content;
+	if ( ! content ) {
+		return null;
+	}
+
+	const imgElements = parseHtml( content ).querySelectorAll( 'img' );
+
+	const imageUrl = get(
+		find( imgElements, ( { width } ) => width >= PREVIEW_IMAGE_WIDTH ),
+		'src',
+		null
+	);
+
+	return imageUrl
+		? `${ imageUrl }?s=${ PREVIEW_IMAGE_WIDTH }`
+		: null;
+};
+
+export const getExcerptForPost = ( post ) => {
+	if ( ! post ) {
+		return null;
+	}
+
+	return trim( striptags( formatExcerpt( find( [
+		PostMetadata.metaDescription( post ),
+		post.excerpt,
+		post.content
+	], identity ) ) ) );
+};

--- a/client/blocks/sharing-preview-pane/utils.js
+++ b/client/blocks/sharing-preview-pane/utils.js
@@ -18,8 +18,6 @@ import { parseHtml } from 'lib/formatting';
 
 const PREVIEW_IMAGE_WIDTH = 512;
 
-//Mostly copied from Seo Preview Pane
-
 export const getPostImage = ( post ) => {
 	if ( ! post ) {
 		return null;

--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -1,0 +1,78 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes, PureComponent } from 'react';
+import compact from 'lodash/compact';
+
+import {
+	firstValid,
+	hardTruncation,
+	shortEnough
+} from '../helpers';
+
+//Mostly copied from Seo Preview
+
+const TITLE_LENGTH = 80;
+const DESCRIPTION_LENGTH = 270;
+
+const baseDomain = url =>
+	url
+		.replace( /^[^/]+[/]*/, '' ) // strip leading protocol
+		.replace( /\/.*$/, '' ); // strip everything after the domain
+
+const facebookTitle = firstValid(
+	shortEnough( TITLE_LENGTH ),
+	hardTruncation( TITLE_LENGTH )
+);
+
+const facebookDescription = firstValid(
+	shortEnough( DESCRIPTION_LENGTH ),
+	hardTruncation( DESCRIPTION_LENGTH )
+);
+
+export class FacebookSharePreview extends PureComponent {
+	render() {
+		const {
+			url,
+			type,
+			title,
+			description,
+			image,
+			author
+		} = this.props;
+
+		return (
+			<div className={ `facebook-share-preview facebook-share-preview__${ type }` }>
+				<div className="facebook-share-preview__content">
+					{ image &&
+					<div className="facebook-share-preview__image">
+						<img src={ image } />
+					</div>
+					}
+					<div className="facebook-share-preview__body">
+						<div className="facebook-share-preview__title">
+							{ facebookTitle( title || '' ) }
+						</div>
+						<div className="facebook-share-preview__description">
+							{ facebookDescription( description || '' ) }
+						</div>
+						<div className="facebook-share-preview__url">
+							{ compact( [ baseDomain( url ), author ] ).join( ' | ' ) }
+						</div>
+					</div>
+				</div>
+			</div>
+		);
+	}
+}
+
+FacebookSharePreview.propTypes = {
+	url: PropTypes.string,
+	type: PropTypes.string,
+	title: PropTypes.string,
+	description: PropTypes.string,
+	image: PropTypes.string,
+	author: PropTypes.string
+};
+
+export default FacebookSharePreview;

--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -25,7 +25,7 @@ export class FacebookSharePreview extends PureComponent {
 						</div>
 						<div className="facebook-share-preview__profile-line-part">
 							<div className="facebook-share-preview__profile-line">
-								<a href={ externalProfileUrl }>
+								<a className="facebook-share-preview__profile-name" href={ externalProfileUrl }>
 									{ externalName }
 								</a>
 								published an article on
@@ -33,8 +33,10 @@ export class FacebookSharePreview extends PureComponent {
 									WordPress.
 								</a>
 							</div>
-							<div className="facebook-share-preview__wp-line">
-								WordPress
+							<div className="facebook-share-preview__meta-line">
+								<a href="https://wordpress.com">
+									WordPress
+								</a>
 							</div>
 						</div>
 					</div>
@@ -42,8 +44,11 @@ export class FacebookSharePreview extends PureComponent {
 						<div className="facebook-share-preview__message">
 							{ message }
 						</div>
-						<div className="facebook-share-preview__article-url">
-							{ articleUrl }
+						<div className="facebook-share-preview__article-url-line">
+							<a className="facebook-share-preview__article-url"
+								href={ articleUrl }>
+								{ articleUrl }
+							</a>
 						</div>
 						{ imageUrl &&
 							<div className="facebook-share-preview__image-wrapper">

--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -1,78 +1,63 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, PureComponent } from 'react';
-import compact from 'lodash/compact';
-
-import {
-	firstValid,
-	hardTruncation,
-	shortEnough
-} from '../helpers';
-
-//Mostly copied from Seo Preview
-
-const TITLE_LENGTH = 80;
-const DESCRIPTION_LENGTH = 270;
-
-const baseDomain = url =>
-	url
-		.replace( /^[^/]+[/]*/, '' ) // strip leading protocol
-		.replace( /\/.*$/, '' ); // strip everything after the domain
-
-const facebookTitle = firstValid(
-	shortEnough( TITLE_LENGTH ),
-	hardTruncation( TITLE_LENGTH )
-);
-
-const facebookDescription = firstValid(
-	shortEnough( DESCRIPTION_LENGTH ),
-	hardTruncation( DESCRIPTION_LENGTH )
-);
+import React, { PureComponent } from 'react';
 
 export class FacebookSharePreview extends PureComponent {
 	render() {
-		const {
-			url,
-			type,
-			title,
-			description,
-			image,
-			author
-		} = this.props;
+		// TODO: use real data
+		const externalProfilePicture = 'https://3.bp.blogspot.com/-W__wiaHUjwI/Vt3Grd8df0I/AAAAAAAAA78/7xqUNj8ujtY/s1600/image02.png';
+		const externalProfileUrl = 'https://example.com';
+		const externalName = 'Style and Gear';
+		const message = 'Do you have a trip coming up? Check out this winter travel gear roundup!';
+		const articleUrl = 'https://styleandgear.com/2016/01/03/how-to-dress-like-a-proper-we-need-some-long-url';
+		const imageUrl = 'https://www.w3schools.com/css/trolltunga.jpg';
 
 		return (
-			<div className={ `facebook-share-preview facebook-share-preview__${ type }` }>
+			<div className="facebook-share-preview">
 				<div className="facebook-share-preview__content">
-					{ image &&
-					<div className="facebook-share-preview__image">
-						<img src={ image } />
+					<div className="facebook-share-preview__header">
+						<div className="facebook-share-preview__profile-picture-part">
+							<img
+								className="facebook-share-preview__profile-picture"
+								src={ externalProfilePicture }
+							/>
+						</div>
+						<div className="facebook-share-preview__profile-line-part">
+							<div className="facebook-share-preview__profile-line">
+								<a href={ externalProfileUrl }>
+									{ externalName }
+								</a>
+								published an article on
+								<a href="https://wordpress.com">
+									WordPress.
+								</a>
+							</div>
+							<div className="facebook-share-preview__wp-line">
+								WordPress
+							</div>
+						</div>
 					</div>
-					}
 					<div className="facebook-share-preview__body">
-						<div className="facebook-share-preview__title">
-							{ facebookTitle( title || '' ) }
+						<div className="facebook-share-preview__message">
+							{ message }
 						</div>
-						<div className="facebook-share-preview__description">
-							{ facebookDescription( description || '' ) }
+						<div className="facebook-share-preview__article-url">
+							{ articleUrl }
 						</div>
-						<div className="facebook-share-preview__url">
-							{ compact( [ baseDomain( url ), author ] ).join( ' | ' ) }
-						</div>
+						{ imageUrl &&
+							<div className="facebook-share-preview__image-wrapper">
+								<img
+									className="facebook-share-preview__image"
+									src={ imageUrl }
+								/>
+							</div>
+						}
 					</div>
 				</div>
 			</div>
 		);
 	}
 }
-
-FacebookSharePreview.propTypes = {
-	url: PropTypes.string,
-	type: PropTypes.string,
-	title: PropTypes.string,
-	description: PropTypes.string,
-	image: PropTypes.string,
-	author: PropTypes.string
-};
 
 export default FacebookSharePreview;

--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -1,18 +1,30 @@
 /**
  * External dependencies
  */
-import React, { PureComponent } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
 
 export class FacebookSharePreview extends PureComponent {
-	render() {
-		// TODO: use real data
-		const externalProfilePicture = 'https://3.bp.blogspot.com/-W__wiaHUjwI/Vt3Grd8df0I/AAAAAAAAA78/7xqUNj8ujtY/s1600/image02.png';
-		const externalProfileUrl = 'https://example.com';
-		const externalName = 'Style and Gear';
-		const message = 'Do you have a trip coming up? Check out this winter travel gear roundup!';
-		const articleUrl = 'https://styleandgear.com/2016/01/03/how-to-dress-like-a-proper-we-need-some-long-url';
-		const imageUrl = 'https://www.w3schools.com/css/trolltunga.jpg';
 
+	static PropTypes = {
+		articleUrl: PropTypes.string,
+		externalProfilePicture: PropTypes.string,
+		externalProfileUrl: PropTypes.string,
+		externalName: PropTypes.string,
+		imageUrl: PropTypes.string,
+		message: PropTypes.string,
+	};
+
+	render() {
+		const {
+			articleUrl,
+			externalProfilePicture,
+			externalProfileUrl,
+			externalName,
+			imageUrl,
+			message,
+			translate
+		} = this.props;
 		return (
 			<div className="facebook-share-preview">
 				<div className="facebook-share-preview__content">
@@ -28,14 +40,19 @@ export class FacebookSharePreview extends PureComponent {
 								<a className="facebook-share-preview__profile-name" href={ externalProfileUrl }>
 									{ externalName }
 								</a>
-								published an article on
-								<a href="https://wordpress.com">
-									WordPress.
-								</a>
+								<span>
+									{
+										translate( 'published an article on {{a}}WordPress{{/a}}', {
+											components: {
+												a: <a href="#" />
+											}
+										} )
+									}
+								</span>
 							</div>
 							<div className="facebook-share-preview__meta-line">
 								<a href="https://wordpress.com">
-									WordPress
+									{ translate( 'WordPress' ) }
 								</a>
 							</div>
 						</div>
@@ -65,4 +82,4 @@ export class FacebookSharePreview extends PureComponent {
 	}
 }
 
-export default FacebookSharePreview;
+export default localize( FacebookSharePreview );

--- a/client/components/share/facebook-share-preview/style.scss
+++ b/client/components/share/facebook-share-preview/style.scss
@@ -1,0 +1,73 @@
+.facebook-share-preview {
+	background-color: $white;
+	border: 1px solid;
+	border-color: #e5e6e9 #dfe0e4 #d0d1d5;
+	border-radius: 3px;
+	color: #1d2129;
+	margin: 0 auto;
+	max-width: 486px;
+	padding: 12px;
+	-webkit-overflow-scrolling: touch;
+}
+
+.facebook-share-preview a {
+	color: #365899;
+}
+
+.facebook-share-preview__header {
+	display: flex;
+	margin-bottom: 6px;
+}
+
+.facebook-share-preview__profile-picture-part {
+	flex: 0 0 40px;
+	margin-right: 8px;
+	width: 40px;
+}
+
+.facebook-share-preview__profile-picture,
+.facebook-share-preview__image {
+	display: block;
+}
+
+.facebook-share-preview__profile-line,
+.facebook-share-preview__body {
+	font-size: 14px;
+	line-height: 1.38;
+}
+
+.facebook-share-preview__profile-line {
+	color: #90949c;
+	margin-bottom: 2px;
+}
+
+.facebook-share-preview__profile-name {
+	font-weight: bold;
+}
+
+.facebook-share-preview__meta-line {
+	color: #90949c;
+	font-size: 12px;
+	line-height: 1.34;
+}
+
+.facebook-share-preview .facebook-share-preview__meta-line a {
+	color: #90949c;
+}
+
+.facebook-share-preview__message p {
+	margin-bottom: 6px;
+}
+
+.facebook-share-preview__message p:last-child {
+	margin-bottom: 0;
+}
+
+.facebook-share-preview__article-url-line {
+	margin-top: 6px;
+	word-break: break-word;
+}
+
+.facebook-share-preview__image-wrapper {
+	margin-top: 10px;
+}

--- a/client/components/share/facebook-share-preview/style.scss
+++ b/client/components/share/facebook-share-preview/style.scss
@@ -43,6 +43,7 @@
 
 .facebook-share-preview__profile-name {
 	font-weight: bold;
+	margin-right: 5px;
 }
 
 .facebook-share-preview__meta-line {

--- a/client/components/share/helpers.js
+++ b/client/components/share/helpers.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { find } from 'lodash';
+
+//Mostly copied from Seo Preview
+
+export const shortEnough = limit => title => title.length <= limit ? title : false;
+
+export const truncatedAtSpace = ( lower, upper ) => fullTitle => {
+	const title = fullTitle.slice( 0, upper );
+	const lastSpace = title.lastIndexOf( ' ' );
+
+	return ( lastSpace > lower && lastSpace < upper )
+		? title.slice( 0, lastSpace ).concat( '…' )
+		: false;
+};
+
+export const hardTruncation = limit => title => title.slice( 0, limit ).concat( '…' );
+
+export const firstValid = ( ...predicates ) => a =>
+	find( predicates, ( p => false !== p( a ) ) )( a );

--- a/client/components/share/style.scss
+++ b/client/components/share/style.scss
@@ -1,0 +1,210 @@
+//Mostly copied from Seo Preview
+.facebook-share-preview {
+	border: 1px solid;
+	border-color: #e9ebee #e9ebee #d1d1d1;
+	display: flex;
+	overflow-x: auto;
+	max-width: 527px;
+	margin: 0 auto;
+	-webkit-overflow-scrolling: touch;
+}
+
+.facebook-share-preview__content {
+	display: flex;
+}
+
+.facebook-share-preview__body {
+	display: flex;
+	flex-direction: column;
+	margin: 10px 12px;
+}
+
+.facebook-share-preview__title {
+	color: #1d2129;
+	font-family: Georgia, serif;
+	font-size: 18px;
+	font-weight: 500;
+	line-height: 22px;
+	max-height: 100px;
+	transition: color 0.1s ease-in-out;
+}
+
+.facebook-share-preview__description {
+	color: #4b4f56;
+	flex-grow: 1;
+	font-family: helvetica, arial, sans-serif;
+	font-size: 12px;
+	line-height: 16px;
+	overflow-y: hidden;
+}
+
+.facebook-share-preview__url {
+	color: #90949c;
+	font-family: helvetica, arial, sans-serif;
+	font-size: 11px;
+	line-height: 11px;
+	text-transform: uppercase;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.facebook-share-preview__article {
+	.facebook-share-preview__content {
+		flex-direction: column;
+		min-width: 100%;
+	}
+
+	.facebook-share-preview__image {
+		max-height: 250px;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		overflow-y: hidden;
+
+		& img {
+			height: auto;
+			width: 100%;
+			max-width: 527px;
+		}
+	}
+
+	.facebook-share-preview__body {
+		height: auto;
+		max-height: 100px;
+	}
+
+	.facebook-share-preview__title {
+		margin-bottom: 5px;
+	}
+
+	.facebook-share-preview__url {
+		margin-top: 9px;
+	}
+}
+
+.facebook-share-preview__website {
+	max-height: 158px;
+
+	.facebook-share-preview__image {
+		flex-shrink: 0;
+		height: 100%;
+		width: 158px;
+
+		& img {
+			display: block;
+			font-size: 14px;
+			height: auto;
+			width: 100%;
+		}
+	}
+
+	.facebook-share-preview__body {
+		width: 100%;
+	}
+
+	.facebook-share-preview__title {
+		margin-bottom: 5px;
+		max-height: 110px;
+	}
+
+	.facebook-share-preview__url {
+		margin-top: auto;
+		margin-bottom: 5px;
+	}
+}
+
+
+.twitter-share-preview {
+	width: inherit;
+	overflow-x: auto;
+	-webkit-overflow-scrolling: touch;
+	margin: 20px;
+}
+
+.twitter-share-preview__summary {
+	width: 506px;
+	height: 125px;
+	margin: 0 auto;
+	overflow: hidden;
+	border: 1px solid #E1E8ED;
+	border-radius: 0.42857em;
+}
+
+.twitter-share-preview__large_image_summary {
+	width: 506px;
+	height: auto;
+	margin: 0 auto;
+	overflow: hidden;
+	border: 1px solid #E1E8ED;
+	border-radius: 0.42857em;
+}
+
+.twitter-share-preview__image {
+	background-size: cover;
+	background-position: center;
+}
+
+.twitter-share-preview__summary
+.twitter-share-preview__image {
+	float: left;
+	width: 125px;
+	height: 125px;
+}
+
+.twitter-share-preview__large_image_summary
+.twitter-share-preview__image {
+	width: 506px;
+	height: 254px;
+	border-bottom: 1px solid #E1E8ED;
+}
+
+.twitter-share-preview__body {
+	padding: .75em;
+	text-decoration: none;
+	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-size: 14px;
+	color: black;
+	text-align: left;
+	line-height: 1.3em;
+	overflow: hidden;
+}
+
+.twitter-share-preview__summary
+.twitter-share-preview__body {
+	margin-left: 125px;
+	border-left: 1px solid #E1E8ED;
+	height: 100%;
+}
+
+.twitter-share-preview__large_image_summary
+.twitter-share-preview__body {
+	padding-left: 1em;
+	padding-right: 1em;
+}
+
+.twitter-share-preview__title {
+	max-height: 1.3em;
+	white-space: nowrap;
+	font-weight: bold;
+	font-size: 1em;
+	margin: 0 0 .15em;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.twitter-share-preview__description {
+	margin-top: 0.32333em;
+	max-height: 3.9em;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.twitter-share-preview__url {
+	text-transform: lowercase;
+	color: #8899A6;
+	max-height: 1.3em;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	margin-top: 0.32333em;
+}

--- a/client/components/share/twitter-share-preview/index.jsx
+++ b/client/components/share/twitter-share-preview/index.jsx
@@ -41,8 +41,11 @@ export class TwitterSharePreview extends PureComponent {
 						<div className="twitter-share-preview__message">
 							{ message }
 						</div>
-						<div className="twitter-share-preview__article-url">
-							{ articleUrl }
+						<div className="twitter-share-preview__article-url-line">
+							<a className="twitter-share-preview__article-url"
+								href={ articleUrl }>
+								{ articleUrl }
+							</a>
 						</div>
 						{ imageUrl &&
 							<div className="twitter-share-preview__image-wrapper">

--- a/client/components/share/twitter-share-preview/index.jsx
+++ b/client/components/share/twitter-share-preview/index.jsx
@@ -1,58 +1,62 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, PureComponent } from 'react';
-
-const baseDomain = url =>
-	url
-		.replace( /^[^/]+[/]*/, '' ) // strip leading protocol
-		.replace( /\/.*$/, '' ); // strip everything after the domain
-
-//Mostly copied from Seo Preview
+import React, { PureComponent } from 'react';
 
 export class TwitterSharePreview extends PureComponent {
 	render() {
-		const {
-			url,
-			title,
-			type,
-			description,
-			image
-		} = this.props;
-
-		const previewImageStyle = {
-			backgroundImage: 'url(' + image + ')'
-		};
+		// TODO: use real data
+		const externalProfilePicture = 'https://3.bp.blogspot.com/-W__wiaHUjwI/Vt3Grd8df0I/AAAAAAAAA78/7xqUNj8ujtY/s1600/image02.png';
+		const externalProfileUrl = 'https://example.com';
+		const externalDisplay = 'Style and Gear';
+		const externalName = 'styleandgear';
+		const message = 'Do you have a trip coming up? Check out this winter travel gear roundup!';
+		const articleUrl = 'https://styleandgear.com/2016/01/03/how-to-dress-like-a-proper-we-need-some-long-url';
+		const imageUrl = 'https://www.w3schools.com/css/trolltunga.jpg';
 
 		return (
 			<div className="twitter-share-preview">
-				<div className={ `twitter-share-preview__${ type }` }>
-					{ image &&
-					<div className="twitter-share-preview__image" style={ previewImageStyle } />
-					}
-					<div className="twitter-share-preview__body">
-						<div className="twitter-share-preview__title">
-							{ title }
+				<div className="twitter-share-preview__content">
+					<div className="twitter-share-preview__profile-picture-part">
+						<img
+							className="twitter-share-preview__profile-picture"
+							src={ externalProfilePicture }
+						/>
+					</div>
+					<div className="twitter-share-preview__content-part">
+						<div className="twitter-share-preview__profile-line">
+							<a
+								className="twitter-share-preview__profile-name"
+								href={ externalProfileUrl }
+							>
+								{ externalDisplay }
+							</a>
+							<a
+								className="twitter-share-preview__profile-handle"
+								href={ externalProfileUrl }
+							>
+								@{ externalName }
+							</a>
 						</div>
-						<div className="twitter-share-preview__description">
-							{ description }
+						<div className="twitter-share-preview__message">
+							{ message }
 						</div>
-						<div className="twitter-share-preview__url">
-							{ baseDomain( url ) }
+						<div className="twitter-share-preview__article-url">
+							{ articleUrl }
 						</div>
+						{ imageUrl &&
+							<div className="twitter-share-preview__image-wrapper">
+								<img
+									className="twitter-share-preview__image"
+									src={ imageUrl }
+								/>
+							</div>
+						}
 					</div>
 				</div>
 			</div>
 		);
 	}
 }
-
-TwitterSharePreview.propTypes = {
-	url: PropTypes.string,
-	title: PropTypes.string,
-	type: PropTypes.string,
-	description: PropTypes.string,
-	image: PropTypes.string
-};
 
 export default TwitterSharePreview;

--- a/client/components/share/twitter-share-preview/index.jsx
+++ b/client/components/share/twitter-share-preview/index.jsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes, PureComponent } from 'react';
+
+const baseDomain = url =>
+	url
+		.replace( /^[^/]+[/]*/, '' ) // strip leading protocol
+		.replace( /\/.*$/, '' ); // strip everything after the domain
+
+//Mostly copied from Seo Preview
+
+export class TwitterSharePreview extends PureComponent {
+	render() {
+		const {
+			url,
+			title,
+			type,
+			description,
+			image
+		} = this.props;
+
+		const previewImageStyle = {
+			backgroundImage: 'url(' + image + ')'
+		};
+
+		return (
+			<div className="twitter-share-preview">
+				<div className={ `twitter-share-preview__${ type }` }>
+					{ image &&
+					<div className="twitter-share-preview__image" style={ previewImageStyle } />
+					}
+					<div className="twitter-share-preview__body">
+						<div className="twitter-share-preview__title">
+							{ title }
+						</div>
+						<div className="twitter-share-preview__description">
+							{ description }
+						</div>
+						<div className="twitter-share-preview__url">
+							{ baseDomain( url ) }
+						</div>
+					</div>
+				</div>
+			</div>
+		);
+	}
+}
+
+TwitterSharePreview.propTypes = {
+	url: PropTypes.string,
+	title: PropTypes.string,
+	type: PropTypes.string,
+	description: PropTypes.string,
+	image: PropTypes.string
+};
+
+export default TwitterSharePreview;

--- a/client/components/share/twitter-share-preview/index.jsx
+++ b/client/components/share/twitter-share-preview/index.jsx
@@ -5,14 +5,15 @@ import React, { PureComponent } from 'react';
 
 export class TwitterSharePreview extends PureComponent {
 	render() {
-		// TODO: use real data
-		const externalProfilePicture = 'https://3.bp.blogspot.com/-W__wiaHUjwI/Vt3Grd8df0I/AAAAAAAAA78/7xqUNj8ujtY/s1600/image02.png';
-		const externalProfileUrl = 'https://example.com';
-		const externalDisplay = 'Style and Gear';
-		const externalName = 'styleandgear';
-		const message = 'Do you have a trip coming up? Check out this winter travel gear roundup!';
-		const articleUrl = 'https://styleandgear.com/2016/01/03/how-to-dress-like-a-proper-we-need-some-long-url';
-		const imageUrl = 'https://www.w3schools.com/css/trolltunga.jpg';
+		const {
+			articleUrl,
+			externalDisplay,
+			externalName,
+			externalProfileURL,
+			externalProfilePicture,
+			message,
+			imageUrl,
+		} = this.props;
 
 		return (
 			<div className="twitter-share-preview">
@@ -27,15 +28,15 @@ export class TwitterSharePreview extends PureComponent {
 						<div className="twitter-share-preview__profile-line">
 							<a
 								className="twitter-share-preview__profile-name"
-								href={ externalProfileUrl }
+								href={ externalProfileURL }
 							>
-								{ externalDisplay }
+								{ externalName }
 							</a>
 							<a
 								className="twitter-share-preview__profile-handle"
-								href={ externalProfileUrl }
+								href={ externalProfileURL }
 							>
-								@{ externalName }
+								{ externalDisplay }
 							</a>
 						</div>
 						<div className="twitter-share-preview__message">

--- a/client/components/share/twitter-share-preview/style.scss
+++ b/client/components/share/twitter-share-preview/style.scss
@@ -1,0 +1,67 @@
+.twitter-share-preview {
+	background-color: $white;
+	border: 1px solid #e6ecf0;
+	color: #14171a;
+	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-size: 14px;
+	line-height: 1.375;
+	margin: 0 auto;
+	max-width: 565px;
+	padding: 12px;
+}
+
+.twitter-share-preview__content {
+	display: flex;
+}
+
+.twitter-share-preview__profile-picture-part {
+	flex: 0 0 48px;
+	margin: 3px 10px 0 0;
+	width: 48px;
+}
+
+.twitter-share-preview__profile-picture {
+	border-radius: 5px;
+	display: block;
+}
+
+.twitter-share-preview__profile-name {
+	color: #14171a;
+	font-weight: bold;
+	margin-right: 5px;
+
+	&:hover {
+		color: #0084B4;
+		text-decoration: underline;
+	}
+}
+
+.twitter-share-preview__profile-handle {
+	color: #657786;
+	font-size: 13px;
+}
+
+.twitter-share-preview__message,
+.twitter-share-preview__article-url {
+	font-size: 16px;
+	line-height: 22px;
+}
+
+.twitter-share-preview__message a,
+.twitter-share-preview__article-url {
+	color: #0084B4;
+}
+
+.twitter-share-preview__article-url-line {
+	word-break: break-word;
+}
+
+.twitter-share-preview__image-wrapper {
+	margin-top: 10px;
+}
+
+.twitter-share-preview__image {
+	border: 1px solid rgba(0,0,0,0.1);
+	border-radius: 5px;
+	display: block;
+}

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -61,6 +61,7 @@ import PostLikes from 'blocks/post-likes/docs/example';
 import ReaderFeaturedVideo from 'blocks/reader-featured-video/docs/example';
 import NpsSurvey from 'blocks/nps-survey/docs/example';
 import ReaderExportButton from 'blocks/reader-export-button/docs/example';
+import SharingPreviewPane from 'blocks/sharing-preview-pane/docs/example';
 
 export default React.createClass( {
 
@@ -139,10 +140,9 @@ export default React.createClass( {
 					<DailyPostButton />
 					<PostLikes />
 					<ReaderFeaturedVideo />
-					{ isEnabled( 'nps-survey/devdocs' ) &&
-						<NpsSurvey />
-					}
+					{ isEnabled( 'nps-survey/devdocs' ) && <NpsSurvey /> }
 					<ReaderExportButton />
+					<SharingPreviewPane />
 				</Collection>
 			</Main>
 		);


### PR DESCRIPTION
This PR adds publicize preview components for Facebook and Twitter. Example data is pulled from the user's primary site connections and first post.

![screen shot 2017-03-28 at 11 51 02 am](https://cloud.githubusercontent.com/assets/744755/24422406/53d380e4-13ae-11e7-8dda-85fb8a846e74.png)

![screen shot 2017-03-28 at 11 51 14 am](https://cloud.githubusercontent.com/assets/744755/24422410/57e9b22a-13ae-11e7-915b-78db6ad8b237.png)

**testing**
- view examples at http://calypso.localhost:3000/devdocs/blocks/sharing-preview-pane


