### PR TITLE
Replace Independent Publisher w/ IP2 in signup

### DIFF
--- a/client/lib/signup/themes-data.js
+++ b/client/lib/signup/themes-data.js
@@ -127,11 +127,11 @@ export const themes = [
 	},
 	{
 		name: 'Independent Publisher',
-		slug: 'independent-publisher',
+		slug: 'independent-publisher-2',
 		repo: 'pub',
 		fallback: false,
 		design: '',
-		demo_uri: 'http://independentpublisherdemo.wordpress.com',
+		demo_uri: 'http://independentpublisher2demo.wordpress.com',
 		verticals: []
 	},
 	{


### PR DESCRIPTION
I'm unsure how to test this, since it appears the theme isn't associated with a particular theme style (blog, grid, page) in signup.

Any ideas what the themes do if they're not listed as one of those three types? Are they ignored?

/cc @michaeldcain 