### PR TITLE
Woo Connect-Insights: Add Store Stats toggle

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -24,6 +24,7 @@ import StickyPanel from 'components/sticky-panel';
 import config from 'config';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getSiteOption, isJetpackSite } from 'state/sites/selectors';
+import { isPluginActive } from 'state/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 class StatsSite extends Component {
@@ -109,7 +110,10 @@ class StatsSite extends Component {
 			<Main wideLayout={ true }>
 				<StatsFirstView />
 				<SidebarNavigation />
-				<StatsNavigation section={ period } />
+				<StatsNavigation
+					{ ...this.props }
+					section={ period }
+				/>
 				<div id="my-stats-content">
 					<ChartTabs
 						barClick={ this.barClick }
@@ -193,9 +197,12 @@ class StatsSite extends Component {
 export default connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
+		const isJetpack = isJetpackSite( state, siteId );
 		return {
-			isJetpack: isJetpackSite( state, siteId ),
+			isJetpack,
 			hasPodcasts: getSiteOption( state, siteId, 'podcasting_archive' ),
+			isWooConnect: isJetpack && isPluginActive( state, siteId, 'woocommerce' ),
+			siteId,
 			slug: getSelectedSiteSlug( state )
 		};
 	},

--- a/client/my-sites/stats/stats-navigation/index.jsx
+++ b/client/my-sites/stats/stats-navigation/index.jsx
@@ -2,9 +2,7 @@
  * External Dependencies
  */
 import React, { PropTypes } from 'react';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { flowRight } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,10 +11,12 @@ import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 import FollowersCount from 'blocks/followers-count';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
+import SegmentedControl from 'components/segmented-control';
+import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
+import config from 'config';
 
 const StatsNavigation = ( props ) => {
-	const { translate, section, slug } = props;
+	const { translate, section, slug, siteId, isJetpack, isWooConnect } = props;
 	const siteFragment = slug ? '/' + slug : '';
 	const sectionTitles = {
 		insights: translate( 'Insights' ),
@@ -25,9 +25,27 @@ const StatsNavigation = ( props ) => {
 		month: translate( 'Months' ),
 		year: translate( 'Years' )
 	};
+	let statsControl;
+
+	if ( config.isEnabled( 'woocommerce/extension-stats' ) ) {
+		if ( isWooConnect ) {
+			statsControl = (
+				<SegmentedControl
+					// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+					className="stats-navigation__control"
+					initialSelected="site"
+					options={ [
+						{ value: 'site', label: translate( 'Site' ) },
+						{ value: 'store', label: translate( 'Store' ), path: `/store/stats/${ slug }` },
+					] }
+				/>
+			);
+		}
+	}
 
 	return (
 		<SectionNav selectedText={ sectionTitles[ section ] }>
+			{ isJetpack && <QueryJetpackPlugins siteIds={ [ siteId ] } /> }
 			<NavTabs label={ translate( 'Stats' ) }>
 				<NavItem path={ '/stats/insights' + siteFragment } selected={ section === 'insights' }>
 					{ sectionTitles.insights }
@@ -45,25 +63,18 @@ const StatsNavigation = ( props ) => {
 					{ sectionTitles.year }
 				</NavItem>
 			</NavTabs>
+			{ statsControl }
 			<FollowersCount />
 		</SectionNav>
 	);
 };
 
 StatsNavigation.propTypes = {
+	isJetpack: PropTypes.bool,
+	isWooConnect: PropTypes.bool,
 	section: PropTypes.string.isRequired,
 	slug: PropTypes.string,
+	siteId: PropTypes.number,
 };
 
-const connectComponent = connect(
-	state => {
-		return {
-			slug: getSelectedSiteSlug( state )
-		};
-	}
-);
-
-export default flowRight(
-	connectComponent,
-	localize
-)( StatsNavigation );
+export default localize( StatsNavigation );

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -40,6 +40,14 @@
 	}
 }
 
+.stats-navigation__control {
+	margin-right: 16px;
+
+	@include breakpoint( "<480px" ) {
+		margin-right: 0;
+	}
+}
+
 // Welcome Stats message
 // -- extends .welcome-message /assets/stylesheets/shared/welcome.scss
 

--- a/config/development.json
+++ b/config/development.json
@@ -153,7 +153,7 @@
 		"upgrades/presale-chat": true,
 		"webpack/persistent-caching": false,
 		"woocommerce/extension-dashboard": true,
-		"woocommerce/extension-stats": true,
+		"woocommerce/extension-stats": false,
 		"wp-login": true
 	}
 }


### PR DESCRIPTION
Create a way to toggle between Store Stats and Site stats for jetpack enabled stores with WooCommerce plugin. These changes provides a link to `/store/stats`.

Depends on https://github.com/Automattic/wp-calypso/pull/12940

### Before
![screen shot 2017-04-12 at 12 21 26 pm](https://cloud.githubusercontent.com/assets/1922453/24936104/a02b39b4-1f7a-11e7-80ee-336a8cbe6158.png)

### After
![screen shot 2017-04-10 at 11 52 41 am](https://cloud.githubusercontent.com/assets/1922453/24936084/74c392da-1f7a-11e7-9db6-396291fe01dd.png)

### Notes
* This pill control is hidden behind the turned off feature flag `woocommerce/extension-stats`
* Designs for this function are not final. cc @raoulwegat @olaolusoga 

### Test
* `ENABLE_FEATURES=woocommerce/extension-stats make run`
* Navigate to `http://calypso.localhost:3000/stats/day/my-cool-website.com`, but will only work if https://github.com/Automattic/wp-calypso/pull/12940 is merged.

Fixes https://github.com/Automattic/wp-calypso/issues/12971
