### PR TITLE
PostActions: Use selectors instead of site attrs

### DIFF
--- a/client/blocks/post-actions/index.jsx
+++ b/client/blocks/post-actions/index.jsx
@@ -104,6 +104,7 @@ const mapStateToProps = ( state, { site, post } ) => {
 	const siteId = get( site, 'ID' );
 	const isJetpack = isJetpackSite( state, siteId );
 
+	// TODO: Maybe add dedicated selectors for the following.
 	const showComments = ( ! isJetpack || isJetpackModuleActive( state, siteId, 'comments' ) ) &&
 		post.discussion && post.discussion.comments_open;
 	const showLikes = ! isJetpack || isJetpackModuleActive( state, siteId, 'likes' );


### PR DESCRIPTION
Rationale: The `isModuleActive()` computed attr isn't available from the `getSite` selector (and isn't probably worth adding, given that it's used in very few places). This was causing trouble with https://github.com/Automattic/wp-calypso/pull/13121.

(I plan to replace `isModuleActive` elsewhere too, but [one at a time](https://www.youtube.com/watch?v=oOS00ttAblQ).)

PostActions is this stuff:

![image](https://cloud.githubusercontent.com/assets/96308/25063554/8aa2f068-21e7-11e7-934f-b2632b5b5e1b.png)

(not the edit/view options below!)

To test:
* http://calypso.localhost:3000/posts/my
* Make sure that post actions (at the bottom of each post) still work. Try posts from a JP site!