### PR TITLE
Framework: remove sites-list usages from traffic

### DIFF
--- a/client/components/data/query-site-purchases/index.jsx
+++ b/client/components/data/query-site-purchases/index.jsx
@@ -36,8 +36,8 @@ class QuerySitePurchases extends Component {
 }
 
 QuerySitePurchases.propTypes = {
-	siteId: PropTypes.number.isRequired,
-	requesting: PropTypes.bool.isRequired,
+	siteId: PropTypes.number,
+	requesting: PropTypes.bool,
 	fetchSitePurchases: PropTypes.func.isRequired
 };
 

--- a/client/components/data/query-site-purchases/index.jsx
+++ b/client/components/data/query-site-purchases/index.jsx
@@ -12,7 +12,9 @@ import { fetchSitePurchases } from 'state/purchases/actions';
 
 class QuerySitePurchases extends Component {
 	requestSitePurchases( props = this.props ) {
-		this.props.fetchSitePurchases( props.siteId );
+		if ( props.siteId ) {
+			this.props.fetchSitePurchases( props.siteId );
+		}
 	}
 
 	componentWillMount() {

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -164,13 +164,7 @@ export const SeoForm = React.createClass( {
 		// save error
 		if ( this.state.isSubmittingForm && nextProps.saveError ) {
 			this.setState( { isSubmittingForm: false } );
-			switch ( nextProps.saveError.error ) {
-				case 'invalid_ip':
-					notices.error( translate( 'One of your IP Addresses was invalid. Please, try again.' ) );
-					break;
-				default:
-					notices.error( translate( 'There was a problem saving your changes. Please, try again.' ) );
-			}
+			notices.error( translate( 'There was a problem saving your changes. Please, try again.' ) );
 		}
 
 		// if we are changing sites, everything goes

--- a/client/my-sites/site-settings/seo-settings/main.jsx
+++ b/client/my-sites/site-settings/seo-settings/main.jsx
@@ -3,7 +3,6 @@
  */
 import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
-import debugFactory from 'debug';
 
 /**
  * Internal dependencies
@@ -12,34 +11,10 @@ import notices from 'notices';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import { getSitePurchases, hasLoadedSitePurchasesFromServer, getPurchasesError } from 'state/purchases/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import SeoForm from './form';
 
-/**
- * Module vars
- */
-const debug = debugFactory( 'calypso:my-sites:site-settings' );
-
 export class SeoSettings extends Component {
-	constructor( props ) {
-		super( props );
-
-		// bound methods
-		this.updateSite = this.updateSite.bind( this );
-
-		this.state = {
-			site: this.props.sites.getSelectedSite()
-		};
-	}
-
-	componentWillMount() {
-		debug( 'Mounting SiteSettings React component.' );
-		this.props.sites.on( 'change', this.updateSite );
-	}
-
-	componentWillUnmount() {
-		this.props.sites.off( 'change', this.updateSite );
-	}
 
 	componentWillReceiveProps( nextProps ) {
 		if ( nextProps.purchasesError ) {
@@ -48,37 +23,38 @@ export class SeoSettings extends Component {
 	}
 
 	render() {
-		const { site } = this.state;
-		const { upgradeToBusiness } = this.props;
+		const { site, siteId, upgradeToBusiness } = this.props;
 
 		return (
 			<div>
-				{ site && <QuerySiteSettings siteId={ site.ID } /> }
-				{ site && <QuerySitePurchases siteId={ site.ID } /> }
+				<QuerySiteSettings siteId={ siteId } />
+				<QuerySitePurchases siteId={ siteId } />
 				{ site && <SeoForm { ...{ site, upgradeToBusiness } } /> }
 			</div>
 		);
 	}
-
-	updateSite() {
-		this.setState( { site: this.props.sites.getSelectedSite() } );
-	}
 }
 
 SeoSettings.propTypes = {
-	hasLoadedSitePurchasesFromServer: PropTypes.bool.isRequired,
-	purchasesError: PropTypes.object,
+	upgradeToBusiness: PropTypes.func,
 	section: PropTypes.string,
-	sitePurchases: PropTypes.array.isRequired,
-	sites: PropTypes.object.isRequired
+	//connected
+	hasLoadedSitePurchasesFromServer: PropTypes.bool,
+	purchasesError: PropTypes.object,
+	sitePurchases: PropTypes.array,
+	site: PropTypes.object,
+	siteId: PropTypes.number
 };
 
 export default connect(
 	( state ) => {
+		const siteId = getSelectedSiteId( state );
 		return {
+			siteId,
+			site: getSelectedSite( state ),
 			hasLoadedSitePurchasesFromServer: hasLoadedSitePurchasesFromServer( state ),
 			purchasesError: getPurchasesError( state ),
-			sitePurchases: getSitePurchases( state, getSelectedSiteId( state ) )
+			sitePurchases: getSitePurchases( state, siteId )
 		};
 	}
 )( SeoSettings );

--- a/client/my-sites/site-settings/traffic/controller.js
+++ b/client/my-sites/site-settings/traffic/controller.js
@@ -44,7 +44,7 @@ export default {
 
 		renderWithReduxStore(
 			React.createElement( TrafficMain, {
-				...{ sites, upgradeToBusiness }
+				...{ upgradeToBusiness }
 			} ),
 			document.getElementById( 'primary' ),
 			context.store

--- a/client/my-sites/site-settings/traffic/controller.js
+++ b/client/my-sites/site-settings/traffic/controller.js
@@ -11,33 +11,22 @@ import analytics from 'lib/analytics';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import route from 'lib/route';
 import TrafficMain from 'my-sites/site-settings/traffic/main';
-import sitesFactory from 'lib/sites-list';
-import utils from 'lib/site/utils';
-
-const sites = sitesFactory();
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { canCurrentUser } from 'state/selectors';
 
 export default {
 	traffic( context ) {
 		const analyticsPageTitle = 'Site Settings > Traffic';
 		const basePath = route.sectionify( context.path );
-		const fiveMinutes = 5 * 60 * 1000;
-		let site = sites.getSelectedSite();
+		const state = context.store.getState();
+		const site = getSelectedSite( state );
+		const siteId = getSelectedSiteId( state );
+		const canManageOptions = canCurrentUser( state, siteId, 'manage_options' );
 
 		// if site loaded, but user cannot manage site, redirect
-		if ( site && ! utils.userCan( 'manage_options', site ) ) {
+		if ( site && ! canManageOptions ) {
 			page.redirect( '/stats' );
 			return;
-		}
-
-		if ( ! site.latestSettings || new Date().getTime() - site.latestSettings > ( fiveMinutes ) ) {
-			if ( sites.initialized ) {
-				site.fetchSettings();
-			} else {
-				sites.once( 'change', function() {
-					site = sites.getSelectedSite();
-					site.fetchSettings();
-				} );
-			}
 		}
 
 		const upgradeToBusiness = () => page( '/checkout/' + site.domain + '/business' );

--- a/client/my-sites/site-settings/traffic/main.jsx
+++ b/client/my-sites/site-settings/traffic/main.jsx
@@ -34,7 +34,6 @@ const SiteSettingsTraffic = ( {
 	isSavingSettings,
 	setFieldValue,
 	site,
-	sites,
 	submitForm,
 	trackEvent,
 	translate,
@@ -75,12 +74,11 @@ const SiteSettingsTraffic = ( {
 		}
 		<AnalyticsSettings />
 		<SeoSettingsHelpCard />
-		<SeoSettingsMain sites={ sites } upgradeToBusiness={ upgradeToBusiness } />
+		<SeoSettingsMain upgradeToBusiness={ upgradeToBusiness } />
 	</Main>
 );
 
 SiteSettingsTraffic.propTypes = {
-	sites: PropTypes.object.isRequired,
 	upgradeToBusiness: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
This PR removes sites-list usages in the traffic subsection of settings

This also updates `seo-settings/form` to use the redux action `saveSiteSettings` and `requestSiteSettings` instead of `lib/site`'s `saveSettings` and `fetchSettings`. I tried to make this diff as small as possible. There's still room for improvement for updating the control flow in seo-settings.

### Testing Instructions
- Navigate to http://calypso.localhost:3000/settings/traffic/:siteId:
- Clear cache: `localStorage.clear(); indexedDB.deleteDatabase( 'calypso' );`
- Refresh page
- Section should fully load and work normally

Note that there's an open bug, where we don't allow you to enable SEO tools for a Jetpack site. We can work around this by visiting: /wp-admin/admin.php?page=jetpack_modules