### PR TITLE
Framework: Add WatchIgnorePlugin for node_modules

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -176,6 +176,7 @@ if ( calypsoEnv === 'development' ) {
 	const DashboardPlugin = require( 'webpack-dashboard/plugin' );
 	webpackConfig.plugins.splice( 0, 0, new DashboardPlugin() );
 	webpackConfig.plugins.push( new webpack.HotModuleReplacementPlugin() );
+	webpackConfig.plugins.push( new webpack.WatchIgnorePlugin( [ path.resolve( __dirname, './node_modules/' ) ] ) );
 	webpackConfig.entry.build = [
 		'webpack-dev-server/client?/',
 		'webpack/hot/only-dev-server',


### PR DESCRIPTION
This change cuts down the numbers of watchers to set from over 7000 to 500-600.

We are setting watchers for all files in node_modules by default but since these files don't change often and if they change they usually warrant a full restart of the dev server, they are OK to ignore. And by ignoring that folder, we no longer exhaust the available file handles in the OS.


### Before:

```
$ osqueryi 'select count(*), p.name from process_open_files as po, processes as p where p.pid=po.pid group by p.pid order by count(*) desc limit 1'

+----------+----------------+
| count(*) | name           |
+----------+----------------+
| 7384     | node           |
+----------+----------------+
```

### After:
```
$osqueryi 'select count(*), p.name from process_open_files as po, processes as p where p.pid=po.pid group by p.pid order by count(*) desc limit 1'

+----------+----------------+
| count(*) | name           |
+----------+----------------+
| 562      | node           |
+----------+----------------+
```

