### PR TITLE
Jetpack: A/B test hiding monthly plans on connect

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -25,15 +25,13 @@ module.exports = {
 		defaultVariation: 'disabled',
 		allowExistingUsers: false
 	},
-	jetpackNewDescriptions: {
-		datestamp: '20170327',
+	jetpackNoMonthly: {
+		datestamp: '20170410',
 		variations: {
-			showNew: 0,
-			showOld: 100 /* test completed. I'm disabling it here first because
-						it need some work to remove the added code for the
-						new variation that's not going to be used */
+			showMonthly: 50,
+			dontShowMonthly: 50
 		},
-		defaultVariation: 'showOld',
+		defaultVariation: 'showMonthly',
 		allowExistingUsers: true
 	},
 	signupSurveyStep: {

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -129,7 +129,7 @@ export const PLANS_LIST = {
 			' website with a custom domain name, and remove all WordPress.com advertising. ' +
 			'Get access to high quality email and live chat support.', {
 				components: {
-					strong: <strong className="plan-features__targeted-description-heading" />
+					strong: <strong className="plans__features plan-features__targeted-description-heading" />
 				}
 			} ),
 		getFeatures: () => [
@@ -155,7 +155,7 @@ export const PLANS_LIST = {
 			' Build a unique website with advanced design tools, CSS editing, lots of space for audio and video,' +
 			' and the ability to monetize your site with ads.', {
 				components: {
-					strong: <strong className="plan-features__targeted-description-heading" />
+					strong: <strong className="plans__features plan-features__targeted-description-heading" />
 				}
 			} ),
 		getFeatures: () => compact( [ // pay attention to ordering, shared features should align on /plan page
@@ -191,7 +191,7 @@ export const PLANS_LIST = {
 			' business website with unlimited premium and business theme templates, Google Analytics support, unlimited' +
 			' storage, and the ability to remove WordPress.com branding.', {
 				components: {
-					strong: <strong className="plan-features__targeted-description-heading" />
+					strong: <strong className="plans__features plan-features__targeted-description-heading" />
 				}
 			} ),
 		getFeatures: () => compact( [ // pay attention to ordering, shared features should align on /plan page
@@ -230,19 +230,11 @@ export const PLANS_LIST = {
 		getProductId: () => 2002,
 		getStoreSlug: () => PLAN_JETPACK_FREE,
 
-		getDescription: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
-			? i18n.translate( 'Everything you need to get started.' )
-			: i18n.translate(
-				'The features most needed by WordPress sites' +
-				' — perfectly packaged and optimized for everyone.'
+		getDescription: () => i18n.translate(
+			'The features most needed by WordPress sites' +
+			' — perfectly packaged and optimized for everyone.'
 		),
-		getFeatures: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
-		? [
-			FEATURE_CORE_JETPACK,
-			FEATURE_BASIC_SECURITY_JETPACK,
-			FEATURE_BASIC_SUPPORT_JETPACK,
-			FEATURE_SPEED_JETPACK ]
-		: [
+		getFeatures: () => [
 			FEATURE_STANDARD_SECURITY_TOOLS,
 			FEATURE_SITE_STATS,
 			FEATURE_TRAFFIC_TOOLS,
@@ -257,25 +249,10 @@ export const PLANS_LIST = {
 		getStoreSlug: () => PLAN_JETPACK_PREMIUM,
 		availableFor: ( plan ) => includes( [ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL_MONTHLY ], plan ),
 		getPathSlug: () => 'premium',
-		getDescription: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) !== 'showNew'
-			? i18n.translate(
-				'Generate income and save on video hosting costs. ' +
-				'Improve security with daily backups, malware scanning, and spam defense.'
-			)
-			: i18n.translate(
+		getDescription: () => i18n.translate(
 				'Earn income and reduce costs.'
 		),
-		getFeatures: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
-		? [
-			FEATURE_CORE_JETPACK,
-			FEATURE_SECURITY_SCANNING_JETPACK,
-			FEATURE_PRIORITY_SUPPORT_JETPACK,
-			FEATURE_SPEED_ADVANCED_JETPACK,
-			FEATURE_REVENUE_GENERATION_JETPACK,
-			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
-			isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
-		]
-		: compact( [
+		getFeatures: () => compact( [
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
 			FEATURE_BACKUP_ARCHIVE_30,
 			FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
@@ -298,24 +275,11 @@ export const PLANS_LIST = {
 		getStoreSlug: () => PLAN_JETPACK_PREMIUM_MONTHLY,
 		getPathSlug: () => 'premium-monthly',
 		availableFor: ( plan ) => includes( [ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL_MONTHLY ], plan ),
-		getDescription: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) !== 'showNew'
-			? i18n.translate(
+		getDescription: () => i18n.translate(
 				'Generate income and save on video hosting costs. ' +
 				'Improve security with daily backups, malware scanning, and spam defense.'
-			)
-			: i18n.translate(
-				'Earn income and reduce costs.'
 		),
-		getFeatures: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
-		? [
-			FEATURE_CORE_JETPACK,
-			FEATURE_SECURITY_SCANNING_JETPACK,
-			FEATURE_PRIORITY_SUPPORT_JETPACK,
-			FEATURE_SPEED_ADVANCED_JETPACK,
-			FEATURE_REVENUE_GENERATION_JETPACK,
-			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
-			isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
-		] : compact( [
+		getFeatures: () => compact( [
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
 			FEATURE_BACKUP_ARCHIVE_30,
 			FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
@@ -338,28 +302,19 @@ export const PLANS_LIST = {
 		getStoreSlug: () => PLAN_JETPACK_PERSONAL,
 		availableFor: ( plan ) => includes( [ PLAN_JETPACK_FREE ], plan ),
 		getPathSlug: () => 'jetpack-personal',
-		getDescription: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
-			? i18n.translate( 'Security essentials for every site.' )
-			: i18n.translate(
+		getDescription: () => i18n.translate(
 				'Essentials for every site. The most affordable solution to keep your' +
 				' personal or small business site backed up and spam-free.'
 		),
-		getFeatures: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
-			? [
-				FEATURE_CORE_JETPACK,
-				FEATURE_SECURITY_ESSENTIALS_JETPACK,
-				FEATURE_PRIORITY_SUPPORT_JETPACK,
-				FEATURE_SPEED_JETPACK
-			]
-			: [
-				FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
-				FEATURE_BACKUP_ARCHIVE_30,
-				FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
-				FEATURE_AUTOMATED_RESTORES,
-				FEATURE_SPAM_AKISMET_PLUS,
-				FEATURE_EASY_SITE_MIGRATION,
-				FEATURE_PREMIUM_SUPPORT
-			],
+		getFeatures: () => [
+			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
+			FEATURE_BACKUP_ARCHIVE_30,
+			FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
+			FEATURE_AUTOMATED_RESTORES,
+			FEATURE_SPAM_AKISMET_PLUS,
+			FEATURE_EASY_SITE_MIGRATION,
+			FEATURE_PREMIUM_SUPPORT
+		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
 	},
 
@@ -369,28 +324,19 @@ export const PLANS_LIST = {
 		getProductId: () => 2006,
 		getPathSlug: () => 'jetpack-personal-monthly',
 		availableFor: ( plan ) => includes( [ PLAN_JETPACK_FREE ], plan ),
-		getDescription: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
-			? i18n.translate( 'Security essentials for every site.' )
-			: i18n.translate(
+		getDescription: () => i18n.translate(
 				'Essentials for every site. The most affordable solution to keep your' +
 				' personal or small business site backed up and spam-free.'
 		),
-		getFeatures: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
-			? [
-				FEATURE_CORE_JETPACK,
-				FEATURE_SECURITY_ESSENTIALS_JETPACK,
-				FEATURE_PRIORITY_SUPPORT_JETPACK,
-				FEATURE_SPEED_JETPACK
-			]
-			: [
-				FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
-				FEATURE_BACKUP_ARCHIVE_30,
-				FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
-				FEATURE_AUTOMATED_RESTORES,
-				FEATURE_SPAM_AKISMET_PLUS,
-				FEATURE_EASY_SITE_MIGRATION,
-				FEATURE_PREMIUM_SUPPORT
-			],
+		getFeatures: () => [
+			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
+			FEATURE_BACKUP_ARCHIVE_30,
+			FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
+			FEATURE_AUTOMATED_RESTORES,
+			FEATURE_SPAM_AKISMET_PLUS,
+			FEATURE_EASY_SITE_MIGRATION,
+			FEATURE_PREMIUM_SUPPORT
+		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' )
 	},
 
@@ -405,41 +351,28 @@ export const PLANS_LIST = {
 			PLAN_JETPACK_PERSONAL_MONTHLY
 		], plan ),
 		getPathSlug: () => 'professional',
-		getDescription: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
-			? i18n.translate( 'Ultimate security and traffic tools.' )
-			: i18n.translate(
-				'Real-time backups, unlimited archives, and one-click threat ' +
-				'resolution. Also includes SEO tools, and unlimited video hosting.'
+
+		getDescription: () => i18n.translate(
+			'Real-time backups, unlimited archives, and one-click threat ' +
+			'resolution. Also includes SEO tools, and unlimited video hosting.'
 		),
-		getFeatures: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
-			? [
-				FEATURE_CORE_JETPACK,
-				FEATURE_SECURITY_SCANNING_JETPACK,
-				FEATURE_PRIORITY_SUPPORT_JETPACK,
-				FEATURE_SPEED_UNLIMITED_JETPACK,
-				FEATURE_REVENUE_GENERATION_JETPACK,
-				FEATURE_ADVANCED_TRAFFIC_TOOLS_JETPACK,
-				isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
-				isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
-			]
-			: compact( [
-				FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
-				FEATURE_BACKUP_ARCHIVE_UNLIMITED,
-				FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
-				FEATURE_AUTOMATED_RESTORES,
-				FEATURE_SPAM_AKISMET_PLUS,
-				FEATURE_EASY_SITE_MIGRATION,
-				FEATURE_PREMIUM_SUPPORT,
-				FEATURE_WORDADS_INSTANT,
-				FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
-				FEATURE_MALWARE_SCANNING_DAILY_AND_ON_DEMAND,
-				FEATURE_ONE_CLICK_THREAT_RESOLUTION,
-				FEATURE_ADVANCED_SEO,
-				FEATURE_GOOGLE_ANALYTICS,
-				isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
-				isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
-			]
-		),
+		getFeatures: () => compact( [
+			FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
+			FEATURE_BACKUP_ARCHIVE_UNLIMITED,
+			FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
+			FEATURE_AUTOMATED_RESTORES,
+			FEATURE_SPAM_AKISMET_PLUS,
+			FEATURE_EASY_SITE_MIGRATION,
+			FEATURE_PREMIUM_SUPPORT,
+			FEATURE_WORDADS_INSTANT,
+			FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
+			FEATURE_MALWARE_SCANNING_DAILY_AND_ON_DEMAND,
+			FEATURE_ONE_CLICK_THREAT_RESOLUTION,
+			FEATURE_ADVANCED_SEO,
+			FEATURE_GOOGLE_ANALYTICS,
+			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
+			isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING
+		] ),
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
 	},
 	[ PLAN_JETPACK_BUSINESS_MONTHLY ]: {
@@ -454,41 +387,27 @@ export const PLANS_LIST = {
 			PLAN_JETPACK_PERSONAL,
 			PLAN_JETPACK_PERSONAL_MONTHLY
 		], plan ),
-		getDescription: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
-			? i18n.translate( 'Ultimate security and traffic tools.' )
-			: i18n.translate(
-				'Real-time backups, unlimited archives, and one-click threat ' +
-				'resolution. Also includes SEO tools, and unlimited video hosting.'
+		getDescription: () => i18n.translate(
+			'Real-time backups, unlimited archives, and one-click threat ' +
+			'resolution. Also includes SEO tools, and unlimited video hosting.'
 		),
-		getFeatures: ( abtest ) => abtest && abtest( 'jetpackNewDescriptions' ) === 'showNew'
-			? [
-				FEATURE_CORE_JETPACK,
-				FEATURE_SECURITY_SCANNING_JETPACK,
-				FEATURE_PRIORITY_SUPPORT_JETPACK,
-				FEATURE_SPEED_UNLIMITED_JETPACK,
-				FEATURE_REVENUE_GENERATION_JETPACK,
-				FEATURE_ADVANCED_TRAFFIC_TOOLS_JETPACK,
-				isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
-				isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
-			]
-			: compact( [
-				FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
-				FEATURE_BACKUP_ARCHIVE_UNLIMITED,
-				FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
-				FEATURE_AUTOMATED_RESTORES,
-				FEATURE_SPAM_AKISMET_PLUS,
-				FEATURE_EASY_SITE_MIGRATION,
-				FEATURE_PREMIUM_SUPPORT,
-				FEATURE_WORDADS_INSTANT,
-				FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
-				FEATURE_MALWARE_SCANNING_DAILY_AND_ON_DEMAND,
-				FEATURE_ONE_CLICK_THREAT_RESOLUTION,
-				FEATURE_ADVANCED_SEO,
-				FEATURE_GOOGLE_ANALYTICS,
-				isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
-				isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
-			]
-		),
+		getFeatures: () => compact( [
+			FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
+			FEATURE_BACKUP_ARCHIVE_UNLIMITED,
+			FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
+			FEATURE_AUTOMATED_RESTORES,
+			FEATURE_SPAM_AKISMET_PLUS,
+			FEATURE_EASY_SITE_MIGRATION,
+			FEATURE_PREMIUM_SUPPORT,
+			FEATURE_WORDADS_INSTANT,
+			FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
+			FEATURE_MALWARE_SCANNING_DAILY_AND_ON_DEMAND,
+			FEATURE_ONE_CLICK_THREAT_RESOLUTION,
+			FEATURE_ADVANCED_SEO,
+			FEATURE_GOOGLE_ANALYTICS,
+			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
+			isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING
+		] ),
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
 	}
 };

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -250,7 +250,8 @@ export const PLANS_LIST = {
 		availableFor: ( plan ) => includes( [ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL_MONTHLY ], plan ),
 		getPathSlug: () => 'premium',
 		getDescription: () => i18n.translate(
-				'Earn income and reduce costs.'
+				'Generate income and save on video hosting costs. ' +
+				'Improve security with daily backups, malware scanning, and spam defense.'
 		),
 		getFeatures: () => compact( [
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -267,7 +267,7 @@ export const PLANS_LIST = {
 			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
 			isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
 		] ),
-		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
+		getBillingTimeFrame: () => i18n.translate( 'per year' )
 	},
 
 	[ PLAN_JETPACK_PREMIUM_MONTHLY ]: {
@@ -316,7 +316,7 @@ export const PLANS_LIST = {
 			FEATURE_EASY_SITE_MIGRATION,
 			FEATURE_PREMIUM_SUPPORT
 		],
-		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
+		getBillingTimeFrame: () => i18n.translate( 'per year' )
 	},
 
 	[ PLAN_JETPACK_PERSONAL_MONTHLY ]: {
@@ -374,7 +374,7 @@ export const PLANS_LIST = {
 			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
 			isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING
 		] ),
-		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
+		getBillingTimeFrame: () => i18n.translate( 'per year' )
 	},
 	[ PLAN_JETPACK_BUSINESS_MONTHLY ]: {
 		getTitle: () => i18n.translate( 'Professional' ),

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -115,10 +115,13 @@ class PlanFeaturesHeader extends Component {
 			rawPrice,
 			intervalType,
 			site,
-			basePlansPath
+			basePlansPath,
+			hideMonthly
 		} = this.props;
 
-		if ( ! rawPrice || this.isPlanCurrent() ) {
+		if ( hideMonthly ||
+			! rawPrice ||
+			this.isPlanCurrent() ) {
 			return (
 				<div className="plan-features__interval-type is-placeholder">
 				</div>

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -78,7 +78,8 @@ class PlanFeaturesHeader extends Component {
 			isPlaceholder,
 			site,
 			translate,
-			isSiteAT
+			isSiteAT,
+			hideMonthly
 		} = this.props;
 
 		const isDiscounted = !! discountPrice;
@@ -90,7 +91,8 @@ class PlanFeaturesHeader extends Component {
 		if (
 			isSiteAT ||
 			! site.jetpack ||
-			this.props.planType === PLAN_JETPACK_FREE
+			this.props.planType === PLAN_JETPACK_FREE ||
+			hideMonthly
 		) {
 			return (
 				<p className={ timeframeClasses }>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -339,7 +339,7 @@ class PlanFeatures extends Component {
 				description={ description }
 				hideInfoPopover={ false }
 			>
-				<span className="plan_features__item-info">
+				<span className="plan-features__item-info">
 					<span className="plan-features__item-title">{ feature.getTitle() }</span>
 				</span>
 			</PlanFeaturesItem>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -136,9 +136,9 @@ class PlanFeatures extends Component {
 				relatedMonthlyPlan,
 				primaryUpgrade,
 				isPlaceholder,
+				hideMonthly
 			} = properties;
 			const { rawPrice, discountPrice } = properties;
-
 			return (
 				<div className="plan-features__mobile-plan" key={ planName }>
 					<PlanFeaturesHeader
@@ -151,6 +151,7 @@ class PlanFeatures extends Component {
 						rawPrice={ rawPrice }
 						discountPrice={ discountPrice }
 						billingTimeFrame={ planConstantObj.getBillingTimeFrame() }
+						hideMonthly={ hideMonthly }
 						isPlaceholder={ isPlaceholder }
 						intervalType={ intervalType }
 						site={ site }
@@ -203,7 +204,8 @@ class PlanFeatures extends Component {
 				popular,
 				newPlan,
 				relatedMonthlyPlan,
-				isPlaceholder
+				isPlaceholder,
+				hideMonthly
 			} = properties;
 			const { rawPrice, discountPrice } = properties;
 			const classes = classNames( 'plan-features__table-item', 'has-border-top' );
@@ -223,6 +225,7 @@ class PlanFeatures extends Component {
 						isPlaceholder={ isPlaceholder }
 						intervalType={ intervalType }
 						site={ site }
+						hideMonthly={ hideMonthly }
 						basePlansPath={ basePlansPath }
 						relatedMonthlyPlan={ relatedMonthlyPlan }
 					/>
@@ -330,25 +333,14 @@ class PlanFeatures extends Component {
 		const description = feature.getDescription
 					? feature.getDescription( abtest )
 					: null;
-		const itemClasses = classNames(
-			'plan-features__item-title',
-			abtest( 'jetpackNewDescriptions' ) === 'showNew'
-			? 'plan-features__item-title-outlined'
-			: null
-		);
-
 		return (
 			<PlanFeaturesItem
 				key={ index }
 				description={ description }
-				hideInfoPopover={ abtest( 'jetpackNewDescriptions' ) === 'showNew' }
+				hideInfoPopover={ false }
 			>
-				<span className="plan-features__item-info">
-					<span className={ itemClasses }>{ feature.getTitle() }</span>
-					{ abtest( 'jetpackNewDescriptions' ) === 'showNew'
-						? <span className="plan-features__item-description">{ description }</span>
-						: null
-					}
+				<span className="plan_features__item-info">
+					<span className="plan-features__item-title">{ feature.getTitle() }</span>
 				</span>
 			</PlanFeaturesItem>
 		);
@@ -480,7 +472,6 @@ export default connect(
 				if ( placeholder || ! planObject || isLoadingSitePlans ) {
 					isPlaceholder = true;
 				}
-
 				return {
 					isPlaceholder,
 					isLandingPage,
@@ -513,6 +504,7 @@ export default connect(
 					planObject: planObject,
 					popular: popular,
 					newPlan: newPlan,
+					hideMonthly: isInSignup && abtest( 'jetpackNoMonthly' ) === 'dontShowMonthly',
 					primaryUpgrade: (
 						( currentPlan === PLAN_PERSONAL && plan === PLAN_PREMIUM ) ||
 						( currentPlan === PLAN_PREMIUM && plan === PLAN_BUSINESS ) ||


### PR DESCRIPTION
This PR cleans some code from the previous jetpack ab tests that was not longer in use, and reintroduces the "no monthly" a/b test, but this time only during the connection flow. So the users who are affected by this test shouldn't see the monthly selector in the plans page during jetpack connect (though they should be able to select a monthly plan in the regular plans page).

![image](https://cloud.githubusercontent.com/assets/1554855/24949883/6686cde6-1f6f-11e7-9696-74eb2eb936d0.png)


How to test:
-------------
1. You need an unconnected jetpack site
2. Go to calypso.localhost:3000, open the dev console, and force the new variation : `localStorage.setItem( 'ABTests', '{"jetpackNoMonthly_20170410":"dontShowMonthly"}' );`
3. Connect the site. Once you are in the plans page, you shouldn't see any monthly/yearly selector.
4. Once you have connected the site, go to calypso.localhost:3000/plans and select it. 
5. You should see the monthly/yearly selector there
6. Change the variation you are in (`localStorage.setItem( 'ABTests', '{"jetpackNoMonthly_20170410":"showMonthly"}' );` and repeat the previous steps, making sure you see the monthly/yearly selector in every step