### PR TITLE
Site Settings: Add checkmark in the Jetpack Site Stats header

### DIFF
--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import Gridicon from 'gridicons';
 import FoldableCard from 'components/foldable-card';
 import SectionHeader from 'components/section-header';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -101,7 +102,12 @@ class JetpackSiteStats extends Component {
 			siteRoles,
 			translate
 		} = this.props;
-		const header = translate( 'Collecting valuable traffic stats and insights' );
+		const header = (
+			<div>
+				<Gridicon icon="checkmark" />
+				{ translate( 'Collecting valuable traffic stats and insights' ) }
+			</div>
+		);
 
 		return (
 			<div className="site-settings__traffic-settings">

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -344,6 +344,12 @@
 
 	.foldable-card__header {
 		padding: 24px;
+
+		.gridicons-checkmark {
+			margin-right: 4px;
+			vertical-align: bottom;
+			color: $alert-green;
+		}
 	}
 
 	.foldable-card__expand {


### PR DESCRIPTION
This PR adds a green checkmark to the Jetpack Site Stats foldable card header. Fixes #12840.

Before:
![](https://cldup.com/ezBsQvrV2X.png)

After:
![](https://cldup.com/-yt-xlOy6v.png)

To test:
* Checkout this branch or get it going on calypso.live
* Go to `/settings/traffic/$site`, where `$site` is one of your Jetpack sites.
* Verify the checkmark is there and looks as shown on the preview.