### PR TITLE
[Desktop] Fix login page redirect

### DIFF
--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -42,7 +42,7 @@ export default {
 		// Check we have an OAuth token, otherwise redirect to auth/login page
 		if ( OAuthToken.getToken() === false && ! isValidSection ) {
 			if ( config( 'env_id' ) === 'desktop' ) {
-				return page( '/login' );
+				return page( config( 'login_url' ) );
 			}
 
 			return page( '/authorize' );

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -6,7 +6,7 @@
 	"i18n_default_locale_slug": "en",
 	"wpcom_user_bootstrap": false,
 	"signup_url": "/start/desktop",
-	"login_url": "/login",
+	"login_url": "/oauth-login",
 	"logout_url": "/logout",
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "/",


### PR DESCRIPTION
It seems https://github.com/Automattic/wp-calypso/pull/12690 broke the desktop build, we have an infinite redirect loop currently on the desktop login page. This PR fixes it

### Testing instructions
- from the `wp-desktop` project master branch
- `cd calypso`
- `git fetch -a`
- `git checkout release/desktop/2.4.0`
- `cd ..`
- `make distclean`
- `make run`
- Test that the login page works as expected

### Reviews
- [ ] Code
- [ ] Product