### PR TITLE
Framework: Update my-sites/upgrades/map-domain to use the sites redux store

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -16,6 +16,7 @@ import DomainRegistrationSuggestion from 'components/domains/domain-registration
 import DomainProductPrice from 'components/domains/domain-product-price';
 import analyticsMixin from 'lib/mixins/analytics';
 import { getCurrentUser } from 'state/current-user/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 import Notice from 'components/notice';
 
 const MapDomainStep = React.createClass( {
@@ -188,4 +189,9 @@ const MapDomainStep = React.createClass( {
 	},
 } );
 
-module.exports = connect( state => ( { currentUser: getCurrentUser( state ) } ) )( localize( MapDomainStep ) );
+module.exports = connect( state => (
+	{
+		currentUser: getCurrentUser( state ),
+		selectedSite: getSelectedSite( state ),
+	}
+) )( localize( MapDomainStep ) );

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -15,6 +15,7 @@ import analytics from 'lib/analytics';
 import sitesFactory from 'lib/sites-list';
 import route from 'lib/route';
 import Main from 'components/main';
+import MapDomain from 'my-sites/upgrades/map-domain';
 import upgradesActions from 'lib/upgrades/actions';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { setSection } from 'state/ui/actions';
@@ -103,7 +104,6 @@ module.exports = {
 
 	mapDomain: function( context ) {
 		var CartData = require( 'components/data/cart' ),
-			MapDomain = require( 'my-sites/upgrades/map-domain' ),
 			basePath = route.sectionify( context.path );
 
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -117,8 +117,7 @@ module.exports = {
 						<MapDomain
 							store={ context.store }
 							productsList={ productsList }
-							initialQuery={ context.query.initialQuery }
-							sites={ sites } />
+							initialQuery={ context.query.initialQuery } />
 					</CartData>
 				</Main>
 			),

--- a/client/my-sites/upgrades/map-domain/index.jsx
+++ b/client/my-sites/upgrades/map-domain/index.jsx
@@ -17,6 +17,7 @@ var HeaderCake = require( 'components/header-cake' ),
 	observe = require( 'lib/mixins/data-observe' ),
 	wpcom = require( 'lib/wp' ).undocumented(),
 	paths = require( 'my-sites/upgrades/paths' );
+import { localize } from 'i18n-calypso';
 import { currentUserHasFlag } from 'state/current-user/selectors';
 import { isSiteUpgradeable, isSiteVip } from 'state/selectors';
 import { getRawSite } from 'state/sites/selectors';
@@ -103,7 +104,7 @@ var MapDomain = React.createClass( {
 		return (
 			<span>
 				<HeaderCake onClick={ this.goBack }>
-					{ this.translate( 'Map a Domain' ) }
+					{ this.props.translate( 'Map a Domain' ) }
 				</HeaderCake>
 
 				{ this.state.errorMessage && <Notice status="is-error" text={ this.state.errorMessage }/> }
@@ -129,4 +130,4 @@ module.exports = connect( state => (
 		selectedSiteIsVip: isSiteVip( state, getSelectedSiteId( state ) ),
 		selectedSiteSlug: getSelectedSiteSlug( state ),
 	}
-) )( MapDomain );
+) )( localize( MapDomain ) );

--- a/client/my-sites/upgrades/map-domain/index.jsx
+++ b/client/my-sites/upgrades/map-domain/index.jsx
@@ -24,7 +24,7 @@ import { getRawSite } from 'state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import Notice from 'components/notice';
 
-var MapDomain = React.createClass( {
+export const MapDomain = React.createClass( {
 	mixins: [ observe( 'productsList' ) ],
 
 	propTypes: {
@@ -121,7 +121,7 @@ var MapDomain = React.createClass( {
 	}
 } );
 
-module.exports = connect( state => (
+export default connect( state => (
 	{
 		domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
 		noSelectedSite: ! getRawSite( state, getSelectedSiteId( state ) ),

--- a/client/my-sites/upgrades/map-domain/index.jsx
+++ b/client/my-sites/upgrades/map-domain/index.jsx
@@ -18,10 +18,13 @@ var HeaderCake = require( 'components/header-cake' ),
 	wpcom = require( 'lib/wp' ).undocumented(),
 	paths = require( 'my-sites/upgrades/paths' );
 import { currentUserHasFlag } from 'state/current-user/selectors';
+import { isSiteUpgradeable, isSiteVip } from 'state/selectors';
+import { getRawSite } from 'state/sites/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import Notice from 'components/notice';
 
 var MapDomain = React.createClass( {
-	mixins: [ observe( 'productsList', 'sites' ) ],
+	mixins: [ observe( 'productsList' ) ],
 
 	propTypes: {
 		query: React.PropTypes.string,
@@ -36,46 +39,31 @@ var MapDomain = React.createClass( {
 	},
 
 	componentWillMount: function() {
-		this.checkSiteIsUpgradeable();
+		this.redirectAwayIfNotUpgradeable( this.props.selectedSiteIsUpgreadable );
 	},
 
-	componentDidMount: function() {
-		if ( this.props.sites ) {
-			this.props.sites.on( 'change', this.checkSiteIsUpgradeable );
-		}
+	componentWillReceiveProps: function( nextProps ) {
+		this.redirectAwayIfNotUpgradeable( nextProps.selectedSiteIsUpgreadable );
 	},
 
-	componentWillUnmount: function() {
-		if ( this.props.sites ) {
-			this.props.sites.off( 'change', this.checkSiteIsUpgradeable );
-		}
-	},
-
-	checkSiteIsUpgradeable: function( ) {
-		if ( ! this.props.sites ) {
-			return;
-		}
-
-		const selectedSite = this.props.sites.getSelectedSite();
-
-		if ( selectedSite && ! selectedSite.isUpgradeable() ) {
+	redirectAwayIfNotUpgradeable: function( isUpgradeable ) {
+		if ( ! isUpgradeable ) {
 			page.redirect( '/domains/add/mapping' );
 		}
 	},
 
 	goBack: function() {
-		const selectedSite = this.props.sites && this.props.sites.getSelectedSite();
-		if ( ! selectedSite ) {
-			page( this.props.path.replace( '/mapping', '' ) );
+		if ( this.props.noSelectedSite ) {
+			page( '/domains/add' );
 			return;
 		}
 
-		if ( selectedSite.is_vip ) {
-			page( paths.domainManagementList( selectedSite.slug ) );
+		if ( this.props.selectedSiteIsVip ) {
+			page( paths.domainManagementList( this.props.selectedSiteSlug ) );
 			return;
 		}
 
-		page( '/domains/add/' + selectedSite.slug );
+		page( '/domains/add/' + this.props.selectedSiteSlug );
 	},
 
 	handleRegisterDomain( suggestion ) {
@@ -87,21 +75,19 @@ var MapDomain = React.createClass( {
 		);
 
 		if ( this.isMounted() ) {
-			page( '/checkout/' + this.props.sites.getSelectedSite().slug );
+			page( '/checkout/' + this.props.selectedSiteSlug );
 		}
 	},
 
 	handleMapDomain( domain ) {
-		const selectedSite = this.props.sites.getSelectedSite();
-
 		this.setState( { errorMessage: null } );
 
 		// For VIP sites we handle domain mappings differently
 		// We don't go through the usual checkout process
 		// Instead, we add the mapping directly
-		if ( selectedSite.is_vip ) {
-			wpcom.addVipDomainMapping( selectedSite.ID, domain ).then( () => {
-				page( paths.domainManagementList( selectedSite.slug ) );
+		if ( this.props.selectedSiteIsVip ) {
+			wpcom.addVipDomainMapping( this.props.selectedSiteId, domain ).then( () => {
+				page( paths.domainManagementList( this.props.selectedSiteSlug ) );
 			}, error => this.setState( { errorMessage: error.message } ) );
 			return;
 		}
@@ -109,17 +95,11 @@ var MapDomain = React.createClass( {
 		upgradesActions.addItem( cartItems.domainMapping( { domain } ) );
 
 		if ( this.isMounted() ) {
-			page( '/checkout/' + selectedSite.slug );
+			page( '/checkout/' + this.props.selectedSiteSlug );
 		}
 	},
 
 	render: function() {
-		let selectedSite;
-
-		if ( this.props.sites ) {
-			selectedSite = this.props.sites.getSelectedSite();
-		}
-
 		return (
 			<span>
 				<HeaderCake onClick={ this.goBack }>
@@ -129,9 +109,8 @@ var MapDomain = React.createClass( {
 				{ this.state.errorMessage && <Notice status="is-error" text={ this.state.errorMessage }/> }
 
 				<MapDomainStep
-					{ ...omit( this.props, [ 'children', 'productsList', 'sites' ] ) }
+					{ ...omit( this.props, [ 'children', 'productsList' ] ) }
 					products={ this.props.productsList.get() }
-					selectedSite={ selectedSite }
 					onRegisterDomain={ this.handleRegisterDomain }
 					onMapDomain={ this.handleMapDomain }
 					analyticsSection="domains"
@@ -143,6 +122,11 @@ var MapDomain = React.createClass( {
 
 module.exports = connect( state => (
 	{
-		domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY )
+		domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
+		noSelectedSite: ! getRawSite( state, getSelectedSiteId( state ) ),
+		selectedSiteId: getSelectedSiteId( state ),
+		selectedSiteIsUpgreadable: isSiteUpgradeable( state, getSelectedSiteId( state ) ),
+		selectedSiteIsVip: isSiteVip( state, getSelectedSiteId( state ) ),
+		selectedSiteSlug: getSelectedSiteSlug( state ),
 	}
 ) )( MapDomain );

--- a/client/my-sites/upgrades/map-domain/index.jsx
+++ b/client/my-sites/upgrades/map-domain/index.jsx
@@ -40,11 +40,11 @@ export const MapDomain = React.createClass( {
 	},
 
 	componentWillMount: function() {
-		this.redirectAwayIfNotUpgradeable( this.props.selectedSiteIsUpgreadable );
+		this.redirectAwayIfNotUpgradeable( this.props.selectedSiteIsUpgradeable );
 	},
 
 	componentWillReceiveProps: function( nextProps ) {
-		this.redirectAwayIfNotUpgradeable( nextProps.selectedSiteIsUpgreadable );
+		this.redirectAwayIfNotUpgradeable( nextProps.selectedSiteIsUpgradeable );
 	},
 
 	redirectAwayIfNotUpgradeable: function( isUpgradeable ) {
@@ -126,7 +126,7 @@ export default connect( state => (
 		domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
 		noSelectedSite: ! getRawSite( state, getSelectedSiteId( state ) ),
 		selectedSiteId: getSelectedSiteId( state ),
-		selectedSiteIsUpgreadable: isSiteUpgradeable( state, getSelectedSiteId( state ) ),
+		selectedSiteIsUpgradeable: isSiteUpgradeable( state, getSelectedSiteId( state ) ),
 		selectedSiteIsVip: isSiteVip( state, getSelectedSiteId( state ) ),
 		selectedSiteSlug: getSelectedSiteSlug( state ),
 	}

--- a/client/my-sites/upgrades/map-domain/index.jsx
+++ b/client/my-sites/upgrades/map-domain/index.jsx
@@ -24,6 +24,8 @@ import { getRawSite } from 'state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import Notice from 'components/notice';
 
+// Disable ES6 class rule until we switch the mixin to just using redux for products
+// eslint-disable-next-line react/prefer-es6-class
 export const MapDomain = React.createClass( {
 	mixins: [ observe( 'productsList' ) ],
 

--- a/client/my-sites/upgrades/map-domain/test/map-domain.js
+++ b/client/my-sites/upgrades/map-domain/test/map-domain.js
@@ -1,0 +1,66 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { spy } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+import useMockery from 'test/helpers/use-mockery';
+
+describe( 'MapDomain component', () => {
+	const pageSpy = spy();
+	pageSpy.redirect = spy();
+	let MapDomain, MapDomainStep;
+
+	useFakeDom();
+
+	useMockery( ( mockery ) => {
+		mockery.registerMock( 'page', pageSpy );
+		MapDomain = require( '../' ).MapDomain;
+		MapDomainStep = require( 'components/domains/map-domain-step' );
+	} );
+
+	beforeEach( () => {
+		pageSpy.reset();
+		pageSpy.redirect.reset();
+	} );
+
+	const defaultProps = {
+		productsList: { get: () => {} },
+		domainsWithPlansOnly: false,
+		translate: () => '',
+		selectedSiteIsUpgradeable: true,
+	};
+
+	it( 'does not blow up with default props', () => {
+		const wrapper = shallow( <MapDomain { ...defaultProps } /> );
+		expect( wrapper.length ).to.eql( 1 );
+	} );
+
+	it( 'redirects if site cannot be upgraded at mounting', () => {
+		shallow( <MapDomain { ...defaultProps } selectedSiteIsUpgradeable={ false } /> );
+		expect( pageSpy.redirect ).to.have.been.calledWith( '/domains/add/mapping' );
+	} );
+
+	it( 'redirects if site cannot be upgraded at new props', () => {
+		const wrapper = shallow( <MapDomain selectedSiteIsUpgradeable={ true } { ...defaultProps } /> );
+		wrapper.setProps( { selectedSiteIsUpgradeable: false } );
+		expect( pageSpy.redirect ).to.have.been.calledWith( '/domains/add/mapping' );
+	} );
+
+	it( 'redirects if site cannot be upgraded at new props', () => {
+		const wrapper = shallow( <MapDomain selectedSiteIsUpgradeable={ true } { ...defaultProps } /> );
+		wrapper.setProps( { selectedSiteIsUpgradeable: false } );
+		expect( pageSpy.redirect ).to.have.been.calledWith( '/domains/add/mapping' );
+	} );
+
+	it( 'renders a MapDomainStep', () => {
+		const wrapper = shallow( <MapDomain { ...defaultProps } /> );
+		expect( wrapper.find( MapDomainStep ) ).to.have.length( 1 );
+	} );
+} );

--- a/client/my-sites/upgrades/map-domain/test/map-domain.js
+++ b/client/my-sites/upgrades/map-domain/test/map-domain.js
@@ -11,6 +11,7 @@ import { spy } from 'sinon';
  */
 import useFakeDom from 'test/helpers/use-fake-dom';
 import useMockery from 'test/helpers/use-mockery';
+import mockDataPoller from 'test/helpers/mocks/data-poller';
 import paths from 'my-sites/upgrades/paths';
 
 describe( 'MapDomain component', () => {
@@ -22,6 +23,9 @@ describe( 'MapDomain component', () => {
 	useFakeDom();
 
 	useMockery( ( mockery ) => {
+		// some deeper dependency was loading sites-lists, which triggers the data poller
+		// and tests were hanging forever
+		mockDataPoller( mockery );
 		mockery.registerMock( 'page', pageSpy );
 		MapDomain = require( '../' ).MapDomain;
 		MapDomainStep = require( 'components/domains/map-domain-step' );

--- a/client/my-sites/upgrades/map-domain/test/map-domain.js
+++ b/client/my-sites/upgrades/map-domain/test/map-domain.js
@@ -17,6 +17,7 @@ describe( 'MapDomain component', () => {
 	pageSpy.redirect = spy();
 	let MapDomain, MapDomainStep;
 
+	// needed, because some dependency of dependency uses `window`
 	useFakeDom();
 
 	useMockery( ( mockery ) => {

--- a/client/my-sites/upgrades/map-domain/test/map-domain.js
+++ b/client/my-sites/upgrades/map-domain/test/map-domain.js
@@ -39,7 +39,7 @@ describe( 'MapDomain component', () => {
 
 	it( 'does not blow up with default props', () => {
 		const wrapper = shallow( <MapDomain { ...defaultProps } /> );
-		expect( wrapper.length ).to.eql( 1 );
+		expect( wrapper ).to.have.length( 1 );
 	} );
 
 	it( 'redirects if site cannot be upgraded at mounting', () => {

--- a/client/my-sites/upgrades/map-domain/test/map-domain.js
+++ b/client/my-sites/upgrades/map-domain/test/map-domain.js
@@ -11,11 +11,12 @@ import { spy } from 'sinon';
  */
 import useFakeDom from 'test/helpers/use-fake-dom';
 import useMockery from 'test/helpers/use-mockery';
+import paths from 'my-sites/upgrades/paths';
 
 describe( 'MapDomain component', () => {
 	const pageSpy = spy();
 	pageSpy.redirect = spy();
-	let MapDomain, MapDomainStep;
+	let MapDomain, MapDomainStep, HeaderCake;
 
 	// needed, because some dependency of dependency uses `window`
 	useFakeDom();
@@ -24,6 +25,7 @@ describe( 'MapDomain component', () => {
 		mockery.registerMock( 'page', pageSpy );
 		MapDomain = require( '../' ).MapDomain;
 		MapDomainStep = require( 'components/domains/map-domain-step' );
+		HeaderCake = require( 'components/header-cake' );
 	} );
 
 	beforeEach( () => {
@@ -63,5 +65,41 @@ describe( 'MapDomain component', () => {
 	it( 'renders a MapDomainStep', () => {
 		const wrapper = shallow( <MapDomain { ...defaultProps } /> );
 		expect( wrapper.find( MapDomainStep ) ).to.have.length( 1 );
+	} );
+
+	it( "goes back when HeaderCake's onClick is fired", () => {
+		const wrapper = shallow( <MapDomain { ...defaultProps } /> );
+		expect( wrapper.find( HeaderCake ).prop( 'onClick' ) ).to.equal( wrapper.instance().goBack );
+	} );
+
+	it( 'goes back to /domains/add if no selected site', () => {
+		const wrapper = shallow( <MapDomain noSelectedSite={ true } { ...defaultProps } /> );
+		wrapper.instance().goBack();
+		expect( pageSpy ).to.have.been.calledWith( '/domains/add' );
+	} );
+
+	it( 'goes back to domain management for VIP sites', () => {
+		const wrapper = shallow( <MapDomain selectedSiteIsVip={ true } selectedSiteSlug="baba" { ...defaultProps } /> );
+		wrapper.instance().goBack();
+		expect( pageSpy ).to.have.been.calledWith( paths.domainManagementList( 'baba' ) );
+	} );
+
+	it( 'goes back to domain add page if non-VIP site', () => {
+		const wrapper = shallow( <MapDomain selectedSiteSlug="baba" { ...defaultProps } /> );
+		wrapper.instance().goBack();
+		expect( pageSpy ).to.have.been.calledWith( '/domains/add/baba' );
+	} );
+
+	it( 'does not render a notice by default', () => {
+		const wrapper = shallow( <MapDomain { ...defaultProps } /> );
+		// we match the notice by props, because enzyme isn't matching the Notice type for some reason
+		expect( wrapper.find( { status: 'is-error' } ) ).to.have.length( 0 );
+	} );
+
+	it( 'render a notice by when there is an errorMessage in the state ', () => {
+		const wrapper = shallow( <MapDomain { ...defaultProps } /> );
+		// we match the notice by props, because enzyme isn't matching the Notice type for some reason
+		wrapper.setState( { errorMessage: 'baba' } );
+		expect( wrapper.find( { status: 'is-error' } ) ).to.have.length( 1 );
 	} );
 } );

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -120,6 +120,7 @@ export isSiteBlocked from './is-site-blocked';
 export isSiteOnFreePlan from './is-site-on-free-plan';
 export isSiteSupportingImageEditor from './is-site-supporting-image-editor';
 export isSiteUpgradeable from './is-site-upgradeable';
+export isSiteVip from './is-site-vip';
 export isTransientMedia from './is-transient-media';
 export isUpdatingJetpackSettings from './is-updating-jetpack-settings';
 export isUserRegistrationDaysWithinRange from './is-user-registration-days-within-range';

--- a/client/state/selectors/is-site-vip.js
+++ b/client/state/selectors/is-site-vip.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { getRawSite } from 'state/sites/selectors';
+
+/**
+ * Returns true if the site is VIP
+ *
+ * If the site is missing returns null.
+ *
+ * @param  {Object}   state  Global state tree
+ * @param  {Number}   siteId Site ID
+ * @return {?Boolean}        Whether site is VIP
+ */
+export default function( state, siteId ) {
+	const site = getRawSite( state, siteId );
+	if ( ! site || typeof site.is_vip === 'undefined' ) {
+		return null;
+	}
+
+	return site.is_vip;
+}

--- a/client/state/selectors/test/is-site-vip.js
+++ b/client/state/selectors/test/is-site-vip.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isSiteVip } from '../';
+
+describe( 'isSiteVip()', () => {
+	it( 'returns null if site does not exist', () => {
+		const isVip = isSiteVip( { sites: { items: { 5: { is_vip: true } } } }, 99999 );
+		expect( isVip ).to.be.null;
+	} );
+
+	it( 'returns true if is_vip property of the site is true', () => {
+		const isVip = isSiteVip( { sites: { items: { 5: { is_vip: true } } } }, 5 );
+		expect( isVip ).to.be.true;
+	} );
+
+	it( 'returns false if is_vip property of the site is false', () => {
+		const isVip = isSiteVip( { sites: { items: { 5: { is_vip: false } } } }, 5 );
+		expect( isVip ).to.be.false;
+	} );
+
+	it( 'returns false if is_vip property of the site does not exist', () => {
+		const isVip = isSiteVip( { sites: { items: { 5: {} } } }, 5 );
+		expect( isVip ).to.be.null;
+	} );
+} );


### PR DESCRIPTION
This PR removes `sites-list` as a dependency from the `MapDomain` component. See #8726.

No major design decisions. Implementation details are in the commit messages.

Testing:

* I mostly tested via manually changing the prop values and seeing if the component behaved correctly.
* Also tested by visiting `/domains/add/mapping` and mapped a domain – it worked :)

TODO:

* [ ] Add tests for the component.
* [ ] Test with a real VIP site.
* [ ] Quickly follow up with a cleanup PR: ES6, propTypes, `isMounted`, redirecting inside the component, selector to check whether a site is in the state…