### PR TITLE
Login: Error notice not dismissable

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -31,34 +31,33 @@ export class Login extends Component {
 		title: '',
 	};
 
-	constructor() {
-		super();
-		this.state = {
-			usernameOrEmail: '',
-			password: '',
-			rememberme: false,
-			submitting: false,
-			errorMessage: '',
-		};
-		this.onChangeField = this.onChangeField.bind( this );
-		this.onSubmitForm = this.onSubmitForm.bind( this );
-	}
+	state = {
+		usernameOrEmail: '',
+		password: '',
+		rememberme: false,
+		submitting: false,
+		errorMessage: '',
+	};
 
-	onChangeField( event ) {
+	dismissNotice = () => {
+		this.setState( {
+			errorMessage: ''
+		} );
+	};
+
+	onChangeField = ( event ) => {
 		this.setState( {
 			[ event.target.name ]: event.target.value
 		} );
-	}
+	};
 
-	onSubmitForm( event ) {
+	onSubmitForm = ( event ) => {
 		event.preventDefault();
 		this.setState( {
 			submitting: true
 		} );
 		this.props.loginUser( this.state.usernameOrEmail, this.state.password ).then( () => {
-			this.setState( {
-				errorMessage: ''
-			} );
+			this.dismissNotice();
 			createFormAndSubmit( config( 'login_url' ), {
 				log: this.state.usernameOrEmail,
 				pwd: this.state.password,
@@ -71,12 +70,14 @@ export class Login extends Component {
 				errorMessage
 			} );
 		} );
-	}
+	};
 
 	renderNotices() {
 		if ( this.state.errorMessage ) {
 			return (
-				<Notice status="is-error" text={ this.state.errorMessage } />
+				<Notice status="is-error"
+					text={ this.state.errorMessage }
+					onDismissClick={ this.dismissNotice } />
 			);
 		}
 	}


### PR DESCRIPTION
> We should fix notices that are displayed on the new `Login` page as right now they remain visible even if you click on the cross.

<img width="490" alt="screenshot" src="https://cloud.githubusercontent.com/assets/699132/25226511/912a3446-25c5-11e7-822f-0a9b3e80dc8e.png">


### Testing
1. Go to http://calypso.localhost:3000/login when logged out.
2. Provide invalid credentials.
3. Click the cross on the notice and make sure it is dismissed.

### Review

* [ ] Code
* [ ] Product