### PR TITLE
ES6ify and Migrate DomainSearch to use isUpgradeable

### DIFF
--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -68,9 +68,7 @@ module.exports = {
 				<CartData>
 					<DomainSearch
 						basePath={ basePath }
-						context={ context }
-						sites={ sites }
-						productsList={ productsList } />
+						context={ context } />
 				</CartData>
 			),
 			document.getElementById( 'primary' ),

--- a/client/my-sites/upgrades/domain-search/domain-search.jsx
+++ b/client/my-sites/upgrades/domain-search/domain-search.jsx
@@ -1,89 +1,83 @@
 /**
  * External dependencies
  */
-var connect = require( 'react-redux' ).connect,
-	page = require( 'page' ),
-	React = require( 'react' ),
-	classnames = require( 'classnames' );
+import { connect } from 'react-redux';
+import page from 'page';
+import React, { Component, PropTypes } from 'react';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
  */
-var observe = require( 'lib/mixins/data-observe' ),
-	EmptyContent = require( 'components/empty-content' ),
-	{ DOMAINS_WITH_PLANS_ONLY } = require( 'state/current-user/constants' ),
-	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
-	RegisterDomainStep = require( 'components/domains/register-domain-step' ),
-	UpgradesNavigation = require( 'my-sites/upgrades/navigation' ),
-	Main = require( 'components/main' ),
-	upgradesActions = require( 'lib/upgrades/actions' ),
-	cartItems = require( 'lib/cart-values/cart-items' ),
-	analyticsMixin = require( 'lib/mixins/analytics' );
+import EmptyContent from 'components/empty-content';
+import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import RegisterDomainStep from 'components/domains/register-domain-step';
+import UpgradesNavigation from 'my-sites/upgrades/navigation';
+import Main from 'components/main';
+import upgradesActions from 'lib/upgrades/actions';
+import cartItems from 'lib/cart-values/cart-items';
+import analyticsMixin from 'lib/mixins/analytics';
 import { currentUserHasFlag } from 'state/current-user/selectors';
+import isSiteUpgradeable from 'state/selectors/is-site-upgradeable';
+import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import QueryProductsList from 'components/data/query-products-list';
 
-var DomainSearch = React.createClass( {
-	mixins: [ observe( 'productsList', 'sites' ), analyticsMixin( 'registerDomain' ) ],
+const analytics = analyticsMixin( 'registerDomain' );
 
-	propTypes: {
-		sites: React.PropTypes.object.isRequired,
-		productsList: React.PropTypes.object.isRequired,
-		basePath: React.PropTypes.string.isRequired,
-		context: React.PropTypes.object.isRequired,
-		domainsWithPlansOnly: React.PropTypes.bool.isRequired
-	},
+class DomainSearch extends Component {
+	static propTypes = {
+		basePath: PropTypes.string.isRequired,
+		context: PropTypes.object.isRequired,
+		domainsWithPlansOnly: PropTypes.bool.isRequired,
+		isSiteUpgradeable: PropTypes.bool,
+		productsList: PropTypes.object.isRequired,
+		selectedSite: PropTypes.object,
+		selectedSiteId: PropTypes.number,
+		selectedSiteSlug: PropTypes.string,
+	};
 
-	getInitialState: function() {
-		return { domainRegistrationAvailable: true };
-	},
+	state = {
+		domainRegistrationAvailable: true
+	};
 
-	componentWillMount: function() {
-		this.checkSiteIsUpgradeable();
-	},
-
-	componentDidMount: function() {
-		this.props.sites.on( 'change', this.checkSiteIsUpgradeable );
-
-		this.previousSelectedSite = this.props.sites.getSelectedSite();
-	},
-
-	componentWillReceiveProps: function() {
-		var selectedSite = this.props.sites.getSelectedSite();
-		if ( this.previousSelectedSite !== selectedSite ) {
-			this.previousSelectedSite = selectedSite;
-		}
-	},
-
-	componentWillUnmount: function() {
-		this.props.sites.off( 'change', this.checkSiteIsUpgradeable );
-	},
-
-	checkSiteIsUpgradeable: function() {
-		var selectedSite = this.props.sites.getSelectedSite();
-
-		if ( selectedSite && ! selectedSite.isUpgradeable() ) {
-			page.redirect( '/domains/add' );
-		}
-	},
-
-	handleDomainsAvailabilityChange: function( isAvailable ) {
+	handleDomainsAvailabilityChange = ( isAvailable ) => {
 		this.setState( { domainRegistrationAvailable: isAvailable } );
-	},
+	};
 
-	handleAddRemoveDomain: function( suggestion ) {
+	handleAddRemoveDomain = ( suggestion ) => {
 		if ( ! cartItems.hasDomainInCart( this.props.cart, suggestion.domain_name ) ) {
 			this.addDomain( suggestion );
 		} else {
 			this.removeDomain( suggestion );
 		}
-	},
+	};
 
-	handleAddMapping( domain ) {
+	handleAddMapping = ( domain ) => {
 		upgradesActions.addItem( cartItems.domainMapping( { domain } ) );
-		page( '/checkout/' + this.props.sites.getSelectedSite().slug );
-	},
+		page( '/checkout/' + this.props.selectedSiteSlug );
+	};
+
+	componentWillMount() {
+		this.checkSiteIsUpgradeable( this.props );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.selectedSiteId !== this.props.selectedSiteId ) {
+			this.checkSiteIsUpgradeable( nextProps );
+		}
+	}
+
+	checkSiteIsUpgradeable( props ) {
+		if ( props.selectedSite && ! props.isSiteUpgradeable ) {
+			page.redirect( '/domains/add' );
+		}
+	}
 
 	addDomain( suggestion ) {
-		this.recordEvent( 'addDomainButtonClick', suggestion.domain_name, 'domains' );
+		analytics.recordEvent( 'addDomainButtonClick', suggestion.domain_name, 'domains' );
 		const items = [
 			cartItems.domainRegistration( { domain: suggestion.domain_name, productSlug: suggestion.product_slug } )
 		];
@@ -96,28 +90,28 @@ var DomainSearch = React.createClass( {
 
 		upgradesActions.addItems( items );
 		upgradesActions.goToDomainCheckout( suggestion );
-	},
+	}
 
 	removeDomain( suggestion ) {
-		this.recordEvent( 'removeDomainButtonClick', suggestion.domain_name );
+		analytics.recordEvent( 'removeDomainButtonClick', suggestion.domain_name );
 		upgradesActions.removeDomainFromCart( suggestion );
-	},
+	}
 
-	render: function() {
-		var selectedSite = this.props.sites.getSelectedSite(),
+	render() {
+		const { selectedSite, selectedSiteSlug, translate } = this.props,
 			classes = classnames( 'main-column', {
 				'domain-search-page-wrapper': this.state.domainRegistrationAvailable
-			} ),
-			content;
+			} );
+		let content;
 
-		if ( ! this.state.domainRegistrationAvailable ) {
+		if ( ! this.state.domainRegistrationAvailable || isEmpty( this.props.productsList ) ) {
 			content = (
 				<EmptyContent
 					illustration="/calypso/images/drake/drake-500.svg"
-					title={ this.translate( 'Domain registration is unavailable' ) }
-					line={ this.translate( "We're hard at work on the issue. Please check back shortly." ) }
-					action={ this.translate( 'Back to Plans' ) }
-					actionURL={ '/plans/' + selectedSite.slug } />
+					title={ translate( 'Domain registration is unavailable' ) }
+					line={ translate( "We're hard at work on the issue. Please check back shortly." ) }
+					action={ translate( 'Back to Plans' ) }
+					actionURL={ '/plans/' + selectedSiteSlug } />
 			);
 		} else {
 			content = (
@@ -139,7 +133,7 @@ var DomainSearch = React.createClass( {
 							selectedSite={ selectedSite }
 							offerMappingOption
 							basePath={ this.props.basePath }
-							products={ this.props.productsList.get() } />
+							products={ this.props.productsList } />
 					</div>
 				</span>
 			);
@@ -147,15 +141,21 @@ var DomainSearch = React.createClass( {
 
 		return (
 			<Main className={ classes }>
+				<QueryProductsList />
 				<SidebarNavigation />
 				{ content }
 			</Main>
 		);
 	}
-} );
+}
 
-module.exports = connect(
+export default connect(
 	( state ) => ( {
-		domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY )
+		selectedSite: getSelectedSite( state ),
+		selectedSiteId: getSelectedSiteId( state ),
+		selectedSiteSlug: getSelectedSiteSlug( state ),
+		domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
+		isSiteUpgradeable: isSiteUpgradeable( state, getSelectedSiteId( state ) ),
+		productsList: state.productsList.items,
 	} )
-)( DomainSearch );
+)( localize( DomainSearch ) );


### PR DESCRIPTION
Part of #11328

This refactor of `DomainSearch` is part of an effort to remove `SitesList`.
In #12059, the `isUpgradeable` selector was introduced which allowed us to replace checks on `site.isUpgradeable()`.

### Testing Instructions
Boot the branch locally and visit
- `http://calypso.localhost:3000/domains/add/:siteSlug`
- `http://calypso.localhost:3000/domains/add/suggestion/hello+world/:siteSlug`

to check that there is no regression on the domain search component.
Try switching site while being on each page.

### Reviews
- [x] Code
- [x] Product
