### PR TITLE
Site Settings: Update copy in CustomContentTypes to match Jetpack

### DIFF
--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -85,8 +85,13 @@ class CustomContentTypes extends Component {
 		const { translate } = this.props;
 		const fieldLabel = translate( 'Testimonials' );
 		const fieldDescription = translate(
-			'Add, organize, and display testimonials. If your theme doesn’t support testimonials yet, ' +
-			'you can display them using the shortcode ( [testimonials] ).'
+			'Add, organize, and display {{link}}testimonials{{/link}}. If your theme doesn’t support testimonials yet, ' +
+			'you can display them using the shortcode ( [testimonials] ).',
+			{
+				components: {
+					link: <a href="https://support.wordpress.com/testimonials/" />
+				}
+			}
 		);
 
 		return this.renderContentTypeSettings( 'jetpack_testimonial', fieldLabel, fieldDescription );
@@ -96,8 +101,13 @@ class CustomContentTypes extends Component {
 		const { translate } = this.props;
 		const fieldLabel = translate( 'Portfolios' );
 		const fieldDescription = translate(
-			'Add, organize, and display portfolios. If your theme doesn’t support portfolios yet, ' +
-			'you can display them using the shortcode ( [portfolios] ).'
+			'Add, organize, and display {{link}}portfolios{{/link}}. If your theme doesn’t support portfolios yet, ' +
+			'you can display them using the shortcode ( [portfolios] ).',
+			{
+				components: {
+					link: <a href="https://support.wordpress.com/portfolios/" />
+				}
+			}
 		);
 
 		return this.renderContentTypeSettings( 'jetpack_portfolio', fieldLabel, fieldDescription );

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -16,6 +16,8 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackModuleActive, isActivatingJetpackModule } from 'state/selectors';
 import { activateModule } from 'state/jetpack/modules/actions';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import InfoPopover from 'components/info-popover';
+import ExternalLink from 'components/external-link';
 
 class CustomContentTypes extends Component {
 	componentDidUpdate() {
@@ -109,6 +111,14 @@ class CustomContentTypes extends Component {
 
 				<Card className="custom-content-types__card site-settings">
 					<FormFieldset>
+						<div className="custom-content-types__info-link-container site-settings__info-link-container">
+							<InfoPopover position={ 'left' }>
+								<ExternalLink href={ 'https://support.wordpress.com/custom-post-types/' } icon target="_blank">
+									{ translate( 'Learn more about Custom Content Types.' ) }
+								</ExternalLink>
+							</InfoPopover>
+						</div>
+
 						{ this.renderTestimonialSettings() }
 						{ this.renderPortfolioSettings() }
 					</FormFieldset>

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -12,7 +12,7 @@ import SectionHeader from 'components/section-header';
 import Card from 'components/card';
 import FormFieldset from 'components/forms/form-fieldset';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackModuleActive, isActivatingJetpackModule } from 'state/selectors';
 import { activateModule } from 'state/jetpack/modules/actions';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
@@ -80,58 +80,22 @@ class CustomContentTypes extends Component {
 	}
 
 	renderTestimonialSettings() {
-		const {
-			site,
-			translate
-		} = this.props;
-		const fieldLabel = translate(
-			'Enable {{strong}}Testimonial{{/strong}} custom content types',
-			{
-				components: {
-					strong: <strong />,
-				}
-			}
-		);
+		const { translate } = this.props;
+		const fieldLabel = translate( 'Testimonials' );
 		const fieldDescription = translate(
-			'The Testimonial custom content type allows you to add, organize, and display your ' +
-			'testimonials. If your theme doesn’t support it yet, you can display testimonials using ' +
-			'the {{shortcodeLink}}testimonial shortcode{{/shortcodeLink}} ( [testimonials] ) ' +
-			'or you can {{archiveLink}}view a full archive of your testimonials{{/archiveLink}}.',
-			{
-				components: {
-					shortcodeLink: <a href="https://support.wordpress.com/testimonials-shortcode/" />,
-					archiveLink: <a href={ site.URL.replace( /\/$/, '' ) + '/testimonial' } />
-				}
-			}
+			'Add, organize, and display testimonials. If your theme doesn’t support testimonials yet, ' +
+			'you can display them using the shortcode ( [testimonials] ).'
 		);
 
 		return this.renderContentTypeSettings( 'jetpack_testimonial', fieldLabel, fieldDescription );
 	}
 
 	renderPortfolioSettings() {
-		const {
-			site,
-			translate
-		} = this.props;
-		const fieldLabel = translate(
-			'Enable {{strong}}Portfolio{{/strong}} custom content types',
-			{
-				components: {
-					strong: <strong />,
-				}
-			}
-		);
+		const { translate } = this.props;
+		const fieldLabel = translate( 'Portfolios' );
 		const fieldDescription = translate(
-			'The Portfolio custom content type gives you an easy way to manage and showcase projects ' +
-			'on your site. If your theme doesn’t support it yet, you can display the portfolio using ' +
-			'the {{shortcodeLink}}portfolio shortcode{{/shortcodeLink}} ( [portfolio] ) ' +
-			'or you can {{archiveLink}}view a full archive of your portfolio projects{{/archiveLink}}.',
-			{
-				components: {
-					shortcodeLink: <a href="https://support.wordpress.com/portfolios/portfolio-shortcode/" />,
-					archiveLink: <a href={ site.URL.replace( /\/$/, '' ) + '/portfolio' } />
-				}
-			}
+			'Add, organize, and display portfolios. If your theme doesn’t support portfolios yet, ' +
+			'you can display them using the shortcode ( [portfolios] ).'
 		);
 
 		return this.renderContentTypeSettings( 'jetpack_portfolio', fieldLabel, fieldDescription );
@@ -141,7 +105,7 @@ class CustomContentTypes extends Component {
 		const { translate } = this.props;
 		return (
 			<div>
-				<SectionHeader label={ translate( 'Custom Content Types' ) } />
+				<SectionHeader label={ translate( 'Custom content types' ) } />
 
 				<Card className="custom-content-types__card site-settings">
 					<FormFieldset>
@@ -171,11 +135,9 @@ CustomContentTypes.propTypes = {
 export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
-		const site = getSelectedSite( state );
 
 		return {
 			siteId,
-			site,
 			customContentTypesModuleActive: isJetpackModuleActive( state, siteId, 'custom-content-types' ),
 			activatingCustomContentTypesModule: isActivatingJetpackModule( state, siteId, 'custom-content-types' ),
 		};


### PR DESCRIPTION
### Purpose

This PR updates the copy in Custom Content Types to match the one we have currently in Jetpack. A great benefit from this is the fact that this copy update helped simplify the component a bit.

### Preview

**Before**
![](https://cldup.com/haJZzlTmAd.png)

**After**
![](https://cldup.com/9GO-z44ch3.png)

### To test

*  Checkout this branch
* `/settings/writing/$site`, where `$site` is one of your Jetpack sites.
* Verify the **Custom content types** box looks as shown on the preview.