### PR TITLE
Add Contents tab settings

### DIFF
--- a/client/extensions/wp-super-cache/cached-files.jsx
+++ b/client/extensions/wp-super-cache/cached-files.jsx
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import FoldableCard from 'components/foldable-card';
+
+const CachedFiles = ( {
+	files,
+	header,
+	translate,
+} ) => {
+	return (
+		<FoldableCard compact
+			className="wp-super-cache__foldable-card"
+			header={ header }>
+			<ul className="wp-super-cache__contents-list wp-super-cache__contents-list-legend">
+				<li className="wp-super-cache__contents-list-item">
+					<span className="wp-super-cache__contents-list-item-right">
+						<span className="wp-super-cache__contents-list-item-value">
+							{ translate( 'Age' ) }
+						</span>
+						<span className="wp-super-cache__contents-list-item-action"></span>
+					</span>
+					<span className="wp-super-cache__contents-list-item-label">
+						{ translate( 'URI' ) }
+					</span>
+				</li>
+			</ul>
+
+			<ul className="wp-super-cache__contents-list">
+			{ files && files.map( ( file ) =>
+				<li className="wp-super-cache__contents-list-item" key={ file.uri }>
+					<span className="wp-super-cache__contents-list-item-right">
+						<span className="wp-super-cache__contents-list-item-value">
+							{ file.age }
+						</span>
+						<span className="wp-super-cache__contents-list-item-action">
+							<Button compact>
+								{ translate( 'Delete' ) }
+							</Button>
+						</span>
+					</span>
+					<span className="wp-super-cache__contents-list-item-label">
+						<a href={ `http://${ file.uri }` }>
+							{ file.uri }
+						</a>
+					</span>
+				</li>
+			) }
+			</ul>
+		</FoldableCard>
+	);
+};
+
+export default localize( CachedFiles );

--- a/client/extensions/wp-super-cache/contents-tab.js
+++ b/client/extensions/wp-super-cache/contents-tab.js
@@ -1,0 +1,161 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { pick } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+import CachedFiles from './cached-files';
+import SectionHeader from 'components/section-header';
+import WrapSettingsForm from './wrap-settings-form';
+
+const ContentsTab = ( {
+	fields: {
+		cache_max_time,
+		generated,
+		supercache,
+		wpcache,
+		wp_cache_object_cache,
+	},
+	isMultisite,
+	translate,
+} ) => {
+	const wpCacheCachedCount = wpcache && wpcache.cached_list ? wpcache.cached_list.length : 0;
+	const wpCacheExpiredCount = wpcache && wpcache.expired_list ? wpcache.expired_list.length : 0;
+	const supercacheCachedCount = supercache && supercache.cached_list ? supercache.cached_list.length : 0;
+	const supercacheExpiredCount = supercache && supercache.expired_list ? supercache.expired_list.length : 0;
+
+	return (
+		<div>
+			<SectionHeader label={ translate( 'Cache Contents' ) } />
+			<Card compact>
+			{ wp_cache_object_cache &&
+				<p>
+					{ translate( 'Object cache in use. No cache listing available.' ) }
+				</p>
+			}
+			{ ! wp_cache_object_cache &&
+				<div>
+				{ wpcache &&
+					<div className="wp-super-cache__cache-stat">
+						<span className="wp-super-cache__cache-stat-label">
+							{ translate(
+								'WP-Cache (%(size)s)',
+								{
+									args: { size: wpcache && wpcache.fsize || '0KB' },
+								}
+							) }
+						</span>
+						<span className="wp-super-cache__cache-stat-item">
+							{ `${ wpCacheCachedCount } Cached Pages` }
+						</span>
+						<span className="wp-super-cache__cache-stat-item">
+							{ `${ wpCacheExpiredCount } Expired Pages` }
+						</span>
+					</div>
+				}
+
+				{ supercache &&
+					<div className="wp-super-cache__cache-stat">
+						<span className="wp-super-cache__cache-stat-label">
+							{ translate(
+								'WP-Super-Cache (%(size)s)',
+								{
+									args: { size: supercache && supercache.fsize || '0KB' },
+								}
+							) }
+						</span>
+						<span className="wp-super-cache__cache-stat-item">
+							{ `${ supercacheCachedCount } Cached Pages` }
+						</span>
+						<span className="wp-super-cache__cache-stat-item">
+							{ `${ supercacheExpiredCount } Expired Pages` }
+						</span>
+					</div>
+				}
+
+				{ ( wpcache || supercache ) &&
+					<p className="wp-super-cache__cache-stat-refresh">
+						{ translate(
+							'Cache stats last generated: %(generated)d minutes ago.',
+							{
+								args: { generated: generated || 0 },
+							}
+						) }
+					</p>
+				}
+					<Button compact>
+						{ translate( 'Regenerate Cache Stats' ) }
+					</Button>
+				</div>
+			}
+			</Card>
+
+		{ ! wp_cache_object_cache &&
+			<div>
+			{ wpcache && wpcache.cached_list &&
+				<CachedFiles header="Fresh WP-Cached Files" files={ wpcache.cached_list } />
+			}
+
+			{ wpcache && wpcache.expired_list &&
+				<CachedFiles header="Stale WP-Cached Files" files={ wpcache.expired_list } />
+			}
+
+			{ supercache && supercache.cached_list &&
+				<CachedFiles header="Fresh Super Cached Files" files={ supercache.cached_list } />
+			}
+
+			{ supercache && supercache.expired_list &&
+				<CachedFiles header="Stale Super Cached Files" files={ supercache.expired_list } />
+			}
+			</div>
+		}
+
+			<Card>
+				{ !! cache_max_time &&
+					<p>
+						{ translate(
+							'Expired files are files older than %(cache_max_time)d seconds. They are still used by ' +
+							'the plugin and are deleted periodically.',
+							{
+								args: { cache_max_time: cache_max_time || 0 }
+							}
+						) }
+					</p>
+				}
+				<div>
+					<Button compact primary>
+						{ translate( 'Delete Expired' ) }
+					</Button>
+					<Button compact>
+						{ translate( 'Delete Cache' ) }
+					</Button>
+					{ isMultisite &&
+						<Button compact>
+							{ translate( 'Delete Cache On All Blogs' ) }
+						</Button>
+					}
+				</div>
+			</Card>
+		</div>
+	);
+};
+const getFormSettings = settings => {
+	const cacheStats = pick( settings.cache_stats, [
+		'generated',
+		'supercache',
+		'wpcache',
+	] );
+	const otherSettings = pick( settings, [
+		'cache_max_time',
+		'wp_cache_object_cache',
+	] );
+
+	return Object.assign( {}, cacheStats, otherSettings );
+};
+
+export default WrapSettingsForm( getFormSettings )( ContentsTab );

--- a/client/extensions/wp-super-cache/main.jsx
+++ b/client/extensions/wp-super-cache/main.jsx
@@ -7,6 +7,7 @@ import React, { PropTypes } from 'react';
  * Internal dependencies
  */
 import AdvancedTab from './advanced-tab';
+import ContentsTab from './contents-tab';
 import Easy from './easy';
 import Main from 'components/main';
 import Navigation from './navigation';
@@ -20,7 +21,7 @@ const WPSuperCache = ( { site, tab } ) => {
 			case Tabs.CDN:
 				break;
 			case Tabs.CONTENTS:
-				break;
+				return <ContentsTab isMultisite={ site.is_multisite } />;
 			case Tabs.PRELOAD:
 				break;
 			case Tabs.PLUGINS:

--- a/client/extensions/wp-super-cache/style.scss
+++ b/client/extensions/wp-super-cache/style.scss
@@ -10,6 +10,10 @@
 	margin-top: 3px;
 }
 
+.wp-super-cache__main .button {
+	margin-right: 8px;
+}
+
 .wp-super-cache__cache-timeout.form-text-input {
 	width: 100px;
 	margin-right: 10px;
@@ -36,4 +40,74 @@
 .wp-super-cache__directly-cached-files .form-text-input,
 .wp-super-cache__directly-cached-files .form-text-input-with-action {
 	width: 300px;
+}
+
+// Contents Tab
+.wp-super-cache__cache-stat {
+	margin-bottom: 20px;
+}
+
+.wp-super-cache__cache-stat-label {
+	display: block;
+	font-size: 14px;
+	font-weight: 600;
+	margin-bottom: 5px;
+}
+
+.wp-super-cache__cache-stat-item {
+	display: block;
+}
+
+.wp-super-cache__cache-stat-refresh {
+	font-style: italic;
+	font-size: 13px;
+}
+
+.wp-super-cache__foldable-card.is-compact .foldable-card__header {
+	padding: 24px;
+}
+
+.wp-super-cache__contents-list {
+	padding: 0;
+	margin: 0 0 .5em;
+	list-style-type: none;
+}
+
+.wp-super-cache__contents-list-legend {
+	padding-top: .5em;
+	margin-bottom: 0;
+}
+
+.wp-super-cache__contents-list-legend .wp-super-cache__contents-list-item-value,
+.wp-super-cache__contents-list-legend .wp-super-cache__contents-list-item-label {
+	color: $gray;
+	font-weight: bold;
+}
+
+.wp-super-cache__contents-list-item {
+	font-size: 14px;
+	line-height: 28px;
+	margin-bottom: 5px;
+}
+
+.wp-super-cache__contents-list-item-right {
+	float: right;
+}
+
+.wp-super-cache__contents-list-item-label {
+	display: block;
+	overflow: hidden;
+	word-break: break-all;
+}
+
+.wp-super-cache__contents-list-item-value {
+	display: inline-block;
+	min-width: 44px;
+	margin: 0 1em 0 0;
+	text-align: right;
+}
+
+.wp-super-cache__contents-list-item-action {
+	display: inline-block;
+	width: 60px;
 }

--- a/client/extensions/wp-super-cache/wrap-settings-form.jsx
+++ b/client/extensions/wp-super-cache/wrap-settings-form.jsx
@@ -104,7 +104,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 
 				// Expiry Time & Garbage Collection
 				cache_gc_email_me: false,
-				cache_max_time: '3600',
+				cache_max_time: 3600,
 				cache_schedule_interval: 'five_minutes_interval',
 				cache_schedule_type: 'interval',
 				cache_scheduled_time: '00:00',
@@ -142,6 +142,57 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				wp_cache_path: '/wordpress/',
 				wp_cache_readonly: false,
 				wp_cache_writable: false,
+
+				// Contents
+				cache_stats: {
+					generated: 60,
+					supercache: {
+						cached_list: [
+							{
+								age: 3029,
+								uri: 'localhost/blogs/',
+							},
+							{
+								age: 3031,
+								uri: 'localhost/professionals/',
+							},
+							{
+								age: 3322,
+								uri: 'localhost/',
+							},
+						],
+						expired_list: [
+							{
+								age: 4975,
+								uri: 'localhost/support/',
+							},
+							{
+								age: 4973,
+								uri: 'localhost/get-involved/',
+							},
+						],
+						fsize: '69.78KB',
+					},
+					wpcache: {
+						cached_list: [
+							{
+								age: 95,
+								uri: 'localhost/support-info/',
+							},
+							{
+								age: 3031,
+								uri: 'localhost/about/',
+							},
+						],
+						expired_list: [
+							{
+								age: 81,
+								uri: 'localhost/blogs/',
+							},
+						],
+						fsize: '32.18KB',
+					},
+				},
 			};
 
 			return {


### PR DESCRIPTION
This PR adds settings for the Contents tab of WP Super Cache.

_Contents Tab in WordPress Plugin - Single Site_

![contents-wp-super-cache](https://cloud.githubusercontent.com/assets/1190420/24548524/9b49f46c-15e3-11e7-94b4-fdd9a69a88b7.jpg)

_Contents Tab in Calypso - Single Site_

![contents-calypso-single](https://cloud.githubusercontent.com/assets/1190420/24549080/bcc614ac-15e5-11e7-8403-652ac1811e92.jpg)

_Contents Tab in Calypso - Multisite_

![contents-calypso](https://cloud.githubusercontent.com/assets/1190420/24548443/3ab8cc54-15e3-11e7-8c05-816c2c1bca54.jpg)