### PR TITLE
Editor: change "remove" icon from X to trash can.

### DIFF
--- a/client/components/tinymce/plugins/wpeditimage/plugin.js
+++ b/client/components/tinymce/plugins/wpeditimage/plugin.js
@@ -21,7 +21,7 @@ function wpEditImage( editor ) {
 
 	editor.addButton( 'wp_img_remove', {
 		tooltip: 'Remove',
-		icon: 'dashicon dashicons-no',
+		icon: 'dashicon dashicons-trash',
 		onclick: function() {
 			removeImage( editor.selection.getNode() );
 		}


### PR DESCRIPTION
Fixes #11921.

**Before:**
<img width="286" alt="screen shot 2017-03-29 at 2 30 25 pm" src="https://cloud.githubusercontent.com/assets/942359/24470251/48c5a4fa-148c-11e7-9dfc-273cf1538216.png">

**After:**
![screen shot 2017-03-29 at 2 28 11 pm](https://cloud.githubusercontent.com/assets/942359/24470204/1c83ef00-148c-11e7-8a10-112a734b1f6e.png)

**To test:**
1. Add an image to a post.
2. Click on the image to bring up the quick edit tooltip.
3. Make sure the "remove" icon is a trash can, and that clicking it properly removes the image from the post.