### PR TITLE
Purchases: Fix the Jetpack plan keys list & add header

### DIFF
--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -43,9 +43,9 @@ class PurchasePlanDetails extends Component {
 			return null;
 		}
 
-		const headerText = translate( '%(plan)s Plan', {
+		const headerText = translate( '%(planName)s Plan', {
 			args: {
-				plan: getName( purchase )
+				planName: getName( purchase )
 			}
 		} );
 

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -51,9 +51,9 @@ class PurchasePlanDetails extends Component {
 
 		return (
 			<div>
+				<QueryPluginKeys siteId={ selectedSite.ID } />
 				<SectionHeader label={ headerText } />
 				<Card>
-					<QueryPluginKeys siteId={ selectedSite.ID } />
 					{ pluginList.map( ( plugin, i ) => {
 						return (
 							<FormFieldset key={ i }>

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -41,10 +41,6 @@ class PurchasePlanDetails extends Component {
 			return null;
 		}
 
-		if ( pluginList.length < 1 ) {
-			return null;
-		}
-
 		return (
 			<Card>
 				<QueryPluginKeys siteId={ selectedSite.ID } />

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -13,9 +13,11 @@ import ClipboardButtonInput from 'components/clipboard-button-input';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import QueryPluginKeys from 'components/data/query-plugin-keys';
+import SectionHeader from 'components/section-header';
 import { isRequestingSites } from 'state/sites/selectors';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { getPurchase, isDataLoading } from 'me/purchases/utils';
+import { getName } from 'lib/purchases';
 import { isJetpackPlan, isFreeJetpackPlan } from 'lib/products-values';
 import { getPluginsForSite } from 'state/plugins/premium/selectors';
 
@@ -30,7 +32,7 @@ class PurchasePlanDetails extends Component {
 	}
 
 	render() {
-		const { selectedSite, pluginList } = this.props;
+		const { selectedSite, pluginList, translate } = this.props;
 		const purchase = getPurchase( this.props );
 
 		if ( isDataLoading( this.props ) || ! this.props.selectedSite ) {
@@ -41,18 +43,27 @@ class PurchasePlanDetails extends Component {
 			return null;
 		}
 
+		const headerText = translate( '%(plan)s Plan', {
+			args: {
+				plan: getName( purchase )
+			}
+		} );
+
 		return (
-			<Card>
-				<QueryPluginKeys siteId={ selectedSite.ID } />
-				{ pluginList.map( ( plugin, i ) => {
-					return (
-						<FormFieldset key={ i }>
-							<FormLabel htmlFor={ `plugin-${ plugin.slug }` }>{ this.renderPluginLabel( plugin.slug ) }</FormLabel>
-							<ClipboardButtonInput id={ `plugin-${ plugin.slug }` } value={ plugin.key } />
-						</FormFieldset>
-					);
-				} ) }
-			</Card>
+			<div>
+				<SectionHeader label={ headerText } />
+				<Card>
+					<QueryPluginKeys siteId={ selectedSite.ID } />
+					{ pluginList.map( ( plugin, i ) => {
+						return (
+							<FormFieldset key={ i }>
+								<FormLabel htmlFor={ `plugin-${ plugin.slug }` }>{ this.renderPluginLabel( plugin.slug ) }</FormLabel>
+								<ClipboardButtonInput id={ `plugin-${ plugin.slug }` } value={ plugin.key } />
+							</FormFieldset>
+						);
+					} ) }
+				</Card>
+			</div>
 		);
 	}
 }


### PR DESCRIPTION
In #12999 I added a check for `pluginList.length`, which returned from rendering `PurchasePlanDetails` too early, before the plugins could be queried from the API. This PR removes that check, and also adds a SectionHeader to this card.

![detail](https://cloud.githubusercontent.com/assets/541093/25152764/1c16e316-2458-11e7-8782-4123bc6f3f29.png)

To test:

- Visit `/me/purchases` & click into a Jetpack plan purchase
- You should see a card with plugin keys & a header 🎉 

Note: This is only enabled on wpcalypso & development by a feature flag.