### PR TITLE
Media Section: Fix inconsistent styles for add button

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -265,7 +265,8 @@ form.sidebar__button {
 	&:not(.selected) {
 		background-color: lighten( $sidebar-bg-color, 3% );
 
-		a {
+		a,
+		form {
 			color: $blue-medium;
 
 			&:first-child:after {
@@ -289,7 +290,8 @@ form.sidebar__button {
 	@include breakpoint( "<660px" ) {
 		background-color: $gray-light;
 
-		a {
+		a,
+		form {
 			color: $blue-medium;
 
 			&:first-child:after {
@@ -311,9 +313,16 @@ form.sidebar__button {
 	}
 }
 
-.notouch .sidebar__menu li:not(.selected) a, form {
-	&.sidebar__button:hover {
-		color: $blue-medium;
+.notouch .sidebar__menu li:not(.selected) {
+	a,
+	form {
+		&.sidebar__button:hover {
+			color: $blue-medium;
+		}
+	}
+
+	form.sidebar__button:hover {
+		border-color: darken( $sidebar-bg-color, 10% );
 	}
 }
 

--- a/client/my-sites/media-library/upload-button.scss
+++ b/client/my-sites/media-library/upload-button.scss
@@ -11,6 +11,10 @@
 		left: 0;
 	opacity: 0;
 	cursor: pointer;
+
+	&::-webkit-file-upload-button {
+		cursor: pointer; /* webkit needs this to change cursor for file type input. */
+	}
 }
 
 @include breakpoint( "<480px" ) {


### PR DESCRIPTION
This PR fixes #12755.

**After**

Hover over menu item:
<img width="280" alt="screen shot 2017-04-07 at 21 54 03" src="https://cloud.githubusercontent.com/assets/908665/24819667/7632cbd6-1bdd-11e7-959f-dfbd2f720a08.png">

Hover over add button:
<img width="274" alt="screen shot 2017-04-07 at 21 54 24" src="https://cloud.githubusercontent.com/assets/908665/24819672/7b8f039c-1bdd-11e7-9c9d-211245efe862.png">

Pointer cursor for add button:
<img width="276" alt="screen shot 2017-04-07 at 21 55 24" src="https://cloud.githubusercontent.com/assets/908665/24819678/812e56f4-1bdd-11e7-8031-ba4e36ec8f09.png">

Small screens:
<img width="414" alt="screen shot 2017-04-07 at 22 02 14" src="https://cloud.githubusercontent.com/assets/908665/24819817/199f0dd4-1bde-11e7-9085-716037845b0a.png">


cc: @drw158 
