### PR TITLE
Framework: Check if run-lint needs to be performed

### DIFF
--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -7,7 +7,7 @@ printf "\nBy contributing to this project, you license the materials you contrib
 # Make quick pass over config files on every change
 make config-defaults-lint || exit 1
 
-files=$(git diff --cached --name-only --diff-filter=ACM | grep ".jsx*$")
+files=$(git diff --cached --name-only client/ server/ test/ | grep ".jsx*$")
 if [ "$files" = "" ]; then
     exit 0
 fi
@@ -16,7 +16,7 @@ pass=true
 
 printf "\nValidating .jsx and .js:\n"
 
-./bin/run-lint $(git diff --cached --name-only client/ server/ test/ | grep ".jsx*$") -- --diff=index
+./bin/run-lint $files -- --diff=index
 linter_exit_code=$?
 if [ ! 0 = "$linter_exit_code" ]
 then


### PR DESCRIPTION
## Context
The pre-commit script does not exit successfully when a developer edits a file outside of `client`, `server`, or `test` directories. Here is an easy repro:

1) Add a lint violation to `/index.js` (e.g. changing line 6 to `var boot = require('boot'),`).
2) Commit the changes - `git commit -m "Try making an invalid commit"`
3) Error.

The above error occurs because `run-lint` was invoked without a valid file parameter [in this line](https://github.com/Automattic/wp-calypso/blob/a7721d3a10a53b5343e7a7f2b97b3a2ac9f8a59b/bin/pre-commit#L19). In other words, `git diff --cached --name-only client/ server/ test/ | grep ".jsx*$"` evaluated to `""`.

## Solution
This change fixes this by exiting the script with code 0 if `git diff --cached --name-only client/ server/ test/ | grep ".jsx*$"` evaluates to `""`.

## Pre-commit error stacktrace
```
Validating .jsx and .js:
undefined:1
eslint [options] file.js [file.js] [dir]
^

SyntaxError: Unexpected token e in JSON at position 0
    at Object.parse (native)
    at Socket.process.stdin.on (/Users/jsnmoon/Projects/wp-calypso/node_modules/eslines/index.js:36:27)
    at emitNone (events.js:91:20)
    at Socket.emit (events.js:185:7)
    at endReadableNT (_stream_readable.js:974:12)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```