### PR TITLE
AT: Add theme upload size check

### DIFF
--- a/client/lib/automated-transfer/constants.js
+++ b/client/lib/automated-transfer/constants.js
@@ -1,0 +1,3 @@
+
+// Keep this value in sync with wpcom sandbox bin/transfers/at-get-theme-slug.sh MAX_FILE_SIZE.
+export const MAX_UPLOADED_THEME_SIZE = 50 * 1000000; // 50MB

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -139,7 +139,10 @@ class Upload extends React.Component {
 			'too large': translate( 'Upload problem: Theme zip must be under 10MB.' ),
 			incompatible: translate( 'Upload problem: Incompatible theme.' ),
 			unsupported_mime_type: translate( 'Upload problem: Not a valid zip file' ),
-			initiate_failure: translate( 'Upload problem: Theme may not be valid' ),
+			initiate_failure: translate(
+				'Upload problem: Theme may not be valid. Check that your zip file contains only the theme ' +
+				'you are trying to upload.'
+			),
 		};
 
 		const errorString = JSON.stringify( error ).toLowerCase();

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -169,7 +169,7 @@ class Upload extends React.Component {
 
 		if ( file.size > MAX_UPLOADED_THEME_SIZE ) {
 			notices.error(
-				translate( 'Theme zip is too big. Max theme size is 50 MB.' )
+				translate( 'Theme zip is too large. Please upload a theme under 50 MB.' )
 			);
 
 			return;

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -58,6 +58,9 @@ import {
 } from 'state/automated-transfer/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import WpAdminAutoLogin from 'components/wpadmin-auto-login';
+import {
+	MAX_UPLOADED_THEME_SIZE
+} from 'lib/automated-transfer/constants';
 
 const debug = debugFactory( 'calypso:themes:theme-upload' );
 
@@ -160,6 +163,14 @@ class Upload extends React.Component {
 		// DropZone supplies an array, FilePicker supplies a FileList
 		const file = files[ 0 ] || files.item( 0 );
 		debug( 'zip file:', file );
+
+		if ( file.size && file.size > MAX_UPLOADED_THEME_SIZE ) {
+			notices.error(
+				translate( 'Theme zip is too big. Max theme size is 50 MB.' )
+			);
+
+			return;
+		}
 
 		const action = this.props.isJetpack
 			? this.props.uploadTheme : this.props.initiateThemeTransfer;

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -167,7 +167,7 @@ class Upload extends React.Component {
 		const file = files[ 0 ] || files.item( 0 );
 		debug( 'zip file:', file );
 
-		if ( file.size && file.size > MAX_UPLOADED_THEME_SIZE ) {
+		if ( file.size > MAX_UPLOADED_THEME_SIZE ) {
 			notices.error(
 				translate( 'Theme zip is too big. Max theme size is 50 MB.' )
 			);


### PR DESCRIPTION
Currently, we only check for the uploaded theme file size on the server but do not respond back with an error if the uploaded theme has bigger size. In this PR, we add a client-side check for the uploaded theme size so users know more info.

We also make the failure message for failing to upload a theme better.

## Testing instructions

1. Navigate to http://calypso.localhost:3000/themes/upload/<site> and try to upload a file which is over 50MB. You should get an error saying that the theme zip is too big.
2. Try uploading a proper theme to verify that AT works