### PR TITLE
Make SitesList an abstract layer over `state.sites`

### DIFF
--- a/client/boot/project/wordpress-com.js
+++ b/client/boot/project/wordpress-com.js
@@ -73,6 +73,9 @@ export const configureReduxStore = ( currentUser, reduxStore ) => {
 export function setupMiddlewares( currentUser, reduxStore ) {
 	debug( 'Executing WordPress.com setup middlewares.' );
 
+	const sites = sitesFactory();
+	sites.setReduxStore( reduxStore );
+
 	analytics.setDispatch( reduxStore.dispatch );
 
 	if ( currentUser.get() ) {
@@ -219,7 +222,7 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 	reduxStore.dispatch( initializeHappychat() );
 
 	if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
-		require( 'lib/keyboard-shortcuts/global' )( sitesFactory() );
+		require( 'lib/keyboard-shortcuts/global' )( sites );
 	}
 
 	if ( config.isEnabled( 'desktop' ) ) {

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -89,15 +89,6 @@ export function items( state = {}, action ) {
 			const initialNextState = SITES_RECEIVE === action.type ? {} : state;
 
 			return reduce( sites, ( memo, site ) => {
-				// If we're not already tracking the site upon an update, don't
-				// merge into state (we only currently maintain sites which
-				// have at one point been selected in state)
-				//
-				// TODO: Consider dropping condition once sites-list abolished
-				if ( SITES_UPDATE === action.type && ! memo[ site.ID ] ) {
-					return memo;
-				}
-
 				// Bypass if site object hasn't change
 				const transformedSite = pick( site, VALID_SITE_KEYS );
 				if ( isEqual( memo[ site.ID ], transformedSite ) ) {

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -428,6 +428,22 @@ export const getSiteBySlug = createSelector(
 );
 
 /**
+ * Returns a site object by its Domain.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {String}  domain Site domain
+ * @return {?Object}       Site object
+ */
+export const getSiteByDomain = createSelector(
+	( state, domain ) => (
+		find( state.sites.items, ( item, siteId ) => (
+			getSiteDomain( state, siteId ) === domain
+		) ) || null
+	),
+	( state ) => state.sites.items
+);
+
+/**
  * Returns a site object by its URL.
  *
  * @param  {Object}  state Global state tree

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -24,6 +24,7 @@ import {
 	isSitePreviewable,
 	isRequestingSites,
 	isRequestingSite,
+	getSiteByDomain,
 	getSiteBySlug,
 	getSiteByUrl,
 	getSitePlan,
@@ -749,6 +750,34 @@ describe( 'selectors', () => {
 			}, 2916284 );
 
 			expect( isRequesting ).to.be.false;
+		} );
+	} );
+
+	describe( '#getSiteByDomain()', () => {
+		it( 'should return null if a site cannot be found', () => {
+			const site = getSiteByDomain( {
+				sites: {
+					items: {}
+				}
+			}, 'testtwosites2014.com' );
+
+			expect( site ).to.be.null;
+		} );
+
+		it( 'should return a matched site', () => {
+			const state = {
+				sites: {
+					items: {
+						77203199: {
+							ID: 77203199,
+							domain: 'testtwosites2014.com'
+						}
+					}
+				}
+			};
+			const site = getSiteByDomain( state, 'testtwosites2014.com' );
+
+			expect( site ).to.equal( state.sites.items[ 77203199 ] );
 		} );
 	} );
 


### PR DESCRIPTION
This is just an experiment to see if we can transform SitesList into an abstract layer over our sites selectors.
