### PR TITLE
Magic Login: WP-Login: Enable flags in wpcalypso config

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -34,6 +34,7 @@
 		"jetpack/api-cache": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
+		"magic-login": true,
 		"manage/customize": true,
 		"manage/custom-post-types": true,
 		"manage/drafts": true,
@@ -116,7 +117,8 @@
 		"upgrades/premium-themes": true,
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
-		"upgrades/presale-chat": true
+		"upgrades/presale-chat": true,
+		"wp-login": true
 	},
 	"siftscience_key": "e00e878351",
 	"wpcom_signup_id": "39911",


### PR DESCRIPTION
Enables Magic Login flow in the wpcalypso config.

Since the `wp-login` feature is required for visiting `/login`, this also enables that flag in the wpcalyspo config (even though the basic login form is not yet hooked up).