### PR TITLE
Sites: Remove unused canAutoupdateCore and getDefaultCategory from site utils

### DIFF
--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -133,18 +133,6 @@ export default {
 		return true;
 	},
 
-	canAutoupdateCore( site ) {
-		if ( ! this.canAutoupdateFiles( site ) ) {
-			return false;
-		}
-
-		if ( site.options.file_mod_disabled &&
-			-1 < site.options.file_mod_disabled.indexOf( 'automatic_updater_disabled' ) ) {
-			return false;
-		}
-		return true;
-	},
-
 	isMainNetworkSite( site ) {
 		if ( ! site ) {
 			return false;

--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -38,20 +38,6 @@ export default {
 		return site && site.options ? site.options.gmt_offset : null;
 	},
 
-	getDefaultCategory( site ) {
-		if ( ! site ) {
-			return;
-		}
-
-		if ( site.settings ) {
-			return site.settings.default_category;
-		}
-
-		if ( site.options ) {
-			return site.options.default_category;
-		}
-	},
-
 	getDefaultPostFormat( site ) {
 		if ( ! site ) {
 			return;


### PR DESCRIPTION
This PR removes the obsolete `canAutoupdateCore` and `getDefaultCategory` from `lib/site/utils`.

Since they're not used anywhere, no real testing is required. All that's necessary is to verify they're not used anywhere and can be safely removed.