### PR TITLE
Domains: Update email forwarding behavior if site has custom domain

### DIFF
--- a/client/my-sites/upgrades/domain-management/email/index.jsx
+++ b/client/my-sites/upgrades/domain-management/email/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import page from 'page';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -24,6 +25,7 @@ import {
 	getSelectedDomain
 } from 'lib/domains';
 import { isPlanFeaturesEnabled } from 'lib/plans';
+import { hasCustomDomain } from 'lib/site/utils';
 
 const Email = React.createClass( {
 	propTypes: {
@@ -58,7 +60,7 @@ const Email = React.createClass( {
 				<Header
 					onClick={ this.goToEditOrList }
 					selectedDomainName={ this.props.selectedDomainName }>
-					{ this.translate( 'Email' ) }
+					{ this.props.translate( 'Email' ) }
 				</Header>
 			);
 		}
@@ -91,20 +93,21 @@ const Email = React.createClass( {
 		const {
 			selectedSite,
 			selectedDomainName,
+			translate
 			} = this.props;
 		let emptyContentProps;
 
 		if ( selectedDomainName ) {
 			emptyContentProps = {
-				title: this.translate( 'G Suite is not supported on this domain' ),
-				line: this.translate( 'Only domains registered with WordPress.com are eligible for G Suite.' ),
-				secondaryAction: this.translate( 'Add Email Forwarding' ),
+				title: translate( 'G Suite is not supported on this domain' ),
+				line: translate( 'Only domains registered with WordPress.com are eligible for G Suite.' ),
+				secondaryAction: translate( 'Add Email Forwarding' ),
 				secondaryActionURL: paths.domainManagementEmailForwarding( selectedSite.slug, selectedDomainName )
 			};
 		} else {
 			emptyContentProps = {
-				title: this.translate( "Enable powerful email features." ),
-				line: this.translate(
+				title: translate( 'Enable powerful email features.' ),
+				line: translate(
 					'To set up email forwarding, G Suite, and other email ' +
 					'services for your site, upgrade your site’s web address ' +
 					'to a professional custom domain.'
@@ -113,7 +116,7 @@ const Email = React.createClass( {
 		}
 		Object.assign( emptyContentProps, {
 			illustration: '/calypso/images/drake/drake-whoops.svg',
-			action: this.translate( 'Add a Custom Domain' ),
+			action: translate( 'Add a Custom Domain' ),
 			actionURL: '/domains/add/' + this.props.selectedSite.slug
 		} );
 
@@ -126,16 +129,30 @@ const Email = React.createClass( {
 		return <GoogleAppsUsersCard { ...this.props } />;
 	},
 
+	renderEmailForwarding() {
+		let domain;
+
+		if ( this.props.selectedDomainName ) {
+			domain = this.props.selectedDomainName;
+		} else if ( hasCustomDomain( this.props.selectedSite ) ) {
+			domain = this.props.selectedSite.domain;
+		}
+
+		return (
+			domain && <VerticalNav>
+				<VerticalNavItem
+					path={ paths.domainManagementEmailForwarding( this.props.selectedSite.slug, domain ) }>
+					{ this.props.translate( 'Email Forwarding' ) }
+				</VerticalNavItem>
+			</VerticalNav>
+		);
+	},
+
 	addGoogleAppsCard() {
 		return (
 			<div>
 				<AddGoogleAppsCard { ...this.props } />
-				{ this.props.selectedDomainName && <VerticalNav>
-					<VerticalNavItem
-						path={ paths.domainManagementEmailForwarding( this.props.selectedSite.slug, this.props.selectedDomainName ) }>
-						{ this.translate( 'Email Forwarding' ) }
-					</VerticalNavItem>
-				</VerticalNav> }
+				{ this.renderEmailForwarding() }
 			</div>
 		);
 	},
@@ -149,4 +166,4 @@ const Email = React.createClass( {
 	}
 } );
 
-module.exports = Email;
+export default localize( Email );


### PR DESCRIPTION
This is an enhancement targeted at fixing #12932. Currently, if you navigate to Plan -> Email from WordPress.com, you won't see the email forwarding option underneath the G Suite card since a domain isn't selected. This PR defaults back to the primary domain on the site if the site has a custom domain. 

This assumption that you would want to use the primary domain on your account matches the G Suite behavior meaning if you have multiple domains and navigate to Plan -> Email -> Add G Suite, we assume you want to add it to the primary custom domain on your account.

G Suite also has a toggle on the form to change the domain associated with the email. I'm torn on which is a better experience - defaulting to the primary custom domain or building in a toggle. Thoughts?

<img width="756" alt="screen shot 2017-04-13 at 6 29 28 am" src="https://cloud.githubusercontent.com/assets/7240478/25004774/34499d82-2013-11e7-8f98-00a5df8c3a8d.png">

## To test
1. Setup a site with a custom domain and a plan. Do not set the custom domain as primary.
2. Start on the Plan page here: https://calypso.localhost:3000/plans/my-plan/.
3. Click "Email" in the top menu bar. You should not see any email forwarding option.
4. Click "Domains" and set your custom domain as the primary domain.
5. Go back to https://calypso.localhost:3000/plans/my-plan/. Click on "Email" again. You should see the Email Forwarding option. If you click on it, it should use the primary custom domain associated with your site.

## GIF
![emailforwarding](https://cloud.githubusercontent.com/assets/7240478/25004767/2dfe931a-2013-11e7-9c34-8341b40c8c0e.gif)