### PR TITLE
[Remove SitesList] Add isSiteCustomizable selector

### DIFF
--- a/client/lib/site/computed-attributes.js
+++ b/client/lib/site/computed-attributes.js
@@ -49,11 +49,5 @@ export default function( site ) {
 		isHttps( attributes.options.unmapped_url )
 	);
 
-	//TODO:(ehg) Replace instances with canCurrentUser selector when my-sites/sidebar is connected
-	attributes.is_customizable = !! (
-		site.capabilities &&
-		site.capabilities.edit_theme_options
-	);
-
 	return attributes;
 }

--- a/client/lib/site/index.js
+++ b/client/lib/site/index.js
@@ -218,8 +218,4 @@ Site.prototype.isUpgradeable = function() {
 	return this.capabilities && this.capabilities.manage_options;
 };
 
-Site.prototype.isCustomizable = function() {
-	return !! ( this.capabilities && this.capabilities.edit_theme_options );
-};
-
 module.exports = Site;

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -139,6 +139,7 @@ export isSendingBillingReceiptEmail from './is-sending-billing-receipt-email';
 export isSharingButtonsSaveSuccessful from './is-sharing-buttons-save-successful';
 export isSiteAutomatedTransfer from './is-site-automated-transfer';
 export isSiteBlocked from './is-site-blocked';
+export isSiteCustomizable from './is-site-customizable';
 export isSiteOnFreePlan from './is-site-on-free-plan';
 export isSiteSupportingImageEditor from './is-site-supporting-image-editor';
 export isSiteUpgradeable from './is-site-upgradeable';

--- a/client/state/selectors/is-site-customizable.js
+++ b/client/state/selectors/is-site-customizable.js
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies
+ */
+import { canCurrentUser } from 'state/selectors';
+import { getCurrentUserId } from 'state/current-user/selectors';
+import { getRawSite } from 'state/sites/selectors';
+
+/**
+ * Returns true if the site can be customized by the user, false if the
+ * site cannot be customized, or null if customizing ability cannot be
+ * determined.
+ *
+ * @param  {Object}   state  Global state tree
+ * @param  {Number}   siteId Site ID
+ * @return {?Boolean}        Whether site is customizable
+ */
+export default function isSiteCustomizable( state, siteId ) {
+	// Cannot determine site customizing ability if there is no current user
+	if ( ! getCurrentUserId( state ) || ! getRawSite( state, siteId ) ) {
+		return null;
+	}
+
+	return canCurrentUser( state, siteId, 'edit_theme_options' );
+}

--- a/client/state/selectors/test/get-visible-sites.js
+++ b/client/state/selectors/test/get-visible-sites.js
@@ -55,7 +55,7 @@ describe( 'getVisibleSites()', () => {
 				domain: 'example.com',
 				slug: 'example.com',
 				hasConflict: false,
-				is_customizable: false,
+				is_customizable: null,
 				is_previewable: false,
 				options: {
 					default_post_format: 'standard',

--- a/client/state/selectors/test/get-visible-sites.js
+++ b/client/state/selectors/test/get-visible-sites.js
@@ -55,7 +55,6 @@ describe( 'getVisibleSites()', () => {
 				domain: 'example.com',
 				slug: 'example.com',
 				hasConflict: false,
-				is_customizable: null,
 				is_previewable: false,
 				options: {
 					default_post_format: 'standard',

--- a/client/state/selectors/test/is-site-customizable.js
+++ b/client/state/selectors/test/is-site-customizable.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isSiteCustomizable } from '../';
+
+describe( 'isSiteCustomizable()', () => {
+	it( 'should return null if the capability is not set for the current user', () => {
+		const isCustomizable = isSiteCustomizable( {
+			sites: {
+				items: {
+					77203199: {
+						ID: 77203199,
+						URL: 'https://example.com'
+					}
+				}
+			},
+			currentUser: {
+				id: 12345678,
+				capabilities: {
+					77203199: {}
+				}
+			}
+		}, 77203199 );
+
+		expect( isCustomizable ).to.be.null;
+	} );
+
+	it( 'should return true is the corresponding user capability is true for this site', () => {
+		const isCustomizable = isSiteCustomizable( {
+			sites: {
+				items: {
+					77203199: {
+						ID: 77203199,
+						URL: 'http://example.com',
+						options: {
+							unmapped_url: 'http://example.com'
+						}
+					}
+				}
+			},
+			currentUser: {
+				id: 12345678,
+				capabilities: {
+					77203199: {
+						edit_theme_options: true
+					}
+				}
+			}
+		}, 77203199 );
+
+		expect( isCustomizable ).to.be.true;
+	} );
+} );

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -70,7 +70,8 @@ export const getSite = createSelector(
 			title: getSiteTitle( state, siteId ),
 			slug: getSiteSlug( state, siteId ),
 			domain: getSiteDomain( state, siteId ),
-			is_previewable: isSitePreviewable( state, siteId )
+			is_previewable: isSitePreviewable( state, siteId ),
+			is_customizable: isSiteCustomizable( state, siteId )
 		};
 	},
 	( state ) => state.sites.items
@@ -86,7 +87,7 @@ export function getComputedAttributes( state, siteId ) {
 
 	// The 'standard' post format is saved as an option of '0'
 	let defaultPostFormat = getSiteOption( state, siteId, 'default_post_format' );
-	if ( defaultPostFormat === null || defaultPostFormat === '0' ) {
+	if ( defaultPostFormat == null || defaultPostFormat === '0' ) {
 		defaultPostFormat = 'standard';
 	}
 
@@ -94,12 +95,10 @@ export function getComputedAttributes( state, siteId ) {
 		title: trim( site.name ) || domain,
 		slug,
 		domain: isRedirectOrConflicting ? slug : domain,
-		options: Object.assign( site.options, {
+		options: Object.assign( site.options || {}, {
 			...isWpcomMappedDomain && { wpcom_url: wpcomUrl },
 			default_post_format: defaultPostFormat
-		} ),
-		is_previewable: isSitePreviewable( state, siteId ),
-		is_customizable: canCurrentUser( state, siteId, 'edit_theme_options' )
+		} )
 	};
 }
 
@@ -310,6 +309,19 @@ export function isSitePreviewable( state, siteId ) {
 
 	const unmappedUrl = getSiteOption( state, siteId, 'unmapped_url' );
 	return !! unmappedUrl && isHttps( unmappedUrl );
+}
+
+/**
+ * Returns true if the site can be customized by the user, false if the
+ * site cannot be customized, or null if customizing ability cannot be
+ * determined.
+ *
+ * @param  {Object}   state  Global state tree
+ * @param  {Number}   siteId Site ID
+ * @return {?Boolean}        Whether site is customizable
+ */
+export function isSiteCustomizable( state, siteId ) {
+	return state.currentUser ? canCurrentUser( state, siteId, 'edit_theme_options' ) : false;
 }
 
 /**

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -68,13 +68,13 @@ export const getSite = createSelector(
 			slug: getSiteSlug( state, siteId ),
 			domain: getSiteDomain( state, siteId ),
 			is_previewable: isSitePreviewable( state, siteId ),
-			options: getSiteOptions( state, siteId ),
+			options: computeSiteOptions( state, siteId ),
 		};
 	},
 	( state ) => state.sites.items
 );
 
-export function getSiteOptions( state, siteId ) {
+export function computeSiteOptions( state, siteId ) {
 	const site = getRawSite( state, siteId );
 	if ( ! site ) {
 		return null;

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -31,7 +31,7 @@ import createSelector from 'lib/create-selector';
 import { fromApi as seoTitleFromApi } from 'components/seo/meta-title-editor/mappings';
 import versionCompare from 'lib/version-compare';
 import { getCustomizerFocus } from 'my-sites/customize/panels';
-import canCurrentUser from 'state/selectors/can-current-user';
+import { isSiteCustomizable } from 'state/selectors';
 
 /**
  * Returns a raw site object by its ID.
@@ -305,24 +305,6 @@ export function isSitePreviewable( state, siteId ) {
 
 	const unmappedUrl = getSiteOption( state, siteId, 'unmapped_url' );
 	return !! unmappedUrl && isHttps( unmappedUrl );
-}
-
-/**
- * Returns true if the site can be customized by the user, false if the
- * site cannot be customized, or null if customizing ability cannot be
- * determined.
- *
- * @param  {Object}   state  Global state tree
- * @param  {Number}   siteId Site ID
- * @return {?Boolean}        Whether site is customizable
- */
-export function isSiteCustomizable( state, siteId ) {
-	// Cannot determine site customizing ability if there is no current user
-	if ( ! state.currentUser ) {
-		return null;
-	}
-
-	return canCurrentUser( state, siteId, 'edit_theme_options' );
 }
 
 /**

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -15,7 +15,6 @@ import {
 	split,
 	includes,
 	startsWith,
-	trim
 } from 'lodash';
 import i18n from 'i18n-calypso';
 
@@ -64,41 +63,38 @@ export const getSite = createSelector(
 
 		return {
 			...site,
-			...getComputedAttributes( state, siteId ),
 			...getJetpackComputedAttributes( state, siteId ),
 			hasConflict: isSiteConflicting( state, siteId ),
 			title: getSiteTitle( state, siteId ),
 			slug: getSiteSlug( state, siteId ),
 			domain: getSiteDomain( state, siteId ),
 			is_previewable: isSitePreviewable( state, siteId ),
-			is_customizable: isSiteCustomizable( state, siteId )
+			is_customizable: isSiteCustomizable( state, siteId ),
+			options: getSiteOptions( state, siteId ),
 		};
 	},
 	( state ) => state.sites.items
 );
 
-export function getComputedAttributes( state, siteId ) {
+export function getSiteOptions( state, siteId ) {
 	const site = getRawSite( state, siteId );
-	const domain = site.URL && withoutHttp( site.URL );
-	const isRedirectOrConflicting = getSiteOption( state, siteId, 'is_redirect' ) || isSiteConflicting( state, siteId );
+	if ( ! site ) {
+		return null;
+	}
+
 	const isWpcomMappedDomain = getSiteOption( state, siteId, 'is_mapped_domain' ) && ! isJetpackSite( state, siteId );
 	const wpcomUrl = withoutHttp( getSiteOption( state, siteId, 'unmapped_url' ) );
-	const slug = isRedirectOrConflicting ? wpcomUrl : ( domain && domain.replace( /\//g, '::' ) );
 
 	// The 'standard' post format is saved as an option of '0'
 	let defaultPostFormat = getSiteOption( state, siteId, 'default_post_format' );
-	if ( defaultPostFormat == null || defaultPostFormat === '0' ) {
+	if ( ! defaultPostFormat || defaultPostFormat === '0' ) {
 		defaultPostFormat = 'standard';
 	}
 
 	return {
-		title: trim( site.name ) || domain,
-		slug,
-		domain: isRedirectOrConflicting ? slug : domain,
-		options: Object.assign( site.options || {}, {
-			...isWpcomMappedDomain && { wpcom_url: wpcomUrl },
-			default_post_format: defaultPostFormat
-		} )
+		...site.options,
+		...isWpcomMappedDomain && { wpcom_url: wpcomUrl },
+		default_post_format: defaultPostFormat
 	};
 }
 
@@ -321,7 +317,12 @@ export function isSitePreviewable( state, siteId ) {
  * @return {?Boolean}        Whether site is customizable
  */
 export function isSiteCustomizable( state, siteId ) {
-	return state.currentUser ? canCurrentUser( state, siteId, 'edit_theme_options' ) : false;
+	// Cannot determine site customizing ability if there is no current user
+	if ( ! state.currentUser ) {
+		return null;
+	}
+
+	return canCurrentUser( state, siteId, 'edit_theme_options' );
 }
 
 /**

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -31,7 +31,6 @@ import createSelector from 'lib/create-selector';
 import { fromApi as seoTitleFromApi } from 'components/seo/meta-title-editor/mappings';
 import versionCompare from 'lib/version-compare';
 import { getCustomizerFocus } from 'my-sites/customize/panels';
-import { isSiteCustomizable } from 'state/selectors';
 
 /**
  * Returns a raw site object by its ID.
@@ -69,7 +68,6 @@ export const getSite = createSelector(
 			slug: getSiteSlug( state, siteId ),
 			domain: getSiteDomain( state, siteId ),
 			is_previewable: isSitePreviewable( state, siteId ),
-			is_customizable: isSiteCustomizable( state, siteId ),
 			options: getSiteOptions( state, siteId ),
 		};
 	},

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -23,6 +23,7 @@ import {
 	getSiteTitle,
 	getSiteThemeShowcasePath,
 	isSitePreviewable,
+	isSiteCustomizable,
 	isRequestingSites,
 	isRequestingSite,
 	getSiteBySlug,
@@ -750,6 +751,53 @@ describe( 'selectors', () => {
 
 				expect( isPreviewable ).to.be.true;
 			} );
+		} );
+	} );
+
+	describe( 'isSiteCustomizable()', () => {
+		it( 'should return null if the capability is not set for the current user', () => {
+			const isCustomizable = isSiteCustomizable( {
+				sites: {
+					items: {
+						77203199: {
+							ID: 77203199,
+							URL: 'https://example.com'
+						}
+					}
+				},
+				currentUser: {
+					capabilities: {
+						77203199: {}
+					}
+				}
+			}, 77203199 );
+
+			expect( isCustomizable ).to.be.null;
+		} );
+
+		it( 'should return true is the corresponding user capability is true for this site', () => {
+			const isCustomizable = isSiteCustomizable( {
+				sites: {
+					items: {
+						77203199: {
+							ID: 77203199,
+							URL: 'http://example.com',
+							options: {
+								unmapped_url: 'http://example.com'
+							}
+						}
+					}
+				},
+				currentUser: {
+					capabilities: {
+						77203199: {
+							edit_theme_options: true
+						}
+					}
+				}
+			}, 77203199 );
+
+			expect( isCustomizable ).to.be.true;
 		} );
 	} );
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -11,6 +11,7 @@ import config from 'config';
 import { useSandbox } from 'test/helpers/use-sinon';
 import {
 	getSite,
+	getSiteOptions,
 	getSiteCollisions,
 	isSiteConflicting,
 	isSingleUserSite,
@@ -110,6 +111,64 @@ describe( 'selectors', () => {
 					default_post_format: 'standard',
 					unmapped_url: 'https://example.wordpress.com'
 				}
+			} );
+		} );
+	} );
+
+	describe( '#getSiteOptions()', () => {
+		it( 'should return null if the site is not known', () => {
+			const siteOptions = getSiteOptions( {
+				sites: {
+					items: {}
+				}
+			}, 2916284 );
+
+			expect( siteOptions ).to.be.null;
+		} );
+
+		it( 'should return a the site options along with the computed option wpcom_url', () => {
+			const siteOptions = getSiteOptions( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.com',
+							options: {
+								unmapped_url: 'https://example.wordpress.com',
+								is_mapped_domain: true
+							}
+						}
+					}
+				}
+			}, 2916284 );
+
+			expect( siteOptions ).to.eql( {
+				default_post_format: 'standard',
+				unmapped_url: 'https://example.wordpress.com',
+				is_mapped_domain: true,
+				wpcom_url: 'example.wordpress.com'
+			} );
+		} );
+
+		it( 'should fix `default_post_format` if it is equal to \'0\'', () => {
+			const siteOptions = getSiteOptions( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.com',
+							options: {
+								default_post_format: '0',
+								unmapped_url: 'https://example.wordpress.com'
+							}
+						}
+					}
+				}
+			}, 2916284 );
+
+			expect( siteOptions ).to.eql( {
+				default_post_format: 'standard',
+				unmapped_url: 'https://example.wordpress.com'
 			} );
 		} );
 	} );

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -104,7 +104,7 @@ describe( 'selectors', () => {
 				domain: 'example.com',
 				slug: 'example.com',
 				hasConflict: false,
-				is_customizable: false,
+				is_customizable: null,
 				is_previewable: true,
 				options: {
 					default_post_format: 'standard',

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -105,7 +105,6 @@ describe( 'selectors', () => {
 				domain: 'example.com',
 				slug: 'example.com',
 				hasConflict: false,
-				is_customizable: null,
 				is_previewable: true,
 				options: {
 					default_post_format: 'standard',

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -11,7 +11,7 @@ import config from 'config';
 import { useSandbox } from 'test/helpers/use-sinon';
 import {
 	getSite,
-	getSiteOptions,
+	computeSiteOptions,
 	getSiteCollisions,
 	isSiteConflicting,
 	isSingleUserSite,
@@ -114,9 +114,9 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( '#getSiteOptions()', () => {
+	describe( '#computeSiteOptions()', () => {
 		it( 'should return null if the site is not known', () => {
-			const siteOptions = getSiteOptions( {
+			const siteOptions = computeSiteOptions( {
 				sites: {
 					items: {}
 				}
@@ -126,7 +126,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should return a the site options along with the computed option wpcom_url', () => {
-			const siteOptions = getSiteOptions( {
+			const siteOptions = computeSiteOptions( {
 				sites: {
 					items: {
 						2916284: {
@@ -150,7 +150,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should fix `default_post_format` if it is equal to \'0\'', () => {
-			const siteOptions = getSiteOptions( {
+			const siteOptions = computeSiteOptions( {
 				sites: {
 					items: {
 						2916284: {

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -23,7 +23,6 @@ import {
 	getSiteTitle,
 	getSiteThemeShowcasePath,
 	isSitePreviewable,
-	isSiteCustomizable,
 	isRequestingSites,
 	isRequestingSite,
 	getSiteBySlug,
@@ -751,53 +750,6 @@ describe( 'selectors', () => {
 
 				expect( isPreviewable ).to.be.true;
 			} );
-		} );
-	} );
-
-	describe( 'isSiteCustomizable()', () => {
-		it( 'should return null if the capability is not set for the current user', () => {
-			const isCustomizable = isSiteCustomizable( {
-				sites: {
-					items: {
-						77203199: {
-							ID: 77203199,
-							URL: 'https://example.com'
-						}
-					}
-				},
-				currentUser: {
-					capabilities: {
-						77203199: {}
-					}
-				}
-			}, 77203199 );
-
-			expect( isCustomizable ).to.be.null;
-		} );
-
-		it( 'should return true is the corresponding user capability is true for this site', () => {
-			const isCustomizable = isSiteCustomizable( {
-				sites: {
-					items: {
-						77203199: {
-							ID: 77203199,
-							URL: 'http://example.com',
-							options: {
-								unmapped_url: 'http://example.com'
-							}
-						}
-					}
-				},
-				currentUser: {
-					capabilities: {
-						77203199: {
-							edit_theme_options: true
-						}
-					}
-				}
-			}, 77203199 );
-
-			expect( isCustomizable ).to.be.true;
 		} );
 	} );
 

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -12,7 +12,7 @@ import {
 } from 'state/ui/selectors';
 import { getLastAction } from 'state/ui/action-log/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
-import { canCurrentUser } from 'state/selectors';
+import { canCurrentUser, isSiteCustomizable } from 'state/selectors';
 import {
 	hasDefaultSiteTitle,
 	isCurrentPlanPaid,
@@ -122,7 +122,7 @@ export const isSelectedSitePreviewable = state =>
  * @return {Boolean} True if user can run customizer, false otherwise.
  */
 export const isSelectedSiteCustomizable = state =>
-	getSelectedSite( state ) && getSelectedSite( state ).is_customizable;
+	isSiteCustomizable( state, getSelectedSiteId( state ) );
 
 /**
  * Returns a selector that tests whether an A/B test is in a given variant.

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -48,7 +48,7 @@ describe( 'selectors', () => {
 				URL: 'https://example.com',
 				domain: 'example.com',
 				hasConflict: false,
-				is_customizable: false,
+				is_customizable: null,
 				is_previewable: false,
 				options: {
 					default_post_format: 'standard',

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -48,7 +48,6 @@ describe( 'selectors', () => {
 				URL: 'https://example.com',
 				domain: 'example.com',
 				hasConflict: false,
-				is_customizable: null,
 				is_previewable: false,
 				options: {
 					default_post_format: 'standard',


### PR DESCRIPTION
This PR creates the `isSiteCustomizable()` selector and update the `getSite` selector to use it instead of using `getComputedAttribute`. It also updates usages of `isCustomizable()` in components so we can remove `Sites#isCustomizable()` as well as the computed attribute `site.is_customizable`.

### Testing Instructions
- Checkout the branch locally
- Run the tests (`make test`)
- Run the app and check that you don't have access to Themes in the left sidebar when you don't have the permissions.
