### PR TITLE
Sharing: fix connecting conflicting accounts

### DIFF
--- a/client/my-sites/sharing/connections/account-dialog.jsx
+++ b/client/my-sites/sharing/connections/account-dialog.jsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { filter, find, identity, isEqual } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import Notice from 'components/notice';
 
 /**
  * Internal dependencies
@@ -113,12 +113,21 @@ class AccountDialog extends Component {
 		const connectedAccounts = this.getAccountsByConnectedStatus( true );
 
 		if ( connectedAccounts.length ) {
+			const hasConflictingAccounts = this.isSelectedAccountConflicting();
+
 			return (
 				<div className="account-dialog__connected-accounts">
 					<h3 className="account-dialog__connected-accounts-heading">{ this.props.translate( 'Connected' ) }</h3>
 					<ul className="account-dialog__accounts">
 						{ this.getAccountElements( connectedAccounts ) }
 					</ul>
+					{ hasConflictingAccounts &&
+					<Notice
+						status="is-warning"
+						icon="notice"
+						text={ this.props.translate( 'The marked connection will be replaced with your selection.' ) }
+						isCompact />
+					}
 				</div>
 			);
 		}
@@ -152,13 +161,6 @@ class AccountDialog extends Component {
 				{ action: 'connect', label: this.props.translate( 'Connect' ), isPrimary: true }
 			];
 
-		if ( this.isSelectedAccountConflicting() ) {
-			this.props.warningNotice( this.props.translate( 'The connection marked {{icon/}} will be replaced with your selection.', {
-				components: { icon: <Gridicon icon="notice" size={ 18 } /> },
-				context: 'Sharing: Publicize confirmation',
-			} ), { showDismiss: false } );
-		}
-
 		return (
 			<Dialog isVisible={ this.props.isVisible } buttons={ buttons } additionalClassNames={ classes } onClose={ this.onClose }>
 				<h2 className="account-dialog__authorizing-service">
@@ -170,6 +172,7 @@ class AccountDialog extends Component {
 				<p className="account-dialog__authorizing-disclaimer">{ this.getDisclaimerText() }</p>
 				<ul className="account-dialog__accounts">{ this.getAccountElements( this.getAccountsByConnectedStatus( false ) ) }</ul>
 				{ this.getConnectedAccountsContent() }
+
 			</Dialog>
 		);
 	}

--- a/client/my-sites/sharing/connections/service.jsx
+++ b/client/my-sites/sharing/connections/service.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
-import { identity, find, replace, some } from 'lodash';
+import { identity, isEqual, find, replace, some } from 'lodash';
 import { localize } from 'i18n-calypso';
 import SocialLogo from 'social-logos';
 
@@ -234,7 +234,7 @@ class SharingService extends Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		if ( this.props.siteUserConnections.length !== nextProps.siteUserConnections.length ) {
+		if ( ! isEqual( this.props.siteUserConnections, nextProps.siteUserConnections ) ) {
 			this.setState( {
 				isConnecting: false,
 				isDisconnecting: false,
@@ -242,7 +242,7 @@ class SharingService extends Component {
 			} );
 		}
 
-		if ( this.props.brokenConnections.length !== nextProps.brokenConnections.length ) {
+		if ( ! isEqual( this.props.brokenConnections, nextProps.brokenConnections ) ) {
 			this.setState( { isRefreshing: false } );
 		}
 


### PR DESCRIPTION
This PR fixes an issue where clicking on "Add a different account" will crash the page when adding an additional account that has a conflict. Eg, we've added a Facebook account, but we want to replace add a Facebook Page that's already linked to the account.

## Testing Instructions
- Navigate to http://calypso.localhost:3000/sharing/:siteId:
- Connect an account that has a facebook page, but select the main account
- Connect another facebook account, a dialog should appear that lets you select either the page, but with a notice that it will replace the existing connection
- Clicking proceeds through connection flow
- You can connect other social accounts

In prod this will hard crash your browser, since we get into an infinite loop.

### Notes

It appears that a dispatch to display a warning notice in render was causing this to explode. As an alternative I opted for an inline notice. Design suggestions are welcome. @obenland suggested that maybe we should just update the instruction text in this case?

<img width="516" alt="screen shot 2017-03-31 at 2 26 43 pm" src="https://cloud.githubusercontent.com/assets/1270189/24570597/1c2cde5e-1621-11e7-8b9f-3b3c1cd7d008.png">
