### PR TITLE
Themes: removed MLB from filter snapshot

### DIFF
--- a/client/my-sites/themes/theme-filters.js
+++ b/client/my-sites/themes/theme-filters.js
@@ -113,8 +113,6 @@ const taxonomies = {
         "journal",
         "lifestream",
         "magazine",
-        "major-league-baseball",
-        "mlb",
         "music",
         "nature",
         "news",


### PR DESCRIPTION
Updating the snapshot removing "mlb" and "major-league-baseball". 

The snapshot was done before MLB themes were removed, so it needs manual update until we make the taxonomies dynamically loaded from an API endpoint (see #12777).

### To test

1. Open Calypso → `/themes`
2. Try to search for either "mlb" or "baseball" and verify they don't show up anymore.
3. Test other searches to make sure everything else still works.