### PR TITLE
Site Settings: Complete the PHP Date to Moment.js datetime formats mapping

### DIFF
--- a/client/lib/formatting/index.js
+++ b/client/lib/formatting/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { keys, trim } from 'lodash';
+import { trim } from 'lodash';
 import stripTags from 'striptags';
 
 /**
@@ -324,87 +324,6 @@ function unescapeAndFormatSpaces( str ) {
 	return decodeEntities( str ).replace( / /g, nbsp );
 }
 
-/**
- * Mapping object between PHP date() and Moment.js format() tokens.
- * The commented tokens exist in PHP but have no direct Moment.js equivalent.
- *
- * The "S" case is an exception, since it's only used in conjunction with "j":
- * PHP `date( 'jS' )` returns "1st", which is equivalent to `moment().format( 'Do' )`)
- *
- * @see http://php.net/manual/en/function.date.php#refsect1-function.date-parameters
- * @see http://momentjs.com/docs/#/displaying/format/
- *
- * @type {Object}
- */
-const phpToMomentMapping = {
-	// Days
-	d: 'DD',
-	D: 'ddd',
-	jS: 'Do',
-	j: 'D',
-	l: 'dddd',
-	N: 'E',
-	// See "jS"
-	//S: '',
-	w: 'd',
-	z: 'DDD',
-	// Week
-	W: 'W',
-	// Month
-	F: 'MMMM',
-	m: 'MM',
-	M: 'MMM',
-	n: 'M',
-	// Moment.js has no "t" token equivalent, but a `moment().daysInMonth()` function
-	//t: '',
-	// Year
-	// Moment.js has no "L" token equivalent, but a `moment().isLeapYear()` function
-	//L: '',
-	o: 'Y',
-	Y: 'YYYY',
-	y: 'YY',
-	// Time
-	a: 'a',
-	A: 'A',
-	// Moment.js has no "B" token equivalent
-	//B: '',
-	g: 'h',
-	G: 'H',
-	h: 'hh',
-	H: 'HH',
-	i: 'mm',
-	s: 'ss',
-	u: 'SSSSSS',
-	v: 'SSS',
-	// Timezone
-	e: 'z',
-	// Moment.js has no "I" token, but a `moment().isDST()` function
-	//I: '',
-	O: 'ZZ',
-	P: 'Z',
-	// Moment.js has no "T" token equivalent
-	//T: '',
-	// Moment.js has no "Z" token equivalent
-	//Z: '',
-	// Full Date/Time
-	c: 'YYYY-MM-DDTHH:mm-ssZ',
-	r: 'ddd, DD MMM YYYY HH:mm:ss ZZ',
-	U: 'X',
-};
-
-/**
- * Convert a PHP datetime format string into a Moment.js one.
- *
- * @param  {String} str PHP datetime format string
- * @return {String} Moment.js datetime format string
- */
-function phpToMomentDatetimeFormat( str ) {
-	return str.replace(
-		new RegExp( keys( phpToMomentMapping ).join( '|' ), 'g' ),
-		match => phpToMomentMapping[ match ],
-	);
-}
-
 module.exports = {
 	decodeEntities: decodeEntities,
 	interpose: interpose,
@@ -415,5 +334,4 @@ module.exports = {
 	capitalPDangit: capitalPDangit,
 	parseHtml: parseHtml,
 	unescapeAndFormatSpaces: unescapeAndFormatSpaces,
-	phpToMomentDatetimeFormat,
 };

--- a/client/lib/formatting/test/index.js
+++ b/client/lib/formatting/test/index.js
@@ -10,7 +10,7 @@ import useFakeDom from 'test/helpers/use-fake-dom';
 import decodeEntitiesNode from '../decode-entities/node';
 
 describe( 'formatting', () => {
-	let formatting, capitalPDangit, parseHtml, decodeEntitiesBrowser, preventWidows, phpToMomentDatetimeFormat;
+	let formatting, capitalPDangit, parseHtml, decodeEntitiesBrowser, preventWidows;
 
 	useFakeDom();
 
@@ -20,7 +20,6 @@ describe( 'formatting', () => {
 		parseHtml = formatting.parseHtml;
 		decodeEntitiesBrowser = require( '../decode-entities/browser' );
 		preventWidows = formatting.preventWidows;
-		phpToMomentDatetimeFormat = formatting.phpToMomentDatetimeFormat;
 	} );
 
 	describe( '#capitalPDangit()', function() {
@@ -176,21 +175,6 @@ describe( 'formatting', () => {
 				preventWidows( input, 4 ),
 				'I really love BBQ. It is one of my favorite foods. Beef\xA0ribs\xA0are\xA0amazing.'
 			);
-		} );
-	} );
-
-	describe( '#phpToMomentDatetimeFormat()', () => {
-		it( 'should return the correct Moment date', function() {
-			chai.assert.equal( phpToMomentDatetimeFormat( 'F j, Y' ), 'MMMM D, YYYY' );
-			chai.assert.equal( phpToMomentDatetimeFormat( 'Y-m-d' ), 'YYYY-MM-DD' );
-			chai.assert.equal( phpToMomentDatetimeFormat( 'm/d/Y' ), 'MM/DD/YYYY' );
-			chai.assert.equal( phpToMomentDatetimeFormat( 'd/m/Y' ), 'DD/MM/YYYY' );
-		} );
-
-		it( 'should return the correct Moment time', function() {
-			chai.assert.equal( phpToMomentDatetimeFormat( 'g:i a' ), 'h:mm a' );
-			chai.assert.equal( phpToMomentDatetimeFormat( 'g:i A' ), 'h:mm A' );
-			chai.assert.equal( phpToMomentDatetimeFormat( 'H:i' ), 'HH:mm' );
 		} );
 	} );
 } );

--- a/client/my-sites/site-settings/date-time-format/date-format-option.jsx
+++ b/client/my-sites/site-settings/date-time-format/date-format-option.jsx
@@ -12,8 +12,8 @@ import FormInput from 'components/forms/form-text-input';
 import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import { phpToMomentDatetimeFormat } from 'lib/formatting';
 import { defaultDateFormats } from './default-formats';
+import { phpToMomentDatetimeFormat } from './utils';
 
 export const DateFormatOption = ( {
 	dateFormat,
@@ -37,7 +37,7 @@ export const DateFormatOption = ( {
 					onChange={ setDateFormat }
 					value={ format }
 				/>
-				<span>{ localizedDate.format( phpToMomentDatetimeFormat( format ) ) }</span>
+				<span>{ phpToMomentDatetimeFormat( localizedDate, format ) }</span>
 			</FormLabel>
 		) }
 		<FormLabel className="date-time-format__custom-field">
@@ -60,7 +60,7 @@ export const DateFormatOption = ( {
 				<FormSettingExplanation>
 					{ isCustom && dateFormat &&
 						translate( 'Preview: %s', {
-							args: localizedDate.format( phpToMomentDatetimeFormat( dateFormat ) ),
+							args: phpToMomentDatetimeFormat( localizedDate, dateFormat ),
 							comment: 'Date/time format preview',
 						} )
 					}

--- a/client/my-sites/site-settings/date-time-format/test/index.js
+++ b/client/my-sites/site-settings/date-time-format/test/index.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import chai from 'chai';
+import { moment } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { phpToMomentDatetimeFormat } from '../utils';
+
+describe( 'phpToMomentDatetimeFormat', () => {
+	const testDate = moment();
+	it( 'should return the correct Moment date', function() {
+		chai.assert.equal( phpToMomentDatetimeFormat( testDate, 'F j, Y' ), testDate.format( 'MMMM D, YYYY' ) );
+		chai.assert.equal( phpToMomentDatetimeFormat( testDate, 'Y-m-d' ), testDate.format( 'YYYY-MM-DD' ) );
+		chai.assert.equal( phpToMomentDatetimeFormat( testDate, 'm/d/Y' ), testDate.format( 'MM/DD/YYYY' ) );
+		chai.assert.equal( phpToMomentDatetimeFormat( testDate, 'd/m/Y' ), testDate.format( 'DD/MM/YYYY' ) );
+	} );
+
+	it( 'should return the correct Moment time', function() {
+		chai.assert.equal( phpToMomentDatetimeFormat( testDate, 'g:i a' ), testDate.format( 'h:mm a' ) );
+		chai.assert.equal( phpToMomentDatetimeFormat( testDate, 'g:i A' ), testDate.format( 'h:mm A' ) );
+		chai.assert.equal( phpToMomentDatetimeFormat( testDate, 'H:i' ), testDate.format( 'HH:mm' ) );
+	} );
+} );

--- a/client/my-sites/site-settings/date-time-format/time-format-option.jsx
+++ b/client/my-sites/site-settings/date-time-format/time-format-option.jsx
@@ -13,8 +13,8 @@ import FormInput from 'components/forms/form-text-input';
 import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import { phpToMomentDatetimeFormat } from 'lib/formatting';
 import { defaultTimeFormats } from './default-formats';
+import { phpToMomentDatetimeFormat } from './utils';
 
 export const TimeFormatOption = ( {
 	disabled,
@@ -38,7 +38,7 @@ export const TimeFormatOption = ( {
 					onChange={ setTimeFormat }
 					value={ format }
 				/>
-				<span>{ localizedDate.format( phpToMomentDatetimeFormat( format ) ) }</span>
+				<span>{ phpToMomentDatetimeFormat( localizedDate, format ) }</span>
 			</FormLabel>
 		) }
 		<FormLabel className="date-time-format__custom-field">
@@ -61,7 +61,7 @@ export const TimeFormatOption = ( {
 				<FormSettingExplanation>
 					{ isCustom && timeFormat &&
 						translate( 'Preview: %s', {
-							args: localizedDate.format( phpToMomentDatetimeFormat( timeFormat ) ),
+							args: phpToMomentDatetimeFormat( localizedDate, timeFormat ),
 							comment: 'Date/time format preview'
 						} )
 					}

--- a/client/my-sites/site-settings/date-time-format/utils.js
+++ b/client/my-sites/site-settings/date-time-format/utils.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { moment } from 'i18n-calypso';
-import { startsWith } from 'lodash';
+import { has, startsWith } from 'lodash';
 
 /**
  * Adjust the current date and time to the site settings timezone.
@@ -21,4 +21,133 @@ export function getLocalizedDate( timezoneString ) {
 	return startsWith( timezoneString, 'UTC' )
 		? moment().utcOffset( timezoneString.substring( 3 ) * 60 ) // E.g. "UTC+5" -> "+5" * 60 -> 300
 		: moment.tz( timezoneString );
+}
+
+/**
+ * Mapping object between PHP date() and Moment.js format() tokens.
+ * The commented tokens exist in PHP but have no direct Moment.js equivalent.
+ *
+ * The "S" case is an exception, since it's only used in conjunction with "j":
+ * PHP `date( 'jS' )` returns "1st", which is equivalent to `moment().format( 'Do' )`)
+ *
+ * @see http://php.net/manual/en/function.date.php#refsect1-function.date-parameters
+ * @see http://momentjs.com/docs/#/displaying/format/
+ *
+ * @type {Object}
+ */
+const phpToMomentMapping = {
+	d: 'DD',
+	D: 'ddd',
+	jS: 'Do',
+	j: 'D',
+	l: 'dddd',
+	N: 'E',
+	// See "jS"
+	//S: '',
+	w: 'd',
+	// Moment.js equivalent of 'z' (0 based) is 'DDD' (1 based), so it must be adjusted
+	//z: 'DDD',
+	W: 'W',
+	F: 'MMMM',
+	m: 'MM',
+	M: 'MMM',
+	n: 'M',
+	// Moment.js has no "t" token equivalent, but a `moment().daysInMonth()` function
+	//t: '',
+	// Moment.js has no "L" token equivalent, but a `moment().isLeapYear()` function
+	//L: '',
+	o: 'Y',
+	Y: 'YYYY',
+	y: 'YY',
+	a: 'a',
+	A: 'A',
+	// Moment.js has no "B" token equivalent, but can be generated nonetheless
+	//B: '',
+	g: 'h',
+	G: 'H',
+	h: 'hh',
+	H: 'HH',
+	i: 'mm',
+	s: 'ss',
+	u: 'SSSSSS',
+	v: 'SSS',
+	e: 'z',
+	// Moment.js has no "I" token, but a `moment().isDST()` function
+	//I: '',
+	O: 'ZZ',
+	P: 'Z',
+	// Moment.js has no "T" token equivalent, but is similar enough to "z"
+	T: 'z',
+	// Moment.js has no "Z" token equivalent, but can be generated nonetheless
+	//Z: '',
+	c: 'YYYY-MM-DDTHH:mm-ssZ',
+	r: 'ddd, DD MMM YYYY HH:mm:ss ZZ',
+	U: 'X',
+};
+
+/**
+ * Convert a PHP datetime format string into a Moment.js one.
+ *
+ * @param {Object} momentDate A Moment.js object of the current date and time.
+ * @param {String} formatString A PHP datetime format string
+ * @return {String} A Moment.js datetime format string
+ */
+export function phpToMomentDatetimeFormat( momentDate, formatString ) {
+	const mappedFormat = formatString.split( '' ).map( ( c, i, a ) => {
+		const prev = a[ i - 1 ];
+		const next = a[ i + 1 ];
+
+		// Check if character is escaped
+		if ( '\\' === prev ) {
+			return `[${ c }]`;
+		}
+		if ( '\\' === c ) {
+			return '';
+		}
+
+		// Check if character is "jS", currently the only double-character token
+		if ( 'j' === c && 'S' === next ) {
+			return 'Do';
+		}
+		if ( 'S' === c && 'j' === prev ) {
+			return '';
+		}
+
+		// Check if character is a token mapped as a function
+		if ( 'z' === c ) {
+			// 'DDD' is 1 based but 'z' is 0 based
+			return `[${ momentDate.format( 'DDD' ) - 1 }]`;
+		}
+		if ( 't' === c ) {
+			return `[${ momentDate.daysInMonth() }]`;
+		}
+		if ( 'L' === c ) {
+			// 1 or 0
+			return `[${ momentDate.isLeapYear() | 0 }]`;
+		}
+		if ( 'B' === c ) {
+			const utcDate = momentDate.clone().utc();
+			const swatchTime = ( ( utcDate.hours() + 1 ) % 24 ) + ( utcDate.minutes() / 60 ) + ( utcDate.seconds() / 3600 );
+			return Math.floor( swatchTime * 1000 / 24 );
+		}
+		if ( 'I' === c ) {
+			// 1 or 0
+			return `[${ momentDate.isDST() | 0 }]`;
+		}
+		if ( 'Z' === c ) {
+			// Timezone offset in seconds
+			// E.g. "+0100" -> "3600"
+			return parseInt( momentDate.format( 'ZZ' ), 10 ) * 36;
+		}
+
+		// Check if character is a recognized mapping token
+		if ( has( phpToMomentMapping, c ) ) {
+			return phpToMomentMapping[ c ];
+		}
+
+		// Otherwise, return the character as-is, escaped for Moment.js
+		return `[${ c }]`;
+	} ).join( '' );
+
+	return momentDate.format( mappedFormat );
 }

--- a/client/my-sites/site-settings/date-time-format/utils.js
+++ b/client/my-sites/site-settings/date-time-format/utils.js
@@ -38,14 +38,13 @@ export function getLocalizedDate( timezoneString ) {
 const phpToMomentMapping = {
 	d: 'DD',
 	D: 'ddd',
-	jS: 'Do',
 	j: 'D',
 	l: 'dddd',
 	N: 'E',
-	// See "jS"
+	// "S" is andled via custom check
 	//S: '',
 	w: 'd',
-	// Moment.js equivalent of 'z' (0 based) is 'DDD' (1 based), so it must be adjusted
+	// Moment.js equivalent of "z" (0 based) is "DDD" (1 based), so it must be adjusted
 	//z: 'DDD',
 	W: 'W',
 	F: 'MMMM',
@@ -115,7 +114,7 @@ export function phpToMomentDatetimeFormat( momentDate, formatString ) {
 
 		// Check if character is a token mapped as a function
 		if ( 'z' === c ) {
-			// 'DDD' is 1 based but 'z' is 0 based
+			// "DDD" is 1 based but "z" is 0 based
 			return `[${ momentDate.format( 'DDD' ) - 1 }]`;
 		}
 		if ( 't' === c ) {

--- a/client/my-sites/site-settings/date-time-format/utils.js
+++ b/client/my-sites/site-settings/date-time-format/utils.js
@@ -113,30 +113,26 @@ export function phpToMomentDatetimeFormat( momentDate, formatString ) {
 		}
 
 		// Check if character is a token mapped as a function
-		if ( 'z' === c ) {
-			// "DDD" is 1 based but "z" is 0 based
-			return `[${ momentDate.format( 'DDD' ) - 1 }]`;
-		}
-		if ( 't' === c ) {
-			return `[${ momentDate.daysInMonth() }]`;
-		}
-		if ( 'L' === c ) {
-			// 1 or 0
-			return `[${ momentDate.isLeapYear() | 0 }]`;
-		}
-		if ( 'B' === c ) {
-			const utcDate = momentDate.clone().utc();
-			const swatchTime = ( ( utcDate.hours() + 1 ) % 24 ) + ( utcDate.minutes() / 60 ) + ( utcDate.seconds() / 3600 );
-			return Math.floor( swatchTime * 1000 / 24 );
-		}
-		if ( 'I' === c ) {
-			// 1 or 0
-			return `[${ momentDate.isDST() | 0 }]`;
-		}
-		if ( 'Z' === c ) {
-			// Timezone offset in seconds
-			// E.g. "+0100" -> "3600"
-			return parseInt( momentDate.format( 'ZZ' ), 10 ) * 36;
+		switch ( c ) {
+			case 'z':
+				// "DDD" is 1 based but "z" is 0 based
+				return `[${ momentDate.format( 'DDD' ) - 1 }]`;
+			case 't':
+				return `[${ momentDate.daysInMonth() }]`;
+			case 'L':
+				// 1 or 0
+				return `[${ momentDate.isLeapYear() | 0 }]`;
+			case 'B':
+				const utcDate = momentDate.clone().utc();
+				const swatchTime = ( ( utcDate.hours() + 1 ) % 24 ) + ( utcDate.minutes() / 60 ) + ( utcDate.seconds() / 3600 );
+				return Math.floor( swatchTime * 1000 / 24 );
+			case 'I':
+				// 1 or 0
+				return `[${ momentDate.isDST() | 0 }]`;
+			case 'Z':
+				// Timezone offset in seconds
+				// E.g. "+0100" -> "3600"
+				return parseInt( momentDate.format( 'ZZ' ), 10 ) * 36;
 		}
 
 		// Check if character is a recognized mapping token

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -32,8 +32,10 @@ import UpgradeNudge from 'my-sites/upgrade-nudge';
 import { isBusiness } from 'lib/products-values';
 import { FEATURE_NO_BRANDING } from 'lib/plans/constants';
 import QuerySiteSettings from 'components/data/query-site-settings';
-import { phpToMomentDatetimeFormat } from 'lib/formatting';
-import { getLocalizedDate } from './date-time-format/utils';
+import {
+	getLocalizedDate,
+	phpToMomentDatetimeFormat,
+} from './date-time-format/utils';
 
 class SiteSettingsFormGeneral extends Component {
 	componentWillMount() {
@@ -383,10 +385,10 @@ class SiteSettingsFormGeneral extends Component {
 				<div className="site-settings__date-time-format-info">
 					{
 						dateFormat &&
-							localizedDate.format( phpToMomentDatetimeFormat( dateFormat ) )
+							phpToMomentDatetimeFormat( localizedDate, dateFormat )
 					} &bull; {
 						timeFormat &&
-							localizedDate.format( phpToMomentDatetimeFormat( timeFormat ) )
+							phpToMomentDatetimeFormat( localizedDate, timeFormat )
 					} &bull; {
 						translate( 'Week starts on %s', { args: weekday } )
 					}


### PR DESCRIPTION
Change the logic of the PHP Date to Moment.js from a simple RegExp to a more complicated function in order to:

1. Map those PHP Date tokens that don't have an immediate equivalent in Moment.js (e.g. `B`).
2. Reliably match escaped character (JS RegExp does not support negative lookbehind).

Also move the mapping constant, function and tests from `lib/formatting` into the Date Time Format settings utilities, as their use is limited to this setting.