### PR TITLE
Reader Manage Following Refresh: add import button

### DIFF
--- a/client/reader/following-manage/import.jsx
+++ b/client/reader/following-manage/import.jsx
@@ -16,7 +16,7 @@ class FollowingManageImport extends Component {
 
 	onImportSuccess = ( feedImport ) => {
 		const message = this.props.translate(
-			'{{em}}%(name)s{{/em}} has been received. You`ll get an email when your import is complete.',
+			'{{em}}%(name)s{{/em}} has been received. You\'ll get an email when your import is complete.',
 			{
 				args: { name: feedImport.fileName },
 				components: { em: <em /> },

--- a/client/reader/following-manage/import.jsx
+++ b/client/reader/following-manage/import.jsx
@@ -4,7 +4,6 @@
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal Dependencies
@@ -47,5 +46,5 @@ class FollowingManageImport extends Component {
 
 export default connect(
 	null,
-	dispatch => bindActionCreators( { successNotice, errorNotice }, dispatch )
+	{ successNotice, errorNotice },
 )( localize( FollowingManageImport ) );

--- a/client/reader/following-manage/import.jsx
+++ b/client/reader/following-manage/import.jsx
@@ -1,0 +1,51 @@
+/**
+ * External Dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+/**
+ * Internal Dependencies
+ */
+import ReaderImportButton from 'blocks/reader-import-button';
+import { successNotice, errorNotice } from 'state/notices/actions';
+
+class FollowingManageImport extends Component {
+
+	onImportSuccess = ( feedImport ) => {
+		const message = this.props.translate(
+			'{{em}}%(name)s{{/em}} has been received. You`ll get an email when your import is complete.',
+			{
+				args: { name: feedImport.fileName },
+				components: { em: <em /> },
+			}
+		);
+		this.props.successNotice( message );
+	}
+
+	onImportFailure = ( error ) => {
+		if ( ! error ) {
+			return null;
+		}
+
+		const message = this.props.translate( 'Whoops, something went wrong. %(message)s. Please try again.', {
+			args: { message: error.message }
+		} );
+		this.props.errorNotice( message );
+	}
+
+	render() {
+		return (
+			<div className="following-manage__import">
+				<ReaderImportButton onImport={ this.onImportSuccess } onError={ this.onImportFailure } />
+			</div>
+		);
+	}
+}
+
+export default connect(
+	null,
+	dispatch => bindActionCreators( { successNotice, errorNotice }, dispatch )
+)( localize( FollowingManageImport ) );

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -20,6 +20,7 @@ import ReaderMain from 'components/reader-main';
 import { getReaderFeedsForQuery } from 'state/selectors';
 import QueryReaderFeedsSearch from 'components/data/query-reader-feeds-search';
 import ConnectedSubscriptionListItem from './connected-subscription-list-item';
+import FollowingManageSubscriptions from './subscriptions';
 
 class FollowingManage extends Component {
 	static propTypes = {
@@ -134,6 +135,7 @@ class FollowingManage extends Component {
 						)}
 					</WindowScroller>
 				}
+				<FollowingManageSubscriptions />
 			</ReaderMain>
 		);
 	}

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -1,7 +1,13 @@
 .following-manage .search {
-	margin: 0px;
+	margin: 0;
 }
 
 .following-manage .following-manage__input-card {
-	padding: 0px;
+	padding: 0;
+}
+
+.following-manage__subscriptions {
+	margin-top: 20px;
+	padding-top: 10px;
+	border-top: 1px solid $gray-light;
 }

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -3,23 +3,51 @@
  */
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 
 /**
  * Internal Dependencies
  */
 import ReaderImportButton from 'blocks/reader-import-button';
+import { successNotice, errorNotice } from 'state/notices/actions';
 
 class FollowingManageSubscriptions extends Component {
+
+	onImportSuccess = ( feedImport ) => {
+		const message = this.props.translate(
+			'{{em}}%(name)s{{/em}} has been imported. Refresh this page to see the new sites you follow.',
+			{
+				args: { name: feedImport.fileName },
+				components: { em: <em /> },
+			}
+		);
+		this.props.successNotice( message );
+	}
+
+	onImportFailure = ( error ) => {
+		if ( ! error ) {
+			return null;
+		}
+
+		const message = this.props.translate( 'Whoops, something went wrong. %(message)s. Please try again.', {
+			args: { message: error.message }
+		} );
+		this.props.errorNotice( message );
+	}
 
 	render() {
 		return (
 			<div className="following-manage__subscriptions">
 				<div className="following-manage__subscriptions-controls">
-					<ReaderImportButton />
+					<ReaderImportButton onImport={ this.onImportSuccess } onError={ this.onImportFailure } />
 				</div>
 			</div>
 		);
 	}
 }
 
-export default localize( FollowingManageSubscriptions );
+export default connect(
+	null,
+	dispatch => bindActionCreators( { successNotice, errorNotice }, dispatch )
+)( localize( FollowingManageSubscriptions ) );

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -2,52 +2,22 @@
  * External Dependencies
  */
 import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal Dependencies
  */
-import ReaderImportButton from 'blocks/reader-import-button';
-import { successNotice, errorNotice } from 'state/notices/actions';
+import FollowingManageImport from './import';
 
 class FollowingManageSubscriptions extends Component {
-
-	onImportSuccess = ( feedImport ) => {
-		const message = this.props.translate(
-			'{{em}}%(name)s{{/em}} has been imported. Refresh this page to see the new sites you follow.',
-			{
-				args: { name: feedImport.fileName },
-				components: { em: <em /> },
-			}
-		);
-		this.props.successNotice( message );
-	}
-
-	onImportFailure = ( error ) => {
-		if ( ! error ) {
-			return null;
-		}
-
-		const message = this.props.translate( 'Whoops, something went wrong. %(message)s. Please try again.', {
-			args: { message: error.message }
-		} );
-		this.props.errorNotice( message );
-	}
-
 	render() {
 		return (
 			<div className="following-manage__subscriptions">
 				<div className="following-manage__subscriptions-controls">
-					<ReaderImportButton onImport={ this.onImportSuccess } onError={ this.onImportFailure } />
+					<FollowingManageImport />
 				</div>
 			</div>
 		);
 	}
 }
 
-export default connect(
-	null,
-	dispatch => bindActionCreators( { successNotice, errorNotice }, dispatch )
-)( localize( FollowingManageSubscriptions ) );
+export default FollowingManageSubscriptions;

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -1,0 +1,25 @@
+/**
+ * External Dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal Dependencies
+ */
+import ReaderImportButton from 'blocks/reader-import-button';
+
+class FollowingManageSubscriptions extends Component {
+
+	render() {
+		return (
+			<div className="following-manage__subscriptions">
+				<div className="following-manage__subscriptions-controls">
+					<ReaderImportButton />
+				</div>
+			</div>
+		);
+	}
+}
+
+export default localize( FollowingManageSubscriptions );

--- a/client/state/notices/README.md
+++ b/client/state/notices/README.md
@@ -11,14 +11,13 @@ First, the component that wants to send notices must be connected to Redux.
 
 ```javascript
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { successNotice, errorNotice } from 'state/notices/actions';
 
 ...
 
 export default connect(
 	null,
-	dispatch => bindActionCreators( { successNotice, errorNotice }, dispatch )
+	{ successNotice, errorNotice },
 )( Component );
 ```
 


### PR DESCRIPTION
Add the new import button block to the new Manage Following at `/following/manage`.

Part of https://github.com/Automattic/wp-calypso/issues/12958.

Success:

<img width="906" alt="screen shot 2017-04-11 at 12 56 55" src="https://cloud.githubusercontent.com/assets/17325/24908005/6e3c752c-1eb6-11e7-9dd2-eb20808d0d1f.png">

Failure:

<img width="922" alt="screen shot 2017-04-11 at 12 51 49" src="https://cloud.githubusercontent.com/assets/17325/24908003/6a9872b8-1eb6-11e7-8ef6-679d60225377.png">


### To test

Head to http://calypso.localhost:3000/following/manage, hit 'Import' and try importing an OPML file. To test the failure case, try uploading something else :)