### PR TITLE
Magic Login: Disable input in email field during submission

### DIFF
--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -92,6 +92,7 @@ class RequestLoginEmailForm extends React.Component {
 						<FormTextInput
 							autoCapitalize="off"
 							autoFocus="true"
+							disabled={ isFetching || emailRequested }
 							name="emailAddress"
 							placeholder="Email address"
 							value={ this.props.emailAddress }


### PR DESCRIPTION
Since the form input is tied directly to a value in state, continued editing of the email field after the fetch is initiated results in an inconsistent state. Namely, the email address shown on the "go check your email" page will reflect any change in input before the server response is received and processed.

This avoids that issue by disabling the input field after submission.

## To Test

* Enable network throttling in your browser. For example, in the network tab of the Chrome developer console, select GPRS:
<img width="559" alt="screen shot 2017-04-13 at 11 10 59 am" src="https://cloud.githubusercontent.com/assets/1587282/25011085/21178842-203a-11e7-9542-8dcacd93ceee.png">

* Browse to the [login page](http://calypso.localhost/login)
* Request an email be sent to your address
* Quickly attempt to edit the email address field.
  * The field should be non-editable after form submission
  * The "check your email" page should show the address which was submitted
