### PR TITLE
Jetpack: Fix undefined feature in jetpack plans

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -273,7 +273,7 @@ export const PLANS_LIST = {
 			FEATURE_SPEED_ADVANCED_JETPACK,
 			FEATURE_REVENUE_GENERATION_JETPACK
 		]
-		: [
+		: compact( [
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
 			FEATURE_BACKUP_ARCHIVE_30,
 			FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
@@ -286,7 +286,7 @@ export const PLANS_LIST = {
 			FEATURE_MALWARE_SCANNING_DAILY,
 			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
 			isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
-		],
+		] ),
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
 	},
 
@@ -311,7 +311,7 @@ export const PLANS_LIST = {
 			FEATURE_PRIORITY_SUPPORT_JETPACK,
 			FEATURE_SPEED_ADVANCED_JETPACK,
 			FEATURE_REVENUE_GENERATION_JETPACK
-		] : [
+		] : compact( [
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
 			FEATURE_BACKUP_ARCHIVE_30,
 			FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
@@ -324,7 +324,7 @@ export const PLANS_LIST = {
 			FEATURE_MALWARE_SCANNING_DAILY,
 			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
 			isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
-		],
+		] ),
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' )
 	},
 


### PR DESCRIPTION
Plans page is broken in production right now for 50% of the jetpack sites, because in https://github.com/Automattic/wp-calypso/commit/8689cd31abe4fc47c87f99815a2e9b9c4999b500#diff-682fa9ded512d0b6e17bad5c1b613f85 , we introduced a new feature under a feature flag that is off for production. So it's adding an 'undefined' to the array, and since that feature list wasn't inside of a _.compact, it breaks some functions downstream.

How to test:
=======
1. Go to calypso and make sure you are not in the 'new' half of the jetpack plans ab tests running `localStorage.setItem( 'ABTests', '{"jetpackNewDescriptions_20170327":"showOld"}' );` in the console
2. Reload and select a jetpack site. Go to your plans page.
3. They should render ok  