### PR TITLE
Site Settings: Move Analytics upgrade nudge below header, hide form

### DIFF
--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -107,7 +107,7 @@ class GoogleAnalyticsForm extends Component {
 					</Notice>
 				}
 
-				<SectionHeader label={ translate( 'Analytics Settings' ) }>
+				<SectionHeader label={ translate( 'Analytics settings' ) }>
 					{
 						! showUpgradeNudge &&
 						<Button

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -85,19 +85,6 @@ class GoogleAnalyticsForm extends Component {
 					<QueryJetpackModules siteId={ siteId } />
 				}
 
-				{ showUpgradeNudge &&
-					<Banner
-						description={ siteIsJetpack
-							? translate( 'Upgrade to the Professional Plan and include your own analytics tracking ID.' )
-							: translate( 'Upgrade to the Business Plan and include your own analytics tracking ID.' )
-						}
-						event={ 'google_analytics_settings' }
-						feature={ FEATURE_GOOGLE_ANALYTICS }
-						plan={ PLAN_BUSINESS }
-						title={ translate( 'Add Google Analytics' ) }
-					/>
-				}
-
 				{ isJetpackUnsupported && ! showUpgradeNudge &&
 					<Notice
 						status="is-warning"
@@ -121,70 +108,91 @@ class GoogleAnalyticsForm extends Component {
 				}
 
 				<SectionHeader label={ translate( 'Analytics Settings' ) }>
-					<Button
-						primary
-						compact
-						disabled={ this.isSubmitButtonDisabled() }
-						onClick={ handleSubmitForm }
-					>
-						{
-							isSavingSettings
-									? translate( 'Saving…' )
-									: translate( 'Save Settings' )
-						}
-					</Button>
-				</SectionHeader>
-				<Card className="analytics-settings site-settings__analytics-settings">
-					<fieldset>
-						<FormLabel htmlFor="wgaCode">
-							{ translate( 'Google Analytics Tracking ID', { context: 'site setting' } ) }
-						</FormLabel>
-						<FormTextInput
-							name="wgaCode"
-							id="wgaCode"
-							value={ fields.wga ? fields.wga.code : '' }
-							onChange={ this.handleCodeChange }
-							placeholder={ placeholderText }
-							disabled={ isRequestingSettings || ! enableForm }
-							onClick={ eventTracker( 'Clicked Analytics Key Field' ) }
-							onKeyPress={ uniqueEventTracker( 'Typed In Analytics Key Field' ) }
-							isError={ ! this.state.isCodeValid }
-						/>
-						{
-							! this.state.isCodeValid &&
-							<FormTextValidation isError={ true } text={ translate( 'Invalid Google Analytics Tracking ID.' ) } />
-						}
-						<ExternalLink
-							icon
-							href="https://support.google.com/analytics/answer/1032385?hl=en"
-							target="_blank"
-							rel="noopener noreferrer"
+					{
+						! showUpgradeNudge &&
+						<Button
+							primary
+							compact
+							disabled={ this.isSubmitButtonDisabled() }
+							onClick={ handleSubmitForm }
 						>
-							{ translate( 'Where can I find my Tracking ID?' ) }
-						</ExternalLink>
-					</fieldset>
-					<p>
-						{ translate(
-							'Google Analytics is a free service that complements our {{a}}built-in stats{{/a}} with different insights into your traffic.' +
-							' WordPress.com stats and Google Analytics use different methods to identify and track activity on your site, so they will ' +
-							'normally show slightly different totals for your visits, views, etc.',
 							{
-								components: {
-									a: <a href={ '/stats/' + site.domain } />
+								isSavingSettings
+										? translate( 'Saving…' )
+										: translate( 'Save Settings' )
+							}
+						</Button>
+					}
+				</SectionHeader>
+
+				{ showUpgradeNudge
+					? (
+						<Banner
+							description={ siteIsJetpack
+								? translate( 'Upgrade to the Professional Plan and include your own analytics tracking ID.' )
+								: translate( 'Upgrade to the Business Plan and include your own analytics tracking ID.' )
+							}
+							event={ 'google_analytics_settings' }
+							feature={ FEATURE_GOOGLE_ANALYTICS }
+							plan={ PLAN_BUSINESS }
+							title={ translate( 'Add Google Analytics' ) }
+						/>
+					)
+					: (
+						<Card className="analytics-settings site-settings__analytics-settings">
+							<fieldset>
+								<FormLabel htmlFor="wgaCode">
+									{ translate( 'Google Analytics Tracking ID', { context: 'site setting' } ) }
+								</FormLabel>
+								<FormTextInput
+									name="wgaCode"
+									id="wgaCode"
+									value={ fields.wga ? fields.wga.code : '' }
+									onChange={ this.handleCodeChange }
+									placeholder={ placeholderText }
+									disabled={ isRequestingSettings || ! enableForm }
+									onClick={ eventTracker( 'Clicked Analytics Key Field' ) }
+									onKeyPress={ uniqueEventTracker( 'Typed In Analytics Key Field' ) }
+									isError={ ! this.state.isCodeValid }
+								/>
+								{
+									! this.state.isCodeValid &&
+									<FormTextValidation isError={ true } text={ translate( 'Invalid Google Analytics Tracking ID.' ) } />
 								}
-							}
-						) }
-					</p>
-					<p>
-					{ translate( 'Learn more about using {{a}}Google Analytics with WordPress.com{{/a}}.',
-						{
-							components: {
-								a: <a href={ analyticsSupportUrl } target="_blank" rel="noopener noreferrer" />
-							}
-						}
-					) }
-					</p>
-				</Card>
+								<ExternalLink
+									icon
+									href="https://support.google.com/analytics/answer/1032385?hl=en"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									{ translate( 'Where can I find my Tracking ID?' ) }
+								</ExternalLink>
+							</fieldset>
+							<p>
+								{ translate(
+									'Google Analytics is a free service that complements our {{a}}built-in stats{{/a}} ' +
+									'with different insights into your traffic. WordPress.com stats and Google Analytics ' +
+									'use different methods to identify and track activity on your site, so they will ' +
+									'normally show slightly different totals for your visits, views, etc.',
+									{
+										components: {
+											a: <a href={ '/stats/' + site.domain } />
+										}
+									}
+								) }
+							</p>
+							<p>
+							{ translate( 'Learn more about using {{a}}Google Analytics with WordPress.com{{/a}}.',
+								{
+									components: {
+										a: <a href={ analyticsSupportUrl } target="_blank" rel="noopener noreferrer" />
+									}
+								}
+							) }
+							</p>
+						</Card>
+					)
+				}
 			</form>
 		);
 	}

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -107,7 +107,7 @@ class GoogleAnalyticsForm extends Component {
 					</Notice>
 				}
 
-				<SectionHeader label={ translate( 'Analytics settings' ) }>
+				<SectionHeader label={ translate( 'Google Analytics' ) }>
 					{
 						! showUpgradeNudge &&
 						<Button


### PR DESCRIPTION
This PR fixes a couple of issues that arised with the latest changes in the Traffic settings section:

* Moves the Analytics nudge below the Analytics section header
* Hides the Analytics form if the upgrade nudge is shown.

Preview for a site with non-business plan:

![screenshot from 2017-04-12 20-38-35](https://cloud.githubusercontent.com/assets/8436925/24971379/70a4d2fe-1fc0-11e7-91d8-50f2a47a96c9.png)

Fixes #12265.

To test:
* Checkout this branch
* Go to `/settings/traffic/$site`, where `$site` is a Jetpack site with a Professional plan.
* Verify the Analytics form looks and works properly.
* Go to `/settings/traffic/$site`, where `$site` is a Jetpack site with a non-Professional plan.
* Verify you see the nudge and no form, as on the above screenshot.
* Test the above 2 cases for a WordPress.com site.