### PR TITLE
Framework: Allow debug everywhere

### DIFF
--- a/client/lib/debug-noop/README.md
+++ b/client/lib/debug-noop/README.md
@@ -1,4 +1,0 @@
-Debug Noop
-==========
-
-Debug Noop is a simple [noop](https://en.wikipedia.org/wiki/NOP) intended for use as a drop-in substitute for the [`debug` module](http://npmjs.com/package/debug) in production Webpack configurations using the [`webpack.NormalModuleReplacementPlugin` plugin](https://webpack.github.io/docs/list-of-plugins.html#normalmodulereplacementplugin).

--- a/client/lib/debug-noop/index.js
+++ b/client/lib/debug-noop/index.js
@@ -1,1 +1,0 @@
-export default () => () => {};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -201,13 +201,6 @@ if ( calypsoEnv === 'development' ) {
 	webpackConfig.devtool = false;
 }
 
-if ( calypsoEnv === 'production' ) {
-	webpackConfig.plugins.push( new webpack.NormalModuleReplacementPlugin(
-		/^debug$/,
-		path.join( __dirname, 'client', 'lib', 'debug-noop' )
-	) );
-}
-
 if ( ! config.isEnabled( 'desktop' ) ) {
 	webpackConfig.plugins.push( new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]desktop$/, 'lodash/noop' ) );
 }


### PR DESCRIPTION
Stop replacing debug with debug-noop in in production.

Thinking:
1. its helpful to be able to look at debug statements in every environment
2. debug is a tiny library that [doesn't add much](https://github.com/Automattic/wp-calypso/pull/12841#issuecomment-313754572) to our bundle size
3. debug wont' hurt performance in any way for those uninterested since it is opt-in via localStorage anway.


To Test:
- [ ] debug statements should still work in development
- [ ] debug statements should now work in docker