### PR TITLE
Reader Data Layer: add test to make sure the request calls next with the action

### DIFF
--- a/client/state/data-layer/wpcom/read/teams/test/index.js
+++ b/client/state/data-layer/wpcom/read/teams/test/index.js
@@ -37,7 +37,7 @@ describe( 'wpcom-api', () => {
 				.reply( 500, new Error() )
 		) );
 
-		it( 'should pass the action foward', () => {
+		it( 'handleTeamsRequest should pass the action forward', () => {
 			const dispatch = sinon.spy();
 			const action = requestTeams();
 

--- a/client/state/data-layer/wpcom/read/teams/test/index.js
+++ b/client/state/data-layer/wpcom/read/teams/test/index.js
@@ -32,8 +32,18 @@ describe( 'wpcom-api', () => {
 				.get( '/rest/v1.2/read/teams' )
 				.reply( 200, successfulResponse )
 				.get( '/rest/v1.2/read/teams' )
+				.reply( 200, successfulResponse )
+				.get( '/rest/v1.2/read/teams' )
 				.reply( 500, new Error() )
 		) );
+
+		it( 'should pass the action foward', () => {
+			const dispatch = sinon.spy();
+			const action = requestTeams();
+
+			handleTeamsRequest( { dispatch }, action, nextSpy, );
+			expect( nextSpy ).calledWith( action );
+		} );
 
 		it( 'should dispatch RECEIVE action when request completes', ( done ) => {
 			const dispatch = sinon.spy( action => {


### PR DESCRIPTION
Fulfilling one of the checkboxes in the greater [Reader Reduxification](https://github.com/Automattic/wp-calypso/issues/10984) project