### PR TITLE
Add railcar to FollowButton for recs and related posts

### DIFF
--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -43,7 +43,7 @@ function AuthorAndSiteFollow( { post, site, onSiteClick, followSource } ) {
 					<a href={ siteUrl } onClick={ onSiteClick } className="reader-related-card-v2__link">{ siteName }</a>
 				</span>
 			</div>
-			<FollowButton siteUrl={ post.site_URL } followSource={ followSource } />
+			<FollowButton siteUrl={ post.site_URL } followSource={ followSource } railcar= { post.railcar } />
 		</div>
 	);
 }

--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -43,7 +43,7 @@ function AuthorAndSiteFollow( { post, site, onSiteClick, followSource } ) {
 					<a href={ siteUrl } onClick={ onSiteClick } className="reader-related-card-v2__link">{ siteName }</a>
 				</span>
 			</div>
-			<FollowButton siteUrl={ post.site_URL } followSource={ followSource } railcar= { post.railcar } />
+			<FollowButton siteUrl={ post.site_URL } followSource={ followSource } railcar={ post.railcar } />
 		</div>
 	);
 }


### PR DESCRIPTION
Fix for #13201: Recommendations and related posts currently do not have traintracks for the follow button.

This patch attempts to trigger a `calypso_traintracks_interact` event with property `action=site_followed` whenever a site is followed from post recommendations and full post related posts.