### PR TITLE
Change day range from 2-30 to 0-180 for free to paid upsell criteria.

### DIFF
--- a/client/state/selectors/eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/eligible-for-free-to-paid-upsell.js
@@ -20,7 +20,7 @@ const eligibleForFreeToPaidUpsell = ( state, siteId, moment ) => {
 	const userCanManageOptions = canCurrentUser( state, siteId, 'manage_options' );
 	const siteHasMappedDomain = isMappedDomainSite( state, siteId );
 	const siteIsOnFreePlan = isSiteOnFreePlan( state, siteId );
-	const registrationDaysIsWithinRange = isUserRegistrationDaysWithinRange( state, moment, 2, 30 );
+	const registrationDaysIsWithinRange = isUserRegistrationDaysWithinRange( state, moment, 0, 180 );
 
 	return userCanManageOptions && ! siteHasMappedDomain && siteIsOnFreePlan && registrationDaysIsWithinRange;
 };

--- a/client/state/selectors/test/eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/test/eligible-for-free-to-paid-upsell.js
@@ -42,7 +42,7 @@ describe( 'eligibleForFreeToPaidUpsell', () => {
 		canCurrentUser.withArgs( state, siteId, 'manage_options' ).returns( true );
 		isMappedDomainSite.withArgs( state, siteId ).returns( false );
 		isSiteOnFreePlan.withArgs( state, siteId ).returns( true );
-		isUserRegistrationDaysWithinRange.withArgs( state, moment, 2, 30 ).returns( true );
+		isUserRegistrationDaysWithinRange.withArgs( state, moment, 0, 180 ).returns( true );
 	};
 
 	it( 'should return false when user can not manage options', () => {
@@ -65,7 +65,7 @@ describe( 'eligibleForFreeToPaidUpsell', () => {
 
 	it( 'should return false when user registration days is not within range', () => {
 		meetAllConditions();
-		isUserRegistrationDaysWithinRange.withArgs( state, moment, 2, 30 ).returns( false );
+		isUserRegistrationDaysWithinRange.withArgs( state, moment, 0, 180 ).returns( false );
 		expect( eligibleForFreeToPaidUpsell( state, siteId, moment ) ).to.be.false;
 	} );
 


### PR DESCRIPTION
This PR changes the criteria for displaying the free to paid plan upsell nudges.

Previously the nudge was displayed between days 2 and 30.  This change will result in the nudge being displayed for the first 180 days.

# Testing

* create a site for a new or existing user with a free plan
* verify that the following nudge should be visible

![screen shot 2017-04-18 at 12 05 32 pm](https://cloud.githubusercontent.com/assets/1926/25111614/5e8e3bdc-242f-11e7-898c-4dfa3449d9c7.png)
