### PR TITLE
WooCommerce: Add currentlyEditing state for products and variations.

### DIFF
--- a/client/extensions/woocommerce/state/products/selectors.js
+++ b/client/extensions/woocommerce/state/products/selectors.js
@@ -1,0 +1,13 @@
+
+/**
+ * Gets product fetched from server.
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} productId Numeric product Id.
+ * @return {Object} Product object from API.
+ */
+export function getProduct( state, productId ) {
+	// TODO: Add fetched product data.
+	return productId === 1 && { id: productId } || undefined;
+}
+

--- a/client/extensions/woocommerce/state/ui/helpers.js
+++ b/client/extensions/woocommerce/state/ui/helpers.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { isNumber } from 'lodash';
+
+/**
+ * Returns an index object to be used for temporary IDs before saving edits to
+ * the server.
+ *
+ * @param {Array} bucketEdits Array of creates or updates.
+ * @return {Object} Index for the next entry.
+ */
+export function nextBucketIndex( bucketEdits ) {
+	return {
+		index: ( bucketEdits || [] ).length
+	};
+}
+
+/**
+ * Returns which bucket should be used when saving edits for a particular object.
+ * @param {Object} object Data object such as product or variation.
+ * @return {String} 'updates' for existing objects, 'creates' for new objects.
+ */
+export function getBucket( object ) {
+	return object && isNumber( object.id ) && 'updates' || 'creates';
+}

--- a/client/extensions/woocommerce/state/ui/products/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/edits-reducer.js
@@ -29,9 +29,14 @@ function editProductAction( edits, action ) {
 
 	const prevEdits = edits || {};
 	const bucket = product && isNumber( product.id ) && 'updates' || 'creates';
-	const _array = editProduct( prevEdits[ bucket ], product, data );
+	const _product = product || { id: { index: ( prevEdits[ bucket ] || [] ).length } };
+	const _array = editProduct( prevEdits[ bucket ], _product, data );
 
-	return { ...prevEdits, [ bucket ]: _array };
+	return {
+		...prevEdits,
+		[ bucket ]: _array,
+		currentlyEditingId: _product.id,
+	};
 }
 
 function editProductAttributeAction( edits, action ) {
@@ -41,21 +46,25 @@ function editProductAttributeAction( edits, action ) {
 	const prevEdits = edits || {};
 	const bucket = product && isNumber( product.id ) && 'updates' || 'creates';
 	const _attributes = editProductAttribute( attributes, attribute, data );
-	const _array = editProduct( prevEdits[ bucket ], product, { attributes: _attributes } );
+	const _product = product || { id: { index: ( prevEdits[ bucket ] || [] ).length } };
+	const _array = editProduct( prevEdits[ bucket ], _product, { attributes: _attributes } );
 
-	return { ...prevEdits, [ bucket ]: _array };
+	return {
+		...prevEdits,
+		[ bucket ]: _array,
+		currentlyEditingId: _product.id,
+	};
 }
 
 function editProduct( array, product, data ) {
 	// Use the existing product id (real or placeholder), or creates.length if no product.
 	const prevArray = array || [];
-	const productId = ( product ? product.id : { index: prevArray.length } );
 
 	let found = false;
 
 	// Look for this object in the appropriate create or edit array first.
 	const _array = prevArray.map( ( p ) => {
-		if ( productId === p.id ) {
+		if ( product.id === p.id ) {
 			found = true;
 			return { ...p, ...data };
 		}
@@ -65,7 +74,7 @@ function editProduct( array, product, data ) {
 
 	if ( ! found ) {
 		// update or create not already in edit state, so add it now.
-		_array.push( { id: productId, ...data } );
+		_array.push( { id: product.id, ...data } );
 	}
 
 	return _array;

--- a/client/extensions/woocommerce/state/ui/products/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/edits-reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isNumber, uniqueId } from 'lodash';
+import { uniqueId } from 'lodash';
 
 /**
  * Internal dependencies
@@ -10,6 +10,7 @@ import {
 	WOOCOMMERCE_EDIT_PRODUCT,
 	WOOCOMMERCE_EDIT_PRODUCT_ATTRIBUTE,
 } from '../../action-types';
+import { nextBucketIndex, getBucket } from '../helpers';
 
 const initialState = null;
 
@@ -28,8 +29,8 @@ function editProductAction( edits, action ) {
 	const { product, data } = action.payload;
 
 	const prevEdits = edits || {};
-	const bucket = product && isNumber( product.id ) && 'updates' || 'creates';
-	const _product = product || { id: { index: ( prevEdits[ bucket ] || [] ).length } };
+	const bucket = getBucket( product );
+	const _product = product || { id: nextBucketIndex( prevEdits[ bucket ] ) };
 	const _array = editProduct( prevEdits[ bucket ], _product, data );
 
 	return {
@@ -44,9 +45,9 @@ function editProductAttributeAction( edits, action ) {
 	const attributes = product && product.attributes;
 
 	const prevEdits = edits || {};
-	const bucket = product && isNumber( product.id ) && 'updates' || 'creates';
+	const bucket = getBucket( product );
 	const _attributes = editProductAttribute( attributes, attribute, data );
-	const _product = product || { id: { index: ( prevEdits[ bucket ] || [] ).length } };
+	const _product = product || { id: nextBucketIndex( prevEdits[ bucket ] ) };
 	const _array = editProduct( prevEdits[ bucket ], _product, { attributes: _attributes } );
 
 	return {

--- a/client/extensions/woocommerce/state/ui/products/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/selectors.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { get, find, isNumber } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getProduct } from '../../products/selectors';
+
+function getEditsState( state ) {
+	const woocommerce = state.extensions.woocommerce;
+	return get( woocommerce, 'ui.products.edits', {} );
+}
+
+/**
+ * Gets the accumulated edits for a product, if any.
+ *
+ * @param {Object} state Global state tree
+ * @param {any} productId The id of the product (or { index: # } )
+ * @return {Object} The current accumulated edits
+ */
+export function getProductEdits( state, productId ) {
+	const edits = getEditsState( state );
+	const bucket = isNumber( productId ) && 'updates' || 'creates';
+	const array = get( edits, bucket, [] );
+
+	return find( array, ( p ) => productId === p.id );
+}
+
+/**
+ * Gets a product with local edits overlayed on top of fetched data.
+ *
+ * @param {Object} state Global state tree
+ * @param {any} productId The id of the product (or { index: # } )
+ * @return {Object} The product data merged between the fetched data and edits
+ */
+export function getProductWithLocalEdits( state, productId ) {
+	const existing = isNumber( productId );
+
+	const product = existing && getProduct( state, productId );
+	const productEdits = getProductEdits( state, productId );
+
+	return ( product || productEdits ) && { ...product, ...productEdits } || undefined;
+}
+
+/**
+ * Gets the product being currently edited in the UI.
+ *
+ * @param {Object} state Global state tree
+ * @return {Object} Product object that is merged between fetched data and edits
+ */
+export function getCurrentlyEditingProduct( state ) {
+	const edits = getEditsState( state ) || {};
+	const { currentlyEditingId } = edits;
+
+	return getProductWithLocalEdits( state, currentlyEditingId );
+}

--- a/client/extensions/woocommerce/state/ui/products/test/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/test/edits-reducer.js
@@ -215,4 +215,26 @@ describe( 'edits-reducer', () => {
 		expect( attribute1.name ).to.eql( 'Attribute One' );
 		expect( attribute2.name ).to.eql( 'Attribute Two' );
 	} );
+
+	it( 'should set currentlyEditingId when editing a new product', () => {
+		const edits1 = reducer( undefined, editProduct( null, {
+			name: 'A new product',
+		} ) );
+
+		expect( edits1.currentlyEditingId ).to.eql( edits1.creates[ 0 ].id );
+
+		const edits2 = reducer( edits1, editProduct( null, {
+			name: 'Second product',
+		} ) );
+
+		expect( edits2.currentlyEditingId ).to.eql( edits2.creates[ 1 ].id );
+	} );
+
+	it( 'should set currentlyEditingId when editing an existing product', () => {
+		const product1 = { id: 1 };
+		const edits1 = reducer( undefined, editProduct( product1, {
+			name: 'First product',
+		} ) );
+		expect( edits1.currentlyEditingId ).to.eql( edits1.updates[ 0 ].id );
+	} );
 } );

--- a/client/extensions/woocommerce/state/ui/products/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/test/selectors.js
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { set } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getProductEdits,
+	getProductWithLocalEdits,
+	getCurrentlyEditingProduct,
+} from '../selectors';
+
+describe( 'selectors', () => {
+	let state;
+
+	beforeEach( () => {
+		state = {
+			extensions: {
+				woocommerce: {
+					products: [
+						// TODO: After the product API code is in, add more fields here.
+						{ id: 1 },
+					],
+					ui: {
+						products: {
+						}
+					},
+				},
+			},
+		};
+	} );
+
+	describe( 'getProductEdits', () => {
+		it( 'should get a product from "creates"', () => {
+			const newProduct = { id: { index: 0 }, name: 'New Product' };
+			const uiProducts = state.extensions.woocommerce.ui.products;
+			set( uiProducts, 'edits.creates', [ newProduct ] );
+
+			expect( getProductEdits( state, newProduct.id ) ).to.equal( newProduct );
+		} );
+
+		it( 'should get a product from "updates"', () => {
+			const updateProduct = { id: 1, name: 'Existing Product' };
+			const uiProducts = state.extensions.woocommerce.ui.products;
+			set( uiProducts, 'edits.updates', [ updateProduct ] );
+
+			expect( getProductEdits( state, updateProduct.id ) ).to.equal( updateProduct );
+		} );
+
+		it( 'should return undefined if no edits are found for productId', () => {
+			expect( getProductEdits( state, 1 ) ).to.not.exist;
+			expect( getProductEdits( state, { index: 9 } ) ).to.not.exist;
+		} );
+	} );
+
+	describe( 'getProductWithLocalEdits', () => {
+		it( 'should get just edits for a product in "creates"', () => {
+			const newProduct = { id: { index: 0 }, name: 'New Product' };
+			const uiProducts = state.extensions.woocommerce.ui.products;
+			set( uiProducts, 'edits.creates', [ newProduct ] );
+
+			expect( getProductWithLocalEdits( state, newProduct.id ) ).to.eql( newProduct );
+		} );
+
+		it( 'should get just fetched data for a product that has no edits', () => {
+			const products = state.extensions.woocommerce.products;
+
+			expect( getProductWithLocalEdits( state, 1 ) ).to.eql( products[ 0 ] );
+		} );
+
+		it( 'should get both fetched data and edits for a product in "updates"', () => {
+			const uiProducts = state.extensions.woocommerce.ui.products;
+			const products = state.extensions.woocommerce.products;
+
+			const existingProduct = { id: 1, name: 'Existing Product' };
+			set( uiProducts, 'edits.updates', [ existingProduct ] );
+
+			const combinedProduct = { ...products[ 0 ], ...existingProduct };
+			expect( getProductWithLocalEdits( state, 1 ) ).to.eql( combinedProduct );
+		} );
+
+		it( 'should return undefined if no product is found for productId', () => {
+			expect( getProductWithLocalEdits( state, 42 ) ).to.not.exist;
+			expect( getProductWithLocalEdits( state, { index: 42 } ) ).to.not.exist;
+		} );
+	} );
+
+	describe( 'getCurrentlyEditingProduct', () => {
+		it( 'should return undefined if there are no edits', () => {
+			expect( getCurrentlyEditingProduct( state ) ).to.not.exist;
+		} );
+
+		it( 'should get the last edited product', () => {
+			const newProduct = { id: { index: 0 }, name: 'New Product' };
+			const uiProducts = state.extensions.woocommerce.ui.products;
+			set( uiProducts, 'edits.creates', [ newProduct ] );
+			set( uiProducts, 'edits.currentlyEditingId', newProduct.id );
+
+			expect( getCurrentlyEditingProduct( state ) ).to.eql( newProduct );
+		} );
+	} );
+} );

--- a/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
@@ -39,7 +39,7 @@ function editProductVariationAction( edits, action ) {
 			return {
 				...productEdits,
 				[ bucket ]: _array,
-				currentlyEditing: variationId,
+				currentlyEditingId: variationId,
 			};
 		}
 
@@ -55,7 +55,7 @@ function editProductVariationAction( edits, action ) {
 		_edits.push( {
 			productId,
 			[ bucket ]: _array,
-			currentlyEditing: variationId,
+			currentlyEditingId: variationId,
 		} );
 	}
 

--- a/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
@@ -1,14 +1,10 @@
 /**
- * External dependencies
- */
-import { isNumber } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import {
 	WOOCOMMERCE_EDIT_PRODUCT_VARIATION,
 } from '../../../action-types';
+import { nextBucketIndex, getBucket } from '../../helpers';
 
 const initialState = null;
 
@@ -26,14 +22,14 @@ function editProductVariationAction( edits, action ) {
 	const { product, variation, data } = action.payload;
 	const prevEdits = edits || [];
 	const productId = product.id;
-	const bucket = variation && isNumber( variation.id ) && 'updates' || 'creates';
+	const bucket = getBucket( variation );
 	let found = false;
 
 	// Look for an existing product edits first.
 	const _edits = prevEdits.map( ( productEdits ) => {
 		if ( productId === productEdits.productId ) {
 			found = true;
-			const variationId = variation && variation.id || { index: ( productEdits[ bucket ] || [] ).length };
+			const variationId = variation && variation.id || nextBucketIndex( productEdits[ bucket ] );
 			const _variation = variation || { id: variationId };
 			const _array = editProductVariation( productEdits[ bucket ], _variation, data );
 			return {
@@ -48,7 +44,7 @@ function editProductVariationAction( edits, action ) {
 
 	if ( ! found ) {
 		// product not in edits, so add it now.
-		const variationId = variation && variation.id || { index: ( prevEdits[ bucket ] || [] ).length };
+		const variationId = variation && variation.id || nextBucketIndex( prevEdits[ bucket ] );
 		const _variation = variation || { id: variationId };
 
 		const _array = editProductVariation( null, _variation, data );

--- a/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
@@ -27,15 +27,20 @@ function editProductVariationAction( edits, action ) {
 	const prevEdits = edits || [];
 	const productId = product.id;
 	const bucket = variation && isNumber( variation.id ) && 'updates' || 'creates';
-
 	let found = false;
 
 	// Look for an existing product edits first.
 	const _edits = prevEdits.map( ( productEdits ) => {
 		if ( productId === productEdits.productId ) {
 			found = true;
-			const _array = editProductVariation( productEdits[ bucket ], variation, data );
-			return { ...productEdits, [ bucket ]: _array };
+			const variationId = variation && variation.id || { index: ( productEdits[ bucket ] || [] ).length };
+			const _variation = variation || { id: variationId };
+			const _array = editProductVariation( productEdits[ bucket ], _variation, data );
+			return {
+				...productEdits,
+				[ bucket ]: _array,
+				currentlyEditing: variationId,
+			};
 		}
 
 		return productEdits;
@@ -43,8 +48,15 @@ function editProductVariationAction( edits, action ) {
 
 	if ( ! found ) {
 		// product not in edits, so add it now.
-		const _array = editProductVariation( null, variation, data );
-		_edits.push( { productId, [ bucket ]: _array } );
+		const variationId = variation && variation.id || { index: ( prevEdits[ bucket ] || [] ).length };
+		const _variation = variation || { id: variationId };
+
+		const _array = editProductVariation( null, _variation, data );
+		_edits.push( {
+			productId,
+			[ bucket ]: _array,
+			currentlyEditing: variationId,
+		} );
 	}
 
 	return _edits;
@@ -53,13 +65,12 @@ function editProductVariationAction( edits, action ) {
 function editProductVariation( array, variation, data ) {
 	// Use the existing variation id (real or placeholder), or creates.length if no product.
 	const prevArray = array || [];
-	const variationId = ( variation ? variation.id : { index: prevArray.length } );
 
 	let found = false;
 
 	// Look for this object in the appropriate create or edit array first.
 	const _array = prevArray.map( ( v ) => {
-		if ( variationId === v.id ) {
+		if ( variation.id === v.id ) {
 			found = true;
 			return { ...v, ...data };
 		}
@@ -69,9 +80,8 @@ function editProductVariation( array, variation, data ) {
 
 	if ( ! found ) {
 		// update or create not already in edit state, so add it now.
-		_array.push( { id: variationId, ...data } );
+		_array.push( { id: variation.id, ...data } );
 	}
 
 	return _array;
 }
-

--- a/client/extensions/woocommerce/state/ui/products/variations/test/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/test/edits-reducer.js
@@ -98,5 +98,40 @@ describe( 'edits-reducer', () => {
 		expect( edits2[ 1 ].productId ).to.eql( 49 );
 		expect( edits2[ 1 ].creates[ 0 ] ).to.eql( { id: { index: 0 }, regular_price: '2.99' } );
 	} );
-} );
 
+	it( 'should set currentlyEditing when editing a new variation', () => {
+		const product = { id: 48 };
+
+		const edits1 = reducer( undefined, editProductVariation( product, null, { regular_price: '1.99' } ) );
+		const _edits1 = edits1.find( function( p ) {
+			if ( product.id === p.productId ) {
+				return p;
+			}
+		} );
+
+		expect( _edits1.currentlyEditing ).to.eql( { index: 0 } );
+
+		const edits2 = reducer( edits1, editProductVariation( product, null, { regular_price: '2.99' } ) );
+		const _edits2 = edits2.find( function( p ) {
+			if ( product.id === p.productId ) {
+				return p;
+			}
+		} );
+
+		expect( _edits2.currentlyEditing ).to.eql( { index: 1 } );
+	} );
+
+	it( 'should set currentlyEditing when editing an existing variation', () => {
+		const product = { id: 48 };
+		const variation1 = { id: 23, regular_price: '0.99', attributes: [ { name: 'Color', option: 'Red' } ] };
+
+		const edits1 = reducer( undefined, editProductVariation( product, variation1, { regular_price: '1.99' } ) );
+		const _edits1 = edits1.find( function( p ) {
+			if ( product.id === p.productId ) {
+				return p;
+			}
+		} );
+
+		expect( _edits1.currentlyEditing ).to.eql( 23 );
+	} );
+} );

--- a/client/extensions/woocommerce/state/ui/products/variations/test/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/test/edits-reducer.js
@@ -99,29 +99,29 @@ describe( 'edits-reducer', () => {
 		expect( edits2[ 1 ].creates[ 0 ] ).to.eql( { id: { index: 0 }, regular_price: '2.99' } );
 	} );
 
-	it( 'should set currentlyEditing when editing a new variation', () => {
+	it( 'should set currentlyEditingId when editing a new variation', () => {
 		const product = { id: 48 };
 
 		const edits1 = reducer( undefined, editProductVariation( product, null, { regular_price: '1.99' } ) );
-		const _edits1 = edits1.find( function( p ) {
+		const productEdits1 = edits1.find( function( p ) {
 			if ( product.id === p.productId ) {
 				return p;
 			}
 		} );
 
-		expect( _edits1.currentlyEditing ).to.eql( { index: 0 } );
+		expect( productEdits1.currentlyEditingId ).to.eql( productEdits1.creates[ 0 ].id );
 
 		const edits2 = reducer( edits1, editProductVariation( product, null, { regular_price: '2.99' } ) );
-		const _edits2 = edits2.find( function( p ) {
+		const productEdits2 = edits2.find( function( p ) {
 			if ( product.id === p.productId ) {
 				return p;
 			}
 		} );
 
-		expect( _edits2.currentlyEditing ).to.eql( { index: 1 } );
+		expect( productEdits2.currentlyEditingId ).to.eql( productEdits2.creates[ 1 ].id );
 	} );
 
-	it( 'should set currentlyEditing when editing an existing variation', () => {
+	it( 'should set currentlyEditingId when editing an existing variation', () => {
 		const product = { id: 48 };
 		const variation1 = { id: 23, regular_price: '0.99', attributes: [ { name: 'Color', option: 'Red' } ] };
 
@@ -132,6 +132,6 @@ describe( 'edits-reducer', () => {
 			}
 		} );
 
-		expect( _edits1.currentlyEditing ).to.eql( 23 );
+		expect( _edits1.currentlyEditingId ).to.eql( variation1.id );
 	} );
 } );


### PR DESCRIPTION
Adds currentlyEditing state to both products and variations to track the current object being edited.

To test:

1. Run `make test` and ensure all tests succeed.