### PR TITLE
Framework: make resize-url deal with missing hostnames

### DIFF
--- a/client/lib/resize-image-url/index.js
+++ b/client/lib/resize-image-url/index.js
@@ -69,6 +69,10 @@ export default function resizeImageUrl( imageUrl, resize, height ) {
 	if ( ! REGEXP_VALID_PROTOCOL.test( parsedUrl.protocol ) ) {
 		return imageUrl;
 	}
+	if ( ! parsedUrl.hostname ) {
+		// no hostname? must be a bad url.
+		return imageUrl;
+	}
 
 	parsedUrl.query = omit( parsedUrl.query, SIZE_PARAMS );
 


### PR DESCRIPTION
Some image icons have newlines and really broken forms.
```
http:http://example.com
/a/path
```
 This prevents `lib/resize-image-url` from throwing and breaking calypso.