### PR TITLE
Themes: search welcome dropdown fit on one line

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -189,7 +189,6 @@
 	flex-direction: column;
 	text-align: center;
 	flex: 1 0 auto;
-	width: 28%;
 	overflow: hidden;
 	padding: 10px 6px;
 	margin: 0;


### PR DESCRIPTION
Before the number of items was different, without a `width` set, with this PR they just use flex to adapt as needed. No extra tweaking, which makes it future proof. 

If items get longer, flex automatically drop them on the following line as expected.

Before:

![screen shot 2017-04-11 at 12 56 13](https://cloud.githubusercontent.com/assets/4389/24907964/44bdaa90-1eb6-11e7-8c84-e2cabb29abb3.png)


After: 

![screen shot 2017-04-11 at 12 53 34](https://cloud.githubusercontent.com/assets/4389/24907982/5845deac-1eb6-11e7-9ffe-9e82a1c371cc.png)

And if labels gets longer, it behaves as before:

![screen shot 2017-04-11 at 12 53 15](https://cloud.githubusercontent.com/assets/4389/24908031/80e21c4a-1eb6-11e7-9a18-dee15ef16583.png)


### To test

1. Open Calypso Themes on Mobile
2. Check the items are on the same line (if they fit) or not (if the text is too long)
3. Check that search still works properly
