### PR TITLE
Editor: Update behavior of notice and preview action

### DIFF
--- a/client/post-editor/editor-preview/index.jsx
+++ b/client/post-editor/editor-preview/index.jsx
@@ -92,7 +92,7 @@ const EditorPreview = React.createClass( {
 			return null;
 		}
 		const parsed = url.parse( externalUrl, true );
-		parsed.query = omit( parsed.query, 'preview', 'iframe', 'frame-nonce' );
+		parsed.query = omit( parsed.query, 'iframe', 'frame-nonce' );
 		delete parsed.search;
 		return url.format( parsed );
 	},


### PR DESCRIPTION
This is a first attempt at fixing #12829. It feels a bit hacky tbh. Right now, the "Preview" link in the Editor and the "View" link have the same behavior. This works in most cases, but in specific instances, it produces unexpected behavior. For example:

> I have a published post. I make changes to the post, but I haven't updated the post yet. I would expect the "View" link in the notice to show me the saved version of the post (without my new changes). I would expect the "Preview" link to show me the new changes as well. Right now, you would see the new changes in both instances.

To decipher when we should show a preview versus the published post, I introduced a new state item `previewAction` that changes according to which action is taken by the user.

While testing this out, I also noticed that when we modify the `ExternalUrl` prop in [`editor-preview/index.jsx`](https://github.com/Automattic/wp-calypso/blob/master/client/post-editor/editor-preview/index.jsx#L88), we're stripping out the `preview` component. This leads to some counterintuitive behavior. For example, try the following:

1. Start a new post and enter some content. Publish the post.
2. Enter some new content in the post, but do not update the post.
3. Click the "Preview" link at the top of the Editor. The iframe will show your changes as expected.
4. Click the external icon on the iframe. The resulting window will _not_ show your changes.

I would expect the iframe and the external icon URL to show the same content. If we leave in the `preview` piece to the URL, this behavior is fixed. cc @ehg as it looks like you removed it in #5550. I'm not quite clear on the ramifications of leaving `preview`. I didn't see any adverse side effects.

## To test
1. Create a new post.
2. Type in some content and use the Preview link at the top of the editor. Verify that you see the same content as currently in the editor.
3. Publish the post. The View Post link should show the same content.
4. Leave the notice in place. Add some new content to the editor, but don't update it.
5. Click on View Post. You _should not_ see the new content that you haven't updated/saved yet. Click on Preview at the top of the editor. You should see the new content since it's a post preview.

## GIF

Here's a GIF of the various flows.

![editoraction](https://cloud.githubusercontent.com/assets/7240478/24915797/622fa414-1e95-11e7-8883-85c05e8599b7.gif)
