### PR TITLE
Themes: Fix details page for active theme

### DIFF
--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -310,8 +310,8 @@ export const queries = ( () => {
 	return createReducer( {}, {
 		[ THEMES_REQUEST_SUCCESS ]: ( state, { siteId, query, themes, found } ) => {
 			return applyToManager(
-				// Always 'patch' to avoid overwriting fields when receiving from a
-				// less rich endpoint such as /mine
+				// Always 'patch' to avoid overwriting existing fields when receiving
+				// from a less rich endpoint such as /mine
 				state, siteId, 'receive', true, themes, { query, found, patch: true }
 			);
 		},

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -309,7 +309,11 @@ export const queries = ( () => {
 
 	return createReducer( {}, {
 		[ THEMES_REQUEST_SUCCESS ]: ( state, { siteId, query, themes, found } ) => {
-			return applyToManager( state, siteId, 'receive', true, themes, { query, found } );
+			return applyToManager(
+				// Always 'patch' to avoid overwriting fields when receiving from a
+				// less rich endpoint such as /mine
+				state, siteId, 'receive', true, themes, { query, found, patch: true }
+			);
 		},
 		[ THEME_DELETE_SUCCESS ]: ( state, { siteId, themeId } ) => {
 			return applyToManager( state, siteId, 'removeItem', false, themeId );


### PR DESCRIPTION
Fixes #12743

The response from the /themes/mine endpoint, which has less data than theme details endpoint, was overwriting theme data in the store, leading to missing data on the theme details page for an active theme.

Fix by always using QueryManager.receive() in 'patch' mode, which adds merges to existing items rather than overwriting.

**To Test**
* see #12743
