### PR TITLE
Reader: Fix photo card wide in Safari

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -356,7 +356,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	display: flex;
 	flex-direction: row;
 	margin-top: 14px;
-	flex-wrap: wrap;
 
 	.reader-post-card__post-details {
 		flex: 1 auto;
@@ -374,6 +373,10 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	@media #{$reader-post-card-breakpoint-small} {
 		flex-direction: column;
 	}
+}
+
+.reader-post-card.is-expanded-video .reader-post-card__post {
+	flex-wrap: wrap;
 }
 
 .reader-post-card__post-details {


### PR DESCRIPTION
This happens as you scale down and if photo card titles are long.

**Before:**
![screenshot 2017-04-19 21 32 12](https://cloud.githubusercontent.com/assets/4924246/25214383/bda0b088-254b-11e7-85e3-da63fc654173.png)

**After:**
![screenshot 2017-04-19 21 32 30](https://cloud.githubusercontent.com/assets/4924246/25214388/c69b9d6a-254b-11e7-85be-87e4667c9051.png)

