### PR TITLE
Social Signup: Update the scope of the google+ login button

### DIFF
--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -14,7 +14,7 @@ export default class GoogleLoginButton extends Component {
 	};
 
 	static defaultProps = {
-		scope: 'profile',
+		scope: 'https://www.googleapis.com/auth/plus.login',
 		fetchBasicProfile: true,
 	};
 


### PR DESCRIPTION
Based on p6qnuF-4uk-p2, I think we should change the scope we ask for when users sign up with Google.

This PR changes the scope to `https://www.googleapis.com/auth/plus.login`, which is <a href="https://developers.google.com/+/web/api/rest/oauth#login-scopes">recommended</a> to access social features:

The verification screen looks like this:
<img width="600" alt="screen shot 2017-03-30 at 14 23 38" src="https://cloud.githubusercontent.com/assets/275961/24507109/77376e56-1557-11e7-8a0f-cc6e315dc759.png">
  
#### Testing instructions
  
1. Run `git checkout update/google-plus-scope` and start your server, or open a [live branch](https://calypso.live/?branch=update/google-plus-scope)
2. Open the [`Social signup` page](http://calypso.localhost:3000/start/social)
3. Check that when you connect with Google you are shown the authorization screen above
  
#### Reviews
  
- [ ] Code
- [ ] Product
   
@Automattic/sdev-feed