### PR TITLE
Site Settings: Update AfterTheDeadline advanced options to use FoldableCard

### DIFF
--- a/client/my-sites/site-settings/composing/after-the-deadline.jsx
+++ b/client/my-sites/site-settings/composing/after-the-deadline.jsx
@@ -67,15 +67,7 @@ class AfterTheDeadline extends Component {
 		const { afterTheDeadlineModuleActive, translate } = this.props;
 
 		return (
-			<div className="composing__module-settings site-settings__child-settings">
-				<div className="composing__info-link-container site-settings__info-link-container">
-					<InfoPopover position={ 'left' }>
-						<ExternalLink href={ 'https://jetpack.com/support/spelling-and-grammar/' } icon target="_blank">
-							{ translate( 'Learn more about After the Deadline.' ) }
-						</ExternalLink>
-					</InfoPopover>
-				</div>
-
+			<FormFieldset>
 				<FormLegend>
 					{ translate( 'Proofreading' ) }
 				</FormLegend>
@@ -94,7 +86,7 @@ class AfterTheDeadline extends Component {
 						'Posts or pages are updated'
 					) )
 				}
-			</div>
+			</FormFieldset>
 		);
 	}
 
@@ -102,7 +94,7 @@ class AfterTheDeadline extends Component {
 		const { afterTheDeadlineModuleActive, translate } = this.props;
 
 		return (
-			<div className="composing__module-settings site-settings__child-settings">
+			<FormFieldset>
 				<FormLegend>
 					{ translate( 'Automatic Language Detection' ) }
 				</FormLegend>
@@ -115,7 +107,7 @@ class AfterTheDeadline extends Component {
 						'Use automatically detected language to proofread posts and pages'
 					) )
 				}
-			</div>
+			</FormFieldset>
 		);
 	}
 
@@ -123,7 +115,7 @@ class AfterTheDeadline extends Component {
 		const { afterTheDeadlineModuleActive, translate } = this.props;
 
 		return (
-			<div className="composing__module-settings site-settings__child-settings">
+			<FormFieldset>
 				<FormLegend>
 					{ translate( 'English Options' ) }
 				</FormLegend>
@@ -141,7 +133,7 @@ class AfterTheDeadline extends Component {
 				{ this.renderToggle( 'Passive voice', ! afterTheDeadlineModuleActive, translate( 'Passive Voice' ) ) }
 				{ this.renderToggle( 'Phrases to Avoid', ! afterTheDeadlineModuleActive, translate( 'Phrases to Avoid' ) ) }
 				{ this.renderToggle( 'Redundant Expression', ! afterTheDeadlineModuleActive, translate( 'Redundant Phrases' ) ) }
-			</div>
+			</FormFieldset>
 		);
 	}
 
@@ -152,7 +144,7 @@ class AfterTheDeadline extends Component {
 			: [];
 
 		return (
-			<div className="composing__module-settings site-settings__child-settings">
+			<FormFieldset>
 				<FormLegend>
 					{ translate( 'Ignored Phrases' ) }
 				</FormLegend>
@@ -162,7 +154,7 @@ class AfterTheDeadline extends Component {
 					value={ ignoredPhrases }
 					disabled={ ! afterTheDeadlineModuleActive || moduleUnavailable }
 				/>
-			</div>
+			</FormFieldset>
 		);
 	}
 
@@ -188,12 +180,20 @@ class AfterTheDeadline extends Component {
 			<FoldableCard className="composing__foldable-card site-settings__foldable-card" header={ atdToggle }>
 				<QueryJetpackConnection siteId={ selectedSiteId } />
 
-				<FormFieldset>
+				<div className="composing__module-settings site-settings__child-settings">
+					<div className="composing__info-link-container site-settings__info-link-container">
+						<InfoPopover position={ 'left' }>
+							<ExternalLink href={ 'https://jetpack.com/support/spelling-and-grammar/' } icon target="_blank">
+								{ translate( 'Learn more about After the Deadline.' ) }
+							</ExternalLink>
+						</InfoPopover>
+					</div>
+
 					{ this.renderProofreadingSection() }
 					{ this.renderAutoLanguageDetectionSection() }
 					{ this.renderEnglishOptionsSection() }
 					{ this.renderIgnoredPhrasesSection() }
-				</FormFieldset>
+				</div>
 			</FoldableCard>
 		);
 	}

--- a/client/my-sites/site-settings/composing/after-the-deadline.jsx
+++ b/client/my-sites/site-settings/composing/after-the-deadline.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
+import FoldableCard from 'components/foldable-card';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLegend from 'components/forms/form-legend';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
@@ -39,20 +40,8 @@ class AfterTheDeadline extends Component {
 		fields: PropTypes.object,
 	};
 
-	state = {
-		advancedOptionsVisible: false,
-	};
-
 	onChangeIgnoredPhrases = ( phrases ) => {
 		this.props.setFieldValue( 'ignored_phrases', phrases.join( ',' ) );
-	};
-
-	onAdvancedOptionsClick = ( event ) => {
-		event.preventDefault();
-
-		this.setState( {
-			advancedOptionsVisible: ! this.state.advancedOptionsVisible,
-		} );
 	};
 
 	renderToggle( name, isDisabled, label ) {
@@ -79,6 +68,14 @@ class AfterTheDeadline extends Component {
 
 		return (
 			<div className="composing__module-settings site-settings__child-settings">
+				<div className="composing__info-link-container site-settings__info-link-container">
+					<InfoPopover position={ 'left' }>
+						<ExternalLink href={ 'https://jetpack.com/support/spelling-and-grammar/' } icon target="_blank">
+							{ translate( 'Learn more about After the Deadline.' ) }
+						</ExternalLink>
+					</InfoPopover>
+				</div>
+
 				<FormLegend>
 					{ translate( 'Proofreading' ) }
 				</FormLegend>
@@ -178,40 +175,26 @@ class AfterTheDeadline extends Component {
 			translate
 		} = this.props;
 
+		const atdToggle = (
+			<JetpackModuleToggle
+				siteId={ selectedSiteId }
+				moduleSlug="after-the-deadline"
+				label={ translate( 'Check your spelling, style, and grammar' ) }
+				disabled={ isRequestingSettings || isSavingSettings || moduleUnavailable }
+			/>
+		);
+
 		return (
-			<FormFieldset>
+			<FoldableCard className="composing__foldable-card site-settings__foldable-card" header={ atdToggle }>
 				<QueryJetpackConnection siteId={ selectedSiteId } />
 
-				<div className="composing__info-link-container site-settings__info-link-container">
-					<InfoPopover position={ 'left' }>
-						<ExternalLink href={ 'https://jetpack.com/support/spelling-and-grammar/' } icon target="_blank">
-							{ translate( 'Learn more about After the Deadline.' ) }
-						</ExternalLink>
-					</InfoPopover>
-				</div>
-
-				<JetpackModuleToggle
-					siteId={ selectedSiteId }
-					moduleSlug="after-the-deadline"
-					label={ translate( 'Check your spelling, style, and grammar' ) }
-					disabled={ isRequestingSettings || isSavingSettings || moduleUnavailable }
-					/>
-
-				<div className="composing__module-settings site-settings__child-settings">
-					<a href="#" onClick={ this.onAdvancedOptionsClick }>
-						{ translate( 'Advanced Options' ) }
-					</a>
-				</div>
-
-				{ this.state.advancedOptionsVisible && (
-					<div>
-						{ this.renderProofreadingSection() }
-						{ this.renderAutoLanguageDetectionSection() }
-						{ this.renderEnglishOptionsSection() }
-						{ this.renderIgnoredPhrasesSection() }
-					</div>
-				) }
-			</FormFieldset>
+				<FormFieldset>
+					{ this.renderProofreadingSection() }
+					{ this.renderAutoLanguageDetectionSection() }
+					{ this.renderEnglishOptionsSection() }
+					{ this.renderIgnoredPhrasesSection() }
+				</FormFieldset>
+			</FoldableCard>
 		);
 	}
 }

--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import Card from 'components/card';
+import CompactCard from 'components/card/compact';
 import DefaultPostFormat from './default-post-format';
 import AfterTheDeadline from './after-the-deadline';
 import { isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
@@ -22,11 +23,12 @@ const Composing = ( {
 	isRequestingSettings,
 	isSavingSettings,
 	jetpackSettingsUISupported,
-	siteIsJetpack
 } ) => {
+	const CardComponent = jetpackSettingsUISupported ? CompactCard : Card;
+
 	return (
 		<div>
-			<Card className="composing__card site-settings">
+			<CardComponent className="composing__card site-settings">
 				<DefaultPostFormat
 					onChangeField={ onChangeField }
 					eventTracker={ eventTracker }
@@ -34,9 +36,9 @@ const Composing = ( {
 					isRequestingSettings={ isRequestingSettings }
 					fields={ fields }
 				/>
-			</Card>
+			</CardComponent>
 
-			{ siteIsJetpack && jetpackSettingsUISupported &&
+			{ jetpackSettingsUISupported &&
 				<AfterTheDeadline
 					handleToggle={ handleToggle }
 					setFieldValue={ setFieldValue }
@@ -68,10 +70,10 @@ Composing.propTypes = {
 export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
+		const siteIsJetpack = isJetpackSite( state, siteId );
 
 		return {
-			jetpackSettingsUISupported: siteSupportsJetpackSettingsUi( state, siteId ),
-			siteIsJetpack: isJetpackSite( state, siteId ),
+			jetpackSettingsUISupported: siteIsJetpack && siteSupportsJetpackSettingsUi( state, siteId ),
 		};
 	}
 )( Composing );

--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -25,29 +25,27 @@ const Composing = ( {
 	siteIsJetpack
 } ) => {
 	return (
-		<Card className="site-settings">
-			<DefaultPostFormat
-				onChangeField={ onChangeField }
-				eventTracker={ eventTracker }
-				isSavingSettings={ isSavingSettings }
-				isRequestingSettings={ isRequestingSettings }
-				fields={ fields }
-			/>
-			{
-				siteIsJetpack && jetpackSettingsUISupported && (
-					<div>
-						<hr />
-						<AfterTheDeadline
-							handleToggle={ handleToggle }
-							setFieldValue={ setFieldValue }
-							isSavingSettings={ isSavingSettings }
-							isRequestingSettings={ isRequestingSettings }
-							fields={ fields }
-						/>
-					</div>
-				)
+		<div>
+			<Card className="composing__card site-settings">
+				<DefaultPostFormat
+					onChangeField={ onChangeField }
+					eventTracker={ eventTracker }
+					isSavingSettings={ isSavingSettings }
+					isRequestingSettings={ isRequestingSettings }
+					fields={ fields }
+				/>
+			</Card>
+
+			{ siteIsJetpack && jetpackSettingsUISupported &&
+				<AfterTheDeadline
+					handleToggle={ handleToggle }
+					setFieldValue={ setFieldValue }
+					isSavingSettings={ isSavingSettings }
+					isRequestingSettings={ isRequestingSettings }
+					fields={ fields }
+				/>
 			}
-		</Card>
+		</div>
 	);
 };
 

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -364,6 +364,11 @@
 	&.is-expanded.is-top-level .foldable-card__content {
 		padding: 24px;
 	}
+
+	.site-settings__info-link-container {
+		margin-right: -36px;
+		height: 0;
+	}
 }
 
 // Site settings group styles


### PR DESCRIPTION
### Purpose

After the Deadline settings in the Writing section uses a Foldable card in Jetpack, but not in Calypso. This PR updates it to use a FoldableCard in Calypso, too. A good side effect is that we no longer need to manage internal state in the `AfterTheDeadline` component.

---

### Preview - before

**Collapsed**
![](https://cldup.com/pvaKtHI4OO.png)

**Expanded**
![](https://cldup.com/GefyA1WCev.png)

---

### Preview - after

**Collapsed**
![](https://cldup.com/RtT-crxzTe.png)

**Expanded**
![](https://cldup.com/RO1APd7MHn.png)

---

### To test

* Checkout this branch or get it going on calypso.live
* Go to `/settings/writing/$site`, where `$site` is one of your Jetpack sites.
* Verify the module settings appear as shown on the preview.
* Verify the module settings are retrieved and saved correctly like before.
* Go to `/settings/writing/$site`, where `$site` is one of your WordPress.com sites.
* Verify the Composing card looks well and the "After the Deadline" module settings are not shown.
