### PR TITLE
Enable WooCommerce extension UI in wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -120,6 +120,8 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
+		"woocommerce/extension-dashboard": true,
+		"woocommerce/extension-stats": true,
 		"wp-login": true
 	},
 	"siftscience_key": "e00e878351",


### PR DESCRIPTION
This enables the two WooCommerce extension UI flags in wpcalypso environment - this is currently enabled in development only.