### PR TITLE
Site Settings: Remove sites-list from settings controller

### DIFF
--- a/client/my-sites/site-settings/settings-controller.js
+++ b/client/my-sites/site-settings/settings-controller.js
@@ -9,38 +9,21 @@ import page from 'page';
 import analytics from 'lib/analytics';
 import route from 'lib/route';
 import { sectionify } from 'lib/route/path';
-import sitesFactory from 'lib/sites-list';
 import titlecase from 'to-title-case';
 import utils from 'lib/site/utils';
-
-/**
- * Module vars
- */
-const sites = sitesFactory();
+import { getSelectedSite } from 'state/ui/selectors';
 
 export default {
 	siteSettings( context, next ) {
 		let analyticsPageTitle = 'Site Settings';
 		const basePath = route.sectionify( context.path );
-		const fiveMinutes = 5 * 60 * 1000;
-		let site = sites.getSelectedSite();
+		const site = getSelectedSite( context.store.getState() );
 		const section = sectionify( context.path ).split( '/' )[ 2 ];
 
 		// if site loaded, but user cannot manage site, redirect
 		if ( site && ! utils.userCan( 'manage_options', site ) ) {
 			page.redirect( '/stats' );
 			return;
-		}
-
-		if ( ! site.latestSettings || new Date().getTime() - site.latestSettings > ( fiveMinutes ) ) {
-			if ( sites.initialized ) {
-				site.fetchSettings();
-			} else {
-				sites.once( 'change', function() {
-					site = sites.getSelectedSite();
-					site.fetchSettings();
-				} );
-			}
 		}
 
 		// analytics tracking


### PR DESCRIPTION
This PR removes `sites-list` usage from the site settings controller. It's not necessary at all, since it's used for 2 totally replaceable purposes:

* Fetching the currently selected site - can be done by using the `getSelectedSite` selector.
* Fetching the site settings - it's already being done using the query components in `wrapSettingsForm`.

To test:
* Checkout this branch
* Verify Writing and Discussion settings are retrieved and stored properly for a WordPress.com site.
* Verify Writing and Discussion settings are retrieved and stored properly for a Jetpack site.