### PR TITLE
Plugins: Fix broken track events on install and remove of plugins

### DIFF
--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -38,13 +38,13 @@ export class PluginInstallButton extends Component {
 		if ( isEmbed ) {
 			recordGAEvent( 'Plugins', 'Install with no selected site', 'Plugin Name', plugin.slug );
 			recordEvent( 'calypso_plugin_install_click_from_sites_list', {
-				site: selectedSite,
+				site: selectedSite.ID,
 				plugin: plugin.slug
 			} );
 		} else {
 			recordGAEvent( 'Plugins', 'Install on selected Site', 'Plugin Name', plugin.slug );
 			recordEvent( 'calypso_plugin_install_click_from_plugin_info', {
-				site: selectedSite,
+				site: selectedSite.ID,
 				plugin: plugin.slug
 			} );
 		}
@@ -59,7 +59,7 @@ export class PluginInstallButton extends Component {
 
 		recordGAEvent( 'Plugins', 'Update jetpack', 'Plugin Name', plugin.slug );
 		recordEvent( 'calypso_plugin_update_jetpack', {
-			site: selectedSite,
+			site: selectedSite.ID,
 			plugin: plugin.slug
 		} );
 	}

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -44,13 +44,13 @@ module.exports = React.createClass( {
 			if ( this.props.isEmbed ) {
 				analytics.ga.recordEvent( 'Plugins', 'Remove plugin with no selected site', 'Plugin Name', this.props.plugin.slug );
 				analytics.tracks.recordEvent( 'calypso_plugin_remove_click_from_sites_list', {
-					site: this.props.site,
+					site: this.props.site.ID,
 					plugin: this.props.plugin.slug
 				} );
 			} else {
 				analytics.ga.recordEvent( 'Plugins', 'Remove plugin on selected Site', 'Plugin Name', this.props.plugin.slug );
 				analytics.tracks.recordEvent( 'calypso_plugin_remove_click_from_plugin_info', {
-					site: this.props.site,
+					site: this.props.site.ID,
 					plugin: this.props.plugin.slug
 				} );
 			}
@@ -85,7 +85,7 @@ module.exports = React.createClass( {
 
 		if ( ! this.props.site.canUpdateFiles && this.props.site.options.file_mod_disabled ) {
 			const reasons = utils.getSiteFileModDisableReason( this.props.site, 'modifyFiles' );
-			let html = [];
+			const html = [];
 
 			if ( reasons.length > 1 ) {
 				html.push(
@@ -93,7 +93,7 @@ module.exports = React.createClass( {
 						{ this.translate( '%(pluginName)s cannot be removed:', { args: { pluginName: this.props.plugin.name } } ) }
 					</p>
 				);
-				let list = reasons.map( ( reason, i ) => ( <li key={ 'reason-i' + i + '-' + this.props.site.ID } >{ reason }</li> ) );
+				const list = reasons.map( ( reason, i ) => ( <li key={ 'reason-i' + i + '-' + this.props.site.ID } >{ reason }</li> ) );
 				html.push( <ul className="plugin-action__disabled-info-list" key="reason-shell-list">{ list }</ul> );
 			} else {
 				html.push(


### PR DESCRIPTION
Removes js errors and records the tracks events (for installing and removing) as expected

To test: 
Go to you favourite not yet installed plugin ( single plugin view ) 
http://calypso.localhost:3000/plugins/autocorrect 
and click the install button. 

Click the trash can to uninstall the plugin. 

Go to the single site single plugin view 
click the install button. 

Click the uninstall button to remove the plugin. 

Notice the events are being recorded as expected. 

