### PR TITLE
Reader Fix: Video card titles should wrap to the next line

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -357,6 +357,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	display: flex;
 	flex-direction: row;
 	margin-top: 14px;
+	flex-wrap: wrap;
 
 	.reader-post-card__post-details {
 		flex: 1 auto;


### PR DESCRIPTION
Fix for https://github.com/Automattic/wp-calypso/issues/13051.

@jancavan, I was able to lock it down to this commit: bb77a4ca16d392dce8e920709241ddba9e3caab5

Specifically the removal of the line `flex-wrap: wrap`. 
Do you remember what that was for?