### PR TITLE
Purchases: Update cancellation survey to include concierge offer

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import shuffle from 'lodash/shuffle';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -19,6 +20,7 @@ import Button from 'components/button';
 
 const CancelPurchaseForm = React.createClass( {
 	propTypes: {
+		translate: React.PropTypes.func,
 		surveyStep: React.PropTypes.number.isRequired,
 		finalStep: React.PropTypes.number.isRequired,
 		showSurvey: React.PropTypes.bool.isRequired,
@@ -124,6 +126,7 @@ const CancelPurchaseForm = React.createClass( {
 
 	renderQuestionOne() {
 		const reasons = {};
+		const { translate } = this.props;
 
 		const couldNotInstallInput = (
 			<FormTextInput
@@ -132,7 +135,7 @@ const CancelPurchaseForm = React.createClass( {
 				id="couldNotInstallInput"
 				value={ this.state.questionOneText }
 				onChange={ this.onTextOneChange }
-				placeholder={ this.translate( 'What plugin/theme were you trying to install?' ) } />
+				placeholder={ translate( 'What plugin/theme were you trying to install?' ) } />
 		);
 		reasons.couldNotInstall = (
 			<FormLabel key="couldNotInstall">
@@ -141,7 +144,7 @@ const CancelPurchaseForm = React.createClass( {
 					value="couldNotInstall"
 					checked={ 'couldNotInstall' === this.state.questionOneRadio }
 					onChange={ this.onRadioOneChange } />
-				<span>{ this.translate( 'I couldn\'t install a plugin/theme I wanted.' ) }</span>
+				<span>{ translate( 'I couldn\'t install a plugin/theme I wanted.' ) }</span>
 				{ 'couldNotInstall' === this.state.questionOneRadio && couldNotInstallInput }
 			</FormLabel>
 		);
@@ -153,7 +156,7 @@ const CancelPurchaseForm = React.createClass( {
 				id="tooHardInput"
 				value={ this.state.questionOneText }
 				onChange={ this.onTextOneChange }
-				placeholder={ this.translate( 'Where did you run into problems?' ) } />
+				placeholder={ translate( 'Where did you run into problems?' ) } />
 		);
 		reasons.tooHard = (
 			<FormLabel key="tooHard">
@@ -162,7 +165,7 @@ const CancelPurchaseForm = React.createClass( {
 					value="tooHard"
 					checked={ 'tooHard' === this.state.questionOneRadio }
 					onChange={ this.onRadioOneChange } />
-				<span>{ this.translate( 'It was too hard to set up my site.' ) }</span>
+				<span>{ translate( 'It was too hard to set up my site.' ) }</span>
 				{ 'tooHard' === this.state.questionOneRadio && tooHardInput }
 			</FormLabel>
 		);
@@ -174,7 +177,7 @@ const CancelPurchaseForm = React.createClass( {
 				id="didNotIncludeInput"
 				value={ this.state.questionOneText }
 				onChange={ this.onTextOneChange }
-				placeholder={ this.translate( 'What are we missing that you need?' ) } />
+				placeholder={ translate( 'What are we missing that you need?' ) } />
 		);
 		reasons.didNotInclude = (
 			<FormLabel key="didNotInclude">
@@ -183,7 +186,7 @@ const CancelPurchaseForm = React.createClass( {
 					value="didNotInclude"
 					checked={ 'didNotInclude' === this.state.questionOneRadio }
 					onChange={ this.onRadioOneChange } />
-				<span>{ this.translate( 'This upgrade didn\'t include what I needed.' ) }</span>
+				<span>{ translate( 'This upgrade didn\'t include what I needed.' ) }</span>
 				{ 'didNotInclude' === this.state.questionOneRadio && didNotIncludeInput }
 			</FormLabel>
 		);
@@ -195,7 +198,7 @@ const CancelPurchaseForm = React.createClass( {
 				id="onlyNeedFreeInput"
 				value={ this.state.questionOneText }
 				onChange={ this.onTextOneChange }
-				placeholder={ this.translate( 'How can we improve our upgrades?' ) } />
+				placeholder={ translate( 'How can we improve our upgrades?' ) } />
 		);
 		reasons.onlyNeedFree = (
 			<FormLabel key="onlyNeedFree">
@@ -204,7 +207,7 @@ const CancelPurchaseForm = React.createClass( {
 					value="onlyNeedFree"
 					checked={ 'onlyNeedFree' === this.state.questionOneRadio }
 					onChange={ this.onRadioOneChange } />
-				<span>{ this.translate( 'The plan was too expensive.' ) }</span>
+				<span>{ translate( 'The plan was too expensive.' ) }</span>
 				{ 'onlyNeedFree' === this.state.questionOneRadio && onlyNeedFreeInput }
 			</FormLabel>
 		);
@@ -224,7 +227,7 @@ const CancelPurchaseForm = React.createClass( {
 					value="anotherReasonOne"
 					checked={ 'anotherReasonOne' === this.state.questionOneRadio }
 					onChange={ this.onRadioOneChange } />
-				<span>{ this.translate( 'Another reason…' ) }</span>
+				<span>{ translate( 'Another reason…' ) }</span>
 				{ 'anotherReasonOne' === this.state.questionOneRadio && anotherReasonOneInput }
 			</FormLabel>
 		);
@@ -237,7 +240,7 @@ const CancelPurchaseForm = React.createClass( {
 				id="couldNotActivateInput"
 				value={ this.state.questionOneText }
 				onChange={ this.onTextOneChange }
-				placeholder={ this.translate( 'Where did you run into problems?' ) } />
+				placeholder={ translate( 'Where did you run into problems?' ) } />
 		);
 		reasons.couldNotActivate = (
 			<FormLabel key="couldNotActivate">
@@ -246,7 +249,7 @@ const CancelPurchaseForm = React.createClass( {
 					value="couldNotActivate"
 					checked={ 'couldNotActivate' === this.state.questionOneRadio }
 					onChange={ this.onRadioOneChange } />
-				<span>{ this.translate( 'I was unable to activate or use the product.' ) }</span>
+				<span>{ translate( 'I was unable to activate or use the product.' ) }</span>
 				{ 'couldNotActivate' === this.state.questionOneRadio && couldNotActivateInput }
 			</FormLabel>
 		);
@@ -256,7 +259,7 @@ const CancelPurchaseForm = React.createClass( {
 
 		return (
 			<div>
-				<FormLegend>{ this.translate( 'Please tell us why you are canceling:' ) }</FormLegend>
+				<FormLegend>{ translate( 'Please tell us why you are canceling:' ) }</FormLegend>
 				{ orderedReasons }
 			</div>
 		);
@@ -264,6 +267,7 @@ const CancelPurchaseForm = React.createClass( {
 
 	renderQuestionTwo() {
 		const reasons = {};
+		const { translate } = this.props;
 
 		reasons.stayingHere = (
 			<FormLabel key="stayingHere">
@@ -272,7 +276,7 @@ const CancelPurchaseForm = React.createClass( {
 					value="stayingHere"
 					checked={ 'stayingHere' === this.state.questionTwoRadio }
 					onChange={ this.onRadioTwoChange } />
-				<span>{ this.translate( 'I\'m staying here and using the free plan.' ) }</span>
+				<span>{ translate( 'I\'m staying here and using the free plan.' ) }</span>
 			</FormLabel>
 		);
 
@@ -283,7 +287,7 @@ const CancelPurchaseForm = React.createClass( {
 				id="otherWordPressInput"
 				value={ this.state.questionTwoText }
 				onChange={ this.onTextTwoChange }
-				placeholder={ this.translate( 'Mind telling us where?' ) } />
+				placeholder={ translate( 'Mind telling us where?' ) } />
 		);
 		reasons.otherWordPress = (
 			<FormLabel key="otherWordPress">
@@ -292,7 +296,7 @@ const CancelPurchaseForm = React.createClass( {
 					value="otherWordPress"
 					checked={ 'otherWordPress' === this.state.questionTwoRadio }
 					onChange={ this.onRadioTwoChange } />
-				<span>{ this.translate( 'I\'m going to use WordPress somewhere else.' ) }</span>
+				<span>{ translate( 'I\'m going to use WordPress somewhere else.' ) }</span>
 				{ 'otherWordPress' === this.state.questionTwoRadio && otherWordPressInput }
 			</FormLabel>
 		);
@@ -304,7 +308,7 @@ const CancelPurchaseForm = React.createClass( {
 				id="differentServiceInput"
 				value={ this.state.questionTwoText }
 				onChange={ this.onTextTwoChange }
-				placeholder={ this.translate( 'Mind telling us which one?' ) } />
+				placeholder={ translate( 'Mind telling us which one?' ) } />
 		);
 		reasons.differentService = (
 			<FormLabel key="differentService">
@@ -313,7 +317,7 @@ const CancelPurchaseForm = React.createClass( {
 					value="differentService"
 					checked={ 'differentService' === this.state.questionTwoRadio }
 					onChange={ this.onRadioTwoChange } />
-				<span>{ this.translate( 'I\'m going to use a different service for my website or blog.' ) }</span>
+				<span>{ translate( 'I\'m going to use a different service for my website or blog.' ) }</span>
 				{ 'differentService' === this.state.questionTwoRadio && differentServiceInput }
 			</FormLabel>
 		);
@@ -325,7 +329,7 @@ const CancelPurchaseForm = React.createClass( {
 				id="noNeedInput"
 				value={ this.state.questionTwoText }
 				onChange={ this.onTextTwoChange }
-				placeholder={ this.translate( 'What will you do instead?' ) } />
+				placeholder={ translate( 'What will you do instead?' ) } />
 		);
 		reasons.noNeed = (
 			<FormLabel key="noNeed">
@@ -334,7 +338,7 @@ const CancelPurchaseForm = React.createClass( {
 					value="noNeed"
 					checked={ 'noNeed' === this.state.questionTwoRadio }
 					onChange={ this.onRadioTwoChange } />
-				<span>{ this.translate( 'I no longer need a website or blog.' ) }</span>
+				<span>{ translate( 'I no longer need a website or blog.' ) }</span>
 				{ 'noNeed' === this.state.questionTwoRadio && noNeedInput }
 			</FormLabel>
 		);
@@ -354,7 +358,7 @@ const CancelPurchaseForm = React.createClass( {
 					value="anotherReasonTwo"
 					checked={ 'anotherReasonTwo' === this.state.questionTwoRadio }
 					onChange={ this.onRadioTwoChange } />
-				<span>{ this.translate( 'Another reason…' ) }</span>
+				<span>{ translate( 'Another reason…' ) }</span>
 				{ 'anotherReasonTwo' === this.state.questionTwoRadio && anotherReasonTwoInput }
 			</FormLabel>
 		);
@@ -367,7 +371,7 @@ const CancelPurchaseForm = React.createClass( {
 				id="otherPluginInput"
 				value={ this.state.questionTwoText }
 				onChange={ this.onTextTwoChange }
-				placeholder={ this.translate( 'Mind telling us which one(s)?' ) } />
+				placeholder={ translate( 'Mind telling us which one(s)?' ) } />
 		);
 		reasons.otherPlugin = (
 			<FormLabel key="otherPlugin">
@@ -376,7 +380,7 @@ const CancelPurchaseForm = React.createClass( {
 					value="otherPlugin"
 					checked={ 'otherPlugin' === this.state.questionTwoRadio }
 					onChange={ this.onRadioTwoChange } />
-				<span>{ this.translate( 'I found a better plugin or service.' ) }</span>
+				<span>{ translate( 'I found a better plugin or service.' ) }</span>
 				{ 'otherPlugin' === this.state.questionTwoRadio && otherPluginInput }
 			</FormLabel>
 		);
@@ -388,7 +392,7 @@ const CancelPurchaseForm = React.createClass( {
 				id="leavingWPInput"
 				value={ this.state.questionTwoText }
 				onChange={ this.onTextTwoChange }
-				placeholder={ this.translate( 'Any particular reason(s)?' ) } />
+				placeholder={ translate( 'Any particular reason(s)?' ) } />
 		);
 		reasons.leavingWP = (
 			<FormLabel key="leavingWP">
@@ -397,7 +401,7 @@ const CancelPurchaseForm = React.createClass( {
 					value="leavingWP"
 					checked={ 'leavingWP' === this.state.questionTwoRadio }
 					onChange={ this.onRadioTwoChange } />
-				<span>{ this.translate( 'I\'m moving my site off of WordPress.' ) }</span>
+				<span>{ translate( 'I\'m moving my site off of WordPress.' ) }</span>
 				{ 'leavingWP' === this.state.questionTwoRadio && leavingWPInput }
 			</FormLabel>
 		);
@@ -407,17 +411,18 @@ const CancelPurchaseForm = React.createClass( {
 
 		return (
 			<div>
-				<FormLegend>{ this.translate( 'Where is your next adventure taking you?' ) }</FormLegend>
+				<FormLegend>{ translate( 'Where is your next adventure taking you?' ) }</FormLegend>
 				{ orderedReasons }
 			</div>
 		);
 	},
 
 	renderFreeformQuestion() {
+		const { translate } = this.props;
 		return (
 			<FormFieldset>
 				<FormLabel>
-					{ this.translate( 'What\'s one thing we could have done better? (optional)' ) }
+					{ translate( 'What\'s one thing we could have done better? (optional)' ) }
 					<FormTextarea
 						name="improvementInput"
 						id="improvementInput"
@@ -434,14 +439,15 @@ const CancelPurchaseForm = React.createClass( {
 	},
 
 	renderConciergeOffer() {
+		const { translate } = this.props;
 		return (
 			<FormFieldset>
 				<FormLabel>
-					{ this.translate( 'Let us help you setup your site!' ) }
+					{ translate( 'Let us help you setup your site!' ) }
 				</FormLabel>
 				<p>
 					{
-						this.translate(
+						translate(
 							'Schedule a 30 minute orientation with one of our Happiness Engineers. ' +
 							'We\'ll help you to setup your site and answer any questions you have!'
 						)
@@ -451,7 +457,7 @@ const CancelPurchaseForm = React.createClass( {
 					onClick={ this.openCalendly }
 					primary
 				>
-					{ this.translate( 'Schedule a session' ) }
+					{ translate( 'Schedule a session' ) }
 				</Button>
 			</FormFieldset>
 		);
@@ -504,4 +510,4 @@ export default connect(
 			'calypso_purchases_cancel_form_concierge_click'
 		) ),
 	} )
-)( CancelPurchaseForm );
+)( localize( CancelPurchaseForm ) );

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -15,10 +15,12 @@ import FormRadio from 'components/forms/form-radio';
 import FormTextInput from 'components/forms/form-text-input';
 import FormTextarea from 'components/forms/form-textarea';
 import { recordTracksEvent } from 'state/analytics/actions';
+import Button from 'components/button';
 
 const CancelPurchaseForm = React.createClass( {
 	propTypes: {
 		surveyStep: React.PropTypes.number.isRequired,
+		finalStep: React.PropTypes.number.isRequired,
 		showSurvey: React.PropTypes.bool.isRequired,
 		defaultContent: React.PropTypes.node.isRequired,
 		onInputChange: React.PropTypes.func.isRequired,
@@ -426,6 +428,35 @@ const CancelPurchaseForm = React.createClass( {
 		);
 	},
 
+	openCalendly() {
+		this.props.clickCalendly();
+		return window.open( 'https://calendly.com/wordpressdotcom/wordpress-com-business-site-setup/' );
+	},
+
+	renderConciergeOffer() {
+		return (
+			<FormFieldset>
+				<FormLabel>
+					{ this.translate( 'Let us help you setup your site!' ) }
+				</FormLabel>
+				<p>
+					{
+						this.translate(
+							'Schedule a 30 minute orientation with one of our Happiness Engineers. ' +
+							'We\'ll help you to setup your site and answer any questions you have!'
+						)
+					}
+				</p>
+				<Button
+					onClick={ this.openCalendly }
+					primary
+				>
+					{ this.translate( 'Schedule a session' ) }
+				</Button>
+			</FormFieldset>
+		);
+	},
+
 	render() {
 		if ( this.props.showSurvey ) {
 			if ( this.props.surveyStep === 1 ) {
@@ -437,7 +468,16 @@ const CancelPurchaseForm = React.createClass( {
 				);
 			}
 
-			// 2nd surveyStep
+			// Render concierge offer if appropriate
+			if ( this.props.surveyStep === 2 && this.props.finalStep === 3 ) {
+				return (
+					<div>
+						{ this.renderConciergeOffer() }
+					</div>
+				);
+			}
+
+			// Render cancellation step
 			return (
 				<div>
 					{ this.renderFreeformQuestion() }
@@ -459,6 +499,9 @@ export default connect(
 				option: option,
 				value: value
 			}
+		) ),
+		clickCalendly: () => dispatch( recordTracksEvent(
+			'calypso_purchases_cancel_form_concierge_click'
 		) ),
 	} )
 )( CancelPurchaseForm );

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -62,4 +62,12 @@ module.exports = {
 		},
 		defaultVariation: 'hideSurveyStep',
 	},
+	conciergeOfferOnCancel: {
+		datestamp: '20170410',
+		variations: {
+			showConciergeOffer: 50,
+			hideConciergeOffer: 50,
+		},
+		defaultVariation: 'showConciergeOffer',
+	},
 };

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
  * Internal Dependencies
  */
 import config from 'config';
+import { abtest } from 'lib/abtest';
 import Button from 'components/button';
 import { cancelAndRefundPurchase, cancelPurchase, submitSurvey } from 'lib/upgrades/actions';
 import { clearPurchases } from 'state/purchases/actions';
@@ -84,7 +85,10 @@ class CancelPurchaseButton extends Component {
 		const { purchase } = this.props;
 		let newStep;
 
-		if ( isBusiness( purchase ) && this.state.survey.questionOneRadio === 'tooHard' ) {
+		if ( purchase && isBusiness( purchase ) &&
+			this.state.survey.questionOneRadio === 'tooHard' &&
+			abtest( 'conciergeOfferOnCancel' ) === 'showConciergeOffer'
+		) {
 			this.setState( { finalStep: 3 } );
 
 			switch ( this.state.surveyStep ) {

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -19,7 +19,7 @@ import Dialog from 'components/dialog';
 import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
 import { getName, getSubscriptionEndDate, isOneTimePurchase, isRefundable, isSubscription } from 'lib/purchases';
 import { enrichedSurveyData } from '../utils';
-import { isDomainRegistration, isJetpackPlan } from 'lib/products-values';
+import { isDomainRegistration, isJetpackPlan, isBusiness } from 'lib/products-values';
 import notices from 'notices';
 import paths from 'me/purchases/paths';
 import { refreshSitePlans } from 'state/sites/plans/actions';
@@ -38,6 +38,7 @@ class CancelPurchaseButton extends Component {
 		showDialog: false,
 		isRemoving: false,
 		surveyStep: 1,
+		finalStep: 2,
 		survey: {
 			questionOneRadio: null,
 			questionTwoRadio: null
@@ -79,8 +80,31 @@ class CancelPurchaseButton extends Component {
 		} );
 	}
 
-	changeSurveyStep = () => {
-		const newStep = this.state.surveyStep === 1 ? 2 : 1;
+	changeSurveyStep = ( direction ) => {
+		const { purchase } = this.props;
+		let newStep;
+
+		if ( isBusiness( purchase ) && this.state.survey.questionOneRadio === 'tooHard' ) {
+			this.setState( { finalStep: 3 } );
+
+			switch ( this.state.surveyStep ) {
+				case 1:
+					newStep = 2;
+					break;
+				case 2:
+					newStep = direction === 'previous' ? 1 : 3;
+					break;
+				case 3:
+					newStep = 2;
+					break;
+				default:
+					newStep = 1;
+					break;
+			}
+		} else {
+			this.setState( { finalStep: 2 } );
+			newStep = this.state.surveyStep === 1 ? 2 : 1;
+		}
 
 		this.recordEvent( 'calypso_purchases_cancel_survey_step', { new_step: newStep } );
 
@@ -116,7 +140,7 @@ class CancelPurchaseButton extends Component {
 				action: 'prev',
 				disabled: this.state.isRemoving,
 				label: translate( 'Previous Step' ),
-				onClick: this.changeSurveyStep
+				onClick: this.changeSurveyStep.bind( null, 'previous' )
 			},
 			cancel: {
 				action: 'cancel',
@@ -127,13 +151,17 @@ class CancelPurchaseButton extends Component {
 			}
 		};
 		const purchaseName = getName( purchase );
-		const inStepOne = this.state.surveyStep === 1;
+		const inFinalStep = ( this.state.surveyStep === this.state.finalStep );
 
 		let buttonsArr;
 		if ( ! config.isEnabled( 'upgrades/removal-survey' ) ) {
 			buttonsArr = [ buttons.close, buttons.cancel ];
+		} else if ( inFinalStep ) {
+			buttonsArr = [ buttons.close, buttons.prev, buttons.cancel ];
 		} else {
-			buttonsArr = inStepOne ? [ buttons.close, buttons.next ] : [ buttons.prev, buttons.close, buttons.cancel ];
+			buttonsArr = this.state.surveyStep === 2
+				? [ buttons.close, buttons.prev, buttons.next ]
+				: [ buttons.close, buttons.next ];
 		}
 
 		return (
@@ -146,6 +174,7 @@ class CancelPurchaseButton extends Component {
 				<CancelPurchaseForm
 					surveyStep={ this.state.surveyStep }
 					showSurvey={ config.isEnabled( 'upgrades/removal-survey' ) }
+					finalStep={ this.state.finalStep }
 					defaultContent={ this.renderCancellationEffect() }
 					onInputChange={ this.onSurveyChange }
 					isJetpack={ isJetpackPlan( purchase ) }

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -13,6 +13,7 @@ import { get } from 'lodash';
  */
 import wpcom from 'lib/wp';
 import config from 'config';
+import { abtest } from 'lib/abtest';
 import CompactCard from 'components/card/compact';
 import Dialog from 'components/dialog';
 import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
@@ -135,7 +136,10 @@ const RemovePurchase = React.createClass( {
 		const purchase = getPurchase( this.props );
 		let newStep;
 
-		if ( isBusiness( purchase ) && this.state.survey.questionOneRadio === 'tooHard' ) {
+		if ( purchase && isBusiness( purchase ) &&
+			this.state.survey.questionOneRadio === 'tooHard' &&
+			abtest( 'conciergeOfferOnCancel' ) === 'showConciergeOffer'
+		) {
 			this.setState( { finalStep: 3 } );
 
 			switch ( this.state.surveyStep ) {


### PR DESCRIPTION
This updates the marketing survey shown on cancellation to offer onboarding sessions with Happiness Engineers. This only applies if users are on the WordPress.com Business plan and have indicated that the setup was too hard.

This is an experiment pending the discussion in p7EOS0-Jg-p2 so please don't merge :) The copy & design likely need work.

The cancellation form was built with two steps in mind so adding a third step required some reworking of the logic. If this form is going to stick around for awhile, it might make sense to adjust how the steps are calculated to make it easier to add/remove as necessary. For example, we're now using this to record progress:
```js
this.recordEvent( 'calypso_purchases_cancel_form_step', { new_step: newStep } );
```
This makes less sense now that there could be 2 or 3 steps in the form with the new addition. If you were to run a Tracks funnel with that event, it would be hard to know how far into the form a user went.

## To test
1. Visit /me/purchases/ on a site with the Business plan.
2. Click to either cancel or remove the Business plan from your site. You should get the cancellation form.
3. Indicate it was "Too hard" on the first question and anything on the second. Click "Next." You should see the onboarding offer. Clicking previous/next should allow you to continue to navigate the form as desired. If you click on the Calendly offer, you should see `calypso_purchases_cancel_form_concierge_click` recorded as a Tracks event (run `localStorage.setItem('debug', 'calypso:analytics*');` in your console to log these). If you choose a different option than "Too hard" on the first step, you should not see the offer.
4. Try this with a Premium/Personal/other upgrade, you shouldn't see the offer at all.

## GIF
![cancellation](https://cloud.githubusercontent.com/assets/7240478/24587431/9c225294-1773-11e7-8fa6-0127e5f89840.gif)
