### PR TITLE
Selectors: Add getPrimarySiteId()

### DIFF
--- a/client/state/selectors/get-primary-site-id.js
+++ b/client/state/selectors/get-primary-site-id.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentUser } from 'state/current-user/selectors';
+
+/**
+ * Returns the current user's primary site's ID.
+ *
+ * @param  {Object}  state Global state tree
+ * @return {?Number}       The current user's primary site's ID
+ */
+export default function getPrimarySiteId( state ) {
+	const currentUser = getCurrentUser( state );
+	return get( currentUser, 'primary_blog', null );
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -52,6 +52,7 @@ export getPastBillingTransactions from './get-past-billing-transactions';
 export getPosterUploadProgress from './get-poster-upload-progress';
 export getPosterUrl from './get-poster-url';
 export getPostLikes from './get-post-likes';
+export getPrimarySiteId from './get-primary-site-id';
 export getRawOffsets from './get-raw-offsets';
 export getReaderFeedsForQuery from './get-reader-feeds-for-query';
 export getReaderFollowedTags from './get-reader-followed-tags';
@@ -126,4 +127,3 @@ export isUpdatingJetpackSettings from './is-updating-jetpack-settings';
 export isUserRegistrationDaysWithinRange from './is-user-registration-days-within-range';
 export shouldCloseVideoEditorModal from './should-close-video-editor-modal';
 export shouldShowVideoEditorError from './should-show-video-editor-error';
-

--- a/client/state/selectors/test/get-primary-site-id.js
+++ b/client/state/selectors/test/get-primary-site-id.js
@@ -16,7 +16,7 @@ describe( 'getPrimarySiteId()', () => {
 		expect( siteId ).to.be.null;
 	} );
 
-	it( 'should return current user\'s primary site\s ID', () => {
+	it( 'should return current user\'s primary site\'s ID', () => {
 		const siteId = getPrimarySiteId( {
 			currentUser: {
 				id: 12345678

--- a/client/state/selectors/test/get-primary-site-id.js
+++ b/client/state/selectors/test/get-primary-site-id.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getPrimarySiteId } from '../';
+
+describe( 'getPrimarySiteId()', () => {
+	it( 'should return null if there is no current user', () => {
+		const siteId = getPrimarySiteId( {
+			currentUser: {}
+		} );
+		expect( siteId ).to.be.null;
+	} );
+
+	it( 'should return current user\'s primary site\s ID', () => {
+		const siteId = getPrimarySiteId( {
+			currentUser: {
+				id: 12345678
+			},
+			users: {
+				items: {
+					12345678: {
+						primary_blog: 7654321
+					}
+				}
+			}
+		} );
+		expect( siteId ).to.equal( 7654321 );
+	} );
+} );


### PR DESCRIPTION
Using the current user object's `primary_blog` attr. Not used in code yet.

Only implementing for the current user for now since I haven't needed it for other users yet.