### PR TITLE
Reader Manage Following Refresh: add sort controls

### DIFF
--- a/client/reader/following-manage/sort-controls.jsx
+++ b/client/reader/following-manage/sort-controls.jsx
@@ -1,0 +1,42 @@
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { noop } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import FormSelect from 'components/forms/form-select';
+
+class FollowingManageSortControls extends React.Component {
+
+	static propTypes = {
+		onSelectChange: React.PropTypes.func,
+		sortOrder: React.PropTypes.oneOf( [ 'date-followed', 'alpha' ] ),
+	}
+
+	static defaultProps = {
+		onSelectChange: noop,
+		sortOrder: 'date-followed',
+	}
+
+	handleSelectChange = ( event ) => {
+		this.props.onSelectChange( event.target.value );
+	}
+
+	render() {
+		const sortOrder = this.props.sortOrder;
+
+		return (
+			<FormSelect className="following-manage__sort-controls" onChange={ this.handleSelectChange } value={ sortOrder }>
+				<option value="date-followed">{ this.props.translate( 'Sort by date' ) }</option>
+				<option value="alpha">{ this.props.translate( 'Sort by name' ) }</option>
+			</FormSelect>
+		);
+	}
+}
+
+export default localize( FollowingManageSortControls );

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -1,3 +1,4 @@
+
 .following-manage__header {
 	font-weight: 600;
 	margin: 14px 0 14px 14px;
@@ -7,7 +8,7 @@
 	}
 }
 
-.following-manage__search-new {
+.following-manage .search {
 	margin: 0;
 }
 
@@ -18,15 +19,97 @@
 .following-manage__subscriptions {
 	margin-top: 20px;
 	padding-top: 10px;
-	border-top: 1px solid $gray-light;
 }
 
+// Subscription controls
 .following-manage__subscriptions-controls {
 	display: flex;
-	padding-bottom: 20px;
 
-	.reader-import-button, .reader-export-button, .following-manage__search-followed {
+	@include breakpoint( "<660px" ) {
+		flex-wrap: wrap;
+		margin: 0 15px;
+	}
+
+	> :not( :first-child ) {
 		margin-right: 10px;
+	}
+
+	.following-manage__subscriptions-heading {
+		flex: 1;
+		font-weight: 700;
+		padding-bottom: 15px;
+
+		@include breakpoint( "<480px" ) {
+			flex: 0 0 auto;
+			width: 100%;
+		}
+	}
+
+	.following-manage__subscriptions-sort,
+	.following-manage__subscriptions-search {
+
+		@include breakpoint( "<480px" ) {
+			flex: 1;
+		}
+	}
+
+	.following-manage__subscriptions-sort .following-manage__sort-controls {
+		color: darken( $gray, 10% );
+		font-size: 12px;
+		font-weight: normal;
+
+		@include breakpoint( "<480px" ) {
+			width: 100%;
+		}
+	}
+
+	.following-manage__subscriptions-search {
+		margin-top: 1px;
+
+		@include breakpoint( "<660px" ) {
+			margin-right: 0;
+		}
+	}
+
+	.following-manage__subscriptions-search .search-card {
+		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .3 );
+
+		.following-manage__search-followed-input.is-compact {
+			height: 32px;
+
+			@include breakpoint( "<660px" ) {
+				min-width: 0;
+			}
+		}
+
+		.search__input {
+			background: transparent;
+			height: 30px;
+		}
+	}
+
+	.following-manage__subscriptions-import-export {
+		margin-right: 0;
+
+		@include breakpoint( "<660px" ) {
+			display: none;
+		}
+	}
+}
+
+.following-manage__subscriptions-import-export-menu-item {
+	.reader-import-button__icon, .reader-export-button__icon {
+		vertical-align: middle;
+	}
+
+	&:hover {
+		.reader-import-button__icon, .reader-export-button__icon {
+			fill: $white;
+		}
+
+		.reader-import-button__label, .reader-export-button__label {
+			color: $white;
+		}
 	}
 }
 

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -25,8 +25,11 @@
 .following-manage__subscriptions-controls {
 	display: flex;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( "<960px" ) {
 		flex-wrap: wrap;
+	}
+
+	@include breakpoint( "<660px" ) {
 		margin: 0 15px;
 	}
 
@@ -34,12 +37,12 @@
 		margin-right: 10px;
 	}
 
-	.following-manage__subscriptions-heading {
+	.following-manage__subscriptions-header {
 		flex: 1;
-		font-weight: 700;
+		font-weight: 600;
 		padding-bottom: 15px;
 
-		@include breakpoint( "<480px" ) {
+		@include breakpoint( "<960px" ) {
 			flex: 0 0 auto;
 			width: 100%;
 		}
@@ -48,7 +51,7 @@
 	.following-manage__subscriptions-sort,
 	.following-manage__subscriptions-search {
 
-		@include breakpoint( "<480px" ) {
+		@include breakpoint( "<960px" ) {
 			flex: 1;
 		}
 	}
@@ -58,7 +61,7 @@
 		font-size: 12px;
 		font-weight: normal;
 
-		@include breakpoint( "<480px" ) {
+		@include breakpoint( "<960px" ) {
 			width: 100%;
 		}
 	}
@@ -94,20 +97,30 @@
 		@include breakpoint( "<660px" ) {
 			display: none;
 		}
+
+		.gridicon.gridicons-ellipsis {
+			fill: lighten( $gray, 10% );
+			top: 0;
+		}
 	}
 }
 
 .following-manage__subscriptions-import-export-menu-item {
-	.reader-import-button__icon, .reader-export-button__icon {
+
+	.reader-import-button__icon,
+	.reader-export-button__icon {
 		vertical-align: middle;
 	}
 
-	&:hover {
-		.reader-import-button__icon, .reader-export-button__icon {
+	&:hover,
+	&:focus {
+		.reader-import-button__icon,
+		.reader-export-button__icon {
 			fill: $white;
 		}
 
-		.reader-import-button__label, .reader-export-button__label {
+		.reader-import-button__label,
+		.reader-export-button__label {
 			color: $white;
 		}
 	}

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -4,32 +4,58 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { getReaderFollows } from 'state/selectors';
+import escapeRegexp from 'escape-string-regexp';
 
 /**
  * Internal Dependencies
  */
-import SitesWindowScroller from './sites-window-scroller';
-import QueryReaderFollows from 'components/data/query-reader-follows';
-import FollowingManageSortControls from './sort-controls';
-import FollowingManageSearchFollowed from './search-followed';
-import EllipsisMenu from 'components/ellipsis-menu';
-import PopoverMenuItem from 'components/popover/menu-item';
 import ReaderImportButton from 'blocks/reader-import-button';
 import ReaderExportButton from 'blocks/reader-export-button';
+import SitesWindowScroller from './sites-window-scroller';
+import QueryReaderFollows from 'components/data/query-reader-follows';
+import FollowingManageSearchFollowed from './search-followed';
+import FollowingManageSortControls from './sort-controls';
+import { getFeed as getReaderFeed } from 'state/reader/feeds/selectors';
+import { getSite as getReaderSite } from 'state/reader/sites/selectors';
+import { getReaderFollows } from 'state/selectors';
+import UrlSearch from 'lib/url-search';
+import { getSiteName, getSiteUrl, getSiteDescription, getSiteAuthorName } from 'reader/get-helpers';
+import EllipsisMenu from 'components/ellipsis-menu';
+import PopoverMenuItem from 'components/popover/menu-item';
 
 class FollowingManageSubscriptions extends Component {
 	static propTypes = {
 		follows: PropTypes.array.isRequired,
+		doSearch: PropTypes.func.isRequired,
 	};
 
+	filterFollowsByQuery( query ) {
+		const { getFeed, getSite, follows } = this.props;
+		const phraseRe = new RegExp( escapeRegexp( query ), 'i' );
+
+		return follows.filter( follow => {
+			const feed = getFeed( follow.feed_ID ); // todo grab feed and site for current sub
+			const site = getSite( follow.site_ID );
+			const siteName = getSiteName( { feed, site } );
+			const siteUrl = getSiteUrl( { feed, site } );
+			const siteDescription = getSiteDescription( { feed, site } );
+			const siteAuthor = getSiteAuthorName( site );
+
+			return (
+				`${ follow.URL }${ siteName }${ siteUrl }${ siteDescription }${ siteAuthor }`
+			).search( phraseRe ) !== -1;
+		} );
+	}
+
 	render() {
-		const { follows, width, translate } = this.props;
+		const { follows, width, translate, query } = this.props;
+		const filteredFollows = this.filterFollowsByQuery( query );
+
 		return (
 			<div className="following-manage__subscriptions">
 				<QueryReaderFollows />
 				<div className="following-manage__subscriptions-controls">
-					<h1 className="following-manage__subscriptions-heading">
+					<h1 className="following-manage__subscriptions-header">
 						{
 							translate( '%(num)s Followed Sites', {
 								args: { num: follows.length }
@@ -40,7 +66,7 @@ class FollowingManageSubscriptions extends Component {
 						<FollowingManageSortControls />
 					</div>
 					<div className="following-manage__subscriptions-search">
-						<FollowingManageSearchFollowed />
+						<FollowingManageSearchFollowed onSearch={ this.props.doSearch } initialValue={ query } />
 					</div>
 					<div className="following-manage__subscriptions-import-export">
 						<EllipsisMenu toggleTitle={ translate( 'More' ) } position="bottom">
@@ -54,16 +80,25 @@ class FollowingManageSubscriptions extends Component {
 					</div>
 				</div>
 				<div className="following-manage__subscriptions-list">
-					<SitesWindowScroller
-						sites={ follows }
-						width={ width }
-					/>
+					{ follows &&
+						<SitesWindowScroller
+							sites={ filteredFollows }
+							width={ width } />
+					}
 				</div>
 			</div>
 		);
 	}
 }
 
+const mapStateToProps = state => {
+	const follows = getReaderFollows( state );
+	const getFeed = feedId => getReaderFeed( state, feedId );
+	const getSite = siteId => getReaderSite( state, siteId );
+
+	return { follows, getFeed, getSite };
+};
+
 export default connect(
-	state => ( { follows: getReaderFollows( state ) } ),
-)( localize( FollowingManageSubscriptions ) );
+	mapStateToProps,
+)( localize( UrlSearch( FollowingManageSubscriptions ) ) );

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -4,84 +4,52 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import escapeRegexp from 'escape-string-regexp';
+import { getReaderFollows } from 'state/selectors';
 
 /**
  * Internal Dependencies
  */
-import ReaderImportButton from 'blocks/reader-import-button';
-import ReaderExportButton from 'blocks/reader-export-button';
 import SitesWindowScroller from './sites-window-scroller';
 import QueryReaderFollows from 'components/data/query-reader-follows';
+import FollowingManageSortControls from './sort-controls';
 import FollowingManageSearchFollowed from './search-followed';
-import { getFeed as getReaderFeed } from 'state/reader/feeds/selectors';
-import { getSite as getReaderSite } from 'state/reader/sites/selectors';
-import { getReaderFollows } from 'state/selectors';
-import UrlSearch from 'lib/url-search';
-import { getSiteName, getSiteUrl, getSiteDescription, getSiteAuthorName } from 'reader/get-helpers';
+import Gridicon from 'gridicons';
 
 class FollowingManageSubscriptions extends Component {
 	static propTypes = {
 		follows: PropTypes.array.isRequired,
-		doSearch: PropTypes.func.isRequired,
 	};
 
-	filterFollowsByQuery( query ) {
-		const { getFeed, getSite, follows } = this.props;
-		const phraseRe = new RegExp( escapeRegexp( query ), 'i' );
-
-		return follows.filter( follow => {
-			const feed = getFeed( follow.feed_ID ); // todo grab feed and site for current sub
-			const site = getSite( follow.site_ID );
-			const siteName = getSiteName( { feed, site } );
-			const siteUrl = getSiteUrl( { feed, site } );
-			const siteDescription = getSiteDescription( { feed, site } );
-			const siteAuthor = getSiteAuthorName( site );
-
-			return (
-				`${ follow.URL }${ siteName }${ siteUrl }${ siteDescription }${ siteAuthor }`
-			).search( phraseRe ) !== -1;
-		} );
-	}
-
 	render() {
-		const { follows, width, translate, query } = this.props;
-		const filteredFollows = this.filterFollowsByQuery( query );
-
+		const { follows, width, translate } = this.props;
 		return (
 			<div className="following-manage__subscriptions">
 				<QueryReaderFollows />
 				<div className="following-manage__subscriptions-controls">
-					{
-						translate( '%(num)s Followed Sites', {
-							args: { num: follows.length }
-						} )
-					}
-					<ReaderImportButton />
-					<ReaderExportButton />
-					<FollowingManageSearchFollowed onSearch={ this.props.doSearch } initialValue={ query } />
+					<h1 className="following-manage__subscriptions-controls-heading">
+						{
+							translate( '%(num)s Followed Sites', {
+								args: { num: follows.length }
+							} )
+						}
+						</h1>
+					<FollowingManageSortControls />
+					<div className="following-manage__subscriptions-controls-search">
+						<FollowingManageSearchFollowed />
+					</div>
+					<Gridicon icon="ellipsis" size={ 24 } />
 				</div>
 				<div className="following-manage__subscriptions-list">
-					{ follows &&
-						<SitesWindowScroller
-							sites={ filteredFollows }
-							width={ width }
-						/>
-					}
+					<SitesWindowScroller
+						sites={ follows }
+						width={ width }
+					/>
 				</div>
 			</div>
 		);
 	}
 }
 
-const mapStateToProps = state => {
-	const follows = getReaderFollows( state );
-	const getFeed = feedId => getReaderFeed( state, feedId );
-	const getSite = siteId => getReaderSite( state, siteId );
-
-	return { follows, getFeed, getSite };
-};
-
 export default connect(
-	mapStateToProps,
-)( localize( UrlSearch( FollowingManageSubscriptions ) ) );
+	state => ( { follows: getReaderFollows( state ) } ),
+)( localize( FollowingManageSubscriptions ) );

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -15,6 +15,8 @@ import FollowingManageSortControls from './sort-controls';
 import FollowingManageSearchFollowed from './search-followed';
 import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuItem from 'components/popover/menu-item';
+import ReaderImportButton from 'blocks/reader-import-button';
+import ReaderExportButton from 'blocks/reader-export-button';
 
 class FollowingManageSubscriptions extends Component {
 	static propTypes = {
@@ -41,9 +43,13 @@ class FollowingManageSubscriptions extends Component {
 						<FollowingManageSearchFollowed />
 					</div>
 					<div className="following-manage__subscriptions-import-export">
-						<EllipsisMenu toggleTitle={ translate( 'More' ) }>
-							<PopoverMenuItem icon="cloud-upload">{ translate( 'Import' ) }</PopoverMenuItem>
-							<PopoverMenuItem icon="cloud-download">{ translate( 'Export' ) }</PopoverMenuItem>
+						<EllipsisMenu toggleTitle={ translate( 'More' ) } position="bottom">
+							<PopoverMenuItem className="following-manage__subscriptions-import-export-menu-item">
+								<ReaderImportButton />
+							</PopoverMenuItem>
+							<PopoverMenuItem className="following-manage__subscriptions-import-export-menu-item">
+								<ReaderExportButton />
+							</PopoverMenuItem>
 						</EllipsisMenu>
 					</div>
 				</div>

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -13,7 +13,8 @@ import SitesWindowScroller from './sites-window-scroller';
 import QueryReaderFollows from 'components/data/query-reader-follows';
 import FollowingManageSortControls from './sort-controls';
 import FollowingManageSearchFollowed from './search-followed';
-import Gridicon from 'gridicons';
+import EllipsisMenu from 'components/ellipsis-menu';
+import PopoverMenuItem from 'components/popover/menu-item';
 
 class FollowingManageSubscriptions extends Component {
 	static propTypes = {
@@ -26,18 +27,25 @@ class FollowingManageSubscriptions extends Component {
 			<div className="following-manage__subscriptions">
 				<QueryReaderFollows />
 				<div className="following-manage__subscriptions-controls">
-					<h1 className="following-manage__subscriptions-controls-heading">
+					<h1 className="following-manage__subscriptions-heading">
 						{
 							translate( '%(num)s Followed Sites', {
 								args: { num: follows.length }
 							} )
 						}
 						</h1>
-					<FollowingManageSortControls />
-					<div className="following-manage__subscriptions-controls-search">
+					<div className="following-manage__subscriptions-sort">
+						<FollowingManageSortControls />
+					</div>
+					<div className="following-manage__subscriptions-search">
 						<FollowingManageSearchFollowed />
 					</div>
-					<Gridicon icon="ellipsis" size={ 24 } />
+					<div className="following-manage__subscriptions-import-export">
+						<EllipsisMenu toggleTitle={ translate( 'More' ) }>
+							<PopoverMenuItem icon="cloud-upload">{ translate( 'Import' ) }</PopoverMenuItem>
+							<PopoverMenuItem icon="cloud-download">{ translate( 'Export' ) }</PopoverMenuItem>
+						</EllipsisMenu>
+					</div>
 				</div>
 				<div className="following-manage__subscriptions-list">
 					<SitesWindowScroller


### PR DESCRIPTION
Adds a sort order dropdown for existing subscriptions. Not yet wired up to the subscriptions list.

Part of https://github.com/Automattic/wp-calypso/issues/12959.

![74767498-1e06-11e7-9465-0e34862af401-1](https://cloud.githubusercontent.com/assets/17325/25013180/95bad548-206a-11e7-81ef-b4eeeebf8293.jpg)

### To test

Visit http://calypso.localhost:3000/following/manage and check that the 'Sort by...' dropdown appears.