### PR TITLE
Data Layer: Allow setting `apiNamespace` in requests

### DIFF
--- a/client/state/data-layer/wpcom-http/actions.js
+++ b/client/state/data-layer/wpcom-http/actions.js
@@ -4,23 +4,30 @@
 import { WPCOM_HTTP_REQUEST } from 'state/action-types';
 
 /**
+ * @typedef {Object} RequestDescription
+ * @property {?String} apiVersion specific API version for request
+ * @property {?String} apiNamespace specific API namespace for request (preferred over version)
+ * @property {?Object} body JSON-serializable body for POST requests
+ * @property {string} method name of HTTP method to use
+ * @property {string} path WordPress.com API path with %s and %d placeholders, e.g. /sites/%s
+ * @property {?Object} query key/value pairs for query string
+ * @property {?FormData} formData key/value pairs for POST body, encoded as "multipart/form-data"
+ * @property {?Object} onSuccess Redux action to call when request succeeds
+ * @property {?Object} onFailure Redux action to call when request fails
+ * @property {?Object} onProgress Redux action to call on progress events from an upload
+ * @property {?Object} options extra options to send to the middleware, e.g. retry policy or offline policy
+ */
+
+/**
  * Returns a valid WordPress.com API HTTP Request action object
  *
- * @param {string} [apiVersion] specific API version for request
- * @param {Object} [body] JSON-serializable body for POST requests
- * @param {string} method name of HTTP method to use
- * @param {string} path WordPress.com API path with %s and %d placeholders, e.g. /sites/%s
- * @param {Object} [query] key/value pairs for query string
- * @param {FormData} [formData] key/value pairs for POST body, encoded as "multipart/form-data"
- * @param {Object} [onSuccess] Redux action to call when request succeeds
- * @param {Object} [onFailure] Redux action to call when request fails
- * @param {Object} [onProgress] Redux action to call on progress events from an upload
- * @param {Object} [options] extra options to send to the middleware, e.g. retry policy or offline policy
- * @param {Object} [action] default action to call on HTTP events
+ * @param {RequestDescription} HTTP request description
+ * @param {?Object} action default action to call on HTTP events
  * @returns {Object} Redux action describing WordPress.com API HTTP request
  */
 export const http = ( {
-	apiVersion = 'v1',
+	apiVersion,
+	apiNamespace,
 	body,
 	method,
 	path,
@@ -30,15 +37,21 @@ export const http = ( {
 	onFailure,
 	onProgress,
 	...options,
-}, action = null ) => ( {
-	type: WPCOM_HTTP_REQUEST,
-	body,
-	method,
-	path,
-	query: method === 'GET' ? { ...query, apiVersion } : { apiVersion },
-	formData,
-	onSuccess: onSuccess || action,
-	onFailure: onFailure || action,
-	onProgress: onProgress || action,
-	options,
-} );
+}, action = null ) => {
+	const version = apiNamespace
+		? { apiNamespace }
+		: { apiVersion };
+
+	return {
+		type: WPCOM_HTTP_REQUEST,
+		body,
+		method,
+		path,
+		query: method === 'GET' ? { ...query, ...version } : version,
+		formData,
+		onSuccess: onSuccess || action,
+		onFailure: onFailure || action,
+		onProgress: onProgress || action,
+		options,
+	};
+};

--- a/client/state/data-layer/wpcom-http/test/actions.js
+++ b/client/state/data-layer/wpcom-http/test/actions.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { http } from '../actions';
+
+const version = 'query.apiVersion';
+const namespace = 'query.apiNamespace';
+
+describe( '#http', () => {
+	it( 'should set the apiVersion', () => {
+		const request = http( { apiVersion: 'v1' } );
+
+		expect( request ).to.have.deep.property( version, 'v1' );
+		expect( request ).to.not.have.deep.property( namespace );
+	} );
+
+	it( 'should set the apiNamespace', () => {
+		const request = http( { apiNamespace: 'wpcom/v1' } );
+
+		expect( request ).to.not.have.deep.property( version );
+		expect( request ).to.have.deep.property( namespace, 'wpcom/v1' );
+	} );
+
+	it( 'should prefer apiNamespace when apiVersion is also given', () => {
+		const request = http( { apiVersion: 'v1', apiNamespace: 'wpcom/v1' } );
+
+		expect( request ).to.not.have.deep.property( version );
+		expect( request ).to.have.deep.property( namespace, 'wpcom/v1' );
+	} );
+} );


### PR DESCRIPTION
See #10942
Replaces #11280

Certain API requests need to specify an `apiNamespace` query parameter
which is used to dispatch the request on the WordPress.com servers to
the right kind of API: WordPress.com API, WordPress wp-api, etc...

This change introduces the new parameter and checks to make sure that we
don't accidentally set both values. Previously in #10942 this
duplication happened and all requests in the HTTP layer failed.

This PR is much less ambitious than #11280 which builds a request
validation service into the HTTP layer itself. This merely adds the
parameter and safety check in `actions#http()` but that seems sufficient
for now and it leaves further validation up to `wpcom.js` down the line.

**Testing**

Nothing currently uses the `apiNamespace` in the data layer (because this introduces it) but to test we should smoke-test the existing stuff. Reader tag lists and the plans page is a good test.

cc: @retrofox @gwwar @samouri 

P.S. It was my intention to build on the work @retrofox did in #11280 but I felt like the changes were much bigger than we needed and this is a nice incremental approach without introducing a lot more.