### PR TITLE
Site Settings: Add compatibility for Mobile Theme settings on sites with Jetpack < 4.8

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -61,6 +61,8 @@ class SiteSettingsFormWriting extends Component {
 			setFieldValue,
 			siteId,
 			translate,
+			trackEvent,
+			submitForm,
 			updateFields,
 		} = this.props;
 
@@ -140,6 +142,9 @@ class SiteSettingsFormWriting extends Component {
 								isSavingSettings={ isSavingSettings }
 								isRequestingSettings={ isRequestingSettings }
 								fields={ fields }
+								trackEvent={ trackEvent }
+								submitForm={ submitForm }
+								updateFields={ updateFields }
 							/>
 
 							{ config.isEnabled( 'press-this' ) &&


### PR DESCRIPTION
This PR adds a mapping of boolean setting values to `enabled`/`disabled` when targetting a site with Jetpack < 4.8

Depends on #12526 

#### Testing instructions

1. Visit `/settings/writing` for a Jetpack Site (With Jetpack < 4.8)
1. On the **Theme Enhancements** card make sure the setting `Optimize your site with a mobile-friendly theme for tablets and phones` is on. 
1. Toggle `Hide all featured images` and confirm that it shows a success notice.
1. Refresh the page and check that the change persisted.
1. Also, verify the tests pass.
    ```sh
    $ npm run test-client client/state/jetpack
    ```
1. Verify that all of the above fails for a site with Jetpack >= 4.8


#### Why

Jetpack 4.8 introduced a change in the way the Mobile Themes settings values are represented. They're boolean now instead of `'disabled'`/`'enabled'`. It looked better to create a small PR (#12526) to fix this for the freshly released Jetpack 4.8 and handle the backwards compatibility in an another PR that can be reverted when we stop maintaining compatibility for Jetpack 4.7
