### PR TITLE
Site Settings: Introduce AMP card for Jetpack sites

### DIFF
--- a/client/my-sites/site-settings/amp/jetpack.jsx
+++ b/client/my-sites/site-settings/amp/jetpack.jsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+import SectionHeader from 'components/section-header';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+
+const AmpJetpack = ( {
+	siteSlug,
+	translate
+} ) => {
+	return (
+		<div>
+			<SectionHeader label={ translate( 'Accelerated Mobile Pages (AMP)' ) } />
+
+			<CompactCard>
+				<p>
+					{ translate(
+						'AMP enables the creation of websites and ads that load near instantly, ' +
+						'giving site visitors a smooth, more engaging experience on mobile and desktop.'
+					) }
+				</p>
+			</CompactCard>
+
+			<CompactCard href={ '/plugins/amp/' + siteSlug }>
+				{ translate( 'Install the AMP plugin' ) }
+			</CompactCard>
+		</div>
+	);
+};
+
+export default connect(
+	( state ) => ( {
+		siteSlug: getSelectedSiteSlug( state ),
+	} )
+)( localize( AmpJetpack ) );

--- a/client/my-sites/site-settings/amp/jetpack.jsx
+++ b/client/my-sites/site-settings/amp/jetpack.jsx
@@ -10,14 +10,34 @@ import { connect } from 'react-redux';
  */
 import CompactCard from 'components/card/compact';
 import SectionHeader from 'components/section-header';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
+import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
+import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { getPluginOnSite } from 'state/plugins/installed/selectors';
 
 const AmpJetpack = ( {
+	ampPluginInstalled,
+	site,
+	siteId,
 	siteSlug,
 	translate
 } ) => {
+	let linkUrl, linkText;
+	if ( ampPluginInstalled && ampPluginInstalled.active ) {
+		linkUrl = site.URL + '/wp-admin/customize.php?autofocus%5Bpanel%5D=amp_panel&customize_amp=1';
+		linkText = translate( 'Edit the design of your Accelerated Mobile Pages' );
+	} else {
+		linkUrl = '/plugins/amp/' + siteSlug;
+		if ( ampPluginInstalled ) {
+			linkText = translate( 'Activate the AMP plugin' );
+		} else {
+			linkText = translate( 'Install the AMP plugin' );
+		}
+	}
+
 	return (
 		<div className="amp__jetpack">
+			{ siteId && <QueryJetpackPlugins siteIds={ [ siteId ] } /> }
+
 			<SectionHeader label={ translate( 'Accelerated Mobile Pages (AMP)' ) } />
 
 			<CompactCard>
@@ -29,15 +49,22 @@ const AmpJetpack = ( {
 				</p>
 			</CompactCard>
 
-			<CompactCard href={ '/plugins/amp/' + siteSlug }>
-				{ translate( 'Install the AMP plugin' ) }
+			<CompactCard href={ linkUrl }>
+				{ linkText }
 			</CompactCard>
 		</div>
 	);
 };
 
 export default connect(
-	( state ) => ( {
-		siteSlug: getSelectedSiteSlug( state ),
-	} )
+	( state ) => {
+		const site = getSelectedSite( state );
+
+		return {
+			site,
+			siteId: getSelectedSiteId( state ),
+			ampPluginInstalled: getPluginOnSite( state, site, 'amp' ),
+			siteSlug: getSelectedSiteSlug( state ),
+		};
+	}
 )( localize( AmpJetpack ) );

--- a/client/my-sites/site-settings/amp/jetpack.jsx
+++ b/client/my-sites/site-settings/amp/jetpack.jsx
@@ -12,10 +12,11 @@ import CompactCard from 'components/card/compact';
 import SectionHeader from 'components/section-header';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { getPluginOnSite } from 'state/plugins/installed/selectors';
+import { isRequesting, getPluginOnSite } from 'state/plugins/installed/selectors';
 
 const AmpJetpack = ( {
 	ampPluginInstalled,
+	requestingPlugins,
 	site,
 	siteId,
 	siteSlug,
@@ -49,9 +50,12 @@ const AmpJetpack = ( {
 				</p>
 			</CompactCard>
 
-			<CompactCard href={ linkUrl }>
-				{ linkText }
-			</CompactCard>
+			{
+				! requestingPlugins &&
+				<CompactCard href={ linkUrl }>
+					{ linkText }
+				</CompactCard>
+			}
 		</div>
 	);
 };
@@ -59,11 +63,13 @@ const AmpJetpack = ( {
 export default connect(
 	( state ) => {
 		const site = getSelectedSite( state );
+		const siteId = getSelectedSiteId( state );
 
 		return {
 			site,
-			siteId: getSelectedSiteId( state ),
+			siteId,
 			ampPluginInstalled: getPluginOnSite( state, site, 'amp' ),
+			requestingPlugins: isRequesting( state, siteId ),
 			siteSlug: getSelectedSiteSlug( state ),
 		};
 	}

--- a/client/my-sites/site-settings/amp/jetpack.jsx
+++ b/client/my-sites/site-settings/amp/jetpack.jsx
@@ -17,7 +17,7 @@ const AmpJetpack = ( {
 	translate
 } ) => {
 	return (
-		<div>
+		<div className="amp__jetpack">
 			<SectionHeader label={ translate( 'Accelerated Mobile Pages (AMP)' ) } />
 
 			<CompactCard>

--- a/client/my-sites/site-settings/amp/style.scss
+++ b/client/my-sites/site-settings/amp/style.scss
@@ -7,3 +7,7 @@
 		}
 	}
 }
+
+.amp__jetpack {
+	margin-bottom: 16px;
+}

--- a/client/my-sites/site-settings/traffic/main.jsx
+++ b/client/my-sites/site-settings/traffic/main.jsx
@@ -18,6 +18,7 @@ import SeoSettingsHelpCard from 'my-sites/site-settings/seo-settings/help';
 import AnalyticsSettings from 'my-sites/site-settings/form-analytics';
 import JetpackSiteStats from 'my-sites/site-settings/jetpack-site-stats';
 import RelatedPosts from 'my-sites/site-settings/related-posts';
+import AmpJetpack from 'my-sites/site-settings/amp/jetpack';
 import AmpWpcom from 'my-sites/site-settings/amp/wpcom';
 import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
@@ -61,9 +62,9 @@ const SiteSettingsTraffic = ( {
 			isRequestingSettings={ isRequestingSettings }
 			fields={ fields }
 		/>
-		{
-			! isJetpack &&
-			<AmpWpcom
+		{ isJetpack
+			? <AmpJetpack />
+			: <AmpWpcom
 				submitForm={ submitForm }
 				trackEvent={ trackEvent }
 				updateFields={ updateFields }


### PR DESCRIPTION
This PR introduces a simple AMP card for Jetpack sites. Fixes #12367.

Preview:
![](https://cldup.com/J4iKDjnj3X.png)

To test:
* Checkout this branch or get it going on calypso.live.
* Go to `/settings/traffic/$site` where `$site` is a Jetpack site.
* Verify the card appears as shown on the preview.
* Verify the card does not appear on a WP.com site, and the WP.com AMP card is shown there instead.

