### PR TITLE
EditGravatar: Update done button text

### DIFF
--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -166,6 +166,7 @@ export class EditGravatar extends Component {
 						media={ { src: this.state.image } }
 						onDone={ this.onImageEditorDone }
 						onCancel={ this.hideImageEditor }
+						doneButtonText={ this.props.translate( 'Change My Photo' ) }
 					/>
 				</Dialog>
 			);

--- a/client/blocks/image-editor/README.md
+++ b/client/blocks/image-editor/README.md
@@ -111,6 +111,15 @@ A function which will get called on clicking the "Reset" image editor button. Th
 
 String of classes (class names) appended to the image editor wrapper (`.image-editor [className]`).
 
+### `doneButtonText`
+
+<table>
+	<tr><th>Type</th><td>string</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+Already-translated string which will be used on the 'Done' button. If not used, it will default to 'Done'.
+
 ## Example
 
 ```js
@@ -124,5 +133,4 @@ render() {
 		/>
 	);
 }
-``
-
+```

--- a/client/blocks/image-editor/image-editor-buttons.jsx
+++ b/client/blocks/image-editor/image-editor-buttons.jsx
@@ -22,7 +22,8 @@ class ImageEditorButtons extends Component {
 		resetImageEditorState: PropTypes.func,
 		onDone: PropTypes.func,
 		onCancel: PropTypes.func,
-		onReset: PropTypes.func
+		onReset: PropTypes.func,
+		doneButtonText: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -31,7 +32,8 @@ class ImageEditorButtons extends Component {
 		resetImageEditorState: noop,
 		onDone: noop,
 		onCancel: noop,
-		onReset: noop
+		onReset: noop,
+		doneButtonText: '',
 	};
 
 	render() {
@@ -41,7 +43,8 @@ class ImageEditorButtons extends Component {
 			src,
 			onDone,
 			onReset,
-			translate
+			translate,
+			doneButtonText,
 		} = this.props;
 
 		return (
@@ -67,7 +70,7 @@ class ImageEditorButtons extends Component {
 					primary
 					onClick={ onDone }
 				>
-					{ translate( ' Done ' ) }
+					{ doneButtonText || translate( ' Done ' ) }
 				</Button>
 			</div>
 		);

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -240,6 +240,7 @@ const ImageEditor = React.createClass( {
 							onCancel={ this.props.onCancel && this.onCancel }
 							onDone={ this.onDone }
 							onReset={ this.onReset }
+							doneButtonText={ this.props.doneButtonText }
 						/>
 					</div>
 				</figure>


### PR DESCRIPTION
# Changes 
The text of the 'Done' button on the image editor was updated to 'Change My Photo' from 'Done'. This is to make it obvious to users that their Gravatar is about to change, upon clicking that button.

Before:

<img width="877" alt="done" src="https://cloud.githubusercontent.com/assets/11487924/25106741/2b063eae-2399-11e7-90ad-0a366b583640.png">

After:

<img width="883" alt="change-my-photo" src="https://cloud.githubusercontent.com/assets/11487924/25106745/2ddcc1c0-2399-11e7-8cf0-7b5dcadba060.png">

# Testing instructions

1. Make sure that you see the text 'Change My Photo' when editing the image.
2. Make sure other places `<ImageEditor />` is used still has the 'Done' text by editing an image in your media library at `http://calypso.localhost:3000/media/yoursite.wordpress.com`