### PR TITLE
Reader: fix reader-post-options requiring wrong Query component

### DIFF
--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -107,8 +107,8 @@ class ReaderPostOptionsMenu extends React.Component {
 
 		return (
 			<span className={ classes }>
-				{ ! feed && post && post.feed_ID && <QueryReaderFeed feedId={ post.feed_ID } /> }
-				{ ! site && post && post.site_ID && <QueryReaderSite siteId={ post.site_ID } /> }
+				{ ! feed && post && post.feed_ID && <QueryReaderFeed feedId={ +post.feed_ID } /> }
+				{ ! site && post && post.site_ID && <QueryReaderSite siteId={ +post.site_ID } /> }
 				<EllipsisMenu
 					className="reader-post-options-menu__ellipsis-menu"
 					popoverClassName="reader-post-options-menu__popover"

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -21,7 +21,7 @@ import * as stats from 'reader/stats';
 import { getFeed } from 'state/reader/feeds/selectors';
 import { getSite } from 'state/reader/sites/selectors';
 import QueryReaderFeed from 'components/data/query-reader-feed';
-import QueryReaderSite from 'components/data/query-reader-feed';
+import QueryReaderSite from 'components/data/query-reader-site';
 
 class ReaderPostOptionsMenu extends React.Component {
 


### PR DESCRIPTION
Fix for faulty 404 we have been throwing caused by handing a QueryReaderFeed component a `siteId` instead of a `feedId`.  

also fixes a proptype warning