### PR TITLE
Janitorial: clean up url-search hoc

### DIFF
--- a/client/lib/url-search/index.js
+++ b/client/lib/url-search/index.js
@@ -76,12 +76,12 @@ const UrlSearch = Component => class extends React.Component {
 			queryKey: this.props.queryKey
 		} );
 
-		debug( 'search for:', query );
+		debug( 'search for: %s', query );
 		if ( this.props.search && query ) {
-			debug( 'replacing URL: ' + searchURL );
+			debug( 'replacing URL: %s', searchURL );
 			page.replace( searchURL );
 		} else {
-			debug( 'setting URL: ' + searchURL );
+			debug( 'setting URL: %s', searchURL );
 			page( searchURL );
 		}
 	};

--- a/client/lib/url-search/index.js
+++ b/client/lib/url-search/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import debugModule from 'debug';
+import debugFactory from 'debug';
 import page from 'page';
 import url from 'url';
 import { pick } from 'lodash';
@@ -10,7 +10,7 @@ import { pick } from 'lodash';
 /**
  * Internal dependencies
  */
-const debug = debugModule( 'calypso:url-search' );
+const debug = debugFactory( 'calypso:url-search' );
 
 /**
  * Function for constructing the url to page to. e.g.
@@ -40,8 +40,12 @@ const buildSearchUrl = ( { uri, search, queryKey = 's' } ) => {
 	return url.format( parsedUrl ).replace( /\%20/g, '+' );
 };
 
-const UrlSearch = Component => class extends Component {
+const UrlSearch = Component => class extends React.Component {
 	static displayName = `UrlSearch(${ Component.displayName || Component.name || '' })`;
+	static defaultProps = {
+		search: '',
+		queryKey: 's',
+	}
 
 	state = {
 		searchOpen: false

--- a/client/lib/url-search/index.js
+++ b/client/lib/url-search/index.js
@@ -13,8 +13,13 @@ import { pick } from 'lodash';
 const debug = debugFactory( 'calypso:url-search' );
 
 /**
- * Function for constructing the url to page to. e.g.
- * { uri: 'google.com', search:'hello' } --> 'google.com?s=hello'
+ * Function for constructing the url to page to. Here are some examples:
+ * 1. { uri: 'google.com', search:'hello' } --> 'google.com?s=hello'
+ * 2. {
+ *     uri: 'wordpress.com/read/search?q=reader+is+awesome',
+ *     search: 'reader is super awesome'
+ *     queryKey: 'q',
+ *    } --> 'wordpress.com/read/search?q=reader+is+super+awesome'
  *
  * @param {Object} options the options object
  * @param {string} options.uri the base uri to modify and add a query to
@@ -23,7 +28,7 @@ const debug = debugFactory( 'calypso:url-search' );
  *
  * @returns {string} The built search url
  */
-const buildSearchUrl = ( { uri, search, queryKey = 's' } ) => {
+export const buildSearchUrl = ( { uri, search, queryKey = 's' } ) => {
 	const parsedUrl = pick(
 		url.parse( uri, true ),
 		'pathname',

--- a/client/lib/url-search/index.js
+++ b/client/lib/url-search/index.js
@@ -4,13 +4,41 @@
 import React from 'react';
 import debugModule from 'debug';
 import page from 'page';
+import url from 'url';
+import { pick } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import buildUrl from 'lib/mixins/url-search/build-url';
-
 const debug = debugModule( 'calypso:url-search' );
+
+/**
+ * Function for constructing the url to page to. e.g.
+ * { uri: 'google.com', search:'hello' } --> 'google.com?s=hello'
+ *
+ * @param {Object} options the options object
+ * @param {string} options.uri the base uri to modify and add a query to
+ * @param {string} options.search the search term
+ * @param {string} [options.queryKey = s] the key to place in the url.  defaults to s
+ *
+ * @returns {string} The built search url
+ */
+const buildSearchUrl = ( { uri, search, queryKey = 's' } ) => {
+	const parsedUrl = pick(
+		url.parse( uri, true ),
+		'pathname',
+		'hash',
+		'query',
+	);
+
+	if ( search ) {
+		parsedUrl.query[ queryKey ] = search;
+	} else {
+		delete parsedUrl.query[ queryKey ];
+	}
+
+	return url.format( parsedUrl ).replace( /\%20/g, '+' );
+};
 
 const UrlSearch = Component => class extends Component {
 	static displayName = Component.displayName || Component.name || '';
@@ -21,20 +49,24 @@ const UrlSearch = Component => class extends Component {
 
 	componentWillReceiveProps = ( { search } ) => ! search && this.setState( { searchOpen: false } );
 
-	doSearch = ( keywords ) => {
+	doSearch = ( query ) => {
 		this.setState( {
-			searchOpen: ( false !== keywords )
+			searchOpen: ( false !== query )
 		} );
 
 		if ( this.onSearch ) {
-			this.onSearch( keywords );
+			this.onSearch( query );
 			return;
 		}
 
-		const searchURL = buildUrl( window.location.href, keywords );
+		const searchURL = buildSearchUrl( {
+			uri: window.location.href,
+			search: query,
+			queryKey: this.props.queryKey
+		} );
 
-		debug( 'search posts for:', keywords );
-		if ( this.props.search && keywords ) {
+		debug( 'search for:', query );
+		if ( this.props.search && query ) {
 			debug( 'replacing URL: ' + searchURL );
 			page.replace( searchURL );
 		} else {

--- a/client/lib/url-search/index.js
+++ b/client/lib/url-search/index.js
@@ -41,13 +41,15 @@ const buildSearchUrl = ( { uri, search, queryKey = 's' } ) => {
 };
 
 const UrlSearch = Component => class extends Component {
-	static displayName = Component.displayName || Component.name || '';
+	static displayName = `UrlSearch(${ Component.displayName || Component.name || '' })`;
 
 	state = {
 		searchOpen: false
 	};
 
-	componentWillReceiveProps = ( { search } ) => ! search && this.setState( { searchOpen: false } );
+	componentWillReceiveProps( { search } ) {
+		return ! search && this.setState( { searchOpen: false } );
+	}
 
 	doSearch = ( query ) => {
 		this.setState( {
@@ -84,7 +86,7 @@ const UrlSearch = Component => class extends Component {
 			<Component
 				{ ...this.props }
 				doSearch = { this.doSearch }
-				getSearchOpen={ this.getSearch }
+				getSearchOpen={ this.getSearchOpen }
 			/>
 		);
 	}

--- a/client/lib/url-search/test/index.js
+++ b/client/lib/url-search/test/index.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { buildSearchUrl } from '../';
+
+describe( '#buildSearchUrl', () => {
+	it( 'should return original url if there is no search', () => {
+		const params = { uri: 'chicken.com' };
+		expect( buildSearchUrl( params ) ).eql( 'chicken.com' );
+	} );
+
+	it( 'should add add the default params of s to built query', () => {
+		const params = {
+			uri: 'google.com',
+			search: 'hello',
+		};
+		const url = buildSearchUrl( params );
+		expect( url ).eql( 'google.com?s=hello' );
+	} );
+
+	it( 'should replace current query with new one even when using custom query key', () => {
+		const params = {
+			uri: 'wordpress.com/read/search?q=reader+is+awesome',
+			search: 'reader is super awesome',
+			queryKey: 'q',
+		};
+		const url = buildSearchUrl( params );
+		expect( url ).eql( 'wordpress.com/read/search?q=reader+is+super+awesome' );
+	} );
+
+	it( 'should remove the query if search is empty', () => {
+		const params = {
+			uri: 'wordpress.com/read/search?q=reader+is+awesome',
+			queryKey: 'q',
+		};
+		const url = buildSearchUrl( params );
+		expect( url ).eql( 'wordpress.com/read/search' );
+	} );
+} );


### PR DESCRIPTION
This PR has two goals:
1. remove the dependency from the mixin component.
3. add in functionality to use a custom query key.  "s" isn't always the right one to use.

TODO:
-  [x] remove dependency from the mixin so it can be phased out 

To Test:
- make sure that the search here still behaves properly.  It is the only thing currently relying on the HoC. http://calypso.localhost:3000/plugins