### PR TITLE
Improve large theme upload error

### DIFF
--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -133,7 +133,7 @@ class Upload extends React.Component {
 		const errorCauses = {
 			exists: translate( 'Upload problem: Theme already installed on site.' ),
 			already_installed: translate( 'Upload problem: Theme already installed on site.' ),
-			'too large': translate( 'Upload problem: Zip file too large to upload.' ),
+			'too large': translate( 'Upload problem: Theme zip must be under 10MB.' ),
 			incompatible: translate( 'Upload problem: Incompatible theme.' ),
 			unsupported_mime_type: translate( 'Upload problem: Not a valid zip file' ),
 			initiate_failure: translate( 'Upload problem: Theme may not be valid' ),


### PR DESCRIPTION
This is a quick patch to fix #13128. It would be better to get the upload limit from the host itself and use that instead of a hard limit of 10mb

![screenshot_14-04-2017-16 03 34](https://cloud.githubusercontent.com/assets/150348/25058276/810548dc-212c-11e7-825f-732d1705b871.png)

**To Test**

    Go to http://calypso.localhost:3000/design/upload/{jetpack site]
    Upload a theme zip > 10MB