### PR TITLE
Framework: remove siteslist getSelected site from email verification

### DIFF
--- a/client/components/email-verification/email-unverified-notice.jsx
+++ b/client/components/email-verification/email-unverified-notice.jsx
@@ -7,34 +7,24 @@ import * as React from 'react';
  * Internal dependencies
  */
 
-import userUtils from 'lib/user/utils';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import Spinner from 'components/spinner';
 import i18n from 'i18n-calypso';
-import sitesFactory from 'lib/sites-list';
 import userFactory from 'lib/user';
 
-const sites = sitesFactory();
-const user = userFactory();
+const userLib = userFactory();
 
 export default class EmailUnverifiedNotice extends React.Component {
-	constructor( props ) {
-		super( props );
 
-		this.updateVerificationState = this.updateVerificationState.bind( this );
-		this.handleDismiss = this.handleDismiss.bind( this );
-		this.handleSendVerificationEmail = this.handleSendVerificationEmail.bind( this );
-
-		this.state = {
-			needsVerification: userUtils.needsVerificationForSite( sites.getSelectedSite() ),
-			pendingRequest: false,
-			emailSent: false,
-			error: null,
-		};
-	}
+	state = {
+		pendingRequest: false,
+		emailSent: false,
+		error: null,
+	};
 
 	static propTypes = {
+		userEmail: React.PropTypes.string,
 		noticeText: React.PropTypes.node,
 		noticeStatus: React.PropTypes.string
 	};
@@ -44,29 +34,11 @@ export default class EmailUnverifiedNotice extends React.Component {
 		noticeStatus: ''
 	};
 
-	componentWillMount() {
-		user.on( 'change', this.updateVerificationState );
-		user.on( 'verify', this.updateVerificationState );
-		sites.on( 'change', this.updateVerificationState );
-	}
-
-	componentWillUnmount() {
-		user.off( 'change', this.updateVerificationState );
-		user.off( 'verify', this.updateVerificationState );
-		sites.off( 'change', this.updateVerificationState );
-	}
-
-	updateVerificationState() {
-		this.setState( {
-			needsVerification: userUtils.needsVerificationForSite( sites.getSelectedSite() ),
-		} );
-	}
-
-	handleDismiss() {
+	handleDismiss = () => {
 		this.setState( { error: null, emailSent: false } );
-	}
+	};
 
-	handleSendVerificationEmail( e ) {
+	handleSendVerificationEmail = ( e ) => {
 		e.preventDefault();
 
 		if ( this.state.pendingRequest ) {
@@ -77,14 +49,14 @@ export default class EmailUnverifiedNotice extends React.Component {
 			pendingRequest: true
 		} );
 
-		user.sendVerificationEmail( ( error, response ) => {
+		userLib.sendVerificationEmail( ( error, response ) => {
 			this.setState( {
 				emailSent: response && response.success,
 				error: error,
 				pendingRequest: false,
 			} );
 		} );
-	}
+	};
 
 	renderEmailSendPending() {
 		return (
@@ -100,7 +72,7 @@ export default class EmailUnverifiedNotice extends React.Component {
 	renderEmailSendSuccess() {
 		const noticeText = i18n.translate(
 			'We sent another confirmation email to %(email)s.',
-			{ args: { email: user.get().email } }
+			{ args: { email: this.props.userEmail } }
 		);
 
 		return (
@@ -159,7 +131,7 @@ export default class EmailUnverifiedNotice extends React.Component {
 								'To post and keep using WordPress.com you need to confirm your email address. ' +
 								'Please click the link in the email we sent at %(email)s.', {
 									args: {
-										email: user.get().email
+										email: this.props.userEmail
 									}
 								}
 							)

--- a/client/components/email-verification/email-verification-gate.jsx
+++ b/client/components/email-verification/email-verification-gate.jsx
@@ -64,6 +64,7 @@ export default class EmailVerificationGate extends React.Component {
 			return (
 				<div tabIndex="-1" className="email-verification-gate" onFocus={ this.handleFocus }>
 					<EmailUnverifiedNotice
+						userEmail={ user.get().email }
 						noticeText={ this.props.noticeText }
 						noticeStatus={ this.props.noticeStatus } />
 					<div className="email-verification-gate__content">

--- a/client/components/email-verification/email-verification-gate.jsx
+++ b/client/components/email-verification/email-verification-gate.jsx
@@ -9,9 +9,8 @@ import { connect } from 'react-redux';
  */
 
 import EmailUnverifiedNotice from './email-unverified-notice.jsx';
-import userUtils from 'lib/user/utils';
 import { getCurrentUser } from 'state/current-user/selectors';
-import { getSelectedSite } from 'state/ui/selectors';
+import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 
 export class EmailVerificationGate extends React.Component {
 	static propTypes = {
@@ -53,10 +52,9 @@ export class EmailVerificationGate extends React.Component {
 export default connect(
 	( state ) => {
 		const user = getCurrentUser( state );
-		const site = getSelectedSite( state );
 		return {
 			userEmail: user && user.email,
-			needsVerification: userUtils.needsVerificationForSite( site )
+			needsVerification: ! isCurrentUserEmailVerified( state )
 		};
 	}
 )( EmailVerificationGate );


### PR DESCRIPTION
This PR simplifies email-unverified-notice.jsx to be a simple UI component, and removes the sitelist usage in email-verification-gate.jsx

### Testing Instructions

1. Create a new user
2. Navigate to http://calypso.localhost:3000/people/new/:siteId:
3. You see the email notice. The action links work.
4. Navigate to http://calypso.localhost:3000/settings/import/:siteId:
5. You see the email notice. The action links work.

I'm having trouble testing the last usage in `JetpackSSOForm` for Jetpack connect. Maybe @tyxla knows? 

![screen shot 2017-04-13 at 12 00 26 pm](https://cloud.githubusercontent.com/assets/1270189/25020186/388d8654-2042-11e7-87c1-edb80fd7fa01.png)
