### PR TITLE
Stats: Update lists.items reducer to recreate only modified stats

### DIFF
--- a/client/state/stats/lists/reducer.js
+++ b/client/state/stats/lists/reducer.js
@@ -79,9 +79,9 @@ export function items( state = {}, action ) {
 			return {
 				...state,
 				[ siteId ]: {
-					...get( state, [ siteId ], null ),
+					...get( state, [ siteId ] ),
 					[ statType ]: {
-						...get( state, [ siteId, statType ], null ),
+						...get( state, [ siteId, statType ] ),
 						[ queryKey ]: data
 					}
 				}

--- a/client/state/stats/lists/reducer.js
+++ b/client/state/stats/lists/reducer.js
@@ -79,7 +79,7 @@ export function items( state = {}, action ) {
 			return {
 				...state,
 				[ siteId ]: {
-					...get( state, [ siteId ] ),
+					...state[ siteId ],
 					[ statType ]: {
 						...get( state, [ siteId, statType ] ),
 						[ queryKey ]: data

--- a/client/state/stats/lists/reducer.js
+++ b/client/state/stats/lists/reducer.js
@@ -74,19 +74,17 @@ export function items( state = {}, action ) {
 			const { siteId, statType, query, data } = action;
 			const queryKey = getSerializedStatsQuery( query );
 
-			const newQueries = {
-				...get( state, [ siteId, statType ], null ),
-				[ queryKey ]: data
-			};
-
-			const newStatType = {
-				...get( state, [ siteId ], null ),
-				[ statType ]: newQueries
-			};
-
+			// Build the items state in a way that will preserve all unmodified parts
+			// and recreate site -> statType -> queryKey that was currently changed.
 			return {
 				...state,
-				[ siteId ]: newStatType
+				[ siteId ]: {
+					...get( state, [ siteId ], null ),
+					[ statType ]: {
+						...get( state, [ siteId, statType ], null ),
+						[ queryKey ]: data
+					}
+				}
 			};
 
 		case DESERIALIZE:

--- a/client/state/stats/lists/test/reducer.js
+++ b/client/state/stats/lists/test/reducer.js
@@ -258,6 +258,26 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		it( 'should change root site property when received stats by statType', () => {
+			const original = deepFreeze( {
+				2916284: {
+					statsStreak: {
+						'[["endDate","2016-07-01"],["startDate","2016-06-01"]]': streakResponse
+					}
+				}
+			} );
+
+			const state = items( original, {
+				type: SITE_STATS_RECEIVE,
+				siteId: 2916284,
+				statType: 'statsStreak',
+				query: streakQueryDos,
+				data: streakResponseDos
+			} );
+
+			expect( state[ 2916284 ] ).to.not.equal( original[ 2916284 ] );
+		} );
+
 		it( 'should add additional statTypes', () => {
 			const original = deepFreeze( {
 				2916284: {
@@ -285,6 +305,46 @@ describe( 'reducer', () => {
 					}
 				}
 			} );
+		} );
+
+		it( 'should should not change another statTypes property', () => {
+			const original = deepFreeze( {
+				2916284: {
+					statsStreak: {
+						'[["endDate","2016-07-01"],["startDate","2016-06-01"]]': streakResponse
+					}
+				}
+			} );
+
+			const state = items( original, {
+				type: SITE_STATS_RECEIVE,
+				siteId: 2916284,
+				statType: 'statsCountryViews',
+				query: streakQuery,
+				data: {}
+			} );
+
+			expect( state[ 2916284 ].statsStreak ).to.equal( original[ 2916284 ].statsStreak );
+		} );
+
+		it( 'should not change another site property', () => {
+			const original = deepFreeze( {
+				2916284: {
+					statsStreak: {
+						'[["endDate","2016-07-01"],["startDate","2016-06-01"]]': streakResponse
+					}
+				}
+			} );
+
+			const state = items( original, {
+				type: SITE_STATS_RECEIVE,
+				siteId: 3916284,
+				statType: 'statsCountryViews',
+				query: streakQuery,
+				data: {}
+			} );
+
+			expect( state[ 2916284 ].statsStreak ).to.equal( original[ 2916284 ].statsStreak );
 		} );
 	} );
 } );


### PR DESCRIPTION
The stats.list.items reducer keep the state tree hierarchy by site -> statType -> queryKey -> data.
When new stats is received the state tree needs to update to include the new stats.
Until now the update were done using `merge` function by passing empty object as first parameter which resulted in re-building the whole state tree. Even though the values looked the same the object instances were different ( !== ).

This resulted in over-render of all the `StatsModules`. Every time any of the statTypes were received _all_ of the `StatModule`s instances were rendering, not just the one that actually changed.

The fix was to rebuild the state tree from the bottom-up, preserving all properties that were not changed. That is any `queryKey`s that were already received were left with the exact same object instance, any other `statType` were left the same and any other sites were left the same.

This will allow `StatsModule` components to update only if the data they are useing actually changed.