### PR TITLE
Reader: Coerce values in subscriptions

### DIFF
--- a/client/reader/id-helpers.js
+++ b/client/reader/id-helpers.js
@@ -1,20 +1,24 @@
 /**
- * External Dependencies
+ * Convert a string or number to valid reader ID
+ *
+ * @export
+ * @param {string|number} val The value to convert
+ * @returns {number|undefined} A valid ID or undefined if we could not convert val
  */
-
-/**
- * Internal Dependencies
- */
-
 export function toValidId( val ) {
-	if ( val === true ) {
-		return undefined;
+	const valType = typeof val;
+	if ( valType === 'string' && /^\d+$/.test( val ) ) {
+		const v = Number( val );
+		return v === 0 ? undefined : v;
 	}
-	const id = Number( val );
-	if ( Math.floor( id ) !== id ) {
-		return undefined;
+	if ( valType === 'number' ) {
+		if ( val === 0 ||
+			isNaN( val ) ||
+			! isFinite( val ) ||
+			val !== Math.floor( val ) ) {
+			return undefined;
+		}
+		return val;
 	}
-	return id !== 0 && ! isNaN( id )
-		? id
-		: undefined;
+	return undefined;
 }

--- a/client/reader/id-helpers.js
+++ b/client/reader/id-helpers.js
@@ -1,0 +1,20 @@
+/**
+ * External Dependencies
+ */
+
+/**
+ * Internal Dependencies
+ */
+
+export function toValidId( val ) {
+	if ( val === true ) {
+		return undefined;
+	}
+	const id = Number( val );
+	if ( Math.floor( id ) !== id ) {
+		return undefined;
+	}
+	return id !== 0 && ! isNaN( id )
+		? id
+		: undefined;
+}

--- a/client/reader/test/id-helpers.js
+++ b/client/reader/test/id-helpers.js
@@ -1,0 +1,32 @@
+/**
+ * External Dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal Dependencies
+ */
+import { toValidId } from '../id-helpers';
+
+describe( 'toValidId', () => {
+	const testCases = [
+			[ undefined, undefined ],
+			[ null, undefined ],
+			[ 0, undefined ],
+			[ '0', undefined ],
+			[ false, undefined ],
+			[ true, undefined ],
+			[ 1, 1 ],
+			[ '1', 1 ],
+			[ 4, 4 ],
+			[ '4', 4 ],
+			[ '4.8', undefined ],
+	];
+
+	testCases.forEach( function( testCase ) {
+		const [ provided, expected ] = testCase;
+		it( `'${ provided }' should yield '${ expected }'`, () => {
+			expect( toValidId( provided ) ).to.equal( expected );
+		} );
+	} );
+} );

--- a/client/reader/test/id-helpers.js
+++ b/client/reader/test/id-helpers.js
@@ -21,6 +21,7 @@ describe( 'toValidId', () => {
 			[ 4, 4 ],
 			[ '4', 4 ],
 			[ '4.8', undefined ],
+			[ 1 / 0, undefined ],
 	];
 
 	testCases.forEach( function( testCase ) {

--- a/client/state/data-layer/wpcom/read/following/mine/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { map, omit, isArray } from 'lodash';
+import { map, omitBy, isArray, isUndefined } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,6 +18,13 @@ import { errorNotice } from 'state/notices/actions';
 
 const ITEMS_PER_PAGE = 200;
 const MAX_ITEMS = 2000;
+
+function toNumberOrUndefined( val ) {
+	if ( val ) {
+		return Number( val );
+	}
+	return undefined;
+}
 
 export const requestPageAction = ( page = 1, number = ITEMS_PER_PAGE, meta = '' )=> ( {
 	type: READER_FOLLOWS_SYNC_PAGE,
@@ -35,9 +42,17 @@ export const subscriptionsFromApi = apiResponse => {
 		return [];
 	}
 
-	return map( apiResponse.subscriptions, subscription =>
-		omit( subscription, 'meta' )
-	);
+	return map( apiResponse.subscriptions, subscription => {
+		return omitBy( {
+			ID: Number( subscription.ID ),
+			URL: subscription.URL,
+			blog_ID: toNumberOrUndefined( subscription.blog_ID ),
+			feed_ID: toNumberOrUndefined( subscription.feed_ID ),
+			date_subscribed: Date.parse( subscription.date_subscribed ),
+			delivery_methods: subscription.delivery_methods,
+			is_owner: subscription.is_owner,
+		}, isUndefined );
+	} );
 };
 
 let syncingFollows = false;

--- a/client/state/data-layer/wpcom/read/following/mine/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/index.js
@@ -19,11 +19,17 @@ import { errorNotice } from 'state/notices/actions';
 const ITEMS_PER_PAGE = 200;
 const MAX_ITEMS = 2000;
 
-function toNumberOrUndefined( val ) {
-	if ( val ) {
-		return Number( val );
+export function toValidId( val ) {
+	if ( val === true ) {
+		return undefined;
 	}
-	return undefined;
+	const id = Number( val );
+	if ( Math.floor( id ) !== id ) {
+		return undefined;
+	}
+	return id !== 0 && ! isNaN( id )
+		? id
+		: undefined;
 }
 
 export const requestPageAction = ( page = 1, number = ITEMS_PER_PAGE, meta = '' )=> ( {
@@ -46,8 +52,8 @@ export const subscriptionsFromApi = apiResponse => {
 		return omitBy( {
 			ID: Number( subscription.ID ),
 			URL: subscription.URL,
-			blog_ID: toNumberOrUndefined( subscription.blog_ID ),
-			feed_ID: toNumberOrUndefined( subscription.feed_ID ),
+			blog_ID: toValidId( subscription.blog_ID ),
+			feed_ID: toValidId( subscription.feed_ID ),
 			date_subscribed: Date.parse( subscription.date_subscribed ),
 			delivery_methods: subscription.delivery_methods,
 			is_owner: subscription.is_owner,

--- a/client/state/data-layer/wpcom/read/following/mine/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/index.js
@@ -15,22 +15,10 @@ import { receiveFollows as receiveFollowsAction } from 'state/reader/follows/act
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
+import { toValidId } from 'reader/id-helpers';
 
 const ITEMS_PER_PAGE = 200;
 const MAX_ITEMS = 2000;
-
-export function toValidId( val ) {
-	if ( val === true ) {
-		return undefined;
-	}
-	const id = Number( val );
-	if ( Math.floor( id ) !== id ) {
-		return undefined;
-	}
-	return id !== 0 && ! isNaN( id )
-		? id
-		: undefined;
-}
 
 export const requestPageAction = ( page = 1, number = ITEMS_PER_PAGE, meta = '' )=> ( {
 	type: READER_FOLLOWS_SYNC_PAGE,

--- a/client/state/data-layer/wpcom/read/following/mine/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/test/index.js
@@ -141,8 +141,21 @@ describe( 'get follow subscriptions', () => {
 
 	describe( '#subscriptionsFromApi', () => {
 		it( 'should return subscriptions from the apiResponse', () => {
-			const subs = successfulApiResponse.subscriptions;
-			expect( subscriptionsFromApi( successfulApiResponse ) ).eql( subs );
+			const transformedSubs = [
+				{
+					ID: 12345,
+					blog_ID: 122463145,
+					URL: 'http://readerpostcards.wordpress.com',
+					date_subscribed: Date.parse( '2017-01-12T03:55:45+00:00' ),
+				},
+				{
+					ID: 123456,
+					blog_ID: 64146350,
+					URL: 'https://fivethirtyeight.com/',
+					date_subscribed: Date.parse( '2016-01-12T03:55:45+00:00' ),
+				}
+			];
+			expect( subscriptionsFromApi( successfulApiResponse ) ).eql( transformedSubs );
 		} );
 
 		it( 'should return an empty list from invalid apiResponse', () => {

--- a/client/state/data-layer/wpcom/read/following/mine/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/test/index.js
@@ -19,6 +19,7 @@ import {
 	isValidApiResponse,
 	syncReaderFollows,
 	resetSyncingFollows,
+	toValidId,
 } from '../';
 import { receiveFollows as receiveFollowsAction } from 'state/reader/follows/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
@@ -161,6 +162,29 @@ describe( 'get follow subscriptions', () => {
 		it( 'should return an empty list from invalid apiResponse', () => {
 			expect( subscriptionsFromApi( { notExpected: 'true' } ) ).eql( [] );
 			expect( subscriptionsFromApi( { subscriptions: 'true' } ) ).eql( [] );
+		} );
+	} );
+
+	describe( 'toValidId', () => {
+		const testCases = [
+			[ undefined, undefined ],
+			[ null, undefined ],
+			[ 0, undefined ],
+			[ '0', undefined ],
+			[ false, undefined ],
+			[ true, undefined ],
+			[ 1, 1 ],
+			[ '1', 1 ],
+			[ 4, 4 ],
+			[ '4', 4 ],
+			[ '4.8', undefined ],
+		];
+
+		testCases.forEach( function( testCase ) {
+			const [ provided, expected ] = testCase;
+			it( `'${ provided }' should yield '${ expected }'`, () => {
+				expect( toValidId( provided ) ).to.equal( expected );
+			} );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/following/mine/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/test/index.js
@@ -19,7 +19,6 @@ import {
 	isValidApiResponse,
 	syncReaderFollows,
 	resetSyncingFollows,
-	toValidId,
 } from '../';
 import { receiveFollows as receiveFollowsAction } from 'state/reader/follows/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
@@ -162,29 +161,6 @@ describe( 'get follow subscriptions', () => {
 		it( 'should return an empty list from invalid apiResponse', () => {
 			expect( subscriptionsFromApi( { notExpected: 'true' } ) ).eql( [] );
 			expect( subscriptionsFromApi( { subscriptions: 'true' } ) ).eql( [] );
-		} );
-	} );
-
-	describe( 'toValidId', () => {
-		const testCases = [
-			[ undefined, undefined ],
-			[ null, undefined ],
-			[ 0, undefined ],
-			[ '0', undefined ],
-			[ false, undefined ],
-			[ true, undefined ],
-			[ 1, 1 ],
-			[ '1', 1 ],
-			[ 4, 4 ],
-			[ '4', 4 ],
-			[ '4.8', undefined ],
-		];
-
-		testCases.forEach( function( testCase ) {
-			const [ provided, expected ] = testCase;
-			it( `'${ provided }' should yield '${ expected }'`, () => {
-				expect( toValidId( provided ) ).to.equal( expected );
-			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
This coerces feed_ID and blog_ID to numbers to make for safer and faster comparisons down-stream. Should be no functional changes as the data layer isn't actively used yet.