### PR TITLE
Sites: Move JetpackSite.prototype.handleError into site-settings/formBase

### DIFF
--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-var debug = require( 'debug' )( 'calypso:site:jetpack' ),
-	i18n = require( 'i18n-calypso' );
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
@@ -10,12 +9,13 @@ var debug = require( 'debug' )( 'calypso:site:jetpack' ),
 var wpcom = require( 'lib/wp' ),
 	Site = require( 'lib/site' ),
 	inherits = require( 'inherits' ),
-	notices = require( 'notices' ),
 	versionCompare = require( 'lib/version-compare' ),
 	SiteUtils = require( 'lib/site/utils' ),
 	config = require( 'config' );
 
 inherits( JetpackSite, Site );
+
+const debug = debugFactory( 'calypso:site:jetpack' );
 
 function JetpackSite( attributes ) {
 	if ( ! ( this instanceof JetpackSite ) ) {
@@ -89,71 +89,6 @@ JetpackSite.prototype.verifyModulesActive = function( moduleIds, callback ) {
 JetpackSite.prototype.getRemoteManagementURL = function() {
 	var configure = versionCompare( this.options.jetpack_version, 3.4, '>=' ) ? 'manage' : 'json-api';
 	return this.options.admin_url + 'admin.php?page=jetpack&configure=' + configure;
-};
-
-JetpackSite.prototype.handleError = function( error, action, plugin, module ) {
-	var moduleTranslationArgs = {},
-		buttonRemoteManagement,
-		remoteManagementUrl;
-
-	if ( ! error.error ) {
-		return;
-	}
-
-	if ( module ) {
-		moduleTranslationArgs = { args: { module: module, site: this.domain } };
-	}
-
-	remoteManagementUrl = this.getRemoteManagementURL();
-
-	buttonRemoteManagement = {
-		button: i18n.translate( 'Turn On.' ),
-		href: remoteManagementUrl
-	};
-
-	if ( 'activateModule' === action ) {
-		switch ( error.error ) {
-			case 'unauthorized_full_access':
-				notices.error(
-					i18n.translate(
-						'Error activating the Jetpack %(module)s feature on %(site)s, remote management is off.',
-						moduleTranslationArgs
-					),
-					buttonRemoteManagement
-				);
-				break;
-			default:
-				notices.error(
-					i18n.translate(
-						'An error occurred while activating the Jetpack %(module)s feature on %(site)s.',
-						moduleTranslationArgs
-					)
-				);
-				break;
-		}
-	}
-
-	if ( 'deactivateModule' === action ) {
-		switch ( error.error ) {
-			case 'unauthorized_full_access':
-				notices.error(
-					i18n.translate(
-						'Error deactivating the Jetpack %(module)s feature on %(site)s, remote management is off.',
-						moduleTranslationArgs
-					),
-					buttonRemoteManagement
-				);
-				break;
-			default:
-				notices.error(
-					i18n.translate(
-						'An error occurred while deactivating the Jetpack %(module)s feature on %(site)s.',
-						moduleTranslationArgs
-					)
-				);
-				break;
-		}
-	}
 };
 
 JetpackSite.prototype.updateWordPress = function( onError, onSuccess ) {

--- a/client/my-sites/site-settings/form-base.js
+++ b/client/my-sites/site-settings/form-base.js
@@ -3,6 +3,7 @@
  */
 import debugFactory from 'debug';
 import omit from 'lodash/omit';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -107,6 +108,67 @@ module.exports = {
 		this.setState( { [ currentTargetName ]: currentTargetValue } );
 	},
 
+	handleToggleJetpackModuleError( error, action, module ) {
+		if ( ! error.error ) {
+			return;
+		}
+
+		const remoteManagementUrl = this.props.site.getRemoteManagementURL();
+		const buttonRemoteManagement = {
+			button: i18n.translate( 'Turn On.' ),
+			href: remoteManagementUrl
+		};
+		let moduleTranslationArgs = {};
+
+		if ( module ) {
+			moduleTranslationArgs = { args: { module: module, site: this.props.site.domain } };
+		}
+
+		if ( 'activateModule' === action ) {
+			switch ( error.error ) {
+				case 'unauthorized_full_access':
+					notices.error(
+						i18n.translate(
+							'Error activating the Jetpack %(module)s feature on %(site)s, remote management is off.',
+							moduleTranslationArgs
+						),
+						buttonRemoteManagement
+					);
+					break;
+				default:
+					notices.error(
+						i18n.translate(
+							'An error occurred while activating the Jetpack %(module)s feature on %(site)s.',
+							moduleTranslationArgs
+						)
+					);
+					break;
+			}
+		}
+
+		if ( 'deactivateModule' === action ) {
+			switch ( error.error ) {
+				case 'unauthorized_full_access':
+					notices.error(
+						i18n.translate(
+							'Error deactivating the Jetpack %(module)s feature on %(site)s, remote management is off.',
+							moduleTranslationArgs
+						),
+						buttonRemoteManagement
+					);
+					break;
+				default:
+					notices.error(
+						i18n.translate(
+							'An error occurred while deactivating the Jetpack %(module)s feature on %(site)s.',
+							moduleTranslationArgs
+						)
+					);
+					break;
+			}
+		}
+	},
+
 	toggleJetpackModule( module ) {
 		const event = this.props.site.isModuleActive( module ) ? 'deactivate' : 'activate';
 		notices.clearNotices( 'notices' );
@@ -116,10 +178,9 @@ module.exports = {
 			if ( error ) {
 				debug( 'jetpack module toggle error', error );
 				this.handleError();
-				this.props.site.handleError(
+				this.handleToggleJetpackModuleError(
 					error,
 					this.props.site.isModuleActive( module ) ? 'deactivateModule' : 'activateModule',
-					{},
 					module
 				);
 			} else {

--- a/client/my-sites/site-settings/form-base.js
+++ b/client/my-sites/site-settings/form-base.js
@@ -3,7 +3,7 @@
  */
 import debugFactory from 'debug';
 import omit from 'lodash/omit';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -115,7 +115,7 @@ module.exports = {
 
 		const remoteManagementUrl = this.props.site.getRemoteManagementURL();
 		const buttonRemoteManagement = {
-			button: i18n.translate( 'Turn On.' ),
+			button: translate( 'Turn On.' ),
 			href: remoteManagementUrl
 		};
 		let moduleTranslationArgs = {};
@@ -128,7 +128,7 @@ module.exports = {
 			switch ( error.error ) {
 				case 'unauthorized_full_access':
 					notices.error(
-						i18n.translate(
+						translate(
 							'Error activating the Jetpack %(module)s feature on %(site)s, remote management is off.',
 							moduleTranslationArgs
 						),
@@ -137,7 +137,7 @@ module.exports = {
 					break;
 				default:
 					notices.error(
-						i18n.translate(
+						translate(
 							'An error occurred while activating the Jetpack %(module)s feature on %(site)s.',
 							moduleTranslationArgs
 						)
@@ -150,7 +150,7 @@ module.exports = {
 			switch ( error.error ) {
 				case 'unauthorized_full_access':
 					notices.error(
-						i18n.translate(
+						translate(
 							'Error deactivating the Jetpack %(module)s feature on %(site)s, remote management is off.',
 							moduleTranslationArgs
 						),
@@ -159,7 +159,7 @@ module.exports = {
 					break;
 				default:
 					notices.error(
-						i18n.translate(
+						translate(
 							'An error occurred while deactivating the Jetpack %(module)s feature on %(site)s.',
 							moduleTranslationArgs
 						)
@@ -215,14 +215,14 @@ module.exports = {
 				// handle error case here
 				switch ( error.error ) {
 					case 'invalid_ip':
-						notices.error( this.translate( 'One of your IP Addresses was invalid. Please, try again.' ) );
+						notices.error( translate( 'One of your IP Addresses was invalid. Please, try again.' ) );
 						break;
 					default:
-						notices.error( this.translate( 'There was a problem saving your changes. Please, try again.' ) );
+						notices.error( translate( 'There was a problem saving your changes. Please, try again.' ) );
 				}
 				this.setState( { submittingForm: false } );
 			} else {
-				notices.success( this.translate( 'Settings saved!' ) );
+				notices.success( translate( 'Settings saved!' ) );
 				this.props.markSaved && this.props.markSaved();
 				//for dirtyFields, see lib/mixins/dirty-linked-state
 				this.setState( { submittingForm: false, dirtyFields: [] } );


### PR DESCRIPTION
It appears that `JetpackSite.prototype.handleError` is used in only one location: https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/site-settings/form-base.js#L119

It's not the best designed method anyway, and serves a purpose that's too component-specific. We can definitely move it directly to `formBase` for now. This is what this PR essentially suggests:

* Moving the `JetpackSite.prototype.handleError` as a separate method in `formBase`.
* Adapting it to work within the new context.
* Removing `JetpackSite.prototype.handleError` completely.

There should be no functional changes; everything should be working like it did before.

To test:
* Checkout this branch
* Go to `/settings/security/$site`, where `$site` is one of your Jetpack sites.
* Force Calypso to bail when activating/deactivating Monitor by either:
  * Loading `/settings/security`, then manually toggling Monitor in your JP site, then clicking the button;
  * Loading `/settings/security` in 2 separate tabs, toggling in one of them, then immediately toggling the other.
* In the Monitor card, click "Activate" / "Deactivate", but after you force Calypso to fail at that action.
* You should see an error like this one:

![](https://cldup.com/hA2ltDglpN.png)
* Test the same steps in production and verify there are no functional/behavioral changes.