### PR TITLE
Reader: fix dismiss rec by passing in the proper storeId to Recommend…

### DIFF
--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -379,6 +379,7 @@ class ReaderStream extends React.Component {
 	}
 
 	renderPost = ( postKey, index ) => {
+		const recStoreId = this.props.recommendationsStore && this.props.recommendationsStore.id;
 		const selectedPostKey = this.props.postsStore.getSelectedPostKey();
 		const isSelected = !! ( selectedPostKey &&
 			selectedPostKey.postId === postKey.postId &&
@@ -414,6 +415,7 @@ class ReaderStream extends React.Component {
 			blockedSites={ this.props.blockedSites }
 			index={ index }
 			selectedPostKey={ selectedPostKey }
+			recStoreId={ recStoreId }
 		/>;
 	}
 

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -30,6 +30,7 @@ export default class PostLifecycle extends React.PureComponent {
 		postKey: PropTypes.object.isRequired,
 		isDiscoverStream: PropTypes.bool,
 		handleClick: PropTypes.func,
+		recStoreId: PropTypes.string,
 	}
 
 	state = {
@@ -82,14 +83,14 @@ export default class PostLifecycle extends React.PureComponent {
 
 	render() {
 		const post = this.state.post;
-		const { postKey, selectedPostKey } = this.props;
+		const { postKey, selectedPostKey, recStoreId } = this.props;
 
 		if ( postKey.isRecommendationBlock ) {
 			return (
 				<RecommendedPosts
 					recommendations={ postKey.recommendations }
 					index={ postKey.index }
-					storeId={ this.props.store.id }
+					storeId={ recStoreId }
 					followSource={ IN_STREAM_RECOMMENDATION }
 				/>
 			);


### PR DESCRIPTION
Reader: fix dismiss rec by passing in the proper storeId to RecommendedPosts component.

Fix for https://github.com/Automattic/wp-calypso/issues/12820