### PR TITLE
Magic Login: Add a link at the bottom of the native login form

### DIFF
--- a/client/auth/request-login-email-form.jsx
+++ b/client/auth/request-login-email-form.jsx
@@ -25,6 +25,7 @@ import { localize } from 'i18n-calypso';
 import wpcom from 'lib/wp';
 
 const debug = debugFactory( 'calypso:magic-login' );
+const loginUrl = config( 'native_login_url' );
 
 class RequestLoginEmailForm extends React.Component {
 	state = {
@@ -156,7 +157,7 @@ class RequestLoginEmailForm extends React.Component {
 					</FormFieldset>
 				</LoggedOutForm>
 				<LoggedOutFormLinks>
-					<LoggedOutFormLinkItem href={ config( 'login_url' ) }>
+					<LoggedOutFormLinkItem href={ loginUrl }>
 						{ translate( 'Enter a password instead' ) }
 					</LoggedOutFormLinkItem>
 				</LoggedOutFormLinks>

--- a/client/auth/wp-login/index.js
+++ b/client/auth/wp-login/index.js
@@ -9,6 +9,7 @@ import Gridicon from 'gridicons';
  */
 import Main from 'components/main';
 import LoginBlock from 'blocks/login';
+import { isEnabled } from 'config';
 import { localize } from 'i18n-calypso';
 
 const Login = ( { translate } ) => (
@@ -20,6 +21,13 @@ const Login = ( { translate } ) => (
 		<div className="wp-login__container">
 			<LoginBlock
 				title={ translate( 'Sign in to WordPress.com' ) } />
+		</div>
+		<div className="wp-login__footer">
+			{
+				isEnabled( 'magic-login' ) && (
+					<a href="/login/send-me-a-link">{ translate( 'Email me a login link' ) }</a>
+				)
+			}
 		</div>
 	</Main>
 );

--- a/client/auth/wp-login/style.scss
+++ b/client/auth/wp-login/style.scss
@@ -9,3 +9,15 @@
 	margin-bottom: 16px;
 	text-align: center;
 }
+
+.wp-login__footer {
+	text-align: left;
+
+	a {
+		color: #87a6bc;
+		display: block;
+		font-size: 16px;
+		padding: 16px 24px;
+		text-decoration: none;
+	}
+}

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -24,6 +24,7 @@
 	"login_url": null,
 	"logout_url": null,
 	"mc_analytics_enabled": null,
+	"native_login_url": null,
 	"oauth_client_id": false,
 	"olark": {},
 	"port": null,

--- a/config/development.json
+++ b/config/development.json
@@ -25,6 +25,7 @@
 	"signup_url": "/start",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
+	"native_login_url": "/login",
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",


### PR DESCRIPTION
Also changes the `Enter a password instead` link to point back to `/login`
Only shows when the feature flag is enabled.

Until we integrate Magic Logins more fully into the flow, this provides an entry point.

## Looks Like
![ml-footer-link](https://cloud.githubusercontent.com/assets/1587282/24525064/f04515e6-1566-11e7-83c7-be536248d2b5.gif)

## To Test
* `ENABLE_FEATURES=magic-login make run`
* http://calypso.localhost:3000/login

Addresses the `Provide a simple mechanism to initiate the ML flow from the login form (e.g. a link at the bottom of the form)` item in #12677