### PR TITLE
Extensions: Add data-layer middleware

### DIFF
--- a/client/state/data-layer/extensions-middleware.js
+++ b/client/state/data-layer/extensions-middleware.js
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import { toPairs, fromPairs } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { local, mergeHandlers } from './utils';
+
+const stripHandlersForKey = ( key, keyHandlers, keyHandlersToStrip ) => {
+	const newKeyHandlers = (
+		keyHandlersToStrip
+			? keyHandlers.filter( ( handler ) => ! keyHandlersToStrip.includes( handler ) )
+			: keyHandlers
+	);
+
+	return [ key, newKeyHandlers ];
+};
+
+const stripHandlers = ( handlers, handlersToStrip ) => {
+	return fromPairs(
+		toPairs( handlers ).map(
+			( [ key, keyHandlers ] ) => stripHandlersForKey( key, keyHandlers, handlersToStrip[ key ] )
+		)
+	);
+};
+
+export const extensionsHandlers = () => {
+	let handlers = {};
+
+	/**
+	 * Dynamically add handlers to this middleware.
+	 *
+	 * @function
+	 * @param {Object} handlersToAdd The actions to be added.
+	 * @return {Function} removeHandlers, removes the handlers that were added.
+	 */
+	const addHandlers = ( handlersToAdd ) => {
+		handlers = mergeHandlers( handlers, handlersToAdd );
+
+		return function removeHandlers() {
+			handlers = stripHandlers( handlers, handlersToAdd );
+		};
+	};
+
+	/**
+	 * WPCOM Extensions Middleware
+	 *
+	 * Intercepts actions requesting data for extensions
+	 * and passes them to the appropriate handler.
+	 *
+	 * This code patterns off of datalayer wpcom-api-middleware
+	 * @see state/data-layer/wpcom-api-middleware
+	 *
+	 * @param {Object} store Common `store => next => action` pattern for middlewares.
+	 * @return {Function} middleware handler
+	 */
+	const middleware = store => next => {
+		const localNext = action => next( local( action ) );
+
+		/**
+		 * Middleware handler
+		 *
+		 * @function
+		 * @param {Object} action Redux action
+		 * @returns {undefined} please do not use
+		 */
+		return action => {
+			const handlerChain = handlers[ action.type ];
+
+			// if no handler is defined for the action type
+			// then pass it along the chain untouched
+			if ( ! handlerChain ) {
+				return next( action );
+			}
+
+			const meta = action.meta;
+			if ( meta ) {
+				const dataLayer = meta.dataLayer;
+
+				// if the action indicates that we should
+				// bypass the data layer, then pass it
+				// along the chain untouched
+				if ( dataLayer && true === dataLayer.doBypass ) {
+					return next( action );
+				}
+			}
+
+			return handlerChain.forEach( handler => handler( store, action, localNext ) );
+		};
+	};
+
+	return { middleware, addHandlers };
+};
+
+const instance = extensionsHandlers();
+
+export default instance.middleware;
+export const addHandlers = instance.addHandlers;
+

--- a/client/state/data-layer/extensions-middleware.js
+++ b/client/state/data-layer/extensions-middleware.js
@@ -1,101 +1,58 @@
 /**
- * External dependencies
- */
-import { toPairs, fromPairs } from 'lodash';
-
-/**
  * Internal dependencies
  */
-import { local, mergeHandlers } from './utils';
+import { mergeHandlers } from './utils';
+import { middleware } from './wpcom-api-middleware';
+import debugFactory from 'debug';
 
-const stripHandlersForKey = ( key, keyHandlers, keyHandlersToStrip ) => {
-	const newKeyHandlers = (
-		keyHandlersToStrip
-			? keyHandlers.filter( ( handler ) => ! keyHandlersToStrip.includes( handler ) )
-			: keyHandlers
+const debug = debugFactory( 'calypso:state:data-layer' );
+let extensionHandlers = Object.create( null );
+let handlerMiddleware = buildMiddleware( extensionHandlers );
+
+export function addHandlers( extensionName, handlers, existingHandlers = extensionHandlers ) {
+	if ( Object.keys( existingHandlers ).includes( extensionName ) ) {
+		throw new Error( `Handlers for extension ${ extensionName } already present.` );
+	}
+
+	// Set the module globals for convenience
+	extensionHandlers = { ...existingHandlers, [ extensionName ]: handlers };
+	handlerMiddleware = buildMiddleware( extensionHandlers );
+
+	return extensionHandlers;
+}
+
+export function removeHandlers( extensionName, existingHandlers = extensionHandlers ) {
+	const { [ extensionName ]: omitted, ...remainingHandlers } = existingHandlers;
+
+	if ( ! omitted ) {
+		debug( `Trying to remove nonexistent handlers for ${ extensionName }` );
+	}
+
+	// Set the module globals for convenience
+	extensionHandlers = remainingHandlers;
+	handlerMiddleware = buildMiddleware( extensionHandlers );
+
+	return extensionHandlers;
+}
+
+export function buildMiddleware( handlersByExtension ) {
+	const allHandlers = Object.values( handlersByExtension ).reduce(
+		( accumulated, handlers ) => {
+			return mergeHandlers( accumulated, handlers );
+		},
+		{}
 	);
 
-	return [ key, newKeyHandlers ];
+	return middleware( allHandlers );
+}
+
+/**
+ * Extensions Middleware
+ * @function
+ * @param {Object} store The store for the middleware chain.
+ * @returns {Function} The next => action part of the middleware.
+ */
+export default store => next => action => {
+	return handlerMiddleware( store )( next )( action );
 };
-
-const stripHandlers = ( handlers, handlersToStrip ) => {
-	return fromPairs(
-		toPairs( handlers ).map(
-			( [ key, keyHandlers ] ) => stripHandlersForKey( key, keyHandlers, handlersToStrip[ key ] )
-		)
-	);
-};
-
-export const extensionsHandlers = () => {
-	let handlers = {};
-
-	/**
-	 * Dynamically add handlers to this middleware.
-	 *
-	 * @function
-	 * @param {Object} handlersToAdd The actions to be added.
-	 * @return {Function} removeHandlers, removes the handlers that were added.
-	 */
-	const addHandlers = ( handlersToAdd ) => {
-		handlers = mergeHandlers( handlers, handlersToAdd );
-
-		return function removeHandlers() {
-			handlers = stripHandlers( handlers, handlersToAdd );
-		};
-	};
-
-	/**
-	 * WPCOM Extensions Middleware
-	 *
-	 * Intercepts actions requesting data for extensions
-	 * and passes them to the appropriate handler.
-	 *
-	 * This code patterns off of datalayer wpcom-api-middleware
-	 * @see state/data-layer/wpcom-api-middleware
-	 *
-	 * @param {Object} store Common `store => next => action` pattern for middlewares.
-	 * @return {Function} middleware handler
-	 */
-	const middleware = store => next => {
-		const localNext = action => next( local( action ) );
-
-		/**
-		 * Middleware handler
-		 *
-		 * @function
-		 * @param {Object} action Redux action
-		 * @returns {undefined} please do not use
-		 */
-		return action => {
-			const handlerChain = handlers[ action.type ];
-
-			// if no handler is defined for the action type
-			// then pass it along the chain untouched
-			if ( ! handlerChain ) {
-				return next( action );
-			}
-
-			const meta = action.meta;
-			if ( meta ) {
-				const dataLayer = meta.dataLayer;
-
-				// if the action indicates that we should
-				// bypass the data layer, then pass it
-				// along the chain untouched
-				if ( dataLayer && true === dataLayer.doBypass ) {
-					return next( action );
-				}
-			}
-
-			return handlerChain.forEach( handler => handler( store, action, localNext ) );
-		};
-	};
-
-	return { middleware, addHandlers };
-};
-
-const instance = extensionsHandlers();
-
-export default instance.middleware;
-export const addHandlers = instance.addHandlers;
 

--- a/client/state/data-layer/test/extensions-middleware.js
+++ b/client/state/data-layer/test/extensions-middleware.js
@@ -1,0 +1,204 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { spy, stub } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import { extensionsHandlers } from '../extensions-middleware';
+import { local } from '../utils';
+
+describe( 'Calypso Extensions Data Layer Middleware', () => {
+	let next;
+	let store;
+	let middleware;
+	let addHandlers;
+
+	beforeEach( () => {
+		const handlers = extensionsHandlers();
+
+		next = spy();
+
+		store = {
+			dispatch: spy(),
+			getState: stub(),
+			replaceReducers: spy(),
+			subscribe: spy(),
+		};
+
+		store.getState.returns( Object.create( null ) );
+
+		middleware = handlers.middleware;
+		addHandlers = handlers.addHandlers;
+	} );
+
+	it( 'should pass along actions without corresponding handlers', () => {
+		const action = { type: 'UNSUPPORTED_ACTION' };
+
+		addHandlers( Object.create( null ) );
+		middleware( store )( next )( action );
+
+		expect( store.dispatch ).to.not.have.beenCalled;
+		expect( next ).to.have.been.calledWith( action );
+	} );
+
+	it( 'should pass along local actions untouched', () => {
+		const adder = spy();
+
+		addHandlers( {
+			[ 'ADD' ]: [ adder ],
+		} );
+		const action = local( { type: 'ADD' } );
+
+		middleware( store )( next )( action );
+
+		expect( next ).to.have.been.calledWith( action );
+		expect( adder ).to.not.have.beenCalled;
+	} );
+
+	it( 'should not pass along non-local actions with non data-layer meta', () => {
+		const adder = spy();
+
+		addHandlers( {
+			[ 'ADD' ]: [ adder ],
+		} );
+		const action = { type: 'ADD', meta: { semigroup: true } };
+
+		middleware( store )( next )( action );
+
+		expect( next ).to.not.have.beenCalled;
+		expect( adder ).to.have.been.calledWith( store, action );
+	} );
+
+	it( 'should not pass along non-local actions with data-layer meta but no bypass', () => {
+		const adder = spy();
+
+		addHandlers( {
+			[ 'ADD' ]: [ adder ],
+		} );
+		const action = { type: 'ADD', meta: { dataLayer: { data: 42 } } };
+
+		middleware( store )( next )( action );
+
+		expect( next ).to.not.have.beenCalled;
+		expect( adder ).to.have.been.calledWith( store, action );
+	} );
+
+	it( 'should intercept actions in appropriate handler', () => {
+		const adder = spy();
+
+		addHandlers( {
+			[ 'ADD' ]: [ adder ],
+		} );
+		const action = { type: 'ADD' };
+
+		middleware( store )( next )( action );
+
+		expect( next ).to.not.have.been.calledWith( action );
+		expect( adder ).to.have.been.calledWith( store, action );
+	} );
+
+	it( 'should allow continuing the action down the chain', () => {
+		const adder = spy( ( _store, _action, _next ) => _next( _action ) );
+
+		addHandlers( {
+			[ 'ADD' ]: [ adder ],
+		} );
+		const action = { type: 'ADD' };
+
+		middleware( store )( next )( action );
+
+		expect( next ).to.have.been.calledOnce;
+		expect( next ).to.have.been.calledWith( local( action ) );
+		expect( adder ).to.have.been.calledWith( store, action );
+	} );
+
+	it( 'should call all given handlers (same list)', () => {
+		const adder = spy();
+		const doubler = spy();
+
+		addHandlers( {
+			[ 'MATHS' ]: [ adder, doubler ],
+		} );
+		const action = { type: 'MATHS' };
+
+		middleware( store )( next )( action );
+
+		expect( adder ).to.have.been.calledWith( store, action );
+		expect( doubler ).to.have.been.calledWith( store, action );
+		expect( next ).to.not.have.beenCalled;
+	} );
+
+	it( 'should call all given handlers (different lists)', () => {
+		const adder = spy();
+		const doubler = spy();
+
+		addHandlers( {
+			[ 'MATHS' ]: [ adder ],
+		} );
+
+		addHandlers( {
+			[ 'MATHS' ]: [ doubler ],
+		} );
+
+		const action = { type: 'MATHS' };
+
+		middleware( store )( next )( action );
+
+		expect( adder ).to.have.been.calledWith( store, action );
+		expect( doubler ).to.have.been.calledWith( store, action );
+		expect( next ).to.not.have.beenCalled;
+	} );
+
+	it( 'should no longer call handlers that have been removed', () => {
+		const adder = spy();
+
+		const removeAdder = addHandlers( {
+			[ 'MATHS' ]: [ adder ],
+		} );
+		const action = { type: 'MATHS' };
+
+		middleware( store )( next )( action );
+		expect( adder ).to.have.been.calledWith( store, action );
+
+		removeAdder();
+
+		middleware( store )( next )( action );
+		expect( adder ).to.not.have.beenCalled;
+	} );
+
+	it( 'should still call handlers even after some handlers have been removed', () => {
+		const adder = spy();
+		const doubler = spy();
+		const other = spy();
+
+		const removeAdder = addHandlers( {
+			[ 'MATHS' ]: [ adder ],
+		} );
+
+		addHandlers( {
+			[ 'MATHS' ]: [ doubler ],
+			[ 'OTHER' ]: [ other ],
+		} );
+
+		const mathsAction = { type: 'MATHS' };
+		const otherAction = { type: 'OTHER' };
+
+		middleware( store )( next )( mathsAction );
+		middleware( store )( next )( otherAction );
+		expect( adder ).to.have.been.calledWith( store, mathsAction );
+		expect( doubler ).to.have.been.calledWith( store, mathsAction );
+		expect( other ).to.have.been.calledWith( store, otherAction );
+
+		removeAdder();
+
+		middleware( store )( next )( mathsAction );
+		middleware( store )( next )( otherAction );
+		expect( adder ).to.have.been.calledOnce;
+		expect( doubler ).to.have.been.calledTwice;
+		expect( other ).to.have.been.calledTwice;
+	} );
+} );
+

--- a/client/state/data-layer/test/extensions-middleware.js
+++ b/client/state/data-layer/test/extensions-middleware.js
@@ -7,7 +7,7 @@ import { spy, stub } from 'sinon';
 /**
  * Internal dependencies
  */
-import { addHandlers, removeHandlers, buildMiddleware } from '../extensions-middleware';
+import { addHandlers, removeHandlers, configureMiddleware } from '../extensions-middleware';
 import { local } from '../utils';
 
 describe( 'Calypso Extensions Data Layer Middleware', () => {
@@ -30,10 +30,10 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 	it( 'should pass along actions without corresponding handlers', () => {
 		const action = { type: 'UNSUPPORTED_ACTION' };
 
-		const extensionHandlers = addHandlers( 'my-extension', {}, {} );
-		const middleware = buildMiddleware( extensionHandlers );
+		const config = configureMiddleware( Object.create( null ), Object.create( null ) );
+		addHandlers( 'my-extension', {}, config );
 
-		middleware( store )( next )( action );
+		config.middleware( store )( next )( action );
 
 		expect( store.dispatch ).to.not.have.beenCalled;
 		expect( next ).to.have.been.calledWith( action );
@@ -45,11 +45,11 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 			[ 'ADD' ]: [ adder ],
 		};
 
-		const extensionHandlers = addHandlers( 'my-extension', handlers, {} );
-		const middleware = buildMiddleware( extensionHandlers );
+		const config = configureMiddleware( Object.create( null ), Object.create( null ) );
+		addHandlers( 'my-extension', handlers, config );
 		const action = local( { type: 'ADD' } );
 
-		middleware( store )( next )( action );
+		config.middleware( store )( next )( action );
 
 		expect( next ).to.have.been.calledWith( action );
 		expect( adder ).to.not.have.beenCalled;
@@ -61,11 +61,11 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 			[ 'ADD' ]: [ adder ],
 		};
 
-		const extensionHandlers = addHandlers( 'my-extension', handlers, {} );
-		const middleware = buildMiddleware( extensionHandlers );
+		const config = configureMiddleware( Object.create( null ), Object.create( null ) );
+		addHandlers( 'my-extension', handlers, config );
 		const action = { type: 'ADD', meta: { semigroup: true } };
 
-		middleware( store )( next )( action );
+		config.middleware( store )( next )( action );
 
 		expect( next ).to.not.have.beenCalled;
 		expect( adder ).to.have.been.calledWith( store, action );
@@ -77,11 +77,11 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 			[ 'ADD' ]: [ adder ],
 		};
 
-		const extensionHandlers = addHandlers( 'my-extension', handlers, {} );
-		const middleware = buildMiddleware( extensionHandlers );
+		const config = configureMiddleware( Object.create( null ), Object.create( null ) );
+		addHandlers( 'my-extension', handlers, config );
 		const action = { type: 'ADD', meta: { dataLayer: { data: 42 } } };
 
-		middleware( store )( next )( action );
+		config.middleware( store )( next )( action );
 
 		expect( next ).to.not.have.beenCalled;
 		expect( adder ).to.have.been.calledWith( store, action );
@@ -94,11 +94,11 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 			[ 'ADD' ]: [ adder ],
 		};
 
-		const extensionHandlers = addHandlers( 'my-extension', handlers, {} );
-		const middleware = buildMiddleware( extensionHandlers );
+		const config = configureMiddleware( Object.create( null ), Object.create( null ) );
+		addHandlers( 'my-extension', handlers, config );
 		const action = { type: 'ADD' };
 
-		middleware( store )( next )( action );
+		config.middleware( store )( next )( action );
 
 		expect( next ).to.not.have.been.calledWith( action );
 		expect( adder ).to.have.been.calledWith( store, action );
@@ -111,11 +111,11 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 			[ 'ADD' ]: [ adder ],
 		};
 
-		const extensionHandlers = addHandlers( 'my-extension', handlers, {} );
-		const middleware = buildMiddleware( extensionHandlers );
+		const config = configureMiddleware( Object.create( null ), Object.create( null ) );
+		addHandlers( 'my-extension', handlers, config );
 		const action = { type: 'ADD' };
 
-		middleware( store )( next )( action );
+		config.middleware( store )( next )( action );
 
 		expect( next ).to.have.been.calledOnce;
 		expect( next ).to.have.been.calledWith( local( action ) );
@@ -130,11 +130,11 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 			[ 'MATHS' ]: [ adder, doubler ],
 		};
 
-		const extensionHandlers = addHandlers( 'my-extension', handlers, {} );
-		const middleware = buildMiddleware( extensionHandlers );
+		const config = configureMiddleware( Object.create( null ), Object.create( null ) );
+		addHandlers( 'my-extension', handlers, config );
 		const action = { type: 'MATHS' };
 
-		middleware( store )( next )( action );
+		config.middleware( store )( next )( action );
 
 		expect( adder ).to.have.been.calledWith( store, action );
 		expect( doubler ).to.have.been.calledWith( store, action );
@@ -153,12 +153,12 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 			[ 'MATHS' ]: [ doubler ],
 		};
 
-		const extensionHandlers1 = addHandlers( 'adder-extension', adderHandlers, {} );
-		const extensionHandlers2 = addHandlers( 'doubler-extension', doublerHandlers, extensionHandlers1 );
-		const middleware = buildMiddleware( extensionHandlers2 );
+		const config = configureMiddleware( Object.create( null ), Object.create( null ) );
+		addHandlers( 'adder-extension', adderHandlers, config );
+		addHandlers( 'doubler-extension', doublerHandlers, config );
 		const action = { type: 'MATHS' };
 
-		middleware( store )( next )( action );
+		config.middleware( store )( next )( action );
 
 		expect( adder ).to.have.been.calledWith( store, action );
 		expect( doubler ).to.have.been.calledWith( store, action );
@@ -172,17 +172,16 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 			[ 'MATHS' ]: [ adder ],
 		};
 
-		const extensionHandlers1 = addHandlers( 'my-extension', handlers, {} );
-		const middleware1 = buildMiddleware( extensionHandlers1 );
+		const config = configureMiddleware( Object.create( null ), Object.create( null ) );
+		addHandlers( 'my-extension', handlers, config );
 		const action = { type: 'MATHS' };
 
-		middleware1( store )( next )( action );
+		config.middleware( store )( next )( action );
 		expect( adder ).to.have.been.calledWith( store, action );
 
-		const extensionHandlers2 = removeHandlers( 'my-extension', extensionHandlers1 );
-		const middleware2 = buildMiddleware( extensionHandlers2 );
+		removeHandlers( 'my-extension', config );
 
-		middleware2( store )( next )( action );
+		config.middleware( store )( next )( action );
 		expect( adder ).to.not.have.beenCalled;
 	} );
 
@@ -203,34 +202,38 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 		const mathsAction = { type: 'MATHS' };
 		const otherAction = { type: 'OTHER' };
 
-		const extensionHandlers1 = addHandlers( 'adder-extension', adderHandlers, {} );
-		const extensionHandlers2 = addHandlers( 'doubler-extension', doublerHandlers, extensionHandlers1 );
-		const middleware2 = buildMiddleware( extensionHandlers2 );
+		const config = configureMiddleware( Object.create( null ), Object.create( null ) );
+		addHandlers( 'adder-extension', adderHandlers, config );
+		addHandlers( 'doubler-extension', doublerHandlers, config );
 
-		middleware2( store )( next )( mathsAction );
-		middleware2( store )( next )( otherAction );
+		config.middleware( store )( next )( mathsAction );
+		config.middleware( store )( next )( otherAction );
 		expect( adder ).to.have.been.calledWith( store, mathsAction );
 		expect( doubler ).to.have.been.calledWith( store, mathsAction );
 		expect( other ).to.have.been.calledWith( store, otherAction );
 
-		const extensionHandlers3 = removeHandlers( 'adder-extension', extensionHandlers2 );
-		const middleware3 = buildMiddleware( extensionHandlers3 );
+		removeHandlers( 'adder-extension', config );
 
-		middleware3( store )( next )( mathsAction );
-		middleware3( store )( next )( otherAction );
+		config.middleware( store )( next )( mathsAction );
+		config.middleware( store )( next )( otherAction );
 		expect( adder ).to.have.been.calledOnce;
 		expect( doubler ).to.have.been.calledTwice;
 		expect( other ).to.have.been.calledTwice;
 	} );
 
-	it( 'should throw an Error when trying to add handlers for the same extension twice.', () => {
-		const extensionHandlers1 = addHandlers( 'my-extension', {}, {} );
+	it( 'should return false when trying to add handlers for the same extension twice.', () => {
+		const config = configureMiddleware( Object.create( null ), Object.create( null ) );
+		addHandlers( 'my-extension', {}, config );
 
-		const willThrow = () => {
-			addHandlers( 'my-extension', {}, extensionHandlers1 );
-		};
+		expect( addHandlers( 'my-extension', {}, config ) ).to.eql( false );
+	} );
 
-		expect( willThrow ).to.throw( Error );
+	it( 'should return false when trying to remove handlers for the same extension twice.', () => {
+		const config = configureMiddleware( Object.create( null ), Object.create( null ) );
+		addHandlers( 'my-extension', {}, config );
+
+		expect( removeHandlers( 'my-extension', config ) ).to.eql( true );
+		expect( removeHandlers( 'my-extension', config ) ).to.eql( false );
 	} );
 } );
 

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -149,6 +149,7 @@ export function createReduxStore( initialState = {} ) {
 		isBrowser && require( './analytics/middleware.js' ).analyticsMiddleware,
 		require( './data-layer/wpcom-api-middleware.js' ).default,
 		isBrowser && require( './lib/middleware.js' ).default,
+		isBrowser && require( './data-layer/extensions-middleware.js' ).default,
 		isAudioSupported && require( './audio/middleware.js' ).default,
 		isBrowser && config.isEnabled( 'automated-transfer' ) && require( './automated-transfer/middleware.js' ).default,
 	].filter( Boolean );


### PR DESCRIPTION
**NOTICE: I intend to merge this PR Monday, May 1st.**

This adds a data-layer that can be used by extensions where they may add
or remove handlers dynamically. This allows them to control when they
apply such handlers and get out of the way when they're not needed.

To test:
1. Run `make test` as normal, or `npm run test-client client/state/data-layer/test/extensions-middleware.js`