### PR TITLE
Framework: Only persist state for logged-in users

### DIFF
--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -232,12 +232,12 @@ User.prototype.clear = function( onClear ) {
 	 * Clear internal user data and empty localStorage cache
 	 * to discard any user reference that the application may hold
 	 */
-	const persistedDataKey = 'redux-state-' + this.data.ID;
+	const userID = this.data.ID;
 	this.data = [];
 	delete this.settings;
 	store.clear();
 	if ( config.isEnabled( 'persist-redux' ) ) {
-		localforage.removeItem( persistedDataKey, onClear );
+		localforage.removeItem( 'redux-state-' + userID, onClear );
 	}
 };
 

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -232,11 +232,12 @@ User.prototype.clear = function( onClear ) {
 	 * Clear internal user data and empty localStorage cache
 	 * to discard any user reference that the application may hold
 	 */
+	const persistedDataKey = 'redux-state-' + this.data.ID;
 	this.data = [];
 	delete this.settings;
 	store.clear();
 	if ( config.isEnabled( 'persist-redux' ) ) {
-		localforage.removeItem( 'redux-state', onClear );
+		localforage.removeItem( persistedDataKey, onClear );
 	}
 };
 

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -232,12 +232,11 @@ User.prototype.clear = function( onClear ) {
 	 * Clear internal user data and empty localStorage cache
 	 * to discard any user reference that the application may hold
 	 */
-	const userID = this.data.ID;
 	this.data = [];
 	delete this.settings;
 	store.clear();
 	if ( config.isEnabled( 'persist-redux' ) ) {
-		localforage.removeItem( 'redux-state-' + userID, onClear );
+		localforage.clear( onClear );
 	}
 };
 

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -70,7 +70,8 @@ function loadInitialStateFailed( error ) {
 }
 
 function isLoggedIn() {
-	return !! user.get() && user.get().ID;
+	const userData = user.get();
+	return !! userData && userData.ID;
 }
 
 export function persistOnChange( reduxStore, serializeState = serialize ) {

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -16,11 +16,13 @@ import {
 import localforage from 'lib/localforage';
 import { isSupportUserSession } from 'lib/user/support-user-interop';
 import config from 'config';
+import User from 'lib/user';
 
 /**
  * Module variables
  */
 const debug = debugModule( 'calypso:state' );
+const user = User();
 
 const DAY_IN_HOURS = 24;
 const HOUR_IN_MS = 3600000;
@@ -71,6 +73,10 @@ export function persistOnChange( reduxStore, serializeState = serialize ) {
 	let state;
 
 	const throttledSaveState = throttle( function() {
+		if ( ! user.get() ) {
+			return;
+		}
+
 		const nextState = reduxStore.getState();
 		if ( state && nextState === state ) {
 			return;

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -73,13 +73,6 @@ function isLoggedIn() {
 	return !! user.get() && user.get().ID;
 }
 
-export function getPersistedStorageKey() {
-	if ( ! isLoggedIn() ) {
-		return null;
-	}
-	return 'redux-state-' + user.get().ID;
-}
-
 export function persistOnChange( reduxStore, serializeState = serialize ) {
 	let state;
 
@@ -95,7 +88,7 @@ export function persistOnChange( reduxStore, serializeState = serialize ) {
 
 		state = nextState;
 
-		localforage.setItem( getPersistedStorageKey(), serializeState( state ) )
+		localforage.setItem( 'redux-state-' + user.get().ID, serializeState( state ) )
 			.catch( ( setError ) => {
 				debug( 'failed to set redux-store state', setError );
 			} );
@@ -112,9 +105,9 @@ export function persistOnChange( reduxStore, serializeState = serialize ) {
 
 export default function createReduxStoreFromPersistedInitialState( reduxStoreReady ) {
 	if ( config.isEnabled( 'persist-redux' ) && isLoggedIn() && ! isSupportUserSession() ) {
-		// clear storage with old-style key
+		// clear storage any storage that used the old-style key
 		localforage.removeItem( 'redux-state' );
-		localforage.getItem( getPersistedStorageKey() )
+		localforage.getItem( 'redux-state-' + user.get().ID )
 			.then( loadInitialState )
 			.catch( loadInitialStateFailed )
 			.then( persistOnChange )

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -105,8 +105,6 @@ export function persistOnChange( reduxStore, serializeState = serialize ) {
 
 export default function createReduxStoreFromPersistedInitialState( reduxStoreReady ) {
 	if ( config.isEnabled( 'persist-redux' ) && isLoggedIn() && ! isSupportUserSession() ) {
-		// clear storage any storage that used the old-style key
-		localforage.removeItem( 'redux-state' );
 		localforage.getItem( 'redux-state-' + user.get().ID )
 			.then( loadInitialState )
 			.catch( loadInitialStateFailed )

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -42,7 +42,9 @@ describe( 'initial-state', () => {
 		mockery.registerMock( 'lib/localforage', localforage );
 		mockery.registerMock( 'lib/user', () => {
 			return {
-				get: () => true
+				get: () => {
+					return { ID: 123456789 };
+				}
 			};
 		} );
 		const initialState = require( 'state/initial-state' );
@@ -397,8 +399,8 @@ describe( 'initial-state', () => {
 			clock.tick( SERIALIZE_THROTTLE );
 
 			expect( localforage.setItem ).to.have.been.calledTwice;
-			expect( localforage.setItem ).to.have.been.calledWith( 'redux-state', 3 );
-			expect( localforage.setItem ).to.have.been.calledWith( 'redux-state', 5 );
+			expect( localforage.setItem ).to.have.been.calledWith( 'redux-state-123456789', 3 );
+			expect( localforage.setItem ).to.have.been.calledWith( 'redux-state-123456789', 5 );
 		} );
 	} );
 } );

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -40,6 +40,11 @@ describe( 'initial-state', () => {
 		mockery.registerMock( 'config', configMock );
 		localforage = require( 'lib/localforage/localforage-bypass' );
 		mockery.registerMock( 'lib/localforage', localforage );
+		mockery.registerMock( 'lib/user', () => {
+			return {
+				get: () => true
+			};
+		} );
 		const initialState = require( 'state/initial-state' );
 		createReduxStoreFromPersistedInitialState = initialState.default;
 		persistOnChange = initialState.persistOnChange;


### PR DESCRIPTION
Fixes #11766

Only ever read or write persistent state if a user is logged-in, and key the store by user ID to prevent any cross-contamination.

**To Test**
* Log in and out, checking the `calypso_store` in IndexedDB in the browser.
* The `redux-state` item should now be `redux-state-{userId}` when logged in
* When logged out that item should not be present

