### PR TITLE
Happychat: Improve connection Redux lifecycle

### DIFF
--- a/client/components/happychat/connection.jsx
+++ b/client/components/happychat/connection.jsx
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import { connectChat } from 'state/happychat/actions';
+import { isHappychatUninitialized } from 'state/happychat/selectors';
+
+class HappychatConnection extends Component {
+	componentDidMount() {
+		if ( config.isEnabled( 'happychat' ) && this.props.isUninitialized ) {
+			this.props.connectChat();
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect(
+	state => ( {
+		isUninitialized: isHappychatUninitialized( state )
+	} ),
+	{ connectChat }
+)( HappychatConnection );

--- a/client/components/happychat/index.jsx
+++ b/client/components/happychat/index.jsx
@@ -14,7 +14,6 @@ import {
 	any,
 	when
 } from './functional';
-import { connectChat } from 'state/happychat/actions';
 import {
 	getHappychatConnectionStatus
 } from 'state/happychat/selectors';
@@ -33,6 +32,7 @@ import {
 	timeline,
 	composer
 } from './helpers';
+import HappychatConnection from './connection';
 import Notices from './notices';
 import { translate } from 'i18n-calypso';
 
@@ -87,11 +87,6 @@ const title = first(
  * Main chat UI component
  */
 const Happychat = React.createClass( {
-
-	componentDidMount() {
-		this.props.connectChat();
-	},
-
 	render() {
 		const {
 			connectionStatus,
@@ -103,6 +98,7 @@ const Happychat = React.createClass( {
 
 		return (
 			<div className="happychat">
+				<HappychatConnection />
 				<div
 					className={ classnames( 'happychat__container', {
 						'is-open': isChatOpen( { connectionStatus } ),
@@ -145,9 +141,6 @@ const mapDispatch = ( dispatch ) => {
 				dispatch( closeChat() );
 			}, 500 );
 		},
-		connectChat() {
-			dispatch( connectChat() );
-		}
 	};
 };
 

--- a/client/lib/happychat/connection.js
+++ b/client/lib/happychat/connection.js
@@ -19,11 +19,11 @@ class Connection extends EventEmitter {
 				const url = config( 'happychat_url' );
 				const socket = new IO( url );
 				socket
-					.once( 'connect', () => {
-						debug( 'connected' );
-						this.emit( 'connect' );
+					.once( 'connect', () => debug( 'connected' ) )
+					.on( 'init', () => {
+						this.emit( 'connected' );
+						resolve( socket );
 					} )
-					.on( 'init', () => resolve( socket ) )
 					.on( 'token', handler => {
 						handler( { signer_user_id: user_id, jwt: token, locale } );
 					} )

--- a/client/lib/happychat/connection.js
+++ b/client/lib/happychat/connection.js
@@ -19,7 +19,10 @@ class Connection extends EventEmitter {
 				const url = config( 'happychat_url' );
 				const socket = new IO( url );
 				socket
-					.once( 'connect', () => debug( 'connected' ) )
+					.once( 'connect', () => {
+						debug( 'connected' );
+						this.emit( 'connect' );
+					} )
 					.on( 'init', () => resolve( socket ) )
 					.on( 'token', handler => {
 						handler( { signer_user_id: user_id, jwt: token, locale } );

--- a/client/me/happychat/main.jsx
+++ b/client/me/happychat/main.jsx
@@ -8,10 +8,10 @@ import { findDOMNode } from 'react-dom';
  * Internal dependencies
  */
 import viewport from 'lib/viewport';
-import { connectChat } from 'state/happychat/actions';
 import { openChat } from 'state/ui/happychat/actions';
 import { getHappychatConnectionStatus } from 'state/happychat/selectors';
 import { timeline, composer } from 'components/happychat/helpers';
+import HappychatConnection from 'components/happychat/connection';
 
 /**
  * React component for rendering a happychat client as a full page
@@ -19,7 +19,6 @@ import { timeline, composer } from 'components/happychat/helpers';
 class HappychatPage extends Component {
 	componentDidMount() {
 		this.props.openChat();
-		this.props.connectChat();
 	}
 
 	onFocus() {
@@ -35,6 +34,7 @@ class HappychatPage extends Component {
 		const { connectionStatus } = this.props;
 		return (
 			<div className="happychat__page" aria-live="polite" aria-relevant="additions">
+				<HappychatConnection />
 				{ timeline( { connectionStatus } ) }
 				{ composer( { connectionStatus } ) }
 			</div>
@@ -46,4 +46,4 @@ const mapState = state => ( {
 	connectionStatus: getHappychatConnectionStatus( state )
 } );
 
-export default connect( mapState, { connectChat, openChat } )( HappychatPage );
+export default connect( mapState, { openChat } )( HappychatPage );

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -31,10 +31,11 @@ import { isOlarkTimedOut } from 'state/ui/olark/selectors';
 import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import { isHappychatAvailable } from 'state/happychat/selectors';
 import { isTicketSupportEligible, isTicketSupportConfigurationReady, getTicketSupportRequestError } from 'state/help/ticket/selectors';
+import HappychatConnection from 'components/happychat/connection';
 import QueryOlark from 'components/data/query-olark';
 import QueryTicketSupportConfiguration from 'components/data/query-ticket-support-configuration';
 import HelpUnverifiedWarning from '../help-unverified-warning';
-import { connectChat as connectHappychat, sendChatMessage as sendHappychatMessage, sendBrowserInfo } from 'state/happychat/actions';
+import { sendChatMessage as sendHappychatMessage, sendBrowserInfo } from 'state/happychat/actions';
 import { openChat as openHappychat } from 'state/ui/happychat/actions';
 import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selectors';
 import { askQuestion as askDirectlyQuestion, initialize as initializeDirectly } from 'state/help/directly/actions';
@@ -66,10 +67,6 @@ const HelpContact = React.createClass( {
 	},
 
 	componentDidMount: function() {
-		if ( config.isEnabled( 'happychat' ) ) {
-			this.props.connectHappychat();
-		}
-
 		this.prepareDirectlyWidget();
 
 		olarkStore.on( 'change', this.updateOlarkState );
@@ -683,6 +680,7 @@ const HelpContact = React.createClass( {
 				<Card className={ this.canShowChatbox() ? 'help-contact__chat-form' : 'help-contact__form' }>
 					{ this.getView() }
 				</Card>
+				<HappychatConnection />
 				<QueryOlark />
 				<QueryTicketSupportConfiguration />
 			</Main>
@@ -707,7 +705,6 @@ export default connect(
 		};
 	},
 	{
-		connectHappychat,
 		openHappychat,
 		sendHappychatMessage,
 		sendBrowserInfo,

--- a/client/state/happychat/README.md
+++ b/client/state/happychat/README.md
@@ -10,7 +10,9 @@ Used in combination with the Redux store instance `dispatch` function, actions c
 
 ### `connectChat()`
 
-Opens Happychat Socket.IO client connection
+Opens Happychat Socket.IO client connection. _Note: Most use cases should use the Query Component
+[`<HappychatConnection />`](../../components/happychat/connection.jsx) instead of dispatching
+this action directly._
 
 ### `setChatMessage( message: String )`
 

--- a/client/state/happychat/actions.js
+++ b/client/state/happychat/actions.js
@@ -9,6 +9,7 @@
  * Internal dependencies
  */
 import {
+	HAPPYCHAT_CONNECT,
 	HAPPYCHAT_CONNECTING,
 	HAPPYCHAT_CONNECTED,
 	HAPPYCHAT_RECEIVE_EVENT,
@@ -29,7 +30,9 @@ export const receiveChatTranscript = ( messages, timestamp ) => ( {
 	type: HAPPYCHAT_TRANSCRIPT_RECEIVE, messages, timestamp
 } );
 
-export const setChatConnected = () => ( { type: HAPPYCHAT_CONNECTED } );
+export const connectChat = () => ( { type: HAPPYCHAT_CONNECT } );
+export const setConnected = () => ( { type: HAPPYCHAT_CONNECTED } );
+export const setConnecting = () => ( { type: HAPPYCHAT_CONNECTING } );
 
 export const setHappychatAvailable = isAvailable => ( { type: HAPPYCHAT_SET_AVAILABLE, isAvailable } );
 
@@ -39,7 +42,5 @@ export const clearChatMessage = () => setChatMessage( '' );
 export const receiveChatEvent = event => ( { type: HAPPYCHAT_RECEIVE_EVENT, event } );
 
 export const sendBrowserInfo = siteUrl => ( { type: HAPPYCHAT_SEND_BROWSER_INFO, siteUrl } );
-
-export const connectChat = () => ( { type: HAPPYCHAT_CONNECTING } );
 
 export const sendChatMessage = message => ( { type: HAPPYCHAT_SEND_MESSAGE, message } );

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -77,7 +77,7 @@ export const connectChat = ( connection, { getState, dispatch } ) => {
 
 	// Before establishing a connection, set up connection handlers
 	connection
-		.on( 'connect', () => {
+		.on( 'connected', () => {
 			dispatch( setConnected() );
 
 			// TODO: There's no need to dispatch a separate action to request a transcript.

--- a/client/state/happychat/reducer.js
+++ b/client/state/happychat/reducer.js
@@ -143,12 +143,11 @@ export const message = ( state = '', action ) => {
  * @return {Object}        Updated state
  *
  */
-const connectionStatus = ( state = 'disconnected', action ) => {
+const connectionStatus = ( state = 'uninitialized', action ) => {
 	switch ( action.type ) {
-		case SERIALIZE:
-			return 'disconnected';
 		case DESERIALIZE:
-			return state;
+			// Always boot up in the uninitialized state
+			return 'uninitialized';
 		case HAPPYCHAT_CONNECTING:
 			return 'connecting';
 		case HAPPYCHAT_CONNECTED:

--- a/client/state/happychat/selectors.js
+++ b/client/state/happychat/selectors.js
@@ -32,6 +32,8 @@ export const getHappychatConnectionStatus = createSelector(
 	state => state.happychat.connectionStatus
 );
 
+export const isHappychatUninitialized = state => getHappychatConnectionStatus( state ) === 'uninitialized';
+
 export const isHappychatChatActive = createSelector(
 	state => state.happychat.chatStatus !== HAPPYCHAT_CHAT_STATUS_DEFAULT,
 	state => state.happychat.chatStatus

--- a/client/state/happychat/test/middleware.js
+++ b/client/state/happychat/test/middleware.js
@@ -83,7 +83,7 @@ describe( 'middleware', () => {
 						expect( connection.on.callCount ).to.equal( 4 );
 
 						// Ensure 'connect' listener was connected by executing a fake message event
-						connection.on.withArgs( 'connect' ).firstCall.args[ 1 ]( true );
+						connection.on.withArgs( 'connected' ).firstCall.args[ 1 ]( true );
 						expect( dispatch ).to.have.been.calledWith( { type: HAPPYCHAT_CONNECTED } );
 						expect( dispatch ).to.have.been.calledWith( { type: HAPPYCHAT_TRANSCRIPT_REQUEST } );
 

--- a/client/state/happychat/test/middleware.js
+++ b/client/state/happychat/test/middleware.js
@@ -29,60 +29,63 @@ import middleware, {
 } from '../middleware';
 
 describe( 'middleware', () => {
-	describe( 'HAPPYCHAT_CONNECTING action', () => {
+	describe( 'HAPPYCHAT_CONNECT action', () => {
 		// TODO: Add tests for cases outside the happy path
-		const action = { type: HAPPYCHAT_CONNECTING };
-
-		it( 'should do nothing if Happychat is already connected', () => {
-			const getState = stub().returns( { happychat: { connectionStatus: 'connected' } } );
-			const next = stub();
-			const dispatch = stub();
-			middleware( stub() )( { getState, dispatch } )( next )( action );
-			expect( dispatch ).not.to.have.beenCalled;
-			expect( next ).not.to.have.beenCalled;
+		let connection;
+		let dispatch, getState;
+		const uninitializedState = deepFreeze( {
+			currentUser: { id: 1 },
+			happychat: { connectionStatus: 'uninitialized' },
+			users: { items: { 1: {} } }
 		} );
 
-		describe( 'after successful connection', () => {
-			let connection;
-			let dispatch, getState;
-			const state = deepFreeze( {
-				currentUser: { id: 1 },
-				happychat: { connectionStatus: 'disconnected' },
-				users: { items: { 1: {} } }
+		useSandbox( sandbox => {
+			connection = {
+				on: sandbox.stub(),
+				open: sandbox.stub().returns( Promise.resolve() )
+			};
+			// Need to add return value after re-assignment, otherwise it will return
+			// a reference to the previous (undefined) connection variable.
+			connection.on.returns( connection );
+
+			dispatch = sandbox.stub();
+			getState = sandbox.stub();
+			sandbox.stub( wpcom, 'request', ( args, callback ) => callback( null, {} ) );
+		} );
+
+		it( 'should not attempt to connect when Happychat has been initialized', () => {
+			const connectedState = { happychat: { connectionStatus: 'connected' } };
+			const connectingState = { happychat: { connectionStatus: 'connecting' } };
+
+			return Promise.all( [
+				connectChat( connection, { dispatch, getState: getState.returns( connectedState ) } ),
+				connectChat( connection, { dispatch, getState: getState.returns( connectingState ) } ),
+			] ).then( () => expect( connection.on ).not.to.have.been.called );
+		} );
+
+		describe( 'when Happychat is uninitialized', () => {
+			before( () => {
+				getState.returns( uninitializedState );
 			} );
 
-			useSandbox( sandbox => {
-				connection = {
-					on: sandbox.stub(),
-					open: sandbox.stub().returns( Promise.resolve() )
-				};
-				// Need to add return value after re-assignment, otherwise it will return
-				// a reference to the previous (undefined) connection variable.
-				connection.on.returns( connection );
-
-				dispatch = sandbox.stub();
-				getState = sandbox.stub().returns( state );
-				sandbox.stub( wpcom, 'request', ( args, callback ) => callback( null, {} ) );
-			} );
-
-			it( 'should send notice of the connection state', () => {
+			it( 'should attempt to connect', () => {
+				getState.returns( uninitializedState );
 				return connectChat( connection, { dispatch, getState } )
-					.then( () => expect( dispatch ).to.have.been.calledWith( { type: HAPPYCHAT_CONNECTED } ) );
-			} );
-
-			it( 'should fetch transcripts', () => {
-				return connectChat( connection, { dispatch, getState } )
-					.then( () => expect( dispatch ).to.have.been.calledWith( { type: HAPPYCHAT_TRANSCRIPT_REQUEST } ) );
+					.then( () => {
+						expect( connection.open ).to.have.been.calledOnce;
+						expect( dispatch ).to.have.been.calledWith( { type: HAPPYCHAT_CONNECTING } );
+					} );
 			} );
 
 			it( 'should set up listeners for various connection events', () => {
-				connection.on.withArgs( 'accept' );
-				connection.on.withArgs( 'message' );
-				connection.on.withArgs( 'status' );
-
 				return connectChat( connection, { dispatch, getState } )
 					.then( () => {
-						expect( connection.on.callCount ).to.equal( 3 );
+						expect( connection.on.callCount ).to.equal( 4 );
+
+						// Ensure 'connect' listener was connected by executing a fake message event
+						connection.on.withArgs( 'connect' ).firstCall.args[ 1 ]( true );
+						expect( dispatch ).to.have.been.calledWith( { type: HAPPYCHAT_CONNECTED } );
+						expect( dispatch ).to.have.been.calledWith( { type: HAPPYCHAT_TRANSCRIPT_REQUEST } );
 
 						// Ensure 'accept' listener was connected by executing a fake message event
 						connection.on.withArgs( 'accept' ).firstCall.args[ 1 ]( true );


### PR DESCRIPTION
Refactors the Redux actions around Happychat opening a connection.

Previously, when a connection was desired a `HAPPYCHAT_CONNECTING` action was dispatched. If HC hadn't been connected yet, the middleware would start the connection and the reducers would set the status as `'connecting'`. If HC _had_ already connected, the middleware would throw the dispatch away, preventing reducers from receiving it.

This PR does two things:

#### 1. Creates a new action chain for HC connections

The new action chain for connecting HC looks like this:

- `HAPPYCHAT_CONNECT`: Dispatched when an HC connection is desired. Middleware responds by starting a new connection if one hasn't already been established. The reducers receive this action but don't respond to it.  

- `HAPPYCHAT_CONNECTING`: Dispatched by middleware when it starts establishing a connection. Reducers respond by setting the connection status to `'connecting'`.  
  
- `HAPPYCHAT_CONNECTED`: Dispatched by middleware when a connection has been established. Reducers respond by setting the connection status to `'connected'`.

It's also worth noting that this PR changes the initial HC connection status from `'disconnected'` to `'uninitialized'` — this mirrors the same thing being done in https://github.com/Automattic/wp-calypso/pull/12706 and leaves `'disconnected'` open for upcoming work where we're informing users that a `'connected'` session actually becomes disconnected.

#### 2. Creates a "connection component" to manage the HC connection in components

Currently this just opens a connection if one hasn't already been opened. This component may not be _entirely_ necessary at the moment (since it's now safe to dispatch `HAPPYCHAT_CONNECT` after a connection is made without side effects). But it does provide some opportunity in the future to do more detailed management of HC connections without digging through the whole app. For example, on `componentWillUnmount` we could send an action that notifies the HC service that the session is not being actively looked at (or something similar).

(Props to @southp for noting that stopping the dispatch in middleware felt a bit odd, and @omarjackman for pushing further and suggesting this alternative)

### To test

- Verify that the actions above are being dispatched through Redux dev tools  
  
- Start a session at `/me/chat` and then navigate to `/help/contact` and start a new Happychat session, to verify that there's no side effects from multiple HC-connected components connecting during a browsing session  