### PR TITLE
Framework: remove sites-list usage from post-editor

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -16,7 +16,6 @@ import { map, pick, startsWith } from 'lodash';
  */
 import actions from 'lib/posts/actions';
 import route from 'lib/route';
-import SitesList from 'lib/sites-list';
 import User from 'lib/user';
 import userUtils from 'lib/user/utils';
 import analytics from 'lib/analytics';
@@ -30,7 +29,6 @@ import wpcom from 'lib/wp';
 import Dispatcher from 'dispatcher';
 import { getFeaturedImageId } from 'lib/posts/utils';
 
-const sites = SitesList();
 const user = User();
 
 function getPostID( context ) {
@@ -61,7 +59,6 @@ function renderEditor( context, postType ) {
 			React.createElement( PostEditor, {
 				user: user,
 				userUtils: userUtils,
-				sites: sites,
 				type: postType
 			} )
 		),

--- a/client/post-editor/editor-author/index.jsx
+++ b/client/post-editor/editor-author/index.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -11,27 +13,25 @@ import userFactory from 'lib/user';
 import AuthorSelector from 'blocks/author-selector';
 import PostActions from 'lib/posts/actions';
 import touchDetect from 'lib/touch-detect';
-import sitesFactory from 'lib/sites-list';
 import * as stats from 'lib/posts/stats';
+import { getSelectedSite } from 'state/ui/selectors';
 
 /**
  * Module dependencies
  */
 const user = userFactory();
-const sites = sitesFactory();
 
-export default React.createClass( {
-	displayName: 'EditorAuthor',
+export class EditorAuthor extends Component {
 
-	propTypes: {
+	static propTypes = {
 		post: React.PropTypes.object,
 		isNew: React.PropTypes.bool
-	},
+	};
 
-	render: function() {
+	render() {
 		// if it's not a new post and we are still loading
 		// show a placeholder component
-		const post = this.props.post;
+		const { post, translate } = this.props;
 
 		if ( ! post && ! this.props.isNew ) {
 			return this.renderPlaceholder();
@@ -44,36 +44,35 @@ export default React.createClass( {
 
 		return (
 			<div className="editor-author">
-				<Wrapper siteId={ this.props.post.site_ID } onSelect={ this.onSelect } popoverPosition={ popoverPosition }>
+				<Wrapper siteId={ post.site_ID } onSelect={ this.onSelect } popoverPosition={ popoverPosition }>
 					<Gravatar size={ 26 } user={ author } />
 					<span className="editor-author__name">
-							{ this.translate( 'by %(name)s', { args: { name: name } } ) }
+							{ translate( 'by %(name)s', { args: { name: name } } ) }
 					</span>
 				</Wrapper>
 			</div>
 		);
-	},
+	}
 
-	renderPlaceholder: function() {
+	renderPlaceholder() {
 		return (
 			<div className="editor-author is-placeholder">
 				<Gravatar size={ 26 } />
 				<span className="editor-author__name" />
 			</div>
 		);
-	},
+	}
 
-	onSelect: function( author ) {
+	onSelect = ( author ) => {
 		stats.recordStat( 'advanced_author_changed' );
 		stats.recordEvent( 'Changed Author' );
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		PostActions.edit( { author: author } );
-	},
+	};
 
-	userCanAssignAuthor: function() {
-		var post = this.props.post,
-			reassignCapability = 'edit_others_' + post.type + 's',
-			site = sites.getSite( this.props.post.site_ID );
+	userCanAssignAuthor() {
+		const { post, site } = this.props;
+		const reassignCapability = 'edit_others_' + post.type + 's';
 
 		// if user cannot edit others posts
 		if ( ! site || ! site.capabilities || ! site.capabilities[ reassignCapability ] ) {
@@ -81,6 +80,13 @@ export default React.createClass( {
 		}
 
 		return true;
-	},
+	}
 
-} );
+}
+
+export default connect(
+	( state ) => ( {
+		site: getSelectedSite( state )
+	} )
+)( localize( EditorAuthor ) );
+

--- a/client/post-editor/editor-sharing/publicize-options.jsx
+++ b/client/post-editor/editor-sharing/publicize-options.jsx
@@ -108,7 +108,7 @@ const EditorSharingPublicizeOptions = React.createClass( {
 		// possible state.  Also prevents a possible infinite loading state due
 		// to connections previously returning a 400 error
 		this.props.site.once( 'change', () => {
-			if ( this.props.site.isModuleActive( 'publicize' ) ) {
+			if ( this.props.isPublicizeEnabled ) {
 				this.props.requestConnections( this.props.site.ID );
 			}
 		} );
@@ -194,7 +194,7 @@ const EditorSharingPublicizeOptions = React.createClass( {
 			);
 		}
 
-		if ( this.props.site && this.props.site.jetpack && ! this.props.site.isModuleActive( 'publicize' ) ) {
+		if ( this.props.site && this.props.site.jetpack && ! this.props.isPublicizeEnabled ) {
 			return (
 				<div className="editor-sharing__publicize-disabled">
 					<p><span>{ this.translate( 'Enable the Publicize module to automatically share new posts to social networks.' ) }</span></p>

--- a/client/post-editor/test/post-editor.jsx
+++ b/client/post-editor/test/post-editor.jsx
@@ -14,7 +14,7 @@ import useMockery from 'test/helpers/use-mockery';
 import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'PostEditor', function() {
-	let sandbox, TestUtils, PostEditor, SitesList, PostEditStore;
+	let sandbox, TestUtils, PostEditor, PostEditStore;
 	const defaultProps = {
 		translate: string => string,
 		markSaved: () => {},
@@ -73,7 +73,6 @@ describe( 'PostEditor', function() {
 			connect: () => ( component ) => component
 		} );
 
-		SitesList = require( 'lib/sites-list/list' );
 		PostEditStore = require( 'lib/posts/post-edit-store' );
 		PostEditor = require( '../post-editor' ).PostEditor;
 	} );
@@ -87,7 +86,6 @@ describe( 'PostEditor', function() {
 			const tree = TestUtils.renderIntoDocument(
 				<PostEditor
 					preferences={ {} }
-					sites={ new SitesList() }
 					{ ...defaultProps }
 				/>
 			);
@@ -104,7 +102,6 @@ describe( 'PostEditor', function() {
 			const tree = TestUtils.renderIntoDocument(
 				<PostEditor
 					preferences={ {} }
-					sites={ new SitesList() }
 					{ ...defaultProps }
 				/>
 			);
@@ -121,7 +118,6 @@ describe( 'PostEditor', function() {
 			const tree = TestUtils.renderIntoDocument(
 				<PostEditor
 					preferences={ {} }
-					sites={ new SitesList() }
 					{ ...defaultProps }
 				/>
 			);
@@ -137,7 +133,6 @@ describe( 'PostEditor', function() {
 			const tree = TestUtils.renderIntoDocument(
 				<PostEditor
 					preferences={ {} }
-					sites={ new SitesList() }
 					{ ...defaultProps }
 				/>
 			);
@@ -157,7 +152,6 @@ describe( 'PostEditor', function() {
 			const tree = TestUtils.renderIntoDocument(
 				<PostEditor
 					preferences={ {} }
-					sites={ new SitesList() }
 					{ ...defaultProps }
 				/>
 			);
@@ -178,7 +172,6 @@ describe( 'PostEditor', function() {
 			const tree = TestUtils.renderIntoDocument(
 				<PostEditor
 					preferences={ {} }
-					sites={ new SitesList() }
 					{ ...defaultProps }
 				/>
 			);
@@ -202,7 +195,6 @@ describe( 'PostEditor', function() {
 			const tree = TestUtils.renderIntoDocument(
 				<PostEditor
 					preferences={ {} }
-					sites={ new SitesList() }
 					{ ...defaultProps }
 				/>
 			);


### PR DESCRIPTION
This PR removes the remaining sites list usages from the `client/post-editor` folder. 

I've updated the components to use the selectedSite rather than the post site since I couldn't think of any cases where the selectSite was different from the post's site. Let me know if we need to handle this case, and I can update the PR.

### Testing Instructions
1. Navigate to http://calypso.localhost:3000/post
2. Select a site that has more than one user, and at least 2 users with edit permissions
3. Edit a post, the EditorAuthor component should load, and work as it does in prod
![screen shot 2017-04-14 at 4 01 06 pm](https://cloud.githubusercontent.com/assets/1270189/25058281/95950e7c-212c-11e7-8727-1f9098af62cf.png)
4. You're able to edit and publish posts, pages, and custom post types without errors:
http://calypso.localhost:3000/post/:siteId:
http://calypso.localhost:3000/page/:siteId:
http://calypso.localhost:3000/edit/:custom-post-type:/:site-id:
