### PR TITLE
Menus: Send the user to the Customizer top level if they have not verified their email.

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -243,6 +243,10 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
+		if ( ! this.props.currentUser.email_verified ) {
+			menusLink = '/customize' + this.siteSuffix();
+		}
+
 		if ( site.jetpack ) {
 			menusLink = site.options.admin_url + 'customize.php?autofocus[panel]=nav_menus';
 		}


### PR DESCRIPTION
Currently, the Menus link in the sidebar will send a user directly to the Menus panel in the Customizer, which shouldn't be available to them if they haven't verified their email yet. This PR bumps them up to the Customizer top level instead, where the user will (maybe?) see that Menus are not available to them yet.

![screen shot 2017-04-11 at 3 36 05 pm](https://cloud.githubusercontent.com/assets/349751/24933723/a71aa18c-1ecc-11e7-87e1-6a23fec1fde3.png)
