### PR TITLE
NPS Survey: Enable survey feature flag in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -65,7 +65,7 @@
 		"me/trophies": false,
 		"nps-survey/devdocs": false,
 		"nps-survey/dev-trigger": false,
-		"nps-survey/notice": false,
+		"nps-survey/notice": true,
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,


### PR DESCRIPTION
This enables the Net Promotor Score survey in the production environment.

The feature has been available in wpcalypso and staging environments and this change completes the initial release.

Testing is mostly a spot check for unexpected behavior post-merge.

Since this flag is not yet present in the desktop config, this change should not affect that environment.