### PR TITLE
Pages: Use siteObj as source of truth to fix homepage flicker

### DIFF
--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -228,6 +228,14 @@ SitesList.prototype.update = function( sites ) {
 				return siteObj;
 			}
 
+			// When we set a new front page, we clear out SitesList. On accounts with a large
+			// number of sites, the resulting fetch can take time resulting in incorrect data
+			// being displayed. This uses the correct siteObj as the source of truth in case
+			// of a mismatch. See #13143.
+			if ( siteObj.options.page_on_front !== site.options.page_on_front ) {
+				return siteObj;
+			}
+
 			if ( site.options.is_automated_transfer && ! siteObj.jetpack && site.jetpack ) {
 				//We have a site that was not jetpack and now is.
 				siteObj.off( 'change', this.propagateChange );


### PR DESCRIPTION
This is a proposed fix for #11815. It was a tricky one to track down since it seems to only happen intermittently and on accounts with a large number of sites. Here's a recap of the main items in the flow for setting a new front page as I understand it:

1. Triggers `setAsHomepage` in [client/my-sites/pages/page.jsx](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/pages/page.jsx#L115)
2. Dispatches `setFrontPage` action in [client/state/sites/actions.js](https://github.com/Automattic/wp-calypso/blob/master/client/state/sites/actions.js#L135). This updates the site settings.
3. Step 1 has a callback of `updateSitesList` in [client/my-sites/pages/helpers.js](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/pages/helpers.js#L31), which clears out the local storage of `SitesList`, triggers a new `fetch()` for sites, and updates the selected site.
4. To update the selected site, there's an `updateSite()` function in [client/lib/sites-list/list.js](https://github.com/Automattic/wp-calypso/blob/master/client/lib/sites-list/list.js#L529) that handles updates to the sites collection.
5. The data is then synced with the existing sites list using SitesList.prototype.sync [here](https://github.com/Automattic/wp-calypso/blob/master/client/lib/sites-list/list.js#L108).

The issue appears to pop up with accounts that have a larger collection of sites (200-300+). It happens intermittently, which leads me to believe it's a race condition of sorts with the updates and the new fetch. If the update takes some time, there's a chance you will see the correct data initially, see stale data briefly because the site options haven't updated, then see the correct data when the sites list is fully updated.

As a workaround, this PR establishes the updated siteObj as the source of truth if the `page_on_front` options don't match between our stored value `site` and our updated value used to create `siteObj`. This allows us to show the correct front page while the sites list is updating in the background.

## To test
You'll need to be on an account with a large number of sites for this to surface.

1. Start at http://calypso.localhost:3000/pages/published
2. Click the toggle and then choose a new page to "Set as Homepage"
3. To trigger this bug, it's best to do this several times in a row and then wait to see if the home icon moves back to a previous page. On WordPress.com, this will happen occasionally. It shouldn't happen on this branch.

## GIF

Here's the incorrect behavior. You can see I set Events as the front page from Welcome. That worked fine. When I then set New Page as the front page, the icon flickered back to Events. If I wait long enough, it will eventually go back to New Page (correct).

![pagebug](https://cloud.githubusercontent.com/assets/7240478/25088390/4604f3f0-2333-11e7-892c-08fa4004828b.gif)

Here's the updated flow. I switch the front page numerous times without any issue.

![fixedpagebug](https://cloud.githubusercontent.com/assets/7240478/25088463/c5cd4dc6-2333-11e7-90dc-13a95711a2e3.gif)