### PR TITLE
Framework: remove sites list usage from media

### DIFF
--- a/client/my-sites/media/controller.js
+++ b/client/my-sites/media/controller.js
@@ -11,11 +11,7 @@ import route from 'lib/route';
 import analytics from 'lib/analytics';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { renderWithReduxStore } from 'lib/react-helpers';
-import {
-	getSelectedSiteId,
-	getSelectedSite
-} from 'state/ui/selectors';
-import { getSiteSlug } from 'state/sites/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 
 module.exports = {
 
@@ -26,9 +22,7 @@ module.exports = {
 			baseAnalyticsPath = route.sectionify( context.path );
 
 		const state = context.store.getState();
-		const selectedSiteId = getSelectedSiteId( state );
 		const selectedSite = getSelectedSite( state );
-		const selectedSiteSlug = getSiteSlug( state, selectedSiteId );
 
 		// Analytics
 		if ( selectedSite ) {
@@ -44,7 +38,6 @@ module.exports = {
 		renderWithReduxStore(
 			React.createElement( MediaComponent, {
 				selectedSite,
-				selectedSiteSlug,
 				filter: filter,
 				search: search
 			} ),

--- a/client/my-sites/media/controller.js
+++ b/client/my-sites/media/controller.js
@@ -7,13 +7,15 @@ import i18n from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import sitesFactory from 'lib/sites-list';
 import route from 'lib/route';
 import analytics from 'lib/analytics';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { renderWithReduxStore } from 'lib/react-helpers';
-
-const sites = sitesFactory();
+import {
+	getSelectedSiteId,
+	getSelectedSite
+} from 'state/ui/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 
 module.exports = {
 
@@ -23,8 +25,13 @@ module.exports = {
 			search = context.query.s,
 			baseAnalyticsPath = route.sectionify( context.path );
 
+		const state = context.store.getState();
+		const selectedSiteId = getSelectedSiteId( state );
+		const selectedSite = getSelectedSite( state );
+		const selectedSiteSlug = getSiteSlug( state, selectedSiteId );
+
 		// Analytics
-		if ( sites.getSelectedSite() ) {
+		if ( selectedSite ) {
 			baseAnalyticsPath += '/:site';
 		}
 		analytics.pageView.record( baseAnalyticsPath, 'Media' );
@@ -36,7 +43,8 @@ module.exports = {
 		// Render
 		renderWithReduxStore(
 			React.createElement( MediaComponent, {
-				sites: sites,
+				selectedSite,
+				selectedSiteSlug,
 				filter: filter,
 				search: search
 			} ),

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -23,7 +23,6 @@ class Media extends Component {
 
 	static propTypes = {
 		selectedSite: PropTypes.object,
-		selectedSiteSlug: PropTypes.string,
 		filter: PropTypes.string,
 		search: PropTypes.string
 	};
@@ -47,8 +46,8 @@ class Media extends Component {
 			redirect += '/' + filter;
 		}
 
-		if ( this.props.selectedSiteSlug ) {
-			redirect += '/' + this.props.selectedSiteSlug;
+		if ( this.props.selectedSite ) {
+			redirect += '/' + this.props.selectedSite.slug;
 		}
 
 		page( redirect );


### PR DESCRIPTION
This PR removes SitesList usage from the media section.

### Testing Instructions
- Navigate to http://calypso.localhost:3000/media
- Select a site
- You can: upload new images, filter, edit, restore, and modify meta data like titles
- No functional changes