### PR TITLE
Reader: adding common utils for extracting data from feeds/sites/posts

### DIFF
--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -12,12 +12,12 @@ import Card from 'components/card';
 import { getStreamUrl } from 'reader/route';
 import ReaderAvatar from 'blocks/reader-avatar';
 import ReaderSiteStreamLink from 'blocks/reader-site-stream-link';
-import { siteNameFromSiteAndPost } from 'reader/utils';
 import ReaderCombinedCardPost from './post';
 import { keysAreEqual, keyForPost } from 'lib/feed-stream-store/post-key';
 import QueryReaderSite from 'components/data/query-reader-site';
 import QueryReaderFeed from 'components/data/query-reader-feed';
 import { recordTrack } from 'reader/stats';
+import { getSiteName } from 'reader/get-helpers';
 import FollowButton from 'reader/follow-button';
 
 class ReaderCombinedCard extends React.Component {
@@ -68,7 +68,7 @@ class ReaderCombinedCard extends React.Component {
 		const siteIcon = get( site, 'icon.img' );
 		const feedIcon = get( feed, 'image' );
 		const streamUrl = getStreamUrl( feedId, siteId );
-		const siteName = siteNameFromSiteAndPost( site, posts[ 0 ] );
+		const siteName = getSiteName( { site, post: posts[ 0 ] } );
 		const isSelectedPost = post => keysAreEqual( keyForPost( post ), selectedPostKey );
 		const followUrl = feed && feed.URL || site && site.URL;
 		const mediaCount = filter( posts, post => ! isEmpty( post.canonical_media ) ).length;

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -34,7 +34,7 @@ import { recordAction, recordGaEvent, recordTrackForPost, recordPermalinkClick }
 import Comments from 'blocks/comments';
 import scrollTo from 'lib/scroll-to';
 import PostExcerptLink from 'reader/post-excerpt-link';
-import { siteNameFromSiteAndPost } from 'reader/utils';
+import { getSiteName } from 'reader/get-helpers';
 import { keyForPost } from 'lib/feed-stream-store/post-key';
 import KeyboardShortcuts from 'lib/keyboard-shortcuts';
 import ReaderPostActions from 'blocks/reader-post-actions';
@@ -274,7 +274,7 @@ export class FullPostView extends React.Component {
 			return <ReaderFullPostUnavailable post={ post } onBackClick={ this.handleBack } />;
 		}
 
-		const siteName = siteNameFromSiteAndPost( site, post );
+		const siteName = getSiteName( { site, post } );
 		const classes = { 'reader-full-post': true };
 		const showRelatedPosts = ! post.is_external && post.site_ID;
 		const relatedPostsFromOtherSitesTitle = translate(

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -10,7 +10,7 @@ import Gridicon from 'gridicons';
  */
 import ReaderAvatar from 'blocks/reader-avatar';
 import PostTime from 'reader/post-time';
-import { siteNameFromSiteAndPost } from 'reader/utils';
+import { getSiteName } from 'reader/get-helpers';
 import {
 	recordAction,
 	recordGaEvent,
@@ -70,7 +70,7 @@ class PostByline extends React.Component {
 		const { post, site, feed, isDiscoverPost, showSiteName } = this.props;
 		const feedId = get( post, 'feed_ID' );
 		const siteId = get( site, 'ID' );
-		const siteName = siteNameFromSiteAndPost( site, post );
+		const siteName = getSiteName( { site, feed, post } );
 		const hasAuthorName = has( post, 'author.name' );
 		const hasMatchingAuthorAndSiteNames = hasAuthorName && areEqualIgnoringWhitespaceAndCase( siteName, post.author.name );
 		const shouldDisplayAuthor = ! isDiscoverPost && hasAuthorName && ( ! hasMatchingAuthorAndSiteNames || ! showSiteName );

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -13,6 +13,7 @@ import ReaderAvatar from 'blocks/reader-avatar';
 import FollowButton from 'reader/follow-button';
 import { getStreamUrl } from 'reader/route';
 import EmailSettings from './email-settings';
+import { getSiteName, getSiteUrl } from 'reader/get-helpers';
 
 function ReaderSubscriptionListItem( {
 	url,
@@ -24,7 +25,7 @@ function ReaderSubscriptionListItem( {
 	translate,
 	followSource,
 } ) {
-	const siteTitle = ( site && site.title ) || ( feed && feed.name );
+	const siteTitle = getSiteName( { feed, site } );
 	const siteAuthor = site && site.owner;
 	const siteExcerpt = ( site && site.description ) || ( feed && feed.description );
 	// prefer a users name property
@@ -34,9 +35,7 @@ function ReaderSubscriptionListItem( {
 	const siteIcon = get( site, 'icon.img' );
 	const feedIcon = get( feed, 'image' );
 	const streamUrl = getStreamUrl( feedId, siteId );
-	const siteUrl = url ||
-		( site && site.URL ) ||
-		( feed && ( feed.feed_URL || feed.URL ) );
+	const siteUrl = url || getSiteUrl( { feed, site } );
 	const isFollowing = ( site && site.is_following ) || ( feed && feed.is_following );
 
 	return (

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import url from 'url';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
@@ -18,6 +17,7 @@ import QueryReaderSite from 'components/data/query-reader-site';
 import QueryReaderFeed from 'components/data/query-reader-feed';
 import { getSite } from 'state/reader/sites/selectors';
 import { getFeed } from 'state/reader/feeds/selectors';
+import { getSiteName } from 'reader/get-helpers';
 
 // If the blog_ID of a reader feed is 0, that means no site exists for it.
 const getReaderSiteId = feed => feed && feed.blog_ID === 0
@@ -37,48 +37,12 @@ class FeedStream extends React.Component {
 		className: 'is-site-stream',
 	};
 
-	getTitle = ( feed, site ) => {
-		let title;
-
-		if ( ! feed && ! site ) {
-			return this.props.translate( 'Loading Feed' );
-		}
-
-		if ( feed.is_error ) {
-			title = this.props.translate( 'Error fetching feed' );
-		} else if ( feed ) {
-			title = feed.name;
-		}
-
-		if ( ! title && site ) {
-			title = site.name;
-		}
-
-		if ( ! title && feed ) {
-			title = feed.URL || feed.feed_URL;
-			if ( title ) {
-				title = url.parse( title ).hostname;
-			}
-		}
-
-		if ( ! title && site ) {
-			title = site.URL;
-			if ( title ) {
-				title = url.parse( title ).hostname;
-			}
-		}
-
-		if ( ! title ) {
-			title = this.props.translate( 'Loading Feed' );
-		}
-
-		return title;
-	}
-
 	render() {
 		const { feed, site, siteId } = this.props;
 		const emptyContent = ( <EmptyContent /> );
-		const title = this.getTitle( feed, site );
+		const title = (
+			getSiteName( { feed, site } ) || this.props.translate( 'Loading Feed' )
+		);
 
 		if ( feed && feed.is_error ) {
 			return <FeedError sidebarTitle={ title } />;

--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -11,7 +11,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Given a feed, site, or post: return the url. return false if one could not be found.
  *
- * @param {*} options - a feed and/or site
+ * @param {*} options - an object containing a feed, site, and post. all optional.
  * @returns {string} the site url
  */
 export const getSiteUrl = ( { feed, site, post } = {} ) => {
@@ -22,14 +22,13 @@ export const getSiteUrl = ( { feed, site, post } = {} ) => {
 	return siteUrl || feedUrl || postUrl;
 };
 
-// TODO: remove siteNameFromSiteAndPost in followup pr because this should replace it.
 /**
  * Given a feed, site, or post: output the best title to use for the owning site.
  *
- * @param {*} options param.  optional feed, site, and post.
+ * @param {*} options - an object containing a feed, site, and post. all optional
  * @returns {string} the site title
  */
-export const getSiteName = ( { feed, site, post } ) => {
+export const getSiteName = ( { feed, site, post } = {} ) => {
 	let siteName = null;
 
 	if ( site && site.title ) {
@@ -47,7 +46,7 @@ export const getSiteName = ( { feed, site, post } ) => {
 	 */
 	if ( ! siteName ) {
 		if ( ( site && site.is_error ) || ( feed && feed.is_error ) && ( ! post ) ) {
-			siteName = translate( 'Error fetching feed' ); // TODO: remove this and keep logic just in feed/site stream?
+			siteName = translate( 'Error fetching feed' );
 		} else if ( getSiteUrl( { feed, site, post } ) ) {
 			siteName = url.parse( getSiteUrl( { feed, site, post } ) ).hostname;
 		}

--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -1,0 +1,60 @@
+/**
+ * External Dependencies
+ */
+import url from 'url';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal Dependencies
+ */
+
+/**
+ * Given a feed, site, or post: return the url. return false if one could not be found.
+ *
+ * @param {*} options - a feed and/or site
+ * @returns {string} the site url
+ */
+export const getSiteUrl = ( { feed, site, post } = {} ) => {
+	const siteUrl = ( !! site ) && site.URL;
+	const feedUrl = ( !! feed ) && ( feed.URL || feed.feed_URL );
+	const postUrl = ( !! post ) && ( post.site_URL || post.feed_URL );
+
+	return siteUrl || feedUrl || postUrl;
+};
+
+// TODO: remove siteNameFromSiteAndPost in followup pr because this should replace it.
+/**
+ * Given a feed, site, or post: output the best title to use for the owning site.
+ *
+ * @param {*} options param.  optional feed, site, and post.
+ * @returns {string} the site title
+ */
+export const getSiteName = ( { feed, site, post } ) => {
+	let siteName;
+
+	if ( site && ( site.title || site.domain ) ) {
+		siteName = site.title || site.domain;
+	} else if ( feed && ( feed.name || feed.title ) ) {
+		siteName = feed.name || feed.title;
+	} else if ( post && post.site_name ) {
+		siteName = post.site_name;
+	}
+
+	/* less happy cases
+	 * 1. error occured loading feed/site. only applies when not given a post.
+	 * 2. there is genuinely no title, fallback to url
+	 * 3. there isn't even a url, fall back to '(no title)'?
+	 */
+	if ( ! siteName ) {
+		if ( ( site && site.is_error ) || ( feed && feed.is_error ) && ( ! post ) ) {
+			siteName = translate( 'Error fetching feed' ); // TODO: remove this and keep logic just in feed/site stream?
+		} else if ( getSiteUrl( { feed, site, post } ) ) {
+			siteName = url.parse( getSiteUrl( { feed, site, post } ) ).hostname;
+		} else {
+			siteName = translate( '(no title)' );
+			// TODO: when should this exist? ideally never because url should always be a better fallback?
+		}
+	}
+
+	return siteName;
+};

--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -15,7 +15,7 @@ import { translate } from 'i18n-calypso';
  * @returns {string} the site url
  */
 export const getSiteUrl = ( { feed, site, post } = {} ) => {
-	const siteUrl = ( !! site ) && site.URL;
+	const siteUrl = ( !! site ) && ( site.URL || site.domain );
 	const feedUrl = ( !! feed ) && ( feed.URL || feed.feed_URL );
 	const postUrl = ( !! post ) && ( post.site_URL || post.feed_URL );
 
@@ -32,7 +32,7 @@ export const getSiteUrl = ( { feed, site, post } = {} ) => {
 export const getSiteName = ( { feed, site, post } ) => {
 	let siteName;
 
-	if ( site && ( site.title || site.domain ) ) {
+	if ( site && site.title ) {
 		siteName = site.title || site.domain;
 	} else if ( feed && ( feed.name || feed.title ) ) {
 		siteName = feed.name || feed.title;
@@ -53,6 +53,7 @@ export const getSiteName = ( { feed, site, post } ) => {
 		} else {
 			siteName = translate( '(no title)' );
 			// TODO: when should this exist? ideally never because url should always be a better fallback?
+			// and even if it isn't then lets return null;
 		}
 	}
 

--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -30,7 +30,7 @@ export const getSiteUrl = ( { feed, site, post } = {} ) => {
  * @returns {string} the site title
  */
 export const getSiteName = ( { feed, site, post } ) => {
-	let siteName;
+	let siteName = null;
 
 	if ( site && site.title ) {
 		siteName = site.title || site.domain;
@@ -43,17 +43,13 @@ export const getSiteName = ( { feed, site, post } ) => {
 	/* less happy cases
 	 * 1. error occured loading feed/site. only applies when not given a post.
 	 * 2. there is genuinely no title, fallback to url
-	 * 3. there isn't even a url, fall back to '(no title)'?
+	 * 3. can't find anything, return null
 	 */
 	if ( ! siteName ) {
 		if ( ( site && site.is_error ) || ( feed && feed.is_error ) && ( ! post ) ) {
 			siteName = translate( 'Error fetching feed' ); // TODO: remove this and keep logic just in feed/site stream?
 		} else if ( getSiteUrl( { feed, site, post } ) ) {
 			siteName = url.parse( getSiteUrl( { feed, site, post } ) ).hostname;
-		} else {
-			siteName = translate( '(no title)' );
-			// TODO: when should this exist? ideally never because url should always be a better fallback?
-			// and even if it isn't then lets return null;
 		}
 	}
 

--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -15,7 +15,7 @@ import { translate } from 'i18n-calypso';
  * @returns {string} the site url
  */
 export const getSiteUrl = ( { feed, site, post } = {} ) => {
-	const siteUrl = ( !! site ) && ( site.URL || site.domain );
+	const siteUrl = ( !! site ) && ( site.URL );
 	const feedUrl = ( !! feed ) && ( feed.URL || feed.feed_URL );
 	const postUrl = ( !! post ) && ( post.site_URL || post.feed_URL );
 
@@ -32,24 +32,18 @@ export const getSiteName = ( { feed, site, post } = {} ) => {
 	let siteName = null;
 
 	if ( site && site.title ) {
-		siteName = site.title || site.domain;
+		siteName = site.title;
 	} else if ( feed && ( feed.name || feed.title ) ) {
 		siteName = feed.name || feed.title;
 	} else if ( post && post.site_name ) {
 		siteName = post.site_name;
-	}
-
-	/* less happy cases
-	 * 1. error occured loading feed/site. only applies when not given a post.
-	 * 2. there is genuinely no title, fallback to url
-	 * 3. can't find anything, return null
-	 */
-	if ( ! siteName ) {
-		if ( ( site && site.is_error ) || ( feed && feed.is_error ) && ( ! post ) ) {
-			siteName = translate( 'Error fetching feed' );
-		} else if ( getSiteUrl( { feed, site, post } ) ) {
-			siteName = url.parse( getSiteUrl( { feed, site, post } ) ).hostname;
-		}
+	} else if ( ( site && site.is_error ) || ( feed && feed.is_error ) && ( ! post ) ) {
+		siteName = translate( 'Error fetching feed' );
+	} else if ( site && site.domain ) {
+		siteName = site.domain;
+	} else {
+		const siteUrl = getSiteUrl( { feed, site, post } );
+		siteName = ( !! siteUrl ) ? url.parse( siteUrl ).hostname : null;
 	}
 
 	return siteName;

--- a/client/reader/test/get-helpers.js
+++ b/client/reader/test/get-helpers.js
@@ -68,7 +68,10 @@ describe( '#getSiteName', () => {
 	const feedWithTitle = { title: 'feedTitle' };
 	const feedWithTitleAndName = { ...feedWithTitle, ...feedWithName };
 	const feedWithError = { is_error: true };
+	const feedWithUrl = { URL: 'feedWithUrl.com' };
+	const feedWithFeedUrl = { feed_URL: 'feedwithFeedUrl.com' };
 	const allFeeds = [ feedWithName, feedWithTitle, feedWithTitleAndName, feedWithError ];
+	const postWithSiteName = { site_name: 'postSiteName' };
 
 	it( 'should favor site title over everything', () => {
 		allFeeds.forEach( feed => {
@@ -82,5 +85,37 @@ describe( '#getSiteName', () => {
 			const siteName = getSiteName( { site: siteWithDomain, feed } );
 			expect( siteName ).eql( siteWithDomain.domain );
 		} );
+	} );
+
+	it( 'should fallback to feed if site title doesnt exist', () => {
+		const siteName = getSiteName( { site: {}, feedWithName } );
+		expect( siteName ).eql( feedWithName.name );
+
+		const siteTitle = getSiteName( { site: {}, feedWithTitle } );
+		expect( siteTitle ).eql( feedWithTitle.title );
+	} );
+
+	it( 'should fallback to post if neither site or feed exist', () => {
+		expect(
+			getSiteName( { site: {}, feed: {}, post: postWithSiteName } )
+		).eql( postWithSiteName.siteName );
+
+		expect(
+			getSiteName( { post: postWithSiteName } )
+		).eql( postWithSiteName.siteName );
+	} );
+
+	it( 'should fallback to domain name if cannot find title', () => {
+		expect(
+			getSiteName( { site: siteWithDomain, feed: {}, post: postWithSiteName } )
+		).eql( siteWithDomain.domain );
+
+		expect(
+			getSiteName( { feed: feedWithFeedUrl } )
+		).eql( getSiteUrl( { feed: feedWithFeedUrl } ) );
+
+		expect(
+			getSiteName( { feed: feedWithUrl } )
+		).eql( getSiteUrl( { feed: feedWithUrl } ) );
 	} );
 } );

--- a/client/reader/test/get-helpers.js
+++ b/client/reader/test/get-helpers.js
@@ -59,7 +59,7 @@ describe( '#getSiteUrl', () => {
 } );
 
 describe( '#getSiteName', () => {
-	const siteWithDomain = { domain: 'siteDomain' };
+	const siteWithDomain = { domain: 'siteDomain.com' };
 	const siteWithTitleAndDomain = {
 		title: 'siteWithTitleAndDomainTitle',
 		domain: 'siteWithTitleAndDomainDomain'
@@ -68,8 +68,8 @@ describe( '#getSiteName', () => {
 	const feedWithTitle = { title: 'feedTitle' };
 	const feedWithTitleAndName = { ...feedWithTitle, ...feedWithName };
 	const feedWithError = { is_error: true };
-	const feedWithUrl = { URL: 'feedWithUrl.com' };
-	const feedWithFeedUrl = { feed_URL: 'feedwithFeedUrl.com' };
+	const feedWithUrl = { URL: 'http://feedWithUrl.com' };
+	const feedWithFeedUrl = { feed_URL: 'http://feedwithFeedUrl.com/hello' };
 	const allFeeds = [ feedWithName, feedWithTitle, feedWithTitleAndName, feedWithError ];
 	const postWithSiteName = { site_name: 'postSiteName' };
 
@@ -80,42 +80,43 @@ describe( '#getSiteName', () => {
 		} );
 	} );
 
-	it( 'should favor site domain over everything except site title', () => {
-		allFeeds.forEach( feed => {
-			const siteName = getSiteName( { site: siteWithDomain, feed } );
-			expect( siteName ).eql( siteWithDomain.domain );
-		} );
-	} );
-
 	it( 'should fallback to feed if site title doesnt exist', () => {
-		const siteName = getSiteName( { site: {}, feedWithName } );
+		const siteName = getSiteName( { site: {}, feed: feedWithName } );
 		expect( siteName ).eql( feedWithName.name );
 
-		const siteTitle = getSiteName( { site: {}, feedWithTitle } );
+		const siteTitle = getSiteName( { site: {}, feed: feedWithTitle, post: {} } );
 		expect( siteTitle ).eql( feedWithTitle.title );
 	} );
 
 	it( 'should fallback to post if neither site or feed exist', () => {
 		expect(
 			getSiteName( { site: {}, feed: {}, post: postWithSiteName } )
-		).eql( postWithSiteName.siteName );
+		).eql( postWithSiteName.site_name );
 
 		expect(
 			getSiteName( { post: postWithSiteName } )
-		).eql( postWithSiteName.siteName );
+		).eql( postWithSiteName.site_name );
 	} );
 
 	it( 'should fallback to domain name if cannot find title', () => {
 		expect(
-			getSiteName( { site: siteWithDomain, feed: {}, post: postWithSiteName } )
+			getSiteName( { site: siteWithDomain, post: {} } )
 		).eql( siteWithDomain.domain );
 
 		expect(
 			getSiteName( { feed: feedWithFeedUrl } )
-		).eql( getSiteUrl( { feed: feedWithFeedUrl } ) );
+		).eql( 'feedwithfeedurl.com' );
 
 		expect(
 			getSiteName( { feed: feedWithUrl } )
-		).eql( getSiteUrl( { feed: feedWithUrl } ) );
+		).eql( 'feedwithurl.com' );
+	} );
+
+	it( 'should return null if nothing was found', () => {
+		expect( getSiteName() ).eql( null );
+
+		expect(
+			getSiteName( { feed: {}, site: {}, post: {} } )
+		).eql( null );
 	} );
 } );

--- a/client/reader/test/get-helpers.js
+++ b/client/reader/test/get-helpers.js
@@ -1,0 +1,86 @@
+/**
+ * External Dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal Dependencies
+ */
+import { getSiteUrl, getSiteName } from '../get-helpers';
+
+describe( '#getSiteUrl', () => {
+	const siteWithUrl = { URL: 'siteWithUrl.com' };
+	const feedWithUrl = { URL: 'feedWithUrl.com' };
+	const feedWithFeedUrl = { feed_URL: 'feedwithFeedUrl.com' };
+	const postWithSiteUrl = { site_URL: 'postWithSiteUrl' };
+	const postWithFeedUrl = { feed_URL: 'postWithFeedUrl' };
+
+	it( 'should favor site over feed if both exist', () => {
+		const siteUrl = getSiteUrl( { site: siteWithUrl, feed: feedWithUrl } );
+		expect( siteUrl ).eql( siteWithUrl.URL );
+	} );
+
+	it( 'should get title from site if feed does not exist', () => {
+		const siteUrl = getSiteUrl( { site: siteWithUrl } );
+		expect( siteUrl ).eql( siteWithUrl.URL );
+	} );
+
+	it( 'should get title from feed if site does not exist', () => {
+		const siteUrl = getSiteUrl( { feed: feedWithUrl } );
+		expect( siteUrl ).eql( feedWithUrl.URL );
+
+		const siteUrl2 = getSiteUrl( { feed: feedWithFeedUrl } );
+		expect( siteUrl2 ).eql( feedWithFeedUrl.feed_URL );
+	} );
+
+	it( 'should get title from site if feed does not exist', () => {
+		const siteUrl = getSiteUrl( { site: siteWithUrl } );
+		expect( siteUrl ).eql( siteWithUrl.URL );
+	} );
+
+	it( 'should grab url from post if its there', () => {
+		const siteUrl = getSiteUrl( { post: postWithSiteUrl } );
+		expect( siteUrl ).eql( postWithSiteUrl.site_URL );
+
+		const feedUrl = getSiteUrl( { post: postWithFeedUrl } );
+		expect( feedUrl ).eql( postWithFeedUrl.feed_URL );
+	} );
+
+	it( 'should return false if cannot find a reasonable url', () => {
+		const noArg = getSiteUrl();
+		expect( noArg ).not.ok;
+
+		const emptyArg = getSiteUrl( {} );
+		expect( emptyArg ).not.ok;
+
+		const emptySiteAndFeed = getSiteUrl( { feed: {}, site: {} } );
+		expect( emptySiteAndFeed ).not.ok;
+	} );
+} );
+
+describe( '#getSiteName', () => {
+	const siteWithDomain = { domain: 'siteDomain' };
+	const siteWithTitleAndDomain = {
+		title: 'siteWithTitleAndDomainTitle',
+		domain: 'siteWithTitleAndDomainDomain'
+	};
+	const feedWithName = { name: 'feedName' };
+	const feedWithTitle = { title: 'feedTitle' };
+	const feedWithTitleAndName = { ...feedWithTitle, ...feedWithName };
+	const feedWithError = { is_error: true };
+	const allFeeds = [ feedWithName, feedWithTitle, feedWithTitleAndName, feedWithError ];
+
+	it( 'should favor site title over everything', () => {
+		allFeeds.forEach( feed => {
+			const siteName = getSiteName( { site: siteWithTitleAndDomain, feed } );
+			expect( siteName ).eql( siteWithTitleAndDomain.title );
+		} );
+	} );
+
+	it( 'should favor site domain over everything except site title', () => {
+		allFeeds.forEach( feed => {
+			const siteName = getSiteName( { site: siteWithDomain, feed } );
+			expect( siteName ).eql( siteWithDomain.domain );
+		} );
+	} );
+} );

--- a/client/reader/utils.js
+++ b/client/reader/utils.js
@@ -1,69 +1,17 @@
 /**
  * External Dependencies
  */
-import url from 'url';
 import page from 'page';
 import { every } from 'lodash';
 
 /**
  * Internal Dependencies
  */
-import i18n from 'i18n-calypso';
-import { state as SiteState } from 'lib/reader-site-store/constants';
-import FeedDisplayHelper from 'reader/lib/feed-display-helper';
 import PostStore from 'lib/feed-post-store';
 import XPostHelper, { isXPost } from 'reader/xpost-helper';
 import { setLastStoreId } from 'reader/controller-helper';
 import { fillGap } from 'lib/feed-stream-store/actions';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
-
-export function siteNameFromSiteAndPost( site, post ) {
-	let siteName;
-
-	if ( site && ( site.title || site.domain ) ) {
-		siteName = site.title || site.domain;
-	} else if ( site && site.get && site.get( 'state' ) === SiteState.COMPLETE ) {
-		siteName = site.get( 'title' ) || site.get( 'domain' );
-	} else if ( post ) {
-		if ( post.site_name ) {
-			siteName = post.site_name;
-		} else if ( post.site_URL ) {
-			siteName = url.parse( post.site_URL ).hostname;
-		}
-	}
-
-	if ( ! siteName ) {
-		siteName = i18n.translate( '(no title)' );
-	}
-
-	return siteName;
-}
-
-/**
- * Creates a site-like object from a site and a post.
- *
- * Compliant with what things like the <Site /> object expects
- * @param  {Immutable.Map} site A Reader site (Immutable)
- * @param  {Object} post A Reader post
- * @return {Object}      A site like object
- */
-export function siteishFromSiteAndPost( site, post ) {
-	if ( site ) {
-		return site.toJS();
-	}
-
-	if ( post ) {
-		return {
-			title: siteNameFromSiteAndPost( site, post ),
-			domain: FeedDisplayHelper.formatUrlForDisplay( post.site_URL )
-		};
-	}
-
-	return {
-		title: '',
-		domain: ''
-	};
-}
 
 export function isSpecialClick( event ) {
 	return event.button > 0 || event.metaKey || event.controlKey || event.shiftKey || event.altKey;


### PR DESCRIPTION
Adding new util functions:
```js
const getSiteTitle = ( { site, feed, post } ) --> site title or false
const getSiteUrl = ( { site, feed, post } ) --> site url or null
```

Why? Now full-post, post-cards, subListItems, etc all rely upon the same algorithm for determining both siteTitle and siteUrl. 

~120 lines are tests + comments.  This actually removes more than it adds.

To test:
- ensure that the siteUrls and siteTitles in full-post, combined-cards, manage/following, reader-post-cards, and feed-streams all look good.