### PR TITLE
Plans: add FEATURE_REPUBLICIZE_SCHEDULING feature

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -63,6 +63,7 @@ export const FEATURE_BUSINESS_ONBOARDING = 'business-onboarding';
 export const FEATURE_UPLOAD_PLUGINS = 'upload-plugins';
 export const FEATURE_UPLOAD_THEMES = 'upload-themes';
 export const FEATURE_REPUBLICIZE = 'republicize';
+export const FEATURE_REPUBLICIZE_SCHEDULING = 'republicize-scheduling';
 
 // jetpack features constants
 export const FEATURE_STANDARD_SECURITY_TOOLS = 'standard-security-tools';
@@ -168,6 +169,7 @@ export const PLANS_LIST = {
 			FEATURE_WORDADS_INSTANT,
 			FEATURE_VIDEO_UPLOADS,
 			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
+			isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
 		] ),
 		getPromotedFeatures: () => [
 			FEATURE_CUSTOM_DOMAIN,
@@ -203,6 +205,7 @@ export const PLANS_LIST = {
 			FEATURE_WORDADS_INSTANT,
 			FEATURE_VIDEO_UPLOADS,
 			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
+			isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
 			FEATURE_BUSINESS_ONBOARDING,
 			FEATURE_ADVANCED_SEO,
 			isATEnabledForCurrentSite() && FEATURE_UPLOAD_PLUGINS,
@@ -282,6 +285,7 @@ export const PLANS_LIST = {
 			FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM,
 			FEATURE_MALWARE_SCANNING_DAILY,
 			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
+			isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
 	},
@@ -319,6 +323,7 @@ export const PLANS_LIST = {
 			FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM,
 			FEATURE_MALWARE_SCANNING_DAILY,
 			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
+			isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' )
 	},
@@ -611,6 +616,13 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Targeted Social Media' ),
 		getDescription: () => i18n.translate(
 			'Share your posts as many times as you like on all your connected social media accounts using Publicize.'
+		)
+	},
+	[ FEATURE_REPUBLICIZE_SCHEDULING ]: {
+		getSlug: () => FEATURE_REPUBLICIZE_SCHEDULING,
+		getTitle: () => i18n.translate( 'Targeted Social Media' ),
+		getDescription: () => i18n.translate(
+			'Use Publicize to share your post on social media whenever you want, as many times as you want.'
 		)
 	},
 	[ FEATURE_NO_BRANDING ]: {


### PR DESCRIPTION
This PR defines the `FEATURE_REPUBLICIZE_SCHEDULING` flag and adds into `Premium` and `Business` plan.

It's part of this implementation #12471

### Testing

Just apply the patch and test that the app is working well, especially take a look to the `PostShare` section of the post into the posts-list page.