### PR TITLE
Domains: Email Forwarding Confirmation Page

### DIFF
--- a/client/boot/project/wordpress-com.js
+++ b/client/boot/project/wordpress-com.js
@@ -250,7 +250,7 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 			document.getElementsByClassName( 'wp-singletree-layout' ).length
 		);
 
-		const singleTreeSections = [ 'account-recovery', 'login', 'posts-custom', 'theme', 'themes' ];
+		const singleTreeSections = [ 'account-recovery', 'login', 'posts-custom', 'theme', 'themes', 'verify-email-forward' ];
 		const sectionName = getSectionName( context.store.getState() );
 		const isMultiTreeLayout = ! includes( singleTreeSections, sectionName );
 

--- a/client/my-sites/upgrades/verify-email-forward/controller.jsx
+++ b/client/my-sites/upgrades/verify-email-forward/controller.jsx
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { Base64 } from 'js-base64';
+
+/**
+ * Internal dependencies
+ */
+import i18nUtils from 'lib/i18n-utils';
+import VerifyEmailForward from './verify-email-forward';
+
+export function verifyEmailForward( context, next ) {
+	const { mailbox, destination } = JSON.parse( Base64.decode( context.params.mailbox_base64 ) );
+	context.primary = (
+		<VerifyEmailForward
+			domainEmailId={ context.params.domain_email_id }
+			mailbox={ mailbox }
+			destination={ destination }
+			locale={ i18nUtils.getLanguage( context.params.locale ) }
+			nonce={ context.params.nonce }
+			path={ context.path }
+		/>
+	);
+	context.secondary = null;
+	next();
+}

--- a/client/my-sites/upgrades/verify-email-forward/index.js
+++ b/client/my-sites/upgrades/verify-email-forward/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { verifyEmailForward } from './controller';
+import { makeLayout } from 'controller';
+
+export default ( router ) => {
+	router(
+		'/verify-email-forward/:domain_email_id/:mailbox_base64/:nonce/:locale?',
+		verifyEmailForward,
+		makeLayout
+	);
+};

--- a/client/my-sites/upgrades/verify-email-forward/verify-email-forward.jsx
+++ b/client/my-sites/upgrades/verify-email-forward/verify-email-forward.jsx
@@ -1,0 +1,52 @@
+/**
+ * External Dependencies
+ */
+
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal Dependencies
+ */
+import DocumentHead from 'components/data/document-head';
+import Main from 'components/main';
+import SectionHeader from 'components/section-header';
+import Card from 'components/card';
+import FormButton from 'components/forms/form-button';
+
+class VerifyEmailForward extends React.Component {
+	render() {
+		const { translate, mailbox, destination } = this.props,
+			title = translate( 'Verify Email Forwarding', { context: 'Header' } );
+		return (
+			<Main wideLayout>
+				<DocumentHead title={ title } />
+				<SectionHeader label={ title } />
+				<Card>
+					<p>
+						{ translate(
+							'We will forward all emails arriving to {{strong}}%(inboxEmail)s{{/strong}} ' +
+							'to {{strong}}%(destinationEmail)s{{/strong}}.', {
+								args: {
+									inboxEmail: mailbox,
+									destinationEmail: destination
+								},
+								components: {
+									strong: <strong />
+								}
+							} ) }
+					</p>
+					<FormButton>
+						{ title( 'Continue' ) }
+					</FormButton>
+					<FormButton isPrimary={ false }>
+						{ title( 'Cancel' ) }
+					</FormButton>
+				</Card>
+			</Main>
+		);
+	}
+}
+
+export default connect()( localize( VerifyEmailForward ) );

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -339,4 +339,13 @@ sections.push( {
 	secondary: true
 } );
 
+sections.push( {
+	name: 'verify-email-forward',
+	paths: [ '/verify-email-forward' ],
+	module: 'my-sites/upgrades/verify-email-forward',
+	enableLoggedOut: true,
+	secondary: false,
+	isomorphic: true
+} );
+
 module.exports = sections;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4299,7 +4299,7 @@
       "version": "1.4.2"
     },
     "tiny-emitter": {
-      "version": "1.1.0"
+      "version": "1.2.0"
     },
     "tinymce": {
       "version": "4.3.12"

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "is-my-json-valid": "2.13.1",
     "jade": "pugjs/jade#29784fd",
     "jquery": "1.11.3",
+    "js-base64": "2.1.9",
     "js-sha1": "0.4.1",
     "json-loader": "0.5.4",
     "key-mirror": "1.0.1",


### PR DESCRIPTION
This PR adds a new URL to allow confirmation of email forward setups in Calypso.

It will allow non-wpcom users to confirm as well and implements SSR (server side rendering) as well.

The new URL will be 

`https://wordpress.com/verify-email-forward/{base64_domaindata}/{nonce}/{locale?}`

where `nonce` is the unique value we create for the verification and the `base64_domaindata` is the base64 form of: `{"mailbox":"mailbox@example.com","destination":"destination@example.com"}`.

This is partial PR and the following needs to implemented in a following PR, but it would have made this PR very big to include everything here:

- Create an API endpoint
- Add to Redux tree and tie it with the component and the API


