### PR TITLE
Stats: Fix Date Picker moment

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -165,7 +165,6 @@ module.exports = {
 		let chartTab;
 		let period;
 		let siteOffset = 0;
-		let momentSiteZone = i18n.moment();
 		let numPeriodAgo = 0;
 		const basePath = route.sectionify( context.path );
 		let baseAnalyticsPath;
@@ -191,12 +190,12 @@ module.exports = {
 			if ( currentSite && 'object' === typeof currentSite.options && 'undefined' !== typeof currentSite.options.gmt_offset ) {
 				siteOffset = currentSite.options.gmt_offset;
 			}
-			momentSiteZone = i18n.moment().utcOffset( siteOffset );
+			const momentSiteZone = i18n.moment().utcOffset( siteOffset );
 			if ( queryOptions.startDate && i18n.moment( queryOptions.startDate ).isValid ) {
 				date = i18n.moment( queryOptions.startDate ).locale( 'en' );
 				numPeriodAgo = getNumPeriodAgo( momentSiteZone, date, activeFilter.period );
 			} else {
-				date = rangeOfPeriod( activeFilter.period, momentSiteZone.clone().locale( 'en' ) ).startOf;
+				date = rangeOfPeriod( activeFilter.period, momentSiteZone.locale( 'en' ) ).startOf;
 			}
 
 			numPeriodAgo = parseInt( numPeriodAgo, 10 );

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -69,7 +69,10 @@ class StatsDatePicker extends Component {
 
 	dateForDisplay() {
 		const { date, moment, period, translate } = this.props;
-		const localizedDate = moment( date.format( 'YYYY-MM-DD' ) );
+
+		// Ensure we have a moment instance here to work with.
+		const momentDate = moment.isMoment( date ) ? date : moment( date );
+		const localizedDate = moment( momentDate.format( 'YYYY-MM-DD' ) );
 		let formattedDate;
 
 		switch ( period ) {

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -12,7 +12,6 @@ import { connect } from 'react-redux';
 import Tooltip from 'components/tooltip';
 import { getSiteStatsQueryDate } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getCurrentUserLocale } from 'state/current-user/selectors';
 import { isRequestingSiteStatsForQuery } from 'state/stats/lists/selectors';
 import { isAutoRefreshAllowedForQuery } from 'state/stats/lists/utils';
 
@@ -27,7 +26,6 @@ class StatsDatePicker extends Component {
 		query: PropTypes.object,
 		statType: PropTypes.string,
 		showQueryDate: PropTypes.bool,
-		userLocale: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -47,8 +45,8 @@ class StatsDatePicker extends Component {
 	};
 
 	dateForSummarize() {
-		const { query, moment, translate, userLocale } = this.props;
-		const localizedDate = moment().locale( userLocale );
+		const { query, moment, translate } = this.props;
+		const localizedDate = moment();
 
 		switch ( query.num ) {
 			case '-1':
@@ -70,8 +68,8 @@ class StatsDatePicker extends Component {
 	}
 
 	dateForDisplay() {
-		const { date, moment, period, translate, userLocale } = this.props;
-		const localizedDate = moment( date ).locale( userLocale );
+		const { date, moment, period, translate } = this.props;
+		const localizedDate = moment( date.format( 'YYYY-MM-DD' ) );
 		let formattedDate;
 
 		switch ( period ) {
@@ -178,7 +176,6 @@ const connectComponent = connect(
 	( state, { query, statsType, showQueryDate } ) => {
 		const siteId = getSelectedSiteId( state );
 		return {
-			userLocale: getCurrentUserLocale( state ),
 			queryDate: showQueryDate ? getSiteStatsQueryDate( state, siteId, statsType, query ) : null,
 			requesting: showQueryDate ? isRequestingSiteStatsForQuery( state, siteId, statsType, query ) : false,
 		};


### PR DESCRIPTION
This is a follow-up branch to #12437 - with an alternate, more appropriate fix to ensure dates are properly localized in `StatsDatePicker`

__To Test__
- Set your interface language to something other than English.
- Open a site stats page
- Verify the date in the "Stats for XXXXX" text is localized

/cc @stephanethomas 