### PR TITLE
Add tracking events to login

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -17,6 +17,7 @@ import FormCheckbox from 'components/forms/form-checkbox';
 import { loginUser } from 'state/login/actions';
 import Notice from 'components/notice';
 import { createFormAndSubmit } from 'lib/form';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 export class Login extends Component {
 	static propTypes = {
@@ -46,6 +47,7 @@ export class Login extends Component {
 	};
 
 	onChangeField = ( event ) => {
+		this.props.recordTracksEvent( 'calypso_loginblock_rememberme_change', { new_value: event.target.value } );
 		this.setState( {
 			[ event.target.name ]: event.target.value
 		} );
@@ -56,7 +58,11 @@ export class Login extends Component {
 		this.setState( {
 			submitting: true
 		} );
+
+		this.props.recordTracksEvent( 'calypso_loginblock_login_submit' );
+
 		this.props.loginUser( this.state.usernameOrEmail, this.state.password ).then( () => {
+			this.props.recordTracksEvent( 'calypso_loginblock_login_success' );
 			this.dismissNotice();
 			createFormAndSubmit( config( 'login_url' ), {
 				log: this.state.usernameOrEmail,
@@ -65,6 +71,10 @@ export class Login extends Component {
 				rememberme: this.state.rememberme ? 1 : 0,
 			} );
 		} ).catch( errorMessage => {
+			this.props.recordTracksEvent( 'calypso_loginblock_login_failure', {
+				error_message: errorMessage
+			} );
+
 			this.setState( {
 				submitting: false,
 				errorMessage
@@ -147,5 +157,6 @@ export default connect(
 	null,
 	{
 		loginUser,
+		recordTracksEvent
 	}
 )( localize( Login ) );

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -47,10 +47,15 @@ export class Login extends Component {
 	};
 
 	onChangeField = ( event ) => {
-		this.props.recordTracksEvent( 'calypso_loginblock_rememberme_change', { new_value: event.target.value } );
-		this.setState( {
-			[ event.target.name ]: event.target.value
-		} );
+		const target = event.target;
+		const value = target.type === 'checkbox' ? target.checked : target.value;
+		const name = target.name;
+
+		if ( name === 'rememberme' ) {
+			this.props.recordTracksEvent( 'calypso_loginblock_rememberme_change', { new_value: value } );
+		}
+
+		this.setState( { [ name ]: value } );
 	};
 
 	onSubmitForm = ( event ) => {

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -47,15 +47,17 @@ export class Login extends Component {
 	};
 
 	onChangeField = ( event ) => {
-		const target = event.target;
-		const value = target.type === 'checkbox' ? target.checked : target.value;
-		const name = target.name;
-
-		if ( name === 'rememberme' ) {
-			this.props.recordTracksEvent( 'calypso_loginblock_rememberme_change', { new_value: value } );
-		}
+		const { name, value } = event.target;
 
 		this.setState( { [ name ]: value } );
+	};
+
+	onChangeRememberMe = ( event ) => {
+		const { name, checked } = event.target;
+
+		this.props.recordTracksEvent( 'calypso_loginblock_rememberme_change', { new_value: checked } );
+
+		this.setState( { [ name ]: checked } );
 	};
 
 	onSubmitForm = ( event ) => {
@@ -141,7 +143,7 @@ export class Login extends Component {
 								<FormCheckbox
 									name="rememberme"
 									checked={ this.state.rememberme }
-									onChange={ this.onChangeField }
+									onChange={ this.onChangeRememberMe }
 									{ ...isDisabled } />
 								{ this.props.translate( 'Stay logged in' ) }
 							</label>

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -55,7 +55,7 @@ export class Login extends Component {
 	onChangeRememberMe = ( event ) => {
 		const { name, checked } = event.target;
 
-		this.props.recordTracksEvent( 'calypso_loginblock_rememberme_change', { new_value: checked } );
+		this.props.recordTracksEvent( 'calypso_login_block_remember_me_change', { new_value: checked } );
 
 		this.setState( { [ name ]: checked } );
 	};
@@ -66,10 +66,10 @@ export class Login extends Component {
 			submitting: true
 		} );
 
-		this.props.recordTracksEvent( 'calypso_loginblock_login_submit' );
+		this.props.recordTracksEvent( 'calypso_login_block_login_submit' );
 
 		this.props.loginUser( this.state.usernameOrEmail, this.state.password ).then( () => {
-			this.props.recordTracksEvent( 'calypso_loginblock_login_success' );
+			this.props.recordTracksEvent( 'calypso_login_block_login_success' );
 			this.dismissNotice();
 			createFormAndSubmit( config( 'login_url' ), {
 				log: this.state.usernameOrEmail,
@@ -78,7 +78,7 @@ export class Login extends Component {
 				rememberme: this.state.rememberme ? 1 : 0,
 			} );
 		} ).catch( errorMessage => {
-			this.props.recordTracksEvent( 'calypso_loginblock_login_failure', {
+			this.props.recordTracksEvent( 'calypso_login_block_login_failure', {
 				error_message: errorMessage
 			} );
 

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -33,15 +33,18 @@ import {
 import Main from 'components/main';
 import LoginBlock from 'blocks/login';
 import RequestLoginEmailForm from '../magic-login/request-login-email-form';
+import { recordTracksEvent, recordPageView } from 'state/analytics/actions';
 
 class Login extends React.Component {
 	onClickEnterPasswordInstead = event => {
 		event.preventDefault();
+		this.props.recordTracksEvent( 'calypso_login_enterpasswordinstead_click' );
 		this.props.hideMagicLoginRequestForm();
 	};
 
 	onMagicLoginRequestClick = event => {
 		event.preventDefault();
+		this.props.recordTracksEvent( 'calypso_login_magicloginrequest_click' );
 		this.props.showMagicLoginRequestForm();
 	};
 
@@ -53,10 +56,13 @@ class Login extends React.Component {
 
 		switch ( magicLoginView ) {
 			case LINK_EXPIRED_PAGE:
+				this.props.recordTracksEvent( 'calypso_login_magiclink_expiredlink_view' );
 				return <EmailedLoginLinkExpired />;
 			case CHECK_YOUR_EMAIL_PAGE:
+				this.props.recordTracksEvent( 'calypso_login_magiclink_linksent_view' );
 				return <EmailedLoginLinkSuccessfully emailAddress={ magicLoginEmailAddress } />;
 			case INTERSTITIAL_PAGE:
+				this.props.recordTracksEvent( 'calypso_login_magiclink_interstitial_view' );
 				return <HandleEmailedLinkForm />;
 		}
 	}
@@ -72,8 +78,14 @@ class Login extends React.Component {
 		}
 	}
 
+	componentDidMount() {
+		this.props.recordPageView( document.location.pathname, document.title );
+	}
+
 	goBack( event ) {
 		event.preventDefault();
+
+		this.props.recordTracksEvent( 'calypso_login_goback_click' );
 
 		if ( typeof window !== 'undefined' ) {
 			window.history.back();
@@ -148,6 +160,8 @@ const mapDispatch = {
 	hideMagicLoginRequestForm,
 	showMagicLoginInterstitialPage,
 	showMagicLoginRequestForm,
+	recordTracksEvent,
+	recordPageView,
 };
 
 export default connect( mapState, mapDispatch )( localize( Login ) );

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -39,13 +39,13 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 class Login extends React.Component {
 	onClickEnterPasswordInstead = event => {
 		event.preventDefault();
-		this.props.recordTracksEvent( 'calypso_login_enterpasswordinstead_click' );
+		this.props.recordTracksEvent( 'calypso_login_enter_password_instead_click' );
 		this.props.hideMagicLoginRequestForm();
 	};
 
 	onMagicLoginRequestClick = event => {
 		event.preventDefault();
-		this.props.recordTracksEvent( 'calypso_login_magicloginrequest_click' );
+		this.props.recordTracksEvent( 'calypso_login_magic_login_request_click' );
 		this.props.showMagicLoginRequestForm();
 	};
 
@@ -57,13 +57,13 @@ class Login extends React.Component {
 
 		switch ( magicLoginView ) {
 			case LINK_EXPIRED_PAGE:
-				this.props.recordTracksEvent( 'calypso_login_magiclink_expiredlink_view' );
+				this.props.recordTracksEvent( 'calypso_login_magic_link_expired_link_view' );
 				return <EmailedLoginLinkExpired />;
 			case CHECK_YOUR_EMAIL_PAGE:
-				this.props.recordTracksEvent( 'calypso_login_magiclink_linksent_view' );
+				this.props.recordTracksEvent( 'calypso_login_magic_link_link_sent_view' );
 				return <EmailedLoginLinkSuccessfully emailAddress={ magicLoginEmailAddress } />;
 			case INTERSTITIAL_PAGE:
-				this.props.recordTracksEvent( 'calypso_login_magiclink_interstitial_view' );
+				this.props.recordTracksEvent( 'calypso_login_magic_link_interstitial_view' );
 				return <HandleEmailedLinkForm />;
 		}
 	}
@@ -82,7 +82,7 @@ class Login extends React.Component {
 	goBack = event => {
 		event.preventDefault();
 
-		this.props.recordTracksEvent( 'calypso_login_goback_click' );
+		this.props.recordTracksEvent( 'calypso_login_go_back_click' );
 
 		if ( typeof window !== 'undefined' ) {
 			window.history.back();

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -33,7 +33,8 @@ import {
 import Main from 'components/main';
 import LoginBlock from 'blocks/login';
 import RequestLoginEmailForm from '../magic-login/request-login-email-form';
-import { recordTracksEvent, recordPageView } from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 class Login extends React.Component {
 	onClickEnterPasswordInstead = event => {
@@ -76,10 +77,6 @@ class Login extends React.Component {
 		if ( magicLoginEnabled && queryArguments && queryArguments.action === 'handleLoginEmail' ) {
 			this.props.showMagicLoginInterstitialPage();
 		}
-	}
-
-	componentDidMount() {
-		this.props.recordPageView( document.location.pathname, document.title );
 	}
 
 	goBack = event => {
@@ -140,6 +137,7 @@ class Login extends React.Component {
 
 		return (
 			<Main className="wp-login">
+				<PageViewTracker path="/login" title="Login" />
 				{ this.magicLoginMainContent() || (
 					<div>
 						<div className="wp-login__container">
@@ -175,7 +173,6 @@ const mapDispatch = {
 	showMagicLoginInterstitialPage,
 	showMagicLoginRequestForm,
 	recordTracksEvent,
-	recordPageView,
 };
 
 export default connect( mapState, mapDispatch )( localize( Login ) );

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -88,15 +88,15 @@ class Login extends React.Component {
 		} = this.props;
 
 		if ( magicLoginEnabled && magicLoginView === REQUEST_FORM ) {
-			return <a href="#" onClick={ this.onClickEnterPasswordInstead }>{ translate( 'Enter a password instead' ) }</a>;
+			return <a href="#" key="enter-password-link" onClick={ this.onClickEnterPasswordInstead }>{ translate( 'Enter a password instead' ) }</a>;
 		}
 
 		const showMagicLoginLink = magicLoginEnabled && ! magicLoginView &&
-			<a href="#" onClick={ this.onMagicLoginRequestClick }>{ translate( 'Email me a login link' ) }</a>;
+			<a href="#" key="magic-login-link" onClick={ this.onMagicLoginRequestClick }>{ translate( 'Email me a login link' ) }</a>;
 		const resetPasswordLink = ! magicLoginView &&
-			<a href={ config( 'login_url' ) + '?action=lostpassword' }>{ this.props.translate( 'Lost your password?' ) }</a>;
+			<a href={ config( 'login_url' ) + '?action=lostpassword' } key="lost-password-link">{ this.props.translate( 'Lost your password?' ) }</a>;
 		const goBackLink = ! magicLoginView &&
-			<a href="#" onClick={ this.goBack }><Gridicon icon="arrow-left" size={ 18 } /> { this.props.translate( 'Back' ) }</a>;
+			<a href="#" key="back-link" onClick={ this.goBack }><Gridicon icon="arrow-left" size={ 18 } /> { this.props.translate( 'Back' ) }</a>;
 
 		return compact( [
 			showMagicLoginLink,

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -82,7 +82,7 @@ class Login extends React.Component {
 		this.props.recordPageView( document.location.pathname, document.title );
 	}
 
-	goBack( event ) {
+	goBack = event => {
 		event.preventDefault();
 
 		this.props.recordTracksEvent( 'calypso_login_goback_click' );
@@ -90,7 +90,7 @@ class Login extends React.Component {
 		if ( typeof window !== 'undefined' ) {
 			window.history.back();
 		}
-	}
+	};
 
 	footerLinks() {
 		const {

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -100,15 +100,29 @@ class Login extends React.Component {
 		} = this.props;
 
 		if ( magicLoginEnabled && magicLoginView === REQUEST_FORM ) {
-			return <a href="#" key="enter-password-link" onClick={ this.onClickEnterPasswordInstead }>{ translate( 'Enter a password instead' ) }</a>;
+			return <a href="#"
+				key="enter-password-link"
+				onClick={ this.onClickEnterPasswordInstead }>
+					{ translate( 'Enter a password instead' ) }
+				</a>;
 		}
 
-		const showMagicLoginLink = magicLoginEnabled && ! magicLoginView &&
-			<a href="#" key="magic-login-link" onClick={ this.onMagicLoginRequestClick }>{ translate( 'Email me a login link' ) }</a>;
-		const resetPasswordLink = ! magicLoginView &&
-			<a href={ config( 'login_url' ) + '?action=lostpassword' } key="lost-password-link">{ this.props.translate( 'Lost your password?' ) }</a>;
-		const goBackLink = ! magicLoginView &&
-			<a href="#" key="back-link" onClick={ this.goBack }><Gridicon icon="arrow-left" size={ 18 } /> { this.props.translate( 'Back' ) }</a>;
+		const showMagicLoginLink = magicLoginEnabled && ! magicLoginView && <a href="#"
+			key="magic-login-link"
+			onClick={ this.onMagicLoginRequestClick }>
+				{ translate( 'Email me a login link' ) }
+			</a>;
+		const resetPasswordLink = ! magicLoginView && <a
+				href={ config( 'login_url' ) + '?action=lostpassword' }
+				key="lost-password-link">
+					{ this.props.translate( 'Lost your password?' ) }
+				</a>;
+		const goBackLink = ! magicLoginView && <a
+				href="#"
+				key="back-link"
+				onClick={ this.goBack }>
+					<Gridicon icon="arrow-left" size={ 18 } /> { this.props.translate( 'Back' ) }
+				</a>;
 
 		return compact( [
 			showMagicLoginLink,


### PR DESCRIPTION
Add tracking code to login

The following tracks events are added:
```
calypso_login_enter_password_instead_click
calypso_login_magic_login_request_click
calypso_login_go_back_click

calypso_login_magic_link_expired_link_view
calypso_login_magic_link_link_sent_view
calypso_login_magic_link_interstitial_view

calypso_login_block_remember_me_change with property new_value
calypso_login_block_login_submit
calypso_login_block_login_success
calypso_login_block_login_failure with property error_message
```

Also a pageview event is generated for the login.

![screen shot 2017-04-19 at 11 17 57](https://cloud.githubusercontent.com/assets/326402/25170070/e8f69c66-24f1-11e7-93f4-8bea4d8ee8c4.png)


#### Testing instructions
  
1. Run `git checkout add/tracking-to-login` and start your server, or open a [live branch](https://calypso.live/?branch=add/tracking-to-login)
2. Turn on debugging in the JavaScript developer console to view calls being made with the analytics module: `localStorage.setItem('debug', 'calypso:analytics:*');`
3. Open the [`Login` page](http://calypso.localhost:3000/login)
4. Assert that clicking the various links and viewing the various states results on the emitting of the events above.

#### Reviews
  
- [x] Code
- [x] Product

