### PR TITLE
Themes: Validate filter URL at the server

### DIFF
--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -11,6 +11,7 @@ import {
 	redirectFilterAndType,
 	redirectToThemeDetails
 } from './controller';
+import validateFilters from './validate-filters';
 
 // `logged-out` middleware isn't SSR-compliant yet, but we can at least render
 // the layout.
@@ -28,6 +29,7 @@ export default function( router ) {
 		router( `/themes/:vertical(${ verticals })?/:tier(free|premium)?`, fetchThemeData, loggedOut, makeLayout );
 		router(
 			`/themes/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`,
+			validateFilters,
 			fetchThemeData,
 			loggedOut,
 			makeLayout

--- a/client/my-sites/themes/validate-filters.js
+++ b/client/my-sites/themes/validate-filters.js
@@ -23,7 +23,10 @@ module.exports = function validateFilter( context, next ) {
 			`/filter/${ filterParam }`,
 			sortedValidFilters ? `/filter/${ sortedValidFilters }` : ''
 		);
-		page.redirect( newPath );
+		if ( context.isServerSide ) {
+			return context.res.redirect( newPath );
+		}
+		return page.redirect( newPath );
 	}
 
 	next();


### PR DESCRIPTION
And redirect to canonical URL, which will save on render cache slots (render cache key will use the canonical url).

Previously we were only doing the redirect at the client.

**To Test**
* In a logged out browser window, hit a URL with the filters not alpha ordered, such as http://calypso.localhost:3000/themes/premium/filter/two-columns,blue

**Expected**
* Page should re-direct to alphabetically ordered filters:
http://calypso.localhost:3000/themes/premium/filter/blue,two-columns
