### PR TITLE
Fix import of i18n-calypso in Checkout component

### DIFF
--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -3,7 +3,7 @@
  */
 import { connect } from 'react-redux';
 import { flatten, find, isEmpty, isEqual, reduce, startsWith } from 'lodash';
-import { i18n, localize } from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 import page from 'page';
 import React from 'react';
 


### PR DESCRIPTION
Should fix https://github.com/Automattic/wp-calypso/issues/12969

https://github.com/Automattic/wp-calypso/pull/12666 introduced a regression on `i18n.moment` accesses in `Checkout`. This PR should fix it.

### Testing Instructions
- Apply the patch and run calypso locally
- Go to http://calypso.localhost:3000/me/purchases and try to renew a product (such as a premium plan) using free credits so it doesn't auto-renew and hits the right condition.
- You should see the message `Success! You renewed WordPress.com Premium for a few seconds, until Mar 07, 2018. We sent your receipt to <email>.` (strangely, `bill_period` was not set for my purchase, thus the `a few seconds` so there is probably another bug).