### PR TITLE
NPS Survey: Styling

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -200,6 +200,7 @@
 @import 'components/happychat/agent-w/style';
 @import 'layout/community-translator/style';
 @import 'layout/masterbar/style';
+@import 'layout/nps-survey-notice/style';
 @import 'layout/nux-welcome/style';
 @import 'layout/offline-status/style';
 @import 'layout/sidebar/style';

--- a/client/blocks/nps-survey/docs/example.jsx
+++ b/client/blocks/nps-survey/docs/example.jsx
@@ -24,10 +24,11 @@ class NpsSurveyExample extends PureComponent {
 		isClosed: false,
 	};
 
-	handleClose = () => {
+	handleClose = ( afterClose ) => {
 		this.setState( {
 			isClosed: true,
 		} );
+		afterClose();
 	}
 
 	render() {

--- a/client/blocks/nps-survey/index.jsx
+++ b/client/blocks/nps-survey/index.jsx
@@ -5,6 +5,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,10 +18,9 @@ import {
 	submitNpsSurveyWithNoScore,
 } from 'state/nps-survey/actions';
 import {
-	isNpsSurveyNotSubmitted,
-	isNpsSurveySubmitted,
-	isNpsSurveySubmitting,
-	isNpsSurveySubmitFailure,
+	successNotice
+} from 'state/notices/actions';
+import {
 	hasAnsweredNpsSurvey,
 } from 'state/nps-survey/selectors';
 
@@ -40,13 +40,27 @@ class NpsSurvey extends Component {
 
 	handleFinishClick = () => {
 		this.props.submitNpsSurvey( this.props.name, this.state.score );
+		this.onClose( this.showThanksNotice );
 	}
 
 	handleDismissClick = () => {
 		this.props.submitNpsSurveyWithNoScore( this.props.name );
-		// allow for the state to propagate
+		this.onClose( noop );
+	}
+
+	showThanksNotice = () => {
+		this.props.successNotice(
+			this.props.translate( 'Thanks for your feedback!' ),
+			{
+				duration: 5000,
+			}
+		);
+	}
+
+	onClose = ( afterClose ) => {
+		// ensure that state is updated before onClose handler is called
 		setTimeout( () => {
-			this.props.onClose();
+			this.props.onClose( afterClose );
 		}, 0 );
 	}
 
@@ -88,19 +102,6 @@ class NpsSurvey extends Component {
 						</Button>
 					</div>
 				</div>
-				<div className="nps-survey__thank-you-screen">
-					<div className="nps-survey__thank-you">
-						{ translate( 'Thanks for your feedback!' ) }
-					</div>
-					<div className="nps-survey__buttons">
-						<Button primary
-							className="nps-survey__dismiss-button"
-							onClick={ this.props.onClose }
-						>
-							Close
-						</Button>
-					</div>
-				</div>
 		</Card>
 		);
 	}
@@ -108,10 +109,6 @@ class NpsSurvey extends Component {
 
 const mapStateToProps = ( state ) => {
 	return {
-		isNotSubmitted: isNpsSurveyNotSubmitted( state ),
-		isSubmitting: isNpsSurveySubmitting( state ),
-		isSubmitted: isNpsSurveySubmitted( state ),
-		isSubmitFailure: isNpsSurveySubmitFailure( state ),
 		hasAnswered: hasAnsweredNpsSurvey( state ),
 	};
 };
@@ -119,7 +116,7 @@ const mapStateToProps = ( state ) => {
 export default
 	connect(
 		mapStateToProps,
-		{ submitNpsSurvey, submitNpsSurveyWithNoScore }
+		{ submitNpsSurvey, submitNpsSurveyWithNoScore, successNotice }
 	)( localize(
 		NpsSurvey
 	) );

--- a/client/blocks/nps-survey/index.jsx
+++ b/client/blocks/nps-survey/index.jsx
@@ -4,11 +4,13 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Button from 'components/button';
+import Card from 'components/card';
 import RecommendationSelect from './recommendation-select';
 import {
 	submitNpsSurvey,
@@ -49,49 +51,57 @@ class NpsSurvey extends Component {
 	}
 
 	render() {
+		const { translate } = this.props;
+
 		const className = classNames( 'nps-survey', {
 			'is-recommendation-selected': Number.isInteger( this.state.score ),
 			'is-submitted': this.props.hasAnswered,
 		} );
 
 		return (
-			<div className={ className }>
+			<Card className={ className }>
 				<div className="nps-survey__question-screen">
-					<div>How likely is it that you would recommend WordPress.com to your friends, family, or colleagues?</div>
-					<div>
+					<div className="nps-survey__question">
+						{ translate( 'How likely are you to recommend WordPress.com to your friends, family, or colleagues?' ) }
+					</div>
+					<div className="nps-survey__recommendation-select-wrapper">
 						<RecommendationSelect
 							value={ this.state.score }
 							disabled={ this.props.hasAnswered }
 							onChange={ this.handleRecommendationSelectChange }
 						/>
 					</div>
-					<div>
+					<div className="nps-survey__buttons">
 						<Button primary
 							className="nps-survey__finish-button"
 							disabled={ this.props.hasAnswered }
 							onClick={ this.handleFinishClick }
 						>
-							Finish
+							{ translate( 'Finish', { context: 'verb' } ) }
 						</Button>
 						<Button borderless
+							className="nps-survey__not-answer-button"
 							disabled={ this.props.hasAnswered }
 							onClick={ this.handleDismissClick }
 						>
-							I'd rather not answer
+							{ translate( 'I\'d rather not answer' ) }
 						</Button>
 					</div>
 				</div>
 				<div className="nps-survey__thank-you-screen">
-					Thanks for providing your feedback!
-					<div>
+					<div className="nps-survey__thank-you">
+						{ translate( 'Thanks for your feedback!' ) }
+					</div>
+					<div className="nps-survey__buttons">
 						<Button primary
+							className="nps-survey__dismiss-button"
 							onClick={ this.props.onClose }
 						>
-							Dismiss
+							Close
 						</Button>
 					</div>
 				</div>
-		</div>
+		</Card>
 		);
 	}
 }
@@ -106,7 +116,10 @@ const mapStateToProps = ( state ) => {
 	};
 };
 
-export default connect(
-	mapStateToProps,
-	{ submitNpsSurvey, submitNpsSurveyWithNoScore }
-)( NpsSurvey );
+export default
+	connect(
+		mapStateToProps,
+		{ submitNpsSurvey, submitNpsSurveyWithNoScore }
+	)( localize(
+		NpsSurvey
+	) );

--- a/client/blocks/nps-survey/index.jsx
+++ b/client/blocks/nps-survey/index.jsx
@@ -77,7 +77,7 @@ class NpsSurvey extends Component {
 							disabled={ this.props.hasAnswered }
 							onClick={ this.handleFinishClick }
 						>
-							{ translate( 'Finish', { context: 'verb' } ) }
+							{ translate( 'Finish' ) }
 						</Button>
 						<Button borderless
 							className="nps-survey__not-answer-button"

--- a/client/blocks/nps-survey/recommendation-option.jsx
+++ b/client/blocks/nps-survey/recommendation-option.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
 
 class RecommendationOption extends Component {
 	constructor( props ) {
@@ -20,8 +21,12 @@ class RecommendationOption extends Component {
 	}
 
 	render() {
+		const className = classNames( 'nps-survey__recommendation-option', {
+			'is-selected': this.props.selected,
+		} );
+
 		return (
-			<label className="nps-survey__recommendation-option">
+			<label className={ className }>
 				<input type="radio"
 					name="nps-survey-recommendation-option"
 					value={ this.props.value }

--- a/client/blocks/nps-survey/recommendation-select.jsx
+++ b/client/blocks/nps-survey/recommendation-select.jsx
@@ -36,7 +36,9 @@ class RecommendationSelect extends PureComponent {
 					<span>Unlikely</span>
 					<span className="nps-survey__very-likely-label">Very Likely</span>
 				</div>
-				{ options }
+				<div className="nps-survey__options">
+					{ options }
+				</div>
 			</div>
 		);
 	}

--- a/client/blocks/nps-survey/style.scss
+++ b/client/blocks/nps-survey/style.scss
@@ -1,13 +1,41 @@
-.nps-survey {
-	border: 1px solid $gray-dark;
+.card.nps-survey {
+	margin: 0;
+	padding: 0;
+}
+
+.dialog__content .card.nps-survey {
+	box-shadow: unset;
 }
 
 .nps-survey__thank-you-screen {
 	display: none;
 }
 
+.nps-survey__question,
+.nps-survey__thank-you {
+	padding: 16px;
+
+	@include breakpoint( ">480px" ) {
+		padding: 24px;
+	}
+}
+
+.nps-survey__buttons {
+	padding: 16px;
+}
+
+.button.nps-survey__finish-button,
+.button.nps-survey__not-answer-button,
+.button.nps-survey__dismiss-button {
+	display: block;
+	margin: 0 auto;
+	min-width: 170px;
+}
+
 .button.nps-survey__finish-button {
-	display: none;
+	opacity: 0;
+	visibility: hidden;
+	transition: opacity .25s ease-in;
 }
 
 .nps-survey.is-submitted {
@@ -22,16 +50,42 @@
 
 .nps-survey.is-recommendation-selected {
 	.button.nps-survey__finish-button {
-		display: inline-block;
+		//display: block;
+		opacity: 1;
+		visibility: visible;
+	}
+}
+
+.nps-survey__recommendation-select-wrapper {
+	background-color: $gray-light;
+	border-top: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid lighten( $gray, 20% );
+	padding: 16px 0;
+	text-align: center;
+
+	@include breakpoint( ">480px" ) {
+		padding: 16px;
 	}
 }
 
 .nps-survey__recommendation-select {
+	box-sizing: border-box;
 	display: inline-block;
 }
 
+.nps-survey__scale-labels,
+.nps-survey__recommendation-option {
+	padding: 0 3px;
+	margin-bottom: 8px;
+
+	@include breakpoint( ">480px" ) {
+		padding: 0 6px;
+	}
+}
+
 .nps-survey__scale-labels {
-	padding: 0 6px;
+	color: $gray-text-min;
+	text-align: left;
 }
 
 .nps-survey__very-likely-label {
@@ -40,7 +94,11 @@
 
 .nps-survey__recommendation-option {
 	display: inline-block;
-	padding: 0 6px;
+}
+
+.nps-survey__recommendation-option.is-selected {
+	color: darken( $blue-medium, 8% );
+	font-weight: bold;
 }
 
 .nps-survey__recommendation-option input[type=radio] {

--- a/client/blocks/nps-survey/style.scss
+++ b/client/blocks/nps-survey/style.scss
@@ -7,12 +7,7 @@
 	box-shadow: unset;
 }
 
-.nps-survey__thank-you-screen {
-	display: none;
-}
-
-.nps-survey__question,
-.nps-survey__thank-you {
+.nps-survey__question {
 	padding: 16px;
 
 	@include breakpoint( ">480px" ) {
@@ -21,7 +16,9 @@
 }
 
 .nps-survey__buttons {
-	padding: 16px;
+	padding: 16px 16px 7px;
+	transform: translateY(-25px);
+	transition: transform .1s ease-in;
 }
 
 .button.nps-survey__finish-button,
@@ -35,23 +32,18 @@
 .button.nps-survey__finish-button {
 	opacity: 0;
 	visibility: hidden;
-	transition: opacity .25s ease-in;
-}
-
-.nps-survey.is-submitted {
-	.nps-survey__question-screen {
-		display: none;
-	}
-
-	.nps-survey__thank-you-screen {
-		display: block;
-	}
+	transition: opacity .2s ease-in;
 }
 
 .nps-survey.is-recommendation-selected {
+	.nps-survey__buttons {
+		//height: 75px;
+		transform: translateY(0);
+	}
+
 	.button.nps-survey__finish-button {
-		//display: block;
 		opacity: 1;
+		//transform: translateY(0);
 		visibility: visible;
 	}
 }

--- a/client/layout/nps-survey-notice/index.jsx
+++ b/client/layout/nps-survey-notice/index.jsx
@@ -30,6 +30,13 @@ class NpsSurveyNotice extends Component {
 		this.props.setNpsSurveyDialogShowing( false );
 	}
 
+	handleSurveyClose = ( afterClose ) => {
+		this.props.setNpsSurveyDialogShowing( false );
+
+		// slightly delay the showing of the thank you notice
+		setTimeout( afterClose, 500 );
+	}
+
 	componentDidMount() {
 		// wait a little bit before showing the notice, so that
 		// (1) the user gets a chance to look briefly at the uncluttered screen, and
@@ -46,7 +53,7 @@ class NpsSurveyNotice extends Component {
 				onClose={ this.handleDialogClose }>
 				<NpsSurvey
 					name={ SURVEY_NAME }
-					onClose={ this.handleDialogClose }
+					onClose={ this.handleSurveyClose }
 				/>
 			</Dialog>
 		);

--- a/client/layout/nps-survey-notice/index.jsx
+++ b/client/layout/nps-survey-notice/index.jsx
@@ -40,7 +40,10 @@ class NpsSurveyNotice extends Component {
 
 	render() {
 		return (
-			<Dialog isVisible={ this.props.isNpsSurveyDialogShowing } onClose={ this.handleDialogClose }>
+			<Dialog
+				additionalClassNames="nps-survey-notice"
+				isVisible={ this.props.isNpsSurveyDialogShowing }
+				onClose={ this.handleDialogClose }>
 				<NpsSurvey
 					name={ SURVEY_NAME }
 					onClose={ this.handleDialogClose }

--- a/client/layout/nps-survey-notice/style.scss
+++ b/client/layout/nps-survey-notice/style.scss
@@ -1,0 +1,4 @@
+.dialog.card.nps-survey-notice {
+	max-width: 480px;
+	padding: 0;
+}

--- a/client/state/ui/nps-survey-notice/actions.js
+++ b/client/state/ui/nps-survey-notice/actions.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { translate } from 'i18n-calypso';
 import { random } from 'lodash';
 
 /**
@@ -26,7 +27,7 @@ export function showNpsSurveyNoticeIfEligible() {
 export function showNpsSurveyNotice() {
 	return ( dispatch ) => {
 		const options = {
-			button: 'Sure!',
+			button: translate( 'Sure!' ),
 			onClick: ( event, closeFn ) => {
 				closeFn();
 				dispatch( setNpsSurveyDialogShowing( true ) );
@@ -36,7 +37,7 @@ export function showNpsSurveyNotice() {
 		// NOTE: It would be nice to move to dispatching the `createNotice` action,
 		// but that currently doesn't support notices with `button` and `onClick`
 		// options.
-		notices.new( 'Let us know how we are doing...', options, 'is-info' );
+		notices.new( translate( 'Would you mind answering a question about WordPress.com?' ), options, 'is-info' );
 	};
 }
 


### PR DESCRIPTION
This PR styles the NPS Survey dialog.

![nps survey notice](https://cloud.githubusercontent.com/assets/2098816/24615849/75dd12a0-185d-11e7-95aa-4e8d5dcf6e20.gif)

Test:
- To see debug messages, in browse console:
    - `localStorage.setItem('debug', 'calypso:nps-survey');`
- from `http://calypso.localhost:3000/devdocs/blocks/nps-survey`
    - Survey should submit successfully the first time you answer it (the API errors if a score has been provided in the past 4 months)
- from global notice (see #12522)
    - Survey should error (silently; it always will thank the user for submitting -- no need to trouble the user should there be a problem submitting), since the survey name is not yet whitelisted in the API endpoint
- Verify that dismissing survey without answering it calls API (look at debug messages and Redux actions/state)

For now, this is not enabled in any environments. To enable:

```
ENABLE_FEATURES=nps-survey/notice make run
```

To re-trigger the NPS survey notice, in the browser console, type:

```
dispatch( showNpsSurveyNotice() );
```