### PR TITLE
Add traintracks to search suggestions

### DIFF
--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -30,7 +30,14 @@ function handleSearch( query ) {
 
 const FollowingStream = ( props ) => {
 	const suggestionList = props.suggestions && initial( flatMap( props.suggestions, query =>
-		[ <Suggestion suggestion={ query } source="following" />, ', ' ] ) );
+		[
+			<Suggestion
+				suggestion={ query.text }
+				source="following"
+				railcar={ query.railcar }
+			/>,
+			', '
+		] ) );
 
 	return (
 		<Stream { ...props }>

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -140,12 +140,13 @@ class SearchStream extends Component {
 			);
 		}
 
-		const suggestionList = initial( flatMap( suggestions, suggestionKeyword =>
+		const suggestionList = initial( flatMap( suggestions, suggestion =>
 			[
 				<Suggestion
-					suggestion={ suggestionKeyword }
+					suggestion={ suggestion.text }
 					source="search"
 					sort={ sortOrder === 'date' ? sortOrder : undefined }
+					railcar={ suggestion.railcar }
 				/>,
 				', '
 			] ) );

--- a/client/reader/search-stream/suggestion-provider.jsx
+++ b/client/reader/search-stream/suggestion-provider.jsx
@@ -59,7 +59,7 @@ function suggestionWithRailcar( text, ui_algo, position ) {
 			ui_position: position,
 			rec_result: text,
 		}
-	}
+	};
 }
 
 function getSuggestions( count, tags ) {

--- a/client/reader/search-stream/suggestion-provider.jsx
+++ b/client/reader/search-stream/suggestion-provider.jsx
@@ -11,6 +11,7 @@ import { map, sampleSize } from 'lodash';
 import i18nUtils from 'lib/i18n-utils';
 import { suggestions } from 'reader/search-stream/suggestions';
 import { getReaderFollowedTags } from 'state/selectors';
+import analytics from 'lib/analytics';
 
 /**
  * Build suggestions from subscribed tags
@@ -30,9 +31,24 @@ function suggestionsFromTags( count, tags ) {
 
 function suggestionsFromPicks( count ) {
 	const lang = i18nUtils.getLocaleSlug().split( '-' )[ 0 ];
+	const pickSuggestions = [];
+	let sampleSuggestions = {};
 
 	if ( suggestions[ lang ] ) {
-		return sampleSize( suggestions[ lang ], count );
+		sampleSuggestions = sampleSize( suggestions[ lang ], count );
+
+		for ( let i = 0; i < sampleSuggestions.length; i++ ) {
+			pickSuggestions.push( {
+				suggestion: sampleSuggestions[ i ],
+				railcar: {
+					railcar: analytics.tracks.createRandomId() + '-' + i,
+					ui_algo: 'suggestions-from-picks-1',
+					ui_position: i,
+				}
+			} );
+		}
+
+		return pickSuggestions;
 	}
 	return null;
 }

--- a/client/reader/search-stream/suggestion-provider.jsx
+++ b/client/reader/search-stream/suggestion-provider.jsx
@@ -74,14 +74,7 @@ function getSuggestions( count, tags ) {
 		? tagSuggestions
 		: suggestionsFromPicks( count );
 
-	trackSuggestionRailcarRender( newSuggestions );
 	return newSuggestions;
-}
-
-function trackSuggestionRailcarRender( suggestionsToTrack ) {
-	suggestionsToTrack.forEach( suggestion => {
-		analytics.tracks.recordEvent( 'calypso_traintracks_render', suggestion.railcar );
-	} );
 }
 
 const SuggestionsProvider = ( Element, count = 3 ) => class extends Component {

--- a/client/reader/search-stream/suggestion-provider.jsx
+++ b/client/reader/search-stream/suggestion-provider.jsx
@@ -20,54 +20,46 @@ import analytics from 'lib/analytics';
  * @return {Array}       An array of suggestions, or null if no tags where provided
  */
 function suggestionsFromTags( count, tags ) {
-	const tagSuggestions = [];
-	let sampleSuggestions = {};
 	if ( tags ) {
 		if ( tags.length <= count ) {
 			return [];
 		}
-		sampleSuggestions = map( sampleSize( tags, count ), tag => ( tag.displayName || tag.slug ).replace( /-/g, ' ' ) );
-
-		for ( let i = 0; i < sampleSuggestions.length; i++ ) {
-			tagSuggestions.push( {
-				text: sampleSuggestions[ i ],
-				railcar: {
-					railcar: analytics.tracks.createRandomId() + '-' + i,
-					ui_algo: 'read:search-suggestions:tags/1',
-					ui_position: i,
-					rec_result: sampleSuggestions[ i ],
-				}
-			} );
-		}
-
-		return tagSuggestions;
+		return map(
+			sampleSize( tags, count ),
+			( tag, i ) => {
+				const text = ( tag.displayName || tag.slug ).replace( /-/g, ' ' );
+				const ui_algo = 'read:search-suggestions:tags/1';
+				return suggestionWithRailcar( text, ui_algo, i );
+			}
+		);
 	}
 	return null;
 }
 
 function suggestionsFromPicks( count ) {
 	const lang = i18nUtils.getLocaleSlug().split( '-' )[ 0 ];
-	const pickSuggestions = [];
-	let sampleSuggestions = {};
-
 	if ( suggestions[ lang ] ) {
-		sampleSuggestions = sampleSize( suggestions[ lang ], count );
-
-		for ( let i = 0; i < sampleSuggestions.length; i++ ) {
-			pickSuggestions.push( {
-				text: sampleSuggestions[ i ],
-				railcar: {
-					railcar: analytics.tracks.createRandomId() + '-' + i,
-					ui_algo: 'read:search-suggestions:picks/1',
-					ui_position: i,
-					rec_result: sampleSuggestions[ i ],
-				}
-			} );
-		}
-
-		return pickSuggestions;
+		return map(
+			sampleSize( suggestions[ lang ], count ),
+			( tag, i ) => {
+				const ui_algo = 'read:search-suggestions:picks/1';
+				return suggestionWithRailcar( tag, ui_algo, i );
+			}
+		);
 	}
 	return null;
+}
+
+function suggestionWithRailcar( text, ui_algo, position ) {
+	return {
+		text: text,
+		railcar: {
+			railcar: analytics.tracks.createRandomId() + '-' + position,
+			ui_algo: ui_algo,
+			ui_position: position,
+			rec_result: text,
+		}
+	}
 }
 
 function getSuggestions( count, tags ) {

--- a/client/reader/search-stream/suggestion-provider.jsx
+++ b/client/reader/search-stream/suggestion-provider.jsx
@@ -79,9 +79,9 @@ function getSuggestions( count, tags ) {
 }
 
 function trackSuggestionRailcarRender( suggestionsToTrack ) {
-	for ( let i = 0; i < suggestionsToTrack.length; i++ ) {
-		analytics.tracks.recordEvent( 'calypso_traintracks_render', suggestionsToTrack[ i ].railcar );
-	}
+	suggestionsToTrack.forEach( suggestion => {
+		analytics.tracks.recordEvent( 'calypso_traintracks_render', suggestion.railcar );
+	} );
 }
 
 const SuggestionsProvider = ( Element, count = 3 ) => class extends Component {

--- a/client/reader/search-stream/suggestion-provider.jsx
+++ b/client/reader/search-stream/suggestion-provider.jsx
@@ -63,18 +63,19 @@ function suggestionWithRailcar( text, ui_algo, position ) {
 }
 
 function getSuggestions( count, tags ) {
-	let currentSuggestions = suggestionsFromTags( count, tags );
-	if ( currentSuggestions === null ) {
-		// return null to supperess showing any suggestions until tag subscriptions load
+	const tagSuggestions = suggestionsFromTags( count, tags );
+
+	// return null to suppress showing any suggestions until tag subscriptions load.
+	if ( tagSuggestions === null ) {
 		return null;
 	}
 
-	if ( ! currentSuggestions.length ) {
-		currentSuggestions = suggestionsFromPicks( count );
-	}
+	const newSuggestions = !! tagSuggestions.length
+		? tagSuggestions
+		: suggestionsFromPicks( count );
 
-	trackSuggestionRailcarRender( currentSuggestions );
-	return currentSuggestions;
+	trackSuggestionRailcarRender( newSuggestions );
+	return newSuggestions;
 }
 
 function trackSuggestionRailcarRender( suggestionsToTrack ) {

--- a/client/reader/search-stream/suggestion.jsx
+++ b/client/reader/search-stream/suggestion.jsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { PropTypes, Component } from 'react';
 import { stringify } from 'qs';
 
 /**
@@ -10,33 +10,42 @@ import { stringify } from 'qs';
 import { recordTrack } from 'reader/stats';
 import analytics from 'lib/analytics';
 
-export function Suggestion( { suggestion, source, sort, railcar } ) {
-	const handleSuggestionClick = () => {
+export class Suggestion extends Component {
+	static propTypes = {
+		suggestion: PropTypes.string.isRequired,
+		source: PropTypes.string,
+		sort: PropTypes.string,
+		railcar: PropTypes.object
+	};
+
+	componentWillMount() {
+		const { railcar } = this.props;
+		analytics.tracks.recordEvent( 'calypso_traintracks_render', railcar );
+	}
+
+	handleSuggestionClick = () => {
+		const { suggestion, source, railcar } = this.props;
 		recordTrack( 'calypso_reader_search_suggestion_click', { suggestion, source } );
 		analytics.tracks.recordEvent( 'calypso_traintracks_interact', railcar );
 	};
 
-	const args = {
-		isSuggestion: 1,
-		q: suggestion,
-		sort
-	};
+	render() {
+		const { suggestion, sort } = this.props;
+		const args = {
+			isSuggestion: 1,
+			q: suggestion,
+			sort
+		};
 
-	const searchUrl = '/read/search?' + stringify( args );
+		const searchUrl = '/read/search?' + stringify( args );
 
-	return (
-		<a onClick={ handleSuggestionClick }
-			href={ searchUrl } >
-			{ suggestion }
-		</a>
-	);
+		return (
+			<a onClick={ this.handleSuggestionClick }
+				href={ searchUrl } >
+				{ suggestion }
+			</a>
+		);
+	}
 }
-
-Suggestion.propTypes = {
-	suggestion: PropTypes.string.isRequired,
-	source: PropTypes.string,
-	sort: PropTypes.string,
-	railcar: PropTypes.object
-};
 
 export default Suggestion;

--- a/client/reader/search-stream/suggestion.jsx
+++ b/client/reader/search-stream/suggestion.jsx
@@ -7,7 +7,7 @@ import { stringify } from 'qs';
 /**
  * Internal Dependencies
  */
-import { recordTrack } from 'reader/stats';
+import { recordTrack, recordTracksRailcarInteract } from 'reader/stats';
 import analytics from 'lib/analytics';
 
 export class Suggestion extends Component {
@@ -26,7 +26,7 @@ export class Suggestion extends Component {
 	handleSuggestionClick = () => {
 		const { suggestion, source, railcar } = this.props;
 		recordTrack( 'calypso_reader_search_suggestion_click', { suggestion, source } );
-		analytics.tracks.recordEvent( 'calypso_traintracks_interact', railcar );
+		recordTracksRailcarInteract( 'search_suggestion_click', railcar );
 	};
 
 	render() {

--- a/client/reader/search-stream/suggestion.jsx
+++ b/client/reader/search-stream/suggestion.jsx
@@ -8,10 +8,12 @@ import { stringify } from 'qs';
  * Internal Dependencies
  */
 import { recordTrack } from 'reader/stats';
+import analytics from 'lib/analytics';
 
-export function Suggestion( { suggestion, source, sort } ) {
+export function Suggestion( { suggestion, source, sort, railcar } ) {
 	const handleSuggestionClick = () => {
 		recordTrack( 'calypso_reader_search_suggestion_click', { suggestion, source } );
+		analytics.tracks.recordEvent( 'calypso_traintracks_interact', railcar );
 	};
 
 	const args = {
@@ -31,7 +33,10 @@ export function Suggestion( { suggestion, source, sort } ) {
 }
 
 Suggestion.propTypes = {
-	suggestion: PropTypes.string.isRequired
+	suggestion: PropTypes.string.isRequired,
+	source: PropTypes.string,
+	sort: PropTypes.string,
+	railcar: PropTypes.object
 };
 
 export default Suggestion;


### PR DESCRIPTION
Allows us to compare the click through rates between suggestions generated by
- a reader's tags
- predefined search keywords

Added two new tracks events:

- `calypso_traintracks_render` (with railcar) when the suggestion is loaded
- `calypso_traintracks_interact` (with railcar) when the suggestion is clicked