### PR TITLE
Framework: remove sites-list usage from keyboard shortcuts

### DIFF
--- a/client/boot/project/wordpress-com.js
+++ b/client/boot/project/wordpress-com.js
@@ -20,7 +20,6 @@ const config = require( 'config' ),
 	route = require( 'lib/route' ),
 	normalize = require( 'lib/route/normalize' ),
 	{ isLegacyRoute } = require( 'lib/route/legacy-routes' ),
-	sitesFactory = require( 'lib/sites-list' ), // eslint-disable-line no-restricted-modules
 	superProps = require( 'lib/analytics/super-props' ),
 	translatorJumpstart = require( 'lib/translator-jumpstart' ),
 	nuxWelcome = require( 'layout/nux-welcome' ),
@@ -219,7 +218,7 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 	reduxStore.dispatch( initializeHappychat() );
 
 	if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
-		require( 'lib/keyboard-shortcuts/global' )( sitesFactory() );
+		require( 'lib/keyboard-shortcuts/global' )();
 	}
 
 	if ( config.isEnabled( 'desktop' ) ) {

--- a/client/lib/keyboard-shortcuts/global.js
+++ b/client/lib/keyboard-shortcuts/global.js
@@ -10,19 +10,21 @@ var config = require( 'config' ),
 	route = require( 'lib/route' ),
 	KeyboardShortcuts = require( 'lib/keyboard-shortcuts' );
 
-module.exports = GlobalShortcuts;
+let singleton;
 
-/**
- * This class accepts a sites-list collection and binds KeyboardShortcuts events to methods that change
- * the route based on which keyboard shortcut was triggered.
- */
-function GlobalShortcuts( sites ) {
+export default function() {
+	if ( ! singleton ) {
+		singleton = new GlobalShortcuts();
+	}
+	return singleton;
+}
+
+function GlobalShortcuts() {
 	if ( ! ( this instanceof GlobalShortcuts ) ) {
-		return new GlobalShortcuts( sites );
+		return new GlobalShortcuts();
 	}
 
-	this.sites = sites;
-
+	this.selectedSite = null;
 	this.bindShortcuts();
 }
 
@@ -38,6 +40,10 @@ GlobalShortcuts.prototype.bindShortcuts = function() {
 	}
 };
 
+GlobalShortcuts.prototype.setSelectedSite = function( site ) {
+	this.selectedSite = site;
+};
+
 GlobalShortcuts.prototype.goToReader = function() {
 	page( '/' );
 };
@@ -47,7 +53,7 @@ GlobalShortcuts.prototype.goToMyLikes = function() {
 };
 
 GlobalShortcuts.prototype.goToStats = function() {
-	var site = this.sites.getSelectedSite();
+	const site = this.selectedSite;
 
 	if ( site && site.capabilities && ! site.capabilities.view_stats ) {
 		return null;
@@ -59,7 +65,7 @@ GlobalShortcuts.prototype.goToStats = function() {
 };
 
 GlobalShortcuts.prototype.goToBlogPosts = function() {
-	var site = this.sites.getSelectedSite();
+	const site = this.selectedSite;
 
 	if ( site && site.capabilities && ! site.capabilities.edit_posts ) {
 		return null;
@@ -71,7 +77,7 @@ GlobalShortcuts.prototype.goToBlogPosts = function() {
 };
 
 GlobalShortcuts.prototype.goToPages = function() {
-	var site = this.sites.getSelectedSite();
+	const site = this.selectedSite;
 
 	if ( site && site.capabilities && ! site.capabilities.edit_pages ) {
 		return null;

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -6,6 +6,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import {
 	ANALYTICS_SUPER_PROPS_UPDATE,
 	SELECTED_SITE_SET,
@@ -17,6 +18,11 @@ import analytics from 'lib/analytics';
 import cartStore from 'lib/cart/store';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
+
+let keyboardShortcuts;
+if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
+	keyboardShortcuts = require( 'lib/keyboard-shortcuts/global' )();
+}
 
 /**
  * Sets the selectedSite and siteCount for lib/analytics. This is used to
@@ -48,6 +54,19 @@ const updateSelectedSiteForCart = ( dispatch, action, getState ) => {
 	cartStore.setSelectedSiteId( selectedSiteId );
 };
 
+/**
+ * Sets the selectedSiteId for lib/keyboard-shortcuts/global
+ *
+ * @param {function} dispatch - redux dispatch function
+ * @param {object}   action   - the dispatched action
+ * @param {function} getState - redux getState function
+ */
+const updatedSelectedSiteForKeyboardShortcuts = ( dispatch, action, getState ) => {
+	const state = getState();
+	const selectedSite = getSelectedSite( state );
+	keyboardShortcuts.setSelectedSite( selectedSite );
+};
+
 const handler = ( dispatch, action, getState ) => {
 	switch ( action.type ) {
 		case ANALYTICS_SUPER_PROPS_UPDATE:
@@ -60,6 +79,9 @@ const handler = ( dispatch, action, getState ) => {
 			// Wait a tick for the reducer to update the state tree
 			setTimeout( () => {
 				updateSelectedSiteForCart( dispatch, action, getState );
+				if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
+					updatedSelectedSiteForKeyboardShortcuts( dispatch, action, getState );
+				}
 			}, 0 );
 			return;
 	}

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -19,8 +19,13 @@ import cartStore from 'lib/cart/store';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 
+/**
+ * Module variables
+ */
+const keyBoardShortcutsEnabled = config.isEnabled( 'keyboard-shortcuts' );
 let keyboardShortcuts;
-if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
+
+if ( keyBoardShortcutsEnabled ) {
 	keyboardShortcuts = require( 'lib/keyboard-shortcuts/global' )();
 }
 
@@ -79,7 +84,7 @@ const handler = ( dispatch, action, getState ) => {
 			// Wait a tick for the reducer to update the state tree
 			setTimeout( () => {
 				updateSelectedSiteForCart( dispatch, action, getState );
-				if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
+				if ( keyBoardShortcutsEnabled ) {
 					updatedSelectedSiteForKeyboardShortcuts( dispatch, action, getState );
 				}
 			}, 0 );

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -60,7 +60,7 @@ const updateSelectedSiteForCart = ( dispatch, action, getState ) => {
 };
 
 /**
- * Sets the selectedSiteId for lib/keyboard-shortcuts/global
+ * Sets the selectedSite for lib/keyboard-shortcuts/global
  *
  * @param {function} dispatch - redux dispatch function
  * @param {object}   action   - the dispatched action


### PR DESCRIPTION
This PR removes the sites-list usage from global keyboard shortcuts. Note that this feature is not enabled in prod but is enabled in wpcalypso and dev.

![screen shot 2017-04-18 at 6 05 08 pm](https://cloud.githubusercontent.com/assets/1270189/25159070/d60fe8c2-2461-11e7-84ee-b430da121d37.png)

### Testing Instructions
- Press <kbd>?</kbd> to display menu shortcuts
- Global navigation shortcuts (the ones starting with <kbd>g</kbd> ) should still work.