### PR TITLE
CommentButton: Add i18n context to label

### DIFF
--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -50,7 +50,10 @@ class CommentButton extends Component {
 				}
 				{ showLabel && commentCount > 0 &&
 					<span className="comment-button__label-status">
-						{ translate( 'Comment', 'Comments', { count: commentCount } ) }
+						{ translate( 'Comment', 'Comments', {
+							context: 'noun',
+							count: commentCount,
+						} ) }
 					</span>
 				}
 			</span>


### PR DESCRIPTION
Allows translators to avoid a UI that says:

> 1 (verb "to comment")

and instead correctly say:

> 1 comment