### PR TITLE
Reader Following Manage Refresh: allow searching of existing subscriptions

### DIFF
--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import classnames from 'classnames';
-import { trim, isEmpty, get } from 'lodash';
+import { isEmpty, get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -13,7 +13,12 @@ import ReaderAvatar from 'blocks/reader-avatar';
 import FollowButton from 'reader/follow-button';
 import { getStreamUrl } from 'reader/route';
 import EmailSettings from './email-settings';
-import { getSiteName, getSiteUrl } from 'reader/get-helpers';
+import {
+	getSiteName,
+	getSiteUrl,
+	getSiteDescription,
+	getSiteAuthorName
+} from 'reader/get-helpers';
 
 function ReaderSubscriptionListItem( {
 	url,
@@ -28,11 +33,10 @@ function ReaderSubscriptionListItem( {
 } ) {
 	const siteTitle = getSiteName( { feed, site } );
 	const siteAuthor = site && site.owner;
-	const siteExcerpt = ( site && site.description ) || ( feed && feed.description );
+	const siteExcerpt = getSiteDescription( { feed, site } );
 	// prefer a users name property
 	// if that doesn't exist settle for combining first and last name
-	const authorName = siteAuthor && ( siteAuthor.name ||
-		trim( `${ siteAuthor.first_name || '' } ${ siteAuthor.last_name || '' }` ) );
+	const authorName = getSiteAuthorName( site );
 	const siteIcon = get( site, 'icon.img' );
 	const feedIcon = get( feed, 'image' );
 	const streamUrl = getStreamUrl( feedId, siteId );

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -79,14 +79,6 @@
 	}
 }
 
-.following-manage__subscriptions-list .following-manage__sites-window-scroller > div {
-	border-bottom: 1px solid lighten( $gray, 30% );
-
-	&:last-child {
-		border: 0;
-	}
-}
-
 .reader-subscription-list-item .follow-button {
 	border: 0;
 	padding: 0;

--- a/client/lib/reader-connect-site/index.js
+++ b/client/lib/reader-connect-site/index.js
@@ -48,7 +48,7 @@ const connectSite = Component => {
 			let site = !! siteId ? getSite( state, siteId ) : undefined;
 
 			if ( feed && ! siteId ) {
-				siteId = feed.blog_ID !== 0 && feed.blog_ID;
+				siteId = feed.blog_ID !== 0 ? feed.blog_ID : undefined;
 				site = !! siteId ? getSite( state, feed.blog_ID ) : undefined;
 			}
 			if ( site && ! feedId ) {

--- a/client/reader/following-manage/connected-subscription-list-item.jsx
+++ b/client/reader/following-manage/connected-subscription-list-item.jsx
@@ -1,26 +1,56 @@
 /**
  * External Dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
 
 /**
  * Internal Dependencies
  */
 import connectSite from 'lib/reader-connect-site';
-import SubscriptionListItem from 'blocks/reader-subscription-list-item/';
 import userSettings from 'lib/user-settings';
+import SubscriptionListItem from 'blocks/reader-subscription-list-item';
 
-export default localize( connectSite(
-	( { feed, site, translate, url, feedId, siteId } ) => (
-		<SubscriptionListItem
-			translate={ translate }
-			feedId={ feedId }
-			siteId={ siteId }
-			site={ site }
-			feed={ feed }
-			url={ url }
-			isEmailBlocked={ userSettings.getSetting( 'subscription_delivery_email_blocked' ) }
-		/>
-	)
-) );
+class ConnectedSubscriptionListItem extends React.Component {
+	static propTypes = {
+		feed: PropTypes.object,
+		site: PropTypes.object,
+		translate: PropTypes.func,
+		feedId: PropTypes.number,
+		siteId: PropTypes.number,
+		onLoad: PropTypes.func,
+	};
+
+	static defaultProps = {
+		onLoad: noop,
+	};
+
+	componentDidMount() {
+		this.props.onLoad();
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( this.props !== prevProps ) {
+			this.props.onLoad();
+		}
+	}
+
+	render() {
+		const { feed, site, translate, url, feedId, siteId } = this.props;
+
+		return (
+			<SubscriptionListItem
+				translate={ translate }
+				feedId={ feedId }
+				siteId={ siteId }
+				site={ site }
+				feed={ feed }
+				url={ url }
+				isEmailBlocked={ userSettings.getSetting( 'subscription_delivery_email_blocked' ) }
+			/>
+		);
+	}
+}
+
+export default localize( connectSite( ConnectedSubscriptionListItem ) );

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -23,8 +23,8 @@ import SitesWindowScroller from './sites-window-scroller';
 
 class FollowingManage extends Component {
 	static propTypes = {
-		sitesQuery: React.PropTypes.string,
-		subsQuery: React.PropTypes.string,
+		sitesQuery: PropTypes.string,
+		subsQuery: PropTypes.string,
 	};
 
 	static defaultProps = {

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -23,8 +23,15 @@ import SitesWindowScroller from './sites-window-scroller';
 
 class FollowingManage extends Component {
 	static propTypes = {
-		query: PropTypes.string,
+		sitesQuery: React.PropTypes.string,
+		subsQuery: React.PropTypes.string,
 	};
+
+	static defaultProps = {
+		subsQuery: '',
+		sitesQuery: '',
+	}
+
 	state = { width: 800 };
 
 	// TODO make this common between our different search pages?
@@ -80,14 +87,14 @@ class FollowingManage extends Component {
 	}
 
 	render() {
-		const { query, translate, searchResults } = this.props;
+		const { sitesQuery, subsQuery, translate, searchResults } = this.props;
 		const searchPlaceholderText = translate( 'Search millions of sites' );
 
 		return (
 			<ReaderMain className="following-manage">
 				<DocumentHead title={ 'Manage Following' } />
 				{ this.props.showBack && <HeaderBack /> }
-				{ searchResults.length === 0 && <QueryReaderFeedsSearch query={ query } /> }
+				{ searchResults.length === 0 && <QueryReaderFeedsSearch query={ sitesQuery } /> }
 				<h1 className="following-manage__header"> { translate( 'Follow Something New' ) } </h1>
 				<div ref={ this.handleStreamMounted } />
 				<div className="following-manage__fixed-area" ref={ this.handleSearchBoxMounted }>
@@ -100,13 +107,13 @@ class FollowingManage extends Component {
 							delayTimeout={ 500 }
 							placeholder={ searchPlaceholderText }
 							additionalClasses="following-manage__search-new"
-							initialValue={ query }
-							value={ query }>
+							initialValue={ sitesQuery }
+							value={ sitesQuery }>
 						</SearchInput>
 					</CompactCard>
 				</div>
-				{ ! query && <FollowingManageSubscriptions width={ this.state.width } /> }
-				{ !! query && <SitesWindowScroller sites={ searchResults } width={ this.state.width } /> }
+				{ ! sitesQuery && <FollowingManageSubscriptions width={ this.state.width } query={ subsQuery } /> }
+				{ !! sitesQuery && <SitesWindowScroller sites={ searchResults } width={ this.state.width } /> }
 			</ReaderMain>
 		);
 	}
@@ -114,6 +121,6 @@ class FollowingManage extends Component {
 
 export default connect(
 	( state, ownProps ) => ( {
-		searchResults: getReaderFeedsForQuery( state, ownProps.query ) || [],
+		searchResults: getReaderFeedsForQuery( state, ownProps.sitesQuery ) || [],
 	} ),
 )( localize( FollowingManage ) );

--- a/client/reader/following-manage/search-followed.jsx
+++ b/client/reader/following-manage/search-followed.jsx
@@ -12,7 +12,7 @@ import SearchCard from 'components/search-card';
 
 class FollowingManageSearchFollowed extends Component {
 	static propTypes = {
-		value: PropTypes.string,
+		initialValue: PropTypes.string,
 		onSearch: PropTypes.func,
 	}
 
@@ -31,8 +31,9 @@ class FollowingManageSearchFollowed extends Component {
 				additionalClasses="following-manage__search-followed-input"
 				placeholder={ this.props.translate( 'Search Followed Sites…' ) }
 				onSearch={ this.props.onSearch }
-				initialValue={ this.props.value }
+				initialValue={ this.props.initialValue }
 				delaySearch={ true }
+				delayTimeout={ 100 }
 				hideOpenIcon={ true } />
 		);
 	}

--- a/client/reader/following-manage/sites-window-scroller.jsx
+++ b/client/reader/following-manage/sites-window-scroller.jsx
@@ -2,11 +2,12 @@
  * External Dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import ConnectedSubscriptionListItem from './connected-subscription-list-item';
+import { List, WindowScroller, CellMeasurerCache, CellMeasurer } from 'react-virtualized';
 
 /**
  * Internal Dependencies
  */
+import ConnectedSubscriptionListItem from './connected-subscription-list-item';
 
 /**
  * SitesWindowScroller is a component that takes in a list of site/feed objects.
@@ -19,18 +20,54 @@ class SitesWindowScroller extends Component {
 		sites: PropTypes.array.isRequired,
 	};
 
+	heightCache = new CellMeasurerCache( {
+		fixedWidth: true,
+		minHeight: 50,
+	} );
+
+	siteRowRenderer = ( { index, key, style, parent } ) => {
+		const site = this.props.sites[ index ];
+
+		return (
+			<CellMeasurer
+				cache={ this.heightCache }
+				columnIndex={ 0 }
+				key={ key }
+				rowIndex={ index }
+				parent={ parent }
+			>
+				{ ( { measure } ) => (
+					<div key={ key } style={ style } className="following-manage__sites-window-scroller-row-wrapper" >
+							<ConnectedSubscriptionListItem
+								url={ +site.URL }
+								feedId={ +site.feed_ID }
+								siteId={ +site.blog_ID }
+								onLoad={ measure }
+							/>
+					</div>
+				) }
+			</CellMeasurer>
+		);
+	};
+
 	render() {
 		const { sites, width } = this.props;
 
 		return (
 			<div className="following-manage__sites-window-scroller">
-				{ sites.map( site => {
-					return (
-						<div key={ site.URL } style={ { width } }>
-							<ConnectedSubscriptionListItem url={ site.URL } feedId={ +site.feed_ID } siteId={ +site.blog_ID } />
-						</div>
-					);
-				} ) }
+				<WindowScroller>
+					{ ( { height, scrollTop } ) => (
+						<List
+							autoHeight
+							height={ height }
+							rowCount={ sites.length }
+							rowHeight={ this.heightCache.rowHeight }
+							rowRenderer={ this.siteRowRenderer }
+							scrollTop={ scrollTop }
+							width={ width }
+						/>
+					)}
+				</WindowScroller>
 			</div>
 		);
 	}

--- a/client/reader/following-manage/sites-window-scroller.jsx
+++ b/client/reader/following-manage/sites-window-scroller.jsx
@@ -39,7 +39,7 @@ class SitesWindowScroller extends Component {
 				{ ( { measure } ) => (
 					<div key={ key } style={ style } className="following-manage__sites-window-scroller-row-wrapper" >
 							<ConnectedSubscriptionListItem
-								url={ +site.URL }
+								url={ site.URL }
 								feedId={ +site.feed_ID }
 								siteId={ +site.blog_ID }
 								onLoad={ measure }

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -28,3 +28,11 @@
 .following-manage__search-followed-input {
 	min-width: 200px;
 }
+
+.following-manage__sites-window-scroller-row-wrapper {
+	border-bottom: 1px solid lighten( $gray, 30% );
+
+	&:last-child {
+		border: 0;
+	}
+}

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -28,11 +28,11 @@ class FollowingManageSubscriptions extends Component {
 
 	filterFollowsByQuery( query ) {
 		const { getFeed, getSite, follows } = this.props;
+		const phraseRe = new RegExp( escapeRegexp( query ), 'i' );
 
 		return follows.filter( follow => {
 			const feed = getFeed( follow.feed_ID ); // todo grab feed and site for current sub
 			const site = getSite( follow.site_ID );
-			const phraseRe = new RegExp( escapeRegexp( query ), 'i' );
 			const siteName = getSiteName( { feed, site } );
 			const siteUrl = getSiteUrl( { feed, site } );
 			const siteDescription = getSiteDescription( { feed, site } );

--- a/client/reader/following/controller.js
+++ b/client/reader/following/controller.js
@@ -41,10 +41,11 @@ const exported = {
 	},
 
 	followingManage( context ) {
-		const basePath = route.sectionify( context.path ),
-			fullAnalyticsPageTitle = analyticsPageTitle + ' > Manage Followed Sites',
-			mcKey = 'following_manage',
-			query = context.query.q;
+		const basePath = route.sectionify( context.path );
+		const fullAnalyticsPageTitle = analyticsPageTitle + ' > Manage Followed Sites';
+		const mcKey = 'following_manage';
+		const sitesQuery = context.query.q;
+		const subsQuery = context.query.s;
 
 		setPageTitle( context, i18n.translate( 'Manage Followed Sites' ) );
 
@@ -55,7 +56,8 @@ const exported = {
 				require="reader/following-manage"
 				key="following-manage"
 				initialFollowUrl={ context.query.follow }
-				query={ query }
+				sitesQuery={ sitesQuery }
+				subsQuery={ subsQuery }
 				context={ context }
 				userSettings={ userSettings }
 			/>,

--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -3,6 +3,7 @@
  */
 import url from 'url';
 import { translate } from 'i18n-calypso';
+import { trim } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -47,4 +48,16 @@ export const getSiteName = ( { feed, site, post } = {} ) => {
 	}
 
 	return siteName;
+};
+
+export const getSiteDescription = ( { site, feed } ) => {
+	return ( site && site.description ) || ( feed && feed.description );
+};
+
+export const getSiteAuthorName = site => {
+	const siteAuthor = site && site.owner;
+	return siteAuthor && (
+		siteAuthor.name ||
+		trim( `${ siteAuthor.first_name || '' } ${ siteAuthor.last_name || '' }` )
+	);
 };


### PR DESCRIPTION
Connects up the search box above the existing subscription list.

Fixes #12960.

Todo
- [x] Render subscription list from component state
- [x] Fetch feed and site information for subscriptions so we can search them
- [x] Hook up search box so query is used to filter subscriptions

cc @samouri 