### PR TITLE
Add redux-multi.

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1169,6 +1169,20 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
+### https://github.com/ashaffer/redux-multi
+#### client/state
+```text
+The MIT License (MIT)
+
+Copyright (c) 2015, Weo.io
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
 ### https://github.com/reactjs/react-redux
 ```text
 The MIT License (MIT)

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import thunkMiddleware from 'redux-thunk';
+import multi from 'redux-multi';
 import { createStore, applyMiddleware, combineReducers, compose } from 'redux';
 
 /**
@@ -130,6 +131,7 @@ export function createReduxStore( initialState = {} ) {
 
 	const middlewares = [
 		thunkMiddleware,
+		multi,
 		noticesMiddleware,
 		isBrowser && require( './happychat/middleware.js' ).default(),
 		isBrowser && require( './analytics/middleware.js' ).analyticsMiddleware,

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "react-redux": "5.0.3",
     "react-virtualized": "8.8.1",
     "redux": "3.0.4",
+    "redux-multi": "0.1.12",
     "redux-thunk": "1.0.0",
     "rtlcss": "2.0.5",
     "sanitize-html": "1.11.1",


### PR DESCRIPTION
This PR adds [redux-multi](https://github.com/ashaffer/redux-multi) to our middleware for firing multiple actions from one action creator.

I have a need to take  state and convert that into multiple add actions. After talking with Kevin, it looks like redux-multi is a good choice for this.

This is related to #12684 and our work on product & variation management for WooCommerce (that PR is WIP and is going to be split up): A set of variation types (think color, size, etc) and their values, as well as existing variations, will be used to generate new product variations. The action creator that will do this will return multiple add variation calls for each new one that needs to be created.

`make test` correctly passes & I tested a couple different parts of Calypso.