### PR TITLE
Site Settings: Make toggle descriptions non-clickable

### DIFF
--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -59,17 +59,18 @@ class CustomContentTypes extends Component {
 			handleAutosavingToggle
 		} = this.props;
 		return (
-			<CompactFormToggle
-				checked={ !! fields[ name ] }
-				disabled={ this.isFormPending() || activatingCustomContentTypesModule }
-				onChange={ handleAutosavingToggle( name ) }
-			>
-				{ label }
-				<FormSettingExplanation>
+			<div>
+				<CompactFormToggle
+					checked={ !! fields[ name ] }
+					disabled={ this.isFormPending() || activatingCustomContentTypesModule }
+					onChange={ handleAutosavingToggle( name ) }
+				>
+					{ label }
+				</CompactFormToggle>
+				<FormSettingExplanation isIndented>
 					{ description }
 				</FormSettingExplanation>
-
-			</CompactFormToggle>
+			</div>
 		);
 	}
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -191,10 +191,10 @@ class SiteSettingsFormGeneral extends Component {
 						disabled={ isRequestingSettings }
 						onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) } />
 					<span>{ translate( 'Public' ) }</span>
-					<FormSettingExplanation isIndented>
-						{ translate( 'Your site is visible to everyone, and it may be indexed by search engines.' ) }
-					</FormSettingExplanation>
 				</FormLabel>
+				<FormSettingExplanation isIndented>
+					{ translate( 'Your site is visible to everyone, and it may be indexed by search engines.' ) }
+				</FormSettingExplanation>
 
 				<FormLabel>
 					<FormRadio
@@ -205,25 +205,27 @@ class SiteSettingsFormGeneral extends Component {
 						disabled={ isRequestingSettings }
 						onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) } />
 					<span>{ translate( 'Hidden' ) }</span>
-					<FormSettingExplanation isIndented>
-						{ translate( 'Your site is visible to everyone, but we ask search engines to not index your site.' ) }
-					</FormSettingExplanation>
 				</FormLabel>
+				<FormSettingExplanation isIndented>
+					{ translate( 'Your site is visible to everyone, but we ask search engines to not index your site.' ) }
+				</FormSettingExplanation>
 
 				{ ! site.jetpack &&
-					<FormLabel>
-						<FormRadio
-							name="blog_public"
-							value="-1"
-							checked={ -1 === parseInt( fields.blog_public, 10 ) }
-							onChange={ handleRadio }
-							disabled={ isRequestingSettings }
-							onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) } />
-						<span>{ translate( 'Private' ) }</span>
+					<div>
+						<FormLabel>
+							<FormRadio
+								name="blog_public"
+								value="-1"
+								checked={ -1 === parseInt( fields.blog_public, 10 ) }
+								onChange={ handleRadio }
+								disabled={ isRequestingSettings }
+								onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) } />
+							<span>{ translate( 'Private' ) }</span>
+						</FormLabel>
 						<FormSettingExplanation isIndented>
 							{ translate( 'Your site is only visible to you and users you approve.' ) }
 						</FormSettingExplanation>
-					</FormLabel>
+					</div>
 				}
 
 			</FormFieldset>
@@ -263,7 +265,7 @@ class SiteSettingsFormGeneral extends Component {
 									'Allow synchronization of Posts and Pages with non-public post statuses'
 								) }
 							</CompactFormToggle>
-							<FormSettingExplanation>
+							<FormSettingExplanation isIndented>
 								{ translate( '(e.g. drafts, scheduled, private, etc\u2026)' ) }
 							</FormSettingExplanation>
 						</li>

--- a/client/my-sites/site-settings/jetpack-module-toggle.jsx
+++ b/client/my-sites/site-settings/jetpack-module-toggle.jsx
@@ -65,14 +65,14 @@ class JetpackModuleToggle extends Component {
 					disabled={ this.props.disabled || this.props.toggleDisabled }
 				>
 					{ this.props.label }
-					{
-						this.props.description && (
-							<FormSettingExplanation>
-								{ this.props.description }
-							</FormSettingExplanation>
-						)
-					}
 				</CompactFormToggle>
+				{
+					this.props.description && (
+						<FormSettingExplanation isIndented>
+							{ this.props.description }
+						</FormSettingExplanation>
+					)
+				}
 			</span>
 		);
 	}

--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -131,14 +131,10 @@ class JetpackSiteStats extends Component {
 						</div>
 
 						{ this.renderToggle( 'admin_bar', translate( 'Put a chart showing 48 hours of views in the admin bar' ) ) }
-						{ this.renderToggle( 'hide_smile', (
-							<div>
-								{ translate( 'Hide the stats smiley face image' ) }
-								<FormSettingExplanation>
-									{ translate( 'The image helps collect stats, but should work when hidden.' ) }
-								</FormSettingExplanation>
-							</div>
-						) ) }
+						{ this.renderToggle( 'hide_smile', translate( 'Hide the stats smiley face image' ) ) }
+						<FormSettingExplanation isIndented>
+							{ translate( 'The image helps collect stats, but should work when hidden.' ) }
+						</FormSettingExplanation>
 					</FormFieldset>
 
 					<FormFieldset>

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -84,9 +84,14 @@
 		font-style: italic;
 		font-weight: 400;
 		color: $gray-text-min;
+
 		&.is-indented {
 			margin-left: 24px;
 		}
+	}
+
+	.form-toggle__wrapper + p.form-setting-explanation.is-indented {
+		margin-left: 36px;
 	}
 
 	p.settings-alert {


### PR DESCRIPTION
This PR fixes #12893, where @rickybanister discovered that descriptions within toggles unexpectedly trigger the toggles. To fix this, we had to move those descriptions out of the toggle labels wherever this was happening.

To test:
* Checkout this branch or get it going on calypso.live
* Go to `/settings/general/$site`, where `$site` is one of your WordPress.com sites.
* Verify the descriptions of the **Privacy** radio buttons are no longer clickable, and there are no visual changes there.
* Go to `/settings/writing/$site`, where `$site` is one of your Jetpack sites.
* Verify the descriptions of the **Custom Content Types** toggles are not clickable, and there are no visual changes there.
* Verify the description of the **Speed up your images and photos with Photon** toggle is no longer clickable and there are no visual changes there.
* Go to `/settings/security/$site`, where `$site` is one of your Jetpack sites.
* Verify the description of the **Allow sign in using WordPress.com accounts** toggle is no longer clickable and there are no visual changes there.
* Go to `/settings/traffic/$site`, where `$site` is one of your Jetpack sites.
* Verify the description of the **Hide the stats smiley face image** toggle in the Site Stats card is no longer clickable and there are no visual changes there.
* Go to `/settings/general/$site`, where `$site` is one of your Jetpack sites with Jetpack 4.1.1 or older.
* Verify the description below the **Allow synchronization of Posts and Pages with non-public post statuses** toggle is intended (note this is a feature that's available only for dev/testing environments).