### PR TITLE
Framework: update schema to reflect that endpoints may return null

### DIFF
--- a/client/state/plans/schema.js
+++ b/client/state/plans/schema.js
@@ -32,7 +32,7 @@ export const itemsSchema = {
 			product_id: { type: 'number' },
 			product_name: { type: 'string' },
 			product_name_en: { type: 'string' },
-			product_name_short: { type: 'string' },
+			product_name_short: { type: [ 'string', 'null' ] },
 			product_slug: { type: 'string' },
 			product_type: { type: 'string' },
 			raw_price: { type: 'number' },
@@ -40,7 +40,7 @@ export const itemsSchema = {
 			shortdesc: { type: 'string' },
 			store: { type: [ 'number', 'null' ] },
 			support_document: { type: 'string' },
-			tagline: { type: 'string' },
+			tagline: { type: [ 'string', 'null' ] },
 			width: { type: 'number' }
 		}
 	}

--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -50,7 +50,7 @@ export const sitesSchema = {
 					properties: {
 						product_id: { type: 'number' },
 						product_slug: { type: 'string' },
-						product_name_short: { type: 'string' },
+						product_name_short: { type: [ 'string', 'null' ] },
 						free_trial: { type: 'boolean' },
 						expired: { type: 'boolean' },
 						user_is_owner: { type: 'boolean' },


### PR DESCRIPTION
This PR relaxes the sites and plans schema a bit so we don't throw out data when some fields are null.

### Testing Instructions
- clear state `localStorage.clear(); indexedDB.deleteDatabase( 'calypso' );`
- set `localStorage.debug = 'calypso:state'`
- refresh the page
- navigate around to a few sections like /plan and /posts to populate
- refresh the page
- no validation warnings should be thrown in the console
