### PR TITLE
Remove a/b test for Calypso Signup Step 1 mobile optimization

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -17,14 +17,6 @@ module.exports = {
 		defaultVariation: 'userLast',
 		allowExistingUsers: false,
 	},
-	signupStepOneMobileOptimize: {
-		datestamp: '20170322',
-		variations: {
-			original: 50,
-			modified: 50,
-		},
-		defaultVariation: 'original',
-	},
 	automatedTransfer2: {
 		datestamp: '20170316',
 		variations: {

--- a/client/signup/step-header/style.scss
+++ b/client/signup/step-header/style.scss
@@ -16,7 +16,8 @@
 	margin: 0 0 5px 0;
 
 	@include breakpoint( "<480px" ) {
-		padding: 0 20px;
+		line-height: 1.2em;
+		padding: 0 10px;
 	}
 }
 
@@ -27,14 +28,5 @@
 	@include breakpoint( "<480px" ) {
 		margin: 0;
 		padding: 0 20px;
-	}
-}
-
-.step-wrapper--mobile-test {
-	@include breakpoint( "<480px" ) {
-		.step-header__title {
-		    line-height: 1.2em;
-		    padding: 0 10px;
-		}
 	}
 }

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -9,7 +9,6 @@ import classNames from 'classnames';
  */
 import StepHeader from 'signup/step-header';
 import NavigationLink from 'signup/navigation-link';
-import { abtest } from 'lib/abtest';
 
 export default React.createClass( {
 	displayName: 'StepWrapper',
@@ -77,7 +76,6 @@ export default React.createClass( {
 		const { stepContent, headerButton } = this.props;
 		const classes = classNames( 'step-wrapper', {
 			'is-wide-layout': this.props.isWideLayout,
-			'step-wrapper--mobile-test': abtest( 'signupStepOneMobileOptimize' ) === 'modified',
 		} );
 
 		return (

--- a/client/signup/steps/design-type-with-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/index.jsx
@@ -19,7 +19,6 @@ import BlogImage from './blog-image';
 import PageImage from './page-image';
 import GridImage from './grid-image';
 import StoreImage from './store-image';
-import { abtest } from 'lib/abtest';
 
 class DesignTypeWithStoreStep extends Component {
 	constructor( props ) {
@@ -103,14 +102,8 @@ class DesignTypeWithStoreStep extends Component {
 	};
 
 	renderChoice = ( choice ) => {
-		let choiceCardClass = 'design-type-with-store__choice';
-
-		if ( abtest( 'signupStepOneMobileOptimize' ) === 'modified' ) {
-			choiceCardClass += ' design-type-with-store__choice--mobile-test';
-		}
-
 		return (
-			<Card className={ choiceCardClass } key={ choice.type }>
+			<Card className="design-type-with-store__choice" key={ choice.type }>
 				<a className="design-type-with-store__choice-link"
 					href="#"
 					onClick={ this.handleChoiceClick( choice.type ) }>

--- a/client/signup/steps/design-type-with-store/style.scss
+++ b/client/signup/steps/design-type-with-store/style.scss
@@ -41,47 +41,136 @@
 }
 
 .design-type-with-store__choice {
-	padding: 0;
-	margin: 0 10px 20px 10px;
-	width: 230px;
-	flex-grow: 1;
 	transition: all 100ms ease-in-out;
 	position: relative;
-	text-align: center;
+	border: 1px solid lighten( $gray, 20% );
+	border-bottom: 0;
+	margin: 0 10px;
+	
+	@include breakpoint( "<480px" ) {
+		box-shadow: none; //inherited from .card, remove for mobile only
+	}
+
+	@include breakpoint( ">480px" ) {
+		padding: 0;
+		margin-bottom: 20px;
+		width: 230px;
+		text-align: center;
+		flex-grow: 1;
+		border: 0;
+
+		&:hover {
+			box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20 );
+		}
+	}
+
+	&:active {
+		.design-type-with-store__cta {
+			color: $blue-dark;
+		}
+
+		.design-type-with-store__choice-link:after {
+			border-top-color: $blue-dark;
+			border-right-color: $blue-dark;
+		}
+	}
+
+	&:first-child {
+		border-top-right-radius: 6px;
+		border-top-left-radius: 6px;
+
+		@include breakpoint( ">480px" ) {
+			border-radius: 0;
+		}
+	}
+
+	&:last-of-type {
+		margin-bottom: 20px;
+		border: 1px solid lighten( $gray, 20% );
+		border-bottom-right-radius: 6px;
+		border-bottom-left-radius: 6px;
+
+		@include breakpoint( ">480px" ) {
+			border-radius: 0;
+			border: 0;
+		}
+	}
 
 	a, svg {
 		display: block;
 		width: 100%; // Safari fix
 	}
+}
 
-	&:hover {
-		box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20 );
+.design-type-with-store__choice-link {
+	padding-right: 40px;
+	display: block;
+	box-sizing: border-box;
+
+	&:after {
+		content: '';
+		display: block;
+		width: 8px; //Match the size of the cta copy
+		height: 8px; //Match the size of the cta copy
+		position: absolute;
+		top: 20px;
+		right: 15px;
+		border-top: 2px solid lighten( $gray, 20% );
+		border-right: 2px solid lighten( $gray, 20% );
+		transform: rotate(45deg);
+	}
+
+	@include breakpoint( ">480px" ) {
+		padding-right: 0;
+		&:after {
+			display: none;
+		}
 	}
 }
 
-.design-type-with-store__choice-copy {
-	padding: 15px;
-	border-top: 1px solid transparentize( lighten( $gray, 20% ), .5 );
+.design-type-with-store__image {
+	display: none;
+
+	@include breakpoint( ">480px" ) {
+		display: block;
+	}
+}
+
+@include breakpoint( ">480px" ) {
+	.design-type-with-store__choice-copy {
+		padding: 15px;
+		border-top: 1px solid transparentize( lighten( $gray, 20% ), .5 );
+	}
 }
 
 .design-type-with-store__choice-label {
-	color: darken( $gray, 20% );
-	padding: 0;
-}
-
-.design-type-with-store__choice-label--test {
 	color: $blue-wordpress;
+	padding: 0;
 	position: relative;
 }
 
 .design-type-with-store__choice-description {
-	margin: 10px 0 0;
+	margin: 0;
 	color: $gray;
 	font-size: 0.875em;
+
+	@include breakpoint( ">480px" ) {
+		margin-top: 10px;
+	}
 }
 
 .button.design-type-with-store__cta {
 	color: $blue-wordpress;
+
+	@include breakpoint( "<480px" ) {
+		background: none;
+		font-size: 1.1em;
+		border: 0;
+		padding: 0;
+		text-transform: none;
+		margin: 0;
+		line-height: 1.1em;
+	}
 }
 
 .design-type-with-store__disclaimer {
@@ -91,98 +180,8 @@
 	font-size: 0.875em;
 	width: 100%;
 	box-sizing: border-box;
-}
 
-.design-type-with-store__choice--mobile-test {
 	@include breakpoint( "<480px" ) {
-		margin-bottom: 0;
-		text-align: left;
-		position: relative;
-		border: 1px solid lighten( $gray, 20% );
-		border-bottom: 0;
-		box-shadow: none;
-
-		&:first-child {
-			border-top-right-radius: 6px;
-			border-top-left-radius: 6px;
-		}
-		
-		&:last-of-type {
-			margin-bottom: 20px;
-			border: 1px solid lighten( $gray, 20% );
-			border-bottom-right-radius: 6px;
-			border-bottom-left-radius: 6px;
-		}
-
-		&:hover {
-			box-shadow: none;
-		}
-
-		&:active {
-			.design-type-with-store__cta {
-				color: $blue-dark;
-			}
-
-			.design-type-with-store__choice-link:after {
-				border-top-color: $blue-dark;
-				border-right-color: $blue-dark;
-			}
-		}
-
-		.design-type-with-store__choice-link {
-			padding-right: 40px;
-			display: block;
-			box-sizing: border-box;
-
-			&:after {
-				content: '';
-				display: block;
-				width: 8px; //Match the size of the cta copy
-				height: 8px; //Match the size of the cta copy
-				position: absolute;
-				top: 20px;
-				right: 15px;
-				border-top: 2px solid lighten( $gray, 20% );
-				border-right: 2px solid lighten( $gray, 20% );
-				transform: rotate(45deg);
-			}
-		}
-
-		.design-type-with-store__image {
-			display: none;
-		}
-
-		.design-type-with-store__choice-copy {
-			border-top: 0;
-		}
-
-		//Reset button for now. If this test passes, we should remove button class.
-		.design-type-with-store__cta {
-			background: none;
-			font-size: 1.1em;
-			border: 0;
-			padding: 0;
-			text-transform: none;
-			margin: 0;
-			line-height: 1.1em;
-		}
-
-		.design-type-with-store__choice-description {
-			margin-top: 0;
-		}
-	}
-
-	@include breakpoint( ">480px" ) {
-		.design-type-with-store__image {
-			display: block;
-		}
-	}
-}
-
-.step-wrapper--mobile-test {
-	@include breakpoint( "<480px" ) {
-		.design-type-with-store__disclaimer {
-			padding: 0 20px;
-		}
+		padding: 0 20px;
 	}
 }


### PR DESCRIPTION
We ran a test to determine whether a new mobile design for the first step in our Calypso Signup flow would convert higher. The new design converted at 4 ppts higher than the existing design. 

This PR removes the testing code and applies the design to all visitors. 

## Screenshots
control: `original`
<img width="373" alt="current" src="https://cloud.githubusercontent.com/assets/6981253/24259901/9c8f7b74-0fc8-11e7-8143-f39874e0cae4.png">


test: `modified` 🏆 
<img width="376" alt="screen shot 2017-03-23 at 11 35 09 am" src="https://cloud.githubusercontent.com/assets/6981253/24259896/9972c04a-0fc8-11e7-9bda-eaa0ac1103db.png">

@markryall can you review?