### PR TITLE
Add/republicize preview

### DIFF
--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -214,21 +214,23 @@ class PostShare extends Component {
 							<div className="post-share__main">
 								<div className="post-share__form">
 									{ this.renderMessage() }
+									<div className="post-share__button-actions" >
+										{ isEnabled( 'publicize/preview' ) &&
+											<Button className="post-share__preview-button"
+												onClick={ this.toggleSharingPreview } >
+												{ this.props.translate( 'Preview' ) }
+											</Button>
+										}
 
-									{ isEnabled( 'publicize/preview' ) &&
-										<Button onClick={ this.toggleSharingPreview } >
-											{ this.props.translate( 'Preview' ) }
+										<Button
+											className="post-share__button"
+											primary={ true }
+											onClick={ this.sharePost }
+											disabled={ this.isButtonDisabled() }
+										>
+											{ this.props.translate( 'Share post' ) }
 										</Button>
-									}
-
-									<Button
-										className="post-share__button"
-										primary={ true }
-										onClick={ this.sharePost }
-										disabled={ this.isButtonDisabled() }
-									>
-										{ this.props.translate( 'Share post' ) }
-									</Button>
+									</div>
 								</div>
 
 								<div className="post-share__services">

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -27,6 +27,7 @@ import { hasFeature } from 'state/sites/plans/selectors';
 import { FEATURE_REPUBLICIZE } from 'lib/plans/constants';
 import Banner from 'components/banner';
 import Connection from './connection';
+import SharingPreviewModal from './sharing-preview-modal';
 import { isEnabled } from 'config';
 
 class PostShare extends Component {
@@ -43,7 +44,8 @@ class PostShare extends Component {
 
 	state = {
 		skipped: PostMetadata.publicizeSkipped( this.props.post ) || [],
-		message: PostMetadata.publicizeMessage( this.props.post ) || this.props.post.title
+		message: PostMetadata.publicizeMessage( this.props.post ) || this.props.post.title,
+		showSharingPreview: false,
 	};
 
 	hasConnections() {
@@ -68,6 +70,11 @@ class PostShare extends Component {
 
 	isConnectionActive = connection =>
 		connection.status !== 'broken' && this.skipConnection( connection );
+
+	toggleSharingPreview = () => {
+		const showSharingPreview = ! this.state.showSharingPreview;
+		this.setState( { showSharingPreview } );
+	}
 
 	renderServices() {
 		if ( ! this.props.site || ! this.hasConnections() ) {
@@ -209,7 +216,7 @@ class PostShare extends Component {
 									{ this.renderMessage() }
 
 									{ isEnabled( 'publicize/preview' ) &&
-										<Button>
+										<Button onClick={ this.toggleSharingPreview } >
 											{ this.props.translate( 'Preview' ) }
 										</Button>
 									}
@@ -255,6 +262,13 @@ class PostShare extends Component {
 				</div>
 
 				{ this.props.site && <QueryPublicizeConnections siteId={ this.props.site.ID } /> }
+				<SharingPreviewModal
+					siteId={ this.props.siteId }
+					postId={ this.props.postId }
+					message={ this.state.message }
+					isVisible={ this.state.showSharingPreview }
+					onClose={ this.toggleSharingPreview }
+				/>
 			</div>
 		);
 	}
@@ -263,12 +277,14 @@ class PostShare extends Component {
 export default connect(
 	( state, props ) => {
 		const siteId = props.site.ID;
+		const postId = props.post.ID;
 		const userId = getCurrentUserId( state );
 
 		return {
 			planHasRepublicizeFeature: hasFeature( state, siteId, FEATURE_REPUBLICIZE ),
 			siteSlug: getSiteSlug( state, siteId ),
 			siteId,
+			postId,
 			isPublicizeEnabled: isPublicizeEnabled( state, siteId, props.post.type ),
 			connections: getSiteUserConnections( state, siteId, userId ),
 			hasFetchedConnections: hasFetchedConnections( state, siteId ),

--- a/client/my-sites/post-share/sharing-preview-modal.jsx
+++ b/client/my-sites/post-share/sharing-preview-modal.jsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import Gridicon from 'gridicons';
+import { pick } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+import SharingPreviewPane from 'blocks/sharing-preview-pane';
+
+const SharingPreviewModal = ( props ) => {
+	const previewProps = pick( props, [ 'message', 'siteId', 'postId' ] );
+	const {
+		isVisible,
+		onClose,
+	} = props;
+
+	return (
+		<Dialog isVisible={ isVisible } additionalClassNames="post-share__sharing-preview-modal" >
+			<header className="post-share__sharing-preview-modal-header">
+				<button onClick={ onClose } className="post-share__sharing-preview-modal-close" >
+					<Gridicon icon="cross" />
+				</button>
+			</header>
+			<SharingPreviewPane { ...previewProps } />
+		</Dialog>
+	);
+};
+
+SharingPreviewModal.propTypes = {
+	isVisible: PropTypes.bool.isRequired,
+	onClose: PropTypes.func.isRequired,
+
+	// SharingPreviewPane props
+	siteId: PropTypes.number,
+	postId: PropTypes.number,
+	message: PropTypes.string,
+};
+
+export default SharingPreviewModal;

--- a/client/my-sites/post-share/style.scss
+++ b/client/my-sites/post-share/style.scss
@@ -23,7 +23,7 @@
 		}
 	}
 
-	.post-share__form.is-placeholder, 
+	.post-share__form.is-placeholder,
 	.post-share__services.is-placeholder {
 		@include placeholder;
 		margin-top: 16px;
@@ -129,12 +129,57 @@
 		margin: 0;
 	}
 
-	.post-share__button{
-		width: 100%;
+}
 
-		@include breakpoint( ">480px" ) {
-			width: auto;
+.post-share__button-actions {
+	display: flex;
+	justify-content: flex-end;
+
+	@include breakpoint( "<480px" ) {
+		flex-wrap: wrap-reverse;
+	}
+
+	button {
+		width: auto;
+		margin: 0 0 0 5px;
+		@include breakpoint( "<480px" ) {
+			width: 100%;
+			margin: 0 0 5px 0;
 		}
 	}
 }
 
+.post-share__sharing-preview-modal {
+	padding: 0px;
+	@include breakpoint( ">960px" ) {
+		&.dialog.card {
+			position: absolute;
+		}
+
+		left: 25%;
+		right: 25%;
+		top: 25%;
+		width: 50%;
+		min-width: 500px;
+	}
+
+}
+
+.post-share__sharing-preview-modal-header {
+	height: 48px;
+	background: $white;
+	border-bottom: 1px solid lighten( $gray, 20% );
+	border-radius: 4px 4px 0;
+	display: flex;
+}
+
+.post-share__sharing-preview-modal-close {
+	border-right: 1px solid lighten( $gray, 20% );
+	width: 48px;
+	cursor: pointer;
+	color: $gray;
+
+	&:hover {
+		color: $gray-dark;
+	}
+}


### PR DESCRIPTION
This adds a preview modal to publicize and updates share action button styles.

**Action buttons**

`breakpoint > 480px`
![screen shot 2017-04-03 at 1 41 57 pm](https://cloud.githubusercontent.com/assets/744755/24630931/5cd66084-1873-11e7-86e4-8b41e1fedc70.png)


`breakpoint < 480px`
![action-buttons](https://cloud.githubusercontent.com/assets/744755/24630692/7b0d9726-1872-11e7-963d-5318cb8d9b52.png)


**Modal**
`breakpoint > 660px `

![screen shot 2017-03-30 at 1 28 36 pm](https://cloud.githubusercontent.com/assets/744755/24524978/6c5aee22-154d-11e7-9fc7-ca98db854baa.png)

`breakpoint < 660px`

![screen shot 2017-03-30 at 1 29 05 pm](https://cloud.githubusercontent.com/assets/744755/24525195/4b141efe-154e-11e7-8a0b-16ff038e3cf2.png)

**Note** 
At the moment we only have previews for Facebook and Twitter. #12644 adds the remaining available services.

**Testing**
- build with `ENABLE_FEATURES=publicize/preview make run`
- Open sharing option on a post from http://calypso.localhost:3000/posts/my/:site
- Edit customized message
- Click "Preview"
- The preview modal should open
- The preview should show the customized message
- Click the close modal button ( top left X )
- The preview modal should close