### PR TITLE
Happychat: Middleware refactor of HAPPYCHAT_CONNECTING

### DIFF
--- a/client/state/happychat/actions.js
+++ b/client/state/happychat/actions.js
@@ -8,7 +8,6 @@
 /**
  * Internal dependencies
  */
-import wpcom from 'lib/wp';
 import {
 	HAPPYCHAT_CONNECTING,
 	HAPPYCHAT_CONNECTED,
@@ -21,88 +20,32 @@ import {
 	HAPPYCHAT_TRANSCRIPT_RECEIVE,
 	HAPPYCHAT_TRANSCRIPT_REQUEST,
 } from 'state/action-types';
-import { getHappychatConnectionStatus } from './selectors';
-import { getCurrentUser } from 'state/current-user/selectors';
-import { getCurrentUserLocale } from 'state/current-user/selectors';
 
 // This import will be deleted when the refactor is complete:
 import { connection } from './common';
 
 const debug = require( 'debug' )( 'calypso:happychat:actions' );
 
-// Promise based interface for wpcom.request
-const request = ( ... args ) => new Promise( ( resolve, reject ) => {
-	wpcom.request( ... args, ( error, response ) => {
-		if ( error ) {
-			return reject( error );
-		}
-		resolve( response );
-	} );
-} );
-
-const sign = ( payload ) => request( {
-	method: 'POST',
-	path: '/jwt/sign',
-	body: { payload: JSON.stringify( payload ) }
-} );
-
-const startSession = () => request( {
-	method: 'POST',
-	path: '/happychat/session' }
-);
-
-const setHappychatChatStatus = status => ( {
+export const setHappychatChatStatus = status => ( {
 	type: HAPPYCHAT_SET_CHAT_STATUS, status
 } );
-
 export const requestChatTranscript = () => ( { type: HAPPYCHAT_TRANSCRIPT_REQUEST } );
 export const receiveChatTranscript = ( messages, timestamp ) => ( {
 	type: HAPPYCHAT_TRANSCRIPT_RECEIVE, messages, timestamp
 } );
 
 const setChatConnecting = () => ( { type: HAPPYCHAT_CONNECTING } );
-const setChatConnected = () => ( { type: HAPPYCHAT_CONNECTED } );
+export const setChatConnected = () => ( { type: HAPPYCHAT_CONNECTED } );
 
-const setHappychatAvailable = isAvailable => ( { type: HAPPYCHAT_SET_AVAILABLE, isAvailable } );
+export const setHappychatAvailable = isAvailable => ( { type: HAPPYCHAT_SET_AVAILABLE, isAvailable } );
 
 export const setChatMessage = message => ( { type: HAPPYCHAT_SET_MESSAGE, message } );
 export const clearChatMessage = () => setChatMessage( '' );
 
-const receiveChatEvent = event => ( { type: HAPPYCHAT_RECEIVE_EVENT, event } );
+export const receiveChatEvent = event => ( { type: HAPPYCHAT_RECEIVE_EVENT, event } );
 
 export const sendBrowserInfo = siteUrl => ( { type: HAPPYCHAT_SEND_BROWSER_INFO, siteUrl } );
 
-/**
- * Opens Happychat Socket.IO client connection.
- * @return {Thunk} Action thunk
- */
-export const connectChat = () => ( dispatch, getState ) => {
-	const state = getState();
-	const user = getCurrentUser( state );
-	const locale = getCurrentUserLocale( state );
-
-	debug( 'opening with chat locale', locale );
-
-	// if chat is already connected then do nothing
-	if ( getHappychatConnectionStatus( state ) === 'connected' ) {
-		return;
-	}
-	dispatch( setChatConnecting() );
-	// create new session id and get signed identity data for authenticating
-	startSession()
-	.then( ( { session_id } ) => sign( { user, session_id } ) )
-	.then( ( { jwt } ) => connection.open( user.ID, jwt, locale ) )
-	.then(
-		() => {
-			dispatch( setChatConnected() );
-			dispatch( requestChatTranscript() );
-			connection
-			.on( 'message', event => dispatch( receiveChatEvent( event ) ) )
-			.on( 'status', status => dispatch( setHappychatChatStatus( status ) ) )
-			.on( 'accept', accept => dispatch( setHappychatAvailable( accept ) ) );
-		},
-		e => debug( 'failed to start happychat session', e, e.stack )
-	);
-};
+export const connectChat = () => ( { type: HAPPYCHAT_CONNECTING } );
 
 export const sendChatMessage = message => ( { type: HAPPYCHAT_SEND_MESSAGE, message } );

--- a/client/state/happychat/actions.js
+++ b/client/state/happychat/actions.js
@@ -21,11 +21,6 @@ import {
 	HAPPYCHAT_TRANSCRIPT_REQUEST,
 } from 'state/action-types';
 
-// This import will be deleted when the refactor is complete:
-import { connection } from './common';
-
-const debug = require( 'debug' )( 'calypso:happychat:actions' );
-
 export const setHappychatChatStatus = status => ( {
 	type: HAPPYCHAT_SET_CHAT_STATUS, status
 } );
@@ -34,7 +29,6 @@ export const receiveChatTranscript = ( messages, timestamp ) => ( {
 	type: HAPPYCHAT_TRANSCRIPT_RECEIVE, messages, timestamp
 } );
 
-const setChatConnecting = () => ( { type: HAPPYCHAT_CONNECTING } );
 export const setChatConnected = () => ( { type: HAPPYCHAT_CONNECTED } );
 
 export const setHappychatAvailable = isAvailable => ( { type: HAPPYCHAT_SET_AVAILABLE, isAvailable } );

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -7,20 +7,85 @@ import throttle from 'lodash/throttle';
 /**
  * Internal dependencies
  */
+import wpcom from 'lib/wp';
 import {
+	HAPPYCHAT_CONNECTING,
 	HAPPYCHAT_SEND_BROWSER_INFO,
 	HAPPYCHAT_SEND_MESSAGE,
 	HAPPYCHAT_SET_MESSAGE,
 	HAPPYCHAT_TRANSCRIPT_REQUEST,
 } from 'state/action-types';
-import { receiveChatTranscript } from './actions';
-import { getHappychatTranscriptTimestamp } from './selectors';
+import {
+	setChatConnected,
+	receiveChatEvent,
+	receiveChatTranscript,
+	requestChatTranscript,
+	setHappychatAvailable,
+	setHappychatChatStatus,
+} from './actions';
+import {
+	getHappychatConnectionStatus,
+	getHappychatTranscriptTimestamp,
+} from './selectors';
+import {
+	getCurrentUser,
+	getCurrentUserLocale,
+} from 'state/current-user/selectors';
 
 const debug = require( 'debug' )( 'calypso:happychat:actions' );
 
 const sendTyping = throttle( ( connection, message ) => {
 	connection.typing( message );
 }, 1000, { leading: true, trailing: false } );
+
+// Promise based interface for wpcom.request
+const request = ( ... args ) => new Promise( ( resolve, reject ) => {
+	wpcom.request( ... args, ( error, response ) => {
+		if ( error ) {
+			return reject( error );
+		}
+		resolve( response );
+	} );
+} );
+
+const sign = ( payload ) => request( {
+	method: 'POST',
+	path: '/jwt/sign',
+	body: { payload: JSON.stringify( payload ) }
+} );
+
+const startSession = () => request( {
+	method: 'POST',
+	path: '/happychat/session' }
+);
+
+export const connectChat = ( connection, { getState, dispatch } ) => {
+	const state = getState();
+	const user = getCurrentUser( state );
+	const locale = getCurrentUserLocale( state );
+
+	debug( 'opening with chat locale', locale );
+
+	// create new session id and get signed identity data for authenticating
+	return startSession()
+		.then( ( { session_id } ) => sign( { user, session_id } ) )
+		.then( ( { jwt } ) => connection.open( user.ID, jwt, locale ) )
+		.then(
+			() => {
+				dispatch( setChatConnected() );
+
+				// TODO: There's no need to dispatch a separate action to request a transcript.
+				// The HAPPYCHAT_CONNECTED action should have its own middleware handler that does this.
+				dispatch( requestChatTranscript() );
+
+				connection
+					.on( 'message', event => dispatch( receiveChatEvent( event ) ) )
+					.on( 'status', status => dispatch( setHappychatChatStatus( status ) ) )
+					.on( 'accept', accept => dispatch( setHappychatAvailable( accept ) ) );
+			},
+			e => debug( 'failed to start happychat session', e, e.stack )
+		);
+};
 
 export const requestTranscript = ( connection, { getState, dispatch } ) => {
 	const timestamp = getHappychatTranscriptTimestamp( getState() );
@@ -67,6 +132,14 @@ export default function( connection = null ) {
 
 	return store => next => action => {
 		switch ( action.type ) {
+			case HAPPYCHAT_CONNECTING:
+				if ( getHappychatConnectionStatus( store.getState() ) === 'connected' ) {
+					// If chat is already connected, do nothing and stop the action from proceeding to reducers
+					return;
+				}
+				connectChat( connection, store );
+				break;
+
 			case HAPPYCHAT_SEND_BROWSER_INFO:
 				sendBrowserInfo( connection, action.siteUrl );
 				break;

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -56,8 +56,8 @@ const sign = ( payload ) => request( {
 
 const startSession = () => request( {
 	method: 'POST',
-	path: '/happychat/session' }
-);
+	path: '/happychat/session'
+} );
 
 export const connectChat = ( connection, { getState, dispatch } ) => {
 	const state = getState();

--- a/client/state/happychat/test/middleware.js
+++ b/client/state/happychat/test/middleware.js
@@ -9,15 +9,97 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
+import { useSandbox } from 'test/helpers/use-sinon';
+import wpcom from 'lib/wp';
 import {
+	HAPPYCHAT_CONNECTED,
+	HAPPYCHAT_CONNECTING,
+	HAPPYCHAT_RECEIVE_EVENT,
 	HAPPYCHAT_SEND_BROWSER_INFO,
 	HAPPYCHAT_SEND_MESSAGE,
 	HAPPYCHAT_SET_MESSAGE,
+	HAPPYCHAT_SET_AVAILABLE,
+	HAPPYCHAT_SET_CHAT_STATUS,
 	HAPPYCHAT_TRANSCRIPT_RECEIVE,
+	HAPPYCHAT_TRANSCRIPT_REQUEST,
 } from 'state/action-types';
-import middleware, { requestTranscript } from '../middleware';
+import middleware, {
+	connectChat,
+	requestTranscript,
+} from '../middleware';
 
 describe( 'middleware', () => {
+	describe( 'HAPPYCHAT_CONNECTING action', () => {
+		// TODO: Add tests for cases outside the happy path
+		const action = { type: HAPPYCHAT_CONNECTING };
+
+		it( 'should do nothing if Happychat is already connected', () => {
+			const getState = stub().returns( { happychat: { connectionStatus: 'connected' } } );
+			const next = stub();
+			const dispatch = stub();
+			middleware( stub() )( { getState, dispatch } )( next )( action );
+			expect( dispatch ).not.to.have.beenCalled;
+			expect( next ).not.to.have.beenCalled;
+		} );
+
+		describe( 'after successful connection', () => {
+			let connection;
+			let dispatch, getState;
+			const state = deepFreeze( {
+				currentUser: { id: 1 },
+				happychat: { connectionStatus: 'disconnected' },
+				users: { items: { 1: {} } }
+			} );
+
+			useSandbox( sandbox => {
+				connection = {
+					on: sandbox.stub(),
+					open: sandbox.stub().returns( Promise.resolve() )
+				};
+				// Need to add return value after re-assignment, otherwise it will return
+				// a reference to the previous (undefined) connection variable.
+				connection.on.returns( connection );
+
+				dispatch = sandbox.stub();
+				getState = sandbox.stub().returns( state );
+				sandbox.stub( wpcom, 'request', ( args, callback ) => callback( null, {} ) );
+			} );
+
+			it( 'should send notice of the connection state', () => {
+				return connectChat( connection, { dispatch, getState } )
+					.then( () => expect( dispatch ).to.have.been.calledWith( { type: HAPPYCHAT_CONNECTED } ) );
+			} );
+
+			it( 'should fetch transcripts', () => {
+				return connectChat( connection, { dispatch, getState } )
+					.then( () => expect( dispatch ).to.have.been.calledWith( { type: HAPPYCHAT_TRANSCRIPT_REQUEST } ) );
+			} );
+
+			it( 'should set up listeners for various connection events', () => {
+				connection.on.withArgs( 'accept' );
+				connection.on.withArgs( 'message' );
+				connection.on.withArgs( 'status' );
+
+				return connectChat( connection, { dispatch, getState } )
+					.then( () => {
+						expect( connection.on.callCount ).to.equal( 3 );
+
+						// Ensure 'accept' listener was connected by executing a fake message event
+						connection.on.withArgs( 'accept' ).firstCall.args[ 1 ]( true );
+						expect( dispatch ).to.have.been.calledWith( { type: HAPPYCHAT_SET_AVAILABLE, isAvailable: true } );
+
+						// Ensure 'message' listener was connected by executing a fake message event
+						connection.on.withArgs( 'message' ).firstCall.args[ 1 ]( 'some event' );
+						expect( dispatch ).to.have.been.calledWith( { type: HAPPYCHAT_RECEIVE_EVENT, event: 'some event' } );
+
+						// Ensure 'message' listener was connected by executing a fake message event
+						connection.on.withArgs( 'status' ).firstCall.args[ 1 ]( 'ready' );
+						expect( dispatch ).to.have.been.calledWith( { type: HAPPYCHAT_SET_CHAT_STATUS, status: 'ready' } );
+					} );
+			} );
+		} );
+	} );
+
 	describe( 'HAPPYCHAT_SET_MESSAGE action', () => {
 		it( 'should send relevant browser information to the connection', () => {
 			const action = { type: HAPPYCHAT_SEND_BROWSER_INFO, siteUrl: 'http://butt.holdings/' };


### PR DESCRIPTION
Moves side effects related to `HAPPYCHAT_CONNECTING` actions into the middleware. Part of an ongoing refactor.

`HAPPYCHAT_CONNECTING` kicks off a series of requests that verify the user and open a socket connection to the Happychat service. These side-effecting requests are now in middleware.

**Notes:** There's a lot of room for refactor here — the HC middleware is already starting to feel bloated, and there don't seem to be handlers for error cases. But this PR is focused primarily on moving side-effects out of Thunks and into middleware, per current Redux best practices.

### To test

Open a Happychat session through http://calypso.localhost:3000/me/chat — ensure that all actions are working as normal. The user and operator should be able to communicate back and forth, and ending the conversation should behave as expected.