### PR TITLE
Themes: Remove `themes-ssr` Feature Flag

### DIFF
--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -14,23 +14,15 @@ export default function( router ) {
 	const verticals = getSubjects().join( '|' );
 
 	if ( config.isEnabled( 'manage/themes' ) ) {
-		if ( config.isEnabled( 'manage/themes-ssr' ) ) {
-			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, fetchThemeData, loggedOut, makeLayout );
-			router(
-				`/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`,
-				fetchThemeData,
-				loggedOut,
-				makeLayout
-			);
-			router( '/design/upload/*', makeLayout );
-			// The following route definition is needed so direct hits on `/design/<mysite>` don't result in a 404.
-			router( '/design/*', fetchThemeData, loggedOut, makeLayout );
-		} else {
-			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, makeLayout );
-			router( `/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`, makeLayout );
-			router( '/design/upload/*', makeLayout );
-			// The following route definition is needed so direct hits on `/design/<mysite>` don't result in a 404.
-			router( '/design/*', makeLayout );
-		}
+		router( `/design/:vertical(${ verticals })?/:tier(free|premium)?`, fetchThemeData, loggedOut, makeLayout );
+		router(
+			`/design/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`,
+			fetchThemeData,
+			loggedOut,
+			makeLayout
+		);
+		router( '/design/upload/*', makeLayout );
+		// The following route definition is needed so direct hits on `/design/<mysite>` don't result in a 404.
+		router( '/design/*', fetchThemeData, loggedOut, makeLayout );
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -88,7 +88,6 @@
 		"manage/stats/podcasts": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,
-		"manage/themes-ssr": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,
 		"manage/themes/logged-out": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -53,7 +53,6 @@
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,
-		"manage/themes-ssr": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,
 		"manage/themes/logged-out": true,

--- a/config/production.json
+++ b/config/production.json
@@ -51,7 +51,6 @@
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,
-		"manage/themes-ssr": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,
 		"manage/themes/logged-out": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -53,7 +53,6 @@
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,
-		"manage/themes-ssr": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,
 		"manage/themes/logged-out": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -63,7 +63,6 @@
 		"manage/stats/podcasts": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,
-		"manage/themes-ssr": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,
 		"manage/themes/logged-out": true,


### PR DESCRIPTION
It has been active in all environments (except desktop) for a while. Since the duplicated routes in `my-sites/themes/index.node.js` would be annoying when we change the Theme Showcase's URL from `/design` to `/themes`, I'm removing it now. Note that this means the feature will be implicitly turned on in desktop.

To test:
Check that the showcase still works and continues to be server-side rendered (while logged-out).