### PR TITLE
Site Settings: Use Redux site for themeSetup and startOver selected site

### DIFF
--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -22,6 +22,7 @@ import ThemeSetup from './theme-setup';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import titlecase from 'to-title-case';
 import utils from 'lib/site/utils';
+import { getSelectedSite } from 'state/ui/selectors';
 
 /**
  * Module vars
@@ -151,19 +152,9 @@ module.exports = {
 	},
 
 	startOver( context ) {
-		let site = sites.getSelectedSite();
-
-		if ( sites.initialized ) {
-			if ( ! canDeleteSite( site ) ) {
-				return page( '/settings/general/' + site.slug );
-			}
-		} else {
-			sites.once( 'change', function() {
-				site = sites.getSelectedSite();
-				if ( ! canDeleteSite( site ) ) {
-					return page( '/settings/general/' + site.slug );
-				}
-			} );
+		const site = getSelectedSite( context.store.getState() );
+		if ( site && ! canDeleteSite( site ) ) {
+			return page( '/settings/general/' + site.slug );
 		}
 
 		renderPage(
@@ -173,19 +164,9 @@ module.exports = {
 	},
 
 	themeSetup( context ) {
-		let site = sites.getSelectedSite();
-
-		if ( sites.initialized ) {
-			if ( site.jetpack ) {
-				return page( '/settings/general/' + site.slug );
-			}
-		} else {
-			sites.once( 'change', function() {
-				site = sites.getSelectedSite();
-				if ( site.jetpack ) {
-					return page( '/settings/general/' + site.slug );
-				}
-			} );
+		const site = getSelectedSite( context.store.getState() );
+		if ( site && site.jetpack ) {
+			return page( '/settings/general/' + site.slug );
 		}
 
 		if ( ! config.isEnabled( 'settings/theme-setup' ) ) {


### PR DESCRIPTION
This PR updates the `themeSetup` and `startOver` sections to not use the `sites-list` for retrieving the current site, but rather to use the current site from Redux.

To test:
* Checkout this branch
* Go to `/settings/theme-setup/$site`, where `$site` is one of your WordPress.com sites.
* Verify the page loads correctly.
* Go to `/settings/start-over/$site`, where `$site` is one of your WordPress.com sites.
* Verify the page loads correctly.
* Go to `/settings/theme-setup/$site`, where `$site` is one of your Jetpack sites.
* Verify you're redirected to General settings.
* Go to `/settings/start-over/$site`, where `$site` is one of your Jetpack sites.
* Verify you're redirected to General settings.
* Clean your Redux state & cache and test all of the above.