### PR TITLE
Framework: Redirect old /menus routes to /customize/menus

### DIFF
--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -7,6 +7,7 @@ var React = require( 'react' ),
 	cloneDeep = require( 'lodash/cloneDeep' ),
 	connect = require( 'react-redux' ).connect,
 	debug = require( 'debug' )( 'calypso:my-sites:customize' );
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,6 +20,7 @@ var notices = require( 'notices' ),
 	Actions = require( 'my-sites/customize/actions' ),
 	themeActivated = require( 'state/themes/actions' ).themeActivated;
 import { getCustomizerFocus } from './panels';
+import { getMenusUrl } from 'state/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 
 var loadingTimer;
@@ -51,6 +53,7 @@ var Customize = React.createClass( {
 	},
 
 	componentWillMount: function() {
+		this.redirectIfNeeded( this.props.menusUrl, this.props.site );
 		this.listenToCustomizer();
 		this.waitForLoading();
 		window.scrollTo( 0, 0 );
@@ -59,6 +62,16 @@ var Customize = React.createClass( {
 	componentWillUnmount: function() {
 		window.removeEventListener( 'message', this.onMessage, false );
 		this.cancelWaitingTimer();
+	},
+
+	componentWillReceiveProps: function( nextProps ) {
+		this.redirectIfNeeded( nextProps.menusUrl, nextProps.site );
+	},
+
+	redirectIfNeeded: function( menusUrl, site ) {
+		if ( site && menusUrl !== '/customize/menus/' + site.slug ) {
+			page( menusUrl );
+		}
 	},
 
 	canUserCustomizeDomain: function() {
@@ -301,8 +314,12 @@ var Customize = React.createClass( {
 } );
 
 export default connect(
-	( state ) => ( {
-		site: getSelectedSite( state )
-	} ),
+	( state ) => {
+		const site = getSelectedSite( state );
+		return {
+			site,
+			menusUrl: getMenusUrl( state, get( site, 'ID' ) )
+		};
+	},
 	{ themeActivated }
 )( Customize );

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -337,6 +337,14 @@ module.exports = function() {
 		} );
 	}
 
+	// Redirect legacy `/menus` routes to the corresponding Customizer panel
+	// TODO: Move to `my-sites/customize` route defs once that section is isomorphic
+	app.get( [ '/menus', '/menus/:site?' ], ( req, res ) => {
+		const siteSlug = get( req.params, 'site', '' );
+		const newRoute = '/customize/menus/' + siteSlug;
+		res.redirect( 301, newRoute );
+	} );
+
 	sections
 		.filter( section => ! section.envId || section.envId.indexOf( config( 'env_id' ) ) > -1 )
 		.forEach( section => {


### PR DESCRIPTION
Fixes #12980. Simpler approach than #12998.

This consists of two parts:
* A 'dumb' server side redirect that takes every user from `/menus/:site?` to `/customize/menus/:site`
* A 'smart' client side redirect, see commit description:

> This is for redirects from the old `/menus` section. When a user points their browser to `/menus/myjetpacksite.com`, the server redirects them to `/customize/menus/myjetpacksite.com`. We then check if the given site is a Jetpack site. If it is, we can't use the WP.com customizer. Instead, we redirect them to their self-hosted site's own customizer.
> The `getMenusUrl()` selector we're using is also used by the sidebar -- this way, we ensure that we always mirror its behavior. It also covers other edge cases, such as a user with unverified e-mail.

(We can't do this 'smart' redirect on the server side, since we need information about a user's sites, which isn't available there AFAIK.)

To test:
* Land on http://calypso.localhost:3000/menus and http://calypso.localhost:3000/menus/<yoursite>
* Verify that you're being redirected to http://calypso.localhost:3000/customize/menus and http://calypso.localhost:3000/cusotmize/menus/<yoursite>, respectively
* Use a JP site for <yoursite>. Verify you're redirected to that site's customizer.
* With a user with unverified email, check that you're redirected to `/customize/<yoursite>` (no `/menus` route fragment)