### PR TITLE
Analytics: added doNotTrack prop to calypso_page_view event

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -182,7 +182,8 @@ const analytics = {
 
 		recordPageView: function( urlPath ) {
 			let eventProperties = {
-				path: urlPath
+				path: urlPath,
+				doNotTrack: '1' === navigator.doNotTrack ? 1 : 0
 			};
 
 			// Record all `utm` marketing parameters as event properties on the page view event


### PR DESCRIPTION
This small PR adds a `doNotTrack` property to the `calypso_page_view` event in order to estimate how many users have Do Not Track enabled while using Calypso.

# Testing

In Chrome go to Settings/Privacy and enable the option "Send a Do Not Track request..."

![donottrack](https://cloud.githubusercontent.com/assets/10284338/24864203/bdfa1e1a-1e03-11e7-9c34-ee581e64bebd.png)

Open Calypso and in Chrome's Network tab search for "doNotTrack". You should see the `calypso_page_view` event details in the "Query String Parameters" section with a `doNotTrack: 1` value:

![donottrack-1](https://cloud.githubusercontent.com/assets/10284338/24864200/b83a5cf6-1e03-11e7-8020-e07fc509cde0.png)

Disable the Do Not Track option from Chrome, reload Calypso and search again for "doNotTrack" in Chrome's Network tab. The event details in the "Query String Parameters" section should show a `doNotTrack: 0`.

Thank you!