### PR TITLE
AT: update eligibility tracking events

### DIFF
--- a/client/my-sites/plugins-wpcom/plugin-install-button.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-install-button.jsx
@@ -16,7 +16,6 @@ import { getSelectedSite } from 'state/ui/selectors';
 import { getEligibility } from 'state/automated-transfer/selectors';
 import { initiateThemeTransfer } from 'state/themes/actions';
 import { transferStates } from 'state/automated-transfer/constants';
-import { recordTracksEvent } from 'state/analytics/actions';
 
 export const WpcomPluginInstallButton = props => {
 	const {
@@ -43,18 +42,10 @@ export const WpcomPluginInstallButton = props => {
 
 		const hasErrors = !! eligibilityHolds.length;
 		const hasWarnings = !! eligibilityWarnings.length;
-
 		if ( ! hasErrors && ! hasWarnings ) {
 			// No need to show eligibility warnings page, initiate transfer immediately
 			initiateTransfer( siteId, null, plugin.slug );
 		} else {
-			props.recordTracksEvent( 'calypso_automated_transfer_plugin_install_ineligible',
-				{
-					eligibility_holds: eligibilityHolds.join( ', ' ),
-					eligibility_warnings: eligibilityWarnings.join( ', ' ),
-					plugin_slug: plugin.slug
-				} );
-
 			// Show eligibility warnings before proceeding
 			navigateTo( `/plugins/${ plugin.slug }/eligibility/${ siteSlug }` );
 		}
@@ -83,8 +74,7 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = {
-	initiateTransfer: initiateThemeTransfer,
-	recordTracksEvent,
+	initiateTransfer: initiateThemeTransfer
 };
 
 const withNavigation = WrappedComponent => props => <WrappedComponent { ...{ ...props, navigateTo: page } } />;

--- a/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js
@@ -95,23 +95,23 @@ const trackEligibility = data => {
 		return recordTracksEvent( 'calypso_automated_transfer_eligiblity_eligible' );
 	}
 
-	let hasHoldsEvent;
-	let hasWarningsEvent;
+	let holdsTracksEvent;
+	let warningsTracksEvent;
 
 	if ( ! data.is_eligible ) {
-		hasHoldsEvent = recordTracksEvent( 'calypso_automated_transfer_eligibility_holds', {
+		holdsTracksEvent = recordTracksEvent( 'calypso_automated_transfer_eligibility_holds', {
 			holds: eligibilityHoldsFromApi( data ).join( ',' )
 		} );
 	}
 
 	if ( hasEligibilityWarnings ) {
-		hasWarningsEvent = recordTracksEvent( 'calypso_automated_transfer_eligibility_warnings', {
+		warningsTracksEvent = recordTracksEvent( 'calypso_automated_transfer_eligibility_warnings', {
 			plugins: map( pluginWarnings, 'id' ).join( ',' ),
 			widgets: map( widgetWarnings, 'id' ).join( ',' ),
 		} );
 	}
 
-	const eligibilityEvents = [ hasHoldsEvent, hasWarningsEvent ].filter( identity );
+	const eligibilityEvents = [ holdsTracksEvent, warningsTracksEvent ].filter( identity );
 
 	return composeAnalytics.apply( null, eligibilityEvents );
 };


### PR DESCRIPTION
Currently we are tracking `calypso_automated_transfer_plugin_install_ineligible` with `eligibility_holds` and `elgibility_warnings` event properties.

**Updated**
This PR splits up sets up two new eligibility events:
- `calypso_automated_transfer_eligiblity_eligible`
- `calypso_automated_transfer_eligiblity_ineligible`

**Event Properties**

Both events carry:

| prop | value | |
|---|---|---|
| `has_warnings`| `Boolean` | The site is using unsupported plugins or widgets |
| `plugins` | comma separated list | the ids of unsupported plugins |
| `widgets` | comma separated list | the ids of unsupported widgets |

`calypso_automated_transfer_eligiblity_ineligible` includes an additional `holds` property which is a comma separated list of hold codes

**Need for the changes**

The current ineligibility tracking cannot handle eligibility warnings correctly. The `eligibility_warnings` will be recorded as `[Object object]`.

**Testing**
- Enable analytics logging by setting the debug flag: `localStorage.setItem('debug', 'calypso:analytics:tracks');`
- Add any number of unsupported widgets e.g. blog stats, authors

**Tracking warnings**
- visit calypso.localhost:3000/plugins/:any-plugin-slug/eligibility/:site
- `calypso_automated_transfer_eligiblity_eligible` events should be logged in the console
- the event should carry `has_warnigns`, `plugins`, and `widgets` properties

**Tracking holds**
- Set the primary domain on an existing Business site to the `*.wordpress.com` domain
- visit calypso.localhost:3000/plugins/:any-plugin-slug/eligibility/:site
- `calypso_automated_transfer_eligibility_inelgible` events should be logged in the dev console
- the event should carry `has_warnings`, `plugins`, `widgets` and `holds` properties


