### PR TITLE
Menus: Remove the `/menus` route.

### DIFF
--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -66,13 +66,6 @@ const sections = [
 		secondary: true
 	},
 	{
-		name: 'menus',
-		paths: [ '/menus' ],
-		module: 'my-sites/menus',
-		secondary: true,
-		group: 'sites'
-	},
-	{
 		name: 'people',
 		paths: [ '/people' ],
 		module: 'my-sites/people',

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -30,7 +30,6 @@
 		"manage/import/medium": true,
 		"manage/jetpack": true,
 		"manage/media": true,
-		"manage/menus": true,
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": false,
 		"manage/pages": true,

--- a/config/development.json
+++ b/config/development.json
@@ -64,7 +64,6 @@
 		"manage/import/medium": true,
 		"manage/jetpack": true,
 		"manage/media": true,
-		"manage/menus": true,
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -36,7 +36,6 @@
 		"manage/import/medium": true,
 		"manage/jetpack": true,
 		"manage/media": true,
-		"manage/menus": true,
 		"manage/menus-jetpack": true,
 		"manage/pages": true,
 		"manage/payment-methods": true,

--- a/config/production.json
+++ b/config/production.json
@@ -31,7 +31,6 @@
 		"manage/import/medium": true,
 		"manage/jetpack": true,
 		"manage/media": true,
-		"manage/menus": true,
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": false,
 		"manage/pages": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -34,7 +34,6 @@
 		"manage/import/medium": true,
 		"manage/jetpack": true,
 		"manage/media": true,
-		"manage/menus": true,
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": false,
 		"manage/pages": true,

--- a/config/test.json
+++ b/config/test.json
@@ -47,7 +47,6 @@
 		"manage/import/medium": true,
 		"manage/jetpack": true,
 		"manage/media": true,
-		"manage/menus": true,
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -44,7 +44,6 @@
 		"manage/import/medium": true,
 		"manage/jetpack": true,
 		"manage/media": true,
-		"manage/menus": true,
 		"manage/menus-jetpack": true,
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,


### PR DESCRIPTION
The `/menus` route was left active in #12967  this PR removes it.