### PR TITLE
Fix typo "an other attempt" => "another attempt"

### DIFF
--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -83,7 +83,7 @@ export default React.createClass( {
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'retryingAuth' ) {
-			noticeValues.text = this.translate( 'Error authorizing. Page is refreshing for an other attempt.' );
+			noticeValues.text = this.translate( 'Error authorizing. Page is refreshing for another attempt.' );
 			noticeValues.status = 'is-warning';
 			noticeValues.icon = 'notice';
 			return noticeValues;


### PR DESCRIPTION
Fixes a small typo in Jetpack connect.

> Error authorizing. Page is refreshing for an other attempt.

becomes

> Error authorizing. Page is refreshing for another attempt.