### PR TITLE
Purchases: Update Tracks events on cancellation survey

### DIFF
--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -81,15 +81,26 @@ class CancelPurchaseButton extends Component {
 		} );
 	}
 
+	recordSurveyStepChange = ( currentStep, nextStep, finalStep ) => {
+		if ( nextStep === 1 ) {
+			this.recordEvent( 'calypso_purchases_cancel_survey_step', { new_step: 'initial_step' } );
+		} else if ( nextStep === 2 && finalStep === 3 ) {
+			this.recordEvent( 'calypso_purchases_cancel_survey_step', { new_step: 'concierge_step' } );
+		} else {
+			this.recordEvent( 'calypso_purchases_cancel_survey_step', { new_step: 'cancellation_step' } );
+		}
+	}
+
 	changeSurveyStep = ( direction ) => {
 		const { purchase } = this.props;
-		let newStep;
+		let newStep, finalStep;
 
 		if ( purchase && isBusiness( purchase ) &&
 			this.state.survey.questionOneRadio === 'tooHard' &&
 			abtest( 'conciergeOfferOnCancel' ) === 'showConciergeOffer'
 		) {
-			this.setState( { finalStep: 3 } );
+			finalStep = 3;
+			this.setState( { finalStep: finalStep } );
 
 			switch ( this.state.surveyStep ) {
 				case 1:
@@ -106,12 +117,12 @@ class CancelPurchaseButton extends Component {
 					break;
 			}
 		} else {
-			this.setState( { finalStep: 2 } );
+			finalStep = 2;
 			newStep = this.state.surveyStep === 1 ? 2 : 1;
+			this.setState( { finalStep: finalStep } );
 		}
 
-		this.recordEvent( 'calypso_purchases_cancel_survey_step', { new_step: newStep } );
-
+		this.recordSurveyStepChange( this.state.surveyStep, newStep, finalStep );
 		this.setState( { surveyStep: newStep } );
 	}
 

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -114,15 +114,26 @@ const RemovePurchase = React.createClass( {
 		this.setState( { isDialogVisible: false } );
 	},
 
+	recordSurveyStepChange( currentStep, nextStep, finalStep ) {
+		if ( nextStep === 1 ) {
+			this.recordEvent( 'calypso_purchases_cancel_survey_step', { new_step: 'initial_step' } );
+		} else if ( nextStep === 2 && finalStep === 3 ) {
+			this.recordEvent( 'calypso_purchases_cancel_survey_step', { new_step: 'concierge_step' } );
+		} else {
+			this.recordEvent( 'calypso_purchases_cancel_survey_step', { new_step: 'cancellation_step' } );
+		}
+	},
+
 	changeSurveyStep( direction ) {
 		const purchase = getPurchase( this.props );
-		let newStep;
+		let newStep, finalStep;
 
 		if ( purchase && isBusiness( purchase ) &&
 			this.state.survey.questionOneRadio === 'tooHard' &&
 			abtest( 'conciergeOfferOnCancel' ) === 'showConciergeOffer'
 		) {
-			this.setState( { finalStep: 3 } );
+			finalStep = 3;
+			this.setState( { finalStep: finalStep } );
 
 			switch ( this.state.surveyStep ) {
 				case 1:
@@ -139,11 +150,12 @@ const RemovePurchase = React.createClass( {
 					break;
 			}
 		} else {
-			this.setState( { finalStep: 2 } );
+			finalStep = 2;
 			newStep = this.state.surveyStep === 1 ? 2 : 1;
+			this.setState( { finalStep: finalStep } );
 		}
 
-		this.recordEvent( 'calypso_purchases_cancel_form_step', { new_step: newStep } );
+		this.recordSurveyStepChange( this.state.surveyStep, newStep, finalStep );
 		this.setState( { surveyStep: newStep } );
 	},
 


### PR DESCRIPTION
Currently, we're using numerical steps to measure progress through the cancellation form. Following #12711 though, the number of total steps in the survey could either be 2 or 3 making it difficult to run funnels using step numbers.

This PR changes the step names to use string values instead to indicate the upcoming step:

- `initial_step` - the first step in the cancellation survey
- `concierge_step` - where we offer the Business 1:1 for Business users
- `cancellation_step` - the final step where they can cancel their plan

In the long run, I think this will reduce confusion and make it easier to measure stats on the effectiveness of Business 1:1s for example.

## To test
1. Run `localStorage.setItem('debug', 'calypso:analytics*');` in your console. This logs events when you're in dev.
2. With a Business plan on your site, navigate to http://calypso.localhost:3000/me/purchases
3. Try to remove a Business plan. Choose "Too Hard" on the initial question to trigger the Business Onboarding offer. Verify all steps are recorded appropriately. This is specifically for the `calypso_purchases_cancel_survey_step` event.

@markryall I'll wait for you to merge #12713 and deal with any merge conflicts on my side.