### PR TITLE
Jetpack Plugins: Use real-time Manage module activation status

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -28,8 +28,10 @@ import PluginsList from './plugins-list';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import WpcomPluginPanel from 'my-sites/plugins-wpcom';
 import PluginsBrowser from './plugins-browser';
+import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
-import { isJetpackSite, canJetpackSiteManage, canJetpackSiteUpdateFiles } from 'state/sites/selectors';
+import { isJetpackSite, canJetpackSiteUpdateFiles } from 'state/sites/selectors';
+import { isJetpackModuleActive } from 'state/selectors';
 
 const PluginsMain = React.createClass( {
 	mixins: [ URLSearch ],
@@ -367,6 +369,7 @@ const PluginsMain = React.createClass( {
 				<Main>
 					{ this.renderDocumentHead() }
 					<SidebarNavigation />
+					<QueryJetpackModules siteId={ selectedSiteId } />
 					<JetpackManageErrorPage
 						template="optInManage"
 						siteId={ selectedSiteId }
@@ -386,6 +389,7 @@ const PluginsMain = React.createClass( {
 		return (
 			<Main className={ containerClass }>
 				{ this.renderDocumentHead() }
+				<QueryJetpackModules siteId={ selectedSiteId } />
 				<SidebarNavigation />
 				<SectionNav selectedText={ this.getSelectedText() }>
 					<NavTabs>
@@ -435,7 +439,7 @@ export default connect(
 			selectedSiteId: selectedSite && selectedSite.ID,
 			selectedSiteSlug: getSelectedSiteSlug( state ),
 			selectedSiteIsJetpack: selectedSite && isJetpackSite( state, selectedSite.ID ),
-			canSelectedJetpackSiteManage: selectedSite && canJetpackSiteManage( state, selectedSite.ID ),
+			canSelectedJetpackSiteManage: selectedSite && isJetpackModuleActive( state, selectedSite.ID, 'manage' ),
 			canSelectedJetpackSiteUpdateFiles: selectedSite && canJetpackSiteUpdateFiles( state, selectedSite.ID ),
 			canJetpackSiteUpdateFiles: siteId => canJetpackSiteUpdateFiles( state, siteId ),
 			isJetpackSite: siteId => isJetpackSite( state, siteId ),

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -370,12 +370,27 @@ const PluginsMain = React.createClass( {
 					{ this.renderDocumentHead() }
 					<SidebarNavigation />
 					<QueryJetpackModules siteId={ selectedSiteId } />
-					<JetpackManageErrorPage
-						template="optInManage"
-						siteId={ selectedSiteId }
-						title={ this.translate( 'Looking to manage this site\'s plugins?' ) }
-						section="plugins"
-						featureExample={ this.getMockPluginItems() } />
+					{ this.props.canSelectedJetpackSiteManage === false
+						? (
+							<JetpackManageErrorPage
+								template="optInManage"
+								siteId={ selectedSiteId }
+								title={ this.translate( 'Looking to manage this site\'s plugins?' ) }
+								section="plugins"
+								featureExample={ this.getMockPluginItems() } />
+						)
+						: (
+							<div>
+								<EmptyContent
+									title=""
+									section="plugins"
+									illustration=""
+									/>
+								<FeatureExample>{ this.getMockPluginItems() }</FeatureExample>
+							</div>
+						)
+					}
+
 				</Main>
 			);
 		}
@@ -439,7 +454,7 @@ export default connect(
 			selectedSiteId: selectedSite && selectedSite.ID,
 			selectedSiteSlug: getSelectedSiteSlug( state ),
 			selectedSiteIsJetpack: selectedSite && isJetpackSite( state, selectedSite.ID ),
-			canSelectedJetpackSiteManage: selectedSite && isJetpackModuleActive( state, selectedSite.ID, 'manage' ),
+			canSelectedJetpackSiteManage: isJetpackModuleActive( state, selectedSite.ID, 'manage' ),
 			canSelectedJetpackSiteUpdateFiles: selectedSite && canJetpackSiteUpdateFiles( state, selectedSite.ID ),
 			canJetpackSiteUpdateFiles: siteId => canJetpackSiteUpdateFiles( state, siteId ),
 			isJetpackSite: siteId => isJetpackSite( state, siteId ),

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -25,11 +25,13 @@ import URLSearch from 'lib/mixins/url-search';
 import infiniteScroll from 'lib/mixins/infinite-scroll';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import FeatureExample from 'components/feature-example';
+import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import { hasTouch } from 'lib/touch-detect';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSite } from 'state/ui/selectors';
-import { isJetpackSite, canJetpackSiteManage } from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import { isATEnabledForCurrentSite } from 'lib/automated-transfer';
+import { isJetpackModuleActive } from 'state/selectors';
 
 const PluginsBrowser = React.createClass( {
 	_SHORT_LIST_LENGTH: 6,
@@ -278,11 +280,17 @@ const PluginsBrowser = React.createClass( {
 		return <DocumentHead title={ this.translate( 'Plugin Browser', { textOnly: true } ) } />;
 	},
 
+	renderQueryJetpackModules() {
+		const { selectedSite } = this.props;
+		return selectedSite && <QueryJetpackModules siteId={ selectedSite.ID } />;
+	},
+
 	renderAccessError() {
 		if ( this.state.accessError ) {
 			return (
 				<MainComponent>
 					{ this.renderDocumentHead() }
+					{ this.renderQueryJetpackModules() }
 					<SidebarNavigation />
 					<EmptyContent { ...this.state.accessError } />
 					{ this.state.accessError.featureExample
@@ -334,6 +342,7 @@ const PluginsBrowser = React.createClass( {
 		return (
 			<MainComponent className="is-wide-layout">
 				{ this.renderDocumentHead() }
+				{ this.renderQueryJetpackModules() }
 				<SidebarNavigation />
 				{ this.getPageHeaderView() }
 				{ this.getPluginBrowserContent() }
@@ -346,7 +355,7 @@ export default connect(
 	state => ( {
 		selectedSite: getSelectedSite( state ),
 		isJetpackSite: siteId => isJetpackSite( state, siteId ),
-		canJetpackSiteManage: siteId => canJetpackSiteManage( state, siteId ),
+		canJetpackSiteManage: siteId => isJetpackModuleActive( state, siteId, 'manage' ),
 	} ),
 	{
 		recordTracksEvent


### PR DESCRIPTION
This PR fixes #8404, where Manage module is incorrectly being considered deactivated in certain cases. The PR suggests using the real-time activation status of the Manage module instead of the one we have from the latest sync.

This will require some more testing (cc @lancewillett), as the issue was difficult to reproduce in the first place. I was lucky to reproduce it today, which helped in fixing it.

It's worth to mention that the plugins main component requires some refactor in order to approach this issue the best way (e.g. avoid repetition of rendering the `QueryJetpackModules` query component), but let's leave that for another PR, and get this long-standing issue fixed.

To test:
* Let `$site` is a Jetpack site, and `$plugin` is a plugin of your choice that's active on that site.
* Deactivate the Manage module for that site.
* Go to `/plugins/$site`.
* Verify you're receiving the "Manage not activated" error.
* Activate the Manage module for that site.
* Refresh `/plugins/$site`.
* Verify you see the placeholder while loading.
* Verify you see the plugins list after sites and modules have loaded.
* Deactivate the Manage module for that site.
* Go to `/plugin/$plugin/$site`.
* Verify you're receiving the "Manage not activated" error.
* Activate the Manage module for that site.
* Refresh `/plugins/$plugin/$site`.
* Verify you see the placeholder while loading.
* Verify you see the plugin page after sites and modules have loaded.