### PR TITLE
Framework: Remove tertiary div from Layout

### DIFF
--- a/client/controller/README.md
+++ b/client/controller/README.md
@@ -9,7 +9,6 @@ both versions are provided transparently in those cases (by `index.web.js` and
 
 These middlewares include:
 * `makeLayout`: creates a `Layout` (or `LayoutLoggedOut`) component in `context.layout`.
-  Accepts `primary`, `secondary`, and `tertiary` arguments which it will use to
-  populate the corresponding `<div>`s.
+  Accepts `primary` and `secondary` arguments which it will use to populate the corresponding `<div>`s.
 * `clientRouter`: Essentially an alias for `page`, which invokes a client-side
   `render` middleware after all other middlewares.

--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -15,11 +15,10 @@ import LayoutLoggedOut from 'layout/logged-out';
  */
 export { setSection } from './shared.js';
 
-const ReduxWrappedLoggedOutLayout = ( { store, primary, secondary, tertiary } ) => (
+const ReduxWrappedLoggedOutLayout = ( { store, primary, secondary } ) => (
 	<ReduxProvider store={ store }>
 		<LayoutLoggedOut primary={ primary }
-			secondary={ secondary }
-			tertiary={ tertiary } />
+			secondary={ secondary } />
 	</ReduxProvider>
 );
 
@@ -28,6 +27,6 @@ const ReduxWrappedLoggedOutLayout = ( { store, primary, secondary, tertiary } ) 
  * @param { function } next -- Call next middleware in chain
  *
  * Produce a `LayoutLoggedOut` element in `context.layout`, using
- * `context.primary`, `context.secondary`, and `context.tertiary` to populate it.
+ * `context.primary` and `context.secondary` to populate it.
 */
 export const makeLayout = makeLayoutMiddleware( ReduxWrappedLoggedOutLayout );

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -29,20 +29,18 @@ const user = userFactory();
 const sites = sitesFactory();
 const debug = debugFactory( 'calypso:controller' );
 
-export const ReduxWrappedLayout = ( { store, primary, secondary, tertiary } ) => (
+export const ReduxWrappedLayout = ( { store, primary, secondary } ) => (
 	<ReduxProvider store={ store }>
 		{ getCurrentUser( store.getState() )
 			? <Layout primary={ primary }
 				secondary={ secondary }
-				tertiary={ tertiary }
 				user={ user }
 				sites={ sites }
 				nuxWelcome={ nuxWelcome }
 				translatorInvitation={ translatorInvitation }
 			/>
 			: <LayoutLoggedOut primary={ primary }
-				secondary={ secondary }
-				tertiary={ tertiary } />
+				secondary={ secondary } />
 		}
 	</ReduxProvider>
 );

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -12,7 +12,7 @@ import { getCurrentUser } from 'state/current-user/selectors';
 
 export function makeLayoutMiddleware( LayoutComponent ) {
 	return ( context, next ) => {
-		const { store, primary, secondary, tertiary } = context;
+		const { store, primary, secondary } = context;
 
 		// On server, only render LoggedOutLayout when logged-out.
 		if ( ! context.isServerSide || ! getCurrentUser( context.store.getState() ) ) {
@@ -20,7 +20,6 @@ export function makeLayoutMiddleware( LayoutComponent ) {
 				<LayoutComponent store={ store }
 					primary={ primary }
 					secondary={ secondary }
-					tertiary={ tertiary }
 				/>
 			);
 		}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -56,7 +56,6 @@ Layout = React.createClass( {
 	propTypes: {
 		primary: React.PropTypes.element,
 		secondary: React.PropTypes.element,
-		tertiary: React.PropTypes.element,
 		sites: React.PropTypes.object,
 		user: React.PropTypes.object,
 		nuxWelcome: React.PropTypes.object,
@@ -161,9 +160,6 @@ Layout = React.createClass( {
 					<div id="secondary" className="layout__secondary">
 						{ this.props.secondary }
 					</div>
-				</div>
-				<div id="tertiary">
-					{ this.props.tertiary }
 				</div>
 				<TranslatorLauncher
 					isEnabled={ translator.isEnabled() }

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -14,7 +14,6 @@ import { getSection } from 'state/ui/selectors';
 const LayoutLoggedOut = ( {
 	primary,
 	secondary,
-	tertiary,
 	section,
 } ) => {
 	const classes = classNames( 'layout', {
@@ -36,9 +35,6 @@ const LayoutLoggedOut = ( {
 					{ secondary }
 				</div>
 			</div>
-			<div id="tertiary">
-				{ tertiary }
-			</div>
 		</div>
 	);
 };
@@ -47,7 +43,6 @@ LayoutLoggedOut.displayName = 'LayoutLoggedOut';
 LayoutLoggedOut.propTypes = {
 	primary: React.PropTypes.element,
 	secondary: React.PropTypes.element,
-	tertiary: React.PropTypes.element,
 	section: React.PropTypes.oneOfType( [
 		React.PropTypes.bool,
 		React.PropTypes.object,

--- a/docs/isomorphic-routing.md
+++ b/docs/isomorphic-routing.md
@@ -24,7 +24,7 @@ The contract is that at the end of each route's middleware chain, `context.layou
 should contain the React render tree to be rendered, which will be done magically
 by either the client or the server render, as appropriate. (This is clearly
 different from the previous client-side-only routing approach where you'd have
-to render to `#primary`/`#secondary`/`#tertiary` DOM elements.)
+to render to `#primary`/`#secondary` DOM elements.)
 
 To facilitate that, you can (but don't have to) use the `makeLayout`
 generic middleware found in `client/controller`. So in the above example, the


### PR DESCRIPTION
And corresponding props used by isomorphic helpers.
It doesn't appear to be used anywhere anymore (try grepping).

To test -- Make sure that Calypso still runs and before. Also, make sure there are no references to `tertiary` left in the codebase.

(See https://github.com/Automattic/wp-calypso/issues/5182)