### PR TITLE
Desktop: Merge desktop dependencies into root package.json

### DIFF
--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -9,7 +9,7 @@ THIS_MAKEFILE_PATH := $(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST))
 THIS_DIR := $(shell cd $(dir $(THIS_MAKEFILE_PATH));pwd)
 
 NPM ?= $(NODE) $(shell which npm)
-NPM_BIN = $(shell npm bin)
+NPM_BIN = $(shell cd ..; npm bin)
 
 RED=`tput setaf 1`
 RESET=`tput sgr0`

--- a/desktop/builder.js
+++ b/desktop/builder.js
@@ -10,13 +10,12 @@ var path = require( 'path' );
  */
 var builder = require( './resource/lib/tools' );
 var config = require( './resource/lib/config' );
-var pkg = require( './package.json' );
+var pkg = require( '../package.json' );
 
 /**
  * Module variables
  */
-var electronVersion = pkg.devDependencies['electron'].replace( '^', '' );
-var key;
+var electronVersion = pkg.devDependencies.electron;
 
 var opts = {
 	dir: './build',

--- a/desktop/desktop/lib/menu/editor-context-menu.js
+++ b/desktop/desktop/lib/menu/editor-context-menu.js
@@ -7,7 +7,7 @@
  */
 
 var noop = function(){};
-var cloneDeep = require('lodash.clonedeep');
+var cloneDeep = require('lodash/clonedeep');
 var BrowserWindow = require('electron').BrowserWindow;
 var Menu = require('electron').Menu;
 var platform = require( '../platform' );

--- a/desktop/desktop/lib/menu/general-context-menu.js
+++ b/desktop/desktop/lib/menu/general-context-menu.js
@@ -4,7 +4,7 @@
  */
 
 var Menu = require( 'electron' ).Menu;
-var cloneDeep = require('lodash.clonedeep');
+var cloneDeep = require('lodash/clonedeep');
 var BrowserWindow = require('electron').BrowserWindow;
 var platform = require( '../platform' );
 

--- a/desktop/desktop/window-handlers/window-saver/index.js
+++ b/desktop/desktop/window-handlers/window-saver/index.js
@@ -3,7 +3,7 @@
 /**
  * External Dependencies
  */
-const debounce = require( 'lodash.debounce' );
+const debounce = require( 'lodash/debounce' );
 
 /**
  * Internal dependencies

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -21,40 +21,5 @@
   ],
   "engines": {
     "npm": "^3.5.3"
-  },
-  "optionalDependencies": {
-    "appdmg": "^0.4.5"
-  },
-  "devDependencies": {
-    "asar": "^0.11.0",
-    "babel-core": "^6.9.0",
-    "babel-eslint": "^6.0.4",
-    "babel-loader": "^6.2.2",
-    "babel-preset-es2015": "^6.9.0",
-    "babel-preset-react": "^6.3.13",
-    "chai": "^3.4.1",
-    "electron-builder": "2.8.4",
-    "electron-mocha": "^2.1.0",
-    "electron-packager": "^7.0.2",
-    "electron": "1.3.5",
-    "electron-rebuild": "^1.2.1",
-    "eslint": "^2.10.2",
-    "eslint-plugin-react": "^5.1.1",
-    "json-loader": "^0.5.4",
-    "minimist": "^1.2.0",
-    "mkdirp": "^0.5.1",
-    "mv": "^2.1.1",
-    "unzip": "^0.1.11",
-    "webpack": "^1.13.1"
-  },
-  "dependencies": {
-    "debug": "^2.2.0",
-    "express": "^4.13.3",
-    "jade": "^1.11.0",
-    "lodash.clonedeep": "^4.3.0",
-    "lodash.debounce": "^4.0.0",
-    "portscanner": "^1.0.0",
-    "spellchecker": "^3.2.3",
-    "superagent": "^1.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/Automattic/wp-calypso.git"
   },
   "main": "index.js",
+  "optionalDependencies": {
+    "appdmg": "0.4.5"
+  },
   "dependencies": {
     "async": "0.9.0",
     "atob": "1.1.2",
@@ -26,6 +29,7 @@
     "babel-plugin-transform-react-jsx": "6.8.0",
     "babel-plugin-transform-runtime": "6.9.0",
     "babel-preset-es2015": "6.9.0",
+    "babel-preset-react": "6.3.13",
     "babel-preset-stage-2": "6.5.0",
     "babel-register": "6.9.0",
     "blob": "0.0.4",
@@ -91,6 +95,7 @@
     "percentage-regex": "3.0.0",
     "phone": "git+https://github.com/Automattic/node-phone.git#1.0.8",
     "photon": "2.0.0",
+    "portscanner": "^1.0.0",
     "postcss-cli": "2.5.1",
     "prismjs": "^1.6.0",
     "q": "1.0.1",
@@ -120,6 +125,7 @@
     "source-map": "0.1.39",
     "source-map-loader": "0.1.5",
     "source-map-support": "0.3.2",
+    "spellchecker": "^3.2.3",
     "store": "1.3.16",
     "striptags": "2.1.1",
     "superagent": "2.1.0",
@@ -155,10 +161,16 @@
     "css-lint": "stylelint 'client/**/*.scss' --syntax scss"
   },
   "devDependencies": {
+    "asar": "0.11.0",
     "babel-eslint": "6.1.2",
     "chai": "3.5.0",
     "chai-enzyme": "0.5.2",
     "deep-freeze": "0.0.1",
+    "electron": "1.3.5",
+    "electron-builder": "2.8.4",
+    "electron-mocha": "2.1.0",
+    "electron-packager": "7.0.2",
+    "electron-rebuild": "1.2.1",
     "enzyme": "2.4.1",
     "esformatter": "0.7.3",
     "esformatter-braces": "1.2.1",
@@ -174,10 +186,13 @@
     "glob": "7.0.3",
     "lodash-deep": "1.5.3",
     "md5-file": "3.1.0",
+    "minimist": "1.2.0",
     "mixedindentlint": "1.1.1",
+    "mkdirp": "0.5.1",
     "mocha": "3.1.0",
     "mocha-junit-reporter": "1.12.0",
     "mockery": "1.7.0",
+    "mv": "2.1.1",
     "nock": "8.0.0",
     "nodemon": "1.4.1",
     "react-addons-test-utils": "15.4.0",
@@ -189,6 +204,7 @@
     "socket.io": "1.4.5",
     "stylelint": "^6.5.1",
     "supertest": "2.0.0",
+    "unzip": "0.1.11",
     "webpack-bundle-analyzer": "2.2.1",
     "webpack-dashboard": "0.2.0",
     "webpack-dev-server": "1.11.0"


### PR DESCRIPTION
This PR intends to simplify the projects dependency management after merging `wp-desktop` in. I've essentially merged all of the dependencies found in `/desktop/package.json` in to the root level `package.json` so that we're only having to manage them in one place.

### Dropping Singular Lodash Modules
Now that we have direct access to Calypso's Lodash dependency I wanted to explore the impact of dropping desktops dependency on `lodash.clonedeep` and `lodash.debounce`.
Of course, simply replacing instances with `_.cloneDeep` adds Lodash to the bundle in it's entirety, adding around half a megabyte.
Here are some of my findings from some different approaches:

| Method  | Bundle Size (bytes) |
| ------- | ------- |
| No change, 2 dep locations | 5,882,106 |
| Keep lodash.clonedeep/debounce (in root package.json) | 5,817,871 |
| import { cloneDeep, debounce } from 'lodash' | 5,760,543 |
| require( 'lodash/clonedeep' ) etc | 5,760,453 |

The difference between the last two is negligible - I chose to stick with `require( 'lodash/clonedeep' )` to avoid hitting parse errors in node with `import` syntax.

### optionalDependencies
The only 'optionalDependency' is `appdmg`, which is only used in `build-scripts/package-dmg`.

From my interpretation of [this section of NPM's docs](https://docs.npmjs.com/files/package.json#optionaldependencies) (this is about the only documentation that I could find on `optionalDependencies`), I think that any deps included in `optionalDependencies` should be considered intermittent in that they may or may not be found and so should be guarded against.

In `build-scripts/package-dmg` that's not the case. If `appdmg` was not found we would see an error as the logic tries to call `appdmg( ... )`.

~This suggests to me that we should either add a guard clause to this file or add the package to the regular dependency list so I've added it to `dependencies`. I'm interested to hear if I've made the right assumption here.~

Adding `appdmg` to `dependencies` causes an error in CircleCi as it's os x only - this is why it was in `optionalDependencies` - I've moved it to `optionalDependencies` in the root `package.json`

### Sooo, Can We Drop desktop/package.json?
Not just yet...
Some files within `/desktop` reference certain details from `/desktop/package.json`.
While there's likely a more suitable place for those details to live I'd rather address those changes in another PR as I think that calls for different discussion.

### Electron App Size
Improving bundle sizes is great, but ultimately what matters is the size of the production apps.
I've done a quick comparison of the size of the linux app built from `wp-desktop` on master and from this branch (before and after merging the deps). 

| Method | Size of `.tar.gz` (bytes) |
| ------- | ------- |
| Running from wp-desktop, Calypso @ 23cdf23 * | 53,774,604 |
| Running before changes | 54,514,952 |
| Running after changes | 54,482,961 |

There's very little difference between the before and after runs of this build - I'd expected there to be more of a difference since we're not including 2 versions of the same packages...
That said, most of the packages that were different were `devDependencies` which wouldn't be included anyway - and I *think* those that are included may be included in multiple places, bundled in to the desktop app as well as the Calypso client bundle (just a hunch for now).

Below is a list of package differences, in merging the two lists I've opted for keeping the Calypso version where there are differences.
I'm keen to investigate whether or not there would be any nuances between the packages with major version differences - but that could take some time.

<details>
  <summary>Package Differences</summary>

| package | root | desktop |
| --- | --- | --- |
| jade | pugjs/jade#29784fd | ^1.11.0 |
| lodash.clonedeep | lodash@4.15.0 | ^4.3.0 |
| lodash.debounce | lodash@4.15.0 | ^4.0.0 |
| babel-core | 6.9.1 | ^6.9.0 |
| babel-eslint | 6.1.2 | ^6.0.4 |
| babel-loader | 6.2.4 | ^6.2.2 |
| chai | 3.5.0 | ^3.4.1 |
| eslint | 3.8.1 | ^2.10.2 |
| eslint-plugin-react | 6.4.1 | ^5.1.1 |
</details>