### PR TITLE
My Sites: Reduxify and ES6ify SiteIndicator

### DIFF
--- a/client/my-sites/site-indicator/site-indicator.jsx
+++ b/client/my-sites/site-indicator/site-indicator.jsx
@@ -215,12 +215,21 @@ class SiteIndicator extends Component {
 		const { translate } = this.props;
 		return (
 			<span>
-				{ translate( 'Jetpack %(version)s is required', { args: { version: config( 'jetpack_min_version' ) } } ) }.
-				<a
-					onClick={ this.makeAnalyticsRecordEventHandler( 'Clicked Update Jetpack Now Link' ) }
-					href={ this.props.site.options.admin_url + 'plugins.php?plugin_status=upgrade' }
-					>{ translate( 'Update now' ) }
-				</a>.
+				{
+					translate( 'Jetpack %(version)s is required. {{link}}Update now{{/link}}', {
+						args: {
+							version: config( 'jetpack_min_version' )
+						},
+						components: {
+							link: (
+								<a
+									onClick={ this.makeAnalyticsRecordEventHandler( 'Clicked Update Jetpack Now Link' ) }
+									href={ this.props.site.options.admin_url + 'plugins.php?plugin_status=upgrade' }
+								/>
+							)
+						}
+					} )
+				}
 			</span> );
 	}
 

--- a/client/my-sites/site-indicator/site-indicator.jsx
+++ b/client/my-sites/site-indicator/site-indicator.jsx
@@ -18,7 +18,7 @@ import DisconnectJetpackButton from 'my-sites/plugins/disconnect-jetpack/disconn
 import analytics from 'lib/analytics';
 import QuerySiteConnectionStatus from 'components/data/query-site-connection-status';
 import QuerySiteUpdates from 'components/data/query-site-updates';
-import { userCan } from 'lib/site/utils';
+import { canCurrentUser } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getUpdatesBySiteId } from 'state/sites/updates/selectors';
 import { updateWordPress } from 'state/sites/updates/actions';
@@ -70,11 +70,11 @@ class SiteIndicator extends Component {
 	}
 
 	showIndicator() {
-		const { site, siteIsJetpack } = this.props;
+		const { siteIsJetpack, userCanManage } = this.props;
 
 		// Until WP.com sites have indicators (upgrades expiring, etc) we only show them for Jetpack sites
 		return (
-			userCan( 'manage_options', site ) &&
+			userCanManage &&
 			siteIsJetpack &&
 			! get( site, 'options.is_automated_transfer' ) &&
 			( this.hasUpdate() || this.hasError() || this.hasWarning() || this.state.updateError )
@@ -382,6 +382,7 @@ export default connect(
 			siteIsConnected: site && getSiteConnectionStatus( state, site.ID ),
 			siteIsJetpack: site && isJetpackSite( state, site.ID ),
 			siteUpdates: site && getUpdatesBySiteId( state, site.ID ),
+			userCanManage: site && canCurrentUser( state, site.ID, 'manage_options' ),
 		};
 	},
 	{

--- a/client/my-sites/site-indicator/site-indicator.jsx
+++ b/client/my-sites/site-indicator/site-indicator.jsx
@@ -16,7 +16,6 @@ import ProgressIndicator from 'components/progress-indicator';
 import DisconnectJetpackButton from 'my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button';
 import analytics from 'lib/analytics';
 import QuerySiteConnectionStatus from 'components/data/query-site-connection-status';
-import QuerySiteUpdates from 'components/data/query-site-updates';
 import { canCurrentUser } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getUpdatesBySiteId } from 'state/sites/updates/selectors';
@@ -375,7 +374,6 @@ class SiteIndicator extends Component {
 		return (
 			<div className="site-indicator__wrapper">
 				{ siteIsJetpack && <QuerySiteConnectionStatus siteId={ site.ID } /> }
-				{ siteIsJetpack && <QuerySiteUpdates siteId={ site.ID } /> }
 
 				{ this.showIndicator() && this.renderIndicator() }
 			</div>

--- a/client/my-sites/site-indicator/site-indicator.jsx
+++ b/client/my-sites/site-indicator/site-indicator.jsx
@@ -344,8 +344,8 @@ class SiteIndicator extends Component {
 						</button>
 					</Animate>
 				}
-				{ this.state.expand
-					? <div className="site-indicator__message">
+				{ this.state.expand &&
+					<div className="site-indicator__message">
 						<div className={ textClass }>
 							{ this.getText() }
 						</div>
@@ -355,7 +355,7 @@ class SiteIndicator extends Component {
 							</Animate>
 						</button>
 					</div>
-					: null }
+				}
 			</div>
 		);
 	}

--- a/client/my-sites/site-indicator/site-indicator.jsx
+++ b/client/my-sites/site-indicator/site-indicator.jsx
@@ -62,7 +62,7 @@ class SiteIndicator extends Component {
 				return false;
 			}
 
-			return siteIsConnected === false;
+			return siteIsConnected;
 		}
 
 		return false;
@@ -275,6 +275,10 @@ class SiteIndicator extends Component {
 			return this.errorUpdating();
 		}
 
+		if ( this.hasWarning() ) {
+			return this.unsupportedJetpackVersion();
+		}
+
 		if ( this.hasUpdate() ) {
 			return this.updatesAvailable();
 		}
@@ -283,20 +287,16 @@ class SiteIndicator extends Component {
 			return this.errorAccessing();
 		}
 
-		if ( this.hasWarning() ) {
-			return this.unsupportedJetpackVersion();
-		}
-
 		return null;
 	}
 
 	getIcon() {
-		if ( this.hasUpdate() ) {
-			return 'sync';
-		}
-
 		if ( this.hasWarning() ) {
 			return 'notice';
+		}
+
+		if ( this.hasUpdate() ) {
+			return 'sync';
 		}
 
 		if ( this.hasError() ) {

--- a/client/my-sites/site-indicator/site-indicator.jsx
+++ b/client/my-sites/site-indicator/site-indicator.jsx
@@ -7,7 +7,6 @@ import { localize } from 'i18n-calypso';
 import config from 'config';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,6 +24,7 @@ import { updateWordPress } from 'state/sites/updates/actions';
 import {
 	getSiteConnectionStatus,
 	isRequestingSiteConnectionStatus,
+	isSiteAutomatedTransfer,
 	isWordpressUpdateSuccessful,
 } from 'state/selectors';
 
@@ -70,13 +70,17 @@ class SiteIndicator extends Component {
 	}
 
 	showIndicator() {
-		const { siteIsJetpack, userCanManage } = this.props;
+		const {
+			siteIsAutomatedTransfer,
+			siteIsJetpack,
+			userCanManage,
+		} = this.props;
 
 		// Until WP.com sites have indicators (upgrades expiring, etc) we only show them for Jetpack sites
 		return (
 			userCanManage &&
 			siteIsJetpack &&
-			! get( site, 'options.is_automated_transfer' ) &&
+			! siteIsAutomatedTransfer &&
 			( this.hasUpdate() || this.hasError() || this.hasWarning() || this.state.updateError )
 		);
 	}
@@ -381,6 +385,7 @@ export default connect(
 			requestingConnectionStatus: site && isRequestingSiteConnectionStatus( state, site.ID ),
 			siteIsConnected: site && getSiteConnectionStatus( state, site.ID ),
 			siteIsJetpack: site && isJetpackSite( state, site.ID ),
+			siteIsAutomatedTransfer: site && isSiteAutomatedTransfer( state, site.ID ),
 			siteUpdates: site && getUpdatesBySiteId( state, site.ID ),
 			userCanManage: site && canCurrentUser( state, site.ID, 'manage_options' ),
 		};

--- a/client/my-sites/site-indicator/site-indicator.jsx
+++ b/client/my-sites/site-indicator/site-indicator.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 import config from 'config';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
@@ -14,78 +16,94 @@ import Animate from 'components/animate';
 import ProgressIndicator from 'components/progress-indicator';
 import DisconnectJetpackButton from 'my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button';
 import analytics from 'lib/analytics';
+import QuerySiteConnectionStatus from 'components/data/query-site-connection-status';
+import QuerySiteUpdates from 'components/data/query-site-updates';
 import { userCan } from 'lib/site/utils';
+import { isJetpackSite } from 'state/sites/selectors';
+import { getUpdatesBySiteId } from 'state/sites/updates/selectors';
+import { updateWordPress } from 'state/sites/updates/actions';
+import {
+	getSiteConnectionStatus,
+	getSiteCoreUpdateStatus,
+	isRequestingSiteConnectionStatus
+} from 'state/selectors';
 
-export default React.createClass( {
-	displayName: 'SiteIndicator',
+class SiteIndicator extends Component {
+	static propTypes = {
+		site: PropTypes.object,
 
-	propTypes: {
-		site: React.PropTypes.object.isRequired
-	},
+		// connected props
+		siteIsJetpack: PropTypes.bool,
+		siteUpdates: PropTypes.object,
+		siteIsConnected: PropTypes.bool,
+		requestingConnectionStatus: PropTypes.bool,
+	}
 
-	getInitialState() {
-		return { expand: false };
-	},
+	state = { expand: false };
 
 	hasUpdate() {
-		return this.props.site.updates && ! this.hasError() && this.props.site.updates.total > 0;
-	},
+		const { siteUpdates } = this.props;
+		return siteUpdates && ! this.hasError() && siteUpdates.total > 0;
+	}
 
 	hasError() {
-		var site = this.props.site;
-		if ( site.unreachable ) {
-			return true;
-		}
-		return false;
-	},
+		return this.props.siteIsConnected === false;
+	}
 
 	hasWarning() {
-		var site = this.props.site;
+		const {
+			requestingConnectionStatus,
+			site,
+			siteIsConnected,
+			siteIsJetpack,
+		} = this.props;
 
-		if ( site.jetpack && ! site.hasMinimumJetpackVersion ) {
-			if ( site.callingHome ) {
-				return false;
-			} else if ( typeof site.unreachable === 'undefined' ) {
-				if ( 'function' === typeof site.callHome ) {
-					site.callHome();
-				}
+		if ( siteIsJetpack && ! site.hasMinimumJetpackVersion ) {
+			if ( requestingConnectionStatus ) {
 				return false;
 			}
-			return true;
+
+			return siteIsConnected === false;
 		}
+
 		return false;
-	},
+	}
 
 	showIndicator() {
-		// Until WP.com and Automated Transfer sites have indicators (upgrades expiring, etc) we only show them for Jetpack sites
-		const { site } = this.props;
-		const isJetpackSite = site.jetpack && ! get( site, 'options.is_automated_transfer' );
-		return userCan( 'manage_options', site ) &&
-			isJetpackSite &&
-			( this.hasUpdate() || this.hasError() || this.hasWarning() || this.state.updateError );
-	},
+		const { site, siteIsJetpack } = this.props;
 
-	toggleExpand() {
+		// Until WP.com sites have indicators (upgrades expiring, etc) we only show them for Jetpack sites
+		return (
+			userCan( 'manage_options', site ) &&
+			siteIsJetpack &&
+			! get( site, 'options.is_automated_transfer' ) &&
+			( this.hasUpdate() || this.hasError() || this.hasWarning() || this.state.updateError )
+		);
+	}
+
+	toggleExpand = () => {
 		this.setState( {
 			updateError: false,
 			updateSucceed: false,
 			expand: ! this.state.expand
 		} );
 
-		analytics.ga.recordEvent( 'Site-Indicator', 'Clicked to ' + ( ! this.state.expand ? 'Expand' : 'Collapse' ) + ' the Site Indicator' );
-	},
+		const action = ! this.state.expand ? 'Expand' : 'Collapse';
+		analytics.ga.recordEvent( 'Site-Indicator', `Clicked to ${ action } the Site Indicator` );
+	}
 
 	updatesAvailable() {
-		if ( config.isEnabled( 'jetpack_core_inline_update' ) && this.props.site.updates.wordpress && this.props.site.updates.wp_update_version ) {
+		const { site, siteUpdates, translate } = this.props;
+		if ( config.isEnabled( 'jetpack_core_inline_update' ) && siteUpdates.wordpress && siteUpdates.wp_update_version ) {
 			return (
 				<span>
 					{
-						this.translate( 'A newer version of WordPress is available. {{link}}Update to %(version)s{{/link}}', {
+						translate( 'A newer version of WordPress is available. {{link}}Update to %(version)s{{/link}}', {
 							components: {
-								link: <button className="button is-link" onClick={ this.handleUpdate } />
+								link: <button className="site-indicator__action-button" onClick={ this.handleUpdate } />
 							},
 							args: {
-								version: this.props.site.updates.wp_update_version
+								version: siteUpdates.wp_update_version
 							}
 						} )
 					}
@@ -93,13 +111,21 @@ export default React.createClass( {
 			);
 		}
 
-		if ( this.props.site.updates.plugins === this.props.site.updates.total && this.props.site.canUpdateFiles ) {
+		if ( siteUpdates.plugins === siteUpdates.total && site.canUpdateFiles ) {
 			return (
 				<span>
 					<a
 						onClick={ this.handlePluginsUpdate }
-						href={ '/plugins/updates/' + this.props.site.slug } >
-						{ this.translate( 'There is a plugin update available.', 'There are plugin updates available.', { count: this.props.site.updates.total } ) }
+						href={ '/plugins/updates/' + site.slug } >
+						{
+							translate(
+								'There is a plugin update available.',
+								'There are plugin updates available.',
+								{
+									count: siteUpdates.total
+								}
+							)
+						}
 					</a>
 				</span>
 			);
@@ -110,97 +136,131 @@ export default React.createClass( {
 				'Site-Indicator',
 				'Clicked updates available link to wp-admin updates',
 				'Total Updates',
-				this.props.site.updates && this.props.site.updates.total
+				siteUpdates && siteUpdates.total
 			);
 
 		return (
 			<span>
 				<a
 					onClick={ recordEvent }
-					href={ this.props.site.options.admin_url + 'update-core.php' } >
-					{ this.translate( 'There is an update available.', 'There are updates available.', { count: this.props.site.updates.total } ) }
+					href={ site.options.admin_url + 'update-core.php' } >
+					{ translate( 'There is an update available.', 'There are updates available.', { count: siteUpdates.total } ) }
 				</a>
 			</span>
 		);
-	},
+	}
 
-	onUpdateError() {
+	onUpdateError = () => {
 		this.setState( {
 			expand: true,
 			updating: false,
 			updateError: true
 		} );
-	},
+	}
 
-	onUpdateSuccess() {
+	onUpdateSuccess = () => {
 		this.setState( {
 			updating: false,
 			updateSucceed: true
 		} );
-		this.timer = setTimeout( function() {
+
+		this.timer = setTimeout( () => {
 			this.setState( { updateSucceed: false } );
 			this.timer = null;
-		}.bind( this ), 15000 );
-	},
+		}, 15000 );
+	}
 
-	handlePluginsUpdate() {
+	handlePluginsUpdate = () => {
+		const { siteUpdates } = this.props;
 		window.scrollTo( 0, 0 );
 		this.setState( { expand: false } );
-		analytics.ga.recordEvent( 'Site-Indicator', 'Clicked updates available link to plugins updates', 'Total Updates', this.props.site.updates && this.props.site.updates.total );
-	},
+		analytics.ga.recordEvent(
+			'Site-Indicator',
+			'Clicked updates available link to plugins updates',
+			'Total Updates',
+			siteUpdates && siteUpdates.total
+		);
+	}
 
-	handleUpdate() {
+	handleUpdate = () => {
+		const { coreUpdateStatus, site } = this.props;
+
 		this.setState( {
 			updating: true,
 			expand: false
 		} );
+
 		this.timer != null ? clearTimeout( this.timer ) : null;
-		this.props.site.updateWordPress( this.onUpdateError, this.onUpdateSuccess );
+
+		this.props.updateWordPress( site.ID ).then( () => {
+			if ( coreUpdateStatus ) {
+				this.onUpdateSuccess();
+			} else {
+				this.onUpdateError();
+			}
+		} );
 
 		analytics.ga.recordEvent( 'site-indicator', 'Triggered Update WordPress Core Version From Calypso' );
-	},
+	}
 
 	unsupportedJetpackVersion() {
+		const { translate } = this.props;
 		return (
 			<span>
-				{ this.translate( 'Jetpack %(version)s is required', { args: { version: config( 'jetpack_min_version' ) } } ) }.
+				{ translate( 'Jetpack %(version)s is required', { args: { version: config( 'jetpack_min_version' ) } } ) }.
 				<a
 					onClick={ this.makeAnalyticsRecordEventHandler( 'Clicked Update Jetpack Now Link' ) }
 					href={ this.props.site.options.admin_url + 'plugins.php?plugin_status=upgrade' }
-					>{ this.translate( 'Update now' ) }
+					>{ translate( 'Update now' ) }
 				</a>.
 			</span> );
-	},
+	}
 
-	makeAnalyticsRecordEventHandler( action ) {
-		return function() {
+	makeAnalyticsRecordEventHandler = ( action ) => {
+		return () => {
 			analytics.ga.recordEvent( 'Site-Indicator', action );
 		};
-	},
+	}
 
 	errorAccessing() {
+		const { site, translate } = this.props;
 		let accessFailedMessage;
 
 		// Don't show the button if the site is not defined.
-		if ( this.props.site ) {
-			accessFailedMessage = <span>{ this.translate( 'This site cannot be accessed.' ) } <DisconnectJetpackButton site={ this.props.site } text={ this.translate( 'Disconnect Site' ) } redirect="/sites" /></span>;
+		if ( site ) {
+			accessFailedMessage = (
+				<span>
+					{ translate( 'This site cannot be accessed.' ) }
+					<DisconnectJetpackButton site={ site } text={ translate( 'Disconnect Site' ) } redirect="/sites" />
+				</span>
+			);
 		} else {
-			accessFailedMessage = <span>{ this.translate( 'This site cannot be accessed.' ) }</span>;
+			accessFailedMessage = (
+				<span>{ translate( 'This site cannot be accessed.' ) }</span>
+			);
 		}
+
 		return accessFailedMessage;
-	},
+	}
 
 	errorUpdating() {
+		const { translate } = this.props;
+
 		return ( <span>
-			{ this.translate( 'There was a problem updating. {{link}}Update on site{{/link}}.',
+			{ translate( 'There was a problem updating. {{link}}Update on site{{/link}}.',
 				{
 					components: {
-						link: <a href={ this.props.site.options.admin_url + 'update-core.php' } onClick={ this.makeAnalyticsRecordEventHandler( 'Clicked Update On Site Link' ) } />
+						link: (
+							<a
+								href={ this.props.site.options.admin_url + 'update-core.php' }
+								onClick={ this.makeAnalyticsRecordEventHandler( 'Clicked Update On Site Link' ) }
+							/>
+						)
 					}
 				}
 			) }
 		</span> );
-	},
+	}
 
 	getText() {
 		if ( this.state.updateError ) {
@@ -220,7 +280,7 @@ export default React.createClass( {
 		}
 
 		return null;
-	},
+	}
 
 	getIcon() {
 		if ( this.hasUpdate() ) {
@@ -234,39 +294,40 @@ export default React.createClass( {
 		if ( this.hasError() ) {
 			return 'notice';
 		}
-	},
+	}
 
-	render() {
-		var indicatorClass, textClass, progressStatus;
+	renderUpdateProgress() {
+		let progressStatus;
 
-		if ( ! this.showIndicator() ) {
-			return null;
+		if ( this.state.updating ) {
+			progressStatus = 'processing';
+		}
+		if ( this.state.updateSucceed ) {
+			progressStatus = 'success';
 		}
 
+		return (
+			<div className="site-indicator__main">
+				<ProgressIndicator key="update-progress" status={ progressStatus } className="site-indicator__progress-indicator" />
+			</div>
+		);
+	}
+
+	renderIndicator() {
 		if ( this.state.updating || this.state.updateSucceed ) {
-			if ( this.state.updating ) {
-				progressStatus = 'processing';
-			}
-			if ( this.state.updateSucceed ) {
-				progressStatus = 'success';
-			}
-			return (
-				<div className="site-indicator">
-					<ProgressIndicator key="update-progress" status={ progressStatus } className="site-indicator__progress-indicator" />
-				</div>
-			);
+			return this.renderUpdateProgress();
 		}
 
-		indicatorClass = classNames( {
+		const indicatorClass = classNames( {
 			'is-expanded': this.state.expand,
 			'is-update': this.hasUpdate(),
 			'is-warning': this.hasWarning(),
 			'is-error': this.hasError(),
 			'is-action': true,
-			'site-indicator': true
+			'site-indicator__main': true
 		} );
 
-		textClass = classNames( {
+		const textClass = classNames( {
 			'is-updating': this.state.updating,
 			'is-updated': this.state.updateSucceed,
 			'site-indicator__action': true
@@ -298,4 +359,32 @@ export default React.createClass( {
 			</div>
 		);
 	}
-} );
+
+	render() {
+		const { site, siteIsJetpack } = this.props;
+
+		return (
+			<div className="site-indicator__wrapper">
+				{ siteIsJetpack && <QuerySiteConnectionStatus siteId={ site.ID } /> }
+				{ siteIsJetpack && <QuerySiteUpdates siteId={ site.ID } /> }
+
+				{ this.showIndicator() && this.renderIndicator() }
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state, { site } ) => {
+		return {
+			coreUpdateStatus: site && getSiteCoreUpdateStatus( state, site.ID ),
+			requestingConnectionStatus: site && isRequestingSiteConnectionStatus( state, site.ID ),
+			siteIsConnected: site && getSiteConnectionStatus( state, site.ID ),
+			siteIsJetpack: site && isJetpackSite( state, site.ID ),
+			siteUpdates: site && getUpdatesBySiteId( state, site.ID ),
+		};
+	},
+	{
+		updateWordPress
+	}
+)( localize( SiteIndicator ) );

--- a/client/my-sites/site-indicator/site-indicator.jsx
+++ b/client/my-sites/site-indicator/site-indicator.jsx
@@ -106,7 +106,6 @@ class SiteIndicator extends Component {
 							components: {
 								link: (
 									<a
-										className="site-indicator__action-button"
 										onClick={ this.handleUpdate }
 										href={ site.options.admin_url + 'update-core.php' }
 									/>

--- a/client/my-sites/site-indicator/site-indicator.jsx
+++ b/client/my-sites/site-indicator/site-indicator.jsx
@@ -104,7 +104,13 @@ class SiteIndicator extends Component {
 					{
 						translate( 'A newer version of WordPress is available. {{link}}Update to %(version)s{{/link}}', {
 							components: {
-								link: <button className="site-indicator__action-button" onClick={ this.handleUpdate } />
+								link: (
+									<a
+										className="site-indicator__action-button"
+										onClick={ this.handleUpdate }
+										href={ site.options.admin_url + 'update-core.php' }
+									/>
+								)
 							},
 							args: {
 								version: siteUpdates.wp_update_version

--- a/client/my-sites/site-indicator/site-indicator.jsx
+++ b/client/my-sites/site-indicator/site-indicator.jsx
@@ -24,8 +24,8 @@ import { getUpdatesBySiteId } from 'state/sites/updates/selectors';
 import { updateWordPress } from 'state/sites/updates/actions';
 import {
 	getSiteConnectionStatus,
-	getSiteCoreUpdateStatus,
-	isRequestingSiteConnectionStatus
+	isRequestingSiteConnectionStatus,
+	isWordpressUpdateSuccessful,
 } from 'state/selectors';
 
 class SiteIndicator extends Component {
@@ -183,7 +183,7 @@ class SiteIndicator extends Component {
 	}
 
 	handleUpdate = () => {
-		const { coreUpdateStatus, site } = this.props;
+		const { wordpressUpdateSuccessful, site } = this.props;
 
 		this.setState( {
 			updating: true,
@@ -193,7 +193,7 @@ class SiteIndicator extends Component {
 		this.timer != null ? clearTimeout( this.timer ) : null;
 
 		this.props.updateWordPress( site.ID ).then( () => {
-			if ( coreUpdateStatus ) {
+			if ( wordpressUpdateSuccessful ) {
 				this.onUpdateSuccess();
 			} else {
 				this.onUpdateError();
@@ -377,7 +377,7 @@ class SiteIndicator extends Component {
 export default connect(
 	( state, { site } ) => {
 		return {
-			coreUpdateStatus: site && getSiteCoreUpdateStatus( state, site.ID ),
+			wordpressUpdateSuccessful: site && isWordpressUpdateSuccessful( state, site.ID ),
 			requestingConnectionStatus: site && isRequestingSiteConnectionStatus( state, site.ID ),
 			siteIsConnected: site && getSiteConnectionStatus( state, site.ID ),
 			siteIsJetpack: site && isJetpackSite( state, site.ID ),

--- a/client/my-sites/site-indicator/style.scss
+++ b/client/my-sites/site-indicator/style.scss
@@ -2,9 +2,13 @@
  * Site Indicator
  */
 
-.site-indicator {
+.site-indicator__main {
 	align-self: center;
 	margin-right: 16px;
+}
+
+.site-indicator__wrapper {
+	align-self: center;
 }
 
 .site-indicator__button {
@@ -107,7 +111,7 @@
 
 	// Links within the action message
 	a,
-	.button.is-link {
+	.site-indicator__action-button {
 		border-bottom: 1px solid rgba( 255, 255, 255, 0.6 );
 		color: $white;
 		text-decoration: none;

--- a/client/my-sites/site-indicator/style.scss
+++ b/client/my-sites/site-indicator/style.scss
@@ -111,6 +111,7 @@
 
 	// Links within the action message
 	a,
+	.button.is-borderless.is-scary,
 	.site-indicator__action-button {
 		border-bottom: 1px solid rgba( 255, 255, 255, 0.6 );
 		color: $white;

--- a/client/state/sites/updates/selectors.js
+++ b/client/state/sites/updates/selectors.js
@@ -4,5 +4,5 @@ export const isRequestingSiteUpdates = ( state, siteId ) => {
 };
 
 export const getUpdatesBySiteId = ( state, siteId ) => {
-	return state.sites.updates.items[ siteId ] || {};
+	return state.sites.updates.items[ siteId ] || null;
 };

--- a/client/state/sites/updates/test/selectors.js
+++ b/client/state/sites/updates/test/selectors.js
@@ -55,7 +55,7 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#getUpdatesBySiteId()', () => {
-		it( 'should return an empty object if site updates have not been fetched yet', () => {
+		it( 'should return null if site updates have not been fetched yet', () => {
 			const updates = getUpdatesBySiteId( {
 				sites: {
 					updates: {
@@ -64,7 +64,7 @@ describe( 'selectors', () => {
 				}
 			}, 12345678 );
 
-			expect( updates ).to.eql( {} );
+			expect( updates ).to.be.null;
 		} );
 
 		it( 'should return the updates for an existing site', () => {


### PR DESCRIPTION
This PR attempts to reduxify and ES6ify the `SiteIndicator`:

![](https://cldup.com/yJYwolgpCn.png)

This PR removes a bunch of old sites list functionality that we'll be able to cleanup afterwards.

To test:

* Checkout this branch
* In the site selector, test various Jetpack sites that have updates pending and verify they work correctly:
  * Core update
  * Theme update
  * Other updates
* Verify updating and links work correctly.
* Verify indicator is not shown when there are no updates.