### PR TITLE
Stats: Fix Post Details Stats

### DIFF
--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -27,7 +27,7 @@ import { getPostStat, isRequestingPostStats } from 'state/stats/posts/selectors'
 import { getSelectedSiteId } from 'state/ui/selectors';
 import Button from 'components/button';
 import WebPreview from 'components/web-preview';
-import { getSiteSlug, isJetpackSite, getSite } from 'state/sites/selectors';
+import { getSiteSlug, isJetpackSite, isSitePreviewable } from 'state/sites/selectors';
 import { getSitePost, isRequestingSitePost, getPostPreviewUrl } from 'state/posts/selectors';
 
 class StatsPostDetail extends Component {
@@ -176,7 +176,7 @@ const connectComponent = connect(
 	( state, { postId } ) => {
 		const siteId = getSelectedSiteId( state );
 		const isJetpack = isJetpackSite( state, siteId );
-		const site = getSite( state, siteId );
+		const isPreviewable = isSitePreviewable( state, siteId );
 
 		return {
 			post: getSitePost( state, siteId, postId ),
@@ -184,7 +184,7 @@ const connectComponent = connect(
 			countViews: getPostStat( state, siteId, postId, 'views' ),
 			isRequestingStats: isRequestingPostStats( state, siteId, postId ),
 			siteSlug: getSiteSlug( state, siteId ),
-			showViewLink: ! isJetpack && site.is_previewable,
+			showViewLink: ! isJetpack && isPreviewable,
 			previewUrl: getPostPreviewUrl( state, siteId, postId ),
 			siteId,
 		};


### PR DESCRIPTION
Fixes the following bug (try master):

* http://calypso.localhost:3000/posts/my
* Click on the 'eye' icon at the bottom right of any post where _there is no counter next to that eye_ (i.e. zero views yet).
* You see a message telling you that that post hasn't had any views yet.
* Click the browser's Back button
* Bug: You're not taken back to the previous page. In the console, you see

![image](https://cloud.githubusercontent.com/assets/96308/25063519/83e6610c-21e6-11e7-85e2-21d92f5df1d7.png)

The issue is that apparently, the `site` object hasn't been fetched yet on the line that checks `site.is_previewable`. Using the selector instead (which has guards against this) fixes this.

To test: Verify that this PR fixes that bug.

Per https://github.com/Automattic/wp-calypso/pull/13136#issuecomment-294290437. Props @tyxla for spotting what to fix!