### PR TITLE
WooCommerce: Add product details to form

### DIFF
--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentlyEditingProduct } from '../../state/ui/products/selectors';
+import { editProduct, editProductAttribute } from '../../state/ui/products/actions';
+import ProductForm from './product-form';
+
+class ProductCreate extends Component {
+
+	componentDidMount() {
+		const { product } = this.props;
+
+		if ( ! product ) {
+			this.props.editProduct( null, {
+				type: 'simple'
+			} );
+		}
+	}
+
+	componentWillUnmount() {
+		// TODO: Remove the product we added here from the edit state.
+	}
+
+	render() {
+		const { product } = this.props;
+
+		return (
+			<ProductForm
+				product={ product || {} }
+				editProduct={ this.props.editProduct }
+				editProductAttribute={ editProductAttribute }
+			/>
+		);
+	}
+}
+
+function mapStateToProps( state ) {
+	const product = getCurrentlyEditingProduct( state );
+
+	return {
+		product,
+	};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators(
+		{
+			editProduct,
+			editProductAttribute,
+		},
+		dispatch
+	);
+}
+
+export default connect( mapStateToProps, mapDispatchToProps )( ProductCreate );

--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -33,7 +33,7 @@ class ProductCreate extends Component {
 
 		return (
 			<ProductForm
-				product={ product || {} }
+				product={ product || { type: 'simple' } }
 				editProduct={ this.props.editProduct }
 				editProductAttribute={ editProductAttribute }
 			/>

--- a/client/extensions/woocommerce/app/products/product-form-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-details-card.js
@@ -9,6 +9,7 @@ import i18n from 'i18n-calypso';
  */
 import Card from 'components/card';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
+import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextArea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
@@ -54,8 +55,8 @@ export default class ProductFormDetailsCard extends Component {
 		const __ = i18n.translate;
 		return (
 			<Card className="products__product-form-details">
-				<div>
-					<FormLabel className="products__product-form-featured">
+				<div className="products__product-form-details-featured">
+					<FormLabel>
 						{ __( 'Featured' ) }
 						<CompactFormToggle
 							onChange={ this.toggleFeatured }
@@ -63,15 +64,20 @@ export default class ProductFormDetailsCard extends Component {
 						/>
 					</FormLabel>
 				</div>
-				<div>
-					<FormLabel className="products__product-form-name">
-						<span>{ __( 'Product name' ) }</span>
-						<FormTextInput value={ product.name || '' } onChange={ this.setName } />
-					</FormLabel>
-					<FormLabel className="products__product-form-description">
-						<span>{ __( 'Description' ) }</span>
-						<FormTextArea value={ product.description || '' } onChange={ this.setDescription } />
-					</FormLabel>
+				<div className="products__product-form-details-wrapper">
+					<div className="products__product-form-details-images">
+
+					</div>
+					<div className="products__product-form-details-basic">
+						<FormFieldSet>
+							<FormLabel htmlFor="name">{ __( 'Product name' ) }</FormLabel>
+							<FormTextInput name="name" value={ product.name || '' } onChange={ this.setName } />
+						</FormFieldSet>
+						<FormFieldSet className="products__product-form-details-basic-description">
+							<FormLabel htmlFor="description">{ __( 'Description' ) }</FormLabel>
+							<FormTextArea name="description" value={ product.description || '' } onChange={ this.setDescription } />
+						</FormFieldSet>
+					</div>
 				</div>
 			</Card>
 		);

--- a/client/extensions/woocommerce/app/products/product-form-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-details-card.js
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import i18n from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import FormLabel from 'components/forms/form-label';
+import FormTextArea from 'components/forms/form-textarea';
+import FormTextInput from 'components/forms/form-text-input';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
+
+export default class ProductFormDetailsCard extends Component {
+
+	static propTypes = {
+		product: PropTypes.shape( {
+			id: PropTypes.isRequired,
+			type: PropTypes.string.isRequired,
+			name: PropTypes.string,
+		} ),
+		editProduct: PropTypes.func.isRequired,
+	};
+
+	constructor( props ) {
+		super( props );
+
+		this.setName = this.setName.bind( this );
+		this.setDescription = this.setDescription.bind( this );
+		this.toggleFeatured = this.toggleFeatured.bind( this );
+	}
+
+	setName( e ) {
+		const { product, editProduct } = this.props;
+		editProduct( product, { name: e.target.value } );
+	}
+
+	setDescription( e ) {
+		const { product, editProduct } = this.props;
+		editProduct( product, { description: e.target.value } );
+	}
+
+	toggleFeatured() {
+		const { product, editProduct } = this.props;
+		editProduct( product, { featured: ! product.featured } );
+	}
+
+	render() {
+		const { product } = this.props;
+		const __ = i18n.translate;
+		return (
+			<Card className="products__product-form-details">
+				<div>
+					<FormLabel>
+						{ __( 'Featured' ) }
+						<CompactFormToggle
+							onChange={ this.toggleFeatured }
+							checked={ product.featured }
+						/>
+					</FormLabel>
+				</div>
+				<div>
+
+				</div>
+				<div>
+					<FormLabel>
+						<span>{ __( 'Product name' ) }</span>
+						<FormTextInput value={ product.name || '' } onChange={ this.setName } />
+					</FormLabel>
+					<FormLabel>
+						<span>{ __( 'Description' ) }</span>
+						<FormTextArea value={ product.description || '' } onChange={ this.setDescription } />
+					</FormLabel>
+				</div>
+			</Card>
+		);
+	}
+
+}

--- a/client/extensions/woocommerce/app/products/product-form-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-details-card.js
@@ -8,10 +8,10 @@ import i18n from 'i18n-calypso';
  * Internal dependencies
  */
 import Card from 'components/card';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
 import FormLabel from 'components/forms/form-label';
 import FormTextArea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
-import CompactFormToggle from 'components/forms/form-toggle/compact';
 
 export default class ProductFormDetailsCard extends Component {
 
@@ -32,6 +32,8 @@ export default class ProductFormDetailsCard extends Component {
 		this.toggleFeatured = this.toggleFeatured.bind( this );
 	}
 
+	// TODO: Consider consolidating the following set functions
+	// into a general purpose Higher Order Component
 	setName( e ) {
 		const { product, editProduct } = this.props;
 		editProduct( product, { name: e.target.value } );
@@ -53,7 +55,7 @@ export default class ProductFormDetailsCard extends Component {
 		return (
 			<Card className="products__product-form-details">
 				<div>
-					<FormLabel>
+					<FormLabel className="products__product-form-featured">
 						{ __( 'Featured' ) }
 						<CompactFormToggle
 							onChange={ this.toggleFeatured }
@@ -62,14 +64,11 @@ export default class ProductFormDetailsCard extends Component {
 					</FormLabel>
 				</div>
 				<div>
-
-				</div>
-				<div>
-					<FormLabel>
+					<FormLabel className="products__product-form-name">
 						<span>{ __( 'Product name' ) }</span>
 						<FormTextInput value={ product.name || '' } onChange={ this.setName } />
 					</FormLabel>
-					<FormLabel>
+					<FormLabel className="products__product-form-description">
 						<span>{ __( 'Description' ) }</span>
 						<FormTextArea value={ product.description || '' } onChange={ this.setDescription } />
 					</FormLabel>

--- a/client/extensions/woocommerce/app/products/product-form.js
+++ b/client/extensions/woocommerce/app/products/product-form.js
@@ -8,6 +8,7 @@ import i18n from 'i18n-calypso';
  * Internal dependencies
  */
 import FoldableCard from 'components/foldable-card';
+import ProductFormDetailsCard from './product-form-details-card';
 import ProductVariationTypesForm from './product-variation-types-form';
 import FormToggle from 'components/forms/form-toggle';
 
@@ -15,10 +16,12 @@ export default class ProductForm extends Component {
 
 	static propTypes = {
 		product: PropTypes.shape( {
-			id: PropTypes.number.isRequired,
-			name: PropTypes.string.isRequired,
+			id: PropTypes.isRequired,
 			type: PropTypes.string.isRequired,
-		} )
+			name: PropTypes.string,
+		} ),
+		editProduct: PropTypes.func.isRequired,
+		editProductAttribute: PropTypes.func.isRequired,
 	};
 
 	constructor( props ) {
@@ -48,6 +51,11 @@ export default class ProductForm extends Component {
 		);
 		return (
 			<div className="woocommerce products__form">
+				<ProductFormDetailsCard
+					product={ product }
+					editProduct={ this.props.editProduct }
+				/>
+
 				<FoldableCard
 					icon=""
 					expanded={ true }

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -10,7 +10,7 @@ import config from 'config';
  */
 import { navigation, siteSelection } from 'my-sites/controller';
 import { renderWithReduxStore } from 'lib/react-helpers';
-import ProductForm from './app/products/product-form';
+import ProductCreate from './app/products/product-create';
 import Dashboard from './app/dashboard';
 import Stats from './app/stats';
 
@@ -25,7 +25,7 @@ const Controller = {
 
 	addProduct: function( context ) {
 		renderWithReduxStore(
-			React.createElement( ProductForm, { } ),
+			React.createElement( ProductCreate, { } ),
 			document.getElementById( 'primary' ),
 			context.store
 		);

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -43,7 +43,7 @@ const Controller = {
 export default function() {
 	if ( config.isEnabled( 'woocommerce/extension-dashboard' ) ) {
 		page( '/store/:site?', siteSelection, navigation, Controller.dashboard );
-		page( '/store/products/add/:site?', siteSelection, navigation, Controller.addProduct );
+		page( '/store/:site?/products/add', siteSelection, navigation, Controller.addProduct );
 	}
 
 	if ( config.isEnabled( 'woocommerce/extension-stats' ) ) {

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -1,8 +1,62 @@
+.is-section-woocommerce {
+	.layout__primary {
+		display: flex;
+		justify-content: center;
+	}
+}
+
 .woocommerce {
+	flex-grow: 1;
+	max-width: 720px;
+
+	.form-label {
+		margin-bottom: 16px;
+	}
 
 	.foldable-card.products__variation-card .foldable-card__content {
 		padding: 0;
 		border: 0;
+	}
+
+	.products__product-form-details-featured {
+		text-align: right;
+
+		.form-toggle__wrapper {
+			margin-left: 10px;
+		}
+	}
+
+	.products__product-form-details-wrapper {
+		display: flex;
+		flex-direction: column;
+		@include breakpoint( ">960px" ) {
+			flex-direction: row;
+		}
+	}
+	/* TODO: remove placeholder styles once implemented */
+	.products__product-form-details-images {
+		background: $gray-light;
+		height: 200px;
+		margin-bottom: 16px;
+		@include breakpoint( ">960px" ) {
+			margin-bottom: 0;
+		}
+	}
+
+	.products__product-form-details-images,
+	.products__product-form-details-basic {
+		flex: 1;
+		@include breakpoint( ">960px" ) {
+			margin-right: 32px;
+		}
+
+		&:last-child {
+			margin-right: 0;
+		}
+	}
+
+	.products__product-form-details-basic-description textarea {
+		resize: vertical;
 	}
 
 	.products__variation-types-form-wrapper {


### PR DESCRIPTION
This adds product details and populates them with the current product
edit state.

This PR does not include CSS/design changes, to keep the PR size down. See #13251.

To Test:

1. `make run`
2. Go to `http://calypso.localhost:3000/store/<site_url>/products/add`
3. Verify that you can type in a new name, description, and toggle the "featured" status.
