### PR TITLE
AT: add eligibility page view tracking

### DIFF
--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -55,7 +55,7 @@ export const EligibilityWarnings = ( {
 		<div className={ classes }>
 			<QueryEligibility siteId={ siteId } />
 			<TrackComponentView
-				eventName="calypso_automated_transfer_eligibility_warnings"
+				eventName="calypso_automated_transfer_eligibility_show_warnings"
 				eventProperties={ { context } }
 			/>
 			{ ! hasBusinessPlan && ! isJetpack &&
@@ -166,8 +166,8 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = {
-	trackCancel: ( eventProperties = {} ) => recordTracksEvent( 'calypso_automated_transfer_eligibility_cancel', eventProperties ),
-	trackProceed: ( eventProperties = {} ) => recordTracksEvent( 'calypso_automated_transfer_eligibilty_proceed', eventProperties ),
+	trackCancel: ( eventProperties = {} ) => recordTracksEvent( 'calypso_automated_transfer_eligibility_click_cancel', eventProperties ),
+	trackProceed: ( eventProperties = {} ) => recordTracksEvent( 'calypso_automated_transfer_eligibilty_click_proceed', eventProperties ),
 };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {

--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -4,7 +4,7 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, includes, noop, partition } from 'lodash';
+import { get, includes, noop, partition, flow } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 
@@ -167,7 +167,14 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = {
-	onCancel: () => recordTracksEvent( 'calypso_automated_transfer_eligibility_cancel' )
+	trackCancel: () => recordTracksEvent( 'calypso_automated_transfer_eligibility_cancel' ),
+	trackProceed: () => recordTracksEvent( 'calypso_automated_transfer_eligibilty_proceed' ),
 };
 
-export default connect( mapStateToProps, mapDispatchToProps )( localize( EligibilityWarnings ) );
+const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
+	const onCancel = dispatchProps.trackCancel;
+	const onProceed = flow( ownProps.onProceed, dispatchProps.trackProceed );
+	return Object.assign( {}, ownProps, stateProps, dispatchProps, { onCancel, onProceed } );
+};
+
+export default connect( mapStateToProps, mapDispatchToProps, mergeProps )( localize( EligibilityWarnings ) );

--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -11,18 +11,19 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
+import TrackComponentView from 'lib/analytics/track-component-view';
 import { PLAN_BUSINESS, FEATURE_UPLOAD_PLUGINS, FEATURE_UPLOAD_THEMES } from 'lib/plans/constants';
 import { isBusiness, isEnterprise } from 'lib/products-values';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { getEligibility, isEligibleForAutomatedTransfer } from 'state/automated-transfer/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import Banner from 'components/banner';
 import Button from 'components/button';
 import Card from 'components/card';
-import HoldList from './hold-list';
 import QueryEligibility from 'components/data/query-atat-eligibility';
+import HoldList from './hold-list';
 import WarningList from './warning-list';
-import { recordTracksEvent } from 'state/analytics/actions';
 
 export const EligibilityWarnings = ( {
 	backUrl,
@@ -54,7 +55,10 @@ export const EligibilityWarnings = ( {
 	return (
 		<div className={ classes }>
 			<QueryEligibility siteId={ siteId } />
-
+			<TrackComponentView
+				eventName="calypso_automated_transfer_eligibility_warnings"
+				eventProperties={ { context } }
+			/>
 			{ ! hasBusinessPlan && ! isJetpack &&
 				<Banner
 					description={ translate( 'Also get unlimited themes, advanced customization, no ads, live chat support, and more.' ) }


### PR DESCRIPTION
This adds two new analytics events to transfer eligibility: 

- `calypso_automated_transfer_eligibility_show_warnings` 
 fired when the  eligibility warnings are shown to the user.
- `calypso_automated_transfer_eligibility_click_proceed` fired when the user proceeds with the transfer after being shown eligibility warnings. 

Both events pass the eligibility context as part of the event properties. This value is either `plugins` or `themes`. This context is also added to the existing `calypso_automated_transfer_eligibility_click_cancel` event

**Testing**
- Enable tracks logging in the dev console: `LocalStorage.setItem( 'debug' , 'calypso.analytics.tracks' )`
- Visit http://calypso.localhost:3000/plugins/cornify-for-wordpress/:site_id for a site with either eligibility holds or warnings
- Click 'Install'
- The event `calypso_automated_transfer_eligibility_show_warnings` should be logged in the console with the property `{ context: "plugins" }`
- Click 'Cancel'
- The event `calypso_automated_transfer_eligibility_click_cancel` should be logged in the console with the property `{ context: "plugins" }`
- Click 'Install' again from the plugin page
- Click 'Proceed'
- The event `calypso_automated_transfer_eligibility_click_proceed` should be logged in the console with the property `{ context: "plugins" }`

The same steps can be repeated with a theme upload with the expectation that the event property `context` will be `themes`
