### PR TITLE
Reader: set tag count to 3 on post cards, ending A/B test

### DIFF
--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -21,10 +21,8 @@ import ReaderSiteStreamLink from 'blocks/reader-site-stream-link';
 import { getStreamUrl } from 'reader/route';
 import ReaderAuthorLink from 'blocks/reader-author-link';
 import { areEqualIgnoringWhitespaceAndCase } from 'lib/string';
-import { abtest } from 'lib/abtest';
 
-// A/B test to try showing 3 tags per post instead of 1
-const TAGS_TO_SHOW = abtest( 'readerPostCardTagCount' ) === 'showThree' ? 3 : 1;
+const TAGS_TO_SHOW = 3;
 
 class TagLink extends React.Component {
 	recordSingleTagClick = () => {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -25,15 +25,6 @@ module.exports = {
 		},
 		defaultVariation: 'original',
 	},
-	readerPostCardTagCount: {
-		datestamp: '20170315',
-		variations: {
-			showOne: 50,
-			showThree: 50
-		},
-		defaultVariation: 'showThree',
-		allowExistingUsers: true
-	},
 	automatedTransfer2: {
 		datestamp: '20170316',
 		variations: {


### PR DESCRIPTION
Second go at https://github.com/Automattic/wp-calypso/pull/12824.

Set the tag count to 3 on post cards for everyone.