### PR TITLE
EditGravatar: Add tracking

### DIFF
--- a/client/blocks/edit-gravatar/test/index.jsx
+++ b/client/blocks/edit-gravatar/test/index.jsx
@@ -118,6 +118,7 @@ describe( 'EditGravatar', function() {
 					<EditGravatar
 						translate={ noop }
 						user={ user }
+						recordReceiveImageEvent={ noop }
 					/>
 				);
 				const files = [ {
@@ -142,6 +143,7 @@ describe( 'EditGravatar', function() {
 						receiveGravatarImageFailed={ receiveGravatarImageFailedSpy }
 						translate={ noop }
 						user={ user }
+						recordReceiveImageEvent={ noop }
 					/>
 				);
 				const files = [ {
@@ -174,6 +176,7 @@ describe( 'EditGravatar', function() {
 					translate={ noop }
 					uploadGravatar={ uploadGravatarSpy }
 					user={ user }
+					recordReceiveImageEvent={ noop }
 				/>
 			);
 
@@ -196,6 +199,7 @@ describe( 'EditGravatar', function() {
 					translate={ noop }
 					uploadGravatar={ uploadGravatarSpy }
 					user={ user }
+					recordReceiveImageEvent={ noop }
 				/>
 			);
 
@@ -214,6 +218,7 @@ describe( 'EditGravatar', function() {
 				<EditGravatar
 					translate={ noop }
 					user={ user }
+					recordClickButtonEvent={ noop }
 				/>
 			);
 			// Enzyme requires simulate() to be called directly on the element with the click handler

--- a/client/state/current-user/gravatar-status/actions.js
+++ b/client/state/current-user/gravatar-status/actions.js
@@ -13,10 +13,20 @@ import {
 	GRAVATAR_UPLOAD_REQUEST_SUCCESS,
 	GRAVATAR_UPLOAD_REQUEST_FAILURE
 } from 'state/action-types';
+import {
+	bumpStat,
+	composeAnalytics,
+	recordTracksEvent,
+	withAnalytics,
+} from 'state/analytics/actions';
 
 export function uploadGravatar( file, bearerToken, email ) {
 	return dispatch => {
-		dispatch( { type: GRAVATAR_UPLOAD_REQUEST } );
+		dispatch( withAnalytics(
+			recordTracksEvent( 'calypso_edit_gravatar_upload_start' ),
+			{ type: GRAVATAR_UPLOAD_REQUEST }
+		) );
+
 		const data = new FormData();
 		data.append( 'filedata', file );
 		data.append( 'account', email );
@@ -31,23 +41,33 @@ export function uploadGravatar( file, bearerToken, email ) {
 						type: GRAVATAR_UPLOAD_RECEIVE,
 						src: fileReader.result,
 					} );
-					dispatch( {
-						type: GRAVATAR_UPLOAD_REQUEST_SUCCESS
-					} );
+					dispatch( withAnalytics(
+						recordTracksEvent( 'calypso_edit_gravatar_upload_success' ),
+						{ type: GRAVATAR_UPLOAD_REQUEST_SUCCESS }
+					) );
 				} );
 				fileReader.readAsDataURL( file );
 			} )
 			.catch( () => {
-				dispatch( {
-					type: GRAVATAR_UPLOAD_REQUEST_FAILURE
-				} );
+				dispatch( withAnalytics(
+					composeAnalytics(
+						recordTracksEvent( 'calypso_edit_gravatar_upload_failure' ),
+						bumpStat( 'calypso_gravatar_update_error', 'unsuccessful_http_response' )
+					),
+					{ type: GRAVATAR_UPLOAD_REQUEST_FAILURE }
+				) );
 			} );
 	};
 }
 
-export function receiveGravatarImageFailed( errorMessage ) {
-	return {
-		type: GRAVATAR_RECEIVE_IMAGE_FAILURE,
-		errorMessage
-	};
-}
+export const receiveGravatarImageFailed = ( { errorMessage, statName } ) =>
+	withAnalytics(
+		composeAnalytics(
+			recordTracksEvent( 'calypso_edit_gravatar_file_recieve_failure' ),
+			bumpStat( 'calypso_gravatar_update_error', statName )
+		),
+		{
+			type: GRAVATAR_RECEIVE_IMAGE_FAILURE,
+			errorMessage,
+		}
+	);

--- a/client/state/current-user/gravatar-status/test/actions.js
+++ b/client/state/current-user/gravatar-status/test/actions.js
@@ -3,6 +3,7 @@
  */
 import { expect } from 'chai';
 import { noop } from 'lodash';
+import sinon from 'sinon';
 
 /**
  * Internal dependencies
@@ -42,9 +43,9 @@ describe( 'actions', () => {
 	describe( '#uploadGravatar', () => {
 		it( 'dispatches request action when thunk triggered', () => {
 			uploadGravatar( 'file', 'bearerToken', 'email' )( spy );
-			expect( spy ).to.have.been.calledWith( {
+			expect( spy ).to.have.been.calledWith( sinon.match( {
 				type: GRAVATAR_UPLOAD_REQUEST
-			} );
+			} ) );
 		} );
 
 		describe( 'successful request', () => {
@@ -68,9 +69,9 @@ describe( 'actions', () => {
 			it( 'dispatches success action', () => {
 				return uploadGravatar( 'file', 'bearerToken', 'email' )( spy )
 					.then( () => {
-						expect( spy ).to.have.been.calledWith( {
+						expect( spy ).to.have.been.calledWith( sinon.match( {
 							type: GRAVATAR_UPLOAD_REQUEST_SUCCESS
-						} );
+						} ) );
 					} );
 			} );
 		} );
@@ -85,22 +86,25 @@ describe( 'actions', () => {
 			it( 'dispatches failure action', () => {
 				return uploadGravatar( 'file', 'bearerToken', 'email' )( spy )
 					.then( () => {
-						expect( spy ).to.have.been.calledWith( {
+						expect( spy ).to.have.been.calledWith( sinon.match( {
 							type: GRAVATAR_UPLOAD_REQUEST_FAILURE
-						} );
+						} ) );
 					} );
 			} );
 		} );
 	} );
 
 	describe( '#receiveGravatarImageFailed', () => {
-		it( 'returns image receive failure action with error message', () => {
-			const error = 'error';
-			const result = receiveGravatarImageFailed( error );
-			expect( result ).to.eql( {
-				type: GRAVATAR_RECEIVE_IMAGE_FAILURE,
-				errorMessage: error
+		it( 'dispatches image receive failure action with error message', () => {
+			const errorMessage = 'error';
+			const statName = 'statName';
+			const result = receiveGravatarImageFailed( {
+				errorMessage,
+				statName
 			} );
+			expect( result ).to.have.property( 'type', GRAVATAR_RECEIVE_IMAGE_FAILURE );
+			expect( result ).to.have.property( 'errorMessage', errorMessage );
+			expect( result ).to.have.property( 'meta' );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds tracking to the `EditGravatar` component, and to the new sidebar Gravatar image. Here are the events introduced with their descriptions:

Tracks:
- clicking the Gravatar button: `calypso_edit_gravatar_click` with the parameter userVerified
- receiving a file from the user (via FilePicker or DropZone): `calypso_edit_gravatar_file_receive`
- an error when getting an image from the user: `calypso_edit_gravatar_file_recieve_failure`
- starting the image upload: `calypso_edit_gravatar_upload_start`
- new Gravatar uploaded successfully: `calypso_edit_gravatar_upload_success`
- an error uploading the new Gravatar: `calypso_edit_gravatar_upload_failure`

statBump:
- errors when trying to change Gravatar using `calypso_gravatar_update_error`. Error types are:
  - `unsuccessful_http_response`
  - `bad_filetype`
  - `image_editor_error`
  - `no_bearer_token`

cc @gwwar, @Essayoh, and @travisw for a review of the new events