### PR TITLE
Add border highlight on hover to SitesDropdown

### DIFF
--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -24,9 +24,14 @@
 	margin: 0;
 	position: relative;
 	width: 300px;
+	transition: all .15s ease-in-out;
 
 	@include breakpoint( "<660px" ) {
 		width: 100%;
+	}
+
+	&:hover {
+		border-color: lighten( $gray, 10% );
 	}
 }
 


### PR DESCRIPTION
The `SitesDropdown` border should be highlighted the same way as
any other `<input>` element. Added the needed CSS styles.

Discovered when working on new language picker (#12544) - see the [comment](https://github.com/Automattic/wp-calypso/pull/12544#issuecomment-291231983) by @folletto.

Maybe the search box in the sites dropdown should have a focus ring, too.
