### PR TITLE
Site Settings: Use new banner for Footer credit upgrade nudge

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -28,9 +28,9 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import Timezone from 'components/timezone';
 import JetpackSyncPanel from './jetpack-sync-panel';
 import SiteIconSetting from './site-icon-setting';
-import UpgradeNudge from 'my-sites/upgrade-nudge';
+import Banner from 'components/banner';
 import { isBusiness } from 'lib/products-values';
-import { FEATURE_NO_BRANDING } from 'lib/plans/constants';
+import { FEATURE_NO_BRANDING, PLAN_BUSINESS } from 'lib/plans/constants';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import {
 	getLocalizedDate,
@@ -523,13 +523,15 @@ class SiteSettingsFormGeneral extends Component {
 								</Button>
 							</div>
 						</CompactCard>
-						{ ! isBusiness( site.plan ) && <UpgradeNudge
-							className="site-settings__footer-credit-nudge"
-							feature={ FEATURE_NO_BRANDING }
-							title={ translate( 'Remove the footer credit entirely with WordPress.com Business' ) }
-							message={ translate( 'Upgrade to remove the footer credit, add Google Analytics and more' ) }
-							icon="customize"
-						/> }
+						{
+							! isBusiness( site.plan ) &&
+							<Banner
+								feature={ FEATURE_NO_BRANDING }
+								plan={ PLAN_BUSINESS }
+								title={ translate( 'Remove the footer credit entirely with WordPress.com Business' ) }
+								description={ translate( 'Upgrade to remove the footer credit, add Google Analytics and more' ) }
+							/>
+						}
 					</div>
 				}
 


### PR DESCRIPTION
This PR updates the Footer credit upgrade nudge to use the new purple business plan component. 
Fixes #12835.

Before:
![](https://cldup.com/poTK6h51Ik.png)

After:
![](https://cldup.com/on7PyHRDVh.png)

To test:
* Checkout this branch or get it going on calypso.live
* Go to `/settings/general/$site`, where `$site` is one of your WordPress.com sites with a plan different than Business.
* Verify you see the new nudge under "Footer Credit" instead of the old one.
