### PR TITLE
State: Add tests for sites updates selectors

### DIFF
--- a/client/state/sites/updates/selectors.js
+++ b/client/state/sites/updates/selectors.js
@@ -4,5 +4,5 @@ export const isRequestingSiteUpdates = ( state, siteId ) => {
 };
 
 export const getUpdatesBySiteId = ( state, siteId ) => {
-	return state.sites.updates.items[ siteId ] || [];
+	return state.sites.updates.items[ siteId ] || {};
 };

--- a/client/state/sites/updates/test/selectors.js
+++ b/client/state/sites/updates/test/selectors.js
@@ -55,7 +55,7 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#getUpdatesBySiteId()', () => {
-		it( 'should return an empty array if site updates have not been fetched yet', () => {
+		it( 'should return an empty object if site updates have not been fetched yet', () => {
 			const updates = getUpdatesBySiteId( {
 				sites: {
 					updates: {
@@ -64,7 +64,7 @@ describe( 'selectors', () => {
 				}
 			}, 12345678 );
 
-			expect( updates ).to.eql( [] );
+			expect( updates ).to.eql( {} );
 		} );
 
 		it( 'should return the updates for an existing site', () => {

--- a/client/state/sites/updates/test/selectors.js
+++ b/client/state/sites/updates/test/selectors.js
@@ -1,0 +1,88 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	isRequestingSiteUpdates,
+	getUpdatesBySiteId
+} from '../selectors';
+
+describe( 'selectors', () => {
+	describe( '#isRequestingSiteUpdates()', () => {
+		it( 'should return false if site updates have not been fetched yet', () => {
+			const isRequesting = isRequestingSiteUpdates( {
+				sites: {
+					updates: {
+						requesting: {}
+					}
+				}
+			}, 12345678 );
+
+			expect( isRequesting ).to.be.false;
+		} );
+
+		it( 'should return false if the site updates are not being requested', () => {
+			const isRequesting = isRequestingSiteUpdates( {
+				sites: {
+					updates: {
+						requesting: {
+							12345678: false
+						}
+					}
+				}
+			}, 12345678 );
+
+			expect( isRequesting ).to.be.false;
+		} );
+
+		it( 'should return true if the site updates are being requested', () => {
+			const isRequesting = isRequestingSiteUpdates( {
+				sites: {
+					updates: {
+						requesting: {
+							12345678: true
+						}
+					}
+				}
+			}, 12345678 );
+
+			expect( isRequesting ).to.be.true;
+		} );
+	} );
+
+	describe( '#getUpdatesBySiteId()', () => {
+		it( 'should return an empty array if site updates have not been fetched yet', () => {
+			const updates = getUpdatesBySiteId( {
+				sites: {
+					updates: {
+						items: {}
+					}
+				}
+			}, 12345678 );
+
+			expect( updates ).to.eql( [] );
+		} );
+
+		it( 'should return the updates for an existing site', () => {
+			const exampleUpdates = {
+				plugins: 1,
+				total: 1,
+			};
+			const updates = getUpdatesBySiteId( {
+				sites: {
+					updates: {
+						items: {
+							12345678: exampleUpdates
+						}
+					}
+				}
+			}, 12345678 );
+
+			expect( updates ).to.eql( exampleUpdates );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR adds tests for the sites updates selectors.

To test:

* Checkout this branch
* Verify all tests pass:

```
npm run test-client client/state/sites/updates/test/selectors.js 
```