### PR TITLE
Reader: updates ReaderSubscriptionListItem to use ReaderAvatar

### DIFF
--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -44,7 +44,7 @@ const ReaderAvatar = ( {
 	}
 
 	let hasSiteIcon = !! get( fakeSite, 'icon.img' );
-	let hasAvatar = !! ( author && author.has_avatar );
+	let hasAvatar = ( author && get( author, 'has_avatar', true ) );
 
 	if ( hasSiteIcon && hasAvatar ) {
 		// Do these both reference the same image? Disregard query string params.

--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -44,7 +44,7 @@ const ReaderAvatar = ( {
 	}
 
 	let hasSiteIcon = !! get( fakeSite, 'icon.img' );
-	let hasAvatar = ( author && get( author, 'has_avatar', true ) );
+	let hasAvatar = !! ( author && author.has_avatar );
 
 	if ( hasSiteIcon && hasAvatar ) {
 		// Do these both reference the same image? Disregard query string params.

--- a/client/blocks/reader-subscription-list-item/docs/example.jsx
+++ b/client/blocks/reader-subscription-list-item/docs/example.jsx
@@ -55,19 +55,19 @@ const items = [
 		}
 	},
 	{
-   siteUrl: 'http://b19ytest.wordpress.com',
-   siteTitle: 'AAAA BEST BLOG WOULD BLOG AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN',
-   siteAuthor:{
-      name: 'b3n low3ry',
-      first_name: 'Ben',
-      last_name: 'Lowery',
-      URL: 'http://b19y.com',
-      avatar_URL: 'https://0.gravatar.com/avatar/3b7b2c457b9201d166b9a2b47cadc86d?s=96&d=identicon&r=G'
-   },
-   siteExcerpt:'BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS',
-   feedId:25320833,
-   siteId:77147075,
-   feed: {  image: 'http://s2.wp.com/i/buttonw-com.png' }
+		siteUrl: 'http://b19ytest.wordpress.com',
+		siteTitle: 'AAAA BEST BLOG WOULD BLOG AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN',
+		siteAuthor: {
+			name: 'b3n low3ry',
+			first_name: 'Ben',
+			last_name: 'Lowery',
+			URL: 'http://b19y.com',
+			avatar_URL: 'https://0.gravatar.com/avatar/3b7b2c457b9201d166b9a2b47cadc86d?s=96&d=identicon&r=G'
+		},
+		siteExcerpt: 'BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS',
+		feedId: 25320833,
+		siteId: 77147075,
+		feed: { image: 'http://s2.wp.com/i/buttonw-com.png' }
 	},
 	{
 		siteUrl: 'http://theatlantic.com/feed/all',

--- a/client/blocks/reader-subscription-list-item/docs/example.jsx
+++ b/client/blocks/reader-subscription-list-item/docs/example.jsx
@@ -38,16 +38,55 @@ const items = [
 	},
 	{
 		siteAuthor: {
-			avatar_URL: 'https://1.gravatar.com/avatar/d1becc42ff085294b51c77f3ce850b15?d=mm&r=G&s=96',
-			first_name: 'Morgan',
-			last_name: 'Pencek',
+			avatar_URL: 'https://1.gravatar.com/avatar/d32da26cc0df3353cc997eea1da557a6?s=96&d=https%3A%2F%2Fs0.wp.com%2Fi%2Fmu.gif&r=G',
+			first_name: 'Ben',
+			last_name: 'Orlin',
+			has_avatar: false,
 		},
-		siteUrl: 'https://notyourtypicalhippie.wordpress.com/',
-		siteTitle: 'Not Your Typical Hippi',
-		siteExcerpt: 'Starting Young ♢ Living Healthy',
+		siteUrl: 'http://mathwithbaddrawings.com',
+		siteTitle: 'Math with Bad Drawings',
+		siteExcerpt: 'Math, teaching, copious metaphors, and drawings that will never ever earn a spot on the fridge',
+		lastUpdated: new Date() - 1000000,
+		feedId: '10056049',
+		site: {
+			icon: {
+				img: 'https://secure.gravatar.com/blavatar/11f9cce0bbf89940278ac446f3c3505a',
+			}
+		}
+	},
+	{
+   siteUrl: 'http://b19ytest.wordpress.com',
+   siteTitle: 'AAAA BEST BLOG WOULD BLOG AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN',
+   siteAuthor:{
+      name: 'b3n low3ry',
+      first_name: 'Ben',
+      last_name: 'Lowery',
+      URL: 'http://b19y.com',
+      avatar_URL: 'https://0.gravatar.com/avatar/3b7b2c457b9201d166b9a2b47cadc86d?s=96&d=identicon&r=G'
+   },
+   siteExcerpt:'BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS',
+   feedId:25320833,
+   siteId:77147075,
+   feed: {  image: 'http://s2.wp.com/i/buttonw-com.png' }
+	},
+	{
+		siteUrl: 'http://theatlantic.com/feed/all',
+		siteTitle: 'The Atlantic',
 		lastUpdated: new Date() - 100000,
-		feedId: '42747358',
-	}
+		feedId: '49548095',
+	},
+	{
+		siteUrl: 'http://uproxx.com',
+		siteTitle: 'Real Stories – UPROXX',
+		siteExcerpt: 'The Culture Of Now',
+		lastUpdated: new Date() - 100000,
+		feedId: '19850964',
+		site: {
+			icon: {
+				img: 'https://secure.gravatar.com/blavatar/bae760df0e3bd64e122a0b36facaee58',
+			}
+		}
+	},
 ]
 
 export default class ReaderSubscriptionListItemExample extends PureComponent {

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -3,14 +3,14 @@
  */
 import React from 'react';
 import classnames from 'classnames';
-import { trim, isEmpty } from 'lodash';
+import { trim, isEmpty, get } from 'lodash';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
 
 /**
  * Internal Dependencies
  */
-import Gravatar from 'components/gravatar';
+import ReaderAvatar from 'blocks/reader-avatar';
 import FollowButton from 'reader/follow-button';
 import Gridicon from 'gridicons';
 import { getStreamUrl } from 'reader/route';
@@ -36,39 +36,47 @@ function ReaderSubscriptionListItem( {
 	siteAuthor,
 	siteExcerpt,
 	feedId,
+	feed,
 	siteId,
+	site,
 	className = '',
-	onSiteClick = () => {},
 	followSource,
 	lastUpdated,
 	translate,
 } ) {
 	// prefer a users name property
 	// if that doesn't exist settle for combining first and last name
-	const authorName = siteAuthor.name ||
-		trim( `${ siteAuthor.first_name || '' } ${ siteAuthor.last_name || '' }` );
-	const readerStreamUrl = getStreamUrl( feedId, siteId );
+	const authorName = siteAuthor && ( siteAuthor.name ||
+		trim( `${ siteAuthor.first_name || '' } ${ siteAuthor.last_name || '' }` ) );
+	const siteIcon = get( site, 'icon.img' );
+	const feedIcon = get( feed, 'image' );
+	const streamUrl = getStreamUrl( feedId, siteId );
 
 	return (
 		<div className={ classnames( 'reader-subscription-list-item', className ) }>
 			<div>
-				<a href={ siteUrl } onClick={ onSiteClick }>
-					<Gravatar user={ siteAuthor } />
-				</a>
+				<ReaderAvatar
+					siteIcon={ siteIcon }
+					feedIcon={ feedIcon }
+					author={ siteAuthor }
+					preferGravatar={ true }
+					siteUrl={ streamUrl }
+					isCompact={ true }
+				/>
 			</div>
 			<div className="reader-subscription-list-item__byline">
-				<span className="reader-subscription-list-item__site-title">{ <a href={ readerStreamUrl }> { siteTitle } </a> }</span>
+				<span className="reader-subscription-list-item__site-title">{ <a href={ streamUrl }> { siteTitle } </a> }</span>
 				{ ! isEmpty( authorName ) &&
 					<span>
 						<span className="reader-subscription-list-item__by-text">
 							{ translate( 'by' ) }
 						</span>
-						<span><a href={ readerStreamUrl }> { authorName } </a></span>
+						<span><a href={ streamUrl }> { authorName } </a></span>
 					</span>
 				}
 				<div>{ siteExcerpt }</div>
 				<div className="reader-subscription-list-item__site-url">
-					<a href={ siteUrl }> { stripUrl( siteUrl ) } </a>
+					<a href={ siteUrl }> { siteUrl && stripUrl( siteUrl ) } </a>
 					{ moment( lastUpdated ).fromNow() }
 				</div>
 			</div>

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -59,4 +59,6 @@
 	display: flex;
 	flex-direction: column;
 	margin-left: auto;
+	width: 75px;
+	min-width: 75px;
 }

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -59,6 +59,6 @@
 	display: flex;
 	flex-direction: column;
 	margin-left: auto;
-	width: 75px;
-	min-width: 75px;
+	width: 90px;
+	min-width: 90px;
 }


### PR DESCRIPTION
Few things:

1. adding more examples to the devdocs to better represent how a list of sites would really look (gravatar, blavatar, neither, super long title, etc).
3. ReaderSubscriptionListItem needed to be more defensive about missing values

TODO in future PRs:
- [ ] lots o css magic
- [ ] settings popout

To Test:
- This PR doesn't affect anything currently in use so just check out the devdocs for subscriptionlistitem