### PR TITLE
Framework: remove siteslist usage from lib/cart ( try two )

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -231,6 +231,13 @@ function createSitesComponent( context ) {
 }
 
 module.exports = {
+
+	// Clears selected site from global redux state
+	noSite( context, next ) {
+		context.store.dispatch( setSelectedSiteId( null ) );
+		return next();
+	},
+
 	/*
 	 * Set up site selection based on last URL param and/or handle no-sites error cases
 	 */

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -235,6 +235,7 @@ module.exports = function() {
 	if ( config.isEnabled( 'upgrades/checkout' ) ) {
 		page(
 			'/checkout/thank-you/no-site/:receiptId?',
+			controller.noSite,
 			upgradesController.checkoutThankYou
 		);
 
@@ -258,6 +259,7 @@ module.exports = function() {
 
 		page(
 			'/checkout/no-site',
+			controller.noSite,
 			upgradesController.sitelessCheckout
 		);
 

--- a/client/state/lib/README.md
+++ b/client/state/lib/README.md
@@ -44,7 +44,7 @@ case MY_EXAMPLE_LIBRARY_ACTION:
 ```
 
 
-### Use Redux Middleware to setCurrentSite
+### Use Redux Middleware to setSelectedSite
 
 For libraries that are too large to port, or have too many usages, 
 we can try working around this by setting the selectedSite when

--- a/client/state/lib/README.md
+++ b/client/state/lib/README.md
@@ -1,0 +1,74 @@
+Library Middleware
+==================
+
+With the deprecation of SitesList, our `client/lib` libraries no longer 
+have easy access to the current user site. Since libraries are not react 
+components there isn't an easy way to provide access to our global 
+redux store data.
+
+When writing a library there are currently three ways around this:
+
+### Update the library interface to pass through data needs
+
+If we create a new library, or have a library with few usages, we can
+update the function interface to pass through this data. Calling components
+would then pass through that information.
+
+For example a call like:
+`library.doSomething()`
+
+Would turn into:
+`library.doSomething( currentSite )`
+
+### Use Redux Middleware to perform the library side-effect
+Similarly for a library with few usages, if we don't expect a return value from
+calling a library function this can be abstracted into a dispatched redux action,
+where the side effect is then called. The middleware handler has access to the 
+global store, so it would look something like:
+
+The component dispatches a new action
+
+```jsx
+dispatch( { type: 'MY_EXAMPLE_LIBRARY_ACTION' } );
+```
+
+And in this middleware, we can create a handler:
+```jsx
+import library from 'lib/example'
+//... 
+
+case MY_EXAMPLE_LIBRARY_ACTION:
+	const state = getState();
+	const selectedSite = getSelectedSite( state );
+	library.doSomething( selectedSite );
+```
+
+
+### Use Redux Middleware to setCurrentSite
+
+For libraries that are too large to port, or have too many usages, 
+we can try working around this by setting the selectedSite when
+sites change (eg fetches complete or user sets another site).
+
+First add a new setter function to the library, for example:
+
+```jsx
+library.setSelectedSite( selectedSite );
+```
+
+Then add a handler in this middleware:
+```jsx
+import library from 'lib/example'
+//... 
+
+//All relevant site update events
+case SELECTED_SITE_SET:
+case SITE_RECEIVE:
+case SITES_RECEIVE:
+case SITES_UPDATE:
+	const state = getState();
+	const selectedSite = getSelectedSite( state );
+	library.setSelectedSite( selectedSite );
+```
+
+

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -7,12 +7,25 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import {
-	ANALYTICS_SUPER_PROPS_UPDATE
+	ANALYTICS_SUPER_PROPS_UPDATE,
+	SELECTED_SITE_SET,
+	SITE_RECEIVE,
+	SITES_RECEIVE,
+	SITES_UPDATE,
 } from 'state/action-types';
 import analytics from 'lib/analytics';
-import { getSelectedSite } from 'state/ui/selectors';
+import cartStore from 'lib/cart/store';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 
+/**
+ * Sets the selectedSite and siteCount for lib/analytics. This is used to
+ * populate extra fields on tracks analytics calls.
+ *
+ * @param {function} dispatch - redux dispatch function
+ * @param {object}   action   - the dispatched action
+ * @param {function} getState - redux getState function
+ */
 const updateSelectedSiteForAnalytics = ( dispatch, action, getState ) => {
 	const state = getState();
 	const selectedSite = getSelectedSite( state );
@@ -22,14 +35,38 @@ const updateSelectedSiteForAnalytics = ( dispatch, action, getState ) => {
 	analytics.setSiteCount( siteCount );
 };
 
-export const handlers = {
-	[ ANALYTICS_SUPER_PROPS_UPDATE ]: updateSelectedSiteForAnalytics,
+/**
+ * Sets the selectedSiteId for lib/cart/store
+ *
+ * @param {function} dispatch - redux dispatch function
+ * @param {object}   action   - the dispatched action
+ * @param {function} getState - redux getState function
+ */
+const updateSelectedSiteForCart = ( dispatch, action, getState ) => {
+	const state = getState();
+	const selectedSiteId = getSelectedSiteId( state );
+	cartStore.setSelectedSiteId( selectedSiteId );
+};
+
+const handler = ( dispatch, action, getState ) => {
+	switch ( action.type ) {
+		case ANALYTICS_SUPER_PROPS_UPDATE:
+			return updateSelectedSiteForAnalytics( dispatch, action, getState );
+
+		case SELECTED_SITE_SET:
+		case SITE_RECEIVE:
+		case SITES_RECEIVE:
+		case SITES_UPDATE:
+			//Wait a tick for the reducer to update the state tree
+			setTimeout( () => {
+				updateSelectedSiteForCart( dispatch, action, getState );
+			}, 0 );
+			return;
+	}
 };
 
 export const libraryMiddleware = ( { dispatch, getState } ) => ( next ) => ( action ) => {
-	if ( handlers.hasOwnProperty( action.type ) ) {
-		handlers[ action.type ]( dispatch, action, getState );
-	}
+	handler( dispatch, action, getState );
 
 	return next( action );
 };

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -12,6 +12,7 @@ import {
 	SITE_RECEIVE,
 	SITES_RECEIVE,
 	SITES_UPDATE,
+	ROUTE_SET
 } from 'state/action-types';
 import analytics from 'lib/analytics';
 import cartStore from 'lib/cart/store';
@@ -57,11 +58,18 @@ const handler = ( dispatch, action, getState ) => {
 		case SITE_RECEIVE:
 		case SITES_RECEIVE:
 		case SITES_UPDATE:
-			//Wait a tick for the reducer to update the state tree
+			// Wait a tick for the reducer to update the state tree
 			setTimeout( () => {
 				updateSelectedSiteForCart( dispatch, action, getState );
 			}, 0 );
 			return;
+
+		case ROUTE_SET:
+			// Special case, no site actions are dispatched at all for no-site
+			// checkout flow
+			if ( action.path === '/checkout/no-site' ) {
+				cartStore.setSelectedSiteId( null );
+			}
 	}
 };
 

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -11,8 +11,7 @@ import {
 	SELECTED_SITE_SET,
 	SITE_RECEIVE,
 	SITES_RECEIVE,
-	SITES_UPDATE,
-	ROUTE_SET
+	SITES_UPDATE
 } from 'state/action-types';
 import analytics from 'lib/analytics';
 import cartStore from 'lib/cart/store';
@@ -63,13 +62,6 @@ const handler = ( dispatch, action, getState ) => {
 				updateSelectedSiteForCart( dispatch, action, getState );
 			}, 0 );
 			return;
-
-		case ROUTE_SET:
-			// Special case, no site actions are dispatched at all for no-site
-			// checkout flow
-			if ( action.path === '/checkout/no-site' ) {
-				cartStore.setSelectedSiteId( null );
-			}
 	}
 };
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#13153

This PR removes the SitesList usage from lib/cart and instead provides that information using redux middleware.

### Testing Instructions

* Cart Data should update as expected
* New User Purchases should work
* Existing User purchases should work
* Jetpack connect plan purchases should work.
* Site-less purchases should work
-- Navigate to http://calypso.localhost:3000/start/domain-first/site-or-domain?new=anexampledomaintopurchase.blog
-- Select "just buy a domain"
-- Checkout should load and complete