### PR TITLE
Framework: Remove renderSeparateTrees() Helper

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -17,8 +17,6 @@ import { makeLayoutMiddleware } from './shared.js';
 import { getCurrentUser } from 'state/current-user/selectors';
 import userFactory from 'lib/user';
 import sitesFactory from 'lib/sites-list';
-import debugFactory from 'debug';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 /**
  * Re-export
@@ -27,7 +25,6 @@ export { setSection } from './shared.js';
 
 const user = userFactory();
 const sites = sitesFactory();
-const debug = debugFactory( 'calypso:controller' );
 
 export const ReduxWrappedLayout = ( { store, primary, secondary, tertiary } ) => (
 	<ReduxProvider store={ store }>
@@ -68,40 +65,8 @@ export function clientRouter( route, ...middlewares ) {
 }
 
 function render( context ) {
-	context.layout
-		? renderSingleTree( context )
-		: renderSeparateTrees( context );
-}
-
-function renderSingleTree( context ) {
 	ReactDom.render(
 		context.layout,
 		document.getElementById( 'wpcom' )
 	);
-}
-
-function renderSeparateTrees( context ) {
-	renderPrimary( context );
-	renderSecondary( context );
-}
-
-function renderPrimary( context ) {
-	const { primary, store } = context;
-
-	if ( primary ) {
-		debug( 'Rendering primary', primary );
-		renderWithReduxStore( primary, 'primary', store );
-	}
-}
-
-function renderSecondary( context ) {
-	const { secondary, store } = context;
-
-	if ( secondary === null ) {
-		debug( 'Unmounting secondary' );
-		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
-	} else if ( secondary !== undefined ) {
-		debug( 'Rendering secondary' );
-		renderWithReduxStore( secondary, 'secondary', store );
-	}
 }


### PR DESCRIPTION
This helper was only required in a very specific situation:
For the client-side rendering of isomorphic routes that didn't use the makeLayout middleware.

The rationale is that the `renderSeparateTrees()` helper would take React elements from `context.primary` and `context.secondary`, respectively, and render them to the corresponding `<div />`s.
However, there are no such routes left -- we use the `makeLayout` middleware in all our isomorphic routes (to construct a `<Layout />` component tree in `context.layout` from `context.primary` and `context.secondary`).

To test:
* Land in different Calypso sections and navigate to others from there (try starting at `/design` in particular!). Make sure that there are no weird rendering or console errors. Some particularly interesting cases:
  * Land at `/design` and click on any theme thumbnail.
  * Land at `/design` (logged-in), click on the site selector in the sidebar, and click 'Add New WordPress' > 'WordPress.com site'. Click the browser's 'Back' button.
  * Land at `/design` while logged out. Click on any theme's '...' menu, and select 'Pick this Design'. Click the browser's 'Back' button.

Prompted by https://github.com/Automattic/wp-calypso/pull/12521#discussion_r108334729