### PR TITLE
Ensure user data is actually cleared before logging out

### DIFF
--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -222,7 +222,12 @@ User.prototype.isRTL = function() {
 	return isRTL;
 };
 
-User.prototype.clear = function() {
+/**
+ * Clear any user data.
+ *
+ * @param {function}  onClear called when data has been cleared
+ */
+User.prototype.clear = function( onClear ) {
 	/**
 	 * Clear internal user data and empty localStorage cache
 	 * to discard any user reference that the application may hold
@@ -231,7 +236,7 @@ User.prototype.clear = function() {
 	delete this.settings;
 	store.clear();
 	if ( config.isEnabled( 'persist-redux' ) ) {
-		localforage.removeItem( 'redux-state' );
+		localforage.removeItem( 'redux-state', onClear );
 	}
 };
 

--- a/client/lib/user/utils.js
+++ b/client/lib/user/utils.js
@@ -55,14 +55,10 @@ var userUtils = {
 	},
 
 	logout: function( redirect ) {
-		var logoutUrl = userUtils.getLogoutUrl( redirect );
+		const logoutUrl = userUtils.getLogoutUrl( redirect );
 
 		// Clear any data stored locally within the user data module or localStorage
-		user.clear();
-		debug( 'User stored data cleared' );
-
-		// Forward user to WordPress.com to be logged out
-		location.href = logoutUrl;
+		user.clear( () => location.href = logoutUrl );
 	},
 
 	getLocaleSlug: function() {


### PR DESCRIPTION
Fixes #11766

Supply redirect func as a callback to the async localforage call that clears the persisted state. Seems that previously, the redirect was occurring before the persisted data was cleared.

**To Test**
* Sign out of Calypso and check that the `redux-state` item in indexedDB has actually been removed
