### PR TITLE
Purchases: Extract PurchaseMeta component

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -104,32 +104,6 @@ const ManagePurchase = React.createClass( {
 		return Boolean( getPurchase( props ) );
 	},
 
-	renderContactSupportToRenewMessage() {
-		const purchase = getPurchase( this.props );
-		const { translate } = this.props;
-
-		if ( getSelectedSite( this.props ) ) {
-			return null;
-		}
-
-		return (
-			<div className="manage-purchase__contact-support">
-				{ translate( 'You are the owner of %(purchaseName)s but because you are no longer a user on %(siteSlug)s, ' +
-				'renewing it will require staff assistance. Please {{contactSupportLink}}contact support{{/contactSupportLink}}, ' +
-				'and consider transferring this purchase to another active user on %(siteSlug)s to avoid this issue in the future.',
-					{
-						args: {
-							purchaseName: getName( purchase ),
-							siteSlug: this.props.selectedPurchase.domain
-						},
-						components: {
-							contactSupportLink: <a href={ support.CALYPSO_CONTACT } />
-						}
-					} ) }
-			</div>
-		);
-	},
-
 	handleRenew() {
 		const purchase = getPurchase( this.props ),
 			renewItem = cartItems.getRenewalItemFromProduct( purchase, {
@@ -294,8 +268,7 @@ const ManagePurchase = React.createClass( {
 			renewButton,
 			editPaymentMethodNavItem,
 			cancelPurchaseNavItem,
-			cancelPrivacyProtectionNavItem,
-			contactSupportToRenewMessage;
+			cancelPrivacyProtectionNavItem;
 
 		if ( isDataLoading( this.props ) ) {
 			classes = 'manage-purchase__info is-placeholder';
@@ -315,7 +288,6 @@ const ManagePurchase = React.createClass( {
 				<ProductLink selectedPurchase={ purchase } selectedSite={ this.props.selectedSite } />
 			);
 			renewButton = this.renderRenewButton();
-			contactSupportToRenewMessage = this.renderContactSupportToRenewMessage();
 			editPaymentMethodNavItem = this.renderEditPaymentMethodNavItem();
 			cancelPurchaseNavItem = this.renderCancelPurchaseNavItem();
 			cancelPrivacyProtectionNavItem = this.renderCancelPrivacyProtection();
@@ -342,7 +314,6 @@ const ManagePurchase = React.createClass( {
 					<PurchaseMeta purchaseId={ isDataLoading( this.props ) ? false : this.props.selectedPurchase.id } />
 
 					{ renewButton }
-					{ contactSupportToRenewMessage }
 				</Card>
 
 				{ this.renderPlanDetails() }

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -154,9 +154,8 @@ class PurchaseMeta extends Component {
 
 			return (
 				<span>
-					{ translate( 'Renews with Plan' ) }
 					<a href={ attachedPlanUrl }>
-						{ translate( 'View Plan' ) }
+						{ translate( 'Renews with Plan' ) }
 					</a>
 				</span>
 			);

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -128,15 +128,15 @@ class PurchaseMeta extends Component {
 		}
 
 		if ( isDomainRegistration( purchase ) ) {
-			return translate( 'Domain auto-renews on' );
+			return translate( 'Domain renews on' );
 		}
 
 		if ( isSubscription( purchase ) ) {
-			return translate( 'Subscription auto-renews on' );
+			return translate( 'Subscription renews on' );
 		}
 
 		if ( isOneTimePurchase( purchase ) ) {
-			return translate( 'Auto-renews on' );
+			return translate( 'Renews on' );
 		}
 
 		return null;

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -10,6 +10,7 @@ import { times } from 'lodash';
  * Internal Dependencies
  */
 import {
+	getName,
 	creditCardExpiresBeforeSubscription,
 	isExpired,
 	isExpiring,
@@ -30,6 +31,7 @@ import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
 import { getUser } from 'state/users/selectors';
 import paths from '../paths';
 import PaymentLogo from 'components/payment-logo';
+import support from 'lib/url/support';
 import UserItem from 'components/user';
 import {
 	canEditPaymentDetails,
@@ -245,6 +247,32 @@ class PurchaseMeta extends Component {
 		);
 	}
 
+	renderContactSupportToRenewMessage() {
+		const purchase = getPurchase( this.props );
+		const { translate } = this.props;
+
+		if ( getSelectedSite( this.props ) ) {
+			return null;
+		}
+
+		return (
+			<div className="manage-purchase__contact-support">
+				{ translate( 'You are the owner of %(purchaseName)s but because you are no longer a user on %(siteSlug)s, ' +
+				'renewing it will require staff assistance. Please {{contactSupportLink}}contact support{{/contactSupportLink}}, ' +
+				'and consider transferring this purchase to another active user on %(siteSlug)s to avoid this issue in the future.',
+					{
+						args: {
+							purchaseName: getName( purchase ),
+							siteSlug: this.props.selectedPurchase.domain
+						},
+						components: {
+							contactSupportLink: <a href={ support.CALYPSO_CONTACT } />
+						}
+					} ) }
+			</div>
+		);
+	}
+
 	renderOwner() {
 		const { translate, owner } = this.props;
 		if ( ! owner ) {
@@ -284,18 +312,21 @@ class PurchaseMeta extends Component {
 		}
 
 		return (
-			<ul className="manage-purchase__meta">
-				{ this.renderOwner() }
-				<li>
-					<em className="manage-purchase__content manage-purchase__detail-label">{ translate( 'Price' ) }</em>
-					<span className="manage-purchase__content manage-purchase__detail">{ this.renderPrice() }</span>
-				</li>
-				<li>
-					<em className="manage-purchase__content manage-purchase__detail-label">{ this.renderRenewsOrExpiresOnLabel() }</em>
-					<span className="manage-purchase__content manage-purchase__detail">{ this.renderRenewsOrExpiresOn() }</span>
-				</li>
-				{ this.renderPaymentDetails() }
-			</ul>
+			<div>
+				<ul className="manage-purchase__meta">
+					{ this.renderOwner() }
+					<li>
+						<em className="manage-purchase__content manage-purchase__detail-label">{ translate( 'Price' ) }</em>
+						<span className="manage-purchase__content manage-purchase__detail">{ this.renderPrice() }</span>
+					</li>
+					<li>
+						<em className="manage-purchase__content manage-purchase__detail-label">{ this.renderRenewsOrExpiresOnLabel() }</em>
+						<span className="manage-purchase__content manage-purchase__detail">{ this.renderRenewsOrExpiresOn() }</span>
+					</li>
+					{ this.renderPaymentDetails() }
+				</ul>
+				{ this.renderContactSupportToRenewMessage() }
+			</div>
 		);
 	}
 }

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -245,6 +245,22 @@ class PurchaseMeta extends Component {
 		);
 	}
 
+	renderOwner() {
+		const { translate, owner } = this.props;
+		if ( ! owner ) {
+			return null;
+		}
+
+		return (
+			<li>
+				<em className="manage-purchase__content manage-purchase__detail-label">{ translate( 'Owner' ) }</em>
+				<span className="manage-purchase__content manage-purchase__detail">
+					<UserItem user={ { ...owner, name: owner.display_name } } />
+				</span>
+			</li>
+		);
+	}
+
 	renderPlaceholder() {
 		return (
 			<ul className="manage-purchase__meta">
@@ -261,22 +277,15 @@ class PurchaseMeta extends Component {
 	}
 
 	render() {
-		const { translate, purchaseId, owner } = this.props;
+		const { translate, purchaseId } = this.props;
 
 		if ( isDataLoading( this.props ) || ! purchaseId ) {
 			return this.renderPlaceholder();
 		}
 
-		const displayUser = Object.assign( {}, owner, { name: owner.display_name } );
-
 		return (
 			<ul className="manage-purchase__meta">
-				<li>
-					<em className="manage-purchase__content manage-purchase__detail-label">{ translate( 'Owner' ) }</em>
-					<span className="manage-purchase__content manage-purchase__detail">
-						<UserItem user={ displayUser } />
-					</span>
-				</li>
+				{ this.renderOwner() }
 				<li>
 					<em className="manage-purchase__content manage-purchase__detail-label">{ translate( 'Price' ) }</em>
 					<span className="manage-purchase__content manage-purchase__detail">{ this.renderPrice() }</span>

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -1,0 +1,306 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { times } from 'lodash';
+
+/**
+ * Internal Dependencies
+ */
+import {
+	creditCardExpiresBeforeSubscription,
+	isExpired,
+	isExpiring,
+	isIncludedWithPlan,
+	isOneTimePurchase,
+	isPaidWithCreditCard,
+	isPaidWithPayPalDirect,
+	isRenewing,
+	isSubscription,
+	hasPaymentMethod,
+	paymentLogoType,
+} from 'lib/purchases';
+import { isMonthly } from 'lib/plans/constants';
+import { isDomainRegistration } from 'lib/products-values';
+import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
+import { isRequestingSites } from 'state/sites/selectors';
+import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
+import { getUser } from 'state/users/selectors';
+import paths from '../paths';
+import PaymentLogo from 'components/payment-logo';
+import UserItem from 'components/user';
+import {
+	canEditPaymentDetails,
+	isDataLoading,
+	getEditCardDetailsPath,
+	getPurchase,
+	getSelectedSite
+} from '../utils';
+
+class PurchaseMeta extends Component {
+	static propTypes = {
+		hasLoadedSites: React.PropTypes.bool.isRequired,
+		hasLoadedUserPurchasesFromServer: React.PropTypes.bool.isRequired,
+		purchaseId: React.PropTypes.oneOfType( [
+			React.PropTypes.number,
+			React.PropTypes.bool
+		] ).isRequired,
+		selectedPurchase: React.PropTypes.object,
+		selectedSite: React.PropTypes.oneOfType( [
+			React.PropTypes.object,
+			React.PropTypes.bool,
+			React.PropTypes.undefined
+		] )
+	}
+
+	static defaultProps = {
+		hasLoadedSites: false,
+		hasLoadedUserPurchasesFromServer: false,
+		purchaseId: false,
+	}
+
+	renderPrice() {
+		const { translate } = this.props;
+		const purchase = getPurchase( this.props );
+		const { amount, currencyCode, currencySymbol, productSlug } = purchase;
+		const period = productSlug && isMonthly( productSlug ) ? translate( 'month' ) : translate( 'year' );
+
+		if ( isOneTimePurchase( purchase ) ) {
+			return translate( '%(currencySymbol)s%(amount)f %(currencyCode)s {{period}}(one-time){{/period}}', {
+				args: { amount, currencyCode, currencySymbol },
+				components: {
+					period: <span className="manage-purchase__time-period" />
+				}
+			} );
+		}
+
+		if ( isIncludedWithPlan( purchase ) ) {
+			return translate( 'Free with Plan' );
+		}
+
+		return translate( '%(currencySymbol)s%(amount)f %(currencyCode)s {{period}}/ %(period)s{{/period}}', {
+			args: {
+				amount,
+				currencyCode,
+				currencySymbol,
+				period
+			},
+			components: {
+				period: <span className="manage-purchase__time-period" />
+			}
+		} );
+	}
+
+	renderRenewsOrExpiresOnLabel() {
+		const purchase = getPurchase( this.props );
+		const { translate } = this.props;
+
+		if ( isExpiring( purchase ) || creditCardExpiresBeforeSubscription( purchase ) ) {
+			if ( isDomainRegistration( purchase ) ) {
+				return translate( 'Domain expires on' );
+			}
+
+			if ( isSubscription( purchase ) ) {
+				return translate( 'Subscription expires on' );
+			}
+
+			if ( isOneTimePurchase( purchase ) ) {
+				return translate( 'Expires on' );
+			}
+		}
+
+		if ( isExpired( purchase ) ) {
+			if ( isDomainRegistration( purchase ) ) {
+				return translate( 'Domain expired on' );
+			}
+
+			if ( isSubscription( purchase ) ) {
+				return translate( 'Subscription expired on' );
+			}
+
+			if ( isOneTimePurchase( purchase ) ) {
+				return translate( 'Expired on' );
+			}
+		}
+
+		if ( isDomainRegistration( purchase ) ) {
+			return translate( 'Domain auto-renews on' );
+		}
+
+		if ( isSubscription( purchase ) ) {
+			return translate( 'Subscription auto-renews on' );
+		}
+
+		if ( isOneTimePurchase( purchase ) ) {
+			return translate( 'Auto-renews on' );
+		}
+
+		return null;
+	}
+
+	renderRenewsOrExpiresOn() {
+		const purchase = getPurchase( this.props );
+		const { translate, moment } = this.props;
+
+		if ( isIncludedWithPlan( purchase ) ) {
+			const attachedPlanUrl = paths.managePurchase(
+				this.props.selectedSite.slug,
+				purchase.attachedToPurchaseId
+			);
+
+			return (
+				<span>
+					{ translate( 'Renews with Plan' ) }
+					<a href={ attachedPlanUrl }>
+						{ translate( 'View Plan' ) }
+					</a>
+				</span>
+			);
+		}
+
+		if ( isExpiring( purchase ) || isExpired( purchase ) || creditCardExpiresBeforeSubscription( purchase ) ) {
+			return moment( purchase.expiryDate ).format( 'LL' );
+		}
+
+		if ( isRenewing( purchase ) ) {
+			return moment( purchase.renewDate ).format( 'LL' );
+		}
+
+		if ( isOneTimePurchase( purchase ) ) {
+			return translate( 'Never Expires' );
+		}
+	}
+
+	renderPaymentInfo() {
+		const purchase = getPurchase( this.props );
+		const { translate } = this.props;
+
+		if ( isIncludedWithPlan( purchase ) ) {
+			return (
+				<span className="manage-purchase__content manage-purchase__detail">
+					{ translate( 'Included with plan' ) }
+				</span>
+			);
+		}
+
+		if ( hasPaymentMethod( purchase ) ) {
+			let paymentInfo = null;
+
+			if ( isPaidWithCreditCard( purchase ) ) {
+				paymentInfo = purchase.payment.creditCard.number;
+			} else if ( isPaidWithPayPalDirect( purchase ) ) {
+				paymentInfo = translate( 'expiring %(cardExpiry)s', {
+					args: {
+						cardExpiry: purchase.payment.expiryMoment.format( 'MMMM YYYY' )
+					},
+				} );
+			}
+
+			return (
+				<span className="manage-purchase__content manage-purchase__detail">
+					<PaymentLogo type={ paymentLogoType( purchase ) } />
+					{ paymentInfo }
+				</span>
+			);
+		}
+
+		return (
+			<span className="manage-purchase__content manage-purchase__detail">
+				{ translate( 'None' ) }
+			</span>
+		);
+	}
+
+	renderPaymentDetails() {
+		const purchase = getPurchase( this.props );
+		const { translate } = this.props;
+
+		if ( isOneTimePurchase( purchase ) ) {
+			return null;
+		}
+
+		const paymentDetails = (
+			<span>
+				<em className="manage-purchase__content manage-purchase__detail-label">{ translate( 'Payment method' ) }</em>
+				{ this.renderPaymentInfo() }
+			</span>
+		);
+
+		if ( ! canEditPaymentDetails( purchase ) || ! isPaidWithCreditCard( purchase ) || ! getSelectedSite( this.props ) ) {
+			return (
+				<li>
+					{ paymentDetails }
+				</li>
+			);
+		}
+
+		return (
+			<li>
+				<a href={ getEditCardDetailsPath( this.props.selectedSite, purchase ) }>
+					{ paymentDetails }
+				</a>
+			</li>
+		);
+	}
+
+	renderPlaceholder() {
+		return (
+			<ul className="manage-purchase__meta">
+				{
+					times( 4, ( i ) => (
+						<li key={ i }>
+							<em className="manage-purchase__content manage-purchase__detail-label" />
+							<span className="manage-purchase__content manage-purchase__detail" />
+						</li>
+					) )
+				}
+			</ul>
+		);
+	}
+
+	render() {
+		const { translate, purchaseId, owner } = this.props;
+
+		if ( isDataLoading( this.props ) || ! purchaseId ) {
+			return this.renderPlaceholder();
+		}
+
+		const displayUser = Object.assign( {}, owner, { name: owner.display_name } );
+
+		return (
+			<ul className="manage-purchase__meta">
+				<li>
+					<em className="manage-purchase__content manage-purchase__detail-label">{ translate( 'Owner' ) }</em>
+					<span className="manage-purchase__content manage-purchase__detail">
+						<UserItem user={ displayUser } />
+					</span>
+				</li>
+				<li>
+					<em className="manage-purchase__content manage-purchase__detail-label">{ translate( 'Price' ) }</em>
+					<span className="manage-purchase__content manage-purchase__detail">{ this.renderPrice() }</span>
+				</li>
+				<li>
+					<em className="manage-purchase__content manage-purchase__detail-label">{ this.renderRenewsOrExpiresOnLabel() }</em>
+					<span className="manage-purchase__content manage-purchase__detail">{ this.renderRenewsOrExpiresOn() }</span>
+				</li>
+				{ this.renderPaymentDetails() }
+			</ul>
+		);
+	}
+}
+
+export default connect(
+	( state, props ) => {
+		const purchase = getByPurchaseId( state, props.purchaseId );
+
+		return {
+			hasLoadedSites: ! isRequestingSites( state ),
+			hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
+			selectedPurchase: purchase,
+			selectedSite: getSelectedSiteSelector( state ),
+			owner: purchase ? getUser( state, purchase.userId ) : null,
+		};
+	}
+)( localize( PurchaseMeta ) );

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -202,7 +202,6 @@
 
 	a {
 		display: block;
-		font-size: 12px;
 		cursor: pointer;
 	}
 }

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -108,17 +108,26 @@
 	}
 }
 
-.manage-purchase__meta {
-	display: flex;
-	list-style: none;
-	margin: 0 -24px -16px;
-	overflow: auto;
+.manage-purchase__meta,
+.manage-purchase__contact-support {
+	margin: 0 -24px;
 	padding: 0 24px;
 	border-top: 1px solid lighten( $gray, 30% );
 
 	@include breakpoint( "<660px" ) {
 		margin: 0 -16px;
 		padding: 0 16px;
+	}
+}
+
+.manage-purchase__meta {
+	display: flex;
+	margin-bottom: -16px;
+	list-style: none;
+	overflow: auto;
+
+	@include breakpoint( "<660px" ) {
+		margin-bottom: 0;
 		flex-direction: column;
 	}
 

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -71,7 +71,6 @@
 }
 
 .manage-purchase__header {
-	border-bottom: 1px solid lighten( $gray, 30% );
 	overflow: auto;
 	padding: 0 0 16px 0;
 }
@@ -112,30 +111,33 @@
 .manage-purchase__meta {
 	display: flex;
 	list-style: none;
-	margin: 0;
+	margin: 0 -24px -16px;
 	overflow: auto;
-	padding: 0;
+	padding: 0 24px;
+	border-top: 1px solid lighten( $gray, 30% );
 
 	@include breakpoint( "<660px" ) {
+		margin: 0 -16px;
+		padding: 0 16px;
 		flex-direction: column;
 	}
 
 	li {
 		color: darken( $gray, 30% );
 		font-size: 13px;
-		margin-top: 15px;
 
 		@include breakpoint( "<660px" ) {
 			clear: both;
 			overflow: auto;
+			margin-top: 15px;
 		}
 
 		@include breakpoint( ">660px" ) {
 			box-sizing: border-box;
 			flex: 1 1 auto;
-			font-size: 18px;
+			font-size: 14px;
 			text-align: center;
-			padding: 0 8px;
+			padding: 15px 8px 12px;
 
 			&:first-child {
 				padding-left: 0;
@@ -169,19 +171,13 @@
 	}
 
 	@include breakpoint( ">660px" ) {
-		color: darken( $gray, 10% );
+		color: $gray-text-min;
 		display: block;
 		font-family: $sans;
-		font-size: 10px;
+		font-size: 12px;
 		font-weight: 400;
-		margin: 0 0 5px 0;
-		text-transform: uppercase;
+		margin: 0 0 12px 0;
 	}
-}
-
-.manage-purchase__time-period {
-	font-size: 75%;
-	opacity: .7;
 }
 
 .manage-purchase__detail {

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -8,7 +8,14 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import config from 'config';
 import paths from './paths';
+import {
+	isExpired,
+	isIncludedWithPlan,
+	isOneTimePurchase,
+	isPaidWithCreditCard
+} from 'lib/purchases';
 
 // TODO: Remove these property-masking functions in favor of accessing the props directly
 function getPurchase( props ) {
@@ -84,6 +91,22 @@ function enrichedSurveyData( surveyData, moment, site, purchase ) {
 	);
 }
 
+function canEditPaymentDetails( purchase ) {
+	if ( ! config.isEnabled( 'upgrades/credit-cards' ) ) {
+		return false;
+	}
+	return ! isExpired( purchase ) && ! isOneTimePurchase( purchase ) && ! isIncludedWithPlan( purchase );
+}
+
+function getEditCardDetailsPath( site, purchase ) {
+	if ( isPaidWithCreditCard( purchase ) ) {
+		const { payment: { creditCard } } = purchase;
+
+		return paths.editCardDetails( site.slug, purchase.id, creditCard.id );
+	}
+	return paths.addCardDetails( site.slug, purchase.id );
+}
+
 export {
 	getPurchase,
 	getSelectedSite,
@@ -93,4 +116,6 @@ export {
 	isDataLoading,
 	recordPageView,
 	enrichedSurveyData,
+	canEditPaymentDetails,
+	getEditCardDetailsPath,
 };


### PR DESCRIPTION
This PR creates a new component for the meta info on a purchase detail page (price, expires on, payment method) and adds a new meta detail, "owner". The styles have also been updated to match the mockups in #12746 

Jetpack site:
<img width="733" alt="jetpack" src="https://cloud.githubusercontent.com/assets/541093/25013030/38c515e4-2040-11e7-81f6-d9d9efa569b1.png">

Domain included in plan:
<img width="744" alt="domain-with-plan" src="https://cloud.githubusercontent.com/assets/541093/25013031/38c583b2-2040-11e7-9885-b6e7cbd34e0a.png">

A disconnected site
<img width="740" alt="disconnected-site" src="https://cloud.githubusercontent.com/assets/541093/25013029/38c4594c-2040-11e7-9368-5132f1ee920d.png">

Other than adding the Owner section, there should be no functionality change in the other sections. I've created this component to simplify ManagePurchase.

A basic test — make sure nothing looks broken:

- Check your purchase list view, /me/purchases
- Check a wp.com site
- Check a Jetpack site

To test in-depth, check various plan combos:

- wp.com site, jetpack site, or disconnected jetpack site
- plan expired, plan expiring within 90 days, plan not expiring/auto-renew enabled
- credit card expiring before plan renews

**Note**: this is currently compared to add/purchase-site-header-component, #13003 — once that's merged I'll switch this back to master.