### PR TITLE
Signup: Add a new WPCC flow to accept signups coming from DOPS

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -6,6 +6,7 @@ import { defer } from 'lodash';
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import qs from 'qs';
 
 /**
  * Internal dependencies
@@ -158,9 +159,14 @@ export class LoginForm extends Component {
 			isDisabled.disabled = true;
 		}
 
-		const { requestError, oauth2ClientData } = this.props;
+		const { requestError, redirectTo, oauth2ClientData } = this.props;
 		const linkingSocialUser = this.props.socialAccountIsLinking;
 		const isOauthLogin = !! oauth2ClientData;
+		let signupUrl = config( 'signup_url' );
+
+		if ( isOauthLogin ) {
+			signupUrl = '/start/wpcc?' + qs.stringify( { oauth2_client_id: oauth2ClientData.id, oauth2_redirect: redirectTo } );
+		}
 
 		return (
 			<form onSubmit={ this.onSubmitForm } method="post">
@@ -271,7 +277,7 @@ export class LoginForm extends Component {
 							{ this.props.translate( 'Not on WordPress.com? {{signupLink}}Create an Account{{/signupLink}}.',
 								{
 									components: {
-										signupLink: <a href={ oauth2ClientData.signupUrl } />,
+										signupLink: <a href={ signupUrl } />,
 									}
 								}
 							) }

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -166,6 +166,8 @@ export class LoginForm extends Component {
 
 		if ( isOauthLogin ) {
 			signupUrl = '/start/wpcc?' + qs.stringify( { oauth2_client_id: oauth2ClientData.id, oauth2_redirect: redirectTo } );
+			// TODO remove the following line when WPCC signup is ready
+			signupUrl = oauth2ClientData.signupUrl;
 		}
 
 		return (

--- a/client/boot/app.js
+++ b/client/boot/app.js
@@ -42,7 +42,7 @@ const boot = currentUser => {
 		setupMiddlewares( currentUser, reduxStore );
 		invoke( project, 'setupMiddlewares', currentUser, reduxStore );
 		detectHistoryNavigation.start();
-		page.start();
+		page.start( { decodeURLComponents: false } );
 	} );
 };
 

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -37,6 +37,8 @@ const setupContextMiddleware = reduxStore => {
 	page( '*', ( context, next ) => {
 		const parsed = url.parse( location.href, true );
 
+		// Decode the pathname by default (now disabled in page.js)
+		context.pathname = decodeURIComponent( context.pathname );
 		context.store = reduxStore;
 
 		// Break routing and do full load for logout link in /me

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -39,6 +39,7 @@ const setupContextMiddleware = reduxStore => {
 
 		// Decode the pathname by default (now disabled in page.js)
 		context.pathname = decodeURIComponent( context.pathname );
+
 		context.store = reduxStore;
 
 		// Break routing and do full load for logout link in /me

--- a/client/components/signup-form/README.md
+++ b/client/components/signup-form/README.md
@@ -7,7 +7,7 @@ This component renders a Signup Form. It magically handles email, username, and 
 
 A Signup Form instance expects `save` and `submitForm` properties, `save` is called `onBlur` of each field. `submitForm` is called when the form is submitted.
 Optional:
-getRedirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl }
+redirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl }
 disabled={ this.isDisabled() }
 submitting={ this.isSubmitting() }
 
@@ -18,7 +18,7 @@ render: function() {
 	return (
 		<SignupForm
 			{ ...this.props }
-			getRedirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl }
+			redirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl }
 			disabled={ this.isDisabled() }
 			submitting={ this.isSubmitting() }
 			save={ this.save }

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -57,7 +57,7 @@ class SignupForm extends Component {
 		email: PropTypes.string,
 		footerLink: PropTypes.node,
 		formHeader: PropTypes.node,
-		getRedirectToAfterLoginUrl: PropTypes.string.isRequired,
+		redirectToAfterLoginUrl: PropTypes.string.isRequired,
 		goToNextStep: PropTypes.func,
 		handleSocialResponse: PropTypes.func,
 		isSocialSignupEnabled: PropTypes.bool,
@@ -151,7 +151,7 @@ class SignupForm extends Component {
 			page(
 				login( {
 					isNative: config.isEnabled( 'login/native-login-links' ),
-					redirectTo: this.props.getRedirectToAfterLoginUrl,
+					redirectTo: this.props.redirectToAfterLoginUrl,
 				} )
 			);
 		}
@@ -332,7 +332,7 @@ class SignupForm extends Component {
 
 		let link = login( {
 			isNative: config.isEnabled( 'login/native-login-links' ),
-			redirectTo: this.props.getRedirectToAfterLoginUrl
+			redirectTo: this.props.redirectToAfterLoginUrl
 		} );
 
 		return map( messages, ( message, error_code ) => {
@@ -528,7 +528,7 @@ class SignupForm extends Component {
 		}
 
 		const logInUrl = config.isEnabled( 'login/native-login-links' )
-			? login( { isNative: true } )
+			? login( { isNative: true, redirectTo: this.props.redirectToAfterLoginUrl } )
 			: this.localizeUrlWithSubdomain( config( 'login_url' ) );
 
 		return (

--- a/client/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/jetpack-connect/auth-logged-out-form.jsx
@@ -116,7 +116,7 @@ class LoggedOutForm extends Component {
 				{ this.renderLocaleSuggestions() }
 				{ this.renderFormHeader() }
 				<SignupForm
-					getRedirectToAfterLoginUrl={ this.getRedirectAfterLoginUrl() }
+					redirectToAfterLoginUrl={ this.getRedirectAfterLoginUrl() }
 					disabled={ isAuthorizing }
 					submitting={ isAuthorizing }
 					submitForm={ this.handleSubmitSignup }

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -316,7 +316,8 @@ module.exports = {
 					signup_flow_name: flowName,
 					nux_q_site_type: surveySiteType,
 					nux_q_question_primary: surveyVertical,
-					jetpack_redirect: queryArgs.jetpackRedirect
+					jetpack_redirect: queryArgs.jetpackRedirect,
+					oauth2_redirect: queryArgs.oauth2_redirect,
 				}
 			), ( error, response ) => {
 				const errors = error && error.error ? [ { error: error.error, message: error.message } ] : undefined,

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -317,7 +317,7 @@ module.exports = {
 					nux_q_site_type: surveySiteType,
 					nux_q_question_primary: surveyVertical,
 					jetpack_redirect: queryArgs.jetpackRedirect,
-					oauth2_redirect: queryArgs.oauth2_redirect,
+					oauth2_client_id: queryArgs.oauth2_client_id,
 				}
 			), ( error, response ) => {
 				const errors = error && error.error ? [ { error: error.error, message: error.message } ] : undefined,

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -153,7 +153,7 @@ let InviteAcceptLoggedOut = React.createClass( {
 		return (
 			<div>
 				<SignupForm
-					getRedirectToAfterLoginUrl={ window.location.href }
+					redirectToAfterLoginUrl={ window.location.href }
 					disabled={ this.state.submitting }
 					formHeader={ this.renderFormHeader() }
 					submitting={ this.state.submitting }

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -229,7 +229,7 @@ const flows = {
 	wpcc: {
 		steps: [ 'oauth2-user' ],
 		destination: function( dependencies ) {
-			return dependencies.client_id;
+			return dependencies.oauth2_client_id;
 		},
 		description: 'WordPress.com Connect signup flow',
 		lastModified: '2017-04-03',

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -229,7 +229,7 @@ const flows = {
 	wpcc: {
 		steps: [ 'oauth2-user' ],
 		destination: function( dependencies ) {
-			return dependencies.oauth2_redirect.split( '@' )[ 1 ];
+			return dependencies.client_id;
 		},
 		description: 'WordPress.com Connect signup flow',
 		lastModified: '2017-04-03',

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -225,6 +225,15 @@ const flows = {
 		description: 'Used by `get.blog` users that connect their site to WordPress.com',
 		lastModified: '2016-11-14'
 	},
+
+	wpcc: {
+		steps: [ 'oauth2-user' ],
+		destination: function( dependencies ) {
+			return dependencies.oauth2_redirect.split( '@' )[ 1 ];
+		},
+		description: 'WordPress.com Connect signup flow',
+		lastModified: '2017-04-03',
+	}
 };
 
 if ( config.isEnabled( 'signup/domain-first-flow' ) ) {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -229,10 +229,12 @@ const flows = {
 	wpcc: {
 		steps: [ 'oauth2-user' ],
 		destination: function( dependencies ) {
-			return dependencies.oauth2_client_id;
+			return dependencies.oauth2_redirect || '/';
 		},
 		description: 'WordPress.com Connect signup flow',
 		lastModified: '2017-04-03',
+		disallowResume: true, // don't allow resume so we don't clear query params when we go back in the history
+		autoContinue: true,
 	}
 };
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -232,7 +232,7 @@ const flows = {
 			return dependencies.oauth2_redirect || '/';
 		},
 		description: 'WordPress.com Connect signup flow',
-		lastModified: '2017-04-03',
+		lastModified: '2017-08-24',
 		disallowResume: true, // don't allow resume so we don't clear query params when we go back in the history
 		autoContinue: true,
 	}

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -41,4 +41,5 @@ export default {
 	'themes-site-selected': ThemeSelectionComponent,
 	user: UserSignupComponent,
 	'user-social': UserSignupComponent,
+	'oauth2-user': UserSignupComponent
 };

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -154,7 +154,7 @@ export default {
 			oauth2Signup: true
 		},
 		providesToken: true,
-		providesDependencies: [ 'bearer_token', 'username', 'oauth2_redirect' ]
+		providesDependencies: [ 'bearer_token', 'username', 'oauth2_client_id' ]
 	},
 
 	'get-dot-blog-plans': {

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -154,7 +154,7 @@ export default {
 			oauth2Signup: true
 		},
 		providesToken: true,
-		providesDependencies: [ 'bearer_token', 'username', 'oauth2_client_id' ]
+		providesDependencies: [ 'bearer_token', 'username', 'oauth2_client_id', 'oauth2_redirect' ]
 	},
 
 	'get-dot-blog-plans': {

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -147,6 +147,13 @@ export default {
 		providesDependencies: [ 'bearer_token', 'username' ]
 	},
 
+	'oauth2-user': {
+		stepName: 'oauth2-user',
+		apiRequestFunction: stepActions.createAccount,
+		providesToken: true,
+		providesDependencies: [ 'bearer_token', 'username', 'oauth2_redirect' ]
+	},
+
 	'get-dot-blog-plans': {
 		apiRequestFunction: stepActions.createSiteWithCart,
 		stepName: 'get-dot-blog-plans',

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -150,6 +150,9 @@ export default {
 	'oauth2-user': {
 		stepName: 'oauth2-user',
 		apiRequestFunction: stepActions.createAccount,
+		props: {
+			oauth2Signup: true
+		},
 		providesToken: true,
 		providesDependencies: [ 'bearer_token', 'username', 'oauth2_redirect' ]
 	},

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -236,7 +236,7 @@ const Signup = React.createClass( {
 			}.bind( this ) );
 		}
 
-		if ( ! userIsLoggedIn && ( config.isEnabled( 'oauth' ) || this.props.stepName === 'oauth2-user' ) ) {
+		if ( ! userIsLoggedIn && ( config.isEnabled( 'oauth' ) || dependencies.oauth2_client_id ) ) {
 			oauthToken.setToken( dependencies.bearer_token );
 			window.location.href = destination;
 			return;

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -236,9 +236,10 @@ const Signup = React.createClass( {
 			}.bind( this ) );
 		}
 
-		if ( ! userIsLoggedIn && config.isEnabled( 'oauth' ) ) {
+		if ( ! userIsLoggedIn && ( config.isEnabled( 'oauth' ) || this.props.stepName === 'oauth2-user' ) ) {
 			oauthToken.setToken( dependencies.bearer_token );
 			window.location.href = destination;
+			return;
 		}
 
 		if ( ! userIsLoggedIn && ! config.isEnabled( 'oauth' ) ) {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -77,6 +77,8 @@ export class UserStep extends Component {
 			flowName: this.props.flowName,
 			stepName: this.props.stepName,
 			...data
+		}, null, {
+			oauth2_redirect: data.queryArgs.oauth2_redirect
 		} );
 
 		this.props.goToNextStep();
@@ -86,6 +88,8 @@ export class UserStep extends Component {
 		const queryArgs = {
 			jetpackRedirect: get( this.props, 'queryObject.jetpack_redirect' )
 		};
+
+		queryArgs.oauth2_redirect = get( this.props, 'queryObject.oauth2_redirect' );
 
 		const formWithoutPassword = {
 			...form,

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -72,14 +72,17 @@ export class UserStep extends Component {
 	};
 
 	submit = ( data ) => {
+		const dependencies = {};
+		if ( this.props.oauth2Signup ) {
+			dependencies.oauth2_redirect = data.queryArgs.oauth2_redirect;
+		}
+
 		SignupActions.submitSignupStep( {
 			processingMessage: this.props.translate( 'Creating your account' ),
 			flowName: this.props.flowName,
 			stepName: this.props.stepName,
 			...data
-		}, null, {
-			oauth2_redirect: data.queryArgs.oauth2_redirect
-		} );
+		}, null, dependencies );
 
 		this.props.goToNextStep();
 	};

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -74,7 +74,7 @@ export class UserStep extends Component {
 	submit = ( data ) => {
 		const dependencies = {};
 		if ( this.props.oauth2Signup ) {
-			dependencies.oauth2_redirect = data.queryArgs.oauth2_redirect;
+			dependencies.oauth2_client_id = data.queryArgs.oauth2_client_id;
 		}
 
 		SignupActions.submitSignupStep( {
@@ -92,7 +92,7 @@ export class UserStep extends Component {
 			jetpackRedirect: get( this.props, 'queryObject.jetpack_redirect' )
 		};
 
-		queryArgs.oauth2_redirect = get( this.props, 'queryObject.oauth2_redirect' );
+		queryArgs.oauth2_client_id = get( this.props, 'queryObject.oauth2_client_id' );
 
 		const formWithoutPassword = {
 			...form,


### PR DESCRIPTION
This pull request adds a new signup flow which accepts signup for DOPS. It accepts an oauth2_client_id parameter, which customizes the flow by sending custom emails to these users and marking them as WPCC signups in NA.

Right now this doesn't customize the flows at all. We should do this, but I propose we leave that for a subsequent PR. We also need to think about how we redirect these users back to the right place, and if we want to start auto-activating these users.
  
#### Testing instructions
  
1. Run `git checkout add/wpcc` and start your server
2. Apply patch D6947-code and sandbox the api
3. From a new incognito session, open https://woocommerce.com/my-account/
4. In the url bar, replace `https://wordpress.com` with `http://calypso.localhost:3000`
5. Click on "Create an Account".
6. Create a new WordPress.com account (try entering bad information to see it the flow breaks)
7. Check that you are redirected to WooCommerce authorization page, validate and ensure that you are brought back to woocommerce.com
8. Check that you are marked as a WooCommerce user in NA, and that you receive a custom WooCommerce email.
9. Try all DOPS flows.
10. When you're on the account creation page, try entering an existing email and clicking on the log-in link and ensure that you can log in properly and that the oauth2 flow does not break
11. When you're on the account creation page, try clicking the "Already have a WordPress.com account? Log in now." link at the bottom and ensure that you can log in properly and that the oauth2 flow does not break
12. Try from a non-DOPS client
  
#### Reviews
  
- [x] Code
- [x] Product
   