### PR TITLE
Sharing Controller: Remove sites-list

### DIFF
--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -15,16 +15,20 @@ import { sectionify } from 'lib/route';
 import Sharing from './main';
 import SharingButtons from './buttons/buttons';
 import SharingConnections from './connections/connections';
-import sites from 'lib/sites-list';
-import utils from 'lib/site/utils';
+import { getSelectedSite } from 'state/ui/selectors';
+import { canCurrentUser } from 'state/selectors';
+import { requestSiteSettings } from 'state/site-settings/actions';
+import { isJetpackModuleActive, isJetpackMinimumVersion } from 'state/sites/selectors';
 
 const analyticsPageTitle = 'Sharing';
 
 export const layout = ( { contentComponent, path, store } ) => {
-	const site = sites().getSelectedSite();
+	const state = store.getState();
+	const site = getSelectedSite( state );
 
-	if ( site && ! site.settings && utils.userCan( 'manage_options', site ) ) {
-		site.fetchSettings();
+	if ( site && ! site.settings && canCurrentUser( state, site.ID, 'manage_options' ) ) {
+		// query component?
+		requestSiteSettings( state, site.ID );
 	}
 
 	renderWithReduxStore(
@@ -35,18 +39,19 @@ export const layout = ( { contentComponent, path, store } ) => {
 };
 
 export const connections = ( context, next ) => {
-	const site = sites().getSelectedSite();
+	const state = context.store.getState();
+	const site = getSelectedSite( state );
 	const basePath = sectionify( context.path );
 	const baseAnalyticsPath = site ? basePath + '/:site' : basePath;
 
-	if ( site && ! utils.userCan( 'publish_posts', site ) ) {
+	if ( site && ! canCurrentUser( state, site.ID, 'publish_posts' ) ) {
 		notices.error( translate( 'You are not authorized to manage sharing settings for this site.' ) );
 	}
 
-	if ( site && site.jetpack && ! site.isModuleActive( 'publicize' ) ) {
+	if ( site && site.jetpack && ! isJetpackModuleActive( state, site.ID, 'publicize' ) ) {
 		// Redirect to sharing buttons if Jetpack Publicize module is not
 		// active, but ShareDaddy is active
-		page.redirect( site.isModuleActive( 'sharedaddy' ) ? '/sharing/buttons/' + sites.selected : '/stats' );
+		page.redirect( isJetpackModuleActive( state, site.ID, 'sharedaddy' ) ? '/sharing/buttons/' + site.slug : '/stats' );
 	} else {
 		pageView.record( baseAnalyticsPath, analyticsPageTitle + ' > Connections' );
 
@@ -57,18 +62,23 @@ export const connections = ( context, next ) => {
 };
 
 export const buttons = ( context, next ) => {
-	const site = sites().getSelectedSite();
+	const state = context.store.getState();
+	const site = getSelectedSite( state );
 	const basePath = sectionify( context.path );
 	const baseAnalyticsPath = site ? basePath + '/:site' : basePath;
 
 	pageView.record( baseAnalyticsPath, analyticsPageTitle + ' > Sharing Buttons' );
 
-	if ( site && ! utils.userCan( 'manage_options', site ) ) {
+	if ( site && ! canCurrentUser( state, site.ID, 'manage_options' ) ) {
 		notices.error( translate( 'You are not authorized to manage sharing settings for this site.' ) );
 	}
 
-	if ( site && site.jetpack && ( ! site.isModuleActive( 'sharedaddy' ) || site.versionCompare( '3.4-dev', '<' ) ) ) {
-		notices.error( translate( 'This page is only available to Jetpack sites running version 3.4 or higher with the Sharing module activated.' ) );
+	if ( site && site.jetpack &&
+			! ( isJetpackModuleActive( state, site.ID, 'sharedaddy' ) || isJetpackMinimumVersion( state, site.ID, '3.4-dev' ) )
+		) {
+		notices.error(
+			translate( 'This page is only available to Jetpack sites running version 3.4 or higher with the Sharing module activated.' )
+		);
 	}
 
 	context.contentComponent = createElement( SharingButtons );


### PR DESCRIPTION
Remove the need for `sites-list` from the controller.

To test:
 - See if `/sharing` works for Jetpack & WPCOM sites