### PR TITLE
Themes: sheet screenshot opens live demo on tap

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -203,7 +203,7 @@ const ThemeSheet = React.createClass( {
 		}
 		const img = screenshot && <img className="theme__sheet-img" src={ screenshot + '?w=680' } />;
 		return (
-			<div className="theme__sheet-screenshot">
+			<div className="theme__sheet-screenshot" onClick={ this.previewAction }>
 				{ this.props.demo_uri && this.renderPreviewButton() }
 				{ img }
 			</div>

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -201,9 +201,18 @@ const ThemeSheet = React.createClass( {
 			screenshot = this.getFullLengthScreenshot();
 		}
 		const img = screenshot && <img className="theme__sheet-img" src={ screenshot + '?w=680' } />;
+
+		if ( this.props.demo_uri ) {
+			return (
+				<div className="theme__sheet-screenshot is-active" onClick={ this.previewAction }>
+					{ this.renderPreviewButton() }
+					{ img }
+				</div>
+			);
+		}
+
 		return (
-			<div className="theme__sheet-screenshot" onClick={ this.previewAction }>
-				{ this.props.demo_uri && this.renderPreviewButton() }
+			<div className="theme__sheet-screenshot">
 				{ img }
 			</div>
 		);

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -186,7 +186,6 @@ const ThemeSheet = React.createClass( {
 	renderPreviewButton() {
 		return (
 			<a className="theme__sheet-preview-link" onClick={ this.previewAction } data-tip-target="theme-sheet-preview">
-				<Gridicon icon="themes" size={ 18 } />
 				<span className="theme__sheet-preview-link-text">
 					{ i18n.translate( 'Open Live Demo', { context: 'Individual theme live preview button' } ) }
 				</span>

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -201,7 +201,7 @@ const ThemeSheet = React.createClass( {
 		} else {
 			screenshot = this.getFullLengthScreenshot();
 		}
-		const img = screenshot && <img className="theme__sheet-img" src={ screenshot + '?=w680' } />;
+		const img = screenshot && <img className="theme__sheet-img" src={ screenshot + '?w=680' } />;
 		return (
 			<div className="theme__sheet-screenshot">
 				{ this.props.demo_uri && this.renderPreviewButton() }

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -15,7 +15,7 @@
 	display: block;
 	font-size: 33px;
 	font-weight: 100;
-	padding-top: 70px;
+	padding-top: 78px;
 	padding-left: 25px;
 	line-height: 1;
 }
@@ -23,7 +23,7 @@
 .theme__sheet-bar-tag {
 	max-width: none;
 	display: block;
-	color: rgba(255, 255, 255, 0.6);
+	color: $white;
 	font-size: 16px;
 	font-weight: 200;
 	padding-top: 5px;

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -119,7 +119,7 @@
 	}
 
 	@include breakpoint( ">960px" ) {
-		&:hover {
+		&.is-active:hover {
 			cursor: pointer;
 			box-shadow: 0 0 0 1px $gray, 0px 2px 10px 0px transparentize( $gray-dark, 0.5 );
 

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -160,7 +160,7 @@
 		.theme__sheet-preview-link-text {
 			margin: 0 auto;
 			padding: 2px 8px 3px 8px;
-			background-color: transparentize( $gray-light, 0.4 );
+			background-color: $gray-light;
 			color: $gray-text-min;
 			font-size: 11px;
 			font-weight: 600;

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -135,6 +135,35 @@
 	width: 100%;
 }
 
+.theme__sheet-preview-link {
+	display: flex;
+	position: absolute;
+		top: -24px;
+	color: lighten( $gray, 30% );
+	cursor: pointer;
+	transition: all ease-in-out 100ms;
+
+	&:hover {
+		color: $white;
+	}
+
+	.theme__sheet-preview-link-text {
+		font-size: 12px;
+		margin-top: 2px;
+	}
+
+	@include breakpoint( "<960px" ) {
+		color: $gray-text-min;
+		top: 90%;
+		left: 0;
+		right: 0;
+
+		.theme__sheet-preview-link-text {
+			margin: 0 auto;
+		}
+	}
+}
+
 .theme__sheet-content {
 	padding: 20px;
 	font-size: 14px;
@@ -382,48 +411,6 @@
 	small {
 		display: block;
 		color: $gray;
-	}
-}
-
-.theme__sheet-preview-link {
-	display: flex;
-	position: absolute;
-		top: -28px;
-	color: lighten( $gray, 30% );
-	cursor: pointer;
-	transition: all ease-in-out 100ms;
-
-	&:hover {
-		color: $white;
-	}
-
-	.gridicon {
-		margin: 0 8px 0 -4px;
-	}
-
-	.theme__sheet-preview-link-text {
-		font-size: 12px;
-		margin-top: 2px;
-		text-transform: uppercase;
-	}
-
-	@include breakpoint( "<960px" ) {
-		color: transparentize( $gray, 0.2 );
-		top: 90%;
-		margin-left: 30px;
-
-		&:hover {
-			color: $gray-dark;
-		}
-
-		.gridicon {
-			width: 24px;
-			height: 24px;
-		}
-
-		.theme__sheet-preview-link-text {
-			display: none;
-		}
 	}
 }
 

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -91,8 +91,9 @@
 	position: relative;
 	top: -156px;
 	width: 98%;
-	box-shadow: 0px 2px 8px 0px rgba(46,68,83,0.45);
+	box-shadow: 0 0 0 1px $transparent, 0px 2px 8px 0px transparentize( $gray-dark, 0.5 );
 	background-color: transparentize( white, 0.5 );
+	transition: all 200ms ease-in-out;
 
 	// with width: 98%, gives 4:3 ratio before the image loads
 	// also x-browser issues, so it's smaller than 4:3 proper
@@ -114,6 +115,17 @@
 			width: 100%;
 			height: 30%;
 			background: linear-gradient( to bottom, transparentize( $gray-light, 1.0 ) 0%, transparentize( $gray-light, 0.5 ) 40%, $gray-light 93% );
+		}
+	}
+
+	@include breakpoint( ">960px" ) {
+		&:hover {
+			cursor: pointer;
+			box-shadow: 0 0 0 1px $gray, 0px 2px 10px 0px transparentize( $gray-dark, 0.5 );
+
+			.theme__sheet-preview-link {
+				color: $white;
+			}
 		}
 	}
 }

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -153,13 +153,19 @@
 	}
 
 	@include breakpoint( "<960px" ) {
-		color: $gray-text-min;
 		top: 90%;
 		left: 0;
 		right: 0;
 
 		.theme__sheet-preview-link-text {
 			margin: 0 auto;
+			padding: 2px 8px 3px 8px;
+			background-color: transparentize( $gray-light, 0.4 );
+			color: $gray-text-min;
+			font-size: 11px;
+			font-weight: 600;
+			border-radius: 3px;
+			border: 1px solid darken( $sidebar-bg-color, 10% );
 		}
 	}
 }


### PR DESCRIPTION
This PR makes the entire full-height screenshot clickable. Implements #7668. 

It also does a couple of smaller tweaks:

1. The icon is dropped from "Open Live Demo"
2. On mobile the text is centered
3. The theme shop name is now full white for readability
4. There was a typo in the `?w=` parameter (was `?=w`)

Before:

![screen shot 2017-04-11 at 16 04 31](https://cloud.githubusercontent.com/assets/4389/24915957/94730b92-1ed0-11e7-8d1d-eca139024ea2.png)

![screen shot 2017-04-11 at 16 05 18](https://cloud.githubusercontent.com/assets/4389/24915989/b3458ef0-1ed0-11e7-8b50-9d4e3153e231.png)


After:

![screen shot 2017-04-11 at 16 04 51](https://cloud.githubusercontent.com/assets/4389/24915968/9eefe8e2-1ed0-11e7-8f12-826d09de8230.png)

![screen shot 2017-04-11 at 16 05 26](https://cloud.githubusercontent.com/assets/4389/24915996/b771a5ae-1ed0-11e7-80a6-c065dcf7b39c.png)




### To test

1. Open Calypso Themes
2. Open any theme
3. Notice there's a hover state on the screenshot
4. Clicking anywhere in the screenshot opens the preview
5. The same works on mobile devices too