### PR TITLE
ES6ify and Migrate MapDomain to use isUpgradeable

### DIFF
--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -103,7 +103,7 @@ module.exports = {
 
 	mapDomain: function( context ) {
 		var CartData = require( 'components/data/cart' ),
-			MapDomain = require( 'my-sites/upgrades/map-domain' ),
+			MapDomain = require( 'my-sites/upgrades/map-domain' ).default,
 			basePath = route.sectionify( context.path );
 
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -115,10 +115,7 @@ module.exports = {
 				<Main>
 					<CartData>
 						<MapDomain
-							store={ context.store }
-							productsList={ productsList }
-							initialQuery={ context.query.initialQuery }
-							sites={ sites } />
+							initialQuery={ context.query.initialQuery } />
 					</CartData>
 				</Main>
 			),

--- a/client/my-sites/upgrades/map-domain/test/map-domain.js
+++ b/client/my-sites/upgrades/map-domain/test/map-domain.js
@@ -1,0 +1,66 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { spy } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+import useMockery from 'test/helpers/use-mockery';
+
+describe( 'MapDomain component', () => {
+	const pageSpy = spy();
+	pageSpy.redirect = spy();
+	let MapDomain, MapDomainStep;
+
+	useFakeDom();
+
+	useMockery( ( mockery ) => {
+		mockery.registerMock( 'page', pageSpy );
+		MapDomain = require( '../' ).MapDomain;
+		MapDomainStep = require( 'components/domains/map-domain-step' );
+	} );
+
+	beforeEach( () => {
+		pageSpy.reset();
+		pageSpy.redirect.reset();
+	} );
+
+	const defaultProps = {
+		productsList: { get: () => {} },
+		domainsWithPlansOnly: false,
+		translate: () => '',
+		selectedSiteIsUpgradeable: true,
+	};
+
+	it( 'does not blow up with default props', () => {
+		const wrapper = shallow( <MapDomain { ...defaultProps } /> );
+		expect( wrapper.length ).to.eql( 1 );
+	} );
+
+	it( 'redirects if site cannot be upgraded at mounting', () => {
+		shallow( <MapDomain { ...defaultProps } selectedSiteIsUpgradeable={ false } /> );
+		expect( pageSpy.redirect ).to.have.been.calledWith( '/domains/add/mapping' );
+	} );
+
+	it( 'redirects if site cannot be upgraded at new props', () => {
+		const wrapper = shallow( <MapDomain selectedSiteIsUpgradeable={ true } { ...defaultProps } /> );
+		wrapper.setProps( { selectedSiteIsUpgradeable: false } );
+		expect( pageSpy.redirect ).to.have.been.calledWith( '/domains/add/mapping' );
+	} );
+
+	it( 'redirects if site cannot be upgraded at new props', () => {
+		const wrapper = shallow( <MapDomain selectedSiteIsUpgradeable={ true } { ...defaultProps } /> );
+		wrapper.setProps( { selectedSiteIsUpgradeable: false } );
+		expect( pageSpy.redirect ).to.have.been.calledWith( '/domains/add/mapping' );
+	} );
+
+	it( 'renders a MapDomainStep', () => {
+		const wrapper = shallow( <MapDomain { ...defaultProps } /> );
+		expect( wrapper.find( MapDomainStep ) ).to.have.length( 1 );
+	} );
+} );

--- a/client/my-sites/upgrades/map-domain/test/map-domain.js
+++ b/client/my-sites/upgrades/map-domain/test/map-domain.js
@@ -11,6 +11,7 @@ import { spy } from 'sinon';
  */
 import useFakeDom from 'test/helpers/use-fake-dom';
 import useMockery from 'test/helpers/use-mockery';
+import mockDataPoller from 'test/helpers/mocks/data-poller';
 import paths from 'my-sites/upgrades/paths';
 
 describe( 'MapDomain component', () => {
@@ -22,6 +23,9 @@ describe( 'MapDomain component', () => {
 	useFakeDom();
 
 	useMockery( ( mockery ) => {
+		// some deeper dependency was loading sites-lists, which triggers the data poller
+		// and tests were hanging forever
+		mockDataPoller( mockery );
 		mockery.registerMock( 'page', pageSpy );
 		MapDomain = require( '../' ).MapDomain;
 		MapDomainStep = require( 'components/domains/map-domain-step' );

--- a/client/my-sites/upgrades/map-domain/test/map-domain.js
+++ b/client/my-sites/upgrades/map-domain/test/map-domain.js
@@ -17,6 +17,7 @@ describe( 'MapDomain component', () => {
 	pageSpy.redirect = spy();
 	let MapDomain, MapDomainStep;
 
+	// needed, because some dependency of dependency uses `window`
 	useFakeDom();
 
 	useMockery( ( mockery ) => {

--- a/client/my-sites/upgrades/map-domain/test/map-domain.js
+++ b/client/my-sites/upgrades/map-domain/test/map-domain.js
@@ -39,7 +39,7 @@ describe( 'MapDomain component', () => {
 
 	it( 'does not blow up with default props', () => {
 		const wrapper = shallow( <MapDomain { ...defaultProps } /> );
-		expect( wrapper.length ).to.eql( 1 );
+		expect( wrapper ).to.have.length( 1 );
 	} );
 
 	it( 'redirects if site cannot be upgraded at mounting', () => {

--- a/client/my-sites/upgrades/map-domain/test/map-domain.js
+++ b/client/my-sites/upgrades/map-domain/test/map-domain.js
@@ -11,11 +11,12 @@ import { spy } from 'sinon';
  */
 import useFakeDom from 'test/helpers/use-fake-dom';
 import useMockery from 'test/helpers/use-mockery';
+import paths from 'my-sites/upgrades/paths';
 
 describe( 'MapDomain component', () => {
 	const pageSpy = spy();
 	pageSpy.redirect = spy();
-	let MapDomain, MapDomainStep;
+	let MapDomain, MapDomainStep, HeaderCake;
 
 	// needed, because some dependency of dependency uses `window`
 	useFakeDom();
@@ -24,6 +25,7 @@ describe( 'MapDomain component', () => {
 		mockery.registerMock( 'page', pageSpy );
 		MapDomain = require( '../' ).MapDomain;
 		MapDomainStep = require( 'components/domains/map-domain-step' );
+		HeaderCake = require( 'components/header-cake' );
 	} );
 
 	beforeEach( () => {
@@ -63,5 +65,41 @@ describe( 'MapDomain component', () => {
 	it( 'renders a MapDomainStep', () => {
 		const wrapper = shallow( <MapDomain { ...defaultProps } /> );
 		expect( wrapper.find( MapDomainStep ) ).to.have.length( 1 );
+	} );
+
+	it( "goes back when HeaderCake's onClick is fired", () => {
+		const wrapper = shallow( <MapDomain { ...defaultProps } /> );
+		expect( wrapper.find( HeaderCake ).prop( 'onClick' ) ).to.equal( wrapper.instance().goBack );
+	} );
+
+	it( 'goes back to /domains/add if no selected site', () => {
+		const wrapper = shallow( <MapDomain noSelectedSite={ true } { ...defaultProps } /> );
+		wrapper.instance().goBack();
+		expect( pageSpy ).to.have.been.calledWith( '/domains/add' );
+	} );
+
+	it( 'goes back to domain management for VIP sites', () => {
+		const wrapper = shallow( <MapDomain selectedSiteIsVip={ true } selectedSiteSlug="baba" { ...defaultProps } /> );
+		wrapper.instance().goBack();
+		expect( pageSpy ).to.have.been.calledWith( paths.domainManagementList( 'baba' ) );
+	} );
+
+	it( 'goes back to domain add page if non-VIP site', () => {
+		const wrapper = shallow( <MapDomain selectedSiteSlug="baba" { ...defaultProps } /> );
+		wrapper.instance().goBack();
+		expect( pageSpy ).to.have.been.calledWith( '/domains/add/baba' );
+	} );
+
+	it( 'does not render a notice by default', () => {
+		const wrapper = shallow( <MapDomain { ...defaultProps } /> );
+		// we match the notice by props, because enzyme isn't matching the Notice type for some reason
+		expect( wrapper.find( { status: 'is-error' } ) ).to.have.length( 0 );
+	} );
+
+	it( 'render a notice by when there is an errorMessage in the state ', () => {
+		const wrapper = shallow( <MapDomain { ...defaultProps } /> );
+		// we match the notice by props, because enzyme isn't matching the Notice type for some reason
+		wrapper.setState( { errorMessage: 'baba' } );
+		expect( wrapper.find( { status: 'is-error' } ) ).to.have.length( 1 );
 	} );
 } );

--- a/client/my-sites/upgrades/map-domain/test/map-domain.js
+++ b/client/my-sites/upgrades/map-domain/test/map-domain.js
@@ -27,7 +27,7 @@ describe( 'MapDomain component', () => {
 		// and tests were hanging forever
 		mockDataPoller( mockery );
 		mockery.registerMock( 'page', pageSpy );
-		MapDomain = require( '../' ).MapDomain;
+		MapDomain = require( '..' ).MapDomain;
 		MapDomainStep = require( 'components/domains/map-domain-step' );
 		HeaderCake = require( 'components/header-cake' );
 	} );
@@ -38,10 +38,16 @@ describe( 'MapDomain component', () => {
 	} );
 
 	const defaultProps = {
-		productsList: { get: () => {} },
+		productsList: {},
 		domainsWithPlansOnly: false,
-		translate: () => '',
-		selectedSiteIsUpgradeable: true,
+		translate: string => string,
+		isSiteUpgradeable: true,
+		selectedSite: {
+			ID: 500,
+			slug: 'domain.com',
+		},
+		selectedSiteId: 500,
+		selectedSiteSlug: 'domain.com',
 	};
 
 	it( 'does not blow up with default props', () => {
@@ -50,19 +56,13 @@ describe( 'MapDomain component', () => {
 	} );
 
 	it( 'redirects if site cannot be upgraded at mounting', () => {
-		shallow( <MapDomain { ...defaultProps } selectedSiteIsUpgradeable={ false } /> );
+		shallow( <MapDomain { ...defaultProps } isSiteUpgradeable={ false } /> );
 		expect( pageSpy.redirect ).to.have.been.calledWith( '/domains/add/mapping' );
 	} );
 
 	it( 'redirects if site cannot be upgraded at new props', () => {
-		const wrapper = shallow( <MapDomain selectedSiteIsUpgradeable={ true } { ...defaultProps } /> );
-		wrapper.setProps( { selectedSiteIsUpgradeable: false } );
-		expect( pageSpy.redirect ).to.have.been.calledWith( '/domains/add/mapping' );
-	} );
-
-	it( 'redirects if site cannot be upgraded at new props', () => {
-		const wrapper = shallow( <MapDomain selectedSiteIsUpgradeable={ true } { ...defaultProps } /> );
-		wrapper.setProps( { selectedSiteIsUpgradeable: false } );
+		const wrapper = shallow( <MapDomain { ...defaultProps } isSiteUpgradeable={ true } /> );
+		wrapper.setProps( { selectedSiteId: 501, isSiteUpgradeable: false } );
 		expect( pageSpy.redirect ).to.have.been.calledWith( '/domains/add/mapping' );
 	} );
 
@@ -77,19 +77,20 @@ describe( 'MapDomain component', () => {
 	} );
 
 	it( 'goes back to /domains/add if no selected site', () => {
-		const wrapper = shallow( <MapDomain noSelectedSite={ true } { ...defaultProps } /> );
+		const wrapper = shallow( <MapDomain { ...defaultProps } selectedSite={ null } /> );
 		wrapper.instance().goBack();
 		expect( pageSpy ).to.have.been.calledWith( '/domains/add' );
 	} );
 
 	it( 'goes back to domain management for VIP sites', () => {
-		const wrapper = shallow( <MapDomain selectedSiteIsVip={ true } selectedSiteSlug="baba" { ...defaultProps } /> );
+		const wrapper = shallow( <MapDomain { ...defaultProps } selectedSiteSlug="baba"
+											selectedSite={ { ...defaultProps.selectedSite, is_vip: true } } /> );
 		wrapper.instance().goBack();
 		expect( pageSpy ).to.have.been.calledWith( paths.domainManagementList( 'baba' ) );
 	} );
 
 	it( 'goes back to domain add page if non-VIP site', () => {
-		const wrapper = shallow( <MapDomain selectedSiteSlug="baba" { ...defaultProps } /> );
+		const wrapper = shallow( <MapDomain { ...defaultProps } selectedSiteSlug="baba" /> );
 		wrapper.instance().goBack();
 		expect( pageSpy ).to.have.been.calledWith( '/domains/add/baba' );
 	} );


### PR DESCRIPTION
Part of #11328

This refactor of `MapDomain` is part of an effort to remove `SitesList`.
In #12059, the `isUpgradeable` selector was introduced which allowed us to replace checks on `site.isUpgradeable()`.

### Testing Instructions
Boot the branch locally and visit `http://calypso.localhost:3000/domains/add/mapping/:siteSlug`.
- Check that entering an invalid domain name such as `hello world` or `google.com` triggers an error message
- Check that entering a valid and taken domain name such as `nintendo.com` works and brings you to checkout with a domain mapping item added to your cart
- Check that entering a valid and available domain name such as `djoafeeafw.com` shows you  the option to purchase it and brings you to checkout when you click on Select.
- Check that switching site while on this page works as expected

### Reviews
- [ ] Code
- [ ] Product
