### PR TITLE
Signup: Fix alignment of text on map domain step

### DIFF
--- a/client/components/domains/map-domain-step/style.scss
+++ b/client/components/domains/map-domain-step/style.scss
@@ -21,7 +21,6 @@
 
 		@include breakpoint( ">960px" ) {
 			float: right;
-			margin-top: -5px;
 			margin-bottom: 0;
 		}
 	}


### PR DESCRIPTION
Re issue #12927 
---
Removing `margin-top: -5px` appears to fix the alignment issue.

**Before**
<img width="1440" alt="screenshot-before" src="https://cloud.githubusercontent.com/assets/17498763/25093392/fb66a78a-2346-11e7-9a07-b3ed8e672f1c.png">


**After**
<img width="1440" alt="screenshot-after_alignment of text on map domain step 4-16-2017" src="https://cloud.githubusercontent.com/assets/17498763/25093402/04be0cb0-2347-11e7-9090-64c20ce7db13.png">

Both screenshots from http://calypso.localhost:3000/start/domains/mapping using Firefox 52.0.2 on Mac OS X 10.12.4.