### PR TITLE
Featured Image: Fix pencil icon positioning

### DIFF
--- a/client/post-editor/editor-featured-image/style.scss
+++ b/client/post-editor/editor-featured-image/style.scss
@@ -11,6 +11,10 @@
 	vertical-align: top;
 	max-width: 100%;
 
+	&.button {
+		padding-bottom: 0;
+	}
+
 	&.button.is-borderless .editor-featured-image__edit-icon {
 		position: absolute;
 			top: auto;


### PR DESCRIPTION
#12674 introduced a slight mispositioning. Note the pencil icon in the bottom-right corner of the featured image button.

Before:
<img width="751" alt="screen shot 2017-03-31 at 15 24 23" src="https://cloud.githubusercontent.com/assets/150562/24554613/2479f0ce-1626-11e7-8f2a-97bc0d040d47.png">

After:
<img width="784" alt="screen shot 2017-03-31 at 15 24 12" src="https://cloud.githubusercontent.com/assets/150562/24554623/2d9149f0-1626-11e7-99b5-d283714738f6.png">
