### PR TITLE
Use cards and section headers for app download page

### DIFF
--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -54,8 +54,8 @@ export default {
 	},
 
 	apps( context ) {
-		const AppsComponent = require( 'me/get-apps' ),
-			basePath = context.path;
+		const AppsComponent = require( 'me/get-apps' ).default;
+		const basePath = context.path;
 
 		context.store.dispatch( setTitle( i18n.translate( 'Get Apps', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 

--- a/client/me/get-apps/index.jsx
+++ b/client/me/get-apps/index.jsx
@@ -1,82 +1,99 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React, { PropTypes } from 'react';
+import { identity } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var MeSidebarNavigation = require( 'me/sidebar-navigation' ),
-	Main = require( 'components/main' ),
-	Button = require( 'components/button' ),
-	Card = require( 'components/card' );
+import MeSidebarNavigation from 'me/sidebar-navigation';
+import Main from 'components/main';
+import Button from 'components/button';
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
 
-module.exports = React.createClass( {
+export const GetApps = ( { translate } ) => (
+	<Main className="get-apps">
+		<MeSidebarNavigation />
+		<SectionHeader label={ translate( 'Desktop apps' ) } />
+		<Card className="get-apps__desktop">
 
-	displayName: 'GetApps',
+			<section className="get-apps__app">
+				<div className="get-apps__app-icon">
+					<img src="/calypso/images/me/get-apps-osx.svg" alt={ translate( 'Mac' ) } width="96" height="96" />
+				</div>
+				<p><strong>{ translate( 'Mac' ) }</strong><br />
+				{ translate( 'Requires 10.11 or newer' ) }</p>
+				<Button href="https://apps.wordpress.com/d/osx?ref=getapps">{ translate( 'Download', { context: 'verb' } ) }</Button>
+			</section>
 
-	render: function() {
-		return (
-			<Main className="get-apps">
-				<MeSidebarNavigation />
+			<section className="get-apps__app">
+				<div className="get-apps__app-icon">
+					<img src="/calypso/images/me/get-apps-windows.svg" alt={ translate( 'Windows' ) } width="96" height="96" />
+				</div>
+				<p><strong>{ translate( 'Windows' ) }</strong><br />
+				{ translate( 'Requires 7 or newer' ) }</p>
+				<Button href="https://apps.wordpress.com/d/windows?ref=getapps">{ translate( 'Download' ) }</Button>
+			</section>
 
-				<h1 className="get-apps__title">{ this.translate( 'Get Apps' ) }</h1>
-				<p className="get-apps__subheading">{ this.translate( 'Manage all your WordPress.com and Jetpack-enabled sites in one place. On your desktop, or on the go.' ) }</p>
+			<section className="get-apps__app">
+				<div className="get-apps__app-icon">
+					<img src="/calypso/images/me/get-apps-linux.svg" alt={ translate( 'Linux' ) } width="96" height="96" />
+				</div>
+				<p><strong>{ translate( 'Linux' ) }</strong><br />
+				{ translate( 'Choose your distribution' ) }</p>
+				<Button href="https://apps.wordpress.com/d/linux?ref=getapps">
+					{ translate( '.TAR.GZ' ) }
+				</Button>
+				<Button href="https://apps.wordpress.com/d/linux-deb?ref=getapps">
+					{ translate( '.DEB' ) }
+				</Button>
+			</section>
 
-				<h2 className="form-section-heading">{ this.translate( 'Desktop apps' ) }</h2>
-				<Card className="get-apps__desktop">
+		</Card>
 
-					<section className="get-apps__app">
-						<div className="get-apps__app-icon">
-							<img src="/calypso/images/me/get-apps-osx.svg" alt={ this.translate( 'Mac' ) } width="96" height="96" />
-						</div>
-						<p><strong>{ this.translate( 'Mac' ) }</strong><br />
-						{ this.translate( 'Requires 10.11 or newer' ) }</p>
-						<Button href="https://apps.wordpress.com/d/osx?ref=getapps">{ this.translate( 'Download' ) }</Button>
-					</section>
+		<SectionHeader label={ translate( 'Mobile apps' ) } />
+		<Card className="get-apps__mobile">
 
-					<section className="get-apps__app">
-						<div className="get-apps__app-icon">
-							<img src="/calypso/images/me/get-apps-windows.svg" alt={ this.translate( 'Windows' ) } width="96" height="96" />
-						</div>
-						<p><strong>{ this.translate( 'Windows' ) }</strong><br />
-						{ this.translate( 'Requires 7 or newer' ) }</p>
-						<Button href="https://apps.wordpress.com/d/windows?ref=getapps">{ this.translate( 'Download' ) }</Button>
-					</section>
+			<section className="get-apps__app">
+				<div className="get-apps__app-icon">
+					<img src="/calypso/images/me/get-apps-ios.svg" alt={ translate( 'iOS' ) } width="96" height="96" />
+				</div>
+				<p><strong>{ translate( 'iOS' ) }</strong></p>
+				<a href="https://itunes.apple.com/us/app/wordpress/id335703880?mt=8">
+					<img
+						src="/calypso/images/me/get-apps-app-store.png"
+						alt={ translate( 'Get on the iOS App Store' ) }
+					/>
+				</a>
+			</section>
 
-					<section className="get-apps__app">
-						<div className="get-apps__app-icon">
-							<img src="/calypso/images/me/get-apps-linux.svg" alt={ this.translate( 'Linux' ) } width="96" height="96" />
-						</div>
-						<p><strong>{ this.translate( 'Linux' ) }</strong><br />
-						{ this.translate( 'Choose your distribution' ) }</p>
-						<Button href="https://apps.wordpress.com/d/linux?ref=getapps">{ this.translate( '.TAR.GZ' ) }</Button> <Button href="https://apps.wordpress.com/d/linux-deb?ref=getapps">{ this.translate( '.DEB' ) }</Button>
-					</section>
+			<section className="get-apps__app">
+				<div className="get-apps__app-icon">
+					<img src="/calypso/images/me/get-apps-android.svg" alt={ translate( 'Android' ) } width="96" height="96" />
+				</div>
+				<p><strong>{ translate( 'Android' ) }</strong></p>
+				<a href="https://play.google.com/store/apps/details?id=org.wordpress.android">
+					<img
+						src="/calypso/images/me/get-apps-google-play.png"
+						alt={ translate( 'Get on Google Play' ) }
+					/>
+				</a>
+			</section>
 
-				</Card>
+		</Card>
 
-				<h2 className="form-section-heading">{ this.translate( 'Mobile apps' ) }</h2>
-				<Card className="get-apps__mobile">
+	</Main>
+);
 
-					<section className="get-apps__app">
-						<div className="get-apps__app-icon">
-							<img src="/calypso/images/me/get-apps-ios.svg" alt={ this.translate( 'iOS' ) } width="96" height="96" />
-						</div>
-						<p><strong>{ this.translate( 'iOS' ) }</strong></p>
-						<a href="https://itunes.apple.com/us/app/wordpress/id335703880?mt=8"><img src="/calypso/images/me/get-apps-app-store.png" alt={ this.translate( 'Get on the iOS App Store' ) } /></a>
-					</section>
+GetApps.propTypes = {
+	translate: PropTypes.func,
+};
 
-					<section className="get-apps__app">
-						<div className="get-apps__app-icon">
-							<img src="/calypso/images/me/get-apps-android.svg" alt={ this.translate( 'Android' ) } width="96" height="96" />
-						</div>
-						<p><strong>{ this.translate( 'Android' ) }</strong></p>
-						<a href="https://play.google.com/store/apps/details?id=org.wordpress.android"><img src="/calypso/images/me/get-apps-google-play.png" alt={ this.translate( 'Get on Google Play' ) } /></a>
-					</section>
+GetApps.defaultProps = {
+	translate: identity,
+};
 
-				</Card>
-
-			</Main>
-		);
-	}
-} );
+export default localize( GetApps );

--- a/client/me/get-apps/style.scss
+++ b/client/me/get-apps/style.scss
@@ -1,5 +1,4 @@
 .get-apps__title {
-	text-align: center;
 	font-size: 24px;
 	font-family: $serif;
 	font-weight: 700;
@@ -14,7 +13,6 @@
 .get-apps__subheading {
 	max-width: 500px;
 	margin: 16px auto;
-	text-align: center;
 }
 
 .get-apps__app {


### PR DESCRIPTION
Resolves #8693
See #9017

Code import from the work @jchimienti89 did with some fixes to get the
PR working without error. Previously in #9017 the change in export
format needed to be matched with a change in `require()` to
`require().default`.

**Before/After**
![mobilelayout](https://cloud.githubusercontent.com/assets/5431237/24897976/a3615486-1ecd-11e7-82a3-5fe89bc33f28.png)

cc: @jasmussen @folletto 