### PR TITLE
Notices: Add hidden overflow to dismiss button

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -44,6 +44,7 @@
 
 		.notice__dismiss {
 			color: $white;
+			overflow: hidden;
 		}
 	}
 }


### PR DESCRIPTION
The dismiss button has screenreader text that overflows. Since we've never had full width notices before, this hasn't caused issues because the visibility was hidden. But when publishing with the new editor, sidebar dismissed, the post-publish notice would cause a horizontal scrollbar to appear. This PR fixes that, and as such, fixes #12778.

Screenshot:

![screen shot 2017-04-05 at 10 17 22](https://cloud.githubusercontent.com/assets/1204802/24696320/5f308496-19e9-11e7-883b-5faac5775114.png)
