### PR TITLE
Sharing: Remove redirection behaviour when sharing module is inactive in Jetpack sites

### DIFF
--- a/client/my-sites/sharing/buttons/appearance.jsx
+++ b/client/my-sites/sharing/buttons/appearance.jsx
@@ -90,7 +90,7 @@ class SharingButtonsAppearance extends Component {
 						type="checkbox"
 						checked={ this.isReblogButtonEnabled() }
 						onChange={ this.onReblogsLikesCheckboxClicked }
-						disabled={ ! this.props.initialized }
+						disabled={ this.props.saving }
 					/>
 					<span>{ this.props.translate( 'Show reblog button', { context: 'Sharing options: Checkbox label' } ) }</span>
 				</label>
@@ -99,26 +99,24 @@ class SharingButtonsAppearance extends Component {
 	}
 
 	getReblogLikeOptionsElement() {
-		if ( ( ! this.props.isJetpack || this.props.isLikesModuleActive ) ) {
-			return (
-				<fieldset className="sharing-buttons__fieldset">
-					<legend className="sharing-buttons__fieldset-heading">
-						{ this.props.translate( 'Reblog & Like', { context: 'Sharing options: Header' } ) }
-					</legend>
-					{ this.getReblogOptionElement() }
-					<label>
-						<input
-							name="disabled_likes"
-							type="checkbox"
-							checked={ this.isLikeButtonEnabled() }
-							onChange={ this.onReblogsLikesCheckboxClicked }
-							disabled={ ! this.props.initialized }
-						/>
-						<span>{ this.props.translate( 'Show like button', { context: 'Sharing options: Checkbox label' } ) }</span>
-					</label>
-				</fieldset>
-			);
-		}
+		return (
+			<fieldset className="sharing-buttons__fieldset">
+				<legend className="sharing-buttons__fieldset-heading">
+					{ this.props.translate( 'Reblog & Like', { context: 'Sharing options: Header' } ) }
+				</legend>
+				{ this.getReblogOptionElement() }
+				<label>
+					<input
+						name="disabled_likes"
+						type="checkbox"
+						checked={ this.isLikeButtonEnabled() }
+						onChange={ this.onReblogsLikesCheckboxClicked }
+						disabled={ this.props.saving }
+					/>
+					<span>{ this.props.translate( 'Show like button', { context: 'Sharing options: Checkbox label' } ) }</span>
+				</label>
+			</fieldset>
+		);
 	}
 
 	render() {
@@ -137,7 +135,7 @@ class SharingButtonsAppearance extends Component {
 					<ButtonsStyle
 						onChange={ changeButtonStyle }
 						value={ this.props.values.sharing_button_style }
-						disabled={ ! this.props.initialized }
+						disabled={ this.props.saving }
 					/>
 					{ this.getReblogLikeOptionsElement() }
 				</div>
@@ -145,7 +143,7 @@ class SharingButtonsAppearance extends Component {
 				<button
 					type="submit"
 					className="button is-primary sharing-buttons__submit"
-					disabled={ this.props.saving || ! this.props.initialized }
+					disabled={ this.props.saving }
 				>
 					{ this.props.saving ? this.props.translate( 'Saving…' ) : this.props.translate( 'Save Changes' ) }
 				</button>

--- a/client/my-sites/sharing/buttons/buttons.jsx
+++ b/client/my-sites/sharing/buttons/buttons.jsx
@@ -18,9 +18,12 @@ import { saveSharingButtons } from 'state/sites/sharing-buttons/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSettings, isSavingSiteSettings, isSiteSettingsSaveSuccessful } from 'state/site-settings/selectors';
 import { getSharingButtons, isSavingSharingButtons, isSharingButtonsSaveSuccessful } from 'state/selectors';
+import { isJetpackModuleActive, isJetpackSite } from 'state/sites/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
+import { activateModule } from 'state/jetpack/modules/actions';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import { protectForm } from 'lib/protect-form';
+import DEFAULT_BUTTONS from './default-buttons';
 
 class SharingButtons extends Component {
 	state = {
@@ -40,12 +43,33 @@ class SharingButtons extends Component {
 		translate: PropTypes.func,
 	};
 
+	activateSharingIfNeeded = () => {
+		if ( ! this.props.isJetpackSite || this.props.isShareDaddyModuleActive ) {
+			return Promise.resolve( true );
+		}
+		return this.props.activateModule( this.props.siteId, 'sharedaddy', true );
+	}
+
+	activateLikesIfNeeded = () => {
+		if ( ! this.props.isJetpackSite || this.props.isLikesModuleActive ) {
+			return Promise.resolve( true );
+		}
+		if ( ! this.isLikeButtonEnabled() ) {
+			return this.props.activateModule( this.props.siteId, 'likes', true );
+		}
+	}
+
 	saveChanges = event => {
 		event.preventDefault();
-		this.props.saveSiteSettings( this.props.siteId, this.state.values );
-		if ( this.state.buttonsPendingSave ) {
-			this.props.saveSharingButtons( this.props.siteId, this.state.buttonsPendingSave );
-		}
+
+		this.activateSharingIfNeeded()
+			.then( this.activateLikesIfNeeded )
+			.then( () => {
+				this.props.saveSiteSettings( this.props.siteId, this.state.values );
+				if ( this.state.buttonsPendingSave ) {
+					this.props.saveSharingButtons( this.props.siteId, this.state.buttonsPendingSave );
+				}
+			} );
 		this.props.recordGoogleEvent( 'Sharing', 'Clicked Save Changes Button' );
 	};
 
@@ -86,10 +110,14 @@ class SharingButtons extends Component {
 		}
 	}
 
+	isLikeButtonEnabled() {
+		return '' === this.state.values.disabled_likes || false === this.state.values.disabled_likes;
+	}
+
 	render() {
 		const { buttons, isSaving, settings, siteId } = this.props;
 		const updatedSettings = Object.assign( {}, settings, this.state.values );
-		const updatedButtons = this.state.buttonsPendingSave || buttons;
+		const updatedButtons = this.state.buttonsPendingSave || buttons || DEFAULT_BUTTONS;
 
 		return (
 			<form onSubmit={ this.saveChanges } id="sharing-buttons" className="sharing-settings sharing-buttons">
@@ -116,6 +144,9 @@ const connectComponent = connect(
 		const siteId = getSelectedSiteId( state );
 		const settings = getSiteSettings( state, siteId );
 		const buttons = getSharingButtons( state, siteId );
+		const isJetpack = isJetpackSite( state, siteId );
+		const isLikesModuleActive = isJetpack && isJetpackModuleActive( state, siteId, 'likes' );
+		const isShareDaddyModuleActive = isJetpack && isJetpackModuleActive( state, siteId, 'sharedaddy' );
 		const isSavingSettings = isSavingSiteSettings( state, siteId );
 		const isSavingButtons = isSavingSharingButtons( state, siteId );
 		const isSaveSettingsSuccessful = isSiteSettingsSaveSuccessful( state, siteId );
@@ -125,12 +156,15 @@ const connectComponent = connect(
 			isSaving: isSavingSettings || isSavingButtons,
 			isSaveSettingsSuccessful,
 			isSaveButtonsSuccessful,
+			isJetpackSite: isJetpack,
+			isLikesModuleActive,
+			isShareDaddyModuleActive,
 			settings,
-			buttons,
+			buttons: buttons,
 			siteId
 		};
 	},
-	{ errorNotice, recordGoogleEvent, saveSiteSettings, saveSharingButtons, successNotice }
+	{ errorNotice, activateModule, recordGoogleEvent, saveSiteSettings, saveSharingButtons, successNotice }
 );
 
 export default flowRight(

--- a/client/my-sites/sharing/buttons/default-buttons.js
+++ b/client/my-sites/sharing/buttons/default-buttons.js
@@ -1,0 +1,82 @@
+export default [ {
+	ID: 'twitter',
+	name: 'Twitter',
+	shortname: 'twitter',
+	custom: false,
+	enabled: false,
+	visibility: 'visible'
+}, {
+	ID: 'facebook',
+	name: 'Facebook',
+	shortname: 'facebook',
+	custom: false,
+	enabled: false,
+	visibility: 'visible'
+}, {
+	ID: 'google-plus-1',
+	name: 'Google',
+	shortname: 'googleplus1',
+	custom: false,
+	enabled: false,
+	visibility: 'visible'
+}, {
+	ID: 'email',
+	name: 'Email',
+	shortname: 'email',
+	custom: false,
+	enabled: false
+}, {
+	ID: 'print',
+	name: 'Print',
+	shortname: 'print',
+	custom: false,
+	enabled: false
+}, {
+	ID: 'linkedin',
+	name: 'LinkedIn',
+	shortname: 'linkedin',
+	custom: false,
+	enabled: false
+}, {
+	ID: 'reddit',
+	name: 'Reddit',
+	shortname: 'reddit',
+	custom: false,
+	enabled: false
+}, {
+	ID: 'tumblr',
+	name: 'Tumblr',
+	shortname: 'tumblr',
+	custom: false,
+	enabled: false
+}, {
+	ID: 'pinterest',
+	name: 'Pinterest',
+	shortname: 'pinterest',
+	custom: false,
+	enabled: false
+}, {
+	ID: 'pocket',
+	name: 'Pocket',
+	shortname: 'pocket',
+	custom: false,
+	enabled: false
+}, {
+	ID: 'telegram',
+	name: 'Telegram',
+	shortname: 'telegram',
+	custom: false,
+	enabled: false
+}, {
+	ID: 'jetpack-whatsapp',
+	name: 'WhatsApp',
+	shortname: 'jetpack-whatsapp',
+	custom: false,
+	enabled: false
+}, {
+	ID: 'skype',
+	name: 'Skype',
+	shortname: 'skype',
+	custom: false,
+	enabled: false
+} ];

--- a/client/my-sites/sharing/buttons/preview-buttons.jsx
+++ b/client/my-sites/sharing/buttons/preview-buttons.jsx
@@ -179,10 +179,20 @@ var SharingButtonsPreviewButtons = module.exports = React.createClass( {
 		return <ResizableIframe ref="iframe" src={ previewUrl } width="100%" frameBorder="0" className="official-preview" />;
 	},
 
+	handleButtonClick: function( button ) {
+		return () => this.props.onButtonClick( button );
+	},
+
 	getCustomPreviewElement: function() {
-		var buttons = this.props.buttons.map( function( button ) {
-			return <ButtonsPreviewButton key={ button.ID } button={ button } enabled={ button.visibility === this.props.visibility } style={ this.props.style } onClick={ this.props.onButtonClick.bind( null, button ) } />;
-		}, this );
+		const buttons = this.props.buttons &&
+			this.props.buttons.map( ( button ) => {
+				return <ButtonsPreviewButton
+					key={ button.ID }
+					button={ button }
+					enabled={ button.visibility === this.props.visibility }
+					style={ this.props.style }
+					onClick={ this.handleButtonClick( button ) } />;
+			} );
 
 		if ( this.props.showMore ) {
 			buttons.push(

--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -67,10 +67,6 @@ export const buttons = ( context, next ) => {
 		notices.error( translate( 'You are not authorized to manage sharing settings for this site.' ) );
 	}
 
-	if ( site && site.jetpack && ( ! site.isModuleActive( 'sharedaddy' ) || site.versionCompare( '3.4-dev', '<' ) ) ) {
-		notices.error( translate( 'This page is only available to Jetpack sites running version 3.4 or higher with the Sharing module activated.' ) );
-	}
-
 	context.contentComponent = createElement( SharingButtons );
 
 	next();

--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -2,7 +2,6 @@
  * External Dependencies
  */
 import { createElement } from 'react';
-import page from 'page';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -43,15 +42,8 @@ export const connections = ( context, next ) => {
 		notices.error( translate( 'You are not authorized to manage sharing settings for this site.' ) );
 	}
 
-	if ( site && site.jetpack && ! site.isModuleActive( 'publicize' ) ) {
-		// Redirect to sharing buttons if Jetpack Publicize module is not
-		// active, but ShareDaddy is active
-		page.redirect( site.isModuleActive( 'sharedaddy' ) ? '/sharing/buttons/' + sites.selected : '/stats' );
-	} else {
-		pageView.record( baseAnalyticsPath, analyticsPageTitle + ' > Connections' );
-
-		context.contentComponent = createElement( SharingConnections );
-	}
+	pageView.record( baseAnalyticsPath, analyticsPageTitle + ' > Connections' );
+	context.contentComponent = createElement( SharingConnections );
 
 	next();
 };

--- a/client/my-sites/sharing/index.js
+++ b/client/my-sites/sharing/index.js
@@ -6,11 +6,11 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { jetpackModuleActive, navigation, sites, siteSelection } from 'my-sites/controller';
+import { navigation, sites, siteSelection } from 'my-sites/controller';
 import { buttons, connections, layout } from './controller';
 
 export default function() {
 	page( /^\/sharing(\/buttons)?$/, siteSelection, sites );
-	page( '/sharing/:domain', siteSelection, navigation, jetpackModuleActive( 'publicize', false ), connections, layout );
+	page( '/sharing/:domain', siteSelection, navigation, connections, layout );
 	page( '/sharing/buttons/:domain', siteSelection, navigation, buttons, layout );
 }

--- a/client/my-sites/sharing/index.js
+++ b/client/my-sites/sharing/index.js
@@ -12,5 +12,5 @@ import { buttons, connections, layout } from './controller';
 export default function() {
 	page( /^\/sharing(\/buttons)?$/, siteSelection, sites );
 	page( '/sharing/:domain', siteSelection, navigation, jetpackModuleActive( 'publicize', false ), connections, layout );
-	page( '/sharing/buttons/:domain', siteSelection, navigation, jetpackModuleActive( 'sharedaddy' ), buttons, layout );
+	page( '/sharing/buttons/:domain', siteSelection, navigation, buttons, layout );
 }

--- a/client/my-sites/sharing/main.jsx
+++ b/client/my-sites/sharing/main.jsx
@@ -13,7 +13,6 @@ import { canCurrentUser, isJetpackModuleActive } from 'state/selectors';
 import DocumentHead from 'components/data/document-head';
 import {
 	getSiteSlug,
-	isJetpackMinimumVersion,
 	isJetpackSite,
 } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -102,10 +101,9 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const isJetpack = isJetpackSite( state, siteId );
 		const canManageOptions = canCurrentUser( state, siteId, 'manage_options' );
-		const hasSharedaddy = isJetpackModuleActive( state, siteId, 'sharedaddy' ) && isJetpackMinimumVersion( state, siteId, '3.4-dev' );
 
 		return {
-			showButtons: siteId && canManageOptions && ( ! isJetpack || hasSharedaddy ),
+			showButtons: siteId && canManageOptions,
 			showConnections: ! siteId || ! isJetpack || isJetpackModuleActive( state, siteId, 'publicize' ),
 			siteId,
 			siteSlug: getSiteSlug( state, siteId ),

--- a/client/my-sites/sharing/main.jsx
+++ b/client/my-sites/sharing/main.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { canCurrentUser, isJetpackModuleActive } from 'state/selectors';
+import { canCurrentUser } from 'state/selectors';
 import DocumentHead from 'components/data/document-head';
 import {
 	getSiteSlug,
@@ -104,7 +104,7 @@ export default connect(
 
 		return {
 			showButtons: siteId && canManageOptions,
-			showConnections: ! siteId || ! isJetpack || isJetpackModuleActive( state, siteId, 'publicize' ),
+			showConnections: siteId && isJetpack,
 			siteId,
 			siteSlug: getSiteSlug( state, siteId ),
 		};


### PR DESCRIPTION
Addresses  Automattic/Jetpack#6837 and Automattic/Jetpack#6762

#### Changes introduced by this PR

* Removes the redirection from `/sharing` to `/stats` that happened when the ShareDaddy module was inactive on Jetpack sites.
* Offers an UI that will active Sharing and Likes modules on the site if needed and are currently inactive. Likes will be activated if the "Show LIke Button" option is set. 
* Introduces hardcoded values for Sharing Buttons (`my-sites/sharing/default-butons.js`. These usually come from the API **only if** the module is active, because otherwise the API replies with an error. So, the values are hardcoded here to handle sites that have this module deactivated. 

#### Concerns about this PR

* Error handling when module activation fails is not good currently.
* Showing the Default buttons is some opinionated way of handling the missing API endpoint for sites with Sharedaddy deactivated
* If the users deactivates Sharedaddy while still in Calypso, the settings fields will be overriden by the SITES_RECEIVE action dispatched from sites polling. 


#### Testing instructions..

* Ensure buttons are properly shown when:
  * Sharing has never been configured on the site..
  * Site has ShareDaddy deactivated.
  * Site has ShareDaddy deactivated and Likes deactivated.
  * Site has ShareDaddy active but Likes active.


#### Why

It was decided to go without magic redirections and present the user with an UI even when the modules are deactivated. The idea is to let them configure and save without them having to worry about modules state.

#### Screenshots

**What's shown on a site with Likes and Sharedaddy deactivated**

![image](https://cloud.githubusercontent.com/assets/746152/24654035/8cc32b1a-190e-11e7-90d6-9224bc7e2475.png)

**How saving behaves** (Dispatches two Jetpack module activation actinons)

![sharing](https://cloud.githubusercontent.com/assets/746152/24654261/4d363d9c-190f-11e7-933a-11437847f078.gif)


