### PR TITLE
Removed usages of valueLink from client/me/account

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -55,7 +55,7 @@ const user = _user();
 /**
  * Debug instance
  */
-let debug = new Debug( 'calypso:me:account' );
+const debug = new Debug( 'calypso:me:account' );
 
 const Account = React.createClass( {
 
@@ -219,13 +219,8 @@ const Account = React.createClass( {
 	},
 
 	handleRadioChange( event ) {
-		const name = event.currentTarget.name;
-		const value = event.currentTarget.value;
-		let updateObj = {};
-
-		updateObj[ name ] = value;
-
-		this.setState( updateObj );
+		const { name, value } = event.currentTarget;
+		this.setState( { [ name ]: value } );
 	},
 
 	/**
@@ -274,7 +269,7 @@ const Account = React.createClass( {
 	},
 
 	onSiteSelect( siteSlug ) {
-		let selectedSite = sites.getSite( siteSlug );
+		const selectedSite = sites.getSite( siteSlug );
 		if ( selectedSite ) {
 			this.updateUserSetting( 'primary_site_ID', selectedSite.ID );
 		}
@@ -475,6 +470,9 @@ const Account = React.createClass( {
 	renderAccountFields() {
 		const { translate, userSettings } = this.props;
 
+		const isSubmitButtonDisabled = ! userSettings.hasUnsavedSettings() ||
+			this.getDisabledState() || this.hasEmailValidationError();
+
 		return (
 			<div className="account__settings-form" key="settingsForm">
 				<FormFieldset>
@@ -536,7 +534,7 @@ const Account = React.createClass( {
 
 				<FormButton
 					isSubmitting={ this.state.submittingForm }
-					disabled={ ! userSettings.hasUnsavedSettings() || this.getDisabledState() || this.hasEmailValidationError() }
+					disabled={ isSubmitButtonDisabled }
 					onClick={ this.recordClickEvent( 'Save Account Settings Button' ) }
 				>
 					{ this.state.submittingForm ? translate( 'Saving…' ) : translate( 'Save Account Settings' ) }
@@ -584,6 +582,9 @@ const Account = React.createClass( {
 	 */
 	renderUsernameFields() {
 		const { translate, username } = this.props;
+
+		const isSaveButtonDisabled = ( this.getUserSetting( 'user_login' ) !== this.state.userLoginConfirm ) ||
+			! username.isUsernameValid() || this.state.submittingForm;
 
 		return (
 			<div className="account__username-form" key="usernameForm">
@@ -645,7 +646,7 @@ const Account = React.createClass( {
 
 				<FormButtonsBar>
 					<FormButton
-						disabled={ ( this.getUserSetting( 'user_login' ) !== this.state.userLoginConfirm ) || ! username.isUsernameValid() || this.state.submittingForm }
+						disabled={ isSaveButtonDisabled }
 						type="button"
 						onClick={ this.recordClickEvent( 'Change Username Button', this.submitUsernameForm ) }
 					>

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import i18n, { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
@@ -66,6 +66,12 @@ const Account = React.createClass( {
 		observe( 'userSettings', 'username' ),
 		eventRecorder
 	],
+
+	propTypes: {
+		userSettings: PropTypes.object.isRequired,
+		username: PropTypes.object.isRequired,
+		showNoticeInitially: PropTypes.bool,
+	},
 
 	componentWillMount() {
 		// Clear any username changes that were previously made

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
-import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import i18n, { localize } from 'i18n-calypso';
 import Debug from 'debug';
 import emailValidator from 'email-validator';
@@ -64,7 +63,6 @@ const Account = React.createClass( {
 
 	mixins: [
 		formBase,
-		LinkedStateMixin,
 		observe( 'userSettings', 'username' ),
 		eventRecorder
 	],
@@ -84,25 +82,58 @@ const Account = React.createClass( {
 		debug( this.constructor.displayName + ' component is unmounting.' );
 	},
 
-	updateLanguage() {
-		let valueLink = this.valueLink( 'language' );
+	getUserSetting( settingName ) {
+		return this.props.userSettings.getSetting( settingName );
+	},
 
-		valueLink.requestChange = ( value ) => {
-			const originalLanguage = this.props.userSettings.getOriginalSetting( 'language' );
+	updateUserSetting( settingName, value ) {
+		this.props.userSettings.updateSetting( settingName, value );
+	},
 
-			this.props.userSettings.updateSetting( 'language', value );
-			if ( value !== originalLanguage ) {
-				this.setState( { redirect: '/me/account' } );
-			} else {
-				this.setState( { redirect: false } );
-			}
-		};
+	updateUserSettingInput( event ) {
+		this.updateUserSetting( event.target.name, event.target.value );
+	},
 
-		return valueLink;
+	updateUserSettingCheckbox( event ) {
+		this.updateUserSetting( event.target.name, event.target.checked );
+	},
+
+	updateLanguage( event ) {
+		const { value } = event.target;
+		const originalLanguage = this.props.userSettings.getOriginalSetting( 'language' );
+
+		this.updateUserSetting( 'language', value );
+		if ( value !== originalLanguage ) {
+			this.setState( { redirect: '/me/account' } );
+		} else {
+			this.setState( { redirect: false } );
+		}
+	},
+
+	getEmailAddress() {
+		return this.hasPendingEmailChange()
+			? this.getUserSetting( 'new_user_email' )
+			: this.getUserSetting( 'user_email' );
+	},
+
+	updateEmailAddress( event ) {
+		const { value } = event.target;
+		if ( '' === value ) {
+			this.setState( { emailValidationError: 'empty' } );
+		} else if ( ! emailValidator.validate( value ) ) {
+			this.setState( { emailValidationError: 'invalid' } );
+		} else {
+			this.setState( { emailValidationError: false } );
+		}
+		this.updateUserSetting( 'user_email', value );
+	},
+
+	updateUserLoginConfirm( event ) {
+		this.setState( { userLoginConfirm: event.target.value } );
 	},
 
 	validateUsername() {
-		const username = this.props.userSettings.getSetting( 'user_login' );
+		const username = this.getUserSetting( 'user_login' );
 		debug( 'Validating username ' + username );
 		this.props.username.validate( username );
 	},
@@ -113,7 +144,7 @@ const Account = React.createClass( {
 
 	communityTranslator() {
 		const { translate } = this.props;
-		const userLocale = this.props.userSettings.getSetting( 'language' );
+		const userLocale = this.getUserSetting( 'language' );
 		const showTranslator = userLocale && userLocale !== 'en';
 		if ( config.isEnabled( 'community-translator' ) && showTranslator ) {
 			return (
@@ -121,7 +152,8 @@ const Account = React.createClass( {
 					<FormLegend>{ translate( 'Community Translator' ) }</FormLegend>
 					<FormLabel>
 						<FormCheckbox
-							checkedLink={ this.valueLink( 'enable_translator' ) }
+							checked={ this.getUserSetting( 'enable_translator' ) }
+							onChange={ this.updateUserSettingCheckbox }
 							disabled={ this.getDisabledState() }
 							id="enable_translator"
 							name="enable_translator"
@@ -146,8 +178,8 @@ const Account = React.createClass( {
 	},
 
 	thankTranslationContributors() {
-		const { translate, userSettings } = this.props;
-		const locale = userSettings.getSetting( 'language' );
+		const { translate } = this.props;
+		const locale = this.getUserSetting( 'language' );
 		if ( ! locale || locale === 'en' ) {
 			return;
 		}
@@ -204,7 +236,7 @@ const Account = React.createClass( {
 	 */
 	handleUsernameChange( event ) {
 		this.debouncedUsernameValidate();
-		this.props.userSettings.updateSetting( 'user_login', event.currentTarget.value );
+		this.updateUserSetting( 'user_login', event.currentTarget.value );
 		this.setState( { usernameAction: null } );
 	},
 
@@ -223,7 +255,7 @@ const Account = React.createClass( {
 	},
 
 	submitUsernameForm() {
-		const username = this.props.userSettings.getSetting( 'user_login' );
+		const username = this.getUserSetting( 'user_login' );
 		const action = null === this.state.usernameAction ? 'none' : this.state.usernameAction;
 
 		this.setState( { submittingForm: true } );
@@ -244,7 +276,7 @@ const Account = React.createClass( {
 	onSiteSelect( siteSlug ) {
 		let selectedSite = sites.getSite( siteSlug );
 		if ( selectedSite ) {
-			this.props.userSettings.updateSetting( 'primary_site_ID', selectedSite.ID );
+			this.updateUserSetting( 'primary_site_ID', selectedSite.ID );
 		}
 	},
 
@@ -272,7 +304,8 @@ const Account = React.createClass( {
 				<FormLegend>{ translate( 'Holiday Snow' ) }</FormLegend>
 				<FormLabel>
 					<FormCheckbox
-						checkedLink={ this.valueLink( 'holidaysnow' ) }
+						checked={ this.getUserSetting( 'holidaysnow' ) }
+						onChange={ this.updateUserSettingCheckbox }
 						disabled={ this.getDisabledState() }
 						id="holidaysnow"
 						name="holidaysnow"
@@ -307,7 +340,7 @@ const Account = React.createClass( {
 	},
 
 	renderPendingEmailChange() {
-		const { translate, userSettings } = this.props;
+		const { translate } = this.props;
 
 		if ( ! this.hasPendingEmailChange() ) {
 			return null;
@@ -320,7 +353,7 @@ const Account = React.createClass( {
 				text={
 					translate( 'There is a pending change of your email to %(email)s. Please check your inbox for a confirmation link.', {
 						args: {
-							email: userSettings.getSetting( 'new_user_email' )
+							email: this.getUserSetting( 'new_user_email' )
 						}
 					} )
 				}>
@@ -362,8 +395,8 @@ const Account = React.createClass( {
 	},
 
 	renderUsernameConfirmNotice() {
-		const { translate, username, userSettings } = this.props;
-		const usernameMatch = userSettings.getSetting( 'user_login' ) === this.state.userLoginConfirm;
+		const { translate, username } = this.props;
+		const usernameMatch = this.getUserSetting( 'user_login' ) === this.state.userLoginConfirm;
 		const status = usernameMatch ? 'is-success' : 'is-error';
 		const text = usernameMatch
 			? translate( 'Thanks for confirming your new username!' )
@@ -383,7 +416,7 @@ const Account = React.createClass( {
 	},
 
 	renderPrimarySite() {
-		const { translate, userSettings } = this.props;
+		const { translate } = this.props;
 
 		if ( ! user.get().visible_site_count ) {
 			return (
@@ -397,7 +430,7 @@ const Account = React.createClass( {
 			);
 		}
 
-		const primarySiteId = userSettings.getSetting( 'primary_site_ID' );
+		const primarySiteId = this.getUserSetting( 'primary_site_ID' );
 
 		return (
 			<SitesDropdown
@@ -407,24 +440,6 @@ const Account = React.createClass( {
 				onSiteSelect={ this.onSiteSelect }
 			/>
 		);
-	},
-
-	updateEmailAddress() {
-		return {
-			value: this.hasPendingEmailChange()
-				? this.props.userSettings.getSetting( 'new_user_email' )
-				: this.props.userSettings.getSetting( 'user_email' ),
-			requestChange: ( value ) => {
-				if ( '' === value ) {
-					this.setState( { emailValidationError: 'empty' } );
-				} else if ( ! emailValidator.validate( value ) ) {
-					this.setState( { emailValidationError: 'invalid' } );
-				} else {
-					this.setState( { emailValidationError: false } );
-				}
-				this.props.userSettings.updateSetting( 'user_email', value );
-			}
-		};
 	},
 
 	renderEmailValidation() {
@@ -441,7 +456,7 @@ const Account = React.createClass( {
 		switch ( this.state.emailValidationError ) {
 			case 'invalid':
 				notice = translate( '%(email)s is not a valid email address.', {
-					args: { email: userSettings.getSetting( 'user_email' ) }
+					args: { email: this.getUserSetting( 'user_email' ) }
 				} );
 				break;
 			case 'empty':
@@ -463,15 +478,15 @@ const Account = React.createClass( {
 		return (
 			<div className="account__settings-form" key="settingsForm">
 				<FormFieldset>
-					<FormLabel htmlFor="email">{ translate( 'Email Address' ) }</FormLabel>
+					<FormLabel htmlFor="user_email">{ translate( 'Email Address' ) }</FormLabel>
 					<FormTextInput
 						disabled={ this.getDisabledState() || this.hasPendingEmailChange() }
-						id="email"
-						name="email"
+						id="user_email"
+						name="user_email"
 						isError={ !! this.state.emailValidationError }
 						onFocus={ this.recordFocusEvent( 'Email Address Field' ) }
-						valueLink={ this.updateEmailAddress() }
-						valueKey="user_email"
+						value={ this.getEmailAddress() || '' }
+						onChange={ this.updateEmailAddress }
 					/>
 					{ this.renderEmailValidation() }
 					{ this.renderPendingEmailChange() }
@@ -486,13 +501,14 @@ const Account = React.createClass( {
 				</FormFieldset>
 
 				<FormFieldset>
-					<FormLabel htmlFor="url">{ translate( 'Web Address' ) }</FormLabel>
+					<FormLabel htmlFor="user_URL">{ translate( 'Web Address' ) }</FormLabel>
 					<FormTextInput
 						disabled={ this.getDisabledState() }
-						id="url"
-						name="url"
+						id="user_URL"
+						name="user_URL"
 						onFocus={ this.recordFocusEvent( 'Web Address Field' ) }
-						valueLink={ this.valueLink( 'user_URL' ) }
+						value={ this.getUserSetting( 'user_URL' ) || '' }
+						onChange={ this.updateUserSettingInput }
 					/>
 					<FormSettingExplanation>
 						{ translate( 'Shown publicly when you comment on blogs.' ) }
@@ -500,15 +516,16 @@ const Account = React.createClass( {
 				</FormFieldset>
 
 				<FormFieldset>
-					<FormLabel htmlFor="lang_id">{ translate( 'Interface Language' ) }</FormLabel>
+					<FormLabel htmlFor="language">{ translate( 'Interface Language' ) }</FormLabel>
 					<LanguageSelector
 						disabled={ this.getDisabledState() }
-						id="lang_id"
+						id="language"
 						languages={ config( 'languages' ) }
-						name="lang_id"
+						name="language"
 						onFocus={ this.recordFocusEvent( 'Interface Language Field' ) }
 						valueKey="langSlug"
-						valueLink={ this.updateLanguage() }
+						value={ this.getUserSetting( 'language' ) || '' }
+						onChange={ this.updateLanguage }
 					/>
 					{ this.thankTranslationContributors() }
 				</FormFieldset>
@@ -566,7 +583,7 @@ const Account = React.createClass( {
 	 * These form fields are displayed when a username change is in progress.
 	 */
 	renderUsernameFields() {
-		const { translate, username, userSettings } = this.props;
+		const { translate, username } = this.props;
 
 		return (
 			<div className="account__username-form" key="usernameForm">
@@ -580,7 +597,9 @@ const Account = React.createClass( {
 						id="username_confirm"
 						name="username_confirm"
 						onFocus={ this.recordFocusEvent( 'Username Confirm Field' ) }
-						valueLink={ this.linkState( 'userLoginConfirm' ) } />
+						value={ this.state.userLoginConfirm }
+						onChange={ this.updateUserLoginConfirm }
+					/>
 					{ this.renderUsernameConfirmNotice() }
 					<FormSettingExplanation>{ translate( 'Confirm new username' ) }</FormSettingExplanation>
 				</FormFieldset>
@@ -626,7 +645,7 @@ const Account = React.createClass( {
 
 				<FormButtonsBar>
 					<FormButton
-						disabled={ ( userSettings.getSetting( 'user_login' ) !== this.state.userLoginConfirm ) || ! username.isUsernameValid() || this.state.submittingForm }
+						disabled={ ( this.getUserSetting( 'user_login' ) !== this.state.userLoginConfirm ) || ! username.isUsernameValid() || this.state.submittingForm }
 						type="button"
 						onClick={ this.recordClickEvent( 'Change Username Button', this.submitUsernameForm ) }
 					>
@@ -657,16 +676,16 @@ const Account = React.createClass( {
 				<Card className="account__settings">
 					<form onChange={ markChanged } onSubmit={ this.submitForm } >
 						<FormFieldset>
-							<FormLabel htmlFor="username">{ translate( 'Username' ) }</FormLabel>
+							<FormLabel htmlFor="user_login">{ translate( 'Username' ) }</FormLabel>
 								<FormTextInput
 									autoComplete="off"
 									className="account__username"
-									disabled={ this.getDisabledState() || ! userSettings.getSetting( 'user_login_can_be_changed' ) }
-									id="username"
-									name="username"
+									disabled={ this.getDisabledState() || ! this.getUserSetting( 'user_login_can_be_changed' ) }
+									id="user_login"
+									name="user_login"
 									onFocus={ this.recordFocusEvent( 'Username Field' ) }
 									onChange={ this.handleUsernameChange }
-									value={ userSettings.getSetting( 'user_login' ) }
+									value={ this.getUserSetting( 'user_login' ) || '' }
 								/>
 								{ this.renderUsernameValidation() }
 								<FormSettingExplanation>{ this.renderJoinDate() }</FormSettingExplanation>

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -109,11 +109,8 @@ const Account = React.createClass( {
 		const originalLanguage = this.props.userSettings.getOriginalSetting( 'language' );
 
 		this.updateUserSetting( 'language', value );
-		if ( value !== originalLanguage ) {
-			this.setState( { redirect: '/me/account' } );
-		} else {
-			this.setState( { redirect: false } );
-		}
+		const redirect = value !== originalLanguage ? '/me/account' : false;
+		this.setState( { redirect } );
 	},
 
 	getEmailAddress() {
@@ -124,13 +121,12 @@ const Account = React.createClass( {
 
 	updateEmailAddress( event ) {
 		const { value } = event.target;
-		if ( '' === value ) {
-			this.setState( { emailValidationError: 'empty' } );
-		} else if ( ! emailValidator.validate( value ) ) {
-			this.setState( { emailValidationError: 'invalid' } );
-		} else {
-			this.setState( { emailValidationError: false } );
-		}
+		const emailValidationError = (
+			( '' === value && 'empty' ) ||
+			( ! emailValidator.validate( value ) && 'invalid' ) ||
+			false
+		);
+		this.setState( { emailValidationError } );
 		this.updateUserSetting( 'user_email', value );
 	},
 

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import i18n, { localize } from 'i18n-calypso';
-import Debug from 'debug';
+import debugFactory from 'debug';
 import emailValidator from 'email-validator';
 import {
 	debounce,
@@ -55,7 +55,7 @@ const user = _user();
 /**
  * Debug instance
  */
-const debug = new Debug( 'calypso:me:account' );
+const debug = debugFactory( 'calypso:me:account' );
 
 const Account = React.createClass( {
 


### PR DESCRIPTION
Removes usage of `valueLink` from `client/me/account/main.jsx`.

Similar work has already been done when Reduxifying `client/my-sites/site-settings` and even after this PR, remains to be done in the rest of the `client/me` directory.

Will be useful for PR #12544 - new `LanguageChooser` component that no longer needs to support dual API now.

The commit messages contain additional details.

*Testing instructions:*
Test if all the form elements in `client/me/account` still work properly, especially:
- changing the language and enabling/disabling the community translator
- changing the username, with its "confirm username" workflow
- changing the email address, with its confirmation workflow
- enabling/disabling the "holiday snow" feature :)
