### PR TITLE
Add hasActivePlugin selector

### DIFF
--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -119,6 +119,7 @@ export isJetpackSiteInDevelopmentMode from './is-jetpack-site-in-development-mod
 export isJetpackSiteInStagingMode from './is-jetpack-site-in-staging-mode';
 export isMappedDomainSite from './is-mapped-domain-site';
 export isPendingEmailChange from './is-pending-email-change';
+export isPluginActive from './is-plugin-active';
 export isPrivateSite from './is-private-site';
 export isPublicizeEnabled from './is-publicize-enabled';
 export isReaderCardExpanded from './is-reader-card-expanded';

--- a/client/state/selectors/is-plugin-active.js
+++ b/client/state/selectors/is-plugin-active.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { find } from 'lodash';
+
+/**
+ * Returns a Boolean indicating if a site has a particular plugin that
+ * is active. This is useful for jetpack connected sites.
+ *
+ * @param {Object} state - Global state tree
+ * @param {Number} siteId - Site ID
+ * @param {String} pluginSlug - Plugin slug
+ * @return {Boolean} - truthiness of a site having an active plugin
+ */
+export default function isPluginActive( state, siteId, pluginSlug ) {
+	const sitePlugins = state.plugins.installed.plugins[ siteId ];
+	const plugin = find( sitePlugins, { slug: pluginSlug } );
+	if ( ! plugin ) {
+		return false;
+	}
+	return plugin.active;
+}

--- a/client/state/selectors/test/is-plugin-active.js
+++ b/client/state/selectors/test/is-plugin-active.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { isPluginActive } from '../';
+
+const helloDolly = {
+	id: 'hello-dolly/hello',
+	slug: 'hello-dolly',
+	active: false
+};
+
+export const jetpack = {
+	id: 'jetpack/jetpack',
+	slug: 'jetpack',
+	active: true
+};
+
+const state = deepFreeze( {
+	plugins: {
+		installed: {
+			plugins: {
+				'site.one': [ helloDolly ],
+				'site.two': [ jetpack, helloDolly ],
+			}
+		}
+	}
+} );
+
+describe( 'isPluginActive', () => {
+	it( 'should return false if the site cannot be found', () => {
+		expect( isPluginActive( state, 'some-unknown-id', 'my-slug' ) ).to.be.false;
+	} );
+
+	it( 'should return false if the plugin cannot be found', () => {
+		expect( isPluginActive( state, 'site.two', 'some-non-existant-slug' ) ).to.be.false;
+	} );
+
+	it( 'should return false if the plugin is found, but not active', () => {
+		expect( isPluginActive( state, 'site.two', 'hello-dolly' ) ).to.be.false;
+	} );
+
+	it( 'should return true if the plugin is found and is active', () => {
+		expect( isPluginActive( state, 'site.two', 'jetpack' ) ).to.be.true;
+	} );
+} );


### PR DESCRIPTION
### Goal
Find out if a site has a particular active plugin.

### Why
Site stats will now include Store stats for jetpack enabled stores. In order to know if some kind of toggle control should be rendered, we need to know if `woocommerce` plugin is installed and active.

![screen shot 2017-04-10 at 11 52 41 am](https://cloud.githubusercontent.com/assets/1922453/24844315/e3c5647a-1dfd-11e7-8125-55a6e5a18dcf.png)

The parent components's connect `mapStateToProps` will have something like this
```js
isWooConnect: isJetpack && hasActivePlugin( state, siteId, 'woocommerce' ),
```