### PR TITLE
Publish Menu: Drop `sites` usage

### DIFF
--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { compact, includes, omit, reduce, get, mapValues } from 'lodash';
 
@@ -22,13 +22,22 @@ import { areAllSitesSingleUser, canCurrentUser } from 'state/selectors';
 
 const PublishMenu = React.createClass( {
 	propTypes: {
-		site: React.PropTypes.oneOfType( [
-			React.PropTypes.object,
-			React.PropTypes.bool
+		itemLinkClass: PropTypes.func,
+		onNavigate: PropTypes.func,
+		siteId: PropTypes.number,
+		// connected props
+		allSingleSites: PropTypes.bool,
+		canUser: PropTypes.func,
+		isJetpack: PropTypes.bool,
+		isSingleUser: PropTypes.bool,
+		postTypes: PropTypes.object,
+		postTypeLinks: PropTypes.object,
+		siteAdminUrl: PropTypes.string,
+		site: PropTypes.oneOfType( [
+			PropTypes.object,
+			PropTypes.bool
 		] ),
-		postTypes: React.PropTypes.object,
-		itemLinkClass: React.PropTypes.func,
-		onNavigate: React.PropTypes.func
+		siteSlug: PropTypes.string,
 	},
 
 	// We default to `/my` posts when appropriate
@@ -231,8 +240,8 @@ export default connect( ( state, { siteId } ) => {
 			return getEditorPath( state, siteId, null, postTypeSlug );
 		} ),
 		siteAdminUrl: getSiteAdminUrl( state, siteId, ),
-		siteId,
 		site: getSite( state, siteId ),
+		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
 	};
 } )( PublishMenu );

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -244,6 +244,8 @@ export default connect( ( state, { siteId } ) => {
 
 	return {
 		allSingleSites: areAllSitesSingleUser( state ),
+		// TODO: Instead of passing a canUser function prop, we should compute and filter
+		// the list of menuItems inside `connect` and pass it to `PostList` as a prop.
 		canUser: ( cap ) => canCurrentUser( state, siteId, cap ),
 		isJetpack: isJetpackSite( state, siteId ),
 		isSingleUser: isSingleUserSite( state, siteId ),

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { compact, includes, omit, reduce, get, mapValues } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -20,8 +21,8 @@ import MediaLibraryUploadButton from 'my-sites/media-library/upload-button';
 import { getSite, getSiteAdminUrl, getSiteSlug, isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
 import { areAllSitesSingleUser, canCurrentUser } from 'state/selectors';
 
-const PublishMenu = React.createClass( {
-	propTypes: {
+class PublishMenu extends PureComponent {
+	static propTypes = {
 		itemLinkClass: PropTypes.func,
 		onNavigate: PropTypes.func,
 		siteId: PropTypes.number,
@@ -38,7 +39,7 @@ const PublishMenu = React.createClass( {
 			PropTypes.bool
 		] ),
 		siteSlug: PropTypes.string,
-	},
+	}
 
 	// We default to `/my` posts when appropriate
 	getMyParameter() {
@@ -49,7 +50,7 @@ const PublishMenu = React.createClass( {
 		}
 
 		return ( allSingleSites ) ? '' : '/my';
-	},
+	}
 
 	getDefaultMenuItems() {
 		const { siteSlug } = this.props;
@@ -57,7 +58,7 @@ const PublishMenu = React.createClass( {
 		const items = [
 			{
 				name: 'post',
-				label: this.translate( 'Blog Posts' ),
+				label: this.props.translate( 'Blog Posts' ),
 				className: 'posts',
 				capability: 'edit_posts',
 				config: 'manage/posts',
@@ -70,7 +71,7 @@ const PublishMenu = React.createClass( {
 			},
 			{
 				name: 'page',
-				label: this.translate( 'Pages' ),
+				label: this.props.translate( 'Pages' ),
 				className: 'pages',
 				capability: 'edit_pages',
 				queryable: true,
@@ -85,7 +86,7 @@ const PublishMenu = React.createClass( {
 		if ( config.isEnabled( 'manage/media' ) ) {
 			items.push( {
 				name: 'media',
-				label: this.translate( 'Media' ),
+				label: this.props.translate( 'Media' ),
 				className: 'media-section',
 				capability: 'upload_files',
 				queryable: true,
@@ -97,15 +98,15 @@ const PublishMenu = React.createClass( {
 			} );
 		}
 		return items;
-	},
+	}
 
-	onNavigate( postType ) {
+	onNavigate = ( postType ) => () => {
 		if ( ! includes( [ 'post', 'page' ], postType ) ) {
 			analytics.mc.bumpStat( 'calypso_publish_menu_click', postType );
 		}
 
 		this.props.onNavigate();
-	},
+	}
 
 	renderMenuItem( menuItem ) {
 		const { canUser, site, siteId, siteAdminUrl } = this.props;
@@ -161,19 +162,23 @@ const PublishMenu = React.createClass( {
 				label={ menuItem.label }
 				className={ className }
 				link={ link }
-				onNavigate={ this.onNavigate.bind( this, menuItem.name ) }
+				onNavigate={ this.onNavigate( menuItem.name ) }
 				icon={ icon }
 				preloadSectionName={ preload }
 			>
 				{ menuItem.name === 'media' && (
-					<MediaLibraryUploadButton className="sidebar__button" site={ site } href={ menuItem.buttonLink }>{ this.translate( 'Add' ) }</MediaLibraryUploadButton>
+					<MediaLibraryUploadButton className="sidebar__button" site={ site } href={ menuItem.buttonLink }>
+						{ this.props.translate( 'Add' ) }
+					</MediaLibraryUploadButton>
 				) }
 				{ menuItem.name !== 'media' && (
-					<SidebarButton href={ menuItem.buttonLink } preloadSectionName="post-editor">{ this.translate( 'Add' ) }</SidebarButton>
+					<SidebarButton href={ menuItem.buttonLink } preloadSectionName="post-editor">
+						{ this.props.translate( 'Add' ) }
+					</SidebarButton>
 				) }
 			</SidebarItem>
 		);
-	},
+	}
 
 	getCustomMenuItems() {
 		const customPostTypes = omit( this.props.postTypes, [ 'post', 'page' ] );
@@ -208,7 +213,7 @@ const PublishMenu = React.createClass( {
 				buttonLink
 			} );
 		}, [] );
-	},
+	}
 
 	render() {
 		const menuItems = [
@@ -221,11 +226,11 @@ const PublishMenu = React.createClass( {
 				{ this.props.siteId && (
 					<QueryPostTypes siteId={ this.props.siteId } />
 				) }
-				{ menuItems.map( this.renderMenuItem ) }
+				{ menuItems.map( this.renderMenuItem, this ) }
 			</ul>
 		);
 	}
-} );
+}
 
 export default connect( ( state, { siteId } ) => {
 	const postTypes = getPostTypes( state, siteId );
@@ -244,4 +249,4 @@ export default connect( ( state, { siteId } ) => {
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
 	};
-} )( PublishMenu );
+} )( localize( PublishMenu ) );

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -11,7 +11,7 @@ import { includes, omit, reduce, get, mapValues } from 'lodash';
 import SidebarItem from 'layout/sidebar/item';
 import SidebarButton from 'layout/sidebar/button';
 import config from 'config';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
 import { getPostTypes } from 'state/post-types/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
@@ -223,7 +223,7 @@ const PublishMenu = React.createClass( {
 } );
 
 export default connect( ( state ) => {
-	const siteId = get( getSelectedSite( state ), 'ID' );
+	const siteId = getSelectedSiteId( state );
 	const postTypes = getPostTypes( state, siteId );
 
 	return {

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -17,7 +17,7 @@ import QueryPostTypes from 'components/data/query-post-types';
 import analytics from 'lib/analytics';
 import { decodeEntities } from 'lib/formatting';
 import MediaLibraryUploadButton from 'my-sites/media-library/upload-button';
-import { getSiteAdminUrl, getSiteSlug, isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
+import { getSite, getSiteAdminUrl, getSiteSlug, isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
 import { areAllSitesSingleUser, canCurrentUser } from 'state/selectors';
 
 const PublishMenu = React.createClass( {
@@ -27,8 +27,6 @@ const PublishMenu = React.createClass( {
 			React.PropTypes.bool
 		] ),
 		postTypes: React.PropTypes.object,
-		siteSuffix: React.PropTypes.string,
-		isSingle: React.PropTypes.bool,
 		itemLinkClass: React.PropTypes.func,
 		onNavigate: React.PropTypes.func
 	},
@@ -114,7 +112,7 @@ const PublishMenu = React.createClass( {
 		// Hide the sidebar link for multiple site view if it's not in calypso, or
 		// if it opts not to be shown.
 		const isEnabled = config.isEnabled( menuItem.config );
-		if ( ! this.props.isSingle && ( ! isEnabled || ! menuItem.showOnAllMySites ) ) {
+		if ( ! this.props.siteId && ( ! isEnabled || ! menuItem.showOnAllMySites ) ) {
 			return null;
 		}
 
@@ -233,6 +231,7 @@ export default connect( ( state, { siteId } ) => {
 		} ),
 		siteAdminUrl: getSiteAdminUrl( state, siteId, ),
 		siteId,
+		site: getSite( state, siteId ),
 		siteSlug: getSiteSlug( state, siteId ),
 	};
 } )( PublishMenu );

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -100,7 +100,8 @@ const PublishMenu = React.createClass( {
 
 	renderMenuItem( menuItem ) {
 		const { canUser, site, siteAdminUrl } = this.props;
-		if ( canUser( menuItem.capability ) ) {
+
+		if ( ! canUser( menuItem.capability ) ) {
 			return null;
 		}
 

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -99,9 +99,9 @@ const PublishMenu = React.createClass( {
 	},
 
 	renderMenuItem( menuItem ) {
-		const { canUser, site, siteAdminUrl } = this.props;
+		const { canUser, site, siteId, siteAdminUrl } = this.props;
 
-		if ( ! canUser( menuItem.capability ) ) {
+		if ( siteId && ! canUser( menuItem.capability ) ) {
 			return null;
 		}
 
@@ -113,7 +113,7 @@ const PublishMenu = React.createClass( {
 		// Hide the sidebar link for multiple site view if it's not in calypso, or
 		// if it opts not to be shown.
 		const isEnabled = config.isEnabled( menuItem.config );
-		if ( ! this.props.siteId && ( ! isEnabled || ! menuItem.showOnAllMySites ) ) {
+		if ( ! siteId && ( ! isEnabled || ! menuItem.showOnAllMySites ) ) {
 			return null;
 		}
 

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -235,4 +235,4 @@ export default connect( ( state, { siteId } ) => {
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
 	};
-}, null, null, { pure: false } )( PublishMenu );
+} )( PublishMenu );

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -49,6 +49,13 @@ class PublishMenu extends PureComponent {
 			return ( isSingleUser || isJetpack ) ? '' : '/my';
 		}
 
+		// FIXME: If you clear `IndexedDB` and land on a site that has yourself as its only user,
+		// and then navigate to multi-site mode, the `areAllSites` predicate will return true,
+		// as long as no other sites have been fetched into Redux state. As a consequence, the
+		// 'Posts' link will point to `/posts` (instead of `/posts/my` as it should, when you have
+		// sites with other users).
+		// The fix will be to make sure all sites are fetched into Redux state, see
+		// https://github.com/Automattic/wp-calypso/pull/13094
 		return ( allSingleSites ) ? '' : '/my';
 	}
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -133,8 +133,6 @@ export class MySitesSidebar extends Component {
 	publish() {
 		return (
 			<PublishMenu siteId={ this.props.singleSiteId }
-				siteSuffix={ this.siteSuffix() }
-				isSingle={ this.props.isSingleSite }
 				itemLinkClass={ this.itemLinkClass }
 				onNavigate={ this.onNavigate } />
 		);
@@ -644,15 +642,15 @@ function mapStateToProps( state ) {
 	const selectedSiteId = getSelectedSiteId( state );
 	const isSingleSite = !! selectedSiteId || currentUser.site_count === 1;
 	const singleSiteId = selectedSiteId || ( isSingleSite && getPrimarySiteId( state ) );
+
 	return {
 		currentUser,
 		customizeUrl: getCustomizerUrl( state, selectedSiteId ),
 		isDomainOnly: isDomainOnlySite( state, selectedSiteId ),
 		isJetpack: isJetpackSite( state, selectedSiteId ),
-		isSingleSite,
 		isSiteAutomatedTransfer: !! isSiteAutomatedTransfer( state, selectedSiteId ),
 		menusUrl: getMenusUrl( state, singleSiteId ),
-		selectedSiteId
+		singleSiteId
 	};
 }
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -641,7 +641,7 @@ function mapStateToProps( state ) {
 	const currentUser = getCurrentUser( state );
 	const selectedSiteId = getSelectedSiteId( state );
 	const isSingleSite = !! selectedSiteId || currentUser.site_count === 1;
-	const singleSiteId = selectedSiteId || ( isSingleSite && getPrimarySiteId( state ) );
+	const singleSiteId = selectedSiteId || ( isSingleSite && getPrimarySiteId( state ) ) || null;
 
 	return {
 		currentUser,

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -132,10 +132,9 @@ export class MySitesSidebar extends Component {
 
 	publish() {
 		return (
-			<PublishMenu site={ this.getSelectedSite() }
-				sites={ this.props.sites }
+			<PublishMenu siteId={ this.props.singleSiteId }
 				siteSuffix={ this.siteSuffix() }
-				isSingle={ this.isSingle() }
+				isSingle={ this.props.isSingleSite }
 				itemLinkClass={ this.itemLinkClass }
 				onNavigate={ this.onNavigate } />
 		);
@@ -650,8 +649,10 @@ function mapStateToProps( state ) {
 		customizeUrl: getCustomizerUrl( state, selectedSiteId ),
 		isDomainOnly: isDomainOnlySite( state, selectedSiteId ),
 		isJetpack: isJetpackSite( state, selectedSiteId ),
+		isSingleSite,
 		isSiteAutomatedTransfer: !! isSiteAutomatedTransfer( state, selectedSiteId ),
 		menusUrl: getMenusUrl( state, singleSiteId ),
+		selectedSiteId
 	};
 }
 

--- a/client/state/selectors/are-all-sites-single-user.js
+++ b/client/state/selectors/are-all-sites-single-user.js
@@ -12,5 +12,5 @@ import { isSingleUserSite } from 'state/sites/selectors';
  */
 export default createSelector( ( state ) => {
 	const siteIds = Object.keys( state.sites.items );
-	return siteIds && siteIds.every( ( siteId ) => isSingleUserSite( state, siteId ) );
+	return !! siteIds.length && siteIds.every( ( siteId ) => isSingleUserSite( state, siteId ) );
 }, ( state ) => ( state.sites.items ) );

--- a/client/state/selectors/test/are-all-sites-single-user.js
+++ b/client/state/selectors/test/are-all-sites-single-user.js
@@ -9,6 +9,17 @@ import { expect } from 'chai';
 import { areAllSitesSingleUser } from '../';
 
 describe( 'areAllSitesSingleUser()', () => {
+	it( 'should return false sites haven\'t been fetched yet', () => {
+		const state = {
+			sites: {
+				items: {}
+			}
+		};
+
+		const allAreSingleUser = areAllSitesSingleUser( state );
+		expect( allAreSingleUser ).to.be.false;
+	} );
+
 	it( 'should return false if single_user_site isn\'t true for all sites', () => {
 		const state = {
 			sites: {


### PR DESCRIPTION
The Publish Menu is this thing:

![image](https://cloud.githubusercontent.com/assets/96308/25142163/4e797aa4-2466-11e7-9f9a-a7d0ae2d951c.png)

To test: Compare this branch's behavior to production. Make sure that the same items appear, and that they point to the same URLs. Also check the little 'Add' buttons!

There's a minor _regression_: If you clear `IndexedDB` and land on a site that has yourself as its only user, and then navigate to multi-site mode, the `areAllSitesSingleUser` predicate will return true, as long as no other sites have been fetched into Redux state. As a consequence, the 'Posts' link will point to `/posts` (instead of `/posts/my` as it should, when you have sites with other users).

We'll only be able to get rid of this regression once Redux state becomes our source of truth and is guaranteed to fetch all sites when in multi-site mode.