### PR TITLE
Editor: add "Add another page" link on publish notice

### DIFF
--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -4,7 +4,6 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -90,9 +89,10 @@ export class EditorNotice extends Component {
 				}
 
 				if ( 'page' === type ) {
-					return translate( 'Page published on {{siteLink/}}!', {
+					return translate( 'Page published on {{siteLink/}}! {{a}}Add another page{{/a}}', {
 						components: {
-							siteLink: <a href={ site.URL } target="_blank" rel="noopener noreferrer">{ site.title }</a>
+							siteLink: <a href={ site.URL } target="_blank" rel="noopener noreferrer">{ site.title }</a>,
+							a: <a href={ `/page/${ site.slug }` } />,
 						},
 						comment: 'Editor: Message displayed when a page is published, with a link to the site it was published on.'
 					} );
@@ -115,9 +115,10 @@ export class EditorNotice extends Component {
 				}
 
 				if ( 'page' === type ) {
-					return translate( 'Page scheduled on {{siteLink/}}!', {
+					return translate( 'Page scheduled on {{siteLink/}}! {{a}}Add another page{{/a}}', {
 						components: {
-							siteLink: <a href={ site.URL } target="_blank" rel="noopener noreferrer">{ site.title }</a>
+							siteLink: <a href={ site.URL } target="_blank" rel="noopener noreferrer">{ site.title }</a>,
+							a: <a href={ `/page/${ site.slug }` } />,
 						},
 						comment: 'Editor: Message displayed when a page is scheduled, with a link to the site it was scheduled on.'
 					} );
@@ -140,9 +141,10 @@ export class EditorNotice extends Component {
 				}
 
 				if ( 'page' === type ) {
-					return translate( 'Page privately published on {{siteLink/}}!', {
+					return translate( 'Page privately published on {{siteLink/}}! {{a}}Add another page{{/a}}', {
 						components: {
-							siteLink: <a href={ site.URL } target="_blank" rel="noopener noreferrer">{ site.title }</a>
+							siteLink: <a href={ site.URL } target="_blank" rel="noopener noreferrer">{ site.title }</a>,
+							a: <a href={ `/page/${ site.slug }` } />,
 						},
 						comment: 'Editor: Message displayed when a page is published privately,' +
 							' with a link to the site it was published on.'
@@ -179,9 +181,10 @@ export class EditorNotice extends Component {
 				}
 
 				if ( 'page' === type ) {
-					return translate( 'Page updated on {{siteLink/}}!', {
+					return translate( 'Page updated on {{siteLink/}}! {{a}}Add another page{{/a}}', {
 						components: {
-							siteLink: <a href={ site.URL } target="_blank" rel="noopener noreferrer">{ site.title }</a>
+							siteLink: <a href={ site.URL } target="_blank" rel="noopener noreferrer">{ site.title }</a>,
+							a: <a href={ `/page/${ site.slug }` } />,
 						},
 						comment: 'Editor: Message displayed when a page is updated, with a link to the site it was updated on.'
 					} );
@@ -194,35 +197,6 @@ export class EditorNotice extends Component {
 					comment: 'Editor: Message displayed when a post is updated, with a link to the site it was updated on.'
 				} );
 		}
-	}
-
-	renderAddAnotherPage() {
-		const { message, site, translate, type } = this.props;
-		if (
-			'page' !== type ||
-			! includes( [ 'published', 'publishedPrivately', 'scheduled', 'updated' ], message )
-		) {
-			return null;
-		}
-
-		return (
-			<span>
-				{ translate( '{{a}}Add another page{{/a}}.', {
-					components: {
-						a: <a href={ `/page/${ site.slug }` } />,
-					},
-				} ) }
-			</span>
-		);
-	}
-
-	renderNoticeText( text ) {
-		return (
-			<span className="editor-notice__text">
-				<span>{ text }</span>
-				{ this.renderAddAnotherPage() }
-			</span>
-		);
 	}
 
 	renderNoticeAction() {
@@ -258,9 +232,8 @@ export class EditorNotice extends Component {
 				{ siteId && <QueryPostTypes siteId={ siteId } /> }
 				{ text && (
 					<Notice
-						{ ...{ status, onDismissClick } }
+						{ ...{ status, text, onDismissClick } }
 						showDismiss={ true }
-						text={ this.renderNoticeText( text ) }
 					>
 						{ this.renderNoticeAction() }
 					</Notice>

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -4,6 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -195,6 +196,35 @@ export class EditorNotice extends Component {
 		}
 	}
 
+	renderAddAnotherPage() {
+		const { message, site, translate, type } = this.props;
+		if (
+			'page' !== type ||
+			! includes( [ 'published', 'publishedPrivately', 'scheduled', 'updated' ], message )
+		) {
+			return null;
+		}
+
+		return (
+			<span>
+				{ translate( '{{a}}Add another page{{/a}}.', {
+					components: {
+						a: <a href={ `/page/${ site.slug }` } />,
+					},
+				} ) }
+			</span>
+		);
+	}
+
+	renderNoticeText( text ) {
+		return (
+			<span className="editor-notice__text">
+				<span>{ text }</span>
+				{ this.renderAddAnotherPage() }
+			</span>
+		);
+	}
+
 	renderNoticeAction() {
 		const { onViewClick, action, link, isSitePreviewable } = this.props;
 		if ( onViewClick && isSitePreviewable && link ) {
@@ -223,8 +253,10 @@ export class EditorNotice extends Component {
 				{ siteId && <QueryPostTypes siteId={ siteId } /> }
 				{ text && (
 					<Notice
-						{ ...{ status, text, onDismissClick } }
-						showDismiss={ true }>
+						{ ...{ status, onDismissClick } }
+						showDismiss={ true }
+						text={ this.renderNoticeText( text ) }
+					>
 						{ this.renderNoticeAction() }
 					</Notice>
 				) }

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -226,8 +226,13 @@ export class EditorNotice extends Component {
 	}
 
 	renderNoticeAction() {
-		const { onViewClick, action, link, isSitePreviewable } = this.props;
-		if ( onViewClick && isSitePreviewable && link ) {
+		const {
+			action,
+			isSitePreviewable: isPreviewable,
+			link,
+			onViewClick,
+		} = this.props;
+		if ( onViewClick && isPreviewable && link ) {
 			return (
 				<NoticeAction onClick={ onViewClick }>
 					{ this.getText( action ) }

--- a/client/post-editor/editor-notice/style.scss
+++ b/client/post-editor/editor-notice/style.scss
@@ -11,10 +11,22 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		display: inline-block;
+		width: 100%;
+		max-width: 100%;
 
 		a {
 			text-decoration: underline;
 			background-image: none;
+		}
+	}
+
+	.editor-notice__text {
+		display: flex;
+		flex-flow: row wrap;
+
+		span:first-child {
+			flex-grow: 1;
+			padding-right: 16px;
 		}
 	}
 }

--- a/client/post-editor/editor-notice/style.scss
+++ b/client/post-editor/editor-notice/style.scss
@@ -11,22 +11,10 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		display: inline-block;
-		width: 100%;
-		max-width: 100%;
 
 		a {
 			text-decoration: underline;
 			background-image: none;
-		}
-	}
-
-	.editor-notice__text {
-		display: flex;
-		flex-flow: row wrap;
-
-		span:first-child {
-			flex-grow: 1;
-			padding-right: 16px;
 		}
 	}
 }

--- a/client/post-editor/editor-notice/test/index.jsx
+++ b/client/post-editor/editor-notice/test/index.jsx
@@ -67,14 +67,16 @@ describe( 'EditorNotice', () => {
 				action="view"
 				site={ {
 					URL: 'https://example.wordpress.com',
-					title: 'Example Site'
+					title: 'Example Site',
+					slug: 'example.wordpress.com',
 				} } />
 		);
 
 		expect( wrapper.find( Notice ) ).to.have.prop( 'text' ).eql(
-			translate( 'Page published on {{siteLink/}}!', {
+			translate( 'Page published on {{siteLink/}}! {{a}}Add another page{{/a}}', {
 				components: {
-					siteLink: <a href="https://example.wordpress.com" target="_blank" rel="noopener noreferrer">Example Site</a>
+					siteLink: <a href="https://example.wordpress.com" target="_blank" rel="noopener noreferrer">Example Site</a>,
+					a: <a href="/page/example.wordpress.com" />,
 				}
 			} )
 		);
@@ -131,13 +133,15 @@ describe( 'EditorNotice', () => {
 				site={ {
 					URL: 'https://example.wordpress.com',
 					title: 'Example Site',
+					slug: 'example.wordpress.com',
 				} } />
 		);
 
 		expect( wrapper.find( Notice ) ).to.have.prop( 'text' ).eql(
-			translate( 'Page published on {{siteLink/}}!', {
+			translate( 'Page published on {{siteLink/}}! {{a}}Add another page{{/a}}', {
 				components: {
-					siteLink: <a href="https://example.wordpress.com" target="_blank" rel="noopener noreferrer">Example Site</a>
+					siteLink: <a href="https://example.wordpress.com" target="_blank" rel="noopener noreferrer">Example Site</a>,
+					a: <a href="/page/example.wordpress.com" />,
 				}
 			} )
 		);


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/2426

When publishing or updating a page, there's now a new "Add another page" link in the notice in order to improve the flow of adding multiple pages in a row (especially during NUX).

cc @kellychoffman @drw158 

## Screenshots
<!--<img width="434" alt="screen shot 2017-03-30 at 12 34 53" src="https://cloud.githubusercontent.com/assets/2070010/24502436/a769345e-1545-11e7-87a1-bb33692a9360.png">
<img width="529" alt="screen shot 2017-03-30 at 12 36 48" src="https://cloud.githubusercontent.com/assets/2070010/24502438/a76bdaec-1545-11e7-9b12-4b494b04079a.png">
<img width="733" alt="screen shot 2017-03-30 at 12 35 21" src="https://cloud.githubusercontent.com/assets/2070010/24502437/a769bc12-1545-11e7-969d-bc3d77aec47c.png">-->
<img width="598" alt="screen shot 2017-04-04 at 17 03 12" src="https://cloud.githubusercontent.com/assets/2070010/24666575/a6deccb2-1958-11e7-8f6a-b9a04863c327.png">
