### PR TITLE
Login: Update existing login urls to work with new page

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -79,6 +79,16 @@ const loggedOutMiddleware = currentUser => {
 		return;
 	}
 
+	if ( config.isEnabled( 'devdocs/redirect-loggedout-homepage' ) ) {
+		page( '/', () => {
+			if ( config.isEnabled( 'oauth' ) ) {
+				page.redirect( '/authorize' );
+			} else {
+				page.redirect( '/devdocs/start' );
+			}
+		} );
+	}
+
 	const sections = require( 'sections' );
 	const validSections = sections.get().reduce( ( acc, section ) => {
 		return section.enableLoggedOut ? acc.concat( section.paths ) : acc;
@@ -88,15 +98,6 @@ const loggedOutMiddleware = currentUser => {
 	);
 
 	page( '*', ( context, next ) => {
-		if ( '/' === context.pathname && config.isEnabled( 'devdocs/redirect-loggedout-homepage' ) ) {
-			if ( config.isEnabled( 'oauth' ) ) {
-				page.redirect( '/authorize' );
-			} else {
-				page.redirect( '/devdocs/start' );
-			}
-			return;
-		}
-
 		if ( isValidSection( context.path ) ) {
 			next();
 		}

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -88,6 +88,15 @@ const loggedOutMiddleware = currentUser => {
 	);
 
 	page( '*', ( context, next ) => {
+		if ( '/' === context.pathname && config.isEnabled( 'devdocs/redirect-loggedout-homepage' ) ) {
+			if ( config.isEnabled( 'oauth' ) ) {
+				page.redirect( '/authorize' );
+			} else {
+				page.redirect( '/devdocs/start' );
+			}
+			return;
+		}
+
 		if ( isValidSection( context.path ) ) {
 			next();
 		}

--- a/client/boot/project/wordpress-com.js
+++ b/client/boot/project/wordpress-com.js
@@ -184,15 +184,6 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 	if ( ! currentUser.get() ) {
 		// Dead-end the sections the user can't access when logged out
 		page( '*', function( context, next ) {
-			if ( '/' === context.pathname && config.isEnabled( 'devdocs/redirect-loggedout-homepage' ) ) {
-				if ( config.isEnabled( 'oauth' ) ) {
-					page.redirect( '/authorize' );
-				} else {
-					page.redirect( '/devdocs/start' );
-				}
-				return;
-			}
-
 			//see server/pages/index for prod redirect
 			if ( '/plans' === context.pathname ) {
 				const queryFor = context.query && context.query.for;

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -22,6 +22,7 @@ import FormButton from 'components/forms/form-button';
 import notices from 'notices';
 import Notice from 'components/notice';
 import LoggedOutForm from 'components/logged-out-form';
+import { login } from 'lib/paths';
 import formState from 'lib/form-state';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
@@ -288,7 +289,7 @@ class SignupForm extends Component {
 			return;
 		}
 
-		let link = config( 'login_url' ) + '?redirect_to=' + this.props.getRedirectToAfterLoginUrl;
+		let link = login( { redirectTo: this.props.getRedirectToAfterLoginUrl } );
 		return map( messages, ( message, error_code ) => {
 			if ( error_code === 'taken' ) {
 				link += '&email_address=' + encodeURIComponent( formState.getFieldValue( this.state.form, fieldName ) );
@@ -445,7 +446,7 @@ class SignupForm extends Component {
 			return;
 		}
 
-		const logInUrl = this.localizeUrlWithSubdomain( config( 'login_url' ) );
+		const logInUrl = config.isEnabled( 'wp-login' ) ? login() : this.localizeUrlWithSubdomain( config( 'login_url' ) );
 
 		return (
 			<LoggedOutFormLinks>

--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -12,6 +12,7 @@ import url from 'url';
  * Internal dependencies
  */
 import DocsComponent from './main';
+import { login } from 'lib/paths';
 import SingleDocComponent from './doc';
 import DesignAssetsComponent from './design';
 import Blocks from './design/blocks';
@@ -144,7 +145,7 @@ const devdocs = {
 
 	pleaseLogIn: function( context ) { // eslint-disable-line no-unused-vars
 		const currentUrl = url.parse( location.href );
-		const redirectUrl = currentUrl.protocol + '//' + currentUrl.host + '/devdocs/welcome';
+		const redirectTo = currentUrl.protocol + '//' + currentUrl.host + '/devdocs/welcome';
 
 		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 
@@ -153,7 +154,7 @@ const devdocs = {
 				title: 'Log In to start hacking',
 				line: 'Required to access the WordPress.com API',
 				action: 'Log In to WordPress.com',
-				actionURL: 'https://wordpress.com/wp-login.php?redirect_to=' + encodeURIComponent( redirectUrl ),
+				actionURL: login( { redirectTo } ),
 				secondaryAction: 'Register',
 				secondaryActionURL: '/start/developer',
 				illustration: '/calypso/images/drake/drake-nosites.svg'

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -10,13 +10,15 @@ import { localize } from 'i18n-calypso';
  */
 import Item from './item';
 import config from 'config';
+import { login } from 'lib/paths';
 
 function getLoginUrl() {
-	let loginUrl = config( 'login_url' );
+	const params = {};
 	if ( typeof window !== 'undefined' ) {
-		loginUrl += `?redirect_to=${ encodeURIComponent( window.location.href ) }`;
+		params.redirectTo = window.location.href;
 	}
-	return loginUrl;
+
+	return login( params );
 }
 
 const MasterbarLoggedOut = ( { title, sectionName, translate } ) => (

--- a/client/lib/paths/index.js
+++ b/client/lib/paths/index.js
@@ -1,5 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import { login } from './login';
+
 function editorPathFromSite( site ) {
-	var path = '',
+	let path = '',
 		siteSlug;
 
 	if ( site ) {
@@ -18,10 +23,10 @@ function editorPathFromSite( site ) {
  * @param  {object|string} site Site object or site slug
  * @return {string}      URL to post editor
  */
-module.exports.newPost = function( site ) {
-	var sitePath = editorPathFromSite( site );
+function newPost( site ) {
+	const sitePath = editorPathFromSite( site );
 	return '/post' + sitePath;
-};
+}
 
 /**
  * Returns a URL to the editor for a new page on a given site.
@@ -29,10 +34,10 @@ module.exports.newPost = function( site ) {
  * @param  {object|string} site Site object or site slug
  * @return {string}      URL to page editor
  */
-module.exports.newPage = function( site ) {
-	var sitePath = editorPathFromSite( site );
+function newPage( site ) {
+	const sitePath = editorPathFromSite( site );
 	return '/page' + sitePath;
-};
+}
 
 /**
  * Returns a URL to manage Publicize connections for a given site.
@@ -40,15 +45,15 @@ module.exports.newPage = function( site ) {
  * @param  {object} site Site object
  * @return {string}      URL to manage Publicize connections
  */
-module.exports.publicizeConnections = function( site ) {
-	var url = '/sharing';
+function publicizeConnections( site ) {
+	let url = '/sharing';
 
 	if ( site ) {
 		url += '/' + site.slug;
 	}
 
 	return url;
-};
+}
 
 /**
  * Returns a URL to manage Jetpack modules for a given site.
@@ -57,8 +62,8 @@ module.exports.publicizeConnections = function( site ) {
  * @param  {string} module	Optional module name to link to
  * @return {string}      	URL to manage Jetpack modules
  */
-module.exports.jetpackModules = function( site, module ) {
-	var url = '';
+function jetpackModules( site, module ) {
+	let url = '';
 	if ( ! site.jetpack ) {
 		return url;
 	}
@@ -69,4 +74,12 @@ module.exports.jetpackModules = function( site, module ) {
 	}
 
 	return url;
+}
+
+export default {
+	jetpackModules,
+	login,
+	newPost,
+	newPage,
+	publicizeConnections,
 };

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -4,8 +4,9 @@
 import { addQueryArgs } from 'lib/url';
 import config, { isEnabled } from 'config';
 
-export function login( { redirectTo } = {} ) {
-	const url = isEnabled( 'wp-login' ) ? '/login' : config( 'login_url' );
+export function login( { legacy, redirectTo } = {} ) {
+	const legacyUrl = config( 'login_url' );
+	const url = ! legacy && isEnabled( 'wp-login' ) ? '/login' : legacyUrl;
 
 	return redirectTo
 		? addQueryArgs( { redirect_to: redirectTo }, url )

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -4,7 +4,7 @@
 import { addQueryArgs } from 'lib/url';
 import config, { isEnabled } from 'config';
 
-export function login( { redirectTo } ) {
+export function login( { redirectTo } = {} ) {
 	const url = isEnabled( 'wp-login' ) ? '/login' : config( 'login_url' );
 
 	return redirectTo

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { addQueryArgs } from 'lib/url';
+import config, { isEnabled } from 'config';
+
+export function login( { redirectTo } ) {
+	const url = isEnabled( 'wp-login' ) ? '/login' : config( 'login_url' );
+
+	return redirectTo
+		? addQueryArgs( { redirect_to: redirectTo }, url )
+		: url;
+}

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import { login } from '../';
+import { useSandbox } from 'test/helpers/use-sinon';
+
+describe( 'index', () => {
+	describe( '#login()', () => {
+		useSandbox( sandbox => {
+			sandbox.stub( config, 'isEnabled' ).withArgs( 'wp-login' ).returns( true );
+		} );
+
+		it( 'should return the login url', () => {
+			const url = login();
+
+			expect( url ).to.equal(
+				'/login'
+			);
+		} );
+
+		it( 'should return the login url with encoded redirect url param', () => {
+			const url = login( { redirectTo: 'https://wordpress.com/?search=test&foo=bar' } );
+
+			expect( url ).to.equal(
+				'/login?redirect_to=https%3A%2F%2Fwordpress.com%2F%3Fsearch%3Dtest%26foo%3Dbar'
+			);
+		} );
+	} );
+} );

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -16,6 +16,14 @@ describe( 'index', () => {
 			sandbox.stub( config, 'isEnabled' ).withArgs( 'wp-login' ).returns( true );
 		} );
 
+		it( 'should return the legacy login url', () => {
+			const url = login( { legacy: true } );
+
+			expect( url ).to.equal(
+				'https://wordpress.com/wp-login.php'
+			);
+		} );
+
 		it( 'should return the login url', () => {
 			const url = login();
 

--- a/client/lib/user/utils.js
+++ b/client/lib/user/utils.js
@@ -8,7 +8,6 @@ import debugModule from 'debug';
  */
 import config from 'config';
 import userModule from 'lib/user';
-import { addQueryArgs } from 'lib/url';
 
 /**
  * Module Variables
@@ -16,18 +15,10 @@ import { addQueryArgs } from 'lib/url';
 const user = userModule();
 const debug = debugModule( 'calypso:user:utilities' );
 
-var userUtils = {
-	getLoginUrl: function( redirect ) {
-		const url = config( 'login_url' );
-
-		return redirect
-			? addQueryArgs( { redirect_to: redirect }, url )
-			: url;
-	},
-
-	getLogoutUrl: function( redirect ) {
-		var url = '/logout',
-			userData = user.get(),
+export default {
+	getLogoutUrl( redirect ) {
+		const userData = user.get();
+		let url = '/logout',
 			subdomain = '';
 
 		// If logout_URL isn't set, then go ahead and return the logout URL
@@ -54,26 +45,24 @@ var userUtils = {
 		return url;
 	},
 
-	logout: function( redirect ) {
-		const logoutUrl = userUtils.getLogoutUrl( redirect );
+	logout( redirect ) {
+		const logoutUrl = this.getLogoutUrl( redirect );
 
 		// Clear any data stored locally within the user data module or localStorage
 		user.clear( () => location.href = logoutUrl );
 	},
 
-	getLocaleSlug: function() {
+	getLocaleSlug() {
 		return user.get().localeSlug;
 	},
 
-	isLoggedIn: function() {
+	isLoggedIn() {
 		return Boolean( user.data );
 	},
 
-	needsVerificationForSite: function( site ) {
+	needsVerificationForSite( site ) {
 		// do not allow publish for unverified e-mails,
 		// but allow if the site is VIP
 		return !user.get().email_verified && !( site && site.is_vip );
 	},
 };
-
-module.exports = userUtils;

--- a/client/me/help/controller.js
+++ b/client/me/help/controller.js
@@ -8,6 +8,7 @@ import i18n from 'i18n-calypso';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { login } from 'lib/paths';
 import route from 'lib/route';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import config from 'config';
@@ -15,7 +16,6 @@ import { renderWithReduxStore } from 'lib/react-helpers';
 import HelpComponent from './main';
 import CoursesComponent from './help-courses';
 import ContactComponent from './help-contact';
-import userUtils from 'lib/user/utils';
 import support from 'lib/url/support';
 
 export default {
@@ -33,7 +33,7 @@ export default {
 				url = support.CONTACT;
 				break;
 			default:
-				url = userUtils.getLoginUrl( window.location.href );
+				url = login( { redirectTo: window.location.href } );
 		}
 
 		// Not using the page library here since this is an external URL

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -12,9 +12,9 @@ import debugModule from 'debug';
  */
 import SignupForm from 'components/signup-form';
 import InviteFormHeader from 'my-sites/invites/invite-form-header';
+import { login } from 'lib/paths';
 import { createAccount, acceptInvite } from 'lib/invites/actions';
 import WpcomLoginForm from 'signup/wpcom-login-form';
-import config from 'config';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import analytics from 'lib/analytics';
@@ -46,7 +46,7 @@ let InviteAcceptLoggedOut = React.createClass( {
 	},
 
 	clickSignInLink() {
-		let signInLink = config( 'login_url' ) + '?redirect_to=' + encodeURIComponent( window.location.href );
+		const signInLink = login( { redirectTo: window.location.href } );
 		analytics.tracks.recordEvent( 'calypso_invite_accept_logged_out_sign_in_link_click' );
 		window.location = signInLink;
 	},

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -14,6 +14,7 @@ import { bindActionCreators } from 'redux';
 import InviteHeader from 'my-sites/invites/invite-header';
 import LoggedIn from 'my-sites/invites/invite-accept-logged-in';
 import LoggedOut from 'my-sites/invites/invite-accept-logged-out';
+import { login } from 'lib/paths';
 import _user from 'lib/user';
 import { fetchInvite } from 'lib/invites/actions';
 import InvitesStore from 'lib/invites/stores/invites-accept-validation';
@@ -23,7 +24,6 @@ import analytics from 'lib/analytics';
 import { getRedirectAfterAccept } from 'my-sites/invites/utils';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
-import config from 'config';
 import userUtils from 'lib/user/utils';
 import LocaleSuggestions from 'signup/locale-suggestions';
 
@@ -97,7 +97,7 @@ let InviteAccept = React.createClass( {
 
 	signInLink() {
 		const invite = this.state.invite;
-		let loginUrl = config( 'login_url' ) + '?redirect_to=' + encodeURIComponent( window.location.href );
+		let loginUrl = login( { redirectTo: window.location.href } );
 
 		if ( invite && invite.sentTo ) {
 			let presetEmail = '&email_address=' + encodeURIComponent( invite.sentTo );
@@ -166,14 +166,14 @@ let InviteAccept = React.createClass( {
 						title: error.message, // "You are already a (follower|member) of this site"
 						line: this.translate( 'Would you like to accept the invite with a different account?' ),
 						action: this.translate( 'Switch Accounts' ),
-						actionURL: config( 'login_url' ) + '?redirect_to=' + encodeURIComponent( window.location.href ),
+						actionURL: login( { redirectTo: window.location.href } ),
 					} );
 					break;
 				case 'unauthorized_created_by_self':
 					Object.assign( props, {
 						line: error.message, // "You can not use an invitation that you have created for someone else."
 						action: this.translate( 'Switch Accounts' ),
-						actionURL: config( 'login_url' ) + '?redirect_to=' + encodeURIComponent( window.location.href ),
+						actionURL: login( { redirectTo: window.location.href } ),
 					} );
 					break;
 				default:

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -97,7 +97,7 @@ let InviteAccept = React.createClass( {
 
 	signInLink() {
 		const invite = this.state.invite;
-		let loginUrl = login( { redirectTo: window.location.href } );
+		let loginUrl = login( { legacy: true, redirectTo: window.location.href } );
 
 		if ( invite && invite.sentTo ) {
 			let presetEmail = '&email_address=' + encodeURIComponent( invite.sentTo );
@@ -166,14 +166,14 @@ let InviteAccept = React.createClass( {
 						title: error.message, // "You are already a (follower|member) of this site"
 						line: this.translate( 'Would you like to accept the invite with a different account?' ),
 						action: this.translate( 'Switch Accounts' ),
-						actionURL: login( { redirectTo: window.location.href } ),
+						actionURL: login( { legacy: true, redirectTo: window.location.href } ),
 					} );
 					break;
 				case 'unauthorized_created_by_self':
 					Object.assign( props, {
 						line: error.message, // "You can not use an invitation that you have created for someone else."
 						action: this.translate( 'Switch Accounts' ),
-						actionURL: login( { redirectTo: window.location.href } ),
+						actionURL: login( { legacy: true, redirectTo: window.location.href } ),
 					} );
 					break;
 				default:

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -588,7 +588,7 @@ const LoggedInForm = React.createClass( {
 		return (
 			<LoggedOutFormLinks>
 				{ this.isWaitingForConfirmation() ? backToWpAdminLink : null }
-				<LoggedOutFormLinkItem href={ login( { redirectTo } ) }>
+				<LoggedOutFormLinkItem href={ login( { legacy: true, redirectTo } ) }>
 					{ this.translate( 'Sign in as a different user' ) }
 				</LoggedOutFormLinkItem>
 				<LoggedOutFormLinkItem onClick={ this.handleSignOut }>

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -15,13 +15,13 @@ import cookie from 'cookie';
  * Internal dependencies
  */
 import addQueryArgs from 'lib/route/add-query-args';
+import { login } from 'lib/paths';
 import Main from 'components/main';
 import StepHeader from '../step-header';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import SignupForm from 'components/signup-form';
 import WpcomLoginForm from 'signup/wpcom-login-form';
-import config from 'config';
 import QuerySites from 'components/data/query-sites';
 import {
 	createAccount,
@@ -163,10 +163,10 @@ const LoggedOutForm = React.createClass( {
 	renderFooterLink() {
 		const { queryObject } = this.props.jetpackConnectAuthorize;
 		const redirectTo = addQueryArgs( queryObject, window.location.href );
-		const loginUrl = addQueryArgs( { redirect_to: redirectTo }, config( 'login_url' ) );
+
 		return (
 			<LoggedOutFormLinks>
-				<LoggedOutFormLinkItem href={ loginUrl }>
+				<LoggedOutFormLinkItem href={ login( { redirectTo } ) }>
 					{ this.translate( 'Already have an account? Sign in' ) }
 				</LoggedOutFormLinkItem>
 				<HelpButton onClick={ this.clickHelpButton } />
@@ -561,7 +561,6 @@ const LoggedInForm = React.createClass( {
 		} = this.props.jetpackConnectAuthorize;
 		const { blogname, redirect_after_auth } = queryObject;
 		const redirectTo = addQueryArgs( queryObject, window.location.href );
-		const loginUrl = addQueryArgs( { redirect_to: redirectTo }, config( 'login_url' ) );
 		const backToWpAdminLink = (
 			<LoggedOutFormLinkItem icon={ true } href={ redirect_after_auth }>
 				<Gridicon size={ 18 } icon="arrow-left" />
@@ -589,7 +588,7 @@ const LoggedInForm = React.createClass( {
 		return (
 			<LoggedOutFormLinks>
 				{ this.isWaitingForConfirmation() ? backToWpAdminLink : null }
-				<LoggedOutFormLinkItem href={ loginUrl }>
+				<LoggedOutFormLinkItem href={ login( { redirectTo } ) }>
 					{ this.translate( 'Sign in as a different user' ) }
 				</LoggedOutFormLinkItem>
 				<LoggedOutFormLinkItem onClick={ this.handleSignOut }>

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -21,6 +21,7 @@ import Gravatar from 'components/gravatar';
 import Button from 'components/button';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
+import { login } from 'lib/paths';
 import { validateSSONonce, authorizeSSO } from 'state/jetpack-connect/actions';
 import { getSSO } from 'state/jetpack-connect/selectors';
 import addQueryArgs from 'lib/route/add-query-args';
@@ -135,8 +136,7 @@ const JetpackSSOForm = React.createClass( {
 	},
 
 	getSignInLink() {
-		const loginUrl = config( 'login_url' ) || 'https://wordpress.com/wp-login.php';
-		return addQueryArgs( { redirect_to: window.location.href }, loginUrl );
+		return login( { redirectTo: window.location.href } );
 	},
 
 	maybeValidateSSO( props = this.props ) {

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -136,7 +136,7 @@ const JetpackSSOForm = React.createClass( {
 	},
 
 	getSignInLink() {
-		return login( { redirectTo: window.location.href } );
+		return login( { legacy: true, redirectTo: window.location.href } );
 	},
 
 	maybeValidateSSO( props = this.props ) {

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -10,9 +10,9 @@ const debug = require( 'debug' )( 'calypso:steps:site' ); // eslint-disable-line
  * Internal dependencies
  */
 import wpcom from 'lib/wp';
-import config from 'config';
 import analytics from 'lib/analytics';
 import formState from 'lib/form-state';
+import { login } from 'lib/paths';
 import SignupActions from 'lib/signup/actions';
 import ValidationFieldset from 'signup/validation-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -185,8 +185,8 @@ module.exports = React.createClass( {
 		}
 	},
 
-	getErrorMessagesWithLogin: function( fieldName ) {
-		var link = config( 'login_url' ) + '?redirect_to=' + window.location.href,
+	getErrorMessagesWithLogin( fieldName ) {
+		const link = login( { redirectTo: window.location.href } ),
 			messages = formState.getFieldErrorMessages( this.state.form, fieldName );
 
 		if ( ! messages ) {


### PR DESCRIPTION
This PR tries to make it possible to use new Calypso login page where it is applicable (`development` atm, more to come). Instead of redirecting users to https://wordpress.com/wp-login.php we load `/login` url with proper redirect url set as query param.

This PR also fixes logged out redirect for homepage which was buggy after my latest boot refactoring.

### Testing

1. Open http://calypso.localhost:3000 when logged out.
2. It should redirect to http://calypso.localhost:3000/devdocs/start.
3. Click `Log In to WordPress.com`. 
4. Try to login with credentials not using 2FA.
5. Log out.
6. Click Log In link in the masterbar.
7. You should see Calypso login page.
8. Log in and log out to make sure it works properly.
9. Go to http://calypso.localhost:3000/jetpack/connect.
10. Try to connect your existing Jetpack instance with WordPress.com account.

### Review

* [x] Code
* [x] Product
