### PR TITLE
Themes: Add Redirects for old Showcase Routes

### DIFF
--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { compact, isEmpty, startsWith } from 'lodash';
+import { compact, includes, isEmpty, startsWith } from 'lodash';
 import debugFactory from 'debug';
 import Lru from 'lru';
 import React from 'react';
@@ -136,4 +136,37 @@ export function fetchThemeData( context, next ) {
 			next();
 		} )
 		.catch( () => next() );
+}
+
+// Legacy (Atlas-based Theme Showcase v4) route redirects
+
+export function redirectSearchAndType( { res, params: { site, search, tier } } ) {
+	const target = '/design/' + compact( [ tier, site ] ).join( '/' ); // tier before site!
+	if ( search ) {
+		res.redirect( `${ target }?s=${ search }` );
+	} else {
+		res.redirect( target );
+	}
+}
+
+export function redirectFilterAndType( { res, params: { site, filter, tier } } ) {
+	let parts;
+	if ( filter ) {
+		parts = [ tier, 'filter', filter.replace( '+', ',' ), site ]; // The Atlas Showcase used plusses, we use commas
+	} else {
+		parts = [ tier, site ];
+	}
+	res.redirect( '/design/' + compact( parts ).join( '/' ) );
+}
+
+export function redirectToThemeDetails( { res, params: { site, theme, section } }, next ) {
+	// Make sure we aren't matching a site -- e.g. /design/example.wordpress.com or /design/1234567
+	if ( includes( theme, '.' ) || isFinite( theme ) ) {
+		return next();
+	}
+	let redirectedSection;
+	if ( section === 'support' ) {
+		redirectedSection = 'setup';
+	}
+	res.redirect( '/theme/' + compact( [ theme, redirectedSection, site ] ).join( '/' ) );
 }

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -4,7 +4,13 @@
 import config from 'config';
 import { makeLayout } from 'controller';
 import { getSubjects } from './theme-filters.js';
-import { fetchThemeData, loggedOut } from './controller';
+import {
+	fetchThemeData,
+	loggedOut,
+	redirectSearchAndType,
+	redirectFilterAndType,
+	redirectToThemeDetails
+} from './controller';
 
 // `logged-out` middleware isn't SSR-compliant yet, but we can at least render
 // the layout.
@@ -22,6 +28,17 @@ export default function( router ) {
 			makeLayout
 		);
 		router( '/design/upload/*', makeLayout );
+		// Redirect legacy (Atlas-based Theme Showcase v4) routes
+		router( [
+			'/design/:site?/search/:search',
+			'/design/:site?/type/:tier(free|premium)',
+			'/design/:site?/search/:search/type/:tier(free|premium)'
+		], redirectSearchAndType );
+		router( [
+			'/design/:site?/filter/:filter',
+			'/design/:site?/filter/:filter/type/:tier(free|premium)'
+		], redirectFilterAndType );
+		router( '/design/:site?/:theme/:section(support)?', redirectToThemeDetails );
 		// The following route definition is needed so direct hits on `/design/<mysite>` don't result in a 404.
 		router( '/design/*', fetchThemeData, loggedOut, makeLayout );
 	}

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -20,7 +20,7 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 
 function combineMiddlewares( ...middlewares ) {
 	return function( req, res, next ) {
-		req.context = getEnhancedContext( req );
+		req.context = getEnhancedContext( req, res );
 		applyMiddlewares( req.context, ...middlewares, () => {
 			next();
 		} );
@@ -28,14 +28,15 @@ function combineMiddlewares( ...middlewares ) {
 }
 
 // TODO: Maybe merge into getDefaultContext().
-function getEnhancedContext( req ) {
+function getEnhancedContext( req, res ) {
 	return Object.assign( {}, req.context, {
 		isLoggedIn: req.cookies.wordpress_logged_in,
 		isServerSide: true,
 		path: req.url,
 		pathname: req.path,
 		params: req.params,
-		query: req.query
+		query: req.query,
+		res
 	} );
 }
 


### PR DESCRIPTION
As per discussion at pMz3w-6Q7-p2.

To test: Land on the following routes:
* `/themes/<yoursite>/search/twenty/type/free/` should redirect to `/design/free/<yoursite>?s=twenty`. Also try with only `search` or `type`.
* `/themes/<yoursite>/filter/two-columns+blue/type/premium/` should redirect to `/design/premium/<yoursite>/filter/blue,two-columns`. Also try without `yoursite` and/or `type/premium`.
* `/themes/<yoursite>/mood/support/` should redirect to `/theme/mood/setup/<yoursite>`. Also try without `<yoursite>` and `/support`.
* Verify that these redirects don't get in the way of existing routes -- those should still work as before!

Also, keep in mind that these are only the route patterns I was able to reproduce for the Atlas-based showcase. Don't trust me 😄 Instead, fire up `wordpress.com/themes` and play with the verticals and the input form (under the '... More' button) to create different route patterns, and verify that I didn't miss any. (You can copy the relevant part of the URL over and try with this PR.)