### PR TITLE
AT: track initiate transfer

### DIFF
--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -631,7 +631,7 @@ export function clearThemeUpload( siteId ) {
  * @returns {Promise} for testing purposes only
  */
 export function initiateThemeTransfer( siteId, file, plugin ) {
-	const context = !! plugin ? 'plugin' : 'theme';
+	const context = !! plugin ? 'plugins' : 'themes';
 	return dispatch => {
 		const themeInitiateRequest = {
 			type: THEME_TRANSFER_INITIATE_REQUEST,

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -633,10 +633,15 @@ export function clearThemeUpload( siteId ) {
 export function initiateThemeTransfer( siteId, file, plugin ) {
 	const context = !! plugin ? 'plugin' : 'theme';
 	return dispatch => {
-		dispatch( {
+		const themeInitiateRequest = {
 			type: THEME_TRANSFER_INITIATE_REQUEST,
 			siteId,
-		} );
+		};
+
+		dispatch( withAnalytics(
+			recordTracksEvent( 'calypso_automated_transfer_inititate_request', { plugin, context } ),
+			themeInitiateRequest
+		) );
 		return wpcom.undocumented().initiateTransfer( siteId, plugin, file, ( event ) => {
 			dispatch( {
 				type: THEME_TRANSFER_INITIATE_PROGRESS,

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -639,7 +639,7 @@ export function initiateThemeTransfer( siteId, file, plugin ) {
 		};
 
 		dispatch( withAnalytics(
-			recordTracksEvent( 'calypso_automated_transfer_initiate_request', { plugin, context } ),
+			recordTracksEvent( 'calypso_automated_transfer_initiate_transfer', { plugin, context } ),
 			themeInitiateRequest
 		) );
 		return wpcom.undocumented().initiateTransfer( siteId, plugin, file, ( event ) => {
@@ -738,7 +738,8 @@ export function pollThemeTransferStatus( siteId, transferId, interval = 3000, ti
 					dispatch( transferStatus( siteId, transferId, status, message, uploaded_theme_slug ) );
 					if ( status === 'complete' ) {
 						// finished, stop polling
-						dispatch( recordTracksEvent( 'calypso_automated_transfer_complete', { transfer_id: transferId } ) );
+						const context = !! uploaded_theme_slug ? 'themes' : 'plugins';
+						dispatch( recordTracksEvent( 'calypso_automated_transfer_complete', { transfer_id: transferId, context } ) );
 						return resolve();
 					}
 					// poll again

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -639,7 +639,7 @@ export function initiateThemeTransfer( siteId, file, plugin ) {
 		};
 
 		dispatch( withAnalytics(
-			recordTracksEvent( 'calypso_automated_transfer_inititate_request', { plugin, context } ),
+			recordTracksEvent( 'calypso_automated_transfer_initiate_request', { plugin, context } ),
 			themeInitiateRequest
 		) );
 		return wpcom.undocumented().initiateTransfer( siteId, plugin, file, ( event ) => {
@@ -662,7 +662,7 @@ export function initiateThemeTransfer( siteId, file, plugin ) {
 					transferId: transfer_id,
 				};
 				dispatch( withAnalytics(
-					recordTracksEvent( 'calypso_automated_transfer_inititate_success', { plugin, context } ),
+					recordTracksEvent( 'calypso_automated_transfer_initiate_success', { plugin, context } ),
 					themeInitiateSuccessAction
 				) );
 				dispatch( pollThemeTransferStatus( siteId, transfer_id ) );
@@ -705,7 +705,7 @@ function transferInitiateFailure( siteId, error, plugin ) {
 			error,
 		};
 		dispatch( withAnalytics(
-			recordTracksEvent( 'calypso_automated_transfer_inititate_failure', { plugin, context } ),
+			recordTracksEvent( 'calypso_automated_transfer_initiate_failure', { plugin, context } ),
 			themeInitiateFailureAction
 		) );
 	};

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -631,6 +631,7 @@ export function clearThemeUpload( siteId ) {
  * @returns {Promise} for testing purposes only
  */
 export function initiateThemeTransfer( siteId, file, plugin ) {
+	const context = !! plugin ? 'plugin' : 'theme';
 	return dispatch => {
 		dispatch( {
 			type: THEME_TRANSFER_INITIATE_REQUEST,
@@ -656,7 +657,7 @@ export function initiateThemeTransfer( siteId, file, plugin ) {
 					transferId: transfer_id,
 				};
 				dispatch( withAnalytics(
-					recordTracksEvent( 'calypso_automated_transfer_inititate_success', { plugin } ),
+					recordTracksEvent( 'calypso_automated_transfer_inititate_success', { plugin, context } ),
 					themeInitiateSuccessAction
 				) );
 				dispatch( pollThemeTransferStatus( siteId, transfer_id ) );
@@ -691,6 +692,7 @@ function transferStatusFailure( siteId, transferId, error ) {
 
 // receive a transfer initiation failure
 function transferInitiateFailure( siteId, error, plugin ) {
+	const context = !! plugin ? 'plugin' : 'theme';
 	return dispatch => {
 		const themeInitiateFailureAction = {
 			type: THEME_TRANSFER_INITIATE_FAILURE,
@@ -698,7 +700,7 @@ function transferInitiateFailure( siteId, error, plugin ) {
 			error,
 		};
 		dispatch( withAnalytics(
-			recordTracksEvent( 'calypso_automated_transfer_inititate_failure', { plugin } ),
+			recordTracksEvent( 'calypso_automated_transfer_inititate_failure', { plugin, context } ),
 			themeInitiateFailureAction
 		) );
 	};

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -778,6 +778,7 @@ describe( 'actions', () => {
 				expect( spy ).to.have.been.calledThrice;
 
 				expect( spy ).to.have.been.calledWith( {
+					meta: sinon.match.object,
 					type: THEME_TRANSFER_INITIATE_REQUEST,
 					siteId,
 				} );


### PR DESCRIPTION
This adds an event to track automated transfer initialization under the event name `calypso_automated_transfer_initiate_transfer`

It also adds a `context` event property to the other transfer process events:
- `calypso_automated_transfer_initiate_succes`
- `calypso_automated_transfer_initiate_failed`
- `calypso_automated_transfer_complete`

This property is set to either `plugins` or `themes`

**Testing**
- Enable tracks logging: `localStorage.setItem( 'debug', 'calypso.analytics.tracks' )`
- Visit a plugin page on a site that is eligible for automated transfer
- The event `calypso_automated_transfer_initiate_transfer` should fire after clicking install

The same steps can be repeated with a theme upload transfer flow

Also note that the initialization events should have a `context` event property with the correct context, `plugins` or `themes`

