### PR TITLE
NPS Survey: Show randomly 1/5000 sessions

### DIFF
--- a/client/layout/nps-survey-notice/index.jsx
+++ b/client/layout/nps-survey-notice/index.jsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
  */
 import Dialog from 'components/dialog';
 import NpsSurvey from 'blocks/nps-survey';
-import { showNpsSurveyNotice, setNpsSurveyDialogShowing } from 'state/ui/nps-survey-notice/actions';
+import { showNpsSurveyNoticeIfEligible, setNpsSurveyDialogShowing } from 'state/ui/nps-survey-notice/actions';
 import { isNpsSurveyDialogShowing } from 'state/ui/nps-survey-notice/selectors';
 
 class NpsSurveyNotice extends Component {
@@ -27,7 +27,7 @@ class NpsSurveyNotice extends Component {
 		// (1) the user gets a chance to look briefly at the uncluttered screen, and
 		// (2) the user notices the notice more, since it will cause a change to the
 		//     screen they are already looking at
-		setTimeout( this.props.showNpsSurveyNotice, 3000 );
+		setTimeout( this.props.showNpsSurveyNoticeIfEligible, 3000 );
 	}
 
 	render() {
@@ -50,5 +50,5 @@ const mapStateToProps = ( state ) => {
 
 export default connect(
 	mapStateToProps,
-	{ showNpsSurveyNotice, setNpsSurveyDialogShowing }
+	{ showNpsSurveyNoticeIfEligible, setNpsSurveyDialogShowing }
 )( NpsSurveyNotice );

--- a/client/state/ui/nps-survey-notice/actions.js
+++ b/client/state/ui/nps-survey-notice/actions.js
@@ -1,14 +1,27 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
-import {
-	NPS_SURVEY_DIALOG_IS_SHOWING,
-} from 'state/action-types';
+import { random } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import config from 'config';
 import notices from 'notices';
+import {
+	NPS_SURVEY_RAND_MAX,
+} from './constants';
+import {
+	NPS_SURVEY_DIALOG_IS_SHOWING,
+} from 'state/action-types';
+
+export function showNpsSurveyNoticeIfEligible() {
+	return ( dispatch ) => {
+		if ( 1 === random( 1, NPS_SURVEY_RAND_MAX ) ) {
+			dispatch( showNpsSurveyNotice() );
+		}
+	};
+}
 
 export function showNpsSurveyNotice() {
 	return ( dispatch ) => {
@@ -32,4 +45,8 @@ export function setNpsSurveyDialogShowing( isShowing ) {
 		type: NPS_SURVEY_DIALOG_IS_SHOWING,
 		isShowing,
 	};
+}
+
+if ( 'development' === config( 'env' ) ) {
+	window.showNpsSurveyNotice = showNpsSurveyNotice;
 }

--- a/client/state/ui/nps-survey-notice/constants.js
+++ b/client/state/ui/nps-survey-notice/constants.js
@@ -1,0 +1,1 @@
+export const NPS_SURVEY_RAND_MAX = 5000;


### PR DESCRIPTION
This PR updates the survey such that it's only randomly shown 1/5000 sessions (defined as a load of Calypso). It also exposes `showNpsSurveyNotice` on the `window` object in `development` to make triggering it easier.

![image](https://cloud.githubusercontent.com/assets/363749/24527620/98f58634-1568-11e7-83e4-33a832684390.png)

The feature remains disabled in all environments, to test:

```
ENABLE_FEATURES=nps-survey/notice make run
```

As you're unlikely to see the notice on your first page load (it shows 1/5000 times), you can trigger in manually in development from your browser console like so:

```
dispatch( showNpsSurveyNotice() );
```

To test that the random selection is working properly, change the constant  `NPS_SURVEY_RAND_MAX` to some other, smaller value (such as `2`), and reload Calypso a few times to confirm that the survey prompt only displays roughly 50% of the time.