### PR TITLE
Reader: Correct Recommended Posts layout

### DIFF
--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -161,7 +161,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		&::after {
 			@include long-content-fade( $size: 25% );
 				bottom: 0;
-				height: 25px;
+				height: 22px;
 				top: inherit;
 				visibility: visible;
 		}
@@ -352,19 +352,13 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 				@media #{$reader-related-card-v2-breakpoint-medium} {
 					margin-top: -4px;
 					right: 0;
-					width: calc( 100% - 28% );
+					width: calc( 100% - 97px );
 				}
 
 				@media #{$reader-related-card-v2-breakpoint-small} {
 					margin-top: -4px;
 					right: 0;
-					width: calc( 100% - 29% );
-				}
-
-				@include breakpoint( "<480px" ) {
-					margin-top: -4px;
-					right: 0;
-					width: calc( 100% - 28% );
+					width: calc( 100% - 97px );
 				}
 			}
 
@@ -400,11 +394,13 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		.reader-related-card-v2__featured-image {
 
 			@media #{$reader-related-card-v2-breakpoint-medium} {
+				flex: 0 0 80px;
 				margin: 0 15px 0 0;
 				width: 80px;
 			}
 
 			@media #{$reader-related-card-v2-breakpoint-small} {
+				flex: 0 0 80px;
 				margin: 0 15px 0 0;
 				width: 80px;
 			}

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -5,17 +5,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 .reader-related-card-v2__link-block {
 	cursor: pointer;
-	display: flex;
-	flex-direction: column;
 	position: relative;
-
-	@media #{$reader-related-card-v2-breakpoint-small} {
-		flex-direction: row;
-	}
-
-	@media #{$reader-related-card-v2-breakpoint-medium} {
-		flex-direction: row;
-	}
 }
 
 .reader-related-card-v2__heading {
@@ -146,39 +136,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		width: 100%;
 	}
 
-	.reader-related-card-v2__post {
-		display: block;
-		overflow: hidden;
-
-		@media #{$reader-related-card-v2-breakpoint-medium} {
-			display: flex;
-		}
-
-		@media #{$reader-related-card-v2-breakpoint-small} {
-			display: flex;
-		}
-
-		&::after {
-			@include long-content-fade( $size: 20% );
-				bottom: 0;
-				height: 25px;
-				top: inherit;
-				visibility: visible;
-		}
-	}
-
 	&.has-thumbnail {
-
-		.reader-related-card-v2__site-info {
-
-			@media #{$reader-related-card-v2-breakpoint-small} {
-				flex: 3;
-			}
-
-			@media #{$reader-related-card-v2-breakpoint-medium} {
-				flex: 3;
-			}
-		}
 
 		.reader-related-card-v2__title {
 			font-size: 17px;
@@ -202,7 +160,17 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	padding-top: 11px;
 
 	.reader-related-card-v2__post {
+		display: block;
+		overflow: hidden;
 		max-height: 127px;
+
+		@media #{$reader-related-card-v2-breakpoint-medium} {
+			display: flex;
+		}
+
+		@media #{$reader-related-card-v2-breakpoint-small} {
+			display: flex;
+		}
 
 		@include breakpoint( "<480px" ) {
 			max-height: 126px;
@@ -220,7 +188,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	&.is-same-site {
 
 		.reader-related-card-v2__meta {
-			display: none !important;
+			display: none !important; // Hides meta info in "More In Site"
 		}
 
 		.reader-related-card-v2__featured-image {
@@ -268,14 +236,27 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 		.has-thumbnail {
 
-			.reader-related-card-v2__site-info {
+			.reader-related-card-v2__meta {
 
 				@media #{$reader-related-card-v2-breakpoint-medium} {
-					margin-top: 20px;
+					margin-top: -4px;
+					position: absolute;
+					right: 0;
+					width: calc( 100% - 28% );
 				}
 
 				@media #{$reader-related-card-v2-breakpoint-small} {
-					margin-top: 20px;
+					margin-top: -4px;
+					position: absolute;
+					right: 0;
+					width: calc( 100% - 29% );
+				}
+
+				@include breakpoint( "<480px" ) {
+					margin-top: -4px;
+					position: absolute;
+					right: 0;
+					width: calc( 100% - 28% );
 				}
 			}
 
@@ -283,11 +264,13 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 				max-height: 219px;
 
 				@media #{$reader-related-card-v2-breakpoint-medium} {
-					max-height: 170px;
+					max-height: 180px;
+					margin-top: 45px;
 				}
 
 				@media #{$reader-related-card-v2-breakpoint-small} {
 					max-height: 162px;
+					margin-top: 45px;
 				}
 			}
 		}
@@ -298,12 +281,6 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 		.reader-related-card-v2__featured-image {
 			margin: 0 0 19px;
-		}
-	}
-
-	&.is-other-site {
-
-		.reader-related-card-v2__featured-image {
 
 			@media #{$reader-related-card-v2-breakpoint-medium} {
 				margin: 0 15px 0 0;
@@ -311,6 +288,45 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 			@media #{$reader-related-card-v2-breakpoint-small} {
 				margin: 0 15px 0 0;
+			}
+		}
+	}
+
+	&.is-same-site,
+	&.is-other-site {
+
+		.reader-related-card-v2 {
+
+			@media #{$reader-related-card-v2-breakpoint-medium} {
+				flex-direction: row;
+			}
+
+			@media #{$reader-related-card-v2-breakpoint-small} {
+				flex-direction: row;
+			}
+		}
+
+		.reader-related-card-v2__featured-image {
+
+			@media #{$reader-related-card-v2-breakpoint-medium} {
+				margin: 0 15px 0 0;
+				width: 80px;
+			}
+
+			@media #{$reader-related-card-v2-breakpoint-small} {
+				margin: 0 15px 0 0;
+				width: 80px;
+			}
+		}
+
+		.reader-related-card-v2__post {
+
+			@media #{$reader-related-card-v2-breakpoint-medium} {
+				flex: 3;
+			}
+
+			@media #{$reader-related-card-v2-breakpoint-small} {
+				flex: 3;
 			}
 		}
 	}
@@ -440,13 +456,13 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	// Clamp to 3 lines on larger viewports
 	@include breakpoint( ">660px" ) {
 		overflow: hidden;
-		max-height: 16px * 1.4 * 3;
+		max-height: 16px * 1.5 * 3;
 		word-wrap: break-word;
 
 		&::after {
 			@include long-content-fade( $size: 20% );
-			top: 16px * 1.4 * 2;
-			height: 16px * 1.4;
+			top: 16px * 1.5 * 2;
+			height: 16px * 1.5;
 		}
 	}
 }

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -233,7 +233,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 				max-height: 128px;
 
 				@media #{$reader-related-card-v2-breakpoint-medium} {
-					max-height: 126px;
+					max-height: 127px;
 				}
 
 				@media #{$reader-related-card-v2-breakpoint-small} {

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -79,7 +79,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	min-width: 0;
 
 	&:first-child {
-		margin-right: 15px;
+		margin-right: 10px;
 
 		@include breakpoint( "<660px" ) {
 			margin-right: 10px;
@@ -87,7 +87,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	}
 
 	&:last-child {
-		margin-left: 15px;
+		margin-left: 10px;
 
 		@include breakpoint( "<660px" ) {
 			margin-left: 10px;
@@ -159,7 +159,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		}
 
 		&::after {
-			@include long-content-fade( $size: 20% );
+			@include long-content-fade( $size: 25% );
 				bottom: 0;
 				height: 25px;
 				top: inherit;
@@ -230,11 +230,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		.has-thumbnail {
 
 			.reader-related-card-v2__post {
-				max-height: 219px;
-
-				@include breakpoint( "<960px" ) {
-					max-height: 240px;
-				}
+				max-height: 128px;
 
 				@media #{$reader-related-card-v2-breakpoint-medium} {
 					max-height: 126px;
@@ -262,18 +258,14 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		margin-top: 40px;
 
 		.reader-related-card-v2__post {
-			max-height: 222px;
+			max-height: 110px;
 
 			@include breakpoint( "<960px" ) {
-				max-height: 249px;
+				max-height: 109px;
 			}
 
-			@media #{$reader-related-card-v2-breakpoint-medium} {
-				max-height: 155px;
-			}
-
-			@media #{$reader-related-card-v2-breakpoint-small} {
-				max-height: 142px;
+			@include breakpoint( "<480px" ) {
+				max-height: 104px;
 			}
 		}
 
@@ -291,14 +283,18 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 			}
 
 			.reader-related-card-v2__post {
-				max-height: 219px;
+				max-height: 127px;
 
 				@media #{$reader-related-card-v2-breakpoint-medium} {
-					max-height: 173px;
+					max-height: 153px;
 				}
 
 				@media #{$reader-related-card-v2-breakpoint-small} {
-					max-height: 167px;
+					max-height: 150px;
+				}
+
+				@include breakpoint( "<480px" ) {
+					max-height: 140px;
 				}
 			}
 		}
@@ -329,6 +325,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 			@media #{$reader-related-card-v2-breakpoint-medium} {
 				position: absolute;
+				width: 100%;
 			}
 
 			@media #{$reader-related-card-v2-breakpoint-small} {
@@ -462,6 +459,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	border-radius: 0;
 	margin-bottom: 12px;
 	margin-top: -6px;
+	position: relative;
 	padding: 0;
 	z-index: z-index( '.reader-related-card-v2__meta', '.follow-button' );
 
@@ -553,12 +551,6 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 .reader-related-card-v2__excerpt {
 	line-height: 1.6;
 	word-wrap: break-word;
-
-	&::after {
-		@include long-content-fade( $size: 20% );
-		height: 22px;
-		top: inherit;
-	}
 
 	&.post-excerpt {
 		font-size: 15px;

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -5,7 +5,17 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 .reader-related-card-v2__link-block {
 	cursor: pointer;
+	display: flex;
+	flex-direction: column;
 	position: relative;
+
+	@media #{$reader-related-card-v2-breakpoint-small} {
+		flex-direction: row;
+	}
+
+	@media #{$reader-related-card-v2-breakpoint-medium} {
+		flex-direction: row;
+	}
 }
 
 .reader-related-card-v2__heading {
@@ -136,7 +146,39 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		width: 100%;
 	}
 
+	.reader-related-card-v2__post {
+		display: block;
+		overflow: hidden;
+
+		@media #{$reader-related-card-v2-breakpoint-medium} {
+			display: flex;
+		}
+
+		@media #{$reader-related-card-v2-breakpoint-small} {
+			display: flex;
+		}
+
+		&::after {
+			@include long-content-fade( $size: 20% );
+				bottom: 0;
+				height: 25px;
+				top: inherit;
+				visibility: visible;
+		}
+	}
+
 	&.has-thumbnail {
+
+		.reader-related-card-v2__site-info {
+
+			@media #{$reader-related-card-v2-breakpoint-small} {
+				flex: 3;
+			}
+
+			@media #{$reader-related-card-v2-breakpoint-medium} {
+				flex: 3;
+			}
+		}
 
 		.reader-related-card-v2__title {
 			font-size: 17px;
@@ -160,17 +202,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	padding-top: 11px;
 
 	.reader-related-card-v2__post {
-		display: block;
-		overflow: hidden;
 		max-height: 127px;
-
-		@media #{$reader-related-card-v2-breakpoint-medium} {
-			display: flex;
-		}
-
-		@media #{$reader-related-card-v2-breakpoint-small} {
-			display: flex;
-		}
 
 		@include breakpoint( "<480px" ) {
 			max-height: 126px;
@@ -188,7 +220,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	&.is-same-site {
 
 		.reader-related-card-v2__meta {
-			display: none !important; // Hides meta info in "More In Site"
+			display: none !important; // Hides meta info from "More In Site"
 		}
 
 		.reader-related-card-v2__featured-image {
@@ -211,6 +243,17 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 				@media #{$reader-related-card-v2-breakpoint-small} {
 					max-height: 126px;
 				}
+			}
+		}
+
+		.reader-related-card-v2__post {
+
+			@media #{$reader-related-card-v2-breakpoint-medium} {
+				flex: 3;
+			}
+
+			@media #{$reader-related-card-v2-breakpoint-small} {
+				flex: 3;
 			}
 		}
 	}
@@ -236,27 +279,14 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 		.has-thumbnail {
 
-			.reader-related-card-v2__meta {
+			.reader-related-card-v2__site-info {
 
 				@media #{$reader-related-card-v2-breakpoint-medium} {
-					margin-top: -4px;
-					position: absolute;
-					right: 0;
-					width: calc( 100% - 28% );
+					margin-top: 20px;
 				}
 
 				@media #{$reader-related-card-v2-breakpoint-small} {
-					margin-top: -4px;
-					position: absolute;
-					right: 0;
-					width: calc( 100% - 29% );
-				}
-
-				@include breakpoint( "<480px" ) {
-					margin-top: -4px;
-					position: absolute;
-					right: 0;
-					width: calc( 100% - 28% );
+					margin-top: 20px;
 				}
 			}
 
@@ -264,13 +294,11 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 				max-height: 219px;
 
 				@media #{$reader-related-card-v2-breakpoint-medium} {
-					max-height: 180px;
-					margin-top: 45px;
+					max-height: 173px;
 				}
 
 				@media #{$reader-related-card-v2-breakpoint-small} {
-					max-height: 162px;
-					margin-top: 45px;
+					max-height: 167px;
 				}
 			}
 		}
@@ -281,6 +309,12 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 		.reader-related-card-v2__featured-image {
 			margin: 0 0 19px;
+		}
+	}
+
+	&.is-other-site {
+
+		.reader-related-card-v2__featured-image {
 
 			@media #{$reader-related-card-v2-breakpoint-medium} {
 				margin: 0 15px 0 0;
@@ -288,6 +322,66 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 			@media #{$reader-related-card-v2-breakpoint-small} {
 				margin: 0 15px 0 0;
+			}
+		}
+
+		.reader-related-card-v2__meta {
+
+			@media #{$reader-related-card-v2-breakpoint-medium} {
+				position: absolute;
+			}
+
+			@media #{$reader-related-card-v2-breakpoint-small} {
+				position: absolute;
+			}
+		}
+
+		.reader-related-card-v2__post {
+
+			@media #{$reader-related-card-v2-breakpoint-medium} {
+				margin-top: 55px;
+			}
+
+			@media #{$reader-related-card-v2-breakpoint-small} {
+				margin-top: 55px;
+			}
+		}
+
+
+		.has-thumbnail {
+
+			.reader-related-card-v2__meta {
+
+				@media #{$reader-related-card-v2-breakpoint-medium} {
+					margin-top: -4px;
+					right: 0;
+					width: calc( 100% - 28% );
+				}
+
+				@media #{$reader-related-card-v2-breakpoint-small} {
+					margin-top: -4px;
+					right: 0;
+					width: calc( 100% - 29% );
+				}
+
+				@include breakpoint( "<480px" ) {
+					margin-top: -4px;
+					right: 0;
+					width: calc( 100% - 28% );
+				}
+			}
+
+			.reader-related-card-v2__post {
+
+				@media #{$reader-related-card-v2-breakpoint-medium} {
+					flex: 3;
+					margin-top: 25px;
+				}
+
+				@media #{$reader-related-card-v2-breakpoint-small} {
+					flex: 3;
+					margin-top: 25px;
+				}
 			}
 		}
 	}
@@ -316,17 +410,6 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 			@media #{$reader-related-card-v2-breakpoint-small} {
 				margin: 0 15px 0 0;
 				width: 80px;
-			}
-		}
-
-		.reader-related-card-v2__post {
-
-			@media #{$reader-related-card-v2-breakpoint-medium} {
-				flex: 3;
-			}
-
-			@media #{$reader-related-card-v2-breakpoint-small} {
-				flex: 3;
 			}
 		}
 	}

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -96,11 +96,11 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		max-height: 205px;
 
 		@media #{$reader-related-card-v2-breakpoint-small} {
-			max-height: 100px;
+			max-height: 103px;
 		}
 
 		@media #{$reader-related-card-v2-breakpoint-medium} {
-			max-height: 100px;
+			max-height: 103px;
 		}
 
 		.reader-related-card-v2__excerpt {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -121,29 +121,10 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 				max-height: 145px;
 			}
 		}
-
-		.reader-related-card-v2__site-info {
-
-			@media #{$reader-related-card-v2-breakpoint-small} {
-				margin-top: 20px;
-			}
-
-			@media #{$reader-related-card-v2-breakpoint-medium} {
-				margin-top: 20px;
-			}
-		}
 	}
 
 	.reader-related-card-v2__featured-image {
 		margin: 0 0 17px;
-
-		@media #{$reader-related-card-v2-breakpoint-medium} {
-			margin: 0 15px 0 0;
-		}
-
-		@media #{$reader-related-card-v2-breakpoint-small} {
-			margin: 0 15px 0 0;
-		}
 	}
 
 	.reader-related-card-v2__meta {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -93,7 +93,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	}
 
 	.reader-related-card-v2__post {
-		max-height: 205px;
+		max-height: 130px;
 
 		@media #{$reader-related-card-v2-breakpoint-small} {
 			max-height: 103px;
@@ -111,14 +111,14 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	 .has-thumbnail {
 
 		.reader-related-card-v2__post {
-			max-height: 205px;
+			max-height: 130px;
 
 			@media #{$reader-related-card-v2-breakpoint-small} {
-				max-height: 145px;
+				max-height: 152px;
 			}
 
 			@media #{$reader-related-card-v2-breakpoint-medium} {
-				max-height: 145px;
+				max-height: 152px;
 			}
 		}
 	}

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -565,14 +565,14 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 			}
 
 			.reader-related-card-v2__post {
-				max-height: 205px;
+				max-height: 130px;
 
 				@media #{$reader-related-card-v2-breakpoint-small} {
-					max-height: 150px;
+					max-height: 146px;
 				}
 
 				@media #{$reader-related-card-v2-breakpoint-medium} {
-					max-height: 150px;
+					max-height: 146px;
 				}
 			}
 		}
@@ -615,14 +615,14 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	}
 
 	.reader-related-card-v2__post {
-		max-height: 205px;
+		max-height: 130px;
 
 		@media #{$reader-related-card-v2-breakpoint-medium} {
-			max-height: 100px;
+			max-height: 107px;
 		}
 
 		@media #{$reader-related-card-v2-breakpoint-small} {
-			max-height: 100px;
+			max-height: 103px;
 		}
 
 		.reader-related-card-v2__excerpt {


### PR DESCRIPTION
This fixes Recommended Posts in full-post which are no longer using its correct layout at custom breakpoints.

At least for the byline, it broke because of an old commit: https://github.com/Automattic/wp-calypso/pull/12847/commits/fe95e1e3a0dfc19fc33a1558fb2497c95cc4d7fe, but not sure what caused the rest of it.

I checked the following pages which may be sharing the related posts component and they seem to still be working as expected:
- Full-post recs
- In-stream recs
- Recs in Search

**Before at `<730px`:**
![screenshot 2017-04-12 14 27 40](https://cloud.githubusercontent.com/assets/4924246/24980222/340dcb5e-1f8c-11e7-9150-41787de3b9a5.png)

![screenshot 2017-04-12 14 28 42](https://cloud.githubusercontent.com/assets/4924246/24980263/5857279e-1f8c-11e7-83ff-700826bd8739.png)

**After at `<730px`:**
![screenshot 2017-04-12 14 28 58](https://cloud.githubusercontent.com/assets/4924246/24980271/624f45c4-1f8c-11e7-9d1b-88bc4710c370.png)

![screenshot 2017-04-12 14 29 02](https://cloud.githubusercontent.com/assets/4924246/24980274/64ef3d7a-1f8c-11e7-9b6a-4c86d2fd8ce9.png)

