### PR TITLE
Framework: Convert renderWithReduxStore import to CommonJS

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -50,11 +50,11 @@ var config = require( 'config' ),
 	syncHandler = require( 'lib/wp/sync-handler' ),
 	bindWpLocaleState = require( 'lib/wp/localization' ).bindState,
 	supportUser = require( 'lib/user/support-user-interop' ),
-	createReduxStoreFromPersistedInitialState = require( 'state/initial-state' ).default;
+	createReduxStoreFromPersistedInitialState = require( 'state/initial-state' ).default,
+	renderWithReduxStore = require( 'lib/react-helpers' ).renderWithReduxStore;
 
 import { getSelectedSiteId, getSectionName } from 'state/ui/selectors';
 import { setNextLayoutFocus, activateNextLayoutFocus } from 'state/ui/layout-focus/actions';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 function init() {
 	var i18nLocaleStringsObject = null;


### PR DESCRIPTION
This pull request seeks to resolve an issue where Safari Private Mode does not load because there are dependencies defined in ES2015 import syntax in the boot file which assume the presence of `localStorage`. When transpiled, these imports are placed before the localStorage polyfill `require` and therefore throw an error in Safari Private Mode on attempt to use the unpolyfilled localStorage.

For more stable fix, see in-progress #7232. The changes here simply update the problematic import to CommonJS `require` syntax, which ensures that polyfill is in the correct order in the transpiled file. See previous issues #7038 and #6558.

__Testing Instructions:__

Verify that the app boots while logged in, in Safari Private Mode and your preferred browser.

1. Log in at [WordPress.com](https://wordpress.com)
2. Navigate to [http://calypso.localhost:3000](http://calypso.localhost:3000)
3. Note that the Reader loads without issue