### PR TITLE
Jetpack: remove extra space at the end of string

### DIFF
--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -67,7 +67,7 @@ export class PluginActivateToggle extends Component {
 			<span className="plugin-activate-toggle__link">
 				<a onClick={ this.trackManageConnectionLink }
 					href={ '/settings/general/' + site.slug } >
-					{ translate( 'Manage Connection ', { comment: 'manage Jetpack connnection settings link' } ) }
+					{ translate( 'Manage Connection', { comment: 'manage Jetpack connnection settings link' } ) }
 				</a>
 				<a className="plugin-activate-toggle__icon"
 					onClick={ this.trackManageConnectionLink }


### PR DESCRIPTION
The extra space creates a duplicate string for translation.

Confirmed that removing the extra space doesn't affect the layout:
<img width="241" alt="screen shot 2017-04-09 at 13 33 10" src="https://cloud.githubusercontent.com/assets/844866/24836630/26b9a294-1d29-11e7-99e2-741968ebffa3.png">

