### PR TITLE
WooCommerce: Fix product details layout

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-details-card.js
@@ -72,7 +72,7 @@ export default class ProductFormDetailsCard extends Component {
 							<span>{ __( 'Product name' ) }</span>
 							<FormTextInput value={ product.name || '' } onChange={ this.setName } />
 						</FormLabel>
-						<FormLabel>
+						<FormLabel className="products__product-form-details-basic-description">
 							<span>{ __( 'Description' ) }</span>
 							<FormTextArea value={ product.description || '' } onChange={ this.setDescription } />
 						</FormLabel>

--- a/client/extensions/woocommerce/app/products/product-form-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-details-card.js
@@ -54,8 +54,8 @@ export default class ProductFormDetailsCard extends Component {
 		const __ = i18n.translate;
 		return (
 			<Card className="products__product-form-details">
-				<div>
-					<FormLabel className="products__product-form-featured">
+				<div className="products__product-form-details-featured">
+					<FormLabel>
 						{ __( 'Featured' ) }
 						<CompactFormToggle
 							onChange={ this.toggleFeatured }
@@ -63,15 +63,20 @@ export default class ProductFormDetailsCard extends Component {
 						/>
 					</FormLabel>
 				</div>
-				<div>
-					<FormLabel className="products__product-form-name">
-						<span>{ __( 'Product name' ) }</span>
-						<FormTextInput value={ product.name || '' } onChange={ this.setName } />
-					</FormLabel>
-					<FormLabel className="products__product-form-description">
-						<span>{ __( 'Description' ) }</span>
-						<FormTextArea value={ product.description || '' } onChange={ this.setDescription } />
-					</FormLabel>
+				<div className="products__product-form-details-wrapper">
+					<div className="products__product-form-details-images">
+
+					</div>
+					<div className="products__product-form-details-basic">
+						<FormLabel>
+							<span>{ __( 'Product name' ) }</span>
+							<FormTextInput value={ product.name || '' } onChange={ this.setName } />
+						</FormLabel>
+						<FormLabel>
+							<span>{ __( 'Description' ) }</span>
+							<FormTextArea value={ product.description || '' } onChange={ this.setDescription } />
+						</FormLabel>
+					</div>
 				</div>
 			</Card>
 		);

--- a/client/extensions/woocommerce/app/products/product-form-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-details-card.js
@@ -9,6 +9,7 @@ import i18n from 'i18n-calypso';
  */
 import Card from 'components/card';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
+import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextArea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
@@ -68,14 +69,14 @@ export default class ProductFormDetailsCard extends Component {
 
 					</div>
 					<div className="products__product-form-details-basic">
-						<FormLabel>
-							<span>{ __( 'Product name' ) }</span>
-							<FormTextInput value={ product.name || '' } onChange={ this.setName } />
-						</FormLabel>
-						<FormLabel className="products__product-form-details-basic-description">
-							<span>{ __( 'Description' ) }</span>
-							<FormTextArea value={ product.description || '' } onChange={ this.setDescription } />
-						</FormLabel>
+						<FormFieldSet>
+							<FormLabel htmlFor="name">{ __( 'Product name' ) }</FormLabel>
+							<FormTextInput name="name" value={ product.name || '' } onChange={ this.setName } />
+						</FormFieldSet>
+						<FormFieldSet className="products__product-form-details-basic-description">
+							<FormLabel htmlFor="description">{ __( 'Description' ) }</FormLabel>
+							<FormTextArea name="description" value={ product.description || '' } onChange={ this.setDescription } />
+						</FormFieldSet>
 					</div>
 				</div>
 			</Card>

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -18,47 +18,45 @@
 		border: 0;
 	}
 
-	.products__product-form-details {
-		.products__product-form-details-featured {
-			text-align: right;
+	.products__product-form-details-featured {
+		text-align: right;
 
-			.form-toggle__wrapper {
-				margin-left: 10px;
-			}
+		.form-toggle__wrapper {
+			margin-left: 10px;
+		}
+	}
+
+	.products__product-form-details-wrapper {
+		display: flex;
+		flex-direction: column;
+		@include breakpoint( ">960px" ) {
+			flex-direction: row;
+		}
+	}
+	/* TODO: remove placeholder styles once implemented */
+	.products__product-form-details-images {
+		background: $gray-light;
+		height: 200px;
+		margin-bottom: 16px;
+		@include breakpoint( ">960px" ) {
+			margin-bottom: 0;
+		}
+	}
+
+	.products__product-form-details-images,
+	.products__product-form-details-basic {
+		flex: 1;
+		@include breakpoint( ">960px" ) {
+			margin-right: 32px;
 		}
 
-		.products__product-form-details-wrapper {
-			display: flex;
-			flex-direction: column;
-			@include breakpoint( ">960px" ) {
-				flex-direction: row;
-			}
+		&:last-child {
+			margin-right: 0;
 		}
-		/* TODO: remove placeholder styles once implemented */
-		.products__product-form-details-images {
-			background: $gray-light;
-			height: 200px;
-			margin-bottom: 16px;
-			@include breakpoint( ">960px" ) {
-				margin-bottom: 0;
-			}
-		}
+	}
 
-		.products__product-form-details-images,
-		.products__product-form-details-basic {
-			flex: 1;
-			@include breakpoint( ">960px" ) {
-				margin-right: 32px;
-			}
-
-			&:last-child {
-				margin-right: 0;
-			}
-		}
-
-		.products__product-form-details-basic__description textarea{
-			resize: vertical;
-		}
+	.products__product-form-details-basic-description textarea {
+		resize: vertical;
 	}
 
 	.products__variation-types-form-wrapper {

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -1,4 +1,13 @@
+.is-section-woocommerce {
+	.layout__primary {
+		display: flex;
+		justify-content: center;
+	}
+}
+
 .woocommerce {
+	flex-grow: 1;
+	max-width: 720px;
 
 	.form-label {
 		margin-bottom: 16px;

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -5,6 +5,30 @@
 		border: 0;
 	}
 
+	.products__product-form-details {
+		.products__product-form-details-featured {
+			text-align: right;
+
+			.form-toggle__wrapper {
+				margin-left: 10px;
+			}
+		}
+
+		.products__product-form-details-wrapper {
+			display: flex;
+		}
+
+		.products__product-form-details-images,
+		.products__product-form-details-basic {
+			flex: 1;
+			margin-right: 10px;
+
+			&:last-child {
+				margin-right: 0;
+			}
+		}
+	}
+
 	.products__variation-types-form-wrapper {
 		padding: 24px;
 		border-top: 1px solid $gray-light;

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -1,5 +1,9 @@
 .woocommerce {
 
+	.form-label {
+		margin-bottom: 16px;
+	}
+
 	.foldable-card.products__variation-card .foldable-card__content {
 		padding: 0;
 		border: 0;
@@ -16,16 +20,35 @@
 
 		.products__product-form-details-wrapper {
 			display: flex;
+			flex-direction: column;
+			@include breakpoint( ">960px" ) {
+				flex-direction: row;
+			}
+		}
+		/* TODO: remove placeholder styles once implemented */
+		.products__product-form-details-images {
+			background: $gray-light;
+			height: 200px;
+			margin-bottom: 16px;
+			@include breakpoint( ">960px" ) {
+				margin-bottom: 0;
+			}
 		}
 
 		.products__product-form-details-images,
 		.products__product-form-details-basic {
 			flex: 1;
-			margin-right: 10px;
+			@include breakpoint( ">960px" ) {
+				margin-right: 32px;
+			}
 
 			&:last-child {
 				margin-right: 0;
 			}
+		}
+
+		.products__product-form-details-basic__description textarea{
+			resize: vertical;
 		}
 	}
 


### PR DESCRIPTION
I split the CSS from #13108 out to prevent that PR from getting larger. This PR introduces styles to start laying out our product details card to match the [mockup](https://github.com/Automattic/wp-calypso/issues/11646).

<img width="1383" alt="screen shot 2017-04-19 at 1 59 11 pm" src="https://cloud.githubusercontent.com/assets/689165/25201937/64a6d202-2508-11e7-8933-0c960c66e89c.png">

To Test:
* `make run`
* Go to http://calypso.localhost:3000/store/products/add/<your site url>