### PR TITLE
Reader Search on Manage: search box

### DIFF
--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -77,7 +77,7 @@ function ReaderSubscriptionListItem( {
 				<div>{ siteExcerpt }</div>
 				<div className="reader-subscription-list-item__site-url">
 					<a href={ siteUrl }> { siteUrl && stripUrl( siteUrl ) } </a>
-					{ moment( lastUpdated ).fromNow() }
+					{ lastUpdated && moment( lastUpdated ).fromNow() }
 				</div>
 			</div>
 			<div className="reader-subscription-list-item__options">

--- a/client/components/data/query-reader-feeds-search/index.jsx
+++ b/client/components/data/query-reader-feeds-search/index.jsx
@@ -16,13 +16,11 @@ class QueryFeedSearch extends Component {
 	}
 
 	componentWillMount() {
-		const { searchFeeds, query } = this.props;
-		searchFeeds( query );
+		this.props.requestFeedSearch( this.props.query );
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		const { searchFeeds, query } = nextProps;
-		searchFeeds( query );
+		nextProps.requestFeedSearch( nextProps.query );
 	}
 
 	render() {

--- a/client/lib/reader-connect-site/README.md
+++ b/client/lib/reader-connect-site/README.md
@@ -1,14 +1,14 @@
 Reader Connect Site
 =======
 This is a HoC that takes in a component and wraps it with one that knows how to fetch sites and feeds.
-The output component expects to be handed either a feedId or a blogId.  It will only initiate network requests if the feed/site is not already part of the state tree.
+The output component expects to be handed either a feedId or a siteId.  It will only initiate network requests if the feed/site is not already part of the state tree.
 
 ## Example
 
 ```js
 import connectSite from 'lib/reader-connect-site';
 
-const SiteInfo = => {
+const SiteInfo = () => {
 	if ( ! this.props.site ) {
 		return null;
 	}

--- a/client/lib/reader-connect-site/README.md
+++ b/client/lib/reader-connect-site/README.md
@@ -1,0 +1,27 @@
+Reader Connect Site
+=======
+This is a HoC that takes in a component and wraps it with one that knows how to fetch sites and feeds.
+The output component expects to be handed either a feedId or a blogId.  It will only initiate network requests if the feed/site is not already part of the state tree.
+
+## Example
+
+```js
+import connectSite from 'lib/reader-connect-site';
+
+const SiteInfo = => {
+	if ( ! this.props.site ) {
+		return null;
+	}
+	const { title, url, description } = this.props.site;
+	return (
+		<h1> Site Info! </h1>
+		<p> title: { title }</p>
+		<p> url: { url }</p>
+		<p> title: { description }</p>
+	)
+}
+
+const ConnectedSiteInfo = connectSite( SiteInfo );
+...
+<ConnectedSiteInfo siteId='12345' /> 
+```

--- a/client/lib/reader-connect-site/index.js
+++ b/client/lib/reader-connect-site/index.js
@@ -43,19 +43,13 @@ const connectSite = Component => {
 
 	return connect(
 		( state, ownProps ) => {
-			let { feedId, blogId } = ownProps;
-			let feed, site;
+			let { feedId, siteId } = ownProps;
+			let feed = !! feedId ? getFeed( state, feedId ) : undefined;
+			let site = !! siteId ? getSite( state, siteId ) : undefined;
 
-			if ( feedId ) {
-				feed = getFeed( state, feedId );
-			}
-			if ( blogId ) {
-				site = getSite( state, blogId );
-			}
-
-			if ( feed && ! blogId ) {
-				blogId = feed.blog_ID !== 0 && feed.blog_ID;
-				site = !! blogId ? getSite( state, feed.blog_ID ) : undefined;
+			if ( feed && ! siteId ) {
+				siteId = feed.blog_ID !== 0 && feed.blog_ID;
+				site = !! siteId ? getSite( state, feed.blog_ID ) : undefined;
 			}
 			if ( site && ! feedId ) {
 				feedId = site.feed_ID;
@@ -65,8 +59,8 @@ const connectSite = Component => {
 			return {
 				feed,
 				site,
-				siteId: +blogId,
-				feedId: +feedId,
+				siteId,
+				feedId,
 			};
 		}
 	)( connectSiteFetcher );

--- a/client/lib/reader-connect-site/index.js
+++ b/client/lib/reader-connect-site/index.js
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/*
+ * Internal Dependencies
+ */
+import { getSite } from 'state/reader/sites/selectors';
+import { getFeed } from 'state/reader/feeds/selectors';
+import QueryReaderSite from 'components/data/query-reader-site';
+import QueryReaderFeed from 'components/data/query-reader-feed';
+
+/**
+ * A HoC function that will take in reader identifiers siteId or feedId and
+ * pass down all of the fetched data objects they represent
+ *
+ *  It supports two
+ *  1. feedId --> feedId, siteId, feed, site
+ *  2. blogId --> feedId, siteId, feed, site
+ */
+const connectSite = Component => {
+	class connectSiteFetcher extends React.PureComponent {
+		static propTypes = {
+			feed: PropTypes.object,
+			site: PropTypes.object,
+		}
+
+		render() {
+			return (
+				<div>
+					{ ! this.props.feed && !! this.props.feedId && <QueryReaderFeed feedId={ this.props.feedId } /> }
+					{ ! this.props.site && !! this.props.siteId && <QueryReaderSite siteId={ this.props.siteId } /> }
+					<Component { ...this.props } />
+				</div>
+			);
+		}
+	}
+
+	return connect(
+		( state, ownProps ) => {
+			let { feedId, blogId } = ownProps;
+			let feed, site;
+
+			if ( feedId ) {
+				feed = getFeed( state, feedId );
+			}
+			if ( blogId ) {
+				site = getSite( state, blogId );
+			}
+
+			if ( feed && ! blogId ) {
+				blogId = feed.blog_ID !== 0 && feed.blog_ID;
+				site = !! blogId ? getSite( state, feed.blog_ID ) : undefined;
+			}
+			if ( site && ! feedId ) {
+				feedId = site.feed_ID;
+				feed = !! feedId ? getFeed( state, site.feed_ID ) : undefined;
+			}
+
+			return {
+				feed,
+				site,
+				siteId: +blogId,
+				feedId: +feedId,
+			};
+		}
+	)( connectSiteFetcher );
+};
+
+export default connectSite;

--- a/client/lib/reader-connect-site/index.js
+++ b/client/lib/reader-connect-site/index.js
@@ -19,6 +19,9 @@ import QueryReaderFeed from 'components/data/query-reader-feed';
  *  It supports two
  *  1. feedId --> feedId, siteId, feed, site
  *  2. blogId --> feedId, siteId, feed, site
+ *
+ * @param {object} Component the component to wrap
+ * @returns {object} wrapped component that hands down feed/site to its child
  */
 const connectSite = Component => {
 	class connectSiteFetcher extends React.PureComponent {

--- a/client/reader/following-manage/connected-subscription-list-item.jsx
+++ b/client/reader/following-manage/connected-subscription-list-item.jsx
@@ -1,0 +1,27 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal Dependencies
+ */
+import connectSite from 'lib/reader-connect-site';
+import SubscriptionListItem from 'blocks/reader-subscription-list-item/';
+
+export default localize( connectSite(
+	( { feed, site, translate, url, feedId, siteId } ) => (
+		<SubscriptionListItem
+			siteUrl={ url }
+			siteTitle={ feed && feed.name }
+			siteAuthor={ site && site.owner }
+			siteExcerpt={ feed && feed.description }
+			translate={ translate }
+			feedId={ feedId }
+			siteId={ siteId }
+			site={ site }
+			feed={ feed }
+		/>
+	)
+) );

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -88,7 +88,7 @@ class FollowingManage extends Component {
 						key={ `feedresult-${ feed.URL }` }
 						url={ feed.URL }
 						feedId={ +feed.feed_ID }
-						blogId={ +feed.blog_ID }
+						siteId={ +feed.blog_ID }
 					/>
 			</div>
 		);

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -1,18 +1,146 @@
 /**
- * External dependencies
+ * External Dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { trim, debounce } from 'lodash';
+import { localize } from 'i18n-calypso';
+import page from 'page';
+import qs from 'qs';
+import { List, WindowScroller } from 'react-virtualized';
 
-class FollowingManage extends React.Component {
+/**
+ * Internal Dependencies
+ */
+import CompactCard from 'components/card/compact';
+import DocumentHead from 'components/data/document-head';
+import HeaderBack from 'reader/header-back';
+import SearchInput from 'components/search';
+import ReaderMain from 'components/reader-main';
+import { getReaderFeedsForQuery } from 'state/selectors';
+import QueryReaderFeedsSearch from 'components/data/query-reader-feeds-search';
+import ConnectedSubscriptionListItem from './connected-subscription-list-item';
+
+class FollowingManage extends Component {
+	static propTypes = {
+		query: React.PropTypes.string,
+	};
+	state = { width: 800 };
+
+	// TODO make this common between our different search pages?
+	updateQuery = ( newValue ) => {
+		this.scrollToTop();
+		const trimmedValue = trim( newValue ).substring( 0, 1024 );
+		if ( ( trimmedValue !== '' &&
+				trimmedValue.length > 1 &&
+				trimmedValue !== this.props.query
+			) ||
+			newValue === ''
+		) {
+			let searchUrl = '/following/manage';
+			if ( newValue ) {
+				searchUrl += '?' + qs.stringify( { q: newValue } );
+			}
+			page.replace( searchUrl );
+		}
+	}
+
+	scrollToTop = () => {
+		window.scrollTo( 0, 0 );
+	}
+
+	handleStreamMounted = ( ref ) => {
+		this.streamRef = ref;
+	}
+
+	handleSearchBoxMounted = ( ref ) => {
+		this.searchBoxRef = ref;
+	}
+
+	resizeSearchBox = () => {
+		if ( this.searchBoxRef && this.streamRef ) {
+			const width = this.streamRef.getClientRects()[ 0 ].width;
+			if ( width > 0 ) {
+				this.searchBoxRef.style.width = `${ width }px`;
+			}
+			this.setState( { width } );
+		}
+	}
+
+	componentDidMount() {
+		this.resizeListener = window.addEventListener(
+			'resize',
+			debounce( this.resizeSearchBox, 50 )
+		);
+		this.resizeSearchBox();
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'resize', this.resizeListener );
+	}
+
+	searchResultRowRenderer = ( { index, key, style } ) => {
+		const { searchResults } = this.props;
+		const feed = searchResults[ index ];
+		return (
+			<div key={ key } style={ style }>
+					<ConnectedSubscriptionListItem
+						key={ `feedresult-${ feed.URL }` }
+						url={ feed.URL }
+						feedId={ +feed.feed_ID }
+						blogId={ +feed.blog_ID }
+					/>
+			</div>
+		);
+	};
 
 	render() {
+		const { query, translate, searchResults } = this.props;
+		const searchPlaceholderText = translate( 'Search millions of sites' );
+
 		return (
-			<div className="reader-following-manage">
-				<h1 className="reader-following-manage__title">Manage Following</h1>
-				<p>This is the shiny new version of Manage Following.</p>
-			</div>
+			<ReaderMain className="following-manage">
+				<DocumentHead title={ 'Manage Following' } />
+				{ this.props.showBack && <HeaderBack /> }
+				{ searchResults.length === 0 && <QueryReaderFeedsSearch query={ query } /> }
+				<h1 className="following-manage__header"> { translate( 'Follow Something New' ) } </h1>
+				<div ref={ this.handleStreamMounted } />
+				<div className="following-manage__fixed-area" ref={ this.handleSearchBoxMounted }>
+					<CompactCard className="following-manage__input-card">
+						<SearchInput
+							onSearch={ this.updateQuery }
+							onSearchClose={ this.scrollToTop }
+							autoFocus={ this.props.autoFocusInput }
+							delaySearch={ true }
+							delayTimeout={ 500 }
+							placeholder={ searchPlaceholderText }
+							initialValue={ query }
+							value={ query }>
+						</SearchInput>
+					</CompactCard>
+				</div>
+				{ !! query &&
+					<WindowScroller>
+						{ ( { height, scrollTop } ) => (
+							<List
+								autoHeight
+								height={ height }
+								rowCount={ searchResults.length }
+								rowHeight={ 83 }
+								rowRenderer={ this.searchResultRowRenderer }
+								scrollTop={ scrollTop }
+								width={ this.state.width }
+							/>
+						)}
+					</WindowScroller>
+				}
+			</ReaderMain>
 		);
 	}
 }
 
-export default FollowingManage;
+export default connect(
+	( state, ownProps ) => ( {
+		searchResults: getReaderFeedsForQuery( state, ownProps.query ) || [],
+	} ),
+)( localize( FollowingManage ) );

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -1,3 +1,7 @@
-.reader-following-manage__title {
-	font-size: 1.4em;
+.following-manage .search {
+	margin: 0px;
+}
+
+.following-manage .following-manage__input-card {
+	padding: 0px;
 }

--- a/client/reader/following/controller.js
+++ b/client/reader/following/controller.js
@@ -43,8 +43,8 @@ export default {
 	followingManage( context ) {
 		const basePath = route.sectionify( context.path ),
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Manage Followed Sites',
-			mcKey = 'following_edit',
-			search = context.query.s;
+			mcKey = 'following_manage',
+			query = context.query.q;
 
 		setPageTitle( context, i18n.translate( 'Manage Followed Sites' ) );
 
@@ -55,7 +55,7 @@ export default {
 				require="reader/following-manage"
 				key="following-manage"
 				initialFollowUrl={ context.query.follow }
-				search={ search }
+				query={ query }
 				context={ context }
 				userSettings={ userSettings }
 			/>,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -92,6 +92,7 @@
 		"reader": true,
 		"reader/combined-cards": true,
 		"reader/full-errors": true,
+		"reader/following-manage-refresh": true,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,
 		"reader/search": true,


### PR DESCRIPTION
Spin-off of https://github.com/Automattic/wp-calypso/pull/12560.
First pass at implementing the search box  / results for SoM.

Implementation notes:
1. I've create `reader-connect-site`as a new reusable HoC that will take in feedId or siteId and pass the underlying feed/site to its children.
2. using `react-virtualized`.

Question:
Do we have a better pattern for separating out dumb ui components from the data than the one i followed with `ConnectedSubscriptionListItem`?