### PR TITLE
Stats: Use Object Destructuring to Simplify lists.items Reducer

### DIFF
--- a/client/state/stats/lists/reducer.js
+++ b/client/state/stats/lists/reducer.js
@@ -75,11 +75,11 @@ export function items( state = {}, action ) {
 
 			return {
 				...state,
-				[ action.siteId ]: {
+				[ action.siteId ]: merge( {}, state[ action.siteId ], {
 					[ action.statType ]: {
 						[ queryKey ]: action.data
 					}
-				}
+				} )
 			};
 
 		case DESERIALIZE:

--- a/client/state/stats/lists/reducer.js
+++ b/client/state/stats/lists/reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import { merge, unset } from 'lodash';
+import { merge } from 'lodash';
 
 /**
  * Internal dependencies
@@ -73,17 +73,14 @@ export function items( state = {}, action ) {
 		case SITE_STATS_RECEIVE:
 			const queryKey = getSerializedStatsQuery( action.query );
 
-			// To avoid corrupted stat data with massive arrays
-			// From causing _.merge to crash, first clone, then unset existing data
-			const existingItems = Object.assign( {}, state );
-			unset( existingItems, [ action.siteId, action.statType, queryKey ] );
-			return merge( {}, existingItems, {
+			return {
+				...state,
 				[ action.siteId ]: {
 					[ action.statType ]: {
 						[ queryKey ]: action.data
 					}
 				}
-			} );
+			};
 
 		case DESERIALIZE:
 			if ( isValidStateWithSchema( state, itemSchema ) ) {


### PR DESCRIPTION
Instead of using `merge` on all existing items, this PR merges only at `siteId` level. This should preserve object references of unmodified items for better performance when updating based on changed Redux state.

As per Slack discussion with @edo-ran 

@timmyc @youknowriad Any particular reason you folks were using `merge` instead of destructuring or `Object.assign`? The comment I deleted indicates there has been trouble with `merge` in the past 😄 