### PR TITLE
Sites: Remove unused methods from JetpackSite.prototype

### DIFF
--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -262,24 +262,6 @@ JetpackSite.prototype.updateMonitorSettings = function( emailNotifications, wpNo
 	}.bind( this ) );
 };
 
-JetpackSite.prototype.fetchSshCredentials = function( callback ) {
-	wpcom.undocumented().site( this.ID ).sshCredentialsMine( {}, function( error, data ) {
-		this.emit( 'change' );
-
-		if ( error ) {
-			debug( 'error fetching SSH from api', error );
-			callback && callback( error );
-			return;
-		}
-
-		debug( 'retrieved SSH credentials', data );
-
-		callback && callback( null, data );
-	}.bind( this ) );
-
-	this.emit( 'change' );
-};
-
 JetpackSite.prototype.updateSshCredentials = function( query, callback ) {
 	wpcom.undocumented().site( this.ID ).sshCredentialsNew( query, function( error, data ) {
 		this.emit( 'change' );

--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -292,13 +292,4 @@ JetpackSite.prototype.setOption = function( query, callback ) {
 	this.emit( 'change' );
 };
 
-JetpackSite.prototype.fetchJetpackKeys = function( callback ) {
-	wpcom.undocumented().fetchJetpackKeys( this.ID, function( error, data ) {
-		if ( error ) {
-			debug( 'error getting Jetpack registration keys', error );
-		}
-		callback && callback( error, data );
-	}.bind( this ) );
-};
-
 module.exports = JetpackSite;

--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -262,24 +262,6 @@ JetpackSite.prototype.updateMonitorSettings = function( emailNotifications, wpNo
 	}.bind( this ) );
 };
 
-JetpackSite.prototype.toggleSshScan = function( query, callback ) {
-	wpcom.undocumented().site( this.ID ).sshScanToggle( query, function( error, data ) {
-		this.emit( 'change' );
-
-		if ( error ) {
-			debug( 'error toggling SSH scan', error );
-			callback && callback( error );
-			return;
-		}
-
-		debug( 'toggled SSH scan', data );
-
-		callback && callback( null, data );
-	}.bind( this ) );
-
-	this.emit( 'change' );
-};
-
 JetpackSite.prototype.fetchSshCredentials = function( callback ) {
 	wpcom.undocumented().site( this.ID ).sshCredentialsMine( {}, function( error, data ) {
 		this.emit( 'change' );

--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -196,18 +196,6 @@ JetpackSite.prototype.callHome = function() {
 	}.bind( this ) );
 };
 
-JetpackSite.prototype.deactivateModule = function( moduleId, callback ) {
-	debug( 'deactivate module', moduleId );
-
-	if ( ! this.isModuleActive( moduleId ) ) {
-		// Nothing to do
-		callback();
-		return;
-	}
-
-	this.toggleModule( moduleId, callback );
-};
-
 JetpackSite.prototype.toggleModule = function( moduleId, callback ) {
 	const isActive = this.isModuleActive( moduleId ),
 		method = isActive ? 'jetpackModulesDeactivate' : 'jetpackModulesActivate',

--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -196,23 +196,6 @@ JetpackSite.prototype.callHome = function() {
 	}.bind( this ) );
 };
 
-JetpackSite.prototype.activateModule = function( moduleId, callback ) {
-	debug( 'activate module', moduleId );
-
-	if ( ! moduleId ) {
-		callback && callback( new Error( 'No id' ) );
-		return;
-	}
-
-	if ( this.isModuleActive( moduleId ) ) {
-		// Nothing to do
-		callback();
-		return;
-	}
-
-	this.toggleModule( moduleId, callback );
-};
-
 JetpackSite.prototype.deactivateModule = function( moduleId, callback ) {
 	debug( 'deactivate module', moduleId );
 

--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -262,24 +262,6 @@ JetpackSite.prototype.updateMonitorSettings = function( emailNotifications, wpNo
 	}.bind( this ) );
 };
 
-JetpackSite.prototype.updateSshCredentials = function( query, callback ) {
-	wpcom.undocumented().site( this.ID ).sshCredentialsNew( query, function( error, data ) {
-		this.emit( 'change' );
-
-		if ( error ) {
-			debug( 'error updating SSH credentials', error );
-			callback && callback( error );
-			return;
-		}
-
-		debug( 'updated SSH credentials', data );
-
-		callback && callback( null, data );
-	}.bind( this ) );
-
-	this.emit( 'change' );
-};
-
 JetpackSite.prototype.getOption = function( query, callback ) {
 	wpcom.undocumented().site( this.ID ).getOption( query, function( error, data ) {
 		this.emit( 'change' );


### PR DESCRIPTION
We're in the process of migrating `JetpackSite` to Redux. I noticed that there are several methods that are no longer used, therefore they can be removed and we will not need to migrate them. Essentially, that's what this PR suggests.

This PR should not be introducing any changes, since it only removes unused code. So instead of testing it, just verify that the methods we're removing here are indeed no longer used:

* `activateModule`
* `deactivateModule`
* `toggleSshScan`
* `fetchSshCredentials`
* `updateSshCredentials`
* `fetchJetpackKeys`

Fixes #13027.