### PR TITLE
Reader: Fix Combined Cards too wide

### DIFF
--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -36,9 +36,11 @@
 	margin-top: 4px;
 }
 
-/* Posts */
+// Posts
 .reader-combined-card__post-details {
 	font-family: $serif;
+	overflow: hidden;
+    white-space: nowrap;
 	width: 100%;
 
 	@include breakpoint( "<960px" ) {
@@ -71,7 +73,7 @@
 	}
 
 	&::after {
-		@include long-content-fade( $size: 10% );
+		@include long-content-fade( $size: 5% );
 		height: 16px * 1.4;
 	}
 }

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -40,7 +40,7 @@
 .reader-combined-card__post-details {
 	font-family: $serif;
 	overflow: hidden;
-    white-space: nowrap;
+	white-space: nowrap;
 	width: 100%;
 
 	@include breakpoint( "<960px" ) {


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/13053

**Before:**
![screenshot 2017-04-14 09 35 05](https://cloud.githubusercontent.com/assets/4924246/25049414/90cd8eb8-20f6-11e7-9363-110dd174fec2.png)

**After:**
![screenshot 2017-04-14 09 35 51](https://cloud.githubusercontent.com/assets/4924246/25049416/932acc84-20f6-11e7-8766-dc67cbc0cc04.png)
