### PR TITLE
Posts: Drop sites-list usage

### DIFF
--- a/client/blocks/post-actions/index.jsx
+++ b/client/blocks/post-actions/index.jsx
@@ -16,7 +16,6 @@ import PostRelativeTimeStatus from 'my-sites/post-relative-time-status';
 import CommentButton from 'blocks/comment-button';
 import LikeButton from 'my-sites/post-like-button';
 import PostTotalViews from 'my-sites/posts/post-total-views';
-import utils from 'lib/posts/utils';
 import { canCurrentUser } from 'state/selectors';
 import { isJetpackModuleActive, isJetpackSite } from 'state/sites/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
@@ -25,7 +24,7 @@ const getContentLink = ( state, siteId, post ) => {
 	let contentLinkURL = post.URL;
 	let contentLinkTarget = '_blank';
 
-	if ( utils.userCan( 'edit_post', post ) ) {
+	if ( canCurrentUser( state, siteId, 'edit_post' ) && post.status !== 'trash' ) {
 		contentLinkURL = getEditorPath( state, siteId, post.ID );
 		contentLinkTarget = null;
 	} else if ( post.status === 'trash' ) {

--- a/client/blocks/post-actions/index.jsx
+++ b/client/blocks/post-actions/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { get, partial } from 'lodash';
+import { partial } from 'lodash';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 
@@ -19,13 +19,14 @@ import PostTotalViews from 'my-sites/posts/post-total-views';
 import utils from 'lib/posts/utils';
 import { canCurrentUser } from 'state/selectors';
 import { isJetpackModuleActive, isJetpackSite } from 'state/sites/selectors';
+import { getEditorPath } from 'state/ui/editor/selectors';
 
-const getContentLink = ( site, post ) => {
+const getContentLink = ( state, siteId, post ) => {
 	let contentLinkURL = post.URL;
 	let contentLinkTarget = '_blank';
 
 	if ( utils.userCan( 'edit_post', post ) ) {
-		contentLinkURL = utils.getEditURL( post, site );
+		contentLinkURL = getEditorPath( state, siteId, post.ID );
 		contentLinkTarget = null;
 	} else if ( post.status === 'trash' ) {
 		contentLinkURL = null;
@@ -38,16 +39,16 @@ const recordEvent = partial( recordGoogleEvent, 'Posts' );
 
 const PostActions = ( {
 	className,
+	contentLink,
 	post,
 	showComments,
 	showLikes,
 	showStats,
-	site,
 	toggleComments,
 	trackRelativeTimeStatusOnClick,
 	trackTotalViewsOnClick
 } ) => {
-	const { contentLinkURL, contentLinkTarget } = getContentLink( site, post );
+	const { contentLinkURL, contentLinkTarget } = contentLink;
 	const isDraft = post.status === 'draft';
 
 	return (
@@ -93,14 +94,13 @@ const PostActions = ( {
 PostActions.propTypes = {
 	className: React.PropTypes.string,
 	post: React.PropTypes.object.isRequired,
-	site: React.PropTypes.object.isRequired,
+	siteId: React.PropTypes.number.isRequired,
 	toggleComments: React.PropTypes.func.isRequired,
 	trackRelativeTimeStatusOnClick: React.PropTypes.func,
 	trackTotalViewsOnClick: React.PropTypes.func,
 };
 
-const mapStateToProps = ( state, { site, post } ) => {
-	const siteId = get( site, 'ID' );
+const mapStateToProps = ( state, { siteId, post } ) => {
 	const isJetpack = isJetpackSite( state, siteId );
 
 	// TODO: Maybe add dedicated selectors for the following.
@@ -111,6 +111,7 @@ const mapStateToProps = ( state, { site, post } ) => {
 		( ! isJetpack || isJetpackModuleActive( state, siteId, 'stats' ) );
 
 	return {
+		contentLink: getContentLink( state, siteId, post ),
 		showComments,
 		showLikes,
 		showStats

--- a/client/blocks/post-actions/index.jsx
+++ b/client/blocks/post-actions/index.jsx
@@ -76,8 +76,7 @@ const PostActions = ( {
 						key="like-button"
 						siteId={ +post.site_ID }
 						postId={ +post.ID }
-						post={ post }
-						site={ site } />
+						post={ post } />
 				</li>
 			}
 			{ ! isDraft && showStats &&

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -33,7 +33,6 @@ import { isEnabled } from 'config';
 class PostShare extends Component {
 	static propTypes = {
 		siteSlug: PropTypes.string,
-		site: PropTypes.object,
 		post: PropTypes.object,
 		siteId: PropTypes.number,
 		isPublicizeEnabled: PropTypes.bool,
@@ -77,7 +76,7 @@ class PostShare extends Component {
 	}
 
 	renderServices() {
-		if ( ! this.props.site || ! this.hasConnections() ) {
+		if ( ! this.props.siteId || ! this.hasConnections() ) {
 			return;
 		}
 
@@ -263,7 +262,7 @@ class PostShare extends Component {
 					}
 				</div>
 
-				{ this.props.site && <QueryPublicizeConnections siteId={ this.props.site.ID } /> }
+				{ this.props.siteId && <QueryPublicizeConnections siteId={ this.props.siteId } /> }
 				<SharingPreviewModal
 					siteId={ this.props.siteId }
 					postId={ this.props.postId }
@@ -277,9 +276,8 @@ class PostShare extends Component {
 }
 
 export default connect(
-	( state, props ) => {
-		const siteId = props.site.ID;
-		const postId = props.post.ID;
+	( state, { post, siteId } ) => {
+		const postId = post.ID;
 		const userId = getCurrentUserId( state );
 
 		return {
@@ -287,12 +285,12 @@ export default connect(
 			siteSlug: getSiteSlug( state, siteId ),
 			siteId,
 			postId,
-			isPublicizeEnabled: isPublicizeEnabled( state, siteId, props.post.type ),
+			isPublicizeEnabled: isPublicizeEnabled( state, siteId, post.type ),
 			connections: getSiteUserConnections( state, siteId, userId ),
 			hasFetchedConnections: hasFetchedConnections( state, siteId ),
-			requesting: isRequestingSharePost( state, siteId, props.post.ID ),
-			failed: sharePostFailure( state, siteId, props.post.ID ),
-			success: sharePostSuccessMessage( state, siteId, props.post.ID )
+			requesting: isRequestingSharePost( state, siteId, post.ID ),
+			failed: sharePostFailure( state, siteId, post.ID ),
+			success: sharePostSuccessMessage( state, siteId, post.ID )
 		};
 	},
 	{ requestConnections, sharePost, dismissShareConfirmation }

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -112,11 +112,11 @@ class PostShare extends Component {
 	}
 
 	dismiss = () => {
-		this.props.dismissShareConfirmation( this.props.siteId, this.props.post.ID );
+		this.props.dismissShareConfirmation( this.props.siteId, this.props.postId );
 	};
 
 	sharePost = () => {
-		this.props.sharePost( this.props.siteId, this.props.post.ID, this.state.skipped, this.state.message );
+		this.props.sharePost( this.props.siteId, this.props.postId, this.state.skipped, this.state.message );
 	};
 
 	isButtonDisabled() {
@@ -288,9 +288,9 @@ export default connect(
 			isPublicizeEnabled: isPublicizeEnabled( state, siteId, post.type ),
 			connections: getSiteUserConnections( state, siteId, userId ),
 			hasFetchedConnections: hasFetchedConnections( state, siteId ),
-			requesting: isRequestingSharePost( state, siteId, post.ID ),
-			failed: sharePostFailure( state, siteId, post.ID ),
-			success: sharePostSuccessMessage( state, siteId, post.ID )
+			requesting: isRequestingSharePost( state, siteId, postId ),
+			failed: sharePostFailure( state, siteId, postId ),
+			success: sharePostSuccessMessage( state, siteId, postId )
 		};
 	},
 	{ requestConnections, sharePost, dismissShareConfirmation }

--- a/client/my-sites/posts/controller.js
+++ b/client/my-sites/posts/controller.js
@@ -9,8 +9,7 @@ var page = require( 'page' ),
 /**
  * Internal Dependencies
  */
-var user = require( 'lib/user' )(),
-	route = require( 'lib/route' ),
+const route = require( 'lib/route' ),
 	analytics = require( 'lib/analytics' ),
 	titlecase = require( 'to-title-case' ),
 	trackScrollPage = require( 'lib/track-scroll-page' ),
@@ -20,13 +19,17 @@ import { renderWithReduxStore } from 'lib/react-helpers';
 import { areAllSitesSingleUser } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
+import { getCurrentUserId } from 'state/current-user/selectors';
 
 module.exports = {
 
 	posts: function( context ) {
+		const state = context.store.getState();
+		const siteId = getSelectedSiteId( state );
+
 		var Posts = require( 'my-sites/posts/main' ),
 			siteID = route.getSiteFragment( context.path ),
-			author = ( context.params.author === 'my' ) ? user.get().ID : null,
+			author = ( context.params.author === 'my' ) ? getCurrentUserId( state ) : null,
 			statusSlug = ( author ) ? context.params.status : context.params.author,
 			search = context.query.s,
 			basePath = route.sectionify( context.path ),
@@ -34,9 +37,6 @@ module.exports = {
 			baseAnalyticsPath;
 
 		function shouldRedirectMyPosts() {
-			const state = context.store.getState();
-			const siteId = getSelectedSiteId( state );
-
 			if ( ! author ) {
 				return false;
 			}

--- a/client/my-sites/posts/controller.js
+++ b/client/my-sites/posts/controller.js
@@ -33,7 +33,7 @@ module.exports = {
 			analyticsPageTitle = 'Blog Posts',
 			baseAnalyticsPath;
 
-		function shouldRedirectMyPosts( author ) {
+		function shouldRedirectMyPosts() {
 			const state = context.store.getState();
 			const siteId = getSelectedSiteId( state );
 
@@ -59,7 +59,7 @@ module.exports = {
 		search = ( 'undefined' !== typeof search ) ? search : '';
 		debug( 'search: `%s`', search );
 
-		if ( shouldRedirectMyPosts( author ) ) {
+		if ( shouldRedirectMyPosts() ) {
 			page.redirect( context.path.replace( /\/my\b/, '' ) );
 			return;
 		}

--- a/client/my-sites/posts/controller.js
+++ b/client/my-sites/posts/controller.js
@@ -10,7 +10,6 @@ var page = require( 'page' ),
  * Internal Dependencies
  */
 var user = require( 'lib/user' )(),
-	sites = require( 'lib/sites-list' )(),
 	route = require( 'lib/route' ),
 	analytics = require( 'lib/analytics' ),
 	titlecase = require( 'to-title-case' ),
@@ -18,6 +17,9 @@ var user = require( 'lib/user' )(),
 	setTitle = require( 'state/document-head/actions' ).setDocumentHeadTitle;
 
 import { renderWithReduxStore } from 'lib/react-helpers';
+import { areAllSitesSingleUser } from 'state/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
 
 module.exports = {
 
@@ -31,15 +33,17 @@ module.exports = {
 			analyticsPageTitle = 'Blog Posts',
 			baseAnalyticsPath;
 
-		function shouldRedirectMyPosts( author, sites ) {
-			var selectedSite = sites.getSelectedSite() || {};
+		function shouldRedirectMyPosts( author ) {
+			const state = context.store.getState();
+			const siteId = getSelectedSiteId( state );
+
 			if ( ! author ) {
 				return false;
 			}
-			if ( sites.fetched && sites.allSingleSites ) {
+			if ( areAllSitesSingleUser( state ) ) {
 				return true;
 			}
-			if ( selectedSite.single_user_site || selectedSite.jetpack ) {
+			if ( isSingleUserSite( state, siteId ) || isJetpackSite( state, siteId ) ) {
 				return true;
 			}
 		}
@@ -55,12 +59,13 @@ module.exports = {
 		search = ( 'undefined' !== typeof search ) ? search : '';
 		debug( 'search: `%s`', search );
 
-		if ( shouldRedirectMyPosts( author, sites ) ) {
+		if ( shouldRedirectMyPosts( author ) ) {
 			page.redirect( context.path.replace( /\/my\b/, '' ) );
 			return;
 		}
 
-		context.store.dispatch( setTitle( i18n.translate( 'Blog Posts', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+		context.store.dispatch( setTitle( i18n.translate( 'Blog Posts', { textOnly: true } ) ) );
 
 		if ( siteID ) {
 			baseAnalyticsPath = basePath + '/:site';

--- a/client/my-sites/posts/controller.js
+++ b/client/my-sites/posts/controller.js
@@ -82,7 +82,6 @@ module.exports = {
 				siteID: siteID,
 				author: author,
 				statusSlug: statusSlug,
-				sites: sites,
 				search: search,
 				trackScrollPage: trackScrollPage.bind(
 					null,

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -11,7 +11,6 @@ import { map } from 'lodash';
  * Internal dependencies
  */
 import PostsNavigation from './posts-navigation';
-import observe from 'lib/mixins/data-observe';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import PostList from './post-list';
 import config from 'config';
@@ -34,33 +33,35 @@ import {
 } from 'state/posts/counts/selectors';
 import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 import { warningNotice } from 'state/notices/actions';
+import {
+	getSiteAdminUrl,
+	getSiteSlug,
+	isJetpackSite,
+	siteHasMinimumJetpackVersion
+} from 'state/sites/selectors';
 
 const PostsMain = React.createClass( {
-	mixins: [ observe( 'sites' ) ],
-
 	componentWillMount() {
-		const selectedSite = this.props.sites.getSelectedSite();
-		this.setWarning( selectedSite );
+		this.setWarning( this.props );
 	},
 
 	componentWillReceiveProps( nextProps ) {
-		const selectedSite = nextProps.sites.getSelectedSite();
-		this.setWarning( selectedSite );
+		this.setWarning( nextProps );
 	},
 
 	showDrafts() {
-		const site = this.props.sites.getSelectedSite();
+		const { isJetpack } = this.props;
 
 		// Jetpack sites can have malformed counts
-		if ( site.jetpack && ! this.props.loadingDrafts && this.props.drafts && this.props.drafts.length === 0 ) {
+		if ( isJetpack && ! this.props.loadingDrafts && this.props.drafts && this.props.drafts.length === 0 ) {
 			return false;
 		}
 
-		if ( ! site.jetpack && this.props.draftCount === 0 ) {
+		if ( ! isJetpack && this.props.draftCount === 0 ) {
 			return false;
 		}
 
-		if ( ! site.jetpack && this.props.author && this.props.myDraftCount === 0 ) {
+		if ( ! isJetpack && this.props.author && this.props.myDraftCount === 0 ) {
 			return false;
 		}
 
@@ -68,9 +69,9 @@ const PostsMain = React.createClass( {
 	},
 
 	mostRecentDrafts() {
-		const site = this.props.sites.getSelectedSite();
+		const { siteId, siteSlug } = this.props;
 
-		if ( ! site || ! this.showDrafts() ) {
+		if ( ! siteId || ! this.showDrafts() ) {
 			return null;
 		}
 
@@ -80,9 +81,9 @@ const PostsMain = React.createClass( {
 		return (
 			<div className="posts__recent-drafts">
 				<QueryPosts
-					siteId={ site.ID }
+					siteId={ siteId }
 					query={ this.props.draftsQuery } />
-				<QueryPostCounts siteId={ site.ID } type="post" />
+				<QueryPostCounts siteId={ siteId } type="post" />
 				<SectionHeader className="posts__drafts-header" label={ translate( 'Latest Drafts' ) }>
 					<Button compact href={ this.props.newPostPath }>
 						{ translate( 'New Post' ) }
@@ -93,7 +94,7 @@ const PostsMain = React.createClass( {
 				) ) }
 				{ isLoading && <PostItem compact /> }
 				{ draftCount > 6 &&
-					<Button compact borderless className="posts__see-all-drafts" href={ `/posts/drafts/${ site.slug }` }>
+					<Button compact borderless className="posts__see-all-drafts" href={ `/posts/drafts/${ siteSlug }` }>
 						{ translate( 'See all drafts' ) }
 						{ draftCount ? <Count count={ draftCount } /> : null }
 					</Button>
@@ -105,8 +106,8 @@ const PostsMain = React.createClass( {
 	render() {
 		const path = sectionify( this.props.context.path );
 		const classes = classnames( 'posts', {
-			'is-multisite': ! this.props.sites.selected,
-			'is-single-site': this.props.sites.selected
+			'is-multisite': ! this.props.siteId,
+			'is-single-site': this.props.siteId
 		} );
 
 		return (
@@ -121,15 +122,15 @@ const PostsMain = React.createClass( {
 		);
 	},
 
-	setWarning( selectedSite ) {
-		if ( selectedSite && selectedSite.jetpack && ! selectedSite.hasMinimumJetpackVersion ) {
+	setWarning( { adminUrl, hasMinimumJetpackVersion, isJetpack, siteId } ) {
+		if ( siteId && isJetpack && ! hasMinimumJetpackVersion ) {
 			this.props.warningNotice(
 				this.props.translate( 'Jetpack %(version)s is required to take full advantage of all post editing features.', {
 					args: { version: config( 'jetpack_min_version' ) }
 				} ),
 				{
 					button: this.props.translate( 'Update now' ),
-					href: selectedSite.options.admin_url + 'plugins.php?plugin_status=upgrade',
+					href: adminUrl,
 				}
 			);
 		}
@@ -149,12 +150,17 @@ export default connect(
 		};
 
 		return {
+			adminUrl: getSiteAdminUrl( state, siteId, 'plugins.php?plugin_status=upgrade' ),
 			drafts: getSitePostsForQueryIgnoringPage( state, siteId, draftsQuery ),
 			draftCount: getAllPostCount( state, siteId, 'post', 'draft' ),
 			draftsQuery,
+			hasMinimumJetpackVersion: siteHasMinimumJetpackVersion( state, siteId ),
+			isJetpack: isJetpackSite( state, siteId ),
 			loadingDrafts: isRequestingSitePostsForQuery( state, siteId, draftsQuery ),
 			myDraftCount: getMyPostCount( state, siteId, 'post', 'draft' ),
-			newPostPath: getEditorNewPostPath( state, siteId )
+			newPostPath: getEditorNewPostPath( state, siteId ),
+			siteId,
+			siteSlug: getSiteSlug( state, siteId )
 		};
 	},
 	{

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -138,31 +138,33 @@ const PostsMain = React.createClass( {
 
 } );
 
-export default connect(
-	( state, { author } ) => {
-		const siteId = getSelectedSiteId( state );
-		const draftsQuery = {
-			author,
-			number: 6,
-			order_by: 'modified',
-			status: 'draft',
-			type: 'post',
-		};
+function mapStateToProps( state, { author } ) {
+	const siteId = getSelectedSiteId( state );
+	const draftsQuery = {
+		author,
+		number: 6,
+		order_by: 'modified',
+		status: 'draft',
+		type: 'post',
+	};
 
-		return {
-			adminUrl: getSiteAdminUrl( state, siteId, 'plugins.php?plugin_status=upgrade' ),
-			drafts: getSitePostsForQueryIgnoringPage( state, siteId, draftsQuery ),
-			draftCount: getAllPostCount( state, siteId, 'post', 'draft' ),
-			draftsQuery,
-			hasMinimumJetpackVersion: siteHasMinimumJetpackVersion( state, siteId ),
-			isJetpack: isJetpackSite( state, siteId ),
-			loadingDrafts: isRequestingSitePostsForQuery( state, siteId, draftsQuery ),
-			myDraftCount: getMyPostCount( state, siteId, 'post', 'draft' ),
-			newPostPath: getEditorNewPostPath( state, siteId ),
-			siteId,
-			siteSlug: getSiteSlug( state, siteId )
-		};
-	},
+	return {
+		adminUrl: getSiteAdminUrl( state, siteId, 'plugins.php?plugin_status=upgrade' ),
+		drafts: getSitePostsForQueryIgnoringPage( state, siteId, draftsQuery ),
+		draftCount: getAllPostCount( state, siteId, 'post', 'draft' ),
+		draftsQuery,
+		hasMinimumJetpackVersion: siteHasMinimumJetpackVersion( state, siteId ),
+		isJetpack: isJetpackSite( state, siteId ),
+		loadingDrafts: isRequestingSitePostsForQuery( state, siteId, draftsQuery ),
+		myDraftCount: getMyPostCount( state, siteId, 'post', 'draft' ),
+		newPostPath: getEditorNewPostPath( state, siteId ),
+		siteId,
+		siteSlug: getSiteSlug( state, siteId )
+	};
+}
+
+export default connect(
+	mapStateToProps,
 	{
 		warningNotice,
 	},

--- a/client/my-sites/posts/post-controls.jsx
+++ b/client/my-sites/posts/post-controls.jsx
@@ -15,7 +15,7 @@ import { isEnabled } from 'config';
 import { ga } from 'lib/analytics';
 import { userCan } from 'lib/posts/utils';
 import { isPublicizeEnabled } from 'state/selectors';
-import { isSitePreviewable } from 'state/sites/selectors';
+import { getSiteSlug, isSitePreviewable } from 'state/sites/selectors';
 
 const edit = () => ga.recordEvent( 'Posts', 'Clicked Edit Post' );
 const copy = () => ga.recordEvent( 'Posts', 'Clicked Copy Post' );
@@ -33,7 +33,7 @@ const getAvailableControls = props => {
 		onToggleShare,
 		onTrash,
 		post,
-		site,
+		siteSlug,
 		translate,
 		onViewPost,
 	} = props;
@@ -64,7 +64,7 @@ const getAvailableControls = props => {
 
 		controls.main.push( {
 			className: 'stats',
-			href: `/stats/post/${ post.ID }/${ site.slug }`,
+			href: `/stats/post/${ post.ID }/${ siteSlug }`,
 			icon: 'stats-alt',
 			onClick: viewStats,
 			text: translate( 'Stats' ),
@@ -128,7 +128,7 @@ const getAvailableControls = props => {
 	) {
 		controls.main.push( {
 			className: 'copy',
-			href: `/post/${ site.slug }?copy=${ post.ID }`,
+			href: `/post/${ siteSlug }?copy=${ post.ID }`,
 			icon: 'clipboard',
 			onClick: copy,
 			text: translate( 'Copy' ),
@@ -215,11 +215,12 @@ PostControls.propTypes = {
 	onTrash: PropTypes.func,
 	onViewPost: PropTypes.func,
 	post: PropTypes.object.isRequired,
-	site: PropTypes.object,
+	siteId: PropTypes.number,
 	translate: PropTypes.func,
 };
 
-export default connect( ( state, { site, post } ) => ( {
-	isPreviewable: false !== isSitePreviewable( state, site.ID ),
-	isPublicizeEnabled: isPublicizeEnabled( state, site.ID, post.type ),
+export default connect( ( state, { siteId, post } ) => ( {
+	isPreviewable: false !== isSitePreviewable( state, siteId ),
+	isPublicizeEnabled: isPublicizeEnabled( state, siteId, post.type ),
+	siteSlug: getSiteSlug( state, siteId ),
 } ) )( localize( PostControls ) );

--- a/client/my-sites/posts/post-header.jsx
+++ b/client/my-sites/posts/post-header.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 
@@ -9,6 +10,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import SiteIcon from 'blocks/site-icon';
+import { getSiteSlug, getSiteTitle } from 'state/sites/selectors';
 
 class PostHeader extends PureComponent {
 	static defaultProps = {
@@ -32,8 +34,8 @@ class PostHeader extends PureComponent {
 			<div className={ classes }>
 				<SiteIcon site={ this.props.site } size={ 32 } />
 				<h4 className="post__site-title">
-					<a href={ this.props.path + '/' + this.props.site.slug }>
-						{ this.props.site.title }
+					<a href={ this.props.path + '/' + this.props.siteSlug }>
+						{ this.props.siteTitle }
 					</a>
 				</h4>
 				{ this.props.showAuthor ? <span className="post__author">{ this.getAuthor() }</span> : null }
@@ -42,4 +44,9 @@ class PostHeader extends PureComponent {
 	}
 }
 
-export default localize( PostHeader );
+export default connect(
+	( state, { siteId } ) => ( {
+		siteSlug: getSiteSlug( state, siteId ),
+		siteTitle: getSiteTitle( state, siteId ),
+	} )
+)( localize( PostHeader ) );

--- a/client/my-sites/posts/post-header.jsx
+++ b/client/my-sites/posts/post-header.jsx
@@ -1,36 +1,30 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+import React, { PureComponent } from 'react';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var SiteIcon = require( 'blocks/site-icon' );
+import SiteIcon from 'blocks/site-icon';
 
-module.exports = React.createClass( {
+class PostHeader extends PureComponent {
+	static defaultProps = {
+		showAuthor: false
+	}
 
-	displayName: 'PostHeader',
-
-	getDefaultProps: function() {
-		return {
-			showAuthor: false
-		};
-	},
-
-	getAuthor: function() {
-		return this.translate(
+	getAuthor() {
+		return this.props.translate(
 			'By %(author)s',
 			{ args: { author: this.props.author } }
 		);
-	},
+	}
 
-	render: function() {
-		var classes;
-
-		classes = classNames( {
-			'post__header': true,
+	render() {
+		const classes = classNames( {
+			post__header: true,
 			'has-author': this.props.showAuthor
 		} );
 
@@ -45,7 +39,7 @@ module.exports = React.createClass( {
 				{ this.props.showAuthor ? <span className="post__author">{ this.getAuthor() }</span> : null }
 			</div>
 		);
-
 	}
+}
 
-} );
+export default localize( PostHeader );

--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -261,7 +261,7 @@ var Posts = React.createClass( {
 			i;
 
 		// posts have loaded, sites have loaded, and we have a site instance or are viewing all-sites
-		if ( posts.length && this.props.haveSites ) {
+		if ( posts.length ) {
 			postList = (
 				<InfiniteList
 					key={ 'list-' + this.props.listId } // to reset scroll for new list

--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -36,7 +36,7 @@ var PostList = React.createClass( {
 	propTypes: {
 		context: React.PropTypes.object,
 		search: React.PropTypes.string,
-		haveSites: React.PropTypes.bool,
+		hasSites: React.PropTypes.bool,
 		statusSlug: React.PropTypes.string,
 		siteID: React.PropTypes.any,
 		author: React.PropTypes.number
@@ -72,7 +72,7 @@ var Posts = React.createClass( {
 		posts: React.PropTypes.array.isRequired,
 		search: React.PropTypes.string,
 		siteID: React.PropTypes.any,
-		haveSites: React.PropTypes.bool.isRequired,
+		hasSites: React.PropTypes.bool.isRequired,
 		statusSlug: React.PropTypes.string,
 		trackScrollPage: React.PropTypes.func.isRequired
 	},
@@ -277,7 +277,7 @@ var Posts = React.createClass( {
 				/>
 			);
 		} else {
-			if ( this.props.loading || ! this.props.haveSites ) {
+			if ( this.props.loading || ! this.props.hasSites ) {
 				for ( i = 0; i < placeholderCount; i++ ) {
 					placeholders.push( <PostPlaceholder key={ 'placeholder-' + i } /> );
 				}
@@ -304,6 +304,6 @@ var Posts = React.createClass( {
 export default connect(
 	( state ) => ( {
 		selectedSiteId: getSelectedSiteId( state ),
-		haveSites: !! getSites( state ).length
+		hasSites: !! getSites( state ).length
 	} )
 )( PostList );

--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -3,12 +3,10 @@
  */
 var React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' ),
-	debug = require( 'debug' )( 'calypso:my-sites:posts' ),
-	debounce = require( 'lodash/debounce' ),
-	omit = require( 'lodash/omit' ),
-	isEqual = require( 'lodash/isEqual' );
+	debug = require( 'debug' )( 'calypso:my-sites:posts' );
 
 import { connect } from 'react-redux';
+import { debounce, isEmpty, isEqual, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,7 +22,6 @@ var PostListFetcher = require( 'components/post-list-fetcher' ),
 	mapStatus = route.mapPostStatus;
 
 import UpgradeNudge from 'my-sites/upgrade-nudge';
-import { getSites } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
 var GUESSED_POST_HEIGHT = 250;
@@ -304,6 +301,6 @@ var Posts = React.createClass( {
 export default connect(
 	( state ) => ( {
 		selectedSiteId: getSelectedSiteId( state ),
-		hasSites: !! getSites( state ).length
+		hasSites: ! isEmpty( state.sites.items )
 	} )
 )( PostList );

--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -230,7 +230,6 @@ var Posts = React.createClass( {
 				key={ post.global_ID }
 				post={ post }
 				postImages={ postImages }
-				sites={ this.props.sites }
 				fullWidthPost={ this.state.postsAtFullWidth }
 				path={ route.sectionify( this.props.context.pathname ) }
 			/>

--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -23,7 +23,7 @@ import config from 'config';
 import { setPreviewUrl } from 'state/ui/preview/actions';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getPreviewURL } from 'lib/posts/utils';
-import { getSite, isSingleUserSite, isSitePreviewable } from 'state/sites/selectors';
+import { isSingleUserSite, isSitePreviewable } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
 
@@ -299,8 +299,6 @@ const Post = React.createClass( {
 	},
 
 	render() {
-		const { postSite: site } = this.props;
-
 		return (
 			<Card tagName="article" className={ this.getPostClass() }>
 				<div className="post__body">
@@ -341,7 +339,9 @@ const Post = React.createClass( {
 						onFilterChange={ commentsFilter => this.setState( { commentsFilter } ) }
 						onCommentsUpdate={ () => {} } />
 				}
-				{ this.state.showShare && config.isEnabled( 'republicize' ) && <PostShare post={ this.props.post } site={ site } /> }
+				{ this.state.showShare && config.isEnabled( 'republicize' ) &&
+					<PostShare post={ this.props.post } siteId={ this.props.post.site_ID } />
+				}
 			</Card>
 		);
 	}
@@ -355,7 +355,6 @@ export default connect(
 			editUrl: getEditorPath( state, post.site_ID, post.ID, 'post' ),
 			isPostFromSingleUserSite: isSingleUserSite( state, post.site_ID ),
 			isPreviewable: false !== isSitePreviewable( state, post.site_ID ),
-			postSite: getSite( state, post.site_ID ),
 			previewURL: getPreviewURL( post ),
 			selectedSiteId
 		};

--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -23,7 +23,7 @@ import config from 'config';
 import { setPreviewUrl } from 'state/ui/preview/actions';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getPreviewURL } from 'lib/posts/utils';
-import { getSite, isSitePreviewable } from 'state/sites/selectors';
+import { getSite, isSingleUserSite, isSitePreviewable } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
 import Comments from 'blocks/comments';
@@ -220,7 +220,7 @@ const Post = React.createClass( {
 	getHeader() {
 		const { postSite: site } = this.props;
 
-		if ( this.props.selectedSiteId && site.single_user_site ) {
+		if ( this.props.selectedSiteId && this.props.isPostFromSingleUserSite ) {
 			return null;
 		}
 
@@ -228,7 +228,7 @@ const Post = React.createClass( {
 			<PostHeader site={ site }
 				author={ this.props.post.author ? this.props.post.author.name : '' }
 				path={ this.props.path }
-				showAuthor={ ! site.single_user_site } />
+				showAuthor={ ! this.props.isPostFromSingleUserSite } />
 		);
 	},
 
@@ -351,6 +351,7 @@ const Post = React.createClass( {
 export default connect(
 	( state, { post } ) => {
 		return {
+			isPostFromSingleUserSite: isSingleUserSite( state, post.site_ID ),
 			isPreviewable: false !== isSitePreviewable( state, post.site_ID ),
 			postSite: getSite( state, post.site_ID ),
 			previewURL: getPreviewURL( post ),

--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -307,7 +307,9 @@ const Post = React.createClass( {
 					{ this.getHeader() }
 					{ this.getPostImage() }
 					{ this.getContent() }
-					<PostActions { ...{ site, post: this.props.post, toggleComments: this.toggleComments } } />
+					<PostActions siteId={ this.props.post.site_ID }
+						post={ this.props.post }
+						toggleComments={ this.toggleComments } />
 				</div>
 				<PostControls
 					post={ this.props.post }

--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -282,7 +282,7 @@ const Post = React.createClass( {
 
 	viewPost( event ) {
 		event.preventDefault();
-		const { isPreviewable, previewURL } = this.props;
+		const { isPreviewable, previewUrl } = this.props;
 
 		if ( this.props.post.status && this.props.post.status === 'future' ) {
 			this.analyticsEvents.previewPost;
@@ -291,10 +291,10 @@ const Post = React.createClass( {
 		}
 
 		if ( ! isPreviewable ) {
-			return window.open( previewURL );
+			return window.open( previewUrl );
 		}
 
-		this.props.setPreviewUrl( previewURL );
+		this.props.setPreviewUrl( previewUrl );
 		this.props.setLayoutFocus( 'preview' );
 	},
 
@@ -355,7 +355,7 @@ export default connect(
 			editUrl: getEditorPath( state, post.site_ID, post.ID, 'post' ),
 			isPostFromSingleUserSite: isSingleUserSite( state, post.site_ID ),
 			isPreviewable: false !== isSitePreviewable( state, post.site_ID ),
-			previewURL: getPostPreviewUrl( state, post.site_ID, post.ID ),
+			previewUrl: getPostPreviewUrl( state, post.site_ID, post.ID ),
 			selectedSiteId
 		};
 	},

--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -22,7 +22,7 @@ import analytics from 'lib/analytics';
 import config from 'config';
 import { setPreviewUrl } from 'state/ui/preview/actions';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
-import { getPreviewURL } from 'lib/posts/utils';
+import { getPostPreviewUrl } from 'state/posts/selectors';
 import { isSingleUserSite, isSitePreviewable } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
@@ -355,7 +355,7 @@ export default connect(
 			editUrl: getEditorPath( state, post.site_ID, post.ID, 'post' ),
 			isPostFromSingleUserSite: isSingleUserSite( state, post.site_ID ),
 			isPreviewable: false !== isSitePreviewable( state, post.site_ID ),
-			previewURL: getPreviewURL( post ),
+			previewURL: getPostPreviewUrl( state, post.site_ID, post.ID ),
 			selectedSiteId
 		};
 	},

--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -321,7 +321,7 @@ const Post = React.createClass( {
 					onRestore={ this.restorePost }
 					onToggleShare={ this.toggleShare }
 					onViewPost={ this.viewPost }
-					site={ site }
+					siteId={ this.props.post.site_ID }
 				/>
 				<ReactCSSTransitionGroup
 					transitionName="updated-trans"

--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -25,6 +25,7 @@ import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getPreviewURL } from 'lib/posts/utils';
 import { getSite, isSingleUserSite, isSitePreviewable } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPath } from 'state/ui/editor/selectors';
 
 import Comments from 'blocks/comments';
 import PostShare from 'my-sites/post-share';
@@ -245,10 +246,9 @@ const Post = React.createClass( {
 
 	getContentLinkURL() {
 		const post = this.props.post;
-		const { postSite: site } = this.props;
 
 		if ( utils.userCan( 'edit_post', post ) ) {
-			return utils.getEditURL( post, site );
+			return this.props.editUrl;
 		} else if ( post.status === 'trash' ) {
 			return null;
 		}
@@ -313,7 +313,7 @@ const Post = React.createClass( {
 				</div>
 				<PostControls
 					post={ this.props.post }
-					editURL={ utils.getEditURL( this.props.post, site ) }
+					editURL={ this.props.editUrl }
 					fullWidth={ this.props.fullWidthPost }
 					onShowMore={ this.toggleMoreControls.bind( this, 'show' ) }
 					onHideMore={ this.toggleMoreControls.bind( this, 'hide' ) }
@@ -350,12 +350,14 @@ const Post = React.createClass( {
 
 export default connect(
 	( state, { post } ) => {
+		const selectedSiteId = getSelectedSiteId( state );
 		return {
+			editUrl: getEditorPath( state, post.site_ID, post.ID, 'post' ),
 			isPostFromSingleUserSite: isSingleUserSite( state, post.site_ID ),
 			isPreviewable: false !== isSitePreviewable( state, post.site_ID ),
 			postSite: getSite( state, post.site_ID ),
 			previewURL: getPreviewURL( post ),
-			selectedSiteId: getSelectedSiteId( state )
+			selectedSiteId
 		};
 	},
 	{ setPreviewUrl, setLayoutFocus }

--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -218,14 +218,12 @@ const Post = React.createClass( {
 	},
 
 	getHeader() {
-		const { postSite: site } = this.props;
-
 		if ( this.props.selectedSiteId && this.props.isPostFromSingleUserSite ) {
 			return null;
 		}
 
 		return (
-			<PostHeader site={ site }
+			<PostHeader siteId={ this.props.post.site_ID }
 				author={ this.props.post.author ? this.props.post.author.name : '' }
 				path={ this.props.path }
 				showAuthor={ ! this.props.isPostFromSingleUserSite } />

--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -23,7 +23,8 @@ import config from 'config';
 import { setPreviewUrl } from 'state/ui/preview/actions';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getPreviewURL } from 'lib/posts/utils';
-import { isSitePreviewable } from 'state/sites/selectors';
+import { getSite, isSitePreviewable } from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 import Comments from 'blocks/comments';
 import PostShare from 'my-sites/post-share';
@@ -217,14 +218,18 @@ const Post = React.createClass( {
 	},
 
 	getHeader() {
-		const selectedSite = this.props.sites.getSelectedSite();
-		const site = this.getSite();
+		const { postSite: site } = this.props;
 
-		if ( selectedSite && site.single_user_site ) {
+		if ( this.props.selectedSiteId && site.single_user_site ) {
 			return null;
 		}
 
-		return <PostHeader site={ site } author={ this.props.post.author ? this.props.post.author.name : '' } path={ this.props.path } showAuthor={ ! site.single_user_site } />;
+		return (
+			<PostHeader site={ site }
+				author={ this.props.post.author ? this.props.post.author.name : '' }
+				path={ this.props.path }
+				showAuthor={ ! site.single_user_site } />
+		);
 	},
 
 	getContent() {
@@ -242,7 +247,7 @@ const Post = React.createClass( {
 
 	getContentLinkURL() {
 		const post = this.props.post;
-		const site = this.getSite();
+		const { postSite: site } = this.props;
 
 		if ( utils.userCan( 'edit_post', post ) ) {
 			return utils.getEditURL( post, site );
@@ -264,10 +269,6 @@ const Post = React.createClass( {
 		this.setState( {
 			showMoreOptions: ( visibility === 'show' )
 		} );
-	},
-
-	getSite() {
-		return this.props.sites.getSite( this.props.post.site_ID );
 	},
 
 	toggleComments() {
@@ -300,7 +301,7 @@ const Post = React.createClass( {
 	},
 
 	render() {
-		const site = this.getSite();
+		const { postSite: site } = this.props;
 
 		return (
 			<Card tagName="article" className={ this.getPostClass() }>
@@ -348,10 +349,12 @@ const Post = React.createClass( {
 } );
 
 export default connect(
-	( state, props ) => {
+	( state, { post } ) => {
 		return {
-			isPreviewable: false !== isSitePreviewable( state, props.post.site_ID ),
-			previewURL: getPreviewURL( props.post ),
+			isPreviewable: false !== isSitePreviewable( state, post.site_ID ),
+			postSite: getSite( state, post.site_ID ),
+			previewURL: getPreviewURL( post ),
+			selectedSiteId: getSelectedSiteId( state )
 		};
 	},
 	{ setPreviewUrl, setLayoutFocus }

--- a/client/my-sites/posts/posts-navigation.jsx
+++ b/client/my-sites/posts/posts-navigation.jsx
@@ -174,7 +174,7 @@ const PostsNavigation = React.createClass( {
 					className={ 'is-' + status }
 					key={ 'statusTabs' + path }
 					path={ path }
-					count={ null === this.props.siteId || count }
+					count={ this.props.siteId && count }
 					value={ textItem }
 					selected={ path === this.props.context.pathname }>
 					{ textItem }

--- a/client/my-sites/posts/posts-navigation.jsx
+++ b/client/my-sites/posts/posts-navigation.jsx
@@ -20,6 +20,7 @@ import userLib from 'lib/user';
 import { areAllSitesSingleUser } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
+import { areAllSitesSingleUser } from 'state/selectors';
 
 const debug = new Debug( 'calypso:posts-navigation' );
 const user = userLib();

--- a/client/my-sites/posts/posts-navigation.jsx
+++ b/client/my-sites/posts/posts-navigation.jsx
@@ -157,9 +157,7 @@ const PostsNavigation = React.createClass( {
 
 			let textItem = this.filterStatuses[ status ];
 
-			let count = false !== this.state.counts[ status ]
-				? this.state.counts[ status ]
-				: false;
+			let count = this.state.counts[ status ];
 
 			if ( path === this.props.context.pathname ) {
 				selectedText = textItem;

--- a/client/my-sites/posts/posts-navigation.jsx
+++ b/client/my-sites/posts/posts-navigation.jsx
@@ -20,7 +20,6 @@ import userLib from 'lib/user';
 import { areAllSitesSingleUser } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
-import { areAllSitesSingleUser } from 'state/selectors';
 
 const debug = new Debug( 'calypso:posts-navigation' );
 const user = userLib();

--- a/client/my-sites/posts/posts-navigation.jsx
+++ b/client/my-sites/posts/posts-navigation.jsx
@@ -49,9 +49,9 @@ const PostsNavigation = React.createClass( {
 			state = {
 				show: true,
 				loading: true,
-				counts: ! this.props.siteId ?
-					this._defaultCounts() :
-					this._getCounts()
+				counts: ! this.props.siteId
+					? this._defaultCounts()
+					: this._getCounts()
 			};
 
 		if ( ! this.props.siteId || Object.keys( counts ).length ) {
@@ -86,10 +86,10 @@ const PostsNavigation = React.createClass( {
 			return ( <SectionNav /> );
 		}
 
-		let author = this.props.author ? '/my' : '',
+		const author = this.props.author ? '/my' : '',
 			statusSlug = this.props.statusSlug ? '/' + this.props.statusSlug : '',
-			siteFilter = this.props.siteId ? '/' + this.props.siteId : '',
-			showMyFilter = true;
+			siteFilter = this.props.siteId ? '/' + this.props.siteId : '';
+		let showMyFilter = true;
 
 		this.filterStatuses = {
 			publish: this.translate( 'Published', { context: 'Filter label for posts list' } ),


### PR DESCRIPTION
This also replaces `site` props (that are partly used for computed attrs such as `slug`) by `siteId` ones plus selectors, down to leaf components level (such as `PostShare`) -- fortunately, none of these are used by any other consumers!

To test:
* Verify that the posts list still works (http://calypso.localhost:3000/posts). Be sure to click around on pretty much all navigational elements to make sure they still work.
* Try for a JP site, with a version < than the minimum JP site (3.3-dev): Verify that a notice appears, and works.

Question:
* Is the `areAllSitesSingleUser` selector reliable?

Possible follow-up work:
* Get rid of the `siteID` prop (capital D). Redundant/confusing crap.