### PR TITLE
State: Include updates in sites, update sites/updates reducer

### DIFF
--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -57,7 +57,8 @@ export const sitesSchema = {
 						is_free: { type: 'boolean' }
 					}
 				},
-				single_user_site: { type: 'boolean' }
+				single_user_site: { type: 'boolean' },
+				updates: { type: 'object' },
 			}
 		}
 	},

--- a/client/state/sites/updates/reducer.js
+++ b/client/state/sites/updates/reducer.js
@@ -25,6 +25,10 @@ import { itemsSchema } from './schema';
 
 const receiveUpdatesForSites = ( state, sites ) => {
 	return reduce( sites, ( memo, site ) => {
+		if ( memo === state ) {
+			memo = { ...state };
+		}
+
 		if ( site.updates ) {
 			memo[ site.ID ] = site.updates;
 		}

--- a/client/state/sites/updates/reducer.js
+++ b/client/state/sites/updates/reducer.js
@@ -34,7 +34,7 @@ const receiveUpdatesForSites = ( state, sites ) => {
 export const items = createReducer(
 	{},
 	{
-		[ SITE_UPDATES_RECEIVE ]: ( state, { siteId, updates } ) => Object.assign( {}, state, { [ siteId ]: updates } ),
+		[ SITE_UPDATES_RECEIVE ]: ( state, { siteId, updates } ) => ( { ...state, [ siteId ]: updates } ),
 		[ SITE_RECEIVE ]: ( state, { site } ) => receiveUpdatesForSites( state, [ site ] ),
 		[ SITES_RECEIVE ]: ( state, { sites } ) => receiveUpdatesForSites( state, sites ),
 		[ SITES_UPDATE ]: ( state, { sites } ) => receiveUpdatesForSites( state, sites ),

--- a/client/state/sites/updates/reducer.js
+++ b/client/state/sites/updates/reducer.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
+import { reduce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -9,6 +10,9 @@ import { combineReducers } from 'redux';
 import { createReducer } from 'state/utils';
 
 import {
+	SITE_RECEIVE,
+	SITES_RECEIVE,
+	SITES_UPDATE,
 	SITE_UPDATES_RECEIVE,
 	SITE_UPDATES_REQUEST,
 	SITE_UPDATES_REQUEST_SUCCESS,
@@ -19,9 +23,24 @@ import {
 
 import { itemsSchema } from './schema';
 
+const receiveUpdatesForSites = ( state, sites ) => {
+	return reduce( sites, ( memo, site ) => {
+		if ( site.updates ) {
+			memo[ site.ID ] = site.updates;
+		}
+
+		return memo;
+	}, state );
+};
+
 export const items = createReducer(
 	{},
-	{ [ SITE_UPDATES_RECEIVE ]: ( state, { siteId, updates } ) => Object.assign( {}, state, { [ siteId ]: updates } ) },
+	{
+		[ SITE_UPDATES_RECEIVE ]: ( state, { siteId, updates } ) => Object.assign( {}, state, { [ siteId ]: updates } ),
+		[ SITE_RECEIVE ]: ( state, { site } ) => receiveUpdatesForSites( state, [ site ] ),
+		[ SITES_RECEIVE ]: ( state, { sites } ) => receiveUpdatesForSites( state, sites ),
+		[ SITES_UPDATE ]: ( state, { sites } ) => receiveUpdatesForSites( state, sites ),
+	},
 	itemsSchema
 );
 

--- a/client/state/sites/updates/reducer.js
+++ b/client/state/sites/updates/reducer.js
@@ -48,20 +48,11 @@ export const items = createReducer(
 	itemsSchema
 );
 
-export const requesting = ( state = false, { type } ) => {
-	switch ( type ) {
-		case SITE_UPDATES_REQUEST:
-		case SITE_UPDATES_REQUEST_SUCCESS:
-		case SITE_UPDATES_REQUEST_FAILURE:
-			return type === SITE_UPDATES_REQUEST;
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return false;
-	}
-
-	return state;
-};
+export const requesting = createReducer( {}, {
+	[ SITE_UPDATES_REQUEST ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: true } ),
+	[ SITE_UPDATES_REQUEST_SUCCESS ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
+	[ SITE_UPDATES_REQUEST_FAILURE ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
+} );
 
 export const errors = ( state = false, { type } ) => {
 	switch ( type ) {

--- a/client/state/sites/updates/reducer.js
+++ b/client/state/sites/updates/reducer.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import { isEmpty } from 'lodash';
+import { isEmpty, stubFalse, stubTrue } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { createReducer, keyedReducer } from 'state/utils';
 
 import {
 	SITE_RECEIVE,
@@ -42,17 +42,17 @@ export const items = createReducer(
 	itemsSchema
 );
 
-export const requesting = createReducer( {}, {
-	[ SITE_UPDATES_REQUEST ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: true } ),
-	[ SITE_UPDATES_REQUEST_SUCCESS ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
-	[ SITE_UPDATES_REQUEST_FAILURE ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
-} );
+export const requesting = keyedReducer( 'siteId', createReducer( undefined, {
+	[ SITE_UPDATES_REQUEST ]: stubTrue,
+	[ SITE_UPDATES_REQUEST_SUCCESS ]: stubFalse,
+	[ SITE_UPDATES_REQUEST_FAILURE ]: stubFalse,
+} ) );
 
-export const errors = createReducer( {}, {
-	[ SITE_UPDATES_REQUEST ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
-	[ SITE_UPDATES_REQUEST_SUCCESS ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
-	[ SITE_UPDATES_REQUEST_FAILURE ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: true } ),
-} );
+export const errors = keyedReducer( 'siteId', createReducer( undefined, {
+	[ SITE_UPDATES_REQUEST ]: stubFalse,
+	[ SITE_UPDATES_REQUEST_SUCCESS ]: stubFalse,
+	[ SITE_UPDATES_REQUEST_FAILURE ]: stubTrue,
+} ) );
 
 export default combineReducers( {
 	items,

--- a/client/state/sites/updates/reducer.js
+++ b/client/state/sites/updates/reducer.js
@@ -17,8 +17,6 @@ import {
 	SITE_UPDATES_REQUEST,
 	SITE_UPDATES_REQUEST_SUCCESS,
 	SITE_UPDATES_REQUEST_FAILURE,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 
 import { itemsSchema } from './schema';
@@ -54,22 +52,11 @@ export const requesting = createReducer( {}, {
 	[ SITE_UPDATES_REQUEST_FAILURE ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
 } );
 
-export const errors = ( state = false, { type } ) => {
-	switch ( type ) {
-		case SITE_UPDATES_REQUEST:
-		case SITE_UPDATES_REQUEST_SUCCESS:
-			return false;
-
-		case SITE_UPDATES_REQUEST_FAILURE:
-			return true;
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return false;
-	}
-
-	return state;
-};
+export const errors = createReducer( {}, {
+	[ SITE_UPDATES_REQUEST ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
+	[ SITE_UPDATES_REQUEST_SUCCESS ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: false } ),
+	[ SITE_UPDATES_REQUEST_FAILURE ]: ( state, { siteId } ) => ( { ...state, [ siteId ]: true } ),
+} );
 
 export default combineReducers( {
 	items,

--- a/client/state/sites/updates/reducer.js
+++ b/client/state/sites/updates/reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import { reduce } from 'lodash';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,17 +22,13 @@ import {
 import { itemsSchema } from './schema';
 
 const receiveUpdatesForSites = ( state, sites ) => {
-	return reduce( sites, ( memo, site ) => {
-		if ( memo === state ) {
-			memo = { ...state };
-		}
-
-		if ( site.updates ) {
-			memo[ site.ID ] = site.updates;
-		}
-
-		return memo;
-	}, state );
+	const updatedSites = sites.filter( ( site ) => site.updates );
+	return isEmpty( updatedSites )
+		? state
+		: sites.reduce( ( newState, site ) => {
+			newState[ site.ID ] = site.updates;
+			return newState;
+		}, { ...state } );
 };
 
 export const items = createReducer(

--- a/client/state/sites/updates/schema.js
+++ b/client/state/sites/updates/schema.js
@@ -1,21 +1,17 @@
 export const itemsSchema = {
-	//state.sites.vouchers = {};
 	type: 'object',
 	additionalProperties: false,
 	patternProperties: {
 		'^\\d+$': {
 			type: 'object',
-			items: {
-				type: 'object',
-				properties: {
-					jp_version: { type: 'string' },
-					plugins: { type: 'number' },
-					themes: { type: 'number' },
-					total: { type: 'number' },
-					translations: { type: 'number' },
-					wordress: { type: 'number' },
-					wp_version: { type: 'string' }
-				}
+			properties: {
+				jp_version: { type: 'string' },
+				plugins: { type: 'number' },
+				themes: { type: 'number' },
+				total: { type: 'number' },
+				translations: { type: 'number' },
+				wordress: { type: 'number' },
+				wp_version: { type: 'string' }
 			}
 		}
 	}

--- a/client/state/sites/updates/test/reducer.js
+++ b/client/state/sites/updates/test/reducer.js
@@ -141,6 +141,15 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		it( 'should not store updates if missing when receiving a site', () => {
+			const state = items( undefined, {
+				type: SITE_RECEIVE,
+				site: { ID: 2916284 }
+			} );
+
+			expect( state ).to.eql( {} );
+		} );
+
 		it( 'should store all updates when receiving sites', () => {
 			const state = items( undefined, {
 				type: SITES_RECEIVE,
@@ -191,6 +200,17 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		it( 'should not store updates if missing when receiving sites', () => {
+			const state = items( undefined, {
+				type: SITES_RECEIVE,
+				sites: [
+					{ ID: 2916284 }
+				]
+			} );
+
+			expect( state ).to.eql( {} );
+		} );
+
 		it( 'should store all updates when updating sites', () => {
 			const state = items( undefined, {
 				type: SITES_UPDATE,
@@ -239,6 +259,17 @@ describe( 'reducer', () => {
 				2916284: someOtherUpdates,
 				77203074: exampleUpdates,
 			} );
+		} );
+
+		it( 'should not store updates if missing when updating sites', () => {
+			const state = items( undefined, {
+				type: SITES_UPDATE,
+				sites: [
+					{ ID: 2916284 }
+				]
+			} );
+
+			expect( state ).to.eql( {} );
 		} );
 
 		it( 'should persist state', () => {

--- a/client/state/sites/updates/test/reducer.js
+++ b/client/state/sites/updates/test/reducer.js
@@ -1,0 +1,403 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { useSandbox } from 'test/helpers/use-sinon';
+import {
+	SITE_RECEIVE,
+	SITES_RECEIVE,
+	SITES_UPDATE,
+	SITE_UPDATES_RECEIVE,
+	SITE_UPDATES_REQUEST,
+	SITE_UPDATES_REQUEST_SUCCESS,
+	SITE_UPDATES_REQUEST_FAILURE,
+	SERIALIZE,
+	DESERIALIZE
+} from 'state/action-types';
+import reducer, { items, requesting, errors } from '../reducer';
+
+describe( 'reducer', () => {
+	useSandbox( ( sandbox ) => {
+		sandbox.stub( console, 'warn' );
+	} );
+
+	it( 'should export expected reducer keys', () => {
+		expect( reducer( undefined, {} ) ).to.have.keys( [
+			'items',
+			'requesting',
+			'errors'
+		] );
+	} );
+
+	describe( '#items()', () => {
+		const exampleUpdates = {
+			plugins: 1,
+			themes: 1,
+			total: 2,
+			translations: 0,
+			wordpress: 0,
+		};
+		const someOtherUpdates = {
+			...exampleUpdates,
+			plugins: 0,
+			total: 1,
+		};
+
+		it( 'should default to an empty object', () => {
+			const state = items( undefined, {} );
+
+			expect( state ).to.eql( {} );
+		} );
+
+		it( 'should store all updates when receiving site updates', () => {
+			const state = items( undefined, {
+				type: SITE_UPDATES_RECEIVE,
+				siteId: 2916284,
+				updates: exampleUpdates,
+			} );
+
+			expect( state ).to.eql( {
+				2916284: exampleUpdates,
+			} );
+		} );
+
+		it( 'should accumulate updates when receiving site updates', () => {
+			const original = deepFreeze( {
+				2916284: exampleUpdates
+			} );
+			const state = items( original, {
+				type: SITE_UPDATES_RECEIVE,
+				siteId: 77203074,
+				updates: exampleUpdates,
+			} );
+
+			expect( state ).to.eql( {
+				2916284: exampleUpdates,
+				77203074: exampleUpdates,
+			} );
+		} );
+
+		it( 'should overwrite updates when receiving site updates', () => {
+			const original = deepFreeze( {
+				2916284: exampleUpdates,
+				77203074: exampleUpdates,
+			} );
+			const state = items( original, {
+				type: SITE_UPDATES_RECEIVE,
+				siteId: 2916284,
+				updates: someOtherUpdates,
+			} );
+
+			expect( state ).to.eql( {
+				2916284: someOtherUpdates,
+				77203074: exampleUpdates,
+			} );
+		} );
+
+		it( 'should store site updates when receiving a site', () => {
+			const state = items( undefined, {
+				type: SITE_RECEIVE,
+				site: { ID: 2916284, updates: exampleUpdates },
+			} );
+
+			expect( state ).to.eql( {
+				2916284: exampleUpdates,
+			} );
+		} );
+
+		it( 'should accumulate site updates when receiving a site', () => {
+			const original = deepFreeze( {
+				2916284: exampleUpdates
+			} );
+			const state = items( original, {
+				type: SITE_RECEIVE,
+				site: { ID: 77203074, updates: exampleUpdates }
+			} );
+
+			expect( state ).to.eql( {
+				2916284: exampleUpdates,
+				77203074: exampleUpdates,
+			} );
+		} );
+
+		it( 'should overwrite site updates when receiving a site', () => {
+			const original = deepFreeze( {
+				2916284: exampleUpdates,
+				77203074: exampleUpdates,
+			} );
+			const state = items( original, {
+				type: SITE_RECEIVE,
+				site: { ID: 2916284, updates: someOtherUpdates }
+			} );
+
+			expect( state ).to.eql( {
+				2916284: someOtherUpdates,
+				77203074: exampleUpdates,
+			} );
+		} );
+
+		it( 'should store all updates when receiving sites', () => {
+			const state = items( undefined, {
+				type: SITES_RECEIVE,
+				sites: [
+					{ ID: 2916284, updates: exampleUpdates },
+					{ ID: 77203074, updates: exampleUpdates }
+				]
+			} );
+
+			expect( state ).to.eql( {
+				2916284: exampleUpdates,
+				77203074: exampleUpdates,
+			} );
+		} );
+
+		it( 'should accumulate updates when receiving sites', () => {
+			const original = deepFreeze( {
+				2916284: exampleUpdates
+			} );
+			const state = items( original, {
+				type: SITES_RECEIVE,
+				sites: [
+					{ ID: 77203074, updates: exampleUpdates }
+				]
+			} );
+
+			expect( state ).to.eql( {
+				2916284: exampleUpdates,
+				77203074: exampleUpdates,
+			} );
+		} );
+
+		it( 'should overwrite updates when receiving sites', () => {
+			const original = deepFreeze( {
+				2916284: exampleUpdates,
+				77203074: exampleUpdates,
+			} );
+			const state = items( original, {
+				type: SITES_RECEIVE,
+				sites: [
+					{ ID: 2916284, updates: someOtherUpdates }
+				]
+			} );
+
+			expect( state ).to.eql( {
+				2916284: someOtherUpdates,
+				77203074: exampleUpdates,
+			} );
+		} );
+
+		it( 'should store all updates when updating sites', () => {
+			const state = items( undefined, {
+				type: SITES_UPDATE,
+				sites: [
+					{ ID: 2916284, updates: exampleUpdates },
+					{ ID: 77203074, updates: exampleUpdates }
+				]
+			} );
+
+			expect( state ).to.eql( {
+				2916284: exampleUpdates,
+				77203074: exampleUpdates,
+			} );
+		} );
+
+		it( 'should accumulate updates when updating sites', () => {
+			const original = deepFreeze( {
+				2916284: exampleUpdates
+			} );
+			const state = items( original, {
+				type: SITES_UPDATE,
+				sites: [
+					{ ID: 77203074, updates: exampleUpdates }
+				]
+			} );
+
+			expect( state ).to.eql( {
+				2916284: exampleUpdates,
+				77203074: exampleUpdates,
+			} );
+		} );
+
+		it( 'should overwrite updates when updating sites', () => {
+			const original = deepFreeze( {
+				2916284: exampleUpdates,
+				77203074: exampleUpdates,
+			} );
+			const state = items( original, {
+				type: SITES_UPDATE,
+				sites: [
+					{ ID: 2916284, updates: someOtherUpdates }
+				]
+			} );
+
+			expect( state ).to.eql( {
+				2916284: someOtherUpdates,
+				77203074: exampleUpdates,
+			} );
+		} );
+
+		it( 'should persist state', () => {
+			const original = deepFreeze( {
+				2916284: exampleUpdates
+			} );
+			const state = items( original, { type: SERIALIZE } );
+
+			expect( state ).to.eql( original );
+		} );
+
+		it( 'should load valid persisted state', () => {
+			const original = deepFreeze( {
+				2916284: exampleUpdates
+			} );
+			const state = items( original, { type: DESERIALIZE } );
+
+			expect( state ).to.eql( original );
+		} );
+
+		it( 'should return initial state when state is invalid', () => {
+			const original = deepFreeze( {
+				2916284: { plugins: false }
+			} );
+			const state = items( original, { type: DESERIALIZE } );
+
+			expect( state ).to.eql( {} );
+		} );
+	} );
+
+	describe( 'requesting()', () => {
+		it( 'should default to an empty object', () => {
+			const state = requesting( undefined, {} );
+
+			expect( state ).to.eql( {} );
+		} );
+
+		it( 'should track site updates request started', () => {
+			const state = requesting( undefined, {
+				type: SITE_UPDATES_REQUEST,
+				siteId: 2916284
+			} );
+
+			expect( state ).to.eql( {
+				2916284: true
+			} );
+		} );
+
+		it( 'should accumulate site updates requests started', () => {
+			const original = deepFreeze( {
+				2916284: true
+			} );
+			const state = requesting( original, {
+				type: SITE_UPDATES_REQUEST,
+				siteId: 77203074
+			} );
+
+			expect( state ).to.eql( {
+				2916284: true,
+				77203074: true
+			} );
+		} );
+
+		it( 'should track site updates request succeeded', () => {
+			const original = deepFreeze( {
+				2916284: true,
+				77203074: true
+			} );
+			const state = requesting( original, {
+				type: SITE_UPDATES_REQUEST_SUCCESS,
+				siteId: 2916284
+			} );
+
+			expect( state ).to.eql( {
+				2916284: false,
+				77203074: true
+			} );
+		} );
+
+		it( 'should track site updates request failed', () => {
+			const original = deepFreeze( {
+				2916284: false,
+				77203074: true
+			} );
+			const state = requesting( original, {
+				type: SITE_UPDATES_REQUEST_FAILURE,
+				siteId: 77203074
+			} );
+
+			expect( state ).to.eql( {
+				2916284: false,
+				77203074: false
+			} );
+		} );
+	} );
+
+	describe( 'errors()', () => {
+		it( 'should default to an empty object', () => {
+			const state = errors( undefined, {} );
+
+			expect( state ).to.eql( {} );
+		} );
+
+		it( 'should track site updates request started', () => {
+			const state = errors( undefined, {
+				type: SITE_UPDATES_REQUEST,
+				siteId: 2916284
+			} );
+
+			expect( state ).to.eql( {
+				2916284: false
+			} );
+		} );
+
+		it( 'should accumulate site updates requests started', () => {
+			const original = deepFreeze( {
+				2916284: false
+			} );
+			const state = errors( original, {
+				type: SITE_UPDATES_REQUEST,
+				siteId: 77203074
+			} );
+
+			expect( state ).to.eql( {
+				2916284: false,
+				77203074: false
+			} );
+		} );
+
+		it( 'should track site updates request succeeded', () => {
+			const original = deepFreeze( {
+				2916284: true,
+				77203074: true
+			} );
+			const state = errors( original, {
+				type: SITE_UPDATES_REQUEST_SUCCESS,
+				siteId: 2916284
+			} );
+
+			expect( state ).to.eql( {
+				2916284: false,
+				77203074: true
+			} );
+		} );
+
+		it( 'should track site updates request failed', () => {
+			const original = deepFreeze( {
+				2916284: false,
+				77203074: false
+			} );
+			const state = errors( original, {
+				type: SITE_UPDATES_REQUEST_FAILURE,
+				siteId: 77203074
+			} );
+
+			expect( state ).to.eql( {
+				2916284: false,
+				77203074: true
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
Currently, `/me/sites/` gives us `updates` for Jetpack sites. However, we simply disregard it right now.

This PR adds `updates` to the sites schema, so it will be included in the Redux site objects. Also, it removes the entire `sites/updates` tree and the `QuerySiteUpdates` query component, as they'll be unnecessary now that we'll contain updates information in `sites`. We can safely remove this subtree and this component, because they're not used anywhere yet.

To test:
* Checkout this branch
* Verify all sites tests pass:

```
npm run test-client client/state/sites/
```