### PR TITLE
Activate form-toggle hover-state on label

### DIFF
--- a/client/components/forms/form-toggle/style.scss
+++ b/client/components/forms/form-toggle/style.scss
@@ -70,7 +70,7 @@
 	}
 
 	&:not( :disabled ) {
-		+ .form-toggle__label .form-toggle__switch:hover {
+		+ .form-toggle__label:hover .form-toggle__switch {
 			background: lighten( $gray, 20% );
 		}
 	}
@@ -86,7 +86,7 @@
 	}
 
 	&:checked:not( :disabled ) {
-		+ .form-toggle__label .form-toggle__switch:hover {
+		+ .form-toggle__label:hover .form-toggle__switch {
 			background: $blue-light;
 		}
 	}


### PR DESCRIPTION
Fixes #13244 

`FormToggle` were only activating the toggle's hover state when the toggle itself was hovered. The entire label is clickable, so it makes sense to show the hover state when any part of the clickable label is hovered. This PR makes hover on the entire clickable area activate the toggle hover state.

![hover-label](https://cloud.githubusercontent.com/assets/841763/25226921/e81e8c6a-25c6-11e7-81b3-33d0b71b2b4a.png)

## Review

- [x] Code
- [ ] Design

## Test

1. Run this branch.
1. Visit pages with toggles (`/settings/discussion/:site` for example).
1. Verify that hovering on the clickable toggle area activates the hover state on the toggle.

cc: @jeherve via https://github.com/Automattic/jetpack/issues/6878