### PR TITLE
blue background box fix around wordpress electron app login

### DIFF
--- a/client/components/main/style.scss
+++ b/client/components/main/style.scss
@@ -2,6 +2,7 @@
 	margin: auto;
 	max-width: 720px;
 	z-index: z-index( 'root', '.main' );
+	backface-visibility: hidden;
 
 	// Themes is a great example of using all this new space ;)
 	&.themes {


### PR DESCRIPTION
Fixes this : https://github.com/Automattic/wp-desktop/issues/278

Please let me know if this can break any other functionality in calypso front end side. Though this css is added when screen size is less than 660px so i assumed its safe to add it.