### PR TITLE
Customizer: Fix Menus Redirect for unverified E-Mail

### DIFF
--- a/client/my-sites/customize/controller.js
+++ b/client/my-sites/customize/controller.js
@@ -26,6 +26,7 @@ export function customize( context ) {
 		React.createElement( ReduxProvider, { store: context.store },
 			React.createElement( CustomizeComponent, {
 				domain: context.params.domain || '',
+				pathname: context.params.pathname,
 				prevPath: context.prevPath || '',
 				query: context.query,
 				panel: context.params.panel

--- a/client/my-sites/customize/controller.js
+++ b/client/my-sites/customize/controller.js
@@ -26,7 +26,7 @@ export function customize( context ) {
 		React.createElement( ReduxProvider, { store: context.store },
 			React.createElement( CustomizeComponent, {
 				domain: context.params.domain || '',
-				pathname: context.params.pathname,
+				pathname: context.pathname,
 				prevPath: context.prevPath || '',
 				query: context.query,
 				panel: context.params.panel

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -54,7 +54,7 @@ var Customize = React.createClass( {
 	},
 
 	componentWillMount: function() {
-		this.redirectIfNeeded( this.props.menusUrl, this.props.pathname );
+		this.redirectIfNeeded( this.props.pathname );
 		this.listenToCustomizer();
 		this.waitForLoading();
 		window.scrollTo( 0, 0 );
@@ -66,10 +66,11 @@ var Customize = React.createClass( {
 	},
 
 	componentWillReceiveProps: function( nextProps ) {
-		this.redirectIfNeeded( nextProps.menusUrl, nextProps.pathname );
+		this.redirectIfNeeded( nextProps.pathname );
 	},
 
-	redirectIfNeeded: function( menusUrl, pathname ) {
+	redirectIfNeeded: function( pathname ) {
+		const { menusUrl } = this.props;
 		if ( startsWith( pathname, '/customize/menus' ) && pathname !== menusUrl ) {
 			page( menusUrl );
 		}

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -31,6 +31,7 @@ var Customize = React.createClass( {
 	propTypes: {
 		domain: React.PropTypes.string.isRequired,
 		site: React.PropTypes.object.isRequired,
+		pathname: React.PropTypes.string.isRequired,
 		prevPath: React.PropTypes.string,
 		query: React.PropTypes.object,
 		themeActivated: React.PropTypes.func.isRequired,
@@ -53,7 +54,7 @@ var Customize = React.createClass( {
 	},
 
 	componentWillMount: function() {
-		this.redirectIfNeeded( this.props.menusUrl, this.props.site );
+		this.redirectIfNeeded( this.props.menusUrl, this.props.pathname );
 		this.listenToCustomizer();
 		this.waitForLoading();
 		window.scrollTo( 0, 0 );
@@ -65,11 +66,11 @@ var Customize = React.createClass( {
 	},
 
 	componentWillReceiveProps: function( nextProps ) {
-		this.redirectIfNeeded( nextProps.menusUrl, nextProps.site );
+		this.redirectIfNeeded( nextProps.menusUrl, nextProps.pathname );
 	},
 
-	redirectIfNeeded: function( menusUrl, site ) {
-		if ( site && menusUrl !== '/customize/menus/' + site.slug ) {
+	redirectIfNeeded: function( menusUrl, pathname ) {
+		if ( menusUrl !== pathname ) {
 			page( menusUrl );
 		}
 	},

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -7,7 +7,7 @@ var React = require( 'react' ),
 	cloneDeep = require( 'lodash/cloneDeep' ),
 	connect = require( 'react-redux' ).connect,
 	debug = require( 'debug' )( 'calypso:my-sites:customize' );
-import { get } from 'lodash';
+import { get, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -70,7 +70,7 @@ var Customize = React.createClass( {
 	},
 
 	redirectIfNeeded: function( menusUrl, pathname ) {
-		if ( menusUrl !== pathname ) {
+		if ( startsWith( pathname, '/customize/menus' ) && pathname !== menusUrl ) {
 			page( menusUrl );
 		}
 	},


### PR DESCRIPTION
There's a conceptual error in my original check -- comparing `getMenusUrl` to `/customize/menus/ + site.slug` doesn't cut it, if we really are at `/customize/ + site.slug`.

Instead of building that RHS string ourselves, we should compare to `context.pathname` -- which is what we're really meaning: compare to current path, and if it's not what `getMenusUrl` gives us, redirect to that.

This way, we keep leveraging `getMenusUrl`, thus mirroring the sidebar.

To test:
* Land on `http://calypso.localhost:3000/menus` and `http://calypso.localhost:3000/menus/<yoursite>`
* Verify that you're being redirected to `http://calypso.localhost:3000/customize/menus` and `http://calypso.localhost:3000/cusotmize/menus/<yoursite>`, respectively
* Use a JP site for `<yoursite>`. Verify you're redirected to that site's customizer.
* With a user with unverified email, check that you're redirected to `/customize/<yoursite>` (no `/menus` route fragment)
* Also make sure that the regular 'Customize' menu item still takes you to the Customizer as before.

Fixes #13226

cc @kwight @mattwiebe 