### PR TITLE
Framework: remove site-list from lib/plans

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -57,7 +57,7 @@ export function getFeatureTitle( feature ) {
 	return invoke( FEATURES_LIST, [ feature, 'getTitle' ] );
 }
 
-export function canUpgradeToPlan( planKey, site = sitesList.getSelectedSite() ) {
+export function canUpgradeToPlan( planKey, site ) {
 	const plan = get( site, [ 'plan', 'expired' ], false ) ? PLAN_FREE : get( site, [ 'plan', 'product_slug' ], PLAN_FREE );
 	return get( getPlan( planKey ), 'availableFor', () => false )( plan );
 }

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -57,16 +57,6 @@ export function getFeatureTitle( feature ) {
 	return invoke( FEATURES_LIST, [ feature, 'getTitle' ] );
 }
 
-export function getSitePlanSlug( siteID ) {
-	let site;
-	if ( siteID ) {
-		site = sitesList.getSite( siteID );
-	} else {
-		site = sitesList.getSelectedSite();
-	}
-	return get( site, 'plan.product_slug' );
-}
-
 export function canUpgradeToPlan( planKey, site = sitesList.getSelectedSite() ) {
 	const plan = get( site, [ 'plan', 'expired' ], false ) ? PLAN_FREE : get( site, [ 'plan', 'product_slug' ], PLAN_FREE );
 	return get( getPlan( planKey ), 'availableFor', () => false )( plan );
@@ -86,10 +76,6 @@ export function getPlanPath( plan ) {
 
 export function planHasFeature( plan, feature ) {
 	return includes( get( getPlan( plan ), 'getFeatures', () => [] )(), feature );
-}
-
-export function hasFeature( feature, siteID ) {
-	return planHasFeature( getSitePlanSlug( siteID ), feature );
 }
 
 export function getCurrentTrialPeriodInDays( plan ) {

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -25,12 +25,10 @@ import {
 	PLAN_JETPACK_FREE,
 	PLAN_PERSONAL
 } from 'lib/plans/constants';
-import SitesList from 'lib/sites-list';
 
 /**
  * Module vars
  */
-const sitesList = SitesList();
 const isPersonalPlanEnabled = isEnabled( 'plans/personal-plan' );
 
 export function isFreePlan( plan ) {
@@ -62,8 +60,7 @@ export function canUpgradeToPlan( planKey, site ) {
 	return get( getPlan( planKey ), 'availableFor', () => false )( plan );
 }
 
-export function getUpgradePlanSlugFromPath( path, siteID ) {
-	const site = siteID ? sitesList.getSite( siteID ) : sitesList.getSelectedSite();
+export function getUpgradePlanSlugFromPath( path, site ) {
 	return find( Object.keys( PLANS_LIST ), planKey => (
 		( planKey === path || getPlanPath( planKey ) === path ) &&
 		canUpgradeToPlan( planKey, site )

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -462,7 +462,7 @@ export default connect(
 				const planObject = getPlan( state, planProductId );
 				const isLoadingSitePlans = selectedSiteId && ! sitePlans.hasLoadedFromServer;
 				const showMonthly = ! isMonthly( plan );
-				const available = isInSignup ? true : canUpgradeToPlan( plan ) && canPurchase;
+				const available = isInSignup ? true : canUpgradeToPlan( plan, site ) && canPurchase;
 				const relatedMonthlyPlan = showMonthly ? getPlanBySlug( state, getMonthlyPlanByYearly( plan ) ) : null;
 				const popular = isPopular( plan ) && ! isPaid;
 				const newPlan = isNew( plan ) && ! isPaid;

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -53,7 +53,7 @@ import {
 	isEnterprise,
 	isJetpackBusiness
 } from 'lib/products-values';
-import { hasFeature } from 'lib/plans';
+import { hasFeature } from 'state/sites/plans/selectors';
 import { FEATURE_ADVANCED_SEO, PLAN_BUSINESS } from 'lib/plans/constants';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 
@@ -493,7 +493,7 @@ export const SeoForm = React.createClass( {
 					</Notice>
 				}
 
-				{ ! hasFeature( FEATURE_ADVANCED_SEO, site.ID ) &&
+				{ ! this.props.hasAdvancedSEOFeature &&
 					<Banner
 						description={ translate( 'Adds tools to optimize your site for search engines and social media sharing.' ) }
 						event={ 'calypso_seo_settings_upgrade_nudge' }
@@ -758,6 +758,7 @@ const mapStateToProps = ( state, ownProps ) => {
 		isFetchingSite: isRequestingSite( state, siteId ),
 		isSeoToolsActive: isJetpackModuleActive( state, siteId, 'seo-tools' ),
 		isVerificationToolsActive: isJetpackModuleActive( state, siteId, 'verification-tools' ),
+		hasAdvancedSEOFeature: hasFeature( state, siteId, FEATURE_ADVANCED_SEO ),
 	};
 };
 

--- a/client/my-sites/site-settings/seo-settings/help.jsx
+++ b/client/my-sites/site-settings/seo-settings/help.jsx
@@ -10,13 +10,13 @@ import { localize } from 'i18n-calypso';
  */
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
-import { hasFeature } from 'lib/plans';
+import { hasFeature } from 'state/sites/plans/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { FEATURE_ADVANCED_SEO } from 'lib/plans/constants';
 
 const SeoSettingsHelpCard = ( {
-	siteId,
+	hasAdvancedSEOFeature,
 	siteIsJetpack,
 	translate
 } ) => {
@@ -28,7 +28,7 @@ const SeoSettingsHelpCard = ( {
 		<div>
 			<SectionHeader label={ translate( 'Search engine optimization' ) } />
 			{
-				hasFeature( FEATURE_ADVANCED_SEO, siteId ) &&
+				hasAdvancedSEOFeature &&
 				<Card>
 					<p>
 						{ translate(
@@ -54,10 +54,11 @@ export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
 		const siteIsJetpack = isJetpackSite( state, siteId );
+		const hasAdvancedSEOFeature = hasFeature( state, siteId, FEATURE_ADVANCED_SEO );
 
 		return {
-			siteId,
 			siteIsJetpack,
+			hasAdvancedSEOFeature
 		};
 	}
 )( localize( SeoSettingsHelpCard ) );

--- a/client/my-sites/upgrade-nudge/index.jsx
+++ b/client/my-sites/upgrade-nudge/index.jsx
@@ -13,11 +13,12 @@ import Gridicon from 'gridicons';
  */
 import Button from 'components/button';
 import Card from 'components/card';
-import { getValidFeatureKeys, hasFeature } from 'lib/plans';
+import { hasFeature } from 'state/sites/plans/selectors';
+import { getValidFeatureKeys } from 'lib/plans';
 import { isFreePlan } from 'lib/products-values';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 
 const UpgradeNudge = React.createClass( {
 
@@ -75,7 +76,7 @@ const UpgradeNudge = React.createClass( {
 		) {
 			return false;
 		}
-		if ( feature && hasFeature( feature, site.ID ) ) {
+		if ( feature && this.props.planHasFeature ) {
 			return false;
 		}
 		if ( ! feature && ! isFreePlan( site.plan ) ) {
@@ -147,8 +148,12 @@ const UpgradeNudge = React.createClass( {
 } );
 
 export default connect(
-	state => ( {
-		site: getSelectedSite( state ),
-	} ),
+	( state, ownProps ) => {
+		const siteId = getSelectedSiteId( state );
+		return {
+			site: getSelectedSite( state ),
+			planHasFeature: hasFeature( state, siteId, ownProps.feature )
+		};
+	},
 	{ recordTracksEvent }
 )( localize( UpgradeNudge ) );

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -120,7 +120,7 @@ const Checkout = React.createClass( {
 	},
 
 	addProductToCart: function() {
-		const planSlug = getUpgradePlanSlugFromPath( this.props.product );
+		const planSlug = getUpgradePlanSlugFromPath( this.props.product, this.props.selectedSite );
 
 		let cartItem,
 			cartMeta;


### PR DESCRIPTION
This PR removes sites-list from lib/plans. The follow changes have been made:
- getSitePlanSlug and hasFeature have been removed from 'lib/plans'
- canUpgradeToPlan now expects a site object
- getUpgradePlanSlugFromPath expects a site object

### Testing Instructions
- Search for getSitePlanSlug and hasFeature. We should see no usages from 'lib/plans'
- We see an SEO nudge on http://calypso.localhost:3000/settings/traffic/:siteId: when the current site doesn't have a Business plan
![screen shot 2017-04-19 at 3 44 11 pm](https://cloud.githubusercontent.com/assets/1270189/25205369/109094a0-2517-11e7-926a-c5ff6bd43d92.png)

- The help box for http://calypso.localhost:3000/settings/traffic/:siteId: should be visible when the current site has a Business plan
![screen shot 2017-04-19 at 3 42 44 pm](https://cloud.githubusercontent.com/assets/1270189/25205354/f6ff6282-2516-11e7-9074-e8d96d18b19a.png)
- Plan upgrades work normally from /plans and from a site creation flow
- Upgrade Nudges still work eg http://calypso.localhost:3000/stats/insights/:siteId: with a free plan
![screen shot 2017-04-19 at 3 46 40 pm](https://cloud.githubusercontent.com/assets/1270189/25205445/6de26f8e-2517-11e7-8e85-8ca1f8dc5d25.png)
- A plan is added to cart by visiting a direct url like: `http://calypso.localhost:3000/checkout/:siteId:/business

