### PR TITLE
State: Add tests for sites updates actions

### DIFF
--- a/client/state/sites/updates/test/actions.js
+++ b/client/state/sites/updates/test/actions.js
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	SITE_UPDATES_RECEIVE,
+	SITE_UPDATES_REQUEST,
+	SITE_UPDATES_REQUEST_SUCCESS,
+	SITE_UPDATES_REQUEST_FAILURE,
+} from 'state/action-types';
+import {
+	siteUpdatesReceiveAction,
+	siteUpdatesRequestAction,
+	siteUpdatesRequestSuccessAction,
+	siteUpdatesRequestFailureAction,
+} from '../actions';
+
+describe( 'actions', () => {
+	const siteId = 2916284;
+
+	describe( '#siteUpdatesReceiveAction()', () => {
+		it( 'should return a site updates receive action object', () => {
+			const updates = {
+				plugins: 1,
+			};
+			const action = siteUpdatesReceiveAction( siteId, updates );
+
+			expect( action ).to.eql( {
+				type: SITE_UPDATES_RECEIVE,
+				siteId,
+				updates,
+			} );
+		} );
+	} );
+
+	describe( '#siteUpdatesReceiveAction()', () => {
+		it( 'should return a site updates request action object', () => {
+			const action = siteUpdatesRequestAction( siteId );
+
+			expect( action ).to.eql( {
+				type: SITE_UPDATES_REQUEST,
+				siteId,
+			} );
+		} );
+	} );
+
+	describe( '#siteUpdatesReceiveAction()', () => {
+		it( 'should return a site updates request success action object', () => {
+			const action = siteUpdatesRequestSuccessAction( siteId );
+
+			expect( action ).to.eql( {
+				type: SITE_UPDATES_REQUEST_SUCCESS,
+				siteId,
+			} );
+		} );
+	} );
+
+	describe( '#siteUpdatesReceiveAction()', () => {
+		it( 'should return a site updates request failure action object', () => {
+			const error = 'There was an error while getting the update data for this site.';
+			const action = siteUpdatesRequestFailureAction( siteId, error );
+
+			expect( action ).to.eql( {
+				type: SITE_UPDATES_REQUEST_FAILURE,
+				siteId,
+				error,
+			} );
+		} );
+	} );
+} );

--- a/client/state/sites/updates/test/actions.js
+++ b/client/state/sites/updates/test/actions.js
@@ -37,7 +37,7 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( '#siteUpdatesReceiveAction()', () => {
+	describe( '#siteUpdatesRequestAction()', () => {
 		it( 'should return a site updates request action object', () => {
 			const action = siteUpdatesRequestAction( siteId );
 
@@ -48,7 +48,7 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( '#siteUpdatesReceiveAction()', () => {
+	describe( '#siteUpdatesRequestSuccessAction()', () => {
 		it( 'should return a site updates request success action object', () => {
 			const action = siteUpdatesRequestSuccessAction( siteId );
 
@@ -59,7 +59,7 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( '#siteUpdatesReceiveAction()', () => {
+	describe( '#siteUpdatesRequestFailureAction()', () => {
 		it( 'should return a site updates request failure action object', () => {
 			const error = 'There was an error while getting the update data for this site.';
 			const action = siteUpdatesRequestFailureAction( siteId, error );


### PR DESCRIPTION
This PR adds tests for the sites updates action creators.

To test:

* Checkout this branch
* Verify tests pass:

```
npm run test-client client/state/sites/updates/test/actions.js 
```