### PR TITLE
Stats: OverviewStats Add key to placeholder header

### DIFF
--- a/client/my-sites/stats/overview.jsx
+++ b/client/my-sites/stats/overview.jsx
@@ -109,7 +109,7 @@ class StatsOverview extends Component {
 		items.push( <h3 key="header-placeholder" className="stats-section-title">&nbsp;</h3> ); // eslint-disable-line wpcalypso/jsx-classname-namespace
 
 		for ( let i = 0; i < limit; i++ ) {
-			items.push( <SiteOverviewPlaceholder key={ i + '-placeholder' } /> );
+			items.push( <SiteOverviewPlaceholder key={ 'placeholder-' + i } /> );
 		}
 
 		return items;

--- a/client/my-sites/stats/overview.jsx
+++ b/client/my-sites/stats/overview.jsx
@@ -106,10 +106,10 @@ class StatsOverview extends Component {
 		const limit = Math.min( this.props.user.visible_site_count, 10 );
 
 		// TODO: a separate StatsSectionTitle component should be created
-		items.push( <h3 className="stats-section-title">&nbsp;</h3> ); // eslint-disable-line wpcalypso/jsx-classname-namespace
+		items.push( <h3 key="header-placeholder" className="stats-section-title">&nbsp;</h3> ); // eslint-disable-line wpcalypso/jsx-classname-namespace
 
 		for ( let i = 0; i < limit; i++ ) {
-			items.push( <SiteOverviewPlaceholder key={ i } /> );
+			items.push( <SiteOverviewPlaceholder key={ i + '-placeholder' } /> );
 		}
 
 		return items;


### PR DESCRIPTION
Removes a react js error.

Currently we do not have a key defined in the items list for the place holder header which results in a react error. Telling us to add it. 

This PR fixes this my adding a key to the placeholder.

