### PR TITLE
Plugins: add akismet to auto managed plugin list

### DIFF
--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -468,7 +468,12 @@ export const PluginsList = React.createClass( {
 	},
 
 	getAllowedPluginActions( plugin ) {
-		const hiddenForAutomatedTransfer = this.props.isSiteAutomatedTransfer && includes( [ 'jetpack', 'vaultpress' ], plugin.slug );
+		const autoManagedPlugins = [
+			'jetpack',
+			'vaultpress',
+			'akismet',
+		];
+		const hiddenForAutomatedTransfer = this.props.isSiteAutomatedTransfer && includes( autoManagedPlugins, plugin.slug );
 
 		return {
 			autoupdate: ! hiddenForAutomatedTransfer,


### PR DESCRIPTION
This PR lists Akismet as an auto managed plugin on automated transfer sites. It also excludes Akismet from bulk actions

**Plugin list** 
![screen shot 2017-04-18 at 2 01 26 pm](https://cloud.githubusercontent.com/assets/744755/25152938/90801bbe-243f-11e7-8d03-fa395d28a7ce.png)

**Bulk Actions**
![screen shot 2017-04-18 at 2 02 40 pm](https://cloud.githubusercontent.com/assets/744755/25152982/b8a454f2-243f-11e7-84d5-b978566bbe25.png)

**Testing**
- Visit http://calypso.localhost:3000/plugins/:site_id for an AT site
- Plugin actions should not be displayed for Akismet and it there should be a message indicating automatic management.
-  Click "Edit all" 
- Akismet should not be selectable for bulk actions