### PR TITLE
Extensions: Fetch data from the WP Super Cache REST API

### DIFF
--- a/client/extensions/wp-super-cache/accepted-filenames.jsx
+++ b/client/extensions/wp-super-cache/accepted-filenames.jsx
@@ -20,6 +20,7 @@ import WrapSettingsForm from './wrap-settings-form';
 
 const AcceptedFilenames = ( {
 	fields: {
+		accepted_files,
 		archives,
 		author,
 		category,
@@ -27,11 +28,10 @@ const AcceptedFilenames = ( {
 		frontpage,
 		home,
 		pages,
+		rejected_uri,
 		search,
 		single,
 		tag,
-		wp_accepted_files,
-		wp_rejected_uri,
 	},
 	handleAutosavingToggle,
 	handleChange,
@@ -176,8 +176,8 @@ const AcceptedFilenames = ( {
 						</FormLabel>
 						<FormTextarea
 							disabled={ isRequesting || isSaving }
-							onChange={ handleChange( 'wp_rejected_uri' ) }
-							value={ wp_rejected_uri || '' } />
+							onChange={ handleChange( 'rejected_uri' ) }
+							value={ rejected_uri || '' } />
 						<FormSettingExplanation>
 							{ translate(
 								'Add here strings (not a filename) that forces a page not to be cached. For example, ' +
@@ -194,8 +194,8 @@ const AcceptedFilenames = ( {
 						</FormLabel>
 						<FormTextarea
 							disabled={ isRequesting || isSaving }
-							onChange={ handleChange( 'wp_accepted_files' ) }
-							value={ wp_accepted_files || '' } />
+							onChange={ handleChange( 'accepted_files' ) }
+							value={ accepted_files || '' } />
 						<FormSettingExplanation>
 							{ translate(
 								'Add here those filenames that can be cached, even if they match one of the rejected ' +
@@ -211,10 +211,10 @@ const AcceptedFilenames = ( {
 
 const getFormSettings = settings => {
 	const textSettings = pick( settings, [
-		'wp_accepted_files',
-		'wp_rejected_uri',
+		'accepted_files',
+		'rejected_uri',
 	] );
-	const wpCachePages = pick( settings.wp_cache_pages, [
+	const pages = pick( settings.pages, [
 		'archives',
 		'author',
 		'category',
@@ -227,7 +227,7 @@ const getFormSettings = settings => {
 		'tag',
 	] );
 
-	return Object.assign( {}, textSettings, wpCachePages );
+	return { ...textSettings, ...pages };
 };
 
 export default WrapSettingsForm( getFormSettings )( AcceptedFilenames );

--- a/client/extensions/wp-super-cache/advanced-tab.jsx
+++ b/client/extensions/wp-super-cache/advanced-tab.jsx
@@ -21,8 +21,8 @@ import WrapSettingsForm from './wrap-settings-form';
 
 const AdvancedTab = ( {
 	fields: {
-		super_cache_enabled,
-		wp_cache_enabled,
+		is_cache_enabled,
+		is_super_cache_enabled,
 	},
 	siteUrl,
 } ) => {
@@ -36,7 +36,7 @@ const AdvancedTab = ( {
 			<AcceptedFilenames />
 			<RejectedUserAgents />
 			<LockDown />
-			{	!! wp_cache_enabled && ( '1' === super_cache_enabled || '2' === super_cache_enabled ) &&
+			{ is_cache_enabled && is_super_cache_enabled &&
 				<DirectlyCachedFiles siteUrl={ siteUrl } />
 			}
 			<FixConfig />
@@ -45,8 +45,8 @@ const AdvancedTab = ( {
 };
 const getFormSettings = settings => {
 	return pick( settings, [
-		'super_cache_enabled',
-		'wp_cache_enabled',
+		'is_cache_enabled',
+		'is_super_cache_enabled',
 	] );
 };
 

--- a/client/extensions/wp-super-cache/advanced.jsx
+++ b/client/extensions/wp-super-cache/advanced.jsx
@@ -17,21 +17,18 @@ import WrapSettingsForm from './wrap-settings-form';
 
 const Advanced = ( {
 	fields: {
-		_wp_using_ext_object_cache,
-		super_cache_enabled,
-		wp_cache_clear_on_post_edit,
-		wp_cache_disable_locking,
-		wp_cache_disable_utf8,
-		wp_cache_front_page_checks,
-		wp_cache_mfunc_enabled,
-		wp_cache_mobile_browsers,
-		wp_cache_mobile_enabled,
-		wp_cache_mobile_prefixes,
-		wp_cache_mutex_disabled,
-		wp_cache_object_cache,
-		wp_cache_refresh_single_only,
-		wp_super_cache_late_init,
-		wp_supercache_cache_list,
+		cache_disable_locking,
+		cache_late_init,
+		cache_list,
+		cache_mobile_browsers,
+		cache_mobile_prefixes,
+		cache_mod_rewrite,
+		clear_cache_on_post_edit,
+		disable_utf8,
+		front_page_checks,
+		is_mfunc_enabled,
+		is_mobile_enabled,
+		refresh_current_only_on_comments,
 	},
 	handleAutosavingToggle,
 	isRequesting,
@@ -47,9 +44,9 @@ const Advanced = ( {
 				<form>
 					<FormFieldset>
 						<FormToggle
-							checked={ !! wp_cache_mfunc_enabled }
-							disabled={ isRequesting || isSaving || ( '1' === super_cache_enabled ) }
-							onChange={ handleAutosavingToggle( 'wp_cache_mfunc_enabled' ) }>
+							checked={ !! is_mfunc_enabled }
+							disabled={ isRequesting || isSaving || !! cache_mod_rewrite }
+							onChange={ handleAutosavingToggle( 'is_mfunc_enabled' ) }>
 							<span>
 								{ translate(
 								'Enable dynamic caching. Requires PHP or legacy caching. (See ' +
@@ -70,9 +67,9 @@ const Advanced = ( {
 						</FormToggle>
 
 						<FormToggle
-							checked={ !! wp_cache_mobile_enabled }
+							checked={ !! is_mobile_enabled }
 							disabled={ isRequesting || isSaving }
-							onChange={ handleAutosavingToggle( 'wp_cache_mobile_enabled' ) }>
+							onChange={ handleAutosavingToggle( 'is_mobile_enabled' ) }>
 							<span>
 								{ translate(
 									'Mobile device support. (External plugin or theme required. See the ' +
@@ -90,7 +87,7 @@ const Advanced = ( {
 									}
 								) }
 							</span>
-							{ !! wp_cache_mobile_enabled &&
+							{ is_mobile_enabled &&
 								<FormSettingExplanation>
 									{ translate(
 										'{{strong}}Mobile Browsers{{/strong}}{{br/}}',
@@ -101,7 +98,7 @@ const Advanced = ( {
 											}
 										}
 									) }
-									{ wp_cache_mobile_browsers || '' }
+									{ cache_mobile_browsers || '' }
 
 									{ translate(
 										'{{br/}}{{strong}}Mobile Prefixes{{/strong}}{{br/}}',
@@ -112,15 +109,15 @@ const Advanced = ( {
 											}
 										}
 									) }
-									{ wp_cache_mobile_prefixes || '' }
+									{ cache_mobile_prefixes || '' }
 								</FormSettingExplanation>
 							}
 						</FormToggle>
 
 						<FormToggle
-							checked={ !! wp_cache_disable_utf8 }
+							checked={ !! disable_utf8 }
 							disabled={ isRequesting || isSaving }
-							onChange={ handleAutosavingToggle( 'wp_cache_disable_utf8' ) }>
+							onChange={ handleAutosavingToggle( 'disable_utf8' ) }>
 							<span>
 								{ translate(
 									'Remove UTF8/blog charset support from .htaccess file. Only necessary if you see ' +
@@ -130,18 +127,18 @@ const Advanced = ( {
 						</FormToggle>
 
 						<FormToggle
-							checked={ !! wp_cache_clear_on_post_edit }
+							checked={ !! clear_cache_on_post_edit }
 							disabled={ isRequesting || isSaving }
-							onChange={ handleAutosavingToggle( 'wp_cache_clear_on_post_edit' ) }>
+							onChange={ handleAutosavingToggle( 'clear_cache_on_post_edit' ) }>
 							<span>
 								{ translate( 'Clear all cache files when a post or page is published or updated.' ) }
 							</span>
 						</FormToggle>
 
 						<FormToggle
-							checked={ !! wp_cache_front_page_checks }
+							checked={ !! front_page_checks }
 							disabled={ isRequesting || isSaving }
-							onChange={ handleAutosavingToggle( 'wp_cache_front_page_checks' ) }>
+							onChange={ handleAutosavingToggle( 'front_page_checks' ) }>
 							<span>
 								{ translate(
 									'Extra homepage checks. (Very occasionally stops homepage caching) {{em}}(Recommended){{/em}}',
@@ -153,54 +150,42 @@ const Advanced = ( {
 						</FormToggle>
 
 						<FormToggle
-							checked={ !! wp_cache_refresh_single_only }
+							checked={ !! refresh_current_only_on_comments }
 							disabled={ isRequesting || isSaving }
-							onChange={ handleAutosavingToggle( 'wp_cache_refresh_single_only' ) }>
+							onChange={ handleAutosavingToggle( 'refresh_current_only_on_comments' ) }>
 							<span>
 								{ translate( 'Only refresh current page when comments made.' ) }
 							</span>
 						</FormToggle>
 
 						<FormToggle
-							checked={ !! wp_supercache_cache_list }
+							checked={ !! cache_list }
 							disabled={ isRequesting || isSaving }
-							onChange={ handleAutosavingToggle( 'wp_supercache_cache_list' ) }>
+							onChange={ handleAutosavingToggle( 'cache_list' ) }>
 							<span>
 								{ translate( 'List the newest cached pages on this page.' ) }
 							</span>
 						</FormToggle>
 
-						{ ! wp_cache_disable_locking &&
-							<FormToggle
-								checked={ !! wp_cache_mutex_disabled }
-								disabled={ isRequesting || isSaving }
-								onChange={ handleAutosavingToggle( 'wp_cache_mutex_disabled' ) }>
-								<span>
-									{ translate( 'Coarse file locking. You do not need this as it will slow down your website.' ) }
-								</span>
-							</FormToggle>
-						}
+						<FormToggle
+							checked={ ! cache_disable_locking }
+							disabled={ isRequesting || isSaving }
+							onChange={ handleAutosavingToggle( 'cache_disable_locking' ) }>
+							<span>
+								{ translate( 'Coarse file locking. You do not need this as it will slow down your website.' ) }
+							</span>
+						</FormToggle>
 
 						<FormToggle
-							checked={ !! wp_super_cache_late_init }
+							checked={ !! cache_late_init }
 							disabled={ isRequesting || isSaving }
-							onChange={ handleAutosavingToggle( 'wp_super_cache_late_init' ) }>
+							onChange={ handleAutosavingToggle( 'cache_late_init' ) }>
 							<span>
 								{ translate(
 									'Late init. Display cached files after WordPress has loaded. Most useful in legacy mode.'
 								) }
 							</span>
 						</FormToggle>
-						{ !! _wp_using_ext_object_cache &&
-							<FormToggle
-								checked={ !! wp_cache_object_cache }
-								disabled={ isRequesting || isSaving }
-								onChange={ handleAutosavingToggle( 'wp_cache_object_cache' ) }>
-								<span>
-									{ translate( 'Use object cache to store cached files. (Experimental)' ) }
-								</span>
-							</FormToggle>
-						}
 					</FormFieldset>
 				</form>
 			</Card>
@@ -210,21 +195,18 @@ const Advanced = ( {
 
 const getFormSettings = settings => {
 	return pick( settings, [
-		'_wp_using_ext_object_cache',
-		'super_cache_enabled',
-		'wp_cache_clear_on_post_edit',
-		'wp_cache_disable_locking',
-		'wp_cache_disable_utf8',
-		'wp_cache_front_page_checks',
-		'wp_cache_mfunc_enabled',
-		'wp_cache_mobile_browsers',
-		'wp_cache_mobile_enabled',
-		'wp_cache_mobile_prefixes',
-		'wp_cache_mutex_disabled',
-		'wp_cache_object_cache',
-		'wp_cache_refresh_single_only',
-		'wp_super_cache_late_init',
-		'wp_supercache_cache_list',
+		'cache_disable_locking',
+		'cache_late_init',
+		'cache_list',
+		'cache_mobile_browsers',
+		'cache_mobile_prefixes',
+		'cache_mod_rewrite',
+		'clear_cache_on_post_edit',
+		'disable_utf8',
+		'front_page_checks',
+		'is_mfunc_enabled',
+		'is_mobile_enabled',
+		'refresh_current_only_on_comments',
 	] );
 };
 

--- a/client/extensions/wp-super-cache/cache-location.jsx
+++ b/client/extensions/wp-super-cache/cache-location.jsx
@@ -17,7 +17,7 @@ import WrapSettingsForm from './wrap-settings-form';
 
 const CacheLocation = ( {
 	fields: {
-		wp_cache_location,
+		cache_path,
 	},
 	handleChange,
 	handleSubmitForm,
@@ -44,15 +44,15 @@ const CacheLocation = ( {
 					<FormFieldset>
 						<FormTextInput
 							disabled={ isRequesting || isSaving }
-							onChange={ handleChange( 'wp_cache_location' ) }
-							value={ wp_cache_location || '' } />
+							onChange={ handleChange( 'cache_path' ) }
+							value={ cache_path || '' } />
 						<FormSettingExplanation>
 							{ translate(
 								'Change the location of your cache files. The default is WP_CONTENT_DIR . ' +
 								'/cache/ which translates to {{cacheLocation/}}',
 								{
 									components: {
-										cacheLocation: <span>{ wp_cache_location || '' }</span>,
+										cacheLocation: <span>{ cache_path || '' }</span>,
 									}
 								}
 							) }
@@ -66,7 +66,7 @@ const CacheLocation = ( {
 
 const getFormSettings = settings => {
 	return pick( settings, [
-		'wp_cache_location',
+		'cache_path',
 	] );
 };
 

--- a/client/extensions/wp-super-cache/caching.jsx
+++ b/client/extensions/wp-super-cache/caching.jsx
@@ -19,8 +19,9 @@ import WrapSettingsForm from './wrap-settings-form';
 
 const Caching = ( {
 	fields: {
-		super_cache_enabled,
-		wp_cache_enabled,
+		cache_mod_rewrite,
+		is_cache_enabled,
+		is_super_cache_enabled,
 	},
 	handleAutosavingToggle,
 	handleRadio,
@@ -47,9 +48,9 @@ const Caching = ( {
 				<form>
 					<FormFieldset>
 						<FormToggle
-							checked={ !! wp_cache_enabled }
+							checked={ !! is_cache_enabled }
 							disabled={ isRequesting || isSaving }
-							onChange={ handleAutosavingToggle( 'wp_cache_enabled' ) }>
+							onChange={ handleAutosavingToggle( 'is_cache_enabled' ) }>
 							<span>
 								{ translate( 'Enable Page Caching' ) }
 							</span>
@@ -59,9 +60,9 @@ const Caching = ( {
 					<FormFieldset className="wp-super-cache__cache-type-fieldset">
 						<FormLabel>
 							<FormRadio
-								checked={ '1' === super_cache_enabled }
+								checked={ !! is_super_cache_enabled && !! cache_mod_rewrite }
 								disabled={ isRequesting || isSaving }
-								name="super_cache_enabled"
+								name="is_super_cache_enabled"
 								onChange={ handleRadio }
 								value="1" />
 							<span>
@@ -71,9 +72,9 @@ const Caching = ( {
 
 						<FormLabel>
 							<FormRadio
-								checked={ '2' === super_cache_enabled }
+								checked={ ! cache_mod_rewrite }
 								disabled={ isRequesting || isSaving }
-								name="super_cache_enabled"
+								name="is_super_cache_enabled"
 								onChange={ handleRadio }
 								value="2" />
 							<span>
@@ -88,9 +89,9 @@ const Caching = ( {
 
 						<FormLabel>
 							<FormRadio
-								checked={ '0' === super_cache_enabled }
+								checked={ ! is_super_cache_enabled }
 								disabled={ isRequesting || isSaving }
-								name="super_cache_enabled"
+								name="is_super_cache_enabled"
 								onChange={ handleRadio }
 								value="0" />
 							<span>
@@ -115,8 +116,9 @@ const Caching = ( {
 
 const getFormSettings = settings => {
 	return pick( settings, [
-		'super_cache_enabled',
-		'wp_cache_enabled',
+		'cache_mod_rewrite',
+		'is_cache_enabled',
+		'is_super_cache_enabled',
 	] );
 };
 

--- a/client/extensions/wp-super-cache/contents-tab.js
+++ b/client/extensions/wp-super-cache/contents-tab.js
@@ -19,26 +19,14 @@ const ContentsTab = ( {
 		generated,
 		supercache,
 		wpcache,
-		wp_cache_object_cache,
 	},
 	isMultisite,
 	translate,
 } ) => {
-	const wpCacheCachedCount = wpcache && wpcache.cached_list ? wpcache.cached_list.length : 0;
-	const wpCacheExpiredCount = wpcache && wpcache.expired_list ? wpcache.expired_list.length : 0;
-	const supercacheCachedCount = supercache && supercache.cached_list ? supercache.cached_list.length : 0;
-	const supercacheExpiredCount = supercache && supercache.expired_list ? supercache.expired_list.length : 0;
-
 	return (
 		<div>
 			<SectionHeader label={ translate( 'Cache Contents' ) } />
 			<Card compact>
-			{ wp_cache_object_cache &&
-				<p>
-					{ translate( 'Object cache in use. No cache listing available.' ) }
-				</p>
-			}
-			{ ! wp_cache_object_cache &&
 				<div>
 				{ wpcache &&
 					<div className="wp-super-cache__cache-stat">
@@ -51,10 +39,10 @@ const ContentsTab = ( {
 							) }
 						</span>
 						<span className="wp-super-cache__cache-stat-item">
-							{ `${ wpCacheCachedCount } Cached Pages` }
+							{ `${ wpcache && wpcache.cached || 0 } Cached Pages` }
 						</span>
 						<span className="wp-super-cache__cache-stat-item">
-							{ `${ wpCacheExpiredCount } Expired Pages` }
+							{ `${ wpcache && wpcache.expired || 0 } Expired Pages` }
 						</span>
 					</div>
 				}
@@ -70,10 +58,10 @@ const ContentsTab = ( {
 							) }
 						</span>
 						<span className="wp-super-cache__cache-stat-item">
-							{ `${ supercacheCachedCount } Cached Pages` }
+							{ `${ supercache && supercache.cached || 0 } Cached Pages` }
 						</span>
 						<span className="wp-super-cache__cache-stat-item">
-							{ `${ supercacheExpiredCount } Expired Pages` }
+							{ `${ supercache && supercache.expired || 0 } Expired Pages` }
 						</span>
 					</div>
 				}
@@ -92,10 +80,8 @@ const ContentsTab = ( {
 						{ translate( 'Regenerate Cache Stats' ) }
 					</Button>
 				</div>
-			}
 			</Card>
 
-		{ ! wp_cache_object_cache &&
 			<div>
 			{ wpcache && wpcache.cached_list &&
 				<CachedFiles header="Fresh WP-Cached Files" files={ wpcache.cached_list } />
@@ -113,10 +99,9 @@ const ContentsTab = ( {
 				<CachedFiles header="Stale Super Cached Files" files={ supercache.expired_list } />
 			}
 			</div>
-		}
 
 			<Card>
-				{ !! cache_max_time &&
+				{ cache_max_time &&
 					<p>
 						{ translate(
 							'Expired files are files older than %(cache_max_time)d seconds. They are still used by ' +
@@ -152,10 +137,9 @@ const getFormSettings = settings => {
 	] );
 	const otherSettings = pick( settings, [
 		'cache_max_time',
-		'wp_cache_object_cache',
 	] );
 
-	return Object.assign( {}, cacheStats, otherSettings );
+	return { ...cacheStats, ...otherSettings };
 };
 
 export default WrapSettingsForm( getFormSettings )( ContentsTab );

--- a/client/extensions/wp-super-cache/directly-cached-files.jsx
+++ b/client/extensions/wp-super-cache/directly-cached-files.jsx
@@ -44,10 +44,10 @@ class DirectlyCachedFiles extends Component {
 			translate
 		} = this.props;
 		const {
-			wp_cache_direct_pages = [],
-			wp_cache_path,
-			wp_cache_readonly,
-			wp_cache_writable,
+			cache_direct_pages = [],
+			cache_path,
+			cache_readonly,
+			cache_writable,
 		} = fields;
 
 		return (
@@ -65,25 +65,25 @@ class DirectlyCachedFiles extends Component {
 					</Button>
 				</SectionHeader>
 				<Card className="wp-super-cache__directly-cached-files">
-					{ !! wp_cache_readonly &&
+					{ cache_readonly &&
 					<p>
 					{ translate(
-						'{{strong}}Warning!{{/strong}} You must make %(wp_cache_path)s wp_cache_writable to enable this feature. ' +
+						'{{strong}}Warning!{{/strong}} You must make %(cache_path)s writable to enable this feature. ' +
 						'As this is a security risk, please make it read-only after your page is generated.',
 						{
-							args: { wp_cache_path: wp_cache_path },
+							args: { cache_path: cache_path },
 							components: { strong: <strong /> },
 						}
 					) }
 					</p>
 					}
-					{ !! wp_cache_writable &&
+					{ cache_writable &&
 					<p>
 					{ translate(
-						'{{strong}}Warning!{{/strong}} %(wp_cache_path)s is wp_cache_writable. Please make it wp_cache_readonly ' +
+						'{{strong}}Warning!{{/strong}} %(cache_path)s is writable. Please make it readonly ' +
 						'after your page is generated as this is a security risk.',
 						{
-							args: { wp_cache_path: wp_cache_path },
+							args: { cache_path: cache_path },
 							components: { strong: <strong /> },
 						}
 					) }
@@ -91,14 +91,14 @@ class DirectlyCachedFiles extends Component {
 					}
 					<p>
 						{ translate(
-							'Directly cached files are files created directly off %(wp_cache_path)s where your blog lives. This ' +
+							'Directly cached files are files created directly off %(cache_path)s where your blog lives. This ' +
 							'feature is only useful if you are expecting a major Digg or Slashdot level of traffic to one post or page.',
 							{
-								args: { wp_cache_path: wp_cache_path },
+								args: { cache_path: cache_path },
 							}
 						) }
 					</p>
-						{ ! wp_cache_readonly &&
+						{ ! cache_readonly &&
 						<div>
 							<p>
 								{ translate(
@@ -119,27 +119,27 @@ class DirectlyCachedFiles extends Component {
 										ref="newDirectPage" />
 								</FormFieldset>
 
-								{ wp_cache_direct_pages.length > 0 &&
+								{ cache_direct_pages.length > 0 &&
 								<FormLabel>
 									{ translate(
 										'Existing Direct Page',
 										'Existing Direct Pages',
-										{ count: wp_cache_direct_pages.length }
+										{ count: cache_direct_pages.length }
 									) }
 								</FormLabel>
 								}
 
-								{ wp_cache_direct_pages.map( ( page, index ) => (
+								{ cache_direct_pages.map( ( page, index ) => (
 									<FormFieldset key={ index }>
 										<FormTextInput
 											disabled={ isRequesting || isSaving }
 											key={ index }
-											onChange={ setFieldArrayValue( 'wp_cache_direct_pages', index ) }
+											onChange={ setFieldArrayValue( 'cache_direct_pages', index ) }
 											value={ page || '' } />
 									</FormFieldset>
 								) ) }
 
-								{ wp_cache_direct_pages.length > 0 &&
+								{ cache_direct_pages.length > 0 &&
 								<FormSettingExplanation>
 									{ translate(
 										'Make the textbox blank to remove it from the list of direct pages and delete the cached file.'
@@ -157,10 +157,10 @@ class DirectlyCachedFiles extends Component {
 
 const getFormSettings = settings => {
 	return pick( settings, [
-		'wp_cache_direct_pages',
-		'wp_cache_path',
-		'wp_cache_readonly',
-		'wp_cache_writable',
+		'cache_direct_pages',
+		'cache_path',
+		'cache_readonly',
+		'cache_writable',
 	] );
 };
 

--- a/client/extensions/wp-super-cache/easy-tab.jsx
+++ b/client/extensions/wp-super-cache/easy-tab.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { get, pick } from 'lodash';
 
 /**
@@ -16,104 +16,114 @@ import FormToggle from 'components/forms/form-toggle/compact';
 import SectionHeader from 'components/section-header';
 import WrapSettingsForm from './wrap-settings-form';
 
-const EasyTab = ( {
-	fields: {
-		cache_mod_rewrite,
-		http_only,
-		is_cache_enabled,
-	},
-	handleAutosavingToggle,
-	handleToggle,
-	isRequesting,
-	isSaving,
-	site,
-	translate,
-} ) => {
-	const enableCacheNotice = translate(
-		'PHP caching is enabled but Supercache mod_rewrite rules were ' +
-		'detected. Cached files will be served using those rules. If your site is working ok, ' +
-		'please ignore this message. Otherwise, you can edit the .htaccess file in the root of your ' +
-		'install and remove the SuperCache rules.'
-	);
+class EasyTab extends Component {
+	state = {
+		httpOnly: true,
+	}
 
-	return (
-		<div>
-			<SectionHeader
-				label={ translate( 'Caching' ) }>
-			</SectionHeader>
-			<Card>
-				<form>
-					<FormToggle
-						checked={ is_cache_enabled }
-						disabled={ isRequesting || isSaving }
-						onChange={ handleAutosavingToggle( 'is_cache_enabled' ) }>
-						<span>
-							{ translate( 'Enable Page Caching' ) }
-						</span>
-					</FormToggle>
-				</form>
-			</Card>
+	handleHttpOnlyChange = () => {
+		this.setState( { httpOnly: ! this.state.httpOnly } );
+	}
 
-			{ is_cache_enabled && ! cache_mod_rewrite &&
-				<Notice text={ enableCacheNotice } showDismiss={ false } className="wp-super-cache__notice-hug-card" />
-			}
+	render() {
+		const {
+			fields,
+			handleAutosavingToggle,
+			isRequesting,
+			isSaving,
+			site,
+			translate,
+		} = this.props;
+		const {
+			cache_mod_rewrite,
+			is_cache_enabled,
+		} = fields;
 
-			{ is_cache_enabled &&
-				<div>
-					<SectionHeader label={ translate( 'Cache Tester' ) } />
-					<Card>
-						<p>
-							{ translate( 'Test your cached website by clicking the test button below.' ) }
-						</p>
+		const enableCacheNotice = translate(
+			'PHP caching is enabled but Supercache mod_rewrite rules were ' +
+			'detected. Cached files will be served using those rules. If your site is working ok, ' +
+			'please ignore this message. Otherwise, you can edit the .htaccess file in the root of your ' +
+			'install and remove the SuperCache rules.'
+		);
 
-						{ isHttps( get( site, 'options.admin_url', '' ) ) &&
-							<form>
-								<FormFieldset>
-									<FormToggle
-										checked={ http_only }
-										onChange={ handleToggle( 'http_only' ) }>
-										<span>
-											{ translate( 'Send non-secure (non https) request for homepage' ) }
-										</span>
-									</FormToggle>
-								</FormFieldset>
-							</form>
+		return (
+			<div>
+				<SectionHeader
+					label={ translate( 'Caching' ) }>
+				</SectionHeader>
+				<Card>
+					<form>
+						<FormToggle
+							checked={ is_cache_enabled }
+							disabled={ isRequesting || isSaving }
+							onChange={ handleAutosavingToggle( 'is_cache_enabled' ) }>
+							<span>
+								{ translate( 'Enable Page Caching' ) }
+							</span>
+						</FormToggle>
+					</form>
+				</Card>
+
+				{ is_cache_enabled && ! cache_mod_rewrite &&
+					<Notice text={ enableCacheNotice } showDismiss={ false } className="wp-super-cache__notice-hug-card" />
+				}
+
+				{ is_cache_enabled &&
+					<div>
+						<SectionHeader label={ translate( 'Cache Tester' ) } />
+						<Card>
+							<p>
+								{ translate( 'Test your cached website by clicking the test button below.' ) }
+							</p>
+
+							{ isHttps( get( site, 'options.admin_url', '' ) ) &&
+								<form>
+									<FormFieldset>
+										<FormToggle
+											checked={ this.state.httpOnly }
+											onChange={ this.handleHttpOnlyChange }>
+											<span>
+												{ translate( 'Send non-secure (non https) request for homepage' ) }
+											</span>
+										</FormToggle>
+									</FormFieldset>
+								</form>
+							}
+
+							<Button compact>
+								{ translate( 'Test Cache' ) }
+							</Button>
+						</Card>
+					</div>
+				}
+
+				<SectionHeader label={ translate( 'Delete Cached Pages' ) } />
+				<Card>
+					<p>
+						{ translate(
+						'Cached pages are stored on your server as HTML and PHP files. ' +
+						'If you need to delete them, use the buttons below.'
+						) }
+					</p>
+					<div>
+						<Button compact>
+							{ translate( 'Delete Cache' ) }
+						</Button>
+						{ site.jetpack && site.is_multisite &&
+							<Button compact>
+								{ translate( 'Delete Cache On All Blogs' ) }
+							</Button>
 						}
-
-						<Button compact>
-							{ translate( 'Test Cache' ) }
-						</Button>
-					</Card>
-				</div>
-			}
-
-			<SectionHeader label={ translate( 'Delete Cached Pages' ) } />
-			<Card>
-				<p>
-					{ translate(
-					'Cached pages are stored on your server as HTML and PHP files. ' +
-					'If you need to delete them, use the buttons below.'
-					) }
-				</p>
-				<div>
-					<Button compact>
-						{ translate( 'Delete Cache' ) }
-					</Button>
-					{ site.jetpack && site.is_multisite &&
-						<Button compact>
-							{ translate( 'Delete Cache On All Blogs' ) }
-						</Button>
-					}
-				</div>
-			</Card>
-		</div>
-	);
-};
+					</div>
+				</Card>
+			</div>
+		);
+	}
+}
 
 const getFormSettings = settings => {
 	return pick( settings, [
 		'cache_mod_rewrite',
-		'http_only',
 		'is_cache_enabled',
 	] );
 };

--- a/client/extensions/wp-super-cache/expiry-time.jsx
+++ b/client/extensions/wp-super-cache/expiry-time.jsx
@@ -24,12 +24,12 @@ const ExpiryTime = ( {
 	fields: {
 		cache_gc_email_me,
 		cache_max_time,
+		cache_next_gc,
 		cache_schedule_interval,
 		cache_schedule_type,
 		cache_scheduled_time,
 		cache_time_interval,
-		wp_cache_next_gc,
-		wp_cache_preload_on,
+		preload_on,
 	},
 	handleAutosavingToggle,
 	handleChange,
@@ -157,6 +157,14 @@ const ExpiryTime = ( {
 		);
 	};
 
+	const formatUnixTimestamp = ( timestamp ) => {
+		if ( ! timestamp ) {
+			return;
+		}
+
+		return moment.unix( timestamp ).utc().format( 'YYYY-MM-DD H:mm:ss' );
+	};
+
 	return (
 		<div>
 			<SectionHeader label={ translate( 'Expiry Time & Garbage Collection' ) }>
@@ -173,16 +181,16 @@ const ExpiryTime = ( {
 			</SectionHeader>
 			<Card>
 				<p>
-					{ translate( 'UTC time is ' ) + moment().utc().format( 'YYYY-MM-DD h:mm:ss' ) }
+					{ translate( 'UTC time is ' ) + moment().utc().format( 'YYYY-MM-DD H:mm:ss' ) }
 					<br />
-					{ translate( 'Local time is ' ) + moment().format( 'YYYY-MM-DD h:mm:ss' ) }
+					{ translate( 'Local time is ' ) + moment().format( 'YYYY-MM-DD H:mm:ss' ) }
 				</p>
-				{ wp_cache_next_gc &&
+				{ cache_next_gc &&
 					<p>
-						{ translate( 'Next scheduled garbage collection will be at ' ) + wp_cache_next_gc }
+						{ translate( 'Next scheduled garbage collection will be at ' ) + `${ formatUnixTimestamp( cache_next_gc ) } UTC` }
 					</p>
 				}
-				{ wp_cache_preload_on &&
+				{ preload_on &&
 					<p>
 						{ translate(
 							'Warning! {{strong}}PRELOAD MODE{{/strong}} activated. Supercache files will not be ' +
@@ -207,12 +215,12 @@ const getFormSettings = settings => {
 	return pick( settings, [
 		'cache_gc_email_me',
 		'cache_max_time',
+		'cache_next_gc',
 		'cache_schedule_interval',
 		'cache_schedule_type',
 		'cache_scheduled_time',
 		'cache_time_interval',
-		'wp_cache_next_gc',
-		'wp_cache_preload_on',
+		'preload_on',
 	] );
 };
 

--- a/client/extensions/wp-super-cache/lock-down.jsx
+++ b/client/extensions/wp-super-cache/lock-down.jsx
@@ -19,9 +19,11 @@ import Notice from 'components/notice';
 
 const LockDown = ( {
 	fields: {
-		wp_lock_down,
+		lock_down,
 	},
-	handleToggle,
+	handleAutosavingToggle,
+	isRequesting,
+	isSaving,
 	translate,
 } ) => {
 	const lockdownCodeSnippet = translate(
@@ -36,9 +38,9 @@ const LockDown = ( {
 				<form>
 					<FormFieldset>
 						<FormToggle
-							checked={ !! wp_lock_down }
-							disabled={ '1' === wp_lock_down }
-							onChange={ handleToggle( 'wp_lock_down' ) }>
+							checked={ !! lock_down }
+							disabled={ isRequesting || isSaving }
+							onChange={ handleAutosavingToggle( 'lock_down' ) }>
 							<span>
 								{ translate( 'Enable lock down to prepare your server for an expected spike in traffic.' ) }
 							</span>
@@ -51,6 +53,7 @@ const LockDown = ( {
 									'When this is enabled, new comments on a post will not refresh the cached static files.'
 								) }
 						</FormSettingExplanation>
+
 						<FormSettingExplanation className="wp-super-cache__lock-down-explanation">
 							{ translate(
 								'Developers: Make your plugin lock down compatible by checking the "WPLOCKDOWN" ' +
@@ -70,12 +73,12 @@ const LockDown = ( {
 						<Notice
 							isCompact={ true }
 							className="wp-super-cache__lock-down-notice"
-							status={ wp_lock_down ? 'is-warning' : 'is-info' }
-							text={ !! wp_lock_down
-							? translate( 'WordPress is locked down. Super Cache static files will not be deleted ' +
-								'when new comments are made.' )
-							: translate( 'WordPress is not locked down. New comments will refresh Super Cache ' +
-								'static files as normal.' )
+							status={ lock_down ? 'is-warning' : 'is-info' }
+							text={ lock_down
+								? translate( 'WordPress is locked down. Super Cache static files will not be deleted ' +
+									'when new comments are made.' )
+								: translate( 'WordPress is not locked down. New comments will refresh Super Cache ' +
+									'static files as normal.' )
 						}
 						/>
 					</div>
@@ -87,7 +90,7 @@ const LockDown = ( {
 
 const getFormSettings = settings => {
 	return pick( settings, [
-		'wp_lock_down',
+		'lock_down',
 	] );
 };
 

--- a/client/extensions/wp-super-cache/miscellaneous.jsx
+++ b/client/extensions/wp-super-cache/miscellaneous.jsx
@@ -18,14 +18,14 @@ import WrapSettingsForm from './wrap-settings-form';
 const Miscellaneous = ( {
 	fields: {
 		cache_compression,
-		cache_rebuild_files,
-		super_cache_enabled,
-		wp_cache_compression_disabled,
-		wp_cache_hello_world,
-		wp_cache_make_known_anon,
-		wp_cache_no_cache_for_get,
-		wp_cache_not_logged_in,
-		wp_supercache_304,
+		cache_compression_disabled,
+		cache_hello_world,
+		cache_mod_rewrite,
+		cache_rebuild,
+		dont_cache_logged_in,
+		make_known_anon,
+		no_cache_for_get,
+		use_304_headers,
 	},
 	handleAutosavingToggle,
 	isRequesting,
@@ -39,7 +39,7 @@ const Miscellaneous = ( {
 			</SectionHeader>
 			<Card>
 				<form>
-					{ !! wp_cache_compression_disabled &&
+					{ cache_compression_disabled &&
 					<p>
 						{ translate(
 							' {{em}}Warning! Compression is disabled as gzencode() function was not found.{{/em}}',
@@ -50,7 +50,7 @@ const Miscellaneous = ( {
 					</p>
 					}
 					<FormFieldset>
-						{ ! wp_cache_compression_disabled &&
+						{ ! cache_compression_disabled &&
 						<FormToggle
 							checked={ !! cache_compression }
 							disabled={ isRequesting || isSaving }
@@ -67,9 +67,9 @@ const Miscellaneous = ( {
 						}
 
 						<FormToggle
-							checked={ !! wp_cache_not_logged_in }
+							checked={ !! dont_cache_logged_in }
 							disabled={ isRequesting || isSaving }
-							onChange={ handleAutosavingToggle( 'wp_cache_not_logged_in' ) }>
+							onChange={ handleAutosavingToggle( 'dont_cache_logged_in' ) }>
 							<span>
 								{ translate(
 									'Don’t cache pages for known users. {{em}}(Recommended){{/em}}',
@@ -81,9 +81,9 @@ const Miscellaneous = ( {
 						</FormToggle>
 
 						<FormToggle
-							checked={ !! cache_rebuild_files }
+							checked={ !! cache_rebuild }
 							disabled={ isRequesting || isSaving }
-							onChange={ handleAutosavingToggle( 'cache_rebuild_files' ) }>
+							onChange={ handleAutosavingToggle( 'cache_rebuild' ) }>
 							<span>
 								{ translate(
 									'Cache rebuild. Serve a supercache file to anonymous users while a new ' +
@@ -96,9 +96,9 @@ const Miscellaneous = ( {
 						</FormToggle>
 
 						<FormToggle
-							checked={ !! wp_supercache_304 }
-							disabled={ isRequesting || isSaving || ( '1' === super_cache_enabled ) }
-							onChange={ handleAutosavingToggle( 'wp_supercache_304' ) }>
+							checked={ !! use_304_headers }
+							disabled={ isRequesting || isSaving || !! cache_mod_rewrite }
+							onChange={ handleAutosavingToggle( 'use_304_headers' ) }>
 							<span>
 								{ translate(
 									'304 Not Modified browser caching. Indicate when a page has not been ' +
@@ -108,47 +108,49 @@ const Miscellaneous = ( {
 									}
 								) }
 							</span>
-							{ '1' === super_cache_enabled &&
-								<Notice className="wp-super-cache__miscellaneous-304-notice"
-										isCompact={ true }
-										status="is-error"
-										text={ translate(
-									'304 browser caching is only supported when mod_rewrite caching ' +
-									'is not used.' ) }
-								/>
-							}
-							{ '1' !== super_cache_enabled &&
-								<Notice className="wp-super-cache__miscellaneous-304-notice"
-										isCompact={ true }
-										text={ translate(
-									'304 support is disabled by default because some hosts have had problems with the ' +
-									'headers used in the past.' ) }
-								/>
-							}
 						</FormToggle>
 
+						{ cache_mod_rewrite &&
+							<Notice
+								isCompact
+								className="wp-super-cache__miscellaneous-304-notice"
+								status="is-error"
+								text={ translate( '304 browser caching is only supported when mod_rewrite caching ' +
+									'is not used.' ) }
+							/>
+						}
+
+						{ ! cache_mod_rewrite &&
+							<Notice
+								isCompact
+								className="wp-super-cache__miscellaneous-304-notice"
+								text={ translate( '304 support is disabled by default because some hosts have had problems with the ' +
+									'headers used in the past.' ) }
+							/>
+						}
+
 						<FormToggle
-							checked={ !! wp_cache_no_cache_for_get }
+							checked={ !! no_cache_for_get }
 							disabled={ isRequesting || isSaving }
-							onChange={ handleAutosavingToggle( 'wp_cache_no_cache_for_get' ) }>
+							onChange={ handleAutosavingToggle( 'no_cache_for_get' ) }>
 							<span>
 								{ translate( 'Don’t cache pages with GET parameters. (?x=y at the end of a url)' ) }
 							</span>
 						</FormToggle>
 
 						<FormToggle
-							checked={ !! wp_cache_make_known_anon }
+							checked={ !! make_known_anon }
 							disabled={ isRequesting || isSaving }
-							onChange={ handleAutosavingToggle( 'wp_cache_make_known_anon' ) }>
+							onChange={ handleAutosavingToggle( 'make_known_anon' ) }>
 							<span>
 								{ translate( 'Make known users anonymous so they’re served supercached static files.' ) }
 							</span>
 						</FormToggle>
 
 						<FormToggle
-							checked={ !! wp_cache_hello_world }
+							checked={ !! cache_hello_world }
 							disabled={ isRequesting || isSaving }
-							onChange={ handleAutosavingToggle( 'wp_cache_hello_world' ) }>
+							onChange={ handleAutosavingToggle( 'cache_hello_world' ) }>
 							<span>
 								{ translate( 'Proudly tell the world your server is {{fry}}Stephen Fry proof{{/fry}}! ' +
 									'(places a message in your blog’s footer)',
@@ -176,14 +178,14 @@ const Miscellaneous = ( {
 const getFormSettings = settings => {
 	return pick( settings, [
 		'cache_compression',
-		'cache_rebuild_files',
-		'super_cache_enabled',
-		'wp_cache_compression_disabled',
-		'wp_cache_hello_world',
-		'wp_cache_make_known_anon',
-		'wp_cache_no_cache_for_get',
-		'wp_cache_not_logged_in',
-		'wp_supercache_304',
+		'cache_compression_disabled',
+		'cache_hello_world',
+		'cache_mod_rewrite',
+		'cache_rebuild',
+		'dont_cache_logged_in',
+		'make_known_anon',
+		'no_cache_for_get',
+		'use_304_headers',
 	] );
 };
 

--- a/client/extensions/wp-super-cache/rejected-user-agents.jsx
+++ b/client/extensions/wp-super-cache/rejected-user-agents.jsx
@@ -17,7 +17,7 @@ import WrapSettingsForm from './wrap-settings-form';
 
 const RejectedUserAgents = ( {
 	fields: {
-		wp_rejected_user_agent,
+		rejected_user_agent,
 	},
 	handleChange,
 	handleSubmitForm,
@@ -44,8 +44,8 @@ const RejectedUserAgents = ( {
 					<FormFieldset>
 						<FormTextarea
 							disabled={ isRequesting || isSaving }
-							onChange={ handleChange( 'wp_rejected_user_agent' ) }
-							value={ wp_rejected_user_agent || '' } />
+							onChange={ handleChange( 'rejected_user_agent' ) }
+							value={ rejected_user_agent || '' } />
 						<FormSettingExplanation>
 							{ translate(
 								'Strings in the HTTP ’User Agent’ header that prevent WP-Cache from caching bot, ' +
@@ -62,7 +62,7 @@ const RejectedUserAgents = ( {
 
 const getFormSettings = settings => {
 	return pick( settings, [
-		'wp_rejected_user_agent',
+		'rejected_user_agent',
 	] );
 };
 

--- a/client/extensions/wp-super-cache/style.scss
+++ b/client/extensions/wp-super-cache/style.scss
@@ -136,7 +136,8 @@
 	margin-top: -10px;
 }
 
-.wp-super-cache__miscellaneous-304-notice {
+.wp-super-cache__miscellaneous-304-notice.is-compact {
+	margin-left: 36px;
 	margin-bottom: 5px;
 }
 

--- a/client/extensions/wp-super-cache/wrap-settings-form.jsx
+++ b/client/extensions/wp-super-cache/wrap-settings-form.jsx
@@ -179,162 +179,26 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			const isSaving = isSavingSettings( state, siteId );
 			const isSaveSuccessful = isSettingsSaveSuccessful( state, siteId );
 			const settings = Object.assign( {}, getSettings( state, siteId ), {
-				// Caching
-				wp_cache_enabled: true,
-
 				// Miscellaneous
-				cache_compression: false,
-				cache_rebuild_files: true,
-				wp_cache_compression_disabled: false,
-				wp_cache_hello_world: false,
-				wp_cache_make_known_anon: false,
-				wp_cache_no_cache_for_get: false,
-				wp_cache_not_logged_in: false,
-				wp_supercache_304: false,
-
-				// Advanced
-				_wp_using_ext_object_cache: true,
-				cache_page_secret: 'af1a001901367ede34cb22ffadb9a565',
-				super_cache_enabled: '1',	// Also used by Caching & Miscellaneous
-				wp_cache_clear_on_post_edit: false,
-				wp_cache_disable_locking: false,
-				wp_cache_disable_utf8: false,
-				wp_cache_front_page_checks: true,
-				wp_cache_mfunc_enabled: false,
-				wp_cache_mobile_browsers: 'w3c , w3c-, acs-, alav, alca, amoi, audi, avan, benq, bird, blac, ' +
-					'blaz, brew, cell, cldc, cmd-, dang, doco, eric, hipt, htc_, inno, ipaq, ipod, jigs, kddi, ' +
-					'keji, leno, lg-c, lg-d, lg-g, lge-, lg/u, maui, maxo, midp, mits, mmef, mobi, mot-, moto, ' +
-					'mwbp, nec-, newt, noki, palm, pana, pant, phil, play, port, prox, qwap, sage, sams, sany, ' +
-					'sch-, sec-, send, seri, sgh-, shar, sie-, siem, smal, smar, sony, sph-, symb, t-mo, teli, ' +
-					'tim-, tosh, tsm-, upg1, upsi, vk-v, voda, wap-, wapa, wapi, wapp, wapr, webc, winw, winw, xda , xda-',
-				wp_cache_mobile_enabled: true,
-				wp_cache_mobile_prefixes: 'w3c , w3c-, acs-, alav, alca, amoi, audi, avan, benq, bird, blac, ' +
-					'blaz, brew, cell, cldc, cmd-, dang, doco, eric, hipt, htc_, inno, ipaq, ipod, jigs, kddi, ' +
-					'keji, leno, lg-c, lg-d, lg-g, lge-, lg/u, maui, maxo, midp, mits, mmef, mobi, mot-, moto, ' +
-					'mwbp, nec-, newt, noki, palm, pana, pant, phil, play, port, prox, qwap, sage, sams, sany, ' +
-					'sch-, sec-, send, seri, sgh-, shar, sie-, siem, smal, smar, sony, sph-, symb, t-mo, teli, ' +
-					'tim-, tosh, tsm-, upg1, upsi, vk-v, voda, wap-, wapa, wapi, wapp, wapr, webc, winw, winw, xda , xda-',
-				wp_cache_mod_rewrite: false,
-				wp_cache_mutex_disabled: false,
-				wp_cache_object_cache: false,
-				wp_cache_refresh_single_only: false,
-				wp_super_cache_late_init: false,
-				wp_supercache_cache_list: false,
-
-				// Cache Location
-				wp_cache_location: '/wordpress/wp-content/cache/',
-
-				// Expiry Time & Garbage Collection
-				cache_gc_email_me: false,
-				cache_max_time: 3600,
-				cache_schedule_interval: 'five_minutes_interval',
-				cache_schedule_type: 'interval',
-				cache_scheduled_time: '00:00',
-				cache_time_interval: '60',
-				wp_cache_next_gc: '2017-03-23 17:45:16 UTC',
-				wp_cache_preload_on: true,
+				cache_compression_disabled: false,
 
 				// Accepted Filenames & Rejected URIs
-				wp_accepted_files: 'wp-comments-popup.php',
-				wp_cache_pages: {
-					search: false,
-					feed: false,
-					category: false,
-					home: false,
-					frontpage: false,
-					tag: false,
-					archives: false,
-					pages: false,
-					single: false,
-					author: false,
-				},
-				wp_rejected_uri: 'wp-.*\.php',
+				accepted_files: 'wp-comments-popup.php',
+				rejected_uri: 'wp-.*\.php',
 
 				// Rejected User Agents
-				wp_rejected_user_agent: 'bot\nia_archive\nslurp\ncrawl\nspider\nYandex',
+				rejected_user_agent: 'bot\nia_archive\nslurp\ncrawl\nspider\nYandex',
 
 				// Lock Down
-				wp_lock_down: false,
+				lock_down: false,
 
 				// Directly Cached Files
-				wp_cache_direct_pages: [
+				cache_direct_pages: [
 					'/about/',
 					'/home/',
 				],
-				wp_cache_path: '/wordpress/',
-				wp_cache_readonly: false,
-				wp_cache_writable: false,
-
-				// CDN
-				ossdl_cname: '',
-				ossdl_https: false,
-				ossdl_off_cdn_url: 'http://donnapep.wpsandbox.me',
-				ossdl_off_exclude: '.php',
-				ossdl_off_include_dirs: 'wp-content,wp-includes',
-				ossdlcdn: false,
-
-				// Contents
-				cache_stats: {
-					generated: 60,
-					supercache: {
-						cached_list: [
-							{
-								age: 3029,
-								uri: 'localhost/blogs/',
-							},
-							{
-								age: 3031,
-								uri: 'localhost/professionals/',
-							},
-							{
-								age: 3322,
-								uri: 'localhost/',
-							},
-						],
-						expired_list: [
-							{
-								age: 4975,
-								uri: 'localhost/support/',
-							},
-							{
-								age: 4973,
-								uri: 'localhost/get-involved/',
-							},
-						],
-						fsize: '69.78KB',
-					},
-					wpcache: {
-						cached_list: [
-							{
-								age: 95,
-								uri: 'localhost/support-info/',
-							},
-							{
-								age: 3031,
-								uri: 'localhost/about/',
-							},
-						],
-						expired_list: [
-							{
-								age: 81,
-								uri: 'localhost/blogs/',
-							},
-						],
-						fsize: '32.18KB',
-					},
-				},
-
-				// Preload
-				is_preload_enabled: true,
-				is_preloading: false,
-				minimum_preload_interval: 30,
-				preload_email_volume: 'none',
-				preload_interval: 30,
-				preload_on: false,
-				preload_posts: 'all',
-				preload_posts_options: [ 'all', '161', '322' ],
-				preload_refresh: true,
-				preload_taxonomies: false,
+				cache_readonly: false,
+				cache_writable: false,
 			} );
 			const isRequesting = isRequestingSettings( state, siteId ) && ! settings;
 			// Don't include read-only fields when saving.
@@ -351,7 +215,6 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				'generated',
 				'is_preload_enabled',
 				'is_preloading',
-				'lock_down',
 				'minimum_preload_interval',
 				'post_count',
 				'preload_refresh',


### PR DESCRIPTION
This PR eliminates some of the hard-coded data and instead fetches real data from the REST API. Field names were updated to match those returned by the API.

There are still some fields that are not being returned, so these will need to be removed in a future PR as the API changes.