### PR TITLE
Jetpack Plans: Always display Google Analytics for Pro plan

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -429,7 +429,7 @@ export const PLANS_LIST = {
 				FEATURE_MALWARE_SCANNING_DAILY_AND_ON_DEMAND,
 				FEATURE_ONE_CLICK_THREAT_RESOLUTION,
 				FEATURE_ADVANCED_SEO,
-				isEnabled( 'jetpack/google-analytics' ) && FEATURE_GOOGLE_ANALYTICS
+				FEATURE_GOOGLE_ANALYTICS
 			]
 		),
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
@@ -474,7 +474,7 @@ export const PLANS_LIST = {
 				FEATURE_MALWARE_SCANNING_DAILY_AND_ON_DEMAND,
 				FEATURE_ONE_CLICK_THREAT_RESOLUTION,
 				FEATURE_ADVANCED_SEO,
-				isEnabled( 'jetpack/google-analytics' ) && FEATURE_GOOGLE_ANALYTICS
+				FEATURE_GOOGLE_ANALYTICS
 			]
 		),
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )


### PR DESCRIPTION
This PR fixes #12814, where Google Analytics is not visible for the Professional Jetpack plan. It appears that we no longer use the `jetpack/google-analytics` config keys, so those checks will no longer be necessary anyway.

To test:
* Checkout this branch or get it going on calypso.live
* Go to `/plans/$site` and verify the **Google Analytics Integration** feature is listed under the **Professional** plan.
* Go to `/plans/$site?feature=google-analytics` and verify the **Google Analytics Integration** feature is highlighted under the **Professional** plan.