### PR TITLE
Purchases: Update renewal period on success notice

### DIFF
--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -277,7 +277,7 @@ const Checkout = React.createClass( {
 						'We sent your receipt to %(email)s.', {
 							args: {
 								productName: renewalItem.product_name,
-								duration: i18n.moment.duration( renewalItem.bill_period, 'days' ).humanize(),
+								duration: i18n.moment.duration( { days: renewalItem.bill_period } ).humanize(),
 								date: i18n.moment( product.expiry ).format( 'MMM DD, YYYY' ),
 								email: product.user_email
 							}


### PR DESCRIPTION
As noted in #12701, the time duration in the success message displayed on renewal is off. Instead of "renewed for a year," you'll see "renewed for a few seconds."

I still not sure why `moment.duration()` is behaving this way. It should be showing the correct time period. I created [a JS Bin](http://jsbin.com/tayoneveli/2/edit?js,console) using the same format that's working as expected. 

In `checkout.jsx`, this is fixed by passing an object into `duration()` (laid out in the docs [here](http://momentjs.com/docs/#/durations/creating/)).

## To test
1. Starting URL: http://calypso.localhost:3000/plans
2. Purchase a plan
3. Go to http://calypso.localhost:3000/me/purchases/ and manually renew for another year

## Screenshots

**Previous**
![64a14190-1615-11e7-9adb-122b1a647b96](https://cloud.githubusercontent.com/assets/7240478/25134231/4be0c68a-240c-11e7-9ec3-9cea95c4f87e.png)

**Updated**
<img width="800" alt="screen shot 2017-04-18 at 7 29 06 am" src="https://cloud.githubusercontent.com/assets/7240478/25134238/50682400-240c-11e7-9fae-10cc98da3033.png">
