### PR TITLE
Add "View" button to current site card

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import classnames from 'classnames';
 import { noop } from 'lodash';
 import Gridicon from 'gridicons';
@@ -11,60 +11,55 @@ import Gridicon from 'gridicons';
  */
 import SiteIcon from 'blocks/site-icon';
 import SiteIndicator from 'my-sites/site-indicator';
+import { localize } from 'i18n-calypso';
 
-export default React.createClass( {
-	displayName: 'Site',
+class Site extends Component {
 
-	getDefaultProps() {
-		return {
-			// onSelect callback
-			onSelect: noop,
-			// mouse event callbacks
-			onMouseEnter: noop,
-			onMouseLeave: noop,
+	static defaultProps = {
+		// onSelect callback
+		onSelect: noop,
+		// mouse event callbacks
+		onMouseEnter: noop,
+		onMouseLeave: noop,
 
-			// Set a href attribute to the anchor
-			href: null,
+		// Set a href attribute to the anchor
+		href: null,
 
-			// Choose to show the SiteIndicator
-			indicator: true,
+		// Choose to show the SiteIndicator
+		indicator: true,
 
-			// Mark as selected or not
-			isSelected: false,
+		// Mark as selected or not
+		isSelected: false,
 
-			homeLink: false,
-			// if homeLink is enabled
-			showHomeIcon: true,
-			compact: false
-		};
-	},
+		homeLink: false,
+		// if homeLink is enabled
+		showHomeIcon: true,
+		compact: false
+	}
 
-	propTypes: {
-		href: React.PropTypes.string,
-		externalLink: React.PropTypes.bool,
-		indicator: React.PropTypes.bool,
-		onSelect: React.PropTypes.func,
-		onMouseEnter: React.PropTypes.func,
-		onMouseLeave: React.PropTypes.func,
-		isSelected: React.PropTypes.bool,
-		isHighlighted: React.PropTypes.bool,
-		site: React.PropTypes.object,
-		homeLink: React.PropTypes.bool,
-		showHomeIcon: React.PropTypes.bool,
-		compact: React.PropTypes.bool
-	},
+	static propTypes = {
+		href: PropTypes.string,
+		externalLink: PropTypes.bool,
+		indicator: PropTypes.bool,
+		onSelect: PropTypes.func,
+		onMouseEnter: PropTypes.func,
+		onMouseLeave: PropTypes.func,
+		isSelected: PropTypes.bool,
+		isHighlighted: PropTypes.bool,
+		site: PropTypes.object,
+		homeLink: PropTypes.bool,
+		showHomeIcon: PropTypes.bool,
+		compact: PropTypes.bool,
 
-	onSelect( event ) {
-		this.props.onSelect( event, this.props.site.slug );
-	},
+		// from localize()
+		translate: PropTypes.func.isRequired
+	}
 
-	onMouseEnter( event ) {
-		this.props.onMouseEnter( event, this.props.site.slug );
-	},
+	onSelect = ( event ) => this.props.onSelect( event, this.props.site.slug );
 
-	onMouseLeave( event ) {
-		this.props.onMouseLeave( event, this.props.site.slug );
-	},
+	onMouseEnter = ( event ) => this.props.onMouseEnter( event, this.props.site.slug );
+
+	onMouseLeave = ( event ) => this.props.onMouseLeave( event, this.props.site.slug );
 
 	render() {
 		const site = this.props.site;
@@ -92,17 +87,17 @@ export default React.createClass( {
 					data-tip-target={ this.props.tipTarget }
 					target={ this.props.externalLink && '_blank' }
 					title={ this.props.homeLink
-						? this.translate( 'View this site' )
-						: this.translate( 'Select this site' )
+						? this.props.translate( 'View this site' )
+						: this.props.translate( 'Select this site' )
 					}
 					onClick={ this.onSelect }
 					onMouseEnter={ this.onMouseEnter }
 					onMouseLeave={ this.onMouseLeave }
 					aria-label={ this.props.homeLink && site.is_previewable
-						? this.translate( 'Open site %(domain)s in a preview', {
+						? this.props.translate( 'Open site %(domain)s in a preview', {
 							args: { domain: site.domain }
 						} )
-						: this.translate( 'Open site %(domain)s in new tab', {
+						: this.props.translate( 'Open site %(domain)s in new tab', {
 							args: { domain: site.domain }
 						} )
 					}
@@ -139,4 +134,6 @@ export default React.createClass( {
 			</div>
 		);
 	}
-} );
+}
+
+export default localize( Site );

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -121,15 +121,10 @@ class Site extends Component {
 						</div>
 						<div className="site__domain">{ site.domain }</div>
 					</div>
-					{ this.props.homeLink &&
-						<div className="site__link-hint">
-							{ this.props.translate( 'View' ) }
-						</div>
-					}
 					{ this.props.homeLink && this.props.showHomeIcon &&
-						<span className="site__home">
+						<div className="site__home">
 							<Gridicon icon="house" size={ 18 } />
-						</span>
+						</div>
 					}
 				</a>
 				{ this.props.indicator

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -121,6 +121,11 @@ class Site extends Component {
 						</div>
 						<div className="site__domain">{ site.domain }</div>
 					</div>
+					{ this.props.homeLink &&
+						<div className="site__link-hint">
+							{ this.props.translate( 'View' ) }
+						</div>
+					}
 					{ this.props.homeLink && this.props.showHomeIcon &&
 						<span className="site__home">
 							<Gridicon icon="house" size={ 18 } />

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -119,7 +119,6 @@
 }
 
 .site__link-hint {
-	//width: auto;
 	flex: 0 1 auto;
 	position: relative;
 
@@ -145,6 +144,11 @@
 		margin: 10px 10px 0 0;
 	}
 	// /a.sidebar-button
+}
+
+.site__content:hover .site__link-hint {
+	background-color: lighten( $sidebar-bg-color, 10% );
+	color: $sidebar-text-color;
 }
 
 .site__home {

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -49,15 +49,6 @@
 			line-height: 46px;
 		}
 
-		.site__home {
-			top: 11px;
-			line-height: 18px;
-		}
-
-		.site__home .gridicon {
-			margin-top: 0;
-		}
-
 	}
 }
 
@@ -69,6 +60,7 @@
 	padding: 16px;
 	position: relative;
 	width: 100%;
+	align-items: center;
 
 	&:focus {
 		outline: none;
@@ -119,67 +111,15 @@
 	}
 }
 
-.site__link-hint {
-	flex: 0 1 auto;
-	position: relative;
-
-	// from layout/sidebar/styles.scss a.sidebar-button
-	box-sizing: border-box;
-	white-space: nowrap;
-	overflow: hidden;
-	padding: 2px 8px 3px 8px;
-	height: 24px;
-	margin: 11px 8px 0 0;
-	line-height: 18px;
-	background-color: $gray-light;
-	color: darken( $gray, 20% );
-	font-size: 11px;
-	font-weight: 600;
-	border-radius: 3px;
-	border: 1px solid darken( $sidebar-bg-color, 10% );
-
-	@include breakpoint( "<660px" ) {
-		font-size: 14px;
-		height: 35px;
-		padding: 8px 16px;
-		margin: 10px 10px 0 0;
-	}
-	// /a.sidebar-button
-}
-
-.site__content:hover .site__link-hint {
-	background-color: lighten( $sidebar-bg-color, 10% );
-	color: $sidebar-text-color;
-}
-
 .site__home {
-	background: $blue-medium;
-	color: $white;
-	display: block;
-	width: 32px;
-	height: 32px;
+	flex: 0 1 auto;
+	color: $gray;
 	text-align: center;
 	text-transform: none;
 	overflow: initial;
-	opacity: 0;
-	transition: opacity 0.2s;
-	transform: translate3d(0, 0, 0);
-	position: absolute;
-		left: 16px;
-		top: 17px;
 
-	.gridicon {
-		margin-top: 5px;
-		vertical-align: middle;
-	}
-
-	.site.is-compact & {
-		width: 24px;
-		height: 24px;
-	}
-
-	&:hover {
-		color: $white;
+	.site__content:hover & {
+		color: $blue-medium;
 	}
 
 	@include breakpoint( "<660px" ) {
@@ -187,9 +127,6 @@
 	}
 }
 
-.site__content:hover .site__home {
-	opacity: 1;
-}
 
 .site__badge {
 	color: $gray;

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -118,6 +118,35 @@
 	}
 }
 
+.site__link-hint {
+	//width: auto;
+	flex: 0 1 auto;
+	position: relative;
+
+	// from layout/sidebar/styles.scss a.sidebar-button
+	box-sizing: border-box;
+	white-space: nowrap;
+	overflow: hidden;
+	padding: 2px 8px 3px 8px;
+	height: 24px;
+	margin: 11px 8px 0 0;
+	line-height: 18px;
+	background-color: $gray-light;
+	color: darken( $gray, 20% );
+	font-size: 11px;
+	font-weight: 600;
+	border-radius: 3px;
+	border: 1px solid darken( $sidebar-bg-color, 10% );
+
+	@include breakpoint( "<660px" ) {
+		font-size: 14px;
+		height: 35px;
+		padding: 8px 16px;
+		margin: 10px 10px 0 0;
+	}
+	// /a.sidebar-button
+}
+
 .site__home {
 	background: $blue-medium;
 	color: $white;

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -91,6 +91,7 @@
 .site__info {
 	width: 0; // Firefox needs explicit width (even 0)
 	flex: 1 0 auto;
+	position: relative;
 }
 
 .site__title {


### PR DESCRIPTION
This PR addresses #12781. 

The purpose is to clarify that clicking on the site will take you to the site.

To test:

1. Open a site ( `https://wordpress.com/stats/insights/$site` )
1. Check that the appearance is coherent and that site card the link functions correctly (see screenshots).
1. Verify that `homeLink=false` site cards _do not_ display the button (`/sites` or by clicking "Switch site" in the sidebar)