### PR TITLE
Editor: fix linking hotlinked images

### DIFF
--- a/client/components/tinymce/plugins/wpcom-view/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-view/plugin.js
@@ -321,8 +321,8 @@ function wpview( editor ) {
 		if ( pastedStr ) {
 			pastedStr = tinymce.trim( pastedStr.replace( /<[^>]+>/g, '' ) );
 
-			let imageMatch;
-			if ( imageMatch = /(https?:\/\/[^<]*)(\.jpg|\.jpeg|\.gif|\.png)\??.*$/i.exec( pastedStr ) ) {
+			const imageMatch = /(https?:\/\/[^<]*)(\.jpg|\.jpeg|\.gif|\.png)\??.*$/i.exec( pastedStr );
+			if ( imageMatch ) {
 				// If the link looks like an image, replace the pasted content with an <img> tag.
 				// As a side effect, this won't request an embed code to the REST API anymore.
 				event.content = `<img src="${ imageMatch[ 1 ] }${ imageMatch[ 2 ] }" style="max-width:100%;" />`;

--- a/client/components/tinymce/plugins/wpcom-view/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-view/plugin.js
@@ -321,7 +321,13 @@ function wpview( editor ) {
 		if ( pastedStr ) {
 			pastedStr = tinymce.trim( pastedStr.replace( /<[^>]+>/g, '' ) );
 
-			if ( /^https?:\/\/\S+$/i.test( pastedStr ) ) {
+			let imageMatch;
+			if ( imageMatch = /(https?:\/\/[^<]*)(\.jpg|\.jpeg|\.gif|\.png)\??.*$/i.exec( pastedStr ) ) {
+				// If the link looks like an image, replace the pasted content with an <img> tag.
+				// As a side effect, this won't request an embed code to the REST API anymore.
+				event.content = `<img src="${ imageMatch[ 1 ] }${ imageMatch[ 2 ] }" style="max-width:100%;" />`;
+			} else if ( /^https?:\/\/\S+$/i.test( pastedStr ) ) {
+				// Otherwise replace the content with the cleaned URL.
 				event.content = pastedStr;
 			}
 		}


### PR DESCRIPTION
Fixes: #7148 

## Previously

Pasting an image URL into the visual editor fired a REST request to obtain an embed code.
Then, while the visual editor displayed the image in an embedded iframe, internally it was handled as a simple URL.
Because of this, if we tried to add a link to an hotlinked (embedded) image, the embedded image was removed and the link was added to the image URL instead.

## Now

Add a regex check for images when pasting URLs into the visual editor.

If the URL is an image, instead of requesting the oEmbed code via REST API, simply replace the pasted content with an `<img>` tag.

![mar-28-2017 20-10-17](https://cloud.githubusercontent.com/assets/2070010/24422865/e5fdd156-13f2-11e7-926c-f7e0337908ff.gif)

## Caveat

Before, an embedded image was displayed as a simple URL in the HTML editor.
Now, it's an `<img>` tag - which by the way is the same as if inserting an image URL via the HTML toolbar.

## Question

I've added a `style="max-width: 100%"` because that's what the oEmbed code does.
I'm not sure if it's needed here (the Calypso editor is perfectly capable of resizing huge images by itself) or we should simply leave it for the theme developers.