### PR TITLE
SEO: Show the current month and year in the SEO Archives settings preview text

### DIFF
--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
@@ -8,6 +11,12 @@ import {
 	min,
 	noop,
 } from 'lodash';
+import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentUserLocale } from 'state/current-user/selectors';
 
 // The following polyfills exist for the draft-js editor, since
 // we are unable to change its codebase and yet we are waiting
@@ -388,6 +397,8 @@ export class TitleFormatEditor extends Component {
 const mapStateToProps = ( state, ownProps ) => {
 	const site = getSelectedSite( state );
 	const { translate } = ownProps;
+	const userLocale = getCurrentUserLocale( state );
+	const formattedDate = moment().locale( userLocale ).format( 'MMMM YYYY' );
 
 	// Add example content for post/page title, tag name and archive dates
 	return ( {
@@ -395,7 +406,7 @@ const mapStateToProps = ( state, ownProps ) => {
 			site,
 			post: { title: translate( 'Example Title' ) },
 			tag: translate( 'Example Tag' ),
-			date: translate( 'August 2016' )
+			date: formattedDate
 		}
 	} );
 };

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -1,10 +1,8 @@
-/**
- * External dependencies
- */
 import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import {
+	get,
 	head,
 	map,
 	max,
@@ -12,11 +10,6 @@ import {
 	noop,
 } from 'lodash';
 import moment from 'moment';
-
-/**
- * Internal dependencies
- */
-import { getCurrentUserLocale } from 'state/current-user/selectors';
 
 // The following polyfills exist for the draft-js editor, since
 // we are unable to change its codebase and yet we are waiting
@@ -397,8 +390,7 @@ export class TitleFormatEditor extends Component {
 const mapStateToProps = ( state, ownProps ) => {
 	const site = getSelectedSite( state );
 	const { translate } = ownProps;
-	const userLocale = getCurrentUserLocale( state );
-	const formattedDate = moment().locale( userLocale ).format( 'MMMM YYYY' );
+	const formattedDate = moment().locale( get( site, 'lang', '' ) ).format( 'MMMM YYYY' );
 
 	// Add example content for post/page title, tag name and archive dates
 	return ( {

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';


### PR DESCRIPTION
I thought it'd be nice to show a dynamic date in the SEO Settings area where we previously showed a hardcoded string `August 2016`. Now it will show the current month and year, and it's localized too:

<img width="285" alt="screen shot 2017-04-07 at 10 47 29 am" src="https://cloud.githubusercontent.com/assets/789137/24812690/f07b7ca2-1b7f-11e7-8d66-202522a93c37.png">

<img width="274" alt="screen shot 2017-04-07 at 10 48 12 am" src="https://cloud.githubusercontent.com/assets/789137/24812691/f07cb202-1b7f-11e7-9e19-e4cd2276bf7d.png">

**To test**
* Ensure you have a business plan on your test site.
* Visit `settings/traffic` and scroll down to the SEO settings.
* Add a new `Date` token to the archives setting. It should display the current month and year in the preview text.