### PR TITLE
Checkout: Add default payment localization redux

### DIFF
--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -131,6 +131,17 @@ function getRefundPolicy( cart ) {
 	return 'genericRefund';
 }
 
+function isPaymentMethodEnabled( cart, method ) {
+	switch ( method ) {
+		case 'credit-card':
+			return isCreditCardPaymentsEnabled( cart );
+		case 'paypal':
+			return isPayPalExpressEnabled( cart );
+		default:
+			return false;
+	}
+}
+
 function isCreditCardPaymentsEnabled( cart ) {
 	return cart.allowed_payment_methods.indexOf( 'WPCOM_Billing_MoneyPress_Paygate' ) >= 0;
 }
@@ -151,6 +162,7 @@ module.exports = {
 	getRefundPolicy,
 	isFree,
 	isPaidForFullyInCredits,
+	isPaymentMethodEnabled,
 	isPayPalExpressEnabled,
 	isCreditCardPaymentsEnabled
 };

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -38,7 +38,10 @@ import { planItem as getCartItemForPlan } from 'lib/cart-values/cart-items';
 import { recordViewCheckout } from 'lib/analytics/ad-tracking';
 import { recordApplePayStatus } from 'lib/apple-pay';
 import { requestSite } from 'state/sites/actions';
-import { isDomainOnlySite } from 'state/selectors';
+import {
+	isDomainOnlySite,
+	getCurrentUserPaymentMethods
+} from 'state/selectors';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
@@ -344,6 +347,7 @@ const Checkout = React.createClass( {
 				cart={ this.props.cart }
 				transaction={ this.props.transaction }
 				cards={ this.props.cards }
+				paymentMethods={ this.props.paymentMethods }
 				products={ this.props.productsList.get() }
 				selectedSite={ selectedSite }
 				redirectTo={ this.getCheckoutCompleteRedirectPath }
@@ -391,6 +395,7 @@ module.exports = connect(
 
 		return {
 			cards: getStoredCards( state ),
+			paymentMethods: getCurrentUserPaymentMethods( state ),
 			isDomainOnly: isDomainOnlySite( state, selectedSiteId ),
 			selectedSite: getSelectedSite( state ),
 			selectedSiteId,

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -23,6 +23,7 @@ const analytics = require( 'lib/analytics' ),
 	observe = require( 'lib/mixins/data-observe' ),
 	purchasePaths = require( 'me/purchases/paths' ),
 	QueryStoredCards = require( 'components/data/query-stored-cards' ),
+	QueryGeo = require( 'components/data/query-geo' ),
 	SecurePaymentForm = require( './secure-payment-form' ),
 	SecurePaymentFormPlaceholder = require( './secure-payment-form-placeholder' ),
 	supportPaths = require( 'lib/url/support' ),
@@ -381,6 +382,7 @@ const Checkout = React.createClass( {
 			<div className="main main-column" role="main">
 				<div className="checkout">
 					<QueryStoredCards />
+					<QueryGeo />
 
 					{ this.content() }
 				</div>

--- a/client/my-sites/upgrades/checkout/secure-payment-form.jsx
+++ b/client/my-sites/upgrades/checkout/secure-payment-form.jsx
@@ -48,12 +48,14 @@ const SecurePaymentForm = React.createClass( {
 	getInitialState() {
 		return {
 			userSelectedPaymentBox: null,
-			visiblePaymentBox: this.getVisiblePaymentBox( this.props.cart ),
+			visiblePaymentBox: this.getVisiblePaymentBox( this.props.cart, this.props.paymentMethods ),
 			previousCart: null
 		};
 	},
 
-	getVisiblePaymentBox( cart ) {
+	getVisiblePaymentBox( cart, paymentMethods ) {
+		const primary = 0, secondary = 1;
+
 		if ( isPaidForFullyInCredits( cart ) ) {
 			return 'credits';
 		} else if ( isFree( cart ) ) {
@@ -62,10 +64,10 @@ const SecurePaymentForm = React.createClass( {
 			return 'free-trial';
 		} else if ( this.state && this.state.userSelectedPaymentBox ) {
 			return this.state.userSelectedPaymentBox;
-		} else if ( cartValues.isCreditCardPaymentsEnabled( cart ) ) {
-			return 'credit-card';
-		} else if ( cartValues.isPayPalExpressEnabled( cart ) ) {
-			return 'paypal';
+		} else if ( cartValues.isPaymentMethodEnabled( cart, paymentMethods[ primary ] ) ) {
+			return paymentMethods[ primary ];
+		} else if ( cartValues.isPaymentMethodEnabled( cart, paymentMethods[ secondary ] ) ) {
+			return paymentMethods[ secondary ];
 		}
 
 		return null;
@@ -77,7 +79,7 @@ const SecurePaymentForm = React.createClass( {
 		}
 
 		this.setState( {
-			visiblePaymentBox: this.getVisiblePaymentBox( nextProps.cart )
+			visiblePaymentBox: this.getVisiblePaymentBox( nextProps.cart, nextProps.paymentMethods )
 		} );
 	},
 

--- a/client/my-sites/upgrades/checkout/secure-payment-form.jsx
+++ b/client/my-sites/upgrades/checkout/secure-payment-form.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { find, defer } from 'lodash';
+import { get, find, defer } from 'lodash';
 
 /**
  * Internal dependencies
@@ -64,9 +64,9 @@ const SecurePaymentForm = React.createClass( {
 			return 'free-trial';
 		} else if ( this.state && this.state.userSelectedPaymentBox ) {
 			return this.state.userSelectedPaymentBox;
-		} else if ( cartValues.isPaymentMethodEnabled( cart, paymentMethods[ primary ] ) ) {
+		} else if ( cartValues.isPaymentMethodEnabled( cart, get( paymentMethods, [ primary ] ) ) ) {
 			return paymentMethods[ primary ];
-		} else if ( cartValues.isPaymentMethodEnabled( cart, paymentMethods[ secondary ] ) ) {
+		} else if ( cartValues.isPaymentMethodEnabled( cart, get( paymentMethods, [ secondary ] ) ) ) {
 			return paymentMethods[ secondary ];
 		}
 

--- a/client/state/geo/selectors.js
+++ b/client/state/geo/selectors.js
@@ -32,3 +32,13 @@ export function getGeo( state ) {
 export function getGeoCountry( state ) {
 	return get( getGeo( state ), 'country_long', null );
 }
+
+/**
+ * Returns the current browser IP geolocation abbreviated country name.
+ *
+ * @param  {Object}  state Global state tree
+ * @return {?String}       Current browser IP geolocation short country name
+ */
+export function getGeoCountryShort( state ) {
+	return get( getGeo( state ), 'country_short', null );
+}

--- a/client/state/geo/test/selectors.js
+++ b/client/state/geo/test/selectors.js
@@ -6,7 +6,12 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { isRequestingGeo, getGeo, getGeoCountry } from '../selectors';
+import {
+	isRequestingGeo,
+	getGeo,
+	getGeoCountry,
+	getGeoCountryShort
+} from '../selectors';
 
 describe( 'selectors', () => {
 	describe( 'isRequestingGeo()', () => {
@@ -73,6 +78,35 @@ describe( 'selectors', () => {
 			} );
 
 			expect( country ).to.equal( 'United States' );
+		} );
+	} );
+
+	describe( 'getGeoCountryShort()', () => {
+		it( 'should return null if no geo data state', () => {
+			const country = getGeoCountryShort( {
+				geo: {
+					geo: null
+				}
+			} );
+
+			expect( country ).to.be.null;
+		} );
+
+		it( 'should return abbreviated country name of geo data state', () => {
+			const country = getGeoCountryShort( {
+				geo: {
+					geo: {
+						latitude: '39.36006',
+						longitude: '-84.30994',
+						country_short: 'US',
+						country_long: 'United States',
+						region: 'Ohio',
+						city: 'Mason'
+					}
+				}
+			} );
+
+			expect( country ).to.equal( 'US' );
 		} );
 	} );
 } );

--- a/client/state/selectors/get-current-user-payment-methods.js
+++ b/client/state/selectors/get-current-user-payment-methods.js
@@ -15,7 +15,7 @@ import { getGeoCountryShort } from 'state/geo/selectors';
  * Payment methods can be targeted via a WP.com locale code (actually
  * a two letter lang usually) or by a full lang-CC locale.
  */
-const default_payment_methods = [ 'credit-card', 'paypal' ];
+const DEFAULT_PAYMENT_METHODS = [ 'credit-card', 'paypal' ];
 
 const paymentMethodsByLocale = {
 	de: [ 'paypal', 'credit-card' ],
@@ -29,11 +29,11 @@ const paymentMethodsByLocale = {
  * @return {Array}               Preferred payment methods
  */
 export default function getCurrentUserPaymentMethods( state ) {
-	const countryCode = getGeoCountryShort( state ),
-		locale = getCurrentUserLocale( state ),
-		generated_locale = kebabCase( locale ) + '-' + upperCase( countryCode );
+	const countryCode = getGeoCountryShort( state );
+	const locale = getCurrentUserLocale( state );
+	const generatedLocale = kebabCase( locale ) + '-' + upperCase( countryCode );
 
-	return paymentMethodsByLocale[ generated_locale ] ||
+	return paymentMethodsByLocale[ generatedLocale ] ||
 		paymentMethodsByLocale[ locale ] ||
-		default_payment_methods;
+		[ ...DEFAULT_PAYMENT_METHODS ];
 }

--- a/client/state/selectors/get-current-user-payment-methods.js
+++ b/client/state/selectors/get-current-user-payment-methods.js
@@ -18,8 +18,8 @@ import { getGeoCountryShort } from 'state/geo/selectors';
 const default_payment_methods = [ 'credit-card', 'paypal' ];
 
 const paymentMethodsByLocale = {
-	"de": [ 'paypal', 'credit-card' ],
-	"en-US": default_payment_methods,
+	de: [ 'paypal', 'credit-card' ],
+	'en-US': default_payment_methods,
 };
 
 /**

--- a/client/state/selectors/get-current-user-payment-methods.js
+++ b/client/state/selectors/get-current-user-payment-methods.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { kebabCase, upperCase } from 'lodash';
+import { lowerCase, upperCase } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,14 +12,23 @@ import { getGeoCountryShort } from 'state/geo/selectors';
 /**
  * Constants
  *
- * Payment methods can be targeted via a WP.com locale code (actually
- * a two letter lang usually) or by a full lang-CC locale.
+ * Payment methods can be targeted via a full lang-CC locale, a two
+ * digit GeoIP country code, or a WP.com "locale" code (more of a
+ * two letter lang code really). Return value precedence is in that order.
  */
 const DEFAULT_PAYMENT_METHODS = [ 'credit-card', 'paypal' ];
 
-const paymentMethodsByLocale = {
-	de: [ 'paypal', 'credit-card' ],
-	'en-US': default_payment_methods,
+const paymentMethods = {
+	byLocale: {
+		'de-DE': [ 'paypal', 'credit-card' ],
+		'en-DE': [ 'paypal', 'credit-card' ]
+	},
+
+	byCountry: {
+		US: DEFAULT_PAYMENT_METHODS
+	},
+
+	byWpcomLang: {}
 };
 
 /**
@@ -30,10 +39,11 @@ const paymentMethodsByLocale = {
  */
 export default function getCurrentUserPaymentMethods( state ) {
 	const countryCode = getGeoCountryShort( state );
-	const locale = getCurrentUserLocale( state );
-	const generatedLocale = kebabCase( locale ) + '-' + upperCase( countryCode );
+	const wpcomLang = getCurrentUserLocale( state );
+	const generatedLocale = lowerCase( wpcomLang ) + '-' + upperCase( countryCode );
 
-	return paymentMethodsByLocale[ generatedLocale ] ||
-		paymentMethodsByLocale[ locale ] ||
+	return paymentMethods.byLocale[ generatedLocale ] ||
+		paymentMethods.byCountry[ countryCode ] ||
+		paymentMethods.byWpcomLang[ wpcomLang ] ||
 		[ ...DEFAULT_PAYMENT_METHODS ];
 }

--- a/client/state/selectors/get-current-user-payment-methods.js
+++ b/client/state/selectors/get-current-user-payment-methods.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { kebabCase, upperCase } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentUserLocale } from 'state/current-user/selectors';
+import { getGeoCountryShort } from 'state/geo/selectors';
+
+/**
+ * Constants
+ *
+ * Payment methods can be targeted via a WP.com locale code (actually
+ * a two letter lang usually) or by a full lang-CC locale.
+ */
+const default_payment_methods = [ 'credit-card', 'paypal' ];
+
+const paymentMethodsByLocale = {
+	"de": [ 'paypal', 'credit-card' ],
+	"en-US": default_payment_methods,
+};
+
+/**
+ * Returns the preferred payment methods for the current locale.
+ *
+ * @param  {Object}  state       Global state tree
+ * @return {Array}               Preferred payment methods
+ */
+export default function getCurrentUserPaymentMethods( state ) {
+	const countryCode = getGeoCountryShort( state ),
+		locale = getCurrentUserLocale( state ),
+		generated_locale = kebabCase( locale ) + '-' + upperCase( countryCode );
+
+	return paymentMethodsByLocale[ generated_locale ] ||
+		paymentMethodsByLocale[ locale ] ||
+		default_payment_methods;
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -27,6 +27,7 @@ export getAccountRecoveryResetOptionsError from './get-account-recovery-reset-op
 export getAccountRecoveryResetRequestError from './get-account-recovery-reset-request-error';
 export getBlockedSites from './get-blocked-sites';
 export getBillingTransactions from './get-billing-transactions';
+export getCurrentUserPaymentMethods from './get-current-user-payment-methods';
 export getFollowCount from './get-follow-count';
 export getImageEditorOriginalAspectRatio from './get-image-editor-original-aspect-ratio';
 export getJetpackConnectionStatus from './get-jetpack-connection-status';

--- a/client/state/selectors/test/get-current-user-payment-methods.js
+++ b/client/state/selectors/test/get-current-user-payment-methods.js
@@ -88,12 +88,16 @@ describe( 'getCurrentUserPaymentMethods()', () => {
 		expect( getCurrentUserPaymentMethods( enLangUsCountryState ) ).to.eql( creditCardPaypal );
 	} );
 
+	it( 'en-DE should return PayPal primary, credit card secondary', () => {
+		expect( getCurrentUserPaymentMethods( deLangDeCountryState ) ).to.eql( paypalCreditCard );
+	} );
+
 	it( 'de-DE should return PayPal primary, credit card secondary', () => {
 		expect( getCurrentUserPaymentMethods( deLangDeCountryState ) ).to.eql( paypalCreditCard );
 	} );
 
-	it( 'de-JP should return PayPal primary, credit card secondary', () => {
-		expect( getCurrentUserPaymentMethods( deLangJpCountryState ) ).to.eql( paypalCreditCard );
+	it( 'de-JP should return credit card primary, PayPal secondary', () => {
+		expect( getCurrentUserPaymentMethods( deLangJpCountryState ) ).to.eql( creditCardPaypal );
 	} );
 
 	it( 'fr-DE should return credit card primary, PayPal secondary', () => {

--- a/client/state/selectors/test/get-current-user-payment-methods.js
+++ b/client/state/selectors/test/get-current-user-payment-methods.js
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentUserPaymentMethods } from '../';
+
+describe( 'getCurrentUserPaymentMethods()', () => {
+	const creditCardPaypal = [ 'credit-card', 'paypal' ],
+		paypalCreditCard = [ 'paypal', 'credit-card' ];
+
+	const enLangUsCountryState = {
+		geo: {
+			geo: {
+				country_short: 'US'
+			}
+		},
+
+		users: {
+			items: {
+				73705554: { ID: 73705554, login: 'testonesite2014', localeSlug: 'en' }
+			}
+		},
+
+		currentUser: {
+			id: 73705554
+		}
+	};
+
+	const deLangDeCountryState = {
+		geo: {
+			geo: {
+				country_short: 'DE'
+			}
+		},
+
+		users: {
+			items: {
+				73705554: { ID: 73705554, login: 'testonesite2014', localeSlug: 'de' }
+			}
+		},
+
+		currentUser: {
+			id: 73705554
+		}
+	};
+
+	const deLangJpCountryState = {
+		geo: {
+			geo: {
+				country_short: 'JP'
+			}
+		},
+
+		users: {
+			items: {
+				73705554: { ID: 73705554, login: 'testonesite2014', localeSlug: 'de' }
+			}
+		},
+
+		currentUser: {
+			id: 73705554
+		}
+	};
+
+	const frLangDeCountryState = {
+		geo: {
+			geo: {
+				country_short: 'DE'
+			}
+		},
+
+		users: {
+			items: {
+				73705554: { ID: 73705554, login: 'testonesite2014', localeSlug: 'fr' }
+			}
+		},
+
+		currentUser: {
+			id: 73705554
+		}
+	};
+
+	it( 'en-US should return credit card primary, PayPal secondary', () => {
+		expect( getCurrentUserPaymentMethods( enLangUsCountryState ) ).to.eql( creditCardPaypal );
+	} );
+
+	it( 'de-DE should return PayPal primary, credit card secondary', () => {
+		expect( getCurrentUserPaymentMethods( deLangDeCountryState ) ).to.eql( paypalCreditCard );
+	} );
+
+	it( 'de-JP should return PayPal primary, credit card secondary', () => {
+		expect( getCurrentUserPaymentMethods( deLangJpCountryState ) ).to.eql( paypalCreditCard );
+	} );
+
+	it( 'fr-DE should return credit card primary, PayPal secondary', () => {
+		expect( getCurrentUserPaymentMethods( frLangDeCountryState ) ).to.eql( creditCardPaypal );
+	} );
+} );


### PR DESCRIPTION
Problem: current payment flow assumes credit card first for all markets. Not all markets internationally have such affinity for credit cards.

Solution: add logic to facilitate varying the default payment options by locale.

**Test (for those not located in Germany):**
0. Use a WP.com account without any previously saved payment cards.

_VPN option:_
1. VPN into Germany-based node.
2. Set Calypso language setting to German.
3. Browse to My Sites->[any site]->Plans->[choose anything to add to cart].
4. You should see a Paypal payment form.
5. Go back to the `/plans` screen in Calypso, switch language to anything other than English or German, hard refresh browser, and repeat these steps. You should see the credit card payment form.
5. Go back to the `/plans` screen in Calypso, switch language to `en`, hard refresh browser, and repeat these steps. You should the Paypal payment form again.

_Non-VPN option:_
1. Install [Redux Dev Tools](https://github.com/zalmoxisus/redux-devtools-extension).
2. Set Calypso language setting to German.
2. Browse to My Sites->[any site]->Plans->[choose anything to add to cart].
3. You should see a credit card payment form.
4. Open Redux Dev Tools, click "Commit", click the little mail envelope (Dispatcher) icon at bottom of pane, copy paste in the the following Redux action to convince Redux you are in Germany and click "Dispatch":
```
{
  type: 'GEO_RECEIVE',
  geo: {
    country_short: 'DE'
  }
}
```
5. You should see the payment form refresh to a Paypal payment form.
6. Go back to the `/plans` screen in Calypso, switch language to `en`, hard refresh browser, and repeat these steps. You should see the same behavior.
7. Go back to the `/plans` screen in Calypso, switch language to anything other than English or German, hard refresh browser, and repeat these steps. You should see nothing change on the payment form screen.

For previous history--this PR is a simplified version of https://github.com/Automattic/wp-calypso/pull/12827.