### PR TITLE
Site Settings: Make the notices shown when SEO, Analytics and verification tools are deactivated, be able to activate the modules

### DIFF
--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -24,6 +24,7 @@ import {
 	isEnterprise,
 	isJetpackBusiness
 } from 'lib/products-values';
+import { activateModule } from 'state/jetpack/modules/actions';
 import { getSiteOption, isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { isJetpackModuleActive } from 'state/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
@@ -60,7 +61,6 @@ class GoogleAnalyticsForm extends Component {
 			handleSubmitForm,
 			isRequestingSettings,
 			isSavingSettings,
-			jetpackManagementUrl,
 			jetpackModuleActive,
 			jetpackVersionSupportsModule,
 			showUpgradeNudge,
@@ -71,7 +71,7 @@ class GoogleAnalyticsForm extends Component {
 			translate,
 			uniqueEventTracker,
 		} = this.props;
-
+		const activateGoogleAnalytics = () => this.props.activateModule( siteId, 'google-analytics' );
 		const placeholderText = isRequestingSettings ? translate( 'Loading' ) : '';
 		const isJetpackUnsupported = siteIsJetpack && ! jetpackVersionSupportsModule;
 		const analyticsSupportUrl = siteIsJetpack
@@ -101,7 +101,7 @@ class GoogleAnalyticsForm extends Component {
 						status="is-warning"
 						showDismiss={ false }
 						text={ translate( 'The Google Analytics module is disabled in Jetpack.' ) } >
-						<NoticeAction href={ jetpackManagementUrl + 'admin.php?page=jetpack#/engagement' }>
+						<NoticeAction onClick={ activateGoogleAnalytics }>
 							{ translate( 'Enable' ) }
 						</NoticeAction>
 					</Notice>
@@ -236,8 +236,9 @@ const mapStateToProps = ( state ) => {
 };
 
 const connectComponent = connect(
-	mapStateToProps,
-	null,
+	mapStateToProps, {
+		activateModule
+	},
 	null,
 	{ pure: false }
 );

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -37,7 +37,6 @@ import CountedTextarea from 'components/forms/counted-textarea';
 import Banner from 'components/banner';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import {
-	getSiteOption,
 	getSeoTitleFormatsForSite,
 	isJetpackMinimumVersion,
 	isJetpackSite,
@@ -54,6 +53,7 @@ import { toApi as seoTitleToApi } from 'components/seo/meta-title-editor/mapping
 import { recordTracksEvent } from 'state/analytics/actions';
 import WebPreview from 'components/web-preview';
 import { requestSite } from 'state/sites/actions';
+import { activateModule } from 'state/jetpack/modules/actions';
 import {
 	isBusiness,
 	isEnterprise,
@@ -375,7 +375,6 @@ export const SeoForm = React.createClass( {
 		const {
 			siteId,
 			siteIsJetpack,
-			jetpackManagementUrl,
 			jetpackVersionSupportsSeo,
 			showAdvancedSeo,
 			showWebsiteMeta,
@@ -403,6 +402,8 @@ export const SeoForm = React.createClass( {
 
 		let { googleCode, bingCode, pinterestCode, yandexCode } = this.state;
 
+		const activateSeoTools = () => this.props.activateModule( siteId, 'seo-tools' );
+		const activateVerificationServices = () => this.props.activateModule( siteId, 'verification-tools' );
 		const isSitePrivate = siteSettings && parseInt( siteSettings.blog_public, 10 ) !== 1;
 		const isJetpackUnsupported = siteIsJetpack && ! jetpackVersionSupportsSeo;
 		const isDisabled = isSitePrivate || isJetpackUnsupported || isSubmittingForm || isFetchingSettings;
@@ -492,7 +493,7 @@ export const SeoForm = React.createClass( {
 							'SEO Tools module is disabled in Jetpack.'
 						) }
 					>
-						<NoticeAction href={ jetpackManagementUrl + 'admin.php?page=jetpack#/engagement' }>
+						<NoticeAction onClick={ activateSeoTools }>
 							{ translate( 'Enable' ) }
 						</NoticeAction>
 					</Notice>
@@ -590,7 +591,7 @@ export const SeoForm = React.createClass( {
 								'Site Verification Services are disabled in Jetpack.'
 							) }
 						>
-							<NoticeAction href={ jetpackManagementUrl + 'admin.php?page=jetpack#/engagement' }>
+							<NoticeAction onClick={ activateVerificationServices }>
 								{ translate( 'Enable' ) }
 							</NoticeAction>
 						</Notice>
@@ -733,7 +734,6 @@ const mapStateToProps = ( state, ownProps ) => {
 	const isAdvancedSeoEligible = site && site.plan && hasBusinessPlan( site.plan );
 	const siteId = getSelectedSiteId( state );
 	const siteIsJetpack = isJetpackSite( state, siteId );
-	const jetpackManagementUrl = getSiteOption( state, siteId, 'admin_url' );
 	const jetpackVersionSupportsSeo = isJetpackMinimumVersion( state, siteId, '4.4-beta1' );
 	const isAdvancedSeoSupported = site && ( ! siteIsJetpack || ( siteIsJetpack && jetpackVersionSupportsSeo ) );
 
@@ -745,7 +745,6 @@ const mapStateToProps = ( state, ownProps ) => {
 		siteSettings: getSiteSettings( state, siteId ),
 		showAdvancedSeo: isAdvancedSeoEligible && isAdvancedSeoSupported,
 		showWebsiteMeta: !! get( site, 'options.advanced_seo_front_page_description', '' ),
-		jetpackManagementUrl,
 		jetpackVersionSupportsSeo: jetpackVersionSupportsSeo,
 		isFetchingSite: isRequestingSite( state, siteId ),
 		isSeoToolsActive: isJetpackModuleActive( state, siteId, 'seo-tools' ),
@@ -763,6 +762,7 @@ const mapDispatchToProps = {
 	trackFormSubmitted: partial( recordTracksEvent, 'calypso_seo_settings_form_submit' ),
 	trackTitleFormatsUpdated: partial( recordTracksEvent, 'calypso_seo_tools_title_formats_updated' ),
 	trackFrontPageMetaUpdated: partial( recordTracksEvent, 'calypso_seo_tools_front_page_meta_updated' ),
+	activateModule,
 };
 
 export default connect(


### PR DESCRIPTION
This PR changes the *Enable* links that are shown in notices ( which state that some required module is not active) to be able to activate the modules right away instead of taking the user to wp-admin. 

![enabling](https://cloud.githubusercontent.com/assets/746152/25232141/c80beabe-25b0-11e7-9add-ab153faaa4e7.gif)


#### Testing instructions

1. On a site with Jetpack 4.8, get to disable the modules: SEO tools, Site Verification, and Google Analyitics.
1. Checkout this branch or visit the [traffic settings live branch](https://calypso.live/settings/traffic?branch=fix/activate-links-in-seo-settings-notices) and pick your site.
1. Confirm that you see the three notices stating that the modules are inactive. Enable the modules from the `Enable` links
1. Confirm they're activated.
1. Refresh the page and confirm the changes persist.

Fixes #13255 

Fixes #13075

Fixes Automattic/jetpack#7001