### PR TITLE
Site Settings: Use a non-compact button for Regenerate address

### DIFF
--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -79,7 +79,6 @@ class PublishingTools extends Component {
 					value={ email }
 				/>
 				<Button
-					compact
 					onClick={ this.onRegenerateButtonClick }
 					disabled={ isFormPending || regeneratingPostByEmail || ! postByEmailAddressModuleActive || moduleUnavailable }
 				>


### PR DESCRIPTION
This PR updates the **Regenerate address** button in the **Publishing Tools** card under **Writing** settings to use a non-compact button.

**Before**
![](https://cldup.com/_BUBZ0rCeo.png)

**After**
![](https://cldup.com/iLwHZzSFPH.png)

To test:
* Checkout this branch or get it going on calypso.live.
* Go to `/settings/writing/$site`, where `$site` is one of your Jetpack sites.
* Verify the **Regenerate address** button is not compact and looks as shown in the second preview.