### PR TITLE
Framework: Declarative Data Dependencies

### DIFF
--- a/client/lib/needs/index.js
+++ b/client/lib/needs/index.js
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import React from 'react';
+import { bindActionCreators } from 'redux';
+import { map, reduce, merge, isFunction, omit } from 'lodash';
+
+export readerFeed from './reader-feed';
+export readerSite from './reader-site';
+export readerTags from './reader-tags';
+
+/**
+ * A need represents a component's data needs. Its core is two different functions, mapStateToProps
+ * and mapStateToRequestAction.
+ *
+ * mapStateToProps: given redux state, return all the data needed by children
+ * mapStateToRequestActions: given redux state, return all of the actions needed to
+ *                           be dispatched in order to fetch needed data
+ * @typedef {Object} Need
+ * @property {func} mapStateToProps
+ * @property {func} mapStateToRequestAction
+ */
+
+const mergeMapPropsToRequestActions = ( needs, state, ownProps ) =>
+	reduce(
+		needs.mapStateToRequestActions,
+		( accum, mapStateToRequestActions ) => [
+			...accum,
+			mapStateToRequestActions( state, ownProps ),
+		],
+		[]
+	);
+
+const mergeMapStateToProps = ( needs, state, ownProps ) =>
+	reduce(
+		map( needs, 'mapStateToProps' ),
+		( accum, mapStateToProps ) => merge( accum, mapStateToProps( state, ownProps ) ),
+		{}
+	);
+
+export default ( needs, mapDispatchToProps ) => Component => {
+	class EnhancedComponent extends React.Component {
+		static displayName = `Needs(${ Component.displayName })`;
+
+		componentWillMount() {
+			this.makeRequests( this.props.requestActions );
+		}
+
+		componentWillReceiveProps( nextProps ) {
+			this.makeRequests( nextProps.requestActions );
+		}
+
+		makeRequests = ( requestActions = [] ) => {
+			requestActions.forEach( action => this.props.dispatch( action ) );
+		};
+
+		render() {
+			return <Component { ...omit( this.props, 'dispatch' ) } />;
+		}
+	}
+
+	return connect(
+		( state, ownProps ) => ( {
+			requestActions: mergeMapPropsToRequestActions( needs, state, ownProps ),
+			...mergeMapStateToProps( needs, state, ownProps ),
+		} ),
+		( dispatch, ownProps ) => {
+			const props = { dispatch };
+
+			if ( ! mapDispatchToProps ) {
+				return props;
+			}
+
+			return isFunction( mapDispatchToProps )
+				? Object.assign( props, mapDispatchToProps( dispatch, ownProps ) )
+				: Object.assign( props, bindActionCreators( mapDispatchToProps, dispatch ) );
+		}
+	)( EnhancedComponent );
+};

--- a/client/lib/needs/reader-feed.js
+++ b/client/lib/needs/reader-feed.js
@@ -1,0 +1,36 @@
+/**
+ * Internal dependencies
+ */
+import { getSite } from 'state/reader/sites/selectors';
+import { getFeed } from 'state/reader/feeds/selectors';
+import { requestFeed } from 'state/reader/feeds/actions';
+import { shouldFeedBeFetched } from 'state/reader/feeds/selectors';
+
+const readerFeed = ( { feed: feedIdKey, site: siteIdKey } ) => {
+	return {
+		mapStateToProps: ( state, ownProps ) => {
+			const siteId = ownProps[ siteIdKey ];
+			const site = siteId && getSite( state, siteId );
+
+			const feedId = ownProps[ feedIdKey ] ? ownProps[ feedIdKey ] : site && site.feed_ID;
+
+			return {
+				feed: getFeed( state, feedId ),
+			};
+		},
+
+		mapStateToRequestActions: ( state, ownProps ) => {
+			const siteId = ownProps[ siteIdKey ];
+			const site = siteId && getSite( state, siteId );
+
+			const feedId = ownProps[ feedIdKey ] ? ownProps[ feedIdKey ] : site && site.feed_ID;
+
+			if ( shouldFeedBeFetched( state, feedId ) ) {
+				return [ requestFeed( feedId ) ];
+			}
+			return [];
+		},
+	};
+};
+
+export default readerFeed;

--- a/client/lib/needs/reader-site.js
+++ b/client/lib/needs/reader-site.js
@@ -1,0 +1,47 @@
+/**
+ * Internal dependencies
+ */
+import { getSite } from 'state/reader/sites/selectors';
+import { getFeed } from 'state/reader/feeds/selectors';
+import { shouldSiteBeFetched } from 'state/reader/sites/selectors';
+import { requestSite } from 'state/reader/sites/actions';
+
+const getReaderSiteId = ( { state, feedId, siteId } ) => {
+	if ( siteId ) {
+		return siteId;
+	}
+
+	// If the blog_ID of a reader feed is 0, that means no site exists for it.
+	const feed = feedId && getFeed( state, feedId );
+	return ( ! feed || feed.blog_ID === 0 ) ? null : feed.blog_ID;
+};
+
+/**
+ *  Need for reader site.
+ * @param {String} site - which prop represents the siteId that is needed
+ * @param {String} feed - which prop represents the feed for which to grab its corresponding site
+ *
+ * @returns {Object} the wrapped component that will fetch reader tags
+ */
+const readerSite = ( { site: siteIdKey, feed: feedIdKey } ) => ( {
+	mapStateToProps: ( state, ownProps ) => {
+		const siteId = getReaderSiteId(
+			{ state, feedId: ownProps[ feedIdKey ], siteId: ownProps[ siteIdKey ] }
+		);
+		const site = getSite( state, siteId );
+		return { site };
+	},
+
+	mapStateToRequestActions: ( state, ownProps ) => {
+		const siteId = getReaderSiteId(
+			{ state, feedId: ownProps[ feedIdKey ], siteId: ownProps[ siteIdKey ] }
+		);
+
+		if ( siteId && shouldSiteBeFetched( state, siteId ) ) {
+			return [ requestSite( siteId ) ];
+		}
+		return [];
+	},
+} );
+
+export default readerSite;

--- a/client/lib/needs/reader-tags.js
+++ b/client/lib/needs/reader-tags.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { find } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { requestTags } from 'state/reader/tags/items/actions';
+import { getReaderFollowedTags, getReaderTags } from 'state/selectors';
+
+/**
+ * @param {Boolean} tags - if true then will hand over all tags currently in redux. Will also request for followed tags if empty
+ * @param {Boolean} followedTags - if true will hand over 'followedTags' prop to its children.  Will request for followedTags if empty
+ * @param {undefined|Object} tag - must be of the form: { slug }.  Will request a specific tag and hand the key 'tag' to its child.
+ *
+ * @returns {Need} the need for a reader tag
+ */
+const readerTags = ( { tags = false, followedTags = false, tag = undefined } ) => ( {
+	mapStateToProps: ( state, ownProps ) => {
+		const props = {};
+
+		if ( tag ) {
+			const slug = ownProps[ tag.slug ];
+			props.tag = find( getReaderTags( state ), { slug } );
+		}
+		if ( tags ) {
+			props.tags = getReaderTags( state );
+		}
+		if ( followedTags ) {
+			props.followedTags = getReaderFollowedTags( state );
+		}
+
+		return props;
+	},
+
+	mapStateToRequestActions: ( state, ownProps ) => {
+		const requestActions = [];
+		const tagsShouldBeFetched = ( followedTags || tags ) && getReaderTags( state ) === null;
+		const tagShouldBeFetched =
+			tag &&
+			ownProps[ tag.slug ] &&
+			! find( getReaderTags( state ), { slug: ownProps[ tag.slug ] } );
+
+		tagsShouldBeFetched && requestActions.push( requestTags() );
+		tagShouldBeFetched && requestActions.push( requestTags( ownProps[ tag.slug ] ) );
+
+		return requestActions;
+	},
+} );
+
+export default readerTags;

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -13,14 +12,8 @@ import DocumentHead from 'components/data/document-head';
 import Stream from 'reader/stream';
 import FeedError from 'reader/feed-error';
 import RefreshFeedHeader from 'blocks/reader-feed-header';
-import QueryReaderSite from 'components/data/query-reader-site';
-import QueryReaderFeed from 'components/data/query-reader-feed';
-import { getSite } from 'state/reader/sites/selectors';
-import { getFeed } from 'state/reader/feeds/selectors';
 import { getSiteName } from 'reader/get-helpers';
-
-// If the blog_ID of a reader feed is 0, that means no site exists for it.
-const getReaderSiteId = feed => ( feed && feed.blog_ID === 0 ? null : feed && feed.blog_ID );
+import needs, { readerSite, readerFeed } from 'lib/needs';
 
 class FeedStream extends React.Component {
 	static propTypes = {
@@ -35,7 +28,7 @@ class FeedStream extends React.Component {
 	};
 
 	render() {
-		const { feed, site, siteId } = this.props;
+		const { feed, site } = this.props;
 		const emptyContent = <EmptyContent />;
 		const title = getSiteName( { feed, site } ) || this.props.translate( 'Loading Feed' );
 
@@ -54,20 +47,12 @@ class FeedStream extends React.Component {
 			>
 				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: title } ) } />
 				<RefreshFeedHeader feed={ feed } site={ site } showBack={ this.props.showBack } />
-				{ ! feed && <QueryReaderFeed feedId={ this.props.feedId } /> }
-				{ siteId && <QueryReaderSite siteId={ siteId } /> }
 			</Stream>
 		);
 	}
 }
 
-export default connect( ( state, ownProps ) => {
-	const feed = getFeed( state, ownProps.feedId );
-	const siteId = getReaderSiteId( feed );
-
-	return {
-		feed,
-		siteId,
-		site: siteId && getSite( state, siteId ),
-	};
-} )( localize( FeedStream ) );
+export default needs( [
+	readerSite( { site: 'siteId' } ),
+	readerFeed( { feed: 'feedId' } ),
+] )( localize( FeedStream ) );

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
 import page from 'page';
 
 /**
@@ -14,11 +13,8 @@ import RefreshFeedHeader from 'blocks/reader-feed-header';
 import EmptyContent from './empty';
 import Stream from 'reader/stream';
 import FeedError from 'reader/feed-error';
-import { getSite } from 'state/reader/sites/selectors';
-import { getFeed } from 'state/reader/feeds/selectors';
-import QueryReaderSite from 'components/data/query-reader-site';
-import QueryReaderFeed from 'components/data/query-reader-feed';
 import FeedFeatured from './featured';
+import needs, { readerSite, readerFeed } from 'lib/needs';
 
 class SiteStream extends React.Component {
 	static propTypes = {
@@ -70,17 +66,14 @@ class SiteStream extends React.Component {
 				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: title } ) } />
 				<RefreshFeedHeader site={ site } feed={ feed } showBack={ this.props.showBack } />
 				{ featuredContent }
-				{ ! site && <QueryReaderSite siteId={ this.props.siteId } /> }
-				{ ! feed && site && site.feed_ID && <QueryReaderFeed feedId={ site.feed_ID } /> }
 			</Stream>
 		);
 	}
 }
 
-export default connect( ( state, ownProps ) => {
-	const site = getSite( state, ownProps.siteId );
-	return {
-		site: site,
-		feed: site && site.feed_ID && getFeed( state, site.feed_ID ),
-	};
-} )( localize( SiteStream ) );
+export default needs( [
+	readerSite( { site: 'siteId' } ),
+	readerFeed( { feed: 'feedId' } ),
+] )(
+	localize( SiteStream )
+);

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
+import needs, { readerTags } from 'lib/needs';
 
 /**
  * Internal Dependencies
@@ -14,7 +14,6 @@ import EmptyContent from './empty';
 import TagStreamHeader from './header';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import HeaderBack from 'reader/header-back';
-import { getReaderFollowedTags, getReaderTags } from 'state/selectors';
 import { requestFollowTag, requestUnfollowTag } from 'state/reader/tags/items/actions';
 import QueryReaderFollowedTags from 'components/data/query-reader-followed-tags';
 import QueryReaderTag from 'components/data/query-reader-tag';
@@ -93,11 +92,11 @@ class TagStream extends React.Component {
 	};
 
 	render() {
-		const emptyContent = <EmptyContent decodedTagSlug={ this.props.decodedTagSlug } />;
-		const title = this.props.decodedTagSlug;
-		const tag = find( this.props.tags, { slug: this.props.encodedTagSlug } );
+		const { tag, decodedTagSlug, encodedTagSlug, translate, showBack } = this.props;
+		const emptyContent = <EmptyContent decodedTagSlug={ decodedTagSlug } />;
+		const title = decodedTagSlug;
 
-		let imageSearchString = this.props.encodedTagSlug;
+		let imageSearchString = encodedTagSlug;
 
 		// If the tag contains emoji, convert to text equivalent
 		if ( this.state.emojiText && this.state.isEmojiTitle ) {
@@ -114,8 +113,8 @@ class TagStream extends React.Component {
 				showFollowInHeader={ true }
 			>
 				<QueryReaderFollowedTags />
-				<QueryReaderTag tag={ this.props.decodedTagSlug } />
-				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: title } ) } />
+				<QueryReaderTag tag={ decodedTagSlug } />
+				<DocumentHead title={ translate( '%s ‹ Reader', { args: title } ) } />
 				{ this.props.showBack && <HeaderBack /> }
 				<TagStreamHeader
 					title={ title }
@@ -123,18 +122,17 @@ class TagStream extends React.Component {
 					showFollow={ !! ( tag && tag.id ) }
 					following={ this.isSubscribed() }
 					onFollowToggle={ this.toggleFollowing }
-					showBack={ this.props.showBack }
+					showBack={ showBack }
 				/>
 			</Stream>
 		);
 	}
 }
 
-export default connect(
-	state => ( {
-		followedTags: getReaderFollowedTags( state ),
-		tags: getReaderTags( state ),
-	} ),
+export default needs(
+	[
+		readerTags( { tag: { slug: 'encodedTagSlug' } } ),
+	],
 	{
 		followTag: requestFollowTag,
 		unfollowTag: requestUnfollowTag,


### PR DESCRIPTION
In Calypso, we know that we want declarative dependencies for our ui components/blocks.  The big question is how?

My proposal here is to create a new HoC function, `needs`, that takes the place of `connect`, query components, and selectors.  Under the hood, needs does a few things:
1. wraps component in a standard React Component that contains all the usual lifecycle hooks
2. the component issues necessary requests for data on both `componentWillMount` and `componentWillReceiveProps`
3. takes the fetched data from the redux tree once it is available and hands it to its children

### API

#### `needs(list of need objects, [mapStateToDispatch])`
This composes all of the specified `needs` into a single HoC that can be used to wrap a component class.  It issues any necessary requests on `componentWillMount` and `componentWillReceiveProps`.

##### Arguments

* [`need objects`] \(*array*): represents a list of needs. 

* [`mapDispatchToProps(dispatch, [ownProps]): dispatchProps`] \(*Object|Function*): behaves the same way as redux-connect's mapDispatchToProps [docs](https://github.com/reactjs/react-redux/blob/master/docs/api.md#arguments)

#### Need Object
A need is any object that contains these two functions:
##### mapStateToProps( state, [ownProps] ):stateProps (Function).  
This behaves the same way as `connect`'s first parameter and under the hood gets directly passed to connect.
##### mapStateToRequestActions( state, [ownProps] ): requestActions (Function). 
This is one of the unique bits of this proposal and is a pretty good corollary to query component.  Based on state and ownProps, it should figure out what requests need to be made and then return an array of actions that will be dispatched (instead of directly dispatching them).

