### PR TITLE
Use unambiguous routes for support urls.

### DIFF
--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -38,7 +38,10 @@ export default function( router ) {
 			'/themes/:site?/filter/:filter',
 			'/themes/:site?/filter/:filter/type/:tier(free|premium)'
 		], redirectFilterAndType );
-		router( '/themes/:site?/:theme/:section(support)?', redirectToThemeDetails );
+		router( [
+			'/themes/:theme/:section(support)?',
+			'/themes/:site/:theme/:section(support)?'
+		], redirectToThemeDetails );
 		// The following route definition is needed so direct hits on `/themes/<mysite>` don't result in a 404.
 		router( '/themes/*', fetchThemeData, loggedOut, makeLayout );
 	}


### PR DESCRIPTION
### Info
`'/themes/:site/:theme/:section(support)?'` was reacting in a wrong way for no sites urls. This url support was split into two routes that are able to understand site vs no site situations.

### Testing
`/themes/<yoursite>/mood/support/` should redirect to `/theme/mood/setup/<yoursite>`. Also try without `<yoursite>` and `/support`.