### PR TITLE
Themes: updated Banner, better copy, tailored to plans

### DIFF
--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -34,14 +34,18 @@ const ConnectedSingleSiteWpcom = connectOptions(
 				{ ( currentPlanSlug === PLAN_FREE || currentPlanSlug === PLAN_PERSONAL ) && <Banner
 					plan={ PLAN_PREMIUM }
 					title={ translate( 'Access all our premium themes with our Premium and Business plans!' ) }
-					description={ translate( 'Get also advanced customization, more space, and video support.' ) }
+					description={
+						translate( 'Get advanced customization, more storage space, and video support along with all your new themes.' )
+					}
 					event="themes_custom_design"
 				/>
 				}
 				{ ( currentPlanSlug === PLAN_PREMIUM ) && <Banner
 					plan={ PLAN_BUSINESS }
 					title={ translate( 'Why not upgrade to Business?' ) }
-					description={ translate( 'Get Google Analytics integration, more SEO tools, personalized help, and more.' ) }
+					description={
+						translate( 'Get Google Analytics integration, advanced SEO tools, personalized help, and more.' )
+					}
 					event="themes_custom_design"
 				/>
 				}

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -10,26 +11,41 @@ import CurrentTheme from 'my-sites/themes/current-theme';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 import { connectOptions } from './theme-options';
-import { FEATURE_ADVANCED_DESIGN } from 'lib/plans/constants';
-import UpgradeNudge from 'my-sites/upgrade-nudge';
+import Banner from 'components/banner';
+import {
+	PLAN_FREE,
+	PLAN_PERSONAL,
+	PLAN_PREMIUM,
+	PLAN_BUSINESS,
+} from 'lib/plans/constants';
+import { getCurrentPlan } from 'state/sites/plans/selectors';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ThemeShowcase from './theme-showcase';
 
-export default connectOptions(
+const ConnectedSingleSiteWpcom = connectOptions(
 	( props ) => {
-		const { siteId, translate } = props;
+		const { siteId, currentPlanSlug, translate } = props;
 
 		return (
 			<div>
 				<SidebarNavigation />
 				<CurrentTheme siteId={ siteId } />
-				<UpgradeNudge
-					title={ translate( 'Get Custom Design with Premium' ) }
-					message={ translate( 'Customize your theme using premium fonts, color palettes, and the CSS editor.' ) }
-					feature={ FEATURE_ADVANCED_DESIGN }
+				{ ( currentPlanSlug === PLAN_FREE || currentPlanSlug === PLAN_PERSONAL ) && <Banner
+					plan={ PLAN_PREMIUM }
+					title={ translate( 'Access all our premium themes with our Premium and Business plans!' ) }
+					description={ translate( 'Get also advanced customization, more space, and video support.' ) }
 					event="themes_custom_design"
-					/>
+				/>
+				}
+				{ ( currentPlanSlug === PLAN_PREMIUM ) && <Banner
+					plan={ PLAN_BUSINESS }
+					title={ translate( 'Why not upgrade to Business?' ) }
+					description={ translate( 'Get Google Analytics integration, more SEO tools, personalized help, and more.' ) }
+					event="themes_custom_design"
+				/>
+				}
+
 				<ThemeShowcase { ...props } siteId={ siteId }>
 					{ siteId && <QuerySitePlans siteId={ siteId } /> }
 					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
@@ -39,3 +55,12 @@ export default connectOptions(
 		);
 	}
  );
+
+export default connect(
+	( state, { siteId } ) => {
+		const currentPlan = getCurrentPlan( state, siteId ) || null;
+		return {
+			currentPlanSlug: currentPlan && currentPlan.productSlug,
+		};
+	}
+)( ConnectedSingleSiteWpcom );

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -17,7 +17,6 @@ import {
 	PLAN_FREE,
 	PLAN_PERSONAL,
 	PLAN_PREMIUM,
-	PLAN_BUSINESS,
 } from 'lib/plans/constants';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import QuerySitePlans from 'components/data/query-site-plans';
@@ -39,15 +38,6 @@ const ConnectedSingleSiteWpcom = connectOptions(
 						translate( 'Get advanced customization, more storage space, and video support along with all your new themes.' )
 					}
 					event="themes_plans_free_personal"
-				/>
-				}
-				{ ( currentPlanSlug === PLAN_PREMIUM ) && <Banner
-					plan={ PLAN_BUSINESS }
-					title={ translate( 'Why not upgrade to Business?' ) }
-					description={
-						translate( 'Get Google Analytics integration, advanced SEO tools, personalized help, and more.' )
-					}
-					event="themes_plans_premium"
 				/>
 				}
 

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -62,9 +63,9 @@ const ConnectedSingleSiteWpcom = connectOptions(
 
 export default connect(
 	( state, { siteId } ) => {
-		const currentPlan = getCurrentPlan( state, siteId ) || null;
+		const currentPlan = getCurrentPlan( state, siteId );
 		return {
-			currentPlanSlug: currentPlan && currentPlan.productSlug,
+			currentPlanSlug: get( currentPlan, 'productSlug', null ),
 		};
 	}
 )( ConnectedSingleSiteWpcom );

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -38,7 +38,7 @@ const ConnectedSingleSiteWpcom = connectOptions(
 					description={
 						translate( 'Get advanced customization, more storage space, and video support along with all your new themes.' )
 					}
-					event="themes_custom_design"
+					event="themes_plans_free_personal"
 				/>
 				}
 				{ ( currentPlanSlug === PLAN_PREMIUM ) && <Banner
@@ -47,7 +47,7 @@ const ConnectedSingleSiteWpcom = connectOptions(
 					description={
 						translate( 'Get Google Analytics integration, advanced SEO tools, personalized help, and more.' )
 					}
-					event="themes_custom_design"
+					event="themes_plans_premium"
 				/>
 				}
 

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -2,6 +2,10 @@
 /*
  * Search card and text input
  */
+.themes-magic-search {
+	margin-top: 24px;
+}
+
 .themes-magic-search-card {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
This PR brings a series of improvements to the existing banner in Themes:

1. It shows different banners to Free and Personal -vs- Premium.
2. Shows the banner also to lower-tier plans, not just Free.
3. Updated copy (I need a review on this, it's just a first draft)
4. Switches out the deprecated `UpgradeNudge` with `Banner`.

Current (shown on Free only):

![screen shot 2017-04-13 at 16 13 53](https://cloud.githubusercontent.com/assets/4389/25011133/3ca5129e-2064-11e7-8fe4-8e6e9bf1fd49.png)



This PR, Banner for sites on Free and Personal (copy has been updated, see below):

![screen shot 2017-04-13 at 16 02 01](https://cloud.githubusercontent.com/assets/4389/25010825/2e50cf68-2063-11e7-89d4-e3da50ecf497.png)

This PR, Banner for sites on Premium (copy has been updated, see below):

![screen shot 2017-04-13 at 16 01 53](https://cloud.githubusercontent.com/assets/4389/25010832/33167ebc-2063-11e7-8c29-46c10898424c.png)



Note that changing the component also changes tracking from `calypso_upgrade_nudge_cta_click` to `calypso_banner_cta_click`. In both cases the `cta_name` will stay the same: `themes_custom_design`. We might want do differentiate the two banners tho? Advice is welcome.

### To test

1. Open Calypso Themes
2. Check the banner on a Free site (green banner)
3. Check the banner on a Personal site (green banner)
4. Check the banner on a Premium site (violet banner)
5. Check the banner on a Business site (no banner)