### PR TITLE
HTTP: Pass along the api version for all request methods

### DIFF
--- a/client/state/data-layer/wpcom-http/actions.js
+++ b/client/state/data-layer/wpcom-http/actions.js
@@ -35,7 +35,7 @@ export const http = ( {
 	body,
 	method,
 	path,
-	query: method === 'GET' && { ...query, apiVersion },
+	query: method === 'GET' ? { ...query, apiVersion } : { apiVersion },
 	formData,
 	onSuccess: onSuccess || action,
 	onFailure: onFailure || action,


### PR DESCRIPTION
Previously, we would only pass it along for GET requests. This allows POST to also use api versions other than v1.