### PR TITLE
Purchases: Extract PurchaseSiteHeader component

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -48,6 +48,7 @@ import PurchasePlanDetails from './plan-details';
 import PaymentLogo from 'components/payment-logo';
 import ProductLink from 'me/purchases/product-link';
 import PurchaseNotice from './notices';
+import PurchaseSiteHeader from '../purchases-site/header';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import RemovePurchase from '../remove-purchase';
 import VerticalNavItem from 'components/vertical-nav/item';
@@ -531,6 +532,11 @@ const ManagePurchase = React.createClass( {
 
 		return (
 			<div>
+				<PurchaseSiteHeader
+					siteId={ this.props.selectedSite.ID }
+					name={ siteName }
+					domain={ siteDomain }
+					isPlaceholder={ isDataLoading( this.props ) } />
 				<Card className={ classes }>
 					<header className="manage-purchase__header">
 						<strong className="manage-purchase__content manage-purchase__title">{ purchaseTitleText }</strong>

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -39,7 +39,10 @@ import {
 } from 'lib/purchases';
 import { isDataLoading, getPurchase, getSelectedSite, goToList, recordPageView } from '../utils';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
-import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
+import {
+	getSelectedSite as getSelectedSiteSelector,
+	getSelectedSiteId,
+} from 'state/ui/selectors';
 import HeaderCake from 'components/header-cake';
 import { isDomainRegistration } from 'lib/products-values';
 import { isRequestingSites } from 'state/sites/selectors';
@@ -533,7 +536,7 @@ const ManagePurchase = React.createClass( {
 		return (
 			<div>
 				<PurchaseSiteHeader
-					siteId={ this.props.selectedSite && this.props.selectedSite.ID }
+					siteId={ this.props.selectedSiteId }
 					name={ siteName }
 					domain={ siteDomain }
 					isPlaceholder={ isDataLoading( this.props ) } />
@@ -619,6 +622,7 @@ export default connect(
 		hasLoadedSites: ! isRequestingSites( state ),
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		selectedPurchase: getByPurchaseId( state, props.purchaseId ),
-		selectedSite: getSelectedSiteSelector( state )
+		selectedSite: getSelectedSiteSelector( state ),
+		selectedSiteId: getSelectedSiteId( state ),
 	} )
 )( localize( ManagePurchase ) );

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -533,7 +533,7 @@ const ManagePurchase = React.createClass( {
 		return (
 			<div>
 				<PurchaseSiteHeader
-					siteId={ this.props.selectedSite.ID }
+					siteId={ this.props.selectedSite && this.props.selectedSite.ID }
 					name={ siteName }
 					domain={ siteDomain }
 					isPlaceholder={ isDataLoading( this.props ) } />

--- a/client/me/purchases/purchases-site/header.jsx
+++ b/client/me/purchases/purchases-site/header.jsx
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import React, { Component } from 'react';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+import { getSite } from 'state/sites/selectors';
+import QuerySites from 'components/data/query-sites';
+import Site from 'blocks/site';
+import SitePlaceholder from 'blocks/site/placeholder';
+
+class PurchaseSiteHeader extends Component {
+	// Disconnected sites can't render the `Site` component, but there can be
+	// purchases from disconnected sites. Here we spoof the Site header.
+	renderFauxSite() {
+		const { name, domain } = this.props;
+
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
+		return (
+			<div className="site is-disconnected">
+				<div className="site__content">
+					<div className="site-icon is-blank">
+						<Gridicon icon="notice" />
+					</div>
+					<div className="site__info">
+						<div className="site__title">{ name }</div>
+						<div className="site__domain">{ domain }</div>
+					</div>
+				</div>
+			</div>
+		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
+	}
+
+	render() {
+		const { isPlaceholder, siteId, site, name, domain } = this.props;
+		let header;
+
+		if ( isPlaceholder ) {
+			header = (
+				<SitePlaceholder />
+			);
+		} else if ( site ) {
+			header = (
+				<Site isCompact site={ site } />
+			);
+		} else {
+			header = this.renderFauxSite( name, domain );
+		}
+
+		return (
+			<CompactCard className="purchases-site__header">
+				<QuerySites siteId={ siteId } />
+				{ header }
+			</CompactCard>
+		);
+	}
+}
+
+PurchaseSiteHeader.propTypes = {
+	isPlaceholder: React.PropTypes.bool,
+	siteId: React.PropTypes.number,
+	name: React.PropTypes.string,
+	domain: React.PropTypes.string,
+};
+
+export default connect(
+	( state, { siteId } ) => ( {
+		site: getSite( state, siteId )
+	} )
+)( PurchaseSiteHeader );

--- a/client/me/purchases/purchases-site/header.jsx
+++ b/client/me/purchases/purchases-site/header.jsx
@@ -15,6 +15,13 @@ import Site from 'blocks/site';
 import SitePlaceholder from 'blocks/site/placeholder';
 
 class PurchaseSiteHeader extends Component {
+	static propTypes = {
+		isPlaceholder: React.PropTypes.bool,
+		siteId: React.PropTypes.number,
+		name: React.PropTypes.string,
+		domain: React.PropTypes.string,
+	}
+
 	// Disconnected sites can't render the `Site` component, but there can be
 	// purchases from disconnected sites. Here we spoof the Site header.
 	renderFauxSite() {
@@ -61,13 +68,6 @@ class PurchaseSiteHeader extends Component {
 		);
 	}
 }
-
-PurchaseSiteHeader.propTypes = {
-	isPlaceholder: React.PropTypes.bool,
-	siteId: React.PropTypes.number,
-	name: React.PropTypes.string,
-	domain: React.PropTypes.string,
-};
 
 export default connect(
 	( state, { siteId } ) => ( {

--- a/client/me/purchases/purchases-site/index.jsx
+++ b/client/me/purchases/purchases-site/index.jsx
@@ -2,51 +2,22 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { connect } from 'react-redux';
 import React from 'react';
 import times from 'lodash/times';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
-import CompactCard from 'components/card/compact';
-import { getSite } from 'state/sites/selectors';
 import PurchaseItem from '../purchase-item';
-import QuerySites from 'components/data/query-sites';
-import Site from 'blocks/site';
-import SitePlaceholder from 'blocks/site/placeholder';
+import PurchaseSiteHeader from './header';
 
-// Disconnected sites can't render the `Site` component, but there can be
-// purchases from disconnected sites. Here we spoof the Site header.
-const renderFauxSite = ( name, domain ) => {
-	/* eslint-disable wpcalypso/jsx-classname-namespace */
-	return (
-		<div className="site is-disconnected">
-			<div className="site__content">
-				<div className="site-icon is-blank">
-					<Gridicon icon="notice" />
-				</div>
-				<div className="site__info">
-					<div className="site__title">{ name }</div>
-					<div className="site__domain">{ domain }</div>
-				</div>
-			</div>
-		</div>
-	);
-	/* eslint-enable wpcalypso/jsx-classname-namespace */
-};
-
-const PurchasesSite = ( { isPlaceholder, siteId, site, purchases, name, domain, slug } ) => {
-	let items, header;
+const PurchasesSite = ( { isPlaceholder, siteId, purchases, name, domain, slug } ) => {
+	let items;
 
 	if ( isPlaceholder ) {
 		items = times( 2, index => (
 			<PurchaseItem isPlaceholder key={ index } />
 		) );
-		header = (
-			<SitePlaceholder />
-		);
 	} else {
 		items = purchases.map( purchase => (
 			<PurchaseItem
@@ -54,21 +25,15 @@ const PurchasesSite = ( { isPlaceholder, siteId, site, purchases, name, domain, 
 				slug={ slug }
 				purchase={ purchase } />
 		) );
-		if ( site ) {
-			header = (
-				<Site isCompact site={ site } />
-			);
-		} else {
-			header = renderFauxSite( name, domain );
-		}
 	}
 
 	return (
 		<div className={ classNames( 'purchases-site', { 'is-placeholder': isPlaceholder } ) }>
-			<QuerySites siteId={ siteId } />
-			<CompactCard className="purchases-site__header">
-				{ header }
-			</CompactCard>
+			<PurchaseSiteHeader
+				siteId={ siteId }
+				name={ name }
+				domain={ domain }
+				isPlaceholder={ isPlaceholder } />
 
 			{ items }
 		</div>
@@ -84,8 +49,4 @@ PurchasesSite.propTypes = {
 	slug: React.PropTypes.string,
 };
 
-export default connect(
-	( state, { siteId } ) => ( {
-		site: getSite( state, siteId )
-	} )
-)( PurchasesSite );
+export default PurchasesSite;


### PR DESCRIPTION
This PR creates a new component for site headers on the purchase list and detail view

List view:
<img width="738" alt="screen shot 2017-04-11 at 11 05 40 am" src="https://cloud.githubusercontent.com/assets/541093/24916006/da8cf270-1ea6-11e7-9e86-a2fa076b2064.png">

Detail view:
<img width="740" alt="screen shot 2017-04-11 at 11 05 46 am" src="https://cloud.githubusercontent.com/assets/541093/24916013/df49fbaa-1ea6-11e7-8aa4-70d751174a12.png">

To test, make sure nothing looks broken:

- Check your purchase list view, `/me/purchases`
- Check a wp.com site
- Check a Jetpack site

