### PR TITLE
Themes: Redirect /themes to /design

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -338,6 +338,10 @@ module.exports = function() {
 	}
 
 	app.get( '/theme', ( req, res ) => res.redirect( '/design' ) );
+	// Interim redirect before we make `/themes` the canonical showcase URL.
+	app.get( [ '/themes', '/themes/*' ], ( req, res ) => {
+		res.redirect( '/design' + req.originalUrl.slice( '/themes'.length ) );
+	} );
 
 	sections
 		.filter( section => ! section.envId || section.envId.indexOf( config( 'env_id' ) ) > -1 )


### PR DESCRIPTION
Step 1 of p4axMe-1jd-p2. Enables Calypso to handle  `/themes` routes, redirecting them to `/design`.

To test:
Land on a couple of different `/themes` routes (with different combinations of tier/vertical/filter/search string), and observe that you are being redirected to the corresponding `/design` route.

Note that in production (and staging?), `/themes` still routes to Atlas, so this PR won't have any visible effect there yet. Step 2 will be to route `/themes` to Calypso instead.