### PR TITLE
Framework: remove siteslist usage from lib/cart

### DIFF
--- a/client/lib/cart/store/index.js
+++ b/client/lib/cart/store/index.js
@@ -34,15 +34,15 @@ var CartStore = {
 			hasPendingServerUpdates: hasPendingServerUpdates()
 		} );
 	},
-	setSelectedSite( selectedSite ) {
-		if ( selectedSite && _cartKey === selectedSite.ID ) {
+	setSelectedSiteId( selectedSiteId ) {
+		if ( selectedSiteId && _cartKey === selectedSiteId ) {
 			return;
 		}
 
-		if ( ! selectedSite ) {
+		if ( ! selectedSiteId ) {
 			_cartKey = 'no-site';
 		} else {
-			_cartKey = selectedSite.ID;
+			_cartKey = selectedSiteId;
 		}
 
 		if ( _synchronizer && _poller ) {

--- a/client/lib/cart/store/index.js
+++ b/client/lib/cart/store/index.js
@@ -11,7 +11,6 @@ var assign = require( 'lodash/assign' ),
  */
 var UpgradesActionTypes = require( 'lib/upgrades/constants' ).action,
 	emitter = require( 'lib/mixins/emitter' ),
-	sites = require( 'lib/sites-list' )(),
 	cartSynchronizer = require( './cart-synchronizer' ),
 	wpcom = require( 'lib/wp' ).undocumented(),
 	PollerPool = require( 'lib/data-poller' ),
@@ -34,6 +33,27 @@ var CartStore = {
 			hasLoadedFromServer: hasLoadedFromServer(),
 			hasPendingServerUpdates: hasPendingServerUpdates()
 		} );
+	},
+	setSelectedSite( selectedSite ) {
+		if ( selectedSite && _cartKey === selectedSite.ID ) {
+			return;
+		}
+
+		if ( ! selectedSite ) {
+			_cartKey = 'no-site';
+		} else {
+			_cartKey = selectedSite.ID;
+		}
+
+		if ( _synchronizer && _poller ) {
+			PollerPool.remove( _poller );
+			_synchronizer.off( 'change', emitChange );
+		}
+
+		_synchronizer = cartSynchronizer( _cartKey, wpcom );
+		_synchronizer.on( 'change', emitChange );
+
+		_poller = PollerPool.add( CartStore, _synchronizer._poll.bind( _synchronizer ) );
 	}
 };
 
@@ -45,30 +65,6 @@ function hasLoadedFromServer() {
 
 function hasPendingServerUpdates() {
 	return ( _synchronizer && _synchronizer.hasPendingServerUpdates() );
-}
-
-function setSelectedSite() {
-	var selectedSite = sites.getSelectedSite();
-
-	if ( selectedSite && _cartKey === selectedSite.ID ) {
-		return;
-	}
-
-	if ( ! selectedSite ) {
-		_cartKey = 'no-site';
-	} else {
-		_cartKey = selectedSite.ID;
-	}
-
-	if ( _synchronizer && _poller ) {
-		PollerPool.remove( _poller );
-		_synchronizer.off( 'change', emitChange );
-	}
-
-	_synchronizer = cartSynchronizer( _cartKey, wpcom );
-	_synchronizer.on( 'change', emitChange );
-
-	_poller = PollerPool.add( CartStore, _synchronizer._poll.bind( _synchronizer ) );
 }
 
 function emitChange() {
@@ -137,10 +133,4 @@ CartStore.dispatchToken = Dispatcher.register( ( payload ) => {
 	}
 } );
 
-sites.on( 'change', setSelectedSite );
-
-if ( sites.fetched ) {
-	setSelectedSite();
-}
-
-module.exports = CartStore;
+export default CartStore;

--- a/client/state/lib/README.md
+++ b/client/state/lib/README.md
@@ -47,7 +47,7 @@ case MY_EXAMPLE_LIBRARY_ACTION:
 ### Use Redux Middleware to setCurrentSite
 
 For libraries that are too large to port, or have too many usages, 
-we can try working around this by setting the selectedSite when it
+we can try working around this by setting the selectedSite when
 sites change (eg fetches complete or user sets another site).
 
 First add a new setter function to the library, for example:
@@ -57,7 +57,6 @@ library.setSelectedSite( selectedSite );
 ```
 
 Then add a handler in this middleware:
-And in this middleware, we can create a handler:
 ```jsx
 import library from 'lib/example'
 //... 

--- a/client/state/lib/README.md
+++ b/client/state/lib/README.md
@@ -1,0 +1,75 @@
+Library Middleware
+===========
+
+With the deprecation of SitesList, our `client/lib` libraries no longer 
+have easy access to the current user site. Since libraries are not react 
+components there isn't an easy way to provide access to our global 
+redux store data.
+
+When writing a library there are currently three ways around this:
+
+### Update the library interface to pass through data needs
+
+If we create a new library, or have a library with few usages, we can
+update the function interface to pass through this data. Calling components
+would then pass through that information.
+
+For example a call like:
+`library.doSomething()`
+
+Would turn into:
+`library.doSomething( currentSite )`
+
+### Use Redux Middleware to perform the library side-effect
+Similarly for a library with few usages, if we don't expect a return value from
+calling a library function this can be abstracted into a dispatched redux action,
+where the side effect is then called. The middleware handler has access to the 
+global store, so it would look something like:
+
+The component dispatches a new action
+
+```jsx
+dispatch( { type: 'MY_EXAMPLE_LIBRARY_ACTION' } );
+```
+
+And in this middleware, we can create a handler:
+```jsx
+import library from 'lib/example'
+//... 
+
+case MY_EXAMPLE_LIBRARY_ACTION:
+	const state = getState();
+    const selectedSite = getSelectedSite( state );
+	library.doSomething( selectedSite );
+```
+
+
+### Use Redux Middleware to setCurrentSite
+
+For libraries that are too large to port, or have too many usages, 
+we can try working around this by setting the selectedSite when it
+sites change (eg fetches complete or user sets another site).
+
+First add a new setter function to the library, for example:
+
+```jsx
+library.setSelectedSite( selectedSite );
+```
+
+Then add a handler in this middleware:
+And in this middleware, we can create a handler:
+```jsx
+import library from 'lib/example'
+//... 
+
+//All relevant site update events
+case SELECTED_SITE_SET:
+case SITE_RECEIVE:
+case SITES_RECEIVE:
+case SITES_UPDATE:
+	const state = getState();
+    const selectedSite = getSelectedSite( state );
+	library.setSelectedSite( selectedSite );
+```
+
+

--- a/client/state/lib/README.md
+++ b/client/state/lib/README.md
@@ -1,5 +1,5 @@
 Library Middleware
-===========
+==================
 
 With the deprecation of SitesList, our `client/lib` libraries no longer 
 have easy access to the current user site. Since libraries are not react 

--- a/client/state/lib/README.md
+++ b/client/state/lib/README.md
@@ -39,7 +39,7 @@ import library from 'lib/example'
 
 case MY_EXAMPLE_LIBRARY_ACTION:
 	const state = getState();
-    const selectedSite = getSelectedSite( state );
+	const selectedSite = getSelectedSite( state );
 	library.doSomething( selectedSite );
 ```
 
@@ -68,7 +68,7 @@ case SITE_RECEIVE:
 case SITES_RECEIVE:
 case SITES_UPDATE:
 	const state = getState();
-    const selectedSite = getSelectedSite( state );
+	const selectedSite = getSelectedSite( state );
 	library.setSelectedSite( selectedSite );
 ```
 

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -15,7 +15,7 @@ import {
 } from 'state/action-types';
 import analytics from 'lib/analytics';
 import cartStore from 'lib/cart/store';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 
 /**
@@ -44,8 +44,8 @@ const updateSelectedSiteForAnalytics = ( dispatch, action, getState ) => {
  */
 const updateSelectedSiteForCart = ( dispatch, action, getState ) => {
 	const state = getState();
-	const selectedSite = getSelectedSite( state );
-	cartStore.setSelectedSite( selectedSite );
+	const selectedSiteId = getSelectedSiteId( state );
+	cartStore.setSelectedSiteId( selectedSiteId );
 };
 
 const handler = ( dispatch, action, getState ) => {

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -7,12 +7,25 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import {
-	ANALYTICS_SUPER_PROPS_UPDATE
+	ANALYTICS_SUPER_PROPS_UPDATE,
+	SELECTED_SITE_SET,
+	SITE_RECEIVE,
+	SITES_RECEIVE,
+	SITES_UPDATE,
 } from 'state/action-types';
 import analytics from 'lib/analytics';
+import cartStore from 'lib/cart/store';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 
+/**
+ * Sets the currentSite and siteCount for lib/analytics. This is used to
+ * populate extra fields on tracks analytics calls.
+ *
+ * @param {function} dispatch - redux dispatch function
+ * @param {object}   action   - the dispatched action
+ * @param {function} getState - redux getState function
+ */
 const updateSelectedSiteForAnalytics = ( dispatch, action, getState ) => {
 	const state = getState();
 	const selectedSite = getSelectedSite( state );
@@ -22,14 +35,38 @@ const updateSelectedSiteForAnalytics = ( dispatch, action, getState ) => {
 	analytics.setSiteCount( siteCount );
 };
 
-export const handlers = {
-	[ ANALYTICS_SUPER_PROPS_UPDATE ]: updateSelectedSiteForAnalytics,
+/**
+ * Sets the currentSite for lib/cart/store
+ *
+ * @param {function} dispatch - redux dispatch function
+ * @param {object}   action   - the dispatched action
+ * @param {function} getState - redux getState function
+ */
+const updateSelectedSiteForCart = ( dispatch, action, getState ) => {
+	const state = getState();
+	const selectedSite = getSelectedSite( state );
+	cartStore.setSelectedSite( selectedSite );
+};
+
+const handler = ( dispatch, action, getState ) => {
+	switch ( action.type ) {
+		case ANALYTICS_SUPER_PROPS_UPDATE:
+			return updateSelectedSiteForAnalytics( dispatch, action, getState );
+
+		case SELECTED_SITE_SET:
+		case SITE_RECEIVE:
+		case SITES_RECEIVE:
+		case SITES_UPDATE:
+			//Wait a tick for the reducer to update the state tree
+			setTimeout( () => {
+				updateSelectedSiteForCart( dispatch, action, getState );
+			}, 0 );
+			return;
+	}
 };
 
 export const libraryMiddleware = ( { dispatch, getState } ) => ( next ) => ( action ) => {
-	if ( handlers.hasOwnProperty( action.type ) ) {
-		handlers[ action.type ]( dispatch, action, getState );
-	}
+	handler( dispatch, action, getState );
 
 	return next( action );
 };

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -19,7 +19,7 @@ import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 
 /**
- * Sets the currentSite and siteCount for lib/analytics. This is used to
+ * Sets the selectedSite and siteCount for lib/analytics. This is used to
  * populate extra fields on tracks analytics calls.
  *
  * @param {function} dispatch - redux dispatch function
@@ -36,7 +36,7 @@ const updateSelectedSiteForAnalytics = ( dispatch, action, getState ) => {
 };
 
 /**
- * Sets the currentSite for lib/cart/store
+ * Sets the selectedSiteId for lib/cart/store
  *
  * @param {function} dispatch - redux dispatch function
  * @param {object}   action   - the dispatched action


### PR DESCRIPTION
This PR removes the SitesList usage from lib/cart and instead provides that information using redux middleware.

### Testing Instructions
- Cart Data should update as expected
- New User Purchases should work
- Existing User purchases should work