### PR TITLE
Add new LanguagePicker component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -125,6 +125,7 @@
 @import 'components/info-popover/style';
 @import 'components/input-chrono/style';
 @import 'components/logged-out-form/style';
+@import 'components/language-picker/style';
 @import 'components/main/style';
 @import 'components/marketing-survey/cancel-purchase-form/style';
 @import 'components/mobile-back-to-sidebar/style';

--- a/client/components/language-picker/README.md
+++ b/client/components/language-picker/README.md
@@ -1,0 +1,77 @@
+LanguagePicker
+==============
+
+React component used to display a Language Picker.
+
+---
+
+## Example Usage
+
+```js
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import LanguagePicker from 'components/language-picker';
+import { getUserSetting } from 'state/selectors';
+import { saveUserSettings } from 'state/user-settings/actions';
+
+const languages = [
+	{
+		value: 1,
+		langSlug: 'en',
+		name: 'English',
+		wpLocale: 'en_US',
+		popular: 1
+	},
+	{
+		value: 11,
+		langSlug: 'cs',
+		name: 'Čeština',
+		wpLocale: 'cs_CZ'
+	}
+];
+
+class LanguagePickerDemo extends PureComponent {
+	onSelectLanguage = ( event ) => {
+		this.props.saveUserSettings( { language: event.target.value } );
+	}
+
+	render() {
+		return (
+			<LanguagePicker
+				languages={ languages }
+				valueKey="langSlug"
+				value={ this.props.language }
+				onChange={ this.onSelectLanguage }
+			/>
+		);
+	}
+}
+
+export default connect(
+	state => ( { language: getUserSetting( state, 'language' ) } ),
+	{ saveUserSettings }
+)( LanguagePickerDemo );
+```
+
+---
+
+## LanguagePicker
+
+The `LanguagePicker` is a form component with API similar to a HTML `input` or `select`
+element - its value is specified in a `value` prop, and it calls an `onChange` handler
+when its value changes.
+
+#### Props
+
+`languages` - **required** Array with information about languages, their names, language
+slugs, popularity etc. It's exported by `config` module under the `languages` key.
+
+`valueKey` - **optional** Determines which property of the `languages` objects will be used
+in the `value` and `onChange` props of the component. Possible values are `value` (default),
+`langSlug` and `wpLocale`.
+
+`value` - **optional** The selected value of the language picker
+
+`onChange` - **optional** Handler called when the selected value is changed
+
+------------

--- a/client/components/language-picker/docs/example.jsx
+++ b/client/components/language-picker/docs/example.jsx
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import LanguagePicker from 'components/language-picker';
+import Card from 'components/card';
+
+class LanguagePickerExample extends PureComponent {
+	state = {
+		disabled: false,
+		loading: false,
+		language: 'en'
+	}
+
+	selectLanguage = ( event ) => {
+		this.setState( { language: event.target.value } );
+	}
+
+	toggleDisabled = () => {
+		this.setState( { disabled: ! this.state.disabled } );
+	}
+
+	triggerLoading = () => {
+		if ( ! this.state.loading ) {
+			this.setState( { loading: true } );
+			setTimeout( () => this.setState( { loading: false } ), 2000 );
+		}
+	}
+
+	render() {
+		const { disabled, loading, language } = this.state;
+
+		const loadingCls = classNames( 'docs__design-toggle button', {
+			'is-busy': loading
+		} );
+
+		return (
+			<div>
+				<a className="docs__design-toggle button" onClick={ this.toggleDisabled }>
+					{ disabled ? 'Enabled State' : 'Disabled State' }
+				</a>
+				<a
+					className={ loadingCls }
+					style={ { marginRight: '8px' } }
+					onClick={ this.triggerLoading }
+				>Test Loading</a>
+				<Card>
+					<LanguagePicker
+						languages={ config( 'languages' ) }
+						valueKey="langSlug"
+						value={ loading ? null : language }
+						onChange={ this.selectLanguage }
+						disabled={ disabled }
+					/>
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default LanguagePickerExample;

--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -1,0 +1,134 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes, PureComponent } from 'react';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { find, noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import LanguagePickerModal from './modal';
+
+class LanguagePicker extends PureComponent {
+
+	static propTypes = {
+		languages: PropTypes.array.isRequired,
+		valueKey: PropTypes.string,
+		value: PropTypes.any,
+		onChange: PropTypes.func,
+	}
+
+	static defaultProps = {
+		languages: [],
+		valueKey: 'value',
+		onChange: noop,
+	}
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			selectedLanguage: this.findLanguage( props.valueKey, props.value )
+		};
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.value !== this.props.value || nextProps.valueKey !== this.props.valueKey ) {
+			this.setState( {
+				selectedLanguage: this.findLanguage( nextProps.valueKey, nextProps.value )
+			} );
+		}
+	}
+
+	findLanguage( valueKey, value ) {
+		return find( this.props.languages, lang => {
+			// The value passed is sometimes string instead of number - need to use ==
+			return lang[ valueKey ] == value; // eslint-disable-line eqeqeq
+		} );
+	}
+
+	selectLanguage = ( languageSlug ) => {
+		// Find the language by the slug
+		const language = this.findLanguage( 'langSlug', languageSlug );
+		if ( ! language ) {
+			return;
+		}
+
+		// onChange takes an object in shape of a DOM event as argument
+		const value = language[ this.props.valueKey ];
+		const event = { target: { value } };
+		this.props.onChange( event );
+		this.setState( {
+			selectedLanguage: language,
+		} );
+	}
+
+	toggleOpen = () => {
+		if ( ! this.props.disabled ) {
+			this.setState( { open: ! this.state.open } );
+		}
+	}
+
+	handleClose = () => {
+		this.setState( { open: false } );
+	}
+
+	renderPlaceholder() {
+		const classes = classNames( 'language-picker', 'is-loading' );
+
+		return (
+			<div className={ classes }>
+				<div className="language-picker__icon">
+					<div className="language-picker__icon-inner" />
+				</div>
+				<div className="language-picker__name">
+					<div className="language-picker__name-inner" />
+				</div>
+			</div>
+		);
+	}
+
+	render() {
+		const language = this.state.selectedLanguage;
+		if ( ! language ) {
+			return this.renderPlaceholder();
+		}
+
+		const [ langCode, langSubcode ] = language.langSlug.split( '-' );
+		const langName = language.name;
+		const { disabled, translate } = this.props;
+
+		return (
+			<div className="language-picker" onClick={ this.toggleOpen } disabled={ disabled }>
+				<div className="language-picker__icon">
+					<div className="language-picker__icon-inner">
+						{ langCode }
+						{ langSubcode && <br /> }
+						{ langSubcode }
+					</div>
+				</div>
+				<div className="language-picker__name">
+					<div className="language-picker__name-inner">
+						<div className="language-picker__name-label">
+							{ langName }
+						</div>
+						<div className="language-picker__name-change" >
+							{ translate( 'Change' ) }
+						</div>
+					</div>
+				</div>
+				<LanguagePickerModal
+					isVisible={ this.state.open }
+					languages={ this.props.languages }
+					onClose={ this.handleClose }
+					onSelected={ this.selectLanguage }
+					selected={ language.langSlug }
+				/>
+			</div>
+		);
+	}
+}
+
+export default localize( LanguagePicker );

--- a/client/components/language-picker/modal.jsx
+++ b/client/components/language-picker/modal.jsx
@@ -1,0 +1,189 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes, PureComponent } from 'react';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { includes, map, noop, partial } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+import SectionNav from 'components/section-nav';
+import SectionNavTabs from 'components/section-nav/tabs';
+import SectionNavTabItem from 'components/section-nav/item';
+import Search from 'components/search';
+
+class LanguagePickerModal extends PureComponent {
+	static propTypes = {
+		onSelected: PropTypes.func,
+		onClose: PropTypes.func,
+	}
+
+	static defaultProps = {
+		onSelected: noop,
+		onClose: noop,
+	}
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			filter: 'popular',
+			search: false,
+			selectedLanguageSlug: this.props.selected,
+		};
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.selected !== this.state.selectedLanguageSlug ) {
+			this.setState( {
+				selectedLanguageSlug: nextProps.selected
+			} );
+		}
+	}
+
+	getFilterLabel( filter ) {
+		const { translate } = this.props;
+
+		switch ( filter ) {
+			case 'popular':
+				return translate( 'Popular languages', { textOnly: true } );
+			default:
+				return translate( 'All languages', { textOnly: true } );
+		}
+	}
+
+	getDisplayedLanguages() {
+		const { languages } = this.props;
+		const { search, filter } = this.state;
+
+		if ( search ) {
+			const searchString = search.toLowerCase();
+			return languages.filter( language => {
+				return includes( language.name.toLowerCase(), searchString );
+			} );
+		}
+
+		switch ( filter ) {
+			case 'popular':
+				const popularLanguages = languages.filter( language => language.popular );
+				popularLanguages.sort( ( a, b ) => a.popular - b.popular );
+				return popularLanguages;
+			default:
+				return languages;
+		}
+	}
+
+	handleSearch = ( search ) => {
+		this.setState( { search } );
+	}
+
+	handleClick = ( selectedLanguageSlug ) => {
+		this.setState( { selectedLanguageSlug } );
+	}
+
+	handleSelectLanguage = () => {
+		const langSlug = this.state.selectedLanguageSlug;
+		this.props.onSelected( langSlug );
+		this.handleClose();
+	}
+
+	handleClose = () => {
+		this.props.onClose();
+	}
+
+	renderTabItems() {
+		const tabs = [ 'popular', '' ];
+
+		return map( tabs, filter => {
+			const selected = this.state.filter === filter;
+			const onClick = () => this.setState( { filter } );
+
+			return (
+				<SectionNavTabItem
+					key={ filter }
+					selected={ selected }
+					onClick={ onClick }
+				>
+					{ this.getFilterLabel( filter ) }
+				</SectionNavTabItem>
+			);
+		} );
+	}
+
+	renderLanguageList() {
+		const languages = this.getDisplayedLanguages();
+
+		return (
+			<div className="language-picker__modal-list">
+				{ map( languages, this.renderLanguageItem ) }
+			</div>
+		);
+	}
+
+	renderLanguageItem = ( language ) => {
+		const isSelected = language.langSlug === this.state.selectedLanguageSlug;
+		const classes = classNames( 'language-picker__modal-text', {
+			'is-selected': isSelected
+		} );
+
+		return (
+			<div
+				className="language-picker__modal-item"
+				key={ language.langSlug }
+				onClick={ partial( this.handleClick, language.langSlug ) }
+			>
+				<span className={ classes }>{ language.name }</span>
+			</div>
+		);
+	}
+
+	render() {
+		const { isVisible, translate } = this.props;
+
+		if ( ! isVisible ) {
+			// Render nothing at all if the modal is not visible
+			// <Dialog isVisible={ false }> still renders a lot of useless elements
+			return null;
+		}
+
+		const buttons = [
+			{
+				action: 'cancel',
+				label: translate( 'Cancel' )
+			},
+			{
+				action: 'confirm',
+				label: translate( 'Select Language' ),
+				isPrimary: true,
+				onClick: this.handleSelectLanguage
+			},
+		];
+
+		return (
+			<Dialog
+				isVisible
+				buttons={ buttons }
+				onClose={ this.handleClose }
+				additionalClassNames="language-picker__modal"
+			>
+				<SectionNav selectedText={ this.getFilterLabel( this.state.filter ) }>
+					<SectionNavTabs>
+						{ this.renderTabItems() }
+					</SectionNavTabs>
+					<Search
+						pinned
+						fitsContainer
+						onSearch={ this.handleSearch }
+						placeholder={ translate( 'Search languages…' ) }
+					/>
+				</SectionNav>
+				{ this.renderLanguageList() }
+			</Dialog>
+		);
+	}
+}
+
+export default localize( LanguagePickerModal );

--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -1,0 +1,177 @@
+.language-picker {
+	background: $white;
+	border: 1px solid lighten( $gray, 20% );
+	border-width: 1px 1px 2px;
+	border-radius: 4px;
+	width: 300px;
+	display: flex;
+	flex: 1 0 auto;
+	font-size: 14px;
+	height: 64px;
+	align-items: stretch;
+	cursor: pointer;
+	transition: border-color .15s ease-in-out;
+
+	@include breakpoint( "<660px" ) {
+		width: 100%;
+	}
+
+	&[disabled] {
+		cursor: default;
+
+		&,
+		.language-picker__icon {
+			border-color: lighten( $gray, 30% );
+		}
+
+		&,
+		.language-picker__name-change {
+			color: lighten( $gray, 30% );
+		}
+	}
+
+	&:not([disabled]):hover {
+		&,
+		.language-picker__icon {
+			border-color: lighten( $gray, 10% );
+		}
+	}
+
+	&.is-loading {
+		.language-picker__icon-inner {
+			width: 30px;
+			height: 30px;
+			animation: pulse-light 0.8s ease-in-out infinite;
+		}
+
+		.language-picker__name-inner {
+			width: 100%;
+			height: 30px;
+			background-color: lighten( $gray, 30% );
+		}
+	}
+}
+
+.language-picker__icon {
+	width: 64px;
+	margin: 4px 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex: none;
+	border-right: 1px solid lighten( $gray, 20% );
+	transition: border-color .15s ease-in-out;
+}
+
+.language-picker__icon-inner {
+	text-transform: uppercase;
+	font-weight: 700;
+	line-height: 1.0;
+}
+
+.language-picker__name {
+	flex: auto;
+	margin: 4px 16px;
+	display: flex;
+	align-items: center;
+}
+
+.language-picker__name-inner {
+	font-weight: 600;
+	overflow: hidden;
+}
+
+.language-picker__name-label {
+	white-space: nowrap;
+}
+
+.language-picker__name-change {
+	text-transform: uppercase;
+	color: $gray-text-min;
+}
+
+.language-picker__modal {
+	padding: 0;
+
+	&.dialog.card {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		max-width: none;
+		font-size: 14px;
+		display: flex;
+		flex-direction: column;
+
+		@include breakpoint( ">660px" ) {
+			top: 5%;
+			bottom: 5%;
+			left: 5%;
+			right: 5%;
+			width: 90%;
+		}
+
+		@include breakpoint( ">960px" ) {
+			left: 12.5%;
+			right: 12.5%;
+			width: 75%;
+		}
+	}
+
+	.dialog__content {
+		display: flex;
+		flex-direction: column;
+		flex: auto;
+	}
+
+	.dialog__action-buttons {
+		flex: none;
+		margin: 0;
+	}
+
+	.section-nav {
+		flex: none;
+		margin-bottom: 0;
+		z-index: 10;
+	}
+}
+
+.language-picker__modal-list {
+	box-sizing: border-box;
+	width: 100%;
+	overflow-y: auto;
+	padding: 8px 16px;
+	flex: auto;
+}
+
+.language-picker__modal-item {
+	display: inline-block;
+	width: 100%;
+	white-space: nowrap;
+	overflow: hidden;
+
+	@include breakpoint( ">480px") {
+		width: 50%;
+	}
+
+	@include breakpoint( ">660px" ) {
+		width: 33%;
+	}
+
+	@include breakpoint( ">960px" ) {
+		width: 25%;
+	}
+}
+
+.language-picker__modal-text {
+	display: inline-block;
+	padding: 4px 8px;
+	border-radius: 4px;
+	cursor: pointer;
+
+	&.is-selected {
+		background: $blue-medium;
+		color: $white;
+	}
+}

--- a/client/components/language-picker/test/index.jsx
+++ b/client/components/language-picker/test/index.jsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { render } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import useMockery from 'test/helpers/use-mockery';
+
+const languages = [
+	{
+		value: 1,
+		langSlug: 'en',
+		name: 'English',
+		wpLocale: 'en_US',
+		popular: 1
+	},
+	{
+		value: 11,
+		langSlug: 'cs',
+		name: 'Čeština',
+		wpLocale: 'cs_CZ'
+	}
+];
+
+describe( 'LanguagePicker', () => {
+	let LanguagePicker;
+
+	useMockery( mockery => {
+		mockery.registerMock( 'lib/analytics', {} );
+	} );
+
+	before( () => {
+		LanguagePicker = require( '../' );
+	} );
+
+	it( 'should render the right icon and label', () => {
+		const wrapper = render(
+			<LanguagePicker
+				languages={ languages }
+				valueKey="langSlug"
+				value="en"
+			/>
+		);
+		expect( wrapper.find( '.language-picker__icon' ) ).to.have.text( 'en' );
+		expect( wrapper.find( '.language-picker__name-label' ) ).to.have.text( 'English' );
+	} );
+} );

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -70,6 +70,7 @@ import FAQ from 'components/faq/docs/example';
 import VerticalMenu from 'components/vertical-menu/docs/example';
 import Banner from 'components/banner/docs/example';
 import EmojifyExample from 'components/emojify/docs/example';
+import LanguagePicker from 'components/language-picker/docs/example';
 
 let DesignAssets = React.createClass( {
 	displayName: 'DesignAssets',
@@ -144,6 +145,7 @@ let DesignAssets = React.createClass( {
 					<InfoPopover />
 					<Tooltip />
 					<InputChrono />
+					<LanguagePicker />
 					<Notices />
 					<PaymentLogo />
 					<Popovers />


### PR DESCRIPTION
This is a basic `LanguagePicker` component that's been split off the big #12544 PR -- see the comments there to learn what's the big picture.

![language-picker-recording](https://cloud.githubusercontent.com/assets/664258/25040248/6a684800-2108-11e7-9dfc-e6eed5b0e920.gif)

It's not yet used anywhere in the UI, but can be tested on the [example in devdocs](https://calypso.live/devdocs/design/language-picker?branch=add/language-picker)

The language picker modal is pretty basic in this first version -- more features like suggested languages and grouping languages by territory will be coming in follow-up PRs.