### PR TITLE
Remove isSubscriptionsModuleActive from form-discussion

### DIFF
--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -598,14 +598,12 @@ const connectComponent = connect(
 		const isJetpack = isJetpackSite( state, siteId );
 		const jetpackSettingsUISupported = siteSupportsJetpackSettingsUi( state, siteId );
 		const isLikesModuleActive = isJetpackModuleActive( state, siteId, 'likes' );
-		const isSubscriptionsModuleActive = isJetpackModuleActive( state, siteId, 'subscriptions' );
 
 		return {
 			siteId,
 			isJetpack,
 			jetpackSettingsUISupported,
 			isLikesModuleActive,
-			isSubscriptionsModuleActive,
 		};
 	}
 );


### PR DESCRIPTION
This prop/selector is unused and should not be included.

Test:

1. Checkout branch
1. `make run`
1. Visit /settings/discussion/:site
1. Verify that the page continues to work correctly