### PR TITLE
Signup: remove `userFirstSignup` AB test.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -8,15 +8,6 @@ module.exports = {
 		},
 		defaultVariation: 'singlePurchaseFlow'
 	},
-	userFirstSignup: {
-		datestamp: '20160124',
-		variations: {
-			userLast: 100,
-			userFirst: 0,
-		},
-		defaultVariation: 'userLast',
-		allowExistingUsers: false,
-	},
 	signupPlansCallToAction: {
 		datestamp: '20170403',
 		variations: {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -206,13 +206,6 @@ const flows = {
 		description: 'Used by `get.blog` users that connect their site to WordPress.com',
 		lastModified: '2016-11-14'
 	},
-
-	'user-first': {
-		steps: [ 'user', 'design-type', 'themes', 'domains', 'plans' ],
-		destination: getSiteDestination,
-		description: 'User-first signup flow',
-		lastModified: '2016-01-18',
-	},
 };
 
 if ( config.isEnabled( 'signup/domain-first-flow' ) ) {
@@ -274,18 +267,27 @@ function filterDesignTypeInFlow( flow ) {
 	} );
 }
 
+/**
+ * Properly filter the current flow.
+ *
+ * Called by `getFlowName` in 'signup/utils.js' to allow conditional filtering of the current
+ * flow for AB tests.
+ *
+ * @example
+ * function filterFlowName( flowName ) {
+ *   const defaultFlows = [ 'main', 'website' ];
+ *   if ( ! user.get() && includes( defaultFlows, flowName ) ) {
+ *     return 'filtered-flow-name';
+ *   }
+ *   return flowName;
+ * }
+ * // If user is logged out and the current flow is 'main' or 'website' switch to 'filtered-flow-name' flow.
+ *
+ * @param  {string} flowName Current flow name.
+ * @return {string}          New flow name.
+ */
 function filterFlowName( flowName ) {
-	const defaultFlows = [ 'main', 'website' ];
-
-	/**
-	 * Only run the User First Signup for logged out users.
-	 */
-	if ( ! user.get() ) {
-		if ( includes( defaultFlows, flowName ) && abtest( 'userFirstSignup' ) === 'userFirst' ) {
-			return 'user-first';
-		}
-	}
-
+	// do nothing. No flows to filter at the moment.
 	return flowName;
 }
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -56,10 +56,7 @@ export class UserStep extends Component {
 		/**
 		 * Update the step sub-header if they only want to create an account, without a site.
 		 */
-		if (
-			1 === signupUtils.getFlowSteps( props.flowName ).length &&
-			'userfirst' !== props.flowName
-		) {
+		if ( 1 === signupUtils.getFlowSteps( props.flowName ).length ) {
 			subHeaderText = this.props.translate( 'Welcome to the wonderful WordPress.com community' );
 		}
 


### PR DESCRIPTION
The user-first AB test (#10260) has been running at 100% default variant (#11461) while we decided whether or not to pursue future tests. With the focus change of Delta, future tests aren't planned. Cleaning up the test.

**To test:**
1. Attempt to enter Signup through `/start/user-first/`.
2. Verify that Signup redirects you to `/start/` (default flow).
3. Complete Signup and verify that site and user are correctly created.