### PR TITLE
Themes: Add reducer for theme filters

### DIFF
--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -19,6 +19,7 @@ import {
 	THEME_ACTIVATE_FAILURE,
 	THEME_CLEAR_ACTIVATED,
 	THEME_DELETE_SUCCESS,
+	THEME_FILTERS_ADD,
 	THEME_INSTALL,
 	THEME_INSTALL_SUCCESS,
 	THEME_INSTALL_FAILURE,
@@ -39,6 +40,7 @@ import { createReducer, isValidStateWithSchema } from 'state/utils';
 import {
 	queriesSchema,
 	activeThemesSchema,
+	themeFiltersSchema,
 	themeRequestErrorsSchema,
 } from './schema';
 import themesUI from './themes-ui/reducer';
@@ -375,6 +377,10 @@ export const themePreviewVisibility = createReducer( null, {
 	[ THEME_PREVIEW_STATE ]: ( state, { themeId } ) => ( themeId )
 } );
 
+export const themeFilters = createReducer( null, {
+	[ THEME_FILTERS_ADD ]: ( state, { filters } ) => ( filters )
+}, themeFiltersSchema );
+
 export default combineReducers( {
 	queries,
 	queryRequests,
@@ -390,5 +396,6 @@ export default combineReducers( {
 	themesUI,
 	uploadTheme,
 	themePreviewOptions,
-	themePreviewVisibility
+	themePreviewVisibility,
+	themeFilters,
 } );

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -377,7 +377,7 @@ export const themePreviewVisibility = createReducer( null, {
 	[ THEME_PREVIEW_STATE ]: ( state, { themeId } ) => ( themeId )
 } );
 
-export const themeFilters = createReducer( null, {
+export const themeFilters = createReducer( {}, {
 	[ THEME_FILTERS_ADD ]: ( state, { filters } ) => ( filters )
 }, themeFiltersSchema );
 

--- a/client/state/themes/schema.js
+++ b/client/state/themes/schema.js
@@ -108,3 +108,15 @@ export const themeRequestErrorsSchema = {
 		}
 	}
 };
+
+export const themeFiltersSchema = {
+	type: 'object',
+	patternProperties: {
+		'^\\w+$': {
+			type: 'array',
+			items: { type: 'string' },
+			uniqueItems: true
+		},
+	},
+	additionalProperties: false,
+};

--- a/client/state/themes/test/reducer.js
+++ b/client/state/themes/test/reducer.js
@@ -85,7 +85,8 @@ describe( 'reducer', () => {
 			'themesUI',
 			'uploadTheme',
 			'themePreviewOptions',
-			'themePreviewVisibility'
+			'themePreviewVisibility',
+			'themeFilters',
 		] );
 	} );
 


### PR DESCRIPTION
No visual changes.

Add a reducer to store the theme filter data added in #12698 and D4901-code.

**To Test**
* In the JS console
* call the theme-filters endpoint: `dispatch( { type:'THEME_FILTERS_REQUEST' } )`
* check the redux tree is populated: `state.themes.themeFilters`

**Expected**
<img width="368" alt="screen shot 2017-04-07 at 14 26 40" src="https://cloud.githubusercontent.com/assets/7767559/24802008/3ffd7c58-1b9e-11e7-880d-5d96ee42f501.png">

