### PR TITLE
Site Settings: Move defaultProps and propTypes into ThemeEnhancements

### DIFF
--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -19,6 +19,20 @@ import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
 
 class ThemeEnhancements extends Component {
+	static defaultProps = {
+		isSavingSettings: false,
+		isRequestingSettings: true,
+		fields: {}
+	};
+
+	static propTypes = {
+		onSubmitForm: PropTypes.func.isRequired,
+		handleAutosavingToggle: PropTypes.func.isRequired,
+		isSavingSettings: PropTypes.bool,
+		isRequestingSettings: PropTypes.bool,
+		fields: PropTypes.object,
+	};
+
 	isFormPending() {
 		const {
 			isRequestingSettings,
@@ -150,20 +164,6 @@ class ThemeEnhancements extends Component {
 		);
 	}
 }
-
-ThemeEnhancements.defaultProps = {
-	isSavingSettings: false,
-	isRequestingSettings: true,
-	fields: {}
-};
-
-ThemeEnhancements.propTypes = {
-	onSubmitForm: PropTypes.func.isRequired,
-	handleAutosavingToggle: PropTypes.func.isRequired,
-	isSavingSettings: PropTypes.bool,
-	isRequestingSettings: PropTypes.bool,
-	fields: PropTypes.object,
-};
 
 export default connect(
 	( state ) => {


### PR DESCRIPTION
This PR moves the `defaultProps` and `propTypes` into the `ThemeEnhancements` class - there is no reason for them to stay outside.

To test:
* Go to `/settings/writing/$site`, where `$site` is one of your Jetpack sites.
* Verify there are no regressions in the Theme Enhancements card.

Note: there is currently an issue with the subsettings of the Minileven module and newer Jetpack versions, this one will be handled in a separate PR.