### PR TITLE
Jetpack Connect: conditionally activate the manage module

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -292,8 +292,12 @@ const LoggedInForm = React.createClass( {
 
 	activateManageAndRedirect() {
 		const { queryObject, activateManageSecret } = this.props.jetpackConnectAuthorize;
-		debug( 'Activating Manage module and calculating redirection', queryObject );
-		this.props.activateManage( queryObject.client_id, queryObject.state, activateManageSecret );
+
+		if ( versionCompare( queryObject.jp_version, '4.4', '<' ) ) {
+			debug( 'Activating Manage module and calculating redirection', queryObject );
+			this.props.activateManage( queryObject.client_id, queryObject.state, activateManageSecret );
+		}
+
 		if ( 'jpo' === queryObject.from || this.props.isSSO ) {
 			debug( 'Going back to WP Admin.', 'Connection initiated via: ', queryObject.from, 'SSO found:', this.props.isSSO );
 			this.props.goBackToWpAdmin( queryObject.redirect_after_auth );


### PR DESCRIPTION
With Jetpack Connect, we make an API request to activate the Manage Module
so that the site will immediately function well within Calypso.

However, since Jetpack 4.4, the Manage Module is activated by default. On sites
running 4.4 or later, we do not need to make this request.

To test:
- run this branch locally on or calypso.live
- go to /jetpack/connect
- attempt to connect a Jetpack site running Jetpack 4.4 or later
- check your dev tools network tab, and ensure no network requests were made to `activate-manage`

Bonus testing:
- try it with a site running Jetpack 4.3, and ensure that the `actitvate-manage` request is made