### PR TITLE
Revert "Framework: make resize-url deal with missing hostnames"

### DIFF
--- a/client/lib/resize-image-url/index.js
+++ b/client/lib/resize-image-url/index.js
@@ -69,10 +69,6 @@ export default function resizeImageUrl( imageUrl, resize, height ) {
 	if ( ! REGEXP_VALID_PROTOCOL.test( parsedUrl.protocol ) ) {
 		return imageUrl;
 	}
-	if ( ! parsedUrl.hostname ) {
-		// no hostname? must be a bad url.
-		return imageUrl;
-	}
 
 	parsedUrl.query = omit( parsedUrl.query, SIZE_PARAMS );
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#12669