### PR TITLE
SidebarNavigation (My Sites): Remove sites-list dependency

### DIFF
--- a/client/my-sites/sidebar-navigation/sidebar-navigation.jsx
+++ b/client/my-sites/sidebar-navigation/sidebar-navigation.jsx
@@ -7,7 +7,6 @@ var React = require( 'react' );
  * Internal Dependencies
  */
 var SidebarNavigation = require( 'components/sidebar-navigation' ),
-	AllSitesIcon = require( 'my-sites/all-sites-icon' ),
 	SiteIcon = require( 'blocks/site-icon' ),
 	sites = require( 'lib/sites-list' )();
 
@@ -29,9 +28,7 @@ module.exports = React.createClass( {
 				linkClassName={ allSitesClass }
 				sectionName="site"
 				sectionTitle={ currentSiteTitle }>
-				{ site ?
-					<SiteIcon site={ site } /> :
-					<AllSitesIcon sites={ sites.get() } /> }
+				{ site && <SiteIcon site={ site } /> }
 			</SidebarNavigation>
 		);
 	}

--- a/client/my-sites/sidebar-navigation/sidebar-navigation.jsx
+++ b/client/my-sites/sidebar-navigation/sidebar-navigation.jsx
@@ -1,35 +1,36 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
  */
-var SidebarNavigation = require( 'components/sidebar-navigation' ),
-	SiteIcon = require( 'blocks/site-icon' ),
-	sites = require( 'lib/sites-list' )();
+import SidebarNavigation from 'components/sidebar-navigation';
+import SiteIcon from 'blocks/site-icon';
+import sitesFactory from 'lib/sites-list';
 
-module.exports = React.createClass( {
-	displayName: 'SidebarNavigation',
+const sites = sitesFactory();
 
-	render: function() {
-		var site = sites.getSelectedSite(),
-			currentSiteTitle = site.title,
-			allSitesClass;
+const MySitesSidebarNavigation = ( { translate } ) => {
+	const site = sites.getSelectedSite();
+	let currentSiteTitle = site.title,
+		allSitesClass;
 
-		if ( ! site ) {
-			currentSiteTitle = this.translate( 'All Sites' );
-			allSitesClass = 'all-sites';
-		}
-
-		return (
-			<SidebarNavigation
-				linkClassName={ allSitesClass }
-				sectionName="site"
-				sectionTitle={ currentSiteTitle }>
-				{ site && <SiteIcon site={ site } /> }
-			</SidebarNavigation>
-		);
+	if ( ! site ) {
+		currentSiteTitle = translate( 'All Sites' );
+		allSitesClass = 'all-sites';
 	}
-} );
+
+	return (
+		<SidebarNavigation
+			linkClassName={ allSitesClass }
+			sectionName="site"
+			sectionTitle={ currentSiteTitle }>
+			{ site && <SiteIcon site={ site } /> }
+		</SidebarNavigation>
+	);
+};
+
+export default localize( MySitesSidebarNavigation );

--- a/client/my-sites/sidebar-navigation/sidebar-navigation.jsx
+++ b/client/my-sites/sidebar-navigation/sidebar-navigation.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -9,18 +10,15 @@ import { localize } from 'i18n-calypso';
  */
 import SidebarNavigation from 'components/sidebar-navigation';
 import SiteIcon from 'blocks/site-icon';
-import sitesFactory from 'lib/sites-list';
+import { getSelectedSite } from 'state/ui/selectors';
 
-const sites = sitesFactory();
-
-const MySitesSidebarNavigation = ( { translate } ) => {
-	const site = sites.getSelectedSite();
-	let currentSiteTitle = site.title,
-		allSitesClass;
-
-	if ( ! site ) {
-		currentSiteTitle = translate( 'All Sites' );
+const MySitesSidebarNavigation = ( { site, translate } ) => {
+	let currentSiteTitle = translate( 'All Sites' ),
 		allSitesClass = 'all-sites';
+
+	if ( site ) {
+		currentSiteTitle = site.title;
+		allSitesClass = null;
 	}
 
 	return (
@@ -33,4 +31,8 @@ const MySitesSidebarNavigation = ( { translate } ) => {
 	);
 };
 
-export default localize( MySitesSidebarNavigation );
+export default connect(
+	( state ) => ( {
+		site: getSelectedSite( state )
+	} )
+)( localize( MySitesSidebarNavigation ) );

--- a/client/my-sites/sidebar-navigation/style.scss
+++ b/client/my-sites/sidebar-navigation/style.scss
@@ -29,10 +29,6 @@
 		margin-right: 8px;
 	}
 
-	.all-sites-icon {
-		display: none;
-	}
-
 	.gridicons-chevron-left {
 		color: $gray;
 		margin: 0 8px;


### PR DESCRIPTION
SidebarNavigation is that thing that we display on top of the sidebar on small screens:

![image](https://cloud.githubusercontent.com/assets/96308/25066303/7ed5c6ee-2222-11e7-9c7c-46075c6d9b41.png)

To test: Make sure that component still works. Site title (or 'All Sites'), section title, etc. If clicking around feels weird, compare to prod.

[This](https://github.com/Automattic/wp-calypso/pull/13140/commits/36a88faab575eecc90a9ac3c82771bef6cfc8372) was interesting. [Erm](https://github.com/Automattic/wp-calypso/blame/fcf789ebb43b7d8fe9a912d8fa82d5bee66573b5/client/my-sites/sidebar-navigation/style.scss#L35), @mtias?