### PR TITLE
Add signup plan reorder a/b test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -50,6 +50,14 @@ module.exports = {
 		},
 		defaultVariation: 'original',
 	},
+	signupPlansReorderTest: {
+		datestamp: '20170410',
+		variations: {
+			original: 50,
+			modified: 50,
+		},
+		defaultVariation: 'original',
+	},
 	conciergeOfferOnCancel: {
 		datestamp: '20170410',
 		variations: {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -28,6 +28,7 @@ import FAQ from 'components/faq';
 import FAQItem from 'components/faq/faq-item';
 import { isEnabled } from 'config';
 import purchasesPaths from 'me/purchases/paths';
+import { abtest } from 'lib/abtest';
 
 class PlansFeaturesMain extends Component {
 	getPlanFeatures() {
@@ -71,7 +72,12 @@ class PlansFeaturesMain extends Component {
 		}
 
 		if ( displayJetpackPlans ) {
-			const jetpackPlans = [ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PREMIUM, PLAN_JETPACK_BUSINESS ];
+			const jetpackPlans = [
+				PLAN_JETPACK_FREE,
+				PLAN_JETPACK_PERSONAL,
+				PLAN_JETPACK_PREMIUM,
+				PLAN_JETPACK_BUSINESS
+			];
 			if ( hideFreePlan ) {
 				jetpackPlans.shift();
 			}
@@ -91,13 +97,24 @@ class PlansFeaturesMain extends Component {
 			);
 		}
 
-		const plans = filter(
-			[
-				hideFreePlan ? null : PLAN_FREE,
-				isPersonalPlanEnabled ? PLAN_PERSONAL : null,
+		let signupPlans = [
+			hideFreePlan ? null : PLAN_FREE,
+			isPersonalPlanEnabled ? PLAN_PERSONAL : null,
+			PLAN_PREMIUM,
+			PLAN_BUSINESS
+		];
+
+		if ( abtest( 'signupPlansReorderTest' ) === 'modified' ) {
+			signupPlans = [
+				PLAN_BUSINESS,
 				PLAN_PREMIUM,
-				PLAN_BUSINESS
-			],
+				isPersonalPlanEnabled ? PLAN_PERSONAL : null,
+				hideFreePlan ? null : PLAN_FREE,
+			];
+		}
+
+		const plans = filter(
+			signupPlans,
 			value => !! value
 		);
 

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
-import { filter, get } from 'lodash';
+import { filter, get, reverse } from 'lodash';
 
 /**
  * Internal dependencies
@@ -97,24 +97,15 @@ class PlansFeaturesMain extends Component {
 			);
 		}
 
-		let signupPlans = [
+		const signupPlans = [
 			hideFreePlan ? null : PLAN_FREE,
 			isPersonalPlanEnabled ? PLAN_PERSONAL : null,
 			PLAN_PREMIUM,
 			PLAN_BUSINESS
 		];
 
-		if ( abtest( 'signupPlansReorderTest' ) === 'modified' ) {
-			signupPlans = [
-				PLAN_BUSINESS,
-				PLAN_PREMIUM,
-				isPersonalPlanEnabled ? PLAN_PERSONAL : null,
-				hideFreePlan ? null : PLAN_FREE,
-			];
-		}
-
 		const plans = filter(
-			signupPlans,
+			abtest( 'signupPlansReorderTest' ) === 'modified' ? reverse( signupPlans ) : signupPlans,
 			value => !! value
 		);
 


### PR DESCRIPTION
## Hypothesis 
We can increase the number of paying users by reordering our plans in the Calypso signup flow.

## Why
According to [Wikipedia](https://en.wikipedia.org/wiki/Anchoring) the anchoring effect is described like this:

>Anchoring is a cognitive bias that describes the common human tendency to rely too heavily on the first piece of information offered (the "anchor") when making decisions. During decision making, anchoring occurs when individuals use an initial piece of information to make subsequent judgments. Once an anchor is set, other judgments are made by adjusting away from that anchor, and there is a bias toward interpreting other information around the anchor. For example, the initial price offered for a used car sets the standard for the rest of the negotiations, so that prices lower than the initial price seem more reasonable even if they are still higher than what the car is really worth.

Taking this idea a little further, we'd like to see what impact showing the most expensive plan first has on the choices people make. By seeing the most expensive plan first, the viewer might perceive the other plans as a good deal and would therefore be more likely to pick a paying plan over a free plan.  <a href="http://www.inc.com/the-build-network/the-anchoring-effect.html">Checkout this post</a> if you're interested to learn more about anchoring.

## Test parameters
**TestName:** `signupPlansReorderTest`
**Variations:** `Original` 50% — `Modified` 50%
**Traffic:** 143,601 English visitors/week
**Duration:** 1 week minimum

## Screenshots
`Original`
![screen shot 2017-04-10 at 1 20 52 pm](https://cloud.githubusercontent.com/assets/6981253/24874288/232aafbe-1df2-11e7-9f5d-6f7ace432ea0.png)

`Modified`
![screen shot 2017-04-10 at 1 21 56 pm](https://cloud.githubusercontent.com/assets/6981253/24874303/2e459a9e-1df2-11e7-9793-2b7e6d6c0137.png)

## Testing instructions
- Go through the [signup flow](https://calypso.localhost:3000/start) until you reach the plans page. 
- Ensure that you set `signupPlansReorderTest` to `modified` in your local storage.

This PR will only get merged after this test is completed: https://github.com/Automattic/wp-calypso/pull/12963