### PR TITLE
Plans: Allow thank you page autoconfig for Jetpack up to staging

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -68,6 +68,7 @@
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
+		"plans/jetpack-config-v2": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
 		"press-this": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -71,6 +71,7 @@
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
+		"plans/jetpack-config-v2": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
 		"press-this": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -83,6 +83,7 @@
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
+		"plans/jetpack-config-v2": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
 		"press-this": true,


### PR DESCRIPTION
This PR allow the new Jetpack auto-config thank you page up to staging so that we can begin testing on it.

To test that the feature is enabled you'll want to buy a plan for a Jetpack site. After paying, you should be redirected to the thank you page which will begin installing/configuring the different plugins.

It should look a bit like this:

![2228da58-1edf-11e7-8e7d-3a96603f0d56](https://cloud.githubusercontent.com/assets/1126811/25153696/17c11d40-2453-11e7-82e6-9d05103f1802.png)
