### PR TITLE
Domains: Fix duplicated validation error on state field

### DIFF
--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -3,7 +3,15 @@
  */
 import React from 'react';
 import classNames from 'classnames';
-import { camelCase, head, kebabCase, map, omit, reduce } from 'lodash';
+import {
+	camelCase,
+	deburr,
+	head,
+	kebabCase,
+	map,
+	omit,
+	reduce,
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -73,7 +81,7 @@ export default React.createClass( {
 		const sanitizedFieldValues = Object.assign( {}, fieldValues );
 		this.fieldNames.forEach( ( fieldName ) => {
 			if ( typeof fieldValues[ fieldName ] === 'string' ) {
-				sanitizedFieldValues[ fieldName ] = fieldValues[ fieldName ].trim();
+				sanitizedFieldValues[ fieldName ] = deburr( fieldValues[ fieldName ].trim() );
 				if ( fieldName === 'postalCode' ) {
 					sanitizedFieldValues[ fieldName ] = sanitizedFieldValues[ fieldName ].toUpperCase();
 				}

--- a/client/my-sites/upgrades/components/form/state-select.jsx
+++ b/client/my-sites/upgrades/components/form/state-select.jsx
@@ -70,9 +70,9 @@ class StateSelect extends Component {
 								<option key={ state.code } value={ state.code }>{ state.name }</option>
 							) }
 						</FormSelect>
+						{ this.props.errorMessage && <FormInputValidation text={ this.props.errorMessage } isError /> }
 					</div>
 				}
-				{ this.props.errorMessage && <FormInputValidation text={ this.props.errorMessage } isError /> }
 			</div>
 		);
 	}


### PR DESCRIPTION
The problem was that in case of the text Input (when we don't have a strict list of states for the given country), we've been showing the `Input` component - which has its own `FormInputValidation`. This was conflicting with the one in `StateSelect`. I've moved the one in `StateSelect` so that it's only renendered when the `FormSelect` implementation is used.

Additionally, I've used [`deburr` from Lodash](https://lodash.com/docs#deburr) to "downgrade" the user input to the basic Latin character set we require them to use:
![eyzrgjq4yl](https://cloud.githubusercontent.com/assets/3392497/24624559/8c38ac4a-18ac-11e7-8fb1-ef2cb403efdc.gif)

### Testing
Go to Calypso, try to register a new domain name, on the `DOMAIN CONTACT INFORMATION` form:

* Verify that the state field does not have a duplicated error when it's a text field:
   <img width="628" alt="screen shot 2017-04-03 at 20 06 28" src="https://cloud.githubusercontent.com/assets/3392497/24624610/b5422f8a-18ac-11e7-96f0-ff3a216187cb.png">
* Verify that the state field does not have a duplicated error when it's a select field:
  <img width="628" alt="screen shot 2017-04-03 at 20 05 55" src="https://cloud.githubusercontent.com/assets/3392497/24624627/bf33cc06-18ac-11e7-8223-9c1b0cc10c49.png">
* And last but not least, if there are no errors, no errors should be shown ;)
   <img width="625" alt="screen shot 2017-04-03 at 20 06 41" src="https://cloud.githubusercontent.com/assets/3392497/24624646/ceaaf7a4-18ac-11e7-9d44-e4ec3d070fb0.png">

Additionally, try different fields and verify that non-basic Latin characters (like żąłć or ä) are converted to their basic Latin versions. Make sure that it doesn't crap out on other alphabets too, like the Japanese or Arabic ones. Of course, it won't convert them to basic Latin, but it shouldn't cause any JavaScript errors (just validation ones ;)).

Fixes #12599 
Props to @kriskorn for the report 🙇 