### PR TITLE
Reader: add ReaderImportButton block

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -53,6 +53,7 @@
 @import 'blocks/reader-featured-image/style';
 @import 'blocks/reader-featured-video/style';
 @import 'blocks/reader-full-post/style';
+@import 'blocks/reader-import-button/style';
 @import 'blocks/reader-post-actions/style';
 @import 'blocks/reader-post-card/style';
 @import 'blocks/reader-post-options-menu/style';

--- a/client/blocks/reader-import-button/README.md
+++ b/client/blocks/reader-import-button/README.md
@@ -1,3 +1,11 @@
 # Reader Import Button
 
 Allows a Reader user to import their subscriptions in OPML or XML format.
+
+## Props
+
+| Prop | Type | Required | Description |
+|-----|:----:|:--------:|-------------|
+| `onError`| Function | No | Function to execute in the case of an import error |
+| `onImport`| Function | No | Function to execute in the case of successful import |
+| `onProgress`| Function | No | Function to execute when the upload is in progress |

--- a/client/blocks/reader-import-button/README.md
+++ b/client/blocks/reader-import-button/README.md
@@ -1,0 +1,3 @@
+# Reader Import Button
+
+Allows a Reader user to import their subscriptions in OPML or XML format.

--- a/client/blocks/reader-import-button/docs/example.jsx
+++ b/client/blocks/reader-import-button/docs/example.jsx
@@ -1,0 +1,21 @@
+/**
+* External dependencies
+*/
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import ReaderImportButtonBlock from 'blocks/reader-import-button';
+
+const ReaderImportButton = () => (
+	<div className="design-assets__group">
+		<div>
+			<ReaderImportButtonBlock />
+		</div>
+	</div>
+);
+
+ReaderImportButton.displayName = 'ReaderImportButton';
+
+export default ReaderImportButton;

--- a/client/blocks/reader-import-button/index.jsx
+++ b/client/blocks/reader-import-button/index.jsx
@@ -29,14 +29,14 @@ class ReaderImportButton extends React.Component {
 	state = { disabled: false };
 
 	onClick = ( event ) => {
-		// Don't kick off a new export request if there's one in progress
+		// Don't allow picking of a new file if there's an import in progress
 		if ( this.state.disabled ) {
 			event.preventDefault();
 		}
 	}
 
 	onPick = ( files ) => {
-		// we only care about the first file in the list
+		// We only care about the first file in the list
 		const file = files[ 0 ];
 		if ( ! file ) {
 			return;
@@ -59,7 +59,7 @@ class ReaderImportButton extends React.Component {
 		if ( err ) {
 			this.props.onError( err );
 		} else {
-			// tack on the file name since it will be displayed in the UI
+			// Tack on the file name since it will be displayed in the UI
 			data.fileName = this.fileName;
 			this.props.onImport( data );
 		}

--- a/client/blocks/reader-import-button/index.jsx
+++ b/client/blocks/reader-import-button/index.jsx
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { noop } from 'lodash';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import wpcom from 'lib/wp';
+import FilePicker from 'components/file-picker';
+
+class ReaderImportButton extends React.Component {
+
+	static propTypes = {
+		onError: React.PropTypes.func,
+		onImport: React.PropTypes.func,
+		onProgress: React.PropTypes.func,
+	}
+
+	static defaultProps = {
+		onError: noop,
+		onImport: noop,
+		onProgress: noop,
+	}
+
+	state = { disabled: false };
+
+	onClick = ( event ) => {
+		// Don't kick off a new export request if there's one in progress
+		if ( this.state.disabled ) {
+			event.preventDefault();
+		}
+	}
+
+	onPick = ( files ) => {
+		// we only care about the first file in the list
+		const file = files[ 0 ];
+		if ( ! file ) {
+			return;
+		}
+
+		this.fileName = file.name;
+		const req = wpcom.undocumented().importReaderFeed( file, this.onImport );
+		req.upload.onprogress = this.onImportProgress;
+
+		this.setState( {
+			disabled: true
+		} );
+	}
+
+	onImport = ( err, data ) => {
+		this.setState( {
+			disabled: false
+		} );
+
+		if ( err ) {
+			this.props.onError( err );
+		} else {
+			// tack on the file name since it will be displayed in the UI
+			data.fileName = this.fileName;
+			this.props.onImport( data );
+		}
+	}
+
+	onImportProgress = ( event ) => {
+		this.props.onProgress( event );
+	}
+
+	render() {
+		return (
+			<div className="reader-import-button">
+				<FilePicker accept=".xml,.opml" onClick={ this.onClick } onPick={ this.onPick }>
+					<Gridicon icon="cloud-upload" className="reader-import-button__icon" />
+					<span className="reader-import-button__label">
+						{ this.props.translate( 'Import' ) }
+					</span>
+				</FilePicker>
+			</div>
+		);
+	}
+}
+
+export default localize( ReaderImportButton );

--- a/client/blocks/reader-import-button/style.scss
+++ b/client/blocks/reader-import-button/style.scss
@@ -1,0 +1,24 @@
+.reader-import-button {
+	cursor: pointer;
+
+	&:hover {
+		.reader-import-button__icon {
+			fill: $blue-medium;
+		}
+
+		.reader-import-button__label {
+			color: $blue-medium;
+		}
+	}
+}
+
+.reader-import-button__icon {
+	fill: $gray;
+	vertical-align: middle;
+}
+
+.reader-import-button__label {
+	font-size: 14px;
+	color: $gray;
+	padding-left: 4px;
+}

--- a/client/components/file-picker/index.jsx
+++ b/client/components/file-picker/index.jsx
@@ -2,8 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import assign from 'lodash/assign';
-import noop from 'lodash/noop';
+import { assign, noop } from 'lodash';
 import pick from 'component-file-picker';
 
 export default class FilePicker extends React.Component {
@@ -13,12 +12,13 @@ export default class FilePicker extends React.Component {
 	}
 
 	showPicker() {
+		this.props.onClick();
 		pick( assign( {}, this.props ), this.props.onPick );
 	}
 
 	render() {
 		return (
-			<span className="file-picker" onClick={ this.showPicker } >
+			<span className="file-picker" onClick={ this.showPicker }>
 				{ this.props.children }
 			</span>
 		);
@@ -31,12 +31,14 @@ FilePicker.propTypes = {
 	multiple: React.PropTypes.bool,
 	directory: React.PropTypes.bool,
 	accept: React.PropTypes.string,
-	onPick: React.PropTypes.func
+	onClick: React.PropTypes.func,
+	onPick: React.PropTypes.func,
 };
 
 FilePicker.defaultProps = {
 	multiple: false,
 	directory: false,
 	accept: null,
+	onClick: noop,
 	onPick: noop
 };

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -62,6 +62,7 @@ import PostLikes from 'blocks/post-likes/docs/example';
 import ReaderFeaturedVideo from 'blocks/reader-featured-video/docs/example';
 import NpsSurvey from 'blocks/nps-survey/docs/example';
 import ReaderExportButton from 'blocks/reader-export-button/docs/example';
+import ReaderImportButton from 'blocks/reader-import-button/docs/example';
 import SharingPreviewPane from 'blocks/sharing-preview-pane/docs/example';
 
 export default React.createClass( {
@@ -144,6 +145,7 @@ export default React.createClass( {
 					<ReaderFeaturedVideo />
 					{ isEnabled( 'nps-survey/devdocs' ) && <NpsSurvey /> }
 					<ReaderExportButton />
+					<ReaderImportButton />
 					<SharingPreviewPane />
 				</Collection>
 			</Main>


### PR DESCRIPTION
This PR extracts the existing 'import feed' functionality to a separate block, ready for the new Manage Following.

<img width="114" alt="screen shot 2017-04-07 at 15 51 52" src="https://cloud.githubusercontent.com/assets/17325/24805572/26804ba0-1baa-11e7-819d-3e8f8cbc81eb.png">

### To test

Visit the devdocs example:

http://calypso.localhost:3000/devdocs/blocks/reader-import-button

Import an OPML or XML file of subscriptions. You can obtain your existing subs using the export button:

http://calypso.localhost:3000/devdocs/blocks/reader-export-button

Nothing will happen after the upload completes, but you should receive an email similar to this:

<img width="830" alt="screen shot 2017-04-07 at 15 46 45" src="https://cloud.githubusercontent.com/assets/17325/24805518/fc4a996c-1ba9-11e7-875d-21f5b484df11.png">

