### PR TITLE
Change cancellation survey header copy

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -15,6 +15,7 @@ import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
 import FormTextInput from 'components/forms/form-text-input';
 import FormTextarea from 'components/forms/form-textarea';
+import FormSectionHeading from 'components/forms/form-section-heading';
 import { recordTracksEvent } from 'state/analytics/actions';
 import Button from 'components/button';
 
@@ -442,9 +443,6 @@ const CancelPurchaseForm = React.createClass( {
 		const { translate } = this.props;
 		return (
 			<FormFieldset>
-				<FormLabel>
-					{ translate( 'Let us help you setup your site!' ) }
-				</FormLabel>
 				<p>
 					{
 						translate(
@@ -464,10 +462,17 @@ const CancelPurchaseForm = React.createClass( {
 	},
 
 	render() {
+		const { translate } = this.props;
 		if ( this.props.showSurvey ) {
 			if ( this.props.surveyStep === 1 ) {
 				return (
 					<div>
+						<FormSectionHeading>
+							{ translate( 'Your thoughts are needed.' ) }
+						</FormSectionHeading>
+						<p>
+							{ translate( 'Before you go, please answer a few quick questions to help us improve WordPress.com.' ) }
+						</p>
 						{ this.renderQuestionOne() }
 						{ this.renderQuestionTwo() }
 					</div>
@@ -478,6 +483,9 @@ const CancelPurchaseForm = React.createClass( {
 			if ( this.props.surveyStep === 2 && this.props.finalStep === 3 ) {
 				return (
 					<div>
+						<FormSectionHeading>
+							{ translate( 'Let us help you setup your site!' ) }
+						</FormSectionHeading>
 						{ this.renderConciergeOffer() }
 					</div>
 				);
@@ -486,6 +494,9 @@ const CancelPurchaseForm = React.createClass( {
 			// Render cancellation step
 			return (
 				<div>
+					<FormSectionHeading>
+						{ translate( 'One more question before you go.' ) }
+					</FormSectionHeading>
 					{ this.renderFreeformQuestion() }
 					{ this.props.defaultContent }
 				</div>

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -24,7 +24,6 @@ import { isDomainRegistration, isJetpackPlan, isBusiness } from 'lib/products-va
 import notices from 'notices';
 import paths from 'me/purchases/paths';
 import { refreshSitePlans } from 'state/sites/plans/actions';
-import FormSectionHeading from 'components/forms/form-section-heading';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { cancellationEffectDetail, cancellationEffectHeadline } from './cancellation-effect';
 
@@ -184,12 +183,6 @@ class CancelPurchaseButton extends Component {
 				buttons={ buttonsArr }
 				onClose={ this.closeDialog }
 				className="cancel-purchase__button-warning-dialog">
-				<FormSectionHeading>
-					{ translate( 'Your thoughts are needed.' ) }
-				</FormSectionHeading>
-				<p>
-					{ translate( 'Before you go, please answer a few quick questions to help us improve WordPress.com.' ) }
-				</p>
 				<CancelPurchaseForm
 					surveyStep={ this.state.surveyStep }
 					showSurvey={ config.isEnabled( 'upgrades/removal-survey' ) }

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -165,7 +165,6 @@ class CancelPurchaseButton extends Component {
 				onClick: this.submitCancelAndRefundPurchase
 			}
 		};
-		const purchaseName = getName( purchase );
 		const inFinalStep = ( this.state.surveyStep === this.state.finalStep );
 
 		let buttonsArr;
@@ -185,7 +184,12 @@ class CancelPurchaseButton extends Component {
 				buttons={ buttonsArr }
 				onClose={ this.closeDialog }
 				className="cancel-purchase__button-warning-dialog">
-				<FormSectionHeading>{ translate( 'Cancel %(purchaseName)s', { args: { purchaseName } } ) }</FormSectionHeading>
+				<FormSectionHeading>
+					{ translate( 'Your thoughts are needed.' ) }
+				</FormSectionHeading>
+				<p>
+					{ translate( 'Before you go, please answer a few quick questions to help us improve WordPress.com.' ) }
+				</p>
 				<CancelPurchaseForm
 					surveyStep={ this.state.surveyStep }
 					showSurvey={ config.isEnabled( 'upgrades/removal-survey' ) }

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -148,7 +148,7 @@ class CancelPurchaseButton extends Component {
 			next: {
 				action: 'next',
 				disabled: this.state.isRemoving || this.isSurveyIncomplete(),
-				label: translate( 'Next' ),
+				label: translate( 'Next Step' ),
 				onClick: this.changeSurveyStep
 			},
 			prev: {

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -167,7 +167,7 @@ class RemovePurchase extends Component {
 		this.setState( { isRemoving: true } );
 
 		const purchase = getPurchase( this.props );
-		const { isDomainOnlySite, setAllSitesSelected, selectedSite, translate } = this.props;
+		const { isDomainOnlySite, selectedSite, translate } = this.props;
 
 		if ( ! isDomainRegistration( purchase ) && config.isEnabled( 'upgrades/removal-survey' ) ) {
 			this.recordEvent( 'calypso_purchases_cancel_form_submit' );
@@ -211,7 +211,7 @@ class RemovePurchase extends Component {
 						// exists in `sites-list` as well as the global store.
 						receiveDeletedSiteDeprecated( selectedSite );
 						this.props.receiveDeletedSite( selectedSite );
-						setAllSitesSelected();
+						this.props.setAllSitesSelected();
 					}
 
 					notices.success(

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -338,7 +338,7 @@ class RemovePurchase extends Component {
 					action: 'prev',
 					disabled: this.state.isRemoving,
 					label: translate( 'Previous Step' ),
-					onClick: this.changeSurveyStep
+					onClick: this.changeSurveyStep.bind( null, 'previous' )
 				},
 				remove: {
 					action: 'remove',

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -3,7 +3,7 @@
  */
 import { connect } from 'react-redux';
 import page from 'page';
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import Gridicon from 'gridicons';
 import { localize, moment } from 'i18n-calypso';
 import { get } from 'lodash';
@@ -40,33 +40,31 @@ const user = userFactory();
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:purchases:survey' );
 
-const RemovePurchase = React.createClass( {
-	propTypes: {
-		hasLoadedUserPurchasesFromServer: React.PropTypes.bool.isRequired,
-		isDomainOnlySite: React.PropTypes.bool,
-		receiveDeletedSite: React.PropTypes.func.isRequired,
-		removePurchase: React.PropTypes.func.isRequired,
-		selectedPurchase: React.PropTypes.object,
-		selectedSite: React.PropTypes.oneOfType( [
-			React.PropTypes.object,
-			React.PropTypes.bool,
-			React.PropTypes.undefined
+class RemovePurchase extends Component {
+	static propTypes = {
+		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
+		isDomainOnlySite: PropTypes.bool,
+		receiveDeletedSite: PropTypes.func.isRequired,
+		removePurchase: PropTypes.func.isRequired,
+		selectedPurchase: PropTypes.object,
+		selectedSite: PropTypes.oneOfType( [
+			PropTypes.object,
+			PropTypes.bool,
+			PropTypes.undefined
 		] ),
-		setAllSitesSelected: React.PropTypes.func.isRequired,
-	},
+		setAllSitesSelected: PropTypes.func.isRequired,
+	}
 
-	getInitialState() {
-		return {
-			isDialogVisible: false,
-			isRemoving: false,
-			surveyStep: 1,
-			finalStep: 2,
-			survey: {
-				questionOneRadio: null,
-				questionTwoRadio: null
-			}
-		};
-	},
+	state = {
+		isDialogVisible: false,
+		isRemoving: false,
+		surveyStep: 1,
+		finalStep: 2,
+		survey: {
+			questionOneRadio: null,
+			questionTwoRadio: null
+		}
+	}
 
 	recordChatEvent( eventAction ) {
 		const purchase = this.props.selectedPurchase;
@@ -77,18 +75,18 @@ const RemovePurchase = React.createClass( {
 			is_domain_registration: isDomainRegistration( purchase ),
 			has_included_domain: hasIncludedDomain( purchase ),
 		} );
-	},
+	}
 
-	recordEvent( name, properties = {} ) {
+	recordEvent = ( name, properties = {} ) => {
 		const product_slug = get( this.props, 'selectedPurchase.productSlug' );
 		const cancellation_flow = 'remove';
 		this.props.recordTracksEvent(
 			name,
 			Object.assign( { cancellation_flow, product_slug }, properties )
 		);
-	},
+	}
 
-	closeDialog() {
+	closeDialog = () => {
 		this.recordEvent( 'calypso_purchases_cancel_form_close' );
 		this.setState( {
 			isDialogVisible: false,
@@ -98,23 +96,23 @@ const RemovePurchase = React.createClass( {
 				questionTwoRadio: null
 			}
 		} );
-	},
+	}
 
-	openDialog( event ) {
+	openDialog = ( event ) => {
 		this.recordEvent( 'calypso_purchases_cancel_form_start' );
 		event.preventDefault();
 
 		this.setState( { isDialogVisible: true } );
-	},
+	}
 
-	chatButtonClicked( event ) {
+	chatButtonClicked = ( event ) => {
 		this.recordChatEvent( 'calypso_precancellation_chat_click' );
 		event.preventDefault();
 
 		this.setState( { isDialogVisible: false } );
-	},
+	}
 
-	recordSurveyStepChange( currentStep, nextStep, finalStep ) {
+	recordSurveyStepChange = ( currentStep, nextStep, finalStep ) => {
 		if ( nextStep === 1 ) {
 			this.recordEvent( 'calypso_purchases_cancel_survey_step', { new_step: 'initial_step' } );
 		} else if ( nextStep === 2 && finalStep === 3 ) {
@@ -122,9 +120,9 @@ const RemovePurchase = React.createClass( {
 		} else {
 			this.recordEvent( 'calypso_purchases_cancel_survey_step', { new_step: 'cancellation_step' } );
 		}
-	},
+	}
 
-	changeSurveyStep( direction ) {
+	changeSurveyStep = ( direction ) => {
 		const purchase = getPurchase( this.props );
 		let newStep, finalStep;
 
@@ -157,15 +155,15 @@ const RemovePurchase = React.createClass( {
 
 		this.recordSurveyStepChange( this.state.surveyStep, newStep, finalStep );
 		this.setState( { surveyStep: newStep } );
-	},
+	}
 
-	onSurveyChange( update ) {
+	onSurveyChange = ( update ) => {
 		this.setState( {
 			survey: update,
 		} );
-	},
+	}
 
-	removePurchase( closeDialog ) {
+	removePurchase = ( closeDialog ) => {
 		this.setState( { isRemoving: true } );
 
 		const purchase = getPurchase( this.props );
@@ -241,9 +239,9 @@ const RemovePurchase = React.createClass( {
 
 				notices.error( this.props.selectedPurchase.error );
 			} );
-	},
+	}
 
-	renderCard() {
+	renderCard = () => {
 		const { translate } = this.props;
 		const productName = getName( getPurchase( this.props ) );
 
@@ -255,9 +253,9 @@ const RemovePurchase = React.createClass( {
 				</a>
 			</CompactCard>
 		);
-	},
+	}
 
-	getChatButton() {
+	getChatButton = () => {
 		return (
 			<HappychatButton
 				className="remove-purchase__chat-button"
@@ -265,9 +263,9 @@ const RemovePurchase = React.createClass( {
 				{ this.translate( 'Need help? Chat with us' ) }
 			</HappychatButton>
 		);
-	},
+	}
 
-	renderDomainDialog() {
+	renderDomainDialog = () => {
 		const { translate } = this.props;
 		const buttons = [ {
 				action: 'cancel',
@@ -297,9 +295,9 @@ const RemovePurchase = React.createClass( {
 				{ this.renderDomainDialogText() }
 			</Dialog>
 		);
-	},
+	}
 
-	renderDomainDialogText() {
+	renderDomainDialogText = () => {
 		const { translate } = this.props;
 		const purchase = getPurchase( this.props ),
 			productName = getName( purchase );
@@ -316,9 +314,9 @@ const RemovePurchase = React.createClass( {
 				}
 			</p>
 		);
-	},
+	}
 
-	renderPlanDialogs() {
+	renderPlanDialogs = () => {
 		const { translate } = this.props;
 		const buttons = {
 				cancel: {
@@ -387,9 +385,9 @@ const RemovePurchase = React.createClass( {
 				</Dialog>
 			</div>
 		);
-	},
+	}
 
-	renderPlanDialogsText() {
+	renderPlanDialogsText = () => {
 		const { translate } = this.props;
 		const purchase = getPurchase( this.props ),
 			productName = getName( purchase ),
@@ -434,7 +432,7 @@ const RemovePurchase = React.createClass( {
 				{ ( isPlan( purchase ) && hasIncludedDomain( purchase ) ) && includedDomainText }
 			</div>
 		);
-	},
+	}
 
 	render() {
 		if ( isDataLoading( this.props ) || ! this.props.selectedSite ) {
@@ -453,7 +451,7 @@ const RemovePurchase = React.createClass( {
 			</span>
 		);
 	}
-} );
+}
 
 export default connect(
 	( state, { selectedSite } ) => ( {

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -322,7 +322,7 @@ class RemovePurchase extends Component {
 				cancel: {
 					action: 'cancel',
 					disabled: this.state.isRemoving,
-					label: translate( 'Cancel' )
+					label: translate( "No, I'll Keep It" )
 				},
 				next: {
 					action: 'next',
@@ -331,20 +331,20 @@ class RemovePurchase extends Component {
 						this.state.survey.questionTwoRadio === null ||
 						( this.state.survey.questionOneRadio === 'anotherReasonOne' && this.state.survey.questionOneText === '' ) ||
 						( this.state.survey.questionTwoRadio === 'anotherReasonTwo' && this.state.survey.questionTwoText === '' ),
-					label: translate( 'Next' ),
+					label: translate( 'Next Step' ),
 					onClick: this.changeSurveyStep
 				},
 				prev: {
 					action: 'prev',
 					disabled: this.state.isRemoving,
-					label: translate( 'Previous' ),
+					label: translate( 'Previous Step' ),
 					onClick: this.changeSurveyStep
 				},
 				remove: {
 					action: 'remove',
 					disabled: this.state.isRemoving,
 					isPrimary: true,
-					label: translate( 'Remove' ),
+					label: translate( 'Yes, Remove Now' ),
 					onClick: this.removePurchase
 				}
 			},

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import page from 'page';
 import React from 'react';
 import Gridicon from 'gridicons';
-import { moment } from 'i18n-calypso';
+import { localize, moment } from 'i18n-calypso';
 import { get } from 'lodash';
 
 /**
@@ -169,7 +169,7 @@ const RemovePurchase = React.createClass( {
 		this.setState( { isRemoving: true } );
 
 		const purchase = getPurchase( this.props );
-		const { isDomainOnlySite, setAllSitesSelected, selectedSite } = this.props;
+		const { isDomainOnlySite, setAllSitesSelected, selectedSite, translate } = this.props;
 
 		if ( ! isDomainRegistration( purchase ) && config.isEnabled( 'upgrades/removal-survey' ) ) {
 			this.recordEvent( 'calypso_purchases_cancel_form_submit' );
@@ -217,14 +217,14 @@ const RemovePurchase = React.createClass( {
 					}
 
 					notices.success(
-						this.translate( 'The domain {{domain/}} was removed from your account.', {
+						translate( 'The domain {{domain/}} was removed from your account.', {
 							components: { domain: <em>{ productName }</em> }
 						} ),
 						{ persistent: true }
 					);
 				} else {
 					notices.success(
-						this.translate( '%(productName)s was removed from {{siteName/}}.', {
+						translate( '%(productName)s was removed from {{siteName/}}.', {
 							args: { productName },
 							components: { siteName: <em>{ selectedSite.domain }</em> }
 						} ),
@@ -244,13 +244,14 @@ const RemovePurchase = React.createClass( {
 	},
 
 	renderCard() {
+		const { translate } = this.props;
 		const productName = getName( getPurchase( this.props ) );
 
 		return (
 			<CompactCard className="remove-purchase__card" onClick={ this.openDialog }>
 				<a href="#">
 					<Gridicon icon="trash" />
-					{ this.translate( 'Remove %(productName)s', { args: { productName } } ) }
+					{ translate( 'Remove %(productName)s', { args: { productName } } ) }
 				</a>
 			</CompactCard>
 		);
@@ -267,16 +268,17 @@ const RemovePurchase = React.createClass( {
 	},
 
 	renderDomainDialog() {
+		const { translate } = this.props;
 		const buttons = [ {
 				action: 'cancel',
 				disabled: this.state.isRemoving,
-				label: this.translate( 'Cancel' )
+				label: translate( 'Cancel' )
 			},
 			{
 				action: 'remove',
 				disabled: this.state.isRemoving,
 				isPrimary: true,
-				label: this.translate( 'Remove Now' ),
+				label: translate( 'Remove Now' ),
 				onClick: this.removePurchase
 			} ],
 			productName = getName( getPurchase( this.props ) );
@@ -291,20 +293,21 @@ const RemovePurchase = React.createClass( {
 				className="remove-purchase__dialog"
 				isVisible={ this.state.isDialogVisible }
 				onClose={ this.closeDialog }>
-				<FormSectionHeading>{ this.translate( 'Remove %(productName)s', { args: { productName } } ) }</FormSectionHeading>
+				<FormSectionHeading>{ translate( 'Remove %(productName)s', { args: { productName } } ) }</FormSectionHeading>
 				{ this.renderDomainDialogText() }
 			</Dialog>
 		);
 	},
 
 	renderDomainDialogText() {
+		const { translate } = this.props;
 		const purchase = getPurchase( this.props ),
 			productName = getName( purchase );
 
 		return (
 			<p>
 				{
-					this.translate(
+					translate(
 						'This will remove %(domain)s from your account. By removing, ' +
 							'you are canceling the domain registration. This may stop ' +
 							'you from using it again, even with another service.',
@@ -316,11 +319,12 @@ const RemovePurchase = React.createClass( {
 	},
 
 	renderPlanDialogs() {
+		const { translate } = this.props;
 		const buttons = {
 				cancel: {
 					action: 'cancel',
 					disabled: this.state.isRemoving,
-					label: this.translate( 'Cancel' )
+					label: translate( 'Cancel' )
 				},
 				next: {
 					action: 'next',
@@ -329,20 +333,20 @@ const RemovePurchase = React.createClass( {
 						this.state.survey.questionTwoRadio === null ||
 						( this.state.survey.questionOneRadio === 'anotherReasonOne' && this.state.survey.questionOneText === '' ) ||
 						( this.state.survey.questionTwoRadio === 'anotherReasonTwo' && this.state.survey.questionTwoText === '' ),
-					label: this.translate( 'Next' ),
+					label: translate( 'Next' ),
 					onClick: this.changeSurveyStep
 				},
 				prev: {
 					action: 'prev',
 					disabled: this.state.isRemoving,
-					label: this.translate( 'Previous' ),
-					onClick: this.changeSurveyStep.bind( null, 'previous' )
+					label: translate( 'Previous' ),
+					onClick: this.changeSurveyStep
 				},
 				remove: {
 					action: 'remove',
 					disabled: this.state.isRemoving,
 					isPrimary: true,
-					label: this.translate( 'Remove' ),
+					label: translate( 'Remove' ),
 					onClick: this.removePurchase
 				}
 			},
@@ -371,7 +375,7 @@ const RemovePurchase = React.createClass( {
 					className="remove-purchase__dialog"
 					isVisible={ this.state.isDialogVisible }
 					onClose={ this.closeDialog }>
-					<FormSectionHeading>{ this.translate( 'Remove %(productName)s', { args: { productName } } ) }</FormSectionHeading>
+					<FormSectionHeading>{ translate( 'Remove %(productName)s', { args: { productName } } ) }</FormSectionHeading>
 					<CancelPurchaseForm
 						surveyStep={ this.state.surveyStep }
 						finalStep={ this.state.finalStep }
@@ -386,12 +390,13 @@ const RemovePurchase = React.createClass( {
 	},
 
 	renderPlanDialogsText() {
+		const { translate } = this.props;
 		const purchase = getPurchase( this.props ),
 			productName = getName( purchase ),
 			includedDomainText = (
 				<p>
 					{
-						this.translate(
+						translate(
 							'The domain associated with this plan, {{domain/}}, will not be removed. ' +
 								'It will remain active on your site, unless also removed.',
 							{ components: { domain: <em>{ getIncludedDomain( purchase ) }</em> } }
@@ -404,7 +409,7 @@ const RemovePurchase = React.createClass( {
 			<div>
 				<p>
 					{
-						this.translate(
+						translate(
 							'Are you sure you want to remove %(productName)s from {{siteName/}}?',
 							{
 								args: { productName },
@@ -414,11 +419,11 @@ const RemovePurchase = React.createClass( {
 					}
 					{ ' ' }
 					{ isGoogleApps( purchase )
-						? this.translate(
+						? translate(
 							'Your G Suite account will continue working without interruption. ' +
 								'You will be able to manage your G Suite billing directly through Google.'
 						)
-						: this.translate(
+						: translate(
 							'You will not be able to reuse it again without purchasing a new subscription.',
 							{ comment: "'it' refers to a product purchased by a user" }
 						)
@@ -460,4 +465,4 @@ export default connect(
 		removePurchase,
 		setAllSitesSelected,
 	}
-)( RemovePurchase );
+)( localize( RemovePurchase ) );

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -372,12 +372,6 @@ class RemovePurchase extends Component {
 					className="remove-purchase__dialog"
 					isVisible={ this.state.isDialogVisible }
 					onClose={ this.closeDialog }>
-					<FormSectionHeading>
-						{ translate( 'Your thoughts are needed.' ) }
-					</FormSectionHeading>
-					<p>
-						{ translate( 'Before you go, please answer a few quick questions to help us improve WordPress.com.' ) }
-					</p>
 					<CancelPurchaseForm
 						surveyStep={ this.state.surveyStep }
 						finalStep={ this.state.finalStep }

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -348,7 +348,6 @@ class RemovePurchase extends Component {
 					onClick: this.removePurchase
 				}
 			},
-			productName = getName( getPurchase( this.props ) ),
 			inFinalStep = ( this.state.surveyStep === this.state.finalStep );
 
 		let buttonsArr;
@@ -373,7 +372,12 @@ class RemovePurchase extends Component {
 					className="remove-purchase__dialog"
 					isVisible={ this.state.isDialogVisible }
 					onClose={ this.closeDialog }>
-					<FormSectionHeading>{ translate( 'Remove %(productName)s', { args: { productName } } ) }</FormSectionHeading>
+					<FormSectionHeading>
+						{ translate( 'Your thoughts are needed.' ) }
+					</FormSectionHeading>
+					<p>
+						{ translate( 'Before you go, please answer a few quick questions to help us improve WordPress.com.' ) }
+					</p>
 					<CancelPurchaseForm
 						surveyStep={ this.state.surveyStep }
 						finalStep={ this.state.finalStep }

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -260,7 +260,7 @@ class RemovePurchase extends Component {
 			<HappychatButton
 				className="remove-purchase__chat-button"
 				onClick={ this.chatButtonClicked }>
-				{ this.translate( 'Need help? Chat with us' ) }
+				{ this.props.translate( 'Need help? Chat with us' ) }
 			</HappychatButton>
 		);
 	}


### PR DESCRIPTION
This PR changes the copy for headings and buttons in the cancellation survey:

from:

![screen shot 2017-04-03 at 10 13 28 am](https://cloud.githubusercontent.com/assets/1926/24592210/3ab4966e-1856-11e7-92a8-c17a08cd4343.png)
and
![screen shot 2017-04-10 at 1 35 03 pm](https://cloud.githubusercontent.com/assets/1926/24845089/86854722-1df2-11e7-8822-9b9f4c39f50b.png)

to:

![screen shot 2017-04-10 at 1 36 42 pm](https://cloud.githubusercontent.com/assets/1926/24845119/c0d41d54-1df2-11e7-9200-33a6d464f88b.png)
and
![screen shot 2017-04-10 at 1 35 44 pm](https://cloud.githubusercontent.com/assets/1926/24845105/a06fcbb2-1df2-11e7-878d-98d4e7a9cdc7.png)

To test, you will need a plan which is not eligible for a refund.  This can be accomplished by purchasing a plan using free credits.

Browse to `/me/purchases`, click the plan and then 'Remove <plan name>'.
