### PR TITLE
Add plans call to action a/b test in signup

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -17,6 +17,14 @@ module.exports = {
 		defaultVariation: 'userLast',
 		allowExistingUsers: false,
 	},
+	signupPlansCallToAction: {
+		datestamp: '20170403',
+		variations: {
+			original: 50,
+			modified: 50,
+		},
+		defaultVariation: 'original',
+	},
 	automatedTransfer2: {
 		datestamp: '20170316',
 		variations: {

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -11,6 +11,7 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import Button from 'components/button';
+import { abtest } from 'lib/abtest';
 
 const PlanFeaturesActions = ( {
 	canPurchase,
@@ -21,17 +22,19 @@ const PlanFeaturesActions = ( {
 	freePlan = false,
 	onUpgradeClick = noop,
 	isPlaceholder = false,
+	isPopular,
 	isInSignup,
 	translate,
 	manageHref,
-	isLandingPage
+	isLandingPage,
+	planName
 } ) => {
 	let upgradeButton;
 	const classes = classNames(
 		'plan-features__actions-button',
 		{
 			'is-current': current,
-			'is-primary': primaryUpgrade && ! isPlaceholder
+			'is-primary': ( primaryUpgrade && ! isPlaceholder ) || ( isPopular && abtest( 'signupPlansCallToAction' ) === 'modified' )
 		},
 		className
 	);
@@ -50,6 +53,10 @@ const PlanFeaturesActions = ( {
 		if ( isLandingPage ) {
 			buttonText = translate( 'Select', { context: 'button' } );
 		}
+		if ( isInSignup && ( abtest( 'signupPlansCallToAction' ) === 'modified' ) ) {
+			buttonText = 'Start with ' + planName;
+		}
+
 		upgradeButton = (
 			<Button
 				className={ classes }

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -135,7 +135,7 @@ class PlanFeatures extends Component {
 				newPlan,
 				relatedMonthlyPlan,
 				primaryUpgrade,
-				isPlaceholder
+				isPlaceholder,
 			} = properties;
 			const { rawPrice, discountPrice } = properties;
 
@@ -171,6 +171,8 @@ class PlanFeatures extends Component {
 						isPlaceholder={ isPlaceholder }
 						isInSignup={ isInSignup }
 						isLandingPage={ isLandingPage }
+						isPopular = { popular }
+						planName ={ planConstantObj.getTitle() }
 					/>
 					<FoldableCard
 						header={ translate( 'Show features' ) }
@@ -269,7 +271,9 @@ class PlanFeatures extends Component {
 				onUpgradeClick,
 				planName,
 				primaryUpgrade,
-				isPlaceholder
+				isPlaceholder,
+				planConstantObj,
+				popular,
 			} = properties;
 
 			const classes = classNames(
@@ -286,9 +290,11 @@ class PlanFeatures extends Component {
 						current={ current }
 						available = { available }
 						primaryUpgrade={ primaryUpgrade }
+						planName ={ planConstantObj.getTitle() }
 						onUpgradeClick={ onUpgradeClick }
 						freePlan={ isFreePlan( planName ) }
 						isPlaceholder={ isPlaceholder }
+						isPopular = { popular }
 						isInSignup={ isInSignup }
 						isLandingPage={ isLandingPage }
 						manageHref={ `/plans/my-plan/${ site.slug }` }
@@ -337,7 +343,7 @@ class PlanFeatures extends Component {
 				description={ description }
 				hideInfoPopover={ abtest( 'jetpackNewDescriptions' ) === 'showNew' }
 			>
-				<span className="plan_features__item-info">
+				<span className="plan-features__item-info">
 					<span className={ itemClasses }>{ feature.getTitle() }</span>
 					{ abtest( 'jetpackNewDescriptions' ) === 'showNew'
 						? <span className="plan-features__item-description">{ description }</span>
@@ -390,7 +396,9 @@ class PlanFeatures extends Component {
 				onUpgradeClick,
 				planName,
 				primaryUpgrade,
-				isPlaceholder
+				isPlaceholder,
+				planConstantObj,
+				popular,
 			} = properties;
 			const classes = classNames(
 				'plan-features__table-item',
@@ -405,11 +413,13 @@ class PlanFeatures extends Component {
 						current={ current }
 						available = { available }
 						primaryUpgrade={ primaryUpgrade }
+						planName ={ planConstantObj.getTitle() }
 						onUpgradeClick={ onUpgradeClick }
 						freePlan={ isFreePlan( planName ) }
 						isPlaceholder={ isPlaceholder }
 						isInSignup={ isInSignup }
 						isLandingPage={ isLandingPage }
+						isPopular = { popular }
 						manageHref={ `/plans/my-plan/${ site.slug }` }
 					/>
 				</td>

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -438,7 +438,7 @@ $plan-features-sidebar-width: 272px;
 	}
 }
 
-.plan_features__item-info {
+.plan-features__item-info {
 	flex: 1 0 0;
 	width: 100%;
 }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -45,7 +45,12 @@ class PlansFeaturesMain extends Component {
 
 		const isPersonalPlanEnabled = isEnabled( 'plans/personal-plan' );
 		if ( displayJetpackPlans && intervalType === 'monthly' ) {
-			const jetpackPlans = [ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL_MONTHLY, PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_BUSINESS_MONTHLY ];
+			const jetpackPlans = [
+				PLAN_JETPACK_FREE,
+				PLAN_JETPACK_PERSONAL_MONTHLY,
+				PLAN_JETPACK_PREMIUM_MONTHLY,
+				PLAN_JETPACK_BUSINESS_MONTHLY
+			];
 			if ( hideFreePlan ) {
 				jetpackPlans.shift();
 			}


### PR DESCRIPTION
## Hypothesis 
Changing the Call to action (CTA) for our plans from “Upgrade” to “Start with { PlanName }” will increase the number of people selecting a plan on the plans signup step.

## Why
I remember the first time I signed up and saw the “Upgrade” button — It through me off. I was only just signing up and it was already asking me to upgrade. I felt apprehensive to press the button as I was not sure what it was going to do.

## Test parameters

**TestName:** `plans-cta-test`
**Variations:** `Original` 50% — `Modified` 50%
**Traffic:** 143,601 English visitors/week
**Baseline Conversion Rate (BCR):** 9.9%
**Minimum Detectable Effect (MDE):** 2%
**Sample size (MSS):** 409,815
**Statistical Power:** 85%
**Significance Level:** 5%
**Duration:** 3 weeks (minimum 1 week)
**Start:** 2017-04-11
**End:** 2017-05-02

## Screenshots
`Original`
![screen shot 2017-04-10 at 8 54 26 am](https://cloud.githubusercontent.com/assets/6981253/24873361/86e50c24-1dee-11e7-9b77-94b6e80b347b.png)

`Modified`
![screen shot 2017-04-10 at 3 50 55 pm](https://cloud.githubusercontent.com/assets/6981253/24879634/805ef25e-1e05-11e7-9d26-14081e5636b0.png)


@markryall @travisw can you please review?


