### PR TITLE
DevDocs Reader: make SubscriptionListItem connected to actual feeds/s…

### DIFF
--- a/client/blocks/reader-subscription-list-item/docs/example.jsx
+++ b/client/blocks/reader-subscription-list-item/docs/example.jsx
@@ -9,7 +9,7 @@ import React, { PureComponent } from 'react';
 import ReaderSubscriptionListItem from '../';
 import Card from 'components/card';
 import { getCurrentUser } from 'state/current-user/selectors';
-import feedSiteFluxAdapter from 'lib/reader-post-flux-adapter';
+import connectSite from 'lib/reader-connect-site';
 import { localize } from 'i18n-calypso';
 
 
@@ -21,7 +21,7 @@ const items = [
 	{ feedId: 19850964 },
 ];
 
-const ConnectedListItem = localize( feedSiteFluxAdapter(
+const ConnectedListItem = localize( connectSite(
 	( { feed, site, translate, url, feedId, siteId } ) => (
 		<ReaderSubscriptionListItem
 			siteUrl={ url }

--- a/client/blocks/reader-subscription-list-item/docs/example.jsx
+++ b/client/blocks/reader-subscription-list-item/docs/example.jsx
@@ -9,85 +9,33 @@ import React, { PureComponent } from 'react';
 import ReaderSubscriptionListItem from '../';
 import Card from 'components/card';
 import { getCurrentUser } from 'state/current-user/selectors';
+import feedSiteFluxAdapter from 'lib/reader-post-flux-adapter';
+import { localize } from 'i18n-calypso';
 
 
 const items = [
-	{
-		siteAuthor: {
-			avatar_URL: 'https://2.gravatar.com/avatar/83cb16245c3d8ac5f625ebf91a7827e7?d=identicon&r=G&s=1600A',
-			first_name: 'Allison',
-			last_name: undefined,
-		},
-		siteUrl: 'http://afarmgirlslife.wordpress.com',
-		siteTitle: 'A Farm Girls Life',
-		siteExcerpt: 'Photography, Crafty Things, and Life on the Farm',
-		lastUpdated: new Date() - 10000000,
-		feedId: '21587482',
-	},
-	{
-		siteAuthor: {
-			avatar_URL: 'https://2.gravatar.com/avatar/bd02f74face048cc62c4eda28cea9937?d=mm&r=G&s=96',
-			first_name: undefined,
-			last_name: undefined,
-		},
-		siteUrl: 'https://fourthgenerationfarmgirl.com/',
-		siteTitle: 'fourth generation farmgirl',
-		siteExcerpt: 'wool and wine to tractors and travel',
-		lastUpdated: new Date() - 5000,
-		feedId: '24393283',
-	},
-	{
-		siteAuthor: {
-			avatar_URL: 'https://1.gravatar.com/avatar/d32da26cc0df3353cc997eea1da557a6?s=96&d=https%3A%2F%2Fs0.wp.com%2Fi%2Fmu.gif&r=G',
-			first_name: 'Ben',
-			last_name: 'Orlin',
-			has_avatar: false,
-		},
-		siteUrl: 'http://mathwithbaddrawings.com',
-		siteTitle: 'Math with Bad Drawings',
-		siteExcerpt: 'Math, teaching, copious metaphors, and drawings that will never ever earn a spot on the fridge',
-		lastUpdated: new Date() - 1000000,
-		feedId: '10056049',
-		site: {
-			icon: {
-				img: 'https://secure.gravatar.com/blavatar/11f9cce0bbf89940278ac446f3c3505a',
-			}
-		}
-	},
-	{
-		siteUrl: 'http://b19ytest.wordpress.com',
-		siteTitle: 'AAAA BEST BLOG WOULD BLOG AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN AND AGAIN',
-		siteAuthor: {
-			name: 'b3n low3ry',
-			first_name: 'Ben',
-			last_name: 'Lowery',
-			URL: 'http://b19y.com',
-			avatar_URL: 'https://0.gravatar.com/avatar/3b7b2c457b9201d166b9a2b47cadc86d?s=96&d=identicon&r=G'
-		},
-		siteExcerpt: 'BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS BEST SITE ON THE INTERWEBS',
-		feedId: 25320833,
-		siteId: 77147075,
-		feed: { image: 'http://s2.wp.com/i/buttonw-com.png' }
-	},
-	{
-		siteUrl: 'http://theatlantic.com/feed/all',
-		siteTitle: 'The Atlantic',
-		lastUpdated: new Date() - 100000,
-		feedId: '49548095',
-	},
-	{
-		siteUrl: 'http://uproxx.com',
-		siteTitle: 'Real Stories – UPROXX',
-		siteExcerpt: 'The Culture Of Now',
-		lastUpdated: new Date() - 100000,
-		feedId: '19850964',
-		site: {
-			icon: {
-				img: 'https://secure.gravatar.com/blavatar/bae760df0e3bd64e122a0b36facaee58',
-			}
-		}
-	},
-]
+	{ feedId: 21587482 },
+	{ feedId: 24393283 },
+	{ feedId: 10056049 },
+	{ siteId: 77147075 },
+	{ feedId: 19850964 },
+];
+
+const ConnectedListItem = localize( feedSiteFluxAdapter(
+	( { feed, site, translate, url, feedId, siteId } ) => (
+		<ReaderSubscriptionListItem
+			siteUrl={ url }
+			siteTitle={ feed && feed.name }
+			siteAuthor={ site && site.owner }
+			siteExcerpt={ feed && feed.description }
+			translate={ translate }
+			feedId={ feedId }
+			siteId={ siteId }
+			site={ site }
+			feed={ feed }
+		/>
+	)
+) );
 
 export default class ReaderSubscriptionListItemExample extends PureComponent {
 	static displayName = 'ReaderSubscriptionListItem';
@@ -96,13 +44,13 @@ export default class ReaderSubscriptionListItemExample extends PureComponent {
 		return (
 			<Card>
 				{ items.map( item =>
-						<ReaderSubscriptionListItem
-							isFollowing={ true }
-							key={ item.siteUrl }
+						<ConnectedListItem
+							key={ item.feedId || item.siteId }
 							{ ...item }
 						/>
 				) }
 			</Card>
+
 		);
 	}
 };

--- a/client/blocks/reader-subscription-list-item/docs/example.jsx
+++ b/client/blocks/reader-subscription-list-item/docs/example.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PureComponent } from 'react';
+import { map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -10,24 +11,15 @@ import ConnectedReaderSubscriptionListItem from 'reader/following-manage/connect
 import Card from 'components/card';
 
 
-const longreads = { siteId: 70135762 };
-const wordpress = { feedId: 25823 };
-const bestBlogInTheWorldAAA = { siteId: 77147075 };
-const mathWithBadDrawings = { feedId: 10056049 };
-const uproxx = { feedId: 19850964 };
-const atlantic = { feedId: 49548095 };
-const fourthGenerationFarmGirl = { feedId: 24393283 };
-
-
-const items = [
-	longreads,
-	wordpress,
-	bestBlogInTheWorldAAA,
-	fourthGenerationFarmGirl,
-	atlantic,
-	mathWithBadDrawings,
-	uproxx,
-];
+const sites = {
+	'longreads': { siteId: 70135762 },
+	'wordpress': { feedId: 25823 },
+	'bestBlogInTheWorldAAA': { siteId: 77147075 },
+	'mathWithBadDrawings': { feedId: 10056049 },
+	'uproxx': { feedId: 19850964 },
+	'atlantic': { feedId: 49548095 },
+	'fourthGenerationFarmGirl': { feedId: 24393283 },
+}
 
 export default class ReaderSubscriptionListItemExample extends PureComponent {
 	static displayName = 'ReaderSubscriptionListItem';
@@ -35,10 +27,10 @@ export default class ReaderSubscriptionListItemExample extends PureComponent {
 	render() {
 		return (
 			<Card>
-				{ items.map( item =>
+				{ map( sites, site =>
 						<ConnectedReaderSubscriptionListItem
-							key={ item.feedId || item.siteId }
-							{ ...item }
+							key={ site.feedId || site.siteId }
+							{ ...site }
 						/>
 				) }
 			</Card>

--- a/client/blocks/reader-subscription-list-item/docs/example.jsx
+++ b/client/blocks/reader-subscription-list-item/docs/example.jsx
@@ -6,11 +6,8 @@ import React, { PureComponent } from 'react';
 /**
  * Internal dependencies
  */
-import ReaderSubscriptionListItem from '../';
+import ConnectedReaderSubscriptionListItem from 'reader/following-manage/connected-subscription-list-item';
 import Card from 'components/card';
-import { getCurrentUser } from 'state/current-user/selectors';
-import connectSite from 'lib/reader-connect-site';
-import { localize } from 'i18n-calypso';
 
 
 const items = [
@@ -21,22 +18,6 @@ const items = [
 	{ feedId: 19850964 },
 ];
 
-const ConnectedListItem = localize( connectSite(
-	( { feed, site, translate, url, feedId, siteId } ) => (
-		<ReaderSubscriptionListItem
-			siteUrl={ url }
-			siteTitle={ feed && feed.name }
-			siteAuthor={ site && site.owner }
-			siteExcerpt={ feed && feed.description }
-			translate={ translate }
-			feedId={ feedId }
-			siteId={ siteId }
-			site={ site }
-			feed={ feed }
-		/>
-	)
-) );
-
 export default class ReaderSubscriptionListItemExample extends PureComponent {
 	static displayName = 'ReaderSubscriptionListItem';
 
@@ -44,7 +25,7 @@ export default class ReaderSubscriptionListItemExample extends PureComponent {
 		return (
 			<Card>
 				{ items.map( item =>
-						<ConnectedListItem
+						<ConnectedReaderSubscriptionListItem
 							key={ item.feedId || item.siteId }
 							{ ...item }
 						/>

--- a/client/blocks/reader-subscription-list-item/docs/example.jsx
+++ b/client/blocks/reader-subscription-list-item/docs/example.jsx
@@ -10,12 +10,23 @@ import ConnectedReaderSubscriptionListItem from 'reader/following-manage/connect
 import Card from 'components/card';
 
 
+const longreads = { siteId: 70135762 };
+const wordpress = { feedId: 25823 };
+const bestBlogInTheWorldAAA = { siteId: 77147075 };
+const mathWithBadDrawings = { feedId: 10056049 };
+const uproxx = { feedId: 19850964 };
+const atlantic = { feedId: 49548095 };
+const fourthGenerationFarmGirl = { feedId: 24393283 };
+
+
 const items = [
-	{ feedId: 21587482 },
-	{ feedId: 24393283 },
-	{ feedId: 10056049 },
-	{ siteId: 77147075 },
-	{ feedId: 19850964 },
+	longreads,
+	wordpress,
+	bestBlogInTheWorldAAA,
+	fourthGenerationFarmGirl,
+	atlantic,
+	mathWithBadDrawings,
+	uproxx,
 ];
 
 export default class ReaderSubscriptionListItemExample extends PureComponent {

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -30,11 +30,7 @@ function SettingsMenu() {
 }
 
 function ReaderSubscriptionListItem( {
-	isFollowing,
-	siteUrl,
-	siteTitle,
-	siteAuthor,
-	siteExcerpt,
+	url,
 	feedId,
 	feed,
 	siteId,
@@ -44,6 +40,9 @@ function ReaderSubscriptionListItem( {
 	lastUpdated,
 	translate,
 } ) {
+	const siteTitle = feed && feed.name;
+	const siteAuthor = site && site.owner;
+	const siteExcerpt = feed && feed.description;
 	// prefer a users name property
 	// if that doesn't exist settle for combining first and last name
 	const authorName = siteAuthor && ( siteAuthor.name ||
@@ -51,6 +50,10 @@ function ReaderSubscriptionListItem( {
 	const siteIcon = get( site, 'icon.img' );
 	const feedIcon = get( feed, 'image' );
 	const streamUrl = getStreamUrl( feedId, siteId );
+	const siteUrl = url ||
+		( feed && ( feed.feed_URL || feed.URL ) ) ||
+		( site && site.URL );
+	const isFollowing = ( feed && feed.is_following ) || ( site && site.is_following );
 
 	return (
 		<div className={ classnames( 'reader-subscription-list-item', className ) }>

--- a/client/reader/following-manage/connected-subscription-list-item.jsx
+++ b/client/reader/following-manage/connected-subscription-list-item.jsx
@@ -13,15 +13,12 @@ import SubscriptionListItem from 'blocks/reader-subscription-list-item/';
 export default localize( connectSite(
 	( { feed, site, translate, url, feedId, siteId } ) => (
 		<SubscriptionListItem
-			siteUrl={ url }
-			siteTitle={ feed && feed.name }
-			siteAuthor={ site && site.owner }
-			siteExcerpt={ feed && feed.description }
 			translate={ translate }
 			feedId={ feedId }
 			siteId={ siteId }
 			site={ site }
 			feed={ feed }
+			url={ url }
 		/>
 	)
 ) );

--- a/client/state/reader/feeds/reducer.js
+++ b/client/state/reader/feeds/reducer.js
@@ -94,6 +94,9 @@ export function queuedRequests( state = {}, action ) {
 		case READER_FEED_REQUEST_SUCCESS:
 		case READER_FEED_REQUEST_FAILURE:
 			return omit( state, action.payload.feed_ID );
+		case SERIALIZE:
+		case DESERIALIZE:
+			return {};
 	}
 	return state;
 }


### PR DESCRIPTION
We recently changed the `sites` api to return `has_avatar` in the `owner` property of site.  Unfortunately since this example is using hard coded data, it became outdated.

- This PR seeks to make the example depend on the actual api endpoint.
- also makes the ReaderSubscriptionListItem depend on site/feed objects instead of needing everything handed to it

Future PR:
- still need to connect the `ReaderFollowButton` component so that it picks up follow state changes