### PR TITLE
Use null component for Popover SSR

### DIFF
--- a/client/components/null-component/README.md
+++ b/client/components/null-component/README.md
@@ -1,0 +1,15 @@
+EmptyComponent
+==============
+
+Useful for stubbing out components that will not build on the server when rendering server-side.
+
+#### How to use:
+
+In the webpack server [config file](/webpack.config.node.js):
+```js
+plugins: [
+  ...
+	new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/thanks-modal$/, 'components/empty-component' ) // Depends on BOM
+],
+```
+In the above example, on the server build, any occurrences of `/my-sites/themes/thanks-modal` will be replaced with the empty component.

--- a/client/components/null-component/README.md
+++ b/client/components/null-component/README.md
@@ -1,4 +1,4 @@
-EmptyComponent
+NullComponent
 ==============
 
 Useful for stubbing out components that will not build on the server when rendering server-side.
@@ -9,7 +9,7 @@ In the webpack server [config file](/webpack.config.node.js):
 ```js
 plugins: [
   ...
-	new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/thanks-modal$/, 'components/empty-component' ) // Depends on BOM
+	new webpack.NormalModuleReplacementPlugin( /^components\/popover$/, 'components/null-component' )
 ],
 ```
-In the above example, on the server build, any occurrences of `/my-sites/themes/thanks-modal` will be replaced with the empty component.
+In the above example, on the server build, any occurrences of `/client/components/popover` will be replaced with the react generated string comment indicating that nothing was rendered.

--- a/client/components/null-component/index.jsx
+++ b/client/components/null-component/index.jsx
@@ -1,0 +1,6 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export default () => null;

--- a/client/components/null-component/index.jsx
+++ b/client/components/null-component/index.jsx
@@ -1,6 +1,1 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
 export default () => null;

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -110,7 +110,7 @@ var webpackConfig = {
 		new webpack.NormalModuleReplacementPlugin( /^lib\/post-normalizer\/rule-create-better-excerpt$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^components\/seo\/preview-upgrade-nudge$/, 'components/empty-component' ), // Depends on page.js and should never be required server side
 		new webpack.NormalModuleReplacementPlugin( /^components\/seo\/reader-preview$/, 'components/empty-component' ), // Conflicts with component-closest module
-		new webpack.NormalModuleReplacementPlugin( /^components\/popover$/, 'components/empty-component' ), // Depends on BOM and interactions don't work without JS
+		new webpack.NormalModuleReplacementPlugin( /^components\/popover$/, 'components/null-component' ), // Depends on BOM and interactions don't work without JS
 		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/themes-site-selector-modal$/, 'components/empty-component' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/theme-upload$/, 'components/empty-component' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/single-site$/, 'components/empty-component' ), // Depends on DOM


### PR DESCRIPTION
### Info 
Some of components are not SSR compatible like for example Popover. On server it is rendered with `empty-component` component which is an actual `div`. On client side Popover is either closed or opened
on initial render. For opened case there is nothing that we can do to aid react reconciliation. For the initially closed Popover - which is the majority of cases client side `render()` returns `null` which is turned into comment by React. This results in reconciliation error of empty `div` versus react generated comment. 
This PR addresses this issue by adding new `null-component` that will be rendered as comment also on server.

After the #12785 and this PR Themes showcase should not have any other reconciliation errors - at least in logged out. This would mean that Showcase would be starting faster especially on low power devices.

This will be merged after #12785 because errors seen there hide reconciliation errors fixed here.

### Testing
Go to the `/design` logged-out and observe co sole. There should not be any reconciliation errors.
( after 12785 )

I hope that all other usage of `Popover` is unaffected.