### PR TITLE
AT: Add tracking events to upload and install buttons

### DIFF
--- a/client/my-sites/plugins-wpcom/plugin-install-button.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-install-button.jsx
@@ -15,6 +15,7 @@ import { getAutomatedTransferStatus } from 'state/automated-transfer/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getEligibility } from 'state/automated-transfer/selectors';
 import { initiateThemeTransfer } from 'state/themes/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { transferStates } from 'state/automated-transfer/constants';
 
 export const WpcomPluginInstallButton = props => {
@@ -27,7 +28,8 @@ export const WpcomPluginInstallButton = props => {
 		eligibilityData,
 		navigateTo,
 		initiateTransfer,
-		transferState
+		transferState,
+		trackButtonAction,
 	} = props;
 
 	if ( transferStates.COMPLETE === transferState ) {
@@ -36,7 +38,7 @@ export const WpcomPluginInstallButton = props => {
 
 	function installButtonAction( event ) {
 		event.preventDefault();
-
+		trackButtonAction( plugin.slug );
 		const eligibilityHolds = get( eligibilityData, 'eligibilityHolds', [] );
 		const eligibilityWarnings = get( eligibilityData, 'eligibilityWarnings', [] );
 
@@ -74,7 +76,8 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = {
-	initiateTransfer: initiateThemeTransfer
+	initiateTransfer: initiateThemeTransfer,
+	trackButtonAction: ( plugin ) => recordTracksEvent( 'calypso_automated_transfer_click_plugin_install', { plugin } )
 };
 
 const withNavigation = WrappedComponent => props => <WrappedComponent { ...{ ...props, navigateTo: page } } />;

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -25,6 +25,7 @@ import ThemePreview from './theme-preview';
 import config from 'config';
 import { isATEnabledForCurrentSite } from 'lib/automated-transfer';
 import { getThemeShowcaseDescription } from 'state/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 const ThemesSearchCard = config.isEnabled( 'manage/themes/magic-search' )
 	? require( './themes-magic-search-card' )
@@ -64,6 +65,7 @@ const ThemeShowcase = React.createClass( {
 		secondaryOption: optionShape,
 		getScreenshotOption: PropTypes.func,
 		siteSlug: PropTypes.string,
+		trackATUploadClick: PropTypes.func,
 	},
 
 	getDefaultProps() {
@@ -107,6 +109,9 @@ const ThemeShowcase = React.createClass( {
 
 	onUploadClick() {
 		trackClick( 'upload theme' );
+		if ( isATEnabledForCurrentSite() ) {
+			this.props.trackATUploadClick();
+		}
 	},
 
 	showUploadButton() {
@@ -195,11 +200,14 @@ const ThemeShowcase = React.createClass( {
 	}
 } );
 
-export default connect(
-	( state, { siteId, filter, tier, vertical } ) => ( {
-		isLoggedIn: !! getCurrentUserId( state ),
-		siteSlug: getSiteSlug( state, siteId ),
-		isJetpack: isJetpackSite( state, siteId ),
-		description: getThemeShowcaseDescription( state, { filter, tier, vertical } ),
-	} )
-)( localize( ThemeShowcase ) );
+const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
+	isLoggedIn: !! getCurrentUserId( state ),
+	siteSlug: getSiteSlug( state, siteId ),
+	isJetpack: isJetpackSite( state, siteId ),
+	description: getThemeShowcaseDescription( state, { filter, tier, vertical } ),
+} );
+
+const mapDispatchToProps = {
+	trackATUploadClick: () => recordTracksEvent( 'calypso_automated_transfer_click_theme_upload' )
+};
+export default connect( mapStateToProps, mapDispatchToProps )( localize( ThemeShowcase ) );


### PR DESCRIPTION
This PR adds events to track button events that start the automated transfer process:

- `calypso_automated_transfer_click_plugin_install` - fired when a user clicks the wpcom plugin install button
- `calypso_automated_transfer_click_theme_upload` - fired when a user clicks a theme upload button on a non jetpack site.

**Testing**
- Enable tracks logging: `localStorage.setItem( 'debug', 'calypso.analytics.tracks' )`
- Visit a plugin page on a site that is eligible for automated transfer
- The event `calypso_automated_transfer_click_plugin_install` should fire after clicking "Install"
- Visit the theme showcase on another eligible automated transfer site
- The event `calypso_automated_transfer_click_theme_upload` should fire after clicking "upload theme"