### PR TITLE
Single plugin view: added missing placeholder for image and fixed stray W

### DIFF
--- a/client/my-sites/plugins/plugin-information/style.scss
+++ b/client/my-sites/plugins/plugin-information/style.scss
@@ -121,8 +121,12 @@
 	}
 
 	.plugin-information__external-link,
-	.version{
+	.version {
 		color: transparent;
+
+		svg {
+			fill: transparent;
+		}
 	}
 
 	.plugin-information__version-limit,

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -75,9 +75,10 @@ const PluginMeta = React.createClass( {
 	displayBanner() {
 		if ( this.props.plugin && this.props.plugin.banners && ( this.props.plugin.banners.high || this.props.plugin.banners.low ) ) {
 			return <div className="plugin-meta__banner">
-						<img className="plugin-meta__banner-image"
-						src={ this.props.plugin.banners.high || this.props.plugin.banners.low } />
-					</div>;
+					<div
+						className="plugin-meta__banner-image"
+						style={ { backgroundImage: `url(${ this.props.plugin.banners.high || this.props.plugin.banners.low })` } } />
+				</div>;
 		}
 	},
 

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -73,13 +73,17 @@ const PluginMeta = React.createClass( {
 	},
 
 	displayBanner() {
-		if ( this.props.plugin && this.props.plugin.banners && ( this.props.plugin.banners.high || this.props.plugin.banners.low ) ) {
-			return <div className="plugin-meta__banner">
-					<div
-						className="plugin-meta__banner-image"
-						style={ { backgroundImage: `url(${ this.props.plugin.banners.high || this.props.plugin.banners.low })` } } />
-				</div>;
-		}
+		const lowBanner = get( this.props, [ 'plugin', 'banners', 'low' ], '' );
+		const highBanner = get( this.props, [ 'plugin', 'banners', 'high' ], '' );
+
+		return (
+			<div className="plugin-meta__banner">
+				<div
+					className="plugin-meta__banner-image"
+					style={ { backgroundImage: `url(${ highBanner || lowBanner })` } }
+				/>
+			</div>
+		);
 	},
 
 	hasBusinessPlan() {

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -24,6 +24,12 @@
 	}
 }
 
+.plugin-meta__banner-image {
+	background-size: cover;
+	background-repeat:no-repeat;
+	padding-top: 32.4%;
+}
+
 .plugin-meta__information {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
This PR adds a placeholder block for images by changing the header to a `div` with a background image instead of an `img`.

There is still a problem with the logic that I could use some help with. I don't know why, but it doesn't show up until after some data loads. Can we fix that? @tyxla 