### PR TITLE
Sidebar: increase contrast of sidebar text

### DIFF
--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -48,7 +48,7 @@ $border-ultra-light-gray: #e8f0f5;
 $masterbar-color:          $blue-wordpress;
 $sidebar-bg-color:         lighten( $gray, 30% );
 $sidebar-text-color:       $gray-dark;
-$sidebar-selected-color:   $gray;
+$sidebar-selected-color:   $gray-text-min;
 
 
 //Social media colors

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -69,7 +69,7 @@
 
 // Sidebar group headings
 .sidebar__heading {
-	color: rgba( saturate( $sidebar-text-color, 60% ), 0.6 );
+	color: darken( $gray, 10% );
 	font-weight: 600;
 	font-size: 12px;
 	margin: 16px 8px 6px 14px;
@@ -154,7 +154,8 @@
 		position: absolute;
 			top: 12px;
 			right: 8px;
-		color: rgba( saturate( $sidebar-text-color, 60% ), 0.7 );
+		color: darken( $gray, 10% );
+		font-weight: 600;
 		font-size: 11px;
 
 		@include breakpoint( "<660px" ) {
@@ -204,8 +205,8 @@ a.sidebar__button, form.sidebar__button {
 	height: 24px;
 	margin: 11px 8px 0 0;
 	line-height: 18px;
-	background-color: lighten( $sidebar-bg-color, 3% );
-	color: rgba( saturate( $sidebar-text-color, 50% ), 0.8 );
+	background-color: $gray-light;
+	color: darken( $gray, 20% );
 	font-size: 11px;
 	font-weight: 600;
 	border-radius: 3px;
@@ -239,8 +240,7 @@ form.sidebar__button {
 		}
 
 		.sidebar__button {
-			background: lighten( $sidebar-selected-color, 30% );
-			color: darken( $sidebar-selected-color, 30% );
+			color: $gray-dark;
 			border: 1px solid darken( $sidebar-selected-color, 10% );
 		}
 


### PR DESCRIPTION
This updates the sidebar text to meet AA contrast standards. No changes to the blue colors used during hover; on affects gray text.

Changes made:

- darken sidebar headers
- darken plan name and make bold
- darken button text
- darken selected state



Before|After
---|---
![artboard 2](https://cloud.githubusercontent.com/assets/618551/24630245/8f6a682a-1881-11e7-99fe-759dbb48cdb2.png)|![artboard](https://cloud.githubusercontent.com/assets/618551/24630249/917fc65a-1881-11e7-8a84-30030ec28310.png)



