### PR TITLE
Use srcset for screenshot in ThemesShowcase.

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -142,7 +142,6 @@ const Theme = React.createClass( {
 			return this.renderPlaceholder();
 		}
 
-		const screenshotWidth = typeof window !== 'undefined' && window.devicePixelRatio > 1 ? 680 : 340;
 		return (
 			<Card className={ themeClass }>
 				<div className="theme__content">
@@ -153,7 +152,11 @@ const Theme = React.createClass( {
 						{ this.renderInstalling() }
 						{ screenshot
 							? <img className="theme__img"
-								src={ screenshot + '?w=' + screenshotWidth }
+								src={ screenshot + '?w=340' }
+								srcSet={
+									screenshot + '?w=340 1x, ' +
+									screenshot + '?w=680 2x'
+								}
 								onClick={ this.onScreenshotClick }
 								id={ screenshotID } />
 							: <div className="theme__no-screenshot" >


### PR DESCRIPTION
### Info
The logic behind selection of high res devices on Retina type screens causes reconciliation errors. Since server does not know which resolution should be rendered it takes the low res. With this change it does not matter because selection is not done with JS but is done by browser. This is how the error looks:

![image](https://cloud.githubusercontent.com/assets/17271089/24676854/ef0fd126-1984-11e7-9a26-b34a1c17ba9f.png)

### Testing
Go to `/design` in logged-out and observe console. The warning from ^ should not be visible. Other reconciliation error can be visible but it is a different issue. 
Testing should be done on Retina type screen. If it is not available then Chrome dev tools have Device panel that allows setting different DPR. 
If DPR is <= 1 the 340 width screenshot should be chosen by browser. For DPR > 1 the 680 width screenshot should be chosen. The only sure way to know which one is used is to check img element Property tab:
![image](https://cloud.githubusercontent.com/assets/17271089/24677194/39ba3a6c-1986-11e7-9d79-312300f9a89e.png)

### The good, the bad, the Internet Explorer
![image](https://cloud.githubusercontent.com/assets/17271089/24677337/c7eec2c6-1986-11e7-91ed-758af0a5e354.png)
`srcset` is not supported by IE. This would mean that after this PR IE would be stuck with 340 w screenshot no matter what DPR. I assume that sets of devices that use IE and highDPR devices is practically non-overlapping so this is not a problem.