### PR TITLE
Add CDN tab settings

### DIFF
--- a/client/extensions/wp-super-cache/cdn-tab.jsx
+++ b/client/extensions/wp-super-cache/cdn-tab.jsx
@@ -1,0 +1,179 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { pick } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+import ExternalLink from 'components/external-link';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import FormTextInput from 'components/forms/form-text-input';
+import FormToggle from 'components/forms/form-toggle/compact';
+import SectionHeader from 'components/section-header';
+import WrapSettingsForm from './wrap-settings-form';
+
+const CdnTab = ( {
+	fields: {
+		ossdl_cname,
+		ossdl_https,
+		ossdl_off_cdn_url,
+		ossdl_off_exclude,
+		ossdl_off_include_dirs,
+		ossdlcdn,
+	},
+	handleChange,
+	handleToggle,
+	siteUrl,
+	translate,
+} ) => {
+	return (
+		<div>
+			<SectionHeader label={ translate( 'CDN' ) }>
+				<Button
+					compact={ true }
+					primary={ true }
+					type="submit">
+						{ translate( 'Save Settings' ) }
+				</Button>
+			</SectionHeader>
+
+			<Card>
+				<form>
+					<FormFieldset>
+						<FormToggle
+							checked={ !! ossdlcdn }
+							onChange={ handleToggle( 'ossdlcdn' ) }>
+							<span>
+								{ translate( 'Enable CDN Support' ) }
+							</span>
+						</FormToggle>
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLabel htmlFor="ossdl_off_cdn_url">
+							{ translate( 'Off-site URL' ) }
+						</FormLabel>
+
+						<FormTextInput
+							id="ossdl_off_cdn_url"
+							onChange={ handleChange( 'ossdl_off_cdn_url' ) }
+							value={ ossdl_off_cdn_url || '' } />
+
+						<FormSettingExplanation>
+							{ translate(
+								'The new URL to be used in place of %(url)s for rewriting. No trailing / please.',
+								{
+									args: { url: siteUrl },
+								}
+							) }
+						</FormSettingExplanation>
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLabel htmlFor="ossdl_off_include_dirs">
+							{ translate( 'Include directories' ) }
+						</FormLabel>
+
+						<FormTextInput
+							id="ossdl_off_include_dirs"
+							onChange={ handleChange( 'ossdl_off_include_dirs' ) }
+							value={ ossdl_off_include_dirs || '' } />
+
+						<FormSettingExplanation>
+							{ translate(
+								'Directories to include in static file matching. Use a comma as the delimiter. Default is ' +
+								'{{code}}wp-content, wp-includes{{/code}}, which will be enforced if this field is left empty.',
+								{
+									components: { code: <code /> }
+								}
+							) }
+						</FormSettingExplanation>
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLabel htmlFor="ossdl_off_exclude">
+							{ translate( 'Exclude if substring' ) }
+						</FormLabel>
+
+						<FormTextInput
+							id="ossdl_off_exclude"
+							onChange={ handleChange( 'ossdl_off_exclude' ) }
+							value={ ossdl_off_exclude || '' } />
+
+						<FormSettingExplanation>
+							{ translate(
+								'Excludes something from being rewritten if one of the above strings is found in the match. ' +
+								'Use a comma as the delimiter like this, {{code}}.php, .flv, .do{{/code}}, and always ' +
+								'include {{code}}.php{{/code}} (default).',
+								{
+									components: { code: <code /> }
+								}
+							) }
+						</FormSettingExplanation>
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLabel htmlFor="ossdl_cname">
+							{ translate( 'Additional CNAMES' ) }
+						</FormLabel>
+
+						<FormTextInput
+							id="ossdl_cname"
+							onChange={ handleChange( 'ossdl_cname' ) }
+							value={ ossdl_cname || '' } />
+
+						<FormSettingExplanation>
+							{ translate(
+								'These {{a}}CNAMES{{/a}} will be used in place of %(url)s for rewriting (in addition to the ' +
+								'off-site URL above). Use a comma as the delimiter. For pages with a large number of static files, ' +
+								'this can improve browser performance. CNAMEs may also need to be configured on your CDN.',
+								{
+									args: {
+										url: siteUrl,
+									},
+									components: {
+										a: (
+											<ExternalLink
+												icon={ true }
+												target="_blank"
+												href="http://en.wikipedia.org/wiki/CNAME_record"
+											/>
+										),
+									}
+								}
+							) }
+						</FormSettingExplanation>
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormToggle
+							checked={ !! ossdl_https }
+							onChange={ handleToggle( 'ossdl_https' ) }>
+							<span>
+								{ translate( 'Skip https URLs to avoid "mixed content" errors' ) }
+							</span>
+						</FormToggle>
+					</FormFieldset>
+				</form>
+			</Card>
+		</div>
+	);
+};
+const getFormSettings = settings => {
+	return pick( settings, [
+		'ossdl_cname',
+		'ossdl_https',
+		'ossdl_off_cdn_url',
+		'ossdl_off_exclude',
+		'ossdl_off_include_dirs',
+		'ossdlcdn',
+	] );
+};
+
+export default WrapSettingsForm( getFormSettings )( CdnTab );

--- a/client/extensions/wp-super-cache/main.jsx
+++ b/client/extensions/wp-super-cache/main.jsx
@@ -7,6 +7,7 @@ import React, { PropTypes } from 'react';
  * Internal dependencies
  */
 import AdvancedTab from './advanced-tab';
+import CdnTab from './cdn-tab';
 import ContentsTab from './contents-tab';
 import Easy from './easy';
 import Main from 'components/main';
@@ -19,7 +20,7 @@ const WPSuperCache = ( { site, tab } ) => {
 			case Tabs.ADVANCED:
 				return <AdvancedTab siteUrl={ site.URL } />;
 			case Tabs.CDN:
-				break;
+				return <CdnTab siteUrl={ site.URL } />;
 			case Tabs.CONTENTS:
 				return <ContentsTab isMultisite={ site.is_multisite } />;
 			case Tabs.PRELOAD:

--- a/client/extensions/wp-super-cache/wrap-settings-form.jsx
+++ b/client/extensions/wp-super-cache/wrap-settings-form.jsx
@@ -143,6 +143,14 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				wp_cache_readonly: false,
 				wp_cache_writable: false,
 
+				// CDN
+				ossdl_cname: '',
+				ossdl_https: false,
+				ossdl_off_cdn_url: 'http://donnapep.wpsandbox.me',
+				ossdl_off_exclude: '.php',
+				ossdl_off_include_dirs: 'wp-content,wp-includes',
+				ossdlcdn: false,
+
 				// Contents
 				cache_stats: {
 					generated: 60,


### PR DESCRIPTION
This PR adds settings for the CDN tab of WP Super Cache.

_CDN Tab in WordPress Plugin_

![wp-super-cache-cdn](https://cloud.githubusercontent.com/assets/1190420/24473767/66f02606-1498-11e7-82d2-81c6eae135e2.jpg)

_CDN Tab in Calypso_

![cdn-calypso](https://cloud.githubusercontent.com/assets/1190420/24549353/e14ea95a-15e6-11e7-9965-74e923e71239.jpg)