### PR TITLE
devdocs: fix title for calendars docs components

### DIFF
--- a/client/blocks/calendar-button/docs/example.jsx
+++ b/client/blocks/calendar-button/docs/example.jsx
@@ -16,4 +16,6 @@ const CalendarButtonExample = () => {
 	);
 };
 
+CalendarButtonExample.displayName = 'CalendarButton';
+
 export default CalendarButtonExample;

--- a/client/blocks/calendar-popover/docs/example.jsx
+++ b/client/blocks/calendar-popover/docs/example.jsx
@@ -42,4 +42,6 @@ class CalendarPopoverExample extends PureComponent {
 	}
 }
 
+CalendarPopoverExample.displayName = 'CalendarPopover';
+
 export default CalendarPopoverExample;

--- a/client/components/popover/docs/example.jsx
+++ b/client/components/popover/docs/example.jsx
@@ -136,4 +136,6 @@ class PopoverExample extends PureComponent {
 	}
 }
 
+PopoverExample.displayName = 'Popover';
+
 export default PopoverExample;

--- a/client/components/tooltip/docs/example.jsx
+++ b/client/components/tooltip/docs/example.jsx
@@ -98,4 +98,6 @@ class Tooltip extends PureComponent {
 	}
 }
 
+Tooltip.displayName = 'Tooltip';
+
 export default Tooltip;


### PR DESCRIPTION
This PR fixes the title issue in the production environment for the <CalendarButton /> and <CalendarPopover /> components because by the js compression.

<img src="https://cloud.githubusercontent.com/assets/77539/24630182/0d4cf220-1892-11e7-9e49-ad5b3191a888.png" width="400px" />

### Testing

Go to Devdocs block page of both components.
http://calypso.localhost:3000/devdocs/blocks/calendar-button
http://calypso.localhost:3000/devdocs/blocks/calendar-popover
You should see the title of component rightly.
Test on prod as well after deploy.