### PR TITLE
Plugins: Fix back button behavior from search query

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -258,10 +258,9 @@ const controller = {
 		renderPluginWarnings( context );
 	},
 
-	resetHistory( context, next ) {
+	resetHistory() {
 		lastPluginsListVisited = null;
 		lastPluginsQuerystring = null;
-		next();
 	}
 };
 

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -82,8 +82,12 @@ module.exports = function() {
 			pluginsController.eligibility
 		);
 
-		page.exit( '/plugins*',
-			pluginsController.resetHistory
-		);
+		page.exit( '/plugins*', ( context, next ) => {
+			if ( 0 !== page.current.indexOf( '/plugins' ) ) {
+				pluginsController.resetHistory();
+			}
+
+			next();
+		} );
 	}
 };

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -82,8 +82,8 @@ module.exports = function() {
 			pluginsController.eligibility
 		);
 
-		page.exit( '/plugins*', ( context, next ) => {
-			if ( 0 !== page.current.indexOf( '/plugins' ) ) {
+		page.exit( '/plugins/*', ( context, next ) => {
+			if ( 0 !== page.current.indexOf( '/plugins/' ) ) {
 				pluginsController.resetHistory();
 			}
 


### PR DESCRIPTION
Plugins has had an interesting history of back navigation fixes for switching sites, searching, etc. The issue in #12978 arose somewhere along the way, where pressing the Back button doesn't return to a search query page.

Since the back behavior is quite fragile, this solution (based on a suggestion from @aduth, thank you!) seems to do the job without effecting the other scenarios for the back button's behavior.

I'm just getting familiar with Page.js myself, so any other ideas for a solution will be most welcome :)

**To test**
* Visit `/plugins` and visit the plugins browser.
* Enter a search query, and select one of the results.
* Press the `Back` button, you should return to the search query results.
* Test the back button in other scenarios, it should work as expected.

Fixes #12978