### PR TITLE
Editor: Update to TinyMCE 4.5.6

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -91,7 +91,15 @@
       "version": "1.1.1"
     },
     "are-we-there-yet": {
-      "version": "1.1.2"
+      "version": "1.1.4",
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.2.9"
+        },
+        "string_decoder": {
+          "version": "1.0.0"
+        }
+      }
     },
     "argparse": {
       "version": "1.0.9",
@@ -695,7 +703,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000656"
+      "version": "1.0.30000657"
     },
     "caseless": {
       "version": "0.12.0"
@@ -1579,7 +1587,7 @@
       "version": "1.0.1"
     },
     "espree": {
-      "version": "3.4.1",
+      "version": "3.4.2",
       "dev": true,
       "dependencies": {
         "acorn": {
@@ -3005,7 +3013,7 @@
       "version": "3.0.6"
     },
     "normalize-package-data": {
-      "version": "2.3.6"
+      "version": "2.3.8"
     },
     "normalize-path": {
       "version": "2.1.1"
@@ -4308,7 +4316,7 @@
       "version": "1.2.0"
     },
     "tinymce": {
-      "version": "4.3.12"
+      "version": "4.5.6"
     },
     "title-case": {
       "version": "1.1.2"
@@ -4920,7 +4928,7 @@
       "dev": true
     },
     "write-file-atomic": {
-      "version": "1.3.1",
+      "version": "1.3.2",
       "dev": true
     },
     "write-file-stdout": {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "store": "1.3.16",
     "striptags": "2.1.1",
     "superagent": "2.1.0",
-    "tinymce": "4.3.12",
+    "tinymce": "4.5.6",
     "to-title-case": "0.1.5",
     "tracekit": "0.4.3",
     "tween.js": "16.3.1",


### PR DESCRIPTION
Chrome 58 (scheduled for release on Apr 25) triggers an error in TinyMCE that is fixed in the latest version.

See https://core.trac.wordpress.org/ticket/40305. 