### PR TITLE
Framework: remove sites-list from people section

### DIFF
--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -21,9 +21,7 @@ import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import config from 'config';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import {
-	isJetpackSite,
-} from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 
 export default {
 	redirectToTeam,

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -10,13 +10,10 @@ import i18n from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import sitesList from 'lib/sites-list';
 import PeopleList from './main';
 import EditTeamMember from './edit-team-member-form';
 import analytics from 'lib/analytics';
 import titlecase from 'to-title-case';
-import UsersStore from 'lib/users/store';
-import UsersActions from 'lib/users/actions';
 import PeopleLogStore from 'lib/people/log-store';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import InvitePeople from './invite-people';
@@ -24,11 +21,7 @@ import { renderWithReduxStore } from 'lib/react-helpers';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import config from 'config';
-
-/**
- * Module variables
- */
-const sites = sitesList();
+import { getSelectedSite } from 'state/ui/selectors';
 
 export default {
 	redirectToTeam,
@@ -70,7 +63,6 @@ function renderPeopleList( filter, context ) {
 
 	renderWithReduxStore(
 		React.createElement( PeopleList, {
-			sites: sites,
 			peopleLog: PeopleLogStore,
 			filter: filter,
 			search: context.query.s
@@ -82,15 +74,12 @@ function renderPeopleList( filter, context ) {
 }
 
 function renderInvitePeople( context ) {
-	const site = sites.getSelectedSite();
+	const state = context.store.getState();
+	const site = getSelectedSite( state );
 	const isJetpack = get( site, 'jetpack' );
 
-	if ( ! sites.initialized ) {
-		sites.once( 'change', () => page( context.path ) );
-	}
-
 	if ( isJetpack && ! config.isEnabled( 'jetpack/invites' ) ) {
-		const currentLayoutFocus = getCurrentLayoutFocus( context.store.getState() );
+		const currentLayoutFocus = getCurrentLayoutFocus( state );
 		context.store.dispatch( setNextLayoutFocus( currentLayoutFocus ) );
 		page.redirect( '/people/team/' + site.slug );
 		analytics.tracks.recordEvent( 'calypso_invite_people_controller_redirect_to_team' );
@@ -108,47 +97,11 @@ function renderInvitePeople( context ) {
 }
 
 function renderSingleTeamMember( context ) {
-	let site,
-		siteId,
-		user,
-		userLogin = context.params.user_login;
-
-	if ( ! sites.initialized ) {
-		sites.once( 'change', () => page( context.path ) );
-	}
-
-	site = sites.getSelectedSite();
-	siteId = site && site.ID ? site.ID : 0;
-
 	context.store.dispatch( setTitle( i18n.translate( 'View Team Member', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-
-	if ( siteId && 0 !== siteId ) {
-		user = UsersStore.getUserByLogin( siteId, userLogin );
-
-		if ( ! user ) {
-			UsersActions.fetchUser( { siteId: siteId }, userLogin );
-			PeopleLogStore.once( 'change', function() {
-				let fetchUserError = PeopleLogStore.getErrors(
-					log => siteId === log.siteId && 'RECEIVE_USER_FAILED' === log.action && userLogin === log.user
-				);
-				if ( fetchUserError.length ) {
-					const currentLayoutFocus = getCurrentLayoutFocus( context.store.getState() );
-					context.store.dispatch( setNextLayoutFocus( currentLayoutFocus ) );
-					page.redirect( '/people/team/' + site.slug );
-				}
-			} );
-		} else {
-			analytics.pageView.record( 'people/edit/:user_login/:site', 'View Team Member' );
-		}
-	}
 
 	renderWithReduxStore(
 		React.createElement( EditTeamMember, {
-			siteSlug: site && site.slug ? site.slug : undefined,
-			siteId: site && site.ID ? site.ID : undefined,
-			isJetpack: site && site.jetpack,
-			isMultisite: site && site.is_multisite,
-			userLogin: userLogin,
+			userLogin: context.params.user_login,
 			prevPath: context.prevPath
 		} ),
 		document.getElementById( 'primary' ),

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -4,7 +4,6 @@
 import React from 'react';
 import page from 'page';
 import route from 'lib/route';
-import get from 'lodash/get';
 import i18n from 'i18n-calypso';
 
 /**
@@ -21,7 +20,10 @@ import { renderWithReduxStore } from 'lib/react-helpers';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import config from 'config';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import {
+	isJetpackSite,
+} from 'state/sites/selectors';
 
 export default {
 	redirectToTeam,
@@ -75,13 +77,15 @@ function renderPeopleList( filter, context ) {
 
 function renderInvitePeople( context ) {
 	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
 	const site = getSelectedSite( state );
-	const isJetpack = get( site, 'jetpack' );
+	const siteSlug = getSelectedSiteSlug( state );
+	const isJetpack = isJetpackSite( state, siteId );
 
 	if ( isJetpack && ! config.isEnabled( 'jetpack/invites' ) ) {
 		const currentLayoutFocus = getCurrentLayoutFocus( state );
 		context.store.dispatch( setNextLayoutFocus( currentLayoutFocus ) );
-		page.redirect( '/people/team/' + site.slug );
+		page.redirect( '/people/team/' + siteSlug );
 		analytics.tracks.recordEvent( 'calypso_invite_people_controller_redirect_to_team' );
 	}
 

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -29,11 +29,11 @@ const DeleteUser = React.createClass( {
 	mixins: [ PureRenderMixin ],
 
 	propTypes: {
-		isMultisite: React.PropTypes.bool.isRequired,
-		isJetpack: React.PropTypes.bool.isRequired,
-		siteId: React.PropTypes.number.isRequired,
-		user: React.PropTypes.object.isRequired,
-		currentUser: React.PropTypes.object.isRequired,
+		isMultisite: React.PropTypes.bool,
+		isJetpack: React.PropTypes.bool,
+		siteId: React.PropTypes.number,
+		user: React.PropTypes.object,
+		currentUser: React.PropTypes.object,
 	},
 
 	getInitialState: function() {

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -32,10 +32,13 @@ import PeopleNotices from 'my-sites/people/people-notices';
 import PeopleLog from 'lib/people/log-store';
 import analytics from 'lib/analytics';
 import RoleSelect from 'my-sites/people/role-select';
-import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
-import { getSiteSlug } from 'state/sites/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import PeopleLogStore from 'lib/people/log-store';
+import {
+	isJetpackSiteMultiSite,
+	isJetpackSite,
+} from 'state/sites/selectors';
 
 /**
  * Module Variables
@@ -388,13 +391,12 @@ export class EditTeamMemberForm extends Component {
 export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
-		const site = getSelectedSite( state );
 
 		return {
 			siteId,
-			siteSlug: getSiteSlug( state, siteId ),
-			isJetpack: site && site.jetpack,
-			isMultisite: site && site.is_multisite,
+			siteSlug: getSelectedSiteSlug( state ),
+			isJetpack: isJetpackSite( state, siteId ),
+			isMultisite: isJetpackSiteMultiSite( state, siteId ),
 		};
 	}
 )( protectForm( EditTeamMemberForm ) );

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -249,7 +249,6 @@ export class EditTeamMemberForm extends Component {
 		this.state = {
 			user: UsersStore.getUserByLogin( props.siteId, props.userLogin ),
 			removingUser: false,
-			requestedUser: false
 		};
 	}
 

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -253,14 +253,11 @@ export class EditTeamMemberForm extends Component {
 		};
 	}
 
-	componentWillMount() {
-		this.refreshUser();
-	}
-
 	componentDidMount() {
 		UsersStore.on( 'change', this.refreshUser );
 		PeopleLog.on( 'change', this.checkRemoveUser );
 		PeopleLog.on( 'change', this.redirectIfError );
+		this.requestUser();
 	}
 
 	componentWillUnmount() {
@@ -269,25 +266,29 @@ export class EditTeamMemberForm extends Component {
 		PeopleLog.removeListener( 'change', this.redirectIfError );
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		this.refreshUser( nextProps );
+	componentDidUpdate( lastProps ) {
+		if ( lastProps.siteId !== this.props.siteId || lastProps.userLogin !== this.props.userLogin ) {
+			this.requestUser();
+		}
 	}
 
-	refreshUser = ( nextProps ) => {
-		const siteId = nextProps && nextProps.siteId ? nextProps.siteId : this.props.siteId;
-
-		const peopleUser = UsersStore.getUserByLogin( siteId, this.props.userLogin );
-
-		let requestedUser = this.state.requestedUser;
-
-		if ( ! peopleUser && siteId && ! requestedUser ) {
-			UsersActions.fetchUser( { siteId }, this.props.userLogin );
-			requestedUser = true;
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.siteId !== this.props.siteId || nextProps.userLogin !== this.props.userLogin ) {
+			this.refreshUser( nextProps );
 		}
+	}
+
+	requestUser = () => {
+		if ( this.props.siteId ) {
+			UsersActions.fetchUser( { siteId: this.props.siteId }, this.props.userLogin );
+		}
+	};
+
+	refreshUser = ( props = this.props ) => {
+		const peopleUser = UsersStore.getUserByLogin( props.siteId, props.userLogin );
 
 		this.setState( {
-			user: peopleUser,
-			requestedUser
+			user: peopleUser
 		} );
 	};
 

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -37,6 +37,7 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import EmptyContent from 'components/empty-content';
 import { userCan } from 'lib/site/utils';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
  * Module variables
@@ -127,7 +128,7 @@ const InvitePeople = React.createClass( {
 			success: filteredSuccess,
 			errorToDisplay: includes( filteredTokens, errorToDisplay ) && errorToDisplay
 		} );
-		createInviteValidation( this.props.site.ID, filteredTokens, role );
+		createInviteValidation( this.props.siteId, filteredTokens, role );
 
 		if ( filteredTokens.length > usernamesOrEmails.length ) {
 			analytics.tracks.recordEvent( 'calypso_invite_people_token_added' );
@@ -143,7 +144,7 @@ const InvitePeople = React.createClass( {
 	onRoleChange( event ) {
 		const role = event.target.value;
 		this.setState( { role } );
-		createInviteValidation( this.props.site.ID, this.state.usernamesOrEmails, role );
+		createInviteValidation( this.props.siteId, this.state.usernamesOrEmails, role );
 	},
 
 	onFocusTokenField() {
@@ -167,8 +168,8 @@ const InvitePeople = React.createClass( {
 	},
 
 	refreshValidation() {
-		const errors = InvitesCreateValidationStore.getErrors( this.props.site.ID, this.state.role ) || {},
-			success = InvitesCreateValidationStore.getSuccess( this.props.site.ID, this.state.role ) || [],
+		const errors = InvitesCreateValidationStore.getErrors( this.props.siteId, this.state.role ) || {},
+			success = InvitesCreateValidationStore.getSuccess( this.props.siteId, this.state.role ) || [],
 			errorsKeys = Object.keys( errors ),
 			errorToDisplay = this.state.errorToDisplay || ( errorsKeys.length > 0 && errorsKeys[ 0 ] );
 
@@ -229,7 +230,7 @@ const InvitePeople = React.createClass( {
 
 		this.setState( { sendingInvites: true, formId } );
 		this.props.sendInvites(
-			this.props.site.ID,
+			this.props.siteId,
 			usernamesOrEmails,
 			role,
 			message,
@@ -344,7 +345,7 @@ const InvitePeople = React.createClass( {
 								id="role"
 								name="role"
 								includeFollower
-								siteId={ this.props.site.ID }
+								siteId={ this.props.siteId }
 								onChange={ this.onRoleChange }
 								onFocus={ this.onFocusRoleSelect }
 								value={ this.state.role }
@@ -390,6 +391,8 @@ const InvitePeople = React.createClass( {
 } );
 
 export default connect(
-	null,
+	( state ) => ( {
+		siteId: getSelectedSiteId( state )
+	} ),
 	dispatch => bindActionCreators( { sendInvites }, dispatch )
 )( InvitePeople );

--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import omit from 'lodash/omit';
 import debugModule from 'debug';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -18,17 +19,19 @@ import PeopleNotices from 'my-sites/people/people-notices';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import PeopleSectionNav from 'my-sites/people/people-section-nav';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import { getSelectedSite } from 'state/ui/selectors';
 
 /**
  * Module variables
  */
 const debug = debugModule( 'calypso:my-sites:people:main' );
 
-export default React.createClass( {
+// TODO: port to es6 once we remove the last observe
+export const People = React.createClass( { // eslint-disable-line react/prefer-es6-class
 
 	displayName: 'People',
 
-	mixins: [ observe( 'sites', 'peopleLog' ) ],
+	mixins: [ observe( 'peopleLog' ) ],
 
 	componentDidMount: function() {
 		debug( 'PeopleList React component mounted.' );
@@ -54,7 +57,7 @@ export default React.createClass( {
 	},
 
 	render: function() {
-		const site = this.props.sites.getSelectedSite();
+		const site = this.props.selectedSite;
 
 		// Jetpack 3.7 is necessary to manage people
 		if ( site && site.jetpack && site.versionCompare( '3.7.0-beta', '<' ) ) {
@@ -92,3 +95,9 @@ export default React.createClass( {
 		);
 	}
 } );
+
+export default connect(
+	( state ) => ( {
+		selectedSite: getSelectedSite( state )
+	} )
+)( People );

--- a/client/my-sites/people/people-section-nav/index.jsx
+++ b/client/my-sites/people/people-section-nav/index.jsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	config = require( 'config' ),
-	find = require( 'lodash/find' ),
-	includes = require( 'lodash/includes' );
+import React, { Component } from 'react';
+import config from 'config';
+import { find, get, includes } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -53,11 +53,13 @@ let PeopleNavTabs = React.createClass( {
 	}
 } );
 
-module.exports = React.createClass( {
+class PeopleSectionNav extends Component {
 
-	displayName: 'PeopleSectionNav',
+	canSearch() {
+		if ( ! this.props.site ) {
+			return false;
+		}
 
-	canSearch: function() {
 		// Disable search for wpcom followers and viewers
 		if ( this.props.filter ) {
 			if ( 'followers' === this.props.filter || 'viewers' === this.props.filter ) {
@@ -76,37 +78,38 @@ module.exports = React.createClass( {
 		}
 
 		return true;
-	},
+	}
 
-	getFilters: function() {
-		var siteFilter = this.props.site.slug,
-			filters = [
-				{
-					title: this.translate( 'Team', { context: 'Filter label for people list' } ),
-					path: '/people/team/' + siteFilter,
-					id: 'team'
-				},
-				{
-					title: this.translate( 'Followers', { context: 'Filter label for people list' } ),
-					path: '/people/followers/' + siteFilter,
-					id: 'followers'
-				},
-				{
-					title: this.translate( 'Email Followers', { context: 'Filter label for people list' } ),
-					path: '/people/email-followers/' + siteFilter,
-					id: 'email-followers'
-				},
-				{
-					title: this.translate( 'Viewers', { context: 'Filter label for people list' } ),
-					path: '/people/viewers/' + siteFilter,
-					id: 'viewers'
-				}
-			];
+	getFilters() {
+		const siteFilter = get( this.props.site, 'slug', '' );
+		const { translate } = this.props;
+		const filters = [
+			{
+				title: translate( 'Team', { context: 'Filter label for people list' } ),
+				path: '/people/team/' + siteFilter,
+				id: 'team'
+			},
+			{
+				title: translate( 'Followers', { context: 'Filter label for people list' } ),
+				path: '/people/followers/' + siteFilter,
+				id: 'followers'
+			},
+			{
+				title: translate( 'Email Followers', { context: 'Filter label for people list' } ),
+				path: '/people/email-followers/' + siteFilter,
+				id: 'email-followers'
+			},
+			{
+				title: translate( 'Viewers', { context: 'Filter label for people list' } ),
+				path: '/people/viewers/' + siteFilter,
+				id: 'viewers'
+			}
+		];
 
 		return filters;
-	},
+	}
 
-	getNavigableFilters: function() {
+	getNavigableFilters() {
 		var allowedFilterIds = [ 'team' ];
 		if ( config.isEnabled( 'manage/people/readers' ) ) {
 			allowedFilterIds.push( 'followers' );
@@ -118,16 +121,20 @@ module.exports = React.createClass( {
 		}
 
 		return this.getFilters().filter( filter => this.props.filter === filter.id || includes( allowedFilterIds, filter.id ) );
-	},
+	}
 
-	shouldDisplayViewers: function() {
+	shouldDisplayViewers() {
+		if ( ! this.props.site ) {
+			return false;
+		}
+
 		if ( 'viewers' === this.props.filter || ( ! this.props.site.jetpack && this.props.site.is_private ) ) {
 			return true;
 		}
 		return false;
-	},
+	}
 
-	render: function() {
+	render() {
 		var selectedText,
 			hasPinnedItems = false,
 			search = null;
@@ -149,4 +156,6 @@ module.exports = React.createClass( {
 			</SectionNav>
 		);
 	}
-} );
+}
+
+export default localize( PeopleSectionNav );

--- a/client/my-sites/people/people-section-nav/index.jsx
+++ b/client/my-sites/people/people-section-nav/index.jsx
@@ -56,23 +56,24 @@ let PeopleNavTabs = React.createClass( {
 class PeopleSectionNav extends Component {
 
 	canSearch() {
+		const { isJetpack, jetpackPeopleSupported, filter } = this.props;
 		if ( ! this.props.site ) {
 			return false;
 		}
 
 		// Disable search for wpcom followers and viewers
-		if ( this.props.filter ) {
-			if ( 'followers' === this.props.filter || 'viewers' === this.props.filter ) {
+		if ( filter ) {
+			if ( 'followers' === filter || 'viewers' === filter ) {
 				return false;
 			}
 		}
 
-		if ( ! this.props.site.jetpack ) {
+		if ( ! isJetpack ) {
 			// wpcom sites will always support search
 			return true;
 		}
 
-		if ( 'team' === this.props.filter && ! this.props.site.versionCompare( '3.7.0-beta', '>=' ) ) {
+		if ( 'team' === filter && ! jetpackPeopleSupported ) {
 			// Jetpack sites can only search team on versions of 3.7.0-beta or later
 			return false;
 		}
@@ -128,7 +129,7 @@ class PeopleSectionNav extends Component {
 			return false;
 		}
 
-		if ( 'viewers' === this.props.filter || ( ! this.props.site.jetpack && this.props.site.is_private ) ) {
+		if ( 'viewers' === this.props.filter || ( ! this.props.isJetpack && this.props.isPrivate ) ) {
 			return true;
 		}
 		return false;
@@ -138,10 +139,6 @@ class PeopleSectionNav extends Component {
 		var selectedText,
 			hasPinnedItems = false,
 			search = null;
-
-		if ( this.props.fetching ) {
-			return <SectionNav></SectionNav>
-		}
 
 		if ( this.canSearch() ) {
 			hasPinnedItems = true;

--- a/client/my-sites/people/team-list/index.jsx
+++ b/client/my-sites/people/team-list/index.jsx
@@ -140,7 +140,7 @@ module.exports = React.createClass( {
 
 	render: function() {
 		var fetchOptions = {
-			siteId: this.props.site.ID,
+			siteId: this.props.site && this.props.site.ID,
 			order: 'ASC',
 			order_by: 'display_name',
 			search: ( this.props.search ) ? '*' + this.props.search + '*' : null,


### PR DESCRIPTION
This PR removes sites-list from the people section. 

### Testing Instructions
- With a clean cache `localStorage.clear(); indexedDB.deleteDatabase( 'calypso' );`
- Navigate to http://calypso.localhost:3000/people
- You should see all users for a site
- Clicking on the user loads
- http://calypso.localhost:3000/people/edit/:site_id/:user_login
- You can edit other user roles, or remove them
- Navigate to http://calypso.localhost:3000/people/new/:site_id
- You can invite new people to the site successfully
- Navigate to http://calypso.localhost:3000/people/edit/:site_id/:user_login but put in an invalid login to the route
- We should be redirected to the people section