### PR TITLE
Framework: Prevent JS script loads from blocking render

### DIFF
--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -128,18 +128,21 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			script(type='text/javascript')!= config
 		if i18nLocaleScript
 			script(src=i18nLocaleScript)
-		if 'development' === env || isDebug
+		if 'development' === env || 'wpcalypso' === env || isDebug
 			script(defer, src=urls[ 'manifest' ])
 			script(defer, src=urls[ 'vendor' ])
-			script(defer, src=urls[ jsFile ])
 			if chunk
+				script(defer, src=urls[ jsFile ])
 				script(defer, src=urls[ chunk ] onload='window.AppBoot()')
+			else
+				script(defer, src=urls[ jsFile ] onload='window.AppBoot()')
 		else
-			script(defer, src=urls[ 'manifest-min' ])
-			script(defer, src=urls[ 'vendor-min' ])
-			script(defer, src=urls[ jsFile + '-min' ])
+			script(src=urls[ 'manifest-min' ])
+			script(src=urls[ 'vendor-min' ])
+			script(src=urls[ jsFile + '-min' ])
 			if chunk
-				script(src=urls[ chunk + '-min' ] onload='window.AppBoot()')
+				script(src=urls[ chunk + '-min' ])
+			script(type='text/javascript')!='window.AppBoot();'
 
 		noscript.wpcom-site__global-noscript
 			|Please enable JavaScript in your browser to enjoy WordPress.com.

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -128,7 +128,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			script(type='text/javascript')!= config
 		if i18nLocaleScript
 			script(src=i18nLocaleScript)
-		if 'development' === env || 'wpcalypso' === env || isDebug
+		if 'development' === env || isDebug
 			script(defer, src=urls[ 'manifest' ])
 			script(defer, src=urls[ 'vendor' ])
 			if chunk
@@ -136,6 +136,14 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 				script(defer, src=urls[ chunk ] onload='window.AppBoot()')
 			else
 				script(defer, src=urls[ jsFile ] onload='window.AppBoot()')
+		else if 'wpcalypso' === env
+			script(defer, src=urls[ 'manifest-min' ])
+			script(defer, src=urls[ 'vendor-min' ])
+			if chunk
+				script(defer, src=urls[ jsFile + '-min' ])
+				script(defer, src=urls[ chunk + '-min' ] onload='window.AppBoot()')
+			else
+				script(defer, src=urls[ jsFile + '-min' ] onload='window.AppBoot()')
 		else
 			script(src=urls[ 'manifest-min' ])
 			script(src=urls[ 'vendor-min' ])

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -129,18 +129,17 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		if i18nLocaleScript
 			script(src=i18nLocaleScript)
 		if 'development' === env || isDebug
-			script(src=urls[ 'manifest' ])
-			script(src=urls[ 'vendor' ])
-			script(src=urls[ jsFile ])
+			script(defer, src=urls[ 'manifest' ])
+			script(defer, src=urls[ 'vendor' ])
+			script(defer, src=urls[ jsFile ])
 			if chunk
-				script(src=urls[ chunk ])
+				script(defer, src=urls[ chunk ] onload='window.AppBoot()')
 		else
-			script(src=urls[ 'manifest-min' ])
-			script(src=urls[ 'vendor-min' ])
-			script(src=urls[ jsFile + '-min' ])
+			script(defer, src=urls[ 'manifest-min' ])
+			script(defer, src=urls[ 'vendor-min' ])
+			script(defer, src=urls[ jsFile + '-min' ])
 			if chunk
-				script(src=urls[ chunk + '-min' ])
-		script(type='text/javascript')!='window.AppBoot();'
+				script(src=urls[ chunk + '-min' ] onload='window.AppBoot()')
 
 		noscript.wpcom-site__global-noscript
 			|Please enable JavaScript in your browser to enjoy WordPress.com.


### PR DESCRIPTION
Action from p55Cj4-lD-p2

Add `defer` attr to script tags for app js files. This will allow initial html render to proceed before scripts have loaded, which will decrease time to render for logged-out server-rendered pages.

**This PR adds defer attribute in development and wpcalypso environments**

**To Test**
* `make run` or `NODE_ENV=wpcalypso make run` should have `defer` in the <script> tags in the page source
* other envs, for example 'horizon', should be as `master`
* Building with `code-splitting: false` should have the `onload` attr on the `build...js` rather than the chunk script


