### PR TITLE
Framework: Remove SitesList usage from lib/automated-transfer

### DIFF
--- a/client/lib/automated-transfer/index.js
+++ b/client/lib/automated-transfer/index.js
@@ -9,6 +9,12 @@ import config, { isEnabled } from 'config';
 import { PLAN_BUSINESS } from 'lib/plans/constants';
 import { userCan } from 'lib/site/utils';
 
+let _selectedSite;
+
+export function setSelectedSite( selectedSite ) {
+	_selectedSite = selectedSite;
+}
+
 /**
  * Returns true if Automated Transfer is enabled for the current site and current user.
  * @returns {Boolean} true if enabled for the current site and current user
@@ -19,10 +25,8 @@ export function isATEnabledForCurrentSite() {
 		return false;
 	}
 
-	const site = require( 'lib/sites-list' )().getSelectedSite();
-
 	// Site has already been transferred
-	if ( get( site, 'options.is_automated_transfer' ) ) {
+	if ( get( _selectedSite, 'options.is_automated_transfer' ) ) {
 		return true;
 	}
 
@@ -37,13 +41,13 @@ export function isATEnabledForCurrentSite() {
 	}
 
 	// Site has Business plan
-	const planSlug = get( site, 'plan.product_slug' );
+	const planSlug = get( _selectedSite, 'plan.product_slug' );
 	if ( planSlug !== PLAN_BUSINESS ) {
 		return false;
 	}
 
 	// Current User can manage site
-	const canManageSite = userCan( 'manage_options', site );
+	const canManageSite = userCan( 'manage_options', _selectedSite );
 	if ( ! canManageSite ) {
 		return false;
 	}

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -14,6 +14,7 @@ import {
 	SITES_UPDATE
 } from 'state/action-types';
 import analytics from 'lib/analytics';
+import { setSelectedSite as setAutomatedTransferSite } from 'lib/automated-transfer';
 import cartStore from 'lib/cart/store';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
@@ -48,6 +49,19 @@ const updateSelectedSiteForCart = ( dispatch, action, getState ) => {
 	cartStore.setSelectedSiteId( selectedSiteId );
 };
 
+/**
+ * Sets the selectedSite for lib/automated-transfer
+ *
+ * @param {function} dispatch - redux dispatch function
+ * @param {object}   action   - the dispatched action
+ * @param {function} getState - redux getState function
+ */
+const updateSelectedSiteForAutomatedTransfer = ( dispatch, action, getState ) => {
+	const state = getState();
+	const selectedSite = getSelectedSite( state );
+	setAutomatedTransferSite( selectedSite );
+};
+
 const handler = ( dispatch, action, getState ) => {
 	switch ( action.type ) {
 		case ANALYTICS_SUPER_PROPS_UPDATE:
@@ -60,6 +74,7 @@ const handler = ( dispatch, action, getState ) => {
 			// Wait a tick for the reducer to update the state tree
 			setTimeout( () => {
 				updateSelectedSiteForCart( dispatch, action, getState );
+				updateSelectedSiteForAutomatedTransfer( dispatch, action, getState );
 			}, 0 );
 			return;
 	}


### PR DESCRIPTION
~~Do not merge.~~ Depends on ~~#13124~~ #13154 (`update/lib-carts-sites`)

This PR removes SitesList usage from `lib/automated-transfer` and instead provides that information using Redux middleware.

### Testing Instructions
- Prep a site that has a custom domain + business plan with you as the only user
- Set the custom domain as primary
- Wait for the SSL cert
- Existing users shouldn't see any options to transfer in /plugins or /themes
- Set abtest to `enabled` for `automated-transfer2` if you match the conditions above you should be able to transfer