### PR TITLE
Add `gravatar-hovercards` toggle

### DIFF
--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -105,7 +105,6 @@ class SiteSettingsFormDiscussion extends Component {
 		const {
 			fields,
 			handleAutosavingToggle,
-			isJetpack,
 			isRequestingSettings,
 			isSavingSettings,
 			siteId,
@@ -184,7 +183,6 @@ class SiteSettingsFormDiscussion extends Component {
 				</CompactFormToggle>
 				<JetpackModuleToggle
 					disabled={ isRequestingSettings || isSavingSettings }
-					isJetpackSite={ isJetpack }
 					label={ translate( 'Enable pop-up business cards over commenters’ Gravatars' ) }
 					moduleSlug="gravatar-hovercards"
 					siteId={ siteId }

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { flowRight, pick } from 'lodash';
+import { flowRight, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -29,6 +29,7 @@ import {
 } from 'state/sites/selectors';
 import { isJetpackModuleActive } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import JetpackModuleToggle from './jetpack-module-toggle';
 
 class SiteSettingsFormDiscussion extends Component {
 	handleCommentOrder = () => {
@@ -104,8 +105,10 @@ class SiteSettingsFormDiscussion extends Component {
 		const {
 			fields,
 			handleAutosavingToggle,
+			isJetpack,
 			isRequestingSettings,
 			isSavingSettings,
+			siteId,
 			translate
 		} = this.props;
 		return (
@@ -179,12 +182,13 @@ class SiteSettingsFormDiscussion extends Component {
 					onChange={ this.handleCommentOrder }>
 					<span>{ translate( 'Comments should be displayed with the older comments at the top of each page' ) }</span>
 				</CompactFormToggle>
-				<CompactFormToggle
-					checked={ fields[ 'gravatar-hovercards' ] }
+				<JetpackModuleToggle
 					disabled={ isRequestingSettings || isSavingSettings }
-					onChange={ handleAutosavingToggle( 'gravatar-hovercards' ) }>
-					<span>{ translate( 'Enable pop-up business cards over commenters’ Gravatars' ) }</span>
-				</CompactFormToggle>
+					isJetpackSite={ isJetpack }
+					label={ translate( 'Enable pop-up business cards over commenters’ Gravatars' ) }
+					moduleSlug="gravatar-hovercards"
+					siteId={ siteId }
+				/>
 			</FormFieldset>
 		);
 	}
@@ -649,7 +653,6 @@ const getFormSettings = settings => {
 		'subscriptions',
 		'stb_enabled',
 		'stc_enabled',
-		'gravatar-hovercards',
 	] );
 };
 

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -179,6 +179,12 @@ class SiteSettingsFormDiscussion extends Component {
 					onChange={ this.handleCommentOrder }>
 					<span>{ translate( 'Comments should be displayed with the older comments at the top of each page' ) }</span>
 				</CompactFormToggle>
+				<CompactFormToggle
+					checked={ fields[ 'gravatar-hovercards' ] }
+					disabled={ isRequestingSettings || isSavingSettings }
+					onChange={ handleAutosavingToggle( 'gravatar-hovercards' ) }>
+					<span>{ translate( 'Enable pop-up business cards over commenters’ Gravatars' ) }</span>
+				</CompactFormToggle>
 			</FormFieldset>
 		);
 	}
@@ -643,6 +649,7 @@ const getFormSettings = settings => {
 		'subscriptions',
 		'stb_enabled',
 		'stc_enabled',
+		'gravatar-hovercards',
 	] );
 };
 


### PR DESCRIPTION
Fixes #12902

## Review status

- [x] Code
- [x] Design

## Captures

Capture of changes, green box highlights new toggle. 

![gravatar-toggle](https://cloud.githubusercontent.com/assets/841763/25222158/ee12b682-25b7-11e7-872f-060b20b1cefe.png)

## To test

1. Checkout and run branch.
1. Open Jetpack site in local calypso.
1. Visit settings/discussion/:site for a Jetpack :site.
1. Ensure that the toggle works correctly to enable/disable the module.