### PR TITLE
WooCommerce: Add edit product selectors

### DIFF
--- a/client/extensions/woocommerce/state/products/selectors.js
+++ b/client/extensions/woocommerce/state/products/selectors.js
@@ -1,0 +1,13 @@
+
+/**
+ * Gets product fetched from server.
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} productId Numeric product Id.
+ * @return {Object} Product object from API.
+ */
+export function getProduct( state, productId ) {
+	// TODO: Add fetched product data.
+	return productId === 1 && { id: productId } || undefined;
+}
+

--- a/client/extensions/woocommerce/state/ui/products/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/selectors.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { get, find, isNumber } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getProduct } from '../../products/selectors';
+
+function getEditsState( state ) {
+	const woocommerce = state.extensions.woocommerce;
+	return get( woocommerce, 'ui.products.edits', {} );
+}
+
+/**
+ * Gets the accumulated edits for a product, if any.
+ *
+ * @param {Object} state Global state tree
+ * @param {any} productId The id of the product (or { index: # } )
+ * @return {Object} The current accumulated edits
+ */
+export function getProductEdits( state, productId ) {
+	const edits = getEditsState( state );
+	const bucket = isNumber( productId ) && 'updates' || 'creates';
+	const array = get( edits, bucket, [] );
+
+	return find( array, ( p ) => productId === p.id );
+}
+
+/**
+ * Gets a product with local edits overlayed on top of fetched data.
+ *
+ * @param {Object} state Global state tree
+ * @param {any} productId The id of the product (or { index: # } )
+ * @return {Object} The product data merged between the fetched data and edits
+ */
+export function getProductWithLocalEdits( state, productId ) {
+	const existing = isNumber( productId );
+
+	const product = existing && getProduct( state, productId );
+	const productEdits = getProductEdits( state, productId );
+
+	return ( product || productEdits ) && { ...product, ...productEdits } || undefined;
+}
+
+/**
+ * Gets the product being currently edited in the UI.
+ *
+ * @param {Object} state Global state tree
+ * @return {Object} Product object that is merged between fetched data and edits
+ */
+export function getCurrentlyEditingProduct( state ) {
+	const edits = getEditsState( state ) || {};
+	const { currentlyEditingId } = edits;
+
+	return getProductWithLocalEdits( state, currentlyEditingId );
+}

--- a/client/extensions/woocommerce/state/ui/products/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/test/selectors.js
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { set } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getProductEdits,
+	getProductWithLocalEdits,
+	getCurrentlyEditingProduct,
+} from '../selectors';
+
+describe( 'selectors', () => {
+	let state;
+
+	beforeEach( () => {
+		state = {
+			extensions: {
+				woocommerce: {
+					products: [
+						// TODO: After the product API code is in, add more fields here.
+						{ id: 1 },
+					],
+					ui: {
+						products: {
+						}
+					},
+				},
+			},
+		};
+	} );
+
+	describe( 'getProductEdits', () => {
+		it( 'should get a product from "creates"', () => {
+			const newProduct = { id: { index: 0 }, name: 'New Product' };
+			const uiProducts = state.extensions.woocommerce.ui.products;
+			set( uiProducts, 'edits.creates', [ newProduct ] );
+
+			expect( getProductEdits( state, newProduct.id ) ).to.equal( newProduct );
+		} );
+
+		it( 'should get a product from "updates"', () => {
+			const updateProduct = { id: 1, name: 'Existing Product' };
+			const uiProducts = state.extensions.woocommerce.ui.products;
+			set( uiProducts, 'edits.updates', [ updateProduct ] );
+
+			expect( getProductEdits( state, updateProduct.id ) ).to.equal( updateProduct );
+		} );
+
+		it( 'should return undefined if no edits are found for productId', () => {
+			expect( getProductEdits( state, 1 ) ).to.not.exist;
+			expect( getProductEdits( state, { index: 9 } ) ).to.not.exist;
+		} );
+	} );
+
+	describe( 'getProductWithLocalEdits', () => {
+		it( 'should get just edits for a product in "creates"', () => {
+			const newProduct = { id: { index: 0 }, name: 'New Product' };
+			const uiProducts = state.extensions.woocommerce.ui.products;
+			set( uiProducts, 'edits.creates', [ newProduct ] );
+
+			expect( getProductWithLocalEdits( state, newProduct.id ) ).to.eql( newProduct );
+		} );
+
+		it( 'should get just fetched data for a product that has no edits', () => {
+			const products = state.extensions.woocommerce.products;
+
+			expect( getProductWithLocalEdits( state, 1 ) ).to.eql( products[ 0 ] );
+		} );
+
+		it( 'should get both fetched data and edits for a product in "updates"', () => {
+			const uiProducts = state.extensions.woocommerce.ui.products;
+			const products = state.extensions.woocommerce.products;
+
+			const existingProduct = { id: 1, name: 'Existing Product' };
+			set( uiProducts, 'edits.updates', [ existingProduct ] );
+
+			const combinedProduct = { ...products[ 0 ], ...existingProduct };
+			expect( getProductWithLocalEdits( state, 1 ) ).to.eql( combinedProduct );
+		} );
+
+		it( 'should return undefined if no product is found for productId', () => {
+			expect( getProductWithLocalEdits( state, 42 ) ).to.not.exist;
+			expect( getProductWithLocalEdits( state, { index: 42 } ) ).to.not.exist;
+		} );
+	} );
+
+	describe( 'getCurrentlyEditingProduct', () => {
+		it( 'should return undefined if there are no edits', () => {
+			expect( getCurrentlyEditingProduct( state ) ).to.not.exist;
+		} );
+
+		it( 'should get the last edited product', () => {
+			const newProduct = { id: { index: 0 }, name: 'New Product' };
+			const uiProducts = state.extensions.woocommerce.ui.products;
+			set( uiProducts, 'edits.creates', [ newProduct ] );
+			set( uiProducts, 'edits.currentlyEditingId', newProduct.id );
+
+			expect( getCurrentlyEditingProduct( state ) ).to.eql( newProduct );
+		} );
+	} );
+} );


### PR DESCRIPTION
This adds selectors for the product edit state.
It will allow just the edits to be retrieved or the edits overlaid on
top of the fetched data.