### PR TITLE
[Don't Merge] Woo stats in Woo extension Proof of Concept

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -9,6 +9,7 @@ import React, { Component } from 'react';
 import Main from 'components/main';
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
+import MyCoolComponent from '../stats/my-cool-component';
 
 export default class Dashboard extends Component {
 
@@ -19,6 +20,9 @@ export default class Dashboard extends Component {
 				<Card>
 					<p>This is the start of something great!</p>
 					<p>This will be the home for your WooCommerce Store integration with WordPress.com.</p>
+				</Card>
+				<Card>
+					<MyCoolComponent/>
 				</Card>
 			</Main>
 		);

--- a/client/extensions/woocommerce/app/stats/index.js
+++ b/client/extensions/woocommerce/app/stats/index.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+
+export default class Stats extends Component {
+
+	render() {
+		return (
+			<Main className="stats woocommerce__main">
+				<SectionHeader label="WooCommerce Store - Stats" />
+				<Card>
+					<p>This will be the home for your WooCommerce Store Stats</p>
+				</Card>
+			</Main>
+		);
+	}
+
+}

--- a/client/extensions/woocommerce/app/stats/index.js
+++ b/client/extensions/woocommerce/app/stats/index.js
@@ -9,15 +9,24 @@ import React, { Component } from 'react';
 import Main from 'components/main';
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
+import SegmentedControl from 'components/segmented-control';
+import MyCoolComponent from './my-cool-component';
 
 export default class Stats extends Component {
 
 	render() {
 		return (
 			<Main className="stats woocommerce__main">
+				<SegmentedControl
+					initialSelected="store"
+					options={ [
+						{ value: 'site', label: 'Site', path: '/stats/day/<-my-cool-site->' },
+						{ value: 'store', label: 'Store' },
+					] }
+				/>
 				<SectionHeader label="WooCommerce Store - Stats" />
 				<Card>
-					<p>This will be the home for your WooCommerce Store Stats</p>
+					<MyCoolComponent/>
 				</Card>
 			</Main>
 		);

--- a/client/extensions/woocommerce/app/stats/my-cool-component.js
+++ b/client/extensions/woocommerce/app/stats/my-cool-component.js
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+export default class MyCoolComponent extends Component {
+	render() {
+		return (
+			<h1>My Cool Stats</h1>
+		);
+	}
+
+}

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import page from 'page';
+import config from 'config';
 
 /**
  * Internal dependencies
@@ -11,6 +12,7 @@ import { navigation, siteSelection } from 'my-sites/controller';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import ProductForm from './app/products/product-form';
 import Dashboard from './app/dashboard';
+import Stats from './app/stats';
 
 const Controller = {
 	dashboard: function( context ) {
@@ -27,10 +29,24 @@ const Controller = {
 			document.getElementById( 'primary' ),
 			context.store
 		);
+	},
+
+	stats: function( context ) {
+		renderWithReduxStore(
+			React.createElement( Stats, { } ),
+			document.getElementById( 'primary' ),
+			context.store
+		);
 	}
 };
 
 export default function() {
-	page( '/store/:site?', siteSelection, navigation, Controller.dashboard );
-	page( '/store/:site?/products/add', siteSelection, navigation, Controller.addProduct );
+	if ( config.isEnabled( 'woocommerce/extension' ) ) {
+		page( '/store/:site?', siteSelection, navigation, Controller.dashboard );
+		page( '/store/products/add/:site?', siteSelection, navigation, Controller.addProduct );
+	}
+
+	if ( config.isEnabled( 'woocommerce/extension/stats' ) ) {
+		page( '/store/stats/:site?', siteSelection, navigation, Controller.stats );
+	}
 }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -25,6 +25,7 @@ import config from 'config';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getSiteOption, isJetpackSite } from 'state/sites/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
+import SegmentedControl from 'components/segmented-control';
 
 class StatsSite extends Component {
 	constructor( props ) {
@@ -73,6 +74,7 @@ class StatsSite extends Component {
 		const moduleStrings = statsStrings();
 		let videoList;
 		let podcastList;
+		let storeStatsControl;
 
 		const query = {
 			period: period,
@@ -105,10 +107,23 @@ class StatsSite extends Component {
 			);
 		}
 
+		if ( config.isEnabled( 'woocommerce/extension/stats' ) ) { // Check also that site has a Jetpack store
+			storeStatsControl = (
+				<SegmentedControl
+					initialSelected="site"
+					options={ [
+						{ value: 'site', label: 'Site' },
+						{ value: 'store', label: 'Store', path: '/store/stats/piwakawaka.mystagingwebsite.com' },
+					] }
+				/>
+			);
+		}
+
 		return (
 			<Main wideLayout={ true }>
 				<StatsFirstView />
 				<SidebarNavigation />
+				{ storeStatsControl }
 				<StatsNavigation section={ period } />
 				<div id="my-stats-content">
 					<ChartTabs
@@ -196,7 +211,8 @@ export default connect(
 		return {
 			isJetpack: isJetpackSite( state, siteId ),
 			hasPodcasts: getSiteOption( state, siteId, 'podcasting_archive' ),
-			slug: getSelectedSiteSlug( state )
+			slug: getSelectedSiteSlug( state ),
+			siteId,
 		};
 	},
 	{  recordGoogleEvent }

--- a/config/development.json
+++ b/config/development.json
@@ -153,6 +153,8 @@
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
 		"webpack/persistent-caching": false,
+		"woocommerce/extension": true,
+		"woocommerce/extension/stats": true,
 		"wp-login": true
 	}
 }


### PR DESCRIPTION
### Problem
Store stats need to be in the same place as Site stats in the UI. In order to keep all Woo Calypso logic in one place, development of Store stats can't happen in core Calypso.

### Solution
Develop Store stats in the extension. In order to place Site stats and Store stats in the same place visually, create a tab to link to the extension for only the applicable users.