### PR TITLE
Extensions: WP Super Cache - Remove Plugins and Debug tabs

### DIFF
--- a/client/extensions/wp-super-cache/constants.js
+++ b/client/extensions/wp-super-cache/constants.js
@@ -4,6 +4,4 @@ export const Tabs = {
 	CDN: 'cdn',
 	CONTENTS: 'contents',
 	PRELOAD: 'preload',
-	PLUGINS: 'plugins',
-	DEBUG: 'debug',
 };

--- a/client/extensions/wp-super-cache/main.jsx
+++ b/client/extensions/wp-super-cache/main.jsx
@@ -25,10 +25,6 @@ const WPSuperCache = ( { site, tab } ) => {
 				return <ContentsTab isMultisite={ site.is_multisite } />;
 			case Tabs.PRELOAD:
 				break;
-			case Tabs.PLUGINS:
-				break;
-			case Tabs.DEBUG:
-				break;
 			default:
 				return <Easy site={ site } />;
 		}

--- a/client/extensions/wp-super-cache/navigation.jsx
+++ b/client/extensions/wp-super-cache/navigation.jsx
@@ -25,10 +25,6 @@ const Navigation = ( { activeTab, site, translate } ) => {
 				return translate( 'Contents' );
 			case Tabs.PRELOAD:
 				return translate( 'Preload' );
-			case Tabs.PLUGINS:
-				return translate( 'Plugins' );
-			case Tabs.DEBUG:
-				return translate( 'Debug' );
 		}
 	};
 


### PR DESCRIPTION
The "Plugins" and "Debug" tabs are not being going to be ported from the WordPress plugin at this time.