### PR TITLE
Reader: fix search recs excerpt text

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -55,7 +55,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	display: flex;
 	flex-basis: calc( 50% - 15px );
 	margin: 0 0 0 15px;
-	padding: 18px 0 32px 0;
+	padding: 18px 0 21px 0;
 
 	@media #{$reader-related-card-v2-breakpoint-medium} {
 		flex-basis: 100%;
@@ -111,7 +111,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	 .has-thumbnail {
 
 		.reader-related-card-v2__post {
-			max-height: 200px;
+			max-height: 205px;
 
 			@media #{$reader-related-card-v2-breakpoint-small} {
 				max-height: 145px;


### PR DESCRIPTION
This PR adjusts padding and max-height in the search recs items that caused the bottom of the rec excerpt text to be cut off. Fixes #12601.

**Before:**

<img width="403" alt="screen shot 2017-03-30 at 7 28 52 pm" src="https://cloud.githubusercontent.com/assets/2627210/24494910/39a75b0a-157f-11e7-80bf-9ab76fd88762.png">


**After:**

<img width="347" alt="screen shot 2017-03-30 at 7 29 21 pm" src="https://cloud.githubusercontent.com/assets/2627210/24494915/3ff48d66-157f-11e7-9cb5-e5050e6aafbd.png">

@fraying: I've set 20px space between the bottom of the excerpt and the line below it.
