### PR TITLE
Components: Update overflow on Section Header

### DIFF
--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -4,6 +4,7 @@
 	padding-top: 11px;
 	padding-bottom: 11px;
 	position: relative;
+	line-height: 28px;
 
 	&:after {
 		content: '';
@@ -14,9 +15,8 @@
 	display: flex;
 		align-items: center;
 	flex-grow: 1;
-	line-height: 28px;
 	position: relative;
-
+	overflow: hidden;
 
 	&:before {
 		@include long-content-fade( $color : $white );


### PR DESCRIPTION
This is a quick fix for #12747. It updates the overflow to `hidden` on the section header component to avoid long site titles overflowing the container. With long site titles on the Purchases page, there was also a small difference between the height of the site title and the URL. This bumps up the `line-height` declaration to `.section-header.card` so it's applied to both the site title and the site URL to fix the issue.

## To test
1. Load this branch.
2. Set a long title for a site. I used:
> This is a really long site title like really long because I have a lot to say and long titles are fun
3. Visit http://calypso.localhost:3000/me/purchases
4. Also spot check a few other places where `SectionHeader` is used to make sure there aren't any regressions like:
- http://calypso.localhost:3000/domains/manage/ (various spots like [this](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/upgrades/domain-management/edit/card/header/index.jsx#L31))
- http://calypso.localhost:3000/help (https://github.com/Automattic/wp-calypso/blob/master/client/me/help/help-results/index.jsx#L26)

## Screenshots
**Previous**
(The height difference between the URL is really small)
<img width="1048" alt="screen shot 2017-04-03 at 15 11 14" src="https://cloud.githubusercontent.com/assets/7240478/24632019/dd4adafe-187f-11e7-8ba9-98139c7f5994.png">

**After**
<img width="784" alt="screen shot 2017-04-03 at 15 12 08" src="https://cloud.githubusercontent.com/assets/7240478/24632040/f11867c2-187f-11e7-9660-588cd075793d.png">
