### PR TITLE
Checkout: Refetch sites and user on upgrade form domain only to a plan

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -5,7 +5,7 @@ import page from 'page';
 import ReactDom from 'react-dom';
 import React from 'react';
 import i18n from 'i18n-calypso';
-import { uniq } from 'lodash';
+import { uniq, startsWith } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -168,7 +168,8 @@ function isPathAllowedForDomainOnlySite( path, domainName ) {
 		`/checkout/${ domainName }`
 	];
 
-	return [ ...domainManagementPaths, ...otherPaths ].indexOf( path ) > -1;
+	return [ ...domainManagementPaths, ...otherPaths ].indexOf( path ) > -1 ||
+		startsWith( path, '/checkout/thank-you' );
 }
 
 function onSelectedSiteAvailable( context ) {

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -3,7 +3,7 @@
  */
 import { connect } from 'react-redux';
 import { flatten, find, isEmpty, isEqual, reduce, startsWith } from 'lodash';
-import i18n from 'i18n-calypso';
+import { i18n, localize } from 'i18n-calypso';
 import page from 'page';
 import React from 'react';
 
@@ -232,7 +232,8 @@ const Checkout = React.createClass( {
 				step: {
 					data: receipt
 				}
-			}
+			},
+			translate
 		} = this.props;
 		const redirectPath = this.getCheckoutCompleteRedirectPath();
 
@@ -253,7 +254,7 @@ const Checkout = React.createClass( {
 
 			if ( product && product.will_auto_renew ) {
 				notices.success(
-					this.translate( '%(productName)s has been renewed and will now auto renew in the future. ' +
+					translate( '%(productName)s has been renewed and will now auto renew in the future. ' +
 						'{{a}}Learn more{{/a}}', {
 							args: {
 								productName: renewalItem.product_name
@@ -267,7 +268,7 @@ const Checkout = React.createClass( {
 				);
 			} else if ( product ) {
 				notices.success(
-					this.translate( 'Success! You renewed %(productName)s for %(duration)s, until %(date)s. ' +
+					translate( 'Success! You renewed %(productName)s for %(duration)s, until %(date)s. ' +
 						'We sent your receipt to %(email)s.', {
 							args: {
 								productName: renewalItem.product_name,
@@ -299,7 +300,7 @@ const Checkout = React.createClass( {
 			( isDomainOnly && cartItems.hasPlan( cart ) )
 		) {
 			notices.info(
-				this.translate( 'Almost done…' )
+				translate( 'Almost done…' )
 			);
 
 			const domainName = getDomainNameFromReceiptOrCart( receipt, cart );
@@ -402,4 +403,4 @@ module.exports = connect(
 		recordApplePayStatus,
 		requestSite
 	}
-)( Checkout );
+)( localize( Checkout ) );

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -37,6 +37,7 @@ import {
 import { planItem as getCartItemForPlan } from 'lib/cart-values/cart-items';
 import { recordViewCheckout } from 'lib/analytics/ad-tracking';
 import { recordApplePayStatus } from 'lib/apple-pay';
+import { requestSite } from 'state/sites/actions';
 import { isDomainOnlySite } from 'state/selectors';
 import {
 	getSelectedSite,
@@ -310,6 +311,10 @@ const Checkout = React.createClass( {
 
 				return;
 			}
+
+			if ( selectedSiteId ) {
+				this.props.requestSite( selectedSiteId );
+			}
 		}
 
 		page( redirectPath );
@@ -394,6 +399,7 @@ module.exports = connect(
 		clearPurchases,
 		clearSitePlans,
 		fetchReceiptCompleted,
-		recordApplePayStatus
+		recordApplePayStatus,
+		requestSite
 	}
 )( Checkout );

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -37,6 +37,7 @@ import {
 import { planItem as getCartItemForPlan } from 'lib/cart-values/cart-items';
 import { recordViewCheckout } from 'lib/analytics/ad-tracking';
 import { recordApplePayStatus } from 'lib/apple-pay';
+import { isDomainOnlySite } from 'state/selectors';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
@@ -224,6 +225,7 @@ const Checkout = React.createClass( {
 
 		const {
 			cart,
+			isDomainOnly,
 			selectedSiteId,
 			transaction: {
 				step: {
@@ -291,7 +293,10 @@ const Checkout = React.createClass( {
 			} );
 		}
 
-		if ( cart.create_new_blog && receipt && isEmpty( receipt.failed_purchases ) ) {
+		if (
+			( cart.create_new_blog && receipt && isEmpty( receipt.failed_purchases ) ) ||
+			( isDomainOnly && cartItems.hasPlan( cart ) )
+		) {
 			notices.info(
 				this.translate( 'Almost done…' )
 			);
@@ -379,6 +384,7 @@ module.exports = connect(
 
 		return {
 			cards: getStoredCards( state ),
+			isDomainOnly: isDomainOnlySite( state, selectedSiteId ),
 			selectedSite: getSelectedSite( state ),
 			selectedSiteId,
 			selectedSiteSlug: getSelectedSiteSlug( state ),


### PR DESCRIPTION
When upgrading a domain only site we need to refetch the site
because the old site still has domain-only flag and will
show featuregate screen.
Allow `/checkout/thank-you` path for domain only sites.

Fixes: https://github.com/Automattic/wp-calypso/issues/12103

Test:
1. Login with existing user
2. Create a domain only site
3. Click Create a site
4. Buy a plan
5. After checkout, you should see proper thank you page
6. When going back to my sites, you should see stats, not featuregate