### PR TITLE
Site Settings: Introduce Masterbar card to Writing section

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -15,11 +15,16 @@ import SectionHeader from 'components/section-header';
 import Button from 'components/button';
 import QueryTaxonomies from 'components/data/query-taxonomies';
 import TaxonomyCard from './taxonomies/taxonomy-card';
-import { isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
+import {
+	isJetpackSite,
+	isJetpackMinimumVersion,
+	siteSupportsJetpackSettingsUi
+} from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestPostTypes } from 'state/post-types/actions';
 import Composing from './composing';
 import CustomContentTypes from './custom-content-types';
+import Masterbar from './masterbar';
 import MediaSettings from './media-settings';
 import ThemeEnhancements from './theme-enhancements';
 import PublishingTools from './publishing-tools';
@@ -65,6 +70,21 @@ class SiteSettingsFormWriting extends Component {
 				onSubmit={ this.props.handleSubmitForm }
 				className="site-settings__general-settings"
 			>
+
+				{
+					this.props.isJetpackSite && this.props.jetpackMasterbarSupported && (
+						<div>
+							{
+								this.renderSectionHeader( translate( 'WordPress.com toolbar' ), false )
+							}
+							<Masterbar
+								isSavingSettings={ isSavingSettings }
+								isRequestingSettings={ isRequestingSettings }
+							/>
+						</div>
+					)
+				}
+
 				{ config.isEnabled( 'manage/site-settings/categories' ) &&
 					<div className="site-settings__taxonomies">
 						<QueryTaxonomies siteId={ siteId } postType="post" />
@@ -156,6 +176,7 @@ const connectComponent = connect(
 
 		return {
 			jetpackSettingsUISupported: siteSupportsJetpackSettingsUi( state, siteId ),
+			jetpackMasterbarSupported: isJetpackMinimumVersion( state, siteId, '4.8' ),
 			isJetpackSite: isJetpackSite( state, siteId ),
 			siteId
 		};

--- a/client/my-sites/site-settings/masterbar.jsx
+++ b/client/my-sites/site-settings/masterbar.jsx
@@ -33,7 +33,7 @@ const Masterbar = ( {
 					<div className="masterbar__info-link-container site-settings__info-link-container">
 						<InfoPopover position={ 'left' }>
 							<ExternalLink href={ 'https://jetpack.com/support/masterbar/' } icon target="_blank">
-								{ translate( 'Learn more about WordPress.com Toolbar.' ) }
+								{ translate( 'Learn more about the WordPress.com Toolbar.' ) }
 							</ExternalLink>
 						</InfoPopover>
 					</div>

--- a/client/my-sites/site-settings/masterbar.jsx
+++ b/client/my-sites/site-settings/masterbar.jsx
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
+import FormFieldset from 'components/forms/form-fieldset';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackModuleUnavailableInDevelopmentMode, isJetpackSiteInDevelopmentMode } from 'state/selectors';
+import InfoPopover from 'components/info-popover';
+import ExternalLink from 'components/external-link';
+import QueryJetpackConnection from 'components/data/query-jetpack-connection';
+
+const Masterbar = ( {
+	isRequestingSettings,
+	isSavingSettings,
+	selectedSiteId,
+	masterbarModuleUnavailable,
+	translate
+} ) => {
+	return (
+		<div>
+			<QueryJetpackConnection siteId={ selectedSiteId } />
+
+			<Card className="masterbar__card site-settings__security-settings">
+				<FormFieldset>
+					<div className="masterbar__info-link-container site-settings__info-link-container">
+						<InfoPopover position={ 'left' }>
+							<ExternalLink href={ 'https://jetpack.com/support/masterbar/' } icon target="_blank">
+								{ translate( 'Learn more about WordPress.com Toolbar.' ) }
+							</ExternalLink>
+						</InfoPopover>
+					</div>
+
+					<JetpackModuleToggle
+						siteId={ selectedSiteId }
+						moduleSlug="masterbar"
+						label={ translate( 'Enable the WordPress.com toolbar' ) }
+						description={
+							translate(
+								'The WordPress.com toolbar replaces the default admin bar and offers quick links to ' +
+								'the Reader, all your sites, your WordPress.com profile, and notifications. ' +
+								'Centralize your WordPress experience with a single global toolbar.'
+							)
+						}
+						disabled={ isRequestingSettings || isSavingSettings || masterbarModuleUnavailable }
+					/>
+				</FormFieldset>
+			</Card>
+		</div>
+	);
+};
+
+Masterbar.defaultProps = {
+	isSavingSettings: false,
+	isRequestingSettings: true,
+};
+
+Masterbar.propTypes = {
+	isSavingSettings: PropTypes.bool,
+	isRequestingSettings: PropTypes.bool,
+};
+
+export default connect(
+	( state ) => {
+		const selectedSiteId = getSelectedSiteId( state );
+		const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
+		const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode( state, selectedSiteId, 'masterbar' );
+
+		return {
+			selectedSiteId,
+			masterbarModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
+		};
+	}
+)( localize( Masterbar ) );


### PR DESCRIPTION
This PR introduces a WordPress.com card to the Writing section. It allows the user to toggle the masterbar for Jetpack sites with Jetpack 4.8 or newer. Fixes #12171.

Preview:
![](https://cldup.com/-kNcPnkQNO.png)

To test:
* Checkout this branch or get it going on calypso.live
* Go to `/settings/writing/$site` where `$site` is one of your sites with Jetpack 4.8 or newer.
* Verify you see the card.
* Play with the toggle and verify it enables the WordPress.com toolbar on your site.
* Enable dev mode on your site and verify the toggle is disabled.
* Test with a site that has older Jetpack and verify the card does not appear.
* Verify the card does not appear on a WordPress.com site.