### PR TITLE
Reader: Provide a redux bound follow button

### DIFF
--- a/client/blocks/follow-button/index.jsx
+++ b/client/blocks/follow-button/index.jsx
@@ -1,71 +1,43 @@
 /**
  * External Dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { noop } from 'lodash';
+import { connect } from 'react-redux';
 
 /**
  * Internal Dependencies
  */
 import FollowButton from './button';
-import FeedSubscriptionActions from 'lib/reader-feed-subscriptions/actions';
-import FeedSubscriptionStore from 'lib/reader-feed-subscriptions';
+import { follow, unfollow } from 'state/reader/follows/actions';
+import { isFollowing } from 'state/selectors';
 
-const FollowButtonContainer = React.createClass( {
-	propTypes: {
+class FollowButtonContainer extends Component {
+	static propTypes = {
 		siteUrl: React.PropTypes.string.isRequired,
 		iconSize: React.PropTypes.number,
 		onFollowToggle: React.PropTypes.func,
 		followLabel: React.PropTypes.string,
 		followingLabel: React.PropTypes.string
-	},
+	}
 
-	getDefaultProps() {
-		return {
-			onFollowToggle: noop
-		};
-	},
+	static defaultProps = {
+		onFollowToggle: noop
+	}
 
-	getInitialState() {
-		return this.getStateFromStores();
-	},
-
-	getStateFromStores( props = this.props ) {
-		return { following: FeedSubscriptionStore.getIsFollowingBySiteUrl( props.siteUrl ) };
-	},
-
-	componentDidMount() {
-		FeedSubscriptionStore.on( 'change', this.onStoreChange );
-	},
-
-	componentWillUnmount() {
-		FeedSubscriptionStore.off( 'change', this.onStoreChange );
-	},
-
-	componentWillReceiveProps( nextProps ) {
-		this.updateState( nextProps );
-	},
-
-	updateState( props = this.props ) {
-		const newState = this.getStateFromStores( props );
-		if ( newState.following !== this.state.following ) {
-			this.setState( newState );
+	handleFollowToggle = ( following ) => {
+		if ( following ) {
+			this.props.follow( this.props.siteUrl );
+		} else {
+			this.props.unfollow( this.props.siteUrl );
 		}
-	},
-
-	onStoreChange() {
-		this.updateState();
-	},
-
-	handleFollowToggle( following ) {
-		FeedSubscriptionActions[ following ? 'follow' : 'unfollow' ]( this.props.siteUrl );
 		this.props.onFollowToggle( following );
-	},
+	}
 
 	render() {
 		return (
 			<FollowButton
-				following={ this.state.following }
+				following={ this.props.following }
 				onFollowToggle={ this.handleFollowToggle }
 				iconSize={ this.props.iconSize }
 				tagName={ this.props.tagName }
@@ -75,6 +47,14 @@ const FollowButtonContainer = React.createClass( {
 				className={ this.props.className } />
 		);
 	}
-} );
+}
 
-export default FollowButtonContainer;
+export default connect(
+	( state, ownProps ) => ( {
+		following: isFollowing( state, { feedUrl: ownProps.siteUrl } )
+	} ),
+	{
+		follow,
+		unfollow
+	}
+)( FollowButtonContainer );

--- a/client/components/data/sync-reader-follows/index.js
+++ b/client/components/data/sync-reader-follows/index.js
@@ -1,0 +1,41 @@
+/**
+ * External Dependencies
+ */
+import { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal Dependencies
+ */
+import { getReaderFollowsLastSyncTime } from 'state/selectors';
+import { requestFollows } from 'state/reader/follows/actions';
+
+const TIME_BETWEEN_SYNCS = 1000 * 60 * 60; // one hour
+
+class SyncReaderFollows extends Component {
+	check() {
+		if ( ! this.props.lastSyncTime ||
+			Date.now() > this.props.lastSyncTime + TIME_BETWEEN_SYNCS ) {
+			this.props.requestFollows();
+		}
+	}
+
+	componentDidMount() {
+		this.check();
+	}
+
+	componentDidUpate() {
+		this.check();
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect(
+	( state ) => ( {
+		lastSyncTime: getReaderFollowsLastSyncTime( state ) || 0
+	} ),
+	{ requestFollows }
+)( SyncReaderFollows );

--- a/client/components/reader-main/index.jsx
+++ b/client/components/reader-main/index.jsx
@@ -7,6 +7,7 @@ import React from 'react';
  * Internal Dependencies
  */
 import Main from 'components/main';
+import SyncReaderFollows from 'components/data/sync-reader-follows';
 
 /**
  * A specialization of `Main` that adds a class to the body of the document
@@ -24,6 +25,13 @@ export default class ReaderMain extends React.Component {
 	}
 
 	render() {
-		return ( <Main { ...this.props } /> );
+		let { children, ...props } = this.props;
+		children = React.Children.toArray( children );
+		children.push( <SyncReaderFollows key="syncReaderFollows" /> );
+		return (
+			<Main { ...props }>
+				{ children }
+			</Main>
+		);
 	}
 }

--- a/client/components/reader-main/index.jsx
+++ b/client/components/reader-main/index.jsx
@@ -25,11 +25,10 @@ export default class ReaderMain extends React.Component {
 	}
 
 	render() {
-		let { children, ...props } = this.props;
-		children = React.Children.toArray( children );
-		children.push( <SyncReaderFollows key="syncReaderFollows" /> );
+		const { children, ...props } = this.props;
 		return (
 			<Main { ...props }>
+				<SyncReaderFollows key="syncReaderFollows" />
 				{ children }
 			</Main>
 		);

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -15,7 +15,6 @@ import feedLookup from 'lib/feed-lookup';
 import feedStreamFactory from 'lib/feed-stream-store';
 import { ensureStoreLoading, trackPageLoad, trackUpdatesLoaded, trackScrollPage, setPageTitle } from './controller-helper';
 import FeedError from 'reader/feed-error';
-import FeedSubscriptionActions from 'lib/reader-feed-subscriptions/actions';
 import StreamComponent from 'reader/following/main';
 import {
 	getPrettyFeedUrl,
@@ -25,11 +24,6 @@ import { recordTrack } from 'reader/stats';
 import { preload } from 'sections-preload';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import AsyncLoad from 'components/async-load';
-
-// these three are included to ensure that the stores required have been loaded and can accept actions
-import FeedSubscriptionStore from 'lib/reader-feed-subscriptions'; // eslint-disable-line no-unused-vars
-import PostEmailSubscriptionStore from 'lib/reader-post-email-subscriptions'; // eslint-disable-line no-unused-vars
-import CommentEmailSubscriptionStore from 'lib/reader-comment-email-subscriptions'; // eslint-disable-line no-unused-vars
 
 const analyticsPageTitle = 'Reader';
 
@@ -120,11 +114,6 @@ const exported = {
 
 	preloadReaderBundle( context, next ) {
 		preload( 'reader' );
-		next();
-	},
-
-	loadSubscriptions( context, next ) {
-		FeedSubscriptionActions.fetchAll();
 		next();
 	},
 

--- a/client/reader/discover/index.js
+++ b/client/reader/discover/index.js
@@ -9,7 +9,6 @@ import page from 'page';
 import { discover } from './controller';
 import {
 	initAbTests,
-	loadSubscriptions,
 	preloadReaderBundle,
 	sidebar,
 	updateLastRoute,
@@ -19,7 +18,6 @@ export default function() {
 	page( '/discover',
 		preloadReaderBundle,
 		updateLastRoute,
-		loadSubscriptions,
 		initAbTests,
 		sidebar,
 		discover

--- a/client/reader/follow-button/index.jsx
+++ b/client/reader/follow-button/index.jsx
@@ -2,8 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
@@ -14,10 +12,6 @@ import {
 	recordFollow as recordFollowTracks,
 	recordUnfollow as recordUnfollowTracks,
 } from 'reader/stats';
-import {
-	recordFollow as recordFollowAction,
-	recordUnfollow as recordUnfollowAction,
-} from 'state/reader/follows/actions';
 
 function ReaderFollowButton( props ) {
 	const {
@@ -25,17 +19,13 @@ function ReaderFollowButton( props ) {
 		railcar,
 		followSource,
 		isButtonOnly,
-		dispatchRecordFollow,
-		dispatchRecordUnfollow,
 		siteUrl,
 	} = props;
 
 	function recordFollowToggle( isFollowing ) {
 		if ( isFollowing ) {
-			dispatchRecordFollow( siteUrl );
 			recordFollowTracks( siteUrl, railcar, { follow_source: followSource } );
 		} else {
-			dispatchRecordUnfollow( siteUrl );
 			recordUnfollowTracks( siteUrl, railcar, { follow_source: followSource } );
 		}
 
@@ -61,12 +51,4 @@ ReaderFollowButton.propTypes = {
 	followSource: React.PropTypes.string,
 };
 
-export default connect(
-	( state ) => ( {} ), // eslint-disable-line no-unused-vars
-	( dispatch ) => bindActionCreators( {
-		dispatchRecordFollow: recordFollowAction,
-		dispatchRecordUnfollow: recordUnfollowAction,
-	}, dispatch ),
-	null,
-	{ pure: true } // TODO: is this component pure?
-)( ReaderFollowButton );
+export default ReaderFollowButton;

--- a/client/reader/following/index.js
+++ b/client/reader/following/index.js
@@ -11,7 +11,6 @@ import {
 	followingManage,
 } from './controller';
 import {
-	loadSubscriptions,
 	initAbTests,
 	updateLastRoute,
 	sidebar,
@@ -19,7 +18,7 @@ import {
 import config from 'config';
 
 export default function() {
-	page( '/following/*', loadSubscriptions, initAbTests );
+	page( '/following/*', initAbTests );
 	page( '/following/edit', updateLastRoute, sidebar, followingEdit );
 	if ( config.isEnabled( 'reader/following-manage-refresh' ) ) {
 		page( '/following/manage', updateLastRoute, sidebar, followingManage );

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -14,7 +14,6 @@ import {
 	incompleteUrlRedirects,
 	initAbTests,
 	legacyRedirects,
-	loadSubscriptions,
 	preloadReaderBundle,
 	prettyRedirects,
 	readA8C,
@@ -32,7 +31,6 @@ export default function() {
 	if ( config.isEnabled( 'reader' ) ) {
 		page( '/',
 			preloadReaderBundle,
-			loadSubscriptions,
 			initAbTests,
 			updateLastRoute,
 			sidebar,
@@ -48,7 +46,7 @@ export default function() {
 		page( '/read/feed', '/' );
 
 		// Feed stream
-		page( '/read/*', preloadReaderBundle, loadSubscriptions, initAbTests );
+		page( '/read/*', preloadReaderBundle, initAbTests );
 		page( '/read/blog/feed/:feed_id', legacyRedirects );
 		page( '/read/feeds/:feed_id/posts', incompleteUrlRedirects );
 		page( '/read/feeds/:feed_id',
@@ -74,4 +72,4 @@ export default function() {
 
 	// Automattic Employee Posts
 	page( '/read/a8c', updateLastRoute, sidebar, forceTeamA8C, readA8C );
-};
+}

--- a/client/reader/liked-stream/index.js
+++ b/client/reader/liked-stream/index.js
@@ -11,7 +11,6 @@ import {
 } from './controller';
 import {
 	preloadReaderBundle,
-	loadSubscriptions,
 	initAbTests,
 	updateLastRoute,
 	sidebar,
@@ -20,7 +19,6 @@ import {
 export default function() {
 	page( '/activities/likes',
 		preloadReaderBundle,
-		loadSubscriptions,
 		initAbTests,
 		updateLastRoute,
 		sidebar,

--- a/client/reader/recommendations/index.js
+++ b/client/reader/recommendations/index.js
@@ -13,7 +13,6 @@ import {
 } from './controller';
 import {
 	initAbTests,
-	loadSubscriptions,
 	preloadReaderBundle,
 	sidebar,
 	updateLastRoute,
@@ -27,7 +26,6 @@ export default function() {
 	// Blog Recommendations
 	page( '/recommendations',
 		preloadReaderBundle,
-		loadSubscriptions,
 		initAbTests,
 		updateLastRoute,
 		sidebar,
@@ -41,7 +39,6 @@ export default function() {
 				page.apply( page, [
 					path,
 					preloadReaderBundle,
-					loadSubscriptions,
 					updateLastRoute,
 					sidebar,
 					recommendedPosts

--- a/client/reader/tag-stream/index.js
+++ b/client/reader/tag-stream/index.js
@@ -12,7 +12,6 @@ import {
 } from './controller';
 import {
 	initAbTests,
-	loadSubscriptions,
 	preloadReaderBundle,
 	sidebar,
 	updateLastRoute,
@@ -21,7 +20,6 @@ import {
 export default function() {
 	page( '/tag/*',
 		preloadReaderBundle,
-		loadSubscriptions,
 		initAbTests
 	);
 	page( '/tag/:tag',
@@ -31,7 +29,6 @@ export default function() {
 	);
 
 	page( '/tags',
-		loadSubscriptions,
 		initAbTests,
 		updateLastRoute,
 		sidebar,

--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -12,6 +12,7 @@ import {
 	READER_UNFOLLOW,
 	READER_RECORD_FOLLOW,
 	READER_RECORD_UNFOLLOW,
+	READER_FOLLOWS_SYNC_START,
 	READER_FOLLOWS_RECEIVE,
 	READER_SUBSCRIBE_TO_NEW_POST_EMAIL,
 	READER_SUBSCRIBE_TO_NEW_COMMENT_EMAIL,
@@ -139,7 +140,14 @@ export const itemsCount = createReducer( 0, {
 	}
 } );
 
+export const lastSyncTime = createReducer( null, {
+	[ READER_FOLLOWS_SYNC_START ]: ( ) => {
+		return Date.now();
+	}
+} );
+
 export default combineReducers( {
 	items,
 	itemsCount,
+	lastSyncTime
 } );

--- a/client/state/selectors/get-reader-follows-last-sync-time.js
+++ b/client/state/selectors/get-reader-follows-last-sync-time.js
@@ -1,0 +1,1 @@
+export default ( state ) => state.reader.follows.lastSyncTime;

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -39,6 +39,7 @@ export getJetpackSetting from './get-jetpack-setting';
 export getJetpackSettings from './get-jetpack-settings';
 export getJetpackSettingsSaveError from './get-jetpack-settings-save-error';
 export getJetpackSettingsSaveRequestStatus from './get-jetpack-settings-save-request-status';
+export getReaderFollowsLastSyncTime from './get-reader-follows-last-sync-time';
 export getMagicLoginCurrentView from './get-magic-login-current-view';
 export getMagicLoginEmailAddressFormInput from './get-magic-login-email-address-form-input';
 export getMagicLoginEmailAddressFormInputIsValid from './get-magic-login-email-address-form-input-is-valid';


### PR DESCRIPTION
Currently the only Following buttons that exist within Reader are based off of flux data.

As we are transitioning to Redux, it is necessary to make a FollowButton that relies upon the data in the state tree.