### PR TITLE
Happychat: Disable composer for customers that were blocked by operators

### DIFF
--- a/client/state/happychat/selectors.js
+++ b/client/state/happychat/selectors.js
@@ -22,7 +22,6 @@ export const HAPPYCHAT_CHAT_STATUS_ASSIGNING = 'assigning';
 export const HAPPYCHAT_CHAT_STATUS_PENDING = 'pending';
 export const HAPPYCHAT_CHAT_STATUS_MISSED = 'missed';
 export const HAPPYCHAT_CHAT_STATUS_ABANDONED = 'abandoned';
-export const HAPPYCHAT_CHAT_STATUS_BLOCKED = 'blocked';
 
 export const getHappychatChatStatus = createSelector(
 	state => state.happychat.chatStatus
@@ -43,8 +42,12 @@ export const getHappychatConnectionStatus = createSelector(
 
 export const isHappychatUninitialized = state => getHappychatConnectionStatus( state ) === 'uninitialized';
 
+export const isHappychatAcceptingChats = createSelector(
+	state => state.happychat.isAvailable
+);
+
 export const isHappychatChatActive = createSelector(
-	state => ! includes( [ HAPPYCHAT_CHAT_STATUS_DEFAULT, HAPPYCHAT_CHAT_STATUS_BLOCKED ], state.happychat.chatStatus ),
+	state => ! includes( [ HAPPYCHAT_CHAT_STATUS_DEFAULT ], state.happychat.chatStatus ) && isHappychatAcceptingChats( state ),
 	state => state.happychat.chatStatus
 );
 
@@ -59,10 +62,6 @@ export const isHappychatServerReachable = createSelector(
  */
 export const getHappychatStatus = createSelector(
 	state => state.happychat.chatStatus
-);
-
-export const isHappychatAcceptingChats = createSelector(
-	state => state.happychat.isAvailable
 );
 
 export const isHappychatAvailable = createSelector(
@@ -85,9 +84,9 @@ export const canUserSendMessages = createSelector(
 		getHappychatConnectionStatus( state ) === 'connected' &&
 		! includes(
 			[	HAPPYCHAT_CHAT_STATUS_PENDING, HAPPYCHAT_CHAT_STATUS_MISSED,
-				HAPPYCHAT_CHAT_STATUS_ABANDONED, HAPPYCHAT_CHAT_STATUS_BLOCKED ],
+				HAPPYCHAT_CHAT_STATUS_ABANDONED ],
 			getHappychatChatStatus( state )
-		)
+		) && isHappychatAcceptingChats( state )
 	),
 	[ getHappychatConnectionStatus, getHappychatChatStatus ]
 );

--- a/client/state/happychat/selectors.js
+++ b/client/state/happychat/selectors.js
@@ -44,7 +44,7 @@ export const getHappychatConnectionStatus = createSelector(
 export const isHappychatUninitialized = state => getHappychatConnectionStatus( state ) === 'uninitialized';
 
 export const isHappychatChatActive = createSelector(
-	state => state.happychat.chatStatus !== HAPPYCHAT_CHAT_STATUS_DEFAULT,
+	state => ! includes( [ HAPPYCHAT_CHAT_STATUS_DEFAULT, HAPPYCHAT_CHAT_STATUS_BLOCKED ], state.happychat.chatStatus ),
 	state => state.happychat.chatStatus
 );
 

--- a/client/state/happychat/selectors.js
+++ b/client/state/happychat/selectors.js
@@ -22,6 +22,7 @@ export const HAPPYCHAT_CHAT_STATUS_ASSIGNING = 'assigning';
 export const HAPPYCHAT_CHAT_STATUS_PENDING = 'pending';
 export const HAPPYCHAT_CHAT_STATUS_MISSED = 'missed';
 export const HAPPYCHAT_CHAT_STATUS_ABANDONED = 'abandoned';
+export const HAPPYCHAT_CHAT_STATUS_BLOCKED = 'blocked';
 
 export const getHappychatChatStatus = createSelector(
 	state => state.happychat.chatStatus
@@ -83,7 +84,8 @@ export const canUserSendMessages = createSelector(
 	state => (
 		getHappychatConnectionStatus( state ) === 'connected' &&
 		! includes(
-			[	HAPPYCHAT_CHAT_STATUS_PENDING, HAPPYCHAT_CHAT_STATUS_MISSED, HAPPYCHAT_CHAT_STATUS_ABANDONED ],
+			[	HAPPYCHAT_CHAT_STATUS_PENDING, HAPPYCHAT_CHAT_STATUS_MISSED,
+				HAPPYCHAT_CHAT_STATUS_ABANDONED, HAPPYCHAT_CHAT_STATUS_BLOCKED ],
 			getHappychatChatStatus( state )
 		)
 	),


### PR DESCRIPTION
This PR will disable typing in the chat box for users that were blocked by happiness engineers.
This is dependent on other systems being deployed, more information about this and how to test it on  235-gh-happychat

Implementation description:
- Added a new chat status for blocked users (HAPPYCHAT_CHAT_STATUS_BLOCKED)
- Added the block status `canUserSendMessages` list of statuses that do not allow typing
- Method `isHappychatChatActive` will return `false` if the chat is blocked this will make Happychat button disabled for blocked users.