### PR TITLE
Editor: Fix Editor Notice to open in another tab on command + click

### DIFF
--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -197,9 +197,9 @@ export class EditorNotice extends Component {
 
 	renderNoticeAction() {
 		const { onViewClick, action, link, isSitePreviewable } = this.props;
-		if ( onViewClick && isSitePreviewable ) {
+		if ( onViewClick && isSitePreviewable && link ) {
 			return (
-				<NoticeAction onClick={ onViewClick } icon={ 'visible' }>
+				<NoticeAction onClick={ onViewClick }>
 					{ this.getText( action ) }
 				</NoticeAction>
 			);

--- a/client/post-editor/editor-notice/test/index.jsx
+++ b/client/post-editor/editor-notice/test/index.jsx
@@ -22,14 +22,19 @@ describe( 'EditorNotice', () => {
 	} );
 
 	it( 'should display an no content error message if recognized', () => {
+		const spy = sinon.stub();
+
 		const wrapper = shallow(
 			<EditorNotice
 				translate={ translate }
 				status="is-error"
 				message="publishFailure"
+				isSitePreviewable={ true }
+				onViewClick={ spy }
 				error={ new Error( 'NO_CONTENT' ) } />
 		);
 
+		expect( wrapper.find( Notice ) ).to.not.have.descendants( NoticeAction );
 		expect( wrapper.find( Notice ) ).to.have.prop( 'text' ).equal( 'You haven\'t written anything yet!' );
 		expect( wrapper.find( Notice ) ).to.have.prop( 'status' ).equal( 'is-error' );
 		expect( wrapper.find( Notice ) ).to.have.prop( 'showDismiss' ).be.true;
@@ -137,7 +142,6 @@ describe( 'EditorNotice', () => {
 			} )
 		);
 		expect( wrapper.find( Notice ) ).to.have.prop( 'status' ).equal( 'is-success' );
-		expect( wrapper.find( NoticeAction ) ).to.have.prop( 'icon' ).equal( 'visible' );
 		expect( wrapper.find( NoticeAction ) ).to.have.prop( 'children' ).equal( 'View Page' );
 		expect( wrapper.find( NoticeAction ) ).to.have.prop( 'onClick' ).equal( spy );
 		wrapper.find( NoticeAction ).simulate( 'click' );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -251,7 +251,7 @@ export const PostEditor = React.createClass( {
 							<EditorNotice
 								{ ...this.state.notice }
 								onDismissClick={ this.hideNotice }
-								onViewClick={ this.iframePreview } />
+								onViewClick={ this.onPreview } />
 							<EditorActionBar
 								isNew={ this.state.isNew }
 								onPrivatePublish={ this.onPublish }


### PR DESCRIPTION
Per the comment [here](https://github.com/Automattic/wp-calypso/pull/12114#issuecomment-290069200), we're removing the `visible` icon if the Editor Notice will open the in-app preview.

This also updates how we display the preview to use `onPreview` instead of `iframePreview`. The former [already has logic in place](https://github.com/Automattic/wp-calypso/blob/master/client/post-editor/post-editor.jsx#L587) to detect command + click and open the preview in a new window as a result.

**To test**
1. Open a new post in the Editor
2. Publish the post. You should see the new notice without the `visible` icon
3. Command + click the action in the notice. It should open in a new tab
4. If you update the post again and click the action normally, you should see the preview

**Before**
<img width="294" alt="screen shot 2017-03-30 at 6 16 53 am" src="https://cloud.githubusercontent.com/assets/7240478/24503705/7dbf1ce8-1510-11e7-8d31-2c22e45c9132.png">

**After**
<img width="547" alt="screen shot 2017-03-30 at 6 12 44 am" src="https://cloud.githubusercontent.com/assets/7240478/24503688/66bf9838-1510-11e7-94e3-fba36058f027.png">