### PR TITLE
Purchases: Extract PurchaseNotice component

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -595,7 +595,7 @@ const ManagePurchase = React.createClass( {
 		}
 		const { selectedSite, selectedPurchase } = this.props;
 		let editCardDetailsPath;
-		if ( ! isDataLoading( this.props ) ) {
+		if ( ! isDataLoading( this.props ) && selectedSite ) {
 			editCardDetailsPath = canEditPaymentDetails( selectedPurchase ) && getEditCardDetailsPath( selectedSite, selectedPurchase );
 		}
 

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -45,7 +45,6 @@ import { isDomainRegistration } from 'lib/products-values';
 import { isRequestingSites } from 'state/sites/selectors';
 import Main from 'components/main';
 import PurchasePlanDetails from './plan-details';
-import Notice from 'components/notice';
 import PaymentLogo from 'components/payment-logo';
 import ProductLink from 'me/purchases/product-link';
 import PurchaseNotice from './notices';
@@ -318,28 +317,6 @@ const ManagePurchase = React.createClass( {
 		);
 	},
 
-	renderExpiredRenewNotice() {
-		const purchase = getPurchase( this.props );
-		const { translate } = this.props;
-
-		if ( ! isRenewable( purchase ) && ! isRedeemable( purchase ) ) {
-			return null;
-		}
-
-		if ( ! isExpired( purchase ) ) {
-			return null;
-		}
-
-		return (
-			<Notice
-				showDismiss={ false }
-				status="is-error"
-				text={ translate( 'This purchase has expired and is no longer in use.' ) }>
-				{ this.renderRenewNoticeAction() }
-			</Notice>
-		);
-	},
-
 	renderRenewsOrExpiresOnLabel() {
 		const purchase = getPurchase( this.props );
 		const { translate } = this.props;
@@ -531,7 +508,6 @@ const ManagePurchase = React.createClass( {
 			renewsOrExpiresOnLabel,
 			renewsOrExpiresOn,
 			renewButton,
-			expiredRenewNotice,
 			editPaymentMethodNavItem,
 			cancelPurchaseNavItem,
 			cancelPrivacyProtectionNavItem,
@@ -559,7 +535,6 @@ const ManagePurchase = React.createClass( {
 			renewsOrExpiresOn = this.renderRenewsOrExpiresOn();
 			renewButton = this.renderRenewButton();
 			contactSupportToRenewMessage = this.renderContactSupportToRenewMessage();
-			expiredRenewNotice = this.renderExpiredRenewNotice();
 			editPaymentMethodNavItem = this.renderEditPaymentMethodNavItem();
 			cancelPurchaseNavItem = this.renderCancelPurchaseNavItem();
 			cancelPrivacyProtectionNavItem = this.renderCancelPrivacyProtection();
@@ -600,7 +575,6 @@ const ManagePurchase = React.createClass( {
 
 				{ this.renderPlanDetails() }
 
-				{ expiredRenewNotice }
 				{ editPaymentMethodNavItem }
 				{ cancelPurchaseNavItem }
 				{ cancelPrivacyProtectionNavItem }

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -37,7 +37,7 @@ import {
 	paymentLogoType,
 	purchaseType,
 } from 'lib/purchases';
-import { getPurchase, getSelectedSite, goToList, recordPageView } from '../utils';
+import { isDataLoading, getPurchase, getSelectedSite, goToList, recordPageView } from '../utils';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
 import HeaderCake from 'components/header-cake';
@@ -74,17 +74,6 @@ function getEditCardDetailsPath( site, purchase ) {
 		return paths.editCardDetails( site.slug, purchase.id, creditCard.id );
 	}
 	return paths.addCardDetails( site.slug, purchase.id );
-}
-
-/**
- * Determines if data is being fetched. This is different than `isDataLoading` in `PurchasesUtils`
- * because this page can be rendered without a selected site.
- *
- * @param {object} props The props passed to `ManagePurchase`
- * @return {boolean} Whether or not the data is loading
- */
-function isDataLoading( props ) {
-	return ! props.hasLoadedSites || ! props.hasLoadedUserPurchasesFromServer;
 }
 
 const ManagePurchase = React.createClass( {

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -25,6 +25,21 @@ import NoticeAction from 'components/notice/notice-action';
 import { isMonthly } from 'lib/plans/constants';
 
 class PurchaseNotice extends Component {
+	static propTypes = {
+		isDataLoading: React.PropTypes.bool,
+		handleRenew: React.PropTypes.func,
+		selectedPurchase: React.PropTypes.object,
+		selectedSite: React.PropTypes.oneOfType( [
+			React.PropTypes.object,
+			React.PropTypes.bool,
+			React.PropTypes.undefined
+		] ),
+		editCardDetailsPath: React.PropTypes.oneOfType( [
+			React.PropTypes.string,
+			React.PropTypes.bool
+		] )
+	}
+
 	getExpiringText( purchase ) {
 		const { translate, moment, selectedSite } = this.props;
 		if ( selectedSite && purchase.expiryStatus === 'manualRenew' ) {
@@ -164,20 +179,5 @@ class PurchaseNotice extends Component {
 		return this.renderExpiredRenewNotice() || this.renderPurchaseExpiringNotice() || this.renderCreditCardExpiringNotice();
 	}
 }
-
-PurchaseNotice.propTypes = {
-	isDataLoading: React.PropTypes.bool,
-	handleRenew: React.PropTypes.func,
-	selectedPurchase: React.PropTypes.object,
-	selectedSite: React.PropTypes.oneOfType( [
-		React.PropTypes.object,
-		React.PropTypes.bool,
-		React.PropTypes.undefined
-	] ),
-	editCardDetailsPath: React.PropTypes.oneOfType( [
-		React.PropTypes.string,
-		React.PropTypes.bool
-	] )
-};
 
 export default localize( PurchaseNotice );

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -15,6 +15,8 @@ import {
 	isExpiring,
 	isIncludedWithPlan,
 	isOneTimePurchase,
+	isRedeemable,
+	isRenewable,
 	showCreditCardExpiringWarning
 } from 'lib/purchases';
 import { getPurchase, getSelectedSite } from '../utils';
@@ -132,12 +134,34 @@ class PurchaseNotice extends Component {
 		}
 	}
 
+	renderExpiredRenewNotice() {
+		const purchase = getPurchase( this.props );
+		const { translate } = this.props;
+
+		if ( ! isRenewable( purchase ) && ! isRedeemable( purchase ) ) {
+			return null;
+		}
+
+		if ( ! isExpired( purchase ) ) {
+			return null;
+		}
+
+		return (
+			<Notice
+				showDismiss={ false }
+				status="is-error"
+				text={ translate( 'This purchase has expired and is no longer in use.' ) }>
+				{ this.renderRenewNoticeAction() }
+			</Notice>
+		);
+	}
+
 	render() {
 		if ( this.props.isDataLoading ) {
 			return null;
 		}
 
-		return this.renderPurchaseExpiringNotice() || this.renderCreditCardExpiringNotice();
+		return this.renderExpiredRenewNotice() || this.renderPurchaseExpiringNotice() || this.renderCreditCardExpiringNotice();
 	}
 }
 

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -176,7 +176,22 @@ class PurchaseNotice extends Component {
 			return null;
 		}
 
-		return this.renderExpiredRenewNotice() || this.renderPurchaseExpiringNotice() || this.renderCreditCardExpiringNotice();
+		const expiredNotice = this.renderExpiredRenewNotice();
+		if ( expiredNotice ) {
+			return expiredNotice;
+		}
+
+		const expiringNotice = this.renderPurchaseExpiringNotice();
+		if ( expiringNotice ) {
+			return expiringNotice;
+		}
+
+		const expiringCreditCardNotice = this.renderCreditCardExpiringNotice();
+		if ( expiringCreditCardNotice ) {
+			return expiringCreditCardNotice;
+		}
+
+		return null;
 	}
 }
 

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -26,8 +26,8 @@ import { isMonthly } from 'lib/plans/constants';
 
 class PurchaseNotice extends Component {
 	getExpiringText( purchase ) {
-		const { translate, moment } = this.props;
-		if ( purchase.expiryStatus === 'manualRenew' ) {
+		const { translate, moment, selectedSite } = this.props;
+		if ( selectedSite && purchase.expiryStatus === 'manualRenew' ) {
 			return translate( '%(purchaseName)s will expire and be removed from your site %(expiry)s. ' +
 				'Please, add a credit card if you want it to autorenew. ',
 				{


### PR DESCRIPTION
This PR creates a new component, `PurchaseNotice`, which extracts all the notice functionality from `ManagePurchase`. The only visual change is for expired purchases, the notice is now above the card (where all other notices display), rather than below/attached.

Subscription expiring soon, and needs a card:
![expiring](https://cloud.githubusercontent.com/assets/541093/24922996/2c98ea9e-1ebe-11e7-84c5-af751f9f940b.png)

Subscription expiring eventually:
![expiring later](https://cloud.githubusercontent.com/assets/541093/24923053/574e9068-1ebe-11e7-8391-b6ef8c5d6d78.png)

Expired purchase:
![expired](https://cloud.githubusercontent.com/assets/541093/24922986/1fb78f24-1ebe-11e7-8fa3-1fee7a39a6a7.png)

Subscription on a disconnected site (can't be renewed without support, so no renew action — see text in card)
![screen shot 2017-04-11 at 1 49 55 pm](https://cloud.githubusercontent.com/assets/541093/24923027/3f7a0f4e-1ebe-11e7-89cf-58262e89b454.png)

To test, visit sites with various plan combos:

- wp.com site, jetpack site, or disconnected jetpack site
- plan expired, plan expiring within 90 days, plan not expiring/auto-renew enabled
- credit card expiring before plan renews

_Note, this includes the change in #12999 otherwise this can't be tested. Once that's merged, it'll get rid of the change in `plan-details/index.jsx`._