### PR TITLE
Framework: Remove renderSeparateTrees() Helper, Take Two

### DIFF
--- a/client/account-recovery/index.js
+++ b/client/account-recovery/index.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { makeLayout } from 'controller';
 import {
 	lostPassword,
 	forgotUsername,
@@ -16,12 +17,12 @@ import config from 'config';
 export default function( router ) {
 	// Main route for account recovery is the lost password page
 	if ( config.isEnabled( 'account-recovery' ) ) {
-		router( '/account-recovery', redirectLoggedIn, lostPassword );
-		router( '/account-recovery/forgot-username', redirectLoggedIn, forgotUsername );
-		router( '/account-recovery/reset-password', redirectLoggedIn, resetPassword );
-		router( '/account-recovery/reset-password/sms-form', redirectLoggedIn, resetPasswordSmsForm );
-		router( '/account-recovery/reset-password/email-form', redirectLoggedIn, resetPasswordEmailForm );
-		router( '/account-recovery/reset-password/transaction-id', redirectLoggedIn, resetPasswordByTransactionId );
-		router( '/account-recovery/reset-password/confirm', redirectLoggedIn, resetPasswordConfirmForm );
+		router( '/account-recovery', redirectLoggedIn, lostPassword, makeLayout );
+		router( '/account-recovery/forgot-username', redirectLoggedIn, forgotUsername, makeLayout );
+		router( '/account-recovery/reset-password', redirectLoggedIn, resetPassword, makeLayout );
+		router( '/account-recovery/reset-password/sms-form', redirectLoggedIn, resetPasswordSmsForm, makeLayout );
+		router( '/account-recovery/reset-password/email-form', redirectLoggedIn, resetPasswordEmailForm, makeLayout );
+		router( '/account-recovery/reset-password/transaction-id', redirectLoggedIn, resetPasswordByTransactionId, makeLayout );
+		router( '/account-recovery/reset-password/confirm', redirectLoggedIn, resetPasswordConfirmForm, makeLayout );
 	}
 }

--- a/client/boot/project/wordpress-com.js
+++ b/client/boot/project/wordpress-com.js
@@ -245,7 +245,7 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 			document.getElementsByClassName( 'wp-singletree-layout' ).length
 		);
 
-		const singleTreeSections = [ 'theme', 'themes' ];
+		const singleTreeSections = [ 'posts-custom', 'theme', 'themes' ];
 		const sectionName = getSectionName( context.store.getState() );
 		const isMultiTreeLayout = ! includes( singleTreeSections, sectionName );
 

--- a/client/boot/project/wordpress-com.js
+++ b/client/boot/project/wordpress-com.js
@@ -245,7 +245,7 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 			document.getElementsByClassName( 'wp-singletree-layout' ).length
 		);
 
-		const singleTreeSections = [ 'posts-custom', 'theme', 'themes' ];
+		const singleTreeSections = [ 'account-recovery', 'posts-custom', 'theme', 'themes' ];
 		const sectionName = getSectionName( context.store.getState() );
 		const isMultiTreeLayout = ! includes( singleTreeSections, sectionName );
 

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -17,8 +17,6 @@ import { makeLayoutMiddleware } from './shared.js';
 import { getCurrentUser } from 'state/current-user/selectors';
 import userFactory from 'lib/user';
 import sitesFactory from 'lib/sites-list';
-import debugFactory from 'debug';
-import { renderWithReduxStore } from 'lib/react-helpers';
 
 /**
  * Re-export
@@ -27,7 +25,6 @@ export { setSection } from './shared.js';
 
 const user = userFactory();
 const sites = sitesFactory();
-const debug = debugFactory( 'calypso:controller' );
 
 export const ReduxWrappedLayout = ( { store, primary, secondary } ) => (
 	<ReduxProvider store={ store }>
@@ -66,40 +63,8 @@ export function clientRouter( route, ...middlewares ) {
 }
 
 function render( context ) {
-	context.layout
-		? renderSingleTree( context )
-		: renderSeparateTrees( context );
-}
-
-function renderSingleTree( context ) {
 	ReactDom.render(
 		context.layout,
 		document.getElementById( 'wpcom' )
 	);
-}
-
-function renderSeparateTrees( context ) {
-	renderPrimary( context );
-	renderSecondary( context );
-}
-
-function renderPrimary( context ) {
-	const { primary, store } = context;
-
-	if ( primary ) {
-		debug( 'Rendering primary', primary );
-		renderWithReduxStore( primary, 'primary', store );
-	}
-}
-
-function renderSecondary( context ) {
-	const { secondary, store } = context;
-
-	if ( secondary === null ) {
-		debug( 'Unmounting secondary' );
-		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
-	} else if ( secondary !== undefined ) {
-		debug( 'Rendering secondary' );
-		renderWithReduxStore( secondary, 'secondary', store );
-	}
 }

--- a/client/my-sites/types/index.js
+++ b/client/my-sites/types/index.js
@@ -1,7 +1,8 @@
 /**
  * Internal dependencies
  */
-import { siteSelection, navigation, sites } from 'my-sites/controller';
+import { makeLayout } from 'controller';
+import { siteSelection, makeNavigation, sites } from 'my-sites/controller';
 import { list, redirect } from './controller';
 import config from 'config';
 
@@ -10,7 +11,7 @@ export default function( router ) {
 		return;
 	}
 
-	router( '/types/:type/:status?/:site', siteSelection, navigation, list );
-	router( '/types/:type', siteSelection, sites );
+	router( '/types/:type/:status?/:site', siteSelection, makeNavigation, list, makeLayout );
+	router( '/types/:type', siteSelection, sites, makeLayout );
 	router( '/types', redirect );
 }


### PR DESCRIPTION
(First attempt was #12610.)

This helper was only required in a very specific situation:
For the client-side rendering of isomorphic routes that didn't use the makeLayout middleware.

The rationale is that the `renderSeparateTrees()` helper would take React elements from `context.primary` and `context.secondary`, respectively, and render them to the corresponding `<div />`s.
This PR changes the last such routes (`/account-recovery` and `/types`) to use the `makeLayout` middleware (to construct a `<Layout />` component tree in `context.layout` from `context.primary` and `context.secondary`), and subsequently removes the now-obsolete `renderSeparateTrees()` helper.

To test:
* Land in different Calypso sections and navigate to others from there (try starting at `/design` in particular!). Make sure that there are no weird rendering or console errors. Some particularly interesting cases:
  * Land at `/design` and click on any theme thumbnail.
  * Land at `/design` (logged-in), click on the site selector in the sidebar, and click 'Add New WordPress' > 'WordPress.com site'. Click the browser's 'Back' button.
  * Land at `/design` while logged out. Click on any theme's '...' menu, and select 'Pick this Design'. Click the browser's 'Back' button.
  * _Changed over #12610_: On a site that supports CPTs, try viewing existing projects or testimonials from Calypso.
  * _Changed over #12610_: Test Account Recovery (`/account-recovery`, and [subroutes found here](https://github.com/Automattic/wp-calypso/blob/5dd706b8875999c60e501e67fbbfebbf383bfd70/client/account-recovery/index.js#L19-L25)), both logged-in and out. (Not sure how to cover all cases. 😄 Maybe @omarjackman knows?)

Prompted by https://github.com/Automattic/wp-calypso/pull/12521#discussion_r108334729