### PR TITLE
State: Add more Jetpack computed attributes to sites

### DIFF
--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -83,6 +83,9 @@ export function getJetpackComputedAttributes( state, siteId ) {
 		hasMinimumJetpackVersion: siteHasMinimumJetpackVersion( state, siteId ),
 		canAutoupdateFiles: canJetpackSiteAutoUpdateFiles( state, siteId ),
 		canUpdateFiles: canJetpackSiteUpdateFiles( state, siteId ),
+		canManage: canJetpackSiteManage( state, siteId ),
+		isMainNetworkSite: isJetpackSiteMainNetworkSite( state, siteId ),
+		isSecondaryNetworkSite: isJetpackSiteSecondaryNetworkSite( state, siteId ),
 	};
 }
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -2485,6 +2485,9 @@ describe( 'selectors', () => {
 			expect( noNewAttributes.hasMinimumJetpackVersion ).to.equal( undefined );
 			expect( noNewAttributes.canAutoupdateFiles ).to.equal( undefined );
 			expect( noNewAttributes.canUpdateFiles ).to.equal( undefined );
+			expect( noNewAttributes.canManage ).to.equal( undefined );
+			expect( noNewAttributes.isMainNetworkSite ).to.equal( undefined );
+			expect( noNewAttributes.isSecondaryNetworkSite ).to.equal( undefined );
 		} );
 
 		it( 'should return exists for attributes if a site is Jetpack', () => {
@@ -2502,6 +2505,9 @@ describe( 'selectors', () => {
 			expect( noNewAttributes.hasMinimumJetpackVersion ).to.have.property;
 			expect( noNewAttributes.canAutoupdateFiles ).to.have.property;
 			expect( noNewAttributes.canUpdateFiles ).to.have.property;
+			expect( noNewAttributes.canManage ).to.have.property;
+			expect( noNewAttributes.isMainNetworkSite ).to.have.property;
+			expect( noNewAttributes.isSecondaryNetworkSite ).to.have.property;
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds some more Jetpack computed attributes that we'll need with our migration away from `sites-list`. When being migrated, usages of these will have to be updated to use attributes, instead of methods (previously they were methods of `JetpackSite` - see https://github.com/Automattic/wp-calypso/blob/master/client/lib/site/jetpack.js).

To test:

* Checkout this branch
* Verify all `getJetpackComputedAttributes` tests pass:

```
npm run test-client client/state/sites/test/selectors.js -- --grep "getJetpackComputedAttributes"
```