### PR TITLE
Data Layer: Fix POST-ing `formData` with an `apiVersion` while introducing `apiNamespace`

### DIFF
--- a/client/state/data-layer/wpcom-http/actions.js
+++ b/client/state/data-layer/wpcom-http/actions.js
@@ -28,7 +28,7 @@ import { WPCOM_HTTP_REQUEST } from 'state/action-types';
 export const http = ( {
 	apiVersion,
 	apiNamespace,
-	body,
+	body = {},
 	method,
 	path,
 	query = {},
@@ -47,7 +47,7 @@ export const http = ( {
 		body,
 		method,
 		path,
-		query: method === 'GET' ? { ...query, ...version } : version,
+		query: { ...query, ...version },
 		formData,
 		onSuccess: onSuccess || action,
 		onFailure: onFailure || action,


### PR DESCRIPTION
Ok so this started as part of my trial where I need to use the `wp/v2` namespace: #12733.

I initially figured it was just a matter of adding `apiNamespace` in the `http` action creator and quickly ended up in the deep hole of understanding why we weren't passing `query` for `POST`: https://github.com/Automattic/wp-calypso/blob/master/client/state/data-layer/wpcom-http/actions.js#L38

I just saw @dmsnell approach in #13022 which probably is better as we're passing only one of `apiNamespace` / `apiVersion`, but I still feel like there is value in 976dec9 and f4e4115, 		33c7293 is included as context for why I ended up here :) I am pretty sure #12839 breaks what #12135 tried to do.