### PR TITLE
Login: Set the background color in CSS

### DIFF
--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -30,8 +30,6 @@ export default {
 
 	login: function( context ) {
 		if ( config.isEnabled( 'oauth' ) ) {
-			// hack to keep the blue background for Desktop login
-			document.querySelector( '.layout' ).style.backgroundColor = '#0087be';
 			if ( OAuthToken.getToken() ) {
 				page( '/' );
 			} else {

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -127,61 +127,63 @@ module.exports = React.createClass( {
 
 		return (
 			<Main className="auth">
-				<WordPressLogo />
-				<form className="auth__form" onSubmit={ this.submitForm }>
-					<FormFieldset>
-						<div className="auth__input-wrapper">
-							<Gridicon icon="user"/>
-							<FormTextInput
-								name="login"
-								ref="login"
-								disabled={ requires2fa || inProgress }
-								placeholder={ this.translate( 'Username or email address' ) }
-								onFocus={ this.recordFocusEvent( 'Username or email address' ) }
-								valueLink={ this.linkState( 'login' ) } />
-						</div>
-						<div className="auth__input-wrapper">
-							<Gridicon icon="lock" />
-							<FormPasswordInput
-								name="password"
-								ref="password"
-								disabled={ requires2fa || inProgress }
-								placeholder={ this.translate( 'Password' ) }
-								onFocus={ this.recordFocusEvent( 'Password' ) }
-								hideToggle={ requires2fa }
-								submitting={ inProgress }
-								valueLink={ this.linkState( 'password' ) } />
-						</div>
-						{ requires2fa &&
-							<FormFieldset>
+				<div className="auth__content">
+					<WordPressLogo />
+					<form className="auth__form" onSubmit={ this.submitForm }>
+						<FormFieldset>
+							<div className="auth__input-wrapper">
+								<Gridicon icon="user"/>
 								<FormTextInput
-									name="auth_code"
-									type="number"
-									ref="auth_code"
-									disabled={ inProgress }
-									placeholder={ this.translate( 'Verification code' ) }
-									onFocus={ this.recordFocusEvent( 'Verification code' ) }
-									valueLink={ this.linkState( 'auth_code' ) } />
-							</FormFieldset>
-						}
-					</FormFieldset>
-					<FormButtonsBar>
-						<FormButton disabled={ ! this.canSubmitForm() } onClick={ this.recordClickEvent( 'Sign in' ) } >
-							{ requires2fa ? this.translate( 'Verify' ) : this.translate( 'Sign in' ) }
-						</FormButton>
-					</FormButtonsBar>
-					{ ! requires2fa && <LostPassword /> }
-					{ errorMessage && <Notice text={ errorMessage } status={ errorLevel } showDismiss={ false } /> }
-					{ requires2fa && <AuthCodeButton username={ this.state.login } password={ this.state.password } /> }
-				</form>
-				<a className="auth__help" target="_blank" rel="noopener noreferrer" title={ this.translate( 'Visit the WordPress.com support site for help' ) } href="https://en.support.wordpress.com/">
-					<Gridicon icon="help" />
-				</a>
-				<div className="auth__links">
-					<a href="#" onClick={ this.toggleSelfHostedInstructions }>{ this.translate( 'Add self-hosted site' ) }</a>
-					<a href={ config( 'signup_url' ) }>{ this.translate( 'Create account' ) }</a>
+									name="login"
+									ref="login"
+									disabled={ requires2fa || inProgress }
+									placeholder={ this.translate( 'Username or email address' ) }
+									onFocus={ this.recordFocusEvent( 'Username or email address' ) }
+									valueLink={ this.linkState( 'login' ) } />
+							</div>
+							<div className="auth__input-wrapper">
+								<Gridicon icon="lock" />
+								<FormPasswordInput
+									name="password"
+									ref="password"
+									disabled={ requires2fa || inProgress }
+									placeholder={ this.translate( 'Password' ) }
+									onFocus={ this.recordFocusEvent( 'Password' ) }
+									hideToggle={ requires2fa }
+									submitting={ inProgress }
+									valueLink={ this.linkState( 'password' ) } />
+							</div>
+							{ requires2fa &&
+								<FormFieldset>
+									<FormTextInput
+										name="auth_code"
+										type="number"
+										ref="auth_code"
+										disabled={ inProgress }
+										placeholder={ this.translate( 'Verification code' ) }
+										onFocus={ this.recordFocusEvent( 'Verification code' ) }
+										valueLink={ this.linkState( 'auth_code' ) } />
+								</FormFieldset>
+							}
+						</FormFieldset>
+						<FormButtonsBar>
+							<FormButton disabled={ ! this.canSubmitForm() } onClick={ this.recordClickEvent( 'Sign in' ) } >
+								{ requires2fa ? this.translate( 'Verify' ) : this.translate( 'Sign in' ) }
+							</FormButton>
+						</FormButtonsBar>
+						{ ! requires2fa && <LostPassword /> }
+						{ errorMessage && <Notice text={ errorMessage } status={ errorLevel } showDismiss={ false } /> }
+						{ requires2fa && <AuthCodeButton username={ this.state.login } password={ this.state.password } /> }
+					</form>
+					<a className="auth__help" target="_blank" rel="noopener noreferrer" title={ this.translate( 'Visit the WordPress.com support site for help' ) } href="https://en.support.wordpress.com/">
+						<Gridicon icon="help" />
+					</a>
+					<div className="auth__links">
+						<a href="#" onClick={ this.toggleSelfHostedInstructions }>{ this.translate( 'Add self-hosted site' ) }</a>
+						<a href={ config( 'signup_url' ) }>{ this.translate( 'Create account' ) }</a>
+					</div>
+					{ showInstructions && <SelfHostedInstructions onClickClose={ this.toggleSelfHostedInstructions } /> }
 				</div>
-				{ showInstructions && <SelfHostedInstructions onClickClose={ this.toggleSelfHostedInstructions } /> }
 			</Main>
 		);
 	}

--- a/client/auth/style.scss
+++ b/client/auth/style.scss
@@ -10,9 +10,7 @@
 		margin: 0 auto;
 		overflow: hidden;
 		max-width: none;
-		padding-top: 32px;
-		padding-left: 0;
-		padding-right: 0;
+		padding: 0;
 	}
 
 	.layout__content::after {
@@ -29,15 +27,19 @@
 }
 
 .auth.main {
+	background: $blue-wordpress;
 	float: none;
 	height: 100%;
-	margin: 0 auto;
-	text-align: center;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
 	align-content: center;
-	background: none;
+	max-width: 100%;
+}
+
+.auth__content {
+	margin: 0 auto;
+	text-align: center;
 
 	.notice {
 		width: calc( 100% - 20px );


### PR DESCRIPTION
In #12594 we introduced a hack to set the background color to blue for the OAuth login screen. This seems to be possible to do in CSS.

<img width="898" alt="screen shot 2017-03-31 at 11 46 04" src="https://cloud.githubusercontent.com/assets/275961/24547437/b14e7ad4-1607-11e7-9f44-633483569ffa.png">
  
#### Testing instructions
  
1. Run `git checkout update/login`
2. Update the config at config/development.json to set features.oauth to true and features.wp-login to false
2. Open the [`Login` page](http://calypso.localhost:3000/login)
3. Check that the background is still blue

#### Reviews
  
- [x] Code
- [x] Product
   
@Automattic/sdev-feed