### PR TITLE
Editor: Avoid Photonizing external images

### DIFF
--- a/client/components/tinymce/plugins/media/restrict-size/index.js
+++ b/client/components/tinymce/plugins/media/restrict-size/index.js
@@ -35,7 +35,7 @@ function setImageSrc( img, opening, src, closing ) {
 	}
 
 	const parsed = deserialize( img );
-	if ( parsed.media.transient ) {
+	if ( parsed.media.transient || ! parsed.media.ID ) {
 		return img;
 	}
 

--- a/client/components/tinymce/plugins/media/restrict-size/test/index.js
+++ b/client/components/tinymce/plugins/media/restrict-size/test/index.js
@@ -83,5 +83,12 @@ describe( 'restrictSize', () => {
 			const value = setImages( '<p><img src="https://wordpress.com/2015/11/forest.jpg" alt="forest" class="alignnone size-thumbnail wp-image-5823" data-mce-selected="1"></p>' );
 			expect( value ).to.equal( '<p><img src="https://wordpress.com/2015/11/forest.jpg?w=680" data-wpmedia-src="https://wordpress.com/2015/11/forest.jpg" alt="forest" class="alignnone size-thumbnail wp-image-5823" data-mce-selected="1"></p>' );
 		} );
+
+		it( 'should not replace external images (those without media ID)', () => {
+			const markup = '<p><img src="https://wordpress.com/2015/11/forest.jpg" alt="forest" class="alignnone size-thumbnail"></p>';
+
+			const value = setImages( markup );
+			expect( value ).to.equal( markup );
+		} );
 	} );
 } );


### PR DESCRIPTION
Fixes: #12957
Related: #11239

This pull request seeks to resolve an issue where some external images containing query parameters will appear as broken in the editor. This is related to changes applied in #11239 where every image (except in-progress uploads) are passed through Photon. Due to restrictions on how Photon strips query parameters and potential proxying restrictions from the external image host, we should simply avoid passing through Photon images not  #belonging to the media library.

__Testing Instructions:__

Ensure unit tests pass:

```
npm run test-client client/components/tinymce/plugin/media/restrict-size/index.js
```

Repeat steps from #12957, verifying that the image is shown correctly.
Repeat steps from #11239, verifying that the image is shown with correct rotation after upload.

Verify that upon inserting an image from your media library that inspecting the image reveals that the `restrict-size` logic has been applied (`img` should have `?w=680` query parameter optionally multiplied by screen pixel density and `data-wpmedia-src` attribute).