### PR TITLE
Reader: remove extra width on combined-card

### DIFF
--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -92,6 +92,7 @@
 .reader-combined-card__post-list {
 	margin-left: 0;
 	margin-bottom: 18px;
+	width: 100%;
 }
 
 .reader-combined-card__post {
@@ -236,7 +237,6 @@
 	margin: 0 15px;
 	padding: 18px 0 0;
 	position: relative;
-	width: 100%;
 
 	@include breakpoint( ">660px" ) {
 		margin: 0;


### PR DESCRIPTION
This PR fixes #12651 by removing the extra width on combined cards by bringing back the right margin.

**After:**

<img width="675" alt="screen shot 2017-04-04 at 10 20 49 pm" src="https://cloud.githubusercontent.com/assets/2627210/24656350/860b76ca-1985-11e7-9203-1d9942e231b3.png">