### PR TITLE
Woo Connect-Insights: Create Stats Navigation

### DIFF
--- a/client/extensions/woocommerce/app/stats/index.js
+++ b/client/extensions/woocommerce/app/stats/index.js
@@ -7,20 +7,14 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import Main from 'components/main';
-import Card from 'components/card';
-import SectionHeader from 'components/section-header';
+import StatsNavigation from './stats-navigation';
 
 export default class Stats extends Component {
-
 	render() {
 		return (
-			<Main className="stats woocommerce">
-				<SectionHeader label="WooCommerce Store - Stats" />
-				<Card>
-					<p>This will be the home for your WooCommerce Store Stats</p>
-				</Card>
+			<Main className="woocommerce stats" wideLayout={ true }>
+				<StatsNavigation />
 			</Main>
 		);
 	}
-
 }

--- a/client/extensions/woocommerce/app/stats/stats-navigation/index.js
+++ b/client/extensions/woocommerce/app/stats/stats-navigation/index.js
@@ -1,0 +1,66 @@
+/**
+ * External Dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import i18n from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import SectionNav from 'components/section-nav';
+import NavTabs from 'components/section-nav/tabs';
+import NavItem from 'components/section-nav/item';
+import FollowersCount from 'blocks/followers-count';
+import SegmentedControl from 'components/segmented-control';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+
+const StatsNavigation = props => {
+	const { translate, slug } = props;
+	const section = 'orders';
+	const sectionTitles = {
+		orders: translate( 'Orders' ),
+		customers: translate( 'Customers' ),
+		stock: translate( 'Stock' ),
+		taxes: translate( 'Taxes' ),
+		coupons: translate( 'Coupons' ),
+		subscriptions: translate( 'Subscriptions' ),
+	};
+	return (
+		<SectionNav selectedText={ sectionTitles[ section ] }>
+			<NavTabs label={ translate( 'Stats' ) }>
+				<NavItem path={ `/store/stats/${ slug }` } selected={ section === 'orders' }>
+					{ sectionTitles.orders }
+				</NavItem>
+				<NavItem path={ `/store/stats/${ slug }` } selected={ section === 'customers' }>
+					{ sectionTitles.customers }
+				</NavItem>
+				<NavItem path={ `/store/stats/${ slug }` } selected={ section === 'stock' }>
+					{ sectionTitles.stock }
+				</NavItem>
+			</NavTabs>
+			<SegmentedControl
+				className="stats-navigation__control"
+				initialSelected="store"
+				options={ [
+					{ value: 'site', label: translate( 'Site' ), path: `/stats/day/${ slug }` },
+					{ value: 'store', label: translate( 'Store' ) },
+				] }
+			/>
+			<FollowersCount />
+		</SectionNav>
+	);
+};
+
+StatsNavigation.propTypes = {
+	slug: PropTypes.string
+};
+
+export default connect(
+	state => {
+		return {
+			slug: getSelectedSiteSlug( state ),
+			translate: i18n.translate,
+		};
+	}
+)( StatsNavigation );


### PR DESCRIPTION
Create the same navigation item in Site Stats for Woo Extension Stats. Populate it with relevant nav items.

NB: associated routes to be established in next pull request. Similarly, highlight of the "Stats" section on the Sidebar is yet to come.

### Before
![screen shot 2017-04-20 at 3 34 03 pm](https://cloud.githubusercontent.com/assets/1922453/25212517/d7af6986-25de-11e7-800d-644f140c5431.png)

### After
![screen shot 2017-04-20 at 3 32 43 pm](https://cloud.githubusercontent.com/assets/1922453/25212500/b9706542-25de-11e7-806a-946150877403.png)

Fixes https://github.com/Automattic/wp-calypso/issues/12972