### PR TITLE
Add "Site Preview" to sidebar

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -29,6 +29,7 @@ import { getSelectedOrAllSites } from 'state/selectors';
 class CurrentSite extends Component {
 	static propTypes = {
 		isJetpack: React.PropTypes.bool,
+		isPreviewShowing: React.PropTypes.bool,
 		siteCount: React.PropTypes.number.isRequired,
 		setLayoutFocus: React.PropTypes.func.isRequired,
 		selectedSiteId: React.PropTypes.number,
@@ -141,12 +142,12 @@ class CurrentSite extends Component {
 						<a
 							href={ selectedSite.URL }
 							onClick={ this.previewSite }
-							className="current-site__view-site"
+							className={ `current-site__view-site${ this.props.isPreviewShowing ? ' selected' : '' }` }
 						>
+							<Gridicon icon="computer" />
 							<span className="current-site__view-site-text">
-								{ translate( 'View Site' ) }
+								{ translate( 'Site Preview' ) }
 							</span>
-							<Gridicon icon="arrow-right" />
 						</a>
 					</div>
 					: <AllSites />

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -136,12 +136,19 @@ class CurrentSite extends Component {
 					</span>
 				}
 				{ selectedSite
-					? <Site
-						site={ selectedSite }
-						homeLink={ true }
-						externalLink={ true }
-						onSelect={ this.previewSite }
-						tipTarget="site-card-preview" />
+					? <div>
+						<Site site={ selectedSite } />
+						<a
+							href={ selectedSite.URL }
+							onClick={ this.previewSite }
+							className="current-site__view-site"
+						>
+							<span className="current-site__view-site-text">
+								{ translate( 'View Site' ) }
+							</span>
+							<Gridicon icon="arrow-right" />
+						</a>
+					</div>
 					: <AllSites />
 				}
 				{ ! isJetpack && this.getDomainWarnings() }

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -102,10 +102,7 @@ class CurrentSite extends Component {
 		);
 	}
 
-	previewSite = ( event ) => {
-		analytics.ga.recordEvent( 'Sidebar', 'Clicked View Site' );
-		this.props.onClick && this.props.onClick( event );
-	}
+	previewSite = ( event ) => this.props.onClick && this.props.onClick( event );
 
 	render() {
 		const { isJetpack, selectedSite, translate, anySiteSelected } = this.props;

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -144,10 +144,10 @@ class CurrentSite extends Component {
 							onClick={ this.previewSite }
 							className={ `current-site__view-site${ this.props.isPreviewShowing ? ' selected' : '' }` }
 						>
-							<Gridicon icon="computer" />
 							<span className="current-site__view-site-text">
 								{ translate( 'Site Preview' ) }
 							</span>
+							<Gridicon icon="computer" />
 						</a>
 					</div>
 					: <AllSites />

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -44,7 +44,7 @@
 
 .current-site__view-site {
 	font-size: 13px;
-	padding: 14px 16px;
+	padding: 11px 16px;
 	color: $gray-dark;
 	box-sizing: border-box;
 	white-space: nowrap;

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -44,8 +44,7 @@
 
 .current-site__view-site {
 	font-size: 13px;
-	position: relative;
-	padding: 14px 16px 14px 55px;
+	padding: 14px 16px;
 	color: $gray-dark;
 	box-sizing: border-box;
 	white-space: nowrap;
@@ -60,23 +59,11 @@
 	-webkit-tap-highlight-color: rgba( $gray-dark, .2 );
 
 	@include breakpoint( "<660px" ) {
-		padding: 18px 16px 18px 53px;
+		padding: 18px 16px;
 	}
 
 	.gridicon {
-		position: absolute;
-			top: 11px;
-			left: 20px;
 		fill: $gray;
-		height: 24px;
-		width: 24px;
-
-		@include breakpoint( "<660px" ) {
-				top: 15px;
-				left: 16px;
-			height: 24px;
-			width: 24px;
-		}
 	}
 
 	.notouch &:hover:not(.selected) {
@@ -108,6 +95,7 @@
 	align-self: center;
 	color: $gray-dark;
 	font-size: 13px;
+	width: 100%;
 }
 
 .current-site__switch-sites {

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -43,17 +43,43 @@
 }
 
 .current-site__view-site {
+	font-size: 13px;
+	position: relative;
+	padding: 14px 16px 14px 55px;
+	color: $gray-dark;
+	box-sizing: border-box;
+	white-space: nowrap;
+	overflow: hidden;
 	display: flex;
-	border-top: 1px solid darken( $sidebar-bg-color, 5% );
-	flex: 1 0 auto;
-	padding: 8px 16px;
+	border-top: 1px solid darken( $gray-light, 10% );
 
-	.gridicon {
-		fill: $gray;
+	&:focus {
+		outline: none;
 	}
 
-	&:hover,
-	&:focus {
+	-webkit-tap-highlight-color: rgba( $gray-dark, .2 );
+
+	@include breakpoint( "<660px" ) {
+		padding: 18px 16px 18px 53px;
+	}
+
+	.gridicon {
+		position: absolute;
+			top: 11px;
+			left: 20px;
+		fill: $gray;
+		height: 24px;
+		width: 24px;
+
+		@include breakpoint( "<660px" ) {
+				top: 15px;
+				left: 16px;
+			height: 24px;
+			width: 24px;
+		}
+	}
+
+	.notouch &:hover:not(.selected) {
 		background-color: $gray-light;
 
 		.current-site__view-site-text {
@@ -63,12 +89,23 @@
 			fill: $blue-medium;
 		}
 	}
+
+	&.selected {
+		background-color: $sidebar-selected-color;
+
+		.current-site__view-site-text {
+			color: $white;
+		}
+
+		.gridicon {
+			fill: $white;
+		}
+	}
 }
 
 .current-site__view-site-text {
 	display: flex;
 	align-self: center;
-	width: 100%;
 	color: $gray-dark;
 	font-size: 13px;
 }

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -42,6 +42,37 @@
 	}
 }
 
+.current-site__view-site {
+	display: flex;
+	border-top: 1px solid darken( $sidebar-bg-color, 5% );
+	flex: 1 0 auto;
+	padding: 8px 16px;
+
+	.gridicon {
+		fill: $gray;
+	}
+
+	&:hover,
+	&:focus {
+		background-color: $gray-light;
+
+		.current-site__view-site-text {
+			color: $blue-medium;
+		}
+		.gridicon {
+			fill: $blue-medium;
+		}
+	}
+}
+
+.current-site__view-site-text {
+	display: flex;
+	align-self: center;
+	width: 100%;
+	color: $gray-dark;
+	font-size: 13px;
+}
+
 .current-site__switch-sites {
 	background: $sidebar-bg-color;
 	border-bottom: 1px solid darken( $sidebar-bg-color, 5% );

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -29,6 +29,7 @@ import JetpackLogo from 'components/jetpack-logo';
 import { isPersonal, isPremium, isBusiness } from 'lib/products-values';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus, setLayoutFocus } from 'state/ui/layout-focus/actions';
 import {
 	canCurrentUser,
@@ -102,6 +103,10 @@ export class MySitesSidebar extends Component {
 	};
 
 	isItemLinkSelected( paths ) {
+		if ( this.props.isPreviewShowing ) {
+			return false;
+		}
+
 		if ( ! Array.isArray( paths ) ) {
 			paths = [ paths ];
 		}
@@ -559,6 +564,7 @@ export class MySitesSidebar extends Component {
 			<Sidebar>
 				<SidebarRegion>
 					<CurrentSite
+						isPreviewShowing={ this.props.isPreviewShowing }
 						onClick={ this.onPreviewSite }
 					/>
 					{ this.renderSidebarMenus() }
@@ -591,6 +597,8 @@ function mapStateToProps( state ) {
 	// FIXME: Turn into dedicated selector
 	const hasJetpackSites = getSites( state ).some( s => s.jetpack );
 
+	const isPreviewShowing = getCurrentLayoutFocus( state ) === 'preview';
+
 	return {
 		atEnabled: isATEnabled( site ),
 		canManagePlugins,
@@ -604,6 +612,7 @@ function mapStateToProps( state ) {
 		hasJetpackSites,
 		isDomainOnly: isDomainOnlySite( state, selectedSiteId ),
 		isJetpack,
+		isPreviewShowing,
 		isSharingEnabledOnJetpackSite,
 		isSiteAutomatedTransfer: !! isSiteAutomatedTransfer( state, selectedSiteId ),
 		siteId,

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -76,6 +76,7 @@ export class MySitesSidebar extends Component {
 
 	onPreviewSite = ( event ) => {
 		const { site } = this.props;
+		analytics.ga.recordEvent( 'Sidebar', 'Clicked View Site' );
 		if ( site.is_previewable && ! event.metaKey && ! event.ctrlKey ) {
 			event.preventDefault();
 			this.props.setLayoutFocus( 'preview' );
@@ -116,6 +117,17 @@ export class MySitesSidebar extends Component {
 				itemLinkClass={ this.itemLinkClass }
 				onNavigate={ this.onNavigate } />
 		);
+	}
+
+	view() {
+		const { site } = this.props;
+		return site
+			? <SidebarItem
+				icon="house"
+				link={ site.URL }
+				label={ this.props.translate( 'View Site' ) }
+				onNavigate={ this.onPreviewSite } />
+			: null;
 	}
 
 	stats() {
@@ -511,6 +523,7 @@ export class MySitesSidebar extends Component {
 			<div>
 				<SidebarMenu>
 					<ul>
+						{ this.view() }
 						{ this.stats() }
 						{ this.plan() }
 					</ul>

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -119,17 +119,6 @@ export class MySitesSidebar extends Component {
 		);
 	}
 
-	view() {
-		const { site } = this.props;
-		return site
-			? <SidebarItem
-				icon="house"
-				link={ site.URL }
-				label={ this.props.translate( 'View Site' ) }
-				onNavigate={ this.onPreviewSite } />
-			: null;
-	}
-
 	stats() {
 		const { siteId, canUserViewStats } = this.props;
 
@@ -523,7 +512,6 @@ export class MySitesSidebar extends Component {
 			<div>
 				<SidebarMenu>
 					<ul>
-						{ this.view() }
 						{ this.stats() }
 						{ this.plan() }
 					</ul>


### PR DESCRIPTION
Fixes #12781. Replaces PR #12962.

The original view site link (the current site card) maintains original behavior. "View Site" sidebar item is added with the same functionality.

![View Site sidebar item](https://cloud.githubusercontent.com/assets/841763/25128735/1a47cf5e-243b-11e7-861e-9126089d2db0.png)

cc @rickybanister @mtias @folletto 