### PR TITLE
StatsModule: Optimize data selection and render

### DIFF
--- a/client/lib/create-selector/README.md
+++ b/client/lib/create-selector/README.md
@@ -28,6 +28,13 @@ const sitePosts = getSitePosts( state, siteId );
 
 This result would only be calculated once, so long as `state.posts` remains the same.
 
+`createSelectorPerKey` accept the same parameters as `createSelector`.
+The difference is how it invalidate the cache and as the name suggest it is per-key and not per-selector.
+
+For example, the stats module have state section that stores all the different stats types keyed by a query. This function allows the dependent data function to return a very specific sub-tree of the state and if that sub-tree changes only the current cache key (3rd parameter) will be invalidated. In the stats case when authors stats changes only it will be invalidated while posts stats will still be served from the cache.
+
+Please note the effect might be higher memory usage because invalid cache keys will not be reevaluated until they are requested, which might never happen.
+
 ## FAQ
 
 ### What is a memoized selector?

--- a/client/lib/create-selector/test/index.js
+++ b/client/lib/create-selector/test/index.js
@@ -10,216 +10,295 @@ import sinon from 'sinon';
 /**
  * Internal dependencies
  */
-import createSelector from '../';
+import createSelector, { createSelectorPerKey } from '../';
 import { useSandbox } from 'test/helpers/use-sinon';
 
-describe( 'index', () => {
-	let selector, getSitePosts;
+const createSelectorFunctionNames = [ 'createSelector', 'createSelectorPerKey' ];
+[ createSelector, createSelectorPerKey ].forEach( ( createSelectorFactory, createSelectorIndex ) => {
+	describe( createSelectorFunctionNames[ createSelectorIndex ], () => {
+		let selector, getSitePosts;
+
+		useSandbox( ( sandbox ) => {
+			sandbox.stub( console, 'warn' );
+			selector = sandbox.spy( ( state, siteId ) => {
+				return filter( state.posts, { site_ID: siteId } );
+			} );
+		} );
+
+		before( () => {
+			getSitePosts = createSelectorFactory( selector, ( state ) => state.posts );
+		} );
+
+		beforeEach( () => {
+			getSitePosts.memoizedSelector.cache.clear();
+		} );
+
+		it( 'should expose its memoized function', () => {
+			expect( getSitePosts.memoizedSelector ).to.be.a( 'function' );
+		} );
+
+		it( 'should create a function which returns the expected value when called', () => {
+			const state = {
+				posts: {
+					'3d097cb7c5473c169bba0eb8e3c6cb64':
+						{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
+				}
+			};
+
+			expect( getSitePosts( state, 2916284 ) ).to.eql( [
+				{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
+			] );
+		} );
+
+		it( 'should cache the result of a selector function', () => {
+			const state = {
+				posts: {
+					'3d097cb7c5473c169bba0eb8e3c6cb64': {
+						ID: 841,
+						site_ID: 2916284,
+						global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+						title: 'Hello World'
+					}
+				}
+			};
+
+			getSitePosts( state, 2916284 );
+			getSitePosts( state, 2916284 );
+
+			expect( selector ).to.have.been.calledOnce;
+		} );
+
+		it( 'should warn against complex arguments in development mode', () => {
+			// NOTE: if we use createSelectorFactory here console.warn will be called
+			// six times, it's like the sinon stub does not reset after the test.
+			getSitePosts = createSelector( selector, ( state ) => state.posts );
+
+			const state = { posts: {} };
+
+			getSitePosts( state, 1 );
+			getSitePosts( state, '' );
+			getSitePosts( state, 'foo' );
+			getSitePosts( state, true );
+			getSitePosts( state, null );
+			getSitePosts( state, undefined );
+			getSitePosts( state, {} );
+			getSitePosts( state, [] );
+			getSitePosts( state, 1, [] );
+
+			expect( console.warn ).to.have.been.calledThrice;
+		} );
+
+		it( 'should return the expected value of differing arguments', () => {
+			const state = {
+				posts: {
+					'3d097cb7c5473c169bba0eb8e3c6cb64':
+						{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' },
+					'6c831c187ffef321eb43a67761a525a3':
+						{ ID: 413, site_ID: 38303081, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs & Chicken' }
+				}
+			};
+
+			getSitePosts( state, 2916284 );
+			const sitePosts = getSitePosts( state, 38303081 );
+			getSitePosts( state, 2916284 );
+
+			expect( sitePosts ).to.eql( [
+				{ ID: 413, site_ID: 38303081, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs & Chicken' }
+			] );
+			expect( selector ).to.have.been.calledTwice;
+		} );
+
+		it( 'should bust the cache when watched state changes', () => {
+			const currentState = {
+				posts: {
+					'3d097cb7c5473c169bba0eb8e3c6cb64':
+						{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
+				}
+			};
+
+			getSitePosts( currentState, 2916284 );
+
+			const nextState = {
+				posts: {
+					'3d097cb7c5473c169bba0eb8e3c6cb64':
+						{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' },
+					'6c831c187ffef321eb43a67761a525a3':
+						{ ID: 413, site_ID: 38303081, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs & Chicken' }
+				}
+			};
+
+			expect( getSitePosts( nextState, 2916284 ) ).to.eql( [
+				{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
+			] );
+			expect( selector ).to.have.been.calledTwice;
+		} );
+
+		it( 'should accept an array of dependent state values', () => {
+			const getSitePostsWithArrayDependants = createSelectorFactory( selector, ( state ) => [ state.posts ] );
+			const state = {
+				posts: {
+					'3d097cb7c5473c169bba0eb8e3c6cb64':
+						{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
+				}
+			};
+
+			getSitePostsWithArrayDependants( state, 2916284 );
+			getSitePostsWithArrayDependants( state, 2916284 );
+
+			expect( selector ).to.have.been.calledOnce;
+		} );
+
+		it( 'should accept an array of dependent selectors', () => {
+			const getPosts = ( state ) => state.posts;
+			const getSitePostsWithArrayDependants = createSelectorFactory( selector, [ getPosts ] );
+			const state = {
+				posts: {
+					'3d097cb7c5473c169bba0eb8e3c6cb64': {
+						ID: 841,
+						site_ID: 2916284,
+						global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+						title: 'Hello World'
+					}
+				}
+			};
+
+			const nextState = { posts: {} };
+
+			getSitePostsWithArrayDependants( state, 2916284 );
+			getSitePostsWithArrayDependants( state, 2916284 );
+			getSitePostsWithArrayDependants( nextState, 2916284 );
+			getSitePostsWithArrayDependants( nextState, 2916284 );
+
+			expect( selector ).to.have.been.calledTwice;
+		} );
+
+		it( 'should default to watching entire state, returning cached result if no changes', () => {
+			const getSitePostsWithDefaultGetDependants = createSelectorFactory( selector );
+			const state = {
+				posts: {
+					'3d097cb7c5473c169bba0eb8e3c6cb64':
+						{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
+				}
+			};
+
+			getSitePostsWithDefaultGetDependants( state, 2916284 );
+			getSitePostsWithDefaultGetDependants( state, 2916284 );
+
+			expect( selector ).to.have.been.calledOnce;
+		} );
+
+		it( 'should default to watching entire state, busting if state has changed', () => {
+			const getSitePostsWithDefaultGetDependants = createSelectorFactory( selector );
+			const currentState = {
+				posts: {
+					'3d097cb7c5473c169bba0eb8e3c6cb64':
+						{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
+				}
+			};
+
+			getSitePostsWithDefaultGetDependants( currentState, 2916284 );
+
+			const nextState = {
+				posts: {
+					'3d097cb7c5473c169bba0eb8e3c6cb64':
+						{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' },
+					'6c831c187ffef321eb43a67761a525a3':
+						{ ID: 413, site_ID: 38303081, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs & Chicken' }
+				}
+			};
+
+			getSitePostsWithDefaultGetDependants( nextState, 2916284 );
+
+			expect( selector ).to.have.been.calledTwice;
+		} );
+
+		it( 'should accept an optional custom cache key generating function', () => {
+			const getSitePostsWithCustomGetCacheKey = createSelectorFactory(
+				selector,
+				( state ) => state.posts,
+				( state, siteId ) => `CUSTOM${ siteId }`
+			);
+
+			getSitePostsWithCustomGetCacheKey( { posts: {} }, 2916284 );
+
+			expect( getSitePostsWithCustomGetCacheKey.memoizedSelector.cache.has( 'CUSTOM2916284' ) ).to.be.true;
+		} );
+
+		it( 'should call dependant state getter with arguments', () => {
+			const getDeps = sinon.spy();
+			const memoizedSelector = createSelectorFactory( () => null, getDeps );
+			const state = {};
+
+			memoizedSelector( state, 1, 2, 3 );
+
+			expect( getDeps ).to.have.been.calledWithExactly( state, 1, 2, 3 );
+		} );
+
+		it( 'should handle an array of selectors instead of a dependant state getter', () => {
+			const getPosts = sinon.spy();
+			const getQuuxs = sinon.spy();
+			const memoizedSelector = createSelectorFactory( () => null, [ getPosts, getQuuxs ] );
+			const state = {};
+
+			memoizedSelector( state, 1, 2, 3 );
+			expect( getPosts ).to.have.been.calledWithExactly( state, 1, 2, 3 );
+			expect( getQuuxs ).to.have.been.calledWithExactly( state, 1, 2, 3 );
+		} );
+	} );
+} );
+
+describe( 'createSelectorPerKey specific', () => {
+
+	let selector, depedent, keyFunc, getStats;
 
 	useSandbox( ( sandbox ) => {
 		sandbox.stub( console, 'warn' );
-		selector = sandbox.spy( ( state, siteId ) => {
-			return filter( state.posts, { site_ID: siteId } );
+		selector = sandbox.spy( ( state, statType ) => {
+			return state[ statType ];
+		} );
+		depedent = sandbox.spy( ( state, statType ) => {
+			return state[ statType ];
+		} );
+		keyFunc = sandbox.spy( ( state, statType ) => {
+			return statType;
 		} );
 	} );
 
 	before( () => {
-		getSitePosts = createSelector( selector, ( state ) => state.posts );
+		getStats = createSelectorPerKey( selector, depedent, keyFunc );
 	} );
 
 	beforeEach( () => {
-		getSitePosts.memoizedSelector.cache.clear();
+		getStats.memoizedSelector.cache.clear();
 	} );
 
-	it( 'should expose its memoized function', () => {
-		expect( getSitePosts.memoizedSelector ).to.be.a( 'function' );
-	} );
-
-	it( 'should create a function which returns the expected value when called', () => {
-		const state = {
-			posts: {
-				'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
-			}
+	it( 'should bust the cache of specific key when watched state changes', () => {
+		const statVisitors = {
+			numVisitors: 5
 		};
-
-		expect( getSitePosts( state, 2916284 ) ).to.eql( [
-			{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
-		] );
-	} );
-
-	it( 'should cache the result of a selector function', () => {
-		const state = {
-			posts: {
-				'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
-			}
+		const statAuthors1 = {
+			numAuthros: 9
 		};
-
-		getSitePosts( state, 2916284 );
-		getSitePosts( state, 2916284 );
-
-		expect( selector ).to.have.been.calledOnce;
-	} );
-
-	it( 'should warn against complex arguments in development mode', () => {
-		const state = { posts: {} };
-
-		getSitePosts( state, 1 );
-		getSitePosts( state, '' );
-		getSitePosts( state, 'foo' );
-		getSitePosts( state, true );
-		getSitePosts( state, null );
-		getSitePosts( state, undefined );
-		getSitePosts( state, {} );
-		getSitePosts( state, [] );
-		getSitePosts( state, 1, [] );
-
-		expect( console.warn ).to.have.been.calledThrice;
-	} );
-
-	it( 'should return the expected value of differing arguments', () => {
-		const state = {
-			posts: {
-				'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' },
-				'6c831c187ffef321eb43a67761a525a3': { ID: 413, site_ID: 38303081, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs & Chicken' }
-			}
+		const statAuthors2 = {
+			numAuthros: 9
 		};
-
-		getSitePosts( state, 2916284 );
-		const sitePosts = getSitePosts( state, 38303081 );
-		getSitePosts( state, 2916284 );
-
-		expect( sitePosts ).to.eql( [
-			{ ID: 413, site_ID: 38303081, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs & Chicken' }
-		] );
-		expect( selector ).to.have.been.calledTwice;
-	} );
-
-	it( 'should bust the cache when watched state changes', () => {
 		const currentState = {
-			posts: {
-				'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
-			}
+			statVisitors, statAuthors: statAuthors1
 		};
 
-		getSitePosts( currentState, 2916284 );
+		// First call to selector with visitors
+		getStats( currentState, 'statVisitors' );
+
+		// Second call to selector authros
+		getStats( currentState, 'statAuthors' );
 
 		const nextState = {
-			posts: {
-				'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' },
-				'6c831c187ffef321eb43a67761a525a3': { ID: 413, site_ID: 38303081, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs & Chicken' }
-			}
+			statVisitors, statAuthors: statAuthors2
 		};
 
-		expect( getSitePosts( nextState, 2916284 ) ).to.eql( [
-			{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
-		] );
+		// This call should no call the selector as only the authors
+		// stats were changed and the visitor is not dependent on that.
+		expect( getStats( nextState, 'statVisitors' ) ).to.equal( statVisitors );
 		expect( selector ).to.have.been.calledTwice;
-	} );
-
-	it( 'should accept an array of dependent state values', () => {
-		const getSitePostsWithArrayDependants = createSelector( selector, ( state ) => [ state.posts ] );
-		const state = {
-			posts: {
-				'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
-			}
-		};
-
-		getSitePostsWithArrayDependants( state, 2916284 );
-		getSitePostsWithArrayDependants( state, 2916284 );
-
-		expect( selector ).to.have.been.calledOnce;
-	} );
-
-	it( 'should accept an array of dependent selectors', () => {
-		const getPosts = ( state ) => state.posts;
-		const getSitePostsWithArrayDependants = createSelector( selector, [ getPosts ] );
-		const state = {
-			posts: {
-				'3d097cb7c5473c169bba0eb8e3c6cb64': {
-					ID: 841,
-					site_ID: 2916284,
-					global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
-					title: 'Hello World'
-				}
-			}
-		};
-
-		const nextState = { posts: {} };
-
-		getSitePostsWithArrayDependants( state, 2916284 );
-		getSitePostsWithArrayDependants( state, 2916284 );
-		getSitePostsWithArrayDependants( nextState, 2916284 );
-		getSitePostsWithArrayDependants( nextState, 2916284 );
-
-		expect( selector ).to.have.been.calledTwice;
-	} );
-
-	it( 'should default to watching entire state, returning cached result if no changes', () => {
-		const getSitePostsWithDefaultGetDependants = createSelector( selector );
-		const state = {
-			posts: {
-				'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
-			}
-		};
-
-		getSitePostsWithDefaultGetDependants( state, 2916284 );
-		getSitePostsWithDefaultGetDependants( state, 2916284 );
-
-		expect( selector ).to.have.been.calledOnce;
-	} );
-
-	it( 'should default to watching entire state, busting if state has changed', () => {
-		const getSitePostsWithDefaultGetDependants = createSelector( selector );
-		const currentState = {
-			posts: {
-				'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
-			}
-		};
-
-		getSitePostsWithDefaultGetDependants( currentState, 2916284 );
-
-		const nextState = {
-			posts: {
-				'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' },
-				'6c831c187ffef321eb43a67761a525a3': { ID: 413, site_ID: 38303081, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs & Chicken' }
-			}
-		};
-
-		getSitePostsWithDefaultGetDependants( nextState, 2916284 );
-
-		expect( selector ).to.have.been.calledTwice;
-	} );
-
-	it( 'should accept an optional custom cache key generating function', () => {
-		const getSitePostsWithCustomGetCacheKey = createSelector(
-			selector,
-			( state ) => state.posts,
-			( state, siteId ) => `CUSTOM${ siteId }`
-		);
-
-		getSitePostsWithCustomGetCacheKey( { posts: {} }, 2916284 );
-
-		expect( getSitePostsWithCustomGetCacheKey.memoizedSelector.cache.has( 'CUSTOM2916284' ) ).to.be.true;
-	} );
-
-	it( 'should call dependant state getter with arguments', () => {
-		const getDeps = sinon.spy();
-		const memoizedSelector = createSelector( () => null, getDeps );
-		const state = {};
-
-		memoizedSelector( state, 1, 2, 3 );
-
-		expect( getDeps ).to.have.been.calledWithExactly( state, 1, 2, 3 );
-	} );
-
-	it( 'should handle an array of selectors instead of a dependant state getter', () => {
-		const getPosts = sinon.spy();
-		const getQuuxs = sinon.spy();
-		const memoizedSelector = createSelector( () => null, [ getPosts, getQuuxs ] );
-		const state = {};
-
-		memoizedSelector( state, 1, 2, 3 );
-		expect( getPosts ).to.have.been.calledWithExactly( state, 1, 2, 3 );
-		expect( getQuuxs ).to.have.been.calledWithExactly( state, 1, 2, 3 );
 	} );
 } );

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -5,7 +5,7 @@ import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { isEqual, includes } from 'lodash';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -62,25 +62,6 @@ class StatsModule extends Component {
 		if ( nextProps.query !== this.props.query && this.state.loaded ) {
 			this.setState( { loaded: false } );
 		}
-	}
-
-	shouldComponentUpdate( nextProps ) {
-		for ( const key in nextProps ) {
-			if ( this.props[ key ] !== nextProps[ key ] ) {
-				if ( key !== 'data' ) {
-					return true; // found shallow unequal prop, should update.
-				}
-
-				// Special case for data prop, do deep equality check.
-				const isDeepEqual = isEqual( this.props[ key ], nextProps[ key ] );
-				if ( ! isDeepEqual ) {
-					return true; // data has changed, the comoponent should update.
-				}
-			}
-		}
-
-		// All keys are either shallow equal or deep equal, no updated required.
-		return false;
 	}
 
 	getModuleLabel() {

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -5,7 +5,7 @@ import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
+import { isEqual, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -62,6 +62,25 @@ class StatsModule extends Component {
 		if ( nextProps.query !== this.props.query && this.state.loaded ) {
 			this.setState( { loaded: false } );
 		}
+	}
+
+	shouldComponentUpdate( nextProps ) {
+		for ( const key in nextProps ) {
+			if ( this.props[ key ] !== nextProps[ key ] ) {
+				if ( key !== 'data' ) {
+					return true; // found shallow unequal prop, should update.
+				}
+
+				// Special case for data prop, do deep equality check.
+				const isDeepEqual = isEqual( this.props[ key ], nextProps[ key ] );
+				if ( ! isDeepEqual ) {
+					return true; // data has changed, the comoponent should update.
+				}
+			}
+		}
+
+		// All keys are either shallow equal or deep equal, no updated required.
+		return false;
 	}
 
 	getModuleLabel() {

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -7,7 +7,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import createSelector from 'lib/create-selector';
+import createSelector, { createSelectorPerKey } from 'lib/create-selector';
 import {
 	getSerializedStatsQuery,
 	normalizers,
@@ -170,7 +170,7 @@ export function getSiteStatsPostsCountByDay( state, siteId, query, date ) {
  * @param  {Object}  query    Stats query object
  * @return {*}                Normalized Data for the query, typically an array or object
  */
-export const getSiteStatsNormalizedData = createSelector(
+export const getSiteStatsNormalizedData = createSelectorPerKey(
 	( state, siteId, statType, query ) => {
 		const data = getSiteStatsForQuery( state, siteId, statType, query );
 		if ( 'function' === typeof normalizers[ statType ] ) {

--- a/client/state/stats/lists/test/reducer.js
+++ b/client/state/stats/lists/test/reducer.js
@@ -258,6 +258,26 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		it( 'should change root site property when received stats by statType', () => {
+			const original = deepFreeze( {
+				2916284: {
+					statsStreak: {
+						'[["endDate","2016-07-01"],["startDate","2016-06-01"]]': streakResponse
+					}
+				}
+			} );
+
+			const state = items( original, {
+				type: SITE_STATS_RECEIVE,
+				siteId: 2916284,
+				statType: 'statsStreak',
+				query: streakQueryDos,
+				data: streakResponseDos
+			} );
+
+			expect( state[ 2916284 ] ).to.not.equal( original[ 2916284 ] );
+		} );
+
 		it( 'should add additional statTypes', () => {
 			const original = deepFreeze( {
 				2916284: {
@@ -285,6 +305,46 @@ describe( 'reducer', () => {
 					}
 				}
 			} );
+		} );
+
+		it( 'should should not change another statTypes property', () => {
+			const original = deepFreeze( {
+				2916284: {
+					statsStreak: {
+						'[["endDate","2016-07-01"],["startDate","2016-06-01"]]': streakResponse
+					}
+				}
+			} );
+
+			const state = items( original, {
+				type: SITE_STATS_RECEIVE,
+				siteId: 2916284,
+				statType: 'statsCountryViews',
+				query: streakQuery,
+				data: {}
+			} );
+
+			expect( state[ 2916284 ].statsStreak ).to.equal( original[ 2916284 ].statsStreak );
+		} );
+
+		it( 'should not change another site property', () => {
+			const original = deepFreeze( {
+				2916284: {
+					statsStreak: {
+						'[["endDate","2016-07-01"],["startDate","2016-06-01"]]': streakResponse
+					}
+				}
+			} );
+
+			const state = items( original, {
+				type: SITE_STATS_RECEIVE,
+				siteId: 3916284,
+				statType: 'statsCountryViews',
+				query: streakQuery,
+				data: {}
+			} );
+
+			expect( state[ 2916284 ].statsStreak ).to.equal( original[ 2916284 ].statsStreak );
 		} );
 	} );
 } );


### PR DESCRIPTION
This is performance improvement to StatsModule as part of performance improvement to My Sites.

getSiteStatsNormalizedData uses `createSelector`, which memoize the result, but because StatModule is generic and uses this selector for all types of stats the result end up never been cached because the dependent data for cache invalidation was the data of the specific stats type. This, in turn, caused the StatsModule component to render over and over even though the data didn't change.

Using the new `createSelectorPerKey` now invalidate the cache on a per-key basis which eliminates most of the wasted render calls.

There is also a change in the way `state/stats/list/reducer.js` handle received stats. Before all of the `items` subtree would have been recreated because of the use of `merge( {}, existingItems, ... )`. Now only the path that changed in site -> statType -> queryKey is recreated, the rest of the state remain exactly the same which allows `connect` HOC to detect nothing has changed and not re-render `StatsModule`.

The result is about 40ms of wasted render time instead of about 800ms of wasted render time.

## To Test
1. Visit the live branch or pull the branch
2. Transition between Reader and My Sites - use site with lots of stats

I've done the test #10326  even though we're not using `merge` any more but just to be on the safe side.