### PR TITLE
AT: Redirect AT sites from Jetpack plans page

### DIFF
--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -36,6 +36,7 @@ import {
 	isCalypsoStartedConnection
 } from 'state/jetpack-connect/selectors';
 import { mc } from 'lib/analytics';
+import { isSiteAutomatedTransfer } from 'state/selectors';
 
 const CALYPSO_REDIRECTION_PAGE = '/posts/';
 const CALYPSO_PLANS_PAGE = '/plans/my-plan/';
@@ -69,6 +70,10 @@ class Plans extends Component {
 	}
 
 	componentDidUpdate() {
+		if ( this.props.isAutomatedTransfer && ! this.redirecting ) {
+			this.redirect( CALYPSO_REDIRECTION_PAGE );
+		}
+
 		if ( this.hasPlan( this.props.selectedSite ) && ! this.redirecting ) {
 			this.redirect( CALYPSO_PLANS_PAGE );
 		}
@@ -297,6 +302,7 @@ export default connect(
 			selectedSite,
 			selectedSiteSlug,
 			selectedPlan,
+			isAutomatedTransfer: selectedSite ? isSiteAutomatedTransfer( state, selectedSite.ID ) : false,
 			sitePlans: getPlansBySite( state, selectedSite ),
 			jetpackConnectAuthorize: getAuthorizationData( state ),
 			userId: user ? user.ID : null,

--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -70,8 +70,9 @@ class Plans extends Component {
 	}
 
 	componentDidUpdate() {
-		if ( this.props.isAutomatedTransfer && ! this.redirecting ) {
-			this.redirect( CALYPSO_REDIRECTION_PAGE );
+		if ( this.props.isAutomatedTransfer && ! this.redirecting && this.props.selectedSite ) {
+			this.redirecting = true;
+			this.props.goBackToWpAdmin( this.props.selectedSite.URL + JETPACK_ADMIN_PATH );
 		}
 
 		if ( this.hasPlan( this.props.selectedSite ) && ! this.redirecting ) {


### PR DESCRIPTION
We have successfully solved reconnection issues when AT user is trying to reconnect the site ( D4953-code ).

The problem remains, that after user reconnects, she gets shown JP plans.
AT sites SHOULD NOT have JP sites, so if user buys one, its bad.

This PR redirects the user away from the plans page once we have enough data that it's a AT site.

## Testing instructions

Go to http://calypso.localhost:3000/jetpack/connect/plans/hypertransfer73.blog

[replace slug with your site]

If its a AT site, you will be redirected to /posts.
Otherwise, functionality will stay as it is.