### PR TITLE
Site Settings: Import: Use Redux site instead of sites-list

### DIFF
--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -81,7 +81,7 @@ export class SiteSettingsComponent extends Component {
 			case 'security':
 				return <SiteSecurity site={ site } />;
 			case 'import':
-				return <ImportSettings site={ site } />;
+				return <ImportSettings />;
 			case 'export':
 				return <ExportSettings />;
 			case 'guidedTransfer':

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -23,7 +23,7 @@ import { getSelectedSite } from 'state/ui/selectors';
 class SiteSettingsImport extends Component {
 	static propTypes = {
 		site: PropTypes.object,
-	};
+	}
 
 	state = getImporterState();
 
@@ -66,11 +66,11 @@ class SiteSettingsImport extends Component {
 
 	updateFromAPI = () => {
 		fetchState( this.props.site.ID );
-	};
+	}
 
 	updateState = () => {
 		this.setState( getImporterState() );
-	};
+	}
 
 	render() {
 		const { site, translate } = this.props;

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 import config from 'config';
 
 /**
@@ -16,31 +18,26 @@ import MediumImporter from 'my-sites/importer/importer-medium';
 import { fetchState } from 'lib/importer/actions';
 import { appStates, WORDPRESS, MEDIUM } from 'state/imports/constants';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
+import { getSelectedSite } from 'state/ui/selectors';
 
-export default React.createClass( {
-	displayName: 'SiteSettingsImport',
+class SiteSettingsImport extends Component {
+	static propTypes = {
+		site: PropTypes.object,
+	};
 
-	propTypes: {
-		site: React.PropTypes.oneOfType( [
-			React.PropTypes.bool,
-			PropTypes.shape( {
-				slug: PropTypes.string.isRequired,
-				title: PropTypes.string.isRequired
-			} )
-		] )
-	},
+	constructor( props ) {
+		super( props );
 
-	componentDidMount: function() {
+		this.state = getImporterState();
+	}
+
+	componentDidMount() {
 		ImporterStore.on( 'change', this.updateState );
-	},
+	}
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		ImporterStore.off( 'change', this.updateState );
-	},
-
-	getInitialState: function() {
-		return getImporterState();
-	},
+	}
 
 	/**
 	 * Finds the import status objects for a
@@ -49,7 +46,7 @@ export default React.createClass( {
 	 * @param {enum} type ImportConstants.IMPORT_TYPE_*
 	 * @returns {Array<Object>} ImportStatus objects
 	 */
-	getImports: function( type ) {
+	getImports( type ) {
 		const { api: { isHydrated }, importers } = this.state;
 		const { site } = this.props;
 		const { slug, title } = site;
@@ -69,21 +66,25 @@ export default React.createClass( {
 		}
 
 		return status.map( item => Object.assign( {}, item, { site, siteTitle } ) );
-	},
+	}
 
-	updateFromAPI: function() {
+	updateFromAPI = () => {
 		fetchState( this.props.site.ID );
-	},
+	};
 
-	updateState: function() {
+	updateState = () => {
 		this.setState( getImporterState() );
-	},
+	};
 
-	render: function() {
-		const { site } = this.props;
+	render() {
+		const { site, translate } = this.props;
+		if ( ! site ) {
+			return null;
+		}
+
 		const { jetpack: isJetpack, options: { admin_url: adminUrl }, slug, title: siteTitle } = site;
 		const title = siteTitle.length ? siteTitle : slug;
-		const description = this.translate(
+		const description = translate(
 			'Import another site\'s content into ' +
 			'{{strong}}%(title)s{{/strong}}. Once you start an ' +
 			'import, come back here to check on the progress. ' +
@@ -101,9 +102,9 @@ export default React.createClass( {
 			return (
 				<EmptyContent
 					illustration="/calypso/images/drake/drake-jetpack.svg"
-					title={ this.translate( 'Want to import into your site?' ) }
-					line={ this.translate( `Visit your site's wp-admin for all your import and export needs.` ) }
-					action={ this.translate( 'Import into %(title)s', { args: { title } } ) }
+					title={ translate( 'Want to import into your site?' ) }
+					line={ translate( 'Visit your site\'s wp-admin for all your import and export needs.' ) }
+					action={ translate( 'Import into %(title)s', { args: { title } } ) }
 					actionURL={ adminUrl + 'import.php' }
 					actionTarget="_blank"
 				/>
@@ -116,7 +117,9 @@ export default React.createClass( {
 					<Interval onTick={ this.updateFromAPI } period={ EVERY_FIVE_SECONDS } />
 					<CompactCard>
 						<header>
-							<h1 className="importer__section-title">{ this.translate( 'Import Another Site' ) }</h1>
+							<h1 className="site-settings__importer-section-title importer__section-title">
+								{ translate( 'Import Another Site' ) }
+							</h1>
 							<p className="importer__section-description">{ description }</p>
 						</header>
 					</CompactCard>
@@ -129,10 +132,16 @@ export default React.createClass( {
 							<MediumImporter { ...{ key, site, importerStatus } } /> ) }
 
 					<CompactCard href={ adminUrl + 'import.php' } target="_blank" rel="noopener noreferrer">
-						{ this.translate( 'Other importers' ) }
+						{ translate( 'Other importers' ) }
 					</CompactCard>
 				</EmailVerificationGate>
 			</div>
 		);
 	}
-} );
+}
+
+export default connect(
+	( state ) => ( {
+		site: getSelectedSite( state ),
+	} )
+)( localize( SiteSettingsImport ) );

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -25,11 +25,7 @@ class SiteSettingsImport extends Component {
 		site: PropTypes.object,
 	};
 
-	constructor( props ) {
-		super( props );
-
-		this.state = getImporterState();
-	}
+	state = getImporterState();
 
 	componentDidMount() {
 		ImporterStore.on( 'change', this.updateState );


### PR DESCRIPTION
This PR updates the Import settings section form to NOT use the `sites-list` selected site, but rather the Redux one. It also takes care of several edge cases that were occurring when the user visits the Import settings page with no cache. In addition it refactors `SiteSettingsImport` to a class, as recommended by our code standards.

This PR is part of a series that aims to remove `sites-list` completely from site settings. 

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/settings/import/:site where:
  * `:site` is one of your Jetpack sites
  * `:site` is one of your WordPress.com sites
* For both site types, verify the section loads correctly without errors.
* For both site types, clear all of your browser cache (except cookies), and verify the section still loads correctly without errors.
* For WordPress.com sites, verify the import process still works like it did before.