### PR TITLE
The onProgress parameter of dispatchRequest should default to _.noop

### DIFF
--- a/client/state/data-layer/wpcom-http/test/utils.js
+++ b/client/state/data-layer/wpcom-http/test/utils.js
@@ -122,6 +122,11 @@ describe( 'WPCOM HTTP Data Layer', () => {
 				expect( onFailure ).to.not.have.beenCalled;
 				expect( onProgress ).to.have.been.calledWith( store, progress, next, progressInfo );
 			} );
+
+			it( 'should not throw runtime error if onProgress is not specified', () => {
+				dispatcher = dispatchRequest( initiator, onSuccess, onFailure );
+				expect( () => dispatcher( store, progress, next ) ).to.not.throw( TypeError );
+			} );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { get, noop } from 'lodash';
 
 /**
  * Returns response data from an HTTP request success action if available
@@ -61,10 +61,11 @@ export const getProgress = action => get( action, 'meta.dataLayer.progress', nul
  * @param {Function} initiator called if action lacks response meta; should create HTTP request
  * @param {Function} onSuccess called if the action meta includes response data
  * @param {Function} onError called if the action meta includes error data
- * @param {Function} [onProgress] called on progress events when uploading
+ * @param {Function} [onProgress] called on progress events when uploading. The default
+ *                                behavior of this optional handler is to do nothing.
  * @returns {?*} please ignore return values, they are undefined
  */
-export const dispatchRequest = ( initiator, onSuccess, onError, onProgress = null ) => ( store, action, next ) => {
+export const dispatchRequest = ( initiator, onSuccess, onError, onProgress = noop ) => ( store, action, next ) => {
 	const error = getError( action );
 	if ( error ) {
 		return onError( store, action, next, error );


### PR DESCRIPTION
There are cases where a request initiator issues a `POST` request and yet its `dispatchRequest` omits the `onProgress` argument, which then defaults to `null`:

- [read/site/post-email-subscriptions/update](https://github.com/Automattic/wp-calypso/blob/master/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js#L56-L60)
- [me/settings](https://github.com/Automattic/wp-calypso/blob/master/client/state/data-layer/wpcom/me/settings/index.js#L90)

The browser (Chrome, at least) however fires the `progress` event for any XHR that POSTs something -- even a tiny JSON body, not just a big file upload. In such case, a `ReferenceError` is thrown when trying to call `null`.

Discovered when converting the `me/account` form to the new Reduxized data layer. The `post-email-subscriptions/update` action would surely also fail after being used for the first time.

Fixed by defaulting the `dispatchRequest` args to `noop`.