### PR TITLE
Framework: Avoid double Redux Provider component in the render chain

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -50,8 +50,7 @@ var config = require( 'config' ),
 	syncHandler = require( 'lib/wp/sync-handler' ),
 	bindWpLocaleState = require( 'lib/wp/localization' ).bindState,
 	supportUser = require( 'lib/user/support-user-interop' ),
-	createReduxStoreFromPersistedInitialState = require( 'state/initial-state' ).default,
-	renderWithReduxStore = require( 'lib/react-helpers' ).renderWithReduxStore;
+	createReduxStoreFromPersistedInitialState = require( 'state/initial-state' ).default;
 
 import { getSelectedSiteId, getSectionName } from 'state/ui/selectors';
 import { setNextLayoutFocus, activateNextLayoutFocus } from 'state/ui/layout-focus/actions';
@@ -166,7 +165,14 @@ function boot() {
 function renderLayout( reduxStore ) {
 	const Layout = require( 'controller' ).ReduxWrappedLayout;
 
-	renderWithReduxStore( React.createElement( Layout, { store: reduxStore } ), 'wpcom', reduxStore );
+	const layoutElement = React.createElement( Layout, {
+		store: reduxStore
+	} );
+
+	ReactDom.render(
+		layoutElement,
+		document.getElementById( 'wpcom' )
+	);
 
 	debug( 'Main layout rendered.' );
 }


### PR DESCRIPTION
Props to @aduth for discovering this issue in https://github.com/Automattic/wp-calypso/pull/12451#pullrequestreview-29564411.

This happens only for multi-tree layout:
![screen shot 2017-03-29 at 13 51 23](https://cloud.githubusercontent.com/assets/699132/24453145/f2e841aa-1486-11e7-932e-155dcf0d871e.png)

It looks like it should be removed from `boot`. For SSRed logged out pages we don't have this kind of issue:

![screen shot 2017-03-29 at 13 53 20](https://cloud.githubusercontent.com/assets/699132/24453173/19d162ba-1487-11e7-872f-c3232a504ec8.png)

### After
Multi-tree layout logged out:
![screen shot 2017-03-29 at 14 45 44](https://cloud.githubusercontent.com/assets/699132/24455017/6cc8d3b6-148e-11e7-8d07-4888bc542e7b.png)

Multi-tree layout logged in:
![screen shot 2017-03-29 at 14 44 43](https://cloud.githubusercontent.com/assets/699132/24454977/4a656e42-148e-11e7-86ac-b592597e89a7.png)

### Testing
1. Navigate to https://calypso.localhost (multi-tree page) when logged in.
2. Make sure there is only one `<Provider />` component rendered in React Dev tools.
3. Try the same when logged out.
4. Navigate to http://calypso.localhost:3000/theme/button-2 (single-tree page) when logged out.
5. Make sure there is only one `<Provider />` component rendered in React Dev tools.
6. Try the same when logged in.

### Review
* [x] Code
* [x] Product
