### PR TITLE
Themes: Move Redirects from server/pages to Corresponding Sections

### DIFF
--- a/client/my-sites/theme/index.node.js
+++ b/client/my-sites/theme/index.node.js
@@ -7,6 +7,7 @@ import { details, fetchThemeDetailsData, notFoundError } from './controller';
 
 export default function( router ) {
 	if ( config.isEnabled( 'manage/themes/details' ) ) {
+		router( '/theme', ( { res } ) => res.redirect( '/themes' ) );
 		router( '/theme/:slug/:section(setup|support)?/:site_id?', fetchThemeDetailsData, details, makeLayout );
 		router( notFoundError );
 	}

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -20,6 +20,11 @@ export default function( router ) {
 	const verticals = getSubjects().join( '|' );
 
 	if ( config.isEnabled( 'manage/themes' ) ) {
+		// Redirect interim showcase route to permanent one
+		router( [ '/design', '/design/*' ], ( { originalUrl, res } ) => {
+			res.redirect( 301, '/themes' + originalUrl.slice( '/design'.length ) );
+		} );
+
 		router( `/themes/:vertical(${ verticals })?/:tier(free|premium)?`, fetchThemeData, loggedOut, makeLayout );
 		router(
 			`/themes/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`,

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -154,7 +154,7 @@ const sections = [
 	// or it'll be falsely associated with the latter section.
 	{
 		name: 'themes',
-		paths: [ '/themes' ],
+		paths: [ '/themes', '/design' ],
 		module: 'my-sites/themes',
 		enableLoggedOut: true,
 		secondary: true,

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -49,6 +49,7 @@ function getEnhancedContext( req, res ) {
 	return Object.assign( {}, req.context, {
 		isLoggedIn: req.cookies.wordpress_logged_in,
 		isServerSide: true,
+		originalUrl: req.originalUrl,
 		path: req.url,
 		pathname: req.path,
 		params: req.params,

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -84,7 +84,7 @@ function generateStaticUrls( request ) {
 	const assets = request.app.get( 'assets' );
 
 	assets.forEach( function( asset ) {
-		let name = asset.name;
+		const name = asset.name;
 		urls[ name ] = asset.url;
 		if ( config( 'env' ) !== 'development' ) {
 			urls[ name + '-min' ] = asset.url.replace( '.js', '.m.js' );

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -337,12 +337,6 @@ module.exports = function() {
 		} );
 	}
 
-	app.get( '/theme', ( req, res ) => res.redirect( '/themes' ) );
-	// Interim redirect before this is handled on server route config level
-	app.get( [ '/design', '/design/*' ], ( req, res ) => {
-		res.redirect( 301, '/themes' + req.originalUrl.slice( '/design'.length ) );
-	} );
-
 	sections
 		.filter( section => ! section.envId || section.envId.indexOf( config( 'env_id' ) ) > -1 )
 		.forEach( section => {


### PR DESCRIPTION
To avoid cluttering `/server/pages` with section-specific stuff. Also updates a comment to better reflect what we think is happening 😄 

To test: Make sure landing on those various routes still works.