### PR TITLE
Analytics: added Media Wallah pixel for DGI

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -44,6 +44,7 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 	TWITTER_TRACKING_SCRIPT_URL = 'https://static.ads-twitter.com/uwt.js',
 	DCM_FLOODLIGHT_IFRAME_URL = 'https://6355556.fls.doubleclick.net/activityi',
 	LINKED_IN_SCRIPT_URL = 'https://snap.licdn.com/li.lms-analytics/insight.min.js',
+	MEDIA_WALLAH_URL = 'https://d3ir0rz7vxwgq5.cloudfront.net/mwData.min.js',
 	TRACKING_IDS = {
 		bingInit: '4074038',
 		facebookInit: '823166884443641',
@@ -100,6 +101,36 @@ if ( ! window.twq ) {
 
 if ( ! window._linkedin_data_partner_id ) {
 	window._linkedin_data_partner_id = TRACKING_IDS.linkedInPartnerId;
+}
+
+/**
+ * Initializes Media Wallah tracking.
+ * This is a rework of the obfuscated tracking code provided by Media Wallah.
+ */
+function initMediaWallah() {
+	const mwOptions = {
+		uid: '',
+		custom: '',
+		account_id: 1015,
+		customer_id: 1012,
+		tag_action: 'visit',
+		timeout: 100 // in milliseconds
+	};
+
+	window.setBrowserAttributeData();
+	let counter = 0;
+	const init = function() {
+		if ( window.mwDataReady() ) {
+			document.body.appendChild( window.mwPixel( mwOptions ) );
+		} else if ( counter === mwOptions.timeout ) {
+			clearTimeout( init );
+		} else {
+			setTimeout( init, 1 );
+			counter++;
+		}
+	};
+
+	window.addEventListener ? window.addEventListener( 'load', init, false ) : window.attachEvent( 'onload', init );
 }
 
 /**
@@ -164,20 +195,26 @@ function loadTrackingScripts( callback ) {
 		},
 		function( onComplete ) {
 			loadScript.loadScript( LINKED_IN_SCRIPT_URL, onComplete );
+		},
+		function( onComplete ) {
+			loadScript.loadScript( MEDIA_WALLAH_URL, onComplete );
 		}
 	], function( errors ) {
 		if ( ! some( errors ) ) {
-			// update Facebook's tracking global
+			// init Facebook's tracking global
 			window.fbq( 'init', TRACKING_IDS.facebookInit );
 
-			// update Bing's tracking global
+			// init Bing's tracking global
 			const bingConfig = {
 				ti: TRACKING_IDS.bingInit,
 				q: window.uetq
 			};
 
-			// update Twitter's tracking global
+			// init Twitter's tracking global
 			window.twq( 'init', TRACKING_IDS.twitterPixelId );
+
+			// init Media Wallah tracking
+			initMediaWallah();
 
 			if ( typeof UET !== 'undefined' ) {
 				// bing's script creates the UET global for us


### PR DESCRIPTION
This implements Media Wallah pixel for our Device Graph implementation.

Its basically an adaptation to Calypso standards of the obfuscated code provided by Media Wallah:

```
<script type="text/javascript">
    (function(){
        const mwOptions = {
            uid: '',
            custom: '',
            account_id: 1015,
            customer_id: 1012,
            tag_action: 'visit',
            timeout: 100 // in milliseconds
        };

        function loadScript(a,b){var c=document.createElement("script");c.type="text/javascript",c.readyState?c.onreadystatechange=function(){"loaded"!=c.readyState&&"complete"!=c.readyState||(c.onreadystatechange=null,b())}:c.onload=function(){b()},c.src=a,document.getElementsByTagName("head")[0].appendChild(c)}loadScript("https://d3ir0rz7vxwgq5.cloudfront.net/mwData.min.js",function(){setBrowserAttributeData();var a=0;const b=function(){return 1!=mwDataReady()?a==mwOptions.timeout?void clearTimeout(b):(setTimeout(b,1),void a++):void document.body.appendChild(mwPixel(mwOptions))};window.addEventListener?window.addEventListener("load",b,!1):window.attachEvent("onload",b)});
    })();
</script>
```

# Testing 

- In `config/development.json` set `"ad-tracking": true`
- Open a new tab in Chrome and reload Calypso
- In the Network tab search for "1015"
- After a few seconds after reloading you should see something similar to:

![media-wallah-tag](https://cloud.githubusercontent.com/assets/10284338/25228543/0f150028-25cd-11e7-8f11-c0e628b14880.png)
