### PR TITLE
WPSC: Update the caching label to be more descriptive

### DIFF
--- a/client/extensions/wp-super-cache/caching.jsx
+++ b/client/extensions/wp-super-cache/caching.jsx
@@ -46,11 +46,7 @@ const Caching = ( {
 							disabled={ isRequesting }
 							onChange={ handleToggle( 'wp_cache_enabled' ) }>
 							<span>
-								{ translate( 'Caching On {{em}}(Recommended){{/em}}',
-									{
-										components: { em: <em /> }
-									}
-								) }
+								{ translate( 'Enable Page Caching' ) }
 							</span>
 						</FormToggle>
 					</FormFieldset>

--- a/client/extensions/wp-super-cache/easy-tab.jsx
+++ b/client/extensions/wp-super-cache/easy-tab.jsx
@@ -51,7 +51,7 @@ const EasyTab = ( {
 						disabled={ isRequesting }
 						onChange={ handleToggle( 'is_cache_enabled' ) }>
 						<span>
-							{ translate( 'Caching On {{em}}(Recommended){{/em}}',
+							{ translate( 'Enable Page Caching',
 								{
 									components: { em: <em /> }
 								}

--- a/client/extensions/wp-super-cache/easy-tab.jsx
+++ b/client/extensions/wp-super-cache/easy-tab.jsx
@@ -51,11 +51,7 @@ const EasyTab = ( {
 						disabled={ isRequesting }
 						onChange={ handleToggle( 'is_cache_enabled' ) }>
 						<span>
-							{ translate( 'Enable Page Caching',
-								{
-									components: { em: <em /> }
-								}
-							) }
+							{ translate( 'Enable Page Caching' ) }
 						</span>
 					</FormToggle>
 				</form>


### PR DESCRIPTION
Fixes an issue in #12885 

The old label simply said "Caching On", which was one of two radio buttons in the plugin interface. Instead, let's use a more direct alternative.

<img width="752" alt="screen shot 2017-04-08 at 2 01 10 pm" src="https://cloud.githubusercontent.com/assets/195095/24828727/d93de752-1c63-11e7-8aeb-bff92d32c93a.png">
