### PR TITLE
Analytics: disallow remarketing based on URL rules

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -197,11 +197,61 @@ function loadTrackingScripts( callback ) {
 }
 
 /**
+ * Whether we're allowed to track the current page for retargeting.
+ *
+ * We disable retargetinig on certain pages/URLs in order to protect our users' privacy.
+ *
+ * @returns {Boolean}
+ */
+function isRetargetAllowed() {
+	// If this list catches things that are not necessarily forbidden we're ok with
+	// a little bit of approximation as long as we do catch the ones that we have to.
+	// We need to be quite aggressive with how we filter candiate pages as failing
+	// to protect our users' privacy puts us in breach of our own TOS and our
+	// retargeting partners' TOS. We also see personally identifiable information in
+	// unexpected places like email addresses in users' posts URLs and titles for
+	// various (accidental or not) reasons. We also pass PII to URLs like
+	// `wordpress.com/jetpack/connect` etc.
+	const forbiddenPatterns = [
+		'@',
+		'%40',
+		'first=',
+		'last=',
+		'email=',
+		'email_address=',
+		'user_email=',
+		'address-1=',
+		'country-code=',
+		'phone=',
+		'last-name=',
+		'first-name=',
+		'wordpress.com/jetpack/connect',
+		'wordpress.com/error-report',
+	];
+
+	const href = document.location.href;
+
+	for ( const pattern of forbiddenPatterns ) {
+		if ( href.indexOf( pattern ) !== -1 ) {
+			debug( 'isRetargetAllowed(): no' );
+			return false;
+		}
+	}
+
+	debug( 'isRetargetAllowed(): yes' );
+	return true;
+}
+
+/**
  * Fire tracking events for the purposes of retargeting on all Calypso pages
  *
  * @returns {void}
  */
 function retarget() {
+	if ( ! isRetargetAllowed() ) {
+		return;
+	}
+
 	if ( ! hasStartedFetchingScripts ) {
 		return loadTrackingScripts( retarget );
 	}
@@ -243,6 +293,10 @@ function retarget() {
  * A generic function that we can export and call to track plans page views with our ad partners
  */
 function retargetViewPlans() {
+	if ( ! isRetargetAllowed() ) {
+		return;
+	}
+
 	if ( ! config.isEnabled( 'ad-tracking' ) ) {
 		return;
 	}
@@ -929,9 +983,10 @@ module.exports = {
 		nextFunction();
 	},
 
+	retargetViewPlans,
+
 	recordAliasInFloodlight,
 	recordPageViewInFloodlight,
-	retargetViewPlans,
 	recordAddToCart,
 	recordViewCheckout,
 	recordOrder,


### PR DESCRIPTION
This PR adds a new function `isRetargetAllowed()` that checks whether retargeting tracking should be enabled or not on the current URL.

It uses a simple pattern matching test and excludes all pages that could potentially contain personally identifiable information. The test is deliberately quite aggressive as we need to make sure we're compliant with our own and our partners' policies (Google in particular).

# Testing

- Set `"ad-tracking": true` in `development.json`.
- Open Calypso, ex. http://calypso.localhost:3000/
- From the JS console in Chrome enable debugging: `localStorage.setItem( 'debug', 'calypso:ad-tracking' );`
- Reload the page
- In the JS console you should see `isRetargetAllowed(): yes`:

![retargetyes](https://cloud.githubusercontent.com/assets/10284338/24869277/07840bea-1e13-11e7-979f-285d6b452a85.png)

- Now set the URL to something that would be forbidden based on the `isRetargetAllowed()` function, ex. http://calypso.localhost:3000/?email=forbidden@email.com

- In the JS console you should now see a new entry with `isRetargetAllowed(): no`.

You can also double check that when retargeting is off no retargeting events are fired. For example looking for our Facebook pixel id `823166884443641` in Chrome's Network tab will yield no results while the retargeting is disallowed, while visiting an allowed URL will yield one entry similar to:

![fbpixel](https://cloud.githubusercontent.com/assets/10284338/24869657/36de76ae-1e14-11e7-97bf-43ffbf12f945.png)
