### PR TITLE
MagicSearch: show all suggestions option for suggestions list.

### DIFF
--- a/client/components/suggestions/index.jsx
+++ b/client/components/suggestions/index.jsx
@@ -16,15 +16,15 @@ import {
 import classNames from 'classnames';
 import i18n from 'i18n-calypso';
 
-function ShowAll( props ) {
+function SuggestionsButtonAll( props ) {
 	function click() {
-		return props.onClick( props.cat );
+		return props.onClick( props.category );
 	}
 
 	return <span
 		className="suggestions__category-show-all"
 		onClick={ click }>
-		{ props.txt }
+		{ props.label }
 	</span>;
 }
 
@@ -229,10 +229,10 @@ class Suggestions extends React.Component {
 		return token;
 	}
 
-	onShowAllClick = ( value ) => {
-		const suggestions = this.narrowDown( this.props.input, value );
+	onShowAllClick = ( category ) => {
+		const suggestions = this.narrowDown( this.props.input, category );
 		this.setState( {
-			showAll: value,
+			showAll: category,
 			suggestions,
 			taxonomySuggestionsArray: this.createTaxonomySuggestionsArray( suggestions )
 		} );
@@ -259,15 +259,15 @@ class Suggestions extends React.Component {
 						} ) }
 					</span>
 					{ this.props.terms[ key ].length > suggestions[ key ].length &&
-						<ShowAll
+						<SuggestionsButtonAll
 							onClick={ this.onShowAllClick }
-							cat={ key }
-							txt={ i18n.translate( 'Show All' ) } /> }
+							category={ key }
+							label={ i18n.translate( 'Show all' ) } /> }
 					{ key === this.state.showAll &&
-						<ShowAll
+						<SuggestionsButtonAll
 							onClick={ this.onShowAllClick }
-							cat={ '' }
-							txt={ i18n.translate( 'Show Less' ) } /> }
+							category={ '' }
+							label={ i18n.translate( 'Show less' ) } /> }
 				</div>
 			);
 			//Add values

--- a/client/components/suggestions/style.scss
+++ b/client/components/suggestions/style.scss
@@ -42,6 +42,11 @@
 		text-transform: uppercase;
 		color: $gray-text-min;
 	}
+
+	.suggestions__category-show-all {
+		float: right;
+		cursor: pointer;
+	}
 }
 
 .suggestions__value {

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -297,22 +297,24 @@ class ThemesMagicSearchCard extends React.Component {
 						}
 					</div>
 				</StickyPanel>
-				{ renderSuggestions &&
-					<Suggestions
-						ref="suggestions"
-						terms={ taxonomies }
-						input={ this.state.editedSearchElement }
-						suggest={ this.suggest }
-					/>
-				}
-				{ ! renderSuggestions &&
-					<MagicSearchWelcome
-						ref="welcome"
-						taxonomies={ taxonomiesKeys }
-						topSearches={ [] }
-						suggestionsCallback={ this.insertTextInInput }
-					/>
-				}
+				<div onClick={ this.handleClickInside }>
+					{ renderSuggestions &&
+						<Suggestions
+							ref="suggestions"
+							terms={ taxonomies }
+							input={ this.state.editedSearchElement }
+							suggest={ this.suggest }
+						/>
+					}
+					{ ! renderSuggestions &&
+						<MagicSearchWelcome
+							ref="welcome"
+							taxonomies={ taxonomiesKeys }
+							topSearches={ [] }
+							suggestionsCallback={ this.insertTextInInput }
+						/>
+					}
+				</div>
 			</div>
 		);
 	}


### PR DESCRIPTION
### Info
When typing into Search suggestions are shown. But because the list of suggestions can be very long we limit visible numbers of suggestions. This PR adds `Show all` button that when clicked will show all available suggestions for that category (button marked red):
![image](https://cloud.githubusercontent.com/assets/17271089/24456247/b5ccf6c4-1492-11e7-9dd5-b4ec9b0658dc.png)

After click the list gets expanded:
![image](https://cloud.githubusercontent.com/assets/17271089/24456437/4ce2ddbc-1493-11e7-96f8-9075d91b182c.png)

Also the button text changes and it allows to fold the list back.

### Testing
Go to `/design` start searching and click Show all button. 