### PR TITLE
Selectors: Add getMenusUrl() selector, use in Sidebar

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -641,10 +641,12 @@ export class MySitesSidebar extends Component {
 }
 
 function mapStateToProps( state ) {
+	const currentUser = getCurrentUser( state );
 	const selectedSiteId = getSelectedSiteId( state );
-	const singleSiteId = selectedSiteId || getPrimarySiteId( state );
+	const isSingleSite = !! selectedSiteId || currentUser.site_count === 1;
+	const singleSiteId = selectedSiteId || ( isSingleSite && getPrimarySiteId( state ) );
 	return {
-		currentUser: getCurrentUser( state ),
+		currentUser,
 		customizeUrl: getCustomizerUrl( state, selectedSiteId ),
 		isDomainOnly: isDomainOnlySite( state, selectedSiteId ),
 		isJetpack: isJetpackSite( state, selectedSiteId ),

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -31,7 +31,7 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { setNextLayoutFocus, setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { userCan } from 'lib/site/utils';
-import { isDomainOnlySite } from 'state/selectors';
+import { getMenusUrl, getPrimarySiteId, isDomainOnlySite } from 'state/selectors';
 import { getCustomizerUrl, isJetpackSite } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { getStatsPathForTab } from 'lib/route/path';
@@ -224,31 +224,9 @@ export class MySitesSidebar extends Component {
 	}
 
 	menus() {
-		const site = this.getSelectedSite();
-		let menusLink = '/customize/menus' + this.siteSuffix();
-
-		if ( ! site ) {
+		const { menusUrl } = this.props;
+		if ( ! menusUrl ) {
 			return null;
-		}
-
-		if ( ! site.capabilities ) {
-			return null;
-		}
-
-		if ( site.capabilities && ! site.capabilities.edit_theme_options ) {
-			return null;
-		}
-
-		if ( ! this.isSingle() ) {
-			return null;
-		}
-
-		if ( ! this.props.currentUser.email_verified ) {
-			menusLink = '/customize' + this.siteSuffix();
-		}
-
-		if ( site.jetpack ) {
-			menusLink = site.options.admin_url + 'customize.php?autofocus[panel]=nav_menus';
 		}
 
 		return (
@@ -256,7 +234,7 @@ export class MySitesSidebar extends Component {
 				tipTarget="menus"
 				label={ this.props.translate( 'Menus' ) }
 				className={ this.itemLinkClass( '/menus', 'menus' ) }
-				link={ menusLink }
+				link={ menusUrl }
 				onNavigate={ this.onNavigate }
 				icon="menus"
 				preloadSectionName="menus" />
@@ -664,12 +642,14 @@ export class MySitesSidebar extends Component {
 
 function mapStateToProps( state ) {
 	const selectedSiteId = getSelectedSiteId( state );
+	const singleSiteId = selectedSiteId || getPrimarySiteId( state );
 	return {
 		currentUser: getCurrentUser( state ),
 		customizeUrl: getCustomizerUrl( state, selectedSiteId ),
 		isDomainOnly: isDomainOnlySite( state, selectedSiteId ),
 		isJetpack: isJetpackSite( state, selectedSiteId ),
 		isSiteAutomatedTransfer: !! isSiteAutomatedTransfer( state, selectedSiteId ),
+		menusUrl: getMenusUrl( state, singleSiteId ),
 	};
 }
 

--- a/client/state/selectors/get-menus-url.js
+++ b/client/state/selectors/get-menus-url.js
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import { canCurrentUser } from 'state/selectors';
+import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
+import { getSiteAdminUrl, getSiteSlug, isJetpackSite } from 'state/sites/selectors';
+
+/**
+ * Returns the menus admin URL for the given site ID
+ *
+ * @param {Object}  state   Global state tree
+ * @param {Number}  siteId  A site ID
+ * @return {?String}        Menus admin URL
+ */
+export default function getMenusUrl( state, siteId ) {
+	if ( ! canCurrentUser( state, siteId, 'edit_theme_options' ) ) {
+		return null;
+	}
+
+	if ( isJetpackSite( state, siteId ) ) {
+		return getSiteAdminUrl( state, siteId, 'customize.php' ) + '?autofocus[panel]=nav_menus';
+	}
+	// The Customizer's Menus panel shouldn't be available to users that haven't verified their
+	// email yet, so send them to the top level Customizer where they will (maybe?) see that Menus
+	// are not available to them yet. See https://github.com/Automattic/wp-calypso/pull/13017
+	if ( ! isCurrentUserEmailVerified( state ) ) {
+		return '/customize/' + getSiteSlug( state, siteId );
+	}
+
+	return '/customize/menus/' + getSiteSlug( state, siteId );
+}

--- a/client/state/selectors/get-menus-url.js
+++ b/client/state/selectors/get-menus-url.js
@@ -20,8 +20,8 @@ export default function getMenusUrl( state, siteId ) {
 	if ( isJetpackSite( state, siteId ) ) {
 		return getSiteAdminUrl( state, siteId, 'customize.php' ) + '?autofocus[panel]=nav_menus';
 	}
-	// The Customizer's Menus panel shouldn't be available to users that haven't verified their
-	// email yet, so send them to the top level Customizer where they will (maybe?) see that Menus
+	// The Customizer's Menus panel shouldn't be available to users who haven't verified their
+	// email yet, so send them to the top-level Customizer where they will (maybe?) see that Menus
 	// are not available to them yet. See https://github.com/Automattic/wp-calypso/pull/13017
 	if ( ! isCurrentUserEmailVerified( state ) ) {
 		return '/customize/' + getSiteSlug( state, siteId );

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -47,6 +47,7 @@ export getMedia from './get-media';
 export getMediaItem from './get-media-item';
 export getMediaUrl from './get-media-url';
 export getMenuItemTypes from './get-menu-item-types';
+export getMenusUrl from './get-menus-url';
 export getPastBillingTransaction from './get-past-billing-transaction';
 export getPastBillingTransactions from './get-past-billing-transactions';
 export getPosterUploadProgress from './get-poster-upload-progress';

--- a/client/state/selectors/test/get-menus-url.js
+++ b/client/state/selectors/test/get-menus-url.js
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getMenusUrl } from '../';
+
+const state = {
+	currentUser: {
+		id: 12345678,
+		capabilities: {
+			6543210: {
+				edit_theme_options: false
+			},
+			7654321: {
+				edit_theme_options: true
+			},
+			8765432: {
+				edit_theme_options: true
+			},
+			9876543: {
+				edit_theme_options: true
+			}
+		}
+	},
+	sites: {
+		items: {
+			7654321: {
+				jetpack: true,
+				options: {
+					admin_url: 'https://example.com/wp-admin/'
+				}
+			},
+			8765432: {
+				jetpack: false,
+				URL: 'https://example.wordpress.com'
+			},
+			9876543: {
+				jetpack: false,
+				URL: 'https://example2.wordpress.com'
+			}
+		}
+	}
+};
+
+describe( 'getMenusUrl()', () => {
+	it( 'should return null if no siteId is given', () => {
+		const url = getMenusUrl( state );
+		expect( url ).to.be.null;
+	} );
+
+	it( 'should return null if the current user can\'t edit_theme_options', () => {
+		const url = getMenusUrl( state, 6543210 );
+		expect( url ).to.be.null;
+	} );
+
+	it( 'should return URL of the Jetpack site\'s customizer menu panel for a Jetpack site', () => {
+		const url = getMenusUrl( state, 7654321 );
+		expect( url ).to.equal( 'https://example.com/wp-admin/customize.php?autofocus[panel]=nav_menus' );
+	} );
+
+	it( 'should return URL of the Calypso customizer (top-level) for a user with unverified email', () => {
+		const userState = {
+			users: {
+				items: {
+					12345678: {
+						email_verified: false
+					}
+				}
+			}
+		};
+
+		const url = getMenusUrl( { ...state, ...userState }, 8765432 );
+		expect( url ).to.equal( '/customize/example.wordpress.com' );
+	} );
+
+	it( 'should return URL of the Calypso customizer\'s menu panel for a WP.com site', () => {
+		const userState = {
+			users: {
+				items: {
+					12345678: {
+						email_verified: true
+					}
+				}
+			}
+		};
+
+		const url = getMenusUrl( { ...state, ...userState }, 9876543 );
+		expect( url ).to.equal( '/customize/menus/example2.wordpress.com' );
+	} );
+} );


### PR DESCRIPTION
I'm moving this to a separate function since I also want to use it from #13082.

To test:
* Check the different scenarios that are also covered by the unit test:
  * No site selected: 'Menus' item shouldn't show up in sidebar
  * Jetpack site: 'Menus' item should point directly to JP site's Customizer
  * User with unverified email: 'Menus' item should point to top-level Customizer (not the Menus panel)
  * Regular user: 'Menus' item should point to Customizer's Menus panel
    * Also try regular user with only one site