### PR TITLE
Sites: Get rid of JetpackSite.prototype.verifyModulesActive

### DIFF
--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -72,20 +72,6 @@ JetpackSite.prototype.isModuleActive = function( moduleId ) {
 	return this.modules && this.modules.indexOf( moduleId ) > -1;
 };
 
-JetpackSite.prototype.verifyModulesActive = function( moduleIds, callback ) {
-	var modulesActive;
-
-	if ( ! Array.isArray( moduleIds ) ) {
-		moduleIds = [ moduleIds ];
-	}
-
-	modulesActive = moduleIds.every( function( moduleId ) {
-		return this.isModuleActive( moduleId );
-	}, this );
-
-	callback( null, modulesActive );
-};
-
 JetpackSite.prototype.getRemoteManagementURL = function() {
 	var configure = versionCompare( this.options.jetpack_version, 3.4, '>=' ) ? 'manage' : 'json-api';
 	return this.options.admin_url + 'admin.php?page=jetpack&configure=' + configure;

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -336,7 +336,7 @@ module.exports = {
 		}
 	},
 
-	jetpackModuleActive( moduleIds, redirect ) {
+	jetpackModuleActive( moduleId, redirect ) {
 		return function( context, next ) {
 			const site = sites.getSelectedSite();
 
@@ -344,13 +344,11 @@ module.exports = {
 				return next();
 			}
 
-			site.verifyModulesActive( moduleIds, function( error, supported ) {
-				if ( supported || false === redirect ) {
-					next();
-				} else {
-					page.redirect( 'string' === typeof redirect ? redirect : '/stats' );
-				}
-			} );
+			if ( site.isModuleActive( moduleId ) || false === redirect ) {
+				next();
+			} else {
+				page.redirect( 'string' === typeof redirect ? redirect : '/stats' );
+			}
 		};
 	},
 

--- a/client/my-sites/site-settings/README.md
+++ b/client/my-sites/site-settings/README.md
@@ -18,7 +18,7 @@ Great question. In some cases, multiple users will connect their WordPress.com a
 
 #### API Communications
 
-1. We learn if the Jetpack module is active or not via the `verifyModulesActive` method on the Jetpack site component. This communicates directly with the site via a GET request to a Jetpack endpoint `/sites/:site_id:/jetpack/modules/`.
+1. We learn if the Jetpack module is active or not via the `isModuleActive` method on the Jetpack site component. This communicates directly with the site via a GET request to a Jetpack endpoint `/sites/:site_id:/jetpack/modules/`.
 
 2. We activate / deactivate the module by a POST request to a Jetpack endpoint `/sites/:site_id:/jetpack/modules/monitor`.
 

--- a/client/my-sites/site-settings/form-jetpack-monitor.jsx
+++ b/client/my-sites/site-settings/form-jetpack-monitor.jsx
@@ -55,13 +55,9 @@ module.exports = protectForm( React.createClass( {
 			}
 		} ).bind( this ) );
 
-		site.verifyModulesActive( [ 'monitor' ], ( function( error, moduleStatus ) {
-			if ( ! error ) {
-				this.setState( { enabled: moduleStatus } );
-			} else {
-				debug( 'error getting module status', error );
-			}
-		} ).bind( this ) );
+		this.setState( {
+			enabled: site.isModuleActive( 'monitor' )
+		} );
 	},
 
 	prompt: function() {


### PR DESCRIPTION
### Purpose

It appears that `JetpackSite.prototype.verifyModulesActive` is used in two places only. It does not do anything special, and can be avoided in favor of `isModuleActive` in all of these cases. This is what this PR essentially suggests:

* Refactor Monitor to use `site.isModuleActive` instead of `site.verifyModulesActive`.
* Refactor `my-sites/controller` to use `site.isModuleActive` instead of `site.verifyModulesActive`.
* Remove the `JetpackSite.prototype.verifyModulesActive` method from this world.

There should be no functional or behavioral changes - everything should work like it did before.

### To test:

* Checkout this branch.
* Let `$site` is one of your Jetpack sites.
* Activate the `monitor` module on your site.
* Go to `/settings/security/$site`.
* Verify your Monitor status is retrieved properly (note it might take some seconds to sync).
* Deactivate the `monitor` module on your site.
* Go to `/settings/security/$site`.
* Verify your Monitor status is retrieved properly (note it might take some seconds to sync).
* Disable the `sharedaddy` module on your site.
* Go to `/sharing/buttons/$site` and verify you're redirected to `/stats`.
* Enable the `sharedaddy` module on your site.
* Go to `/sharing/buttons/$site` and verify it does not redirect and loads the sharing buttons page.

### FAQ:

**How to activate a Jetpack module?**
Use Jetpack CLI: `wp jetpack module activate $module`

**How to deactivate a Jetpack module?**
Use Jetpack CLI: `wp jetpack module deactivate $module`