### PR TITLE
Framework: update lib/automated-transfer interface and remove usage

### DIFF
--- a/client/lib/automated-transfer/index.js
+++ b/client/lib/automated-transfer/index.js
@@ -10,8 +10,9 @@ import { PLAN_BUSINESS } from 'lib/plans/constants';
 import { userCan } from 'lib/site/utils';
 
 /**
- * Returns true if Automated Transfer is enabled for the current site and current user.
- * @returns {Boolean} true if enabled for the current site and current user
+ * Returns true if Automated Transfer is enabled for the given site
+ * @param { object } site - a full site object
+ * @returns { boolean } - true if AT is enabled for the site
  */
 export function isATEnabled( site ) {
 	// don't let this explode in SSR'd envs

--- a/client/lib/automated-transfer/index.js
+++ b/client/lib/automated-transfer/index.js
@@ -13,13 +13,11 @@ import { userCan } from 'lib/site/utils';
  * Returns true if Automated Transfer is enabled for the current site and current user.
  * @returns {Boolean} true if enabled for the current site and current user
  */
-export function isATEnabledForCurrentSite() {
+export function isATEnabled( site ) {
 	// don't let this explode in SSR'd envs
 	if ( typeof window !== 'object' ) {
 		return false;
 	}
-
-	const site = require( 'lib/sites-list' )().getSelectedSite();
 
 	// Site has already been transferred
 	if ( get( site, 'options.is_automated_transfer' ) ) {

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -9,7 +9,6 @@ import { compact, includes } from 'lodash';
  * Internal dependencies
  */
 import { isEnabled } from 'config';
-import { isATEnabledForCurrentSite } from 'lib/automated-transfer';
 
 // plans constants
 export const PLAN_BUSINESS = 'business-bundle';
@@ -208,8 +207,6 @@ export const PLANS_LIST = {
 			isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
 			FEATURE_BUSINESS_ONBOARDING,
 			FEATURE_ADVANCED_SEO,
-			isATEnabledForCurrentSite() && FEATURE_UPLOAD_PLUGINS,
-			isATEnabledForCurrentSite() && FEATURE_UPLOAD_THEMES,
 			FEATURE_GOOGLE_ANALYTICS,
 			FEATURE_NO_BRANDING,
 		] ),

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -193,7 +193,7 @@ export const PLANS_LIST = {
 					strong: <strong className="plans__features plan-features__targeted-description-heading" />
 				}
 			} ),
-		getFeatures: () => compact( [ // pay attention to ordering, shared features should align on /plan page
+		getFeatures: ( abtest ) => compact( [ // pay attention to ordering, shared features should align on /plan page
 			FEATURE_CUSTOM_DOMAIN,
 			FEATURE_JETPACK_ESSENTIAL,
 			FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
@@ -207,6 +207,8 @@ export const PLANS_LIST = {
 			isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
 			FEATURE_BUSINESS_ONBOARDING,
 			FEATURE_ADVANCED_SEO,
+			isEnabled( 'automated-transfer' ) && abtest( 'automatedTransfer2' ) === 'enabled' && FEATURE_UPLOAD_PLUGINS,
+			isEnabled( 'automated-transfer' ) && abtest( 'automatedTransfer2' ) === 'enabled' && FEATURE_UPLOAD_THEMES,
 			FEATURE_GOOGLE_ANALYTICS,
 			FEATURE_NO_BRANDING,
 		] ),

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -47,7 +47,7 @@ import {
 	domainManagementTransferToAnotherUser
 } from 'my-sites/upgrades/paths';
 import SitesComponent from 'my-sites/sites';
-import { isATEnabledForCurrentSite } from 'lib/automated-transfer';
+import { isATEnabled } from 'lib/automated-transfer';
 
 /**
  * Module vars
@@ -401,7 +401,7 @@ module.exports = {
 		const basePath = route.sectionify( context.path );
 		const selectedSite = sites.getSelectedSite();
 
-		if ( selectedSite && selectedSite.jetpack && ! isATEnabledForCurrentSite() ) {
+		if ( selectedSite && selectedSite.jetpack && ! isATEnabled( selectedSite ) ) {
 			renderWithReduxStore( (
 				<Main>
 					<JetpackManageErrorPage

--- a/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import {
 	find,
@@ -29,7 +30,8 @@ import NavItem from 'components/section-nav/item';
 import Search from 'components/search';
 import jetpackPlugins from './jetpack-plugins';
 import Tooltip from 'components/tooltip';
-import { isATEnabledForCurrentSite } from 'lib/automated-transfer';
+import { isATEnabled } from 'lib/automated-transfer';
+import { getSelectedSite } from 'state/ui/selectors';
 
 const filterGroup = category => group => {
 	if ( category && category !== 'all' ) {
@@ -174,7 +176,7 @@ class JetpackPluginsPanel extends Component {
 				</SectionNav>
 
 				<SectionHeader label={ translate( 'Plugins' ) }>
-					{ isATEnabledForCurrentSite() &&
+					{ this.props.atEnabled &&
 						<ButtonGroup key="plugin-list-header__buttons-browser">
 							<Button
 								compact
@@ -251,4 +253,11 @@ class JetpackPluginsPanel extends Component {
 	}
 }
 
-export default localize( urlSearch( JetpackPluginsPanel ) );
+export default connect(
+	( state ) => {
+		const selectedSite = getSelectedSite( state );
+		return {
+			atEnabled: isATEnabled( selectedSite )
+		};
+	}
+)( localize( urlSearch( JetpackPluginsPanel ) ) );

--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -23,7 +23,7 @@ import JetpackPluginsPanel from './jetpack-plugins-panel';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { PLAN_BUSINESS, FEATURE_UPLOAD_PLUGINS } from 'lib/plans/constants';
 import Banner from 'components/banner';
-import { isATEnabledForCurrentSite } from 'lib/automated-transfer';
+import { isATEnabled } from 'lib/automated-transfer';
 
 export const PluginPanel = ( {
 	plan,
@@ -31,6 +31,7 @@ export const PluginPanel = ( {
 	category,
 	search,
 	translate,
+	atEnabled
 } ) => {
 	const hasBusiness = isBusiness( plan ) || isEnterprise( plan );
 	const hasPremium = hasBusiness || isPremium( plan );
@@ -40,7 +41,7 @@ export const PluginPanel = ( {
 
 			<PageViewTracker path="/plugins/:site" title="Plugins > WPCOM Site" />
 
-			{ isATEnabledForCurrentSite() && ! hasBusiness &&
+			{ atEnabled && ! hasBusiness &&
 				<Banner
 					feature={ FEATURE_UPLOAD_PLUGINS }
 					plan={ PLAN_BUSINESS }
@@ -60,9 +61,13 @@ export const PluginPanel = ( {
 	);
 };
 
-const mapStateToProps = state => ( {
-	plan: get( getSelectedSite( state ), 'plan', {} ),
-	siteSlug: getSiteSlug( state, getSelectedSiteId( state ) )
-} );
+const mapStateToProps = state => {
+	const selectedSite = getSelectedSite( state );
+	return {
+		atEnabled: isATEnabled( selectedSite ),
+		plan: get( selectedSite, 'plan', {} ),
+		siteSlug: getSiteSlug( state, getSelectedSiteId( state ) )
+	};
+};
 
 export default connect( mapStateToProps )( localize( PluginPanel ) );

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -39,10 +39,10 @@ import {
 	isBusiness,
 	isEnterprise
 } from 'lib/products-values';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { isAutomatedTransferActive, isSiteAutomatedTransfer } from 'state/selectors';
 import QueryEligibility from 'components/data/query-atat-eligibility';
-import { isATEnabledForCurrentSite } from 'lib/automated-transfer';
+import { isATEnabled } from 'lib/automated-transfer';
 
 const PluginMeta = React.createClass( {
 	OUT_OF_DATE_YEARS: 2,
@@ -427,7 +427,7 @@ const PluginMeta = React.createClass( {
 
 		return (
 			<div className="plugin-meta">
-				{ isATEnabledForCurrentSite() && this.props.selectedSite &&
+				{ this.props.atEnabled && this.props.selectedSite &&
 					<QueryEligibility siteId={ this.props.selectedSite.ID } />
 				}
 				<Card>
@@ -466,11 +466,11 @@ const PluginMeta = React.createClass( {
 					}
 				</Card>
 
-				{ isATEnabledForCurrentSite() &&
+				{ this.props.atEnabled &&
 					this.maybeDisplayUnsupportedNotice()
 				}
 
-				{ isATEnabledForCurrentSite() && this.hasBusinessPlan() && ! get( this.props.selectedSite, 'jetpack' ) &&
+				{ this.props.atEnabled && this.hasBusinessPlan() && ! get( this.props.selectedSite, 'jetpack' ) &&
 					<PluginAutomatedTransfer plugin={ this.props.plugin } />
 				}
 
@@ -498,8 +498,10 @@ const PluginMeta = React.createClass( {
 
 const mapStateToProps = state => {
 	const siteId = getSelectedSiteId( state );
+	const selectedSite = getSelectedSite( state );
 
 	return {
+		atEnabled: isATEnabled( selectedSite ),
 		isTransferring: isAutomatedTransferActive( state, siteId ),
 		automatedTransferSite: isSiteAutomatedTransfer( state, siteId ),
 	};

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -33,7 +33,7 @@ import { isJetpackSite, canJetpackSiteManage, getRawSite } from 'state/sites/sel
 import { isSiteAutomatedTransfer } from 'state/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import QuerySites from 'components/data/query-sites';
-import { isATEnabledForCurrentSite } from 'lib/automated-transfer';
+import { isATEnabled } from 'lib/automated-transfer';
 
 const SinglePlugin = React.createClass( {
 	_DEFAULT_PLUGINS_BASE_PATH: 'http://wordpress.org/plugins/',
@@ -318,7 +318,7 @@ const SinglePlugin = React.createClass( {
 		if (
 			selectedSite &&
 			! this.props.isJetpackSite( selectedSite.ID ) &&
-			! isATEnabledForCurrentSite()
+			! this.props.atEnabled
 		) {
 			return (
 				<MainComponent>
@@ -428,6 +428,7 @@ export default connect(
 			selectedSite: selectedSite,
 			isJetpackSite: siteId => isJetpackSite( state, siteId ),
 			canJetpackSiteManage: siteId => canJetpackSiteManage( state, siteId ),
+			atEnabled: isATEnabled( site ),
 			isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, get( selectedSite, 'ID' ) ),
 		};
 	},

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -29,7 +29,7 @@ import { hasTouch } from 'lib/touch-detect';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSite } from 'state/ui/selectors';
 import { isJetpackSite, canJetpackSiteManage } from 'state/sites/selectors';
-import { isATEnabledForCurrentSite } from 'lib/automated-transfer';
+import { isATEnabled } from 'lib/automated-transfer';
 
 const PluginsBrowser = React.createClass( {
 	_SHORT_LIST_LENGTH: 6,
@@ -324,7 +324,7 @@ const PluginsBrowser = React.createClass( {
 				// If automated transfer is _off_ then behave
 				// as normal. If it's on, then only show if we
 				// are getting an error on a Jetpack site
-				! isATEnabledForCurrentSite() ||
+				! this.props.atEnabled ||
 				( selectedSite && selectedSite.jetpack )
 			)
 		) {
@@ -343,11 +343,15 @@ const PluginsBrowser = React.createClass( {
 } );
 
 export default connect(
-	state => ( {
-		selectedSite: getSelectedSite( state ),
-		isJetpackSite: siteId => isJetpackSite( state, siteId ),
-		canJetpackSiteManage: siteId => canJetpackSiteManage( state, siteId ),
-	} ),
+	state => {
+		const selectedSite = getSelectedSite( state );
+		return {
+			selectedSite,
+			atEnabled: isATEnabled( selectedSite ),
+			isJetpackSite: siteId => isJetpackSite( state, siteId ),
+			canJetpackSiteManage: siteId => canJetpackSiteManage( state, siteId ),
+		};
+	},
 	{
 		recordTracksEvent
 	}

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -28,14 +28,14 @@ import SidebarRegion from 'layout/sidebar/region';
 import StatsSparkline from 'blocks/stats-sparkline';
 import { isPersonal, isPremium, isBusiness } from 'lib/products-values';
 import { getCurrentUser } from 'state/current-user/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { setNextLayoutFocus, setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { userCan } from 'lib/site/utils';
 import { getMenusUrl, getPrimarySiteId, isDomainOnlySite } from 'state/selectors';
 import { getCustomizerUrl, isJetpackSite } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { getStatsPathForTab } from 'lib/route/path';
-import { isATEnabledForCurrentSite } from 'lib/automated-transfer';
+import { isATEnabled } from 'lib/automated-transfer';
 
 /**
  * Module variables
@@ -243,7 +243,7 @@ export class MySitesSidebar extends Component {
 			pluginsLink = '/plugins' + this.siteSuffix(),
 			addPluginsLink;
 
-		if ( isATEnabledForCurrentSite() ) {
+		if ( this.props.atEnabled ) {
 			addPluginsLink = '/plugins/browse' + this.siteSuffix();
 		}
 
@@ -298,7 +298,7 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		if ( site.jetpack && ! ( isATEnabledForCurrentSite() ) ) {
+		if ( site.jetpack && ! this.props.atEnabled ) {
 			return null;
 		}
 
@@ -642,9 +642,11 @@ function mapStateToProps( state ) {
 	const selectedSiteId = getSelectedSiteId( state );
 	const isSingleSite = !! selectedSiteId || currentUser.site_count === 1;
 	const singleSiteId = selectedSiteId || ( isSingleSite && getPrimarySiteId( state ) ) || null;
+	const selectedSite = getSelectedSite( state );
 
 	return {
 		currentUser,
+		atEnabled: isATEnabled( selectedSite ),
 		customizeUrl: getCustomizerUrl( state, selectedSiteId ),
 		isDomainOnly: isDomainOnlySite( state, selectedSiteId ),
 		isJetpack: isJetpackSite( state, selectedSiteId ),

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -23,9 +23,10 @@ import { isJetpackSite, getSiteSlug } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import ThemePreview from './theme-preview';
 import config from 'config';
-import { isATEnabledForCurrentSite } from 'lib/automated-transfer';
+import { isATEnabled } from 'lib/automated-transfer';
 import { getThemeShowcaseDescription } from 'state/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { getSelectedSite } from 'state/ui/selectors';
 
 const ThemesSearchCard = config.isEnabled( 'manage/themes/magic-search' )
 	? require( './themes-magic-search-card' )
@@ -109,7 +110,7 @@ const ThemeShowcase = React.createClass( {
 
 	onUploadClick() {
 		trackClick( 'upload theme' );
-		if ( isATEnabledForCurrentSite() ) {
+		if ( this.props.atEnabled ) {
 			this.props.trackATUploadClick();
 		}
 	},
@@ -121,7 +122,7 @@ const ThemeShowcase = React.createClass( {
 			config.isEnabled( 'manage/themes/upload' ) &&
 			isLoggedIn &&
 			! isMultisite &&
-			( isJetpack || isATEnabledForCurrentSite() )
+			( isJetpack || this.props.atEnabled )
 		);
 	},
 
@@ -201,6 +202,7 @@ const ThemeShowcase = React.createClass( {
 } );
 
 const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
+	atEnabled: isATEnabled( getSelectedSite( state ) ),
 	isLoggedIn: !! getCurrentUserId( state ),
 	siteSlug: getSiteSlug( state, siteId ),
 	isJetpack: isJetpackSite( state, siteId ),

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -20,7 +20,7 @@ import ProgressBar from 'components/progress-bar';
 import Button from 'components/button';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 import QueryCanonicalTheme from 'components/data/query-canonical-theme';
-import { isATEnabledForCurrentSite } from 'lib/automated-transfer';
+import { isATEnabled } from 'lib/automated-transfer';
 // Necessary for ThanksModal
 import QueryActiveTheme from 'components/data/query-active-theme';
 import { localize } from 'i18n-calypso';
@@ -312,7 +312,7 @@ class Upload extends React.Component {
 			return this.renderNotAvailableForMultisite();
 		}
 
-		if ( ! isJetpack && ! isATEnabledForCurrentSite() ) {
+		if ( ! isJetpack && ! this.props.atEnabled ) {
 			return this.renderNotAvailable();
 		}
 
@@ -381,7 +381,8 @@ export default connect(
 			backPath: getBackPath( state ),
 			showEligibility: ! isJetpack && ( hasEligibilityMessages || ! isEligible ),
 			isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, siteId ),
-			siteAdminUrl: getSiteAdminUrl( state, siteId )
+			siteAdminUrl: getSiteAdminUrl( state, siteId ),
+			atEnabled: isATEnabled( site )
 		};
 	},
 	{ uploadTheme, clearThemeUpload, initiateThemeTransfer },

--- a/client/my-sites/upgrades/navigation.jsx
+++ b/client/my-sites/upgrades/navigation.jsx
@@ -16,7 +16,7 @@ import NavItem from 'components/section-nav/item';
 import viewport from 'lib/viewport';
 import { action as upgradesActionTypes } from 'lib/upgrades/constants';
 import PopoverCart from 'my-sites/upgrades/cart/popover-cart';
-import { isATEnabledForCurrentSite } from 'lib/automated-transfer';
+import { isATEnabled } from 'lib/automated-transfer';
 
 const PlansNavigation = React.createClass( {
 	propTypes: {
@@ -77,7 +77,7 @@ const PlansNavigation = React.createClass( {
 		const sectionTitle = this.getSectionTitle( path );
 		const userCanManageOptions = get( site, 'capabilities.manage_options', false );
 		const canManageDomain = userCanManageOptions &&
-			( isATEnabledForCurrentSite() || ! site.jetpack );
+			( isATEnabled( site ) || ! site.jetpack );
 
 		return (
 			<SectionNav


### PR DESCRIPTION
Alternative to #13139 This PR removes SitesList usage from `lib/automated-transfer` by updating the library interface.

### Testing Instructions
- Prep a site that has a custom domain + business plan with you as the only user
- Set the custom domain as primary
- Wait for the SSL cert
- Existing users shouldn't see any options to transfer in /plugins or /themes
- Set abtest to `enabled` for `automated-transfer2` if you match the conditions above you should be able to transfer