### PR TITLE
ES6ify and Migrate SiteRedirect to use isUpgradeable

### DIFF
--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -91,9 +91,7 @@ module.exports = {
 		renderWithReduxStore(
 			(
 				<CartData>
-					<SiteRedirect
-						productsList={ productsList }
-						sites={ sites } />
+					<SiteRedirect />
 				</CartData>
 			),
 			document.getElementById( 'primary' ),

--- a/client/my-sites/upgrades/domain-search/site-redirect-step.jsx
+++ b/client/my-sites/upgrades/domain-search/site-redirect-step.jsx
@@ -20,10 +20,7 @@ var SiteRedirectStep = React.createClass( {
 	propTypes: {
 		cart: React.PropTypes.object.isRequired,
 		products: React.PropTypes.object.isRequired,
-		selectedSite: React.PropTypes.oneOfType( [
-			React.PropTypes.object,
-			React.PropTypes.bool
-		] ).isRequired
+		selectedSite: React.PropTypes.object.isRequired,
 	},
 
 	getInitialState: function() {


### PR DESCRIPTION
Part of #11328

This refactor of `SiteRedirect` is part of an effort to remove `SitesList`.
In #12059, the `isUpgradeable` selector was introduced which allowed us to replace checks on `site.isUpgradeable()`.

### Testing Instructions
Boot the branch locally and visit `http://calypso.localhost:3000/domains/add/site-redirect/:siteSlug`.
- Check that entering an invalid domain name such as `hello world` triggers an error notice
- Check that entering a valid domain name such as `helloworld.com` works and brings you to checkout with a Site Redirect product added to your cart
- Check that switching site while on this page works as expected
- Check that the back button brings you to `http://calypso.localhost:3000/domains/add/:siteSlug`

### Reviews
- [x] Code
- [x] Product
