### PR TITLE
QueryActiveTheme: Allow (and ignore) falsey siteId

### DIFF
--- a/client/components/data/query-active-theme/index.jsx
+++ b/client/components/data/query-active-theme/index.jsx
@@ -12,7 +12,7 @@ import { isRequestingActiveTheme } from 'state/themes/selectors';
 
 class QueryActiveTheme extends Component {
 	static propTypes = {
-		siteId: PropTypes.number.isRequired,
+		siteId: PropTypes.number,
 		// Connected props
 		isRequesting: PropTypes.bool.isRequired,
 		requestActiveTheme: PropTypes.func.isRequired,
@@ -30,7 +30,7 @@ class QueryActiveTheme extends Component {
 	}
 
 	request( props ) {
-		if ( ! props.isRequesting ) {
+		if ( props.siteId && ! props.isRequesting ) {
 			props.requestActiveTheme( props.siteId );
 		}
 	}

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -501,14 +501,14 @@ const ThemeSheet = React.createClass( {
 				<QueryCanonicalTheme themeId={ this.props.id } siteId={ siteId } />
 				{ currentUserId && <QueryUserPurchases userId={ currentUserId } /> }
 				{ siteId && <QuerySitePurchases siteId={ siteId } /> /* TODO: Make QuerySitePurchases handle falsey siteId */ }
-				{ <QuerySitePlans siteId={ siteId } /> /* QuerySitePlans can handle a falsey siteId */ }
+				<QuerySitePlans siteId={ siteId } />
 				<DocumentHead
 					title={ title }
 					meta={ metas }
 					link={ links } />
 				<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />
 				{ this.renderBar() }
-				{ siteId && <QueryActiveTheme siteId={ siteId } /> /* TODO: Make QueryActiveTheme handle falsey siteId */ }
+				<QueryActiveTheme siteId={ siteId } />
 				<ThanksModal source={ 'details' } />
 				<HeaderCake className="theme__sheet-action-bar"
 					backHref={ this.props.backPath }

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -52,7 +52,7 @@ class CurrentTheme extends Component {
 
 		return (
 			<Card className="current-theme">
-				{ siteId && <QueryActiveTheme siteId={ siteId } /> }
+				<QueryActiveTheme siteId={ siteId } />
 				{ currentThemeId && <QueryCanonicalTheme themeId={ currentThemeId } siteId={ siteId } /> }
 				<div className="current-theme__current">
 					{ showScreenshotPlaceholder && <div className="current-theme__img-placeholder" /> }


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/12887#discussion_r110290803.

To test:
* Make sure that the theme sheet still works in multi-site mode, e.g. http://calypso.localhost:3000/theme/mood (Watch the console for errors)
* Same for the Current Theme Bar, for http://calypso.localhost:3000/themes/<yoursite> (e.g. when switching sites, there should be a brief moment when `siteId` is falsey)