### PR TITLE
Boot: Sync user with redux state on change

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -185,6 +185,9 @@ function reduxStoreReady( reduxStore ) {
 
 		// Set current user in Redux store
 		reduxStore.dispatch( receiveUser( user.get() ) );
+		user.on( 'change', function() {
+			reduxStore.dispatch( receiveUser( user.get() ) );
+		} );
 		reduxStore.dispatch( setCurrentUserId( user.get().ID ) );
 		reduxStore.dispatch( setCurrentUserFlags( user.get().meta.data.flags.active_flags ) );
 

--- a/client/my-sites/current-site/README.md
+++ b/client/my-sites/current-site/README.md
@@ -10,7 +10,7 @@ var CurrentSite = require( 'my-sites/current-site' );
 
 render: function() {
 	return (
-		<CurrentSite sites={ sitesListObject } siteCount={ user.visible_site_count } />
+		<CurrentSite sites={ sitesListObject } />
 	);
 }
 ```
@@ -18,4 +18,3 @@ render: function() {
 #### Props
 
 * `sites (object)` - (required) An instance of `sites-list`.
-* `siteCount (number)` - (required) The number of sites the user has.

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import debugFactory from 'debug';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 const debug = debugFactory( 'calypso:my-sites:current-site' );
 
@@ -23,6 +24,7 @@ const AllSites = require( 'my-sites/all-sites' ),
 import SiteNotice from './notice';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { getCurrentUser } from 'state/current-user/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 
 const CurrentSite = React.createClass( {
@@ -33,8 +35,8 @@ const CurrentSite = React.createClass( {
 	},
 
 	propTypes: {
-		sites: React.PropTypes.object.isRequired,
 		siteCount: React.PropTypes.number.isRequired,
+		sites: React.PropTypes.object.isRequired,
 		setLayoutFocus: React.PropTypes.func.isRequired,
 		selectedSiteId: React.PropTypes.number,
 		selectedSite: React.PropTypes.object,
@@ -163,12 +165,14 @@ const CurrentSite = React.createClass( {
 // TODO: make this pure when sites can be retrieved from the Redux state
 module.exports = connect(
 	( state ) => {
-		const selectedSiteId = getSelectedSiteId( state );
+		const selectedSiteId = getSelectedSiteId( state ),
+			user = getCurrentUser( state );
 
 		return {
+			isJetpack: isJetpackSite( state, selectedSiteId ),
 			selectedSiteId,
 			selectedSite: getSelectedSite( state ),
-			isJetpack: isJetpackSite( state, selectedSiteId )
+			siteCount: get( user, 'visible_site_count', 0 )
 		};
 	},
 	{ setLayoutFocus },

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import debugFactory from 'debug';
 import { connect } from 'react-redux';
+import debugFactory from 'debug';
 import { get } from 'lodash';
+import { localize } from 'i18n-calypso';
+import React from 'react';
 
 const debug = debugFactory( 'calypso:my-sites:current-site' );
 
@@ -35,12 +36,13 @@ const CurrentSite = React.createClass( {
 	},
 
 	propTypes: {
+		isJetpack: React.PropTypes.bool,
 		siteCount: React.PropTypes.number.isRequired,
 		sites: React.PropTypes.object.isRequired,
 		setLayoutFocus: React.PropTypes.func.isRequired,
 		selectedSiteId: React.PropTypes.number,
 		selectedSite: React.PropTypes.object,
-		isJetpack: React.PropTypes.bool
+		translate: React.PropTypes.func.isRequired
 	},
 
 	componentWillMount() {
@@ -116,7 +118,7 @@ const CurrentSite = React.createClass( {
 	},
 
 	render: function() {
-		const { selectedSite, isJetpack } = this.props;
+		const { isJetpack, selectedSite, translate } = this.props;
 
 		if ( ! this.props.sites.initialized ) {
 			return (
@@ -128,7 +130,7 @@ const CurrentSite = React.createClass( {
 						<a className="site__content">
 							<div className="site-icon" />
 							<div className="site__info">
-								<span className="site__title">{ this.translate( 'Loading My Sites…' ) }</span>
+								<span className="site__title">{ translate( 'Loading My Sites…' ) }</span>
 							</div>
 						</a>
 					</div>
@@ -142,7 +144,7 @@ const CurrentSite = React.createClass( {
 					<span className="current-site__switch-sites">
 						<Button compact borderless onClick={ this.switchSites }>
 							<Gridicon icon="arrow-left" size={ 18 } />
-							{ this.translate( 'Switch Site' ) }
+							{ translate( 'Switch Site' ) }
 						</Button>
 					</span>
 				}
@@ -178,4 +180,4 @@ module.exports = connect(
 	{ setLayoutFocus },
 	null,
 	{ pure: false }
-)( CurrentSite );
+)( localize( CurrentSite ) );

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -647,7 +647,6 @@ export class MySitesSidebar extends Component {
 				<SidebarRegion>
 					<CurrentSite
 						sites={ this.props.sites }
-						siteCount={ this.props.currentUser.visible_site_count }
 						onClick={ this.onPreviewSite }
 					/>
 					{ this.renderSidebarMenus() }


### PR DESCRIPTION
We only set the user on boot. If it gets fetched/updated, `getCurrentUser` still returns the initial one.

Fixes: https://github.com/Automattic/wp-calypso/issues/11668

Test:
1. Create a new user
2. Create a domain-only site on https://wordpress.com/domains (pick a domain, than change URL to Calypso to hit the Flow)
3. Make sure there is no site switcher
4. Create another domain-only site
5. Make sure site switcher is visible w/o refresh