### PR TITLE
wpcom: use current locale by default for all api requests

### DIFF
--- a/client/lib/wp/localization/README.md
+++ b/client/lib/wp/localization/README.md
@@ -1,16 +1,18 @@
 wpcom.js Localization
 =====================
 
-This module enables the extension of a `wpcom.js` instance to include localization helper functions. Specifically, the modified instance will include a new `withLocale` function, which will result in the subsequent chained request being localized according to the current user's preferred locale.
+This module enables the extension of a `wpcom.js` instance to automatically mark wpcom queries for localization. Specifically, the modified instance will add a locale query parameter to wpcom queries so that api responses are properly localized for the user.
+
+The modified instance also includes adds a `withoutLocale` method to suppress this behaviour in case that is required.
 
 ## Usage
 
-The helper is already bound for the global instance of `wpcom.js` used in Calypso. To take advantage of the localization helpers, call the `withLocale` function at the start of your request chain.
+The helper is already bound for the global instance of `wpcom.js` used in Calypso and should work automatically:
 
 ```js
 import wpcom from 'lib/wp';
 
-wpcom.withLocale().site( siteId ).postTypesList().then( ( data ) => {
+wpcom.site( siteId ).postTypesList().then( ( data ) => {
 	// `data` is a localized response
 } );
 ```

--- a/client/lib/wp/localization/README.md
+++ b/client/lib/wp/localization/README.md
@@ -3,8 +3,6 @@ wpcom.js Localization
 
 This module enables the extension of a `wpcom.js` instance to automatically mark wpcom queries for localization. Specifically, the modified instance will add a locale query parameter to wpcom queries so that api responses are properly localized for the user.
 
-The modified instance also includes adds a `withoutLocale` method to suppress this behaviour in case that is required.
-
 ## Usage
 
 The helper is already bound for the global instance of `wpcom.js` used in Calypso and should work automatically:

--- a/client/lib/wp/localization/index.js
+++ b/client/lib/wp/localization/index.js
@@ -58,22 +58,22 @@ export function addLocaleQueryParam( params ) {
  * @return {Object}       Modified WPCOM instance with localization helpers
  */
 export function injectLocalization( wpcom ) {
-	const request = wpcom.request.bind( wpcom );
+	const originalRequest = wpcom.request.bind( wpcom );
 	return Object.assign( wpcom, {
-		localize: true,
+		skipLocalizationOnce: false,
 
 		withoutLocale: function() {
-			this.localize = false;
+			this.skipLocalizationOnce = true;
 			return this;
 		},
 
 		request: function( params, callback ) {
-			if ( ! this.localize ) {
-				this.localize = true;
-				return request( params, callback );
+			if ( this.skipLocalizationOnce ) {
+				this.skipLocalizationOnce = false;
+				return originalRequest( params, callback );
 			}
 
-			return request( addLocaleQueryParam( params ), callback );
+			return originalRequest( addLocaleQueryParam( params ), callback );
 		}
 	} );
 }

--- a/client/lib/wp/localization/index.js
+++ b/client/lib/wp/localization/index.js
@@ -52,7 +52,7 @@ export function addLocaleQueryParam( params ) {
 /**
  * Modifies a WPCOM instance, returning an updated instance with included
  * localization helpers. Specifically, this adds a locale query parameter
- * by default, and adds a `withoutLocale` method to skip it.
+ * by default.
  *
  * @param  {Object} wpcom Original WPCOM instance
  * @return {Object}       Modified WPCOM instance with localization helpers
@@ -60,19 +60,9 @@ export function addLocaleQueryParam( params ) {
 export function injectLocalization( wpcom ) {
 	const originalRequest = wpcom.request.bind( wpcom );
 	return Object.assign( wpcom, {
-		skipLocalizationOnce: false,
-
-		withoutLocale: function() {
-			this.skipLocalizationOnce = true;
-			return this;
-		},
+		localized: true,
 
 		request: function( params, callback ) {
-			if ( this.skipLocalizationOnce ) {
-				this.skipLocalizationOnce = false;
-				return originalRequest( params, callback );
-			}
-
 			return originalRequest( addLocaleQueryParam( params ), callback );
 		}
 	} );

--- a/client/lib/wp/localization/index.js
+++ b/client/lib/wp/localization/index.js
@@ -67,11 +67,6 @@ export function injectLocalization( wpcom ) {
 			return this;
 		},
 
-		// Deprecated - all calls localized by default.
-		withLocale: function() {
-			return this;
-		},
-
 		request: function( params, callback ) {
 			if ( ! this.localize ) {
 				this.localize = true;

--- a/client/lib/wp/localization/test/index.js
+++ b/client/lib/wp/localization/test/index.js
@@ -62,7 +62,7 @@ describe( 'index', () => {
 
 	describe( '#injectLocalization()', () => {
 		it( 'should return a modified object', () => {
-			let wpcom = { request() {} };
+			const wpcom = { request() {} };
 			injectLocalization( wpcom );
 
 			expect( wpcom.withLocale ).to.be.a( 'function' );
@@ -70,17 +70,30 @@ describe( 'index', () => {
 
 		it( 'should override the default request method', () => {
 			const request = () => {};
-			let wpcom = { request };
+			const wpcom = { request };
 			injectLocalization( wpcom );
 
 			expect( wpcom.request ).to.not.equal( request );
 		} );
 
-		it( 'should not modify params if `withLocale` not used', ( done ) => {
+		it( 'should not modify params if `withoutLocale` is used', ( done ) => {
 			setLocale( 'fr' );
-			let wpcom = {
+			const wpcom = {
 				request( params ) {
 					expect( params.query ).to.equal( 'search=foo' );
+					done();
+				}
+			};
+
+			injectLocalization( wpcom );
+			wpcom.withoutLocale().request( { query: 'search=foo' } );
+		} );
+
+		it( 'should modify params even if `withLocale` is not used', ( done ) => {
+			setLocale( 'fr' );
+			const wpcom = {
+				request( params ) {
+					expect( params.query ).to.equal( 'search=foo&locale=fr' );
 					done();
 				}
 			};
@@ -91,7 +104,7 @@ describe( 'index', () => {
 
 		it( 'should modify params if `withLocale` is used', ( done ) => {
 			setLocale( 'fr' );
-			let wpcom = {
+			const wpcom = {
 				request( params ) {
 					expect( params.query ).to.equal( 'search=foo&locale=fr' );
 					done();
@@ -102,22 +115,22 @@ describe( 'index', () => {
 			wpcom.withLocale().request( { query: 'search=foo' } );
 		} );
 
-		it( 'should not modify the request after `withLocale` is used', ( done ) => {
+		it( 'should revert back to modifying the request after `withoutLocale` is used', ( done ) => {
 			setLocale( 'fr' );
 			let assert = false;
-			let wpcom = {
+			const wpcom = {
 				request( params ) {
 					if ( ! assert ) {
 						return;
 					}
 
-					expect( params.query ).to.equal( 'search=foo' );
+					expect( params.query ).to.equal( 'search=foo&locale=fr' );
 					done();
 				}
 			};
 
 			injectLocalization( wpcom );
-			wpcom.withLocale().request( { query: 'search=foo' } );
+			wpcom.withoutLocale().request( { query: 'search=foo' } );
 			assert = true;
 			wpcom.request( { query: 'search=foo' } );
 		} );

--- a/client/lib/wp/localization/test/index.js
+++ b/client/lib/wp/localization/test/index.js
@@ -65,7 +65,7 @@ describe( 'index', () => {
 			const wpcom = { request() {} };
 			injectLocalization( wpcom );
 
-			expect( wpcom.withoutLocale ).to.be.a( 'function' );
+			expect( wpcom.localized ).to.exist;
 		} );
 
 		it( 'should override the default request method', () => {
@@ -74,19 +74,6 @@ describe( 'index', () => {
 			injectLocalization( wpcom );
 
 			expect( wpcom.request ).to.not.equal( request );
-		} );
-
-		it( 'should not modify params if `withoutLocale` is used', ( done ) => {
-			setLocale( 'fr' );
-			const wpcom = {
-				request( params ) {
-					expect( params.query ).to.equal( 'search=foo' );
-					done();
-				}
-			};
-
-			injectLocalization( wpcom );
-			wpcom.withoutLocale().request( { query: 'search=foo' } );
 		} );
 
 		it( 'should modify params by default', ( done ) => {
@@ -99,26 +86,6 @@ describe( 'index', () => {
 			};
 
 			injectLocalization( wpcom );
-			wpcom.request( { query: 'search=foo' } );
-		} );
-
-		it( 'should revert back to modifying the request after `withoutLocale` is used', ( done ) => {
-			setLocale( 'fr' );
-			let assert = false;
-			const wpcom = {
-				request( params ) {
-					if ( ! assert ) {
-						return;
-					}
-
-					expect( params.query ).to.equal( 'search=foo&locale=fr' );
-					done();
-				}
-			};
-
-			injectLocalization( wpcom );
-			wpcom.withoutLocale().request( { query: 'search=foo' } );
-			assert = true;
 			wpcom.request( { query: 'search=foo' } );
 		} );
 	} );

--- a/client/lib/wp/localization/test/index.js
+++ b/client/lib/wp/localization/test/index.js
@@ -65,7 +65,7 @@ describe( 'index', () => {
 			const wpcom = { request() {} };
 			injectLocalization( wpcom );
 
-			expect( wpcom.withLocale ).to.be.a( 'function' );
+			expect( wpcom.withoutLocale ).to.be.a( 'function' );
 		} );
 
 		it( 'should override the default request method', () => {
@@ -89,7 +89,7 @@ describe( 'index', () => {
 			wpcom.withoutLocale().request( { query: 'search=foo' } );
 		} );
 
-		it( 'should modify params even if `withLocale` is not used', ( done ) => {
+		it( 'should modify params by default', ( done ) => {
 			setLocale( 'fr' );
 			const wpcom = {
 				request( params ) {
@@ -100,19 +100,6 @@ describe( 'index', () => {
 
 			injectLocalization( wpcom );
 			wpcom.request( { query: 'search=foo' } );
-		} );
-
-		it( 'should modify params if `withLocale` is used', ( done ) => {
-			setLocale( 'fr' );
-			const wpcom = {
-				request( params ) {
-					expect( params.query ).to.equal( 'search=foo&locale=fr' );
-					done();
-				}
-			};
-
-			injectLocalization( wpcom );
-			wpcom.withLocale().request( { query: 'search=foo' } );
 		} );
 
 		it( 'should revert back to modifying the request after `withoutLocale` is used', ( done ) => {

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -94,7 +94,7 @@ UndocumentedSite.prototype.domains = function( callback ) {
 };
 
 UndocumentedSite.prototype.postFormatsList = function( callback ) {
-	return this.wpcom.withLocale().req.get( '/sites/' + this._id + '/post-formats', {}, callback );
+	return this.wpcom.req.get( '/sites/' + this._id + '/post-formats', {}, callback );
 };
 
 UndocumentedSite.prototype.postAutosave = function( postId, attributes, callback ) {
@@ -124,7 +124,7 @@ UndocumentedSite.prototype.shortcodes = function( attributes, callback ) {
 };
 
 UndocumentedSite.prototype.getRoles = function( callback ) {
-	return this.wpcom.withLocale().req.get( '/sites/' + this._id + '/roles', {}, callback );
+	return this.wpcom.req.get( '/sites/' + this._id + '/roles', {}, callback );
 };
 
 UndocumentedSite.prototype.getViewers = function( query, callback ) {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -427,12 +427,9 @@ Undocumented.prototype.settings = function( siteId, method = 'get', data = {}, f
 	}, fn );
 };
 
-Undocumented.prototype._sendRequestWithLocale = function( originalParams, fn ) {
-	const { apiVersion, body = {}, method } = originalParams,
-		locale = i18n.getLocaleSlug(),
+Undocumented.prototype._sendRequest = function( originalParams, fn ) {
+	const { apiVersion, method } = originalParams,
 		updatedParams = omit( originalParams, [ 'apiVersion', 'method' ] );
-
-	updatedParams.body = Object.assign( {}, body, { locale } );
 
 	if ( apiVersion ) {
 		// TODO: temporary solution for apiVersion until https://github.com/Automattic/wpcom.js/issues/152 is resolved
@@ -506,7 +503,7 @@ Undocumented.prototype.setSiteRedirect = function( siteId, location, fn ) {
 Undocumented.prototype.getDomainContactInformation = function( fn ) {
 	debug( '/me/domain-contact-information query' );
 
-	return this._sendRequestWithLocale( {
+	return this._sendRequest( {
 		path: '/me/domain-contact-information',
 		method: 'get'
 	}, function( error, data ) {
@@ -527,7 +524,7 @@ Undocumented.prototype.getDomainContactInformation = function( fn ) {
 Undocumented.prototype.getDomainRegistrationSupportedStates = function( countryCode, fn ) {
 	debug( '/domains/supported-states/ query' );
 
-	return this._sendRequestWithLocale( {
+	return this._sendRequest( {
 		path: '/domains/supported-states/' + countryCode,
 		method: 'get'
 	}, fn );
@@ -536,7 +533,7 @@ Undocumented.prototype.getDomainRegistrationSupportedStates = function( countryC
 Undocumented.prototype.getDomainRegistrationSupportedCountries = function( fn ) {
 	debug( '/domains/supported-countries/ query' );
 
-	return this._sendRequestWithLocale( {
+	return this._sendRequest( {
 		path: '/domains/supported-countries/',
 		method: 'get'
 	}, fn );
@@ -545,7 +542,7 @@ Undocumented.prototype.getDomainRegistrationSupportedCountries = function( fn ) 
 Undocumented.prototype.getPaymentSupportedCountries = function( fn ) {
 	debug( '/me/transactions/supported-countries/ query' );
 
-	return this._sendRequestWithLocale( {
+	return this._sendRequest( {
 		path: '/me/transactions/supported-countries/',
 		method: 'get'
 	}, fn );
@@ -639,7 +636,7 @@ Undocumented.prototype.validateGoogleAppsContactInformation = function( contactI
  */
 Undocumented.prototype.getProducts = function( fn ) {
 	debug( '/products query' );
-	return this._sendRequestWithLocale( {
+	return this._sendRequest( {
 		path: '/products',
 		method: 'get'
 	}, fn );
@@ -660,7 +657,7 @@ Undocumented.prototype.getSitePlans = function( siteDomain, fn ) {
 	// the request
 	siteDomain = encodeURIComponent( siteDomain );
 
-	return this._sendRequestWithLocale( {
+	return this._sendRequest( {
 		path: '/sites/' + siteDomain + '/plans',
 		method: 'get'
 	}, fn );
@@ -686,7 +683,7 @@ Undocumented.prototype.cart = function( cartKey, method, data, fn ) {
 		method = 'GET';
 		data = {};
 	}
-	return this._sendRequestWithLocale( {
+	return this._sendRequest( {
 		path: '/me/shopping-cart/' + cartKey,
 		method: method,
 		body: data
@@ -1032,7 +1029,7 @@ Undocumented.prototype.transactions = function( method, data, fn ) {
 		data = mapKeysRecursively( data, snakeCase );
 	}
 
-	return this._sendRequestWithLocale( {
+	return this._sendRequest( {
 		path: '/me/transactions',
 		method: method,
 		body: data

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -715,7 +715,7 @@ Undocumented.prototype.getStoredCards = function( fn ) {
 Undocumented.prototype.menus = function( siteId, callback ) {
 	debug( '/sites/:site_id/menus query' );
 
-	return this.wpcom.withLocale().req.get( { path: '/sites/' + siteId + '/menus' }, callback );
+	return this.wpcom.req.get( { path: '/sites/' + siteId + '/menus' }, callback );
 };
 
 /**
@@ -2139,7 +2139,7 @@ Undocumented.prototype.submitSupportForumsTopic = function( subject, message, lo
  * @api public
  */
 Undocumented.prototype.getExportSettings = function( siteId, fn ) {
-	return this.wpcom.withLocale().req.get( {
+	return this.wpcom.req.get( {
 		apiVersion: '1.1',
 		path: `/sites/${ siteId }/exports/settings`
 	}, fn );
@@ -2154,7 +2154,7 @@ Undocumented.prototype.getExportSettings = function( siteId, fn ) {
  * @returns {Promise}                   A promise that resolves when the export started
  */
 Undocumented.prototype.startExport = function( siteId, advancedSettings, fn ) {
-	return this.wpcom.withLocale().req.post( {
+	return this.wpcom.req.post( {
 		apiVersion: '1.1',
 		path: `/sites/${ siteId }/exports/start`
 	}, advancedSettings, fn );
@@ -2169,7 +2169,7 @@ Undocumented.prototype.startExport = function( siteId, advancedSettings, fn ) {
  * @returns {Promise}  promise
  */
 Undocumented.prototype.getExport = function( siteId, exportId, fn ) {
-	return this.wpcom.withLocale().req.get( {
+	return this.wpcom.req.get( {
 		apiVersion: '1.1',
 		path: `/sites/${ siteId }/exports/${ exportId }`
 	}, fn );

--- a/client/state/post-types/actions.js
+++ b/client/state/post-types/actions.js
@@ -39,7 +39,7 @@ export function requestPostTypes( siteId ) {
 			siteId
 		} );
 
-		return wpcom.withLocale().site( siteId ).postTypesList().then( ( { post_types: types } ) => {
+		return wpcom.site( siteId ).postTypesList().then( ( { post_types: types } ) => {
 			dispatch( receivePostTypes( siteId, types ) );
 			dispatch( {
 				type: POST_TYPES_REQUEST_SUCCESS,

--- a/client/state/post-types/taxonomies/actions.js
+++ b/client/state/post-types/taxonomies/actions.js
@@ -44,7 +44,6 @@ export function requestPostTypeTaxonomies( siteId, postType ) {
 		} );
 
 		return wpcom
-			.withLocale()
 			.site( siteId )
 			.postType( postType )
 			.taxonomiesList()


### PR DESCRIPTION
By default, no locale query arg is added to API queries sent with `wpcom`. Across the code base, we currently use two methods to add a locale query arg:
`wpcom.withtLocale().` or `Undocumented._sendRequestWithLocale`

In #8613 there was a limited discussion about making all requests localized by default (with no objections). In part due to issues like  (#8598, #5664, and now #12808). Those issues keep popping up all the time, so we should really do it already :).

This PR implements:
- Removes the `withLocale()` method.
- Adds a `withoutLocale()` method, for edge case use.
- Updates the relevant tests
- Remove all known instances of `withLocale()`
- Refactors `_sendRequestWithLocale` into just `_sendRequest` since that method seems to have additional uses.

Fixes #12808
Fixes #8613
