### PR TITLE
Fix for extensions-loader generated reducers list.

### DIFF
--- a/server/bundler/extensions-loader.js
+++ b/server/bundler/extensions-loader.js
@@ -15,7 +15,7 @@ function generateExtensionsModuleString( reducerRequires ) {
 	return `module.exports = {
 		reducers: function() {
 			return {
-				${ reducerRequires.join( '\n' ) }
+				${ reducerRequires.join( ',\n' ) }
 			};
 		}
 	};`;


### PR DESCRIPTION
The original code was missing the commas between reducers in the
generated javascript code. This adds the commas in that list.

Fixes #12648

To Test:

Add a "dummy" reducer in one more more extensions `state/reducer.js` files.
Verify `make run` works correctly.
