### PR TITLE
Plugins: hide Akismet plugin actions on AT sites

### DIFF
--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -217,7 +217,12 @@ const SinglePlugin = React.createClass( {
 	},
 
 	getAllowedPluginActions( plugin ) {
-		const hiddenForAutomatedTransfer = this.props.isSiteAutomatedTransfer && includes( [ 'jetpack', 'vaultpress' ], plugin.slug );
+		const autoManagedPlugins = [
+			'jetpack',
+			'vaultpress',
+			'akismet',
+		];
+		const hiddenForAutomatedTransfer = this.props.isSiteAutomatedTransfer && includes( autoManagedPlugins, plugin.slug );
 
 		return {
 			autoupdate: ! hiddenForAutomatedTransfer,


### PR DESCRIPTION
This is a followup to #13194. It hides the plugin actions on the Akismet plugin page : http://calypso.localhost:3000/plugins/akismet/:site_id

![screen shot 2017-04-18 at 3 45 49 pm](https://cloud.githubusercontent.com/assets/744755/25156295/8fc5ff36-244e-11e7-8af3-f558d94c7658.png)


**Testing**
- Visit http://calypso.localhost:3000/plugins/akismet/:site_id for an AT site
- The plugin actions should not be displayed
