### PR TITLE
Site Settings: Hide SEO help text if SEO feature is not available

### DIFF
--- a/client/my-sites/site-settings/seo-settings/help.jsx
+++ b/client/my-sites/site-settings/seo-settings/help.jsx
@@ -26,7 +26,7 @@ const SeoSettingsHelpCard = ( {
 
 	return (
 		<div>
-			<SectionHeader label={ translate( 'Search Engine Optimization' ) } />
+			<SectionHeader label={ translate( 'Search engine optimization' ) } />
 			{
 				hasFeature( FEATURE_ADVANCED_SEO, siteId ) &&
 				<Card>

--- a/client/my-sites/site-settings/seo-settings/help.jsx
+++ b/client/my-sites/site-settings/seo-settings/help.jsx
@@ -10,10 +10,13 @@ import { localize } from 'i18n-calypso';
  */
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
+import { hasFeature } from 'lib/plans';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { FEATURE_ADVANCED_SEO } from 'lib/plans/constants';
 
 const SeoSettingsHelpCard = ( {
+	siteId,
 	siteIsJetpack,
 	translate
 } ) => {
@@ -24,22 +27,25 @@ const SeoSettingsHelpCard = ( {
 	return (
 		<div>
 			<SectionHeader label={ translate( 'Search Engine Optimization' ) } />
-			<Card>
-				<p>
-					{ translate(
-						'{{b}}WordPress.com has great SEO{{/b}} out of the box. All of our themes are optimized ' +
-						'for search engines, so you don\'t have to do anything extra. However, you can tweak ' +
-						'these settings if you\'d like more advanced control. Read more about what you can do ' +
-						'to {{a}}optimize your site\'s SEO{{/a}}.',
-						{
-							components: {
-								a: <a href={ seoHelpLink } />,
-								b: <strong />
+			{
+				hasFeature( FEATURE_ADVANCED_SEO, siteId ) &&
+				<Card>
+					<p>
+						{ translate(
+							'{{b}}WordPress.com has great SEO{{/b}} out of the box. All of our themes are optimized ' +
+							'for search engines, so you don\'t have to do anything extra. However, you can tweak ' +
+							'these settings if you\'d like more advanced control. Read more about what you can do ' +
+							'to {{a}}optimize your site\'s SEO{{/a}}.',
+							{
+								components: {
+									a: <a href={ seoHelpLink } />,
+									b: <strong />
+								}
 							}
-						}
-					) }
-				</p>
-			</Card>
+						) }
+					</p>
+				</Card>
+			}
 		</div>
 	);
 };
@@ -50,6 +56,7 @@ export default connect(
 		const siteIsJetpack = isJetpackSite( state, siteId );
 
 		return {
+			siteId,
 			siteIsJetpack,
 		};
 	}


### PR DESCRIPTION
### Purpose

This PR updates the SEO help box to hide its text if the SEO feature is not available for the current site. This helps avoid weird wording when the SEO nudge is displayed, and changes this section to be consistent with what's happening in the Jetpack plugin.

### Background

This one is discussed further in p7rd6c-KI-p2, brought up initially by @designsimply, and solution was suggested by @rickybanister.

---

### Preview - before

Prior to this change, everything was displayed for all non-business plans, which was confusing:

**Free/Personal/Premium plan - preview A:**
![](https://cldup.com/Ud0f3N1n2l.png)

---

### Preview - after

**Business or Professional plan - preview B:**
![](https://cldup.com/lrFa9SPELM.png)

**Free/Personal/Premium plan - preview C:**
![](https://cldup.com/IDkFAiPD2s.png)

---

### To test

* Checkout this branch, or get it going on calypso.live
* Go to `/settings/traffic/$site`, where `$site` is a WordPress.com site with a Business plan.
* Verify you see the SEO box with the text as shown on **preview B**.
* Go to `/settings/traffic/$site`, where `$site` is a WordPress.com site with a non-Business plan.
* Verify you see the SEO box without the text, and the upgrade nudge as shown on **preview C**.
* Go to `/settings/traffic/$site`, where `$site` is a Jetpack site with a Professional plan.
* Verify you see the SEO box with the text as shown on **preview B**.
* Go to `/settings/traffic/$site`, where `$site` is a Jetpack site with a non-Professional plan.
* Verify you see the SEO box without the text, and the upgrade nudge as shown on **preview C**.