### PR TITLE
Remove olark from the contact form

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -13,11 +13,6 @@ import config from 'config';
 import Main from 'components/main';
 import Card from 'components/card';
 import Notice from 'components/notice';
-import OlarkChatbox from 'components/olark-chatbox';
-import olarkStore from 'lib/olark-store';
-import olarkActions from 'lib/olark-store/actions';
-import olarkEvents from 'lib/olark-events';
-import olarkApi from 'lib/olark-api';
 import HelpContactForm from 'me/help/help-contact-form';
 import HelpContactClosed from 'me/help/help-contact-closed';
 import HelpContactConfirmation from 'me/help/help-contact-confirmation';
@@ -26,12 +21,10 @@ import wpcomLib from 'lib/wp';
 import notices from 'notices';
 import siteList from 'lib/sites-list';
 import analytics from 'lib/analytics';
-import { isOlarkTimedOut } from 'state/ui/olark/selectors';
 import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import { isHappychatAvailable } from 'state/happychat/selectors';
 import { isTicketSupportEligible, isTicketSupportConfigurationReady, getTicketSupportRequestError } from 'state/help/ticket/selectors';
 import HappychatConnection from 'components/happychat/connection';
-import QueryOlark from 'components/data/query-olark';
 import QueryTicketSupportConfiguration from 'components/data/query-ticket-support-configuration';
 import HelpUnverifiedWarning from '../help-unverified-warning';
 import { sendChatMessage as sendHappychatMessage, sendBrowserInfo } from 'state/happychat/actions';
@@ -53,37 +46,14 @@ let savedContactForm = null;
 
 const SUPPORT_DIRECTLY = 'SUPPORT_DIRECTLY';
 const SUPPORT_HAPPYCHAT = 'SUPPORT_HAPPYCHAT';
-const SUPPORT_LIVECHAT = 'SUPPORT_LIVECHAT';
 const SUPPORT_TICKET = 'SUPPORT_TICKET';
 const SUPPORT_FORUM = 'SUPPORT_FORUM';
 
 const HelpContact = React.createClass( {
-
-	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.olarkTimedOut && this.olarkTimedOut !== nextProps.olarkTimedOut && ! this.shouldUseHappychat() ) {
-			this.onOlarkUnavailable();
-		}
-	},
-
 	componentDidMount: function() {
 		this.prepareDirectlyWidget();
 
-		olarkStore.on( 'change', this.updateOlarkState );
-		olarkEvents.on( 'api.chat.onOperatorsAway', this.onOperatorsAway );
-		olarkEvents.on( 'api.chat.onOperatorsAvailable', this.onOperatorsAvailable );
-		olarkEvents.on( 'api.chat.onCommandFromOperator', this.onCommandFromOperator );
-		olarkEvents.on( 'api.chat.onMessageToVisitor', this.onMessageToVisitor );
-		olarkEvents.on( 'api.chat.onMessageToOperator', this.onMessageToOperator );
-
 		sites.on( 'change', this.onSitesChanged );
-
-		olarkActions.updateDetails();
-
-		// The following lines trick olark into thinking we are interacting with it. This interaction
-		// makes olark fire off its onOperatorsAway and onOperatorsAvailable events sooner.
-		olarkActions.expandBox();
-		olarkActions.shrinkBox();
-		olarkActions.hideBox();
 	},
 
 	componentDidUpdate: function() {
@@ -94,34 +64,16 @@ const HelpContact = React.createClass( {
 	},
 
 	componentWillUnmount: function() {
-		const { details, isOperatorAvailable } = this.state.olark;
-
-		olarkStore.removeListener( 'change', this.updateOlarkState );
-		olarkEvents.off( 'api.chat.onOperatorsAway', this.onOperatorsAway );
-		olarkEvents.off( 'api.chat.onOperatorsAvailable', this.onOperatorsAvailable );
-		olarkEvents.off( 'api.chat.onCommandFromOperator', this.onCommandFromOperator );
-		olarkEvents.off( 'api.chat.onMessageToVisitor', this.onMessageToVisitor );
-		olarkEvents.off( 'api.chat.onMessageToOperator', this.onMessageToOperator );
-
-		if ( details.isConversing && ! isOperatorAvailable ) {
-			olarkActions.shrinkBox();
-		}
-
 		sites.removeListener( 'change', this.onSitesChanged );
 	},
 
 	getInitialState: function() {
 		return {
-			olark: olarkStore.get(),
 			isSubmitting: false,
 			confirmation: null,
 			isChatEnded: false,
 			sitesInitialized: sites.initialized
 		};
-	},
-
-	updateOlarkState: function() {
-		this.setState( { olark: olarkStore.get() } );
 	},
 
 	onSitesChanged: function() {
@@ -149,28 +101,6 @@ const HelpContact = React.createClass( {
 		} );
 
 		page( '/help' );
-	},
-
-	startChat: function( contactForm ) {
-		const { message, howCanWeHelp, howYouFeel, siteSlug } = contactForm;
-		const site = sites.getSite( siteSlug );
-
-		// Intentionally not translated since only HE's will see this in the olark console as a notification.
-		const notifications = [
-			'How can you help: ' + howCanWeHelp,
-			'How I feel: ' + howYouFeel,
-			'Site I need help with: ' + ( site ? site.URL : 'N/A' )
-		];
-
-		notifications.forEach( olarkActions.sendNotificationToOperator );
-
-		analytics.tracks.recordEvent( 'calypso_help_live_chat_begin', {
-			site_plan_product_id: ( site ? site.plan.product_id : null )
-		} );
-
-		this.sendMessageToOperator( message );
-
-		this.clearSavedContactForm();
 	},
 
 	prepareDirectlyWidget: function() {
@@ -279,141 +209,6 @@ const HelpContact = React.createClass( {
 	},
 
 	/**
-	 * Send a message to an olark operator.
-	 * @param  {string} message The message to be sent to an operator
-	 */
-	sendMessageToOperator: function( message ) {
-		// Get the DOM element of the olark textarea
-		const widgetInput = window.document.getElementById( 'habla_wcsend_input' );
-		const KEY_ENTER = 13;
-
-		if ( ! widgetInput ) {
-			// We couldn't find the input box in the olark widget so return false since we can't send the message
-			return;
-		}
-
-		// Theres no api call that sends a message to an operator so in order to achieve this we send a fake
-		// "enter" keypress event that olark will be listening for. The enter key event is what then triggers the sending of
-		// the message.
-
-		// Show the olark box so that we may manipulate it.
-		// You can only send a message when the olark box is expanded.
-		olarkActions.expandBox();
-
-		// Send focus to the textarea because olark expects it.
-		widgetInput.focus();
-
-		// IE requires this to be executed before the value is set, don't know why.
-		widgetInput.onkeydown( { keyCode: KEY_ENTER } );
-		widgetInput.value = message;
-
-		// Trigger the onkeydown callback added by olark so that we can send the message to the operator.
-		widgetInput.onkeydown( { keyCode: KEY_ENTER } );
-	},
-
-	onMessageToVisitor: function() {
-		this.trackChatDisplayError( 'onMessageToVisitor' );
-	},
-
-	onMessageToOperator: function() {
-		this.trackChatDisplayError( 'onMessageToOperator' );
-	},
-
-	trackChatDisplayError: function( olarkEvent ) {
-		const { olark, isChatEnded } = this.state;
-
-		// If the user sent/received a message to/from an operator but the chatbox is not inlined
-		// then something must be going wrong. Lets record this event and give some details
-		if ( this.canShowChatbox() ) {
-			return;
-		}
-
-		const tracksData = {
-			olark_event: olarkEvent,
-			olark_locale: olark.locale,
-			olark_is_chat_ended: isChatEnded,
-			olark_is_ready: olark.isOlarkReady,
-			olark_is_expanded: olark.isOlarkExpanded,
-			olark_is_user_eligible: olark.isUserEligible,
-			olark_is_operator_available: olark.isOperatorAvailable
-		};
-
-		// Do a check here to make sure that details are present because an error in the
-		// olark event stack could cause it to be null/undefined
-		if ( olark.details ) {
-			tracksData.olark_is_conversing = olark.details.isConversing;
-		} else {
-			tracksData.olark_details_missing = true;
-		}
-
-		analytics.tracks.recordEvent( 'calypso_help_contact_chatbox_mistaken_display', tracksData );
-
-		// Lets call the olark API directly to see if the value we get differs from what our olark store has.
-		olarkApi( 'api.visitor.getDetails', ( details ) => {
-			const data = {
-				olark_event: olarkEvent,
-				olark_is_conversing: details.isConversing,
-			};
-
-			// This does a separate tracks ping just incase the error is occuring in the olark api call
-			analytics.tracks.recordEvent( 'calypso_help_contact_chatbox_mistaken_display_got_details', data );
-		} );
-	},
-
-	trackContactFormAndFillSubject() {
-		const { details } = this.state.olark;
-		if ( ! details.isConversing ) {
-			analytics.tracks.recordEvent( 'calypso_help_offline_form_display', {
-				form_type: 'kayako'
-			} );
-		}
-		this.autofillSubject();
-	},
-
-	onOlarkUnavailable() {
-		this.trackContactFormAndFillSubject();
-		this.showTimeoutNotice();
-	},
-
-	onOperatorsAway: function() {
-		const IS_UNAVAILABLE = false;
-		this.trackContactFormAndFillSubject();
-		this.showAvailabilityNotice( IS_UNAVAILABLE );
-	},
-
-	onOperatorsAvailable: function() {
-		const IS_AVAILABLE = true;
-
-		this.showAvailabilityNotice( IS_AVAILABLE );
-	},
-
-	showAvailabilityNotice( isAvailable ) {
-		const { isUserEligible, isOlarkReady } = this.state.olark;
-
-		if ( ! isOlarkReady || ! isUserEligible ) {
-			return;
-		}
-
-		if ( isAvailable ) {
-			notices.success( this.props.translate( 'Our Happiness Engineers have returned, chat with us.' ) );
-		} else {
-			notices.warning( this.props.translate( 'Sorry! We just missed you as our Happiness Engineers stepped away.' ) );
-		}
-	},
-
-	showTimeoutNotice() {
-		const { isUserEligible, isOlarkReady } = this.state.olark;
-
-		if ( ! isUserEligible || isOlarkReady ) {
-			return;
-		}
-		notices.warning( this.props.translate(
-			'Our chat tools did not load. If you have an adblocker ' +
-			'please disable it and refresh this page.'
-		) );
-	},
-
-	/**
 	 * Auto fill the subject with the first five words contained in the message field of the contact form.
 	 */
 	autofillSubject: function() {
@@ -428,14 +223,8 @@ const HelpContact = React.createClass( {
 		this.forceUpdate();
 	},
 
-	onCommandFromOperator: function( event ) {
-		if ( event.command.name === 'end' ) {
-			this.setState( { isChatEnded: true } );
-		}
-	},
-
 	shouldUseHappychat: function() {
-		const { olark } = this.state;
+		const isUserEligible = true; // TODO: REPLACE WITH AN API CALL
 
 		// if happychat is disabled in the config, do not use it
 		if ( ! config.isEnabled( 'happychat' ) ) {
@@ -443,7 +232,7 @@ const HelpContact = React.createClass( {
 		}
 
 		// if the happychat connection is able to accept chats, use it
-		return this.props.isHappychatAvailable && olark.isUserEligible;
+		return this.props.isHappychatAvailable && isUserEligible;
 	},
 
 	shouldUseDirectly: function() {
@@ -454,24 +243,14 @@ const HelpContact = React.createClass( {
 		);
 	},
 
-	canShowChatbox: function() {
-		const { olark, isChatEnded } = this.state;
-		return isChatEnded || ( olark.details.isConversing && olark.isOperatorAvailable );
-	},
-
 	getSupportVariation: function() {
-		const { olark } = this.state;
 		const { ticketSupportEligible } = this.props;
 
 		if ( this.shouldUseHappychat() ) {
 			return SUPPORT_HAPPYCHAT;
 		}
 
-		if ( olark.isUserEligible && olark.isOperatorAvailable ) {
-			return SUPPORT_LIVECHAT;
-		}
-
-		if ( olark.details.isConversing || ticketSupportEligible ) {
+		if ( ticketSupportEligible ) {
 			return SUPPORT_TICKET;
 		}
 
@@ -493,16 +272,6 @@ const HelpContact = React.createClass( {
 				return {
 					onSubmit: this.startHappychat,
 					buttonLabel: isDev ? 'Happychat' : translate( 'Chat with us' ),
-					showSubjectField: false,
-					showHowCanWeHelpField: true,
-					showHowYouFeelField: true,
-					showSiteField: hasMoreThanOneSite,
-				};
-
-			case SUPPORT_LIVECHAT:
-				return {
-					onSubmit: this.startChat,
-					buttonLabel: translate( 'Chat with us' ),
 					showSubjectField: false,
 					showHowCanWeHelpField: true,
 					showHowYouFeelField: true,
@@ -587,7 +356,7 @@ const HelpContact = React.createClass( {
 	shouldShowTicketRequestErrorNotice: function( variationSlug ) {
 		const { ticketSupportRequestError } = this.props;
 
-		return SUPPORT_HAPPYCHAT !== variationSlug && SUPPORT_LIVECHAT !== variationSlug && null != ticketSupportRequestError;
+		return SUPPORT_HAPPYCHAT !== variationSlug && null != ticketSupportRequestError;
 	},
 
 	/**
@@ -597,13 +366,10 @@ const HelpContact = React.createClass( {
 	 * @returns {Boolean} Whether all the data is present to determine the variation to show
 	 */
 	hasDataToDetermineVariation: function() {
-		const { olark } = this.state;
 		const { ticketSupportConfigurationReady, ticketSupportRequestError } = this.props;
-
-		const olarkReadyOrTimedOut = olark.isOlarkReady || this.props.olarkTimedOut;
 		const ticketReadyOrError = ticketSupportConfigurationReady || null != ticketSupportRequestError;
 
-		return olarkReadyOrTimedOut && ticketReadyOrError;
+		return ticketReadyOrError;
 	},
 
 	shouldShowPreloadForm: function() {
@@ -614,17 +380,18 @@ const HelpContact = React.createClass( {
 	},
 
 	/**
-	 * Get the view for the contact page. This could either be the olark chat widget if a chat is in progress or a contact form.
+	 * Get the view for the contact page.
 	 * @return {object} A JSX object that should be rendered
 	 */
 	getView: function() {
-		const { olark, confirmation } = this.state;
+		const { confirmation } = this.state;
+		const isSupportClosed = false; // TODO: REPLACE THIS WITH AN API CALL
 
 		if ( confirmation ) {
 			return <HelpContactConfirmation { ...confirmation } />;
 		}
 
-		if ( olark.isSupportClosed ) {
+		if ( isSupportClosed ) {
 			return <HelpContactClosed />;
 		}
 
@@ -642,13 +409,6 @@ const HelpContact = React.createClass( {
 				</div>
 			);
 		}
-
-		if ( this.canShowChatbox() ) {
-			return <OlarkChatbox />;
-		}
-
-		// Hide the olark widget in the bottom right corner.
-		olarkActions.hideBox();
 
 		const supportVariation = this.getSupportVariation();
 
@@ -677,11 +437,10 @@ const HelpContact = React.createClass( {
 			<Main className="help-contact">
 				<HeaderCake onClick={ this.backToHelp } isCompact={ true }>{ this.props.translate( 'Contact Us' ) }</HeaderCake>
 				{ ! this.props.isEmailVerified && <HelpUnverifiedWarning /> }
-				<Card className={ this.canShowChatbox() ? 'help-contact__chat-form' : 'help-contact__form' }>
+				<Card className="help-contact__form">
 					{ this.getView() }
 				</Card>
 				<HappychatConnection />
-				<QueryOlark />
 				<QueryTicketSupportConfiguration />
 			</Main>
 		);
@@ -696,7 +455,6 @@ export default connect(
 			isDirectlyFailed: isDirectlyFailed( state ),
 			isDirectlyReady: isDirectlyReady( state ),
 			isDirectlyUninitialized: isDirectlyUninitialized( state ),
-			olarkTimedOut: isOlarkTimedOut( state ),
 			isEmailVerified: isCurrentUserEmailVerified( state ),
 			isHappychatAvailable: isHappychatAvailable( state ),
 			ticketSupportConfigurationReady: isTicketSupportConfigurationReady( state ),


### PR DESCRIPTION
This pull request removes the use of olark from the contact form.

This pull request is mostly done but in order for this to work we need to add an API endpoint that provides `isUserEligible` and `isSupportClosed`. Maybe create a query component called `QueryUserSupportEligibility`