### PR TITLE
Jetpack: Disable new descriptions test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -63,8 +63,10 @@ module.exports = {
 	jetpackNewDescriptions: {
 		datestamp: '20170327',
 		variations: {
-			showNew: 50,
-			showOld: 50
+			showNew: 0,
+			showOld: 100 /* test completed. I'm disabling it here first because
+						it need some work to remove the added code for the
+						new variation that's not going to be used */
 		},
 		defaultVariation: 'showOld',
 		allowExistingUsers: true


### PR DESCRIPTION
The new descriptions test data were not very good, so we are disabling it. It still needs some work to remove the new, now not used code, but we want to remove it from production right away, so I'm changing the test to send 100% of the traffic to the old variant.