### PR TITLE
Plugins: Update Plugins Header to use the new es6 syntax

### DIFF
--- a/client/my-sites/plugins/plugin-list-header/style.scss
+++ b/client/my-sites/plugins/plugin-list-header/style.scss
@@ -36,7 +36,7 @@
 	}
 	@include breakpoint( '>960px' ) {
 		&.is-action-bar-visible {
-			.plugin-list-header__actions_dropdown {
+			.plugin-list-header__actions-dropdown {
 				display: none;
 			}
 			.plugin-list-header__action-buttons {
@@ -58,11 +58,11 @@
 	}
 }
 
-.plugin-list-header__actions_dropdown {
+.plugin-list-header__actions-dropdown {
 	display: inline-block;
 }
 
-.plugin-list-header__actions_remove_item {
+.plugin-list-header__actions-remove-item {
 	color: $alert-red;
 
 	&.is-disabled {
@@ -81,4 +81,8 @@
 	align-items: center;
 	display: none;
 	flex-grow: 1;
+}
+
+.plugin-list-header__screen-reader-text {
+	@extend .screen-reader-text;
 }


### PR DESCRIPTION
This PR updates the Plugin Header component to to use the es6 syntax.

To test:
Open up the console. 

Go to /plugins 
Click on Edit All and try out all the different actions in both mobile and desktop view. 
Try resizing and window as well. 
Do you get any error are you able to perform all the actions as expected? 

Go to /plugins/example.com 
And do the same. 

