### PR TITLE
Framework: remove sites-list usage from lib/desktop

### DIFF
--- a/client/lib/desktop/index.js
+++ b/client/lib/desktop/index.js
@@ -9,7 +9,6 @@ var debug = require( 'debug' )( 'calypso:desktop' ),
  */
 var paths = require( 'lib/paths' ),
 	user = require( 'lib/user' )(),
-	sites = require( 'lib/sites-list' )(),
 	ipc = require( 'electron' ).ipcRenderer,          // From Electron
 	store = require( 'store' ),
 	oAuthToken = require( 'lib/oauth-token' ),
@@ -48,6 +47,12 @@ var Desktop = {
 		location( function( context ) {
 			ipc.send( 'render', context );
 		} );
+	},
+
+	selectedSite: null,
+
+	setSelectedSite: function( site ) {
+		this.selectedSite = site;
 	},
 
 	receiveMessage: function( event ) {
@@ -117,7 +122,7 @@ var Desktop = {
 
 	onShowMySites: function() {
 		debug( 'Showing my sites' );
-		const site = this.getSelectedSite();
+		const site = this.selectedSite;
 		const siteId = this.isSingle() ? site.slug : null;
 
 		this.clearNotificationBar();
@@ -142,7 +147,7 @@ var Desktop = {
 		debug( 'New post' );
 
 		this.clearNotificationBar();
-		page( paths.newPost( sites.getSelectedSite() ) );
+		page( paths.newPost( this.selectedSite ) );
 	},
 
 	// now that our browser session has a valid wordpress.com cookie, let's force

--- a/client/lib/desktop/index.js
+++ b/client/lib/desktop/index.js
@@ -123,10 +123,10 @@ var Desktop = {
 	onShowMySites: function() {
 		debug( 'Showing my sites' );
 		const site = this.selectedSite;
-		const siteId = this.isSingle() ? site.slug : null;
+		const siteSlug = site ? site.slug : null;
 
 		this.clearNotificationBar();
-		page( getStatsPathForTab( 'day', siteId ) );
+		page( getStatsPathForTab( 'day', siteSlug ) );
 	},
 
 	onShowReader: function() {

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -29,6 +29,12 @@ if ( keyBoardShortcutsEnabled ) {
 	keyboardShortcuts = require( 'lib/keyboard-shortcuts/global' )();
 }
 
+const desktopEnabled = config.isEnabled( 'desktop' );
+let desktop;
+if ( desktopEnabled ) {
+	desktop = require( 'lib/desktop' );
+}
+
 /**
  * Sets the selectedSite and siteCount for lib/analytics. This is used to
  * populate extra fields on tracks analytics calls.
@@ -72,6 +78,19 @@ const updatedSelectedSiteForKeyboardShortcuts = ( dispatch, action, getState ) =
 	keyboardShortcuts.setSelectedSite( selectedSite );
 };
 
+/**
+ * Sets the selected site for lib/desktop
+ *
+ * @param {function} dispatch - redux dispatch function
+ * @param {object}   action   - the dispatched action
+ * @param {function} getState - redux getState function
+ */
+const updateSelectedSiteForDesktop = ( dispatch, action, getState ) => {
+	const state = getState();
+	const selectedSite = getSelectedSite( state );
+	desktop.setSelectedSite( selectedSite );
+};
+
 const handler = ( dispatch, action, getState ) => {
 	switch ( action.type ) {
 		case ANALYTICS_SUPER_PROPS_UPDATE:
@@ -86,6 +105,9 @@ const handler = ( dispatch, action, getState ) => {
 				updateSelectedSiteForCart( dispatch, action, getState );
 				if ( keyBoardShortcutsEnabled ) {
 					updatedSelectedSiteForKeyboardShortcuts( dispatch, action, getState );
+				}
+				if ( desktopEnabled ) {
+					updateSelectedSiteForDesktop( dispatch, action, getState );
 				}
 			}, 0 );
 			return;


### PR DESCRIPTION
This PR removes the sites-list usage from `lib/desktop`. 

### Testing Instructions
- Clone https://github.com/Automattic/wp-desktop and follow the Readme for install instructions
- From the Desktop directory, `cd calypso; git pull; git checkout update/lib-desktop`
- From the Desktop directory `make run`

The following app links should work:
![screen shot 2017-04-19 at 2 33 05 pm](https://cloud.githubusercontent.com/assets/1270189/25203357/ce512b9e-250d-11e7-82cc-ec1c7f3aa281.png)
 