### PR TITLE
Reader: Allow images from secure hosts

### DIFF
--- a/client/lib/post-normalizer/rule-content-make-images-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-images-safe.js
@@ -60,10 +60,16 @@ function makeImageSafe( post, image, maxWidth ) {
 		imgSource = url.resolve( post.URL, imgSource );
 	}
 
-	const safeSource = ( maxWidth
+	let safeSource = ( maxWidth
 		? maxWidthPhotonishURL( safeImageURL( imgSource ), maxWidth )
 		: safeImageURL( imgSource )
 		);
+
+	// allow https sources through even if we can't make them 'safe'
+	// helps images that use querystring params and are from secure sources
+	if ( ! safeSource && startsWith( imgSource, 'https://' ) ) {
+		safeSource = imgSource;
+	}
 
 	removeUnwantedAttributes( image );
 

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -458,6 +458,20 @@ describe( 'index', function() {
 			safeImageUrlFake.undoReturns();
 		} );
 
+		it( 'can allow images that cannot be made safe but are from secure hosts', function( done ) {
+			safeImageUrlFake.setReturns( null );
+			normalizer(
+				{
+					content: '<img width="700" height="700" src="https://example.com/example.jpg?nope">'
+				},
+				[ normalizer.withContentDOM( [ normalizer.content.makeImagesSafe( 400 ) ] ) ], function( err, normalized ) {
+					assert.equal( normalized.content, '<img width="700" height="700" src="https://example.com/example.jpg?nope">' );
+					done( err );
+				}
+			);
+			safeImageUrlFake.undoReturns();
+		} );
+
 		it( 'removes event handlers from content images', function( done ) {
 			normalizer(
 				{


### PR DESCRIPTION
Fixes things like the eventbrite buttons which are from a secure host but use querystring arguments.

Compare https://wordpress.com/read/blogs/84643045/posts/1666 to https://calypso.live/read/blogs/84643045/posts/1666?branch=fix/reader/eventbrite-buttons