### PR TITLE
WPSC: Update the mod rewrite notice to use the Notice component.

### DIFF
--- a/client/extensions/wp-super-cache/easy-tab.jsx
+++ b/client/extensions/wp-super-cache/easy-tab.jsx
@@ -26,7 +26,7 @@ const EasyTab = ( {
 	site,
 	translate,
 } ) => {
-	const enable_cache_notice = translate(
+	const enableCacheNotice = translate(
 		'PHP caching is enabled but Supercache mod_rewrite rules were ' +
 		'detected. Cached files will be served using those rules. If your site is working ok, ' +
 		'please ignore this message. Otherwise, you can edit the .htaccess file in the root of your ' +
@@ -56,7 +56,7 @@ const EasyTab = ( {
 				</form>
 			</Card>
 			{ wp_cache_enabled && ! wp_cache_mod_rewrite && scrules &&
-				<Notice text={ enable_cache_notice } showDismiss={ false } className="wp-super-cache__notice-hug-card" />
+				<Notice text={ enableCacheNotice } showDismiss={ false } className="wp-super-cache__notice-hug-card" />
 			}
 			{ wp_cache_enabled &&
 				<div>

--- a/client/extensions/wp-super-cache/easy-tab.jsx
+++ b/client/extensions/wp-super-cache/easy-tab.jsx
@@ -10,6 +10,7 @@ import { get, pick } from 'lodash';
 import { isHttps } from 'lib/url';
 import Button from 'components/button';
 import Card from 'components/card';
+import Notice from 'components/notice';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormToggle from 'components/forms/form-toggle/compact';
 import SectionHeader from 'components/section-header';
@@ -25,6 +26,13 @@ const EasyTab = ( {
 	site,
 	translate,
 } ) => {
+	const enable_cache_notice = translate(
+		'PHP caching is enabled but Supercache mod_rewrite rules were ' +
+		'detected. Cached files will be served using those rules. If your site is working ok, ' +
+		'please ignore this message. Otherwise, you can edit the .htaccess file in the root of your ' +
+		'install and remove the SuperCache rules.'
+	);
+
 	return (
 		<div>
 			<SectionHeader label={ translate( 'Caching' ) }>
@@ -34,35 +42,22 @@ const EasyTab = ( {
 			</SectionHeader>
 			<Card>
 				<form>
-					<FormFieldset>
-						<FormToggle
-							checked={ wp_cache_enabled }
-							onChange={ handleToggle( 'wp_cache_enabled' ) }>
-							<span>
-								{ translate( 'Caching On {{em}}(Recommended){{/em}}',
-									{
-										components: { em: <em /> }
-									}
-								) }
-							</span>
-						</FormToggle>
-					</FormFieldset>
-
-					{ wp_cache_enabled && ! wp_cache_mod_rewrite && scrules &&
-					<p>
-						{ translate( '{{strong}}Notice:{{/strong}} PHP caching enabled but Supercache mod_rewrite rules ' +
-							'detected. Cached files will be served using those rules. If your site is working ok, ' +
-							'please ignore this message. Otherwise, you can edit the .htaccess file in the root of your ' +
-							'install and remove the SuperCache rules.',
-							{
-								components: { strong: <strong /> }
-							}
-						) }
-					</p>
-					}
+					<FormToggle
+						checked={ wp_cache_enabled }
+						onChange={ handleToggle( 'wp_cache_enabled' ) }>
+						<span>
+							{ translate( 'Caching On {{em}}(Recommended){{/em}}',
+								{
+									components: { em: <em /> }
+								}
+							) }
+						</span>
+					</FormToggle>
 				</form>
 			</Card>
-
+			{ wp_cache_enabled && ! wp_cache_mod_rewrite && scrules &&
+				<Notice text={ enable_cache_notice } showDismiss={ false } className="wp-super-cache__notice-hug-card" />
+			}
 			{ wp_cache_enabled &&
 				<div>
 					<SectionHeader label={ translate( 'Cache Tester' ) } />

--- a/client/extensions/wp-super-cache/style.scss
+++ b/client/extensions/wp-super-cache/style.scss
@@ -111,3 +111,9 @@
 	display: inline-block;
 	width: 60px;
 }
+
+
+
+.wp-super-cache__notice-hug-card {
+	margin-top: -15px;
+}


### PR DESCRIPTION
Fixes an issue listed in #12885.

Change the notice to use the Notice component, instead of simply using a paragraph that indicates there is a notice.

Original:

<img width="772" alt="screen shot 2017-04-08 at 1 09 32 pm" src="https://cloud.githubusercontent.com/assets/195095/24828404/aeeff924-1c5c-11e7-9fa3-d7954470f76d.png">

Updated:

<img width="737" alt="screen shot 2017-04-08 at 1 00 47 pm" src="https://cloud.githubusercontent.com/assets/195095/24828406/b63ce962-1c5c-11e7-84a5-6bf7a22fee9e.png">
