### PR TITLE
WooCommerce: Add product variation card component

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-variation-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-variation-card.js
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import i18n from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import FoldableCard from 'components/foldable-card';
+import ProductVariationTypesForm from './product-variation-types-form';
+import FormToggle from 'components/forms/form-toggle';
+
+export default class ProductFormVariationCard extends Component {
+
+	static propTypes = {
+		product: PropTypes.shape( {
+			id: PropTypes.isRequired,
+			type: PropTypes.string.isRequired,
+			name: PropTypes.string,
+		} ),
+		editProduct: PropTypes.func.isRequired,
+		editProductAttribute: PropTypes.func.isRequired,
+	};
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			isVariation: props.product && 'variable' === props.product.type ? true : false,
+		};
+
+		this.handleToggle = this.handleToggle.bind( this );
+	}
+
+	handleToggle() {
+		this.setState( ( prevState ) => ( {
+			isVariation: ! prevState.isVariation,
+		} ) );
+	}
+
+	render() {
+		const { product } = this.props;
+		const variationToggleDescription = i18n.translate(
+			'%(productName)s has variations, for example size and color.', {
+				args: {
+					productName: product && product.name || i18n.translate( 'This product' )
+				}
+			}
+		);
+
+		return (
+			<FoldableCard
+				icon=""
+				expanded={ true }
+				className="products__variation-card"
+				header={ ( <FormToggle onChange={ this.handleToggle } checked={ this.state.isVariation }>
+				{variationToggleDescription}
+				</FormToggle>
+				) }
+			>
+				{ this.state.isVariation && (
+					<ProductVariationTypesForm />
+				) }
+			</FoldableCard>
+		);
+	}
+}

--- a/client/extensions/woocommerce/app/products/product-form-variations-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-card.js
@@ -27,7 +27,7 @@ export default class ProductFormVariationCard extends Component {
 		super( props );
 
 		this.state = {
-			isVariation: props.product && 'variable' === props.product.type ? true : false,
+			isVariableProduct: props.product && 'variable' === props.product.type ? true : false,
 		};
 
 		this.handleToggle = this.handleToggle.bind( this );
@@ -35,7 +35,7 @@ export default class ProductFormVariationCard extends Component {
 
 	handleToggle() {
 		this.setState( ( prevState ) => ( {
-			isVariation: ! prevState.isVariation,
+			isVariableProduct: ! prevState.isVariableProduct,
 		} ) );
 	}
 
@@ -54,12 +54,12 @@ export default class ProductFormVariationCard extends Component {
 				icon=""
 				expanded={ true }
 				className="products__variation-card"
-				header={ ( <FormToggle onChange={ this.handleToggle } checked={ this.state.isVariation }>
-				{variationToggleDescription}
+				header={ ( <FormToggle onChange={ this.handleToggle } checked={ this.state.isVariableProduct }>
+					{ variationToggleDescription }
 				</FormToggle>
 				) }
 			>
-				{ this.state.isVariation && (
+				{ this.state.isVariableProduct && (
 					<ProductVariationTypesForm />
 				) }
 			</FoldableCard>

--- a/client/extensions/woocommerce/app/products/product-form-variations-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-card.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import i18n from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -11,7 +11,7 @@ import FoldableCard from 'components/foldable-card';
 import ProductVariationTypesForm from './product-variation-types-form';
 import FormToggle from 'components/forms/form-toggle';
 
-export default class ProductFormVariationCard extends Component {
+class ProductFormVariationCard extends Component {
 
 	static propTypes = {
 		product: PropTypes.shape( {
@@ -40,11 +40,11 @@ export default class ProductFormVariationCard extends Component {
 	}
 
 	render() {
-		const { product } = this.props;
-		const variationToggleDescription = i18n.translate(
+		const { product, translate } = this.props;
+		const variationToggleDescription = translate(
 			'%(productName)s has variations, for example size and color.', {
 				args: {
-					productName: product && product.name || i18n.translate( 'This product' )
+					productName: ( product && product.name ) || translate( 'This product' )
 				}
 			}
 		);
@@ -52,7 +52,7 @@ export default class ProductFormVariationCard extends Component {
 		return (
 			<FoldableCard
 				icon=""
-				expanded={ true }
+				expanded
 				className="products__variation-card"
 				header={ ( <FormToggle onChange={ this.handleToggle } checked={ this.state.isVariableProduct }>
 					{ variationToggleDescription }
@@ -66,3 +66,5 @@ export default class ProductFormVariationCard extends Component {
 		);
 	}
 }
+
+export default localize( ProductFormVariationCard );

--- a/client/extensions/woocommerce/app/products/product-form.js
+++ b/client/extensions/woocommerce/app/products/product-form.js
@@ -2,15 +2,12 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import FoldableCard from 'components/foldable-card';
 import ProductFormDetailsCard from './product-form-details-card';
-import ProductVariationTypesForm from './product-variation-types-form';
-import FormToggle from 'components/forms/form-toggle';
+import ProductFormVariationCard from './product-form-variation-card';
 
 export default class ProductForm extends Component {
 
@@ -24,31 +21,8 @@ export default class ProductForm extends Component {
 		editProductAttribute: PropTypes.func.isRequired,
 	};
 
-	constructor( props ) {
-		super( props );
-
-		this.state = {
-			isVariation: props.product && 'variable' === props.product.type ? true : false,
-		};
-
-		this.handleToggle = this.handleToggle.bind( this );
-	}
-
-	handleToggle() {
-		this.setState( ( prevState ) => ( {
-			isVariation: ! prevState.isVariation,
-		} ) );
-	}
-
 	render() {
 		const { product } = this.props;
-		const variationToggleDescription = i18n.translate(
-			'%(productName)s has variations, for example size and color.', {
-				args: {
-					productName: product && product.name || i18n.translate( 'This product' )
-				}
-			}
-		);
 		return (
 			<div className="woocommerce products__form">
 				<ProductFormDetailsCard
@@ -56,19 +30,11 @@ export default class ProductForm extends Component {
 					editProduct={ this.props.editProduct }
 				/>
 
-				<FoldableCard
-					icon=""
-					expanded={ true }
-					className="products__variation-card"
-					header={ ( <FormToggle onChange={ this.handleToggle } checked={ this.state.isVariation }>
-					{variationToggleDescription}
-					</FormToggle>
-					) }
-				>
-					{ this.state.isVariation && (
-						<ProductVariationTypesForm />
-					) }
-				</FoldableCard>
+				<ProductFormVariationCard
+					product={ product }
+					editProduct={ this.props.editProduct }
+					editProductAttribute={ this.props.editProductAttribute }
+				/>
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/products/product-form.js
+++ b/client/extensions/woocommerce/app/products/product-form.js
@@ -7,7 +7,7 @@ import React, { Component, PropTypes } from 'react';
  * Internal dependencies
  */
 import ProductFormDetailsCard from './product-form-details-card';
-import ProductFormVariationCard from './product-form-variation-card';
+import ProductFormVariationsCard from './product-form-variations-card';
 
 export default class ProductForm extends Component {
 
@@ -30,7 +30,7 @@ export default class ProductForm extends Component {
 					editProduct={ this.props.editProduct }
 				/>
 
-				<ProductFormVariationCard
+				<ProductFormVariationsCard
 					product={ product }
 					editProduct={ this.props.editProduct }
 					editProductAttribute={ this.props.editProductAttribute }

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -58,8 +58,8 @@
 			margin-right: 0;
 		}
 
-		.products__product-form-details-basic__description textarea{
-			resize: vertical;
+		&:last-child {
+			margin-right: 0;
 		}
 	}
 

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -13,6 +13,10 @@
 		margin-bottom: 16px;
 	}
 
+	.form-label {
+		margin-bottom: 16px;
+	}
+
 	.foldable-card.products__variation-card .foldable-card__content {
 		padding: 0;
 		border: 0;
@@ -52,6 +56,10 @@
 
 		&:last-child {
 			margin-right: 0;
+		}
+
+		.products__product-form-details-basic__description textarea{
+			resize: vertical;
 		}
 	}
 


### PR DESCRIPTION
This adds a new variation card component and moves the current product variation types form to it, so we can start implementing other parts of the variations UI and keep them contained, instead of in the root product form component.

The logic in the card is carried over directly from the existing merged code. #13158 will handle updating this to save our types to the Redux store.

To Test:

* `make run`
* Go to http://calypso.localhost:3000/store/products/add/<your site url>
* Verify that you can see the variations card and use the toggle.