### PR TITLE
Don't add space after suggestion if it is not un-neccesarry.

### DIFF
--- a/client/components/suggestions/index.jsx
+++ b/client/components/suggestions/index.jsx
@@ -120,7 +120,7 @@ class Suggestions extends React.Component {
 				break;
 			case 'Enter' :
 				if ( !! this.state.currentSuggestion ) {
-					this.props.suggest( this.state.currentSuggestion + ' ' );
+					this.props.suggest( this.state.currentSuggestion );
 					return true;
 				}
 				break;
@@ -132,7 +132,7 @@ class Suggestions extends React.Component {
 		event.stopPropagation();
 		event.preventDefault();
 		//Additional empty space at the end adds fluidity to workflow
-		this.props.suggest( event.target.textContent + ' ' );
+		this.props.suggest( event.target.textContent );
 	}
 
 	onMouseOver = ( event ) => {

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -145,7 +145,9 @@ class ThemesMagicSearchCard extends React.Component {
 		// Get rid of empty match at end
 		tokens[ tokens.length - 1 ] === '' && tokens.splice( tokens.length - 1, 1 );
 		const tokenIndex = this.findEditedTokenIndex( tokens, this.state.cursorPosition );
-		tokens[ tokenIndex ] = suggestion;
+		// Check if we want to add additional sapce after suggestion so next suggestions card can be opened immediately
+		const hasNextTokenFirstSpace = tokens[ tokenIndex + 1 ] && tokens[ tokenIndex + 1 ][ 0 ] === ' ';
+		tokens[ tokenIndex ] = hasNextTokenFirstSpace ? suggestion : suggestion + ' ';
 		return tokens.join( '' );
 	}
 


### PR DESCRIPTION
### Info
When using suggestions alternatives the token that was replacing the old one had additional space at the end. This made sense for new token but when we replacing we don't need it. 

### Testing
Go to `/themes` add a token.
Position cursor over the token.
Select an alternative.
Verify that no excessive space characters are present at the end.