### PR TITLE
Global Notice: Add Button Support for Global Redux Notices

### DIFF
--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -68,7 +68,7 @@ const NoticesList = React.createClass( {
 						>
 							{ notice.button }
 						</NoticeAction> }
-					</Notice>
+				</Notice>
 			);
 		}, this );
 
@@ -83,7 +83,15 @@ const NoticesList = React.createClass( {
 					duration = { notice.duration || null }
 					showDismiss={ notice.showDismiss }
 					onDismissClick={ this.props.removeNotice.bind( this, notice.noticeId ) }
-					text={ notice.text }>
+					text={ notice.text }
+				>
+					{ notice.button &&
+						<NoticeAction
+							href={ notice.href }
+							onClick={ notice.onClick }
+						>
+						{ notice.button }
+					</NoticeAction> }
 				</Notice>
 			);
 		}, this ) );

--- a/client/state/notices/README.md
+++ b/client/state/notices/README.md
@@ -54,4 +54,7 @@ The first argument is the text to be displayed on the notice. The second argumen
 * `showDismiss` (default true) To indicate if dismiss button should be rendered within the overlay.
 * `isPersistent` (default false - notices disappear when navigating route) - should notice be persistent between route changes?
 * `displayOnNextPage` (default false) - should notice appear on next route change?
+* `button` (default undefined) - Text label to display on action button
+* `href` (optional, requires button to be set as well) - Url to be used for the button action.
+* `onClick` (optional, requires button to be set as well) - Function to be invoked for the button action.
 

--- a/client/state/notices/actions.js
+++ b/client/state/notices/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import uniqueId from 'lodash/uniqueId';
+import { uniqueId } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,7 +26,10 @@ export function createNotice( status, text, options = {} ) {
 		isPersistent: options.isPersistent || false,
 		displayOnNextPage: options.displayOnNextPage || false,
 		status: status,
-		text: text
+		text: text,
+		button: options.button,
+		href: options.href,
+		onClick: options.onClick
 	};
 
 	return {


### PR DESCRIPTION
Currently the global notices do not support passing buttons arguments. 
This PR adds this ability. Which is something that is supported in the notices list.

This helps solve #12519 by letting us link to the place where we manage the Jetpack Connection. 


## To test 
add the `{ button: 'I am Button', href:'https://wordpress.com', onClick: () => {} }` as a third parameter to 
```
this.props.createNotice( )
in state/global-notices/docs/example.jsx
```

and notice that the new global notices work as expected. 
<img width="438" alt="screen shot 2017-03-30 at 14 10 57" src="https://cloud.githubusercontent.com/assets/115071/24526443/096a71b0-1553-11e7-8940-95f27831138e.png">


