### PR TITLE
Themes: Return 404 Status when Theme isn't Found

### DIFF
--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -52,7 +52,7 @@ export function fetchThemeDetailsData( context, next ) {
 				context.renderCacheKey = 'theme not found';
 				const err = {
 					status: 404,
-					error: 'Theme Not Found',
+					message: 'Theme Not Found',
 					themeSlug
 				};
 				return next( err );

--- a/client/my-sites/theme/index.node.js
+++ b/client/my-sites/theme/index.node.js
@@ -3,10 +3,11 @@
  */
 import config from 'config';
 import { makeLayout } from 'controller';
-import { details, fetchThemeDetailsData } from './controller';
+import { details, fetchThemeDetailsData, notFoundError } from './controller';
 
 export default function( router ) {
 	if ( config.isEnabled( 'manage/themes/details' ) ) {
 		router( '/theme/:slug/:section(setup|support)?/:site_id?', fetchThemeDetailsData, details, makeLayout );
+		router( notFoundError );
 	}
 }

--- a/docs/isomorphic-routing.md
+++ b/docs/isomorphic-routing.md
@@ -47,3 +47,48 @@ handler and add your isomorphic section to the `singleTreeSections` whitelist ar
 * Behind the scenes, we're using a [util](../server/isomorphic-routing/README.md) that adapts `page.js` style middleware to [Express](https://expressjs.com/en/guide/routing.html)',
 our server router's middleware signatures. We might want to switch to an isomorphic
 router in the future.
+
+# Error Handling
+
+We support error handling middleware on the server side. Among other things, this is
+so that server-side rendered sections can set an HTTP error status, such as 404 if something isn't found.
+
+An error handling middleware takes three instead of just two arguments, `err, context, next`.
+Invoke it with `router` at the end of your route definitions:
+
+```js
+export function notFoundError( err, context, next ) {
+	context.layout = (
+		<ReduxProvider store={ context.store }>
+			<LayoutLoggedOut primary={ <ThemeNotFoundError /> } />
+		</ReduxProvider>
+	);
+	next( err );
+}
+
+export default function( router ) {
+  router( '/themes/:slug/:section?/:site_id?', details, makeLayout );
+  router( themeNotFound );
+}
+```
+
+Note that in `notFoundError`, `err` is passed as an argument to `next`. This is how error middleware chains skip skip regular middlewares. The rendering middleware that is implicitly called on the server after all other middlewares are invoked uses `err.status` to set the HTTP error status.
+
+On the other hand, an error-handling middleware like `themeNotFound` will be called if any other middleware before it calls `next` with an error object:
+
+```js
+function details( context, next ) ) {
+  const theme = fetchThemeSomehow( context.params.slug );
+  if ( ! theme ) {
+    const err = {
+      status: 404,
+      error: 'Theme Not Found',
+      context.params.slug
+    };
+    return next( err );
+  }
+  /* Render theme section */
+  next();
+  }
+}
+```

--- a/docs/isomorphic-routing.md
+++ b/docs/isomorphic-routing.md
@@ -82,7 +82,7 @@ function details( context, next ) ) {
   if ( ! theme ) {
     const err = {
       status: 404,
-      error: 'Theme Not Found',
+      message: 'Theme Not Found',
       context.params.slug
     };
     return next( err );

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -8,6 +8,10 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 	return function( route, ...middlewares ) {
 		if ( middlewares.length === 0 && typeof route === 'function' && route.length === 3 ) {
 			// No route def -- the route arg is really an error-handling middleware
+			// `page( someMw )` would be a shorthand for `page( '*', someMw )`, even tho the same isn't true
+			// for Express, we want things to be isomorphic, so that should be handled by the `else` branch.
+			// OTOH, if `someMw` takes 3 args `( err, context, next )` instead of the usual 2 `( context, next )`,
+			// it's an error-handling middleware and needs to be handled by this branch.
 			expressApp.use( ( err, req, res, next ) => {
 				route( err, req.context, next );
 			} );

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -12,12 +12,15 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 			// for Express, we want things to be isomorphic, so that should be handled by the `else` branch.
 			// OTOH, if `someMw` takes 3 args `( err, context, next )` instead of the usual 2 `( context, next )`,
 			// it's an error-handling middleware and needs to be handled by this branch.
-			expressApp.use( ( err, req, res, next ) => {
-				route( err, req.context, next );
-			} );
-			expressApp.use( ( err, req, res, next ) => { // eslint-disable-line no-unused-vars
-				serverRender( req, res.status( err.status ) );
-			} );
+			expressApp.use(
+				( err, req, res, next ) => {
+					route( err, req.context, next );
+				},
+				// We need 4 args so Express knows this is an error-handling middleware
+				( err, req, res, next ) => { // eslint-disable-line no-unused-vars
+					serverRender( req, res.status( err.status ) );
+				}
+			);
 		} else {
 			expressApp.get(
 				route,

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -47,6 +47,6 @@ function applyMiddlewares( context, ...middlewares ) {
 
 function compose( ...functions ) {
 	return functions.reduceRight( ( composed, f ) => (
-		next => f( composed ) // eslint-disable-line no-unused-vars
+		() => f( composed )
 	), () => {} );
 }


### PR DESCRIPTION
This leverages Express' error handling middlewares to allow us to throw an error. Used here for theme sheets, but should work more generally for other sections, too.

To test:
* Restart Calypso, using `DEBUG="calypso:server-render" make run`
* Logged-out, land on a non-existing theme's sheet, e.g. `http://calypso.localhost:3000/theme/garbage`. Verify that it 404s! (e.g. in the node console, or in your browser console's Network tab) Also verify that it renders correctly -- no reconc errors!
* Verify that sheets still work for existing themes.
* Check that API/markup caching still works -- watch your node console for cache hits/misses

cc @budzanowski @seear @mtias @ehg 