### PR TITLE
Framework: Upgrade to eslint-plugin-wpcalypso v3.1.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -703,7 +703,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000657"
+      "version": "1.0.30000660"
     },
     "caseless": {
       "version": "0.12.0"
@@ -1580,7 +1580,7 @@
       }
     },
     "eslint-plugin-wpcalypso": {
-      "version": "3.0.2",
+      "version": "3.1.1",
       "dev": true
     },
     "esmangle-evaluator": {
@@ -1860,7 +1860,7 @@
       "version": "1.0.0"
     },
     "gauge": {
-      "version": "2.7.3"
+      "version": "2.7.4"
     },
     "gaze": {
       "version": "1.1.2"
@@ -4622,11 +4622,15 @@
           "dev": true
         },
         "finalhandler": {
-          "version": "1.0.1",
+          "version": "1.0.2",
           "dev": true,
           "dependencies": {
             "debug": {
-              "version": "2.6.3",
+              "version": "2.6.4",
+              "dev": true
+            },
+            "ms": {
+              "version": "0.7.3",
               "dev": true
             }
           }
@@ -4928,7 +4932,7 @@
       "dev": true
     },
     "write-file-atomic": {
-      "version": "1.3.2",
+      "version": "1.3.3",
       "dev": true
     },
     "write-file-stdout": {

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "eslint": "3.8.1",
     "eslint-config-wpcalypso": "0.6.0",
     "eslint-plugin-react": "6.4.1",
-    "eslint-plugin-wpcalypso": "3.0.2",
+    "eslint-plugin-wpcalypso": "3.1.1",
     "glob": "7.0.3",
     "jscodeshift": "0.3.30",
     "lodash-deep": "1.5.3",


### PR DESCRIPTION
Changes:

* New rule: `post-message-no-wildcard-targets` (not really used).
* Docs URL in `i18n-no-this-translate` error message.

Testing: make sure the build doesn't explode.