### PR TITLE
Publicize: additional sharing preview components

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -152,6 +152,10 @@
 @import 'components/select-dropdown/style';
 @import 'components/seo/style';
 @import 'components/share/facebook-share-preview/style';
+@import 'components/share/google-plus-share-preview/style';
+@import 'components/share/linkedin-share-preview/style';
+@import 'components/share/tumblr-share-preview/style';
+@import 'components/share/path-share-preview/style';
 @import 'components/share/twitter-share-preview/style';
 @import 'blocks/upgrade-nudge-expanded/style';
 @import 'components/seo/preview-upgrade-nudge/style';

--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -11,6 +11,10 @@ import { get, find } from 'lodash';
  */
 import { getPostImage } from './utils';
 import FacebookSharePreview from 'components/share/facebook-share-preview';
+import GooglePlusSharePreview from 'components/share/google-plus-share-preview';
+import LinkedinSharePreview from 'components/share/linkedin-share-preview';
+import PathSharePreview from 'components/share/path-share-preview';
+import TumblrSharePreview from 'components/share/tumblr-share-preview';
 import TwitterSharePreview from 'components/share/twitter-share-preview';
 import VerticalMenu from 'components/vertical-menu';
 import { SocialItem } from 'components/vertical-menu/items';
@@ -34,7 +38,14 @@ class SharingPreviewPane extends PureComponent {
 	};
 
 	static defaultProps = {
-		services: [ 'facebook', 'twitter' ]
+		services: [
+			'facebook',
+			'twitter',
+			'google_plus',
+			'linkedin',
+			'tumblr',
+			'path',
+		]
 	};
 
 	state = {
@@ -78,6 +89,14 @@ class SharingPreviewPane extends PureComponent {
 				return <TwitterSharePreview
 					{ ...previewProps }
 					externalDisplay={ externalDisplay } />;
+			case 'google_plus':
+				return <GooglePlusSharePreview { ...previewProps } />;
+			case 'linkedin':
+				return <LinkedinSharePreview { ...previewProps } />;
+			case 'path':
+				return <PathSharePreview { ...previewProps } />;
+			case 'tumblr':
+				return <TumblrSharePreview { ...previewProps } />;
 			default:
 				return null;
 		}

--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -44,14 +44,14 @@ export class FacebookSharePreview extends PureComponent {
 									{
 										translate( 'published an article on {{a}}WordPress{{/a}}', {
 											components: {
-												a: <a href="#" />
+												a: <a href="#" className="facebook-share-preview__profile-wp-link" />
 											}
 										} )
 									}
 								</span>
 							</div>
 							<div className="facebook-share-preview__meta-line">
-								<a href="https://wordpress.com">
+								<a className="facebook-share-preview__meta-link" href="https://wordpress.com">
 									{ translate( 'WordPress' ) }
 								</a>
 							</div>

--- a/client/components/share/facebook-share-preview/style.scss
+++ b/client/components/share/facebook-share-preview/style.scss
@@ -8,10 +8,17 @@
 	max-width: 486px;
 	padding: 12px;
 	-webkit-overflow-scrolling: touch;
-}
 
-.facebook-share-preview a {
-	color: #365899;
+	// Nesting to win main.scss
+	.facebook-share-preview__profile-name,
+	.facebook-share-preview__profile-wp-link,
+	.facebook-share-preview__article-url {
+		color: #365899;
+	}
+
+	.facebook-share-preview__meta-link {
+		color: #90949c;
+	}
 }
 
 .facebook-share-preview__header {
@@ -50,10 +57,6 @@
 	color: #90949c;
 	font-size: 12px;
 	line-height: 1.34;
-}
-
-.facebook-share-preview .facebook-share-preview__meta-line a {
-	color: #90949c;
 }
 
 .facebook-share-preview__message p {

--- a/client/components/share/google-plus-share-preview/index.jsx
+++ b/client/components/share/google-plus-share-preview/index.jsx
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+
+export class GooglePlusSharePreview extends PureComponent {
+
+	static PropTypes = {
+		articleUrl: PropTypes.string,
+		externalProfilePicture: PropTypes.string,
+		externalProfileUrl: PropTypes.string,
+		externalName: PropTypes.string,
+		imageUrl: PropTypes.string,
+		message: PropTypes.string,
+	};
+
+	render() {
+		const {
+			articleUrl,
+			externalProfilePicture,
+			externalProfileUrl,
+			externalName,
+			imageUrl,
+			message,
+			translate
+		} = this.props;
+
+		return (
+			<div className="google-plus-share-preview">
+				<div className="google-plus-share-preview__content">
+					<div className="google-plus-share-preview__header">
+						<div className="google-plus-share-preview__profile-picture-part">
+							<img
+								className="google-plus-share-preview__profile-picture"
+								src={ externalProfilePicture }
+							/>
+						</div>
+						<div className="google-plus-share-preview__profile-line-part">
+							<div className="google-plus-share-preview__profile-line">
+								<a className="google-plus-share-preview__profile-name" href={ externalProfileUrl }>
+									{ externalName }
+								</a>
+								<span>
+									{
+										translate( 'published an article on {{a}}WordPress{{/a}}', {
+											components: {
+												a: <a href="#" />
+											}
+										} )
+									}
+								</span>
+							</div>
+							<div className="google-plus-share-preview__meta-line">
+								<a href="https://wordpress.com">
+									{ translate( 'WordPress' ) }
+								</a>
+							</div>
+						</div>
+					</div>
+					<div className="google-plus-share-preview__body">
+						<div className="google-plus-share-preview__message">
+							{ message }
+						</div>
+						<div className="google-plus-share-preview__article-url-line">
+							<a className="google-plus-share-preview__article-url"
+								href={ articleUrl }>
+								{ articleUrl }
+							</a>
+						</div>
+						{ imageUrl &&
+							<div className="google-plus-share-preview__image-wrapper">
+								<img
+									className="google-plus-share-preview__image"
+									src={ imageUrl }
+								/>
+							</div>
+						}
+					</div>
+				</div>
+			</div>
+		);
+	}
+}
+
+export default localize( GooglePlusSharePreview );

--- a/client/components/share/google-plus-share-preview/index.jsx
+++ b/client/components/share/google-plus-share-preview/index.jsx
@@ -22,8 +22,7 @@ export class GooglePlusSharePreview extends PureComponent {
 			externalProfileUrl,
 			externalName,
 			imageUrl,
-			message,
-			translate
+			message
 		} = this.props;
 
 		return (
@@ -41,20 +40,6 @@ export class GooglePlusSharePreview extends PureComponent {
 								<a className="google-plus-share-preview__profile-name" href={ externalProfileUrl }>
 									{ externalName }
 								</a>
-								<span>
-									{
-										translate( 'published an article on {{a}}WordPress{{/a}}', {
-											components: {
-												a: <a href="#" />
-											}
-										} )
-									}
-								</span>
-							</div>
-							<div className="google-plus-share-preview__meta-line">
-								<a href="https://wordpress.com">
-									{ translate( 'WordPress' ) }
-								</a>
 							</div>
 						</div>
 					</div>
@@ -62,18 +47,22 @@ export class GooglePlusSharePreview extends PureComponent {
 						<div className="google-plus-share-preview__message">
 							{ message }
 						</div>
-						<div className="google-plus-share-preview__article-url-line">
-							<a className="google-plus-share-preview__article-url"
-								href={ articleUrl }>
-								{ articleUrl }
+						<div className="google-plus-share-preview__article-summary">
+							Summury of the post goes here.
+						</div>
+						<div className="google-plus-share-preview__article-title">
+							<a className="google-plus-share-preview__article-url" href={ articleUrl }>
+							Title of the post goes here.
 							</a>
 						</div>
 						{ imageUrl &&
 							<div className="google-plus-share-preview__image-wrapper">
+								<a href={ articleUrl }>
 								<img
 									className="google-plus-share-preview__image"
 									src={ imageUrl }
 								/>
+								</a>
 							</div>
 						}
 					</div>

--- a/client/components/share/google-plus-share-preview/style.scss
+++ b/client/components/share/google-plus-share-preview/style.scss
@@ -15,6 +15,10 @@
 	padding: 16px;
 }
 
+.google-plus-share-preview__profile-picture-part {
+	flex: 0 0 36px;
+}
+
 .google-plus-share-preview__profile-picture {
 	border-radius: 50%;
 	display: block;

--- a/client/components/share/google-plus-share-preview/style.scss
+++ b/client/components/share/google-plus-share-preview/style.scss
@@ -1,0 +1,65 @@
+.google-plus-share-preview {
+	background-color: #fefefe;
+	border-radius: 2px;
+	box-shadow: 0 1px 4px 0 rgba(0,0,0,0.14);
+	color: rgba(0, 0, 0, 0.87);
+	font-family: Roboto, RobotoDraft, Helvetica, Arial, sans-serif;
+	margin: 0 auto;
+	max-width: 530px;
+	width: 100%;
+}
+
+.google-plus-share-preview__header {
+	align-items: center;
+	display: flex;
+	padding: 16px;
+}
+
+.google-plus-share-preview__profile-picture {
+	border-radius: 50%;
+	display: block;
+	height: 36px;
+	width: 36px;
+}
+
+.google-plus-share-preview__profile-line {
+	font-size: 14px;
+	font-weight: 500;
+	line-height: 1.285714286;
+	margin-left: 6px;
+}
+
+.google-plus-share-preview__message,
+.google-plus-share-preview__article-summary {
+	font-size: 14px;
+	line-height: 20px;
+	margin: 0 16px 16px;
+	word-wrap: break-word;
+}
+
+.google-plus-share-preview__article-title {
+	border-top: 1px solid #ebebeb;
+	display: -webkit-box;
+	font-size: 20px;
+	font-weight: 300;
+	line-height: 1.4;
+	margin: 16px;
+	max-height: 56px;
+	overflow: hidden;
+	padding-top: 16px;
+	text-overflow: ellipsis;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+}
+
+.google-plus-share-preview__article-url {
+	color: rgba(0, 0, 0, 0.87);
+
+	&:hover {
+		color: rgba(0, 0, 0, 0.87);
+	}
+}
+
+.google-plus-share-preview__image {
+	display: block;
+}

--- a/client/components/share/google-plus-share-preview/style.scss
+++ b/client/components/share/google-plus-share-preview/style.scss
@@ -33,6 +33,10 @@
 	margin-left: 6px;
 }
 
+.google-plus-share-preview__profile-name {
+	color: rgba(0, 0, 0, 0.87);
+}
+
 .google-plus-share-preview__message,
 .google-plus-share-preview__article-summary {
 	font-size: 14px;

--- a/client/components/share/google-plus-share-preview/style.scss
+++ b/client/components/share/google-plus-share-preview/style.scss
@@ -7,6 +7,23 @@
 	margin: 0 auto;
 	max-width: 530px;
 	width: 100%;
+
+	// Nesting to win main.scss
+	.google-plus-share-preview__profile-name {
+		color: rgba(0, 0, 0, 0.87);
+
+		&:hover {
+			color: rgba(0, 0, 0, 0.87);
+		}
+	}
+
+	.google-plus-share-preview__article-url {
+		color: rgba(0, 0, 0, 0.87);
+
+		&:hover {
+			color: rgba(0, 0, 0, 0.87);
+		}
+	}
 }
 
 .google-plus-share-preview__header {
@@ -33,16 +50,12 @@
 	margin-left: 6px;
 }
 
-.google-plus-share-preview__profile-name {
-	color: rgba(0, 0, 0, 0.87);
-}
-
 .google-plus-share-preview__message,
 .google-plus-share-preview__article-summary {
 	font-size: 14px;
 	line-height: 20px;
 	margin: 0 16px 16px;
-	word-wrap: break-word;
+	word-break: break-word;
 }
 
 .google-plus-share-preview__article-title {
@@ -58,14 +71,6 @@
 	text-overflow: ellipsis;
 	-webkit-box-orient: vertical;
 	-webkit-line-clamp: 2;
-}
-
-.google-plus-share-preview__article-url {
-	color: rgba(0, 0, 0, 0.87);
-
-	&:hover {
-		color: rgba(0, 0, 0, 0.87);
-	}
 }
 
 .google-plus-share-preview__image {

--- a/client/components/share/linkedin-share-preview/index.jsx
+++ b/client/components/share/linkedin-share-preview/index.jsx
@@ -56,16 +56,14 @@ export class LinkedinSharePreview extends PureComponent {
 								</a>
 							</div>
 						}
-						<div className="linkedin-share-preview__message-part">
-							<a href={ articleUrl }>
-								<div className="linkedin-share-preview__message">
-									{ message }
-								</div>
-								<div className="linkedin-share-preview__site-url">
-									siteUrl
-								</div>
-							</a>
-						</div>
+						<a href={ articleUrl }>
+							<div className="linkedin-share-preview__message">
+								{ message }
+							</div>
+							<div className="linkedin-share-preview__site-url">
+								siteUrl
+							</div>
+						</a>
 					</div>
 				</div>
 			</div>

--- a/client/components/share/linkedin-share-preview/index.jsx
+++ b/client/components/share/linkedin-share-preview/index.jsx
@@ -22,8 +22,7 @@ export class LinkedinSharePreview extends PureComponent {
 			externalProfileUrl,
 			externalName,
 			imageUrl,
-			message,
-			translate
+			message
 		} = this.props;
 		return (
 			<div className="linkedin-share-preview">
@@ -40,41 +39,33 @@ export class LinkedinSharePreview extends PureComponent {
 								<a className="linkedin-share-preview__profile-name" href={ externalProfileUrl }>
 									{ externalName }
 								</a>
-								<span>
-									{
-										translate( 'published an article on {{a}}WordPress{{/a}}', {
-											components: {
-												a: <a href="#" />
-											}
-										} )
-									}
-								</span>
 							</div>
 							<div className="linkedin-share-preview__meta-line">
-								<a href="https://wordpress.com">
-									{ translate( 'WordPress' ) }
-								</a>
+								companyName
 							</div>
 						</div>
 					</div>
 					<div className="linkedin-share-preview__body">
-						<div className="linkedin-share-preview__message">
-							{ message }
-						</div>
-						<div className="linkedin-share-preview__article-url-line">
-							<a className="linkedin-share-preview__article-url"
-								href={ articleUrl }>
-								{ articleUrl }
-							</a>
-						</div>
 						{ imageUrl &&
 							<div className="linkedin-share-preview__image-wrapper">
-								<img
-									className="linkedin-share-preview__image"
-									src={ imageUrl }
-								/>
+								<a href={ articleUrl }>
+									<img
+										className="linkedin-share-preview__image"
+										src={ imageUrl }
+									/>
+								</a>
 							</div>
 						}
+						<div className="linkedin-share-preview__message-part">
+							<a href={ articleUrl }>
+								<div className="linkedin-share-preview__message">
+									{ message }
+								</div>
+								<div className="linkedin-share-preview__site-url">
+									siteUrl
+								</div>
+							</a>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/client/components/share/linkedin-share-preview/index.jsx
+++ b/client/components/share/linkedin-share-preview/index.jsx
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+
+export class LinkedinSharePreview extends PureComponent {
+
+	static PropTypes = {
+		articleUrl: PropTypes.string,
+		externalProfilePicture: PropTypes.string,
+		externalProfileUrl: PropTypes.string,
+		externalName: PropTypes.string,
+		imageUrl: PropTypes.string,
+		message: PropTypes.string,
+	};
+
+	render() {
+		const {
+			articleUrl,
+			externalProfilePicture,
+			externalProfileUrl,
+			externalName,
+			imageUrl,
+			message,
+			translate
+		} = this.props;
+		return (
+			<div className="linkedin-share-preview">
+				<div className="linkedin-share-preview__content">
+					<div className="linkedin-share-preview__header">
+						<div className="linkedin-share-preview__profile-picture-part">
+							<img
+								className="linkedin-share-preview__profile-picture"
+								src={ externalProfilePicture }
+							/>
+						</div>
+						<div className="linkedin-share-preview__profile-line-part">
+							<div className="linkedin-share-preview__profile-line">
+								<a className="linkedin-share-preview__profile-name" href={ externalProfileUrl }>
+									{ externalName }
+								</a>
+								<span>
+									{
+										translate( 'published an article on {{a}}WordPress{{/a}}', {
+											components: {
+												a: <a href="#" />
+											}
+										} )
+									}
+								</span>
+							</div>
+							<div className="linkedin-share-preview__meta-line">
+								<a href="https://wordpress.com">
+									{ translate( 'WordPress' ) }
+								</a>
+							</div>
+						</div>
+					</div>
+					<div className="linkedin-share-preview__body">
+						<div className="linkedin-share-preview__message">
+							{ message }
+						</div>
+						<div className="linkedin-share-preview__article-url-line">
+							<a className="linkedin-share-preview__article-url"
+								href={ articleUrl }>
+								{ articleUrl }
+							</a>
+						</div>
+						{ imageUrl &&
+							<div className="linkedin-share-preview__image-wrapper">
+								<img
+									className="linkedin-share-preview__image"
+									src={ imageUrl }
+								/>
+							</div>
+						}
+					</div>
+				</div>
+			</div>
+		);
+	}
+}
+
+export default localize( LinkedinSharePreview );

--- a/client/components/share/linkedin-share-preview/style.scss
+++ b/client/components/share/linkedin-share-preview/style.scss
@@ -42,8 +42,8 @@
 
 .linkedin-share-preview__meta-line {
 	color: rgba(0, 0, 0, 0.55);
-    font-size: 13px;
-    line-height: 16px;
+	font-size: 13px;
+	line-height: 16px;
 }
 
 .linkedin-share-preview__body {

--- a/client/components/share/linkedin-share-preview/style.scss
+++ b/client/components/share/linkedin-share-preview/style.scss
@@ -5,6 +5,11 @@
 	margin: 0 auto;
 	max-width: 552px;
 	padding: 16px;
+
+	// Nesting to win main.scss
+	.linkedin-share-preview__profile-name {
+		color: rgba(0, 0, 0, 0.85);
+	}
 }
 
 .linkedin-share-preview__header {
@@ -32,7 +37,6 @@
 }
 
 .linkedin-share-preview__profile-name {
-	color: rgba(0, 0, 0, 0.85);
 	font-weight: 600;
 }
 
@@ -86,5 +90,5 @@
 	line-height: 16px;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	word-wrap: break-word;
+	word-break: break-word;
 }

--- a/client/components/share/linkedin-share-preview/style.scss
+++ b/client/components/share/linkedin-share-preview/style.scss
@@ -1,0 +1,90 @@
+.linkedin-share-preview {
+	background: $white;
+	box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), 0 2px 3px rgba(0, 0, 0, 0.2);
+	font-family: Source Sans Pro,Helvetica,Arial,sans-serif,Hiragino Kaku Gothic Pro,Meiryo,Hiragino Sans GB W3,Noto Naskh Arabic,Droid Arabic Naskh,Geeza Pro,Simplified Arabic,Noto Sans Thai,Thonburi,Dokchampa,Droid Sans Thai,Droid Sans Fallback,-apple-system,'.SFNSDisplay-Regular',Heiti SC,Microsoft Yahei,Segoe UI;
+	margin: 0 auto;
+	max-width: 552px;
+	padding: 16px;
+}
+
+.linkedin-share-preview__header {
+	display: flex;
+}
+
+.linkedin-share-preview__profile-picture-part {
+	flex: 0 0 48px;
+}
+
+.linkedin-share-preview__profile-picture {
+	border-radius: 50%;
+	display: block;
+	height: 48px;
+	width: 48px;
+}
+
+.linkedin-share-preview__profile-line-part {
+	margin-left: 8px;
+}
+
+.linkedin-share-preview__profile-line {
+	font-size: 15px;
+	line-height: 20px;
+}
+
+.linkedin-share-preview__profile-name {
+	color: rgba(0, 0, 0, 0.85);
+	font-weight: 600;
+}
+
+.linkedin-share-preview__meta-line {
+	color: rgba(0, 0, 0, 0.55);
+    font-size: 13px;
+    line-height: 16px;
+}
+
+.linkedin-share-preview__body {
+	align-items: center;
+	border-radius: 2px;
+	box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+	display: flex;
+	margin-top: 16px;
+	padding: 8px;
+}
+
+.linkedin-share-preview__image-wrapper {
+	flex: 0 0 138px;
+	height: 72px;
+	margin-right: 8px;
+	max-width: 138px;
+	overflow: hidden;
+	position: relative;
+}
+
+.linkedin-share-preview__image {
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+}
+
+.linkedin-share-preview__message {
+	color: rgba(0, 0, 0, 0.85);
+	display: -webkit-box;
+	font-size: 15px;
+	font-weight: 600;
+	line-height: 16px;
+	max-height: 40px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+}
+
+.linkedin-share-preview__site-url {
+	color: rgba(0, 0, 0, 0.55);
+	font-size: 13px;
+	font-weight: 400;
+	line-height: 16px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	word-wrap: break-word;
+}

--- a/client/components/share/path-share-preview/index.jsx
+++ b/client/components/share/path-share-preview/index.jsx
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+
+export class PathSharePreview extends PureComponent {
+
+	static PropTypes = {
+		articleUrl: PropTypes.string,
+		externalProfilePicture: PropTypes.string,
+		externalProfileUrl: PropTypes.string,
+		externalName: PropTypes.string,
+		imageUrl: PropTypes.string,
+		message: PropTypes.string,
+	};
+
+	render() {
+		const {
+			articleUrl,
+			externalProfilePicture,
+			externalProfileUrl,
+			externalName,
+			imageUrl,
+			message,
+			translate
+		} = this.props;
+		return (
+			<div className="path-share-preview">
+				<div className="path-share-preview__content">
+					<div className="path-share-preview__header">
+						<div className="path-share-preview__profile-picture-part">
+							<img
+								className="path-share-preview__profile-picture"
+								src={ externalProfilePicture }
+							/>
+						</div>
+						<div className="path-share-preview__profile-line-part">
+							<div className="path-share-preview__profile-line">
+								<a className="path-share-preview__profile-name" href={ externalProfileUrl }>
+									{ externalName }
+								</a>
+								<span>
+									{
+										translate( 'published an article on {{a}}WordPress{{/a}}', {
+											components: {
+												a: <a href="#" />
+											}
+										} )
+									}
+								</span>
+							</div>
+							<div className="path-share-preview__meta-line">
+								<a href="https://wordpress.com">
+									{ translate( 'WordPress' ) }
+								</a>
+							</div>
+						</div>
+					</div>
+					<div className="path-share-preview__body">
+						<div className="path-share-preview__message">
+							{ message }
+						</div>
+						<div className="path-share-preview__article-url-line">
+							<a className="path-share-preview__article-url"
+								href={ articleUrl }>
+								{ articleUrl }
+							</a>
+						</div>
+						{ imageUrl &&
+							<div className="path-share-preview__image-wrapper">
+								<img
+									className="path-share-preview__image"
+									src={ imageUrl }
+								/>
+							</div>
+						}
+					</div>
+				</div>
+			</div>
+		);
+	}
+}
+
+export default localize( PathSharePreview );
+

--- a/client/components/share/path-share-preview/index.jsx
+++ b/client/components/share/path-share-preview/index.jsx
@@ -19,62 +19,49 @@ export class PathSharePreview extends PureComponent {
 		const {
 			articleUrl,
 			externalProfilePicture,
-			externalProfileUrl,
 			externalName,
 			imageUrl,
-			message,
-			translate
+			message
 		} = this.props;
 		return (
 			<div className="path-share-preview">
 				<div className="path-share-preview__content">
 					<div className="path-share-preview__header">
-						<div className="path-share-preview__profile-picture-part">
+						<img
+							className="path-share-preview__profile-picture"
+							src={ externalProfilePicture }
+						/>
+						<span className="path-share-preview__profile-name">
+							{ externalName }
+						</span>
+					</div>
+					{ imageUrl &&
+						<div className="path-share-preview__image-wrapper">
 							<img
-								className="path-share-preview__profile-picture"
-								src={ externalProfilePicture }
+								className="path-share-preview__image"
+								src={ imageUrl }
 							/>
 						</div>
-						<div className="path-share-preview__profile-line-part">
-							<div className="path-share-preview__profile-line">
-								<a className="path-share-preview__profile-name" href={ externalProfileUrl }>
-									{ externalName }
-								</a>
-								<span>
-									{
-										translate( 'published an article on {{a}}WordPress{{/a}}', {
-											components: {
-												a: <a href="#" />
-											}
-										} )
-									}
-								</span>
-							</div>
-							<div className="path-share-preview__meta-line">
-								<a href="https://wordpress.com">
-									{ translate( 'WordPress' ) }
-								</a>
-							</div>
-						</div>
-					</div>
+					}
 					<div className="path-share-preview__body">
-						<div className="path-share-preview__message">
-							{ message }
-						</div>
-						<div className="path-share-preview__article-url-line">
-							<a className="path-share-preview__article-url"
-								href={ articleUrl }>
-								{ articleUrl }
-							</a>
-						</div>
-						{ imageUrl &&
-							<div className="path-share-preview__image-wrapper">
-								<img
-									className="path-share-preview__image"
-									src={ imageUrl }
-								/>
+						<img
+							className="path-share-preview__profile-picture"
+							src={ externalProfilePicture }
+						/>
+						<div className="path-share-preview__message-part">
+							<div className="path-share-preview__message">
+								<span className="path-share-preview__profile-name">{ externalName }:</span> { message }
 							</div>
-						}
+							<div className="path-share-preview__summery">
+								Summury of the post goes here.
+							</div>
+							<div className="path-share-preview__article-url-line">
+								<a className="path-share-preview__article-url"
+									href={ articleUrl }>
+									{ articleUrl }
+								</a>
+							</div>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/client/components/share/path-share-preview/style.scss
+++ b/client/components/share/path-share-preview/style.scss
@@ -68,5 +68,5 @@
 
 .path-share-preview__article-url-line {
 	margin-bottom: 0;
-    word-break: break-word;
+	word-break: break-word;
 }

--- a/client/components/share/path-share-preview/style.scss
+++ b/client/components/share/path-share-preview/style.scss
@@ -1,0 +1,72 @@
+.path-share-preview {
+	background: $white;
+	border-bottom: 1px solid #e4e4e4;
+	color: #333;
+	font-family: Helvetica Neue, Helvetica,Arial, Lucida Grande, sans-serif;
+
+	// Nesting to win main.scss
+	.path-share-preview__article-url {
+		color: #888;
+
+		&:hover {
+			color: #888;
+		}
+	}
+}
+
+.path-share-preview__header {
+	border-bottom: 1px solid #f1f1f1;
+	display: flex;
+	padding: 19px 9px 10px;
+}
+
+.path-share-preview__profile-picture {
+	border-radius: 2px;
+	display: block;
+	flex: 0 0 35px;
+	height: 35px;
+	width: 35px;
+}
+
+.path-share-preview__profile-name {
+    font-weight: 500;
+    font-size: 15px;
+    line-height: 16px;
+    padding-left: 9px;
+}
+
+.path-share-preview__image {
+	display: block;
+}
+
+.path-share-preview__body {
+	display: flex;
+	padding: 13px 10px 13px 9px;
+}
+
+.path-share-preview__body .path-share-preview__profile-picture {
+	flex: 0 0 30px;
+	height: 30px;
+	width: 30px;
+}
+
+.path-share-preview__message-part {
+	padding-left: 9px;
+}
+
+.path-share-preview__message,
+.path-share-preview__summery,
+.path-share-preview__article-url-line {
+	font-size: 15px;
+	line-height: 19px;
+	margin-bottom: 17px;
+}
+
+.path-share-preview__message .path-share-preview__profile-name {
+	padding-left: 0;
+}
+
+.path-share-preview__article-url-line {
+	margin-bottom: 0;
+    word-break: break-word;
+}

--- a/client/components/share/tumblr-share-preview/index.jsx
+++ b/client/components/share/tumblr-share-preview/index.jsx
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+
+/* Internal dependecies */
+import { localize } from 'i18n-calypso';
+
+export class TumblrSharePreview extends PureComponent {
+	render() {
+		const {
+			externalProfilePicture,
+			externalProfileUrl,
+			externalDisplay,
+			externalName,
+			message,
+			articleUrl,
+			imageUrl,
+			postTitle,
+			translate,
+		} = this.props;
+
+		return (
+			<div className="tumblr-share-preview">
+				<div className="tumblr-share-preview__content">
+					<div className="tumblr-share-preview__profile-picture-part">
+						<img
+							className="tumblr-share-preview__profile-picture"
+							src={ externalProfilePicture }
+						/>
+					</div>
+					<div className="tumblr-share-preview__content-part">
+						<div className="tumblr-share-preview__profile-line">
+							<a
+								className="tumblr-share-preview__profile-name"
+								href={ externalProfileUrl }
+							>
+								{ externalDisplay }
+							</a>
+							<a
+								className="tumblr-share-preview__profile-handle"
+								href={ externalProfileUrl }
+							>
+								{ externalName }
+							</a>
+						</div>
+						<div className="tumblr-share-preview__post-title">
+							<h1> { postTitle } </h1>
+						</div>
+						{ imageUrl &&
+							<div className="tumblr-share-preview__image-wrapper">
+								<img
+									className="tumblr-share-preview__image"
+									src={ imageUrl }
+								/>
+							</div>
+						}
+						<div className="tumblr-share-preview__message">
+							<blockquote>
+								{ message }
+							</blockquote>
+						</div>
+						<div className="tumblr-share-preview__article-url-line">
+							<a className="tumblr-share-preview__article-url"
+								href={ articleUrl }>
+								{ translate( 'View On WordPress' ) }
+							</a>
+						</div>
+					</div>
+				</div>
+			</div>
+		);
+	}
+}
+
+export default localize( TumblrSharePreview );
+

--- a/client/components/share/tumblr-share-preview/index.jsx
+++ b/client/components/share/tumblr-share-preview/index.jsx
@@ -11,7 +11,6 @@ export class TumblrSharePreview extends PureComponent {
 		const {
 			externalProfilePicture,
 			externalProfileUrl,
-			externalDisplay,
 			externalName,
 			message,
 			articleUrl,
@@ -35,17 +34,20 @@ export class TumblrSharePreview extends PureComponent {
 								className="tumblr-share-preview__profile-name"
 								href={ externalProfileUrl }
 							>
-								{ externalDisplay }
-							</a>
-							<a
-								className="tumblr-share-preview__profile-handle"
-								href={ externalProfileUrl }
-							>
 								{ externalName }
 							</a>
+							<span className="tumblr-share-preview__profile-wp">
+								{ translate( 'WordPress' ) }
+							</span>
 						</div>
-						<div className="tumblr-share-preview__post-title">
-							<h1> { postTitle } </h1>
+						<div className="tumblr-share-preview__post-title-part">
+							<h1 className="tumblr-share-preview__post-title">{ postTitle }</h1>
+						</div>
+						<div className="tumblr-share-preview__message">
+							<a className="tumblr-share-preview__message-link"
+								href={ articleUrl }>
+								{ message }
+							</a>
 						</div>
 						{ imageUrl &&
 							<div className="tumblr-share-preview__image-wrapper">
@@ -55,13 +57,13 @@ export class TumblrSharePreview extends PureComponent {
 								/>
 							</div>
 						}
-						<div className="tumblr-share-preview__message">
-							<blockquote>
-								{ message }
+						<div className="tumblr-share-preview__summery-part">
+							<blockquote className="tumblr-share-preview__summery">
+								Post contents goes here.
 							</blockquote>
 						</div>
-						<div className="tumblr-share-preview__article-url-line">
-							<a className="tumblr-share-preview__article-url"
+						<div className="tumblr-share-preview__article-link-line">
+							<a className="tumblr-share-preview__article-link"
 								href={ articleUrl }>
 								{ translate( 'View On WordPress' ) }
 							</a>

--- a/client/components/share/tumblr-share-preview/style.scss
+++ b/client/components/share/tumblr-share-preview/style.scss
@@ -3,6 +3,17 @@
 	font-family: Helvetica Neue, HelveticaNeue, Helvetica, Arial, sans-serif;
 	margin: 0 auto;
 	max-width: 624px;
+
+	// Nesting to win main.scss
+	.tumblr-share-preview__profile-name,
+	.tumblr-share-preview__message-link,
+	.tumblr-share-preview__article-link {
+		color: #444;
+
+		&:hover {
+			color: #444;
+		}
+	}
 }
 
 .tumblr-share-preview__content {
@@ -30,7 +41,6 @@
 }
 
 .tumblr-share-preview__profile-name {
-	color: #444;
 	font-weight: bold;
 }
 
@@ -68,11 +78,6 @@
 .tumblr-share-preview__message-link,
 .tumblr-share-preview__article-link {
 	border-bottom: 1px solid #d1d1d1;
-	color: #444;
-
-	&:hover {
-		color: #444;
-	}
 }
 
 .tumblr-share-preview__summery {

--- a/client/components/share/tumblr-share-preview/style.scss
+++ b/client/components/share/tumblr-share-preview/style.scss
@@ -1,0 +1,84 @@
+.tumblr-share-preview {
+	color: #444;
+	font-family: Helvetica Neue, HelveticaNeue, Helvetica, Arial, sans-serif;
+	margin: 0 auto;
+	max-width: 624px;
+}
+
+.tumblr-share-preview__content {
+	display: flex;
+}
+
+.tumblr-share-preview__profile-picture-part {
+	flex: 0 0 10%;
+	margin-right: 20px;
+}
+
+.tumblr-share-preview__content-part {
+	background-color: $white;
+	border-radius: 3px;
+	flex: 1 1 auto;
+	padding: 15px 20px;
+}
+
+.tumblr-share-preview__profile-line {
+	display: flex;
+	font-size: 13px;
+	justify-content: space-between;
+	line-height: 20px;
+	margin-bottom: 13px;
+}
+
+.tumblr-share-preview__profile-name {
+	color: #444;
+	font-weight: bold;
+}
+
+.tumblr-share-preview__profile-wp {
+	color: #8f8f8f;
+}
+
+.tumblr-share-preview__post-title {
+    font-family: Gibson, Helvetica Neue, HelveticaNeue, Helvetica, Arial, sans-serif;
+    font-weight: 400;
+    font-size: 36px;
+    line-height: 47px;
+    margin-bottom: 10px;
+}
+
+.tumblr-share-preview__image-wrapper {
+	margin: 15px 0;
+}
+
+.tumblr-share-preview__image {
+	width: 300px;
+}
+
+.tumblr-share-preview__message,
+.tumblr-share-preview__summery,
+.tumblr-share-preview__article-link-line {
+	font-size: 14px;
+	line-height: 21px;
+}
+
+.tumblr-share-preview__message {
+	margin-bottom: 15px;
+}
+
+.tumblr-share-preview__message-link,
+.tumblr-share-preview__article-link {
+	border-bottom: 1px solid #d1d1d1;
+	color: #444;
+
+	&:hover {
+		color: #444;
+	}
+}
+
+.tumblr-share-preview__summery {
+	background: transparent;
+	border-left: 2px solid #e7e7e7;
+	margin-top: 15px;
+	margin-bottom: 15px;
+	padding: 0 0 0 18px;
+}

--- a/client/components/share/twitter-share-preview/style.scss
+++ b/client/components/share/twitter-share-preview/style.scss
@@ -16,6 +16,10 @@
 
 	.twitter-share-preview__profile-name {
 		color: #14171a;
+
+		&:hover {
+			color: #0084b4;
+		}
 	}
 
 	.twitter-share-preview__article-url {
@@ -39,12 +43,10 @@
 }
 
 .twitter-share-preview__profile-name {
-	color: #14171a;
 	font-weight: bold;
 	margin-right: 5px;
 
 	&:hover {
-		color: #0084b4;
 		text-decoration: underline;
 	}
 }

--- a/client/components/share/twitter-share-preview/style.scss
+++ b/client/components/share/twitter-share-preview/style.scss
@@ -8,6 +8,19 @@
 	margin: 0 auto;
 	max-width: 565px;
 	padding: 12px;
+
+	// Nesting to win main.scss
+	.twitter-share-preview__profile-handle {
+		color: #657786;
+	}
+
+	.twitter-share-preview__profile-name {
+		color: #14171a;
+	}
+
+	.twitter-share-preview__article-url {
+		color: #0084b4;
+	}
 }
 
 .twitter-share-preview__content {
@@ -31,13 +44,12 @@
 	margin-right: 5px;
 
 	&:hover {
-		color: #0084B4;
+		color: #0084b4;
 		text-decoration: underline;
 	}
 }
 
 .twitter-share-preview__profile-handle {
-	color: #657786;
 	font-size: 13px;
 }
 
@@ -45,11 +57,6 @@
 .twitter-share-preview__article-url {
 	font-size: 16px;
 	line-height: 22px;
-}
-
-.twitter-share-preview__message a,
-.twitter-share-preview__article-url {
-	color: #0084B4;
 }
 
 .twitter-share-preview__article-url-line {

--- a/client/components/vertical-menu/items/social-item.jsx
+++ b/client/components/vertical-menu/items/social-item.jsx
@@ -13,7 +13,10 @@ import SocialLogo from 'social-logos';
 const services = translate => ( {
 	facebook: { icon: 'facebook', label: translate( 'Facebook feed' ) },
 	google: { icon: 'google', label: translate( 'Google search' ) },
+	google_plus: { icon: 'google-plus', label: translate( 'Google+' ) },
 	linkedin: { icon: 'linkedin', label: translate( 'LinkedIn share' ) },
+	path: { icon: 'path', label: translate( 'Path' ) },
+	tumblr: { icon: 'tumblr', label: translate( 'Tumblr post' ) },
 	twitter: { icon: 'twitter', label: translate( 'Twitter card' ) },
 	wordpress: { icon: 'wordpress', label: translate( 'WordPress.com Reader' ) }
 } );


### PR DESCRIPTION
This adds sharing preview components for :
- Google+
- Linkedin
- Tumblr
- Path 

**Testing**
visit http://calypso.localhost:3000/devdocs/blocks/sharing-preview-pane to see the new sharing components

**[Added]**
Make sure your primary site is set to a public site with Business plan, and is connected to all 6 services before you test, otherwise you won't see any previews.