### PR TITLE
Site Settings: Preload writing and discussion sections on nav mouse enter

### DIFF
--- a/client/components/section-nav/item.jsx
+++ b/client/components/section-nav/item.jsx
@@ -9,6 +9,8 @@ var React = require( 'react' ),
  * Internal Dependencies
  */
 import Count from 'components/count';
+import { preload } from 'sections-preload';
+
 /**
  * Main
  */
@@ -25,7 +27,17 @@ var NavItem = React.createClass( {
 		isExternalLink: React.PropTypes.bool,
 		disabled: React.PropTypes.bool,
 		count: React.PropTypes.number,
-		className: React.PropTypes.string
+		className: React.PropTypes.string,
+		preloadSectionName: React.PropTypes.string
+	},
+
+	_preloaded: false,
+
+	preload() {
+		if ( ! this._preloaded && this.props.preloadSectionName ) {
+			this._preloaded = true;
+			preload( this.props.preloadSectionName );
+		}
 	},
 
 	render: function() {
@@ -58,6 +70,7 @@ var NavItem = React.createClass( {
 					target={ target }
 					className={ 'section-nav-' + itemClassPrefix + '__link' }
 					onClick={ onClick }
+					onMouseEnter={ this.preload }
 					tabIndex={ this.props.tabIndex || 0 }
 					aria-selected={ this.props.selected }
 					disabled={ this.props.disabled }

--- a/client/my-sites/site-settings/navigation.jsx
+++ b/client/my-sites/site-settings/navigation.jsx
@@ -75,12 +75,14 @@ export default React.createClass( {
 
 					<NavItem
 						path={ `/settings/writing/${ site.slug }` }
+						preloadSectionName="settings-writing"
 						selected={ section === 'writing' } >
 							{ strings.writing }
 					</NavItem>
 
 					<NavItem
 						path={ `/settings/discussion/${ site.slug }` }
+						preloadSectionName="settings-discussion"
 						selected={ section === 'discussion' } >
 							{ strings.discussion }
 					</NavItem>


### PR DESCRIPTION
This PR adds support to `SectionNav` items for preloading sections on mouse enter. It also uses that functionality to preload the **Writing** and **Discussion** settings when the mouse enters the corresponding section nav menu items.

Addresses part of #12659.

![](https://cldup.com/IgvepKgCb7.png)

To test:
1. Checkout this branch or get it going on calypso.live
2. Go to `/settings/general/$site` where `$site` is one of your sites.
3. Inspect the network requests (Network tab in Chrome)
4. Roll your mouse over the **Writing** nav item.
5. Verify the `settings-writing` chunk gets loaded immediately.
6. Roll over something else, then roll over **Writing** again.
7. Verify the `settings-writing` chunk is not requested anymore.
8. Repeat steps 4-7 for the **Discussion** section.
