### PR TITLE
Reader Manage Following Refresh: add export button

### DIFF
--- a/client/blocks/reader-export-button/README.md
+++ b/client/blocks/reader-export-button/README.md
@@ -1,3 +1,9 @@
 # Reader Export Button
 
 Allows a Reader user to export their subscriptions in OPML format.
+
+## Props
+
+| Prop | Type | Required | Description |
+|-----|:----:|:--------:|-------------|
+| `saveAs`| String | No | The filename to use when saving the export - defaults to wpcom-subscriptions.opml |

--- a/client/blocks/reader-export-button/index.jsx
+++ b/client/blocks/reader-export-button/index.jsx
@@ -3,26 +3,23 @@
  */
 import React from 'react';
 import Blob from 'blob';
-import { noop } from 'lodash';
 import { saveAs } from 'browser-filesaver';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import wpcom from 'lib/wp';
+import { errorNotice } from 'state/notices/actions';
 
 class ReaderExportButton extends React.Component {
 	static propTypes = {
-		onError: React.PropTypes.func,
-		onExport: React.PropTypes.func,
-		saveAs: React.PropTypes.string
+		saveAs: React.PropTypes.string,
 	}
 
 	static defaultProps = {
-		onError: noop,
-		onExport: noop,
 		saveAs: 'wpcom-subscriptions.opml',
 	}
 
@@ -46,16 +43,14 @@ class ReaderExportButton extends React.Component {
 		} );
 
 		if ( ! err && ! data.success ) {
-			err = new Error( this.props.translate( 'Error exporting Reader feed' ) );
+			this.props.errorNotice(
+				this.props.translate( 'Sorry, there was a problem creating your export file.' )
+			);
+			return;
 		}
 
-		if ( err ) {
-			this.props.onError( err );
-		} else {
-			const blob = new Blob( [ data.opml ], { type: 'text/xml;charset=utf-8' } );
-			saveAs( blob, this.props.saveAs );
-			this.props.onExport( this.props.saveAs );
-		}
+		const blob = new Blob( [ data.opml ], { type: 'text/xml;charset=utf-8' } );
+		saveAs( blob, this.props.saveAs );
 	}
 
 	render() {
@@ -70,4 +65,7 @@ class ReaderExportButton extends React.Component {
 	}
 }
 
-export default localize( ReaderExportButton );
+export default connect(
+	null,
+	{ errorNotice },
+)( localize( ReaderExportButton ) );

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -11,3 +11,11 @@
 	padding-top: 10px;
 	border-top: 1px solid $gray-light;
 }
+
+.following-manage__subscriptions-controls {
+	display: flex;
+
+	.reader-import-button, .reader-export-button {
+		margin-right: 10px;
+	}
+}

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -7,6 +7,7 @@ import React, { Component } from 'react';
  * Internal Dependencies
  */
 import FollowingManageImport from './import';
+import ReaderExportButton from 'blocks/reader-export-button';
 
 class FollowingManageSubscriptions extends Component {
 	render() {
@@ -14,6 +15,7 @@ class FollowingManageSubscriptions extends Component {
 			<div className="following-manage__subscriptions">
 				<div className="following-manage__subscriptions-controls">
 					<FollowingManageImport />
+					<ReaderExportButton />
 				</div>
 			</div>
 		);


### PR DESCRIPTION
Add the new export button block to the new Manage Following at `/following/manage`.

Fixes https://github.com/Automattic/wp-calypso/issues/12958.

<img width="380" alt="screen shot 2017-04-12 at 16 40 58" src="https://cloud.githubusercontent.com/assets/17325/24966441/d8b5cca8-1f9e-11e7-8202-599689ecba2b.png">

### To test

Head to http://calypso.localhost:3000/following/manage, hit 'Export' and verify that you receive a valid OPML file.