### PR TITLE
Signup: Redirect the user back after signing up

### DIFF
--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -11,6 +11,14 @@ import { localize } from 'i18n-calypso';
 import Item from './item';
 import config from 'config';
 
+function getLoginUrl() {
+	let loginUrl = config( 'login_url' );
+	if ( typeof window !== 'undefined' ) {
+		loginUrl += `?redirect_to=${ encodeURIComponent( window.location.href ) }`;
+	}
+	return loginUrl;
+}
+
 const MasterbarLoggedOut = ( { title, sectionName, translate } ) => (
 	<Masterbar>
 		<Item className="masterbar__item-logo">
@@ -31,7 +39,7 @@ const MasterbarLoggedOut = ( { title, sectionName, translate } ) => (
 			}
 
 			{ 'login' !== sectionName
-			?	<Item url={ config( 'login_url' ) }>
+			?	<Item url={ getLoginUrl() }>
 					{ translate( 'Log In', {
 						context: 'Toolbar',
 						comment: 'Should be shorter than ~12 chars',


### PR DESCRIPTION
During signup, when the user logs in, we should redirect them back to from where they tried to log in, instead of the Reader.

### Testing
1. As a logged out user, navigate to `http://calypso.localhost:3000/start` to start the normal signup flow.
2. Try logging in using the `Log in` link in the upper right corner during various states of signup and verify that you are redirected back more or less into the same place (it seems there are some existing bugs with navigating signup: #12118).

----

1. Start a domain-only signup flow by visiting `http://calypso.localhost:3000/start/domain-first?new=somerandomdomain20170411.com`.
2. Same as #2 above.

Reported in `p6qnuF-4Hv-p2`.