### PR TITLE
Reader: ReaderAvatar has_avatar should default to true

### DIFF
--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -44,7 +44,7 @@ const ReaderAvatar = ( {
 	}
 
 	let hasSiteIcon = !! get( fakeSite, 'icon.img' );
-	let hasAvatar = !! ( author && author.has_avatar );
+	let hasAvatar = ( author && get( author, 'has_avatar', true ) );
 
 	if ( hasSiteIcon && hasAvatar ) {
 		// Do these both reference the same image? Disregard query string params.


### PR DESCRIPTION
compare: http://calypso.localhost:3000/devdocs/blocks/reader-subscription-list-item before and after.

Question: why does the has_avatar flag sometimes not exist on the author object?