### PR TITLE
Plugins: Add UX for AT initiate failure

### DIFF
--- a/client/my-sites/plugins/plugin-automated-transfer/index.jsx
+++ b/client/my-sites/plugins/plugin-automated-transfer/index.jsx
@@ -46,13 +46,13 @@ class PluginAutomatedTransfer extends Component {
 		const { COMPLETE } = transferStates;
 		const {
 			isTransferring,
-			isTransferFailed,
+			isFailedTransfer,
 			transferState,
 		} = this.props;
 
 		if ( COMPLETE === transferState ) {
 			this.setState( { transferComplete: true } );
-		} else if ( isTransferring || isTransferFailed ) {
+		} else if ( isTransferring || isFailedTransfer ) {
 			this.setState( { shouldDisplay: true } );
 		}
 	}
@@ -72,7 +72,7 @@ class PluginAutomatedTransfer extends Component {
 				newState.shouldDisplay = true;
 			}
 		} else if ( ! transferComplete ) {
-			newState.shouldDisplay = nextProps.isTransferring || nextProps.isTransferFailed;
+			newState.shouldDisplay = nextProps.isTransferring || nextProps.isFailedTransfer;
 		}
 
 		this.setState( newState );
@@ -97,26 +97,26 @@ class PluginAutomatedTransfer extends Component {
 	}
 
 	getStatus = () => {
-		const { isTransferFailed } = this.props;
+		const { isFailedTransfer } = this.props;
 		const { clickOutside } = this.state;
 
 		if ( clickOutside ) {
 			return 'is-info';
 		}
-		if ( isTransferFailed ) {
+		if ( isFailedTransfer ) {
 			return 'is-error';
 		}
 		return 'is-info';
 	}
 
 	getIcon = () => {
-		const { isTransferFailed } = this.props;
+		const { isFailedTransfer } = this.props;
 		const { clickOutside } = this.state;
 
 		if ( clickOutside ) {
 			return 'sync';
 		}
-		if ( isTransferFailed ) {
+		if ( isFailedTransfer ) {
 			return 'notice';
 		}
 		return 'sync';
@@ -168,7 +168,7 @@ const mapStateToProps = state => {
 	return {
 		transferState: getAutomatedTransferStatus( state, siteId ),
 		isTransferring: isAutomatedTransferActive( state, siteId ),
-		isTransferFailed: isAutomatedTransferFailed( state, siteId ),
+		isFailedTransfer: isAutomatedTransferFailed( state, siteId ),
 		site: getSite( state, siteId ),
 	};
 };

--- a/client/my-sites/plugins/plugin-automated-transfer/index.jsx
+++ b/client/my-sites/plugins/plugin-automated-transfer/index.jsx
@@ -80,7 +80,7 @@ class PluginAutomatedTransfer extends Component {
 			return translate( "Don't leave quite yet! Just a bit longer." );
 		}
 		if ( transferComplete ) {
-			return translate( 'Activating %(plugin)s...', { args: { plugin: plugin.name } } );
+			return translate( 'Activating %(plugin)s…', { args: { plugin: plugin.name } } );
 		}
 		switch ( transferState ) {
 			case START: return translate( 'Installing %(plugin)s…', { args: { plugin: plugin.name } } );
@@ -137,7 +137,7 @@ class PluginAutomatedTransfer extends Component {
 			<div>
 				<Notice
 					icon={ this.getIcon() }
-					className="plugin-automated-transfer"
+					className="plugin-automated-transfer__notice"
 					showDismiss={ false }
 					status={ this.getStatus() }
 					text={ this.getNoticeText() }

--- a/client/my-sites/plugins/plugin-automated-transfer/style.scss
+++ b/client/my-sites/plugins/plugin-automated-transfer/style.scss
@@ -1,4 +1,4 @@
-.plugin-automated-transfer {
+.plugin-automated-transfer__notice {
 	.gridicons-sync g {
 		animation: spinning-sync-icon linear 2s infinite;
 		transform-origin: center;

--- a/client/state/automated-transfer/constants.js
+++ b/client/state/automated-transfer/constants.js
@@ -1,5 +1,6 @@
 export const transferStates = {
 	INQUIRING: 'inquiring',
+	FAILURE: 'failure',
 	START: 'start',
 	SETUP: 'setup',
 	CONFLICTS: 'conflicts',

--- a/client/state/automated-transfer/reducer.js
+++ b/client/state/automated-transfer/reducer.js
@@ -25,7 +25,7 @@ import {
 export const status = ( state = null, action ) => get( {
 	[ ELIGIBILITY_UPDATE ]: state || transferStates.INQUIRING,
 	[ INITIATE ]: transferStates.START,
-	[ INITIATE_FAILURE ]: transferStates.INQUIRING,
+	[ INITIATE_FAILURE ]: transferStates.FAILURE,
 	[ SET_STATUS ]: action.status,
 	[ TRANSFER_UPDATE ]: 'complete' === action.status ? transferStates.COMPLETE : state,
 }, action.type, state );

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -79,6 +79,7 @@ export isAccountRecoveryResetOptionsReady from './is-account-recovery-reset-opti
 export isActivatingJetpackJumpstart from './is-activating-jetpack-jumpstart';
 export isActivatingJetpackModule from './is-activating-jetpack-module';
 export isAutomatedTransferActive from './is-automated-transfer-active';
+export isAutomatedTransferFailed from './is-automated-transfer-failed';
 export isDeactivatingJetpackJumpstart from './is-deactivating-jetpack-jumpstart';
 export isDeactivatingJetpackModule from './is-deactivating-jetpack-module';
 export isDirectlyFailed from './is-directly-failed';
@@ -126,4 +127,3 @@ export isUpdatingJetpackSettings from './is-updating-jetpack-settings';
 export isUserRegistrationDaysWithinRange from './is-user-registration-days-within-range';
 export shouldCloseVideoEditorModal from './should-close-video-editor-modal';
 export shouldShowVideoEditorError from './should-show-video-editor-error';
-

--- a/client/state/selectors/is-automated-transfer-failed.js
+++ b/client/state/selectors/is-automated-transfer-failed.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import {
+	flowRight as compose,
+} from 'lodash';
+
+/**
+ * Internal Dependencies
+ */
+import { transferStates } from 'state/automated-transfer/constants';
+import { getAutomatedTransferStatus } from 'state/automated-transfer/selectors';
+
+/**
+ * Maps automated transfer status value to indication if transfer is failed
+ *
+ * @param {String} status name of current state in automated transfer
+ * @returns {?boolean} is transfer currently failed? null if unknown
+ */
+export const isFailed = status =>
+	status
+		? status === transferStates.CONFLICTS || status === transferStates.FAILURE
+		: null;
+
+/**
+ * Indicates whether or not an automated transfer is failed for a given site
+ *
+ * @param {Object} state app state
+ * @param {Number} siteId site of interest
+ * @returns {?boolean} whether or not transfer is failed, or null if not known
+ */
+export const isAutomatedTransferFailed = compose(
+	isFailed,
+	getAutomatedTransferStatus,
+);
+
+export default isAutomatedTransferFailed;

--- a/client/state/selectors/test/is-automated-transfer-active.js
+++ b/client/state/selectors/test/is-automated-transfer-active.js
@@ -24,6 +24,7 @@ describe( 'Automated Transfer', () => {
 		it( 'should return `false` for non-active transfer states', () => {
 			expect( isActive( transferStates.COMPLETE ) ).to.be.false;
 			expect( isActive( transferStates.CONFLICTS ) ).to.be.false;
+			expect( isActive( transferStates.FAILURE ) ).to.be.false;
 			expect( isActive( transferStates.INQUIRING ) ).to.be.false;
 		} );
 	} );

--- a/client/state/selectors/test/is-automated-transfer-failed.js
+++ b/client/state/selectors/test/is-automated-transfer-failed.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { transferStates } from 'state/automated-transfer/constants';
+
+import { isFailed } from '../is-automated-transfer-active';
+
+describe( 'Automated Transfer', () => {
+	describe( 'isActive()', () => {
+		it( 'should return `null` if no information is available', () => {
+			expect( isFailed( null ) ).to.be.null;
+			expect( isFailed( '' ) ).to.be.null; // plausible that the status could wind up as an empty string
+		} );
+
+		it( 'should return `true` for active transfer states', () => {
+			expect( isFailed( transferStates.CONFLICTS ) ).to.be.true;
+			expect( isFailed( transferStates.FAILURE ) ).to.be.true;
+		} );
+
+		it( 'should return `false` for non-active transfer states', () => {
+			expect( isFailed( transferStates.COMPLETE ) ).to.be.false;
+			expect( isFailed( transferStates.INQUIRING ) ).to.be.false;
+			expect( isFailed( transferStates.START ) ).to.be.false;
+		} );
+	} );
+} );

--- a/client/state/selectors/test/is-automated-transfer-failed.js
+++ b/client/state/selectors/test/is-automated-transfer-failed.js
@@ -8,21 +8,21 @@ import { expect } from 'chai';
  */
 import { transferStates } from 'state/automated-transfer/constants';
 
-import { isFailed } from '../is-automated-transfer-active';
+import { isFailed } from '../is-automated-transfer-failed';
 
 describe( 'Automated Transfer', () => {
-	describe( 'isActive()', () => {
+	describe( 'isFailed()', () => {
 		it( 'should return `null` if no information is available', () => {
 			expect( isFailed( null ) ).to.be.null;
 			expect( isFailed( '' ) ).to.be.null; // plausible that the status could wind up as an empty string
 		} );
 
-		it( 'should return `true` for active transfer states', () => {
+		it( 'should return `true` for failed transfer states', () => {
 			expect( isFailed( transferStates.CONFLICTS ) ).to.be.true;
 			expect( isFailed( transferStates.FAILURE ) ).to.be.true;
 		} );
 
-		it( 'should return `false` for non-active transfer states', () => {
+		it( 'should return `false` for non-failed transfer states', () => {
 			expect( isFailed( transferStates.COMPLETE ) ).to.be.false;
 			expect( isFailed( transferStates.INQUIRING ) ).to.be.false;
 			expect( isFailed( transferStates.START ) ).to.be.false;


### PR DESCRIPTION
Fix 137-gh-automated-transfer

<img width="627" alt="screen shot 2017-04-12 at 17 49 24" src="https://cloud.githubusercontent.com/assets/2070010/24969588/27b04d9c-1fa9-11e7-8153-1778d1fd5817.png">

- Add a new AT status constant: `FAILURE`.
- Create a new `isAutomatedTransferFailed` selector for when the AT status is either `CONFLICTS` or `FAILURE`.
- Hook the new selector to the `PluginAutomatedTransfer` component, and mostly use it instead of `CONFLICTS === transferState`.
- Map the new `FAILURE` status to a new error message, while retaining the same color and icon of `CONFLICTS`.

---

To be extra clear, the new selector replaces:
```es6
CONFLICTS === transferState
```
with what basically is:
```es6
CONFLICTS === transferState || FAILURE === transferState
```