### PR TITLE
Blog Posts: Increasing contrast of text

### DIFF
--- a/client/blocks/post-actions/style.scss
+++ b/client/blocks/post-actions/style.scss
@@ -18,7 +18,7 @@
 
 		a,
 		&.post-actions__relative-time {
-			color: $gray;
+			color: $gray-text-min;
 
 			&:hover {
 				color: $blue-medium;

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -323,7 +323,7 @@
 	}
 }
 .post__site-title {
-	color: darken( $gray, 20 );
+	color: $gray-dark;
 	display: block;
 	font-size: 14px;
 	line-height: 38px;
@@ -331,7 +331,7 @@
 	padding-left: 48px;
 
 	a {
-		color: darken( $gray, 20 );
+		color: $gray-dark;
 	}
 }
 .post__header.has-author {
@@ -342,7 +342,7 @@
 }
 .post__author {
 	display: block;
-	color: $gray;
+	color: $gray-text-min;
 	font-size: 12px;
 	padding-left: 48px;
 }
@@ -432,12 +432,12 @@
 		}
 		a {
 			display: block;
-			color: darken( $gray, 10% );
+			color: $gray-text-min;
 			box-sizing: border-box;
 			font-size: inherit;
 			padding: (11 / 14) * 1em 0;
 			&:hover {
-				color: darken( $gray, 20% );
+				color: $gray-dark;
 				cursor: pointer;
 			}
 			.gridicon{


### PR DESCRIPTION
This tweaks a few text colors so that it passes AA contrast tests.

- site title and author
- timestamp and actions
- post buttons

This affects the PostActions block.

Before|After
---|---
![image](https://cloud.githubusercontent.com/assets/618551/24805508/a99f1e36-1b77-11e7-9b08-878afb85272b.png)|![image](https://cloud.githubusercontent.com/assets/618551/24805504/a6e26f68-1b77-11e7-9a16-e191d04004f4.png)