### PR TITLE
Themes: Add query component for filters

### DIFF
--- a/client/components/data/query-theme-filters/index.jsx
+++ b/client/components/data/query-theme-filters/index.jsx
@@ -23,10 +23,6 @@ export class QueryThemeFilters extends Component {
 	}
 }
 
-export const mapDispatchToProps = ( {
-	requestThemeFilters,
-} );
-
 export default connect(
 	null, { requestThemeFilters }
 )( QueryThemeFilters );

--- a/client/components/data/query-theme-filters/index.jsx
+++ b/client/components/data/query-theme-filters/index.jsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { requestThemeFilters } from 'state/themes/actions';
+
+export class QueryThemeFilters extends Component {
+	static propTypes = {
+		requestThemeFilters: PropTypes.func.isRequired,
+	}
+
+	componentWillMount() {
+		requestThemeFilters();
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export const mapDispatchToProps = ( {
+	requestThemeFilters,
+} );
+
+export default connect(
+	null, { requestThemeFilters }
+)( QueryThemeFilters );

--- a/client/components/data/query-theme-filters/index.jsx
+++ b/client/components/data/query-theme-filters/index.jsx
@@ -15,7 +15,7 @@ export class QueryThemeFilters extends Component {
 	}
 
 	componentWillMount() {
-		requestThemeFilters();
+		this.props.requestThemeFilters();
 	}
 
 	render() {

--- a/client/components/data/query-theme-filters/index.jsx
+++ b/client/components/data/query-theme-filters/index.jsx
@@ -14,7 +14,7 @@ export class QueryThemeFilters extends Component {
 		requestThemeFilters: PropTypes.func.isRequired,
 	}
 
-	componentWillMount() {
+	componentDidMount() {
 		this.props.requestThemeFilters();
 	}
 

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -29,6 +29,7 @@ import { getThemeShowcaseDescription } from 'state/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSite } from 'state/ui/selectors';
 import ThemesSearchCard from './themes-magic-search-card';
+import QueryThemeFilters from 'components/data/query-theme-filters';
 
 function getThemeShowcaseTitle( tier ) {
 	const titles = {
@@ -186,6 +187,7 @@ const ThemeShowcase = React.createClass( {
 						uri={ `/themes${ verticalSection }` } />
 				)}
 				<div className="themes__content">
+					<QueryThemeFilters />
 					<ThemesSearchCard
 						onSearch={ this.doSearch }
 						search={ prependFilterKeys( filter ) + search }


### PR DESCRIPTION
No visual changes. Adds a component to trigger a request to fetch the theme filters.

**To Test**
* clear out persisted storage
* boot calypso at /stats
* click the _Themes_ link
* check that `state.themes.themeFilters` in the console returns populated object
