### PR TITLE
Change wording on gdocs tour

### DIFF
--- a/client/layout/guided-tours/tours/gdocs-integration-tour.js
+++ b/client/layout/guided-tours/tours/gdocs-integration-tour.js
@@ -30,7 +30,7 @@ export const GDocsIntegrationTour = makeTour(
 		when={ hasUserPastedFromGoogleDocs }
 	>
 		<Step name="init" placement="right">
-			<p>{ translate( 'Do you want to post drafts directly from Google Docs?' ) }</p>
+			<p>{ translate( 'Did you know you can create drafts from Google Docs?' ) }</p>
 			<ButtonRow>
 				<LinkQuit
 					primary


### PR DESCRIPTION
Before:

<img width="440" alt="do-you-want" src="https://cloud.githubusercontent.com/assets/583546/24457441/91b635b2-1496-11e7-8cc4-a467a7a2478b.png">


After:

![did-you-know](https://cloud.githubusercontent.com/assets/583546/24457412/78f85672-1496-11e7-85e9-ff3084a682c8.png)


# How to test

* open calypso.live or clone the PR
* add `?tour=gdocsIntegrationTour` to any URL
* expected behaviour is that the card is shown with the text 'Did you know you can create drafts from Google Docs?'