### PR TITLE
Taxonomy: Prefill new tag/category field if coming from search

### DIFF
--- a/client/blocks/taxonomy-manager/index.jsx
+++ b/client/blocks/taxonomy-manager/index.jsx
@@ -93,6 +93,7 @@ export class TaxonomyManager extends Component {
 					onClose={ this.closeTermFormDialog }
 					taxonomy={ this.props.taxonomy }
 					postType={ this.props.postType }
+					searchTerm={ search }
 					term={ this.state.selectedTerm }
 					showDescriptionInput
 				/>

--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -42,6 +42,7 @@ class TermFormDialog extends Component {
 		onClose: PropTypes.func,
 		onSuccess: PropTypes.func,
 		postType: PropTypes.string,
+		searchTerm: PropTypes.string,
 		showDescriptionInput: PropTypes.bool,
 		showDialog: PropTypes.bool,
 		siteId: PropTypes.number,
@@ -145,6 +146,13 @@ class TermFormDialog extends Component {
 
 	init( props ) {
 		if ( ! props.term ) {
+			if ( props.searchTerm && props.searchTerm.trim().length ) {
+				this.setState( assign( {}, this.constructor.initialState, {
+					name: props.searchTerm,
+				} ), this.isValid );
+				return;
+			}
+
 			this.setState( this.constructor.initialState );
 			return;
 		}


### PR DESCRIPTION
This is a small enhancement to address #9965. If a user searches for an existing taxonomy then clicks "Add," we could prefill the new tag/category field assuming they want to add the taxonomy they just searched for. I like this approach, but I'd be curious to get other opinions.

Some notes:
- `props.searchTerm.trim().length` ensures that we don't prefill the new taxonomy field if the user has entered spaces in the search
- Providing `isValid` as a callback to `setState` provides the validation and throws the expected errors if the user has entered the same value as another existing taxonomy.

## To test
1. Start at http://calypso.localhost:3000/settings/taxonomies/post_tag/
2. Type a query into the search box.
3. Click "Add New Tag." The name field should be prefilled.
4. Go back to the search and try entering the name of an existing tag and pressing "Add New Tag." You should see an error.
5. Leave the search field blank and click "Add New Tag." You should see the default blank field with the placeholder text.

## GIF
![taxonomy](https://cloud.githubusercontent.com/assets/7240478/25180258/8288881c-24ca-11e7-9867-1bfc3da96f06.gif)