### PR TITLE
Purchases: Check for a site ID before trying to use it

### DIFF
--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -41,6 +41,10 @@ class PurchasePlanDetails extends Component {
 			return null;
 		}
 
+		if ( pluginList.length < 1 ) {
+			return null;
+		}
+
 		return (
 			<Card>
 				<QueryPluginKeys siteId={ selectedSite.ID } />
@@ -64,6 +68,6 @@ export default connect(
 		hasLoadedSites: ! isRequestingSites( state ),
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		selectedPurchase: getByPurchaseId( state, props.purchaseId ),
-		pluginList: getPluginsForSite( state, props.selectedSite.ID ),
+		pluginList: props.selectedSite ? getPluginsForSite( state, props.selectedSite.ID ) : [],
 	} )
 )( localize( PurchasePlanDetails ) );


### PR DESCRIPTION
In #12247 we merged a new component to display API keys for Jetpack (behind a feature flag, for development & wpcalypso). If you try to click into this for a disconnected site, there's a JS error because it tries to use `selectedSite.ID` when selectedSite is null (disconnected). This PR checks selectedSite before trying to access it.

**To test:**

- Buy/have a plan for a site, then disconnect the site.
- On master, load `/me/purchases` & click into that site's purchase
- You can't 😞  (JS error in console)
- Check out this branch, try clicking that site's purchase again
- It works 🙂 

This only applies to the feature-flagged environments, so it's not breaking anything in production, but should still be fixed soon.