### PR TITLE
Reduxify `Sites` component

### DIFF
--- a/client/my-sites/sites/sites.jsx
+++ b/client/my-sites/sites/sites.jsx
@@ -3,6 +3,8 @@
  */
 import React from 'react';
 import page from 'page';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -12,13 +14,15 @@ import Main from 'components/main';
 import observe from 'lib/mixins/data-observe';
 import SiteSelector from 'components/site-selector';
 import { addSiteFragment } from 'lib/route';
+import isSiteUpgradeable from 'state/selectors/is-site-upgradeable';
 
-export default React.createClass( {
+const Sites = React.createClass( {
 	displayName: 'Sites',
 
 	mixins: [ observe( 'sites', 'user' ) ],
 
 	propTypes: {
+		isSiteUpgradeable: React.PropTypes.func.isRequired,
 		path: React.PropTypes.string.isRequired
 	},
 
@@ -44,7 +48,7 @@ export default React.createClass( {
 
 		// Filter out sites with no upgrades on particular routes
 		if ( /^\/domains/.test( path ) || /^\/plans/.test( this.props.sourcePath ) ) {
-			return site.isUpgradeable();
+			return this.props.isSiteUpgradeable( site ) !== false;
 		}
 
 		return site;
@@ -65,7 +69,7 @@ export default React.createClass( {
 
 		const path = this.props.path.split( '?' )[ 0 ].replace( /\//g, ' ' );
 
-		return this.translate( 'Please select a site to open {{strong}}%(path)s{{/strong}}', {
+		return this.props.translate( 'Please select a site to open {{strong}}%(path)s{{/strong}}', {
 			args: {
 				path: path
 			},
@@ -94,3 +98,9 @@ export default React.createClass( {
 		);
 	}
 } );
+
+export default connect(
+	( state ) => ( {
+		isSiteUpgradeable: ( site ) => isSiteUpgradeable( state, site.ID )
+	} )
+)( localize( Sites ) );


### PR DESCRIPTION
Part of #11328

This PR connects `my-sites/sites` to the redux store.
It is part of a larger refactor aimed at removing SitesList.

### Testing instructions
Load the branch locally and test those routes:
- `/sites`
- `/sites/private`
- `/plans` (or other routes that use the `sites` controller such as `/menus`, `/customize`, `/domains` or `/design/upload`)

The site selector should behave the same as in production (with the same quirks such as `/plans` which shows sites with no upgrades for instance because the list of sites is not loaded when the page loads)

### Reviews
- [ ] Product
- [ ] Code
