### PR TITLE
Analytics: renamed do_not_track Tracks event property

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -187,7 +187,7 @@ const analytics = {
 		recordPageView: function( urlPath ) {
 			let eventProperties = {
 				path: urlPath,
-				doNotTrack: '1' === navigator.doNotTrack ? 1 : 0
+				do_not_track: '1' === navigator.doNotTrack ? 1 : 0
 			};
 
 			// Record all `utm` marketing parameters as event properties on the page view event


### PR DESCRIPTION
Renamed `doNotTrack` property to `do_not_track` to follow Tracks naming convention for `calypso_page_view` Tracks event.