### PR TITLE
Login: Update the login screen to match the mockups

### DIFF
--- a/client/components/logged-out-form/footer.jsx
+++ b/client/components/logged-out-form/footer.jsx
@@ -14,12 +14,13 @@ export default React.createClass( {
 
 	propTypes: {
 		children: React.PropTypes.node.isRequired,
-		className: React.PropTypes.string
+		className: React.PropTypes.string,
+		isBlended: React.PropTypes.bool
 	},
 
 	render() {
 		return (
-			<Card className={ classnames( 'logged-out-form__footer', this.props.className ) } >
+			<Card className={ classnames( 'logged-out-form__footer', this.props.className, { 'is-blended': this.props.isBlended } ) } >
 				{ this.props.children }
 			</Card>
 		);

--- a/client/components/logged-out-form/footer.jsx
+++ b/client/components/logged-out-form/footer.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import classnames from 'classnames';
 
 /**
@@ -9,14 +9,12 @@ import classnames from 'classnames';
  */
 import Card from 'components/card';
 
-export default React.createClass( {
-	displayName: 'LoggedOutFormFooter',
-
-	propTypes: {
-		children: React.PropTypes.node.isRequired,
-		className: React.PropTypes.string,
-		isBlended: React.PropTypes.bool
-	},
+class LoggedOutFormFooter extends Component {
+	static propTypes = {
+		children: PropTypes.node.isRequired,
+		className: PropTypes.string,
+		isBlended: PropTypes.bool
+	};
 
 	render() {
 		return (
@@ -25,4 +23,6 @@ export default React.createClass( {
 			</Card>
 		);
 	}
-} );
+}
+
+export default LoggedOutFormFooter;

--- a/client/components/logged-out-form/style.scss
+++ b/client/components/logged-out-form/style.scss
@@ -16,6 +16,12 @@
 		padding: 24px;
 	}
 
+	&.is-blended {
+		background: none;
+		border-top: none;
+		padding-top: 0;
+	}
+
 	.button.is-primary {
 		float: none;
 		margin: 0;

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -154,7 +154,7 @@ class SignupForm extends Component {
 
 	validate( fields, onComplete ) {
 		wpcom.undocumented().validateNewUser( fields, ( error, response ) => {
-			if ( this.state.readyToLogin || this.props.submitting ) {
+			if ( this.props.submitting ) {
 				// this is a stale callback, we have already signed up or are logging in
 				return;
 			}
@@ -448,10 +448,6 @@ class SignupForm extends Component {
 			returnUrl += this.props.locale + '.';
 		}
 		return returnUrl + urlArray[ 1 ];
-	}
-
-	localizeUrlWithLastSlug( url ) {
-		return ( this.props.locale ) ? '/log-in/' + this.props.locale : url;
 	}
 
 	footerLink() {

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -78,18 +78,6 @@ class SignupForm extends Component {
 		validationInitialized: false
 	};
 
-	constructor( props ) {
-		super( props );
-
-		this.handleBlur = this.handleBlur.bind( this );
-		this.handleChangeEvent = this.handleChangeEvent.bind( this );
-		this.handleOnClickTos = this.handleOnClickTos.bind( this );
-		this.handleSubmit = this.handleSubmit.bind( this );
-		this.sanitize = this.sanitize.bind( this );
-		this.setFormState = this.setFormState.bind( this );
-		this.validate = this.validate.bind( this );
-	}
-
 	getInitialFields() {
 		return {
 			email: this.props.email || '',
@@ -140,7 +128,7 @@ class SignupForm extends Component {
 		return username && username.replace( /[^a-zA-Z0-9]/g, '' ).toLowerCase();
 	}
 
-	sanitize( fields, onComplete ) {
+	sanitize = ( fields, onComplete ) => {
 		const sanitizedEmail = this.sanitizeEmail( fields.email ),
 			sanitizedUsername = this.sanitizeUsername( fields.username );
 
@@ -150,9 +138,9 @@ class SignupForm extends Component {
 				username: sanitizedUsername
 			} );
 		}
-	}
+	};
 
-	validate( fields, onComplete ) {
+	validate = ( fields, onComplete ) => {
 		wpcom.undocumented().validateNewUser( fields, ( error, response ) => {
 			if ( this.props.submitting ) {
 				// this is a stale callback, we have already signed up or are logging in
@@ -212,11 +200,11 @@ class SignupForm extends Component {
 				this.setState( { validationInitialized: true } );
 			}
 		} );
-	}
+	};
 
-	setFormState( state ) {
+	setFormState = ( state ) => {
 		this.setState( { form: state } );
-	}
+	};
 
 	handleFormControllerError( error ) {
 		if ( error ) {
@@ -224,7 +212,7 @@ class SignupForm extends Component {
 		}
 	}
 
-	handleChangeEvent( event ) {
+	handleChangeEvent = ( event ) => {
 		const name = event.target.name,
 			value = event.target.value;
 
@@ -234,15 +222,15 @@ class SignupForm extends Component {
 			name: name,
 			value: value
 		} );
-	}
+	};
 
-	handleBlur() {
+	handleBlur = () => {
 		this.formStateController.sanitize();
 		this.formStateController.validate();
 		this.props.save && this.props.save( this.state.form );
-	}
+	};
 
-	handleSubmit( event ) {
+	handleSubmit = ( event ) => {
 		event.preventDefault();
 
 		if ( this.state.submitting ) {
@@ -275,7 +263,7 @@ class SignupForm extends Component {
 
 			resetAnalyticsData();
 		} );
-	}
+	};
 
 	globalNotice( notice ) {
 		return <Notice
@@ -383,12 +371,12 @@ class SignupForm extends Component {
 		);
 	}
 
-	handleOnClickTos() {
+	handleOnClickTos = () => {
 		analytics.tracks.recordEvent.bind(
 			analytics,
 			'calypso_signup_tos_link_click'
 		);
-	}
+	};
 
 	getTermsOfServiceUrl() {
 		// locales where we don't have translated TOS will simply show the English one

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -5,7 +5,7 @@ import React, { PropTypes } from 'react';
 import { map, forEach, head, includes, isEmpty, keys } from 'lodash';
 import debugModule from 'debug';
 import classNames from 'classnames';
-import i18n from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -42,7 +42,7 @@ const resetAnalyticsData = () => {
 	timesPasswordValidationFailed = 0;
 };
 
-export default React.createClass( {
+export default localize( React.createClass( {
 
 	displayName: 'SignupForm',
 
@@ -66,6 +66,7 @@ export default React.createClass( {
 		submitButtonText: PropTypes.string.isRequired,
 		submitting: PropTypes.bool,
 		suggestedUsername: PropTypes.string.isRequired,
+		translate: PropTypes.func.isRequired
 	},
 
 	getDefaultProps() {
@@ -194,7 +195,7 @@ export default React.createClass( {
 						// show an error message.
 						messages = Object.assign( {}, messages, {
 							email: {
-								invalid: this.translate( 'Use a working email address, so you can receive our messages.' )
+								invalid: this.props.translate( 'Use a working email address, so you can receive our messages.' )
 							}
 						} );
 					}
@@ -302,7 +303,7 @@ export default React.createClass( {
 					<span>
 						<p>
 							{ message }&nbsp;
-							{ this.translate( 'If this is you {{a}}log in now{{/a}}.', {
+							{ this.props.translate( 'If this is you {{a}}log in now{{/a}}.', {
 								components: {
 									a: <a href={ link } />
 								}
@@ -319,7 +320,7 @@ export default React.createClass( {
 		return (
 			<div>
 				<ValidationFieldset errorMessages={ this.getErrorMessagesWithLogin( 'email' ) }>
-					<FormLabel htmlFor="email">{ this.translate( 'Your email address' ) }</FormLabel>
+					<FormLabel htmlFor="email">{ this.props.translate( 'Your email address' ) }</FormLabel>
 					<FormTextInput
 						autoFocus={ isEmpty( this.props.email ) && ! this.props.isSocialSignupEnabled }
 						autoCapitalize="off"
@@ -338,7 +339,7 @@ export default React.createClass( {
 				</ValidationFieldset>
 
 				<ValidationFieldset errorMessages={ this.getErrorMessagesWithLogin( 'username' ) }>
-					<FormLabel htmlFor="username">{ this.translate( 'Choose a username' ) }</FormLabel>
+					<FormLabel htmlFor="username">{ this.props.translate( 'Choose a username' ) }</FormLabel>
 					<FormTextInput
 						autoFocus={ ! isEmpty( this.props.email ) }
 						autoCapitalize="off"
@@ -355,7 +356,7 @@ export default React.createClass( {
 				</ValidationFieldset>
 
 				<ValidationFieldset errorMessages={ formState.getFieldErrorMessages( this.state.form, 'password' ) }>
-					<FormLabel htmlFor="password">{ this.translate( 'Choose a password' ) }</FormLabel>
+					<FormLabel htmlFor="password">{ this.props.translate( 'Choose a password' ) }</FormLabel>
 					<FormPasswordInput
 						className="signup-form__input"
 						disabled={ this.state.submitting || this.props.disabled }
@@ -368,7 +369,7 @@ export default React.createClass( {
 						onChange={ this.handleChangeEvent }
 						submitting={ this.state.submitting || this.props.submitting } />
 					<FormSettingExplanation>
-						{ this.translate( 'Your password must be at least six characters long.' ) }
+						{ this.props.translate( 'Your password must be at least six characters long.' ) }
 					</FormSettingExplanation>
 				</ValidationFieldset>
 			</div>
@@ -390,7 +391,7 @@ export default React.createClass( {
 	termsOfServiceLink() {
 		return (
 			<p className="signup-form__terms-of-service-link">{
-				this.translate(
+				this.props.translate(
 					'By creating an account you agree to our {{a}}fascinating Terms of Service{{/a}}.',
 					{
 						components: {
@@ -458,7 +459,7 @@ export default React.createClass( {
 		return (
 			<LoggedOutFormLinks>
 				<LoggedOutFormLinkItem href={ logInUrl }>
-					{ this.translate( 'Already have a WordPress.com account? Log in now.' ) }
+					{ this.props.translate( 'Already have a WordPress.com account? Log in now.' ) }
 				</LoggedOutFormLinkItem>
 			</LoggedOutFormLinks>
 		);
@@ -489,4 +490,4 @@ export default React.createClass( {
 			</div>
 		);
 	}
-} );
+} ) );

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -422,7 +422,7 @@ class SignupForm extends Component {
 
 	formFooter() {
 		return (
-			<LoggedOutFormFooter className={ classNames( { 'is-blended': this.props.isSocialSignupEnabled } ) }>
+			<LoggedOutFormFooter isBlended={ this.props.isSocialSignupEnabled }>
 				{ this.termsOfServiceLink() }
 				<FormButton className="signup-form__submit" disabled={ this.state.submitting || this.props.disabled }>
 					{ this.props.submitButtonText }

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -259,12 +259,14 @@ export default React.createClass( {
 				return;
 			}
 
-			let analyticsData = {
+			const analyticsData = {
 				unique_usernames_searched: usernamesSearched.length,
 				times_username_validation_failed: timesUsernameValidationFailed,
 				times_password_validation_failed: timesPasswordValidationFailed
 			};
+
 			this.props.submitForm( this.state.form, this.getUserData(), analyticsData );
+
 			resetAnalyticsData();
 		} );
 	},

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -28,7 +28,6 @@ import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import { mergeFormWithValue } from 'signup/utils';
 import SocialSignupForm from './social';
-import HrWithText from 'components/hr-with-text';
 
 const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 1500,
 	debug = debugModule( 'calypso:signup-form:form' );
@@ -425,7 +424,7 @@ export default React.createClass( {
 
 	formFooter() {
 		return (
-			<LoggedOutFormFooter>
+			<LoggedOutFormFooter className={ classNames( { 'is-blended': this.props.isSocialSignupEnabled } ) }>
 				{ this.termsOfServiceLink() }
 				<FormButton className="signup-form__submit" disabled={ this.state.submitting || this.props.disabled }>
 					{ this.props.submitButtonText }
@@ -467,18 +466,21 @@ export default React.createClass( {
 		return (
 			<div className={ classNames( 'signup-form', this.props.className ) }>
 				<LoggedOutForm onSubmit={ this.handleSubmit } noValidate={ true }>
-					{ this.props.formHeader &&
+					{ this.props.formHeader && (
 						<header className="signup-form__header">
 							{ this.props.formHeader }
 						</header>
-					}
-					{ this.props.isSocialSignupEnabled && <SocialSignupForm handleResponse={ this.props.handleSocialResponse } /> }
-					{ this.props.isSocialSignupEnabled && <HrWithText>
-						{ i18n.translate( 'Or sign up with your email address:' ) }
-					</HrWithText> }
+					) }
+
 					{ this.getNotice() }
+
 					{ this.formFields() }
+
 					{ this.props.formFooter || this.formFooter() }
+
+					{ this.props.isSocialSignupEnabled && (
+						<SocialSignupForm handleResponse={ this.props.handleSocialResponse } />
+					) }
 				</LoggedOutForm>
 
 				{ this.props.footerLink || this.footerLink() }

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -322,6 +322,8 @@ class SignupForm extends Component {
 	}
 
 	formFields() {
+		const isEmailValid = ! this.props.disableEmailInput && formState.isFieldValid( this.state.form, 'email' );
+
 		return (
 			<div>
 				<ValidationFieldset errorMessages={ this.getErrorMessagesWithLogin( 'email' ) }>
@@ -337,7 +339,7 @@ class SignupForm extends Component {
 						type="email"
 						value={ formState.getFieldValue( this.state.form, 'email' ) }
 						isError={ formState.isFieldInvalid( this.state.form, 'email' ) }
-						isValid={ ! this.props.disableEmailInput && this.state.validationInitialized && formState.isFieldValid( this.state.form, 'email' ) }
+						isValid={ this.state.validationInitialized && isEmailValid }
 						onBlur={ this.handleBlur }
 						onChange={ this.handleChangeEvent } />
 					{ this.emailDisableExplanation() }

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { map, forEach, head, includes, isEmpty, keys } from 'lodash';
 import debugModule from 'debug';
 import classNames from 'classnames';
@@ -42,11 +42,8 @@ const resetAnalyticsData = () => {
 	timesPasswordValidationFailed = 0;
 };
 
-export default localize( React.createClass( {
-
-	displayName: 'SignupForm',
-
-	propTypes: {
+class SignupForm extends Component {
+	static propTypes = {
 		className: PropTypes.string,
 		disableEmailExplanation: PropTypes.bool,
 		disableEmailInput: PropTypes.bool,
@@ -67,23 +64,31 @@ export default localize( React.createClass( {
 		submitting: PropTypes.bool,
 		suggestedUsername: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired
-	},
+	};
 
-	getDefaultProps() {
-		return {
-			isSocialSignupEnabled: false,
-		};
-	},
+	static defaultProps = {
+		isSocialSignupEnabled: false,
+	};
 
-	getInitialState() {
-		return {
-			notice: null,
-			submitting: false,
-			form: null,
-			signedUp: false,
-			validationInitialized: false
-		};
-	},
+	state = {
+		notice: null,
+		submitting: false,
+		form: null,
+		signedUp: false,
+		validationInitialized: false
+	};
+
+	constructor( props ) {
+		super( props );
+
+		this.handleBlur = this.handleBlur.bind( this );
+		this.handleChangeEvent = this.handleChangeEvent.bind( this );
+		this.handleOnClickTos = this.handleOnClickTos.bind( this );
+		this.handleSubmit = this.handleSubmit.bind( this );
+		this.sanitize = this.sanitize.bind( this );
+		this.setFormState = this.setFormState.bind( this );
+		this.validate = this.validate.bind( this );
+	}
 
 	getInitialFields() {
 		return {
@@ -91,7 +96,7 @@ export default localize( React.createClass( {
 			username: '',
 			password: ''
 		};
-	},
+	}
 
 	autoFillUsername( form ) {
 		return mergeFormWithValue( {
@@ -99,7 +104,7 @@ export default localize( React.createClass( {
 			fieldName: 'username',
 			fieldValue: this.props.suggestedUsername || ''
 		} );
-	},
+	}
 
 	componentWillMount() {
 		debug( 'Mounting the SignupForm React component.' );
@@ -118,22 +123,22 @@ export default localize( React.createClass( {
 		const stateWithFilledUsername = this.autoFillUsername( initialState );
 
 		this.setState( { form: stateWithFilledUsername } );
-	},
+	}
 
 	componentDidMount() {
 		// If we initialized the form with an email, we need to validate the email
 		if ( this.props.email ) {
 			this.handleBlur();
 		}
-	},
+	}
 
 	sanitizeEmail( email ) {
 		return email && email.replace( /\s+/g, '' ).toLowerCase();
-	},
+	}
 
 	sanitizeUsername( username ) {
 		return username && username.replace( /[^a-zA-Z0-9]/g, '' ).toLowerCase();
-	},
+	}
 
 	sanitize( fields, onComplete ) {
 		const sanitizedEmail = this.sanitizeEmail( fields.email ),
@@ -145,7 +150,7 @@ export default localize( React.createClass( {
 				username: sanitizedUsername
 			} );
 		}
-	},
+	}
 
 	validate( fields, onComplete ) {
 		wpcom.undocumented().validateNewUser( fields, ( error, response ) => {
@@ -207,17 +212,17 @@ export default localize( React.createClass( {
 				this.setState( { validationInitialized: true } );
 			}
 		} );
-	},
+	}
 
 	setFormState( state ) {
 		this.setState( { form: state } );
-	},
+	}
 
 	handleFormControllerError( error ) {
 		if ( error ) {
 			throw error;
 		}
-	},
+	}
 
 	handleChangeEvent( event ) {
 		const name = event.target.name,
@@ -229,13 +234,13 @@ export default localize( React.createClass( {
 			name: name,
 			value: value
 		} );
-	},
+	}
 
 	handleBlur() {
 		this.formStateController.sanitize();
 		this.formStateController.validate();
 		this.props.save && this.props.save( this.state.form );
-	},
+	}
 
 	handleSubmit( event ) {
 		event.preventDefault();
@@ -270,7 +275,7 @@ export default localize( React.createClass( {
 
 			resetAnalyticsData();
 		} );
-	},
+	}
 
 	globalNotice( notice ) {
 		return <Notice
@@ -279,7 +284,7 @@ export default localize( React.createClass( {
 			showDismiss={ false }
 			status={ notices.getStatusHelper( notice ) }
 			text={ notice.message } />;
-	},
+	}
 
 	getUserData() {
 		return {
@@ -287,7 +292,7 @@ export default localize( React.createClass( {
 			password: formState.getFieldValue( this.state.form, 'password' ),
 			email: formState.getFieldValue( this.state.form, 'email' )
 		};
-	},
+	}
 
 	getErrorMessagesWithLogin( fieldName ) {
 		const messages = formState.getFieldErrorMessages( this.state.form, fieldName );
@@ -314,7 +319,7 @@ export default localize( React.createClass( {
 			}
 			return message;
 		} );
-	},
+	}
 
 	formFields() {
 		return (
@@ -374,19 +379,19 @@ export default localize( React.createClass( {
 				</ValidationFieldset>
 			</div>
 		);
-	},
+	}
 
 	handleOnClickTos() {
 		analytics.tracks.recordEvent.bind(
 			analytics,
 			'calypso_signup_tos_link_click'
 		);
-	},
+	}
 
 	getTermsOfServiceUrl() {
 		// locales where we don't have translated TOS will simply show the English one
 		return 'https://' + i18n.getLocaleSlug() + '.wordpress.com/tos/';
-	},
+	}
 
 	termsOfServiceLink() {
 		return (
@@ -405,7 +410,7 @@ export default localize( React.createClass( {
 				)
 			}</p>
 		);
-	},
+	}
 
 	getNotice() {
 		if ( this.props.step && 'invalid' === this.props.step.status ) {
@@ -415,7 +420,7 @@ export default localize( React.createClass( {
 			return this.globalNotice( this.state.notice );
 		}
 		return false;
-	},
+	}
 
 	emailDisableExplanation() {
 		if ( this.props.disableEmailInput && this.props.disableEmailExplanation ) {
@@ -423,7 +428,7 @@ export default localize( React.createClass( {
 				<FormSettingExplanation noValidate={ true }>{ this.props.disableEmailExplanation }</FormSettingExplanation>
 			);
 		}
-	},
+	}
 
 	formFooter() {
 		return (
@@ -434,7 +439,7 @@ export default localize( React.createClass( {
 				</FormButton>
 			</LoggedOutFormFooter>
 		);
-	},
+	}
 
 	localizeUrlWithSubdomain( url ) {
 		const urlArray = url.split( '//' );
@@ -443,11 +448,11 @@ export default localize( React.createClass( {
 			returnUrl += this.props.locale + '.';
 		}
 		return returnUrl + urlArray[ 1 ];
-	},
+	}
 
 	localizeUrlWithLastSlug( url ) {
 		return ( this.props.locale ) ? '/log-in/' + this.props.locale : url;
-	},
+	}
 
 	footerLink() {
 		if ( this.props.positionInFlow !== 0 ) {
@@ -463,7 +468,7 @@ export default localize( React.createClass( {
 				</LoggedOutFormLinkItem>
 			</LoggedOutFormLinks>
 		);
-	},
+	}
 
 	render() {
 		return (
@@ -490,4 +495,6 @@ export default localize( React.createClass( {
 			</div>
 		);
 	}
-} ) );
+}
+
+export default localize( SignupForm );

--- a/client/components/signup-form/social.jsx
+++ b/client/components/signup-form/social.jsx
@@ -4,6 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import GoogleLoginButton from 'components/social-buttons/google';
 import FacebookLoginButton from 'components/social-buttons/facebook';
+import { localize } from 'i18n-calypso';
 
 /**
  * External dependencies
@@ -13,10 +14,12 @@ import config from 'config';
 class SocialSignupForm extends Component {
 	static propTypes = {
 		handleResponse: PropTypes.func.isRequired,
-	}
+		translate: PropTypes.func.isRequired,
+	};
 
 	constructor() {
 		super();
+
 		this.handleGoogleResponse = this.handleGoogleResponse.bind( this );
 		this.handleFacebookResponse = this.handleFacebookResponse.bind( this );
 	}
@@ -39,15 +42,26 @@ class SocialSignupForm extends Component {
 	render() {
 		return (
 			<div className="signup-form__social">
-				<GoogleLoginButton
-					clientId={ config( 'google_oauth_client_id' ) }
-					responseHandler={ this.handleGoogleResponse } />
-				<FacebookLoginButton
-					appId={ config( 'facebook_app_id' ) }
-					responseHandler={ this.handleFacebookResponse } />
+				<p>
+					{ this.props.translate( 'Or create account using social profile:' ) }
+				</p>
+
+				<div className="signup-form__social-buttons">
+					<GoogleLoginButton
+						clientId={ config( 'google_oauth_client_id' ) }
+						responseHandler={ this.handleGoogleResponse } />
+
+					<FacebookLoginButton
+						appId={ config( 'facebook_app_id' ) }
+						responseHandler={ this.handleFacebookResponse } />
+				</div>
+
+				<p>
+					{ this.props.translate( 'Connect to your existing social profile to get started faster. We\'ll never post without your permission.' ) }
+				</p>
 			</div>
 		);
 	}
 }
 
-export default SocialSignupForm;
+export default localize( SocialSignupForm );

--- a/client/components/signup-form/social.jsx
+++ b/client/components/signup-form/social.jsx
@@ -57,7 +57,9 @@ class SocialSignupForm extends Component {
 				</div>
 
 				<p>
-					{ this.props.translate( 'Connect to your existing social profile to get started faster. We\'ll never post without your permission.' ) }
+					{ this.props.translate(
+						"Connect to your existing social profile to get started faster. We'll never post without your permission."
+					) }
 				</p>
 			</div>
 		);

--- a/client/components/signup-form/style.scss
+++ b/client/components/signup-form/style.scss
@@ -5,6 +5,11 @@
 
 .signup-form .logged-out-form__footer {
 	margin-top: 10px;
+
+	&.is-blended {
+		background: none;
+		border-top: none;
+	}
 }
 
 .signup-form__terms-of-service-link {
@@ -20,6 +25,11 @@
 }
 
 .signup-form__social {
+	margin: 0 -24px -24px -24px;
+	padding: 24px;
+}
+
+.signup-form__social-buttons {
 	display: flex;
 	align-items: center;
 	margin: 0 -5px;

--- a/client/components/signup-form/style.scss
+++ b/client/components/signup-form/style.scss
@@ -9,6 +9,7 @@
 	&.is-blended {
 		background: none;
 		border-top: none;
+		padding-top: 0;
 	}
 }
 
@@ -25,22 +26,25 @@
 }
 
 .signup-form__social {
-	margin: 0 -24px -24px -24px;
+	background-color: #f6f9fa;
+	border-top: 1px solid #e9eff3;
+	margin: 24px -24px -24px -24px;
 	padding: 24px;
+
+	p {
+		font-size: 11px;
+		margin: 0 0 20px 0;
+		text-align: center;
+
+		&:last-child {
+			margin: 10px 0 0;
+		}
+	}
 }
 
 .signup-form__social-buttons {
-	display: flex;
-	align-items: center;
-	margin: 0 -5px;
-
-	> button {
-		flex: 1;
-		box-sizing: border-box;
-		margin: 0 5px;
-	}
-
 	button {
+		margin: 0 0 10px;
 		width: 100%;
 	}
 }

--- a/client/components/signup-form/style.scss
+++ b/client/components/signup-form/style.scss
@@ -5,12 +5,6 @@
 
 .signup-form .logged-out-form__footer {
 	margin-top: 10px;
-
-	&.is-blended {
-		background: none;
-		border-top: none;
-		padding-top: 0;
-	}
 }
 
 .signup-form__terms-of-service-link {

--- a/client/components/social-buttons/facebook.js
+++ b/client/components/social-buttons/facebook.js
@@ -4,9 +4,9 @@
 import React, { Component, PropTypes } from 'react';
 import SocialLogo from 'social-logos';
 import { loadScript } from 'lib/load-script';
+import { localize } from 'i18n-calypso';
 
-export default class FacebookLoginButton extends Component {
-
+class FacebookLoginButton extends Component {
 	// See: https://developers.facebook.com/docs/javascript/reference/FB.init/v2.8
 	static propTypes = {
 		appId: PropTypes.string.isRequired,
@@ -16,6 +16,7 @@ export default class FacebookLoginButton extends Component {
 		xfbml: PropTypes.bool,
 		responseHandler: PropTypes.func.isRequired,
 		scope: PropTypes.string,
+		translate: PropTypes.func.isRequired
 	};
 
 	static defaultProps = {
@@ -91,10 +92,15 @@ export default class FacebookLoginButton extends Component {
 					<SocialLogo className="social-buttons__logo" icon="facebook" size={ 24 } />
 
 					<span className="social-buttons__service-name">
-						Facebook
+						{ this.props.translate( 'Continue with %(service)s', {
+							args: { service: 'Facebook' },
+							comment: '%(service)s is the name of a Social Network, e.g. "Google", "Facebook", "Twitter" ...'
+						} ) }
 					</span>
 				</span>
 			</button>
 		);
 	}
 }
+
+export default localize( FacebookLoginButton );

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -4,13 +4,15 @@
 import React, { Component, PropTypes } from 'react';
 import SocialLogo from 'social-logos';
 import { loadScript } from 'lib/load-script';
+import { localize } from 'i18n-calypso';
 
-export default class GoogleLoginButton extends Component {
+class GoogleLoginButton extends Component {
 	static propTypes = {
 		clientId: PropTypes.string.isRequired,
 		scope: PropTypes.string,
 		fetchBasicProfile: PropTypes.bool,
 		responseHandler: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired
 	};
 
 	static defaultProps = {
@@ -78,10 +80,15 @@ export default class GoogleLoginButton extends Component {
 					<SocialLogo className="social-buttons__logo" icon="google" size={ 24 } />
 
 					<span className="social-buttons__service-name">
-						Google
+						{ this.props.translate( 'Continue with %(service)s', {
+							args: { service: 'Google' },
+							comment: '%(service)s is the name of a Social Network, e.g. "Google", "Facebook", "Twitter" ...'
+						} ) }
 					</span>
 				</span>
 			</button>
 		);
 	}
 }
+
+export default localize( GoogleLoginButton );

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 
 /**
@@ -10,11 +11,12 @@ import classNames from 'classnames';
 import StepHeader from 'signup/step-header';
 import NavigationLink from 'signup/navigation-link';
 
-export default React.createClass( {
+export default localize( React.createClass( {
 	displayName: 'StepWrapper',
 
 	propTypes: {
-		shouldHideNavButtons: React.PropTypes.bool
+		shouldHideNavButtons: React.PropTypes.bool,
+		translate: React.PropTypes.func.isRequired
 	},
 
 	renderBack: function() {
@@ -51,7 +53,7 @@ export default React.createClass( {
 			if ( this.props.headerText ) {
 				return this.props.headerText;
 			}
-			return this.translate( 'Create your account.' );
+			return this.props.translate( 'Create your account.' );
 		}
 
 		if ( this.props.fallbackHeaderText ) {
@@ -81,4 +83,4 @@ export default React.createClass( {
 			</div>
 		);
 	}
-} );
+} ) );

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -51,24 +51,11 @@ export default React.createClass( {
 			if ( this.props.headerText ) {
 				return this.props.headerText;
 			}
-			return this.translate( 'Let\'s get started.' );
+			return this.translate( 'Create your account.' );
 		}
 
 		if ( this.props.fallbackHeaderText ) {
 			return this.props.fallbackHeaderText;
-		}
-	},
-
-	subHeaderText: function() {
-		if ( this.props.positionInFlow === 0 ) {
-			if ( this.props.subHeaderText ) {
-				return this.props.subHeaderText;
-			}
-			return this.translate( 'Welcome to the best place for your WordPress website.' );
-		}
-
-		if ( this.props.fallbackSubHeaderText ) {
-			return this.props.fallbackSubHeaderText;
 		}
 	},
 
@@ -81,8 +68,7 @@ export default React.createClass( {
 		return (
 			<div className={ classes }>
 				<StepHeader
-					headerText={ this.headerText() }
-					subHeaderText={ this.subHeaderText() }>
+					headerText={ this.headerText() }>
 					{ ( headerButton ) }
 				</StepHeader>
 				<div className="step-wrapper__content is-animated-content">

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 
@@ -11,15 +11,13 @@ import classNames from 'classnames';
 import StepHeader from 'signup/step-header';
 import NavigationLink from 'signup/navigation-link';
 
-export default localize( React.createClass( {
-	displayName: 'StepWrapper',
+class StepWrapper extends Component {
+	static propTypes = {
+		shouldHideNavButtons: PropTypes.bool,
+		translate: PropTypes.func.isRequired,
+	};
 
-	propTypes: {
-		shouldHideNavButtons: React.PropTypes.bool,
-		translate: React.PropTypes.func.isRequired
-	},
-
-	renderBack: function() {
+	renderBack() {
 		if ( this.props.shouldHideNavButtons ) {
 			return null;
 		}
@@ -33,9 +31,9 @@ export default localize( React.createClass( {
 				backUrl={ this.props.backUrl }
 				signupProgress={ this.props.signupProgress } />
 		);
-	},
+	}
 
-	renderSkip: function() {
+	renderSkip() {
 		if ( ! this.props.shouldHideNavButtons && this.props.goToNextStep ) {
 			return (
 				<NavigationLink
@@ -46,9 +44,9 @@ export default localize( React.createClass( {
 					stepName={ this.props.stepName } />
 			);
 		}
-	},
+	}
 
-	headerText: function() {
+	headerText() {
 		if ( this.props.positionInFlow === 0 ) {
 			if ( this.props.headerText ) {
 				return this.props.headerText;
@@ -59,9 +57,9 @@ export default localize( React.createClass( {
 		if ( this.props.fallbackHeaderText ) {
 			return this.props.fallbackHeaderText;
 		}
-	},
+	}
 
-	render: function() {
+	render() {
 		const { stepContent, headerButton } = this.props;
 		const classes = classNames( 'step-wrapper', {
 			'is-wide-layout': this.props.isWideLayout,
@@ -83,4 +81,6 @@ export default localize( React.createClass( {
 			</div>
 		);
 	}
-} ) );
+}
+
+export default localize( StepWrapper );


### PR DESCRIPTION
This pull request updates the design of the sign up form based on the mockups in p6qnuF-4hO-p2. 

It updates the order of the social sign up buttons and adds more copy and some styling to the elements.

There are few things that still need to be done:

- [x]  Replace the labels on the buttons with “continue with …”
- [ ]  Replace the social icons with version with color, the svg's can be found [here](https://cloudup.com/cZ136-hGGXY)

The terminology of the actions is still under discussion, let's keep it as is for this PR and address this later.

**Testing instructions**

1. Run git checkout update/social-signup-design and start your server, or open a live branch
2. Open the Login page /start/social
3. Check that the design matches the mockup considering the points above. 

You should also check that **other signup flows work as before**.

**Reviews**

- [x]  Code
- [x]  Product
- [x]  Design