### PR TITLE
Fix CSS Wrapper & Class Names

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -14,7 +14,7 @@ export default class Dashboard extends Component {
 
 	render() {
 		return (
-			<Main className="woocommerce__main">
+			<Main className="woocommerce dashboard">
 				<SectionHeader label="WooCommerce Store" />
 				<Card>
 					<p>This is the start of something great!</p>

--- a/client/extensions/woocommerce/app/products/product-form.js
+++ b/client/extensions/woocommerce/app/products/product-form.js
@@ -47,19 +47,21 @@ export default class ProductForm extends Component {
 			}
 		);
 		return (
-			<FoldableCard
-				icon=""
-				expanded={ true }
-				className="product-variations"
-				header={ ( <FormToggle onChange={ this.handleToggle } checked={ this.state.isVariation }>
-				{variationToggleDescription}
-				</FormToggle>
-				) }
-			>
-				{ this.state.isVariation && (
-					<ProductVariationTypesForm />
-				) }
-			</FoldableCard>
+			<div className="woocommerce products__form">
+				<FoldableCard
+					icon=""
+					expanded={ true }
+					className="products__variation-card"
+					header={ ( <FormToggle onChange={ this.handleToggle } checked={ this.state.isVariation }>
+					{variationToggleDescription}
+					</FormToggle>
+					) }
+				>
+					{ this.state.isVariation && (
+						<ProductVariationTypesForm />
+					) }
+				</FoldableCard>
+			</div>
 		);
 	}
 

--- a/client/extensions/woocommerce/app/products/product-variation-types-form.js
+++ b/client/extensions/woocommerce/app/products/product-variation-types-form.js
@@ -64,13 +64,13 @@ export default class ProductVariationTypesForm extends Component {
 
 	renderInputs( variation, index ) {
 		return (
-			<div key={index} className="product-variation-types-form__fieldset">
+			<div key={ index } className="products__variation-types-form-fieldset">
 				<FormTextInput
 					placeholder={ i18n.translate( 'Color' ) }
 					value={ variation.type }
 					name="type"
 					onChange={ ( e ) => this.updateType( index, e ) }
-					className="product-variation-types-form__field"
+					className="products__variation-types-form-field"
 				/>
 				<TokenField
 					placeholder={ i18n.translate( 'Comma separate these' ) }
@@ -91,18 +91,19 @@ export default class ProductVariationTypesForm extends Component {
 	render() {
 		const inputs = this.state.variations.map( this.renderInputs, this );
 		return (
-			<div className="product-variation-types-form__wrapper">
+			<div className="products__variation-types-form-wrapper">
 				<strong>{ i18n.translate( 'Variation types' ) }</strong>
 				<p>
 					{ i18n.translate(
-						'Let\'s add some variations! A common {{em}}variation type{{/em}} is color. The {{em}}values{{/em}} would be the colors the product is available in.',
+						'Let\'s add some variations! A common {{em}}variation type{{/em}} is color. ' +
+						'The {{em}}values{{/em}} would be the colors the product is available in.',
 						{ components: { em: <em /> } }
 					) }
 				</p>
 
-				<div className="product-variation-types-form__group">
-					<div className="product-variation-types-form__labels">
-						<FormLabel className="product-variation-types-form__label">{ i18n.translate( 'Variation type' ) }</FormLabel>
+				<div className="products__variation-types-form-group">
+					<div className="products__variation-types-form-labels">
+						<FormLabel className="products__variation-types-form-label">{ i18n.translate( 'Variation type' ) }</FormLabel>
 						<FormLabel>{ i18n.translate( 'Variation values' ) }</FormLabel>
 					</div>
 					{inputs}

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -1,32 +1,37 @@
-.foldable-card.product-variations .foldable-card__content {
-	padding: 0;
-	border: 0;
-}
+.woocommerce {
 
-.product-variation-types-form__wrapper {
-	padding: 24px;
-	border-top: 1px solid $gray-light;
-}
-
-.product-variation-types-form__group {
-
-	.product-variation-types-form__fieldset, .product-variation-types-form__labels {
-		display: flex;
+	.foldable-card.products__variation-card .foldable-card__content {
+		padding: 0;
+		border: 0;
 	}
 
-	.product-variation-types-form__fieldset {
-		margin-bottom: 16px;
+	.products__variation-types-form-wrapper {
+		padding: 24px;
+		border-top: 1px solid $gray-light;
 	}
 
-	.product-variation-types-form__field {
-		width: 50%;
+	.products__variation-types-form-group {
+
+		.products__variation-types-form-fieldset,
+		.products__variation-types-form-labels {
+			display: flex;
+		}
+
+		.products__variation-types-form-fieldset {
+			margin-bottom: 16px;
+		}
+
+		.products__variation-types-form-field {
+			width: 50%;
+		}
+
+		.products__variation-types-form-label {
+			width: 35%;
+		}
+
+		.token-field {
+			margin-left: 16px;
+		}
 	}
 
-	.product-variation-types-form__label {
-		width: 35%;
-	}
-
-	.token-field {
-		margin-left: 16px;
-	}
 }


### PR DESCRIPTION
None of our CSS is currently name spaced under anything. This PR moves our CSS classes under a wrapper class so our changes target just our extension.

This also adjusts class names because moving files around in #12741 caused a number of linter warnings based on expected class prefixes.

To Test:
* Load the products page (/store/.../products/add)
* Verify that the variations component looks visually the same after applying this PR.