### PR TITLE
Site Settings: Use proper URL for analytics support link for Jetpack sites

### DIFF
--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -74,6 +74,9 @@ class GoogleAnalyticsForm extends Component {
 
 		const placeholderText = isRequestingSettings ? translate( 'Loading' ) : '';
 		const isJetpackUnsupported = siteIsJetpack && ! jetpackVersionSupportsModule;
+		const analyticsSupportUrl = siteIsJetpack
+			? 'https://jetpack.com/support/google-analytics/'
+			: 'https://support.wordpress.com/google-analytics/';
 
 		return (
 			<form id="site-settings" onSubmit={ handleSubmitForm }>
@@ -176,7 +179,7 @@ class GoogleAnalyticsForm extends Component {
 					{ translate( 'Learn more about using {{a}}Google Analytics with WordPress.com{{/a}}.',
 						{
 							components: {
-								a: <a href="http://en.support.wordpress.com/google-analytics/" target="_blank" rel="noopener noreferrer" />
+								a: <a href={ analyticsSupportUrl } target="_blank" rel="noopener noreferrer" />
 							}
 						}
 					) }


### PR DESCRIPTION
This PR fixes #11088, where the Analytics support link should lead to the Jetpack support document for Jetpack sites:

![](https://cldup.com/6w2tE226hX.png)

To test:
* Checkout this branch or get it going on calypso.live
* Go to `/settings/traffic/$site`, where `$site` is one of your Jetpack sites.
* Verify the "Google Analytics with WordPress.com" link leads to https://jetpack.com/support/google-analytics/
* Go to `/settings/traffic/$site`, where `$site` is one of your WordPress.com sites.
* Verify the "Google Analytics with WordPress.com" link leads to https://support.wordpress.com/google-analytics/

