### PR TITLE
Render emojis more prominently

### DIFF
--- a/client/components/emojify/index.jsx
+++ b/client/components/emojify/index.jsx
@@ -24,7 +24,7 @@ export default class Emojify extends PureComponent {
 	}
 
 	parseEmoji = () => {
-		const { className } = this.props;
+		const { className, soloClassName } = this.props;
 
 		twemoji.parse( this.refs.emojified, {
 			base: config( 'twemoji_cdn_url' ),
@@ -32,8 +32,9 @@ export default class Emojify extends PureComponent {
 			className: className
 		} );
 
-		if ( ! this.refs.emojified.textContent ) {
-			this.refs.emojified.className = 'emojify__solo';
+		if ( soloClassName != null ) {
+			this.refs.emojified.className =
+				this.refs.emojified.textContent ? '' : soloClassName;
 		}
 	}
 

--- a/client/components/emojify/index.jsx
+++ b/client/components/emojify/index.jsx
@@ -31,6 +31,10 @@ export default class Emojify extends PureComponent {
 			size: '72x72',
 			className: className
 		} );
+
+		if ( ! this.refs.emojified.textContent ) {
+			this.refs.emojified.className = 'emojify__solo';
+		}
 	}
 
 	render() {

--- a/client/components/emojify/style.scss
+++ b/client/components/emojify/style.scss
@@ -1,8 +1,14 @@
-// Styles recommended by twemoji
+// Adapted from styles recommended by twemoji
 // https://github.com/twitter/twemoji#inline-styles
 .emojify__emoji {
-	height: 1em;
-	width: 1em;
+	height: 1.2em;
+	width: 1.2em;
 	margin: 0 .05em 0 .1em;
 	vertical-align: -0.1em;
+}
+
+.emojify__solo .emojify__emoji {
+	height: 2em;
+	width: 2em;
+	vertical-align: -0.2em;
 }

--- a/client/components/happychat/timeline.jsx
+++ b/client/components/happychat/timeline.jsx
@@ -35,7 +35,8 @@ const debug = require( 'debug' )( 'calypso:happychat:timeline' );
 
 const linksNotEmpty = ( { links } ) => ! isEmpty( links );
 
-const messageParagraph = ( { message, key } ) => <p key={ key }><Emojify>{ message }</Emojify></p>;
+const messageParagraph = ( { message, key } ) =>
+	<p key={ key }><Emojify soloClassName="emojify__solo">{ message }</Emojify></p>;
 
 /*
  * Given a message and array of links contained within that message, returns the message


### PR DESCRIPTION
Emoji images (converted from raw emojis using twemoji) now appear slightly larger than text, while still not affecting line height.

Also, if emojis alone comprise a whole Happychat message, they appear significantly larger.

The size change affects all uses of the Emojify component ([1](https://github.com/Automattic/wp-calypso/blob/e33be1e283a80756f115b2a4559249bbd525cfdc/client/my-sites/stats/post-performance/index.jsx#L117), [2](https://github.com/Automattic/wp-calypso/blob/515849ea0e3fd4fa6554359aa98eb8955b099d16/client/my-sites/stats/stats-post-detail/index.jsx#L94), [3](https://github.com/Automattic/wp-calypso/blob/e5edf0ba590a2f4d9745ee43ef72d96e9436e2d4/client/my-sites/stats/stats-list/stats-list-item.jsx#L194) in My Sites -> Stats, plus [Happychat](https://github.com/Automattic/wp-calypso/blob/0c569302c9e8b410ee144eadc1ce95dbc51591fd/client/components/happychat/timeline.jsx#L38)). That covers all uses of `twemoji.parse` conversion to images except for the [Reader's full post view](https://github.com/Automattic/wp-calypso/blob/95868ebe3febb26c438d29fe2a8aed04fc9dd145/client/blocks/reader-full-post/index.jsx#L227-L229), the styling for which is defined separately. Willing to either broaden the scope to include the Reader full post, or alternatively narrow the scope to Happychat.

Before:
![screen shot 2017-04-13 at 2 24 26 am](https://cloud.githubusercontent.com/assets/1867547/24992721/da9dfb60-1ff0-11e7-8b28-a6aec3bc0829.png)

After:
![screen shot 2017-04-13 at 2 27 38 am](https://cloud.githubusercontent.com/assets/1867547/24992722/dc1dc52e-1ff0-11e7-8b2c-de2c7e9339be.png)
