### PR TITLE
Site Settings: Introduce a Sitemaps card in the Traffic section

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -410,7 +410,6 @@ export const SeoForm = React.createClass( {
 		const isVerificationDisabled = isDisabled || isVerificationToolsActive === false;
 		const isSaveDisabled = isDisabled || isSubmittingForm || ( ! showPasteError && invalidCodes.length > 0 );
 
-		const sitemapUrl = `${ siteUrl }/sitemap.xml`;
 		const generalTabUrl = getGeneralTabUrl( slug );
 		const jetpackUpdateUrl = getJetpackPluginUrl( slug );
 		const placeholderTagContent = '1234';
@@ -711,20 +710,6 @@ export const SeoForm = React.createClass( {
 								placeholder={ getMetaTag( 'yandex', placeholderTagContent ) }
 								onChange={ this.changeYandexCode } />
 							{ hasError( 'yandex' ) && this.getVerificationError( showPasteError ) }
-						</FormFieldset>
-						<FormFieldset>
-							<FormLabel htmlFor="seo_sitemap">{ translate( 'XML Sitemap' ) }</FormLabel>
-							<ExternalLink
-								className="seo-settings__seo-sitemap"
-								icon={ true }
-								href={ sitemapUrl }
-								target="_blank"
-							>
-								{ sitemapUrl }
-							</ExternalLink>
-							<FormSettingExplanation>
-								{ translate( 'Your site\'s sitemap is automatically sent to all major search engines for indexing.' ) }
-							</FormSettingExplanation>
 						</FormFieldset>
 					</Card>
 				</form>

--- a/client/my-sites/site-settings/sitemaps.jsx
+++ b/client/my-sites/site-settings/sitemaps.jsx
@@ -140,21 +140,26 @@ class Sitemaps extends Component {
 			'sitemap_url',
 			'news_sitemap_url',
 		];
-		const isSitePublic = this.isSitePublic();
+
+		if ( ! this.isSitePublic() ) {
+			return (
+				<div className="sitemaps__module-settings site-settings__child-settings">
+					{ this.renderNonPublicExplanation() }
+				</div>
+			);
+		}
 
 		return (
 			<div className="sitemaps__module-settings site-settings__child-settings">
-				{ ! isSitePublic && this.renderNonPublicExplanation() }
-
 				{
-					isSitePublic && activatingSitemapsModule &&
+					activatingSitemapsModule &&
 					<FormSettingExplanation>
 						{ translate( 'Generating sitemap…' ) }
 					</FormSettingExplanation>
 				}
 
 				{
-					isSitePublic && sitemapsModuleActive &&
+					sitemapsModuleActive &&
 					<div>
 						{ this.renderSitemapExplanation() }
 

--- a/client/my-sites/site-settings/sitemaps.jsx
+++ b/client/my-sites/site-settings/sitemaps.jsx
@@ -1,0 +1,196 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes, Component } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import InfoPopover from 'components/info-popover';
+import ExternalLink from 'components/external-link';
+import QueryJetpackConnection from 'components/data/query-jetpack-connection';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { getJetpackModule, isActivatingJetpackModule, isJetpackModuleActive } from 'state/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+
+class Sitemaps extends Component {
+	static defaultProps = {
+		isSavingSettings: false,
+		isRequestingSettings: true,
+	};
+
+	static propTypes = {
+		isSavingSettings: PropTypes.bool,
+		isRequestingSettings: PropTypes.bool,
+	};
+
+	renderSitemapLink( sitemapUrl ) {
+		return (
+			<div key={ sitemapUrl }>
+				<ExternalLink href={ sitemapUrl } icon target="_blank">
+					{ sitemapUrl }
+				</ExternalLink>
+			</div>
+		);
+	}
+
+	renderInfoLink( url ) {
+		const { translate } = this.props;
+
+		return (
+			<div className="sitemaps__info-link-container site-settings__info-link-container">
+				<InfoPopover position={ 'left' }>
+					<ExternalLink href={ url } icon target="_blank">
+						{ translate( 'Learn more about Sitemaps.' ) }
+					</ExternalLink>
+				</InfoPopover>
+			</div>
+		);
+	}
+
+	renderSitemapExplanation() {
+		const { translate } = this.props;
+
+		return (
+			<FormSettingExplanation>
+				{ translate( 'Your sitemap is automatically sent to all major search engines for indexing.' ) }
+			</FormSettingExplanation>
+		);
+	}
+
+	renderWpcomSettings() {
+		const { site } = this.props;
+		const sitemapTypes = [
+			'sitemap',
+			'news-sitemap',
+		];
+
+		return (
+			<div>
+				{ this.renderInfoLink( 'https://support.wordpress.com/sitemaps/' ) }
+
+				{ this.renderSitemapExplanation() }
+
+				{
+					sitemapTypes.map( ( sitemapType ) => {
+						const sitemapUrl = site.URL + '/' + sitemapType + '.xml';
+						return this.renderSitemapLink( sitemapUrl );
+					} )
+				}
+			</div>
+		);
+	}
+
+	renderJetpackSettingsContent() {
+		const {
+			activatingSitemapsModule,
+			sitemapsModule,
+			sitemapsModuleActive,
+			translate
+		} = this.props;
+
+		if ( ! activatingSitemapsModule && ! sitemapsModuleActive ) {
+			return;
+		}
+
+		const sitemapTypes = [
+			'sitemap_url',
+			'news_sitemap_url',
+		];
+
+		return (
+			<div className="sitemaps__module-settings site-settings__child-settings">
+				{
+					activatingSitemapsModule &&
+					<FormSettingExplanation>
+						{ translate( 'Generating sitemap…' ) }
+					</FormSettingExplanation>
+				}
+
+				{
+					sitemapsModuleActive &&
+					<div>
+						{ this.renderSitemapExplanation() }
+
+						{
+							sitemapsModule &&
+							sitemapTypes.map( ( sitemapType ) =>
+								sitemapsModule.extra[ sitemapType ] &&
+								this.renderSitemapLink( sitemapsModule.extra[ sitemapType ] )
+							)
+						}
+					</div>
+				}
+			</div>
+		);
+	}
+
+	renderJetpackSettings() {
+		const {
+			isRequestingSettings,
+			isSavingSettings,
+			siteId,
+			translate
+		} = this.props;
+
+		return (
+			<FormFieldset>
+				{ this.renderInfoLink( 'https://jetpack.com/support/sitemaps' ) }
+
+				<JetpackModuleToggle
+					siteId={ siteId }
+					moduleSlug="sitemaps"
+					label={ translate( 'Generate XML sitemaps' ) }
+					disabled={ isRequestingSettings || isSavingSettings }
+				/>
+
+				{ this.renderJetpackSettingsContent() }
+			</FormFieldset>
+		);
+	}
+
+	render() {
+		const {
+			siteId,
+			siteIsJetpack,
+			translate
+		} = this.props;
+
+		return (
+			<div>
+				<QueryJetpackConnection siteId={ siteId } />
+
+				<SectionHeader label={ translate( 'Sitemaps' ) } />
+
+				<Card className="sitemaps__card site-settings__traffic-settings">
+					{ siteIsJetpack
+						? this.renderJetpackSettings()
+						: this.renderWpcomSettings()
+					}
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+
+		return {
+			siteId,
+			activatingSitemapsModule: !! isActivatingJetpackModule( state, siteId, 'sitemaps' ),
+			site: getSelectedSite( state ),
+			siteIsJetpack: isJetpackSite( state, siteId ),
+			sitemapsModule: getJetpackModule( state, siteId, 'sitemaps' ),
+			sitemapsModuleActive: !! isJetpackModuleActive( state, siteId, 'sitemaps' ),
+		};
+	}
+)( localize( Sitemaps ) );

--- a/client/my-sites/site-settings/sitemaps.jsx
+++ b/client/my-sites/site-settings/sitemaps.jsx
@@ -82,8 +82,8 @@ class Sitemaps extends Component {
 			<FormSettingExplanation>
 				{
 					translate(
-						'Your site is currently not accessible to search engines. ' +
-						'It is possible that "Privacy" is not set to "Public" in your {{a}}General{{/a}} settings.',
+						'Your site is not currently accessible to search engines. ' +
+						'You must set your {{a}}privacy settings{{/a}} to "public".',
 						{
 							components: {
 								a: <a href={ '/settings/general/' + siteSlug } />,

--- a/client/my-sites/site-settings/sitemaps.jsx
+++ b/client/my-sites/site-settings/sitemaps.jsx
@@ -132,6 +132,14 @@ class Sitemaps extends Component {
 			translate
 		} = this.props;
 
+		if ( ! this.isSitePublic() && ! activatingSitemapsModule ) {
+			return (
+				<div className="sitemaps__module-settings site-settings__child-settings">
+					{ this.renderNonPublicExplanation() }
+				</div>
+			);
+		}
+
 		if ( ! activatingSitemapsModule && ! sitemapsModuleActive ) {
 			return;
 		}
@@ -140,14 +148,6 @@ class Sitemaps extends Component {
 			'sitemap_url',
 			'news_sitemap_url',
 		];
-
-		if ( ! this.isSitePublic() ) {
-			return (
-				<div className="sitemaps__module-settings site-settings__child-settings">
-					{ this.renderNonPublicExplanation() }
-				</div>
-			);
-		}
 
 		return (
 			<div className="sitemaps__module-settings site-settings__child-settings">

--- a/client/my-sites/site-settings/traffic/main.jsx
+++ b/client/my-sites/site-settings/traffic/main.jsx
@@ -79,6 +79,7 @@ const SiteSettingsTraffic = ( {
 		<Sitemaps
 			isSavingSettings={ isSavingSettings }
 			isRequestingSettings={ isRequestingSettings }
+			fields={ fields }
 		/>
 	</Main>
 );
@@ -114,6 +115,7 @@ const getFormSettings = partialRight( pick, [
 	'jetpack_relatedposts_show_thumbnails',
 	'amp_is_supported',
 	'amp_is_enabled',
+	'blog_public',
 ] );
 
 export default flowRight(

--- a/client/my-sites/site-settings/traffic/main.jsx
+++ b/client/my-sites/site-settings/traffic/main.jsx
@@ -20,6 +20,7 @@ import JetpackSiteStats from 'my-sites/site-settings/jetpack-site-stats';
 import RelatedPosts from 'my-sites/site-settings/related-posts';
 import AmpJetpack from 'my-sites/site-settings/amp/jetpack';
 import AmpWpcom from 'my-sites/site-settings/amp/wpcom';
+import Sitemaps from 'my-sites/site-settings/sitemaps';
 import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
@@ -75,6 +76,10 @@ const SiteSettingsTraffic = ( {
 		<AnalyticsSettings />
 		<SeoSettingsHelpCard />
 		<SeoSettingsMain upgradeToBusiness={ upgradeToBusiness } />
+		<Sitemaps
+			isSavingSettings={ isSavingSettings }
+			isRequestingSettings={ isRequestingSettings }
+		/>
 	</Main>
 );
 


### PR DESCRIPTION
### Purpose

This PR introduces the Sitemaps card in the Traffic section, and removes the Sitemap section from the Site Verification Services card. UI of the card has been borrowed from Jetpack. 

Part of #12845. Moving this card above the Site Verification Services card will be done once we separate Site Verification Services from the main form (currently they're all one large component). Or the other way around will be to insert that component in the main SEO form.

### How it works

This card looks and behaves differently for WordPress.com and Jetpack sites. For WordPress.com sites it simply lists the sitemap links, while for Jetpack sites it also allows the user to toggle the Sitemaps module. See previews for more details.

### Previews

**Site Verification Services card - XML sitemaps section is now removed**
![](https://cldup.com/rC7K_kcrjM.png)

**Sitemaps card for WordPress.com sites**
![](https://cldup.com/2fJ9LuSlNA.png)

**Sitemaps card for Jetpack sites, when Sitemaps module is disabled**
![](https://cldup.com/8zzLHIvcPo.png)

**Sitemaps card for Jetpack sites, while Sitemaps module is being activated**
![](https://cldup.com/a4o6x9o1c4.png)

**Sitemaps card for Jetpack sites, when Sitemaps module is active**
![](https://cldup.com/e3MCc2tYtA.png)

### To test
* Checkout this branch, or get it going on calypso.live
* Go to `/settings/traffic/$site`, where `$site` is one of your WordPress.com sites.
* Verify the Sitemaps card is shown at the bottom and it looks as shown on the preview.
* Verify the links in the Sitemaps card look and work right.
* Go to `/settings/traffic/$site`, where `$site` is one of your Jetpack sites.
* Verify the Sitemaps card is shown at the bottom and it looks as shown on the preview.
* Verify the module toggle works correctly as shown on the preview.
* Verify the sitemap links look and work right.