### PR TITLE
Updating the user display name to use System fonts

### DIFF
--- a/client/me/profile-gravatar/style.scss
+++ b/client/me/profile-gravatar/style.scss
@@ -106,7 +106,7 @@
 
 .profile-gravatar__user-display-name {
 	font-size: 24px;
-	font-weight: 700;
+	font-weight: 600;
 	line-height: 32px;
 	margin: 16px 0 0;
 	text-align: center;

--- a/client/me/profile-gravatar/style.scss
+++ b/client/me/profile-gravatar/style.scss
@@ -106,7 +106,6 @@
 
 .profile-gravatar__user-display-name {
 	font-size: 24px;
-	font-family: $serif;
 	font-weight: 700;
 	line-height: 32px;
 	margin: 16px 0 0;


### PR DESCRIPTION
I’ll be making this change here, and also in the front-end masterbar.

Though technically the name is content here (and would therefore use
Merriweather), it feels much more like UI in this context. This mirrors
the treatment in the mobile apps.

In addition, when this change is mirrored in the masterbar, it’ll allow
us to stop loading in Merriweather — Merriweather is currently only
used for this single instance in the masterbar.

Before:
<img width="272" alt="screen shot 2017-04-03 at 4 04 40 pm" src="https://cloud.githubusercontent.com/assets/1202812/24631871/a4de02b0-1887-11e7-9e3e-bedc756a8929.png">

After:
<img width="273" alt="screen shot 2017-04-03 at 4 04 03 pm" src="https://cloud.githubusercontent.com/assets/1202812/24631873/a8ec32f0-1887-11e7-866e-31d6726f70aa.png">
