### PR TITLE
Sidebar: Change icon of Domains

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -330,7 +330,7 @@ export class MySitesSidebar extends Component {
 				className={ this.itemLinkClass( [ '/domains' ], 'domains' ) }
 				link={ domainsLink }
 				onNavigate={ this.onNavigate }
-				icon="globe"
+				icon="domains"
 				preloadSectionName="upgrades"
 			>
 				<SidebarButton href={ addDomainLink }>


### PR DESCRIPTION
We created an icon for domains. This updates the icon in Calypso.

Before

![screen shot 2017-04-04 at 11 50 55 am](https://cloud.githubusercontent.com/assets/618551/24668868/deeb4a20-192d-11e7-9d59-c21e86a62380.png)

After

![screen shot 2017-04-04 at 11 50 48 am](https://cloud.githubusercontent.com/assets/618551/24668878/e8489faa-192d-11e7-856b-fbd9369e4b0d.png)