### PR TITLE
Customize: allow visiting the Customizer with an unverified email address.

### DIFF
--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -24,6 +24,7 @@ import { getMenusUrl } from 'state/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 
 var loadingTimer;
+let isRedirecting = false;
 
 var Customize = React.createClass( {
 	displayName: 'Customize',
@@ -69,8 +70,13 @@ var Customize = React.createClass( {
 	},
 
 	redirectIfNeeded: function( menusUrl, site ) {
+		if ( isRedirecting ) {
+			return;
+		}
 		if ( site && menusUrl !== '/customize/menus/' + site.slug ) {
+			isRedirecting = true;
 			page( menusUrl );
+			isRedirecting = false;
 		}
 	},
 


### PR DESCRIPTION
An infinite loop was happening in the `redirectIfNeeded` method, now prevented with a quick check.

I'm not 100% certain if this is still behaving as desired from #13082 but it works.

Fixes #13226