### PR TITLE
Components: Upgrade react-virtualized to v9.4.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -534,7 +534,7 @@
       "version": "6.24.1"
     },
     "babylon": {
-      "version": "6.16.1"
+      "version": "6.17.0"
     },
     "backo2": {
       "version": "1.0.2"
@@ -576,6 +576,9 @@
     },
     "binary-extensions": {
       "version": "1.8.0"
+    },
+    "binary-search-bounds": {
+      "version": "1.0.0"
     },
     "bindings": {
       "version": "1.2.1"
@@ -692,7 +695,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000655"
+      "version": "1.0.30000656"
     },
     "caseless": {
       "version": "0.12.0"
@@ -2160,6 +2163,9 @@
     "interpret": {
       "version": "0.6.6"
     },
+    "interval-tree-1d": {
+      "version": "1.0.3"
+    },
     "invariant": {
       "version": "2.2.2"
     },
@@ -2564,7 +2570,7 @@
       "version": "0.0.3"
     },
     "jsx-ast-utils": {
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dev": true
     },
     "key-mirror": {
@@ -3471,7 +3477,7 @@
       }
     },
     "react-virtualized": {
-      "version": "8.8.1",
+      "version": "9.4.0",
       "dependencies": {
         "classnames": {
           "version": "2.2.5"
@@ -3686,7 +3692,7 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.3.2"
+      "version": "1.3.3"
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -4299,7 +4305,7 @@
       "version": "1.4.2"
     },
     "tiny-emitter": {
-      "version": "1.1.0"
+      "version": "1.2.0"
     },
     "tinymce": {
       "version": "4.3.12"

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "react-modal": "1.6.5",
     "react-pure-render": "1.0.2",
     "react-redux": "5.0.3",
-    "react-virtualized": "8.8.1",
+    "react-virtualized": "9.4.0",
     "redux": "3.0.4",
     "redux-thunk": "1.0.0",
     "rtlcss": "2.0.5",


### PR DESCRIPTION
This pull requests bumps the version of our ```react-virtualized``` dependency from ```8.8.1``` to ```9.4.0```.

A list of breaking changes introduced in 9.x can be found in the following pull request: https://github.com/bvaughn/react-virtualized/pull/577.  
For a complete list of changes, refer to the [change log](https://github.com/bvaughn/react-virtualized/blob/master/CHANGELOG.md).

React version isn't a problem since we already use ```15.4.0```.  
I also didn't find any instance of ```CellMeasurer``` in our codebase.

**Places to check:**

- [Editor](http://calypso.localhost:3000/post) "Link to existing content" post selector
- [Editor](http://calypso.localhost:3000/post) "Page parent" post selector
- [Editor](http://calypso.localhost:3000/post) "Category" term selector
- [Settings > Writing](http://calypso.localhost:3000/settings/writing) taxonomy manager listing
- [Custom post type list screen](http://calypso.localhost:3000/types/post)