### PR TITLE
Render emojis as images in Happychat messages

### DIFF
--- a/client/components/happychat/timeline.jsx
+++ b/client/components/happychat/timeline.jsx
@@ -17,6 +17,7 @@ import {
 	forEach
 } from './functional';
 import autoscroll from './autoscroll';
+import Emojify from 'components/emojify';
 import scrollbleed from './scrollbleed';
 import { translate } from 'i18n-calypso';
 import { getCurrentUser } from 'state/current-user/selectors';
@@ -34,7 +35,7 @@ const debug = require( 'debug' )( 'calypso:happychat:timeline' );
 
 const linksNotEmpty = ( { links } ) => ! isEmpty( links );
 
-const messageParagraph = ( { message, key } ) => <p key={ key }>{ message }</p>;
+const messageParagraph = ( { message, key } ) => <p key={ key }><Emojify>{ message }</Emojify></p>;
 
 /*
  * Given a message and array of links contained within that message, returns the message


### PR DESCRIPTION
Converting unicode emojis to images ensures consistency and compatibility across clients, and critically, between users and operators: since emoji selection features are on their way for Happychat operators, it's essential that emojis they select appear exactly as they will for the user.

This change simply wraps chat messages in the Emojify component (which wraps the twemoji library), used in a few other contexts already.