### PR TITLE
Themes: Merge fetchThemeDataWithCaching() into fetchThemeData()

### DIFF
--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -94,11 +94,12 @@ export function loggedOut( context, next ) {
 	next();
 }
 
-export function fetchThemeData( context, next, shouldUseCache = false ) {
+export function fetchThemeData( context, next ) {
 	if ( ! context.isServerSide ) {
 		return next();
 	}
 
+	const shouldUseCache = isEmpty( context.query ); // Don't cache URLs with query params
 	const siteId = 'wpcom';
 	const query = {
 		search: context.query.s,
@@ -135,13 +136,4 @@ export function fetchThemeData( context, next, shouldUseCache = false ) {
 			next();
 		} )
 		.catch( () => next() );
-}
-
-export function fetchThemeDataWithCaching( context, next ) {
-	if ( ! isEmpty( context.query ) ) {
-		// Don't cache URLs with query params
-		return fetchThemeData( context, next, false );
-	}
-
-	return fetchThemeData( context, next, true );
 }

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -4,7 +4,7 @@
 import config from 'config';
 import { makeLayout } from 'controller';
 import { getSubjects } from './theme-filters.js';
-import { fetchThemeDataWithCaching, loggedOut } from './controller';
+import { fetchThemeData, loggedOut } from './controller';
 
 // `logged-out` middleware isn't SSR-compliant yet, but we can at least render
 // the layout.
@@ -15,16 +15,16 @@ export default function( router ) {
 
 	if ( config.isEnabled( 'manage/themes' ) ) {
 		if ( config.isEnabled( 'manage/themes-ssr' ) ) {
-			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, fetchThemeDataWithCaching, loggedOut, makeLayout );
+			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, fetchThemeData, loggedOut, makeLayout );
 			router(
 				`/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`,
-				fetchThemeDataWithCaching,
+				fetchThemeData,
 				loggedOut,
 				makeLayout
 			);
 			router( '/design/upload/*', makeLayout );
 			// The following route definition is needed so direct hits on `/design/<mysite>` don't result in a 404.
-			router( '/design/*', fetchThemeDataWithCaching, loggedOut, makeLayout );
+			router( '/design/*', fetchThemeData, loggedOut, makeLayout );
 		} else {
 			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, makeLayout );
 			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`, makeLayout );


### PR DESCRIPTION
Postscript to #12592. We were only ever using `fetchThemeDataWithCaching`, so this PR removes the additional `shouldUseCache` parameter and computes it inside that middleware, replaces the old `fetchThemeData` middleware, and finally renames all instances of `fetchThemeDataWithCaching` to `fetchThemeData`.

To test: Make sure that: 
Every little thing
[gonna be alright](https://www.youtube.com/watch?v=mACqcZZwG0k).