### PR TITLE
Customizer: Remove sites-list

### DIFF
--- a/client/my-sites/customize/controller.js
+++ b/client/my-sites/customize/controller.js
@@ -9,12 +9,9 @@ import { Provider as ReduxProvider } from 'react-redux';
 /**
  * Internal Dependencies
  */
-import sitesFactory from 'lib/sites-list';
 import { sectionify } from 'lib/route/path';
 import analytics from 'lib/analytics';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-
-const sites = sitesFactory();
 
 export function customize( context ) {
 	const CustomizeComponent = require( 'my-sites/customize/main' ),
@@ -29,7 +26,6 @@ export function customize( context ) {
 		React.createElement( ReduxProvider, { store: context.store },
 			React.createElement( CustomizeComponent, {
 				domain: context.params.domain || '',
-				sites: sites,
 				prevPath: context.prevPath || '',
 				query: context.query,
 				panel: context.params.panel

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -5,7 +5,6 @@ var React = require( 'react' ),
 	url = require( 'url' ),
 	Qs = require( 'qs' ),
 	cloneDeep = require( 'lodash/cloneDeep' ),
-	bindActionCreators = require( 'redux' ).bindActionCreators,
 	connect = require( 'react-redux' ).connect,
 	debug = require( 'debug' )( 'calypso:my-sites:customize' );
 
@@ -318,6 +317,6 @@ var Customize = React.createClass( {
 } );
 
 export default connect(
-	( state, props ) => props,
-	bindActionCreators.bind( null, { themeActivated } )
+	null,
+	{ themeActivated }
 )( Customize );

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -19,6 +19,7 @@ var notices = require( 'notices' ),
 	Actions = require( 'my-sites/customize/actions' ),
 	themeActivated = require( 'state/themes/actions' ).themeActivated;
 import { getCustomizerFocus } from './panels';
+import { getSelectedSite } from 'state/ui/selectors';
 
 var loadingTimer;
 
@@ -27,7 +28,7 @@ var Customize = React.createClass( {
 
 	propTypes: {
 		domain: React.PropTypes.string.isRequired,
-		sites: React.PropTypes.object.isRequired,
+		site: React.PropTypes.object.isRequired,
 		prevPath: React.PropTypes.string,
 		query: React.PropTypes.object,
 		themeActivated: React.PropTypes.func.isRequired,
@@ -43,7 +44,6 @@ var Customize = React.createClass( {
 
 	getInitialState: function() {
 		return {
-			isWaitingForSiteData: true,
 			iframeLoaded: false,
 			errorFromIframe: false,
 			timeoutError: false
@@ -51,32 +51,18 @@ var Customize = React.createClass( {
 	},
 
 	componentWillMount: function() {
-		this.props.sites.on( 'change', this.sitesDidUpdate );
 		this.listenToCustomizer();
 		this.waitForLoading();
-		this.sitesDidUpdate();
 		window.scrollTo( 0, 0 );
 	},
 
 	componentWillUnmount: function() {
-		this.props.sites.off( 'change', this.sitesDidUpdate );
 		window.removeEventListener( 'message', this.onMessage, false );
 		this.cancelWaitingTimer();
 	},
 
-	sitesDidUpdate: function() {
-		if ( this.props.sites.fetched === true ) {
-			this.props.sites.off( 'change', this.sitesDidUpdate );
-			this.setState( { isWaitingForSiteData: false } );
-		}
-	},
-
-	getSite: function() {
-		return this.props.sites.getSite( this.props.domain );
-	},
-
 	canUserCustomizeDomain: function() {
-		var site = this.getSite();
+		const { site } = this.props;
 		if ( ! site ) {
 			debug( 'domain is not in the user\'s site list', this.props.domain );
 			return false;
@@ -129,7 +115,7 @@ var Customize = React.createClass( {
 	},
 
 	getUrl: function() {
-		var site = this.getSite();
+		const { site } = this.props;
 		if ( ! site ) {
 			return false;
 		}
@@ -148,8 +134,7 @@ var Customize = React.createClass( {
 	buildCustomizerQuery: function() {
 		const { protocol, host } = window.location;
 		const query = cloneDeep( this.props.query );
-		const site = this.getSite();
-		const { panel } = this.props;
+		const { panel, site } = this.props;
 
 		query.return = protocol + '//' + host + this.getPreviousPath();
 		query.calypso = true;
@@ -176,15 +161,14 @@ var Customize = React.createClass( {
 	},
 
 	onMessage: function( event ) {
-		var message, themeSlug, parsedOrigin, parsedSite,
-			site = this.getSite();
+		const { site } = this.props;
 		if ( ! site || ! site.options ) {
 			debug( 'ignoring message received from iframe because the site data cannot be found' );
 			return;
 		}
 
-		parsedOrigin = url.parse( event.origin, true );
-		parsedSite = url.parse( site.options.unmapped_url );
+		const parsedOrigin = url.parse( event.origin, true );
+		const parsedSite = url.parse( site.options.unmapped_url );
 
 		if ( parsedOrigin.hostname !== this.props.domain && parsedOrigin.hostname !== parsedSite.hostname ) {
 			debug( 'ignoring message received from iframe with incorrect origin', event.origin );
@@ -195,7 +179,7 @@ var Customize = React.createClass( {
 			debug( 'ignoring message received from iframe with bad data', event.data );
 			return;
 		}
-		message = JSON.parse( event.data );
+		const message = JSON.parse( event.data );
 		if ( message.calypso && message.command ) {
 			switch ( message.command ) {
 				case 'back':
@@ -228,7 +212,7 @@ var Customize = React.createClass( {
 					Actions.activated( message.theme.stylesheet, site, this.props.themeActivated );
 					break;
 				case 'purchased':
-					themeSlug = message.theme.stylesheet.split( '/' )[ 1 ];
+					const themeSlug = message.theme.stylesheet.split( '/' )[ 1 ];
 					Actions.purchase( themeSlug, site );
 					break;
 			}
@@ -271,7 +255,7 @@ var Customize = React.createClass( {
 			} );
 		}
 
-		if ( this.props.sites.fetched !== true ) {
+		if ( ! this.props.site ) {
 			return (
 				<div className="main main-column customize is-iframe" role="main">
 					<CustomizerLoadingPanel />
@@ -317,6 +301,8 @@ var Customize = React.createClass( {
 } );
 
 export default connect(
-	null,
+	( state ) => ( {
+		site: getSelectedSite( state )
+	} ),
 	{ themeActivated }
 )( Customize );


### PR DESCRIPTION
Use the `getSelectedSite` selector instead.

To test:
* Make sure that the customizer still works. 

~Note that as of this writing, the customizer is broken in the `development` environment -- you'll only see the Customizer proper on the left, but the side preview on the right remains blank (because of a `frame-ancestors` CSP directive).~ @mattwiebe ~is fixing~ fixed it!