### PR TITLE
Direct the sidebar Menus link to the Customizer.

### DIFF
--- a/client/my-sites/customize/panels.js
+++ b/client/my-sites/customize/panels.js
@@ -8,7 +8,8 @@ export const PANEL_MAPPINGS = {
 	fonts: [ 'section', 'jetpack_fonts' ],
 	identity: [ 'section', 'title_tagline' ],
 	'custom-css': [ 'section', 'jetpack_custom_css' ],
-	amp: [ 'section', 'amp_design' ]
+	amp: [ 'section', 'amp_design' ],
+	menus: [ 'panel', 'nav_menus' ],
 };
 
 /**

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -224,9 +224,8 @@ export class MySitesSidebar extends Component {
 	}
 
 	menus() {
-		var site = this.getSelectedSite(),
-			menusLink = '/menus' + this.siteSuffix(),
-			showClassicLink = ! config.isEnabled( 'manage/menus' );
+		const site = this.getSelectedSite();
+		const menusLink = '/customize' + this.siteSuffix();
 
 		if ( ! site ) {
 			return null;
@@ -242,10 +241,6 @@ export class MySitesSidebar extends Component {
 
 		if ( ! this.isSingle() ) {
 			return null;
-		}
-
-		if ( showClassicLink ) {
-			menusLink = site.options.admin_url + 'nav-menus.php';
 		}
 
 		return (

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -225,7 +225,7 @@ export class MySitesSidebar extends Component {
 
 	menus() {
 		const site = this.getSelectedSite();
-		const menusLink = '/customize/menus' + this.siteSuffix();
+		let menusLink = '/customize/menus' + this.siteSuffix();
 
 		if ( ! site ) {
 			return null;
@@ -241,6 +241,10 @@ export class MySitesSidebar extends Component {
 
 		if ( ! this.isSingle() ) {
 			return null;
+		}
+
+		if ( site.jetpack ) {
+			menusLink = site.options.admin_url + 'customize.php';
 		}
 
 		return (

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -244,7 +244,7 @@ export class MySitesSidebar extends Component {
 		}
 
 		if ( site.jetpack ) {
-			menusLink = site.options.admin_url + 'customize.php';
+			menusLink = site.options.admin_url + 'customize.php?autofocus[panel]=nav_menus';
 		}
 
 		return (

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -225,7 +225,7 @@ export class MySitesSidebar extends Component {
 
 	menus() {
 		const site = this.getSelectedSite();
-		const menusLink = '/customize' + this.siteSuffix();
+		const menusLink = '/customize/menus' + this.siteSuffix();
 
 		if ( ! site ) {
 			return null;


### PR DESCRIPTION
This PR effectively disables the Calypso Menus feature, and simply sends the user to the Customizer's Menus panel.