### PR TITLE
Plugins: Copy update for private site eligibility hold

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.jsx
+++ b/client/blocks/eligibility-warnings/hold-list.jsx
@@ -32,7 +32,7 @@ function getHoldMessages( siteSlug, translate ) {
 		},
 		SITE_PRIVATE: {
 			title: translate( 'Private site not supported' ),
-			description: translate( 'Make your site public to resolve.' ),
+			description: translate( 'Make your site public or hidden to resolve.' ),
 			supportUrl: `/settings/general/${ siteSlug }`,
 		},
 		SITE_GRAYLISTED: {


### PR DESCRIPTION
Updates the copy for the private site eligibility hold to include `or hidden`, since this is another option the user can choose to enable the transfer.