### PR TITLE
Make Jetpack "Go back to {site}" link to Jetpack dashboard

### DIFF
--- a/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-return-to-dashboard.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-return-to-dashboard.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
+import { untrailingslashit } from 'lib/route';
 
 /**
  * Internal dependencies
@@ -11,7 +12,10 @@ import { get } from 'lodash';
 import PurchaseDetail from 'components/purchase-detail';
 
 export default localize( ( { selectedSite, translate } ) => {
-	const adminURL = get( selectedSite, 'options.admin_url', '' );
+	let adminURL = get( selectedSite, 'options.admin_url', '' );
+	if ( adminURL ) {
+		adminURL = untrailingslashit( adminURL ) + '/admin.php?page=jetpack';
+	}
 
 	return (
 		<div className="product-purchase-features-list__item">


### PR DESCRIPTION
Fixes #12789 

To test:
1. Checkout branch `git checkout fix/12789-jp-back-to-site-link`.
1. Visit `/plans/my-plan/:site` for a Jetpack site.
1. Click "Go back to {site}" link under "Return to your site's dashboard."
1. You should go directly to the Jetpack dashboard rather than the site dashboard.

cc @beaulebens 