### PR TITLE
Add missing displayName property causing mangled devdocs titles (#11079)

### DIFF
--- a/client/components/date-picker/docs/example.jsx
+++ b/client/components/date-picker/docs/example.jsx
@@ -15,6 +15,7 @@ var Card = require( 'components/card' ),
  */
 var datePicker = React.createClass( {
 	mixins: [ PureRenderMixin ],
+	displayName: 'DatePicker',
 
 	getInitialState: function() {
 		var date = new Date();

--- a/client/components/external-link/docs/example.jsx
+++ b/client/components/external-link/docs/example.jsx
@@ -10,7 +10,6 @@ import ExternalLink from 'components/external-link';
 import Card from 'components/card';
 
 export default React.createClass( {
-
 	displayName: 'ExternalLink',
 
 	render() {

--- a/client/components/tooltip/docs/example.jsx
+++ b/client/components/tooltip/docs/example.jsx
@@ -98,4 +98,6 @@ class Tooltip extends PureComponent {
 	}
 }
 
+Tooltip.displayName = 'Tooltip';
+
 export default Tooltip;


### PR DESCRIPTION
Example components that don't have a displayName property fallback to using the Class.name which gets mangled by UglifyJS in production.