### PR TITLE
Add woocommerce stats paths

### DIFF
--- a/client/extensions/woocommerce/app/stats/index.js
+++ b/client/extensions/woocommerce/app/stats/index.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+
+export default class Stats extends Component {
+
+	render() {
+		return (
+			<Main className="stats woocommerce">
+				<SectionHeader label="WooCommerce Store - Stats" />
+				<Card>
+					<p>This will be the home for your WooCommerce Store Stats</p>
+				</Card>
+			</Main>
+		);
+	}
+
+}

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import page from 'page';
+import config from 'config';
 
 /**
  * Internal dependencies
@@ -11,6 +12,7 @@ import { navigation, siteSelection } from 'my-sites/controller';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import ProductForm from './app/products/product-form';
 import Dashboard from './app/dashboard';
+import Stats from './app/stats';
 
 const Controller = {
 	dashboard: function( context ) {
@@ -27,10 +29,24 @@ const Controller = {
 			document.getElementById( 'primary' ),
 			context.store
 		);
+	},
+
+	stats: function( context ) {
+		renderWithReduxStore(
+			React.createElement( Stats, { } ),
+			document.getElementById( 'primary' ),
+			context.store
+		);
 	}
 };
 
 export default function() {
-	page( '/store/:site?', siteSelection, navigation, Controller.dashboard );
-	page( '/store/:site?/products/add', siteSelection, navigation, Controller.addProduct );
+	if ( config.isEnabled( 'woocommerce/extension-dashboard' ) ) {
+		page( '/store/:site?', siteSelection, navigation, Controller.dashboard );
+		page( '/store/products/add/:site?', siteSelection, navigation, Controller.addProduct );
+	}
+
+	if ( config.isEnabled( 'woocommerce/extension-stats' ) ) {
+		page( '/store/stats/:site?', siteSelection, navigation, Controller.stats );
+	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -154,6 +154,8 @@
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
 		"webpack/persistent-caching": false,
+		"woocommerce/extension-dashboard": true,
+		"woocommerce/extension-stats": true,
 		"wp-login": true
 	}
 }


### PR DESCRIPTION
### Establish WooCommerce Stats routes
Begin inclusion of [WooCommerce Store Stats](https://github.com/Automattic/wp-calypso/projects/26) into [WooCommerce for Calypso](https://github.com/Automattic/wp-calypso/projects/22). It appears each project will occupy the same space.

### Routes
I've added the beginning of a basic route for `stats` section. I also organised the `/products/add` path to follow the convention set by the rest of Calypso where the `:site` parameter [comes last](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/stats/index.js).

### Feature Flags
Although the extension is hidden from production builds by the environment id, there may be a scenario where we may want to move forward with one portion before the others are finished. The flags can be changed to reflect that.

Any feedback on naming, conventions, or otherwise are welcome.


cc @justinshreve @coderkevin @greenafrican 