### PR TITLE
Sites: Define schema for plan.is_free

### DIFF
--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -53,7 +53,8 @@ export const sitesSchema = {
 						product_name_short: { type: 'string' },
 						free_trial: { type: 'boolean' },
 						expired: { type: 'boolean' },
-						user_is_owner: { type: 'boolean' }
+						user_is_owner: { type: 'boolean' },
+						is_free: { type: 'boolean' }
 					}
 				},
 				single_user_site: { type: 'boolean' }


### PR DESCRIPTION
This pull request seeks to define schema information for a proposed `site.plan.is_free` API field.

__Testing Instructions:__

Requires: D5023-code

With above patch applied, verify upon refreshing several times on a sites section that no warnings are logged about sites state invalidated by schema violation.